### PR TITLE
[codex] Teach Hermes decision coaching

### DIFF
--- a/services/slack-operator/src/monitor-hermes-narration.ts
+++ b/services/slack-operator/src/monitor-hermes-narration.ts
@@ -1,6 +1,7 @@
 import type { CollaborationTarget } from "./monitor-collab.js";
 import {
   applyHermesMemoryInfluence,
+  hermesDecisionCoachForCard,
   type HermesBoardCardSnapshot,
   type HermesBoardSnapshot,
 } from "./monitor-hermes-voice.js";
@@ -74,19 +75,31 @@ function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
   }
   const label = prLabel(primary);
   if (primary.lane === "Waiting / Drafts") {
-    return `${label} is parked in Waiting / Drafts: ${sentence(primary.why || "GitHub still marks it as a draft")} I will keep it out of the release path; the next move is ${lowerFirst(primary.next || "wait for the PR author or owning agent")}.`;
+    return decisionNarration(
+      primary,
+      `${label} is parked in Waiting / Drafts: ${sentence(primary.why || "GitHub still marks it as a draft")} I will keep it out of the release path.`
+    );
   }
   if (primary.lane === "Needs Attention") {
-    return `${label} needs attention: ${sentence(primary.why || "a blocking signal is still present")} Current owner is ${primary.owner}; next move is ${lowerFirst(primary.next || "inspect the failing evidence and send back a smaller fix")}.`;
+    return decisionNarration(
+      primary,
+      `${label} needs attention: ${sentence(primary.why || "a blocking signal is still present")} Current owner is ${primary.owner}.`
+    );
   }
   if (primary.lane === "Operator Review") {
-    return `${label} is in Operator Review: ${sentence(primary.why || "Hermes has gone as far as automation safely can")} Pascal, the useful next move is ${lowerFirst(primary.next || "decide whether the risk is acceptable")}.`;
+    return decisionNarration(
+      primary,
+      `${label} is in Operator Review: ${sentence(primary.why || "Hermes has gone as far as automation safely can")} Pascal, this is a project-level decision, not more hidden automation.`
+    );
   }
   if (primary.lane === "Codex Needed") {
     return `${label} is Codex-owned now: ${sentence(primary.why || "the board has a task for Codex")} Codex should ${lowerFirst(primary.next || "work the next smallest verifiable step and report back")}.`;
   }
   if (primary.lane === "Release Queue") {
-    return `${label} is in the Release Queue: ${sentence(primary.why || "the checks look merge-ready")} The merge steward owns the next move; ${lowerFirst(primary.next || "merge only after branch protection is green")}.`;
+    return decisionNarration(
+      primary,
+      `${label} is in the Release Queue: ${sentence(primary.why || "the checks look merge-ready")} The merge steward owns the next move.`
+    );
   }
   if (primary.lane === "Hermes Checking") {
     return `${label} is with Hermes now: ${sentence(primary.why || "checks are still moving")} I will wait for the evidence to settle before assigning new work.`;
@@ -95,6 +108,18 @@ function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
     return `${label} is in deploy verification: ${sentence(primary.why || "production checks are still moving")} I will call out a pass or failure when the signal lands.`;
   }
   return `${label}: ${sentence(primary.why || board.headline || "the board changed")} Next move is ${lowerFirst(primary.next || "watch the card until the owner changes")}.`;
+}
+
+function decisionNarration(item: HermesBoardCardSnapshot, opening: string): string {
+  const coach = hermesDecisionCoachForCard(item);
+  if (!coach) {
+    return `${opening} Next move is ${lowerFirst(item.next || "watch the card until the owner changes")}.`;
+  }
+  return [
+    opening,
+    `The button ${coach.button}; ${coach.avoid}.`,
+    `Safest next step: ${coach.safestNext}.`,
+  ].join(" ");
 }
 
 export function targetForHermesBoardNarration(board: HermesBoardSnapshot): CollaborationTarget {

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -121,6 +121,12 @@ export interface HermesMemoryInfluence {
   conflict: boolean;
 }
 
+export interface HermesDecisionCoach {
+  button: string;
+  avoid: string;
+  safestNext: string;
+}
+
 export async function generateHermesReply(
   context: HermesReplyContext,
   options: GenerateHermesReplyOptions
@@ -299,6 +305,7 @@ export function buildBoardNarrationPrompt(context: HermesBoardNarrationContext):
   lines.push("Narration rules:");
   lines.push("- 1-3 conversational sentences, no greeting, no filler.");
   lines.push("- Name what changed, who owns the next move, and whether Pascal/Codex/Hermes should act or wait.");
+  lines.push("- For decision lanes, coach the decision: say what the visible button opens, what it does not do, and the safest next step.");
   lines.push("- If the board shows drafts parked outside Codex, say they are waiting on the PR author unless Pascal explicitly delegates takeover.");
   lines.push("- Do not claim you clicked buttons, started Codex, merged, deployed, approved, or changed GitHub.");
 
@@ -389,6 +396,42 @@ export function hermesMemoryInfluence(context: HermesWhyTraceContext): HermesMem
     sentence: `I am carrying forward your remembered guidance here: ${truncate(cleaned, 160)}`,
     trace: truncate(cleaned, 120),
   };
+}
+
+export function hermesDecisionCoachForCard(item: HermesBoardCardSnapshot): HermesDecisionCoach | null {
+  if (item.lane === "Waiting / Drafts") {
+    return {
+      button: "opens draft context only; it does not start Codex work",
+      avoid: "do not route this to Codex unless Pascal explicitly delegates takeover",
+      safestNext: "wait for the PR author or owning agent to mark it ready, then let CI and Hermes re-check",
+    };
+  }
+
+  if (item.lane === "Needs Attention") {
+    return {
+      button: "opens the blocker or failed-task evidence; it does not repair the PR by itself",
+      avoid: "do not approve, merge, or rerun blindly while the red signal is still unexplained",
+      safestNext: "inspect the failing output or PR signal, then ask Codex for the smallest verifiable fix or a smaller retry task",
+    };
+  }
+
+  if (item.lane === "Operator Review") {
+    return {
+      button: "opens the operator checklist; approval is a local monitor sign-off, not a merge",
+      avoid: "do not re-review code line by line if Hermes/Codex already attached the code-level pre-check",
+      safestNext: "decide whether project intent, architecture direction, rollout risk, and evidence are acceptable; send it back to Codex with a concrete ask if not",
+    };
+  }
+
+  if (item.lane === "Release Queue") {
+    return {
+      button: "asks for merge-steward context; it does not merge the PR",
+      avoid: "do not treat a green-looking card as permission to bypass branch protection or missing sign-off",
+      safestNext: "merge outside the monitor only after branch protection is green and any operator sign-off is clean",
+    };
+  }
+
+  return null;
 }
 
 function hermesWhyTrace(context: HermesWhyTraceContext): string | null {
@@ -532,6 +575,7 @@ function formatBoardCounts(counts: HermesBoardSnapshot["counts"]): string {
 
 function formatBoardCard(item: HermesBoardCardSnapshot): string {
   const pr = item.repo && item.number ? `${item.repo}#${item.number}` : item.repo || "unknown PR";
+  const coach = hermesDecisionCoachForCard(item);
   const parts = [
     `${item.lane} / owner ${item.owner}`,
     pr,
@@ -540,6 +584,9 @@ function formatBoardCard(item: HermesBoardCardSnapshot): string {
     `title ${truncate(item.title, 140)}`,
     item.why ? `why ${truncate(item.why, 220)}` : "",
     item.next ? `next ${truncate(item.next, 220)}` : "",
+    coach ? `button ${coach.button}` : "",
+    coach ? `avoid ${coach.avoid}` : "",
+    coach ? `safest ${coach.safestNext}` : "",
     item.tags && item.tags.length > 0 ? `tags ${item.tags.slice(0, 5).join(", ")}` : "",
   ].filter(Boolean);
   return parts.join(" | ");

--- a/test/unit/monitor-hermes-narration.test.ts
+++ b/test/unit/monitor-hermes-narration.test.ts
@@ -98,4 +98,50 @@ describe("Hermes proactive board narration", () => {
     expect(text).toContain("remembered draft rule");
     expect(text).toContain("unless Pascal explicitly delegates takeover");
   });
+
+  it("coaches operator-review decisions in fallback narration", () => {
+    const text = fallbackHermesBoardNarration(board({
+      counts: { operator: 1 },
+      items: [
+        {
+          repo: "averray-reference-agent",
+          number: 183,
+          title: "2 changed files touch review-gated surfaces.",
+          lane: "Operator Review",
+          owner: "Operator",
+          verdict: "needs review",
+          why: "Hermes has already done the code-level pre-check.",
+          next: "decide whether project intent and rollout risk are acceptable",
+        },
+      ],
+    }));
+
+    expect(text).toContain("project-level decision");
+    expect(text).toContain("button opens the operator checklist");
+    expect(text).toContain("approval is a local monitor sign-off, not a merge");
+    expect(text).toContain("Safest next step");
+    expect(text).toContain("send it back to Codex with a concrete ask");
+  });
+
+  it("coaches release queue decisions without implying the monitor merges", () => {
+    const text = fallbackHermesBoardNarration(board({
+      counts: { queue: 1 },
+      items: [
+        {
+          repo: "averray-agent/agent",
+          number: 440,
+          title: "Live GitHub PR metadata and checks look merge-ready.",
+          lane: "Release Queue",
+          owner: "Merge steward",
+          verdict: "ready",
+          why: "Live GitHub PR metadata and checks look merge-ready.",
+          next: "merge only after branch protection is green",
+        },
+      ],
+    }));
+
+    expect(text).toContain("button asks for merge-steward context");
+    expect(text).toContain("it does not merge the PR");
+    expect(text).toContain("branch protection is green");
+  });
 });

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -8,6 +8,7 @@ import {
   buildUserPrompt,
   generateHermesBoardNarration,
   generateHermesReply,
+  hermesDecisionCoachForCard,
   hermesMemoryInfluence,
   type HermesReplyContext,
 } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -169,6 +170,60 @@ describe("buildBoardNarrationPrompt", () => {
     expect(prompt).toContain("Do not claim you clicked buttons");
     expect(prompt).toContain("Memory audit");
     expect(prompt).toContain("Why:");
+  });
+
+  it("includes lane-specific decision coaching in the board prompt", () => {
+    const prompt = buildBoardNarrationPrompt({
+      board: {
+        headline: "Board now: 1 operator decision.",
+        counts: { operator: 1 },
+        items: [
+          {
+            repo: "averray-reference-agent",
+            number: 183,
+            title: "2 changed files touch review-gated surfaces.",
+            lane: "Operator Review",
+            owner: "Operator",
+            verdict: "needs review",
+            why: "Hermes has already done the code-level pre-check.",
+            next: "decide whether project intent and rollout risk are acceptable",
+          },
+        ],
+      },
+      recentMessages: [],
+    });
+
+    expect(prompt).toContain("For decision lanes, coach the decision");
+    expect(prompt).toContain("button opens the operator checklist");
+    expect(prompt).toContain("approval is a local monitor sign-off, not a merge");
+    expect(prompt).toContain("avoid do not re-review code line by line");
+    expect(prompt).toContain("safest decide whether project intent");
+  });
+});
+
+describe("hermesDecisionCoachForCard", () => {
+  it("explains what key lane buttons do and do not do", () => {
+    expect(hermesDecisionCoachForCard({
+      repo: "averray-agent/agent",
+      number: 438,
+      title: "1 PR check failed.",
+      lane: "Needs Attention",
+      owner: "Codex",
+    })?.button).toContain("failed-task evidence");
+    expect(hermesDecisionCoachForCard({
+      repo: "averray-agent/agent",
+      number: 439,
+      title: "PR is still marked as draft.",
+      lane: "Waiting / Drafts",
+      owner: "PR author",
+    })?.avoid).toContain("unless Pascal explicitly delegates takeover");
+    expect(hermesDecisionCoachForCard({
+      repo: "averray-agent/agent",
+      number: 440,
+      title: "Ready to merge.",
+      lane: "Release Queue",
+      owner: "Merge steward",
+    })?.button).toContain("does not merge");
   });
 });
 


### PR DESCRIPTION
## What changed
- Added shared lane-specific decision coaching for Waiting / Drafts, Needs Attention, Operator Review, and Release Queue cards.
- Fed that coaching into Hermes board narration prompts so the LLM can explain what the visible button does, what it does not do, and the safest next step.
- Updated fallback narration so Hermes still gives clear operator guidance when the LLM path is unavailable.

## Impact
- Affects the slack-operator monitor collaboration backend only.
- No frontend, indexer, contracts, Caddy, public site, generated output, or VPS secret changes.

## Checks
- `npm test -- monitor-hermes-voice monitor-hermes-narration`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `npm test`