### PR TITLE
Add claim readiness smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ docker compose --env-file .env.prod -f ops/compose.yml -p avg up -d
 
 For the first VPS smoke, follow [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md).
 
+After the read-only smoke passes and `.env.prod` contains a real testnet-only
+wallet key, run the non-mutating claim-readiness smoke:
+
+```bash
+scripts/claim-readiness-smoke.sh
+```
+
+It checks wallet status, policy budget, compact Wikipedia discovery, one job
+definition, and claim policy. It must not claim or submit.
+
 ## Hermes Pin
 
 The runtime image is pinned in [ops/.env.example](ops/.env.example):

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -75,6 +75,36 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
   -q "Open app.averray.com testnet, find a Wikipedia job, inspect it, and write what you learned. Do not claim or submit."
 ```
 
+## Claim Readiness Smoke
+
+Run this only after `.env.prod` contains a real testnet-only
+`AGENT_WALLET_PRIVATE_KEY`. The script validates that the key has the expected
+shape without printing it. It may print `AGENT_WALLET_ADDRESS`, which is safe.
+
+This smoke checks wallet status, policy budget, compact Wikipedia discovery,
+one job definition, and `policy_check_claim`. It explicitly forbids
+`averray_claim`, `averray_submit`, approvals, and Wikipedia edits.
+
+```bash
+scripts/claim-readiness-smoke.sh
+```
+
+To compare a second model without changing `.env.prod`:
+
+```bash
+scripts/claim-readiness-smoke.sh --model qwen3.5:cloud
+```
+
+Expected result:
+
+- `wallet_status.configured` is true.
+- `wallet_export_address` returns the same testnet wallet address you expect.
+- `policy_get_budget` returns current per-run/per-day budget limits.
+- `averray_list_jobs` returns a compact Wikipedia subset.
+- `averray_get_definition` returns one Wikipedia definition.
+- `policy_check_claim` returns `pass` or a clear blocker.
+- No session is claimed and no work is submitted.
+
 ## Tool Smoke
 
 After Hermes boots, verify the MCP tools from a shell inside the Hermes container when Hermes MCP config is loaded:

--- a/scripts/claim-readiness-smoke.sh
+++ b/scripts/claim-readiness-smoke.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL="${HERMES_DEFAULT_MODEL:-}"
+ENV_FILE=".env.prod"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --model)
+      MODEL="$2"
+      shift 2
+      ;;
+    --env-file)
+      ENV_FILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "${ENV_FILE} is missing. Create it from ops/.env.example or scripts/bootstrap-wallet.sh first." >&2
+  exit 1
+fi
+
+if [[ -z "${MODEL}" ]]; then
+  MODEL="$(grep '^HERMES_DEFAULT_MODEL=' "${ENV_FILE}" | tail -n 1 | cut -d= -f2- || true)"
+fi
+MODEL="${MODEL:-deepseek-v4-pro:cloud}"
+
+if ! grep -Eq '^AGENT_WALLET_PRIVATE_KEY=0x[0-9a-fA-F]{64}$' "${ENV_FILE}"; then
+  echo "AGENT_WALLET_PRIVATE_KEY is missing or malformed in ${ENV_FILE}." >&2
+  echo "Use a testnet-only key. Do not paste the private key into chat or logs." >&2
+  exit 1
+fi
+
+if grep -q '^AGENT_WALLET_ADDRESS=' "${ENV_FILE}"; then
+  grep '^AGENT_WALLET_ADDRESS=' "${ENV_FILE}"
+else
+  echo "AGENT_WALLET_ADDRESS is not set; wallet_status should still derive the address from the private key."
+fi
+
+PROMPT=$(cat <<'PROMPT'
+Use the configured Averray reference MCP tools only for this claim-readiness smoke. Do not use browser, shell, or Python fallback tools.
+
+Goal:
+1. Check wallet readiness with wallet_status and wallet_export_address.
+2. Check policy readiness with policy_get_budget.
+3. List open Wikipedia jobs compactly with averray_list_jobs using category/source/state filters and a small limit.
+4. Inspect one Wikipedia job definition with averray_get_definition.
+5. Run policy_check_claim for that job using the job definition fields.
+6. Report whether this agent appears ready to claim a Wikipedia job, and list any blockers or uncertainties.
+
+Safety boundary:
+- Do NOT call averray_claim.
+- Do NOT call averray_submit.
+- Do NOT request approval.
+- Do NOT edit Wikipedia.
+- Do NOT reveal or ask for private keys.
+- Stop after the readiness report.
+PROMPT
+)
+
+docker compose --env-file "${ENV_FILE}" -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+  exec hermes /opt/hermes/.venv/bin/hermes chat \
+  --provider ollama-cloud \
+  -m "${MODEL}" \
+  -q "${PROMPT}"


### PR DESCRIPTION
## What changed
- Adds scripts/claim-readiness-smoke.sh for the next non-mutating wallet/policy/job readiness check.
- Documents the claim-readiness milestone in README and docs/VPS_SMOKE.md.
- The script validates AGENT_WALLET_PRIVATE_KEY shape without printing it, uses the configured/default Hermes model, and explicitly forbids claim/submit/approval/Wikipedia edits.

## Checks
- bash -n scripts/claim-readiness-smoke.sh
- npm run typecheck
- npm test

## Impact
- Reference-agent ops/docs only.
- No backend contract or Averray product changes.
- Requires .env.prod to contain a real testnet-only AGENT_WALLET_PRIVATE_KEY before running.