### PR TITLE
Add Slack alerts for stale PR handoffs

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -27,6 +27,11 @@ import {
   parseMonitorConfig,
   renderMonitorHtml,
 } from "./monitor.js";
+import {
+  formatStalePrAlertForSlack,
+  shouldPostStalePrAlert,
+  stalePrAlertItems,
+} from "./stale-pr-alerts.js";
 
 const enabled = optionalEnv("SLACK_OPERATOR_ENABLED", "0") === "1";
 const httpPort = Number.parseInt(optionalEnv("SLACK_OPERATOR_HTTP_PORT", "8790"), 10);
@@ -59,6 +64,8 @@ logger.info({
     opsHealth: routineConfig.opsHealth.enabled,
     opsHealthTimeUtc: `${String(routineConfig.opsHealth.timeUtc.hour).padStart(2, "0")}:${String(routineConfig.opsHealth.timeUtc.minute).padStart(2, "0")}`,
     safeWorkScanIntervalMs: routineConfig.safeWorkScan.enabled ? routineConfig.safeWorkScan.intervalMs : 0,
+    stalePrAlertIntervalMs: routineConfig.stalePrAlerts.enabled ? routineConfig.stalePrAlerts.intervalMs : 0,
+    stalePrAlertAfterMinutes: routineConfig.stalePrAlerts.staleAfterMinutes,
   },
   monitor: {
     enabled: monitorConfig.enabled,
@@ -107,6 +114,11 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           enabled: routineConfig.safeWorkScan.enabled,
           intervalMs: routineConfig.safeWorkScan.enabled ? routineConfig.safeWorkScan.intervalMs : 0,
           notifyOnlyOnAvailable: routineConfig.safeWorkScan.notifyOnlyOnAvailable,
+        },
+        stalePrAlerts: {
+          enabled: routineConfig.stalePrAlerts.enabled,
+          intervalMs: routineConfig.stalePrAlerts.enabled ? routineConfig.stalePrAlerts.intervalMs : 0,
+          staleAfterMinutes: routineConfig.stalePrAlerts.staleAfterMinutes,
         },
       },
       monitor: {
@@ -282,6 +294,7 @@ function startOperatorRoutines() {
       || routineConfig.dailyGithubBrief.enabled
       || routineConfig.opsHealth.enabled
       || routineConfig.safeWorkScan.enabled
+      || routineConfig.stalePrAlerts.enabled
     ) {
       logger.warn("slack_operator_routines_no_channel");
     }
@@ -292,10 +305,12 @@ function startOperatorRoutines() {
   let lastDailyGithubBriefDateKey: string | undefined;
   let lastOpsHealthDateKey: string | undefined;
   let lastSafeWorkSignature: string | undefined;
+  let lastStalePrSignature: string | undefined;
   let dailyBriefRunning = false;
   let dailyGithubBriefRunning = false;
   let opsHealthRunning = false;
   let safeWorkRunning = false;
+  let stalePrAlertsRunning = false;
 
   const checkDailyBrief = async () => {
     if (dailyBriefRunning) return;
@@ -385,6 +400,47 @@ function startOperatorRoutines() {
     }
   };
 
+  const checkStalePrAlerts = async () => {
+    if (stalePrAlertsRunning || !routineConfig.stalePrAlerts.enabled) return;
+    stalePrAlertsRunning = true;
+    try {
+      const monitor = await getHandoffMonitor({ limit: 100, activeWindowMinutes: 24 * 60 });
+      const items = stalePrAlertItems({
+        monitor,
+        staleAfterMinutes: routineConfig.stalePrAlerts.staleAfterMinutes,
+      });
+      const decision = shouldPostStalePrAlert(items, lastStalePrSignature);
+      if (!decision.shouldPost) return;
+      const text = formatStalePrAlertForSlack(items, optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor"));
+      const replyPermalink = await postSlack(routineEnvelope("stale PR handoff alert"), text);
+      const result = {
+        kind: "stale_pr_handoff_alert",
+        staleCount: items.length,
+        staleAfterMinutes: routineConfig.stalePrAlerts.staleAfterMinutes,
+        items,
+        safety: {
+          readOnly: true,
+          mutatesGithub: false,
+          mutatesAverray: false,
+          editsWikipedia: false,
+        },
+      };
+      await recordOperatorCommandEvent({
+        source: "slack_routine",
+        commandText: "stale PR handoff alert",
+        channelId: routineConfig.channelId,
+        replyPermalink,
+        result,
+      }, query);
+      lastStalePrSignature = decision.signature;
+      logger.info({ staleCount: items.length, signature: decision.signature }, "slack_operator_stale_pr_alert_posted");
+    } catch (error) {
+      logger.error({ err: error }, "slack_operator_stale_pr_alert_failed");
+    } finally {
+      stalePrAlertsRunning = false;
+    }
+  };
+
   if (routineConfig.dailyBrief.enabled) {
     setTimeout(() => void checkDailyBrief(), 5_000);
     setInterval(() => void checkDailyBrief(), 60_000);
@@ -400,6 +456,10 @@ function startOperatorRoutines() {
   if (routineConfig.safeWorkScan.enabled) {
     setTimeout(() => void checkSafeWork(), 10_000);
     setInterval(() => void checkSafeWork(), routineConfig.safeWorkScan.intervalMs);
+  }
+  if (routineConfig.stalePrAlerts.enabled) {
+    setTimeout(() => void checkStalePrAlerts(), 12_000);
+    setInterval(() => void checkStalePrAlerts(), routineConfig.stalePrAlerts.intervalMs);
   }
 }
 

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -18,6 +18,11 @@ export interface SlackRoutineConfig {
     intervalMs: number;
     notifyOnlyOnAvailable: boolean;
   };
+  stalePrAlerts: {
+    enabled: boolean;
+    intervalMs: number;
+    staleAfterMinutes: number;
+  };
 }
 
 export function parseSlackRoutineConfig(
@@ -28,6 +33,7 @@ export function parseSlackRoutineConfig(
     || firstSetValue(allowedChannelIds)
     || env.SLACK_OPERATOR_CHANNEL_ID;
   const safeWorkMinutes = positiveNumber(env.SLACK_OPERATOR_SAFE_WORK_SCAN_INTERVAL_MINUTES);
+  const stalePrMinutes = positiveNumber(env.SLACK_OPERATOR_STALE_PR_ALERT_INTERVAL_MINUTES);
   return {
     channelId,
     dailyBrief: {
@@ -51,6 +57,11 @@ export function parseSlackRoutineConfig(
       enabled: safeWorkMinutes > 0,
       intervalMs: Math.max(60_000, safeWorkMinutes * 60_000),
       notifyOnlyOnAvailable: env.SLACK_OPERATOR_SAFE_WORK_NOTIFY_ONLY_ON_AVAILABLE !== "0",
+    },
+    stalePrAlerts: {
+      enabled: stalePrMinutes > 0,
+      intervalMs: Math.max(60_000, stalePrMinutes * 60_000),
+      staleAfterMinutes: positiveNumber(env.SLACK_OPERATOR_STALE_PR_ALERT_AFTER_MINUTES) || 120,
     },
   };
 }

--- a/services/slack-operator/src/stale-pr-alerts.ts
+++ b/services/slack-operator/src/stale-pr-alerts.ts
@@ -1,0 +1,215 @@
+export interface StalePrAlertItem {
+  correlationId: string;
+  repo: string;
+  pullRequestNumber?: number;
+  pullRequestUrl?: string;
+  owner: string;
+  ageMinutes: number;
+  ageLabel: string;
+  nextAction: string;
+  reason: string;
+  updatedAt?: string;
+}
+
+export interface StalePrAlertInput {
+  monitor: unknown;
+  staleAfterMinutes: number;
+  now?: Date;
+}
+
+export function stalePrAlertItems(input: StalePrAlertInput): StalePrAlertItem[] {
+  const now = input.now ?? new Date();
+  const monitor = toRecord(input.monitor);
+  const candidates = [...arrayField(monitor, "active"), ...arrayField(monitor, "recent")];
+  const seen = new Set<string>();
+  const items: StalePrAlertItem[] = [];
+  for (const value of candidates) {
+    const item = toRecord(value);
+    if (!isPrHandoff(item)) continue;
+    const correlationId = stringField(item, "correlationId") ?? "";
+    const key = correlationId || `${stringField(item, "repo") ?? "unknown"}#${numberField(item, "pullRequestNumber") ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const updatedAt = stringField(item, "updatedAt");
+    const ageMinutes = ageInMinutes(updatedAt, now);
+    if (ageMinutes < input.staleAfterMinutes) continue;
+    const verdict = releaseVerdict(item);
+    const owner = nextOwner(item, verdict);
+    items.push({
+      correlationId: correlationId || key,
+      repo: stringField(item, "repo") ?? "unknown repo",
+      pullRequestNumber: numberField(item, "pullRequestNumber"),
+      pullRequestUrl: stringField(item, "pullRequestUrl") ?? derivePullRequestUrl(item),
+      owner,
+      ageMinutes,
+      ageLabel: formatDuration(ageMinutes),
+      nextAction: nextActionText(owner, verdict),
+      reason: releaseReason(item, verdict),
+      updatedAt,
+    });
+  }
+  return items.sort((a, b) => b.ageMinutes - a.ageMinutes);
+}
+
+export function stalePrAlertSignature(items: StalePrAlertItem[]): string | undefined {
+  if (items.length === 0) return undefined;
+  return items
+    .map((item) => `${item.correlationId}:${item.owner}:${Math.floor(item.ageMinutes / 30)}`)
+    .sort()
+    .join("|");
+}
+
+export function shouldPostStalePrAlert(
+  items: StalePrAlertItem[],
+  previousSignature: string | undefined
+): { shouldPost: boolean; signature?: string } {
+  const signature = stalePrAlertSignature(items);
+  if (!signature) return { shouldPost: false };
+  return { shouldPost: signature !== previousSignature, signature };
+}
+
+export function formatStalePrAlertForSlack(items: StalePrAlertItem[], monitorUrl?: string): string {
+  const header = `*Hermes stale PR handoffs* — ${items.length} need attention`;
+  const lines = items.slice(0, 8).map((item) => {
+    const pr = item.pullRequestUrl
+      ? `<${item.pullRequestUrl}|${item.repo}${item.pullRequestNumber ? ` #${item.pullRequestNumber}` : ""}>`
+      : `${item.repo}${item.pullRequestNumber ? ` #${item.pullRequestNumber}` : ""}`;
+    return [
+      `• ${pr}`,
+      `owner: \`${item.owner}\``,
+      `age: \`${item.ageLabel}\``,
+      `next: ${item.nextAction}`,
+      `why: ${item.reason}`,
+    ].join(" · ");
+  });
+  const extra = items.length > 8 ? [`• plus ${items.length - 8} more stale handoff${items.length - 8 === 1 ? "" : "s"}`] : [];
+  const footer = monitorUrl ? [`Open monitor: ${monitorUrl}`] : [];
+  return [header, ...lines, ...extra, ...footer].join("\n");
+}
+
+function isPrHandoff(item: Record<string, unknown>): boolean {
+  const intent = normalize(stringField(item, "intent"));
+  const correlationId = stringField(item, "correlationId") ?? "";
+  return Boolean(
+    numberField(item, "pullRequestNumber")
+    || intent === "pr_handoff"
+    || intent === "pr_code_review"
+    || correlationId.startsWith("github-pr-")
+  );
+}
+
+function releaseVerdict(item: Record<string, unknown>): "block" | "needs-review" | "pass" | "running" | "unknown" {
+  const summary = toRecord(item.summary);
+  const status = normalize(stringField(item, "status"));
+  const finalVerdict = normalize(stringField(summary, "finalVerdict") ?? stringField(summary, "status"));
+  const mergeRecommendation = normalize(stringField(summary, "mergeRecommendation"));
+  const reason = normalize(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(item, "reason"));
+  const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
+  if (status === "running") return "running";
+  if (
+    status === "failed"
+    || status === "blocked"
+    || includesAny(finalVerdict, ["block", "blocked", "failed", "failure", "hold"])
+    || includesAny(mergeRecommendation, ["block", "blocked", "failed", "failure", "hold", "do_not_merge"])
+    || includesAny(reason, ["deploy_failure", "deploy_failed", "ci_failed"])
+  ) {
+    return "block";
+  }
+  if (
+    status === "needs_review"
+    || includesAny(finalVerdict, ["review", "needs_review"])
+    || includesAny(mergeRecommendation, ["review", "wait", "needs_review"])
+    || includesAny(reason, ["github_needs_review", "pr_review_hold", "needs_review"])
+    || reviewReasons.length > 0
+  ) {
+    return "needs-review";
+  }
+  if (status || finalVerdict || mergeRecommendation) return "pass";
+  return "unknown";
+}
+
+function nextOwner(item: Record<string, unknown>, verdict: ReturnType<typeof releaseVerdict>): string {
+  const status = normalize(stringField(item, "status"));
+  if (item.active === true || stringField(item, "activeState") === "running" || status === "running") return "Hermes";
+  if (verdict === "block") return "Codex";
+  if (verdict === "needs-review") return "Human owner";
+  if (verdict === "pass") return "Merge queue";
+  return "GitHub Actions";
+}
+
+function nextActionText(owner: string, verdict: ReturnType<typeof releaseVerdict>): string {
+  if (owner === "Hermes") return "finish checks and publish a verdict";
+  if (owner === "Codex") return "fix the blocking signal and push an update";
+  if (owner === "Human owner") return "review the gated surface and decide whether it can proceed";
+  if (owner === "Merge queue") return "merge when branch protection and queue checks are green";
+  if (verdict === "unknown") return "wait for CI/Hermes metadata";
+  return "finish CI before release-gate recommendation";
+}
+
+function releaseReason(item: Record<string, unknown>, verdict: ReturnType<typeof releaseVerdict>): string {
+  const summary = toRecord(item.summary);
+  const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
+  const first = toRecord(reviewReasons.find(Boolean));
+  if (stringField(first, "message")) return stringField(first, "message") ?? "Human review recommended.";
+  const reason = normalize(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(item, "reason"));
+  if (reason === "github_needs_review") return "Human review recommended by the GitHub risk gate.";
+  if (reason === "pr_review_hold") return "PR risk gate held this for human review.";
+  if (reason === "ci_failed") return "CI failed; fix before merge.";
+  if (reason === "ci_in_progress") return "CI is still running.";
+  if (verdict === "block") return "Blocked by release gate.";
+  if (verdict === "needs-review") return "Human review recommended.";
+  if (verdict === "pass") return "No blocking release signals recorded.";
+  return "No reason recorded.";
+}
+
+function ageInMinutes(updatedAt: string | undefined, now: Date): number {
+  const parsed = Date.parse(updatedAt ?? "");
+  if (!Number.isFinite(parsed)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, Math.floor((now.getTime() - parsed) / 60_000));
+}
+
+function formatDuration(minutes: number): string {
+  if (!Number.isFinite(minutes)) return "unknown age";
+  if (minutes < 1) return "under 1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest ? `${hours}h ${rest}m` : `${hours}h`;
+}
+
+function derivePullRequestUrl(item: Record<string, unknown>): string | undefined {
+  const repo = stringField(item, "repo") ?? "";
+  const prNumber = numberField(item, "pullRequestNumber");
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo)) return undefined;
+  if (prNumber === undefined || !Number.isInteger(prNumber) || prNumber < 1) return undefined;
+  return `https://github.com/${repo}/pull/${prNumber}`;
+}
+
+function normalize(value: string | undefined): string {
+  return String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+function stringField(value: unknown, key: string): string | undefined {
+  const record = toRecord(value);
+  const field = record[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+function numberField(value: unknown, key: string): number | undefined {
+  const record = toRecord(value);
+  const field = record[key];
+  return typeof field === "number" && Number.isFinite(field) ? field : undefined;
+}
+
+function arrayField(value: unknown, key: string): unknown[] {
+  const field = toRecord(value)[key];
+  return Array.isArray(field) ? field : [];
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}

--- a/test/unit/slack-routines.test.ts
+++ b/test/unit/slack-routines.test.ts
@@ -20,6 +20,8 @@ describe("slack operator routines", () => {
       SLACK_OPERATOR_OPS_HEALTH_ENABLED: "1",
       SLACK_OPERATOR_OPS_HEALTH_TIME_UTC: "06:35",
       SLACK_OPERATOR_SAFE_WORK_SCAN_INTERVAL_MINUTES: "15",
+      SLACK_OPERATOR_STALE_PR_ALERT_INTERVAL_MINUTES: "20",
+      SLACK_OPERATOR_STALE_PR_ALERT_AFTER_MINUTES: "180",
     }, new Set(["C1"]));
 
     expect(config.channelId).toBe("C1");
@@ -33,6 +35,9 @@ describe("slack operator routines", () => {
     expect(config.safeWorkScan.enabled).toBe(true);
     expect(config.safeWorkScan.intervalMs).toBe(15 * 60_000);
     expect(config.safeWorkScan.notifyOnlyOnAvailable).toBe(true);
+    expect(config.stalePrAlerts.enabled).toBe(true);
+    expect(config.stalePrAlerts.intervalMs).toBe(20 * 60_000);
+    expect(config.stalePrAlerts.staleAfterMinutes).toBe(180);
   });
 
   it("lets an explicit routine channel override the allowed-channel fallback", () => {

--- a/test/unit/stale-pr-alerts.test.ts
+++ b/test/unit/stale-pr-alerts.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatStalePrAlertForSlack,
+  shouldPostStalePrAlert,
+  stalePrAlertItems,
+} from "../../services/slack-operator/src/stale-pr-alerts.js";
+
+describe("stale PR handoff alerts", () => {
+  const now = new Date("2026-05-16T12:00:00.000Z");
+
+  it("extracts stale PR handoffs and ignores fresh or deploy handoffs", () => {
+    const items = stalePrAlertItems({
+      now,
+      staleAfterMinutes: 120,
+      monitor: {
+        recent: [
+          {
+            correlationId: "github-pr-10-run-1",
+            intent: "pr_handoff",
+            repo: "depre-dev/averray-reference-agent",
+            pullRequestNumber: 10,
+            updatedAt: "2026-05-16T09:30:00.000Z",
+            status: "completed",
+            summary: {
+              finalVerdict: "hold",
+              mergeRecommendation: "hold",
+              reviewReasons: [{ message: "CI failed." }],
+            },
+          },
+          {
+            correlationId: "github-pr-11-run-1",
+            intent: "pr_handoff",
+            repo: "depre-dev/averray-reference-agent",
+            pullRequestNumber: 11,
+            updatedAt: "2026-05-16T11:10:00.000Z",
+            status: "completed",
+            summary: { finalVerdict: "ok_to_merge", mergeRecommendation: "ok_to_merge" },
+          },
+          {
+            correlationId: "github-deploy-1-sha",
+            intent: "testbed_suite",
+            repo: "averray-agent/agent",
+            updatedAt: "2026-05-16T08:00:00.000Z",
+            status: "completed",
+          },
+        ],
+      },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      correlationId: "github-pr-10-run-1",
+      repo: "depre-dev/averray-reference-agent",
+      pullRequestNumber: 10,
+      owner: "Codex",
+      ageMinutes: 150,
+      ageLabel: "2h 30m",
+      reason: "CI failed.",
+      pullRequestUrl: "https://github.com/depre-dev/averray-reference-agent/pull/10",
+    });
+  });
+
+  it("dedupes active and recent entries by correlation id", () => {
+    const handoff = {
+      correlationId: "github-pr-12-run-1",
+      intent: "pr_handoff",
+      repo: "depre-dev/averray-reference-agent",
+      pullRequestNumber: 12,
+      updatedAt: "2026-05-16T08:00:00.000Z",
+      status: "completed",
+      summary: { finalVerdict: "needs_review", mergeRecommendation: "needs_review" },
+    };
+
+    const items = stalePrAlertItems({
+      now,
+      staleAfterMinutes: 120,
+      monitor: { active: [handoff], recent: [handoff] },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]?.owner).toBe("Human owner");
+  });
+
+  it("only posts when stale handoffs exist and signature changes", () => {
+    const items = stalePrAlertItems({
+      now,
+      staleAfterMinutes: 120,
+      monitor: {
+        recent: [{
+          correlationId: "github-pr-13-run-1",
+          intent: "pr_handoff",
+          repo: "depre-dev/averray-reference-agent",
+          pullRequestNumber: 13,
+          updatedAt: "2026-05-16T08:00:00.000Z",
+          status: "completed",
+          summary: { finalVerdict: "needs_review", mergeRecommendation: "needs_review" },
+        }],
+      },
+    });
+    const first = shouldPostStalePrAlert(items, undefined);
+
+    expect(first.shouldPost).toBe(true);
+    expect(first.signature).toContain("github-pr-13-run-1");
+    expect(shouldPostStalePrAlert(items, first.signature)).toEqual({
+      shouldPost: false,
+      signature: first.signature,
+    });
+    expect(shouldPostStalePrAlert([], undefined)).toEqual({ shouldPost: false });
+  });
+
+  it("formats a compact Slack alert with monitor link", () => {
+    const text = formatStalePrAlertForSlack([
+      {
+        correlationId: "github-pr-14-run-1",
+        repo: "depre-dev/averray-reference-agent",
+        pullRequestNumber: 14,
+        pullRequestUrl: "https://github.com/depre-dev/averray-reference-agent/pull/14",
+        owner: "Human owner",
+        ageMinutes: 180,
+        ageLabel: "3h",
+        nextAction: "review the gated surface",
+        reason: "Human review recommended.",
+      },
+    ], "https://monitor.averray.com/monitor");
+
+    expect(text).toContain("*Hermes stale PR handoffs*");
+    expect(text).toContain("<https://github.com/depre-dev/averray-reference-agent/pull/14|depre-dev/averray-reference-agent #14>");
+    expect(text).toContain("owner: `Human owner`");
+    expect(text).toContain("age: `3h`");
+    expect(text).toContain("Open monitor: https://monitor.averray.com/monitor");
+  });
+});


### PR DESCRIPTION
Adds an opt-in Slack routine that watches the Hermes handoff monitor for stale PR handoffs and posts a compact nudge only when stale work exists and the stale set changes.\n\nConfiguration:\n- SLACK_OPERATOR_STALE_PR_ALERT_INTERVAL_MINUTES enables the routine\n- SLACK_OPERATOR_STALE_PR_ALERT_AFTER_MINUTES controls the stale threshold, default 120\n- SLACK_OPERATOR_MONITOR_URL controls the footer link, default https://monitor.averray.com/monitor\n\nChecks run:\n- npm test -- test/unit/slack-routines.test.ts test/unit/stale-pr-alerts.test.ts\n- npm run build\n- git diff --check\n\nSafety:\n- read-only handoff monitor scan\n- no GitHub mutations\n- no deploy mutations\n- no Wikipedia or Averray job mutations