### PR TITLE
Add Slack operator commands for Wikipedia repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,8 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   They cover claim prechecks, claim/submit outcomes, local validation failures,
   TTL warnings, and inventory exhaustion/replenishment. See
   [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md#slack-operational-alerts).
+- Slack and command-center operators can route short commands through
+  `averray_handle_operator_command` instead of a free-form Hermes prompt. It
+  recognizes `run one wikipedia citation repair if safe` and calls the
+  Wikipedia workflow tool directly; `status last wikipedia citation repair`
+  returns the latest run/session/draft/submit status without mutating anything.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -81,6 +81,23 @@ Local submission validation alerts fire before `averray_submit` touches the
 submit mutation budget, so schema mistakes are visible without burning the
 one-shot submit attempt.
 
+Inbound Slack or command-center messages should be routed to the direct MCP
+operator command tool, not rephrased as free-form Hermes prompts. The supported
+commands are:
+
+```text
+run one wikipedia citation repair if safe
+run wikipedia citation repair for wiki-en-... if safe
+status last wikipedia citation repair
+```
+
+`averray_handle_operator_command` parses those messages. Repair commands call
+`averray_run_wikipedia_citation_repair` directly with the workflow's wallet,
+policy, draft, validation, submit, and Slack alert gates. Status commands are
+read-only and return the latest `runId`, `jobId`, `sessionId`, submitted/failed
+state, `draftId`, and Slack permalink when one is available. Add `dry run only`
+to a repair command when you want a proposal preview without claim or submit.
+
 Check the host env file:
 
 ```bash

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -37,6 +37,10 @@ import {
   type WikipediaEvidenceBundle,
   type WorkflowJob,
 } from "./job-workflows.js";
+import {
+  getLastWikipediaCitationRepairStatus,
+  parseOperatorCommand,
+} from "./operator-commands.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -121,6 +125,46 @@ server.tool(
   },
   async ({ url, timestampHint, timeoutMs }) => {
     return jsonContent(await findArchiveSnapshot({ url, timestampHint, timeoutMs }));
+  }
+);
+
+server.tool(
+  "averray_handle_operator_command",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'run one wikipedia citation repair if safe' and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status commands are read-only.",
+  {
+    text: z.string().min(1),
+    source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),
+    expectedWallet: z.string().optional(),
+    defaultDryRun: z.boolean().default(false),
+    maxEvidenceUrls: z.number().int().min(1).max(20).default(5),
+    confidenceThreshold: z.number().min(0).max(1).default(0.7)
+  },
+  async ({ text, source, expectedWallet, defaultDryRun, maxEvidenceUrls, confidenceThreshold }) => {
+    const command = parseOperatorCommand(text, {
+      source,
+      defaultDryRun,
+      maxEvidenceUrls,
+      confidenceThreshold,
+    });
+    if (!command.handled) return jsonContent(command);
+    if (command.kind === "status_last_wikipedia_citation_repair") {
+      const status = await getLastWikipediaCitationRepairStatus(query);
+      return jsonContent({ ...command, status });
+    }
+    const result = await runWikipediaCitationRepairWorkflow(
+      { ...command.input, expectedWallet },
+      workflowDeps()
+    );
+    return jsonContent({ ...command, result });
+  }
+);
+
+server.tool(
+  "averray_status_last_wikipedia_citation_repair",
+  "Read-only status command for Slack/operator use. Returns the latest Wikipedia citation-repair runId, jobId, sessionId, submitted/failed state, draftId, and Slack permalink when available.",
+  {},
+  async () => {
+    return jsonContent(await getLastWikipediaCitationRepairStatus(query));
   }
 );
 

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,0 +1,248 @@
+import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
+
+export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes";
+
+export type ParsedOperatorCommand =
+  | {
+      handled: true;
+      kind: "run_wikipedia_citation_repair";
+      source: OperatorCommandSource;
+      input: WikipediaCitationRepairWorkflowInput;
+    }
+  | {
+      handled: true;
+      kind: "status_last_wikipedia_citation_repair";
+      source: OperatorCommandSource;
+    }
+  | {
+      handled: false;
+      kind: "unknown";
+      source: OperatorCommandSource;
+      normalizedText: string;
+      examples: string[];
+    };
+
+export type OperatorQueryFn = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[]
+) => Promise<T[]>;
+
+export interface LastWikipediaCitationRepairStatus {
+  found: boolean;
+  runId?: string;
+  jobId?: string;
+  sessionId?: string;
+  status?: string;
+  submittedAt?: string;
+  failedAt?: string;
+  draftId?: string;
+  draftValidationStatus?: string;
+  submitSucceeded: boolean;
+  slackPermalink?: string | null;
+  source: "submissions" | "draft_submissions" | "none";
+  lastError?: string;
+  updatedAt?: string;
+}
+
+const EXAMPLES = [
+  "run one wikipedia citation repair if safe",
+  "run wikipedia citation repair for wiki-en-... if safe",
+  "status last wikipedia citation repair",
+];
+
+export function parseOperatorCommand(
+  text: string,
+  options: {
+    source?: OperatorCommandSource;
+    defaultDryRun?: boolean;
+    maxEvidenceUrls?: number;
+    confidenceThreshold?: number;
+  } = {}
+): ParsedOperatorCommand {
+  const source = options.source ?? "operator";
+  const normalizedText = normalizeCommandText(text);
+
+  if (normalizedText === "status last wikipedia citation repair") {
+    return { handled: true, kind: "status_last_wikipedia_citation_repair", source };
+  }
+
+  if (
+    normalizedText.startsWith("run ") &&
+    normalizedText.includes("wikipedia citation repair") &&
+    normalizedText.includes("if safe")
+  ) {
+    const jobId = extractToken(text, /\bfor\s+([A-Za-z0-9_.:-]+)/i);
+    const runId = extractToken(text, /\brun\s*id\s*[:=]?\s*([A-Za-z0-9_.:-]+)/i);
+    const dryRun = /\b(dry\s*run|preview|read[-\s]*only|no\s+submit)\b/i.test(text)
+      ? true
+      : options.defaultDryRun ?? false;
+    return {
+      handled: true,
+      kind: "run_wikipedia_citation_repair",
+      source,
+      input: {
+        ...(runId ? { runId } : {}),
+        ...(jobId ? { jobId } : {}),
+        dryRun,
+        maxEvidenceUrls: options.maxEvidenceUrls ?? 5,
+        confidenceThreshold: options.confidenceThreshold ?? 0.7,
+      },
+    };
+  }
+
+  return { handled: false, kind: "unknown", source, normalizedText, examples: EXAMPLES };
+}
+
+export async function getLastWikipediaCitationRepairStatus(
+  query: OperatorQueryFn
+): Promise<LastWikipediaCitationRepairStatus> {
+  const submissions = await query<SubmissionStatusRow>(
+    `select
+       s.request,
+       s.response,
+       s.status,
+       s.last_error,
+       s.updated_at,
+       d.draft_id,
+       d.run_id as draft_run_id,
+       d.job_id as draft_job_id,
+       d.session_id as draft_session_id,
+       d.validation_status as draft_validation_status
+     from submissions s
+     left join draft_submissions d on d.draft_id = s.request->>'draftId'
+     where s.kind = 'submit'
+       and coalesce(s.request->>'jobId', d.job_id, '') like 'wiki-en-%citation-repair%'
+     order by s.updated_at desc
+     limit 1`
+  );
+  if (submissions[0]) return statusFromSubmissionRow(submissions[0]);
+
+  const drafts = await query<DraftStatusRow>(
+    `select draft_id, run_id, job_id, session_id, validation_status, updated_at
+     from draft_submissions
+     where job_id like 'wiki-en-%citation-repair%'
+     order by updated_at desc
+     limit 1`
+  );
+  if (drafts[0]) return statusFromDraftRow(drafts[0]);
+
+  return { found: false, source: "none", submitSucceeded: false, slackPermalink: null };
+}
+
+function statusFromSubmissionRow(row: SubmissionStatusRow): LastWikipediaCitationRepairStatus {
+  const request = toRecord(row.request);
+  const response = toRecord(row.response);
+  const rawStatus = stringField(row, "status") ?? "unknown";
+  const submitSucceeded = rawStatus === "completed";
+  const status = submitSucceeded
+    ? firstDeepString(response, ["state", "status"]) ?? "submitted"
+    : rawStatus === "failed"
+      ? "failed"
+      : rawStatus;
+  const updatedAt = dateString(row.updated_at);
+  return {
+    found: true,
+    runId: stringField(request, "policyRunId") ?? stringField(request, "runId") ?? stringField(row, "draft_run_id"),
+    jobId: stringField(request, "jobId") ?? stringField(row, "draft_job_id"),
+    sessionId: stringField(request, "sessionId") ?? stringField(row, "draft_session_id"),
+    status,
+    ...(submitSucceeded && updatedAt ? { submittedAt: updatedAt } : {}),
+    ...(!submitSucceeded && rawStatus === "failed" && updatedAt ? { failedAt: updatedAt } : {}),
+    draftId: stringField(request, "draftId") ?? stringField(row, "draft_id"),
+    draftValidationStatus: stringField(row, "draft_validation_status"),
+    submitSucceeded,
+    slackPermalink: firstDeepString(response, ["slackPermalink", "slack_permalink", "permalink"]) ?? null,
+    source: "submissions",
+    ...(stringField(row, "last_error") ? { lastError: stringField(row, "last_error") } : {}),
+    ...(updatedAt ? { updatedAt } : {}),
+  };
+}
+
+function statusFromDraftRow(row: DraftStatusRow): LastWikipediaCitationRepairStatus {
+  const updatedAt = dateString(row.updated_at);
+  return {
+    found: true,
+    runId: stringField(row, "run_id"),
+    jobId: stringField(row, "job_id"),
+    sessionId: stringField(row, "session_id"),
+    status: "draft_saved",
+    draftId: stringField(row, "draft_id"),
+    draftValidationStatus: stringField(row, "validation_status"),
+    submitSucceeded: false,
+    slackPermalink: null,
+    source: "draft_submissions",
+    ...(updatedAt ? { updatedAt } : {}),
+  };
+}
+
+function normalizeCommandText(text: string): string {
+  return text.trim().toLowerCase().replace(/[.!?]+$/g, "").replace(/\s+/g, " ");
+}
+
+function extractToken(text: string, pattern: RegExp): string | undefined {
+  const match = text.match(pattern);
+  return match?.[1]?.replace(/[.,!?]+$/g, "");
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value);
+      return isRecord(parsed) ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+  return {};
+}
+
+function firstDeepString(value: unknown, keys: string[], depth = 0): string | undefined {
+  if (depth > 5 || !isRecord(value)) return undefined;
+  for (const key of keys) {
+    const direct = value[key];
+    if (typeof direct === "string" && direct.length > 0) return direct;
+  }
+  for (const nested of Object.values(value)) {
+    const match = firstDeepString(nested, keys, depth + 1);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function dateString(value: unknown): string | undefined {
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface SubmissionStatusRow {
+  request?: unknown;
+  response?: unknown;
+  status?: string;
+  last_error?: string | null;
+  updated_at?: string | Date;
+  draft_id?: string | null;
+  draft_run_id?: string | null;
+  draft_job_id?: string | null;
+  draft_session_id?: string | null;
+  draft_validation_status?: string | null;
+}
+
+interface DraftStatusRow {
+  draft_id?: string;
+  run_id?: string | null;
+  job_id?: string;
+  session_id?: string | null;
+  validation_status?: string;
+  updated_at?: string | Date;
+}

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getLastWikipediaCitationRepairStatus,
+  parseOperatorCommand,
+} from "../../packages/averray-mcp/src/operator-commands.js";
+
+describe("operator commands", () => {
+  it("routes the short Slack repair command to the workflow with mutations enabled", () => {
+    const parsed = parseOperatorCommand("run one wikipedia citation repair if safe", {
+      source: "slack",
+    });
+
+    expect(parsed).toMatchObject({
+      handled: true,
+      kind: "run_wikipedia_citation_repair",
+      source: "slack",
+      input: {
+        dryRun: false,
+        maxEvidenceUrls: 5,
+        confidenceThreshold: 0.7,
+      },
+    });
+  });
+
+  it("extracts a target job and respects dry-run wording", () => {
+    const parsed = parseOperatorCommand(
+      "Run Wikipedia citation repair for wiki-en-58158792-citation-repair-r5 if safe, dry run only",
+      { source: "command_center" }
+    );
+
+    expect(parsed).toMatchObject({
+      handled: true,
+      kind: "run_wikipedia_citation_repair",
+      source: "command_center",
+      input: {
+        jobId: "wiki-en-58158792-citation-repair-r5",
+        dryRun: true,
+      },
+    });
+  });
+
+  it("routes the latest status command read-only", () => {
+    const parsed = parseOperatorCommand("status last wikipedia citation repair.", { source: "operator" });
+
+    expect(parsed).toEqual({
+      handled: true,
+      kind: "status_last_wikipedia_citation_repair",
+      source: "operator",
+    });
+  });
+
+  it("returns latest submit status with draft id and Slack permalink when stored", async () => {
+    const status = await getLastWikipediaCitationRepairStatus(async (text) => {
+      if (text.includes("from submissions")) {
+        return [
+          {
+            request: {
+              policyRunId: "wikipedia-citation-repair-run-1",
+              jobId: "wiki-en-45188030-citation-repair-album-r2",
+              sessionId: "wiki-en-45188030-citation-repair-album-r2:0xWallet",
+              draftId: "draft-1",
+            },
+            response: {
+              state: "submitted",
+              slack: { permalink: "https://slack.example/archives/C/p123" },
+            },
+            status: "completed",
+            updated_at: "2026-05-02T16:28:06.073Z",
+            draft_validation_status: "valid",
+          },
+        ];
+      }
+      return [];
+    });
+
+    expect(status).toMatchObject({
+      found: true,
+      runId: "wikipedia-citation-repair-run-1",
+      jobId: "wiki-en-45188030-citation-repair-album-r2",
+      sessionId: "wiki-en-45188030-citation-repair-album-r2:0xWallet",
+      status: "submitted",
+      submittedAt: "2026-05-02T16:28:06.073Z",
+      draftId: "draft-1",
+      draftValidationStatus: "valid",
+      submitSucceeded: true,
+      slackPermalink: "https://slack.example/archives/C/p123",
+      source: "submissions",
+    });
+  });
+
+  it("falls back to the latest draft when no submit exists", async () => {
+    const status = await getLastWikipediaCitationRepairStatus(async (text) => {
+      if (text.includes("from draft_submissions")) {
+        return [
+          {
+            draft_id: "draft-2",
+            run_id: "run-2",
+            job_id: "wiki-en-62871101-citation-repair-hash-r2",
+            session_id: "wiki-en-62871101-citation-repair-hash-r2:0xWallet",
+            validation_status: "valid",
+            updated_at: new Date("2026-05-02T16:30:00.000Z"),
+          },
+        ];
+      }
+      return [];
+    });
+
+    expect(status).toMatchObject({
+      found: true,
+      runId: "run-2",
+      jobId: "wiki-en-62871101-citation-repair-hash-r2",
+      status: "draft_saved",
+      draftId: "draft-2",
+      draftValidationStatus: "valid",
+      submitSucceeded: false,
+      source: "draft_submissions",
+      updatedAt: "2026-05-02T16:30:00.000Z",
+    });
+  });
+});


### PR DESCRIPTION
What changed:\n- Adds averray_handle_operator_command as the direct router for Slack/operator/command-center messages.\n- Routes `run one wikipedia citation repair if safe` and `run wikipedia citation repair for <jobId> if safe` straight into averray_run_wikipedia_citation_repair instead of relying on a free-form Hermes prompt.\n- Adds the read-only averray_status_last_wikipedia_citation_repair tool for `status last wikipedia citation repair`.\n- Status reports latest runId, jobId, sessionId, submitted/failed state, draftId, validation state, and Slack permalink when available.\n- Documents the commands in README and VPS smoke docs.\n\nChecks:\n- npm run typecheck\n- npm test (61/61)\n- npm run build\n- git diff --check\n\nImpact:\n- MCP/operator command layer and docs.\n- No chain/RPC, contracts, or VPS secret changes.\n- Slack permalink is returned only if a future Slack path stores one; webhook-only alerts currently report null.