### PR TITLE
Add PR detail signals to monitor

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -394,6 +394,31 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       margin: 2px 0 0;
       overflow-wrap: anywhere;
     }
+    .pipeline-detail-title {
+      margin: 12px 0 8px;
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+    }
+    .pipeline-detail {
+      display: grid;
+      grid-template-columns: 170px minmax(0, 1fr);
+      gap: 8px 12px;
+      margin: 0;
+      border-top: 1px solid var(--line);
+      padding-top: 12px;
+    }
+    .pipeline-detail dt {
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .pipeline-detail dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
     .pipeline-links {
       display: flex;
       flex-wrap: wrap;
@@ -489,7 +514,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       .staleness-summary { grid-template-columns: 1fr; }
       .owner-summary { grid-template-columns: 1fr; }
       .pipeline-steps,
-      .pipeline-meta { grid-template-columns: 1fr; }
+      .pipeline-meta,
+      .pipeline-detail { grid-template-columns: 1fr; }
       dl { grid-template-columns: 1fr; }
     }
   </style>
@@ -741,8 +767,35 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("Updated", escapeHtml(item.updatedAt ? new Date(item.updatedAt).toLocaleString() : "unknown")) +
         row("Correlation", "<code>" + escapeHtml(item.correlationId || "unknown") + "</code>") +
         '</dl>' +
+        renderPipelineDetails(item, summary, verdict, action) +
         (links ? '<div class="pipeline-links">' + links + '</div>' : "") +
         '</article>';
+    }
+
+    function renderPipelineDetails(item, summary, verdict, action) {
+      const signals = summary.reviewSignals || {};
+      const touchedAreas = Array.isArray(signals.touchedAreas) ? signals.touchedAreas : [];
+      const missingTests = Array.isArray(signals.missingTestSignals) ? signals.missingTestSignals : [];
+      const testSignals = Array.isArray(signals.testSignals) ? signals.testSignals : [];
+      const rollout = signals.rolloutNotesRequired === true
+        ? signals.rolloutNotesPresent === true ? "present" : "missing"
+        : "not required";
+      const rows = [
+        row("Verdict", escapeHtml(verdict.label)),
+        row("Merge", escapeHtml(summary.mergeRecommendation || summary.finalVerdict || summary.status || "n/a")),
+        row("PR state", escapeHtml([item.status, item.phase, liveStateLabel(item.activeState)].filter(Boolean).join(" / ") || "n/a")),
+        row("Suggested owner", escapeHtml(action.owner)),
+        row("Changed areas", touchedAreas.length ? chips(touchedAreas) : "n/a"),
+        row("Test coverage", testSignals.length ? chips(testSignals.slice(0, 5)) : "n/a"),
+        row("Missing tests", missingTests.length ? chips(missingTests) : "none recorded"),
+        row("Rollout notes", escapeHtml(rollout)),
+      ];
+      const reviewRows = reviewReasonRows(summary);
+      return '<div class="pipeline-detail-title">PR detail</div><dl class="pipeline-detail">' +
+        rows.join("") +
+        reviewRows +
+        row("Why", escapeHtml(releaseReason(summary, item, verdict.level))) +
+        '</dl>';
     }
 
     function collectPipelineItems(payload) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -74,6 +74,11 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Recent history");
     expect(html).toContain("Next action:");
     expect(html).toContain("Next actor");
+    expect(html).toContain("PR detail");
+    expect(html).toContain("PR state");
+    expect(html).toContain("Suggested owner");
+    expect(html).toContain("Changed areas");
+    expect(html).toContain("Test coverage");
     expect(html).toContain("PR");
     expect(html).toContain("CI");
     expect(html).toContain("Hermes");
@@ -101,6 +106,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("updatePipelineFilterButtons()");
     expect(html).toContain("pipelineStage(item, verdict)");
     expect(html).toContain("nextPipelineAction(item, verdict)");
+    expect(html).toContain("renderPipelineDetails(item, summary, verdict, action)");
     expect(html).toContain("handoffAge(item)");
     expect(html).toContain("formatDuration(minutes)");
     expect(html).toContain("nextPipelineActor(item, verdict)");


### PR DESCRIPTION
## Summary
- add a compact PR detail block to each monitor pipeline card
- show verdict, merge recommendation, PR state, suggested owner, changed areas, test coverage, missing tests, rollout notes, and review reasons
- keep the data read-only and derived from existing handoff summaries

## Checks
- npm test -- test/unit/slack-monitor.test.ts
- npm run build
- git diff --check

## Surfaces
- Slack operator monitor UI only
- No GitHub, Wikipedia, backend, or platform mutations