### PR TITLE
monitor-ui: browser mission drawer + spawn flow (M7')

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -95,4 +95,46 @@ describe("MonitorPage — container", () => {
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
     expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
+
+  test("the composer's /mission command reaches the spawn handler", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
+    const onSpawnMission = vi.fn();
+    const { container } = render(
+      <MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} onSpawnMission={onSpawnMission} />,
+      { wrapper },
+    );
+    await waitFor(() => expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy());
+
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "/mission https://staging.averray.com/onboarding" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/onboarding");
+  });
+
+  test("the default spawn POSTs targetUrl to /monitor/testbed-missions", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
+    // The board fetch uses the injected fetcher; defaultSpawnMission uses
+    // the global fetch — so spying on it isolates the spawn call.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
+    try {
+      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+        wrapper,
+      });
+      await waitFor(() =>
+        expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy(),
+      );
+
+      const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+      fireEvent.change(input, { target: { value: "/mission https://x.test/y" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/testbed-missions");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(String(init.body))).toEqual({ targetUrl: "https://x.test/y" });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -1,4 +1,4 @@
-// Hermes Handoff Monitor — board page (M6')
+// Hermes Handoff Monitor — board page (M7')
 //
 // The live data container: wires useMonitorBoard() (SWR fetch of
 // /monitor/v2/board + the SSE LiveStream against /monitor/v2/stream) and
@@ -7,23 +7,32 @@
 // event → applyEventToBoard → SWR cache → re-render; the Refresh button
 // revalidates the HTTP snapshot; clicking a card opens its drawer.
 //
+// The Hermes composer's `/mission <url>` spawns a real browser mission
+// by POSTing to /monitor/testbed-missions; the Playwright runner reports
+// back through the same v2 board feed, so the new mission card appears
+// and updates live.
+//
 // Auth is handled at the edge (Cloudflare Access), so there is no
 // client-side guard here.
 //
 // Deferred, by milestone:
-//   - the working Hermes co-pilot rail → M8'
+//   - the working Hermes narration stream + free-form Q&A → M8'
 //   - the degraded TopStrip ("?" KPIs) → M11'
 
 import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitorBoard.js";
 import { useCardParam } from "./hooks/useCardParam.js";
 import { BoardView } from "./components/BoardView.js";
 
+const MISSIONS_URL = "/monitor/testbed-missions";
+
 export interface MonitorPageProps {
   /** Override the live wiring (fetcher, EventSource, storage) for tests. */
   options?: UseMonitorBoardOptions;
+  /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
+  onSpawnMission?: (url: string) => void;
 }
 
-export function MonitorPage({ options }: MonitorPageProps = {}) {
+export function MonitorPage({ options, onSpawnMission = defaultSpawnMission }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
   const { cardId, setCard, clearCard } = useCardParam();
 
@@ -36,6 +45,24 @@ export function MonitorPage({ options }: MonitorPageProps = {}) {
       onCardClick={setCard}
       onCardClose={clearCard}
       onCardNavigate={setCard}
+      onSpawnMission={onSpawnMission}
     />
   );
+}
+
+/**
+ * Spawn a browser mission against `url`. The slack-operator's
+ * /monitor/testbed-missions runner accepts `{ targetUrl }`, runs a fresh
+ * Playwright agent, and surfaces the result as a mission card on the v2
+ * board — so the spawned card appears and updates through the live feed.
+ * Fire-and-forget: the board feed, not this call, drives the UI.
+ */
+function defaultSpawnMission(url: string): void {
+  void fetch(MISSIONS_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ targetUrl: url }),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
 }

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -27,6 +27,7 @@ import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
 import { DetailDrawer } from "./drawer/DetailDrawer.js";
+import { CoPilotRail } from "./hermes/CoPilotRail.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
 // action preset expands that lane (not operator-review) to keep the
@@ -58,6 +59,10 @@ export interface BoardViewProps {
   onCardClose?: () => void;
   /** j/k traversal target within the drawer. */
   onCardNavigate?: (id: string) => void;
+  /** Spawn a browser mission via the Hermes composer (/mission <url>). */
+  onSpawnMission?: (url: string) => void;
+  /** Ask Hermes a free-form question (M8'). */
+  onAsk?: (text: string) => void;
 }
 
 export function BoardView({
@@ -68,6 +73,8 @@ export function BoardView({
   onCardClick,
   onCardClose,
   onCardNavigate,
+  onSpawnMission,
+  onAsk,
 }: BoardViewProps) {
   // The stream is "degraded" only on a real drop (reconnecting/closed);
   // idle/connecting are pre-live transients, not disconnections. The
@@ -127,7 +134,7 @@ export function BoardView({
           />
         </div>
 
-        <HermesRailPlaceholder />
+        <CoPilotRail onSpawnMission={onSpawnMission} onAsk={onAsk} focusedCardId={focusedCardId} />
       </div>
 
       {focusedCard ? (
@@ -139,36 +146,6 @@ export function BoardView({
         />
       ) : null}
     </div>
-  );
-}
-
-/**
- * Minimal Hermes co-pilot rail chrome so the `.hm-main` two-column grid
- * (1fr | 420px) renders end-to-end. The narrating stream + composer are
- * wired in M8'; this stub only holds the column and the rail header.
- */
-function HermesRailPlaceholder() {
-  return (
-    <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
-      {/* A <div>, not <header>: only the TopStrip is the page banner
-          landmark — the rail's own header must not register as a second. */}
-      <div className="hm-hermes-head">
-        <div className="hm-hermes-mark" aria-hidden>
-          H
-        </div>
-        <div>
-          <div className="hm-hermes-title">Hermes co-pilot</div>
-          <div className="hm-hermes-sub">
-            <span className="pulse" aria-hidden />
-            Live · narrating the board · context: everywhere
-          </div>
-        </div>
-      </div>
-
-      <div className="hm-hermes-stream">
-        <div className="hm-lane-empty">Hermes narration lands in M8'.</div>
-      </div>
-    </aside>
   );
 }
 

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -119,12 +119,29 @@ describe("DetailDrawer — variants", () => {
     expect(getByText(/Coalesce repeated policy-attach entries/)).toBeTruthy();
   });
 
-  test("mission card shows the hermes eyebrow and the M7' deferral note", () => {
+  test("mission card shows the full report — verdict, path, blockers, evidence, boundary, recommendations", () => {
     const card = fixture("mission browser-onboard-04");
-    const { getByText } = render(
+    const { container, getByText } = render(
       <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
     );
     expect(getByText("Browser mission · agent report")).toBeTruthy();
-    expect(getByText(/lands in M7'/)).toBeTruthy();
+    // Verdict + confidence (0.81 → 81%) + scores
+    expect(getByText(/Verdict · run #4/)).toBeTruthy();
+    expect(getByText("PARTIAL")).toBeTruthy();
+    expect(getByText(/81/)).toBeTruthy();
+    // Path steps
+    expect(getByText("Path taken")).toBeTruthy();
+    expect(getByText("Clicked Connect wallet")).toBeTruthy();
+    // Blockers
+    expect(getByText("Sign-message modal latency")).toBeTruthy();
+    // Evidence
+    expect(getByText("Evidence")).toBeTruthy();
+    expect(getByText("step-3-modal-gap.png")).toBeTruthy();
+    // Mutation boundary
+    expect(getByText(/BOUNDARY · enforced/)).toBeTruthy();
+    expect(getByText(/Read-only mission/)).toBeTruthy();
+    // Recommendations
+    expect(getByText("Hermes recommends")).toBeTruthy();
+    expect(container.querySelectorAll(".hm-mpath .step").length).toBe(6);
   });
 });

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -1,9 +1,8 @@
 // Hermes Handoff Monitor — detail-drawer bodies, one per card type.
 //
 // Each body is driven entirely by real card fields (verdict, files,
-// checks, prompt, verification, mergeStatus, …) — no fabricated CI rows
-// or operator checklists. The mission body is a stub here; the rich
-// browser-mission report lands in M7'.
+// checks, prompt, verification, mergeStatus, mission report, …) — no
+// fabricated CI rows or operator checklists.
 
 import type {
   BoardCard,
@@ -213,17 +212,139 @@ function DoneBody({ card }: { card: DoneCard }) {
 
 function MissionBody({ card }: { card: MissionCard }) {
   const m = card.mission;
+  const verdictColor =
+    m.verdictTone === "warn"
+      ? "var(--hm-amber-deep)"
+      : m.verdictTone === "fail"
+        ? "var(--hm-rose)"
+        : "var(--hm-sage-deep)";
+
   return (
     <>
-      <VerdictBlock head="Mission verdict" accent="var(--hm-hermes-deep)">
-        {m.verdict} · confidence {m.confidence} · target {m.target}
-      </VerdictBlock>
       <section>
-        <div className="hm-section-h">Full mission report</div>
-        <div className="hm-files" style={{ padding: "10px 12px", color: "var(--hm-muted)" }}>
-          The full browser-mission report — path, blockers, evidence, mutation boundary, recommendations — lands in M7'.
+        <div className="hm-section-h">
+          Verdict · run #{m.runs} · {m.latency}
+        </div>
+        <div className="hm-mission-confidence">
+          <div className="col">
+            <span className="lbl">Verdict</span>
+            <span className="val" style={{ color: verdictColor }}>
+              {m.verdict}
+            </span>
+            <span className="meta">{m.target}</span>
+          </div>
+          <div className="col">
+            <span className="lbl">Confidence</span>
+            <span className={"val " + (m.confidence < 0.7 ? "warn" : "")}>
+              {Math.round(m.confidence * 100)}
+              <span style={{ fontSize: 14, color: "var(--hm-muted)" }}>%</span>
+            </span>
+            <span className="meta">{m.seed}</span>
+          </div>
+          <div className="col">
+            <span className="lbl">Scores · success · clarity · latency</span>
+            <span className="val">
+              {m.successScore}
+              <span style={{ color: "var(--hm-muted)" }}> · </span>
+              {m.clarityScore}
+              <span style={{ color: "var(--hm-muted)" }}> · </span>
+              {m.latencyScore}
+            </span>
+            <span className="meta">out of 10 · by Hermes</span>
+          </div>
         </div>
       </section>
+
+      {m.path.length > 0 ? (
+        <section>
+          <div className="hm-section-h">Path taken</div>
+          <div className="hm-mpath">
+            {m.path.map((step) => (
+              <div className={"step " + step.status} key={step.n}>
+                <span className="n">{step.n}</span>
+                <span className="desc">{step.desc}</span>
+                <span className="lat">{step.lat}</span>
+                <span
+                  className={
+                    "hm-pill " +
+                    (step.status === "ok" ? "hm-pill--ok" : step.status === "warn" ? "hm-pill--running" : "hm-pill--err")
+                  }
+                >
+                  {step.status === "ok" ? "pass" : step.status === "warn" ? "slow" : "fail"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {m.blockers.length > 0 ? (
+        <section>
+          <div className="hm-section-h">Blockers · confusing moments</div>
+          <div style={{ display: "grid", gap: 10 }}>
+            {m.blockers.map((b, i) => (
+              <div className="hm-mblock" key={i}>
+                <div className="head">{b.head}</div>
+                <div className="body">{b.body}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {m.evidence.length > 0 ? (
+        <section>
+          <div className="hm-section-h">Evidence</div>
+          <div className="hm-evidence">
+            {m.evidence.map((e, i) => {
+              const hasLink = typeof e.href === "string" && e.href.length > 0 && e.href !== "#";
+              return (
+                <div className="row" key={i}>
+                  <span className="kind">{e.kind}</span>
+                  {hasLink ? (
+                    <a href={e.href} target="_blank" rel="noreferrer">
+                      {e.label}
+                    </a>
+                  ) : (
+                    <span>{e.label}</span>
+                  )}
+                  {hasLink ? <span style={{ color: "var(--hm-muted)" }}>open ↗</span> : null}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      <section>
+        <div className="hm-section-h">Mutation boundary</div>
+        <div
+          className="hm-verdict-block"
+          style={{ background: "var(--hm-hermes-soft)", borderColor: "rgba(15,107,90,0.18)" }}
+        >
+          <div className="head" style={{ color: "var(--hm-hermes-deep)" }}>
+            BOUNDARY · enforced
+          </div>
+          <div className="body">{m.mutationBoundary}</div>
+        </div>
+      </section>
+
+      {m.recommendations.length > 0 ? (
+        <section>
+          <div className="hm-section-h">Hermes recommends</div>
+          <div className="hm-checklist">
+            {m.recommendations.map((r, i) => (
+              <div className="row" key={i}>
+                <span className="box" style={{ borderColor: "var(--hm-hermes)", color: "transparent" }}>
+                  ✓
+                </span>
+                <span>{r}</span>
+                <span className="hint">→ codex</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
     </>
   );
 }

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { AskHermesComposer } from "./AskHermesComposer.js";
+
+afterEach(cleanup);
+
+function type(el: HTMLElement, value: string) {
+  fireEvent.change(el, { target: { value } });
+}
+
+describe("AskHermesComposer", () => {
+  test("/mission <url> spawns a mission and clears the input", () => {
+    const onSpawnMission = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/mission https://staging.averray.com/onboarding");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/onboarding");
+    expect(input.value).toBe("");
+  });
+
+  test("Enter sends; Shift+Enter does not", () => {
+    const onSpawnMission = vi.fn();
+    const { container } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+
+    type(input, "/mission https://x.test/a");
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(onSpawnMission).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSpawnMission).toHaveBeenCalledWith("https://x.test/a");
+  });
+
+  test("/mission with no URL shows an error and does not spawn", () => {
+    const onSpawnMission = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/mission");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onSpawnMission).not.toHaveBeenCalled();
+    expect(within(container).getByRole("alert").textContent).toMatch(/needs a target URL/);
+    // The bad input is preserved so the operator can fix it.
+    expect(input.value).toBe("/mission");
+  });
+
+  test("a plain question calls onAsk when a handler is provided", () => {
+    const onAsk = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onAsk={onAsk} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "what's blocking #548?");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onAsk).toHaveBeenCalledWith("what's blocking #548?");
+    expect(input.value).toBe("");
+  });
+
+  test("a plain question without an onAsk handler surfaces the M8' hint", () => {
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={vi.fn()} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "hello hermes");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(within(container).getByRole("alert").textContent).toMatch(/lands in M8'/);
+  });
+
+  test("the scope chip reflects the focused card", () => {
+    const { getByText } = render(<AskHermesComposer focusedCardId="agent #548" />);
+    expect(getByText("scope · agent #548")).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -1,0 +1,91 @@
+// Hermes Handoff Monitor — Ask-Hermes composer (M7').
+//
+// A single text input that doubles as a command line. `/mission <url>`
+// spawns a browser mission; anything else is a question for Hermes.
+// Enter sends, Shift+Enter inserts a newline. Parsing lives in the pure
+// hermes-commands helper; this component owns only input + dispatch.
+//
+// In M7' the mission-spawn path is wired end-to-end; the free-form "ask
+// Hermes" reply stream is M8'. When no onAsk handler is supplied, a plain
+// message surfaces a short hint rather than silently doing nothing.
+
+import { useState, type KeyboardEvent } from "react";
+import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
+
+export interface AskHermesComposerProps {
+  /** Spawn a browser mission against a URL (/mission <url>). */
+  onSpawnMission?: (url: string) => void;
+  /** Ask Hermes a free-form question (M8'). */
+  onAsk?: (text: string) => void;
+  /** Focused card id, shown in the scope chip. */
+  focusedCardId?: string | null;
+}
+
+export function AskHermesComposer({ onSpawnMission, onAsk, focusedCardId }: AskHermesComposerProps) {
+  const [value, setValue] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const send = () => {
+    const command = parseHermesInput(value);
+    switch (command.kind) {
+      case "empty":
+        return;
+      case "error":
+        setError(command.message);
+        return;
+      case "mission":
+        onSpawnMission?.(command.url);
+        setValue("");
+        setError(null);
+        return;
+      case "ask":
+        if (onAsk) {
+          onAsk(command.text);
+          setValue("");
+          setError(null);
+        } else {
+          setError("Ask Hermes lands in M8'. For now: /mission <url> spawns a browser mission.");
+        }
+        return;
+    }
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  return (
+    <div className="hm-compose">
+      <div className="hm-compose-toolbar">
+        <span className="hm-compose-chip is-on">to · operator</span>
+        <span className="hm-compose-chip">intent · mission spawn</span>
+        <span className="hm-compose-chip">scope · {focusedCardId ?? "board"}</span>
+        <span style={{ marginLeft: "auto", color: "var(--hm-muted-soft)" }}>⏎ send · ⇧⏎ newline</span>
+      </div>
+      <div className="hm-compose-row">
+        <textarea
+          className="hm-compose-input"
+          placeholder="Ask Hermes, or spawn a mission · /mission https://staging.averray.com/onboarding"
+          aria-label="Ask Hermes or spawn a browser mission"
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={onKeyDown}
+        />
+        <button type="button" className="hm-compose-send" onClick={send}>
+          Send <span className="hm-kbd">⏎</span>
+        </button>
+      </div>
+      {error ? (
+        <div className="hm-compose-error" role="alert" style={{ color: "var(--hm-rose)", fontSize: 12, marginTop: 6 }}>
+          {error}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -1,0 +1,41 @@
+// Hermes Handoff Monitor — co-pilot rail (M7' shell).
+//
+// The right-hand rail: header + (M8') narration stream + the Ask-Hermes
+// composer. M7' wires the composer's /mission spawn flow; the live
+// card-stream narration and free-form Q&A land in M8', filling the
+// stream region that is a stub here.
+
+import { AskHermesComposer } from "./AskHermesComposer.js";
+
+export interface CoPilotRailProps {
+  onSpawnMission?: (url: string) => void;
+  onAsk?: (text: string) => void;
+  focusedCardId?: string | null;
+}
+
+export function CoPilotRail({ onSpawnMission, onAsk, focusedCardId }: CoPilotRailProps) {
+  return (
+    <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
+      {/* A <div>, not <header>: only the TopStrip is the page banner
+          landmark — the rail's own header must not register as a second. */}
+      <div className="hm-hermes-head">
+        <div className="hm-hermes-mark" aria-hidden>
+          H
+        </div>
+        <div>
+          <div className="hm-hermes-title">Hermes co-pilot</div>
+          <div className="hm-hermes-sub">
+            <span className="pulse" aria-hidden />
+            Live · narrating the board · context: {focusedCardId ?? "everywhere"}
+          </div>
+        </div>
+      </div>
+
+      <div className="hm-hermes-stream">
+        <div className="hm-lane-empty">Board narration lands in M8'.</div>
+      </div>
+
+      <AskHermesComposer onSpawnMission={onSpawnMission} onAsk={onAsk} focusedCardId={focusedCardId} />
+    </aside>
+  );
+}

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
@@ -1,0 +1,58 @@
+import { test, assert } from "vitest";
+
+import { parseHermesInput } from "./hermes-commands.js";
+
+test("parseHermesInput: /mission with a valid https URL → mission", () => {
+  assert.deepEqual(parseHermesInput("/mission https://staging.averray.com/onboarding"), {
+    kind: "mission",
+    url: "https://staging.averray.com/onboarding",
+  });
+});
+
+test("parseHermesInput: http and localhost URLs are accepted", () => {
+  assert.deepEqual(parseHermesInput("/mission http://localhost:5173/claim"), {
+    kind: "mission",
+    url: "http://localhost:5173/claim",
+  });
+});
+
+test("parseHermesInput: case-insensitive command + surrounding whitespace", () => {
+  assert.deepEqual(parseHermesInput("   /MISSION   https://x.test/y  "), {
+    kind: "mission",
+    url: "https://x.test/y",
+  });
+});
+
+test("parseHermesInput: only the first token is taken as the URL", () => {
+  assert.deepEqual(parseHermesInput("/mission https://x.test/y and then check the footer"), {
+    kind: "mission",
+    url: "https://x.test/y",
+  });
+});
+
+test("parseHermesInput: /mission with no URL → error", () => {
+  const out = parseHermesInput("/mission");
+  assert.equal(out.kind, "error");
+});
+
+test("parseHermesInput: /mission with a non-URL arg → error", () => {
+  const out = parseHermesInput("/mission staging.averray.com");
+  assert.equal(out.kind, "error");
+});
+
+test("parseHermesInput: plain text → ask", () => {
+  assert.deepEqual(parseHermesInput("what's blocking #548?"), {
+    kind: "ask",
+    text: "what's blocking #548?",
+  });
+});
+
+test("parseHermesInput: empty / whitespace → empty", () => {
+  assert.equal(parseHermesInput("").kind, "empty");
+  assert.equal(parseHermesInput("   ").kind, "empty");
+  assert.equal(parseHermesInput(undefined as unknown as string).kind, "empty");
+});
+
+test("parseHermesInput: a word starting with mission but not the command is an ask", () => {
+  assert.equal(parseHermesInput("missionary work").kind, "ask");
+});

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
@@ -1,0 +1,35 @@
+// Hermes Handoff Monitor — co-pilot composer command parsing (M7').
+//
+// The Hermes composer is a single text input that doubles as a command
+// line. `/mission <url>` spawns a browser mission against a live URL;
+// anything else is a question routed to Hermes. Parsing lives here as a
+// pure function so the composer stays dumb and the contract is tested.
+
+export type HermesCommand =
+  | { kind: "mission"; url: string }
+  | { kind: "ask"; text: string }
+  | { kind: "error"; message: string }
+  | { kind: "empty" };
+
+const MISSION_RE = /^\/mission\b\s*(.*)$/is;
+const URL_RE = /^https?:\/\/\S+$/i;
+
+export function parseHermesInput(raw: string): HermesCommand {
+  const text = (raw ?? "").trim();
+  if (!text) return { kind: "empty" };
+
+  const m = MISSION_RE.exec(text);
+  if (m) {
+    const arg = (m[1] ?? "").trim();
+    if (!arg) {
+      return { kind: "error", message: "/mission needs a target URL, e.g. /mission https://staging.averray.com/onboarding" };
+    }
+    const url = arg.split(/\s+/)[0] ?? "";
+    if (!URL_RE.test(url)) {
+      return { kind: "error", message: `"${url}" is not a valid http(s) URL.` };
+    }
+    return { kind: "mission", url };
+  }
+
+  return { kind: "ask", text };
+}

--- a/packages/monitor-ui/src/lib/monitor/index.ts
+++ b/packages/monitor-ui/src/lib/monitor/index.ts
@@ -14,4 +14,5 @@ export * from "./board-cache.js";
 export * from "./drawer-routing.js";
 export * from "./snapshot-store.js";
 export * from "./live-stream.js";
+export * from "./hermes-commands.js";
 export * from "./fixtures.js";


### PR DESCRIPTION
## Summary
- **M7'** of the Hermes Handoff Monitor redesign: the full **browser-mission drawer body** (replacing the M6' stub) plus the **`/mission <url>` spawn flow** in the Hermes composer.

## Mission drawer body (`DrawerBody`)
Driven entirely by `card.mission`:
- **Verdict** + **confidence** (0–1 → %) + **success / clarity / latency** scores
- **Path taken** — each step with a pass / slow / fail pill
- **Blockers** (confusing moments), **Evidence** (linked only when there's a real `href`; otherwise plain text — no dead `#` links), the enforced **mutation boundary**, and Hermes's **recommendations**
- Dropped the design bundle's prototype `<details>` spec block (non-data) and fixed its `claritScore` typo.

## Hermes composer + rail
- **`hermes-commands.parseHermesInput()`** — pure parser: `/mission <url>` (requires an http(s) URL) vs ask vs error vs empty.
- **`AskHermesComposer`** — textarea command line; **Enter** sends, **Shift+Enter** newline; `/mission` spawns, plain text asks (M8'), a bad `/mission` shows an inline error.
- Extracted the rail into **`CoPilotRail`** (header + M8' stream stub + composer), replacing `BoardView`'s inline placeholder.

## Spawn wiring — a *real* end-to-end spawn
`/mission <url>` POSTs `{ targetUrl }` to **`/monitor/testbed-missions`** — the existing Playwright mission runner — which reports back as a `mission`-type card on the same v2 board feed. So the spawned card **appears and updates live** through the SSE pipeline (no debug shim). `MonitorPage` owns the default spawn (injectable for tests).

## Deferred
- The Hermes **narration stream** + free-form **Q&A reply** → **M8'** (the stream region is a stub).
- Drawer/footer action buttons remain inert (wired later).
- Note: mission-spawn auth (admin OR `mission-operator` per §21.5) is a backend role check on `/monitor/testbed-missions`, separate from this frontend wiring.

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **277/277** (hermes-commands parse matrix, `AskHermesComposer` spawn/ask/error/Enter, the rich `MissionBody` via the drawer, and `MonitorPage` spawn integration — composer → handler, plus the default POST to `/monitor/testbed-missions`)
- [x] `npm test` (full repo) → **611/611**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)