### PR TITLE
Clarify handoff review reasons

### DIFF
--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -128,11 +128,13 @@ export function summarizeHandoffResult(result: unknown): Record<string, unknown>
     kind: stringField(record, "kind") ?? stringField(nestedResult, "kind"),
     status: stringField(record, "status") ?? stringField(nestedResult, "status"),
     reason: stringField(record, "reason") ?? stringField(nestedResult, "finalReason"),
+    finalReason: stringField(nestedResult, "finalReason"),
     finalVerdict: stringField(nestedResult, "finalVerdict"),
     mergeRecommendation: firstDeepString(nestedResult, [
       ["github", "mergeRecommendation"],
       ["github", "merge_recommendation"],
     ]),
+    reviewReasons: githubReviewReasons(nestedResult),
     requestedCaseIds: arrayField(nestedResult, "requestedCaseIds"),
     summary,
     safety,
@@ -272,6 +274,21 @@ function firstDeepString(record: Record<string, unknown>, paths: string[][]): st
     if (typeof value === "string" && value.length > 0) return value;
   }
   return undefined;
+}
+
+function githubReviewReasons(record: Record<string, unknown>): Record<string, unknown>[] | undefined {
+  const github = isRecord(record.github) ? record.github : undefined;
+  const findings = Array.isArray(github?.riskFindings) ? github.riskFindings : [];
+  const reviewReasons = findings
+    .filter(isRecord)
+    .filter((finding) => stringField(finding, "code") !== "pr_review_green")
+    .slice(0, 5)
+    .map((finding) => compactRecord({
+      severity: stringField(finding, "severity"),
+      code: stringField(finding, "code"),
+      message: stringField(finding, "message"),
+    }));
+  return reviewReasons.length > 0 ? reviewReasons : undefined;
 }
 
 function stringField(record: Record<string, unknown>, key: string): string | undefined {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -288,6 +288,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("PR", pr) +
         row("Verdict", escapeHtml(summary.finalVerdict || summary.status || "n/a")) +
         row("Merge", escapeHtml(summary.mergeRecommendation || "n/a")) +
+        reviewReasonRows(summary) +
         row("Updated", escapeHtml(item.updatedAt ? new Date(item.updatedAt).toLocaleString() : "unknown")) +
         '</dl></article>';
     }
@@ -311,7 +312,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const status = normalize(item.status);
       const finalVerdict = normalize(summary.finalVerdict || summary.status);
       const mergeRecommendation = normalize(summary.mergeRecommendation);
-      const reason = String(summary.reason || item.reason || item.phase || "No reason recorded.");
+      const reason = releaseReason(summary, item);
 
       if (status === "running") {
         return { level: "running", label: "RUNNING", why: reason };
@@ -336,6 +337,28 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return { level: "needs-review", label: "NEEDS REVIEW", why: reason };
       }
       return { level: "pass", label: "PASS", why: reason };
+    }
+
+    function releaseReason(summary, item) {
+      const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
+      const first = reviewReasons.find(Boolean);
+      if (first) {
+        const code = String(first.code || "review");
+        const message = String(first.message || "Human review recommended.");
+        return code + ": " + message;
+      }
+      return String(summary.finalReason || summary.reason || item.reason || item.phase || "No reason recorded.");
+    }
+
+    function reviewReasonRows(summary) {
+      const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
+      if (!reviewReasons.length) return "";
+      return reviewReasons.slice(0, 3).map((reason, index) => {
+        const code = reason && reason.code ? String(reason.code) : "review";
+        const severity = reason && reason.severity ? String(reason.severity) : "unknown";
+        const message = reason && reason.message ? String(reason.message) : "Human review recommended.";
+        return row(index === 0 ? "Review why" : "", escapeHtml(severity + " / " + code + " - " + message));
+      }).join("");
     }
 
     function normalize(value) {

--- a/test/unit/handoff-events.test.ts
+++ b/test/unit/handoff-events.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   getHandoffMonitor,
   recordHandoffEvent,
+  summarizeHandoffResult,
 } from "../../packages/averray-mcp/src/handoff-events.js";
 
 describe("handoff event monitor", () => {
@@ -166,5 +167,46 @@ describe("handoff event monitor", () => {
       }
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("preserves GitHub review reasons in handoff summaries", () => {
+    const summary = summarizeHandoffResult({
+      result: {
+        kind: "agent_pr_handoff",
+        status: "completed",
+        finalVerdict: "needs_review",
+        finalReason: "GitHub review found medium risk.",
+        github: {
+          mergeRecommendation: "needs_review",
+          riskFindings: [
+            {
+              severity: "info",
+              code: "pr_review_green",
+              message: "Branch CI is green.",
+            },
+            {
+              severity: "medium",
+              code: "high_risk_files",
+              message: "PR touches deployment scripts; human review recommended.",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary).toMatchObject({
+      kind: "agent_pr_handoff",
+      status: "completed",
+      finalVerdict: "needs_review",
+      finalReason: "GitHub review found medium risk.",
+      mergeRecommendation: "needs_review",
+      reviewReasons: [
+        {
+          severity: "medium",
+          code: "high_risk_files",
+          message: "PR touches deployment scripts; human review recommended.",
+        },
+      ],
+    });
   });
 });

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -57,6 +57,9 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("activeWindowMinutes: \"240\"");
     expect(html).toContain("limit: \"50\"");
     expect(html).toContain("releaseVerdict(item)");
+    expect(html).toContain("reviewReasonRows(summary)");
+    expect(html).toContain("Review why");
+    expect(html).toContain("releaseReason(summary, item)");
     expect(html).toContain("derivePullRequestUrl(item)");
     expect(html).toContain("https://github.com/");
     expect(html).not.toContain("handleOperatorCommand");


### PR DESCRIPTION
## Summary
- preserve GitHub risk findings in handoff summaries as compact review reasons
- show the first review reason as the monitor card why-line
- render up to three review reason rows so needs_review cards explain themselves

## Checks
- npm test -- test/unit/handoff-events.test.ts test/unit/slack-monitor.test.ts
- npm run typecheck

## Notes
- Monitor/Slack-operator display only; no external mutations.