### PR TITLE
Improve Hermes release handoff signals

### DIFF
--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -640,6 +640,7 @@ async function recordInvocationEvent(
       phase: event.phase,
       status: event.status,
       ...(input.repo ? { repo: input.repo } : {}),
+      ...(input.sha ? { sha: input.sha } : {}),
       ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
       ...(input.pullRequestUrl ? { pullRequestUrl: input.pullRequestUrl } : {}),
       ...(input.testCaseId ? { testCaseId: normalizeTestCaseId(input.testCaseId) } : {}),

--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -16,6 +16,7 @@ export interface HandoffEventInput {
   phase: string;
   status: HandoffEventStatus;
   repo?: string;
+  sha?: string;
   pullRequestNumber?: number;
   pullRequestUrl?: string;
   testCaseId?: string;
@@ -204,6 +205,7 @@ function summarizeCorrelation(eventsNewestFirst: HandoffEvent[], now: Date) {
     requester: latest?.requester ?? oldest?.requester ?? null,
     intent: latest?.intent ?? oldest?.intent ?? null,
     repo: latest?.repo ?? oldest?.repo ?? null,
+    sha: latest?.sha ?? oldest?.sha ?? null,
     pullRequestNumber: latest?.pullRequestNumber ?? oldest?.pullRequestNumber ?? null,
     pullRequestUrl: latest?.pullRequestUrl ?? oldest?.pullRequestUrl ?? null,
     testCaseIds: latest?.testCaseIds ?? oldest?.testCaseIds ?? [],
@@ -324,12 +326,26 @@ function deploymentHealthSummary(record: Record<string, unknown>): Record<string
     suiteSkipped: numberField(suite, "skipped"),
     hostedStatus: stringField(hosted, "status"),
     hostedChecks: Array.isArray(hosted.checks) ? hosted.checks.length : undefined,
+    hostedFailedUrls: urlsFromRecords(hosted.checks, (check) => check.status === "failed"),
     githubHealth: stringField(github, "health"),
     githubFailingWorkflowRuns: numberField(githubTotals, "failingWorkflowRuns"),
     githubActiveWorkflowRuns: numberField(githubTotals, "activeWorkflowRuns"),
+    githubFailingWorkflowRunUrls: urlsFromRecords(github.failingWorkflowRuns),
+    githubActiveWorkflowRunUrls: urlsFromRecords(github.activeWorkflowRuns),
     opsStatus: stringField(ops, "status"),
     opsRecentErrors: numberField(ops, "recentErrors"),
   });
+}
+
+function urlsFromRecords(value: unknown, predicate: (record: Record<string, unknown>) => boolean = () => true): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const urls = value
+    .filter(isRecord)
+    .filter(predicate)
+    .map((record) => stringField(record, "url"))
+    .filter((url): url is string => Boolean(url))
+    .slice(0, 3);
+  return urls.length > 0 ? urls : undefined;
 }
 
 function stringField(record: Record<string, unknown>, key: string): string | undefined {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -313,6 +313,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const prUrl = item.pullRequestUrl || derivePullRequestUrl(item);
       const prLabel = item.pullRequestNumber ? "#" + escapeHtml(String(item.pullRequestNumber)) : "open PR";
       const pr = prUrl ? '<a href="' + escapeAttr(prUrl) + '" target="_blank" rel="noreferrer">' + prLabel + '</a>' : "n/a";
+      const commit = deriveCommitUrl(item);
+      const workflowRun = deriveWorkflowRunUrl(item);
       const tests = Array.isArray(item.testCaseIds) && item.testCaseIds.length ? item.testCaseIds.map((id) => "<code>" + escapeHtml(id) + "</code>").join(" ") : "n/a";
       return '<article class="handoff" data-status="' + escapeAttr(item.status || "unknown") + '" data-verdict="' + escapeAttr(verdict.level) + '">' +
         '<div class="handoff-head"><div class="handoff-title">' + escapeHtml(title || item.correlationId || "handoff") + '</div><span class="pill state-pill" data-level="' + escapeAttr(verdict.level) + '">' + escapeHtml(verdict.label) + '</span></div>' +
@@ -325,6 +327,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("Reason", escapeHtml(item.reason || "n/a")) +
         row("Tests", tests) +
         row("PR", pr) +
+        row("Commit", commit ? '<a href="' + escapeAttr(commit) + '" target="_blank" rel="noreferrer">' + escapeHtml(compactSha(item.sha)) + '</a>' : "n/a") +
+        row("Workflow run", workflowRun ? '<a href="' + escapeAttr(workflowRun) + '" target="_blank" rel="noreferrer">open run</a>' : "n/a") +
         row("Verdict", escapeHtml(summary.finalVerdict || summary.status || "n/a")) +
         row("Merge", escapeHtml(summary.mergeRecommendation || "n/a")) +
         deploymentHealthRows(summary) +
@@ -433,12 +437,21 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         const checks = health.hostedChecks !== undefined ? " (" + health.hostedChecks + " checks)" : "";
         rows.push(row("Hosted health", escapeHtml(String(health.hostedStatus) + checks)));
       }
+      if (Array.isArray(health.hostedFailedUrls) && health.hostedFailedUrls.length) {
+        rows.push(row("Health failures", links(health.hostedFailedUrls)));
+      }
       if (health.githubHealth) {
         const workflowBits = [
           health.githubFailingWorkflowRuns !== undefined ? "failed " + health.githubFailingWorkflowRuns : "",
           health.githubActiveWorkflowRuns !== undefined ? "active " + health.githubActiveWorkflowRuns : "",
         ].filter(Boolean).join(" / ");
         rows.push(row("GitHub workflows", escapeHtml(String(health.githubHealth) + (workflowBits ? " - " + workflowBits : ""))));
+      }
+      if (Array.isArray(health.githubFailingWorkflowRunUrls) && health.githubFailingWorkflowRunUrls.length) {
+        rows.push(row("Failed runs", links(health.githubFailingWorkflowRunUrls)));
+      }
+      if (Array.isArray(health.githubActiveWorkflowRunUrls) && health.githubActiveWorkflowRunUrls.length) {
+        rows.push(row("Active runs", links(health.githubActiveWorkflowRunUrls)));
       }
       if (health.opsStatus) {
         const recentErrors = health.opsRecentErrors !== undefined ? " - recent errors " + health.opsRecentErrors : "";
@@ -477,6 +490,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       return '<span class="tags">' + values.map((value) => '<code>' + escapeHtml(String(value)) + '</code>').join("") + '</span>';
     }
 
+    function links(values) {
+      return '<span class="tags">' + values.map((value, index) => '<a class="pill" href="' + escapeAttr(String(value)) + '" target="_blank" rel="noreferrer">open ' + String(index + 1) + '</a>').join("") + '</span>';
+    }
+
     function normalize(value) {
       return String(value || "").trim().toLowerCase().replace(/[\\s-]+/g, "_");
     }
@@ -498,6 +515,27 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (!/^[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+$/.test(repo)) return "";
       if (!Number.isInteger(prNumber) || prNumber < 1) return "";
       return "https://github.com/" + repo + "/pull/" + prNumber;
+    }
+
+    function deriveCommitUrl(item) {
+      const repo = String(item.repo || "");
+      const sha = String(item.sha || "");
+      if (!/^[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+$/.test(repo)) return "";
+      if (!/^[a-f0-9]{7,40}$/i.test(sha)) return "";
+      return "https://github.com/" + repo + "/commit/" + sha;
+    }
+
+    function deriveWorkflowRunUrl(item) {
+      const repo = String(item.repo || "");
+      const correlationId = String(item.correlationId || "");
+      if (!/^[A-Za-z0-9_.-]+\\/[A-Za-z0-9_.-]+$/.test(repo)) return "";
+      const match = correlationId.match(/github-(?:pr|deploy)-(\\d+)/);
+      return match ? "https://github.com/" + repo + "/actions/runs/" + match[1] : "";
+    }
+
+    function compactSha(value) {
+      const sha = String(value || "");
+      return sha ? sha.slice(0, 12) : "commit";
     }
 
     function row(label, value) {

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -577,6 +577,7 @@ function formatHandoffMonitorForSlack(result: Record<string, unknown>): string {
 function formatHandoffSummary(value: unknown, includePhase: boolean): string {
   if (!isRecord(value)) return "• unknown handoff";
   const summary = isRecord(value.summary) ? value.summary : {};
+  const release = handoffReleaseVerdict(value, summary);
   const status = stringField(value, "status") ?? "unknown";
   const phase = includePhase ? ` / ${stringField(value, "phase") ?? "unknown"}` : "";
   const target = formatHandoffTarget(value);
@@ -590,15 +591,100 @@ function formatHandoffSummary(value: unknown, includePhase: boolean): string {
   const review = stringField(summary, "codeReviewVerdict");
   const reason = stringField(value, "reason");
   const updatedAt = stringField(value, "updatedAt") ?? stringField(value, "startedAt");
+  const links = formatHandoffLinks(value);
+  const deployHealth = formatDeploymentHealthForSlack(summary);
   return [
-    `• \`${status}${phase}\` ${target} - \`${intent}\` - \`${correlationId}\``,
+    `• *${release.label}* ${target} - \`${intent}\` - \`${correlationId}\``,
+    `  why: ${release.why}`,
+    `  state: \`${status}${phase}\``,
     updatedAt ? `  updated: \`${updatedAt}\`` : "",
+    links ? `  links: ${links}` : "",
     verdict ? `  verdict: \`${verdict}\`` : "",
     review ? `  code review: \`${review}\`` : "",
     merge ? `  merge: ${merge}` : "",
     reason ? `  reason: ${reason}` : "",
+    deployHealth,
     tests,
   ].filter(Boolean).join("\n");
+}
+
+function handoffReleaseVerdict(value: Record<string, unknown>, summary: Record<string, unknown>): { label: string; why: string } {
+  const status = normalizeToken(stringField(value, "status"));
+  const finalVerdict = normalizeToken(stringField(summary, "finalVerdict") ?? stringField(summary, "status"));
+  const mergeRecommendation = normalizeToken(stringField(summary, "mergeRecommendation"));
+  const finalReason = normalizeToken(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(value, "reason"));
+  const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons.filter(isRecord) : [];
+  if (status === "running") return { label: "RUNNING", why: "Hermes is still working." };
+  if (
+    status === "failed" ||
+    status === "blocked" ||
+    includesToken(finalVerdict, ["block", "blocked", "failed", "failure", "hold"]) ||
+    includesToken(mergeRecommendation, ["block", "blocked", "failed", "failure", "hold", "do_not_merge"]) ||
+    includesToken(finalReason, ["deploy_failure", "deploy_failed", "ci_failed"])
+  ) {
+    return { label: "BLOCK", why: handoffWhy(summary, value, "block") };
+  }
+  if (
+    status === "needs_review" ||
+    includesToken(finalVerdict, ["review", "needs_review"]) ||
+    includesToken(mergeRecommendation, ["review", "wait", "needs_review"]) ||
+    includesToken(finalReason, ["github_needs_review", "pr_review_hold", "needs_review"]) ||
+    reviewReasons.length > 0
+  ) {
+    return { label: "NEEDS REVIEW", why: handoffWhy(summary, value, "needs_review") };
+  }
+  return { label: "PASS", why: handoffWhy(summary, value, "pass") };
+}
+
+function handoffWhy(summary: Record<string, unknown>, value: Record<string, unknown>, level: string): string {
+  const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons.filter(isRecord) : [];
+  const firstReviewReason = reviewReasons[0];
+  if (firstReviewReason) {
+    const code = stringField(firstReviewReason, "code") ?? "review";
+    const message = stringField(firstReviewReason, "message") ?? "Human review recommended.";
+    return `${code}: ${message}`;
+  }
+  const reason = normalizeToken(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(value, "reason"));
+  if (reason === "post_deploy_healthy") return "post-deploy suite, GitHub workflows, and hosted health are clean";
+  if (reason === "hosted_health_failed") return "hosted health failed after deploy";
+  if (reason === "github_workflow_failed") return "GitHub has a failed workflow";
+  if (reason === "testbed_cases_failed") return "one or more read-only testbed cases failed";
+  if (reason === "github_needs_review") return "GitHub still has a review signal open";
+  if (reason === "pr_review_hold") return "PR risk gate held this for human review";
+  if (reason === "ci_failed") return "CI failed";
+  if (level === "pass") return "no blocking release signals recorded";
+  return stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(value, "reason") ?? "no reason recorded";
+}
+
+function formatHandoffLinks(value: Record<string, unknown>): string {
+  const links: string[] = [];
+  const prUrl = stringField(value, "pullRequestUrl") ?? derivePullRequestUrl(value);
+  if (prUrl) links.push(`<${prUrl}|PR>`);
+  const commitUrl = deriveCommitUrl(value);
+  if (commitUrl) links.push(`<${commitUrl}|${formatId(stringField(value, "sha"), false) ?? "commit"}>`);
+  const runUrl = deriveWorkflowRunUrl(value);
+  if (runUrl) links.push(`<${runUrl}|workflow run>`);
+  return links.join(" · ");
+}
+
+function formatDeploymentHealthForSlack(summary: Record<string, unknown>): string {
+  const health = isRecord(summary.deploymentHealth) ? summary.deploymentHealth : {};
+  if (Object.keys(health).length === 0) return "";
+  const suite = [
+    numberField(health, "suitePassed") !== undefined ? `pass ${numberField(health, "suitePassed")}` : "",
+    numberField(health, "suiteFailed") !== undefined ? `fail ${numberField(health, "suiteFailed")}` : "",
+    numberField(health, "suiteSkipped") !== undefined ? `skip ${numberField(health, "suiteSkipped")}` : "",
+  ].filter(Boolean).join(" / ");
+  const hosted = stringField(health, "hostedStatus");
+  const github = stringField(health, "githubHealth");
+  const ops = stringField(health, "opsStatus");
+  const parts = [
+    suite ? `suite ${suite}` : "",
+    hosted ? `hosted ${hosted}` : "",
+    github ? `github ${github}` : "",
+    ops ? `ops ${ops}` : "",
+  ].filter(Boolean);
+  return parts.length > 0 ? `  deploy health: \`${parts.join(" · ")}\`` : "";
 }
 
 function formatHandoffTarget(value: Record<string, unknown>): string {
@@ -607,6 +693,38 @@ function formatHandoffTarget(value: Record<string, unknown>): string {
   const url = stringField(value, "pullRequestUrl");
   const label = repo && pr ? `${repo}#${pr}` : repo ?? "no repo";
   return url ? `<${url}|${label}>` : label;
+}
+
+function derivePullRequestUrl(value: Record<string, unknown>): string | undefined {
+  const repo = stringField(value, "repo");
+  const pr = numberField(value, "pullRequestNumber");
+  if (!repo || !pr || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) return undefined;
+  return `https://github.com/${repo}/pull/${pr}`;
+}
+
+function deriveCommitUrl(value: Record<string, unknown>): string | undefined {
+  const repo = stringField(value, "repo");
+  const sha = stringField(value, "sha");
+  if (!repo || !sha || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) || !/^[a-f0-9]{7,40}$/i.test(sha)) {
+    return undefined;
+  }
+  return `https://github.com/${repo}/commit/${sha}`;
+}
+
+function deriveWorkflowRunUrl(value: Record<string, unknown>): string | undefined {
+  const repo = stringField(value, "repo");
+  const correlationId = stringField(value, "correlationId");
+  if (!repo || !correlationId || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) return undefined;
+  const match = correlationId.match(/github-(?:pr|deploy)-(\d+)/);
+  return match ? `https://github.com/${repo}/actions/runs/${match[1]}` : undefined;
+}
+
+function normalizeToken(value: string | undefined): string {
+  return String(value ?? "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function includesToken(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
 }
 
 function formatDailyBriefDecisionSummary(brief: Record<string, unknown>): string {

--- a/test/unit/agent-invocation.test.ts
+++ b/test/unit/agent-invocation.test.ts
@@ -214,6 +214,7 @@ describe("agent invocation hook", () => {
     });
     expect(events.at(-1)).toMatchObject({
       correlationId: "github-deploy-123",
+      sha: "abc1234",
       phase: "completed",
       summary: {
         finalVerdict: "pass",

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -69,6 +69,11 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Review why");
     expect(html).toContain("releaseReason(summary, item, terminal.level)");
     expect(html).toContain("derivePullRequestUrl(item)");
+    expect(html).toContain("deriveCommitUrl(item)");
+    expect(html).toContain("deriveWorkflowRunUrl(item)");
+    expect(html).toContain("Health failures");
+    expect(html).toContain("Failed runs");
+    expect(html).toContain("Active runs");
     expect(html).toContain("https://github.com/");
     expect(html).not.toContain("handleOperatorCommand");
   });

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -737,12 +737,22 @@ describe("slack operator bridge", () => {
             requester: "github-actions",
             intent: "post_deploy",
             repo: "averray-agent/agent",
+            sha: "22beb113398569d4bd5d0bf85373777486f8b70c",
             status: "completed",
             phase: "completed",
             updatedAt: "2026-05-09T20:36:00.000Z",
             summary: {
-              finalVerdict: "PASS",
+              finalVerdict: "pass",
+              finalReason: "post_deploy_healthy",
               mergeRecommendation: "n/a",
+              deploymentHealth: {
+                suitePassed: 7,
+                suiteFailed: 0,
+                suiteSkipped: 1,
+                hostedStatus: "ok",
+                githubHealth: "ok",
+                opsStatus: "ok",
+              },
             },
           },
         ],
@@ -764,6 +774,11 @@ describe("slack operator bridge", () => {
     expect(text).toContain("code review: `ok`");
     expect(text).toContain("*Recent handoffs*");
     expect(text).toContain("post_deploy");
+    expect(text).toContain("*PASS* averray-agent/agent");
+    expect(text).toContain("why: post-deploy suite, GitHub workflows, and hosted health are clean");
+    expect(text).toContain("<https://github.com/averray-agent/agent/commit/22beb113398569d4bd5d0bf85373777486f8b70c|22beb113398569d4...86f8b70c>");
+    expect(text).toContain("<https://github.com/averray-agent/agent/actions/runs/25608715158|workflow run>");
+    expect(text).toContain("deploy health: `suite pass 7 / fail 0 / skip 1 · hosted ok · github ok · ops ok`");
     expect(text).toContain("GitHub mutated: `false`");
   });
 


### PR DESCRIPTION
## Summary
- carry deploy SHA and health/run URLs into handoff monitor summaries
- show commit and workflow-run links in the private handoff monitor
- make Slack handoff monitor replies lead with PASS / BLOCK / NEEDS REVIEW, one-line why, links, and compact deploy health

## Checks
- npm run build
- npm test
- git diff --check