### PR TITLE
[codex] Add Hermes testbed mission agent entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ Wikipedia citation-repair execution.
 Start with [docs/COMMAND_CENTER.md](docs/COMMAND_CENTER.md). Do not install
 Workspace with `curl | bash` on the VPS, and do not expose the UI publicly.
 
+Other local agents can ask Hermes to run a browser-only testbed mission through
+the command center API:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:8790/monitor/testbed-missions \
+  -H 'content-type: application/json' \
+  -d '{"requester":"codex","targetUrl":"https://testbed.averray.com","goal":"Test the main flow like a new outside agent.","allowTestMutations":true}' | jq .
+```
+
+Poll `GET /monitor/testbed-missions` for mission and runner status. If the
+monitor is token-protected, send the same bearer token used for the board.
+For a local wrapper, run:
+
+```bash
+ALLOW_TEST_MUTATIONS=true scripts/request-hermes-testbed-mission.sh \
+  https://testbed.averray.com \
+  "Test the main flow like a new outside agent."
+```
+
 ## Safety Defaults
 
 - Testnet only.

--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -132,6 +132,44 @@ Mission state is stored in `AVERRAY_TESTBED_MISSIONS_PATH`, defaulting to
 `/data/testbed-missions.json` in Docker so the monitor and runner share durable
 state across container restarts.
 
+Other agents can queue the same mission directly through the monitor API. This
+is the stable handoff point when Claude, Codex, or another local agent wants
+Hermes to test a page without clicking the board:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:8790/monitor/testbed-missions \
+  -H 'content-type: application/json' \
+  -d '{
+    "requester": "codex",
+    "targetUrl": "https://testbed.averray.com",
+    "goal": "Try the main onboarding flow like a new outside agent.",
+    "allowTestMutations": true
+  }' | jq .
+```
+
+Agents can poll mission and runner state with:
+
+```bash
+curl -fsS 'http://127.0.0.1:8790/monitor/testbed-missions?limit=10' | jq .
+curl -fsS 'http://127.0.0.1:8790/monitor/testbed-missions/<mission-id>' | jq .
+```
+
+If `SLACK_OPERATOR_MONITOR_TOKEN` is set, pass the same token as
+`Authorization: Bearer <token>` or `?token=<token>`. Creating a mission does not
+run privileged Averray MCP tools; it writes a browser mission packet for the
+Hermes testbed runner to claim.
+
+For local agents, the repo ships a small wrapper that handles JSON and optional
+bearer auth:
+
+```bash
+MONITOR_URL=http://127.0.0.1:8790 \
+ALLOW_TEST_MUTATIONS=true \
+scripts/request-hermes-testbed-mission.sh \
+  https://testbed.averray.com \
+  "Try the main onboarding flow like a new outside agent."
+```
+
 The runner is opt-in and fail-closed:
 
 ```env

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -17,6 +17,10 @@
       "types": "./dist/operator-handler.d.ts",
       "import": "./dist/operator-handler.js"
     },
+    "./operator-testbed": {
+      "types": "./dist/operator-testbed.d.ts",
+      "import": "./dist/operator-testbed.js"
+    },
     "./handoff-events": {
       "types": "./dist/handoff-events.d.ts",
       "import": "./dist/handoff-events.js"

--- a/scripts/request-hermes-testbed-mission.sh
+++ b/scripts/request-hermes-testbed-mission.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  scripts/request-hermes-testbed-mission.sh <target-url> [goal]
+
+Environment:
+  MONITOR_URL=http://127.0.0.1:8790
+  MONITOR_TOKEN=<optional monitor bearer token>
+  REQUESTER=<agent name, default current user>
+  AGENT_NAME=Hermes
+  ALLOW_TEST_MUTATIONS=true|false
+  FRESH_MEMORY=true|false
+  MAX_BROWSER_STEPS=80
+  MAX_MINUTES=20
+
+Examples:
+  scripts/request-hermes-testbed-mission.sh https://testbed.averray.com \
+    "Try the main onboarding flow like a new outside agent."
+
+  MONITOR_TOKEN=... ALLOW_TEST_MUTATIONS=true \
+    scripts/request-hermes-testbed-mission.sh https://testbed.averray.com
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+target_url="${1:-${TARGET_URL:-}}"
+if [[ -z "${target_url}" ]]; then
+  usage
+  exit 64
+fi
+
+monitor_url="${MONITOR_URL:-http://127.0.0.1:8790}"
+requester="${REQUESTER:-${USER:-agent}}"
+agent_name="${AGENT_NAME:-Hermes}"
+goal="${2:-${GOAL:-Test the page like a new outside agent and return a structured report.}}"
+allow_test_mutations="${ALLOW_TEST_MUTATIONS:-false}"
+fresh_memory="${FRESH_MEMORY:-true}"
+max_browser_steps="${MAX_BROWSER_STEPS:-80}"
+max_minutes="${MAX_MINUTES:-20}"
+
+payload="$(
+  jq -n \
+    --arg requester "${requester}" \
+    --arg targetUrl "${target_url}" \
+    --arg goal "${goal}" \
+    --arg agentName "${agent_name}" \
+    --argjson allowTestMutations "${allow_test_mutations}" \
+    --argjson freshMemory "${fresh_memory}" \
+    --argjson maxBrowserSteps "${max_browser_steps}" \
+    --argjson maxMinutes "${max_minutes}" \
+    '{
+      requester: $requester,
+      targetUrl: $targetUrl,
+      goal: $goal,
+      agentName: $agentName,
+      allowTestMutations: $allowTestMutations,
+      freshMemory: $freshMemory,
+      maxBrowserSteps: $maxBrowserSteps,
+      maxMinutes: $maxMinutes
+    }'
+)"
+
+headers=(-H "content-type: application/json")
+if [[ -n "${MONITOR_TOKEN:-}" ]]; then
+  headers+=(-H "authorization: Bearer ${MONITOR_TOKEN}")
+fi
+
+curl -fsS -X POST "${monitor_url%/}/monitor/testbed-missions" \
+  "${headers[@]}" \
+  -d "${payload}" \
+  | jq '{ok, requester, missionId:.run.id, status:.run.status, targetUrl:.run.targetUrl, runner, nextStep, detailUrl:("/monitor/testbed-missions/" + .run.id)}'

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -73,6 +73,11 @@ import {
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
 import {
+  createTestbedMissionFromAgent,
+  getTestbedMissionForAgent,
+  listTestbedMissionsForAgent,
+} from "./testbed-agent-entrypoint.js";
+import {
   formatStalePrAlertForSlack,
   shouldPostStalePrAlert,
   stalePrAlertItems,
@@ -185,6 +190,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/recheck",
           "/monitor/codex-tasks",
           "/monitor/collaboration",
+          "/monitor/testbed-missions",
           "/monitor/manifest.webmanifest",
         ] : [],
       },
@@ -270,6 +276,45 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorCommandRequest(request, response);
+    return;
+  }
+  const testbedMissionId = monitorTestbedMissionId(url.pathname);
+  if (request.method === "GET" && (url.pathname === "/monitor/testbed-missions" || testbedMissionId)) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    if (testbedMissionId) {
+      const mission = getTestbedMissionForAgent(testbedMissionId);
+      if (!mission) {
+        writeJson(response, 404, { error: "testbed_mission_not_found", id: testbedMissionId });
+        return;
+      }
+      writeJson(response, 200, mission);
+      return;
+    }
+    const limit = parseOptionalInteger(url.searchParams.get("limit"));
+    const activeOnly = parseOptionalBoolean(url.searchParams.get("activeOnly"));
+    writeJson(response, 200, listTestbedMissionsForAgent({
+      ...(limit !== undefined ? { limit } : {}),
+      ...(activeOnly !== undefined ? { activeOnly } : {}),
+    }));
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/monitor/testbed-missions") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorTestbedMissionRequest(request, response);
     return;
   }
   if (request.method === "GET" && url.pathname === "/monitor/collaboration") {
@@ -749,6 +794,56 @@ async function handleMonitorCommandRequest(request: http.IncomingMessage, respon
     logger.error({ err: error }, "monitor_operator_command_failed");
     writeJson(response, 500, {
       error: "monitor_command_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+
+    const targetUrl = stringField(payload, "targetUrl");
+    if (!targetUrl) {
+      writeJson(response, 400, {
+        error: "missing_target_url",
+        message: "targetUrl is required so Hermes knows which page to test.",
+      });
+      return;
+    }
+
+    const created = createTestbedMissionFromAgent({
+      targetUrl,
+      ...(stringField(payload, "goal") ? { goal: stringField(payload, "goal") } : {}),
+      ...(stringField(payload, "agentName") ? { agentName: stringField(payload, "agentName") } : {}),
+      ...(stringField(payload, "requester") ? { requester: stringField(payload, "requester") } : {}),
+      ...(booleanField(payload, "freshMemory") !== undefined ? { freshMemory: booleanField(payload, "freshMemory") } : {}),
+      ...(booleanField(payload, "allowTestMutations") !== undefined ? { allowTestMutations: booleanField(payload, "allowTestMutations") } : {}),
+      ...(numberField(payload, "maxBrowserSteps") !== undefined ? { maxBrowserSteps: numberField(payload, "maxBrowserSteps") } : {}),
+      ...(numberField(payload, "maxMinutes") !== undefined ? { maxMinutes: numberField(payload, "maxMinutes") } : {}),
+    });
+    recordTestbedMissionCollaboration(created.run);
+    logger.info(
+      {
+        missionId: created.run.id,
+        requester: created.requester,
+        targetUrl: created.run.targetUrl,
+      },
+      "monitor_testbed_mission_created_from_agent"
+    );
+    writeJson(response, 200, {
+      ok: true,
+      ...created,
+    });
+  } catch (error) {
+    logger.error({ err: error }, "monitor_testbed_mission_create_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_mission_create_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }
@@ -1511,6 +1606,14 @@ function numberField(value: unknown, key: string): number | undefined {
   return undefined;
 }
 
+function booleanField(value: unknown, key: string): boolean | undefined {
+  if (!isRecord(value)) return undefined;
+  const field = value[key];
+  if (typeof field === "boolean") return field;
+  if (typeof field === "string") return parseOptionalBoolean(field);
+  return undefined;
+}
+
 function formatUtcTime(time: { hour: number; minute: number }): string {
   return `${String(time.hour).padStart(2, "0")}:${String(time.minute).padStart(2, "0")}`;
 }
@@ -1519,6 +1622,21 @@ function parseOptionalInteger(value: string | null): number | undefined {
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function parseOptionalBoolean(value: string | null): boolean | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function monitorTestbedMissionId(pathname: string): string | undefined {
+  const prefix = "/monitor/testbed-missions/";
+  if (!pathname.startsWith(prefix)) return undefined;
+  const id = decodeURIComponent(pathname.slice(prefix.length)).trim();
+  return id.length > 0 && !id.includes("/") ? id : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -98,9 +98,10 @@ let loadedMissionStorePath: string | undefined;
 
 export function recordTestbedMissionRunFromOperatorResult(
   result: unknown,
-  nowMs: number = Date.now()
+  nowMs: number = Date.now(),
+  path?: string
 ): TestbedMissionRun | undefined {
-  ensureMissionStoreLoaded();
+  ensureMissionStoreLoaded(path);
   if (!isRecord(result) || result.kind !== "testbed_agent_mission") return undefined;
   const mission = isRecord(result.mission) ? result.mission : undefined;
   if (!mission || mission.kind !== "testbed_agent_browser_mission") return undefined;
@@ -139,7 +140,7 @@ export function recordTestbedMissionRunFromOperatorResult(
   };
   missionRuns.push(run);
   while (missionRuns.length > MAX_MISSION_RUNS) missionRuns.shift();
-  persistMissionStore();
+  persistMissionStore(path);
   return run;
 }
 

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -1,0 +1,127 @@
+import { getTestbedAgentMission, type TestbedAgentMissionInput } from "@avg/averray-mcp/operator-testbed";
+
+import {
+  listTestbedMissionRuns,
+  readTestbedMissionRunnerHeartbeat,
+  recordTestbedMissionRunFromOperatorResult,
+  summarizeTestbedMissionRunnerHeartbeat,
+  type TestbedMissionRun,
+} from "./monitor-testbed-missions.js";
+
+export interface AgentTestbedMissionInput extends TestbedAgentMissionInput {
+  requester?: string;
+  path?: string;
+}
+
+export interface AgentTestbedMissionListInput {
+  limit?: number;
+  activeOnly?: boolean;
+  path?: string;
+}
+
+export interface AgentTestbedMissionGetInput {
+  path?: string;
+}
+
+export interface AgentTestbedMissionResult {
+  schemaVersion: 1;
+  kind: "hermes_testbed_agent_entrypoint";
+  requester: string;
+  run: TestbedMissionRun;
+  mission: Record<string, unknown>;
+  runner: ReturnType<typeof summarizeTestbedMissionRunnerHeartbeat>;
+  statusUrlHint: string;
+  nextStep: string;
+}
+
+export function createTestbedMissionFromAgent(
+  input: AgentTestbedMissionInput = {},
+  nowMs: number = Date.now()
+): AgentTestbedMissionResult {
+  const mission = getTestbedAgentMission(input);
+  const run = recordTestbedMissionRunFromOperatorResult(
+    {
+      kind: "testbed_agent_mission",
+      mission,
+    },
+    nowMs,
+    input.path
+  );
+  if (!run) {
+    throw new Error("Hermes testbed mission could not be recorded.");
+  }
+
+  const runner = summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat({ path: input.path }));
+  const runnerReady = runner && !runner.stale && runner.status !== "disabled" && runner.status !== "misconfigured";
+  return {
+    schemaVersion: 1,
+    kind: "hermes_testbed_agent_entrypoint",
+    requester: cleanString(input.requester) ?? "agent",
+    run,
+    mission,
+    runner,
+    statusUrlHint: `/monitor/testbed-missions?limit=20`,
+    nextStep: runnerReady
+      ? "Hermes testbed runner can claim this mission; poll /monitor/testbed-missions or watch the board for the structured report."
+      : "Mission is queued, but no healthy automatic runner is visible; use the mission prompt manually or start the testbed runner.",
+  };
+}
+
+export function listTestbedMissionsForAgent(input: AgentTestbedMissionListInput = {}) {
+  const runner = summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat({ path: input.path }));
+  return {
+    schemaVersion: 1,
+    kind: "hermes_testbed_agent_mission_list",
+    runner,
+    counts: summarizeMissionCounts(listTestbedMissionRuns({ limit: 50, path: input.path })),
+    items: listTestbedMissionRuns(input),
+  };
+}
+
+export function getTestbedMissionForAgent(id: string, input: AgentTestbedMissionGetInput = {}) {
+  const runner = summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat({ path: input.path }));
+  const run = listTestbedMissionRuns({ limit: 50, path: input.path })
+    .find((candidate) => candidate.id === id);
+  if (!run) return undefined;
+  return {
+    schemaVersion: 1,
+    kind: "hermes_testbed_agent_mission",
+    runner,
+    run,
+    mission: run.mission,
+    nextStep: nextStepForRun(run, runner),
+  };
+}
+
+function summarizeMissionCounts(runs: TestbedMissionRun[]) {
+  return {
+    total: runs.length,
+    ready: runs.filter((run) => run.status === "ready").length,
+    running: runs.filter((run) => run.status === "running").length,
+    completed: runs.filter((run) => run.status === "completed").length,
+    failed: runs.filter((run) => run.status === "failed").length,
+  };
+}
+
+function nextStepForRun(
+  run: TestbedMissionRun,
+  runner: ReturnType<typeof summarizeTestbedMissionRunnerHeartbeat>
+): string {
+  if (run.status === "completed") {
+    return "Mission completed; inspect result, evidence, and recommendations before deciding the product follow-up.";
+  }
+  if (run.status === "failed") {
+    return "Mission failed; inspect failureReason/stdoutTail/stderrTail, then fix the runner setup or queue a smaller mission.";
+  }
+  if (run.status === "running") {
+    return "Hermes testbed runner is working; poll this mission until it records a structured report or failure.";
+  }
+  const runnerReady = runner && !runner.stale && runner.status !== "disabled" && runner.status !== "misconfigured";
+  return runnerReady
+    ? "Mission is ready; Hermes testbed runner should claim it on its next poll."
+    : "Mission is ready, but no healthy automatic runner is visible; start the runner or copy the mission prompt for manual execution.";
+}
+
+function cleanString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}

--- a/test/unit/testbed-agent-entrypoint.test.ts
+++ b/test/unit/testbed-agent-entrypoint.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetTestbedMissionRunsForTests,
+  updateTestbedMissionRunnerHeartbeat,
+} from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import {
+  createTestbedMissionFromAgent,
+  getTestbedMissionForAgent,
+  listTestbedMissionsForAgent,
+} from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
+
+vi.mock("@avg/averray-mcp/operator-testbed", () => ({
+  getTestbedAgentMission: (input: Record<string, unknown> = {}) => ({
+    schemaVersion: 1,
+    kind: "testbed_agent_browser_mission",
+    target: {
+      url: input.targetUrl ?? "[TESTBED_URL]",
+      goal: input.goal ?? "test the page",
+      agentName: input.agentName ?? "Hermes",
+      freshMemory: input.freshMemory !== false,
+      maxBrowserSteps: input.maxBrowserSteps ?? 80,
+      maxMinutes: input.maxMinutes ?? 20,
+    },
+    missionPrompt: `Goal: ${input.goal ?? "test the page"}`,
+    safety: {
+      browserMissionShouldMutate: input.allowTestMutations === true,
+    },
+  }),
+}));
+
+describe("testbed agent entrypoint", () => {
+  let dir = "";
+  let path = "";
+
+  beforeEach(() => {
+    __resetTestbedMissionRunsForTests();
+    dir = mkdtempSync(join(tmpdir(), "averray-testbed-agent-entrypoint-"));
+    path = join(dir, "missions.json");
+  });
+
+  afterEach(() => {
+    __resetTestbedMissionRunsForTests();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("lets another agent queue a Hermes browser mission", () => {
+    updateTestbedMissionRunnerHeartbeat({
+      path,
+      runnerId: "test-runner",
+      status: "idle",
+      now: new Date(),
+    });
+
+    const result = createTestbedMissionFromAgent(
+      {
+        path,
+        requester: "claude",
+        targetUrl: "https://testbed.example/onboarding",
+        goal: "try the onboarding flow like a new external agent",
+        allowTestMutations: true,
+        maxBrowserSteps: 40,
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    expect(result).toMatchObject({
+      kind: "hermes_testbed_agent_entrypoint",
+      requester: "claude",
+      run: {
+        status: "ready",
+        targetUrl: "https://testbed.example/onboarding",
+        goal: "try the onboarding flow like a new external agent",
+        allowTestMutations: true,
+      },
+      runner: {
+        runnerId: "test-runner",
+        status: "idle",
+        stale: false,
+      },
+    });
+    expect(result.nextStep).toContain("Hermes testbed runner can claim this mission");
+    expect(String(result.mission.missionPrompt)).toContain("try the onboarding flow");
+  });
+
+  it("lists missions and runner state for polling agents", () => {
+    createTestbedMissionFromAgent(
+      {
+        path,
+        requester: "codex",
+        targetUrl: "https://testbed.example/app",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    const list = listTestbedMissionsForAgent({ path, limit: 10 });
+
+    expect(list).toMatchObject({
+      kind: "hermes_testbed_agent_mission_list",
+      counts: {
+        total: 1,
+        ready: 1,
+        running: 0,
+        completed: 0,
+        failed: 0,
+      },
+      items: [
+        {
+          targetUrl: "https://testbed.example/app",
+          status: "ready",
+        },
+      ],
+    });
+  });
+
+  it("returns one mission with the next useful agent action", () => {
+    const created = createTestbedMissionFromAgent(
+      {
+        path,
+        requester: "codex",
+        targetUrl: "https://testbed.example/app",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    const detail = getTestbedMissionForAgent(created.run.id, { path });
+
+    expect(detail).toMatchObject({
+      kind: "hermes_testbed_agent_mission",
+      run: {
+        id: created.run.id,
+        status: "ready",
+        targetUrl: "https://testbed.example/app",
+      },
+      mission: {
+        kind: "testbed_agent_browser_mission",
+      },
+    });
+    expect(detail?.nextStep).toContain("Mission is ready");
+    expect(getTestbedMissionForAgent("missing", { path })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed
- Added a monitor API entrypoint so other agents can queue Hermes browser testbed missions without using the board UI.
- Added a list/poll endpoint for mission state and runner heartbeat.
- Exported the operator testbed module for service reuse.
- Documented curl usage for agent-created missions.

## Checks run
- npm test -- test/unit/testbed-agent-entrypoint.test.ts test/unit/testbed-mission-runner.test.ts test/unit/monitor-testbed-missions.test.ts
- npm run typecheck
- npm test

## Affected areas
- backend / slack-operator monitor API
- docs

## Env or VPS changes
- No new secrets required. Existing SLACK_OPERATOR_MONITOR_TOKEN protection applies if enabled.
