### PR TITLE
Improve active handoff visibility

### DIFF
--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -43,6 +43,7 @@ export interface HandoffMonitorOptions {
 
 const DEFAULT_LIMIT = 20;
 const DEFAULT_ACTIVE_WINDOW_MINUTES = 120;
+const ACTIVE_LINGER_MINUTES = 3;
 
 export async function recordHandoffEvent(input: HandoffEventInput): Promise<HandoffEvent> {
   const event: HandoffEvent = {
@@ -75,16 +76,15 @@ export async function getHandoffMonitor(options: HandoffMonitorOptions = {}) {
     24 * 60
   ) * 60_000;
   const summaries = Array.from(grouped.values()).map((group) => summarizeCorrelation(group, now));
-  const active = summaries.filter((summary) => (
-    summary.active === true
-    && now.getTime() - Date.parse(summary.updatedAt) <= activeWindowMs
-  ));
+  const active = summaries.filter((summary) => isVisibleActive(summary, now, activeWindowMs));
+  const running = active.filter((summary) => summary.activeState === "running").length;
+  const justFinished = active.filter((summary) => summary.activeState === "just_finished").length;
 
   return {
     schemaVersion: 1,
     kind: "agent_handoff_monitor",
     generatedAt: now.toISOString(),
-    status: active.length > 0 ? "active" : "idle",
+    status: running > 0 ? "active" : justFinished > 0 ? "recently_active" : "idle",
     source: "local_handoff_event_log",
     filter: {
       correlationId: options.correlationId ?? null,
@@ -95,6 +95,8 @@ export async function getHandoffMonitor(options: HandoffMonitorOptions = {}) {
       events: filtered.length,
       correlations: summaries.length,
       active: active.length,
+      running,
+      justFinished,
       recent: Math.min(summaries.length, limit),
     },
     active: active.slice(0, limit),
@@ -190,6 +192,9 @@ function summarizeCorrelation(eventsNewestFirst: HandoffEvent[], now: Date) {
   const latest = eventsNewestFirst[0];
   const oldest = eventsNewestFirst[eventsNewestFirst.length - 1];
   const status = latest?.status ?? "completed";
+  const sawRunning = eventsNewestFirst.some((event) => event.status === "running");
+  const active = status === "running";
+  const updatedAt = latest?.timestamp ?? now.toISOString();
   return {
     correlationId: latest?.correlationId ?? "unknown",
     requester: latest?.requester ?? oldest?.requester ?? null,
@@ -201,13 +206,36 @@ function summarizeCorrelation(eventsNewestFirst: HandoffEvent[], now: Date) {
     reason: latest?.reason ?? oldest?.reason ?? null,
     status,
     phase: latest?.phase ?? "unknown",
-    active: status === "running",
+    active,
+    activeState: active
+      ? "running"
+      : sawRunning && isTerminalStatus(status) && now.getTime() - Date.parse(updatedAt) <= ACTIVE_LINGER_MINUTES * 60_000
+        ? "just_finished"
+        : "inactive",
     startedAt: oldest?.timestamp ?? now.toISOString(),
-    updatedAt: latest?.timestamp ?? now.toISOString(),
+    updatedAt,
     eventCount: eventsNewestFirst.length,
     summary: latest?.summary ?? null,
     safety: latest?.safety ?? null,
   };
+}
+
+function isVisibleActive(
+  summary: { activeState?: string; updatedAt: string },
+  now: Date,
+  activeWindowMs: number
+): boolean {
+  const ageMs = now.getTime() - Date.parse(summary.updatedAt);
+  if (ageMs > activeWindowMs) return false;
+  return summary.activeState === "running" || summary.activeState === "just_finished";
+}
+
+function isTerminalStatus(status: string): boolean {
+  return status === "completed"
+    || status === "passed"
+    || status === "blocked"
+    || status === "failed"
+    || status === "needs_review";
 }
 
 function handoffEventLogPath(): string {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -212,13 +212,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     </header>
     <section class="grid" aria-label="Monitor summary">
       <div class="card"><span class="metric">Status</span><span id="status" class="value">...</span></div>
-      <div class="card"><span class="metric">Active</span><span id="active-count" class="value">0</span></div>
+      <div class="card"><span class="metric">Active / Just Finished</span><span id="active-count" class="value">0</span></div>
       <div class="card"><span class="metric">Needs Attention</span><span id="attention-count" class="value">0</span></div>
       <div class="card"><span class="metric">Recent</span><span id="recent-count" class="value">0</span></div>
       <div class="card"><span class="metric">Events</span><span id="event-count" class="value">0</span></div>
     </section>
-    <div class="section-title"><h2>Active Now</h2><span id="generated" class="pill">waiting</span></div>
-    <section id="active" class="list"><div class="empty">No active handoffs.</div></section>
+    <div class="section-title"><h2>Live Lane</h2><span id="generated" class="pill">waiting</span></div>
+    <section id="active" class="list"><div class="empty">No running or just-finished handoffs.</div></section>
     <div class="section-title"><h2>Needs Attention</h2><span class="pill">release gate</span></div>
     <section id="attention" class="list"><div class="empty">No handoffs need attention.</div></section>
     <div class="section-title"><h2>Release Timeline</h2><span class="pill">auto-refresh 5s</span></div>
@@ -253,7 +253,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       document.getElementById("recent-count").textContent = counts.recent || 0;
       document.getElementById("event-count").textContent = counts.events || 0;
       document.getElementById("generated").textContent = payload.generatedAt ? new Date(payload.generatedAt).toLocaleString() : "unknown";
-      renderList("active", payload.active || [], "No active handoffs.");
+      renderList("active", payload.active || [], "No running or just-finished handoffs.");
       renderList("attention", attention, "No handoffs need attention.");
       renderList("recent", recent, "No recent handoffs in the monitor window.");
     }
@@ -282,6 +282,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("Correlation", "<code>" + escapeHtml(item.correlationId || "unknown") + "</code>") +
         row("Requester", escapeHtml(item.requester || "n/a")) +
         row("Phase", escapeHtml(item.phase || "unknown")) +
+        row("Live state", escapeHtml(liveStateLabel(item.activeState))) +
         row("Reason", escapeHtml(item.reason || "n/a")) +
         row("Tests", tests) +
         row("PR", pr) +
@@ -315,6 +316,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (status === "running") {
         return { level: "running", label: "RUNNING", why: reason };
       }
+      if (item.activeState === "just_finished") {
+        const label = finalVerdict.includes("review") || mergeRecommendation.includes("review")
+          ? "JUST FINISHED - REVIEW"
+          : finalVerdict.includes("block") || status === "blocked" || status === "failed"
+            ? "JUST FINISHED - BLOCK"
+            : "JUST FINISHED";
+        return { level: "running", label, why: reason };
+      }
       if (status === "failed" || status === "blocked" || finalVerdict.includes("block")) {
         return { level: "block", label: "BLOCK", why: reason };
       }
@@ -331,6 +340,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function normalize(value) {
       return String(value || "").trim().toLowerCase().replace(/[\\s-]+/g, "_");
+    }
+
+    function liveStateLabel(value) {
+      const state = normalize(value);
+      if (state === "running") return "running";
+      if (state === "just_finished") return "just finished";
+      return "inactive";
     }
 
     function derivePullRequestUrl(item) {

--- a/test/unit/handoff-events.test.ts
+++ b/test/unit/handoff-events.test.ts
@@ -78,6 +78,7 @@ describe("handoff event monitor", () => {
             intent: "testbed_suite",
             status: "running",
             active: true,
+            activeState: "running",
             testCaseIds: ["TBE2E-001", "TBE2E-002"],
           },
         ],
@@ -91,6 +92,70 @@ describe("handoff event monitor", () => {
               mergeRecommendation: "ok_to_merge",
             },
           }),
+        ],
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.AVERRAY_HANDOFF_EVENTS_PATH;
+      } else {
+        process.env.AVERRAY_HANDOFF_EVENTS_PATH = previous;
+      }
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps just-finished handoffs visible briefly in the active lane", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-handoff-events-"));
+    const previous = process.env.AVERRAY_HANDOFF_EVENTS_PATH;
+    process.env.AVERRAY_HANDOFF_EVENTS_PATH = join(dir, "events.jsonl");
+    try {
+      await recordHandoffEvent({
+        correlationId: "github-pr-240-sha-run",
+        requester: "github-actions",
+        intent: "pr_handoff",
+        phase: "started",
+        status: "running",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 240,
+        testCaseIds: ["TBE2E-004"],
+        timestamp: "2026-05-12T14:36:00.000Z",
+      });
+      await recordHandoffEvent({
+        correlationId: "github-pr-240-sha-run",
+        requester: "github-actions",
+        intent: "pr_handoff",
+        phase: "completed",
+        status: "completed",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 240,
+        testCaseIds: ["TBE2E-004"],
+        summary: {
+          finalVerdict: "needs_review",
+          mergeRecommendation: "needs_review",
+        },
+        timestamp: "2026-05-12T14:36:58.000Z",
+      });
+
+      const monitor = await getHandoffMonitor({
+        now: new Date("2026-05-12T14:37:30.000Z"),
+        activeWindowMinutes: 60,
+        limit: 10,
+      });
+
+      expect(monitor).toMatchObject({
+        status: "recently_active",
+        counts: {
+          active: 1,
+          running: 0,
+          justFinished: 1,
+        },
+        active: [
+          {
+            correlationId: "github-pr-240-sha-run",
+            status: "completed",
+            active: false,
+            activeState: "just_finished",
+          },
         ],
       });
     } finally {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -46,6 +46,10 @@ describe("slack operator personal monitor", () => {
 
     expect(html).toContain("<title>Pascal Monitor</title>");
     expect(html).toContain("Live private view of agent-to-agent handoffs.");
+    expect(html).toContain("Active / Just Finished");
+    expect(html).toContain("Live Lane");
+    expect(html).toContain("Live state");
+    expect(html).toContain("JUST FINISHED");
     expect(html).toContain("const eventsPath = \"/monitor/events\";");
     expect(html).toContain("Needs Attention");
     expect(html).toContain("Release Timeline");


### PR DESCRIPTION
## What changed
- Keep just-finished handoffs visible briefly in the monitor live lane so short runs are observable.
- Add running vs just-finished counts to the handoff monitor API.
- Update the monitor UI labels to show a live state for each handoff.

## Checks
- npm test -- handoff-events slack-monitor
- npm run typecheck
- git diff --check

## Scope
- Slack operator monitor UI
- Averray MCP handoff monitor summaries
- No GitHub/Wikipedia mutations or deployment behavior changes