### PR TITLE
Keep Codex runner alive while idle

### DIFF
--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -335,7 +335,6 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (signal?.aborted) return Promise.resolve();
   return new Promise((resolve) => {
     const timeout = setTimeout(resolve, ms);
-    timeout.unref();
     signal?.addEventListener("abort", () => {
       clearTimeout(timeout);
       resolve();


### PR DESCRIPTION
## What changed
- Keeps the Codex task runner process alive while it is idle instead of unref'ing the polling timer and letting Node exit cleanly.

## Why
- Production runner was restarting with exit 0 while no approved task was waiting.
- The monitor needs a stable runner heartbeat for approved task pickup.

## Checks
- npm test -- codex-task-runner
- npm run typecheck

## Surfaces
- slack-operator Codex task runner only

## Env / VPS
- Uses the existing codex-runner Compose profile/env already configured on the VPS.