### PR TITLE
[codex] Use Hermes memory in replies

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -44,7 +44,7 @@ import {
   relatedPrForHermesBoardNarration,
   targetForHermesBoardNarration,
 } from "./monitor-hermes-narration.js";
-import { generateHermesBoardNarration, generateHermesReply } from "./monitor-hermes-voice.js";
+import { appendHermesWhyTrace, generateHermesBoardNarration, generateHermesReply } from "./monitor-hermes-voice.js";
 import {
   approveCodexTask,
   cancelCodexTask,
@@ -442,32 +442,32 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
 
   const timer = setTimeout(async () => {
     let text = draft.text;
+    const memoryNotes = listHermesMemoryNotes({
+      ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
+      ...(operatorMessage.relatedCorrelationId ? { relatedCorrelationId: operatorMessage.relatedCorrelationId } : {}),
+      limit: 8,
+    }).map((note) => note.text);
+    const shouldLoadBoard = Boolean(apiKey) || memoryNotes.length > 0;
+    const board = shouldLoadBoard ? await loadHermesBoardSnapshotForReply(operatorMessage) : undefined;
+    const replyContext = {
+      operatorMessage: {
+        text: operatorMessage.text,
+        addressedTo: operatorMessage.addressedTo,
+        kind: operatorMessage.kind,
+        ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
+      },
+      recentMessages: apiKey
+        ? listCollaborationMessages({ limit: 10 }).map((m) => ({ author: m.author, text: m.text, ts: m.ts }))
+        : [],
+      memoryNotes,
+      ...(operatorMessage.relatedPr ? { selectedPr: operatorMessage.relatedPr } : {}),
+      ...(board ? { board } : {}),
+    };
     if (apiKey) {
       try {
-        // Pull the last ~10 messages, oldest-first, so the model sees
-        // the conversation in natural order rather than reversed.
-        const recent = listCollaborationMessages({ limit: 10 });
-        const memoryNotes = listHermesMemoryNotes({
-          ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
-          ...(operatorMessage.relatedCorrelationId ? { relatedCorrelationId: operatorMessage.relatedCorrelationId } : {}),
-          limit: 8,
-        }).map((note) => note.text);
-        const board = await loadHermesBoardSnapshotForReply(operatorMessage);
-        const llmText = await generateHermesReply(
-          {
-            operatorMessage: {
-              text: operatorMessage.text,
-              addressedTo: operatorMessage.addressedTo,
-              kind: operatorMessage.kind,
-              ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
-            },
-            recentMessages: recent.map((m) => ({ author: m.author, text: m.text, ts: m.ts })),
-            memoryNotes,
-            ...(operatorMessage.relatedPr ? { selectedPr: operatorMessage.relatedPr } : {}),
-            ...(board ? { board } : {}),
-          },
-          { apiKey, baseUrl, model }
-        );
+        // replyContext carries the recent thread oldest-first so the
+        // model sees the conversation in natural order rather than reversed.
+        const llmText = await generateHermesReply(replyContext, { apiKey, baseUrl, model });
         if (llmText) {
           text = llmText;
         } else {
@@ -477,6 +477,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
         logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_llm_reply_threw");
       }
     }
+    text = appendHermesWhyTrace(text, replyContext);
     try {
       recordCollaborationMessage({
         author: "hermes",
@@ -1138,25 +1139,24 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
 
   inFlightHermesBoardNarrationSignature = decision.signature;
   const timer = setTimeout(async () => {
-    let text = fallbackHermesBoardNarration(board);
+    const memoryNotes = hermesMemoryNotesForBoard(board, 8);
+    const narrationContext = {
+      board,
+      recentMessages: listCollaborationMessages({ limit: 8 }).map((m) => ({
+        author: m.author,
+        text: m.text,
+        ts: m.ts,
+      })),
+      memoryNotes,
+      trigger: decision.signature,
+    };
+    let text = appendHermesWhyTrace(fallbackHermesBoardNarration(board), narrationContext);
     const apiKey = optionalEnv("OLLAMA_API_KEY");
     const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
     const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";
     if (apiKey) {
       try {
-        const llmText = await generateHermesBoardNarration(
-          {
-            board,
-            recentMessages: listCollaborationMessages({ limit: 8 }).map((m) => ({
-              author: m.author,
-              text: m.text,
-              ts: m.ts,
-            })),
-            memoryNotes: listHermesMemoryNotes({ limit: 8 }).map((note) => note.text),
-            trigger: decision.signature,
-          },
-          { apiKey, baseUrl, model, timeoutMs: 6_000 }
-        );
+        const llmText = await generateHermesBoardNarration(narrationContext, { apiKey, baseUrl, model, timeoutMs: 6_000 });
         if (llmText) text = llmText;
       } catch (error) {
         logger.warn({ err: error }, "monitor_collaboration_board_narration_llm_threw");
@@ -1183,6 +1183,34 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
     }
   }, 900);
   timer.unref?.();
+}
+
+function hermesMemoryNotesForBoard(board: ReturnType<typeof buildHermesBoardSnapshotFromMonitor>, limit: number): string[] {
+  const notes: string[] = [];
+  const seen = new Set<string>();
+  const addNotes = (nextNotes: string[]) => {
+    for (const note of nextNotes) {
+      const key = note.toLowerCase().replace(/\s+/g, " ").trim();
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      notes.push(note);
+      if (notes.length >= limit) return;
+    }
+  };
+
+  for (const item of board?.items?.slice(0, 6) ?? []) {
+    if (notes.length >= limit) break;
+    if (!item.repo || !item.number) continue;
+    addNotes(listHermesMemoryNotes({
+      relatedPr: { repo: item.repo, number: item.number },
+      limit: 4,
+    }).map((note) => note.text));
+  }
+
+  if (notes.length < limit) {
+    addNotes(listHermesMemoryNotes({ limit }).map((note) => note.text));
+  }
+  return notes;
 }
 
 async function loadCodexTaskQueueSummary() {

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -36,6 +36,7 @@ Job:
 - Orchestrate the monitor board: explain what changed, who owns the next move, what is waiting, and what Pascal should decide.
 - Treat the live board snapshot as the highest-priority evidence. If memory or old chat conflicts with the board, say the board wins.
 - Use memory notes to honor Pascal's preferences and prior room decisions. Treat memory as guidance, not live proof.
+- When memory influences your routing, include a final short "Why:" trace that ties the live board signal to the memory cue.
 - Ask for help when a human decision is needed. Hand work to Codex only as a request or recommendation, never as a claim that Codex already acted.
 - Do not silently mutate GitHub, merge, deploy, approve, start Codex work, or mark anything reviewed. Those actions require visible board controls or normal PR workflows.
 
@@ -107,6 +108,13 @@ export interface GenerateHermesReplyOptions {
   fetchFn?: typeof fetch;
 }
 
+export interface HermesWhyTraceContext {
+  memoryNotes?: ReadonlyArray<string>;
+  selectedPr?: HermesReplyPrSnapshot;
+  board?: HermesBoardSnapshot;
+  trigger?: string;
+}
+
 export async function generateHermesReply(
   context: HermesReplyContext,
   options: GenerateHermesReplyOptions
@@ -143,7 +151,8 @@ export async function generateHermesReply(
     });
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
-    return extractReplyText(json);
+    const text = extractReplyText(json);
+    return text ? appendHermesWhyTrace(text, context) : null;
   } catch {
     return null;
   } finally {
@@ -187,7 +196,8 @@ export async function generateHermesBoardNarration(
     });
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
-    return extractReplyText(json);
+    const text = extractReplyText(json);
+    return text ? appendHermesWhyTrace(text, context) : null;
   } catch {
     return null;
   } finally {
@@ -233,6 +243,7 @@ export function buildUserPrompt(context: HermesReplyContext): string {
     for (const note of context.memoryNotes) {
       lines.push(`- ${truncate(note, 260)}`);
     }
+    lines.push("Memory audit: if this guidance changes your routing or tone, include a final one-line `Why:` trace that names the live board signal and memory cue.");
     lines.push("");
   }
 
@@ -275,6 +286,7 @@ export function buildBoardNarrationPrompt(context: HermesBoardNarrationContext):
     for (const note of context.memoryNotes) {
       lines.push(`- ${truncate(note, 240)}`);
     }
+    lines.push("Memory audit: if this guidance changes the narration, include a final one-line `Why:` trace that names the live board signal and memory cue.");
     lines.push("");
   }
 
@@ -285,6 +297,68 @@ export function buildBoardNarrationPrompt(context: HermesBoardNarrationContext):
   lines.push("- Do not claim you clicked buttons, started Codex, merged, deployed, approved, or changed GitHub.");
 
   return lines.join("\n");
+}
+
+export function appendHermesWhyTrace(text: string, context: HermesWhyTraceContext): string {
+  const trimmed = text.trim();
+  if (!trimmed || /^why:/im.test(trimmed)) return trimmed;
+
+  const trace = hermesWhyTrace(context);
+  if (!trace) return trimmed;
+
+  return `${trimmed}\nWhy: ${trace}`.slice(0, 1200);
+}
+
+function hermesWhyTrace(context: HermesWhyTraceContext): string | null {
+  const memory = memoryTrace(context.memoryNotes);
+  if (!memory) return null;
+
+  const board = boardTrace(context);
+  return [board ? `board ${board}` : null, `memory ${memory}`]
+    .filter(Boolean)
+    .join("; ");
+}
+
+function memoryTrace(notes: ReadonlyArray<string> | undefined): string | null {
+  const note = notes?.find((entry) => entry.trim());
+  if (!note) return null;
+  const cleaned = note
+    .replace(/^Pascal (?:preference|note|outcome)(?: for [^:]+)?:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned ? truncate(cleaned, 120) : null;
+}
+
+function boardTrace(context: HermesWhyTraceContext): string | null {
+  const selectedItem = selectedBoardItem(context);
+  if (selectedItem) {
+    const label = tracePrLabel(selectedItem);
+    const owner = selectedItem.owner ? `, ${selectedItem.owner} owns next` : "";
+    return truncate(`${label} in ${selectedItem.lane}${owner}`, 120);
+  }
+  if (context.selectedPr) {
+    return `${context.selectedPr.repo}#${context.selectedPr.number} is selected`;
+  }
+  if (context.board?.headline) return truncate(context.board.headline, 120);
+  if (context.trigger) return truncate(`changed on ${context.trigger}`, 120);
+  return null;
+}
+
+function selectedBoardItem(context: HermesWhyTraceContext): HermesBoardCardSnapshot | undefined {
+  const items = context.board?.items ?? [];
+  if (context.selectedPr) {
+    const selected = items.find((item) =>
+      item.repo?.toLowerCase() === context.selectedPr?.repo.toLowerCase()
+      && item.number === context.selectedPr?.number
+    );
+    if (selected) return selected;
+  }
+  return items[0];
+}
+
+function tracePrLabel(item: HermesBoardCardSnapshot): string {
+  if (item.repo && item.number) return `${item.repo}#${item.number}`;
+  return item.repo || item.title || "card";
 }
 
 function appendBoardSnapshotLines(lines: string[], board: HermesBoardSnapshot): void {

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   HERMES_PERSONA,
+  appendHermesWhyTrace,
   buildBoardNarrationPrompt,
   buildUserPrompt,
   generateHermesBoardNarration,
@@ -44,6 +45,7 @@ describe("HERMES_PERSONA", () => {
     expect(HERMES_PERSONA).toMatch(/never claim/i);
     expect(HERMES_PERSONA).toMatch(/memory notes/i);
     expect(HERMES_PERSONA).toMatch(/visible board controls/i);
+    expect(HERMES_PERSONA).toMatch(/Why:/);
     expect(HERMES_PERSONA).toMatch(/Pascal/);
     expect(HERMES_PERSONA).toMatch(/Codex/);
   });
@@ -94,6 +96,8 @@ describe("buildUserPrompt", () => {
     expect(prompt).toContain("Hermes memory");
     expect(prompt).toContain("draft PRs owned by another agent");
     expect(prompt).toContain("use as guidance, not proof");
+    expect(prompt).toContain("Memory audit");
+    expect(prompt).toContain("Why:");
   });
 
   it("includes live board context as higher-priority evidence", () => {
@@ -161,6 +165,41 @@ describe("buildBoardNarrationPrompt", () => {
     expect(prompt).toContain("Needs Attention / owner Codex");
     expect(prompt).toContain("Pascal prefers live");
     expect(prompt).toContain("Do not claim you clicked buttons");
+    expect(prompt).toContain("Memory audit");
+    expect(prompt).toContain("Why:");
+  });
+});
+
+describe("appendHermesWhyTrace", () => {
+  it("adds a compact board-plus-memory trace when memory is present", () => {
+    const text = appendHermesWhyTrace("I will keep this parked until Pascal delegates it.", {
+      selectedPr: { repo: "averray-agent/agent", number: 439 },
+      board: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 439,
+            title: "PR is still marked as draft.",
+            lane: "Waiting / Drafts",
+            owner: "PR author",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal outcome for averray-agent/agent#439: delegated draft takeover to Codex; Codex may inspect only verifiable missing work.",
+      ],
+    });
+
+    expect(text).toContain("\nWhy:");
+    expect(text).toContain("board averray-agent/agent#439 in Waiting / Drafts");
+    expect(text).toContain("memory delegated draft takeover");
+  });
+
+  it("does not add a trace without memory notes", () => {
+    const text = appendHermesWhyTrace("I will keep watching.", {
+      board: { headline: "Board now: idle." },
+    });
+    expect(text).toBe("I will keep watching.");
   });
 });
 
@@ -173,6 +212,32 @@ describe("generateHermesReply", () => {
       jsonResponse({ choices: [{ message: { content: "Got it. Watching averray-agent/agent#137 — verdict lands here when the checks clear." } }] });
     const text = await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
     expect(text).toMatch(/averray-agent\/agent#137/);
+  });
+
+  it("adds a deterministic why trace when memory guides the reply", async () => {
+    const fetchFn = async (_url: string, _init: RequestInit) =>
+      jsonResponse({ choices: [{ message: { content: "I will keep this in Waiting / Drafts unless Pascal delegates takeover." } }] });
+    const text = await generateHermesReply(baseContext({
+      selectedPr: { repo: "averray-agent/agent", number: 439 },
+      board: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 439,
+            title: "PR is still marked as draft.",
+            lane: "Waiting / Drafts",
+            owner: "PR author",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal note for averray-agent/agent#439: external-agent drafts should wait unless Pascal explicitly delegates takeover.",
+      ],
+    }), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
+
+    expect(text).toContain("\nWhy:");
+    expect(text).toContain("board averray-agent/agent#439 in Waiting / Drafts");
+    expect(text).toContain("memory external-agent drafts should wait");
   });
 
   it("returns null when the API key is empty", async () => {
@@ -301,5 +366,37 @@ describe("generateHermesBoardNarration", () => {
     expect(text).toMatch(/averray-agent\/agent#438/);
     expect(body.max_tokens).toBe(180);
     expect(body.messages[1].content).toContain("Speak proactively as Hermes");
+  });
+
+  it("adds a why trace when board narration receives relevant memory", async () => {
+    const fetchFn = async (_url: string, _init: RequestInit) =>
+      jsonResponse({ choices: [{ message: { content: "Pascal, this draft stays parked unless you explicitly delegate Codex takeover." } }] });
+    const text = await generateHermesBoardNarration(
+      {
+        board: {
+          headline: "Board now: 1 draft parked.",
+          counts: { waiting: 1 },
+          items: [
+            {
+              repo: "averray-agent/agent",
+              number: 439,
+              title: "PR is still marked as draft.",
+              lane: "Waiting / Drafts",
+              owner: "PR author",
+            },
+          ],
+        },
+        recentMessages: [],
+        memoryNotes: [
+          "Pascal preference: drafts owned by another agent should wait unless Pascal delegates takeover.",
+        ],
+        trigger: "waiting=1",
+      },
+      { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch }
+    );
+
+    expect(text).toContain("\nWhy:");
+    expect(text).toContain("board averray-agent/agent#439 in Waiting / Drafts");
+    expect(text).toContain("memory drafts owned by another agent");
   });
 });


### PR DESCRIPTION
## What changed

- Feed PR-scoped Hermes memory into proactive board narration, not just global memory.
- Add a deterministic short `Why:` trace when memory influences Hermes replies or narration.
- Keep the live board as the highest-priority source of truth while using memory as guidance.

## Why

Hermes was learning operator preferences and outcomes, but the board voice did not reliably show how those memories affected routing. This makes Hermes feel more context-aware while keeping each memory-influenced statement auditable.

## Checks

- `npm test -- monitor-hermes-voice`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check`

## Impact

Affects the Slack/operator monitor collaboration voice and narration path only. No VPS secret or environment changes required.
