### PR TITLE
[codex] Add testbed mission timeline

### DIFF
--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -2,6 +2,13 @@ const MAX_MISSION_RUNS = 50;
 
 export type TestbedMissionStatus = "ready" | "running" | "completed" | "failed";
 
+export interface TestbedMissionHistoryEntry {
+  at: string;
+  status: TestbedMissionStatus;
+  event: string;
+  message: string;
+}
+
 export interface TestbedMissionRun {
   schemaVersion: 1;
   kind: "testbed_mission_run";
@@ -14,6 +21,7 @@ export interface TestbedMissionRun {
   freshMemory: boolean;
   mission: Record<string, unknown>;
   result?: Record<string, unknown>;
+  history: TestbedMissionHistoryEntry[];
   createdAt: string;
   updatedAt: string;
   statusReason: string;
@@ -62,6 +70,14 @@ export function recordTestbedMissionRunFromOperatorResult(
     agentName: stringField(target, "agentName") ?? "Hermes",
     freshMemory: target.freshMemory !== false,
     mission,
+    history: [
+      {
+        at: createdAt,
+        status: "ready",
+        event: "mission_packet_ready",
+        message: "Mission packet generated; waiting for a clean browser-only agent run.",
+      },
+    ],
     createdAt,
     updatedAt: createdAt,
     statusReason: "Mission packet is ready; waiting for a browser-only agent run and structured report.",
@@ -79,7 +95,7 @@ export function listTestbedMissionRuns(options: ListTestbedMissionRunOptions = {
   return runs
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
     .slice(0, limit)
-    .map((run) => ({ ...run, mission: { ...run.mission }, ...(run.result ? { result: { ...run.result } } : {}) }));
+    .map((run) => cloneRun(run));
 }
 
 export function recordTestbedMissionReportFromMessage(
@@ -108,6 +124,12 @@ export function recordTestbedMissionReportFromMessage(
   run.status = status;
   run.updatedAt = updatedAt;
   run.statusReason = missionReportStatusReason(report, status, stoppedBeforeMutation);
+  run.history.push({
+    at: updatedAt,
+    status,
+    event: status === "completed" ? "mission_report_passed" : "mission_report_needs_fix",
+    message: run.statusReason,
+  });
   return cloneRun(run);
 }
 
@@ -263,6 +285,7 @@ function cloneRun(run: TestbedMissionRun): TestbedMissionRun {
   return {
     ...run,
     mission: { ...run.mission },
+    history: run.history.map((entry) => ({ ...entry })),
     ...(run.result ? { result: { ...run.result } } : {}),
   };
 }

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -6556,6 +6556,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const prompt = String(mission.missionPrompt || "");
       const reportTemplate = testbedMissionReportTemplate(run, mission);
       const result = run.result || null;
+      const history = testbedMissionHistoryList(run.history);
       const rows = [
         row("Target", escapeHtml(String(run.targetUrl || target.url || "[TESTBED_URL]"))),
         row("Goal", escapeHtml(String(run.goal || target.goal || "test first-contact usability"))),
@@ -6583,6 +6584,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<h4>Runbook</h4>' + runbookHtml +
         '<h4>Rubric</h4>' + rubricHtml +
         resultHtml +
+        (history.length ? '<h4>Mission timeline</h4><ol class="resolution-steps">' + history.map((entry) => '<li><strong>' + escapeHtml(entry.event) + '</strong> <span class="muted">' + escapeHtml(entry.at) + '</span><br>' + escapeHtml(entry.message) + '</li>').join("") + '</ol>' : "") +
         (prompt ? '<details class="drawer-disclosure prompt-disclosure"><summary>Mission prompt</summary><pre class="prompt-box">' + escapeHtml(prompt) + '</pre></details>' : "") +
         '<details class="drawer-disclosure prompt-disclosure"><summary>Report schema</summary><pre class="prompt-box">' + escapeHtml(prettyJson(reportSchema)) + '</pre></details>' +
         '<details class="drawer-disclosure prompt-disclosure"><summary>Report template</summary><pre class="prompt-box">' + escapeHtml(reportTemplate) + '</pre></details>' +
@@ -6657,6 +6659,18 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         const state = Number.isFinite(numeric) && numeric >= 4 ? "pass" : Number.isFinite(numeric) && numeric <= 2 ? "fail" : "pending";
         return { label, value: String(score), state };
       });
+    }
+
+    function testbedMissionHistoryList(value) {
+      if (!Array.isArray(value)) return [];
+      return value.slice(-6).map((entry) => {
+        const record = entry && typeof entry === "object" && !Array.isArray(entry) ? entry : {};
+        return {
+          at: String(record.at || "unknown time"),
+          event: String(record.event || record.status || "mission update").replace(/_/g, " "),
+          message: String(record.message || "Mission state changed."),
+        };
+      }).filter((entry) => entry.message.trim()).reverse();
     }
 
     function testbedMissionReportTemplate(run, mission) {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -27,6 +27,13 @@ describe("monitor testbed mission runs", () => {
       goal: "complete onboarding",
       agentName: "Hermes",
       freshMemory: true,
+      history: [
+        {
+          event: "mission_packet_ready",
+          status: "ready",
+          message: "Mission packet generated; waiting for a clean browser-only agent run.",
+        },
+      ],
     });
     expect(run?.id).toMatch(/^testbed-mission-/);
     expect(listTestbedMissionRuns()).toHaveLength(1);
@@ -88,6 +95,16 @@ describe("monitor testbed mission runs", () => {
         confidence: 0.91,
         ingestedAt: "2026-05-22T10:05:00.000Z",
       },
+      history: [
+        {
+          event: "mission_packet_ready",
+        },
+        {
+          event: "mission_report_passed",
+          status: "completed",
+          at: "2026-05-22T10:05:00.000Z",
+        },
+      ],
     });
 
     const item = testbedMissionRunToMonitorItem(updated!);
@@ -135,6 +152,16 @@ describe("monitor testbed mission runs", () => {
       result: {
         verdict: "partial",
       },
+      history: [
+        {
+          event: "mission_packet_ready",
+        },
+        {
+          event: "mission_report_needs_fix",
+          status: "failed",
+          message: "Browser-agent report returned partial; blocker: Could not find the submit boundary.",
+        },
+      ],
     });
 
     const item = testbedMissionRunToMonitorItem(updated!);

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -246,6 +246,8 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderTestbedMissionReportPacket(result)");
     expect(html).toContain("Browser-agent report");
     expect(html).toContain("Structured result JSON");
+    expect(html).toContain("Mission timeline");
+    expect(html).toContain("testbedMissionHistoryList(run.history)");
     expect(html).toContain("browser-only report");
     expect(html).toContain("result.testbedMissionRun");
     expect(html).toContain("data-codex-task-action=\"send-back\"");


### PR DESCRIPTION
## What changed
- Added a small history trail to each testbed browser mission run.
- Records mission packet creation and report verdict attachment as auditable timeline entries.
- Shows the latest mission timeline in the monitor drawer so operators and fresh agents can understand what happened without reading raw JSON.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- slack-operator / monitor testbed mission state and drawer UI
- No environment or VPS secret changes