### PR TITLE
[codex] Add testbed mission baseline prompt

### DIFF
--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -294,6 +294,32 @@ export function testbedMissionRerunPrompt(run: TestbedMissionRun): string | unde
   ].filter(Boolean).join("\n");
 }
 
+export function testbedMissionBaselinePrompt(run: TestbedMissionRun): string | undefined {
+  if (run.status !== "completed" || !run.result) return undefined;
+  const result = run.result;
+  const completedPath = stringArray(result.completedPath);
+  const evidence = missionEvidenceStrings(result.evidence).slice(0, 5);
+  const recommendations = stringArray(result.recommendations);
+  const prompt = isRecord(run.mission) && typeof run.mission.missionPrompt === "string"
+    ? run.mission.missionPrompt.trim()
+    : "";
+  return [
+    `Use testbed mission ${run.id} as the baseline for future page checks.`,
+    "",
+    `Target: ${run.targetUrl}`,
+    `Goal: ${run.goal}`,
+    "Memory mode: fresh browser agent; do not use Averray project memory or previous monitor discussion as product context.",
+    `Baseline verdict: ${String(result.verdict || run.status)}`,
+    typeof result.confidence === "number" ? `Baseline confidence: ${Math.round(result.confidence * 100)}%` : "",
+    completedPath.length ? `Known-good path:\n- ${completedPath.join("\n- ")}` : "Known-good path: see the attached browser-agent report.",
+    evidence.length ? `Baseline evidence:\n- ${evidence.join("\n- ")}` : "",
+    recommendations[0] ? `Watch next time: ${recommendations[0]}` : "Watch next time: any new hesitation, missing context, or safety ambiguity compared with the known-good path.",
+    "",
+    "When the page changes, run this mission again and compare against the known-good path. Report whether the path still works, became clearer, or regressed.",
+    prompt ? `\nOriginal mission prompt:\n${prompt}` : "",
+  ].filter(Boolean).join("\n");
+}
+
 export function __resetTestbedMissionRunsForTests(): void {
   missionRuns.splice(0, missionRuns.length);
   missionSeq = 0;

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -6558,6 +6558,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const result = run.result || null;
       const history = testbedMissionHistoryList(run.history);
       const rerunPrompt = testbedMissionRerunPrompt(run, mission);
+      const baselinePrompt = testbedMissionBaselinePrompt(run, mission);
       const rows = [
         row("Target", escapeHtml(String(run.targetUrl || target.url || "[TESTBED_URL]"))),
         row("Goal", escapeHtml(String(run.goal || target.goal || "test first-contact usability"))),
@@ -6585,6 +6586,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<h4>Runbook</h4>' + runbookHtml +
         '<h4>Rubric</h4>' + rubricHtml +
         resultHtml +
+        (baselinePrompt ? '<details class="drawer-disclosure prompt-disclosure"><summary>Baseline for future runs</summary><pre class="prompt-box">' + escapeHtml(baselinePrompt) + '</pre></details>' : "") +
         (rerunPrompt ? '<details class="drawer-disclosure prompt-disclosure" open><summary>Rerun after fix</summary><pre class="prompt-box">' + escapeHtml(rerunPrompt) + '</pre></details>' : "") +
         (history.length ? '<h4>Mission timeline</h4><ol class="resolution-steps">' + history.map((entry) => '<li><strong>' + escapeHtml(entry.event) + '</strong> <span class="muted">' + escapeHtml(entry.at) + '</span><br>' + escapeHtml(entry.message) + '</li>').join("") + '</ol>' : "") +
         (prompt ? '<details class="drawer-disclosure prompt-disclosure"><summary>Mission prompt</summary><pre class="prompt-box">' + escapeHtml(prompt) + '</pre></details>' : "") +
@@ -6592,6 +6594,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<details class="drawer-disclosure prompt-disclosure"><summary>Report template</summary><pre class="prompt-box">' + escapeHtml(reportTemplate) + '</pre></details>' +
         '<div class="resolution-actions">' +
           (prompt ? '<button class="soft-button" type="button" data-copy-label="Mission prompt copied" data-copy-text="' + escapeAttr(prompt) + '">Copy mission prompt</button>' : "") +
+          (baselinePrompt ? '<button class="soft-button" type="button" data-copy-label="Baseline prompt copied" data-copy-text="' + escapeAttr(baselinePrompt) + '">Copy baseline prompt</button>' : "") +
           (rerunPrompt ? '<button class="soft-button" type="button" data-copy-label="Rerun prompt copied" data-copy-text="' + escapeAttr(rerunPrompt) + '">Copy rerun prompt</button>' : "") +
           '<button class="soft-button" type="button" data-copy-label="Report schema copied" data-copy-text="' + escapeAttr(prettyJson(reportSchema)) + '">Copy report schema</button>' +
           '<button class="soft-button" type="button" data-copy-label="Report template copied" data-copy-text="' + escapeAttr(reportTemplate) + '">Copy report template</button>' +
@@ -6606,8 +6609,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const prompt = String(mission.missionPrompt || "");
       const reportTemplate = testbedMissionReportTemplate(run, mission);
       const rerunPrompt = testbedMissionRerunPrompt(run, mission);
+      const baselinePrompt = testbedMissionBaselinePrompt(run, mission);
       return [
         prompt ? '<button class="soft-button" type="button" data-copy-label="Mission prompt copied" data-copy-text="' + escapeAttr(prompt) + '">Copy mission prompt</button>' : "",
+        baselinePrompt ? '<button class="soft-button" type="button" data-copy-label="Baseline prompt copied" data-copy-text="' + escapeAttr(baselinePrompt) + '">Copy baseline prompt</button>' : "",
         rerunPrompt ? '<button class="soft-button" type="button" data-copy-label="Rerun prompt copied" data-copy-text="' + escapeAttr(rerunPrompt) + '">Copy rerun prompt</button>' : "",
         '<button class="soft-button" type="button" data-copy-label="Report template copied" data-copy-text="' + escapeAttr(reportTemplate) + '">Copy report template</button>',
       ].filter(Boolean).join("");
@@ -6702,6 +6707,36 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         recommendations[0] ? "Expected improvement: " + recommendations[0] : "Expected improvement: the previous blocker should either disappear or become clearly different.",
         "",
         "Run the same visible-page path again. Stop before any real mutation boundary. Report whether the previous blocker is fixed, still present, or replaced by a new blocker.",
+        prompt ? nl + "Original mission prompt:" + nl + prompt : "",
+      ].filter(Boolean).join(nl);
+    }
+
+    function testbedMissionBaselinePrompt(run, mission) {
+      const result = run && run.result;
+      const status = String(run && run.status || "");
+      const verdict = String(result && result.verdict || "");
+      const stopped = result && typeof result.stoppedBeforeMutation === "boolean" ? result.stoppedBeforeMutation : true;
+      const isBaseline = result && (status === "completed" || verdict === "pass") && stopped !== false;
+      if (!isBaseline) return "";
+      const completedPath = testbedReportList(result && result.completedPath);
+      const evidence = testbedReportEvidenceList(result && result.evidence).map((entry) => entry.label + ": " + entry.value).slice(0, 5);
+      const recommendations = testbedReportList(result && result.recommendations);
+      const prompt = String(mission && mission.missionPrompt || "").trim();
+      const confidence = typeof result.confidence === "number" ? String(Math.round(result.confidence * 100)) + "%" : "";
+      const nl = String.fromCharCode(10);
+      return [
+        "Use testbed mission " + String(run && run.id || "unknown") + " as the baseline for future page checks.",
+        "",
+        "Target: " + String(run && run.targetUrl || "[TESTBED_URL]"),
+        "Goal: " + String(run && run.goal || "test first-contact usability"),
+        "Memory mode: fresh browser agent; do not use Averray project memory or previous monitor discussion as product context.",
+        "Baseline verdict: " + String(verdict || status || "pass"),
+        confidence ? "Baseline confidence: " + confidence : "",
+        completedPath.length ? "Known-good path:" + nl + "- " + completedPath.join(nl + "- ") : "Known-good path: see the attached browser-agent report.",
+        evidence.length ? "Baseline evidence:" + nl + "- " + evidence.join(nl + "- ") : "",
+        recommendations[0] ? "Watch next time: " + recommendations[0] : "Watch next time: any new hesitation, missing context, or safety ambiguity compared with the known-good path.",
+        "",
+        "When the page changes, run this mission again and compare against the known-good path. Report whether the path still works, became clearer, or regressed.",
         prompt ? nl + "Original mission prompt:" + nl + prompt : "",
       ].filter(Boolean).join(nl);
     }

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -6,6 +6,7 @@ import {
   listTestbedMissionRuns,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
+  testbedMissionBaselinePrompt,
   testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
   testbedMissionRerunPrompt,
@@ -120,6 +121,14 @@ describe("monitor testbed mission runs", () => {
         },
       },
     });
+
+    const baselinePrompt = testbedMissionBaselinePrompt(updated!);
+    expect(baselinePrompt).toContain("Use testbed mission");
+    expect(baselinePrompt).toContain("as the baseline for future page checks");
+    expect(baselinePrompt).toContain("Known-good path:");
+    expect(baselinePrompt).toContain("opened page");
+    expect(baselinePrompt).toContain("Baseline confidence: 91%");
+    expect(baselinePrompt).toContain("When the page changes, run this mission again");
   });
 
   it("attaches a partial browser-agent report and keeps blockers visible", () => {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -248,6 +248,9 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("Structured result JSON");
     expect(html).toContain("Mission timeline");
     expect(html).toContain("testbedMissionHistoryList(run.history)");
+    expect(html).toContain("Baseline for future runs");
+    expect(html).toContain("Copy baseline prompt");
+    expect(html).toContain("testbedMissionBaselinePrompt(run, mission)");
     expect(html).toContain("Rerun after fix");
     expect(html).toContain("Copy rerun prompt");
     expect(html).toContain("testbedMissionRerunPrompt(run, mission)");


### PR DESCRIPTION
## What changed
- Added a reusable baseline prompt for completed testbed browser missions.
- The prompt captures target, goal, confidence, known-good path, baseline evidence, and the fresh-memory rule for future regression checks.
- Shows a "Baseline for future runs" drawer section and Copy baseline prompt action only when a mission has passed.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- slack-operator / monitor testbed mission drawer and prompt generation
- No environment or VPS secret changes