### PR TITLE
Add GitHub brief operator command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,18 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
   recognizes `what can you do for us`, `admin readiness`, `business ledger`,
   `ops health`, `github status`, `github open prs`, `github ci failures`,
-  `github issue digest`, `daily operator brief`, `find safe work`,
+  `github issue digest`, `github brief`, `daily github brief`,
+  `what changed since last time`, `daily operator brief`, `find safe work`,
   `operator status`, `operator status details`,
   `run one wikipedia citation repair if safe`, and
   `status last wikipedia citation repair`. GitHub commands call
   `averray_github_status`, a read-only helper configured with `GITHUB_TOKEN`
   plus `GITHUB_DEFAULT_REPO` or `GITHUB_HELPER_REPOS`; it summarizes open PRs,
-  open issues, and recent CI failures without mutating GitHub. When configured
+  open issues, and recent CI failures without mutating GitHub. `github brief`
+  and `daily github brief` call `averray_github_brief`, which answers what
+  changed since the last brief, what merged, what deployed, what failed, and
+  what needs attention. It mutates no GitHub state; it only stores a local
+  checkpoint timestamp so the next brief can compare against it. When configured
   repositories live under different GitHub owners, use `GITHUB_OWNER_TOKENS` or
   `GITHUB_REPO_TOKENS` for owner/repo-specific read-only tokens. `what can you do for us` calls the
   read-only `averray_agent_usefulness_plan` MCP tool and explains the useful

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -167,6 +167,9 @@ github status
 github open prs
 github ci failures
 github issue digest
+github brief
+daily github brief
+what changed since last time
 find safe work
 operator status
 operator status details
@@ -188,6 +191,10 @@ calls `averray_ops_health` for wallet/budget readiness, latest-run state,
 recent operator events, recent failures, and Postgres control-plane counts.
 GitHub commands call `averray_github_status`, a read-only helper configured
 with `GITHUB_TOKEN` and either `GITHUB_DEFAULT_REPO` or `GITHUB_HELPER_REPOS`.
+Brief commands call `averray_github_brief`, which reports what changed since
+the last brief, what merged, what deployed, what failed, and what needs
+attention. It does not mutate GitHub; it only persists a local checkpoint so
+the next brief can compare against it.
 It reports open PRs, open issues, and recent GitHub Actions failures without
 merging PRs, editing issues, rerunning workflows, deploying, or mutating
 GitHub state. If configured repositories live under different GitHub owners,

--- a/ops/migrations/001_init.sql
+++ b/ops/migrations/001_init.sql
@@ -125,9 +125,17 @@ create table if not exists operator_command_events (
   updated_at timestamptz default now()
 );
 
+create table if not exists operator_state_snapshots (
+  scope text primary key,
+  value jsonb not null default '{}'::jsonb,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
 create index if not exists tool_calls_run_idx on tool_calls(run_id, idx);
 create index if not exists skills_observed_file_idx on skills_observed(file_path);
 create index if not exists draft_submissions_lookup_idx on draft_submissions(job_id, run_id, session_id, updated_at desc);
 create index if not exists draft_submissions_session_idx on draft_submissions(session_id, updated_at desc);
 create index if not exists operator_command_events_run_idx on operator_command_events(run_id, updated_at desc);
 create index if not exists operator_command_events_source_idx on operator_command_events(source, updated_at desc);
+create index if not exists operator_state_snapshots_updated_idx on operator_state_snapshots(updated_at desc);

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -45,7 +45,7 @@ import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
-import { getGithubOperatorStatus } from "./operator-github.js";
+import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -208,8 +208,17 @@ server.tool(
 );
 
 server.tool(
+  "averray_github_brief",
+  "Canonical read-only GitHub operator brief for humans, Slack, Command Center, and other agents. Answers what changed since the last brief, what merged, what deployed, what failed, and what needs attention. It does not mutate GitHub; it only persists a local checkpoint timestamp so the next brief can compare changes.",
+  {},
+  async () => {
+    return jsonContent(await getGithubOperatorBrief({ query }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github open prs', 'github ci failures', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github commands are read-only. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github commands are read-only against external systems. GitHub brief persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -66,6 +66,12 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "github_brief";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -102,6 +108,9 @@ const EXAMPLES = [
   "business ledger",
   "ops health",
   "github status",
+  "github brief",
+  "daily github brief",
+  "what changed since last time",
   "github open prs",
   "github ci failures",
   "github issue digest",
@@ -155,6 +164,10 @@ export function parseOperatorCommand(
   const githubView = githubOperatorView(normalizedText);
   if (githubView) {
     return { handled: true, kind: "github_status", source, view: githubView, detailed };
+  }
+
+  if (isGithubBriefCommand(normalizedText)) {
+    return { handled: true, kind: "github_brief", source, detailed };
   }
 
   if (isLatestWikipediaCitationRepairStatusCommand(normalizedText)) {
@@ -331,6 +344,11 @@ function githubOperatorView(text: string): GithubOperatorView | undefined {
   if (/^(github issues|github issue digest|github open issues|issue digest)$/.test(compact)) return "issues";
   if (/^(github digest|github attention|github needs attention|github work digest)$/.test(compact)) return "digest";
   return undefined;
+}
+
+function isGithubBriefCommand(text: string): boolean {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  return /^(github brief|daily github brief|github daily brief|github changes|github changed|what changed since last time|what changed in github since last time|what merged|what deployed|what failed|what needs attention)$/.test(compact);
 }
 
 function wantsDetailedOutput(text: string): boolean {

--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -1,4 +1,5 @@
 export type GithubOperatorView = "status" | "prs" | "ci" | "issues" | "digest";
+export type GithubBriefSection = "changed" | "merged" | "deployed" | "failed" | "attention";
 
 export interface GithubOperatorStatus {
   schemaVersion: 1;
@@ -99,12 +100,58 @@ export interface GithubWarning {
   repo?: string;
 }
 
+export interface GithubBriefItem {
+  kind: "pull_request" | "issue" | "workflow_run" | "warning" | "repo";
+  section: GithubBriefSection;
+  repo?: string;
+  title: string;
+  detail?: string;
+  url?: string;
+  occurredAt?: string;
+  severity?: "info" | "attention" | "blocked";
+}
+
+export interface GithubOperatorBrief {
+  schemaVersion: 1;
+  generatedAt: string;
+  mutatesGithub: false;
+  persistsLocalSnapshot: boolean;
+  configured: boolean;
+  authConfigured: boolean;
+  health: "ok" | "attention" | "degraded";
+  repoCount: number;
+  since?: string;
+  isFirstBrief: boolean;
+  summary: {
+    changed: number;
+    merged: number;
+    deployed: number;
+    failed: number;
+    attention: number;
+  };
+  sections: Record<GithubBriefSection, GithubBriefItem[]>;
+  warnings: GithubWarning[];
+  recommendations: string[];
+}
+
 export interface GithubOperatorStatusOptions {
   view?: GithubOperatorView;
   env?: NodeJS.ProcessEnv;
   fetchFn?: typeof fetch;
   now?: Date;
 }
+
+export interface GithubOperatorBriefOptions {
+  env?: NodeJS.ProcessEnv;
+  fetchFn?: typeof fetch;
+  now?: Date;
+  query?: GithubBriefQueryFn;
+}
+
+type GithubBriefQueryFn = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[]
+) => Promise<T[]>;
 
 interface GithubApiRepo {
   full_name?: string;
@@ -124,7 +171,9 @@ interface GithubApiPullRequest {
   html_url?: string;
   user?: GithubApiUser | null;
   draft?: boolean;
+  created_at?: string;
   updated_at?: string;
+  merged_at?: string | null;
   state?: string;
 }
 
@@ -133,7 +182,9 @@ interface GithubApiIssue {
   title?: string;
   html_url?: string;
   user?: GithubApiUser | null;
+  created_at?: string;
   updated_at?: string;
+  closed_at?: string | null;
   state?: string;
   labels?: Array<{ name?: string }>;
   pull_request?: unknown;
@@ -147,7 +198,13 @@ interface GithubApiWorkflowRun {
   head_branch?: string | null;
   event?: string;
   html_url?: string;
+  created_at?: string;
   updated_at?: string;
+}
+
+interface GithubBriefSnapshot {
+  generatedAt?: string;
+  repos?: string[];
 }
 
 export async function getGithubOperatorStatus(
@@ -254,6 +311,125 @@ export async function getGithubOperatorStatus(
   };
 }
 
+export async function getGithubOperatorBrief(
+  options: GithubOperatorBriefOptions = {}
+): Promise<GithubOperatorBrief> {
+  const env = options.env ?? process.env;
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const repos = parseGithubRepos(env);
+  const tokenConfig = buildGithubTokenConfig(env);
+  const warnings: GithubWarning[] = [];
+  const snapshotScope = githubBriefSnapshotScope(repos);
+
+  if (!tokenConfig.hasAnyToken || repos.length === 0) {
+    if (!tokenConfig.hasAnyToken) {
+      warnings.push({
+        severity: "high",
+        code: "github_token_missing",
+        message: "No GitHub token is configured, so the GitHub brief is unavailable.",
+      });
+    }
+    if (repos.length === 0) {
+      warnings.push({
+        severity: "high",
+        code: "github_repos_missing",
+        message: "Set GITHUB_HELPER_REPOS or GITHUB_DEFAULT_REPO to enable the GitHub brief.",
+      });
+    }
+    return emptyBrief({
+      generatedAt,
+      authConfigured: tokenConfig.hasAnyToken,
+      configured: false,
+      warnings,
+      persistsLocalSnapshot: false,
+    });
+  }
+
+  const fetchFn = options.fetchFn ?? fetch;
+  const baseUrl = (env.GITHUB_API_BASE_URL ?? "https://api.github.com").replace(/\/+$/g, "");
+  const limit = clampLimit(env.GITHUB_HELPER_LIMIT);
+  const repoInputs = repos.flatMap((repo) => {
+    const token = resolveGithubTokenForRepo(repo, tokenConfig);
+    if (!token) {
+      warnings.push({
+        severity: "high",
+        code: "github_repo_token_missing",
+        repo,
+        message: `No GitHub token is configured for ${repo}.`,
+      });
+      return [];
+    }
+    return [{ repo, token }];
+  });
+
+  const previousSnapshot = await readGithubBriefSnapshot(options.query, snapshotScope, warnings);
+  const since = previousSnapshot?.generatedAt;
+  const repoResults = await Promise.all(
+    repoInputs.map(({ repo, token }) => collectRepoBrief({ repo, baseUrl, token, limit, fetchFn }))
+  );
+
+  const allOpenPrs: GithubPullRequestItem[] = [];
+  const allMergedPrs: GithubPullRequestItem[] = [];
+  const allOpenIssues: GithubIssueItem[] = [];
+  const allClosedIssues: GithubIssueItem[] = [];
+  const allRuns: GithubWorkflowRunItem[] = [];
+  const repositories: GithubRepositoryStatus[] = [];
+
+  for (const result of repoResults) {
+    warnings.push(...result.warnings);
+    if (result.status) repositories.push(result.status);
+    allOpenPrs.push(...result.openPullRequests);
+    allMergedPrs.push(...result.mergedPullRequests);
+    allOpenIssues.push(...result.openIssues);
+    allClosedIssues.push(...result.closedIssues);
+    allRuns.push(...result.workflowRuns);
+  }
+
+  const sections = buildGithubBriefSections({
+    since,
+    warnings,
+    openPullRequests: allOpenPrs,
+    mergedPullRequests: allMergedPrs,
+    openIssues: allOpenIssues,
+    closedIssues: allClosedIssues,
+    workflowRuns: allRuns,
+  });
+  const summary = {
+    changed: sections.changed.length,
+    merged: sections.merged.length,
+    deployed: sections.deployed.length,
+    failed: sections.failed.length,
+    attention: sections.attention.length,
+  };
+  const health = warnings.some((warning) => warning.severity === "high")
+    ? "degraded"
+    : summary.failed > 0 || summary.attention > 0
+      ? "attention"
+      : "ok";
+
+  const snapshotSaved = await writeGithubBriefSnapshot(options.query, snapshotScope, {
+    generatedAt,
+    repos,
+  }, warnings);
+
+  return {
+    schemaVersion: 1,
+    generatedAt,
+    mutatesGithub: false,
+    persistsLocalSnapshot: snapshotSaved,
+    configured: repoInputs.length > 0,
+    authConfigured: true,
+    health,
+    repoCount: repositories.length,
+    ...(since ? { since } : {}),
+    isFirstBrief: !since,
+    summary,
+    sections,
+    warnings,
+    recommendations: buildGithubBriefRecommendations({ health, summary, isFirstBrief: !since }),
+  };
+}
+
 function emptyStatus(input: {
   generatedAt: string;
   view: GithubOperatorView;
@@ -290,6 +466,53 @@ function emptyStatus(input: {
       digest,
     },
     selectedView: { name: input.view, items: input.view === "digest" ? digest : [] },
+    warnings: input.warnings,
+    recommendations: [
+      "Set GITHUB_TOKEN with read-only access to all target repositories, or use owner/repo token maps.",
+      "Set GITHUB_DEFAULT_REPO=owner/repo or GITHUB_HELPER_REPOS=owner/repo,owner/repo.",
+    ],
+  };
+}
+
+function emptyBrief(input: {
+  generatedAt: string;
+  authConfigured: boolean;
+  configured: boolean;
+  warnings: GithubWarning[];
+  persistsLocalSnapshot: boolean;
+}): GithubOperatorBrief {
+  const attention = input.warnings.map((warning): GithubBriefItem => ({
+    kind: "warning",
+    section: "attention",
+    severity: warning.severity === "high" ? "blocked" : "attention",
+    repo: warning.repo,
+    title: warning.message,
+    detail: warning.code,
+  }));
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    mutatesGithub: false,
+    persistsLocalSnapshot: input.persistsLocalSnapshot,
+    configured: input.configured,
+    authConfigured: input.authConfigured,
+    health: "degraded",
+    repoCount: 0,
+    isFirstBrief: true,
+    summary: {
+      changed: 0,
+      merged: 0,
+      deployed: 0,
+      failed: 0,
+      attention: attention.length,
+    },
+    sections: {
+      changed: [],
+      merged: [],
+      deployed: [],
+      failed: [],
+      attention,
+    },
     warnings: input.warnings,
     recommendations: [
       "Set GITHUB_TOKEN with read-only access to all target repositories, or use owner/repo token maps.",
@@ -461,6 +684,147 @@ async function collectRepoStatus(input: {
   }
 }
 
+async function collectRepoBrief(input: {
+  repo: string;
+  baseUrl: string;
+  token: string;
+  limit: number;
+  fetchFn: typeof fetch;
+}): Promise<{
+  status?: GithubRepositoryStatus;
+  openPullRequests: GithubPullRequestItem[];
+  mergedPullRequests: GithubPullRequestItem[];
+  openIssues: GithubIssueItem[];
+  closedIssues: GithubIssueItem[];
+  workflowRuns: GithubWorkflowRunItem[];
+  warnings: GithubWarning[];
+}> {
+  const warnings: GithubWarning[] = [];
+  const repoPath = encodeRepoPath(input.repo);
+  try {
+    const [repo, openPulls, closedPulls, openIssues, closedIssues, runs] = await Promise.all([
+      githubGet<GithubApiRepo>(`${input.baseUrl}/repos/${repoPath}`, input.token, input.fetchFn),
+      githubGet<GithubApiPullRequest[]>(
+        `${input.baseUrl}/repos/${repoPath}/pulls?state=open&sort=updated&direction=desc&per_page=${input.limit}`,
+        input.token,
+        input.fetchFn
+      ),
+      githubGet<GithubApiPullRequest[]>(
+        `${input.baseUrl}/repos/${repoPath}/pulls?state=closed&sort=updated&direction=desc&per_page=${input.limit}`,
+        input.token,
+        input.fetchFn
+      ),
+      githubGet<GithubApiIssue[]>(
+        `${input.baseUrl}/repos/${repoPath}/issues?state=open&sort=updated&direction=desc&per_page=${input.limit * 2}`,
+        input.token,
+        input.fetchFn
+      ),
+      githubGet<GithubApiIssue[]>(
+        `${input.baseUrl}/repos/${repoPath}/issues?state=closed&sort=updated&direction=desc&per_page=${input.limit * 2}`,
+        input.token,
+        input.fetchFn
+      ),
+      githubGet<{ workflow_runs?: GithubApiWorkflowRun[] }>(
+        `${input.baseUrl}/repos/${repoPath}/actions/runs?per_page=${input.limit}`,
+        input.token,
+        input.fetchFn
+      ),
+    ]);
+    const openPullRequestItems = mapPullRequests(openPulls, input.repo, input.limit);
+    const mergedPullRequestItems = mapPullRequests(
+      closedPulls.filter((pull) => Boolean(pull.merged_at)),
+      input.repo,
+      input.limit
+    );
+    const openIssueItems = mapIssues(openIssues, input.repo, input.limit);
+    const closedIssueItems = mapIssues(closedIssues, input.repo, input.limit);
+    const workflowRuns = mapWorkflowRuns(runs.workflow_runs ?? [], input.repo, input.limit);
+
+    return {
+      status: {
+        repo: input.repo,
+        defaultBranch: repo.default_branch,
+        private: repo.private,
+        openPullRequests: openPullRequestItems.length,
+        openIssues: openIssueItems.length,
+        failingWorkflowRuns: workflowRuns.filter((run) => isFailedRun(run)).length,
+        activeWorkflowRuns: workflowRuns.filter((run) => run.status !== "completed").length,
+        url: repo.html_url,
+      },
+      openPullRequests: openPullRequestItems,
+      mergedPullRequests: mergedPullRequestItems,
+      openIssues: openIssueItems,
+      closedIssues: closedIssueItems,
+      workflowRuns,
+      warnings,
+    };
+  } catch (error) {
+    warnings.push({
+      severity: "high",
+      code: "github_repo_fetch_failed",
+      repo: input.repo,
+      message: error instanceof Error ? error.message : `Failed to fetch ${input.repo}`,
+    });
+    return {
+      openPullRequests: [],
+      mergedPullRequests: [],
+      openIssues: [],
+      closedIssues: [],
+      workflowRuns: [],
+      warnings,
+    };
+  }
+}
+
+function mapPullRequests(pulls: GithubApiPullRequest[], repo: string, limit: number): GithubPullRequestItem[] {
+  return pulls.slice(0, limit).map((pull) => ({
+    kind: "pull_request" as const,
+    repo,
+    number: numberField(pull.number),
+    title: pull.title ?? "Untitled pull request",
+    url: pull.html_url,
+    author: pull.user?.login,
+    draft: pull.draft === true,
+    updatedAt: pull.merged_at ?? pull.updated_at ?? pull.created_at,
+    state: pull.state ?? "open",
+  })).filter((pull) => pull.number > 0);
+}
+
+function mapIssues(issues: GithubApiIssue[], repo: string, limit: number): GithubIssueItem[] {
+  return issues
+    .filter((issue) => issue.pull_request === undefined)
+    .slice(0, limit)
+    .map((issue) => ({
+      kind: "issue" as const,
+      repo,
+      number: numberField(issue.number),
+      title: issue.title ?? "Untitled issue",
+      url: issue.html_url,
+      author: issue.user?.login,
+      updatedAt: issue.closed_at ?? issue.updated_at ?? issue.created_at,
+      state: issue.state ?? "open",
+      labels: Array.isArray(issue.labels)
+        ? issue.labels.map((label) => label.name).filter((label): label is string => Boolean(label))
+        : [],
+    }))
+    .filter((issue) => issue.number > 0);
+}
+
+function mapWorkflowRuns(runs: GithubApiWorkflowRun[], repo: string, limit: number): GithubWorkflowRunItem[] {
+  return runs.slice(0, limit).map((run) => ({
+    kind: "workflow_run" as const,
+    repo,
+    id: numberField(run.id),
+    name: run.name ?? "Unnamed workflow",
+    status: run.status ?? "unknown",
+    ...(run.conclusion ? { conclusion: run.conclusion } : {}),
+    ...(run.head_branch ? { branch: run.head_branch } : {}),
+    ...(run.event ? { event: run.event } : {}),
+    ...(run.html_url ? { url: run.html_url } : {}),
+    ...(run.updated_at ?? run.created_at ? { updatedAt: run.updated_at ?? run.created_at } : {}),
+  })).filter((run) => run.id > 0);
+}
+
 async function githubGet<T>(url: string, token: string, fetchFn: typeof fetch): Promise<T> {
   const response = await fetchFn(url, {
     headers: {
@@ -594,6 +958,232 @@ function buildRecommendations(input: {
   return recommendations;
 }
 
+function buildGithubBriefSections(input: {
+  since?: string;
+  warnings: GithubWarning[];
+  openPullRequests: GithubPullRequestItem[];
+  mergedPullRequests: GithubPullRequestItem[];
+  openIssues: GithubIssueItem[];
+  closedIssues: GithubIssueItem[];
+  workflowRuns: GithubWorkflowRunItem[];
+}): Record<GithubBriefSection, GithubBriefItem[]> {
+  const afterSince = (value: string | undefined) => !input.since || isAfter(value, input.since);
+  const changed: GithubBriefItem[] = [
+    ...input.openPullRequests
+      .filter((pr) => afterSince(pr.updatedAt))
+      .map((pr) => briefItemFromPullRequest(pr, "changed", input.since ? "Opened or updated PR" : "Open PR")),
+    ...input.openIssues
+      .filter((issue) => afterSince(issue.updatedAt))
+      .map((issue) => briefItemFromIssue(issue, "changed", input.since ? "Opened or updated issue" : "Open issue")),
+    ...input.closedIssues
+      .filter((issue) => afterSince(issue.updatedAt))
+      .map((issue) => briefItemFromIssue(issue, "changed", "Closed issue")),
+  ];
+  const merged = input.mergedPullRequests
+    .filter((pr) => afterSince(pr.updatedAt))
+    .map((pr) => briefItemFromPullRequest(pr, "merged", "Merged PR"));
+  const deployed = input.workflowRuns
+    .filter((run) => run.status === "completed" && run.conclusion === "success" && isDeploymentRun(run) && afterSince(run.updatedAt))
+    .map((run) => briefItemFromWorkflowRun(run, "deployed", "Successful deploy/publish workflow"));
+  const failed = input.workflowRuns
+    .filter((run) => isFailedRun(run) && afterSince(run.updatedAt))
+    .map((run) => briefItemFromWorkflowRun(run, "failed", `Workflow ${run.conclusion ?? run.status}`));
+  const attention: GithubBriefItem[] = [
+    ...input.warnings.map((warning): GithubBriefItem => ({
+      kind: "warning",
+      section: "attention",
+      severity: warning.severity === "high" ? "blocked" : "attention",
+      repo: warning.repo,
+      title: warning.message,
+      detail: warning.code,
+    })),
+    ...input.openPullRequests
+      .filter((pr) => !pr.draft)
+      .map((pr) => briefItemFromPullRequest(pr, "attention", "Open PR needs review/merge decision")),
+    ...input.workflowRuns
+      .filter((run) => isFailedRun(run))
+      .map((run) => briefItemFromWorkflowRun(run, "attention", `Failed workflow needs attention (${run.conclusion ?? run.status})`)),
+    ...input.workflowRuns
+      .filter((run) => run.status !== "completed")
+      .map((run) => briefItemFromWorkflowRun(run, "attention", `Workflow still ${run.status}`)),
+    ...input.openIssues
+      .map((issue) => briefItemFromIssue(issue, "attention", "Open issue")),
+  ];
+
+  return {
+    changed: sortBriefItems(changed).slice(0, 10),
+    merged: sortBriefItems(merged).slice(0, 10),
+    deployed: sortBriefItems(deployed).slice(0, 10),
+    failed: sortBriefItems(failed).slice(0, 10),
+    attention: sortBriefItems(attention).slice(0, 10),
+  };
+}
+
+function briefItemFromPullRequest(
+  pr: GithubPullRequestItem,
+  section: GithubBriefSection,
+  detail: string
+): GithubBriefItem {
+  return {
+    kind: "pull_request",
+    section,
+    severity: section === "failed" ? "blocked" : section === "attention" ? "attention" : "info",
+    repo: pr.repo,
+    title: `PR #${pr.number}: ${pr.title}`,
+    detail: pr.draft ? `${detail} (draft)` : detail,
+    url: pr.url,
+    occurredAt: pr.updatedAt,
+  };
+}
+
+function briefItemFromIssue(
+  issue: GithubIssueItem,
+  section: GithubBriefSection,
+  detail: string
+): GithubBriefItem {
+  return {
+    kind: "issue",
+    section,
+    severity: section === "attention" ? "attention" : "info",
+    repo: issue.repo,
+    title: `Issue #${issue.number}: ${issue.title}`,
+    detail: issue.labels.length > 0 ? `${detail}; labels: ${issue.labels.join(", ")}` : detail,
+    url: issue.url,
+    occurredAt: issue.updatedAt,
+  };
+}
+
+function briefItemFromWorkflowRun(
+  run: GithubWorkflowRunItem,
+  section: GithubBriefSection,
+  detail: string
+): GithubBriefItem {
+  return {
+    kind: "workflow_run",
+    section,
+    severity: section === "failed" ? "blocked" : section === "attention" ? "attention" : "info",
+    repo: run.repo,
+    title: run.name,
+    detail: [detail, run.branch ? `branch ${run.branch}` : undefined, run.event ? `event ${run.event}` : undefined]
+      .filter(Boolean)
+      .join("; "),
+    url: run.url,
+    occurredAt: run.updatedAt,
+  };
+}
+
+function sortBriefItems(items: GithubBriefItem[]): GithubBriefItem[] {
+  return [...items].sort((a, b) => timestampMs(b.occurredAt) - timestampMs(a.occurredAt));
+}
+
+function buildGithubBriefRecommendations(input: {
+  health: GithubOperatorBrief["health"];
+  summary: GithubOperatorBrief["summary"];
+  isFirstBrief: boolean;
+}): string[] {
+  const recommendations: string[] = [];
+  if (input.isFirstBrief) recommendations.push("Baseline saved. The next `github brief` will report changes since this checkpoint.");
+  if (input.summary.failed > 0) recommendations.push("Start with failed workflow runs before merging or deploying more work.");
+  if (input.summary.attention > 0) recommendations.push("Review the attention section for open PRs, active CI, issues, or setup warnings.");
+  if (input.summary.deployed > 0) recommendations.push("Check deploy outputs if any production-facing workflow changed.");
+  if (recommendations.length === 0 && input.health === "ok") recommendations.push("No GitHub changes need attention since the last brief.");
+  return recommendations;
+}
+
+function isFailedRun(run: GithubWorkflowRunItem): boolean {
+  return run.conclusion === "failure"
+    || run.conclusion === "cancelled"
+    || run.conclusion === "timed_out"
+    || run.conclusion === "action_required";
+}
+
+function isDeploymentRun(run: GithubWorkflowRunItem): boolean {
+  const text = `${run.name} ${run.event ?? ""} ${run.branch ?? ""}`.toLowerCase();
+  return /\b(deploy|publish|release|production|discovery manifest)\b/.test(text);
+}
+
+function isAfter(value: string | undefined, since: string): boolean {
+  const valueMs = timestampMs(value);
+  const sinceMs = timestampMs(since);
+  return valueMs > 0 && sinceMs > 0 && valueMs > sinceMs;
+}
+
+function timestampMs(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function githubBriefSnapshotScope(repos: string[]): string {
+  return `github_brief:${repos.length > 0 ? [...repos].sort().join(",") : "unconfigured"}`;
+}
+
+async function readGithubBriefSnapshot(
+  query: GithubBriefQueryFn | undefined,
+  scope: string,
+  warnings: GithubWarning[]
+): Promise<GithubBriefSnapshot | undefined> {
+  if (!query) return undefined;
+  try {
+    const rows = await query<{ value?: unknown }>(
+      "select value from operator_state_snapshots where scope = $1 limit 1",
+      [scope]
+    );
+    const value = rows[0]?.value;
+    return toGithubBriefSnapshot(value);
+  } catch (error) {
+    warnings.push({
+      severity: "medium",
+      code: "github_brief_snapshot_read_failed",
+      message: error instanceof Error ? error.message : "Failed to read the previous GitHub brief snapshot.",
+    });
+    return undefined;
+  }
+}
+
+async function writeGithubBriefSnapshot(
+  query: GithubBriefQueryFn | undefined,
+  scope: string,
+  snapshot: GithubBriefSnapshot,
+  warnings: GithubWarning[]
+): Promise<boolean> {
+  if (!query) return false;
+  try {
+    await query(
+      `insert into operator_state_snapshots(scope, value, updated_at)
+       values ($1, $2::jsonb, now())
+       on conflict (scope)
+       do update set value = excluded.value, updated_at = now()`,
+      [scope, JSON.stringify(snapshot)]
+    );
+    return true;
+  } catch (error) {
+    warnings.push({
+      severity: "medium",
+      code: "github_brief_snapshot_write_failed",
+      message: error instanceof Error ? error.message : "Failed to save the GitHub brief snapshot.",
+    });
+    return false;
+  }
+}
+
+function toGithubBriefSnapshot(value: unknown): GithubBriefSnapshot | undefined {
+  const record = typeof value === "string" ? safeJsonRecord(value) : isRecord(value) ? value : undefined;
+  if (!record) return undefined;
+  const generatedAt = typeof record.generatedAt === "string" ? record.generatedAt : undefined;
+  const repos = Array.isArray(record.repos) ? record.repos.map(String) : undefined;
+  return { ...(generatedAt ? { generatedAt } : {}), ...(repos ? { repos } : {}) };
+}
+
+function safeJsonRecord(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function selectView(input: {
   view: GithubOperatorView;
   status: GithubStatusItem[];
@@ -611,4 +1201,8 @@ function selectView(input: {
 
 function numberField(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -7,7 +7,7 @@ import {
 } from "./operator-commands.js";
 import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
-import { getGithubOperatorStatus } from "./operator-github.js";
+import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
@@ -71,6 +71,10 @@ export async function handleOperatorCommandText(
   }
   if (command.kind === "github_status") {
     const github = await getGithubOperatorStatus({ view: command.view });
+    return { ...command, github };
+  }
+  if (command.kind === "github_brief") {
+    const github = await getGithubOperatorBrief({ query: deps.query });
     return { ...command, github };
   }
   const result = await runWikipediaCitationRepairWorkflow(

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -248,6 +248,9 @@ export function formatOperatorResultForSlack(result: unknown): string {
   if (result.kind === "github_status") {
     return formatGithubStatusForSlack(result);
   }
+  if (result.kind === "github_brief") {
+    return formatGithubBriefForSlack(result);
+  }
   if (result.kind === "operator_status") {
     const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
@@ -420,6 +423,50 @@ function formatGithubStatusForSlack(result: Record<string, unknown>): string {
   ].filter(Boolean).join("\n");
 }
 
+function formatGithubBriefForSlack(result: Record<string, unknown>): string {
+  const github = isRecord(result.github) ? result.github : {};
+  const summary = isRecord(github.summary) ? github.summary : {};
+  const sections = isRecord(github.sections) ? github.sections : {};
+  const warnings = Array.isArray(github.warnings) ? github.warnings : [];
+  const recommendations = Array.isArray(github.recommendations) ? github.recommendations : [];
+  const configured = github.configured === true;
+
+  if (!configured) {
+    const warningLines = warnings.slice(0, 4).map(formatGithubWarning).join("\n");
+    return [
+      "*GitHub brief*",
+      "GitHub read-only helper is not configured yet.",
+      warningLines ? `*Missing setup*\n${warningLines}` : "",
+      "*Needed*",
+      "• `GITHUB_TOKEN` with read-only access to the target repo, or owner/repo-specific token maps",
+      "• `GITHUB_DEFAULT_REPO=owner/repo` or `GITHUB_HELPER_REPOS=owner/repo,owner/repo`",
+    ].filter(Boolean).join("\n");
+  }
+
+  const changed = arrayField(sections, "changed");
+  const merged = arrayField(sections, "merged");
+  const deployed = arrayField(sections, "deployed");
+  const failed = arrayField(sections, "failed");
+  const attention = arrayField(sections, "attention");
+  return [
+    "*GitHub brief*",
+    github.isFirstBrief === true
+      ? "Baseline saved. Future briefs will compare against this one."
+      : `Since: \`${stringField(github, "since") ?? "previous brief"}\``,
+    `• repos: \`${numberField(github, "repoCount") ?? 0}\``,
+    `• changed/merged/deployed/failed/attention: \`${numberField(summary, "changed") ?? 0}/${numberField(summary, "merged") ?? 0}/${numberField(summary, "deployed") ?? 0}/${numberField(summary, "failed") ?? 0}/${numberField(summary, "attention") ?? 0}\``,
+    changed.length > 0 ? `*Changed*\n${changed.slice(0, 5).map(formatGithubBriefItem).join("\n")}` : "*Changed*\n• none",
+    merged.length > 0 ? `*Merged*\n${merged.slice(0, 5).map(formatGithubBriefItem).join("\n")}` : "*Merged*\n• none",
+    deployed.length > 0 ? `*Deployed*\n${deployed.slice(0, 5).map(formatGithubBriefItem).join("\n")}` : "*Deployed*\n• none",
+    failed.length > 0 ? `*Failed*\n${failed.slice(0, 5).map(formatGithubBriefItem).join("\n")}` : "*Failed*\n• none",
+    attention.length > 0 ? `*Needs attention*\n${attention.slice(0, 5).map(formatGithubBriefItem).join("\n")}` : "*Needs attention*\n• none",
+    recommendations.length > 0 ? `*Next*\n${recommendations.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+    github.persistsLocalSnapshot === true
+      ? "GitHub was not mutated; only the local brief checkpoint was updated."
+      : "GitHub was not mutated. Local brief checkpoint was not saved.",
+  ].filter(Boolean).join("\n");
+}
+
 function githubViewTitle(view: string): string {
   if (view === "prs") return "Open PRs";
   if (view === "ci") return "Workflow runs";
@@ -459,6 +506,20 @@ function formatGithubWarning(value: unknown): string {
   if (!isRecord(value)) return "• unknown warning";
   const repo = stringField(value, "repo");
   return `• \`${stringField(value, "severity") ?? "warning"}\`${repo ? ` ${repo}` : ""}: ${stringField(value, "message") ?? stringField(value, "code") ?? "unknown"}`;
+}
+
+function formatGithubBriefItem(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const repo = stringField(value, "repo");
+  const detail = stringField(value, "detail");
+  const occurredAt = stringField(value, "occurredAt");
+  const meta = [repo, detail, occurredAt].filter(Boolean).join(" - ");
+  return `• ${meta ? `\`${meta}\` ` : ""}${stringField(value, "title") ?? "unknown"}${linkSuffix(value)}`;
+}
+
+function arrayField(value: Record<string, unknown>, key: string): unknown[] {
+  const field = value[key];
+  return Array.isArray(field) ? field : [];
 }
 
 function linkSuffix(value: Record<string, unknown>): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -164,6 +164,18 @@ describe("operator commands", () => {
       view: "issues",
       detailed: false,
     });
+    expect(parseOperatorCommand("daily github brief", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "github_brief",
+      source: "slack",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("what changed since last time details", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "github_brief",
+      source: "command_center",
+      detailed: true,
+    });
   });
 
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getGithubOperatorStatus } from "../../packages/averray-mcp/src/operator-github.js";
+import { getGithubOperatorBrief, getGithubOperatorStatus } from "../../packages/averray-mcp/src/operator-github.js";
 
 describe("github operator status", () => {
   it("reports setup blockers when token or repo config is missing", async () => {
@@ -145,6 +145,109 @@ describe("github operator status", () => {
     });
     expect(seenAuthByRepo.get("averray-agent/agent")).toBe("Bearer token-averray-agent");
     expect(seenAuthByRepo.get("depre-dev/averray-reference-agent")).toBe("Bearer token-depre-dev");
+  });
+
+  it("builds a since-last-time brief and persists a local checkpoint", async () => {
+    const writes: unknown[][] = [];
+    const query = async <T = Record<string, unknown>>(text: string, values?: unknown[]): Promise<T[]> => {
+      if (text.includes("select value from operator_state_snapshots")) {
+        return [{ value: { generatedAt: "2026-05-08T10:00:00.000Z", repos: ["averray-agent/agent"] } } as T];
+      }
+      if (text.includes("insert into operator_state_snapshots")) {
+        writes.push(values ?? []);
+        return [];
+      }
+      return [];
+    };
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent")) return githubRepoResponse("averray-agent/agent");
+      if (text.includes("/pulls?state=open")) {
+        return jsonResponse([
+          {
+            number: 185,
+            title: "Record testnet deployment manifest",
+            html_url: "https://github.com/averray-agent/agent/pull/185",
+            user: { login: "depre-dev" },
+            draft: false,
+            updated_at: "2026-05-08T11:30:00.000Z",
+            state: "open",
+          },
+        ]);
+      }
+      if (text.includes("/pulls?state=closed")) {
+        return jsonResponse([
+          {
+            number: 184,
+            title: "Reconcile testnet checklists",
+            html_url: "https://github.com/averray-agent/agent/pull/184",
+            user: { login: "codex" },
+            draft: false,
+            merged_at: "2026-05-08T11:00:00.000Z",
+            updated_at: "2026-05-08T11:00:00.000Z",
+            state: "closed",
+          },
+        ]);
+      }
+      if (text.includes("/issues?state=open")) return jsonResponse([]);
+      if (text.includes("/issues?state=closed")) return jsonResponse([]);
+      if (text.includes("/actions/runs?")) {
+        return jsonResponse({
+          workflow_runs: [
+            {
+              id: 2,
+              name: "Deploy Production",
+              status: "completed",
+              conclusion: "success",
+              head_branch: "main",
+              event: "push",
+              html_url: "https://github.com/averray-agent/agent/actions/runs/2",
+              updated_at: "2026-05-08T11:15:00.000Z",
+            },
+            {
+              id: 3,
+              name: "CI",
+              status: "completed",
+              conclusion: "failure",
+              head_branch: "feature",
+              event: "pull_request",
+              html_url: "https://github.com/averray-agent/agent/actions/runs/3",
+              updated_at: "2026-05-08T11:20:00.000Z",
+            },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const brief = await getGithubOperatorBrief({
+      env: {
+        GITHUB_TOKEN: "ghp_readonly",
+        GITHUB_DEFAULT_REPO: "averray-agent/agent",
+      },
+      fetchFn,
+      query,
+      now: new Date("2026-05-08T12:00:00.000Z"),
+    });
+
+    expect(brief).toMatchObject({
+      configured: true,
+      authConfigured: true,
+      since: "2026-05-08T10:00:00.000Z",
+      isFirstBrief: false,
+      summary: {
+        changed: 1,
+        merged: 1,
+        deployed: 1,
+        failed: 1,
+        attention: 2,
+      },
+      persistsLocalSnapshot: true,
+    });
+    expect(brief.sections.merged[0]).toMatchObject({ title: "PR #184: Reconcile testnet checklists" });
+    expect(brief.sections.deployed[0]).toMatchObject({ title: "Deploy Production" });
+    expect(brief.sections.failed[0]).toMatchObject({ title: "CI" });
+    expect(writes).toHaveLength(1);
   });
 });
 

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -479,6 +479,81 @@ describe("slack operator bridge", () => {
     expect(text).toContain("GITHUB_DEFAULT_REPO");
   });
 
+  it("formats GitHub brief replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "github_brief",
+      detailed: false,
+      github: {
+        configured: true,
+        repoCount: 1,
+        since: "2026-05-08T10:00:00.000Z",
+        isFirstBrief: false,
+        persistsLocalSnapshot: true,
+        summary: {
+          changed: 1,
+          merged: 1,
+          deployed: 1,
+          failed: 1,
+          attention: 1,
+        },
+        sections: {
+          changed: [
+            {
+              kind: "pull_request",
+              repo: "averray-agent/agent",
+              title: "PR #185: Record testnet deployment manifest",
+              detail: "Opened or updated PR",
+              occurredAt: "2026-05-08T11:30:00.000Z",
+            },
+          ],
+          merged: [
+            {
+              kind: "pull_request",
+              repo: "averray-agent/agent",
+              title: "PR #184: Reconcile testnet checklists",
+              detail: "Merged PR",
+            },
+          ],
+          deployed: [
+            {
+              kind: "workflow_run",
+              repo: "averray-agent/agent",
+              title: "Deploy Production",
+              detail: "Successful deploy/publish workflow",
+            },
+          ],
+          failed: [
+            {
+              kind: "workflow_run",
+              repo: "averray-agent/agent",
+              title: "CI",
+              detail: "Workflow failure",
+            },
+          ],
+          attention: [
+            {
+              kind: "pull_request",
+              repo: "averray-agent/agent",
+              title: "PR #185: Record testnet deployment manifest",
+              detail: "Open PR needs review/merge decision",
+            },
+          ],
+        },
+        warnings: [],
+        recommendations: ["Start with failed workflow runs before merging or deploying more work."],
+      },
+    });
+
+    expect(text).toContain("*GitHub brief*");
+    expect(text).toContain("Since: `2026-05-08T10:00:00.000Z`");
+    expect(text).toContain("changed/merged/deployed/failed/attention: `1/1/1/1/1`");
+    expect(text).toContain("*Merged*");
+    expect(text).toContain("Deploy Production");
+    expect(text).toContain("Workflow failure");
+    expect(text).toContain("local brief checkpoint was updated");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## What changed
- Added a read-only GitHub brief MCP tool and operator command route for `github brief`, `daily github brief`, and `what changed since last time`.
- Reports what changed, merged, deployed, failed, and needs attention across configured GitHub repos.
- Persists only a local checkpoint timestamp in Postgres so the next brief can compare against the previous one.
- Added Slack formatting and docs for the new command.

## Checks run
- `npm run typecheck`
- `npm test`

## Impact
- Backend/MCP: yes
- Slack operator: yes
- Database migration: yes, adds `operator_state_snapshots`
- Frontend/indexer/contracts/public site/Caddy: no

## Env/VPS notes
- Uses existing `GITHUB_TOKEN`, `GITHUB_DEFAULT_REPO`, `GITHUB_HELPER_REPOS`, `GITHUB_OWNER_TOKENS`, and `GITHUB_REPO_TOKENS` config.
- No new secrets required.