### PR TITLE
[codex] Add testbed mission mutation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,10 @@ Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
   query private state, use Averray operator/workflow tools, call GitHub, deploy,
   submit, merge, or mutate anything; the receiving agent should use only
   browser-visible evidence and stop before real payments, signatures, submits,
-  deploys, merges, or account-affecting actions.
+  deploys, merges, or account-affecting actions. Add phrases like
+  `test mode`, `sandbox`, or `allow test mutations` when the target is a fake
+  testbed page and the agent should complete clearly labeled sandbox submits;
+  reports must then list `mutationsAttempted` so Hermes can audit what happened.
   `testbed e2e suite` and `platform e2e suite` call
   `averray_testbed_e2e_suite`, a read-only E2E checklist for backend agents,
   Slack, Command Center, and MCP clients. It returns ordered test cases,

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -611,6 +611,7 @@ function testbedAgentMissionInput(
       ? "Claude"
       : "Hermes";
   const freshMemory = !/\b(with memory|use memory|warm memory|returning agent|returning-agent|not fresh)\b/.test(compact);
+  const allowTestMutations = /\b(test mode|test-mode|sandbox|fake|demo|allow test mutation|allow test mutations|test mutation allowed|test mutations allowed|may submit|can submit)\b/.test(compact);
   return {
     handled: true,
     input: {
@@ -618,6 +619,7 @@ function testbedAgentMissionInput(
       ...(goal ? { goal } : {}),
       agentName,
       freshMemory,
+      ...(allowTestMutations ? { allowTestMutations: true } : {}),
     },
   };
 }

--- a/packages/averray-mcp/src/operator-testbed.ts
+++ b/packages/averray-mcp/src/operator-testbed.ts
@@ -25,6 +25,7 @@ export interface TestbedAgentMissionInput {
   goal?: string;
   agentName?: string;
   freshMemory?: boolean;
+  allowTestMutations?: boolean;
   maxBrowserSteps?: number;
   maxMinutes?: number;
 }
@@ -35,6 +36,7 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
     ?? "Figure out what this page is for, complete the main user flow as far as the public UI allows, and report whether a normal outside agent can use it without private project context.";
   const agentName = cleanOptional(input.agentName) ?? "Hermes";
   const freshMemory = input.freshMemory !== false;
+  const allowTestMutations = input.allowTestMutations === true;
   const maxBrowserSteps = clampInt(input.maxBrowserSteps, 20, 200, 80);
   const maxMinutes = clampInt(input.maxMinutes, 5, 60, 20);
 
@@ -43,7 +45,9 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
     kind: "testbed_agent_browser_mission",
     generatedAt: new Date().toISOString(),
     mutates: false,
-    headline: "Fresh-agent browser mission ready: test the page like a normal outside agent, not like an internal operator.",
+    headline: allowTestMutations
+      ? "Fresh-agent browser mission ready: test-mode page mutation is allowed, but only inside the sandbox/testbed flow."
+      : "Fresh-agent browser mission ready: test the page like a normal outside agent, not like an internal operator.",
     target: {
       url: targetUrl,
       goal,
@@ -59,6 +63,7 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
       privilegedAverrayMcpAllowed: false,
       hiddenProjectContextAllowed: false,
       humanHelpAllowed: false,
+      mutationMode: allowTestMutations ? "testbed_mutation_allowed" : "stop_before_mutation",
       purpose: "Measure whether an agent with ordinary browser access can understand and use the public/testbed page.",
     },
     missionPrompt: [
@@ -68,9 +73,11 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
       "",
       "Use only the browser-visible page, normal public links, and screenshots/observations from the page.",
       "Do not use private repository knowledge, databases, hidden monitor state, Averray MCP tools, Slack, GitHub, SSH, or operator memory unless the page itself gives you that information.",
-      "Work like a future external agent would: explain what you infer, try the main flow, note where you are uncertain, and stop before any real mutation, payment, wallet signature, submit, deploy, merge, or account-affecting action.",
+      allowTestMutations
+        ? "Work like a future external agent would: explain what you infer, try the main flow, and you may complete test-only submits or fake/sandbox mutations that the page itself presents as safe. Stop before real payment, real wallet signature, deploy, merge, production data change, or anything that is not clearly testbed-only."
+        : "Work like a future external agent would: explain what you infer, try the main flow, note where you are uncertain, and stop before any real mutation, payment, wallet signature, submit, deploy, merge, or account-affecting action.",
       "",
-      "Report with: verdict, completed path, blockers, confusing moments, evidence, screenshots or trace references, and what would make the page easier for the next agent.",
+      "Report with: verdict, completed path, blockers, confusing moments, evidence, screenshots or trace references, mutation boundary notes, and what would make the page easier for the next agent.",
     ].join("\n"),
     runbook: [
       "Start with a clean browser profile or explicitly ignore prior memory.",
@@ -78,7 +85,9 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
       "Identify the product purpose, primary user, and main task without reading private project notes.",
       "Attempt the main flow using only visible UI controls.",
       "Collect evidence: page states, URLs visited, visible copy that helped or blocked you, screenshots/trace references, and any console/network failures if available.",
-      "Stop before real mutations or irreversible actions; describe the next required human or sandbox approval instead.",
+      (allowTestMutations
+        ? "Complete test-only page mutations when the UI clearly marks them as sandbox/fake/test; stop before real mutations or irreversible actions."
+        : "Stop before real mutations or irreversible actions; describe the next required human or sandbox approval instead."),
       "Score the experience using the rubric and return the structured report.",
     ],
     allowedEvidence: [
@@ -93,13 +102,17 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
       "database queries",
       "Averray operator or workflow MCP tools after receiving this mission",
       "Slack, GitHub, monitor internals, or VPS commands",
-      "wallet signatures, payment, submit, deploy, merge, or account mutation",
+      allowTestMutations
+        ? "real wallet signatures, real payment, production submit, deploy, merge, or account mutation"
+        : "wallet signatures, payment, submit, deploy, merge, or account mutation",
       "asking Pascal what to do during the mission",
     ],
     successCriteria: [
       "The agent can state what the page is for within the first screen or first natural click.",
       "The agent can identify the main task and whether it is safe to proceed.",
-      "The agent can complete or reach a clear sandbox stop point in the primary flow.",
+      allowTestMutations
+        ? "The agent can complete the primary test flow, including safe sandbox/test-only actions when clearly labeled."
+        : "The agent can complete or reach a clear sandbox stop point in the primary flow.",
       "Any blocker is explained with visible evidence, not private assumptions.",
       "The final report is useful enough for another agent to reproduce the run.",
     ],
@@ -135,6 +148,8 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
         evidenceQuality: "0-5",
       },
       recommendations: ["smallest page/product changes that would help the next outside agent"],
+      mutationMode: allowTestMutations ? "testbed_mutation_allowed" : "stop_before_mutation",
+      mutationsAttempted: ["test-only actions submitted, or empty array"],
       stoppedBeforeMutation: "boolean",
     },
     nextSteps: [
@@ -144,7 +159,10 @@ export function getTestbedAgentMission(input: TestbedAgentMissionInput = {}) {
     ],
     safety: {
       missionGeneratorMutates: false,
-      browserMissionShouldMutate: false,
+      browserMissionShouldMutate: allowTestMutations,
+      allowedMutationScope: allowTestMutations
+        ? "testbed-only page actions that are visibly fake, sandbox, or non-production"
+        : "none; stop at mutation boundary",
       freshAgentDefault: true,
       requiresEvidence: true,
       comparesAcrossAgents: true,

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -19,6 +19,7 @@ export interface TestbedMissionRun {
   goal: string;
   agentName: string;
   freshMemory: boolean;
+  allowTestMutations: boolean;
   mission: Record<string, unknown>;
   result?: Record<string, unknown>;
   history: TestbedMissionHistoryEntry[];
@@ -65,7 +66,9 @@ export function recordTestbedMissionRunFromOperatorResult(
   const mission = isRecord(result.mission) ? result.mission : undefined;
   if (!mission || mission.kind !== "testbed_agent_browser_mission") return undefined;
   const target = isRecord(mission.target) ? mission.target : {};
+  const safety = isRecord(mission.safety) ? mission.safety : {};
   const createdAt = new Date(nowMs).toISOString();
+  const allowTestMutations = safety.browserMissionShouldMutate === true;
   const run: TestbedMissionRun = {
     schemaVersion: 1,
     kind: "testbed_mission_run",
@@ -77,18 +80,23 @@ export function recordTestbedMissionRunFromOperatorResult(
       ?? "Test whether a normal outside agent can understand and use the page.",
     agentName: stringField(target, "agentName") ?? "Hermes",
     freshMemory: target.freshMemory !== false,
+    allowTestMutations,
     mission,
     history: [
       {
         at: createdAt,
         status: "ready",
         event: "mission_packet_ready",
-        message: "Mission packet generated; waiting for a clean browser-only agent run.",
+        message: allowTestMutations
+          ? "Mission packet generated; waiting for a clean browser-only test-mode run where safe sandbox page mutations are allowed."
+          : "Mission packet generated; waiting for a clean browser-only agent run.",
       },
     ],
     createdAt,
     updatedAt: createdAt,
-    statusReason: "Mission packet is ready; waiting for a browser-only agent run and structured report.",
+    statusReason: allowTestMutations
+      ? "Mission packet is ready; waiting for a browser-only test-mode run and structured report."
+      : "Mission packet is ready; waiting for a browser-only agent run and structured report.",
   };
   missionRuns.push(run);
   while (missionRuns.length > MAX_MISSION_RUNS) missionRuns.shift();
@@ -121,8 +129,9 @@ export function recordTestbedMissionReportFromMessage(
 
   const verdict = normalizeVerdict(report.verdict);
   const stoppedBeforeMutation = report.stoppedBeforeMutation !== false;
-  const completed = verdict === "pass" && stoppedBeforeMutation;
-  const failed = !verdict || verdict === "fail" || verdict === "partial" || !stoppedBeforeMutation;
+  const mutationBoundaryOk = stoppedBeforeMutation || run.allowTestMutations;
+  const completed = verdict === "pass" && mutationBoundaryOk;
+  const failed = !verdict || verdict === "fail" || verdict === "partial" || !mutationBoundaryOk;
   const status: TestbedMissionStatus = completed ? "completed" : failed ? "failed" : "completed";
   const updatedAt = new Date(nowMs).toISOString();
   run.result = {
@@ -131,7 +140,7 @@ export function recordTestbedMissionReportFromMessage(
   };
   run.status = status;
   run.updatedAt = updatedAt;
-  run.statusReason = missionReportStatusReason(report, status, stoppedBeforeMutation);
+  run.statusReason = missionReportStatusReason(report, status, stoppedBeforeMutation, run.allowTestMutations);
   run.history.push({
     at: updatedAt,
     status,
@@ -192,6 +201,7 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
         touchedAreas: ["testbed"],
         testSignals: [
           "browser mission packet ready",
+          ...(run.allowTestMutations ? ["test-mode page mutation allowed"] : []),
           ...(reportAttached ? ["browser agent report attached"] : []),
         ],
         missingTestSignals: reportAttached ? [] : ["browser agent report"],
@@ -204,6 +214,7 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
     safety: {
       source: "monitor",
       wouldMutate: false,
+      browserMissionShouldMutate: run.allowTestMutations,
       wouldWriteLocalCheckpoint: false,
       freeFormHermesPromptUsed: false,
     },
@@ -463,6 +474,9 @@ function validateMissionReport(report: Record<string, unknown>): string[] {
   if (!nonEmptyStringArray(report.evidence)) {
     errors.push("Add at least one evidence item or observation.");
   }
+  if (report.stoppedBeforeMutation === false && !nonEmptyStringArray(report.mutationsAttempted)) {
+    errors.push("List mutationsAttempted when the browser agent crossed a test mutation boundary.");
+  }
   if (!isRecord(report.scores)) {
     errors.push("Add a scores object, even if some scores are 0.");
   }
@@ -492,16 +506,20 @@ function normalizeVerdict(value: unknown): "pass" | "partial" | "fail" | undefin
 function missionReportStatusReason(
   report: Record<string, unknown>,
   status: TestbedMissionStatus,
-  stoppedBeforeMutation: boolean
+  stoppedBeforeMutation: boolean,
+  allowTestMutations: boolean
 ): string {
   const verdict = normalizeVerdict(report.verdict) ?? "reported";
   const blockers = Array.isArray(report.blockers)
     ? report.blockers.map(String).filter(Boolean)
     : [];
-  if (!stoppedBeforeMutation) {
+  if (!stoppedBeforeMutation && !allowTestMutations) {
     return "Browser-agent report says the mission crossed or attempted a mutation boundary.";
   }
   if (status === "completed") {
+    if (!stoppedBeforeMutation && allowTestMutations) {
+      return "Browser-agent report passed after permitted testbed-only page mutation; Hermes has structured evidence for this mission.";
+    }
     return "Browser-agent report passed; Hermes has structured evidence for this testbed mission.";
   }
   if (blockers.length > 0) {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -42,6 +42,10 @@ export function normalizeMonitorCommandText(text: string): string {
 }
 
 function isBlockedMonitorCommand(text: string): boolean {
+  if (isTestbedMissionMonitorCommand(text) && isTestbedMutationModeText(text)) {
+    return /\b(merge\s+(pr|#|now)|deploy(?! for)|rollback(?! for)|restart|rotate|set secret|secret set|ssh|claim)\b/.test(text)
+      || /\bwikipedia citation repair\b/.test(text);
+  }
   return Boolean(
     /\b(approve|execute|merge)\b.*\b(merge steward|github merge steward)\b/.test(text)
     || /\b(merge steward|github merge steward)\b.*\b(approve|execute|merge)\b/.test(text)
@@ -63,9 +67,17 @@ function isAllowedMonitorCommand(text: string): boolean {
     || /^what can you do for us( details?| full| audit)?$/.test(text)
     || /^(how do we deploy|runbook for|secret rotation runbook)( .*)?$/.test(text)
     || /^propose (merge|deploy|secret rotation|rollback)\b/.test(text)
-    || /^(testbed agent mission|agent testbed mission|agent browser mission|browser mission|fresh agent mission|fresh agent page test|out of box agent test|out-of-box agent test|normal agent page test|can hermes test the page|test page as fresh agent)(\b.*)?$/.test(text)
+    || isTestbedMissionMonitorCommand(text)
     || /^run testbed e2e read[ -]?only( details?| full| audit)?$/.test(text)
   );
+}
+
+function isTestbedMissionMonitorCommand(text: string): boolean {
+  return /^(testbed agent mission|agent testbed mission|agent browser mission|browser mission|fresh agent mission|fresh agent page test|out of box agent test|out-of-box agent test|normal agent page test|can hermes test the page|test page as fresh agent)(\b.*)?$/.test(text);
+}
+
+function isTestbedMutationModeText(text: string): boolean {
+  return /\b(test mode|test-mode|sandbox|fake|demo|allow test mutation|allow test mutations|test mutation allowed|test mutations allowed|may submit|can submit)\b/.test(text);
 }
 
 // Inline SVG used for the PWA icon and apple-touch-icon. The brand mark
@@ -6582,6 +6594,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const rubric = Array.isArray(mission.scoringRubric) ? mission.scoringRubric : [];
       const runbook = Array.isArray(mission.runbook) ? mission.runbook : [];
       const prompt = String(mission.missionPrompt || "");
+      const safety = mission.safety || {};
+      const allowTestMutations = run.allowTestMutations === true || safety.browserMissionShouldMutate === true;
       const reportTemplate = testbedMissionReportTemplate(run, mission);
       const result = run.result || null;
       const history = testbedMissionHistoryList(run.history);
@@ -6595,11 +6609,14 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("Goal", escapeHtml(String(run.goal || target.goal || "test first-contact usability"))),
         row("Agent", escapeHtml(String(run.agentName || target.agentName || "Hermes"))),
         row("Memory", escapeHtml(run.freshMemory === false ? "returning memory allowed" : "fresh or explicitly ignored")),
+        row("Mutation mode", escapeHtml(allowTestMutations ? "testbed-only mutation allowed" : "stop before mutation")),
         row("Status", escapeHtml(String(run.status || summary.status || "ready"))),
       ].join("");
       const runbookHtml = runbook.length
         ? '<ol class="resolution-steps">' + runbook.slice(0, 8).map((step) => '<li>' + escapeHtml(String(step)) + '</li>').join("") + '</ol>'
-        : '<p class="resolution-summary">Open the target in a clean browser profile, follow the visible UI, stop before mutation, and report evidence.</p>';
+        : '<p class="resolution-summary">' + escapeHtml(allowTestMutations
+          ? "Open the target in a clean browser profile, follow the visible UI, complete only clearly testbed/fake actions, and report evidence."
+          : "Open the target in a clean browser profile, follow the visible UI, stop before mutation, and report evidence.") + '</p>';
       const rubricHtml = rubric.length
         ? '<div class="check-matrix">' + rubric.slice(0, 8).map((entry) => {
           const id = entry && entry.id ? String(entry.id) : "rubric";
@@ -6612,7 +6629,9 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
           '<details class="drawer-disclosure prompt-disclosure"><summary>Structured result JSON</summary><pre class="prompt-box">' + escapeHtml(prettyJson(result)) + '</pre></details>'
         : '<p class="resolution-summary">No report is attached yet. The next useful thing is to run the browser mission and paste the structured report into the collaboration chat.</p>';
       return '<section class="drawer-section testbed-mission-panel"><h3>Testbed mission</h3>' +
-        '<p class="resolution-summary">This starts from the monitor, but execution is browser-only: copy the prompt into a clean agent/browser run, then bring the report back here for Hermes to judge.</p>' +
+        '<p class="resolution-summary">' + escapeHtml(allowTestMutations
+          ? "This starts from the monitor, but execution is browser-only. In test mode the agent may complete clearly fake/sandbox page actions, then bring the report back here for Hermes to judge."
+          : "This starts from the monitor, but execution is browser-only: copy the prompt into a clean agent/browser run, then bring the report back here for Hermes to judge.") + '</p>' +
         '<dl class="resolution-grid">' + rows + '</dl>' +
         '<h4>Runbook</h4>' + runbookHtml +
         '<h4>Rubric</h4>' + rubricHtml +
@@ -6672,12 +6691,15 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const verdict = String(result && result.verdict || "reported");
       const confidence = typeof result.confidence === "number" ? String(Math.round(result.confidence * 100)) + "%" : "not recorded";
       const stopped = result && typeof result.stoppedBeforeMutation === "boolean" ? (result.stoppedBeforeMutation ? "yes" : "no") : "not recorded";
+      const mutationMode = result && result.mutationMode ? String(result.mutationMode) : "not recorded";
       const rows = [
         row("Verdict", escapeHtml(verdict)),
         row("Confidence", escapeHtml(confidence)),
+        row("Mutation mode", escapeHtml(mutationMode)),
         row("Stopped before mutation", escapeHtml(stopped)),
       ].join("");
       const completedPath = testbedReportList(result && result.completedPath);
+      const mutationsAttempted = testbedReportList(result && result.mutationsAttempted);
       const blockers = testbedReportList(result && result.blockers);
       const confusingMoments = testbedReportList(result && result.confusingMoments);
       const recommendations = testbedReportList(result && result.recommendations);
@@ -6686,6 +6708,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       return '<section class="drawer-section testbed-report-packet"><h3>Browser-agent report</h3>' +
         '<dl class="resolution-grid">' + rows + '</dl>' +
         (completedPath.length ? '<h4>Completed path</h4><ol class="resolution-steps">' + completedPath.map((step) => '<li>' + escapeHtml(step) + '</li>').join("") + '</ol>' : "") +
+        (mutationsAttempted.length ? '<h4>Test mutations attempted</h4><ol class="resolution-steps">' + mutationsAttempted.map((entry) => '<li>' + escapeHtml(entry) + '</li>').join("") + '</ol>' : "") +
         (blockers.length ? '<h4>Blockers</h4><ol class="resolution-steps">' + blockers.map((entry) => '<li>' + escapeHtml(entry) + '</li>').join("") + '</ol>' : "") +
         (confusingMoments.length ? '<h4>Confusing moments</h4><ol class="resolution-steps">' + confusingMoments.map((entry) => '<li>' + escapeHtml(entry) + '</li>').join("") + '</ol>' : "") +
         (evidence.length ? '<h4>Evidence</h4><div class="operator-evidence">' + evidence.map((entry) => '<div class="operator-evidence-item"><span class="operator-evidence-label">' + escapeHtml(entry.label) + '</span><span class="operator-evidence-value">' + escapeHtml(entry.value) + '</span></div>').join("") + '</div>' : "") +
@@ -10093,7 +10116,10 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
               mergeRecommendation: "not_applicable",
               reviewSignals: {
                 touchedAreas: ["testbed"],
-                testSignals: ["browser mission packet ready"],
+                testSignals: [
+                  "browser mission packet ready",
+                  ...(run.allowTestMutations === true ? ["test-mode page mutation allowed"] : []),
+                ],
                 missingTestSignals: status === "completed" ? [] : ["browser agent report"],
               },
               reviewReasons: status === "failed"

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -694,17 +694,21 @@ function formatTestbedAgentMissionForSlack(result: Record<string, unknown>): str
     `• goal: ${stringField(target, "goal") ?? "test first-contact usability"}`,
     `• agent: \`${stringField(target, "agentName") ?? "Hermes"}\``,
     `• memory: \`${stringField(agentMode, "memoryMode") ?? (target.freshMemory === false ? "returning_agent_memory_allowed" : "fresh_or_ignored")}\``,
+    `• mutation mode: \`${stringField(agentMode, "mutationMode") ?? (safety.browserMissionShouldMutate === true ? "testbed_mutation_allowed" : "stop_before_mutation")}\``,
     "",
     "*How to run it*",
     "• Start a clean browser-capable agent with the mission prompt.",
     "• Use only visible page UI; no repo, Slack, GitHub, SSH, MCP, or operator memory.",
-    "• Stop before any real mutation and report the structured verdict back into the monitor chat.",
+    safety.browserMissionShouldMutate === true
+      ? "• Test-mode page actions are allowed only when the UI clearly marks them fake/sandbox/test; stop before real payment, wallet signature, deploy, merge, or production data change."
+      : "• Stop before any real mutation and report the structured verdict back into the monitor chat.",
     "",
     "*Rubric*",
     rubric.length > 0 ? rubric.slice(0, 6).map(formatTestbedMissionRubricItem).join("\n") : "• orientation, navigation, task completion, safety, recoverability, evidence quality",
     "*Safety*",
     `• mission generator mutates: \`${String(safety.missionGeneratorMutates === true)}\``,
     `• browser mission should mutate: \`${String(safety.browserMissionShouldMutate === true)}\``,
+    `• allowed mutation scope: \`${stringField(safety, "allowedMutationScope") ?? "none"}\``,
     prompt ? `*Prompt preview*\n\`\`\`${prompt.slice(0, 900)}${prompt.length > 900 ? "\n..." : ""}\`\`\`` : "",
   ].filter(Boolean).join("\n");
 }

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -31,6 +31,7 @@ describe("monitor testbed mission runs", () => {
       goal: "complete onboarding",
       agentName: "Hermes",
       freshMemory: true,
+      allowTestMutations: false,
       history: [
         {
           event: "mission_packet_ready",
@@ -41,6 +42,56 @@ describe("monitor testbed mission runs", () => {
     });
     expect(run?.id).toMatch(/^testbed-mission-/);
     expect(listTestbedMissionRuns()).toHaveLength(1);
+  });
+
+  it("accepts a passing test-mode report that crossed an allowed sandbox mutation", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ allowTestMutations: true }),
+      Date.parse("2026-05-22T10:00:00.000Z")
+    );
+    expect(run).toMatchObject({
+      allowTestMutations: true,
+      statusReason: "Mission packet is ready; waiting for a browser-only test-mode run and structured report.",
+    });
+
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: run!.id,
+        text: JSON.stringify({
+          verdict: "pass",
+          confidence: 0.88,
+          mutationMode: "testbed_mutation_allowed",
+          mutationsAttempted: ["submitted fake onboarding form"],
+          stoppedBeforeMutation: false,
+          completedPath: ["opened page", "submitted fake onboarding form", "saw sandbox success"],
+          blockers: [],
+          evidence: [{ type: "visible_text", value: "Sandbox submission complete" }],
+          scores: { taskCompletion: 5 },
+        }),
+      },
+      Date.parse("2026-05-22T10:05:00.000Z")
+    );
+
+    expect(updated).toMatchObject({
+      status: "completed",
+      statusReason: "Browser-agent report passed after permitted testbed-only page mutation; Hermes has structured evidence for this mission.",
+      result: {
+        mutationMode: "testbed_mutation_allowed",
+        mutationsAttempted: ["submitted fake onboarding form"],
+        stoppedBeforeMutation: false,
+      },
+    });
+    const item = testbedMissionRunToMonitorItem(updated!);
+    expect(item).toMatchObject({
+      summary: {
+        reviewSignals: {
+          testSignals: ["browser mission packet ready", "test-mode page mutation allowed", "browser agent report attached"],
+        },
+      },
+      safety: {
+        browserMissionShouldMutate: true,
+      },
+    });
   });
 
   it("turns active mission runs into Hermes Checking board items", () => {
@@ -280,7 +331,7 @@ describe("monitor testbed mission runs", () => {
   });
 });
 
-function missionResult() {
+function missionResult(options: { allowTestMutations?: boolean } = {}) {
   return {
     kind: "testbed_agent_mission",
     mission: {
@@ -300,6 +351,7 @@ function missionResult() {
       ],
       safety: {
         missionGeneratorMutates: false,
+        browserMissionShouldMutate: options.allowTestMutations === true,
       },
     },
   };

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -338,6 +338,19 @@ describe("operator commands", () => {
         freshMemory: true,
       },
     });
+    expect(parseOperatorCommand("agent browser mission https://testbed.example/app goal: complete onboarding in test mode allow test mutations", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "testbed_agent_mission",
+      source: "operator",
+      detailed: false,
+      input: {
+        targetUrl: "https://testbed.example/app",
+        goal: "complete onboarding in test mode allow test mutations",
+        agentName: "Hermes",
+        freshMemory: true,
+        allowTestMutations: true,
+      },
+    });
   });
 
   it("routes the executable read-only testbed E2E run separately from the suite", () => {

--- a/test/unit/operator-testbed-agent-mission.test.ts
+++ b/test/unit/operator-testbed-agent-mission.test.ts
@@ -17,10 +17,12 @@ describe("testbed agent mission", () => {
         privilegedAverrayMcpAllowed: false,
         hiddenProjectContextAllowed: false,
         humanHelpAllowed: false,
+        mutationMode: "stop_before_mutation",
       },
       safety: {
         missionGeneratorMutates: false,
         browserMissionShouldMutate: false,
+        allowedMutationScope: "none; stop at mutation boundary",
         freshAgentDefault: true,
         requiresEvidence: true,
         comparesAcrossAgents: true,
@@ -33,6 +35,8 @@ describe("testbed agent mission", () => {
     expect(mission.reportSchema).toMatchObject({
       verdict: "pass | partial | fail",
       confidence: "0.0-1.0",
+      mutationMode: "stop_before_mutation",
+      mutationsAttempted: ["test-only actions submitted, or empty array"],
       stoppedBeforeMutation: "boolean",
     });
     expect(mission.reportSchema.completedPath).toEqual(["ordered browser actions the agent took"]);
@@ -68,5 +72,27 @@ describe("testbed agent mission", () => {
     expect(mission.missionPrompt).toContain("You are Claude");
     expect(mission.missionPrompt).toContain("Open https://testbed.example/app.");
     expect(mission.missionPrompt).toContain("Goal: Complete onboarding");
+  });
+
+  it("can build a test-mode mission where sandbox page mutations are allowed", () => {
+    const mission = getTestbedAgentMission({
+      targetUrl: "https://testbed.example/app",
+      goal: "Complete fake onboarding",
+      allowTestMutations: true,
+    });
+
+    expect(mission.agentMode.mutationMode).toBe("testbed_mutation_allowed");
+    expect(mission.safety).toMatchObject({
+      missionGeneratorMutates: false,
+      browserMissionShouldMutate: true,
+      allowedMutationScope: "testbed-only page actions that are visibly fake, sandbox, or non-production",
+    });
+    expect(mission.missionPrompt).toContain("you may complete test-only submits");
+    expect(mission.missionPrompt).toContain("Stop before real payment");
+    expect(mission.deniedShortcuts).toContain("real wallet signatures, real payment, production submit, deploy, merge, or account mutation");
+    expect(mission.reportSchema).toMatchObject({
+      mutationMode: "testbed_mutation_allowed",
+      stoppedBeforeMutation: "boolean",
+    });
   });
 });

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -46,6 +46,11 @@ describe("slack operator personal monitor", () => {
     expect(guardMonitorCommand("ops health")).toMatchObject({ allowed: true });
     expect(guardMonitorCommand("propose deploy for averray-agent/agent sha abc1234")).toMatchObject({ allowed: true });
     expect(guardMonitorCommand("agent browser mission https://testbed.example/app goal: complete onboarding")).toMatchObject({ allowed: true });
+    expect(guardMonitorCommand("agent browser mission https://testbed.example/app goal: complete onboarding test mode allow test mutations")).toMatchObject({ allowed: true });
+    expect(guardMonitorCommand("agent browser mission https://testbed.example/app test mode deploy now")).toMatchObject({
+      allowed: false,
+      reason: "mutation_command_blocked",
+    });
     expect(guardMonitorCommand("merge steward approve averray-agent/agent#123")).toMatchObject({
       allowed: false,
       reason: "mutation_command_blocked",
@@ -240,6 +245,8 @@ describe("slack operator personal monitor", () => {
     expect(html).toContain("isTestbedMissionItem(item)");
     expect(html).toContain("renderTestbedMissionPanel(item, summary)");
     expect(html).toContain("Fresh-agent browser mission");
+    expect(html).toContain("testbed-only mutation allowed");
+    expect(html).toContain("Test mutations attempted");
     expect(html).toContain("Copy mission prompt");
     expect(html).toContain("Copy report template");
     expect(html).toContain("testbedMissionReportTemplate(run, mission)");

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -812,6 +812,7 @@ describe("slack operator bridge", () => {
         },
         agentMode: {
           memoryMode: "fresh_or_ignored",
+          mutationMode: "stop_before_mutation",
         },
         missionPrompt: "Open https://testbed.example/app.\nGoal: complete onboarding",
         scoringRubric: [
@@ -823,6 +824,7 @@ describe("slack operator bridge", () => {
         safety: {
           missionGeneratorMutates: false,
           browserMissionShouldMutate: false,
+          allowedMutationScope: "none; stop at mutation boundary",
         },
       },
     });
@@ -830,8 +832,10 @@ describe("slack operator bridge", () => {
     expect(text).toContain("*Fresh-agent browser mission*");
     expect(text).toContain("url: `https://testbed.example/app`");
     expect(text).toContain("Use only visible page UI");
+    expect(text).toContain("mutation mode: `stop_before_mutation`");
     expect(text).toContain("`orientation`");
     expect(text).toContain("browser mission should mutate: `false`");
+    expect(text).toContain("allowed mutation scope: `none; stop at mutation boundary`");
   });
 
   it("formats testbed E2E suite replies", () => {


### PR DESCRIPTION
## Summary
- add explicit test-mode mutation support for fresh-agent browser missions
- keep mission generation non-mutating while allowing fake/sandbox page actions when requested
- require reports to identify attempted test mutations and show mutation mode in Slack/monitor surfaces

## Checks
- npm run typecheck
- npm test -- test/unit/operator-testbed-agent-mission.test.ts test/unit/operator-commands.test.ts test/unit/monitor-testbed-missions.test.ts test/unit/slack-monitor.test.ts test/unit/slack-operator.test.ts
- npm test

## Surfaces
- MCP operator testbed mission packet
- Slack/operator monitor and mission report ingestion
- README docs
- no VPS secret or environment changes