### PR TITLE
Hermes auto-acks operator posts so the chat is bidirectional

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -34,6 +34,7 @@ import {
   CollaborationValidationError,
   listCollaborationMessages,
   recordCollaborationMessage,
+  synthesizeHermesReplyFor,
 } from "./monitor-collab.js";
 import {
   approveCodexTask,
@@ -399,6 +400,34 @@ async function handleCommand(envelope: SlackCommandEnvelope) {
   }
 }
 
+// Hermes-side auto-acknowledgment for operator posts. Operators need
+// the channel to feel like a conversation — silence after a post
+// reads as "the agents aren't listening". A short canned reply is
+// enough to fix the perception without depending on the LLM stack.
+//
+// Fire-and-forget: a setTimeout records a Hermes reply ~800ms after
+// the operator post. The next SSE snapshot tick (and the client's
+// post-message poll, see submitCollaborationPost) surface it.
+function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof recordCollaborationMessage>>) {
+  const draft = synthesizeHermesReplyFor(operatorMessage);
+  if (!draft) return;
+  const timer = setTimeout(() => {
+    try {
+      recordCollaborationMessage({
+        author: "hermes",
+        kind: "chat",
+        text: draft.text,
+        addressedTo: draft.addressedTo,
+        ...(draft.relatedPr ? { relatedPr: draft.relatedPr } : {}),
+        ...(draft.relatedCorrelationId ? { relatedCorrelationId: draft.relatedCorrelationId } : {}),
+      });
+    } catch (error) {
+      logger.warn({ err: error }, "monitor_collaboration_auto_reply_failed");
+    }
+  }, 800);
+  timer.unref?.();
+}
+
 async function handleMonitorCollaborationRequest(request: http.IncomingMessage, response: http.ServerResponse) {
   try {
     const rawBody = await readBody(request);
@@ -412,6 +441,7 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
       { author: message.author, kind: message.kind, addressedTo: message.addressedTo, id: message.id },
       "monitor_collaboration_message_recorded"
     );
+    scheduleHermesAutoReply(message);
     writeJson(response, 200, { ok: true, message });
   } catch (error) {
     if (error instanceof CollaborationValidationError) {

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -182,3 +182,66 @@ function nextId(nowMs: number): string {
   idSeq = (idSeq + 1) % 1_000_000;
   return `collab-${nowMs.toString(36)}-${idSeq.toString(36)}`;
 }
+
+// ───────────────────────────────────────────────────────────────────────
+// Hermes auto-reply synthesizer
+//
+// Operators expect the channel to feel like a conversation: post a
+// message, get an acknowledgment. Today the chat is one-way for
+// operator posts (Codex/Hermes only "speak" via synthesized board
+// state). This helper produces a short, contextual ack from Hermes so
+// the channel reads as bidirectional.
+//
+// Tone: brief, professional, on-message. Not LLM-routed — canned
+// templates keyed on intent and whether a PR is referenced. Cheap and
+// predictable; richer LLM-backed replies can layer on later.
+//
+// Returns null when no reply is warranted (operator talking to
+// themselves, message from a non-operator, addressed only to Codex,
+// etc.) so the caller can skip the schedule.
+// ───────────────────────────────────────────────────────────────────────
+
+export interface HermesReplyDraft {
+  text: string;
+  addressedTo: CollaborationTarget;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+export function synthesizeHermesReplyFor(message: CollaborationMessage): HermesReplyDraft | null {
+  if (message.author !== "operator") return null;
+  // Only chime in when the operator is talking to Hermes or to the
+  // whole room. Don't reply to ops-to-Codex or ops-to-self posts —
+  // those have a different conversational partner.
+  if (message.addressedTo !== "hermes" && message.addressedTo !== "everyone") return null;
+
+  const prRef = message.relatedPr
+    ? `${message.relatedPr.repo}#${message.relatedPr.number}`
+    : null;
+
+  let text: string;
+  if (message.kind === "request_help") {
+    text = prRef
+      ? `On it — what specifically is blocking you on ${prRef}?`
+      : "On it. What's the blocker?";
+  } else if (message.kind === "proposal") {
+    text = prRef
+      ? `Noted on ${prRef}. I'll surface a verdict here once Codex picks it up or the checks move.`
+      : "Noted. I'll surface a verdict here once the work lands.";
+  } else if (message.kind === "status") {
+    text = prRef
+      ? `Acknowledged. I'll keep watching ${prRef} and call out anything new.`
+      : "Acknowledged. I'll keep watching the board.";
+  } else if (prRef) {
+    text = `Got it. I've got eyes on ${prRef} — I'll post here as soon as the verdict moves or the checks settle.`;
+  } else {
+    text = "Got it. I'll keep watching the board and surface anything that needs your call.";
+  }
+
+  return {
+    text,
+    addressedTo: "operator",
+    ...(message.relatedPr ? { relatedPr: message.relatedPr } : {}),
+    ...(message.relatedCorrelationId ? { relatedCorrelationId: message.relatedCorrelationId } : {}),
+  };
+}

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -3847,6 +3847,43 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       });
     }
 
+    // Short post-message poll: after an operator posts, hit GET
+    // /monitor/collaboration?sinceMs=<just-posted-ts> a handful of times
+    // over ~3 seconds so any Hermes auto-reply (recorded server-side
+    // ~800ms after our POST) surfaces visibly without waiting for the
+    // next SSE snapshot tick (up to 5s). Bails out as soon as a new
+    // message arrives so we don't keep polling forever.
+    function pollCollaborationSince(sinceMs) {
+      let attempts = 0;
+      const maxAttempts = 5;
+      const intervalMs = 700;
+      const tick = async () => {
+        attempts += 1;
+        try {
+          const url = buildCommandUrl(collaborationPath + "?sinceMs=" + (sinceMs + 1));
+          const resp = await fetch(url);
+          if (resp.ok) {
+            const body = await resp.json();
+            if (body && Array.isArray(body.messages) && body.messages.length > 0) {
+              const known = new Set((latestCollabMessages || []).map((m) => m && m.id).filter(Boolean));
+              const fresh = body.messages.filter((m) => m && m.id && !known.has(m.id));
+              if (fresh.length > 0) {
+                latestCollabMessages = (latestCollabMessages || []).concat(fresh);
+                forceThreadMode();
+                renderAutoCollaborationThread();
+                return; // got the reply, stop polling
+              }
+            }
+          }
+        } catch (e) {
+          // Network blips are fine — the next SSE snapshot will surface
+          // the reply anyway. Don't spam the console.
+        }
+        if (attempts < maxAttempts) setTimeout(tick, intervalMs);
+      };
+      setTimeout(tick, intervalMs);
+    }
+
     async function submitCollaborationPost(text) {
       const submit = document.getElementById("command-submit");
       const input = document.getElementById("command-input");
@@ -3883,6 +3920,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           // the new message shows up.
           forceThreadMode();
           renderAutoCollaborationThread();
+          // Hermes auto-replies on the server ~800ms after our post. The
+          // next SSE snapshot tick is up to 5s away, which feels sluggish
+          // for a conversation. Run a short GET poll loop so the reply
+          // surfaces in roughly a second.
+          pollCollaborationSince(result.message.ts);
         }
         setComposeStatus("Posted.", "ok");
         if (input) input.value = "";

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -5,6 +5,7 @@ import {
   __resetCollaborationStoreForTests,
   listCollaborationMessages,
   recordCollaborationMessage,
+  synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
 
 const NOW = Date.UTC(2026, 4, 18, 12, 0, 0);
@@ -141,5 +142,88 @@ describe("monitor collaboration channel", () => {
     // The first 100 should have been evicted.
     expect(listed[0].text).toBe("m100");
     expect(listed[499].text).toBe("m599");
+  });
+});
+
+describe("synthesizeHermesReplyFor", () => {
+  beforeEach(() => {
+    __resetCollaborationStoreForTests();
+  });
+
+  function opMessage(overrides: Record<string, unknown> = {}) {
+    return recordCollaborationMessage(
+      {
+        author: "operator",
+        text: "ping",
+        addressedTo: "hermes",
+        ...overrides,
+      },
+      NOW
+    );
+  }
+
+  it("does not reply to messages from non-operator authors", () => {
+    const m = recordCollaborationMessage(
+      { author: "codex", text: "I picked up #1.", addressedTo: "hermes" },
+      NOW
+    );
+    expect(synthesizeHermesReplyFor(m)).toBeNull();
+  });
+
+  it("does not reply to operator messages addressed only to codex", () => {
+    const m = opMessage({ addressedTo: "codex" });
+    expect(synthesizeHermesReplyFor(m)).toBeNull();
+  });
+
+  it("does not reply when operator addresses only themselves", () => {
+    const m = opMessage({ addressedTo: "operator" });
+    expect(synthesizeHermesReplyFor(m)).toBeNull();
+  });
+
+  it("replies when operator addresses hermes", () => {
+    const m = opMessage({ addressedTo: "hermes" });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply).not.toBeNull();
+    expect(reply?.addressedTo).toBe("operator");
+    expect(reply?.text.length).toBeGreaterThan(0);
+  });
+
+  it("replies when operator addresses everyone", () => {
+    const m = opMessage({ addressedTo: "everyone" });
+    expect(synthesizeHermesReplyFor(m)).not.toBeNull();
+  });
+
+  it("references the related PR in the reply when present", () => {
+    const m = opMessage({
+      addressedTo: "hermes",
+      relatedPr: { repo: "averray-agent/agent", number: 137 },
+    });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply?.text).toContain("averray-agent/agent#137");
+    expect(reply?.relatedPr).toEqual({ repo: "averray-agent/agent", number: 137 });
+  });
+
+  it("uses a help-specific reply for request_help intent", () => {
+    const m = opMessage({ kind: "request_help" });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply?.text.toLowerCase()).toContain("blocker");
+  });
+
+  it("uses a proposal-specific reply for proposal intent", () => {
+    const m = opMessage({
+      kind: "proposal",
+      relatedPr: { repo: "averray-agent/agent", number: 200 },
+    });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply?.text.toLowerCase()).toMatch(/noted|verdict/);
+  });
+
+  it("forwards relatedCorrelationId so the reply stays threaded to the same PR session", () => {
+    const m = opMessage({
+      addressedTo: "everyone",
+      relatedCorrelationId: "smoke-2026-05-18-abc",
+    });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply?.relatedCorrelationId).toBe("smoke-2026-05-18-abc");
   });
 });

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -312,6 +312,13 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain('.done-rail:hover');
     expect(html).toContain('.done-rail .lane-head::before');
     expect(html).toContain('.done-rail .lane-title .pill');
+
+    // Hermes auto-reply (PR: monitor-hermes-replies): client polls the
+    // collaboration buffer right after a post so the server-side
+    // Hermes reply (~800ms later) surfaces in ~1s instead of waiting
+    // for the next SSE snapshot.
+    expect(html).toContain('pollCollaborationSince');
+    expect(html).toContain('sinceMs=');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Operator feedback from a live session: posts to Hermes never get a reply. The channel is one-way today — agents only "speak" through synthesized lines derived from board state, never in direct response to an operator message. So even after the bubble polish (#141), conversation flow (#142), and dock-size fix (#145), the chat feels static.

This PR makes Hermes actually acknowledge operator posts.

## What's in

**Backend — `synthesizeHermesReplyFor(message)` in `monitor-collab.ts`**

Pure function with canned templates keyed on intent + whether a PR is referenced. Returns `null` when no reply is warranted (operator addressing Codex only, self-addressed, or message from a non-operator). Reply templates:

| Operator intent | Reply template |
|---|---|
| `request_help` + PR | "On it — what's blocking you on `<pr>`?" |
| `request_help` no PR | "On it. What's the blocker?" |
| `proposal` + PR | "Noted on `<pr>`. I'll surface a verdict here once Codex picks it up..." |
| `status` + PR | "Acknowledged. I'll keep watching `<pr>`..." |
| `chat` + PR | "Got it. I've got eyes on `<pr>` — I'll post here as soon as the verdict moves..." |
| `chat` no PR | "Got it. I'll keep watching the board..." |

`relatedPr` and `relatedCorrelationId` flow through so the reply stays threaded to the same PR session.

**Backend wiring — `scheduleHermesAutoReply` in `index.ts`**

`POST /monitor/collaboration` records the operator post, then schedules a Hermes reply ~800ms later via the same ring-buffer path. No new transport, no new auth surface. `timer.unref()` so the reply doesn't keep the process alive on shutdown.

**Frontend — `pollCollaborationSince()` in `monitor.ts`**

After a successful POST, a short GET poll loop hits `/monitor/collaboration?sinceMs=<ts>` up to 5 times over ~3.5s. New messages merge into the local thread and trigger `renderAutoCollaborationThread`. Bails out as soon as a new message arrives. Without this the operator would wait up to 5s (next SSE snapshot) to see Hermes reply.

## Tone

Intentionally canned — predictable, cheap, no LLM dependency. Hermes acknowledges, references the PR by ID, and promises to surface verdicts.

**Out of scope (deliberate follow-up):** Route operator text through the existing Ask-Hermes insight handler when it matches an allowed command pattern (`merge steward details`, `what is happening now`, etc.) so Hermes gives a *real* answer when the operator asks one. Easy layer to add later.

## Tests

- 154/154 vitest cases pass (was 145; +9 new tests for `synthesizeHermesReplyFor`). Same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on `main`, unchanged.
- New unit tests cover: non-operator authors (no reply), operator → codex only (no reply), operator → self (no reply), operator → hermes (reply), operator → everyone (reply), PR reference flow-through, intent-keyed templates (`request_help`, `proposal`), `relatedCorrelationId` propagation.
- Surface assertions for `pollCollaborationSince` and the `sinceMs=` query in the rendered client JS.

## Test plan

- [ ] Post a message addressed to Hermes (or Everyone) from the operator compose — Hermes acks within ~1.5s, referencing the selected PR if one is selected.
- [ ] Post a message with intent **Needs help** — Hermes asks for the blocker.
- [ ] Post a message addressed only to Codex — no Hermes reply (Codex's job to respond).
- [ ] Open a second tab, post from tab #1 — tab #2 sees the Hermes reply on the next SSE snapshot (within 5s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)