### PR TITLE
Compact operator status identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,14 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   localhost. See [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md#slack-operator-commands).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `operator status`, `run one wikipedia citation repair if safe`,
-  and `status last wikipedia citation repair`. `operator status` calls the
+  recognizes `operator status`, `operator status details`,
+  `run one wikipedia citation repair if safe`, and
+  `status last wikipedia citation repair`. `operator status` calls the
   canonical read-only `averray_operator_status` MCP tool and returns wallet,
   budget, open-job, latest-run, safety, and safe-command metadata for any MCP
-  client. Repair commands call the Wikipedia workflow tool directly; latest-run
-  status returns the current run/session/draft/submit state, including
-  persisted Slack context when available, without mutating anything.
+  client. Human surfaces can show compact identifiers by default while keeping
+  full identifiers in the structured MCP JSON; add `details`, `full`, or
+  `audit` to a status command when an operator needs the full run/session/draft
+  audit trail. Repair commands call the Wikipedia workflow tool directly;
+  latest-run status returns the current run/session/draft/submit state,
+  including persisted Slack context when available, without mutating anything.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -138,9 +138,11 @@ commands are:
 
 ```text
 operator status
+operator status details
 run one wikipedia citation repair if safe
 run wikipedia citation repair for wiki-en-... if safe
 status last wikipedia citation repair
+status last wikipedia citation repair details
 ```
 
 `averray_handle_operator_command` parses those messages. `operator status`
@@ -151,8 +153,11 @@ commands call `averray_run_wikipedia_citation_repair` directly with the
 workflow's wallet, policy, draft, validation, submit, and Slack alert gates.
 Latest-run status commands are read-only and return the latest `runId`,
 `jobId`, `sessionId`, submitted/failed state, `draftId`, and Slack permalink
-when one is available. Add `dry run only` to a repair command when you want a
-proposal preview without claim or submit.
+when one is available. Human-facing Slack/Workspace renderers should compact
+long identifiers by default and preserve full identifiers in structured MCP
+JSON. Add `details`, `full`, or `audit` to a status command when a human
+operator needs full run/session/draft IDs. Add `dry run only` to a repair
+command when you want a proposal preview without claim or submit.
 
 Check the host env file:
 

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -140,7 +140,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'operator status', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help commands are read-only.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -13,11 +13,13 @@ export type ParsedOperatorCommand =
       handled: true;
       kind: "status_last_wikipedia_citation_repair";
       source: OperatorCommandSource;
+      detailed: boolean;
     }
   | {
       handled: true;
       kind: "operator_status";
       source: OperatorCommandSource;
+      detailed: boolean;
     }
   | {
       handled: false;
@@ -51,9 +53,11 @@ export interface LastWikipediaCitationRepairStatus {
 
 const EXAMPLES = [
   "operator status",
+  "operator status details",
   "run one wikipedia citation repair if safe",
   "run wikipedia citation repair for wiki-en-... if safe",
   "status last wikipedia citation repair",
+  "status last wikipedia citation repair details",
 ];
 
 export function parseOperatorCommand(
@@ -68,17 +72,14 @@ export function parseOperatorCommand(
   const source = options.source ?? "operator";
   const normalizedText = normalizeCommandText(text);
 
-  if (normalizedText === "status last wikipedia citation repair") {
-    return { handled: true, kind: "status_last_wikipedia_citation_repair", source };
+  const detailed = wantsDetailedOutput(normalizedText);
+
+  if (isLatestWikipediaCitationRepairStatusCommand(normalizedText)) {
+    return { handled: true, kind: "status_last_wikipedia_citation_repair", source, detailed };
   }
 
-  if (
-    normalizedText === "operator status" ||
-    normalizedText === "averray operator status" ||
-    normalizedText === "averray status" ||
-    normalizedText === "help"
-  ) {
-    return { handled: true, kind: "operator_status", source };
+  if (isOperatorStatusCommand(normalizedText)) {
+    return { handled: true, kind: "operator_status", source, detailed };
   }
 
   if (
@@ -204,6 +205,19 @@ function statusFromDraftRow(row: DraftStatusRow): LastWikipediaCitationRepairSta
 
 function normalizeCommandText(text: string): string {
   return text.trim().toLowerCase().replace(/[.!?]+$/g, "").replace(/\s+/g, " ");
+}
+
+function isLatestWikipediaCitationRepairStatusCommand(text: string): boolean {
+  return /^status last wikipedia citation repair( details?| full| audit)?$/.test(text);
+}
+
+function isOperatorStatusCommand(text: string): boolean {
+  return /^(operator status|averray operator status|averray status)( details?| full| audit)?$/.test(text)
+    || text === "help";
+}
+
+function wantsDetailedOutput(text: string): boolean {
+  return /\b(details?|full|audit)\b/.test(text);
 }
 
 function extractToken(text: string, pattern: RegExp): string | undefined {

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -87,21 +87,24 @@ export function formatOperatorResultForSlack(result: unknown): string {
     return [`I did not recognize that Averray command.`, examples].filter(Boolean).join("\n");
   }
   if (result.kind === "status_last_wikipedia_citation_repair") {
+    const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
     if (status.found === false) return "No Wikipedia citation-repair run was found yet.";
     return [
-      "*Last Wikipedia citation repair*",
-      `• runId: \`${stringField(status, "runId") ?? "unknown"}\``,
-      `• jobId: \`${stringField(status, "jobId") ?? "unknown"}\``,
-      `• sessionId: \`${stringField(status, "sessionId") ?? "unknown"}\``,
+      detailed ? "*Last Wikipedia citation repair - details*" : "*Last Wikipedia citation repair*",
+      `• runId: \`${formatId(stringField(status, "runId"), detailed) ?? "unknown"}\``,
+      `• jobId: \`${formatId(stringField(status, "jobId"), detailed) ?? "unknown"}\``,
+      `• sessionId: \`${formatId(stringField(status, "sessionId"), detailed) ?? "unknown"}\``,
       `• status: \`${stringField(status, "status") ?? "unknown"}\``,
       `• submittedAt: \`${stringField(status, "submittedAt") ?? "n/a"}\``,
-      `• draftId: \`${stringField(status, "draftId") ?? "n/a"}\``,
+      `• draftId: \`${formatId(stringField(status, "draftId"), detailed) ?? "n/a"}\``,
       `• submit_succeeded: \`${String(Boolean(status.submitSucceeded))}\``,
       `• slack: ${stringField(status, "slackPermalink") ?? "n/a"}`,
+      detailed ? `• source: \`${stringField(status, "source") ?? "n/a"}\`` : "Use `status last wikipedia citation repair details` for full IDs.",
     ].join("\n");
   }
   if (result.kind === "operator_status") {
+    const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
     const agent = isRecord(status.agent) ? status.agent : {};
     const policy = isRecord(status.policy) ? status.policy : {};
@@ -109,17 +112,41 @@ export function formatOperatorResultForSlack(result: unknown): string {
     const workflows = isRecord(status.workflows) ? status.workflows : {};
     const wikipedia = isRecord(workflows.wikipediaCitationRepair) ? workflows.wikipediaCitationRepair : {};
     const latestRun = isRecord(wikipedia.latestRun) ? wikipedia.latestRun : {};
+    const candidateJobs = Array.isArray(wikipedia.candidateJobs) ? wikipedia.candidateJobs : [];
     const commands = Array.isArray(wikipedia.safeCommands)
       ? wikipedia.safeCommands.slice(0, 4).map((entry) => `• \`${String(entry)}\``).join("\n")
       : "";
+    if (detailed) {
+      return [
+        "*Averray operator status - details*",
+        `• generatedAt: \`${stringField(status, "generatedAt") ?? "n/a"}\``,
+        `• mutates: \`${String(status.mutates === true)}\``,
+        `• wallet: \`${agent.walletReady === true ? "ready" : "not_ready"}\``,
+        `• address: \`${formatId(stringField(agent, "walletAddress"), true) ?? "n/a"}\``,
+        `• network: \`${stringField(agent, "network") ?? "n/a"}\``,
+        `• budget today: \`${numberField(budget, "todayUsdSpent") ?? "n/a"} / ${numberField(budget, "perDayUsdMax") ?? "n/a"} USD\``,
+        `• wikipedia jobs: \`${numberField(wikipedia, "openJobs") ?? "n/a"} open / ${numberField(wikipedia, "discoveredJobs") ?? "n/a"} discovered\``,
+        "*Latest run*",
+        `• runId: \`${formatId(stringField(latestRun, "runId"), true) ?? "n/a"}\``,
+        `• jobId: \`${formatId(stringField(latestRun, "jobId"), true) ?? "n/a"}\``,
+        `• sessionId: \`${formatId(stringField(latestRun, "sessionId"), true) ?? "n/a"}\``,
+        `• status: \`${stringField(latestRun, "status") ?? "none"}\``,
+        `• draftId: \`${formatId(stringField(latestRun, "draftId"), true) ?? "n/a"}\``,
+        `• slack: ${stringField(latestRun, "slackPermalink") ?? "n/a"}`,
+        candidateJobs.length > 0 ? `*Open jobs*\n${candidateJobs.slice(0, 5).map(formatCandidateJob).join("\n")}` : "",
+        commands ? `*Safe commands*\n${commands}` : "",
+      ].filter(Boolean).join("\n");
+    }
     return [
       "*Averray operator status*",
       `• wallet: \`${agent.walletReady === true ? "ready" : "not_ready"}\``,
-      `• address: \`${stringField(agent, "walletAddress") ?? "n/a"}\``,
+      `• address: \`${formatId(stringField(agent, "walletAddress"), false) ?? "n/a"}\``,
       `• budget today: \`${numberField(budget, "todayUsdSpent") ?? "n/a"} / ${numberField(budget, "perDayUsdMax") ?? "n/a"} USD\``,
       `• wikipedia jobs: \`${numberField(wikipedia, "openJobs") ?? "n/a"} open / ${numberField(wikipedia, "discoveredJobs") ?? "n/a"} discovered\``,
       `• latest run: \`${stringField(latestRun, "status") ?? "none"}\``,
+      `• latest job: \`${formatId(stringField(latestRun, "jobId"), false) ?? "n/a"}\``,
       commands ? `*Safe commands*\n${commands}` : "",
+      "Use `operator status details` for full IDs.",
     ].filter(Boolean).join("\n");
   }
   if (result.kind === "run_wikipedia_citation_repair") {
@@ -130,10 +157,10 @@ export function formatOperatorResultForSlack(result: unknown): string {
     return [
       "*Wikipedia citation repair workflow*",
       `• status: \`${stringField(workflow, "status") ?? "unknown"}\``,
-      `• runId: \`${stringField(workflow, "runId") ?? "unknown"}\``,
-      `• jobId: \`${stringField(workflow, "jobId") ?? "unknown"}\``,
-      `• sessionId: \`${stringField(workflow, "sessionId") ?? "n/a"}\``,
-      `• draftId: \`${stringField(workflow, "draftId") ?? "n/a"}\``,
+      `• runId: \`${formatId(stringField(workflow, "runId"), false) ?? "unknown"}\``,
+      `• jobId: \`${formatId(stringField(workflow, "jobId"), false) ?? "unknown"}\``,
+      `• sessionId: \`${formatId(stringField(workflow, "sessionId"), false) ?? "n/a"}\``,
+      `• draftId: \`${formatId(stringField(workflow, "draftId"), false) ?? "n/a"}\``,
       `• confidence: \`${numberField(workflow, "confidence") ?? "n/a"}\``,
       `• validation: \`${validation.valid === true ? "valid" : validation.valid === false ? "invalid" : "n/a"}\``,
       `• citations reviewed: \`${numberField(evidence, "totalCitations") ?? "n/a"}\``,
@@ -167,6 +194,29 @@ function stringField(value: unknown, key: string): string | undefined {
   if (!isRecord(value)) return undefined;
   const field = value[key];
   return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function formatCandidateJob(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const jobId = formatId(stringField(value, "jobId"), true) ?? "unknown";
+  const title = stringField(value, "title") ?? stringField(value, "pageTitle") ?? "untitled";
+  const revisionId = stringField(value, "revisionId") ?? "n/a";
+  return `• \`${jobId}\` - ${title} (rev ${revisionId})`;
+}
+
+function formatId(value: string | undefined, detailed: boolean): string | undefined {
+  if (!value) return undefined;
+  return detailed ? value : compactId(value);
+}
+
+function compactId(value: string): string {
+  if (value.length <= 32) return value;
+  if (value.startsWith("0x") && value.length > 14) return `${value.slice(0, 6)}...${value.slice(-4)}`;
+  if (value.includes(":0x")) return `${value.slice(0, 16)}...${value.slice(-9)}`;
+  if (value.startsWith("wiki-en-")) return `${value.slice(0, 16)}...${value.slice(-9)}`;
+  if (value.startsWith("wikipedia-citation")) return `${value.slice(0, 16)}...${value.slice(-10)}`;
+  if (/^[a-f0-9]{48,}$/i.test(value)) return `${value.slice(0, 12)}...${value.slice(-10)}`;
+  return `${value.slice(0, 16)}...${value.slice(-8)}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -47,6 +47,7 @@ describe("operator commands", () => {
       handled: true,
       kind: "status_last_wikipedia_citation_repair",
       source: "operator",
+      detailed: false,
     });
   });
 
@@ -55,11 +56,25 @@ describe("operator commands", () => {
       handled: true,
       kind: "operator_status",
       source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("operator status details", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "operator_status",
+      source: "operator",
+      detailed: true,
+    });
+    expect(parseOperatorCommand("status last wikipedia citation repair full", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "status_last_wikipedia_citation_repair",
+      source: "slack",
+      detailed: true,
     });
     expect(parseOperatorCommand("help", { source: "slack" })).toEqual({
       handled: true,
       kind: "operator_status",
       source: "slack",
+      detailed: false,
     });
   });
 

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -94,9 +94,10 @@ describe("slack operator bridge", () => {
     const text = formatOperatorResultForSlack({
       handled: true,
       kind: "status_last_wikipedia_citation_repair",
+      detailed: false,
       status: {
         found: true,
-        runId: "run-1",
+        runId: "wikipedia-citation-repair-035bee96-0d62-45a0-a800-eb7f5316b09f",
         jobId: "wiki-en-1-citation-repair",
         sessionId: "wiki-en-1-citation-repair:0xWallet",
         status: "submitted",
@@ -107,20 +108,49 @@ describe("slack operator bridge", () => {
       },
     });
 
-    expect(text).toContain("runId: `run-1`");
+    expect(text).toContain("runId: `wikipedia-citati...7f5316b09f`");
     expect(text).toContain("jobId: `wiki-en-1-citation-repair`");
     expect(text).toContain("submit_succeeded: `true`");
     expect(text).toContain("https://slack.example/archives/C/p123");
+    expect(text).toContain("Use `status last wikipedia citation repair details` for full IDs.");
+  });
+
+  it("formats detailed status replies with full identifiers", () => {
+    const fullRunId = "wikipedia-citation-repair-035bee96-0d62-45a0-a800-eb7f5316b09f";
+    const fullDraftId = "c9f24fbfd21cb081af2feac8ef5acf77d65d247889f4fd91706cc516925c1fc1";
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "status_last_wikipedia_citation_repair",
+      detailed: true,
+      status: {
+        found: true,
+        runId: fullRunId,
+        jobId: "wiki-en-58158792-citation-repair-r7",
+        sessionId: "wiki-en-58158792-citation-repair-r7:0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+        status: "submitted",
+        submittedAt: "2026-05-03T11:43:23.872Z",
+        draftId: fullDraftId,
+        submitSucceeded: true,
+        source: "submissions",
+      },
+    });
+
+    expect(text).toContain("*Last Wikipedia citation repair - details*");
+    expect(text).toContain(fullRunId);
+    expect(text).toContain(fullDraftId);
+    expect(text).toContain("source: `submissions`");
+    expect(text).not.toContain("for full IDs");
   });
 
   it("formats canonical operator status replies", () => {
     const text = formatOperatorResultForSlack({
       handled: true,
       kind: "operator_status",
+      detailed: false,
       status: {
         agent: {
           walletReady: true,
-          walletAddress: "0xWallet",
+          walletAddress: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
         },
         policy: {
           budget: {
@@ -132,7 +162,10 @@ describe("slack operator bridge", () => {
           wikipediaCitationRepair: {
             openJobs: 2,
             discoveredJobs: 3,
-            latestRun: { status: "submitted" },
+            latestRun: {
+              status: "submitted",
+              jobId: "wiki-en-58158792-citation-repair-r7",
+            },
             safeCommands: [
               "operator status",
               "status last wikipedia citation repair",
@@ -144,11 +177,61 @@ describe("slack operator bridge", () => {
 
     expect(text).toContain("*Averray operator status*");
     expect(text).toContain("wallet: `ready`");
-    expect(text).toContain("address: `0xWallet`");
+    expect(text).toContain("address: `0x30BC...eE05`");
     expect(text).toContain("budget today: `0.25 / 1 USD`");
     expect(text).toContain("wikipedia jobs: `2 open / 3 discovered`");
     expect(text).toContain("latest run: `submitted`");
+    expect(text).toContain("latest job: `wiki-en-58158792...repair-r7`");
     expect(text).toContain("`operator status`");
+    expect(text).toContain("Use `operator status details` for full IDs.");
+  });
+
+  it("formats detailed operator status replies with full audit identifiers", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "operator_status",
+      detailed: true,
+      status: {
+        schemaVersion: 1,
+        generatedAt: "2026-05-03T12:00:00.000Z",
+        mutates: false,
+        agent: {
+          walletReady: true,
+          walletAddress: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+          network: "testnet",
+        },
+        policy: {
+          budget: { todayUsdSpent: 0, perDayUsdMax: 1 },
+        },
+        workflows: {
+          wikipediaCitationRepair: {
+            openJobs: 1,
+            discoveredJobs: 1,
+            latestRun: {
+              runId: "wikipedia-citation-repair-run-1",
+              jobId: "wiki-en-58158792-citation-repair-r7",
+              sessionId: "wiki-en-58158792-citation-repair-r7:0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+              status: "submitted",
+              draftId: "draft-1",
+            },
+            candidateJobs: [
+              {
+                jobId: "wiki-en-58158792-citation-repair-r8",
+                title: "Wikipedia citation repair: (+ +)",
+                revisionId: "1351905437",
+              },
+            ],
+            safeCommands: ["operator status"],
+          },
+        },
+      },
+    });
+
+    expect(text).toContain("*Averray operator status - details*");
+    expect(text).toContain("0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05");
+    expect(text).toContain("wiki-en-58158792-citation-repair-r7");
+    expect(text).toContain("wiki-en-58158792-citation-repair-r8");
+    expect(text).toContain("*Open jobs*");
   });
 
   it("formats workflow replies with compact validation and evidence summary", () => {
@@ -157,10 +240,10 @@ describe("slack operator bridge", () => {
       kind: "run_wikipedia_citation_repair",
       result: {
         status: "submitted",
-        runId: "run-2",
-        jobId: "wiki-en-2-citation-repair",
-        sessionId: "session-2",
-        draftId: "draft-2",
+        runId: "wikipedia-citation-repair-035bee96-0d62-45a0-a800-eb7f5316b09f",
+        jobId: "wiki-en-58158792-citation-repair-r7",
+        sessionId: "wiki-en-58158792-citation-repair-r7:0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05",
+        draftId: "c9f24fbfd21cb081af2feac8ef5acf77d65d247889f4fd91706cc516925c1fc1",
         confidence: 0.72,
         validation: { valid: true },
         evidenceSummary: { totalCitations: 45, flaggedCitations: 45 },
@@ -169,6 +252,8 @@ describe("slack operator bridge", () => {
     });
 
     expect(text).toContain("status: `submitted`");
+    expect(text).toContain("runId: `wikipedia-citati...7f5316b09f`");
+    expect(text).toContain("sessionId: `wiki-en-58158792...a57CdeE05`");
     expect(text).toContain("validation: `valid`");
     expect(text).toContain("citations reviewed: `45`");
     expect(text).toContain("issues proposed: `5`");


### PR DESCRIPTION
## Summary
- compact long run/session/draft/wallet identifiers in Slack-facing operator replies by default
- add `details`, `full`, and `audit` status command variants for full audit identifiers
- document compact human rendering while preserving full IDs in structured MCP JSON

## Checks
- npm run typecheck
- npm run build
- npm test
- git diff --check

## Impact
- Backend/MCP: parser metadata for detailed status commands
- Slack operator: compact default formatting plus detailed audit output
- Command Center: details/full/audit command variants available via operator router
- Indexer/Caddy/contracts/public site: no
- Env/VPS secrets: none