### PR TITLE
Tune GitHub PR verdict risk gate

### DIFF
--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -192,6 +192,7 @@ export interface GithubPullRequestFileSummary {
 
 export interface GithubPullRequestFileRisk extends GithubPullRequestFileSummary {
   risk: "high" | "medium";
+  category: "secrets" | "contracts" | "database" | "ops" | "deploy" | "workflow" | "lockfile" | "large_file";
   reason: string;
 }
 
@@ -872,23 +873,29 @@ function fileSummary(file: GithubApiPullRequestFile): GithubPullRequestFileSumma
 
 function fileRisk(file: GithubPullRequestFileSummary): GithubPullRequestFileRisk | undefined {
   const path = file.filename.toLowerCase();
-  const highRiskPatterns = [
-    /^\.env/,
-    /(^|\/)\.env/,
-    /(^|\/)secrets?\b/,
-    /(^|\/)contracts?\//,
-    /(^|\/)migrations?\//,
-    /(^|\/)ops\//,
-    /(^|\/)deploy/,
-    /compose.*\.ya?ml$/,
-    /caddyfile$/,
-    /package-lock\.json$/,
+  const criticalPatterns: Array<Pick<GithubPullRequestFileRisk, "category" | "reason"> & { pattern: RegExp }> = [
+    { pattern: /^\.env/, category: "secrets", reason: "touches environment or secret material" },
+    { pattern: /(^|\/)\.env/, category: "secrets", reason: "touches environment or secret material" },
+    { pattern: /(^|\/)secrets?\b/, category: "secrets", reason: "touches secret material" },
+    { pattern: /(^|\/)contracts?\//, category: "contracts", reason: "touches smart contract code" },
+    { pattern: /(^|\/)migrations?\//, category: "database", reason: "touches database migration code" },
   ];
-  if (highRiskPatterns.some((pattern) => pattern.test(path))) {
-    return { ...file, risk: "high", reason: "touches deploy, secret, contract, lockfile, or infrastructure surface" };
+  for (const match of criticalPatterns) {
+    if (match.pattern.test(path)) return { ...file, risk: "high", category: match.category, reason: match.reason };
+  }
+  const reviewPatterns: Array<Pick<GithubPullRequestFileRisk, "category" | "reason"> & { pattern: RegExp }> = [
+    { pattern: /^\.github\/workflows\//, category: "workflow", reason: "touches GitHub workflow automation" },
+    { pattern: /(^|\/)ops\//, category: "ops", reason: "touches operator or infrastructure configuration" },
+    { pattern: /(^|\/)deploy/, category: "deploy", reason: "touches deploy automation" },
+    { pattern: /compose.*\.ya?ml$/, category: "ops", reason: "touches container compose configuration" },
+    { pattern: /caddyfile$/, category: "ops", reason: "touches edge/proxy configuration" },
+    { pattern: /package-lock\.json$/, category: "lockfile", reason: "touches dependency lockfile" },
+  ];
+  for (const match of reviewPatterns) {
+    if (match.pattern.test(path)) return { ...file, risk: "medium", category: match.category, reason: match.reason };
   }
   if ((file.changes ?? 0) >= 400) {
-    return { ...file, risk: "medium", reason: "large single-file change" };
+    return { ...file, risk: "medium", category: "large_file", reason: "large single-file change" };
   }
   return undefined;
 }
@@ -948,12 +955,21 @@ function buildPullRequestRiskFindings(input: {
   if (input.checks.total === 0) {
     findings.push({ severity: "medium", code: "pr_checks_missing", message: "No PR check runs were found for the head commit." });
   }
-  const highRisk = input.highRiskFiles.filter((file) => file.risk === "high");
-  if (highRisk.length > 0) {
+  const criticalRisk = input.highRiskFiles.filter((file) => file.risk === "high");
+  if (criticalRisk.length > 0) {
+    findings.push({
+      severity: "high",
+      code: "pr_critical_files",
+      message: `${criticalRisk.length} changed file(s) touch secrets, contracts, or database migrations.`,
+    });
+  }
+  const reviewRisk = input.highRiskFiles.filter((file) => file.risk === "medium");
+  if (reviewRisk.length > 0) {
+    const categories = [...new Set(reviewRisk.map((file) => file.category))].join(", ");
     findings.push({
       severity: "medium",
-      code: "pr_high_risk_files",
-      message: `${highRisk.length} changed file(s) touch deploy, secret, contract, lockfile, or infrastructure surfaces.`,
+      code: "pr_review_risk_files",
+      message: `${reviewRisk.length} changed file(s) touch review-gated surfaces${categories ? ` (${categories})` : ""}.`,
     });
   }
   if (input.files.length > 25) {

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -318,6 +318,176 @@ describe("github operator status", () => {
     });
   });
 
+  it("keeps frontend, docs, and tests PRs merge-ready when CI is green", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent/pulls/187")) {
+        return jsonResponse({
+          number: 187,
+          title: "Polish dashboard empty states",
+          html_url: "https://github.com/averray-agent/agent/pull/187",
+          user: { login: "codex" },
+          draft: false,
+          state: "open",
+          base: { ref: "main" },
+          head: { ref: "codex/ui-polish", sha: "ui123" },
+          additions: 42,
+          deletions: 8,
+          changed_files: 3,
+          mergeable_state: "clean",
+        });
+      }
+      if (text.includes("/pulls/187/files")) {
+        return jsonResponse([
+          { filename: "app/(authed)/overview/page.tsx", status: "modified", additions: 24, deletions: 3, changes: 27 },
+          { filename: "test/unit/overview-empty-state.test.ts", status: "modified", additions: 14, deletions: 5, changes: 19 },
+          { filename: "docs/operator-dashboard.md", status: "modified", additions: 4, deletions: 0, changes: 4 },
+        ]);
+      }
+      if (text.includes("/commits/ui123/check-runs")) {
+        return jsonResponse({
+          check_runs: [
+            { name: "CI", status: "completed", conclusion: "success" },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const review = await getGithubPullRequestReview({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 187,
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(review).toMatchObject({
+      health: "ok",
+      files: {
+        highRisk: [],
+      },
+      mergeRecommendation: "ok_to_merge",
+    });
+    expect(review.riskFindings).toEqual([
+      expect.objectContaining({ severity: "low", code: "pr_review_green" }),
+    ]);
+  });
+
+  it("asks for human review on deploy and workflow-only risk", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent/pulls/188")) {
+        return jsonResponse({
+          number: 188,
+          title: "Tune production deploy workflow",
+          html_url: "https://github.com/averray-agent/agent/pull/188",
+          user: { login: "codex" },
+          draft: false,
+          state: "open",
+          head: { ref: "codex/deploy-workflow", sha: "deploy123" },
+          changed_files: 1,
+          mergeable_state: "clean",
+        });
+      }
+      if (text.includes("/pulls/188/files")) {
+        return jsonResponse([
+          { filename: ".github/workflows/deploy-production.yml", status: "modified", additions: 6, deletions: 2, changes: 8 },
+        ]);
+      }
+      if (text.includes("/commits/deploy123/check-runs")) {
+        return jsonResponse({
+          check_runs: [
+            { name: "CI", status: "completed", conclusion: "success" },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const review = await getGithubPullRequestReview({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 188,
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(review).toMatchObject({
+      health: "attention",
+      files: {
+        highRisk: [
+          expect.objectContaining({
+            filename: ".github/workflows/deploy-production.yml",
+            risk: "medium",
+            category: "workflow",
+          }),
+        ],
+      },
+      mergeRecommendation: "needs_review",
+    });
+    expect(review.riskFindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ severity: "medium", code: "pr_review_risk_files" }),
+    ]));
+  });
+
+  it("holds PRs that touch secrets or contract surfaces even when CI is green", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent/pulls/189")) {
+        return jsonResponse({
+          number: 189,
+          title: "Update settlement contract",
+          html_url: "https://github.com/averray-agent/agent/pull/189",
+          user: { login: "codex" },
+          draft: false,
+          state: "open",
+          head: { ref: "codex/settlement-contract", sha: "contract123" },
+          changed_files: 1,
+          mergeable_state: "clean",
+        });
+      }
+      if (text.includes("/pulls/189/files")) {
+        return jsonResponse([
+          { filename: "contracts/Settlement.sol", status: "modified", additions: 12, deletions: 4, changes: 16 },
+        ]);
+      }
+      if (text.includes("/commits/contract123/check-runs")) {
+        return jsonResponse({
+          check_runs: [
+            { name: "CI", status: "completed", conclusion: "success" },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const review = await getGithubPullRequestReview({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 189,
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(review).toMatchObject({
+      health: "attention",
+      files: {
+        highRisk: [
+          expect.objectContaining({
+            filename: "contracts/Settlement.sol",
+            risk: "high",
+            category: "contracts",
+          }),
+        ],
+      },
+      mergeRecommendation: "hold",
+    });
+    expect(review.riskFindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ severity: "high", code: "pr_critical_files" }),
+    ]));
+  });
+
   it("holds a pull request with failing checks or active checks", async () => {
     const fetchFn = async (url: string | URL | Request) => {
       const text = String(url);


### PR DESCRIPTION
## Summary
- separate critical PR surfaces from review-only release surfaces
- allow green frontend/docs/tests PRs to return ok_to_merge
- keep workflow/deploy/ops/lockfile/large-file changes as needs_review and secrets/contracts/migrations as hold

## Checks
- npm test -- test/unit/operator-github.test.ts test/unit/agent-invocation.test.ts
- npm test
- npm run build
- git diff --check