### PR TITLE
Allow low-risk Dependabot steward candidates

### DIFF
--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -702,13 +702,20 @@ export async function getGithubPullRequestReview(
       files: fileSummaries,
       checks: checkSummaries,
     });
-    const riskFindings = buildPullRequestRiskFindings({
+    const initialRiskFindings = buildPullRequestRiskFindings({
       pullRequest: pullRequestSummary,
       files: fileSummaries,
       highRiskFiles,
       checks: checkTotals,
       review: reviewSignals,
       warnings,
+    });
+    const riskFindings = applyDependabotLowRiskPolicy({
+      pullRequest: pullRequestSummary,
+      files: fileSummaries,
+      highRiskFiles,
+      checks: checkTotals,
+      riskFindings: initialRiskFindings,
     });
     const mergeRecommendation = chooseMergeRecommendation(riskFindings);
     const health = warnings.some((warning) => warning.severity === "high")
@@ -1271,6 +1278,56 @@ function buildPullRequestRiskFindings(input: {
   return findings;
 }
 
+function applyDependabotLowRiskPolicy(input: {
+  pullRequest: NonNullable<GithubPullRequestReview["pullRequest"]>;
+  files: GithubPullRequestFileSummary[];
+  highRiskFiles: GithubPullRequestFileRisk[];
+  checks: ReturnType<typeof summarizeChecks>;
+  riskFindings: GithubPullRequestRiskFinding[];
+}): GithubPullRequestRiskFinding[] {
+  if (!isDependabotPullRequest(input.pullRequest)) return input.riskFindings;
+  if (!isPatchOrMinorDependencyBump(input.pullRequest.title)) return input.riskFindings;
+  if (!input.files.every((file) => isDependencyManifestOrLockfile(file.filename))) return input.riskFindings;
+  if (input.checks.total === 0 || input.checks.failed > 0 || input.checks.active > 0) return input.riskFindings;
+  if (input.pullRequest.state !== "open" || input.pullRequest.draft) return input.riskFindings;
+  if (input.pullRequest.mergeableState && ["dirty", "blocked", "unknown"].includes(input.pullRequest.mergeableState)) {
+    return input.riskFindings;
+  }
+  if (input.highRiskFiles.some((file) => file.risk === "high")) return input.riskFindings;
+
+  const remainingFindings = input.riskFindings.filter((finding) => finding.code !== "pr_review_risk_files");
+  if (remainingFindings.some((finding) => finding.severity !== "low")) return input.riskFindings;
+
+  return [
+    ...remainingFindings.filter((finding) => finding.code !== "pr_review_green"),
+    {
+      severity: "low",
+      code: "dependabot_low_risk",
+      message: "Dependabot patch/minor dependency-only PR with green checks.",
+    },
+  ];
+}
+
+function isDependabotPullRequest(pullRequest: NonNullable<GithubPullRequestReview["pullRequest"]>): boolean {
+  return pullRequest.author === "dependabot[bot]" || pullRequest.author === "dependabot";
+}
+
+function isPatchOrMinorDependencyBump(title: string): boolean {
+  const match = title.match(/\bfrom\s+v?(\d+)\.(\d+)\.(\d+)(?:[-+\w.]*)?\s+to\s+v?(\d+)\.(\d+)\.(\d+)(?:[-+\w.]*)?/i)
+    ?? title.match(/\bv?(\d+)\.(\d+)\.(\d+)(?:[-+\w.]*)?\s*(?:->|→|to)\s*v?(\d+)\.(\d+)\.(\d+)(?:[-+\w.]*)?/i);
+  if (!match) return false;
+  const [, fromMajor, fromMinor, fromPatch, toMajor, toMinor, toPatch] = match.map(Number);
+  if (![fromMajor, fromMinor, fromPatch, toMajor, toMinor, toPatch].every(Number.isFinite)) return false;
+  if (toMajor !== fromMajor) return false;
+  if (toMinor > fromMinor) return true;
+  return toMinor === fromMinor && toPatch >= fromPatch;
+}
+
+function isDependencyManifestOrLockfile(filename: string): boolean {
+  const path = filename.toLowerCase();
+  return /(^|\/)(package\.json|package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb)$/.test(path);
+}
+
 function unique<T>(values: T[]): T[] {
   return [...new Set(values)];
 }
@@ -1312,7 +1369,8 @@ function stewardItemFromReview(review: GithubPullRequestReview): GithubMergeStew
     && review.configured
     && review.checks.failed === 0
     && review.checks.active === 0
-    && review.files.highRisk.length === 0
+    && !review.files.highRisk.some((file) => file.risk === "high")
+    && review.riskFindings.every((finding) => finding.severity === "low")
     && pullRequest?.state === "open"
     && pullRequest?.draft === false;
 

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -490,6 +490,115 @@ describe("github operator status", () => {
     });
   });
 
+  it("treats green Dependabot patch and minor dependency bumps as clean steward candidates", async () => {
+    const fetchFn = async (url: string | URL | Request) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent")) {
+        return githubRepoResponse("averray-agent/agent");
+      }
+      if (text.includes("/pulls?")) {
+        return jsonResponse([
+          {
+            number: 191,
+            title: "Bump next from 15.5.15 to 15.5.18",
+            html_url: "https://github.com/averray-agent/agent/pull/191",
+            user: { login: "dependabot[bot]" },
+            draft: false,
+            updated_at: "2026-05-08T10:10:00.000Z",
+            state: "open",
+          },
+          {
+            number: 192,
+            title: "Bump next from 15.5.18 to 16.0.0",
+            html_url: "https://github.com/averray-agent/agent/pull/192",
+            user: { login: "dependabot[bot]" },
+            draft: false,
+            updated_at: "2026-05-08T10:15:00.000Z",
+            state: "open",
+          },
+        ]);
+      }
+      if (text.includes("/issues?")) return jsonResponse([]);
+      if (text.includes("/actions/runs?")) return jsonResponse({ workflow_runs: [] });
+      if (text.endsWith("/repos/averray-agent/agent/pulls/191")) {
+        return jsonResponse({
+          number: 191,
+          title: "Bump next from 15.5.15 to 15.5.18",
+          html_url: "https://github.com/averray-agent/agent/pull/191",
+          user: { login: "dependabot[bot]" },
+          draft: false,
+          state: "open",
+          head: { ref: "dependabot/npm_and_yarn/next-15.5.18", sha: "depPatch123" },
+          changed_files: 2,
+          mergeable_state: "clean",
+        });
+      }
+      if (text.includes("/pulls/191/files")) {
+        return jsonResponse([
+          { filename: "app/package.json", status: "modified", additions: 1, deletions: 1, changes: 2 },
+          { filename: "app/package-lock.json", status: "modified", additions: 20, deletions: 18, changes: 38 },
+        ]);
+      }
+      if (text.includes("/commits/depPatch123/check-runs")) {
+        return jsonResponse({ check_runs: [{ name: "CI", status: "completed", conclusion: "success" }] });
+      }
+      if (text.endsWith("/repos/averray-agent/agent/pulls/192")) {
+        return jsonResponse({
+          number: 192,
+          title: "Bump next from 15.5.18 to 16.0.0",
+          html_url: "https://github.com/averray-agent/agent/pull/192",
+          user: { login: "dependabot[bot]" },
+          draft: false,
+          state: "open",
+          head: { ref: "dependabot/npm_and_yarn/next-16.0.0", sha: "depMajor123" },
+          changed_files: 2,
+          mergeable_state: "clean",
+        });
+      }
+      if (text.includes("/pulls/192/files")) {
+        return jsonResponse([
+          { filename: "app/package.json", status: "modified", additions: 1, deletions: 1, changes: 2 },
+          { filename: "app/package-lock.json", status: "modified", additions: 20, deletions: 18, changes: 38 },
+        ]);
+      }
+      if (text.includes("/commits/depMajor123/check-runs")) {
+        return jsonResponse({ check_runs: [{ name: "CI", status: "completed", conclusion: "success" }] });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const steward = await getGithubMergeSteward({
+      env: {
+        GITHUB_TOKEN: "ghp_readonly",
+        GITHUB_DEFAULT_REPO: "averray-agent/agent",
+      },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(steward).toMatchObject({
+      counts: {
+        openPullRequests: 2,
+        pass: 1,
+        humanReview: 1,
+        block: 0,
+        autoMergeCandidates: 1,
+      },
+    });
+    expect(steward.groups.autoMergeCandidates[0]).toMatchObject({
+      pullRequestNumber: 191,
+      finalVerdict: "pass",
+      reason: "dependabot_low_risk",
+      canAutoMergeIfEnabled: true,
+    });
+    expect(steward.groups.humanReview[0]).toMatchObject({
+      pullRequestNumber: 192,
+      finalVerdict: "human_review",
+      reason: "pr_review_risk_files",
+      canAutoMergeIfEnabled: false,
+    });
+  });
+
   it("asks for human review on deploy and workflow-only risk", async () => {
     const fetchFn = async (url: string | URL | Request) => {
       const text = String(url);


### PR DESCRIPTION
## Summary
- Classify Dependabot patch/minor dependency-only PRs with green checks as clean merge-steward candidates
- Keep major bumps, dirty/blocked merge states, non-dependency files, missing checks, and failed/running checks under human review or block
- Add regression coverage for patch/minor vs major Dependabot PRs

## Checks
- npm test -- test/unit/operator-github.test.ts test/unit/slack-operator.test.ts
- npm run build
- git diff --check

## Surfaces
- Backend/MCP: GitHub merge steward policy only
- Slack/UI/deploy/contracts: no direct changes

## Safety
- Read-only steward behavior only; no GitHub mutations or merge execution enabled