### PR TITLE
Add PR code review verifier intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,10 +200,13 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   when they need Hermes/Averray to run a post-deploy smoke or E2E check. The
   hook accepts structured requester metadata, an optional `correlationId`, and
   either a safe operator command, the full read-only E2E suite, a single
-  testcase ID, or a PR handoff workflow. PR handoff is the normal path for an
-  agent that has opened a PR and wants Hermes to review it, recommend whether it
-  is merge-ready, run the requested testbed checks, and report the result back
-  to the calling agent.
+  testcase ID, a read-only PR code-review verifier, or a PR handoff workflow.
+  `pr_code_review` is the narrow independent-verifier lane: it inspects PR
+  metadata, changed files, check status, rollout notes, and test signals, then
+  returns an `ok_to_merge`, `needs_review`, or `hold` recommendation without
+  mutating GitHub. PR handoff is the normal path for an agent that has opened a
+  PR and wants Hermes to review it, recommend whether it is merge-ready, run the
+  requested testbed checks, and report the result back to the calling agent.
 
   ```json
   {"requester":"codex","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
@@ -215,6 +218,10 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
 
   ```json
   {"requester":"deploy-agent","intent":"pr_handoff","repo":"averray-agent/agent","pullRequestNumber":185,"testCaseIds":["TBE2E-004"],"correlationId":"deploy-20260509","reason":"pre-merge smoke"}
+  ```
+
+  ```json
+  {"requester":"codex","intent":"pr_code_review","repo":"averray-agent/agent","pullRequestNumber":185,"correlationId":"review-20260509","reason":"independent verifier lane"}
   ```
 
   ```json

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -314,10 +314,13 @@ policy, draft, validation, submit, and Slack alert gates.
 Trusted deploy scripts, backend agents, Codex, and other operator agents should
 use `averray_invoke_agent_task` as the stable agent-to-agent hook. It records
 `requester`, optional `correlationId`, and optional `reason`, then runs one of
-the structured paths below without sending a free-form Hermes prompt. Use the
-PR handoff path when another agent has opened a PR and needs Hermes/Averray to
-inspect the PR, recommend merge readiness, run the requested testbed check, and
-return a machine-readable report.
+the structured paths below without sending a free-form Hermes prompt. Use
+`intent: "pr_code_review"` for the narrow independent verifier lane: Hermes
+inspects PR metadata, changed files, checks, rollout notes, and test signals,
+then returns a read-only merge recommendation. Use the PR handoff path when
+another agent has opened a PR and needs Hermes/Averray to inspect the PR,
+recommend merge readiness, run the requested testbed check, and return a
+machine-readable report.
 
 ```json
 {"requester":"deploy-agent","intent":"testbed_e2e_read_only","correlationId":"deploy-20260509","reason":"post-deploy smoke"}
@@ -337,6 +340,10 @@ read-only cases and reports mutation-bound cases as skipped.
 
 ```json
 {"requester":"deploy-agent","intent":"pr_handoff","repo":"averray-agent/agent","pullRequestNumber":185,"testCaseIds":["TBE2E-004"],"correlationId":"deploy-20260509","reason":"pre-merge smoke"}
+```
+
+```json
+{"requester":"codex","intent":"pr_code_review","repo":"averray-agent/agent","pullRequestNumber":185,"correlationId":"review-20260509","reason":"independent verifier lane"}
 ```
 
 ```json

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -4,7 +4,13 @@ import {
   type OperatorQueryFn,
   type ParsedOperatorCommand,
 } from "./operator-commands.js";
-import { getGithubOperatorStatus, getGithubPullRequestReview } from "./operator-github.js";
+import {
+  getGithubOperatorStatus,
+  getGithubPullRequestReview,
+  type GithubPullRequestMergeRecommendation,
+  type GithubPullRequestReview,
+  type GithubPullRequestTouchedArea,
+} from "./operator-github.js";
 import { handleOperatorCommandText } from "./operator-handler.js";
 import { runTestbedE2eReadOnly } from "./operator-testbed.js";
 import {
@@ -19,6 +25,7 @@ export type AgentInvocationIntent =
   | "testbed_e2e_read_only"
   | "testbed_suite"
   | "testbed_case"
+  | "pr_code_review"
   | "pr_handoff"
   | "post_deploy_verification";
 
@@ -153,6 +160,10 @@ async function invokeAgentTaskInner(
     return invokePullRequestHandoff(input, deps, invocation, startedAt);
   }
 
+  if (intent === "pr_code_review") {
+    return invokePullRequestCodeReview(input, deps, invocation, startedAt);
+  }
+
   if (intent === "post_deploy_verification") {
     return invokePostDeployVerification(input, deps, invocation, startedAt);
   }
@@ -265,6 +276,38 @@ async function invokePostDeployVerification(
   }, { mutates: false, localCheckpoint: false });
 }
 
+async function invokePullRequestCodeReview(
+  input: AgentInvocationInput,
+  deps: AgentInvocationDeps,
+  invocation: Record<string, unknown>,
+  startedAt: Date
+): Promise<unknown> {
+  const review = await getGithubPullRequestReview({
+    ...(input.repo ? { repo: input.repo } : {}),
+    ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+    ...(input.pullRequestUrl ? { pullRequestUrl: input.pullRequestUrl } : {}),
+    ...(deps.githubEnv ? { env: deps.githubEnv } : {}),
+    ...(deps.githubFetchFn ? { fetchFn: deps.githubFetchFn } : {}),
+    ...(deps.now ? { now: deps.now } : {}),
+  });
+  const codeReview = buildPullRequestCodeReview(review);
+
+  return completedInvocation(invocation, startedAt, {
+    schemaVersion: 1,
+    kind: "agent_pr_code_review",
+    status: review.configured && review.health !== "degraded" ? "completed" : "blocked",
+    repo: review.repo ?? input.repo ?? null,
+    pullRequestNumber: review.pullRequestNumber ?? input.pullRequestNumber ?? null,
+    pullRequestUrl: review.pullRequest?.url ?? input.pullRequestUrl ?? null,
+    github: review,
+    codeReview,
+    finalVerdict: codeReview.finalVerdict,
+    finalReason: codeReview.finalReason,
+    mergeRecommendation: codeReview.mergeRecommendation,
+    safety: prHandoffSafety(false, false),
+  }, { mutates: false, localCheckpoint: false });
+}
+
 async function invokePullRequestHandoff(
   input: AgentInvocationInput,
   deps: AgentInvocationDeps,
@@ -279,6 +322,7 @@ async function invokePullRequestHandoff(
     ...(deps.githubFetchFn ? { fetchFn: deps.githubFetchFn } : {}),
     ...(deps.now ? { now: deps.now } : {}),
   });
+  const codeReview = buildPullRequestCodeReview(review);
   const requestedTestCaseIds = normalizeTestCaseIds([
     ...(input.testCaseId ? [input.testCaseId] : []),
     ...(input.testCaseIds ?? []),
@@ -295,6 +339,7 @@ async function invokePullRequestHandoff(
       kind: "agent_pr_handoff",
       status: "blocked",
       github: review,
+      codeReview,
       requestedActions,
       tests: [],
       finalVerdict: "hold",
@@ -309,6 +354,7 @@ async function invokePullRequestHandoff(
       kind: "agent_pr_handoff",
       status: "completed",
       github: review,
+      codeReview,
       requestedActions,
       tests: [],
       finalVerdict: "hold",
@@ -368,12 +414,100 @@ async function invokePullRequestHandoff(
     kind: "agent_pr_handoff",
     status: "completed",
     github: review,
+    codeReview,
     requestedActions,
     tests,
     finalVerdict,
     finalReason: failedTests > 0 ? "requested_tests_failed_or_blocked" : `github_${review.mergeRecommendation}`,
     safety: prHandoffSafety(wouldMutate, wouldWriteLocalCheckpoint),
   }, { mutates: wouldMutate, localCheckpoint: wouldWriteLocalCheckpoint });
+}
+
+function buildPullRequestCodeReview(review: GithubPullRequestReview) {
+  const finalVerdict: GithubPullRequestMergeRecommendation = !review.configured || review.health === "degraded"
+    ? "hold"
+    : review.mergeRecommendation;
+  const finalReason = !review.configured || review.health === "degraded"
+    ? "github_pr_review_unavailable"
+    : `github_${review.mergeRecommendation}`;
+  const riskCategory = classifyPullRequestRiskCategory(review.review.touchedAreas);
+  const highestRisk = review.riskFindings.some((finding) => finding.severity === "high")
+    ? "high"
+    : review.riskFindings.some((finding) => finding.severity === "medium")
+      ? "medium"
+      : "low";
+  const why = review.riskFindings[0]?.message
+    ?? (finalVerdict === "ok_to_merge"
+      ? "PR metadata, changed files, and checks look merge-ready."
+      : "PR needs human review before merge.");
+
+  return {
+    schemaVersion: 1,
+    kind: "agent_pr_code_review",
+    mode: "read_only_recommendation",
+    verifierLane: {
+      purpose: "independent_pr_verification",
+      currentRuntime: "structured_github_review",
+      plannedRuntime: "codex_app_server",
+      codexRuntimeUsed: false,
+    },
+    finalVerdict,
+    finalReason,
+    mergeRecommendation: finalVerdict,
+    riskCategory,
+    highestRisk,
+    why,
+    changedFiles: review.files.total,
+    touchedAreas: review.review.touchedAreas,
+    highRiskFiles: review.files.highRisk,
+    checks: {
+      total: review.checks.total,
+      failed: review.checks.failed,
+      active: review.checks.active,
+      passed: review.checks.passed,
+    },
+    tests: {
+      matchedTouchedAreas: review.review.missingTestSignals.length === 0,
+      testFilesChanged: review.review.testFilesChanged,
+      testSignals: review.review.testSignals,
+      missingTestSignals: review.review.missingTestSignals,
+    },
+    rollout: {
+      notesRequired: review.review.rolloutNotesRequired,
+      notesPresent: review.review.rolloutNotesPresent,
+    },
+    reasons: review.riskFindings,
+    recommendations: review.recommendations,
+    safety: {
+      source: "agent",
+      readOnly: true,
+      githubMutated: false,
+      mergePerformed: false,
+      deployTriggered: false,
+      freeFormHermesPromptUsed: false,
+      codexRuntimeUsed: false,
+    },
+  };
+}
+
+function classifyPullRequestRiskCategory(touchedAreas: GithubPullRequestTouchedArea[]): string {
+  if (touchedAreas.length === 0) return "unknown";
+  const highPriorityAreas: GithubPullRequestTouchedArea[] = [
+    "contracts",
+    "deploy",
+    "workflow",
+    "ops",
+    "backend",
+    "indexer",
+    "frontend",
+    "dependencies",
+    "config",
+    "tests",
+    "docs",
+  ];
+  const matched = highPriorityAreas.filter((area) => touchedAreas.includes(area));
+  if (matched.length === 0) return "mixed";
+  return matched.length === 1 ? matched[0] : "mixed";
 }
 
 async function invokeOperatorCommand(

--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -133,9 +133,11 @@ export function summarizeHandoffResult(result: unknown): Record<string, unknown>
     finalVerdict: stringField(nestedResult, "finalVerdict"),
     deploymentHealth: deploymentHealthSummary(nestedResult),
     mergeRecommendation: firstDeepString(nestedResult, [
+      ["codeReview", "mergeRecommendation"],
       ["github", "mergeRecommendation"],
       ["github", "merge_recommendation"],
     ]),
+    codeReview: codeReviewSummary(nestedResult),
     reviewSignals: githubReviewSignals(nestedResult),
     reviewReasons: githubReviewReasons(nestedResult),
     requestedCaseIds: arrayField(nestedResult, "requestedCaseIds"),
@@ -293,6 +295,27 @@ function githubReviewReasons(record: Record<string, unknown>): Record<string, un
       message: stringField(finding, "message"),
     }));
   return reviewReasons.length > 0 ? reviewReasons : undefined;
+}
+
+function codeReviewSummary(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  const codeReview = isRecord(record.codeReview) ? record.codeReview : undefined;
+  if (!codeReview) return undefined;
+  const tests = isRecord(codeReview.tests) ? codeReview.tests : undefined;
+  const verifierLane = isRecord(codeReview.verifierLane) ? codeReview.verifierLane : undefined;
+  const summary = compactRecord({
+    finalVerdict: stringField(codeReview, "finalVerdict"),
+    finalReason: stringField(codeReview, "finalReason"),
+    mergeRecommendation: stringField(codeReview, "mergeRecommendation"),
+    riskCategory: stringField(codeReview, "riskCategory"),
+    highestRisk: stringField(codeReview, "highestRisk"),
+    why: stringField(codeReview, "why"),
+    changedFiles: numberField(codeReview, "changedFiles"),
+    testsMatchedTouchedAreas: tests ? booleanField(tests, "matchedTouchedAreas") : undefined,
+    missingTestSignals: tests ? arrayField(tests, "missingTestSignals") : undefined,
+    currentRuntime: verifierLane ? stringField(verifierLane, "currentRuntime") : undefined,
+    plannedRuntime: verifierLane ? stringField(verifierLane, "plannedRuntime") : undefined,
+  });
+  return Object.keys(summary).length > 0 ? summary : undefined;
 }
 
 function githubReviewSignals(record: Record<string, unknown>): Record<string, unknown> | undefined {

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -295,10 +295,10 @@ server.tool(
 
 server.tool(
   "averray_invoke_agent_task",
-  "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, one testbed testcase by ID, a post-deploy verification workflow, or a PR handoff workflow that reviews GitHub PR metadata/checks/files and then runs requested tests with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, local checkpoint writes, and PRs that are not merge-ready unless the caller explicitly opts into that class of action. PR handoff only recommends merge state; it never merges.",
+  "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, one testbed testcase by ID, a post-deploy verification workflow, a read-only PR code-review verifier, or a PR handoff workflow that reviews GitHub PR metadata/checks/files and then runs requested tests with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, local checkpoint writes, and PRs that are not merge-ready unless the caller explicitly opts into that class of action. PR handoff and PR code review only recommend merge state; they never merge.",
   {
     requester: z.string().min(1),
-    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_suite", "testbed_case", "pr_handoff", "post_deploy_verification"]).default("operator_command"),
+    intent: z.enum(["operator_command", "testbed_e2e_read_only", "testbed_suite", "testbed_case", "pr_code_review", "pr_handoff", "post_deploy_verification"]).default("operator_command"),
     command: z.string().min(1).optional(),
     testCaseId: z.string().min(1).optional(),
     testCaseIds: z.array(z.string().min(1)).max(20).optional(),

--- a/test/unit/agent-invocation.test.ts
+++ b/test/unit/agent-invocation.test.ts
@@ -369,6 +369,27 @@ describe("agent invocation hook", () => {
       result: {
         kind: "agent_pr_handoff",
         finalVerdict: "ok_to_merge",
+        codeReview: {
+          mode: "read_only_recommendation",
+          verifierLane: {
+            currentRuntime: "structured_github_review",
+            plannedRuntime: "codex_app_server",
+            codexRuntimeUsed: false,
+          },
+          finalVerdict: "ok_to_merge",
+          mergeRecommendation: "ok_to_merge",
+          riskCategory: "docs",
+          highestRisk: "low",
+          tests: {
+            matchedTouchedAreas: true,
+          },
+          safety: {
+            githubMutated: false,
+            mergePerformed: false,
+            deployTriggered: false,
+            codexRuntimeUsed: false,
+          },
+        },
         github: {
           mergeRecommendation: "ok_to_merge",
           checks: { failed: 0, active: 0 },
@@ -421,6 +442,71 @@ describe("agent invocation hook", () => {
           mergeRecommendation: "hold",
         },
         tests: [],
+      },
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("runs a standalone read-only PR code review verifier", async () => {
+    const calls: string[] = [];
+    const result = await invokeAgentTask(
+      {
+        requester: "codex",
+        intent: "pr_code_review",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 185,
+        correlationId: "review-123",
+      },
+      deps(calls, githubFetch())
+    );
+
+    expect(result).toMatchObject({
+      kind: "agent_invocation",
+      status: "completed",
+      invocation: {
+        requester: "codex",
+        intent: "pr_code_review",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 185,
+        correlationId: "review-123",
+      },
+      result: {
+        kind: "agent_pr_code_review",
+        status: "completed",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 185,
+        finalVerdict: "ok_to_merge",
+        finalReason: "github_ok_to_merge",
+        mergeRecommendation: "ok_to_merge",
+        codeReview: {
+          mode: "read_only_recommendation",
+          riskCategory: "docs",
+          highestRisk: "low",
+          changedFiles: 1,
+          checks: {
+            total: 1,
+            failed: 0,
+            active: 0,
+          },
+          tests: {
+            matchedTouchedAreas: true,
+            missingTestSignals: [],
+          },
+          verifierLane: {
+            purpose: "independent_pr_verification",
+            currentRuntime: "structured_github_review",
+            plannedRuntime: "codex_app_server",
+            codexRuntimeUsed: false,
+          },
+          safety: {
+            readOnly: true,
+            githubMutated: false,
+            mergePerformed: false,
+            deployTriggered: false,
+            freeFormHermesPromptUsed: false,
+            codexRuntimeUsed: false,
+          },
+        },
       },
     });
     expect(calls).toEqual([]);

--- a/test/unit/handoff-events.test.ts
+++ b/test/unit/handoff-events.test.ts
@@ -176,6 +176,23 @@ describe("handoff event monitor", () => {
         status: "completed",
         finalVerdict: "needs_review",
         finalReason: "GitHub review found medium risk.",
+        codeReview: {
+          finalVerdict: "needs_review",
+          finalReason: "github_needs_review",
+          mergeRecommendation: "needs_review",
+          riskCategory: "workflow",
+          highestRisk: "medium",
+          why: "PR touches deployment scripts; human review recommended.",
+          changedFiles: 2,
+          tests: {
+            matchedTouchedAreas: true,
+            missingTestSignals: [],
+          },
+          verifierLane: {
+            currentRuntime: "structured_github_review",
+            plannedRuntime: "codex_app_server",
+          },
+        },
         github: {
           mergeRecommendation: "needs_review",
           review: {
@@ -208,6 +225,19 @@ describe("handoff event monitor", () => {
       finalVerdict: "needs_review",
       finalReason: "GitHub review found medium risk.",
       mergeRecommendation: "needs_review",
+      codeReview: {
+        finalVerdict: "needs_review",
+        finalReason: "github_needs_review",
+        mergeRecommendation: "needs_review",
+        riskCategory: "workflow",
+        highestRisk: "medium",
+        why: "PR touches deployment scripts; human review recommended.",
+        changedFiles: 2,
+        testsMatchedTouchedAreas: true,
+        missingTestSignals: [],
+        currentRuntime: "structured_github_review",
+        plannedRuntime: "codex_app_server",
+      },
       reviewSignals: {
         touchedAreas: ["workflow", "config"],
         testFilesChanged: false,


### PR DESCRIPTION
Adds a read-only pr_code_review invocation intent for the agent-to-agent hook. The verifier reuses the GitHub PR review evidence, returns a structured codeReview verdict/reasons block, and tags the lane as ready for a future Codex app-server verifier runtime without using it yet.

Also attaches the same codeReview summary to normal pr_handoff results so the monitor and other agents get one consistent merge-readiness contract.

Checks run:
- npm run build
- npm test
- git diff --check

Affected surfaces: Averray MCP hook, handoff monitor summaries, docs/tests. No env or VPS secret changes required.