### PR TITLE
Allow dashboard behind loopback bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Then open `http://127.0.0.1:9119`.
 - One wallet.
 - No public dashboard port.
 - The dashboard is bound to `127.0.0.1:9119` on the VPS for SSH/Tailscale access.
+- Hermes runs dashboard mode with `--insecure` only because Docker publishes it
+  to VPS loopback, not to the public interface.
 - No Averray admin token.
 - No shared Averray DB, Redis, Docker network, or volumes.
 - No Docker socket.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -46,7 +46,9 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
 
 Hermes dashboard is not exposed publicly. Docker binds it to
 `127.0.0.1:9119` on the VPS, so open the SSH tunnel from your laptop, not from
-inside the VPS shell.
+inside the VPS shell. The Hermes dashboard command uses `--insecure` because
+Hermes requires it for the container-internal `0.0.0.0` bind; Docker still
+limits host access to VPS loopback.
 
 SSH tunnel:
 

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -122,8 +122,9 @@ services:
     networks: [avg-internal]
     ports:
       - "127.0.0.1:9119:9119"
-    # Bound to VPS localhost only by the port mapping above. Use Tailscale/SSH tunnel.
-    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119"]
+    # Hermes requires --insecure for non-loopback container binds. The Docker
+    # port mapping above keeps this reachable only from VPS localhost.
+    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--insecure"]
 
 volumes:
   avg-postgres:


### PR DESCRIPTION
## Summary
- add Hermes dashboard `--insecure` because Hermes refuses container-internal `0.0.0.0` without it
- keep Docker publishing constrained to `127.0.0.1:9119`, so the dashboard remains private to VPS loopback / SSH tunnel
- document why this flag is used

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Deployment impact
- Reference-agent Compose/docs only
- No public port, no generated artifacts, no secrets, no Averray production changes