### PR TITLE
Add Slack operational alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,7 @@ Then open `http://127.0.0.1:9119`.
   per run, blocks retries unless explicitly enabled, and can be narrowed with
   exact `AVERRAY_SUBMIT_SESSION_ALLOWLIST` and `AVERRAY_SUBMIT_JOB_ALLOWLIST`
   values.
+- Optional Slack operational alerts can be enabled with `SLACK_WEBHOOK_URL`.
+  They cover claim prechecks, claim/submit outcomes, local validation failures,
+  TTL warnings, and inventory exhaustion/replenishment. See
+  [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md#slack-operational-alerts).

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -55,6 +55,45 @@ docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -
   up -d --build --force-recreate hermes
 ```
 
+## Slack Operational Alerts
+
+Slack alerts are opt-in. If `SLACK_WEBHOOK_URL` is unset, the reference agent
+continues normally and alert delivery is skipped. When configured, alerts are
+short, redacted, and include safe identifiers such as `jobId`, `runId`,
+`sessionId`, wallet address, claim deadline, and whether a mutation budget was
+consumed.
+
+Configured events:
+
+- `claim_precheck_passed`
+- `claim_blocked`
+- `claim_succeeded`
+- `claim_failed`
+- `submit_validation_failed`
+- `submit_blocked`
+- `submit_succeeded`
+- `submit_failed`
+- `ttl_nearing_expiry`
+- `inventory_exhausted`
+- `inventory_replenished`
+
+Local submission validation alerts fire before `averray_submit` touches the
+submit mutation budget, so schema mistakes are visible without burning the
+one-shot submit attempt.
+
+Check the host env file:
+
+```bash
+grep -E '^SLACK_WEBHOOK_URL=.+$' .env.prod >/dev/null && echo "SLACK_WEBHOOK_URL configured"
+```
+
+Check the running Hermes container after boot or force-recreate:
+
+```bash
+docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
+  exec hermes sh -lc 'test -n "$SLACK_WEBHOOK_URL" && echo "SLACK_WEBHOOK_URL configured"'
+```
+
 ## Dashboard Access
 
 Hermes dashboard is not exposed publicly. Docker binds it to

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -11,6 +11,7 @@ import {
   trimTrailingSlash
 } from "@avg/mcp-common";
 import { evaluateClaimMutationPolicy, evaluateSubmitMutationPolicy, isUuid } from "./mutation-policy.js";
+import { postSlackAlert, validationFailureDetails } from "./slack-alerts.js";
 import { buildSubmitRequestBody } from "./submit-payload.js";
 import { validateSubmissionLocally } from "./validate-submission.js";
 
@@ -20,6 +21,8 @@ const server = new McpServer({
 });
 
 const baseUrl = trimTrailingSlash(optionalEnv("AVERRAY_API_BASE_URL", "https://api.averray.com"));
+const ttlAlertedSessions = new Set<string>();
+const inventoryStateByScope = new Map<string, boolean>();
 
 server.tool("averray_list_jobs", "List Averray jobs in compact form. Use search/source/category/state filters to find specific jobs without flooding context.", {
   recommendations: z.boolean().default(false),
@@ -31,7 +34,9 @@ server.tool("averray_list_jobs", "List Averray jobs in compact form. Use search/
 }, async ({ recommendations, search, source, category, state, limit }) => {
   const path = recommendations ? "/jobs/recommendations" : "/jobs";
   const payload = await request(path);
-  return jsonContent(compactJobsPayload(payload, { recommendations, search, source, category, state, limit }));
+  const compact = compactJobsPayload(payload, { recommendations, search, source, category, state, limit });
+  await maybePostInventoryAlert(compact, { recommendations, search, source, category, state, limit });
+  return jsonContent(compact);
 });
 
 server.tool("averray_get_definition", "Get the canonical job definition for a job id.", {
@@ -47,10 +52,34 @@ server.tool("averray_claim", "Claim a job through Averray's public API fallback 
 }, async ({ runId, jobId, idempotencyKey: providedKey }) => {
   await assertNoKillSwitch("averray_claim");
   const key = providedKey ?? idempotencyKey(["averray", jobId, "claim"]);
+  const definition = await safeGetDefinition(jobId);
   const policy = await evaluateClaimMutationPolicy({ runId, jobId, idempotencyKey: key }, query);
   if (!policy.allowed) {
+    await postSlackAlert({
+      kind: "claim_blocked",
+      title: "claim blocked before mutation",
+      identifiers: { jobId, runId: policy.runId },
+      details: {
+        reason: policy.reason,
+        mutationBudgetConsumed: false,
+        maxClaimAttempts: policy.maxClaimAttempts,
+        previousAttempts: policy.previousAttempts,
+        ...jobDefinitionDetails(definition),
+      },
+    });
     return jsonContent({ blocked: true, tool: "averray_claim", policy });
   }
+  await postSlackAlert({
+    kind: "claim_precheck_passed",
+    title: "claim precheck passed",
+    identifiers: { jobId, runId: policy.runId },
+    details: {
+      mutationBudgetConsumed: false,
+      maxClaimAttempts: policy.maxClaimAttempts,
+      previousAttempts: policy.previousAttempts,
+      ...jobDefinitionDetails(definition),
+    },
+  });
 
   const session = await authSession();
   await upsertSubmission({ runId, kind: "claim", key, request: { jobId, policyRunId: policy.runId } });
@@ -61,9 +90,37 @@ server.tool("averray_claim", "Claim a job through Averray's public API fallback 
       body: { jobId, idempotencyKey: key }
     });
     await completeSubmission(key, response);
+    const sessionDetails = sessionResponseDetails(response);
+    await postSlackAlert({
+      kind: "claim_succeeded",
+      title: "claim succeeded",
+      identifiers: {
+        jobId,
+        runId: policy.runId,
+        sessionId: sessionDetails.sessionId,
+        wallet: session.wallet,
+      },
+      details: {
+        claimDeadline: sessionDetails.claimDeadline,
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        ...jobDefinitionDetails(definition),
+      },
+    });
     return jsonContent({ idempotencyKey: key, policy, response });
   } catch (error) {
     await failSubmission(key, error);
+    await postSlackAlert({
+      kind: "claim_failed",
+      title: "claim failed after mutation attempt",
+      identifiers: { jobId, runId: policy.runId, wallet: session.wallet },
+      details: {
+        error: error instanceof Error ? error.message : String(error),
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        ...jobDefinitionDetails(definition),
+      },
+    });
     throw error;
   }
 });
@@ -78,6 +135,18 @@ server.tool(
   async ({ jobId, output }) => {
     const definition = await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
     const validation = validateSubmissionLocally(definition, output);
+    if (!validation.valid) {
+      await postSlackAlert({
+        kind: "submit_validation_failed",
+        title: "local submission validation failed",
+        identifiers: { jobId },
+        details: {
+          mutationBudgetConsumed: false,
+          ...validationFailureDetails(validation),
+          ...jobDefinitionDetails(definition),
+        },
+      });
+    }
     return jsonContent({ jobId, ...validation });
   }
 );
@@ -107,6 +176,16 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
       // Couldn't reach the definition endpoint — surface the error to
       // the agent rather than silently skipping validation. The
       // mutation budget is untouched.
+      await postSlackAlert({
+        kind: "submit_blocked",
+        title: "submit blocked before mutation",
+        identifiers: { jobId, runId, sessionId },
+        details: {
+          reason: "definition_fetch_failed",
+          message: error instanceof Error ? error.message : String(error),
+          mutationBudgetConsumed: false,
+        },
+      });
       return jsonContent({
         blocked: true,
         tool: "averray_submit",
@@ -116,6 +195,16 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
     }
     const validation = validateSubmissionLocally(definition, output);
     if (!validation.valid) {
+      await postSlackAlert({
+        kind: "submit_validation_failed",
+        title: "local submission validation failed",
+        identifiers: { jobId, runId, sessionId },
+        details: {
+          mutationBudgetConsumed: false,
+          ...validationFailureDetails(validation),
+          ...jobDefinitionDetails(definition),
+        },
+      });
       return jsonContent({
         blocked: true,
         tool: "averray_submit",
@@ -128,6 +217,17 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
   const key = idempotencyKey(["averray", runId ?? sessionId, "submit", outputHash ?? JSON.stringify(output)]);
   const policy = await evaluateSubmitMutationPolicy({ runId, sessionId, jobId, idempotencyKey: key }, query);
   if (!policy.allowed) {
+    await postSlackAlert({
+      kind: "submit_blocked",
+      title: "submit blocked before mutation",
+      identifiers: { jobId: policy.jobId, runId: policy.runId, sessionId },
+      details: {
+        reason: policy.reason,
+        mutationBudgetConsumed: false,
+        maxSubmitAttempts: policy.maxSubmitAttempts,
+        previousAttempts: policy.previousAttempts,
+      },
+    });
     return jsonContent({ blocked: true, tool: "averray_submit", policy });
   }
 
@@ -140,9 +240,31 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
       body: buildSubmitRequestBody({ sessionId, output })
     });
     await completeSubmission(key, response);
+    await postSlackAlert({
+      kind: "submit_succeeded",
+      title: "submit succeeded",
+      identifiers: { jobId, runId: policy.runId, sessionId, wallet: session.wallet },
+      details: {
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        outputHash,
+        ...submitResponseDetails(response),
+      },
+    });
     return jsonContent({ idempotencyKey: key, policy, response });
   } catch (error) {
     await failSubmission(key, error);
+    await postSlackAlert({
+      kind: "submit_failed",
+      title: "submit failed after mutation attempt",
+      identifiers: { jobId, runId: policy.runId, sessionId, wallet: session.wallet },
+      details: {
+        error: error instanceof Error ? error.message : String(error),
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        outputHash,
+      },
+    });
     throw error;
   }
 });
@@ -151,7 +273,9 @@ server.tool("averray_observe_session", "Read the current Averray session state a
   sessionId: z.string().min(1)
 }, async ({ sessionId }) => {
   const session = await authSession();
-  return jsonContent(await request(`/session?sessionId=${encodeURIComponent(sessionId)}`, { token: session.token }));
+  const payload = await request(`/session?sessionId=${encodeURIComponent(sessionId)}`, { token: session.token });
+  await maybePostTtlAlert(sessionId, payload, session.wallet);
+  return jsonContent(payload);
 });
 
 await runStdioServer(server);
@@ -185,6 +309,14 @@ async function request(path: string, options: { method?: string; token?: string;
     throw new Error(`${path} failed ${response.status}: ${payload?.message ?? "unknown_error"}`);
   }
   return payload;
+}
+
+async function safeGetDefinition(jobId: string): Promise<unknown> {
+  try {
+    return await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
+  } catch {
+    return undefined;
+  }
 }
 
 async function upsertSubmission(input: { runId?: string; kind: "claim" | "submit"; key: string; request: unknown }) {
@@ -245,6 +377,114 @@ function compactJobsPayload(
         ? "Result was truncated. Re-run with a narrower search/source/category/state filter or a higher limit."
         : "Use averray_get_definition(jobId) for full details before planning work."
   };
+}
+
+async function maybePostInventoryAlert(
+  compact: ReturnType<typeof compactJobsPayload>,
+  filters: { recommendations: boolean; search?: string; source?: string; category?: string; state?: string; limit: number }
+) {
+  const scope = JSON.stringify({
+    recommendations: filters.recommendations,
+    search: filters.search ?? null,
+    source: filters.source ?? null,
+    category: filters.category ?? null,
+    state: filters.state ?? null,
+  });
+  const hasInventory = compact.matched > 0;
+  const previous = inventoryStateByScope.get(scope);
+  inventoryStateByScope.set(scope, hasInventory);
+  if (previous === undefined && hasInventory) return;
+  if (previous === hasInventory) return;
+  if (hasInventory) {
+    await postSlackAlert({
+      kind: "inventory_replenished",
+      title: "job inventory replenished",
+      identifiers: { scope },
+      details: { matched: compact.matched, total: compact.total, returned: compact.returned },
+    });
+    return;
+  }
+  await postSlackAlert({
+    kind: "inventory_exhausted",
+    title: "job inventory exhausted",
+    identifiers: { scope },
+    details: { matched: compact.matched, total: compact.total, returned: compact.returned },
+  });
+}
+
+async function maybePostTtlAlert(sessionId: string, payload: unknown, wallet: string) {
+  const deadline = firstDeepString(payload, ["claimExpiresAt", "claim_expires_at", "claimDeadline", "deadline"]);
+  if (!deadline) return;
+  const deadlineMs = Date.parse(deadline);
+  if (!Number.isFinite(deadlineMs)) return;
+  const ttlMs = deadlineMs - Date.now();
+  const thresholdMs = Number.parseInt(optionalEnv("AVERRAY_SLACK_TTL_WARNING_MS", "600000"), 10);
+  if (ttlMs <= 0 || ttlMs > thresholdMs) return;
+  const state = firstDeepString(payload, ["status", "state"]);
+  if (state && !["claimed", "active", "open"].includes(state.toLowerCase())) return;
+  const key = `${sessionId}:${deadline}`;
+  if (ttlAlertedSessions.has(key)) return;
+  ttlAlertedSessions.add(key);
+  await postSlackAlert({
+    kind: "ttl_nearing_expiry",
+    title: "claim TTL nearing expiry",
+    identifiers: {
+      jobId: firstDeepString(payload, ["jobId", "job_id"]),
+      runId: firstDeepString(payload, ["runId", "run_id"]),
+      sessionId,
+      wallet,
+    },
+    details: {
+      claimDeadline: deadline,
+      ttlSecondsRemaining: Math.max(0, Math.round(ttlMs / 1000)),
+      state,
+      mutationBudgetConsumed: false,
+    },
+  });
+}
+
+function jobDefinitionDetails(definition: unknown) {
+  if (!isRecord(definition)) return {};
+  const source = isRecord(definition.source) ? definition.source : {};
+  const reward = isRecord(definition.reward) ? definition.reward : {};
+  return {
+    title: firstString(definition.title, definition.name, definition.summary),
+    source: firstString(source.type, source.kind, definition.sourceType, definition.source),
+    taskType: firstString(source.taskType, definition.taskType),
+    verifierMode: firstString(definition.verifierMode, definition.verifier),
+    reward: firstPresent(definition.rewardAmount, reward.amount, definition.reward),
+    rewardAsset: firstString(definition.rewardAsset, reward.asset),
+  };
+}
+
+function sessionResponseDetails(response: unknown) {
+  return {
+    sessionId: firstDeepString(response, ["sessionId", "session_id"]),
+    claimDeadline: firstDeepString(response, ["claimExpiresAt", "claim_expires_at", "claimDeadline", "deadline"]),
+  };
+}
+
+function submitResponseDetails(response: unknown) {
+  return {
+    verifierMode: firstDeepString(response, ["verifierMode", "verifier_mode"]),
+    reward: firstDeepString(response, ["reward", "rewardAmount", "reward_amount"]),
+    state: firstDeepString(response, ["state", "status"]),
+  };
+}
+
+function firstDeepString(value: unknown, keys: string[], depth = 0): string | undefined {
+  if (depth > 5 || !isRecord(value)) return undefined;
+  for (const key of keys) {
+    const direct = value[key];
+    if (typeof direct === "string" && direct.length > 0) return direct;
+  }
+  for (const nested of Object.values(value)) {
+    if (isRecord(nested)) {
+      const match = firstDeepString(nested, keys, depth + 1);
+      if (match) return match;
+    }
+  }
+  return undefined;
 }
 
 function extractJobArray(payload: unknown): unknown[] {

--- a/packages/averray-mcp/src/slack-alerts.ts
+++ b/packages/averray-mcp/src/slack-alerts.ts
@@ -1,0 +1,156 @@
+import { logger, optionalEnv } from "@avg/mcp-common";
+
+export type SlackSeverity = "info" | "success" | "warning" | "error";
+
+export type SlackAlertKind =
+  | "claim_precheck_passed"
+  | "claim_blocked"
+  | "claim_succeeded"
+  | "claim_failed"
+  | "submit_validation_failed"
+  | "submit_blocked"
+  | "submit_succeeded"
+  | "submit_failed"
+  | "ttl_nearing_expiry"
+  | "inventory_exhausted"
+  | "inventory_replenished";
+
+export interface SlackAlert {
+  kind: SlackAlertKind;
+  severity?: SlackSeverity;
+  title: string;
+  identifiers?: Record<string, unknown>;
+  details?: Record<string, unknown>;
+}
+
+export interface SlackPayload {
+  text: string;
+}
+
+const MAX_FIELD_LENGTH = 320;
+const MAX_TEXT_LENGTH = 3500;
+const SECRET_KEY_RE = /(?:private.?key|secret|token|authorization|jwt|password|mnemonic|signature|webhook)/iu;
+
+const SEVERITY_ICON: Record<SlackSeverity, string> = {
+  info: "[info]",
+  success: "[ok]",
+  warning: "[warn]",
+  error: "[error]",
+};
+
+export async function postSlackAlert(alert: SlackAlert, webhookUrl = optionalEnv("SLACK_WEBHOOK_URL")) {
+  if (!webhookUrl) return;
+  const payload = buildSlackPayload(alert);
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      logger.warn({ status: response.status, kind: alert.kind }, "slack_post_failed");
+    }
+  } catch (error) {
+    logger.warn({ err: error, kind: alert.kind }, "slack_post_failed");
+  }
+}
+
+export function buildSlackPayload(alert: SlackAlert): SlackPayload {
+  const severity = alert.severity ?? severityForKind(alert.kind);
+  const lines = [
+    `${SEVERITY_ICON[severity]} *Averray reference agent*: ${alert.title}`,
+    `event: \`${alert.kind}\``,
+    ...formatRecord("ids", alert.identifiers),
+    ...formatRecord("details", alert.details),
+  ];
+  return { text: truncate(lines.join("\n"), MAX_TEXT_LENGTH) };
+}
+
+export function validationFailureDetails(validation: unknown) {
+  const record = asRecord(validation);
+  const errors = Array.isArray(record.errors) ? record.errors.slice(0, 6) : [];
+  const paths = errors
+    .map((entry) => asRecord(entry).path)
+    .filter((path): path is string => typeof path === "string" && path.length > 0);
+  const messages = errors
+    .map((entry) => {
+      const error = asRecord(entry);
+      const path = typeof error.path === "string" ? error.path : "(unknown)";
+      const message = typeof error.message === "string" ? error.message : "invalid";
+      return `${path}: ${message}`;
+    })
+    .filter(Boolean);
+  return {
+    validator: record.validator,
+    taskType: record.taskType,
+    errorCount: Array.isArray(record.errors) ? record.errors.length : 0,
+    paths,
+    messages,
+  };
+}
+
+function formatRecord(label: string, value: Record<string, unknown> | undefined): string[] {
+  if (!value || Object.keys(value).length === 0) return [];
+  const lines = [`*${label}*`];
+  for (const [key, raw] of Object.entries(value)) {
+    const sanitized = sanitizeValue(key, raw);
+    if (sanitized === undefined || sanitized === null || sanitized === "") continue;
+    lines.push(`- ${key}: ${formatValue(sanitized)}`);
+  }
+  return lines;
+}
+
+function sanitizeValue(key: string, value: unknown): unknown {
+  if (SECRET_KEY_RE.test(key)) return "[redacted]";
+  if (Array.isArray(value)) {
+    return value.slice(0, 8).map((item) => sanitizeValue(key, item));
+  }
+  if (isRecord(value)) {
+    const next: Record<string, unknown> = {};
+    for (const [childKey, childValue] of Object.entries(value)) {
+      next[childKey] = sanitizeValue(childKey, childValue);
+    }
+    return next;
+  }
+  if (typeof value === "string") return truncate(redactInlineSecrets(value), MAX_FIELD_LENGTH);
+  return value;
+}
+
+function formatValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map((entry) => `\`${escapeSlack(String(entry))}\``).join(", ");
+  if (isRecord(value)) return `\`${escapeSlack(JSON.stringify(value))}\``;
+  return `\`${escapeSlack(String(value))}\``;
+}
+
+function severityForKind(kind: SlackAlertKind): SlackSeverity {
+  if (kind.endsWith("_succeeded") || kind === "claim_precheck_passed" || kind === "inventory_replenished") {
+    return "success";
+  }
+  if (kind.endsWith("_failed")) return "error";
+  if (kind.endsWith("_blocked") || kind === "submit_validation_failed" || kind === "ttl_nearing_expiry" || kind === "inventory_exhausted") {
+    return "warning";
+  }
+  return "info";
+}
+
+function redactInlineSecrets(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gu, "Bearer [redacted]")
+    .replace(/0x[a-f0-9]{64}/giu, "[redacted-hex-secret]");
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 3))}...`;
+}
+
+function escapeSlack(value: string): string {
+  return value.replace(/&/gu, "&amp;").replace(/</gu, "&lt;").replace(/>/gu, "&gt;");
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/unit/slack-alerts.test.ts
+++ b/test/unit/slack-alerts.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSlackPayload,
+  validationFailureDetails,
+} from "../../packages/averray-mcp/src/slack-alerts.js";
+
+describe("Slack operational alerts", () => {
+  it("formats claim alerts with identifiers and mutation budget state", () => {
+    const payload = buildSlackPayload({
+      kind: "claim_succeeded",
+      title: "claim succeeded",
+      identifiers: {
+        jobId: "wiki-en-62871101-citation-repair-hash",
+        runId: "controlled-wikipedia-hash-001",
+        sessionId: "session-123",
+        wallet: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+      },
+      details: {
+        claimDeadline: "2026-05-02T12:00:00.000Z",
+        mutationBudgetConsumed: true,
+      },
+    });
+
+    expect(payload.text).toContain("claim succeeded");
+    expect(payload.text).toContain("wiki-en-62871101-citation-repair-hash");
+    expect(payload.text).toContain("controlled-wikipedia-hash-001");
+    expect(payload.text).toContain("session-123");
+    expect(payload.text).toContain("mutationBudgetConsumed: `true`");
+  });
+
+  it("redacts secret-like fields and inline bearer/hex secrets", () => {
+    const privateKey = `0x${"a".repeat(64)}`;
+    const inlineHexSecret = `0x${"b".repeat(64)}`;
+    const payload = buildSlackPayload({
+      kind: "submit_failed",
+      title: "submit failed",
+      identifiers: {
+        jobId: "job-1",
+        authorization: "Bearer abc.def.ghi",
+      },
+      details: {
+        privateKey,
+        message: `server said Bearer abc.def.ghi and ${inlineHexSecret}`,
+      },
+    });
+
+    expect(payload.text).toContain("[redacted]");
+    expect(payload.text).toContain("Bearer [redacted]");
+    expect(payload.text).toContain("[redacted-hex-secret]");
+    expect(payload.text).not.toContain("abc.def.ghi");
+    expect(payload.text).not.toContain("aaaaaaaaaaaaaaaa");
+    expect(payload.text).not.toContain("bbbbbbbbbbbbbbbb");
+  });
+
+  it("summarizes local validation failures with actionable JSON paths", () => {
+    const details = validationFailureDetails({
+      valid: false,
+      validator: "wikipedia",
+      taskType: "citation_repair",
+      errors: [
+        {
+          path: "citation_findings.0.citation_number",
+          code: "unrecognized_keys",
+          message: "citation_findings.0.citation_number is not allowed",
+        },
+      ],
+    });
+
+    expect(details).toEqual({
+      validator: "wikipedia",
+      taskType: "citation_repair",
+      errorCount: 1,
+      paths: ["citation_findings.0.citation_number"],
+      messages: [
+        "citation_findings.0.citation_number: citation_findings.0.citation_number is not allowed",
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Closes #26.\n\n## What changed\n- Adds opt-in Slack webhook alerts for claim precheck/block/success/failure, local validation failures, submit block/success/failure, TTL warnings, and inventory exhaustion/replenishment.\n- Includes safe identifiers and mutation-budget status while redacting secret-looking fields and long payload bodies.\n- Documents VPS setup checks and the configured event vocabulary.\n\n## Checks\n- npm run typecheck\n- npm test\n- npm run build\n\n## Impact\n- MCP/reference-agent backend only.\n- Requires no env changes unless operators want Slack alerts; set SLACK_WEBHOOK_URL to enable.