### PR TITLE
Prefer workflow tool for short Wikipedia repair intents

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -203,6 +203,12 @@ run Wikipedia citation repair for wiki-en-... with runId controlled-wikipedia-on
 The workflow tool is `averray_run_wikipedia_citation_repair`. Its default is
 `dryRun=true`, which may fetch read-only Wikipedia/source evidence and validate
 a proposal preview but must not call `averray_claim` or `averray_submit`.
+For short operator intents such as `Run one Wikipedia citation repair if safe.`
+or `Run Wikipedia citation repair for <jobId> if safe.`, including Slack and
+command-center requests, Hermes should call
+`averray_run_wikipedia_citation_repair` first. Lower-level tools such as
+`averray_list_jobs` and `averray_claim` are fallback primitives, not the
+preferred route for this intent.
 With `dryRun=false`, claim and submit still go through the same one-shot
 mutation guards, draft persistence, local schema validation, confidence gate,
 and Slack lifecycle alerts. If a mutation run omits `runId`, the workflow

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -126,7 +126,7 @@ server.tool(
 
 server.tool(
   "averray_run_wikipedia_citation_repair",
-  "Run the reference agent's safe Wikipedia citation-repair workflow from one short command. It uses the generic Averray lifecycle skeleton plus the Wikipedia citation-repair adapter: wallet check, job discovery/definition, claimability/policy checks, optional claim, deterministic read-only evidence gathering, draft persistence, local validation, and guarded submit. dryRun defaults to true and never calls claim or submit.",
+  "Preferred first tool for short operator intents like 'Run one Wikipedia citation repair if safe' or 'Run Wikipedia citation repair for <jobId> if safe'. Run the reference agent's safe Wikipedia citation-repair workflow from one short command. It uses the generic Averray lifecycle skeleton plus the Wikipedia citation-repair adapter: wallet check, job discovery/definition, claimability/policy checks, optional claim, deterministic read-only evidence gathering, draft persistence, local validation, and guarded submit. dryRun defaults to true and never calls claim or submit. Use this workflow before lower-level tools such as averray_list_jobs or averray_claim for Wikipedia citation-repair requests.",
   {
     runId: z.string().optional(),
     jobId: z.string().optional(),
@@ -143,7 +143,7 @@ server.tool(
   }
 );
 
-server.tool("averray_claim", "Claim a job through Averray's public API fallback path.", {
+server.tool("averray_claim", "Low-level claim primitive for explicit claim operations. Do not use this directly for short Wikipedia citation-repair operator intents; prefer averray_run_wikipedia_citation_repair so runId generation, evidence helpers, draft persistence, validation, submit limits, and Slack alerts are handled together.", {
   runId: z.string().optional(),
   jobId: z.string().min(1),
   idempotencyKey: z.string().optional()


### PR DESCRIPTION
Closes #39.\n\nWhat changed:\n- Marks averray_run_wikipedia_citation_repair as the preferred first tool for short operator prompts like `Run one Wikipedia citation repair if safe`.\n- Marks averray_claim as a low-level primitive and points Wikipedia repair intents at the workflow tool instead.\n- Documents the same routing for Slack and command-center/operator requests.\n\nChecks:\n- npm run typecheck\n- npm test (56/56)\n- npm run build\n- git diff --check\n\nImpact:\n- MCP/tool descriptions and docs only.\n- No backend API, chain/RPC, contracts, or VPS secret changes.