### PR TITLE
[codex] Remember testbed mission report lessons

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -36,6 +36,7 @@ import {
   listCollaborationMessages,
   listHermesMemoryNotes,
   recordCollaborationMessage,
+  recordHermesMemoryNote,
   synthesizeHermesReplyFor,
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
@@ -606,6 +607,10 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
 function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
   try {
     const verdict = typeof run.result?.verdict === "string" ? run.result.verdict : run.status;
+    recordHermesMemoryNote({
+      text: testbedMissionMemoryText(run),
+      relatedCorrelationId: run.id,
+    });
     recordCollaborationMessage({
       author: "hermes",
       kind: "status",
@@ -626,6 +631,29 @@ function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
   } catch (error) {
     logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_report_collaboration_failed");
   }
+}
+
+function testbedMissionMemoryText(run: TestbedMissionRun): string {
+  const result = run.result ?? {};
+  const verdict = typeof result.verdict === "string" ? result.verdict : run.status;
+  const blockers = Array.isArray(result.blockers)
+    ? result.blockers.map(String).filter(Boolean)
+    : [];
+  const recommendations = Array.isArray(result.recommendations)
+    ? result.recommendations.map(String).filter(Boolean)
+    : [];
+  const scores = isRecord(result.scores) ? result.scores : {};
+  const weakScores = Object.entries(scores)
+    .filter(([, value]) => Number(value) <= 3)
+    .map(([key, value]) => `${key}:${String(value)}`)
+    .slice(0, 3);
+  const details = [
+    `Testbed mission report for ${run.targetUrl}: verdict ${verdict}.`,
+    blockers.length ? `Top blocker: ${blockers[0]}.` : "",
+    weakScores.length ? `Weak scores: ${weakScores.join(", ")}.` : "",
+    recommendations.length ? `Useful recommendation: ${recommendations[0]}.` : "",
+  ].filter(Boolean).join(" ");
+  return `${details} Treat this as learned testbed evidence for future page missions, not as live proof that the current page is fixed.`;
 }
 
 async function handleMonitorCommandRequest(request: http.IncomingMessage, response: http.ServerResponse) {

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -87,6 +87,13 @@ export interface ListHermesMemoryOptions {
   limit?: number;
 }
 
+export interface RecordHermesMemoryNoteInput {
+  text: string;
+  scope?: "global" | "pr";
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
 export class CollaborationValidationError extends Error {
   constructor(public readonly code: string, message: string) {
     super(message);
@@ -166,6 +173,25 @@ export function listHermesMemoryNotes(options: ListHermesMemoryOptions = {}): He
     return false;
   });
   return filtered.slice(-limit);
+}
+
+export function recordHermesMemoryNote(
+  input: RecordHermesMemoryNoteInput,
+  nowMs: number = Date.now()
+): HermesMemoryNote | undefined {
+  loadHermesMemoryIfNeeded();
+  const text = normalizeText(input.text).slice(0, HERMES_MEMORY_NOTE_MAX_CHARS);
+  if (!text) return undefined;
+  const note: HermesMemoryNote = {
+    id: nextMemoryId(nowMs),
+    ts: nowMs,
+    scope: input.scope ?? (input.relatedPr ? "pr" : "global"),
+    text,
+    ...(input.relatedPr ? { relatedPr: input.relatedPr } : {}),
+    ...(input.relatedCorrelationId ? { relatedCorrelationId: input.relatedCorrelationId.trim().slice(0, 256) } : {}),
+  };
+  upsertHermesMemoryNote(note);
+  return note;
 }
 
 export function classifyHermesMemoryRequest(message: Pick<CollaborationMessage, "author" | "addressedTo" | "text">): HermesMemoryRequestKind {
@@ -249,15 +275,15 @@ function learnHermesMemoryFromMessage(message: CollaborationMessage): void {
   const noteText = memoryTextForMessage(message);
   if (!noteText) return;
 
-  const note: HermesMemoryNote = {
-    id: nextMemoryId(message.ts),
-    ts: message.ts,
-    scope: message.relatedPr ? "pr" : "global",
+  recordHermesMemoryNote({
     text: noteText,
+    scope: message.relatedPr ? "pr" : "global",
     ...(message.relatedPr ? { relatedPr: message.relatedPr } : {}),
     ...(message.relatedCorrelationId ? { relatedCorrelationId: message.relatedCorrelationId } : {}),
-  };
+  }, message.ts);
+}
 
+function upsertHermesMemoryNote(note: HermesMemoryNote): void {
   const dedupeKey = memoryDedupeKey(note);
   const existingIndex = hermesMemoryNotes.findIndex((candidate) =>
     memoryDedupeKey(candidate) === dedupeKey

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -390,6 +390,14 @@ export function hermesMemoryInfluence(context: HermesWhyTraceContext): HermesMem
     };
   }
 
+  if (lowerNote.includes("testbed mission report")) {
+    return {
+      conflict: false,
+      sentence: "I am carrying forward the last testbed mission evidence here, so I will compare new page runs against what the browser-agent report already taught us.",
+      trace: "testbed mission report memory",
+    };
+  }
+
   if (boardSaysCodex && noteSaysDelegatedCodex) {
     return {
       conflict: false,

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -10,6 +10,7 @@ import {
   listCollaborationMessages,
   listHermesMemoryNotes,
   recordCollaborationMessage,
+  recordHermesMemoryNote,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
 
@@ -170,6 +171,27 @@ describe("Hermes collaboration memory", () => {
       scope: "global",
       text: expect.stringContaining("draft PRs that belong to another agent"),
     });
+  });
+
+  it("records system-learned testbed mission memory with correlation context", () => {
+    const note = recordHermesMemoryNote(
+      {
+        text: "Testbed mission report for https://testbed.example/app: verdict partial. Top blocker: unclear wallet boundary.",
+        relatedCorrelationId: "testbed-mission-abc-1",
+      },
+      NOW
+    );
+
+    expect(note).toMatchObject({
+      scope: "global",
+      relatedCorrelationId: "testbed-mission-abc-1",
+      text: expect.stringContaining("verdict partial"),
+    });
+    expect(listHermesMemoryNotes({
+      relatedCorrelationId: "testbed-mission-abc-1",
+    }).map((entry) => entry.text)).toEqual([
+      expect.stringContaining("unclear wallet boundary"),
+    ]);
   });
 
   it("keeps PR-scoped memory tied to the selected PR while retaining global guidance", () => {

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -396,6 +396,26 @@ describe("applyHermesMemoryInfluence", () => {
     expect(text).toContain("merge-steward ownership");
   });
 
+  it("uses remembered testbed mission report evidence", () => {
+    const text = applyHermesMemoryInfluence("Hermes has a testbed browser mission ready.", {
+      board: {
+        items: [
+          {
+            title: "Fresh-agent browser mission",
+            lane: "Hermes Checking",
+            owner: "Hermes",
+          },
+        ],
+      },
+      memoryNotes: [
+        "Testbed mission report for https://testbed.example/app: verdict partial. Top blocker: unclear wallet boundary.",
+      ],
+    });
+
+    expect(text).toContain("last testbed mission evidence");
+    expect(text).toContain("browser-agent report");
+  });
+
   it("does not duplicate a memory sentence that already exists", () => {
     const text = "This matches your remembered draft rule: keep external-agent drafts parked.";
     expect(applyHermesMemoryInfluence(text, {


### PR DESCRIPTION
## What changed
- Added an explicit Hermes memory API for system-learned notes.
- When a testbed mission report is ingested, Hermes now records a compact learned lesson with verdict, top blocker, weak scores, and recommendation.
- Hermes memory influence now recognizes testbed mission report memories and uses them in future board narration/replies with the existing why-trace path.

## Dependency
- Stacked on #190 because this consumes the mission report ingestion path.

## Checks run
- npm test -- test/unit/monitor-collab.test.ts test/unit/monitor-hermes-voice.test.ts test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- Backend: slack-operator monitor memory and mission report handling.
- Hermes voice/narration memory influence.
- No indexer, Caddy, contracts, public site, VPS secret, or environment changes.