### PR TITLE
Pin Hermes runtime image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.git
+.github
+node_modules
+dist
+coverage
+data
+reports
+.env
+.env.prod
+*.tsbuildinfo
+npm-debug.log*
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ docker compose --env-file .env.prod -f ops/compose.yml -p avg up -d
 
 For the first VPS smoke, follow [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md).
 
+## Hermes Pin
+
+The runtime image is pinned in [ops/.env.example](ops/.env.example):
+
+```text
+nousresearch/hermes-agent:dafe443beba74384871e2c79d5b17db8bc51880e
+```
+
+Do not use `latest` in production. Test a new Hermes tag in a branch, run the smoke flow, then update the pin deliberately.
+
 Run the reference prompt:
 
 ```bash

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -26,6 +26,7 @@ scripts/bootstrap-wallet.sh
 # - set OLLAMA_API_KEY
 # - set SLACK_WEBHOOK_URL
 # - confirm AVERRAY_API_BASE_URL points at testnet
+# - keep HERMES_IMAGE pinned; do not use latest for production smoke
 chmod 600 .env.prod
 
 docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg up -d --build
@@ -72,6 +73,16 @@ Look for:
 - Skills observer started.
 - Postgres migrations applied.
 
+## Runtime Pin
+
+The default Hermes image is pinned to:
+
+```text
+nousresearch/hermes-agent:dafe443beba74384871e2c79d5b17db8bc51880e
+```
+
+Before changing that pin, test the new tag on a branch and re-run the safe first prompt.
+
 ## Kill Switch
 
 Create the halt file to stop mutating tools:
@@ -95,4 +106,3 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
 ```
 
 Use `down -v` only when you explicitly want to delete Postgres/Hermes data.
-

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -1,7 +1,7 @@
 # Copy to ../.env.prod, fill secrets, then chmod 600 ../.env.prod.
 
-# Pin this to an exact Hermes image tag or digest before production use.
-HERMES_IMAGE=nousresearch/hermes-agent:latest
+# Pinned Hermes image tag. Refresh intentionally after testing a new Hermes release.
+HERMES_IMAGE=nousresearch/hermes-agent:dafe443beba74384871e2c79d5b17db8bc51880e
 
 POSTGRES_USER=avg_agent
 POSTGRES_PASSWORD=change-me

--- a/ops/Dockerfile.node
+++ b/ops/Dockerfile.node
@@ -1,7 +1,7 @@
 FROM node:22-bookworm-slim AS deps
 WORKDIR /app
 COPY . .
-RUN npm install
+RUN npm ci
 
 FROM deps AS build
 RUN npm run build


### PR DESCRIPTION
## Summary

- Add `.dockerignore` so Docker builds do not include local caches, secrets, node_modules, or build artifacts.
- Pin the Hermes runtime image in `ops/.env.example` instead of using `latest`.
- Document the pin in the README and VPS smoke runbook.

## Checks run locally

- `npm run typecheck`
- `npm test`
- `git diff --check`

## Notes

This keeps the v1 runtime reproducible while we validate Hermes against the Averray smoke flow.