### PR TITLE
[codex] Add Hermes testbed mission harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `business ledger`,
   `ops health`, `github status`, `github open prs`, `github ci failures`,
   `github issue digest`, `github brief`, `daily github brief`,
-  `what changed since last time`, `testbed e2e suite`,
-  `platform e2e suite`, `run testbed e2e read-only`,
+  `what changed since last time`, `testbed agent mission`,
+  `agent browser mission https://testbed.example/app goal: complete onboarding`,
+  `testbed e2e suite`, `platform e2e suite`, `run testbed e2e read-only`,
   `daily operator brief`, `find safe work`,
   `operator status`, `operator status details`,
   `run one wikipedia citation repair if safe`, and
@@ -195,6 +196,15 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   `daily operator brief` and `find safe work` are read-only summaries that turn
   the current wallet, budget, latest-run, and open-job state into practical next
   actions for any MCP client, not just Slack or Hermes Workspace.
+  `testbed agent mission` and `agent browser mission ... goal: ...` call
+  `averray_testbed_agent_mission`, a read-only mission packet for testing Hermes
+  or any other agent like a normal out-of-the-box visitor. It returns the target
+  URL, goal, fresh-memory mode, browser-only prompt, denied shortcuts, evidence
+  schema, and scoring rubric. The mission generator does not run the browser,
+  query private state, use Averray operator/workflow tools, call GitHub, deploy,
+  submit, merge, or mutate anything; the receiving agent should use only
+  browser-visible evidence and stop before real payments, signatures, submits,
+  deploys, merges, or account-affecting actions.
   `testbed e2e suite` and `platform e2e suite` call
   `averray_testbed_e2e_suite`, a read-only E2E checklist for backend agents,
   Slack, Command Center, and MCP clients. It returns ordered test cases,

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -50,7 +50,7 @@ import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { getProjectMemory } from "./operator-project-memory.js";
 import { getProjectRunbook } from "./operator-project-runbook.js";
 import { approveGithubMergeStewardCandidate, getGithubOperatorBrief, getGithubOperatorStatus } from "./operator-github.js";
-import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
+import { getTestbedAgentMission, getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { invokeAgentTask } from "./agent-invocation.js";
 import { getHandoffMonitor } from "./handoff-events.js";
 
@@ -278,6 +278,22 @@ server.tool(
 );
 
 server.tool(
+  "averray_testbed_agent_mission",
+  "Read-only neutral browser mission contract for testing Hermes or another agent as a normal out-of-the-box visitor. Returns a prompt, browser-only rules, denied shortcuts, evidence schema, and scoring rubric. It does not run the browser, query private state, mutate Averray, call GitHub, deploy, submit, merge, or edit anything.",
+  {
+    targetUrl: z.string().url().optional(),
+    goal: z.string().min(1).optional(),
+    agentName: z.string().min(1).optional(),
+    freshMemory: z.boolean().default(true),
+    maxBrowserSteps: z.number().int().min(20).max(200).default(80),
+    maxMinutes: z.number().int().min(5).max(60).default(20)
+  },
+  async (input) => {
+    return jsonContent(getTestbedAgentMission(input));
+  }
+);
+
+server.tool(
   "averray_testbed_e2e_suite",
   "Canonical read-only testbed E2E suite for backend agents, Slack, Command Center, and MCP clients. Returns the ordered platform test cases, commands, expected evidence, readiness blockers, and mutation boundaries for exercising the Averray reference agent like a normal operator. The suite generator itself does not claim, submit, deploy, edit GitHub, edit Wikipedia, or mutate Averray state.",
   {},
@@ -340,7 +356,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'codex handoff protocol', 'what should Codex do when Hermes blocks', 'runbook for deploy averray-agent/agent', 'merge runbook for averray-agent/agent', 'secret rotation runbook', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github steward', 'merge steward', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/project-memory/project-runbook/codex-handoff-protocol/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'codex handoff protocol', 'what should Codex do when Hermes blocks', 'runbook for deploy averray-agent/agent', 'merge runbook for averray-agent/agent', 'secret rotation runbook', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github steward', 'merge steward', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed agent mission', 'agent browser mission https://testbed.example/app goal: complete onboarding', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized agent mission commands call averray_testbed_agent_mission directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/project-memory/project-runbook/codex-handoff-protocol/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -1,6 +1,7 @@
 import type { WikipediaCitationRepairWorkflowInput } from "./job-workflows.js";
 import type { AdminActionKind, AdminActionProposalInput } from "./operator-admin.js";
 import type { GithubMergeStewardApprovalInput, GithubOperatorView } from "./operator-github.js";
+import type { TestbedAgentMissionInput } from "./operator-testbed.js";
 
 export type OperatorCommandSource = "slack" | "operator" | "command_center" | "hermes" | "agent";
 
@@ -116,6 +117,13 @@ export type ParsedOperatorCommand =
     }
   | {
       handled: true;
+      kind: "testbed_agent_mission";
+      source: OperatorCommandSource;
+      detailed: boolean;
+      input: TestbedAgentMissionInput;
+    }
+  | {
+      handled: true;
       kind: "testbed_e2e_suite";
       source: OperatorCommandSource;
       detailed: boolean;
@@ -191,6 +199,9 @@ const EXAMPLES = [
   "github open prs",
   "github ci failures",
   "github issue digest",
+  "testbed agent mission",
+  "agent browser mission https://testbed.example/app goal: complete onboarding",
+  "out of box agent test",
   "testbed e2e suite",
   "platform e2e suite",
   "run testbed e2e read-only",
@@ -279,6 +290,11 @@ export function parseOperatorCommand(
 
   if (isGithubMergeStewardCommand(normalizedText)) {
     return { handled: true, kind: "github_merge_steward", source, detailed };
+  }
+
+  const testbedMission = testbedAgentMissionInput(text, normalizedText);
+  if (testbedMission.handled) {
+    return { handled: true, kind: "testbed_agent_mission", source, detailed, input: testbedMission.input };
   }
 
   if (isRunTestbedE2eReadOnlyCommand(normalizedText)) {
@@ -577,6 +593,33 @@ function isGithubBriefCommand(text: string): boolean {
 function isGithubMergeStewardCommand(text: string): boolean {
   const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
   return /^(github steward|merge steward|pr steward|pull request steward|github merge steward|take care of open prs|drain open prs|review open prs)$/.test(compact);
+}
+
+function testbedAgentMissionInput(
+  originalText: string,
+  text: string
+): { handled: true; input: TestbedAgentMissionInput } | { handled: false } {
+  const compact = text.replace(/\b(details?|full|audit)\b/g, "").replace(/\s+/g, " ").trim();
+  const handled = /^(testbed agent mission|agent testbed mission|agent browser mission|browser mission|fresh agent mission|fresh agent page test|out of box agent test|out-of-box agent test|normal agent page test|can hermes test the page|test page as fresh agent)(\b.*)?$/.test(compact);
+  if (!handled) return { handled: false };
+
+  const targetUrl = extractToken(originalText, /\b(https?:\/\/[^\s)]+)/i);
+  const goal = extractToken(originalText, /\bgoal\s*:\s*(.+)$/i);
+  const agentName = compact.includes("codex")
+    ? "Codex"
+    : compact.includes("claude")
+      ? "Claude"
+      : "Hermes";
+  const freshMemory = !/\b(with memory|use memory|warm memory|returning agent|returning-agent|not fresh)\b/.test(compact);
+  return {
+    handled: true,
+    input: {
+      ...(targetUrl ? { targetUrl } : {}),
+      ...(goal ? { goal } : {}),
+      agentName,
+      freshMemory,
+    },
+  };
 }
 
 function githubMergeStewardApprovalInput(

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -17,7 +17,7 @@ import { getDailyOperatorBrief, getOperatorStatus, getSafeWorkReport } from "./o
 import { getProjectMemory } from "./operator-project-memory.js";
 import { getProjectRunbook } from "./operator-project-runbook.js";
 import { getCodexHandoffProtocol } from "./codex-handoff-protocol.js";
-import { getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
+import { getTestbedAgentMission, getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 import { getHandoffMonitor } from "./handoff-events.js";
@@ -115,6 +115,10 @@ export async function handleOperatorCommandText(
   if (command.kind === "github_merge_steward_approval") {
     const approval = await approveGithubMergeStewardCandidate(command.input);
     return { ...command, approval };
+  }
+  if (command.kind === "testbed_agent_mission") {
+    const mission = getTestbedAgentMission(command.input);
+    return { ...command, mission };
   }
   if (command.kind === "run_testbed_e2e_read_only") {
     const run = await runTestbedE2eReadOnly({ query: deps.query, workflowDeps: deps.workflowDeps });

--- a/packages/averray-mcp/src/operator-testbed.ts
+++ b/packages/averray-mcp/src/operator-testbed.ts
@@ -20,6 +20,138 @@ export interface TestbedE2eReadOnlyRunOptions {
   testCaseIds?: string[];
 }
 
+export interface TestbedAgentMissionInput {
+  targetUrl?: string;
+  goal?: string;
+  agentName?: string;
+  freshMemory?: boolean;
+  maxBrowserSteps?: number;
+  maxMinutes?: number;
+}
+
+export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
+  const targetUrl = cleanOptional(input.targetUrl) ?? "[TESTBED_URL]";
+  const goal = cleanOptional(input.goal)
+    ?? "Figure out what this page is for, complete the main user flow as far as the public UI allows, and report whether a normal outside agent can use it without private project context.";
+  const agentName = cleanOptional(input.agentName) ?? "Hermes";
+  const freshMemory = input.freshMemory !== false;
+  const maxBrowserSteps = clampInt(input.maxBrowserSteps, 20, 200, 80);
+  const maxMinutes = clampInt(input.maxMinutes, 5, 60, 20);
+
+  return {
+    schemaVersion: 1,
+    kind: "testbed_agent_browser_mission",
+    generatedAt: new Date().toISOString(),
+    mutates: false,
+    headline: "Fresh-agent browser mission ready: test the page like a normal outside agent, not like an internal operator.",
+    target: {
+      url: targetUrl,
+      goal,
+      agentName,
+      freshMemory,
+      maxBrowserSteps,
+      maxMinutes,
+    },
+    agentMode: {
+      identity: "normal_out_of_box_agent",
+      memoryMode: freshMemory ? "fresh_or_ignored" : "returning_agent_memory_allowed",
+      browserOnly: true,
+      privilegedAverrayMcpAllowed: false,
+      hiddenProjectContextAllowed: false,
+      humanHelpAllowed: false,
+      purpose: "Measure whether an agent with ordinary browser access can understand and use the public/testbed page.",
+    },
+    missionPrompt: [
+      `You are ${agentName}, acting as a normal out-of-the-box agent visiting Averray for the first time.`,
+      `Open ${targetUrl}.`,
+      `Goal: ${goal}`,
+      "",
+      "Use only the browser-visible page, normal public links, and screenshots/observations from the page.",
+      "Do not use private repository knowledge, databases, hidden monitor state, Averray MCP tools, Slack, GitHub, SSH, or operator memory unless the page itself gives you that information.",
+      "Work like a future external agent would: explain what you infer, try the main flow, note where you are uncertain, and stop before any real mutation, payment, wallet signature, submit, deploy, merge, or account-affecting action.",
+      "",
+      "Report with: verdict, completed path, blockers, confusing moments, evidence, screenshots or trace references, and what would make the page easier for the next agent.",
+    ].join("\n"),
+    runbook: [
+      "Start with a clean browser profile or explicitly ignore prior memory.",
+      "Open the target URL and record the first thing the page appears to ask from a new agent.",
+      "Identify the product purpose, primary user, and main task without reading private project notes.",
+      "Attempt the main flow using only visible UI controls.",
+      "Collect evidence: page states, URLs visited, visible copy that helped or blocked you, screenshots/trace references, and any console/network failures if available.",
+      "Stop before real mutations or irreversible actions; describe the next required human or sandbox approval instead.",
+      "Score the experience using the rubric and return the structured report.",
+    ],
+    allowedEvidence: [
+      "browser-visible UI text and controls",
+      "screenshots or trace references",
+      "public documentation linked from the page",
+      "client-side console or network errors if the browser exposes them",
+      "the agent's own step-by-step observations",
+    ],
+    deniedShortcuts: [
+      "private repo knowledge",
+      "database queries",
+      "Averray operator or workflow MCP tools after receiving this mission",
+      "Slack, GitHub, monitor internals, or VPS commands",
+      "wallet signatures, payment, submit, deploy, merge, or account mutation",
+      "asking Pascal what to do during the mission",
+    ],
+    successCriteria: [
+      "The agent can state what the page is for within the first screen or first natural click.",
+      "The agent can identify the main task and whether it is safe to proceed.",
+      "The agent can complete or reach a clear sandbox stop point in the primary flow.",
+      "Any blocker is explained with visible evidence, not private assumptions.",
+      "The final report is useful enough for another agent to reproduce the run.",
+    ],
+    scoringRubric: [
+      score("orientation", "Could the agent understand purpose and audience from the page itself?"),
+      score("navigation", "Could the agent find the main path without private instructions?"),
+      score("taskCompletion", "Could the agent complete the intended flow or reach a legitimate sandbox stop?"),
+      score("trustAndSafety", "Did the page make mutation boundaries, wallet/signature risk, and data use clear?"),
+      score("recoverability", "Could the agent recover from errors, empty states, or missing context?"),
+      score("evidenceQuality", "Did the agent return enough trace/screenshot/detail for a reviewer to verify the verdict?"),
+    ],
+    reportSchema: {
+      verdict: "pass | partial | fail",
+      confidence: "0.0-1.0",
+      targetUrl: "string",
+      goal: "string",
+      memoryMode: "fresh_or_ignored | returning_agent_memory_allowed",
+      completedPath: ["ordered browser actions the agent took"],
+      blockers: ["visible blocker or empty array"],
+      confusingMoments: ["where the page required guessing"],
+      evidence: [
+        {
+          type: "screenshot | url | visible_text | console | network | observation",
+          value: "bounded evidence reference",
+        },
+      ],
+      scores: {
+        orientation: "0-5",
+        navigation: "0-5",
+        taskCompletion: "0-5",
+        trustAndSafety: "0-5",
+        recoverability: "0-5",
+        evidenceQuality: "0-5",
+      },
+      recommendations: ["smallest page/product changes that would help the next outside agent"],
+      stoppedBeforeMutation: "boolean",
+    },
+    nextSteps: [
+      "Run this once with fresh memory to measure first-contact usability.",
+      "Run it again with returning-agent memory to measure whether memory improves the agent without hiding page gaps.",
+      "Compare Hermes against other agents with the same mission prompt and rubric.",
+    ],
+    safety: {
+      missionGeneratorMutates: false,
+      browserMissionShouldMutate: false,
+      freshAgentDefault: true,
+      requiresEvidence: true,
+      comparesAcrossAgents: true,
+    },
+  };
+}
+
 export async function getTestbedE2eSuite(deps: TestbedE2eSuiteDeps) {
   const [status, safeWork] = await Promise.all([
     getOperatorStatus(deps),
@@ -316,6 +448,20 @@ function testCase(input: {
     expectedEvidence: input.expectedEvidence,
     successCriteria: input.successCriteria,
   };
+}
+
+function score(id: string, question: string) {
+  return { id, scale: "0-5", question };
+}
+
+function cleanOptional(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function clampInt(value: number | undefined, min: number, max: number, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.min(max, Math.max(min, Math.round(value)));
 }
 
 type TestbedCase = ReturnType<typeof testCase>;

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -305,6 +305,41 @@ describe("operator commands", () => {
     });
   });
 
+  it("routes fresh-agent testbed browser missions read-only", () => {
+    expect(parseOperatorCommand("agent browser mission https://testbed.example/app goal: complete onboarding", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "testbed_agent_mission",
+      source: "operator",
+      detailed: false,
+      input: {
+        targetUrl: "https://testbed.example/app",
+        goal: "complete onboarding",
+        agentName: "Hermes",
+        freshMemory: true,
+      },
+    });
+    expect(parseOperatorCommand("out of box agent test with memory details", { source: "slack" })).toEqual({
+      handled: true,
+      kind: "testbed_agent_mission",
+      source: "slack",
+      detailed: true,
+      input: {
+        agentName: "Hermes",
+        freshMemory: false,
+      },
+    });
+    expect(parseOperatorCommand("test page as fresh agent with Codex", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "testbed_agent_mission",
+      source: "command_center",
+      detailed: false,
+      input: {
+        agentName: "Codex",
+        freshMemory: true,
+      },
+    });
+  });
+
   it("routes the executable read-only testbed E2E run separately from the suite", () => {
     expect(parseOperatorCommand("run testbed e2e read-only", { source: "operator" })).toEqual({
       handled: true,

--- a/test/unit/operator-testbed-agent-mission.test.ts
+++ b/test/unit/operator-testbed-agent-mission.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { getTestbedAgentMission } from "../../packages/averray-mcp/src/operator-testbed.js";
+
+describe("testbed agent mission", () => {
+  it("builds a read-only fresh browser mission for a normal outside agent", () => {
+    const mission = getTestbedAgentMission();
+
+    expect(mission).toMatchObject({
+      schemaVersion: 1,
+      kind: "testbed_agent_browser_mission",
+      mutates: false,
+      agentMode: {
+        identity: "normal_out_of_box_agent",
+        memoryMode: "fresh_or_ignored",
+        browserOnly: true,
+        privilegedAverrayMcpAllowed: false,
+        hiddenProjectContextAllowed: false,
+        humanHelpAllowed: false,
+      },
+      safety: {
+        missionGeneratorMutates: false,
+        browserMissionShouldMutate: false,
+        freshAgentDefault: true,
+        requiresEvidence: true,
+        comparesAcrossAgents: true,
+      },
+    });
+    expect(mission.missionPrompt).toContain("normal out-of-the-box agent");
+    expect(mission.missionPrompt).toContain("Do not use private repository knowledge");
+    expect(mission.missionPrompt).toContain("Averray MCP tools");
+    expect(mission.deniedShortcuts).toContain("Averray operator or workflow MCP tools after receiving this mission");
+    expect(mission.reportSchema).toMatchObject({
+      verdict: "pass | partial | fail",
+      confidence: "0.0-1.0",
+      stoppedBeforeMutation: "boolean",
+    });
+    expect(mission.reportSchema.completedPath).toEqual(["ordered browser actions the agent took"]);
+    expect(mission.scoringRubric.map((entry) => entry.id)).toEqual([
+      "orientation",
+      "navigation",
+      "taskCompletion",
+      "trustAndSafety",
+      "recoverability",
+      "evidenceQuality",
+    ]);
+  });
+
+  it("accepts a target URL, goal, returning-agent mode, and bounded run limits", () => {
+    const mission = getTestbedAgentMission({
+      targetUrl: "https://testbed.example/app",
+      goal: "Complete onboarding",
+      agentName: "Claude",
+      freshMemory: false,
+      maxBrowserSteps: 999,
+      maxMinutes: 1,
+    });
+
+    expect(mission.target).toEqual({
+      url: "https://testbed.example/app",
+      goal: "Complete onboarding",
+      agentName: "Claude",
+      freshMemory: false,
+      maxBrowserSteps: 200,
+      maxMinutes: 5,
+    });
+    expect(mission.agentMode.memoryMode).toBe("returning_agent_memory_allowed");
+    expect(mission.missionPrompt).toContain("You are Claude");
+    expect(mission.missionPrompt).toContain("Open https://testbed.example/app.");
+    expect(mission.missionPrompt).toContain("Goal: Complete onboarding");
+  });
+});


### PR DESCRIPTION
## What changed
- Added a read-only averray_testbed_agent_mission contract for fresh/out-of-box browser testing.
- Routed operator commands like agent browser mission ... to return the mission packet.
- Documented the mission and added unit coverage.

## Impact
- Affects Averray MCP operator/testbed command layer and docs.
- Does not run browser, mutate Averray/GitHub/Wikipedia, deploy, submit, or touch secrets.
- No frontend/indexer/contracts/Caddy/public site/generated output/VPS secret changes.

## Checks
- npm test -- operator-testbed-agent-mission operator-commands
- npm run typecheck
- npm run build
- git diff --check
- npm test