### PR TITLE
Remove Workspace dashboard token alias

### DIFF
--- a/docs/COMMAND_CENTER.md
+++ b/docs/COMMAND_CENTER.md
@@ -23,10 +23,12 @@ published only to VPS localhost.
 - Use SSH or Tailscale tunnels to reach the UI.
 - Set strong `HERMES_WORKSPACE_PASSWORD` and `HERMES_GATEWAY_API_KEY`
   values before starting the workspace.
-- The Workspace image still checks legacy `CLAUDE_API_TOKEN` and
-  `CLAUDE_DASHBOARD_TOKEN` names for some enhanced gateway/dashboard calls.
-  The Compose overlay maps them to `HERMES_GATEWAY_API_KEY`; keep all three
-  token aliases aligned.
+- The Workspace image still checks the legacy `CLAUDE_API_TOKEN` name for
+  OpenAI-compatible gateway calls. The Compose overlay maps that gateway alias
+  to `HERMES_GATEWAY_API_KEY`.
+- Do not set `CLAUDE_DASHBOARD_TOKEN` to the gateway bearer. The dashboard
+  session path is separate from the OpenAI-compatible gateway API and a stale
+  or mismatched dashboard token can produce `401 Unauthorized` session calls.
 - Workspace writes session and Kanban metadata below `$HOME/.hermes`. The
   Compose overlay sets `HOME=/tmp/workspace-home` because the upstream image's
   default `/home/workspace` path is not writable in this deployment mode.
@@ -155,8 +157,8 @@ model:
 
 If the Workspace UI shows `Authentication required — Hermes Agent rejected the
 connection token` while `/v1/chat/completions` works, clear the Workspace
-server-side and browser-side saved state after confirming the token aliases are
-present:
+server-side and browser-side saved state after confirming only gateway token
+aliases are present:
 
 ```bash
 docker compose --env-file .env.prod \
@@ -166,7 +168,14 @@ docker compose --env-file .env.prod \
   -p avg \
   --profile command-center \
   exec hermes-workspace env | grep -E 'HERMES_API|CLAUDE_API|CLAUDE_DASHBOARD|HOME'
+```
 
+The expected state is that `HERMES_API_TOKEN` and `CLAUDE_API_TOKEN` are set,
+while `CLAUDE_DASHBOARD_TOKEN` is absent.
+
+Then clear Workspace server-side state and recreate the container:
+
+```bash
 docker compose --env-file .env.prod \
   -f ops/compose.yml \
   -f ops/compose.prod.yml \
@@ -174,6 +183,14 @@ docker compose --env-file .env.prod \
   -p avg \
   --profile command-center \
   exec hermes-workspace sh -lc 'rm -rf /tmp/workspace-home/.hermes && mkdir -p /tmp/workspace-home/.hermes'
+
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -p avg \
+  --profile command-center \
+  up -d --force-recreate hermes-workspace
 ```
 
 Then clear site data for `127.0.0.1:3000` in the browser and reconnect.

--- a/ops/compose.command-center.yml
+++ b/ops/compose.command-center.yml
@@ -76,7 +76,6 @@ services:
       HERMES_DASHBOARD_URL: http://hermes:9119
       HERMES_API_TOKEN: ${HERMES_GATEWAY_API_KEY:?Set HERMES_GATEWAY_API_KEY in .env.prod before enabling the command center}
       CLAUDE_API_TOKEN: ${HERMES_GATEWAY_API_KEY:?Set HERMES_GATEWAY_API_KEY in .env.prod before enabling the command center}
-      CLAUDE_DASHBOARD_TOKEN: ${HERMES_GATEWAY_API_KEY:?Set HERMES_GATEWAY_API_KEY in .env.prod before enabling the command center}
       CLAUDE_PASSWORD: ${HERMES_WORKSPACE_PASSWORD:?Set HERMES_WORKSPACE_PASSWORD in .env.prod before enabling the command center}
       COOKIE_SECURE: ${HERMES_WORKSPACE_COOKIE_SECURE:-0}
       TRUST_PROXY: ${HERMES_WORKSPACE_TRUST_PROXY:-0}


### PR DESCRIPTION
## Summary
- stop passing the gateway bearer as CLAUDE_DASHBOARD_TOKEN to Hermes Workspace
- keep HERMES_API_TOKEN and CLAUDE_API_TOKEN for the OpenAI-compatible gateway path
- update command-center docs with the dashboard/session auth cleanup procedure

## Checks
- git diff --check
- npm run typecheck (not run successfully locally: temp worktree lacked node_modules/tsc)
- npm test (not run successfully locally: temp worktree lacked node_modules/vitest)

## Impact
- command-center/Workspace configuration only
- no Slack operator, Averray MCP workflow, chain-facing, or wallet changes

## VPS test plan after merge
- pull main
- recreate hermes-workspace
- confirm CLAUDE_DASHBOARD_TOKEN is absent in the container env
- clear /tmp/workspace-home/.hermes and browser site data
- verify whether the yellow auth banner and /api/sessions 401 disappear