### PR TITLE
[codex] Add testbed mission rerun prompt

### DIFF
--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -269,6 +269,31 @@ export function testbedMissionCodexFollowupPrompt(run: TestbedMissionRun): strin
   ].join("\n");
 }
 
+export function testbedMissionRerunPrompt(run: TestbedMissionRun): string | undefined {
+  if (run.status !== "failed" || !run.result) return undefined;
+  const result = run.result;
+  const blockers = stringArray(result.blockers);
+  const confusingMoments = stringArray(result.confusingMoments);
+  const recommendations = stringArray(result.recommendations);
+  const primaryBlocker = blockers[0] || confusingMoments[0] || "the previous browser-agent run did not complete cleanly";
+  const prompt = isRecord(run.mission) && typeof run.mission.missionPrompt === "string"
+    ? run.mission.missionPrompt.trim()
+    : "";
+  return [
+    `Rerun testbed mission ${run.id} after the product fix.`,
+    "",
+    `Target: ${run.targetUrl}`,
+    `Goal: ${run.goal}`,
+    "Memory mode: fresh browser agent; do not use Averray project memory or this monitor as product context.",
+    `Previous verdict: ${String(result.verdict || run.status)}`,
+    `Previous blocker to compare against: ${primaryBlocker}`,
+    recommendations[0] ? `Expected improvement: ${recommendations[0]}` : "Expected improvement: the previous blocker should either disappear or become clearly different.",
+    "",
+    "Run the same visible-page path again. Stop before any real mutation boundary. Report whether the previous blocker is fixed, still present, or replaced by a new blocker.",
+    prompt ? `\nOriginal mission prompt:\n${prompt}` : "",
+  ].filter(Boolean).join("\n");
+}
+
 export function __resetTestbedMissionRunsForTests(): void {
   missionRuns.splice(0, missionRuns.length);
   missionSeq = 0;

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -6557,6 +6557,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const reportTemplate = testbedMissionReportTemplate(run, mission);
       const result = run.result || null;
       const history = testbedMissionHistoryList(run.history);
+      const rerunPrompt = testbedMissionRerunPrompt(run, mission);
       const rows = [
         row("Target", escapeHtml(String(run.targetUrl || target.url || "[TESTBED_URL]"))),
         row("Goal", escapeHtml(String(run.goal || target.goal || "test first-contact usability"))),
@@ -6584,12 +6585,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<h4>Runbook</h4>' + runbookHtml +
         '<h4>Rubric</h4>' + rubricHtml +
         resultHtml +
+        (rerunPrompt ? '<details class="drawer-disclosure prompt-disclosure" open><summary>Rerun after fix</summary><pre class="prompt-box">' + escapeHtml(rerunPrompt) + '</pre></details>' : "") +
         (history.length ? '<h4>Mission timeline</h4><ol class="resolution-steps">' + history.map((entry) => '<li><strong>' + escapeHtml(entry.event) + '</strong> <span class="muted">' + escapeHtml(entry.at) + '</span><br>' + escapeHtml(entry.message) + '</li>').join("") + '</ol>' : "") +
         (prompt ? '<details class="drawer-disclosure prompt-disclosure"><summary>Mission prompt</summary><pre class="prompt-box">' + escapeHtml(prompt) + '</pre></details>' : "") +
         '<details class="drawer-disclosure prompt-disclosure"><summary>Report schema</summary><pre class="prompt-box">' + escapeHtml(prettyJson(reportSchema)) + '</pre></details>' +
         '<details class="drawer-disclosure prompt-disclosure"><summary>Report template</summary><pre class="prompt-box">' + escapeHtml(reportTemplate) + '</pre></details>' +
         '<div class="resolution-actions">' +
           (prompt ? '<button class="soft-button" type="button" data-copy-label="Mission prompt copied" data-copy-text="' + escapeAttr(prompt) + '">Copy mission prompt</button>' : "") +
+          (rerunPrompt ? '<button class="soft-button" type="button" data-copy-label="Rerun prompt copied" data-copy-text="' + escapeAttr(rerunPrompt) + '">Copy rerun prompt</button>' : "") +
           '<button class="soft-button" type="button" data-copy-label="Report schema copied" data-copy-text="' + escapeAttr(prettyJson(reportSchema)) + '">Copy report schema</button>' +
           '<button class="soft-button" type="button" data-copy-label="Report template copied" data-copy-text="' + escapeAttr(reportTemplate) + '">Copy report template</button>' +
         '</div>' +
@@ -6602,8 +6605,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const mission = run.mission || {};
       const prompt = String(mission.missionPrompt || "");
       const reportTemplate = testbedMissionReportTemplate(run, mission);
+      const rerunPrompt = testbedMissionRerunPrompt(run, mission);
       return [
         prompt ? '<button class="soft-button" type="button" data-copy-label="Mission prompt copied" data-copy-text="' + escapeAttr(prompt) + '">Copy mission prompt</button>' : "",
+        rerunPrompt ? '<button class="soft-button" type="button" data-copy-label="Rerun prompt copied" data-copy-text="' + escapeAttr(rerunPrompt) + '">Copy rerun prompt</button>' : "",
         '<button class="soft-button" type="button" data-copy-label="Report template copied" data-copy-text="' + escapeAttr(reportTemplate) + '">Copy report template</button>',
       ].filter(Boolean).join("");
     }
@@ -6671,6 +6676,34 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           message: String(record.message || "Mission state changed."),
         };
       }).filter((entry) => entry.message.trim()).reverse();
+    }
+
+    function testbedMissionRerunPrompt(run, mission) {
+      const result = run && run.result;
+      const status = String(run && run.status || "");
+      const verdict = String(result && result.verdict || "");
+      const stopped = result && typeof result.stoppedBeforeMutation === "boolean" ? result.stoppedBeforeMutation : true;
+      const needsRerun = result && (status === "failed" || verdict === "partial" || verdict === "fail" || stopped === false);
+      if (!needsRerun) return "";
+      const blockers = testbedReportList(result && result.blockers);
+      const confusingMoments = testbedReportList(result && result.confusingMoments);
+      const recommendations = testbedReportList(result && result.recommendations);
+      const prompt = String(mission && mission.missionPrompt || "").trim();
+      const primaryBlocker = blockers[0] || confusingMoments[0] || "the previous browser-agent run did not complete cleanly";
+      const nl = String.fromCharCode(10);
+      return [
+        "Rerun testbed mission " + String(run && run.id || "unknown") + " after the product fix.",
+        "",
+        "Target: " + String(run && run.targetUrl || "[TESTBED_URL]"),
+        "Goal: " + String(run && run.goal || "test first-contact usability"),
+        "Memory mode: fresh browser agent; do not use Averray project memory or this monitor as product context.",
+        "Previous verdict: " + String(verdict || status || "reported"),
+        "Previous blocker to compare against: " + primaryBlocker,
+        recommendations[0] ? "Expected improvement: " + recommendations[0] : "Expected improvement: the previous blocker should either disappear or become clearly different.",
+        "",
+        "Run the same visible-page path again. Stop before any real mutation boundary. Report whether the previous blocker is fixed, still present, or replaced by a new blocker.",
+        prompt ? nl + "Original mission prompt:" + nl + prompt : "",
+      ].filter(Boolean).join(nl);
     }
 
     function testbedMissionReportTemplate(run, mission) {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -8,6 +8,7 @@ import {
   recordTestbedMissionRunFromOperatorResult,
   testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
+  testbedMissionRerunPrompt,
   testbedMissionResultCoaching,
   testbedMissionRunToMonitorItem,
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
@@ -192,6 +193,13 @@ describe("monitor testbed mission runs", () => {
     expect(prompt).toContain("Suggested product fix: make the mutation boundary explicit");
     expect(prompt).toContain("After the change, run the same testbed mission again");
     expect(prompt).toContain("observation: The browser agent stopped at the wallet prompt.");
+
+    const rerunPrompt = testbedMissionRerunPrompt(updated!);
+    expect(rerunPrompt).toContain("Rerun testbed mission");
+    expect(rerunPrompt).toContain("Memory mode: fresh browser agent");
+    expect(rerunPrompt).toContain("Previous blocker to compare against: Could not find the submit boundary.");
+    expect(rerunPrompt).toContain("Original mission prompt:");
+    expect(rerunPrompt).toContain("Open the app and complete onboarding.");
   });
 
   it("rejects incomplete browser-agent reports before attaching them", () => {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -248,6 +248,9 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Structured result JSON");
     expect(html).toContain("Mission timeline");
     expect(html).toContain("testbedMissionHistoryList(run.history)");
+    expect(html).toContain("Rerun after fix");
+    expect(html).toContain("Copy rerun prompt");
+    expect(html).toContain("testbedMissionRerunPrompt(run, mission)");
     expect(html).toContain("browser-only report");
     expect(html).toContain("result.testbedMissionRun");
     expect(html).toContain("data-codex-task-action=\"send-back\"");


### PR DESCRIPTION
## What changed
- Added a reusable rerun prompt for failed testbed browser missions.
- The prompt carries forward the previous verdict, blocker, expected improvement, original mission prompt, and fresh-memory rule.
- Shows a "Rerun after fix" drawer section and Copy rerun prompt action only when a mission result needs another run.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- slack-operator / monitor testbed mission drawer and prompt generation
- No environment or VPS secret changes