### PR TITLE
[codex] Add Hermes memory governance

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -32,6 +32,7 @@ import {
 } from "./monitor.js";
 import {
   CollaborationValidationError,
+  classifyHermesMemoryRequest,
   listCollaborationMessages,
   listHermesMemoryNotes,
   recordCollaborationMessage,
@@ -463,7 +464,10 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       ...(operatorMessage.relatedPr ? { selectedPr: operatorMessage.relatedPr } : {}),
       ...(board ? { board } : {}),
     };
-    if (apiKey) {
+    const memoryRequest = classifyHermesMemoryRequest(operatorMessage);
+    if (memoryRequest !== "none") {
+      text = hermesMemoryGovernanceReply(operatorMessage, memoryRequest, memoryNotes);
+    } else if (apiKey) {
       try {
         // replyContext carries the recent thread oldest-first so the
         // model sees the conversation in natural order rather than reversed.
@@ -477,7 +481,9 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
         logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_llm_reply_threw");
       }
     }
-    text = appendHermesWhyTrace(text, replyContext);
+    if (memoryRequest !== "forget_pr") {
+      text = appendHermesWhyTrace(text, replyContext);
+    }
     try {
       recordCollaborationMessage({
         author: "hermes",
@@ -492,6 +498,40 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
     }
   }, 600);
   timer.unref?.();
+}
+
+function hermesMemoryGovernanceReply(
+  operatorMessage: Awaited<ReturnType<typeof recordCollaborationMessage>>,
+  request: ReturnType<typeof classifyHermesMemoryRequest>,
+  memoryNotes: string[]
+): string {
+  const prLabel = operatorMessage.relatedPr
+    ? `${operatorMessage.relatedPr.repo}#${operatorMessage.relatedPr.number}`
+    : "";
+  if (request === "forget_pr") {
+    if (!operatorMessage.relatedPr) {
+      return "I can forget PR-scoped memory, but I need a selected PR first. Pick the card, then say `Hermes, forget this PR memory` and I will clear only that PR's notes.";
+    }
+    return `Done. I cleared any PR-scoped memory I had for ${prLabel}; global Pascal preferences are still intact. If this PR needs a replacement rule, tell me with \`remember:\` and I will learn the corrected version.`;
+  }
+
+  if (!memoryNotes.length) {
+    return prLabel
+      ? `I do not have any remembered guidance for ${prLabel} yet. I will use the live board as the source of truth and learn from your next explicit correction or decision.`
+      : "I do not have any global monitor memory yet. I will learn from explicit `remember:` notes and operator decisions as they happen.";
+  }
+
+  const scope = prLabel ? `for ${prLabel}` : "for the monitor";
+  const bullets = memoryNotes.slice(0, 4).map((note) => `- ${shortMemoryNote(note)}`).join("\n");
+  return `Here is what I remember ${scope}. I will treat this as guidance, not proof; the live board still wins if it disagrees.\n${bullets}`;
+}
+
+function shortMemoryNote(note: string): string {
+  const compact = note
+    .replace(/^Pascal (?:preference|note|outcome)(?: for [^:]+)?:\s*/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return compact.length > 180 ? `${compact.slice(0, 179)}…` : compact;
 }
 
 async function loadHermesBoardSnapshotForReply(

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -65,6 +65,8 @@ export interface HermesMemoryNote {
   relatedCorrelationId?: string;
 }
 
+export type HermesMemoryRequestKind = "show" | "forget_pr" | "none";
+
 export interface RecordCollaborationInput {
   author?: unknown;
   kind?: unknown;
@@ -136,7 +138,9 @@ export function recordCollaborationMessage(
 
   store.push(message);
   while (store.length > MAX_MESSAGES) store.shift();
-  learnHermesMemoryFromMessage(message);
+  if (!applyHermesMemoryGovernanceFromMessage(message)) {
+    learnHermesMemoryFromMessage(message);
+  }
   return message;
 }
 
@@ -162,6 +166,15 @@ export function listHermesMemoryNotes(options: ListHermesMemoryOptions = {}): He
     return false;
   });
   return filtered.slice(-limit);
+}
+
+export function classifyHermesMemoryRequest(message: Pick<CollaborationMessage, "author" | "addressedTo" | "text">): HermesMemoryRequestKind {
+  if (message.author !== "operator") return "none";
+  if (message.addressedTo !== "hermes" && message.addressedTo !== "everyone") return "none";
+  const lower = message.text.toLowerCase();
+  if (isForgetMemoryRequest(lower)) return "forget_pr";
+  if (isShowMemoryRequest(lower)) return "show";
+  return "none";
 }
 
 export function __resetCollaborationStoreForTests(): void {
@@ -257,6 +270,24 @@ function learnHermesMemoryFromMessage(message: CollaborationMessage): void {
   persistHermesMemoryNotes();
 }
 
+function applyHermesMemoryGovernanceFromMessage(message: CollaborationMessage): boolean {
+  loadHermesMemoryIfNeeded();
+  const request = classifyHermesMemoryRequest(message);
+  if (request === "none") return false;
+  if (request !== "forget_pr") return true;
+  if (!message.relatedPr) return true;
+
+  const before = hermesMemoryNotes.length;
+  for (let i = hermesMemoryNotes.length - 1; i >= 0; i -= 1) {
+    const note = hermesMemoryNotes[i];
+    if (note.scope === "pr" && note.relatedPr && samePr(note.relatedPr, message.relatedPr)) {
+      hermesMemoryNotes.splice(i, 1);
+    }
+  }
+  if (hermesMemoryNotes.length !== before) persistHermesMemoryNotes();
+  return true;
+}
+
 function memoryTextForMessage(message: CollaborationMessage): string | null {
   if (message.author !== "operator") return null;
   if (message.addressedTo === "operator") return null;
@@ -319,6 +350,29 @@ function classifyOperatorOutcome(lower: string): string | null {
 
 function includesAll(text: string, cues: string[]): boolean {
   return cues.every((cue) => text.includes(cue));
+}
+
+function includesAny(text: string, cues: string[]): boolean {
+  return cues.some((cue) => text.includes(cue));
+}
+
+function isForgetMemoryRequest(lower: string): boolean {
+  const asksForget = includesAny(lower, ["forget", "clear", "remove", "delete"]);
+  const namesMemory = includesAny(lower, ["memory", "remember", "remembered", "what you know"]);
+  return asksForget && namesMemory;
+}
+
+function isShowMemoryRequest(lower: string): boolean {
+  return includesAny(lower, [
+    "what do you remember",
+    "what are you remembering",
+    "show memory",
+    "show memories",
+    "list memory",
+    "list memories",
+    "memory for this pr",
+    "what memory",
+  ]);
 }
 
 function looksLikeOperatorGuidance(text: string): boolean {

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   CollaborationValidationError,
   __resetCollaborationStoreForTests,
+  classifyHermesMemoryRequest,
   listCollaborationMessages,
   listHermesMemoryNotes,
   recordCollaborationMessage,
@@ -301,6 +302,101 @@ describe("Hermes collaboration memory", () => {
       NOW + 1
     );
     expect(listHermesMemoryNotes()).toEqual([]);
+  });
+
+  it("classifies memory show and forget requests only when Hermes is addressed", () => {
+    expect(classifyHermesMemoryRequest({
+      author: "operator",
+      addressedTo: "hermes",
+      text: "Hermes, what do you remember about this PR?",
+    })).toBe("show");
+    expect(classifyHermesMemoryRequest({
+      author: "operator",
+      addressedTo: "everyone",
+      text: "Hermes, forget this PR memory.",
+    })).toBe("forget_pr");
+    expect(classifyHermesMemoryRequest({
+      author: "codex",
+      addressedTo: "hermes",
+      text: "what do you remember about this PR?",
+    })).toBe("none");
+    expect(classifyHermesMemoryRequest({
+      author: "operator",
+      addressedTo: "codex",
+      text: "what do you remember about this PR?",
+    })).toBe("none");
+  });
+
+  it("does not learn memory governance requests as guidance", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "Hermes, what do you remember about this PR?",
+        relatedPr: { repo: "averray-agent/agent", number: 439 },
+      },
+      NOW
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "Hermes, forget this PR memory.",
+      },
+      NOW + 1
+    );
+
+    expect(listHermesMemoryNotes()).toEqual([]);
+  });
+
+  it("forgets only PR-scoped memory for the selected PR", () => {
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "Remember: ask me before moving external-agent drafts.",
+      },
+      NOW
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "This draft belongs to another agent; do not ask Codex to start it yet.",
+        relatedPr: { repo: "averray-agent/agent", number: 439 },
+      },
+      NOW + 1
+    );
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "This draft belongs to Codex now.",
+        relatedPr: { repo: "averray-agent/agent", number: 440 },
+      },
+      NOW + 2
+    );
+
+    recordCollaborationMessage(
+      {
+        author: "operator",
+        addressedTo: "hermes",
+        text: "Hermes, forget this PR memory.",
+        relatedPr: { repo: "averray-agent/agent", number: 439 },
+      },
+      NOW + 3
+    );
+
+    const pr439 = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 439 },
+    }).map((note) => note.text).join("\n");
+    const pr440 = listHermesMemoryNotes({
+      relatedPr: { repo: "averray-agent/agent", number: 440 },
+    }).map((note) => note.text).join("\n");
+
+    expect(pr439).toContain("external-agent drafts");
+    expect(pr439).not.toContain("averray-agent/agent#439");
+    expect(pr440).toContain("averray-agent/agent#440");
   });
 
   it("deduplicates repeated guidance", () => {


### PR DESCRIPTION
## What changed
- Added Hermes memory governance commands for collaboration chat: show remembered guidance and forget PR-scoped memory.
- Prevented memory-management prompts from being learned as guidance.
- Kept forget scoped to the selected PR so global Pascal preferences stay intact.

## Checks
- npm test -- monitor-collab
- npm run typecheck
- npm test
- npm run build
- git diff --check

## Impact
- Affects the Slack/operator monitor backend and collaboration memory behavior.
- No environment or VPS secret changes required.