### PR TITLE
Fix Hermes chat invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ Do not use `latest` in production. Test a new Hermes tag in a branch, run the sm
 Run the reference prompt:
 
 ```bash
-docker compose -p avg exec hermes hermes "Find a Wikipedia citation-repair task on app.averray.com testnet, claim it, complete it, get paid. Use my wallet."
+docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+  exec hermes /opt/hermes/.venv/bin/hermes chat \
+  --provider ollama-cloud \
+  -m qwen3.5:cloud \
+  -q "Find a Wikipedia citation-repair task on app.averray.com testnet, claim it, complete it, get paid. Use my wallet."
 ```
 
 Access Hermes dashboard through an SSH tunnel. Run this from your laptop, not

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -68,7 +68,10 @@ Do not claim or submit during the first smoke.
 
 ```bash
 docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
-  exec hermes hermes "Open app.averray.com testnet, find a Wikipedia job, inspect it, and write what you learned. Do not claim or submit."
+  exec hermes /opt/hermes/.venv/bin/hermes chat \
+  --provider ollama-cloud \
+  -m qwen3.5:cloud \
+  -q "Open app.averray.com testnet, find a Wikipedia job, inspect it, and write what you learned. Do not claim or submit."
 ```
 
 ## Tool Smoke

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -1,7 +1,7 @@
 # Copied into /opt/data/config.yaml by the operator after `hermes setup`.
 # Keep this file declarative; Hermes owns its runtime data under /opt/data.
 model:
-  provider: ollama
+  provider: ollama-cloud
   base_url: ${OLLAMA_BASE_URL}
   api_key_env: OLLAMA_API_KEY
   default: ${HERMES_DEFAULT_MODEL}
@@ -27,4 +27,3 @@ paths:
   skills: /opt/data/skills
   memory: /opt/data/memory.db
   plugins: /opt/data/plugins
-

--- a/scripts/compare-brains.sh
+++ b/scripts/compare-brains.sh
@@ -29,6 +29,9 @@ fi
 IFS=',' read -r -a model_array <<< "${MODELS}"
 for model in "${model_array[@]}"; do
   echo "== Running Hermes with model ${model}"
-  docker compose -p avg exec -e HERMES_DEFAULT_MODEL="${model}" hermes hermes "${TASK}"
+  docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+    exec hermes /opt/hermes/.venv/bin/hermes chat \
+    --provider ollama-cloud \
+    -m "${model}" \
+    -q "${TASK}"
 done
-


### PR DESCRIPTION
## Summary
- update smoke/reference commands to use Hermes `chat -q` instead of a positional prompt
- pass the actual `ollama-cloud` provider and `qwen3.5:cloud` model explicitly
- update the comparison script to use the same CLI shape
- align Hermes config provider naming with this Hermes build

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Deployment impact
- Reference-agent docs/config/scripts only
- No generated artifacts, no secrets, no Averray production changes