### PR TITLE
Add Codex task runner and live PR monitor fallback

### DIFF
--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -60,6 +60,57 @@ Hermes must not merge PRs, deploy, submit work, or run guarded live mutation dur
 - If **BLOCK**: stop. Fix the PR, add missing tests or notes, wait for CI, then let Hermes re-run. Do not ask Hermes to override the block.
 - If Hermes could not inspect the PR: treat it as HUMAN REVIEW and repair the missing token/repo/config separately.
 
+## Monitor-to-Codex Task Queue
+
+The monitor can now turn a PR card into a small Codex task:
+
+1. Hermes identifies the current owner and next action.
+2. The operator clicks **Propose Codex task** to persist the exact prompt and PR metadata.
+3. The operator clicks **Approve Codex task** when Codex is allowed to start.
+4. The optional `codex-task-runner` service claims approved tasks, marks them `running`, executes the configured command, then records `completed` or `failed`.
+5. Codex pushes branch updates. CI and Hermes handoff run again through the normal GitHub Actions path.
+
+The runner is opt-in and fail-closed. It does not start unless
+`CODEX_TASK_RUNNER_ENABLED=1` and `CODEX_TASK_RUNNER_COMMAND` are configured. A
+typical command can use JSON args with placeholders, for example:
+
+```env
+CODEX_TASK_RUNNER_COMMAND=codex
+CODEX_TASK_RUNNER_ARGS=["exec","--full-auto","{prompt}"]
+```
+
+Task state is stored in `AVERRAY_CODEX_TASKS_PATH`, defaulting to
+`/data/codex-tasks.json` in Docker so the monitor and runner share durable state.
+The runner redacts common private keys, JWTs, GitHub tokens, and API keys from
+captured output before persisting tails in the queue.
+
+## Monitor GitHub-Live Fallback
+
+The monitor has two read-only inputs:
+
+- Hermes handoff events from the local handoff log.
+- Live GitHub PR state for repos configured by `GITHUB_HELPER_REPOS`,
+  `GITHUB_DEFAULT_REPO`, or `GITHUB_REPOSITORY`.
+
+The GitHub-live layer exists so an open PR is still visible even before Hermes
+has emitted a handoff event, or after the local event window expires. It fetches
+open PRs, check runs, and touched files, then creates synthetic monitor cards
+with `requester=github-live` and `intent=github_open_pr`. Those cards are grouped
+with Hermes events by `repo#pullRequestNumber`, so the board should show one
+logical card per PR rather than duplicate rows.
+
+The default live PR scan limit is 20. Set `GITHUB_MONITOR_PR_LIMIT` if the
+monitor needs a different value without changing other GitHub helper commands.
+
+This layer never mutates GitHub. It only helps assign ownership:
+
+- draft PRs go to Codex.
+- failed PR checks go to Codex / Needs Attention.
+- running PR checks go to the Codex-needed lane until CI settles.
+- review-gated surfaces go to Operator only after the agent pre-check evidence
+  is attached.
+- green low-risk PRs go to the merge queue.
+
 ## Correlation Metadata
 
 Use stable metadata so all surfaces connect:

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -85,6 +85,7 @@ services:
       GITHUB_HELPER_REPOS: ${GITHUB_HELPER_REPOS:-}
       GITHUB_API_BASE_URL: ${GITHUB_API_BASE_URL:-https://api.github.com}
       GITHUB_HELPER_LIMIT: ${GITHUB_HELPER_LIMIT:-5}
+      GITHUB_MONITOR_PR_LIMIT: ${GITHUB_MONITOR_PR_LIMIT:-20}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
       TRACE_HTTP_PORT: ${TRACE_HTTP_PORT:-8789}
       TRACE_HTTP_URL: http://127.0.0.1:${TRACE_HTTP_PORT:-8789}/hermes-event
@@ -168,12 +169,41 @@ services:
       GITHUB_API_BASE_URL: ${GITHUB_API_BASE_URL:-https://api.github.com}
       GITHUB_HELPER_LIMIT: ${GITHUB_HELPER_LIMIT:-5}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
+      AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-data:/data
     networks: [avg-internal]
     ports:
       - "127.0.0.1:${SLACK_OPERATOR_HTTP_PORT:-8790}:${SLACK_OPERATOR_HTTP_PORT:-8790}"
+
+  codex-task-runner:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+    image: avg-node-runtime
+    profiles: ["codex-runner"]
+    restart: unless-stopped
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+      mcp-bundle:
+        condition: service_completed_successfully
+    command: ["node", "services/slack-operator/dist/codex-task-runner.js"]
+    environment:
+      AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
+      CODEX_TASK_RUNNER_ENABLED: ${CODEX_TASK_RUNNER_ENABLED:-0}
+      CODEX_TASK_RUNNER_ID: ${CODEX_TASK_RUNNER_ID:-vps-codex-task-runner}
+      CODEX_TASK_RUNNER_COMMAND: ${CODEX_TASK_RUNNER_COMMAND:-}
+      CODEX_TASK_RUNNER_ARGS: ${CODEX_TASK_RUNNER_ARGS:-}
+      CODEX_TASK_RUNNER_CWD: ${CODEX_TASK_RUNNER_CWD:-}
+      CODEX_TASK_RUNNER_POLL_INTERVAL_MS: ${CODEX_TASK_RUNNER_POLL_INTERVAL_MS:-10000}
+      CODEX_TASK_RUNNER_TIMEOUT_MS: ${CODEX_TASK_RUNNER_TIMEOUT_MS:-1800000}
+      CODEX_TASK_RUNNER_OUTPUT_TAIL_BYTES: ${CODEX_TASK_RUNNER_OUTPUT_TAIL_BYTES:-12000}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - avg-data:/data
+    networks: [avg-internal]
 
   hermes:
     image: ${HERMES_IMAGE}

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -30,6 +30,16 @@ export interface CodexTask extends CodexTaskInput {
   approvedBy?: string;
   cancelledAt?: string;
   cancelledBy?: string;
+  startedAt?: string;
+  runnerId?: string;
+  attemptCount?: number;
+  completedAt?: string;
+  completionSummary?: string;
+  failedAt?: string;
+  failureReason?: string;
+  exitCode?: number;
+  stdoutTail?: string;
+  stderrTail?: string;
 }
 
 export interface CodexTaskQueueDeps {
@@ -125,6 +135,86 @@ export async function cancelCodexTask(
     status: "cancelled",
     cancelledAt: now,
     cancelledBy: deps.cancelledBy ?? "monitor",
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function claimNextApprovedCodexTask(
+  deps: CodexTaskQueueDeps & { runnerId?: string } = {}
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks
+    .filter((task) => task.status === "approved")
+    .sort((a, b) => Date.parse(a.approvedAt ?? a.updatedAt) - Date.parse(b.approvedAt ?? b.updatedAt))[0];
+  if (!existing) return undefined;
+  const now = (deps.now ?? new Date()).toISOString();
+  const task: CodexTask = {
+    ...existing,
+    status: "running",
+    startedAt: now,
+    runnerId: deps.runnerId ?? existing.runnerId ?? "codex-task-runner",
+    attemptCount: (existing.attemptCount ?? 0) + 1,
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function completeCodexTask(
+  id: string,
+  deps: CodexTaskQueueDeps & {
+    completionSummary?: string;
+    exitCode?: number;
+    stdoutTail?: string;
+    stderrTail?: string;
+  } = {}
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  if (existing.status !== "running") return existing;
+  const now = (deps.now ?? new Date()).toISOString();
+  const task: CodexTask = {
+    ...existing,
+    status: "completed",
+    completedAt: now,
+    ...(deps.completionSummary ? { completionSummary: deps.completionSummary } : {}),
+    ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
+    ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
+    ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function failCodexTask(
+  id: string,
+  deps: CodexTaskQueueDeps & {
+    failureReason?: string;
+    exitCode?: number;
+    stdoutTail?: string;
+    stderrTail?: string;
+  } = {}
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  if (TERMINAL_STATUSES.has(existing.status)) return existing;
+  const now = (deps.now ?? new Date()).toISOString();
+  const task: CodexTask = {
+    ...existing,
+    status: "failed",
+    failedAt: now,
+    failureReason: deps.failureReason ?? "Codex task runner failed.",
+    ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
+    ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
+    ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
     updatedAt: now,
   };
   await writeCodexTasks(path, replaceTask(tasks, task));

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -1,0 +1,283 @@
+import { spawn } from "node:child_process";
+import { hostname } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import type { CodexTask } from "./codex-task-queue.js";
+import {
+  claimNextApprovedCodexTask,
+  completeCodexTask,
+  failCodexTask,
+} from "./codex-task-queue.js";
+
+export interface CodexTaskRunnerConfig {
+  enabled: boolean;
+  path?: string;
+  runnerId: string;
+  command?: string;
+  args: string[];
+  cwd?: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  outputTailBytes: number;
+}
+
+export interface CodexTaskRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  summary?: string;
+}
+
+export type CodexTaskExecutor = (
+  task: CodexTask,
+  config: CodexTaskRunnerConfig
+) => Promise<CodexTaskRunResult>;
+
+export type CodexTaskRunnerOnceResult =
+  | { status: "disabled" }
+  | { status: "misconfigured"; reason: string }
+  | { status: "idle" }
+  | { status: "completed"; task: CodexTask }
+  | { status: "failed"; task: CodexTask; reason: string };
+
+export function parseCodexTaskRunnerConfig(env: NodeJS.ProcessEnv = process.env): CodexTaskRunnerConfig {
+  const runnerId = env.CODEX_TASK_RUNNER_ID
+    || `${hostname()}-${process.pid}`;
+  return {
+    enabled: env.CODEX_TASK_RUNNER_ENABLED === "1" || env.CODEX_TASK_RUNNER_ENABLED === "true",
+    ...(env.AVERRAY_CODEX_TASKS_PATH ? { path: env.AVERRAY_CODEX_TASKS_PATH } : {}),
+    runnerId,
+    ...(env.CODEX_TASK_RUNNER_COMMAND ? { command: env.CODEX_TASK_RUNNER_COMMAND } : {}),
+    args: parseArgs(env.CODEX_TASK_RUNNER_ARGS),
+    ...(env.CODEX_TASK_RUNNER_CWD ? { cwd: env.CODEX_TASK_RUNNER_CWD } : {}),
+    pollIntervalMs: positiveInt(env.CODEX_TASK_RUNNER_POLL_INTERVAL_MS, 10_000),
+    timeoutMs: positiveInt(env.CODEX_TASK_RUNNER_TIMEOUT_MS, 30 * 60_000),
+    outputTailBytes: positiveInt(env.CODEX_TASK_RUNNER_OUTPUT_TAIL_BYTES, 12_000),
+  };
+}
+
+export async function runCodexTaskRunnerOnce(
+  config: CodexTaskRunnerConfig,
+  deps: { executor?: CodexTaskExecutor; now?: Date } = {}
+): Promise<CodexTaskRunnerOnceResult> {
+  if (!config.enabled) return { status: "disabled" };
+  const executor = deps.executor ?? executeCodexTaskCommand;
+  if (!config.command && executor === executeCodexTaskCommand) {
+    return {
+      status: "misconfigured",
+      reason: "CODEX_TASK_RUNNER_COMMAND is required when the Codex task runner is enabled.",
+    };
+  }
+
+  const claimed = await claimNextApprovedCodexTask({
+    path: config.path,
+    runnerId: config.runnerId,
+    now: deps.now,
+  });
+  if (!claimed) return { status: "idle" };
+
+  try {
+    const result = await executor(claimed, config);
+    if (result.exitCode === 0) {
+      const task = await completeCodexTask(claimed.id, {
+        path: config.path,
+        completionSummary: sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout)),
+        exitCode: result.exitCode,
+        stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
+        stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+      });
+      return { status: "completed", task: task ?? claimed };
+    }
+    const reason = summarizeFailure(result);
+    const task = await failCodexTask(claimed.id, {
+      path: config.path,
+      failureReason: reason,
+      exitCode: result.exitCode,
+      stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
+      stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+    });
+    return { status: "failed", task: task ?? claimed, reason };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    const task = await failCodexTask(claimed.id, {
+      path: config.path,
+      failureReason: reason,
+    });
+    return { status: "failed", task: task ?? claimed, reason };
+  }
+}
+
+export async function runCodexTaskRunnerForever(
+  config: CodexTaskRunnerConfig,
+  deps: { executor?: CodexTaskExecutor; signal?: AbortSignal } = {}
+): Promise<void> {
+  while (!deps.signal?.aborted) {
+    const result = await runCodexTaskRunnerOnce(config, { executor: deps.executor });
+    if (result.status === "misconfigured") {
+      console.warn(`[codex-task-runner] ${result.reason}`);
+    } else if (result.status === "completed") {
+      console.info(`[codex-task-runner] completed ${result.task.id}`);
+    } else if (result.status === "failed") {
+      console.warn(`[codex-task-runner] failed ${result.task.id}: ${result.reason}`);
+    }
+    await sleep(config.pollIntervalMs, deps.signal);
+  }
+}
+
+export async function executeCodexTaskCommand(
+  task: CodexTask,
+  config: CodexTaskRunnerConfig
+): Promise<CodexTaskRunResult> {
+  if (!config.command) {
+    throw new Error("CODEX_TASK_RUNNER_COMMAND is not configured.");
+  }
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(config.command as string, renderCodexTaskRunnerArgs(config.args, task), {
+      cwd: config.cwd,
+      env: taskEnvironment(task),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let finished = false;
+    const timeout = setTimeout(() => {
+      if (finished) return;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!finished) child.kill("SIGKILL");
+      }, 5_000).unref();
+      reject(new Error(`Codex task command timed out after ${config.timeoutMs}ms.`));
+    }, config.timeoutMs);
+    timeout.unref();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = tail(stdout + chunk.toString("utf8"), config.outputTailBytes);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = tail(stderr + chunk.toString("utf8"), config.outputTailBytes);
+    });
+    child.on("error", (error) => {
+      finished = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      finished = true;
+      clearTimeout(timeout);
+      resolve({
+        exitCode: code ?? 1,
+        stdout,
+        stderr,
+        summary: summarizeCommandResult(stdout) || summarizeCommandResult(stderr),
+      });
+    });
+  });
+}
+
+function taskEnvironment(task: CodexTask): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CODEX_TASK_ID: task.id,
+    CODEX_TASK_REPO: task.repo,
+    CODEX_TASK_PR: String(task.pullRequestNumber),
+    CODEX_TASK_TITLE: task.title ?? "",
+    CODEX_TASK_CORRELATION_ID: task.correlationId ?? "",
+    CODEX_TASK_REASON: task.reason ?? "",
+    CODEX_TASK_REQUESTER: task.requester ?? "",
+    CODEX_TASK_PROMPT: task.prompt,
+  };
+}
+
+function summarizeFailure(result: CodexTaskRunResult): string {
+  const stderr = sanitizeOutput(summarizeCommandResult(result.stderr));
+  const stdout = sanitizeOutput(summarizeCommandResult(result.stdout));
+  return stderr || stdout || `Codex task command exited with ${result.exitCode}.`;
+}
+
+function summarizeCommandResult(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-3).join("\n").trim();
+}
+
+function parseArgs(value: string | undefined): string[] {
+  const trimmed = value?.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("CODEX_TASK_RUNNER_ARGS must be a JSON string array when it starts with '['.");
+    }
+    return parsed;
+  }
+  return trimmed.split(/\s+/);
+}
+
+export function renderCodexTaskRunnerArgs(args: string[], task: CodexTask): string[] {
+  const replacements: Record<string, string> = {
+    "{taskId}": task.id,
+    "{repo}": task.repo,
+    "{pr}": String(task.pullRequestNumber),
+    "{title}": task.title ?? "",
+    "{correlationId}": task.correlationId ?? "",
+    "{prompt}": task.prompt,
+    "{CODEX_TASK_ID}": task.id,
+    "{CODEX_TASK_REPO}": task.repo,
+    "{CODEX_TASK_PR}": String(task.pullRequestNumber),
+    "{CODEX_TASK_TITLE}": task.title ?? "",
+    "{CODEX_TASK_CORRELATION_ID}": task.correlationId ?? "",
+    "{CODEX_TASK_PROMPT}": task.prompt,
+  };
+  return args.map((arg) => {
+    let value = arg;
+    for (const [token, replacement] of Object.entries(replacements)) {
+      value = value.split(token).join(replacement);
+    }
+    return value;
+  });
+}
+
+function sanitizeTail(value: string, maxBytes: number): string | undefined {
+  const output = sanitizeOutput(tail(value, maxBytes));
+  return output ? output : undefined;
+}
+
+function sanitizeOutput(value: string): string {
+  return value
+    .replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[redacted private key]")
+    .replace(/\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g, "[redacted jwt]")
+    .replace(/\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b/g, "[redacted github token]")
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, "[redacted api key]");
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function tail(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  return Buffer.from(value, "utf8").subarray(-maxBytes).toString("utf8");
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    timeout.unref();
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const controller = new AbortController();
+  process.once("SIGINT", () => controller.abort());
+  process.once("SIGTERM", () => controller.abort());
+  runCodexTaskRunnerForever(parseCodexTaskRunnerConfig(), { signal: controller.signal })
+    .catch((error) => {
+      console.error("[codex-task-runner] fatal", error);
+      process.exitCode = 1;
+    });
+}

--- a/services/slack-operator/src/github-pr-state.ts
+++ b/services/slack-operator/src/github-pr-state.ts
@@ -9,6 +9,8 @@ export interface MonitorPullRequestState {
   author?: string;
   mergeableState?: string;
   headSha?: string;
+  baseBranch?: string;
+  headBranch?: string;
   updatedAt?: string;
   checkedAt: string;
   source: "github_live";
@@ -31,8 +33,39 @@ type MonitorPayload = Record<string, unknown> & {
   recent?: unknown[];
 };
 
+interface GithubApiUser {
+  login?: string;
+}
+
+interface GithubApiPullRequest {
+  number?: number;
+  title?: string;
+  body?: string | null;
+  html_url?: string;
+  user?: GithubApiUser | null;
+  draft?: boolean;
+  created_at?: string;
+  updated_at?: string;
+  merged_at?: string | null;
+  state?: string;
+  base?: { ref?: string } | null;
+  head?: { ref?: string; sha?: string } | null;
+  mergeable_state?: string | null;
+}
+
+interface GithubApiPullRequestFile {
+  filename?: string;
+}
+
+interface GithubApiCheckRun {
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+}
+
 const CACHE_TTL_MS = 60_000;
 const cache = new Map<string, { expiresAt: number; value: MonitorPullRequestState }>();
+const openPullRequestCache = new Map<string, { expiresAt: number; value: MonitorEntry[] }>();
 
 export async function enrichMonitorWithGithubPrState<T extends MonitorPayload>(
   monitor: T,
@@ -41,9 +74,13 @@ export async function enrichMonitorWithGithubPrState<T extends MonitorPayload>(
   const env = deps.env ?? process.env;
   const fetchFn = deps.fetchFn ?? fetch;
   const now = deps.now ?? new Date();
-  const entries = [...monitorEntries(monitor.active), ...monitorEntries(monitor.recent)];
+  const entries = [
+    ...monitorEntries(monitor.active),
+    ...monitorEntries(monitor.recent),
+  ];
+  const githubLiveEntries = await fetchOpenPullRequestMonitorEntries({ env, fetchFn, now }).catch(() => []);
   const keys = uniquePrKeys(entries);
-  if (!keys.length) return monitor;
+  if (!keys.length && githubLiveEntries.length === 0) return monitor;
 
   const states = new Map<string, MonitorPullRequestState>();
   await Promise.all(keys.map(async ({ key, repo, pullRequestNumber }) => {
@@ -58,12 +95,12 @@ export async function enrichMonitorWithGithubPrState<T extends MonitorPayload>(
     }).catch(() => undefined);
     if (state) states.set(key, state);
   }));
-  if (states.size === 0) return monitor;
+  if (states.size === 0 && githubLiveEntries.length === 0) return monitor;
 
   return {
     ...monitor,
     ...(Array.isArray(monitor.active) ? { active: enrichEntries(monitor.active, states) } : {}),
-    ...(Array.isArray(monitor.recent) ? { recent: enrichEntries(monitor.recent, states) } : {}),
+    recent: mergeGithubLiveEntries(enrichEntries(Array.isArray(monitor.recent) ? monitor.recent : [], states), githubLiveEntries),
   };
 }
 
@@ -137,12 +174,361 @@ async function fetchPullRequestState(input: {
     ...(isRecord(pull.user) && stringField(pull.user, "login") ? { author: stringField(pull.user, "login") } : {}),
     ...(stringField(pull, "mergeable_state") ? { mergeableState: stringField(pull, "mergeable_state") } : {}),
     ...(isRecord(pull.head) && stringField(pull.head, "sha") ? { headSha: stringField(pull.head, "sha") } : {}),
+    ...(isRecord(pull.base) && stringField(pull.base, "ref") ? { baseBranch: stringField(pull.base, "ref") } : {}),
+    ...(isRecord(pull.head) && stringField(pull.head, "ref") ? { headBranch: stringField(pull.head, "ref") } : {}),
     ...(stringField(pull, "updated_at") ? { updatedAt: stringField(pull, "updated_at") } : {}),
     checkedAt: input.now.toISOString(),
     source: "github_live",
   };
   cache.set(key, { expiresAt: input.now.getTime() + CACHE_TTL_MS, value });
   return value;
+}
+
+async function fetchOpenPullRequestMonitorEntries(input: {
+  env: NodeJS.ProcessEnv;
+  fetchFn: typeof fetch;
+  now: Date;
+}): Promise<MonitorEntry[]> {
+  const repos = parseGithubRepos(input.env);
+  if (repos.length === 0) return [];
+  const limit = clampLimit(input.env.GITHUB_MONITOR_PR_LIMIT ?? input.env.GITHUB_HELPER_LIMIT);
+  const cacheKey = repos.join(",") + "|" + (input.env.GITHUB_API_BASE_URL ?? "https://api.github.com") + "|" + String(limit);
+  const cached = openPullRequestCache.get(cacheKey);
+  if (cached && cached.expiresAt > input.now.getTime()) return cached.value;
+
+  const baseUrl = (input.env.GITHUB_API_BASE_URL ?? "https://api.github.com").replace(/\/+$/g, "");
+  const results = await Promise.all(repos.map(async (repo) => {
+    const token = resolveGithubTokenForRepo(repo, input.env);
+    if (!token) return [];
+    return fetchRepoOpenPullRequestEntries({ repo, token, limit, baseUrl, fetchFn: input.fetchFn, now: input.now });
+  }));
+  const entries = results.flat();
+  openPullRequestCache.set(cacheKey, { expiresAt: input.now.getTime() + CACHE_TTL_MS, value: entries });
+  return entries;
+}
+
+async function fetchRepoOpenPullRequestEntries(input: {
+  repo: string;
+  token: string;
+  limit: number;
+  baseUrl: string;
+  fetchFn: typeof fetch;
+  now: Date;
+}): Promise<MonitorEntry[]> {
+  const repoPath = encodeRepoPath(input.repo);
+  const pulls = await githubGet<GithubApiPullRequest[]>(
+    `${input.baseUrl}/repos/${repoPath}/pulls?state=open&sort=updated&direction=desc&per_page=${input.limit}`,
+    input.token,
+    input.fetchFn
+  ).catch(() => []);
+
+  const entries = await Promise.all(pulls
+    .slice(0, input.limit)
+    .map(async (pull) => openPullRequestEntryFromGithub({ repo: input.repo, pull, token: input.token, baseUrl: input.baseUrl, fetchFn: input.fetchFn, now: input.now })));
+  return entries.filter((entry): entry is MonitorEntry => Boolean(entry));
+}
+
+async function openPullRequestEntryFromGithub(input: {
+  repo: string;
+  pull: GithubApiPullRequest;
+  token: string;
+  baseUrl: string;
+  fetchFn: typeof fetch;
+  now: Date;
+}): Promise<MonitorEntry | undefined> {
+  const number = numberField(input.pull.number);
+  if (number <= 0) return undefined;
+  const repoPath = encodeRepoPath(input.repo);
+  const headSha = input.pull.head?.sha;
+  const [files, checks] = await Promise.all([
+    githubGet<GithubApiPullRequestFile[]>(
+      `${input.baseUrl}/repos/${repoPath}/pulls/${number}/files?per_page=100`,
+      input.token,
+      input.fetchFn
+    ).catch(() => []),
+    headSha
+      ? githubGet<{ check_runs?: GithubApiCheckRun[] }>(
+        `${input.baseUrl}/repos/${repoPath}/commits/${encodeURIComponent(headSha)}/check-runs?per_page=100`,
+        input.token,
+        input.fetchFn
+      ).then((result) => result.check_runs ?? []).catch(() => [])
+      : Promise.resolve([]),
+  ]);
+  const reviewSignals = buildLiveReviewSignals(input.pull, files, checks);
+  const checksSummary = summarizeGithubChecks(checks);
+  const reviewReasons = liveReviewReasons(input.pull, files, reviewSignals, checksSummary);
+  const highSeverity = reviewReasons.some((reason) => reason.severity === "high");
+  const mediumSeverity = reviewReasons.some((reason) => reason.severity === "medium");
+  const finalVerdict = highSeverity ? "hold" : mediumSeverity ? "needs_review" : "ok_to_merge";
+  const mergeRecommendation = highSeverity ? "hold" : mediumSeverity ? "needs_review" : "ok_to_merge";
+  const reason = reviewReasons.find((entry) => entry.code !== "pr_review_green")?.code
+    ?? (finalVerdict === "ok_to_merge" ? "github_ok_to_merge" : "github_needs_review");
+  const state: MonitorPullRequestState = {
+    repo: input.repo,
+    number,
+    state: input.pull.state ?? "open",
+    draft: input.pull.draft === true,
+    merged: Boolean(input.pull.merged_at),
+    ...(input.pull.html_url ? { url: input.pull.html_url } : {}),
+    ...(input.pull.title ? { title: input.pull.title } : {}),
+    ...(input.pull.user?.login ? { author: input.pull.user.login } : {}),
+    ...(input.pull.mergeable_state ? { mergeableState: input.pull.mergeable_state } : {}),
+    ...(headSha ? { headSha } : {}),
+    ...(input.pull.base?.ref ? { baseBranch: input.pull.base.ref } : {}),
+    ...(input.pull.head?.ref ? { headBranch: input.pull.head.ref } : {}),
+    ...(input.pull.updated_at ? { updatedAt: input.pull.updated_at } : {}),
+    checkedAt: input.now.toISOString(),
+    source: "github_live",
+  };
+
+  return {
+    correlationId: `github-live-pr-${input.repo.replace(/[^A-Za-z0-9]+/g, "-")}-${number}`,
+    requester: "github-live",
+    intent: "github_open_pr",
+    repo: input.repo,
+    pullRequestNumber: number,
+    pullRequestUrl: input.pull.html_url,
+    status: finalVerdict === "hold" ? "blocked" : "completed",
+    phase: "github_live",
+    active: false,
+    activeState: "inactive",
+    startedAt: input.pull.created_at ?? input.pull.updated_at ?? input.now.toISOString(),
+    updatedAt: input.pull.updated_at ?? input.now.toISOString(),
+    eventCount: 0,
+    reason,
+    summary: {
+      kind: "github_live_pull_request",
+      source: "github_live",
+      status: finalVerdict === "hold" ? "blocked" : finalVerdict === "needs_review" ? "needs_review" : "completed",
+      finalReason: reason,
+      finalVerdict,
+      mergeRecommendation,
+      pullRequest: state,
+      currentPullRequest: state,
+      reviewReasons,
+      reviewSignals,
+      checks: checks.map((check) => ({
+        name: check.name ?? "check",
+        status: check.status ?? "unknown",
+        conclusion: check.conclusion ?? undefined,
+      })),
+      githubLive: {
+        checkedAt: input.now.toISOString(),
+        checkTotals: checksSummary,
+      },
+    },
+    safety: {
+      source: "github_live",
+      wouldMutate: false,
+      wouldWriteLocalCheckpoint: false,
+      freeFormHermesPromptUsed: false,
+    },
+  };
+}
+
+function mergeGithubLiveEntries(recent: unknown[], githubLiveEntries: MonitorEntry[]): unknown[] {
+  if (githubLiveEntries.length === 0) return recent;
+  return [...githubLiveEntries, ...recent];
+}
+
+function buildLiveReviewSignals(
+  pull: GithubApiPullRequest,
+  files: GithubApiPullRequestFile[],
+  checks: GithubApiCheckRun[]
+): Record<string, unknown> {
+  const touchedFiles = files.map((file) => ({
+    path: file.filename ?? "",
+    area: inferTouchedArea(file.filename ?? ""),
+  })).filter((file) => file.path);
+  const touchedAreas = [...new Set(touchedFiles.map((file) => file.area))].filter(Boolean);
+  const testSignals = [
+    ...files.map((file) => file.filename ?? "").filter(isTestFile).map((filename) => `test file changed: ${filename}`),
+    ...checks.map((check) => check.name ?? "").filter(Boolean).map((name) => `check: ${name}`),
+  ];
+  const missingTestSignals = touchedAreas.filter((area) => needsMatchingTestSignal(area) && !hasTestSignalForArea(area, testSignals));
+  const rolloutNotesRequired = touchedAreas.some((area) => ["ops", "contracts", "indexer", "blockchain", "settlement"].includes(area));
+  const body = pull.body ?? "";
+  const rolloutNotesPresent = /rollout|rollback|deploy|migration|feature flag|feature-flag/i.test(body);
+  return {
+    touchedAreas,
+    touchedFiles,
+    testSignals,
+    missingTestSignals,
+    rolloutNotesRequired,
+    rolloutNotesPresent,
+    abiCompatChecked: checks.some((check) => /forge|solidity|contract/i.test(check.name ?? "")),
+    abiCompatible: undefined,
+    staticAnalysisHigh: 0,
+    staticAnalysisInfo: 0,
+  };
+}
+
+function liveReviewReasons(
+  pull: GithubApiPullRequest,
+  files: GithubApiPullRequestFile[],
+  signals: Record<string, unknown>,
+  checks: ReturnType<typeof summarizeGithubChecks>
+): Array<{ severity: "low" | "medium" | "high"; code: string; message: string }> {
+  const findings: Array<{ severity: "low" | "medium" | "high"; code: string; message: string }> = [];
+  const touchedAreas = Array.isArray(signals.touchedAreas) ? signals.touchedAreas.map(String) : [];
+  const missingTests = Array.isArray(signals.missingTestSignals) ? signals.missingTestSignals.map(String) : [];
+  if (pull.draft === true) findings.push({ severity: "high", code: "pr_is_draft", message: "PR is still marked as draft." });
+  if (checks.failed > 0) findings.push({ severity: "high", code: "pr_checks_failed", message: `${checks.failed} PR check(s) failed.` });
+  if (checks.active > 0) findings.push({ severity: "high", code: "pr_checks_active", message: `${checks.active} PR check(s) are still running.` });
+  if (checks.total === 0) findings.push({ severity: "medium", code: "pr_checks_missing", message: "No PR check runs were found for the head commit." });
+  const criticalFiles = files.filter((file) => highRiskForFile(file.filename ?? "") === "high");
+  if (criticalFiles.length > 0) {
+    findings.push({
+      severity: "high",
+      code: "pr_critical_files",
+      message: `${criticalFiles.length} changed file(s) touch secrets, contracts, or database migrations.`,
+    });
+  }
+  const reviewFiles = files.filter((file) => highRiskForFile(file.filename ?? "") === "medium");
+  if (reviewFiles.length > 0) {
+    const areas = [...new Set(reviewFiles.map((file) => inferTouchedArea(file.filename ?? "")))].join(", ");
+    findings.push({
+      severity: "medium",
+      code: "pr_review_risk_files",
+      message: `${reviewFiles.length} changed file(s) touch review-gated surfaces${areas ? ` (${areas})` : ""}.`,
+    });
+  }
+  if (missingTests.length > 0) {
+    findings.push({
+      severity: "medium",
+      code: "pr_test_signal_missing",
+      message: `No changed test files or matching check names found for ${missingTests.join(", ")} changes.`,
+    });
+  }
+  if (signals.rolloutNotesRequired === true && signals.rolloutNotesPresent !== true) {
+    findings.push({
+      severity: "medium",
+      code: "pr_rollout_notes_missing",
+      message: "Deploy, ops, contract, indexer, blockchain, or settlement changes should include rollout or rollback notes in the PR body.",
+    });
+  }
+  if (findings.length === 0) {
+    findings.push({ severity: "low", code: "pr_review_green", message: "Live GitHub PR metadata and checks look merge-ready." });
+  }
+  return findings;
+}
+
+function summarizeGithubChecks(checks: GithubApiCheckRun[]): {
+  total: number;
+  passed: number;
+  failed: number;
+  active: number;
+  neutral: number;
+} {
+  const total = checks.length;
+  let passed = 0;
+  let failed = 0;
+  let active = 0;
+  let neutral = 0;
+  for (const check of checks) {
+    const status = normalize(check.status);
+    const conclusion = normalize(check.conclusion ?? undefined);
+    if (status !== "completed") {
+      active += 1;
+    } else if (["success"].includes(conclusion)) {
+      passed += 1;
+    } else if (["failure", "cancelled", "timed_out", "action_required", "startup_failure"].includes(conclusion)) {
+      failed += 1;
+    } else {
+      neutral += 1;
+    }
+  }
+  return { total, passed, failed, active, neutral };
+}
+
+async function githubGet<T>(url: string, token: string, fetchFn: typeof fetch): Promise<T> {
+  const response = await fetchFn(url, {
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "user-agent": "averray-reference-agent-monitor",
+      "x-github-api-version": "2022-11-28",
+    },
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`GitHub API ${response.status} for ${url}${text ? `: ${text.slice(0, 180)}` : ""}`);
+  }
+  return await response.json() as T;
+}
+
+function parseGithubRepos(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.GITHUB_HELPER_REPOS ?? env.GITHUB_DEFAULT_REPO ?? env.GITHUB_REPOSITORY ?? "";
+  return [...new Set(raw.split(",").map(normalizeRepo).filter((repo): repo is string => Boolean(repo)))];
+}
+
+function normalizeRepo(value: string): string | undefined {
+  const trimmed = value.trim().replace(/^https:\/\/github\.com\//i, "").replace(/\.git$/i, "").replace(/^\/+|\/+$/g, "");
+  const [owner, repo] = trimmed.split("/");
+  if (!owner || !repo) return undefined;
+  return `${owner}/${repo}`;
+}
+
+function encodeRepoPath(repo: string): string {
+  const [owner, name] = repo.split("/");
+  return `${encodeURIComponent(owner ?? "")}/${encodeURIComponent(name ?? "")}`;
+}
+
+function clampLimit(value: string | undefined): number {
+  const parsed = Number.parseInt(value ?? "20", 10);
+  if (!Number.isFinite(parsed)) return 20;
+  return Math.max(1, Math.min(50, parsed));
+}
+
+function numberField(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function inferTouchedArea(path: string): string {
+  const p = path.toLowerCase();
+  if (p.includes("secret") || p.endsWith(".env") || p.includes(".env.")) return "secrets";
+  if (p.startsWith("contracts/") || p.endsWith(".sol")) return "contracts";
+  if (p.startsWith("indexer/")) return "indexer";
+  if (p.includes("xcm") || p.includes("settlement") || p.includes("escrow") || p.includes("claim") || p.includes("submit")) return "settlement";
+  if (p.startsWith("mcp-server/") || p.startsWith("backend/") || p.startsWith("services/") || p.startsWith("packages/")) return "backend";
+  if (p.startsWith("app/") || p.startsWith("frontend/") || p.endsWith(".tsx") || p.endsWith(".jsx")) return "frontend";
+  if (p.startsWith("ops/") || p.startsWith(".github/") || p.startsWith("scripts/") || p.includes("docker") || p.includes("compose")) return "ops";
+  if (p.startsWith("docs/") || p.endsWith(".md")) return "docs";
+  if (isTestFile(path)) return "tests";
+  if (/package(-lock)?\.json$|pnpm-lock\.yaml$|yarn\.lock$|bun\.lockb$/i.test(p)) return "dependencies";
+  return "other";
+}
+
+function highRiskForFile(path: string): "high" | "medium" | "low" {
+  const p = path.toLowerCase();
+  if (p.includes("secret") || p.endsWith(".env") || p.includes(".env.") || p.includes("migration") || p.startsWith("contracts/") || p.endsWith(".sol")) return "high";
+  const area = inferTouchedArea(path);
+  if (["ops", "indexer", "settlement", "backend", "dependencies"].includes(area)) return "medium";
+  return "low";
+}
+
+function isTestFile(path: string): boolean {
+  const p = path.toLowerCase();
+  return p.includes("/test/") || p.includes("/tests/") || p.endsWith(".test.ts") || p.endsWith(".test.tsx") || p.endsWith(".spec.ts") || p.endsWith(".spec.tsx");
+}
+
+function needsMatchingTestSignal(area: string): boolean {
+  return ["backend", "frontend", "indexer", "contracts", "settlement"].includes(area);
+}
+
+function hasTestSignalForArea(area: string, testSignals: string[]): boolean {
+  const text = testSignals.join(" ").toLowerCase();
+  if (!text) return false;
+  if (area === "contracts") return /forge|solidity|contract/.test(text);
+  if (area === "frontend") return /frontend|app|react|tsx|build/.test(text);
+  if (area === "backend") return /backend|node|test|mcp|server/.test(text);
+  if (area === "indexer") return /indexer|ponder|typecheck/.test(text);
+  if (area === "settlement") return /settlement|xcm|claim|submit|backend|node|test/.test(text);
+  return /test|check|typecheck|build/.test(text);
+}
+
+function normalize(value: string | undefined): string {
+  return String(value ?? "").trim().toLowerCase().replace(/[-\s]+/g, "_");
 }
 
 function resolveGithubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -1367,7 +1367,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       box-shadow: -30px 0 80px rgba(0, 0, 0, 0.46);
       transform: translateX(104%);
       transition: transform 0.2s ease;
+      overflow: hidden;
     }
+    .drawer-handle { display: none; }
     .drawer[data-open="true"] { transform: translateX(0); }
     .drawer-head {
       display: grid;
@@ -2251,10 +2253,16 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       gap: 6px;
       flex-shrink: 1;
       min-width: 0;
+      overflow: hidden;
     }
     .drawer-topline .drawer-head-links .pill {
       padding: 2px 8px;
       font-size: 0.72rem;
+      min-width: 0;
+      max-width: 120px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
     .drawer-topline .dr-age {
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -2271,6 +2279,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       place-items: center;
       font-size: 0.9rem;
       color: var(--muted);
+      flex: 0 0 auto;
     }
     .drawer-topline .dr-close:hover { color: var(--text); }
     .drawer-title {
@@ -2977,11 +2986,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       }
       const closeDrawer = event.target && event.target.closest ? event.target.closest("[data-close-drawer]") : null;
       if (closeDrawer) {
-        selectedKey = "";
-        autoFocusPending = false;
-        renderBoard(latestPipelineItems);
-        renderDrawer(null);
-        renderCommandContext();
+        closeSelectedDrawer();
         return;
       }
       const reviewCard = event.target && event.target.closest ? event.target.closest("[data-review-card]") : null;
@@ -3015,7 +3020,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return;
       }
       const button = event.target && event.target.closest ? event.target.closest("[data-monitor-decision]") : null;
-      if (!button) return;
+      if (!button) {
+        const drawer = event.target && event.target.closest ? event.target.closest("#detail-drawer") : null;
+        const consoleSurface = event.target && event.target.closest ? event.target.closest("#command-console,#ask-sheet,#fab-ask") : null;
+        if (selectedKey && !drawer && !consoleSurface) closeSelectedDrawer();
+        return;
+      }
       const key = String(button.getAttribute("data-decision-key") || "");
       const decision = String(button.getAttribute("data-monitor-decision") || "");
       if (!key) return;
@@ -3023,6 +3033,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (decision === "reset") setMonitorDecision(key, null);
       if (latestPayload) render(latestPayload);
     });
+
+    function closeSelectedDrawer() {
+      selectedKey = "";
+      autoFocusPending = false;
+      renderBoard(latestPipelineItems);
+      renderDrawer(null);
+      renderCommandContext();
+    }
     document.querySelectorAll("[data-pipeline-filter]").forEach((button) => {
       button.addEventListener("click", () => {
         pipelineFilter = String(button.getAttribute("data-pipeline-filter") || "all");
@@ -3804,7 +3822,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const codexTask = codexTaskForItem(item);
       if (codexTask && !isTerminalCodexTask(codexTask)) return { key: "codex" };
       if (isDraftPullRequest(item)) return { key: "codex" };
-      if (reason === "ci_in_progress") return { key: "codex" };
+      if (reason === "ci_in_progress" || reason === "pr_checks_active") return { key: "codex" };
       if (verdict.level === "block") return { key: "attention" };
       if (verdict.level === "needs-review") return { key: "operator" };
       if (verdict.level === "pass") return { key: "queue" };
@@ -4056,7 +4074,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
             '<button class="soft-button" type="button" data-codex-task-action="cancel" data-codex-task-id="' + escapeAttr(task.id) + '">Cancel task</button>';
         }
         if (status === "approved") {
-          return '<button class="soft-button" data-action="primary" type="button" data-copy-label="' + escapeAttr(codexCopyLabel()) + '" data-copy-text="' + escapeAttr(task.prompt || prompt) + '">Copy approved prompt</button>' +
+          return '<button class="soft-button" data-action="primary" type="button" data-copy-label="' + escapeAttr(codexCopyLabel()) + '" data-copy-text="' + escapeAttr(task.prompt || prompt) + '">Copy prompt fallback</button>' +
             '<button class="soft-button" type="button" data-codex-task-action="cancel" data-codex-task-id="' + escapeAttr(task.id) + '">Cancel task</button>';
         }
         return '<button class="soft-button" type="button" data-copy-label="' + escapeAttr(codexCopyLabel()) + '" data-copy-text="' + escapeAttr(task.prompt || prompt) + '">Copy Codex prompt</button>';
@@ -4073,10 +4091,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function codexTaskStatusText(task) {
       const status = normalize(task && task.status);
       if (status === "proposed") return "Hermes proposed this task. It is waiting for operator approval before Codex should work on it.";
-      if (status === "approved") return "Operator approved this task. Codex should pick it up next; until the runner is wired, copy the approved prompt into Codex.";
-      if (status === "running") return "Codex is actively working on this task.";
-      if (status === "completed") return "Codex reported this task completed.";
-      if (status === "failed") return "Codex reported this task failed.";
+      if (status === "approved") return "Operator approved this task. The Codex task runner may claim it next; use copy only as a fallback if no runner is configured.";
+      if (status === "running") return "Codex task runner is actively working on this task.";
+      if (status === "completed") return "Codex task runner reported this task completed.";
+      if (status === "failed") return "Codex task runner reported this task failed.";
       if (status === "cancelled") return "This Codex task was cancelled.";
       return "No Codex task status recorded.";
     }
@@ -5339,6 +5357,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function nextPipelineAction(item, verdict) {
       const status = normalize(item.status);
+      const summary = item.summary || {};
+      const reason = normalize(summary.finalReason || summary.reason || item.reason);
       const prState = pullRequestState(item, item.summary || {});
       if (isDonePullRequestState(prState)) {
         return { owner: "Done", text: "PR is no longer open in GitHub; keep this handoff as release history" };
@@ -5348,6 +5368,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       }
       if (isDraftPullRequest(item)) {
         return { owner: "Codex", text: "finish the draft or mark it ready for review, then let CI and Hermes re-run" };
+      }
+      if (reason === "pr_checks_active" || reason === "ci_in_progress") {
+        return { owner: "Codex", text: "wait for CI to finish on the current commit; if it fails, push the smallest fix and let Hermes re-run" };
       }
       if (verdict.level === "block") {
         if (isDeployItem(item)) {
@@ -5593,6 +5616,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (prState && normalize(prState.mergeableState) === "dirty") {
         return { level: "block", label: "CONFLICT", why: "GitHub reports this PR has merge conflicts." };
       }
+      if (reason === "pr_checks_active" || reason === "ci_in_progress") {
+        return { level: "running", label: "CI RUNNING", why: releaseReason(summary, item, "running") };
+      }
       const terminal = classifyReleaseGate(status, finalVerdict, mergeRecommendation, reason, reviewReasons);
       if (item.activeState === "just_finished") {
         return {
@@ -5680,6 +5706,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (reason === "testbed_cases_failed") return "One or more read-only post-deploy checks failed.";
       if (reason === "github_workflow_failed") return "GitHub has a failed workflow after deploy.";
       if (reason === "ci_failed") return "CI failed; fix before merge.";
+      if (reason === "pr_checks_failed") return "One or more PR checks failed; Codex should fix the failing signal before merge.";
+      if (reason === "pr_checks_active") return "PR checks are still running on the head commit.";
+      if (reason === "pr_checks_missing") return "GitHub has not surfaced PR check runs for this head commit yet.";
+      if (reason === "pr_is_draft") return "PR is still marked as draft; Codex owns finishing it or marking it ready.";
       if (reason === "ci_in_progress") return "CI is still running; wait for the result.";
       if (level === "pass") return "No blocking release signals recorded.";
       return String(summary.finalReason || summary.reason || item.reason || item.phase || "No reason recorded.");

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -6,6 +6,9 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   approveCodexTask,
   cancelCodexTask,
+  claimNextApprovedCodexTask,
+  completeCodexTask,
+  failCodexTask,
   listCodexTasks,
   proposeCodexTask,
   summarizeCodexTasks,
@@ -104,5 +107,82 @@ describe("codex task queue", () => {
       proposed: 1,
       terminal: 1,
     });
+  });
+
+  it("claims the oldest approved task and records runner completion", async () => {
+    const path = await tempQueuePath();
+    const first = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 387,
+      prompt: "Fix PR #387.",
+    }, { path, now: new Date("2026-05-17T12:00:00.000Z") });
+    const second = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 388,
+      prompt: "Fix PR #388.",
+    }, { path, now: new Date("2026-05-17T12:01:00.000Z") });
+
+    await approveCodexTask(second.task.id, { path, now: new Date("2026-05-17T12:02:00.000Z") });
+    await approveCodexTask(first.task.id, { path, now: new Date("2026-05-17T12:03:00.000Z") });
+
+    const claimed = await claimNextApprovedCodexTask({
+      path,
+      runnerId: "runner-a",
+      now: new Date("2026-05-17T12:04:00.000Z"),
+    });
+
+    expect(claimed).toMatchObject({
+      id: second.task.id,
+      status: "running",
+      runnerId: "runner-a",
+      attemptCount: 1,
+    });
+
+    const completed = await completeCodexTask(second.task.id, {
+      path,
+      completionSummary: "Pushed fix.",
+      exitCode: 0,
+      stdoutTail: "ok",
+      now: new Date("2026-05-17T12:05:00.000Z"),
+    });
+
+    expect(completed).toMatchObject({
+      status: "completed",
+      completionSummary: "Pushed fix.",
+      exitCode: 0,
+      stdoutTail: "ok",
+    });
+    expect(summarizeCodexTasks(await listCodexTasks({ path })).counts).toMatchObject({
+      approved: 1,
+      running: 0,
+      terminal: 1,
+    });
+  });
+
+  it("records runner failures without claiming another task", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 389,
+      prompt: "Fix PR #389.",
+    }, { path, now: new Date("2026-05-17T13:00:00.000Z") });
+    await approveCodexTask(proposed.task.id, { path, now: new Date("2026-05-17T13:01:00.000Z") });
+    await claimNextApprovedCodexTask({ path, runnerId: "runner-b", now: new Date("2026-05-17T13:02:00.000Z") });
+
+    const failed = await failCodexTask(proposed.task.id, {
+      path,
+      failureReason: "CI stayed red.",
+      exitCode: 2,
+      stderrTail: "failed",
+      now: new Date("2026-05-17T13:03:00.000Z"),
+    });
+
+    expect(failed).toMatchObject({
+      status: "failed",
+      failureReason: "CI stayed red.",
+      exitCode: 2,
+      stderrTail: "failed",
+    });
+    expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
   });
 });

--- a/test/unit/codex-task-runner.test.ts
+++ b/test/unit/codex-task-runner.test.ts
@@ -1,0 +1,159 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  approveCodexTask,
+  listCodexTasks,
+  proposeCodexTask,
+} from "../../services/slack-operator/src/codex-task-queue.js";
+import {
+  parseCodexTaskRunnerConfig,
+  renderCodexTaskRunnerArgs,
+  runCodexTaskRunnerOnce,
+  type CodexTaskRunnerConfig,
+} from "../../services/slack-operator/src/codex-task-runner.js";
+
+describe("codex task runner", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  async function tempQueuePath(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "averray-codex-runner-"));
+    tempDirs.push(dir);
+    return join(dir, "tasks.json");
+  }
+
+  function config(path: string, overrides: Partial<CodexTaskRunnerConfig> = {}): CodexTaskRunnerConfig {
+    return {
+      enabled: true,
+      path,
+      runnerId: "test-runner",
+      command: "fake-codex",
+      args: [],
+      pollIntervalMs: 10,
+      timeoutMs: 1_000,
+      outputTailBytes: 1_000,
+      ...overrides,
+    };
+  }
+
+  it("claims an approved task, executes it, and marks it completed", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 390,
+      title: "Finish draft",
+      prompt: "Finish PR #390.",
+      correlationId: "github-pr-390",
+      requester: "monitor",
+    }, { path });
+    await approveCodexTask(proposed.task.id, { path, approvedBy: "operator" });
+
+    const result = await runCodexTaskRunnerOnce(config(path), {
+      executor: async (task) => {
+        expect(task.prompt).toBe("Finish PR #390.");
+        return {
+          exitCode: 0,
+          stdout: "branch pushed\nready for Hermes\n",
+          stderr: "",
+          summary: "ready for Hermes",
+        };
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      id: proposed.task.id,
+      status: "completed",
+      runnerId: "test-runner",
+      attemptCount: 1,
+      completionSummary: "ready for Hermes",
+      stdoutTail: "branch pushed\nready for Hermes\n",
+    });
+  });
+
+  it("marks an approved task failed when the executor exits nonzero", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 391,
+      prompt: "Fix PR #391.",
+    }, { path });
+    await approveCodexTask(proposed.task.id, { path });
+
+    const result = await runCodexTaskRunnerOnce(config(path), {
+      executor: async () => ({
+        exitCode: 7,
+        stdout: "some progress\n",
+        stderr: "could not push branch\n",
+      }),
+    });
+
+    expect(result.status).toBe("failed");
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      status: "failed",
+      exitCode: 7,
+      failureReason: "could not push branch",
+      stderrTail: "could not push branch\n",
+    });
+  });
+
+  it("does not mutate tasks when disabled or missing command", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 392,
+      prompt: "Fix PR #392.",
+    }, { path });
+    await approveCodexTask(proposed.task.id, { path });
+
+    await expect(runCodexTaskRunnerOnce(config(path, { enabled: false }))).resolves.toMatchObject({ status: "disabled" });
+    expect((await listCodexTasks({ path }))[0]).toMatchObject({ status: "approved" });
+
+    await expect(runCodexTaskRunnerOnce(config(path, { command: undefined }))).resolves.toMatchObject({
+      status: "misconfigured",
+    });
+    expect((await listCodexTasks({ path }))[0]).toMatchObject({ status: "approved" });
+  });
+
+  it("parses JSON command arguments from env", () => {
+    const parsed = parseCodexTaskRunnerConfig({
+      CODEX_TASK_RUNNER_ENABLED: "1",
+      CODEX_TASK_RUNNER_COMMAND: "codex",
+      CODEX_TASK_RUNNER_ARGS: "[\"exec\",\"--full-auto\"]",
+      CODEX_TASK_RUNNER_POLL_INTERVAL_MS: "5000",
+    });
+
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.command).toBe("codex");
+    expect(parsed.args).toEqual(["exec", "--full-auto"]);
+    expect(parsed.pollIntervalMs).toBe(5_000);
+  });
+
+  it("renders prompt placeholders in configured command args", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 393,
+      title: "Finish draft",
+      prompt: "Continue PR #393.",
+      correlationId: "github-pr-393",
+    }, { path });
+
+    expect(renderCodexTaskRunnerArgs(["exec", "--full-auto", "{prompt}", "--pr={pr}", "{repo}"], proposed.task)).toEqual([
+      "exec",
+      "--full-auto",
+      "Continue PR #393.",
+      "--pr=393",
+      "averray-agent/agent",
+    ]);
+  });
+});

--- a/test/unit/slack-monitor-pr-state.test.ts
+++ b/test/unit/slack-monitor-pr-state.test.ts
@@ -91,4 +91,86 @@ describe("monitor GitHub PR state enrichment", () => {
     });
     expect(monitor.recent?.[1]).toEqual({ repo: "unknown-owner/repo", pullRequestNumber: 99, summary: {} });
   });
+
+  it("adds live open GitHub PRs even when no Hermes handoff event exists", async () => {
+    const calls: string[] = [];
+    const monitor = await enrichMonitorWithGithubPrState({ recent: [] }, {
+      env: {
+        GITHUB_DEFAULT_REPO: "averray-agent/agent",
+        GITHUB_TOKEN: "ghp_readonly",
+      },
+      now: new Date("2026-05-17T10:00:00.000Z"),
+      fetchFn: async (url, init) => {
+        calls.push(String(url));
+        expect(init?.headers).toMatchObject({ authorization: "Bearer ghp_readonly" });
+        const href = String(url);
+        if (href.endsWith("/pulls?state=open&sort=updated&direction=desc&per_page=20")) {
+          return new Response(JSON.stringify([
+            {
+              number: 395,
+              title: "Surface observability env vars",
+              html_url: "https://github.com/averray-agent/agent/pull/395",
+              user: { login: "depre-dev" },
+              state: "open",
+              draft: false,
+              created_at: "2026-05-17T09:50:00.000Z",
+              updated_at: "2026-05-17T09:58:00.000Z",
+              head: { sha: "abc123", ref: "codex/live-pr" },
+              base: { ref: "main" },
+            },
+          ]), { status: 200 });
+        }
+        if (href.endsWith("/pulls/395/files?per_page=100")) {
+          return new Response(JSON.stringify([
+            { filename: "services/slack-operator/src/monitor.ts" },
+            { filename: "test/unit/slack-monitor.test.ts" },
+          ]), { status: 200 });
+        }
+        if (href.endsWith("/commits/abc123/check-runs?per_page=100")) {
+          return new Response(JSON.stringify({
+            check_runs: [
+              { name: "Backend - node --test", status: "completed", conclusion: "success" },
+              { name: "Indexer - typecheck", status: "completed", conclusion: "failure" },
+            ],
+          }), { status: 200 });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+
+    expect(calls.sort()).toEqual([
+      "https://api.github.com/repos/averray-agent/agent/commits/abc123/check-runs?per_page=100",
+      "https://api.github.com/repos/averray-agent/agent/pulls/395/files?per_page=100",
+      "https://api.github.com/repos/averray-agent/agent/pulls?state=open&sort=updated&direction=desc&per_page=20",
+    ].sort());
+    expect(monitor.recent?.[0]).toMatchObject({
+      correlationId: "github-live-pr-averray-agent-agent-395",
+      requester: "github-live",
+      intent: "github_open_pr",
+      repo: "averray-agent/agent",
+      pullRequestNumber: 395,
+      reason: "pr_checks_failed",
+      summary: {
+        source: "github_live",
+        finalVerdict: "hold",
+        mergeRecommendation: "hold",
+        currentPullRequest: {
+          repo: "averray-agent/agent",
+          number: 395,
+          state: "open",
+          draft: false,
+          headSha: "abc123",
+          baseBranch: "main",
+          headBranch: "codex/live-pr",
+        },
+        checks: [
+          { name: "Backend - node --test", status: "completed", conclusion: "success" },
+          { name: "Indexer - typecheck", status: "completed", conclusion: "failure" },
+        ],
+      },
+    });
+    expect((monitor.recent?.[0] as any).summary.reviewReasons).toEqual(expect.arrayContaining([
+      { severity: "high", code: "pr_checks_failed", message: "1 PR check(s) failed." },
+    ]));
+  });
 });


### PR DESCRIPTION
## Summary
- add a read-only live GitHub open-PR fallback so the Hermes monitor shows PRs even without recent handoff events
- route draft, failed, running, review-gated, and ready PRs into the correct owner lanes using live checks and touched-area signals
- add an opt-in Codex task runner queue lifecycle so approved monitor tasks can be claimed, executed, and reported back safely

## Checks
- npm test -- slack-monitor-pr-state slack-monitor codex-task-queue codex-task-runner
- npm run typecheck
- npm run build
- git diff --check