### PR TITLE
Fix monitor inline regex syntax

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -4906,8 +4906,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
 
     function lastCodexTaskTail(task) {
-      const stderr = String(task.stderrTail || "").trim().split(/\r?\n/).filter(Boolean).slice(-1)[0] || "";
-      const stdout = String(task.stdoutTail || "").trim().split(/\r?\n/).filter(Boolean).slice(-1)[0] || "";
+      const stderr = String(task.stderrTail || "").trim().split(/\\r?\\n/).filter(Boolean).slice(-1)[0] || "";
+      const stdout = String(task.stdoutTail || "").trim().split(/\\r?\\n/).filter(Boolean).slice(-1)[0] || "";
       return stderr || stdout;
     }
 

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -1,3 +1,4 @@
+import { Script } from "node:vm";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -268,5 +269,12 @@ describe("slack operator personal monitor", () => {
     expect(Array.isArray(manifest.icons)).toBe(true);
     expect(manifest.icons.length).toBeGreaterThan(0);
     expect(manifest.icons[0].type).toBe("image/svg+xml");
+  });
+
+  it("renders inline browser JavaScript that compiles", () => {
+    const html = renderMonitorHtml();
+    const script = html.split("<script>")[1]?.split("</script>")[0] ?? "";
+    expect(script).toContain("function render(payload)");
+    expect(() => new Script(script, { filename: "monitor-inline.js" })).not.toThrow();
   });
 });


### PR DESCRIPTION
## What changed
- Escaped newline regex literals inside the rendered monitor inline script so the browser receives valid JavaScript.
- Added a unit test that extracts the rendered inline script and compiles it with node:vm to catch future template-script syntax regressions.

## Checks run
- npx tsx inline script compile reproduction
- npm test -- slack-monitor
- npm run typecheck
- npm run build
- git diff --check

## Impact
- Affects the private monitor frontend served by slack-operator.
- No backend data model, secrets, VPS env, contracts, indexer, or public site changes.

## Why
Production /monitor/events and /monitor/stream return healthy data, but the browser board fails before fetching because the inline script throws: Invalid regular expression: missing /.