### PR TITLE
Clarify operator review handoff language

### DIFF
--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -464,7 +464,7 @@ function buildPullRequestCodeReview(review: GithubPullRequestReview) {
   const why = review.riskFindings[0]?.message
     ?? (finalVerdict === "ok_to_merge"
       ? "PR metadata, changed files, and checks look merge-ready."
-      : "PR needs human review before merge.");
+      : "PR needs operator review before merge.");
 
   return {
     schemaVersion: 1,
@@ -557,7 +557,7 @@ function buildPrHandoffCommentBody(input: AgentInvocationInput, handoff: Record<
   const missingTestSignals = arrayField(tests, "missingTestSignals").map(String);
   const requestedActions = isRecord(handoff.requestedActions) ? handoff.requestedActions : {};
   const requestedTests = arrayField(requestedActions, "testCaseIds").map(String);
-  const commentVerdict = humanPrVerdict(finalVerdict);
+  const commentVerdict = prVerdictLabel(finalVerdict);
   const nextAction = nextCodexAction(commentVerdict);
 
   return [
@@ -583,15 +583,15 @@ function buildPrHandoffCommentBody(input: AgentInvocationInput, handoff: Record<
   ].join("\n");
 }
 
-function humanPrVerdict(value: string): "PASS" | "HUMAN REVIEW" | "BLOCK" {
+function prVerdictLabel(value: string): "PASS" | "OPERATOR REVIEW" | "BLOCK" {
   if (value === "ok_to_merge" || value === "pass") return "PASS";
-  if (value === "needs_review" || value === "human_review") return "HUMAN REVIEW";
+  if (value === "needs_review" || value === "human_review") return "OPERATOR REVIEW";
   return "BLOCK";
 }
 
-function nextCodexAction(verdict: "PASS" | "HUMAN REVIEW" | "BLOCK"): string {
-  if (verdict === "PASS") return "Continue normal merge queue or ask the human owner for final approval.";
-  if (verdict === "HUMAN REVIEW") return "Explain the review-gated surface and wait for the human owner.";
+function nextCodexAction(verdict: "PASS" | "OPERATOR REVIEW" | "BLOCK"): string {
+  if (verdict === "PASS") return "Continue normal merge queue or ask the operator for final approval.";
+  if (verdict === "OPERATOR REVIEW") return "Attach the code-level pre-check evidence, then ask the operator for project/architecture sign-off.";
   return "Fix the blocking issue, push an update, and rerun CI before handing off again.";
 }
 

--- a/packages/averray-mcp/src/codex-handoff-protocol.ts
+++ b/packages/averray-mcp/src/codex-handoff-protocol.ts
@@ -10,7 +10,7 @@ export function getCodexHandoffProtocol() {
     roles: {
       builder: "Codex edits code, works in branches/worktrees, opens PRs, and fixes failures.",
       reviewerOperator: "Hermes reviews PR risk, runs read-only checks, reports to PR comments/Slack/monitor, and proposes actions without broad merge/deploy execution.",
-      approver: "Human owner approves merge, deploy, override, rollback, or secret rotation.",
+      approver: "Operator approves merge, deploy, override, rollback, or secret rotation after agent pre-check evidence is attached.",
     },
     flow: [
       "Codex opens or updates a PR.",
@@ -18,7 +18,7 @@ export function getCodexHandoffProtocol() {
       "GitHub Actions calls averray_invoke_agent_task with intent=pr_code_review.",
       "GitHub Actions calls averray_invoke_agent_task with intent=pr_handoff and requested read-only testbed cases.",
       "Hermes records handoff events and, when enabled, upserts one PR verdict comment alongside Slack and monitor reports.",
-      "Codex responds to PASS / HUMAN REVIEW / BLOCK.",
+      "Codex responds to PASS / OPERATOR REVIEW / BLOCK.",
       "After merge/deploy, Hermes runs post_deploy_verification.",
     ],
     codexPrRequirements: [
@@ -40,16 +40,16 @@ export function getCodexHandoffProtocol() {
       {
         label: "PASS",
         meaning: "No blocking or review-gated release signal was found.",
-        codexAction: "Continue normal merge queue or ask the human owner for final approval.",
+        codexAction: "Continue normal merge queue or ask the operator for final approval.",
       },
       {
-        label: "HUMAN REVIEW",
-        meaning: "Not necessarily broken; review-gated surface or incomplete automated proof needs a human look.",
-        codexAction: "Explain the risk, tests, and rollout/rollback plan in the PR, then ask the human owner to review.",
+        label: "OPERATOR REVIEW",
+        meaning: "Not necessarily broken; agents should provide code-level pre-check evidence, and the operator decides project intent, architecture, or rollout risk.",
+        codexAction: "Attach the risk, tests, rollout/rollback plan, and agent pre-check evidence, then ask the operator for sign-off.",
       },
       {
         label: "BLOCK",
-        meaning: "Do not merge or deploy until fixed or explicitly overridden by a human owner outside Hermes.",
+        meaning: "Do not merge or deploy until fixed or explicitly overridden by the operator outside Hermes.",
         codexAction: "Stop, fix the PR or missing evidence, wait for CI, and let Hermes re-run.",
       },
     ],

--- a/packages/averray-mcp/src/operator-admin.ts
+++ b/packages/averray-mcp/src/operator-admin.ts
@@ -105,7 +105,7 @@ export async function getAdminReadiness(deps: OperatorStatusDeps) {
       "Deploy, restart, or reconfigure production services automatically.",
       "Change DNS, Cloudflare Access, Slack app scopes, or secrets.",
       "Spend money, move funds, or change wallet configuration.",
-      "Override confidence gates without a separate human review path.",
+      "Override confidence gates without a separate operator review path.",
     ],
     requiredBeforeProjectAdmin: [
       "Define a project registry with owners, environments, and allowed actions.",

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -464,7 +464,7 @@ function projectMemoryTarget(
 }
 
 function isCodexHandoffProtocolCommand(text: string): boolean {
-  return /^(codex handoff protocol|codex hermes protocol|hermes codex protocol|codex handoff|builder reviewer protocol|what should codex do when hermes blocks|what does human review mean|what does hermes block mean|how should codex hand off prs)( details?| full| audit)?$/.test(text);
+  return /^(codex handoff protocol|codex hermes protocol|hermes codex protocol|codex handoff|builder reviewer protocol|what should codex do when hermes blocks|what does operator review mean|what does human review mean|what does hermes block mean|how should codex hand off prs)( details?| full| audit)?$/.test(text);
 }
 
 function projectRunbookTarget(

--- a/packages/averray-mcp/src/operator-github.ts
+++ b/packages/averray-mcp/src/operator-github.ts
@@ -1652,7 +1652,7 @@ function buildPullRequestRiskFindings(input: {
     findings.push({
       severity: "medium",
       code: "pr_blockchain_settlement_review",
-      message: `${settlementRisk.length} changed file(s) touch blockchain/XCM settlement flow. Human should verify request metadata preservation, claim/submit routing, settlement IDs, and rollback notes before merge.`,
+      message: `${settlementRisk.length} changed file(s) touch blockchain/XCM settlement flow. Agent pre-checks own code-level verification; operator sign-off should confirm the architecture intent, accepted rollout/rollback risk, and whether Codex should adjust before merge.`,
     });
   }
   if (reviewRisk.length > 0) {
@@ -1770,8 +1770,13 @@ function buildPullRequestReviewRecommendations(input: {
   const mediumCodes = input.riskFindings
     .filter((finding) => finding.severity === "medium")
     .map((finding) => finding.code);
+  if (mediumCodes.includes("pr_blockchain_settlement_review")) {
+    return [
+      "Operator review recommended before merge: Hermes/Codex should provide the technical pre-check evidence, and the operator should decide whether the blockchain/XCM settlement behavior and rollout risk are acceptable.",
+    ];
+  }
   return [
-    `Human review recommended before merge${mediumCodes.length > 0 ? ` (${[...new Set(mediumCodes)].join(", ")})` : ""}.`,
+    `Operator review recommended before merge${mediumCodes.length > 0 ? ` (${[...new Set(mediumCodes)].join(", ")})` : ""}. Hermes/Codex should provide code-level evidence; the operator decides project intent, rollout risk, or approval.`,
   ];
 }
 
@@ -1867,7 +1872,7 @@ function buildMergeStewardRecommendations(input: {
     recommendations.push(`${input.autoMergeCandidates.length} PR(s) are clean merge candidates. Merge execution is still disabled in this read-only steward.`);
   }
   if (input.humanReview.length > 0) {
-    recommendations.push(`${input.humanReview.length} PR(s) need a human review before merge.`);
+    recommendations.push(`${input.humanReview.length} PR(s) need operator review before merge; code-level evidence should already be provided by Hermes/Codex.`);
   }
   if (input.blocked.length > 0) {
     recommendations.push(`${input.blocked.length} PR(s) are blocked. Fix high-severity findings before merge.`);

--- a/packages/averray-mcp/src/operator-project-memory.ts
+++ b/packages/averray-mcp/src/operator-project-memory.ts
@@ -57,7 +57,7 @@ const CURATED_PROJECTS: ProjectMemoryEntry[] = [
       "propose deploy for averray-agent/agent sha <SHA>",
     ],
     handoff: {
-      pr: "Hermes PR handoff runs after CI, reviews GitHub metadata/checks/files, runs requested testbed checks, and reports PASS / HUMAN REVIEW / BLOCK.",
+      pr: "Hermes PR handoff runs after CI, reviews GitHub metadata/checks/files, runs requested testbed checks, and reports PASS / OPERATOR REVIEW / BLOCK.",
       protocol: "Codex builds; Hermes reviews and operates. See docs/CODEX_HANDOFF_PROTOCOL.md.",
       deploy: "Post-deploy verification runs the read-only testbed suite and reports deploy health.",
       mutates: false,
@@ -71,7 +71,7 @@ const CURATED_PROJECTS: ProjectMemoryEntry[] = [
       deployIntent: "post_deploy_verification",
       verdicts: {
         PASS: "No blocking or review-gated release signal; continue normal human/merge policy.",
-        HUMAN_REVIEW: "Not necessarily broken; a human should inspect the review-gated area before merge.",
+        OPERATOR_REVIEW: "Not necessarily broken; agents should provide code-level pre-check evidence, and the operator decides project intent, architecture, or rollout risk.",
         BLOCK: "Do not merge/deploy until fixed or explicitly overridden outside Hermes.",
       },
       codexOnBlock: "Stop, fix the PR or missing evidence, wait for CI, then let Hermes re-run. Do not ask Hermes to override.",
@@ -140,7 +140,7 @@ const CURATED_PROJECTS: ProjectMemoryEntry[] = [
       deployIntent: "post_deploy_verification",
       verdicts: {
         PASS: "Normal release path may continue.",
-        HUMAN_REVIEW: "Human owner should inspect the risk signal.",
+        OPERATOR_REVIEW: "Operator should inspect the agent pre-check evidence and decide project/architecture sign-off.",
         BLOCK: "Stop until fixed or explicitly overridden outside Hermes.",
       },
       codexOnBlock: "Fix or add evidence; do not bypass Hermes by retrying blindly.",

--- a/packages/averray-mcp/src/operator-project-runbook.ts
+++ b/packages/averray-mcp/src/operator-project-runbook.ts
@@ -84,11 +84,11 @@ function runbookForAction(action: AdminActionKind, project: ProjectMemoryEntry |
 function mergeRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
   const repo = primaryRepo(project);
   return {
-    goal: "Decide whether a pull request is ready for a human merge approval.",
+    goal: "Decide whether a pull request is ready for operator merge approval.",
     trigger: "A PR has green CI and the author asks for review, merge, or release readiness.",
     requiredEvidence: [
       "GitHub CI and merge queue checks are green.",
-      "Hermes PR handoff verdict is ok_to_merge, or every needs_review / hold reason has a human resolution.",
+      "Hermes PR handoff verdict is ok_to_merge, or every needs_review / hold reason has an operator resolution based on attached agent pre-check evidence.",
       "Changed files match the stated PR scope and required tests.",
       "PR notes mention affected surfaces: backend, frontend, indexer, Caddy, contracts, public site, or docs.",
       "Rollback/deploy notes are present when deployment or ops files changed.",
@@ -96,9 +96,9 @@ function mergeRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate 
     operatorSteps: [
       repo ? `Run \`github status\` and inspect ${repo} PR status.` : "Run `github status` and inspect PR status.",
       "Open the handoff monitor and read the latest PR handoff card.",
-      "If high-risk files changed, ask for explicit human review before merge.",
+      "If high-risk files changed, ask for explicit operator review before merge.",
       "Use `propose merge for owner/repo#PR` to get a proposal-only admin recommendation.",
-      "Merge manually only after the human owner approves the evidence.",
+      "Merge manually only after the operator approves the attached agent pre-check evidence.",
     ],
     stopConditions: [
       "Any required CI or merge queue check is failing, cancelled, or still running.",
@@ -121,7 +121,7 @@ function deployRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate
   const deploy = project?.deploy ?? {};
   return {
     goal: "Ship a known commit and verify production is healthy afterward.",
-    trigger: stringField(deploy, "trigger") ?? "A human owner decides a commit or PR should be released.",
+    trigger: stringField(deploy, "trigger") ?? "An operator decides a commit or PR should be released.",
     requiredEvidence: [
       "Target commit is known and points at the intended branch or release.",
       "CI is green for the target commit.",
@@ -157,7 +157,7 @@ function deployRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate
       "Verify public app/API URLs listed in project memory if applicable.",
     ],
     rollbackNotes: [
-      "Rollback requires explicit human approval.",
+      "Rollback requires explicit operator approval.",
       "Prefer the project’s rollback workflow or redeploying a known-good commit.",
       "Capture failure command/logs before rollback so the cause is not lost.",
     ],
@@ -167,12 +167,12 @@ function deployRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate
 function rollbackRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
   return {
     goal: "Return production to a known-good state with an audit trail.",
-    trigger: "A deploy is unhealthy, customer-facing behavior regressed, or a human owner requests rollback.",
+    trigger: "A deploy is unhealthy, customer-facing behavior regressed, or an operator requests rollback.",
     requiredEvidence: [
       "Current bad deploy SHA/run is identified.",
       "Known-good SHA/run is identified.",
       "Failure symptom and first failing check/log are captured.",
-      "Human owner explicitly approves rollback.",
+      "Operator explicitly approves rollback.",
       project ? `Project memory reviewed for ${project.name}.` : "Project memory reviewed for the target project.",
     ],
     operatorSteps: [
@@ -268,13 +268,13 @@ function restartRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplat
 
 function genericRunbook(project: ProjectMemoryEntry | undefined): RunbookTemplate {
   return {
-    goal: "Prepare a safe admin action with human approval.",
-    trigger: "A human or agent asks whether a project-admin action is ready.",
+    goal: "Prepare a safe admin action with operator approval.",
+    trigger: "An operator or agent asks whether a project-admin action is ready.",
     requiredEvidence: [
       "Action type is explicit: merge, deploy, rollback, secret_rotation, or restart.",
       "Target project/repo/environment is identified.",
       "Read-only health/GitHub/handoff evidence has been checked.",
-      "Human owner approval path is known.",
+      "Operator approval path is known.",
     ],
     operatorSteps: [
       project ? `Start from project memory for ${project.name}.` : "Run `project memory` to identify the target project.",

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -728,7 +728,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     <section class="grid" aria-label="Monitor summary">
       <div class="card"><span class="metric">Status</span><span id="status" class="value">...</span></div>
       <div class="card"><span class="metric">Active / Just Finished</span><span id="active-count" class="value">0</span></div>
-      <div class="card"><span class="metric">Blocked / Human Review</span><span id="gate-count" class="value">0 / 0</span></div>
+      <div class="card"><span class="metric">Blocked / Operator Review</span><span id="gate-count" class="value">0 / 0</span></div>
       <div class="card"><span class="metric">Recent</span><span id="recent-count" class="value">0</span></div>
       <div class="card"><span class="metric">Events</span><span id="event-count" class="value">0</span></div>
     </section>
@@ -749,7 +749,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     </section>
     <section class="owner-summary" aria-label="Next action owners">
       <div class="owner-card"><span class="owner-label">Codex needs</span><span id="owner-codex" class="owner-count">0</span></div>
-      <div class="owner-card"><span class="owner-label">Human needs</span><span id="owner-human" class="owner-count">0</span></div>
+      <div class="owner-card"><span class="owner-label">Operator needs</span><span id="owner-human" class="owner-count">0</span></div>
       <div class="owner-card"><span class="owner-label">Merge queue</span><span id="owner-merge" class="owner-count">0</span></div>
       <div class="owner-card"><span class="owner-label">Hermes active</span><span id="owner-hermes" class="owner-count">0</span></div>
     </section>
@@ -757,7 +757,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     <section id="owner-lanes" class="owner-lanes" aria-label="Owner lanes"><div class="empty">No PR handoffs in the monitor window.</div></section>
     <div class="section-title"><h2>PR Pipeline</h2><span class="pill">grouped by repo</span></div>
     <section id="pipeline" class="pipeline-list"><div class="empty">No PR handoffs in the monitor window.</div></section>
-    <div class="section-title"><h2>Release Gate</h2><span class="pill">blocks + human review</span></div>
+    <div class="section-title"><h2>Release Gate</h2><span class="pill">blocks + operator review</span></div>
     <section id="attention" class="list"><div class="empty">No handoffs need attention.</div></section>
     <div class="section-title"><h2>Release Timeline</h2><span class="pill">auto-refresh 5s</span></div>
     <section id="recent" class="list"><div class="empty">Loading recent handoffs...</div></section>
@@ -899,7 +899,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function renderOwnerSummary(entries) {
       const owners = entries.map((item) => nextPipelineAction(item, releaseVerdict(item)).owner);
       document.getElementById("owner-codex").textContent = String(owners.filter((owner) => owner === "Codex").length);
-      document.getElementById("owner-human").textContent = String(owners.filter((owner) => owner === "Human owner").length);
+      document.getElementById("owner-human").textContent = String(owners.filter((owner) => owner === "Operator").length);
       document.getElementById("owner-merge").textContent = String(owners.filter((owner) => owner === "Merge queue").length);
       document.getElementById("owner-hermes").textContent = String(owners.filter((owner) => owner === "Hermes").length);
     }
@@ -918,7 +918,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       return [
         { key: "codex", title: "Codex", owner: "Codex", empty: "Nothing waiting on Codex." },
         { key: "hermes", title: "Hermes", owner: "Hermes", empty: "Hermes has no active PR checks." },
-        { key: "human", title: "Human", owner: "Human owner", empty: "No human review needed." },
+        { key: "operator", title: "Operator", owner: "Operator", empty: "No operator review needed." },
         { key: "merge", title: "Merge Queue", owner: "Merge queue", empty: "Nothing ready to merge." },
         { key: "done", title: "Done", owner: "Done", empty: "No completed PRs in view." },
       ];
@@ -1146,7 +1146,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function renderDecisionActions(item) {
       const key = decisionKeyForItem(item);
       return '<div class="decision-actions">' +
-        '<button class="decision-button" type="button" data-monitor-decision="approve" data-decision-key="' + escapeAttr(key) + '">Human approved</button>' +
+        '<button class="decision-button" type="button" data-monitor-decision="approve" data-decision-key="' + escapeAttr(key) + '">Operator approved</button>' +
         '</div>';
     }
 
@@ -1155,8 +1155,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (decision.status !== "approved") return "";
       const key = decisionKeyForItem(item);
       const at = decision.at ? " at " + new Date(decision.at).toLocaleString() : "";
-      return '<section class="decision-note" aria-label="Human decision">' +
-        '<strong>Human approved</strong>' + escapeHtml(at) + '. This is a private monitor decision only; GitHub was not mutated. ' +
+      return '<section class="decision-note" aria-label="Operator decision">' +
+        '<strong>Operator approved</strong>' + escapeHtml(at) + '. This is a private monitor decision only; GitHub was not mutated. ' +
         '<button class="decision-button" type="button" data-monitor-decision="reset" data-decision-key="' + escapeAttr(key) + '">Reset approval</button>' +
         '</section>';
     }
@@ -1173,7 +1173,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         ? fixRequest.checks.map(String).filter(Boolean)
         : missingTests.length ? missingTests : testSignals.slice(0, 5);
       return {
-        title: fixRequest.title || (verdict.level === "block" ? "Fix request for Codex" : "Review request for owner"),
+        title: fixRequest.title || (verdict.level === "block" ? "Fix request for Codex" : "Operator decision request"),
         owner: fixRequest.owner || action.owner,
         instruction: fixRequest.instruction || fixRequestInstruction(verdict, action),
         reason,
@@ -1188,7 +1188,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return "Codex should fix the blocking signal, push the PR branch, and wait for CI plus Hermes to re-run.";
       }
       if (verdict.level === "needs-review") {
-        return "Human owner should review the gated surface, then tell Codex whether to adjust the PR or proceed.";
+        return "Hermes/Codex should provide the code-level pre-check evidence. Operator should decide whether the project intent, architecture, and rollout risk are acceptable.";
       }
       return action.text;
     }
@@ -1197,7 +1197,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const first = reviewReasons.find(Boolean);
       if (!first) return "";
       const code = first.code ? String(first.code) : "review";
-      const message = first.message ? String(first.message) : "Human review recommended.";
+      const message = first.message ? String(first.message) : "Operator review recommended.";
       return code + ": " + message;
     }
 
@@ -1242,7 +1242,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return { key: "hermes", label: "Hermes reviewing" };
       }
       if (verdict.level === "block") return { key: "gate", label: "Blocked at gate" };
-      if (verdict.level === "needs-review") return { key: "gate", label: "Human review" };
+      if (verdict.level === "needs-review") return { key: "gate", label: "Operator review" };
       if (verdict.level === "pass") return { key: "gate", label: "Ready for merge" };
       return { key: "ci", label: "CI / handoff" };
     }
@@ -1251,7 +1251,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const status = normalize(item.status);
       if (item.active === true || item.activeState === "running" || status === "running") return "Hermes";
       if (verdict.level === "block") return "Codex";
-      if (verdict.level === "needs-review") return "Human owner";
+      if (verdict.level === "needs-review") return "Operator";
       if (verdict.level === "pass") return "Merge queue";
       return "GitHub Actions";
     }
@@ -1269,7 +1269,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return { owner: "Codex", text: "fix the blocking signal, push the PR branch, and wait for CI/Hermes to re-run" };
       }
       if (verdict.level === "needs-review") {
-        return { owner: "Human owner", text: "review the gated surface and decide whether Codex should adjust or the PR can proceed" };
+        return { owner: "Operator", text: "use the agent pre-check evidence to decide project intent, architecture, and rollout risk" };
       }
       if (verdict.level === "pass") {
         return { owner: "Merge queue", text: "merge when branch protection and queue checks are green" };
@@ -1452,7 +1452,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return {
           level: "pass",
           label: "APPROVED",
-          why: "Human owner approved this review gate in the private monitor; merge only if GitHub branch protection is green.",
+          why: "Operator approved this review gate in the private monitor; merge only if GitHub branch protection is green.",
         };
       }
       return verdict;
@@ -1540,7 +1540,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         || includesAny(reason, ["github_needs_review", "pr_review_hold", "needs_review"])
         || reviewReasons.length > 0
       ) {
-        return { level: "needs-review", label: "HUMAN REVIEW" };
+        return { level: "needs-review", label: "OPERATOR REVIEW" };
       }
       return { level: "pass", label: "PASS" };
     }
@@ -1550,12 +1550,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const first = reviewReasons.find(Boolean);
       if (first) {
         const code = String(first.code || "review");
-        const message = String(first.message || "Human review recommended.");
+        const message = String(first.message || "Operator review recommended.");
         return code + ": " + message;
       }
       const reason = normalize(summary.finalReason || summary.reason || item.reason);
-      if (reason === "github_needs_review") return "Human review recommended by the GitHub risk gate.";
-      if (reason === "pr_review_hold") return "PR risk gate held this for human review.";
+      if (reason === "github_needs_review") return "Operator review recommended by the GitHub risk gate; agent pre-check evidence should be attached.";
+      if (reason === "pr_review_hold") return "PR risk gate held this for operator review.";
       if (reason === "deploy_failure" || reason === "deploy_failed") return "Deploy failed; investigate before release.";
       if (reason === "post_deploy_healthy") return "Post-deploy suite, GitHub workflows, and configured health checks are clean.";
       if (reason === "hosted_health_failed") return "Hosted health check failed after deploy.";
@@ -1632,7 +1632,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       return reviewReasons.slice(0, 3).map((reason, index) => {
         const code = reason && reason.code ? String(reason.code) : "review";
         const severity = reason && reason.severity ? String(reason.severity) : "unknown";
-        const message = reason && reason.message ? String(reason.message) : "Human review recommended.";
+        const message = reason && reason.message ? String(reason.message) : "Operator review recommended.";
         return row(index === 0 ? "Review why" : "", escapeHtml(severity + " / " + code + " - " + message));
       }).join("");
     }

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -287,7 +287,7 @@ export function formatOperatorResultForSlack(result: unknown): string {
       evidence.length > 0 ? `*Evidence*\n${evidence.slice(0, 3).map(formatAdminProposalEvidence).join("\n")}` : "",
       risks.length > 0 ? `*Risks*\n${risks.slice(0, 4).map(formatAdminProposalRisk).join("\n")}` : "",
       blocked.length > 0 ? `*Blocked here*\n${blocked.slice(0, 5).map((entry) => `• \`${String(entry)}\``).join("\n")}` : "",
-      stringField(proposal, "nextHumanStep") ? `*Next human step*\n${stringField(proposal, "nextHumanStep")}` : "",
+      stringField(proposal, "nextHumanStep") ? `*Next operator step*\n${stringField(proposal, "nextHumanStep")}` : "",
       "Proposal-only. Hermes did not approve, merge, deploy, restart, rotate secrets, or mutate GitHub.",
     ].filter(Boolean).join("\n");
   }
@@ -599,11 +599,11 @@ function formatGithubMergeStewardForSlack(result: Record<string, unknown>): stri
   return [
     "*GitHub merge steward*",
     `• health: \`${stringField(github, "health") ?? "unknown"}\``,
-    `• open/pass/human/block: \`${numberField(counts, "openPullRequests") ?? 0}/${numberField(counts, "pass") ?? 0}/${numberField(counts, "humanReview") ?? 0}/${numberField(counts, "block") ?? 0}\``,
+    `• open/pass/operator/block: \`${numberField(counts, "openPullRequests") ?? 0}/${numberField(counts, "pass") ?? 0}/${numberField(counts, "humanReview") ?? 0}/${numberField(counts, "block") ?? 0}\``,
     `• auto-merge candidates: \`${numberField(counts, "autoMergeCandidates") ?? 0}\``,
     `• merge execution enabled: \`${String(github.mergeExecutionEnabled === true)}\``,
     candidates.length > 0 ? `*Clean candidates*\n${candidates.slice(0, 5).map(formatGithubStewardItem).join("\n")}` : "*Clean candidates*\n• none",
-    humanReview.length > 0 ? `*Human review*\n${humanReview.slice(0, 5).map(formatGithubStewardItem).join("\n")}` : "",
+    humanReview.length > 0 ? `*Operator review*\n${humanReview.slice(0, 5).map(formatGithubStewardItem).join("\n")}` : "",
     blocked.length > 0 ? `*Blocked*\n${blocked.slice(0, 5).map(formatGithubStewardItem).join("\n")}` : "",
     recommendations.length > 0 ? `*Next*\n${recommendations.slice(0, 3).map((entry) => `• ${String(entry)}`).join("\n")}` : "",
     "Read-only steward. Hermes did not merge, approve, rerun CI, or mutate GitHub.",
@@ -790,7 +790,7 @@ function handoffReleaseVerdict(value: Record<string, unknown>, summary: Record<s
     includesToken(finalReason, ["github_needs_review", "pr_review_hold", "needs_review"]) ||
     reviewReasons.length > 0
   ) {
-    return { label: "HUMAN REVIEW", why: handoffWhy(summary, value, "needs_review") };
+    return { label: "OPERATOR REVIEW", why: handoffWhy(summary, value, "needs_review") };
   }
   return { label: "PASS", why: handoffWhy(summary, value, "pass") };
 }
@@ -800,7 +800,7 @@ function handoffWhy(summary: Record<string, unknown>, value: Record<string, unkn
   const firstReviewReason = reviewReasons[0];
   if (firstReviewReason) {
     const code = stringField(firstReviewReason, "code") ?? "review";
-    const message = stringField(firstReviewReason, "message") ?? "Human review recommended.";
+    const message = stringField(firstReviewReason, "message") ?? "Operator review recommended.";
     return `${code}: ${message}`;
   }
   const reason = normalizeToken(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(value, "reason"));
@@ -808,8 +808,8 @@ function handoffWhy(summary: Record<string, unknown>, value: Record<string, unkn
   if (reason === "hosted_health_failed") return "hosted health failed after deploy";
   if (reason === "github_workflow_failed") return "GitHub has a failed workflow";
   if (reason === "testbed_cases_failed") return "one or more read-only testbed cases failed";
-  if (reason === "github_needs_review") return "human review recommended by the GitHub risk gate";
-  if (reason === "pr_review_hold") return "PR risk gate held this for human review";
+  if (reason === "github_needs_review") return "operator review recommended by the GitHub risk gate; agent pre-check evidence should be attached";
+  if (reason === "pr_review_hold") return "PR risk gate held this for operator review";
   if (reason === "ci_failed") return "CI failed";
   if (level === "pass") return "no blocking release signals recorded";
   return stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(value, "reason") ?? "no reason recorded";
@@ -955,7 +955,7 @@ function formatCodexHandoffProtocolForSlack(protocol: Record<string, unknown>): 
     .map((entry) => {
       const label = stringField(entry, "label") ?? "UNKNOWN";
       const meaning = stringField(entry, "meaning") ?? "No meaning recorded.";
-      const codexAction = stringField(entry, "codexAction") ?? "Follow normal human review policy.";
+      const codexAction = stringField(entry, "codexAction") ?? "Follow normal operator review policy.";
       return `• *${label}*: ${meaning} Codex: ${codexAction}`;
     })
     .join("\n");
@@ -971,7 +971,7 @@ function formatCodexHandoffProtocolForSlack(protocol: Record<string, unknown>): 
     "*Roles*",
     `• Codex: ${stringField(roles, "builder") ?? "builds in branches/worktrees and opens PRs."}`,
     `• Hermes: ${stringField(roles, "reviewerOperator") ?? "reviews risk and runs read-only checks."}`,
-    `• Human: ${stringField(roles, "approver") ?? "approves merge, deploy, rollback, and overrides."}`,
+    `• Operator: ${stringField(roles, "approver") ?? "approves merge, deploy, rollback, and overrides."}`,
     flow ? `*Flow*\n${flow}` : "",
     verdicts ? `*Verdicts*\n${verdicts}` : "",
     "*Contracts*",

--- a/services/slack-operator/src/stale-pr-alerts.ts
+++ b/services/slack-operator/src/stale-pr-alerts.ts
@@ -132,7 +132,7 @@ function nextOwner(item: Record<string, unknown>, verdict: ReturnType<typeof rel
   const status = normalize(stringField(item, "status"));
   if (item.active === true || stringField(item, "activeState") === "running" || status === "running") return "Hermes";
   if (verdict === "block") return "Codex";
-  if (verdict === "needs-review") return "Human owner";
+  if (verdict === "needs-review") return "Operator";
   if (verdict === "pass") return "Merge queue";
   return "GitHub Actions";
 }
@@ -140,7 +140,7 @@ function nextOwner(item: Record<string, unknown>, verdict: ReturnType<typeof rel
 function nextActionText(owner: string, verdict: ReturnType<typeof releaseVerdict>): string {
   if (owner === "Hermes") return "finish checks and publish a verdict";
   if (owner === "Codex") return "fix the blocking signal and push an update";
-  if (owner === "Human owner") return "review the gated surface and decide whether it can proceed";
+  if (owner === "Operator") return "use the agent pre-check evidence to decide project intent, architecture, and rollout risk";
   if (owner === "Merge queue") return "merge when branch protection and queue checks are green";
   if (verdict === "unknown") return "wait for CI/Hermes metadata";
   return "finish CI before release-gate recommendation";
@@ -150,14 +150,14 @@ function releaseReason(item: Record<string, unknown>, verdict: ReturnType<typeof
   const summary = toRecord(item.summary);
   const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
   const first = toRecord(reviewReasons.find(Boolean));
-  if (stringField(first, "message")) return stringField(first, "message") ?? "Human review recommended.";
+  if (stringField(first, "message")) return stringField(first, "message") ?? "Operator review recommended.";
   const reason = normalize(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(item, "reason"));
-  if (reason === "github_needs_review") return "Human review recommended by the GitHub risk gate.";
-  if (reason === "pr_review_hold") return "PR risk gate held this for human review.";
+  if (reason === "github_needs_review") return "Operator review recommended by the GitHub risk gate; agent pre-check evidence should be attached.";
+  if (reason === "pr_review_hold") return "PR risk gate held this for operator review.";
   if (reason === "ci_failed") return "CI failed; fix before merge.";
   if (reason === "ci_in_progress") return "CI is still running.";
   if (verdict === "block") return "Blocked by release gate.";
-  if (verdict === "needs-review") return "Human review recommended.";
+  if (verdict === "needs-review") return "Operator review recommended.";
   if (verdict === "pass") return "No blocking release signals recorded.";
   return "No reason recorded.";
 }

--- a/test/unit/handoff-events.test.ts
+++ b/test/unit/handoff-events.test.ts
@@ -182,7 +182,7 @@ describe("handoff event monitor", () => {
           mergeRecommendation: "needs_review",
           riskCategory: "workflow",
           highestRisk: "medium",
-          why: "PR touches deployment scripts; human review recommended.",
+          why: "PR touches deployment scripts; operator review recommended.",
           changedFiles: 2,
           tests: {
             matchedTouchedAreas: true,
@@ -212,7 +212,7 @@ describe("handoff event monitor", () => {
             {
               severity: "medium",
               code: "high_risk_files",
-              message: "PR touches deployment scripts; human review recommended.",
+              message: "PR touches deployment scripts; operator review recommended.",
             },
           ],
         },
@@ -231,7 +231,7 @@ describe("handoff event monitor", () => {
         mergeRecommendation: "needs_review",
         riskCategory: "workflow",
         highestRisk: "medium",
-        why: "PR touches deployment scripts; human review recommended.",
+        why: "PR touches deployment scripts; operator review recommended.",
         changedFiles: 2,
         testsMatchedTouchedAreas: true,
         missingTestSignals: [],
@@ -250,7 +250,7 @@ describe("handoff event monitor", () => {
         {
           severity: "medium",
           code: "high_risk_files",
-          message: "PR touches deployment scripts; human review recommended.",
+          message: "PR touches deployment scripts; operator review recommended.",
         },
       ],
     });

--- a/test/unit/operator-github.test.ts
+++ b/test/unit/operator-github.test.ts
@@ -721,7 +721,7 @@ describe("github operator status", () => {
     });
   });
 
-  it("asks for human review on deploy and workflow-only risk", async () => {
+  it("asks for operator review on deploy and workflow-only risk", async () => {
     const fetchFn = async (url: string | URL | Request) => {
       const text = String(url);
       if (text.endsWith("/repos/averray-agent/agent/pulls/188")) {
@@ -785,7 +785,7 @@ describe("github operator status", () => {
     ]));
   });
 
-  it("asks for human review on blockchain and XCM settlement changes even when CI is green", async () => {
+  it("asks for operator review on blockchain and XCM settlement changes even when CI is green", async () => {
     const fetchFn = async (url: string | URL | Request) => {
       const text = String(url);
       if (text.endsWith("/repos/averray-agent/agent/pulls/342")) {
@@ -859,7 +859,7 @@ describe("github operator status", () => {
       expect.objectContaining({
         severity: "medium",
         code: "pr_blockchain_settlement_review",
-        message: expect.stringContaining("request metadata preservation"),
+        message: expect.stringContaining("Agent pre-checks own code-level verification"),
       }),
       expect.objectContaining({ severity: "medium", code: "pr_review_risk_files" }),
     ]));

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -50,7 +50,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("live-status");
     expect(html).toContain("connecting");
     expect(html).toContain("Active / Just Finished");
-    expect(html).toContain("Blocked / Human Review");
+    expect(html).toContain("Blocked / Operator Review");
     expect(html).toContain("Live Lane");
     expect(html).toContain("Live state");
     expect(html).toContain("JUST FINISHED");
@@ -64,14 +64,14 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("data-pipeline-filter=\"running\"");
     expect(html).toContain("Next action owners");
     expect(html).toContain("Codex needs");
-    expect(html).toContain("Human needs");
+    expect(html).toContain("Operator needs");
     expect(html).toContain("Merge queue");
     expect(html).toContain("Hermes active");
     expect(html).toContain("Owner Lanes");
     expect(html).toContain("who acts next");
     expect(html).toContain("Nothing waiting on Codex.");
     expect(html).toContain("Hermes has no active PR checks.");
-    expect(html).toContain("No human review needed.");
+    expect(html).toContain("No operator review needed.");
     expect(html).toContain("Nothing ready to merge.");
     expect(html).toContain("No completed PRs in view.");
     expect(html).toContain("PR staleness summary");
@@ -86,8 +86,8 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Next actor");
     expect(html).toContain("Fix request");
     expect(html).toContain("Fix request for Codex");
-    expect(html).toContain("Review request for owner");
-    expect(html).toContain("Human approved");
+    expect(html).toContain("Operator decision request");
+    expect(html).toContain("Operator approved");
     expect(html).toContain("Reset approval");
     expect(html).toContain("private monitor decision only");
     expect(html).toContain("PR timeline");
@@ -110,7 +110,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("addEventListener(\"monitor\"");
     expect(html).toContain("startPolling(\"polling fallback 5s\")");
     expect(html).toContain("Release Gate");
-    expect(html).toContain("blocks + human review");
+    expect(html).toContain("blocks + operator review");
     expect(html).toContain("Release Timeline");
     expect(html).toContain("auto-refresh 5s");
     expect(html).toContain("activeWindowMinutes: \"240\"");

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -443,7 +443,7 @@ describe("slack operator bridge", () => {
 
     expect(text).toContain("*Codex Handoff Protocol*");
     expect(text).toContain("Codex remains the builder");
-    expect(text).toContain("*HUMAN REVIEW*");
+    expect(text).toContain("*OPERATOR REVIEW*");
     expect(text).toContain("intent=pr_code_review");
     expect(text).toContain("intent=pr_handoff");
     expect(text).toContain("email required: `false`");
@@ -763,7 +763,7 @@ describe("slack operator bridge", () => {
     });
 
     expect(text).toContain("*GitHub merge steward*");
-    expect(text).toContain("open/pass/human/block: `2/1/0/1`");
+    expect(text).toContain("open/pass/operator/block: `2/1/0/1`");
     expect(text).toContain("merge execution enabled: `false`");
     expect(text).toContain("*Clean candidates*");
     expect(text).toContain("github_ok_to_merge");

--- a/test/unit/stale-pr-alerts.test.ts
+++ b/test/unit/stale-pr-alerts.test.ts
@@ -79,7 +79,7 @@ describe("stale PR handoff alerts", () => {
     });
 
     expect(items).toHaveLength(1);
-    expect(items[0]?.owner).toBe("Human owner");
+    expect(items[0]?.owner).toBe("Operator");
   });
 
   it("only posts when stale handoffs exist and signature changes", () => {
@@ -116,17 +116,17 @@ describe("stale PR handoff alerts", () => {
         repo: "depre-dev/averray-reference-agent",
         pullRequestNumber: 14,
         pullRequestUrl: "https://github.com/depre-dev/averray-reference-agent/pull/14",
-        owner: "Human owner",
+        owner: "Operator",
         ageMinutes: 180,
         ageLabel: "3h",
-        nextAction: "review the gated surface",
-        reason: "Human review recommended.",
+        nextAction: "use the agent pre-check evidence to decide project intent, architecture, and rollout risk",
+        reason: "Operator review recommended.",
       },
     ], "https://monitor.averray.com/monitor");
 
     expect(text).toContain("*Hermes stale PR handoffs*");
     expect(text).toContain("<https://github.com/depre-dev/averray-reference-agent/pull/14|depre-dev/averray-reference-agent #14>");
-    expect(text).toContain("owner: `Human owner`");
+    expect(text).toContain("owner: `Operator`");
     expect(text).toContain("age: `3h`");
     expect(text).toContain("Open monitor: https://monitor.averray.com/monitor");
   });


### PR DESCRIPTION
## Summary
- rename user-facing Human Review wording to Operator Review across monitor, Slack, runbooks, and handoff protocol
- clarify blockchain/XCM settlement review as an operator sign-off after Hermes/Codex code-level pre-checks
- update stale PR alerts and PR handoff comments so the operator queue asks for intent/architecture/rollout decisions, not code auditing

## Checks
- npm test -- test/unit/operator-github.test.ts test/unit/slack-monitor.test.ts test/unit/stale-pr-alerts.test.ts test/unit/slack-operator.test.ts test/unit/handoff-events.test.ts
- npm run build
- git diff --check