### PR TITLE
Sync monitor PR state from GitHub

### DIFF
--- a/packages/averray-mcp/src/handoff-events.ts
+++ b/packages/averray-mcp/src/handoff-events.ts
@@ -137,6 +137,7 @@ export function summarizeHandoffResult(result: unknown): Record<string, unknown>
       ["github", "mergeRecommendation"],
       ["github", "merge_recommendation"],
     ]),
+    pullRequest: githubPullRequestSummary(nestedResult),
     codeReview: codeReviewSummary(nestedResult),
     reviewSignals: githubReviewSignals(nestedResult),
     reviewReasons: githubReviewReasons(nestedResult),
@@ -331,6 +332,29 @@ function githubReviewSignals(record: Record<string, unknown>): Record<string, un
     rolloutNotesPresent: booleanField(review, "rolloutNotesPresent"),
   });
   return Object.keys(signals).length > 0 ? signals : undefined;
+}
+
+function githubPullRequestSummary(record: Record<string, unknown>): Record<string, unknown> | undefined {
+  const github = isRecord(record.github) ? record.github : undefined;
+  const pullRequest = isRecord(github?.pullRequest) ? github.pullRequest : undefined;
+  if (!pullRequest) return undefined;
+  const summary = compactRecord({
+    repo: stringField(pullRequest, "repo"),
+    number: numberField(pullRequest, "number"),
+    title: stringField(pullRequest, "title"),
+    url: stringField(pullRequest, "url"),
+    author: stringField(pullRequest, "author"),
+    state: stringField(pullRequest, "state"),
+    draft: booleanField(pullRequest, "draft"),
+    baseBranch: stringField(pullRequest, "baseBranch"),
+    headBranch: stringField(pullRequest, "headBranch"),
+    headSha: stringField(pullRequest, "headSha"),
+    changedFiles: numberField(pullRequest, "changedFiles"),
+    mergeableState: stringField(pullRequest, "mergeableState"),
+    updatedAt: stringField(pullRequest, "updatedAt"),
+    source: "github_review",
+  });
+  return Object.keys(summary).length > 0 ? summary : undefined;
 }
 
 function deploymentHealthSummary(record: Record<string, unknown>): Record<string, unknown> | undefined {

--- a/services/slack-operator/src/github-pr-state.ts
+++ b/services/slack-operator/src/github-pr-state.ts
@@ -1,0 +1,189 @@
+export interface MonitorPullRequestState {
+  repo: string;
+  number: number;
+  state: string;
+  draft: boolean;
+  merged: boolean;
+  url?: string;
+  title?: string;
+  author?: string;
+  mergeableState?: string;
+  headSha?: string;
+  updatedAt?: string;
+  checkedAt: string;
+  source: "github_live";
+}
+
+export interface GithubPrStateDeps {
+  env?: NodeJS.ProcessEnv;
+  fetchFn?: typeof fetch;
+  now?: Date;
+}
+
+type MonitorEntry = Record<string, unknown> & {
+  repo?: string | null;
+  pullRequestNumber?: number | null;
+  summary?: Record<string, unknown> | null;
+};
+
+type MonitorPayload = Record<string, unknown> & {
+  active?: unknown[];
+  recent?: unknown[];
+};
+
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, { expiresAt: number; value: MonitorPullRequestState }>();
+
+export async function enrichMonitorWithGithubPrState<T extends MonitorPayload>(
+  monitor: T,
+  deps: GithubPrStateDeps = {}
+): Promise<T> {
+  const env = deps.env ?? process.env;
+  const fetchFn = deps.fetchFn ?? fetch;
+  const now = deps.now ?? new Date();
+  const entries = [...monitorEntries(monitor.active), ...monitorEntries(monitor.recent)];
+  const keys = uniquePrKeys(entries);
+  if (!keys.length) return monitor;
+
+  const states = new Map<string, MonitorPullRequestState>();
+  await Promise.all(keys.map(async ({ key, repo, pullRequestNumber }) => {
+    const token = resolveGithubTokenForRepo(repo, env);
+    if (!token) return;
+    const state = await fetchPullRequestState({
+      repo,
+      pullRequestNumber,
+      token,
+      fetchFn,
+      now,
+    }).catch(() => undefined);
+    if (state) states.set(key, state);
+  }));
+  if (states.size === 0) return monitor;
+
+  return {
+    ...monitor,
+    ...(Array.isArray(monitor.active) ? { active: enrichEntries(monitor.active, states) } : {}),
+    ...(Array.isArray(monitor.recent) ? { recent: enrichEntries(monitor.recent, states) } : {}),
+  };
+}
+
+function monitorEntries(value: unknown[] | undefined): MonitorEntry[] {
+  return Array.isArray(value) ? value.filter(isRecord) as MonitorEntry[] : [];
+}
+
+function uniquePrKeys(entries: MonitorEntry[]): Array<{ key: string; repo: string; pullRequestNumber: number }> {
+  const seen = new Set<string>();
+  const result: Array<{ key: string; repo: string; pullRequestNumber: number }> = [];
+  for (const entry of entries) {
+    const repo = typeof entry.repo === "string" ? entry.repo : "";
+    const pullRequestNumber = typeof entry.pullRequestNumber === "number" ? entry.pullRequestNumber : NaN;
+    if (!repo || !Number.isFinite(pullRequestNumber) || pullRequestNumber <= 0) continue;
+    const key = prKey(repo, pullRequestNumber);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ key, repo, pullRequestNumber });
+  }
+  return result;
+}
+
+function enrichEntries(entries: unknown[], states: Map<string, MonitorPullRequestState>): unknown[] {
+  return entries.map((entry) => {
+    if (!isRecord(entry)) return entry;
+    const repo = typeof entry.repo === "string" ? entry.repo : "";
+    const pullRequestNumber = typeof entry.pullRequestNumber === "number" ? entry.pullRequestNumber : NaN;
+    const state = repo && Number.isFinite(pullRequestNumber) ? states.get(prKey(repo, pullRequestNumber)) : undefined;
+    if (!state) return entry;
+    const summary = isRecord(entry.summary) ? entry.summary : {};
+    return {
+      ...entry,
+      summary: {
+        ...summary,
+        currentPullRequest: state,
+      },
+    };
+  });
+}
+
+async function fetchPullRequestState(input: {
+  repo: string;
+  pullRequestNumber: number;
+  token: string;
+  fetchFn: typeof fetch;
+  now: Date;
+}): Promise<MonitorPullRequestState | undefined> {
+  const key = prKey(input.repo, input.pullRequestNumber);
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > input.now.getTime()) return cached.value;
+
+  const response = await input.fetchFn(`https://api.github.com/repos/${input.repo}/pulls/${input.pullRequestNumber}`, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${input.token}`,
+      "user-agent": "averray-reference-agent-monitor",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (!response.ok) return undefined;
+  const pull: unknown = await response.json();
+  if (!isRecord(pull)) return undefined;
+  const value: MonitorPullRequestState = {
+    repo: input.repo,
+    number: input.pullRequestNumber,
+    state: stringField(pull, "state") ?? "unknown",
+    draft: pull.draft === true,
+    merged: pull.merged === true || typeof pull.merged_at === "string",
+    ...(stringField(pull, "html_url") ? { url: stringField(pull, "html_url") } : {}),
+    ...(stringField(pull, "title") ? { title: stringField(pull, "title") } : {}),
+    ...(isRecord(pull.user) && stringField(pull.user, "login") ? { author: stringField(pull.user, "login") } : {}),
+    ...(stringField(pull, "mergeable_state") ? { mergeableState: stringField(pull, "mergeable_state") } : {}),
+    ...(isRecord(pull.head) && stringField(pull.head, "sha") ? { headSha: stringField(pull.head, "sha") } : {}),
+    ...(stringField(pull, "updated_at") ? { updatedAt: stringField(pull, "updated_at") } : {}),
+    checkedAt: input.now.toISOString(),
+    source: "github_live",
+  };
+  cache.set(key, { expiresAt: input.now.getTime() + CACHE_TTL_MS, value });
+  return value;
+}
+
+function resolveGithubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) return env.GITHUB_TOKEN?.trim() || undefined;
+  const repoToken = parseTokenMap(env.GITHUB_REPO_TOKENS).get(`${owner}/${name}`);
+  const ownerToken = parseTokenMap(env.GITHUB_OWNER_TOKENS).get(owner);
+  const envRepoToken = env[`GITHUB_TOKEN_${toEnvKey(owner)}_${toEnvKey(name)}`]?.trim();
+  const envOwnerToken = env[`GITHUB_TOKEN_${toEnvKey(owner)}`]?.trim();
+  return repoToken
+    ?? ownerToken
+    ?? envRepoToken
+    ?? envOwnerToken
+    ?? env.GITHUB_TOKEN?.trim()
+    ?? undefined;
+}
+
+function parseTokenMap(value: string | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const entry of (value ?? "").split(/[\n,;]+/)) {
+    const [rawKey, ...rest] = entry.split("=");
+    const key = rawKey?.trim();
+    const token = rest.join("=").trim();
+    if (key && token) map.set(key, token);
+  }
+  return map;
+}
+
+function prKey(repo: string, pullRequestNumber: number): string {
+  return `${repo}#${pullRequestNumber}`;
+}
+
+function toEnvKey(value: string): string {
+  return value.replace(/[^A-Za-z0-9]/g, "_").toUpperCase();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -32,6 +32,7 @@ import {
   shouldPostStalePrAlert,
   stalePrAlertItems,
 } from "./stale-pr-alerts.js";
+import { enrichMonitorWithGithubPrState } from "./github-pr-state.js";
 
 const enabled = optionalEnv("SLACK_OPERATOR_ENABLED", "0") === "1";
 const httpPort = Number.parseInt(optionalEnv("SLACK_OPERATOR_HTTP_PORT", "8790"), 10);
@@ -152,7 +153,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       limit: parseOptionalInteger(url.searchParams.get("limit")),
       activeWindowMinutes: parseOptionalInteger(url.searchParams.get("activeWindowMinutes")),
     });
-    writeJson(response, 200, monitor);
+    writeJson(response, 200, await enrichMonitorWithGithubPrState(monitor));
     return;
   }
   if (!enabled) {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -703,12 +703,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function repoSummaryChips(items, current) {
       const verdicts = items.map(releaseVerdict);
       const stale = items.map(handoffAge).filter((age) => age.state === "stale").length;
+      const done = items.map((item) => pullRequestState(item, item.summary || {})).filter(isDonePullRequestState).length;
       const chips = [
         { label: "Current", value: current.length },
         { label: "Blocked", value: verdicts.filter((verdict) => verdict.level === "block").length },
         { label: "Review", value: verdicts.filter((verdict) => verdict.level === "needs-review").length },
         { label: "Ready", value: verdicts.filter((verdict) => verdict.level === "pass").length },
         { label: "Stale", value: stale },
+        { label: "Done", value: done },
       ];
       return chips.map((chip) => '<span class="pill">' + escapeHtml(chip.label + " " + chip.value) + '</span>').join("");
     }
@@ -730,6 +732,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const verdict = releaseVerdict(item);
       const age = handoffAge(item);
       const status = normalize(item.status);
+      const prState = pullRequestState(item, item.summary || {});
+      if (isDonePullRequestState(prState)) return false;
       return Boolean(
         item.active === true
         || item.activeState === "running"
@@ -774,6 +778,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function renderPipelineDetails(item, summary, verdict, action) {
       const signals = summary.reviewSignals || {};
+      const prState = pullRequestState(item, summary);
       const touchedAreas = Array.isArray(signals.touchedAreas) ? signals.touchedAreas : [];
       const missingTests = Array.isArray(signals.missingTestSignals) ? signals.missingTestSignals : [];
       const testSignals = Array.isArray(signals.testSignals) ? signals.testSignals : [];
@@ -783,7 +788,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const rows = [
         row("Verdict", escapeHtml(verdict.label)),
         row("Merge", escapeHtml(summary.mergeRecommendation || summary.finalVerdict || summary.status || "n/a")),
-        row("PR state", escapeHtml([item.status, item.phase, liveStateLabel(item.activeState)].filter(Boolean).join(" / ") || "n/a")),
+        row("PR state", escapeHtml(pullRequestStateLabel(prState) || [item.status, item.phase, liveStateLabel(item.activeState)].filter(Boolean).join(" / ") || "n/a")),
         row("Suggested owner", escapeHtml(action.owner)),
         row("Changed areas", touchedAreas.length ? chips(touchedAreas) : "n/a"),
         row("Test coverage", testSignals.length ? chips(testSignals.slice(0, 5)) : "n/a"),
@@ -833,6 +838,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function pipelineStage(item, verdict) {
       const status = normalize(item.status);
+      const prState = pullRequestState(item, item.summary || {});
+      if (isDonePullRequestState(prState)) return { key: "deploy", label: pullRequestStateLabel(prState) };
       if (item.active === true || item.activeState === "running" || status === "running") {
         return { key: "hermes", label: "Hermes reviewing" };
       }
@@ -853,6 +860,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function nextPipelineAction(item, verdict) {
       const status = normalize(item.status);
+      const prState = pullRequestState(item, item.summary || {});
+      if (isDonePullRequestState(prState)) {
+        return { owner: "Done", text: "PR is no longer open in GitHub; keep this handoff as release history" };
+      }
       if (item.active === true || item.activeState === "running" || status === "running") {
         return { owner: "Hermes", text: "finish the current handoff checks and publish a verdict" };
       }
@@ -960,6 +971,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function releaseVerdict(item) {
       const summary = item.summary || {};
       const status = normalize(item.status);
+      const prState = pullRequestState(item, summary);
       const finalVerdict = normalize(summary.finalVerdict || summary.status);
       const mergeRecommendation = normalize(summary.mergeRecommendation);
       const reason = normalize(summary.finalReason || summary.reason || item.reason);
@@ -967,6 +979,18 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
       if (status === "running") {
         return { level: "running", label: "RUNNING", why: releaseReason(summary, item, "running") };
+      }
+      if (prState && prState.merged === true) {
+        return { level: "pass", label: "MERGED", why: "GitHub reports this PR is merged; this handoff is history." };
+      }
+      if (prState && normalize(prState.state) === "closed") {
+        return { level: "pass", label: "CLOSED", why: "GitHub reports this PR is closed; this handoff is history." };
+      }
+      if (prState && prState.draft === true) {
+        return { level: "needs-review", label: "DRAFT", why: "GitHub reports this PR is still a draft." };
+      }
+      if (prState && normalize(prState.mergeableState) === "dirty") {
+        return { level: "block", label: "CONFLICT", why: "GitHub reports this PR has merge conflicts." };
       }
       const terminal = classifyReleaseGate(status, finalVerdict, mergeRecommendation, reason, reviewReasons);
       if (item.activeState === "just_finished") {
@@ -1025,6 +1049,28 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (reason === "ci_in_progress") return "CI is still running; wait for the result.";
       if (level === "pass") return "No blocking release signals recorded.";
       return String(summary.finalReason || summary.reason || item.reason || item.phase || "No reason recorded.");
+    }
+
+    function pullRequestState(item, summary) {
+      if (summary && typeof summary.currentPullRequest === "object" && summary.currentPullRequest !== null) return summary.currentPullRequest;
+      if (summary && typeof summary.pullRequest === "object" && summary.pullRequest !== null) return summary.pullRequest;
+      return null;
+    }
+
+    function isDonePullRequestState(prState) {
+      return Boolean(prState && (prState.merged === true || normalize(prState.state) === "closed"));
+    }
+
+    function pullRequestStateLabel(prState) {
+      if (!prState) return "";
+      const parts = [];
+      if (prState.merged === true) parts.push("merged");
+      else if (prState.state) parts.push(String(prState.state));
+      if (prState.draft === true) parts.push("draft");
+      if (prState.mergeableState) parts.push("mergeable:" + String(prState.mergeableState));
+      if (prState.source === "github_live") parts.push("live");
+      else if (prState.source) parts.push(String(prState.source));
+      return parts.join(" / ");
     }
 
     function deploymentHealthRows(summary) {

--- a/test/unit/agent-invocation.test.ts
+++ b/test/unit/agent-invocation.test.ts
@@ -336,6 +336,7 @@ describe("agent invocation hook", () => {
 
   it("runs a PR handoff review and requested read-only testcase", async () => {
     const calls: string[] = [];
+    const events: HandoffEventInput[] = [];
     const result = await invokeAgentTask(
       {
         requester: "codex",
@@ -346,7 +347,7 @@ describe("agent invocation hook", () => {
         correlationId: "handoff-789",
         reason: "pre-merge check",
       },
-      deps(calls, githubFetch())
+      deps(calls, githubFetch(), events)
     );
 
     expect(result).toMatchObject({
@@ -418,6 +419,15 @@ describe("agent invocation hook", () => {
       "fetchEvidence",
       "validateDirectSubmission",
     ]));
+    expect(events.at(-1)?.summary).toMatchObject({
+      pullRequest: {
+        repo: "averray-agent/agent",
+        number: 185,
+        state: "open",
+        draft: false,
+        mergeableState: "clean",
+      },
+    });
   });
 
   it("posts an idempotent PR handoff comment when enabled", async () => {

--- a/test/unit/slack-monitor-pr-state.test.ts
+++ b/test/unit/slack-monitor-pr-state.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import { enrichMonitorWithGithubPrState } from "../../services/slack-operator/src/github-pr-state.js";
+
+describe("monitor GitHub PR state enrichment", () => {
+  it("adds live GitHub PR state to matching monitor entries", async () => {
+    const calls: string[] = [];
+    const monitor = await enrichMonitorWithGithubPrState({
+      recent: [
+        {
+          correlationId: "github-pr-123-abc-456",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 123,
+          summary: { finalVerdict: "needs_review" },
+        },
+      ],
+    }, {
+      env: { GITHUB_TOKEN: "ghp_readonly" },
+      now: new Date("2026-05-16T10:00:00.000Z"),
+      fetchFn: async (url, init) => {
+        calls.push(String(url));
+        expect(init?.headers).toMatchObject({ authorization: "Bearer ghp_readonly" });
+        return new Response(JSON.stringify({
+          number: 123,
+          title: "Ship monitor state",
+          html_url: "https://github.com/averray-agent/agent/pull/123",
+          user: { login: "codex" },
+          state: "closed",
+          merged: true,
+          draft: false,
+          mergeable_state: "clean",
+          head: { sha: "abc123" },
+          updated_at: "2026-05-16T09:55:00.000Z",
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    expect(calls).toEqual(["https://api.github.com/repos/averray-agent/agent/pulls/123"]);
+    expect(monitor.recent?.[0]).toMatchObject({
+      summary: {
+        finalVerdict: "needs_review",
+        currentPullRequest: {
+          repo: "averray-agent/agent",
+          number: 123,
+          state: "closed",
+          merged: true,
+          draft: false,
+          mergeableState: "clean",
+          headSha: "abc123",
+          checkedAt: "2026-05-16T10:00:00.000Z",
+          source: "github_live",
+        },
+      },
+    });
+  });
+
+  it("uses owner-specific tokens and leaves entries unchanged without a token", async () => {
+    const calls: string[] = [];
+    const monitor = await enrichMonitorWithGithubPrState({
+      recent: [
+        { repo: "depre-dev/averray-reference-agent", pullRequestNumber: 88, summary: {} },
+        { repo: "unknown-owner/repo", pullRequestNumber: 99, summary: {} },
+      ],
+    }, {
+      env: { GITHUB_OWNER_TOKENS: "depre-dev=owner-token" },
+      now: new Date("2026-05-16T10:05:00.000Z"),
+      fetchFn: async (url, init) => {
+        calls.push(String(url));
+        expect(init?.headers).toMatchObject({ authorization: "Bearer owner-token" });
+        return new Response(JSON.stringify({
+          number: 88,
+          state: "open",
+          draft: false,
+          merged: false,
+        }), { status: 200 });
+      },
+    });
+
+    expect(calls).toEqual(["https://api.github.com/repos/depre-dev/averray-reference-agent/pulls/88"]);
+    expect(monitor.recent?.[0]).toMatchObject({
+      summary: {
+        currentPullRequest: {
+          repo: "depre-dev/averray-reference-agent",
+          number: 88,
+          state: "open",
+        },
+      },
+    });
+    expect(monitor.recent?.[1]).toEqual({ repo: "unknown-owner/repo", pullRequestNumber: 99, summary: {} });
+  });
+});

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -79,6 +79,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Suggested owner");
     expect(html).toContain("Changed areas");
     expect(html).toContain("Test coverage");
+    expect(html).toContain("Done");
     expect(html).toContain("PR");
     expect(html).toContain("CI");
     expect(html).toContain("Hermes");
@@ -108,6 +109,9 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("nextPipelineAction(item, verdict)");
     expect(html).toContain("renderPipelineDetails(item, summary, verdict, action)");
     expect(html).toContain("handoffAge(item)");
+    expect(html).toContain("pullRequestState(item, summary)");
+    expect(html).toContain("isDonePullRequestState(prState)");
+    expect(html).toContain("pullRequestStateLabel(prState)");
     expect(html).toContain("formatDuration(minutes)");
     expect(html).toContain("nextPipelineActor(item, verdict)");
     expect(html).toContain("renderPipelineSteps(stage, verdict)");


### PR DESCRIPTION
## Summary
- enrich /monitor/events with live read-only GitHub PR state using the existing token env and a short cache
- preserve PR state from Hermes GitHub review summaries as a fallback
- show merged/closed/draft/conflict state in the PR pipeline and move merged/closed PRs into history instead of current work

## Checks
- npm test -- test/unit/slack-monitor.test.ts test/unit/slack-monitor-pr-state.test.ts test/unit/agent-invocation.test.ts
- npm run build
- git diff --check

## Surfaces
- Slack operator monitor endpoint and UI
- Averray MCP handoff summary shape
- Read-only GitHub API calls only; no GitHub, Wikipedia, platform, or deploy mutations