### PR TITLE
Make Hermes replies board-aware

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -37,6 +37,7 @@ import {
   recordCollaborationMessage,
   synthesizeHermesReplyFor,
 } from "./monitor-collab.js";
+import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
 import { generateHermesReply } from "./monitor-hermes-voice.js";
 import {
   approveCodexTask,
@@ -438,6 +439,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
           ...(operatorMessage.relatedCorrelationId ? { relatedCorrelationId: operatorMessage.relatedCorrelationId } : {}),
           limit: 8,
         }).map((note) => note.text);
+        const board = await loadHermesBoardSnapshotForReply(operatorMessage);
         const llmText = await generateHermesReply(
           {
             operatorMessage: {
@@ -449,6 +451,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
             recentMessages: recent.map((m) => ({ author: m.author, text: m.text, ts: m.ts })),
             memoryNotes,
             ...(operatorMessage.relatedPr ? { selectedPr: operatorMessage.relatedPr } : {}),
+            ...(board ? { board } : {}),
           },
           { apiKey, baseUrl, model }
         );
@@ -475,6 +478,19 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
     }
   }, 600);
   timer.unref?.();
+}
+
+async function loadHermesBoardSnapshotForReply(
+  operatorMessage: Awaited<ReturnType<typeof recordCollaborationMessage>>
+) {
+  try {
+    const url = new URL("http://localhost/monitor/events?limit=40&activeWindowMinutes=240");
+    const snapshot = await withTimeout(loadMonitorSnapshot(url), 4_000, "monitor_reply_board_snapshot_timeout");
+    return buildHermesBoardSnapshotFromMonitor(snapshot);
+  } catch (error) {
+    logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_board_snapshot_unavailable");
+    return undefined;
+  }
 }
 
 async function handleMonitorCollaborationRequest(request: http.IncomingMessage, response: http.ServerResponse) {

--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -1,0 +1,473 @@
+import type { HermesBoardCardSnapshot, HermesBoardSnapshot } from "./monitor-hermes-voice.js";
+
+interface PrIdentity {
+  repo?: string;
+  number?: number;
+}
+
+interface BoardClassification {
+  lane: string;
+  owner: string;
+  verdict: string;
+  next: string;
+}
+
+const TERMINAL_CODEX_STATUSES = new Set(["completed", "cancelled", "failed", "terminal"]);
+
+export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBoardSnapshot | undefined {
+  if (!isRecord(snapshot)) return undefined;
+
+  const activeTasks = activeCodexTaskMap(snapshot);
+  const rawItems = dedupeItems([...arrayRecords(snapshot.active), ...arrayRecords(snapshot.recent)]);
+  const cards = rawItems
+    .map((item) => boardCardFromItem(item, snapshot, activeTasks))
+    .filter((item): item is HermesBoardCardSnapshot => Boolean(item))
+    .slice(0, 10);
+
+  const counts = boardCounts(cards, snapshot);
+  const runner = runnerSummary(snapshot);
+  return {
+    ...stringProp(snapshot, "generatedAt", "generatedAt"),
+    ...stringProp(snapshot, "status", "status"),
+    headline: boardHeadline(counts),
+    counts,
+    ...(runner ? { runner } : {}),
+    items: cards,
+  };
+}
+
+function boardCardFromItem(
+  item: Record<string, unknown>,
+  snapshot: Record<string, unknown>,
+  activeTasks: ReadonlyMap<string, string>
+): HermesBoardCardSnapshot | undefined {
+  const summary = recordProp(item, "summary") ?? {};
+  const prState = pullRequestState(item, summary);
+  const identity = prIdentity(item, summary, prState);
+  const key = identityKey(identity);
+  const codexTaskStatus = key ? activeTasks.get(key) : undefined;
+  const classification = classifyItem(item, summary, prState, codexTaskStatus);
+  const title = titleForItem(item, summary, prState, identity);
+  if (!title && !identity.repo) return undefined;
+  const why = reasonForItem(item, summary, prState, codexTaskStatus);
+  return {
+    ...identity,
+    title: title || "Untitled handoff",
+    lane: classification.lane,
+    owner: classification.owner,
+    verdict: classification.verdict,
+    ...ageLabelProp(item, snapshot),
+    ...(why ? { why } : {}),
+    next: classification.next,
+    tags: tagsForItem(item, summary),
+  };
+}
+
+function classifyItem(
+  item: Record<string, unknown>,
+  summary: Record<string, unknown>,
+  prState: Record<string, unknown> | undefined,
+  codexTaskStatus?: string
+): BoardClassification {
+  const reason = normalize(textProp(summary, "finalReason") || textProp(summary, "reason") || textProp(item, "reason"));
+  const status = normalize(textProp(item, "status"));
+  const finalVerdict = normalize(textProp(summary, "finalVerdict") || textProp(summary, "status"));
+  const mergeRecommendation = normalize(textProp(summary, "mergeRecommendation"));
+  const intent = normalize(textProp(item, "intent"));
+
+  if (isDonePrState(prState)) {
+    return {
+      lane: "Done",
+      owner: "History",
+      verdict: prState && booleanProp(prState, "merged") ? "merged" : "closed",
+      next: "keep this as release history; no board action is needed",
+    };
+  }
+  if (intent.includes("deploy")) {
+    const failed = includesAny(reason, ["failed", "failure"]) || includesAny(finalVerdict, ["failed", "failure", "block"]);
+    if (status === "running" || booleanProp(item, "active")) {
+      return {
+        lane: "Deploying",
+        owner: "Hermes",
+        verdict: "deploy running",
+        next: "wait for production verification to publish a pass or failure",
+      };
+    }
+    if (failed) {
+      return {
+        lane: "Needs Attention",
+        owner: "Codex",
+        verdict: "deploy failed",
+        next: "prepare a fix or rollback plan, then let deployment verification run again",
+      };
+    }
+  }
+  if (isRunningItem(item, status)) {
+    return {
+      lane: "Hermes Checking",
+      owner: "Hermes",
+      verdict: "running",
+      next: "wait for Hermes/GitHub checks to finish before assigning new work",
+    };
+  }
+  if (booleanProp(prState, "draft")) {
+    if (codexTaskStatus) {
+      return {
+        lane: "Codex Needed",
+        owner: "Codex",
+        verdict: "delegated draft",
+        next: "continue the explicit Codex takeover task, finish only verifiable work, then mark the PR ready when it is actually ready",
+      };
+    }
+    return {
+      lane: "Waiting / Drafts",
+      owner: "PR author",
+      verdict: "draft",
+      next: "wait for the PR author or owning agent to mark it ready; Codex takes over only if Pascal explicitly delegates it",
+    };
+  }
+  if (
+    reason === "pr_checks_active"
+    || reason === "ci_in_progress"
+    || includesAny(finalVerdict, ["running", "active"])
+  ) {
+    return {
+      lane: "Codex Needed",
+      owner: "Codex",
+      verdict: "CI running",
+      next: "wait for CI on the current commit; if it fails, Codex should push the smallest fix and let Hermes re-run",
+    };
+  }
+  if (
+    status === "failed"
+    || status === "blocked"
+    || reason === "pr_checks_failed"
+    || includesAny(reason, ["failed", "failure", "block"])
+    || includesAny(finalVerdict, ["failed", "failure", "block", "hold"])
+    || includesAny(mergeRecommendation, ["failed", "failure", "block", "hold", "do_not_merge"])
+  ) {
+    return {
+      lane: "Needs Attention",
+      owner: "Codex",
+      verdict: "blocked",
+      next: "inspect the failing signal, make the smallest justified fix or propose a smaller retry task, then wait for CI and Hermes",
+    };
+  }
+  if (
+    reason === "pr_critical_files"
+    || reason === "pr_review_risk_files"
+    || finalVerdict.includes("review")
+    || mergeRecommendation.includes("review")
+    || reviewReasons(summary).length > 0
+  ) {
+    return {
+      lane: "Operator Review",
+      owner: "Operator",
+      verdict: "needs review",
+      next: "use Hermes/Codex pre-check evidence to decide whether the project intent, rollout risk, and critical-file boundary are acceptable",
+    };
+  }
+  if (
+    finalVerdict === "ok_to_merge"
+    || finalVerdict === "pass"
+    || mergeRecommendation === "ok_to_merge"
+    || mergeRecommendation === "merge"
+    || status === "completed"
+  ) {
+    return {
+      lane: "Release Queue",
+      owner: "Merge steward",
+      verdict: "ready",
+      next: "merge only after branch protection is green and any operator sign-off is clean",
+    };
+  }
+  return {
+    lane: "Hermes Checking",
+    owner: "Hermes",
+    verdict: status || finalVerdict || "unknown",
+    next: "collect a fresh Hermes verdict before moving the card forward",
+  };
+}
+
+function reasonForItem(
+  item: Record<string, unknown>,
+  summary: Record<string, unknown>,
+  prState: Record<string, unknown> | undefined,
+  codexTaskStatus?: string
+): string {
+  if (codexTaskStatus) return `Codex task is ${codexTaskStatus}.`;
+  const firstReason = reviewReasons(summary)[0];
+  if (firstReason) return firstReason;
+  const codeReview = recordProp(summary, "codeReview");
+  const codeReviewWhy = codeReview ? textProp(codeReview, "why") : "";
+  if (codeReviewWhy) return codeReviewWhy;
+  if (booleanProp(prState, "draft")) return "GitHub reports this PR is still a draft.";
+  const live = recordProp(summary, "githubLive");
+  const totals = live ? recordProp(live, "checkTotals") : undefined;
+  if (totals) {
+    const failed = numberProp(totals, "failed") ?? 0;
+    const active = numberProp(totals, "active") ?? 0;
+    if (failed > 0) return `${failed} PR check(s) failed.`;
+    if (active > 0) return `${active} PR check(s) are still running.`;
+  }
+  return textProp(summary, "finalReason")
+    || textProp(summary, "reason")
+    || textProp(item, "reason")
+    || textProp(item, "phase")
+    || "";
+}
+
+function titleForItem(
+  item: Record<string, unknown>,
+  summary: Record<string, unknown>,
+  prState: Record<string, unknown> | undefined,
+  identity: PrIdentity
+): string {
+  const prTitle = prState ? textProp(prState, "title") : "";
+  if (prTitle) return prTitle;
+  const pullRequest = recordProp(summary, "pullRequest");
+  const summaryTitle = pullRequest ? textProp(pullRequest, "title") : "";
+  if (summaryTitle) return summaryTitle;
+  const fallback = textProp(item, "reason") || textProp(summary, "finalReason") || textProp(item, "intent");
+  if (fallback) return fallback.replace(/_/g, " ");
+  if (identity.repo && identity.number) return `${identity.repo}#${identity.number}`;
+  return "";
+}
+
+function tagsForItem(item: Record<string, unknown>, summary: Record<string, unknown>): string[] {
+  const reviewSignals = recordProp(summary, "reviewSignals");
+  const touchedAreas = reviewSignals ? arrayStrings(reviewSignals.touchedAreas) : [];
+  const testCaseIds = arrayStrings(item.testCaseIds);
+  return unique([...touchedAreas, ...testCaseIds]).slice(0, 6);
+}
+
+function boardCounts(
+  cards: ReadonlyArray<HermesBoardCardSnapshot>,
+  snapshot: Record<string, unknown>
+): Record<string, number | string | boolean> {
+  const counts: Record<string, number | string | boolean> = {
+    attention: countLane(cards, "Needs Attention"),
+    waiting: countLane(cards, "Waiting / Drafts"),
+    codex: countLane(cards, "Codex Needed"),
+    hermes: countLane(cards, "Hermes Checking"),
+    operator: countLane(cards, "Operator Review"),
+    queue: countLane(cards, "Release Queue"),
+    deploying: countLane(cards, "Deploying"),
+  };
+  const sourceCounts = recordProp(snapshot, "counts");
+  if (sourceCounts) {
+    const active = numberProp(sourceCounts, "active");
+    const running = numberProp(sourceCounts, "running");
+    const recent = numberProp(sourceCounts, "recent");
+    if (active !== undefined) counts.active = active;
+    if (running !== undefined) counts.running = running;
+    if (recent !== undefined) counts.recent = recent;
+  }
+  const codexTasks = recordProp(snapshot, "codexTasks");
+  const codexTaskCounts = codexTasks ? recordProp(codexTasks, "counts") : undefined;
+  if (codexTaskCounts) {
+    const proposed = numberProp(codexTaskCounts, "proposed");
+    const approved = numberProp(codexTaskCounts, "approved");
+    const taskRunning = numberProp(codexTaskCounts, "running");
+    if (proposed !== undefined) counts.codexTasksProposed = proposed;
+    if (approved !== undefined) counts.codexTasksApproved = approved;
+    if (taskRunning !== undefined) counts.codexTasksRunning = taskRunning;
+  }
+  return counts;
+}
+
+function boardHeadline(counts: Readonly<Record<string, number | string | boolean>>): string {
+  const parts: string[] = [];
+  const attention = numericCount(counts.attention);
+  const waiting = numericCount(counts.waiting);
+  const codex = numericCount(counts.codex);
+  const operator = numericCount(counts.operator);
+  const queue = numericCount(counts.queue);
+  const deploying = numericCount(counts.deploying);
+  if (attention > 0) parts.push(`${attention} blocked/attention item${attention === 1 ? "" : "s"}`);
+  if (waiting > 0) parts.push(`${waiting} draft${waiting === 1 ? "" : "s"} parked`);
+  if (codex > 0) parts.push(`${codex} Codex-owned item${codex === 1 ? "" : "s"}`);
+  if (operator > 0) parts.push(`${operator} operator decision${operator === 1 ? "" : "s"}`);
+  if (queue > 0) parts.push(`${queue} ready for merge stewardship`);
+  if (deploying > 0) parts.push(`${deploying} deploy verification${deploying === 1 ? "" : "s"}`);
+  return parts.length > 0
+    ? `Board now: ${parts.join("; ")}.`
+    : "Board now: no active PR handoffs need attention.";
+}
+
+function runnerSummary(snapshot: Record<string, unknown>): string {
+  const codexTasks = recordProp(snapshot, "codexTasks");
+  const runner = codexTasks ? recordProp(codexTasks, "runner") : undefined;
+  if (!runner) return "";
+  const status = textProp(runner, "status");
+  const message = textProp(runner, "message");
+  const stale = booleanProp(runner, "stale");
+  return [status ? `status=${status}` : "", stale ? "stale=true" : "", message].filter(Boolean).join(" | ");
+}
+
+function activeCodexTaskMap(snapshot: Record<string, unknown>): Map<string, string> {
+  const result = new Map<string, string>();
+  const codexTasks = recordProp(snapshot, "codexTasks");
+  const items = codexTasks ? arrayRecords(codexTasks.items) : [];
+  for (const task of items) {
+    const status = normalize(textProp(task, "status"));
+    if (!status || TERMINAL_CODEX_STATUSES.has(status)) continue;
+    const repo = textProp(task, "repo");
+    const number = numberProp(task, "pullRequestNumber");
+    if (!repo || !number) continue;
+    result.set(`${repo}#${number}`, status);
+  }
+  return result;
+}
+
+function dedupeItems(items: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  const seen = new Set<string>();
+  const result: Array<Record<string, unknown>> = [];
+  for (const item of items) {
+    const summary = recordProp(item, "summary") ?? {};
+    const prState = pullRequestState(item, summary);
+    const identity = prIdentity(item, summary, prState);
+    const key = identityKey(identity) || textProp(item, "correlationId");
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
+}
+
+function prIdentity(
+  item: Record<string, unknown>,
+  summary: Record<string, unknown>,
+  prState?: Record<string, unknown>
+): PrIdentity {
+  const repo = textProp(item, "repo")
+    || (prState ? textProp(prState, "repo") : "")
+    || textProp(recordProp(summary, "pullRequest") ?? {}, "repo");
+  const number = numberProp(item, "pullRequestNumber")
+    ?? (prState ? numberProp(prState, "number") : undefined)
+    ?? numberProp(recordProp(summary, "pullRequest") ?? {}, "number")
+    ?? pullRequestNumberFromCorrelation(textProp(item, "correlationId"));
+  return {
+    ...(repo ? { repo } : {}),
+    ...(number ? { number } : {}),
+  };
+}
+
+function identityKey(identity: PrIdentity): string {
+  return identity.repo && identity.number ? `${identity.repo}#${identity.number}` : "";
+}
+
+function pullRequestState(
+  item: Record<string, unknown>,
+  summary: Record<string, unknown>
+): Record<string, unknown> | undefined {
+  return recordProp(summary, "currentPullRequest")
+    ?? recordProp(summary, "pullRequest")
+    ?? recordProp(item, "pullRequest")
+    ?? undefined;
+}
+
+function reviewReasons(summary: Record<string, unknown>): string[] {
+  return arrayRecords(summary.reviewReasons)
+    .map((reason) => {
+      const message = textProp(reason, "message");
+      const code = textProp(reason, "code");
+      if (code && message) return `${code}: ${message}`;
+      return message || code;
+    })
+    .filter(Boolean);
+}
+
+function isRunningItem(item: Record<string, unknown>, status: string): boolean {
+  return status === "running" || booleanProp(item, "active") || normalize(textProp(item, "activeState")) === "running";
+}
+
+function isDonePrState(prState: Record<string, unknown> | undefined): boolean {
+  if (!prState) return false;
+  return booleanProp(prState, "merged") === true || normalize(textProp(prState, "state")) === "closed";
+}
+
+function ageLabelProp(item: Record<string, unknown>, snapshot: Record<string, unknown>): { ageLabel?: string } {
+  const updatedAt = textProp(item, "updatedAt") || textProp(item, "startedAt");
+  const generatedAt = textProp(snapshot, "generatedAt");
+  if (!updatedAt || !generatedAt) return {};
+  const updated = Date.parse(updatedAt);
+  const generated = Date.parse(generatedAt);
+  if (!Number.isFinite(updated) || !Number.isFinite(generated) || generated < updated) return {};
+  const minutes = Math.floor((generated - updated) / 60_000);
+  if (minutes < 2) return { ageLabel: "fresh" };
+  if (minutes < 60) return { ageLabel: `${minutes}m` };
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  return { ageLabel: `${hours}h${remainingMinutes ? ` ${remainingMinutes}m` : ""}` };
+}
+
+function stringProp<T extends string>(record: Record<string, unknown>, key: string, outputKey: T): Partial<Record<T, string>> {
+  const value = textProp(record, key);
+  return value ? { [outputKey]: value } as Partial<Record<T, string>> : {};
+}
+
+function countLane(cards: ReadonlyArray<HermesBoardCardSnapshot>, lane: string): number {
+  return cards.filter((card) => card.lane === lane).length;
+}
+
+function numericCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function recordProp(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function textProp(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function numberProp(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function booleanProp(record: Record<string, unknown> | undefined, key: string): boolean {
+  return Boolean(record && record[key] === true);
+}
+
+function arrayRecords(value: unknown): Array<Record<string, unknown>> {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function arrayStrings(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map((entry) => String(entry || "").trim()).filter(Boolean)
+    : [];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function normalize(value: unknown): string {
+  return String(value || "").trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function pullRequestNumberFromCorrelation(correlationId: string): number | undefined {
+  const match = correlationId.match(/(?:^|-)pr-([0-9]+)(?:-|$)/);
+  if (!match) return undefined;
+  const parsed = Number.parseInt(match[1] ?? "", 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -34,6 +34,7 @@ Voice:
 
 Job:
 - Orchestrate the monitor board: explain what changed, who owns the next move, what is waiting, and what Pascal should decide.
+- Treat the live board snapshot as the highest-priority evidence. If memory or old chat conflicts with the board, say the board wins.
 - Use memory notes to honor Pascal's preferences and prior room decisions. Treat memory as guidance, not live proof.
 - Ask for help when a human decision is needed. Hand work to Codex only as a request or recommendation, never as a claim that Codex already acted.
 - Do not silently mutate GitHub, merge, deploy, approve, start Codex work, or mark anything reviewed. Those actions require visible board controls or normal PR workflows.
@@ -51,6 +52,28 @@ export interface HermesReplyPrSnapshot {
   why?: string;
 }
 
+export interface HermesBoardCardSnapshot {
+  repo?: string;
+  number?: number;
+  title: string;
+  lane: string;
+  owner: string;
+  verdict?: string;
+  ageLabel?: string;
+  why?: string;
+  next?: string;
+  tags?: ReadonlyArray<string>;
+}
+
+export interface HermesBoardSnapshot {
+  generatedAt?: string;
+  status?: string;
+  headline?: string;
+  counts?: Readonly<Record<string, number | string | boolean>>;
+  runner?: string;
+  items?: ReadonlyArray<HermesBoardCardSnapshot>;
+}
+
 export interface HermesReplyContext {
   operatorMessage: Pick<CollaborationMessage, "text" | "addressedTo" | "kind" | "relatedPr">;
   /** Most-recent first. Caller decides how many. */
@@ -59,6 +82,8 @@ export interface HermesReplyContext {
   memoryNotes?: ReadonlyArray<string>;
   /** State of the PR the operator was looking at (or that's attached to the message). */
   selectedPr?: HermesReplyPrSnapshot;
+  /** Current monitor board state, built server-side from the live snapshot. */
+  board?: HermesBoardSnapshot;
 }
 
 export interface GenerateHermesReplyOptions {
@@ -119,6 +144,25 @@ export async function generateHermesReply(
 export function buildUserPrompt(context: HermesReplyContext): string {
   const lines: string[] = [];
 
+  if (context.board) {
+    lines.push("Live board snapshot (highest-priority evidence; if it conflicts with memory or older chat, trust the board):");
+    if (context.board.generatedAt) lines.push(`- generatedAt: ${context.board.generatedAt}`);
+    if (context.board.status) lines.push(`- status: ${context.board.status}`);
+    if (context.board.headline) lines.push(`- headline: ${truncate(context.board.headline, 360)}`);
+    const counts = formatBoardCounts(context.board.counts);
+    if (counts) lines.push(`- lane counts: ${counts}`);
+    if (context.board.runner) lines.push(`- codex runner: ${truncate(context.board.runner, 260)}`);
+    if (context.board.items && context.board.items.length > 0) {
+      lines.push("- top cards:");
+      for (const item of context.board.items.slice(0, 8)) {
+        lines.push(`  - ${formatBoardCard(item)}`);
+      }
+    } else {
+      lines.push("- top cards: none");
+    }
+    lines.push("");
+  }
+
   const pr = context.selectedPr ?? (context.operatorMessage.relatedPr
     ? { repo: context.operatorMessage.relatedPr.repo, number: context.operatorMessage.relatedPr.number }
     : undefined);
@@ -154,6 +198,7 @@ export function buildUserPrompt(context: HermesReplyContext): string {
 
   lines.push("Hermes job on this board:");
   lines.push("- Orchestrate: explain state, route the next turn, remember preferences, and ask for decisions.");
+  lines.push("- Use the live board snapshot to name the owner and next move. Mention uncertainty when the board lacks proof.");
   lines.push("- Stay truthful: do not claim hidden actions or speak as Codex.");
   lines.push("");
 
@@ -165,6 +210,29 @@ export function buildUserPrompt(context: HermesReplyContext): string {
   lines.push("Reply as Hermes in 1-4 conversational sentences. Do not greet, do not summarize Pascal's message, do not pad. Explain the next move if the board state needs one.");
 
   return lines.join("\n");
+}
+
+function formatBoardCounts(counts: HermesBoardSnapshot["counts"]): string {
+  if (!counts) return "";
+  return Object.entries(counts)
+    .filter(([, value]) => value !== undefined && value !== "" && value !== false)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(", ");
+}
+
+function formatBoardCard(item: HermesBoardCardSnapshot): string {
+  const pr = item.repo && item.number ? `${item.repo}#${item.number}` : item.repo || "unknown PR";
+  const parts = [
+    `${item.lane} / owner ${item.owner}`,
+    pr,
+    item.verdict ? `verdict ${item.verdict}` : "",
+    item.ageLabel ? `age ${item.ageLabel}` : "",
+    `title ${truncate(item.title, 140)}`,
+    item.why ? `why ${truncate(item.why, 220)}` : "",
+    item.next ? `next ${truncate(item.next, 220)}` : "",
+    item.tags && item.tags.length > 0 ? `tags ${item.tags.slice(0, 5).join(", ")}` : "",
+  ].filter(Boolean);
+  return parts.join(" | ");
 }
 
 function extractReplyText(json: unknown): string | null {

--- a/test/unit/monitor-hermes-board.test.ts
+++ b/test/unit/monitor-hermes-board.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import { buildHermesBoardSnapshotFromMonitor } from "../../services/slack-operator/src/monitor-hermes-board.js";
+
+describe("buildHermesBoardSnapshotFromMonitor", () => {
+  it("turns live monitor data into lane/owner context for Hermes", () => {
+    const board = buildHermesBoardSnapshotFromMonitor({
+      generatedAt: "2026-05-20T08:54:42.000Z",
+      status: "attention",
+      counts: { active: 0, running: 0, recent: 20 },
+      recent: [
+        {
+          correlationId: "github-live-pr-averray-agent-agent-439",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 439,
+          status: "completed",
+          reason: "pr_is_draft",
+          updatedAt: "2026-05-19T22:08:42.000Z",
+          summary: {
+            finalVerdict: "needs_review",
+            currentPullRequest: {
+              repo: "averray-agent/agent",
+              number: 439,
+              draft: true,
+              state: "open",
+              title: "PR is still marked as draft.",
+            },
+            reviewSignals: { touchedAreas: ["backend", "secrets"] },
+          },
+        },
+        {
+          correlationId: "github-live-pr-averray-reference-agent-176",
+          repo: "averray-reference-agent",
+          pullRequestNumber: 176,
+          status: "completed",
+          reason: "pr_critical_files",
+          updatedAt: "2026-05-20T08:49:42.000Z",
+          summary: {
+            finalVerdict: "needs_review",
+            reviewReasons: [
+              { code: "pr_critical_files", message: "1 changed file(s) touch secrets, contracts, or database migrations." },
+            ],
+            currentPullRequest: {
+              repo: "averray-reference-agent",
+              number: 176,
+              draft: false,
+              state: "open",
+              title: "Critical deploy review",
+            },
+            reviewSignals: { touchedAreas: ["ops"] },
+          },
+        },
+      ],
+      codexTasks: {
+        counts: { proposed: 0, approved: 0, running: 0 },
+        runner: {
+          status: "idle",
+          message: "Codex runner is online; no approved task is waiting.",
+          stale: false,
+        },
+      },
+    });
+
+    expect(board?.headline).toContain("1 draft");
+    expect(board?.counts?.waiting).toBe(1);
+    expect(board?.counts?.operator).toBe(1);
+    expect(board?.runner).toContain("status=idle");
+    expect(board?.items?.[0]).toMatchObject({
+      repo: "averray-agent/agent",
+      number: 439,
+      lane: "Waiting / Drafts",
+      owner: "PR author",
+      verdict: "draft",
+    });
+    expect(board?.items?.[0]?.next).toMatch(/explicitly delegates/);
+    expect(board?.items?.[1]).toMatchObject({
+      repo: "averray-reference-agent",
+      number: 176,
+      lane: "Operator Review",
+      owner: "Operator",
+      verdict: "needs review",
+    });
+  });
+
+  it("moves draft PRs with active Codex tasks into Codex context", () => {
+    const board = buildHermesBoardSnapshotFromMonitor({
+      generatedAt: "2026-05-20T08:54:42.000Z",
+      status: "attention",
+      recent: [
+        {
+          correlationId: "github-live-pr-averray-agent-agent-439",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 439,
+          status: "completed",
+          reason: "pr_is_draft",
+          summary: {
+            currentPullRequest: {
+              repo: "averray-agent/agent",
+              number: 439,
+              draft: true,
+              state: "open",
+              title: "Delegated draft",
+            },
+          },
+        },
+      ],
+      codexTasks: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            pullRequestNumber: 439,
+            status: "approved",
+          },
+        ],
+      },
+    });
+
+    expect(board?.items?.[0]).toMatchObject({
+      lane: "Codex Needed",
+      owner: "Codex",
+      verdict: "delegated draft",
+      why: "Codex task is approved.",
+    });
+  });
+});

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -94,6 +94,37 @@ describe("buildUserPrompt", () => {
     expect(prompt).toContain("use as guidance, not proof");
   });
 
+  it("includes live board context as higher-priority evidence", () => {
+    const prompt = buildUserPrompt(baseContext({
+      board: {
+        generatedAt: "2026-05-20T08:54:42.000Z",
+        status: "attention",
+        headline: "Board now: 1 draft parked; 1 operator decision.",
+        counts: { waiting: 1, operator: 1, codex: 0 },
+        runner: "status=idle | Codex runner is online.",
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 439,
+            title: "PR is still marked as draft.",
+            lane: "Waiting / Drafts",
+            owner: "PR author",
+            verdict: "draft",
+            why: "GitHub reports this PR is still a draft.",
+            next: "wait for the PR author unless Pascal delegates takeover",
+            tags: ["backend", "secrets"],
+          },
+        ],
+      },
+    }));
+    expect(prompt).toContain("Live board snapshot");
+    expect(prompt).toContain("highest-priority evidence");
+    expect(prompt).toContain("Board now: 1 draft parked");
+    expect(prompt).toContain("waiting=1");
+    expect(prompt).toContain("Waiting / Drafts / owner PR author");
+    expect(prompt).toContain("trust the board");
+  });
+
   it("tells the model to reply as Hermes in 1-4 sentences", () => {
     const prompt = buildUserPrompt(baseContext());
     expect(prompt).toMatch(/1-4 conversational sentences/);


### PR DESCRIPTION
## What changed
- Added a server-side Hermes board snapshot builder that summarizes live lanes, owners, runner status, top cards, reasons, and next moves.
- Fed that board snapshot into Hermes' LLM prompt so replies can orchestrate from live board evidence, not only the chat message and memory.
- Updated Hermes voice tests and added board snapshot tests for draft, operator-review, and delegated Codex-task routing.

## Checks run
- npm test -- monitor-hermes-voice monitor-hermes-board
- npm run typecheck
- npm test
- npm run build
- git diff --check

## Impact
- Affects slack-operator / command-center monitor backend prompt context only.
- No frontend, indexer, contracts, Caddy, public site, VPS secret, or environment changes required.