### PR TITLE
Surface Codex runner presence in monitor

### DIFF
--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -9,6 +9,15 @@ export type CodexTaskStatus =
   | "failed"
   | "cancelled";
 
+export type CodexRunnerHeartbeatStatus =
+  | "idle"
+  | "running"
+  | "completed"
+  | "failed"
+  | "disabled"
+  | "misconfigured"
+  | "error";
+
 export interface CodexTaskInput {
   repo: string;
   pullRequestNumber: number;
@@ -49,6 +58,16 @@ export interface CodexTask extends CodexTaskInput {
   progressMessage?: string;
   progressAt?: string;
   events?: CodexTaskEvent[];
+}
+
+export interface CodexRunnerHeartbeat {
+  schemaVersion: 1;
+  kind: "codex_runner_heartbeat";
+  runnerId: string;
+  status: CodexRunnerHeartbeatStatus;
+  message: string;
+  updatedAt: string;
+  activeTaskId?: string;
 }
 
 export interface CodexTaskQueueDeps {
@@ -298,8 +317,51 @@ export async function failCodexTask(
   return task;
 }
 
-export function summarizeCodexTasks(tasks: CodexTask[], limit = 100) {
+export async function readCodexRunnerHeartbeat(
+  deps: CodexTaskQueueDeps = {}
+): Promise<CodexRunnerHeartbeat | undefined> {
+  try {
+    const content = await readFile(runnerHeartbeatPath(deps.path), "utf8");
+    const value: unknown = JSON.parse(content);
+    return isCodexRunnerHeartbeat(value) ? value : undefined;
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+export async function updateCodexRunnerHeartbeat(
+  deps: CodexTaskQueueDeps & {
+    runnerId: string;
+    status: CodexRunnerHeartbeatStatus;
+    message?: string;
+    activeTaskId?: string;
+  }
+): Promise<CodexRunnerHeartbeat> {
+  const now = (deps.now ?? new Date()).toISOString();
+  const heartbeat: CodexRunnerHeartbeat = {
+    schemaVersion: 1,
+    kind: "codex_runner_heartbeat",
+    runnerId: deps.runnerId,
+    status: deps.status,
+    message: deps.message ?? codexRunnerStatusMessage(deps.status),
+    updatedAt: now,
+    ...(deps.activeTaskId ? { activeTaskId: deps.activeTaskId } : {}),
+  };
+  const path = runnerHeartbeatPath(deps.path);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(heartbeat, null, 2)}\n`);
+  return heartbeat;
+}
+
+export function summarizeCodexTasks(
+  tasks: CodexTask[],
+  limit = 100,
+  deps: { runner?: CodexRunnerHeartbeat; now?: Date } = {}
+) {
   const sorted = tasks.slice().sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+  const runner = deps.runner ? summarizeCodexRunnerHeartbeat(deps.runner, deps.now ?? new Date()) : undefined;
   return {
     schemaVersion: 1,
     kind: "codex_task_queue",
@@ -310,6 +372,7 @@ export function summarizeCodexTasks(tasks: CodexTask[], limit = 100) {
       running: sorted.filter((task) => task.status === "running").length,
       terminal: sorted.filter((task) => TERMINAL_STATUSES.has(task.status)).length,
     },
+    ...(runner ? { runner } : {}),
     items: sorted.slice(0, limit),
   };
 }
@@ -361,10 +424,52 @@ function queuePath(path?: string): string {
     ?? "/tmp/averray-reference-agent/codex-tasks.json";
 }
 
+function runnerHeartbeatPath(path?: string): string {
+  return `${queuePath(path)}.runner.json`;
+}
+
+function summarizeCodexRunnerHeartbeat(heartbeat: CodexRunnerHeartbeat, now: Date) {
+  const updatedMs = Date.parse(heartbeat.updatedAt);
+  const ageMs = Number.isFinite(updatedMs) ? Math.max(0, now.getTime() - updatedMs) : undefined;
+  return {
+    ...heartbeat,
+    ...(typeof ageMs === "number" ? { ageMs, stale: ageMs > 90_000 } : { stale: true }),
+  };
+}
+
+function codexRunnerStatusMessage(status: CodexRunnerHeartbeatStatus): string {
+  switch (status) {
+    case "idle":
+      return "Codex runner is online and waiting for an approved task.";
+    case "running":
+      return "Codex runner is executing a task.";
+    case "completed":
+      return "Codex runner completed its latest task.";
+    case "failed":
+      return "Codex runner failed its latest task.";
+    case "disabled":
+      return "Codex task runner is disabled.";
+    case "misconfigured":
+      return "Codex task runner is misconfigured.";
+    case "error":
+      return "Codex task runner hit an error.";
+  }
+}
+
 function makeCodexTaskId(repo: string, pullRequestNumber: number, timestamp: string): string {
   const safeRepo = repo.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
   const stamp = timestamp.replace(/[^0-9A-Za-z]/g, "");
   return `codex-task-${safeRepo}-${pullRequestNumber}-${stamp}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function isCodexRunnerHeartbeat(value: unknown): value is CodexRunnerHeartbeat {
+  if (!isRecord(value)) return false;
+  return value.kind === "codex_runner_heartbeat"
+    && value.schemaVersion === 1
+    && typeof value.runnerId === "string"
+    && typeof value.status === "string"
+    && typeof value.message === "string"
+    && typeof value.updatedAt === "string";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -8,6 +8,7 @@ import {
   completeCodexTask,
   failCodexTask,
   updateCodexTaskProgress,
+  updateCodexRunnerHeartbeat,
 } from "./codex-task-queue.js";
 
 export interface CodexTaskRunnerConfig {
@@ -61,9 +62,18 @@ export async function runCodexTaskRunnerOnce(
   config: CodexTaskRunnerConfig,
   deps: { executor?: CodexTaskExecutor; now?: Date } = {}
 ): Promise<CodexTaskRunnerOnceResult> {
-  if (!config.enabled) return { status: "disabled" };
+  if (!config.enabled) {
+    await updateRunnerHeartbeat(config, "disabled", "Codex task runner is disabled.", deps.now);
+    return { status: "disabled" };
+  }
   const executor = deps.executor ?? executeCodexTaskCommand;
   if (!config.command && executor === executeCodexTaskCommand) {
+    await updateRunnerHeartbeat(
+      config,
+      "misconfigured",
+      "CODEX_TASK_RUNNER_COMMAND is required when the Codex task runner is enabled.",
+      deps.now
+    );
     return {
       status: "misconfigured",
       reason: "CODEX_TASK_RUNNER_COMMAND is required when the Codex task runner is enabled.",
@@ -75,18 +85,37 @@ export async function runCodexTaskRunnerOnce(
     runnerId: config.runnerId,
     now: deps.now,
   });
-  if (!claimed) return { status: "idle" };
+  if (!claimed) {
+    await updateRunnerHeartbeat(config, "idle", "Codex runner is online; no approved task is waiting.", deps.now);
+    return { status: "idle" };
+  }
+
+  await updateRunnerHeartbeat(
+    config,
+    "running",
+    `Codex runner claimed ${claimed.repo}#${claimed.pullRequestNumber}.`,
+    deps.now,
+    claimed.id
+  );
 
   try {
     const result = await executor(claimed, config);
     if (result.exitCode === 0) {
+      const summary = sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout));
       const task = await completeCodexTask(claimed.id, {
         path: config.path,
-        completionSummary: sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout)),
+        completionSummary: summary,
         exitCode: result.exitCode,
         stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
         stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
       });
+      await updateRunnerHeartbeat(
+        config,
+        "completed",
+        summary || `Codex runner completed ${claimed.repo}#${claimed.pullRequestNumber}.`,
+        undefined,
+        claimed.id
+      );
       return { status: "completed", task: task ?? claimed };
     }
     const reason = summarizeFailure(result);
@@ -97,6 +126,7 @@ export async function runCodexTaskRunnerOnce(
       stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
       stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
     });
+    await updateRunnerHeartbeat(config, "failed", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
@@ -104,6 +134,7 @@ export async function runCodexTaskRunnerOnce(
       path: config.path,
       failureReason: reason,
     });
+    await updateRunnerHeartbeat(config, "error", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
   }
 }
@@ -207,6 +238,23 @@ function taskEnvironment(task: CodexTask): NodeJS.ProcessEnv {
     CODEX_TASK_REQUESTER: task.requester ?? "",
     CODEX_TASK_PROMPT: task.prompt,
   };
+}
+
+async function updateRunnerHeartbeat(
+  config: CodexTaskRunnerConfig,
+  status: Parameters<typeof updateCodexRunnerHeartbeat>[0]["status"],
+  message: string,
+  now?: Date,
+  activeTaskId?: string
+): Promise<void> {
+  await updateCodexRunnerHeartbeat({
+    path: config.path,
+    runnerId: config.runnerId,
+    status,
+    message,
+    ...(activeTaskId ? { activeTaskId } : {}),
+    ...(now ? { now } : {}),
+  }).catch(() => undefined);
 }
 
 function summarizeFailure(result: CodexTaskRunResult): string {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -35,6 +35,7 @@ import {
   cancelCodexTask,
   listCodexTasks,
   proposeCodexTask,
+  readCodexRunnerHeartbeat,
   summarizeCodexTasks,
 } from "./codex-task-queue.js";
 import {
@@ -190,7 +191,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       writeJson(response, 401, { error: "monitor_unauthorized" });
       return;
     }
-    writeJson(response, 200, summarizeCodexTasks(await listCodexTasks(), 100));
+    writeJson(response, 200, await loadCodexTaskQueueSummary());
     return;
   }
   if (request.method === "POST" && url.pathname === "/monitor/codex-tasks") {
@@ -500,7 +501,7 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
         action,
         created: result.created,
         task: result.task,
-        queue: summarizeCodexTasks(await listCodexTasks(), 100),
+        queue: await loadCodexTaskQueueSummary(),
       });
       return;
     }
@@ -520,7 +521,7 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
         ok: true,
         action,
         task,
-        queue: summarizeCodexTasks(await listCodexTasks(), 100),
+        queue: await loadCodexTaskQueueSummary(),
       });
       return;
     }
@@ -540,7 +541,7 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
         ok: true,
         action,
         task,
-        queue: summarizeCodexTasks(await listCodexTasks(), 100),
+        queue: await loadCodexTaskQueueSummary(),
       });
       return;
     }
@@ -868,8 +869,14 @@ async function loadMonitorSnapshot(url: URL): Promise<unknown> {
   const enriched = await enrichMonitorWithGithubPrState(monitor);
   return {
     ...enriched,
-    codexTasks: summarizeCodexTasks(await listCodexTasks(), 100),
+    codexTasks: await loadCodexTaskQueueSummary(),
   };
+}
+
+async function loadCodexTaskQueueSummary() {
+  const codexTasks = await listCodexTasks();
+  const codexRunner = await readCodexRunnerHeartbeat().catch(() => undefined);
+  return summarizeCodexTasks(codexTasks, 100, { runner: codexRunner });
 }
 
 async function writeMonitorStream(

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -3317,6 +3317,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     let autoFocusPending = true;
     let latestPipelineItems = [];
     let latestCodexTasks = [];
+    let latestCodexRunner = null;
     let latestPayload = null;
     let monitorDecisions = loadMonitorDecisions();
     let pollTimer = null;
@@ -3760,6 +3761,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const recent = payload.recent || [];
       setText("generated", payload.generatedAt ? new Date(payload.generatedAt).toLocaleTimeString() : "unknown");
       latestCodexTasks = normalizeCodexTasks(payload.codexTasks);
+      latestCodexRunner = normalizeCodexRunner(payload.codexTasks && payload.codexTasks.runner);
       latestPipelineItems = groupPrPipelineItems(collectPipelineItems(payload));
       const attention = latestPipelineItems.filter(needsAttention);
       const verdicts = latestPipelineItems.map(releaseVerdict);
@@ -3837,6 +3839,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
 
     function codexAgentSnapshot(items) {
+      const runner = latestCodexRunner;
+      const runnerStatus = normalize(runner && runner.status);
+      const runnerLabel = codexRunnerStatusLabel(runner);
       const tasks = latestCodexTasks.slice().sort((a, b) => taskUpdatedMs(b) - taskUpdatedMs(a));
       const runningTask = tasks.find((task) => normalize(task.status) === "running");
       const approvedTask = tasks.find((task) => normalize(task.status) === "approved");
@@ -3850,10 +3855,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           stateLabel: "active",
           title: codexTaskTitle(runningTask),
           detail: runningTask.progressMessage || "task runner is working now.",
-          waitingOn: "Codex CLI worker",
+          waitingOn: runner && runner.runnerId ? "runner " + runner.runnerId : "Codex CLI worker",
           nextHandoff: "push branch -> CI -> Hermes",
           updated: taskAgeLabel(runningTask),
-          tags: ["runner active", normalize(runningTask.status), taskAgeLabel(runningTask)],
+          tags: ["runner active", runnerLabel, taskAgeLabel(runningTask)].filter(Boolean),
         };
       }
       if (ciItem) {
@@ -3876,10 +3881,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           stateLabel: "queued",
           title: codexTaskTitle(approvedTask),
           detail: "approved task is waiting for the Codex runner to claim it.",
-          waitingOn: "runner pickup",
+          waitingOn: runnerStatus ? runnerLabel : "runner pickup",
           nextHandoff: "Codex starts",
           updated: taskAgeLabel(approvedTask),
-          tags: ["approved", "waiting runner"],
+          tags: ["approved", runnerStatus ? runnerLabel : "waiting runner"],
         };
       }
       if (proposedTask) {
@@ -3908,16 +3913,55 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           tags: [handoffAge(codexOwned).label.toLowerCase(), "no active run"],
         };
       }
+      if (runner && runner.stale) {
+        return {
+          agent: "Codex",
+          state: "waiting",
+          stateLabel: "heartbeat stale",
+          title: "Codex worker heartbeat is stale.",
+          detail: runner.message || "Last runner heartbeat is older than the freshness window.",
+          waitingOn: "runner heartbeat",
+          nextHandoff: "verify Codex runner",
+          updated: codexRunnerAgeLabel(runner),
+          tags: [runnerLabel, "check runner"].filter(Boolean),
+        };
+      }
+      if (runnerStatus === "idle" || runnerStatus === "completed") {
+        return {
+          agent: "Codex",
+          state: "idle",
+          stateLabel: "idle / online",
+          title: "Codex worker online.",
+          detail: runner.message || "No approved task is waiting.",
+          waitingOn: "approved task",
+          nextHandoff: "starts when a task is approved",
+          updated: codexRunnerAgeLabel(runner),
+          tags: [runnerLabel, runner && runner.stale ? "stale heartbeat" : "heartbeat ok"].filter(Boolean),
+        };
+      }
+      if (["misconfigured", "failed", "error", "disabled"].includes(runnerStatus)) {
+        return {
+          agent: "Codex",
+          state: "waiting",
+          stateLabel: runnerStatus === "disabled" ? "disabled" : "runner issue",
+          title: "Codex worker needs attention.",
+          detail: runner.message || "Runner cannot safely claim work.",
+          waitingOn: runnerStatus === "disabled" ? "operator enable" : "runner config",
+          nextHandoff: "fix runner before dispatch",
+          updated: codexRunnerAgeLabel(runner),
+          tags: [runnerLabel, runner && runner.stale ? "stale heartbeat" : "heartbeat"].filter(Boolean),
+        };
+      }
       return {
         agent: "Codex",
         state: "idle",
-        stateLabel: "idle",
-        title: "No Codex work active.",
-        detail: "No proposed, approved, or running Codex task is visible.",
-        waitingOn: "new task",
-        nextHandoff: "none",
+        stateLabel: "no heartbeat",
+        title: "No Codex heartbeat visible.",
+        detail: "Queue proposals can be created, but no Codex runner has checked in yet.",
+        waitingOn: "runner heartbeat",
+        nextHandoff: "start / verify Codex runner",
         updated: "now",
-        tags: [],
+        tags: ["runner unknown"],
       };
     }
 
@@ -4019,6 +4063,17 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           priority: 400,
         });
       });
+      if (latestCodexRunner) {
+        const runnerStatus = normalize(latestCodexRunner.status);
+        const runnerPriority = runnerStatus === "running" ? 390 : ["failed", "error", "misconfigured", "disabled"].includes(runnerStatus) ? 340 : 100;
+        rows.push({
+          actor: "Codex",
+          text: "runner " + codexRunnerStatusLabel(latestCodexRunner) + " - " + (latestCodexRunner.message || "no runner message"),
+          age: codexRunnerAgeLabel(latestCodexRunner),
+          ts: Date.parse(String(latestCodexRunner.updatedAt || "")) || Date.now(),
+          priority: runnerPriority,
+        });
+      }
       latestCodexTasks.forEach((task) => {
         const status = normalize(task.status);
         if (isTerminalCodexTask(task) && status !== "completed") return;
@@ -4083,6 +4138,24 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const ms = taskUpdatedMs(task);
       if (!ms) return "unknown";
       return formatDuration(Math.max(0, Math.floor((Date.now() - ms) / 60000)));
+    }
+
+    function normalizeCodexRunner(value) {
+      if (!value || typeof value !== "object") return null;
+      return value;
+    }
+
+    function codexRunnerAgeLabel(runner) {
+      const parsed = Date.parse(String((runner && runner.updatedAt) || ""));
+      if (!Number.isFinite(parsed)) return "unknown";
+      return formatDuration(Math.max(0, Math.floor((Date.now() - parsed) / 60000)));
+    }
+
+    function codexRunnerStatusLabel(runner) {
+      if (!runner) return "";
+      const status = normalize(runner.status);
+      if (runner.stale) return status ? status + " / stale" : "stale heartbeat";
+      return status || "heartbeat";
     }
 
     function titleCaseActor(value) {
@@ -5522,12 +5595,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const queue = items.filter((item) => nextPipelineAction(item, releaseVerdict(item)).owner === "Merge queue").length;
       const blocked = items.filter((item) => releaseVerdict(item).level === "block").length;
       const runningTasks = latestCodexTasks.filter((task) => !isTerminalCodexTask(task)).length;
+      const runnerLabel = latestCodexRunner ? "Codex runner " + codexRunnerStatusLabel(latestCodexRunner) : "no Codex runner heartbeat";
       const summary = [
         blocked ? blocked + " blocked" : "no blockers",
         runningTasks ? runningTasks + " Codex queue item(s)" : "no active Codex task",
+        runnerLabel,
         hermes ? hermes + " awaiting Hermes" : "Hermes idle",
       ].join(" · ");
-      return { codex, hermes, operator, queue, blocked, runningTasks, summary };
+      return { codex, hermes, operator, queue, blocked, runningTasks, runnerLabel, summary };
     }
 
     function renderInsightMetrics(entries) {
@@ -5565,8 +5640,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function renderCodexQueueConsoleHint(label) {
       if (label !== "Codex") return "";
       const tasks = latestCodexTasks.filter((task) => !isTerminalCodexTask(task)).slice(0, 3);
-      if (!tasks.length) return '<div class="ci-note">No Codex queue task is currently proposed, approved, or running.</div>';
-      return '<div class="ci-note">Codex queue: ' + escapeHtml(tasks.map((task) => normalize(task.status) + " " + (task.repo || "") + "#" + (task.pullRequestNumber || "?")).join(" · ")) + '</div>';
+      const runnerText = latestCodexRunner
+        ? "Runner: " + codexRunnerStatusLabel(latestCodexRunner) + " · " + (latestCodexRunner.message || "no runner message")
+        : "Runner: no heartbeat yet";
+      if (!tasks.length) return '<div class="ci-note">No Codex queue task is currently proposed, approved, or running. ' + escapeHtml(runnerText) + '.</div>';
+      return '<div class="ci-note">Codex queue: ' + escapeHtml(tasks.map((task) => normalize(task.status) + " " + (task.repo || "") + "#" + (task.pullRequestNumber || "?")).join(" · ")) + '. ' + escapeHtml(runnerText) + '.</div>';
     }
 
     function currentStreamLabel() {
@@ -5634,6 +5712,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (!response.ok) throw new Error(result.message || result.error || "HTTP " + response.status);
       if (result.queue) {
         latestCodexTasks = normalizeCodexTasks(result.queue);
+        latestCodexRunner = normalizeCodexRunner(result.queue && result.queue.runner);
         if (latestPayload) {
           latestPayload = Object.assign({}, latestPayload, { codexTasks: result.queue });
           render(latestPayload);

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -11,8 +11,10 @@ import {
   failCodexTask,
   listCodexTasks,
   proposeCodexTask,
+  readCodexRunnerHeartbeat,
   summarizeCodexTasks,
   updateCodexTaskProgress,
+  updateCodexRunnerHeartbeat,
 } from "../../services/slack-operator/src/codex-task-queue.js";
 
 describe("codex task queue", () => {
@@ -207,5 +209,35 @@ describe("codex task queue", () => {
       stderrTail: "failed",
     });
     expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
+  });
+
+  it("records runner heartbeat and includes freshness in queue summary", async () => {
+    const path = await tempQueuePath();
+    const heartbeat = await updateCodexRunnerHeartbeat({
+      path,
+      runnerId: "runner-a",
+      status: "idle",
+      message: "waiting for approved work",
+      now: new Date("2026-05-17T14:00:00.000Z"),
+    });
+
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
+      kind: "codex_runner_heartbeat",
+      runnerId: "runner-a",
+      status: "idle",
+      message: "waiting for approved work",
+    });
+
+    expect(summarizeCodexTasks([], 100, {
+      runner: heartbeat,
+      now: new Date("2026-05-17T14:00:10.000Z"),
+    })).toMatchObject({
+      runner: {
+        runnerId: "runner-a",
+        status: "idle",
+        ageMs: 10_000,
+        stale: false,
+      },
+    });
   });
 });

--- a/test/unit/codex-task-runner.test.ts
+++ b/test/unit/codex-task-runner.test.ts
@@ -7,6 +7,7 @@ import {
   approveCodexTask,
   listCodexTasks,
   proposeCodexTask,
+  readCodexRunnerHeartbeat,
 } from "../../services/slack-operator/src/codex-task-queue.js";
 import {
   parseCodexTaskRunnerConfig,
@@ -77,6 +78,12 @@ describe("codex task runner", () => {
       completionSummary: "ready for Hermes",
       stdoutTail: "branch pushed\nready for Hermes\n",
     });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
+      runnerId: "test-runner",
+      status: "completed",
+      activeTaskId: proposed.task.id,
+      message: "ready for Hermes",
+    });
   });
 
   it("marks an approved task failed when the executor exits nonzero", async () => {
@@ -104,6 +111,12 @@ describe("codex task runner", () => {
       failureReason: "could not push branch",
       stderrTail: "could not push branch\n",
     });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
+      runnerId: "test-runner",
+      status: "failed",
+      activeTaskId: proposed.task.id,
+      message: "could not push branch",
+    });
   });
 
   it("does not mutate tasks when disabled or missing command", async () => {
@@ -117,11 +130,24 @@ describe("codex task runner", () => {
 
     await expect(runCodexTaskRunnerOnce(config(path, { enabled: false }))).resolves.toMatchObject({ status: "disabled" });
     expect((await listCodexTasks({ path }))[0]).toMatchObject({ status: "approved" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({ status: "disabled" });
 
     await expect(runCodexTaskRunnerOnce(config(path, { command: undefined }))).resolves.toMatchObject({
       status: "misconfigured",
     });
     expect((await listCodexTasks({ path }))[0]).toMatchObject({ status: "approved" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({ status: "misconfigured" });
+  });
+
+  it("reports idle heartbeat when no approved task is waiting", async () => {
+    const path = await tempQueuePath();
+
+    await expect(runCodexTaskRunnerOnce(config(path))).resolves.toMatchObject({ status: "idle" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
+      runnerId: "test-runner",
+      status: "idle",
+      message: "Codex runner is online; no approved task is waiting.",
+    });
   });
 
   it("parses JSON command arguments from env", () => {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -122,7 +122,15 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderCodexTaskProgress(task)");
     expect(html).toContain("renderCodexTaskEvents(task)");
     expect(html).toContain("latestCodexTasks");
+    expect(html).toContain("latestCodexRunner");
     expect(html).toContain("normalizeCodexTasks(payload.codexTasks)");
+    expect(html).toContain("normalizeCodexRunner(payload.codexTasks && payload.codexTasks.runner)");
+    expect(html).toContain("codexRunnerAgeLabel(runner)");
+    expect(html).toContain("codexRunnerStatusLabel(latestCodexRunner)");
+    expect(html).toContain("Codex worker online.");
+    expect(html).toContain("Codex worker heartbeat is stale.");
+    expect(html).toContain("No Codex heartbeat visible.");
+    expect(html).toContain("Runner: no heartbeat yet");
     expect(html).toContain("codexTaskForItem(item)");
     expect(html).toContain("data-codex-task-action");
     expect(html).toContain("handleCodexTaskAction(codexTaskButton)");


### PR DESCRIPTION
Adds a Codex runner heartbeat alongside the existing Codex task queue so the Hermes monitor can show whether Codex is online, idle, running, failed, disabled, misconfigured, or stale. The monitor now uses that heartbeat in the Codex status card, activity radar, and console hints instead of only inferring state from PR/task records.\n\nChecks run:\n- npm test -- codex-task-queue codex-task-runner slack-monitor\n- npm run typecheck\n- npm run build\n- npm test\n- git diff --check\n\nSurfaces affected: slack-operator monitor backend/UI and Codex task runner queue state. No secrets or VPS env changes required.