### PR TITLE
[codex] Add testbed mission comparison brief

### DIFF
--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -320,6 +320,36 @@ export function testbedMissionBaselinePrompt(run: TestbedMissionRun): string | u
   ].filter(Boolean).join("\n");
 }
 
+export function testbedMissionComparisonBrief(run: TestbedMissionRun): string | undefined {
+  if (!run.result) return undefined;
+  const result = run.result;
+  const verdict = String(result.verdict || run.status);
+  const completedPath = stringArray(result.completedPath);
+  const blockers = stringArray(result.blockers);
+  const confusingMoments = stringArray(result.confusingMoments);
+  const recommendations = stringArray(result.recommendations);
+  const weakScores = weakMissionScores(result.scores);
+  if (run.status === "completed") {
+    const knownGood = completedPath.length
+      ? `Known-good path starts with "${completedPath[0]}".`
+      : "Known-good path is attached in the browser-agent report.";
+    return [
+      "Comparison brief: treat this mission as a pass baseline.",
+      knownGood,
+      recommendations[0]
+        ? `Next run should preserve the pass while checking this improvement: ${recommendations[0]}`
+        : "Next run should preserve the same visible path and watch for any new hesitation or safety ambiguity.",
+    ].join(" ");
+  }
+  const primaryBlocker = blockers[0] || confusingMoments[0] || "the fresh browser agent did not complete the mission cleanly";
+  const weak = weakScores.length ? ` Weak signal: ${weakScores.join(", ")}.` : "";
+  return [
+    `Comparison brief: verdict ${verdict}; next run must check whether "${primaryBlocker}" is gone, unchanged, or replaced.`,
+    recommendations[0] ? `Expected improvement: ${recommendations[0]}.` : "Expected improvement: the next safe step should be clearer to an outside agent.",
+    weak,
+  ].filter(Boolean).join(" ");
+}
+
 export function __resetTestbedMissionRunsForTests(): void {
   missionRuns.splice(0, missionRuns.length);
   missionSeq = 0;

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -6559,6 +6559,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const history = testbedMissionHistoryList(run.history);
       const rerunPrompt = testbedMissionRerunPrompt(run, mission);
       const baselinePrompt = testbedMissionBaselinePrompt(run, mission);
+      const comparisonBrief = testbedMissionComparisonBrief(run);
       const rows = [
         row("Target", escapeHtml(String(run.targetUrl || target.url || "[TESTBED_URL]"))),
         row("Goal", escapeHtml(String(run.goal || target.goal || "test first-contact usability"))),
@@ -6586,6 +6587,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         '<h4>Runbook</h4>' + runbookHtml +
         '<h4>Rubric</h4>' + rubricHtml +
         resultHtml +
+        (comparisonBrief ? '<h4>Comparison brief</h4><p class="resolution-summary">' + escapeHtml(comparisonBrief) + '</p>' : "") +
         (baselinePrompt ? '<details class="drawer-disclosure prompt-disclosure"><summary>Baseline for future runs</summary><pre class="prompt-box">' + escapeHtml(baselinePrompt) + '</pre></details>' : "") +
         (rerunPrompt ? '<details class="drawer-disclosure prompt-disclosure" open><summary>Rerun after fix</summary><pre class="prompt-box">' + escapeHtml(rerunPrompt) + '</pre></details>' : "") +
         (history.length ? '<h4>Mission timeline</h4><ol class="resolution-steps">' + history.map((entry) => '<li><strong>' + escapeHtml(entry.event) + '</strong> <span class="muted">' + escapeHtml(entry.at) + '</span><br>' + escapeHtml(entry.message) + '</li>').join("") + '</ol>' : "") +
@@ -6739,6 +6741,46 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         "When the page changes, run this mission again and compare against the known-good path. Report whether the path still works, became clearer, or regressed.",
         prompt ? nl + "Original mission prompt:" + nl + prompt : "",
       ].filter(Boolean).join(nl);
+    }
+
+    function testbedMissionComparisonBrief(run) {
+      const result = run && run.result;
+      if (!result) return "";
+      const status = String(run && run.status || "");
+      const verdict = String(result.verdict || status || "reported");
+      const completedPath = testbedReportList(result && result.completedPath);
+      const blockers = testbedReportList(result && result.blockers);
+      const confusingMoments = testbedReportList(result && result.confusingMoments);
+      const recommendations = testbedReportList(result && result.recommendations);
+      const weakScores = testbedWeakScoreLabels(result && result.scores);
+      const isPass = status === "completed" || verdict === "pass";
+      if (isPass) {
+        const knownGood = completedPath.length
+          ? 'Known-good path starts with "' + completedPath[0] + '".'
+          : "Known-good path is attached in the browser-agent report.";
+        return [
+          "Comparison brief: treat this mission as a pass baseline.",
+          knownGood,
+          recommendations[0]
+            ? "Next run should preserve the pass while checking this improvement: " + recommendations[0]
+            : "Next run should preserve the same visible path and watch for any new hesitation or safety ambiguity.",
+        ].join(" ");
+      }
+      const primaryBlocker = blockers[0] || confusingMoments[0] || "the fresh browser agent did not complete the mission cleanly";
+      const weak = weakScores.length ? " Weak signal: " + weakScores.join(", ") + "." : "";
+      return [
+        'Comparison brief: verdict ' + verdict + '; next run must check whether "' + primaryBlocker + '" is gone, unchanged, or replaced.',
+        recommendations[0] ? "Expected improvement: " + recommendations[0] + "." : "Expected improvement: the next safe step should be clearer to an outside agent.",
+        weak,
+      ].filter(Boolean).join(" ");
+    }
+
+    function testbedWeakScoreLabels(value) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+      return Object.entries(value)
+        .filter((entry) => Number(entry[1]) <= 3)
+        .map((entry) => String(entry[0]) + ":" + String(entry[1]))
+        .slice(0, 3);
     }
 
     function testbedMissionReportTemplate(run, mission) {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -7,6 +7,7 @@ import {
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
   testbedMissionBaselinePrompt,
+  testbedMissionComparisonBrief,
   testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
   testbedMissionRerunPrompt,
@@ -129,6 +130,11 @@ describe("monitor testbed mission runs", () => {
     expect(baselinePrompt).toContain("opened page");
     expect(baselinePrompt).toContain("Baseline confidence: 91%");
     expect(baselinePrompt).toContain("When the page changes, run this mission again");
+
+    const comparisonBrief = testbedMissionComparisonBrief(updated!);
+    expect(comparisonBrief).toContain("pass baseline");
+    expect(comparisonBrief).toContain('Known-good path starts with "opened page".');
+    expect(comparisonBrief).toContain("preserve the same visible path");
   });
 
   it("attaches a partial browser-agent report and keeps blockers visible", () => {
@@ -209,6 +215,12 @@ describe("monitor testbed mission runs", () => {
     expect(rerunPrompt).toContain("Previous blocker to compare against: Could not find the submit boundary.");
     expect(rerunPrompt).toContain("Original mission prompt:");
     expect(rerunPrompt).toContain("Open the app and complete onboarding.");
+
+    const comparisonBrief = testbedMissionComparisonBrief(updated!);
+    expect(comparisonBrief).toContain("verdict partial");
+    expect(comparisonBrief).toContain("Could not find the submit boundary");
+    expect(comparisonBrief).toContain("gone, unchanged, or replaced");
+    expect(comparisonBrief).toContain("trustAndSafety:2");
   });
 
   it("rejects incomplete browser-agent reports before attaching them", () => {

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -246,6 +246,8 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("renderTestbedMissionReportPacket(result)");
     expect(html).toContain("Browser-agent report");
     expect(html).toContain("Structured result JSON");
+    expect(html).toContain("Comparison brief");
+    expect(html).toContain("testbedMissionComparisonBrief(run)");
     expect(html).toContain("Mission timeline");
     expect(html).toContain("testbedMissionHistoryList(run.history)");
     expect(html).toContain("Baseline for future runs");


### PR DESCRIPTION
## What changed
- Added a compact comparison brief for testbed mission reports.
- Passed missions now explain what path should be preserved as the baseline.
- Failed/partial missions now explain what blocker should be checked as gone, unchanged, or replaced on the next run.
- Shows the comparison brief in the mission drawer before baseline/rerun prompts.

## Checks run
- npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- slack-operator / monitor testbed mission drawer and report interpretation
- No environment or VPS secret changes