### PR TITLE
Harden command center workspace config

### DIFF
--- a/docs/COMMAND_CENTER.md
+++ b/docs/COMMAND_CENTER.md
@@ -23,6 +23,13 @@ published only to VPS localhost.
 - Use SSH or Tailscale tunnels to reach the UI.
 - Set strong `HERMES_WORKSPACE_PASSWORD` and `HERMES_GATEWAY_API_KEY`
   values before starting the workspace.
+- The Workspace image still checks legacy `CLAUDE_API_TOKEN` and
+  `CLAUDE_DASHBOARD_TOKEN` names for some enhanced gateway/dashboard calls.
+  The Compose overlay maps them to `HERMES_GATEWAY_API_KEY`; keep all three
+  token aliases aligned.
+- Workspace writes session and Kanban metadata below `$HOME/.hermes`. The
+  Compose overlay sets `HOME=/tmp/workspace-home` because the upstream image's
+  default `/home/workspace` path is not writable in this deployment mode.
 - Do not mount the Docker socket.
 - Do not give the Workspace container the Averray wallet private key or MCP
   runtime env volume. The gateway owns agent execution; the UI only talks to
@@ -127,9 +134,49 @@ In the Workspace UI, verify:
 
 - it detects the gateway URL `http://hermes-gateway:8642`
 - it detects the dashboard URL `http://hermes:9119`
+- settings show model `hermes-agent` and chat can answer a tiny prompt such as
+  `say ok`
 - chat can reach the configured Hermes provider
 - sessions/tool activity are visible, if supported by the pinned Hermes image
 - terminal/file/memory panes are either usable or clearly marked unsupported
+
+If chat returns `model "${HERMES_DEFAULT_MODEL}" not found`, the mounted
+Hermes config is still using an unexpanded placeholder. The checked-in
+`hermes/config/hermes.yaml` intentionally uses concrete Ollama Cloud defaults
+for the gateway process:
+
+```yaml
+model:
+  provider: ollama-cloud
+  base_url: https://ollama.com/v1
+  api_key_env: OLLAMA_API_KEY
+  default: deepseek-v4-pro:cloud
+```
+
+If the Workspace UI shows `Authentication required — Hermes Agent rejected the
+connection token` while `/v1/chat/completions` works, clear the Workspace
+server-side and browser-side saved state after confirming the token aliases are
+present:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -p avg \
+  --profile command-center \
+  exec hermes-workspace env | grep -E 'HERMES_API|CLAUDE_API|CLAUDE_DASHBOARD|HOME'
+
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -p avg \
+  --profile command-center \
+  exec hermes-workspace sh -lc 'rm -rf /tmp/workspace-home/.hermes && mkdir -p /tmp/workspace-home/.hermes'
+```
+
+Then clear site data for `127.0.0.1:3000` in the browser and reconnect.
 
 ## Shut Down
 

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -2,9 +2,9 @@
 # Keep this file declarative; Hermes owns its runtime data under /opt/data.
 model:
   provider: ollama-cloud
-  base_url: ${OLLAMA_BASE_URL}
+  base_url: https://ollama.com/v1
   api_key_env: OLLAMA_API_KEY
-  default: ${HERMES_DEFAULT_MODEL}
+  default: deepseek-v4-pro:cloud
 
 mcp_servers:
   averray:

--- a/ops/compose.command-center.yml
+++ b/ops/compose.command-center.yml
@@ -75,9 +75,12 @@ services:
       HERMES_API_URL: http://hermes-gateway:8642
       HERMES_DASHBOARD_URL: http://hermes:9119
       HERMES_API_TOKEN: ${HERMES_GATEWAY_API_KEY:?Set HERMES_GATEWAY_API_KEY in .env.prod before enabling the command center}
+      CLAUDE_API_TOKEN: ${HERMES_GATEWAY_API_KEY:?Set HERMES_GATEWAY_API_KEY in .env.prod before enabling the command center}
+      CLAUDE_DASHBOARD_TOKEN: ${HERMES_GATEWAY_API_KEY:?Set HERMES_GATEWAY_API_KEY in .env.prod before enabling the command center}
       CLAUDE_PASSWORD: ${HERMES_WORKSPACE_PASSWORD:?Set HERMES_WORKSPACE_PASSWORD in .env.prod before enabling the command center}
       COOKIE_SECURE: ${HERMES_WORKSPACE_COOKIE_SECURE:-0}
       TRUST_PROXY: ${HERMES_WORKSPACE_TRUST_PROXY:-0}
+      HOME: /tmp/workspace-home
     networks: [avg-internal]
     ports:
       - "127.0.0.1:${HERMES_WORKSPACE_PORT:-3000}:3000"


### PR DESCRIPTION
What changed:\n- Sets concrete Hermes gateway model defaults in hermes/config/hermes.yaml so Hermes does not pass literal `` to Ollama Cloud.\n- Adds CLAUDE_API_TOKEN and CLAUDE_DASHBOARD_TOKEN aliases for Hermes Workspace enhanced gateway/dashboard calls.\n- Sets HOME=/tmp/workspace-home for the Workspace container so it can persist session/Kanban state without EACCES.\n- Documents the command-center verification and recovery steps we used on the VPS.\n\nChecks:\n- npm run typecheck\n- npm test (61/61)\n- npm run build\n- git diff --check\n\nImpact:\n- Command-center overlay and Hermes config only.\n- No chain/RPC, contracts, or wallet secret changes.\n- VPS should pull/recreate hermes, hermes-gateway, and hermes-workspace after merge.