### PR TITLE
Guard one-command workflow run ids

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -196,7 +196,7 @@ run Wikipedia citation repair for wiki-en-... if safe, dry run only
 Mutation run, only after allowlists are set for the exact job/session boundary:
 
 ```text
-run Wikipedia citation repair for wiki-en-... if safe with dryRun=false
+run Wikipedia citation repair for wiki-en-... with runId controlled-wikipedia-onecommand-r1-001 if safe with dryRun=false
 ```
 
 The workflow tool is `averray_run_wikipedia_citation_repair`. Its default is
@@ -204,7 +204,10 @@ The workflow tool is `averray_run_wikipedia_citation_repair`. Its default is
 a proposal preview but must not call `averray_claim` or `averray_submit`.
 With `dryRun=false`, claim and submit still go through the same one-shot
 mutation guards, draft persistence, local schema validation, confidence gate,
-and Slack lifecycle alerts.
+and Slack lifecycle alerts. If a mutation run omits `runId`, the workflow
+generates one before claim and carries that same value through claim, draft
+persistence, validation, submit, and Slack context. A blank explicit `runId`
+fails closed before any wallet check or mutation.
 
 ## Tool Smoke
 

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -524,10 +524,13 @@ function workflowDeps() {
       );
       return { draftId: draft.draftId, outputHash: draft.outputHash };
     },
-    async validate(input: { jobId: string; draftId?: string; output?: Record<string, unknown> }) {
+    async validate(input: { runId: string; jobId: string; sessionId?: string; draftId?: string; output?: Record<string, unknown> }) {
       const definition = await request(`/jobs/definition?jobId=${encodeURIComponent(input.jobId)}`);
       if (input.draftId) {
-        const draft = await getDraftSubmission({ draftId: input.draftId, jobId: input.jobId }, query);
+        const draft = await getDraftSubmission(
+          { draftId: input.draftId, runId: input.runId, jobId: input.jobId, sessionId: input.sessionId },
+          query
+        );
         const validation = validateSubmissionLocally(definition, draft.output);
         await markDraftValidation(draft.draftId, validation.valid, validation, query);
         return validation;

--- a/packages/averray-mcp/src/job-workflows.ts
+++ b/packages/averray-mcp/src/job-workflows.ts
@@ -47,6 +47,7 @@ export interface WorkflowSubmitResult {
 }
 
 export interface WorkflowDeps {
+  generateRunId?(): string;
   listJobs(): Promise<WorkflowJob[]>;
   getDefinition(jobId: string): Promise<unknown>;
   walletStatus(): Promise<WorkflowWallet>;
@@ -69,7 +70,9 @@ export interface WorkflowDeps {
     output: Record<string, unknown>;
   }): Promise<WorkflowDraft>;
   validate(input: {
+    runId: string;
     jobId: string;
+    sessionId?: string;
     draftId?: string;
     output?: Record<string, unknown>;
   }): Promise<SubmissionValidationResult>;
@@ -100,13 +103,26 @@ export async function runWikipediaCitationRepairWorkflow(
   input: WikipediaCitationRepairWorkflowInput,
   deps: WorkflowDeps
 ) {
-  const runId = input.runId ?? `wikipedia-citation-repair-${randomUUID()}`;
+  const explicitRunId = input.runId === undefined ? undefined : normalizeRunId(input.runId);
+  let runId = explicitRunId;
   const dryRun = input.dryRun ?? true;
   const maxEvidenceUrls = input.maxEvidenceUrls ?? 5;
   const confidenceThreshold = input.confidenceThreshold ?? 0.7;
   const events: string[] = [];
 
   try {
+    if (input.runId !== undefined && !explicitRunId) {
+      return {
+        status: "blocked" as WorkflowStatus,
+        dryRun,
+        runId: null,
+        reason: "invalid_run_id",
+        slack: slackSummary(events),
+      };
+    }
+    runId = runId
+      ?? normalizeRunId(deps.generateRunId?.())
+      ?? `wikipedia-citation-repair-${randomUUID()}`;
     const wallet = await deps.walletStatus();
     events.push("wallet_checked");
     if (!wallet.configured) {
@@ -170,7 +186,7 @@ export async function runWikipediaCitationRepairWorkflow(
     const proposal = buildWikipediaCitationRepairProposal(definition, evidence);
 
     if (dryRun) {
-      const validation = await deps.validate({ jobId: selected.jobId, output: proposal.output });
+      const validation = await deps.validate({ runId, jobId: selected.jobId, output: proposal.output });
       events.push("validated_without_mutation");
       return {
         status: "needs_review" as WorkflowStatus,
@@ -190,6 +206,7 @@ export async function runWikipediaCitationRepairWorkflow(
       };
     }
 
+    assertMutationRunId(runId, "claim");
     const claim = await deps.claim({ runId, jobId: selected.jobId });
     events.push("claimed");
     if (!claim.sessionId) {
@@ -204,6 +221,7 @@ export async function runWikipediaCitationRepairWorkflow(
       };
     }
 
+    assertMutationRunId(runId, "draft");
     const draft = await deps.saveDraft({
       runId,
       jobId: selected.jobId,
@@ -212,7 +230,7 @@ export async function runWikipediaCitationRepairWorkflow(
     });
     events.push("draft_saved");
 
-    let validation = await deps.validate({ jobId: selected.jobId, draftId: draft.draftId });
+    let validation = await deps.validate({ runId, jobId: selected.jobId, sessionId: claim.sessionId, draftId: draft.draftId });
     events.push("validated");
     if (!validation.valid) {
       const fixed = fixSchemaOnlyWikipediaProposal(proposal.output);
@@ -224,7 +242,7 @@ export async function runWikipediaCitationRepairWorkflow(
           output: fixed,
         });
         events.push("schema_fixed_and_resaved");
-        validation = await deps.validate({ jobId: selected.jobId, draftId: fixedDraft.draftId });
+        validation = await deps.validate({ runId, jobId: selected.jobId, sessionId: claim.sessionId, draftId: fixedDraft.draftId });
         if (validation.valid) {
           draft.draftId = fixedDraft.draftId;
           draft.outputHash = fixedDraft.outputHash;
@@ -264,6 +282,7 @@ export async function runWikipediaCitationRepairWorkflow(
       };
     }
 
+    assertMutationRunId(runId, "submit");
     const submit = await deps.submit({
       runId,
       jobId: selected.jobId,
@@ -309,6 +328,18 @@ export async function runWikipediaCitationRepairWorkflow(
       reason: error instanceof Error ? error.message : String(error),
       slack: slackSummary(events),
     };
+  }
+}
+
+function normalizeRunId(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function assertMutationRunId(runId: string | undefined, phase: string): asserts runId is string {
+  if (!normalizeRunId(runId)) {
+    throw new Error(`workflow_missing_run_id_before_${phase}`);
   }
 }
 

--- a/test/unit/job-workflows.test.ts
+++ b/test/unit/job-workflows.test.ts
@@ -86,9 +86,10 @@ describe("runWikipediaCitationRepairWorkflow", () => {
 
   it("claims, saves, validates, and submits on the happy path", async () => {
     const calls: string[] = [];
+    const records = callRecords();
     const result = await runWikipediaCitationRepairWorkflow(
       { jobId, dryRun: false, runId: "run-1" },
-      deps({ calls })
+      deps({ calls, records })
     );
 
     expect(result).toMatchObject({
@@ -109,6 +110,44 @@ describe("runWikipediaCitationRepairWorkflow", () => {
       "validate",
       "submit",
     ]);
+    expect(records.claim[0]).toMatchObject({ runId: "run-1", jobId });
+    expect(records.saveDraft[0]).toMatchObject({ runId: "run-1", jobId, sessionId });
+    expect(records.validate[0]).toMatchObject({ runId: "run-1", jobId, sessionId, draftId: "draft-1" });
+    expect(records.submit[0]).toMatchObject({ runId: "run-1", jobId, sessionId, draftId: "draft-1" });
+  });
+
+  it("generates a runId before mutations and carries it through submit", async () => {
+    const calls: string[] = [];
+    const records = callRecords();
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: false },
+      deps({ calls, records, generatedRunId: "generated-run-1" })
+    );
+
+    expect(result.status).toBe("submitted");
+    expect(result.runId).toBe("generated-run-1");
+    expect(records.policyCheckClaim[0]).toMatchObject({ runId: "generated-run-1", jobId });
+    expect(records.claim[0]).toMatchObject({ runId: "generated-run-1", jobId });
+    expect(records.saveDraft[0]).toMatchObject({ runId: "generated-run-1", jobId, sessionId });
+    expect(records.validate[0]).toMatchObject({ runId: "generated-run-1", jobId, sessionId, draftId: "draft-1" });
+    expect(records.submit[0]).toMatchObject({ runId: "generated-run-1", jobId, sessionId, draftId: "draft-1" });
+  });
+
+  it("fails closed before submit when an explicit runId is blank", async () => {
+    const calls: string[] = [];
+    const records = callRecords();
+    const result = await runWikipediaCitationRepairWorkflow(
+      { jobId, dryRun: false, runId: "   " },
+      deps({ calls, records })
+    );
+
+    expect(result).toMatchObject({
+      status: "blocked",
+      reason: "invalid_run_id",
+      runId: null,
+    });
+    expect(calls).toEqual([]);
+    expect(records.submit).toHaveLength(0);
   });
 
   it("re-saves and re-validates after a schema-only validation failure", async () => {
@@ -172,6 +211,8 @@ describe("runWikipediaCitationRepairWorkflow", () => {
 
 function deps(options: {
   calls: string[];
+  records?: WorkflowCallRecords;
+  generatedRunId?: string;
   jobs?: Array<{ jobId: string; definition?: unknown }>;
   policyAllowed?: boolean;
   validationSequence?: boolean[];
@@ -179,7 +220,7 @@ function deps(options: {
 }): WorkflowDeps {
   let draftCounter = 0;
   const validationSequence = [...(options.validationSequence ?? [true])];
-  return {
+  const workflowDeps: WorkflowDeps = {
     async listJobs() {
       options.calls.push("listJobs");
       return options.jobs ?? [{ jobId, definition }];
@@ -192,27 +233,31 @@ function deps(options: {
       options.calls.push("walletStatus");
       return { configured: true, address: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05" };
     },
-    async policyCheckClaim() {
+    async policyCheckClaim(input) {
       options.calls.push("policyCheckClaim");
+      options.records?.policyCheckClaim.push(input);
       return options.policyAllowed === false
         ? { allowed: false, reason: "policy_rejected_claim" }
         : { allowed: true };
     },
-    async claim() {
+    async claim(input) {
       options.calls.push("claim");
+      options.records?.claim.push(input);
       return { sessionId, claimDeadline: "2026-05-02T13:36:37.224Z" };
     },
     async fetchEvidence() {
       options.calls.push("fetchEvidence");
       return evidence;
     },
-    async saveDraft() {
+    async saveDraft(input) {
       options.calls.push("saveDraft");
+      options.records?.saveDraft.push(input);
       draftCounter += 1;
       return { draftId: `draft-${draftCounter}`, outputHash: `hash-${draftCounter}` };
     },
-    async validate() {
+    async validate(input) {
       options.calls.push("validate");
+      options.records?.validate.push(input);
       const valid = validationSequence.length > 1 ? validationSequence.shift()! : validationSequence[0] ?? true;
       return valid
         ? { valid: true, validator: "wikipedia", taskType: "citation_repair" }
@@ -223,11 +268,34 @@ function deps(options: {
             errors: [{ path: "citation_findings.0.extra", code: "unrecognized_keys", message: "extra" }],
           };
     },
-    async submit() {
+    async submit(input) {
       options.calls.push("submit");
+      options.records?.submit.push(input);
       return options.submitBlocked
         ? { blocked: true, reason: "max_submit_attempts_exceeded" }
         : { response: { status: "submitted" } };
     },
+  };
+  if (options.generatedRunId) {
+    workflowDeps.generateRunId = () => options.generatedRunId!;
+  }
+  return workflowDeps;
+}
+
+interface WorkflowCallRecords {
+  policyCheckClaim: Array<Parameters<WorkflowDeps["policyCheckClaim"]>[0]>;
+  claim: Array<Parameters<WorkflowDeps["claim"]>[0]>;
+  saveDraft: Array<Parameters<WorkflowDeps["saveDraft"]>[0]>;
+  validate: Array<Parameters<WorkflowDeps["validate"]>[0]>;
+  submit: Array<Parameters<WorkflowDeps["submit"]>[0]>;
+}
+
+function callRecords(): WorkflowCallRecords {
+  return {
+    policyCheckClaim: [],
+    claim: [],
+    saveDraft: [],
+    validate: [],
+    submit: [],
   };
 }


### PR DESCRIPTION
Closes #36.

## What changed
- Generate or require the workflow runId before any mutation path.
- Carry the same runId through claim policy, claim, draft persistence, validation lookup context, submit, and Slack-facing workflow state.
- Fail closed on an explicitly blank runId before wallet checks or submit can run.
- Document the one-command mutation prompt with an explicit runId example.

## Checks
- npm run typecheck
- npm test
- git diff --check

## Surface area
- MCP workflow/backend only; no frontend, contracts, indexer, Caddy, or public site changes.