### PR TITLE
[codex] Make deploy card titles specific

### DIFF
--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -5878,7 +5878,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       if (explicit) return String(explicit);
       const raw = String(title || "").trim();
       if (item && isTestbedMissionItem(item)) return "Fresh-agent browser mission";
-      if (item && isDeployItem(item)) return "Post-deploy verification";
+      if (item && isDeployItem(item)) return deployCardTitle(item, summary);
       const derived = derivePrCardTitle(item, summary);
       if (derived) return derived;
       if (prNumber) {
@@ -5887,6 +5887,34 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         return humaniseIntentLabel(stripped);
       }
       return humaniseIntentLabel(raw);
+    }
+
+    function deployCardTitle(item, summary) {
+      const prState = pullRequestState(item, summary || {});
+      const prTitle = prState && String(prState.title || prState.prTitle || prState.pullRequestTitle || "").trim();
+      if (prTitle) return clampTitleText("Deploy verification · " + prTitle);
+      const workflowTitle = deployWorkflowTitle(summary || {});
+      if (workflowTitle) return clampTitleText("Deploy verification · " + workflowTitle);
+      const sha = item && (item.sha || summary && (summary.sha || summary.headSha));
+      if (sha) return "Post-deploy verification · " + compactSha(sha);
+      return "Post-deploy verification";
+    }
+
+    function deployWorkflowTitle(summary) {
+      const health = summary.deploymentHealth && typeof summary.deploymentHealth === "object" ? summary.deploymentHealth : {};
+      const candidates = [
+        summary.workflowRun,
+        summary.githubWorkflowRun,
+        summary.deploymentWorkflowRun,
+        health.workflowRun,
+        health.githubWorkflowRun,
+      ];
+      for (const candidate of candidates) {
+        if (!candidate || typeof candidate !== "object") continue;
+        const title = String(candidate.displayTitle || candidate.title || candidate.name || "").trim();
+        if (title) return title;
+      }
+      return "";
     }
 
     // Build a human, item-distinct card title from the verdict + review reasons

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -356,6 +356,10 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("open a follow-up fix PR or rollback proposal");
     expect(html).toContain("hosted app/config health failure");
     expect(html).toContain("hosted health is ok and the post-deploy suite returns PASS");
+    expect(html).toContain("deployCardTitle(item, summary)");
+    expect(html).toContain("Deploy verification · ");
+    expect(html).toContain("deployWorkflowTitle(summary || {})");
+    expect(html).toContain("Post-deploy verification · ");
     expect(html).toContain("Operator decision");
     expect(html).toContain("Operator decision request");
     expect(html).toContain("Approve only if");


### PR DESCRIPTION
## Summary
- replace the generic deploy card title with deploy-specific context
- use related PR title when present, then workflow title, then commit SHA fallback
- keep post-deploy correlations readable when they are not GitHub PRs

## Checks
- npm test -- test/unit/slack-monitor.test.ts
- npm run typecheck

## Surfaces
- Slack/operator monitor frontend only
- no VPS secret or environment changes