### PR TITLE
Harden claim readiness smoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ scripts/claim-readiness-smoke.sh
 
 It checks wallet status, policy budget, compact Wikipedia discovery, one job
 definition, and claim policy. It must not claim or submit.
+If the wallet key was added after Hermes was already running, recreate the
+Hermes service first so the container sees the updated environment.
 
 ## Hermes Pin
 

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -43,6 +43,15 @@ chmod 600 .env.prod
 docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg up -d --build
 ```
 
+If you add or change `AGENT_WALLET_PRIVATE_KEY` after Hermes is already
+running, force-recreate the Hermes service so Docker injects the new
+environment:
+
+```bash
+docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+  up -d --build --force-recreate hermes
+```
+
 ## Dashboard Access
 
 Hermes dashboard is not exposed publicly. Docker binds it to
@@ -84,6 +93,8 @@ shape without printing it. It may print `AGENT_WALLET_ADDRESS`, which is safe.
 This smoke checks wallet status, policy budget, compact Wikipedia discovery,
 one job definition, and `policy_check_claim`. It explicitly forbids
 `averray_claim`, `averray_submit`, approvals, and Wikipedia edits.
+Before launching Hermes, it also verifies that the running Hermes container can
+see `AGENT_WALLET_PRIVATE_KEY`; if that fails, force-recreate `hermes`.
 
 ```bash
 scripts/claim-readiness-smoke.sh

--- a/scripts/claim-readiness-smoke.sh
+++ b/scripts/claim-readiness-smoke.sh
@@ -43,6 +43,14 @@ else
   echo "AGENT_WALLET_ADDRESS is not set; wallet_status should still derive the address from the private key."
 fi
 
+if ! docker compose --env-file "${ENV_FILE}" -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+  exec -T hermes sh -lc 'printf "%s" "${AGENT_WALLET_PRIVATE_KEY:-}" | grep -Eq "^0x[0-9a-fA-F]{64}$"'; then
+  echo "Hermes container does not see AGENT_WALLET_PRIVATE_KEY." >&2
+  echo "Recreate Hermes after env changes, then rerun this smoke:" >&2
+  echo "  docker compose --env-file ${ENV_FILE} -f ops/compose.yml -f ops/compose.prod.yml -p avg up -d --build --force-recreate hermes" >&2
+  exit 1
+fi
+
 PROMPT=$(cat <<'PROMPT'
 Use the configured Averray reference MCP tools only for this claim-readiness smoke. Do not use browser, shell, or Python fallback tools.
 
@@ -51,7 +59,10 @@ Goal:
 2. Check policy readiness with policy_get_budget.
 3. List open Wikipedia jobs compactly with averray_list_jobs using category/source/state filters and a small limit.
 4. Inspect one Wikipedia job definition with averray_get_definition.
-5. Run policy_check_claim for that job using the job definition fields.
+5. Run policy_check_claim for that job using:
+   - taskType: job.agentContext.taskType if present, otherwise job.source.taskType.
+   - verifierMode: job.verifierMode.
+   - rewardUsd/estimatedCostUsd: 0 unless the definition provides USD estimates.
 6. Report whether this agent appears ready to claim a Wikipedia job, and list any blockers or uncertainties.
 
 Safety boundary:


### PR DESCRIPTION
## What changed
- Fails fast if the host .env.prod has a wallet key but the running Hermes container does not see it.
- Prints the force-recreate command needed after wallet env changes.
- Tightens the smoke prompt so policy_check_claim uses agentContext.taskType/source.taskType, not top-level jobType.
- Documents the Hermes force-recreate step in the VPS smoke runbook.

## Checks
- bash -n scripts/claim-readiness-smoke.sh
- npm run typecheck
- npm test

## Impact
- Reference-agent ops/docs only.
- No claim/submit behavior added.