### PR TITLE
Dim zero filter pills + tier stale-badge color by age

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -1145,10 +1145,19 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       border-radius: 7px;
       font-size: 0.78rem;
       background: var(--surface-soft);
+      transition: opacity 140ms ease, border-color 140ms ease;
     }
     .toggle-pill[aria-pressed="true"] {
       border-color: var(--accent);
       background: var(--accent-bg);
+    }
+    /* Mirror the top-strip counter-chip dim treatment (#157): filter
+       pills with count=0 fade so the eye lands on the ones that
+       actually have work. Only applies when the pill ISN'T the
+       currently selected filter — losing visual weight on a pressed
+       pill would hide the active state. */
+    .toggle-pill[data-empty="true"]:not([aria-pressed="true"]) {
+      opacity: 0.42;
     }
     .board-shell {
       min-height: 0;
@@ -2758,6 +2767,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
     .stale-dot[data-stale="waiting"] { background: var(--warn); box-shadow: 0 0 0 2px rgba(217, 173, 66, 0.22); }
     .stale-dot[data-stale="stale"]   { background: var(--bad);  box-shadow: 0 0 0 2px rgba(238, 98, 96, 0.24); animation: pulse 1.6s ease-out infinite; }
+    /* Stale-tier escalation: a 2-hour stuck PR is yellow, a half-day
+       stuck PR is orange, a day-plus stuck PR is bold red. Heavier
+       font-weight on higher tiers as a color-blind-friendly fallback. */
+    .stale-dot[data-stale-tier="warn"]     { background: var(--warn);      box-shadow: 0 0 0 2px rgba(217, 173, 66, 0.24); animation: none; }
+    .stale-dot[data-stale-tier="high"]     { background: #f59c47;          box-shadow: 0 0 0 2px rgba(245, 156, 71, 0.30); animation: pulse 2.2s ease-out infinite; }
+    .stale-dot[data-stale-tier="critical"] { background: var(--bad);       box-shadow: 0 0 0 2px rgba(238, 98, 96, 0.40); animation: pulse 1.3s ease-out infinite; }
     .card-age {
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       font-size: 0.7rem;
@@ -2768,6 +2783,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
     .card-head .stale-dot[data-stale="stale"] ~ .card-age { color: var(--bad); }
     .card-head .stale-dot[data-stale="waiting"] ~ .card-age { color: var(--warn); }
+    /* Stale-tier wins over the broader data-stale rules so the age
+       text matches its dot. Higher tiers get a heavier weight. */
+    .kc-head-r[data-stale-tier="warn"]     .card-age { color: var(--warn);  font-weight: 600; }
+    .kc-head-r[data-stale-tier="high"]     .card-age { color: #f59c47;      font-weight: 700; }
+    .kc-head-r[data-stale-tier="critical"] .card-age { color: var(--bad);   font-weight: 800; letter-spacing: 0.06em; }
     .kc-id {
       display: flex;
       align-items: baseline;
@@ -5561,8 +5581,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
             (codexState ? '<span class="work-state" data-state="' + escapeAttr(codexState.state) + '">' + escapeHtml(codexState.label) + '</span>' : "") +
             (activeAgent ? '<span class="active-agent" data-agent="' + escapeAttr(activeAgent.id) + '"><span class="aa-dot"></span>' + escapeHtml(activeAgent.label) + '</span>' : "") +
           '</div>' +
-          '<div class="kc-head-r">' +
-            '<span class="stale-dot" data-stale="' + escapeAttr(staleState) + '" title="' + escapeAttr(staleState) + '"></span>' +
+          '<div class="kc-head-r" data-stale-tier="' + escapeAttr(age.staleTier || "") + '">' +
+            '<span class="stale-dot" data-stale="' + escapeAttr(staleState) + '" data-stale-tier="' + escapeAttr(age.staleTier || "") + '" title="' + escapeAttr(staleState + (age.staleTier ? " · " + age.staleTier : "")) + '"></span>' +
             '<span class="card-age">' + escapeHtml(age.label + " " + age.duration) + '</span>' +
           '</div>' +
         '</div>' +
@@ -8599,15 +8619,33 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function renderPipelineBoard(entries) {
       const counts = commandBoardLaneCounts(entries);
-      setText("board-all", String(entries.length - (counts.done || 0)));
-      setText("board-block", String(counts.attention || 0));
-      setText("board-review", String(counts.operator || 0));
-      setText("board-ready", String(counts.queue || 0));
-      setText("board-running", String((counts.hermes || 0) + (counts.deploy || 0)));
-      setText("done-count", String(counts.done || 0));
+      // Same setText path as before, plus mirror the data-empty toggle
+      // we already use for the top-strip counter chips (#157) so the
+      // bottom filter pills dim when their count is 0. Reduces visual
+      // noise — operator's eye lands on the pills that actually have
+      // work behind them.
+      setFilterPillCount("board-all", entries.length - (counts.done || 0));
+      setFilterPillCount("board-block", counts.attention || 0);
+      setFilterPillCount("board-review", counts.operator || 0);
+      setFilterPillCount("board-ready", counts.queue || 0);
+      setFilterPillCount("board-running", (counts.hermes || 0) + (counts.deploy || 0));
+      setFilterPillCount("done-count", counts.done || 0);
       renderOwnerSummary(entries);
       renderStalenessSummary(entries);
       updatePipelineFilterButtons();
+    }
+
+    // Set a filter pill's inner count span AND toggle data-empty on
+    // the outer button so CSS can dim 0-count filters. Mirrors
+    // setCounterChip for the top-strip chips.
+    function setFilterPillCount(spanId, value) {
+      const span = document.getElementById(spanId);
+      if (!span) return;
+      const num = Number(value);
+      const safe = Number.isFinite(num) ? Math.max(0, Math.floor(num)) : 0;
+      span.textContent = String(safe);
+      const pill = span.closest(".toggle-pill");
+      if (pill) pill.setAttribute("data-empty", safe > 0 ? "false" : "true");
     }
 
     function renderStalenessSummary(entries) {
@@ -9294,11 +9332,19 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function handoffAge(item) {
       const updated = Date.parse(String(item.updatedAt || ""));
-      if (!Number.isFinite(updated)) return { state: "waiting", label: "Waiting", duration: "unknown age" };
+      if (!Number.isFinite(updated)) return { state: "waiting", label: "Waiting", duration: "unknown age", staleTier: "" };
       const minutes = Math.max(0, Math.floor((Date.now() - updated) / 60000));
       const state = minutes >= 120 ? "stale" : minutes >= 30 ? "waiting" : "fresh";
       const label = state === "stale" ? "Stale" : state === "waiting" ? "Waiting" : "Fresh";
-      return { state, label, duration: formatDuration(minutes) };
+      // Sub-tier so a 1-day-old stuck PR signals louder than a freshly-
+      // stale 2-hour-old one. Empty string when the item isn't stale.
+      //   warn:     2h  ≤ age < 12h  (default stale yellow/red)
+      //   high:    12h  ≤ age < 24h  (orange, bolder)
+      //   critical: 24h ≤ age        (red, bold, faster pulse)
+      const staleTier = state === "stale"
+        ? (minutes >= 1440 ? "critical" : minutes >= 720 ? "high" : "warn")
+        : "";
+      return { state, label, duration: formatDuration(minutes), staleTier };
     }
 
     function formatDuration(minutes) {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -547,6 +547,21 @@ describe("slack operator personal monitor", () => {
     // regression: the constant names must NOT appear at script level.
     expect(html).not.toContain('const COLLAB_SUMMARY_MAX_CHARS');
     expect(html).not.toContain('const COLLAB_SUMMARY_MAX_SENTENCES');
+
+    // Filter pills + stale tiers (PR: monitor-polish-filters-stale):
+    // bottom filter pills dim when their count is 0 (same idiom as
+    // the top-strip counter chips); stale badges escalate yellow →
+    // orange → red as the age grows past 12h / 24h.
+    expect(html).toContain('setFilterPillCount');
+    expect(html).toContain('pill.setAttribute("data-empty"');
+    expect(html).toContain('.toggle-pill[data-empty="true"]:not([aria-pressed="true"])');
+    expect(html).toContain('staleTier');
+    expect(html).toContain('data-stale-tier="warn"');
+    expect(html).toContain('data-stale-tier="high"');
+    expect(html).toContain('data-stale-tier="critical"');
+    // The thresholds: 12h (720m) → high, 24h (1440m) → critical.
+    expect(html).toContain('minutes >= 1440');
+    expect(html).toContain('minutes >= 720');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Two small polish items chosen from the leftover list.

## 1. Dim zero filter pills

The bottom filter pills (`all 1`, `blocked 1`, `review 0`, `ready 0`, `running 0`, `done lane 18`) didn't dim their zero-count variants, even though the top-strip counter chips did (#157). All pills looked the same weight regardless of whether anything was behind them. Now mirrors the counter-chip treatment:

- New `setFilterPillCount(spanId, value)` helper sets the inner count AND toggles `data-empty` on the outer `.toggle-pill`. The `setText("board-*")` calls in `renderPipelineBoard` switch over to it.
- CSS rule fades `data-empty="true"` pills to 0.42 opacity, scoped with `:not([aria-pressed="true"])` so the active filter never dims even if its count happens to be 0.

## 2. Tier stale-badge color by age

Stale-badge color was binary: ≤30m fresh, ≤2h waiting, ≥2h stale. So a 2-hour-old stuck PR and a 24-hour-old stuck PR looked the same red. Now tiered:

| Age | Tier | Color | Treatment |
|---|---|---|---|
| `2h ≤ age < 12h` | `warn` | yellow | font-weight 600, no pulse |
| `12h ≤ age < 24h` | `high` | orange | font-weight 700, slow pulse |
| `24h ≤ age` | `critical` | red | font-weight 800, tracked letters, fast pulse |

- `handoffAge()` returns a new `staleTier` field
- `renderBoardCard` emits `data-stale-tier` on the `.kc-head-r` container AND the `.stale-dot`
- CSS picks per-tier color + box-shadow + animation speed
- Heavier font-weight on higher tiers as a color-blind-friendly fallback

## Tests

- **174/174 vitest cases pass** (boot smoke + parse + render still green).
- New positive assertions for `setFilterPillCount`, the dim CSS rule, `staleTier` wire, all three `data-stale-tier` values (`warn`/`high`/`critical`), and the 720m/1440m thresholds.

## Test plan

- [ ] Glance at the filter row → `review 0` / `ready 0` / `running 0` look faded; `all 1` / `blocked 1` / `done lane 18` stay full strength.
- [ ] Click `review 0` → it un-dims because it becomes the pressed filter; clicking back to `all` re-dims it.
- [ ] PR stuck >24h (like the screenshot's `STALE 24H 55M`) → dot and age text render bold red with a faster pulse.
- [ ] Mid-stale PR (12-24h) → orange + bolder than yellow.

## Deploy

Same target:

```bash
cd /srv/averray-reference-agent && git pull --rebase && \
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner && \
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)