### PR TITLE
Pin Hermes image by digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For the first VPS smoke, follow [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md).
 The runtime image is pinned in [ops/.env.example](ops/.env.example):
 
 ```text
-nousresearch/hermes-agent:dafe443beba74384871e2c79d5b17db8bc51880e
+nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08
 ```
 
 Do not use `latest` in production. Test a new Hermes tag in a branch, run the smoke flow, then update the pin deliberately.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -78,7 +78,7 @@ Look for:
 The default Hermes image is pinned to:
 
 ```text
-nousresearch/hermes-agent:dafe443beba74384871e2c79d5b17db8bc51880e
+nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08
 ```
 
 Before changing that pin, test the new tag on a branch and re-run the safe first prompt.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -1,7 +1,7 @@
 # Copy to ../.env.prod, fill secrets, then chmod 600 ../.env.prod.
 
-# Pinned Hermes image tag. Refresh intentionally after testing a new Hermes release.
-HERMES_IMAGE=nousresearch/hermes-agent:dafe443beba74384871e2c79d5b17db8bc51880e
+# Pinned Hermes image digest. Refresh intentionally after testing a new Hermes release.
+HERMES_IMAGE=nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08
 
 POSTGRES_USER=avg_agent
 POSTGRES_PASSWORD=change-me


### PR DESCRIPTION
## Summary
- replace the stale Hermes tag with the digest verified on the VPS
- update README, smoke runbook, and `.env.example` so fresh deployments boot the same image

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Deployment impact
- Config/docs only for the reference-agent stack
- No Averray production stack changes
- No secrets or generated artifacts