### PR TITLE
Persist draft submission objects before validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   per run, blocks retries unless explicitly enabled, and can be narrowed with
   exact `AVERRAY_SUBMIT_SESSION_ALLOWLIST` and `AVERRAY_SUBMIT_JOB_ALLOWLIST`
   values.
+- Submission proposals should be persisted before validation with
+  `averray_save_draft_submission`. Resumed sessions can use
+  `averray_get_draft_submission`, `averray_list_draft_submissions`, or pass
+  `draftId` into `averray_validate_submission` / `averray_submit` so validation
+  and submit use the exact same structured JSON object instead of reconstructed
+  chat text.
 - Optional Slack operational alerts can be enabled with `SLACK_WEBHOOK_URL`.
   They cover claim prechecks, claim/submit outcomes, local validation failures,
   TTL warnings, and inventory exhaustion/replenishment. See

--- a/ops/migrations/001_init.sql
+++ b/ops/migrations/001_init.sql
@@ -36,6 +36,26 @@ create table if not exists submissions (
   updated_at timestamptz default now()
 );
 
+create table if not exists draft_submissions (
+  draft_id text primary key,
+  run_id text,
+  job_id text not null,
+  session_id text,
+  output jsonb not null,
+  output_hash text not null,
+  output_bytes integer not null check (output_bytes >= 2),
+  proposal_only boolean not null default true,
+  no_wikipedia_edit boolean not null default true,
+  validation_status text not null default 'unvalidated'
+    check (validation_status in ('unvalidated', 'valid', 'invalid')),
+  validation_result jsonb not null default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  check (run_id is not null or session_id is not null),
+  check (proposal_only = true),
+  check (no_wikipedia_edit = true)
+);
+
 create table if not exists receipts (
   id uuid primary key default gen_random_uuid(),
   run_id uuid unique references runs(id) on delete cascade,
@@ -87,3 +107,5 @@ create table if not exists auth_sessions (
 
 create index if not exists tool_calls_run_idx on tool_calls(run_id, idx);
 create index if not exists skills_observed_file_idx on skills_observed(file_path);
+create index if not exists draft_submissions_lookup_idx on draft_submissions(job_id, run_id, session_id, updated_at desc);
+create index if not exists draft_submissions_session_idx on draft_submissions(session_id, updated_at desc);

--- a/packages/averray-mcp/src/draft-submissions.ts
+++ b/packages/averray-mcp/src/draft-submissions.ts
@@ -1,0 +1,332 @@
+import { Buffer } from "node:buffer";
+import {
+  canonicalJson,
+  idempotencyKey,
+  optionalEnv,
+  sha256Text,
+} from "@avg/mcp-common";
+
+export type DraftQueryFn = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[]
+) => Promise<T[]>;
+
+export interface DraftSubmission {
+  draftId: string;
+  runId?: string;
+  jobId: string;
+  sessionId?: string;
+  output: Record<string, unknown>;
+  outputHash: string;
+  outputBytes: number;
+  proposalOnly: boolean;
+  noWikipediaEdit: boolean;
+  validationStatus: "unvalidated" | "valid" | "invalid";
+  validationResult?: unknown;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface DraftSummary {
+  draftId: string;
+  runId?: string;
+  jobId: string;
+  sessionId?: string;
+  outputHash: string;
+  outputBytes: number;
+  proposalOnly: boolean;
+  noWikipediaEdit: boolean;
+  validationStatus: "unvalidated" | "valid" | "invalid";
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SaveDraftInput {
+  runId?: string;
+  jobId: string;
+  sessionId?: string;
+  output: unknown;
+  proposalOnly?: boolean;
+  noWikipediaEdit?: boolean;
+}
+
+export interface DraftLookup {
+  draftId?: string;
+  runId?: string;
+  jobId?: string;
+  sessionId?: string;
+}
+
+export interface NormalizedDraftOutput {
+  output: Record<string, unknown>;
+  outputHash: string;
+  outputBytes: number;
+  warning?: string;
+}
+
+const SECRET_KEY_PATTERN =
+  /(^|[_-])(private.?key|seed.?phrase|mnemonic|password|secret|api.?key|access.?token|bearer|authorization|jwt)($|[_-])/i;
+
+export function buildDraftId(input: {
+  runId?: string;
+  jobId: string;
+  sessionId?: string;
+}): string {
+  return idempotencyKey(["draft-submission", input.runId, input.jobId, input.sessionId]);
+}
+
+export function normalizeDraftOutput(input: unknown): NormalizedDraftOutput {
+  let value = input;
+  let warning: string | undefined;
+  if (typeof input === "string") {
+    try {
+      value = JSON.parse(input);
+      warning = "parsed_stringified_json_object";
+    } catch {
+      throw new Error(
+        "draft_submission_output_must_be_object: output was a string, not JSON. Load the saved draft or pass the structured object directly."
+      );
+    }
+  }
+
+  if (!isRecord(value)) {
+    throw new Error(
+      "draft_submission_output_must_be_object: pass the top-level schema object, not a string, array, or primitive."
+    );
+  }
+  assertNoSecretLikeKeys(value);
+  const serialized = canonicalJson(value);
+  const outputBytes = Buffer.byteLength(serialized, "utf8");
+  const maxBytes = Number.parseInt(optionalEnv("AVERRAY_DRAFT_MAX_BYTES", "200000"), 10);
+  if (outputBytes > maxBytes) {
+    throw new Error(`draft_submission_too_large: ${outputBytes} bytes exceeds limit ${maxBytes}`);
+  }
+  return {
+    output: value,
+    outputHash: sha256Text(serialized),
+    outputBytes,
+    ...(warning ? { warning } : {}),
+  };
+}
+
+export async function saveDraftSubmission(
+  input: SaveDraftInput,
+  query: DraftQueryFn
+): Promise<DraftSubmission> {
+  if (!input.jobId) throw new Error("draft_job_id_required");
+  if (!input.runId && !input.sessionId) {
+    throw new Error("draft_lookup_key_required: provide runId or sessionId before saving a draft");
+  }
+  if (input.proposalOnly === false || input.noWikipediaEdit === false) {
+    throw new Error("draft_must_be_proposal_only: drafts may not claim a direct Wikipedia edit");
+  }
+  const normalized = normalizeDraftOutput(input.output);
+  const draftId = buildDraftId(input);
+  const rows = await query<DraftRow>(
+    `insert into draft_submissions(
+       draft_id, run_id, job_id, session_id, output, output_hash,
+       output_bytes, proposal_only, no_wikipedia_edit, validation_status
+     )
+     values ($1, $2, $3, $4, $5::jsonb, $6, $7, true, true, 'unvalidated')
+     on conflict(draft_id) do update set
+       output = excluded.output,
+       output_hash = excluded.output_hash,
+       output_bytes = excluded.output_bytes,
+       proposal_only = true,
+       no_wikipedia_edit = true,
+       validation_status = 'unvalidated',
+       validation_result = '{}'::jsonb,
+       updated_at = now()
+     returning *`,
+    [
+      draftId,
+      input.runId ?? null,
+      input.jobId,
+      input.sessionId ?? null,
+      JSON.stringify(normalized.output),
+      normalized.outputHash,
+      normalized.outputBytes,
+    ]
+  );
+  return fromDraftRow(rows[0]);
+}
+
+export async function getDraftSubmission(
+  lookup: DraftLookup,
+  query: DraftQueryFn
+): Promise<DraftSubmission> {
+  const row = await getDraftRow(lookup, query);
+  return fromDraftRow(row);
+}
+
+export async function listDraftSubmissions(
+  lookup: { runId?: string; jobId?: string; sessionId?: string; limit?: number },
+  query: DraftQueryFn
+): Promise<DraftSummary[]> {
+  const limit = Math.min(Math.max(lookup.limit ?? 20, 1), 50);
+  const filters: string[] = [];
+  const values: unknown[] = [];
+  if (lookup.runId) {
+    values.push(lookup.runId);
+    filters.push(`run_id = $${values.length}`);
+  }
+  if (lookup.jobId) {
+    values.push(lookup.jobId);
+    filters.push(`job_id = $${values.length}`);
+  }
+  if (lookup.sessionId) {
+    values.push(lookup.sessionId);
+    filters.push(`session_id = $${values.length}`);
+  }
+  values.push(limit);
+  const rows = await query<DraftRow>(
+    `select * from draft_submissions
+     ${filters.length > 0 ? `where ${filters.join(" and ")}` : ""}
+     order by updated_at desc
+     limit $${values.length}`,
+    values
+  );
+  return rows.map((row) => summarizeDraft(fromDraftRow(row)));
+}
+
+export async function markDraftValidation(
+  draftId: string,
+  valid: boolean,
+  validationResult: unknown,
+  query: DraftQueryFn
+): Promise<void> {
+  await query(
+    `update draft_submissions
+     set validation_status = $2,
+         validation_result = $3::jsonb,
+         updated_at = now()
+     where draft_id = $1`,
+    [draftId, valid ? "valid" : "invalid", JSON.stringify(validationResult)]
+  );
+}
+
+export function summarizeDraft(draft: DraftSubmission): DraftSummary {
+  return {
+    draftId: draft.draftId,
+    ...(draft.runId ? { runId: draft.runId } : {}),
+    jobId: draft.jobId,
+    ...(draft.sessionId ? { sessionId: draft.sessionId } : {}),
+    outputHash: draft.outputHash,
+    outputBytes: draft.outputBytes,
+    proposalOnly: draft.proposalOnly,
+    noWikipediaEdit: draft.noWikipediaEdit,
+    validationStatus: draft.validationStatus,
+    ...(draft.createdAt ? { createdAt: draft.createdAt } : {}),
+    ...(draft.updatedAt ? { updatedAt: draft.updatedAt } : {}),
+  };
+}
+
+async function getDraftRow(lookup: DraftLookup, query: DraftQueryFn): Promise<DraftRow> {
+  if (lookup.draftId) {
+    const rows = await query<DraftRow>(
+      "select * from draft_submissions where draft_id = $1 limit 1",
+      [lookup.draftId]
+    );
+    const row = rows[0];
+    if (!row) throw new Error("draft_not_found");
+    assertLookupMatches(row, lookup);
+    return row;
+  }
+
+  const filters: string[] = [];
+  const values: unknown[] = [];
+  if (lookup.jobId) {
+    values.push(lookup.jobId);
+    filters.push(`job_id = $${values.length}`);
+  }
+  if (lookup.runId) {
+    values.push(lookup.runId);
+    filters.push(`run_id = $${values.length}`);
+  }
+  if (lookup.sessionId) {
+    values.push(lookup.sessionId);
+    filters.push(`session_id = $${values.length}`);
+  }
+  if (filters.length === 0) {
+    throw new Error("draft_lookup_key_required: provide draftId, runId, jobId, or sessionId to load a draft");
+  }
+  const rows = await query<DraftRow>(
+    `select * from draft_submissions
+     where ${filters.join(" and ")}
+     order by updated_at desc
+     limit 1`,
+    values
+  );
+  if (!rows[0]) throw new Error("draft_not_found");
+  return rows[0];
+}
+
+function assertLookupMatches(row: DraftRow, lookup: DraftLookup) {
+  const mismatches: string[] = [];
+  if (lookup.jobId && row.job_id !== lookup.jobId) mismatches.push("jobId");
+  if (lookup.sessionId && row.session_id !== lookup.sessionId) mismatches.push("sessionId");
+  if (lookup.runId && row.run_id !== lookup.runId) mismatches.push("runId");
+  if (mismatches.length > 0) {
+    throw new Error(`draft_lookup_mismatch: ${mismatches.join(", ")}`);
+  }
+}
+
+function assertNoSecretLikeKeys(value: unknown, path: string[] = []) {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoSecretLikeKeys(item, [...path, String(index)]));
+    return;
+  }
+  if (!isRecord(value)) return;
+  for (const [key, item] of Object.entries(value)) {
+    if (SECRET_KEY_PATTERN.test(key)) {
+      const fullPath = [...path, key].join(".");
+      throw new Error(`draft_contains_secret_like_key: ${fullPath}`);
+    }
+    assertNoSecretLikeKeys(item, [...path, key]);
+  }
+}
+
+function fromDraftRow(row: DraftRow | undefined): DraftSubmission {
+  if (!row) throw new Error("draft_not_found");
+  const output = typeof row.output === "string" ? JSON.parse(row.output) : row.output;
+  if (!isRecord(output)) throw new Error("draft_corrupt_output_not_object");
+  return {
+    draftId: row.draft_id,
+    ...(row.run_id ? { runId: row.run_id } : {}),
+    jobId: row.job_id,
+    ...(row.session_id ? { sessionId: row.session_id } : {}),
+    output,
+    outputHash: row.output_hash,
+    outputBytes: Number(row.output_bytes),
+    proposalOnly: Boolean(row.proposal_only),
+    noWikipediaEdit: Boolean(row.no_wikipedia_edit),
+    validationStatus: normalizeValidationStatus(row.validation_status),
+    ...(row.validation_result ? { validationResult: row.validation_result } : {}),
+    ...(row.created_at ? { createdAt: String(row.created_at) } : {}),
+    ...(row.updated_at ? { updatedAt: String(row.updated_at) } : {}),
+  };
+}
+
+function normalizeValidationStatus(value: unknown): "unvalidated" | "valid" | "invalid" {
+  return value === "valid" || value === "invalid" ? value : "unvalidated";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface DraftRow {
+  draft_id: string;
+  run_id: string | null;
+  job_id: string;
+  session_id: string | null;
+  output: unknown;
+  output_hash: string;
+  output_bytes: number | string;
+  proposal_only: boolean;
+  no_wikipedia_edit: boolean;
+  validation_status: string;
+  validation_result?: unknown;
+  created_at?: string | Date;
+  updated_at?: string | Date;
+}

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -14,6 +14,15 @@ import { evaluateClaimMutationPolicy, evaluateSubmitMutationPolicy, isUuid } fro
 import { postSlackAlert, validationFailureDetails } from "./slack-alerts.js";
 import { buildSubmitRequestBody } from "./submit-payload.js";
 import { validateSubmissionLocally } from "./validate-submission.js";
+import {
+  getDraftSubmission,
+  listDraftSubmissions,
+  markDraftValidation,
+  normalizeDraftOutput,
+  saveDraftSubmission,
+  summarizeDraft,
+  type DraftSubmission,
+} from "./draft-submissions.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -126,28 +135,95 @@ server.tool("averray_claim", "Claim a job through Averray's public API fallback 
 });
 
 server.tool(
-  "averray_validate_submission",
-  "Validate a structured submission output locally against the job's output schema. Read-only — does NOT consume the submit attempt budget and never calls the backend. Use this BEFORE averray_submit when an output schema is defined for the job source. Returns { valid, validator, errors[], message } where errors carry actionable JSON paths (e.g. citation_findings.0.citation_number is not allowed).",
+  "averray_save_draft_submission",
+  "Persist a structured proposal object before local validation or submit. Use this once the proposal is assembled so an interrupted Hermes session can resume with the exact JSON object. Drafts are keyed by runId/jobId/sessionId, size-limited, secret-key scanned, and always marked proposal-only/no Wikipedia edit.",
   {
+    runId: z.string().optional(),
     jobId: z.string().min(1),
-    output: z.unknown()
+    sessionId: z.string().optional(),
+    output: z.unknown(),
+    proposalOnly: z.boolean().default(true),
+    noWikipediaEdit: z.boolean().default(true)
   },
-  async ({ jobId, output }) => {
+  async ({ runId, jobId, sessionId, output, proposalOnly, noWikipediaEdit }) => {
+    const draft = await saveDraftSubmission(
+      { runId, jobId, sessionId, output, proposalOnly, noWikipediaEdit },
+      query
+    );
+    return jsonContent({
+      saved: true,
+      draft: summarizeDraft(draft),
+      note: "Load this draft with averray_get_draft_submission or pass draftId to averray_validate_submission/averray_submit after resume."
+    });
+  }
+);
+
+server.tool(
+  "averray_get_draft_submission",
+  "Load a previously persisted structured proposal object. Use this after Hermes resume instead of reconstructing JSON from chat history. If draftId plus jobId/sessionId/runId are supplied, mismatches fail closed.",
+  {
+    draftId: z.string().optional(),
+    runId: z.string().optional(),
+    jobId: z.string().optional(),
+    sessionId: z.string().optional()
+  },
+  async ({ draftId, runId, jobId, sessionId }) => {
+    const draft = await getDraftSubmission({ draftId, runId, jobId, sessionId }, query);
+    return jsonContent({ draft: { ...summarizeDraft(draft), output: draft.output } });
+  }
+);
+
+server.tool(
+  "averray_list_draft_submissions",
+  "List recent persisted draft submissions without returning the proposal body. Use this to recover draftId/runId/jobId/sessionId after interruption.",
+  {
+    runId: z.string().optional(),
+    jobId: z.string().optional(),
+    sessionId: z.string().optional(),
+    limit: z.number().int().min(1).max(50).default(20)
+  },
+  async ({ runId, jobId, sessionId, limit }) => {
+    const drafts = await listDraftSubmissions({ runId, jobId, sessionId, limit }, query);
+    return jsonContent({ count: drafts.length, drafts });
+  }
+);
+
+server.tool(
+  "averray_validate_submission",
+  "Validate a structured submission output locally against the job's output schema. Read-only — does NOT consume the submit attempt budget and never calls the backend. Save the proposal first with averray_save_draft_submission, or pass draftId/runId/sessionId so resume loads the exact object. Returns { valid, validator, errors[], message } where errors carry actionable JSON paths (e.g. citation_findings.0.citation_number is not allowed).",
+  {
+    runId: z.string().optional(),
+    jobId: z.string().min(1),
+    sessionId: z.string().optional(),
+    draftId: z.string().optional(),
+    output: z.unknown().optional()
+  },
+  async ({ runId, jobId, sessionId, draftId, output }) => {
+    const resolved = await resolveSubmissionOutput({ runId, jobId, sessionId, draftId, output });
     const definition = await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
-    const validation = validateSubmissionLocally(definition, output);
+    const validation = validateSubmissionLocally(definition, resolved.output);
+    if (resolved.draft) {
+      await markDraftValidation(resolved.draft.draftId, validation.valid, validation, query);
+    }
     if (!validation.valid) {
       await postSlackAlert({
         kind: "submit_validation_failed",
         title: "local submission validation failed",
-        identifiers: { jobId },
+        identifiers: { jobId, runId, sessionId },
         details: {
           mutationBudgetConsumed: false,
+          draftId: resolved.draft?.draftId,
           ...validationFailureDetails(validation),
           ...jobDefinitionDetails(definition),
         },
       });
     }
-    return jsonContent({ jobId, ...validation });
+    return jsonContent({
+      jobId,
+      ...(resolved.warning ? { warning: resolved.warning } : {}),
+      ...(resolved.draft ? { draft: summarizeDraft(resolved.draft) } : {}),
+      ...validation
+    });
   }
 );
 
@@ -155,10 +231,14 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
   runId: z.string().optional(),
   sessionId: z.string().min(1),
   jobId: z.string().optional(),
-  output: z.unknown(),
+  draftId: z.string().optional(),
+  output: z.unknown().optional(),
   outputHash: z.string().optional()
-}, async ({ runId, sessionId, jobId, output, outputHash }) => {
+}, async ({ runId, sessionId, jobId, draftId, output, outputHash }) => {
   await assertNoKillSwitch("averray_submit");
+  const resolved = await resolveSubmissionOutput({ runId, jobId, sessionId, draftId, output });
+  const effectiveJobId = jobId ?? resolved.draft?.jobId;
+  const effectiveOutputHash = outputHash ?? resolved.draft?.outputHash ?? resolved.outputHash;
 
   // Pre-flight schema validation — runs BEFORE the mutation policy
   // check and BEFORE any HTTP call. The reference agent has
@@ -168,10 +248,10 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
   // the corrected payload. We need a jobId to pull the right schema;
   // when the agent omits it (legacy path) we skip validation rather
   // than refusing the submit.
-  if (typeof jobId === "string" && jobId.length > 0) {
+  if (typeof effectiveJobId === "string" && effectiveJobId.length > 0) {
     let definition: unknown;
     try {
-      definition = await request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
+      definition = await request(`/jobs/definition?jobId=${encodeURIComponent(effectiveJobId)}`);
     } catch (error) {
       // Couldn't reach the definition endpoint — surface the error to
       // the agent rather than silently skipping validation. The
@@ -179,7 +259,7 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
       await postSlackAlert({
         kind: "submit_blocked",
         title: "submit blocked before mutation",
-        identifiers: { jobId, runId, sessionId },
+        identifiers: { jobId: effectiveJobId, runId, sessionId },
         details: {
           reason: "definition_fetch_failed",
           message: error instanceof Error ? error.message : String(error),
@@ -193,14 +273,18 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
         message: error instanceof Error ? error.message : String(error)
       });
     }
-    const validation = validateSubmissionLocally(definition, output);
+    const validation = validateSubmissionLocally(definition, resolved.output);
+    if (resolved.draft) {
+      await markDraftValidation(resolved.draft.draftId, validation.valid, validation, query);
+    }
     if (!validation.valid) {
       await postSlackAlert({
         kind: "submit_validation_failed",
         title: "local submission validation failed",
-        identifiers: { jobId, runId, sessionId },
+        identifiers: { jobId: effectiveJobId, runId, sessionId },
         details: {
           mutationBudgetConsumed: false,
+          draftId: resolved.draft?.draftId,
           ...validationFailureDetails(validation),
           ...jobDefinitionDetails(definition),
         },
@@ -214,8 +298,8 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
     }
   }
 
-  const key = idempotencyKey(["averray", runId ?? sessionId, "submit", outputHash ?? JSON.stringify(output)]);
-  const policy = await evaluateSubmitMutationPolicy({ runId, sessionId, jobId, idempotencyKey: key }, query);
+  const key = idempotencyKey(["averray", runId ?? sessionId, "submit", effectiveOutputHash]);
+  const policy = await evaluateSubmitMutationPolicy({ runId, sessionId, jobId: effectiveJobId, idempotencyKey: key }, query);
   if (!policy.allowed) {
     await postSlackAlert({
       kind: "submit_blocked",
@@ -232,22 +316,28 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
   }
 
   const session = await authSession();
-  await upsertSubmission({ runId, kind: "submit", key, request: { sessionId, jobId, outputHash, policyRunId: policy.runId } });
+  await upsertSubmission({
+    runId,
+    kind: "submit",
+    key,
+    request: { sessionId, jobId: effectiveJobId, draftId: resolved.draft?.draftId, outputHash: effectiveOutputHash, policyRunId: policy.runId }
+  });
   try {
     const response = await request("/jobs/submit", {
       method: "POST",
       token: session.token,
-      body: buildSubmitRequestBody({ sessionId, output })
+      body: buildSubmitRequestBody({ sessionId, output: resolved.output })
     });
     await completeSubmission(key, response);
     await postSlackAlert({
       kind: "submit_succeeded",
       title: "submit succeeded",
-      identifiers: { jobId, runId: policy.runId, sessionId, wallet: session.wallet },
+      identifiers: { jobId: effectiveJobId, runId: policy.runId, sessionId, wallet: session.wallet },
       details: {
         mutationBudgetConsumed: true,
         idempotencyKey: key,
-        outputHash,
+        draftId: resolved.draft?.draftId,
+        outputHash: effectiveOutputHash,
         ...submitResponseDetails(response),
       },
     });
@@ -257,12 +347,13 @@ server.tool("averray_submit", "Submit work through Averray's public API fallback
     await postSlackAlert({
       kind: "submit_failed",
       title: "submit failed after mutation attempt",
-      identifiers: { jobId, runId: policy.runId, sessionId, wallet: session.wallet },
+      identifiers: { jobId: effectiveJobId, runId: policy.runId, sessionId, wallet: session.wallet },
       details: {
         error: error instanceof Error ? error.message : String(error),
         mutationBudgetConsumed: true,
         idempotencyKey: key,
-        outputHash,
+        draftId: resolved.draft?.draftId,
+        outputHash: effectiveOutputHash,
       },
     });
     throw error;
@@ -279,6 +370,53 @@ server.tool("averray_observe_session", "Read the current Averray session state a
 });
 
 await runStdioServer(server);
+
+async function resolveSubmissionOutput(input: {
+  runId?: string;
+  jobId?: string;
+  sessionId?: string;
+  draftId?: string;
+  output?: unknown;
+}): Promise<{
+  output: Record<string, unknown>;
+  outputHash: string;
+  warning?: string;
+  draft?: DraftSubmission;
+}> {
+  if (input.output !== undefined) {
+    if (input.jobId && (input.runId || input.sessionId)) {
+      const draft = await saveDraftSubmission(
+        {
+          runId: input.runId,
+          jobId: input.jobId,
+          sessionId: input.sessionId,
+          output: input.output,
+          proposalOnly: true,
+          noWikipediaEdit: true
+        },
+        query
+      );
+      return { output: draft.output, outputHash: draft.outputHash, draft };
+    }
+    const normalized = normalizeDraftOutput(input.output);
+    return {
+      output: normalized.output,
+      outputHash: normalized.outputHash,
+      ...(normalized.warning ? { warning: normalized.warning } : {})
+    };
+  }
+
+  const draft = await getDraftSubmission(
+    {
+      draftId: input.draftId,
+      runId: input.runId,
+      jobId: input.jobId,
+      sessionId: input.sessionId
+    },
+    query
+  );
+  return { output: draft.output, outputHash: draft.outputHash, draft };
+}
 
 async function authSession() {
   const cached = await query<{ wallet: string; jwt: string; expires_at: string | null }>(

--- a/test/unit/draft-submissions.test.ts
+++ b/test/unit/draft-submissions.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDraftId,
+  getDraftSubmission,
+  normalizeDraftOutput,
+  saveDraftSubmission,
+  type DraftQueryFn,
+} from "../../packages/averray-mcp/src/draft-submissions.js";
+import { validateSubmissionLocally } from "../../packages/averray-mcp/src/validate-submission.js";
+
+const jobId = "wiki-en-45188030-citation-repair-album";
+const runId = "controlled-wikipedia-album-001";
+const sessionId =
+  "wiki-en-45188030-citation-repair-album:0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05";
+
+const wikipediaCitationRepairDefinition = {
+  source: { type: "wikipedia_article", taskType: "citation_repair" },
+};
+
+const proposal = {
+  page_title: "Album",
+  revision_id: "123456789",
+  citation_findings: [
+    {
+      section: "Reception",
+      problem: "dead_link" as const,
+      current_claim: "A review citation is dead.",
+      evidence_url: "https://example.com/archive",
+    },
+  ],
+  proposed_changes: [
+    {
+      change_type: "replace_citation" as const,
+      target_text: "dead citation",
+      replacement_text: "archived citation",
+      source_url: "https://web.archive.org/example",
+    },
+  ],
+  review_notes: "Averray-attributed proposal only. No Wikipedia edit was made.",
+};
+
+describe("draft submissions", () => {
+  it("saves and loads the exact structured proposal object", async () => {
+    const db = memoryDraftDb();
+    const saved = await saveDraftSubmission({ runId, jobId, sessionId, output: proposal }, db.query);
+    const loaded = await getDraftSubmission({ runId, jobId, sessionId }, db.query);
+    const resumedBySession = await getDraftSubmission({ sessionId }, db.query);
+
+    expect(loaded.draftId).toBe(saved.draftId);
+    expect(loaded.output).toEqual(proposal);
+    expect(resumedBySession.output).toEqual(proposal);
+    expect(loaded.proposalOnly).toBe(true);
+    expect(loaded.noWikipediaEdit).toBe(true);
+    expect(loaded.outputHash).toBe(saved.outputHash);
+  });
+
+  it("lets a resumed validation path use the persisted object shape", async () => {
+    const db = memoryDraftDb();
+    await saveDraftSubmission({ runId, jobId, sessionId, output: proposal }, db.query);
+
+    const loaded = await getDraftSubmission({ runId, jobId, sessionId }, db.query);
+    const validation = validateSubmissionLocally(wikipediaCitationRepairDefinition, loaded.output);
+
+    expect(typeof loaded.output).toBe("object");
+    expect(Array.isArray(loaded.output)).toBe(false);
+    expect(validation).toEqual({
+      valid: true,
+      validator: "wikipedia",
+      taskType: "citation_repair",
+    });
+  });
+
+  it("parses stringified JSON objects before validation code sees them", () => {
+    const normalized = normalizeDraftOutput(JSON.stringify(proposal));
+
+    expect(normalized.warning).toBe("parsed_stringified_json_object");
+    expect(normalized.output).toEqual(proposal);
+  });
+
+  it("rejects non-JSON strings with an actionable error", () => {
+    expect(() => normalizeDraftOutput("page_title: Album")).toThrow(
+      /draft_submission_output_must_be_object/
+    );
+  });
+
+  it("fails closed when a draftId lookup has a session mismatch", async () => {
+    const db = memoryDraftDb();
+    const saved = await saveDraftSubmission({ runId, jobId, sessionId, output: proposal }, db.query);
+
+    await expect(
+      getDraftSubmission({ draftId: saved.draftId, jobId, sessionId: `${sessionId}-typo` }, db.query)
+    ).rejects.toThrow(/draft_lookup_mismatch: sessionId/);
+  });
+
+  it("rejects secret-like keys before persisting the draft", async () => {
+    const db = memoryDraftDb();
+
+    await expect(
+      saveDraftSubmission(
+        { runId, jobId, sessionId, output: { ...proposal, private_key: "0xabc" } },
+        db.query
+      )
+    ).rejects.toThrow(/draft_contains_secret_like_key/);
+  });
+});
+
+function memoryDraftDb(): { query: DraftQueryFn } {
+  const rows = new Map<string, DraftRow>();
+  const now = "2026-05-02T14:00:00.000Z";
+  const query: DraftQueryFn = async <T>(text: string, values: unknown[] = []) => {
+    if (text.includes("insert into draft_submissions")) {
+      const [draftId, rowRunId, rowJobId, rowSessionId, outputJson, outputHash, outputBytes] = values;
+      const existing = rows.get(String(draftId));
+      const row: DraftRow = {
+        draft_id: String(draftId),
+        run_id: typeof rowRunId === "string" ? rowRunId : null,
+        job_id: String(rowJobId),
+        session_id: typeof rowSessionId === "string" ? rowSessionId : null,
+        output: JSON.parse(String(outputJson)),
+        output_hash: String(outputHash),
+        output_bytes: Number(outputBytes),
+        proposal_only: true,
+        no_wikipedia_edit: true,
+        validation_status: "unvalidated",
+        validation_result: {},
+        created_at: existing?.created_at ?? now,
+        updated_at: now,
+      };
+      rows.set(row.draft_id, row);
+      return [row] as T[];
+    }
+
+    if (text.includes("where draft_id = $1")) {
+      return [rows.get(String(values[0]))].filter(Boolean) as T[];
+    }
+
+    if (text.includes("from draft_submissions")) {
+      const result = [...rows.values()].find((row) => {
+        let cursor = 0;
+        if (text.includes("job_id =")) {
+          if (row.job_id !== values[cursor]) return false;
+          cursor += 1;
+        }
+        if (text.includes("run_id =")) {
+          if (row.run_id !== values[cursor]) return false;
+          cursor += 1;
+        }
+        if (text.includes("session_id =")) {
+          if (row.session_id !== values[cursor]) return false;
+        }
+        return true;
+      });
+      return [result].filter(Boolean) as T[];
+    }
+
+    if (text.includes("update draft_submissions")) {
+      const [draftId, status, validationResultJson] = values;
+      const row = rows.get(String(draftId));
+      if (row) {
+        row.validation_status = String(status);
+        row.validation_result = JSON.parse(String(validationResultJson));
+      }
+      return [] as T[];
+    }
+
+    return [] as T[];
+  };
+  return { query };
+}
+
+interface DraftRow {
+  draft_id: string;
+  run_id: string | null;
+  job_id: string;
+  session_id: string | null;
+  output: unknown;
+  output_hash: string;
+  output_bytes: number;
+  proposal_only: boolean;
+  no_wikipedia_edit: boolean;
+  validation_status: string;
+  validation_result: unknown;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Summary
- add a Postgres-backed draft_submissions store keyed by run/job/session identifiers
- add MCP draft tools for save/get/list and wire draftId support into validation and submit
- normalize stringified JSON into structured objects or reject bad strings before schema validation
- keep drafts proposal-only/no-Wikipedia-edit, size-limited, and secret-key scanned

Closes #31

## Checks
- npm run typecheck
- npm test

## Deployment notes
- Existing migration runner re-applies ops/migrations/001_init.sql; the new draft_submissions table is created idempotently on deploy.