### PR TITLE
Add project admin runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,10 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   recognizes `what can you do for us`, `project memory`, `known projects`,
   `how do we deploy averray-agent/agent`, `admin readiness`, `admin proposal`,
   `propose merge for averray-agent/agent#123`,
-  `propose deploy for averray-agent/agent sha abc1234`, `business ledger`,
+  `propose deploy for averray-agent/agent sha abc1234`,
+  `runbook for deploy averray-agent/agent`,
+  `merge runbook for averray-agent/agent`, `secret rotation runbook`,
+  `business ledger`,
   `ops health`, `github status`, `github open prs`, `github ci failures`,
   `github issue digest`, `github brief`, `daily github brief`,
   `what changed since last time`, `testbed e2e suite`,
@@ -158,6 +161,12 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   of known projects, repos, deploy surfaces, useful commands, handoff
   expectations, safety notes, and open questions. It stores no secrets and does
   not merge, deploy, SSH, edit GitHub, edit Wikipedia, or mutate Averray state.
+  Project runbook commands call `averray_project_runbook`, a read-only
+  project-admin checklist for merge, deploy, rollback, restart, and
+  secret-rotation work. It returns required evidence, operator steps, stop
+  conditions, verification, rollback notes, and suggested Hermes commands. It
+  never approves, merges, deploys, restarts, rotates secrets, SSHes, or mutates
+  GitHub.
   `what can you do for us` calls the
   read-only `averray_agent_usefulness_plan` MCP tool and explains the useful
   surfaces and use cases across Slack, Command Center/mobile, MCP clients,

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -240,6 +240,9 @@ operator status details
 admin proposal
 propose merge for averray-agent/agent#123
 propose deploy for averray-agent/agent sha abc1234
+runbook for deploy averray-agent/agent
+merge runbook for averray-agent/agent
+secret rotation runbook
 run one wikipedia citation repair if safe
 run wikipedia citation repair for wiki-en-... if safe
 status last wikipedia citation repair
@@ -254,6 +257,12 @@ Averray business tracking, and durable memory. `project memory` and
 known projects, repos, deploy surfaces, useful commands, handoff expectations,
 safety notes, and open questions. It stores no secrets and does not merge,
 deploy, SSH, edit GitHub, edit Wikipedia, or mutate Averray state.
+Project runbook commands call `averray_project_runbook`, a read-only
+project-admin checklist for merge, deploy, rollback, restart, and
+secret-rotation work. It returns required evidence, operator steps, stop
+conditions, verification, rollback notes, and suggested Hermes commands. It
+never approves, merges, deploys, restarts, rotates secrets, SSHes, or mutates
+GitHub.
 `admin readiness` calls
 `averray_admin_readiness`, a read-only staged plan for growing from operator
 copilot to approval-gated project admin without granting broad mutation powers

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -46,6 +46,7 @@ import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getProjectMemory } from "./operator-project-memory.js";
+import { getProjectRunbook } from "./operator-project-runbook.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { invokeAgentTask } from "./agent-invocation.js";
@@ -186,6 +187,19 @@ server.tool(
 );
 
 server.tool(
+  "averray_project_runbook",
+  "Read-only project admin runbooks for humans, Slack, Command Center, and other agents. Returns action-specific evidence, stop conditions, verification steps, and rollback notes for merge, deploy, rollback, restart, and secret-rotation decisions. It never approves, merges, deploys, restarts, rotates secrets, SSHes to production, edits GitHub, or mutates Averray state.",
+  {
+    action: z.enum(["merge", "deploy", "rollback", "secret_rotation", "restart", "unknown"]).default("unknown"),
+    project: z.string().min(1).optional(),
+    query: z.string().min(1).optional()
+  },
+  async ({ action, project, query: projectQuery }) => {
+    return jsonContent(getProjectRunbook({ action, project, query: projectQuery }));
+  }
+);
+
+server.tool(
   "averray_admin_readiness",
   "Canonical read-only admin-readiness plan for humans, Slack, Command Center, mobile surfaces, and other agents. Returns the current operator-copilot role, admin maturity ladder, guardrails, allowed/denied actions, and required controls before project-admin powers. Does not claim, submit, deploy, edit code, edit Wikipedia, request approval, or mutate Averray state.",
   {},
@@ -311,7 +325,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/project-memory/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'runbook for deploy averray-agent/agent', 'merge runbook for averray-agent/agent', 'secret rotation runbook', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/project-memory/project-runbook/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,5 +1,5 @@
 import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
-import type { AdminActionProposalInput } from "./operator-admin.js";
+import type { AdminActionKind, AdminActionProposalInput } from "./operator-admin.js";
 import type { GithubOperatorView } from "./operator-github.js";
 
 export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes" | "agent";
@@ -47,6 +47,15 @@ export type ParsedOperatorCommand =
       source: OperatorCommandSource;
       detailed: boolean;
       project?: string;
+    }
+  | {
+      handled: true;
+      kind: "project_runbook";
+      source: OperatorCommandSource;
+      detailed: boolean;
+      action: AdminActionKind;
+      project?: string;
+      query?: string;
     }
   | {
       handled: true;
@@ -141,6 +150,9 @@ const EXAMPLES = [
   "known projects",
   "project memory for averray-agent/agent",
   "how do we deploy averray-agent/agent",
+  "runbook for deploy averray-agent/agent",
+  "merge runbook for averray-agent/agent",
+  "secret rotation runbook",
   "admin readiness",
   "admin proposal",
   "propose merge for averray-agent/agent#123",
@@ -199,6 +211,11 @@ export function parseOperatorCommand(
   const projectMemory = projectMemoryTarget(text, normalizedText);
   if (projectMemory.handled) {
     return { handled: true, kind: "project_memory", source, detailed, ...projectMemory.target };
+  }
+
+  const projectRunbook = projectRunbookTarget(text, normalizedText);
+  if (projectRunbook.handled) {
+    return { handled: true, kind: "project_runbook", source, detailed, ...projectRunbook.target };
   }
 
   if (isAdminReadinessCommand(normalizedText)) {
@@ -407,6 +424,41 @@ function projectMemoryTarget(
     return { handled: true, target: project ? { project } : {} };
   }
   return { handled: false };
+}
+
+function projectRunbookTarget(
+  originalText: string,
+  text: string
+): { handled: true; target: { action: AdminActionKind; project?: string; query: string } } | { handled: false } {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  if (
+    !/\brunbook\b/.test(compact)
+    && !/^(what evidence do i need|what evidence is needed|before i approve|before approving)\b/.test(compact)
+  ) {
+    return { handled: false };
+  }
+
+  const action: AdminActionKind = compact.includes("secret") || compact.includes("token") || compact.includes("credential")
+    ? "secret_rotation"
+    : compact.includes("rollback") || compact.includes("roll back") || compact.includes("revert")
+      ? "rollback"
+      : compact.includes("restart") || compact.includes("recreate")
+        ? "restart"
+        : compact.includes("deploy") || compact.includes("release") || compact.includes("ship")
+          ? "deploy"
+          : compact.includes("merge") || compact.includes("pull request") || /\bpr\b/.test(compact)
+            ? "merge"
+            : "unknown";
+  const project = extractToken(originalText, /\b(?:for|about|deploy|merge|rollback|restart)\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/i)
+    ?? extractToken(originalText, /([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/i);
+  return {
+    handled: true,
+    target: {
+      action,
+      ...(project ? { project } : {}),
+      query: originalText.trim(),
+    },
+  };
 }
 
 function isAdminReadinessCommand(text: string): boolean {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -10,6 +10,7 @@ import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
 import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getProjectMemory } from "./operator-project-memory.js";
+import { getProjectRunbook } from "./operator-project-runbook.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
@@ -64,6 +65,14 @@ export async function handleOperatorCommandText(
   if (command.kind === "project_memory") {
     const memory = getProjectMemory({ project: command.project });
     return { ...command, memory };
+  }
+  if (command.kind === "project_runbook") {
+    const runbook = getProjectRunbook({
+      action: command.action,
+      project: command.project,
+      query: command.query,
+    });
+    return { ...command, runbook };
   }
   if (command.kind === "admin_readiness") {
     const readiness = await getAdminReadiness({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/packages/averray-mcp/src/operator-project-runbook.ts
+++ b/packages/averray-mcp/src/operator-project-runbook.ts
@@ -1,0 +1,329 @@
+import type { AdminActionKind } from "./operator-admin.js";
+import { getProjectMemory, type ProjectMemoryEntry } from "./operator-project-memory.js";
+
+export interface ProjectRunbookInput {
+  action?: AdminActionKind;
+  project?: string;
+  query?: string;
+}
+
+export interface RunbookTemplate {
+  goal: string;
+  trigger: string;
+  requiredEvidence: string[];
+  operatorSteps: string[];
+  stopConditions: string[];
+  postActionVerification: string[];
+  rollbackNotes: string[];
+}
+
+export function getProjectRunbook(input: ProjectRunbookInput = {}) {
+  const generatedAt = new Date().toISOString();
+  const action = normalizeAction(input.action, input.query);
+  const memory = getProjectMemory({ project: input.project, query: input.query });
+  const selectedProject = projectFromMemory(memory);
+  const template = runbookForAction(action, selectedProject);
+  const projectName = selectedProject?.name ?? input.project ?? "unknown project";
+
+  return {
+    schemaVersion: 1,
+    kind: "project_admin_runbook",
+    generatedAt,
+    mutates: false,
+    action,
+    target: {
+      project: selectedProject?.id ?? null,
+      name: selectedProject?.name ?? null,
+      repos: selectedProject?.repos ?? [],
+      requestedProject: input.project ?? null,
+      requestedQuery: input.query ?? null,
+    },
+    title: `${titleCase(action)} runbook - ${projectName}`,
+    project: selectedProject ? projectSummary(selectedProject) : null,
+    runbook: template,
+    suggestedHermesCommands: suggestedHermesCommands(action, selectedProject),
+    safety: {
+      readOnly: true,
+      mutates: false,
+      proposalOnly: true,
+      approvalRequired: true,
+      secretsIncluded: false,
+      githubMutated: false,
+      deployTriggered: false,
+      serviceRestarted: false,
+      rollbackTriggered: false,
+      freeFormHermesPromptUsed: false,
+    },
+  };
+}
+
+function normalizeAction(action: AdminActionKind | undefined, query: string | undefined): AdminActionKind {
+  if (action && action !== "unknown") return action;
+  const normalized = String(query ?? "").toLowerCase();
+  if (/\bsecret|token|credential|jwt\b/.test(normalized)) return "secret_rotation";
+  if (/\brollback|roll back|revert\b/.test(normalized)) return "rollback";
+  if (/\brestart|recreate\b/.test(normalized)) return "restart";
+  if (/\bdeploy|release|ship\b/.test(normalized)) return "deploy";
+  if (/\bmerge|pull request|pr\b/.test(normalized)) return "merge";
+  return "unknown";
+}
+
+function projectFromMemory(memory: ReturnType<typeof getProjectMemory>): ProjectMemoryEntry | undefined {
+  return "selectedProject" in memory ? memory.selectedProject : undefined;
+}
+
+function runbookForAction(action: AdminActionKind, project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  if (action === "merge") return mergeRunbook(project);
+  if (action === "deploy") return deployRunbook(project);
+  if (action === "rollback") return rollbackRunbook(project);
+  if (action === "secret_rotation") return secretRotationRunbook(project);
+  if (action === "restart") return restartRunbook(project);
+  return genericRunbook(project);
+}
+
+function mergeRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  const repo = primaryRepo(project);
+  return {
+    goal: "Decide whether a pull request is ready for a human merge approval.",
+    trigger: "A PR has green CI and the author asks for review, merge, or release readiness.",
+    requiredEvidence: [
+      "GitHub CI and merge queue checks are green.",
+      "Hermes PR handoff verdict is ok_to_merge, or every needs_review / hold reason has a human resolution.",
+      "Changed files match the stated PR scope and required tests.",
+      "PR notes mention affected surfaces: backend, frontend, indexer, Caddy, contracts, public site, or docs.",
+      "Rollback/deploy notes are present when deployment or ops files changed.",
+    ],
+    operatorSteps: [
+      repo ? `Run \`github status\` and inspect ${repo} PR status.` : "Run `github status` and inspect PR status.",
+      "Open the handoff monitor and read the latest PR handoff card.",
+      "If high-risk files changed, ask for explicit human review before merge.",
+      "Use `propose merge for owner/repo#PR` to get a proposal-only admin recommendation.",
+      "Merge manually only after the human owner approves the evidence.",
+    ],
+    stopConditions: [
+      "Any required CI or merge queue check is failing, cancelled, or still running.",
+      "Hermes says hold/block, or the handoff monitor shows unresolved risks.",
+      "Secrets, contract deployment, production config, or generated assets changed without explicit notes.",
+    ],
+    postActionVerification: [
+      "Confirm the merge landed on main.",
+      "Watch production deploy workflow if this repo auto-deploys on main.",
+      "Check the handoff monitor for post-deploy verification if a deploy starts.",
+    ],
+    rollbackNotes: [
+      "A merge rollback is usually a revert PR, not a force push.",
+      "If production breaks after merge, follow the deploy/rollback runbook instead of retrying blindly.",
+    ],
+  };
+}
+
+function deployRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  const deploy = project?.deploy ?? {};
+  return {
+    goal: "Ship a known commit and verify production is healthy afterward.",
+    trigger: stringField(deploy, "trigger") ?? "A human owner decides a commit or PR should be released.",
+    requiredEvidence: [
+      "Target commit is known and points at the intended branch or release.",
+      "CI is green for the target commit.",
+      "No open blocker in `github status`, `handoff monitor`, or `ops health`.",
+      stringField(deploy, "knownSecretRotation")
+        ? `Known secret/token state checked: ${stringField(deploy, "knownSecretRotation")}`
+        : "Required deploy credentials/secrets are present and not pasted into Hermes.",
+      "Rollback path is known before starting the deploy.",
+    ],
+    operatorSteps: [
+      stringField(deploy, "workflow")
+        ? `Trigger or watch GitHub workflow \`${stringField(deploy, "workflow")}\` when applicable.`
+        : "Trigger or watch the documented deploy workflow.",
+      stringField(deploy, "script")
+        ? `On the VPS, the deploy script is \`${stringField(deploy, "script")}\`.`
+        : "",
+      stringField(deploy, "command")
+        ? `Manual deploy command: \`${stringField(deploy, "command")}\`.`
+        : "",
+      "Keep deployment serialized; do not start a second deploy while one is active.",
+      "After deploy completes, run the read-only Hermes post-deploy testbed suite.",
+    ].filter(Boolean),
+    stopConditions: [
+      "Deploy workflow is already running or locked.",
+      "Required token/JWT/credential is expired or missing.",
+      "CI is not green for the target commit.",
+      "Recent post-deploy checks failed and have not been explained.",
+    ],
+    postActionVerification: [
+      "Check deploy workflow result.",
+      "Run `run testbed e2e read-only` or the configured post-deploy suite.",
+      "Check `ops health`, `github status`, and the handoff monitor.",
+      "Verify public app/API URLs listed in project memory if applicable.",
+    ],
+    rollbackNotes: [
+      "Rollback requires explicit human approval.",
+      "Prefer the project’s rollback workflow or redeploying a known-good commit.",
+      "Capture failure command/logs before rollback so the cause is not lost.",
+    ],
+  };
+}
+
+function rollbackRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  return {
+    goal: "Return production to a known-good state with an audit trail.",
+    trigger: "A deploy is unhealthy, customer-facing behavior regressed, or a human owner requests rollback.",
+    requiredEvidence: [
+      "Current bad deploy SHA/run is identified.",
+      "Known-good SHA/run is identified.",
+      "Failure symptom and first failing check/log are captured.",
+      "Human owner explicitly approves rollback.",
+      project ? `Project memory reviewed for ${project.name}.` : "Project memory reviewed for the target project.",
+    ],
+    operatorSteps: [
+      "Freeze new deploy attempts until rollback decision is clear.",
+      "Collect deploy workflow URL, failing check, and relevant health output.",
+      "Use `propose rollback for owner/repo sha <known-good-sha>` for an advisory recommendation.",
+      "Execute rollback manually through the project’s documented deploy/rollback path.",
+    ],
+    stopConditions: [
+      "No known-good target is available.",
+      "The issue is a secret/config outage that rollback will not fix.",
+      "The rollback itself would deploy contracts, move funds, or change DNS without a separate plan.",
+    ],
+    postActionVerification: [
+      "Run post-deploy verification against the rollback target.",
+      "Confirm GitHub/deploy status and app/API health.",
+      "Record the bad deploy, rollback target, and remaining follow-up.",
+    ],
+    rollbackNotes: [
+      "Rollback is itself a mutation and must be approved outside this runbook.",
+      "Hermes can propose and verify, but should not execute rollback yet.",
+    ],
+  };
+}
+
+function secretRotationRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  return {
+    goal: "Rotate a credential without exposing it to Hermes or chat logs.",
+    trigger: "A token expires, is suspected compromised, or needs scheduled rotation.",
+    requiredEvidence: [
+      "Secret name and owning system are identified.",
+      "Consumer services/workflows that depend on the secret are listed.",
+      "A rollback/recovery path exists if the new secret fails.",
+      "New secret value is handled only in approved secret stores, never pasted into Hermes/Slack.",
+      project ? `Project owner known: ${project.owner}.` : "Project owner is identified.",
+    ],
+    operatorSteps: [
+      "Pause deploys or workflows that depend on the expiring secret if needed.",
+      "Generate or obtain the new secret in the provider UI/CLI.",
+      "Update GitHub/VPS/Cloudflare/Slack secret stores directly; do not send the value to Hermes.",
+      "Restart or rerun only the affected workflow/service.",
+      "Ask Hermes to verify via read-only health checks after rotation.",
+    ],
+    stopConditions: [
+      "You cannot identify all consumers of the secret.",
+      "The secret value appears in chat, logs, PRs, or shell history.",
+      "There is no way to verify the new secret safely.",
+    ],
+    postActionVerification: [
+      "Run affected workflow or health check.",
+      "Confirm no auth errors remain.",
+      "Record that rotation happened without storing the secret value.",
+    ],
+    rollbackNotes: [
+      "Keep the old credential valid only until verification succeeds, when provider policy allows.",
+      "If the new credential fails, restore from the secure provider/store, not from Hermes output.",
+    ],
+  };
+}
+
+function restartRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  return {
+    goal: "Restart only the affected service with minimal blast radius.",
+    trigger: "A service is unhealthy and read-only checks suggest a restart may clear the condition.",
+    requiredEvidence: [
+      "Affected service/container is identified.",
+      "Current health/log symptom is captured.",
+      "No deploy or migration is already running.",
+      "Restart command and expected health endpoint are known.",
+      project ? `Project memory reviewed for ${project.name}.` : "Project memory reviewed for the target project.",
+    ],
+    operatorSteps: [
+      "Run read-only health/log checks first.",
+      "Prefer targeted service restart/recreate over whole-stack restart.",
+      "Watch logs and health for the affected service.",
+      "Escalate to deploy/rollback runbook if restart does not resolve it.",
+    ],
+    stopConditions: [
+      "Database migration, deploy, or backup is active.",
+      "Restart would drop in-flight work with no recovery plan.",
+      "The root issue is expired credentials or config drift.",
+    ],
+    postActionVerification: [
+      "Health endpoint returns ok.",
+      "Recent errors stop increasing.",
+      "Operator surfaces still work.",
+    ],
+    rollbackNotes: [
+      "A restart rollback is usually another targeted restart or deploy rollback if new code caused it.",
+    ],
+  };
+}
+
+function genericRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
+  return {
+    goal: "Prepare a safe admin action with human approval.",
+    trigger: "A human or agent asks whether a project-admin action is ready.",
+    requiredEvidence: [
+      "Action type is explicit: merge, deploy, rollback, secret_rotation, or restart.",
+      "Target project/repo/environment is identified.",
+      "Read-only health/GitHub/handoff evidence has been checked.",
+      "Human owner approval path is known.",
+    ],
+    operatorSteps: [
+      project ? `Start from project memory for ${project.name}.` : "Run `project memory` to identify the target project.",
+      "Pick a specific runbook: merge, deploy, rollback, secret rotation, or restart.",
+      "Use an admin proposal command before any mutation.",
+    ],
+    stopConditions: [
+      "The requested action is ambiguous.",
+      "The action would expose or change secrets through chat.",
+      "The action affects contracts, funds, DNS, or production config without a separate plan.",
+    ],
+    postActionVerification: [
+      "Use read-only status checks appropriate to the selected action.",
+    ],
+    rollbackNotes: [
+      "No mutation should happen from the generic runbook.",
+    ],
+  };
+}
+
+function suggestedHermesCommands(action: AdminActionKind, project: ProjectMemoryEntry | undefined) {
+  const repo = primaryRepo(project) ?? "owner/repo";
+  if (action === "merge") return [`propose merge for ${repo}#<PR>`, "github status", "handoff monitor"];
+  if (action === "deploy") return [`propose deploy for ${repo} sha <SHA>`, "run testbed e2e read-only", "ops health"];
+  if (action === "rollback") return [`propose rollback for ${repo} sha <KNOWN_GOOD_SHA>`, "ops health", "handoff monitor"];
+  if (action === "secret_rotation") return ["propose secret rotation", "ops health", "github status"];
+  if (action === "restart") return ["ops health", "handoff monitor"];
+  return ["project memory", "admin readiness", "admin proposal"];
+}
+
+function projectSummary(project: ProjectMemoryEntry) {
+  return {
+    id: project.id,
+    name: project.name,
+    repos: project.repos,
+    owner: project.owner,
+    role: project.role,
+  };
+}
+
+function primaryRepo(project: ProjectMemoryEntry | undefined) {
+  return project?.repos[0];
+}
+
+function titleCase(action: AdminActionKind) {
+  return action.split("_").map((part) => part.slice(0, 1).toUpperCase() + part.slice(1)).join(" ");
+}
+
+function stringField(value: Record<string, unknown>, key: string) {
+  const field = value[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}

--- a/packages/averray-mcp/src/operator-usefulness.ts
+++ b/packages/averray-mcp/src/operator-usefulness.ts
@@ -39,6 +39,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
           "brief me",
           "what can you do for us",
           "project memory",
+          "runbook for deploy averray-agent/agent",
           "admin readiness",
           "what should i do next",
           "run one wikipedia citation repair dry run only",
@@ -58,6 +59,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
           "daily operator brief",
           "what can you do for us",
           "project memory",
+          "merge runbook for averray-agent/agent",
           "admin readiness",
           "find safe work",
         ],
@@ -68,6 +70,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         tools: [
           "averray_agent_usefulness_plan",
           "averray_project_memory",
+          "averray_project_runbook",
           "averray_admin_readiness",
           "averray_business_ledger",
           "averray_ops_health",
@@ -119,8 +122,8 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
       {
         id: "knowledge_memory",
         status: "enabled",
-        value: "Provides curated non-secret project memory: repos, deploy surfaces, useful commands, handoff expectations, safety notes, and open questions.",
-        commands: ["project memory", "known projects", "how do we deploy averray-agent/agent"],
+        value: "Provides curated non-secret project memory and read-only runbooks: repos, deploy surfaces, merge/deploy/rollback evidence, handoff expectations, safety notes, and open questions.",
+        commands: ["project memory", "known projects", "how do we deploy averray-agent/agent", "runbook for deploy averray-agent/agent"],
       },
     ],
     nextImplementationTracks: [

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -210,6 +210,30 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Read-only. No secrets are stored.",
     ].join("\n");
   }
+  if (result.kind === "project_runbook") {
+    const runbookEnvelope = isRecord(result.runbook) ? result.runbook : {};
+    const runbook = isRecord(runbookEnvelope.runbook) ? runbookEnvelope.runbook : {};
+    const project = isRecord(runbookEnvelope.project) ? runbookEnvelope.project : {};
+    const target = isRecord(runbookEnvelope.target) ? runbookEnvelope.target : {};
+    const safety = isRecord(runbookEnvelope.safety) ? runbookEnvelope.safety : {};
+    const commands = arrayField(runbookEnvelope, "suggestedHermesCommands");
+    const projectName = stringField(project, "name") ?? stringField(target, "name") ?? "unknown project";
+    return [
+      `*${stringField(runbookEnvelope, "title") ?? "Project admin runbook"}*`,
+      stringField(runbook, "goal") ?? "Prepare a project-admin action safely.",
+      "",
+      `• action: \`${stringField(runbookEnvelope, "action") ?? "unknown"}\``,
+      `• project: \`${projectName}\``,
+      `• trigger: ${stringField(runbook, "trigger") ?? "n/a"}`,
+      formatRunbookSection("Required evidence", arrayField(runbook, "requiredEvidence"), 5),
+      formatRunbookSection("Operator steps", arrayField(runbook, "operatorSteps"), 5),
+      formatRunbookSection("Stop if", arrayField(runbook, "stopConditions"), 4),
+      formatRunbookSection("Verify after", arrayField(runbook, "postActionVerification"), 4),
+      commands.length > 0 ? `*Suggested Hermes commands*\n${commands.slice(0, 4).map((entry) => `• \`${String(entry)}\``).join("\n")}` : "",
+      `*Safety*\n• read-only: \`${String(safety.readOnly !== false)}\`\n• approval required: \`${String(safety.approvalRequired === true)}\`\n• mutates: \`${String(safety.mutates === true)}\`\n• secrets included: \`${String(safety.secretsIncluded === true)}\``,
+      "Runbook-only. Hermes did not approve, merge, deploy, restart, rotate secrets, or mutate GitHub.",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "admin_readiness") {
     const readiness = isRecord(result.readiness) ? result.readiness : {};
     const currentRole = isRecord(readiness.currentRole) ? readiness.currentRole : {};
@@ -844,6 +868,11 @@ function formatProjectEnvironment(value: unknown): string {
   const label = stringField(value, "name") ?? "surface";
   const target = stringField(value, "url") ?? stringField(value, "path") ?? stringField(value, "purpose") ?? "n/a";
   return `• ${label}: ${target}`;
+}
+
+function formatRunbookSection(title: string, values: unknown[], limit: number): string {
+  if (values.length === 0) return "";
+  return `*${title}*\n${values.slice(0, limit).map((entry) => `• ${String(entry)}`).join("\n")}`;
 }
 
 function githubViewTitle(view: string): string {

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -143,6 +143,23 @@ describe("operator commands", () => {
       detailed: true,
       project: "averray-agent/agent",
     });
+    expect(parseOperatorCommand("runbook for deploy averray-agent/agent", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "project_runbook",
+      source: "operator",
+      detailed: false,
+      action: "deploy",
+      project: "averray-agent/agent",
+      query: "runbook for deploy averray-agent/agent",
+    });
+    expect(parseOperatorCommand("secret rotation runbook details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "project_runbook",
+      source: "slack",
+      detailed: true,
+      action: "secret_rotation",
+      query: "secret rotation runbook details",
+    });
     expect(parseOperatorCommand("can you admin my projects?", { source: "operator" })).toEqual({
       handled: true,
       kind: "admin_readiness",

--- a/test/unit/operator-status.test.ts
+++ b/test/unit/operator-status.test.ts
@@ -9,6 +9,7 @@ import { getBusinessLedger, getOpsHealth } from "../../packages/averray-mcp/src/
 import { getAgentUsefulnessPlan } from "../../packages/averray-mcp/src/operator-usefulness.js";
 import { getAdminReadiness } from "../../packages/averray-mcp/src/operator-admin.js";
 import { getProjectMemory } from "../../packages/averray-mcp/src/operator-project-memory.js";
+import { getProjectRunbook } from "../../packages/averray-mcp/src/operator-project-runbook.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "../../packages/averray-mcp/src/operator-testbed.js";
 
 describe("operator status", () => {
@@ -340,6 +341,28 @@ describe("operator status", () => {
       },
     });
     expect(memory.commands).toContain("how do we deploy averray-agent/agent");
+
+    const runbook = getProjectRunbook({ query: "runbook for deploy averray-agent/agent" });
+    expect(runbook).toMatchObject({
+      kind: "project_admin_runbook",
+      mutates: false,
+      action: "deploy",
+      target: {
+        project: "averray-platform",
+        repos: ["averray-agent/agent"],
+      },
+      safety: {
+        readOnly: true,
+        approvalRequired: true,
+        mutates: false,
+      },
+    });
+    expect(runbook.runbook.requiredEvidence).toEqual(expect.arrayContaining([
+      expect.stringContaining("CI is green"),
+    ]));
+    expect(runbook.suggestedHermesCommands).toEqual(expect.arrayContaining([
+      "run testbed e2e read-only",
+    ]));
 
     const suite = await getTestbedE2eSuite({
       ...deps,

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -397,6 +397,42 @@ describe("slack operator bridge", () => {
     expect(selected).toContain("Read-only project memory");
   });
 
+  it("formats project runbook replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "project_runbook",
+      runbook: {
+        title: "Deploy runbook - Averray Platform",
+        action: "deploy",
+        target: { name: "Averray Platform" },
+        project: { name: "Averray Platform" },
+        runbook: {
+          goal: "Ship a known commit safely.",
+          trigger: "Merge to main after CI passes.",
+          requiredEvidence: ["CI is green", "Rollback path is known"],
+          operatorSteps: ["Watch deploy workflow", "Run post-deploy suite"],
+          stopConditions: ["CI is failing"],
+          postActionVerification: ["Check hosted health"],
+        },
+        suggestedHermesCommands: ["run testbed e2e read-only"],
+        safety: {
+          readOnly: true,
+          approvalRequired: true,
+          mutates: false,
+          secretsIncluded: false,
+        },
+      },
+    });
+
+    expect(text).toContain("*Deploy runbook - Averray Platform*");
+    expect(text).toContain("action: `deploy`");
+    expect(text).toContain("*Required evidence*");
+    expect(text).toContain("CI is green");
+    expect(text).toContain("*Operator steps*");
+    expect(text).toContain("run testbed e2e read-only");
+    expect(text).toContain("Runbook-only");
+  });
+
   it("formats admin readiness replies with staged guardrails", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
Adds read-only project-admin runbooks for merge, deploy, rollback, restart, and secret-rotation decisions.\n\nWhat changed:\n- Adds averray_project_runbook MCP tool and operator-command routing for runbook prompts.\n- Formats runbook responses for Slack/operator surfaces.\n- Documents runbook commands in README and VPS smoke docs.\n- Covers parser, structured runbook output, and Slack formatting in unit tests.\n\nChecks run:\n- npm run build\n- npm test\n- git diff --check\n\nSafety:\n- Runbooks are advisory/read-only only. They do not approve, merge, deploy, restart, rotate secrets, SSH, edit GitHub, or mutate Averray state.