### PR TITLE
Wire Hermes monitor voice env into stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Do not use `latest` in production. Test a new Hermes tag in a branch, run the
 smoke flow, then update the pin deliberately. For this release, review the
 upstream notes for API approval events, Codex runtime fixes, MCP parallel tool
 calls, dashboard/kanban changes, and security hardening before deploying.
+The monitor collaboration chat also passes `OLLAMA_API_KEY`,
+`OLLAMA_BASE_URL`, and `HERMES_MONITOR_REPLY_MODEL` into `slack-operator` so
+Hermes can use the same v0.14-era OpenAI-compatible provider path for live
+operator replies. If the key is unset, the monitor falls back to deterministic
+local acknowledgments.
 
 Run the reference prompt:
 

--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -34,6 +34,7 @@ cp ops/.env.example .env.prod
 # Edit .env.prod:
 # - set OLLAMA_API_KEY
 # - keep OLLAMA_BASE_URL as https://ollama.com/v1
+# - keep HERMES_MONITOR_REPLY_MODEL aligned with the Hermes default model unless testing a different monitor voice
 # - set SLACK_WEBHOOK_URL
 # - set AGENT_WALLET_PRIVATE_KEY if you did not use bootstrap-wallet.sh
 # - confirm AVERRAY_API_BASE_URL points at testnet

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -28,6 +28,7 @@ AVERRAY_MUTATION_POLICY_FAIL_OPEN=false
 OLLAMA_API_KEY=
 OLLAMA_BASE_URL=https://ollama.com/v1
 HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud
+HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud
 HERMES_COMPARISON_MODEL=qwen3.5:cloud
 
 # Optional read-only GitHub operator helper.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -168,6 +168,9 @@ services:
       GITHUB_HELPER_REPOS: ${GITHUB_HELPER_REPOS:-}
       GITHUB_API_BASE_URL: ${GITHUB_API_BASE_URL:-https://api.github.com}
       GITHUB_HELPER_LIMIT: ${GITHUB_HELPER_LIMIT:-5}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-https://ollama.com/v1}
+      HERMES_MONITOR_REPLY_MODEL: ${HERMES_MONITOR_REPLY_MODEL:-deepseek-v4-pro:cloud}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
       AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/scripts/bootstrap-wallet.sh
+++ b/scripts/bootstrap-wallet.sh
@@ -16,7 +16,7 @@ import { randomUUID } from "node:crypto";
 const privateKey = generatePrivateKey();
 const account = privateKeyToAccount(privateKey);
 
-console.log(`HERMES_IMAGE=nousresearch/hermes-agent@sha256:8811f1809971ac558f8d5e311e22fe73dc2944616dda7295c98acb6028f9df08`);
+console.log(`HERMES_IMAGE=nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33`);
 console.log(`POSTGRES_USER=avg_agent`);
 console.log(`POSTGRES_PASSWORD=${randomUUID().replaceAll("-", "")}`);
 console.log(`POSTGRES_DB=avg_agent`);
@@ -28,6 +28,7 @@ console.log(`AGENT_WALLET_ADDRESS=${account.address}`);
 console.log(`OLLAMA_API_KEY=`);
 console.log(`OLLAMA_BASE_URL=https://ollama.com/v1`);
 console.log(`HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud`);
+console.log(`HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud`);
 console.log(`HERMES_COMPARISON_MODEL=qwen3.5:cloud`);
 console.log(`SLACK_WEBHOOK_URL=`);
 console.log(`TRACE_HTTP_PORT=8789`);

--- a/test/unit/compose-env.test.ts
+++ b/test/unit/compose-env.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readText(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("compose environment wiring", () => {
+  it("passes Hermes monitor voice provider settings into slack-operator", () => {
+    const compose = parse(readText("../../ops/compose.yml")) as {
+      services?: Record<string, { environment?: Record<string, string> }>;
+    };
+
+    const env = compose.services?.["slack-operator"]?.environment;
+    expect(env?.OLLAMA_API_KEY).toBe("${OLLAMA_API_KEY:-}");
+    expect(env?.OLLAMA_BASE_URL).toBe("${OLLAMA_BASE_URL:-https://ollama.com/v1}");
+    expect(env?.HERMES_MONITOR_REPLY_MODEL).toBe("${HERMES_MONITOR_REPLY_MODEL:-deepseek-v4-pro:cloud}");
+  });
+
+  it("keeps bootstrap-generated env files on the documented Hermes pin", () => {
+    const envExample = readText("../../ops/.env.example");
+    const bootstrap = readText("../../scripts/bootstrap-wallet.sh");
+    const pin = envExample.match(/^HERMES_IMAGE=(.+)$/m)?.[1];
+
+    expect(pin).toBeTruthy();
+    expect(bootstrap).toContain(`HERMES_IMAGE=${pin}`);
+    expect(envExample).toContain("HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud");
+    expect(bootstrap).toContain("HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud");
+  });
+});


### PR DESCRIPTION
## What changed
- Pass Ollama provider settings into slack-operator so the merged Hermes monitor LLM reply path can run in production.
- Add HERMES_MONITOR_REPLY_MODEL to env examples and bootstrap output.
- Keep bootstrap-wallet on the documented Hermes v0.14 image digest.
- Add a compose/env regression test.

## Checks
- npm test -- compose-env
- npm run typecheck
- npm test
- git diff --check

## Impact
- Affects ops compose/env docs and slack-operator runtime configuration.
- No backend API, database, contracts, public site, or indexer changes.
- VPS needs .env.prod to include HERMES_MONITOR_REPLY_MODEL or it will use the compose default. OLLAMA_API_KEY must be set for live LLM replies; otherwise fallback acknowledgments remain active.