### PR TITLE
[codex] Ingest testbed mission reports from chat

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -36,6 +36,7 @@ import {
   listCollaborationMessages,
   listHermesMemoryNotes,
   recordCollaborationMessage,
+  recordHermesMemoryNote,
   synthesizeHermesReplyFor,
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
@@ -606,6 +607,10 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
 function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
   try {
     const verdict = typeof run.result?.verdict === "string" ? run.result.verdict : run.status;
+    recordHermesMemoryNote({
+      text: testbedMissionMemoryText(run),
+      relatedCorrelationId: run.id,
+    });
     recordCollaborationMessage({
       author: "hermes",
       kind: "status",
@@ -626,6 +631,29 @@ function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
   } catch (error) {
     logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_report_collaboration_failed");
   }
+}
+
+function testbedMissionMemoryText(run: TestbedMissionRun): string {
+  const result = run.result ?? {};
+  const verdict = typeof result.verdict === "string" ? result.verdict : run.status;
+  const blockers = Array.isArray(result.blockers)
+    ? result.blockers.map(String).filter(Boolean)
+    : [];
+  const recommendations = Array.isArray(result.recommendations)
+    ? result.recommendations.map(String).filter(Boolean)
+    : [];
+  const scores = isRecord(result.scores) ? result.scores : {};
+  const weakScores = Object.entries(scores)
+    .filter(([, value]) => Number(value) <= 3)
+    .map(([key, value]) => `${key}:${String(value)}`)
+    .slice(0, 3);
+  const details = [
+    `Testbed mission report for ${run.targetUrl}: verdict ${verdict}.`,
+    blockers.length ? `Top blocker: ${blockers[0]}.` : "",
+    weakScores.length ? `Weak scores: ${weakScores.join(", ")}.` : "",
+    recommendations.length ? `Useful recommendation: ${recommendations[0]}.` : "",
+  ].filter(Boolean).join(" ");
+  return `${details} Treat this as learned testbed evidence for future page missions, not as live proof that the current page is fixed.`;
 }
 
 async function handleMonitorCommandRequest(request: http.IncomingMessage, response: http.ServerResponse) {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -61,6 +61,7 @@ import {
 } from "./codex-task-queue.js";
 import {
   listTestbedMissionRuns,
+  recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
@@ -570,12 +571,25 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
       return;
     }
     const message = recordCollaborationMessage(payload);
+    const testbedMissionRun = recordTestbedMissionReportFromMessage({
+      relatedCorrelationId: message.relatedCorrelationId,
+      text: message.text,
+    });
+    if (testbedMissionRun) {
+      recordTestbedMissionReportCollaboration(testbedMissionRun);
+    }
     logger.info(
-      { author: message.author, kind: message.kind, addressedTo: message.addressedTo, id: message.id },
+      {
+        author: message.author,
+        kind: message.kind,
+        addressedTo: message.addressedTo,
+        id: message.id,
+        testbedMissionRunId: testbedMissionRun?.id,
+      },
       "monitor_collaboration_message_recorded"
     );
     scheduleHermesAutoReply(message);
-    writeJson(response, 200, { ok: true, message });
+    writeJson(response, 200, { ok: true, message, ...(testbedMissionRun ? { testbedMissionRun } : {}) });
   } catch (error) {
     if (error instanceof CollaborationValidationError) {
       writeJson(response, 400, { error: error.code, message: error.message });
@@ -586,6 +600,31 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
       error: "monitor_collaboration_failed",
       message: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
+  try {
+    const verdict = typeof run.result?.verdict === "string" ? run.result.verdict : run.status;
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "status",
+      addressedTo: run.status === "completed" ? "everyone" : "operator",
+      relatedCorrelationId: run.id,
+      text: run.status === "completed"
+        ? [
+          `I ingested the browser-agent report for ${run.id}.`,
+          `Verdict is ${verdict}; the mission is complete and the board now has structured evidence attached.`,
+          "Use the report in the drawer as the testbed proof for the next product improvement.",
+        ].join(" ")
+        : [
+          `I ingested the browser-agent report for ${run.id}.`,
+          `Verdict is ${verdict}; I am keeping the mission visible because the report needs follow-up.`,
+          "Open the card to inspect blockers, scores, and evidence before changing the page or mission prompt.",
+        ].join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_report_collaboration_failed");
   }
 }
 

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -87,6 +87,13 @@ export interface ListHermesMemoryOptions {
   limit?: number;
 }
 
+export interface RecordHermesMemoryNoteInput {
+  text: string;
+  scope?: "global" | "pr";
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
 export class CollaborationValidationError extends Error {
   constructor(public readonly code: string, message: string) {
     super(message);
@@ -166,6 +173,25 @@ export function listHermesMemoryNotes(options: ListHermesMemoryOptions = {}): He
     return false;
   });
   return filtered.slice(-limit);
+}
+
+export function recordHermesMemoryNote(
+  input: RecordHermesMemoryNoteInput,
+  nowMs: number = Date.now()
+): HermesMemoryNote | undefined {
+  loadHermesMemoryIfNeeded();
+  const text = normalizeText(input.text).slice(0, HERMES_MEMORY_NOTE_MAX_CHARS);
+  if (!text) return undefined;
+  const note: HermesMemoryNote = {
+    id: nextMemoryId(nowMs),
+    ts: nowMs,
+    scope: input.scope ?? (input.relatedPr ? "pr" : "global"),
+    text,
+    ...(input.relatedPr ? { relatedPr: input.relatedPr } : {}),
+    ...(input.relatedCorrelationId ? { relatedCorrelationId: input.relatedCorrelationId.trim().slice(0, 256) } : {}),
+  };
+  upsertHermesMemoryNote(note);
+  return note;
 }
 
 export function classifyHermesMemoryRequest(message: Pick<CollaborationMessage, "author" | "addressedTo" | "text">): HermesMemoryRequestKind {
@@ -249,15 +275,15 @@ function learnHermesMemoryFromMessage(message: CollaborationMessage): void {
   const noteText = memoryTextForMessage(message);
   if (!noteText) return;
 
-  const note: HermesMemoryNote = {
-    id: nextMemoryId(message.ts),
-    ts: message.ts,
-    scope: message.relatedPr ? "pr" : "global",
+  recordHermesMemoryNote({
     text: noteText,
+    scope: message.relatedPr ? "pr" : "global",
     ...(message.relatedPr ? { relatedPr: message.relatedPr } : {}),
     ...(message.relatedCorrelationId ? { relatedCorrelationId: message.relatedCorrelationId } : {}),
-  };
+  }, message.ts);
+}
 
+function upsertHermesMemoryNote(note: HermesMemoryNote): void {
   const dedupeKey = memoryDedupeKey(note);
   const existingIndex = hermesMemoryNotes.findIndex((candidate) =>
     memoryDedupeKey(candidate) === dedupeKey

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -390,6 +390,14 @@ export function hermesMemoryInfluence(context: HermesWhyTraceContext): HermesMem
     };
   }
 
+  if (lowerNote.includes("testbed mission report")) {
+    return {
+      conflict: false,
+      sentence: "I am carrying forward the last testbed mission evidence here, so I will compare new page runs against what the browser-agent report already taught us.",
+      trace: "testbed mission report memory",
+    };
+  }
+
   if (boardSaysCodex && noteSaysDelegatedCodex) {
     return {
       conflict: false,

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -24,6 +24,11 @@ export interface ListTestbedMissionRunOptions {
   activeOnly?: boolean;
 }
 
+export interface MissionReportInput {
+  relatedCorrelationId?: string;
+  text?: string;
+}
+
 const missionRuns: TestbedMissionRun[] = [];
 let missionSeq = 0;
 
@@ -68,10 +73,39 @@ export function listTestbedMissionRuns(options: ListTestbedMissionRunOptions = {
     .map((run) => ({ ...run, mission: { ...run.mission }, ...(run.result ? { result: { ...run.result } } : {}) }));
 }
 
+export function recordTestbedMissionReportFromMessage(
+  input: MissionReportInput,
+  nowMs: number = Date.now()
+): TestbedMissionRun | undefined {
+  const report = parseMissionReport(input.text ?? "");
+  if (!report) return undefined;
+  const missionId = missionIdFromReportInput(input, report);
+  const run = missionId
+    ? missionRuns.find((candidate) => candidate.id === missionId)
+    : onlyActiveMissionRun();
+  if (!run) return undefined;
+
+  const verdict = normalizeVerdict(report.verdict);
+  const stoppedBeforeMutation = report.stoppedBeforeMutation !== false;
+  const completed = verdict === "pass" && stoppedBeforeMutation;
+  const failed = !verdict || verdict === "fail" || verdict === "partial" || !stoppedBeforeMutation;
+  const status: TestbedMissionStatus = completed ? "completed" : failed ? "failed" : "completed";
+  const updatedAt = new Date(nowMs).toISOString();
+  run.result = {
+    ...report,
+    ingestedAt: updatedAt,
+  };
+  run.status = status;
+  run.updatedAt = updatedAt;
+  run.statusReason = missionReportStatusReason(report, status, stoppedBeforeMutation);
+  return cloneRun(run);
+}
+
 export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<string, unknown> {
   const active = run.status === "ready" || run.status === "running";
   const terminalStatus = run.status === "completed" ? "completed" : run.status === "failed" ? "failed" : "running";
   const verdict = run.status === "completed" ? "pass" : run.status === "failed" ? "failed" : "running";
+  const reportAttached = Boolean(run.result);
   return {
     correlationId: run.id,
     requester: "monitor",
@@ -94,8 +128,11 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
       mergeRecommendation: "not_applicable",
       reviewSignals: {
         touchedAreas: ["testbed"],
-        testSignals: ["browser mission packet ready"],
-        missingTestSignals: run.status === "completed" ? [] : ["browser agent report"],
+        testSignals: [
+          "browser mission packet ready",
+          ...(reportAttached ? ["browser agent report attached"] : []),
+        ],
+        missingTestSignals: reportAttached ? [] : ["browser agent report"],
       },
       reviewReasons: run.status === "failed"
         ? [{ severity: "high", code: "testbed_mission_failed", message: run.statusReason }]
@@ -114,6 +151,105 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
 export function __resetTestbedMissionRunsForTests(): void {
   missionRuns.splice(0, missionRuns.length);
   missionSeq = 0;
+}
+
+function onlyActiveMissionRun(): TestbedMissionRun | undefined {
+  const activeRuns = missionRuns
+    .filter((run) => run.status === "ready" || run.status === "running")
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  return activeRuns.length === 1 ? activeRuns[0] : undefined;
+}
+
+function cloneRun(run: TestbedMissionRun): TestbedMissionRun {
+  return {
+    ...run,
+    mission: { ...run.mission },
+    ...(run.result ? { result: { ...run.result } } : {}),
+  };
+}
+
+function missionIdFromReportInput(
+  input: MissionReportInput,
+  report: Record<string, unknown>
+): string | undefined {
+  const related = input.relatedCorrelationId?.trim();
+  if (related && related.startsWith("testbed-mission-")) return related;
+  const reportMissionId = stringField(report, "missionId");
+  if (reportMissionId && reportMissionId.startsWith("testbed-mission-")) return reportMissionId;
+  const textMissionId = input.text?.match(/\b(testbed-mission-[A-Za-z0-9-]+)\b/)?.[1];
+  return textMissionId;
+}
+
+function parseMissionReport(text: string): Record<string, unknown> | undefined {
+  const normalized = text.trim();
+  if (!normalized) return undefined;
+  const jsonText = extractJsonObject(normalized);
+  if (!jsonText) return undefined;
+  try {
+    const parsed = JSON.parse(jsonText) as unknown;
+    if (!isRecord(parsed)) return undefined;
+    if (parsed.kind === "testbed_mission_report" && isRecord(parsed.report)) {
+      return parsed.report;
+    }
+    if (isRecord(parsed.testbedMissionReport)) {
+      return parsed.testbedMissionReport;
+    }
+    if (isRecord(parsed.report) && looksLikeMissionReport(parsed.report)) {
+      return parsed.report;
+    }
+    return looksLikeMissionReport(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractJsonObject(text: string): string | undefined {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const source = fenced ? fenced[1]?.trim() ?? "" : text;
+  const first = source.indexOf("{");
+  const last = source.lastIndexOf("}");
+  if (first < 0 || last <= first) return undefined;
+  return source.slice(first, last + 1);
+}
+
+function looksLikeMissionReport(value: Record<string, unknown>): boolean {
+  if (normalizeVerdict(value.verdict)) return true;
+  if (Array.isArray(value.completedPath) || Array.isArray(value.blockers) || isRecord(value.scores)) return true;
+  return false;
+}
+
+function normalizeVerdict(value: unknown): "pass" | "partial" | "fail" | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "passed" || normalized === "success" || normalized === "ok") return "pass";
+  if (normalized === "partial" || normalized === "mixed") return "partial";
+  if (normalized === "failed" || normalized === "failure" || normalized === "blocked") return "fail";
+  if (normalized === "pass" || normalized === "fail") return normalized;
+  return undefined;
+}
+
+function missionReportStatusReason(
+  report: Record<string, unknown>,
+  status: TestbedMissionStatus,
+  stoppedBeforeMutation: boolean
+): string {
+  const verdict = normalizeVerdict(report.verdict) ?? "reported";
+  const blockers = Array.isArray(report.blockers)
+    ? report.blockers.map(String).filter(Boolean)
+    : [];
+  if (!stoppedBeforeMutation) {
+    return "Browser-agent report says the mission crossed or attempted a mutation boundary.";
+  }
+  if (status === "completed") {
+    return "Browser-agent report passed; Hermes has structured evidence for this testbed mission.";
+  }
+  if (blockers.length > 0) {
+    return `Browser-agent report returned ${verdict}; blocker: ${blockers[0]}`;
+  }
+  if (!normalizeVerdict(report.verdict)) {
+    return "Browser-agent report was attached but did not include a clear verdict; inspect it before Hermes can close the mission.";
+  }
+  return `Browser-agent report returned ${verdict}; inspect the attached evidence before changing the page or mission prompt.`;
 }
 
 function nextMissionId(nowMs: number): string {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -4749,6 +4749,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           // surfaces in roughly a second.
           pollCollaborationSince(result.message.ts);
         }
+        if (result && result.testbedMissionRun) {
+          await load();
+          selectedKey = String(result.testbedMissionRun.id || selectedKey || "");
+          renderBoard(latestPipelineItems);
+          renderDrawer(selectedItem());
+          renderCommandContext();
+        }
         setComposeStatus("Posted.", "ok");
         if (input) input.value = "";
       } catch (error) {

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -10,6 +10,7 @@ import {
   listCollaborationMessages,
   listHermesMemoryNotes,
   recordCollaborationMessage,
+  recordHermesMemoryNote,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
 
@@ -170,6 +171,27 @@ describe("Hermes collaboration memory", () => {
       scope: "global",
       text: expect.stringContaining("draft PRs that belong to another agent"),
     });
+  });
+
+  it("records system-learned testbed mission memory with correlation context", () => {
+    const note = recordHermesMemoryNote(
+      {
+        text: "Testbed mission report for https://testbed.example/app: verdict partial. Top blocker: unclear wallet boundary.",
+        relatedCorrelationId: "testbed-mission-abc-1",
+      },
+      NOW
+    );
+
+    expect(note).toMatchObject({
+      scope: "global",
+      relatedCorrelationId: "testbed-mission-abc-1",
+      text: expect.stringContaining("verdict partial"),
+    });
+    expect(listHermesMemoryNotes({
+      relatedCorrelationId: "testbed-mission-abc-1",
+    }).map((entry) => entry.text)).toEqual([
+      expect.stringContaining("unclear wallet boundary"),
+    ]);
   });
 
   it("keeps PR-scoped memory tied to the selected PR while retaining global guidance", () => {

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -396,6 +396,26 @@ describe("applyHermesMemoryInfluence", () => {
     expect(text).toContain("merge-steward ownership");
   });
 
+  it("uses remembered testbed mission report evidence", () => {
+    const text = applyHermesMemoryInfluence("Hermes has a testbed browser mission ready.", {
+      board: {
+        items: [
+          {
+            title: "Fresh-agent browser mission",
+            lane: "Hermes Checking",
+            owner: "Hermes",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Testbed mission report for https://testbed.example/app: verdict partial. Top blocker: unclear wallet boundary.",
+      ],
+    });
+
+    expect(text).toContain("last testbed mission evidence");
+    expect(text).toContain("browser-agent report");
+  });
+
   it("does not duplicate a memory sentence that already exists", () => {
     const text = "This matches your remembered draft rule: keep external-agent drafts parked.";
     expect(applyHermesMemoryInfluence(text, {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, beforeEach } from "vitest";
 import {
   __resetTestbedMissionRunsForTests,
   listTestbedMissionRuns,
+  recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
   testbedMissionRunToMonitorItem,
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
@@ -51,6 +52,97 @@ describe("monitor testbed mission runs", () => {
       },
       safety: {
         wouldMutate: false,
+      },
+    });
+  });
+
+  it("attaches a passing browser-agent report and completes the mission", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    expect(run).toBeDefined();
+
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: run!.id,
+        text: JSON.stringify({
+          verdict: "pass",
+          confidence: 0.91,
+          stoppedBeforeMutation: true,
+          completedPath: ["opened page", "completed onboarding"],
+          blockers: [],
+          scores: { orientation: 5 },
+        }),
+      },
+      Date.parse("2026-05-22T10:05:00.000Z")
+    );
+
+    expect(updated).toMatchObject({
+      id: run!.id,
+      status: "completed",
+      result: {
+        verdict: "pass",
+        confidence: 0.91,
+        ingestedAt: "2026-05-22T10:05:00.000Z",
+      },
+    });
+
+    const item = testbedMissionRunToMonitorItem(updated!);
+    expect(item).toMatchObject({
+      status: "completed",
+      active: false,
+      summary: {
+        finalVerdict: "pass",
+        reviewSignals: {
+          testSignals: ["browser mission packet ready", "browser agent report attached"],
+          missingTestSignals: [],
+        },
+      },
+    });
+  });
+
+  it("attaches a partial browser-agent report and keeps blockers visible", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    expect(run).toBeDefined();
+
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        text: [
+          "mission report",
+          run!.id,
+          "```json",
+          JSON.stringify({
+            verdict: "partial",
+            stoppedBeforeMutation: true,
+            blockers: ["Could not find the submit boundary."],
+            scores: { trustAndSafety: 2 },
+          }),
+          "```",
+        ].join("\n"),
+      },
+      Date.parse("2026-05-22T10:05:00.000Z")
+    );
+
+    expect(updated).toMatchObject({
+      id: run!.id,
+      status: "failed",
+      statusReason: "Browser-agent report returned partial; blocker: Could not find the submit boundary.",
+      result: {
+        verdict: "partial",
+      },
+    });
+
+    const item = testbedMissionRunToMonitorItem(updated!);
+    expect(item).toMatchObject({
+      status: "failed",
+      summary: {
+        finalVerdict: "failed",
+        reviewSignals: {
+          missingTestSignals: [],
+        },
+        reviewReasons: [
+          {
+            code: "testbed_mission_failed",
+          },
+        ],
       },
     });
   });

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -242,6 +242,7 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Fresh-agent browser mission");
     expect(html).toContain("Copy mission prompt");
     expect(html).toContain("browser-only report");
+    expect(html).toContain("result.testbedMissionRun");
     expect(html).toContain("data-codex-task-action=\"send-back\"");
     expect(html).toContain("Send back to Codex");
     expect(html).toContain("codexOperatorSendBackPromptForItem(item");


### PR DESCRIPTION
## What changed
- Attach structured browser-agent mission reports posted in the monitor collaboration chat to the selected testbed mission run.
- Mark passing reports complete, keep partial/failing/unsafe reports visible with blockers and evidence attached.
- Refresh the board/drawer immediately after report ingestion so Hermes shows the attached result without waiting for the next stream tick.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts test/unit/slack-operator.test.ts test/unit/monitor-collab.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- Backend: slack-operator monitor collaboration and mission-run state.
- Frontend: monitor board refresh after collaboration report post.
- No indexer, Caddy, contracts, public site, VPS secret, or environment changes.