### PR TITLE
Add agent invocation hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   business ledger, ops health, and GitHub status. It intentionally skips the
   guarded live repair case, the local GitHub brief checkpoint, and manual
   surface parity checks.
+  Other trusted agents and deploy scripts should call `averray_invoke_agent_task`
+  when they need Hermes/Averray to run a post-deploy smoke or E2E check. The
+  hook accepts structured requester metadata, an optional `correlationId`, and
+  either a safe operator command, the full read-only E2E suite, or a single
+  testcase ID. Example payloads:
+
+  ```json
+  {"requester":"codex","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
+  ```
+
+  ```json
+  {"requester":"backend-agent","intent":"testbed_case","testCaseId":"TBE2E-004","correlationId":"ci-123"}
+  ```
+
+  ```json
+  {"requester":"codex","command":"operator status","correlationId":"deploy-20260509"}
+  ```
+
+  The hook uses structured MCP/operator workflows instead of a free-form Hermes
+  prompt. Unknown commands are blocked. Live repair cases require
+  `allowMutations: true`; `github brief` and testcase `TBE2E-010` require
+  `allowLocalCheckpoint: true` because they write the local comparison
+  checkpoint. The response always reports whether free-form prompts were avoided
+  and whether the requested action would mutate Averray or write a local
+  checkpoint.
   `operator status` calls the canonical read-only
   `averray_operator_status` MCP tool and returns wallet, budget, open-job,
   latest-run, safety, and safe-command metadata. Human surfaces can show

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -228,6 +228,30 @@ policy budget, open Wikipedia job counts, latest run state, safety guarantees,
 and safe command suggestions as structured JSON. Repair commands call
 `averray_run_wikipedia_citation_repair` directly with the workflow's wallet,
 policy, draft, validation, submit, and Slack alert gates.
+
+Trusted deploy scripts, backend agents, Codex, and other operator agents should
+use `averray_invoke_agent_task` as the stable agent-to-agent hook. It records
+`requester`, optional `correlationId`, and optional `reason`, then runs one of
+three structured paths without sending a free-form Hermes prompt:
+
+```json
+{"requester":"deploy-agent","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
+```
+
+```json
+{"requester":"backend-agent","intent":"testbed_case","testCaseId":"TBE2E-004","correlationId":"ci-123"}
+```
+
+```json
+{"requester":"codex","command":"operator status","correlationId":"deploy-20260509"}
+```
+
+The hook fails closed for unknown commands. It blocks the guarded live repair
+case unless `allowMutations: true` is passed, and blocks `github brief` or
+`TBE2E-010` unless `allowLocalCheckpoint: true` is passed. Responses include
+the original invocation metadata plus safety fields for whether the action would
+mutate Averray, write a local checkpoint, or use a free-form Hermes prompt.
+
 Latest-run status commands are read-only and return the latest `runId`,
 `jobId`, `sessionId`, submitted/failed state, `draftId`, and Slack permalink
 when one is available. Human-facing Slack/Workspace renderers should compact

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -1,0 +1,205 @@
+import type { WorkflowDeps } from "./job-workflows.js";
+import {
+  parseOperatorCommand,
+  type OperatorQueryFn,
+  type ParsedOperatorCommand,
+} from "./operator-commands.js";
+import { handleOperatorCommandText } from "./operator-handler.js";
+import { runTestbedE2eReadOnly } from "./operator-testbed.js";
+
+export type AgentInvocationIntent =
+  | "operator_command"
+  | "testbed_e2e_read_only"
+  | "testbed_case";
+
+export interface AgentInvocationInput {
+  requester: string;
+  intent?: AgentInvocationIntent;
+  command?: string;
+  testCaseId?: string;
+  correlationId?: string;
+  reason?: string;
+  allowMutations?: boolean;
+  allowLocalCheckpoint?: boolean;
+  expectedWallet?: string;
+  defaultDryRun?: boolean;
+  maxEvidenceUrls?: number;
+  confidenceThreshold?: number;
+}
+
+export interface AgentInvocationDeps {
+  query: OperatorQueryFn;
+  workflowDeps: WorkflowDeps;
+}
+
+const READ_ONLY_TEST_CASES = new Set([
+  "TBE2E-001",
+  "TBE2E-002",
+  "TBE2E-003",
+  "TBE2E-004",
+  "TBE2E-006",
+  "TBE2E-007",
+  "TBE2E-008",
+  "TBE2E-009",
+]);
+
+export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentInvocationDeps) {
+  const startedAt = new Date();
+  const intent = input.intent ?? (input.testCaseId ? "testbed_case" : "operator_command");
+  const invocation = {
+    requester: input.requester,
+    intent,
+    ...(input.command ? { command: input.command } : {}),
+    ...(input.testCaseId ? { testCaseId: normalizeTestCaseId(input.testCaseId) } : {}),
+    ...(input.correlationId ? { correlationId: input.correlationId } : {}),
+    ...(input.reason ? { reason: input.reason } : {}),
+  };
+
+  if (!input.requester.trim()) {
+    return blockedInvocation(invocation, startedAt, "requester_required");
+  }
+
+  if (intent === "testbed_e2e_read_only") {
+    const run = await runTestbedE2eReadOnly(deps);
+    return completedInvocation(invocation, startedAt, run, {
+      mutates: false,
+      localCheckpoint: false,
+    });
+  }
+
+  if (intent === "testbed_case") {
+    const testCaseId = normalizeTestCaseId(input.testCaseId ?? "");
+    if (!testCaseId) return blockedInvocation(invocation, startedAt, "test_case_id_required");
+    if (READ_ONLY_TEST_CASES.has(testCaseId)) {
+      const run = await runTestbedE2eReadOnly(deps, { testCaseIds: [testCaseId] });
+      return completedInvocation(invocation, startedAt, run, {
+        mutates: false,
+        localCheckpoint: false,
+      });
+    }
+    if (testCaseId === "TBE2E-005") {
+      if (!input.allowMutations) {
+        return blockedInvocation(invocation, startedAt, "mutation_case_requires_allow_mutations");
+      }
+      return invokeOperatorCommand("run one wikipedia citation repair if safe", input, deps, invocation, startedAt);
+    }
+    if (testCaseId === "TBE2E-010") {
+      if (!input.allowLocalCheckpoint) {
+        return blockedInvocation(invocation, startedAt, "local_checkpoint_case_requires_allow_local_checkpoint");
+      }
+      return invokeOperatorCommand("github brief", input, deps, invocation, startedAt);
+    }
+    if (testCaseId === "TBE2E-011") {
+      return blockedInvocation(invocation, startedAt, "manual_surface_parity_case");
+    }
+    return blockedInvocation(invocation, startedAt, "unknown_test_case");
+  }
+
+  const command = input.command?.trim();
+  if (!command) return blockedInvocation(invocation, startedAt, "command_required");
+  return invokeOperatorCommand(command, input, deps, invocation, startedAt);
+}
+
+async function invokeOperatorCommand(
+  command: string,
+  input: AgentInvocationInput,
+  deps: AgentInvocationDeps,
+  invocation: Record<string, unknown>,
+  startedAt: Date
+) {
+  const parsed = parseOperatorCommand(command, {
+    source: "agent",
+    defaultDryRun: input.defaultDryRun,
+    maxEvidenceUrls: input.maxEvidenceUrls,
+    confidenceThreshold: input.confidenceThreshold,
+  });
+  if (!parsed.handled) return blockedInvocation(invocation, startedAt, "unknown_operator_command", parsed);
+
+  const mutation = mutationRisk(parsed);
+  if (mutation.mutates && !input.allowMutations) {
+    return blockedInvocation(invocation, startedAt, "mutation_requires_allow_mutations", parsed, mutation);
+  }
+  if (mutation.localCheckpoint && !input.allowLocalCheckpoint) {
+    return blockedInvocation(invocation, startedAt, "local_checkpoint_requires_allow_local_checkpoint", parsed, mutation);
+  }
+
+  const result = await handleOperatorCommandText(
+    {
+      text: command,
+      source: "agent",
+      expectedWallet: input.expectedWallet,
+      defaultDryRun: input.defaultDryRun,
+      maxEvidenceUrls: input.maxEvidenceUrls,
+      confidenceThreshold: input.confidenceThreshold,
+    },
+    deps
+  );
+  return completedInvocation(invocation, startedAt, result, mutation);
+}
+
+function mutationRisk(command: ParsedOperatorCommand) {
+  if (!command.handled) return { mutates: false, localCheckpoint: false };
+  if (command.kind === "github_brief") return { mutates: false, localCheckpoint: true };
+  if (command.kind === "run_wikipedia_citation_repair") {
+    return {
+      mutates: command.input.dryRun !== true,
+      localCheckpoint: false,
+    };
+  }
+  return { mutates: false, localCheckpoint: false };
+}
+
+function completedInvocation(
+  invocation: Record<string, unknown>,
+  startedAt: Date,
+  result: unknown,
+  risk: { mutates: boolean; localCheckpoint: boolean }
+) {
+  return {
+    schemaVersion: 1,
+    kind: "agent_invocation",
+    status: "completed",
+    startedAt: startedAt.toISOString(),
+    completedAt: new Date().toISOString(),
+    durationMs: Date.now() - startedAt.getTime(),
+    invocation,
+    safety: {
+      source: "agent",
+      wouldMutate: risk.mutates,
+      wouldWriteLocalCheckpoint: risk.localCheckpoint,
+      freeFormHermesPromptUsed: false,
+    },
+    result,
+  };
+}
+
+function blockedInvocation(
+  invocation: Record<string, unknown>,
+  startedAt: Date,
+  reason: string,
+  parsed?: unknown,
+  risk?: { mutates: boolean; localCheckpoint: boolean }
+) {
+  return {
+    schemaVersion: 1,
+    kind: "agent_invocation",
+    status: "blocked",
+    startedAt: startedAt.toISOString(),
+    completedAt: new Date().toISOString(),
+    durationMs: Date.now() - startedAt.getTime(),
+    invocation,
+    reason,
+    mutates: false,
+    safety: {
+      source: "agent",
+      wouldMutate: risk?.mutates === true,
+      wouldWriteLocalCheckpoint: risk?.localCheckpoint === true,
+      freeFormHermesPromptUsed: false,
+    },
+    ...(parsed ? { parsed } : {}),
+  };
+}
+
+function normalizeTestCaseId(id: string): string {
+  return id.trim().toUpperCase();
+}

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -47,6 +47,7 @@ import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./o
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
+import { invokeAgentTask } from "./agent-invocation.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -236,11 +237,33 @@ server.tool(
 );
 
 server.tool(
+  "averray_invoke_agent_task",
+  "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, or one testbed testcase by ID with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, and local checkpoint writes unless the caller explicitly opts into that class of action.",
+  {
+    requester: z.string().min(1),
+    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_case"]).default("operator_command"),
+    command: z.string().min(1).optional(),
+    testCaseId: z.string().min(1).optional(),
+    correlationId: z.string().optional(),
+    reason: z.string().optional(),
+    allowMutations: z.boolean().default(false),
+    allowLocalCheckpoint: z.boolean().default(false),
+    expectedWallet: z.string().optional(),
+    defaultDryRun: z.boolean().default(false),
+    maxEvidenceUrls: z.number().int().min(1).max(20).default(5),
+    confidenceThreshold: z.number().min(0).max(1).default(0.7)
+  },
+  async (input) => {
+    return jsonContent(await invokeAgentTask(input, { query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_handle_operator_command",
   "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
-    source: z.enum(["slack", "operator", "command_center", "hermes"]).default("operator"),
+    source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),
     expectedWallet: z.string().optional(),
     defaultDryRun: z.boolean().default(false),
     maxEvidenceUrls: z.number().int().min(1).max(20).default(5),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,7 +1,7 @@
 import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
 import type { GithubOperatorView } from "./operator-github.js";
 
-export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes";
+export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes" | "agent";
 
 export type ParsedOperatorCommand =
   | {

--- a/packages/averray-mcp/src/operator-testbed.ts
+++ b/packages/averray-mcp/src/operator-testbed.ts
@@ -16,6 +16,10 @@ export interface TestbedE2eReadOnlyRunDeps {
   env?: Record<string, string | undefined>;
 }
 
+export interface TestbedE2eReadOnlyRunOptions {
+  testCaseIds?: string[];
+}
+
 export async function getTestbedE2eSuite(deps: TestbedE2eSuiteDeps) {
   const [status, safeWork] = await Promise.all([
     getOperatorStatus(deps),
@@ -219,12 +223,23 @@ export async function getTestbedE2eSuite(deps: TestbedE2eSuiteDeps) {
   };
 }
 
-export async function runTestbedE2eReadOnly(deps: TestbedE2eReadOnlyRunDeps) {
+export async function runTestbedE2eReadOnly(
+  deps: TestbedE2eReadOnlyRunDeps,
+  options: TestbedE2eReadOnlyRunOptions = {}
+) {
   const suite = await getTestbedE2eSuite(deps);
-  const runnable = suite.testCases.filter(isReadOnlyRunnableCase);
-  const skipped = suite.testCases
+  const requestedIds = normalizeTestCaseIds(options.testCaseIds);
+  const selectedCases = requestedIds.length > 0
+    ? suite.testCases.filter((entry) => requestedIds.includes(entry.id))
+    : suite.testCases;
+  const unknownCases = requestedIds
+    .filter((id) => !suite.testCases.some((entry) => entry.id === id))
+    .map((id) => unknownSkippedCase(id));
+  const runnable = selectedCases.filter(isReadOnlyRunnableCase);
+  const skipped = selectedCases
     .filter((entry) => !isReadOnlyRunnableCase(entry))
-    .map((entry) => skippedCase(entry, skipReason(entry)));
+    .map((entry) => skippedCase(entry, skipReason(entry)))
+    .concat(unknownCases);
   const startedAt = new Date();
   const executed = [];
 
@@ -242,8 +257,9 @@ export async function runTestbedE2eReadOnly(deps: TestbedE2eReadOnlyRunDeps) {
     mutates: false,
     status: failed === 0 ? "passed" : "failed",
     suiteGeneratedAt: suite.generatedAt,
+    requestedCaseIds: requestedIds,
     summary: {
-      totalCases: suite.testCases.length,
+      totalCases: selectedCases.length + unknownCases.length,
       executed: executed.length,
       passed,
       failed,
@@ -450,11 +466,29 @@ function skippedCase(test: TestbedCase, reason: string) {
   };
 }
 
+function unknownSkippedCase(id: string) {
+  return {
+    id,
+    phase: "unknown",
+    name: "Unknown testbed case",
+    command: "",
+    status: "skipped" as const,
+    mutates: false,
+    reason: "unknown_test_case",
+  };
+}
+
 function skipReason(test: TestbedCase): string {
   if (test.mutationScope === "local_brief_checkpoint_only") return "writes_local_github_brief_checkpoint";
   if (test.mutates) return "requires_explicit_mutation_command";
   if (test.status === "manual") return "requires_manual_surface_or_human_action";
   return "not_read_only_runnable";
+}
+
+function normalizeTestCaseIds(ids: string[] | undefined): string[] {
+  return Array.from(new Set((ids ?? [])
+    .map((id) => id.trim().toUpperCase())
+    .filter(Boolean)));
 }
 
 function assertFalse(value: boolean | undefined, message: string) {

--- a/test/unit/agent-invocation.test.ts
+++ b/test/unit/agent-invocation.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+
+import { invokeAgentTask } from "../../packages/averray-mcp/src/agent-invocation.js";
+import type { WorkflowDeps } from "../../packages/averray-mcp/src/job-workflows.js";
+
+const jobId = "wiki-en-58158792-citation-repair-r9";
+const definition = {
+  source: {
+    type: "wikipedia_article",
+    taskType: "citation_repair",
+    pageTitle: "(+ +)",
+    revisionId: "1351905437",
+  },
+  publicDetails: { title: "Wikipedia citation repair: (+ +)" },
+  state: "open",
+  claimStatus: { claimable: true },
+};
+
+describe("agent invocation hook", () => {
+  it("runs one read-only testbed testcase with agent metadata", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      {
+        requester: "codex",
+        intent: "testbed_case",
+        testCaseId: "tbe2e-004",
+        correlationId: "deploy-123",
+        reason: "post-deploy smoke",
+      },
+      deps(calls)
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "completed",
+      invocation: {
+        requester: "codex",
+        intent: "testbed_case",
+        testCaseId: "TBE2E-004",
+        correlationId: "deploy-123",
+        reason: "post-deploy smoke",
+      },
+      safety: {
+        source: "agent",
+        wouldMutate: false,
+        wouldWriteLocalCheckpoint: false,
+        freeFormHermesPromptUsed: false,
+      },
+      result: {
+        kind: "testbed_e2e_read_only_run",
+        requestedCaseIds: ["TBE2E-004"],
+        summary: {
+          totalCases: 1,
+          executed: 1,
+          passed: 1,
+          failed: 0,
+          skipped: 0,
+        },
+      },
+    });
+    expect(calls).toEqual(expect.arrayContaining([
+      "walletStatus",
+      "listJobs",
+      "policyCheckClaim",
+      "fetchEvidence",
+      "validate",
+    ]));
+    expect(calls).not.toContain("claim");
+    expect(calls).not.toContain("saveDraft");
+    expect(calls).not.toContain("submit");
+  });
+
+  it("blocks mutation-bound testcase invocations unless explicitly allowed", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      { requester: "deploy-agent", intent: "testbed_case", testCaseId: "TBE2E-005" },
+      deps(calls)
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "blocked",
+      reason: "mutation_case_requires_allow_mutations",
+      mutates: false,
+      safety: {
+        freeFormHermesPromptUsed: false,
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("routes explicit safe operator commands through the operator handler", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      { requester: "backend-agent", command: "operator status", correlationId: "ci-456" },
+      deps(calls)
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "completed",
+      invocation: {
+        requester: "backend-agent",
+        intent: "operator_command",
+        command: "operator status",
+        correlationId: "ci-456",
+      },
+      result: {
+        kind: "operator_status",
+        source: "agent",
+        status: {
+          mutates: false,
+          agent: { walletReady: true },
+        },
+      },
+    });
+    expect(calls).toEqual(["walletStatus", "listJobs"]);
+  });
+
+  it("blocks free-form live repair commands by default", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      { requester: "codex", command: "run one wikipedia citation repair if safe" },
+      deps(calls)
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "blocked",
+      reason: "mutation_requires_allow_mutations",
+      mutates: false,
+      safety: {
+        wouldMutate: true,
+        freeFormHermesPromptUsed: false,
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+});
+
+function deps(calls: string[]) {
+  return {
+    async query(text: string) {
+      if (text.includes("from budgets")) return [{ usd_spent: "0" }];
+      if (text.includes("from submissions")) return [];
+      if (text.includes("from draft_submissions")) return [];
+      return [];
+    },
+    workflowDeps: workflowDeps(calls),
+  };
+}
+
+function workflowDeps(calls: string[]): WorkflowDeps {
+  return {
+    async walletStatus() {
+      calls.push("walletStatus");
+      return { configured: true, address: "0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05" };
+    },
+    async listJobs() {
+      calls.push("listJobs");
+      return [{ jobId, definition }];
+    },
+    async getDefinition() {
+      calls.push("getDefinition");
+      return definition;
+    },
+    async policyCheckClaim() {
+      calls.push("policyCheckClaim");
+      return { allowed: true };
+    },
+    async claim() {
+      calls.push("claim");
+      throw new Error("agent invocation test must not claim");
+    },
+    async fetchEvidence() {
+      calls.push("fetchEvidence");
+      return {
+        pageTitle: "(+ +)",
+        revisionId: "1351905437",
+        revisionUrl: "https://en.wikipedia.org/w/index.php?title=%28%2B_%2B%29&oldid=1351905437",
+        citations: [
+          {
+            index: 1,
+            referenceId: "review",
+            templateNames: ["cite web"],
+            urls: ["https://dead.example/review"],
+            archiveUrls: ["https://web.archive.org/web/20200101000000/https://dead.example/review"],
+            deadLinkMarkers: ["url_status_dead"],
+            accessDates: ["2020-01-02"],
+            title: "Review",
+            context: "A review citation with a dead source.",
+          },
+        ],
+        sourceChecks: [
+          {
+            url: "https://dead.example/review",
+            status: 404,
+            ok: false,
+            finalUrl: "https://dead.example/review",
+            archiveUrl: "https://web.archive.org/web/20200101000000/https://dead.example/review",
+          },
+        ],
+      };
+    },
+    async saveDraft() {
+      calls.push("saveDraft");
+      throw new Error("agent invocation test must not save drafts");
+    },
+    async validate() {
+      calls.push("validate");
+      return { valid: true, validator: "wikipedia", taskType: "citation_repair" };
+    },
+    async submit() {
+      calls.push("submit");
+      throw new Error("agent invocation test must not submit");
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- add averray_invoke_agent_task as a structured agent-to-agent MCP hook
- allow full read-only E2E suite, individual testcase runs, and safe operator commands with requester/correlation metadata
- fail closed for unknown commands, live mutation cases, and local checkpoint writes unless explicitly allowed

## Checks
- npm run typecheck
- npm run build
- npm test
- npm test -- test/unit/agent-invocation.test.ts test/unit/operator-commands.test.ts test/unit/operator-status.test.ts
- git diff --check

## Surface Impact
- Backend/MCP: yes
- Slack/Command Center: indirect, shares operator command source enum
- GitHub/Wikipedia mutations: none by default; mutation cases require explicit flags
- Env/VPS changes: none