### PR TITLE
monitor-ui: top strip + Board Now banner + empty layout (M3')

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,27 @@
       "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
       "license": "MIT"
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/@avg/averray-mcp": {
       "resolved": "packages/averray-mcp",
       "link": true
@@ -78,6 +99,413 @@
     "node_modules/@avg/wallet-mcp": {
       "resolved": "packages/wallet-mcp",
       "link": true
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -533,12 +961,55 @@
         "hono": "^4"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -623,6 +1094,13 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1011,6 +1489,106 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1038,6 +1616,55 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.29",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
+      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1187,6 +1814,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -1220,6 +1857,39 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1230,6 +1900,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -1237,6 +1914,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/body-parser": {
@@ -1261,6 +1951,40 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/bytes": {
@@ -1311,6 +2035,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -1353,6 +2098,19 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -1374,6 +2132,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1424,6 +2189,48 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1441,6 +2248,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1451,6 +2265,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1459,6 +2283,23 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -1492,6 +2333,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.363",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.363.tgz",
+      "integrity": "sha512-VjUKPyWzGnT1fujlkEGC/BvN70Hh70KXtAqcmniXviYlJC/ivcT+BWGPyxWVbJZLfvtKR6dqg1L7T7pgAMBtWA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -1499,6 +2347,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -1533,6 +2394,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1578,6 +2455,16 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -1746,6 +2633,46 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1786,6 +2713,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1862,6 +2799,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -1883,6 +2836,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1901,6 +2867,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -1943,6 +2937,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -1979,6 +2980,66 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1991,12 +3052,57 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2097,6 +3203,23 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2176,6 +3299,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -2445,6 +3581,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -2472,6 +3623,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -2517,6 +3678,48 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readdirp": {
@@ -2621,6 +3824,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
@@ -2635,6 +3845,38 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -2838,6 +4080,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -2891,6 +4140,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2898,6 +4167,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tsx": {
@@ -2962,6 +4257,37 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/vary": {
@@ -3582,6 +4908,80 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3641,6 +5041,23 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -3649,6 +5066,13 @@
       "engines": {
         "node": ">=0.4"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",
@@ -3707,7 +5131,20 @@
     },
     "packages/monitor-ui": {
       "name": "@avg/monitor-ui",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/react": "^16.1.0",
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^25.0.1",
+        "vite": "^5.4.11"
+      }
     },
     "packages/policy-mcp": {
       "name": "@avg/policy-mcp",

--- a/packages/monitor-ui/index.html
+++ b/packages/monitor-ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Hermes — Averray</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/monitor-ui/package.json
+++ b/packages/monitor-ui/package.json
@@ -3,11 +3,27 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Hermes Handoff Monitor — redesigned operator UI (Direction A). M2': pure-logic scaffold; React/Vite frontend lands M3'+.",
+  "description": "Hermes Handoff Monitor — redesigned operator UI (Direction A). M3': Vite + React layout (top strip, Board Now banner, lanes, mini-rails).",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -b",
-    "typecheck": "tsc -b --pretty false"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -b --pretty false",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^25.0.1",
+    "vite": "^5.4.11"
   }
 }

--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, within } from "@testing-library/react";
+import { MonitorPage } from "./MonitorPage.js";
+
+afterEach(cleanup);
+
+describe("MonitorPage — calm / A5 state", () => {
+  test("renders the full board chrome end-to-end", () => {
+    const { container } = render(<MonitorPage />);
+    const view = within(container);
+
+    // Top strip
+    expect(view.getByRole("banner")).toBeTruthy();
+    expect(view.getByText("Hermes")).toBeTruthy();
+
+    // Board Now banner — calm tone
+    expect(container.querySelector(".hm-now--calm")).toBeTruthy();
+    expect(view.getByText(/Nothing waits on you/)).toBeTruthy();
+
+    // Lanes bar
+    expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
+
+    // Board grid with all eight lanes
+    expect(view.getByRole("region", { name: "Lane grid" })).toBeTruthy();
+    expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+
+    // Hermes co-pilot rail chrome (full rail lands in M8')
+    expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
+  });
+
+  test("only the Done lane is expanded; the seven live lanes are mini-rails", () => {
+    const { container } = render(<MonitorPage />);
+    expect(within(container).getByRole("region", { name: "Done lane" })).toBeTruthy();
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(7);
+  });
+
+  test("KPI pills read zero for every live lane in the calm state", () => {
+    const { container } = render(<MonitorPage />);
+    // "Operator review" is both a KPI label and a lane name, so scope the
+    // assertion to the banner (TopStrip) KPI region.
+    const banner = within(container).getByRole("banner");
+    expect(within(banner).getByText("Action needed")).toBeTruthy();
+    expect(within(banner).getByText("Operator review")).toBeTruthy();
+  });
+
+  test("the Done lane reflects the release-history fixture count", () => {
+    const { container } = render(<MonitorPage />);
+    // 11 done-history fixtures → the calm banner reports them shipped.
+    expect(within(container).getByText(/11 card\(s\) shipped today/)).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -1,0 +1,100 @@
+// Hermes Handoff Monitor — board page (M3')
+//
+// Composes the Direction A layout against fixtures and renders the
+// calm / "you're done for now" state (artboard A5): every live lane
+// collapses to a mini-rail, only Done stays expanded, and the BoardNow
+// banner reads the calm prose.
+//
+//   <div.hm-board>
+//     <TopStrip />               KPI pills + LIVE indicator + refresh
+//     <BoardNowBanner />         sage calm hero sentence
+//     <div.hm-main>              grid: lanes-wrap | hermes rail (420px)
+//       <div.hm-lanes-wrap>
+//         <LanesBar />           search + filter chips + urgency label
+//         <Board />              the eight lanes (mini-rails + Done)
+//       <aside.hm-hermes>        co-pilot rail chrome (full rail = M8')
+//
+// What's deferred, by milestone:
+//   - card bodies inside lanes → M4' (the <Card> vocabulary)
+//   - live SSE data + real refresh → M5'
+//   - the working Hermes co-pilot rail → M8'
+//
+// Auth is handled at the edge (Cloudflare Access), so there is no
+// client-side guard here.
+
+import { useMemo } from "react";
+import { deriveBoardState } from "./lib/monitor/board-state.js";
+import { FIXTURE_CARDS } from "./lib/monitor/fixtures.js";
+import type { BoardCard } from "./lib/monitor/card-types.js";
+import { TopStrip } from "./components/TopStrip.js";
+import { BoardNowBanner } from "./components/BoardNowBanner.js";
+import { LanesBar } from "./components/LanesBar.js";
+import { Board, CALM_EXPANDED } from "./components/Board.js";
+
+export function MonitorPage() {
+  // Calm / A5 state: only the day's release history exists — every live
+  // lane is empty. Reading against fixtures (rather than an empty list)
+  // proves the data pipeline end-to-end: counts, banner prose, and lane
+  // grouping all derive from real card shapes.
+  const cards: BoardCard[] = useMemo(() => FIXTURE_CARDS.filter((c) => c.lane === "done"), []);
+  const nowLabel = useMemo(() => buildNowLabel(), []);
+
+  const state = useMemo(
+    () => deriveBoardState(cards, { nowLabel, streamOnline: true }),
+    [cards, nowLabel],
+  );
+
+  return (
+    <div className="hm-board">
+      <TopStrip counts={state.counts} liveAt={nowLabel.replace(/ utc$/i, "")} />
+
+      <BoardNowBanner banner={state.banner} />
+
+      <div className="hm-main">
+        <div className="hm-lanes-wrap">
+          <LanesBar counts={state.counts} mode={state.mode} />
+          <Board grouped={state.grouped} initialExpanded={CALM_EXPANDED} />
+        </div>
+
+        <HermesRailPlaceholder />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Minimal Hermes co-pilot rail chrome so the `.hm-main` two-column grid
+ * (1fr | 420px) renders end-to-end. The narrating stream + composer are
+ * wired in M8'; this stub only holds the column and the rail header.
+ */
+function HermesRailPlaceholder() {
+  return (
+    <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
+      {/* A <div>, not <header>: only the TopStrip is the page banner
+          landmark — the rail's own header must not register as a second. */}
+      <div className="hm-hermes-head">
+        <div className="hm-hermes-mark" aria-hidden>
+          H
+        </div>
+        <div>
+          <div className="hm-hermes-title">Hermes co-pilot</div>
+          <div className="hm-hermes-sub">
+            <span className="pulse" aria-hidden />
+            Live · narrating the board · context: everywhere
+          </div>
+        </div>
+      </div>
+
+      <div className="hm-hermes-stream">
+        <div className="hm-lane-empty">Hermes narration lands in M8'.</div>
+      </div>
+    </aside>
+  );
+}
+
+/** Render the current UTC time as "HH:MM:SS utc". */
+function buildNowLabel(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} utc`;
+}

--- a/packages/monitor-ui/src/components/Board.test.tsx
+++ b/packages/monitor-ui/src/components/Board.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { Board, CALM_EXPANDED, DEFAULT_EXPANDED, LANE_DESCRIPTORS } from "./Board.js";
+import { groupByLane } from "../lib/monitor/lane-rules.js";
+import { FIXTURE_CARDS } from "../lib/monitor/fixtures.js";
+
+afterEach(cleanup);
+
+const doneOnly = groupByLane(FIXTURE_CARDS.filter((c) => c.lane === "done"));
+const richMix = groupByLane(FIXTURE_CARDS);
+
+describe("Board", () => {
+  test("renders all eight lanes", () => {
+    const { container } = render(<Board grouped={doneOnly} initialExpanded={CALM_EXPANDED} />);
+    expect(container.querySelectorAll(".hm-lane").length).toBe(LANE_DESCRIPTORS.length);
+    expect(LANE_DESCRIPTORS.length).toBe(8);
+  });
+
+  test("CALM_EXPANDED expands only Done; live lanes are mini-rails", () => {
+    const { container, getByRole } = render(<Board grouped={doneOnly} initialExpanded={CALM_EXPANDED} />);
+    // Done is an expanded <section>.
+    expect(getByRole("region", { name: "Done lane" })).toBeTruthy();
+    // The other seven lanes are collapsed buttons (mini-rails).
+    const collapsed = container.querySelectorAll(".hm-lane--collapsed");
+    expect(collapsed.length).toBe(7);
+  });
+
+  test("Done mini-rail count reflects the grouped cards", () => {
+    const { getByRole } = render(<Board grouped={doneOnly} initialExpanded={new Set()} />);
+    // With nothing expanded, Done collapses to a rail labelled with its count.
+    const doneRail = getByRole("button", { name: /^Done \(/ });
+    expect(doneRail.getAttribute("aria-label")).toContain(`(${doneOnly.done.length} cards)`);
+  });
+
+  test("DEFAULT_EXPANDED expands five lanes", () => {
+    const { container } = render(<Board grouped={richMix} initialExpanded={DEFAULT_EXPANDED} />);
+    const expandedSections = container.querySelectorAll("section.hm-lane");
+    expect(expandedSections.length).toBe(DEFAULT_EXPANDED.size);
+  });
+
+  test("clicking a collapsed lane expands it", () => {
+    const { getByRole, queryByRole } = render(<Board grouped={richMix} initialExpanded={CALM_EXPANDED} />);
+    // Operator review starts collapsed (a button), no region yet.
+    expect(queryByRole("region", { name: "Operator review lane" })).toBeNull();
+    fireEvent.click(getByRole("button", { name: /Operator review/ }));
+    // Now it is an expanded region.
+    expect(getByRole("region", { name: "Operator review lane" })).toBeTruthy();
+  });
+
+  test("the lane grid is a labelled region", () => {
+    const { getByRole } = render(<Board grouped={doneOnly} initialExpanded={CALM_EXPANDED} />);
+    expect(getByRole("region", { name: "Lane grid" })).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/Board.tsx
+++ b/packages/monitor-ui/src/components/Board.tsx
@@ -1,0 +1,86 @@
+// Hermes Handoff Monitor — Board (lane grid)
+//
+// Renders the `.hm-lanes` grid that contains every lane. The wrapping
+// `.hm-board` / `.hm-main` / `.hm-lanes-wrap` containers live in the
+// page component — Board only owns the lanes themselves.
+//
+// M3': ships with the three expansion presets and an optional
+// `renderCard` slot. The calm/empty A5 state collapses every live lane
+// to a mini-rail and expands only Done. M4' supplies the rich <Card>
+// renderer; M5' drives the expansion preset off live board mode.
+
+import { useState, useCallback } from "react";
+import type { ReactNode } from "react";
+import { Lane, type LaneDescriptor, type LaneId } from "./Lane.js";
+import type { BoardCard, Lane as LaneKey } from "../lib/monitor/card-types.js";
+
+// Lane catalogue — the eight lanes the monitor renders, in display
+// order. The first six are "live" lanes (work in progress); the
+// seventh is release-queue (merge-ready); the eighth is done
+// (release history).
+export const LANE_DESCRIPTORS: readonly LaneDescriptor[] = [
+  { id: "needs-attention", name: "Needs attention", action: "Review decision waiting", isAction: true },
+  { id: "drafts", name: "Drafts", action: "Author finishes" },
+  { id: "codex-needed", name: "Codex needed", action: "Create / approve task" },
+  { id: "hermes-checking", name: "Hermes checking", action: "Pre-check in flight" },
+  { id: "operator-review", name: "Operator review", action: "Risk decision" },
+  { id: "release-queue", name: "Release queue", action: "Branch protection" },
+  { id: "deploying", name: "Deploying", action: "Verifying post-merge" },
+  { id: "done", name: "Done", action: "Release history" },
+] as const;
+
+/** Expansion preset for the calm / empty state (A5 in the bundle). */
+export const CALM_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>(["done"]);
+
+/** Expansion preset for the default rich-mix state (A1 in the bundle). */
+export const DEFAULT_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
+  "hermes-checking",
+  "operator-review",
+  "release-queue",
+  "deploying",
+  "done",
+]);
+
+/** Expansion preset when an action card is in flight (A2). */
+export const ACTION_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
+  "operator-review",
+  "hermes-checking",
+  "deploying",
+  "done",
+]);
+
+export type BoardProps = {
+  /** Lane → card[] grouping from `groupByLane(cards)`. */
+  grouped: Record<LaneKey, BoardCard[]>;
+  /** Lanes that should render expanded (rest collapse to mini-rails). */
+  initialExpanded?: ReadonlySet<LaneId>;
+  /** Optional renderer for a single card. M4' supplies the card components. */
+  renderCard?: (card: BoardCard) => ReactNode;
+};
+
+export function Board({ grouped, initialExpanded = DEFAULT_EXPANDED, renderCard }: BoardProps) {
+  const [expanded, setExpanded] = useState<Set<LaneId>>(() => new Set(initialExpanded));
+
+  const onToggle = useCallback((id: LaneId) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="hm-lanes" role="region" aria-label="Lane grid">
+      {LANE_DESCRIPTORS.map((lane) => {
+        const cards = grouped[lane.id] ?? [];
+        const isExpanded = expanded.has(lane.id);
+        return (
+          <Lane key={lane.id} lane={lane} expanded={isExpanded} count={cards.length} onToggle={onToggle}>
+            {renderCard ? cards.map(renderCard) : null}
+          </Lane>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/BoardNowBanner.test.tsx
+++ b/packages/monitor-ui/src/components/BoardNowBanner.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { BoardNowBanner, type BannerData } from "./BoardNowBanner.js";
+
+afterEach(cleanup);
+
+function banner(tone: BannerData["tone"]): BannerData {
+  return {
+    tone,
+    eyebrow: `eyebrow-${tone}`,
+    headline: `headline-${tone}`,
+    sub: `sub-${tone}`,
+    primaryActionId: undefined,
+  };
+}
+
+describe("BoardNowBanner", () => {
+  test("calm tone → sage class + ✓ glyph + prose", () => {
+    const { container, getByText } = render(<BoardNowBanner banner={banner("calm")} />);
+    expect(container.querySelector(".hm-now--calm")).toBeTruthy();
+    expect(getByText("✓")).toBeTruthy();
+    expect(getByText("headline-calm")).toBeTruthy();
+    expect(getByText("sub-calm")).toBeTruthy();
+    expect(getByText(/eyebrow-calm/)).toBeTruthy();
+  });
+
+  test("action tone → amber class + ! glyph", () => {
+    const { container, getByText } = render(<BoardNowBanner banner={banner("action")} />);
+    expect(container.querySelector(".hm-now--action")).toBeTruthy();
+    expect(getByText("!")).toBeTruthy();
+  });
+
+  test("degraded tone → rose class + ‼ glyph", () => {
+    const { container, getByText } = render(<BoardNowBanner banner={banner("degraded")} />);
+    expect(container.querySelector(".hm-now--degraded")).toBeTruthy();
+    expect(getByText("‼")).toBeTruthy();
+  });
+
+  test("headline renders inside an <h1> for landmark structure", () => {
+    const { container } = render(<BoardNowBanner banner={banner("calm")} />);
+    const h1 = container.querySelector("h1.hm-now-head");
+    expect(h1?.textContent).toBe("headline-calm");
+  });
+
+  test("is a polite live region", () => {
+    const { container } = render(<BoardNowBanner banner={banner("calm")} />);
+    const root = container.querySelector(".hm-now");
+    expect(root?.getAttribute("aria-live")).toBe("polite");
+    expect(root?.getAttribute("role")).toBe("status");
+  });
+
+  test("renders the cta slot when provided, omits it otherwise", () => {
+    const withCta = render(<BoardNowBanner banner={banner("action")} cta={<button>Jump to</button>} />);
+    expect(withCta.getByText("Jump to")).toBeTruthy();
+    expect(withCta.container.querySelector(".hm-now-cta")).toBeTruthy();
+
+    const noCta = render(<BoardNowBanner banner={banner("calm")} />);
+    expect(noCta.container.querySelector(".hm-now-cta")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/BoardNowBanner.tsx
+++ b/packages/monitor-ui/src/components/BoardNowBanner.tsx
@@ -1,0 +1,59 @@
+// Hermes Handoff Monitor — BoardNowBanner
+//
+// The hero sentence at the top of the board. Reads the composed prose
+// from `boardNowBanner(cards)` and renders one of three tone variants:
+//   - "action"   — amber wash; "1 card needs your review decision…"
+//   - "calm"     — sage; "Nothing waits on you…"
+//   - "degraded" — rose; "Live stream disconnected…"
+//
+// The text content comes from the selector — the component just picks
+// the glyph and tone class and renders. This keeps the prose
+// composition testable (board-state.test.ts) and the React tree dumb.
+
+import type { ReactNode } from "react";
+
+export type BannerData = {
+  tone: "action" | "calm" | "degraded";
+  eyebrow: string;
+  headline: string;
+  sub: string;
+  primaryActionId: string | undefined;
+};
+
+export type BoardNowBannerProps = {
+  banner: BannerData;
+  /** Right-side action buttons. Caller composes (Jump to / Ask Hermes / etc). */
+  cta?: ReactNode;
+};
+
+const GLYPHS: Record<BannerData["tone"], string> = {
+  action: "!",
+  calm: "✓",
+  degraded: "‼",
+};
+
+export function BoardNowBanner({ banner, cta }: BoardNowBannerProps) {
+  const toneClass =
+    banner.tone === "action"
+      ? "hm-now hm-now--action"
+      : banner.tone === "calm"
+        ? "hm-now hm-now--calm"
+        : "hm-now hm-now--degraded";
+
+  return (
+    <div className={toneClass} role="status" aria-live="polite">
+      <div className="hm-now-glyph" aria-hidden>
+        {GLYPHS[banner.tone]}
+      </div>
+      <div>
+        <div className="hm-now-eyebrow">
+          <span className="live" aria-hidden />
+          {banner.eyebrow}
+        </div>
+        <h1 className="hm-now-head">{banner.headline}</h1>
+        <p className="hm-now-sub">{banner.sub}</p>
+      </div>
+      {cta ? <div className="hm-now-cta">{cta}</div> : null}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/Lane.test.tsx
+++ b/packages/monitor-ui/src/components/Lane.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { Lane, type LaneDescriptor } from "./Lane.js";
+
+afterEach(cleanup);
+
+const lane: LaneDescriptor = { id: "operator-review", name: "Operator review", action: "Risk decision" };
+
+describe("Lane", () => {
+  test("collapsed lane delegates to MiniRail (a button)", () => {
+    const { container, getByRole } = render(<Lane lane={lane} expanded={false} count={2} />);
+    expect(container.querySelector("section")).toBeNull();
+    expect(getByRole("button", { name: /Operator review/ })).toBeTruthy();
+    expect(container.querySelector(".hm-lane--collapsed")).toBeTruthy();
+  });
+
+  test("expanded empty lane shows the empty placeholder", () => {
+    const { container, getByText } = render(<Lane lane={lane} expanded count={0} />);
+    expect(container.querySelector("section.hm-lane")).toBeTruthy();
+    expect(getByText("No operator review right now.")).toBeTruthy();
+    // Empty lane is not the --expanded variant.
+    expect((container.querySelector(".hm-lane") as HTMLElement).className).not.toContain("hm-lane--expanded");
+  });
+
+  test("expanded populated lane renders children and the --expanded variant", () => {
+    const { container, getByText, queryByText } = render(
+      <Lane lane={lane} expanded count={2}>
+        <div>card-one</div>
+        <div>card-two</div>
+      </Lane>,
+    );
+    expect((container.querySelector(".hm-lane") as HTMLElement).className).toContain("hm-lane--expanded");
+    expect(getByText("card-one")).toBeTruthy();
+    expect(getByText("card-two")).toBeTruthy();
+    expect(queryByText(/right now\./)).toBeNull();
+  });
+
+  test("expanded header shows title, count, and action eyebrow", () => {
+    const { getByText } = render(<Lane lane={lane} expanded count={2} />);
+    expect(getByText("Operator review")).toBeTruthy();
+    expect(getByText("2")).toBeTruthy();
+    expect(getByText("Risk decision")).toBeTruthy();
+  });
+
+  test("collapse button fires onToggle in expanded mode", () => {
+    const onToggle = vi.fn();
+    const { getByRole } = render(<Lane lane={lane} expanded count={1} onToggle={onToggle} />);
+    fireEvent.click(getByRole("button", { name: /Collapse Operator review lane/ }));
+    expect(onToggle).toHaveBeenCalledWith("operator-review");
+  });
+
+  test("omits the collapse button when no onToggle is given", () => {
+    const { queryByRole } = render(<Lane lane={lane} expanded count={1} />);
+    expect(queryByRole("button", { name: /Collapse/ })).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/Lane.tsx
+++ b/packages/monitor-ui/src/components/Lane.tsx
@@ -1,0 +1,71 @@
+// Hermes Handoff Monitor — Lane
+//
+// A single lane rendered in one of two visual modes:
+//   - collapsed → delegates to <MiniRail>: a vertical strip showing the
+//     lane's name and card count. Clicking expands.
+//   - expanded → full lane with header, optional action eyebrow, and the
+//     card list (or an empty placeholder when count === 0).
+//
+// M3': renders the empty / mini-rail / populated variants. Card bodies
+// are supplied by the page via the `children` slot; the rich <Card>
+// vocabulary lands in M4'.
+
+import type { ReactNode } from "react";
+import { MiniRail, type LaneDescriptor, type LaneId } from "./MiniRail.js";
+
+export type { LaneDescriptor, LaneId };
+
+export type LaneProps = {
+  lane: LaneDescriptor;
+  /** Whether the lane is expanded (default) or collapsed to a mini-rail. */
+  expanded: boolean;
+  /** Number of cards in the lane. */
+  count: number;
+  /** Cards rendered into the body slot. M4' wires the <Card /> renders. */
+  children?: ReactNode;
+  /** Click handler to toggle this lane's expand/collapse state. */
+  onToggle?: (id: LaneId) => void;
+};
+
+export function Lane({ lane, expanded, count, children, onToggle }: LaneProps) {
+  if (!expanded) {
+    return <MiniRail lane={lane} count={count} onToggle={onToggle} />;
+  }
+
+  const classes = [
+    "hm-lane",
+    count === 0 ? "" : "hm-lane--expanded",
+    lane.isAction ? "hm-lane--action" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section className={classes} aria-label={`${lane.name} lane`}>
+      <div className="hm-lane-head">
+        <div className="hm-lane-head-row">
+          <span className="hm-lane-title">{lane.name}</span>
+          <span className="hm-lane-count">{count}</span>
+          {onToggle ? (
+            <button
+              type="button"
+              className="hm-lane-collapse"
+              onClick={() => onToggle(lane.id)}
+              aria-label={`Collapse ${lane.name} lane`}
+            >
+              collapse ‹
+            </button>
+          ) : null}
+        </div>
+        {lane.action ? <div className="hm-lane-action">{lane.action}</div> : null}
+      </div>
+      <div className="hm-lane-body">
+        {count === 0 ? (
+          <div className="hm-lane-empty">No {lane.name.toLowerCase()} right now.</div>
+        ) : (
+          children
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/monitor-ui/src/components/LanesBar.test.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { LanesBar } from "./LanesBar.js";
+import type { KPICounts } from "../lib/monitor/board-state.js";
+
+afterEach(cleanup);
+
+const counts: KPICounts = {
+  action: 1,
+  review: 2,
+  checking: 3,
+  queue: 1,
+  deploying: 1,
+  blocked: 0,
+  done: 9,
+  total: 8,
+};
+
+describe("LanesBar", () => {
+  test("renders a disabled, read-only search input with the / hint", () => {
+    const { container, getByText } = render(<LanesBar counts={counts} mode="calm" />);
+    const input = container.querySelector(".hm-search input") as HTMLInputElement;
+    expect(input).toBeTruthy();
+    expect(input.disabled).toBe(true);
+    expect(input.readOnly).toBe(true);
+    expect(getByText("/")).toBeTruthy();
+  });
+
+  test("tip text follows board mode", () => {
+    const calm = render(<LanesBar counts={counts} mode="calm" />);
+    expect(calm.getByText(/everything quiet · history below/)).toBeTruthy();
+
+    const action = render(<LanesBar counts={counts} mode="action" />);
+    expect(action.getByText(/focus on the lane that needs you/)).toBeTruthy();
+
+    const degraded = render(<LanesBar counts={counts} mode="degraded" />);
+    expect(degraded.getByText(/auto-reconnecting/)).toBeTruthy();
+  });
+
+  test("renders all six filter chips with the All chip active", () => {
+    const { container } = render(<LanesBar counts={counts} mode="calm" />);
+    const chips = container.querySelectorAll(".hm-filter-chip");
+    expect(chips.length).toBe(6);
+    expect((chips[0] as HTMLElement).className).toContain("is-active");
+    expect(chips[0].textContent).toContain("All");
+    // Filter chips carry their counts.
+    expect(chips[0].querySelector(".ct")?.textContent).toBe("8"); // All = total
+    expect(chips[5].textContent).toContain("Done");
+    expect(chips[5].querySelector(".ct")?.textContent).toBe("9");
+  });
+
+  test("filter chips are non-interactive in M3'", () => {
+    const { container } = render(<LanesBar counts={counts} mode="calm" />);
+    const chip = container.querySelector(".hm-filter-chip") as HTMLElement;
+    expect(chip.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  test("shows the urgency-sort label", () => {
+    const { getByText } = render(<LanesBar counts={counts} mode="calm" />);
+    expect(getByText("sorted by next-action urgency")).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/LanesBar.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.tsx
@@ -1,0 +1,73 @@
+// Hermes Handoff Monitor — LanesBar
+//
+// The thin tools row between the BoardNow banner and the lane grid.
+// Holds:
+//   - Search input on the left (with `/` keyboard hint)
+//   - Short status tip ("focus on the lane that needs you" / "everything
+//     quiet · history below" / "data may be stale; auto-reconnecting")
+//   - "sorted by next-action urgency" label
+//   - Six filter chips: All, Blocked, Review, Ready, Running, Done
+//
+// M3': search input renders but is disabled (M5' wires the filter state
+// via URL params). Filter chips render count-only and are
+// non-interactive. The tip is derived from the board mode.
+
+import type { KPICounts, BoardMode } from "../lib/monitor/board-state.js";
+
+const TIPS: Record<BoardMode, string> = {
+  action: "· focus on the lane that needs you",
+  calm: "· everything quiet · history below",
+  degraded: "· data may be stale; auto-reconnecting",
+};
+
+export type LanesBarProps = {
+  counts: KPICounts;
+  mode: BoardMode;
+  /** Search value (M5' wires this; M3' is read-only). */
+  searchValue?: string;
+};
+
+export function LanesBar({ counts, mode, searchValue = "" }: LanesBarProps) {
+  const tip = TIPS[mode];
+  const filters: Array<[label: string, count: number]> = [
+    ["All", counts.total],
+    ["Blocked", counts.blocked],
+    ["Review", counts.review],
+    ["Ready", counts.queue],
+    ["Running", counts.checking],
+    ["Done", counts.done],
+  ];
+
+  return (
+    <div className="hm-lanes-bar">
+      <div className="hm-lanes-tools">
+        <span className="hm-search">
+          <span className="hm-muted" aria-hidden>
+            ⌕
+          </span>
+          <input
+            type="search"
+            placeholder="search PR, repo, correlation id…"
+            value={searchValue}
+            disabled
+            aria-label="Search PRs, repos, or correlation IDs (wired in M5')"
+            readOnly
+          />
+          <kbd>/</kbd>
+        </span>
+        <span className="hm-mono hm-muted" style={{ marginLeft: 6 }}>
+          {tip}
+        </span>
+      </div>
+
+      <div className="hm-lanes-tools">
+        <span className="hm-mono hm-muted">sorted by next-action urgency</span>
+        {filters.map(([label, n], i) => (
+          <span key={label} className={"hm-filter-chip " + (i === 0 ? "is-active" : "")} aria-disabled="true">
+            {label} <span className="ct">{n}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/MiniRail.test.tsx
+++ b/packages/monitor-ui/src/components/MiniRail.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { MiniRail, type LaneDescriptor } from "./MiniRail.js";
+
+afterEach(cleanup);
+
+const lane: LaneDescriptor = { id: "release-queue", name: "Release queue", action: "Branch protection" };
+const actionLane: LaneDescriptor = { id: "needs-attention", name: "Needs attention", isAction: true };
+
+describe("MiniRail", () => {
+  test("renders the count and lane name as a collapsed rail", () => {
+    const { container, getByText } = render(<MiniRail lane={lane} count={3} />);
+    const root = container.querySelector(".hm-lane--collapsed");
+    expect(root).toBeTruthy();
+    expect(getByText("3")).toBeTruthy();
+    expect(getByText("Release queue")).toBeTruthy();
+  });
+
+  test("zero count wears ct--zero, non-zero wears ct--has", () => {
+    const zero = render(<MiniRail lane={lane} count={0} />);
+    expect((zero.container.querySelector(".ct") as HTMLElement).className).toContain("ct--zero");
+
+    const some = render(<MiniRail lane={lane} count={5} />);
+    expect((some.container.querySelector(".ct") as HTMLElement).className).toContain("ct--has");
+  });
+
+  test("action lane wears the amber action modifier", () => {
+    const { container } = render(<MiniRail lane={actionLane} count={1} />);
+    expect((container.querySelector(".hm-lane") as HTMLElement).className).toContain("hm-lane--action");
+  });
+
+  test("clicking the rail expands the lane via onToggle", () => {
+    const onToggle = vi.fn();
+    const { getByRole } = render(<MiniRail lane={lane} count={2} onToggle={onToggle} />);
+    fireEvent.click(getByRole("button"));
+    expect(onToggle).toHaveBeenCalledWith("release-queue");
+  });
+
+  test("aria-label pluralizes the card count", () => {
+    const one = render(<MiniRail lane={lane} count={1} />);
+    expect(within(one.container).getByRole("button").getAttribute("aria-label")).toContain("(1 card)");
+
+    const many = render(<MiniRail lane={lane} count={4} />);
+    expect(within(many.container).getByRole("button").getAttribute("aria-label")).toContain("(4 cards)");
+  });
+});

--- a/packages/monitor-ui/src/components/MiniRail.tsx
+++ b/packages/monitor-ui/src/components/MiniRail.tsx
@@ -1,0 +1,56 @@
+// Hermes Handoff Monitor — MiniRail
+//
+// A collapsed lane rendered as a vertical mini-rail: a thin strip
+// showing the lane's card count and name, clickable to expand. In the
+// Direction A layout there is no separate left/right rail container —
+// every collapsed lane *is* a mini-rail, rendered inline in lane order
+// inside `.hm-lanes`. `<Lane>` delegates here when `expanded` is false.
+//
+// Visual contract: the bundle's `hm-lane--collapsed` / `hm-lane-rail`
+// block in styles/monitor.css.
+
+import type { Lane } from "../lib/monitor/card-types.js";
+
+/** Canonical lane id — re-exported so <Lane>/<Board> share one source. */
+export type LaneId = Lane;
+
+export type LaneDescriptor = {
+  id: LaneId;
+  name: string;
+  /** Optional eyebrow / hint label shown under the lane title when expanded. */
+  action?: string;
+  /** When true the lane wears the amber action styling. */
+  isAction?: boolean;
+};
+
+export type MiniRailProps = {
+  lane: LaneDescriptor;
+  /** Number of cards in the lane. */
+  count: number;
+  /** Click handler to expand this lane. */
+  onToggle?: (id: LaneId) => void;
+};
+
+export function MiniRail({ lane, count, onToggle }: MiniRailProps) {
+  const classes = ["hm-lane", "hm-lane--collapsed", lane.isAction ? "hm-lane--action" : ""]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <button
+      type="button"
+      className={classes}
+      onClick={() => onToggle?.(lane.id)}
+      aria-label={`${lane.name} (${count} ${count === 1 ? "card" : "cards"}) — click to expand`}
+      title={`${lane.name} (${count})`}
+    >
+      <div className="hm-lane-rail">
+        <span className={"ct " + (count > 0 ? "ct--has" : "ct--zero")}>{count}</span>
+        <span className="lbl">{lane.name}</span>
+        <span className="icn" aria-hidden>
+          ›
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/packages/monitor-ui/src/components/TopStrip.test.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { TopStrip } from "./TopStrip.js";
+import type { KPICounts } from "../lib/monitor/board-state.js";
+
+afterEach(cleanup);
+
+const calmCounts: KPICounts = {
+  action: 0,
+  review: 0,
+  checking: 0,
+  queue: 0,
+  deploying: 0,
+  blocked: 0,
+  done: 11,
+  total: 0,
+};
+
+const busyCounts: KPICounts = {
+  action: 2,
+  review: 1,
+  checking: 3,
+  queue: 1,
+  deploying: 1,
+  blocked: 0,
+  done: 4,
+  total: 8,
+};
+
+describe("TopStrip", () => {
+  test("renders the brand mark and banner role", () => {
+    const { getByText, getByRole } = render(<TopStrip counts={calmCounts} />);
+    expect(getByText("Hermes")).toBeTruthy();
+    expect(getByText("Handoff monitor · Averray")).toBeTruthy();
+    expect(getByRole("banner")).toBeTruthy();
+  });
+
+  test("renders KPI labels with their counts", () => {
+    const { getByText } = render(<TopStrip counts={busyCounts} />);
+    // Each KPI label is present; the count lives in the sibling `.n` span.
+    expect(getByText("Action needed")).toBeTruthy();
+    expect(getByText("Operator review")).toBeTruthy();
+    expect(getByText("Hermes checking")).toBeTruthy();
+    expect(getByText("Release queue")).toBeTruthy();
+    expect(getByText("Deploying")).toBeTruthy();
+  });
+
+  test("zero-count KPIs wear the --zero modifier, non-zero do not", () => {
+    const { container } = render(<TopStrip counts={busyCounts} />);
+    const kpis = container.querySelectorAll(".hm-kpi");
+    // First KPI (action=2) should be the --action variant, not --zero.
+    const action = kpis[0] as HTMLElement;
+    expect(action.className).toContain("hm-kpi--action");
+    expect(action.className).not.toContain("hm-kpi--zero");
+  });
+
+  test("zero counts render the --zero modifier", () => {
+    const { container } = render(<TopStrip counts={calmCounts} />);
+    const action = container.querySelector(".hm-kpi") as HTMLElement;
+    expect(action.className).toContain("hm-kpi--zero");
+  });
+
+  test("shows the live timestamp when provided, dash otherwise", () => {
+    const withTime = render(<TopStrip counts={calmCounts} liveAt="14:32:08" />);
+    expect(withTime.getByText(/Live · 14:32:08/)).toBeTruthy();
+
+    const noTime = render(<TopStrip counts={calmCounts} />);
+    expect(noTime.getByText(/Live · —/)).toBeTruthy();
+  });
+
+  test("refresh button is disabled without a handler", () => {
+    const { getByRole } = render(<TopStrip counts={calmCounts} />);
+    const disabledBtn = getByRole("button", { name: "Refresh board" }) as HTMLButtonElement;
+    expect(disabledBtn.disabled).toBe(true);
+  });
+
+  test("refresh button is enabled and fires when given a handler", () => {
+    const onRefresh = vi.fn();
+    const { getByRole } = render(<TopStrip counts={calmCounts} onRefresh={onRefresh} />);
+    const btn = getByRole("button", { name: "Refresh board" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  test("renders the deploy-health pill", () => {
+    const { getByText } = render(<TopStrip counts={calmCounts} deployHealth="DEGRADED" />);
+    expect(getByText(/Deploy DEGRADED/)).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/TopStrip.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.tsx
@@ -1,0 +1,89 @@
+// Hermes Handoff Monitor — TopStrip
+//
+// Header strip showing the brand mark, KPI counts per lane, LIVE
+// indicator, and a manual refresh button.
+//
+// M3' renders against derived board state from fixtures. M5' wires it to
+// live SSE data + the real refresh; M11' adds the degraded-mode variant
+// (KPIs show `?` instead of `0` when the live stream is disconnected).
+//
+// Visual contract is the bundle's `hm-top` block in styles/monitor.css.
+
+import type { KPICounts } from "../lib/monitor/board-state.js";
+
+export type TopStripProps = {
+  /** Current KPI counts from `kpiCounts(cards)`. */
+  counts: KPICounts;
+  /** Live indicator timestamp, e.g. "14:32:08". When undefined, dashes shown. */
+  liveAt?: string;
+  /** Deploy-health label shown in the rightmost KPI pill. Default "OK". */
+  deployHealth?: "OK" | "DEGRADED" | "UNKNOWN";
+  /** Click handler for the refresh button (M5' wires the actual refresh). */
+  onRefresh?: () => void;
+};
+
+export function TopStrip({ counts, liveAt, deployHealth = "OK", onRefresh }: TopStripProps) {
+  return (
+    <div className="hm-top" role="banner">
+      <div className="hm-brand">
+        <div className="hm-brand-mark" aria-hidden>
+          A
+        </div>
+        <div>
+          <div className="hm-brand-name">Hermes</div>
+          <div className="hm-brand-sub">Handoff monitor · Averray</div>
+        </div>
+      </div>
+
+      <div className="hm-kpis" role="status" aria-live="polite" aria-label="Board KPI counts">
+        <Kpi count={counts.action} label="Action needed" tone={counts.action ? "action" : "zero"} />
+        <Kpi count={counts.review} label="Operator review" tone={counts.review ? "action" : "zero"} />
+        <Kpi count={counts.checking} label="Hermes checking" tone={counts.checking ? "default" : "zero"} />
+        <Kpi count={counts.queue} label="Release queue" tone={counts.queue ? "default" : "zero"} />
+        <Kpi count={counts.deploying} label="Deploying" tone={counts.deploying ? "default" : "zero"} />
+        <span className="hm-kpi hm-kpi--ok">
+          <span className="dot" aria-hidden />
+          Deploy {deployHealth}
+        </span>
+      </div>
+
+      <div className="hm-top-right">
+        <span className="hm-deploy-pill" aria-label={liveAt ? `Live as of ${liveAt}` : "Live indicator"}>
+          <span className="ledge" aria-hidden />
+          Live · {liveAt ?? "—"}
+        </span>
+        <button
+          type="button"
+          className="hm-refresh"
+          onClick={onRefresh}
+          disabled={!onRefresh}
+          aria-label="Refresh board"
+        >
+          ⟳ Refresh
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Kpi({
+  count,
+  label,
+  tone,
+}: {
+  count: number;
+  label: string;
+  tone: "default" | "action" | "zero";
+}) {
+  const cls =
+    tone === "action"
+      ? "hm-kpi hm-kpi--action"
+      : tone === "zero"
+        ? "hm-kpi hm-kpi--zero"
+        : "hm-kpi";
+  return (
+    <span className={cls}>
+      <span className="n">{count}</span> {label}
+    </span>
+  );
+}

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -1,0 +1,23 @@
+// Hermes Handoff Monitor — Vite entry point.
+//
+// Bootstraps the React tree and pulls in the bundle CSS (shipped
+// verbatim as styles/monitor.css). This file is the only place the
+// global stylesheet is imported; it is excluded from the composite
+// `tsc -b` graph (Vite/esbuild own it) so the CSS side-effect import
+// never trips NodeNext module resolution.
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { MonitorPage } from "./MonitorPage.js";
+import "./styles/monitor.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  throw new Error("Hermes monitor: #root element not found");
+}
+
+createRoot(rootEl).render(
+  <StrictMode>
+    <MonitorPage />
+  </StrictMode>,
+);

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1,0 +1,1999 @@
+/* ============================================================
+   Hermes Handoff Monitor — Averray light, operator-grade
+   ============================================================
+   Visual system:
+   - Warm beige page · cream paper cards · sage accent · amber for action
+   - Auto-sizing lanes: empty collapse to thin rails, busy expand to fill
+   - Hermes promoted to a persistent right column with card-stream chat
+   - Stale = desaturated; Action-needed = amber wash + breathing motion
+   ============================================================ */
+
+/* ---------- Local theme additions (on top of averray-tokens.css) ---------- */
+:root {
+  --hm-paper:       #fffdf7;
+  --hm-paper-2:     #faf7ee;
+  --hm-paper-3:     #f5f1e3;
+  --hm-rail:        #efebde;
+  --hm-rail-strong: #e8e3d2;
+  --hm-ink:         #111315;
+  --hm-ink-soft:    #2c2f31;
+  --hm-muted:       #5e635a;        /* darkened from #6c7068 to push to ~5.5:1 on cream */
+  --hm-muted-soft:  #767870;        /* darkened from #8d8f86 — now ~4.5:1 on cream */
+  --hm-line:        rgba(17,19,21,0.10);
+  --hm-line-soft:   rgba(17,19,21,0.06);
+  --hm-line-strong: rgba(17,19,21,0.18);
+
+  --hm-sage:        #1e6642;        /* success / verdict accent */
+  --hm-sage-deep:   #134b30;        /* AAA text on sage-wash */
+  --hm-sage-soft:   #d6eadf;
+  --hm-sage-wash:   #e9f1e9;
+
+  /* Hermes uses a slightly bluer / teal sage so its mark is distinguishable
+     from the green "success" sage at a glance — important to keep
+     "Hermes spoke" from reading as "this passed". */
+  --hm-hermes:      #0f6b5a;
+  --hm-hermes-deep: #074a3e;
+  --hm-hermes-soft: #d2e8e2;
+
+  --hm-amber:       #a76122;
+  --hm-amber-deep:  #7d4615;        /* AA text on amber-wash; AAA on cream */
+  --hm-amber-soft:  #f4e3cf;
+  --hm-amber-wash:  #faecd6;
+  --hm-amber-ring:  rgba(167, 97, 34, 0.32);
+
+  --hm-clay:        #c98a55;
+  --hm-blue:        #254e9a;
+  --hm-blue-soft:   #dee5f4;
+  --hm-rose:        #a23a3a;
+  --hm-rose-soft:   #f2dad6;
+
+  /* Grey for "offline / source unreachable" — neutral, no urgency */
+  --hm-offline:      #5a5e5a;
+  --hm-offline-soft: #d6d8d0;
+
+  --hm-stale:       #a59f8e;
+  --hm-fresh:       #1e6642;
+
+  --hm-shadow-card: 0 1px 0 rgba(17,19,21,0.04), 0 8px 24px rgba(34,43,36,0.06);
+  --hm-shadow-pop:  0 24px 60px rgba(34,43,36,0.16), 0 0 0 1px rgba(17,19,21,0.06);
+  --hm-shadow-action: 0 0 0 1px var(--hm-amber-ring), 0 12px 28px rgba(167,97,34,0.18), 0 1px 0 rgba(167,97,34,0.10);
+
+  --hm-radius:    10px;
+  --hm-radius-sm: 6px;
+  --hm-radius-lg: 14px;
+}
+
+/* ---------- Reset-ish ---------- */
+* { box-sizing: border-box; }
+body { margin: 0; }
+
+/* The artboards have their own background; let the canvas paint the rest. */
+
+/* ============================================================
+   ROOT BOARD CONTAINER — fills the artboard
+   ============================================================ */
+.hm-board {
+  width: 100%;
+  height: 100%;
+  background: var(--hm-paper-3);
+  color: var(--hm-ink);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  overflow: hidden;
+  letter-spacing: 0 !important;
+}
+
+/* ============================================================
+   TOP STRIP — brand, top-line KPIs, refresh
+   ============================================================ */
+.hm-top {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 22px;
+  padding: 14px 22px;
+  background: var(--hm-paper);
+  border-bottom: 1px solid var(--hm-line);
+}
+
+.hm-brand { display: flex; align-items: center; gap: 12px; }
+.hm-brand-mark {
+  width: 34px; height: 34px;
+  border-radius: 8px;
+  background: var(--hm-ink);
+  color: #fffdf7;
+  display: grid; place-items: center;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 16px;
+}
+.hm-brand-name {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 16px;
+  color: var(--hm-ink);
+  line-height: 1.1;
+}
+.hm-brand-sub {
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage);
+  margin-top: 2px;
+}
+
+/* KPI strip — top-line counters */
+.hm-kpis {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.hm-kpi {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 13px 7px 11px;
+  border-radius: 999px;
+  background: var(--hm-paper-2);
+  border: 1px solid var(--hm-line-soft);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--hm-muted);
+  letter-spacing: 0.06em !important;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.hm-kpi .n {
+  display: inline-grid;
+  place-items: center;
+  min-width: 22px; height: 22px;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--hm-rail);
+  color: var(--hm-ink);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0 !important;
+}
+.hm-kpi--ok       { background: var(--hm-sage-wash); border-color: rgba(30,102,66,0.18); color: var(--hm-sage-deep); }
+.hm-kpi--ok .n    { background: var(--hm-sage-soft); color: var(--hm-sage-deep); }
+.hm-kpi--action   { background: var(--hm-amber-wash); border-color: var(--hm-amber-ring); color: var(--hm-amber-deep); }
+.hm-kpi--action .n{ background: var(--hm-amber-soft); color: var(--hm-amber-deep); }
+.hm-kpi--zero     { opacity: 0.55; }
+.hm-kpi .dot { width: 6px; height: 6px; border-radius: 999px; background: currentColor; opacity: 0.7; }
+
+.hm-top-right {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-refresh {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 12px;
+  border: 1px solid var(--hm-line);
+  border-radius: 8px;
+  background: var(--hm-paper);
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em !important;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.hm-refresh:hover { border-color: var(--hm-line-strong); }
+.hm-deploy-pill {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 6px 11px;
+  border-radius: 999px;
+  background: var(--hm-sage-wash);
+  border: 1px solid rgba(30,102,66,0.18);
+  color: var(--hm-sage-deep);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.1em !important;
+  text-transform: uppercase;
+}
+.hm-deploy-pill .ledge {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--hm-sage);
+  box-shadow: 0 0 0 3px rgba(30,102,66,0.18);
+  animation: hm-pulse 2.4s infinite;
+}
+@keyframes hm-pulse {
+  0%, 100% { box-shadow: 0 0 0 3px rgba(30,102,66,0.16); }
+  50%      { box-shadow: 0 0 0 5px rgba(30,102,66,0.06); }
+}
+
+/* ============================================================
+   BOARD NOW BANNER — the single most important surface
+   ============================================================ */
+.hm-now {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 22px;
+  padding: 18px 24px;
+  background: var(--hm-paper);
+  border-bottom: 1px solid var(--hm-line);
+  position: relative;
+}
+.hm-now--action {
+  background: linear-gradient(180deg, var(--hm-amber-wash) 0%, var(--hm-paper) 92%);
+  border-bottom-color: var(--hm-amber-ring);
+}
+.hm-now--calm {
+  background: linear-gradient(180deg, var(--hm-sage-wash) 0%, var(--hm-paper) 92%);
+}
+
+.hm-now-eyebrow {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.18em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  display: flex; align-items: center; gap: 10px;
+  margin: 0 0 5px;
+}
+.hm-now--action .hm-now-eyebrow { color: var(--hm-amber-deep); }
+.hm-now--calm   .hm-now-eyebrow { color: var(--hm-sage-deep); }
+.hm-now-eyebrow .live {
+  display: inline-block;
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--hm-amber);
+  animation: hm-breathe 1.8s infinite;
+}
+.hm-now--calm .hm-now-eyebrow .live { background: var(--hm-sage); }
+@keyframes hm-breathe {
+  0%, 100% { transform: scale(1);   opacity: 1;   }
+  50%      { transform: scale(1.3); opacity: 0.55;}
+}
+
+.hm-now-head {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.18;
+  color: var(--hm-ink);
+  margin: 0;
+  max-width: 96ch;
+  text-wrap: pretty;
+}
+.hm-now-sub {
+  margin: 6px 0 0;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--hm-muted);
+  max-width: 96ch;
+  text-wrap: pretty;
+}
+.hm-now-sub strong { color: var(--hm-ink); font-weight: 600; }
+
+.hm-now-cta {
+  display: inline-flex; flex-direction: column; align-items: flex-end; gap: 8px;
+}
+.hm-now-cta .button-row { display: flex; gap: 8px; }
+.hm-now-quick {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+}
+
+.hm-now-glyph {
+  width: 56px; height: 56px;
+  border-radius: 14px;
+  display: grid; place-items: center;
+  background: var(--hm-paper-2);
+  border: 1px solid var(--hm-line);
+}
+.hm-now--action .hm-now-glyph {
+  background: var(--hm-amber-soft);
+  border-color: var(--hm-amber-ring);
+}
+.hm-now--calm .hm-now-glyph {
+  background: var(--hm-sage-soft);
+  border-color: rgba(30,102,66,0.18);
+}
+
+/* ============================================================
+   MAIN — two columns: lanes (flex) + hermes co-pilot (fixed)
+   ============================================================ */
+.hm-main {
+  display: grid;
+  grid-template-columns: 1fr 420px;
+  min-height: 0;
+  overflow: hidden;
+}
+.hm-main--hermes-wide {
+  grid-template-columns: 1fr 540px;
+}
+
+/* ============================================================
+   LANES — auto-sizing kanban
+   ============================================================ */
+.hm-lanes-wrap {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+.hm-lanes-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 22px 10px;
+  gap: 14px;
+}
+.hm-lanes-tools {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-search {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 7px 11px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: 8px;
+  width: 280px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--hm-muted);
+}
+.hm-search input {
+  flex: 1; border: 0; background: transparent; outline: none;
+  font: inherit; color: var(--hm-ink);
+}
+.hm-search kbd {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+  letter-spacing: 0 !important;
+}
+.hm-filter-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.06em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  cursor: default;
+}
+.hm-filter-chip.is-active {
+  background: var(--hm-ink);
+  color: #fffdf7;
+  border-color: var(--hm-ink);
+}
+.hm-filter-chip .ct {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0 !important;
+  color: var(--hm-muted-soft);
+}
+.hm-filter-chip.is-active .ct { color: rgba(255,253,247,0.7); }
+
+.hm-lanes {
+  display: flex;
+  gap: 12px;
+  padding: 4px 22px 22px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex: 1;
+  min-height: 0;
+  align-items: stretch;
+  scrollbar-width: none;
+}
+.hm-lanes::-webkit-scrollbar { display: none; }
+
+/* Lane states: collapsed (empty/quiet) vs expanded */
+.hm-lane {
+  display: flex;
+  flex-direction: column;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  min-height: 0;
+  transition: width 220ms var(--ease, cubic-bezier(.2,.7,.2,1)), background 220ms;
+  position: relative;
+  overflow: hidden;
+}
+.hm-lane--collapsed {
+  width: 64px;
+  flex: 0 0 auto;
+  background: var(--hm-paper-2);
+  cursor: pointer;
+}
+.hm-lane--expanded {
+  flex: 1 1 0;
+  min-width: 280px;
+}
+.hm-lane--xl { flex: 2 1 0; }
+.hm-lane--focus { flex: 4 1 0; min-width: 520px; background: var(--hm-paper); }
+.hm-lane--action { border-color: var(--hm-amber-ring); }
+.hm-lane--action::before {
+  content: ""; position: absolute; inset: 0 0 auto 0; height: 3px;
+  background: linear-gradient(90deg, var(--hm-amber) 0%, var(--hm-amber-soft) 100%);
+}
+
+/* Collapsed lane: vertical name + count, NO rotated text — readable */
+.hm-lane--collapsed .hm-lane-head { display: none; }
+.hm-lane--collapsed .hm-lane-body { display: none; }
+.hm-lane-rail {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  padding: 14px 0;
+  gap: 10px;
+  height: 100%;
+}
+.hm-lane--collapsed .hm-lane-rail { display: flex; }
+.hm-lane-rail .ct {
+  display: grid; place-items: center;
+  width: 30px; height: 30px;
+  border-radius: 999px;
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+}
+.hm-lane-rail .ct--zero {
+  background: transparent;
+  border: 1px dashed var(--hm-line);
+  color: var(--hm-muted-soft);
+}
+.hm-lane-rail .ct--has {
+  background: var(--hm-sage-soft);
+  color: var(--hm-sage-deep);
+}
+.hm-lane-rail .lbl {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  white-space: nowrap;
+}
+.hm-lane-rail .lbl-h {
+  /* horizontal version for very short labels — fallback */
+  writing-mode: horizontal-tb;
+  transform: none;
+}
+.hm-lane-rail .icn {
+  margin-top: auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hm-muted-soft);
+  letter-spacing: 0 !important;
+}
+
+/* Lane head (expanded) */
+.hm-lane-head {
+  padding: 14px 16px 10px;
+  display: grid;
+  gap: 4px;
+  border-bottom: 1px solid var(--hm-line-soft);
+}
+.hm-lane-head-row {
+  display: flex; align-items: center; gap: 10px;
+}
+.hm-lane-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--hm-ink);
+}
+.hm-lane-count {
+  display: inline-grid; place-items: center;
+  min-width: 22px; height: 22px;
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 600;
+}
+.hm-lane--action .hm-lane-count {
+  background: var(--hm-amber);
+  color: #fffdf7;
+}
+.hm-lane-action {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-lane--action .hm-lane-action { color: var(--hm-amber-deep); }
+.hm-lane-collapse {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted-soft);
+  cursor: pointer;
+  padding: 4px 7px;
+  border-radius: 5px;
+}
+.hm-lane-collapse:hover { background: var(--hm-rail); color: var(--hm-ink); }
+
+.hm-lane-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  scrollbar-width: thin;
+  scrollbar-color: var(--hm-line) transparent;
+}
+.hm-lane-body::-webkit-scrollbar { width: 6px; }
+.hm-lane-body::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
+
+.hm-lane-empty {
+  margin: 18px 4px;
+  padding: 18px 14px;
+  border: 1px dashed var(--hm-line);
+  border-radius: var(--hm-radius);
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--hm-muted-soft);
+  text-align: center;
+  line-height: 1.5;
+}
+
+/* ============================================================
+   CARDS
+   ============================================================ */
+.hm-card {
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  padding: 11px 12px 12px;
+  display: grid;
+  gap: 7px;
+  cursor: pointer;
+  position: relative;
+  transition: border-color 160ms, box-shadow 160ms, transform 160ms;
+}
+.hm-card:hover {
+  border-color: var(--hm-line-strong);
+  box-shadow: var(--hm-shadow-card);
+  transform: translateY(-1px);
+}
+.hm-card.is-focused {
+  border-color: var(--hm-sage);
+  box-shadow: 0 0 0 1px var(--hm-sage), var(--hm-shadow-card);
+}
+
+/* Stale visual: desaturate, soften */
+.hm-card.is-stale {
+  background: var(--hm-paper-2);
+  color: var(--hm-muted);
+}
+.hm-card.is-stale .hm-card-title { color: var(--hm-muted); font-weight: 500; }
+.hm-card.is-stale .hm-card-meta  { opacity: 0.7; }
+.hm-card.is-stale .hm-pill       { opacity: 0.7; }
+
+/* Action-needed card */
+.hm-card--action {
+  background: var(--hm-amber-wash);
+  border-color: var(--hm-amber-ring);
+  box-shadow: var(--hm-shadow-action);
+  animation: hm-action-breathe 3.4s ease-in-out infinite;
+}
+@keyframes hm-action-breathe {
+  0%, 100% { box-shadow: 0 0 0 1px var(--hm-amber-ring), 0 12px 28px rgba(167,97,34,0.16); }
+  50%      { box-shadow: 0 0 0 1px var(--hm-amber-ring), 0 16px 38px rgba(167,97,34,0.26); }
+}
+.hm-card--action::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 12px; bottom: 12px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--hm-amber);
+}
+
+/* Card pieces */
+.hm-card-head {
+  display: flex; align-items: flex-start; gap: 8px;
+}
+.hm-card-id {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+  display: inline-flex; align-items: center; gap: 5px;
+  flex-shrink: 0;
+}
+.hm-card-id .agent-dot {
+  width: 6px; height: 6px; border-radius: 999px;
+}
+.hm-card-id .agent-dot--codex  { background: #6b8a4e; }
+.hm-card-id .agent-dot--claude { background: var(--hm-clay); }
+.hm-card-id .agent-dot--hermes { background: var(--hm-sage); }
+.hm-card-id .agent-dot--ext    { background: var(--hm-muted); }
+.hm-card-id strong {
+  font-weight: 600;
+  color: var(--hm-ink);
+  letter-spacing: 0 !important;
+}
+
+.hm-card-fresh {
+  margin-left: auto;
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+  white-space: nowrap;
+}
+.hm-card-fresh .fresh-dot {
+  width: 6px; height: 6px; border-radius: 999px; background: var(--hm-fresh);
+}
+.hm-card-fresh.is-stale .fresh-dot   { background: var(--hm-stale); }
+.hm-card-fresh.is-fresh .fresh-dot   { background: var(--hm-sage); box-shadow: 0 0 0 3px rgba(30,102,66,0.16); }
+.hm-card-fresh.is-warm .fresh-dot    { background: var(--hm-amber); }
+
+.hm-card-title {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.4;
+  color: var(--hm-ink);
+  text-wrap: pretty;
+}
+.hm-card--action .hm-card-title {
+  font-weight: 700;
+  color: var(--hm-ink);
+}
+
+.hm-card-meta {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+}
+.hm-card-meta .sep { color: var(--hm-muted-soft); }
+.hm-card-meta .repo { color: var(--hm-ink-soft); }
+
+.hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }
+.hm-pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 20px;
+  padding: 0 8px;
+  border-radius: 999px;
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase;
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+  white-space: nowrap;
+}
+.hm-pill--risk   { background: var(--hm-amber-soft); color: var(--hm-amber-deep); }
+.hm-pill--secret { background: var(--hm-rose-soft); color: var(--hm-rose); }
+.hm-pill--ok     { background: var(--hm-sage-soft); color: var(--hm-sage-deep); }
+.hm-pill--info   { background: var(--hm-blue-soft); color: var(--hm-blue); }
+.hm-pill--neutral{ background: var(--hm-rail); color: var(--hm-muted); }
+.hm-pill--draft  { background: #ece8db; color: #756d58; border: 1px dashed rgba(0,0,0,0.06); }
+.hm-pill--ghost  { background: transparent; color: var(--hm-muted-soft); border: 1px solid var(--hm-line); }
+
+.hm-pill .dot { width: 5px; height: 5px; border-radius: 999px; background: currentColor; }
+
+/* Checks bar */
+.hm-checks {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+.hm-checks-bar {
+  display: flex;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--hm-rail);
+  overflow: hidden;
+}
+.hm-checks-bar > span { display: block; height: 100%; }
+.hm-checks-bar .pass    { background: var(--hm-sage); }
+.hm-checks-bar .running { background: var(--hm-amber); }
+.hm-checks-bar .fail    { background: var(--hm-rose); }
+.hm-checks-bar .pending { background: var(--hm-rail-strong); }
+
+.hm-checks-label {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+  white-space: nowrap;
+}
+
+/* Waiting on */
+.hm-waiting {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  margin-top: 2px;
+}
+.hm-waiting .target {
+  background: var(--hm-amber-soft);
+  color: var(--hm-amber-deep);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+.hm-waiting--ok .target  { background: var(--hm-sage-soft); color: var(--hm-sage-deep); }
+.hm-waiting--info .target{ background: var(--hm-blue-soft); color: var(--hm-blue); }
+
+/* Hermes verdict */
+.hm-verdict {
+  padding: 9px 10px;
+  border-radius: var(--hm-radius-sm);
+  background: var(--hm-sage-wash);
+  border: 1px solid rgba(30,102,66,0.14);
+  font-family: var(--font-body);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--hm-ink-soft);
+}
+.hm-verdict .label {
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage-deep);
+  margin-right: 6px;
+}
+
+/* Inline button group on card */
+.hm-card-actions {
+  display: flex; gap: 6px; margin-top: 4px;
+  flex-wrap: wrap;
+}
+
+/* ============================================================
+   BUTTONS
+   ============================================================ */
+.hm-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  height: 32px;
+  padding: 0 14px;
+  border-radius: 8px;
+  font-family: var(--font-display);
+  font-size: 11.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em !important;
+  text-transform: none;
+  border: 1px solid transparent;
+  background: var(--hm-paper);
+  color: var(--hm-ink);
+  cursor: pointer;
+  transition: transform 160ms, border-color 160ms, background 160ms;
+  white-space: nowrap;
+}
+.hm-btn:hover { transform: translateY(-1px); }
+.hm-btn--primary {
+  background: var(--hm-sage);
+  color: #fffdf7;
+}
+.hm-btn--primary:hover { background: var(--hm-sage-deep); }
+.hm-btn--action {
+  background: var(--hm-amber);
+  color: #fffdf7;
+}
+.hm-btn--action:hover { background: var(--hm-amber-deep); }
+.hm-btn--ghost {
+  background: transparent;
+  border-color: var(--hm-line-strong);
+  color: var(--hm-ink);
+}
+.hm-btn--ghost:hover { background: var(--hm-paper); }
+.hm-btn--xs { height: 26px; padding: 0 10px; font-size: 10.5px; }
+.hm-btn--sm { height: 28px; padding: 0 11px; font-size: 11px; }
+
+.hm-kbd {
+  display: inline-grid; place-items: center;
+  min-width: 18px; height: 18px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: rgba(17,19,21,0.10);
+  color: currentColor;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0 !important;
+}
+.hm-btn--primary .hm-kbd,
+.hm-btn--action .hm-kbd { background: rgba(255,253,247,0.22); }
+
+/* ============================================================
+   HERMES CO-PILOT
+   ============================================================ */
+.hm-hermes {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--hm-paper-2);
+  border-left: 1px solid var(--hm-line);
+  overflow: hidden;
+}
+.hm-hermes-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px 18px 12px;
+  border-bottom: 1px solid var(--hm-line-soft);
+  background: var(--hm-paper);
+}
+.hm-hermes-mark {
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  background: var(--hm-hermes);
+  color: #fffdf7;
+  display: grid; place-items: center;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 13px;
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,0.18);
+}
+.hm-hermes-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 14px;
+  color: var(--hm-ink);
+  line-height: 1.1;
+}
+.hm-hermes-sub {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+  letter-spacing: 0 !important;
+  margin-top: 1px;
+}
+.hm-hermes-sub .pulse {
+  display: inline-block;
+  width: 6px; height: 6px;
+  border-radius: 999px;
+  background: var(--hm-hermes);
+  margin-right: 5px;
+  vertical-align: 0;
+  animation: hm-pulse 2s infinite;
+}
+.hm-hermes-tools {
+  margin-left: auto;
+  display: flex; gap: 6px;
+}
+.hm-hermes-tool {
+  width: 28px; height: 28px;
+  display: grid; place-items: center;
+  border-radius: 6px;
+  background: transparent;
+  border: 1px solid var(--hm-line);
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+}
+.hm-hermes-tool:hover { color: var(--hm-ink); background: var(--hm-rail); }
+
+.hm-hermes-stream {
+  flex: 1;
+  overflow-y: auto;
+  padding: 14px 16px 8px;
+  display: flex; flex-direction: column; gap: 10px;
+  scrollbar-width: thin;
+}
+.hm-hermes-stream::-webkit-scrollbar { width: 6px; }
+.hm-hermes-stream::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
+
+/* Hermes turn (card-stream) */
+.hm-turn {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+.hm-turn-head {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.1em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-turn-actor {
+  display: inline-flex; align-items: center; gap: 5px;
+  color: var(--hm-ink);
+}
+.hm-turn-actor .actor-dot { width: 7px; height: 7px; border-radius: 999px; }
+.hm-turn--hermes  .actor-dot { background: var(--hm-hermes); }
+.hm-turn--operator .actor-dot { background: var(--hm-ink); }
+.hm-turn--codex   .actor-dot { background: var(--hm-clay); }
+.hm-turn-time {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: 0 !important;
+  color: var(--hm-muted-soft);
+}
+
+.hm-turn-body { color: var(--hm-ink-soft); }
+.hm-turn-body b { color: var(--hm-ink); font-weight: 600; }
+.hm-turn-body code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 1px 5px;
+  background: var(--hm-rail);
+  border-radius: 4px;
+  color: var(--hm-ink);
+}
+
+/* Pinned context card inside a Hermes turn */
+.hm-turn-pin {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 9px;
+  padding: 8px 10px;
+  border-radius: var(--hm-radius-sm);
+  background: var(--hm-paper-3);
+  border: 1px solid var(--hm-line-soft);
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--hm-ink-soft);
+  text-decoration: none;
+}
+.hm-turn-pin:hover { border-color: var(--hm-line-strong); }
+.hm-turn-pin .pin-id {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-turn-pin .pin-title {
+  font-weight: 600;
+  color: var(--hm-ink);
+  font-size: 12px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.hm-turn-pin .pin-arrow {
+  color: var(--hm-muted-soft);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.hm-turn-actions {
+  display: flex; gap: 6px;
+}
+.hm-turn-suggest {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 9px;
+  border-radius: 999px;
+  background: var(--hm-sage-wash);
+  color: var(--hm-sage-deep);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em !important;
+  cursor: pointer;
+  border: 1px solid rgba(30,102,66,0.14);
+}
+.hm-turn-suggest:hover { background: var(--hm-sage-soft); }
+
+/* Compose */
+.hm-compose {
+  padding: 10px 14px 14px;
+  background: var(--hm-paper);
+  border-top: 1px solid var(--hm-line-soft);
+  display: grid; gap: 8px;
+}
+.hm-compose-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: end;
+}
+.hm-compose-input {
+  border: 1px solid var(--hm-line);
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: var(--hm-paper-2);
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--hm-ink);
+  min-height: 56px;
+  resize: none;
+  outline: none;
+  line-height: 1.45;
+}
+.hm-compose-input:focus { border-color: var(--hm-sage); background: var(--hm-paper); }
+.hm-compose-input::placeholder { color: var(--hm-muted-soft); }
+.hm-compose-toolbar {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-compose-send {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 0 14px;
+  height: 56px;
+  border-radius: 10px;
+  background: var(--hm-sage);
+  color: #fffdf7;
+  border: 0;
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.hm-compose-send:hover { background: var(--hm-sage-deep); }
+.hm-compose-chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--hm-line);
+  color: var(--hm-muted);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em !important;
+  text-transform: uppercase;
+  cursor: pointer;
+  background: var(--hm-paper-2);
+}
+.hm-compose-chip.is-on { background: var(--hm-ink); color: #fffdf7; border-color: var(--hm-ink); }
+
+/* ============================================================
+   DETAIL DRAWER (over board)
+   ============================================================ */
+.hm-drawer-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(17,19,21,0.30);
+  backdrop-filter: blur(2px);
+  display: grid;
+  place-items: stretch;
+  z-index: 50;
+  padding: 16px 0 16px 16px;
+}
+.hm-drawer {
+  margin-left: auto;
+  width: 720px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-left: 4px solid var(--hm-amber);
+  border-radius: 14px 0 0 14px;
+  box-shadow: var(--hm-shadow-pop);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.hm-drawer-head {
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid var(--hm-line-soft);
+  display: grid; gap: 8px;
+}
+.hm-drawer-eyebrow {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase;
+  color: var(--hm-amber-deep);
+}
+.hm-drawer-eyebrow .close {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+  letter-spacing: 0 !important;
+  font-weight: 500;
+  text-transform: none;
+}
+.hm-drawer-eyebrow .close:hover { background: var(--hm-rail); color: var(--hm-ink); }
+.hm-drawer-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.3;
+  color: var(--hm-ink);
+  margin: 0;
+  text-wrap: pretty;
+}
+.hm-drawer-meta {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-drawer-meta a {
+  color: var(--hm-sage-deep);
+  text-decoration: underline;
+  text-decoration-color: rgba(30,102,66,0.3);
+}
+.hm-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 20px 18px;
+  display: grid;
+  gap: 16px;
+  scrollbar-width: thin;
+}
+
+.hm-section-h {
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.hm-section-h::before {
+  content: ""; width: 6px; height: 6px; border-radius: 999px; background: var(--hm-sage);
+}
+
+.hm-verdict-block {
+  padding: 14px 16px;
+  border-radius: var(--hm-radius);
+  background: var(--hm-sage-wash);
+  border: 1px solid rgba(30,102,66,0.18);
+  display: grid; gap: 8px;
+}
+.hm-verdict-block .head {
+  display: flex; align-items: center; gap: 10px;
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage-deep);
+}
+.hm-verdict-block .body {
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--hm-ink-soft);
+}
+.hm-verdict-block .body b { color: var(--hm-ink); font-weight: 600; }
+
+.hm-checklist {
+  display: grid; gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper-2);
+}
+.hm-checklist .row {
+  display: grid; grid-template-columns: 22px 1fr auto; gap: 10px;
+  align-items: start;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--hm-ink-soft);
+  padding: 4px 0;
+}
+.hm-checklist .row .box {
+  width: 16px; height: 16px;
+  border-radius: 4px;
+  background: var(--hm-paper);
+  border: 1.5px solid var(--hm-line-strong);
+  margin-top: 2px;
+  display: grid; place-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 800;
+  color: transparent;
+}
+.hm-checklist .row.done .box  { background: var(--hm-sage); border-color: var(--hm-sage); color: #fffdf7; }
+.hm-checklist .row.done span  { color: var(--hm-muted); text-decoration: line-through; }
+.hm-checklist .row .hint      { font-family: var(--font-mono); font-size: 10.5px; color: var(--hm-muted-soft); }
+
+.hm-files {
+  display: grid; gap: 0;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  overflow: hidden;
+  background: var(--hm-paper);
+}
+.hm-files .row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-ink-soft);
+  border-bottom: 1px solid var(--hm-line-soft);
+}
+.hm-files .row:last-child { border-bottom: 0; }
+.hm-files .row .path { color: var(--hm-ink); }
+.hm-files .row .diff { color: var(--hm-muted); font-family: var(--font-mono); font-size: 10.5px; }
+.hm-files .row .diff .add { color: var(--hm-sage-deep); }
+.hm-files .row .diff .rm  { color: var(--hm-rose); }
+
+.hm-drawer-foot {
+  padding: 14px 20px;
+  border-top: 1px solid var(--hm-line);
+  background: var(--hm-paper-2);
+  display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+}
+.hm-drawer-foot .spacer { flex: 1; }
+
+/* Inline buttons in lane (subtle, action-needed only) */
+.hm-card-cta {
+  display: flex; gap: 6px; margin-top: 2px;
+}
+
+/* ============================================================
+   KEYBOARD SHORTCUTS OVERLAY
+   ============================================================ */
+.hm-keys {
+  position: absolute;
+  right: 22px; bottom: 18px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: 10px;
+  box-shadow: var(--hm-shadow-card);
+  padding: 14px 16px;
+  display: grid; gap: 7px;
+  max-width: 280px;
+  z-index: 40;
+}
+.hm-keys .title {
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  margin-bottom: 4px;
+}
+.hm-keys .row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  align-items: center;
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--hm-ink-soft);
+}
+.hm-keys .row .key {
+  display: inline-flex; gap: 3px;
+}
+
+/* Persistent Ask Hermes floating composer (for board with no Hermes column) */
+.hm-ask-float {
+  position: absolute;
+  right: 22px; bottom: 22px;
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px 10px 12px;
+  border-radius: 999px;
+  background: var(--hm-ink);
+  color: #fffdf7;
+  box-shadow: var(--hm-shadow-pop);
+  cursor: pointer;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 12.5px;
+}
+.hm-ask-float .mark {
+  width: 22px; height: 22px;
+  border-radius: 6px;
+  background: var(--hm-sage);
+  color: #fffdf7;
+  display: grid; place-items: center;
+  font-size: 11px; font-weight: 800;
+}
+
+/* ============================================================
+   TIMELINE STRIP (deploy timeline / activity)
+   ============================================================ */
+.hm-strip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 10px 22px;
+  background: var(--hm-paper-2);
+  border-bottom: 1px solid var(--hm-line-soft);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-strip-label {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-strip-track {
+  display: flex; gap: 4px; align-items: center;
+}
+.hm-strip-track .tick {
+  width: 22px; height: 16px;
+  border-radius: 3px;
+  background: var(--hm-sage);
+}
+.hm-strip-track .tick.warn { background: var(--hm-amber); }
+.hm-strip-track .tick.fail { background: var(--hm-rose); }
+.hm-strip-track .tick.queue{ background: var(--hm-rail-strong); }
+.hm-strip-track .tick.now  {
+  background: var(--hm-amber);
+  box-shadow: 0 0 0 2px var(--hm-amber-wash);
+  position: relative;
+}
+
+/* ============================================================
+   Section / divider helpers
+   ============================================================ */
+.hm-divider-h {
+  height: 1px; background: var(--hm-line); margin: 14px 0;
+}
+
+/* ============================================================
+   Direction B — Spotlight + rail (alt layout)
+   ============================================================ */
+.hm-boardB { grid-template-rows: auto 1fr; }
+.hm-boardB .hm-bodyB {
+  display: grid;
+  grid-template-columns: 100px 1fr 380px;
+  min-height: 0;
+}
+.hm-railB {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 8px;
+  background: var(--hm-paper-2);
+  border-right: 1px solid var(--hm-line);
+}
+.hm-railB-item {
+  display: grid; grid-template-rows: auto auto auto;
+  gap: 4px;
+  padding: 10px 8px 12px;
+  border-radius: 8px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line-soft);
+  text-align: center;
+  cursor: pointer;
+  transition: background 160ms, border-color 160ms;
+}
+.hm-railB-item:hover { background: var(--hm-rail); }
+.hm-railB-item.is-active {
+  background: var(--hm-ink);
+  border-color: var(--hm-ink);
+}
+.hm-railB-item.is-active .ct,
+.hm-railB-item.is-active .lb,
+.hm-railB-item.is-active .ow { color: #fffdf7; }
+.hm-railB-item.is-action {
+  background: var(--hm-amber-wash);
+  border-color: var(--hm-amber-ring);
+}
+.hm-railB-item .ct {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--hm-ink);
+  line-height: 1;
+}
+.hm-railB-item .lb {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.10em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  line-height: 1.15;
+}
+.hm-railB-item .ow {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--hm-muted-soft);
+  letter-spacing: 0 !important;
+}
+
+.hm-spotlight {
+  padding: 18px 24px;
+  overflow-y: auto;
+  display: grid; gap: 14px;
+}
+.hm-spotlight-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 12px;
+}
+.hm-spotlight-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 26px;
+  color: var(--hm-ink);
+  letter-spacing: -0.005em !important;
+}
+.hm-spotlight-sub {
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--hm-muted);
+  line-height: 1.55;
+  max-width: 80ch;
+}
+
+.hm-spotlight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+  gap: 12px;
+}
+.hm-spotlight-grid .hm-card { min-height: 0; }
+
+/* Card relationship arrow */
+.hm-rel {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted-soft);
+}
+.hm-rel .arrow { color: var(--hm-muted); }
+
+/* ============================================================
+   Generic utilities
+   ============================================================ */
+.hm-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.hm-col { display: grid; gap: 6px; }
+.hm-spacer { flex: 1; }
+.hm-mono { font-family: var(--font-mono); }
+.hm-muted { color: var(--hm-muted); }
+.hm-ink   { color: var(--hm-ink); }
+
+/* ============================================================
+   PILLS — additional states
+   ============================================================ */
+.hm-pill--err {
+  background: var(--hm-rose-soft);
+  color: var(--hm-rose);
+  border: 1px solid rgba(162,58,58,0.18);
+}
+.hm-pill--offline {
+  background: var(--hm-offline-soft);
+  color: var(--hm-offline);
+  border: 1px dashed rgba(0,0,0,0.18);
+}
+.hm-pill--running {
+  background: var(--hm-amber-soft);
+  color: var(--hm-amber-deep);
+}
+.hm-pill--running .dot {
+  background: var(--hm-amber);
+  animation: hm-pulse 1.3s infinite;
+}
+.hm-pill--hermes {
+  background: var(--hm-hermes-soft);
+  color: var(--hm-hermes-deep);
+}
+
+/* ============================================================
+   CARD — additional states
+   ============================================================ */
+/* Failed-fetch: GitHub/source returned an error trying to read this card. */
+.hm-card--err {
+  background: #fbf0ee;
+  border-color: rgba(162,58,58,0.32);
+}
+.hm-card--err::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 12px; bottom: 12px;
+  width: 3px;
+  border-radius: 0 3px 3px 0;
+  background: var(--hm-rose);
+}
+.hm-card--err .hm-card-title { color: var(--hm-rose); }
+
+/* Source-offline: upstream unreachable. Neutral grey, dashed border. */
+.hm-card--offline {
+  background: var(--hm-paper-2);
+  border: 1px dashed var(--hm-offline);
+  color: var(--hm-muted);
+}
+.hm-card--offline .hm-card-title { color: var(--hm-muted); }
+
+/* Running: CI in flight on this card. */
+.hm-card--running {
+  border-color: rgba(167,97,34,0.32);
+  background: linear-gradient(180deg, var(--hm-paper) 0%, #fcf7ec 100%);
+}
+
+/* ============================================================
+   DEGRADED MODE HEADER
+   Replaces .hm-top when the monitor's live stream disconnects.
+   ============================================================ */
+.hm-top--degraded {
+  background: repeating-linear-gradient(
+    135deg,
+    #fbf0ee 0,
+    #fbf0ee 12px,
+    #fae5e2 12px,
+    #fae5e2 24px
+  );
+  border-bottom: 1px solid rgba(162,58,58,0.32);
+}
+.hm-top--degraded .hm-brand-name { color: var(--hm-rose); }
+.hm-degraded-banner {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 22px;
+  background: var(--hm-rose);
+  color: #fff5f3;
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.06em !important;
+}
+.hm-degraded-banner .pill {
+  background: rgba(255,253,247,0.18);
+  color: #fffdf7;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase;
+}
+.hm-degraded-banner .reasons {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0 !important;
+  font-weight: 500;
+  opacity: 0.92;
+}
+.hm-degraded-banner .reasons code {
+  background: rgba(255,253,247,0.18);
+  color: #fffdf7;
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.hm-degraded-banner .right {
+  margin-left: auto;
+  display: flex; gap: 8px;
+}
+.hm-degraded-banner button {
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,253,247,0.30);
+  background: rgba(255,253,247,0.12);
+  color: #fffdf7;
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em !important;
+  cursor: pointer;
+}
+
+/* ============================================================
+   MISSION DRAWER — different layout than PR drawer
+   ============================================================ */
+.hm-mission-confidence {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 10px;
+  padding: 12px;
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper-2);
+  border: 1px solid var(--hm-line);
+}
+.hm-mission-confidence .col {
+  display: grid; gap: 2px;
+  padding: 4px 6px;
+  border-right: 1px solid var(--hm-line-soft);
+}
+.hm-mission-confidence .col:last-child { border-right: 0; }
+.hm-mission-confidence .lbl {
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-mission-confidence .val {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--hm-ink);
+  line-height: 1.08;
+}
+.hm-mission-confidence .val.warn { color: var(--hm-amber-deep); }
+.hm-mission-confidence .meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+
+/* Mission path (numbered steps with status) */
+.hm-mpath {
+  display: grid; gap: 4px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  overflow: hidden;
+  background: var(--hm-paper);
+}
+.hm-mpath .step {
+  display: grid;
+  grid-template-columns: 28px 1fr auto auto;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--hm-line-soft);
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  color: var(--hm-ink-soft);
+}
+.hm-mpath .step:last-child { border-bottom: 0; }
+.hm-mpath .step .n {
+  width: 22px; height: 22px;
+  border-radius: 999px;
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 700;
+  display: grid; place-items: center;
+}
+.hm-mpath .step.ok    .n { background: var(--hm-sage); color: #fffdf7; }
+.hm-mpath .step.warn  .n { background: var(--hm-amber); color: #fffdf7; }
+.hm-mpath .step.fail  .n { background: var(--hm-rose); color: #fffdf7; }
+.hm-mpath .step .desc strong { color: var(--hm-ink); font-weight: 600; }
+.hm-mpath .step .lat   { font-family: var(--font-mono); font-size: 10.5px; color: var(--hm-muted); }
+
+/* Mission report block — blockers / confusing moments */
+.hm-mblock {
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+  padding: 12px 14px;
+  display: grid; gap: 6px;
+}
+.hm-mblock .head {
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.1em !important;
+  text-transform: uppercase;
+  color: var(--hm-amber-deep);
+}
+.hm-mblock .body {
+  font-family: var(--font-body);
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--hm-ink-soft);
+}
+.hm-mblock .body code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 1px 5px;
+  background: var(--hm-rail);
+  border-radius: 4px;
+}
+
+/* Evidence list */
+.hm-evidence {
+  display: grid; gap: 0;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  overflow: hidden;
+}
+.hm-evidence .row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-ink-soft);
+  border-bottom: 1px solid var(--hm-line-soft);
+  background: var(--hm-paper);
+}
+.hm-evidence .row:last-child { border-bottom: 0; }
+.hm-evidence .kind {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  background: var(--hm-rail);
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+.hm-evidence .row a { color: var(--hm-hermes-deep); border-bottom: 1px dotted var(--hm-line-strong); }
+
+/* Spec note (collapsible, monospace, sits at the foot of the mission drawer) */
+.hm-spec {
+  margin-top: 4px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper-2);
+}
+.hm-spec summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 10px 14px;
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  display: flex; align-items: center; gap: 8px;
+}
+.hm-spec summary::before {
+  content: "▸";
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--hm-muted-soft);
+}
+.hm-spec[open] summary::before { content: "▾"; }
+.hm-spec .body {
+  padding: 0 14px 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.65;
+  color: var(--hm-ink-soft);
+}
+.hm-spec .body code {
+  background: var(--hm-rail);
+  padding: 1px 5px;
+  border-radius: 4px;
+  color: var(--hm-ink);
+}
+.hm-spec .body .endpoint {
+  display: inline-block;
+  padding: 2px 7px;
+  margin: 2px 4px 2px 0;
+  border-radius: 4px;
+  background: #131715;
+  color: #d8e8df;
+  font-size: 11px;
+}
+
+/* ============================================================
+   STATES SHEET — documentation artboard
+   ============================================================ */
+.hm-sheet {
+  width: 100%; height: 100%;
+  background: var(--hm-paper-3);
+  color: var(--hm-ink);
+  font-family: var(--font-body);
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  overflow: hidden;
+}
+.hm-sheet-head {
+  padding: 24px 32px 16px;
+  background: var(--hm-paper);
+  border-bottom: 1px solid var(--hm-line);
+  display: grid; gap: 8px;
+}
+.hm-sheet-eyebrow {
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase;
+  color: var(--hm-hermes-deep);
+}
+.hm-sheet-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 28px;
+  color: var(--hm-ink);
+  line-height: 1.1;
+  margin: 0;
+}
+.hm-sheet-lede {
+  font-family: var(--font-body);
+  font-size: 14px;
+  color: var(--hm-muted);
+  max-width: 92ch;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.hm-sheet-body {
+  overflow-y: auto;
+  padding: 18px 32px 32px;
+  display: grid; gap: 24px;
+}
+
+.hm-grid {
+  display: grid;
+  grid-template-columns: 200px repeat(5, minmax(0, 1fr));
+  gap: 0;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  overflow: hidden;
+  background: var(--hm-paper-2);
+}
+.hm-grid .hdr {
+  padding: 12px 14px;
+  background: var(--hm-paper);
+  border-bottom: 1px solid var(--hm-line);
+  border-right: 1px solid var(--hm-line-soft);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  display: grid; gap: 2px;
+}
+.hm-grid .hdr:last-child { border-right: 0; }
+.hm-grid .hdr .sub {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted-soft);
+  letter-spacing: 0 !important;
+  font-weight: 500;
+  text-transform: none;
+}
+.hm-grid .typehdr {
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 14px 16px;
+  background: var(--hm-paper);
+  border-right: 1px solid var(--hm-line);
+  border-bottom: 1px solid var(--hm-line-soft);
+}
+.hm-grid .typehdr .name {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--hm-ink);
+}
+.hm-grid .typehdr .who {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-grid .cell {
+  padding: 12px;
+  border-right: 1px solid var(--hm-line-soft);
+  border-bottom: 1px solid var(--hm-line-soft);
+  min-height: 0;
+}
+.hm-grid .cell:last-child { border-right: 0; }
+.hm-grid > div:nth-last-child(-n+6) { border-bottom: 0; }
+.hm-grid .cell .hm-card { margin: 0; }
+.hm-grid .cell .hm-card .hm-card-title { font-size: 12.5px; }
+
+/* Variant: tighten internal card spacing in the grid */
+.hm-grid .hm-card { padding: 10px; gap: 6px; }
+.hm-grid .hm-card .hm-card-meta { font-size: 10.5px; }
+.hm-grid .hm-card .hm-pill { font-size: 9px; height: 18px; padding: 0 7px; }
+.hm-grid .hm-card .hm-card-fresh { font-size: 9.5px; }
+
+/* ============================================================
+   A11Y NOTES — receipts for the contrast audit
+   ============================================================ */
+.hm-a11y {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+.hm-a11y-pair {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 14px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+}
+.hm-a11y-pair .chip {
+  width: 56px; height: 40px;
+  border-radius: 6px;
+  display: grid; place-items: center;
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 700;
+}
+.hm-a11y-pair .name {
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  font-weight: 700;
+  color: var(--hm-ink);
+}
+.hm-a11y-pair .meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-a11y-pair .score {
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--hm-ink);
+}
+.hm-a11y-pair .verdict {
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  padding: 3px 8px;
+  border-radius: 4px;
+  display: inline-block;
+  margin-top: 2px;
+}
+.hm-a11y-pair .verdict.aaa { background: var(--hm-sage-soft); color: var(--hm-sage-deep); }
+.hm-a11y-pair .verdict.aa  { background: var(--hm-sage-wash); color: var(--hm-sage-deep); }
+.hm-a11y-pair .verdict.fail{ background: var(--hm-rose-soft); color: var(--hm-rose); }
+
+.hm-notes-block {
+  padding: 14px 16px;
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--hm-ink-soft);
+  display: grid; gap: 8px;
+}
+.hm-notes-block .h {
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.14em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-notes-block b { color: var(--hm-ink); font-weight: 600; }
+.hm-notes-block code {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  padding: 1px 5px;
+  background: var(--hm-rail);
+  border-radius: 4px;
+}

--- a/packages/monitor-ui/tsconfig.json
+++ b/packages/monitor-ui/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "composite": true
+    "composite": true,
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/main.tsx"]
 }

--- a/packages/monitor-ui/vite.config.ts
+++ b/packages/monitor-ui/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// Hermes Handoff Monitor — Vite build.
+//
+// The SPA is bundled to `dist/` and served by `services/slack-operator`
+// from the same HTTP server that serves the legacy HTML monitor (M5'+).
+// `base: "./"` keeps asset URLs relative so the bundle works whether it
+// is mounted at `/` or `/monitor`.
+export default defineConfig({
+  plugins: [react()],
+  base: "./",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5174,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,14 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts", "packages/**/*.test.ts", "services/**/*.test.ts"],
+    include: [
+      "test/**/*.test.ts",
+      "packages/**/*.test.ts",
+      "packages/**/*.test.tsx",
+      "services/**/*.test.ts"
+    ],
+    // Default to node; component tests opt into jsdom via a
+    // `// @vitest-environment jsdom` docblock at the top of the file.
     environment: "node"
   }
 });


### PR DESCRIPTION
## Summary
- **M3'** of the Hermes Handoff Monitor redesign: introduces the **Vite 5 + React 18** layer on top of the M2' pure-logic core and renders the Direction A **calm / empty board (artboard A5)** end-to-end against fixtures.
- Lands the six layout components from the spec — `TopStrip`, `BoardNowBanner`, `LanesBar`, `Board`, `Lane`, `MiniRail` — plus the composed `MonitorPage`.
- Stays a completely separate deployment from the operator app: this is the `@avg/monitor-ui` package in `depre-dev/averray-reference-agent`, served by `slack-operator` (M5'+).

## Toolchain
- Vite 5 + `@vitejs/plugin-react`; jsdom + Testing Library for component tests.
- `tsconfig` gains `jsx: react-jsx` + `.tsx` includes. `main.tsx` (the only file importing CSS) is excluded from the composite `tsc -b` graph, so Docker/CI's `npm run build` never trips NodeNext resolution on the CSS side-effect import. Vite and `tsc -b` both target `dist/` (gitignored) but never run in the same CI job.
- Root `vitest.config` now includes `.tsx`; component suites opt into jsdom via a per-file `// @vitest-environment jsdom` docblock (the 153 node-env logic tests are untouched).

## UI
- `src/styles/monitor.css` ships the design bundle's `hermes.css` **verbatim** (1999 lines; self-contained `--hm-*` tokens, no `--avy-` refs).
- A collapsed lane *is* a mini-rail (`MiniRail`); `Lane` delegates to it. `MonitorPage` composes the calm A5 state: live lanes collapse to rails, **Done** stays expanded, and KPI pills + banner prose derive from `deriveBoardState()` over the done-history fixtures.
- A minimal Hermes-rail chrome stub holds the `1fr | 420px` grid (the working co-pilot rail is M8'). Its inner header is a `<div>`, not `<header>`, so only `TopStrip` is the page `banner` landmark.

## Deferred (per the milestone plan)
- Card bodies inside lanes → **M4'** (the `<Card>` vocabulary)
- Live SSE data + real refresh → **M5'**
- The working Hermes co-pilot rail → **M8'**

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **193/193** (153 logic + 40 new component cases)
- [x] `npm test` (full repo) → **515/515**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/` (41 modules, CSS + JS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)