### PR TITLE
Add approval-gated admin proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   [docs/COMMAND_CENTER_PUBLIC_ACCESS.md](docs/COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `what can you do for us`, `admin readiness`, `business ledger`,
+  recognizes `what can you do for us`, `admin readiness`, `admin proposal`,
+  `propose merge for averray-agent/agent#123`,
+  `propose deploy for averray-agent/agent sha abc1234`, `business ledger`,
   `ops health`, `github status`, `github open prs`, `github ci failures`,
   `github issue digest`, `github brief`, `daily github brief`,
   `what changed since last time`, `testbed e2e suite`,
@@ -156,7 +158,11 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   GitHub-helper planning, ops care, Averray business tracking, and durable
   memory. `admin readiness` calls `averray_admin_readiness`, a read-only staged
   plan for growing from operator copilot to approval-gated project admin without
-  granting broad mutation powers by default. `business ledger` calls
+  granting broad mutation powers by default. Admin proposal commands call
+  `averray_admin_action_proposal`, which can recommend whether a merge, deploy,
+  rollback, restart, or secret rotation is ready for human approval. It never
+  records approval, merges, deploys, restarts, rotates secrets, SSHes, or
+  mutates GitHub. `business ledger` calls
   `averray_business_ledger` for recent submissions, drafts, operator commands,
   budget, and open work. `ops health` calls `averray_ops_health` for
   wallet/budget readiness, latest-run state, and Postgres control-plane counts.

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -234,6 +234,9 @@ handoff monitor
 find safe work
 operator status
 operator status details
+admin proposal
+propose merge for averray-agent/agent#123
+propose deploy for averray-agent/agent sha abc1234
 run one wikipedia citation repair if safe
 run wikipedia citation repair for wiki-en-... if safe
 status last wikipedia citation repair
@@ -246,7 +249,11 @@ Slack, Command Center/mobile, MCP clients, future GitHub helper work, ops care,
 Averray business tracking, and durable memory. `admin readiness` calls
 `averray_admin_readiness`, a read-only staged plan for growing from operator
 copilot to approval-gated project admin without granting broad mutation powers
-by default. `business ledger` calls `averray_business_ledger` for recent
+by default. Admin proposal commands call `averray_admin_action_proposal`, a
+proposal-only planner for merge, deploy, rollback, restart, and secret-rotation
+recommendations. It gathers read-only evidence and required approval notes, but
+does not approve, merge, deploy, SSH, restart, rotate secrets, or mutate GitHub.
+`business ledger` calls `averray_business_ledger` for recent
 submissions, drafts, operator commands, budget, and open work. `ops health`
 calls `averray_ops_health` for wallet/budget readiness, latest-run state,
 recent operator events, recent failures, and Postgres control-plane counts.

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -41,7 +41,7 @@ import {
   getLastWikipediaCitationRepairStatus,
 } from "./operator-commands.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
-import { getAdminReadiness } from "./operator-admin.js";
+import { getAdminActionProposal, getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
@@ -182,6 +182,22 @@ server.tool(
 );
 
 server.tool(
+  "averray_admin_action_proposal",
+  "Proposal-only admin action planner for humans, Slack, Command Center, and other agents. Produces read-only evidence, risks, required human approval, and a merge/deploy/rollback/restart/secret-rotation recommendation. It never records approval, merges PRs, deploys, restarts services, changes secrets, SSHes to production, edits GitHub, edits Wikipedia, or mutates Averray state.",
+  {
+    action: z.enum(["merge", "deploy", "rollback", "secret_rotation", "restart", "unknown"]).default("unknown"),
+    repo: z.string().min(1).optional(),
+    pullRequestNumber: z.number().int().min(1).optional(),
+    sha: z.string().min(7).optional(),
+    requester: z.string().min(1).optional(),
+    reason: z.string().optional()
+  },
+  async (input) => {
+    return jsonContent(await getAdminActionProposal(input, { query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
   "averray_business_ledger",
   "Canonical read-only Averray business ledger for humans, Slack, Command Center, and other agents. Summarizes recent Wikipedia citation-repair submissions, drafts, operator commands, latest run, open jobs, and budget. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
   {},
@@ -282,7 +298,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),

--- a/packages/averray-mcp/src/operator-admin.ts
+++ b/packages/averray-mcp/src/operator-admin.ts
@@ -1,7 +1,26 @@
 import { optionalEnv } from "@avg/mcp-common";
 import type { OperatorStatusDeps } from "./operator-status.js";
+import { getHandoffMonitor } from "./handoff-events.js";
+import { getGithubOperatorStatus } from "./operator-github.js";
 import { getOpsHealth } from "./operator-insights.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
+
+export type AdminActionKind =
+  | "merge"
+  | "deploy"
+  | "rollback"
+  | "secret_rotation"
+  | "restart"
+  | "unknown";
+
+export interface AdminActionProposalInput {
+  action: AdminActionKind;
+  repo?: string;
+  pullRequestNumber?: number;
+  sha?: string;
+  requester?: string;
+  reason?: string;
+}
 
 export async function getAdminReadiness(deps: OperatorStatusDeps) {
   const [ops, usefulness] = await Promise.all([
@@ -113,6 +132,76 @@ export async function getAdminReadiness(deps: OperatorStatusDeps) {
   };
 }
 
+export async function getAdminActionProposal(
+  input: AdminActionProposalInput,
+  deps: OperatorStatusDeps
+) {
+  const generatedAt = new Date().toISOString();
+  const proposalId = [
+    "admin-proposal",
+    input.action,
+    input.repo?.replace(/[^a-zA-Z0-9]+/g, "-") ?? "no-repo",
+    input.pullRequestNumber ? `pr-${input.pullRequestNumber}` : input.sha?.slice(0, 12) ?? "no-target",
+    generatedAt.replace(/[^0-9]/g, "").slice(0, 14),
+  ].join("-");
+
+  const [ops, github, handoffMonitor] = await Promise.all([
+    getOpsHealth(deps).catch((error) => ({
+      error: `ops_health_unavailable:${errorMessage(error)}`,
+    })),
+    getGithubOperatorStatus({ view: "digest" }).catch((error) => ({
+      error: `github_status_unavailable:${errorMessage(error)}`,
+    })),
+    getHandoffMonitor().catch((error) => ({
+      error: `handoff_monitor_unavailable:${errorMessage(error)}`,
+    })),
+  ]);
+
+  const context = buildProposalContext({ input, ops, github, handoffMonitor });
+  const recommendation = recommendationForAction(input.action, context);
+  const risks = risksForAction(input.action, context);
+
+  return {
+    schemaVersion: 1,
+    kind: "admin_action_proposal",
+    generatedAt,
+    proposalId,
+    mutates: false,
+    action: {
+      type: input.action,
+      target: {
+        repo: input.repo ?? null,
+        pullRequestNumber: input.pullRequestNumber ?? null,
+        sha: input.sha ?? null,
+      },
+      requester: input.requester ?? "operator",
+      reason: input.reason ?? null,
+    },
+    recommendation,
+    approval: {
+      required: true,
+      mode: "explicit_human_approval",
+      status: "not_requested",
+      canExecuteFromThisProposal: false,
+      note: "This proposal is advisory only. The current agent cannot consume this as approval or execute the admin action.",
+    },
+    evidence: context.evidence,
+    risks,
+    blockedActions: blockedActionsForAction(input.action),
+    nextHumanStep: nextHumanStep(input.action, recommendation),
+    safety: {
+      proposalOnly: true,
+      mutates: false,
+      githubMutated: false,
+      deployTriggered: false,
+      serviceRestarted: false,
+      secretsChanged: false,
+      approvalRecorded: false,
+      freeFormHermesPromptUsed: false,
+    },
+  };
+}
+
 function readinessFromHealth(health: string) {
   if (health === "ready") return "ready_for_operator_copilot";
   if (health === "quiet") return "ready_but_low_activity";
@@ -124,4 +213,273 @@ function auditReadiness(ops: Awaited<ReturnType<typeof getOpsHealth>>) {
   const events = ops.controlPlane.tables.operatorEvents;
   if (events > 0) return "operator_events_recorded";
   return "no_operator_events_seen";
+}
+
+function buildProposalContext(input: {
+  input: AdminActionProposalInput;
+  ops: unknown;
+  github: unknown;
+  handoffMonitor: unknown;
+}) {
+  const ops = toRecord(input.ops);
+  const github = toRecord(input.github);
+  const githubTotals = toRecord(github.totals);
+  const handoffMonitor = toRecord(input.handoffMonitor);
+  const handoffCounts = toRecord(handoffMonitor.counts);
+  const recentHandoffs = arrayField(handoffMonitor, "recent");
+  const matchingHandoff = findMatchingHandoff(recentHandoffs, input.input);
+  const matchingSummary = toRecord(matchingHandoff?.summary);
+
+  const context = {
+    targetMissing: targetMissing(input.input),
+    opsUnavailable: Boolean(stringField(ops, "error")),
+    opsHealth: stringField(ops, "health") ?? "unknown",
+    githubUnavailable: Boolean(stringField(github, "error")),
+    githubHealth: stringField(github, "health") ?? "unknown",
+    openPullRequests: numberField(githubTotals, "openPullRequests"),
+    openIssues: numberField(githubTotals, "openIssues"),
+    failingWorkflowRuns: numberField(githubTotals, "failingWorkflowRuns"),
+    activeWorkflowRuns: numberField(githubTotals, "activeWorkflowRuns"),
+    handoffUnavailable: Boolean(stringField(handoffMonitor, "error")),
+    activeHandoffs: numberField(handoffCounts, "active"),
+    recentHandoffs: numberField(handoffCounts, "recent"),
+    matchingHandoff,
+    matchingVerdict: stringField(matchingSummary, "finalVerdict"),
+    matchingMergeRecommendation: stringField(matchingSummary, "mergeRecommendation"),
+    matchingReason: stringField(matchingSummary, "finalReason") ?? stringField(matchingSummary, "reason"),
+  };
+
+  return {
+    ...context,
+    evidence: [
+      {
+        source: "ops_health",
+        status: context.opsUnavailable ? "unavailable" : context.opsHealth,
+        detail: context.opsUnavailable
+          ? stringField(ops, "error")
+          : `operator health is ${context.opsHealth}`,
+      },
+      {
+        source: "github",
+        status: context.githubUnavailable ? "unavailable" : context.githubHealth,
+        detail: context.githubUnavailable
+          ? stringField(github, "error")
+          : `${context.openPullRequests} open PRs, ${context.openIssues} open issues, ${context.failingWorkflowRuns} failing workflows, ${context.activeWorkflowRuns} active workflows`,
+      },
+      {
+        source: "handoff_monitor",
+        status: context.handoffUnavailable
+          ? "unavailable"
+          : context.matchingHandoff
+            ? context.matchingVerdict ?? "seen"
+            : "no_matching_handoff",
+        detail: context.handoffUnavailable
+          ? stringField(handoffMonitor, "error")
+          : context.matchingHandoff
+            ? `matching handoff verdict ${context.matchingVerdict ?? "unknown"} / merge ${context.matchingMergeRecommendation ?? "unknown"}`
+            : `${context.activeHandoffs} active handoffs, ${context.recentHandoffs} recent handoffs`,
+      },
+    ],
+  };
+}
+
+function recommendationForAction(
+  action: AdminActionKind,
+  context: ReturnType<typeof buildProposalContext>
+) {
+  if (action === "unknown") {
+    return {
+      status: "not_ready",
+      reason: "admin_action_unknown",
+      summary: "Name the admin action first: merge, deploy, rollback, restart, or secret rotation.",
+    };
+  }
+  if (context.targetMissing) {
+    return {
+      status: "not_ready",
+      reason: "target_missing",
+      summary: "The proposal needs a concrete target before a human can approve it.",
+    };
+  }
+  if (action === "rollback" || action === "secret_rotation" || action === "restart") {
+    return {
+      status: "needs_human_review",
+      reason: `${action}_is_high_risk`,
+      summary: "High-risk admin action. Prepare a rollback/owner note and get explicit human approval outside Hermes.",
+    };
+  }
+  if (context.opsUnavailable || context.githubUnavailable || context.handoffUnavailable) {
+    return {
+      status: "needs_human_review",
+      reason: "evidence_incomplete",
+      summary: "One or more read-only evidence sources were unavailable. Do not execute until a human checks the missing source.",
+    };
+  }
+  if (context.failingWorkflowRuns > 0 || isBlockingVerdict(context.matchingVerdict) || isBlockingVerdict(context.matchingMergeRecommendation)) {
+    return {
+      status: "not_ready",
+      reason: "blocking_signal_present",
+      summary: "A failing workflow or blocking handoff signal is present. Resolve that first.",
+    };
+  }
+  if (context.activeWorkflowRuns > 0 || isNeedsReviewVerdict(context.matchingVerdict) || isNeedsReviewVerdict(context.matchingMergeRecommendation)) {
+    return {
+      status: "needs_human_review",
+      reason: "review_signal_present",
+      summary: "Read-only signals are not blocking, but a human should review before acting.",
+    };
+  }
+  return {
+    status: "ready_for_human_approval",
+    reason: "read_only_signals_clear",
+    summary: "Read-only signals are clear. A human may approve and execute the action manually.",
+  };
+}
+
+function risksForAction(
+  action: AdminActionKind,
+  context: ReturnType<typeof buildProposalContext>
+) {
+  const risks: Array<Record<string, string>> = [];
+  if (context.targetMissing) {
+    risks.push({
+      severity: "high",
+      code: "target_missing",
+      message: "No concrete repo/PR/SHA target was provided.",
+    });
+  }
+  if (context.opsUnavailable || context.githubUnavailable || context.handoffUnavailable) {
+    risks.push({
+      severity: "medium",
+      code: "evidence_incomplete",
+      message: "One or more read-only evidence sources could not be checked.",
+    });
+  }
+  if (context.failingWorkflowRuns > 0) {
+    risks.push({
+      severity: "high",
+      code: "github_failing_workflows",
+      message: `${context.failingWorkflowRuns} failing GitHub workflow run(s) are visible.`,
+    });
+  }
+  if (context.activeWorkflowRuns > 0) {
+    risks.push({
+      severity: "medium",
+      code: "github_active_workflows",
+      message: `${context.activeWorkflowRuns} GitHub workflow run(s) are still active.`,
+    });
+  }
+  if (context.matchingReason) {
+    risks.push({
+      severity: isBlockingVerdict(context.matchingVerdict) ? "high" : "medium",
+      code: context.matchingReason,
+      message: `Matching handoff reason: ${context.matchingReason}.`,
+    });
+  }
+  if (action === "rollback" || action === "secret_rotation" || action === "restart") {
+    risks.push({
+      severity: "high",
+      code: `${action}_requires_owner`,
+      message: "This action can affect production access or availability and requires an owner-approved runbook.",
+    });
+  }
+  if (risks.length === 0) {
+    risks.push({
+      severity: "low",
+      code: "proposal_only",
+      message: "No blocking read-only signal found; execution is still manual and approval-gated.",
+    });
+  }
+  return risks;
+}
+
+function blockedActionsForAction(action: AdminActionKind) {
+  const common = ["record_approval", "execute_admin_action"];
+  if (action === "merge") return [...common, "merge_pull_request", "push_code"];
+  if (action === "deploy") return [...common, "trigger_deploy", "ssh_to_production"];
+  if (action === "rollback") return [...common, "trigger_rollback", "change_production_pointer"];
+  if (action === "secret_rotation") return [...common, "read_or_write_secret", "rotate_secret"];
+  if (action === "restart") return [...common, "restart_service", "ssh_to_production"];
+  return common;
+}
+
+function nextHumanStep(action: AdminActionKind, recommendation: Record<string, string>) {
+  if (recommendation.status === "not_ready") {
+    return "Resolve the listed blockers, then request a fresh proposal.";
+  }
+  if (action === "merge") {
+    return "Review the PR, CI, and handoff monitor. If you agree, merge manually in GitHub.";
+  }
+  if (action === "deploy") {
+    return "Review deployment inputs and current GitHub/ops signals. If you agree, run the deploy workflow manually.";
+  }
+  if (action === "rollback") {
+    return "Open an incident note, choose a known-good target, and execute rollback manually with an owner watching.";
+  }
+  if (action === "secret_rotation") {
+    return "Rotate the secret through the owning control plane or GitHub secret UI; never paste secrets into Hermes.";
+  }
+  if (action === "restart") {
+    return "Check host/service health and restart manually only if the owner accepts the availability impact.";
+  }
+  return "Pick a concrete admin action and target, then request a fresh proposal.";
+}
+
+function targetMissing(input: AdminActionProposalInput): boolean {
+  if (input.action === "merge") return !input.repo || !input.pullRequestNumber;
+  if (input.action === "deploy") return !input.repo || !input.sha;
+  if (input.action === "rollback") return !input.repo;
+  if (input.action === "secret_rotation") return !input.repo && !input.reason;
+  if (input.action === "restart") return !input.repo && !input.reason;
+  return false;
+}
+
+function findMatchingHandoff(
+  handoffs: unknown[],
+  input: AdminActionProposalInput
+): Record<string, unknown> | undefined {
+  return handoffs.find((handoff) => {
+    const record = toRecord(handoff);
+    const repoMatches = !input.repo || stringField(record, "repo") === input.repo;
+    const prMatches = !input.pullRequestNumber || numberField(record, "pullRequestNumber") === input.pullRequestNumber;
+    return repoMatches && prMatches;
+  }) as Record<string, unknown> | undefined;
+}
+
+function isBlockingVerdict(value: string | undefined) {
+  return value === "block" || value === "blocked" || value === "hold" || value === "not_ready";
+}
+
+function isNeedsReviewVerdict(value: string | undefined) {
+  return value === "needs_review" || value === "needs_human_review";
+}
+
+function arrayField(value: unknown, key: string): unknown[] {
+  if (!isRecord(value)) return [];
+  const field = value[key];
+  return Array.isArray(field) ? field : [];
+}
+
+function numberField(value: unknown, key: string): number {
+  if (!isRecord(value)) return 0;
+  const field = value[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : 0;
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,4 +1,5 @@
 import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
+import type { AdminActionProposalInput } from "./operator-admin.js";
 import type { GithubOperatorView } from "./operator-github.js";
 
 export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes" | "agent";
@@ -45,6 +46,13 @@ export type ParsedOperatorCommand =
       kind: "admin_readiness";
       source: OperatorCommandSource;
       detailed: boolean;
+    }
+  | {
+      handled: true;
+      kind: "admin_proposal";
+      source: OperatorCommandSource;
+      detailed: boolean;
+      input: AdminActionProposalInput;
     }
   | {
       handled: true;
@@ -123,6 +131,10 @@ const EXAMPLES = [
   "daily operator brief",
   "what can you do for us",
   "admin readiness",
+  "admin proposal",
+  "propose merge for averray-agent/agent#123",
+  "propose deploy for averray-agent/agent sha abc1234",
+  "propose secret rotation",
   "business ledger",
   "ops health",
   "github status",
@@ -175,6 +187,11 @@ export function parseOperatorCommand(
 
   if (isAdminReadinessCommand(normalizedText)) {
     return { handled: true, kind: "admin_readiness", source, detailed };
+  }
+
+  const adminProposal = adminActionProposalInput(text, normalizedText, source);
+  if (adminProposal) {
+    return { handled: true, kind: "admin_proposal", source, detailed, input: adminProposal };
   }
 
   if (isBusinessLedgerCommand(normalizedText)) {
@@ -364,6 +381,47 @@ function isAdminReadinessCommand(text: string): boolean {
   return /^(admin readiness|project admin readiness|admin plan|project admin plan|can you be admin|can you admin my projects|how can you admin my projects|admin mode|future admin plan)( details?| full| audit)?$/.test(text);
 }
 
+function adminActionProposalInput(
+  originalText: string,
+  text: string,
+  source: OperatorCommandSource
+): AdminActionProposalInput | undefined {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  if (!/\b(propose|proposal|approval|approve|admin action)\b/.test(compact)) return undefined;
+  const action = compact.includes("secret") || compact.includes("token") || compact.includes("credential")
+    ? "secret_rotation"
+    : compact.includes("rollback") || compact.includes("roll back")
+      ? "rollback"
+      : compact.includes("restart")
+        ? "restart"
+        : compact.includes("deploy")
+          ? "deploy"
+          : compact.includes("merge") || compact.includes("pr ")
+            ? "merge"
+            : "unknown";
+  return {
+    action,
+    requester: source,
+    reason: originalText.trim(),
+    ...adminProposalTarget(originalText),
+  };
+}
+
+function adminProposalTarget(text: string): Pick<AdminActionProposalInput, "repo" | "pullRequestNumber" | "sha"> {
+  const repoWithPr = text.match(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#(\d+)\b/);
+  const repo = repoWithPr?.[1]
+    ?? extractToken(text, /\b(?:repo|repository|for)\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/i);
+  const pullRequestNumber = repoWithPr?.[2]
+    ? Number.parseInt(repoWithPr[2], 10)
+    : numberToken(text, /\b(?:pr|pull request|pull-request|#)\s*#?(\d+)\b/i);
+  const sha = extractToken(text, /\b(?:sha|commit)\s+([a-f0-9]{7,40})\b/i);
+  return {
+    ...(repo ? { repo } : {}),
+    ...(pullRequestNumber ? { pullRequestNumber } : {}),
+    ...(sha ? { sha } : {}),
+  };
+}
+
 function isBusinessLedgerCommand(text: string): boolean {
   return /^(business ledger|averray business ledger|business status|business report|work ledger|reward ledger|run ledger)( details?| full| audit)?$/.test(text);
 }
@@ -414,6 +472,13 @@ function wantsDryRunOnly(text: string): boolean {
 function extractToken(text: string, pattern: RegExp): string | undefined {
   const match = text.match(pattern);
   return match?.[1]?.replace(/[.,!?]+$/g, "");
+}
+
+function numberToken(text: string, pattern: RegExp): number | undefined {
+  const token = extractToken(text, pattern);
+  if (!token) return undefined;
+  const value = Number.parseInt(token, 10);
+  return Number.isFinite(value) ? value : undefined;
 }
 
 function toRecord(value: unknown): Record<string, unknown> {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -5,7 +5,7 @@ import {
   type OperatorCommandSource,
   type OperatorQueryFn,
 } from "./operator-commands.js";
-import { getAdminReadiness } from "./operator-admin.js";
+import { getAdminActionProposal, getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
@@ -63,6 +63,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "admin_readiness") {
     const readiness = await getAdminReadiness({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, readiness };
+  }
+  if (command.kind === "admin_proposal") {
+    const proposal = await getAdminActionProposal(command.input, { query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, proposal };
   }
   if (command.kind === "business_ledger") {
     const ledger = await getBusinessLedger({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -198,6 +198,34 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Read-only. Broad project-admin actions are denied by default until an approval policy exists.",
     ].filter(Boolean).join("\n");
   }
+  if (result.kind === "admin_proposal") {
+    const proposal = isRecord(result.proposal) ? result.proposal : {};
+    const action = isRecord(proposal.action) ? proposal.action : {};
+    const target = isRecord(action.target) ? action.target : {};
+    const recommendation = isRecord(proposal.recommendation) ? proposal.recommendation : {};
+    const approval = isRecord(proposal.approval) ? proposal.approval : {};
+    const evidence = arrayField(proposal, "evidence");
+    const risks = arrayField(proposal, "risks");
+    const blocked = arrayField(proposal, "blockedActions");
+    return [
+      `*Admin proposal - ${stringField(action, "type") ?? "unknown"}*`,
+      stringField(recommendation, "summary") ?? "Proposal generated.",
+      "",
+      "*Target*",
+      `• repo: \`${stringField(target, "repo") ?? "n/a"}\``,
+      `• PR: \`${numberField(target, "pullRequestNumber") ?? "n/a"}\``,
+      `• sha: \`${formatId(stringField(target, "sha"), false) ?? "n/a"}\``,
+      "*Recommendation*",
+      `• status: \`${stringField(recommendation, "status") ?? "unknown"}\``,
+      `• reason: \`${stringField(recommendation, "reason") ?? "unknown"}\``,
+      `• approval required: \`${String(approval.required === true)}\``,
+      evidence.length > 0 ? `*Evidence*\n${evidence.slice(0, 3).map(formatAdminProposalEvidence).join("\n")}` : "",
+      risks.length > 0 ? `*Risks*\n${risks.slice(0, 4).map(formatAdminProposalRisk).join("\n")}` : "",
+      blocked.length > 0 ? `*Blocked here*\n${blocked.slice(0, 5).map((entry) => `• \`${String(entry)}\``).join("\n")}` : "",
+      stringField(proposal, "nextHumanStep") ? `*Next human step*\n${stringField(proposal, "nextHumanStep")}` : "",
+      "Proposal-only. Hermes did not approve, merge, deploy, restart, rotate secrets, or mutate GitHub.",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "business_ledger") {
     const ledger = isRecord(result.ledger) ? result.ledger : {};
     const summary = isRecord(ledger.summary) ? ledger.summary : {};
@@ -756,6 +784,16 @@ function formatDailyBriefAttentionItem(value: unknown): string {
   const url = stringField(value, "url");
   const suffix = [detail, url].filter(Boolean).join(" - ");
   return `• \`${severity}\` ${source}: ${title}${suffix ? ` — ${suffix}` : ""}`;
+}
+
+function formatAdminProposalEvidence(value: unknown): string {
+  if (!isRecord(value)) return "• unknown evidence";
+  return `• \`${stringField(value, "source") ?? "unknown"}\`: \`${stringField(value, "status") ?? "unknown"}\` - ${stringField(value, "detail") ?? "no detail"}`;
+}
+
+function formatAdminProposalRisk(value: unknown): string {
+  if (!isRecord(value)) return "• unknown risk";
+  return `• \`${stringField(value, "severity") ?? "info"}\` ${stringField(value, "code") ?? "risk"} - ${stringField(value, "message") ?? "no detail"}`;
 }
 
 function githubViewTitle(view: string): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -136,6 +136,32 @@ describe("operator commands", () => {
       source: "slack",
       detailed: true,
     });
+    expect(parseOperatorCommand("propose merge for averray-agent/agent#123", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "admin_proposal",
+      source: "operator",
+      detailed: false,
+      input: {
+        action: "merge",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 123,
+        requester: "operator",
+        reason: "propose merge for averray-agent/agent#123",
+      },
+    });
+    expect(parseOperatorCommand("propose deploy for averray-agent/agent sha abc1234 details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "admin_proposal",
+      source: "slack",
+      detailed: true,
+      input: {
+        action: "deploy",
+        repo: "averray-agent/agent",
+        sha: "abc1234",
+        requester: "slack",
+        reason: "propose deploy for averray-agent/agent sha abc1234 details",
+      },
+    });
     expect(parseOperatorCommand("business ledger", { source: "slack" })).toEqual({
       handled: true,
       kind: "business_ledger",

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -381,6 +381,47 @@ describe("slack operator bridge", () => {
     expect(text).toContain("Broad project-admin actions are denied by default");
   });
 
+  it("formats admin proposal replies as proposal-only", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "admin_proposal",
+      proposal: {
+        kind: "admin_action_proposal",
+        action: {
+          type: "merge",
+          target: {
+            repo: "averray-agent/agent",
+            pullRequestNumber: 123,
+            sha: null,
+          },
+        },
+        recommendation: {
+          status: "ready_for_human_approval",
+          reason: "read_only_signals_clear",
+          summary: "Read-only signals are clear.",
+        },
+        approval: {
+          required: true,
+        },
+        evidence: [
+          { source: "github", status: "ok", detail: "0 failing workflows" },
+        ],
+        risks: [
+          { severity: "low", code: "proposal_only", message: "Execution is manual." },
+        ],
+        blockedActions: ["merge_pull_request", "push_code"],
+        nextHumanStep: "Review the PR, CI, and handoff monitor.",
+      },
+    });
+
+    expect(text).toContain("*Admin proposal - merge*");
+    expect(text).toContain("status: `ready_for_human_approval`");
+    expect(text).toContain("approval required: `true`");
+    expect(text).toContain("`github`: `ok`");
+    expect(text).toContain("`merge_pull_request`");
+    expect(text).toContain("Hermes did not approve, merge, deploy");
+  });
+
   it("formats business ledger and ops health replies", () => {
     const ledger = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
Adds a proposal-only admin action planner for Hermes/Averray.\n\nWhat changed:\n- Adds averray_admin_action_proposal for merge/deploy/rollback/restart/secret-rotation recommendations.\n- Routes short operator commands like propose merge for owner/repo#123 and propose deploy for owner/repo sha abc1234.\n- Adds Slack formatting that clearly marks proposals as advisory only and lists blocked execution actions.\n- Documents the command surface in README and VPS smoke notes.\n\nSafety:\n- Proposal-only: no approval recording, no GitHub mutation, no deploy, no restart, no secret rotation, no SSH.\n- Uses read-only ops, GitHub, and handoff-monitor signals as evidence.\n\nChecks:\n- npm test\n- npm run build\n- git diff --check