### PR TITLE
Fix Slack workflow proposal counts

### DIFF
--- a/packages/averray-mcp/src/job-workflows.ts
+++ b/packages/averray-mcp/src/job-workflows.ts
@@ -195,6 +195,7 @@ export async function runWikipediaCitationRepairWorkflow(
         jobId: selected.jobId,
         wallet,
         evidenceSummary: summarizeEvidence(evidence),
+        proposalSummary: summarizeProposal(proposal.output),
         proposalPreview: proposal.output,
         confidence: proposal.confidence,
         validation,
@@ -259,6 +260,7 @@ export async function runWikipediaCitationRepairWorkflow(
         sessionId: claim.sessionId,
         draftId: draft.draftId,
         evidenceSummary: summarizeEvidence(evidence),
+        proposalSummary: summarizeProposal(proposal.output),
         validation,
         confidence: proposal.confidence,
         reason: "validation_failed",
@@ -276,6 +278,7 @@ export async function runWikipediaCitationRepairWorkflow(
         sessionId: claim.sessionId,
         draftId: draft.draftId,
         evidenceSummary: summarizeEvidence(evidence),
+        proposalSummary: summarizeProposal(proposal.output),
         validation,
         confidence: proposal.confidence,
         reason: "confidence_below_threshold",
@@ -302,6 +305,7 @@ export async function runWikipediaCitationRepairWorkflow(
         sessionId: claim.sessionId,
         draftId: draft.draftId,
         evidenceSummary: summarizeEvidence(evidence),
+        proposalSummary: summarizeProposal(proposal.output),
         validation,
         confidence: proposal.confidence,
         reason: submit.reason ?? "submit_blocked",
@@ -318,6 +322,7 @@ export async function runWikipediaCitationRepairWorkflow(
       sessionId: claim.sessionId,
       draftId: draft.draftId,
       evidenceSummary: summarizeEvidence(evidence),
+      proposalSummary: summarizeProposal(proposal.output),
       validation,
       confidence: proposal.confidence,
       submit,
@@ -486,6 +491,17 @@ function summarizeEvidence(evidence: WikipediaEvidenceBundle) {
     citationCount: evidence.citations.length,
     checkedSourceCount: evidence.sourceChecks.length,
     sourceUrls: evidence.sourceChecks.map((source) => source.url),
+  };
+}
+
+function summarizeProposal(output: Record<string, unknown>) {
+  const citationFindings = Array.isArray(output.citation_findings) ? output.citation_findings : [];
+  const proposedChanges = Array.isArray(output.proposed_changes) ? output.proposed_changes : [];
+  return {
+    pageTitle: typeof output.page_title === "string" ? output.page_title : undefined,
+    revisionId: typeof output.revision_id === "string" ? output.revision_id : undefined,
+    citationFindings: citationFindings.length,
+    proposedChanges: proposedChanges.length,
   };
 }
 

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -105,6 +105,7 @@ export function formatOperatorResultForSlack(result: unknown): string {
     const workflow = isRecord(result.result) ? result.result : {};
     const validation = isRecord(workflow.validation) ? workflow.validation : {};
     const evidence = isRecord(workflow.evidenceSummary) ? workflow.evidenceSummary : {};
+    const proposal = isRecord(workflow.proposalSummary) ? workflow.proposalSummary : {};
     return [
       "*Wikipedia citation repair workflow*",
       `• status: \`${stringField(workflow, "status") ?? "unknown"}\``,
@@ -115,7 +116,8 @@ export function formatOperatorResultForSlack(result: unknown): string {
       `• confidence: \`${numberField(workflow, "confidence") ?? "n/a"}\``,
       `• validation: \`${validation.valid === true ? "valid" : validation.valid === false ? "invalid" : "n/a"}\``,
       `• citations reviewed: \`${numberField(evidence, "totalCitations") ?? "n/a"}\``,
-      `• issues flagged: \`${numberField(evidence, "flaggedCitations") ?? "n/a"}\``,
+      `• issues proposed: \`${numberField(proposal, "citationFindings") ?? "n/a"}\``,
+      `• changes proposed: \`${numberField(proposal, "proposedChanges") ?? "n/a"}\``,
       `• reason: \`${stringField(workflow, "reason") ?? "n/a"}\``,
     ].join("\n");
   }

--- a/test/unit/job-workflows.test.ts
+++ b/test/unit/job-workflows.test.ts
@@ -99,6 +99,10 @@ describe("runWikipediaCitationRepairWorkflow", () => {
       sessionId,
       draftId: "draft-1",
       confidence: 0.72,
+      proposalSummary: {
+        citationFindings: 1,
+        proposedChanges: 1,
+      },
     });
     expect(calls).toEqual([
       "walletStatus",

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -125,14 +125,17 @@ describe("slack operator bridge", () => {
         draftId: "draft-2",
         confidence: 0.72,
         validation: { valid: true },
-        evidenceSummary: { totalCitations: 45, flaggedCitations: 5 },
+        evidenceSummary: { totalCitations: 45, flaggedCitations: 45 },
+        proposalSummary: { citationFindings: 5, proposedChanges: 5 },
       },
     });
 
     expect(text).toContain("status: `submitted`");
     expect(text).toContain("validation: `valid`");
     expect(text).toContain("citations reviewed: `45`");
-    expect(text).toContain("issues flagged: `5`");
+    expect(text).toContain("issues proposed: `5`");
+    expect(text).toContain("changes proposed: `5`");
+    expect(text).not.toContain("issues flagged");
   });
 
   it("persists workflow run context but does not attach status commands to the run", async () => {


### PR DESCRIPTION
## Summary
- add proposalSummary counts to Wikipedia citation repair workflow results
- show Slack operator replies as issues proposed / changes proposed from the final proposal object
- keep citations reviewed as the evidence scan total

## Checks
- npm run typecheck
- npm run build
- npm test
- git diff --check

## Impact
- Slack/operator UX only; no chain-facing changes and no mutation policy changes.