### PR TITLE
Add one-command Wikipedia citation workflow

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -176,6 +176,36 @@ Expected result:
 - `policy_check_claim` returns `pass` or a clear blocker.
 - No session is claimed and no work is submitted.
 
+## One-Command Wikipedia Workflow Smoke
+
+The reference agent exposes a first-class workflow so operators do not need to
+paste the full claim/evidence/draft/validate/submit sequence each time.
+
+Safe dry run:
+
+```text
+run one Wikipedia citation repair if safe, dry run only
+```
+
+Specific job dry run:
+
+```text
+run Wikipedia citation repair for wiki-en-... if safe, dry run only
+```
+
+Mutation run, only after allowlists are set for the exact job/session boundary:
+
+```text
+run Wikipedia citation repair for wiki-en-... if safe with dryRun=false
+```
+
+The workflow tool is `averray_run_wikipedia_citation_repair`. Its default is
+`dryRun=true`, which may fetch read-only Wikipedia/source evidence and validate
+a proposal preview but must not call `averray_claim` or `averray_submit`.
+With `dryRun=false`, claim and submit still go through the same one-shot
+mutation guards, draft persistence, local schema validation, confidence gate,
+and Slack lifecycle alerts.
+
 ## Tool Smoke
 
 After Hermes boots, verify the MCP tools from a shell inside the Hermes container when Hermes MCP config is loaded:

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { privateKeyToAccount } from "viem/accounts";
 import { z } from "zod";
 import {
   assertNoKillSwitch,
@@ -29,6 +30,13 @@ import {
   fetchWikipediaRevision,
   findArchiveSnapshot,
 } from "./wiki-evidence.js";
+import {
+  readPageTitle,
+  readRevisionId,
+  runWikipediaCitationRepairWorkflow,
+  type WikipediaEvidenceBundle,
+  type WorkflowJob,
+} from "./job-workflows.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -113,6 +121,25 @@ server.tool(
   },
   async ({ url, timestampHint, timeoutMs }) => {
     return jsonContent(await findArchiveSnapshot({ url, timestampHint, timeoutMs }));
+  }
+);
+
+server.tool(
+  "averray_run_wikipedia_citation_repair",
+  "Run the reference agent's safe Wikipedia citation-repair workflow from one short command. It uses the generic Averray lifecycle skeleton plus the Wikipedia citation-repair adapter: wallet check, job discovery/definition, claimability/policy checks, optional claim, deterministic read-only evidence gathering, draft persistence, local validation, and guarded submit. dryRun defaults to true and never calls claim or submit.",
+  {
+    runId: z.string().optional(),
+    jobId: z.string().optional(),
+    dryRun: z.boolean().default(true),
+    expectedWallet: z.string().optional(),
+    maxEvidenceUrls: z.number().int().min(1).max(20).default(5),
+    confidenceThreshold: z.number().min(0).max(1).default(0.7)
+  },
+  async ({ runId, jobId, dryRun, expectedWallet, maxEvidenceUrls, confidenceThreshold }) => {
+    return jsonContent(await runWikipediaCitationRepairWorkflow(
+      { runId, jobId, dryRun, expectedWallet, maxEvidenceUrls, confidenceThreshold },
+      workflowDeps()
+    ));
   }
 );
 
@@ -432,6 +459,275 @@ server.tool("averray_observe_session", "Read the current Averray session state a
 });
 
 await runStdioServer(server);
+
+function workflowDeps() {
+  return {
+    async listJobs(): Promise<WorkflowJob[]> {
+      const payload = await request("/jobs");
+      const jobs: WorkflowJob[] = [];
+      for (const job of extractJobArray(payload)) {
+        if (isRecord(job)) {
+          const jobId = firstString(job.id, job.jobId, job.externalTaskId);
+          if (jobId) jobs.push({ jobId, definition: job });
+        }
+      }
+      return jobs;
+    },
+    async getDefinition(jobId: string) {
+      return request(`/jobs/definition?jobId=${encodeURIComponent(jobId)}`);
+    },
+    async walletStatus() {
+      const privateKey = optionalEnv("AGENT_WALLET_PRIVATE_KEY");
+      if (!privateKey) return { configured: false, address: null };
+      try {
+        const account = privateKeyToAccount(privateKey as `0x${string}`);
+        return { configured: true, address: account.address };
+      } catch {
+        return { configured: false, address: null };
+      }
+    },
+    async policyCheckClaim(input: {
+      runId: string;
+      jobId: string;
+      taskType?: string;
+      verifierMode?: string;
+      rewardUsd: number;
+    }) {
+      const reasons: string[] = [];
+      if (input.taskType && input.taskType !== "citation_repair") {
+        reasons.push(`task_type_not_allowed:${input.taskType}`);
+      }
+      if (input.verifierMode === "human_fallback") {
+        reasons.push("verifier_mode_rejected:human_fallback");
+      }
+      if (reasons.length > 0) {
+        return { allowed: false, reason: reasons.join(","), details: { reasons } };
+      }
+      const key = idempotencyKey(["averray", input.jobId, "claim"]);
+      const policy = await evaluateClaimMutationPolicy({ runId: input.runId, jobId: input.jobId, idempotencyKey: key }, query);
+      return {
+        allowed: policy.allowed,
+        reason: policy.allowed ? undefined : policy.reason ?? undefined,
+        details: policy
+      };
+    },
+    async claim(input: { runId: string; jobId: string }) {
+      return claimOnceForWorkflow(input);
+    },
+    async fetchEvidence(input: { definition: unknown; maxEvidenceUrls: number }): Promise<WikipediaEvidenceBundle> {
+      return fetchWikipediaEvidenceForWorkflow(input.definition, input.maxEvidenceUrls);
+    },
+    async saveDraft(input: { runId: string; jobId: string; sessionId?: string; output: Record<string, unknown> }) {
+      const draft = await saveDraftSubmission(
+        { ...input, proposalOnly: true, noWikipediaEdit: true },
+        query
+      );
+      return { draftId: draft.draftId, outputHash: draft.outputHash };
+    },
+    async validate(input: { jobId: string; draftId?: string; output?: Record<string, unknown> }) {
+      const definition = await request(`/jobs/definition?jobId=${encodeURIComponent(input.jobId)}`);
+      if (input.draftId) {
+        const draft = await getDraftSubmission({ draftId: input.draftId, jobId: input.jobId }, query);
+        const validation = validateSubmissionLocally(definition, draft.output);
+        await markDraftValidation(draft.draftId, validation.valid, validation, query);
+        return validation;
+      }
+      return validateSubmissionLocally(definition, input.output);
+    },
+    async submit(input: { runId: string; jobId: string; sessionId: string; draftId: string; outputHash?: string }) {
+      return submitDraftOnceForWorkflow(input);
+    }
+  };
+}
+
+async function claimOnceForWorkflow(input: { runId: string; jobId: string }) {
+  await assertNoKillSwitch("averray_claim");
+  const key = idempotencyKey(["averray", input.jobId, "claim"]);
+  const definition = await safeGetDefinition(input.jobId);
+  const policy = await evaluateClaimMutationPolicy(
+    { runId: input.runId, jobId: input.jobId, idempotencyKey: key },
+    query
+  );
+  if (!policy.allowed) {
+    await postSlackAlert({
+      kind: "claim_blocked",
+      title: "workflow claim blocked before mutation",
+      identifiers: { jobId: input.jobId, runId: policy.runId },
+      details: {
+        reason: policy.reason,
+        mutationBudgetConsumed: false,
+        maxClaimAttempts: policy.maxClaimAttempts,
+        previousAttempts: policy.previousAttempts,
+        ...jobDefinitionDetails(definition),
+      },
+    });
+    throw new Error(`claim_blocked:${policy.reason}`);
+  }
+
+  const session = await authSession();
+  await upsertSubmission({ runId: input.runId, kind: "claim", key, request: { jobId: input.jobId, policyRunId: policy.runId } });
+  try {
+    const response = await request("/jobs/claim", {
+      method: "POST",
+      token: session.token,
+      body: { jobId: input.jobId, idempotencyKey: key }
+    });
+    await completeSubmission(key, response);
+    const details = sessionResponseDetails(response);
+    await postSlackAlert({
+      kind: "claim_succeeded",
+      title: "workflow claim succeeded",
+      identifiers: { jobId: input.jobId, runId: policy.runId, sessionId: details.sessionId, wallet: session.wallet },
+      details: {
+        claimDeadline: details.claimDeadline,
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        ...jobDefinitionDetails(definition),
+      },
+    });
+    if (!details.sessionId) throw new Error("claim_response_missing_session_id");
+    return { sessionId: details.sessionId, claimDeadline: details.claimDeadline, response };
+  } catch (error) {
+    await failSubmission(key, error);
+    await postSlackAlert({
+      kind: "claim_failed",
+      title: "workflow claim failed after mutation attempt",
+      identifiers: { jobId: input.jobId, runId: policy.runId, wallet: session.wallet },
+      details: {
+        error: error instanceof Error ? error.message : String(error),
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+      },
+    });
+    throw error;
+  }
+}
+
+async function submitDraftOnceForWorkflow(input: {
+  runId: string;
+  jobId: string;
+  sessionId: string;
+  draftId: string;
+  outputHash?: string;
+}) {
+  await assertNoKillSwitch("averray_submit");
+  const definition = await request(`/jobs/definition?jobId=${encodeURIComponent(input.jobId)}`);
+  const draft = await getDraftSubmission({ draftId: input.draftId, jobId: input.jobId, sessionId: input.sessionId }, query);
+  const validation = validateSubmissionLocally(definition, draft.output);
+  await markDraftValidation(draft.draftId, validation.valid, validation, query);
+  if (!validation.valid) {
+    return { blocked: true, reason: "local_schema_validation_failed", validation };
+  }
+
+  const outputHash = input.outputHash ?? draft.outputHash;
+  const key = idempotencyKey(["averray", input.runId, "submit", outputHash]);
+  const policy = await evaluateSubmitMutationPolicy({
+    runId: input.runId,
+    sessionId: input.sessionId,
+    jobId: input.jobId,
+    idempotencyKey: key
+  }, query);
+  if (!policy.allowed) {
+    await postSlackAlert({
+      kind: "submit_blocked",
+      title: "workflow submit blocked before mutation",
+      identifiers: { jobId: policy.jobId, runId: policy.runId, sessionId: input.sessionId },
+      details: {
+        reason: policy.reason,
+        mutationBudgetConsumed: false,
+        maxSubmitAttempts: policy.maxSubmitAttempts,
+        previousAttempts: policy.previousAttempts,
+      },
+    });
+    return { blocked: true, reason: policy.reason ?? undefined, policy };
+  }
+
+  const session = await authSession();
+  await upsertSubmission({
+    runId: input.runId,
+    kind: "submit",
+    key,
+    request: { sessionId: input.sessionId, jobId: input.jobId, draftId: input.draftId, outputHash, policyRunId: policy.runId }
+  });
+  try {
+    const response = await request("/jobs/submit", {
+      method: "POST",
+      token: session.token,
+      body: buildSubmitRequestBody({ sessionId: input.sessionId, output: draft.output })
+    });
+    await completeSubmission(key, response);
+    await postSlackAlert({
+      kind: "submit_succeeded",
+      title: "workflow submit succeeded",
+      identifiers: { jobId: input.jobId, runId: policy.runId, sessionId: input.sessionId, wallet: session.wallet },
+      details: {
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        draftId: input.draftId,
+        outputHash,
+        ...submitResponseDetails(response),
+      },
+    });
+    return { response };
+  } catch (error) {
+    await failSubmission(key, error);
+    await postSlackAlert({
+      kind: "submit_failed",
+      title: "workflow submit failed after mutation attempt",
+      identifiers: { jobId: input.jobId, runId: policy.runId, sessionId: input.sessionId, wallet: session.wallet },
+      details: {
+        error: error instanceof Error ? error.message : String(error),
+        mutationBudgetConsumed: true,
+        idempotencyKey: key,
+        draftId: input.draftId,
+        outputHash,
+      },
+    });
+    throw error;
+  }
+}
+
+async function fetchWikipediaEvidenceForWorkflow(definition: unknown, maxEvidenceUrls: number): Promise<WikipediaEvidenceBundle> {
+  const pageTitle = readPageTitle(definition);
+  const revisionId = readRevisionId(definition);
+  if (!pageTitle || !revisionId) {
+    throw new Error("wikipedia_definition_missing_page_title_or_revision_id");
+  }
+  const revision = await fetchWikipediaRevision({ title: pageTitle, revisionId, format: "references" });
+  const citations = "references" in revision && Array.isArray(revision.references) ? revision.references : [];
+  const urls = [...new Set(citations.flatMap((citation) => citation.urls).filter(Boolean))].slice(0, maxEvidenceUrls);
+  const sourceChecks = [];
+  for (const url of urls) {
+    const check = await checkSourceUrl({ url }).catch((error) => ({
+      url,
+      ok: false,
+      status: 0,
+      finalUrl: url,
+      error: error instanceof Error ? error.message : String(error),
+    }));
+    const archive = await findArchiveSnapshot({ url }).catch(() => undefined);
+    sourceChecks.push({
+      url,
+      status: isRecord(check) && typeof check.status === "number" ? check.status : undefined,
+      ok: isRecord(check) && typeof check.ok === "boolean" ? check.ok : undefined,
+      finalUrl: isRecord(check) && typeof check.finalUrl === "string" ? check.finalUrl : url,
+      archiveUrl: firstArchiveUrl(archive),
+    });
+  }
+  return {
+    pageTitle: revision.title,
+    revisionId: revision.revisionId,
+    revisionUrl: revision.revisionUrl,
+    citations,
+    sourceChecks,
+  };
+}
+
+function firstArchiveUrl(value: unknown): string | null {
+  if (!isRecord(value) || !Array.isArray(value.candidates)) return null;
+  const first = value.candidates.find(isRecord);
+  return typeof first?.archiveUrl === "string" ? first.archiveUrl : null;
+}
 
 async function resolveSubmissionOutput(input: {
   runId?: string;

--- a/packages/averray-mcp/src/job-workflows.ts
+++ b/packages/averray-mcp/src/job-workflows.ts
@@ -1,0 +1,602 @@
+import { randomUUID } from "node:crypto";
+import type { SubmissionValidationResult } from "./validate-submission.js";
+import type { WikipediaCitation } from "./wiki-evidence.js";
+
+export type WorkflowStatus =
+  | "submitted"
+  | "no_submit"
+  | "blocked"
+  | "needs_review"
+  | "failed";
+
+export interface WikipediaCitationRepairWorkflowInput {
+  runId?: string;
+  jobId?: string;
+  dryRun?: boolean;
+  expectedWallet?: string;
+  maxEvidenceUrls?: number;
+  confidenceThreshold?: number;
+}
+
+export interface WorkflowJob {
+  jobId: string;
+  definition?: unknown;
+}
+
+export interface WorkflowWallet {
+  configured: boolean;
+  address: string | null;
+}
+
+export interface WorkflowDraft {
+  draftId: string;
+  outputHash?: string;
+}
+
+export interface WorkflowClaimResult {
+  sessionId: string;
+  claimDeadline?: string;
+  response?: unknown;
+}
+
+export interface WorkflowSubmitResult {
+  response?: unknown;
+  blocked?: boolean;
+  reason?: string;
+  policy?: unknown;
+}
+
+export interface WorkflowDeps {
+  listJobs(): Promise<WorkflowJob[]>;
+  getDefinition(jobId: string): Promise<unknown>;
+  walletStatus(): Promise<WorkflowWallet>;
+  policyCheckClaim(input: {
+    runId: string;
+    jobId: string;
+    taskType?: string;
+    verifierMode?: string;
+    rewardUsd: number;
+  }): Promise<{ allowed: boolean; reason?: string; details?: unknown }>;
+  claim(input: { runId: string; jobId: string }): Promise<WorkflowClaimResult>;
+  fetchEvidence(input: {
+    definition: unknown;
+    maxEvidenceUrls: number;
+  }): Promise<WikipediaEvidenceBundle>;
+  saveDraft(input: {
+    runId: string;
+    jobId: string;
+    sessionId?: string;
+    output: Record<string, unknown>;
+  }): Promise<WorkflowDraft>;
+  validate(input: {
+    jobId: string;
+    draftId?: string;
+    output?: Record<string, unknown>;
+  }): Promise<SubmissionValidationResult>;
+  submit(input: {
+    runId: string;
+    jobId: string;
+    sessionId: string;
+    draftId: string;
+    outputHash?: string;
+  }): Promise<WorkflowSubmitResult>;
+}
+
+export interface WikipediaEvidenceBundle {
+  pageTitle: string;
+  revisionId: string;
+  revisionUrl?: string;
+  citations: WikipediaCitation[];
+  sourceChecks: Array<{
+    url: string;
+    status?: number;
+    ok?: boolean;
+    finalUrl?: string;
+    archiveUrl?: string | null;
+  }>;
+}
+
+export async function runWikipediaCitationRepairWorkflow(
+  input: WikipediaCitationRepairWorkflowInput,
+  deps: WorkflowDeps
+) {
+  const runId = input.runId ?? `wikipedia-citation-repair-${randomUUID()}`;
+  const dryRun = input.dryRun ?? true;
+  const maxEvidenceUrls = input.maxEvidenceUrls ?? 5;
+  const confidenceThreshold = input.confidenceThreshold ?? 0.7;
+  const events: string[] = [];
+
+  try {
+    const wallet = await deps.walletStatus();
+    events.push("wallet_checked");
+    if (!wallet.configured) {
+      return blocked({ runId, dryRun, reason: "wallet_not_configured", wallet, events });
+    }
+    if (input.expectedWallet && !sameWallet(wallet.address, input.expectedWallet)) {
+      return blocked({ runId, dryRun, reason: "wallet_mismatch", wallet, events });
+    }
+
+    const selected = await selectWikipediaCitationRepairJob(input.jobId, deps);
+    if (!selected) {
+      return blocked({ runId, dryRun, reason: "no_claimable_wikipedia_citation_repair_jobs", wallet, events });
+    }
+    events.push("job_selected");
+
+    const definition = selected.definition ?? await deps.getDefinition(selected.jobId);
+    if (!isWikipediaDefinition(definition) || readTaskType(definition) !== "citation_repair") {
+      return blocked({
+        runId,
+        dryRun,
+        jobId: selected.jobId,
+        reason: "job_is_not_wikipedia_citation_repair",
+        wallet,
+        events,
+      });
+    }
+    const claimState = readClaimState(definition);
+    if (claimState.claimable === false) {
+      return blocked({
+        runId,
+        dryRun,
+        jobId: selected.jobId,
+        reason: claimState.reason ?? "job_not_claimable",
+        wallet,
+        events,
+      });
+    }
+
+    const policy = await deps.policyCheckClaim({
+      runId,
+      jobId: selected.jobId,
+      taskType: readTaskType(definition),
+      verifierMode: readVerifierMode(definition),
+      rewardUsd: readRewardUsd(definition),
+    });
+    events.push("claim_policy_checked");
+    if (!policy.allowed) {
+      return blocked({
+        runId,
+        dryRun,
+        jobId: selected.jobId,
+        reason: policy.reason ?? "policy_rejected_claim",
+        policy,
+        wallet,
+        events,
+      });
+    }
+
+    const evidence = await deps.fetchEvidence({ definition, maxEvidenceUrls });
+    events.push("evidence_fetched");
+    const proposal = buildWikipediaCitationRepairProposal(definition, evidence);
+
+    if (dryRun) {
+      const validation = await deps.validate({ jobId: selected.jobId, output: proposal.output });
+      events.push("validated_without_mutation");
+      return {
+        status: "needs_review" as WorkflowStatus,
+        dryRun,
+        runId,
+        jobId: selected.jobId,
+        wallet,
+        evidenceSummary: summarizeEvidence(evidence),
+        proposalPreview: proposal.output,
+        confidence: proposal.confidence,
+        validation,
+        reviewNotes: [
+          "Dry run only: no Averray claim or submit was attempted.",
+          "Review proposalPreview before running with dryRun=false.",
+        ],
+        slack: slackSummary(events),
+      };
+    }
+
+    const claim = await deps.claim({ runId, jobId: selected.jobId });
+    events.push("claimed");
+    if (!claim.sessionId) {
+      return {
+        status: "failed" as WorkflowStatus,
+        dryRun,
+        runId,
+        jobId: selected.jobId,
+        reason: "claim_missing_session_id",
+        wallet,
+        slack: slackSummary(events),
+      };
+    }
+
+    const draft = await deps.saveDraft({
+      runId,
+      jobId: selected.jobId,
+      sessionId: claim.sessionId,
+      output: proposal.output,
+    });
+    events.push("draft_saved");
+
+    let validation = await deps.validate({ jobId: selected.jobId, draftId: draft.draftId });
+    events.push("validated");
+    if (!validation.valid) {
+      const fixed = fixSchemaOnlyWikipediaProposal(proposal.output);
+      if (fixed !== proposal.output) {
+        const fixedDraft = await deps.saveDraft({
+          runId,
+          jobId: selected.jobId,
+          sessionId: claim.sessionId,
+          output: fixed,
+        });
+        events.push("schema_fixed_and_resaved");
+        validation = await deps.validate({ jobId: selected.jobId, draftId: fixedDraft.draftId });
+        if (validation.valid) {
+          draft.draftId = fixedDraft.draftId;
+          draft.outputHash = fixedDraft.outputHash;
+        }
+      }
+    }
+
+    if (!validation.valid) {
+      return {
+        status: "no_submit" as WorkflowStatus,
+        dryRun,
+        runId,
+        jobId: selected.jobId,
+        sessionId: claim.sessionId,
+        draftId: draft.draftId,
+        validation,
+        confidence: proposal.confidence,
+        reason: "validation_failed",
+        reviewNotes: ["Draft saved, but local schema validation failed. No submit attempted."],
+        slack: slackSummary(events),
+      };
+    }
+
+    if (proposal.confidence < confidenceThreshold) {
+      return {
+        status: "needs_review" as WorkflowStatus,
+        dryRun,
+        runId,
+        jobId: selected.jobId,
+        sessionId: claim.sessionId,
+        draftId: draft.draftId,
+        validation,
+        confidence: proposal.confidence,
+        reason: "confidence_below_threshold",
+        reviewNotes: ["Draft validated, but evidence confidence is below submit threshold. No submit attempted."],
+        slack: slackSummary(events),
+      };
+    }
+
+    const submit = await deps.submit({
+      runId,
+      jobId: selected.jobId,
+      sessionId: claim.sessionId,
+      draftId: draft.draftId,
+      outputHash: draft.outputHash,
+    });
+    events.push("submit_attempted");
+    if (submit.blocked) {
+      return {
+        status: "blocked" as WorkflowStatus,
+        dryRun,
+        runId,
+        jobId: selected.jobId,
+        sessionId: claim.sessionId,
+        draftId: draft.draftId,
+        validation,
+        confidence: proposal.confidence,
+        reason: submit.reason ?? "submit_blocked",
+        submit,
+        slack: slackSummary(events),
+      };
+    }
+
+    return {
+      status: "submitted" as WorkflowStatus,
+      dryRun,
+      runId,
+      jobId: selected.jobId,
+      sessionId: claim.sessionId,
+      draftId: draft.draftId,
+      validation,
+      confidence: proposal.confidence,
+      submit,
+      reviewNotes: ["Submitted exactly once using the validated persisted draft."],
+      slack: slackSummary(events),
+    };
+  } catch (error) {
+    return {
+      status: "failed" as WorkflowStatus,
+      dryRun,
+      runId,
+      reason: error instanceof Error ? error.message : String(error),
+      slack: slackSummary(events),
+    };
+  }
+}
+
+async function selectWikipediaCitationRepairJob(jobId: string | undefined, deps: WorkflowDeps) {
+  if (jobId) {
+    return { jobId, definition: await deps.getDefinition(jobId) };
+  }
+  const jobs = await deps.listJobs();
+  for (const job of jobs) {
+    const definition = job.definition ?? await deps.getDefinition(job.jobId);
+    if (readTaskType(definition) !== "citation_repair") continue;
+    if (!isWikipediaDefinition(definition)) continue;
+    if (readClaimState(definition).claimable === false) continue;
+    return { jobId: job.jobId, definition };
+  }
+  return undefined;
+}
+
+export function buildWikipediaCitationRepairProposal(
+  definition: unknown,
+  evidence: WikipediaEvidenceBundle
+): { output: Record<string, unknown>; confidence: number } {
+  const findings = evidence.citations
+    .filter((citation) => citation.urls.length > 0 || citation.deadLinkMarkers.length > 0)
+    .slice(0, 5)
+    .map((citation) => {
+      const evidenceUrl = citation.archiveUrls[0] ?? citation.urls[0] ?? evidence.revisionUrl ?? "";
+      return {
+        section: "References",
+        problem: citation.deadLinkMarkers.length > 0 ? "dead_link" : "weak_source",
+        current_claim: citation.context || citation.title || `Reference ${citation.index}`,
+        evidence_url: evidenceUrl,
+      };
+    });
+  const proposedChanges = evidence.citations
+    .filter((citation) => citation.urls.length > 0 || citation.archiveUrls.length > 0)
+    .slice(0, 5)
+    .map((citation) => {
+      const sourceUrl = citation.archiveUrls[0] ?? citation.urls[0] ?? evidence.revisionUrl ?? "";
+      return {
+        change_type: citation.archiveUrls.length > 0 ? "replace_citation" : "flag_for_editor_review",
+        target_text: citation.context || citation.title || `Reference ${citation.index}`,
+        replacement_text:
+          citation.archiveUrls.length > 0
+            ? `Use archived source ${citation.archiveUrls[0]} after editor review.`
+            : "Editor should verify and replace this citation with a live reliable source or archive.",
+        source_url: sourceUrl,
+      };
+    });
+
+  if (findings.length === 0 && evidence.citations[0]) {
+    const citation = evidence.citations[0];
+    findings.push({
+      section: "References",
+      problem: "weak_source",
+      current_claim: citation.context || citation.title || `Reference ${citation.index}`,
+      evidence_url: citation.urls[0] ?? evidence.revisionUrl ?? "",
+    });
+    proposedChanges.push({
+      change_type: "flag_for_editor_review",
+      target_text: citation.context || citation.title || `Reference ${citation.index}`,
+      replacement_text: "Editor should review this citation before publishing any change.",
+      source_url: citation.urls[0] ?? evidence.revisionUrl ?? "",
+    });
+  }
+
+  const hasDeadMarker = evidence.citations.some((citation) => citation.deadLinkMarkers.length > 0);
+  const hasSource = evidence.citations.some((citation) => citation.urls.length > 0 || citation.archiveUrls.length > 0);
+  const confidence = hasDeadMarker && hasSource ? 0.72 : hasSource ? 0.62 : 0.4;
+
+  return {
+    output: {
+      page_title: evidence.pageTitle || readPageTitle(definition) || "Unknown page",
+      revision_id: evidence.revisionId || readRevisionId(definition) || "unknown",
+      citation_findings: findings,
+      proposed_changes: proposedChanges,
+      review_notes:
+        "Averray-attributed proposal only. No Wikipedia edit was made. Human editor should verify the source/archive before publishing.",
+    },
+    confidence,
+  };
+}
+
+export function fixSchemaOnlyWikipediaProposal(output: Record<string, unknown>): Record<string, unknown> {
+  const allowedTop = new Set(["page_title", "revision_id", "citation_findings", "proposed_changes", "review_notes"]);
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(output)) {
+    if (allowedTop.has(key)) cleaned[key] = value;
+  }
+  if (Array.isArray(cleaned.citation_findings)) {
+    cleaned.citation_findings = cleaned.citation_findings.map((item) => pickRecord(item, [
+      "section",
+      "problem",
+      "current_claim",
+      "evidence_url",
+    ]));
+  }
+  if (Array.isArray(cleaned.proposed_changes)) {
+    cleaned.proposed_changes = cleaned.proposed_changes.map((item) => pickRecord(item, [
+      "change_type",
+      "target_text",
+      "replacement_text",
+      "source_url",
+    ]));
+  }
+  return cleaned;
+}
+
+function blocked(input: {
+  runId: string;
+  dryRun: boolean;
+  jobId?: string;
+  reason: string;
+  wallet?: WorkflowWallet;
+  policy?: unknown;
+  events: string[];
+}) {
+  return {
+    status: "blocked" as WorkflowStatus,
+    dryRun: input.dryRun,
+    runId: input.runId,
+    ...(input.jobId ? { jobId: input.jobId } : {}),
+    reason: input.reason,
+    ...(input.wallet ? { wallet: input.wallet } : {}),
+    ...(input.policy ? { policy: input.policy } : {}),
+    slack: slackSummary(input.events),
+  };
+}
+
+function summarizeEvidence(evidence: WikipediaEvidenceBundle) {
+  return {
+    pageTitle: evidence.pageTitle,
+    revisionId: evidence.revisionId,
+    citationCount: evidence.citations.length,
+    checkedSourceCount: evidence.sourceChecks.length,
+    sourceUrls: evidence.sourceChecks.map((source) => source.url),
+  };
+}
+
+function slackSummary(events: string[]) {
+  return {
+    configured: Boolean(process.env.SLACK_WEBHOOK_URL),
+    events,
+  };
+}
+
+function isWikipediaDefinition(definition: unknown): boolean {
+  const source = recordField(definition, "source");
+  const publicDetails = recordField(definition, "publicDetails");
+  const value = stringField(source, "type") ?? stringField(publicDetails, "source") ?? stringField(definition, "source");
+  return value === "wikipedia_article" || value === "wikipedia";
+}
+
+function readClaimState(definition: unknown): { claimable?: boolean; reason?: string } {
+  const claimStatus = recordField(definition, "claimStatus") ?? recordField(definition, "claim_state");
+  const lifecycle = recordField(definition, "lifecycle");
+  return {
+    claimable: booleanField(claimStatus, "claimable") ?? booleanField(definition, "claimable"),
+    reason:
+      stringField(claimStatus, "reason") ??
+      stringField(claimStatus, "claimBlockReason") ??
+      stringField(lifecycle, "reason"),
+  };
+}
+
+function readTaskType(definition: unknown): string | undefined {
+  const source = recordField(definition, "source");
+  const publicDetails = recordField(definition, "publicDetails");
+  const agentContext = recordField(definition, "agentContext");
+  return stringField(agentContext, "taskType") ?? stringField(source, "taskType") ?? stringField(publicDetails, "taskType");
+}
+
+function readVerifierMode(definition: unknown): string | undefined {
+  return stringField(definition, "verifierMode") ?? stringField(definition, "verifier");
+}
+
+function readRewardUsd(definition: unknown): number {
+  const reward = recordField(definition, "reward");
+  const values = [
+    numberField(definition, "rewardUsd"),
+    numberField(definition, "reward_usd"),
+    numberField(reward, "usd"),
+    numberField(reward, "usdValue"),
+  ];
+  return values.find((value) => value !== undefined) ?? 0;
+}
+
+export function readPageTitle(definition: unknown): string | undefined {
+  const source = recordField(definition, "source");
+  const publicDetails = recordField(definition, "publicDetails");
+  const urlTitle =
+    titleFromWikipediaUrl(stringField(source, "articleUrl")) ??
+    titleFromWikipediaUrl(stringField(source, "pinnedRevisionUrl")) ??
+    titleFromWikipediaUrl(stringField(publicDetails, "articleUrl")) ??
+    titleFromWikipediaUrl(stringField(publicDetails, "pinnedRevisionUrl"));
+  return (
+    stringField(source, "pageTitle") ??
+    stringField(source, "page_title") ??
+    stringField(source, "articleTitle") ??
+    stringField(source, "title") ??
+    stringField(publicDetails, "pageTitle") ??
+    stringField(publicDetails, "articleTitle") ??
+    stringField(publicDetails, "title") ??
+    urlTitle
+  );
+}
+
+export function readRevisionId(definition: unknown): string | undefined {
+  const source = recordField(definition, "source");
+  const publicDetails = recordField(definition, "publicDetails");
+  const urlRevisionId =
+    oldIdFromWikipediaUrl(stringField(source, "pinnedRevisionUrl")) ??
+    oldIdFromWikipediaUrl(stringField(publicDetails, "pinnedRevisionUrl"));
+  const numericRevisionId =
+    numberField(source, "revisionId") ??
+    numberField(source, "revision_id") ??
+    numberField(source, "pinnedRevisionId") ??
+    numberField(publicDetails, "revisionId") ??
+    numberField(publicDetails, "revision_id");
+  return (
+    stringField(source, "revisionId") ??
+    stringField(source, "revision_id") ??
+    stringField(source, "pinnedRevisionId") ??
+    stringField(publicDetails, "revisionId") ??
+    stringField(publicDetails, "revision_id") ??
+    (numericRevisionId !== undefined ? String(numericRevisionId) : undefined) ??
+    urlRevisionId
+  );
+}
+
+function sameWallet(a: string | null | undefined, b: string): boolean {
+  return typeof a === "string" && a.toLowerCase() === b.toLowerCase();
+}
+
+function pickRecord(value: unknown, keys: string[]): Record<string, unknown> {
+  const record = isRecord(value) ? value : {};
+  return Object.fromEntries(keys.map((key) => [key, record[key]]).filter(([, item]) => item !== undefined));
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return isRecord(field) ? field : undefined;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  if (typeof field === "number") return field;
+  if (typeof field === "string" && field.length > 0 && Number.isFinite(Number(field))) return Number(field);
+  return undefined;
+}
+
+function booleanField(value: unknown, key: string): boolean | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "boolean" ? field : undefined;
+}
+
+function titleFromWikipediaUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    const title = url.searchParams.get("title");
+    if (title) return title.replace(/_/g, " ");
+    const wikiPathMatch = url.pathname.match(/\/wiki\/(.+)$/);
+    return wikiPathMatch ? decodeURIComponent(wikiPathMatch[1]).replace(/_/g, " ") : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function oldIdFromWikipediaUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const oldid = new URL(value).searchParams.get("oldid");
+    return oldid && oldid.length > 0 ? oldid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/unit/job-workflows.test.ts
+++ b/test/unit/job-workflows.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  readPageTitle,
+  readRevisionId,
+  runWikipediaCitationRepairWorkflow,
+  type WorkflowDeps,
+} from "../../packages/averray-mcp/src/job-workflows.js";
+
+const jobId = "wiki-en-45188030-citation-repair-album";
+const sessionId = `${jobId}:0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05`;
+
+const definition = {
+  source: {
+    type: "wikipedia_article",
+    taskType: "citation_repair",
+    pageTitle: "Album",
+    revisionId: "123456789",
+  },
+  verifierMode: "schema",
+  claimStatus: { claimable: true },
+};
+
+const evidence = {
+  pageTitle: "Album",
+  revisionId: "123456789",
+  revisionUrl: "https://en.wikipedia.org/w/index.php?title=Album&oldid=123456789",
+  citations: [
+    {
+      index: 1,
+      referenceId: "review",
+      templateNames: ["cite web"],
+      urls: ["https://dead.example/review"],
+      archiveUrls: ["https://web.archive.org/web/20200101000000/https://dead.example/review"],
+      deadLinkMarkers: ["url_status_dead"],
+      accessDates: ["2020-01-02"],
+      title: "Review",
+      context: "A review citation with a dead source.",
+    },
+  ],
+  sourceChecks: [
+    {
+      url: "https://dead.example/review",
+      status: 404,
+      ok: false,
+      finalUrl: "https://dead.example/review",
+      archiveUrl: "https://web.archive.org/web/20200101000000/https://dead.example/review",
+    },
+  ],
+};
+
+describe("runWikipediaCitationRepairWorkflow", () => {
+  it("blocks when no claimable jobs are available", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow({}, deps({ calls, jobs: [] }));
+
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("no_claimable_wikipedia_citation_repair_jobs");
+    expect(calls).not.toContain("claim");
+    expect(calls).not.toContain("submit");
+  });
+
+  it("blocks wallet mismatch before selecting or mutating", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow(
+      { expectedWallet: "0xDifferent", dryRun: false },
+      deps({ calls })
+    );
+
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("wallet_mismatch");
+    expect(calls).toEqual(["walletStatus"]);
+  });
+
+  it("blocks policy rejection before claim", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: false },
+      deps({ calls, policyAllowed: false })
+    );
+
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("policy_rejected_claim");
+    expect(calls).not.toContain("claim");
+  });
+
+  it("claims, saves, validates, and submits on the happy path", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: false, runId: "run-1" },
+      deps({ calls })
+    );
+
+    expect(result).toMatchObject({
+      status: "submitted",
+      runId: "run-1",
+      jobId,
+      sessionId,
+      draftId: "draft-1",
+      confidence: 0.72,
+    });
+    expect(calls).toEqual([
+      "walletStatus",
+      "getDefinition",
+      "policyCheckClaim",
+      "fetchEvidence",
+      "claim",
+      "saveDraft",
+      "validate",
+      "submit",
+    ]);
+  });
+
+  it("re-saves and re-validates after a schema-only validation failure", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: false },
+      deps({ calls, validationSequence: [false, true] })
+    );
+
+    expect(result.status).toBe("submitted");
+    expect(result.draftId).toBe("draft-2");
+    expect(calls.filter((call) => call === "saveDraft")).toHaveLength(2);
+    expect(calls.filter((call) => call === "validate")).toHaveLength(2);
+  });
+
+  it("reports submit blocked without pretending success", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: false },
+      deps({ calls, submitBlocked: true })
+    );
+
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("max_submit_attempts_exceeded");
+    expect(calls).toContain("submit");
+  });
+
+  it("dry run validates evidence and never mutates", async () => {
+    const calls: string[] = [];
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: true },
+      deps({ calls })
+    );
+
+    expect(result.status).toBe("needs_review");
+    expect(result.dryRun).toBe(true);
+    expect(result.proposalPreview).toBeDefined();
+    expect(calls).toEqual([
+      "walletStatus",
+      "getDefinition",
+      "policyCheckClaim",
+      "fetchEvidence",
+      "validate",
+    ]);
+  });
+
+  it("reads page title and pinned revision id from Wikipedia URLs", () => {
+    const urlDefinition = {
+      source: {
+        type: "wikipedia_article",
+        taskType: "citation_repair",
+        articleUrl: "https://en.wikipedia.org/wiki/Album",
+        pinnedRevisionUrl: "https://en.wikipedia.org/w/index.php?title=Album&oldid=987654321",
+      },
+    };
+
+    expect(readPageTitle(urlDefinition)).toBe("Album");
+    expect(readRevisionId(urlDefinition)).toBe("987654321");
+  });
+});
+
+function deps(options: {
+  calls: string[];
+  jobs?: Array<{ jobId: string; definition?: unknown }>;
+  policyAllowed?: boolean;
+  validationSequence?: boolean[];
+  submitBlocked?: boolean;
+}): WorkflowDeps {
+  let draftCounter = 0;
+  const validationSequence = [...(options.validationSequence ?? [true])];
+  return {
+    async listJobs() {
+      options.calls.push("listJobs");
+      return options.jobs ?? [{ jobId, definition }];
+    },
+    async getDefinition() {
+      options.calls.push("getDefinition");
+      return definition;
+    },
+    async walletStatus() {
+      options.calls.push("walletStatus");
+      return { configured: true, address: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05" };
+    },
+    async policyCheckClaim() {
+      options.calls.push("policyCheckClaim");
+      return options.policyAllowed === false
+        ? { allowed: false, reason: "policy_rejected_claim" }
+        : { allowed: true };
+    },
+    async claim() {
+      options.calls.push("claim");
+      return { sessionId, claimDeadline: "2026-05-02T13:36:37.224Z" };
+    },
+    async fetchEvidence() {
+      options.calls.push("fetchEvidence");
+      return evidence;
+    },
+    async saveDraft() {
+      options.calls.push("saveDraft");
+      draftCounter += 1;
+      return { draftId: `draft-${draftCounter}`, outputHash: `hash-${draftCounter}` };
+    },
+    async validate() {
+      options.calls.push("validate");
+      const valid = validationSequence.length > 1 ? validationSequence.shift()! : validationSequence[0] ?? true;
+      return valid
+        ? { valid: true, validator: "wikipedia", taskType: "citation_repair" }
+        : {
+            valid: false,
+            validator: "wikipedia",
+            taskType: "citation_repair",
+            errors: [{ path: "citation_findings.0.extra", code: "unrecognized_keys", message: "extra" }],
+          };
+    },
+    async submit() {
+      options.calls.push("submit");
+      return options.submitBlocked
+        ? { blocked: true, reason: "max_submit_attempts_exceeded" }
+        : { response: { status: "submitted" } };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add averray_run_wikipedia_citation_repair as a first-class MCP workflow entrypoint
- factor a generic workflow skeleton with the first adapter for wikipedia_citation_repair
- keep dryRun=true by default; dry runs fetch evidence and validate a preview but never claim or submit
- route mutation runs through existing wallet checks, claim/submit policy guards, draft persistence, local validation, confidence gate, and Slack lifecycle alerts
- document short terminal/Slack-style prompts in VPS smoke docs

Closes #35

## Checks
- npm run typecheck
- npm test

## Safety
- No Wikipedia edits
- Dry run never calls claim/submit
- Non-dry runs still use the existing one-shot mutation guards and persisted draft submit path