### PR TITLE
Add live monitor event stream

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -125,7 +125,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       monitor: {
         enabled: monitorConfig.enabled,
         tokenProtected: Boolean(monitorConfig.token),
-        paths: monitorConfig.enabled ? ["/monitor", "/monitor/events"] : [],
+        paths: monitorConfig.enabled ? ["/monitor", "/monitor/events", "/monitor/stream"] : [],
       },
     });
     return;
@@ -135,7 +135,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     writeRedirect(response, "/monitor");
     return;
   }
-  if (request.method === "GET" && (url.pathname === "/monitor" || url.pathname === "/monitor/events")) {
+  if (request.method === "GET" && (url.pathname === "/monitor" || url.pathname === "/monitor/events" || url.pathname === "/monitor/stream")) {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
       return;
@@ -148,12 +148,11 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       writeHtml(response, 200, renderMonitorHtml());
       return;
     }
-    const monitor = await getHandoffMonitor({
-      correlationId: url.searchParams.get("correlationId") ?? undefined,
-      limit: parseOptionalInteger(url.searchParams.get("limit")),
-      activeWindowMinutes: parseOptionalInteger(url.searchParams.get("activeWindowMinutes")),
-    });
-    writeJson(response, 200, await enrichMonitorWithGithubPrState(monitor));
+    if (url.pathname === "/monitor/stream") {
+      await writeMonitorStream(request, response, url);
+      return;
+    }
+    writeJson(response, 200, await loadMonitorSnapshot(url));
     return;
   }
   if (!enabled) {
@@ -590,6 +589,65 @@ function writeHtml(response: http.ServerResponse, status: number, html: string) 
 function writeRedirect(response: http.ServerResponse, location: string) {
   response.writeHead(302, { location });
   response.end();
+}
+
+async function loadMonitorSnapshot(url: URL): Promise<unknown> {
+  const monitor = await getHandoffMonitor({
+    correlationId: url.searchParams.get("correlationId") ?? undefined,
+    limit: parseOptionalInteger(url.searchParams.get("limit")),
+    activeWindowMinutes: parseOptionalInteger(url.searchParams.get("activeWindowMinutes")),
+  });
+  return enrichMonitorWithGithubPrState(monitor);
+}
+
+async function writeMonitorStream(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  url: URL
+): Promise<void> {
+  const intervalMs = Math.max(1_000, parseOptionalInteger(url.searchParams.get("intervalMs")) ?? 5_000);
+  let closed = false;
+  let inFlight = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  response.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache, no-transform",
+    connection: "keep-alive",
+    "x-accel-buffering": "no",
+  });
+  response.write(`retry: ${intervalMs}\n\n`);
+
+  const send = async () => {
+    if (closed || inFlight) return;
+    inFlight = true;
+    try {
+      writeSseEvent(response, "monitor", await loadMonitorSnapshot(url));
+    } catch (error) {
+      writeSseEvent(response, "error", {
+        error: "monitor_snapshot_failed",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  request.on("close", () => {
+    closed = true;
+    if (timer) clearInterval(timer);
+  });
+
+  await send();
+  if (!closed) timer = setInterval(() => void send(), intervalMs);
+}
+
+function writeSseEvent(response: http.ServerResponse, event: string, payload: unknown) {
+  const data = JSON.stringify(payload)
+    .split(/\r?\n/)
+    .map((line) => `data: ${line}`)
+    .join("\n");
+  response.write(`event: ${event}\n${data}\n\n`);
 }
 
 function headerValue(value: string | string[] | undefined): string | undefined {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -21,9 +21,10 @@ export function isMonitorAuthorized(
   return url.searchParams.get("token") === config.token;
 }
 
-export function renderMonitorHtml(options: { title?: string; eventsPath?: string } = {}): string {
+export function renderMonitorHtml(options: { title?: string; eventsPath?: string; streamPath?: string } = {}): string {
   const title = escapeHtml(options.title ?? "Hermes Handoff Monitor");
   const eventsPath = JSON.stringify(options.eventsPath ?? "/monitor/events");
+  const streamPath = JSON.stringify(options.streamPath ?? "/monitor/stream");
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -72,6 +73,28 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       letter-spacing: 0;
     }
     p { color: var(--muted); margin: 0; }
+    .live-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-left: 8px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      padding: 2px 8px;
+      color: var(--muted);
+      font-size: 0.78rem;
+      white-space: nowrap;
+    }
+    .live-status::before {
+      content: "";
+      width: 7px;
+      height: 7px;
+      border-radius: 999px;
+      background: var(--warn);
+    }
+    .live-status[data-state="live"]::before { background: var(--ok); }
+    .live-status[data-state="polling"]::before { background: #64d2ff; }
+    .live-status[data-state="error"]::before { background: var(--bad); }
     button {
       min-height: 38px;
       border: 1px solid var(--line);
@@ -698,7 +721,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     <header>
       <div>
         <h1>${title}</h1>
-        <p id="subtitle">Live private view of agent-to-agent handoffs.</p>
+        <p id="subtitle">Live private view of agent-to-agent handoffs.<span id="live-status" class="live-status" data-state="connecting">connecting</span></p>
       </div>
       <button id="refresh" type="button">Refresh</button>
     </header>
@@ -741,13 +764,17 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
   </main>
   <script>
     const eventsPath = ${eventsPath};
+    const streamPath = ${streamPath};
     const token = new URLSearchParams(location.search).get("token");
-    const withToken = buildEventsUrl();
+    const withToken = buildMonitorUrl(eventsPath);
+    const streamUrl = buildMonitorUrl(streamPath);
     const decisionStorageKey = "averray-monitor-human-decisions:v1";
     let pipelineFilter = "all";
     let latestPipelineItems = [];
     let latestPayload = null;
     let monitorDecisions = loadMonitorDecisions();
+    let pollTimer = null;
+    let streamSource = null;
 
     document.getElementById("refresh").addEventListener("click", () => load());
     document.addEventListener("click", (event) => {
@@ -768,7 +795,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       });
     });
     load();
-    setInterval(load, 5000);
+    startLiveUpdates();
 
     async function load() {
       try {
@@ -776,8 +803,46 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         if (!response.ok) throw new Error("HTTP " + response.status);
         render(await response.json());
       } catch (error) {
+        updateLiveStatus("error", "update failed");
         document.getElementById("recent").innerHTML = '<div class="empty error">Monitor unavailable: ' + escapeHtml(String(error.message || error)) + '</div>';
       }
+    }
+
+    function startLiveUpdates() {
+      if ("EventSource" in window) {
+        connectMonitorStream();
+        return;
+      }
+      startPolling("polling 5s");
+    }
+
+    function connectMonitorStream() {
+      updateLiveStatus("connecting", "connecting");
+      streamSource = new EventSource(streamUrl);
+      streamSource.addEventListener("open", () => updateLiveStatus("live", "live"));
+      streamSource.addEventListener("monitor", (event) => {
+        updateLiveStatus("live", "live");
+        render(JSON.parse(event.data));
+      });
+      streamSource.addEventListener("error", () => {
+        updateLiveStatus("error", "reconnecting");
+        if (streamSource) streamSource.close();
+        streamSource = null;
+        startPolling("polling fallback 5s");
+      });
+    }
+
+    function startPolling(label) {
+      updateLiveStatus("polling", label || "polling 5s");
+      if (pollTimer) return;
+      pollTimer = setInterval(load, 5000);
+    }
+
+    function updateLiveStatus(state, label) {
+      const target = document.getElementById("live-status");
+      if (!target) return;
+      target.dataset.state = state;
+      target.textContent = label;
     }
 
     function render(payload) {
@@ -1365,14 +1430,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '</dl></article>';
     }
 
-    function buildEventsUrl() {
-      const separator = eventsPath.includes("?") ? "&" : "?";
+    function buildMonitorUrl(path) {
+      const separator = path.includes("?") ? "&" : "?";
       const params = new URLSearchParams({
         limit: "50",
         activeWindowMinutes: "240"
       });
       if (token) params.set("token", token);
-      return eventsPath + separator + params.toString();
+      return path + separator + params.toString();
     }
 
     function needsAttention(item) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -42,10 +42,13 @@ describe("slack operator personal monitor", () => {
     const html = renderMonitorHtml({
       title: "Pascal Monitor",
       eventsPath: "/monitor/events",
+      streamPath: "/monitor/stream",
     });
 
     expect(html).toContain("<title>Pascal Monitor</title>");
     expect(html).toContain("Live private view of agent-to-agent handoffs.");
+    expect(html).toContain("live-status");
+    expect(html).toContain("connecting");
     expect(html).toContain("Active / Just Finished");
     expect(html).toContain("Blocked / Human Review");
     expect(html).toContain("Live Lane");
@@ -102,6 +105,10 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Gate");
     expect(html).toContain("Deploy");
     expect(html).toContain("const eventsPath = \"/monitor/events\";");
+    expect(html).toContain("const streamPath = \"/monitor/stream\";");
+    expect(html).toContain("new EventSource(streamUrl)");
+    expect(html).toContain("addEventListener(\"monitor\"");
+    expect(html).toContain("startPolling(\"polling fallback 5s\")");
     expect(html).toContain("Release Gate");
     expect(html).toContain("blocks + human review");
     expect(html).toContain("Release Timeline");
@@ -125,6 +132,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("ownerLaneSortScore(item)");
     expect(html).toContain("isCurrentPipelineItem(item)");
     expect(html).toContain("updatePipelineFilterButtons()");
+    expect(html).toContain("buildMonitorUrl(path)");
     expect(html).toContain("pipelineStage(item, verdict)");
     expect(html).toContain("nextPipelineAction(item, verdict)");
     expect(html).toContain("renderFixRequest(item, summary, verdict, action)");


### PR DESCRIPTION
Adds a read-only Server-Sent Events backend for the Hermes handoff monitor. The existing /monitor/events JSON endpoint remains as polling fallback, while /monitor/stream emits monitor snapshots and the monitor shell prefers EventSource when available.\n\nChecks run:\n- npm test -- test/unit/slack-monitor.test.ts\n- npm run build\n- git diff --check\n\nAffects: Slack operator monitor backend/UI only. No VPS secrets or environment changes required.