### PR TITLE
Add read-only GitHub operator commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,14 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
   recognizes `what can you do for us`, `admin readiness`, `business ledger`,
-  `ops health`, `daily operator brief`, `find safe work`, `operator status`,
-  `operator status details`, `run one wikipedia citation repair if safe`, and
-  `status last wikipedia citation repair`. `what can you do for us` calls the
+  `ops health`, `github status`, `github open prs`, `github ci failures`,
+  `github issue digest`, `daily operator brief`, `find safe work`,
+  `operator status`, `operator status details`,
+  `run one wikipedia citation repair if safe`, and
+  `status last wikipedia citation repair`. GitHub commands call
+  `averray_github_status`, a read-only helper configured with `GITHUB_TOKEN`
+  plus `GITHUB_DEFAULT_REPO` or `GITHUB_HELPER_REPOS`; it summarizes open PRs,
+  open issues, and recent CI failures without mutating GitHub. `what can you do for us` calls the
   read-only `averray_agent_usefulness_plan` MCP tool and explains the useful
   surfaces and use cases across Slack, Command Center/mobile, MCP clients,
   GitHub-helper planning, ops care, Averray business tracking, and durable

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -163,6 +163,10 @@ what can you do for us
 admin readiness
 business ledger
 ops health
+github status
+github open prs
+github ci failures
+github issue digest
 find safe work
 operator status
 operator status details
@@ -182,6 +186,11 @@ by default. `business ledger` calls `averray_business_ledger` for recent
 submissions, drafts, operator commands, budget, and open work. `ops health`
 calls `averray_ops_health` for wallet/budget readiness, latest-run state,
 recent operator events, recent failures, and Postgres control-plane counts.
+GitHub commands call `averray_github_status`, a read-only helper configured
+with `GITHUB_TOKEN` and either `GITHUB_DEFAULT_REPO` or `GITHUB_HELPER_REPOS`.
+It reports open PRs, open issues, and recent GitHub Actions failures without
+merging PRs, editing issues, rerunning workflows, deploying, or mutating
+GitHub state.
 `daily operator brief` and
 `find safe work` are read-only views for humans and agents: they summarize
 wallet/budget readiness, latest run state, candidate jobs, blockers, and the

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -29,6 +29,13 @@ OLLAMA_BASE_URL=https://ollama.com/v1
 HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud
 HERMES_COMPARISON_MODEL=qwen3.5:cloud
 
+# Optional read-only GitHub operator helper.
+GITHUB_TOKEN=
+GITHUB_DEFAULT_REPO=
+GITHUB_HELPER_REPOS=
+GITHUB_API_BASE_URL=https://api.github.com
+GITHUB_HELPER_LIMIT=5
+
 # Optional command-center evaluation. See docs/COMMAND_CENTER.md.
 # Keep these ports localhost-bound through ops/compose.command-center.yml.
 HERMES_WORKSPACE_IMAGE=ghcr.io/outsourc-e/hermes-workspace:latest

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -45,6 +45,7 @@ import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
+import { getGithubOperatorStatus } from "./operator-github.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -196,8 +197,19 @@ server.tool(
 );
 
 server.tool(
+  "averray_github_status",
+  "Canonical read-only GitHub operator status for humans, Slack, Command Center, and other agents. Uses GITHUB_TOKEN plus GITHUB_DEFAULT_REPO or GITHUB_HELPER_REPOS to summarize open PRs, open issues, and recent CI failures. Does not merge PRs, edit issues, rerun workflows, deploy, push code, or mutate GitHub.",
+  {
+    view: z.enum(["status", "prs", "ci", "issues", "digest"]).default("status")
+  },
+  async ({ view }) => {
+    return jsonContent(await getGithubOperatorStatus({ view }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github open prs', 'github ci failures', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,4 +1,5 @@
 import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
+import type { GithubOperatorView } from "./operator-github.js";
 
 export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes";
 
@@ -58,6 +59,13 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "github_status";
+      source: OperatorCommandSource;
+      view: GithubOperatorView;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -93,6 +101,10 @@ const EXAMPLES = [
   "admin readiness",
   "business ledger",
   "ops health",
+  "github status",
+  "github open prs",
+  "github ci failures",
+  "github issue digest",
   "find safe work",
   "operator status",
   "operator status details",
@@ -138,6 +150,11 @@ export function parseOperatorCommand(
 
   if (isOpsHealthCommand(normalizedText)) {
     return { handled: true, kind: "ops_health", source, detailed };
+  }
+
+  const githubView = githubOperatorView(normalizedText);
+  if (githubView) {
+    return { handled: true, kind: "github_status", source, view: githubView, detailed };
   }
 
   if (isLatestWikipediaCitationRepairStatusCommand(normalizedText)) {
@@ -304,6 +321,16 @@ function isBusinessLedgerCommand(text: string): boolean {
 
 function isOpsHealthCommand(text: string): boolean {
   return /^(ops health|operator health|agent health|stack health|health check|control plane health|mcp health)( details?| full| audit)?$/.test(text);
+}
+
+function githubOperatorView(text: string): GithubOperatorView | undefined {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  if (/^(github status|github repo status|github repositories|github repos)$/.test(compact)) return "status";
+  if (/^(github open prs|github prs|github pull requests|github open pull requests|open prs)$/.test(compact)) return "prs";
+  if (/^(github ci|github ci failures|github failures|github checks|github actions|ci failures)$/.test(compact)) return "ci";
+  if (/^(github issues|github issue digest|github open issues|issue digest)$/.test(compact)) return "issues";
+  if (/^(github digest|github attention|github needs attention|github work digest)$/.test(compact)) return "digest";
+  return undefined;
 }
 
 function wantsDetailedOutput(text: string): boolean {

--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -1,0 +1,533 @@
+export type GithubOperatorView = "status" | "prs" | "ci" | "issues" | "digest";
+
+export interface GithubOperatorStatus {
+  schemaVersion: 1;
+  generatedAt: string;
+  mutates: false;
+  configured: boolean;
+  authConfigured: boolean;
+  view: GithubOperatorView;
+  health: "ok" | "attention" | "degraded";
+  repoCount: number;
+  totals: {
+    openPullRequests: number;
+    openIssues: number;
+    failingWorkflowRuns: number;
+    activeWorkflowRuns: number;
+  };
+  repositories: GithubRepositoryStatus[];
+  views: {
+    status: GithubStatusItem[];
+    prs: GithubPullRequestItem[];
+    ci: GithubWorkflowRunItem[];
+    issues: GithubIssueItem[];
+    digest: GithubDigestItem[];
+  };
+  selectedView: {
+    name: GithubOperatorView;
+    items: Array<GithubStatusItem | GithubPullRequestItem | GithubWorkflowRunItem | GithubIssueItem | GithubDigestItem>;
+  };
+  warnings: GithubWarning[];
+  recommendations: string[];
+}
+
+export interface GithubRepositoryStatus {
+  repo: string;
+  defaultBranch?: string;
+  private?: boolean;
+  openPullRequests: number;
+  openIssues: number;
+  failingWorkflowRuns: number;
+  activeWorkflowRuns: number;
+  url?: string;
+}
+
+export interface GithubStatusItem extends GithubRepositoryStatus {
+  kind: "repo_status";
+}
+
+export interface GithubPullRequestItem {
+  kind: "pull_request";
+  repo: string;
+  number: number;
+  title: string;
+  url?: string;
+  author?: string;
+  draft: boolean;
+  updatedAt?: string;
+  state: string;
+}
+
+export interface GithubIssueItem {
+  kind: "issue";
+  repo: string;
+  number: number;
+  title: string;
+  url?: string;
+  author?: string;
+  updatedAt?: string;
+  labels: string[];
+  state: string;
+}
+
+export interface GithubWorkflowRunItem {
+  kind: "workflow_run";
+  repo: string;
+  id: number;
+  name: string;
+  status: string;
+  conclusion?: string;
+  branch?: string;
+  event?: string;
+  url?: string;
+  updatedAt?: string;
+}
+
+export interface GithubDigestItem {
+  kind: "digest_item";
+  severity: "info" | "attention" | "blocked";
+  repo?: string;
+  title: string;
+  detail?: string;
+  url?: string;
+}
+
+export interface GithubWarning {
+  severity: "low" | "medium" | "high";
+  code: string;
+  message: string;
+  repo?: string;
+}
+
+export interface GithubOperatorStatusOptions {
+  view?: GithubOperatorView;
+  env?: NodeJS.ProcessEnv;
+  fetchFn?: typeof fetch;
+  now?: Date;
+}
+
+interface GithubApiRepo {
+  full_name?: string;
+  default_branch?: string;
+  private?: boolean;
+  html_url?: string;
+  open_issues_count?: number;
+}
+
+interface GithubApiUser {
+  login?: string;
+}
+
+interface GithubApiPullRequest {
+  number?: number;
+  title?: string;
+  html_url?: string;
+  user?: GithubApiUser | null;
+  draft?: boolean;
+  updated_at?: string;
+  state?: string;
+}
+
+interface GithubApiIssue {
+  number?: number;
+  title?: string;
+  html_url?: string;
+  user?: GithubApiUser | null;
+  updated_at?: string;
+  state?: string;
+  labels?: Array<{ name?: string }>;
+  pull_request?: unknown;
+}
+
+interface GithubApiWorkflowRun {
+  id?: number;
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+  head_branch?: string | null;
+  event?: string;
+  html_url?: string;
+  updated_at?: string;
+}
+
+export async function getGithubOperatorStatus(
+  options: GithubOperatorStatusOptions = {}
+): Promise<GithubOperatorStatus> {
+  const env = options.env ?? process.env;
+  const view = options.view ?? "status";
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const token = env.GITHUB_TOKEN?.trim();
+  const repos = parseGithubRepos(env);
+  const warnings: GithubWarning[] = [];
+
+  if (!token || repos.length === 0) {
+    if (!token) {
+      warnings.push({
+        severity: "high",
+        code: "github_token_missing",
+        message: "GITHUB_TOKEN is not configured, so GitHub status is unavailable.",
+      });
+    }
+    if (repos.length === 0) {
+      warnings.push({
+        severity: "high",
+        code: "github_repos_missing",
+        message: "Set GITHUB_HELPER_REPOS or GITHUB_DEFAULT_REPO to enable GitHub status.",
+      });
+    }
+    return emptyStatus({ generatedAt, view, authConfigured: Boolean(token), warnings });
+  }
+
+  const fetchFn = options.fetchFn ?? fetch;
+  const baseUrl = (env.GITHUB_API_BASE_URL ?? "https://api.github.com").replace(/\/+$/g, "");
+  const limit = clampLimit(env.GITHUB_HELPER_LIMIT);
+  const repoResults = await Promise.all(
+    repos.map((repo) => collectRepoStatus({ repo, baseUrl, token, limit, fetchFn }))
+  );
+
+  const repositoryStatuses: GithubRepositoryStatus[] = [];
+  const prs: GithubPullRequestItem[] = [];
+  const issues: GithubIssueItem[] = [];
+  const ci: GithubWorkflowRunItem[] = [];
+
+  for (const result of repoResults) {
+    warnings.push(...result.warnings);
+    if (result.status) repositoryStatuses.push(result.status);
+    prs.push(...result.prs);
+    issues.push(...result.issues);
+    ci.push(...result.ci);
+  }
+
+  const failingWorkflowRuns = ci.filter((run) => run.conclusion === "failure" || run.conclusion === "cancelled").length;
+  const activeWorkflowRuns = ci.filter((run) => run.status !== "completed").length;
+  const statusItems = repositoryStatuses.map((status): GithubStatusItem => ({ ...status, kind: "repo_status" }));
+  const digest = buildDigest({ repositories: repositoryStatuses, prs, issues, ci, warnings });
+  const totals = {
+    openPullRequests: prs.length,
+    openIssues: issues.length,
+    failingWorkflowRuns,
+    activeWorkflowRuns,
+  };
+  const health = warnings.some((warning) => warning.severity === "high")
+    ? "degraded"
+    : failingWorkflowRuns > 0 || activeWorkflowRuns > 0 || prs.length > 0 || issues.length > 0
+      ? "attention"
+      : "ok";
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    mutates: false,
+    configured: true,
+    authConfigured: true,
+    view,
+    health,
+    repoCount: repositoryStatuses.length,
+    totals,
+    repositories: repositoryStatuses,
+    views: {
+      status: statusItems,
+      prs,
+      ci,
+      issues,
+      digest,
+    },
+    selectedView: {
+      name: view,
+      items: selectView({ view, status: statusItems, prs, ci, issues, digest }),
+    },
+    warnings,
+    recommendations: buildRecommendations({ health, totals, repoCount: repositoryStatuses.length }),
+  };
+}
+
+function emptyStatus(input: {
+  generatedAt: string;
+  view: GithubOperatorView;
+  authConfigured: boolean;
+  warnings: GithubWarning[];
+}): GithubOperatorStatus {
+  const digest = input.warnings.map((warning): GithubDigestItem => ({
+    kind: "digest_item",
+    severity: warning.severity === "high" ? "blocked" : "attention",
+    title: warning.message,
+    detail: warning.code,
+  }));
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    mutates: false,
+    configured: false,
+    authConfigured: input.authConfigured,
+    view: input.view,
+    health: "degraded",
+    repoCount: 0,
+    totals: {
+      openPullRequests: 0,
+      openIssues: 0,
+      failingWorkflowRuns: 0,
+      activeWorkflowRuns: 0,
+    },
+    repositories: [],
+    views: {
+      status: [],
+      prs: [],
+      ci: [],
+      issues: [],
+      digest,
+    },
+    selectedView: { name: input.view, items: input.view === "digest" ? digest : [] },
+    warnings: input.warnings,
+    recommendations: [
+      "Set GITHUB_TOKEN with read-only access to the target repository.",
+      "Set GITHUB_DEFAULT_REPO=owner/repo or GITHUB_HELPER_REPOS=owner/repo,owner/repo.",
+    ],
+  };
+}
+
+async function collectRepoStatus(input: {
+  repo: string;
+  baseUrl: string;
+  token: string;
+  limit: number;
+  fetchFn: typeof fetch;
+}): Promise<{
+  status?: GithubRepositoryStatus;
+  prs: GithubPullRequestItem[];
+  issues: GithubIssueItem[];
+  ci: GithubWorkflowRunItem[];
+  warnings: GithubWarning[];
+}> {
+  const warnings: GithubWarning[] = [];
+  const repoPath = encodeRepoPath(input.repo);
+  try {
+    const [repo, pulls, issues, runs] = await Promise.all([
+      githubGet<GithubApiRepo>(`${input.baseUrl}/repos/${repoPath}`, input.token, input.fetchFn),
+      githubGet<GithubApiPullRequest[]>(
+        `${input.baseUrl}/repos/${repoPath}/pulls?state=open&sort=updated&direction=desc&per_page=${input.limit}`,
+        input.token,
+        input.fetchFn
+      ),
+      githubGet<GithubApiIssue[]>(
+        `${input.baseUrl}/repos/${repoPath}/issues?state=open&sort=updated&direction=desc&per_page=${input.limit * 2}`,
+        input.token,
+        input.fetchFn
+      ),
+      githubGet<{ workflow_runs?: GithubApiWorkflowRun[] }>(
+        `${input.baseUrl}/repos/${repoPath}/actions/runs?per_page=${input.limit}`,
+        input.token,
+        input.fetchFn
+      ),
+    ]);
+
+    const pullItems = pulls.slice(0, input.limit).map((pull) => ({
+      kind: "pull_request" as const,
+      repo: input.repo,
+      number: numberField(pull.number),
+      title: pull.title ?? "Untitled pull request",
+      url: pull.html_url,
+      author: pull.user?.login,
+      draft: pull.draft === true,
+      updatedAt: pull.updated_at,
+      state: pull.state ?? "open",
+    })).filter((pull) => pull.number > 0);
+
+    const issueItems = issues
+      .filter((issue) => issue.pull_request === undefined)
+      .slice(0, input.limit)
+      .map((issue) => ({
+        kind: "issue" as const,
+        repo: input.repo,
+        number: numberField(issue.number),
+        title: issue.title ?? "Untitled issue",
+        url: issue.html_url,
+        author: issue.user?.login,
+        updatedAt: issue.updated_at,
+        state: issue.state ?? "open",
+        labels: Array.isArray(issue.labels)
+          ? issue.labels.map((label) => label.name).filter((label): label is string => Boolean(label))
+          : [],
+      }))
+      .filter((issue) => issue.number > 0);
+
+    const ciItems = (runs.workflow_runs ?? []).slice(0, input.limit).map((run) => ({
+      kind: "workflow_run" as const,
+      repo: input.repo,
+      id: numberField(run.id),
+      name: run.name ?? "Unnamed workflow",
+      status: run.status ?? "unknown",
+      ...(run.conclusion ? { conclusion: run.conclusion } : {}),
+      ...(run.head_branch ? { branch: run.head_branch } : {}),
+      ...(run.event ? { event: run.event } : {}),
+      ...(run.html_url ? { url: run.html_url } : {}),
+      ...(run.updated_at ? { updatedAt: run.updated_at } : {}),
+    })).filter((run) => run.id > 0);
+
+    return {
+      status: {
+        repo: input.repo,
+        defaultBranch: repo.default_branch,
+        private: repo.private,
+        openPullRequests: pullItems.length,
+        openIssues: issueItems.length,
+        failingWorkflowRuns: ciItems.filter((run) => run.conclusion === "failure" || run.conclusion === "cancelled").length,
+        activeWorkflowRuns: ciItems.filter((run) => run.status !== "completed").length,
+        url: repo.html_url,
+      },
+      prs: pullItems,
+      issues: issueItems,
+      ci: ciItems,
+      warnings,
+    };
+  } catch (error) {
+    warnings.push({
+      severity: "high",
+      code: "github_repo_fetch_failed",
+      repo: input.repo,
+      message: error instanceof Error ? error.message : `Failed to fetch ${input.repo}`,
+    });
+    return { prs: [], issues: [], ci: [], warnings };
+  }
+}
+
+async function githubGet<T>(url: string, token: string, fetchFn: typeof fetch): Promise<T> {
+  const response = await fetchFn(url, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "user-agent": "averray-reference-agent-github-helper",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`GitHub API ${response.status} for ${url}${text ? `: ${text.slice(0, 180)}` : ""}`);
+  }
+  return await response.json() as T;
+}
+
+function parseGithubRepos(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.GITHUB_HELPER_REPOS ?? env.GITHUB_DEFAULT_REPO ?? env.GITHUB_REPOSITORY ?? "";
+  const repos = raw.split(",")
+    .map((entry) => normalizeRepo(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return [...new Set(repos)];
+}
+
+function normalizeRepo(value: string): string | undefined {
+  const trimmed = value.trim().replace(/^https:\/\/github\.com\//i, "").replace(/\.git$/i, "").replace(/^\/+|\/+$/g, "");
+  const [owner, repo] = trimmed.split("/");
+  if (!owner || !repo) return undefined;
+  return `${owner}/${repo}`;
+}
+
+function encodeRepoPath(repo: string): string {
+  const [owner, name] = repo.split("/");
+  return `${encodeURIComponent(owner ?? "")}/${encodeURIComponent(name ?? "")}`;
+}
+
+function clampLimit(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? "5", 10);
+  if (!Number.isFinite(parsed)) return 5;
+  return Math.max(1, Math.min(20, parsed));
+}
+
+function buildDigest(input: {
+  repositories: GithubRepositoryStatus[];
+  prs: GithubPullRequestItem[];
+  issues: GithubIssueItem[];
+  ci: GithubWorkflowRunItem[];
+  warnings: GithubWarning[];
+}): GithubDigestItem[] {
+  const items: GithubDigestItem[] = [];
+  for (const warning of input.warnings) {
+    items.push({
+      kind: "digest_item",
+      severity: warning.severity === "high" ? "blocked" : "attention",
+      repo: warning.repo,
+      title: warning.message,
+      detail: warning.code,
+    });
+  }
+  for (const run of input.ci.filter((entry) => entry.conclusion === "failure" || entry.conclusion === "cancelled")) {
+    items.push({
+      kind: "digest_item",
+      severity: "blocked",
+      repo: run.repo,
+      title: `CI ${run.conclusion}: ${run.name}`,
+      detail: run.branch ? `branch ${run.branch}` : undefined,
+      url: run.url,
+    });
+  }
+  for (const run of input.ci.filter((entry) => entry.status !== "completed")) {
+    items.push({
+      kind: "digest_item",
+      severity: "attention",
+      repo: run.repo,
+      title: `CI still ${run.status}: ${run.name}`,
+      detail: run.branch ? `branch ${run.branch}` : undefined,
+      url: run.url,
+    });
+  }
+  for (const pr of input.prs.slice(0, 5)) {
+    items.push({
+      kind: "digest_item",
+      severity: pr.draft ? "info" : "attention",
+      repo: pr.repo,
+      title: `PR #${pr.number}: ${pr.title}`,
+      detail: pr.draft ? "draft" : "open",
+      url: pr.url,
+    });
+  }
+  for (const issue of input.issues.slice(0, 5)) {
+    items.push({
+      kind: "digest_item",
+      severity: "info",
+      repo: issue.repo,
+      title: `Issue #${issue.number}: ${issue.title}`,
+      detail: issue.labels.length > 0 ? issue.labels.join(", ") : undefined,
+      url: issue.url,
+    });
+  }
+  if (items.length === 0 && input.repositories.length > 0) {
+    items.push({
+      kind: "digest_item",
+      severity: "info",
+      title: "No open GitHub work or failing CI was found for the configured repositories.",
+    });
+  }
+  return items;
+}
+
+function buildRecommendations(input: {
+  health: GithubOperatorStatus["health"];
+  totals: GithubOperatorStatus["totals"];
+  repoCount: number;
+}): string[] {
+  if (input.repoCount === 0) return ["Configure at least one repository before using GitHub status."];
+  const recommendations: string[] = [];
+  if (input.totals.failingWorkflowRuns > 0) recommendations.push("Start with `github ci failures` and inspect the failing run logs.");
+  if (input.totals.openPullRequests > 0) recommendations.push("Use `github open prs` to decide what needs review or merge attention.");
+  if (input.totals.openIssues > 0) recommendations.push("Use `github issue digest` to triage open issues.");
+  if (recommendations.length === 0 && input.health === "ok") recommendations.push("No GitHub blockers found for the configured repositories.");
+  return recommendations;
+}
+
+function selectView(input: {
+  view: GithubOperatorView;
+  status: GithubStatusItem[];
+  prs: GithubPullRequestItem[];
+  ci: GithubWorkflowRunItem[];
+  issues: GithubIssueItem[];
+  digest: GithubDigestItem[];
+}): GithubOperatorStatus["selectedView"]["items"] {
+  if (input.view === "prs") return input.prs;
+  if (input.view === "ci") return input.ci;
+  if (input.view === "issues") return input.issues;
+  if (input.view === "digest") return input.digest;
+  return input.status;
+}
+
+function numberField(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -7,6 +7,7 @@ import {
 } from "./operator-commands.js";
 import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
+import { getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
@@ -67,6 +68,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "ops_health") {
     const health = await getOpsHealth({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, health };
+  }
+  if (command.kind === "github_status") {
+    const github = await getGithubOperatorStatus({ view: command.view });
+    return { ...command, github };
   }
   const result = await runWikipediaCitationRepairWorkflow(
     { ...command.input, expectedWallet: input.expectedWallet },

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -245,6 +245,9 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Read-only health. Host disk/log/WAL checks still need the VPS ops script.",
     ].filter(Boolean).join("\n");
   }
+  if (result.kind === "github_status") {
+    return formatGithubStatusForSlack(result);
+  }
   if (result.kind === "operator_status") {
     const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
@@ -377,6 +380,89 @@ function formatRecentEvent(value: unknown): string {
   const source = stringField(value, "source") ?? "unknown";
   const status = stringField(value, "status") ?? "n/a";
   return `• \`${command}\` (${source}, ${status})`;
+}
+
+function formatGithubStatusForSlack(result: Record<string, unknown>): string {
+  const github = isRecord(result.github) ? result.github : {};
+  const detailed = result.detailed === true;
+  const totals = isRecord(github.totals) ? github.totals : {};
+  const selectedView = isRecord(github.selectedView) ? github.selectedView : {};
+  const items = Array.isArray(selectedView.items) ? selectedView.items : [];
+  const warnings = Array.isArray(github.warnings) ? github.warnings : [];
+  const recommendations = Array.isArray(github.recommendations) ? github.recommendations : [];
+  const configured = github.configured === true;
+  const view = stringField(selectedView, "name") ?? stringField(result, "view") ?? "status";
+
+  if (!configured) {
+    const warningLines = warnings.slice(0, 4).map(formatGithubWarning).join("\n");
+    return [
+      "*GitHub operator status*",
+      "GitHub read-only helper is not configured yet.",
+      warningLines ? `*Missing setup*\n${warningLines}` : "",
+      "*Needed*",
+      "• `GITHUB_TOKEN` with read-only access to the target repo",
+      "• `GITHUB_DEFAULT_REPO=owner/repo` or `GITHUB_HELPER_REPOS=owner/repo,owner/repo`",
+    ].filter(Boolean).join("\n");
+  }
+
+  return [
+    `*GitHub ${view}*`,
+    `• health: \`${stringField(github, "health") ?? "unknown"}\``,
+    `• repos: \`${numberField(github, "repoCount") ?? 0}\``,
+    `• open PRs: \`${numberField(totals, "openPullRequests") ?? 0}\``,
+    `• open issues: \`${numberField(totals, "openIssues") ?? 0}\``,
+    `• CI failing/active: \`${numberField(totals, "failingWorkflowRuns") ?? 0}/${numberField(totals, "activeWorkflowRuns") ?? 0}\``,
+    items.length > 0 ? `*${githubViewTitle(view)}*\n${items.slice(0, detailed ? 10 : 5).map((item) => formatGithubItem(item, detailed)).join("\n")}` : "*Items*\n• none",
+    warnings.length > 0 ? `*Warnings*\n${warnings.slice(0, 3).map(formatGithubWarning).join("\n")}` : "",
+    recommendations.length > 0 ? `*Next*\n${recommendations.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+    detailed ? "Read-only GitHub digest. No PRs, issues, workflows, or repo settings were changed." : "Use `github status details` for fuller IDs and more items.",
+  ].filter(Boolean).join("\n");
+}
+
+function githubViewTitle(view: string): string {
+  if (view === "prs") return "Open PRs";
+  if (view === "ci") return "Workflow runs";
+  if (view === "issues") return "Open issues";
+  if (view === "digest") return "Needs attention";
+  return "Repositories";
+}
+
+function formatGithubItem(value: unknown, detailed: boolean): string {
+  if (!isRecord(value)) return "• unknown";
+  const kind = stringField(value, "kind");
+  const repo = stringField(value, "repo") ?? "unknown";
+  if (kind === "repo_status") {
+    return `• \`${repo}\` - PRs ${numberField(value, "openPullRequests") ?? 0}, issues ${numberField(value, "openIssues") ?? 0}, CI fail/active ${numberField(value, "failingWorkflowRuns") ?? 0}/${numberField(value, "activeWorkflowRuns") ?? 0}`;
+  }
+  if (kind === "pull_request") {
+    const draft = value.draft === true ? " draft" : "";
+    return `• \`${repo}#${numberField(value, "number") ?? "?"}\`${draft} - ${stringField(value, "title") ?? "untitled"}${detailed ? linkSuffix(value) : ""}`;
+  }
+  if (kind === "issue") {
+    const labels = Array.isArray(value.labels) && value.labels.length > 0 ? ` [${value.labels.map(String).join(", ")}]` : "";
+    return `• \`${repo}#${numberField(value, "number") ?? "?"}\` - ${stringField(value, "title") ?? "untitled"}${labels}${detailed ? linkSuffix(value) : ""}`;
+  }
+  if (kind === "workflow_run") {
+    const status = stringField(value, "conclusion") ?? stringField(value, "status") ?? "unknown";
+    const branch = stringField(value, "branch") ? ` (${stringField(value, "branch")})` : "";
+    return `• \`${repo}\` - ${stringField(value, "name") ?? "workflow"}: \`${status}\`${branch}${detailed ? linkSuffix(value) : ""}`;
+  }
+  if (kind === "digest_item") {
+    const severity = stringField(value, "severity") ?? "info";
+    return `• \`${severity}\`${repo !== "unknown" ? ` ${repo}` : ""} - ${stringField(value, "title") ?? "unknown"}${detailed ? linkSuffix(value) : ""}`;
+  }
+  return `• \`${repo}\` - ${stringField(value, "title") ?? kind ?? "unknown"}`;
+}
+
+function formatGithubWarning(value: unknown): string {
+  if (!isRecord(value)) return "• unknown warning";
+  const repo = stringField(value, "repo");
+  return `• \`${stringField(value, "severity") ?? "warning"}\`${repo ? ` ${repo}` : ""}: ${stringField(value, "message") ?? stringField(value, "code") ?? "unknown"}`;
+}
+
+function linkSuffix(value: Record<string, unknown>): string {
+  const url = stringField(value, "url");
+  return url ? ` - ${url}` : "";
 }
 
 function formatId(value: string | undefined, detailed: boolean): string | undefined {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -135,6 +135,37 @@ describe("operator commands", () => {
     });
   });
 
+  it("routes GitHub helper commands read-only", () => {
+    expect(parseOperatorCommand("github status", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "github_status",
+      source: "operator",
+      view: "status",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("github open prs details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "github_status",
+      source: "slack",
+      view: "prs",
+      detailed: true,
+    });
+    expect(parseOperatorCommand("github ci failures", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "github_status",
+      source: "command_center",
+      view: "ci",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("github issue digest", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "github_status",
+      source: "operator",
+      view: "issues",
+      detailed: false,
+    });
+  });
+
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {
     const status = await getLastWikipediaCitationRepairStatus(async (text) => {
       if (text.includes("from submissions")) {

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { getGithubOperatorStatus } from "../../packages/averray-mcp/src/operator-github.js";
+
+describe("github operator status", () => {
+  it("reports setup blockers when token or repo config is missing", async () => {
+    const status = await getGithubOperatorStatus({
+      env: {},
+      now: new Date("2026-05-08T12:00:00.000Z"),
+    });
+
+    expect(status).toMatchObject({
+      configured: false,
+      authConfigured: false,
+      health: "degraded",
+      warnings: expect.arrayContaining([
+        expect.objectContaining({ code: "github_token_missing" }),
+        expect.objectContaining({ code: "github_repos_missing" }),
+      ]),
+    });
+  });
+
+  it("summarizes read-only repository, PR, issue, and CI state", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent")) {
+        return jsonResponse({
+          full_name: "averray-agent/agent",
+          default_branch: "main",
+          private: true,
+          html_url: "https://github.com/averray-agent/agent",
+        });
+      }
+      if (text.includes("/pulls?")) {
+        return jsonResponse([
+          {
+            number: 182,
+            title: "Add GitHub operator digest views",
+            html_url: "https://github.com/averray-agent/agent/pull/182",
+            user: { login: "codex" },
+            draft: false,
+            updated_at: "2026-05-08T10:00:00.000Z",
+            state: "open",
+          },
+        ]);
+      }
+      if (text.includes("/issues?")) {
+        return jsonResponse([
+          {
+            number: 10,
+            title: "Operator should explain CI failures",
+            html_url: "https://github.com/averray-agent/agent/issues/10",
+            user: { login: "pkuriger" },
+            updated_at: "2026-05-08T09:00:00.000Z",
+            state: "open",
+            labels: [{ name: "ops" }],
+          },
+          {
+            number: 182,
+            title: "PR should be filtered from issues",
+            pull_request: {},
+          },
+        ]);
+      }
+      if (text.includes("/actions/runs?")) {
+        return jsonResponse({
+          workflow_runs: [
+            {
+              id: 1,
+              name: "CI",
+              status: "completed",
+              conclusion: "failure",
+              head_branch: "main",
+              event: "push",
+              html_url: "https://github.com/averray-agent/agent/actions/runs/1",
+              updated_at: "2026-05-08T11:00:00.000Z",
+            },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const status = await getGithubOperatorStatus({
+      view: "digest",
+      env: {
+        GITHUB_TOKEN: "ghp_readonly",
+        GITHUB_DEFAULT_REPO: "https://github.com/averray-agent/agent.git",
+      },
+      fetchFn,
+      now: new Date("2026-05-08T12:00:00.000Z"),
+    });
+
+    expect(status).toMatchObject({
+      configured: true,
+      authConfigured: true,
+      view: "digest",
+      health: "attention",
+      repoCount: 1,
+      totals: {
+        openPullRequests: 1,
+        openIssues: 1,
+        failingWorkflowRuns: 1,
+        activeWorkflowRuns: 0,
+      },
+    });
+    expect(status.views.prs[0]).toMatchObject({ repo: "averray-agent/agent", number: 182 });
+    expect(status.views.issues[0]).toMatchObject({ repo: "averray-agent/agent", number: 10 });
+    expect(status.views.digest.some((item) => item.title.includes("CI failure"))).toBe(true);
+  });
+});
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -414,6 +414,71 @@ describe("slack operator bridge", () => {
     expect(health).toContain("none recorded");
   });
 
+  it("formats GitHub helper replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "github_status",
+      view: "digest",
+      detailed: false,
+      github: {
+        configured: true,
+        health: "attention",
+        repoCount: 1,
+        totals: {
+          openPullRequests: 1,
+          openIssues: 1,
+          failingWorkflowRuns: 1,
+          activeWorkflowRuns: 0,
+        },
+        selectedView: {
+          name: "digest",
+          items: [
+            {
+              kind: "digest_item",
+              severity: "blocked",
+              repo: "averray-agent/agent",
+              title: "CI failure: CI",
+            },
+            {
+              kind: "digest_item",
+              severity: "attention",
+              repo: "averray-agent/agent",
+              title: "PR #182: Add GitHub operator digest views",
+            },
+          ],
+        },
+        warnings: [],
+        recommendations: ["Start with `github ci failures` and inspect the failing run logs."],
+      },
+    });
+
+    expect(text).toContain("*GitHub digest*");
+    expect(text).toContain("health: `attention`");
+    expect(text).toContain("open PRs: `1`");
+    expect(text).toContain("CI failing/active: `1/0`");
+    expect(text).toContain("CI failure: CI");
+    expect(text).toContain("github ci failures");
+    expect(text).toContain("Use `github status details`");
+  });
+
+  it("formats unconfigured GitHub helper replies with setup guidance", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "github_status",
+      github: {
+        configured: false,
+        warnings: [
+          { severity: "high", code: "github_token_missing", message: "GITHUB_TOKEN is not configured." },
+        ],
+      },
+    });
+
+    expect(text).toContain("*GitHub operator status*");
+    expect(text).toContain("not configured yet");
+    expect(text).toContain("GITHUB_TOKEN");
+    expect(text).toContain("GITHUB_DEFAULT_REPO");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## Summary
- add a read-only GitHub operator status helper for configured repositories
- route `github status`, `github open prs`, `github ci failures`, `github issue digest`, and digest commands through `averray_handle_operator_command`
- format GitHub helper output for Slack/operator surfaces and document required env vars

## Checks
- `npm run typecheck`
- `npm test`
- `npm run build`

## Surface / Safety
- Affects Averray MCP operator commands, Slack formatting, docs, and env examples
- GitHub helper is read-only: no PR merges, issue edits, workflow reruns, deploys, pushes, or GitHub mutations
- Requires `GITHUB_TOKEN` plus `GITHUB_DEFAULT_REPO` or `GITHUB_HELPER_REPOS` on the VPS