### PR TITLE
Add project admin memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   [docs/COMMAND_CENTER_PUBLIC_ACCESS.md](docs/COMMAND_CENTER_PUBLIC_ACCESS.md).
 - Slack and command-center operators can route short commands through
   `averray_handle_operator_command` instead of a free-form Hermes prompt. It
-  recognizes `what can you do for us`, `admin readiness`, `admin proposal`,
+  recognizes `what can you do for us`, `project memory`, `known projects`,
+  `how do we deploy averray-agent/agent`, `admin readiness`, `admin proposal`,
   `propose merge for averray-agent/agent#123`,
   `propose deploy for averray-agent/agent sha abc1234`, `business ledger`,
   `ops health`, `github status`, `github open prs`, `github ci failures`,
@@ -152,7 +153,12 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   what needs attention. It mutates no GitHub state; it only stores a local
   checkpoint timestamp so the next brief can compare against it. When configured
   repositories live under different GitHub owners, use `GITHUB_OWNER_TOKENS` or
-  `GITHUB_REPO_TOKENS` for owner/repo-specific read-only tokens. `what can you do for us` calls the
+  `GITHUB_REPO_TOKENS` for owner/repo-specific read-only tokens. `project memory`
+  and `known projects` call `averray_project_memory`, a read-only curated memory
+  of known projects, repos, deploy surfaces, useful commands, handoff
+  expectations, safety notes, and open questions. It stores no secrets and does
+  not merge, deploy, SSH, edit GitHub, edit Wikipedia, or mutate Averray state.
+  `what can you do for us` calls the
   read-only `averray_agent_usefulness_plan` MCP tool and explains the useful
   surfaces and use cases across Slack, Command Center/mobile, MCP clients,
   GitHub-helper planning, ops care, Averray business tracking, and durable

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -217,6 +217,9 @@ commands are:
 ```text
 daily operator brief
 what can you do for us
+project memory
+known projects
+how do we deploy averray-agent/agent
 admin readiness
 business ledger
 ops health
@@ -246,7 +249,12 @@ status last wikipedia citation repair details
 `averray_handle_operator_command` parses those messages. `what can you do for
 us` calls `averray_agent_usefulness_plan`, a read-only cross-surface plan for
 Slack, Command Center/mobile, MCP clients, future GitHub helper work, ops care,
-Averray business tracking, and durable memory. `admin readiness` calls
+Averray business tracking, and durable memory. `project memory` and
+`known projects` call `averray_project_memory`, a read-only curated memory of
+known projects, repos, deploy surfaces, useful commands, handoff expectations,
+safety notes, and open questions. It stores no secrets and does not merge,
+deploy, SSH, edit GitHub, edit Wikipedia, or mutate Averray state.
+`admin readiness` calls
 `averray_admin_readiness`, a read-only staged plan for growing from operator
 copilot to approval-gated project admin without granting broad mutation powers
 by default. Admin proposal commands call `averray_admin_action_proposal`, a

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -45,6 +45,7 @@ import { getAdminActionProposal, getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
+import { getProjectMemory } from "./operator-project-memory.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { invokeAgentTask } from "./agent-invocation.js";
@@ -169,6 +170,18 @@ server.tool(
   {},
   async () => {
     return jsonContent(await getAgentUsefulnessPlan({ query, workflowDeps: workflowDeps() }));
+  }
+);
+
+server.tool(
+  "averray_project_memory",
+  "Read-only project admin memory for humans, Slack, Command Center, and other agents. Returns curated non-secret knowledge about known projects, repositories, deploy surfaces, useful commands, handoff expectations, and open questions. It never stores or reveals secrets, deploys, edits GitHub, SSHes to production, or mutates Averray state.",
+  {
+    project: z.string().min(1).optional(),
+    query: z.string().min(1).optional()
+  },
+  async ({ project, query: projectQuery }) => {
+    return jsonContent(getProjectMemory({ project, query: projectQuery }));
   }
 );
 
@@ -298,7 +311,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/project-memory/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -43,6 +43,13 @@ export type ParsedOperatorCommand =
     }
   | {
       handled: true;
+      kind: "project_memory";
+      source: OperatorCommandSource;
+      detailed: boolean;
+      project?: string;
+    }
+  | {
+      handled: true;
       kind: "admin_readiness";
       source: OperatorCommandSource;
       detailed: boolean;
@@ -130,6 +137,10 @@ export interface LastWikipediaCitationRepairStatus {
 const EXAMPLES = [
   "daily operator brief",
   "what can you do for us",
+  "project memory",
+  "known projects",
+  "project memory for averray-agent/agent",
+  "how do we deploy averray-agent/agent",
   "admin readiness",
   "admin proposal",
   "propose merge for averray-agent/agent#123",
@@ -183,6 +194,11 @@ export function parseOperatorCommand(
 
   if (isAgentUsefulnessPlanCommand(normalizedText)) {
     return { handled: true, kind: "agent_usefulness_plan", source, detailed };
+  }
+
+  const projectMemory = projectMemoryTarget(text, normalizedText);
+  if (projectMemory.handled) {
+    return { handled: true, kind: "project_memory", source, detailed, ...projectMemory.target };
   }
 
   if (isAdminReadinessCommand(normalizedText)) {
@@ -375,6 +391,22 @@ function isFindSafeWorkCommand(text: string): boolean {
 
 function isAgentUsefulnessPlanCommand(text: string): boolean {
   return /^(what can you do|what can you do for us|how can you help|how can you work for us|work for us|agent usefulness|agent usefulness plan|agent plan|usefulness plan|show use cases|show agent use cases)( details?| full| audit)?$/.test(text);
+}
+
+function projectMemoryTarget(
+  originalText: string,
+  text: string
+): { handled: true; target: { project?: string } } | { handled: false } {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  if (/^(project memory|known projects|project registry|what projects do you know|what do you know about my projects)$/.test(compact)) {
+    return { handled: true, target: {} };
+  }
+  if (/^(project memory|project registry|known project|how do we deploy|how to deploy|deploy memory)\b/.test(compact)) {
+    const project = extractToken(originalText, /\b(?:for|deploy)\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/i)
+      ?? extractToken(originalText, /\b(?:for|about)\s+(.+)$/i);
+    return { handled: true, target: project ? { project } : {} };
+  }
+  return { handled: false };
 }
 
 function isAdminReadinessCommand(text: string): boolean {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -9,6 +9,7 @@ import { getAdminActionProposal, getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
+import { getProjectMemory } from "./operator-project-memory.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
@@ -59,6 +60,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "agent_usefulness_plan") {
     const plan = await getAgentUsefulnessPlan({ query: deps.query, workflowDeps: deps.workflowDeps });
     return { ...command, plan };
+  }
+  if (command.kind === "project_memory") {
+    const memory = getProjectMemory({ project: command.project });
+    return { ...command, memory };
   }
   if (command.kind === "admin_readiness") {
     const readiness = await getAdminReadiness({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/packages/averray-mcp/src/operator-project-memory.ts
+++ b/packages/averray-mcp/src/operator-project-memory.ts
@@ -1,0 +1,248 @@
+import { optionalEnv } from "@avg/mcp-common";
+
+export interface ProjectMemoryInput {
+  project?: string;
+  query?: string;
+}
+
+export interface ProjectMemoryEntry {
+  id: string;
+  name: string;
+  aliases: string[];
+  repos: string[];
+  role: string;
+  owner: string;
+  environments: Array<Record<string, unknown>>;
+  surfaces: Array<Record<string, unknown>>;
+  deploy: Record<string, unknown>;
+  routineCommands: string[];
+  handoff: Record<string, unknown>;
+  safety: Record<string, unknown>;
+  openQuestions: string[];
+}
+
+const CURATED_PROJECTS: ProjectMemoryEntry[] = [
+  {
+    id: "averray-platform",
+    name: "Averray Platform",
+    aliases: ["platform", "agent", "averray-agent", "operator app", "backend"],
+    repos: ["averray-agent/agent"],
+    role: "Primary product platform: app, API, indexer, public site, deploy workflows, and product-proof checks.",
+    owner: "Pascal / Averray",
+    environments: [
+      { name: "production app", url: "https://app.averray.com" },
+      { name: "production API", url: "https://api.averray.com" },
+      { name: "GitHub repo", url: "https://github.com/averray-agent/agent" },
+    ],
+    surfaces: [
+      { name: "GitHub Actions", purpose: "CI, production deploy, discovery manifest publishing, Hermes PR handoff." },
+      { name: "Operator app", purpose: "Human-facing product control plane." },
+      { name: "Hermes handoff monitor", purpose: "Private release/handoff observability from the reference-agent stack." },
+    ],
+    deploy: {
+      trigger: "Merge to main after CI and merge queue pass.",
+      workflow: "Deploy Production",
+      vpsPath: "/srv/agent-stack/app",
+      script: "/srv/agent-stack/app/scripts/ops/deploy-production.sh",
+      serializedBy: "GitHub Actions concurrency and a VPS flock lock",
+      postDeployVerification: "Hermes post-deploy read-only testbed suite",
+      knownSecretRotation: "ADMIN_JWT / product-proof worker token can expire and must be rotated outside Hermes.",
+    },
+    routineCommands: [
+      "github status",
+      "github brief",
+      "handoff monitor",
+      "propose merge for averray-agent/agent#<PR>",
+      "propose deploy for averray-agent/agent sha <SHA>",
+    ],
+    handoff: {
+      pr: "Hermes PR handoff runs after CI, reviews GitHub metadata/checks/files, and recommends ok_to_merge / needs_review / hold.",
+      deploy: "Post-deploy verification runs the read-only testbed suite and reports deploy health.",
+      mutates: false,
+    },
+    safety: {
+      secretsInMemory: false,
+      autoMergeEnabled: false,
+      autoDeployEnabled: false,
+      approvalRequiredForAdmin: true,
+      contractDeploys: "Never part of normal production deploy; require explicit contract deployment plan.",
+    },
+    openQuestions: [
+      "Document the exact owner/runbook for rotating ADMIN_JWT and product-proof worker tokens.",
+      "Add durable hosted app error/log checks beyond current read-only testbed checks.",
+    ],
+  },
+  {
+    id: "averray-reference-agent",
+    name: "Averray Reference Agent",
+    aliases: ["reference agent", "hermes", "command center", "slack operator", "monitor"],
+    repos: ["depre-dev/averray-reference-agent"],
+    role: "Hermes/Averray reference-agent stack: MCP tools, Slack operator, command center access, handoff monitor, and guarded Wikipedia citation repair.",
+    owner: "Pascal / depre-dev",
+    environments: [
+      { name: "VPS path", path: "/srv/averray-reference-agent" },
+      { name: "Command Center", url: "https://command.averray.com" },
+      { name: "Handoff Monitor", url: "https://monitor.averray.com" },
+      { name: "GitHub repo", url: "https://github.com/depre-dev/averray-reference-agent" },
+    ],
+    surfaces: [
+      { name: "Hermes Workspace", purpose: "Human chat and inspection surface." },
+      { name: "Slack operator", purpose: "Daily brief, ops health, GitHub brief, and short operator commands." },
+      { name: "Averray MCP", purpose: "Structured tool contract for Hermes, Codex, GitHub Actions, and other agents." },
+      { name: "Cloudflare Access", purpose: "Private access to Command Center and monitor without local tunnels." },
+    ],
+    deploy: {
+      trigger: "Manual VPS deploy after PR merges.",
+      vpsPath: "/srv/averray-reference-agent",
+      command: "git pull --ff-only origin main && docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -f ops/compose.command-center.yml -f ops/compose.cloudflare-access.yml -p avg --profile command-center up -d --build --force-recreate mcp-bundle slack-operator hermes hermes-gateway",
+      healthChecks: [
+        "curl -sS http://127.0.0.1:8790/health",
+        "curl -sS http://127.0.0.1:8790/monitor/events",
+      ],
+    },
+    routineCommands: [
+      "daily operator brief",
+      "daily github brief",
+      "ops health",
+      "handoff monitor",
+      "project memory",
+      "run testbed e2e read-only",
+    ],
+    handoff: {
+      hook: "averray_invoke_agent_task",
+      monitor: "averray_handoff_monitor and https://monitor.averray.com",
+      mutates: false,
+    },
+    safety: {
+      secretsInMemory: false,
+      wikipediaDirectEdits: false,
+      projectAdminEnabled: "proposal-only",
+      broadAdminDeniedByDefault: true,
+    },
+    openQuestions: [
+      "Decide whether project memory should become user-editable with approval receipts.",
+      "Add host-level disk/log/WAL housekeeping as a routine if needed.",
+    ],
+  },
+];
+
+export function getProjectMemory(input: ProjectMemoryInput = {}) {
+  const generatedAt = new Date().toISOString();
+  const configuredRepos = configuredGithubRepos();
+  const projects = mergeConfiguredRepos(CURATED_PROJECTS, configuredRepos);
+  const target = selectProject(projects, input.project ?? input.query);
+
+  return {
+    schemaVersion: 1,
+    kind: "project_admin_memory",
+    generatedAt,
+    mutates: false,
+    scope: {
+      source: "curated_repo_memory",
+      editableByHermes: false,
+      secretsStored: false,
+      configuredGithubRepos: configuredRepos,
+    },
+    ...(target
+      ? {
+          selectedProject: target,
+          relatedProjects: projects
+            .filter((project) => project.id !== target.id)
+            .map(projectSummary),
+        }
+      : {
+          projects: projects.map(projectSummary),
+        }),
+    commands: [
+      "project memory",
+      "known projects",
+      "project memory for averray-agent/agent",
+      "how do we deploy averray-agent/agent",
+    ],
+    safety: {
+      readOnly: true,
+      mutates: false,
+      secretsIncluded: false,
+      autoAdminEnabled: false,
+    },
+  };
+}
+
+function configuredGithubRepos() {
+  const raw = optionalEnv("GITHUB_HELPER_REPOS", "")
+    || optionalEnv("GITHUB_DEFAULT_REPO", "")
+    || optionalEnv("GITHUB_REPOSITORY", "");
+  return raw.split(",").map((entry) => entry.trim()).filter(Boolean);
+}
+
+function mergeConfiguredRepos(projects: ProjectMemoryEntry[], configuredRepos: string[]) {
+  const known = new Set(projects.flatMap((project) => project.repos));
+  const extras = configuredRepos
+    .filter((repo) => !known.has(repo))
+    .map<ProjectMemoryEntry>((repo) => ({
+      id: repo.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-|-$/g, ""),
+      name: repo,
+      aliases: [repo],
+      repos: [repo],
+      role: "GitHub repository configured for read-only Hermes status/briefing, but not yet curated in project memory.",
+      owner: "unknown",
+      environments: [{ name: "GitHub repo", url: `https://github.com/${repo}` }],
+      surfaces: [{ name: "GitHub status", purpose: "Read-only PR, issue, and CI visibility." }],
+      deploy: { status: "unknown" },
+      routineCommands: [`github status`, `project memory for ${repo}`],
+      handoff: { status: "not_configured" },
+      safety: { secretsInMemory: false, autoAdminEnabled: false },
+      openQuestions: ["Curate deploy URLs, owners, runbooks, and handoff expectations for this repo."],
+    }));
+  return [...projects, ...extras];
+}
+
+function selectProject(projects: ProjectMemoryEntry[], query: string | undefined) {
+  const normalized = normalize(extractRepoCandidate(query) ?? query);
+  if (!normalized) return undefined;
+  return projects.find((project) => {
+    const haystack = [
+      project.id,
+      project.name,
+      ...project.aliases,
+      ...project.repos,
+    ].map(normalize);
+    return haystack.some((entry) => entry === normalized || entry.includes(normalized) || normalized.includes(entry));
+  });
+}
+
+function extractRepoCandidate(value: string | undefined) {
+  const match = String(value ?? "").match(/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+/);
+  return match?.[0];
+}
+
+function projectSummary(project: ProjectMemoryEntry) {
+  return {
+    id: project.id,
+    name: project.name,
+    repos: project.repos,
+    role: project.role,
+    owner: project.owner,
+    primaryUrl: primaryUrl(project),
+    deployTrigger: stringField(project.deploy, "trigger") ?? stringField(project.deploy, "status") ?? "unknown",
+    usefulCommands: project.routineCommands.slice(0, 4),
+    openQuestions: project.openQuestions,
+  };
+}
+
+function primaryUrl(project: ProjectMemoryEntry) {
+  for (const environment of project.environments) {
+    const url = stringField(environment, "url");
+    if (url) return url;
+  }
+  return null;
+}
+
+function normalize(value: string | undefined) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function stringField(value: Record<string, unknown>, key: string) {
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}

--- a/packages/averray-mcp/src/operator-usefulness.ts
+++ b/packages/averray-mcp/src/operator-usefulness.ts
@@ -38,6 +38,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         commands: [
           "brief me",
           "what can you do for us",
+          "project memory",
           "admin readiness",
           "what should i do next",
           "run one wikipedia citation repair dry run only",
@@ -56,6 +57,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
           "operator status",
           "daily operator brief",
           "what can you do for us",
+          "project memory",
           "admin readiness",
           "find safe work",
         ],
@@ -65,6 +67,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         use: "Canonical structured contract any compatible agent can call without learning Slack or Workspace.",
         tools: [
           "averray_agent_usefulness_plan",
+          "averray_project_memory",
           "averray_admin_readiness",
           "averray_business_ledger",
           "averray_ops_health",
@@ -115,9 +118,9 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
       },
       {
         id: "knowledge_memory",
-        status: "partially_enabled",
-        value: "Keeps durable operator events in Postgres; next track is a human-readable runbook/memory export for setup decisions and commands.",
-        commands: ["operator status details", "status last wikipedia citation repair details"],
+        status: "enabled",
+        value: "Provides curated non-secret project memory: repos, deploy surfaces, useful commands, handoff expectations, safety notes, and open questions.",
+        commands: ["project memory", "known projects", "how do we deploy averray-agent/agent"],
       },
     ],
     nextImplementationTracks: [

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -173,6 +173,43 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Read-only plan. Use `what can you do for us details` in MCP/Workspace for the full structured JSON.",
     ].filter(Boolean).join("\n");
   }
+  if (result.kind === "project_memory") {
+    const memory = isRecord(result.memory) ? result.memory : {};
+    const selected = isRecord(memory.selectedProject) ? memory.selectedProject : undefined;
+    const projects = Array.isArray(memory.projects) ? memory.projects : [];
+    if (selected) {
+      const deploy = isRecord(selected.deploy) ? selected.deploy : {};
+      const safety = isRecord(selected.safety) ? selected.safety : {};
+      const commands = Array.isArray(selected.routineCommands) ? selected.routineCommands : [];
+      const envs = Array.isArray(selected.environments) ? selected.environments : [];
+      const questions = Array.isArray(selected.openQuestions) ? selected.openQuestions : [];
+      return [
+        `*Project memory - ${stringField(selected, "name") ?? stringField(selected, "id") ?? "unknown"}*`,
+        stringField(selected, "role") ?? "No role recorded.",
+        "",
+        `• repos: ${arrayField(selected, "repos").map((entry) => `\`${String(entry)}\``).join(", ") || "`n/a`"}`,
+        `• owner: \`${stringField(selected, "owner") ?? "unknown"}\``,
+        envs.length > 0 ? `*Surfaces*\n${envs.slice(0, 4).map(formatProjectEnvironment).join("\n")}` : "",
+        "*Deploy memory*",
+        `• trigger: \`${stringField(deploy, "trigger") ?? "unknown"}\``,
+        stringField(deploy, "workflow") ? `• workflow: \`${stringField(deploy, "workflow")}\`` : "",
+        stringField(deploy, "script") ? `• script: \`${stringField(deploy, "script")}\`` : "",
+        stringField(deploy, "command") ? `• command: \`${stringField(deploy, "command")}\`` : "",
+        commands.length > 0 ? `*Useful commands*\n${commands.slice(0, 5).map((entry) => `• \`${String(entry)}\``).join("\n")}` : "",
+        questions.length > 0 ? `*Open questions*\n${questions.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+        `*Safety*\n• secrets stored: \`${String(safety.secretsInMemory === true)}\`\n• auto-admin: \`${String(safety.autoAdminEnabled === true || safety.autoMergeEnabled === true || safety.autoDeployEnabled === true)}\``,
+        "Read-only project memory.",
+      ].filter(Boolean).join("\n");
+    }
+    const lines = projects.slice(0, 6).map(formatProjectSummary).join("\n");
+    return [
+      "*Known project memory*",
+      lines || "No projects are known yet.",
+      "",
+      "Try `project memory for averray-agent/agent` or `how do we deploy averray-agent/agent`.",
+      "Read-only. No secrets are stored.",
+    ].join("\n");
+  }
   if (result.kind === "admin_readiness") {
     const readiness = isRecord(result.readiness) ? result.readiness : {};
     const currentRole = isRecord(readiness.currentRole) ? readiness.currentRole : {};
@@ -794,6 +831,19 @@ function formatAdminProposalEvidence(value: unknown): string {
 function formatAdminProposalRisk(value: unknown): string {
   if (!isRecord(value)) return "• unknown risk";
   return `• \`${stringField(value, "severity") ?? "info"}\` ${stringField(value, "code") ?? "risk"} - ${stringField(value, "message") ?? "no detail"}`;
+}
+
+function formatProjectSummary(value: unknown): string {
+  if (!isRecord(value)) return "• unknown project";
+  const repos = arrayField(value, "repos").map((entry) => String(entry)).join(", ");
+  return `• *${stringField(value, "name") ?? stringField(value, "id") ?? "unknown"}* - ${repos ? `\`${repos}\` ` : ""}${stringField(value, "role") ?? "no role recorded"}`;
+}
+
+function formatProjectEnvironment(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const label = stringField(value, "name") ?? "surface";
+  const target = stringField(value, "url") ?? stringField(value, "path") ?? stringField(value, "purpose") ?? "n/a";
+  return `• ${label}: ${target}`;
 }
 
 function githubViewTitle(view: string): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -124,6 +124,25 @@ describe("operator commands", () => {
       source: "command_center",
       detailed: true,
     });
+    expect(parseOperatorCommand("project memory", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "project_memory",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("known projects details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "project_memory",
+      source: "slack",
+      detailed: true,
+    });
+    expect(parseOperatorCommand("how do we deploy averray-agent/agent details", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "project_memory",
+      source: "command_center",
+      detailed: true,
+      project: "averray-agent/agent",
+    });
     expect(parseOperatorCommand("can you admin my projects?", { source: "operator" })).toEqual({
       handled: true,
       kind: "admin_readiness",

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -8,6 +8,7 @@ import {
 import { getBusinessLedger, getOpsHealth } from "../../packages/averray-mcp/src/operator-insights.js";
 import { getAgentUsefulnessPlan } from "../../packages/averray-mcp/src/operator-usefulness.js";
 import { getAdminReadiness } from "../../packages/averray-mcp/src/operator-admin.js";
+import { getProjectMemory } from "../../packages/averray-mcp/src/operator-project-memory.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "../../packages/averray-mcp/src/operator-testbed.js";
 
 describe("operator status", () => {
@@ -319,6 +320,26 @@ describe("operator status", () => {
       expect.stringContaining("Merge PRs"),
       expect.stringContaining("Change DNS"),
     ]));
+
+    const memory = getProjectMemory({ query: "how do we deploy averray-agent/agent?" });
+    expect(memory).toMatchObject({
+      kind: "project_admin_memory",
+      mutates: false,
+      selectedProject: {
+        id: "averray-platform",
+        repos: ["averray-agent/agent"],
+        deploy: {
+          workflow: "Deploy Production",
+          postDeployVerification: "Hermes post-deploy read-only testbed suite",
+        },
+      },
+      safety: {
+        readOnly: true,
+        secretsIncluded: false,
+        autoAdminEnabled: false,
+      },
+    });
+    expect(memory.commands).toContain("how do we deploy averray-agent/agent");
 
     const suite = await getTestbedE2eSuite({
       ...deps,

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -345,6 +345,58 @@ describe("slack operator bridge", () => {
     expect(text).toContain("GitHub PR/issue digest");
   });
 
+  it("formats project memory replies", () => {
+    const list = formatOperatorResultForSlack({
+      handled: true,
+      kind: "project_memory",
+      memory: {
+        projects: [
+          {
+            id: "averray-platform",
+            name: "Averray Platform",
+            repos: ["averray-agent/agent"],
+            role: "Primary product platform.",
+          },
+        ],
+      },
+    });
+
+    expect(list).toContain("*Known project memory*");
+    expect(list).toContain("*Averray Platform*");
+    expect(list).toContain("`averray-agent/agent`");
+    expect(list).toContain("No secrets are stored");
+
+    const selected = formatOperatorResultForSlack({
+      handled: true,
+      kind: "project_memory",
+      memory: {
+        selectedProject: {
+          id: "averray-platform",
+          name: "Averray Platform",
+          repos: ["averray-agent/agent"],
+          owner: "Pascal / Averray",
+          role: "Primary product platform.",
+          environments: [{ name: "production app", url: "https://app.averray.com" }],
+          deploy: {
+            trigger: "Merge to main after CI passes.",
+            workflow: "Deploy Production",
+            script: "/srv/agent-stack/app/scripts/ops/deploy-production.sh",
+          },
+          routineCommands: ["github status", "github brief"],
+          safety: { secretsInMemory: false, autoMergeEnabled: false, autoDeployEnabled: false },
+          openQuestions: ["Document token rotation owner."],
+        },
+      },
+    });
+
+    expect(selected).toContain("*Project memory - Averray Platform*");
+    expect(selected).toContain("production app: https://app.averray.com");
+    expect(selected).toContain("trigger: `Merge to main after CI passes.`");
+    expect(selected).toContain("workflow: `Deploy Production`");
+    expect(selected).toContain("secrets stored: `false`");
+    expect(selected).toContain("Read-only project memory");
+  });
+
   it("formats admin readiness replies with staged guardrails", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
Adds a read-only project memory surface for Hermes and other agents.\n\nWhat changed:\n- Adds averray_project_memory with curated non-secret memory for Averray Platform and the reference-agent stack.\n- Routes project memory / known projects / deploy-memory commands through the operator handler.\n- Formats project memory replies for Slack and Command Center usage.\n- Documents the commands and adds unit coverage for parser, memory output, and Slack formatting.\n\nChecks run:\n- npm run build\n- npm test\n- git diff --check\n\nSafety:\n- Read-only only. No secrets stored or returned. No GitHub mutations, SSH, deploys, Wikipedia edits, or Averray state mutations.