### PR TITLE
Drawer focus mode: scrim, Esc-to-close, done-row click fix

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -1473,10 +1473,23 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     .handoff-card[data-verdict="needs-review"] { --verdict-accent: var(--warn); }
     .handoff-card[data-verdict="running"]      { --verdict-accent: var(--cyan); }
     .handoff-card[data-verdict="pass"]         { --verdict-accent: var(--ok); }
-    .handoff-card:hover,
+    .handoff-card:hover {
+      transform: translateY(-1px);
+      border-color: var(--verdict-accent, var(--lane-accent));
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.32);
+    }
+    /* Selected card pops a touch more than hover — thicker accent rail
+       and a subtle outer glow so when the drawer is open you can still
+       see which card it belongs to behind the scrim. */
     .handoff-card[data-selected="true"] {
       transform: translateY(-1px);
       border-color: var(--verdict-accent, var(--lane-accent));
+      border-left-width: 4px;
+      box-shadow:
+        0 0 0 1px color-mix(in srgb, var(--verdict-accent, var(--lane-accent)) 70%, transparent),
+        0 14px 36px rgba(0, 0, 0, 0.36);
+      z-index: 21;
+      position: relative;
     }
     .command-shell.has-selection .handoff-card:not([data-selected="true"]) {
       opacity: 0.42;
@@ -1675,6 +1688,23 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       border-color: var(--lane-accent);
       color: var(--lane-accent);
       background: color-mix(in srgb, var(--lane-accent) 12%, transparent);
+    }
+    /* Backdrop scrim that dims the rest of the page while the detail
+       drawer is open. Sits between the page content (low z-index) and
+       the drawer (z-index 20). Click anywhere on the scrim to close. */
+    #drawer-scrim {
+      position: fixed;
+      inset: 0;
+      z-index: 19;
+      background: rgba(2, 9, 8, 0.55);
+      backdrop-filter: blur(2px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 180ms ease;
+    }
+    #drawer-scrim[data-open="true"] {
+      opacity: 1;
+      pointer-events: auto;
     }
     .drawer {
       position: fixed;
@@ -2736,10 +2766,22 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       transition: border-color 0.14s ease, transform 0.14s ease;
     }
     .done-row[data-verdict="block"] { border-left-color: var(--bad); }
-    .done-row:hover,
+    .done-row:hover {
+      transform: translateY(-1px);
+      border-color: var(--ok);
+      background: color-mix(in srgb, var(--ok) 6%, var(--surface-strong));
+    }
+    .done-row[data-verdict="block"]:hover { border-color: var(--bad); background: color-mix(in srgb, var(--bad) 6%, var(--surface-strong)); }
+    /* Selected done-row pops above the scrim too, so it stays visible
+       when the drawer focus mode is active. */
     .done-row[data-selected="true"] {
       transform: translateY(-1px);
       border-color: var(--ok);
+      box-shadow:
+        0 0 0 1px color-mix(in srgb, var(--ok) 70%, transparent),
+        0 10px 26px rgba(0, 0, 0, 0.34);
+      z-index: 21;
+      position: relative;
     }
     .done-row .done-check {
       width: 14px;
@@ -3591,6 +3633,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       <div id="pull-indicator" data-state="idle" aria-hidden="true"><span class="pi-spinner"></span><span class="pi-label">Pull to refresh</span></div>
       <section id="owner-lanes" class="kanban-board" aria-label="Release command board"><div class="empty">Loading command board...</div></section>
     </section>
+    <div id="drawer-scrim" data-open="false" aria-hidden="true"></div>
     <aside id="detail-drawer" class="drawer" data-open="false" aria-label="Selected handoff detail"></aside>
     <form id="command-console" class="command-console" autocomplete="off">
       <section class="console-main" aria-label="Hermes and Codex collaboration transcript">
@@ -3730,7 +3773,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     document.addEventListener("click", (event) => {
       const card = event.target && event.target.closest ? event.target.closest("[data-select-card]") : null;
       const interactive = event.target && event.target.closest ? event.target.closest("button,a,input") : null;
-      if (card && !interactive) {
+      // The "interactive" check exists to stop clicks on inner buttons
+      // inside a kanban card from also selecting the card. But when the
+      // selectable element IS itself a button (the done-row case), the
+      // interactive check would skip the selection. Treat "interactive
+      // === card" as "this whole element is the selectable" and let the
+      // selection happen.
+      if (card && (!interactive || interactive === card)) {
         selectedKey = String(card.getAttribute("data-select-card") || "");
         autoFocusPending = false;
         renderBoard(latestPipelineItems);
@@ -3803,6 +3852,19 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       renderDrawer(null);
       renderCommandContext();
     }
+    // Scrim → click anywhere outside the drawer to close it. The scrim
+    // sits z-index 19 below the drawer's z-index 20 so it never eats
+    // clicks meant for the drawer's content.
+    document.getElementById("drawer-scrim")?.addEventListener("click", () => {
+      if (selectedKey) closeSelectedDrawer();
+    });
+    // Esc key → close the drawer. Doesn't interfere with form input
+    // because the existing compose form doesn't use Esc for anything.
+    document.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      if (!selectedKey) return;
+      closeSelectedDrawer();
+    });
     document.querySelectorAll("[data-pipeline-filter]").forEach((button) => {
       button.addEventListener("click", () => {
         pipelineFilter = String(button.getAttribute("data-pipeline-filter") || "all");
@@ -5299,9 +5361,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function renderDrawer(item) {
       const target = document.getElementById("detail-drawer");
+      const scrim = document.getElementById("drawer-scrim");
       if (!target) return;
       if (!item) {
         target.dataset.open = "false";
+        if (scrim) scrim.dataset.open = "false";
         target.innerHTML = "";
         return;
       }
@@ -5331,6 +5395,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         commitUrl ? '<a class="pill" href="' + escapeAttr(commitUrl) + '" target="_blank" rel="noreferrer">commit</a>' : "",
       ].filter(Boolean).join("");
       target.dataset.open = "true";
+      if (scrim) scrim.dataset.open = "true";
       const drawerTitle = pipelineTitle(item);
       const drawerTitleShort = cardTitleText(drawerTitle, item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
       const richReviewWhy = renderReviewReasonsRich(summary) || (verdict.why ? '<div class="rw-note">' + escapeHtml(verdict.why) + '</div>' : "");

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -334,6 +334,15 @@ describe("slack operator personal monitor", () => {
     // for the next SSE snapshot.
     expect(html).toContain('pollCollaborationSince');
     expect(html).toContain('sinceMs=');
+
+    // Drawer focus mode (PR: monitor-drawer-scrim): scrim element +
+    // CSS, scrim click handler, Esc-to-close, done-row select-card
+    // bug fix, stronger selected-card visual.
+    expect(html).toContain('id="drawer-scrim"');
+    expect(html).toContain('#drawer-scrim[data-open="true"]');
+    expect(html).toContain('interactive === card');
+    expect(html).toContain('event.key !== "Escape"');
+    expect(html).toContain('scrim.dataset.open = "true"');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Two pieces of feedback from the live session, plus a couple quick polish wins.

## Bug fixes / restorations

- **Done-row clicks were silently no-op.** The board click handler bailed out when the click target matched `button,a,input` — that check exists to prevent clicks on *inner* buttons inside a kanban card from also selecting the card. But `.done-row` is itself a `<button>` with `data-select-card` on the same element, so the check skipped it. Now the condition also accepts `interactive === card` (the selectable element *is* the button being clicked). Done-rows now open the drawer just like kanban cards.

- **Drawer scrim restored.** A semi-transparent dim layer over the rest of the page when the drawer is open. New `#drawer-scrim` element + CSS sits at `z-index: 19` between page content and the drawer (`z-index: 20`). Opens whenever `renderDrawer` mounts an item, closes when the drawer closes.

- **Click outside / Esc to close.** Clicking anywhere on the scrim closes the drawer. A global `keydown` listener also handles Escape (only when a drawer is selected, so it doesn't fight form inputs).

## Polish bundled in

- **Selected-card pops harder.** Both `.handoff-card[data-selected="true"]` and `.done-row[data-selected="true"]` now get a thicker accent rail + outer glow + `z-index: 21` so they stay visible *above* the scrim while everything else dims. Makes it obvious which card the drawer belongs to.
- **Hover state strengthened.** Soft `translateY(-1px)` + larger shadow on cards; tinted background on done-rows. Cards already had `cursor: pointer`; just made the feedback more discoverable.

## What's NOT in this PR (called out in the conversation)

Bigger polish items that I'd want a separate nod on before bundling:

- Empty lanes are very tall when the Done lane is expanded — the kanban grid stretches all rows to match the tallest column. We could make lanes auto-shrink to content.
- `STALE 2h 44m` badge could escalate yellow → orange → red by hours.
- The collaboration "POSTED" tag is a bit muted; could brighten.
- Sticky lane headers when the kanban scrolls.

## Tests

- 145/145 vitest cases pass; same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on `main`, unchanged.
- New surface assertions for `#drawer-scrim`, the scrim's `[data-open="true"]` rule, `interactive === card`, `event.key !== "Escape"`, and `scrim.dataset.open = "true"`. Existing inline-JS parse test still green.

## Test plan

- [ ] Click a kanban card → drawer slides in from the right, page dims, ESC closes it
- [ ] Click a done-row in the expanded Done lane → drawer opens with that PR's detail
- [ ] Click the dim scrim area → drawer closes
- [ ] Hover any card → subtle lift + shadow; cursor stays a pointer
- [ ] With the drawer open, the selected card stays visually clear (thicker rail + glow) while other cards fade

🤖 Generated with [Claude Code](https://claude.com/claude-code)