### PR TITLE
Add monitor-triggered Hermes recheck

### DIFF
--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -76,6 +76,10 @@ PR verdict, the card moves to **Hermes Checking** with a `HERMES RECHECK`
 verdict until Hermes/GitHub Actions publish a newer review. If the task is
 `failed`, the card moves to **Needs Attention** with a Codex-owned retry/fix
 action. Draft PRs always stay Codex-owned until GitHub reports `draft=false`.
+The monitor's **Ask Hermes to re-check** action runs a private, read-only
+`pr_code_review` + `pr_handoff` re-check for the PR and records fresh handoff
+events; it intentionally disables PR comment writes so the private command
+center cannot mutate GitHub.
 
 The runner is opt-in and fail-closed. It does not start unless
 `CODEX_TASK_RUNNER_ENABLED=1` and `CODEX_TASK_RUNNER_COMMAND` are configured. A

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -20,6 +20,10 @@
     "./handoff-events": {
       "types": "./dist/handoff-events.d.ts",
       "import": "./dist/handoff-events.js"
+    },
+    "./agent-invocation": {
+      "types": "./dist/agent-invocation.d.ts",
+      "import": "./dist/agent-invocation.js"
     }
   },
   "scripts": {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -2,6 +2,7 @@ import http from "node:http";
 import { setTimeout as delay } from "node:timers/promises";
 import { logger, optionalEnv, query } from "@avg/mcp-common";
 import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
+import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
 import { getHandoffMonitor } from "@avg/averray-mcp/handoff-events";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
 import {
@@ -139,6 +140,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/events",
           "/monitor/stream",
           "/monitor/command",
+          "/monitor/recheck",
           "/monitor/codex-tasks",
           "/monitor/manifest.webmanifest",
         ] : [],
@@ -201,6 +203,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorCodexTaskRequest(request, response);
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/monitor/recheck") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorRecheckRequest(request, response);
     return;
   }
   if (request.method === "POST" && url.pathname === "/monitor/command") {
@@ -386,6 +400,67 @@ async function handleMonitorCommandRequest(request: http.IncomingMessage, respon
     logger.error({ err: error }, "monitor_operator_command_failed");
     writeJson(response, 500, {
       error: "monitor_command_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorRecheckRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+
+    const repo = stringField(payload, "repo");
+    const pullRequestNumber = numberField(payload, "pullRequestNumber");
+    if (!repo || typeof pullRequestNumber !== "number" || pullRequestNumber < 1) {
+      writeJson(response, 400, {
+        error: "invalid_recheck_request",
+        message: "repo and pullRequestNumber are required to ask Hermes for a PR re-check.",
+      });
+      return;
+    }
+
+    const correlationId = stringField(payload, "correlationId")
+      ?? `monitor-recheck-${repo.replace(/[^a-zA-Z0-9]+/g, "-")}-${pullRequestNumber}-${Date.now()}`;
+    const reason = stringField(payload, "reason") ?? "monitor requested Hermes re-check after Codex handoff";
+    const deps = {
+      query,
+      workflowDeps: createDefaultWorkflowDeps(),
+      githubEnv: {
+        ...process.env,
+        // Monitor-triggered re-checks are private/read-only. The GitHub Actions
+        // handoff remains the path that may update PR comments.
+        GITHUB_PR_HANDOFF_COMMENTS_ENABLED: "0",
+      },
+    };
+    const base = {
+      requester: "command-center",
+      repo,
+      pullRequestNumber,
+      correlationId,
+      reason,
+    };
+    const codeReview = await invokeAgentTask({ ...base, intent: "pr_code_review" }, deps);
+    const handoff = await invokeAgentTask({
+      ...base,
+      intent: "pr_handoff",
+      testCaseIds: ["TBE2E-004"],
+    }, deps);
+    writeJson(response, 200, {
+      ok: true,
+      text: `Hermes re-check completed for ${repo}#${pullRequestNumber}.`,
+      codeReview,
+      handoff,
+      monitor: await loadMonitorSnapshot(new URL("http://localhost/monitor/events?limit=50&activeWindowMinutes=240")),
+    });
+  } catch (error) {
+    logger.error({ err: error }, "monitor_recheck_failed");
+    writeJson(response, 500, {
+      error: "monitor_recheck_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -104,12 +104,13 @@ export function renderMonitorManifest(options: { name?: string; shortName?: stri
   );
 }
 
-export function renderMonitorHtml(options: { title?: string; eventsPath?: string; streamPath?: string; commandPath?: string; codexTasksPath?: string; manifestPath?: string } = {}): string {
+export function renderMonitorHtml(options: { title?: string; eventsPath?: string; streamPath?: string; commandPath?: string; codexTasksPath?: string; recheckPath?: string; manifestPath?: string } = {}): string {
   const title = escapeHtml(options.title ?? "Hermes Handoff Monitor");
   const eventsPath = JSON.stringify(options.eventsPath ?? "/monitor/events");
   const streamPath = JSON.stringify(options.streamPath ?? "/monitor/stream");
   const commandPath = JSON.stringify(options.commandPath ?? "/monitor/command");
   const codexTasksPath = JSON.stringify(options.codexTasksPath ?? "/monitor/codex-tasks");
+  const recheckPath = JSON.stringify(options.recheckPath ?? "/monitor/recheck");
   const manifestPath = options.manifestPath ?? "/monitor/manifest.webmanifest";
   const brandIcon = svgDataUrl(MONITOR_BRAND_SVG);
   return `<!doctype html>
@@ -2926,11 +2927,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     const streamPath = ${streamPath};
     const commandPath = ${commandPath};
     const codexTasksPath = ${codexTasksPath};
+    const recheckPath = ${recheckPath};
     const token = new URLSearchParams(location.search).get("token");
     const withToken = buildMonitorUrl(eventsPath);
     const streamUrl = buildMonitorUrl(streamPath);
     const commandUrl = buildCommandUrl(commandPath);
     const codexTasksUrl = buildCommandUrl(codexTasksPath);
+    const recheckUrl = buildCommandUrl(recheckPath);
     const decisionStorageKey = "averray-monitor-operator-decisions:v1";
     let pipelineFilter = "all";
     let repoFilter = "all";
@@ -3017,6 +3020,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const codexTaskButton = event.target && event.target.closest ? event.target.closest("[data-codex-task-action]") : null;
       if (codexTaskButton) {
         void handleCodexTaskAction(codexTaskButton);
+        return;
+      }
+      const recheckButton = event.target && event.target.closest ? event.target.closest("[data-hermes-recheck]") : null;
+      if (recheckButton) {
+        void handleHermesRecheckAction(recheckButton);
         return;
       }
       const button = event.target && event.target.closest ? event.target.closest("[data-monitor-decision]") : null;
@@ -4138,7 +4146,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return '<button class="soft-button" type="button" data-copy-label="' + escapeAttr(codexCopyLabel()) + '" data-copy-text="' + escapeAttr(task.prompt || prompt) + '">Copy Codex prompt</button>';
       }
       if (task && normalize(task.status) === "completed" && codexTaskCompletedAfterHermesReview(item)) {
-        return '<button class="soft-button" data-action="primary" type="button" data-command-suggestion="handoff monitor details">Ask Hermes to re-check</button>';
+        return '<button class="soft-button" data-action="primary" type="button" data-hermes-recheck="true" data-card-key="' + escapeAttr(boardItemKey(item)) + '">Ask Hermes to re-check</button>';
       }
       if (task && normalize(task.status) === "failed") {
         return '<button class="soft-button" data-action="primary" type="button" data-codex-task-action="propose" data-card-key="' + escapeAttr(boardItemKey(item)) + '">Propose retry</button>';
@@ -4751,6 +4759,47 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           latestPayload = Object.assign({}, latestPayload, { codexTasks: result.queue });
           render(latestPayload);
         }
+      }
+      return result;
+    }
+
+    async function handleHermesRecheckAction(button) {
+      const key = String(button.getAttribute("data-card-key") || selectedKey || "");
+      const item = itemByBoardKey(key) || selectedItem();
+      const output = document.getElementById("command-output");
+      button.disabled = true;
+      try {
+        if (!item) throw new Error("No PR selected for Hermes re-check.");
+        const pr = Number(item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId));
+        const repo = String(item.repo || "averray-agent/agent");
+        if (!repo || !Number.isFinite(pr) || pr < 1) throw new Error("This card does not have enough PR metadata for Hermes re-check.");
+        if (output) output.textContent = "Asking Hermes to re-check " + repo + "#" + pr + "…";
+        const result = await postHermesRecheck({
+          repo,
+          pullRequestNumber: pr,
+          correlationId: item.correlationId,
+          reason: "monitor requested Hermes re-check after Codex handoff",
+        });
+        if (output) output.textContent = result.text || ("Hermes re-check completed for " + repo + "#" + pr + ".");
+      } catch (error) {
+        if (output) output.textContent = "Hermes re-check failed: " + String(error.message || error);
+      } finally {
+        button.disabled = false;
+      }
+    }
+
+    async function postHermesRecheck(payload) {
+      const response = await fetch(recheckUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(result.message || result.error || "HTTP " + response.status);
+      if (result.monitor) {
+        render(result.monitor);
+      } else {
+        await load();
       }
       return result;
     }

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -61,6 +61,7 @@ describe("slack operator personal monitor", () => {
       streamPath: "/monitor/stream",
       commandPath: "/monitor/command",
       codexTasksPath: "/monitor/codex-tasks",
+      recheckPath: "/monitor/recheck",
     });
 
     expect(html).toContain("<title>Pascal Monitor</title>");
@@ -105,6 +106,9 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Codex task runner reported this task completed. Hermes should re-check");
     expect(html).toContain("CODEX FAILED");
     expect(html).toContain("Propose retry");
+    expect(html).toContain("data-hermes-recheck");
+    expect(html).toContain("handleHermesRecheckAction(recheckButton)");
+    expect(html).toContain("fetch(recheckUrl");
     expect(html).toContain("isCodexActivelyWorking");
     expect(html).toContain("Copy for Codex app");
     expect(html).toContain("Propose Codex task");
@@ -143,6 +147,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("const streamPath = \"/monitor/stream\";");
     expect(html).toContain("const commandPath = \"/monitor/command\";");
     expect(html).toContain("const codexTasksPath = \"/monitor/codex-tasks\";");
+    expect(html).toContain("const recheckPath = \"/monitor/recheck\";");
     expect(html).toContain("new EventSource(streamUrl)");
     expect(html).toContain("addEventListener(\"monitor\"");
     expect(html).toContain("startPolling(\"polling fallback 5s\")");


### PR DESCRIPTION
## Summary
- add a private /monitor/recheck action that runs Hermes pr_code_review + pr_handoff for a selected PR
- wire Ask Hermes to re-check to the backend and refresh the monitor with the returned snapshot
- add live Ask Hermes console insight commands for current Codex, Hermes, operator, deploy, and queue activity
- keep monitor-triggered re-checks read-only by disabling PR comment writes from this path

## Checks
- npm test -- slack-monitor agent-invocation codex-task-queue codex-task-runner
- npm run typecheck
- npm run build
- git diff --check