### PR TITLE
Route MCP diagnostics to stderr

### DIFF
--- a/packages/mcp-common/src/logger.ts
+++ b/packages/mcp-common/src/logger.ts
@@ -1,23 +1,33 @@
 import pino from "pino";
+import { Writable } from "node:stream";
 
-export const logger = pino({
-  level: process.env.LOG_LEVEL ?? "info",
-  redact: {
-    paths: [
-      "privateKey",
-      "*.privateKey",
-      "authorization",
-      "*.authorization",
-      "signature",
-      "*.signature",
-      "cookie",
-      "*.cookie",
-      "*.jwt",
-      "jwt",
-      "mnemonic",
-      "*.mnemonic"
-    ],
-    censor: "[redacted]"
+const stderrStream = new Writable({
+  write(chunk, encoding, callback) {
+    process.stderr.write(chunk, encoding, callback);
   }
 });
 
+export function createLogger(stream: NodeJS.WritableStream = stderrStream) {
+  return pino({
+    level: process.env.LOG_LEVEL ?? "info",
+    redact: {
+      paths: [
+        "privateKey",
+        "*.privateKey",
+        "authorization",
+        "*.authorization",
+        "signature",
+        "*.signature",
+        "cookie",
+        "*.cookie",
+        "*.jwt",
+        "jwt",
+        "mnemonic",
+        "*.mnemonic"
+      ],
+      censor: "[redacted]"
+    }
+  }, stream);
+}
+
+export const logger = createLogger();

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -1,0 +1,21 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("shared MCP logger", () => {
+  it("writes diagnostics to stderr so stdio stdout remains JSON-RPC-only", () => {
+    const script = [
+      "import { logger } from './packages/mcp-common/src/logger.ts';",
+      "logger.info({ component: 'mcp-stdio' }, 'mcp_stdio_log_test');",
+      "await new Promise((resolve) => setTimeout(resolve, 20));"
+    ].join("\n");
+
+    const result = spawnSync(process.execPath, ["--import", "tsx", "-e", script], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("mcp_stdio_log_test");
+    expect(result.stdout).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- route the shared MCP pino logger to stderr instead of stdout
- keep stdio stdout reserved for JSON-RPC protocol frames
- add a regression test that launches the logger and verifies stdout remains empty while diagnostics land on stderr

## Checks
- npm install
- npm run typecheck
- npm run build
- npm test
- git diff --check

## Impact
- Affects shared MCP logging only
- No backend API, frontend, indexer, contracts, public site, or chain-facing changes
- No required env or VPS secret changes