### PR TITLE
Dedupe the chat: one synthesized line per PR, not six

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -6590,7 +6590,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       latestCollabMessages
         .filter((m) => postedMessageMatchesKind(m, kind))
         .forEach((m) => messages.push(postedToCollabRow(m)));
-      messages.push(...buildBoardBriefingMessages(kind));
+      // The board briefing emits a header + N per-item lines. Capture
+      // which items it covered so the per-item ask loop below doesn't
+      // echo the same content for those same items.
+      const briefing = buildBoardBriefingMessages(kind);
+      messages.push(...briefing.messages);
+      const briefingCoveredKeys = new Set(briefing.items.map(boardItemKey));
       latestCodexTasks
         .filter((task) => !isTerminalCodexTask(task))
         .sort((a, b) => taskUpdatedMs(b) - taskUpdatedMs(a))
@@ -6600,6 +6605,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         const verdict = releaseVerdict(item);
         const lane = boardLaneForItem(item, verdict);
         if (lane.key === "done") return;
+        // Skip items the briefing already covered — otherwise the thread
+        // shows two near-identical synthesized lines per PR.
+        if (briefingCoveredKeys.has(boardItemKey(item))) return;
         const action = nextPipelineAction(item, verdict);
         if (kind === "codex" && action.owner !== "Codex" && lane.key !== "codex") return;
         if (kind === "hermes" && action.owner !== "Hermes" && lane.key !== "hermes") return;
@@ -6619,10 +6627,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       return messages;
     }
 
+    // Returns { messages, items } so the caller can dedupe — items
+    // here are the pipeline items the briefing already mentioned by
+    // name, and the per-item ask loop should skip those keys to avoid
+    // echoing the same status twice.
     function buildBoardBriefingMessages(kind) {
-      if (!["all", "now", "blocked"].includes(kind || "all")) return [];
+      if (!["all", "now", "blocked"].includes(kind || "all")) return { messages: [], items: [] };
       const items = topConsoleItems(boardBriefingItems(kind), 4);
-      if (!items.length) return [];
+      if (!items.length) return { messages: [], items: [] };
       const baseTs = newestBoardItemUpdateMs(items);
       const messages = [
         collabMessage("Hermes", boardBriefingSummary(items), "board briefing", baseTs),
@@ -6633,7 +6645,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         const action = nextPipelineAction(item, verdict);
         messages.push(collabMessage("Hermes", boardBriefingLineForItem(item, verdict, action, lane), boardBriefingMeta(item, verdict, lane), baseTs + index + 1));
       });
-      return messages;
+      return { messages, items };
     }
 
     function boardBriefingItems(kind) {
@@ -6686,10 +6698,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function boardBriefingLineForItem(item, verdict, action, lane) {
       const title = cardTitleText(pipelineTitle(item), item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
       if (codexTaskFailedForItem(item)) {
-        return "Codex: " + title + " is blocked because the last Codex task failed. First open the failed runner output; if it is auth or clone setup, fix the runner, otherwise create a smaller retry task or push the smallest PR-check fix.";
+        return "Codex: " + title + " — last runner task failed. Open the failed runner output first; if it's auth or clone setup, fix the runner. Otherwise create a smaller retry task or push the smallest PR-check fix.";
       }
       if (isDraftPullRequest(item)) {
-        return "Codex: " + title + " is still draft. Finish the draft or mark it ready for review, then let CI and Hermes re-run.";
+        return "Codex: " + title + " — finish the draft or mark it ready for review, then let CI and Hermes re-run.";
       }
       if (lane.key === "attention" && action.owner === "Codex") {
         return "Codex: " + title + " is blocked. " + capitalizeFirst(action.text) + ". Hermes will clear it only after the blocking signal disappears.";
@@ -6726,8 +6738,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     // terse, action-first. Hermes's voice: dry, methodical, observing.
     function collaborationAskForItem(item, verdict, action, lane) {
       const title = cardTitleText(pipelineTitle(item), item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
-      if (codexTaskFailedForItem(item)) return "Codex — " + title + " failed in the runner. Open the failed task output first; then fix the runner setup, push the smallest PR-check fix, or create a smaller retry task.";
-      if (isDraftPullRequest(item)) return "Codex — " + title + " is still draft. Finish the draft or mark it ready for review, then let CI and Hermes re-run.";
+      if (codexTaskFailedForItem(item)) return "Codex — " + title + ": last runner task failed. Open the failed task output first; then fix the runner setup, push the smallest PR-check fix, or create a smaller retry task.";
+      if (isDraftPullRequest(item)) return "Codex — " + title + ": finish the draft or mark it ready for review, then let CI and Hermes re-run.";
       if (action.owner === "Codex" || lane.key === "codex") return "Codex — you're up on " + title + ". " + action.text;
       if (action.owner === "Operator" || lane.key === "operator" || lane.key === "attention") return "Pascal, this one needs your call on " + title + ". " + action.text;
       if (action.owner === "Hermes" || lane.key === "hermes") return "Watching " + title + ". I'll land the verdict here once the checks clear.";
@@ -6748,9 +6760,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const ts = taskUpdatedMs(task);
       const messages = [];
       if (status === "proposed") {
-        messages.push(collabMessage("Hermes", "Drafted a task for Codex on " + title + ".", "task proposed", ts));
-        messages.push(collabMessage("Hermes", "Pascal — approve when you want Codex to start.", "approval needed", ts + 1));
+        // Collapsed from two Hermes lines into one — they were back-to-
+        // back from the same speaker and read as duplicate noise.
+        messages.push(collabMessage("Hermes", "Drafted a task for Codex on " + title + ". Pascal — approve when you want Codex to start.", "task proposed · approval needed", ts));
       } else if (status === "approved") {
+        // Same collapse — Hermes's approval note and Codex's queued
+        // ack happen in the same beat; keep them as one row each but
+        // tighten the wording.
         messages.push(collabMessage("Hermes", "Approved — " + title + " is yours, Codex.", "approved", ts));
         messages.push(collabMessage("Codex", "Queued. Runner's picking me up next.", "waiting runner", ts + 1));
       } else if (status === "running") {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -189,7 +189,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("buildBoardBriefingMessages(kind)");
     expect(html).toContain("Board read:");
     expect(html).toContain("No operator decision is needed right now.");
-    expect(html).toContain("First open the failed runner output");
+    expect(html).toContain("Open the failed runner output first");
     expect(html).toContain("Finish the draft or mark it ready for review");
     expect(html).toContain("forceThreadMode();\n          renderAutoCollaborationThread();\n          setComposeStatus(\"Codex task approved");
     expect(html).toContain("latestCodexTasks\n        .filter((task) => !isTerminalCodexTask(task))");
@@ -392,6 +392,18 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain('done-detail-open');
     // The expansion toggles via data-expanded.
     expect(html).toContain('expanded ? "true" : "false"');
+
+    // Chat dedupe (PR: monitor-chat-dedup): when the board briefing
+    // already covers a PR, the per-item ask loop skips it so the
+    // thread doesn't show two near-identical lines per item. The
+    // proposed-task branch collapses two Hermes lines into one.
+    expect(html).toContain('briefingCoveredKeys');
+    expect(html).toContain('briefingCoveredKeys.has(boardItemKey(item))');
+    expect(html).toContain('Pascal — approve when you want Codex to start');
+    expect(html).toContain('task proposed · approval needed');
+    // The old "is still draft. " redundancy is gone (title already
+    // describes the draft state via pipelineTitle).
+    expect(html).not.toContain('" is still draft. Finish the draft');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Live screenshot showed one DRAFT PR (#439) producing **six** Hermes lines back-to-back in the collaboration thread:

> 1. *Board read: Codex owns 1. No operator decision is needed right now…*
> 2. *Codex — PR is still marked as draft. **is still draft**. Finish the draft…*
> 3. *Codex: PR is still marked as draft. **is still draft**. Finish the draft…*
> 4. *Drafted a task for Codex on averray-agent/agent #439.*
> 5. *Pascal — approve when you want Codex to start.*
> 6. *Hermes proposed a bounded Codex task.*

Three layers of duplication, plus a text bug.

## What was wrong

1. **`buildBoardBriefingMessages` (#154)** emits a per-item line for each PR it summarizes. The per-item ask loop right after it emits *another* line for the same item — same content, different prefix ("Codex —" vs "Codex:"). Lines 2 and 3 above.
2. **`collaborationMessagesForTask` for status "proposed"** emits 2 Hermes lines that arrive back-to-back from the same speaker. Lines 4 and 5 above.
3. **Title/action text overlap**: both helpers concatenate `title + " is still draft. Finish…"` without checking whether `title` already mentions draft. With `pipelineTitle` returning "PR is still marked as draft", the result is *"PR is still marked as draft. is still draft. Finish…"*.

## What ships

- `buildBoardBriefingMessages` now returns `{ messages, items }` so the caller knows which items it covered.
- `buildCollaborationMessages` collects those item keys into a Set and **skips them in the per-item ask loop**. Result: one synthesized line per PR for the kinds that show the briefing (`all`, `now`, `blocked`). Per-agent kinds (`codex` / `hermes` / `operator`) don't trigger the briefing, so they still get the per-item ask — no regression there.
- `collaborationMessagesForTask` proposed-branch collapses two Hermes pushes into one combined sentence with meta `task proposed · approval needed`.
- Both `boardBriefingLineForItem` and `collaborationAskForItem` drop the redundant *" is still draft"* / *" failed in the runner"* / *" is blocked because…"* phrases that overlapped with the title. The follow-up imperative ("finish the draft…", "open the failed runner output…") already conveys the state.

## Result

The same DRAFT PR will now produce ~2 lines instead of 6:

> *Board read: Codex owns 1. No operator decision is needed right now…*
> *Codex: PR is still marked as draft — finish the draft or mark it ready for review, then let CI and Hermes re-run.*
> *Drafted a task for Codex on averray-agent/agent #439. Pascal — approve when you want Codex to start.*

## Tests

- **171/171 vitest cases pass** (same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on `main`, unchanged).
- One existing assertion updated to match the rephrased failed-runner copy.
- New positive assertions for `briefingCoveredKeys` + the collapsed proposed-task meta.
- New negative assertion that *" is still draft. Finish the draft"* redundancy is gone.

## Deploy

Same target as the recent chat PRs (slack-operator + codex-task-runner, **not** hermes):

```bash
cd /srv/averray-reference-agent
git pull --rebase
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)