### PR TITLE
[codex] Make Hermes handoffs owner-specific

### DIFF
--- a/services/slack-operator/src/monitor-hermes-narration.ts
+++ b/services/slack-operator/src/monitor-hermes-narration.ts
@@ -2,6 +2,7 @@ import type { CollaborationTarget } from "./monitor-collab.js";
 import {
   applyHermesMemoryInfluence,
   hermesDecisionCoachForCard,
+  hermesOwnerAskForCard,
   type HermesBoardCardSnapshot,
   type HermesBoardSnapshot,
 } from "./monitor-hermes-voice.js";
@@ -93,7 +94,10 @@ function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
     );
   }
   if (primary.lane === "Codex Needed") {
-    return `${label} is Codex-owned now: ${sentence(primary.why || "the board has a task for Codex")} Codex should ${lowerFirst(primary.next || "work the next smallest verifiable step and report back")}.`;
+    return ownerAskNarration(
+      primary,
+      `${label} is Codex-owned now: ${sentence(primary.why || "the board has a task for Codex")}`
+    );
   }
   if (primary.lane === "Release Queue") {
     return decisionNarration(
@@ -102,23 +106,43 @@ function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
     );
   }
   if (primary.lane === "Hermes Checking") {
-    return `${label} is with Hermes now: ${sentence(primary.why || "checks are still moving")} I will wait for the evidence to settle before assigning new work.`;
+    return ownerAskNarration(
+      primary,
+      `${label} is with Hermes now: ${sentence(primary.why || "checks are still moving")}`
+    );
   }
   if (primary.lane === "Deploying") {
-    return `${label} is in deploy verification: ${sentence(primary.why || "production checks are still moving")} I will call out a pass or failure when the signal lands.`;
+    return ownerAskNarration(
+      primary,
+      `${label} is in deploy verification: ${sentence(primary.why || "production checks are still moving")}`
+    );
   }
   return `${label}: ${sentence(primary.why || board.headline || "the board changed")} Next move is ${lowerFirst(primary.next || "watch the card until the owner changes")}.`;
 }
 
 function decisionNarration(item: HermesBoardCardSnapshot, opening: string): string {
   const coach = hermesDecisionCoachForCard(item);
+  const ownerAsk = hermesOwnerAskForCard(item);
   if (!coach) {
-    return `${opening} Next move is ${lowerFirst(item.next || "watch the card until the owner changes")}.`;
+    return ownerAskNarration(item, opening);
   }
   return [
     opening,
     `The button ${coach.button}; ${coach.avoid}.`,
     `Safest next step: ${coach.safestNext}.`,
+    ownerAsk ? `${ownerAsk.target}, ${ownerAsk.ask}; I am waiting for ${ownerAsk.waitingFor}.` : "",
+  ].filter(Boolean).join(" ");
+}
+
+function ownerAskNarration(item: HermesBoardCardSnapshot, opening: string): string {
+  const ownerAsk = hermesOwnerAskForCard(item);
+  if (!ownerAsk) {
+    return `${opening} Next move is ${lowerFirst(item.next || "watch the card until the owner changes")}.`;
+  }
+  return [
+    opening,
+    `${ownerAsk.target}, ${ownerAsk.ask}.`,
+    `I am waiting for ${ownerAsk.waitingFor}.`,
   ].join(" ");
 }
 

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -127,6 +127,12 @@ export interface HermesDecisionCoach {
   safestNext: string;
 }
 
+export interface HermesOwnerAsk {
+  target: string;
+  ask: string;
+  waitingFor: string;
+}
+
 export async function generateHermesReply(
   context: HermesReplyContext,
   options: GenerateHermesReplyOptions
@@ -305,6 +311,7 @@ export function buildBoardNarrationPrompt(context: HermesBoardNarrationContext):
   lines.push("Narration rules:");
   lines.push("- 1-3 conversational sentences, no greeting, no filler.");
   lines.push("- Name what changed, who owns the next move, and whether Pascal/Codex/Hermes should act or wait.");
+  lines.push("- Make the handoff conversational: address the current owner with one concrete ask, then say what signal you are waiting for.");
   lines.push("- For decision lanes, coach the decision: say what the visible button opens, what it does not do, and the safest next step.");
   lines.push("- If the board shows drafts parked outside Codex, say they are waiting on the PR author unless Pascal explicitly delegates takeover.");
   lines.push("- Do not claim you clicked buttons, started Codex, merged, deployed, approved, or changed GitHub.");
@@ -428,6 +435,66 @@ export function hermesDecisionCoachForCard(item: HermesBoardCardSnapshot): Herme
       button: "asks for merge-steward context; it does not merge the PR",
       avoid: "do not treat a green-looking card as permission to bypass branch protection or missing sign-off",
       safestNext: "merge outside the monitor only after branch protection is green and any operator sign-off is clean",
+    };
+  }
+
+  return null;
+}
+
+export function hermesOwnerAskForCard(item: HermesBoardCardSnapshot): HermesOwnerAsk | null {
+  if (item.lane === "Waiting / Drafts") {
+    return {
+      target: "PR author or owning agent",
+      ask: "finish the draft and mark it ready, or have Pascal explicitly delegate Codex takeover",
+      waitingFor: "the PR leaving draft state or an explicit takeover decision from Pascal",
+    };
+  }
+
+  if (item.lane === "Needs Attention") {
+    return {
+      target: item.owner === "Codex" ? "Codex" : item.owner || "current owner",
+      ask: "open the failed evidence and come back with the smallest verifiable fix or a smaller retry task",
+      waitingFor: "the red signal to disappear and Hermes to record a fresh pass",
+    };
+  }
+
+  if (item.lane === "Codex Needed") {
+    return {
+      target: "Codex",
+      ask: "pick up the approved task, keep the change narrow, and report the branch plus checks when done",
+      waitingFor: "the Codex runner heartbeat to move from waiting into running or terminal output",
+    };
+  }
+
+  if (item.lane === "Hermes Checking") {
+    return {
+      target: "Hermes",
+      ask: "keep checking without assigning new work until the evidence settles",
+      waitingFor: "a pass, block, operator-review, or release-queue verdict",
+    };
+  }
+
+  if (item.lane === "Operator Review") {
+    return {
+      target: "Pascal",
+      ask: "decide whether the intent, architecture, rollout risk, and evidence are acceptable",
+      waitingFor: "operator approval or a concrete request to send back to Codex",
+    };
+  }
+
+  if (item.lane === "Release Queue") {
+    return {
+      target: "merge steward",
+      ask: "confirm branch protection is green and own the merge/deploy handoff outside the monitor",
+      waitingFor: "a merge/deploy event or the card falling back because protection changed",
+    };
+  }
+
+  if (item.lane === "Deploying") {
+    return {
+      target: "Hermes",
+      ask: "watch production verification and call out the pass or failure when it lands",
+      waitingFor: "post-deploy health to pass or produce an actionable failure",
     };
   }
 
@@ -576,6 +643,7 @@ function formatBoardCounts(counts: HermesBoardSnapshot["counts"]): string {
 function formatBoardCard(item: HermesBoardCardSnapshot): string {
   const pr = item.repo && item.number ? `${item.repo}#${item.number}` : item.repo || "unknown PR";
   const coach = hermesDecisionCoachForCard(item);
+  const ownerAsk = hermesOwnerAskForCard(item);
   const parts = [
     `${item.lane} / owner ${item.owner}`,
     pr,
@@ -587,6 +655,9 @@ function formatBoardCard(item: HermesBoardCardSnapshot): string {
     coach ? `button ${coach.button}` : "",
     coach ? `avoid ${coach.avoid}` : "",
     coach ? `safest ${coach.safestNext}` : "",
+    ownerAsk ? `ask target ${ownerAsk.target}` : "",
+    ownerAsk ? `ask ${ownerAsk.ask}` : "",
+    ownerAsk ? `waiting for ${ownerAsk.waitingFor}` : "",
     item.tags && item.tags.length > 0 ? `tags ${item.tags.slice(0, 5).join(", ")}` : "",
   ].filter(Boolean);
   return parts.join(" | ");

--- a/test/unit/monitor-hermes-narration.test.ts
+++ b/test/unit/monitor-hermes-narration.test.ts
@@ -121,6 +121,8 @@ describe("Hermes proactive board narration", () => {
     expect(text).toContain("approval is a local monitor sign-off, not a merge");
     expect(text).toContain("Safest next step");
     expect(text).toContain("send it back to Codex with a concrete ask");
+    expect(text).toContain("Pascal, decide whether the intent");
+    expect(text).toContain("waiting for operator approval");
   });
 
   it("coaches release queue decisions without implying the monitor merges", () => {
@@ -143,5 +145,29 @@ describe("Hermes proactive board narration", () => {
     expect(text).toContain("button asks for merge-steward context");
     expect(text).toContain("it does not merge the PR");
     expect(text).toContain("branch protection is green");
+    expect(text).toContain("merge steward, confirm branch protection is green");
+    expect(text).toContain("waiting for a merge/deploy event");
+  });
+
+  it("uses owner-specific asks for Codex-owned fallback narration", () => {
+    const text = fallbackHermesBoardNarration(board({
+      counts: { codex: 1 },
+      items: [
+        {
+          repo: "averray-agent/agent",
+          number: 438,
+          title: "1 PR check failed.",
+          lane: "Needs Attention",
+          owner: "Codex",
+          verdict: "blocked",
+          why: "Codex task runner failed.",
+          next: "inspect the runner output",
+        },
+      ],
+    }));
+
+    expect(text).toContain("Codex, open the failed evidence");
+    expect(text).toContain("smallest verifiable fix");
+    expect(text).toContain("waiting for the red signal to disappear");
   });
 });

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -10,6 +10,7 @@ import {
   generateHermesReply,
   hermesDecisionCoachForCard,
   hermesMemoryInfluence,
+  hermesOwnerAskForCard,
   type HermesReplyContext,
 } from "../../services/slack-operator/src/monitor-hermes-voice.js";
 
@@ -194,10 +195,14 @@ describe("buildBoardNarrationPrompt", () => {
     });
 
     expect(prompt).toContain("For decision lanes, coach the decision");
+    expect(prompt).toContain("Make the handoff conversational");
     expect(prompt).toContain("button opens the operator checklist");
     expect(prompt).toContain("approval is a local monitor sign-off, not a merge");
     expect(prompt).toContain("avoid do not re-review code line by line");
     expect(prompt).toContain("safest decide whether project intent");
+    expect(prompt).toContain("ask target Pascal");
+    expect(prompt).toContain("ask decide whether the intent");
+    expect(prompt).toContain("waiting for operator approval");
   });
 });
 
@@ -224,6 +229,44 @@ describe("hermesDecisionCoachForCard", () => {
       lane: "Release Queue",
       owner: "Merge steward",
     })?.button).toContain("does not merge");
+  });
+});
+
+describe("hermesOwnerAskForCard", () => {
+  it("turns board lanes into concrete owner handoffs", () => {
+    expect(hermesOwnerAskForCard({
+      repo: "averray-agent/agent",
+      number: 438,
+      title: "1 PR check failed.",
+      lane: "Needs Attention",
+      owner: "Codex",
+    })).toMatchObject({
+      target: "Codex",
+      ask: expect.stringContaining("smallest verifiable fix"),
+      waitingFor: expect.stringContaining("fresh pass"),
+    });
+    expect(hermesOwnerAskForCard({
+      repo: "averray-agent/agent",
+      number: 439,
+      title: "PR is still marked as draft.",
+      lane: "Waiting / Drafts",
+      owner: "PR author",
+    })).toMatchObject({
+      target: "PR author or owning agent",
+      ask: expect.stringContaining("mark it ready"),
+      waitingFor: expect.stringContaining("explicit takeover decision"),
+    });
+    expect(hermesOwnerAskForCard({
+      repo: "averray-agent/agent",
+      number: 440,
+      title: "Ready to merge.",
+      lane: "Release Queue",
+      owner: "Merge steward",
+    })).toMatchObject({
+      target: "merge steward",
+      ask: expect.stringContaining("branch protection is green"),
+      waitingFor: expect.stringContaining("merge/deploy event"),
+    });
   });
 });
 


### PR DESCRIPTION
## What changed
- Added shared owner-specific ask guidance for board lanes so Hermes knows who the handoff is for, what to ask, and what signal to wait on.
- Included that ask/waiting context in board narration prompts for the Hermes LLM.
- Updated fallback narration so Codex, Pascal/operator, merge-steward, draft, Hermes-checking, and deploy states still read like concrete handoffs when the LLM path is unavailable.

## Impact
- Affects the slack-operator monitor collaboration backend only.
- No frontend, indexer, contracts, Caddy, public site, generated output, or VPS secret changes.

## Checks
- `npm test -- monitor-hermes-voice monitor-hermes-narration`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- `npm test`