### PR TITLE
monitor v2: dev-only POST /monitor/v2/debug/spawn endpoint

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -42,6 +42,12 @@ import {
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
 import { buildV2BoardSnapshot } from "./monitor-v2.js";
 import {
+  isDebugSpawnEnabled,
+  mergeDebugCards,
+  onDebugCardSpawned,
+  spawnDebugCard,
+} from "./monitor-v2-debug.js";
+import {
   decideHermesBoardNarration,
   fallbackHermesBoardNarration,
   relatedPrForHermesBoardNarration,
@@ -189,6 +195,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/stream",
           "/monitor/v2/board",
           "/monitor/v2/stream",
+          ...(isDebugSpawnEnabled() ? ["/monitor/v2/debug/spawn"] : []),
           "/monitor/command",
           "/monitor/recheck",
           "/monitor/codex-tasks",
@@ -255,7 +262,35 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
-    writeJson(response, 200, buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }));
+    writeJson(response, 200, mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() })));
+    return;
+  }
+  // Dev-only acceptance vehicle: inject a synthetic card so the
+  // spawn → appears-live path can be exercised before real ingestion
+  // lands. Invisible (404) unless MONITOR_V2_DEBUG_SPAWN=1.
+  if (request.method === "POST" && url.pathname === "/monitor/v2/debug/spawn") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isDebugSpawnEnabled()) {
+      writeJson(response, 404, { error: "debug_spawn_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    let payload: unknown = {};
+    try {
+      const rawBody = await readBody(request);
+      payload = rawBody ? (JSON.parse(rawBody) as unknown) : {};
+    } catch {
+      writeJson(response, 400, { error: "invalid_json" });
+      return;
+    }
+    const card = spawnDebugCard(payload, { defaultRepo: monitorV2Repo() });
+    writeJson(response, 201, { ok: true, card, at: new Date().toISOString() });
     return;
   }
   if (request.method === "GET" && url.pathname === "/monitor/codex-tasks") {
@@ -1650,7 +1685,7 @@ async function writeMonitorV2Stream(
     inFlight = true;
     try {
       const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
-      writeSseEvent(response, "board.snapshot", buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }));
+      writeSseEvent(response, "board.snapshot", mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() })));
     } catch (error) {
       writeSseEvent(response, "error", {
         error: "monitor_v2_snapshot_failed",
@@ -1661,9 +1696,18 @@ async function writeMonitorV2Stream(
     }
   };
 
+  // Push a board.card.added the instant a debug card is spawned, so the
+  // dev acceptance path lands in milliseconds rather than on the next
+  // poll. No-op in production (nothing ever spawns).
+  const offSpawn = onDebugCardSpawned((card) => {
+    if (closed) return;
+    writeSseEvent(response, "board.card.added", { card, at: new Date().toISOString() });
+  });
+
   request.on("close", () => {
     closed = true;
     if (timer) clearInterval(timer);
+    offSpawn();
   });
 
   await send();

--- a/services/slack-operator/src/monitor-v2-debug.ts
+++ b/services/slack-operator/src/monitor-v2-debug.ts
@@ -1,0 +1,189 @@
+// Hermes Handoff Monitor — dev-only debug card spawner.
+//
+// Acceptance vehicle for "spawn a card via the API, see it appear in the
+// UI within 500ms" (spec §6, M5'). Gated behind MONITOR_V2_DEBUG_SPAWN=1;
+// when that env is unset the route 404s and this store stays empty, so
+// production behaviour is unchanged.
+//
+// A spawned card is SYNTHETIC by construction (default title "Debug spawn
+// card") and lives only in memory (lost on restart). It is:
+//   - merged into every v2 snapshot so it survives the periodic
+//     full-snapshot replace the SSE stream pushes, and
+//   - broadcast to live SSE connections as board.card.added so it lands
+//     within milliseconds rather than on the next poll.
+//
+// Replaced by real GitHub/Codex/Hermes ingestion as those milestones land.
+
+import type {
+  AgentType,
+  BoardCard,
+  BoardSnapshotV2,
+  CardState,
+  CardType,
+  Lane,
+  RiskTag,
+  WaitingOn,
+} from "./monitor-v2.js";
+
+export const MONITOR_V2_DEBUG_SPAWN_ENV = "MONITOR_V2_DEBUG_SPAWN";
+const MAX_DEBUG_CARDS = 50;
+
+const LANES: readonly Lane[] = [
+  "needs-attention",
+  "drafts",
+  "codex-needed",
+  "hermes-checking",
+  "operator-review",
+  "release-queue",
+  "deploying",
+  "done",
+];
+const CARD_TYPES: readonly CardType[] = ["pr", "mission", "task", "deploy", "draft", "done"];
+const AGENT_TYPES: readonly AgentType[] = ["claude", "codex", "hermes", "ext"];
+const CARD_STATES: readonly CardState[] = ["fresh", "stale", "failed-fetch", "source-offline", "running"];
+const RISK_TAGS: readonly RiskTag[] = [
+  "workflow",
+  "config",
+  "review-gated",
+  "contracts",
+  "secrets",
+  "indexer",
+  "xcm",
+  "docs",
+  "testbed",
+  "ui-only",
+  "deps",
+  "quality",
+];
+const WAITING_ACTORS: readonly WaitingOn["actor"][] = [
+  "operator",
+  "author",
+  "agent",
+  "CI",
+  "relay",
+  "branch-protection",
+];
+const WAITING_TONES: readonly WaitingOn["tone"][] = ["warn", "info", "neutral"];
+
+let store: BoardCard[] = [];
+let counter = 0;
+const subscribers = new Set<(card: BoardCard) => void>();
+
+/** Dev-only gate. The route 404s unless MONITOR_V2_DEBUG_SPAWN=1. */
+export function isDebugSpawnEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env[MONITOR_V2_DEBUG_SPAWN_ENV] === "1";
+}
+
+export interface SpawnDebugCardOptions {
+  /** Repo to stamp on the card when the body omits one. */
+  defaultRepo?: string;
+}
+
+/**
+ * Coerce an arbitrary request body into a valid BoardCard with sensible
+ * synthetic defaults, store it (replacing any same-id card, capped), and
+ * notify subscribers (live SSE connections). Unknown enum values fall
+ * back to defaults rather than erroring — this is a forgiving dev tool.
+ */
+export function spawnDebugCard(input: unknown, opts: SpawnDebugCardOptions = {}): BoardCard {
+  const body = isRecord(input) ? input : {};
+  counter += 1;
+
+  const card: BoardCard = {
+    id: nonEmptyString(body.id) ?? `debug #${counter}`,
+    lane: oneOf(body.lane, LANES, "operator-review"),
+    type: oneOf(body.type, CARD_TYPES, "pr"),
+    agentType: oneOf(body.agentType, AGENT_TYPES, "claude"),
+    title: nonEmptyString(body.title) ?? "Debug spawn card",
+    summary:
+      typeof body.summary === "string"
+        ? body.summary
+        : "Synthetic card injected via /monitor/v2/debug/spawn for pipeline testing.",
+    repo: nonEmptyString(body.repo) ?? opts.defaultRepo ?? "debug/local",
+    freshness:
+      typeof body.freshness === "number" && Number.isFinite(body.freshness) && body.freshness >= 0
+        ? body.freshness
+        : 0,
+    state: oneOf(body.state, CARD_STATES, "fresh"),
+    risk: Array.isArray(body.risk) ? body.risk.filter((r): r is RiskTag => RISK_TAGS.includes(r as RiskTag)) : [],
+    waitingOn: parseWaitingOn(body.waitingOn),
+  };
+
+  const branch = nonEmptyString(body.branch);
+  if (branch) card.branch = branch;
+  if (body.isAction === true) card.isAction = true;
+  if (body.isDraft === true) card.isDraft = true;
+  if (body.archiveHint === true) card.archiveHint = true;
+  if (typeof body.next === "string") card.next = body.next;
+  if (typeof body.verdict === "string") card.verdict = body.verdict;
+
+  // Re-spawning an id replaces the prior card; keep only the newest N.
+  store = store.filter((c) => c.id !== card.id);
+  store.push(card);
+  if (store.length > MAX_DEBUG_CARDS) store = store.slice(-MAX_DEBUG_CARDS);
+
+  for (const fn of subscribers) {
+    try {
+      fn(card);
+    } catch {
+      /* a thrown subscriber must never break the spawn */
+    }
+  }
+
+  return card;
+}
+
+/** Snapshot of the current in-memory debug cards. */
+export function getDebugCards(): BoardCard[] {
+  return store.slice();
+}
+
+/** Drop all debug cards (used by tests and a future clear endpoint). */
+export function clearDebugCards(): void {
+  store = [];
+}
+
+/** Subscribe to spawns (live SSE connections). Returns an unsubscribe fn. */
+export function onDebugCardSpawned(fn: (card: BoardCard) => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+/**
+ * Append the in-memory debug cards to a snapshot so they survive the
+ * periodic full-snapshot replace. Debug cards win on id collision. A
+ * no-op (returns the same object) when the store is empty — i.e. always,
+ * in production.
+ */
+export function mergeDebugCards(snapshot: BoardSnapshotV2): BoardSnapshotV2 {
+  if (store.length === 0) return snapshot;
+  const ids = new Set(store.map((c) => c.id));
+  const base = snapshot.cards.filter((c) => !ids.has(c.id));
+  return { ...snapshot, cards: [...base, ...store] };
+}
+
+// ── helpers ─────────────────────────────────────────────────────────
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function nonEmptyString(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim().length > 0 ? v : undefined;
+}
+
+function oneOf<T>(value: unknown, allowed: readonly T[], fallback: T): T {
+  return allowed.includes(value as T) ? (value as T) : fallback;
+}
+
+function parseWaitingOn(value: unknown): WaitingOn {
+  if (isRecord(value)) {
+    return {
+      actor: oneOf(value.actor, WAITING_ACTORS, "operator"),
+      tone: oneOf(value.tone, WAITING_TONES, "info"),
+    };
+  }
+  return { actor: "operator", tone: "info" };
+}

--- a/test/unit/monitor-v2-debug.test.ts
+++ b/test/unit/monitor-v2-debug.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  MONITOR_V2_DEBUG_SPAWN_ENV,
+  clearDebugCards,
+  getDebugCards,
+  isDebugSpawnEnabled,
+  mergeDebugCards,
+  onDebugCardSpawned,
+  spawnDebugCard,
+} from "../../services/slack-operator/src/monitor-v2-debug.js";
+import type { BoardSnapshotV2 } from "../../services/slack-operator/src/monitor-v2.js";
+
+afterEach(() => {
+  clearDebugCards();
+});
+
+describe("isDebugSpawnEnabled", () => {
+  it("is true only when MONITOR_V2_DEBUG_SPAWN === '1'", () => {
+    expect(isDebugSpawnEnabled({ [MONITOR_V2_DEBUG_SPAWN_ENV]: "1" })).toBe(true);
+    expect(isDebugSpawnEnabled({ [MONITOR_V2_DEBUG_SPAWN_ENV]: "0" })).toBe(false);
+    expect(isDebugSpawnEnabled({ [MONITOR_V2_DEBUG_SPAWN_ENV]: "true" })).toBe(false);
+    expect(isDebugSpawnEnabled({})).toBe(false);
+  });
+});
+
+describe("spawnDebugCard", () => {
+  it("builds a synthetic card with safe defaults from an empty body", () => {
+    const card = spawnDebugCard({}, { defaultRepo: "depre-dev/agent" });
+    expect(card.id).toMatch(/^debug #\d+$/);
+    expect(card.lane).toBe("operator-review");
+    expect(card.type).toBe("pr");
+    expect(card.agentType).toBe("claude");
+    expect(card.title).toBe("Debug spawn card");
+    expect(card.repo).toBe("depre-dev/agent");
+    expect(card.state).toBe("fresh");
+    expect(card.freshness).toBe(0);
+    expect(card.risk).toEqual([]);
+    expect(card.waitingOn).toEqual({ actor: "operator", tone: "info" });
+  });
+
+  it("honours valid overrides", () => {
+    const card = spawnDebugCard({
+      id: "agent #999",
+      lane: "deploying",
+      type: "deploy",
+      agentType: "ext",
+      title: "Verify XCM settlement",
+      summary: "watching the relay",
+      repo: "depre-dev/site",
+      branch: "main",
+      freshness: 12,
+      state: "running",
+      risk: ["xcm", "indexer"],
+      waitingOn: { actor: "relay", tone: "warn" },
+      isAction: true,
+      verdict: "looks good",
+    });
+    expect(card.id).toBe("agent #999");
+    expect(card.lane).toBe("deploying");
+    expect(card.type).toBe("deploy");
+    expect(card.agentType).toBe("ext");
+    expect(card.branch).toBe("main");
+    expect(card.freshness).toBe(12);
+    expect(card.state).toBe("running");
+    expect(card.risk).toEqual(["xcm", "indexer"]);
+    expect(card.waitingOn).toEqual({ actor: "relay", tone: "warn" });
+    expect(card.isAction).toBe(true);
+    expect(card.verdict).toBe("looks good");
+  });
+
+  it("falls back to defaults for invalid enum values and filters bogus risk tags", () => {
+    const card = spawnDebugCard({
+      lane: "nowhere",
+      type: "spaceship",
+      agentType: "robot",
+      state: "melted",
+      risk: ["xcm", "not-a-risk", 42],
+      waitingOn: { actor: "ceo", tone: "loud" },
+    });
+    expect(card.lane).toBe("operator-review");
+    expect(card.type).toBe("pr");
+    expect(card.agentType).toBe("claude");
+    expect(card.state).toBe("fresh");
+    expect(card.risk).toEqual(["xcm"]);
+    expect(card.waitingOn).toEqual({ actor: "operator", tone: "info" });
+  });
+
+  it("coerces a non-object body without throwing", () => {
+    expect(() => spawnDebugCard("not an object")).not.toThrow();
+    expect(() => spawnDebugCard(null)).not.toThrow();
+    expect(getDebugCards().length).toBe(2);
+  });
+
+  it("accumulates cards and replaces on id collision", () => {
+    spawnDebugCard({ id: "a", title: "first" });
+    spawnDebugCard({ id: "b", title: "second" });
+    expect(getDebugCards().map((c) => c.id)).toEqual(["a", "b"]);
+
+    spawnDebugCard({ id: "a", title: "first-updated" });
+    const cards = getDebugCards();
+    expect(cards.map((c) => c.id)).toEqual(["b", "a"]);
+    expect(cards.find((c) => c.id === "a")?.title).toBe("first-updated");
+  });
+
+  it("caps the store at 50 cards", () => {
+    for (let i = 0; i < 55; i += 1) spawnDebugCard({ id: `card-${i}` });
+    expect(getDebugCards().length).toBe(50);
+    // The oldest were evicted; the newest survive.
+    expect(getDebugCards().some((c) => c.id === "card-54")).toBe(true);
+    expect(getDebugCards().some((c) => c.id === "card-0")).toBe(false);
+  });
+});
+
+describe("onDebugCardSpawned", () => {
+  it("notifies subscribers with the spawned card and stops after unsubscribe", () => {
+    const seen: string[] = [];
+    const off = onDebugCardSpawned((card) => seen.push(card.id));
+
+    spawnDebugCard({ id: "x" });
+    expect(seen).toEqual(["x"]);
+
+    off();
+    spawnDebugCard({ id: "y" });
+    expect(seen).toEqual(["x"]);
+  });
+
+  it("a throwing subscriber does not break the spawn", () => {
+    const off = onDebugCardSpawned(() => {
+      throw new Error("boom");
+    });
+    expect(() => spawnDebugCard({ id: "z" })).not.toThrow();
+    expect(getDebugCards().some((c) => c.id === "z")).toBe(true);
+    off();
+  });
+});
+
+describe("mergeDebugCards", () => {
+  const snapshot: BoardSnapshotV2 = {
+    cards: [{ id: "real #1", lane: "hermes-checking", type: "pr", agentType: "codex", title: "real", summary: "", repo: "r", freshness: 1, state: "fresh", risk: [], waitingOn: { actor: "CI", tone: "info" } }],
+    at: "2026-05-28T10:00:00Z",
+    repo: "r",
+  };
+
+  it("returns the snapshot unchanged when the store is empty", () => {
+    expect(mergeDebugCards(snapshot)).toBe(snapshot);
+  });
+
+  it("appends debug cards to the snapshot", () => {
+    spawnDebugCard({ id: "debug-a" });
+    const merged = mergeDebugCards(snapshot);
+    expect(merged.cards.map((c) => c.id)).toEqual(["real #1", "debug-a"]);
+    expect(merged.at).toBe(snapshot.at);
+  });
+
+  it("lets a debug card override a real card with the same id", () => {
+    spawnDebugCard({ id: "real #1", title: "debug override" });
+    const merged = mergeDebugCards(snapshot);
+    expect(merged.cards.length).toBe(1);
+    expect(merged.cards[0]?.title).toBe("debug override");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the **dev-only** `POST /monitor/v2/debug/spawn` endpoint — the acceptance vehicle for the M5' goal *"spawn a card via the API, see it appear in the UI within 500ms."* It was referenced in spec §6 but never built in M1'.
- Lets a developer inject a synthetic `BoardCard` that flows through the existing v2 SSE pipeline (`board.card.added` → client `applyEventToBoard` → re-render), ahead of real GitHub/Codex/Hermes ingestion.

## What's in it
- **New `services/slack-operator/src/monitor-v2-debug.ts`**
  - In-memory store + `spawnDebugCard()` — coerces an arbitrary request body into a valid `BoardCard` with synthetic defaults; unknown enum values fall back rather than erroring (forgiving dev tool).
  - A subscriber registry (`onDebugCardSpawned`) and `mergeDebugCards()` that appends the store to a snapshot — a **no-op when the store is empty**, i.e. always, in production.
- **`index.ts` wiring**
  - `POST /monitor/v2/debug/spawn`: `404` when the monitor is disabled **or the `MONITOR_V2_DEBUG_SPAWN=1` gate is off**, `401` unauthorized, `400` on bad JSON, else `201 { ok, card, at }`.
  - Debug cards merged into `GET /monitor/v2/board` and the SSE `board.snapshot`, so a spawned card survives the periodic full-snapshot replace.
  - `writeMonitorV2Stream` subscribes to spawns and emits `board.card.added` **immediately** (lands in ms, not on the next ~5s poll); unsubscribes on connection close.

## Truth-boundary
Gated behind `MONITOR_V2_DEBUG_SPAWN=1` **and** the existing monitor auth. With the gate off the endpoint is invisible (`404`) and the store stays empty, so production behaviour is unchanged — synthetic cards only exist when a dev explicitly opts in, and the default card is plainly titled "Debug spawn card".

## How to use (local)
```
MONITOR_V2_DEBUG_SPAWN=1  # on the slack-operator process
curl -X POST localhost:<port>/monitor/v2/debug/spawn \
  -H 'content-type: application/json' \
  -d '{"title":"Smoke test","lane":"operator-review","isAction":true}'
# → open the monitor; the card appears within ~ms via board.card.added
```

## Test plan
- [x] `npx vitest run test/unit/monitor-v2-debug.test.ts` → **12/12** (env gate, spawn defaults/overrides/enum fallback/risk filtering, store dedup + cap, subscriber notify/unsub, merge append/override/no-op)
- [x] `npm test` (full repo) → **552/552**
- [x] `npm run typecheck` → clean
- [x] `npm run build` (`tsc -b`) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)