### PR TITLE
Add read-only testbed E2E runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `ops health`, `github status`, `github open prs`, `github ci failures`,
   `github issue digest`, `github brief`, `daily github brief`,
   `what changed since last time`, `testbed e2e suite`,
-  `platform e2e suite`, `daily operator brief`, `find safe work`,
+  `platform e2e suite`, `run testbed e2e read-only`,
+  `daily operator brief`, `find safe work`,
   `operator status`, `operator status details`,
   `run one wikipedia citation repair if safe`, and
   `status last wikipedia citation repair`. GitHub commands call
@@ -167,6 +168,12 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   commands, expected evidence, readiness blockers, and mutation boundaries for
   exercising the platform like a normal operator without accidentally claiming,
   submitting, deploying, editing GitHub, or editing Wikipedia.
+  `run testbed e2e read-only` calls `averray_run_testbed_e2e_read_only` and
+  executes the automatable non-mutating cases in order: status, daily brief,
+  safe-work discovery, one citation-repair dry run, latest-run verification,
+  business ledger, ops health, and GitHub status. It intentionally skips the
+  guarded live repair case, the local GitHub brief checkpoint, and manual
+  surface parity checks.
   `operator status` calls the canonical read-only
   `averray_operator_status` MCP tool and returns wallet, budget, open-job,
   latest-run, safety, and safe-command metadata. Human surfaces can show

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -172,6 +172,7 @@ daily github brief
 what changed since last time
 testbed e2e suite
 platform e2e suite
+run testbed e2e read-only
 find safe work
 operator status
 operator status details
@@ -216,7 +217,12 @@ returns ordered E2E cases, exact operator commands, MCP tools, expected
 evidence, readiness blockers, and mutation boundaries. The suite generator does
 not claim, submit, deploy, edit GitHub, or edit Wikipedia; it marks the live
 workflow case and the local GitHub-brief checkpoint case separately so agents
-can decide what to run safely. `operator status` calls the canonical
+can decide what to run safely. `run testbed e2e read-only` calls
+`averray_run_testbed_e2e_read_only` and executes the automatable non-mutating
+cases in order: status, daily brief, safe-work discovery, one citation-repair
+dry run, latest-run verification, business ledger, ops health, and GitHub
+status. It skips the guarded live workflow, local GitHub brief checkpoint, and
+manual surface parity checks. `operator status` calls the canonical
 read-only `averray_operator_status` MCP tool, returning wallet readiness,
 policy budget, open Wikipedia job counts, latest run state, safety guarantees,
 and safe command suggestions as structured JSON. Repair commands call

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -46,7 +46,7 @@ import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
-import { getTestbedE2eSuite } from "./operator-testbed.js";
+import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -227,8 +227,17 @@ server.tool(
 );
 
 server.tool(
+  "averray_run_testbed_e2e_read_only",
+  "Run the canonical non-mutating Averray testbed E2E checks in order and return a combined pass/fail report. Executes operator status, daily brief, safe-work discovery, one Wikipedia citation-repair dry run, latest-run status, business ledger, ops health, and GitHub status. Skips guarded live repair, GitHub brief checkpointing, and manual surface parity. Does not claim, submit, deploy, edit GitHub, edit Wikipedia, or mutate Averray state.",
+  {},
+  async () => {
+    return jsonContent(await runTestbedE2eReadOnly({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized run commands call averray_run_wikipedia_citation_repair directly; recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed commands are read-only against external systems. GitHub brief persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -78,6 +78,12 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "run_testbed_e2e_read_only";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -122,6 +128,7 @@ const EXAMPLES = [
   "github issue digest",
   "testbed e2e suite",
   "platform e2e suite",
+  "run testbed e2e read-only",
   "find safe work",
   "operator status",
   "operator status details",
@@ -176,6 +183,10 @@ export function parseOperatorCommand(
 
   if (isGithubBriefCommand(normalizedText)) {
     return { handled: true, kind: "github_brief", source, detailed };
+  }
+
+  if (isRunTestbedE2eReadOnlyCommand(normalizedText)) {
+    return { handled: true, kind: "run_testbed_e2e_read_only", source, detailed };
   }
 
   if (isTestbedE2eSuiteCommand(normalizedText)) {
@@ -366,6 +377,13 @@ function isGithubBriefCommand(text: string): boolean {
 function isTestbedE2eSuiteCommand(text: string): boolean {
   const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
   return /^(testbed e2e|testbed e2e suite|platform e2e|platform e2e suite|e2e test suite|full e2e suite|testbed full suite|run testbed e2e|run platform e2e)$/.test(compact);
+}
+
+function isRunTestbedE2eReadOnlyCommand(text: string): boolean {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  return /^(run )?(testbed|platform)?\s*e2e read[-\s]*only$/.test(compact)
+    || /^(run )?(testbed|platform) e2e suite read[-\s]*only$/.test(compact)
+    || /^(run )?read[-\s]*only testbed e2e$/.test(compact);
 }
 
 function wantsDetailedOutput(text: string): boolean {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -9,7 +9,7 @@ import { getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
-import { getTestbedE2eSuite } from "./operator-testbed.js";
+import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 
@@ -77,6 +77,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "github_brief") {
     const github = await getGithubOperatorBrief({ query: deps.query });
     return { ...command, github };
+  }
+  if (command.kind === "run_testbed_e2e_read_only") {
+    const run = await runTestbedE2eReadOnly({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, run };
   }
   if (command.kind === "testbed_e2e_suite") {
     const suite = await getTestbedE2eSuite({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/packages/averray-mcp/src/operator-testbed.ts
+++ b/packages/averray-mcp/src/operator-testbed.ts
@@ -1,7 +1,18 @@
+import type { WorkflowDeps } from "./job-workflows.js";
+import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
+import { getLastWikipediaCitationRepairStatus } from "./operator-commands.js";
+import { getGithubOperatorStatus } from "./operator-github.js";
+import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import type { OperatorStatusDeps } from "./operator-status.js";
-import { getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 
 export interface TestbedE2eSuiteDeps extends OperatorStatusDeps {
+  env?: Record<string, string | undefined>;
+}
+
+export interface TestbedE2eReadOnlyRunDeps {
+  query: OperatorStatusDeps["query"];
+  workflowDeps: WorkflowDeps;
   env?: Record<string, string | undefined>;
 }
 
@@ -208,6 +219,57 @@ export async function getTestbedE2eSuite(deps: TestbedE2eSuiteDeps) {
   };
 }
 
+export async function runTestbedE2eReadOnly(deps: TestbedE2eReadOnlyRunDeps) {
+  const suite = await getTestbedE2eSuite(deps);
+  const runnable = suite.testCases.filter(isReadOnlyRunnableCase);
+  const skipped = suite.testCases
+    .filter((entry) => !isReadOnlyRunnableCase(entry))
+    .map((entry) => skippedCase(entry, skipReason(entry)));
+  const startedAt = new Date();
+  const executed = [];
+
+  for (const test of runnable) {
+    executed.push(await runReadOnlyCase(test, deps));
+  }
+
+  const cases = [...executed, ...skipped];
+  const failed = executed.filter((entry) => entry.status === "failed").length;
+  const passed = executed.filter((entry) => entry.status === "passed").length;
+  return {
+    schemaVersion: 1,
+    kind: "testbed_e2e_read_only_run",
+    generatedAt: new Date().toISOString(),
+    mutates: false,
+    status: failed === 0 ? "passed" : "failed",
+    suiteGeneratedAt: suite.generatedAt,
+    summary: {
+      totalCases: suite.testCases.length,
+      executed: executed.length,
+      passed,
+      failed,
+      skipped: skipped.length,
+    },
+    cases,
+    skippedMutationBoundaries: skipped
+      .filter((entry) => entry.mutationScope)
+      .map((entry) => ({
+        id: entry.id,
+        name: entry.name,
+        mutationScope: entry.mutationScope,
+        reason: entry.reason,
+      })),
+    safety: {
+      mutates: false,
+      skippedGuardedLiveWorkflow: true,
+      skippedGithubBriefCheckpoint: true,
+      skippedManualSurfaceParity: true,
+      dryRunWorkflowAllowed: true,
+      editsWikipedia: false,
+    },
+    durationMs: Date.now() - startedAt.getTime(),
+  };
+}
+
 function testCase(input: {
   id: string;
   phase: string;
@@ -238,6 +300,178 @@ function testCase(input: {
     expectedEvidence: input.expectedEvidence,
     successCriteria: input.successCriteria,
   };
+}
+
+type TestbedCase = ReturnType<typeof testCase>;
+
+async function runReadOnlyCase(test: TestbedCase, deps: TestbedE2eReadOnlyRunDeps) {
+  const startedAt = Date.now();
+  try {
+    const evidence = await evidenceForCase(test.id, deps);
+    return {
+      id: test.id,
+      phase: test.phase,
+      name: test.name,
+      command: test.surfaces.operatorCommand,
+      status: "passed" as const,
+      mutates: false,
+      evidence,
+      durationMs: Date.now() - startedAt,
+    };
+  } catch (error) {
+    return {
+      id: test.id,
+      phase: test.phase,
+      name: test.name,
+      command: test.surfaces.operatorCommand,
+      status: "failed" as const,
+      mutates: false,
+      error: errorMessage(error),
+      durationMs: Date.now() - startedAt,
+    };
+  }
+}
+
+async function evidenceForCase(id: string, deps: TestbedE2eReadOnlyRunDeps) {
+  if (id === "TBE2E-001") {
+    const status = await getOperatorStatus(deps);
+    assertFalse(status.mutates, "operator status must not mutate");
+    return {
+      walletReady: status.agent.walletReady,
+      openJobs: status.workflows.wikipediaCitationRepair.openJobs,
+      latestRunStatus: status.workflows.wikipediaCitationRepair.latestRun.found
+        ? status.workflows.wikipediaCitationRepair.latestRun.status ?? "none"
+        : "none",
+    };
+  }
+  if (id === "TBE2E-002") {
+    const brief = await getDailyOperatorBrief(deps);
+    assertFalse(brief.mutates, "daily operator brief must not mutate");
+    return {
+      headline: brief.headline,
+      openJobs: brief.openWikipediaCitationRepairJobs,
+      suggestedCommands: brief.suggestedCommands.length,
+    };
+  }
+  if (id === "TBE2E-003") {
+    const safeWork = await getSafeWorkReport(deps);
+    assertFalse(safeWork.mutates, "safe work report must not mutate");
+    return {
+      available: safeWork.available,
+      blockers: safeWork.blockers,
+      safeWorkItems: safeWork.safeWorkItems.length,
+      recommendedCommand: safeWork.recommendedCommand,
+    };
+  }
+  if (id === "TBE2E-004") {
+    const result = await runWikipediaCitationRepairWorkflow(
+      { dryRun: true, maxEvidenceUrls: 5, confidenceThreshold: 0.7 },
+      deps.workflowDeps
+    );
+    const resultRecord: Record<string, unknown> = isRecord(result) ? result : {};
+    const validation = isRecord(resultRecord.validation) ? resultRecord.validation : {};
+    const evidenceSummary = isRecord(resultRecord.evidenceSummary) ? resultRecord.evidenceSummary : {};
+    const proposalSummary = isRecord(resultRecord.proposalSummary) ? resultRecord.proposalSummary : {};
+    assertFalse(result.dryRun === false, "citation repair preview must be dryRun=true");
+    return {
+      status: result.status,
+      runId: result.runId,
+      jobId: result.jobId,
+      confidence: numberField(resultRecord, "confidence") ?? null,
+      validation: validation.valid === true ? "valid" : validation.valid === false ? "invalid" : "n/a",
+      citationsReviewed: numberField(evidenceSummary, "totalCitations") ?? null,
+      proposedFindings: numberField(proposalSummary, "citationFindings") ?? null,
+    };
+  }
+  if (id === "TBE2E-006") {
+    const status = await getLastWikipediaCitationRepairStatus(deps.query);
+    return {
+      found: status.found,
+      runId: status.runId ?? null,
+      jobId: status.jobId ?? null,
+      status: status.status ?? "none",
+      draftId: status.draftId ?? null,
+      submitSucceeded: status.submitSucceeded,
+    };
+  }
+  if (id === "TBE2E-007") {
+    const ledger = await getBusinessLedger(deps);
+    assertFalse(ledger.mutates, "business ledger must not mutate");
+    return {
+      openJobs: ledger.summary.openWikipediaCitationRepairJobs,
+      submissions7d: ledger.summary.sevenDaySubmissions.total,
+      drafts7d: ledger.summary.sevenDayDrafts.total,
+      operatorCommands7d: ledger.summary.sevenDayOperatorCommands.total,
+    };
+  }
+  if (id === "TBE2E-008") {
+    const health = await getOpsHealth(deps);
+    assertFalse(health.mutates, "ops health must not mutate");
+    return {
+      health: health.health,
+      walletReady: health.wallet.walletReady,
+      recentErrors: health.controlPlane.recentErrors.length,
+      operatorEvents: health.controlPlane.tables.operatorEvents,
+    };
+  }
+  if (id === "TBE2E-009") {
+    const github = await getGithubOperatorStatus({ env: deps.env as NodeJS.ProcessEnv | undefined });
+    assertFalse(github.mutates, "GitHub status must not mutate");
+    return {
+      configured: github.configured,
+      health: github.health,
+      repos: github.repoCount,
+      openPullRequests: github.totals.openPullRequests,
+      openIssues: github.totals.openIssues,
+      failingWorkflowRuns: github.totals.failingWorkflowRuns,
+      activeWorkflowRuns: github.totals.activeWorkflowRuns,
+      warnings: github.warnings.map((entry) => entry.code),
+    };
+  }
+  throw new Error(`No read-only runner registered for ${id}`);
+}
+
+function isReadOnlyRunnableCase(test: TestbedCase): boolean {
+  return test.status !== "manual"
+    && test.mutates !== true
+    && test.mutationScope !== "local_brief_checkpoint_only";
+}
+
+function skippedCase(test: TestbedCase, reason: string) {
+  return {
+    id: test.id,
+    phase: test.phase,
+    name: test.name,
+    command: test.surfaces.operatorCommand,
+    status: "skipped" as const,
+    mutates: test.mutates,
+    ...(test.mutationScope ? { mutationScope: test.mutationScope } : {}),
+    reason,
+  };
+}
+
+function skipReason(test: TestbedCase): string {
+  if (test.mutationScope === "local_brief_checkpoint_only") return "writes_local_github_brief_checkpoint";
+  if (test.mutates) return "requires_explicit_mutation_command";
+  if (test.status === "manual") return "requires_manual_surface_or_human_action";
+  return "not_read_only_runnable";
+}
+
+function assertFalse(value: boolean | undefined, message: string) {
+  if (value === true) throw new Error(message);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function numberField(value: Record<string, unknown>, key: string): number | undefined {
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function hasAny(env: Record<string, string | undefined>, keys: string[]): boolean {

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -251,6 +251,9 @@ export function formatOperatorResultForSlack(result: unknown): string {
   if (result.kind === "github_brief") {
     return formatGithubBriefForSlack(result);
   }
+  if (result.kind === "run_testbed_e2e_read_only") {
+    return formatTestbedE2eReadOnlyRunForSlack(result);
+  }
   if (result.kind === "testbed_e2e_suite") {
     return formatTestbedE2eSuiteForSlack(result);
   }
@@ -508,6 +511,34 @@ function formatTestbedE2eSuiteForSlack(result: Record<string, unknown>): string 
   ].filter(Boolean).join("\n");
 }
 
+function formatTestbedE2eReadOnlyRunForSlack(result: Record<string, unknown>): string {
+  const run = isRecord(result.run) ? result.run : {};
+  const summary = isRecord(run.summary) ? run.summary : {};
+  const safety = isRecord(run.safety) ? run.safety : {};
+  const cases = arrayField(run, "cases");
+  const skippedBoundaries = arrayField(run, "skippedMutationBoundaries");
+  const failedCases = cases.filter((entry) => isRecord(entry) && stringField(entry, "status") === "failed");
+  const skippedCases = cases.filter((entry) => isRecord(entry) && stringField(entry, "status") === "skipped");
+
+  return [
+    "*Averray testbed E2E read-only run*",
+    `• status: \`${stringField(run, "status") ?? "unknown"}\``,
+    `• executed/passed/failed/skipped: \`${numberField(summary, "executed") ?? 0}/${numberField(summary, "passed") ?? 0}/${numberField(summary, "failed") ?? 0}/${numberField(summary, "skipped") ?? 0}\``,
+    `• duration: \`${numberField(run, "durationMs") ?? "n/a"} ms\``,
+    "",
+    "*Cases*",
+    cases.length > 0 ? cases.slice(0, 11).map(formatTestbedRunCase).join("\n") : "• none",
+    failedCases.length > 0 ? `*Failed*\n${failedCases.slice(0, 5).map(formatTestbedRunCase).join("\n")}` : "",
+    skippedCases.length > 0 ? `*Skipped intentionally*\n${skippedCases.slice(0, 5).map(formatTestbedRunCase).join("\n")}` : "",
+    skippedBoundaries.length > 0 ? `*Mutation boundaries skipped*\n${skippedBoundaries.slice(0, 5).map(formatMutationBoundary).join("\n")}` : "",
+    "*Safety*",
+    `• run mutates: \`${String(safety.mutates === true)}\``,
+    `• guarded live skipped: \`${String(safety.skippedGuardedLiveWorkflow === true)}\``,
+    `• GitHub brief checkpoint skipped: \`${String(safety.skippedGithubBriefCheckpoint === true)}\``,
+    `• edits Wikipedia: \`${String(safety.editsWikipedia === true)}\``,
+  ].filter(Boolean).join("\n");
+}
+
 function githubViewTitle(view: string): string {
   if (view === "prs") return "Open PRs";
   if (view === "ci") return "Workflow runs";
@@ -525,6 +556,22 @@ function formatTestbedCase(value: unknown): string {
   const command = stringField(surfaces, "operatorCommand") ?? "operator status";
   const mutates = value.mutates === true ? " mutates" : "";
   return `• \`${id}\` ${name}: \`${status}${mutates}\` - \`${command}\``;
+}
+
+function formatTestbedRunCase(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const id = stringField(value, "id") ?? "unknown";
+  const name = stringField(value, "name") ?? "untitled";
+  const status = stringField(value, "status") ?? "unknown";
+  const reason = stringField(value, "reason");
+  const error = stringField(value, "error");
+  const suffix = error ? ` - ${error}` : reason ? ` - ${reason}` : "";
+  return `• \`${id}\` ${name}: \`${status}\`${suffix}`;
+}
+
+function formatMutationBoundary(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  return `• \`${stringField(value, "id") ?? "unknown"}\` ${stringField(value, "name") ?? "untitled"} - \`${stringField(value, "mutationScope") ?? "mutation"}\` (${stringField(value, "reason") ?? "skipped"})`;
 }
 
 function formatGithubItem(value: unknown, detailed: boolean): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -208,6 +208,21 @@ describe("operator commands", () => {
     });
   });
 
+  it("routes the executable read-only testbed E2E run separately from the suite", () => {
+    expect(parseOperatorCommand("run testbed e2e read-only", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "run_testbed_e2e_read_only",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("platform e2e read only details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "run_testbed_e2e_read_only",
+      source: "slack",
+      detailed: true,
+    });
+  });
+
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {
     const status = await getLastWikipediaCitationRepairStatus(async (text) => {
       if (text.includes("from submissions")) {

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -8,7 +8,7 @@ import {
 import { getBusinessLedger, getOpsHealth } from "../../packages/averray-mcp/src/operator-insights.js";
 import { getAgentUsefulnessPlan } from "../../packages/averray-mcp/src/operator-usefulness.js";
 import { getAdminReadiness } from "../../packages/averray-mcp/src/operator-admin.js";
-import { getTestbedE2eSuite } from "../../packages/averray-mcp/src/operator-testbed.js";
+import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "../../packages/averray-mcp/src/operator-testbed.js";
 
 describe("operator status", () => {
   it("returns a canonical read-only status for agents and UIs", async () => {
@@ -182,6 +182,58 @@ describe("operator status", () => {
             },
           ];
         },
+        async getDefinition() {
+          return {
+            source: { type: "wikipedia_article", taskType: "citation_repair", pageTitle: "(+ +)", revisionId: "1351905437" },
+            publicDetails: { title: "Wikipedia citation repair: (+ +)" },
+            state: "open",
+            claimStatus: { claimable: true },
+          };
+        },
+        async policyCheckClaim() {
+          return { allowed: true };
+        },
+        async claim() {
+          throw new Error("read-only testbed run must not claim");
+        },
+        async fetchEvidence() {
+          return {
+            pageTitle: "(+ +)",
+            revisionId: "1351905437",
+            revisionUrl: "https://en.wikipedia.org/w/index.php?title=%28%2B_%2B%29&oldid=1351905437",
+            citations: [
+              {
+                index: 1,
+                referenceId: "review",
+                templateNames: ["cite web"],
+                urls: ["https://dead.example/review"],
+                archiveUrls: ["https://web.archive.org/web/20200101000000/https://dead.example/review"],
+                deadLinkMarkers: ["url_status_dead"],
+                accessDates: ["2020-01-02"],
+                title: "Review",
+                context: "A review citation with a dead source.",
+              },
+            ],
+            sourceChecks: [
+              {
+                url: "https://dead.example/review",
+                status: 404,
+                ok: false,
+                finalUrl: "https://dead.example/review",
+                archiveUrl: "https://web.archive.org/web/20200101000000/https://dead.example/review",
+              },
+            ],
+          };
+        },
+        async saveDraft() {
+          throw new Error("read-only testbed run must not save drafts");
+        },
+        async validate() {
+          return { valid: true, validator: "wikipedia", taskType: "citation_repair" };
+        },
+        async submit() {
+          throw new Error("read-only testbed run must not submit");
+        },
       },
     };
 
@@ -317,6 +369,45 @@ describe("operator status", () => {
       status: "ready",
       mutates: true,
       mutationScope: "local_brief_checkpoint_only",
+    });
+
+    const run = await runTestbedE2eReadOnly({
+      ...deps,
+      env: {},
+    });
+    expect(run).toMatchObject({
+      kind: "testbed_e2e_read_only_run",
+      mutates: false,
+      status: "passed",
+      summary: {
+        totalCases: 11,
+        executed: 8,
+        passed: 8,
+        failed: 0,
+        skipped: 3,
+      },
+      safety: {
+        skippedGuardedLiveWorkflow: true,
+        skippedGithubBriefCheckpoint: true,
+        skippedManualSurfaceParity: true,
+        editsWikipedia: false,
+      },
+    });
+    expect(run.cases.find((entry) => entry.id === "TBE2E-004")).toMatchObject({
+      status: "passed",
+      mutates: false,
+      evidence: {
+        validation: "valid",
+        proposedFindings: 1,
+      },
+    });
+    expect(run.cases.find((entry) => entry.id === "TBE2E-005")).toMatchObject({
+      status: "skipped",
+      reason: "requires_explicit_mutation_command",
+    });
+    expect(run.cases.find((entry) => entry.id === "TBE2E-010")).toMatchObject({
+      status: "skipped",
+      reason: "writes_local_github_brief_checkpoint",
     });
   });
 

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -606,6 +606,77 @@ describe("slack operator bridge", () => {
     expect(text).toContain("edits Wikipedia: `false`");
   });
 
+  it("formats executable read-only testbed E2E run replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "run_testbed_e2e_read_only",
+      run: {
+        status: "passed",
+        durationMs: 1234,
+        summary: {
+          totalCases: 11,
+          executed: 8,
+          passed: 8,
+          failed: 0,
+          skipped: 3,
+        },
+        cases: [
+          {
+            id: "TBE2E-001",
+            name: "Operator readiness",
+            status: "passed",
+            mutates: false,
+          },
+          {
+            id: "TBE2E-005",
+            name: "Guarded live Wikipedia citation repair",
+            status: "skipped",
+            mutates: true,
+            mutationScope: "averray_claim_draft_validate_submit_only",
+            reason: "requires_explicit_mutation_command",
+          },
+          {
+            id: "TBE2E-010",
+            name: "GitHub delta brief",
+            status: "skipped",
+            mutates: true,
+            mutationScope: "local_brief_checkpoint_only",
+            reason: "writes_local_github_brief_checkpoint",
+          },
+        ],
+        skippedMutationBoundaries: [
+          {
+            id: "TBE2E-005",
+            name: "Guarded live Wikipedia citation repair",
+            mutationScope: "averray_claim_draft_validate_submit_only",
+            reason: "requires_explicit_mutation_command",
+          },
+          {
+            id: "TBE2E-010",
+            name: "GitHub delta brief",
+            mutationScope: "local_brief_checkpoint_only",
+            reason: "writes_local_github_brief_checkpoint",
+          },
+        ],
+        safety: {
+          mutates: false,
+          skippedGuardedLiveWorkflow: true,
+          skippedGithubBriefCheckpoint: true,
+          editsWikipedia: false,
+        },
+      },
+    });
+
+    expect(text).toContain("*Averray testbed E2E read-only run*");
+    expect(text).toContain("status: `passed`");
+    expect(text).toContain("executed/passed/failed/skipped: `8/8/0/3`");
+    expect(text).toContain("`TBE2E-001` Operator readiness: `passed`");
+    expect(text).toContain("`TBE2E-005` Guarded live Wikipedia citation repair: `skipped`");
+    expect(text).toContain("writes_local_github_brief_checkpoint");
+    expect(text).toContain("GitHub brief checkpoint skipped: `true`");
+    expect(text).toContain("edits Wikipedia: `false`");
+  });
+
   it("formats workflow replies with compact validation and evidence summary", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## Summary
- add a first-class averray_run_testbed_e2e_read_only MCP tool and operator command route
- execute the automatable non-mutating E2E cases in order, while explicitly skipping guarded live repair, GitHub brief checkpointing, and manual surface parity
- add Slack formatting plus docs and unit coverage for the new read-only run report

## Checks
- npm run typecheck
- npm run build
- npm test -- test/unit/operator-commands.test.ts test/unit/operator-status.test.ts test/unit/slack-operator.test.ts
- npm test
- git diff --check

## Impact
- Backend/MCP: yes
- Slack operator: yes
- Docs: yes
- Frontend/indexer/contracts/public site/Caddy: no
- Env or VPS secret changes: none