### PR TITLE
Polish the top strip so it stops looking like a placeholder

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -1009,37 +1009,54 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       min-width: 0;
       flex-wrap: wrap;
     }
+    /* Counter chip — number on top, small uppercase label below.
+       Matches the kanban-card "pill" vocabulary instead of the
+       generic outlined-pill look. Non-zero chips light up in their
+       tone color; zero chips fade so the eye lands on what's actually
+       live. Toggled via data-empty by JS after each render. */
     .counter-chip {
       display: inline-flex;
-      align-items: center;
-      gap: 6px;
-      height: 30px;
-      padding: 0 10px;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: center;
+      gap: 3px;
+      min-width: 70px;
+      padding: 6px 12px;
       border: 1px solid var(--line);
-      border-radius: 7px;
-      background: var(--surface-soft);
+      border-radius: 6px;
+      background: rgba(2, 9, 8, 0.3);
       white-space: nowrap;
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       line-height: 1;
+      transition: opacity 140ms ease, border-color 140ms ease, background 140ms ease;
     }
-    .counter-chip[data-tone="warn"] {
-      border-color: rgba(255, 209, 102, 0.66);
-      background: rgba(255, 209, 102, 0.1);
+    .counter-chip[data-empty="true"] {
+      opacity: 0.42;
+      background: transparent;
+      border-color: var(--line-soft);
     }
-    .counter-chip[data-tone="bad"] {
-      border-color: rgba(255, 107, 107, 0.68);
-      background: rgba(255, 107, 107, 0.1);
+    .counter-chip[data-tone="warn"]:not([data-empty="true"]) {
+      border-color: color-mix(in srgb, var(--warn) 50%, var(--line));
+      background: color-mix(in srgb, var(--warn) 10%, rgba(2, 9, 8, 0.3));
     }
-    .counter-chip[data-tone="ok"] {
-      border-color: rgba(82, 210, 115, 0.62);
-      background: rgba(82, 210, 115, 0.1);
+    .counter-chip[data-tone="warn"]:not([data-empty="true"]) .counter-number { color: var(--warn); }
+    .counter-chip[data-tone="bad"]:not([data-empty="true"]) {
+      border-color: color-mix(in srgb, var(--bad) 55%, var(--line));
+      background: color-mix(in srgb, var(--bad) 10%, rgba(2, 9, 8, 0.3));
     }
+    .counter-chip[data-tone="bad"]:not([data-empty="true"]) .counter-number { color: var(--bad); }
+    .counter-chip[data-tone="ok"]:not([data-empty="true"]) {
+      border-color: color-mix(in srgb, var(--ok) 50%, var(--line));
+      background: color-mix(in srgb, var(--ok) 10%, rgba(2, 9, 8, 0.3));
+    }
+    .counter-chip[data-tone="ok"]:not([data-empty="true"]) .counter-number { color: var(--ok); }
     .counter-number {
       display: inline-flex;
       align-items: center;
       color: var(--text);
       font-weight: 800;
-      font-size: 0.92rem;
+      font-size: 1.05rem;
+      letter-spacing: 0.01em;
       line-height: 1;
     }
     .counter-label {
@@ -1047,27 +1064,34 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       align-items: center;
       color: var(--muted);
       text-transform: uppercase;
-      letter-spacing: 0.08em;
-      font-size: 0.62rem;
+      letter-spacing: 0.1em;
+      font-size: 0.58rem;
       line-height: 1;
-      padding-top: 1px; /* nudges small caps onto the visual midline */
     }
+    /* Right-side cluster — compact: live indicator, pause toggle, last-
+       refresh timestamp, refresh button. Inline rather than stacked,
+       smaller padding, so the whole topbar feels coordinated instead
+       of three separate widgets jammed together. */
     .refresh-cluster {
       display: flex;
       align-items: center;
-      gap: 10px;
+      gap: 6px;
       justify-content: flex-end;
     }
     .refresh-meta {
-      display: grid;
-      gap: 2px;
-      text-align: right;
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      font-size: 0.68rem;
+      font-size: 0.66rem;
       color: var(--muted);
       text-transform: uppercase;
-      letter-spacing: 0.06em;
+      letter-spacing: 0.08em;
+      padding: 0 8px;
+      white-space: nowrap;
     }
+    .refresh-meta-label { color: color-mix(in srgb, var(--muted) 70%, var(--line)); }
+    .refresh-meta #generated { color: var(--text); font-weight: 600; }
     .filterbar {
       display: flex;
       align-items: center;
@@ -2239,6 +2263,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       background: var(--surface-soft);
       white-space: nowrap;
     }
+    /* Hide the sys-block when it's idle — the live-status indicator on
+       the right of the topbar already conveys "system is doing fine".
+       Two "idle" indicators is the placeholder vibe we're cleaning up. */
+    .sys[data-state="idle"] { display: none; }
     .sys-dot {
       width: 7px;
       height: 7px;
@@ -3691,8 +3719,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           <span class="cmd-status-sub" id="live-status-sub">auto 5s</span>
         </span>
         <button id="pause" class="cmd-pause" type="button" aria-pressed="false" title="Pause live updates">❚❚</button>
-        <span class="refresh-meta"><span>last refresh</span><span id="generated">waiting</span></span>
-        <button id="refresh" type="button">Refresh</button>
+        <span class="refresh-meta" title="time of the last monitor snapshot"><span class="refresh-meta-label">last refresh</span><span id="generated">waiting</span></span>
+        <button id="refresh" type="button" title="Force a refresh now">Refresh</button>
       </div>
     </header>
     <section class="filterbar" aria-label="Monitor filters">
@@ -4464,11 +4492,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const review = laneCounts.operator || 0;
       const ready = laneCounts.queue || 0;
       const running = (laneCounts.hermes || 0) + (laneCounts.deploy || 0);
-      setText("attention-chip", String(blocked + review + (laneCounts.codex || 0)));
-      setText("blocked-chip", String(blocked));
-      setText("review-chip", String(review));
-      setText("ready-chip", String(ready));
-      setText("running-chip", String(running));
+      setCounterChip("attention-chip", blocked + review + (laneCounts.codex || 0));
+      setCounterChip("blocked-chip", blocked);
+      setCounterChip("review-chip", review);
+      setCounterChip("ready-chip", ready);
+      setCounterChip("running-chip", running);
       updateSysAgents(latestPipelineItems);
       updateDeployHealth(latestPipelineItems);
       renderPipelineBoard(latestPipelineItems);
@@ -7815,6 +7843,19 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function setText(id, value) {
       const target = document.getElementById(id);
       if (target) target.textContent = String(value);
+    }
+
+    // Set a counter-chip's number and toggle data-empty on its outer
+    // chip so the CSS can dim zero-count chips. The value is expected
+    // to be a non-negative integer; anything else is treated as 0.
+    function setCounterChip(numberId, value) {
+      const numberEl = document.getElementById(numberId);
+      if (!numberEl) return;
+      const num = Number(value);
+      const safe = Number.isFinite(num) ? Math.max(0, Math.floor(num)) : 0;
+      numberEl.textContent = String(safe);
+      const chip = numberEl.closest(".counter-chip");
+      if (chip) chip.setAttribute("data-empty", safe > 0 ? "false" : "true");
     }
 
     function needsAttention(item) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -404,6 +404,19 @@ describe("slack operator personal monitor", () => {
     // The old "is still draft. " redundancy is gone (title already
     // describes the draft state via pipelineTitle).
     expect(html).not.toContain('" is still draft. Finish the draft');
+
+    // Top-strip polish (PR: monitor-top-polish): counter chips use
+    // a stacked number-over-label layout with data-empty driving the
+    // zero-state dim; setCounterChip toggles it; the redundant
+    // "system idle" pill is hidden via CSS when idle.
+    expect(html).toContain('setCounterChip');
+    expect(html).toContain('chip.setAttribute("data-empty"');
+    expect(html).toContain('.counter-chip[data-empty="true"]');
+    expect(html).toContain('.sys[data-state="idle"] { display: none; }');
+    // The old setText("attention-chip", ...) plumbing is replaced
+    // by setCounterChip so the zero-dim toggle stays in sync.
+    expect(html).not.toContain('setText("attention-chip"');
+    expect(html).not.toContain('setText("blocked-chip"');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Operator screenshot of the top strip with: *"it's just not polished like the rest of the UI, very placeholder."* Three concrete things made it read that way:

1. **Counter chips were generic outlined pills** with `number + label` side-by-side and equal visual weight regardless of whether the count was `0` or live. Six chips all looking the same when only one had a meaningful number.
2. **Right-side cluster** (Live indicator + pause + `LAST REFRESH` stack + Refresh button) had loose gaps and a stacked `refresh-meta` that made it read as three separate widgets rather than one cluster.
3. **`• system idle` pill** next to the title was redundant with the `Live · stream open` indicator on the right of the same row.

## Changes

### Counter chip redesign

- **Number-on-top, small uppercase label below** — matches the kanban-card pill vocabulary instead of the generic outlined-pill look.
- **New `data-empty` attribute** set by JS whenever the chip value changes; CSS dims `data-empty="true"` chips (opacity 0.42, transparent background, soft border) so the eye lands on the live counts.
- **Non-zero chips with `data-tone="warn" / "bad" / "ok"`** pick up the tone color on both border AND number, not just the background.
- **New `setCounterChip(numberId, value)` helper** replaces `setText` for the five board counters so the `data-empty` toggle always stays in sync.

### Right-side cluster compact

- **`refresh-meta`** switches from a stacked grid (`last refresh` on top, timestamp below) to an inline row with a faint label + brighter timestamp.
- **Cluster gap** drops from `10px` to `6px`.

### Drop redundant "system idle"

- **`.sys[data-state="idle"] { display: none; }`** — the JS that sets `data-state` to `running` when active agents are working (`updateSysAgents`) already exists, no JS change needed. The pill just disappears when nothing's happening and reappears with active agents.

## Tests

- **171/171 vitest cases pass** (same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on `main`).
- **New positive assertions**: `setCounterChip`, `chip.setAttribute("data-empty"`, the dim CSS rule, `.sys[data-state="idle"] { display: none; }`.
- **New negative assertions**: the old `setText("attention-chip"`/`setText("blocked-chip"` plumbing is gone — guards against a future refactor accidentally reverting the data-empty wire.

## What I deliberately didn't touch

- The title block (`A` mark + `Hermes` / `handoff monitor · averray`) — looked fine in the screenshot.
- The bottom filter pills (`all` / `blocked` / `review` / `ready` / `running` / `done lane`) — they're already structurally different from the top counter row (clickable filters with `aria-pressed` selection state). Could be tightened further but wanted to keep this PR focused.

## Deploy

Same target as the recent chat PRs (`slack-operator` + `codex-task-runner`, **not** `hermes`):

```bash
cd /srv/averray-reference-agent
git pull --rebase
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)