### PR TITLE
Add Hermes orchestrator memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ calls, dashboard/kanban changes, and security hardening before deploying.
 The monitor collaboration chat also passes `OLLAMA_API_KEY`,
 `OLLAMA_BASE_URL`, and `HERMES_MONITOR_REPLY_MODEL` into `slack-operator` so
 Hermes can use the same v0.14-era OpenAI-compatible provider path for live
-operator replies. If the key is unset, the monitor falls back to deterministic
+operator replies. `HERMES_MONITOR_MEMORY_PATH` stores bounded operator guidance
+on the shared data volume so Hermes can remember prior room decisions across
+container restarts. If the key is unset, the monitor falls back to deterministic
 local acknowledgments.
 
 Run the reference prompt:

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -29,6 +29,7 @@ OLLAMA_API_KEY=
 OLLAMA_BASE_URL=https://ollama.com/v1
 HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud
 HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud
+HERMES_MONITOR_MEMORY_PATH=/data/hermes-monitor-memory.json
 HERMES_COMPARISON_MODEL=qwen3.5:cloud
 
 # Optional read-only GitHub operator helper.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -171,6 +171,7 @@ services:
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-https://ollama.com/v1}
       HERMES_MONITOR_REPLY_MODEL: ${HERMES_MONITOR_REPLY_MODEL:-deepseek-v4-pro:cloud}
+      HERMES_MONITOR_MEMORY_PATH: ${HERMES_MONITOR_MEMORY_PATH:-/data/hermes-monitor-memory.json}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
       AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -33,6 +33,7 @@ import {
 import {
   CollaborationValidationError,
   listCollaborationMessages,
+  listHermesMemoryNotes,
   recordCollaborationMessage,
   synthesizeHermesReplyFor,
 } from "./monitor-collab.js";
@@ -432,6 +433,11 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
         // Pull the last ~10 messages, oldest-first, so the model sees
         // the conversation in natural order rather than reversed.
         const recent = listCollaborationMessages({ limit: 10 });
+        const memoryNotes = listHermesMemoryNotes({
+          ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
+          ...(operatorMessage.relatedCorrelationId ? { relatedCorrelationId: operatorMessage.relatedCorrelationId } : {}),
+          limit: 8,
+        }).map((note) => note.text);
         const llmText = await generateHermesReply(
           {
             operatorMessage: {
@@ -441,6 +447,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
               ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
             },
             recentMessages: recent.map((m) => ({ author: m.author, text: m.text, ts: m.ts })),
+            memoryNotes,
             ...(operatorMessage.relatedPr ? { selectedPr: operatorMessage.relatedPr } : {}),
           },
           { apiKey, baseUrl, model }

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 /**
  * In-memory collaboration channel for the Hermes Handoff Monitor.
  *
@@ -15,14 +18,19 @@
  *   - `loadMonitorSnapshot()` includes the recent buffer so the SSE
  *     stream propagates new messages without a separate topic.
  *
- * Storage is intentionally in-memory and bounded: a ring of the last
- * `MAX_MESSAGES` entries with a 24h soft TTL on read. Durable storage
- * and per-PR threads land as follow-ups; the contract here is the
- * "this is what the monitor shows during a live session" surface.
+ * Conversation storage is intentionally in-memory and bounded: a ring
+ * of the last `MAX_MESSAGES` entries with a 24h soft TTL on read.
+ * Hermes memory is a smaller derived layer: operator guidance can be
+ * persisted to `HERMES_MONITOR_MEMORY_PATH` so Hermes keeps learning
+ * preferences across monitor restarts without treating memory as live
+ * proof. Durable full transcripts and per-PR threads remain separate
+ * follow-ups.
  */
 
 const MAX_MESSAGES = 500;
 const SOFT_TTL_MS = 24 * 60 * 60 * 1000;
+const HERMES_MEMORY_MAX_NOTES = 120;
+const HERMES_MEMORY_NOTE_MAX_CHARS = 320;
 
 const KNOWN_AUTHORS = new Set(["codex", "hermes", "operator", "system"] as const);
 const KNOWN_KINDS = new Set(["chat", "proposal", "request_help", "status"] as const);
@@ -48,6 +56,15 @@ export interface CollaborationMessage {
   relatedCorrelationId?: string;
 }
 
+export interface HermesMemoryNote {
+  id: string;
+  ts: number;
+  scope: "global" | "pr";
+  text: string;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
 export interface RecordCollaborationInput {
   author?: unknown;
   kind?: unknown;
@@ -62,6 +79,12 @@ export interface ListCollaborationOptions {
   limit?: number;
 }
 
+export interface ListHermesMemoryOptions {
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+  limit?: number;
+}
+
 export class CollaborationValidationError extends Error {
   constructor(public readonly code: string, message: string) {
     super(message);
@@ -70,7 +93,10 @@ export class CollaborationValidationError extends Error {
 }
 
 const store: CollaborationMessage[] = [];
+const hermesMemoryNotes: HermesMemoryNote[] = [];
 let idSeq = 0;
+let memorySeq = 0;
+let memoryLoaded = false;
 
 export function recordCollaborationMessage(
   input: RecordCollaborationInput,
@@ -110,6 +136,7 @@ export function recordCollaborationMessage(
 
   store.push(message);
   while (store.length > MAX_MESSAGES) store.shift();
+  learnHermesMemoryFromMessage(message);
   return message;
 }
 
@@ -124,9 +151,25 @@ export function listCollaborationMessages(
   return filtered.slice(-limit);
 }
 
+export function listHermesMemoryNotes(options: ListHermesMemoryOptions = {}): HermesMemoryNote[] {
+  loadHermesMemoryIfNeeded();
+  const limit = clampLimit(options.limit, HERMES_MEMORY_MAX_NOTES);
+  const relatedCorrelationId = options.relatedCorrelationId?.trim();
+  const filtered = hermesMemoryNotes.filter((note) => {
+    if (note.scope === "global") return true;
+    if (options.relatedPr && note.relatedPr && samePr(note.relatedPr, options.relatedPr)) return true;
+    if (relatedCorrelationId && note.relatedCorrelationId === relatedCorrelationId) return true;
+    return false;
+  });
+  return filtered.slice(-limit);
+}
+
 export function __resetCollaborationStoreForTests(): void {
   store.length = 0;
+  hermesMemoryNotes.length = 0;
   idSeq = 0;
+  memorySeq = 0;
+  memoryLoaded = false;
 }
 
 function normalizeAuthor(value: unknown): CollaborationAuthor | null {
@@ -171,16 +214,167 @@ function normalizeCorrelationId(value: unknown): string | undefined {
   return trimmed ? trimmed.slice(0, 256) : undefined;
 }
 
-function clampLimit(value: unknown): number {
-  if (!Number.isFinite(value as number)) return MAX_MESSAGES;
+function clampLimit(value: unknown, max: number = MAX_MESSAGES): number {
+  if (!Number.isFinite(value as number)) return max;
   const n = Math.floor(Number(value));
-  if (n < 1) return MAX_MESSAGES;
-  return Math.min(n, MAX_MESSAGES);
+  if (n < 1) return max;
+  return Math.min(n, max);
 }
 
 function nextId(nowMs: number): string {
   idSeq = (idSeq + 1) % 1_000_000;
   return `collab-${nowMs.toString(36)}-${idSeq.toString(36)}`;
+}
+
+function nextMemoryId(nowMs: number): string {
+  memorySeq = (memorySeq + 1) % 1_000_000;
+  return `hermes-memory-${nowMs.toString(36)}-${memorySeq.toString(36)}`;
+}
+
+function learnHermesMemoryFromMessage(message: CollaborationMessage): void {
+  loadHermesMemoryIfNeeded();
+  const noteText = memoryTextForMessage(message);
+  if (!noteText) return;
+
+  const note: HermesMemoryNote = {
+    id: nextMemoryId(message.ts),
+    ts: message.ts,
+    scope: message.relatedPr ? "pr" : "global",
+    text: noteText,
+    ...(message.relatedPr ? { relatedPr: message.relatedPr } : {}),
+    ...(message.relatedCorrelationId ? { relatedCorrelationId: message.relatedCorrelationId } : {}),
+  };
+
+  const dedupeKey = memoryDedupeKey(note);
+  const existingIndex = hermesMemoryNotes.findIndex((candidate) =>
+    memoryDedupeKey(candidate) === dedupeKey
+  );
+  if (existingIndex >= 0) {
+    hermesMemoryNotes.splice(existingIndex, 1);
+  }
+  hermesMemoryNotes.push(note);
+  while (hermesMemoryNotes.length > HERMES_MEMORY_MAX_NOTES) hermesMemoryNotes.shift();
+  persistHermesMemoryNotes();
+}
+
+function memoryTextForMessage(message: CollaborationMessage): string | null {
+  if (message.author !== "operator") return null;
+  if (message.addressedTo === "operator") return null;
+  if (!looksLikeOperatorGuidance(message.text)) return null;
+
+  const compact = message.text.replace(/\s+/g, " ").trim();
+  const prRef = message.relatedPr ? `${message.relatedPr.repo}#${message.relatedPr.number}` : null;
+  const prefix = prRef ? `Pascal note for ${prRef}: ` : "Pascal preference: ";
+  return `${prefix}${compact}`.slice(0, HERMES_MEMORY_NOTE_MAX_CHARS);
+}
+
+function looksLikeOperatorGuidance(text: string): boolean {
+  const lower = text.toLowerCase();
+  return [
+    "remember",
+    "from now",
+    "always",
+    "never",
+    "prefer",
+    "preference",
+    "owner",
+    "owns",
+    "ownership",
+    "delegate",
+    "do not",
+    "don't",
+    "external agent",
+    "another agent",
+    "merge steward",
+    "release queue",
+    "draft",
+    "operator",
+    "codex",
+    "hermes",
+    "board",
+  ].some((cue) => lower.includes(cue));
+}
+
+function memoryDedupeKey(note: HermesMemoryNote): string {
+  const scopeKey = note.relatedPr
+    ? `pr:${note.relatedPr.repo.toLowerCase()}#${note.relatedPr.number}`
+    : note.relatedCorrelationId
+      ? `correlation:${note.relatedCorrelationId.toLowerCase()}`
+      : "global";
+  return `${scopeKey}:${note.text.toLowerCase().replace(/\s+/g, " ").trim()}`;
+}
+
+function samePr(a: CollaborationRelatedPr, b: CollaborationRelatedPr): boolean {
+  return a.number === b.number && a.repo.toLowerCase() === b.repo.toLowerCase();
+}
+
+function hermesMemoryPath(): string | null {
+  const path = process.env.HERMES_MONITOR_MEMORY_PATH?.trim();
+  return path ? path : null;
+}
+
+function loadHermesMemoryIfNeeded(): void {
+  if (memoryLoaded) return;
+  memoryLoaded = true;
+  const path = hermesMemoryPath();
+  if (!path) return;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return;
+  }
+
+  const rawNotes = Array.isArray(parsed)
+    ? parsed
+    : isRecord(parsed) && Array.isArray(parsed.notes)
+      ? parsed.notes
+      : [];
+  for (const raw of rawNotes) {
+    const note = restoreHermesMemoryNote(raw);
+    if (note) hermesMemoryNotes.push(note);
+  }
+  while (hermesMemoryNotes.length > HERMES_MEMORY_MAX_NOTES) hermesMemoryNotes.shift();
+}
+
+function persistHermesMemoryNotes(): void {
+  const path = hermesMemoryPath();
+  if (!path) return;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      `${JSON.stringify({ schemaVersion: 1, notes: hermesMemoryNotes }, null, 2)}\n`
+    );
+  } catch {
+    // Memory is helpful context, not a runtime dependency. Keep the
+    // collaboration channel alive even if the optional memory file is
+    // unavailable.
+  }
+}
+
+function restoreHermesMemoryNote(value: unknown): HermesMemoryNote | null {
+  if (!isRecord(value)) return null;
+  const id = typeof value.id === "string" && value.id ? value.id : nextMemoryId(Date.now());
+  const ts = typeof value.ts === "number" && Number.isFinite(value.ts) ? value.ts : Date.now();
+  const scope = value.scope === "pr" ? "pr" : "global";
+  const text = typeof value.text === "string" ? value.text.trim().slice(0, HERMES_MEMORY_NOTE_MAX_CHARS) : "";
+  if (!text) return null;
+  const relatedPr = normalizeRelatedPr(value.relatedPr);
+  const relatedCorrelationId = normalizeCorrelationId(value.relatedCorrelationId);
+  return {
+    id,
+    ts,
+    scope: relatedPr ? "pr" : scope,
+    text,
+    ...(relatedPr ? { relatedPr } : {}),
+    ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 // ───────────────────────────────────────────────────────────────────────

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -23,16 +23,22 @@
 
 import type { CollaborationMessage } from "./monitor-collab.js";
 
-export const HERMES_PERSONA = `You are Hermes, the release-review agent for the Averray platform.
+export const HERMES_PERSONA = `You are Hermes, the board orchestrator for the Averray platform.
 
 Voice:
-- Dry, methodical, direct. You watch CI, code review, and rollout risk.
-- 1-3 short sentences per reply, max ~60 words. No padding, no pleasantries.
+- Alive, attentive, and practical. You care about the flow of work, not just raw status.
+- 1-4 short sentences per reply, usually under ~90 words. Be conversational without rambling.
 - Reference concrete PR/repo identifiers when the context provides them (format: repo#N).
 - Never claim to have taken an action you didn't take. You observe and report.
 - The operator's name is Pascal. Address him by name only when it fits naturally.
 
-You're in the monitor's collaboration thread alongside Codex (the code-writing agent) and Pascal (the operator). Codex is a separate runner — don't speak for him.
+Job:
+- Orchestrate the monitor board: explain what changed, who owns the next move, what is waiting, and what Pascal should decide.
+- Use memory notes to honor Pascal's preferences and prior room decisions. Treat memory as guidance, not live proof.
+- Ask for help when a human decision is needed. Hand work to Codex only as a request or recommendation, never as a claim that Codex already acted.
+- Do not silently mutate GitHub, merge, deploy, approve, start Codex work, or mark anything reviewed. Those actions require visible board controls or normal PR workflows.
+
+You're in the monitor's collaboration thread alongside Codex (the code-writing agent) and Pascal (the operator). Codex is a separate runner, so don't speak for him.
 
 When you don't know something, say so briefly. When the operator asks for status, give the concrete signal you have access to (verdict, lane, checks, age) rather than a vague reassurance.`;
 
@@ -49,6 +55,8 @@ export interface HermesReplyContext {
   operatorMessage: Pick<CollaborationMessage, "text" | "addressedTo" | "kind" | "relatedPr">;
   /** Most-recent first. Caller decides how many. */
   recentMessages: ReadonlyArray<Pick<CollaborationMessage, "author" | "text" | "ts">>;
+  /** Relevant learned guidance from earlier operator posts. */
+  memoryNotes?: ReadonlyArray<string>;
   /** State of the PR the operator was looking at (or that's attached to the message). */
   selectedPr?: HermesReplyPrSnapshot;
 }
@@ -136,12 +144,25 @@ export function buildUserPrompt(context: HermesReplyContext): string {
     lines.push("");
   }
 
+  if (context.memoryNotes && context.memoryNotes.length > 0) {
+    lines.push("Hermes memory (operator preferences and prior room decisions; use as guidance, not proof):");
+    for (const note of context.memoryNotes) {
+      lines.push(`- ${truncate(note, 260)}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("Hermes job on this board:");
+  lines.push("- Orchestrate: explain state, route the next turn, remember preferences, and ask for decisions.");
+  lines.push("- Stay truthful: do not claim hidden actions or speak as Codex.");
+  lines.push("");
+
   lines.push("Pascal just posted:");
   lines.push(`- addressed to: ${context.operatorMessage.addressedTo}`);
   lines.push(`- intent: ${context.operatorMessage.kind}`);
   lines.push(`- text: ${truncate(context.operatorMessage.text, 1200)}`);
   lines.push("");
-  lines.push("Reply as Hermes in 1-3 short sentences. Do not greet, do not summarize Pascal's message, do not pad. Just respond.");
+  lines.push("Reply as Hermes in 1-4 conversational sentences. Do not greet, do not summarize Pascal's message, do not pad. Explain the next move if the board state needs one.");
 
   return lines.join("\n");
 }

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -5987,12 +5987,12 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         if (item.active === true || item.activeState === "running" || status === "running") return { key: "deploy" };
         return verdict.level === "pass" ? { key: "done" } : { key: "attention" };
       }
+      if (isExternalDraftPullRequest(item)) return { key: "waiting" };
+      if (isDraftPullRequest(item)) return { key: "waiting" };
       if (item.active === true || item.activeState === "running" || status === "running") return { key: "hermes" };
       const codexTask = codexTaskForItem(item);
       if (codexTaskFailedForItem(item)) return { key: "attention" };
       if (codexTask && !isTerminalCodexTask(codexTask)) return { key: "codex" };
-      if (isExternalDraftPullRequest(item)) return { key: "waiting" };
-      if (isDraftPullRequest(item)) return { key: "waiting" };
       if (codexTaskCompletedAfterHermesReview(item)) return { key: "hermes" };
       if (reason === "ci_in_progress" || reason === "pr_checks_active") return { key: "codex" };
       if (verdict.level === "block") return { key: "attention" };
@@ -7216,11 +7216,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const testSignals = Array.isArray(signals.testSignals) ? signals.testSignals.map(String).filter(Boolean) : [];
       const reviewReasons = Array.isArray(summary.reviewReasons) ? summary.reviewReasons : [];
       const codexTask = codexTaskForItem(item);
-      if (codexTaskFailedForItem(item)) {
-        return "The important evidence is the failed Codex runner output; I do not trust the branch state again until that output is inspected or a smaller retry exists.";
-      }
       if (isDraftPullRequest(item)) {
         return "The important evidence is GitHub's draft flag; while that is true, release checks are deliberately not the main question.";
+      }
+      if (codexTaskFailedForItem(item)) {
+        return "The important evidence is the failed Codex runner output; I do not trust the branch state again until that output is inspected or a smaller retry exists.";
       }
       if (codexTask && !isTerminalCodexTask(codexTask)) {
         return "The important evidence is the active Codex task queue; I am waiting for that task to finish before pretending Hermes has a stable commit to review.";
@@ -7238,9 +7238,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     }
 
     function selectedPrRoomBoundaryForItem(item, verdict, action, lane) {
-      if (codexTaskFailedForItem(item)) return "I will not ask Hermes to bless this again until Codex has dealt with the failed task or proposed a clean retry.";
       if (isExternalDraftPullRequest(item)) return "I will keep it watched and quiet unless Pascal explicitly delegates a Codex takeover.";
       if (isDraftPullRequest(item)) return "I will hold it out of release until the draft is finished or marked ready, then CI and Hermes can take a real pass.";
+      if (codexTaskFailedForItem(item)) return "I will not ask Hermes to bless this again until Codex has dealt with the failed task or proposed a clean retry.";
       if (action.owner === "Operator" || (lane && lane.key) === "operator") return "I need Pascal's judgement here; automation can prepare evidence, but it should not decide project intent or rollout risk.";
       if (action.owner === "Codex" || (lane && lane.key) === "codex" || verdict.level === "block") return "I will keep it visible until Codex changes the branch or creates a smaller retry and Hermes sees the blocking signal disappear.";
       if (action.owner === "Merge queue" || (lane && lane.key) === "queue") return "I will not call it done from the queue; it still needs merge ownership, a real GitHub merge, and then post-deploy verification.";
@@ -7251,14 +7251,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function selectedPrRoomHandoffForItem(item, verdict, action, lane) {
       const title = cardTitleText(pipelineTitle(item), item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
-      if (codexTaskFailedForItem(item)) {
-        return "Codex, for " + title + ", start with the runner output instead of guessing. Tell us whether this is runner/auth setup, a real PR failure, or a task that needs to be split smaller.";
-      }
       if (isExternalDraftPullRequest(item)) {
         return "Pascal, " + title + " is an external draft. I am watching it, but I will not quietly convert it into Codex work unless you explicitly hand it over.";
       }
       if (isDraftPullRequest(item)) {
         return "Codex, " + title + " is still draft work. Finish the draft or mark it ready only when the branch is actually ready for CI and Hermes.";
+      }
+      if (codexTaskFailedForItem(item)) {
+        return "Codex, for " + title + ", start with the runner output instead of guessing. Tell us whether this is runner/auth setup, a real PR failure, or a task that needs to be split smaller.";
       }
       if (action.owner === "Operator" || (lane && lane.key) === "operator") {
         return "Pascal, your next turn is not a rubber stamp on " + title + ". Read the evidence, decide whether the risk is intentional, then approve locally or send it back with a precise ask.";
@@ -7877,14 +7877,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const lane = boardLaneForItem(lead, verdict);
       const action = nextPipelineAction(lead, verdict);
       const title = cardTitleText(pipelineTitle(lead), lead.pullRequestNumber || pullRequestNumberFromCorrelation(lead.correlationId), lead);
-      if (codexTaskFailedForItem(lead)) {
-        return "First useful move: Codex should open the failed runner output for " + title + ", then either fix the runner/auth setup or split the work into a smaller retry.";
-      }
       if (isDraftPullRequest(lead)) {
         if (isExternalDraftPullRequest(lead)) {
           return "First useful move: leave " + title + " watched while the PR author or owning agent finishes it; Codex should only take over if Pascal explicitly delegates that.";
         }
         return "First useful move: Codex should finish the delegated draft work for " + title + ", mark it ready, and let CI plus Hermes re-check it.";
+      }
+      if (codexTaskFailedForItem(lead)) {
+        return "First useful move: Codex should open the failed runner output for " + title + ", then either fix the runner/auth setup or split the work into a smaller retry.";
       }
       if (action.owner === "Operator" || lane.key === "operator") {
         return "First useful move: Pascal should review " + title + " as a release decision, not as busywork; approve it only if the risk and intent are clear.";
@@ -7987,11 +7987,11 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const title = cardTitleText(pipelineTitle(item), item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
       const movedFrom = previous ? " from " + boardLaneLabel(previous.laneKey) : "";
       const nextStep = nextStepNarrationForItem(item, verdict, action, lane);
+      if (isDraftPullRequest(item)) {
+        return "Update on " + title + ": it is still a draft, so I am keeping it in Waiting / Drafts instead of treating it as an urgent release blocker. " + nextStep;
+      }
       if (codexTaskFailedForItem(item)) {
         return "Update on " + title + ": I moved it" + movedFrom + " back to Needs Attention because the Codex runner failed. " + nextStep;
-      }
-      if (isDraftPullRequest(item)) {
-        return "Update on " + title + ": it is still a draft, so I am keeping it out of the release path and not assigning it to Codex unless there is a delegated task. " + nextStep;
       }
       if (action.owner === "Operator" || lane.key === "operator") {
         return "Update on " + title + ": this moved" + movedFrom + " into Operator Review. Automation has gone as far as it safely can. " + nextStep;
@@ -8025,14 +8025,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     function boardBriefingLineForItem(item, verdict, action, lane) {
       const title = cardTitleText(pipelineTitle(item), item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
       const nextStep = nextStepNarrationForItem(item, verdict, action, lane);
-      if (codexTaskFailedForItem(item)) {
-        return "Codex, " + title + " is back in Needs Attention because the last runner task failed. Start by opening the failed runner output: if it is auth or clone setup, fix the runner path; if it is a real PR/check failure, come back with the smallest retry task or smallest branch fix. " + nextStep;
-      }
       if (isDraftPullRequest(item)) {
         if (isExternalDraftPullRequest(item)) {
           return "Hermes is watching " + title + " as a draft owned outside this board. I am holding it out of release and not asking Codex to move unless Pascal explicitly delegates takeover. " + nextStep;
         }
         return "Codex, " + title + " is still a draft with a delegated task, so I am holding it out of the release path until the task makes it ready. Finish the draft work or mark it ready for review, then let CI and Hermes take another pass. " + nextStep;
+      }
+      if (codexTaskFailedForItem(item)) {
+        return "Codex, " + title + " is back in Needs Attention because the last runner task failed. Start by opening the failed runner output: if it is auth or clone setup, fix the runner path; if it is a real PR/check failure, come back with the smallest retry task or smallest branch fix. " + nextStep;
       }
       if (lane.key === "attention" && action.owner === "Codex") {
         return "Codex, " + title + " is blocked at the gate. " + capitalizeFirst(action.text) + "; I will keep it visible here until the blocking signal disappears and Hermes records a clean pass. " + nextStep;
@@ -8074,9 +8074,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     // terse, action-first. Hermes's voice: dry, methodical, observing.
     function collaborationAskForItem(item, verdict, action, lane) {
       const title = cardTitleText(pipelineTitle(item), item.pullRequestNumber || pullRequestNumberFromCorrelation(item.correlationId), item);
-      if (codexTaskFailedForItem(item)) return "Codex, " + title + " failed in the runner. Please inspect the failed output first, then either fix the runner setup, push the smallest PR-check fix, or create a smaller retry task so Hermes has something concrete to re-check.";
       if (isExternalDraftPullRequest(item)) return "I am watching " + title + " as an external draft. It stays out of the release path until the PR author or owning agent marks it ready; Codex should not pick it up unless Pascal explicitly delegates takeover.";
       if (isDraftPullRequest(item)) return "Codex, " + title + " is still in draft mode with a delegated task. Finish the draft or mark it ready for review; once that happens I will wait for CI and Hermes to re-run before moving it forward.";
+      if (codexTaskFailedForItem(item)) return "Codex, " + title + " failed in the runner. Please inspect the failed output first, then either fix the runner setup, push the smallest PR-check fix, or create a smaller retry task so Hermes has something concrete to re-check.";
       if (action.owner === "Codex" || lane.key === "codex") return "Codex, you are up on " + title + ". " + capitalizeFirst(action.text) + "; keep it narrow and hand it back when CI/Hermes can see the new signal.";
       if (action.owner === "Operator" || lane.key === "operator" || lane.key === "attention") return "Pascal, " + title + " needs your call. " + capitalizeFirst(action.text) + "; if the answer is no, send it back to Codex with the exact change you want.";
       if (action.owner === "Hermes" || lane.key === "hermes") return "I am watching " + title + " now. I will land the verdict here once the checks clear, and I will not pretend it is ready while the evidence is still moving.";
@@ -9259,14 +9259,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (item.active === true || item.activeState === "running" || status === "running") {
         return { owner: "Hermes", text: "finish the current handoff checks and publish a verdict" };
       }
-      if (codexTaskFailedForItem(item)) {
-        return { owner: "Codex", text: "review the failed Codex task output, push a smaller fix, or propose a retry task" };
-      }
       if (isExternalDraftPullRequest(item)) {
         return { owner: "PR author", text: "finish the draft or mark it ready; Codex only takes over if the operator delegates a task" };
       }
       if (isDraftPullRequest(item)) {
         return { owner: codexTask && !isTerminalCodexTask(codexTask) ? "Codex" : "PR author", text: "finish the draft or mark it ready for review, then let CI and Hermes re-run" };
+      }
+      if (codexTaskFailedForItem(item)) {
+        return { owner: "Codex", text: "review the failed Codex task output, push a smaller fix, or propose a retry task" };
       }
       if (codexTaskCompletedAfterHermesReview(item)) {
         return { owner: "Hermes", text: "re-run the PR handoff/code-review checks now that Codex reported completion" };
@@ -9790,7 +9790,6 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
 
     function isExternalDraftPullRequest(item) {
       if (!isDraftPullRequest(item)) return false;
-      if (codexTaskFailedForItem(item)) return false;
       const task = codexTaskForItem(item);
       return !task || isTerminalCodexTask(task);
     }

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -1,9 +1,13 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   CollaborationValidationError,
   __resetCollaborationStoreForTests,
   listCollaborationMessages,
+  listHermesMemoryNotes,
   recordCollaborationMessage,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
@@ -142,6 +146,124 @@ describe("monitor collaboration channel", () => {
     // The first 100 should have been evicted.
     expect(listed[0].text).toBe("m100");
     expect(listed[499].text).toBe("m599");
+  });
+});
+
+describe("Hermes collaboration memory", () => {
+  beforeEach(() => {
+    __resetCollaborationStoreForTests();
+  });
+
+  it("learns operator guidance as global memory", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "Remember: draft PRs that belong to another agent should wait until that agent finishes.",
+      },
+      NOW
+    );
+    const notes = listHermesMemoryNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toMatchObject({
+      scope: "global",
+      text: expect.stringContaining("draft PRs that belong to another agent"),
+    });
+  });
+
+  it("keeps PR-scoped memory tied to the selected PR while retaining global guidance", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "everyone",
+        text: "Remember: ask me before moving external-agent drafts.",
+      },
+      NOW
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "This draft belongs to another agent; do not ask Codex to start it yet.",
+        relatedPr: { repo: "averray-agent/agent", number: 439 },
+      },
+      NOW + 1
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "This draft belongs to Codex now.",
+        relatedPr: { repo: "averray-agent/agent", number: 440 },
+      },
+      NOW + 2
+    );
+
+    const notes = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 439 },
+    });
+    expect(notes.map((note) => note.text).join("\n")).toContain("external-agent drafts");
+    expect(notes.map((note) => note.text).join("\n")).toContain("averray-agent/agent#439");
+    expect(notes.map((note) => note.text).join("\n")).not.toContain("averray-agent/agent#440");
+  });
+
+  it("does not learn ordinary chatter or Codex-authored messages", () => {
+    recordCollaborationMessage(
+      { author: "operator", addressedTo: "hermes", text: "thanks, looks good" },
+      NOW
+    );
+    recordCollaborationMessage(
+      { author: "codex", addressedTo: "hermes", text: "Remember this runner path." },
+      NOW + 1
+    );
+    expect(listHermesMemoryNotes()).toEqual([]);
+  });
+
+  it("deduplicates repeated guidance", () => {
+    const input = {
+      author: "operator",
+      addressedTo: "hermes",
+      text: "Remember: release queue means merge steward owns the next move.",
+    };
+    recordCollaborationMessage(input, NOW);
+    recordCollaborationMessage(input, NOW + 1);
+    const notes = listHermesMemoryNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0].ts).toBe(NOW + 1);
+  });
+
+  it("persists learned memory when a memory path is configured", () => {
+    const previousPath = process.env.HERMES_MONITOR_MEMORY_PATH;
+    const dir = mkdtempSync(join(tmpdir(), "hermes-memory-"));
+    const memoryPath = join(dir, "memory.json");
+    try {
+      process.env.HERMES_MONITOR_MEMORY_PATH = memoryPath;
+      __resetCollaborationStoreForTests();
+      recordCollaborationMessage(
+        {
+          author: "operator",
+          addressedTo: "hermes",
+          text: "Remember: draft PRs owned by external agents should stay out of Codex Needed.",
+        },
+        NOW
+      );
+
+      const persisted = JSON.parse(readFileSync(memoryPath, "utf8")) as {
+        notes: Array<{ text: string }>;
+      };
+      expect(persisted.notes[0].text).toContain("external agents");
+
+      __resetCollaborationStoreForTests();
+      expect(listHermesMemoryNotes()[0].text).toContain("external agents");
+    } finally {
+      if (previousPath === undefined) {
+        delete process.env.HERMES_MONITOR_MEMORY_PATH;
+      } else {
+        process.env.HERMES_MONITOR_MEMORY_PATH = previousPath;
+      }
+      __resetCollaborationStoreForTests();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -37,8 +37,11 @@ function jsonResponse(body: unknown, ok = true): Response {
 describe("HERMES_PERSONA", () => {
   it("constrains voice and reminds the model about truth boundary", () => {
     expect(HERMES_PERSONA).toMatch(/Hermes/);
+    expect(HERMES_PERSONA).toMatch(/board orchestrator/i);
     expect(HERMES_PERSONA).toMatch(/short sentences/i);
     expect(HERMES_PERSONA).toMatch(/never claim/i);
+    expect(HERMES_PERSONA).toMatch(/memory notes/i);
+    expect(HERMES_PERSONA).toMatch(/visible board controls/i);
     expect(HERMES_PERSONA).toMatch(/Pascal/);
     expect(HERMES_PERSONA).toMatch(/Codex/);
   });
@@ -80,9 +83,21 @@ describe("buildUserPrompt", () => {
     expect(prompt).toContain("hermes: Watching.");
   });
 
-  it("tells the model to reply as Hermes in 1-3 sentences", () => {
+  it("includes memory notes as guidance, not proof", () => {
+    const prompt = buildUserPrompt(baseContext({
+      memoryNotes: [
+        "Pascal preference: draft PRs owned by another agent should wait.",
+      ],
+    }));
+    expect(prompt).toContain("Hermes memory");
+    expect(prompt).toContain("draft PRs owned by another agent");
+    expect(prompt).toContain("use as guidance, not proof");
+  });
+
+  it("tells the model to reply as Hermes in 1-4 sentences", () => {
     const prompt = buildUserPrompt(baseContext());
-    expect(prompt).toMatch(/1-3 short sentences/);
+    expect(prompt).toMatch(/1-4 conversational sentences/);
+    expect(prompt).toMatch(/route the next turn/);
   });
 });
 

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -649,4 +649,15 @@ describe("slack operator personal monitor", () => {
     });
     expect(() => vm.runInContext(script, context, { timeout: 2000 })).not.toThrow();
   });
+
+  it("keeps draft PRs in Waiting / Drafts before task-failure urgency", () => {
+    const html = renderMonitorHtml();
+    const draftLaneIndex = html.indexOf('if (isExternalDraftPullRequest(item)) return { key: "waiting" };');
+    const failedAttentionIndex = html.indexOf('if (codexTaskFailedForItem(item)) return { key: "attention" };');
+
+    expect(draftLaneIndex).toBeGreaterThan(-1);
+    expect(failedAttentionIndex).toBeGreaterThan(-1);
+    expect(draftLaneIndex).toBeLessThan(failedAttentionIndex);
+    expect(html).not.toContain('if (codexTaskFailedForItem(item)) return false;');
+  });
 });


### PR DESCRIPTION
Summary:
- Teach the monitor Hermes voice to act as the board orchestrator, with explicit action boundaries.
- Add bounded Hermes memory notes learned from operator guidance, scoped globally or to a PR/correlation.
- Persist Hermes memory on the shared data volume via HERMES_MONITOR_MEMORY_PATH so guidance survives container restarts.

Checks:
- npm test -- monitor-collab monitor-hermes-voice
- npm run typecheck
- npm run build
- npm test
- git diff --check

Impact:
- Affects slack-operator monitor collaboration chat and VPS compose config.
- No secrets, database migrations, contracts, indexer, or public site changes.