### PR TITLE
[codex] Teach Hermes memory operator outcomes

### DIFF
--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -20,11 +20,11 @@ import { dirname } from "node:path";
  *
  * Conversation storage is intentionally in-memory and bounded: a ring
  * of the last `MAX_MESSAGES` entries with a 24h soft TTL on read.
- * Hermes memory is a smaller derived layer: operator guidance can be
- * persisted to `HERMES_MONITOR_MEMORY_PATH` so Hermes keeps learning
- * preferences across monitor restarts without treating memory as live
- * proof. Durable full transcripts and per-PR threads remain separate
- * follow-ups.
+ * Hermes memory is a smaller derived layer: operator guidance and
+ * operator outcomes can be persisted to `HERMES_MONITOR_MEMORY_PATH`
+ * so Hermes keeps learning preferences across monitor restarts without
+ * treating memory as live proof. Durable full transcripts and per-PR
+ * threads remain separate follow-ups.
  */
 
 const MAX_MESSAGES = 500;
@@ -260,12 +260,65 @@ function learnHermesMemoryFromMessage(message: CollaborationMessage): void {
 function memoryTextForMessage(message: CollaborationMessage): string | null {
   if (message.author !== "operator") return null;
   if (message.addressedTo === "operator") return null;
+
+  const outcomeMemory = operatorOutcomeMemoryTextForMessage(message);
+  if (outcomeMemory) return outcomeMemory;
+
   if (!looksLikeOperatorGuidance(message.text)) return null;
 
   const compact = message.text.replace(/\s+/g, " ").trim();
   const prRef = message.relatedPr ? `${message.relatedPr.repo}#${message.relatedPr.number}` : null;
   const prefix = prRef ? `Pascal note for ${prRef}: ` : "Pascal preference: ";
   return `${prefix}${compact}`.slice(0, HERMES_MEMORY_NOTE_MAX_CHARS);
+}
+
+function operatorOutcomeMemoryTextForMessage(message: CollaborationMessage): string | null {
+  if (!message.relatedPr) return null;
+
+  const compact = message.text.replace(/\s+/g, " ").trim();
+  const lower = compact.toLowerCase();
+  const prRef = `${message.relatedPr.repo}#${message.relatedPr.number}`;
+  const prefix = `Pascal outcome for ${prRef}: `;
+
+  const outcome = classifyOperatorOutcome(lower);
+  if (!outcome) return null;
+
+  return `${prefix}${outcome}`.slice(0, HERMES_MEMORY_NOTE_MAX_CHARS);
+}
+
+function classifyOperatorOutcome(lower: string): string | null {
+  if (includesAll(lower, ["opened the failed task output", "runner error"])) {
+    return "opened the failed Codex runner output; next move is a smaller retry task or a clear no-code-change explanation.";
+  }
+  if (includesAll(lower, ["please take over", "still a draft"])) {
+    return "delegated draft takeover to Codex; Codex may inspect and finish only verifiable missing work, then mark ready only if complete.";
+  }
+  if (includesAll(lower, ["sending", "back from operator review"])) {
+    return "sent operator review back to Codex because the pre-check was not enough; Codex should make the smallest justified fix or explain no change.";
+  }
+  if (includesAll(lower, ["reopened my local review", "keep it out of the release path"])) {
+    return "reopened local review; keep the PR out of the release path until it is marked reviewed again or sent back to Codex.";
+  }
+  if (includesAll(lower, ["marked", "reviewed for release"])) {
+    return "marked the PR reviewed for release; this is not a merge and it may move toward release only while branch protection stays green.";
+  }
+  if (includesAll(lower, ["accepting the project-level review gate"])) {
+    return "accepted the project-level review gate; if CI or evidence changes, bring the PR back before it moves forward.";
+  }
+  if (includesAll(lower, ["created a proposed task", "not a runner start yet"])) {
+    return "proposed a Codex task but did not start the runner; Codex should hold until the task is explicitly approved.";
+  }
+  if (includesAll(lower, ["approved the task", "allowed to pick it up now"])) {
+    return "approved the Codex task; Codex may pick it up, keep the change bounded, and let Hermes re-check after CI.";
+  }
+  if (includesAll(lower, ["cancelled the codex task"])) {
+    return "cancelled the Codex task; keep the card parked until the next move is clearer or a smaller task is proposed.";
+  }
+  return null;
+}
+
+function includesAll(text: string, cues: string[]): boolean {
+  return cues.every((cue) => text.includes(cue));
 }
 
 function looksLikeOperatorGuidance(text: string): boolean {
@@ -292,6 +345,14 @@ function looksLikeOperatorGuidance(text: string): boolean {
     "codex",
     "hermes",
     "board",
+    "approved",
+    "reviewed",
+    "sent back",
+    "take over",
+    "takeover",
+    "runner start",
+    "pick it up",
+    "reopened",
   ].some((cue) => lower.includes(cue));
 }
 

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -207,6 +207,90 @@ describe("Hermes collaboration memory", () => {
     expect(notes.map((note) => note.text).join("\n")).not.toContain("averray-agent/agent#440");
   });
 
+  it("learns operator outcome memory from failed task review actions", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        kind: "status",
+        addressedTo: "codex",
+        text: "Codex, I opened the failed task output for averray-agent/agent#438. I am looking for the runner error first; the next move is either a smaller retry task or a clear no-code-change explanation.",
+        relatedPr: { repo: "averray-agent/agent", number: 438 },
+      },
+      NOW
+    );
+
+    const notes = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 438 },
+    });
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toMatchObject({
+      scope: "pr",
+      text: expect.stringContaining("failed Codex runner output"),
+      relatedPr: { repo: "averray-agent/agent", number: 438 },
+    });
+  });
+
+  it("learns draft takeover and operator send-back outcomes addressed to Codex", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        kind: "proposal",
+        addressedTo: "codex",
+        text: "Codex, please take over averray-agent/agent#439. It is still a draft, but I want you to inspect the branch, finish only the missing work you can verify, run the relevant checks, and mark it ready only if it is actually complete. Do not merge or deploy.",
+        relatedPr: { repo: "averray-agent/agent", number: 439 },
+      },
+      NOW
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        kind: "request_help",
+        addressedTo: "codex",
+        text: "Codex, I am sending averray-agent/agent#151 back from operator review. Hermes' pre-check is not enough for me to approve it yet: backend changed. Please make the smallest justified fix, or report clearly if the right answer is no code change.",
+        relatedPr: { repo: "averray-agent/agent", number: 151 },
+      },
+      NOW + 1
+    );
+
+    const draftNotes = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 439 },
+    });
+    const sendBackNotes = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 151 },
+    });
+    expect(draftNotes.map((note) => note.text).join("\n")).toContain("delegated draft takeover");
+    expect(sendBackNotes.map((note) => note.text).join("\n")).toContain("sent operator review back to Codex");
+  });
+
+  it("learns local review and Codex task approval outcomes", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        kind: "status",
+        addressedTo: "hermes",
+        text: "Hermes, I reopened my local review for averray-agent/agent#440. Keep it out of the release path until I mark it reviewed again or send it back to Codex.",
+        relatedPr: { repo: "averray-agent/agent", number: 440 },
+      },
+      NOW
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        kind: "approval",
+        addressedTo: "codex",
+        text: "Codex, I approved the task for averray-agent/agent#440. You are allowed to pick it up now; please keep the change bounded, push only if there is a concrete fix, and let Hermes re-check after CI.",
+        relatedPr: { repo: "averray-agent/agent", number: 440 },
+      },
+      NOW + 1
+    );
+
+    const text = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 440 },
+    }).map((note) => note.text).join("\n");
+    expect(text).toContain("reopened local review");
+    expect(text).toContain("approved the Codex task");
+  });
+
   it("does not learn ordinary chatter or Codex-authored messages", () => {
     recordCollaborationMessage(
       { author: "operator", addressedTo: "hermes", text: "thanks, looks good" },
@@ -228,6 +312,22 @@ describe("Hermes collaboration memory", () => {
     recordCollaborationMessage(input, NOW);
     recordCollaborationMessage(input, NOW + 1);
     const notes = listHermesMemoryNotes();
+    expect(notes).toHaveLength(1);
+    expect(notes[0].ts).toBe(NOW + 1);
+  });
+
+  it("deduplicates repeated operator outcome memory", () => {
+    const input = {
+      author: "operator",
+      addressedTo: "codex",
+      text: "Codex, I approved the task for averray-agent/agent#443. You are allowed to pick it up now; please keep the change bounded, push only if there is a concrete fix, and let Hermes re-check after CI.",
+      relatedPr: { repo: "averray-agent/agent", number: 443 },
+    };
+    recordCollaborationMessage(input, NOW);
+    recordCollaborationMessage(input, NOW + 1);
+    const notes = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 443 },
+    });
     expect(notes).toHaveLength(1);
     expect(notes[0].ts).toBe(NOW + 1);
   });


### PR DESCRIPTION
## What changed

- Teach Hermes memory to learn from operator outcomes, not only explicit "remember" guidance.
- Capture PR-scoped memories for failed task review, draft takeover, operator send-back, local review reset, review approval, Codex task proposal/approval/cancel outcomes.
- Keep learning bounded to operator-authored messages so Hermes does not learn from its own narration or Codex self-reports.

## Why

The monitor collaboration thread is becoming the place where Hermes, Codex, and Pascal coordinate. Hermes should remember useful operator decisions over time, so future replies can reflect how similar cards were handled.

## Checks

- `npm test -- monitor-collab`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

## Impact

Affects the Slack/operator monitor collaboration memory layer only. No VPS secret or environment changes required.
