### PR TITLE
Collapse long chat messages with a "more ↓" toggle; widen rails 60→66px

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -2109,6 +2109,31 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       line-height: 1.5;
       overflow-wrap: anywhere;
     }
+    /* "more ↓" / "less ↑" toggle for long synthesized messages. Sits
+       inline at the end of the truncated text so it reads as an
+       extension of the sentence, not a separate UI block. */
+    .collab-more {
+      display: inline-flex;
+      align-items: center;
+      margin-left: 6px;
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: color-mix(in srgb, var(--cyan) 80%, var(--text));
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.72rem;
+      letter-spacing: 0.02em;
+      cursor: pointer;
+      vertical-align: baseline;
+    }
+    .collab-more:hover { color: var(--cyan); text-decoration: underline; }
+    /* When fully expanded the "less ↑" sits on its own line beneath the
+       text — looks neater than glued to the end of a paragraph. */
+    .collab-message[data-expanded="true"] .collab-more {
+      display: inline-block;
+      margin-left: 0;
+      margin-top: 6px;
+    }
     /* Posted messages: the inline POSTED pill in the byline already
        signals "real chat". Brighten the body text so it reads as the
        load-bearing line in the thread. No background tint, no rail. */
@@ -4154,6 +4179,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     // session; cleared on reload. Doesn't apply to lanes that have items
     // (those are always expanded).
     const forcedExpandedLaneKeys = new Set();
+    // Per-message expand state for long synthesized chat lines. Persists
+    // for the session; keyed by collabRowKey(message) so synthesized
+    // messages (no server id) match across re-renders. The renderer
+    // shows a truncated summary + "more ↓" button by default, expands
+    // to the full text when the key is in this set.
+    const expandedCollabRowKeys = new Set();
     // Compose state for the new collaboration "post" mode. The compose form
     // can run in two modes: "post" (POST /monitor/collaboration → real
     // multi-agent message) and "ask" (POST /monitor/command → Hermes
@@ -4296,6 +4327,23 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         // Play a confirmation chime on enable so the operator hears
         // what they just turned on (and the AudioContext gets unlocked).
         if (collabSoundEnabled) playOperatorChime();
+        return;
+      }
+      // Toggle the expanded state for a long synthesized chat message.
+      // Re-renders the collaboration thread so the row paints with
+      // the full text (or back to the summary) using the same diff/
+      // animation path as a normal SSE tick.
+      const collabMore = event.target && event.target.closest ? event.target.closest("[data-collab-more]") : null;
+      if (collabMore) {
+        const key = collabMore.getAttribute("data-collab-more");
+        if (key) {
+          if (expandedCollabRowKeys.has(key)) expandedCollabRowKeys.delete(key);
+          else expandedCollabRowKeys.add(key);
+          // Force the thread to re-render even if data-auto is currently
+          // false (some flows pin it off — see Ask Hermes).
+          forceThreadMode();
+          renderAutoCollaborationThread();
+        }
         return;
       }
       const button = event.target && event.target.closest ? event.target.closest("[data-monitor-decision]") : null;
@@ -5312,7 +5360,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       } else {
         const cols = visibleLanes.map((lane) => {
           if (lane.key === "done") return "minmax(220px, 1fr)";
-          return collapsedKeys.has(lane.key) ? "60px" : "minmax(186px, 1fr)";
+          return collapsedKeys.has(lane.key) ? "66px" : "minmax(186px, 1fr)";
         });
         if (!showDone) cols.push("56px");
         target.style.gridTemplateColumns = cols.join(" ");
@@ -7486,6 +7534,23 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
             addressedBadge + kindBadge + postedBadge +
             (meta ? '<span class="collab-meta">' + escapeHtml(meta) + '</span>' : "") +
           '</div>';
+      // Long synthesized messages were a wall of text in the live
+      // thread. Compute a short summary (first ~2 sentences, capped
+      // at 180 chars) and a "more" affordance — clicking expands the
+      // row to show the full text. expandedCollabRowKeys persists the
+      // expanded state per-session, keyed by the same composite key
+      // collabRowKey() uses for fresh-detection.
+      const rowKey = collabRowKey(message);
+      const text = String(message.text || "");
+      const summary = collapsedCollabSummary(text);
+      const isOverflow = summary !== text;
+      const expanded = isOverflow && expandedCollabRowKeys.has(rowKey);
+      const overflowAttr = isOverflow ? ' data-overflow="true"' : "";
+      const expandedAttr = expanded ? ' data-expanded="true"' : "";
+      const renderText = !isOverflow || expanded ? text : summary;
+      const moreButton = isOverflow
+        ? '<button type="button" class="collab-more" data-collab-more="' + escapeAttr(rowKey) + '" aria-expanded="' + (expanded ? "true" : "false") + '">' + (expanded ? "less ↑" : "more ↓") + '</button>'
+        : "";
       return '<article class="collab-message"' +
         ' data-speaker="' + escapeAttr(slug) + '"' +
         ' data-posted="' + posted + '"' +
@@ -7494,10 +7559,44 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         ' data-grouped="' + (grouped ? "true" : "false") + '"' +
         (isNewest ? ' data-newest="true"' : "") +
         (isFresh ? ' data-fresh="true"' : "") +
+        overflowAttr +
+        expandedAttr +
         '>' +
         byline +
-        '<div class="collab-text">' + escapeHtml(message.text || "") + '</div>' +
+        '<div class="collab-text">' + escapeHtml(renderText) + moreButton + '</div>' +
       '</article>';
+    }
+
+    // Synthesized board-state messages can run 4-6 sentences explaining
+    // the whole workflow. That made the thread feel like a wall of text
+    // on a busy board. Show only the first 1-2 sentences (max ~180
+    // chars) by default; the operator can expand inline if they need
+    // the full explanation.
+    const COLLAB_SUMMARY_MAX_CHARS = 180;
+    const COLLAB_SUMMARY_MAX_SENTENCES = 2;
+    function collapsedCollabSummary(text) {
+      const trimmed = String(text || "").trim();
+      if (!trimmed) return trimmed;
+      if (trimmed.length <= COLLAB_SUMMARY_MAX_CHARS) return trimmed;
+      // Sentence boundary = period/exclaim/question followed by space
+      // (so URLs and "1 changed file(s)" parens don't trip the split).
+      const sentences = trimmed.split(/(?<=[.!?])\s+/);
+      let out = "";
+      for (let i = 0; i < Math.min(sentences.length, COLLAB_SUMMARY_MAX_SENTENCES); i += 1) {
+        const next = (out ? out + " " : "") + sentences[i];
+        if (next.length > COLLAB_SUMMARY_MAX_CHARS) {
+          if (!out) {
+            // First sentence is already too long — hard-cap on chars.
+            out = next.slice(0, COLLAB_SUMMARY_MAX_CHARS).trimEnd() + "…";
+          }
+          break;
+        }
+        out = next;
+      }
+      if (!out) out = trimmed.slice(0, COLLAB_SUMMARY_MAX_CHARS).trimEnd() + "…";
+      // If we cut before the end, add ellipsis so the trim is obvious.
+      if (out.length < trimmed.length && !out.endsWith("…")) out += " …";
+      return out;
     }
 
     function collabMessage(speaker, text, meta, ts, addressedTo) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -529,6 +529,19 @@ describe("slack operator personal monitor", () => {
     // grid template comes from the inline style now.
     expect(html).not.toContain('.kanban-board[data-active-lanes="3"]');
     expect(html).not.toContain('target.dataset.activeLanes = String(activeLaneCount)');
+
+    // Chat collapse (PR: monitor-chat-collapse): long synthesized
+    // messages render as a 1-2 sentence summary with a "more ↓"
+    // affordance to expand. Expand state lives in
+    // expandedCollabRowKeys per session. Rail width bumped 60→66px.
+    expect(html).toContain('expandedCollabRowKeys');
+    expect(html).toContain('collapsedCollabSummary');
+    expect(html).toContain('COLLAB_SUMMARY_MAX_CHARS');
+    expect(html).toContain('data-collab-more');
+    expect(html).toContain('.collab-more');
+    expect(html).toContain('"66px"'); // rail width bump
+    // Old 60px rail width is gone.
+    expect(html).not.toContain('? "60px" : "minmax(186px, 1fr)"');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Two small follow-ups from the live screenshot.

## Chat readability — "wall of text"

Synthesized board-changed messages can run 4–6 sentences (a full workflow explanation). Three lane transitions in a row stacked into one big paragraph block that was hard to scan.

- **`collapsedCollabSummary(text)`** returns the first 1–2 sentences capped at 180 chars; falls back to a hard char-truncate when a single sentence is already too long.
- **`renderCollabMessage`** shows the summary by default and, when the full text is longer, appends an inline **"more ↓"** button right after the truncated text. Clicking it toggles the row's key in `expandedCollabRowKeys` (a per-session `Set`, same composite key as the slide-in fresh-detection) and forces a thread re-render so the row paints with the full text. Clicking "less ↑" collapses it back.
- **`.collab-more` CSS** — inline cyan-tinted link sitting at the end of the truncated text. When the row is expanded the "less ↑" moves to its own line beneath the body (looks neater than glued to the end of a long paragraph).

Before (one row):
> Update on 1 changed file(s) touch review-gated surfaces (deploy).: this moved into Operator Review. Automation has gone as far as it safely can. Here is the actual handoff: Operator owns it because hermes/Codex completed the code-level pre-check, but project intent, architecture, or rollout risk needs sign-off. Right move now: Read the operator checklist, approve locally only if the project-level risk is acceptable, otherwise send it back to Codex. The card button just opens the operator checklist. After that, approve locally or send it back to Codex with a concrete ask. I will move it once operator approves locally or Codex updates the PR so Hermes no longer asks for sign-off.

After (one row, default):
> Update on 1 changed file(s) touch review-gated surfaces (deploy).: this moved into Operator Review. Automation has gone as far as it safely can. **more ↓**

Click → full text expands inline.

## Rail width 60 → 66px

The vertical title + count pill in `WAITING / DRAFTS` and `OPERATOR REVIEW` felt cramped at 60px. Bumped to 66px in the inline grid template so the long lane titles have breathing room.

## Tests

- **173/173 vitest cases pass**.
- New positive assertions: `expandedCollabRowKeys`, `collapsedCollabSummary`, `COLLAB_SUMMARY_MAX_CHARS`, `data-collab-more`, `.collab-more` CSS, `"66px"` rail width.
- Negative assertion: old `60px` rail width is gone.

## Test plan

- [ ] Open the monitor with multiple PRs in transit (multiple board-changed messages in the chat) → each long message shows as 1–2 sentences + `more ↓`.
- [ ] Click `more ↓` → row expands to full text + `less ↑` appears on a new line beneath; click again to re-collapse.
- [ ] Glance at the rails (Waiting/Drafts, Codex Needed, Release Queue, Deploying) → the vertical title and count pill have more room; no clipping.

## Deploy

```bash
cd /srv/averray-reference-agent
git pull --rebase
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)