### PR TITLE
Responsive polish: chat meta overflow, wider lanes, stack chat at mid-width

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -2012,6 +2012,28 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
     .command-shell.has-selection .command-console {
       right: calc(clamp(420px, 31vw, 640px) + 18px);
     }
+    /* Mid-width breakpoint: when the viewport is too narrow for the
+       chat thread + 320-430px compose form to sit side-by-side and
+       still leave the thread readable, stack the compose BELOW the
+       thread instead. Thread takes full width; compose gets a fixed
+       compact height. Below 760px we already have a different layout
+       (mobile bottom-sheet via #fab-ask), so this only covers the
+       1180-760px range. */
+    @media (max-width: 1180px) and (min-width: 761px) {
+      .command-console {
+        grid-template-columns: minmax(0, 1fr);
+        grid-template-rows: minmax(0, 1fr) auto;
+        max-height: min(56vh, 540px);
+      }
+      .command-shell.has-selection .command-console {
+        right: 14px;
+      }
+      .console-compose {
+        padding-left: 0;
+        padding-top: 10px;
+        border-top: 1px solid var(--line-soft);
+      }
+    }
     .console-main {
       position: relative; /* anchor point for the unread-pill */
       display: grid;
@@ -2197,6 +2219,15 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
       font-size: 0.64rem;
       letter-spacing: 0.02em;
+      /* Cap so a long meta ("board changed · Operator Review ·
+         OPERATOR REVIEW") can't push past the chat column and bleed
+         into the compose area. Ellipsis when it would otherwise
+         overflow; min-width:0 lets it actually shrink in the flex
+         row instead of forcing horizontal overflow. */
+      max-width: min(60%, 320px);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
       white-space: nowrap;
       margin-left: auto;
     }
@@ -5496,7 +5527,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       } else {
         const cols = visibleLanes.map((lane) => {
           if (lane.key === "done") return "minmax(220px, 1fr)";
-          return collapsedKeys.has(lane.key) ? "66px" : "minmax(186px, 1fr)";
+          // 210px min (was 186px) so card content has room before it
+          // wraps — "Stale 35h 38m", action buttons, and the "Inspect
+          // draft" pill were getting squished at the old min.
+          return collapsedKeys.has(lane.key) ? "66px" : "minmax(210px, 1fr)";
         });
         if (!showDone) cols.push("56px");
         target.style.gridTemplateColumns = cols.join(" ");

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -580,6 +580,16 @@ describe("slack operator personal monitor", () => {
     // The thresholds: 12h (720m) → high, 24h (1440m) → critical.
     expect(html).toContain('minutes >= 1440');
     expect(html).toContain('minutes >= 720');
+
+    // Responsive polish (PR: monitor-responsive-polish): chat meta
+    // shrinks/truncates instead of overflowing; min lane width bumped
+    // 186px → 210px; chat compose stacks below thread at mid-width
+    // (≤1180px). Together these stop the cramped/overflow look at
+    // medium viewports.
+    expect(html).toContain('"minmax(210px, 1fr)"');
+    expect(html).not.toContain('? "66px" : "minmax(186px, 1fr)"');
+    expect(html).toContain('text-overflow: ellipsis');
+    expect(html).toContain('@media (max-width: 1180px) and (min-width: 761px)');
   });
 
   it("serves a PWA manifest with the canonical name + scope", () => {


### PR DESCRIPTION
Three connected fixes after the screenshot showed cramped content on a mid-width desktop viewport.

## 1. Chat meta no longer bleeds into the compose area

The `.collab-meta` span had `white-space: nowrap` + `margin-left: auto`, so a long meta like `board changed · Operator Review · OPERATOR REVIEW` pushed past its column and ran into the right-side compose form. Now:

```css
.collab-meta {
  max-width: min(60%, 320px);
  min-width: 0;
  overflow: hidden;
  text-overflow: ellipsis;
}
```

Truncates with `…` instead of overflowing horizontally.

## 2. Kanban lane min width 186px → 210px

The previous min was tight enough that `Stale 35h 38m`, action buttons, and the `Inspect draft` pill on the Waiting/Drafts card all wrapped awkwardly at normal desktop widths. 210px gives card content breathing room before it has to break.

## 3. Stack chat compose below thread at mid-width

New `@media (max-width: 1180px) and (min-width: 761px)` breakpoint. At mid-width viewports the 320-430px compose form was leaving the chat thread column narrow and dense. Now in this range:

- `.command-console` grid switches to a single column — thread on top (full width), compose below
- Dock `max-height` bumps to `min(56vh, 540px)` so both fit comfortably
- Compose border-top divider for visual separation
- `.command-shell.has-selection .command-console { right: 14px }` so opening the drawer doesn't double-shrink the dock

**Below 761px**: existing mobile bottom-sheet (`fab-ask` + sheet) already wins.
**Above 1180px**: side-by-side layout still wins.
This only fills the mid-width gap.

## Tests

- **181/181 vitest cases pass** (boot smoke + parse + render still green).
- Positive: `"minmax(210px, 1fr)"`, `text-overflow: ellipsis`, the new `@media (max-width: 1180px) and (min-width: 761px)` selector.
- Negative: the old `? "66px" : "minmax(186px, 1fr)"` pair is gone.

## Test plan

- [ ] Open the monitor at the screenshot's width (~1700px) → cards have room (no wrapping in "Stale 35h 38m" or action buttons), chat meta truncates with `…` instead of bleeding into the compose form.
- [ ] Resize to ~1100px → compose form slides BELOW the chat thread, thread takes full width.
- [ ] Resize to ~700px → existing mobile bottom-sheet layout takes over.
- [ ] Resize to ~1300px → side-by-side returns.

## Deploy

```bash
cd /srv/averray-reference-agent && git pull --rebase && \
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  build --no-cache slack-operator codex-task-runner && \
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg \
  up -d --force-recreate slack-operator codex-task-runner
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)