### PR TITLE
Add canonical operator status tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   localhost. See [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md#slack-operator-commands).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `run one wikipedia citation repair if safe` and calls the
-  Wikipedia workflow tool directly; `status last wikipedia citation repair`
-  returns the latest run/session/draft/submit status, including persisted Slack
-  context when available, without mutating anything.
+  recognizes `operator status`, `run one wikipedia citation repair if safe`,
+  and `status last wikipedia citation repair`. `operator status` calls the
+  canonical read-only `averray_operator_status` MCP tool and returns wallet,
+  budget, open-job, latest-run, safety, and safe-command metadata for any MCP
+  client. Repair commands call the Wikipedia workflow tool directly; latest-run
+  status returns the current run/session/draft/submit state, including
+  persisted Slack context when available, without mutating anything.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -137,17 +137,22 @@ operator command tool, not rephrased as free-form Hermes prompts. The supported
 commands are:
 
 ```text
+operator status
 run one wikipedia citation repair if safe
 run wikipedia citation repair for wiki-en-... if safe
 status last wikipedia citation repair
 ```
 
-`averray_handle_operator_command` parses those messages. Repair commands call
-`averray_run_wikipedia_citation_repair` directly with the workflow's wallet,
-policy, draft, validation, submit, and Slack alert gates. Status commands are
-read-only and return the latest `runId`, `jobId`, `sessionId`, submitted/failed
-state, `draftId`, and Slack permalink when one is available. Add `dry run only`
-to a repair command when you want a proposal preview without claim or submit.
+`averray_handle_operator_command` parses those messages. `operator status`
+calls the canonical read-only `averray_operator_status` MCP tool, returning
+wallet readiness, policy budget, open Wikipedia job counts, latest run state,
+safety guarantees, and safe command suggestions as structured JSON. Repair
+commands call `averray_run_wikipedia_citation_repair` directly with the
+workflow's wallet, policy, draft, validation, submit, and Slack alert gates.
+Latest-run status commands are read-only and return the latest `runId`,
+`jobId`, `sessionId`, submitted/failed state, `draftId`, and Slack permalink
+when one is available. Add `dry run only` to a repair command when you want a
+proposal preview without claim or submit.
 
 Check the host env file:
 

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -41,6 +41,7 @@ import {
   getLastWikipediaCitationRepairStatus,
 } from "./operator-commands.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
+import { getOperatorStatus } from "./operator-status.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -129,8 +130,17 @@ server.tool(
 );
 
 server.tool(
+  "averray_operator_status",
+  "Canonical read-only operator status contract for agents and UIs. Returns wallet readiness, policy budget, open Wikipedia citation-repair jobs, latest run/session/draft status, safe command suggestions, and safety guarantees. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getOperatorStatus({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'run one wikipedia citation repair if safe' and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status commands are read-only.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'operator status', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help commands are read-only.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -15,6 +15,11 @@ export type ParsedOperatorCommand =
       source: OperatorCommandSource;
     }
   | {
+      handled: true;
+      kind: "operator_status";
+      source: OperatorCommandSource;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -45,6 +50,7 @@ export interface LastWikipediaCitationRepairStatus {
 }
 
 const EXAMPLES = [
+  "operator status",
   "run one wikipedia citation repair if safe",
   "run wikipedia citation repair for wiki-en-... if safe",
   "status last wikipedia citation repair",
@@ -64,6 +70,15 @@ export function parseOperatorCommand(
 
   if (normalizedText === "status last wikipedia citation repair") {
     return { handled: true, kind: "status_last_wikipedia_citation_repair", source };
+  }
+
+  if (
+    normalizedText === "operator status" ||
+    normalizedText === "averray operator status" ||
+    normalizedText === "averray status" ||
+    normalizedText === "help"
+  ) {
+    return { handled: true, kind: "operator_status", source };
   }
 
   if (

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -5,6 +5,7 @@ import {
   type OperatorCommandSource,
   type OperatorQueryFn,
 } from "./operator-commands.js";
+import { getOperatorStatus } from "./operator-status.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 
 export interface HandleOperatorCommandInput {
@@ -34,6 +35,10 @@ export async function handleOperatorCommandText(
   if (!command.handled) return command;
   if (command.kind === "status_last_wikipedia_citation_repair") {
     const status = await getLastWikipediaCitationRepairStatus(deps.query);
+    return { ...command, status };
+  }
+  if (command.kind === "operator_status") {
+    const status = await getOperatorStatus({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, status };
   }
   const result = await runWikipediaCitationRepairWorkflow(

--- a/packages/averray-mcp/src/operator-status.ts
+++ b/packages/averray-mcp/src/operator-status.ts
@@ -1,0 +1,232 @@
+import { optionalEnv, readYamlFile } from "@avg/mcp-common";
+import type { WorkflowDeps, WorkflowJob, WorkflowWallet } from "./job-workflows.js";
+import {
+  getLastWikipediaCitationRepairStatus,
+  type LastWikipediaCitationRepairStatus,
+  type OperatorQueryFn,
+} from "./operator-commands.js";
+
+export interface OperatorStatusDeps {
+  query: OperatorQueryFn;
+  workflowDeps: Pick<WorkflowDeps, "listJobs" | "walletStatus">;
+  now?: Date;
+  policyConfig?: OperatorPolicyConfig;
+}
+
+export interface OperatorPolicyConfig {
+  claim?: {
+    allowed_task_types?: string[];
+    reject_verifier_modes?: string[];
+    min_reward_usd?: number;
+  };
+  submit?: {
+    require_approval_if_confidence_lt?: number;
+  };
+  budget?: {
+    per_run_usd_max?: number;
+    per_day_usd_max?: number;
+    max_browser_steps?: number;
+  };
+}
+
+const defaultPolicyConfig: OperatorPolicyConfig = {
+  claim: {
+    allowed_task_types: ["citation_repair", "freshness_check"],
+    reject_verifier_modes: ["human_fallback"],
+    min_reward_usd: 0,
+  },
+  submit: {
+    require_approval_if_confidence_lt: 0.7,
+  },
+  budget: {
+    per_run_usd_max: 0.5,
+    per_day_usd_max: 1,
+    max_browser_steps: 80,
+  },
+};
+
+export async function getOperatorStatus(deps: OperatorStatusDeps) {
+  const generatedAt = (deps.now ?? new Date()).toISOString();
+  const policyConfig = deps.policyConfig ?? loadPolicyConfig();
+  const errors: string[] = [];
+  const [wallet, budget, jobs, latestRun] = await Promise.all([
+    deps.workflowDeps.walletStatus().catch((error) => {
+      errors.push(`wallet_status_failed:${errorMessage(error)}`);
+      return { configured: false, address: null } satisfies WorkflowWallet;
+    }),
+    readBudget(deps.query, policyConfig, errors),
+    deps.workflowDeps.listJobs().catch((error) => {
+      errors.push(`list_jobs_failed:${errorMessage(error)}`);
+      return [] as WorkflowJob[];
+    }),
+    getLastWikipediaCitationRepairStatus(deps.query).catch((error) => {
+      errors.push(`latest_run_failed:${errorMessage(error)}`);
+      return { found: false, source: "none", submitSucceeded: false, slackPermalink: null } satisfies LastWikipediaCitationRepairStatus;
+    }),
+  ]);
+  const wikipediaJobs = jobs.filter(isWikipediaCitationRepairJob);
+  const claimableJobs = wikipediaJobs.filter(isOpenOrClaimableJob);
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    mutates: false,
+    agent: {
+      walletReady: wallet.configured,
+      walletAddress: wallet.address,
+      network: optionalEnv("WALLET_NETWORK", "testnet"),
+    },
+    policy: {
+      claimAllowedTaskTypes: policyConfig.claim?.allowed_task_types ?? [],
+      rejectVerifierModes: policyConfig.claim?.reject_verifier_modes ?? [],
+      submitConfidenceThreshold: policyConfig.submit?.require_approval_if_confidence_lt ?? 0.7,
+      budget,
+    },
+    workflows: {
+      wikipediaCitationRepair: {
+        ready: wallet.configured && claimableJobs.length > 0,
+        openJobs: claimableJobs.length,
+        discoveredJobs: wikipediaJobs.length,
+        latestRun,
+        candidateJobs: claimableJobs.slice(0, 5).map(compactJob),
+        safeCommands: [
+          "operator status",
+          "status last wikipedia citation repair",
+          "run one wikipedia citation repair dry run only",
+          "run one wikipedia citation repair if safe",
+        ],
+      },
+    },
+    safety: {
+      mutatesByDefault: false,
+      statusCommandsAreReadOnly: true,
+      repairWorkflowDryRunDefault: true,
+      repairWorkflowRequiresValidationBeforeSubmit: true,
+      persistsDraftBeforeSubmit: true,
+      editsWikipedia: false,
+      mutationCommandsRequireExplicitIntent: true,
+    },
+    surfaces: {
+      slack: {
+        role: "durable audit and operator command channel",
+        mentionExample: "@Averray Reference Agent operator status",
+      },
+      commandCenter: {
+        role: "inspection, dry-run preview, and guided execution UI",
+        promptExample: "operator status",
+      },
+      mcp: {
+        role: "canonical agent-facing structured status contract",
+        tool: "averray_operator_status",
+      },
+    },
+    recommendedNextActions: recommendedNextActions(wallet, claimableJobs.length, latestRun),
+    ...(errors.length > 0 ? { errors } : {}),
+  };
+}
+
+function loadPolicyConfig(): OperatorPolicyConfig {
+  return readYamlFile(optionalEnv("POLICY_CONFIG_PATH", "/config/policy.yaml"), defaultPolicyConfig);
+}
+
+async function readBudget(query: OperatorQueryFn, policyConfig: OperatorPolicyConfig, errors: string[]) {
+  const config = policyConfig.budget ?? defaultPolicyConfig.budget ?? {};
+  const rows = await query<{ usd_spent?: string | number }>("select usd_spent from budgets where date = current_date")
+    .catch((error) => {
+      errors.push(`budget_query_failed:${errorMessage(error)}`);
+      return [];
+    });
+  const todayUsdSpent = Number(rows[0]?.usd_spent ?? 0);
+  const perDayUsdMax = config.per_day_usd_max ?? 1;
+  return {
+    perRunUsdMax: config.per_run_usd_max ?? 0.5,
+    perDayUsdMax,
+    maxBrowserSteps: config.max_browser_steps ?? 80,
+    todayUsdSpent,
+    todayUsdRemaining: Math.max(0, perDayUsdMax - todayUsdSpent),
+  };
+}
+
+function isWikipediaCitationRepairJob(job: WorkflowJob): boolean {
+  const definition = toRecord(job.definition);
+  const source = toRecord(definition.source);
+  const publicDetails = toRecord(definition.publicDetails);
+  const agentContext = toRecord(definition.agentContext);
+  const taskType = stringField(agentContext, "taskType") ?? stringField(source, "taskType") ?? stringField(publicDetails, "taskType");
+  const sourceType = stringField(source, "type") ?? stringField(publicDetails, "source") ?? stringField(definition, "source");
+  return (
+    job.jobId.includes("wiki-en-") &&
+    job.jobId.includes("citation-repair")
+  ) || (
+    taskType === "citation_repair" &&
+    (sourceType === "wikipedia_article" || sourceType === "wikipedia")
+  );
+}
+
+function isOpenOrClaimableJob(job: WorkflowJob): boolean {
+  const definition = toRecord(job.definition);
+  const claimStatus = toRecord(definition.claimStatus);
+  const lifecycle = toRecord(definition.lifecycle);
+  const claimable = booleanField(claimStatus, "claimable") ?? booleanField(definition, "claimable");
+  if (claimable === true) return true;
+  if (claimable === false) return false;
+  const state = stringField(definition, "state")
+    ?? stringField(definition, "effectiveState")
+    ?? stringField(definition, "claimState")
+    ?? stringField(lifecycle, "state");
+  return state === undefined || state === "open" || state === "claimable";
+}
+
+function compactJob(job: WorkflowJob) {
+  const definition = toRecord(job.definition);
+  const publicDetails = toRecord(definition.publicDetails);
+  const claimStatus = toRecord(definition.claimStatus);
+  const source = toRecord(definition.source);
+  return {
+    jobId: job.jobId,
+    title: stringField(publicDetails, "title") ?? stringField(definition, "title"),
+    state: stringField(definition, "state") ?? stringField(definition, "effectiveState"),
+    claimable: booleanField(claimStatus, "claimable") ?? booleanField(definition, "claimable"),
+    pageTitle: stringField(source, "pageTitle"),
+    revisionId: stringField(source, "revisionId"),
+  };
+}
+
+function recommendedNextActions(
+  wallet: WorkflowWallet,
+  openJobs: number,
+  latestRun: LastWikipediaCitationRepairStatus
+) {
+  if (!wallet.configured) return ["Configure the agent wallet before attempting claim or submit workflows."];
+  if (openJobs < 1) return ["No open Wikipedia citation-repair jobs are currently claimable; use read-only status commands."];
+  if (latestRun.found && latestRun.status !== "submitted") {
+    return [
+      "Inspect the latest incomplete Wikipedia citation-repair run before starting another mutation.",
+      "Use: status last wikipedia citation repair",
+    ];
+  }
+  return [
+    "Use: run one wikipedia citation repair dry run only",
+    "If the dry run validates and confidence is sufficient, use: run one wikipedia citation repair if safe",
+  ];
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const record = toRecord(value);
+  const field = record[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function booleanField(value: unknown, key: string): boolean | undefined {
+  const record = toRecord(value);
+  const field = record[key];
+  return typeof field === "boolean" ? field : undefined;
+}

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -101,6 +101,27 @@ export function formatOperatorResultForSlack(result: unknown): string {
       `• slack: ${stringField(status, "slackPermalink") ?? "n/a"}`,
     ].join("\n");
   }
+  if (result.kind === "operator_status") {
+    const status = isRecord(result.status) ? result.status : {};
+    const agent = isRecord(status.agent) ? status.agent : {};
+    const policy = isRecord(status.policy) ? status.policy : {};
+    const budget = isRecord(policy.budget) ? policy.budget : {};
+    const workflows = isRecord(status.workflows) ? status.workflows : {};
+    const wikipedia = isRecord(workflows.wikipediaCitationRepair) ? workflows.wikipediaCitationRepair : {};
+    const latestRun = isRecord(wikipedia.latestRun) ? wikipedia.latestRun : {};
+    const commands = Array.isArray(wikipedia.safeCommands)
+      ? wikipedia.safeCommands.slice(0, 4).map((entry) => `• \`${String(entry)}\``).join("\n")
+      : "";
+    return [
+      "*Averray operator status*",
+      `• wallet: \`${agent.walletReady === true ? "ready" : "not_ready"}\``,
+      `• address: \`${stringField(agent, "walletAddress") ?? "n/a"}\``,
+      `• budget today: \`${numberField(budget, "todayUsdSpent") ?? "n/a"} / ${numberField(budget, "perDayUsdMax") ?? "n/a"} USD\``,
+      `• wikipedia jobs: \`${numberField(wikipedia, "openJobs") ?? "n/a"} open / ${numberField(wikipedia, "discoveredJobs") ?? "n/a"} discovered\``,
+      `• latest run: \`${stringField(latestRun, "status") ?? "none"}\``,
+      commands ? `*Safe commands*\n${commands}` : "",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "run_wikipedia_citation_repair") {
     const workflow = isRecord(result.result) ? result.result : {};
     const validation = isRecord(workflow.validation) ? workflow.validation : {};

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -50,6 +50,19 @@ describe("operator commands", () => {
     });
   });
 
+  it("routes operator status and help to the canonical read-only status", () => {
+    expect(parseOperatorCommand("operator status", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "operator_status",
+      source: "operator",
+    });
+    expect(parseOperatorCommand("help", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "operator_status",
+      source: "slack",
+    });
+  });
+
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {
     const status = await getLastWikipediaCitationRepairStatus(async (text) => {
       if (text.includes("from submissions")) {

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+
+import { getOperatorStatus } from "../../packages/averray-mcp/src/operator-status.js";
+
+describe("operator status", () => {
+  it("returns a canonical read-only status for agents and UIs", async () => {
+    const workflowCalls: string[] = [];
+    const queries: string[] = [];
+
+    const status = await getOperatorStatus({
+      now: new Date("2026-05-03T12:00:00.000Z"),
+      policyConfig: {
+        claim: {
+          allowed_task_types: ["citation_repair", "freshness_check"],
+          reject_verifier_modes: ["human_fallback"],
+        },
+        submit: { require_approval_if_confidence_lt: 0.7 },
+        budget: { per_run_usd_max: 0.5, per_day_usd_max: 1, max_browser_steps: 80 },
+      },
+      async query(text) {
+        queries.push(text);
+        if (text.includes("from budgets")) return [{ usd_spent: "0.25" }];
+        if (text.includes("from submissions")) {
+          return [
+            {
+              request: {
+                policyRunId: "wikipedia-citation-repair-run-1",
+                jobId: "wiki-en-58158792-citation-repair-r7",
+                sessionId: "wiki-en-58158792-citation-repair-r7:0xWallet",
+                draftId: "draft-1",
+              },
+              response: { state: "submitted" },
+              status: "completed",
+              updated_at: "2026-05-03T11:43:23.872Z",
+              draft_validation_status: "valid",
+            },
+          ];
+        }
+        return [];
+      },
+      workflowDeps: {
+        async walletStatus() {
+          workflowCalls.push("walletStatus");
+          return { configured: true, address: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05" };
+        },
+        async listJobs() {
+          workflowCalls.push("listJobs");
+          return [
+            {
+              jobId: "wiki-en-58158792-citation-repair-r8",
+              definition: {
+                source: { type: "wikipedia_article", taskType: "citation_repair", pageTitle: "(+ +)", revisionId: "1351905437" },
+                publicDetails: { title: "Wikipedia citation repair: (+ +)" },
+                state: "open",
+                claimStatus: { claimable: true },
+              },
+            },
+            {
+              jobId: "starter-coding-001",
+              definition: { source: { type: "github_issue", taskType: "coding" }, state: "open" },
+            },
+          ];
+        },
+      },
+    });
+
+    expect(status).toMatchObject({
+      schemaVersion: 1,
+      generatedAt: "2026-05-03T12:00:00.000Z",
+      mutates: false,
+      agent: {
+        walletReady: true,
+        walletAddress: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+        network: "testnet",
+      },
+      policy: {
+        claimAllowedTaskTypes: ["citation_repair", "freshness_check"],
+        submitConfidenceThreshold: 0.7,
+        budget: {
+          perRunUsdMax: 0.5,
+          perDayUsdMax: 1,
+          maxBrowserSteps: 80,
+          todayUsdSpent: 0.25,
+          todayUsdRemaining: 0.75,
+        },
+      },
+      workflows: {
+        wikipediaCitationRepair: {
+          ready: true,
+          openJobs: 1,
+          discoveredJobs: 1,
+          latestRun: {
+            found: true,
+            runId: "wikipedia-citation-repair-run-1",
+            status: "submitted",
+            draftId: "draft-1",
+          },
+        },
+      },
+      safety: {
+        mutatesByDefault: false,
+        statusCommandsAreReadOnly: true,
+        repairWorkflowRequiresValidationBeforeSubmit: true,
+        editsWikipedia: false,
+      },
+    });
+    expect(status.workflows.wikipediaCitationRepair.safeCommands).toContain("operator status");
+    expect(status.workflows.wikipediaCitationRepair.candidateJobs[0]).toMatchObject({
+      jobId: "wiki-en-58158792-citation-repair-r8",
+      title: "Wikipedia citation repair: (+ +)",
+      claimable: true,
+      pageTitle: "(+ +)",
+      revisionId: "1351905437",
+    });
+    expect(workflowCalls.sort()).toEqual(["listJobs", "walletStatus"]);
+    expect(queries.every((text) => text.trim().toLowerCase().startsWith("select"))).toBe(true);
+  });
+
+  it("fails closed to read-only guidance when wallet or jobs are unavailable", async () => {
+    const status = await getOperatorStatus({
+      now: new Date("2026-05-03T12:00:00.000Z"),
+      policyConfig: {},
+      async query() {
+        throw new Error("db unavailable");
+      },
+      workflowDeps: {
+        async walletStatus() {
+          throw new Error("wallet unavailable");
+        },
+        async listJobs() {
+          throw new Error("jobs unavailable");
+        },
+      },
+    });
+
+    expect(status.mutates).toBe(false);
+    expect(status.agent.walletReady).toBe(false);
+    expect(status.workflows.wikipediaCitationRepair.ready).toBe(false);
+    expect(status.recommendedNextActions[0]).toContain("Configure the agent wallet");
+    expect(status.errors).toEqual(expect.arrayContaining([
+      expect.stringContaining("wallet_status_failed"),
+      expect.stringContaining("list_jobs_failed"),
+      expect.stringContaining("budget_query_failed"),
+      expect.stringContaining("latest_run_failed"),
+    ]));
+  });
+});

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -113,6 +113,44 @@ describe("slack operator bridge", () => {
     expect(text).toContain("https://slack.example/archives/C/p123");
   });
 
+  it("formats canonical operator status replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "operator_status",
+      status: {
+        agent: {
+          walletReady: true,
+          walletAddress: "0xWallet",
+        },
+        policy: {
+          budget: {
+            todayUsdSpent: 0.25,
+            perDayUsdMax: 1,
+          },
+        },
+        workflows: {
+          wikipediaCitationRepair: {
+            openJobs: 2,
+            discoveredJobs: 3,
+            latestRun: { status: "submitted" },
+            safeCommands: [
+              "operator status",
+              "status last wikipedia citation repair",
+            ],
+          },
+        },
+      },
+    });
+
+    expect(text).toContain("*Averray operator status*");
+    expect(text).toContain("wallet: `ready`");
+    expect(text).toContain("address: `0xWallet`");
+    expect(text).toContain("budget today: `0.25 / 1 USD`");
+    expect(text).toContain("wikipedia jobs: `2 open / 3 discovered`");
+    expect(text).toContain("latest run: `submitted`");
+    expect(text).toContain("`operator status`");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## Summary
- add read-only averray_operator_status MCP tool as a canonical agent-facing status contract
- route operator status, averray status, and help through the operator command handler
- format the canonical status in Slack and document the command for command-center/operator use

## Checks
- npm run typecheck
- npm run build
- npm test
- git diff --check

## Impact
- Backend/MCP: yes, new read-only status tool
- Slack operator: yes, formats operator status
- Command Center: yes, can call the MCP tool or short command
- Indexer/Caddy/contracts/public site: no
- Env/VPS secrets: none