### PR TITLE
Pass env into Hermes MCP servers

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -45,7 +45,9 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
 
 If you add or change `AGENT_WALLET_PRIVATE_KEY` after Hermes is already
 running, force-recreate the Hermes service so Docker injects the new
-environment:
+environment. Hermes also passes secrets into each stdio MCP server through
+`mcp_servers.<name>.env`, so the MCP servers are reloaded when the service
+starts from this config:
 
 ```bash
 docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -10,18 +10,45 @@ mcp_servers:
   averray:
     command: node
     args: ["/app/packages/averray-mcp/dist/index.js"]
+    env:
+      DATABASE_URL: ${DATABASE_URL}
+      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
+      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
+      HALT_FILE: ${HALT_FILE}
+      LOG_LEVEL: ${LOG_LEVEL}
   wallet:
     command: node
     args: ["/app/packages/wallet-mcp/dist/index.js"]
+    env:
+      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
+      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
+      BROWSER_CDP_URL: ${BROWSER_CDP_URL}
+      HALT_FILE: ${HALT_FILE}
+      WALLET_NETWORK: ${WALLET_NETWORK}
+      LOG_LEVEL: ${LOG_LEVEL}
   receipt:
     command: node
     args: ["/app/packages/receipt-mcp/dist/index.js"]
+    env:
+      DATABASE_URL: ${DATABASE_URL}
+      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
+      LOG_LEVEL: ${LOG_LEVEL}
   trace:
     command: node
     args: ["/app/packages/trace-mcp/dist/index.js"]
+    env:
+      DATABASE_URL: ${DATABASE_URL}
+      TRACE_HTTP_PORT: ${TRACE_HTTP_PORT}
+      LOG_LEVEL: ${LOG_LEVEL}
   policy:
     command: node
     args: ["/app/packages/policy-mcp/dist/index.js"]
+    env:
+      DATABASE_URL: ${DATABASE_URL}
+      POLICY_CONFIG_PATH: ${POLICY_CONFIG_PATH}
+      HALT_FILE: ${HALT_FILE}
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      LOG_LEVEL: ${LOG_LEVEL}
 
 paths:
   skills: /opt/data/skills


### PR DESCRIPTION
## What changed
- Adds explicit mcp_servers.<name>.env mappings to Hermes config for Averray, wallet, receipt, trace, and policy MCP servers.
- Documents that Hermes passes secrets into stdio MCP subprocesses through the MCP env config.

## Why
The claim-readiness smoke proved the Hermes container itself could see AGENT_WALLET_PRIVATE_KEY, but wallet_status inside the wallet MCP server still reported it missing. Hermes stdio MCP servers need env declared per server.

## Checks
- node --input-type=module -e 'parse hermes/config/hermes.yaml and check wallet env'
- npm run typecheck
- npm test
- git diff --check

## Source
Hermes MCP config reference documents env as the stdio subprocess environment: https://hermes-agent.nousresearch.com/docs/reference/mcp-config-reference

## Impact
- Reference-agent config/docs only.
- No claim/submit behavior added.