### PR TITLE
monitor-ui: card vocabulary (M4')

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -5,7 +5,7 @@ import { MonitorPage } from "./MonitorPage.js";
 
 afterEach(cleanup);
 
-describe("MonitorPage — calm / A5 state", () => {
+describe("MonitorPage — rich-mix / A1 state", () => {
   test("renders the full board chrome end-to-end", () => {
     const { container } = render(<MonitorPage />);
     const view = within(container);
@@ -14,9 +14,9 @@ describe("MonitorPage — calm / A5 state", () => {
     expect(view.getByRole("banner")).toBeTruthy();
     expect(view.getByText("Hermes")).toBeTruthy();
 
-    // Board Now banner — calm tone
-    expect(container.querySelector(".hm-now--calm")).toBeTruthy();
-    expect(view.getByText(/Nothing waits on you/)).toBeTruthy();
+    // Board Now banner — action tone (the fixtures include action cards)
+    expect(container.querySelector(".hm-now--action")).toBeTruthy();
+    expect(view.getByText(/your review decision/)).toBeTruthy();
 
     // Lanes bar
     expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
@@ -29,24 +29,37 @@ describe("MonitorPage — calm / A5 state", () => {
     expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
 
-  test("only the Done lane is expanded; the seven live lanes are mini-rails", () => {
+  test("the rich-mix preset expands five lanes; the other three are mini-rails", () => {
     const { container } = render(<MonitorPage />);
-    expect(within(container).getByRole("region", { name: "Done lane" })).toBeTruthy();
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(7);
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(5);
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(3);
   });
 
-  test("KPI pills read zero for every live lane in the calm state", () => {
+  test("renders the action card with its CTA and Hermes verdict", () => {
     const { container } = render(<MonitorPage />);
-    // "Operator review" is both a KPI label and a lane name, so scope the
-    // assertion to the banner (TopStrip) KPI region.
-    const banner = within(container).getByRole("banner");
-    expect(within(banner).getByText("Action needed")).toBeTruthy();
-    expect(within(banner).getByText("Operator review")).toBeTruthy();
+    const view = within(container);
+    // PR #548 is an isAction card, so laneFor() promotes it into the
+    // (expanded) needs-attention lane.
+    expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+    expect(view.getByText("Approve & merge")).toBeTruthy();
+    expect(view.getByText("Hermes verdict")).toBeTruthy();
   });
 
-  test("the Done lane reflects the release-history fixture count", () => {
+  test("renders a spread of card types (mission, deploy, done)", () => {
     const { container } = render(<MonitorPage />);
-    // 11 done-history fixtures → the calm banner reports them shipped.
-    expect(within(container).getByText(/11 card\(s\) shipped today/)).toBeTruthy();
+    const view = within(container);
+    // Mission card (hermes-checking lane, expanded)
+    expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
+    // Deploy card (deploying lane, expanded)
+    expect(view.getByText(/Post-merge verify/)).toBeTruthy();
+    // Done history cards render with CLOSED freshness pips
+    expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
+  });
+
+  test("collapsed lanes hide their card bodies (drafts is a mini-rail)", () => {
+    const { container } = render(<MonitorPage />);
+    // The draft PR #550 lives in the collapsed drafts lane, so its title
+    // is not in the DOM until the lane is expanded.
+    expect(within(container).queryByText(/governance dispute UI/)).toBeNull();
   });
 });

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -1,22 +1,22 @@
-// Hermes Handoff Monitor — board page (M3')
+// Hermes Handoff Monitor — board page (M4')
 //
 // Composes the Direction A layout against fixtures and renders the
-// calm / "you're done for now" state (artboard A5): every live lane
-// collapses to a mini-rail, only Done stays expanded, and the BoardNow
-// banner reads the calm prose.
+// rich-mix board (artboard A1): every card type and state is on screen,
+// dispatched through <CardRouter> so degraded cards never masquerade as
+// fresh ones.
 //
 //   <div.hm-board>
 //     <TopStrip />               KPI pills + LIVE indicator + refresh
-//     <BoardNowBanner />         sage calm hero sentence
+//     <BoardNowBanner />         hero sentence (tone follows board mode)
 //     <div.hm-main>              grid: lanes-wrap | hermes rail (420px)
 //       <div.hm-lanes-wrap>
 //         <LanesBar />           search + filter chips + urgency label
-//         <Board />              the eight lanes (mini-rails + Done)
+//         <Board renderCard />   the eight lanes, cards via <CardRouter>
 //       <aside.hm-hermes>        co-pilot rail chrome (full rail = M8')
 //
 // What's deferred, by milestone:
-//   - card bodies inside lanes → M4' (the <Card> vocabulary)
 //   - live SSE data + real refresh → M5'
+//   - the detail drawer (card click) → M6'
 //   - the working Hermes co-pilot rail → M8'
 //
 // Auth is handled at the edge (Cloudflare Access), so there is no
@@ -29,14 +29,29 @@ import type { BoardCard } from "./lib/monitor/card-types.js";
 import { TopStrip } from "./components/TopStrip.js";
 import { BoardNowBanner } from "./components/BoardNowBanner.js";
 import { LanesBar } from "./components/LanesBar.js";
-import { Board, CALM_EXPANDED } from "./components/Board.js";
+import { Board } from "./components/Board.js";
+import type { LaneId } from "./components/Lane.js";
+import { CardRouter } from "./components/cards/CardRouter.js";
+
+// Expansion preset for the rich-mix demo. Note `laneFor()` promotes
+// every `isAction` card into needs-attention, so that lane (not
+// operator-review) holds the action cards — expand it so the action
+// treatment (verdict + CTA) is on screen. M5' will derive the preset
+// from live board mode.
+const RICH_MIX_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
+  "needs-attention",
+  "hermes-checking",
+  "release-queue",
+  "deploying",
+  "done",
+]);
 
 export function MonitorPage() {
-  // Calm / A5 state: only the day's release history exists — every live
-  // lane is empty. Reading against fixtures (rather than an empty list)
-  // proves the data pipeline end-to-end: counts, banner prose, and lane
-  // grouping all derive from real card shapes.
-  const cards: BoardCard[] = useMemo(() => FIXTURE_CARDS.filter((c) => c.lane === "done"), []);
+  // Rich-mix / A1 state: the full fixture board (PR, mission, task,
+  // deploy, draft, done) so every card type and state is exercised.
+  // M5' swaps fixtures for the live SSE feed and drives the expansion
+  // preset off board mode.
+  const cards: BoardCard[] = useMemo(() => FIXTURE_CARDS, []);
   const nowLabel = useMemo(() => buildNowLabel(), []);
 
   const state = useMemo(
@@ -53,7 +68,11 @@ export function MonitorPage() {
       <div className="hm-main">
         <div className="hm-lanes-wrap">
           <LanesBar counts={state.counts} mode={state.mode} />
-          <Board grouped={state.grouped} initialExpanded={CALM_EXPANDED} />
+          <Board
+            grouped={state.grouped}
+            initialExpanded={RICH_MIX_EXPANDED}
+            renderCard={(card) => <CardRouter key={card.id} card={card} />}
+          />
         </div>
 
         <HermesRailPlaceholder />

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { Card } from "./Card.js";
+import { FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
+import type { BoardCard, PRCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function fixture(id: string): BoardCard {
+  const card = FIXTURE_CARDS.find((c) => c.id === id);
+  if (!card) throw new Error(`fixture not found: ${id}`);
+  return card;
+}
+
+describe("Card — type coverage", () => {
+  test("PR action card: title, FRESH pip, risk pills, checks, verdict, CTA", () => {
+    const { container } = render(<Card card={fixture("agent #548")} />);
+    const view = within(container);
+    expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+    expect(container.querySelector(".hm-card--action")).toBeTruthy();
+    expect(view.getByText(/FRESH/)).toBeTruthy();
+    // risk pills
+    expect(view.getByText("workflow")).toBeTruthy();
+    expect(view.getByText("review-gated")).toBeTruthy();
+    // checks bar + label
+    expect(container.querySelector(".hm-checks-bar")).toBeTruthy();
+    // Hermes verdict + CTA
+    expect(view.getByText("Hermes verdict")).toBeTruthy();
+    expect(view.getByText("Approve & merge")).toBeTruthy();
+    expect(view.getByText("Send back to Codex")).toBeTruthy();
+  });
+
+  test("mission card renders its summary and checks bar", () => {
+    const { container } = render(<Card card={fixture("mission browser-onboard-04")} />);
+    const view = within(container);
+    expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
+    expect(view.getByText("testbed")).toBeTruthy();
+    expect(container.querySelector(".hm-checks-bar")).toBeTruthy();
+  });
+
+  test("deploy card renders its verification summary", () => {
+    const { container } = render(<Card card={fixture("deploy #246")} />);
+    const view = within(container);
+    expect(view.getByText(/Post-merge verify/)).toBeTruthy();
+    expect(view.getByText("xcm")).toBeTruthy();
+  });
+
+  test("codex task card renders without checks (no CI yet)", () => {
+    const { container } = render(<Card card={fixture("task starter-coding-014")} />);
+    const view = within(container);
+    expect(view.getByText("Reduce audit-log noise when policy auto-applies")).toBeTruthy();
+    expect(container.querySelector(".hm-checks-bar")).toBeNull();
+  });
+
+  test("draft PR shows the draft pill", () => {
+    const { container } = render(<Card card={fixture("agent #550")} />);
+    expect(within(container).getByText("draft")).toBeTruthy();
+  });
+
+  test("done/closed card: CLOSED pip, no risk pills, no checks bar", () => {
+    const done = FIXTURE_CARDS.find((c) => c.type === "done");
+    if (!done) throw new Error("no done fixture");
+    const { container } = render(<Card card={done} />);
+    expect(within(container).getByText("CLOSED")).toBeTruthy();
+    expect(container.querySelector(".hm-pillrow")).toBeNull();
+    expect(container.querySelector(".hm-checks-bar")).toBeNull();
+  });
+});
+
+describe("Card — state coverage", () => {
+  test("stale card wears is-stale, a STALE pip, and the archive hint", () => {
+    const { container } = render(<Card card={fixture("agent #542")} />);
+    const view = within(container);
+    expect(container.querySelector(".hm-card.is-stale")).toBeTruthy();
+    expect(view.getByText(/STALE/)).toBeTruthy();
+    expect(view.getByText(/archive in 4h\?/)).toBeTruthy();
+  });
+
+  test("running state renders a fresh-styled, non-stale card", () => {
+    const running: PRCard = {
+      id: "agent #560",
+      lane: "hermes-checking",
+      type: "pr",
+      agentType: "claude",
+      title: "Running CI card",
+      summary: "checks in flight",
+      repo: "depre-dev/agent",
+      freshness: 3,
+      state: "running",
+      risk: [],
+      checks: { pass: 2, running: 4, fail: 0, pending: 0, total: 6 },
+      waitingOn: { actor: "CI", tone: "info" },
+      files: [],
+    };
+    const { container } = render(<Card card={running} />);
+    expect(container.querySelector(".hm-card.is-stale")).toBeNull();
+    expect(within(container).getByText(/FRESH/)).toBeTruthy();
+    expect(container.querySelector(".running")).toBeTruthy();
+  });
+
+  test("focused prop adds is-focused", () => {
+    const { container } = render(<Card card={fixture("agent #547")} focused />);
+    expect(container.querySelector(".hm-card.is-focused")).toBeTruthy();
+  });
+});
+
+describe("Card — interactivity", () => {
+  test("with onClick: role button, fires on click, CTA buttons don't bubble", () => {
+    const onClick = vi.fn();
+    const { container } = render(<Card card={fixture("agent #548")} onClick={onClick} />);
+    const root = container.querySelector(".hm-card") as HTMLElement;
+    expect(root.getAttribute("role")).toBe("button");
+    fireEvent.click(root);
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    // Clicking the primary CTA must not also trigger the card's onClick.
+    fireEvent.click(within(container).getByText("Approve & merge"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("without onClick: role article", () => {
+    const { container } = render(<Card card={fixture("agent #547")} />);
+    expect((container.querySelector(".hm-card") as HTMLElement).getAttribute("role")).toBe("article");
+  });
+});

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -1,0 +1,248 @@
+// Hermes Handoff Monitor — Card (unified renderer)
+//
+// One component handles every "live" card type the monitor knows about
+// (PR, Mission, Codex task, Deploy, Draft, Done). The visual differences
+// between types are driven by which fields are populated, not by separate
+// React components — the design bundle's pattern, mirrored 1:1.
+//
+// The two non-live states (`failed-fetch`, `source-offline`) render
+// through <DegradedCard> instead; <CardRouter> owns that dispatch.
+//
+// State variants this component handles:
+//   - fresh / running → normal shell, full-saturation freshness pip
+//   - stale           → is-stale class; CSS desaturates + "STALE Xh" badge
+//   - done            → compressed historical layout (no risk pills /
+//                       checks bar; header + optional closed-at line)
+//
+// Action variants:
+//   - isAction = true   → amber wash + Hermes verdict + CTA buttons
+//   - archiveHint = true → "archive in 4h?" tail line
+
+import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType } from "../../lib/monitor/card-types.js";
+import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
+import { ChecksBar } from "./ChecksBar.js";
+
+export type CardProps = {
+  card: BoardCard;
+  focused?: boolean;
+  onClick?: (card: BoardCard) => void;
+};
+
+// ── Helpers (mirror the bundle's small inline helpers) ──────────────
+
+function agentLabel(t: AgentType | undefined): string {
+  if (t === "codex" || t === "claude" || t === "hermes") return t;
+  return "ext";
+}
+
+/** CSS class hook for the freshness pip (is-fresh / is-warm / is-stale). */
+function freshClass(card: BoardCard): string {
+  if (card.state === "stale") return "is-stale";
+  const tier = freshnessTier(card.freshness);
+  if (tier === "fresh") return "is-fresh";
+  if (tier === "warm") return "is-warm";
+  return "";
+}
+
+/**
+ * Strip the leading agent-type prefix from a card ID for the monospace
+ * badge. `agent #548` → `#548`, `mission browser-X` → `browser-X`.
+ */
+function shortId(id: string): string {
+  return id.replace(/^[a-z]+ /, "");
+}
+
+// Risk-tag pill classification — matches the bundle's branching.
+const HIGH_RISK_TAGS = new Set<RiskTag>(["contracts", "workflow", "review-gated", "secrets", "config"]);
+const SECRET_RISK_TAGS = new Set<RiskTag>(["secrets"]);
+
+function riskPillClass(tag: RiskTag): string {
+  if (SECRET_RISK_TAGS.has(tag)) return "hm-pill hm-pill--secret";
+  if (HIGH_RISK_TAGS.has(tag)) return "hm-pill hm-pill--risk";
+  return "hm-pill hm-pill--neutral";
+}
+
+// ── Card ───────────────────────────────────────────────────────────
+
+export function Card({ card, focused = false, onClick }: CardProps) {
+  const isAction = Boolean(card.isAction);
+  const isStale = card.state === "stale";
+  const isClosed = card.type === "done";
+
+  const classes = [
+    "hm-card",
+    isAction ? "hm-card--action" : "",
+    isStale ? "is-stale" : "",
+    focused ? "is-focused" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  // Pull the card-type-specific tail fields where they exist. The
+  // discriminated union means these are narrow per branch; we read them
+  // defensively because the same Card renders every type.
+  const verdict = (card as { verdict?: string }).verdict;
+  const action = (card as { action?: { primary: string; secondary?: string } }).action;
+  const checks: CardChecks | undefined = card.checks;
+  const closedAt = (card as { closedAt?: string }).closedAt;
+  const verdictText = (card as { verdictText?: string }).verdictText;
+
+  const onCardClick = onClick ? () => onClick(card) : undefined;
+
+  return (
+    <div
+      className={classes}
+      onClick={onCardClick}
+      // Focusable so j/k traversal (M10') can land on this card; the
+      // Board's keyboard handler reads document.activeElement. tabIndex=-1
+      // keeps it out of the natural tab order (tab would otherwise cycle
+      // through dozens of cards) while staying programmatically reachable.
+      tabIndex={-1}
+      data-card-id={card.id}
+      role={onClick ? "button" : "article"}
+      aria-label={`${agentLabel(card.agentType)} ${shortId(card.id)} — ${card.title}`}
+    >
+      <CardHead card={card} isStale={isStale} isClosed={isClosed} />
+
+      <div className="hm-card-title">{card.title}</div>
+
+      {card.summary && !isClosed ? (
+        <div className="hm-card-meta" style={{ lineHeight: 1.5 }}>
+          <span style={{ color: "var(--hm-ink-soft)", fontFamily: "var(--font-body)", fontSize: 12 }}>
+            {card.summary}
+          </span>
+        </div>
+      ) : null}
+
+      {isClosed && verdictText ? (
+        <div className="hm-card-meta">
+          <span className="hm-mono">{closedAt}</span>
+          <span className="sep">·</span>
+          <span style={{ color: "var(--hm-ink-soft)" }}>{verdictText}</span>
+        </div>
+      ) : null}
+
+      {!isClosed && card.risk && card.risk.length > 0 ? (
+        <div className="hm-pillrow">
+          {card.risk.map((r) => (
+            <span key={r} className={riskPillClass(r)}>
+              {r}
+            </span>
+          ))}
+          {card.isDraft ? <span className="hm-pill hm-pill--draft">draft</span> : null}
+        </div>
+      ) : null}
+
+      {checks ? (
+        <div className="hm-checks">
+          <ChecksBar checks={checks} />
+          <ChecksLabel checks={checks} />
+        </div>
+      ) : null}
+
+      {card.waitingOn ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
+
+      {isAction && verdict ? (
+        <div className="hm-verdict">
+          <span className="label">Hermes verdict</span>
+          {verdict}
+        </div>
+      ) : null}
+
+      {isAction && action ? (
+        <div className="hm-card-cta">
+          <button
+            type="button"
+            className="hm-btn hm-btn--action hm-btn--sm"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {action.primary}
+            <span className="hm-kbd">A</span>
+          </button>
+          {action.secondary ? (
+            <button
+              type="button"
+              className="hm-btn hm-btn--ghost hm-btn--sm"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {action.secondary}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+
+      {card.archiveHint ? (
+        <div className="hm-waiting hm-waiting--neutral" style={{ color: "var(--hm-muted-soft)" }}>
+          <span
+            style={{
+              fontFamily: "var(--font-mono)",
+              textTransform: "none",
+              letterSpacing: 0,
+              fontWeight: 500,
+              fontSize: 11,
+            }}
+          >
+            Hermes: archive in 4h?{" "}
+            <span style={{ color: "var(--hm-sage-deep)", cursor: "pointer", borderBottom: "1px dotted" }}>
+              Keep watching
+            </span>
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// ── Card header — agent dot + ID + freshness pill ──────────────────
+
+function CardHead({ card, isStale, isClosed }: { card: BoardCard; isStale: boolean; isClosed: boolean }) {
+  const formatted = formatFreshness(card.freshness);
+  const freshnessLabel = isClosed ? "CLOSED" : isStale ? `STALE ${formatted ?? ""}` : `FRESH ${formatted ?? ""}`;
+
+  return (
+    <div className="hm-card-head">
+      <span className="hm-card-id">
+        <span className={`agent-dot agent-dot--${card.agentType ?? "ext"}`} aria-hidden />
+        <span className="hm-mono">{agentLabel(card.agentType)}</span>
+        <strong className="hm-mono">{shortId(card.id)}</strong>
+      </span>
+      <span className={"hm-card-fresh " + freshClass(card)}>
+        <span className="fresh-dot" aria-hidden />
+        {freshnessLabel}
+      </span>
+    </div>
+  );
+}
+
+// ── Checks label (e.g. "5/6 · 1 running") ──────────────────────────
+
+function ChecksLabel({ checks }: { checks: CardChecks }) {
+  return (
+    <span className="hm-checks-label">
+      {checks.pass}/{checks.total}
+      {checks.fail > 0 ? (
+        <span style={{ color: "var(--hm-rose)" }}>
+          {" · "}
+          {checks.fail} fail
+        </span>
+      ) : null}
+      {checks.running > 0 ? (
+        <span style={{ color: "var(--hm-amber-deep)" }}>
+          {" · "}
+          {checks.running} running
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+// ── Waiting-on line ────────────────────────────────────────────────
+
+function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
+  return (
+    <div className={`hm-waiting hm-waiting--${waitingOn.tone}`}>
+      waiting on
+      <span className="target">→ {waitingOn.actor}</span>
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/cards/CardRouter.test.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { CardRouter } from "./CardRouter.js";
+import { FIXTURE_CARDS, DEGRADED_FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+const fresh = FIXTURE_CARDS.find((c) => c.id === "agent #548") as BoardCard;
+const failedFetch = DEGRADED_FIXTURE_CARDS.find((c) => c.state === "failed-fetch") as BoardCard;
+const sourceOffline = DEGRADED_FIXTURE_CARDS.find((c) => c.state === "source-offline") as BoardCard;
+
+describe("CardRouter — dispatch", () => {
+  test("a fresh card renders the unified <Card> (not degraded)", () => {
+    const { container } = render(<CardRouter card={fresh} />);
+    expect(container.querySelector(".hm-card--err")).toBeNull();
+    expect(container.querySelector(".hm-card--offline")).toBeNull();
+    expect(within(container).getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+  });
+
+  test("failed-fetch routes to <DegradedCard> with the default error content", () => {
+    const { container } = render(<CardRouter card={failedFetch} />);
+    const view = within(container);
+    expect(container.querySelector(".hm-card--err")).toBeTruthy();
+    expect(view.getByText(/Upstream returned an error/)).toBeTruthy();
+    expect(view.getByText("fetch failed")).toBeTruthy();
+    expect(view.getByText("Retry now")).toBeTruthy();
+  });
+
+  test("source-offline routes to <DegradedCard> with the default offline content", () => {
+    const { container } = render(<CardRouter card={sourceOffline} />);
+    const view = within(container);
+    expect(container.querySelector(".hm-card--offline")).toBeTruthy();
+    expect(view.getByText(/Upstream unreachable/)).toBeTruthy();
+    expect(view.getByText("source · offline")).toBeTruthy();
+    expect(view.getByText("View last known")).toBeTruthy();
+  });
+
+  test("onDegradedAction is wired to the degraded card's action button", () => {
+    const onDegradedAction = vi.fn();
+    const { container } = render(<CardRouter card={failedFetch} onDegradedAction={onDegradedAction} />);
+    fireEvent.click(within(container).getByRole("button", { name: "Retry now" }));
+    expect(onDegradedAction).toHaveBeenCalledWith(failedFetch);
+  });
+});

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -1,0 +1,40 @@
+// Hermes Handoff Monitor — CardRouter
+//
+// React-side dispatch between <Card> and <DegradedCard>. The decision
+// logic lives in lib/monitor/card-router.ts (pure, tested); this
+// component just consumes it. The dispatch is the gate that enforces
+// "we never silently fall back to a fresh-looking card when the data is
+// broken" (§16).
+
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+import { pickRenderer, defaultDegradedContent } from "../../lib/monitor/card-router.js";
+import { Card } from "./Card.js";
+import { DegradedCard } from "./DegradedCard.js";
+
+export type CardRouterProps = {
+  card: BoardCard;
+  focused?: boolean;
+  onClick?: (card: BoardCard) => void;
+  /** Click handler for the degraded card's primary action (Retry / View last known). */
+  onDegradedAction?: (card: BoardCard) => void;
+};
+
+export function CardRouter({ card, focused, onClick, onDegradedAction }: CardRouterProps) {
+  const renderer = pickRenderer(card);
+
+  if (renderer === "degraded") {
+    const content = defaultDegradedContent(card);
+    return (
+      <DegradedCard
+        card={card}
+        body={content.body}
+        pills={content.pills}
+        action={content.action}
+        onClick={onClick}
+        onAction={onDegradedAction ? () => onDegradedAction(card) : undefined}
+      />
+    );
+  }
+
+  return <Card card={card} focused={focused} onClick={onClick} />;
+}

--- a/packages/monitor-ui/src/components/cards/ChecksBar.test.tsx
+++ b/packages/monitor-ui/src/components/cards/ChecksBar.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { ChecksBar } from "./ChecksBar.js";
+
+afterEach(cleanup);
+
+describe("ChecksBar", () => {
+  test("renders one segment per non-zero check kind", () => {
+    const { container } = render(
+      <ChecksBar checks={{ pass: 5, running: 1, fail: 0, pending: 0, total: 6 }} />,
+    );
+    expect(container.querySelector(".pass")).toBeTruthy();
+    expect(container.querySelector(".running")).toBeTruthy();
+    expect(container.querySelector(".fail")).toBeNull();
+    expect(container.querySelector(".pending")).toBeNull();
+  });
+
+  test("segment widths are the fraction of total", () => {
+    const { container } = render(
+      <ChecksBar checks={{ pass: 3, running: 0, fail: 1, pending: 0, total: 4 }} />,
+    );
+    expect((container.querySelector(".pass") as HTMLElement).style.width).toBe("75%");
+    expect((container.querySelector(".fail") as HTMLElement).style.width).toBe("25%");
+  });
+
+  test("falls back to summed total when total is 0", () => {
+    const { container } = render(
+      <ChecksBar checks={{ pass: 1, running: 1, fail: 0, pending: 0, total: 0 }} />,
+    );
+    // 1 of (1+1) = 50%
+    expect((container.querySelector(".pass") as HTMLElement).style.width).toBe("50%");
+  });
+
+  test("renders nothing when there are no checks at all", () => {
+    const { container } = render(
+      <ChecksBar checks={{ pass: 0, running: 0, fail: 0, pending: 0, total: 0 }} />,
+    );
+    expect(container.querySelector(".hm-checks-bar")).toBeNull();
+  });
+
+  test("exposes a screen-reader summary", () => {
+    const { container } = render(
+      <ChecksBar checks={{ pass: 4, running: 3, fail: 0, pending: 0, total: 7 }} />,
+    );
+    expect((container.querySelector(".hm-checks-bar") as HTMLElement).getAttribute("aria-label")).toBe(
+      "4 of 7 checks passed",
+    );
+  });
+});

--- a/packages/monitor-ui/src/components/cards/ChecksBar.tsx
+++ b/packages/monitor-ui/src/components/cards/ChecksBar.tsx
@@ -1,0 +1,37 @@
+// Hermes Handoff Monitor — ChecksBar
+//
+// Compact progress bar showing the pass / running / fail / pending
+// breakdown of a card's CI checks. Each segment is an inline-block
+// whose width is its fraction of the total. The .hm-checks-bar CSS
+// supplies the per-state colors (sage pass, amber running, rose fail,
+// neutral pending) via class hooks.
+
+import type { CardChecks } from "../../lib/monitor/card-types.js";
+
+export type ChecksBarProps = {
+  checks: CardChecks;
+};
+
+export function ChecksBar({ checks }: ChecksBarProps) {
+  // Defensive: if `total` is 0 (or missing), recompute from the segment
+  // breakdown so the bar renders sensibly rather than NaN-width segments.
+  const total =
+    checks.total > 0 ? checks.total : checks.pass + checks.running + checks.fail + checks.pending;
+
+  if (total <= 0) return null;
+
+  const pct = (n: number) => `${(n / total) * 100}%`;
+
+  return (
+    <div className="hm-checks-bar" aria-label={`${checks.pass} of ${total} checks passed`}>
+      {checks.pass > 0 ? <span className="pass" style={{ width: pct(checks.pass) }} aria-hidden /> : null}
+      {checks.running > 0 ? (
+        <span className="running" style={{ width: pct(checks.running) }} aria-hidden />
+      ) : null}
+      {checks.fail > 0 ? <span className="fail" style={{ width: pct(checks.fail) }} aria-hidden /> : null}
+      {checks.pending > 0 ? (
+        <span className="pending" style={{ width: pct(checks.pending) }} aria-hidden />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/cards/DegradedCard.test.tsx
+++ b/packages/monitor-ui/src/components/cards/DegradedCard.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { DegradedCard } from "./DegradedCard.js";
+import { DEGRADED_FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+const failedFetch = DEGRADED_FIXTURE_CARDS.find((c) => c.state === "failed-fetch") as BoardCard;
+const sourceOffline = DEGRADED_FIXTURE_CARDS.find((c) => c.state === "source-offline") as BoardCard;
+
+describe("DegradedCard", () => {
+  test("failed-fetch → rose error treatment, ERROR pip, body + pills + action", () => {
+    const { container } = render(
+      <DegradedCard
+        card={failedFetch}
+        body="Upstream returned an error."
+        pills={[
+          ["hm-pill--err", "fetch failed"],
+          ["hm-pill--neutral", "retry available"],
+        ]}
+        action="Retry now"
+      />,
+    );
+    const view = within(container);
+    expect(container.querySelector(".hm-card--err")).toBeTruthy();
+    expect(view.getByText("ERROR")).toBeTruthy();
+    expect(view.getByText("Upstream returned an error.")).toBeTruthy();
+    expect(view.getByText("fetch failed")).toBeTruthy();
+    expect(view.getByText("Retry now")).toBeTruthy();
+  });
+
+  test("source-offline → neutral treatment, OFFLINE pip", () => {
+    const { container } = render(
+      <DegradedCard
+        card={sourceOffline}
+        body="Upstream unreachable."
+        pills={[["hm-pill--offline", "source · offline"]]}
+        action="View last known"
+      />,
+    );
+    const view = within(container);
+    expect(container.querySelector(".hm-card--offline")).toBeTruthy();
+    expect(view.getByText("OFFLINE")).toBeTruthy();
+    expect(view.getByText("source · offline")).toBeTruthy();
+  });
+
+  test("action button is disabled without a handler and fires with one", () => {
+    const noHandler = render(
+      <DegradedCard card={failedFetch} body="x" pills={[]} action="Retry now" />,
+    );
+    expect((noHandler.getByRole("button", { name: "Retry now" }) as HTMLButtonElement).disabled).toBe(true);
+
+    const onAction = vi.fn();
+    const withHandler = render(
+      <DegradedCard card={failedFetch} body="x" pills={[]} action="Retry now" onAction={onAction} />,
+    );
+    const btn = within(withHandler.container).getByRole("button", { name: "Retry now" });
+    fireEvent.click(btn);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  test("the action click does not bubble to the card onClick", () => {
+    const onClick = vi.fn();
+    const onAction = vi.fn();
+    const { container } = render(
+      <DegradedCard
+        card={failedFetch}
+        body="x"
+        pills={[]}
+        action="Retry now"
+        onClick={onClick}
+        onAction={onAction}
+      />,
+    );
+    fireEvent.click(within(container).getByRole("button", { name: "Retry now" }));
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/monitor-ui/src/components/cards/DegradedCard.tsx
+++ b/packages/monitor-ui/src/components/cards/DegradedCard.tsx
@@ -1,0 +1,93 @@
+// Hermes Handoff Monitor — DegradedCard
+//
+// Hand-built card variant for the two states where the live Card shape
+// isn't trustworthy: `failed-fetch` (upstream returned an error) and
+// `source-offline` (upstream unreachable).
+//
+// Visual contract:
+//   - failed-fetch   → rose ribbon, ERROR pip, "Retry now" action
+//   - source-offline → neutral grey, OFFLINE pip, "View last known"
+//                       action (no urgency — we don't know what's
+//                       happening upstream, so we don't fake confidence)
+//
+// The hard rule from §16 of the spec: zero tolerance for hiding "we
+// don't know if there's action needed." A failed-fetch card must be
+// obviously not-fresh; an offline card must not pretend we have current
+// data.
+
+import type { ReactNode } from "react";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+export type DegradedCardKind = "failed-fetch" | "source-offline";
+
+export type DegradedCardProps = {
+  card: BoardCard;
+  /** Operator-facing body copy explaining what happened. */
+  body: ReactNode;
+  /** Pill labels (e.g. ["fetch failed", "retry available"]). */
+  pills: ReadonlyArray<readonly [pillClass: string, label: string]>;
+  /** Primary action label (e.g. "Retry now", "View last known"). */
+  action: string;
+  /** Click handler — typically wired to a retry / refresh in M5'. */
+  onAction?: () => void;
+  /** Card click handler — opens the context drawer in M6'. */
+  onClick?: (card: BoardCard) => void;
+};
+
+export function DegradedCard({ card, body, pills, action, onAction, onClick }: DegradedCardProps) {
+  const kind: DegradedCardKind = card.state === "source-offline" ? "source-offline" : "failed-fetch";
+  const isErr = kind === "failed-fetch";
+
+  return (
+    <div
+      className={"hm-card " + (isErr ? "hm-card--err" : "hm-card--offline")}
+      onClick={onClick ? () => onClick(card) : undefined}
+      tabIndex={-1}
+      data-card-id={card.id}
+      data-card-state={kind}
+      role={onClick ? "button" : "article"}
+      aria-label={`${card.id} — ${isErr ? "error" : "offline"}: ${card.title}`}
+    >
+      <div className="hm-card-head">
+        <span className="hm-card-id">
+          <span className="agent-dot agent-dot--ext" aria-hidden />
+          <strong className="hm-mono">{card.id}</strong>
+        </span>
+        <span className="hm-card-fresh">
+          <span
+            className="fresh-dot"
+            style={{ background: isErr ? "var(--hm-rose)" : "var(--hm-offline)" }}
+            aria-hidden
+          />
+          {isErr ? "ERROR" : "OFFLINE"}
+        </span>
+      </div>
+
+      <div className="hm-card-title" style={{ color: isErr ? "var(--hm-rose)" : "var(--hm-muted)" }}>
+        {body}
+      </div>
+
+      <div className="hm-pillrow">
+        {pills.map(([cls, label]) => (
+          <span key={label} className={"hm-pill " + cls}>
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div className="hm-card-cta">
+        <button
+          type="button"
+          className="hm-btn hm-btn--ghost hm-btn--sm"
+          onClick={(e) => {
+            e.stopPropagation();
+            onAction?.();
+          }}
+          disabled={!onAction}
+        >
+          {action}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **M4'** of the Hermes Handoff Monitor redesign: adds the unified **card vocabulary** on top of the M3' layout and renders the rich-mix board (**artboard A1**) against fixtures. Every card type and state is on screen, dispatched so a data-broken card never masquerades as fresh.
- New components under `src/components/cards/`: `Card`, `ChecksBar`, `DegradedCard`, `CardRouter`.

## Components
- **`Card`** — one renderer for all six live types (`pr` / `mission` / `task` / `deploy` / `draft` / `done`), driven by which fields are populated (the design bundle's pattern). Handles fresh / running / stale / done states, the `isAction` treatment (Hermes verdict + CTA buttons), risk pills, and the archive hint. Cards are `role=article` today (become `role=button` when the drawer arrives in M6'); CTA clicks `stopPropagation` so they don't trigger the card body.
- **`ChecksBar`** — pass / running / fail / pending progress bar with a summed-total fallback and an `aria-label` summary.
- **`DegradedCard`** — the `failed-fetch` (rose) and `source-offline` (neutral) variants per **§16**: the data-broken card must be obviously not-fresh, never faking confidence.
- **`CardRouter`** — consumes the tested pure logic (`pickRenderer()` / `defaultDegradedContent()`) to choose `Card` vs `DegradedCard`.

## MonitorPage
- Flips from the M3' calm/empty layout to the rich-mix **A1** board: full `FIXTURE_CARDS`, rendered through `<CardRouter>`.
- `laneFor()` promotes `isAction` cards into **needs-attention** (so `operator-review` is empty once #548 moves), so the expansion preset expands `needs-attention` to keep the action treatment on screen. M5' will derive the preset from live board mode.
- The M3' page test was updated to the new card-rendering behavior.

## Deferred (per the milestone plan)
- Live SSE data + real refresh → **M5'**
- Detail drawer on card click → **M6'**
- Working Hermes co-pilot rail → **M8'**

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **218/218** (153 logic + 40 layout + 25 new card cases; A7 degraded states covered)
- [x] `npm test` (full repo) → **540/540**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)