### PR TITLE
Add block fix guidance to monitor

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -1756,6 +1756,39 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
     .verdict-box .vb-head .vb-age { color: var(--muted); }
     .verdict-box .vb-text { color: var(--text); line-height: 1.4; }
+    .owner-contract {
+      display: grid;
+      gap: 10px;
+    }
+    .owner-contract .oc-current {
+      display: grid;
+      gap: 4px;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--surface-soft);
+      padding: 10px 12px;
+    }
+    .oc-owner {
+      color: var(--text);
+      font-weight: 800;
+    }
+    .oc-action {
+      color: var(--muted);
+      line-height: 1.4;
+    }
+    .oc-roles {
+      display: grid;
+      gap: 6px;
+    }
+    .oc-role {
+      display: grid;
+      grid-template-columns: 80px 1fr;
+      gap: 10px;
+      color: var(--muted);
+      font-size: 0.8rem;
+      line-height: 1.35;
+    }
+    .oc-role strong { color: var(--text); }
 
     /* Operator checklist with real checkboxes */
     .operator-checklist { display: grid; gap: 6px; }
@@ -2744,6 +2777,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function primaryActionButton(item, verdict, action, lane) {
       if (verdict.level === "block") return '<button class="soft-button" data-action="primary" type="button" data-review-card="' + escapeAttr(boardItemKey(item)) + '">Fix plan -></button>';
+      if (isDraftPullRequest(item)) return '<button class="soft-button" data-action="primary" type="button" data-review-card="' + escapeAttr(boardItemKey(item)) + '">Codex draft -></button>';
       if (verdict.level === "needs-review") return '<button class="soft-button" data-action="primary" type="button" data-review-card="' + escapeAttr(boardItemKey(item)) + '">Review</button>';
       if (verdict.level === "running") return '<button class="soft-button" data-action="primary" type="button" data-command-suggestion="handoff monitor details">Ask Hermes</button>';
       if (verdict.level === "pass" && lane.key === "queue") return '<button class="soft-button" data-action="primary" type="button" data-command-suggestion="merge steward details">Queue Merge</button>';
@@ -2761,6 +2795,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return verdict.level === "pass" ? { key: "done" } : { key: "attention" };
       }
       if (item.active === true || item.activeState === "running" || status === "running") return { key: "hermes" };
+      if (isDraftPullRequest(item)) return { key: "codex" };
       if (reason === "ci_in_progress") return { key: "codex" };
       if (verdict.level === "block") return { key: "attention" };
       if (verdict.level === "needs-review") return { key: "operator" };
@@ -2852,8 +2887,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<div class="drawer-body">' +
         (verdict.level === "block" ? '<section class="drawer-section">' + renderFailureCallout(verdict, summary) + '</section>' : "") +
         '<section class="drawer-section"><h3>Hermes verdict</h3>' + renderHermesVerdictBox(verdict, age) + (richReviewWhy ? '<div class="review-why">' + richReviewWhy + '</div>' : "") + '</section>' +
+        '<section class="drawer-section">' + renderHandoffOwnerContract(item, verdict, action) + '</section>' +
         (verdict.level === "block" ? renderBlockResolutionPanel(item, summary, verdict, action) : "") +
-        (verdict.level === "needs-review" ? '<section class="drawer-section">' + renderOperatorChecklistPanel(item, verdict, action) + '</section>' : "") +
+        (verdict.level === "needs-review" && !isDraftPullRequest(item) ? '<section class="drawer-section">' + renderOperatorChecklistPanel(item, verdict, action) + '</section>' : "") +
         '<section class="drawer-section"><h3>Agent pre-check</h3>' + renderAgentPrecheckList(item, summary, verdict, stage) + '</section>' +
         '<section class="drawer-section"><h3>Checks</h3>' + renderCheckMatrix(summary, testSignals) + '</section>' +
         ((touchedFiles.length || touchedAreas.length) ? '<section class="drawer-section"><h3>Touched files</h3>' + renderTouchedFiles(touchedFiles, touchedAreas) + '</section>' : "") +
@@ -2882,6 +2918,44 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<div class="vb-head"><span>' + escapeHtml(verdict.label) + '</span><span class="vb-age">' + escapeHtml(age.label + " " + age.duration) + '</span></div>' +
         '<div class="vb-text">' + escapeHtml(shortenVerdictWhy(verdict.why)) + '</div>' +
         '</div>';
+    }
+
+    function renderHandoffOwnerContract(item, verdict, action) {
+      const contract = ownerContractForItem(item, verdict, action);
+      return '<h3>Handoff owner</h3><div class="owner-contract">' +
+        '<div class="oc-current"><span class="oc-owner">Current owner: ' + escapeHtml(contract.owner) + '</span><span class="oc-action">' + escapeHtml(contract.action) + '</span></div>' +
+        '<div class="oc-roles">' +
+          '<div class="oc-role"><strong>Codex</strong><span>builds code, fixes blockers, resolves draft readiness, and pushes PR updates.</span></div>' +
+          '<div class="oc-role"><strong>Hermes</strong><span>runs read-only PR checks, code-risk review, testbed verification, and publishes the verdict.</span></div>' +
+          '<div class="oc-role"><strong>Operator</strong><span>decides project intent, architecture, rollout, and business risk after agent pre-check evidence exists.</span></div>' +
+          '<div class="oc-role"><strong>Queue</strong><span>merges only after branch protection, Hermes verdict, and any operator sign-off are clean.</span></div>' +
+        '</div>' +
+      '</div>';
+    }
+
+    function ownerContractForItem(item, verdict, action) {
+      if (isDraftPullRequest(item)) {
+        return {
+          owner: "Codex",
+          action: "Finish the draft or mark it ready for review. Hermes and Operator should wait until the draft state clears.",
+        };
+      }
+      if (verdict.level === "block") {
+        return {
+          owner: action.owner,
+          action: action.text,
+        };
+      }
+      if (verdict.level === "needs-review") {
+        return {
+          owner: "Operator",
+          action: "Review the project-level decision request only. Code-level analysis should already be attached by Hermes/Codex.",
+        };
+      }
+      return {
+        owner: action.owner,
+        action: action.text,
+      };
     }
 
     // Drop verbose prefixes Hermes adds to roll-up verdicts so the box reads as a clear summary.
@@ -3604,7 +3678,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function renderFixRequest(item, summary, verdict, action) {
       if (verdict.level !== "block" && verdict.level !== "needs-review") return "";
       const request = buildFixRequest(item, summary, verdict, action);
-      const actions = verdict.level === "needs-review" ? renderDecisionActions(item) : "";
+      const actions = verdict.level === "needs-review" && !isDraftPullRequest(item) ? renderDecisionActions(item) : "";
       return '<section class="fix-request" data-level="' + escapeAttr(verdict.level) + '" aria-label="Fix request">' +
         '<p class="fix-request-title">' + escapeHtml(request.title) + '</p>' +
         '<p class="fix-request-copy">' + escapeHtml(request.instruction) + '</p>' +
@@ -3761,8 +3835,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const checks = Array.isArray(fixRequest.checks)
         ? fixRequest.checks.map(String).filter(Boolean)
         : missingTests.length ? missingTests : defaultFixChecks(item, summary, testSignals);
+      const isDraft = isDraftPullRequest(item);
       return {
-        title: fixRequest.title || (verdict.level === "block" ? "Fix request for Codex" : "Operator decision request"),
+        title: fixRequest.title || (isDraft ? "Draft readiness request for Codex" : verdict.level === "block" ? "Fix request for Codex" : "Operator decision request"),
         owner: fixRequest.owner || action.owner,
         instruction: fixRequest.instruction || fixRequestInstruction(item, summary, verdict, action),
         reason,
@@ -3774,6 +3849,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function fixRequestInstruction(item, summary, verdict, action) {
       const reason = normalize(summary.finalReason || summary.reason || item.reason);
+      if (isDraftPullRequest(item)) {
+        return "Codex should finish the draft work, mark the PR ready for review, and let CI plus Hermes run on the ready PR.";
+      }
       if (verdict.level === "block") {
         if (isDeployItem(item) && reason === "hosted_health_failed") {
           return "Codex should fix the hosted app/config health failure in a follow-up PR, or prepare a rollback proposal if production is affected.";
@@ -3939,6 +4017,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (item.active === true || item.activeState === "running" || status === "running") {
         return { key: "hermes", label: "Hermes reviewing" };
       }
+      if (isDraftPullRequest(item)) return { key: "pr", label: "Draft PR" };
       if (verdict.level === "block") return { key: "gate", label: "Blocked at gate" };
       if (verdict.level === "needs-review") return { key: "gate", label: "Operator review" };
       if (verdict.level === "pass") return { key: "gate", label: "Ready for merge" };
@@ -3948,6 +4027,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function nextPipelineActor(item, verdict) {
       const status = normalize(item.status);
       if (item.active === true || item.activeState === "running" || status === "running") return "Hermes";
+      if (isDraftPullRequest(item)) return "Codex";
       if (verdict.level === "block") return "Codex";
       if (verdict.level === "needs-review") return "Operator";
       if (verdict.level === "pass") return "Merge queue";
@@ -3962,6 +4042,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       }
       if (item.active === true || item.activeState === "running" || status === "running") {
         return { owner: "Hermes", text: "finish the current handoff checks and publish a verdict" };
+      }
+      if (isDraftPullRequest(item)) {
+        return { owner: "Codex", text: "finish the draft or mark it ready for review, then let CI and Hermes re-run" };
       }
       if (verdict.level === "block") {
         if (isDeployItem(item)) {
@@ -4202,7 +4285,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return { level: "pass", label: "CLOSED", why: "GitHub reports this PR is closed; this handoff is history." };
       }
       if (prState && prState.draft === true) {
-        return { level: "needs-review", label: "DRAFT", why: "GitHub reports this PR is still a draft." };
+        return { level: "needs-review", label: "DRAFT", why: "GitHub reports this PR is still a draft; Codex owns finishing it or marking it ready before Hermes/operator review." };
       }
       if (prState && normalize(prState.mergeableState) === "dirty") {
         return { level: "block", label: "CONFLICT", why: "GitHub reports this PR has merge conflicts." };
@@ -4302,7 +4385,18 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function pullRequestState(item, summary) {
       if (summary && typeof summary.currentPullRequest === "object" && summary.currentPullRequest !== null) return summary.currentPullRequest;
       if (summary && typeof summary.pullRequest === "object" && summary.pullRequest !== null) return summary.pullRequest;
+      if (item && Array.isArray(item.groupItems)) {
+        for (const entry of item.groupItems) {
+          const nested = pullRequestState(entry, entry.summary || {});
+          if (nested) return nested;
+        }
+      }
       return null;
+    }
+
+    function isDraftPullRequest(item) {
+      const prState = pullRequestState(item, item.summary || {});
+      return Boolean(prState && prState.draft === true && !isDonePullRequestState(prState));
     }
 
     function isDonePullRequestState(prState) {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -488,6 +488,47 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       border-left-color: var(--warn);
       background: var(--warn-bg);
     }
+    .block-resolution {
+      border-left: 4px solid var(--bad);
+    }
+    .resolution-summary {
+      margin: 0;
+      color: var(--text);
+      line-height: 1.42;
+    }
+    .resolution-grid {
+      display: grid;
+      grid-template-columns: 118px minmax(0, 1fr);
+      gap: 7px 10px;
+      margin: 10px 0;
+    }
+    .resolution-grid dt {
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.62rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+    }
+    .resolution-grid dd {
+      margin: 0;
+      overflow-wrap: anywhere;
+    }
+    .resolution-steps {
+      display: grid;
+      gap: 8px;
+      margin: 10px 0 0;
+      padding-left: 20px;
+    }
+    .resolution-steps li {
+      color: var(--text);
+      line-height: 1.35;
+    }
+    .resolution-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 12px;
+    }
     .operator-decision {
       border-left: 4px solid var(--warn);
     }
@@ -1406,6 +1447,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       .fix-request-meta,
       .pipeline-meta,
       .operator-evidence,
+      .resolution-grid,
       .pipeline-detail { grid-template-columns: 1fr; }
       dl { grid-template-columns: 1fr; }
       .cmdbar,
@@ -2701,7 +2743,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
 
     function primaryActionButton(item, verdict, action, lane) {
-      if (verdict.level === "block") return '<button class="soft-button" data-action="primary" type="button" data-command-suggestion="merge steward details">Codex Fix -></button>';
+      if (verdict.level === "block") return '<button class="soft-button" data-action="primary" type="button" data-review-card="' + escapeAttr(boardItemKey(item)) + '">Fix plan -></button>';
       if (verdict.level === "needs-review") return '<button class="soft-button" data-action="primary" type="button" data-review-card="' + escapeAttr(boardItemKey(item)) + '">Review</button>';
       if (verdict.level === "running") return '<button class="soft-button" data-action="primary" type="button" data-command-suggestion="handoff monitor details">Ask Hermes</button>';
       if (verdict.level === "pass" && lane.key === "queue") return '<button class="soft-button" data-action="primary" type="button" data-command-suggestion="merge steward details">Queue Merge</button>';
@@ -2810,6 +2852,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<div class="drawer-body">' +
         (verdict.level === "block" ? '<section class="drawer-section">' + renderFailureCallout(verdict, summary) + '</section>' : "") +
         '<section class="drawer-section"><h3>Hermes verdict</h3>' + renderHermesVerdictBox(verdict, age) + (richReviewWhy ? '<div class="review-why">' + richReviewWhy + '</div>' : "") + '</section>' +
+        (verdict.level === "block" ? renderBlockResolutionPanel(item, summary, verdict, action) : "") +
         (verdict.level === "needs-review" ? '<section class="drawer-section">' + renderOperatorChecklistPanel(item, verdict, action) + '</section>' : "") +
         '<section class="drawer-section"><h3>Agent pre-check</h3>' + renderAgentPrecheckList(item, summary, verdict, stage) + '</section>' +
         '<section class="drawer-section"><h3>Checks</h3>' + renderCheckMatrix(summary, testSignals) + '</section>' +
@@ -3576,6 +3619,25 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '</section>';
     }
 
+    function renderBlockResolutionPanel(item, summary, verdict, action) {
+      const plan = blockResolutionPlan(item, summary, verdict, action);
+      const evidenceRows = [
+        row("Owner", escapeHtml(plan.owner)),
+        row("Blocked by", escapeHtml(plan.reason)),
+        row("Evidence", plan.evidence.length ? chips(plan.evidence) : escapeHtml("Hermes verdict only")),
+        row("Clears when", escapeHtml(plan.clearsWhen)),
+      ].join("");
+      return '<section class="drawer-section block-resolution"><h3>Fix this block</h3>' +
+        '<p class="resolution-summary">' + escapeHtml(plan.summary) + '</p>' +
+        '<dl class="resolution-grid">' + evidenceRows + '</dl>' +
+        '<ol class="resolution-steps">' + plan.steps.map((step) => '<li>' + escapeHtml(step) + '</li>').join("") + '</ol>' +
+        '<div class="resolution-actions">' +
+          '<button class="soft-button" type="button" data-command-suggestion="' + escapeAttr(plan.askCommand) + '">Ask Hermes for details</button>' +
+          '<button class="soft-button" type="button" data-command-suggestion="ops health">Run ops health</button>' +
+        '</div>' +
+        '</section>';
+    }
+
     function renderDecisionActions(item) {
       const key = decisionKeyForItem(item);
       return '<div class="decision-actions">' +
@@ -3594,6 +3656,100 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '</section>';
     }
 
+    function blockResolutionPlan(item, summary, verdict, action) {
+      const reason = normalize(summary.finalReason || summary.reason || item.reason);
+      const request = buildFixRequest(item, summary, verdict, action);
+      const evidence = blockResolutionEvidence(summary, request);
+      const base = {
+        owner: request.owner || action.owner,
+        reason: request.reason || verdict.why,
+        evidence,
+        askCommand: "what should we do next",
+      };
+      if (isDeployItem(item) && reason === "hosted_health_failed") {
+        return {
+          ...base,
+          summary: "Production deploy finished, but the hosted app health check is failing. Treat this as a follow-up fix or rollback decision, not a merge approval.",
+          clearsWhen: "hosted health is ok and the post-deploy suite returns PASS",
+          steps: [
+            "Open the workflow run and inspect the hosted-health or post-deploy verification step.",
+            "Run ops health from this monitor to confirm whether the backend, frontend, and command-center are currently healthy.",
+            "Have Codex open a small fix PR for the broken app/config path, or prepare a rollback proposal if production is affected.",
+            "After the fix deploys, wait for Hermes post-deploy verification to record hosted ok and zero failing workflows.",
+          ],
+        };
+      }
+      if (isDeployItem(item) && reason === "github_workflow_failed") {
+        return {
+          ...base,
+          summary: "The deployed commit has a failed GitHub workflow. The release is blocked until the red run is understood and fixed.",
+          clearsWhen: "the failed workflow is green on a new commit or a follow-up deploy",
+          steps: [
+            "Open the failed workflow run from References.",
+            "Identify the failing job and affected component.",
+            "Have Codex fix the failing check in a follow-up PR, then let CI and Hermes post-deploy verification re-run.",
+          ],
+        };
+      }
+      if (isDeployItem(item) && reason === "testbed_cases_failed") {
+        return {
+          ...base,
+          summary: "The read-only post-deploy testbed suite failed. The release is blocked until the failing case is explained or fixed.",
+          clearsWhen: "all requested post-deploy testbed cases pass or the failed case is explicitly waived by an operator",
+          steps: [
+            "Ask Hermes for handoff details to get the failed testbed case IDs.",
+            "Have Codex fix the platform behavior or test fixture that caused the failure.",
+            "Re-run post-deploy verification and confirm the suite has zero failures.",
+          ],
+        };
+      }
+      if (reason === "ci_failed") {
+        return {
+          ...base,
+          summary: "CI is red. Codex owns this until the failing job is fixed on the PR branch.",
+          clearsWhen: "all branch protection checks are green and Hermes re-checks the PR",
+          steps: [
+            "Open the workflow run and identify the failing job.",
+            "Have Codex patch the PR branch with the smallest fix.",
+            "Wait for CI and Hermes PR handoff to re-run on the new commit.",
+          ],
+        };
+      }
+      if (reason === "deploy_failure" || reason === "deploy_failed") {
+        return {
+          ...base,
+          summary: "The production deploy workflow failed. Do not continue release work until the failing deploy step is fixed or rolled back.",
+          clearsWhen: "deploy workflow succeeds and post-deploy verification is green",
+          steps: [
+            "Open the deploy workflow run and find the exact failing command.",
+            "Have Codex fix the deploy script/config issue, or prepare a rollback proposal if the broken deploy reached production.",
+            "Re-run through the normal PR/deploy path and wait for Hermes verification.",
+          ],
+        };
+      }
+      return {
+        ...base,
+        summary: request.instruction || "The release gate is blocked. Codex should fix the blocking signal before this item moves forward.",
+        clearsWhen: "the blocking reason disappears and Hermes records PASS",
+        steps: [
+          "Open the linked PR or workflow run and inspect the red signal named above.",
+          "Have Codex make the smallest targeted fix and push a new commit.",
+          "Wait for CI, Hermes handoff, and any requested testbed checks to re-run cleanly.",
+        ],
+      };
+    }
+
+    function blockResolutionEvidence(summary, request) {
+      const health = summary.deploymentHealth && typeof summary.deploymentHealth === "object" ? summary.deploymentHealth : {};
+      const bits = [];
+      if (Array.isArray(health.hostedFailedUrls) && health.hostedFailedUrls.length) bits.push("hosted health URL failed");
+      if (typeof health.githubFailingWorkflowRuns === "number" && health.githubFailingWorkflowRuns > 0) bits.push(String(health.githubFailingWorkflowRuns) + " failed workflow run(s)");
+      if (typeof health.suiteFailed === "number" && health.suiteFailed > 0) bits.push(String(health.suiteFailed) + " failed testbed case(s)");
+      if (request.checks.length) bits.push.apply(bits, request.checks.slice(0, 4));
+      if (request.surfaces.length) bits.push.apply(bits, request.surfaces.slice(0, 4));
+      return Array.from(new Set(bits.filter(Boolean)));
+    }
+
     function buildFixRequest(item, summary, verdict, action) {
       const signals = summary.reviewSignals || {};
       const fixRequest = summary.fixRequest && typeof summary.fixRequest === "object" ? summary.fixRequest : {};
@@ -3604,26 +3760,62 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const reason = firstReviewReason(reviewReasons) || releaseReason(summary, item, verdict.level);
       const checks = Array.isArray(fixRequest.checks)
         ? fixRequest.checks.map(String).filter(Boolean)
-        : missingTests.length ? missingTests : testSignals.slice(0, 5);
+        : missingTests.length ? missingTests : defaultFixChecks(item, summary, testSignals);
       return {
         title: fixRequest.title || (verdict.level === "block" ? "Fix request for Codex" : "Operator decision request"),
         owner: fixRequest.owner || action.owner,
-        instruction: fixRequest.instruction || fixRequestInstruction(verdict, action),
+        instruction: fixRequest.instruction || fixRequestInstruction(item, summary, verdict, action),
         reason,
-        surfaces: Array.isArray(fixRequest.surfaces) ? fixRequest.surfaces.map(String).filter(Boolean) : touchedAreas,
+        surfaces: Array.isArray(fixRequest.surfaces) ? fixRequest.surfaces.map(String).filter(Boolean) : defaultFixSurfaces(item, summary, touchedAreas),
         checks,
-        rerun: fixRequest.rerun || "push an update, then let CI and Hermes handoff run again",
+        rerun: fixRequest.rerun || defaultFixRerun(item, summary),
       };
     }
 
-    function fixRequestInstruction(verdict, action) {
+    function fixRequestInstruction(item, summary, verdict, action) {
+      const reason = normalize(summary.finalReason || summary.reason || item.reason);
       if (verdict.level === "block") {
+        if (isDeployItem(item) && reason === "hosted_health_failed") {
+          return "Codex should fix the hosted app/config health failure in a follow-up PR, or prepare a rollback proposal if production is affected.";
+        }
+        if (isDeployItem(item)) {
+          return "Codex should fix the failed deploy or post-deploy signal in a follow-up PR, then let the production verification run again.";
+        }
         return "Codex should fix the blocking signal, push the PR branch, and wait for CI plus Hermes to re-run.";
       }
       if (verdict.level === "needs-review") {
         return "Hermes/Codex should provide the code-level pre-check evidence. Operator should decide whether the project intent, architecture, and rollout risk are acceptable.";
       }
       return action.text;
+    }
+
+    function defaultFixSurfaces(item, summary, touchedAreas) {
+      const reason = normalize(summary.finalReason || summary.reason || item.reason);
+      if (isDeployItem(item)) {
+        if (reason === "hosted_health_failed") return ["post-deploy", "hosted health"];
+        if (reason === "github_workflow_failed") return ["post-deploy", "github workflow"];
+        if (reason === "testbed_cases_failed") return ["post-deploy", "testbed suite"];
+        return ["post-deploy"];
+      }
+      return touchedAreas;
+    }
+
+    function defaultFixChecks(item, summary, testSignals) {
+      const reason = normalize(summary.finalReason || summary.reason || item.reason);
+      if (isDeployItem(item)) {
+        if (reason === "hosted_health_failed") return ["ops health", "hosted health", "post-deploy suite"];
+        if (reason === "github_workflow_failed") return ["failed workflow run", "post-deploy suite"];
+        if (reason === "testbed_cases_failed") return ["failed testbed case", "post-deploy suite"];
+        return ["deploy workflow", "post-deploy suite"];
+      }
+      return testSignals.slice(0, 5);
+    }
+
+    function defaultFixRerun(item, summary) {
+      if (isDeployItem(item)) {
+        return "merge a fix or rollback path, then let production deploy and Hermes post-deploy verification run again";
+      }
+      return "push an update, then let CI and Hermes handoff run again";
     }
 
     function firstReviewReason(reviewReasons) {
@@ -3772,6 +3964,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return { owner: "Hermes", text: "finish the current handoff checks and publish a verdict" };
       }
       if (verdict.level === "block") {
+        if (isDeployItem(item)) {
+          return { owner: "Codex", text: "open a follow-up fix PR or rollback proposal, then verify hosted health and post-deploy checks" };
+        }
         return { owner: "Codex", text: "fix the blocking signal, push the PR branch, and wait for CI/Hermes to re-run" };
       }
       if (verdict.level === "needs-review") {

--- a/services/slack-operator/src/stale-pr-alerts.ts
+++ b/services/slack-operator/src/stale-pr-alerts.ts
@@ -43,7 +43,7 @@ export function stalePrAlertItems(input: StalePrAlertInput): StalePrAlertItem[] 
       owner,
       ageMinutes,
       ageLabel: formatDuration(ageMinutes),
-      nextAction: nextActionText(owner, verdict),
+      nextAction: nextActionText(owner, verdict, item),
       reason: releaseReason(item, verdict),
       updatedAt,
     });
@@ -131,14 +131,16 @@ function releaseVerdict(item: Record<string, unknown>): "block" | "needs-review"
 function nextOwner(item: Record<string, unknown>, verdict: ReturnType<typeof releaseVerdict>): string {
   const status = normalize(stringField(item, "status"));
   if (item.active === true || stringField(item, "activeState") === "running" || status === "running") return "Hermes";
+  if (isDraftPullRequest(item)) return "Codex";
   if (verdict === "block") return "Codex";
   if (verdict === "needs-review") return "Operator";
   if (verdict === "pass") return "Merge queue";
   return "GitHub Actions";
 }
 
-function nextActionText(owner: string, verdict: ReturnType<typeof releaseVerdict>): string {
+function nextActionText(owner: string, verdict: ReturnType<typeof releaseVerdict>, item: Record<string, unknown>): string {
   if (owner === "Hermes") return "finish checks and publish a verdict";
+  if (owner === "Codex" && isDraftPullRequest(item)) return "finish the draft or mark it ready for review so CI and Hermes can run";
   if (owner === "Codex") return "fix the blocking signal and push an update";
   if (owner === "Operator") return "use the agent pre-check evidence to decide project intent, architecture, and rollout risk";
   if (owner === "Merge queue") return "merge when branch protection and queue checks are green";
@@ -151,6 +153,7 @@ function releaseReason(item: Record<string, unknown>, verdict: ReturnType<typeof
   const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
   const first = toRecord(reviewReasons.find(Boolean));
   if (stringField(first, "message")) return stringField(first, "message") ?? "Operator review recommended.";
+  if (isDraftPullRequest(item)) return "PR is still draft; Codex must finish it or mark it ready before Hermes/operator can proceed.";
   const reason = normalize(stringField(summary, "finalReason") ?? stringField(summary, "reason") ?? stringField(item, "reason"));
   if (reason === "github_needs_review") return "Operator review recommended by the GitHub risk gate; agent pre-check evidence should be attached.";
   if (reason === "pr_review_hold") return "PR risk gate held this for operator review.";
@@ -160,6 +163,25 @@ function releaseReason(item: Record<string, unknown>, verdict: ReturnType<typeof
   if (verdict === "needs-review") return "Operator review recommended.";
   if (verdict === "pass") return "No blocking release signals recorded.";
   return "No reason recorded.";
+}
+
+function isDraftPullRequest(item: Record<string, unknown>): boolean {
+  const prState = pullRequestState(item);
+  return Boolean(prState && prState.draft === true && !isDonePullRequestState(prState));
+}
+
+function pullRequestState(item: Record<string, unknown>): Record<string, unknown> | undefined {
+  const summary = toRecord(item.summary);
+  const current = toRecord(summary.currentPullRequest);
+  if (Object.keys(current).length > 0) return current;
+  const pullRequest = toRecord(summary.pullRequest);
+  if (Object.keys(pullRequest).length > 0) return pullRequest;
+  return undefined;
+}
+
+function isDonePullRequestState(prState: Record<string, unknown> | undefined): boolean {
+  if (!prState) return false;
+  return prState.merged === true || normalize(stringField(prState, "state")) === "closed";
 }
 
 function ageInMinutes(updatedAt: string | undefined, now: Date): number {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -87,6 +87,8 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("sorted by next-action urgency");
     expect(html).toContain("id=\"pause\"");
     expect(html).toContain("renderFailureCallout(verdict, summary)");
+    expect(html).toContain("renderBlockResolutionPanel(item, summary, verdict, action)");
+    expect(html).toContain("blockResolutionPlan(item, summary, verdict, action)");
     expect(html).toContain("renderHermesVerdictBox(verdict, age)");
     expect(html).toContain("renderOperatorChecklistPanel(item, verdict, action)");
     expect(html).toContain("renderAgentPrecheckList(item, summary, verdict, stage)");
@@ -129,6 +131,10 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderPrTimeline(item, stage, verdict, action)");
     expect(html).toContain("renderDecisionActions(item)");
     expect(html).toContain("buildFixRequest(item, summary, verdict, action)");
+    expect(html).toContain("Fix this block");
+    expect(html).toContain("open a follow-up fix PR or rollback proposal");
+    expect(html).toContain("hosted app/config health failure");
+    expect(html).toContain("hosted health is ok and the post-deploy suite returns PASS");
     expect(html).toContain("Operator decision");
     expect(html).toContain("Operator decision request");
     expect(html).toContain("Approve only if");

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -90,6 +90,8 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderBlockResolutionPanel(item, summary, verdict, action)");
     expect(html).toContain("blockResolutionPlan(item, summary, verdict, action)");
     expect(html).toContain("renderHermesVerdictBox(verdict, age)");
+    expect(html).toContain("renderHandoffOwnerContract(item, verdict, action)");
+    expect(html).toContain("ownerContractForItem(item, verdict, action)");
     expect(html).toContain("renderOperatorChecklistPanel(item, verdict, action)");
     expect(html).toContain("renderAgentPrecheckList(item, summary, verdict, stage)");
     expect(html).toContain("renderCheckMatrix(summary, testSignals)");
@@ -132,6 +134,10 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderDecisionActions(item)");
     expect(html).toContain("buildFixRequest(item, summary, verdict, action)");
     expect(html).toContain("Fix this block");
+    expect(html).toContain("Handoff owner");
+    expect(html).toContain("Codex owns finishing it or marking it ready");
+    expect(html).toContain("finish the draft or mark it ready for review");
+    expect(html).toContain("Codex draft");
     expect(html).toContain("open a follow-up fix PR or rollback proposal");
     expect(html).toContain("hosted app/config health failure");
     expect(html).toContain("hosted health is ok and the post-deploy suite returns PASS");

--- a/test/unit/stale-pr-alerts.test.ts
+++ b/test/unit/stale-pr-alerts.test.ts
@@ -82,6 +82,39 @@ describe("stale PR handoff alerts", () => {
     expect(items[0]?.owner).toBe("Operator");
   });
 
+  it("routes stale draft PRs back to Codex instead of operator review", () => {
+    const items = stalePrAlertItems({
+      now,
+      staleAfterMinutes: 120,
+      monitor: {
+        recent: [{
+          correlationId: "github-pr-15-run-1",
+          intent: "pr_handoff",
+          repo: "depre-dev/averray-reference-agent",
+          pullRequestNumber: 15,
+          updatedAt: "2026-05-16T08:00:00.000Z",
+          status: "completed",
+          summary: {
+            finalVerdict: "needs_review",
+            mergeRecommendation: "needs_review",
+            currentPullRequest: {
+              state: "open",
+              draft: true,
+              merged: false,
+            },
+          },
+        }],
+      },
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      owner: "Codex",
+      nextAction: "finish the draft or mark it ready for review so CI and Hermes can run",
+      reason: "PR is still draft; Codex must finish it or mark it ready before Hermes/operator can proceed.",
+    });
+  });
+
   it("only posts when stale handoffs exist and signature changes", () => {
     const items = stalePrAlertItems({
       now,


### PR DESCRIPTION
## Summary
- adds a Fix this block drawer section for BLOCK monitor items
- tailors guidance for hosted health failures, failed workflows, failed testbed cases, deploy failures, and CI failures
- changes blocked card action from vague Codex Fix to opening the concrete fix plan

## Checks
- npm test -- test/unit/slack-monitor.test.ts test/unit/slack-monitor-pr-state.test.ts
- npm run build
- npm test
- git diff --check

## Surfaces
- slack-operator monitor UI
- monitor unit tests

No environment or VPS secret changes required.