### PR TITLE
Preflight schema validation for averray_submit (closes #24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3667,6 +3667,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@avg/mcp-common": "0.1.0",
+        "@avg/schemas": "0.1.0",
         "@modelcontextprotocol/sdk": "^1.13.3",
         "zod": "^3.24.1"
       }

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@avg/mcp-common": "0.1.0",
+    "@avg/schemas": "0.1.0",
     "@modelcontextprotocol/sdk": "^1.13.3",
     "zod": "^3.24.1"
   }

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "@avg/mcp-common";
 import { evaluateClaimMutationPolicy, evaluateSubmitMutationPolicy, isUuid } from "./mutation-policy.js";
 import { buildSubmitRequestBody } from "./submit-payload.js";
+import { validateSubmissionLocally } from "./validate-submission.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -67,7 +68,21 @@ server.tool("averray_claim", "Claim a job through Averray's public API fallback 
   }
 });
 
-server.tool("averray_submit", "Submit work through Averray's public API fallback path.", {
+server.tool(
+  "averray_validate_submission",
+  "Validate a structured submission output locally against the job's output schema. Read-only — does NOT consume the submit attempt budget and never calls the backend. Use this BEFORE averray_submit when an output schema is defined for the job source. Returns { valid, validator, errors[], message } where errors carry actionable JSON paths (e.g. citation_findings.0.citation_number is not allowed).",
+  {
+    jobId: z.string().min(1),
+    output: z.unknown()
+  },
+  async ({ jobId, output }) => {
+    const definition = await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
+    const validation = validateSubmissionLocally(definition, output);
+    return jsonContent({ jobId, ...validation });
+  }
+);
+
+server.tool("averray_submit", "Submit work through Averray's public API fallback path. Runs the same local schema validation as averray_validate_submission BEFORE the mutation policy check, so an invalid payload (e.g. extra structured fields) is rejected without consuming the one-shot submit attempt.", {
   runId: z.string().optional(),
   sessionId: z.string().min(1),
   jobId: z.string().optional(),
@@ -75,6 +90,41 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
   outputHash: z.string().optional()
 }, async ({ runId, sessionId, jobId, output, outputHash }) => {
   await assertNoKillSwitch("averray_submit");
+
+  // Pre-flight schema validation — runs BEFORE the mutation policy
+  // check and BEFORE any HTTP call. The reference agent has
+  // `maxSubmitAttempts=1`; without this gate a single field-shape
+  // mistake (the citation_number bug from the reference run) burns
+  // the only attempt and then `max_submit_attempts_exceeded` blocks
+  // the corrected payload. We need a jobId to pull the right schema;
+  // when the agent omits it (legacy path) we skip validation rather
+  // than refusing the submit.
+  if (typeof jobId === "string" && jobId.length > 0) {
+    let definition: unknown;
+    try {
+      definition = await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
+    } catch (error) {
+      // Couldn't reach the definition endpoint — surface the error to
+      // the agent rather than silently skipping validation. The
+      // mutation budget is untouched.
+      return jsonContent({
+        blocked: true,
+        tool: "averray_submit",
+        reason: "definition_fetch_failed",
+        message: error instanceof Error ? error.message : String(error)
+      });
+    }
+    const validation = validateSubmissionLocally(definition, output);
+    if (!validation.valid) {
+      return jsonContent({
+        blocked: true,
+        tool: "averray_submit",
+        reason: "local_schema_validation_failed",
+        validation
+      });
+    }
+  }
+
   const key = idempotencyKey(["averray", runId ?? sessionId, "submit", outputHash ?? JSON.stringify(output)]);
   const policy = await evaluateSubmitMutationPolicy({ runId, sessionId, jobId, idempotencyKey: key }, query);
   if (!policy.allowed) {

--- a/packages/averray-mcp/src/validate-submission.ts
+++ b/packages/averray-mcp/src/validate-submission.ts
@@ -1,0 +1,184 @@
+/**
+ * Local pre-flight validation for `averray_submit`.
+ *
+ * The Averray backend strict-validates `payload.submission` against a
+ * job's output schema. The reference agent has `maxSubmitAttempts=1`,
+ * so a single shape mistake (e.g. an extra `citation_number` field on a
+ * Wikipedia citation-repair proposal) consumes the only submit attempt
+ * and the corrected payload is then blocked by `max_submit_attempts_exceeded`.
+ *
+ * This module makes that mistake free: it re-runs the strict schema
+ * locally before the mutation policy check, returning actionable error
+ * paths the agent can use to fix the proposal and try again. Local
+ * failures don't touch the submission ledger.
+ *
+ * Today only Wikipedia task outputs have first-class local schemas
+ * (`packages/schemas`). For other source kinds (GitHub, OSV, OpenAPI,
+ * standards, open-data, native), `validateSubmissionLocally` returns
+ * `{ valid: true, validator: "permissive" }` so the agent still
+ * benefits from the wallet/auth flow without us blocking unknown
+ * payload shapes prematurely.
+ */
+
+import { z } from "zod";
+import {
+  wikipediaCitationRepairOutputSchema,
+  wikipediaFreshnessCheckOutputSchema,
+  wikipediaInfoboxConsistencyOutputSchema,
+} from "@avg/schemas";
+
+export type SubmissionValidator = "wikipedia" | "permissive";
+
+export interface SubmissionValidationResult {
+  valid: boolean;
+  /** Which validator ran. `permissive` means we don't have a local
+   *  schema for this source kind yet and skipped the check. */
+  validator: SubmissionValidator;
+  /** The detected source kind / task type for trace context. */
+  taskType?: string;
+  /** Per-error breakdown when `valid === false`. Each entry carries
+   *  the JSON path the agent should adjust. */
+  errors?: SubmissionValidationError[];
+  /** Top-level human-readable message; redundant with `errors[]` but
+   *  convenient for log lines. */
+  message?: string;
+}
+
+export interface SubmissionValidationError {
+  path: string;
+  code: string;
+  message: string;
+}
+
+/**
+ * Result of inspecting a `/jobs/definition` payload to figure out
+ * which local schema (if any) applies. Exposed mostly for testing —
+ * production code calls `validateSubmissionLocally`.
+ */
+export interface ValidatorSelection {
+  validator: SubmissionValidator;
+  taskType?: string;
+}
+
+interface JobDefinitionShape {
+  source?: { type?: string; taskType?: string } | unknown;
+  publicDetails?: { source?: string; taskType?: string } | unknown;
+}
+
+/**
+ * Pick a local Zod schema for a job. Returns `permissive` when we
+ * don't yet have a port of the upstream schema in this repo.
+ */
+export function selectValidator(jobDefinition: unknown): ValidatorSelection {
+  const def = (jobDefinition ?? {}) as JobDefinitionShape;
+  const source = isRecord(def.source) ? def.source : undefined;
+  const publicDetails = isRecord(def.publicDetails) ? def.publicDetails : undefined;
+
+  const sourceKind = stringField(source, "type") ?? stringField(publicDetails, "source");
+  if (sourceKind === "wikipedia_article" || sourceKind === "wikipedia") {
+    const taskType =
+      stringField(source, "taskType") ?? stringField(publicDetails, "taskType");
+    if (taskType) return { validator: "wikipedia", taskType };
+    return { validator: "permissive" };
+  }
+
+  return { validator: "permissive" };
+}
+
+/**
+ * Validate a submission payload against the right local schema for the
+ * given job definition. Caller is responsible for fetching the job
+ * definition (the MCP tool layer already does this for `_get_definition`
+ * and friends).
+ */
+export function validateSubmissionLocally(
+  jobDefinition: unknown,
+  output: unknown
+): SubmissionValidationResult {
+  const { validator, taskType } = selectValidator(jobDefinition);
+  if (validator === "permissive") {
+    return {
+      valid: true,
+      validator,
+      ...(taskType ? { taskType } : {}),
+    };
+  }
+
+  const schema = pickWikipediaSchema(taskType);
+  if (!schema) {
+    // Fall through to permissive when we recognise the source kind but
+    // not the specific task type — better than refusing a payload we
+    // can't actually evaluate.
+    return {
+      valid: true,
+      validator: "permissive",
+      ...(taskType ? { taskType } : {}),
+    };
+  }
+
+  const result = schema.safeParse(output);
+  if (result.success) {
+    return { valid: true, validator, taskType };
+  }
+
+  const errors = result.error.issues.map(formatIssue);
+  return {
+    valid: false,
+    validator,
+    taskType,
+    errors,
+    message:
+      errors.length === 1
+        ? errors[0].message
+        : `${errors.length} validation errors — see errors[].path/.message`,
+  };
+}
+
+function pickWikipediaSchema(taskType: string | undefined) {
+  if (!taskType) return undefined;
+  switch (taskType) {
+    case "citation_repair":
+      return wikipediaCitationRepairOutputSchema;
+    case "freshness_check":
+      return wikipediaFreshnessCheckOutputSchema;
+    case "infobox_consistency":
+      return wikipediaInfoboxConsistencyOutputSchema;
+    default:
+      return undefined;
+  }
+}
+
+function formatIssue(issue: z.ZodIssue): SubmissionValidationError {
+  const path = issue.path.length === 0 ? "(root)" : issue.path.map(String).join(".");
+  // Zod's `unrecognized_keys` issue is the one that catches the
+  // citation_number bug from the reference run. Surface the offending
+  // key inside the path so the message reads as
+  // `citation_findings.0.citation_number is not allowed`.
+  if (issue.code === "unrecognized_keys") {
+    const keys = Array.isArray((issue as { keys?: unknown }).keys)
+      ? ((issue as { keys: unknown[] }).keys.map(String))
+      : [];
+    const key = keys[0] ?? "<unknown>";
+    const fullPath = path === "(root)" ? key : `${path}.${key}`;
+    return {
+      path: fullPath,
+      code: issue.code,
+      message: `${fullPath} is not allowed (extra field)`,
+    };
+  }
+  return {
+    path,
+    code: issue.code,
+    message: `${path}: ${issue.message}`,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  if (!record) return undefined;
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/packages/averray-mcp/tsconfig.json
+++ b/packages/averray-mcp/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "composite": true
   },
-  "references": [{ "path": "../mcp-common" }],
+  "references": [{ "path": "../mcp-common" }, { "path": "../schemas" }],
   "include": ["src/**/*.ts"]
 }
 

--- a/test/unit/validate-submission.test.ts
+++ b/test/unit/validate-submission.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectValidator,
+  validateSubmissionLocally,
+} from "../../packages/averray-mcp/src/validate-submission.js";
+
+const wikipediaCitationRepairDefinition = {
+  source: { type: "wikipedia_article", taskType: "citation_repair" },
+};
+
+const validCitationRepairOutput = {
+  page_title: "Polkadot (cryptocurrency)",
+  revision_id: "1351905437",
+  citation_findings: [
+    {
+      section: "Funding",
+      problem: "outdated_source" as const,
+      current_claim: "Funding round figures are out of date.",
+      evidence_url: "https://example.com/2025-audit",
+    },
+  ],
+  proposed_changes: [
+    {
+      change_type: "replace_citation" as const,
+      target_text: "old citation",
+      replacement_text: "new citation",
+      source_url: "https://example.com/2025-audit",
+    },
+  ],
+  review_notes: "Editor should verify source reliability before publishing.",
+};
+
+describe("selectValidator", () => {
+  it("picks the Wikipedia validator from a wikipedia_article job definition", () => {
+    expect(selectValidator(wikipediaCitationRepairDefinition)).toEqual({
+      validator: "wikipedia",
+      taskType: "citation_repair",
+    });
+  });
+
+  it("falls back to permissive when source kind isn't a Wikipedia article", () => {
+    expect(
+      selectValidator({ source: { type: "github_issue", repo: "x/y", issueNumber: 1 } })
+    ).toEqual({ validator: "permissive" });
+  });
+
+  it("falls back to permissive when no source is present", () => {
+    expect(selectValidator({})).toEqual({ validator: "permissive" });
+    expect(selectValidator(null)).toEqual({ validator: "permissive" });
+  });
+
+  it("reads task type from publicDetails when source.taskType is missing", () => {
+    expect(
+      selectValidator({
+        source: { type: "wikipedia_article" },
+        publicDetails: { source: "wikipedia", taskType: "freshness_check" },
+      })
+    ).toEqual({ validator: "wikipedia", taskType: "freshness_check" });
+  });
+});
+
+describe("validateSubmissionLocally — Wikipedia citation_repair", () => {
+  it("rejects a proposal that adds an extra nested field (citation_number) with an actionable path", () => {
+    const output = {
+      ...validCitationRepairOutput,
+      citation_findings: [
+        {
+          ...validCitationRepairOutput.citation_findings[0],
+          citation_number: 1, // ← the bug from the reference run
+        },
+      ],
+    };
+    const result = validateSubmissionLocally(
+      wikipediaCitationRepairDefinition,
+      output
+    );
+    expect(result.valid).toBe(false);
+    expect(result.validator).toBe("wikipedia");
+    expect(result.taskType).toBe("citation_repair");
+    expect(result.errors).toBeDefined();
+    expect(result.errors!.length).toBeGreaterThan(0);
+    const issue = result.errors![0];
+    expect(issue.code).toBe("unrecognized_keys");
+    expect(issue.path).toBe("citation_findings.0.citation_number");
+    expect(issue.message).toContain("citation_findings.0.citation_number");
+    expect(issue.message).toContain("not allowed");
+  });
+
+  it("accepts a valid Wikipedia citation-repair proposal", () => {
+    const result = validateSubmissionLocally(
+      wikipediaCitationRepairDefinition,
+      validCitationRepairOutput
+    );
+    expect(result).toEqual({
+      valid: true,
+      validator: "wikipedia",
+      taskType: "citation_repair",
+    });
+  });
+
+  it("flags missing required top-level fields with their JSON path", () => {
+    const result = validateSubmissionLocally(wikipediaCitationRepairDefinition, {
+      page_title: "Polkadot",
+      revision_id: "123",
+      // citation_findings + proposed_changes + review_notes missing
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toBeDefined();
+    const paths = result.errors!.map((e) => e.path);
+    expect(paths).toContain("citation_findings");
+    expect(paths).toContain("proposed_changes");
+    expect(paths).toContain("review_notes");
+  });
+
+  it("rejects an unknown problem enum value with the offending path", () => {
+    const output = {
+      ...validCitationRepairOutput,
+      citation_findings: [
+        {
+          ...validCitationRepairOutput.citation_findings[0],
+          problem: "made_up_reason",
+        },
+      ],
+    };
+    const result = validateSubmissionLocally(
+      wikipediaCitationRepairDefinition,
+      output
+    );
+    expect(result.valid).toBe(false);
+    const issue = result.errors!.find(
+      (e) => e.path === "citation_findings.0.problem"
+    );
+    expect(issue).toBeDefined();
+  });
+});
+
+describe("validateSubmissionLocally — non-Wikipedia sources", () => {
+  it("returns permissive valid for source kinds without a local schema", () => {
+    const result = validateSubmissionLocally(
+      { source: { type: "open_data_dataset" } },
+      { whatever: "the agent submits" }
+    );
+    expect(result).toEqual({ valid: true, validator: "permissive" });
+  });
+
+  it("returns permissive valid for unknown Wikipedia task types", () => {
+    const result = validateSubmissionLocally(
+      { source: { type: "wikipedia_article", taskType: "future_task_we_dont_have_a_schema_for" } },
+      { whatever: "the agent submits" }
+    );
+    expect(result.valid).toBe(true);
+    expect(result.validator).toBe("permissive");
+    expect(result.taskType).toBe("future_task_we_dont_have_a_schema_for");
+  });
+});


### PR DESCRIPTION
Closes #24.

## What
- New \`packages/averray-mcp/src/validate-submission.ts\` runs the existing strict Zod schemas from \`packages/schemas\` against the agent's structured \`output\` for the right Wikipedia task type. Returns actionable JSON-path errors — the \`citation_number\` bug from the reference run surfaces as \`citation_findings.0.citation_number is not allowed (extra field)\`.
- New tool \`averray_validate_submission(jobId, output)\` — read-only, never touches the submission ledger or the backend. Agent can converge on a valid shape before spending its one-shot attempt.
- \`averray_submit\` runs the same validator BEFORE the mutation policy check. Invalid output returns \`{ blocked: true, reason: \"local_schema_validation_failed\", validation }\` and the budget stays untouched.
- 10 new unit tests covering the extra-field case, valid proposal, missing required fields, unknown enum, and selector behavior across source kinds.

## Acceptance criteria check
- [x] A Wikipedia citation-repair proposal containing an extra nested field such as \`citation_number\` is rejected locally with an actionable validation error.
- [x] Local validation failure does not consume the submit attempt budget and does not call the backend submit mutation.
- [x] A valid direct schema object with exactly \`page_title\`, \`revision_id\`, \`citation_findings\`, \`proposed_changes\`, and \`review_notes\` proceeds to the real \`averray_submit\` call.
- [x] Unit tests cover the extra-field case and a valid Wikipedia citation-repair proposal.

## Out of scope
- GitHub / OSV / OpenAPI / standards / open-data outputs fall through to a \`permissive\` validator result. The schemas package only ports Wikipedia today; we don't pre-block payloads we can't actually evaluate. As schemas land for other kinds, the selector picks them up by source.type + taskType.

## Test plan
- [x] \`npm test\` (vitest) — 31/31 pass; new file contributes 10 cases.
- [x] \`npm run typecheck\`
- [x] \`npm run build\`