### PR TITLE
Persist Slack operator run context

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,5 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
   recognizes `run one wikipedia citation repair if safe` and calls the
   Wikipedia workflow tool directly; `status last wikipedia citation repair`
-  returns the latest run/session/draft/submit status without mutating anything.
+  returns the latest run/session/draft/submit status, including persisted Slack
+  context when available, without mutating anything.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -127,6 +127,11 @@ route with your chosen tunnel or reverse proxy. Keep
 `SLACK_OPERATOR_CHANNEL_ID`/`SLACK_OPERATOR_CHANNEL_IDS` and
 `SLACK_ALLOWED_USER_IDS` narrow.
 
+Operator command events are persisted in Postgres with their Slack channel,
+user, triggering message permalink, reply permalink, and workflow identifiers
+when a run command produces a run. The read-only status command uses that
+context so `slackPermalink` points back to Slack when available.
+
 Inbound Slack or command-center messages should be routed to the direct MCP
 operator command tool, not rephrased as free-form Hermes prompts. The supported
 commands are:

--- a/ops/migrations/001_init.sql
+++ b/ops/migrations/001_init.sql
@@ -105,7 +105,29 @@ create table if not exists auth_sessions (
   expires_at timestamptz
 );
 
+create table if not exists operator_command_events (
+  id uuid primary key default gen_random_uuid(),
+  source text not null,
+  command_text text not null,
+  normalized_text text not null,
+  team_id text,
+  user_id text,
+  channel_id text,
+  slack_permalink text,
+  reply_permalink text,
+  run_id text,
+  job_id text,
+  session_id text,
+  draft_id text,
+  status text,
+  result jsonb not null default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
 create index if not exists tool_calls_run_idx on tool_calls(run_id, idx);
 create index if not exists skills_observed_file_idx on skills_observed(file_path);
 create index if not exists draft_submissions_lookup_idx on draft_submissions(job_id, run_id, session_id, updated_at desc);
 create index if not exists draft_submissions_session_idx on draft_submissions(session_id, updated_at desc);
+create index if not exists operator_command_events_run_idx on operator_command_events(run_id, updated_at desc);
+create index if not exists operator_command_events_source_idx on operator_command_events(source, updated_at desc);

--- a/packages/averray-mcp/src/job-workflows.ts
+++ b/packages/averray-mcp/src/job-workflows.ts
@@ -258,6 +258,7 @@ export async function runWikipediaCitationRepairWorkflow(
         jobId: selected.jobId,
         sessionId: claim.sessionId,
         draftId: draft.draftId,
+        evidenceSummary: summarizeEvidence(evidence),
         validation,
         confidence: proposal.confidence,
         reason: "validation_failed",
@@ -274,6 +275,7 @@ export async function runWikipediaCitationRepairWorkflow(
         jobId: selected.jobId,
         sessionId: claim.sessionId,
         draftId: draft.draftId,
+        evidenceSummary: summarizeEvidence(evidence),
         validation,
         confidence: proposal.confidence,
         reason: "confidence_below_threshold",
@@ -299,6 +301,7 @@ export async function runWikipediaCitationRepairWorkflow(
         jobId: selected.jobId,
         sessionId: claim.sessionId,
         draftId: draft.draftId,
+        evidenceSummary: summarizeEvidence(evidence),
         validation,
         confidence: proposal.confidence,
         reason: submit.reason ?? "submit_blocked",
@@ -314,6 +317,7 @@ export async function runWikipediaCitationRepairWorkflow(
       jobId: selected.jobId,
       sessionId: claim.sessionId,
       draftId: draft.draftId,
+      evidenceSummary: summarizeEvidence(evidence),
       validation,
       confidence: proposal.confidence,
       submit,
@@ -470,9 +474,15 @@ function blocked(input: {
 }
 
 function summarizeEvidence(evidence: WikipediaEvidenceBundle) {
+  const flaggedCitations = evidence.citations.filter(
+    (citation) => citation.urls.length > 0 || citation.archiveUrls.length > 0 || citation.deadLinkMarkers.length > 0
+  );
   return {
     pageTitle: evidence.pageTitle,
     revisionId: evidence.revisionId,
+    totalCitations: evidence.citations.length,
+    flaggedCitations: flaggedCitations.length,
+    deadLinkCitations: evidence.citations.filter((citation) => citation.deadLinkMarkers.length > 0).length,
     citationCount: evidence.citations.length,
     checkedSourceCount: evidence.sourceChecks.length,
     sourceUrls: evidence.sourceChecks.map((source) => source.url),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -107,9 +107,18 @@ export async function getLastWikipediaCitationRepairStatus(
        d.run_id as draft_run_id,
        d.job_id as draft_job_id,
        d.session_id as draft_session_id,
-       d.validation_status as draft_validation_status
+       d.validation_status as draft_validation_status,
+       e.slack_permalink,
+       e.reply_permalink
      from submissions s
      left join draft_submissions d on d.draft_id = s.request->>'draftId'
+     left join lateral (
+       select slack_permalink, reply_permalink
+       from operator_command_events
+       where run_id = coalesce(s.request->>'policyRunId', s.request->>'runId', d.run_id)
+       order by updated_at desc
+       limit 1
+     ) e on true
      where s.kind = 'submit'
        and coalesce(s.request->>'jobId', d.job_id, '') like 'wiki-en-%citation-repair%'
      order by s.updated_at desc
@@ -151,7 +160,10 @@ function statusFromSubmissionRow(row: SubmissionStatusRow): LastWikipediaCitatio
     draftId: stringField(request, "draftId") ?? stringField(row, "draft_id"),
     draftValidationStatus: stringField(row, "draft_validation_status"),
     submitSucceeded,
-    slackPermalink: firstDeepString(response, ["slackPermalink", "slack_permalink", "permalink"]) ?? null,
+    slackPermalink: stringField(row, "reply_permalink")
+      ?? stringField(row, "slack_permalink")
+      ?? firstDeepString(response, ["slackPermalink", "slack_permalink", "permalink"])
+      ?? null,
     source: "submissions",
     ...(stringField(row, "last_error") ? { lastError: stringField(row, "last_error") } : {}),
     ...(updatedAt ? { updatedAt } : {}),
@@ -236,6 +248,8 @@ interface SubmissionStatusRow {
   draft_job_id?: string | null;
   draft_session_id?: string | null;
   draft_validation_status?: string | null;
+  slack_permalink?: string | null;
+  reply_permalink?: string | null;
 }
 
 interface DraftStatusRow {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -10,8 +10,10 @@ import {
   textFromSlackEvent,
   textFromSlashCommand,
   verifySlackSignature,
+  slackPermalinkFromParts,
   type SlackCommandEnvelope,
 } from "./slack.js";
+import { recordOperatorCommandEvent } from "./persistence.js";
 
 const enabled = optionalEnv("SLACK_OPERATOR_ENABLED", "0") === "1";
 const httpPort = Number.parseInt(optionalEnv("SLACK_OPERATOR_HTTP_PORT", "8790"), 10);
@@ -85,7 +87,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       writeJson(response, 200, { challenge: payload.challenge });
       return;
     }
-    const envelope = isRecord(payload) ? textFromSlackEvent(payload.event) : null;
+    const envelope = isRecord(payload) ? textFromSlackEvent(payload.event, stringField(payload, "team_id")) : null;
     writeJson(response, 200, { ok: true });
     if (envelope && isAuthorizedSlackCommand(envelope, authConfig)) void handleCommand(envelope);
     return;
@@ -141,6 +143,7 @@ async function handleSocketMessage(socket: WebSocket, rawMessage: string) {
     const text = stringField(payload, "text") || command;
     const commandEnvelope: SlackCommandEnvelope = {
       text,
+      teamId: stringField(payload, "team_id"),
       userId: stringField(payload, "user_id"),
       channelId: stringField(payload, "channel_id"),
       responseUrl: stringField(payload, "response_url"),
@@ -151,7 +154,7 @@ async function handleSocketMessage(socket: WebSocket, rawMessage: string) {
 
   if (envelope.type === "events_api") {
     const payload = isRecord(envelope.payload) ? envelope.payload : {};
-    const commandEnvelope = textFromSlackEvent(payload.event);
+    const commandEnvelope = textFromSlackEvent(payload.event, stringField(payload, "team_id"));
     if (commandEnvelope && isAuthorizedSlackCommand(commandEnvelope, authConfig)) void handleCommand(commandEnvelope);
   }
 }
@@ -169,21 +172,31 @@ async function handleCommand(envelope: SlackCommandEnvelope) {
       },
       { query, workflowDeps: createDefaultWorkflowDeps() }
     );
-    await postSlack(envelope, formatOperatorResultForSlack(result));
+    const replyPermalink = await postSlack(envelope, formatOperatorResultForSlack(result));
+    await recordOperatorCommandEvent({
+      source: "slack",
+      commandText: envelope.text,
+      teamId: envelope.teamId,
+      userId: envelope.userId,
+      channelId: envelope.channelId,
+      slackPermalink: envelope.permalink,
+      replyPermalink,
+      result,
+    }, query);
   } catch (error) {
     logger.error({ err: error }, "slack_operator_command_failed");
     await postSlack(envelope, `Averray command failed: ${error instanceof Error ? error.message : String(error)}`);
   }
 }
 
-async function postSlack(envelope: SlackCommandEnvelope, text: string) {
+async function postSlack(envelope: SlackCommandEnvelope, text: string): Promise<string | undefined> {
   if (envelope.responseUrl) {
     await fetch(envelope.responseUrl, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ response_type: "in_channel", text }),
     }).catch((error) => logger.warn({ err: error }, "slack_response_url_failed"));
-    return;
+    return envelope.permalink;
   }
   if (!botToken || !envelope.channelId) {
     logger.warn({ hasBotToken: Boolean(botToken), channelId: envelope.channelId }, "slack_operator_no_reply_route");
@@ -200,7 +213,13 @@ async function postSlack(envelope: SlackCommandEnvelope, text: string) {
   const payload = await response.json().catch(() => undefined);
   if (!response.ok || !isRecord(payload) || payload.ok !== true) {
     logger.warn({ status: response.status, payload }, "slack_chat_post_failed");
+    return envelope.permalink;
   }
+  return slackPermalinkFromParts(
+    envelope.teamId,
+    stringField(payload, "channel") ?? envelope.channelId,
+    stringField(payload, "ts")
+  ) ?? envelope.permalink;
 }
 
 function verifyHttpSignature(request: http.IncomingMessage, rawBody: string): boolean {

--- a/services/slack-operator/src/persistence.ts
+++ b/services/slack-operator/src/persistence.ts
@@ -1,0 +1,85 @@
+export interface OperatorCommandEventInput {
+  source: string;
+  commandText: string;
+  teamId?: string;
+  userId?: string;
+  channelId?: string;
+  slackPermalink?: string;
+  replyPermalink?: string;
+  result: unknown;
+}
+
+export async function recordOperatorCommandEvent(
+  input: OperatorCommandEventInput,
+  query: QueryFn
+) {
+  const extracted = extractResultFields(input.result);
+  await query(
+    `insert into operator_command_events(
+       source,
+       command_text,
+       normalized_text,
+       team_id,
+       user_id,
+       channel_id,
+       slack_permalink,
+       reply_permalink,
+       run_id,
+       job_id,
+       session_id,
+       draft_id,
+       status,
+       result
+     ) values (
+       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::jsonb
+     )`,
+    [
+      input.source,
+      input.commandText,
+      normalizeText(input.commandText),
+      input.teamId ?? null,
+      input.userId ?? null,
+      input.channelId ?? null,
+      input.slackPermalink ?? null,
+      input.replyPermalink ?? null,
+      extracted.runId ?? null,
+      extracted.jobId ?? null,
+      extracted.sessionId ?? null,
+      extracted.draftId ?? null,
+      extracted.status ?? null,
+      JSON.stringify(input.result ?? {}),
+    ]
+  );
+}
+
+type QueryFn = <T = Record<string, unknown>>(text: string, values?: unknown[]) => Promise<T[]>;
+
+function extractResultFields(result: unknown) {
+  const root = toRecord(result) ?? {};
+  const payload = toRecord(root.result) ?? root;
+  return {
+    runId: stringField(payload, "runId") ?? stringField(root, "runId"),
+    jobId: stringField(payload, "jobId") ?? stringField(root, "jobId"),
+    sessionId: stringField(payload, "sessionId") ?? stringField(root, "sessionId"),
+    draftId: stringField(payload, "draftId") ?? stringField(root, "draftId"),
+    status: stringField(payload, "status") ?? stringField(root, "status"),
+  };
+}
+
+function normalizeText(text: string) {
+  return text.trim().toLowerCase().replace(/[.!?]+$/g, "").replace(/\s+/g, " ");
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function toRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -7,6 +7,7 @@ export interface SlackAuthConfig {
 
 export interface SlackCommandEnvelope {
   text: string;
+  teamId?: string;
   userId?: string;
   channelId?: string;
   responseUrl?: string;
@@ -48,7 +49,7 @@ export function isAuthorizedSlackCommand(
   return true;
 }
 
-export function textFromSlackEvent(event: unknown): SlackCommandEnvelope | null {
+export function textFromSlackEvent(event: unknown, teamId?: string): SlackCommandEnvelope | null {
   if (!isRecord(event)) return null;
   const eventType = stringField(event, "type");
   if (eventType !== "message" && eventType !== "app_mention") return null;
@@ -59,9 +60,10 @@ export function textFromSlackEvent(event: unknown): SlackCommandEnvelope | null 
   if (!text) return null;
   return {
     text,
+    teamId,
     userId: stringField(event, "user"),
     channelId: stringField(event, "channel"),
-    permalink: slackPermalinkFromEvent(event),
+    permalink: slackPermalinkFromParts(teamId, stringField(event, "channel"), stringField(event, "ts")),
   };
 }
 
@@ -71,6 +73,7 @@ export function textFromSlashCommand(rawBody: string): SlackCommandEnvelope {
   const text = form.get("text")?.trim() || command.replace(/^\//, "").trim();
   return {
     text,
+    teamId: form.get("team_id") ?? undefined,
     userId: form.get("user_id") ?? undefined,
     channelId: form.get("channel_id") ?? undefined,
     responseUrl: form.get("response_url") ?? undefined,
@@ -95,11 +98,13 @@ export function formatOperatorResultForSlack(result: unknown): string {
       `• submittedAt: \`${stringField(status, "submittedAt") ?? "n/a"}\``,
       `• draftId: \`${stringField(status, "draftId") ?? "n/a"}\``,
       `• submit_succeeded: \`${String(Boolean(status.submitSucceeded))}\``,
-      `• slackPermalink: ${stringField(status, "slackPermalink") ?? "n/a"}`,
+      `• slack: ${stringField(status, "slackPermalink") ?? "n/a"}`,
     ].join("\n");
   }
   if (result.kind === "run_wikipedia_citation_repair") {
     const workflow = isRecord(result.result) ? result.result : {};
+    const validation = isRecord(workflow.validation) ? workflow.validation : {};
+    const evidence = isRecord(workflow.evidenceSummary) ? workflow.evidenceSummary : {};
     return [
       "*Wikipedia citation repair workflow*",
       `• status: \`${stringField(workflow, "status") ?? "unknown"}\``,
@@ -108,17 +113,20 @@ export function formatOperatorResultForSlack(result: unknown): string {
       `• sessionId: \`${stringField(workflow, "sessionId") ?? "n/a"}\``,
       `• draftId: \`${stringField(workflow, "draftId") ?? "n/a"}\``,
       `• confidence: \`${numberField(workflow, "confidence") ?? "n/a"}\``,
+      `• validation: \`${validation.valid === true ? "valid" : validation.valid === false ? "invalid" : "n/a"}\``,
+      `• citations reviewed: \`${numberField(evidence, "totalCitations") ?? "n/a"}\``,
+      `• issues flagged: \`${numberField(evidence, "flaggedCitations") ?? "n/a"}\``,
       `• reason: \`${stringField(workflow, "reason") ?? "n/a"}\``,
     ].join("\n");
   }
   return `Averray operator command completed:\n\`\`\`${JSON.stringify(result, null, 2).slice(0, 2500)}\`\`\``;
 }
 
-function slackPermalinkFromEvent(event: Record<string, unknown>): string | undefined {
-  const channel = stringField(event, "channel");
-  const ts = stringField(event, "ts");
-  if (!channel || !ts) return undefined;
-  return `slack://${channel}/${ts}`;
+export function slackPermalinkFromParts(teamId: string | undefined, channelId: string | undefined, ts: string | undefined): string | undefined {
+  if (!channelId || !ts) return undefined;
+  const compactTs = ts.replace(".", "");
+  if (teamId) return `https://app.slack.com/client/${teamId}/${channelId}/p${compactTs}`;
+  return `slack://${channelId}/${ts}`;
 }
 
 function timingSafeStringEqual(a: string, b: string): boolean {

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -5,10 +5,12 @@ import {
   formatOperatorResultForSlack,
   isAuthorizedSlackCommand,
   parseCsvSet,
+  slackPermalinkFromParts,
   textFromSlackEvent,
   textFromSlashCommand,
   verifySlackSignature,
 } from "../../services/slack-operator/src/slack.js";
+import { recordOperatorCommandEvent } from "../../services/slack-operator/src/persistence.js";
 
 describe("slack operator bridge", () => {
   it("verifies Slack signatures and rejects stale timestamps", () => {
@@ -37,11 +39,12 @@ describe("slack operator bridge", () => {
 
   it("parses slash command bodies into operator text", () => {
     const command = textFromSlashCommand(
-      "command=%2Faverray&text=status+last+wikipedia+citation+repair&user_id=U1&channel_id=C1&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2F1"
+      "command=%2Faverray&text=status+last+wikipedia+citation+repair&team_id=T1&user_id=U1&channel_id=C1&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2F1"
     );
 
     expect(command).toEqual({
       text: "status last wikipedia citation repair",
+      teamId: "T1",
       userId: "U1",
       channelId: "C1",
       responseUrl: "https://hooks.slack.com/commands/1",
@@ -49,20 +52,31 @@ describe("slack operator bridge", () => {
   });
 
   it("extracts app mentions without the bot mention", () => {
-    const command = textFromSlackEvent({
-      type: "app_mention",
-      user: "U1",
-      channel: "C1",
-      ts: "1777740000.123",
-      text: "<@B123> run one wikipedia citation repair if safe",
-    });
+    const command = textFromSlackEvent(
+      {
+        type: "app_mention",
+        user: "U1",
+        channel: "C1",
+        ts: "1777740000.123",
+        text: "<@B123> run one wikipedia citation repair if safe",
+      },
+      "T1"
+    );
 
     expect(command).toEqual({
       text: "run one wikipedia citation repair if safe",
+      teamId: "T1",
       userId: "U1",
       channelId: "C1",
-      permalink: "slack://C1/1777740000.123",
+      permalink: "https://app.slack.com/client/T1/C1/p1777740000123",
     });
+  });
+
+  it("builds Slack permalinks when a team id is available", () => {
+    expect(slackPermalinkFromParts("T1", "C1", "1777740000.123")).toBe(
+      "https://app.slack.com/client/T1/C1/p1777740000123"
+    );
+    expect(slackPermalinkFromParts(undefined, "C1", "1777740000.123")).toBe("slack://C1/1777740000.123");
   });
 
   it("enforces optional user and channel allowlists", () => {
@@ -97,5 +111,77 @@ describe("slack operator bridge", () => {
     expect(text).toContain("jobId: `wiki-en-1-citation-repair`");
     expect(text).toContain("submit_succeeded: `true`");
     expect(text).toContain("https://slack.example/archives/C/p123");
+  });
+
+  it("formats workflow replies with compact validation and evidence summary", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "run_wikipedia_citation_repair",
+      result: {
+        status: "submitted",
+        runId: "run-2",
+        jobId: "wiki-en-2-citation-repair",
+        sessionId: "session-2",
+        draftId: "draft-2",
+        confidence: 0.72,
+        validation: { valid: true },
+        evidenceSummary: { totalCitations: 45, flaggedCitations: 5 },
+      },
+    });
+
+    expect(text).toContain("status: `submitted`");
+    expect(text).toContain("validation: `valid`");
+    expect(text).toContain("citations reviewed: `45`");
+    expect(text).toContain("issues flagged: `5`");
+  });
+
+  it("persists workflow run context but does not attach status commands to the run", async () => {
+    const calls: unknown[][] = [];
+    await recordOperatorCommandEvent({
+      source: "slack",
+      commandText: "run one wikipedia citation repair if safe",
+      teamId: "T1",
+      userId: "U1",
+      channelId: "C1",
+      slackPermalink: "https://app.slack.com/client/T1/C1/p1",
+      replyPermalink: "https://app.slack.com/client/T1/C1/p2",
+      result: {
+        handled: true,
+        kind: "run_wikipedia_citation_repair",
+        result: {
+          status: "submitted",
+          runId: "run-1",
+          jobId: "wiki-en-1-citation-repair",
+          sessionId: "session-1",
+          draftId: "draft-1",
+        },
+      },
+    }, async (_sql, values) => {
+      calls.push(values ?? []);
+      return [];
+    });
+
+    expect(calls[0]).toContain("run-1");
+    expect(calls[0]).toContain("wiki-en-1-citation-repair");
+
+    const statusCalls: unknown[][] = [];
+    await recordOperatorCommandEvent({
+      source: "slack",
+      commandText: "status last wikipedia citation repair",
+      result: {
+        handled: true,
+        kind: "status_last_wikipedia_citation_repair",
+        status: {
+          runId: "run-1",
+          jobId: "wiki-en-1-citation-repair",
+          status: "submitted",
+        },
+      },
+    }, async (_sql, values) => {
+      statusCalls.push(values ?? []);
+      return [];
+    });
+
+    expect(statusCalls[0]).not.toContain("run-1");
   });
 });


### PR DESCRIPTION
## Summary
- persist Slack operator command events with channel/user, trigger permalink, reply permalink, and workflow identifiers
- teach latest Wikipedia repair status to surface the persisted Slack permalink when available
- make Slack workflow replies more compact with validation and evidence counts

## Checks
- npm run typecheck
- npm test
- npm run build
- git diff --check

## Impact
- Backend/service + Postgres migration only
- No chain-facing changes
- Reuses existing Slack operator env; no new secrets required