### PR TITLE
monitor-ui: detail drawer (M6')

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1622,14 +1622,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.29",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
       "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1640,7 +1638,6 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -2214,7 +2211,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -2630,6 +2626,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "11.0.6",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.6.tgz",
+      "integrity": "sha512-8YbWR8kDf2pQ8G9LT11p39VY4T7eWVrj00Fhp1HUSdv5uW9q6+WK8OMAdy9Ui7vGb1zNouFDzwBIqJwt82rIYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^7.8.0",
+        "tabbable": "^6.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/form-data": {
@@ -4099,6 +4120,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "license": "MIT"
+    },
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -5154,6 +5181,7 @@
       "name": "@avg/monitor-ui",
       "version": "0.1.0",
       "dependencies": {
+        "focus-trap-react": "^11.0.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "swr": "^2.2.5"

--- a/packages/monitor-ui/package.json
+++ b/packages/monitor-ui/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "focus-trap-react": "^11.0.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "swr": "^2.2.5"

--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { ReactNode } from "react";
-import { cleanup, render, waitFor, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { MonitorPage } from "./MonitorPage.js";
 import { FIXTURE_CARDS } from "./lib/monitor/fixtures.js";
@@ -44,6 +44,7 @@ function wrapper({ children }: { children: ReactNode }) {
 
 beforeEach(() => {
   FakeEventSource.instances = [];
+  window.history.replaceState({}, "", "/");
 });
 
 describe("MonitorPage — container", () => {
@@ -59,6 +60,26 @@ describe("MonitorPage — container", () => {
     );
     expect(within(container).getByRole("banner")).toBeTruthy();
     expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
+  });
+
+  test("clicking a card opens the drawer and sets ?card=; esc closes it and clears the param", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+      wrapper,
+    });
+
+    const view = within(container);
+    await waitFor(() => expect(view.getByRole("button", { name: /Allow operator override/ })).toBeTruthy());
+
+    // Click the action card → drawer opens, URL carries the focused card.
+    fireEvent.click(view.getByRole("button", { name: /Allow operator override/ }));
+    await waitFor(() => expect(view.getByRole("dialog")).toBeTruthy());
+    expect(new URLSearchParams(window.location.search).get("card")).toBe("agent #548");
+
+    // Esc closes the drawer and clears the param.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    await waitFor(() => expect(view.queryByRole("dialog")).toBeNull());
+    expect(new URLSearchParams(window.location.search).get("card")).toBeNull();
   });
 
   test("renders the board chrome without crashing when the fetch fails", async () => {

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -1,20 +1,21 @@
-// Hermes Handoff Monitor — board page (M5')
+// Hermes Handoff Monitor — board page (M6')
 //
 // The live data container: wires useMonitorBoard() (SWR fetch of
-// /monitor/v2/board + the SSE LiveStream against /monitor/v2/stream) to
-// the presentational <BoardView>. A spawned/updated card on the SSE
-// feed flows event → applyEventToBoard → SWR cache → re-render; the
-// Refresh button revalidates the HTTP snapshot.
+// /monitor/v2/board + the SSE LiveStream against /monitor/v2/stream) and
+// useCardParam() (the ?card= drawer route) to the presentational
+// <BoardView>. A spawned/updated card on the SSE feed flows
+// event → applyEventToBoard → SWR cache → re-render; the Refresh button
+// revalidates the HTTP snapshot; clicking a card opens its drawer.
 //
 // Auth is handled at the edge (Cloudflare Access), so there is no
 // client-side guard here.
 //
 // Deferred, by milestone:
-//   - the detail drawer (card click)   → M6'
 //   - the working Hermes co-pilot rail → M8'
 //   - the degraded TopStrip ("?" KPIs) → M11'
 
 import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitorBoard.js";
+import { useCardParam } from "./hooks/useCardParam.js";
 import { BoardView } from "./components/BoardView.js";
 
 export interface MonitorPageProps {
@@ -24,5 +25,17 @@ export interface MonitorPageProps {
 
 export function MonitorPage({ options }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
-  return <BoardView board={board} status={status} onRefresh={refresh} />;
+  const { cardId, setCard, clearCard } = useCardParam();
+
+  return (
+    <BoardView
+      board={board}
+      status={status}
+      onRefresh={refresh}
+      focusedCardId={cardId}
+      onCardClick={setCard}
+      onCardClose={clearCard}
+      onCardNavigate={setCard}
+    />
+  );
 }

--- a/packages/monitor-ui/src/components/BoardView.drawer.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.drawer.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { BoardView } from "./BoardView.js";
+import { FIXTURE_CARDS } from "../lib/monitor/fixtures.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+
+afterEach(cleanup);
+
+const board: MonitorBoard = { cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" };
+
+describe("BoardView — drawer wiring", () => {
+  test("clicking a card calls onCardClick with its id", () => {
+    const onCardClick = vi.fn();
+    const { getByRole } = render(<BoardView board={board} status="open" onCardClick={onCardClick} />);
+    // The action PR #548 lives in the (expanded) needs-attention lane and
+    // is a role=button because an onCardClick handler was supplied.
+    fireEvent.click(getByRole("button", { name: /Allow operator override/ }));
+    expect(onCardClick).toHaveBeenCalledWith("agent #548");
+  });
+
+  test("a focusedCardId opens the drawer for that card", () => {
+    const { getByRole } = render(<BoardView board={board} status="open" focusedCardId="agent #548" />);
+    const dialog = getByRole("dialog");
+    expect(dialog.getAttribute("aria-label")).toContain("Allow operator override of agent claim-stake floor");
+  });
+
+  test("no drawer when focusedCardId is unset", () => {
+    const { queryByRole } = render(<BoardView board={board} status="open" />);
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  test("an unknown focusedCardId renders no drawer (stale/deleted card)", () => {
+    const { queryByRole } = render(<BoardView board={board} status="open" focusedCardId="agent #99999" />);
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  test("cards are inert (role=article) when no onCardClick is supplied", () => {
+    const { container } = render(<BoardView board={board} status="open" />);
+    const card = container.querySelector(".hm-card");
+    expect(card?.getAttribute("role")).toBe("article");
+  });
+
+  test("the drawer's j/k traversal navigates across the visible board order", () => {
+    const onCardNavigate = vi.fn();
+    const { getByRole } = render(
+      <BoardView board={board} status="open" focusedCardId="agent #548" onCardNavigate={onCardNavigate} />,
+    );
+    // Sanity: drawer is open for #548.
+    expect(getByRole("dialog")).toBeTruthy();
+    fireEvent.keyDown(document.body, { key: "j" });
+    expect(onCardNavigate).toHaveBeenCalledTimes(1);
+    // Navigates to some other card id (lane-ordered neighbour).
+    expect(onCardNavigate.mock.calls[0]?.[0]).not.toBe("agent #548");
+  });
+});

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -19,12 +19,14 @@ import { useMemo } from "react";
 import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
 import type { MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
+import { LANES, type BoardCard } from "../lib/monitor/card-types.js";
 import { TopStrip } from "./TopStrip.js";
 import { BoardNowBanner } from "./BoardNowBanner.js";
 import { LanesBar } from "./LanesBar.js";
 import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
+import { DetailDrawer } from "./drawer/DetailDrawer.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
 // action preset expands that lane (not operator-review) to keep the
@@ -48,9 +50,25 @@ export interface BoardViewProps {
   status: StreamStatus;
   /** Refresh handler (the top-strip Refresh button). */
   onRefresh?: () => void;
+  /** Focused card id (drives the detail drawer); null/undefined = closed. */
+  focusedCardId?: string | null;
+  /** A card was clicked — open its drawer (sets ?card=). */
+  onCardClick?: (id: string) => void;
+  /** Close the drawer (esc / scrim). */
+  onCardClose?: () => void;
+  /** j/k traversal target within the drawer. */
+  onCardNavigate?: (id: string) => void;
 }
 
-export function BoardView({ board, status, onRefresh }: BoardViewProps) {
+export function BoardView({
+  board,
+  status,
+  onRefresh,
+  focusedCardId,
+  onCardClick,
+  onCardClose,
+  onCardNavigate,
+}: BoardViewProps) {
   // The stream is "degraded" only on a real drop (reconnecting/closed);
   // idle/connecting are pre-live transients, not disconnections. The
   // LIVE indicator, by contrast, only lights on a confirmed open stream.
@@ -68,6 +86,14 @@ export function BoardView({ board, status, onRefresh }: BoardViewProps) {
       }),
     [cards, streamOnline, liveLabel],
   );
+
+  // Cards in display (lane) order — the traversal list for the drawer's
+  // j/k, and the lookup for the focused card.
+  const orderedCards = useMemo<BoardCard[]>(
+    () => LANES.flatMap((lane) => state.grouped[lane] ?? []),
+    [state.grouped],
+  );
+  const focusedCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
 
   return (
     <div className="hm-board">
@@ -91,12 +117,27 @@ export function BoardView({ board, status, onRefresh }: BoardViewProps) {
             key={state.mode}
             grouped={state.grouped}
             initialExpanded={expandedForMode(state.mode)}
-            renderCard={(card) => <CardRouter key={card.id} card={card} />}
+            renderCard={(card) => (
+              <CardRouter
+                key={card.id}
+                card={card}
+                onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
+              />
+            )}
           />
         </div>
 
         <HermesRailPlaceholder />
       </div>
+
+      {focusedCard ? (
+        <DetailDrawer
+          card={focusedCard}
+          cards={orderedCards}
+          onClose={() => onCardClose?.()}
+          onNavigate={(id) => onCardNavigate?.(id)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { DetailDrawer } from "./DetailDrawer.js";
+import { FIXTURE_CARDS, DEGRADED_FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function fixture(id: string): BoardCard {
+  const card = [...FIXTURE_CARDS, ...DEGRADED_FIXTURE_CARDS].find((c) => c.id === id);
+  if (!card) throw new Error(`fixture not found: ${id}`);
+  return card;
+}
+
+const noop = () => {};
+
+describe("DetailDrawer — shell", () => {
+  test("renders a labelled modal dialog with the card title", () => {
+    const card = fixture("agent #548");
+    const { getByRole } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    const dialog = getByRole("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(within(dialog).getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+  });
+
+  test("focus is moved into the dialog on open (focus trap)", () => {
+    const card = fixture("agent #548");
+    const { getByRole } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    const dialog = getByRole("dialog");
+    expect(dialog.contains(document.activeElement)).toBe(true);
+  });
+
+  test("esc closes", () => {
+    const onClose = vi.fn();
+    const card = fixture("agent #548");
+    render(<DetailDrawer card={card} cards={[{ id: card.id }]} onClose={onClose} onNavigate={noop} />);
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("scrim click closes; clicking inside the sheet does not", () => {
+    const onClose = vi.fn();
+    const card = fixture("agent #548");
+    const { container, getByRole } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={onClose} onNavigate={noop} />,
+    );
+    fireEvent.click(getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(container.querySelector(".hm-drawer-scrim") as HTMLElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("the close button closes", () => {
+    const onClose = vi.fn();
+    const card = fixture("agent #548");
+    const { getByRole } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={onClose} onNavigate={noop} />,
+    );
+    fireEvent.click(getByRole("button", { name: /esc · close/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("j / k traverse to the next / previous card", () => {
+    const onNavigate = vi.fn();
+    const card = fixture("agent #549");
+    const cards = [{ id: "before" }, { id: "agent #549" }, { id: "after" }];
+    render(<DetailDrawer card={card} cards={cards} onClose={noop} onNavigate={onNavigate} />);
+
+    fireEvent.keyDown(document.body, { key: "j" });
+    expect(onNavigate).toHaveBeenLastCalledWith("after");
+
+    fireEvent.keyDown(document.body, { key: "k" });
+    expect(onNavigate).toHaveBeenLastCalledWith("before");
+  });
+});
+
+describe("DetailDrawer — variants", () => {
+  test("action PR shows the risk eyebrow, Hermes verdict, files, and CTA", () => {
+    const card = fixture("agent #548");
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Operator review · risk decision")).toBeTruthy();
+    expect(getByText("Hermes verdict")).toBeTruthy();
+    expect(getByText("agent/contracts/AgentAccountCore.sol")).toBeTruthy();
+    expect(getByText("Approve & merge")).toBeTruthy();
+    expect(getByText("Send back to Codex")).toBeTruthy();
+  });
+
+  test("done card shows the release-history eyebrow", () => {
+    const done = FIXTURE_CARDS.find((c) => c.type === "done") as BoardCard;
+    const { getByText } = render(
+      <DetailDrawer card={done} cards={[{ id: done.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Closed · in release history")).toBeTruthy();
+    expect(getByText(/MERGED/)).toBeTruthy();
+  });
+
+  test("deploy card shows the verification progress", () => {
+    const card = fixture("deploy #246");
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Deploying · post-merge verification")).toBeTruthy();
+    expect(getByText(/3\/5 · indexer settle/)).toBeTruthy();
+  });
+
+  test("codex task card shows its prompt", () => {
+    const card = fixture("task starter-coding-014");
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Codex task · awaiting dispatch")).toBeTruthy();
+    expect(getByText(/Coalesce repeated policy-attach entries/)).toBeTruthy();
+  });
+
+  test("mission card shows the hermes eyebrow and the M7' deferral note", () => {
+    const card = fixture("mission browser-onboard-04");
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Browser mission · agent report")).toBeTruthy();
+    expect(getByText(/lands in M7'/)).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
@@ -1,0 +1,144 @@
+// Hermes Handoff Monitor — DetailDrawer (M6').
+//
+// Mounts when ?card=<id> resolves to a board card. A right-hand sheet
+// over a scrim, type-routed body, variant-accented header/footer.
+//
+// Interaction contract (§11):
+//   - esc closes, restoring focus to where it was (focus-trap return)
+//   - scrim click closes
+//   - j / k traverse to the prev / next visible card (drawer scope)
+//   - focus is trapped inside the dialog while open
+//
+// We drive esc + j/k ourselves (escapeDeactivates is off) so a single
+// keydown path owns the behaviour; focus-trap-react handles the trap and
+// focus restoration.
+
+import { useEffect, useRef } from "react";
+import { FocusTrap } from "focus-trap-react";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+import { traverseDrawerCard } from "../../lib/monitor/drawer-routing.js";
+import { DRAWER_ACCENT, DrawerBody, drawerVariant } from "./DrawerBody.js";
+
+export interface DetailDrawerProps {
+  card: BoardCard;
+  /** Ordered list of currently-visible cards, for j/k traversal. */
+  cards: ReadonlyArray<{ id: string }>;
+  onClose: () => void;
+  /** Navigate the drawer to another card id (j/k). */
+  onNavigate: (id: string) => void;
+}
+
+export function DetailDrawer({ card, cards, onClose, onNavigate }: DetailDrawerProps) {
+  const variant = drawerVariant(card);
+  const accent = DRAWER_ACCENT[variant];
+  const asideRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      const target = e.target as HTMLElement | null;
+      if (target && /^(INPUT|TEXTAREA)$/.test(target.tagName)) return;
+      if (e.key === "j") {
+        const next = traverseDrawerCard(cards, card.id, "next");
+        if (next) {
+          e.preventDefault();
+          onNavigate(next);
+        }
+      } else if (e.key === "k") {
+        const prev = traverseDrawerCard(cards, card.id, "prev");
+        if (prev) {
+          e.preventDefault();
+          onNavigate(prev);
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [card.id, cards, onClose, onNavigate]);
+
+  const action = "action" in card ? card.action : undefined;
+
+  return (
+    <FocusTrap
+      focusTrapOptions={{
+        escapeDeactivates: false,
+        clickOutsideDeactivates: false,
+        returnFocusOnDeactivate: true,
+        delayInitialFocus: false,
+        // jsdom has no layout, so skip tabbable's visibility check; our
+        // drawer controls are always visible in a real browser anyway.
+        tabbableOptions: { displayCheck: "none" },
+        fallbackFocus: () => asideRef.current ?? document.body,
+      }}
+    >
+      <div className="hm-drawer-scrim" onClick={onClose}>
+        <aside
+          ref={asideRef}
+          className="hm-drawer"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${card.id} — ${card.title}`}
+          tabIndex={-1}
+          onClick={(e) => e.stopPropagation()}
+          style={{ borderLeftColor: accent.border }}
+        >
+          <header className="hm-drawer-head">
+            <div className="hm-drawer-eyebrow">
+              <span className={"hm-pill " + accent.pill}>{accent.label}</span>
+              <button type="button" className="close" onClick={onClose}>
+                esc · close
+              </button>
+            </div>
+            <h2 className="hm-drawer-title">{card.title}</h2>
+            <div className="hm-drawer-meta">
+              <span>
+                <span className="hm-muted">id</span> {card.id}
+              </span>
+              <span>
+                <span className="hm-muted">repo</span> {card.repo}
+              </span>
+              {card.branch ? (
+                <span>
+                  <span className="hm-muted">branch</span> {card.branch}
+                </span>
+              ) : null}
+              {card.waitingOn ? (
+                <span>
+                  <span className="hm-muted">waiting on</span> {card.waitingOn.actor}
+                </span>
+              ) : null}
+            </div>
+          </header>
+
+          <div className="hm-drawer-body">
+            <DrawerBody card={card} variant={variant} />
+          </div>
+
+          <footer className="hm-drawer-foot">
+            {action ? (
+              <>
+                <button type="button" className="hm-btn hm-btn--action">
+                  {action.primary}
+                </button>
+                {action.secondary ? (
+                  <button type="button" className="hm-btn hm-btn--ghost">
+                    {action.secondary}
+                  </button>
+                ) : null}
+              </>
+            ) : null}
+            <button type="button" className="hm-btn hm-btn--ghost">
+              Ask Hermes
+            </button>
+            <span className="spacer" />
+            <span className="hm-mono hm-muted">j ‹ prev · k › next · esc close</span>
+          </footer>
+        </aside>
+      </div>
+    </FocusTrap>
+  );
+}

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -1,0 +1,229 @@
+// Hermes Handoff Monitor — detail-drawer bodies, one per card type.
+//
+// Each body is driven entirely by real card fields (verdict, files,
+// checks, prompt, verification, mergeStatus, …) — no fabricated CI rows
+// or operator checklists. The mission body is a stub here; the rich
+// browser-mission report lands in M7'.
+
+import type {
+  BoardCard,
+  CardChecks,
+  CardFile,
+  DeployCard,
+  DoneCard,
+  MissionCard,
+} from "../../lib/monitor/card-types.js";
+import { ChecksBar } from "../cards/ChecksBar.js";
+
+export type DrawerVariant = "mission" | "action" | "done" | "draft" | "task" | "deploy" | "pr";
+
+export interface DrawerAccent {
+  /** Border + eyebrow accent variable. */
+  border: string;
+  /** Eyebrow pill class. */
+  pill: string;
+  /** Eyebrow label. */
+  label: string;
+}
+
+export const DRAWER_ACCENT: Record<DrawerVariant, DrawerAccent> = {
+  mission: { border: "var(--hm-hermes)", pill: "hm-pill--hermes", label: "Browser mission · agent report" },
+  action: { border: "var(--hm-amber)", pill: "hm-pill--risk", label: "Operator review · risk decision" },
+  done: { border: "var(--hm-sage)", pill: "hm-pill--ok", label: "Closed · in release history" },
+  draft: { border: "var(--hm-muted)", pill: "hm-pill--draft", label: "Draft · author finishes" },
+  task: { border: "var(--hm-sage)", pill: "hm-pill--neutral", label: "Codex task · awaiting dispatch" },
+  deploy: { border: "var(--hm-sage)", pill: "hm-pill--neutral", label: "Deploying · post-merge verification" },
+  pr: { border: "var(--hm-sage)", pill: "hm-pill--ok", label: "Automation in flight" },
+};
+
+/** Pick the drawer variant. isAction wins, then closed, draft, and type. */
+export function drawerVariant(card: BoardCard): DrawerVariant {
+  if (card.type === "mission") return "mission";
+  if (card.isAction) return "action";
+  if (card.type === "done") return "done";
+  if (card.isDraft) return "draft"; // DraftCard always has isDraft:true; covers PRCards flagged draft too
+  if (card.type === "task") return "task";
+  if (card.type === "deploy") return "deploy";
+  return "pr";
+}
+
+export function DrawerBody({ card, variant }: { card: BoardCard; variant: DrawerVariant }) {
+  switch (variant) {
+    case "mission":
+      return <MissionBody card={card as MissionCard} />;
+    case "done":
+      return <DoneBody card={card as DoneCard} />;
+    case "deploy":
+      return <DeployBody card={card as DeployCard} />;
+    case "task":
+      return <TaskBody card={card} />;
+    case "draft":
+      return <DraftBody card={card} />;
+    default:
+      return <PrBody card={card} />;
+  }
+}
+
+// ── Shared building blocks ──────────────────────────────────────────
+
+function VerdictBlock({ head, children, accent }: { head: string; children: React.ReactNode; accent?: string }) {
+  return (
+    <section>
+      <div className="hm-section-h" style={accent ? { color: accent } : undefined}>
+        {head}
+      </div>
+      <div className="hm-verdict-block">
+        <div className="body">{children}</div>
+      </div>
+    </section>
+  );
+}
+
+function FilesSection({ files }: { files: CardFile[] | undefined }) {
+  if (!files || files.length === 0) return null;
+  return (
+    <section>
+      <div className="hm-section-h">Files &amp; risk signals</div>
+      <div className="hm-files">
+        {files.map((f) => (
+          <div className="row" key={f.path}>
+            <span className="path">{f.path}</span>
+            <span className="diff">{f.diff}</span>
+            {f.critical ? (
+              <span className="hm-pill hm-pill--risk">review-gated</span>
+            ) : (
+              <span className="hm-pill hm-pill--neutral">low-risk</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ChecksSection({ checks }: { checks: CardChecks | undefined }) {
+  if (!checks || checks.total <= 0) return null;
+  return (
+    <section>
+      <div className="hm-section-h">
+        Checks · {checks.pass}/{checks.total} passed
+        {checks.running > 0 ? ` · ${checks.running} running` : ""}
+        {checks.fail > 0 ? ` · ${checks.fail} failed` : ""}
+      </div>
+      <div className="hm-checks">
+        <ChecksBar checks={checks} />
+      </div>
+    </section>
+  );
+}
+
+// ── Per-type bodies ─────────────────────────────────────────────────
+
+function PrBody({ card }: { card: BoardCard }) {
+  const verdict = "verdict" in card ? card.verdict : undefined;
+  const files = "files" in card ? card.files : undefined;
+  return (
+    <>
+      {verdict ? (
+        <VerdictBlock head="Hermes verdict">{verdict}</VerdictBlock>
+      ) : (
+        <VerdictBlock head="Status">{card.summary || "No additional context yet."}</VerdictBlock>
+      )}
+      <FilesSection files={files} />
+      <ChecksSection checks={card.checks} />
+    </>
+  );
+}
+
+function DraftBody({ card }: { card: BoardCard }) {
+  const files = "files" in card ? card.files : undefined;
+  return (
+    <>
+      <VerdictBlock head="Draft — not ready for review" accent="var(--hm-muted)">
+        {card.summary ||
+          "Author hasn't marked this ready. Hermes leaves drafts alone until they're marked ready for review."}
+      </VerdictBlock>
+      <FilesSection files={files} />
+    </>
+  );
+}
+
+function TaskBody({ card }: { card: BoardCard }) {
+  const prompt = "prompt" in card ? card.prompt : undefined;
+  const heartbeat = "runnerHeartbeat" in card ? card.runnerHeartbeat : undefined;
+  return (
+    <>
+      <VerdictBlock head="Proposed Codex task">{card.summary || "Awaiting operator approval to dispatch."}</VerdictBlock>
+      {prompt ? (
+        <section>
+          <div className="hm-section-h">Task prompt</div>
+          <div className="hm-files" style={{ padding: "10px 12px", whiteSpace: "pre-wrap" }}>
+            {prompt}
+          </div>
+        </section>
+      ) : null}
+      {heartbeat ? (
+        <section>
+          <div className="hm-section-h">Runner</div>
+          <div className="hm-verdict-block">
+            <div className="head" style={{ color: heartbeat.online ? "var(--hm-sage-deep)" : "var(--hm-muted)" }}>
+              {heartbeat.online ? "ONLINE" : "OFFLINE"}
+            </div>
+            <div className="body">Last seen {heartbeat.lastSeen}.</div>
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
+}
+
+function DeployBody({ card }: { card: DeployCard }) {
+  const { verification } = card;
+  return (
+    <>
+      <VerdictBlock head="Post-merge verification">{card.summary || "Verifying the deploy."}</VerdictBlock>
+      <section>
+        <div className="hm-section-h">Verification progress</div>
+        <div className="hm-verdict-block">
+          <div className="head">
+            {verification.current}/{verification.total} · {verification.label}
+          </div>
+          <div className="body">Deploy {card.deployId}.</div>
+        </div>
+      </section>
+      <ChecksSection checks={card.checks} />
+    </>
+  );
+}
+
+function DoneBody({ card }: { card: DoneCard }) {
+  return (
+    <VerdictBlock head="Final verdict · release history" accent="var(--hm-sage-deep)">
+      {card.mergeStatus === "MERGED" ? "MERGED" : "CLOSED"} · closed at <b>{card.closedAt}</b>.
+      {card.verdictText ? (
+        <>
+          <br />
+          <br />
+          {card.verdictText}
+        </>
+      ) : null}
+    </VerdictBlock>
+  );
+}
+
+function MissionBody({ card }: { card: MissionCard }) {
+  const m = card.mission;
+  return (
+    <>
+      <VerdictBlock head="Mission verdict" accent="var(--hm-hermes-deep)">
+        {m.verdict} · confidence {m.confidence} · target {m.target}
+      </VerdictBlock>
+      <section>
+        <div className="hm-section-h">Full mission report</div>
+        <div className="hm-files" style={{ padding: "10px 12px", color: "var(--hm-muted)" }}>
+          The full browser-mission report — path, blockers, evidence, mutation boundary, recommendations — lands in M7'.
+        </div>
+      </section>
+    </>
+  );
+}

--- a/packages/monitor-ui/src/hooks/useCardParam.test.tsx
+++ b/packages/monitor-ui/src/hooks/useCardParam.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useCardParam } from "./useCardParam.js";
+
+afterEach(cleanup);
+beforeEach(() => {
+  window.history.replaceState({}, "", "/");
+});
+
+function cardParamInUrl(): string | null {
+  return new URLSearchParams(window.location.search).get("card");
+}
+
+describe("useCardParam", () => {
+  test("starts closed when no ?card= is present", () => {
+    const { result } = renderHook(() => useCardParam());
+    expect(result.current.cardId).toBeNull();
+  });
+
+  test("reads an existing ?card= on mount (URL-decoded)", () => {
+    window.history.replaceState({}, "", "/?card=agent%20%23548");
+    const { result } = renderHook(() => useCardParam());
+    expect(result.current.cardId).toBe("agent #548");
+  });
+
+  test("setCard updates state and pushes the encoded param", () => {
+    const { result } = renderHook(() => useCardParam());
+    act(() => result.current.setCard("agent #548"));
+    expect(result.current.cardId).toBe("agent #548");
+    // URLSearchParams percent-encodes the space + hash.
+    expect(cardParamInUrl()).toBe("agent #548");
+    expect(window.location.search).toContain("card=");
+  });
+
+  test("clearCard removes the param", () => {
+    const { result } = renderHook(() => useCardParam());
+    act(() => result.current.setCard("agent #1"));
+    expect(result.current.cardId).toBe("agent #1");
+    act(() => result.current.clearCard());
+    expect(result.current.cardId).toBeNull();
+    expect(cardParamInUrl()).toBeNull();
+  });
+
+  test("an empty / whitespace id clears rather than sets", () => {
+    const { result } = renderHook(() => useCardParam());
+    act(() => result.current.setCard("   "));
+    expect(result.current.cardId).toBeNull();
+    expect(cardParamInUrl()).toBeNull();
+  });
+
+  test("syncs with browser back/forward via popstate", () => {
+    const { result } = renderHook(() => useCardParam());
+    act(() => {
+      window.history.replaceState({}, "", "/?card=mission%20browser-onboard-04");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    });
+    expect(result.current.cardId).toBe("mission browser-onboard-04");
+  });
+});

--- a/packages/monitor-ui/src/hooks/useCardParam.ts
+++ b/packages/monitor-ui/src/hooks/useCardParam.ts
@@ -1,0 +1,55 @@
+// Hermes Handoff Monitor — focused-card URL state (M6').
+//
+// The detail drawer is driven by the `?card=<id>` query param so a focused
+// card is shareable and survives reload / back-forward. This hook reads
+// that param, exposes setters that push history entries, and stays in
+// sync with the browser's back/forward via popstate.
+//
+// Encode/decode go through the tested drawer-routing helpers; writes use
+// URLSearchParams (which percent-encodes) so card ids with spaces and
+// hashes ("agent #548") round-trip cleanly.
+
+import { useCallback, useEffect, useState } from "react";
+import { decodeCardParam } from "../lib/monitor/drawer-routing.js";
+
+const PARAM = "card";
+
+function readCardParam(): string | null {
+  if (typeof window === "undefined") return null;
+  return decodeCardParam(new URLSearchParams(window.location.search).get(PARAM));
+}
+
+export interface CardParamState {
+  /** The currently focused card id, or null when the drawer is closed. */
+  cardId: string | null;
+  /** Set the focused card (null clears it). Pushes a history entry. */
+  setCard: (id: string | null) => void;
+  /** Convenience for setCard(null). */
+  clearCard: () => void;
+}
+
+export function useCardParam(): CardParamState {
+  const [cardId, setCardId] = useState<string | null>(() => readCardParam());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onPop = () => setCardId(readCardParam());
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  const setCard = useCallback((id: string | null) => {
+    const next = typeof id === "string" && id.trim().length > 0 ? id.trim() : null;
+    if (typeof window !== "undefined") {
+      const url = new URL(window.location.href);
+      if (next) url.searchParams.set(PARAM, next);
+      else url.searchParams.delete(PARAM);
+      window.history.pushState({}, "", url);
+    }
+    setCardId(next);
+  }, []);
+
+  const clearCard = useCallback(() => setCard(null), [setCard]);
+
+  return { cardId, setCard, clearCard };
+}


### PR DESCRIPTION
## Summary
- **M6'** of the Hermes Handoff Monitor redesign: the focused-card **detail drawer**, routed by the `?card=` URL param, with a **focus trap** and **j/k traversal**. Cards are now clickable.
- Uses `focus-trap-react` (the chosen library over a hand-rolled trap).

## What's in it
- **`useCardParam` hook** — reads/writes `?card=` via `history.pushState` + `popstate`, encoding through the tested `drawer-routing` helpers so ids with spaces and hashes (`agent #548`) round-trip cleanly.
- **`DetailDrawer` shell** — scrim + `role="dialog"`/`aria-modal` sheet wrapped in `focus-trap-react`. `returnFocusOnDeactivate` restores focus to the trigger on close; `tabbableOptions.displayCheck: "none"` keeps the trap working under jsdom. **esc** and **scrim click** close; **j/k** traverse the lane-ordered card list via `traverseDrawerCard`.
- **`DrawerBody`** — one body per variant (PR/action, Done, Draft, Codex task, Deploy, + a Mission stub), driven **entirely by real card fields** (verdict, files, checks, prompt, runner heartbeat, verification, mergeStatus). No fabricated CI rows or operator checklists — truth-boundary. The full browser-mission report is deferred to **M7'**.
- **`BoardView`** — cards become clickable (`role="button"` via `onClick`) and open their drawer; **`MonitorPage`** owns `useCardParam` and threads the focused card + open/close/navigate handlers down, keeping `BoardView` presentational.

## Interaction contract (§11)
Click card → `?card=` + drawer · esc → close + restore focus + clear param · scrim click → close · j/k → prev/next card · focus trapped while open.

## Deferred
- Full Mission drawer body + spawn flow → **M7'**
- Working Hermes co-pilot rail → **M8'**
- Drawer action buttons (Approve/Send back/…) are present but inert; wired in a later milestone.

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **260/260** (+`useCardParam`, `DetailDrawer` variants + esc/scrim/close/j-k + focus-into-dialog, `BoardView` drawer wiring, and a `MonitorPage` end-to-end: click → `?card=` + drawer → esc closes + clears)
- [x] `npm test` (full repo) → **594/594**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)