### PR TITLE
Add safe Hermes Workspace command-center evaluation path

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ ssh -L 9119:localhost:9119 ubuntu@YOUR_VPS
 
 Then open `http://127.0.0.1:9119`.
 
+## Optional Command Center
+
+Hermes Workspace can be evaluated as a richer operator UI through an opt-in
+Compose overlay. It is disabled by default and keeps the workspace UI and
+gateway bound to VPS localhost for SSH/Tailscale access.
+
+Start with [docs/COMMAND_CENTER.md](docs/COMMAND_CENTER.md). Do not install
+Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
+
 ## Safety Defaults
 
 - Testnet only.

--- a/docs/COMMAND_CENTER.md
+++ b/docs/COMMAND_CENTER.md
@@ -1,0 +1,143 @@
+# Command Center Evaluation
+
+This runbook evaluates Hermes Workspace as an optional operator command center
+for the Averray reference agent. It is not part of the default smoke path.
+
+## Decision Snapshot
+
+Hermes Workspace is worth evaluating as a companion UI, not a replacement yet.
+It can attach to an existing Hermes gateway and Hermes dashboard pair:
+
+- gateway API on `:8642`
+- dashboard API on `:9119`
+- workspace UI on `:3000`
+
+The reference stack already runs the built-in Hermes dashboard on `9119`. This
+overlay adds a separate Hermes gateway process and the Workspace UI, both
+published only to VPS localhost.
+
+## Safety Model
+
+- Do not install Hermes Workspace with `curl | bash` on the VPS.
+- Do not bind the command center to a public interface.
+- Use SSH or Tailscale tunnels to reach the UI.
+- Set a strong `HERMES_WORKSPACE_PASSWORD` before starting the workspace.
+- Do not mount the Docker socket.
+- Do not give the Workspace container the Averray wallet private key or MCP
+  runtime env volume. The gateway owns agent execution; the UI only talks to
+  the gateway and dashboard APIs.
+- Treat browser terminal access as powerful operator access. If the UI exposes
+  a terminal, assume it can run commands inside its container context.
+
+## Configure
+
+Add these values to `.env.prod`:
+
+```dotenv
+HERMES_WORKSPACE_IMAGE=ghcr.io/outsourc-e/hermes-workspace:latest
+HERMES_WORKSPACE_PORT=3000
+HERMES_GATEWAY_PORT=8642
+
+# Optional. If set, the Workspace passes this token to the gateway.
+HERMES_GATEWAY_API_KEY=
+
+# Required by the compose overlay. Use a long random value.
+HERMES_WORKSPACE_PASSWORD=change-this-to-a-long-random-password
+
+# Keep 0 for plain HTTP over SSH/Tailscale localhost tunnels.
+HERMES_WORKSPACE_COOKIE_SECURE=0
+HERMES_WORKSPACE_TRUST_PROXY=0
+```
+
+## Start
+
+From the VPS checkout:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -p avg \
+  --profile command-center \
+  up -d hermes hermes-gateway hermes-workspace
+```
+
+The default stack remains unchanged if `ops/compose.command-center.yml` and the
+`command-center` profile are omitted.
+
+## Open
+
+From your laptop, tunnel the dashboard, gateway, and Workspace UI:
+
+```bash
+ssh \
+  -L 3000:localhost:3000 \
+  -L 8642:localhost:8642 \
+  -L 9119:localhost:9119 \
+  ubuntu@YOUR_VPS
+```
+
+Then open:
+
+```text
+http://127.0.0.1:3000
+```
+
+The existing built-in Hermes dashboard remains available at:
+
+```text
+http://127.0.0.1:9119
+```
+
+## Verify
+
+Check the command-center services:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -p avg \
+  --profile command-center \
+  ps hermes-gateway hermes-workspace
+```
+
+Check the gateway and dashboard from the VPS:
+
+```bash
+curl -fsS http://127.0.0.1:8642/health
+curl -fsS http://127.0.0.1:9119/api/status
+```
+
+In the Workspace UI, verify:
+
+- it detects the gateway URL `http://hermes-gateway:8642`
+- it detects the dashboard URL `http://hermes:9119`
+- chat can reach the configured Hermes provider
+- sessions/tool activity are visible, if supported by the pinned Hermes image
+- terminal/file/memory panes are either usable or clearly marked unsupported
+
+## Shut Down
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -p avg \
+  --profile command-center \
+  stop hermes-workspace hermes-gateway
+```
+
+## Findings To Record
+
+After the evaluation, record:
+
+- whether the pinned `nousresearch/hermes-agent` image exposes enough gateway
+  and dashboard APIs for Hermes Workspace enhanced mode
+- whether the UI is useful for Averray operations without terminal logs
+- whether the Workspace should stay as an optional companion, replace the
+  built-in dashboard, or give way to a small custom Averray operator UI
+- any security gaps before broader use

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -29,6 +29,16 @@ OLLAMA_BASE_URL=https://ollama.com/v1
 HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud
 HERMES_COMPARISON_MODEL=qwen3.5:cloud
 
+# Optional command-center evaluation. See docs/COMMAND_CENTER.md.
+# Keep these ports localhost-bound through ops/compose.command-center.yml.
+HERMES_WORKSPACE_IMAGE=ghcr.io/outsourc-e/hermes-workspace:latest
+HERMES_WORKSPACE_PORT=3000
+HERMES_GATEWAY_PORT=8642
+HERMES_GATEWAY_API_KEY=
+HERMES_WORKSPACE_PASSWORD=
+HERMES_WORKSPACE_COOKIE_SECURE=0
+HERMES_WORKSPACE_TRUST_PROXY=0
+
 SLACK_WEBHOOK_URL=
 POLICY_CONFIG_PATH=/config/policy.yaml
 HALT_FILE=/data/HALT

--- a/ops/compose.command-center.yml
+++ b/ops/compose.command-center.yml
@@ -1,0 +1,83 @@
+# Optional Hermes Workspace evaluation overlay.
+#
+# This file is intentionally not part of the default VPS smoke path. Start it
+# only with `--profile command-center` after reading docs/COMMAND_CENTER.md.
+services:
+  hermes-gateway:
+    image: ${HERMES_IMAGE}
+    profiles: ["command-center"]
+    restart: unless-stopped
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+      mcp-bundle:
+        condition: service_completed_successfully
+      mcp-env:
+        condition: service_completed_successfully
+      skills-observer:
+        condition: service_started
+    environment:
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+      HERMES_DEFAULT_MODEL: ${HERMES_DEFAULT_MODEL:-deepseek-v4-pro:cloud}
+      HERMES_COMPARISON_MODEL: ${HERMES_COMPARISON_MODEL:-qwen3.5:cloud}
+      TRACE_HTTP_PORT: ${TRACE_HTTP_PORT:-8789}
+      TRACE_HTTP_URL: http://127.0.0.1:${TRACE_HTTP_PORT:-8789}/hermes-event
+      DATABASE_URL: ${DATABASE_URL}
+      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
+      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
+      POLICY_CONFIG_PATH: /config/policy.yaml
+      HALT_FILE: ${HALT_FILE:-/data/HALT}
+      WALLET_NETWORK: testnet
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      API_SERVER_ENABLED: "true"
+      API_SERVER_HOST: 0.0.0.0
+      API_SERVER_KEY: ${HERMES_GATEWAY_API_KEY:-}
+    volumes:
+      - avg-hermes:/opt/data
+      - avg-app:/app:ro
+      - avg-data:/data
+      - avg-mcp-env:/config-runtime:ro
+      - ../hermes/config/hermes.yaml:/opt/data/config.yaml:ro
+      - ../hermes/config/policy.yaml:/config/policy.yaml:ro
+      - ../hermes/plugins:/opt/data/plugins:ro
+      - ../hermes/profiles:/opt/data/browser-profiles
+      - avg-hermes-skills:/opt/data/skills
+    networks: [avg-internal]
+    ports:
+      - "127.0.0.1:${HERMES_GATEWAY_PORT:-8642}:8642"
+    command: ["gateway", "run"]
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/hermes/.venv/bin/python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8642/health', timeout=2).read()\""
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  hermes-workspace:
+    image: ${HERMES_WORKSPACE_IMAGE:-ghcr.io/outsourc-e/hermes-workspace:latest}
+    profiles: ["command-center"]
+    restart: unless-stopped
+    depends_on:
+      hermes:
+        condition: service_started
+      hermes-gateway:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      HOST: 0.0.0.0
+      PORT: 3000
+      HERMES_API_URL: http://hermes-gateway:8642
+      HERMES_DASHBOARD_URL: http://hermes:9119
+      HERMES_API_TOKEN: ${HERMES_GATEWAY_API_KEY:-}
+      CLAUDE_PASSWORD: ${HERMES_WORKSPACE_PASSWORD:?Set HERMES_WORKSPACE_PASSWORD in .env.prod before enabling the command center}
+      COOKIE_SECURE: ${HERMES_WORKSPACE_COOKIE_SECURE:-0}
+      TRUST_PROXY: ${HERMES_WORKSPACE_TRUST_PROXY:-0}
+    networks: [avg-internal]
+    ports:
+      - "127.0.0.1:${HERMES_WORKSPACE_PORT:-3000}:3000"


### PR DESCRIPTION
## What changed

- Added an opt-in `ops/compose.command-center.yml` overlay for evaluating Hermes Workspace behind the existing reference-agent stack.
- Added `docs/COMMAND_CENTER.md` with configure/start/open/verify/shutdown steps.
- Added command-center env placeholders to `ops/.env.example`.
- Linked the command-center runbook from `README.md`.

## Safety posture

- Disabled by default; normal smoke/deploy commands are unchanged.
- UI and gateway ports bind to `127.0.0.1` only.
- Requires `HERMES_WORKSPACE_PASSWORD` before the Workspace service starts.
- No Docker socket mount.
- Workspace container does not receive wallet private key or MCP runtime env volume.
- Explicitly forbids `curl | bash` installation on the VPS.

## Checks

- `npm install`
- `npm run build`
- `npm run typecheck`
- `npm test`
- `git diff --check`
- YAML parse validation for `ops/compose.yml`, `ops/compose.prod.yml`, and `ops/compose.command-center.yml`

Could not run `docker compose config` locally because this machine does not have the Docker Compose plugin (`docker: unknown command: docker compose`).

Closes #27
