### PR TITLE
Add gated merge steward approval path

### DIFF
--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -47,7 +47,7 @@ import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./o
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getProjectMemory } from "./operator-project-memory.js";
 import { getProjectRunbook } from "./operator-project-runbook.js";
-import { getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
+import { approveGithubMergeStewardCandidate, getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
 import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { invokeAgentTask } from "./agent-invocation.js";
 import { getHandoffMonitor } from "./handoff-events.js";
@@ -259,6 +259,19 @@ server.tool(
   {},
   async () => {
     return jsonContent(await getGithubOperatorBrief({ query }));
+  }
+);
+
+server.tool(
+  "averray_approve_github_merge_steward_candidate",
+  "Approval-gated GitHub merge executor for the narrow merge-steward path. Requires GITHUB_MERGE_STEWARD_EXECUTION_ENABLED=1, an explicit repo and PR number, green checks, and a low-risk Dependabot patch/minor dependency-only steward verdict. It mutates GitHub only by merging that eligible PR; it never edits code, deploys directly, edits Wikipedia, or merges human-review/block PRs.",
+  {
+    repo: z.string().min(1),
+    pullRequestNumber: z.number().int().min(1),
+    approvalText: z.string().min(1).optional()
+  },
+  async (input) => {
+    return jsonContent(await approveGithubMergeStewardCandidate(input));
   }
 );
 

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,6 +1,6 @@
 import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
 import type { AdminActionKind, AdminActionProposalInput } from "./operator-admin.js";
-import type { GithubOperatorView } from "./operator-github.js";
+import type { GithubMergeStewardApprovalInput, GithubOperatorView } from "./operator-github.js";
 
 export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes" | "agent";
 
@@ -109,6 +109,13 @@ export type ParsedOperatorCommand =
     }
   | {
       handled: true;
+      kind: "github_merge_steward_approval";
+      source: OperatorCommandSource;
+      detailed: boolean;
+      input: GithubMergeStewardApprovalInput;
+    }
+  | {
+      handled: true;
       kind: "testbed_e2e_suite";
       source: OperatorCommandSource;
       detailed: boolean;
@@ -179,6 +186,7 @@ const EXAMPLES = [
   "daily github brief",
   "github steward",
   "merge steward",
+  "merge steward approve averray-agent/agent#123",
   "what changed since last time",
   "github open prs",
   "github ci failures",
@@ -240,6 +248,11 @@ export function parseOperatorCommand(
 
   if (isAdminReadinessCommand(normalizedText)) {
     return { handled: true, kind: "admin_readiness", source, detailed };
+  }
+
+  const mergeStewardApproval = githubMergeStewardApprovalInput(text, normalizedText);
+  if (mergeStewardApproval) {
+    return { handled: true, kind: "github_merge_steward_approval", source, detailed, input: mergeStewardApproval };
   }
 
   const adminProposal = adminActionProposalInput(text, normalizedText, source);
@@ -564,6 +577,26 @@ function isGithubBriefCommand(text: string): boolean {
 function isGithubMergeStewardCommand(text: string): boolean {
   const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
   return /^(github steward|merge steward|pr steward|pull request steward|github merge steward|take care of open prs|drain open prs|review open prs)$/.test(compact);
+}
+
+function githubMergeStewardApprovalInput(
+  originalText: string,
+  text: string
+): Pick<GithubMergeStewardApprovalInput, "repo" | "pullRequestNumber" | "approvalText"> | undefined {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  if (!/\bmerge steward\b/.test(compact) || !/\b(approve|approved|execute|merge)\b/.test(compact)) return undefined;
+  const repoWithPr = originalText.match(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#(\d+)\b/);
+  const repo = repoWithPr?.[1]
+    ?? extractToken(originalText, /\b(?:repo|repository|for)\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)/i);
+  const pullRequestNumber = repoWithPr?.[2]
+    ? Number.parseInt(repoWithPr[2], 10)
+    : numberToken(originalText, /\b(?:pr|pull request|pull-request|#)\s*#?(\d+)\b/i);
+  if (!repo || !pullRequestNumber) return undefined;
+  return {
+    repo,
+    pullRequestNumber,
+    approvalText: originalText.trim(),
+  };
 }
 
 function isTestbedE2eSuiteCommand(text: string): boolean {

--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -231,6 +231,45 @@ export interface GithubMergeSteward {
   recommendations: string[];
 }
 
+export interface GithubMergeStewardApprovalInput {
+  repo?: string;
+  pullRequestNumber?: number;
+  approvalText?: string;
+  env?: NodeJS.ProcessEnv;
+  fetchFn?: typeof fetch;
+  now?: Date;
+}
+
+export interface GithubMergeStewardApproval {
+  schemaVersion: 1;
+  generatedAt: string;
+  mutatesGithub: boolean;
+  executionEnabled: boolean;
+  configured: boolean;
+  authConfigured: boolean;
+  status: "merged" | "blocked" | "failed";
+  repo?: string;
+  pullRequestNumber?: number;
+  finalVerdict?: GithubMergeStewardVerdict;
+  mergeRecommendation?: GithubPullRequestMergeRecommendation;
+  reason: string;
+  reviewReasons: GithubPullRequestRiskFinding[];
+  merge?: {
+    merged?: boolean;
+    sha?: string;
+    message?: string;
+  };
+  safety: {
+    requiresExplicitCommand: true;
+    requiresEnvFlag: true;
+    onlyLowRiskDependabot: true;
+    githubMutated: boolean;
+    wikipediaEdited: false;
+  };
+  warnings: GithubWarning[];
+  recommendations: string[];
+}
+
 export type GithubPullRequestTouchedArea =
   | "frontend"
   | "backend"
@@ -858,6 +897,162 @@ export async function getGithubMergeSteward(
   };
 }
 
+export async function approveGithubMergeStewardCandidate(
+  options: GithubMergeStewardApprovalInput = {}
+): Promise<GithubMergeStewardApproval> {
+  const env = options.env ?? process.env;
+  const generatedAt = (options.now ?? new Date()).toISOString();
+  const repo = normalizeRepo(options.repo ?? "");
+  const pullRequestNumber = options.pullRequestNumber;
+  const executionEnabled = isTruthy(env.GITHUB_MERGE_STEWARD_EXECUTION_ENABLED);
+  const warnings: GithubWarning[] = [];
+
+  if (!repo || !pullRequestNumber) {
+    warnings.push({
+      severity: "high",
+      code: "github_merge_target_missing",
+      message: "Set an explicit target like merge steward approve owner/repo#123.",
+    });
+    return mergeApprovalBlocked({
+      generatedAt,
+      executionEnabled,
+      repo,
+      pullRequestNumber,
+      reason: "target_missing",
+      warnings,
+      recommendations: ["Use `merge steward approve owner/repo#123` with the exact PR target."],
+    });
+  }
+
+  const review = await getGithubPullRequestReview({
+    repo,
+    pullRequestNumber,
+    env,
+    fetchFn: options.fetchFn,
+    now: options.now,
+  });
+  const stewardItem = stewardItemFromReview(review);
+  warnings.push(...review.warnings);
+
+  if (!executionEnabled) {
+    return mergeApprovalBlocked({
+      generatedAt,
+      executionEnabled,
+      repo,
+      pullRequestNumber,
+      review,
+      stewardItem,
+      reason: "merge_execution_disabled",
+      warnings,
+      recommendations: ["Set GITHUB_MERGE_STEWARD_EXECUTION_ENABLED=1 only when you want explicit steward merge commands to mutate GitHub."],
+    });
+  }
+
+  if (!stewardItem.canAutoMergeIfEnabled) {
+    return mergeApprovalBlocked({
+      generatedAt,
+      executionEnabled,
+      repo,
+      pullRequestNumber,
+      review,
+      stewardItem,
+      reason: stewardItem.reason,
+      warnings,
+      recommendations: ["Do not merge. Resolve the steward finding, then rerun the merge steward before asking for approval again."],
+    });
+  }
+
+  if (!review.riskFindings.some((finding) => finding.code === "dependabot_low_risk")) {
+    return mergeApprovalBlocked({
+      generatedAt,
+      executionEnabled,
+      repo,
+      pullRequestNumber,
+      review,
+      stewardItem,
+      reason: "not_low_risk_dependabot",
+      warnings,
+      recommendations: ["This first execution phase only merges low-risk Dependabot patch/minor dependency candidates."],
+    });
+  }
+
+  const tokenConfig = buildGithubTokenConfig(env);
+  const token = resolveGithubTokenForRepo(repo, tokenConfig);
+  if (!token) {
+    warnings.push({
+      severity: "high",
+      code: "github_repo_token_missing",
+      repo,
+      message: `No GitHub token is configured for ${repo}.`,
+    });
+    return mergeApprovalBlocked({
+      generatedAt,
+      executionEnabled,
+      repo,
+      pullRequestNumber,
+      review,
+      stewardItem,
+      reason: "github_repo_token_missing",
+      warnings,
+      recommendations: ["Configure a GitHub token with pull-request write permission for the target repository."],
+    });
+  }
+
+  try {
+    const baseUrl = (env.GITHUB_API_BASE_URL ?? "https://api.github.com").replace(/\/+$/g, "");
+    const mergeMethod = githubMergeMethod(env.GITHUB_MERGE_STEWARD_METHOD);
+    const merge = await githubRequest<{ merged?: boolean; sha?: string; message?: string }>({
+      url: `${baseUrl}/repos/${encodeRepoPath(repo)}/pulls/${pullRequestNumber}/merge`,
+      token,
+      fetchFn: options.fetchFn ?? fetch,
+      method: "PUT",
+      body: {
+        merge_method: mergeMethod,
+        commit_title: `${review.pullRequest?.title ?? `PR #${pullRequestNumber}`} (#${pullRequestNumber})`,
+        commit_message: "Merged by Averray merge steward after explicit operator approval.",
+      },
+    });
+    return {
+      schemaVersion: 1,
+      generatedAt,
+      mutatesGithub: true,
+      executionEnabled,
+      configured: review.configured,
+      authConfigured: true,
+      status: merge.merged === false ? "failed" : "merged",
+      repo,
+      pullRequestNumber,
+      finalVerdict: stewardItem.finalVerdict,
+      mergeRecommendation: stewardItem.mergeRecommendation,
+      reason: merge.merged === false ? "github_merge_not_confirmed" : "merged_low_risk_dependabot",
+      reviewReasons: stewardItem.reviewReasons,
+      merge,
+      safety: mergeApprovalSafety(true),
+      warnings,
+      recommendations: ["Watch CI and the production deploy workflow after the merge lands on main."],
+    };
+  } catch (error) {
+    warnings.push({
+      severity: "high",
+      code: "github_merge_failed",
+      repo,
+      message: error instanceof Error ? error.message : `Failed to merge ${repo}#${pullRequestNumber}.`,
+    });
+    return mergeApprovalBlocked({
+      generatedAt,
+      executionEnabled,
+      repo,
+      pullRequestNumber,
+      review,
+      stewardItem,
+      reason: "github_merge_failed",
+      warnings,
+      recommendations: ["Do not retry blindly. Check the GitHub merge error, branch protection, and merge queue state first."],
+      status: "failed",
+    });
+  }
+}
+
 function emptyStatus(input: {
   generatedAt: string;
   view: GithubOperatorView;
@@ -1396,6 +1591,48 @@ function stewardItemFromReview(review: GithubPullRequestReview): GithubMergeStew
   };
 }
 
+function mergeApprovalBlocked(input: {
+  generatedAt: string;
+  executionEnabled: boolean;
+  repo?: string;
+  pullRequestNumber?: number;
+  review?: GithubPullRequestReview;
+  stewardItem?: GithubMergeStewardItem;
+  reason: string;
+  warnings: GithubWarning[];
+  recommendations: string[];
+  status?: "blocked" | "failed";
+}): GithubMergeStewardApproval {
+  return {
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    mutatesGithub: false,
+    executionEnabled: input.executionEnabled,
+    configured: input.review?.configured ?? false,
+    authConfigured: input.review?.authConfigured ?? false,
+    status: input.status ?? "blocked",
+    ...(input.repo ? { repo: input.repo } : {}),
+    ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+    ...(input.stewardItem ? { finalVerdict: input.stewardItem.finalVerdict } : {}),
+    ...(input.stewardItem ? { mergeRecommendation: input.stewardItem.mergeRecommendation } : {}),
+    reason: input.reason,
+    reviewReasons: input.stewardItem?.reviewReasons ?? [],
+    safety: mergeApprovalSafety(false),
+    warnings: input.warnings,
+    recommendations: input.recommendations,
+  };
+}
+
+function mergeApprovalSafety(githubMutated: boolean): GithubMergeStewardApproval["safety"] {
+  return {
+    requiresExplicitCommand: true,
+    requiresEnvFlag: true,
+    onlyLowRiskDependabot: true,
+    githubMutated,
+    wikipediaEdited: false,
+  };
+}
+
 function buildMergeStewardRecommendations(input: {
   autoMergeCandidates: GithubMergeStewardItem[];
   humanReview: GithubMergeStewardItem[];
@@ -1721,17 +1958,30 @@ function mapWorkflowRuns(runs: GithubApiWorkflowRun[], repo: string, limit: numb
 }
 
 async function githubGet<T>(url: string, token: string, fetchFn: typeof fetch): Promise<T> {
-  const response = await fetchFn(url, {
+  return await githubRequest<T>({ url, token, fetchFn });
+}
+
+async function githubRequest<T>(input: {
+  url: string;
+  token: string;
+  fetchFn: typeof fetch;
+  method?: string;
+  body?: unknown;
+}): Promise<T> {
+  const response = await input.fetchFn(input.url, {
+    ...(input.method ? { method: input.method } : {}),
     headers: {
       accept: "application/vnd.github+json",
-      authorization: `Bearer ${token}`,
+      authorization: `Bearer ${input.token}`,
+      ...(input.body === undefined ? {} : { "content-type": "application/json" }),
       "user-agent": "averray-reference-agent-github-helper",
       "x-github-api-version": "2022-11-28",
     },
+    ...(input.body === undefined ? {} : { body: JSON.stringify(input.body) }),
   });
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(`GitHub API ${response.status} for ${url}${text ? `: ${text.slice(0, 180)}` : ""}`);
+    throw new Error(`GitHub API ${response.status} for ${input.url}${text ? `: ${text.slice(0, 180)}` : ""}`);
   }
   return await response.json() as T;
 }
@@ -1764,6 +2014,14 @@ function toEnvKey(value: string): string {
 function encodeRepoPath(repo: string): string {
   const [owner, name] = repo.split("/");
   return `${encodeURIComponent(owner ?? "")}/${encodeURIComponent(name ?? "")}`;
+}
+
+function githubMergeMethod(value: string | undefined): "merge" | "squash" | "rebase" {
+  return value === "merge" || value === "rebase" ? value : "squash";
+}
+
+function isTruthy(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true" || value?.toLowerCase() === "yes";
 }
 
 function clampLimit(value: string | undefined): number {

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -7,7 +7,12 @@ import {
 } from "./operator-commands.js";
 import { getAdminActionProposal, getAdminReadiness } from "./operator-admin.js";
 import { getBusinessLedger, getOpsHealth } from "./operator-insights.js";
-import { getGithubMergeSteward, getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
+import {
+  approveGithubMergeStewardCandidate,
+  getGithubMergeSteward,
+  getGithubOperatorBrief,
+  getGithubOperatorStatus,
+} from "./operator-github.js";
 import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./operator-status.js";
 import { getProjectMemory } from "./operator-project-memory.js";
 import { getProjectRunbook } from "./operator-project-runbook.js";
@@ -106,6 +111,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "github_merge_steward") {
     const github = await getGithubMergeSteward();
     return { ...command, github };
+  }
+  if (command.kind === "github_merge_steward_approval") {
+    const approval = await approveGithubMergeStewardCandidate(command.input);
+    return { ...command, approval };
   }
   if (command.kind === "run_testbed_e2e_read_only") {
     const run = await runTestbedE2eReadOnly({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -349,6 +349,9 @@ export function formatOperatorResultForSlack(result: unknown): string {
   if (result.kind === "github_merge_steward") {
     return formatGithubMergeStewardForSlack(result);
   }
+  if (result.kind === "github_merge_steward_approval") {
+    return formatGithubMergeStewardApprovalForSlack(result);
+  }
   if (result.kind === "run_testbed_e2e_read_only") {
     return formatTestbedE2eReadOnlyRunForSlack(result);
   }
@@ -604,6 +607,33 @@ function formatGithubMergeStewardForSlack(result: Record<string, unknown>): stri
     blocked.length > 0 ? `*Blocked*\n${blocked.slice(0, 5).map(formatGithubStewardItem).join("\n")}` : "",
     recommendations.length > 0 ? `*Next*\n${recommendations.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
     "Read-only steward. Hermes did not merge, approve, rerun CI, or mutate GitHub.",
+  ].filter(Boolean).join("\n");
+}
+
+function formatGithubMergeStewardApprovalForSlack(result: Record<string, unknown>): string {
+  const approval = isRecord(result.approval) ? result.approval : {};
+  const warnings = arrayField(approval, "warnings");
+  const recommendations = arrayField(approval, "recommendations");
+  const repo = stringField(approval, "repo") ?? "unknown";
+  const pullRequestNumber = numberField(approval, "pullRequestNumber") ?? 0;
+  const status = stringField(approval, "status") ?? "unknown";
+  const reason = stringField(approval, "reason") ?? "no_reason";
+  const target = pullRequestNumber > 0 ? `${repo}#${pullRequestNumber}` : repo;
+
+  return [
+    "*GitHub merge steward approval*",
+    `• target: \`${target}\``,
+    `• status: \`${status}\``,
+    `• reason: \`${reason}\``,
+    `• execution enabled: \`${String(approval.executionEnabled === true)}\``,
+    `• mutated GitHub: \`${String(approval.mutatesGithub === true)}\``,
+    stringField(approval, "finalVerdict") ? `• steward verdict: \`${stringField(approval, "finalVerdict")}\`` : "",
+    stringField(approval, "mergeRecommendation") ? `• merge recommendation: \`${stringField(approval, "mergeRecommendation")}\`` : "",
+    warnings.length > 0 ? `*Warnings*\n${warnings.slice(0, 3).map(formatGithubWarning).join("\n")}` : "",
+    recommendations.length > 0 ? `*Next*\n${recommendations.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
+    approval.mutatesGithub === true
+      ? "GitHub was mutated only through the explicit merge approval path."
+      : "No GitHub mutation was performed.",
   ].filter(Boolean).join("\n");
 }
 

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -277,6 +277,17 @@ describe("operator commands", () => {
       source: "operator",
       detailed: false,
     });
+    expect(parseOperatorCommand("merge steward approve averray-agent/agent#191", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "github_merge_steward_approval",
+      source: "slack",
+      detailed: false,
+      input: {
+        repo: "averray-agent/agent",
+        pullRequestNumber: 191,
+        approvalText: "merge steward approve averray-agent/agent#191",
+      },
+    });
   });
 
   it("routes the platform testbed E2E suite read-only", () => {

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  approveGithubMergeStewardCandidate,
   getGithubMergeSteward,
   getGithubOperatorBrief,
   getGithubOperatorStatus,
@@ -599,6 +600,79 @@ describe("github operator status", () => {
     });
   });
 
+  it("blocks merge steward approvals unless execution is enabled", async () => {
+    const approval = await approveGithubMergeStewardCandidate({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 191,
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      fetchFn: dependabotPatchFetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(approval).toMatchObject({
+      mutatesGithub: false,
+      executionEnabled: false,
+      status: "blocked",
+      repo: "averray-agent/agent",
+      pullRequestNumber: 191,
+      finalVerdict: "pass",
+      mergeRecommendation: "ok_to_merge",
+      reason: "merge_execution_disabled",
+      safety: {
+        requiresExplicitCommand: true,
+        requiresEnvFlag: true,
+        onlyLowRiskDependabot: true,
+        githubMutated: false,
+        wikipediaEdited: false,
+      },
+    });
+  });
+
+  it("merges only approved low-risk Dependabot steward candidates when execution is enabled", async () => {
+    let mergeRequest: { method?: string; body?: unknown } | undefined;
+    const fetchFn = async (url: string | URL | Request, init?: RequestInit) => {
+      const text = String(url);
+      if (text.endsWith("/repos/averray-agent/agent/pulls/191/merge")) {
+        mergeRequest = { method: init?.method, body: init?.body ? JSON.parse(String(init.body)) : undefined };
+        return jsonResponse({ merged: true, sha: "merge-sha", message: "Pull Request successfully merged" });
+      }
+      return dependabotPatchFetchFn(url, init);
+    };
+
+    const approval = await approveGithubMergeStewardCandidate({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 191,
+      env: {
+        GITHUB_TOKEN: "ghp_write",
+        GITHUB_MERGE_STEWARD_EXECUTION_ENABLED: "1",
+      },
+      fetchFn,
+      now: new Date("2026-05-08T12:30:00.000Z"),
+    });
+
+    expect(approval).toMatchObject({
+      mutatesGithub: true,
+      executionEnabled: true,
+      status: "merged",
+      reason: "merged_low_risk_dependabot",
+      merge: {
+        merged: true,
+        sha: "merge-sha",
+      },
+      safety: {
+        githubMutated: true,
+        wikipediaEdited: false,
+      },
+    });
+    expect(mergeRequest).toMatchObject({
+      method: "PUT",
+      body: {
+        merge_method: "squash",
+        commit_title: "Bump next from 15.5.15 to 15.5.18 (#191)",
+      },
+    });
+  });
+
   it("asks for human review on deploy and workflow-only risk", async () => {
     const fetchFn = async (url: string | URL | Request) => {
       const text = String(url);
@@ -846,6 +920,33 @@ function githubRepoResponse(fullName: string): Response {
     private: true,
     html_url: `https://github.com/${fullName}`,
   });
+}
+
+async function dependabotPatchFetchFn(url: string | URL | Request, _init?: RequestInit): Promise<Response> {
+  const text = String(url);
+  if (text.endsWith("/repos/averray-agent/agent/pulls/191")) {
+    return jsonResponse({
+      number: 191,
+      title: "Bump next from 15.5.15 to 15.5.18",
+      html_url: "https://github.com/averray-agent/agent/pull/191",
+      user: { login: "dependabot[bot]" },
+      draft: false,
+      state: "open",
+      head: { ref: "dependabot/npm_and_yarn/next-15.5.18", sha: "depPatch123" },
+      changed_files: 2,
+      mergeable_state: "clean",
+    });
+  }
+  if (text.includes("/pulls/191/files")) {
+    return jsonResponse([
+      { filename: "app/package.json", status: "modified", additions: 1, deletions: 1, changes: 2 },
+      { filename: "app/package-lock.json", status: "modified", additions: 20, deletions: 18, changes: 38 },
+    ]);
+  }
+  if (text.includes("/commits/depPatch123/check-runs")) {
+    return jsonResponse({ check_runs: [{ name: "CI", status: "completed", conclusion: "success" }] });
+  }
+  return new Response("not found", { status: 404 });
 }
 
 function headersObject(headers: HeadersInit | undefined): Record<string, string> {

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -772,6 +772,32 @@ describe("slack operator bridge", () => {
     expect(text).toContain("Hermes did not merge");
   });
 
+  it("formats GitHub merge steward approval replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "github_merge_steward_approval",
+      approval: {
+        status: "blocked",
+        repo: "averray-agent/agent",
+        pullRequestNumber: 191,
+        executionEnabled: false,
+        mutatesGithub: false,
+        finalVerdict: "pass",
+        mergeRecommendation: "ok_to_merge",
+        reason: "merge_execution_disabled",
+        warnings: [],
+        recommendations: ["Set GITHUB_MERGE_STEWARD_EXECUTION_ENABLED=1."],
+      },
+    });
+
+    expect(text).toContain("*GitHub merge steward approval*");
+    expect(text).toContain("target: `averray-agent/agent#191`");
+    expect(text).toContain("status: `blocked`");
+    expect(text).toContain("reason: `merge_execution_disabled`");
+    expect(text).toContain("mutated GitHub: `false`");
+    expect(text).toContain("No GitHub mutation was performed.");
+  });
+
   it("formats testbed E2E suite replies", () => {
     const text = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## Summary
- Add an explicit merge steward approve owner/repo#PR command path
- Add an MCP tool for the same gated action
- Require GITHUB_MERGE_STEWARD_EXECUTION_ENABLED=1 before any GitHub mutation
- Restrict first execution phase to low-risk Dependabot patch/minor dependency-only PRs already classified as clean steward candidates
- Add Slack formatting and regression tests for disabled and successful approval paths

## Checks
- npm test -- test/unit/operator-github.test.ts test/unit/operator-commands.test.ts test/unit/slack-operator.test.ts
- npm run build
- git diff --check

## Surfaces
- Backend/MCP: GitHub merge steward approval path
- Slack: formatter for approval result
- GitHub mutation: only explicit PR merge when env flag and low-risk Dependabot checks pass

## Safety
- Default remains non-mutating
- Human-review and blocked PRs cannot merge through this path
- Non-Dependabot clean candidates cannot merge through this first execution phase
- No deploys, Wikipedia edits, code edits, workflow reruns, or issue/PR comments are performed