### PR TITLE
monitor-ui: live data wiring (M5')

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2288,7 +2288,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4080,6 +4079,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -4288,6 +4300,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vary": {
@@ -5134,7 +5155,8 @@
       "version": "0.1.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "swr": "^2.2.5"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.0",

--- a/packages/monitor-ui/package.json
+++ b/packages/monitor-ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Hermes Handoff Monitor — redesigned operator UI (Direction A). M3': Vite + React layout (top strip, Board Now banner, lanes, mini-rails).",
+  "description": "Hermes Handoff Monitor — redesigned operator UI (Direction A). Vite + React board with live SSE data wiring (M5').",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "swr": "^2.2.5"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.0",

--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -1,65 +1,77 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, test } from "vitest";
-import { cleanup, render, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ReactNode } from "react";
+import { cleanup, render, waitFor, within } from "@testing-library/react";
+import { SWRConfig } from "swr";
 import { MonitorPage } from "./MonitorPage.js";
+import { FIXTURE_CARDS } from "./lib/monitor/fixtures.js";
+import type { MonitorBoard } from "./lib/monitor/board-cache.js";
+import type { StorageLike } from "./lib/monitor/snapshot-store.js";
 
 afterEach(cleanup);
 
-describe("MonitorPage — rich-mix / A1 state", () => {
-  test("renders the full board chrome end-to-end", () => {
-    const { container } = render(<MonitorPage />);
-    const view = within(container);
+// Minimal EventSource stand-in so the container's SSE effect is inert
+// in tests (the fetched board is enough to drive a render).
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  onopen: ((e: unknown) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  constructor(_url: string) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(): void {}
+  close(): void {}
+}
+const ES = FakeEventSource as unknown as typeof EventSource;
 
-    // Top strip
-    expect(view.getByRole("banner")).toBeTruthy();
-    expect(view.getByText("Hermes")).toBeTruthy();
+function memStorage(): StorageLike {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => (m.has(k) ? (m.get(k) as string) : null),
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+    get length() {
+      return m.size;
+    },
+    key: (i) => Array.from(m.keys())[i] ?? null,
+  };
+}
 
-    // Board Now banner — action tone (the fixtures include action cards)
-    expect(container.querySelector(".hm-now--action")).toBeTruthy();
-    expect(view.getByText(/your review decision/)).toBeTruthy();
+function wrapper({ children }: { children: ReactNode }) {
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
 
-    // Lanes bar
-    expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
+beforeEach(() => {
+  FakeEventSource.instances = [];
+});
 
-    // Board grid with all eight lanes
-    expect(view.getByRole("region", { name: "Lane grid" })).toBeTruthy();
+describe("MonitorPage — container", () => {
+  test("wires fetched live board data into the BoardView", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+      wrapper,
+    });
+
+    // Once the fetch resolves, the rich-mix board renders.
+    await waitFor(() =>
+      expect(within(container).getByText("Allow operator override of agent claim-stake floor")).toBeTruthy(),
+    );
+    expect(within(container).getByRole("banner")).toBeTruthy();
+    expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
+  });
+
+  test("renders the board chrome without crashing when the fetch fails", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => {
+      throw new Error("no backend");
+    });
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+      wrapper,
+    });
+
+    // Chrome is present even with no board data — no blank screen, no throw.
+    await waitFor(() => expect(within(container).getByRole("banner")).toBeTruthy());
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
-
-    // Hermes co-pilot rail chrome (full rail lands in M8')
-    expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
-  });
-
-  test("the rich-mix preset expands five lanes; the other three are mini-rails", () => {
-    const { container } = render(<MonitorPage />);
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(5);
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(3);
-  });
-
-  test("renders the action card with its CTA and Hermes verdict", () => {
-    const { container } = render(<MonitorPage />);
-    const view = within(container);
-    // PR #548 is an isAction card, so laneFor() promotes it into the
-    // (expanded) needs-attention lane.
-    expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
-    expect(view.getByText("Approve & merge")).toBeTruthy();
-    expect(view.getByText("Hermes verdict")).toBeTruthy();
-  });
-
-  test("renders a spread of card types (mission, deploy, done)", () => {
-    const { container } = render(<MonitorPage />);
-    const view = within(container);
-    // Mission card (hermes-checking lane, expanded)
-    expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
-    // Deploy card (deploying lane, expanded)
-    expect(view.getByText(/Post-merge verify/)).toBeTruthy();
-    // Done history cards render with CLOSED freshness pips
-    expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
-  });
-
-  test("collapsed lanes hide their card bodies (drafts is a mini-rail)", () => {
-    const { container } = render(<MonitorPage />);
-    // The draft PR #550 lives in the collapsed drafts lane, so its title
-    // is not in the DOM until the lane is expanded.
-    expect(within(container).queryByText(/governance dispute UI/)).toBeNull();
+    expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
 });

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -1,119 +1,28 @@
-// Hermes Handoff Monitor — board page (M4')
+// Hermes Handoff Monitor — board page (M5')
 //
-// Composes the Direction A layout against fixtures and renders the
-// rich-mix board (artboard A1): every card type and state is on screen,
-// dispatched through <CardRouter> so degraded cards never masquerade as
-// fresh ones.
-//
-//   <div.hm-board>
-//     <TopStrip />               KPI pills + LIVE indicator + refresh
-//     <BoardNowBanner />         hero sentence (tone follows board mode)
-//     <div.hm-main>              grid: lanes-wrap | hermes rail (420px)
-//       <div.hm-lanes-wrap>
-//         <LanesBar />           search + filter chips + urgency label
-//         <Board renderCard />   the eight lanes, cards via <CardRouter>
-//       <aside.hm-hermes>        co-pilot rail chrome (full rail = M8')
-//
-// What's deferred, by milestone:
-//   - live SSE data + real refresh → M5'
-//   - the detail drawer (card click) → M6'
-//   - the working Hermes co-pilot rail → M8'
+// The live data container: wires useMonitorBoard() (SWR fetch of
+// /monitor/v2/board + the SSE LiveStream against /monitor/v2/stream) to
+// the presentational <BoardView>. A spawned/updated card on the SSE
+// feed flows event → applyEventToBoard → SWR cache → re-render; the
+// Refresh button revalidates the HTTP snapshot.
 //
 // Auth is handled at the edge (Cloudflare Access), so there is no
 // client-side guard here.
+//
+// Deferred, by milestone:
+//   - the detail drawer (card click)   → M6'
+//   - the working Hermes co-pilot rail → M8'
+//   - the degraded TopStrip ("?" KPIs) → M11'
 
-import { useMemo } from "react";
-import { deriveBoardState } from "./lib/monitor/board-state.js";
-import { FIXTURE_CARDS } from "./lib/monitor/fixtures.js";
-import type { BoardCard } from "./lib/monitor/card-types.js";
-import { TopStrip } from "./components/TopStrip.js";
-import { BoardNowBanner } from "./components/BoardNowBanner.js";
-import { LanesBar } from "./components/LanesBar.js";
-import { Board } from "./components/Board.js";
-import type { LaneId } from "./components/Lane.js";
-import { CardRouter } from "./components/cards/CardRouter.js";
+import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitorBoard.js";
+import { BoardView } from "./components/BoardView.js";
 
-// Expansion preset for the rich-mix demo. Note `laneFor()` promotes
-// every `isAction` card into needs-attention, so that lane (not
-// operator-review) holds the action cards — expand it so the action
-// treatment (verdict + CTA) is on screen. M5' will derive the preset
-// from live board mode.
-const RICH_MIX_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
-  "needs-attention",
-  "hermes-checking",
-  "release-queue",
-  "deploying",
-  "done",
-]);
-
-export function MonitorPage() {
-  // Rich-mix / A1 state: the full fixture board (PR, mission, task,
-  // deploy, draft, done) so every card type and state is exercised.
-  // M5' swaps fixtures for the live SSE feed and drives the expansion
-  // preset off board mode.
-  const cards: BoardCard[] = useMemo(() => FIXTURE_CARDS, []);
-  const nowLabel = useMemo(() => buildNowLabel(), []);
-
-  const state = useMemo(
-    () => deriveBoardState(cards, { nowLabel, streamOnline: true }),
-    [cards, nowLabel],
-  );
-
-  return (
-    <div className="hm-board">
-      <TopStrip counts={state.counts} liveAt={nowLabel.replace(/ utc$/i, "")} />
-
-      <BoardNowBanner banner={state.banner} />
-
-      <div className="hm-main">
-        <div className="hm-lanes-wrap">
-          <LanesBar counts={state.counts} mode={state.mode} />
-          <Board
-            grouped={state.grouped}
-            initialExpanded={RICH_MIX_EXPANDED}
-            renderCard={(card) => <CardRouter key={card.id} card={card} />}
-          />
-        </div>
-
-        <HermesRailPlaceholder />
-      </div>
-    </div>
-  );
+export interface MonitorPageProps {
+  /** Override the live wiring (fetcher, EventSource, storage) for tests. */
+  options?: UseMonitorBoardOptions;
 }
 
-/**
- * Minimal Hermes co-pilot rail chrome so the `.hm-main` two-column grid
- * (1fr | 420px) renders end-to-end. The narrating stream + composer are
- * wired in M8'; this stub only holds the column and the rail header.
- */
-function HermesRailPlaceholder() {
-  return (
-    <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
-      {/* A <div>, not <header>: only the TopStrip is the page banner
-          landmark — the rail's own header must not register as a second. */}
-      <div className="hm-hermes-head">
-        <div className="hm-hermes-mark" aria-hidden>
-          H
-        </div>
-        <div>
-          <div className="hm-hermes-title">Hermes co-pilot</div>
-          <div className="hm-hermes-sub">
-            <span className="pulse" aria-hidden />
-            Live · narrating the board · context: everywhere
-          </div>
-        </div>
-      </div>
-
-      <div className="hm-hermes-stream">
-        <div className="hm-lane-empty">Hermes narration lands in M8'.</div>
-      </div>
-    </aside>
-  );
-}
-
-/** Render the current UTC time as "HH:MM:SS utc". */
-function buildNowLabel(): string {
-  const d = new Date();
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} utc`;
+export function MonitorPage({ options }: MonitorPageProps = {}) {
+  const { board, status, refresh } = useMonitorBoard(options);
+  return <BoardView board={board} status={status} onRefresh={refresh} />;
 }

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { BoardView } from "./BoardView.js";
+import { FIXTURE_CARDS } from "../lib/monitor/fixtures.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+
+afterEach(cleanup);
+
+const richBoard: MonitorBoard = { cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" };
+
+describe("BoardView — rich-mix board (open stream)", () => {
+  test("renders the full board chrome end-to-end", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    const view = within(container);
+    expect(view.getByRole("banner")).toBeTruthy();
+    expect(view.getByText("Hermes")).toBeTruthy();
+    // action tone — the fixtures include action cards
+    expect(container.querySelector(".hm-now--action")).toBeTruthy();
+    expect(view.getByText(/your review decision/)).toBeTruthy();
+    expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
+    expect(view.getByRole("region", { name: "Lane grid" })).toBeTruthy();
+    expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+    expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
+  });
+
+  test("action mode expands five lanes; the other three are mini-rails", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(5);
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(3);
+  });
+
+  test("renders the action card with its CTA and Hermes verdict", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    const view = within(container);
+    expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+    expect(view.getByText("Approve & merge")).toBeTruthy();
+    expect(view.getByText("Hermes verdict")).toBeTruthy();
+  });
+
+  test("renders a spread of card types (mission, deploy, done)", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    const view = within(container);
+    expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
+    expect(view.getByText(/Post-merge verify/)).toBeTruthy();
+    expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
+  });
+
+  test("collapsed lanes hide their card bodies (drafts is a mini-rail)", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    expect(within(container).queryByText(/governance dispute UI/)).toBeNull();
+  });
+
+  test("an open stream lights the LIVE indicator with the snapshot clock", () => {
+    const { getByText } = render(<BoardView board={richBoard} status="open" />);
+    expect(getByText(/Live · 10:30:00/)).toBeTruthy();
+  });
+
+  test("Refresh button is wired to onRefresh", () => {
+    const onRefresh = vi.fn();
+    const { getByRole } = render(<BoardView board={richBoard} status="open" onRefresh={onRefresh} />);
+    fireEvent.click(getByRole("button", { name: "Refresh board" }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("BoardView — degraded + transient states", () => {
+  test("a reconnecting stream renders the degraded banner and a dimmed LIVE", () => {
+    const { container, getByText } = render(<BoardView board={richBoard} status="reconnecting" />);
+    expect(container.querySelector(".hm-now--degraded")).toBeTruthy();
+    expect(getByText(/Live stream disconnected/)).toBeTruthy();
+    // LIVE indicator only lights on a confirmed open stream.
+    expect(getByText(/Live · —/)).toBeTruthy();
+  });
+
+  test("a closed stream is degraded too", () => {
+    const { container } = render(<BoardView board={richBoard} status="closed" />);
+    expect(container.querySelector(".hm-now--degraded")).toBeTruthy();
+  });
+
+  test("no board yet (connecting) renders the calm empty layout, not degraded", () => {
+    const { container, getByText } = render(<BoardView board={undefined} status="connecting" />);
+    expect(container.querySelector(".hm-now--degraded")).toBeNull();
+    expect(getByText(/Nothing waits on you/)).toBeTruthy();
+    // Still eight lanes, all empty.
+    expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+  });
+});

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -1,0 +1,141 @@
+// Hermes Handoff Monitor — BoardView (presentational board)
+//
+// Pure render of the Direction A board from a MonitorBoard + stream
+// status. No data fetching — the live wiring lives in useMonitorBoard()
+// and the page container passes the result down. Keeping this component
+// data-free makes it deterministic to test and storybook against
+// fixtures.
+//
+//   <div.hm-board>
+//     <TopStrip />               KPI pills + LIVE indicator + refresh
+//     <BoardNowBanner />         hero sentence (tone follows board mode)
+//     <div.hm-main>              grid: lanes-wrap | hermes rail (420px)
+//       <div.hm-lanes-wrap>
+//         <LanesBar />           search + filter chips + urgency label
+//         <Board renderCard />   the eight lanes, cards via <CardRouter>
+//       <aside.hm-hermes>        co-pilot rail chrome (full rail = M8')
+
+import { useMemo } from "react";
+import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+import type { StreamStatus } from "../lib/monitor/live-stream.js";
+import { TopStrip } from "./TopStrip.js";
+import { BoardNowBanner } from "./BoardNowBanner.js";
+import { LanesBar } from "./LanesBar.js";
+import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
+import type { LaneId } from "./Lane.js";
+import { CardRouter } from "./cards/CardRouter.js";
+
+// laneFor() promotes every isAction card into needs-attention, so the
+// action preset expands that lane (not operator-review) to keep the
+// action treatment — verdict + CTA — on screen.
+const ACTION_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
+  "needs-attention",
+  "hermes-checking",
+  "release-queue",
+  "deploying",
+  "done",
+]);
+
+function expandedForMode(mode: BoardMode): ReadonlySet<LaneId> {
+  if (mode === "calm") return CALM_EXPANDED;
+  if (mode === "degraded") return DEFAULT_EXPANDED;
+  return ACTION_EXPANDED;
+}
+
+export interface BoardViewProps {
+  board: MonitorBoard | undefined;
+  status: StreamStatus;
+  /** Refresh handler (the top-strip Refresh button). */
+  onRefresh?: () => void;
+}
+
+export function BoardView({ board, status, onRefresh }: BoardViewProps) {
+  // The stream is "degraded" only on a real drop (reconnecting/closed);
+  // idle/connecting are pre-live transients, not disconnections. The
+  // LIVE indicator, by contrast, only lights on a confirmed open stream.
+  const degraded = status === "reconnecting" || status === "closed";
+  const streamOnline = !degraded;
+  const cards = board?.cards ?? [];
+  const liveLabel = useMemo(() => formatClock(board?.at), [board?.at]);
+
+  const state = useMemo(
+    () =>
+      deriveBoardState(cards, {
+        streamOnline,
+        nowLabel: liveLabel,
+        lastGoodLabel: liveLabel || undefined,
+      }),
+    [cards, streamOnline, liveLabel],
+  );
+
+  return (
+    <div className="hm-board">
+      <TopStrip
+        counts={state.counts}
+        liveAt={status === "open" ? liveLabel || undefined : undefined}
+        onRefresh={onRefresh}
+      />
+
+      <BoardNowBanner banner={state.banner} />
+
+      <div className="hm-main">
+        <div className="hm-lanes-wrap">
+          <LanesBar counts={state.counts} mode={state.mode} />
+          {/* Key by mode: <Board> seeds its expansion state from
+              initialExpanded only on mount, so when the board transitions
+              (e.g. empty→action as live data arrives) we remount to apply
+              the new preset. Manual collapse/expand toggles persist within
+              a mode; a mode change is a significant enough event to reset. */}
+          <Board
+            key={state.mode}
+            grouped={state.grouped}
+            initialExpanded={expandedForMode(state.mode)}
+            renderCard={(card) => <CardRouter key={card.id} card={card} />}
+          />
+        </div>
+
+        <HermesRailPlaceholder />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Minimal Hermes co-pilot rail chrome so the `.hm-main` two-column grid
+ * (1fr | 420px) renders end-to-end. The narrating stream + composer are
+ * wired in M8'; this stub only holds the column and the rail header.
+ */
+function HermesRailPlaceholder() {
+  return (
+    <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
+      {/* A <div>, not <header>: only the TopStrip is the page banner
+          landmark — the rail's own header must not register as a second. */}
+      <div className="hm-hermes-head">
+        <div className="hm-hermes-mark" aria-hidden>
+          H
+        </div>
+        <div>
+          <div className="hm-hermes-title">Hermes co-pilot</div>
+          <div className="hm-hermes-sub">
+            <span className="pulse" aria-hidden />
+            Live · narrating the board · context: everywhere
+          </div>
+        </div>
+      </div>
+
+      <div className="hm-hermes-stream">
+        <div className="hm-lane-empty">Hermes narration lands in M8'.</div>
+      </div>
+    </aside>
+  );
+}
+
+/** Format an ISO timestamp as a UTC "HH:MM:SS" clock label, or "" if absent. */
+function formatClock(iso: string | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+}

--- a/packages/monitor-ui/src/hooks/useMonitorBoard.test.tsx
+++ b/packages/monitor-ui/src/hooks/useMonitorBoard.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { ReactNode } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { useMonitorBoard } from "./useMonitorBoard.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+import { SNAPSHOT_KEY_PREFIX, type StorageLike } from "../lib/monitor/snapshot-store.js";
+
+afterEach(cleanup);
+
+// ── Fakes ───────────────────────────────────────────────────────────
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onopen: ((e: unknown) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  private listeners = new Map<string, (e: MessageEvent) => void>();
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, fn: (e: MessageEvent) => void): void {
+    this.listeners.set(type, fn);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  emitNamed(type: string, data: string): void {
+    this.listeners.get(type)?.({ type, data } as MessageEvent);
+  }
+}
+
+function memStorage(): StorageLike {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => (m.has(k) ? (m.get(k) as string) : null),
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+    get length() {
+      return m.size;
+    },
+    key: (i) => Array.from(m.keys())[i] ?? null,
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  // Fresh SWR cache per test; no dedupe so refresh re-fetches immediately.
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
+
+function board(cards: Array<{ id: string }>, at: string): MonitorBoard {
+  return { cards, at } as unknown as MonitorBoard;
+}
+
+const ES = FakeEventSource as unknown as typeof EventSource;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+});
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe("useMonitorBoard", () => {
+  test("loads the initial board over HTTP", async () => {
+    const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage: memStorage() }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.board?.cards.length).toBe(1));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.current.lastUpdated).toBe("2026-05-28T10:00:00Z");
+  });
+
+  test("an SSE board.snapshot replaces the board and persists to storage", async () => {
+    const storage = memStorage();
+    const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage }), { wrapper });
+
+    await waitFor(() => expect(result.current.board).toBeDefined());
+    const es = FakeEventSource.instances.at(-1) as FakeEventSource;
+
+    // M1' BoardSnapshotV2 payload — no `type` field; the client tags it.
+    act(() => {
+      es.emitNamed(
+        "board.snapshot",
+        JSON.stringify({ cards: [{ id: "agent #9" }, { id: "agent #10" }], at: "2026-05-28T11:00:00Z", repo: "x/y" }),
+      );
+    });
+
+    await waitFor(() => expect(result.current.board?.cards.map((c) => c.id)).toEqual(["agent #9", "agent #10"]));
+    expect(result.current.lastUpdated).toBe("2026-05-28T11:00:00Z");
+    // Snapshot persisted for the future time-travel UI.
+    expect(storage.getItem(`${SNAPSHOT_KEY_PREFIX}2026-05-28T11:00:00Z`)).toBeTruthy();
+  });
+
+  test("an SSE board.card.added appends without a refetch (the spawn path)", async () => {
+    const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage: memStorage() }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.board?.cards.length).toBe(1));
+    const es = FakeEventSource.instances.at(-1) as FakeEventSource;
+
+    act(() => {
+      es.emitNamed(
+        "board.card.added",
+        JSON.stringify({ card: { id: "agent #2", lane: "operator-review" }, at: "2026-05-28T10:05:00Z" }),
+      );
+    });
+
+    await waitFor(() => expect(result.current.board?.cards.map((c) => c.id)).toContain("agent #2"));
+    // No extra HTTP fetch — the event patched the cache in place.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  test("status follows the stream lifecycle (connecting → open)", async () => {
+    const fetcher = vi.fn(async () => board([], "2026-05-28T10:00:00Z"));
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage: memStorage() }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.status).toBe("connecting"));
+    const es = FakeEventSource.instances.at(-1) as FakeEventSource;
+    act(() => es.onopen?.({}));
+    expect(result.current.status).toBe("open");
+  });
+
+  test("refresh re-fetches the board snapshot", async () => {
+    const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage: memStorage() }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.board).toBeDefined());
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalledTimes(2));
+  });
+
+  test("live:false skips the SSE connection entirely", async () => {
+    const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
+    renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage: memStorage(), live: false }), {
+      wrapper,
+    });
+    await waitFor(() => expect(fetcher).toHaveBeenCalled());
+    expect(FakeEventSource.instances.length).toBe(0);
+  });
+});

--- a/packages/monitor-ui/src/hooks/useMonitorBoard.ts
+++ b/packages/monitor-ui/src/hooks/useMonitorBoard.ts
@@ -1,0 +1,124 @@
+// Hermes Handoff Monitor — live board data hook (M5').
+//
+// Wires the monitor UI to the slack-operator v2 endpoints:
+//   - GET  /monitor/v2/board   → initial snapshot (SWR query cache)
+//   - GET  /monitor/v2/stream  → SSE push (LiveStream client)
+//
+// SWR holds the board as the single source of truth. SSE events patch
+// the SWR cache in place via applyEventToBoard() (no refetch); the
+// Refresh button revalidates the HTTP query. Full snapshots are
+// persisted to localStorage for the future time-travel UI (§21.4).
+//
+// Everything is dependency-injected (fetcher, EventSource, storage,
+// clock) so the hook is testable without a DOM, a network, or a server.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import useSWR from "swr";
+import { applyEventToBoard, type MonitorBoard, type MonitorEvent } from "../lib/monitor/board-cache.js";
+import { LiveStream, type StreamStatus } from "../lib/monitor/live-stream.js";
+import { writeSnapshot, type StorageLike } from "../lib/monitor/snapshot-store.js";
+
+const DEFAULT_BOARD_URL = "/monitor/v2/board";
+const DEFAULT_STREAM_URL = "/monitor/v2/stream";
+
+export interface UseMonitorBoardOptions {
+  boardUrl?: string;
+  streamUrl?: string;
+  /** Auth token appended to the SSE URL (EventSource can't send headers). */
+  token?: string;
+  /** Initial-snapshot fetcher. Defaults to fetch + JSON. */
+  fetcher?: (url: string) => Promise<MonitorBoard>;
+  /** Injected EventSource constructor (tests / non-browser). */
+  EventSourceCtor?: typeof EventSource;
+  /** Snapshot storage override (defaults to localStorage). */
+  storage?: StorageLike;
+  /** Clock override for snapshot TTL eviction. */
+  now?: () => number;
+  /** When false, the SSE client is not started (default true). */
+  live?: boolean;
+}
+
+export interface MonitorBoardState {
+  board: MonitorBoard | undefined;
+  /** SSE connection status — drives the LIVE indicator + degraded mode. */
+  status: StreamStatus;
+  /** ISO `at` of the most recently applied board, if any. */
+  lastUpdated: string | undefined;
+  error: unknown;
+  isLoading: boolean;
+  /** Re-fetch the board snapshot over HTTP (the Refresh button). */
+  refresh: () => void;
+}
+
+async function defaultFetcher(url: string): Promise<MonitorBoard> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`monitor board fetch failed: ${res.status}`);
+  return (await res.json()) as MonitorBoard;
+}
+
+export function useMonitorBoard(opts: UseMonitorBoardOptions = {}): MonitorBoardState {
+  const boardUrl = opts.boardUrl ?? DEFAULT_BOARD_URL;
+  const fetcher = opts.fetcher ?? defaultFetcher;
+
+  const { data, error, isLoading, mutate } = useSWR<MonitorBoard>(boardUrl, fetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  });
+
+  const [status, setStatus] = useState<StreamStatus>("idle");
+
+  // Latest-value refs so the SSE effect can stay mounted across renders
+  // without tearing down the connection when these identities change.
+  const mutateRef = useRef(mutate);
+  mutateRef.current = mutate;
+  const storageRef = useRef(opts.storage);
+  storageRef.current = opts.storage;
+  const nowRef = useRef(opts.now);
+  nowRef.current = opts.now;
+
+  useEffect(() => {
+    if (opts.live === false) return;
+
+    const stream = new LiveStream({
+      url: opts.streamUrl ?? DEFAULT_STREAM_URL,
+      token: opts.token,
+      EventSourceCtor: opts.EventSourceCtor,
+    });
+
+    const offStatus = stream.onStatus(setStatus);
+    const off = stream.on((event: MonitorEvent) => {
+      // Patch the SWR cache in place — full-state replace on snapshot,
+      // targeted edits on per-card events. No HTTP round-trip.
+      void mutateRef.current((prev) => applyEventToBoard(prev, event), { revalidate: false });
+
+      if (event.type === "board.snapshot") {
+        persistSnapshot(event, storageRef.current, nowRef.current);
+      }
+    });
+
+    stream.start();
+    return () => {
+      off();
+      offStatus();
+      stream.stop();
+    };
+  }, [opts.live, opts.streamUrl, opts.token, opts.EventSourceCtor]);
+
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+
+  return { board: data, status, lastUpdated: data?.at, error, isLoading, refresh };
+}
+
+/** Best-effort persist of a full board snapshot to localStorage. */
+function persistSnapshot(event: MonitorEvent, storage: StorageLike | undefined, now: (() => number) | undefined): void {
+  // event.cards / event.at are `unknown` via MonitorEvent's index signature.
+  const cards = Array.isArray(event.cards) ? event.cards : [];
+  const at = typeof event.at === "string" ? event.at : new Date().toISOString();
+  try {
+    writeSnapshot({ at, cards }, { storage, now });
+  } catch {
+    /* snapshot persistence is best-effort; never block the UI on it */
+  }
+}

--- a/packages/monitor-ui/src/lib/monitor/live-stream.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/live-stream.test.ts
@@ -5,7 +5,8 @@
 
 import { test, assert } from "vitest";
 
-import { backoffDelayMs, nextStatus, RECONNECT_CAP_MS } from "./live-stream.js";
+import { backoffDelayMs, nextStatus, RECONNECT_CAP_MS, LiveStream } from "./live-stream.js";
+import type { MonitorEvent } from "./board-cache.js";
 
 // ── backoffDelayMs ──────────────────────────────────────────────────
 
@@ -100,4 +101,97 @@ test("backoff progression: attempt N steady-state matches the cap", () => {
   // shape from the spec.
   assert.equal(backoffDelayMs(10), backoffDelayMs(20));
   assert.equal(backoffDelayMs(20), backoffDelayMs(99));
+});
+
+// ── LiveStream class — event tagging + delivery ─────────────────────
+//
+// A minimal EventSource stand-in: captures the named-event listeners
+// LiveStream attaches and lets a test drive events synchronously.
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onopen: ((e: unknown) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  private listeners = new Map<string, (e: MessageEvent) => void>();
+  closed = false;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, fn: (e: MessageEvent) => void): void {
+    this.listeners.set(type, fn);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  /** Test helper — dispatch a named SSE event with a JSON string body. */
+  emitNamed(type: string, data: string): void {
+    this.listeners.get(type)?.({ type, data } as MessageEvent);
+  }
+  /** Test helper — dispatch an unnamed `message` event. */
+  emitMessage(data: string): void {
+    this.onmessage?.({ type: "message", data } as MessageEvent);
+  }
+}
+
+function freshStream() {
+  FakeEventSource.instances = [];
+  const stream = new LiveStream({
+    url: "/monitor/v2/stream",
+    EventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+  });
+  const received: MonitorEvent[] = [];
+  stream.on((e) => received.push(e));
+  stream.start();
+  const source = FakeEventSource.instances.at(-1) as FakeEventSource;
+  return { stream, received, source };
+}
+
+test("LiveStream: tags a typeless named-event payload with the event name", () => {
+  // The M1' BoardSnapshotV2 body is `{ cards, at, repo }` — no `type`.
+  const { received, source } = freshStream();
+  source.emitNamed("board.snapshot", JSON.stringify({ cards: [], at: "2026-05-28T00:00:00Z", repo: "x/y" }));
+  assert.equal(received.length, 1);
+  assert.equal(received[0]?.type, "board.snapshot");
+  assert.deepEqual((received[0] as { cards: unknown[] }).cards, []);
+});
+
+test("LiveStream: an explicit payload type wins over the event name", () => {
+  const { received, source } = freshStream();
+  source.emitNamed("board.snapshot", JSON.stringify({ type: "board.card.added", card: { id: "agent #1" } }));
+  assert.equal(received[0]?.type, "board.card.added");
+});
+
+test("LiveStream: the default 'message' event name is not used as a type", () => {
+  const { received, source } = freshStream();
+  source.emitMessage(JSON.stringify({ cards: [] }));
+  assert.equal(received.length, 1);
+  assert.equal(received[0]?.type, undefined);
+});
+
+test("LiveStream: malformed JSON is dropped, not delivered", () => {
+  const { received, source } = freshStream();
+  source.emitNamed("board.snapshot", "{ not json");
+  assert.equal(received.length, 0);
+});
+
+test("LiveStream: onStatus fires immediately and tracks open/closed", () => {
+  FakeEventSource.instances = [];
+  const stream = new LiveStream({
+    url: "/x",
+    EventSourceCtor: FakeEventSource as unknown as typeof EventSource,
+  });
+  const statuses: string[] = [];
+  stream.onStatus((s) => statuses.push(s));
+  assert.equal(statuses[0], "idle"); // fires immediately with current status
+  stream.start();
+  const source = FakeEventSource.instances.at(-1) as FakeEventSource;
+  source.onopen?.({});
+  assert.equal(statuses.at(-1), "open");
+  stream.stop();
+  assert.equal(statuses.at(-1), "closed");
+  assert.equal(source.closed, true);
 });

--- a/packages/monitor-ui/src/lib/monitor/live-stream.ts
+++ b/packages/monitor-ui/src/lib/monitor/live-stream.ts
@@ -179,6 +179,15 @@ export class LiveStream {
       this.logger.warn?.("LiveStream: failed to parse SSE event payload", err);
       return;
     }
+    // The server tags updates with the SSE event name (`event: board.snapshot`)
+    // but the JSON payload itself may omit a `type` discriminator — the M1'
+    // BoardSnapshotV2 is just `{ cards, at, repo }`. Recover the type from the
+    // event name so board-cache's applyEventToBoard() can dispatch on it. A
+    // `type` already in the payload always wins; the default "message" event
+    // (unnamed data) is not a meaningful board type, so we ignore it.
+    if (typeof parsed.type !== "string" && typeof e.type === "string" && e.type !== "message") {
+      parsed = { ...parsed, type: e.type };
+    }
     for (const h of this.handlers) {
       try {
         h(parsed);


### PR DESCRIPTION
## Summary
- **M5'** of the Hermes Handoff Monitor redesign: wires the board to the slack-operator **v2 endpoints** so it renders real, streaming data instead of static fixtures.
- New `useMonitorBoard` hook (SWR + SSE), a presentational `BoardView` split out of `MonitorPage`, the localStorage snapshot writer, and a working Refresh button.

## `useMonitorBoard` hook (`src/hooks/`)
- **SWR** query of `GET /monitor/v2/board` for the initial snapshot + the **Refresh** button (revalidate).
- **`LiveStream` SSE client** against `/monitor/v2/stream`; events patch the SWR cache in place via `applyEventToBoard()` — full-state replace on `board.snapshot`, targeted edits on per-card events — so a spawned card appears **without a refetch**.
- Full snapshots persisted to **localStorage** (`writeSnapshot`) for the future time-travel UI (§21.4).
- Fully **dependency-injected** (fetcher, EventSource, storage, clock) — no DOM, network, or server needed to test.

## `live-stream`: tag SSE payloads with the event name
- The M1' `BoardSnapshotV2` body is `{ cards, at, repo }` — **no `type` discriminator**. `dispatchRaw` now recovers the type from the SSE event name (`event: board.snapshot`) so `board-cache` can dispatch on it. An explicit payload `type` still wins; the default `message` event is ignored.

## `BoardView` + `MonitorPage`
- Extracted the presentational **`BoardView`** (board + stream status → rendered board); **`MonitorPage`** is now a thin live container over the hook. `BoardView` derives `streamOnline`/degraded from status, lights **LIVE** only on a confirmed open stream, and picks the expansion preset by board mode.
- **Bug fix:** `<Board>` seeds expansion from `initialExpanded` only on mount, so it's now **keyed by mode** — when live data flips the board empty→action, the preset re-applies and the action lane is no longer stuck collapsed.

## Scope note — `debug/spawn`
The `POST /monitor/v2/debug/spawn` endpoint named in the M5' acceptance is **backend scope and not yet implemented** (it was never built in M1'). To keep this a one-package PR, the spawn→appears-live path is proven by the hook's `board.card.added` unit test; an end-to-end manual check against a running slack-operator can follow once `debug/spawn` lands (small backend PR).

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **236/236** (+5 LiveStream class cases, the `useMonitorBoard` suite, `BoardView` rich-mix/degraded/empty, `MonitorPage` container)
- [x] `npm test` (full repo) → **558/558**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)