### PR TITLE
Make read-only MCP smoke work without wallet

### DIFF
--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -21,16 +21,14 @@ const baseUrl = trimTrailingSlash(optionalEnv("AVERRAY_API_BASE_URL", "https://a
 server.tool("averray_list_jobs", "List Averray jobs and recommendations for fallback/API control mode.", {
   recommendations: z.boolean().default(false)
 }, async ({ recommendations }) => {
-  const session = await authSession();
   const path = recommendations ? "/jobs/recommendations" : "/jobs";
-  return jsonContent(await request(path, { token: session.token }));
+  return jsonContent(await request(path));
 });
 
 server.tool("averray_get_definition", "Get the canonical job definition for a job id.", {
   jobId: z.string().min(1)
 }, async ({ jobId }) => {
-  const session = await authSession();
-  return jsonContent(await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`, { token: session.token }));
+  return jsonContent(await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`));
 });
 
 server.tool("averray_claim", "Claim a job through Averray's public API fallback path.", {

--- a/packages/wallet-mcp/src/index.ts
+++ b/packages/wallet-mcp/src/index.ts
@@ -9,12 +9,17 @@ const server = new McpServer({
 });
 
 server.tool("wallet_status", "Return wallet status and configured signing modes.", {}, async () => {
-  const account = accountFromEnv();
+  const configuredKey = optionalEnv("AGENT_WALLET_PRIVATE_KEY");
+  const account = configuredKey ? tryAccountFromPrivateKey(configuredKey) : null;
   return jsonContent({
-    address: account.address,
+    address: account?.address ?? null,
+    configured: Boolean(account),
     extensionMode: Boolean(optionalEnv("BROWSER_CDP_URL")),
-    siweFallbackMode: true,
-    network: optionalEnv("WALLET_NETWORK", "testnet")
+    siweFallbackMode: Boolean(account),
+    network: optionalEnv("WALLET_NETWORK", "testnet"),
+    message: account
+      ? "Wallet key is configured for SIWE fallback."
+      : "No usable AGENT_WALLET_PRIVATE_KEY is configured. Read-only tools still work; claiming/submitting requires a testnet wallet key."
   });
 });
 
@@ -60,3 +65,10 @@ function accountFromEnv() {
   return privateKeyToAccount(requiredEnv("AGENT_WALLET_PRIVATE_KEY") as `0x${string}`);
 }
 
+function tryAccountFromPrivateKey(privateKey: string) {
+  try {
+    return privateKeyToAccount(privateKey as `0x${string}`);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- allow `averray_list_jobs` and `averray_get_definition` to call public Averray endpoints without SIWE auth
- make `wallet_status` report missing/invalid wallet configuration instead of throwing
- keep claim, submit, SIWE signing, and wallet export behind the existing private-key requirement

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Deployment impact
- Reference-agent MCP code only
- No generated artifacts, no secrets, no Averray production changes
- VPS needs pull/rebuild for the compiled MCP bundle to update