### PR TITLE
Add Cloudflare Access command center runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `slack-operator` service. Socket Mode is supported for outbound-only VPS
   connectivity; signed HTTP slash/events endpoints are also available on
   localhost. See [docs/VPS_SMOKE.md](docs/VPS_SMOKE.md#slack-operator-commands).
+- Optional public command-center access can be enabled with Cloudflare Access
+  and the `cloudflared` overlay. This keeps Workspace and Hermes gateway ports
+  private while publishing an Access-protected HTTPS hostname. See
+  [docs/COMMAND_CENTER_PUBLIC_ACCESS.md](docs/COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
   recognizes `operator status`, `operator status details`,

--- a/docs/COMMAND_CENTER.md
+++ b/docs/COMMAND_CENTER.md
@@ -43,6 +43,10 @@ Verified golden path:
 - Do not install Hermes Workspace with `curl | bash` on the VPS.
 - Do not bind the command center to a public interface.
 - Use SSH or Tailscale tunnels to reach the UI.
+- If browser access without SSH is required, publish Workspace through
+  Cloudflare Access plus the optional `cloudflared` overlay instead of opening
+  Workspace directly. See
+  [COMMAND_CENTER_PUBLIC_ACCESS.md](COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Set strong `HERMES_WORKSPACE_PASSWORD` and `HERMES_GATEWAY_API_KEY`
   values before starting the workspace.
 - The Workspace image still checks the legacy `CLAUDE_API_TOKEN` name for
@@ -249,8 +253,9 @@ docker compose --env-file .env.prod \
   but their Slack permalink is `n/a` because Slack did not initiate them.
 - The command center should stay as an optional companion to Slack rather than
   replace Slack yet.
-- Do not broaden network exposure. Keep Workspace and gateway bound to VPS
-  localhost and reach them through SSH/Tailscale tunnels.
+- Do not broaden direct network exposure. Keep Workspace and gateway bound to
+  VPS localhost. For browser access without SSH, use Cloudflare Access/Tunnel
+  as described in `docs/COMMAND_CENTER_PUBLIC_ACCESS.md`.
 
 ## Future Work
 

--- a/docs/COMMAND_CENTER_PUBLIC_ACCESS.md
+++ b/docs/COMMAND_CENTER_PUBLIC_ACCESS.md
@@ -1,0 +1,166 @@
+# Command Center Public Access
+
+This runbook publishes Hermes Workspace at a stable HTTPS hostname while keeping
+the Averray reference agent services private. Use this when you need to reach
+the command center from a browser without an SSH tunnel.
+
+## Recommended Shape
+
+Use Cloudflare Zero Trust:
+
+- Cloudflare Tunnel connector runs on the VPS as `cloudflared`.
+- Hermes Workspace still listens only inside Docker and on VPS localhost.
+- The public hostname is protected by Cloudflare Access before traffic reaches
+  the VPS.
+- `hermes-gateway`, `hermes` dashboard, Postgres, and Slack operator ports stay
+  private.
+
+This is stronger than exposing Caddy/Nginx directly because the VPS does not
+need inbound HTTP/HTTPS ports for the command center.
+
+## Cloudflare Setup
+
+In Cloudflare One:
+
+1. Go to **Networks > Connectors > Cloudflare Tunnels**.
+2. Create a tunnel named `averray-command-center`.
+3. Choose the Docker connector option and copy the tunnel token.
+4. Add a public hostname, for example:
+   - hostname: `command.example.com`
+   - service: `http://hermes-workspace:3000`
+5. Go to **Access controls > Applications**.
+6. Add a **Self-hosted** application for the same hostname.
+7. Add an Allow policy for explicit operator email addresses only.
+
+Do not create policies that include `Everyone` or all One-Time PIN users. If
+you use One-Time PIN, pair it with an explicit email list or tightly scoped
+email domain.
+
+## VPS Environment
+
+Add the tunnel token to `.env.prod`:
+
+```dotenv
+CLOUDFLARED_IMAGE=cloudflare/cloudflared:latest
+CLOUDFLARED_TUNNEL_TOKEN=paste-cloudflare-tunnel-token-here
+```
+
+When accessing Workspace through HTTPS via Cloudflare, use secure cookies and
+trust proxy headers:
+
+```dotenv
+HERMES_WORKSPACE_COOKIE_SECURE=1
+HERMES_WORKSPACE_TRUST_PROXY=1
+```
+
+Keep these existing bindings as localhost-only:
+
+```dotenv
+HERMES_WORKSPACE_PORT=3000
+HERMES_GATEWAY_PORT=8642
+```
+
+## Start
+
+From the VPS checkout:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -f ops/compose.cloudflare-access.yml \
+  -p avg \
+  --profile command-center \
+  up -d hermes hermes-gateway hermes-workspace cloudflared
+```
+
+## Verify
+
+Check the services:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -f ops/compose.cloudflare-access.yml \
+  -p avg \
+  --profile command-center \
+  ps hermes-gateway hermes-workspace cloudflared
+```
+
+Watch the tunnel logs:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -f ops/compose.cloudflare-access.yml \
+  -p avg \
+  --profile command-center \
+  logs -f --tail=120 cloudflared
+```
+
+From a browser:
+
+1. Open `https://command.example.com`.
+2. Confirm Cloudflare Access asks for your approved login.
+3. Confirm Workspace still asks for `HERMES_WORKSPACE_PASSWORD` if it is not
+   already stored.
+4. Run `operator status`.
+5. Run `operator status details`.
+
+From a machine that is not authenticated with Access, the hostname should show
+the Cloudflare Access login screen, not Hermes Workspace.
+
+## Safety Checks
+
+From outside the VPS, these ports should not be reachable directly:
+
+- `3000` Workspace UI
+- `8642` Hermes gateway
+- `9119` Hermes dashboard
+- Postgres
+- Slack operator HTTP port
+
+On the VPS, the local checks should still work:
+
+```bash
+curl -fsS http://127.0.0.1:3000 >/dev/null
+curl -fsS http://127.0.0.1:8642/health
+curl -fsS http://127.0.0.1:9119/api/status
+```
+
+## Stop Public Access
+
+To disable public command-center access while keeping the local command center
+running:
+
+```bash
+docker compose --env-file .env.prod \
+  -f ops/compose.yml \
+  -f ops/compose.prod.yml \
+  -f ops/compose.command-center.yml \
+  -f ops/compose.cloudflare-access.yml \
+  -p avg \
+  --profile command-center \
+  stop cloudflared
+```
+
+You can also disable or delete the Access application in Cloudflare One.
+
+## References
+
+- Cloudflare Tunnel publishes local services through outbound-only
+  `cloudflared` connections without exposing inbound origin ports:
+  <https://developers.cloudflare.com/tunnel/>
+- Cloudflare Tunnel public hostnames map a hostname to a local service URL:
+  <https://developers.cloudflare.com/tunnel/routing/>
+- Cloudflare Access self-hosted applications protect internal tools with
+  identity policies:
+  <https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/self-hosted-apps/>
+- Cloudflare warns against broad Access policies such as `Everyone` or all
+  One-Time PIN users:
+  <https://developers.cloudflare.com/cloudflare-one/policies/access/>

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -39,6 +39,12 @@ HERMES_WORKSPACE_PASSWORD=
 HERMES_WORKSPACE_COOKIE_SECURE=0
 HERMES_WORKSPACE_TRUST_PROXY=0
 
+# Optional public command-center access through Cloudflare Zero Trust.
+# Prefer Cloudflare Tunnel + Access so Workspace is reachable by hostname
+# without opening public inbound ports on the VPS.
+CLOUDFLARED_IMAGE=cloudflare/cloudflared:latest
+CLOUDFLARED_TUNNEL_TOKEN=
+
 SLACK_WEBHOOK_URL=
 SLACK_OPERATOR_ENABLED=0
 SLACK_OPERATOR_HTTP_PORT=8790

--- a/ops/compose.cloudflare-access.yml
+++ b/ops/compose.cloudflare-access.yml
@@ -1,0 +1,21 @@
+# Optional Cloudflare Access/Tunnel overlay for the Hermes Workspace command
+# center. This publishes Workspace through Cloudflare Zero Trust without
+# opening public inbound ports on the VPS.
+#
+# Cloudflare dashboard settings:
+# - Tunnel public hostname: command.example.com
+# - Tunnel service URL: http://hermes-workspace:3000
+# - Access app: self-hosted, same hostname, allow only explicit operator emails.
+services:
+  cloudflared:
+    image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:latest}
+    profiles: ["command-center"]
+    restart: unless-stopped
+    read_only: true
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
+    depends_on:
+      hermes-workspace:
+        condition: service_started
+    command: ["tunnel", "--no-autoupdate", "run", "--token", "${CLOUDFLARED_TUNNEL_TOKEN:?Set CLOUDFLARED_TUNNEL_TOKEN in .env.prod}"]
+    networks: [avg-internal]


### PR DESCRIPTION
## Summary
- add optional cloudflared compose overlay for Access-protected public Workspace access
- document Cloudflare Tunnel + Access setup, verification, and stop procedure
- note secure cookie/proxy env settings and keep gateway/dashboard ports private

## Checks
- git diff --check
- ruby YAML parse for ops/compose.cloudflare-access.yml

## Impact
- DevOps/docs: yes
- Backend/MCP/Slack/indexer/contracts/public site: no
- Env/VPS secrets: requires CLOUDFLARED_TUNNEL_TOKEN when enabling the overlay