### PR TITLE
Add cross-surface agent usefulness tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,18 +132,25 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   [docs/COMMAND_CENTER_PUBLIC_ACCESS.md](docs/COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `daily operator brief`, `find safe work`, `operator status`,
-  `operator status details`,
-  `run one wikipedia citation repair if safe`, and
-  `status last wikipedia citation repair`. `daily operator brief` and
-  `find safe work` are read-only summaries that turn the current wallet,
-  budget, latest-run, and open-job state into practical next actions for any
-  MCP client, not just Slack or Hermes Workspace. `operator status` calls the
-  canonical read-only `averray_operator_status` MCP tool and returns wallet,
-  budget, open-job, latest-run, safety, and safe-command metadata. Human
-  surfaces can show compact identifiers by default while keeping full
-  identifiers in the structured MCP JSON; add `details`, `full`, or `audit` to
-  a status command when an operator needs the full run/session/draft audit
-  trail. Repair commands call the Wikipedia workflow tool directly; latest-run
-  status returns the current run/session/draft/submit state, including
-  persisted Slack context when available, without mutating anything.
+  recognizes `what can you do for us`, `business ledger`, `ops health`,
+  `daily operator brief`, `find safe work`, `operator status`,
+  `operator status details`, `run one wikipedia citation repair if safe`, and
+  `status last wikipedia citation repair`. `what can you do for us` calls the
+  read-only `averray_agent_usefulness_plan` MCP tool and explains the useful
+  surfaces and use cases across Slack, Command Center/mobile, MCP clients,
+  GitHub-helper planning, ops care, Averray business tracking, and durable
+  memory. `business ledger` calls `averray_business_ledger` for recent
+  submissions, drafts, operator commands, budget, and open work. `ops health`
+  calls `averray_ops_health` for wallet/budget readiness, latest-run state, and
+  Postgres control-plane counts. `daily operator brief` and `find safe work`
+  are read-only summaries that turn the current wallet, budget, latest-run, and
+  open-job state into practical next actions for any MCP client, not just Slack
+  or Hermes Workspace. `operator status` calls the canonical read-only
+  `averray_operator_status` MCP tool and returns wallet, budget, open-job,
+  latest-run, safety, and safe-command metadata. Human surfaces can show
+  compact identifiers by default while keeping full identifiers in the
+  structured MCP JSON; add `details`, `full`, or `audit` to a status command
+  when an operator needs the full run/session/draft audit trail. Repair
+  commands call the Wikipedia workflow tool directly; latest-run status returns
+  the current run/session/draft/submit state, including persisted Slack context
+  when available, without mutating anything.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -159,6 +159,9 @@ commands are:
 
 ```text
 daily operator brief
+what can you do for us
+business ledger
+ops health
 find safe work
 operator status
 operator status details
@@ -168,13 +171,20 @@ status last wikipedia citation repair
 status last wikipedia citation repair details
 ```
 
-`averray_handle_operator_command` parses those messages. `daily operator brief`
-and `find safe work` are read-only views for humans and agents: they summarize
+`averray_handle_operator_command` parses those messages. `what can you do for
+us` calls `averray_agent_usefulness_plan`, a read-only cross-surface plan for
+Slack, Command Center/mobile, MCP clients, future GitHub helper work, ops care,
+Averray business tracking, and durable memory. `business ledger` calls
+`averray_business_ledger` for recent submissions, drafts, operator commands,
+budget, and open work. `ops health` calls `averray_ops_health` for
+wallet/budget readiness, latest-run state, recent operator events, recent
+failures, and Postgres control-plane counts. `daily operator brief` and
+`find safe work` are read-only views for humans and agents: they summarize
 wallet/budget readiness, latest run state, candidate jobs, blockers, and the
 next dry-run or guarded mutation command. `operator status` calls the canonical
-read-only `averray_operator_status` MCP tool, returning wallet readiness, policy
-budget, open Wikipedia job counts, latest run state, safety guarantees, and safe
-command suggestions as structured JSON. Repair commands call
+read-only `averray_operator_status` MCP tool, returning wallet readiness,
+policy budget, open Wikipedia job counts, latest run state, safety guarantees,
+and safe command suggestions as structured JSON. Repair commands call
 `averray_run_wikipedia_citation_repair` directly with the workflow's wallet,
 policy, draft, validation, submit, and Slack alert gates.
 Latest-run status commands are read-only and return the latest `runId`,

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -41,7 +41,9 @@ import {
   getLastWikipediaCitationRepairStatus,
 } from "./operator-commands.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
+import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -157,8 +159,35 @@ server.tool(
 );
 
 server.tool(
+  "averray_agent_usefulness_plan",
+  "Canonical read-only usefulness plan for humans, Slack, Command Center, mobile surfaces, and other agents. Returns what the agent can do now, which surfaces can use it, useful commands, safety guarantees, and next integration tracks. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getAgentUsefulnessPlan({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
+  "averray_business_ledger",
+  "Canonical read-only Averray business ledger for humans, Slack, Command Center, and other agents. Summarizes recent Wikipedia citation-repair submissions, drafts, operator commands, latest run, open jobs, and budget. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getBusinessLedger({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
+  "averray_ops_health",
+  "Canonical read-only operator health snapshot for humans, Slack, Command Center, and other agents. Summarizes wallet/budget readiness, latest run state, control-plane table counts, recent operator events, and recent failures. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getOpsHealth({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'business ledger', 'ops health', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/ledger/health commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -34,6 +34,24 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "agent_usefulness_plan";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
+      handled: true;
+      kind: "business_ledger";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
+      handled: true;
+      kind: "ops_health";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -65,6 +83,9 @@ export interface LastWikipediaCitationRepairStatus {
 
 const EXAMPLES = [
   "daily operator brief",
+  "what can you do for us",
+  "business ledger",
+  "ops health",
   "find safe work",
   "operator status",
   "operator status details",
@@ -94,6 +115,18 @@ export function parseOperatorCommand(
 
   if (isFindSafeWorkCommand(normalizedText)) {
     return { handled: true, kind: "find_safe_work", source, detailed };
+  }
+
+  if (isAgentUsefulnessPlanCommand(normalizedText)) {
+    return { handled: true, kind: "agent_usefulness_plan", source, detailed };
+  }
+
+  if (isBusinessLedgerCommand(normalizedText)) {
+    return { handled: true, kind: "business_ledger", source, detailed };
+  }
+
+  if (isOpsHealthCommand(normalizedText)) {
+    return { handled: true, kind: "ops_health", source, detailed };
   }
 
   if (isLatestWikipediaCitationRepairStatusCommand(normalizedText)) {
@@ -243,7 +276,19 @@ function isDailyOperatorBriefCommand(text: string): boolean {
 }
 
 function isFindSafeWorkCommand(text: string): boolean {
-  return /^(find safe work|safe work|next safe work|find work|what should i do next|what can you do|operator todo)( details?| full| audit)?$/.test(text);
+  return /^(find safe work|safe work|next safe work|find work|what should i do next|operator todo)( details?| full| audit)?$/.test(text);
+}
+
+function isAgentUsefulnessPlanCommand(text: string): boolean {
+  return /^(what can you do|what can you do for us|how can you help|how can you work for us|work for us|agent usefulness|agent usefulness plan|agent plan|usefulness plan|show use cases|show agent use cases)( details?| full| audit)?$/.test(text);
+}
+
+function isBusinessLedgerCommand(text: string): boolean {
+  return /^(business ledger|averray business ledger|business status|business report|work ledger|reward ledger|run ledger)( details?| full| audit)?$/.test(text);
+}
+
+function isOpsHealthCommand(text: string): boolean {
+  return /^(ops health|operator health|agent health|stack health|health check|control plane health|mcp health)( details?| full| audit)?$/.test(text);
 }
 
 function wantsDetailedOutput(text: string): boolean {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -5,7 +5,9 @@ import {
   type OperatorCommandSource,
   type OperatorQueryFn,
 } from "./operator-commands.js";
+import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 
 export interface HandleOperatorCommandInput {
@@ -48,6 +50,18 @@ export async function handleOperatorCommandText(
   if (command.kind === "find_safe_work") {
     const safeWork = await getSafeWorkReport({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, safeWork };
+  }
+  if (command.kind === "agent_usefulness_plan") {
+    const plan = await getAgentUsefulnessPlan({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, plan };
+  }
+  if (command.kind === "business_ledger") {
+    const ledger = await getBusinessLedger({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, ledger };
+  }
+  if (command.kind === "ops_health") {
+    const health = await getOpsHealth({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, health };
   }
   const result = await runWikipediaCitationRepairWorkflow(
     { ...command.input, expectedWallet: input.expectedWallet },

--- a/packages/averray-mcp/src/operator-insights.ts
+++ b/packages/averray-mcp/src/operator-insights.ts
@@ -1,0 +1,259 @@
+import type { LastWikipediaCitationRepairStatus } from "./operator-commands.js";
+import { getLastWikipediaCitationRepairStatus } from "./operator-commands.js";
+import type { OperatorStatusDeps } from "./operator-status.js";
+import { getOperatorStatus } from "./operator-status.js";
+
+export async function getBusinessLedger(deps: OperatorStatusDeps) {
+  const [status, latestRun, submitStats, draftStats, operatorStats] = await Promise.all([
+    getOperatorStatus(deps),
+    getLastWikipediaCitationRepairStatus(deps.query).catch(() => {
+      return { found: false, source: "none", submitSucceeded: false, slackPermalink: null } satisfies LastWikipediaCitationRepairStatus;
+    }),
+    querySubmitStats(deps),
+    queryDraftStats(deps),
+    queryOperatorStats(deps),
+  ]);
+  const wikipedia = status.workflows.wikipediaCitationRepair;
+  return {
+    schemaVersion: 1,
+    kind: "business_ledger",
+    generatedAt: status.generatedAt,
+    mutates: false,
+    summary: {
+      latestWikipediaCitationRepair: latestRun,
+      openWikipediaCitationRepairJobs: wikipedia.openJobs,
+      discoveredWikipediaCitationRepairJobs: wikipedia.discoveredJobs,
+      budget: status.policy.budget,
+      sevenDaySubmissions: submitStats,
+      sevenDayDrafts: draftStats,
+      sevenDayOperatorCommands: operatorStats,
+    },
+    recommendedNextActions: status.recommendedNextActions,
+    safety: {
+      mutatesByDefault: false,
+      source: "postgres_read_only",
+      editsWikipedia: false,
+    },
+  };
+}
+
+export async function getOpsHealth(deps: OperatorStatusDeps) {
+  const [status, tableStats, recentOperatorEvents, latestErrors] = await Promise.all([
+    getOperatorStatus(deps),
+    queryTableStats(deps),
+    queryRecentOperatorEvents(deps),
+    queryRecentErrors(deps),
+  ]);
+  const health = healthFromStatus(status, tableStats, latestErrors);
+  return {
+    schemaVersion: 1,
+    kind: "ops_health",
+    generatedAt: status.generatedAt,
+    mutates: false,
+    health,
+    wallet: status.agent,
+    budget: status.policy.budget,
+    wikipediaCitationRepair: {
+      ready: status.workflows.wikipediaCitationRepair.ready,
+      openJobs: status.workflows.wikipediaCitationRepair.openJobs,
+      latestRun: status.workflows.wikipediaCitationRepair.latestRun,
+    },
+    controlPlane: {
+      tables: tableStats,
+      recentOperatorEvents,
+      recentErrors: latestErrors,
+      note: "This is database/control-plane health. Container disk, SQLite WAL files, and raw MCP stderr logs require a host-level ops check.",
+    },
+    recommendedNextActions: opsNextActions(health, status.errors ?? []),
+    safety: {
+      mutatesByDefault: false,
+      source: "postgres_read_only",
+      editsWikipedia: false,
+    },
+  };
+}
+
+async function querySubmitStats(deps: OperatorStatusDeps) {
+  const rows = await deps.query<CountStatsRow>(
+    `select
+       count(*)::int as total,
+       count(*) filter (where status = 'completed')::int as completed,
+       count(*) filter (where status = 'failed')::int as failed,
+       count(*) filter (where status not in ('completed', 'failed'))::int as other
+     from submissions
+     where kind = 'submit'
+       and coalesce(request->>'jobId', '') like 'wiki-en-%citation-repair%'
+       and updated_at >= now() - interval '7 days'`
+  ).catch(() => []);
+  return countStats(rows[0]);
+}
+
+async function queryDraftStats(deps: OperatorStatusDeps) {
+  const rows = await deps.query<CountStatsRow>(
+    `select
+       count(*)::int as total,
+       count(*) filter (where validation_status = 'valid')::int as completed,
+       count(*) filter (where validation_status = 'invalid')::int as failed,
+       count(*) filter (where validation_status = 'unvalidated')::int as other
+     from draft_submissions
+     where job_id like 'wiki-en-%citation-repair%'
+       and updated_at >= now() - interval '7 days'`
+  ).catch(() => []);
+  return {
+    total: numberField(rows[0], "total"),
+    valid: numberField(rows[0], "completed"),
+    invalid: numberField(rows[0], "failed"),
+    unvalidated: numberField(rows[0], "other"),
+  };
+}
+
+async function queryOperatorStats(deps: OperatorStatusDeps) {
+  const rows = await deps.query<CountStatsRow>(
+    `select
+       count(*)::int as total,
+       count(*) filter (where source like 'slack%')::int as completed,
+       count(*) filter (where status = 'failed')::int as failed,
+       count(distinct normalized_text)::int as other
+     from operator_command_events
+     where updated_at >= now() - interval '7 days'`
+  ).catch(() => []);
+  return {
+    total: numberField(rows[0], "total"),
+    slackRouted: numberField(rows[0], "completed"),
+    failed: numberField(rows[0], "failed"),
+    distinctCommands: numberField(rows[0], "other"),
+  };
+}
+
+async function queryTableStats(deps: OperatorStatusDeps) {
+  const rows = await deps.query<TableStatsRow>(
+    `select
+       (select count(*)::int from runs) as runs,
+       (select count(*)::int from submissions) as submissions,
+       (select count(*)::int from draft_submissions) as drafts,
+       (select count(*)::int from operator_command_events) as operator_events,
+       (select count(*)::int from budgets) as budgets,
+       (select max(updated_at) from operator_command_events) as last_operator_event_at,
+       (select max(updated_at) from submissions) as last_submission_at`
+  ).catch(() => []);
+  const row = rows[0] ?? {};
+  return {
+    runs: numberField(row, "runs"),
+    submissions: numberField(row, "submissions"),
+    drafts: numberField(row, "drafts"),
+    operatorEvents: numberField(row, "operator_events"),
+    budgets: numberField(row, "budgets"),
+    lastOperatorEventAt: dateString(row.last_operator_event_at),
+    lastSubmissionAt: dateString(row.last_submission_at),
+  };
+}
+
+async function queryRecentOperatorEvents(deps: OperatorStatusDeps) {
+  const rows = await deps.query<OperatorEventRow>(
+    `select normalized_text, source, status, updated_at
+     from operator_command_events
+     order by updated_at desc
+     limit 5`
+  ).catch(() => []);
+  return rows.map((row) => ({
+    command: stringField(row, "normalized_text"),
+    source: stringField(row, "source"),
+    status: stringField(row, "status"),
+    updatedAt: dateString(row.updated_at),
+  }));
+}
+
+async function queryRecentErrors(deps: OperatorStatusDeps) {
+  const rows = await deps.query<OperatorEventRow>(
+    `select normalized_text, source, status, updated_at
+     from operator_command_events
+     where status = 'failed'
+     order by updated_at desc
+     limit 3`
+  ).catch(() => []);
+  return rows.map((row) => ({
+    command: stringField(row, "normalized_text"),
+    source: stringField(row, "source"),
+    status: stringField(row, "status"),
+    updatedAt: dateString(row.updated_at),
+  }));
+}
+
+function healthFromStatus(
+  status: Awaited<ReturnType<typeof getOperatorStatus>>,
+  tableStats: Awaited<ReturnType<typeof queryTableStats>>,
+  latestErrors: Awaited<ReturnType<typeof queryRecentErrors>>
+) {
+  const errors = status.errors ?? [];
+  if (!status.agent.walletReady) return "blocked";
+  if (errors.length > 0 || latestErrors.length > 0) return "degraded";
+  if (tableStats.operatorEvents === 0 && tableStats.submissions === 0) return "quiet";
+  return "ready";
+}
+
+function opsNextActions(health: string, errors: string[]) {
+  if (health === "blocked") return ["Fix wallet readiness before allowing mutation workflows."];
+  if (health === "degraded") return [
+    "Inspect recent operator errors and MCP/server logs.",
+    ...errors.map((error) => `Status error: ${error}`),
+  ];
+  return [
+    "Keep daily brief and safe-work scans enabled.",
+    "Run a host-level ops check periodically for disk, logs, and SQLite WAL housekeeping.",
+  ];
+}
+
+function countStats(row: CountStatsRow | undefined) {
+  return {
+    total: numberField(row, "total"),
+    completed: numberField(row, "completed"),
+    failed: numberField(row, "failed"),
+    other: numberField(row, "other"),
+  };
+}
+
+interface CountStatsRow {
+  total?: number | string;
+  completed?: number | string;
+  failed?: number | string;
+  other?: number | string;
+}
+
+interface TableStatsRow {
+  runs?: number | string;
+  submissions?: number | string;
+  drafts?: number | string;
+  operator_events?: number | string;
+  budgets?: number | string;
+  last_operator_event_at?: string | Date;
+  last_submission_at?: string | Date;
+}
+
+interface OperatorEventRow {
+  normalized_text?: string;
+  source?: string;
+  status?: string;
+  updated_at?: string | Date;
+}
+
+function numberField(value: unknown, key: string): number {
+  const record = toRecord(value);
+  const raw = record[key];
+  const parsed = typeof raw === "number" ? raw : Number.parseInt(String(raw ?? "0"), 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const record = toRecord(value);
+  const field = record[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function dateString(value: unknown): string | undefined {
+  if (value instanceof Date) return value.toISOString();
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}

--- a/packages/averray-mcp/src/operator-usefulness.ts
+++ b/packages/averray-mcp/src/operator-usefulness.ts
@@ -1,0 +1,127 @@
+import { optionalEnv } from "@avg/mcp-common";
+import type { OperatorStatusDeps } from "./operator-status.js";
+import { getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+
+export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
+  const [status, safeWork] = await Promise.all([
+    getOperatorStatus(deps),
+    getSafeWorkReport(deps),
+  ]);
+  const wikipedia = status.workflows.wikipediaCitationRepair;
+  const latestRun = wikipedia.latestRun;
+  const slackEnabled = optionalEnv("SLACK_OPERATOR_ENABLED", "0") === "1";
+  const dailyRoutineEnabled = optionalEnv("SLACK_OPERATOR_DAILY_BRIEF_ENABLED", "0") === "1";
+  const safeWorkScanEnabled = Number.parseFloat(optionalEnv("SLACK_OPERATOR_SAFE_WORK_SCAN_INTERVAL_MINUTES", "0")) > 0;
+  const commandCenterEnabled = Boolean(optionalEnv("HERMES_WORKSPACE_IMAGE"));
+  const publicAccessEnabled = Boolean(optionalEnv("CLOUDFLARED_TUNNEL_TOKEN"));
+
+  return {
+    schemaVersion: 1,
+    kind: "agent_usefulness_plan",
+    generatedAt: status.generatedAt,
+    mutates: false,
+    headline: safeWork.available
+      ? "I can already watch for safe Averray work, brief you, and run guarded Wikipedia citation-repair workflows."
+      : "I can already brief, inspect, and explain status; guarded work starts when wallet, budget, and job inventory are ready.",
+    immediate: {
+      safeWorkAvailable: safeWork.available,
+      blockers: safeWork.blockers,
+      recommendedCommand: safeWork.recommendedCommand,
+      nextMutationCommand: safeWork.nextMutationCommand,
+      openWikipediaCitationRepairJobs: wikipedia.openJobs,
+      latestWikipediaCitationRepair: latestRun,
+    },
+    surfaces: {
+      slack: {
+        status: slackEnabled ? "enabled" : "available",
+        use: "Durable operator channel for briefings, alerts, status, and guarded workflow commands.",
+        commands: [
+          "brief me",
+          "what can you do for us",
+          "what should i do next",
+          "run one wikipedia citation repair dry run only",
+          "run one wikipedia citation repair if safe",
+        ],
+        routines: {
+          dailyBrief: dailyRoutineEnabled ? "enabled" : "off",
+          safeWorkScan: safeWorkScanEnabled ? "enabled" : "off",
+        },
+      },
+      commandCenter: {
+        status: commandCenterEnabled ? "enabled" : "available",
+        publicAccess: publicAccessEnabled ? "cloudflare_access_configured" : "private_or_tunnel_only",
+        use: "Interactive inspection, dry-run preview, and controlled execution from desktop or phone browser.",
+        commands: [
+          "operator status",
+          "daily operator brief",
+          "what can you do for us",
+          "find safe work",
+        ],
+      },
+      mcp: {
+        status: "enabled",
+        use: "Canonical structured contract any compatible agent can call without learning Slack or Workspace.",
+        tools: [
+          "averray_agent_usefulness_plan",
+          "averray_business_ledger",
+          "averray_ops_health",
+          "averray_operator_status",
+          "averray_daily_operator_brief",
+          "averray_find_safe_work",
+          "averray_run_wikipedia_citation_repair",
+        ],
+      },
+    },
+    useCases: [
+      {
+        id: "slack_work_assistant",
+        status: slackEnabled ? "enabled" : "available",
+        value: "Posts compact operator answers where we already coordinate; routines can brief and watch for safe work.",
+        commands: ["brief me", "what should i do next", "status last wikipedia citation repair"],
+      },
+      {
+        id: "mobile_agent",
+        status: publicAccessEnabled || slackEnabled ? "enabled" : "available",
+        value: "Phone access through Slack or Cloudflare-protected Command Center, with short commands instead of terminal prompts.",
+        commands: ["operator status", "find safe work", "run one wikipedia citation repair dry run only"],
+      },
+      {
+        id: "github_helper",
+        status: "next_integration",
+        value: "Useful next track: watch PR/issue comments, summarize CI failures, and draft replies from GitHub context.",
+        nextStep: "Add a read-only GitHub digest command before allowing any write actions.",
+      },
+      {
+        id: "ops_caretaker",
+        status: "enabled",
+        value: "Can report wallet, budget, latest-run, recent command, and control-plane database health; host disk/log/WAL checks remain a VPS ops-script track.",
+        commands: ["ops health", "operator status", "daily operator brief"],
+      },
+      {
+        id: "averray_business_agent",
+        status: "enabled",
+        value: "Tracks latest run, available jobs, budget, seven-day submissions/drafts, and can recommend when to dry-run or submit.",
+        commands: ["business ledger", "status last wikipedia citation repair", "find safe work"],
+      },
+      {
+        id: "knowledge_memory",
+        status: "partially_enabled",
+        value: "Keeps durable operator events in Postgres; next track is a human-readable runbook/memory export for setup decisions and commands.",
+        commands: ["operator status details", "status last wikipedia citation repair details"],
+      },
+    ],
+    nextImplementationTracks: [
+      "GitHub PR/issue digest and CI failure explainer",
+      "Host-level ops routine for disk/log/WAL checks and stale sessions",
+      "Reward ledger with chain/accounting reconciliation once payout data is exposed",
+      "Portable command schema so Slack, Command Center, mobile, and future agents share the same intents",
+    ],
+    safety: {
+      mutatesByDefault: false,
+      readOnlyCommands: ["what can you do for us", "brief me", "operator status", "find safe work"],
+      mutationRequiresExplicitCommand: true,
+      validatesBeforeSubmit: true,
+      editsWikipedia: false,
+    },
+  };
+}

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -143,6 +143,83 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Discovery is read-only. Start with the dry-run command.",
     ].filter(Boolean).join("\n");
   }
+  if (result.kind === "agent_usefulness_plan") {
+    const plan = isRecord(result.plan) ? result.plan : {};
+    const immediate = isRecord(plan.immediate) ? plan.immediate : {};
+    const surfaces = isRecord(plan.surfaces) ? plan.surfaces : {};
+    const slack = isRecord(surfaces.slack) ? surfaces.slack : {};
+    const commandCenter = isRecord(surfaces.commandCenter) ? surfaces.commandCenter : {};
+    const mcp = isRecord(surfaces.mcp) ? surfaces.mcp : {};
+    const useCases = Array.isArray(plan.useCases) ? plan.useCases : [];
+    const tracks = Array.isArray(plan.nextImplementationTracks) ? plan.nextImplementationTracks : [];
+    const useCaseLines = useCases.slice(0, 6).map(formatUseCase).join("\n");
+    const trackLines = tracks.slice(0, 4).map((entry) => `• ${String(entry)}`).join("\n");
+    return [
+      "*Averray agent usefulness plan*",
+      stringField(plan, "headline") ?? "I can help through Slack, Command Center, and MCP tools.",
+      "",
+      "*Right now*",
+      `• safe work: \`${String(immediate.safeWorkAvailable === true)}\``,
+      `• recommended: \`${stringField(immediate, "recommendedCommand") ?? "operator status"}\``,
+      stringField(immediate, "nextMutationCommand") ? `• guarded mutation: \`${stringField(immediate, "nextMutationCommand")}\`` : "",
+      "*Surfaces*",
+      `• Slack: \`${stringField(slack, "status") ?? "unknown"}\``,
+      `• Command Center/mobile: \`${stringField(commandCenter, "status") ?? "unknown"}\` (${stringField(commandCenter, "publicAccess") ?? "unknown"})`,
+      `• MCP: \`${stringField(mcp, "status") ?? "unknown"}\``,
+      useCaseLines ? `*Use cases*\n${useCaseLines}` : "",
+      trackLines ? `*Next tracks*\n${trackLines}` : "",
+      "Read-only plan. Use `what can you do for us details` in MCP/Workspace for the full structured JSON.",
+    ].filter(Boolean).join("\n");
+  }
+  if (result.kind === "business_ledger") {
+    const ledger = isRecord(result.ledger) ? result.ledger : {};
+    const summary = isRecord(ledger.summary) ? ledger.summary : {};
+    const latestRun = isRecord(summary.latestWikipediaCitationRepair) ? summary.latestWikipediaCitationRepair : {};
+    const budget = isRecord(summary.budget) ? summary.budget : {};
+    const submissions = isRecord(summary.sevenDaySubmissions) ? summary.sevenDaySubmissions : {};
+    const drafts = isRecord(summary.sevenDayDrafts) ? summary.sevenDayDrafts : {};
+    const commands = isRecord(summary.sevenDayOperatorCommands) ? summary.sevenDayOperatorCommands : {};
+    return [
+      "*Averray business ledger*",
+      "*Latest Wikipedia repair*",
+      `• status: \`${stringField(latestRun, "status") ?? "none"}\``,
+      `• jobId: \`${formatId(stringField(latestRun, "jobId"), false) ?? "n/a"}\``,
+      `• submittedAt: \`${stringField(latestRun, "submittedAt") ?? "n/a"}\``,
+      "*7-day work*",
+      `• submissions: \`${numberField(submissions, "completed") ?? 0} completed / ${numberField(submissions, "failed") ?? 0} failed / ${numberField(submissions, "total") ?? 0} total\``,
+      `• drafts: \`${numberField(drafts, "valid") ?? 0} valid / ${numberField(drafts, "invalid") ?? 0} invalid / ${numberField(drafts, "total") ?? 0} total\``,
+      `• operator commands: \`${numberField(commands, "total") ?? 0} total (${numberField(commands, "slackRouted") ?? 0} via Slack)\``,
+      "*Today*",
+      `• budget: \`${numberField(budget, "todayUsdSpent") ?? "n/a"} / ${numberField(budget, "perDayUsdMax") ?? "n/a"} USD\``,
+      `• open wiki repair jobs: \`${numberField(summary, "openWikipediaCitationRepairJobs") ?? "n/a"}\``,
+      "Read-only ledger.",
+    ].join("\n");
+  }
+  if (result.kind === "ops_health") {
+    const ops = isRecord(result.health) ? result.health : {};
+    const wallet = isRecord(ops.wallet) ? ops.wallet : {};
+    const budget = isRecord(ops.budget) ? ops.budget : {};
+    const controlPlane = isRecord(ops.controlPlane) ? ops.controlPlane : {};
+    const tables = isRecord(controlPlane.tables) ? controlPlane.tables : {};
+    const recentErrors = Array.isArray(controlPlane.recentErrors) ? controlPlane.recentErrors : [];
+    const recentEvents = Array.isArray(controlPlane.recentOperatorEvents) ? controlPlane.recentOperatorEvents : [];
+    const errorLines = recentErrors.slice(0, 3).map(formatRecentEvent).join("\n");
+    const eventLines = recentEvents.slice(0, 3).map(formatRecentEvent).join("\n");
+    return [
+      "*Averray ops health*",
+      `• health: \`${stringField(ops, "health") ?? "unknown"}\``,
+      `• wallet: \`${wallet.walletReady === true ? "ready" : "not_ready"}\``,
+      `• budget remaining: \`${numberField(budget, "todayUsdRemaining") ?? "n/a"} USD\``,
+      "*Control plane*",
+      `• submissions: \`${numberField(tables, "submissions") ?? 0}\``,
+      `• drafts: \`${numberField(tables, "drafts") ?? 0}\``,
+      `• operator events: \`${numberField(tables, "operatorEvents") ?? 0}\``,
+      `• last operator event: \`${stringField(tables, "lastOperatorEventAt") ?? "n/a"}\``,
+      errorLines ? `*Recent errors*\n${errorLines}` : "*Recent errors*\n• none recorded",
+      eventLines ? `*Recent events*\n${eventLines}` : "",
+      "Read-only health. Host disk/log/WAL checks still need the VPS ops script.",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "operator_status") {
     const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
@@ -251,6 +328,22 @@ function formatSafeWorkItem(value: unknown): string {
   const jobId = formatId(stringField(job, "jobId"), true) ?? "unknown";
   const dryRunCommand = stringField(value, "dryRunCommand") ?? "run one wikipedia citation repair dry run only";
   return `• ${rank}. \`${jobId}\` - dry run: \`${dryRunCommand}\``;
+}
+
+function formatUseCase(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const id = stringField(value, "id") ?? "unknown";
+  const status = stringField(value, "status") ?? "unknown";
+  const summary = stringField(value, "value") ?? "";
+  return `• \`${id}\` - ${status}${summary ? `: ${summary}` : ""}`;
+}
+
+function formatRecentEvent(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const command = stringField(value, "command") ?? "unknown";
+  const source = stringField(value, "source") ?? "unknown";
+  const status = stringField(value, "status") ?? "n/a";
+  return `• \`${command}\` (${source}, ${status})`;
 }
 
 function formatId(value: string | undefined, detailed: boolean): string | undefined {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -97,6 +97,30 @@ describe("operator commands", () => {
       source: "operator",
       detailed: false,
     });
+    expect(parseOperatorCommand("what can you do for us?", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "agent_usefulness_plan",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("how can you help details", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "agent_usefulness_plan",
+      source: "command_center",
+      detailed: true,
+    });
+    expect(parseOperatorCommand("business ledger", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "business_ledger",
+      source: "slack",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("ops health details", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "ops_health",
+      source: "operator",
+      detailed: true,
+    });
   });
 
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -5,6 +5,8 @@ import {
   getOperatorStatus,
   getSafeWorkReport,
 } from "../../packages/averray-mcp/src/operator-status.js";
+import { getBusinessLedger, getOpsHealth } from "../../packages/averray-mcp/src/operator-insights.js";
+import { getAgentUsefulnessPlan } from "../../packages/averray-mcp/src/operator-usefulness.js";
 
 describe("operator status", () => {
   it("returns a canonical read-only status for agents and UIs", async () => {
@@ -206,6 +208,140 @@ describe("operator status", () => {
       workflow: "wikipedia_citation_repair",
       dryRunCommand: "run wikipedia citation repair for wiki-en-58158792-citation-repair-r8 if safe, dry run only",
       mutates: false,
+    });
+
+    const usefulness = await getAgentUsefulnessPlan(deps);
+    expect(usefulness).toMatchObject({
+      kind: "agent_usefulness_plan",
+      mutates: false,
+      immediate: {
+        safeWorkAvailable: true,
+        recommendedCommand: "run one wikipedia citation repair dry run only",
+      },
+      surfaces: {
+        mcp: {
+          status: "enabled",
+        },
+      },
+    });
+    expect(usefulness.useCases.map((entry) => entry.id)).toEqual(expect.arrayContaining([
+      "slack_work_assistant",
+      "mobile_agent",
+      "github_helper",
+      "ops_caretaker",
+      "averray_business_agent",
+      "knowledge_memory",
+    ]));
+    expect(usefulness.useCases.find((entry) => entry.id === "ops_caretaker")).toMatchObject({
+      status: "enabled",
+      commands: expect.arrayContaining(["ops health"]),
+    });
+    expect(usefulness.safety.mutatesByDefault).toBe(false);
+  });
+
+  it("returns read-only business ledger and ops health insights", async () => {
+    const deps = {
+      now: new Date("2026-05-03T12:00:00.000Z"),
+      policyConfig: {
+        budget: { per_run_usd_max: 0.5, per_day_usd_max: 1, max_browser_steps: 80 },
+      },
+      async query(text: string) {
+        if (text.includes("last_operator_event_at")) {
+          return [{
+            runs: 2,
+            submissions: 4,
+            drafts: 5,
+            operator_events: 8,
+            budgets: 1,
+            last_operator_event_at: "2026-05-03T11:50:00.000Z",
+            last_submission_at: "2026-05-03T11:43:23.872Z",
+          }];
+        }
+        if (text.includes("from budgets")) return [{ usd_spent: "0.10" }];
+        if (text.includes("from submissions") && text.includes("left join")) {
+          return [
+            {
+              request: {
+                policyRunId: "wikipedia-citation-repair-run-1",
+                jobId: "wiki-en-58158792-citation-repair-r7",
+                sessionId: "wiki-en-58158792-citation-repair-r7:0xWallet",
+                draftId: "draft-1",
+              },
+              response: { state: "submitted" },
+              status: "completed",
+              updated_at: "2026-05-03T11:43:23.872Z",
+              draft_validation_status: "valid",
+            },
+          ];
+        }
+        if (text.includes("from submissions") && text.includes("count(*)")) {
+          return [{ total: 4, completed: 3, failed: 1, other: 0 }];
+        }
+        if (text.includes("from draft_submissions") && text.includes("count(*)")) {
+          return [{ total: 5, completed: 4, failed: 1, other: 0 }];
+        }
+        if (text.includes("from operator_command_events") && text.includes("count(distinct normalized_text)")) {
+          return [{ total: 8, completed: 6, failed: 0, other: 4 }];
+        }
+        if (text.includes("where status = 'failed'")) return [];
+        if (text.includes("select normalized_text, source, status, updated_at")) {
+          return [
+            {
+              normalized_text: "status last wikipedia citation repair",
+              source: "slack",
+              status: "submitted",
+              updated_at: "2026-05-03T11:50:00.000Z",
+            },
+          ];
+        }
+        if (text.includes("from draft_submissions")) return [];
+        return [];
+      },
+      workflowDeps: {
+        async walletStatus() {
+          return { configured: true, address: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05" };
+        },
+        async listJobs() {
+          return [
+            {
+              jobId: "wiki-en-58158792-citation-repair-r8",
+              definition: {
+                source: { type: "wikipedia_article", taskType: "citation_repair", pageTitle: "(+ +)", revisionId: "1351905437" },
+                publicDetails: { title: "Wikipedia citation repair: (+ +)" },
+                state: "open",
+                claimStatus: { claimable: true },
+              },
+            },
+          ];
+        },
+      },
+    };
+
+    const ledger = await getBusinessLedger(deps);
+    expect(ledger).toMatchObject({
+      kind: "business_ledger",
+      mutates: false,
+      summary: {
+        openWikipediaCitationRepairJobs: 1,
+        sevenDaySubmissions: { total: 4, completed: 3, failed: 1 },
+        sevenDayDrafts: { total: 5, valid: 4, invalid: 1 },
+        sevenDayOperatorCommands: { total: 8, slackRouted: 6, distinctCommands: 4 },
+      },
+    });
+
+    const health = await getOpsHealth(deps);
+    expect(health).toMatchObject({
+      kind: "ops_health",
+      mutates: false,
+      health: "ready",
+      controlPlane: {
+        tables: {
+          submissions: 4,
+          drafts: 5,
+          operatorEvents: 8,
+        },
+        recentErrors: [],
+      },
     });
   });
 });

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -296,6 +296,88 @@ describe("slack operator bridge", () => {
     expect(text).toContain("Discovery is read-only.");
   });
 
+  it("formats agent usefulness replies across surfaces", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "agent_usefulness_plan",
+      plan: {
+        headline: "I can already brief, inspect, and run guarded work.",
+        immediate: {
+          safeWorkAvailable: true,
+          recommendedCommand: "run one wikipedia citation repair dry run only",
+          nextMutationCommand: "run one wikipedia citation repair if safe",
+        },
+        surfaces: {
+          slack: { status: "enabled" },
+          commandCenter: { status: "enabled", publicAccess: "cloudflare_access_configured" },
+          mcp: { status: "enabled" },
+        },
+        useCases: [
+          { id: "slack_work_assistant", status: "enabled", value: "Posts compact operator answers." },
+          { id: "github_helper", status: "next_integration", value: "Summarize CI and draft replies." },
+        ],
+        nextImplementationTracks: ["GitHub PR/issue digest and CI failure explainer"],
+      },
+    });
+
+    expect(text).toContain("*Averray agent usefulness plan*");
+    expect(text).toContain("safe work: `true`");
+    expect(text).toContain("Slack: `enabled`");
+    expect(text).toContain("Command Center/mobile: `enabled`");
+    expect(text).toContain("`slack_work_assistant`");
+    expect(text).toContain("GitHub PR/issue digest");
+  });
+
+  it("formats business ledger and ops health replies", () => {
+    const ledger = formatOperatorResultForSlack({
+      handled: true,
+      kind: "business_ledger",
+      ledger: {
+        summary: {
+          latestWikipediaCitationRepair: {
+            status: "submitted",
+            jobId: "wiki-en-58158792-citation-repair-r7",
+            submittedAt: "2026-05-03T11:43:23.872Z",
+          },
+          openWikipediaCitationRepairJobs: 2,
+          budget: { todayUsdSpent: 0.1, perDayUsdMax: 1 },
+          sevenDaySubmissions: { total: 4, completed: 3, failed: 1 },
+          sevenDayDrafts: { total: 5, valid: 4, invalid: 1 },
+          sevenDayOperatorCommands: { total: 8, slackRouted: 6 },
+        },
+      },
+    });
+    expect(ledger).toContain("*Averray business ledger*");
+    expect(ledger).toContain("3 completed / 1 failed / 4 total");
+    expect(ledger).toContain("open wiki repair jobs: `2`");
+
+    const health = formatOperatorResultForSlack({
+      handled: true,
+      kind: "ops_health",
+      health: {
+        health: "ready",
+        wallet: { walletReady: true },
+        budget: { todayUsdRemaining: 0.9 },
+        controlPlane: {
+          tables: {
+            submissions: 4,
+            drafts: 5,
+            operatorEvents: 8,
+            lastOperatorEventAt: "2026-05-03T11:50:00.000Z",
+          },
+          recentErrors: [],
+          recentOperatorEvents: [
+            { command: "status last wikipedia citation repair", source: "slack", status: "submitted" },
+          ],
+        },
+      },
+    });
+    expect(health).toContain("*Averray ops health*");
+    expect(health).toContain("health: `ready`");
+    expect(health).toContain("operator events: `8`");
+    expect(health).toContain("none recorded");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## What changed
- Added read-only MCP tools: `averray_agent_usefulness_plan`, `averray_business_ledger`, and `averray_ops_health`.
- Routed short operator commands like `what can you do for us`, `business ledger`, and `ops health` through the shared operator handler instead of free-form prompting.
- Added Slack formatting for the new replies, plus docs and unit coverage.

## Checks
- `npm run typecheck`
- `npm test -- test/unit/operator-commands.test.ts test/unit/operator-status.test.ts test/unit/slack-operator.test.ts`
- `npm test`

## Impact
- Affects Averray MCP tools, Slack operator formatting, docs, and tests.
- No indexer, Caddy, contracts, or public site changes.
- No new environment variables required.

## Safety
- New tools are read-only and explicitly report `mutates: false`.
- They do not claim, submit, edit Wikipedia, or request approval.