### PR TITLE
Show PR review signals in handoff monitor

### DIFF
--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -134,6 +134,7 @@ export function summarizeHandoffResult(result: unknown): Record<string, unknown>
       ["github", "mergeRecommendation"],
       ["github", "merge_recommendation"],
     ]),
+    reviewSignals: githubReviewSignals(nestedResult),
     reviewReasons: githubReviewReasons(nestedResult),
     requestedCaseIds: arrayField(nestedResult, "requestedCaseIds"),
     summary,
@@ -291,9 +292,29 @@ function githubReviewReasons(record: Record<string, unknown>): Record<string, un
   return reviewReasons.length > 0 ? reviewReasons : undefined;
 }
 
+function githubReviewSignals(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  const github = isRecord(record.github) ? record.github : undefined;
+  const review = isRecord(github?.review) ? github.review : undefined;
+  if (!review) return undefined;
+  const signals = compactRecord({
+    touchedAreas: arrayField(review, "touchedAreas"),
+    testFilesChanged: booleanField(review, "testFilesChanged"),
+    testSignals: arrayField(review, "testSignals"),
+    missingTestSignals: arrayField(review, "missingTestSignals"),
+    rolloutNotesRequired: booleanField(review, "rolloutNotesRequired"),
+    rolloutNotesPresent: booleanField(review, "rolloutNotesPresent"),
+  });
+  return Object.keys(signals).length > 0 ? signals : undefined;
+}
+
 function stringField(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function booleanField(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key];
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -144,6 +144,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       color: var(--text);
       line-height: 1.4;
     }
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin: 0 0 12px;
+    }
     .handoff-head {
       display: flex;
       align-items: flex-start;
@@ -321,6 +327,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("PR", pr) +
         row("Verdict", escapeHtml(summary.finalVerdict || summary.status || "n/a")) +
         row("Merge", escapeHtml(summary.mergeRecommendation || "n/a")) +
+        reviewSignalRows(summary) +
         reviewReasonRows(summary) +
         row("Updated", escapeHtml(item.updatedAt ? new Date(item.updatedAt).toLocaleString() : "unknown")) +
         '</dl></article>';
@@ -416,6 +423,25 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         const message = reason && reason.message ? String(reason.message) : "Human review recommended.";
         return row(index === 0 ? "Review why" : "", escapeHtml(severity + " / " + code + " - " + message));
       }).join("");
+    }
+
+    function reviewSignalRows(summary) {
+      const signals = summary.reviewSignals || {};
+      const rows = [];
+      const touchedAreas = Array.isArray(signals.touchedAreas) ? signals.touchedAreas : [];
+      const missingTests = Array.isArray(signals.missingTestSignals) ? signals.missingTestSignals : [];
+      const testSignals = Array.isArray(signals.testSignals) ? signals.testSignals : [];
+      if (touchedAreas.length) rows.push(row("Touched", chips(touchedAreas)));
+      if (missingTests.length) rows.push(row("Missing tests", chips(missingTests)));
+      if (testSignals.length) rows.push(row("Test signal", chips(testSignals.slice(0, 4))));
+      if (signals.rolloutNotesRequired === true) {
+        rows.push(row("Rollout notes", escapeHtml(signals.rolloutNotesPresent === true ? "present" : "missing")));
+      }
+      return rows.join("");
+    }
+
+    function chips(values) {
+      return '<span class="tags">' + values.map((value) => '<code>' + escapeHtml(String(value)) + '</code>').join("") + '</span>';
     }
 
     function normalize(value) {

--- a/test/unit/handoff-events.test.ts
+++ b/test/unit/handoff-events.test.ts
@@ -178,6 +178,14 @@ describe("handoff event monitor", () => {
         finalReason: "GitHub review found medium risk.",
         github: {
           mergeRecommendation: "needs_review",
+          review: {
+            touchedAreas: ["workflow", "config"],
+            testFilesChanged: false,
+            testSignals: ["check:CI"],
+            missingTestSignals: [],
+            rolloutNotesRequired: true,
+            rolloutNotesPresent: false,
+          },
           riskFindings: [
             {
               severity: "info",
@@ -200,6 +208,14 @@ describe("handoff event monitor", () => {
       finalVerdict: "needs_review",
       finalReason: "GitHub review found medium risk.",
       mergeRecommendation: "needs_review",
+      reviewSignals: {
+        touchedAreas: ["workflow", "config"],
+        testFilesChanged: false,
+        testSignals: ["check:CI"],
+        missingTestSignals: [],
+        rolloutNotesRequired: true,
+        rolloutNotesPresent: false,
+      },
       reviewReasons: [
         {
           severity: "medium",

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -61,7 +61,11 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("limit: \"50\"");
     expect(html).toContain("releaseVerdict(item)");
     expect(html).toContain("classifyReleaseGate(status, finalVerdict, mergeRecommendation, reason, reviewReasons)");
+    expect(html).toContain("reviewSignalRows(summary)");
     expect(html).toContain("reviewReasonRows(summary)");
+    expect(html).toContain("Missing tests");
+    expect(html).toContain("Rollout notes");
+    expect(html).toContain("Touched");
     expect(html).toContain("Review why");
     expect(html).toContain("releaseReason(summary, item, terminal.level)");
     expect(html).toContain("derivePullRequestUrl(item)");


### PR DESCRIPTION
## Summary
- preserve GitHub PR review signals in handoff summaries
- render touched areas, missing test signals, test evidence, and rollout-note state in the private monitor
- keep the monitor read-only and passive

## Checks
- npm test -- test/unit/handoff-events.test.ts test/unit/slack-monitor.test.ts
- npm test
- npm run build
- git diff --check