### PR TITLE
Hide terminal Codex tasks from collaboration thread

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -5614,7 +5614,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function buildCollaborationMessages(kind) {
       const messages = [];
       latestCodexTasks
-        .slice()
+        .filter((task) => !isTerminalCodexTask(task))
         .sort((a, b) => taskUpdatedMs(b) - taskUpdatedMs(a))
         .slice(0, 8)
         .forEach((task) => messages.push(...collaborationMessagesForTask(task)));

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -178,6 +178,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderAutoCollaborationThread()");
     expect(html).toContain("renderCollaborationThread({ kind");
     expect(html).toContain("renderSelectedCollaborationThread(item)");
+    expect(html).toContain("latestCodexTasks\n        .filter((task) => !isTerminalCodexTask(task))");
     expect(html).toContain("collaborationMessagesForTask(task)");
     expect(html).toContain("data-command-suggestion=\"handoff monitor details\"");
     expect(html).toContain("data-command-suggestion=\"merge steward details\"");


### PR DESCRIPTION
## What changed
- Filters completed, failed, and cancelled Codex tasks out of the default collaboration thread.
- Keeps selected-card detail behavior intact so attached task history can still be explained when relevant.
- Updated the monitor shell test to assert the active-task filter remains in place.

## Checks
- npx tsx inline monitor script compile
- npm test -- slack-monitor
- npm run typecheck
- npm run build
- npm test
- git diff --check

## Impact
- Affects the slack-operator monitor frontend only.
- No environment or VPS secret changes.