### PR TITLE
Clarify human review handoff labels

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -249,13 +249,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     <section class="grid" aria-label="Monitor summary">
       <div class="card"><span class="metric">Status</span><span id="status" class="value">...</span></div>
       <div class="card"><span class="metric">Active / Just Finished</span><span id="active-count" class="value">0</span></div>
-      <div class="card"><span class="metric">Blocked / Review</span><span id="gate-count" class="value">0 / 0</span></div>
+      <div class="card"><span class="metric">Blocked / Human Review</span><span id="gate-count" class="value">0 / 0</span></div>
       <div class="card"><span class="metric">Recent</span><span id="recent-count" class="value">0</span></div>
       <div class="card"><span class="metric">Events</span><span id="event-count" class="value">0</span></div>
     </section>
     <div class="section-title"><h2>Live Lane</h2><span id="generated" class="pill">waiting</span></div>
     <section id="active" class="list"><div class="empty">No running or just-finished handoffs.</div></section>
-    <div class="section-title"><h2>Release Gate</h2><span class="pill">block + review</span></div>
+    <div class="section-title"><h2>Release Gate</h2><span class="pill">blocks + human review</span></div>
     <section id="attention" class="list"><div class="empty">No handoffs need attention.</div></section>
     <div class="section-title"><h2>Release Timeline</h2><span class="pill">auto-refresh 5s</span></div>
     <section id="recent" class="list"><div class="empty">Loading recent handoffs...</div></section>
@@ -396,7 +396,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         || includesAny(reason, ["github_needs_review", "pr_review_hold", "needs_review"])
         || reviewReasons.length > 0
       ) {
-        return { level: "needs-review", label: "NEEDS REVIEW" };
+        return { level: "needs-review", label: "HUMAN REVIEW" };
       }
       return { level: "pass", label: "PASS" };
     }
@@ -410,7 +410,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return code + ": " + message;
       }
       const reason = normalize(summary.finalReason || summary.reason || item.reason);
-      if (reason === "github_needs_review") return "GitHub still has a review signal open.";
+      if (reason === "github_needs_review") return "Human review recommended by the GitHub risk gate.";
       if (reason === "pr_review_hold") return "PR risk gate held this for human review.";
       if (reason === "deploy_failure" || reason === "deploy_failed") return "Deploy failed; investigate before release.";
       if (reason === "post_deploy_healthy") return "Post-deploy suite, GitHub workflows, and configured health checks are clean.";

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -720,7 +720,7 @@ function handoffReleaseVerdict(value: Record<string, unknown>, summary: Record<s
     includesToken(finalReason, ["github_needs_review", "pr_review_hold", "needs_review"]) ||
     reviewReasons.length > 0
   ) {
-    return { label: "NEEDS REVIEW", why: handoffWhy(summary, value, "needs_review") };
+    return { label: "HUMAN REVIEW", why: handoffWhy(summary, value, "needs_review") };
   }
   return { label: "PASS", why: handoffWhy(summary, value, "pass") };
 }
@@ -738,7 +738,7 @@ function handoffWhy(summary: Record<string, unknown>, value: Record<string, unkn
   if (reason === "hosted_health_failed") return "hosted health failed after deploy";
   if (reason === "github_workflow_failed") return "GitHub has a failed workflow";
   if (reason === "testbed_cases_failed") return "one or more read-only testbed cases failed";
-  if (reason === "github_needs_review") return "GitHub still has a review signal open";
+  if (reason === "github_needs_review") return "human review recommended by the GitHub risk gate";
   if (reason === "pr_review_hold") return "PR risk gate held this for human review";
   if (reason === "ci_failed") return "CI failed";
   if (level === "pass") return "no blocking release signals recorded";

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -47,14 +47,14 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("<title>Pascal Monitor</title>");
     expect(html).toContain("Live private view of agent-to-agent handoffs.");
     expect(html).toContain("Active / Just Finished");
-    expect(html).toContain("Blocked / Review");
+    expect(html).toContain("Blocked / Human Review");
     expect(html).toContain("Live Lane");
     expect(html).toContain("Live state");
     expect(html).toContain("JUST FINISHED");
     expect(html).toContain("state-pill");
     expect(html).toContain("const eventsPath = \"/monitor/events\";");
     expect(html).toContain("Release Gate");
-    expect(html).toContain("block + review");
+    expect(html).toContain("blocks + human review");
     expect(html).toContain("Release Timeline");
     expect(html).toContain("auto-refresh 5s");
     expect(html).toContain("activeWindowMinutes: \"240\"");


### PR DESCRIPTION
Updates the private handoff monitor and Slack handoff summaries so review-gated PRs read as human review items instead of failures.

What changed:
- Renames the monitor metric to Blocked / Human Review.
- Renames the release gate badge from NEEDS REVIEW to HUMAN REVIEW.
- Makes github_needs_review copy say human review is recommended by the GitHub risk gate.
- Keeps the internal needs-review level/color/filtering unchanged, so true BLOCK remains reserved for hold/failure/high-risk cases.

Checks run:
- npm run build
- npm test -- test/unit/slack-monitor.test.ts test/unit/slack-operator.test.ts
- git diff --check

Affected surfaces: Slack operator private monitor and Slack handoff formatting. No env or VPS secret changes required.