### PR TITLE
Done-row clicks expand inline, not into the full drawer

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -2851,6 +2851,82 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       letter-spacing: 0.06em;
       white-space: nowrap;
     }
+    /* Tiny chevron at the end of each done-row hints that clicking
+       toggles an inline detail strip below (it flips ▾ → ▴ when open). */
+    .done-row .done-caret {
+      color: var(--muted);
+      font-size: 0.78rem;
+      line-height: 1;
+      margin-left: 2px;
+    }
+    /* Expanded done-row attaches to the detail strip below it: collapse
+       the bottom corners + soften the bottom border so the two read as
+       one stacked panel. */
+    .done-row[data-expanded="true"] {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+      border-bottom-color: transparent;
+      background: color-mix(in srgb, var(--ok) 5%, var(--surface-strong));
+    }
+    .done-row[data-expanded="true"][data-verdict="block"] {
+      background: color-mix(in srgb, var(--bad) 5%, var(--surface-strong));
+    }
+    /* Inline detail strip rendered as a sibling of the .done-row when
+       expanded. Compact two-row dl (Closed time + Verdict) on the left,
+       Open PR link on the right. Read-only — no actions, no drawer. */
+    .done-row-detail {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      gap: 12px;
+      align-items: center;
+      padding: 8px 12px 10px;
+      border: 1px solid var(--line);
+      border-top: 0;
+      border-radius: 0 0 6px 6px;
+      background: var(--surface-strong);
+      margin-top: -2px;
+      font-size: 0.78rem;
+    }
+    .done-row-detail dl {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: 4px 12px;
+      margin: 0;
+      min-width: 0;
+    }
+    .done-row-detail dt {
+      color: var(--muted);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.62rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      align-self: baseline;
+    }
+    .done-row-detail dd {
+      color: var(--text);
+      margin: 0;
+      min-width: 0;
+      overflow-wrap: anywhere;
+    }
+    .done-row-detail .done-detail-open {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--line);
+      background: var(--surface-soft);
+      color: var(--cyan);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.72rem;
+      letter-spacing: 0.02em;
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .done-row-detail .done-detail-open:hover {
+      border-color: color-mix(in srgb, var(--cyan) 55%, var(--line));
+      background: color-mix(in srgb, var(--cyan) 8%, var(--surface-soft));
+    }
 
     /* Operator checklist with real checkboxes */
     .operator-checklist { display: grid; gap: 6px; }
@@ -3755,6 +3831,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     let mobileLaneTab = "all"; // mobile-only lane filter (matches boardLaneForItem keys + "all")
     const isMobileViewport = () => window.matchMedia("(max-width: 640px)").matches;
     let selectedKey = "";
+    // Done-row inline expansion key. Independent from selectedKey because
+    // done-rows DON'T open the full drawer — clicking one toggles a small
+    // detail strip in place. Only one row expanded at a time.
+    let expandedDoneKey = "";
     let autoFocusPending = true;
     let latestPipelineItems = [];
     let latestCodexTasks = [];
@@ -3807,6 +3887,15 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       // === card" as "this whole element is the selectable" and let the
       // selection happen.
       if (card && (!interactive || interactive === card)) {
+        // Done-rows behave differently from kanban cards. The closed-PR
+        // detail is read-only; the big slide-over drawer is overkill.
+        // Toggle a small inline detail strip in place instead.
+        if (card.classList && card.classList.contains("done-row")) {
+          const key = String(card.getAttribute("data-select-card") || "");
+          expandedDoneKey = expandedDoneKey === key ? "" : key;
+          renderBoard(latestPipelineItems);
+          return;
+        }
         selectedKey = String(card.getAttribute("data-select-card") || "");
         autoFocusPending = false;
         renderBoard(latestPipelineItems);
@@ -4894,23 +4983,51 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '</section>';
     }
 
-    // Compact one-line entry for the Done lane when expanded.
+    // Compact one-line entry for the Done lane when expanded. Clicking
+    // the row toggles a small inline detail strip below it (see
+    // renderDoneRowDetail) — not the full slide-over drawer, which is
+    // overkill for read-only closed PRs.
     function renderDoneRow(item /*, lane */) {
       const verdict = releaseVerdict(item);
       const key = boardItemKey(item);
-      const selected = key === selectedKey;
+      const expanded = key === expandedDoneKey;
       const age = handoffAge(item);
       const repo = String(item.repo || "");
       const repoShort = repo.split("/")[1] || repo;
       const prNumber = item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId);
       const idLabel = prNumber ? "#" + prNumber : (isDeployItem(item) ? "deploy" : "handoff");
       const title = cardTitleText(pipelineTitle(item), prNumber, item);
-      return '<button class="done-row" data-select-card="' + escapeAttr(key) + '" data-selected="' + escapeAttr(String(selected)) + '" data-verdict="' + escapeAttr(verdict.level) + '" type="button">' +
+      const row = '<button class="done-row" data-select-card="' + escapeAttr(key) + '" data-expanded="' + (expanded ? "true" : "false") + '" data-verdict="' + escapeAttr(verdict.level) + '" type="button" aria-expanded="' + (expanded ? "true" : "false") + '">' +
         '<span class="done-check">' + (verdict.level === "block" ? "!" : "✓") + '</span>' +
         '<span class="done-id"><span class="done-repo">' + escapeHtml(repoShort) + '</span><span class="done-num">' + escapeHtml(idLabel) + '</span></span>' +
         '<span class="done-title">' + escapeHtml(title) + '</span>' +
         '<span class="done-age">' + escapeHtml(age.label + " " + age.duration) + '</span>' +
+        '<span class="done-caret" aria-hidden="true">' + (expanded ? "▴" : "▾") + '</span>' +
         '</button>';
+      return row + (expanded ? renderDoneRowDetail(item, verdict) : "");
+    }
+
+    // Inline detail strip rendered beneath a clicked done-row. Read-only
+    // summary — what was the verdict, when did it finish, where can the
+    // operator go to look at it on GitHub.
+    function renderDoneRowDetail(item, verdict) {
+      const prUrl = item.pullRequestUrl || derivePullRequestUrl(item);
+      const updatedIso = String(item.updatedAt || "");
+      const closedLabel = updatedIso
+        ? new Date(updatedIso).toLocaleString()
+        : "unknown";
+      const verdictLabel = (verdict && verdict.label) ? verdict.label : "completed";
+      const why = (verdict && verdict.why) ? shortenVerdictWhy(verdict.why) : "";
+      const openPr = prUrl
+        ? '<a class="done-detail-open" href="' + escapeAttr(prUrl) + '" target="_blank" rel="noreferrer">Open PR ↗</a>'
+        : '';
+      return '<div class="done-row-detail" data-key="' + escapeAttr(boardItemKey(item)) + '">' +
+        '<dl>' +
+          '<dt>Closed</dt><dd>' + escapeHtml(closedLabel) + '</dd>' +
+          '<dt>Verdict</dt><dd>' + escapeHtml(verdictLabel) + (why ? ' · ' + escapeHtml(why) : '') + '</dd>' +
+        '</dl>' +
+        openPr +
+      '</div>';
     }
 
     function renderBoardCard(item, lane) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -380,6 +380,18 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain('max-height: min(32vh, 310px)');
     // Old kanban-style chat panel rules are gone.
     expect(html).not.toContain('border-left: 3px solid var(--speaker-accent');
+
+    // Done-row inline expansion (PR: monitor-done-inline): clicking a
+    // closed PR row toggles a small detail strip below it instead of
+    // opening the full slide-over drawer.
+    expect(html).toContain('expandedDoneKey');
+    expect(html).toContain('renderDoneRowDetail');
+    expect(html).toContain('classList.contains("done-row")');
+    expect(html).toContain('done-row-detail');
+    expect(html).toContain('done-caret');
+    expect(html).toContain('done-detail-open');
+    // The expansion toggles via data-expanded.
+    expect(html).toContain('expanded ? "true" : "false"');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Operator feedback after #147 wired done-row clicks to the slide-over drawer: the full drawer is overkill for a closed PR. It renders 8+ sections (HANDOFF OWNER, ACTION RECIPE, HERMES VERDICT, AGENT PRE-CHECK, CHECKS, TOUCHED FILES, TIMELINE, REFERENCES, PHASE HISTORY) — all of those are designed for *active* work. Once a PR is closed, the operator just wants to glance at when it closed, what the verdict was, and maybe jump to GitHub.

This PR switches done-row clicks to a small inline expansion in place. The kanban-card → drawer behavior is untouched.

## What you'll see

Click a row in the expanded Done lane and it expands in place to show a small detail strip beneath it:

```
✓  agent  #435   Ready to merge · docs                          STALE 5h 35m   ▴
   ┌──────────────────────────────────────────────────────────────────┐
   │ CLOSED   5/18/2026, 6:55:10 PM                                   │
   │ VERDICT  merged · GitHub reports this PR is merged…   [Open PR ↗]│
   └──────────────────────────────────────────────────────────────────┘
```

Click again to collapse. Only one row expanded at a time. The ▾/▴ chevron flips to hint the toggle state.

## What's in

- New module-local state `expandedDoneKey` (separate from `selectedKey`).
- Click handler special-cases `.done-row` — toggles `expandedDoneKey`, re-renders the board, does **not** call `renderDrawer`. The drawer scrim and the full drawer remain reserved for kanban-card clicks.
- New helper `renderDoneRowDetail(item, verdict)` builds a compact two-row dl (`Closed` + `Verdict`) plus an `Open PR ↗` link using `item.pullRequestUrl` or `derivePullRequestUrl`.
- `renderDoneRow` emits the button + optional detail sibling, and adds a ▾/▴ chevron at the end of the row.
- CSS: detail strip attaches visually to the row above by collapsing the row's bottom corners + softening its bottom border. `data-verdict` colors flow through so blocked done items keep their warning-color hint.

## What's NOT in

- The full slide-over drawer behavior for kanban cards (active lanes) — same as before, including the scrim.
- No new backend calls; everything reads from the existing pipeline snapshot.

## Tests

- **171/171 vitest cases pass** (same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on `main`, unchanged).
- New surface assertions for `expandedDoneKey`, `renderDoneRowDetail`, the done-row class check in the click handler, the `.done-row-detail` CSS, `done-caret`, `done-detail-open`, and the expanded-ternary in the button output.
- Existing inline-JS parse test still green — the rendered `<script>` block compiles.

## Test plan

- [ ] Click a row in the Done lane → row expands in place to show Closed time + Verdict + Open PR link; chevron flips from ▾ to ▴; **no slide-over drawer opens**, page does not dim.
- [ ] Click the same row again → collapses; chevron flips back.
- [ ] Click a different done-row → previous row collapses, new row expands.
- [ ] Click a kanban card (active lane) → drawer still opens with scrim, exactly as before.
- [ ] Hover any done-row → existing hover treatment still works.

## Deploy

Same target as the previous chat changes (slack-operator + codex-task-runner, **not** hermes):

```bash
cd /srv/averray-reference-agent
git pull --rebase
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)