### PR TITLE
Bind Hermes dashboard to VPS localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Run the reference prompt:
 docker compose -p avg exec hermes hermes "Find a Wikipedia citation-repair task on app.averray.com testnet, claim it, complete it, get paid. Use my wallet."
 ```
 
-Access Hermes dashboard through an SSH tunnel:
+Access Hermes dashboard through an SSH tunnel. Run this from your laptop, not
+from inside the VPS shell:
 
 ```bash
 ssh -L 9119:localhost:9119 ubuntu@YOUR_VPS
@@ -64,6 +65,7 @@ Then open `http://127.0.0.1:9119`.
 - Testnet only.
 - One wallet.
 - No public dashboard port.
+- The dashboard is bound to `127.0.0.1:9119` on the VPS for SSH/Tailscale access.
 - No Averray admin token.
 - No shared Averray DB, Redis, Docker network, or volumes.
 - No Docker socket.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -44,7 +44,9 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
 
 ## Dashboard Access
 
-Hermes dashboard is not exposed publicly.
+Hermes dashboard is not exposed publicly. Docker binds it to
+`127.0.0.1:9119` on the VPS, so open the SSH tunnel from your laptop, not from
+inside the VPS shell.
 
 SSH tunnel:
 
@@ -79,7 +81,7 @@ Look for:
 
 - Hermes dashboard started.
 - MCP servers discovered.
-- No public ports published.
+- No public ports published; dashboard is bound only to VPS localhost.
 - Skills observer started.
 - Postgres migrations applied.
 

--- a/ops/compose.prod.yml
+++ b/ops/compose.prod.yml
@@ -1,5 +1,3 @@
 services:
   postgres:
     ports: []
-  hermes:
-    ports: []

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -120,8 +120,10 @@ services:
       - ../hermes/profiles:/opt/data/browser-profiles
       - avg-hermes-skills:/opt/data/skills
     networks: [avg-internal]
-    # Keep dashboard internal. Use Tailscale/SSH tunnel to reach 127.0.0.1:9119 on the VPS.
-    command: ["dashboard", "--host", "127.0.0.1", "--port", "9119"]
+    ports:
+      - "127.0.0.1:9119:9119"
+    # Bound to VPS localhost only by the port mapping above. Use Tailscale/SSH tunnel.
+    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119"]
 
 volumes:
   avg-postgres:


### PR DESCRIPTION
## Summary
- publish the Hermes dashboard only on VPS localhost (`127.0.0.1:9119`)
- make Hermes listen on `0.0.0.0` inside the container so Docker's localhost-only port mapping can reach it
- update docs to clarify the SSH tunnel must be opened from the laptop, not from inside the VPS shell

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Deployment impact
- Reference-agent Compose/docs only
- Dashboard remains non-public: host binding is `127.0.0.1` only
- No generated artifacts, no secrets, no Averray production stack changes