### PR TITLE
Hotfix: monitor board empty — TDZ on COLLAB_SUMMARY_MAX_CHARS at boot

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -7572,28 +7572,35 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     // on a busy board. Show only the first 1-2 sentences (max ~180
     // chars) by default; the operator can expand inline if they need
     // the full explanation.
-    const COLLAB_SUMMARY_MAX_CHARS = 180;
-    const COLLAB_SUMMARY_MAX_SENTENCES = 2;
+    //
+    // The cap constants are INSIDE the function body (not module-level
+    // const) on purpose. The script body calls setComposeMode() at
+    // boot, which transitively reaches this function — module-level
+    // const declarations below that call hit a TDZ ReferenceError
+    // because they haven't been evaluated yet. Function declarations
+    // are hoisted but const isn't.
     function collapsedCollabSummary(text) {
+      const MAX_CHARS = 180;
+      const MAX_SENTENCES = 2;
       const trimmed = String(text || "").trim();
       if (!trimmed) return trimmed;
-      if (trimmed.length <= COLLAB_SUMMARY_MAX_CHARS) return trimmed;
+      if (trimmed.length <= MAX_CHARS) return trimmed;
       // Sentence boundary = period/exclaim/question followed by space
       // (so URLs and "1 changed file(s)" parens don't trip the split).
       const sentences = trimmed.split(/(?<=[.!?])\s+/);
       let out = "";
-      for (let i = 0; i < Math.min(sentences.length, COLLAB_SUMMARY_MAX_SENTENCES); i += 1) {
+      for (let i = 0; i < Math.min(sentences.length, MAX_SENTENCES); i += 1) {
         const next = (out ? out + " " : "") + sentences[i];
-        if (next.length > COLLAB_SUMMARY_MAX_CHARS) {
+        if (next.length > MAX_CHARS) {
           if (!out) {
             // First sentence is already too long — hard-cap on chars.
-            out = next.slice(0, COLLAB_SUMMARY_MAX_CHARS).trimEnd() + "…";
+            out = next.slice(0, MAX_CHARS).trimEnd() + "…";
           }
           break;
         }
         out = next;
       }
-      if (!out) out = trimmed.slice(0, COLLAB_SUMMARY_MAX_CHARS).trimEnd() + "…";
+      if (!out) out = trimmed.slice(0, MAX_CHARS).trimEnd() + "…";
       // If we cut before the end, add ellipsis so the trim is obvious.
       if (out.length < trimmed.length && !out.endsWith("…")) out += " …";
       return out;

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -1,4 +1,4 @@
-import { Script } from "node:vm";
+import vm, { Script } from "node:vm";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -536,12 +536,17 @@ describe("slack operator personal monitor", () => {
     // expandedCollabRowKeys per session. Rail width bumped 60→66px.
     expect(html).toContain('expandedCollabRowKeys');
     expect(html).toContain('collapsedCollabSummary');
-    expect(html).toContain('COLLAB_SUMMARY_MAX_CHARS');
     expect(html).toContain('data-collab-more');
     expect(html).toContain('.collab-more');
     expect(html).toContain('"66px"'); // rail width bump
     // Old 60px rail width is gone.
     expect(html).not.toContain('? "60px" : "minmax(186px, 1fr)"');
+    // The summary cap constants used to live at module scope but that
+    // hit a TDZ ReferenceError because setComposeMode() runs at boot
+    // before the declarations were reached. Guard against the
+    // regression: the constant names must NOT appear at script level.
+    expect(html).not.toContain('const COLLAB_SUMMARY_MAX_CHARS');
+    expect(html).not.toContain('const COLLAB_SUMMARY_MAX_SENTENCES');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {
@@ -563,5 +568,85 @@ describe("slack operator personal monitor", () => {
     const script = html.split("<script>")[1]?.split("</script>")[0] ?? "";
     expect(script).toContain("function render(payload)");
     expect(() => new Script(script, { filename: "monitor-inline.js" })).not.toThrow();
+  });
+
+  it("inline browser JavaScript boots without throwing (catches TDZ)", () => {
+    // Run the inline <script> in a Node vm context with a catchall
+    // stub for all the browser globals it touches. We only care that
+    // the top-level evaluation doesn't throw — i.e. no TDZ, no
+    // undefined-reference, no syntax-tripping order-of-declaration
+    // bug. We don't assert any rendered output; that would require
+    // a real DOM. This guards against bugs like the COLLAB_SUMMARY_
+    // MAX_CHARS TDZ that took the monitor down in production.
+    const html = renderMonitorHtml();
+    const script = html.split("<script>")[1]?.split("</script>")[0] ?? "";
+    const makeStub = () => {
+      // Function-typed Proxy: callable (event handlers etc.),
+      // constructable (new AudioContext()), every property access
+      // resolves to another stub, every assignment is silently
+      // accepted. Surfaces TDZ + undefined-reference errors at boot
+      // without a real DOM.
+      const fn = function () {};
+      return new Proxy(fn, {
+        get(_target, prop) {
+          if (prop === "then") return undefined; // not a thenable
+          if (prop === Symbol.toPrimitive) return () => "";
+          if (prop === "length") return 0;
+          return makeStub();
+        },
+        set: () => true,
+        apply: () => makeStub(),
+        construct: () => makeStub(),
+        has: () => true,
+      });
+    };
+    const context = vm.createContext({
+      document: makeStub(),
+      window: makeStub(),
+      localStorage: makeStub(),
+      location: { search: "" },
+      navigator: { clipboard: makeStub() },
+      fetch: makeStub(),
+      EventSource: function () { return makeStub(); },
+      AudioContext: function () { return makeStub(); },
+      Notification: function () {},
+      MutationObserver: function () { return makeStub(); },
+      IntersectionObserver: function () { return makeStub(); },
+      ResizeObserver: function () { return makeStub(); },
+      AbortController: function () { return makeStub(); },
+      AbortSignal: makeStub(),
+      URL,
+      TextEncoder,
+      TextDecoder,
+      atob: (s: string) => Buffer.from(s, "base64").toString(),
+      btoa: (s: string) => Buffer.from(s).toString("base64"),
+      performance: { now: () => 0 },
+      URLSearchParams,
+      setTimeout: () => 0,
+      clearTimeout: () => {},
+      setInterval: () => 0,
+      clearInterval: () => {},
+      requestAnimationFrame: () => 0,
+      console,
+      Date,
+      Math,
+      Number,
+      String,
+      Boolean,
+      Array,
+      Object,
+      JSON,
+      Set,
+      Map,
+      WeakSet,
+      WeakMap,
+      Symbol,
+      Error,
+      RegExp,
+      Promise,
+      Proxy,
+      Reflect,
+    });
+    expect(() => vm.runInContext(script, context, { timeout: 2000 })).not.toThrow();
   });
 });


### PR DESCRIPTION
**Urgent — the monitor board is empty in production.**

## What broke

PR #173 introduced two module-level `const` declarations (`COLLAB_SUMMARY_MAX_CHARS` / `COLLAB_SUMMARY_MAX_SENTENCES`) above `collapsedCollabSummary` but **below** the script's boot path. The script calls `setComposeMode(composeMode)` early in the body, which transitively reaches `collapsedCollabSummary` through:

```
setComposeMode → forceThreadMode + renderAutoCollaborationThread
              → renderCollaborationThread
              → renderCollaborationShell
              → renderCollabMessage
              → collapsedCollabSummary
              → reads COLLAB_SUMMARY_MAX_CHARS  ← still in TDZ
```

Function declarations are hoisted; `const` is not. Browser console:
```
Uncaught ReferenceError: Cannot access 'COLLAB_SUMMARY_MAX_CHARS' before initialization
    at collapsedCollabSummary (monitor:7461:29)
```

Board doesn't render at all.

## Fix

Move both cap constants **inside** `collapsedCollabSummary` as local `const`s. No TDZ — they're declared when the function body runs, not at script parse time.

## Regression guard

The existing inline-JS smoke only **parsed** the script (`new Script(script)`) — that's why this TDZ bug slipped through. New test "inline browser JavaScript boots without throwing (catches TDZ)" uses `vm.runInContext` with a catchall Proxy-based stub for the browser globals the script touches (`document`, `window`, `localStorage`, `fetch`, `EventSource`, `AudioContext`, `MutationObserver`, `AbortController`, …). It only checks the top-level evaluation doesn't throw — doesn't assert any rendered output. **It would have failed on the original bug.**

## Tests

- **174/174 vitest cases pass** (was 173 + the new boot smoke).
- Same 6 pre-existing `@avg/schemas` / `@avg/mcp-common` file-level failures on main, unchanged.

## Deploy

Same target. Once merged:

```bash
cd /srv/averray-reference-agent
git pull --rebase
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)