### PR TITLE
Add testbed E2E suite command

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   recognizes `what can you do for us`, `admin readiness`, `business ledger`,
   `ops health`, `github status`, `github open prs`, `github ci failures`,
   `github issue digest`, `github brief`, `daily github brief`,
-  `what changed since last time`, `daily operator brief`, `find safe work`,
+  `what changed since last time`, `testbed e2e suite`,
+  `platform e2e suite`, `daily operator brief`, `find safe work`,
   `operator status`, `operator status details`,
   `run one wikipedia citation repair if safe`, and
   `status last wikipedia citation repair`. GitHub commands call
@@ -160,6 +161,12 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `daily operator brief` and `find safe work` are read-only summaries that turn
   the current wallet, budget, latest-run, and open-job state into practical next
   actions for any MCP client, not just Slack or Hermes Workspace.
+  `testbed e2e suite` and `platform e2e suite` call
+  `averray_testbed_e2e_suite`, a read-only E2E checklist for backend agents,
+  Slack, Command Center, and MCP clients. It returns ordered test cases,
+  commands, expected evidence, readiness blockers, and mutation boundaries for
+  exercising the platform like a normal operator without accidentally claiming,
+  submitting, deploying, editing GitHub, or editing Wikipedia.
   `operator status` calls the canonical read-only
   `averray_operator_status` MCP tool and returns wallet, budget, open-job,
   latest-run, safety, and safe-command metadata. Human surfaces can show

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -170,6 +170,8 @@ github issue digest
 github brief
 daily github brief
 what changed since last time
+testbed e2e suite
+platform e2e suite
 find safe work
 operator status
 operator status details
@@ -207,7 +209,14 @@ force-recreate `mcp-env`, `hermes`, `hermes-gateway`, `hermes-workspace`, and
 `daily operator brief` and
 `find safe work` are read-only views for humans and agents: they summarize
 wallet/budget readiness, latest run state, candidate jobs, blockers, and the
-next dry-run or guarded mutation command. `operator status` calls the canonical
+next dry-run or guarded mutation command. `testbed e2e suite` and
+`platform e2e suite` call `averray_testbed_e2e_suite`, a read-only suite
+generator for backend agents, Slack, Command Center, and MCP clients. It
+returns ordered E2E cases, exact operator commands, MCP tools, expected
+evidence, readiness blockers, and mutation boundaries. The suite generator does
+not claim, submit, deploy, edit GitHub, or edit Wikipedia; it marks the live
+workflow case and the local GitHub-brief checkpoint case separately so agents
+can decide what to run safely. `operator status` calls the canonical
 read-only `averray_operator_status` MCP tool, returning wallet readiness,
 policy budget, open Wikipedia job counts, latest run state, safety guarantees,
 and safe command suggestions as structured JSON. Repair commands call

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -46,6 +46,7 @@ import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
+import { getTestbedE2eSuite } from "./operator-testbed.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -217,8 +218,17 @@ server.tool(
 );
 
 server.tool(
+  "averray_testbed_e2e_suite",
+  "Canonical read-only testbed E2E suite for backend agents, Slack, Command Center, and MCP clients. Returns the ordered platform test cases, commands, expected evidence, readiness blockers, and mutation boundaries for exercising the Averray reference agent like a normal operator. The suite generator itself does not claim, submit, deploy, edit GitHub, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await getTestbedE2eSuite({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github commands are read-only against external systems. GitHub brief persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed commands are read-only against external systems. GitHub brief persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -72,6 +72,12 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "testbed_e2e_suite";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -114,6 +120,8 @@ const EXAMPLES = [
   "github open prs",
   "github ci failures",
   "github issue digest",
+  "testbed e2e suite",
+  "platform e2e suite",
   "find safe work",
   "operator status",
   "operator status details",
@@ -170,6 +178,10 @@ export function parseOperatorCommand(
     return { handled: true, kind: "github_brief", source, detailed };
   }
 
+  if (isTestbedE2eSuiteCommand(normalizedText)) {
+    return { handled: true, kind: "testbed_e2e_suite", source, detailed };
+  }
+
   if (isLatestWikipediaCitationRepairStatusCommand(normalizedText)) {
     return { handled: true, kind: "status_last_wikipedia_citation_repair", source, detailed };
   }
@@ -181,11 +193,11 @@ export function parseOperatorCommand(
   if (
     normalizedText.startsWith("run ") &&
     normalizedText.includes("wikipedia citation repair") &&
-    normalizedText.includes("if safe")
+    (normalizedText.includes("if safe") || wantsDryRunOnly(normalizedText))
   ) {
     const jobId = extractToken(text, /\bfor\s+([A-Za-z0-9_.:-]+)/i);
     const runId = extractToken(text, /\brun\s*id\s*[:=]?\s*([A-Za-z0-9_.:-]+)/i);
-    const dryRun = /\b(dry\s*run|preview|read[-\s]*only|no\s+submit)\b/i.test(text)
+    const dryRun = wantsDryRunOnly(text)
       ? true
       : options.defaultDryRun ?? false;
     return {
@@ -351,8 +363,17 @@ function isGithubBriefCommand(text: string): boolean {
   return /^(github brief|daily github brief|github daily brief|github changes|github changed|what changed since last time|what changed in github since last time|what merged|what deployed|what failed|what needs attention)$/.test(compact);
 }
 
+function isTestbedE2eSuiteCommand(text: string): boolean {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  return /^(testbed e2e|testbed e2e suite|platform e2e|platform e2e suite|e2e test suite|full e2e suite|testbed full suite|run testbed e2e|run platform e2e)$/.test(compact);
+}
+
 function wantsDetailedOutput(text: string): boolean {
   return /\b(details?|full|audit)\b/.test(text);
+}
+
+function wantsDryRunOnly(text: string): boolean {
+  return /\b(dry\s*run|preview|read[-\s]*only|no\s+submit)\b/i.test(text);
 }
 
 function extractToken(text: string, pattern: RegExp): string | undefined {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -9,6 +9,7 @@ import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+import { getTestbedE2eSuite } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 
@@ -76,6 +77,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "github_brief") {
     const github = await getGithubOperatorBrief({ query: deps.query });
     return { ...command, github };
+  }
+  if (command.kind === "testbed_e2e_suite") {
+    const suite = await getTestbedE2eSuite({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, suite };
   }
   const result = await runWikipediaCitationRepairWorkflow(
     { ...command.input, expectedWallet: input.expectedWallet },

--- a/packages/averray-mcp/src/operator-testbed.ts
+++ b/packages/averray-mcp/src/operator-testbed.ts
@@ -1,0 +1,245 @@
+import type { OperatorStatusDeps } from "./operator-status.js";
+import { getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+
+export interface TestbedE2eSuiteDeps extends OperatorStatusDeps {
+  env?: Record<string, string | undefined>;
+}
+
+export async function getTestbedE2eSuite(deps: TestbedE2eSuiteDeps) {
+  const [status, safeWork] = await Promise.all([
+    getOperatorStatus(deps),
+    getSafeWorkReport(deps),
+  ]);
+  const env = deps.env ?? process.env;
+  const githubConfigured = hasAny(env, ["GITHUB_TOKEN", "GITHUB_OWNER_TOKENS", "GITHUB_REPO_TOKENS"])
+    && hasAny(env, ["GITHUB_DEFAULT_REPO", "GITHUB_HELPER_REPOS"]);
+
+  const budgetRemaining = status.policy.budget.todayUsdRemaining;
+  const blockers = [
+    ...(status.agent.walletReady ? [] : ["wallet_not_ready"]),
+    ...(budgetRemaining > 0 ? [] : ["budget_depleted"]),
+    ...(status.workflows.wikipediaCitationRepair.openJobs > 0 ? [] : ["no_open_wikipedia_citation_repair_jobs"]),
+  ];
+  const warnings = [
+    ...(githubConfigured ? [] : ["github_helper_not_fully_configured"]),
+    ...(status.errors ?? []).map((entry) => `operator_status_warning:${entry}`),
+    ...(safeWork.errors ?? []).map((entry) => `safe_work_warning:${entry}`),
+  ];
+  const canRunDryRun = status.agent.walletReady && status.workflows.wikipediaCitationRepair.openJobs > 0;
+  const canRunGuardedLive = blockers.length === 0;
+
+  return {
+    schemaVersion: 1,
+    kind: "testbed_e2e_suite",
+    generatedAt: status.generatedAt,
+    mutates: false,
+    headline: canRunDryRun
+      ? "Platform testbed is ready for read-only and dry-run E2E checks."
+      : "Platform testbed can run read-only checks, but workflow E2E has blockers.",
+    readiness: {
+      overall: blockers.length === 0 ? "ready" : "blocked",
+      canRunReadOnly: true,
+      canRunDryRun,
+      canRunGuardedLive,
+      blockers,
+      warnings,
+    },
+    context: {
+      wallet: {
+        ready: status.agent.walletReady,
+        address: status.agent.walletAddress,
+        network: status.agent.network,
+      },
+      budget: status.policy.budget,
+      openWikipediaCitationRepairJobs: status.workflows.wikipediaCitationRepair.openJobs,
+      latestWikipediaCitationRepair: status.workflows.wikipediaCitationRepair.latestRun,
+      githubConfigured,
+    },
+    recommendedRunOrder: [
+      "TBE2E-001",
+      "TBE2E-002",
+      "TBE2E-003",
+      "TBE2E-004",
+      "TBE2E-005",
+      "TBE2E-006",
+      "TBE2E-007",
+      "TBE2E-008",
+      "TBE2E-009",
+      "TBE2E-010",
+      "TBE2E-011",
+    ],
+    testCases: [
+      testCase({
+        id: "TBE2E-001",
+        phase: "readiness",
+        name: "Operator readiness",
+        command: "operator status",
+        mcpTool: "averray_operator_status",
+        status: "ready",
+        expectedEvidence: ["wallet readiness", "budget state", "open job count", "latest run summary"],
+        successCriteria: ["response mutates=false", "safe commands are present", "no broad admin permissions are implied"],
+      }),
+      testCase({
+        id: "TBE2E-002",
+        phase: "briefing",
+        name: "Daily operator brief",
+        command: "daily operator brief",
+        mcpTool: "averray_daily_operator_brief",
+        status: "ready",
+        expectedEvidence: ["readiness headline", "recommended next action", "candidate jobs if available"],
+        successCriteria: ["brief is read-only", "operators can decide dry-run vs live workflow"],
+      }),
+      testCase({
+        id: "TBE2E-003",
+        phase: "discovery",
+        name: "Safe work discovery",
+        command: "find safe work",
+        mcpTool: "averray_find_safe_work",
+        status: safeWork.available ? "ready" : "blocked",
+        blockers: safeWork.blockers,
+        expectedEvidence: ["available flag", "dry-run command", "guarded mutation command"],
+        successCriteria: ["no claim or submit attempted", "each work item exposes the exact dry-run command"],
+      }),
+      testCase({
+        id: "TBE2E-004",
+        phase: "dry_run",
+        name: "Wikipedia citation repair dry run",
+        command: "run one wikipedia citation repair dry run only",
+        mcpTool: "averray_run_wikipedia_citation_repair",
+        status: canRunDryRun ? "ready" : "blocked",
+        blockers: canRunDryRun ? [] : blockers,
+        expectedEvidence: ["selected job", "read-only source checks", "draft/proposal summary", "validation result"],
+        successCriteria: ["dryRun=true", "no claim", "no submit", "no Wikipedia edit"],
+      }),
+      testCase({
+        id: "TBE2E-005",
+        phase: "guarded_mutation",
+        name: "Guarded live Wikipedia citation repair",
+        command: "run one wikipedia citation repair if safe",
+        mcpTool: "averray_run_wikipedia_citation_repair",
+        status: canRunGuardedLive ? "manual" : "blocked",
+        blockers: canRunGuardedLive ? [] : blockers,
+        mutates: true,
+        mutationScope: "averray_claim_draft_validate_submit_only",
+        expectedEvidence: ["claim policy pass", "draftId", "validation pass", "submit or confidence-held report"],
+        successCriteria: ["explicit command only", "draft saved before validation", "submit only if validation passes and confidence threshold is met"],
+      }),
+      testCase({
+        id: "TBE2E-006",
+        phase: "verification",
+        name: "Latest workflow status verification",
+        command: "status last wikipedia citation repair details",
+        mcpTool: "averray_status_last_wikipedia_citation_repair",
+        status: "ready",
+        expectedEvidence: ["runId", "jobId", "sessionId", "draftId", "submit_succeeded flag"],
+        successCriteria: ["status is read-only", "submitted, failed, or held state is explicit"],
+      }),
+      testCase({
+        id: "TBE2E-007",
+        phase: "business",
+        name: "Business ledger",
+        command: "business ledger",
+        mcpTool: "averray_business_ledger",
+        status: "ready",
+        expectedEvidence: ["recent submissions", "draft counts", "budget snapshot", "operator activity"],
+        successCriteria: ["ledger is read-only", "latest run and open work agree with operator status"],
+      }),
+      testCase({
+        id: "TBE2E-008",
+        phase: "ops",
+        name: "Control-plane ops health",
+        command: "ops health",
+        mcpTool: "averray_ops_health",
+        status: "ready",
+        expectedEvidence: ["wallet/budget", "table counts", "recent errors", "recent operator events"],
+        successCriteria: ["recent errors are reported clearly", "host-level checks are identified as outside MCP if needed"],
+      }),
+      testCase({
+        id: "TBE2E-009",
+        phase: "github",
+        name: "GitHub repo status",
+        command: "github status",
+        mcpTool: "averray_github_status",
+        status: githubConfigured ? "ready" : "optional",
+        blockers: githubConfigured ? [] : ["github_env_missing_or_partial"],
+        expectedEvidence: ["open PRs", "open issues", "CI failures", "active workflow runs"],
+        successCriteria: ["GitHub is read-only", "no PR merge, issue edit, or workflow rerun is attempted"],
+      }),
+      testCase({
+        id: "TBE2E-010",
+        phase: "github",
+        name: "GitHub delta brief",
+        command: "github brief",
+        mcpTool: "averray_github_brief",
+        status: githubConfigured ? "ready" : "optional",
+        blockers: githubConfigured ? [] : ["github_env_missing_or_partial"],
+        mutates: true,
+        mutationScope: "local_brief_checkpoint_only",
+        expectedEvidence: ["what changed", "what merged", "what deployed", "what failed", "what needs attention"],
+        successCriteria: ["GitHub is not mutated", "local checkpoint behavior is disclosed"],
+      }),
+      testCase({
+        id: "TBE2E-011",
+        phase: "surface_parity",
+        name: "Surface parity smoke",
+        command: "operator status",
+        mcpTool: "averray_handle_operator_command",
+        status: "manual",
+        expectedEvidence: ["same command works through MCP", "same command works through Slack", "same command works through Command Center"],
+        successCriteria: ["outputs agree on wallet, budget, open jobs, and latest run", "Slack may compact IDs but details mode exposes full audit IDs"],
+      }),
+    ],
+    safety: {
+      suiteGeneratorMutates: false,
+      readOnlyExternalSystemsMutated: false,
+      githubBriefWritesLocalCheckpoint: true,
+      guardedLiveCaseMutates: true,
+      editsWikipedia: false,
+      requiresExplicitMutationCommand: true,
+      validationRequiredBeforeSubmit: true,
+      confidenceThreshold: status.policy.submitConfidenceThreshold,
+    },
+    nextCommands: {
+      readOnly: "testbed e2e suite",
+      dryRun: "run one wikipedia citation repair dry run only",
+      guardedLive: "run one wikipedia citation repair if safe",
+      verify: "status last wikipedia citation repair details",
+    },
+  };
+}
+
+function testCase(input: {
+  id: string;
+  phase: string;
+  name: string;
+  command: string;
+  mcpTool: string;
+  status: "ready" | "blocked" | "optional" | "manual";
+  mutates?: boolean;
+  mutationScope?: string;
+  blockers?: string[];
+  expectedEvidence: string[];
+  successCriteria: string[];
+}) {
+  return {
+    id: input.id,
+    phase: input.phase,
+    name: input.name,
+    status: input.status,
+    mutates: input.mutates === true,
+    ...(input.mutationScope ? { mutationScope: input.mutationScope } : {}),
+    ...(input.blockers && input.blockers.length > 0 ? { blockers: input.blockers } : {}),
+    surfaces: {
+      mcpTool: input.mcpTool,
+      operatorCommand: input.command,
+      slackExample: `@Averray Reference Agent ${input.command}`,
+      commandCenterPrompt: input.command,
+    },
+    expectedEvidence: input.expectedEvidence,
+    successCriteria: input.successCriteria,
+  };
+}
+
+function hasAny(env: Record<string, string | undefined>, keys: string[]): boolean {
+  return keys.some((key) => typeof env[key] === "string" && env[key]!.trim().length > 0);
+}

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -251,6 +251,9 @@ export function formatOperatorResultForSlack(result: unknown): string {
   if (result.kind === "github_brief") {
     return formatGithubBriefForSlack(result);
   }
+  if (result.kind === "testbed_e2e_suite") {
+    return formatTestbedE2eSuiteForSlack(result);
+  }
   if (result.kind === "operator_status") {
     const detailed = result.detailed === true;
     const status = isRecord(result.status) ? result.status : {};
@@ -467,12 +470,61 @@ function formatGithubBriefForSlack(result: Record<string, unknown>): string {
   ].filter(Boolean).join("\n");
 }
 
+function formatTestbedE2eSuiteForSlack(result: Record<string, unknown>): string {
+  const suite = isRecord(result.suite) ? result.suite : {};
+  const readiness = isRecord(suite.readiness) ? suite.readiness : {};
+  const safety = isRecord(suite.safety) ? suite.safety : {};
+  const commands = isRecord(suite.nextCommands) ? suite.nextCommands : {};
+  const cases = arrayField(suite, "testCases");
+  const blockers = arrayField(readiness, "blockers");
+  const warnings = arrayField(readiness, "warnings");
+  const readyCases = cases.filter((entry) => isRecord(entry) && stringField(entry, "status") === "ready").length;
+  const mutatingCases = cases.filter((entry) => isRecord(entry) && entry.mutates === true).length;
+
+  return [
+    "*Averray testbed E2E suite*",
+    stringField(suite, "headline") ?? "Canonical platform E2E test suite.",
+    "",
+    "*Readiness*",
+    `• overall: \`${stringField(readiness, "overall") ?? "unknown"}\``,
+    `• read-only: \`${String(readiness.canRunReadOnly === true)}\``,
+    `• dry run: \`${String(readiness.canRunDryRun === true)}\``,
+    `• guarded live: \`${String(readiness.canRunGuardedLive === true)}\``,
+    blockers.length > 0 ? `• blockers: \`${blockers.map(String).join(", ")}\`` : "",
+    warnings.length > 0 ? `• warnings: \`${warnings.slice(0, 3).map(String).join(", ")}\`` : "",
+    "*Cases*",
+    `• total: \`${cases.length}\``,
+    `• ready: \`${readyCases}\``,
+    `• mutating/manual: \`${mutatingCases}\``,
+    cases.length > 0 ? cases.slice(0, 6).map(formatTestbedCase).join("\n") : "• none",
+    "*Next commands*",
+    `• suite: \`${stringField(commands, "readOnly") ?? "testbed e2e suite"}\``,
+    `• dry run: \`${stringField(commands, "dryRun") ?? "run one wikipedia citation repair dry run only"}\``,
+    `• guarded live: \`${stringField(commands, "guardedLive") ?? "run one wikipedia citation repair if safe"}\``,
+    "*Safety*",
+    `• suite mutates: \`${String(safety.suiteGeneratorMutates === true)}\``,
+    `• live case mutates: \`${String(safety.guardedLiveCaseMutates === true)}\``,
+    `• edits Wikipedia: \`${String(safety.editsWikipedia === true)}\``,
+  ].filter(Boolean).join("\n");
+}
+
 function githubViewTitle(view: string): string {
   if (view === "prs") return "Open PRs";
   if (view === "ci") return "Workflow runs";
   if (view === "issues") return "Open issues";
   if (view === "digest") return "Needs attention";
   return "Repositories";
+}
+
+function formatTestbedCase(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const surfaces = isRecord(value.surfaces) ? value.surfaces : {};
+  const id = stringField(value, "id") ?? "unknown";
+  const name = stringField(value, "name") ?? "untitled";
+  const status = stringField(value, "status") ?? "unknown";
+  const command = stringField(surfaces, "operatorCommand") ?? "operator status";
+  const mutates = value.mutates === true ? " mutates" : "";
+  return `• \`${id}\` ${name}: \`${status}${mutates}\` - \`${command}\``;
 }
 
 function formatGithubItem(value: unknown, detailed: boolean): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -40,6 +40,21 @@ describe("operator commands", () => {
     });
   });
 
+  it("accepts dry-run repair wording without a live safety phrase", () => {
+    const parsed = parseOperatorCommand("run one wikipedia citation repair dry run only", {
+      source: "operator",
+    });
+
+    expect(parsed).toMatchObject({
+      handled: true,
+      kind: "run_wikipedia_citation_repair",
+      source: "operator",
+      input: {
+        dryRun: true,
+      },
+    });
+  });
+
   it("routes the latest status command read-only", () => {
     const parsed = parseOperatorCommand("status last wikipedia citation repair.", { source: "operator" });
 
@@ -174,6 +189,21 @@ describe("operator commands", () => {
       handled: true,
       kind: "github_brief",
       source: "command_center",
+      detailed: true,
+    });
+  });
+
+  it("routes the platform testbed E2E suite read-only", () => {
+    expect(parseOperatorCommand("testbed e2e suite", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "testbed_e2e_suite",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("platform e2e suite details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "testbed_e2e_suite",
+      source: "slack",
       detailed: true,
     });
   });

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -8,6 +8,7 @@ import {
 import { getBusinessLedger, getOpsHealth } from "../../packages/averray-mcp/src/operator-insights.js";
 import { getAgentUsefulnessPlan } from "../../packages/averray-mcp/src/operator-usefulness.js";
 import { getAdminReadiness } from "../../packages/averray-mcp/src/operator-admin.js";
+import { getTestbedE2eSuite } from "../../packages/averray-mcp/src/operator-testbed.js";
 
 describe("operator status", () => {
   it("returns a canonical read-only status for agents and UIs", async () => {
@@ -266,6 +267,57 @@ describe("operator status", () => {
       expect.stringContaining("Merge PRs"),
       expect.stringContaining("Change DNS"),
     ]));
+
+    const suite = await getTestbedE2eSuite({
+      ...deps,
+      env: {
+        GITHUB_TOKEN: "ghp_readonly",
+        GITHUB_HELPER_REPOS: "depre-dev/averray-reference-agent",
+      },
+    });
+    expect(suite).toMatchObject({
+      kind: "testbed_e2e_suite",
+      mutates: false,
+      readiness: {
+        overall: "ready",
+        canRunReadOnly: true,
+        canRunDryRun: true,
+        canRunGuardedLive: true,
+      },
+      context: {
+        githubConfigured: true,
+        openWikipediaCitationRepairJobs: 1,
+      },
+      safety: {
+        suiteGeneratorMutates: false,
+        guardedLiveCaseMutates: true,
+        githubBriefWritesLocalCheckpoint: true,
+        editsWikipedia: false,
+      },
+    });
+    expect(suite.testCases.map((entry) => entry.id)).toEqual([
+      "TBE2E-001",
+      "TBE2E-002",
+      "TBE2E-003",
+      "TBE2E-004",
+      "TBE2E-005",
+      "TBE2E-006",
+      "TBE2E-007",
+      "TBE2E-008",
+      "TBE2E-009",
+      "TBE2E-010",
+      "TBE2E-011",
+    ]);
+    expect(suite.testCases.find((entry) => entry.id === "TBE2E-005")).toMatchObject({
+      status: "manual",
+      mutates: true,
+      mutationScope: "averray_claim_draft_validate_submit_only",
+    });
+    expect(suite.testCases.find((entry) => entry.id === "TBE2E-010")).toMatchObject({
+      status: "ready",
+      mutates: true,
+      mutationScope: "local_brief_checkpoint_only",
+    });
   });
 
   it("returns read-only business ledger and ops health insights", async () => {

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -554,6 +554,58 @@ describe("slack operator bridge", () => {
     expect(text).toContain("local brief checkpoint was updated");
   });
 
+  it("formats testbed E2E suite replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "testbed_e2e_suite",
+      suite: {
+        headline: "Platform testbed is ready for read-only and dry-run E2E checks.",
+        readiness: {
+          overall: "ready",
+          canRunReadOnly: true,
+          canRunDryRun: true,
+          canRunGuardedLive: true,
+          blockers: [],
+          warnings: [],
+        },
+        testCases: [
+          {
+            id: "TBE2E-001",
+            name: "Operator readiness",
+            status: "ready",
+            mutates: false,
+            surfaces: { operatorCommand: "operator status" },
+          },
+          {
+            id: "TBE2E-005",
+            name: "Guarded live Wikipedia citation repair",
+            status: "manual",
+            mutates: true,
+            surfaces: { operatorCommand: "run one wikipedia citation repair if safe" },
+          },
+        ],
+        nextCommands: {
+          readOnly: "testbed e2e suite",
+          dryRun: "run one wikipedia citation repair dry run only",
+          guardedLive: "run one wikipedia citation repair if safe",
+        },
+        safety: {
+          suiteGeneratorMutates: false,
+          guardedLiveCaseMutates: true,
+          editsWikipedia: false,
+        },
+      },
+    });
+
+    expect(text).toContain("*Averray testbed E2E suite*");
+    expect(text).toContain("overall: `ready`");
+    expect(text).toContain("dry run: `true`");
+    expect(text).toContain("mutating/manual: `1`");
+    expect(text).toContain("`TBE2E-005` Guarded live Wikipedia citation repair: `manual mutates`");
+    expect(text).toContain("suite mutates: `false`");
+    expect(text).toContain("edits Wikipedia: `false`");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## Summary
- add a read-only Averray testbed E2E suite MCP tool for backend agents and operator surfaces
- route testbed/platform E2E commands through the operator command handler
- render the suite in Slack and document the command in README/VPS smoke docs

## Checks
- npm test -- test/unit/operator-commands.test.ts test/unit/operator-status.test.ts test/unit/slack-operator.test.ts
- npm run typecheck
- npm test
- npm run build
- git diff --check

## Scope
- Affects MCP/operator commands, Slack formatting, docs, and tests
- No backend deploy, frontend, indexer, Caddy, contracts, or public site changes
- No environment or VPS secret changes required