### PR TITLE
Submit structured output directly

### DIFF
--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -11,6 +11,7 @@ import {
   trimTrailingSlash
 } from "@avg/mcp-common";
 import { evaluateClaimMutationPolicy, evaluateSubmitMutationPolicy, isUuid } from "./mutation-policy.js";
+import { buildSubmitRequestBody } from "./submit-payload.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -86,15 +87,7 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
     const response = await request("/jobs/submit", {
       method: "POST",
       token: session.token,
-      body: {
-        sessionId,
-        submission: {
-          jobId,
-          output,
-          submittedAt: new Date().toISOString(),
-          idempotencyKey: key
-        }
-      }
+      body: buildSubmitRequestBody({ sessionId, output })
     });
     await completeSubmission(key, response);
     return jsonContent({ idempotencyKey: key, policy, response });

--- a/packages/averray-mcp/src/submit-payload.ts
+++ b/packages/averray-mcp/src/submit-payload.ts
@@ -1,0 +1,9 @@
+export function buildSubmitRequestBody(input: {
+  sessionId: string;
+  output: unknown;
+}) {
+  return {
+    sessionId: input.sessionId,
+    submission: input.output
+  };
+}

--- a/test/unit/submit-payload.test.ts
+++ b/test/unit/submit-payload.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSubmitRequestBody } from "../../packages/averray-mcp/src/submit-payload.js";
+
+describe("submit payload", () => {
+  it("sends structured output directly as the Averray submission", () => {
+    const output = {
+      page_title: "(Hash)",
+      revision_id: "1351905908",
+      citation_findings: [
+        {
+          section: "Charts",
+          problem: "dead_link",
+          current_claim: "Billboard Heatseekers chart entry",
+          evidence_url: "https://web.archive.org/example"
+        }
+      ],
+      proposed_changes: [
+        {
+          change_type: "replace_citation",
+          target_text: "https://www.billboard.com/artist/Loona/chart-history/TLN",
+          replacement_text: "Add archive URL to the existing chart citation",
+          source_url: "https://web.archive.org/example"
+        }
+      ],
+      review_notes: "Averray-attributed proposal only; no Wikipedia edit was made."
+    };
+
+    expect(buildSubmitRequestBody({ sessionId: "job:0xabc", output })).toEqual({
+      sessionId: "job:0xabc",
+      submission: output
+    });
+  });
+
+  it("does not wrap output in submission.output metadata", () => {
+    const output = {
+      page_title: "(Hash)",
+      revision_id: "1351905908",
+      citation_findings: [],
+      proposed_changes: [],
+      review_notes: "Proposal only."
+    };
+
+    const body = buildSubmitRequestBody({ sessionId: "job:0xabc", output });
+
+    expect(body.submission).not.toHaveProperty("output");
+    expect(body.submission).not.toHaveProperty("jobId");
+    expect(body.submission).not.toHaveProperty("submittedAt");
+    expect(body.submission).not.toHaveProperty("idempotencyKey");
+  });
+});


### PR DESCRIPTION
## What changed
- Sends Averray submit output directly as the HTTP `submission` object instead of wrapping it under `submission.output` with metadata.
- Adds a small submit-payload helper and regression tests for the Wikipedia structured-output shape.
- Ensures the MCP submit payload does not add `jobId`, `submittedAt`, or `idempotencyKey` inside the schema-validated submission object.

## Why
The live submit attempt failed with `submission.page_title is required` because Averray validates `payload.submission` directly against the job output schema. The reference-agent was sending `submission.output.page_title`.

## Checks
- npm test -- --run test/unit/submit-payload.test.ts test/unit/mutation-policy.test.ts
- npm run typecheck
- git diff --check