### PR TITLE
[codex] Add Hermes testbed mission runner

### DIFF
--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -125,6 +125,41 @@ configured `CODEX_HOME` and provide a GitHub token that can read the repo and
 push to the PR branch. If the worker is not enabled, the monitor still offers
 copy-prompt fallback buttons for manual Codex App use.
 
+## Hermes Testbed Mission Runner
+
+The command center can also queue browser-first testbed missions for Hermes.
+Mission state is stored in `AVERRAY_TESTBED_MISSIONS_PATH`, defaulting to
+`/data/testbed-missions.json` in Docker so the monitor and runner share durable
+state across container restarts.
+
+The runner is opt-in and fail-closed:
+
+```env
+AVERRAY_TESTBED_MISSIONS_PATH=/data/testbed-missions.json
+TESTBED_MISSION_RUNNER_ENABLED=1
+TESTBED_MISSION_RUNNER_COMMAND=node
+TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/testbed-mission-http-runner.js
+```
+
+The default command is a lightweight HTTP visibility runner. It proves that the
+mission loop works end to end: Hermes creates a mission, the runner claims it,
+loads the target, writes a structured report, and the monitor attaches the
+result. For a full Hermes/browser deployment, replace the command and args with
+the browser-capable Hermes invocation for the host. Supported placeholders are:
+
+- `{missionId}`
+- `{targetUrl}`
+- `{goal}`
+- `{agentName}`
+- `{prompt}`
+- `{reportPath}`
+
+The child command also receives `TESTBED_MISSION_ID`, `TESTBED_TARGET_URL`,
+`TESTBED_MISSION_GOAL`, `TESTBED_MISSION_PROMPT`,
+`TESTBED_MISSION_REPORT_PATH`, and `TESTBED_MISSION_JSON`. It should write the
+structured JSON report to `TESTBED_MISSION_REPORT_PATH` or stdout. Invalid
+reports fail the mission visibly instead of silently clearing the board.
+
 ## Monitor GitHub-Live Fallback
 
 The monitor has two read-only inputs:

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -31,6 +31,13 @@ HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud
 HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud
 HERMES_MONITOR_MEMORY_PATH=/data/hermes-monitor-memory.json
 HERMES_COMPARISON_MODEL=qwen3.5:cloud
+AVERRAY_TESTBED_MISSIONS_PATH=/data/testbed-missions.json
+TESTBED_MISSION_RUNNER_ENABLED=0
+TESTBED_MISSION_RUNNER_ID=vps-hermes-testbed-runner
+TESTBED_MISSION_RUNNER_COMMAND=node
+TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/testbed-mission-http-runner.js
+TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS=10000
+TESTBED_MISSION_RUNNER_TIMEOUT_MS=1200000
 
 # Optional read-only GitHub operator helper.
 GITHUB_TOKEN=

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -174,12 +174,41 @@ services:
       HERMES_MONITOR_MEMORY_PATH: ${HERMES_MONITOR_MEMORY_PATH:-/data/hermes-monitor-memory.json}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
       AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
+      AVERRAY_TESTBED_MISSIONS_PATH: ${AVERRAY_TESTBED_MISSIONS_PATH:-/data/testbed-missions.json}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-data:/data
     networks: [avg-internal]
     ports:
       - "127.0.0.1:${SLACK_OPERATOR_HTTP_PORT:-8790}:${SLACK_OPERATOR_HTTP_PORT:-8790}"
+
+  testbed-mission-runner:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+    image: avg-node-runtime
+    profiles: ["testbed-runner"]
+    restart: unless-stopped
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+      mcp-bundle:
+        condition: service_completed_successfully
+    command: ["node", "services/slack-operator/dist/testbed-mission-runner.js"]
+    environment:
+      AVERRAY_TESTBED_MISSIONS_PATH: ${AVERRAY_TESTBED_MISSIONS_PATH:-/data/testbed-missions.json}
+      TESTBED_MISSION_RUNNER_ENABLED: ${TESTBED_MISSION_RUNNER_ENABLED:-0}
+      TESTBED_MISSION_RUNNER_ID: ${TESTBED_MISSION_RUNNER_ID:-vps-hermes-testbed-runner}
+      TESTBED_MISSION_RUNNER_COMMAND: ${TESTBED_MISSION_RUNNER_COMMAND:-node}
+      TESTBED_MISSION_RUNNER_ARGS: ${TESTBED_MISSION_RUNNER_ARGS:-services/slack-operator/dist/testbed-mission-http-runner.js}
+      TESTBED_MISSION_RUNNER_CWD: ${TESTBED_MISSION_RUNNER_CWD:-}
+      TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS: ${TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS:-10000}
+      TESTBED_MISSION_RUNNER_TIMEOUT_MS: ${TESTBED_MISSION_RUNNER_TIMEOUT_MS:-1200000}
+      TESTBED_MISSION_RUNNER_OUTPUT_TAIL_BYTES: ${TESTBED_MISSION_RUNNER_OUTPUT_TAIL_BYTES:-12000}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - avg-data:/data
+    networks: [avg-internal]
 
   codex-task-runner:
     build:

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -63,8 +63,10 @@ import {
 import {
   diagnoseTestbedMissionReportFromMessage,
   listTestbedMissionRuns,
+  readTestbedMissionRunnerHeartbeat,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
+  summarizeTestbedMissionRunnerHeartbeat,
   testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
   testbedMissionResultCoaching,
@@ -754,6 +756,10 @@ async function handleMonitorCommandRequest(request: http.IncomingMessage, respon
 
 function recordTestbedMissionCollaboration(run: TestbedMissionRun): void {
   try {
+    const runner = summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat());
+    const runnerText = runner && runner.status !== "disabled" && runner.status !== "misconfigured"
+      ? "I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed."
+      : "The mission is queued, but the automatic runner is not active yet, so use the card's copy actions as the manual fallback until TESTBED_MISSION_RUNNER_ENABLED is on.";
     recordCollaborationMessage({
       author: "hermes",
       kind: "status",
@@ -761,8 +767,8 @@ function recordTestbedMissionCollaboration(run: TestbedMissionRun): void {
       relatedCorrelationId: run.id,
       text: [
         `I created a fresh-agent browser mission for ${run.targetUrl}.`,
-        `The mission is now on the board as ${run.id}; open its card to copy the browser-only prompt and report schema.`,
-        "Start it with a clean browser-capable agent, then paste the structured report back here so I can compare the evidence and keep improving the testbed.",
+        `The mission is now on the board as ${run.id}.`,
+        runnerText,
       ].join(" "),
     });
   } catch (error) {
@@ -1299,6 +1305,7 @@ async function loadMonitorSnapshot(
     ...enriched,
     codexTasks,
     testbedMissions: listTestbedMissionRuns({ limit: 20 }),
+    testbedMissionRunner: summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat()),
     collaborationMessages: listCollaborationMessages({ limit: 200 }),
     diagnostics,
   };

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -1,6 +1,17 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
 const MAX_MISSION_RUNS = 50;
 
 export type TestbedMissionStatus = "ready" | "running" | "completed" | "failed";
+export type TestbedMissionRunnerHeartbeatStatus =
+  | "idle"
+  | "running"
+  | "completed"
+  | "failed"
+  | "disabled"
+  | "misconfigured"
+  | "error";
 
 export interface TestbedMissionHistoryEntry {
   at: string;
@@ -26,16 +37,27 @@ export interface TestbedMissionRun {
   createdAt: string;
   updatedAt: string;
   statusReason: string;
+  runnerId?: string;
+  claimedAt?: string;
+  completedAt?: string;
+  failedAt?: string;
+  failureReason?: string;
+  stdoutTail?: string;
+  stderrTail?: string;
+  progressMessage?: string;
+  progressAt?: string;
 }
 
 export interface ListTestbedMissionRunOptions {
   limit?: number;
   activeOnly?: boolean;
+  path?: string;
 }
 
 export interface MissionReportInput {
   relatedCorrelationId?: string;
   text?: string;
+  path?: string;
 }
 
 export interface MissionReportDiagnosis {
@@ -55,13 +77,30 @@ export interface TestbedMissionFixBrief {
   evidence: string[];
 }
 
+export interface TestbedMissionStoreDeps {
+  path?: string;
+  now?: Date;
+}
+
+export interface TestbedMissionRunnerHeartbeat {
+  schemaVersion: 1;
+  kind: "testbed_mission_runner_heartbeat";
+  runnerId: string;
+  status: TestbedMissionRunnerHeartbeatStatus;
+  message: string;
+  updatedAt: string;
+  activeMissionId?: string;
+}
+
 const missionRuns: TestbedMissionRun[] = [];
 let missionSeq = 0;
+let loadedMissionStorePath: string | undefined;
 
 export function recordTestbedMissionRunFromOperatorResult(
   result: unknown,
   nowMs: number = Date.now()
 ): TestbedMissionRun | undefined {
+  ensureMissionStoreLoaded();
   if (!isRecord(result) || result.kind !== "testbed_agent_mission") return undefined;
   const mission = isRecord(result.mission) ? result.mission : undefined;
   if (!mission || mission.kind !== "testbed_agent_browser_mission") return undefined;
@@ -100,10 +139,12 @@ export function recordTestbedMissionRunFromOperatorResult(
   };
   missionRuns.push(run);
   while (missionRuns.length > MAX_MISSION_RUNS) missionRuns.shift();
+  persistMissionStore();
   return run;
 }
 
 export function listTestbedMissionRuns(options: ListTestbedMissionRunOptions = {}): TestbedMissionRun[] {
+  ensureMissionStoreLoaded(options.path);
   const limit = clampInt(options.limit, 1, MAX_MISSION_RUNS, 20);
   const runs = options.activeOnly
     ? missionRuns.filter((run) => run.status === "ready" || run.status === "running")
@@ -118,6 +159,7 @@ export function recordTestbedMissionReportFromMessage(
   input: MissionReportInput,
   nowMs: number = Date.now()
 ): TestbedMissionRun | undefined {
+  ensureMissionStoreLoaded(input.path);
   const diagnosis = diagnoseTestbedMissionReportFromMessage(input);
   if (!diagnosis.valid || !diagnosis.report) return undefined;
   const report = diagnosis.report;
@@ -139,6 +181,8 @@ export function recordTestbedMissionReportFromMessage(
     ingestedAt: updatedAt,
   };
   run.status = status;
+  if (status === "completed") run.completedAt = updatedAt;
+  if (status === "failed") run.failedAt = updatedAt;
   run.updatedAt = updatedAt;
   run.statusReason = missionReportStatusReason(report, status, stoppedBeforeMutation, run.allowTestMutations);
   run.history.push({
@@ -147,7 +191,165 @@ export function recordTestbedMissionReportFromMessage(
     event: status === "completed" ? "mission_report_passed" : "mission_report_needs_fix",
     message: run.statusReason,
   });
+  persistMissionStore(input.path);
   return cloneRun(run);
+}
+
+export function claimNextReadyTestbedMission(
+  deps: TestbedMissionStoreDeps & { runnerId?: string } = {}
+): TestbedMissionRun | undefined {
+  ensureMissionStoreLoaded(deps.path);
+  const existing = missionRuns
+    .filter((run) => run.status === "ready")
+    .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt))[0];
+  if (!existing) return undefined;
+  const now = (deps.now ?? new Date()).toISOString();
+  existing.status = "running";
+  existing.runnerId = deps.runnerId ?? existing.runnerId ?? "testbed-mission-runner";
+  existing.claimedAt = now;
+  existing.progressAt = now;
+  existing.progressMessage = "Hermes testbed runner claimed the browser mission.";
+  existing.statusReason = `Hermes testbed runner ${existing.runnerId} claimed the mission and is running the browser test.`;
+  existing.updatedAt = now;
+  existing.history.push({
+    at: now,
+    status: "running",
+    event: "mission_runner_claimed",
+    message: existing.statusReason,
+  });
+  trimMissionHistory(existing);
+  persistMissionStore(deps.path);
+  return cloneRun(existing);
+}
+
+export function updateTestbedMissionProgress(
+  id: string,
+  deps: TestbedMissionStoreDeps & {
+    progressMessage?: string;
+    stdoutTail?: string;
+    stderrTail?: string;
+  } = {}
+): TestbedMissionRun | undefined {
+  ensureMissionStoreLoaded(deps.path);
+  const existing = missionRuns.find((run) => run.id === id);
+  if (!existing) return undefined;
+  if (existing.status === "completed" || existing.status === "failed") return cloneRun(existing);
+  const now = (deps.now ?? new Date()).toISOString();
+  existing.status = "running";
+  existing.progressAt = now;
+  existing.progressMessage = deps.progressMessage ?? existing.progressMessage ?? "Hermes testbed runner is still working.";
+  existing.updatedAt = now;
+  if (deps.stdoutTail) existing.stdoutTail = deps.stdoutTail;
+  if (deps.stderrTail) existing.stderrTail = deps.stderrTail;
+  existing.history.push({
+    at: now,
+    status: "running",
+    event: "mission_runner_progress",
+    message: existing.progressMessage,
+  });
+  trimMissionHistory(existing);
+  persistMissionStore(deps.path);
+  return cloneRun(existing);
+}
+
+export function failTestbedMissionRun(
+  id: string,
+  deps: TestbedMissionStoreDeps & {
+    failureReason?: string;
+    stdoutTail?: string;
+    stderrTail?: string;
+  } = {}
+): TestbedMissionRun | undefined {
+  ensureMissionStoreLoaded(deps.path);
+  const existing = missionRuns.find((run) => run.id === id);
+  if (!existing) return undefined;
+  if (existing.status === "completed" || existing.status === "failed") return cloneRun(existing);
+  const now = (deps.now ?? new Date()).toISOString();
+  const reason = deps.failureReason ?? "Hermes testbed runner failed before it produced a valid report.";
+  existing.status = "failed";
+  existing.failedAt = now;
+  existing.failureReason = reason;
+  existing.statusReason = reason;
+  existing.progressAt = now;
+  existing.progressMessage = reason;
+  existing.updatedAt = now;
+  if (deps.stdoutTail) existing.stdoutTail = deps.stdoutTail;
+  if (deps.stderrTail) existing.stderrTail = deps.stderrTail;
+  existing.result = {
+    verdict: "fail",
+    confidence: 0,
+    stoppedBeforeMutation: true,
+    blockers: [reason],
+    evidence: [
+      deps.stderrTail ? `stderr: ${deps.stderrTail}` : "",
+      deps.stdoutTail ? `stdout: ${deps.stdoutTail}` : "",
+    ].filter(Boolean),
+    scores: {},
+    ingestedAt: now,
+  };
+  existing.history.push({
+    at: now,
+    status: "failed",
+    event: "mission_runner_failed",
+    message: reason,
+  });
+  trimMissionHistory(existing);
+  persistMissionStore(deps.path);
+  return cloneRun(existing);
+}
+
+export function readTestbedMissionRunnerHeartbeat(
+  deps: TestbedMissionStoreDeps = {}
+): TestbedMissionRunnerHeartbeat | undefined {
+  const path = missionRunnerHeartbeatPath(deps.path);
+  if (!path) return undefined;
+  try {
+    const value: unknown = JSON.parse(readFileSync(path, "utf8"));
+    return isTestbedMissionRunnerHeartbeat(value) ? value : undefined;
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+export function updateTestbedMissionRunnerHeartbeat(
+  deps: TestbedMissionStoreDeps & {
+    runnerId: string;
+    status: TestbedMissionRunnerHeartbeatStatus;
+    message?: string;
+    activeMissionId?: string;
+  }
+): TestbedMissionRunnerHeartbeat {
+  const path = missionRunnerHeartbeatPath(deps.path);
+  const now = (deps.now ?? new Date()).toISOString();
+  const heartbeat: TestbedMissionRunnerHeartbeat = {
+    schemaVersion: 1,
+    kind: "testbed_mission_runner_heartbeat",
+    runnerId: deps.runnerId,
+    status: deps.status,
+    message: deps.message ?? testbedMissionRunnerStatusMessage(deps.status),
+    updatedAt: now,
+    ...(deps.activeMissionId ? { activeMissionId: deps.activeMissionId } : {}),
+  };
+  if (path) {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(heartbeat, null, 2)}\n`);
+  }
+  return heartbeat;
+}
+
+export function summarizeTestbedMissionRunnerHeartbeat(
+  heartbeat: TestbedMissionRunnerHeartbeat | undefined,
+  now: Date = new Date()
+): Record<string, unknown> | undefined {
+  if (!heartbeat) return undefined;
+  const updatedMs = Date.parse(heartbeat.updatedAt);
+  const ageMs = Number.isFinite(updatedMs) ? Math.max(0, now.getTime() - updatedMs) : undefined;
+  return {
+    ...heartbeat,
+    ...(typeof ageMs === "number" ? { ageMs, stale: ageMs > 90_000 } : { stale: true }),
+  };
 }
 
 export function diagnoseTestbedMissionReportFromMessage(input: MissionReportInput): MissionReportDiagnosis {
@@ -201,6 +403,7 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
         touchedAreas: ["testbed"],
         testSignals: [
           "browser mission packet ready",
+          ...(run.status === "running" ? ["browser mission runner claimed"] : []),
           ...(run.allowTestMutations ? ["test-mode page mutation allowed"] : []),
           ...(reportAttached ? ["browser agent report attached"] : []),
         ],
@@ -386,6 +589,93 @@ export function testbedMissionComparisonBrief(run: TestbedMissionRun): string | 
 export function __resetTestbedMissionRunsForTests(): void {
   missionRuns.splice(0, missionRuns.length);
   missionSeq = 0;
+  loadedMissionStorePath = undefined;
+}
+
+function ensureMissionStoreLoaded(path?: string): void {
+  const targetPath = missionStorePath(path);
+  if (!targetPath || loadedMissionStorePath === targetPath) return;
+  try {
+    const value: unknown = JSON.parse(readFileSync(targetPath, "utf8"));
+    const runs = missionStoreRuns(value);
+    missionRuns.splice(0, missionRuns.length, ...runs);
+    missionSeq = missionStoreSeq(value, runs);
+    loadedMissionStorePath = targetPath;
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code !== "ENOENT") throw error;
+    missionRuns.splice(0, missionRuns.length);
+    missionSeq = 0;
+    loadedMissionStorePath = targetPath;
+  }
+}
+
+function persistMissionStore(path?: string): void {
+  const targetPath = missionStorePath(path);
+  if (!targetPath) return;
+  const store = {
+    schemaVersion: 1,
+    kind: "testbed_mission_store",
+    missionSeq,
+    runs: missionRuns.slice(-MAX_MISSION_RUNS),
+  };
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(store, null, 2)}\n`);
+  loadedMissionStorePath = targetPath;
+}
+
+function missionStoreRuns(value: unknown): TestbedMissionRun[] {
+  const rawRuns = Array.isArray(value)
+    ? value
+    : isRecord(value) && Array.isArray(value.runs)
+      ? value.runs
+      : [];
+  return rawRuns.filter(isTestbedMissionRun).slice(-MAX_MISSION_RUNS);
+}
+
+function missionStoreSeq(value: unknown, runs: TestbedMissionRun[]): number {
+  if (isRecord(value) && typeof value.missionSeq === "number" && Number.isFinite(value.missionSeq)) {
+    return Math.max(0, Math.floor(value.missionSeq));
+  }
+  return runs.reduce((max, run) => {
+    const match = run.id.match(/-(\d+)$/);
+    const parsed = match ? Number(match[1]) : 0;
+    return Number.isFinite(parsed) ? Math.max(max, parsed) : max;
+  }, 0);
+}
+
+function missionStorePath(path?: string): string | undefined {
+  return path ?? process.env.AVERRAY_TESTBED_MISSIONS_PATH;
+}
+
+function missionRunnerHeartbeatPath(path?: string): string | undefined {
+  const storePath = missionStorePath(path);
+  return storePath ? `${storePath}.runner.json` : undefined;
+}
+
+function trimMissionHistory(run: TestbedMissionRun): void {
+  run.history = run.history
+    .filter((entry) => entry.at && entry.status && entry.event && entry.message)
+    .slice(-30);
+}
+
+function testbedMissionRunnerStatusMessage(status: TestbedMissionRunnerHeartbeatStatus): string {
+  switch (status) {
+    case "idle":
+      return "Hermes testbed runner is online and waiting for a browser mission.";
+    case "running":
+      return "Hermes testbed runner is executing a browser mission.";
+    case "completed":
+      return "Hermes testbed runner completed its latest browser mission.";
+    case "failed":
+      return "Hermes testbed runner failed its latest browser mission.";
+    case "disabled":
+      return "Hermes testbed runner is disabled.";
+    case "misconfigured":
+      return "Hermes testbed runner is misconfigured.";
+    case "error":
+      return "Hermes testbed runner hit an error.";
+  }
 }
 
 function onlyActiveMissionRun(): TestbedMissionRun | undefined {
@@ -602,6 +892,30 @@ function clampInt(value: unknown, min: number, max: number, fallback: number): n
 function stringField(record: Record<string, unknown>, key: string): string | undefined {
   const value = record[key];
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isTestbedMissionRun(value: unknown): value is TestbedMissionRun {
+  if (!isRecord(value)) return false;
+  return value.schemaVersion === 1
+    && value.kind === "testbed_mission_run"
+    && typeof value.id === "string"
+    && typeof value.status === "string"
+    && typeof value.targetUrl === "string"
+    && typeof value.goal === "string"
+    && typeof value.agentName === "string"
+    && typeof value.createdAt === "string"
+    && typeof value.updatedAt === "string"
+    && Array.isArray(value.history);
+}
+
+function isTestbedMissionRunnerHeartbeat(value: unknown): value is TestbedMissionRunnerHeartbeat {
+  if (!isRecord(value)) return false;
+  return value.schemaVersion === 1
+    && value.kind === "testbed_mission_runner_heartbeat"
+    && typeof value.runnerId === "string"
+    && typeof value.status === "string"
+    && typeof value.message === "string"
+    && typeof value.updatedAt === "string";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -6611,6 +6611,8 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
         row("Memory", escapeHtml(run.freshMemory === false ? "returning memory allowed" : "fresh or explicitly ignored")),
         row("Mutation mode", escapeHtml(allowTestMutations ? "testbed-only mutation allowed" : "stop before mutation")),
         row("Status", escapeHtml(String(run.status || summary.status || "ready"))),
+        run.runnerId ? row("Runner", escapeHtml(String(run.runnerId))) : "",
+        run.progressMessage ? row("Runner progress", escapeHtml(String(run.progressMessage))) : "",
       ].join("");
       const runbookHtml = runbook.length
         ? '<ol class="resolution-steps">' + runbook.slice(0, 8).map((step) => '<li>' + escapeHtml(String(step)) + '</li>').join("") + '</ol>'
@@ -6627,11 +6629,13 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
       const resultHtml = result
         ? renderTestbedMissionReportPacket(result) +
           '<details class="drawer-disclosure prompt-disclosure"><summary>Structured result JSON</summary><pre class="prompt-box">' + escapeHtml(prettyJson(result)) + '</pre></details>'
-        : '<p class="resolution-summary">No report is attached yet. The next useful thing is to run the browser mission and paste the structured report into the collaboration chat.</p>';
+        : '<p class="resolution-summary">' + escapeHtml(run.status === "running"
+          ? "No report is attached yet. Hermes has claimed this browser mission; wait for the runner report, or inspect runner output if it stalls."
+          : "No report is attached yet. If the automatic runner is enabled, Hermes will claim it; otherwise copy the prompt into a clean browser-capable agent and paste the structured report here.") + '</p>';
       return '<section class="drawer-section testbed-mission-panel"><h3>Testbed mission</h3>' +
         '<p class="resolution-summary">' + escapeHtml(allowTestMutations
-          ? "This starts from the monitor, but execution is browser-only. In test mode the agent may complete clearly fake/sandbox page actions, then bring the report back here for Hermes to judge."
-          : "This starts from the monitor, but execution is browser-only: copy the prompt into a clean agent/browser run, then bring the report back here for Hermes to judge.") + '</p>' +
+          ? "This starts from the monitor and runs through the Hermes testbed runner when enabled. In test mode the runner may complete clearly fake/sandbox page actions, then attach the report here for Hermes to judge."
+          : "This starts from the monitor and runs through the Hermes testbed runner when enabled. The runner should use a clean browser context, stop before mutation, and attach the report here for Hermes to judge.") + '</p>' +
         '<dl class="resolution-grid">' + rows + '</dl>' +
         '<h4>Runbook</h4>' + runbookHtml +
         '<h4>Rubric</h4>' + rubricHtml +
@@ -10118,6 +10122,7 @@ export function renderMonitorHtml(options: { title?: string; eventsPath?: string
                 touchedAreas: ["testbed"],
                 testSignals: [
                   "browser mission packet ready",
+                  ...(status === "running" ? ["browser mission runner claimed"] : []),
                   ...(run.allowTestMutations === true ? ["test-mode page mutation allowed"] : []),
                 ],
                 missingTestSignals: status === "completed" ? [] : ["browser agent report"],

--- a/services/slack-operator/src/testbed-mission-http-runner.ts
+++ b/services/slack-operator/src/testbed-mission-http-runner.ts
@@ -1,0 +1,104 @@
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+interface HttpMissionReport {
+  verdict: "pass" | "partial" | "fail";
+  confidence: number;
+  stoppedBeforeMutation: boolean;
+  completedPath?: string[];
+  blockers: string[];
+  confusingMoments?: string[];
+  evidence: Array<{ type: string; value: string }>;
+  scores: Record<string, number>;
+  recommendations?: string[];
+}
+
+export async function runHttpTestbedMission(env: NodeJS.ProcessEnv = process.env): Promise<HttpMissionReport> {
+  const targetUrl = requiredEnv(env, "TESTBED_TARGET_URL");
+  const goal = env.TESTBED_MISSION_GOAL || "test first-contact usability";
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  timeout.unref();
+  try {
+    const response = await fetch(targetUrl, {
+      redirect: "follow",
+      signal: controller.signal,
+      headers: {
+        "User-Agent": "Averray-Hermes-Testbed-Runner/1.0",
+      },
+    });
+    const contentType = response.headers.get("content-type") ?? "";
+    const body = await response.text();
+    const text = visibleText(body);
+    const hasGoalHint = goalWords(goal).some((word) => text.toLowerCase().includes(word));
+    const ok = response.ok && text.length > 0;
+    const verdict = ok ? "pass" : "fail";
+    return {
+      verdict,
+      confidence: ok ? 0.72 : 0.35,
+      stoppedBeforeMutation: true,
+      ...(ok ? { completedPath: [`opened ${targetUrl}`, "loaded first page without mutating state"] } : {}),
+      blockers: ok ? [] : [`HTTP ${response.status} while loading ${targetUrl}`],
+      confusingMoments: hasGoalHint || !ok ? [] : [`The first page loaded, but I did not see words tied to the goal: ${goal}.`],
+      evidence: [
+        { type: "http_status", value: `${response.status} ${response.statusText}` },
+        { type: "content_type", value: contentType || "unknown" },
+        { type: "visible_text_sample", value: text.slice(0, 500) || "[no visible text]" },
+      ],
+      scores: {
+        pageLoads: response.ok ? 5 : 1,
+        orientation: hasGoalHint ? 4 : ok ? 3 : 1,
+        mutationSafety: 5,
+        evidenceQuality: ok ? 3 : 2,
+      },
+      recommendations: ok && !hasGoalHint
+        ? ["Make the page's first-screen copy mirror the mission goal so a fresh agent knows where it is."]
+        : [],
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function main(): Promise<void> {
+  const report = await runHttpTestbedMission();
+  const output = JSON.stringify(report, null, 2);
+  if (process.env.TESTBED_MISSION_REPORT_PATH) {
+    await writeFile(process.env.TESTBED_MISSION_REPORT_PATH, `${output}\n`);
+  }
+  console.log(output);
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+  if (!value) throw new Error(`${key} is required.`);
+  return value;
+}
+
+function visibleText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function goalWords(goal: string): string[] {
+  return goal
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((word) => word.length >= 4)
+    .slice(0, 8);
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -1,0 +1,393 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
+import {
+  claimNextReadyTestbedMission,
+  failTestbedMissionRun,
+  recordTestbedMissionReportFromMessage,
+  updateTestbedMissionProgress,
+  updateTestbedMissionRunnerHeartbeat,
+} from "./monitor-testbed-missions.js";
+
+export interface TestbedMissionRunnerConfig {
+  enabled: boolean;
+  path?: string;
+  runnerId: string;
+  command?: string;
+  args: string[];
+  cwd?: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  outputTailBytes: number;
+}
+
+export interface TestbedMissionRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  reportText?: string;
+  summary?: string;
+}
+
+export type TestbedMissionExecutor = (
+  mission: TestbedMissionRun,
+  config: TestbedMissionRunnerConfig
+) => Promise<TestbedMissionRunResult>;
+
+export type TestbedMissionRunnerOnceResult =
+  | { status: "disabled" }
+  | { status: "misconfigured"; reason: string }
+  | { status: "idle" }
+  | { status: "completed"; mission: TestbedMissionRun }
+  | { status: "failed"; mission: TestbedMissionRun; reason: string };
+
+export function parseTestbedMissionRunnerConfig(
+  env: NodeJS.ProcessEnv = process.env
+): TestbedMissionRunnerConfig {
+  return {
+    enabled: env.TESTBED_MISSION_RUNNER_ENABLED === "1" || env.TESTBED_MISSION_RUNNER_ENABLED === "true",
+    ...(env.AVERRAY_TESTBED_MISSIONS_PATH ? { path: env.AVERRAY_TESTBED_MISSIONS_PATH } : {}),
+    runnerId: env.TESTBED_MISSION_RUNNER_ID || `testbed-mission-runner-${process.pid}`,
+    ...(env.TESTBED_MISSION_RUNNER_COMMAND ? { command: env.TESTBED_MISSION_RUNNER_COMMAND } : {}),
+    args: parseArgs(env.TESTBED_MISSION_RUNNER_ARGS),
+    ...(env.TESTBED_MISSION_RUNNER_CWD ? { cwd: env.TESTBED_MISSION_RUNNER_CWD } : {}),
+    pollIntervalMs: positiveInt(env.TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS, 10_000),
+    timeoutMs: positiveInt(env.TESTBED_MISSION_RUNNER_TIMEOUT_MS, 20 * 60_000),
+    outputTailBytes: positiveInt(env.TESTBED_MISSION_RUNNER_OUTPUT_TAIL_BYTES, 12_000),
+  };
+}
+
+export async function runTestbedMissionRunnerOnce(
+  config: TestbedMissionRunnerConfig,
+  deps: { executor?: TestbedMissionExecutor; now?: Date } = {}
+): Promise<TestbedMissionRunnerOnceResult> {
+  if (!config.enabled) {
+    updateRunnerHeartbeat(config, "disabled", "Hermes testbed runner is disabled.", deps.now);
+    return { status: "disabled" };
+  }
+  const executor = deps.executor ?? executeTestbedMissionCommand;
+  if (!config.command && executor === executeTestbedMissionCommand) {
+    const reason = "TESTBED_MISSION_RUNNER_COMMAND is required when the Hermes testbed runner is enabled.";
+    updateRunnerHeartbeat(config, "misconfigured", reason, deps.now);
+    return { status: "misconfigured", reason };
+  }
+
+  const mission = claimNextReadyTestbedMission({
+    path: config.path,
+    runnerId: config.runnerId,
+    now: deps.now,
+  });
+  if (!mission) {
+    updateRunnerHeartbeat(config, "idle", "Hermes testbed runner is online; no browser mission is waiting.", deps.now);
+    return { status: "idle" };
+  }
+
+  updateRunnerHeartbeat(
+    config,
+    "running",
+    `Hermes testbed runner claimed ${mission.id}.`,
+    deps.now,
+    mission.id
+  );
+
+  try {
+    const result = await executor(mission, config);
+    if (result.exitCode !== 0) {
+      const reason = summarizeFailure(result);
+      const failed = failTestbedMissionRun(mission.id, {
+        path: config.path,
+        failureReason: reason,
+        stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
+        stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+      }) ?? mission;
+      updateRunnerHeartbeat(config, "failed", reason, undefined, mission.id);
+      return { status: "failed", mission: failed, reason };
+    }
+
+    const reportText = result.reportText ?? result.stdout;
+    const updated = recordTestbedMissionReportFromMessage({
+      relatedCorrelationId: mission.id,
+      text: reportText,
+      path: config.path,
+    });
+    if (!updated) {
+      const reason = "Hermes testbed runner finished, but the output did not contain a valid structured mission report.";
+      const failed = failTestbedMissionRun(mission.id, {
+        path: config.path,
+        failureReason: reason,
+        stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
+        stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+      }) ?? mission;
+      updateRunnerHeartbeat(config, "failed", reason, undefined, mission.id);
+      return { status: "failed", mission: failed, reason };
+    }
+
+    const message = updated.status === "completed"
+      ? `Hermes testbed runner completed ${mission.id}.`
+      : `Hermes testbed runner attached a failing report for ${mission.id}.`;
+    updateRunnerHeartbeat(
+      config,
+      updated.status === "completed" ? "completed" : "failed",
+      message,
+      undefined,
+      mission.id
+    );
+    return updated.status === "completed"
+      ? { status: "completed", mission: updated }
+      : { status: "failed", mission: updated, reason: updated.statusReason };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    const failed = failTestbedMissionRun(mission.id, {
+      path: config.path,
+      failureReason: reason,
+    }) ?? mission;
+    updateRunnerHeartbeat(config, "error", reason, undefined, mission.id);
+    return { status: "failed", mission: failed, reason };
+  }
+}
+
+export async function runTestbedMissionRunnerForever(
+  config: TestbedMissionRunnerConfig,
+  deps: { executor?: TestbedMissionExecutor; signal?: AbortSignal } = {}
+): Promise<void> {
+  while (!deps.signal?.aborted) {
+    const result = await runTestbedMissionRunnerOnce(config, { executor: deps.executor });
+    if (result.status === "misconfigured") {
+      console.warn(`[testbed-mission-runner] ${result.reason}`);
+    } else if (result.status === "completed") {
+      console.info(`[testbed-mission-runner] completed ${result.mission.id}`);
+    } else if (result.status === "failed") {
+      console.warn(`[testbed-mission-runner] failed ${result.mission.id}: ${result.reason}`);
+    }
+    await sleep(config.pollIntervalMs, deps.signal);
+  }
+}
+
+export async function executeTestbedMissionCommand(
+  mission: TestbedMissionRun,
+  config: TestbedMissionRunnerConfig
+): Promise<TestbedMissionRunResult> {
+  if (!config.command) {
+    throw new Error("TESTBED_MISSION_RUNNER_COMMAND is not configured.");
+  }
+
+  const runDir = await mkdtemp(join(tmpdir(), "averray-testbed-mission-"));
+  const reportPath = join(runDir, "report.json");
+  return await new Promise((resolve, reject) => {
+    const child = spawn(config.command as string, renderTestbedMissionRunnerArgs(config.args, mission, reportPath), {
+      cwd: config.cwd,
+      env: missionEnvironment(mission, reportPath),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let finished = false;
+    let lastProgressWrite = 0;
+
+    const publishProgress = (message: string) => {
+      const now = Date.now();
+      if (now - lastProgressWrite < 2_000) return;
+      lastProgressWrite = now;
+      updateTestbedMissionProgress(mission.id, {
+        path: config.path,
+        progressMessage: message,
+        stdoutTail: sanitizeTail(stdout, config.outputTailBytes),
+        stderrTail: sanitizeTail(stderr, config.outputTailBytes),
+      });
+    };
+
+    const timeout = setTimeout(() => {
+      if (finished) return;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!finished) child.kill("SIGKILL");
+      }, 5_000).unref();
+      reject(new Error(`Hermes testbed runner command timed out after ${config.timeoutMs}ms.`));
+    }, config.timeoutMs);
+    timeout.unref();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = tail(stdout + chunk.toString("utf8"), config.outputTailBytes);
+      publishProgress(lastMeaningfulLine(stdout) || "Hermes testbed runner emitted output.");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = tail(stderr + chunk.toString("utf8"), config.outputTailBytes);
+      publishProgress(lastMeaningfulLine(stderr) || "Hermes testbed runner emitted stderr.");
+    });
+    child.on("error", (error) => {
+      finished = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      finished = true;
+      clearTimeout(timeout);
+      readFile(reportPath, "utf8")
+        .catch(() => "")
+        .then((reportText) => {
+          resolve({
+            exitCode: code ?? 1,
+            stdout,
+            stderr,
+            ...(reportText.trim() ? { reportText } : {}),
+            summary: summarizeCommandResult(stdout) || summarizeCommandResult(stderr),
+          });
+        });
+    });
+  });
+}
+
+export function renderTestbedMissionRunnerArgs(
+  args: string[],
+  mission: TestbedMissionRun,
+  reportPath: string
+): string[] {
+  const prompt = missionPrompt(mission);
+  const replacements: Record<string, string> = {
+    "{missionId}": mission.id,
+    "{targetUrl}": mission.targetUrl,
+    "{goal}": mission.goal,
+    "{agentName}": mission.agentName,
+    "{prompt}": prompt,
+    "{reportPath}": reportPath,
+    "{TESTBED_MISSION_ID}": mission.id,
+    "{TESTBED_TARGET_URL}": mission.targetUrl,
+    "{TESTBED_MISSION_GOAL}": mission.goal,
+    "{TESTBED_MISSION_PROMPT}": prompt,
+    "{TESTBED_MISSION_REPORT_PATH}": reportPath,
+  };
+  return args.map((arg) => {
+    let value = arg;
+    for (const [token, replacement] of Object.entries(replacements)) {
+      value = value.split(token).join(replacement);
+    }
+    return value;
+  });
+}
+
+function missionEnvironment(mission: TestbedMissionRun, reportPath: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    TESTBED_MISSION_ID: mission.id,
+    TESTBED_TARGET_URL: mission.targetUrl,
+    TESTBED_MISSION_GOAL: mission.goal,
+    TESTBED_AGENT_NAME: mission.agentName,
+    TESTBED_FRESH_MEMORY: String(mission.freshMemory),
+    TESTBED_ALLOW_TEST_MUTATIONS: String(mission.allowTestMutations),
+    TESTBED_MISSION_PROMPT: missionPrompt(mission),
+    TESTBED_MISSION_JSON: JSON.stringify(mission.mission),
+    TESTBED_MISSION_REPORT_PATH: reportPath,
+  };
+}
+
+function missionPrompt(mission: TestbedMissionRun): string {
+  const packetPrompt = mission.mission && typeof mission.mission.missionPrompt === "string"
+    ? mission.mission.missionPrompt
+    : "";
+  return packetPrompt || [
+    `Run testbed mission ${mission.id}.`,
+    `Target: ${mission.targetUrl}`,
+    `Goal: ${mission.goal}`,
+    mission.allowTestMutations
+      ? "Use a fresh browser context and complete only clearly fake/testbed page actions."
+      : "Use a fresh browser context and stop before irreversible mutation.",
+    "Return only the structured JSON report requested by the mission packet.",
+  ].join("\n");
+}
+
+function updateRunnerHeartbeat(
+  config: TestbedMissionRunnerConfig,
+  status: Parameters<typeof updateTestbedMissionRunnerHeartbeat>[0]["status"],
+  message: string,
+  now?: Date,
+  activeMissionId?: string
+): void {
+  try {
+    updateTestbedMissionRunnerHeartbeat({
+      path: config.path,
+      runnerId: config.runnerId,
+      status,
+      message,
+      ...(activeMissionId ? { activeMissionId } : {}),
+      ...(now ? { now } : {}),
+    });
+  } catch {
+    // Heartbeat writes are advisory; the mission claim/result remains authoritative.
+  }
+}
+
+function summarizeFailure(result: TestbedMissionRunResult): string {
+  const stderr = sanitizeOutput(summarizeCommandResult(result.stderr));
+  const stdout = sanitizeOutput(summarizeCommandResult(result.stdout));
+  return stderr || stdout || `Hermes testbed runner command exited with ${result.exitCode}.`;
+}
+
+function summarizeCommandResult(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-3).join("\n").trim();
+}
+
+function lastMeaningfulLine(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-1)[0]?.trim() ?? "";
+}
+
+function parseArgs(value: string | undefined): string[] {
+  const trimmed = value?.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("TESTBED_MISSION_RUNNER_ARGS must be a JSON string array when it starts with '['.");
+    }
+    return parsed;
+  }
+  return trimmed.split(/\s+/);
+}
+
+function sanitizeTail(value: string, maxBytes: number): string | undefined {
+  const output = sanitizeOutput(tail(value, maxBytes));
+  return output ? output : undefined;
+}
+
+function sanitizeOutput(value: string): string {
+  return value
+    .replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[redacted private key]")
+    .replace(/\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g, "[redacted jwt]")
+    .replace(/\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b/g, "[redacted github token]")
+    .replace(/\bsk-[A-Za-z0-9_-]{20,}\b/g, "[redacted api key]");
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function tail(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
+  return Buffer.from(value, "utf8").subarray(-maxBytes).toString("utf8");
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const controller = new AbortController();
+  process.once("SIGINT", () => controller.abort());
+  process.once("SIGTERM", () => controller.abort());
+  runTestbedMissionRunnerForever(parseTestbedMissionRunnerConfig(), { signal: controller.signal })
+    .catch((error) => {
+      console.error("[testbed-mission-runner] fatal", error);
+      process.exitCode = 1;
+    });
+}

--- a/test/unit/testbed-mission-runner.test.ts
+++ b/test/unit/testbed-mission-runner.test.ts
@@ -1,0 +1,202 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetTestbedMissionRunsForTests,
+  listTestbedMissionRuns,
+  recordTestbedMissionRunFromOperatorResult,
+  readTestbedMissionRunnerHeartbeat,
+} from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import {
+  parseTestbedMissionRunnerConfig,
+  renderTestbedMissionRunnerArgs,
+  runTestbedMissionRunnerOnce,
+} from "../../services/slack-operator/src/testbed-mission-runner.js";
+
+describe("testbed mission runner", () => {
+  beforeEach(() => {
+    delete process.env.AVERRAY_TESTBED_MISSIONS_PATH;
+    __resetTestbedMissionRunsForTests();
+  });
+
+  it("claims a ready mission and completes it from a structured report", async () => {
+    const path = tempMissionStorePath();
+    process.env.AVERRAY_TESTBED_MISSIONS_PATH = path;
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-24T10:00:00.000Z"));
+    expect(run).toBeDefined();
+
+    const result = await runTestbedMissionRunnerOnce(
+      {
+        enabled: true,
+        path,
+        runnerId: "test-runner",
+        command: "fake",
+        args: [],
+        pollIntervalMs: 1000,
+        timeoutMs: 1000,
+        outputTailBytes: 4000,
+      },
+      {
+        executor: async (mission) => ({
+          exitCode: 0,
+          stdout: "mission complete",
+          stderr: "",
+          reportText: JSON.stringify({
+            verdict: "pass",
+            confidence: 0.86,
+            stoppedBeforeMutation: true,
+            completedPath: ["opened page", "verified first-run onboarding"],
+            blockers: [],
+            evidence: [{ type: "visible_text", value: "Welcome to the testbed" }],
+            scores: { orientation: 5, mutationSafety: 5 },
+            missionId: mission.id,
+          }),
+        }),
+      }
+    );
+
+    expect(result.status).toBe("completed");
+    const [updated] = listTestbedMissionRuns({ path });
+    expect(updated).toMatchObject({
+      id: run!.id,
+      status: "completed",
+      runnerId: "test-runner",
+      result: {
+        verdict: "pass",
+        confidence: 0.86,
+      },
+      history: expect.arrayContaining([
+        expect.objectContaining({ event: "mission_runner_claimed", status: "running" }),
+        expect.objectContaining({ event: "mission_report_passed", status: "completed" }),
+      ]),
+    });
+    expect(readTestbedMissionRunnerHeartbeat({ path })).toMatchObject({
+      runnerId: "test-runner",
+      status: "completed",
+      activeMissionId: run!.id,
+    });
+  });
+
+  it("fails the mission when the runner output is not a valid report", async () => {
+    const path = tempMissionStorePath();
+    process.env.AVERRAY_TESTBED_MISSIONS_PATH = path;
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-24T10:00:00.000Z"));
+
+    const result = await runTestbedMissionRunnerOnce(
+      {
+        enabled: true,
+        path,
+        runnerId: "test-runner",
+        command: "fake",
+        args: [],
+        pollIntervalMs: 1000,
+        timeoutMs: 1000,
+        outputTailBytes: 200,
+      },
+      {
+        executor: async () => ({
+          exitCode: 0,
+          stdout: "I opened the page but forgot to output JSON.",
+          stderr: "",
+        }),
+      }
+    );
+
+    expect(result.status).toBe("failed");
+    const [updated] = listTestbedMissionRuns({ path });
+    expect(updated).toMatchObject({
+      id: run!.id,
+      status: "failed",
+      failureReason: "Hermes testbed runner finished, but the output did not contain a valid structured mission report.",
+      result: {
+        verdict: "fail",
+      },
+    });
+  });
+
+  it("reports misconfigured instead of claiming a mission without a command", async () => {
+    const path = tempMissionStorePath();
+    process.env.AVERRAY_TESTBED_MISSIONS_PATH = path;
+    recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-24T10:00:00.000Z"));
+
+    const result = await runTestbedMissionRunnerOnce({
+      enabled: true,
+      path,
+      runnerId: "test-runner",
+      args: [],
+      pollIntervalMs: 1000,
+      timeoutMs: 1000,
+      outputTailBytes: 200,
+    });
+
+    expect(result).toMatchObject({
+      status: "misconfigured",
+    });
+    expect(listTestbedMissionRuns({ path })[0]).toMatchObject({
+      status: "ready",
+    });
+  });
+
+  it("renders command arguments with mission placeholders", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-24T10:00:00.000Z"));
+    const args = renderTestbedMissionRunnerArgs(
+      ["run", "{missionId}", "{targetUrl}", "{reportPath}", "{prompt}"],
+      run!,
+      "/tmp/report.json"
+    );
+
+    expect(args[0]).toBe("run");
+    expect(args[1]).toBe(run!.id);
+    expect(args[2]).toBe("https://testbed.example/app");
+    expect(args[3]).toBe("/tmp/report.json");
+    expect(args[4]).toContain("Open the app and complete onboarding.");
+  });
+
+  it("parses opt-in runner env", () => {
+    const config = parseTestbedMissionRunnerConfig({
+      TESTBED_MISSION_RUNNER_ENABLED: "1",
+      TESTBED_MISSION_RUNNER_ID: "runner-a",
+      TESTBED_MISSION_RUNNER_COMMAND: "hermes",
+      TESTBED_MISSION_RUNNER_ARGS: "[\"run\",\"{prompt}\"]",
+      TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS: "500",
+    });
+
+    expect(config).toMatchObject({
+      enabled: true,
+      runnerId: "runner-a",
+      command: "hermes",
+      args: ["run", "{prompt}"],
+      pollIntervalMs: 500,
+    });
+  });
+});
+
+function tempMissionStorePath(): string {
+  return join(mkdtempSync(join(tmpdir(), "averray-testbed-runner-test-")), "missions.json");
+}
+
+function missionResult() {
+  return {
+    kind: "testbed_agent_mission",
+    mission: {
+      kind: "testbed_agent_browser_mission",
+      target: {
+        url: "https://testbed.example/app",
+        goal: "complete onboarding",
+        agentName: "Hermes",
+        freshMemory: true,
+      },
+      missionPrompt: "Open the app and complete onboarding.",
+      reportSchema: {
+        verdict: "pass | partial | fail",
+      },
+      safety: {
+        missionGeneratorMutates: false,
+        browserMissionShouldMutate: false,
+      },
+    },
+  };
+}


### PR DESCRIPTION
## What changed
- Persist testbed browser missions to a shared JSON store and expose a runner heartbeat.
- Add an opt-in testbed mission runner service that claims missions, executes a configured command, ingests structured reports, and fails visibly when output is invalid.
- Add a default lightweight HTTP runner for end-to-end loop proof, plus monitor copy/UI updates and setup docs.

## Checks run
- npm test
- npm run typecheck

## Affected surfaces
- backend/monitor: yes
- frontend/operator monitor UI: yes
- deploy/compose: yes
- docs: yes
- indexer/contracts/public site: no

## Env / VPS notes
- New durable path: AVERRAY_TESTBED_MISSIONS_PATH=/data/testbed-missions.json
- New optional profile/service: --profile testbed-runner
- Enable with TESTBED_MISSION_RUNNER_ENABLED=1. Default command is node services/slack-operator/dist/testbed-mission-http-runner.js; replace TESTBED_MISSION_RUNNER_COMMAND/ARGS with the host Hermes browser invocation when ready.