### PR TITLE
Add operator brief and safe work commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,18 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   [docs/COMMAND_CENTER_PUBLIC_ACCESS.md](docs/COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `operator status`, `operator status details`,
+  recognizes `daily operator brief`, `find safe work`, `operator status`,
+  `operator status details`,
   `run one wikipedia citation repair if safe`, and
-  `status last wikipedia citation repair`. `operator status` calls the
+  `status last wikipedia citation repair`. `daily operator brief` and
+  `find safe work` are read-only summaries that turn the current wallet,
+  budget, latest-run, and open-job state into practical next actions for any
+  MCP client, not just Slack or Hermes Workspace. `operator status` calls the
   canonical read-only `averray_operator_status` MCP tool and returns wallet,
-  budget, open-job, latest-run, safety, and safe-command metadata for any MCP
-  client. Human surfaces can show compact identifiers by default while keeping
-  full identifiers in the structured MCP JSON; add `details`, `full`, or
-  `audit` to a status command when an operator needs the full run/session/draft
-  audit trail. Repair commands call the Wikipedia workflow tool directly;
-  latest-run status returns the current run/session/draft/submit state,
-  including persisted Slack context when available, without mutating anything.
+  budget, open-job, latest-run, safety, and safe-command metadata. Human
+  surfaces can show compact identifiers by default while keeping full
+  identifiers in the structured MCP JSON; add `details`, `full`, or `audit` to
+  a status command when an operator needs the full run/session/draft audit
+  trail. Repair commands call the Wikipedia workflow tool directly; latest-run
+  status returns the current run/session/draft/submit state, including
+  persisted Slack context when available, without mutating anything.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -137,6 +137,8 @@ operator command tool, not rephrased as free-form Hermes prompts. The supported
 commands are:
 
 ```text
+daily operator brief
+find safe work
 operator status
 operator status details
 run one wikipedia citation repair if safe
@@ -145,12 +147,15 @@ status last wikipedia citation repair
 status last wikipedia citation repair details
 ```
 
-`averray_handle_operator_command` parses those messages. `operator status`
-calls the canonical read-only `averray_operator_status` MCP tool, returning
-wallet readiness, policy budget, open Wikipedia job counts, latest run state,
-safety guarantees, and safe command suggestions as structured JSON. Repair
-commands call `averray_run_wikipedia_citation_repair` directly with the
-workflow's wallet, policy, draft, validation, submit, and Slack alert gates.
+`averray_handle_operator_command` parses those messages. `daily operator brief`
+and `find safe work` are read-only views for humans and agents: they summarize
+wallet/budget readiness, latest run state, candidate jobs, blockers, and the
+next dry-run or guarded mutation command. `operator status` calls the canonical
+read-only `averray_operator_status` MCP tool, returning wallet readiness, policy
+budget, open Wikipedia job counts, latest run state, safety guarantees, and safe
+command suggestions as structured JSON. Repair commands call
+`averray_run_wikipedia_citation_repair` directly with the workflow's wallet,
+policy, draft, validation, submit, and Slack alert gates.
 Latest-run status commands are read-only and return the latest `runId`,
 `jobId`, `sessionId`, submitted/failed state, `draftId`, and Slack permalink
 when one is available. Human-facing Slack/Workspace renderers should compact

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -41,7 +41,7 @@ import {
   getLastWikipediaCitationRepairStatus,
 } from "./operator-commands.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
-import { getOperatorStatus } from "./operator-status.js";
+import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -139,8 +139,26 @@ server.tool(
 );
 
 server.tool(
+  "averray_daily_operator_brief",
+  "Canonical read-only daily operator brief for humans and agents. Summarizes wallet readiness, budget, latest Wikipedia citation-repair run, open safe work, recommended next actions, and safety guarantees. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getDailyOperatorBrief({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
+  "averray_find_safe_work",
+  "Canonical read-only safe-work finder for humans and agents. Returns currently available operator work items, dry-run commands, guarded mutation commands, blockers, and safety guarantees. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getSafeWorkReport({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -22,6 +22,18 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "daily_operator_brief";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
+      handled: true;
+      kind: "find_safe_work";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -52,6 +64,8 @@ export interface LastWikipediaCitationRepairStatus {
 }
 
 const EXAMPLES = [
+  "daily operator brief",
+  "find safe work",
   "operator status",
   "operator status details",
   "run one wikipedia citation repair if safe",
@@ -73,6 +87,14 @@ export function parseOperatorCommand(
   const normalizedText = normalizeCommandText(text);
 
   const detailed = wantsDetailedOutput(normalizedText);
+
+  if (isDailyOperatorBriefCommand(normalizedText)) {
+    return { handled: true, kind: "daily_operator_brief", source, detailed };
+  }
+
+  if (isFindSafeWorkCommand(normalizedText)) {
+    return { handled: true, kind: "find_safe_work", source, detailed };
+  }
 
   if (isLatestWikipediaCitationRepairStatusCommand(normalizedText)) {
     return { handled: true, kind: "status_last_wikipedia_citation_repair", source, detailed };
@@ -214,6 +236,14 @@ function isLatestWikipediaCitationRepairStatusCommand(text: string): boolean {
 function isOperatorStatusCommand(text: string): boolean {
   return /^(operator status|averray operator status|averray status)( details?| full| audit)?$/.test(text)
     || text === "help";
+}
+
+function isDailyOperatorBriefCommand(text: string): boolean {
+  return /^(daily operator brief|operator brief|daily brief|morning brief|brief me|what is my brief)( details?| full| audit)?$/.test(text);
+}
+
+function isFindSafeWorkCommand(text: string): boolean {
+  return /^(find safe work|safe work|next safe work|find work|what should i do next|what can you do|operator todo)( details?| full| audit)?$/.test(text);
 }
 
 function wantsDetailedOutput(text: string): boolean {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -5,7 +5,7 @@ import {
   type OperatorCommandSource,
   type OperatorQueryFn,
 } from "./operator-commands.js";
-import { getOperatorStatus } from "./operator-status.js";
+import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 
 export interface HandleOperatorCommandInput {
@@ -40,6 +40,14 @@ export async function handleOperatorCommandText(
   if (command.kind === "operator_status") {
     const status = await getOperatorStatus({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, status };
+  }
+  if (command.kind === "daily_operator_brief") {
+    const brief = await getDailyOperatorBrief({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, brief };
+  }
+  if (command.kind === "find_safe_work") {
+    const safeWork = await getSafeWorkReport({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, safeWork };
   }
   const result = await runWikipediaCitationRepairWorkflow(
     { ...command.input, expectedWallet: input.expectedWallet },

--- a/packages/averray-mcp/src/operator-status.ts
+++ b/packages/averray-mcp/src/operator-status.ts
@@ -125,6 +125,95 @@ export async function getOperatorStatus(deps: OperatorStatusDeps) {
   };
 }
 
+export async function getDailyOperatorBrief(deps: OperatorStatusDeps) {
+  const status = await getOperatorStatus(deps);
+  const wikipedia = status.workflows.wikipediaCitationRepair;
+  const latestRun = wikipedia.latestRun;
+  const budget = status.policy.budget;
+  return {
+    schemaVersion: 1,
+    kind: "daily_operator_brief",
+    generatedAt: status.generatedAt,
+    mutates: false,
+    headline: dailyBriefHeadline(status.agent.walletReady, wikipedia.openJobs, latestRun),
+    readiness: {
+      wallet: status.agent.walletReady ? "ready" : "not_ready",
+      budget: budget.todayUsdRemaining > 0 ? "ready" : "depleted",
+      wikipediaCitationRepair: wikipedia.ready ? "ready" : "not_ready",
+    },
+    wallet: {
+      ready: status.agent.walletReady,
+      address: status.agent.walletAddress,
+      network: status.agent.network,
+    },
+    budget: {
+      todayUsdSpent: budget.todayUsdSpent,
+      todayUsdRemaining: budget.todayUsdRemaining,
+      perRunUsdMax: budget.perRunUsdMax,
+      perDayUsdMax: budget.perDayUsdMax,
+    },
+    latestWikipediaCitationRepair: latestRun,
+    openWikipediaCitationRepairJobs: wikipedia.openJobs,
+    candidateJobs: wikipedia.candidateJobs.slice(0, 3),
+    recommendedNextActions: status.recommendedNextActions,
+    suggestedCommands: [
+      "find safe work",
+      "run one wikipedia citation repair dry run only",
+      "run one wikipedia citation repair if safe",
+      "status last wikipedia citation repair",
+    ],
+    safety: {
+      mutatesByDefault: false,
+      statusCommandsAreReadOnly: true,
+      editsWikipedia: false,
+    },
+    ...(status.errors ? { errors: status.errors } : {}),
+  };
+}
+
+export async function getSafeWorkReport(deps: OperatorStatusDeps) {
+  const status = await getOperatorStatus(deps);
+  const wikipedia = status.workflows.wikipediaCitationRepair;
+  const budget = status.policy.budget;
+  const blockers = safeWorkBlockers(status.agent.walletReady, budget.todayUsdRemaining, wikipedia.openJobs);
+  const available = blockers.length === 0;
+  return {
+    schemaVersion: 1,
+    kind: "find_safe_work",
+    generatedAt: status.generatedAt,
+    mutates: false,
+    available,
+    blockers,
+    recommendedCommand: available
+      ? "run one wikipedia citation repair dry run only"
+      : "operator status",
+    nextMutationCommand: available
+      ? "run one wikipedia citation repair if safe"
+      : null,
+    safeWorkItems: wikipedia.candidateJobs.slice(0, 5).map((job, index) => ({
+      rank: index + 1,
+      workflow: "wikipedia_citation_repair",
+      job,
+      dryRunCommand: job.jobId
+        ? `run wikipedia citation repair for ${job.jobId} if safe, dry run only`
+        : "run one wikipedia citation repair dry run only",
+      mutationCommand: job.jobId
+        ? `run wikipedia citation repair for ${job.jobId} if safe`
+        : "run one wikipedia citation repair if safe",
+      mutates: false,
+      note: "Start with the dry run. Submit still requires validation and confidence >= threshold.",
+    })),
+    latestWikipediaCitationRepair: wikipedia.latestRun,
+    safety: {
+      dryRunMutates: false,
+      mutationRequiresExplicitCommand: true,
+      validatesBeforeSubmit: true,
+      editsWikipedia: false,
+    },
+    ...(status.errors ? { errors: status.errors } : {}),
+  };
+}
+
 function loadPolicyConfig(): OperatorPolicyConfig {
   return readYamlFile(optionalEnv("POLICY_CONFIG_PATH", "/config/policy.yaml"), defaultPolicyConfig);
 }
@@ -209,6 +298,23 @@ function recommendedNextActions(
     "Use: run one wikipedia citation repair dry run only",
     "If the dry run validates and confidence is sufficient, use: run one wikipedia citation repair if safe",
   ];
+}
+
+function dailyBriefHeadline(walletReady: boolean, openJobs: number, latestRun: LastWikipediaCitationRepairStatus): string {
+  if (!walletReady) return "Wallet is not ready; keep to read-only status checks.";
+  if (latestRun.found && latestRun.status && latestRun.status !== "submitted") {
+    return `Latest Wikipedia citation repair is ${latestRun.status}; inspect it before starting another run.`;
+  }
+  if (openJobs > 0) return `${openJobs} Wikipedia citation-repair job${openJobs === 1 ? "" : "s"} available; start with a dry run.`;
+  return "No claimable Wikipedia citation-repair jobs are open right now.";
+}
+
+function safeWorkBlockers(walletReady: boolean, todayUsdRemaining: number, openJobs: number): string[] {
+  const blockers: string[] = [];
+  if (!walletReady) blockers.push("wallet_not_ready");
+  if (todayUsdRemaining <= 0) blockers.push("budget_depleted");
+  if (openJobs < 1) blockers.push("no_claimable_wikipedia_citation_repair_jobs");
+  return blockers;
 }
 
 function errorMessage(error: unknown): string {

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -103,6 +103,46 @@ export function formatOperatorResultForSlack(result: unknown): string {
       detailed ? `• source: \`${stringField(status, "source") ?? "n/a"}\`` : "Use `status last wikipedia citation repair details` for full IDs.",
     ].join("\n");
   }
+  if (result.kind === "daily_operator_brief") {
+    const brief = isRecord(result.brief) ? result.brief : {};
+    const readiness = isRecord(brief.readiness) ? brief.readiness : {};
+    const budget = isRecord(brief.budget) ? brief.budget : {};
+    const latestRun = isRecord(brief.latestWikipediaCitationRepair) ? brief.latestWikipediaCitationRepair : {};
+    const candidateJobs = Array.isArray(brief.candidateJobs) ? brief.candidateJobs : [];
+    const actions = Array.isArray(brief.recommendedNextActions)
+      ? brief.recommendedNextActions.slice(0, 4).map((entry) => `• ${String(entry)}`).join("\n")
+      : "";
+    return [
+      "*Daily Averray operator brief*",
+      stringField(brief, "headline") ?? "No headline available.",
+      "",
+      "*Readiness*",
+      `• wallet: \`${stringField(readiness, "wallet") ?? "unknown"}\``,
+      `• budget remaining: \`${numberField(budget, "todayUsdRemaining") ?? "n/a"} / ${numberField(budget, "perDayUsdMax") ?? "n/a"} USD\``,
+      `• wikipedia repair: \`${stringField(readiness, "wikipediaCitationRepair") ?? "unknown"}\``,
+      "*Latest run*",
+      `• status: \`${stringField(latestRun, "status") ?? "none"}\``,
+      `• jobId: \`${formatId(stringField(latestRun, "jobId"), false) ?? "n/a"}\``,
+      candidateJobs.length > 0 ? `*Candidate jobs*\n${candidateJobs.slice(0, 3).map(formatCandidateJob).join("\n")}` : "",
+      actions ? `*Recommended next actions*\n${actions}` : "",
+      "This brief is read-only.",
+    ].filter(Boolean).join("\n");
+  }
+  if (result.kind === "find_safe_work") {
+    const safeWork = isRecord(result.safeWork) ? result.safeWork : {};
+    const items = Array.isArray(safeWork.safeWorkItems) ? safeWork.safeWorkItems : [];
+    const blockers = Array.isArray(safeWork.blockers) ? safeWork.blockers : [];
+    const itemLines = items.slice(0, 5).map(formatSafeWorkItem).join("\n");
+    return [
+      "*Safe work finder*",
+      `• available: \`${String(safeWork.available === true)}\``,
+      blockers.length > 0 ? `• blockers: \`${blockers.map(String).join(", ")}\`` : "",
+      `• recommended: \`${stringField(safeWork, "recommendedCommand") ?? "operator status"}\``,
+      stringField(safeWork, "nextMutationCommand") ? `• submit command: \`${stringField(safeWork, "nextMutationCommand")}\`` : "",
+      itemLines ? `*Work items*\n${itemLines}` : "No safe work items are currently available.",
+      "Discovery is read-only. Start with the dry-run command.",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "operator_status") {
     const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
@@ -202,6 +242,15 @@ function formatCandidateJob(value: unknown): string {
   const title = stringField(value, "title") ?? stringField(value, "pageTitle") ?? "untitled";
   const revisionId = stringField(value, "revisionId") ?? "n/a";
   return `• \`${jobId}\` - ${title} (rev ${revisionId})`;
+}
+
+function formatSafeWorkItem(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const job = isRecord(value.job) ? value.job : {};
+  const rank = numberField(value, "rank") ?? "?";
+  const jobId = formatId(stringField(job, "jobId"), true) ?? "unknown";
+  const dryRunCommand = stringField(value, "dryRunCommand") ?? "run one wikipedia citation repair dry run only";
+  return `• ${rank}. \`${jobId}\` - dry run: \`${dryRunCommand}\``;
 }
 
 function formatId(value: string | undefined, detailed: boolean): string | undefined {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -78,6 +78,27 @@ describe("operator commands", () => {
     });
   });
 
+  it("routes daily brief and safe work discovery read-only", () => {
+    expect(parseOperatorCommand("daily operator brief", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "daily_operator_brief",
+      source: "slack",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("find safe work details", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "find_safe_work",
+      source: "command_center",
+      detailed: true,
+    });
+    expect(parseOperatorCommand("what should I do next?", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "find_safe_work",
+      source: "operator",
+      detailed: false,
+    });
+  });
+
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {
     const status = await getLastWikipediaCitationRepairStatus(async (text) => {
       if (text.includes("from submissions")) {

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getOperatorStatus } from "../../packages/averray-mcp/src/operator-status.js";
+import {
+  getDailyOperatorBrief,
+  getOperatorStatus,
+  getSafeWorkReport,
+} from "../../packages/averray-mcp/src/operator-status.js";
 
 describe("operator status", () => {
   it("returns a canonical read-only status for agents and UIs", async () => {
@@ -143,5 +147,65 @@ describe("operator status", () => {
       expect.stringContaining("budget_query_failed"),
       expect.stringContaining("latest_run_failed"),
     ]));
+  });
+
+  it("returns daily brief and safe work views without mutating", async () => {
+    const deps = {
+      now: new Date("2026-05-03T12:00:00.000Z"),
+      policyConfig: {
+        budget: { per_run_usd_max: 0.5, per_day_usd_max: 1, max_browser_steps: 80 },
+      },
+      async query(text: string) {
+        if (text.includes("from budgets")) return [{ usd_spent: "0" }];
+        if (text.includes("from submissions")) return [];
+        if (text.includes("from draft_submissions")) return [];
+        return [];
+      },
+      workflowDeps: {
+        async walletStatus() {
+          return { configured: true, address: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05" };
+        },
+        async listJobs() {
+          return [
+            {
+              jobId: "wiki-en-58158792-citation-repair-r8",
+              definition: {
+                source: { type: "wikipedia_article", taskType: "citation_repair", pageTitle: "(+ +)", revisionId: "1351905437" },
+                publicDetails: { title: "Wikipedia citation repair: (+ +)" },
+                state: "open",
+                claimStatus: { claimable: true },
+              },
+            },
+          ];
+        },
+      },
+    };
+
+    const brief = await getDailyOperatorBrief(deps);
+    expect(brief).toMatchObject({
+      kind: "daily_operator_brief",
+      mutates: false,
+      readiness: {
+        wallet: "ready",
+        budget: "ready",
+        wikipediaCitationRepair: "ready",
+      },
+      openWikipediaCitationRepairJobs: 1,
+    });
+    expect(brief.suggestedCommands).toContain("find safe work");
+
+    const safeWork = await getSafeWorkReport(deps);
+    expect(safeWork).toMatchObject({
+      kind: "find_safe_work",
+      mutates: false,
+      available: true,
+      blockers: [],
+      recommendedCommand: "run one wikipedia citation repair dry run only",
+    });
+    expect(safeWork.safeWorkItems[0]).toMatchObject({
+      workflow: "wikipedia_citation_repair",
+      dryRunCommand: "run wikipedia citation repair for wiki-en-58158792-citation-repair-r8 if safe, dry run only",
+      mutates: false,
+    });
   });
 });

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -234,6 +234,68 @@ describe("slack operator bridge", () => {
     expect(text).toContain("*Open jobs*");
   });
 
+  it("formats daily operator brief replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "daily_operator_brief",
+      brief: {
+        headline: "2 Wikipedia citation-repair jobs available; start with a dry run.",
+        readiness: {
+          wallet: "ready",
+          wikipediaCitationRepair: "ready",
+        },
+        budget: {
+          todayUsdRemaining: 1,
+          perDayUsdMax: 1,
+        },
+        latestWikipediaCitationRepair: {
+          status: "submitted",
+          jobId: "wiki-en-58158792-citation-repair-r7",
+        },
+        candidateJobs: [
+          {
+            jobId: "wiki-en-58158792-citation-repair-r8",
+            title: "Wikipedia citation repair: (+ +)",
+            revisionId: "1351905437",
+          },
+        ],
+        recommendedNextActions: ["Use: run one wikipedia citation repair dry run only"],
+      },
+    });
+
+    expect(text).toContain("*Daily Averray operator brief*");
+    expect(text).toContain("wallet: `ready`");
+    expect(text).toContain("budget remaining: `1 / 1 USD`");
+    expect(text).toContain("wiki-en-58158792-citation-repair-r8");
+    expect(text).toContain("This brief is read-only.");
+  });
+
+  it("formats safe work discovery replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "find_safe_work",
+      safeWork: {
+        available: true,
+        blockers: [],
+        recommendedCommand: "run one wikipedia citation repair dry run only",
+        nextMutationCommand: "run one wikipedia citation repair if safe",
+        safeWorkItems: [
+          {
+            rank: 1,
+            job: { jobId: "wiki-en-58158792-citation-repair-r8" },
+            dryRunCommand: "run wikipedia citation repair for wiki-en-58158792-citation-repair-r8 if safe, dry run only",
+          },
+        ],
+      },
+    });
+
+    expect(text).toContain("*Safe work finder*");
+    expect(text).toContain("available: `true`");
+    expect(text).toContain("recommended: `run one wikipedia citation repair dry run only`");
+    expect(text).toContain("submit command: `run one wikipedia citation repair if safe`");
+    expect(text).toContain("Discovery is read-only.");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## Summary
- add read-only MCP tools for daily operator briefs and safe-work discovery
- route short operator and Slack commands such as daily operator brief and find safe work through structured handlers
- add Slack formatting and docs for the new human-friendly commands

## Checks
- npm run typecheck
- npm test -- operator-commands operator-status slack-operator
- npm test

## Impact
- Backend/MCP: yes
- Slack operator: yes
- Command center/frontend: no direct UI changes, but new commands render there through MCP
- Caddy/contracts/indexer/public site: no

## Env/VPS
- No new environment variables required.