### PR TITLE
Add Hermes handoff monitor events

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -241,6 +241,14 @@ return a machine-readable report.
 {"requester":"deploy-agent","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
 ```
 
+Post-deploy workflows may also use `intent: "testbed_suite"` when they want to
+pass an explicit set of case IDs. The suite runner still executes only
+read-only cases and reports mutation-bound cases as skipped.
+
+```json
+{"requester":"github-actions","intent":"testbed_suite","repo":"averray-agent/agent","testCaseIds":["TBE2E-001","TBE2E-004","TBE2E-009"],"correlationId":"github-deploy-25608715158-22beb11","reason":"post-production-deploy verification"}
+```
+
 ```json
 {"requester":"backend-agent","intent":"testbed_case","testCaseId":"TBE2E-004","correlationId":"ci-123"}
 ```
@@ -267,6 +275,14 @@ handoff reads GitHub PR metadata, changed files, and check runs, then returns
 `hold`) plus any requested test results. It is recommendation-only: it never
 merges PRs, pushes commits, reruns workflows, deploys, edits GitHub, or edits
 Wikipedia.
+
+Each agent-to-agent invocation appends a local handoff event with the same
+`correlationId`. Humans and agents can inspect the current/recent handoffs with
+the read-only `averray_handoff_monitor` MCP tool or the operator command
+`handoff monitor` / `what is Hermes doing`. The monitor groups events by
+correlation ID and surfaces requester, repo/PR, requested tests, phase, status,
+summary, and safety metadata. It is observability only: it does not touch
+GitHub, Wikipedia, deployments, or Averray mutations.
 
 Latest-run status commands are read-only and return the latest `runId`,
 `jobId`, `sessionId`, submitted/failed state, `draftId`, and Slack permalink

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -41,6 +41,9 @@ GITHUB_HELPER_REPOS=
 GITHUB_API_BASE_URL=https://api.github.com
 GITHUB_HELPER_LIMIT=5
 
+# Optional local JSONL event log for agent-to-agent handoff monitoring.
+AVERRAY_HANDOFF_EVENTS_PATH=/tmp/averray-reference-agent/handoff-events.jsonl
+
 # Optional command-center evaluation. See docs/COMMAND_CENTER.md.
 # Keep these ports localhost-bound through ops/compose.command-center.yml.
 HERMES_WORKSPACE_IMAGE=ghcr.io/outsourc-e/hermes-workspace:latest

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -7,10 +7,17 @@ import {
 import { getGithubPullRequestReview } from "./operator-github.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
 import { runTestbedE2eReadOnly } from "./operator-testbed.js";
+import {
+  recordHandoffEvent,
+  summarizeHandoffError,
+  summarizeHandoffResult,
+  type HandoffEventInput,
+} from "./handoff-events.js";
 
 export type AgentInvocationIntent =
   | "operator_command"
   | "testbed_e2e_read_only"
+  | "testbed_suite"
   | "testbed_case"
   | "pr_handoff";
 
@@ -40,6 +47,7 @@ export interface AgentInvocationDeps {
   workflowDeps: WorkflowDeps;
   githubEnv?: NodeJS.ProcessEnv;
   githubFetchFn?: typeof fetch;
+  handoffEventRecorder?: (event: HandoffEventInput) => Promise<unknown>;
   now?: Date;
 }
 
@@ -57,12 +65,13 @@ const READ_ONLY_TEST_CASES = new Set([
 export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentInvocationDeps): Promise<unknown> {
   const startedAt = new Date();
   const intent = input.intent ?? (input.testCaseId ? "testbed_case" : "operator_command");
+  const normalizedTestCaseIds = normalizeTestCaseIds(input.testCaseIds ?? []);
   const invocation = {
     requester: input.requester,
     intent,
     ...(input.command ? { command: input.command } : {}),
     ...(input.testCaseId ? { testCaseId: normalizeTestCaseId(input.testCaseId) } : {}),
-    ...(input.testCaseIds?.length ? { testCaseIds: normalizeTestCaseIds(input.testCaseIds) } : {}),
+    ...(normalizedTestCaseIds.length ? { testCaseIds: normalizedTestCaseIds } : {}),
     ...(input.runReadOnlySuite ? { runReadOnlySuite: true } : {}),
     ...(input.postReviewCommand ? { postReviewCommand: input.postReviewCommand } : {}),
     ...(input.repo ? { repo: input.repo } : {}),
@@ -71,13 +80,53 @@ export async function invokeAgentTask(input: AgentInvocationInput, deps: AgentIn
     ...(input.correlationId ? { correlationId: input.correlationId } : {}),
     ...(input.reason ? { reason: input.reason } : {}),
   };
+  const correlationId = input.correlationId?.trim() || localCorrelationId(startedAt, input.requester, intent);
+  await recordInvocationEvent(deps, input, invocation, correlationId, {
+    phase: "started",
+    status: "running",
+    summary: {
+      requestedCaseIds: normalizedTestCaseIds,
+      ...(input.testCaseId ? { requestedCaseId: normalizeTestCaseId(input.testCaseId) } : {}),
+    },
+  });
 
+  try {
+    const result = await invokeAgentTaskInner(input, deps, invocation, startedAt, intent);
+    const resultRecord = isRecord(result) ? result : {};
+    await recordInvocationEvent(deps, input, invocation, correlationId, {
+      phase: resultRecord.status === "blocked" ? "blocked" : "completed",
+      status: resultRecord.status === "blocked" ? "blocked" : "completed",
+      summary: summarizeHandoffResult(result),
+      safety: isRecord(resultRecord.safety) ? resultRecord.safety : undefined,
+    });
+    return result;
+  } catch (error) {
+    await recordInvocationEvent(deps, input, invocation, correlationId, {
+      phase: "failed",
+      status: "failed",
+      summary: summarizeHandoffError(error),
+    });
+    throw error;
+  }
+}
+
+async function invokeAgentTaskInner(
+  input: AgentInvocationInput,
+  deps: AgentInvocationDeps,
+  invocation: Record<string, unknown>,
+  startedAt: Date,
+  intent: AgentInvocationIntent
+): Promise<unknown> {
   if (!input.requester.trim()) {
     return blockedInvocation(invocation, startedAt, "requester_required");
   }
 
-  if (intent === "testbed_e2e_read_only") {
-    const run = await runTestbedE2eReadOnly(deps);
+  if (intent === "testbed_e2e_read_only" || intent === "testbed_suite") {
+    const testCaseIds = normalizeTestCaseIds(input.testCaseIds ?? []);
+    const run = await runTestbedE2eReadOnly(
+      deps,
+      testCaseIds.length > 0 ? { testCaseIds } : {}
+    );
     return completedInvocation(invocation, startedAt, run, {
       mutates: false,
       localCheckpoint: false,
@@ -365,4 +414,38 @@ function testFailed(test: unknown): boolean {
       ? test.result.summary
       : undefined;
   return typeof summary?.failed === "number" && summary.failed > 0;
+}
+
+async function recordInvocationEvent(
+  deps: AgentInvocationDeps,
+  input: AgentInvocationInput,
+  invocation: Record<string, unknown>,
+  correlationId: string,
+  event: Pick<HandoffEventInput, "phase" | "status" | "summary" | "safety">
+) {
+  const recorder = deps.handoffEventRecorder ?? recordHandoffEvent;
+  try {
+    await recorder({
+      correlationId,
+      requester: input.requester,
+      intent: String(invocation.intent ?? "operator_command"),
+      phase: event.phase,
+      status: event.status,
+      ...(input.repo ? { repo: input.repo } : {}),
+      ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+      ...(input.pullRequestUrl ? { pullRequestUrl: input.pullRequestUrl } : {}),
+      ...(input.testCaseId ? { testCaseId: normalizeTestCaseId(input.testCaseId) } : {}),
+      ...(Array.isArray(invocation.testCaseIds) ? { testCaseIds: invocation.testCaseIds as string[] } : {}),
+      ...(input.reason ? { reason: input.reason } : {}),
+      ...(event.summary ? { summary: event.summary } : {}),
+      ...(event.safety ? { safety: event.safety } : {}),
+    });
+  } catch {
+    // Monitoring must never change the safety behavior of the invoked task.
+  }
+}
+
+function localCorrelationId(startedAt: Date, requester: string, intent: string): string {
+  const safeRequester = requester.trim().toLowerCase().replace(/[^a-z0-9_.:-]+/g, "-") || "unknown";
+  return `local-${safeRequester}-${intent}-${startedAt.toISOString().replace(/[^0-9]/g, "")}`;
 }

--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -1,0 +1,256 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export type HandoffEventStatus =
+  | "running"
+  | "completed"
+  | "blocked"
+  | "failed"
+  | "passed"
+  | "needs_review";
+
+export interface HandoffEventInput {
+  correlationId: string;
+  requester?: string;
+  intent?: string;
+  phase: string;
+  status: HandoffEventStatus;
+  repo?: string;
+  pullRequestNumber?: number;
+  pullRequestUrl?: string;
+  testCaseId?: string;
+  testCaseIds?: string[];
+  reason?: string;
+  summary?: Record<string, unknown>;
+  safety?: Record<string, unknown>;
+  timestamp?: string;
+}
+
+export interface HandoffEvent extends HandoffEventInput {
+  schemaVersion: 1;
+  kind: "agent_handoff_event";
+  eventId: string;
+  timestamp: string;
+}
+
+export interface HandoffMonitorOptions {
+  correlationId?: string;
+  limit?: number;
+  activeWindowMinutes?: number;
+  now?: Date;
+  eventLogPath?: string;
+}
+
+const DEFAULT_LIMIT = 20;
+const DEFAULT_ACTIVE_WINDOW_MINUTES = 120;
+
+export async function recordHandoffEvent(input: HandoffEventInput): Promise<HandoffEvent> {
+  const event: HandoffEvent = {
+    schemaVersion: 1,
+    kind: "agent_handoff_event",
+    eventId: makeEventId(input.timestamp),
+    ...input,
+    timestamp: input.timestamp ?? new Date().toISOString(),
+  };
+  const path = handoffEventLogPath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(event)}\n`, { flag: "a" });
+  return event;
+}
+
+export async function getHandoffMonitor(options: HandoffMonitorOptions = {}) {
+  const limit = clampInt(options.limit ?? DEFAULT_LIMIT, 1, 100);
+  const now = options.now ?? new Date();
+  const events = await readHandoffEvents(options.eventLogPath ?? handoffEventLogPath());
+  const filtered = options.correlationId
+    ? events.filter((event) => event.correlationId === options.correlationId)
+    : events;
+  const sorted = filtered
+    .slice()
+    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
+  const grouped = groupByCorrelation(sorted);
+  const activeWindowMs = clampInt(
+    options.activeWindowMinutes ?? DEFAULT_ACTIVE_WINDOW_MINUTES,
+    1,
+    24 * 60
+  ) * 60_000;
+  const summaries = Array.from(grouped.values()).map((group) => summarizeCorrelation(group, now));
+  const active = summaries.filter((summary) => (
+    summary.active === true
+    && now.getTime() - Date.parse(summary.updatedAt) <= activeWindowMs
+  ));
+
+  return {
+    schemaVersion: 1,
+    kind: "agent_handoff_monitor",
+    generatedAt: now.toISOString(),
+    status: active.length > 0 ? "active" : "idle",
+    source: "local_handoff_event_log",
+    filter: {
+      correlationId: options.correlationId ?? null,
+      limit,
+      activeWindowMinutes: options.activeWindowMinutes ?? DEFAULT_ACTIVE_WINDOW_MINUTES,
+    },
+    counts: {
+      events: filtered.length,
+      correlations: summaries.length,
+      active: active.length,
+      recent: Math.min(summaries.length, limit),
+    },
+    active: active.slice(0, limit),
+    recent: summaries.slice(0, limit),
+    safety: {
+      readOnly: true,
+      githubMutated: false,
+      wikipediaEdited: false,
+      freeFormHermesPromptUsed: false,
+    },
+  };
+}
+
+export function summarizeHandoffResult(result: unknown): Record<string, unknown> {
+  const record = isRecord(result) ? result : {};
+  const nestedResult = isRecord(record.result) ? record.result : {};
+  const summary = isRecord(record.summary)
+    ? record.summary
+    : isRecord(nestedResult.summary)
+      ? nestedResult.summary
+      : undefined;
+  const safety = isRecord(record.safety)
+    ? record.safety
+    : isRecord(nestedResult.safety)
+      ? nestedResult.safety
+      : undefined;
+
+  return compactRecord({
+    kind: stringField(record, "kind") ?? stringField(nestedResult, "kind"),
+    status: stringField(record, "status") ?? stringField(nestedResult, "status"),
+    reason: stringField(record, "reason") ?? stringField(nestedResult, "finalReason"),
+    finalVerdict: stringField(nestedResult, "finalVerdict"),
+    mergeRecommendation: firstDeepString(nestedResult, [
+      ["github", "mergeRecommendation"],
+      ["github", "merge_recommendation"],
+    ]),
+    requestedCaseIds: arrayField(nestedResult, "requestedCaseIds"),
+    summary,
+    safety,
+  });
+}
+
+export function summarizeHandoffError(error: unknown): Record<string, unknown> {
+  return {
+    error: error instanceof Error ? error.message : String(error),
+  };
+}
+
+async function readHandoffEvents(path: string): Promise<HandoffEvent[]> {
+  let content = "";
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+  return content
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(parseEventLine)
+    .filter((event): event is HandoffEvent => event !== null);
+}
+
+function parseEventLine(line: string): HandoffEvent | null {
+  try {
+    const value: unknown = JSON.parse(line);
+    if (!isRecord(value)) return null;
+    if (value.kind !== "agent_handoff_event") return null;
+    const correlationId = stringField(value, "correlationId");
+    const timestamp = stringField(value, "timestamp");
+    const phase = stringField(value, "phase");
+    const status = stringField(value, "status");
+    if (!correlationId || !timestamp || !phase || !status) return null;
+    return value as unknown as HandoffEvent;
+  } catch {
+    return null;
+  }
+}
+
+function groupByCorrelation(eventsNewestFirst: HandoffEvent[]) {
+  const groups = new Map<string, HandoffEvent[]>();
+  for (const event of eventsNewestFirst) {
+    const group = groups.get(event.correlationId) ?? [];
+    group.push(event);
+    groups.set(event.correlationId, group);
+  }
+  return groups;
+}
+
+function summarizeCorrelation(eventsNewestFirst: HandoffEvent[], now: Date) {
+  const latest = eventsNewestFirst[0];
+  const oldest = eventsNewestFirst[eventsNewestFirst.length - 1];
+  const status = latest?.status ?? "completed";
+  return {
+    correlationId: latest?.correlationId ?? "unknown",
+    requester: latest?.requester ?? oldest?.requester ?? null,
+    intent: latest?.intent ?? oldest?.intent ?? null,
+    repo: latest?.repo ?? oldest?.repo ?? null,
+    pullRequestNumber: latest?.pullRequestNumber ?? oldest?.pullRequestNumber ?? null,
+    pullRequestUrl: latest?.pullRequestUrl ?? oldest?.pullRequestUrl ?? null,
+    testCaseIds: latest?.testCaseIds ?? oldest?.testCaseIds ?? [],
+    reason: latest?.reason ?? oldest?.reason ?? null,
+    status,
+    phase: latest?.phase ?? "unknown",
+    active: status === "running",
+    startedAt: oldest?.timestamp ?? now.toISOString(),
+    updatedAt: latest?.timestamp ?? now.toISOString(),
+    eventCount: eventsNewestFirst.length,
+    summary: latest?.summary ?? null,
+    safety: latest?.safety ?? null,
+  };
+}
+
+function handoffEventLogPath(): string {
+  return process.env.AVERRAY_HANDOFF_EVENTS_PATH
+    ?? "/tmp/averray-reference-agent/handoff-events.jsonl";
+}
+
+function makeEventId(timestamp?: string): string {
+  const stamp = (timestamp ?? new Date().toISOString()).replace(/[^0-9A-Za-z]/g, "");
+  return `handoff-event-${stamp}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clampInt(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.max(min, Math.min(max, Math.trunc(value)));
+}
+
+function compactRecord(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+}
+
+function arrayField(record: Record<string, unknown>, key: string): string[] | undefined {
+  const value = record[key];
+  if (!Array.isArray(value)) return undefined;
+  return value.filter((entry): entry is string => typeof entry === "string");
+}
+
+function firstDeepString(record: Record<string, unknown>, paths: string[][]): string | undefined {
+  for (const path of paths) {
+    let value: unknown = record;
+    for (const key of path) {
+      value = isRecord(value) ? value[key] : undefined;
+    }
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -48,6 +48,7 @@ import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { invokeAgentTask } from "./agent-invocation.js";
+import { getHandoffMonitor } from "./handoff-events.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -237,11 +238,24 @@ server.tool(
 );
 
 server.tool(
+  "averray_handoff_monitor",
+  "Read-only personal monitor for agent-to-agent Hermes handoffs. Returns active and recent handoffs grouped by correlationId, including requester, intent, repo/PR, requested test cases, latest phase, final summary, and safety metadata. This is local observability only: it does not merge PRs, deploy, claim jobs, submit work, edit GitHub, or edit Wikipedia.",
+  {
+    correlationId: z.string().optional(),
+    limit: z.number().int().min(1).max(100).default(20),
+    activeWindowMinutes: z.number().int().min(1).max(1440).default(120)
+  },
+  async ({ correlationId, limit, activeWindowMinutes }) => {
+    return jsonContent(await getHandoffMonitor({ correlationId, limit, activeWindowMinutes }));
+  }
+);
+
+server.tool(
   "averray_invoke_agent_task",
   "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, one testbed testcase by ID, or a PR handoff workflow that reviews GitHub PR metadata/checks/files and then runs requested tests with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, local checkpoint writes, and PRs that are not merge-ready unless the caller explicitly opts into that class of action. PR handoff only recommends merge state; it never merges.",
   {
     requester: z.string().min(1),
-    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_case", "pr_handoff"]).default("operator_command"),
+    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_suite", "testbed_case", "pr_handoff"]).default("operator_command"),
     command: z.string().min(1).optional(),
     testCaseId: z.string().min(1).optional(),
     testCaseIds: z.array(z.string().min(1)).max(20).optional(),
@@ -266,7 +280,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -84,6 +84,12 @@ export type ParsedOperatorCommand =
       detailed: boolean;
     }
   | {
+      handled: true;
+      kind: "handoff_monitor";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
       handled: false;
       kind: "unknown";
       source: OperatorCommandSource;
@@ -129,6 +135,9 @@ const EXAMPLES = [
   "testbed e2e suite",
   "platform e2e suite",
   "run testbed e2e read-only",
+  "handoff monitor",
+  "hermes handoff monitor",
+  "what is hermes doing",
   "find safe work",
   "operator status",
   "operator status details",
@@ -187,6 +196,10 @@ export function parseOperatorCommand(
 
   if (isRunTestbedE2eReadOnlyCommand(normalizedText)) {
     return { handled: true, kind: "run_testbed_e2e_read_only", source, detailed };
+  }
+
+  if (isHandoffMonitorCommand(normalizedText)) {
+    return { handled: true, kind: "handoff_monitor", source, detailed };
   }
 
   if (isTestbedE2eSuiteCommand(normalizedText)) {
@@ -357,6 +370,10 @@ function isBusinessLedgerCommand(text: string): boolean {
 
 function isOpsHealthCommand(text: string): boolean {
   return /^(ops health|operator health|agent health|stack health|health check|control plane health|mcp health)( details?| full| audit)?$/.test(text);
+}
+
+function isHandoffMonitorCommand(text: string): boolean {
+  return /^(handoff monitor|agent handoff monitor|hermes handoff monitor|hermes monitor|what is hermes doing|what is the agent doing|current handoffs|active handoffs|handoff status)( details?| full| audit)?$/.test(text);
 }
 
 function githubOperatorView(text: string): GithubOperatorView | undefined {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -12,6 +12,7 @@ import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./o
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
+import { getHandoffMonitor } from "./handoff-events.js";
 
 export interface HandleOperatorCommandInput {
   text: string;
@@ -81,6 +82,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "run_testbed_e2e_read_only") {
     const run = await runTestbedE2eReadOnly({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, run };
+  }
+  if (command.kind === "handoff_monitor") {
+    const monitor = await getHandoffMonitor();
+    return { ...command, monitor };
   }
   if (command.kind === "testbed_e2e_suite") {
     const suite = await getTestbedE2eSuite({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/test/unit/agent-invocation.test.ts
+++ b/test/unit/agent-invocation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { invokeAgentTask } from "../../packages/averray-mcp/src/agent-invocation.js";
+import type { HandoffEventInput } from "../../packages/averray-mcp/src/handoff-events.js";
 import type { WorkflowDeps } from "../../packages/averray-mcp/src/job-workflows.js";
 
 const jobId = "wiki-en-58158792-citation-repair-r9";
@@ -17,6 +18,53 @@ const definition = {
 };
 
 describe("agent invocation hook", () => {
+  it("records handoff monitor events around an invocation", async () => {
+    const calls: string[] = [];
+    const events: HandoffEventInput[] = [];
+    const result = await invokeAgentTask(
+      {
+        requester: "github-actions",
+        intent: "testbed_case",
+        testCaseId: "TBE2E-004",
+        correlationId: "github-pr-123",
+        reason: "post-CI PR handoff",
+      },
+      deps(calls, undefined, events)
+    );
+
+    expect(result).toMatchObject({ status: "completed" });
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      correlationId: "github-pr-123",
+      requester: "github-actions",
+      intent: "testbed_case",
+      phase: "started",
+      status: "running",
+      testCaseId: "TBE2E-004",
+      reason: "post-CI PR handoff",
+    });
+    expect(events[1]).toMatchObject({
+      correlationId: "github-pr-123",
+      phase: "completed",
+      status: "completed",
+      summary: {
+        kind: "agent_invocation",
+        status: "completed",
+        summary: {
+          totalCases: 1,
+          executed: 1,
+          passed: 1,
+          failed: 0,
+          skipped: 0,
+        },
+      },
+      safety: {
+        wouldMutate: false,
+        wouldWriteLocalCheckpoint: false,
+      },
+    });
+  });
+
   it("runs one read-only testbed testcase with agent metadata", async () => {
     const calls: string[] = [];
     const result = await invokeAgentTask(
@@ -67,6 +115,50 @@ describe("agent invocation hook", () => {
     ]));
     expect(calls).not.toContain("claim");
     expect(calls).not.toContain("saveDraft");
+    expect(calls).not.toContain("submit");
+  });
+
+  it("accepts the post-deploy testbed_suite intent and skips mutation-bound cases", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      {
+        requester: "github-actions",
+        intent: "testbed_suite",
+        testCaseIds: ["TBE2E-001", "TBE2E-004", "TBE2E-010"],
+        correlationId: "github-deploy-123",
+      },
+      deps(calls)
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "completed",
+      invocation: {
+        requester: "github-actions",
+        intent: "testbed_suite",
+        testCaseIds: ["TBE2E-001", "TBE2E-004", "TBE2E-010"],
+        correlationId: "github-deploy-123",
+      },
+      result: {
+        kind: "testbed_e2e_read_only_run",
+        requestedCaseIds: ["TBE2E-001", "TBE2E-004", "TBE2E-010"],
+        summary: {
+          totalCases: 3,
+          executed: 2,
+          passed: 2,
+          failed: 0,
+          skipped: 1,
+        },
+      },
+    });
+    expect(calls).toEqual(expect.arrayContaining([
+      "walletStatus",
+      "listJobs",
+      "policyCheckClaim",
+      "fetchEvidence",
+      "validate",
+    ]));
+    expect(calls).not.toContain("claim");
     expect(calls).not.toContain("submit");
   });
 
@@ -230,10 +322,11 @@ describe("agent invocation hook", () => {
   });
 });
 
-function deps(calls: string[], githubFetchFn?: typeof fetch) {
+function deps(calls: string[], githubFetchFn?: typeof fetch, events?: HandoffEventInput[]) {
   return {
     githubEnv: { GITHUB_TOKEN: "ghp_readonly" },
     ...(githubFetchFn ? { githubFetchFn } : {}),
+    handoffEventRecorder: async (event: HandoffEventInput) => { events?.push(event); },
     now: new Date("2026-05-09T12:00:00.000Z"),
     async query(text: string) {
       if (text.includes("from budgets")) return [{ usd_spent: "0" }];

--- a/test/unit/handoff-events.test.ts
+++ b/test/unit/handoff-events.test.ts
@@ -1,0 +1,105 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+import {
+  getHandoffMonitor,
+  recordHandoffEvent,
+} from "../../packages/averray-mcp/src/handoff-events.js";
+
+describe("handoff event monitor", () => {
+  it("groups active and recent handoffs by correlation id", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-handoff-events-"));
+    const previous = process.env.AVERRAY_HANDOFF_EVENTS_PATH;
+    process.env.AVERRAY_HANDOFF_EVENTS_PATH = join(dir, "events.jsonl");
+    try {
+      await recordHandoffEvent({
+        correlationId: "github-pr-218-sha-run",
+        requester: "github-actions",
+        intent: "pr_handoff",
+        phase: "started",
+        status: "running",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 218,
+        testCaseIds: ["TBE2E-004"],
+        reason: "post-CI PR handoff",
+        timestamp: "2026-05-09T17:24:30.000Z",
+      });
+      await recordHandoffEvent({
+        correlationId: "github-pr-218-sha-run",
+        requester: "github-actions",
+        intent: "pr_handoff",
+        phase: "completed",
+        status: "completed",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 218,
+        testCaseIds: ["TBE2E-004"],
+        summary: {
+          finalVerdict: "ok_to_merge",
+          mergeRecommendation: "ok_to_merge",
+        },
+        safety: {
+          githubMutated: false,
+          wikipediaEdited: false,
+        },
+        timestamp: "2026-05-09T17:28:30.000Z",
+      });
+      await recordHandoffEvent({
+        correlationId: "github-deploy-25608715158",
+        requester: "github-actions",
+        intent: "testbed_suite",
+        phase: "started",
+        status: "running",
+        repo: "averray-agent/agent",
+        testCaseIds: ["TBE2E-001", "TBE2E-002"],
+        timestamp: "2026-05-09T18:36:00.000Z",
+      });
+
+      const monitor = await getHandoffMonitor({
+        now: new Date("2026-05-09T18:40:00.000Z"),
+        activeWindowMinutes: 60,
+        limit: 10,
+      });
+
+      expect(monitor).toMatchObject({
+        kind: "agent_handoff_monitor",
+        status: "active",
+        counts: {
+          events: 3,
+          correlations: 2,
+          active: 1,
+          recent: 2,
+        },
+        active: [
+          {
+            correlationId: "github-deploy-25608715158",
+            requester: "github-actions",
+            intent: "testbed_suite",
+            status: "running",
+            active: true,
+            testCaseIds: ["TBE2E-001", "TBE2E-002"],
+          },
+        ],
+        recent: [
+          expect.objectContaining({ correlationId: "github-deploy-25608715158" }),
+          expect.objectContaining({
+            correlationId: "github-pr-218-sha-run",
+            status: "completed",
+            summary: {
+              finalVerdict: "ok_to_merge",
+              mergeRecommendation: "ok_to_merge",
+            },
+          }),
+        ],
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AVERRAY_HANDOFF_EVENTS_PATH;
+      } else {
+        process.env.AVERRAY_HANDOFF_EVENTS_PATH = previous;
+      }
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -223,6 +223,21 @@ describe("operator commands", () => {
     });
   });
 
+  it("routes Hermes handoff monitor commands read-only", () => {
+    expect(parseOperatorCommand("handoff monitor", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "handoff_monitor",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("what is Hermes doing details", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "handoff_monitor",
+      source: "command_center",
+      detailed: true,
+    });
+  });
+
   it("returns latest submit status with draft id and Slack permalink when stored", async () => {
     const status = await getLastWikipediaCitationRepairStatus(async (text) => {
       if (text.includes("from submissions")) {


### PR DESCRIPTION
Adds a read-only handoff monitor event log for agent-to-agent Hermes invocations.\n\nWhat changed:\n- Record started/completed/blocked/failed events around averray_invoke_agent_task with correlation IDs.\n- Add averray_handoff_monitor plus operator commands like handoff monitor / what is Hermes doing.\n- Accept testbed_suite as a structured post-deploy invocation intent with explicit testCaseIds.\n- Document the event log env and post-deploy handoff usage.\n\nChecks run:\n- npm test\n- npm run typecheck\n\nSafety:\n- Monitor is observability-only and must not change task execution behavior.\n- No GitHub, deploy, Wikipedia, claim, submit, or wallet mutation is performed by the monitor.