### PR TITLE
Add real posted-message channel to monitor collaboration thread

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -31,6 +31,11 @@ import {
   renderMonitorManifest,
 } from "./monitor.js";
 import {
+  CollaborationValidationError,
+  listCollaborationMessages,
+  recordCollaborationMessage,
+} from "./monitor-collab.js";
+import {
   approveCodexTask,
   cancelCodexTask,
   listCodexTasks,
@@ -143,6 +148,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/command",
           "/monitor/recheck",
           "/monitor/codex-tasks",
+          "/monitor/collaboration",
           "/monitor/manifest.webmanifest",
         ] : [],
       },
@@ -228,6 +234,37 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorCommandRequest(request, response);
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/collaboration") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const sinceMs = parseOptionalInteger(url.searchParams.get("sinceMs"));
+    const limit = parseOptionalInteger(url.searchParams.get("limit"));
+    writeJson(response, 200, {
+      messages: listCollaborationMessages({
+        ...(sinceMs !== undefined ? { sinceMs } : {}),
+        ...(limit !== undefined ? { limit } : {}),
+      }),
+    });
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/monitor/collaboration") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorCollaborationRequest(request, response);
     return;
   }
   if (!enabled) {
@@ -359,6 +396,33 @@ async function handleCommand(envelope: SlackCommandEnvelope) {
   } catch (error) {
     logger.error({ err: error }, "slack_operator_command_failed");
     await postSlack(envelope, `Averray command failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function handleMonitorCollaborationRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const message = recordCollaborationMessage(payload);
+    logger.info(
+      { author: message.author, kind: message.kind, addressedTo: message.addressedTo, id: message.id },
+      "monitor_collaboration_message_recorded"
+    );
+    writeJson(response, 200, { ok: true, message });
+  } catch (error) {
+    if (error instanceof CollaborationValidationError) {
+      writeJson(response, 400, { error: error.code, message: error.message });
+      return;
+    }
+    logger.error({ err: error }, "monitor_collaboration_record_failed");
+    writeJson(response, 500, {
+      error: "monitor_collaboration_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
   }
 }
 
@@ -931,6 +995,7 @@ async function loadMonitorSnapshot(url: URL): Promise<unknown> {
   return {
     ...enriched,
     codexTasks,
+    collaborationMessages: listCollaborationMessages({ limit: 200 }),
     diagnostics,
   };
 }

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -1,0 +1,184 @@
+/**
+ * In-memory collaboration channel for the Hermes Handoff Monitor.
+ *
+ * The existing monitor thread is a *derived* view — it synthesizes
+ * Codex/Hermes/Operator dialogue from the current board state every
+ * render. That works for "what is happening right now" but it cannot
+ * carry an actual conversation: a real Codex agent saying "I picked
+ * this up", Hermes flagging a regression, or the operator asking the
+ * agents for help.
+ *
+ * This module is the additive layer that backs those *real* posts:
+ *
+ *   - `POST /monitor/collaboration`  → recordCollaborationMessage(...)
+ *   - `GET  /monitor/collaboration`  → listCollaborationMessages(...)
+ *   - `loadMonitorSnapshot()` includes the recent buffer so the SSE
+ *     stream propagates new messages without a separate topic.
+ *
+ * Storage is intentionally in-memory and bounded: a ring of the last
+ * `MAX_MESSAGES` entries with a 24h soft TTL on read. Durable storage
+ * and per-PR threads land as follow-ups; the contract here is the
+ * "this is what the monitor shows during a live session" surface.
+ */
+
+const MAX_MESSAGES = 500;
+const SOFT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const KNOWN_AUTHORS = new Set(["codex", "hermes", "operator", "system"] as const);
+const KNOWN_KINDS = new Set(["chat", "proposal", "request_help", "status"] as const);
+const KNOWN_TARGETS = new Set(["everyone", "codex", "hermes", "operator"] as const);
+
+export type CollaborationAuthor = "codex" | "hermes" | "operator" | "system";
+export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
+export type CollaborationTarget = "everyone" | "codex" | "hermes" | "operator";
+
+export interface CollaborationRelatedPr {
+  repo: string;
+  number: number;
+}
+
+export interface CollaborationMessage {
+  id: string;
+  ts: number;
+  author: CollaborationAuthor;
+  kind: CollaborationKind;
+  text: string;
+  addressedTo: CollaborationTarget;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+export interface RecordCollaborationInput {
+  author?: unknown;
+  kind?: unknown;
+  text?: unknown;
+  addressedTo?: unknown;
+  relatedPr?: unknown;
+  relatedCorrelationId?: unknown;
+}
+
+export interface ListCollaborationOptions {
+  sinceMs?: number;
+  limit?: number;
+}
+
+export class CollaborationValidationError extends Error {
+  constructor(public readonly code: string, message: string) {
+    super(message);
+    this.name = "CollaborationValidationError";
+  }
+}
+
+const store: CollaborationMessage[] = [];
+let idSeq = 0;
+
+export function recordCollaborationMessage(
+  input: RecordCollaborationInput,
+  nowMs: number = Date.now()
+): CollaborationMessage {
+  const author = normalizeAuthor(input.author);
+  if (!author) {
+    throw new CollaborationValidationError(
+      "invalid_author",
+      "author must be one of: codex, hermes, operator, system."
+    );
+  }
+
+  const text = normalizeText(input.text);
+  if (!text) {
+    throw new CollaborationValidationError(
+      "invalid_text",
+      "text is required and must be a non-empty string (max 4000 chars)."
+    );
+  }
+
+  const kind = normalizeKind(input.kind) ?? "chat";
+  const addressedTo = normalizeTarget(input.addressedTo) ?? "everyone";
+  const relatedPr = normalizeRelatedPr(input.relatedPr);
+  const relatedCorrelationId = normalizeCorrelationId(input.relatedCorrelationId);
+
+  const message: CollaborationMessage = {
+    id: nextId(nowMs),
+    ts: nowMs,
+    author,
+    kind,
+    text,
+    addressedTo,
+    ...(relatedPr ? { relatedPr } : {}),
+    ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
+  };
+
+  store.push(message);
+  while (store.length > MAX_MESSAGES) store.shift();
+  return message;
+}
+
+export function listCollaborationMessages(
+  options: ListCollaborationOptions = {},
+  nowMs: number = Date.now()
+): CollaborationMessage[] {
+  const cutoff = nowMs - SOFT_TTL_MS;
+  const sinceMs = Number.isFinite(options.sinceMs) ? Number(options.sinceMs) : -Infinity;
+  const limit = clampLimit(options.limit);
+  const filtered = store.filter((m) => m.ts >= cutoff && m.ts > sinceMs);
+  return filtered.slice(-limit);
+}
+
+export function __resetCollaborationStoreForTests(): void {
+  store.length = 0;
+  idSeq = 0;
+}
+
+function normalizeAuthor(value: unknown): CollaborationAuthor | null {
+  if (typeof value !== "string") return null;
+  const v = value.trim().toLowerCase();
+  return (KNOWN_AUTHORS as Set<string>).has(v) ? (v as CollaborationAuthor) : null;
+}
+
+function normalizeKind(value: unknown): CollaborationKind | null {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") return null;
+  const v = value.trim().toLowerCase();
+  return (KNOWN_KINDS as Set<string>).has(v) ? (v as CollaborationKind) : null;
+}
+
+function normalizeTarget(value: unknown): CollaborationTarget | null {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") return null;
+  const v = value.trim().toLowerCase();
+  return (KNOWN_TARGETS as Set<string>).has(v) ? (v as CollaborationTarget) : null;
+}
+
+function normalizeText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  return trimmed.slice(0, 4000);
+}
+
+function normalizeRelatedPr(value: unknown): CollaborationRelatedPr | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const obj = value as Record<string, unknown>;
+  const repo = typeof obj.repo === "string" ? obj.repo.trim() : "";
+  const number = typeof obj.number === "number" && Number.isInteger(obj.number) ? obj.number : NaN;
+  if (!repo || !Number.isFinite(number) || number < 1) return undefined;
+  return { repo, number };
+}
+
+function normalizeCorrelationId(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 256) : undefined;
+}
+
+function clampLimit(value: unknown): number {
+  if (!Number.isFinite(value as number)) return MAX_MESSAGES;
+  const n = Math.floor(Number(value));
+  if (n < 1) return MAX_MESSAGES;
+  return Math.min(n, MAX_MESSAGES);
+}
+
+function nextId(nowMs: number): string {
+  idSeq = (idSeq + 1) % 1_000_000;
+  return `collab-${nowMs.toString(36)}-${idSeq.toString(36)}`;
+}

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -107,13 +107,14 @@ export function renderMonitorManifest(options: { name?: string; shortName?: stri
   );
 }
 
-export function renderMonitorHtml(options: { title?: string; eventsPath?: string; streamPath?: string; commandPath?: string; codexTasksPath?: string; recheckPath?: string; manifestPath?: string } = {}): string {
+export function renderMonitorHtml(options: { title?: string; eventsPath?: string; streamPath?: string; commandPath?: string; codexTasksPath?: string; recheckPath?: string; collaborationPath?: string; manifestPath?: string } = {}): string {
   const title = escapeHtml(options.title ?? "Hermes Handoff Monitor");
   const eventsPath = JSON.stringify(options.eventsPath ?? "/monitor/events");
   const streamPath = JSON.stringify(options.streamPath ?? "/monitor/stream");
   const commandPath = JSON.stringify(options.commandPath ?? "/monitor/command");
   const codexTasksPath = JSON.stringify(options.codexTasksPath ?? "/monitor/codex-tasks");
   const recheckPath = JSON.stringify(options.recheckPath ?? "/monitor/recheck");
+  const collaborationPath = JSON.stringify(options.collaborationPath ?? "/monitor/collaboration");
   const manifestPath = options.manifestPath ?? "/monitor/manifest.webmanifest";
   const brandIcon = svgDataUrl(MONITOR_BRAND_SVG);
   return `<!doctype html>
@@ -1779,6 +1780,111 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       line-height: 1.45;
       overflow-wrap: anywhere;
     }
+    /* Real posted messages get a stronger left rail and a subtle tint so
+       operators can tell them apart from synthesized status lines. */
+    .collab-message[data-posted="true"] .collab-bubble {
+      border-left-width: 4px;
+      background: color-mix(in srgb, var(--speaker-accent, var(--muted)) 6%, rgba(8, 18, 14, 0.86));
+    }
+    .collab-message[data-kind="request_help"] .collab-bubble {
+      border-left-color: var(--warn);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--warn) 22%, transparent);
+    }
+    .collab-tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 1px 7px;
+      border-radius: 999px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.6rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      border: 1px solid var(--line-soft);
+      color: var(--muted);
+      background: rgba(8, 18, 14, 0.6);
+    }
+    .collab-tag[data-tag="proposal"] {
+      border-color: color-mix(in srgb, var(--cyan) 32%, var(--line-soft));
+      color: color-mix(in srgb, var(--cyan) 88%, var(--text));
+    }
+    .collab-tag[data-tag="help"] {
+      border-color: color-mix(in srgb, var(--warn) 40%, var(--line-soft));
+      color: color-mix(in srgb, var(--warn) 92%, var(--text));
+    }
+    .collab-tag[data-tag="status"] {
+      border-color: color-mix(in srgb, var(--violet) 32%, var(--line-soft));
+      color: color-mix(in srgb, var(--violet) 88%, var(--text));
+    }
+    .collab-tag[data-tag="posted"] {
+      border-color: color-mix(in srgb, var(--speaker-accent, var(--muted)) 50%, var(--line-soft));
+      color: color-mix(in srgb, var(--speaker-accent, var(--muted)) 80%, var(--text));
+    }
+    .collab-addressed {
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.7rem;
+      color: var(--cyan);
+      letter-spacing: 0.02em;
+    }
+    /* Compose form mode toggle + post-mode controls (target / intent). */
+    .compose-mode {
+      display: inline-flex;
+      gap: 4px;
+      padding: 2px;
+      border: 1px solid var(--line-soft);
+      border-radius: 999px;
+      background: var(--surface-soft);
+    }
+    .compose-mode button {
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      color: var(--muted);
+      background: transparent;
+      border: none;
+    }
+    .compose-mode button[aria-pressed="true"] {
+      background: color-mix(in srgb, var(--cyan) 18%, transparent);
+      color: var(--cream);
+    }
+    .compose-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      min-width: 0;
+    }
+    .compose-meta label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.66rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .compose-meta select {
+      min-height: 28px;
+      padding: 0 8px;
+      border-radius: 8px;
+      border: 1px solid var(--line);
+      background: var(--surface-soft);
+      color: var(--text);
+      font-size: 0.78rem;
+    }
+    .compose-mode-hint {
+      color: var(--muted);
+      font-size: 0.7rem;
+      line-height: 1.35;
+    }
+    .console-status {
+      color: var(--muted);
+      font-size: 0.72rem;
+      min-height: 1em;
+    }
+    .console-status[data-tone="error"] { color: var(--warn); }
+    .console-status[data-tone="ok"] { color: color-mix(in srgb, var(--cyan) 88%, var(--text)); }
     .quick-asks {
       display: grid;
       gap: 7px;
@@ -3280,13 +3386,38 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       <section class="console-main" aria-label="Hermes and Codex collaboration transcript">
         <div id="command-output" class="console-output" data-mode="thread" data-auto="true">Waiting for Hermes, Codex, and operator messages...</div>
       </section>
-      <aside class="console-compose" aria-label="Ask Hermes">
-        <div class="console-context"><strong>Ask Hermes</strong><span id="console-context">global monitor context</span></div>
+      <aside class="console-compose" aria-label="Collaborate with Codex and Hermes">
+        <div class="console-context">
+          <span class="compose-mode" role="tablist" aria-label="Compose mode">
+            <button type="button" data-compose-mode="post" aria-pressed="true">Post message</button>
+            <button type="button" data-compose-mode="ask" aria-pressed="false">Ask Hermes</button>
+          </span>
+          <span id="console-context">global monitor context</span>
+        </div>
+        <div class="compose-meta" id="compose-meta">
+          <label>To
+            <select id="compose-target" name="addressedTo">
+              <option value="everyone">Everyone</option>
+              <option value="codex">Codex</option>
+              <option value="hermes">Hermes</option>
+              <option value="operator">Operator</option>
+            </select>
+          </label>
+          <label>Intent
+            <select id="compose-intent" name="kind">
+              <option value="chat">Chat</option>
+              <option value="proposal">Proposal</option>
+              <option value="request_help">Needs help</option>
+              <option value="status">Status</option>
+            </select>
+          </label>
+        </div>
         <div class="console-row">
-          <input id="command-input" class="console-input" name="text" placeholder="Ask for status, merge steward, why this PR is here..." autocomplete="off">
+          <input id="command-input" class="console-input" name="text" placeholder="Post to Codex, Hermes, or the operator..." autocomplete="off">
           <button id="command-submit" type="submit">Send</button>
         </div>
-        <div class="quick-asks">
+        <p id="compose-status" class="console-status" aria-live="polite"></p>
+        <div class="quick-asks" id="quick-asks">
           <span class="quick-asks-label">Quick asks</span>
           <div class="suggestions" aria-label="Suggested Hermes commands">
             <button class="suggestion" type="button" data-command-suggestion="what is happening now">now</button>
@@ -3327,12 +3458,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     const commandPath = ${commandPath};
     const codexTasksPath = ${codexTasksPath};
     const recheckPath = ${recheckPath};
+    const collaborationPath = ${collaborationPath};
     const token = new URLSearchParams(location.search).get("token");
     const withToken = buildMonitorUrl(eventsPath);
     const streamUrl = buildMonitorUrl(streamPath);
     const commandUrl = buildCommandUrl(commandPath);
     const codexTasksUrl = buildCommandUrl(codexTasksPath);
     const recheckUrl = buildCommandUrl(recheckPath);
+    const collaborationUrl = buildCommandUrl(collaborationPath);
     const decisionStorageKey = "averray-monitor-operator-decisions:v1";
     let pipelineFilter = "all";
     let repoFilter = "all";
@@ -3347,6 +3480,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     let latestCodexTasks = [];
     let latestCodexRunner = null;
     let latestPayload = null;
+    let latestCollabMessages = [];
+    // Compose state for the new collaboration "post" mode. The compose form
+    // can run in two modes: "post" (POST /monitor/collaboration → real
+    // multi-agent message) and "ask" (POST /monitor/command → Hermes
+    // read-only insight). Operators flip the toggle; agents always post.
+    let composeMode = "post";
+    let composeTarget = "everyone";
+    let composeIntent = "chat";
     let monitorDecisions = loadMonitorDecisions();
     let pollTimer = null;
     let streamSource = null;
@@ -3478,8 +3619,95 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const input = document.getElementById("command-input");
       const text = String(input.value || "").trim();
       if (!text) return;
-      void submitMonitorCommand(text);
+      if (composeMode === "post") {
+        void submitCollaborationPost(text);
+      } else {
+        void submitMonitorCommand(text);
+      }
     });
+
+    // Mode toggle: "post" sends a real message to /monitor/collaboration,
+    // "ask" routes back to the existing read-only Hermes insight command.
+    document.querySelectorAll("[data-compose-mode]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const mode = String(btn.getAttribute("data-compose-mode") || "post");
+        setComposeMode(mode);
+      });
+    });
+    document.getElementById("compose-target")?.addEventListener("change", (event) => {
+      composeTarget = String(event.target.value || "everyone");
+    });
+    document.getElementById("compose-intent")?.addEventListener("change", (event) => {
+      composeIntent = String(event.target.value || "chat");
+    });
+    setComposeMode(composeMode);
+
+    function setComposeMode(mode) {
+      composeMode = mode === "ask" ? "ask" : "post";
+      document.querySelectorAll("[data-compose-mode]").forEach((btn) => {
+        btn.setAttribute("aria-pressed", btn.getAttribute("data-compose-mode") === composeMode ? "true" : "false");
+      });
+      const composeMeta = document.getElementById("compose-meta");
+      const quickAsks = document.getElementById("quick-asks");
+      const input = document.getElementById("command-input");
+      if (composeMode === "post") {
+        if (composeMeta) composeMeta.style.display = "flex";
+        if (quickAsks) quickAsks.style.display = "none";
+        if (input) input.placeholder = "Post to Codex, Hermes, or the operator...";
+      } else {
+        if (composeMeta) composeMeta.style.display = "none";
+        if (quickAsks) quickAsks.style.display = "grid";
+        if (input) input.placeholder = "Ask for status, merge steward, why this PR is here...";
+      }
+      setComposeStatus("", "");
+    }
+
+    function setComposeStatus(text, tone) {
+      const el = document.getElementById("compose-status");
+      if (!el) return;
+      el.textContent = text || "";
+      el.setAttribute("data-tone", tone || "");
+    }
+
+    async function submitCollaborationPost(text) {
+      const submit = document.getElementById("command-submit");
+      const input = document.getElementById("command-input");
+      const item = selectedItem();
+      const payload = {
+        author: "operator",
+        kind: composeIntent,
+        text,
+        addressedTo: composeTarget,
+      };
+      const pr = item && (item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId));
+      if (item && pr) payload.relatedPr = { repo: String(item.repo || "averray-agent/agent"), number: Number(pr) };
+      if (item && item.correlationId) payload.relatedCorrelationId = String(item.correlationId);
+      if (submit) submit.disabled = true;
+      setComposeStatus("Posting...", "");
+      try {
+        const response = await fetch(collaborationUrl, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) throw new Error(result.message || result.error || "HTTP " + response.status);
+        if (result && result.message) {
+          // Optimistic merge so the new message shows up immediately even
+          // before the next SSE snapshot lands (snapshot tick is ~5s).
+          const merged = (latestCollabMessages || []).slice();
+          merged.push(result.message);
+          latestCollabMessages = merged;
+          renderAutoCollaborationThread();
+        }
+        setComposeStatus("Posted.", "ok");
+        if (input) input.value = "";
+      } catch (error) {
+        setComposeStatus("Post failed: " + String(error.message || error), "error");
+      } finally {
+        if (submit) submit.disabled = false;
+      }
+    }
 
     // ── Mobile-only wiring (no-ops on desktop because the elements are hidden) ──
 
@@ -3774,6 +4002,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const counts = payload.counts || {};
       const recent = payload.recent || [];
       setText("generated", payload.generatedAt ? new Date(payload.generatedAt).toLocaleTimeString() : "unknown");
+      latestCollabMessages = normalizeCollabMessages(payload.collaborationMessages);
       latestCodexTasks = normalizeCodexTasks(payload.codexTasks);
       latestCodexRunner = normalizeCodexRunner(payload.codexTasks && payload.codexTasks.runner);
       latestPipelineItems = groupPrPipelineItems(collectPipelineItems(payload));
@@ -5587,21 +5816,40 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         collabMessage("Hermes", "No active handoff right now. When Codex or you are needed, I will ask here.", "idle", Date.now()),
       ])
         .sort((a, b) => a.ts - b.ts)
-        .slice(-14);
+        .slice(-24);
       return '<div class="collab-thread">' +
         '<div class="collab-head"><strong>' + escapeHtml(title) + '</strong><span>' + escapeHtml(currentStreamLabel()) + '</span></div>' +
         rows.map(renderCollabMessage).join("") +
         '</div>';
     }
 
+    // Render one row in the collaboration thread. Two flavors of message
+    // can land here:
+    //   - synthesized: built client-side from board state (verdicts, codex
+    //     tasks) — these are inferences, not posts.
+    //   - posted: real messages recorded via POST /monitor/collaboration —
+    //     marked with data-posted so the user can tell what is real chat
+    //     vs what is Hermes' inferred narrative.
     function renderCollabMessage(message) {
       const speaker = message.speaker || "Hermes";
       const slug = actorSlug(speaker);
       const initial = speaker === "Operator" ? "Me" : speaker.charAt(0).toUpperCase();
-      return '<article class="collab-message" data-speaker="' + escapeAttr(slug) + '">' +
+      const posted = message.posted ? "true" : "false";
+      const kindAttr = message.kind ? message.kind : "";
+      const addressedAttr = message.addressedTo && message.addressedTo !== "everyone" ? message.addressedTo : "";
+      const meta = message.meta || "";
+      const kindBadge = message.kind === "proposal" ? '<span class="collab-tag" data-tag="proposal">proposal</span>'
+        : message.kind === "request_help" ? '<span class="collab-tag" data-tag="help">needs help</span>'
+          : message.kind === "status" ? '<span class="collab-tag" data-tag="status">status</span>'
+            : "";
+      const addressedBadge = addressedAttr
+        ? '<span class="collab-addressed">@' + escapeHtml(addressedAttr) + '</span>'
+        : "";
+      const postedBadge = message.posted ? '<span class="collab-tag" data-tag="posted">posted</span>' : "";
+      return '<article class="collab-message" data-speaker="' + escapeAttr(slug) + '" data-posted="' + posted + '" data-kind="' + escapeAttr(kindAttr) + '" data-addressed="' + escapeAttr(addressedAttr) + '">' +
         '<span class="collab-avatar">' + escapeHtml(initial) + '</span>' +
         '<div class="collab-bubble">' +
-          '<div class="collab-byline"><span class="collab-speaker">' + escapeHtml(speaker) + '</span><span class="collab-meta">' + escapeHtml(message.meta || "") + '</span></div>' +
+          '<div class="collab-byline"><span class="collab-speaker">' + escapeHtml(speaker) + '</span>' + addressedBadge + kindBadge + postedBadge + '<span class="collab-meta">' + escapeHtml(meta) + '</span></div>' +
           '<div class="collab-text">' + escapeHtml(message.text || "") + '</div>' +
         '</div>' +
       '</article>';
@@ -5611,8 +5859,74 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       return { speaker, text, meta: meta || "", ts: Number.isFinite(ts) ? ts : Date.now() };
     }
 
+    // Normalize the wire payload from POST /monitor/collaboration and the
+    // monitor snapshot's collaborationMessages field into the same shape
+    // the in-DOM render expects. Anything malformed is dropped silently
+    // rather than crashing the thread render.
+    function normalizeCollabMessages(value) {
+      if (!Array.isArray(value)) return [];
+      const out = [];
+      for (const entry of value) {
+        if (!entry || typeof entry !== "object") continue;
+        const author = typeof entry.author === "string" ? entry.author : "";
+        const text = typeof entry.text === "string" ? entry.text : "";
+        const ts = Number(entry.ts);
+        if (!author || !text || !Number.isFinite(ts)) continue;
+        out.push({
+          id: typeof entry.id === "string" ? entry.id : "",
+          author,
+          text,
+          ts,
+          kind: typeof entry.kind === "string" ? entry.kind : "chat",
+          addressedTo: typeof entry.addressedTo === "string" ? entry.addressedTo : "everyone",
+          relatedPr: entry.relatedPr && typeof entry.relatedPr === "object" ? entry.relatedPr : null,
+          relatedCorrelationId: typeof entry.relatedCorrelationId === "string" ? entry.relatedCorrelationId : "",
+        });
+      }
+      return out;
+    }
+
+    // Convert a normalized posted message into the shape buildCollaborationMessages
+    // produces — same speaker/text/meta/ts contract, plus the posted/kind/addressedTo
+    // attributes so renderCollabMessage can decorate it correctly.
+    function postedToCollabRow(message) {
+      const speaker = message.author === "codex" ? "Codex"
+        : message.author === "hermes" ? "Hermes"
+          : message.author === "operator" ? "Operator"
+            : "System";
+      const metaParts = [];
+      if (message.relatedPr && message.relatedPr.repo && message.relatedPr.number) {
+        metaParts.push(message.relatedPr.repo + "#" + message.relatedPr.number);
+      }
+      metaParts.push(shortTime(new Date(message.ts).toISOString()));
+      return {
+        speaker,
+        text: message.text,
+        meta: metaParts.join(" · "),
+        ts: message.ts,
+        posted: true,
+        kind: message.kind || "chat",
+        addressedTo: message.addressedTo || "everyone",
+      };
+    }
+
+    function postedMessageMatchesKind(message, kind) {
+      if (!kind || kind === "all") return true;
+      if (kind === "codex") return message.author === "codex" || message.addressedTo === "codex";
+      if (kind === "hermes") return message.author === "hermes" || message.addressedTo === "hermes";
+      if (kind === "operator") return message.author === "operator" || message.addressedTo === "operator";
+      if (kind === "blocked") return message.kind === "request_help" || message.kind === "proposal";
+      return true;
+    }
+
     function buildCollaborationMessages(kind) {
       const messages = [];
+      // Real posted messages take precedence visually — they are the
+      // human/agent voice on the channel and shouldn't be drowned by
+      // synthesized status lines.
+      latestCollabMessages
+        .filter((m) => postedMessageMatchesKind(m, kind))
+        .forEach((m) => messages.push(postedToCollabRow(m)));
       latestCodexTasks
         .filter((task) => !isTerminalCodexTask(task))
         .sort((a, b) => taskUpdatedMs(b) - taskUpdatedMs(a))

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CollaborationValidationError,
+  __resetCollaborationStoreForTests,
+  listCollaborationMessages,
+  recordCollaborationMessage,
+} from "../../services/slack-operator/src/monitor-collab.js";
+
+const NOW = Date.UTC(2026, 4, 18, 12, 0, 0);
+
+describe("monitor collaboration channel", () => {
+  beforeEach(() => {
+    __resetCollaborationStoreForTests();
+  });
+
+  it("records a valid operator chat message with defaults", () => {
+    const message = recordCollaborationMessage(
+      { author: "operator", text: "Codex, pick up #137 next." },
+      NOW
+    );
+    expect(message).toMatchObject({
+      author: "operator",
+      kind: "chat",
+      addressedTo: "everyone",
+      text: "Codex, pick up #137 next.",
+      ts: NOW,
+    });
+    expect(message.id).toMatch(/^collab-/);
+  });
+
+  it("normalizes author/kind/addressedTo casing and trims text", () => {
+    const message = recordCollaborationMessage(
+      {
+        author: "  Codex  ",
+        kind: "PROPOSAL",
+        addressedTo: "Hermes",
+        text: "   Hermes, please re-check after my last push.   ",
+      },
+      NOW
+    );
+    expect(message).toMatchObject({
+      author: "codex",
+      kind: "proposal",
+      addressedTo: "hermes",
+      text: "Hermes, please re-check after my last push.",
+    });
+  });
+
+  it("preserves relatedPr and relatedCorrelationId when well-formed", () => {
+    const message = recordCollaborationMessage(
+      {
+        author: "hermes",
+        kind: "request_help",
+        text: "Pascal, I cannot resolve a flaky test on #221.",
+        addressedTo: "operator",
+        relatedPr: { repo: "averray-agent/agent", number: 221 },
+        relatedCorrelationId: "smoke-2026-05-18-abc",
+      },
+      NOW
+    );
+    expect(message.relatedPr).toEqual({ repo: "averray-agent/agent", number: 221 });
+    expect(message.relatedCorrelationId).toBe("smoke-2026-05-18-abc");
+  });
+
+  it("drops malformed relatedPr without failing the record", () => {
+    const message = recordCollaborationMessage(
+      {
+        author: "codex",
+        text: "Status update.",
+        kind: "status",
+        relatedPr: { repo: "", number: 0 },
+      },
+      NOW
+    );
+    expect(message.relatedPr).toBeUndefined();
+  });
+
+  it("rejects unknown authors", () => {
+    expect(() =>
+      recordCollaborationMessage({ author: "stranger", text: "hi" }, NOW)
+    ).toThrowError(CollaborationValidationError);
+  });
+
+  it("rejects empty text", () => {
+    expect(() =>
+      recordCollaborationMessage({ author: "operator", text: "   " }, NOW)
+    ).toThrowError(CollaborationValidationError);
+  });
+
+  it("truncates very long text to 4000 chars", () => {
+    const long = "a".repeat(5_000);
+    const message = recordCollaborationMessage({ author: "operator", text: long }, NOW);
+    expect(message.text).toHaveLength(4_000);
+  });
+
+  it("falls back to chat/everyone when kind/addressedTo are unknown", () => {
+    const message = recordCollaborationMessage(
+      { author: "operator", text: "hi", kind: "rant", addressedTo: "everybody" },
+      NOW
+    );
+    expect(message.kind).toBe("chat");
+    expect(message.addressedTo).toBe("everyone");
+  });
+
+  it("lists messages newest-last and respects limit", () => {
+    for (let i = 0; i < 5; i += 1) {
+      recordCollaborationMessage(
+        { author: "operator", text: `msg ${i}` },
+        NOW + i
+      );
+    }
+    const listed = listCollaborationMessages({ limit: 3 }, NOW + 1_000);
+    expect(listed.map((m) => m.text)).toEqual(["msg 2", "msg 3", "msg 4"]);
+  });
+
+  it("respects sinceMs for incremental tailing", () => {
+    recordCollaborationMessage({ author: "operator", text: "old" }, NOW);
+    recordCollaborationMessage({ author: "codex", text: "newer" }, NOW + 5_000);
+    const listed = listCollaborationMessages({ sinceMs: NOW + 1_000 }, NOW + 10_000);
+    expect(listed.map((m) => m.text)).toEqual(["newer"]);
+  });
+
+  it("hides entries older than the 24h soft TTL", () => {
+    recordCollaborationMessage({ author: "operator", text: "ancient" }, NOW);
+    const later = NOW + 25 * 60 * 60 * 1000;
+    recordCollaborationMessage({ author: "operator", text: "fresh" }, later);
+    const listed = listCollaborationMessages({}, later);
+    expect(listed.map((m) => m.text)).toEqual(["fresh"]);
+  });
+
+  it("caps the ring buffer at 500 entries (oldest dropped)", () => {
+    for (let i = 0; i < 600; i += 1) {
+      recordCollaborationMessage(
+        { author: "operator", text: `m${i}` },
+        NOW + i
+      );
+    }
+    const listed = listCollaborationMessages({ limit: 500 }, NOW + 700);
+    expect(listed).toHaveLength(500);
+    // The first 100 should have been evicted.
+    expect(listed[0].text).toBe("m100");
+    expect(listed[499].text).toBe("m599");
+  });
+});

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -263,6 +263,21 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain('updateMobileTabCounts(filtered)');
     expect(html).toContain('submitMonitorCommandFrom(text');
     expect(html).toContain('drawer-handle');
+
+    // Real-message collaboration channel surface (PR: collab-room).
+    expect(html).toContain('data-compose-mode="post"');
+    expect(html).toContain('data-compose-mode="ask"');
+    expect(html).toContain('id="compose-target"');
+    expect(html).toContain('id="compose-intent"');
+    expect(html).toContain('id="compose-status"');
+    expect(html).toContain('"/monitor/collaboration"');
+    expect(html).toContain('latestCollabMessages');
+    expect(html).toContain('normalizeCollabMessages');
+    expect(html).toContain('submitCollaborationPost');
+    expect(html).toContain('data-posted="');
+    expect(html).toContain('data-tag="proposal"');
+    expect(html).toContain('data-tag="help"');
+    expect(html).toContain('collab-addressed');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
## Why this PR

The existing collaboration thread (PRs #135-#137) is a *synthesized* view — it builds Codex/Hermes/Operator dialogue from current board state every render. That's great for "what's happening now," but it can't carry an actual conversation:

- Codex can't say "I picked this up, posting on PR #221."
- Hermes can't flag a regression in its own voice.
- The operator can't address an agent or ask for help — the only compose input today is a read-only "Ask Hermes" insight command.

This PR adds the missing real-message layer on top of the synthesized thread.

## What's in the PR

### Backend

- `services/slack-operator/src/monitor-collab.ts` — `CollaborationMessage` type, `recordCollaborationMessage(...)`, `listCollaborationMessages(...)`, validation errors. In-memory ring of last **500 messages**, **24h soft TTL** on read. Empty / unknown / oversized fields are normalized rather than failing.
- `POST /monitor/collaboration` — body `{ author, kind?, text, addressedTo?, relatedPr?, relatedCorrelationId? }`. Validates, records, returns the message. Auth-scoped (same gate as the rest of `/monitor/*`).
- `GET /monitor/collaboration` — query `sinceMs`, `limit`. Returns the recent buffer for incremental tailing.
- `loadMonitorSnapshot()` now includes `collaborationMessages: ...` so the existing SSE stream on `/monitor/stream` propagates new posts every snapshot tick without a separate topic.

### Frontend (inline JS/CSS in `monitor.ts`)

- Real posted messages merge into `buildCollaborationMessages(kind)` alongside the synthesized ones, sorted by timestamp.
- `renderCollabMessage(...)` decorates posts with:
  - **Posted** badge + stronger left rail + tinted bubble — so it's visually clear what's a real post vs. an inferred status line.
  - **`@codex` / `@hermes` / `@operator`** address pill when the post is addressed to a specific agent.
  - **proposal / needs help / status** intent tag.
  - `request_help` posts get a warn-colored left rail so they stand out in the thread.
- Compose form on the desktop bottom strip grows a **"Post message / Ask Hermes"** mode toggle:
  - "Post message" mode reveals To + Intent selects, points Send at `/monitor/collaboration`, optimistically merges the new message into the local thread.
  - "Ask Hermes" mode keeps the existing read-only insight flow (`/monitor/command`) untouched.
- The mobile `#ask-sheet` keeps its existing Ask-Hermes-only behavior in this PR — adding posting from mobile lands as a follow-up.

### Tests

- `test/unit/monitor-collab.test.ts` (12 cases): validation, normalization, related-PR shape, kind/addressedTo defaults, text truncation, `sinceMs` tailing, 24h TTL boundary, ring cap at 500.
- `test/unit/slack-monitor.test.ts` extended with HTML-surface assertions for the new compose elements + the data attributes the renderer emits. The existing "inline browser JavaScript compiles" test continues to enforce that the rendered `<script>` parses as ES2022 — it passes with the new code.

## Out of scope (follow-ups)

- Durable persistence (the ring is in-memory; restarts clear it).
- Per-PR / per-correlation threads (every post lands in the global thread; `relatedPr` is recorded but not yet used for filtering).
- Mobile post-mode compose.
- Address autocomplete for `relatedPr`.

## Test plan

- [x] `vitest run test/unit/monitor-collab.test.ts` — 12/12 pass
- [x] `vitest run test/unit/slack-monitor.test.ts` — 7/7 pass (extended; inline-JS parse test still green)
- [x] `vitest run` full suite — 145/145 cases pass (the 6 file failures are pre-existing `@avg/schemas` / `@avg/mcp-common` packaging issues on `origin/main`, not regressions from this PR)
- [x] `tsc -b` — no new typecheck errors in `services/slack-operator/src/**` (remaining errors are the same pre-existing monorepo module-resolution issues)
- [ ] Smoke test in a live monitor: post as operator → see it land in the thread with @target and intent badges → SSE tick from another tab shows the same message after at most one snapshot interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)