### PR TITLE
Load MCP env from runtime volume

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -45,9 +45,10 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
 
 If you add or change `AGENT_WALLET_PRIVATE_KEY` after Hermes is already
 running, force-recreate the Hermes service so Docker injects the new
-environment. Hermes also passes secrets into each stdio MCP server through
-`mcp_servers.<name>.env`, so the MCP servers are reloaded when the service
-starts from this config:
+environment. The stack also writes selected env values into an internal
+Docker volume at `/config-runtime/reference-agent.env`; the MCP launcher
+sources that file before starting each Node MCP server so Hermes does not
+need to write secrets into `config.yaml`:
 
 ```bash
 docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
@@ -96,7 +97,9 @@ This smoke checks wallet status, policy budget, compact Wikipedia discovery,
 one job definition, and `policy_check_claim`. It explicitly forbids
 `averray_claim`, `averray_submit`, approvals, and Wikipedia edits.
 Before launching Hermes, it also verifies that the running Hermes container can
-see `AGENT_WALLET_PRIVATE_KEY`; if that fails, force-recreate `hermes`.
+see `AGENT_WALLET_PRIVATE_KEY` and that the MCP launcher can read
+`/config-runtime/reference-agent.env`; if either fails, force-recreate
+`hermes`.
 
 ```bash
 scripts/claim-readiness-smoke.sh

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -8,47 +8,20 @@ model:
 
 mcp_servers:
   averray:
-    command: node
+    command: /app/scripts/run-mcp-server.sh
     args: ["/app/packages/averray-mcp/dist/index.js"]
-    env:
-      DATABASE_URL: ${DATABASE_URL}
-      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
-      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
-      HALT_FILE: ${HALT_FILE}
-      LOG_LEVEL: ${LOG_LEVEL}
   wallet:
-    command: node
+    command: /app/scripts/run-mcp-server.sh
     args: ["/app/packages/wallet-mcp/dist/index.js"]
-    env:
-      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
-      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
-      BROWSER_CDP_URL: ${BROWSER_CDP_URL}
-      HALT_FILE: ${HALT_FILE}
-      WALLET_NETWORK: ${WALLET_NETWORK}
-      LOG_LEVEL: ${LOG_LEVEL}
   receipt:
-    command: node
+    command: /app/scripts/run-mcp-server.sh
     args: ["/app/packages/receipt-mcp/dist/index.js"]
-    env:
-      DATABASE_URL: ${DATABASE_URL}
-      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
-      LOG_LEVEL: ${LOG_LEVEL}
   trace:
-    command: node
+    command: /app/scripts/run-mcp-server.sh
     args: ["/app/packages/trace-mcp/dist/index.js"]
-    env:
-      DATABASE_URL: ${DATABASE_URL}
-      TRACE_HTTP_PORT: ${TRACE_HTTP_PORT}
-      LOG_LEVEL: ${LOG_LEVEL}
   policy:
-    command: node
+    command: /app/scripts/run-mcp-server.sh
     args: ["/app/packages/policy-mcp/dist/index.js"]
-    env:
-      DATABASE_URL: ${DATABASE_URL}
-      POLICY_CONFIG_PATH: ${POLICY_CONFIG_PATH}
-      HALT_FILE: ${HALT_FILE}
-      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
-      LOG_LEVEL: ${LOG_LEVEL}
 
 paths:
   skills: /opt/data/skills

--- a/ops/Dockerfile.node
+++ b/ops/Dockerfile.node
@@ -14,5 +14,6 @@ COPY --from=build /app/package.json /app/package-lock.json* ./
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/packages ./packages
 COPY --from=build /app/services ./services
+COPY --from=build /app/scripts ./scripts
 USER appuser
 CMD ["node", "packages/trace-mcp/dist/index.js"]

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -65,6 +65,32 @@ services:
       - avg-app:/runtime-app
     networks: [avg-internal]
 
+  mcp-env:
+    image: alpine:3.20
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
+      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+      HERMES_DEFAULT_MODEL: ${HERMES_DEFAULT_MODEL:-deepseek-v4-pro:cloud}
+      HERMES_COMPARISON_MODEL: ${HERMES_COMPARISON_MODEL:-qwen3.5:cloud}
+      TRACE_HTTP_PORT: ${TRACE_HTTP_PORT:-8789}
+      TRACE_HTTP_URL: http://127.0.0.1:${TRACE_HTTP_PORT:-8789}/hermes-event
+      POLICY_CONFIG_PATH: /config/policy.yaml
+      HALT_FILE: ${HALT_FILE:-/data/HALT}
+      WALLET_NETWORK: testnet
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - avg-mcp-env:/mcp-env
+      - ./write-mcp-env.sh:/write-mcp-env.sh:ro
+    entrypoint: ["/bin/sh", "/write-mcp-env.sh", "/mcp-env/reference-agent.env"]
+    networks: [avg-internal]
+
   skills-observer:
     build:
       context: ..
@@ -93,6 +119,8 @@ services:
         condition: service_completed_successfully
       mcp-bundle:
         condition: service_completed_successfully
+      mcp-env:
+        condition: service_completed_successfully
       skills-observer:
         condition: service_started
     environment:
@@ -114,6 +142,7 @@ services:
       - avg-hermes:/opt/data
       - avg-app:/app:ro
       - avg-data:/data
+      - avg-mcp-env:/config-runtime:ro
       - ../hermes/config/hermes.yaml:/opt/data/config.yaml:ro
       - ../hermes/config/policy.yaml:/config/policy.yaml:ro
       - ../hermes/plugins:/opt/data/plugins:ro
@@ -130,6 +159,7 @@ volumes:
   avg-postgres:
   avg-data:
   avg-app:
+  avg-mcp-env:
   avg-hermes:
   avg-hermes-skills:
 

--- a/ops/write-mcp-env.sh
+++ b/ops/write-mcp-env.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+OUT_FILE="${1:-/mcp-env/reference-agent.env}"
+TMP_FILE="${OUT_FILE}.tmp"
+
+mkdir -p "$(dirname "${OUT_FILE}")"
+umask 077
+: > "${TMP_FILE}"
+
+write_var() {
+  name="$1"
+  eval "value=\${${name}:-}"
+  escaped="$(printf "%s" "${value}" | sed "s/'/'\\\\''/g")"
+  printf "%s='%s'\n" "${name}" "${escaped}" >> "${TMP_FILE}"
+}
+
+for name in \
+  DATABASE_URL \
+  AVERRAY_API_BASE_URL \
+  AGENT_WALLET_PRIVATE_KEY \
+  OLLAMA_API_KEY \
+  OLLAMA_BASE_URL \
+  HERMES_DEFAULT_MODEL \
+  HERMES_COMPARISON_MODEL \
+  TRACE_HTTP_PORT \
+  TRACE_HTTP_URL \
+  POLICY_CONFIG_PATH \
+  HALT_FILE \
+  WALLET_NETWORK \
+  SLACK_WEBHOOK_URL \
+  LOG_LEVEL
+do
+  write_var "${name}"
+done
+
+chmod 0444 "${TMP_FILE}"
+mv "${TMP_FILE}" "${OUT_FILE}"

--- a/scripts/claim-readiness-smoke.sh
+++ b/scripts/claim-readiness-smoke.sh
@@ -51,6 +51,14 @@ if ! docker compose --env-file "${ENV_FILE}" -f ops/compose.yml -f ops/compose.p
   exit 1
 fi
 
+if ! docker compose --env-file "${ENV_FILE}" -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+  exec -T hermes sh -lc 'set -a && . /config-runtime/reference-agent.env && set +a && printf "%s" "${AGENT_WALLET_PRIVATE_KEY:-}" | grep -Eq "^0x[0-9a-fA-F]{64}$"'; then
+  echo "Hermes MCP launcher cannot read a valid AGENT_WALLET_PRIVATE_KEY from /config-runtime/reference-agent.env." >&2
+  echo "Recreate Hermes after pulling the latest compose/config changes, then rerun this smoke:" >&2
+  echo "  docker compose --env-file ${ENV_FILE} -f ops/compose.yml -f ops/compose.prod.yml -p avg up -d --build --force-recreate hermes" >&2
+  exit 1
+fi
+
 PROMPT=$(cat <<'PROMPT'
 Use the configured Averray reference MCP tools only for this claim-readiness smoke. Do not use browser, shell, or Python fallback tools.
 

--- a/scripts/run-mcp-server.sh
+++ b/scripts/run-mcp-server.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+ENV_FILE="${MCP_ENV_FILE:-/config-runtime/reference-agent.env}"
+
+if [ -r "${ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${ENV_FILE}"
+  set +a
+fi
+
+exec node "$@"


### PR DESCRIPTION
## What changed
- Adds an mcp-env one-shot service that writes selected environment values into an internal Docker volume.
- Adds scripts/run-mcp-server.sh so Hermes MCP stdio servers source /config-runtime/reference-agent.env before execing Node.
- Switches all Hermes MCP server commands to the launcher.
- Copies scripts into the runtime app bundle.
- Extends the claim-readiness preflight to verify the runtime env file is readable.

## Why
Hermes did not expand \ inside mcp_servers.<name>.env, so the wallet MCP server received an invalid key while the Hermes container itself had the correct Docker env. This keeps secrets out of config.yaml while making them available to MCP child processes.

## Checks
- bash -n scripts/run-mcp-server.sh ops/write-mcp-env.sh scripts/claim-readiness-smoke.sh
- parsed hermes/config/hermes.yaml and verified MCP commands
- npm run typecheck
- npm test
- git diff --check

Note: local Docker here does not expose the Compose plugin, so docker compose config was not run locally.

## Impact
- Reference-agent Docker/config only.
- No claim/submit behavior added.