### PR TITLE
[codex] Make Hermes memory shape narration

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -45,7 +45,12 @@ import {
   relatedPrForHermesBoardNarration,
   targetForHermesBoardNarration,
 } from "./monitor-hermes-narration.js";
-import { appendHermesWhyTrace, generateHermesBoardNarration, generateHermesReply } from "./monitor-hermes-voice.js";
+import {
+  appendHermesWhyTrace,
+  applyHermesMemoryInfluence,
+  generateHermesBoardNarration,
+  generateHermesReply,
+} from "./monitor-hermes-voice.js";
 import {
   approveCodexTask,
   cancelCodexTask,
@@ -482,7 +487,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       }
     }
     if (memoryRequest !== "forget_pr") {
-      text = appendHermesWhyTrace(text, replyContext);
+      text = appendHermesWhyTrace(applyHermesMemoryInfluence(text, replyContext), replyContext);
     }
     try {
       recordCollaborationMessage({
@@ -1190,7 +1195,10 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
       memoryNotes,
       trigger: decision.signature,
     };
-    let text = appendHermesWhyTrace(fallbackHermesBoardNarration(board), narrationContext);
+    let text = appendHermesWhyTrace(
+      fallbackHermesBoardNarration(board, { memoryNotes }),
+      narrationContext
+    );
     const apiKey = optionalEnv("OLLAMA_API_KEY");
     const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
     const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";

--- a/services/slack-operator/src/monitor-hermes-narration.ts
+++ b/services/slack-operator/src/monitor-hermes-narration.ts
@@ -1,10 +1,18 @@
 import type { CollaborationTarget } from "./monitor-collab.js";
-import type { HermesBoardCardSnapshot, HermesBoardSnapshot } from "./monitor-hermes-voice.js";
+import {
+  applyHermesMemoryInfluence,
+  type HermesBoardCardSnapshot,
+  type HermesBoardSnapshot,
+} from "./monitor-hermes-voice.js";
 
 export interface HermesBoardNarrationDecision {
   signature: string;
   shouldNarrate: boolean;
   reason?: string;
+}
+
+export interface HermesFallbackNarrationOptions {
+  memoryNotes?: ReadonlyArray<string>;
 }
 
 const ACTIONABLE_LANES = new Set([
@@ -48,7 +56,17 @@ export function buildHermesBoardNarrationSignature(board: HermesBoardSnapshot | 
   return [counts, ...cards].filter(Boolean).join("|");
 }
 
-export function fallbackHermesBoardNarration(board: HermesBoardSnapshot): string {
+export function fallbackHermesBoardNarration(
+  board: HermesBoardSnapshot,
+  options: HermesFallbackNarrationOptions = {}
+): string {
+  return applyHermesMemoryInfluence(fallbackHermesBoardNarrationBase(board), {
+    board,
+    memoryNotes: options.memoryNotes,
+  });
+}
+
+function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
   const items = board.items?.filter((item) => ACTIONABLE_LANES.has(item.lane)) ?? [];
   const primary = items[0];
   if (!primary) {

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -115,6 +115,12 @@ export interface HermesWhyTraceContext {
   trigger?: string;
 }
 
+export interface HermesMemoryInfluence {
+  sentence: string;
+  trace: string;
+  conflict: boolean;
+}
+
 export async function generateHermesReply(
   context: HermesReplyContext,
   options: GenerateHermesReplyOptions
@@ -152,7 +158,7 @@ export async function generateHermesReply(
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
     const text = extractReplyText(json);
-    return text ? appendHermesWhyTrace(text, context) : null;
+    return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
   } catch {
     return null;
   } finally {
@@ -197,7 +203,7 @@ export async function generateHermesBoardNarration(
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
     const text = extractReplyText(json);
-    return text ? appendHermesWhyTrace(text, context) : null;
+    return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
   } catch {
     return null;
   } finally {
@@ -309,8 +315,85 @@ export function appendHermesWhyTrace(text: string, context: HermesWhyTraceContex
   return `${trimmed}\nWhy: ${trace}`.slice(0, 1200);
 }
 
+export function applyHermesMemoryInfluence(text: string, context: HermesWhyTraceContext): string {
+  const trimmed = text.trim();
+  if (!trimmed) return trimmed;
+  if (/\b(memory conflict|remembered|memory says|your guidance)\b/i.test(trimmed)) return trimmed;
+
+  const influence = hermesMemoryInfluence(context);
+  if (!influence) return trimmed;
+
+  const whyIndex = trimmed.search(/\nWhy:/i);
+  if (whyIndex >= 0) {
+    return `${trimmed.slice(0, whyIndex).trim()}\n${influence.sentence}\n${trimmed.slice(whyIndex + 1)}`.slice(0, 1200);
+  }
+  return `${trimmed}\n${influence.sentence}`.slice(0, 1200);
+}
+
+export function hermesMemoryInfluence(context: HermesWhyTraceContext): HermesMemoryInfluence | null {
+  const note = relevantMemoryNote(context);
+  if (!note) return null;
+  const cleaned = cleanMemoryNote(note);
+  if (!cleaned) return null;
+
+  const item = selectedBoardItem(context);
+  const lowerNote = cleaned.toLowerCase();
+  const lane = item?.lane ?? context.selectedPr?.lane ?? "";
+  const owner = item?.owner ?? "";
+  const boardSaysCodex = owner === "Codex" || lane === "Codex Needed";
+  const noteSaysExternalDraftWait = saysExternalDraftShouldWait(lowerNote);
+  const noteSaysDelegatedCodex = saysDelegatedCodex(lowerNote);
+
+  if (boardSaysCodex && noteSaysExternalDraftWait && !noteSaysDelegatedCodex) {
+    return {
+      conflict: true,
+      sentence: "I see a memory conflict: the live board says Codex owns the next move, but your remembered draft rule says external-agent drafts should wait unless you delegate takeover. I will trust the live board for now; correct me if this is still external-owned.",
+      trace: "live board assigns Codex while memory says external-agent drafts wait",
+    };
+  }
+
+  if (lane === "Waiting / Drafts" && noteSaysExternalDraftWait) {
+    return {
+      conflict: false,
+      sentence: "This matches your remembered draft rule: keep external-agent drafts parked unless Pascal explicitly delegates takeover.",
+      trace: "draft lane matches external-agent draft memory",
+    };
+  }
+
+  if (lane === "Operator Review" && saysOperatorReviewBoundary(lowerNote)) {
+    return {
+      conflict: false,
+      sentence: "I am applying your remembered review boundary here: backend or review-gated risk gets an operator decision, not another automatic handoff.",
+      trace: "operator-review lane matches review-boundary memory",
+    };
+  }
+
+  if (lane === "Release Queue" && saysReleaseQueueBoundary(lowerNote)) {
+    return {
+      conflict: false,
+      sentence: "I am applying your remembered release rule: the queue waits for merge-steward ownership and green branch protection rather than treating green checks as a merge.",
+      trace: "release queue matches merge-steward memory",
+    };
+  }
+
+  if (boardSaysCodex && noteSaysDelegatedCodex) {
+    return {
+      conflict: false,
+      sentence: "I am applying your remembered delegation rule: Codex should take the smallest verifiable step and report back through Hermes.",
+      trace: "Codex ownership matches delegation memory",
+    };
+  }
+
+  return {
+    conflict: false,
+    sentence: `I am carrying forward your remembered guidance here: ${truncate(cleaned, 160)}`,
+    trace: truncate(cleaned, 120),
+  };
+}
+
 function hermesWhyTrace(context: HermesWhyTraceContext): string | null {
-  const memory = memoryTrace(context.memoryNotes);
+  const influence = hermesMemoryInfluence(context);
+  const memory = influence?.trace ?? memoryTrace(context);
   if (!memory) return null;
 
   const board = boardTrace(context);
@@ -319,14 +402,74 @@ function hermesWhyTrace(context: HermesWhyTraceContext): string | null {
     .join("; ");
 }
 
-function memoryTrace(notes: ReadonlyArray<string> | undefined): string | null {
-  const note = notes?.find((entry) => entry.trim());
+function memoryTrace(context: HermesWhyTraceContext): string | null {
+  const note = relevantMemoryNote(context);
   if (!note) return null;
-  const cleaned = note
+  const cleaned = cleanMemoryNote(note);
+  return cleaned ? truncate(cleaned, 120) : null;
+}
+
+function relevantMemoryNote(context: HermesWhyTraceContext): string | null {
+  const notes = context.memoryNotes?.filter((entry) => entry.trim()) ?? [];
+  if (notes.length === 0) return null;
+  const item = selectedBoardItem(context);
+  const pr = item?.repo && item.number
+    ? { repo: item.repo, number: item.number }
+    : context.selectedPr
+      ? { repo: context.selectedPr.repo, number: context.selectedPr.number }
+      : undefined;
+  if (!pr) return notes[0];
+
+  const repoLower = pr.repo.toLowerCase();
+  const prRef = `${repoLower}#${pr.number}`;
+  return notes.find((note) => {
+    const lower = note.toLowerCase();
+    return lower.includes(prRef) || lower.includes(`#${pr.number}`);
+  }) ?? notes[0];
+}
+
+function cleanMemoryNote(note: string): string {
+  return note
     .replace(/^Pascal (?:preference|note|outcome)(?: for [^:]+)?:\s*/i, "")
     .replace(/\s+/g, " ")
     .trim();
-  return cleaned ? truncate(cleaned, 120) : null;
+}
+
+function saysExternalDraftShouldWait(lower: string): boolean {
+  return lower.includes("draft")
+    && (
+      lower.includes("external agent")
+      || lower.includes("external-agent")
+      || lower.includes("another agent")
+      || lower.includes("other agent")
+      || lower.includes("pr author")
+      || lower.includes("owning agent")
+    )
+    && (lower.includes("wait") || lower.includes("park") || lower.includes("stay out") || lower.includes("do not ask codex") || lower.includes("unless pascal"));
+}
+
+function saysDelegatedCodex(lower: string): boolean {
+  return lower.includes("codex")
+    && (lower.includes("delegated") || lower.includes("take over") || lower.includes("takeover") || lower.includes("approved") || lower.includes("allowed to pick"));
+}
+
+function saysOperatorReviewBoundary(lower: string): boolean {
+  return (lower.includes("operator") || lower.includes("review"))
+    && (
+      lower.includes("backend")
+      || lower.includes("review-gated")
+      || lower.includes("review gated")
+      || lower.includes("risk")
+      || lower.includes("sign-off")
+      || lower.includes("signoff")
+      || lower.includes("project-level")
+      || lower.includes("project level")
+    );
+}
+
+function saysReleaseQueueBoundary(lower: string): boolean {
+  return (lower.includes("release queue") || lower.includes("merge steward") || lower.includes("branch protection"))
+    && (lower.includes("merge") || lower.includes("green") || lower.includes("release"));
 }
 
 function boardTrace(context: HermesWhyTraceContext): string | null {

--- a/test/unit/monitor-hermes-narration.test.ts
+++ b/test/unit/monitor-hermes-narration.test.ts
@@ -87,4 +87,15 @@ describe("Hermes proactive board narration", () => {
     expect(text).toContain("release path");
     expect(text).toContain("delegates takeover");
   });
+
+  it("lets memory shape fallback narration when the LLM is unavailable", () => {
+    const text = fallbackHermesBoardNarration(board(), {
+      memoryNotes: [
+        "Pascal preference: external agent draft PRs should wait unless Pascal explicitly delegates takeover.",
+      ],
+    });
+
+    expect(text).toContain("remembered draft rule");
+    expect(text).toContain("unless Pascal explicitly delegates takeover");
+  });
 });

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from "vitest";
 import {
   HERMES_PERSONA,
   appendHermesWhyTrace,
+  applyHermesMemoryInfluence,
   buildBoardNarrationPrompt,
   buildUserPrompt,
   generateHermesBoardNarration,
   generateHermesReply,
+  hermesMemoryInfluence,
   type HermesReplyContext,
 } from "../../services/slack-operator/src/monitor-hermes-voice.js";
 
@@ -203,6 +205,120 @@ describe("appendHermesWhyTrace", () => {
   });
 });
 
+describe("applyHermesMemoryInfluence", () => {
+  it("uses remembered draft rules when a draft is parked outside Codex", () => {
+    const text = applyHermesMemoryInfluence("averray-agent/agent#439 is parked in Waiting / Drafts.", {
+      board: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 439,
+            title: "PR is still marked as draft.",
+            lane: "Waiting / Drafts",
+            owner: "PR author",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal preference: external agent draft PRs should wait unless Pascal explicitly delegates takeover.",
+      ],
+    });
+
+    expect(text).toContain("remembered draft rule");
+    expect(text).toContain("unless Pascal explicitly delegates takeover");
+  });
+
+  it("calls out a conflict when the board asks Codex to own an external draft", () => {
+    const context = {
+      board: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 439,
+            title: "PR is still marked as draft.",
+            lane: "Codex Needed",
+            owner: "Codex",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal preference: external agent draft PRs should wait unless Pascal explicitly delegates takeover.",
+      ],
+    };
+
+    const influence = hermesMemoryInfluence(context);
+    const text = applyHermesMemoryInfluence("Codex should inspect the draft next.", context);
+
+    expect(influence?.conflict).toBe(true);
+    expect(text).toContain("memory conflict");
+    expect(text).toContain("trust the live board");
+  });
+
+  it("uses remembered operator-review boundaries for review-gated backend risk", () => {
+    const text = applyHermesMemoryInfluence("Pascal, this one needs an operator decision.", {
+      board: {
+        items: [
+          {
+            repo: "averray-reference-agent",
+            number: 183,
+            title: "2 changed files touch review-gated surfaces.",
+            lane: "Operator Review",
+            owner: "Operator",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal note: backend review-gated risk needs operator sign-off instead of another automatic handoff.",
+      ],
+    });
+
+    expect(text).toContain("remembered review boundary");
+    expect(text).toContain("operator decision");
+  });
+
+  it("uses remembered release queue boundaries before merge", () => {
+    const text = applyHermesMemoryInfluence("averray-agent/agent#440 is in the Release Queue.", {
+      board: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 440,
+            title: "Live GitHub PR metadata and checks look merge-ready.",
+            lane: "Release Queue",
+            owner: "Queue",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal preference: release queue waits for merge steward ownership and branch protection green.",
+      ],
+    });
+
+    expect(text).toContain("remembered release rule");
+    expect(text).toContain("merge-steward ownership");
+  });
+
+  it("does not duplicate a memory sentence that already exists", () => {
+    const text = "This matches your remembered draft rule: keep external-agent drafts parked.";
+    expect(applyHermesMemoryInfluence(text, {
+      board: {
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 439,
+            title: "PR is still marked as draft.",
+            lane: "Waiting / Drafts",
+            owner: "PR author",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Pascal preference: external agent draft PRs should wait unless Pascal explicitly delegates takeover.",
+      ],
+    })).toBe(text);
+  });
+});
+
 describe("generateHermesReply", () => {
   const apiKey = "test-key";
   const baseUrl = "https://ollama.example.com/v1";
@@ -237,7 +353,7 @@ describe("generateHermesReply", () => {
 
     expect(text).toContain("\nWhy:");
     expect(text).toContain("board averray-agent/agent#439 in Waiting / Drafts");
-    expect(text).toContain("memory external-agent drafts should wait");
+    expect(text).toContain("memory draft lane matches external-agent draft memory");
   });
 
   it("returns null when the API key is empty", async () => {
@@ -397,6 +513,6 @@ describe("generateHermesBoardNarration", () => {
 
     expect(text).toContain("\nWhy:");
     expect(text).toContain("board averray-agent/agent#439 in Waiting / Drafts");
-    expect(text).toContain("memory drafts owned by another agent");
+    expect(text).toContain("memory draft lane matches external-agent draft memory");
   });
 });


### PR DESCRIPTION
## What changed
- Added deterministic memory influence for Hermes replies and board narration so remembered rules affect the actual spoken line, not only the audit footer.
- Wired memory influence into LLM replies, fallback chat replies, and fallback board narration.
- Added tests for draft parking, Codex/memory conflicts, operator-review boundaries, release queue boundaries, and fallback narration.

## Areas affected
- Backend/slack-operator monitor collaboration only.
- No frontend, indexer, contracts, Caddy, public site, or VPS secret changes.

## Checks
- npm test
- npm run typecheck
- npm run build
- git diff --check