### PR TITLE
Add admin readiness operator plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,20 +132,23 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   [docs/COMMAND_CENTER_PUBLIC_ACCESS.md](docs/COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `what can you do for us`, `business ledger`, `ops health`,
-  `daily operator brief`, `find safe work`, `operator status`,
+  recognizes `what can you do for us`, `admin readiness`, `business ledger`,
+  `ops health`, `daily operator brief`, `find safe work`, `operator status`,
   `operator status details`, `run one wikipedia citation repair if safe`, and
   `status last wikipedia citation repair`. `what can you do for us` calls the
   read-only `averray_agent_usefulness_plan` MCP tool and explains the useful
   surfaces and use cases across Slack, Command Center/mobile, MCP clients,
   GitHub-helper planning, ops care, Averray business tracking, and durable
-  memory. `business ledger` calls `averray_business_ledger` for recent
-  submissions, drafts, operator commands, budget, and open work. `ops health`
-  calls `averray_ops_health` for wallet/budget readiness, latest-run state, and
-  Postgres control-plane counts. `daily operator brief` and `find safe work`
-  are read-only summaries that turn the current wallet, budget, latest-run, and
-  open-job state into practical next actions for any MCP client, not just Slack
-  or Hermes Workspace. `operator status` calls the canonical read-only
+  memory. `admin readiness` calls `averray_admin_readiness`, a read-only staged
+  plan for growing from operator copilot to approval-gated project admin without
+  granting broad mutation powers by default. `business ledger` calls
+  `averray_business_ledger` for recent submissions, drafts, operator commands,
+  budget, and open work. `ops health` calls `averray_ops_health` for
+  wallet/budget readiness, latest-run state, and Postgres control-plane counts.
+  `daily operator brief` and `find safe work` are read-only summaries that turn
+  the current wallet, budget, latest-run, and open-job state into practical next
+  actions for any MCP client, not just Slack or Hermes Workspace.
+  `operator status` calls the canonical read-only
   `averray_operator_status` MCP tool and returns wallet, budget, open-job,
   latest-run, safety, and safe-command metadata. Human surfaces can show
   compact identifiers by default while keeping full identifiers in the

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -160,6 +160,7 @@ commands are:
 ```text
 daily operator brief
 what can you do for us
+admin readiness
 business ledger
 ops health
 find safe work
@@ -174,11 +175,14 @@ status last wikipedia citation repair details
 `averray_handle_operator_command` parses those messages. `what can you do for
 us` calls `averray_agent_usefulness_plan`, a read-only cross-surface plan for
 Slack, Command Center/mobile, MCP clients, future GitHub helper work, ops care,
-Averray business tracking, and durable memory. `business ledger` calls
-`averray_business_ledger` for recent submissions, drafts, operator commands,
-budget, and open work. `ops health` calls `averray_ops_health` for
-wallet/budget readiness, latest-run state, recent operator events, recent
-failures, and Postgres control-plane counts. `daily operator brief` and
+Averray business tracking, and durable memory. `admin readiness` calls
+`averray_admin_readiness`, a read-only staged plan for growing from operator
+copilot to approval-gated project admin without granting broad mutation powers
+by default. `business ledger` calls `averray_business_ledger` for recent
+submissions, drafts, operator commands, budget, and open work. `ops health`
+calls `averray_ops_health` for wallet/budget readiness, latest-run state,
+recent operator events, recent failures, and Postgres control-plane counts.
+`daily operator brief` and
 `find safe work` are read-only views for humans and agents: they summarize
 wallet/budget readiness, latest run state, candidate jobs, blockers, and the
 next dry-run or guarded mutation command. `operator status` calls the canonical

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -41,6 +41,7 @@ import {
   getLastWikipediaCitationRepairStatus,
 } from "./operator-commands.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
+import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
@@ -168,6 +169,15 @@ server.tool(
 );
 
 server.tool(
+  "averray_admin_readiness",
+  "Canonical read-only admin-readiness plan for humans, Slack, Command Center, mobile surfaces, and other agents. Returns the current operator-copilot role, admin maturity ladder, guardrails, allowed/denied actions, and required controls before project-admin powers. Does not claim, submit, deploy, edit code, edit Wikipedia, request approval, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getAdminReadiness({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_business_ledger",
   "Canonical read-only Averray business ledger for humans, Slack, Command Center, and other agents. Summarizes recent Wikipedia citation-repair submissions, drafts, operator commands, latest run, open jobs, and budget. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
   {},
@@ -187,7 +197,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'business ledger', 'ops health', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/ledger/health commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-admin.ts
+++ b/packages/averray-mcp/src/operator-admin.ts
@@ -1,0 +1,127 @@
+import { optionalEnv } from "@avg/mcp-common";
+import type { OperatorStatusDeps } from "./operator-status.js";
+import { getOpsHealth } from "./operator-insights.js";
+import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
+
+export async function getAdminReadiness(deps: OperatorStatusDeps) {
+  const [ops, usefulness] = await Promise.all([
+    getOpsHealth(deps),
+    getAgentUsefulnessPlan(deps),
+  ]);
+  const cloudflareAccess = optionalEnv("CLOUDFLARED_TUNNEL_TOKEN", "").length > 0;
+  const slackOperator = optionalEnv("SLACK_OPERATOR_ENABLED", "0") === "1";
+  const commandCenter = Boolean(optionalEnv("HERMES_WORKSPACE_IMAGE"));
+  const health = ops.health;
+
+  return {
+    schemaVersion: 1,
+    kind: "admin_readiness",
+    generatedAt: ops.generatedAt,
+    mutates: false,
+    headline: "I am ready to be an operator copilot now; project-admin powers should be added in approval-gated stages.",
+    currentRole: {
+      level: "operator_copilot",
+      canAdministerAutomatically: false,
+      reason: "The agent can observe, brief, draft, and run narrow guarded Averray workflows, but broad project administration still needs explicit approval gates and per-action policies.",
+    },
+    readiness: {
+      overall: readinessFromHealth(health),
+      opsHealth: health,
+      walletReady: ops.wallet.walletReady,
+      budgetRemainingUsd: ops.budget.todayUsdRemaining,
+      slackOperator: slackOperator ? "enabled" : "not_configured",
+      commandCenter: commandCenter ? "enabled" : "not_configured",
+      publicAccess: cloudflareAccess ? "cloudflare_access_configured" : "private_or_tunnel_only",
+      auditTrail: auditReadiness(ops),
+    },
+    adminLadder: [
+      {
+        stage: 1,
+        name: "Observe and brief",
+        status: "enabled",
+        examples: ["ops health", "business ledger", "daily operator brief", "status last wikipedia citation repair"],
+        mutates: false,
+      },
+      {
+        stage: 2,
+        name: "Draft and recommend",
+        status: "enabled",
+        examples: ["find safe work", "run one wikipedia citation repair dry run only", "what can you do for us"],
+        mutates: false,
+      },
+      {
+        stage: 3,
+        name: "Approval-gated execution",
+        status: "partially_enabled",
+        examples: ["run one wikipedia citation repair if safe"],
+        mutates: true,
+        requiredControls: ["explicit command", "policy check", "draft persistence", "validation", "confidence threshold", "audit event"],
+      },
+      {
+        stage: 4,
+        name: "Scoped project admin",
+        status: "not_enabled",
+        examples: ["merge approved PR", "restart service", "rotate non-secret config", "open incident report"],
+        mutates: true,
+        requiredControls: ["project allowlist", "action registry", "two-step approval", "rollback plan", "post-action receipt"],
+      },
+      {
+        stage: 5,
+        name: "Autonomous routine admin",
+        status: "future",
+        examples: ["auto-close stale safe alerts", "auto-run read-only health checks", "auto-draft weekly reports"],
+        mutates: "limited",
+        requiredControls: ["time window", "spend limit", "rate limit", "dry-run shadow period", "human override"],
+      },
+    ],
+    canDoNow: [
+      "Summarize current Averray work and budget.",
+      "Find safe citation-repair candidates and dry-run them.",
+      "Submit only narrow Wikipedia citation-repair proposals when policy, validation, and confidence pass.",
+      "Report control-plane health from Postgres.",
+      "Explain which surface to use: Slack, Command Center/mobile, or MCP.",
+    ],
+    shouldNotDoYet: [
+      "Merge PRs or push code without a project-specific approval policy.",
+      "Deploy, restart, or reconfigure production services automatically.",
+      "Change DNS, Cloudflare Access, Slack app scopes, or secrets.",
+      "Spend money, move funds, or change wallet configuration.",
+      "Override confidence gates without a separate human review path.",
+    ],
+    requiredBeforeProjectAdmin: [
+      "Define a project registry with owners, environments, and allowed actions.",
+      "Add an admin action policy engine with read-only, draft-only, approval-required, and denied levels.",
+      "Persist every proposed/admin action with requester, channel, diff/command, approval, result, and rollback note.",
+      "Add GitHub/CI read-only digest first; only then add approval-gated PR comments or merges.",
+      "Add host-level ops checks for disk, logs, WAL files, and service health before allowing restarts.",
+    ],
+    suggestedCommands: [
+      "admin readiness",
+      "what can you do for us",
+      "ops health",
+      "business ledger",
+      "find safe work",
+    ],
+    surfaces: usefulness.surfaces,
+    safety: {
+      mutatesByDefault: false,
+      projectAdminEnabled: false,
+      broadAdminDeniedByDefault: true,
+      explicitApprovalRequiredForAdmin: true,
+      editsWikipedia: false,
+    },
+  };
+}
+
+function readinessFromHealth(health: string) {
+  if (health === "ready") return "ready_for_operator_copilot";
+  if (health === "quiet") return "ready_but_low_activity";
+  if (health === "degraded") return "needs_ops_attention";
+  return "blocked";
+}
+
+function auditReadiness(ops: Awaited<ReturnType<typeof getOpsHealth>>) {
+  const events = ops.controlPlane.tables.operatorEvents;
+  if (events > 0) return "operator_events_recorded";
+  return "no_operator_events_seen";
+}

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -41,6 +41,12 @@ export type ParsedOperatorCommand =
     }
   | {
       handled: true;
+      kind: "admin_readiness";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
+      handled: true;
       kind: "business_ledger";
       source: OperatorCommandSource;
       detailed: boolean;
@@ -84,6 +90,7 @@ export interface LastWikipediaCitationRepairStatus {
 const EXAMPLES = [
   "daily operator brief",
   "what can you do for us",
+  "admin readiness",
   "business ledger",
   "ops health",
   "find safe work",
@@ -119,6 +126,10 @@ export function parseOperatorCommand(
 
   if (isAgentUsefulnessPlanCommand(normalizedText)) {
     return { handled: true, kind: "agent_usefulness_plan", source, detailed };
+  }
+
+  if (isAdminReadinessCommand(normalizedText)) {
+    return { handled: true, kind: "admin_readiness", source, detailed };
   }
 
   if (isBusinessLedgerCommand(normalizedText)) {
@@ -281,6 +292,10 @@ function isFindSafeWorkCommand(text: string): boolean {
 
 function isAgentUsefulnessPlanCommand(text: string): boolean {
   return /^(what can you do|what can you do for us|how can you help|how can you work for us|work for us|agent usefulness|agent usefulness plan|agent plan|usefulness plan|show use cases|show agent use cases)( details?| full| audit)?$/.test(text);
+}
+
+function isAdminReadinessCommand(text: string): boolean {
+  return /^(admin readiness|project admin readiness|admin plan|project admin plan|can you be admin|can you admin my projects|how can you admin my projects|admin mode|future admin plan)( details?| full| audit)?$/.test(text);
 }
 
 function isBusinessLedgerCommand(text: string): boolean {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -5,6 +5,7 @@ import {
   type OperatorCommandSource,
   type OperatorQueryFn,
 } from "./operator-commands.js";
+import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
@@ -54,6 +55,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "agent_usefulness_plan") {
     const plan = await getAgentUsefulnessPlan({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, plan };
+  }
+  if (command.kind === "admin_readiness") {
+    const readiness = await getAdminReadiness({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, readiness };
   }
   if (command.kind === "business_ledger") {
     const ledger = await getBusinessLedger({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/packages/averray-mcp/src/operator-usefulness.ts
+++ b/packages/averray-mcp/src/operator-usefulness.ts
@@ -38,6 +38,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         commands: [
           "brief me",
           "what can you do for us",
+          "admin readiness",
           "what should i do next",
           "run one wikipedia citation repair dry run only",
           "run one wikipedia citation repair if safe",
@@ -55,6 +56,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
           "operator status",
           "daily operator brief",
           "what can you do for us",
+          "admin readiness",
           "find safe work",
         ],
       },
@@ -63,6 +65,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         use: "Canonical structured contract any compatible agent can call without learning Slack or Workspace.",
         tools: [
           "averray_agent_usefulness_plan",
+          "averray_admin_readiness",
           "averray_business_ledger",
           "averray_ops_health",
           "averray_operator_status",
@@ -88,8 +91,15 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
       {
         id: "github_helper",
         status: "next_integration",
-        value: "Useful next track: watch PR/issue comments, summarize CI failures, and draft replies from GitHub context.",
+        value: "Useful next track: watch PR/issue comments, summarize CI failures, and draft replies from GitHub context before any admin-grade GitHub actions.",
+        commands: ["admin readiness"],
         nextStep: "Add a read-only GitHub digest command before allowing any write actions.",
+      },
+      {
+        id: "project_admin_copilot",
+        status: "readiness_enabled",
+        value: "Can explain the staged path from operator copilot to approval-gated project admin, including denied actions and required controls.",
+        commands: ["admin readiness", "what can you do for us"],
       },
       {
         id: "ops_caretaker",
@@ -112,6 +122,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
     ],
     nextImplementationTracks: [
       "GitHub PR/issue digest and CI failure explainer",
+      "Admin action registry with project allowlists, approvals, audit receipts, and rollback notes",
       "Host-level ops routine for disk/log/WAL checks and stale sessions",
       "Reward ledger with chain/accounting reconciliation once payout data is exposed",
       "Portable command schema so Slack, Command Center, mobile, and future agents share the same intents",

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -171,6 +171,31 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Read-only plan. Use `what can you do for us details` in MCP/Workspace for the full structured JSON.",
     ].filter(Boolean).join("\n");
   }
+  if (result.kind === "admin_readiness") {
+    const readiness = isRecord(result.readiness) ? result.readiness : {};
+    const currentRole = isRecord(readiness.currentRole) ? readiness.currentRole : {};
+    const state = isRecord(readiness.readiness) ? readiness.readiness : {};
+    const ladder = Array.isArray(readiness.adminLadder) ? readiness.adminLadder : [];
+    const canDoNow = Array.isArray(readiness.canDoNow) ? readiness.canDoNow : [];
+    const notYet = Array.isArray(readiness.shouldNotDoYet) ? readiness.shouldNotDoYet : [];
+    const required = Array.isArray(readiness.requiredBeforeProjectAdmin) ? readiness.requiredBeforeProjectAdmin : [];
+    return [
+      "*Averray admin readiness*",
+      stringField(readiness, "headline") ?? "I can be an operator copilot now; broad admin needs staged controls.",
+      "",
+      "*Current role*",
+      `• level: \`${stringField(currentRole, "level") ?? "operator_copilot"}\``,
+      `• auto-admin: \`${String(currentRole.canAdministerAutomatically === true)}\``,
+      `• overall: \`${stringField(state, "overall") ?? "unknown"}\``,
+      `• access: Slack \`${stringField(state, "slackOperator") ?? "unknown"}\`, Command Center \`${stringField(state, "commandCenter") ?? "unknown"}\`, public \`${stringField(state, "publicAccess") ?? "unknown"}\``,
+      "*Admin ladder*",
+      ladder.slice(0, 5).map(formatAdminStage).join("\n"),
+      canDoNow.length > 0 ? `*Can do now*\n${canDoNow.slice(0, 4).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+      notYet.length > 0 ? `*Not yet*\n${notYet.slice(0, 4).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+      required.length > 0 ? `*Before project admin*\n${required.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+      "Read-only. Broad project-admin actions are denied by default until an approval policy exists.",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "business_ledger") {
     const ledger = isRecord(result.ledger) ? result.ledger : {};
     const summary = isRecord(ledger.summary) ? ledger.summary : {};
@@ -336,6 +361,14 @@ function formatUseCase(value: unknown): string {
   const status = stringField(value, "status") ?? "unknown";
   const summary = stringField(value, "value") ?? "";
   return `• \`${id}\` - ${status}${summary ? `: ${summary}` : ""}`;
+}
+
+function formatAdminStage(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const stage = numberField(value, "stage") ?? "?";
+  const name = stringField(value, "name") ?? "unknown";
+  const status = stringField(value, "status") ?? "unknown";
+  return `• ${stage}. ${name}: \`${status}\``;
 }
 
 function formatRecentEvent(value: unknown): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -109,6 +109,18 @@ describe("operator commands", () => {
       source: "command_center",
       detailed: true,
     });
+    expect(parseOperatorCommand("can you admin my projects?", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "admin_readiness",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("admin readiness details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "admin_readiness",
+      source: "slack",
+      detailed: true,
+    });
     expect(parseOperatorCommand("business ledger", { source: "slack" })).toEqual({
       handled: true,
       kind: "business_ledger",

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../packages/averray-mcp/src/operator-status.js";
 import { getBusinessLedger, getOpsHealth } from "../../packages/averray-mcp/src/operator-insights.js";
 import { getAgentUsefulnessPlan } from "../../packages/averray-mcp/src/operator-usefulness.js";
+import { getAdminReadiness } from "../../packages/averray-mcp/src/operator-admin.js";
 
 describe("operator status", () => {
   it("returns a canonical read-only status for agents and UIs", async () => {
@@ -228,6 +229,7 @@ describe("operator status", () => {
       "slack_work_assistant",
       "mobile_agent",
       "github_helper",
+      "project_admin_copilot",
       "ops_caretaker",
       "averray_business_agent",
       "knowledge_memory",
@@ -237,6 +239,33 @@ describe("operator status", () => {
       commands: expect.arrayContaining(["ops health"]),
     });
     expect(usefulness.safety.mutatesByDefault).toBe(false);
+
+    const admin = await getAdminReadiness(deps);
+    expect(admin).toMatchObject({
+      kind: "admin_readiness",
+      mutates: false,
+      currentRole: {
+        level: "operator_copilot",
+        canAdministerAutomatically: false,
+      },
+      readiness: {
+        overall: "ready_but_low_activity",
+        walletReady: true,
+      },
+      safety: {
+        projectAdminEnabled: false,
+        broadAdminDeniedByDefault: true,
+      },
+    });
+    expect(admin.adminLadder.map((entry) => entry.name)).toEqual(expect.arrayContaining([
+      "Observe and brief",
+      "Approval-gated execution",
+      "Scoped project admin",
+    ]));
+    expect(admin.shouldNotDoYet).toEqual(expect.arrayContaining([
+      expect.stringContaining("Merge PRs"),
+      expect.stringContaining("Change DNS"),
+    ]));
   });
 
   it("returns read-only business ledger and ops health insights", async () => {

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -328,6 +328,42 @@ describe("slack operator bridge", () => {
     expect(text).toContain("GitHub PR/issue digest");
   });
 
+  it("formats admin readiness replies with staged guardrails", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "admin_readiness",
+      readiness: {
+        headline: "I am ready to be an operator copilot now.",
+        currentRole: {
+          level: "operator_copilot",
+          canAdministerAutomatically: false,
+        },
+        readiness: {
+          overall: "ready_for_operator_copilot",
+          slackOperator: "enabled",
+          commandCenter: "enabled",
+          publicAccess: "cloudflare_access_configured",
+        },
+        adminLadder: [
+          { stage: 1, name: "Observe and brief", status: "enabled" },
+          { stage: 2, name: "Draft and recommend", status: "enabled" },
+          { stage: 3, name: "Approval-gated execution", status: "partially_enabled" },
+          { stage: 4, name: "Scoped project admin", status: "not_enabled" },
+        ],
+        canDoNow: ["Summarize current Averray work and budget."],
+        shouldNotDoYet: ["Merge PRs or push code without a project-specific approval policy."],
+        requiredBeforeProjectAdmin: ["Define a project registry with owners, environments, and allowed actions."],
+      },
+    });
+
+    expect(text).toContain("*Averray admin readiness*");
+    expect(text).toContain("level: `operator_copilot`");
+    expect(text).toContain("auto-admin: `false`");
+    expect(text).toContain("Observe and brief: `enabled`");
+    expect(text).toContain("Scoped project admin: `not_enabled`");
+    expect(text).toContain("Broad project-admin actions are denied by default");
+  });
+
   it("formats business ledger and ops health replies", () => {
     const ledger = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## What changed
- Added read-only `averray_admin_readiness` MCP tool.
- Added `admin readiness` / `can you admin my projects` operator command routing.
- Added Slack formatting for the staged admin-readiness ladder.
- Updated usefulness docs/tests so the agent can explain how it grows from operator copilot to approval-gated project admin.

## Safety
- Read-only only: `mutates: false`.
- Does not grant broad project-admin powers.
- Explicitly marks project admin as disabled and denied by default until project allowlists, approvals, audit receipts, and rollback notes exist.

## Checks
- `npm run typecheck`
- `npm test -- test/unit/operator-commands.test.ts test/unit/operator-status.test.ts test/unit/slack-operator.test.ts`
- `npm test`
- `git diff --check`

## Impact
Affects Averray MCP, Slack operator formatting, docs, and tests. No indexer, Caddy, contracts, or public site changes.