### PR TITLE
Add proactive Hermes board narration

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -38,7 +38,13 @@ import {
   synthesizeHermesReplyFor,
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
-import { generateHermesReply } from "./monitor-hermes-voice.js";
+import {
+  decideHermesBoardNarration,
+  fallbackHermesBoardNarration,
+  relatedPrForHermesBoardNarration,
+  targetForHermesBoardNarration,
+} from "./monitor-hermes-narration.js";
+import { generateHermesBoardNarration, generateHermesReply } from "./monitor-hermes-voice.js";
 import {
   approveCodexTask,
   cancelCodexTask,
@@ -66,6 +72,13 @@ const authConfig = {
 };
 const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedChannelIds);
 const monitorConfig = parseMonitorConfig(process.env);
+const monitorNarrationMinIntervalMs = Math.max(
+  5_000,
+  Number.parseInt(optionalEnv("HERMES_MONITOR_NARRATION_MIN_INTERVAL_MS", "30000"), 10) || 30_000
+);
+let lastHermesBoardNarrationSignature = "";
+let inFlightHermesBoardNarrationSignature = "";
+let lastHermesBoardNarrationAtMs = 0;
 
 logger.info({
   enabled,
@@ -485,7 +498,11 @@ async function loadHermesBoardSnapshotForReply(
 ) {
   try {
     const url = new URL("http://localhost/monitor/events?limit=40&activeWindowMinutes=240");
-    const snapshot = await withTimeout(loadMonitorSnapshot(url), 4_000, "monitor_reply_board_snapshot_timeout");
+    const snapshot = await withTimeout(
+      loadMonitorSnapshot(url, { suppressNarration: true }),
+      4_000,
+      "monitor_reply_board_snapshot_timeout"
+    );
     return buildHermesBoardSnapshotFromMonitor(snapshot);
   } catch (error) {
     logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_board_snapshot_unavailable");
@@ -1019,7 +1036,10 @@ function writeRedirect(response: http.ServerResponse, location: string) {
   response.end();
 }
 
-async function loadMonitorSnapshot(url: URL): Promise<unknown> {
+async function loadMonitorSnapshot(
+  url: URL,
+  options: { suppressNarration?: boolean } = {}
+): Promise<unknown> {
   const startedAt = Date.now();
   const phases: Array<Record<string, unknown>> = [];
   const handoffStartedAt = Date.now();
@@ -1087,12 +1107,82 @@ async function loadMonitorSnapshot(url: URL): Promise<unknown> {
   if (degraded) {
     logger.warn({ diagnostics }, "monitor_snapshot_degraded");
   }
-  return {
+  const snapshot = {
     ...enriched,
     codexTasks,
     collaborationMessages: listCollaborationMessages({ limit: 200 }),
     diagnostics,
   };
+  if (!options.suppressNarration) {
+    scheduleHermesBoardNarration(snapshot);
+  }
+  return snapshot;
+}
+
+function scheduleHermesBoardNarration(snapshot: unknown): void {
+  const board = buildHermesBoardSnapshotFromMonitor(snapshot);
+  const decision = decideHermesBoardNarration(
+    board,
+    lastHermesBoardNarrationSignature,
+    inFlightHermesBoardNarrationSignature
+  );
+  if (!decision.shouldNarrate || !board) return;
+  const now = Date.now();
+  if (lastHermesBoardNarrationAtMs > 0 && now - lastHermesBoardNarrationAtMs < monitorNarrationMinIntervalMs) {
+    logger.info(
+      { reason: "min_interval", signature: decision.signature },
+      "monitor_collaboration_board_narration_skipped"
+    );
+    return;
+  }
+
+  inFlightHermesBoardNarrationSignature = decision.signature;
+  const timer = setTimeout(async () => {
+    let text = fallbackHermesBoardNarration(board);
+    const apiKey = optionalEnv("OLLAMA_API_KEY");
+    const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
+    const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";
+    if (apiKey) {
+      try {
+        const llmText = await generateHermesBoardNarration(
+          {
+            board,
+            recentMessages: listCollaborationMessages({ limit: 8 }).map((m) => ({
+              author: m.author,
+              text: m.text,
+              ts: m.ts,
+            })),
+            memoryNotes: listHermesMemoryNotes({ limit: 8 }).map((note) => note.text),
+            trigger: decision.signature,
+          },
+          { apiKey, baseUrl, model, timeoutMs: 6_000 }
+        );
+        if (llmText) text = llmText;
+      } catch (error) {
+        logger.warn({ err: error }, "monitor_collaboration_board_narration_llm_threw");
+      }
+    }
+
+    try {
+      const relatedPr = relatedPrForHermesBoardNarration(board);
+      recordCollaborationMessage({
+        author: "hermes",
+        kind: "status",
+        addressedTo: targetForHermesBoardNarration(board),
+        text,
+        ...(relatedPr ? { relatedPr } : {}),
+      });
+      lastHermesBoardNarrationSignature = decision.signature;
+      lastHermesBoardNarrationAtMs = Date.now();
+    } catch (error) {
+      logger.warn({ err: error }, "monitor_collaboration_board_narration_record_failed");
+    } finally {
+      if (inFlightHermesBoardNarrationSignature === decision.signature) {
+        inFlightHermesBoardNarrationSignature = "";
+      }
+    }
+  }, 900);
+  timer.unref?.();
 }
 
 async function loadCodexTaskQueueSummary() {

--- a/services/slack-operator/src/monitor-hermes-narration.ts
+++ b/services/slack-operator/src/monitor-hermes-narration.ts
@@ -1,0 +1,120 @@
+import type { CollaborationTarget } from "./monitor-collab.js";
+import type { HermesBoardCardSnapshot, HermesBoardSnapshot } from "./monitor-hermes-voice.js";
+
+export interface HermesBoardNarrationDecision {
+  signature: string;
+  shouldNarrate: boolean;
+  reason?: string;
+}
+
+const ACTIONABLE_LANES = new Set([
+  "Needs Attention",
+  "Waiting / Drafts",
+  "Codex Needed",
+  "Hermes Checking",
+  "Operator Review",
+  "Release Queue",
+  "Deploying",
+]);
+
+export function decideHermesBoardNarration(
+  board: HermesBoardSnapshot | undefined,
+  previousSignature: string | undefined,
+  inFlightSignature: string | undefined
+): HermesBoardNarrationDecision {
+  const signature = buildHermesBoardNarrationSignature(board);
+  if (!signature) return { signature: "", shouldNarrate: false, reason: "no_actionable_board_state" };
+  if (signature === previousSignature) return { signature, shouldNarrate: false, reason: "unchanged" };
+  if (signature === inFlightSignature) return { signature, shouldNarrate: false, reason: "already_in_flight" };
+  return { signature, shouldNarrate: true };
+}
+
+export function buildHermesBoardNarrationSignature(board: HermesBoardSnapshot | undefined): string {
+  if (!board || !board.items || board.items.length === 0) return "";
+  const actionable = board.items
+    .filter((item) => ACTIONABLE_LANES.has(item.lane))
+    .slice(0, 6);
+  if (actionable.length === 0) return "";
+  const counts = board.counts ? stableCounts(board.counts) : "";
+  const cards = actionable.map((item) => [
+    item.lane,
+    item.owner,
+    item.repo || "",
+    item.number || "",
+    item.verdict || "",
+    item.why || "",
+    item.next || "",
+  ].join(":"));
+  return [counts, ...cards].filter(Boolean).join("|");
+}
+
+export function fallbackHermesBoardNarration(board: HermesBoardSnapshot): string {
+  const items = board.items?.filter((item) => ACTIONABLE_LANES.has(item.lane)) ?? [];
+  const primary = items[0];
+  if (!primary) {
+    return board.headline || "The board is quiet right now. I do not see a live handoff that needs a next move.";
+  }
+  const label = prLabel(primary);
+  if (primary.lane === "Waiting / Drafts") {
+    return `${label} is parked in Waiting / Drafts: ${sentence(primary.why || "GitHub still marks it as a draft")} I will keep it out of the release path; the next move is ${lowerFirst(primary.next || "wait for the PR author or owning agent")}.`;
+  }
+  if (primary.lane === "Needs Attention") {
+    return `${label} needs attention: ${sentence(primary.why || "a blocking signal is still present")} Current owner is ${primary.owner}; next move is ${lowerFirst(primary.next || "inspect the failing evidence and send back a smaller fix")}.`;
+  }
+  if (primary.lane === "Operator Review") {
+    return `${label} is in Operator Review: ${sentence(primary.why || "Hermes has gone as far as automation safely can")} Pascal, the useful next move is ${lowerFirst(primary.next || "decide whether the risk is acceptable")}.`;
+  }
+  if (primary.lane === "Codex Needed") {
+    return `${label} is Codex-owned now: ${sentence(primary.why || "the board has a task for Codex")} Codex should ${lowerFirst(primary.next || "work the next smallest verifiable step and report back")}.`;
+  }
+  if (primary.lane === "Release Queue") {
+    return `${label} is in the Release Queue: ${sentence(primary.why || "the checks look merge-ready")} The merge steward owns the next move; ${lowerFirst(primary.next || "merge only after branch protection is green")}.`;
+  }
+  if (primary.lane === "Hermes Checking") {
+    return `${label} is with Hermes now: ${sentence(primary.why || "checks are still moving")} I will wait for the evidence to settle before assigning new work.`;
+  }
+  if (primary.lane === "Deploying") {
+    return `${label} is in deploy verification: ${sentence(primary.why || "production checks are still moving")} I will call out a pass or failure when the signal lands.`;
+  }
+  return `${label}: ${sentence(primary.why || board.headline || "the board changed")} Next move is ${lowerFirst(primary.next || "watch the card until the owner changes")}.`;
+}
+
+export function targetForHermesBoardNarration(board: HermesBoardSnapshot): CollaborationTarget {
+  const primary = board.items?.find((item) => ACTIONABLE_LANES.has(item.lane));
+  if (!primary) return "everyone";
+  if (primary.owner === "Codex") return "codex";
+  if (primary.owner === "Operator" || primary.owner === "PR author") return "operator";
+  return "everyone";
+}
+
+export function relatedPrForHermesBoardNarration(board: HermesBoardSnapshot): { repo: string; number: number } | undefined {
+  const items = board.items?.filter((item) => ACTIONABLE_LANES.has(item.lane) && item.repo && item.number) ?? [];
+  if (items.length !== 1) return undefined;
+  const item = items[0];
+  return item.repo && item.number ? { repo: item.repo, number: item.number } : undefined;
+}
+
+function stableCounts(counts: Readonly<Record<string, number | string | boolean>>): string {
+  return Object.keys(counts)
+    .sort()
+    .filter((key) => key !== "recent" && counts[key] !== undefined && counts[key] !== false && counts[key] !== "")
+    .map((key) => `${key}=${String(counts[key])}`)
+    .join(",");
+}
+
+function prLabel(item: HermesBoardCardSnapshot): string {
+  if (item.repo && item.number) return `${item.repo}#${item.number}`;
+  return item.title || "This handoff";
+}
+
+function sentence(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+function lowerFirst(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) return "";
+  return trimmed[0]?.toLowerCase() + trimmed.slice(1);
+}

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -86,6 +86,16 @@ export interface HermesReplyContext {
   board?: HermesBoardSnapshot;
 }
 
+export interface HermesBoardNarrationContext {
+  board: HermesBoardSnapshot;
+  /** Most-recent first. Caller decides how many. */
+  recentMessages: ReadonlyArray<Pick<CollaborationMessage, "author" | "text" | "ts">>;
+  /** Relevant learned guidance from earlier operator posts. */
+  memoryNotes?: ReadonlyArray<string>;
+  /** Why the narrator woke up, usually a compact board signature change. */
+  trigger?: string;
+}
+
 export interface GenerateHermesReplyOptions {
   apiKey: string;
   baseUrl: string;
@@ -141,25 +151,55 @@ export async function generateHermesReply(
   }
 }
 
+export async function generateHermesBoardNarration(
+  context: HermesBoardNarrationContext,
+  options: GenerateHermesReplyOptions
+): Promise<string | null> {
+  if (!options.apiKey) return null;
+  const baseUrl = options.baseUrl.replace(/\/+$/, "");
+  const url = `${baseUrl}/chat/completions`;
+  const model = options.model ?? "deepseek-v4-pro:cloud";
+  const timeoutMs = options.timeoutMs ?? 6_000;
+  const fetchImpl = options.fetchFn ?? fetch;
+
+  const body = {
+    model,
+    messages: [
+      { role: "system", content: HERMES_PERSONA },
+      { role: "user", content: buildBoardNarrationPrompt(context) },
+    ],
+    stream: false,
+    max_tokens: 180,
+    temperature: 0.65,
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${options.apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const json = await response.json().catch(() => null) as unknown;
+    return extractReplyText(json);
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export function buildUserPrompt(context: HermesReplyContext): string {
   const lines: string[] = [];
 
   if (context.board) {
-    lines.push("Live board snapshot (highest-priority evidence; if it conflicts with memory or older chat, trust the board):");
-    if (context.board.generatedAt) lines.push(`- generatedAt: ${context.board.generatedAt}`);
-    if (context.board.status) lines.push(`- status: ${context.board.status}`);
-    if (context.board.headline) lines.push(`- headline: ${truncate(context.board.headline, 360)}`);
-    const counts = formatBoardCounts(context.board.counts);
-    if (counts) lines.push(`- lane counts: ${counts}`);
-    if (context.board.runner) lines.push(`- codex runner: ${truncate(context.board.runner, 260)}`);
-    if (context.board.items && context.board.items.length > 0) {
-      lines.push("- top cards:");
-      for (const item of context.board.items.slice(0, 8)) {
-        lines.push(`  - ${formatBoardCard(item)}`);
-      }
-    } else {
-      lines.push("- top cards: none");
-    }
+    appendBoardSnapshotLines(lines, context.board);
     lines.push("");
   }
 
@@ -210,6 +250,59 @@ export function buildUserPrompt(context: HermesReplyContext): string {
   lines.push("Reply as Hermes in 1-4 conversational sentences. Do not greet, do not summarize Pascal's message, do not pad. Explain the next move if the board state needs one.");
 
   return lines.join("\n");
+}
+
+export function buildBoardNarrationPrompt(context: HermesBoardNarrationContext): string {
+  const lines: string[] = [];
+
+  lines.push("The monitor board changed. Speak proactively as Hermes in the collaboration thread.");
+  if (context.trigger) lines.push(`Trigger: ${truncate(context.trigger, 360)}`);
+  lines.push("");
+
+  appendBoardSnapshotLines(lines, context.board);
+  lines.push("");
+
+  if (context.recentMessages.length > 0) {
+    lines.push("Recent thread (oldest → newest):");
+    for (const m of context.recentMessages) {
+      lines.push(`- ${m.author}: ${truncate(m.text, 260)}`);
+    }
+    lines.push("");
+  }
+
+  if (context.memoryNotes && context.memoryNotes.length > 0) {
+    lines.push("Hermes memory (operator preferences and prior room decisions; use as guidance, not proof):");
+    for (const note of context.memoryNotes) {
+      lines.push(`- ${truncate(note, 240)}`);
+    }
+    lines.push("");
+  }
+
+  lines.push("Narration rules:");
+  lines.push("- 1-3 conversational sentences, no greeting, no filler.");
+  lines.push("- Name what changed, who owns the next move, and whether Pascal/Codex/Hermes should act or wait.");
+  lines.push("- If the board shows drafts parked outside Codex, say they are waiting on the PR author unless Pascal explicitly delegates takeover.");
+  lines.push("- Do not claim you clicked buttons, started Codex, merged, deployed, approved, or changed GitHub.");
+
+  return lines.join("\n");
+}
+
+function appendBoardSnapshotLines(lines: string[], board: HermesBoardSnapshot): void {
+  lines.push("Live board snapshot (highest-priority evidence; if it conflicts with memory or older chat, trust the board):");
+  if (board.generatedAt) lines.push(`- generatedAt: ${board.generatedAt}`);
+  if (board.status) lines.push(`- status: ${board.status}`);
+  if (board.headline) lines.push(`- headline: ${truncate(board.headline, 360)}`);
+  const counts = formatBoardCounts(board.counts);
+  if (counts) lines.push(`- lane counts: ${counts}`);
+  if (board.runner) lines.push(`- codex runner: ${truncate(board.runner, 260)}`);
+  if (board.items && board.items.length > 0) {
+    lines.push("- top cards:");
+    for (const item of board.items.slice(0, 8)) {
+      lines.push(`  - ${formatBoardCard(item)}`);
+    }
+  } else {
+    lines.push("- top cards: none");
+  }
 }
 
 function formatBoardCounts(counts: HermesBoardSnapshot["counts"]): string {

--- a/test/unit/monitor-hermes-narration.test.ts
+++ b/test/unit/monitor-hermes-narration.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHermesBoardNarrationSignature,
+  decideHermesBoardNarration,
+  fallbackHermesBoardNarration,
+  relatedPrForHermesBoardNarration,
+  targetForHermesBoardNarration,
+} from "../../services/slack-operator/src/monitor-hermes-narration.js";
+import type { HermesBoardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
+
+function board(overrides: Partial<HermesBoardSnapshot> = {}): HermesBoardSnapshot {
+  return {
+    headline: "Board now: 1 draft parked; 1 operator decision.",
+    counts: { waiting: 1, operator: 1, recent: 20 },
+    items: [
+      {
+        repo: "averray-agent/agent",
+        number: 439,
+        title: "PR is still marked as draft.",
+        lane: "Waiting / Drafts",
+        owner: "PR author",
+        verdict: "draft",
+        why: "GitHub reports this PR is still a draft.",
+        next: "wait for the PR author unless Pascal explicitly delegates takeover",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("Hermes proactive board narration", () => {
+  it("builds a stable signature that ignores freshness-only fields", () => {
+    const first = buildHermesBoardNarrationSignature(board({
+      generatedAt: "2026-05-21T08:00:00.000Z",
+      items: [{ ...board().items![0], ageLabel: "fresh" }],
+    }));
+    const second = buildHermesBoardNarrationSignature(board({
+      generatedAt: "2026-05-21T08:05:00.000Z",
+      items: [{ ...board().items![0], ageLabel: "5m" }],
+    }));
+    expect(first).toBe(second);
+    expect(first).toContain("Waiting / Drafts");
+    expect(first).toContain("averray-agent/agent");
+  });
+
+  it("does not narrate unchanged or in-flight board state", () => {
+    const signature = buildHermesBoardNarrationSignature(board());
+    expect(decideHermesBoardNarration(board(), signature, "")).toMatchObject({
+      shouldNarrate: false,
+      reason: "unchanged",
+    });
+    expect(decideHermesBoardNarration(board(), "", signature)).toMatchObject({
+      shouldNarrate: false,
+      reason: "already_in_flight",
+    });
+  });
+
+  it("narrates a new actionable board state", () => {
+    const decision = decideHermesBoardNarration(board(), "", "");
+    expect(decision.shouldNarrate).toBe(true);
+    expect(decision.signature).toContain("waiting=1");
+  });
+
+  it("targets the current owner without pretending to message external PR authors", () => {
+    expect(targetForHermesBoardNarration(board())).toBe("operator");
+    expect(targetForHermesBoardNarration(board({
+      counts: { codex: 1 },
+      items: [{ ...board().items![0], lane: "Codex Needed", owner: "Codex", verdict: "delegated draft" }],
+    }))).toBe("codex");
+  });
+
+  it("attaches relatedPr only for a single actionable PR", () => {
+    expect(relatedPrForHermesBoardNarration(board())).toEqual({ repo: "averray-agent/agent", number: 439 });
+    expect(relatedPrForHermesBoardNarration(board({
+      items: [
+        board().items![0],
+        { repo: "averray-reference-agent", number: 179, title: "Operator review", lane: "Operator Review", owner: "Operator" },
+      ],
+    }))).toBeUndefined();
+  });
+
+  it("falls back to a conversational explanation when the LLM is unavailable", () => {
+    const text = fallbackHermesBoardNarration(board());
+    expect(text).toContain("averray-agent/agent#439");
+    expect(text).toContain("Waiting / Drafts");
+    expect(text).toContain("release path");
+    expect(text).toContain("delegates takeover");
+  });
+});

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 
 import {
   HERMES_PERSONA,
+  buildBoardNarrationPrompt,
   buildUserPrompt,
+  generateHermesBoardNarration,
   generateHermesReply,
   type HermesReplyContext,
 } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -132,6 +134,36 @@ describe("buildUserPrompt", () => {
   });
 });
 
+describe("buildBoardNarrationPrompt", () => {
+  it("asks Hermes to proactively narrate board changes without claiming hidden actions", () => {
+    const prompt = buildBoardNarrationPrompt({
+      board: {
+        headline: "Board now: 1 blocked item.",
+        counts: { attention: 1 },
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 438,
+            title: "1 PR check failed",
+            lane: "Needs Attention",
+            owner: "Codex",
+            verdict: "blocked",
+            why: "1 PR check failed.",
+            next: "inspect the failed runner output",
+          },
+        ],
+      },
+      recentMessages: [{ author: "operator", text: "keep it conversational", ts: NOW - 5_000 }],
+      memoryNotes: ["Pascal prefers live, caring Hermes updates."],
+      trigger: "attention=1",
+    });
+    expect(prompt).toContain("The monitor board changed");
+    expect(prompt).toContain("Needs Attention / owner Codex");
+    expect(prompt).toContain("Pascal prefers live");
+    expect(prompt).toContain("Do not claim you clicked buttons");
+  });
+});
+
 describe("generateHermesReply", () => {
   const apiKey = "test-key";
   const baseUrl = "https://ollama.example.com/v1";
@@ -233,5 +265,41 @@ describe("generateHermesReply", () => {
       fetchFn: fetchFn as typeof fetch,
     });
     expect(capturedUrl).toBe("https://ollama.example.com/v1/chat/completions");
+  });
+});
+
+describe("generateHermesBoardNarration", () => {
+  const apiKey = "test-key";
+  const baseUrl = "https://ollama.example.com/v1";
+
+  it("sends a proactive narration prompt to the configured model", async () => {
+    let capturedBody: unknown;
+    const fetchFn = async (_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return jsonResponse({ choices: [{ message: { content: "Codex, averray-agent/agent#438 needs you on the failed check; I will wait for the runner output before moving it." } }] });
+    };
+    const text = await generateHermesBoardNarration(
+      {
+        board: {
+          headline: "Board now: 1 blocked item.",
+          counts: { attention: 1 },
+          items: [
+            {
+              repo: "averray-agent/agent",
+              number: 438,
+              title: "1 PR check failed",
+              lane: "Needs Attention",
+              owner: "Codex",
+            },
+          ],
+        },
+        recentMessages: [],
+      },
+      { apiKey, baseUrl, model: "deepseek-v4-pro:cloud", fetchFn: fetchFn as typeof fetch }
+    );
+    const body = capturedBody as { max_tokens: number; messages: Array<{ role: string; content: string }> };
+    expect(text).toMatch(/averray-agent\/agent#438/);
+    expect(body.max_tokens).toBe(180);
+    expect(body.messages[1].content).toContain("Speak proactively as Hermes");
   });
 });


### PR DESCRIPTION
## What changed
- Added a throttled proactive Hermes narration path for meaningful monitor board changes.
- Uses the board-aware Hermes LLM prompt when Ollama is configured, with a deterministic fallback so the collaboration thread still explains what changed.
- Suppresses narration while building board context for direct operator replies to avoid duplicate chatter.
- Added tests for narration signatures, targeting, fallback copy, and the proactive LLM prompt.

## Checks run
- npm test -- monitor-hermes-voice monitor-hermes-narration monitor-hermes-board
- npm run typecheck
- npm test
- npm run build
- git diff --check

## Impact
- Affects slack-operator / command-center monitor collaboration behavior only.
- No frontend, indexer, contracts, Caddy, public site, VPS secret, or required environment changes.
- Optional env: HERMES_MONITOR_NARRATION_MIN_INTERVAL_MS can tune the default 30s narration throttle.