### PR TITLE
Restore right-side Done lane expander rail

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -1360,7 +1360,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         minmax(186px, 1fr)
         minmax(190px, 1fr)
         minmax(190px, 1fr)
-        minmax(186px, 0.96fr);
+        minmax(186px, 0.96fr)
+        44px;
       gap: 12px;
       overflow-x: hidden;
       overflow-y: hidden;
@@ -1530,6 +1531,36 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       flex-wrap: wrap;
       gap: 6px;
       justify-content: flex-end;
+    }
+    /* Done-rail: the collapsed Done lane lives as a vertical 44px rail on
+       the right edge of the kanban board. Clicking it toggles into the
+       expanded Done lane view (showDone=true), which uses the .done-row
+       compact row layout below. */
+    .done-rail {
+      min-width: 44px;
+      width: 44px;
+      cursor: pointer;
+      border-style: dashed;
+      background: rgba(2, 15, 13, 0.5);
+    }
+    .done-rail .lane-head {
+      min-height: 100%;
+      height: 100%;
+      justify-content: center;
+      padding: 8px 4px;
+      border-top-width: 0;
+      border-left: 2px solid var(--lane-accent);
+    }
+    .done-rail .lane-title {
+      writing-mode: vertical-rl;
+      transform: rotate(180deg);
+      gap: 8px;
+      overflow: visible;
+    }
+    .done-rail .lane-title::before,
+    .done-rail .lane-body,
+    .done-rail .lane-subtitle {
+      display: none;
     }
     .soft-button {
       min-height: 28px;
@@ -1953,6 +1984,21 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       .kanban-board[data-done-expanded="true"] {
         grid-template-columns: repeat(7, minmax(250px, 82vw));
         overflow-x: auto;
+      }
+      /* On mobile the vertical 44px rail makes no sense — expand it into a
+         full-width horizontal row so the Done lane stays accessible. */
+      .done-rail {
+        min-width: 250px;
+        width: auto;
+      }
+      .done-rail .lane-head {
+        justify-content: space-between;
+        border-left: 0;
+        border-top: 2px solid var(--lane-accent);
+      }
+      .done-rail .lane-title {
+        writing-mode: horizontal-tb;
+        transform: none;
       }
       .command-shell.has-selection .command-console { right: 14px; }
       .drawer { width: 100vw; }
@@ -2512,6 +2558,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       margin-right: 8px;
       vertical-align: middle;
     }
+    .done-rail .lane-empty::before { display: none; }
     /* Done lane — compact rows instead of full kanban cards when expanded */
     .done-row {
       display: grid;
@@ -3089,6 +3136,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         gap: 8px;
         overflow: visible;
       }
+      /* The collapsed Done rail is a desktop convenience; on phones it'd
+         break the flat-list layout, so it's just hidden. The full Done
+         lane is still reachable via the "done lane N" counter chip. */
+      .done-rail { display: none; }
       /* Cards: keep all content; add the lane chip; bump touch sizes. */
       .handoff-card {
         padding: 12px;
@@ -4432,8 +4483,21 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       });
       target.innerHTML = visibleLanes
         .map((lane) => renderBoardLane(lane, filtered, { mobile }))
-        .join("");
+        .join("") + (!mobile && !showDone ? renderDoneStub(filtered) : "");
       updateMobileTabCounts(filtered);
+    }
+
+    // Collapsed Done lane: a 44px vertical rail on the right edge of the
+    // kanban-board. Click anywhere on it to trigger the existing
+    // toggle-done button and expand into the full Done lane. Skipped on
+    // mobile (the flat list there has its own done-tab path).
+    function renderDoneStub(entries) {
+      const done = entries.filter((item) => boardLaneForItem(item, releaseVerdict(item)).key === "done");
+      setText("done-count", String(done.length));
+      return '<button class="lane done-rail" data-lane="done" type="button" id="done-stub" aria-label="Show done lane" onclick="document.getElementById(\\'toggle-done\\').click()">' +
+        '<div class="lane-head"><div class="lane-title">Done ▾ <span class="pill">' + escapeHtml(String(done.length)) + '</span></div></div>' +
+        '<div class="lane-body"><div class="lane-empty">' + escapeHtml(done.length ? done.length + " history item" + (done.length === 1 ? "" : "s") + " · click" : "history · click") + '</div></div>' +
+        '</button>';
     }
 
     function updateMobileTabCounts(entries) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -72,7 +72,11 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("filterbar");
     expect(html).toContain("kanban-board");
     expect(html).toContain("data-done-expanded");
-    expect(html).not.toContain("done-rail");
+    // Right-side 44px vertical Done expander rail. Clicking it triggers
+    // the existing toggle-done button to expand the Done lane.
+    expect(html).toContain("done-rail");
+    expect(html).toContain('id="done-stub"');
+    expect(html).toContain("renderDoneStub");
     expect(html).toContain("detail-drawer");
     expect(html).toContain("command-console");
     expect(html).toContain("Ask Hermes");


### PR DESCRIPTION
The right-side 44px **Done ▾** expander rail that you used to click to open the Done lane is back. It vanished in commit 8298480 ("Polish monitor card wrapping"), which bundled useful card-head wrap fixes with the removal of the rail. The card-wrap improvements stay; this PR just restores the expander.

## What you'll see again
- A thin **44px vertical rail** on the right edge of the kanban board, labelled "Done ▾" with the count.
- Click anywhere on it → triggers the existing `toggle-done` button → full Done lane expands with the compact `.done-row` rows.
- On mobile (≤760px) the rail expands into a full-width row at the end of the column flow.
- On small-mobile (≤640px) the rail is hidden — the flat list there has its own `done` tab path, and the top-bar "done lane N" chip still works.

## What's unchanged from the 8298480 commit
All the good stuff stays: `.card-head` flex-wrap + row-gap, `.kc-head-l` / `.kc-head-r` flex ratios, `.active-agent` / `.work-state` / `.pill` overflow ellipsis.

## Test plan
- [x] `vitest run test/unit/slack-monitor.test.ts` — 7/7 pass. Flipped the assertion that used to require `done-rail` to be absent; now requires `done-rail`, `id="done-stub"`, and `renderDoneStub` to all be present. Inline-JS parse test still green.
- [x] Full `vitest run` — 145/145 cases pass (same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on main, unchanged).
- [ ] Smoke in a live monitor: click the right-side rail → Done lane expands with the same compact row layout as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)