### PR TITLE
[codex] Validate testbed mission reports before ingest

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -61,6 +61,7 @@ import {
   summarizeCodexTasks,
 } from "./codex-task-queue.js";
 import {
+  diagnoseTestbedMissionReportFromMessage,
   listTestbedMissionRuns,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
@@ -578,6 +579,14 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
     });
     if (testbedMissionRun) {
       recordTestbedMissionReportCollaboration(testbedMissionRun);
+    } else {
+      const testbedMissionDiagnosis = diagnoseTestbedMissionReportFromMessage({
+        relatedCorrelationId: message.relatedCorrelationId,
+        text: message.text,
+      });
+      if (testbedMissionDiagnosis.candidate && !testbedMissionDiagnosis.valid) {
+        recordTestbedMissionReportValidationCollaboration(message, testbedMissionDiagnosis.errors, testbedMissionDiagnosis.warnings);
+      }
     }
     logger.info(
       {
@@ -601,6 +610,32 @@ async function handleMonitorCollaborationRequest(request: http.IncomingMessage, 
       error: "monitor_collaboration_failed",
       message: error instanceof Error ? error.message : String(error),
     });
+  }
+}
+
+function recordTestbedMissionReportValidationCollaboration(
+  sourceMessage: Awaited<ReturnType<typeof recordCollaborationMessage>>,
+  errors: string[],
+  warnings: string[]
+): void {
+  try {
+    const missing = errors.slice(0, 4).join(" ");
+    const caution = warnings.length ? ` ${warnings[0]}` : "";
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "status",
+      addressedTo: sourceMessage.author === "operator" ? "operator" : "codex",
+      relatedPr: sourceMessage.relatedPr,
+      relatedCorrelationId: sourceMessage.relatedCorrelationId,
+      text: [
+        "I saw a possible testbed mission report, but I did not ingest it yet.",
+        missing || "The report needs more structure before I can attach it to the mission.",
+        "Use the card's Copy report template action, fill the missing fields, and post it again so I can close or fail the mission with auditable evidence.",
+        caution,
+      ].filter(Boolean).join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, sourceMessageId: sourceMessage.id }, "monitor_testbed_mission_report_validation_collaboration_failed");
   }
 }
 

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -29,6 +29,15 @@ export interface MissionReportInput {
   text?: string;
 }
 
+export interface MissionReportDiagnosis {
+  candidate: boolean;
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  missionId?: string;
+  report?: Record<string, unknown>;
+}
+
 const missionRuns: TestbedMissionRun[] = [];
 let missionSeq = 0;
 
@@ -77,9 +86,10 @@ export function recordTestbedMissionReportFromMessage(
   input: MissionReportInput,
   nowMs: number = Date.now()
 ): TestbedMissionRun | undefined {
-  const report = parseMissionReport(input.text ?? "");
-  if (!report) return undefined;
-  const missionId = missionIdFromReportInput(input, report);
+  const diagnosis = diagnoseTestbedMissionReportFromMessage(input);
+  if (!diagnosis.valid || !diagnosis.report) return undefined;
+  const report = diagnosis.report;
+  const missionId = diagnosis.missionId;
   const run = missionId
     ? missionRuns.find((candidate) => candidate.id === missionId)
     : onlyActiveMissionRun();
@@ -99,6 +109,28 @@ export function recordTestbedMissionReportFromMessage(
   run.updatedAt = updatedAt;
   run.statusReason = missionReportStatusReason(report, status, stoppedBeforeMutation);
   return cloneRun(run);
+}
+
+export function diagnoseTestbedMissionReportFromMessage(input: MissionReportInput): MissionReportDiagnosis {
+  const text = input.text ?? "";
+  const report = parseMissionReport(text);
+  const candidate = Boolean(report) || looksLikeMissionReportText(text);
+  if (!report) {
+    return candidate
+      ? { candidate: true, valid: false, errors: ["No JSON report object was found."], warnings: [] }
+      : { candidate: false, valid: false, errors: [], warnings: [] };
+  }
+  const missionId = missionIdFromReportInput(input, report);
+  const errors = validateMissionReport(report);
+  const warnings = missionId ? [] : ["No missionId was included; Hermes will only attach this if exactly one mission is active."];
+  return {
+    candidate: true,
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    ...(missionId ? { missionId } : {}),
+    report,
+  };
 }
 
 export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<string, unknown> {
@@ -216,6 +248,42 @@ function looksLikeMissionReport(value: Record<string, unknown>): boolean {
   if (normalizeVerdict(value.verdict)) return true;
   if (Array.isArray(value.completedPath) || Array.isArray(value.blockers) || isRecord(value.scores)) return true;
   return false;
+}
+
+function looksLikeMissionReportText(text: string): boolean {
+  const lower = text.toLowerCase();
+  return lower.includes("mission report")
+    || lower.includes("testbed mission")
+    || /\btestbed-mission-[A-Za-z0-9-]+\b/.test(text);
+}
+
+function validateMissionReport(report: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  const verdict = normalizeVerdict(report.verdict);
+  if (!verdict) errors.push("Set verdict to pass, partial, or fail.");
+  if (typeof report.confidence !== "number" || report.confidence < 0 || report.confidence > 1) {
+    errors.push("Set confidence to a number from 0 to 1.");
+  }
+  if (typeof report.stoppedBeforeMutation !== "boolean") {
+    errors.push("Set stoppedBeforeMutation to true or false.");
+  }
+  if (!nonEmptyStringArray(report.evidence)) {
+    errors.push("Add at least one evidence item or observation.");
+  }
+  if (!isRecord(report.scores)) {
+    errors.push("Add a scores object, even if some scores are 0.");
+  }
+  if (verdict === "pass" && !nonEmptyStringArray(report.completedPath)) {
+    errors.push("For a pass, add the completedPath steps the browser agent actually took.");
+  }
+  if ((verdict === "partial" || verdict === "fail") && !nonEmptyStringArray(report.blockers) && !nonEmptyStringArray(report.confusingMoments)) {
+    errors.push("For partial or fail, add blockers or confusingMoments so Hermes knows what stopped the agent.");
+  }
+  return errors;
+}
+
+function nonEmptyStringArray(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => String(entry ?? "").trim().length > 0);
 }
 
 function normalizeVerdict(value: unknown): "pass" | "partial" | "fail" | undefined {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach } from "vitest";
 
 import {
   __resetTestbedMissionRunsForTests,
+  diagnoseTestbedMissionReportFromMessage,
   listTestbedMissionRuns,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
@@ -69,6 +70,7 @@ describe("monitor testbed mission runs", () => {
           stoppedBeforeMutation: true,
           completedPath: ["opened page", "completed onboarding"],
           blockers: [],
+          evidence: [{ type: "observation", value: "The browser agent reached the final review step." }],
           scores: { orientation: 5 },
         }),
       },
@@ -111,8 +113,10 @@ describe("monitor testbed mission runs", () => {
           "```json",
           JSON.stringify({
             verdict: "partial",
+            confidence: 0.63,
             stoppedBeforeMutation: true,
             blockers: ["Could not find the submit boundary."],
+            evidence: [{ type: "observation", value: "The browser agent stopped at the wallet prompt." }],
             scores: { trustAndSafety: 2 },
           }),
           "```",
@@ -145,6 +149,45 @@ describe("monitor testbed mission runs", () => {
         ],
       },
     });
+  });
+
+  it("rejects incomplete browser-agent reports before attaching them", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    expect(run).toBeDefined();
+
+    const diagnosis = diagnoseTestbedMissionReportFromMessage({
+      relatedCorrelationId: run!.id,
+      text: JSON.stringify({
+        verdict: "pass",
+        stoppedBeforeMutation: true,
+        scores: { orientation: 5 },
+      }),
+    });
+
+    expect(diagnosis).toMatchObject({
+      candidate: true,
+      valid: false,
+      errors: expect.arrayContaining([
+        "Set confidence to a number from 0 to 1.",
+        "Add at least one evidence item or observation.",
+        "For a pass, add the completedPath steps the browser agent actually took.",
+      ]),
+    });
+
+    expect(recordTestbedMissionReportFromMessage({
+      relatedCorrelationId: run!.id,
+      text: JSON.stringify({
+        verdict: "pass",
+        stoppedBeforeMutation: true,
+        scores: { orientation: 5 },
+      }),
+    })).toBeUndefined();
+    const stillPending = listTestbedMissionRuns()[0];
+    expect(stillPending).toMatchObject({
+      id: run!.id,
+      status: "ready",
+    });
+    expect(stillPending.result).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What changed
- Added structured validation for pasted testbed mission reports before they attach to a mission run.
- Requires clear verdict, confidence, mutation-boundary flag, evidence, scores, and pass/fail-specific context.
- If a possible report is incomplete, Hermes posts a conversational status reply explaining what is missing and asks for the report template to be filled instead of silently ingesting weak evidence.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- slack-operator / monitor collaboration ingest
- testbed mission run validation
- No environment or VPS secret changes