### PR TITLE
monitor v2: gate mission spawn behind an admin / mission-operator role (§21.5)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -91,6 +91,11 @@ SLACK_OPERATOR_SAFE_WORK_SCAN_INTERVAL_MINUTES=0
 SLACK_OPERATOR_SAFE_WORK_NOTIFY_ONLY_ON_AVAILABLE=1
 SLACK_OPERATOR_MONITOR_ENABLED=0
 SLACK_OPERATOR_MONITOR_TOKEN=
+# Mission-spawn role gate (§21.5). Comma/space-separated Cloudflare Access
+# emails allowed to POST /monitor/testbed-missions. Leave both empty to keep
+# mission spawn unrestricted (relies on the edge gate + token only).
+SLACK_OPERATOR_MONITOR_ADMIN_EMAILS=
+SLACK_OPERATOR_MONITOR_MISSION_OPERATOR_EMAILS=
 AVERRAY_HANDOFF_EVENTS_PATH=/data/handoff-events.jsonl
 SLACK_ALLOWED_USER_IDS=
 POLICY_CONFIG_PATH=/config/policy.yaml

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -48,6 +48,11 @@ import {
   spawnDebugCard,
 } from "./monitor-v2-debug.js";
 import {
+  authorizeMissionSpawn,
+  missionSpawnRestricted,
+  parseMissionSpawnRoles,
+} from "./monitor-mission-roles.js";
+import {
   decideHermesBoardNarration,
   fallbackHermesBoardNarration,
   relatedPrForHermesBoardNarration,
@@ -103,6 +108,7 @@ const authConfig = {
 };
 const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedChannelIds);
 const monitorConfig = parseMonitorConfig(process.env);
+const missionSpawnRoles = parseMissionSpawnRoles(process.env);
 const monitorNarrationMinIntervalMs = Math.max(
   5_000,
   Number.parseInt(optionalEnv("HERMES_MONITOR_NARRATION_MIN_INTERVAL_MS", "30000"), 10) || 30_000
@@ -189,6 +195,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       monitor: {
         enabled: monitorConfig.enabled,
         tokenProtected: Boolean(monitorConfig.token),
+        missionSpawnRestricted: missionSpawnRestricted(missionSpawnRoles),
         paths: monitorConfig.enabled ? [
           "/monitor",
           "/monitor/events",
@@ -375,6 +382,14 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     }
     if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
       writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    // §21.5: spawning a browser mission needs an admin or mission-operator
+    // role on top of the edge gate. Opt-in — unrestricted until allowlists
+    // are configured.
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "mission_spawn_forbidden", reason: missionVerdict.reason });
       return;
     }
     await handleMonitorTestbedMissionRequest(request, response);

--- a/services/slack-operator/src/monitor-mission-roles.ts
+++ b/services/slack-operator/src/monitor-mission-roles.ts
@@ -1,0 +1,93 @@
+// Hermes Handoff Monitor — mission-spawn role gate (§21.5).
+//
+// Spawning a browser mission (POST /monitor/testbed-missions) actuates a
+// real Playwright agent against a live URL, so it is gated to an admin or
+// a dedicated "mission-operator" role — over and above the Cloudflare
+// Access edge gate + optional bearer token that already protect every
+// /monitor route.
+//
+// Identity comes from the `Cf-Access-Authenticated-User-Email` header
+// that Cloudflare Access injects after authenticating the request. The
+// gate is OPT-IN: with no allowlists configured it is a no-op (the
+// endpoint behaves exactly as before), matching the token convention in
+// monitor.ts where an unset token means "no extra gate." Configure
+// either allowlist to switch enforcement on.
+//
+// Trust model: this matches the existing posture — the origin trusts
+// headers set by Cloudflare Access and must not be directly reachable.
+// Verifying the `Cf-Access-Jwt-Assertion` signature against Cloudflare's
+// JWKS would be strictly stronger defense-in-depth; that is a deliberate
+// future hardening, noted here so the boundary is explicit.
+
+const ADMIN_ENV = "SLACK_OPERATOR_MONITOR_ADMIN_EMAILS";
+const OPERATOR_ENV = "SLACK_OPERATOR_MONITOR_MISSION_OPERATOR_EMAILS";
+const IDENTITY_HEADER = "cf-access-authenticated-user-email";
+
+export interface MissionSpawnRoles {
+  /** Lower-cased admin emails allowed to spawn missions. */
+  admins: string[];
+  /** Lower-cased mission-operator emails allowed to spawn missions. */
+  operators: string[];
+}
+
+export type MissionSpawnReason = "unrestricted" | "admin" | "mission-operator" | "no_identity" | "role_required";
+
+export interface MissionSpawnVerdict {
+  allowed: boolean;
+  reason: MissionSpawnReason;
+  identity?: string;
+}
+
+/** Parse the admin / mission-operator allowlists from the environment. */
+export function parseMissionSpawnRoles(env: NodeJS.ProcessEnv): MissionSpawnRoles {
+  return {
+    admins: parseEmailList(env[ADMIN_ENV]),
+    operators: parseEmailList(env[OPERATOR_ENV]),
+  };
+}
+
+/** True once either allowlist is non-empty — i.e. the gate is enforcing. */
+export function missionSpawnRestricted(roles: MissionSpawnRoles): boolean {
+  return roles.admins.length > 0 || roles.operators.length > 0;
+}
+
+/** The Cloudflare-Access identity on a request, lower-cased, or undefined. */
+export function missionSpawnIdentity(
+  headers: Record<string, string | string[] | undefined>,
+): string | undefined {
+  const raw = headers[IDENTITY_HEADER];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  const trimmed = typeof value === "string" ? value.trim().toLowerCase() : "";
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Decide whether a request may spawn a mission.
+ *   - no allowlists configured → allowed (unrestricted; legacy behaviour)
+ *   - allowlists set but no identity header → denied (no_identity)
+ *   - identity in admins → allowed (admin)
+ *   - identity in operators → allowed (mission-operator)
+ *   - otherwise → denied (role_required)
+ */
+export function authorizeMissionSpawn(
+  roles: MissionSpawnRoles,
+  headers: Record<string, string | string[] | undefined>,
+): MissionSpawnVerdict {
+  if (!missionSpawnRestricted(roles)) return { allowed: true, reason: "unrestricted" };
+
+  const identity = missionSpawnIdentity(headers);
+  if (!identity) return { allowed: false, reason: "no_identity" };
+  if (roles.admins.includes(identity)) return { allowed: true, reason: "admin", identity };
+  if (roles.operators.includes(identity)) return { allowed: true, reason: "mission-operator", identity };
+  return { allowed: false, reason: "role_required", identity };
+}
+
+function parseEmailList(value: string | undefined): string[] {
+  if (typeof value !== "string") return [];
+  const seen = new Set<string>();
+  for (const part of value.split(/[,;\s]+/)) {
+    const email = part.trim().toLowerCase();
+    if (email) seen.add(email);
+  }
+  return [...seen];
+}

--- a/test/unit/monitor-mission-roles.test.ts
+++ b/test/unit/monitor-mission-roles.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authorizeMissionSpawn,
+  missionSpawnIdentity,
+  missionSpawnRestricted,
+  parseMissionSpawnRoles,
+  type MissionSpawnRoles,
+} from "../../services/slack-operator/src/monitor-mission-roles.js";
+
+const ADMIN_ENV = "SLACK_OPERATOR_MONITOR_ADMIN_EMAILS";
+const OPERATOR_ENV = "SLACK_OPERATOR_MONITOR_MISSION_OPERATOR_EMAILS";
+
+function header(email?: string): Record<string, string | string[] | undefined> {
+  return email ? { "cf-access-authenticated-user-email": email } : {};
+}
+
+describe("parseMissionSpawnRoles", () => {
+  it("returns empty allowlists when unset", () => {
+    expect(parseMissionSpawnRoles({})).toEqual({ admins: [], operators: [] });
+  });
+
+  it("splits on commas / semicolons / whitespace, lower-cases, trims, and dedupes", () => {
+    const roles = parseMissionSpawnRoles({
+      [ADMIN_ENV]: "Alice@averray.com, alice@averray.com ; BOB@averray.com",
+      [OPERATOR_ENV]: "carol@averray.com\n dave@averray.com",
+    });
+    expect(roles.admins).toEqual(["alice@averray.com", "bob@averray.com"]);
+    expect(roles.operators).toEqual(["carol@averray.com", "dave@averray.com"]);
+  });
+});
+
+describe("missionSpawnRestricted", () => {
+  it("is false only when both allowlists are empty", () => {
+    expect(missionSpawnRestricted({ admins: [], operators: [] })).toBe(false);
+    expect(missionSpawnRestricted({ admins: ["a@x.com"], operators: [] })).toBe(true);
+    expect(missionSpawnRestricted({ admins: [], operators: ["o@x.com"] })).toBe(true);
+  });
+});
+
+describe("missionSpawnIdentity", () => {
+  it("reads and lower-cases the Cloudflare Access email header", () => {
+    expect(missionSpawnIdentity(header("Alice@Averray.com"))).toBe("alice@averray.com");
+  });
+  it("handles array-valued headers and absence", () => {
+    expect(missionSpawnIdentity({ "cf-access-authenticated-user-email": ["x@y.com"] })).toBe("x@y.com");
+    expect(missionSpawnIdentity({})).toBeUndefined();
+    expect(missionSpawnIdentity({ "cf-access-authenticated-user-email": "   " })).toBeUndefined();
+  });
+});
+
+describe("authorizeMissionSpawn", () => {
+  const restricted: MissionSpawnRoles = { admins: ["admin@averray.com"], operators: ["op@averray.com"] };
+
+  it("allows everyone when no allowlists are configured (opt-in gate)", () => {
+    const verdict = authorizeMissionSpawn({ admins: [], operators: [] }, header());
+    expect(verdict).toEqual({ allowed: true, reason: "unrestricted" });
+  });
+
+  it("allows an admin", () => {
+    expect(authorizeMissionSpawn(restricted, header("admin@averray.com"))).toEqual({
+      allowed: true,
+      reason: "admin",
+      identity: "admin@averray.com",
+    });
+  });
+
+  it("allows a mission-operator", () => {
+    expect(authorizeMissionSpawn(restricted, header("op@averray.com"))).toEqual({
+      allowed: true,
+      reason: "mission-operator",
+      identity: "op@averray.com",
+    });
+  });
+
+  it("is case-insensitive on the identity", () => {
+    expect(authorizeMissionSpawn(restricted, header("ADMIN@averray.com")).allowed).toBe(true);
+  });
+
+  it("denies an authenticated identity that holds no role", () => {
+    expect(authorizeMissionSpawn(restricted, header("stranger@averray.com"))).toEqual({
+      allowed: false,
+      reason: "role_required",
+      identity: "stranger@averray.com",
+    });
+  });
+
+  it("denies when restricted but no identity header is present", () => {
+    expect(authorizeMissionSpawn(restricted, header())).toEqual({ allowed: false, reason: "no_identity" });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds the **in-app role gate** on the mission-spawn endpoint that §21.5 calls for. Spawning a browser mission (`POST /monitor/testbed-missions`) actuates a real Playwright agent against a live URL, so it now requires an **admin** or **mission-operator** role on top of the Cloudflare Access edge gate + optional bearer token.
- This is the backend follow-up to M7' (which wired the frontend `/mission <url>` to this endpoint).

## Design
- **New `monitor-mission-roles.ts`** — parses two allowlists (`SLACK_OPERATOR_MONITOR_ADMIN_EMAILS`, `SLACK_OPERATOR_MONITOR_MISSION_OPERATOR_EMAILS`) and authorizes a request against the `Cf-Access-Authenticated-User-Email` identity Cloudflare Access injects.
- **Opt-in**, mirroring the existing token convention (unset token ⇒ no extra gate): with both allowlists empty the gate is a **no-op**, so existing deployments are unaffected until they configure it. Configure either list to switch enforcement on.
- **`index.ts`** — the `POST` handler returns `403 mission_spawn_forbidden` with a `reason` (`no_identity` | `role_required`) when denied. The `/health` monitor block now reports **`missionSpawnRestricted`** so the gate's state is observable, not silently assumed (truth-boundary).
- Documented both env vars in `ops/.env.example`.

## Verdict matrix
| state | result |
|---|---|
| no allowlists configured | allowed · `unrestricted` |
| restricted, identity in admins | allowed · `admin` |
| restricted, identity in operators | allowed · `mission-operator` |
| restricted, identity not listed | **403** · `role_required` |
| restricted, no identity header | **403** · `no_identity` |

## Trust model / future hardening
Matches the existing posture: the origin trusts headers set by Cloudflare Access and must not be directly reachable. Verifying the `Cf-Access-Jwt-Assertion` signature against Cloudflare's JWKS would be strictly stronger defense-in-depth — noted in-code as deliberate future work so the boundary is explicit.

## Test plan
- [x] `npx vitest run test/unit/monitor-mission-roles.test.ts` → **11/11** (parse/dedup/case, restricted toggle, identity header incl. array form, allow admin/operator, deny `role_required`/`no_identity`, unrestricted default)
- [x] `npm test` (full repo) → **622/622**
- [x] `npm run typecheck` → clean
- [x] `npm run build` (`tsc -b`) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)