### PR TITLE
[codex] Draft Codex follow-ups from failed testbed missions

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -65,6 +65,7 @@ import {
   listTestbedMissionRuns,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
+  testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
   testbedMissionResultCoaching,
   type TestbedMissionRun,
@@ -660,6 +661,20 @@ function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
           testbedMissionResultCoaching(run),
         ].join(" "),
     });
+    const followupPrompt = testbedMissionCodexFollowupPrompt(run);
+    if (followupPrompt) {
+      recordCollaborationMessage({
+        author: "hermes",
+        kind: "proposal",
+        addressedTo: "operator",
+        relatedCorrelationId: run.id,
+        text: [
+          "I drafted the smallest Codex follow-up from this failed testbed mission.",
+          "Do not approve runner work automatically from here yet; use this as the task brief once there is a concrete branch/page target.",
+          followupPrompt,
+        ].join("\n\n"),
+      });
+    }
   } catch (error) {
     logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_report_collaboration_failed");
   }

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -218,6 +218,35 @@ export function testbedMissionReportValidationCoaching(errors: string[], warning
   ].filter(Boolean).join(" ");
 }
 
+export function testbedMissionCodexFollowupPrompt(run: TestbedMissionRun): string | undefined {
+  if (run.status === "completed" || !run.result) return undefined;
+  const result = run.result;
+  const blockers = stringArray(result.blockers);
+  const confusingMoments = stringArray(result.confusingMoments);
+  const recommendations = stringArray(result.recommendations);
+  const weakScores = weakMissionScores(result.scores);
+  const primaryBlocker = blockers[0] || confusingMoments[0] || "the fresh browser agent could not complete the mission cleanly";
+  const suggestedFix = recommendations[0] || productFixSuggestion(primaryBlocker, weakScores);
+  const evidence = missionEvidenceStrings(result.evidence)
+    .concat(blockers.map((blocker) => `blocker: ${blocker}`))
+    .concat(confusingMoments.map((moment) => `confusing moment: ${moment}`))
+    .concat(weakScores.map((score) => `weak score: ${score}`))
+    .slice(0, 8);
+  return [
+    `Fix the testbed page for mission ${run.id}.`,
+    "",
+    `Target: ${run.targetUrl}`,
+    `Goal: ${run.goal}`,
+    `Fresh-agent result: ${String(result.verdict || run.status)}`,
+    `Primary blocker: ${primaryBlocker}`,
+    `Suggested product fix: ${suggestedFix}`,
+    "",
+    "Use the smallest product/UI change that helps a normal outside agent complete this goal without project-specific memory. Keep mutation boundaries explicit and do not weaken safety copy.",
+    "After the change, run the same testbed mission again and report whether the blocker disappeared.",
+    evidence.length ? `Evidence:\n- ${evidence.join("\n- ")}` : "Evidence: see the attached testbed mission result in Hermes.",
+  ].join("\n");
+}
+
 export function __resetTestbedMissionRunsForTests(): void {
   missionRuns.splice(0, missionRuns.length);
   missionSeq = 0;
@@ -362,6 +391,21 @@ function stringArray(value: unknown): string[] {
   return Array.isArray(value)
     ? value.map((entry) => String(entry ?? "").trim()).filter(Boolean)
     : [];
+}
+
+function missionEvidenceStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((entry) => {
+    if (typeof entry === "string") return entry.trim();
+    if (!isRecord(entry)) return String(entry ?? "").trim();
+    const type = typeof entry.type === "string" ? entry.type.trim() : "evidence";
+    const detail = typeof entry.value === "string"
+      ? entry.value.trim()
+      : typeof entry.url === "string"
+        ? entry.url.trim()
+        : "";
+    return detail ? `${type}: ${detail}` : type;
+  }).filter(Boolean);
 }
 
 function weakMissionScores(value: unknown): string[] {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -6,6 +6,7 @@ import {
   listTestbedMissionRuns,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
+  testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
   testbedMissionResultCoaching,
   testbedMissionRunToMonitorItem,
@@ -157,6 +158,13 @@ describe("monitor testbed mission runs", () => {
     expect(coaching).toContain("Suggested product fix");
     expect(coaching).toContain("Smallest Codex task");
     expect(coaching).toContain("run this same testbed mission again");
+
+    const prompt = testbedMissionCodexFollowupPrompt(updated!);
+    expect(prompt).toContain("Fix the testbed page for mission");
+    expect(prompt).toContain("Primary blocker: Could not find the submit boundary.");
+    expect(prompt).toContain("Suggested product fix: make the mutation boundary explicit");
+    expect(prompt).toContain("After the change, run the same testbed mission again");
+    expect(prompt).toContain("observation: The browser agent stopped at the wallet prompt.");
   });
 
   it("rejects incomplete browser-agent reports before attaching them", () => {


### PR DESCRIPTION
## What changed
- Added a copy-ready Codex follow-up prompt for failed/partial testbed mission reports.
- Hermes now posts the follow-up as a proposal in the collaboration chat after ingesting failed mission evidence.
- The proposal intentionally does not enqueue or approve runner work automatically, because the current Codex runner is PR-branch based and needs a concrete branch/page target first.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- slack-operator / monitor collaboration replies
- testbed mission report helpers
- No environment or VPS secret changes