### PR TITLE
Upgrade Hermes runtime pin to v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,17 @@ Hermes service first so the container sees the updated environment.
 
 ## Hermes Pin
 
-The runtime image is pinned in [ops/.env.example](ops/.env.example):
+The runtime image is pinned in [ops/.env.example](ops/.env.example). The
+current pin tracks Hermes Agent v0.14.0 / `v2026.5.16`:
 
 ```text
-nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08
+nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
 ```
 
-Do not use `latest` in production. Test a new Hermes tag in a branch, run the smoke flow, then update the pin deliberately.
+Do not use `latest` in production. Test a new Hermes tag in a branch, run the
+smoke flow, then update the pin deliberately. For this release, review the
+upstream notes for API approval events, Codex runtime fixes, MCP parallel tool
+calls, dashboard/kanban changes, and security hardening before deploying.
 
 Run the reference prompt:
 

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -564,13 +564,15 @@ Look for:
 
 ## Runtime Pin
 
-The default Hermes image is pinned to:
+The default Hermes image is pinned to Hermes Agent v0.14.0 / `v2026.5.16`:
 
 ```text
-nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08
+nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
 ```
 
 Before changing that pin, test the new tag on a branch and re-run the safe first prompt.
+This pin is the published multi-arch index digest for `v2026.5.16`; on the
+current VPS (`x86_64`) Docker resolves it to the `linux/amd64` manifest.
 
 ## Kill Switch
 

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -1,7 +1,8 @@
 # Copy to ../.env.prod, fill secrets, then chmod 600 ../.env.prod.
 
-# Pinned Hermes image digest. Refresh intentionally after testing a new Hermes release.
-HERMES_IMAGE=nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08
+# Pinned Hermes Agent v0.14.0 / v2026.5.16 multi-arch image digest.
+# Refresh intentionally after testing a new Hermes release.
+HERMES_IMAGE=nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
 
 POSTGRES_USER=avg_agent
 POSTGRES_PASSWORD=change-me


### PR DESCRIPTION
## Summary
- pin Hermes Agent to v0.14.0 / v2026.5.16 using the published multi-arch Docker index digest
- refresh README and VPS smoke docs so operators can review the release context before deploy
- keep production on a digest pin; no `latest` tag

## Review notes
- Current VPS Hermes image is based on upstream commit `faa13e4` from 2026-05-08.
- `v2026.5.16` is 821 commits ahead of that production source revision.
- Upstream release notes call out API approval events, Codex runtime/session fixes, MCP parallel tool-call support, dashboard/kanban changes, and security hardening.
- Treat this as a runtime upgrade that should pause in READY REVIEW before deployment.

## Checks
- `npm run typecheck`
- `npm test`
- VPS read-only compose interpolation with candidate `HERMES_IMAGE`
- VPS `docker buildx imagetools inspect nousresearch/hermes-agent:v2026.5.16`

## Surface
- Hermes Docker runtime pin
- docs only besides `ops/.env.example`
- no backend/frontend/indexer/contracts/public-site code changes

## Deployment notes
- Requires updating production `.env.prod` `HERMES_IMAGE` to the new digest and recreating Hermes after merge.
- Run the safe VPS smoke path before any mutating claim/submit flow.