### PR TITLE
Add PR handoff agent workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,11 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   Other trusted agents and deploy scripts should call `averray_invoke_agent_task`
   when they need Hermes/Averray to run a post-deploy smoke or E2E check. The
   hook accepts structured requester metadata, an optional `correlationId`, and
-  either a safe operator command, the full read-only E2E suite, or a single
-  testcase ID. Example payloads:
+  either a safe operator command, the full read-only E2E suite, a single
+  testcase ID, or a PR handoff workflow. PR handoff is the normal path for an
+  agent that has opened a PR and wants Hermes to review it, recommend whether it
+  is merge-ready, run the requested testbed checks, and report the result back
+  to the calling agent.
 
   ```json
   {"requester":"codex","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
@@ -189,6 +192,14 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   ```
 
   ```json
+  {"requester":"deploy-agent","intent":"pr_handoff","repo":"averray-agent/agent","pullRequestNumber":185,"testCaseIds":["TBE2E-004"],"correlationId":"deploy-20260509","reason":"pre-merge smoke"}
+  ```
+
+  ```json
+  {"requester":"codex","intent":"pr_handoff","pullRequestUrl":"https://github.com/averray-agent/agent/pull/185","runReadOnlySuite":true,"postReviewCommand":"github status","correlationId":"handoff-123"}
+  ```
+
+  ```json
   {"requester":"codex","command":"operator status","correlationId":"deploy-20260509"}
   ```
 
@@ -196,9 +207,13 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   prompt. Unknown commands are blocked. Live repair cases require
   `allowMutations: true`; `github brief` and testcase `TBE2E-010` require
   `allowLocalCheckpoint: true` because they write the local comparison
-  checkpoint. The response always reports whether free-form prompts were avoided
-  and whether the requested action would mutate Averray or write a local
-  checkpoint.
+  checkpoint. PR handoff reads GitHub PR metadata, changed-file summaries, and
+  check-run state, then returns `mergeRecommendation` and `finalVerdict`
+  (`ok_to_merge`, `needs_review`, or `hold`). It never merges the PR, pushes
+  commits, reruns workflows, deploys, edits GitHub, or edits Wikipedia; the
+  recommendation is evidence for the upstream agent or human operator to act
+  on. The response always reports whether free-form prompts were avoided and
+  whether the requested action would mutate Averray or write a local checkpoint.
   `operator status` calls the canonical read-only
   `averray_operator_status` MCP tool and returns wallet, budget, open-job,
   latest-run, safety, and safe-command metadata. Human surfaces can show

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -232,7 +232,10 @@ policy, draft, validation, submit, and Slack alert gates.
 Trusted deploy scripts, backend agents, Codex, and other operator agents should
 use `averray_invoke_agent_task` as the stable agent-to-agent hook. It records
 `requester`, optional `correlationId`, and optional `reason`, then runs one of
-three structured paths without sending a free-form Hermes prompt:
+the structured paths below without sending a free-form Hermes prompt. Use the
+PR handoff path when another agent has opened a PR and needs Hermes/Averray to
+inspect the PR, recommend merge readiness, run the requested testbed check, and
+return a machine-readable report.
 
 ```json
 {"requester":"deploy-agent","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
@@ -243,6 +246,14 @@ three structured paths without sending a free-form Hermes prompt:
 ```
 
 ```json
+{"requester":"deploy-agent","intent":"pr_handoff","repo":"averray-agent/agent","pullRequestNumber":185,"testCaseIds":["TBE2E-004"],"correlationId":"deploy-20260509","reason":"pre-merge smoke"}
+```
+
+```json
+{"requester":"codex","intent":"pr_handoff","pullRequestUrl":"https://github.com/averray-agent/agent/pull/185","runReadOnlySuite":true,"postReviewCommand":"github status","correlationId":"handoff-123"}
+```
+
+```json
 {"requester":"codex","command":"operator status","correlationId":"deploy-20260509"}
 ```
 
@@ -250,7 +261,12 @@ The hook fails closed for unknown commands. It blocks the guarded live repair
 case unless `allowMutations: true` is passed, and blocks `github brief` or
 `TBE2E-010` unless `allowLocalCheckpoint: true` is passed. Responses include
 the original invocation metadata plus safety fields for whether the action would
-mutate Averray, write a local checkpoint, or use a free-form Hermes prompt.
+mutate Averray, write a local checkpoint, or use a free-form Hermes prompt. PR
+handoff reads GitHub PR metadata, changed files, and check runs, then returns
+`mergeRecommendation` and `finalVerdict` (`ok_to_merge`, `needs_review`, or
+`hold`) plus any requested test results. It is recommendation-only: it never
+merges PRs, pushes commits, reruns workflows, deploys, edits GitHub, or edits
+Wikipedia.
 
 Latest-run status commands are read-only and return the latest `runId`,
 `jobId`, `sessionId`, submitted/failed state, `draftId`, and Slack permalink

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -4,19 +4,27 @@ import {
   type OperatorQueryFn,
   type ParsedOperatorCommand,
 } from "./operator-commands.js";
+import { getGithubPullRequestReview } from "./operator-github.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
 import { runTestbedE2eReadOnly } from "./operator-testbed.js";
 
 export type AgentInvocationIntent =
   | "operator_command"
   | "testbed_e2e_read_only"
-  | "testbed_case";
+  | "testbed_case"
+  | "pr_handoff";
 
 export interface AgentInvocationInput {
   requester: string;
   intent?: AgentInvocationIntent;
   command?: string;
   testCaseId?: string;
+  testCaseIds?: string[];
+  runReadOnlySuite?: boolean;
+  postReviewCommand?: string;
+  repo?: string;
+  pullRequestNumber?: number;
+  pullRequestUrl?: string;
   correlationId?: string;
   reason?: string;
   allowMutations?: boolean;
@@ -30,6 +38,9 @@ export interface AgentInvocationInput {
 export interface AgentInvocationDeps {
   query: OperatorQueryFn;
   workflowDeps: WorkflowDeps;
+  githubEnv?: NodeJS.ProcessEnv;
+  githubFetchFn?: typeof fetch;
+  now?: Date;
 }
 
 const READ_ONLY_TEST_CASES = new Set([
@@ -43,7 +54,7 @@ const READ_ONLY_TEST_CASES = new Set([
   "TBE2E-009",
 ]);
 
-export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentInvocationDeps) {
+export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentInvocationDeps): Promise<unknown> {
   const startedAt = new Date();
   const intent = input.intent ?? (input.testCaseId ? "testbed_case" : "operator_command");
   const invocation = {
@@ -51,6 +62,12 @@ export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentIn
     intent,
     ...(input.command ? { command: input.command } : {}),
     ...(input.testCaseId ? { testCaseId: normalizeTestCaseId(input.testCaseId) } : {}),
+    ...(input.testCaseIds?.length ? { testCaseIds: normalizeTestCaseIds(input.testCaseIds) } : {}),
+    ...(input.runReadOnlySuite ? { runReadOnlySuite: true } : {}),
+    ...(input.postReviewCommand ? { postReviewCommand: input.postReviewCommand } : {}),
+    ...(input.repo ? { repo: input.repo } : {}),
+    ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+    ...(input.pullRequestUrl ? { pullRequestUrl: input.pullRequestUrl } : {}),
     ...(input.correlationId ? { correlationId: input.correlationId } : {}),
     ...(input.reason ? { reason: input.reason } : {}),
   };
@@ -65,6 +82,10 @@ export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentIn
       mutates: false,
       localCheckpoint: false,
     });
+  }
+
+  if (intent === "pr_handoff") {
+    return invokePullRequestHandoff(input, deps, invocation, startedAt);
   }
 
   if (intent === "testbed_case") {
@@ -98,6 +119,117 @@ export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentIn
   const command = input.command?.trim();
   if (!command) return blockedInvocation(invocation, startedAt, "command_required");
   return invokeOperatorCommand(command, input, deps, invocation, startedAt);
+}
+
+async function invokePullRequestHandoff(
+  input: AgentInvocationInput,
+  deps: AgentInvocationDeps,
+  invocation: Record<string, unknown>,
+  startedAt: Date
+): Promise<unknown> {
+  const review = await getGithubPullRequestReview({
+    ...(input.repo ? { repo: input.repo } : {}),
+    ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+    ...(input.pullRequestUrl ? { pullRequestUrl: input.pullRequestUrl } : {}),
+    ...(deps.githubEnv ? { env: deps.githubEnv } : {}),
+    ...(deps.githubFetchFn ? { fetchFn: deps.githubFetchFn } : {}),
+    ...(deps.now ? { now: deps.now } : {}),
+  });
+  const requestedTestCaseIds = normalizeTestCaseIds([
+    ...(input.testCaseId ? [input.testCaseId] : []),
+    ...(input.testCaseIds ?? []),
+  ]);
+  const requestedActions = {
+    runReadOnlySuite: input.runReadOnlySuite === true,
+    testCaseIds: requestedTestCaseIds,
+    ...(input.postReviewCommand ? { postReviewCommand: input.postReviewCommand } : {}),
+  };
+
+  if (!review.configured || review.health === "degraded") {
+    return completedInvocation(invocation, startedAt, {
+      schemaVersion: 1,
+      kind: "agent_pr_handoff",
+      status: "blocked",
+      github: review,
+      requestedActions,
+      tests: [],
+      finalVerdict: "hold",
+      finalReason: "github_pr_review_unavailable",
+      safety: prHandoffSafety(false, false),
+    }, { mutates: false, localCheckpoint: false });
+  }
+
+  if (review.mergeRecommendation === "hold") {
+    return completedInvocation(invocation, startedAt, {
+      schemaVersion: 1,
+      kind: "agent_pr_handoff",
+      status: "completed",
+      github: review,
+      requestedActions,
+      tests: [],
+      finalVerdict: "hold",
+      finalReason: "pr_review_hold",
+      safety: prHandoffSafety(false, false),
+    }, { mutates: false, localCheckpoint: false });
+  }
+
+  const tests: unknown[] = [];
+  let wouldMutate = false;
+  let wouldWriteLocalCheckpoint = false;
+
+  if (input.runReadOnlySuite) {
+    const run = await runTestbedE2eReadOnly(deps);
+    tests.push(run);
+  }
+
+  for (const testCaseId of requestedTestCaseIds) {
+    const {
+      command: _command,
+      testCaseIds: _testCaseIds,
+      runReadOnlySuite: _runReadOnlySuite,
+      postReviewCommand: _postReviewCommand,
+      ...nestedInput
+    } = input;
+    const result: unknown = await invokeAgentTask(
+      {
+        ...nestedInput,
+        intent: "testbed_case",
+        testCaseId,
+      },
+      deps
+    );
+    tests.push(result);
+    const safety: Record<string, unknown> = isRecord(result) && isRecord(result.safety) ? result.safety : {};
+    wouldMutate = wouldMutate || safety.wouldMutate === true;
+    wouldWriteLocalCheckpoint = wouldWriteLocalCheckpoint || safety.wouldWriteLocalCheckpoint === true;
+  }
+
+  if (input.postReviewCommand) {
+    const result: unknown = await invokeOperatorCommand(input.postReviewCommand, input, deps, invocation, startedAt);
+    tests.push(result);
+    const safety: Record<string, unknown> = isRecord(result) && isRecord(result.safety) ? result.safety : {};
+    wouldMutate = wouldMutate || safety.wouldMutate === true;
+    wouldWriteLocalCheckpoint = wouldWriteLocalCheckpoint || safety.wouldWriteLocalCheckpoint === true;
+  }
+
+  const failedTests = tests.filter(testFailed).length;
+  const finalVerdict = failedTests > 0
+    ? "hold"
+    : review.mergeRecommendation === "ok_to_merge"
+      ? "ok_to_merge"
+      : "needs_review";
+
+  return completedInvocation(invocation, startedAt, {
+    schemaVersion: 1,
+    kind: "agent_pr_handoff",
+    status: "completed",
+    github: review,
+    requestedActions,
+    tests,
+    finalVerdict,
+    finalReason: failedTests > 0 ? "requested_tests_failed_or_blocked" : `github_${review.mergeRecommendation}`,
+    safety: prHandoffSafety(wouldMutate, wouldWriteLocalCheckpoint),
+  }, { mutates: wouldMutate, localCheckpoint: wouldWriteLocalCheckpoint });
 }
 
 async function invokeOperatorCommand(
@@ -202,4 +334,35 @@ function blockedInvocation(
 
 function normalizeTestCaseId(id: string): string {
   return id.trim().toUpperCase();
+}
+
+function normalizeTestCaseIds(ids: string[]): string[] {
+  return [...new Set(ids.map(normalizeTestCaseId).filter(Boolean))];
+}
+
+function prHandoffSafety(wouldMutate: boolean, wouldWriteLocalCheckpoint: boolean) {
+  return {
+    source: "agent",
+    githubMutated: false,
+    mergePerformed: false,
+    mergeRecommendationOnly: true,
+    wouldMutate,
+    wouldWriteLocalCheckpoint,
+    freeFormHermesPromptUsed: false,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function testFailed(test: unknown): boolean {
+  if (!isRecord(test)) return false;
+  if (test.status === "blocked") return true;
+  const summary = isRecord(test.summary)
+    ? test.summary
+    : isRecord(test.result) && isRecord(test.result.summary)
+      ? test.result.summary
+      : undefined;
+  return typeof summary?.failed === "number" && summary.failed > 0;
 }

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -238,12 +238,18 @@ server.tool(
 
 server.tool(
   "averray_invoke_agent_task",
-  "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, or one testbed testcase by ID with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, and local checkpoint writes unless the caller explicitly opts into that class of action.",
+  "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, one testbed testcase by ID, or a PR handoff workflow that reviews GitHub PR metadata/checks/files and then runs requested tests with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, local checkpoint writes, and PRs that are not merge-ready unless the caller explicitly opts into that class of action. PR handoff only recommends merge state; it never merges.",
   {
     requester: z.string().min(1),
-    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_case"]).default("operator_command"),
+    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_case", "pr_handoff"]).default("operator_command"),
     command: z.string().min(1).optional(),
     testCaseId: z.string().min(1).optional(),
+    testCaseIds: z.array(z.string().min(1)).max(20).optional(),
+    runReadOnlySuite: z.boolean().default(false),
+    postReviewCommand: z.string().min(1).optional(),
+    repo: z.string().min(1).optional(),
+    pullRequestNumber: z.number().int().min(1).optional(),
+    pullRequestUrl: z.string().url().optional(),
     correlationId: z.string().optional(),
     reason: z.string().optional(),
     allowMutations: z.boolean().default(false),

--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -134,6 +134,80 @@ export interface GithubOperatorBrief {
   recommendations: string[];
 }
 
+export type GithubPullRequestMergeRecommendation = "ok_to_merge" | "needs_review" | "hold";
+
+export interface GithubPullRequestReview {
+  schemaVersion: 1;
+  generatedAt: string;
+  mutatesGithub: false;
+  configured: boolean;
+  authConfigured: boolean;
+  repo?: string;
+  pullRequestNumber?: number;
+  health: "ok" | "attention" | "degraded";
+  pullRequest?: {
+    repo: string;
+    number: number;
+    title: string;
+    url?: string;
+    author?: string;
+    state: string;
+    draft: boolean;
+    baseBranch?: string;
+    headBranch?: string;
+    headSha?: string;
+    additions?: number;
+    deletions?: number;
+    changedFiles?: number;
+    mergeableState?: string;
+    updatedAt?: string;
+  };
+  files: {
+    total: number;
+    highRisk: GithubPullRequestFileRisk[];
+    sample: GithubPullRequestFileSummary[];
+  };
+  checks: {
+    total: number;
+    passed: number;
+    failed: number;
+    active: number;
+    neutral: number;
+    skipped: number;
+    sample: GithubPullRequestCheckSummary[];
+  };
+  riskFindings: GithubPullRequestRiskFinding[];
+  mergeRecommendation: GithubPullRequestMergeRecommendation;
+  recommendations: string[];
+  warnings: GithubWarning[];
+}
+
+export interface GithubPullRequestFileSummary {
+  filename: string;
+  status?: string;
+  additions?: number;
+  deletions?: number;
+  changes?: number;
+}
+
+export interface GithubPullRequestFileRisk extends GithubPullRequestFileSummary {
+  risk: "high" | "medium";
+  reason: string;
+}
+
+export interface GithubPullRequestCheckSummary {
+  name: string;
+  status: string;
+  conclusion?: string;
+  url?: string;
+}
+
+export interface GithubPullRequestRiskFinding {
+  severity: "low" | "medium" | "high";
+  code: string;
+  message: string;
+}
+
 export interface GithubOperatorStatusOptions {
   view?: GithubOperatorView;
   env?: NodeJS.ProcessEnv;
@@ -146,6 +220,15 @@ export interface GithubOperatorBriefOptions {
   fetchFn?: typeof fetch;
   now?: Date;
   query?: GithubBriefQueryFn;
+}
+
+export interface GithubPullRequestReviewOptions {
+  repo?: string;
+  pullRequestNumber?: number;
+  pullRequestUrl?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchFn?: typeof fetch;
+  now?: Date;
 }
 
 type GithubBriefQueryFn = <T = Record<string, unknown>>(
@@ -175,6 +258,27 @@ interface GithubApiPullRequest {
   updated_at?: string;
   merged_at?: string | null;
   state?: string;
+  base?: { ref?: string } | null;
+  head?: { ref?: string; sha?: string } | null;
+  additions?: number;
+  deletions?: number;
+  changed_files?: number;
+  mergeable_state?: string | null;
+}
+
+interface GithubApiPullRequestFile {
+  filename?: string;
+  status?: string;
+  additions?: number;
+  deletions?: number;
+  changes?: number;
+}
+
+interface GithubApiCheckRun {
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+  html_url?: string;
 }
 
 interface GithubApiIssue {
@@ -430,6 +534,145 @@ export async function getGithubOperatorBrief(
   };
 }
 
+export async function getGithubPullRequestReview(
+  options: GithubPullRequestReviewOptions = {}
+): Promise<GithubPullRequestReview> {
+  const env = options.env ?? process.env;
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const tokenConfig = buildGithubTokenConfig(env);
+  const configuredRepos = parseGithubRepos(env);
+  const warnings: GithubWarning[] = [];
+  const urlTarget = parsePullRequestUrl(options.pullRequestUrl);
+  const repo = normalizeRepo(options.repo ?? urlTarget?.repo ?? (configuredRepos.length === 1 ? configuredRepos[0] : ""));
+  const pullRequestNumber = options.pullRequestNumber ?? urlTarget?.pullRequestNumber;
+
+  if (!tokenConfig.hasAnyToken || !repo || !pullRequestNumber) {
+    if (!tokenConfig.hasAnyToken) {
+      warnings.push({
+        severity: "high",
+        code: "github_token_missing",
+        message: "No GitHub token is configured, so PR handoff review is unavailable.",
+      });
+    }
+    if (!repo) {
+      warnings.push({
+        severity: "high",
+        code: "github_pr_repo_missing",
+        message: "Set repo=owner/repo, pass a GitHub pull request URL, or configure exactly one GitHub helper repo.",
+      });
+    }
+    if (!pullRequestNumber) {
+      warnings.push({
+        severity: "high",
+        code: "github_pr_number_missing",
+        message: "Set pullRequestNumber or pass a GitHub pull request URL.",
+      });
+    }
+    return emptyPullRequestReview({
+      generatedAt,
+      authConfigured: tokenConfig.hasAnyToken,
+      repo,
+      pullRequestNumber,
+      warnings,
+    });
+  }
+
+  const token = resolveGithubTokenForRepo(repo, tokenConfig);
+  if (!token) {
+    warnings.push({
+      severity: "high",
+      code: "github_repo_token_missing",
+      repo,
+      message: `No GitHub token is configured for ${repo}.`,
+    });
+    return emptyPullRequestReview({
+      generatedAt,
+      authConfigured: true,
+      repo,
+      pullRequestNumber,
+      warnings,
+    });
+  }
+
+  const fetchFn = options.fetchFn ?? fetch;
+  const baseUrl = (env.GITHUB_API_BASE_URL ?? "https://api.github.com").replace(/\/+$/g, "");
+  const repoPath = encodeRepoPath(repo);
+
+  try {
+    const [pullRequest, files] = await Promise.all([
+      githubGet<GithubApiPullRequest>(`${baseUrl}/repos/${repoPath}/pulls/${pullRequestNumber}`, token, fetchFn),
+      githubGet<GithubApiPullRequestFile[]>(
+        `${baseUrl}/repos/${repoPath}/pulls/${pullRequestNumber}/files?per_page=100`,
+        token,
+        fetchFn
+      ),
+    ]);
+    const headSha = pullRequest.head?.sha;
+    const checks = headSha
+      ? await readPullRequestChecks({ baseUrl, repoPath, headSha, token, fetchFn, warnings, repo })
+      : [];
+    const fileSummaries = files.map(fileSummary).filter((file): file is GithubPullRequestFileSummary => Boolean(file));
+    const highRiskFiles = fileSummaries
+      .map(fileRisk)
+      .filter((file): file is GithubPullRequestFileRisk => Boolean(file));
+    const checkSummaries = checks.map(checkSummary);
+    const checkTotals = summarizeChecks(checkSummaries);
+    const pullRequestSummary = summarizePullRequest(repo, pullRequest);
+    const riskFindings = buildPullRequestRiskFindings({
+      pullRequest: pullRequestSummary,
+      files: fileSummaries,
+      highRiskFiles,
+      checks: checkTotals,
+      warnings,
+    });
+    const mergeRecommendation = chooseMergeRecommendation(riskFindings);
+    const health = warnings.some((warning) => warning.severity === "high")
+      ? "degraded"
+      : mergeRecommendation === "ok_to_merge"
+        ? "ok"
+        : "attention";
+
+    return {
+      schemaVersion: 1,
+      generatedAt,
+      mutatesGithub: false,
+      configured: true,
+      authConfigured: true,
+      repo,
+      pullRequestNumber,
+      health,
+      pullRequest: pullRequestSummary,
+      files: {
+        total: fileSummaries.length,
+        highRisk: highRiskFiles.slice(0, 20),
+        sample: fileSummaries.slice(0, 20),
+      },
+      checks: {
+        ...checkTotals,
+        sample: checkSummaries.slice(0, 20),
+      },
+      riskFindings,
+      mergeRecommendation,
+      recommendations: buildPullRequestReviewRecommendations({ mergeRecommendation, riskFindings }),
+      warnings,
+    };
+  } catch (error) {
+    warnings.push({
+      severity: "high",
+      code: "github_pr_fetch_failed",
+      repo,
+      message: error instanceof Error ? error.message : `Failed to fetch PR #${pullRequestNumber} for ${repo}.`,
+    });
+    return emptyPullRequestReview({
+      generatedAt,
+      authConfigured: true,
+      repo,
+      pullRequestNumber,
+      warnings,
+    });
+  }
+}
+
 function emptyStatus(input: {
   generatedAt: string;
   view: GithubOperatorView;
@@ -519,6 +762,242 @@ function emptyBrief(input: {
       "Set GITHUB_DEFAULT_REPO=owner/repo or GITHUB_HELPER_REPOS=owner/repo,owner/repo.",
     ],
   };
+}
+
+function emptyPullRequestReview(input: {
+  generatedAt: string;
+  authConfigured: boolean;
+  repo?: string;
+  pullRequestNumber?: number;
+  warnings: GithubWarning[];
+}): GithubPullRequestReview {
+  const configured = Boolean(input.authConfigured && input.repo && input.pullRequestNumber);
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    mutatesGithub: false,
+    configured,
+    authConfigured: input.authConfigured,
+    ...(input.repo ? { repo: input.repo } : {}),
+    ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+    health: "degraded",
+    files: { total: 0, highRisk: [], sample: [] },
+    checks: { total: 0, passed: 0, failed: 0, active: 0, neutral: 0, skipped: 0, sample: [] },
+    riskFindings: input.warnings.map((warning) => ({
+      severity: warning.severity,
+      code: warning.code,
+      message: warning.message,
+    })),
+    mergeRecommendation: "hold",
+    recommendations: [
+      "Configure a read-only GitHub token and pass repo plus pullRequestNumber before using PR handoff.",
+    ],
+    warnings: input.warnings,
+  };
+}
+
+async function readPullRequestChecks(input: {
+  baseUrl: string;
+  repoPath: string;
+  headSha: string;
+  token: string;
+  fetchFn: typeof fetch;
+  warnings: GithubWarning[];
+  repo: string;
+}): Promise<GithubApiCheckRun[]> {
+  try {
+    const checks = await githubGet<{ check_runs?: GithubApiCheckRun[] }>(
+      `${input.baseUrl}/repos/${input.repoPath}/commits/${encodeURIComponent(input.headSha)}/check-runs?per_page=100`,
+      input.token,
+      input.fetchFn
+    );
+    return checks.check_runs ?? [];
+  } catch (error) {
+    input.warnings.push({
+      severity: "medium",
+      code: "github_pr_checks_unavailable",
+      repo: input.repo,
+      message: error instanceof Error ? error.message : "Failed to fetch PR check runs.",
+    });
+    return [];
+  }
+}
+
+function parsePullRequestUrl(value: string | undefined): { repo: string; pullRequestNumber: number } | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (!/github\.com$/i.test(url.hostname)) return undefined;
+    const [, owner, repo, marker, number] = url.pathname.split("/");
+    if (!owner || !repo || marker !== "pull") return undefined;
+    const pullRequestNumber = Number.parseInt(number ?? "", 10);
+    if (!Number.isFinite(pullRequestNumber) || pullRequestNumber <= 0) return undefined;
+    return { repo: `${owner}/${repo}`, pullRequestNumber };
+  } catch {
+    return undefined;
+  }
+}
+
+function summarizePullRequest(repo: string, pull: GithubApiPullRequest): NonNullable<GithubPullRequestReview["pullRequest"]> {
+  const number = numberField(pull.number);
+  return {
+    repo,
+    number,
+    title: pull.title ?? "Untitled pull request",
+    ...(pull.html_url ? { url: pull.html_url } : {}),
+    ...(pull.user?.login ? { author: pull.user.login } : {}),
+    state: pull.state ?? "unknown",
+    draft: pull.draft === true,
+    ...(pull.base?.ref ? { baseBranch: pull.base.ref } : {}),
+    ...(pull.head?.ref ? { headBranch: pull.head.ref } : {}),
+    ...(pull.head?.sha ? { headSha: pull.head.sha } : {}),
+    ...(typeof pull.additions === "number" ? { additions: pull.additions } : {}),
+    ...(typeof pull.deletions === "number" ? { deletions: pull.deletions } : {}),
+    ...(typeof pull.changed_files === "number" ? { changedFiles: pull.changed_files } : {}),
+    ...(pull.mergeable_state ? { mergeableState: pull.mergeable_state } : {}),
+    ...(pull.updated_at ? { updatedAt: pull.updated_at } : {}),
+  };
+}
+
+function fileSummary(file: GithubApiPullRequestFile): GithubPullRequestFileSummary | undefined {
+  if (!file.filename) return undefined;
+  return {
+    filename: file.filename,
+    ...(file.status ? { status: file.status } : {}),
+    ...(typeof file.additions === "number" ? { additions: file.additions } : {}),
+    ...(typeof file.deletions === "number" ? { deletions: file.deletions } : {}),
+    ...(typeof file.changes === "number" ? { changes: file.changes } : {}),
+  };
+}
+
+function fileRisk(file: GithubPullRequestFileSummary): GithubPullRequestFileRisk | undefined {
+  const path = file.filename.toLowerCase();
+  const highRiskPatterns = [
+    /^\.env/,
+    /(^|\/)\.env/,
+    /(^|\/)secrets?\b/,
+    /(^|\/)contracts?\//,
+    /(^|\/)migrations?\//,
+    /(^|\/)ops\//,
+    /(^|\/)deploy/,
+    /compose.*\.ya?ml$/,
+    /caddyfile$/,
+    /package-lock\.json$/,
+  ];
+  if (highRiskPatterns.some((pattern) => pattern.test(path))) {
+    return { ...file, risk: "high", reason: "touches deploy, secret, contract, lockfile, or infrastructure surface" };
+  }
+  if ((file.changes ?? 0) >= 400) {
+    return { ...file, risk: "medium", reason: "large single-file change" };
+  }
+  return undefined;
+}
+
+function checkSummary(check: GithubApiCheckRun): GithubPullRequestCheckSummary {
+  return {
+    name: check.name ?? "Unnamed check",
+    status: check.status ?? "unknown",
+    ...(check.conclusion ? { conclusion: check.conclusion } : {}),
+    ...(check.html_url ? { url: check.html_url } : {}),
+  };
+}
+
+function summarizeChecks(checks: GithubPullRequestCheckSummary[]) {
+  return {
+    total: checks.length,
+    passed: checks.filter((check) => check.status === "completed" && check.conclusion === "success").length,
+    failed: checks.filter((check) => isFailedCheck(check)).length,
+    active: checks.filter((check) => check.status !== "completed").length,
+    neutral: checks.filter((check) => check.status === "completed" && (check.conclusion === "neutral" || check.conclusion === "success_with_warnings")).length,
+    skipped: checks.filter((check) => check.status === "completed" && check.conclusion === "skipped").length,
+  };
+}
+
+function isFailedCheck(check: GithubPullRequestCheckSummary): boolean {
+  return check.status === "completed"
+    && (check.conclusion === "failure"
+      || check.conclusion === "cancelled"
+      || check.conclusion === "timed_out"
+      || check.conclusion === "action_required");
+}
+
+function buildPullRequestRiskFindings(input: {
+  pullRequest: NonNullable<GithubPullRequestReview["pullRequest"]>;
+  files: GithubPullRequestFileSummary[];
+  highRiskFiles: GithubPullRequestFileRisk[];
+  checks: ReturnType<typeof summarizeChecks>;
+  warnings: GithubWarning[];
+}): GithubPullRequestRiskFinding[] {
+  const findings: GithubPullRequestRiskFinding[] = input.warnings.map((warning) => ({
+    severity: warning.severity,
+    code: warning.code,
+    message: warning.message,
+  }));
+  if (input.pullRequest.state !== "open") {
+    findings.push({ severity: "high", code: "pr_not_open", message: `PR state is ${input.pullRequest.state}.` });
+  }
+  if (input.pullRequest.draft) {
+    findings.push({ severity: "high", code: "pr_is_draft", message: "PR is still marked as draft." });
+  }
+  if (input.checks.failed > 0) {
+    findings.push({ severity: "high", code: "pr_checks_failed", message: `${input.checks.failed} PR check(s) failed.` });
+  }
+  if (input.checks.active > 0) {
+    findings.push({ severity: "high", code: "pr_checks_active", message: `${input.checks.active} PR check(s) are still running.` });
+  }
+  if (input.checks.total === 0) {
+    findings.push({ severity: "medium", code: "pr_checks_missing", message: "No PR check runs were found for the head commit." });
+  }
+  const highRisk = input.highRiskFiles.filter((file) => file.risk === "high");
+  if (highRisk.length > 0) {
+    findings.push({
+      severity: "medium",
+      code: "pr_high_risk_files",
+      message: `${highRisk.length} changed file(s) touch deploy, secret, contract, lockfile, or infrastructure surfaces.`,
+    });
+  }
+  if (input.files.length > 25) {
+    findings.push({ severity: "medium", code: "pr_large_file_count", message: `PR changes ${input.files.length} files.` });
+  }
+  const totalChanges = input.files.reduce((sum, file) => sum + (file.changes ?? 0), 0);
+  if (totalChanges > 1_000) {
+    findings.push({ severity: "medium", code: "pr_large_diff", message: `PR changes ${totalChanges} lines.` });
+  }
+  if (input.pullRequest.mergeableState && ["dirty", "blocked", "unknown"].includes(input.pullRequest.mergeableState)) {
+    findings.push({
+      severity: input.pullRequest.mergeableState === "dirty" ? "high" : "medium",
+      code: "pr_mergeable_state_attention",
+      message: `GitHub mergeable_state is ${input.pullRequest.mergeableState}.`,
+    });
+  }
+  if (findings.length === 0) {
+    findings.push({ severity: "low", code: "pr_review_green", message: "PR metadata, files, and checks look merge-ready." });
+  }
+  return findings;
+}
+
+function chooseMergeRecommendation(findings: GithubPullRequestRiskFinding[]): GithubPullRequestMergeRecommendation {
+  if (findings.some((finding) => finding.severity === "high")) return "hold";
+  if (findings.some((finding) => finding.severity === "medium")) return "needs_review";
+  return "ok_to_merge";
+}
+
+function buildPullRequestReviewRecommendations(input: {
+  mergeRecommendation: GithubPullRequestMergeRecommendation;
+  riskFindings: GithubPullRequestRiskFinding[];
+}): string[] {
+  if (input.mergeRecommendation === "ok_to_merge") {
+    return ["PR looks merge-ready from read-only GitHub metadata and checks. Run the requested testbed case before merging."];
+  }
+  if (input.mergeRecommendation === "hold") {
+    return ["Do not merge yet. Resolve high-severity findings such as draft state, failing checks, active checks, or merge conflicts first."];
+  }
+  const mediumCodes = input.riskFindings
+    .filter((finding) => finding.severity === "medium")
+    .map((finding) => finding.code);
+  return [
+    `Human review recommended before merge${mediumCodes.length > 0 ? ` (${[...new Set(mediumCodes)].join(", ")})` : ""}.`,
+  ];
 }
 
 interface GithubTokenConfig {

--- a/test/unit/agent-invocation.test.ts
+++ b/test/unit/agent-invocation.test.ts
@@ -136,10 +136,105 @@ describe("agent invocation hook", () => {
     });
     expect(calls).toEqual([]);
   });
+
+  it("runs a PR handoff review and requested read-only testcase", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      {
+        requester: "codex",
+        intent: "pr_handoff",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 185,
+        testCaseIds: ["TBE2E-004"],
+        correlationId: "handoff-789",
+        reason: "pre-merge check",
+      },
+      deps(calls, githubFetch())
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "completed",
+      invocation: {
+        requester: "codex",
+        intent: "pr_handoff",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 185,
+        testCaseIds: ["TBE2E-004"],
+        correlationId: "handoff-789",
+      },
+      safety: {
+        source: "agent",
+        wouldMutate: false,
+        wouldWriteLocalCheckpoint: false,
+        freeFormHermesPromptUsed: false,
+      },
+      result: {
+        kind: "agent_pr_handoff",
+        finalVerdict: "ok_to_merge",
+        github: {
+          mergeRecommendation: "ok_to_merge",
+          checks: { failed: 0, active: 0 },
+        },
+        tests: [
+          expect.objectContaining({
+            kind: "agent_invocation",
+            status: "completed",
+            result: expect.objectContaining({
+              kind: "testbed_e2e_read_only_run",
+              requestedCaseIds: ["TBE2E-004"],
+            }),
+          }),
+        ],
+        safety: {
+          githubMutated: false,
+          mergePerformed: false,
+          mergeRecommendationOnly: true,
+        },
+      },
+    });
+    expect(calls).toEqual(expect.arrayContaining([
+      "walletStatus",
+      "listJobs",
+      "policyCheckClaim",
+      "fetchEvidence",
+      "validate",
+    ]));
+  });
+
+  it("holds PR handoff and skips tests when GitHub checks are not merge-ready", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      {
+        requester: "codex",
+        intent: "pr_handoff",
+        pullRequestUrl: "https://github.com/averray-agent/agent/pull/186",
+        testCaseIds: ["TBE2E-004"],
+      },
+      deps(calls, githubFetch({ failing: true }))
+    );
+
+    expect(result).toMatchObject({
+      status: "completed",
+      result: {
+        kind: "agent_pr_handoff",
+        finalVerdict: "hold",
+        finalReason: "pr_review_hold",
+        github: {
+          mergeRecommendation: "hold",
+        },
+        tests: [],
+      },
+    });
+    expect(calls).toEqual([]);
+  });
 });
 
-function deps(calls: string[]) {
+function deps(calls: string[], githubFetchFn?: typeof fetch) {
   return {
+    githubEnv: { GITHUB_TOKEN: "ghp_readonly" },
+    ...(githubFetchFn ? { githubFetchFn } : {}),
+    now: new Date("2026-05-09T12:00:00.000Z"),
     async query(text: string) {
       if (text.includes("from budgets")) return [{ usd_spent: "0" }];
       if (text.includes("from submissions")) return [];
@@ -148,6 +243,53 @@ function deps(calls: string[]) {
     },
     workflowDeps: workflowDeps(calls),
   };
+}
+
+function githubFetch(options: { failing?: boolean } = {}): typeof fetch {
+  return (async (url: string | URL | Request) => {
+    const text = String(url);
+    const prNumber = options.failing ? 186 : 185;
+    const sha = options.failing ? "def456" : "abc123";
+    if (text.endsWith(`/repos/averray-agent/agent/pulls/${prNumber}`)) {
+      return jsonResponse({
+        number: prNumber,
+        title: options.failing ? "Risky PR" : "Safe PR",
+        html_url: `https://github.com/averray-agent/agent/pull/${prNumber}`,
+        user: { login: "codex" },
+        draft: false,
+        state: "open",
+        base: { ref: "main" },
+        head: { ref: "codex/pr", sha },
+        additions: 10,
+        deletions: 1,
+        changed_files: 1,
+        mergeable_state: "clean",
+        updated_at: "2026-05-09T11:00:00.000Z",
+      });
+    }
+    if (text.includes(`/pulls/${prNumber}/files`)) {
+      return jsonResponse([
+        { filename: "docs/change.md", status: "modified", additions: 10, deletions: 1, changes: 11 },
+      ]);
+    }
+    if (text.includes(`/commits/${sha}/check-runs`)) {
+      return jsonResponse({
+        check_runs: [
+          options.failing
+            ? { name: "CI", status: "completed", conclusion: "failure" }
+            : { name: "CI", status: "completed", conclusion: "success" },
+        ],
+      });
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof fetch;
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 function workflowDeps(calls: string[]): WorkflowDeps {

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getGithubOperatorBrief, getGithubOperatorStatus } from "../../packages/averray-mcp/src/operator-github.js";
+import {
+  getGithubOperatorBrief,
+  getGithubOperatorStatus,
+  getGithubPullRequestReview,
+} from "../../packages/averray-mcp/src/operator-github.js";
 
 describe("github operator status", () => {
   it("reports setup blockers when token or repo config is missing", async () => {
@@ -248,6 +252,127 @@ describe("github operator status", () => {
     expect(brief.sections.deployed[0]).toMatchObject({ title: "Deploy Production" });
     expect(brief.sections.failed[0]).toMatchObject({ title: "CI" });
     expect(writes).toHaveLength(1);
+  });
+
+  it("reviews a pull request and recommends merge when checks are green", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent/pulls/185")) {
+        return jsonResponse({
+          number: 185,
+          title: "Record testnet deployment manifest",
+          html_url: "https://github.com/averray-agent/agent/pull/185",
+          user: { login: "codex" },
+          draft: false,
+          state: "open",
+          base: { ref: "main" },
+          head: { ref: "codex/testnet", sha: "abc123" },
+          additions: 24,
+          deletions: 2,
+          changed_files: 2,
+          mergeable_state: "clean",
+          updated_at: "2026-05-08T12:00:00.000Z",
+        });
+      }
+      if (text.includes("/pulls/185/files")) {
+        return jsonResponse([
+          { filename: "docs/testnet.md", status: "modified", additions: 10, deletions: 0, changes: 10 },
+          { filename: "scripts/verify-testnet.js", status: "modified", additions: 14, deletions: 2, changes: 16 },
+        ]);
+      }
+      if (text.includes("/commits/abc123/check-runs")) {
+        return jsonResponse({
+          check_runs: [
+            { name: "CI", status: "completed", conclusion: "success", html_url: "https://github.com/checks/1" },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const review = await getGithubPullRequestReview({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 185,
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(review).toMatchObject({
+      configured: true,
+      authConfigured: true,
+      health: "ok",
+      pullRequest: {
+        repo: "averray-agent/agent",
+        number: 185,
+        draft: false,
+        headSha: "abc123",
+      },
+      checks: {
+        total: 1,
+        passed: 1,
+        failed: 0,
+        active: 0,
+      },
+      mergeRecommendation: "ok_to_merge",
+    });
+  });
+
+  it("holds a pull request with failing checks or active checks", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent/pulls/186")) {
+        return jsonResponse({
+          number: 186,
+          title: "Risky deploy change",
+          html_url: "https://github.com/averray-agent/agent/pull/186",
+          user: { login: "codex" },
+          draft: false,
+          state: "open",
+          head: { ref: "codex/risky", sha: "def456" },
+          changed_files: 1,
+        });
+      }
+      if (text.includes("/pulls/186/files")) {
+        return jsonResponse([
+          { filename: "ops/compose.yml", status: "modified", additions: 3, deletions: 1, changes: 4 },
+        ]);
+      }
+      if (text.includes("/commits/def456/check-runs")) {
+        return jsonResponse({
+          check_runs: [
+            { name: "CI", status: "completed", conclusion: "failure" },
+            { name: "Deploy preview", status: "in_progress" },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const review = await getGithubPullRequestReview({
+      pullRequestUrl: "https://github.com/averray-agent/agent/pull/186",
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(review).toMatchObject({
+      configured: true,
+      health: "attention",
+      checks: {
+        total: 2,
+        failed: 1,
+        active: 1,
+      },
+      files: {
+        highRisk: [expect.objectContaining({ filename: "ops/compose.yml" })],
+      },
+      mergeRecommendation: "hold",
+    });
+    expect(review.riskFindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "pr_checks_failed" }),
+      expect.objectContaining({ code: "pr_checks_active" }),
+    ]));
   });
 });
 


### PR DESCRIPTION
## Summary
- add a PR handoff path to averray_invoke_agent_task for trusted agent/deploy workflows
- review GitHub PR metadata, changed files, and check runs before recommending ok_to_merge / needs_review / hold
- run requested testbed cases or read-only suite after a merge-ready PR review, while keeping PR merge recommendation-only
- document handoff payloads for README and VPS smoke workflows

## Checks
- npm test
- npm test -- test/unit/operator-github.test.ts test/unit/agent-invocation.test.ts
- npx tsc -p packages/averray-mcp/tsconfig.json --pretty false
- git diff --check

## Scope
- backend/MCP only
- docs only
- no deploy, no secrets, no GitHub mutation behavior