### PR TITLE
monitor-ui: Hermes co-pilot rail (M8')

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe("MonitorPage — container", () => {
   test("wires fetched live board data into the BoardView", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
-    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
       wrapper,
     });
 
@@ -64,7 +64,7 @@ describe("MonitorPage — container", () => {
 
   test("clicking a card opens the drawer and sets ?card=; esc closes it and clears the param", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
-    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
       wrapper,
     });
 
@@ -86,7 +86,7 @@ describe("MonitorPage — container", () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => {
       throw new Error("no backend");
     });
-    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
       wrapper,
     });
 
@@ -100,7 +100,7 @@ describe("MonitorPage — container", () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
     const onSpawnMission = vi.fn();
     const { container } = render(
-      <MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} onSpawnMission={onSpawnMission} />,
+      <MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} onSpawnMission={onSpawnMission} collaboration={{ enabled: false }} />,
       { wrapper },
     );
     await waitFor(() => expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy());
@@ -117,7 +117,7 @@ describe("MonitorPage — container", () => {
     // the global fetch — so spying on it isolates the spawn call.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
     try {
-      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} />, {
+      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
         wrapper,
       });
       await waitFor(() =>

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -1,11 +1,13 @@
-// Hermes Handoff Monitor — board page (M7')
+// Hermes Handoff Monitor — board page (M8')
 //
 // The live data container: wires useMonitorBoard() (SWR fetch of
-// /monitor/v2/board + the SSE LiveStream against /monitor/v2/stream) and
-// useCardParam() (the ?card= drawer route) to the presentational
-// <BoardView>. A spawned/updated card on the SSE feed flows
-// event → applyEventToBoard → SWR cache → re-render; the Refresh button
-// revalidates the HTTP snapshot; clicking a card opens its drawer.
+// /monitor/v2/board + the SSE LiveStream against /monitor/v2/stream),
+// useCardParam() (the ?card= drawer route), and the co-pilot rail's
+// collaboration feed to the presentational <BoardView>. A spawned/updated
+// card on the SSE feed flows event → applyEventToBoard → SWR cache →
+// re-render; the Refresh button revalidates; clicking a card opens its
+// drawer; the rail polls /monitor/collaboration and posts scoped
+// questions.
 //
 // The Hermes composer's `/mission <url>` spawns a real browser mission
 // by POSTing to /monitor/testbed-missions; the Playwright runner reports
@@ -16,11 +18,11 @@
 // client-side guard here.
 //
 // Deferred, by milestone:
-//   - the working Hermes narration stream + free-form Q&A → M8'
 //   - the degraded TopStrip ("?" KPIs) → M11'
 
 import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitorBoard.js";
 import { useCardParam } from "./hooks/useCardParam.js";
+import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { BoardView } from "./components/BoardView.js";
 
 const MISSIONS_URL = "/monitor/testbed-missions";
@@ -30,9 +32,15 @@ export interface MonitorPageProps {
   options?: UseMonitorBoardOptions;
   /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
   onSpawnMission?: (url: string) => void;
+  /** Override the co-pilot collaboration wiring (defaults to live polling). */
+  collaboration?: UseCollaborationOptions;
 }
 
-export function MonitorPage({ options, onSpawnMission = defaultSpawnMission }: MonitorPageProps = {}) {
+export function MonitorPage({
+  options,
+  onSpawnMission = defaultSpawnMission,
+  collaboration = {},
+}: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
   const { cardId, setCard, clearCard } = useCardParam();
 
@@ -46,6 +54,7 @@ export function MonitorPage({ options, onSpawnMission = defaultSpawnMission }: M
       onCardClose={clearCard}
       onCardNavigate={setCard}
       onSpawnMission={onSpawnMission}
+      collaboration={collaboration}
     />
   );
 }

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -28,6 +28,7 @@ import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
 import { DetailDrawer } from "./drawer/DetailDrawer.js";
 import { CoPilotRail } from "./hermes/CoPilotRail.js";
+import type { UseCollaborationOptions } from "../hooks/useCollaboration.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
 // action preset expands that lane (not operator-review) to keep the
@@ -61,8 +62,8 @@ export interface BoardViewProps {
   onCardNavigate?: (id: string) => void;
   /** Spawn a browser mission via the Hermes composer (/mission <url>). */
   onSpawnMission?: (url: string) => void;
-  /** Ask Hermes a free-form question (M8'). */
-  onAsk?: (text: string) => void;
+  /** Co-pilot collaboration wiring. Omit to keep the rail inert. */
+  collaboration?: UseCollaborationOptions;
 }
 
 export function BoardView({
@@ -74,7 +75,7 @@ export function BoardView({
   onCardClose,
   onCardNavigate,
   onSpawnMission,
-  onAsk,
+  collaboration,
 }: BoardViewProps) {
   // The stream is "degraded" only on a real drop (reconnecting/closed);
   // idle/connecting are pre-live transients, not disconnections. The
@@ -134,7 +135,7 @@ export function BoardView({
           />
         </div>
 
-        <CoPilotRail onSpawnMission={onSpawnMission} onAsk={onAsk} focusedCardId={focusedCardId} />
+        <CoPilotRail onSpawnMission={onSpawnMission} focusedCard={focusedCard} collaboration={collaboration} />
       </div>
 
       {focusedCard ? (

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ReactNode } from "react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { CoPilotRail } from "./CoPilotRail.js";
+import { FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { CollaborationMessage } from "../../lib/monitor/collaboration.js";
+
+afterEach(cleanup);
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
+
+function msg(id: string, author: CollaborationMessage["author"], text: string): CollaborationMessage {
+  return { id, ts: Date.parse("2026-05-28T10:00:00Z"), author, kind: "chat", text, addressedTo: "everyone" };
+}
+
+const card548 = FIXTURE_CARDS.find((c) => c.id === "agent #548") as BoardCard;
+
+describe("CoPilotRail", () => {
+  test("renders the collaboration feed as turns", async () => {
+    const fetcher = vi.fn(async () => [msg("1", "hermes", "Pre-check passed on #548.")]);
+    const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
+    await waitFor(() => expect(within(container).getByText("Pre-check passed on #548.")).toBeTruthy());
+  });
+
+  test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
+    const { getByText } = render(<CoPilotRail />, { wrapper });
+    expect(getByText("No board chatter yet.")).toBeTruthy();
+  });
+
+  test("the scope chip reflects the focused card", async () => {
+    const { getByText } = render(
+      <CoPilotRail focusedCard={card548} collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }} />,
+      { wrapper },
+    );
+    expect(getByText("scope · agent #548")).toBeTruthy();
+  });
+
+  test("asking a question scoped to the focused card posts relatedPr and renders the reply", async () => {
+    let turns: CollaborationMessage[] = [];
+    const fetcher = vi.fn(async () => turns);
+    const poster = vi.fn(async () => {
+      turns = [msg("q", "operator", "what's blocking?"), msg("a", "hermes", "CI is still running — 1 check left.")];
+    });
+
+    const { container } = render(
+      <CoPilotRail focusedCard={card548} collaboration={{ fetcher, poster, refreshIntervalMs: 0 }} />,
+      { wrapper },
+    );
+    await waitFor(() => expect(within(container).getByText("No board chatter yet.")).toBeTruthy());
+
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "what's blocking?" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(poster).toHaveBeenCalledWith({
+      text: "what's blocking?",
+      relatedPr: { repo: "depre-dev/agent", number: 548 },
+    });
+    // Hermes's reply lands on the revalidate triggered by ask().
+    await waitFor(() =>
+      expect(within(container).getByText("CI is still running — 1 check left.")).toBeTruthy(),
+    );
+  });
+
+  test("/mission spawn still flows through the composer", () => {
+    const onSpawnMission = vi.fn();
+    const { container } = render(
+      <CoPilotRail onSpawnMission={onSpawnMission} collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }} />,
+      { wrapper },
+    );
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "/mission https://staging.averray.com/x" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/x");
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -1,23 +1,40 @@
-// Hermes Handoff Monitor — co-pilot rail (M7' shell).
+// Hermes Handoff Monitor — co-pilot rail (M8').
 //
-// The right-hand rail: header + (M8') narration stream + the Ask-Hermes
-// composer. M7' wires the composer's /mission spawn flow; the live
-// card-stream narration and free-form Q&A land in M8', filling the
-// stream region that is a stub here.
+// The right-hand rail: header + the live collaboration turn stream +
+// the Ask-Hermes composer. Questions are scoped to the focused card
+// (relatedPr), recorded via /monitor/collaboration, and Hermes's reply
+// shows up on the next poll. `/mission <url>` still spawns a browser
+// mission (M7').
 
+import { useEffect, useRef } from "react";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
+import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
+import { HermesTurn } from "./HermesTurn.js";
 
 export interface CoPilotRailProps {
   onSpawnMission?: (url: string) => void;
-  onAsk?: (text: string) => void;
-  focusedCardId?: string | null;
+  /** Focused card — scopes Ask-Hermes questions + the scope chip. */
+  focusedCard?: BoardCard;
+  /** Collaboration wiring. Omit to keep the rail inert (e.g. in BoardView tests). */
+  collaboration?: UseCollaborationOptions;
 }
 
-export function CoPilotRail({ onSpawnMission, onAsk, focusedCardId }: CoPilotRailProps) {
+export function CoPilotRail({ onSpawnMission, focusedCard, collaboration }: CoPilotRailProps) {
+  const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
+  const relatedPr = relatedPrForCard(focusedCard);
+  const streamRef = useRef<HTMLDivElement>(null);
+
+  // Keep the newest turn in view as the feed grows.
+  useEffect(() => {
+    const el = streamRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+
   return (
     <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
-      {/* A <div>, not <header>: only the TopStrip is the page banner
-          landmark — the rail's own header must not register as a second. */}
+      {/* A <div>, not <header>: only the TopStrip is the page banner landmark. */}
       <div className="hm-hermes-head">
         <div className="hm-hermes-mark" aria-hidden>
           H
@@ -26,16 +43,24 @@ export function CoPilotRail({ onSpawnMission, onAsk, focusedCardId }: CoPilotRai
           <div className="hm-hermes-title">Hermes co-pilot</div>
           <div className="hm-hermes-sub">
             <span className="pulse" aria-hidden />
-            Live · narrating the board · context: {focusedCardId ?? "everywhere"}
+            Live · narrating the board · context: {focusedCard?.id ?? "everywhere"}
           </div>
         </div>
       </div>
 
-      <div className="hm-hermes-stream">
-        <div className="hm-lane-empty">Board narration lands in M8'.</div>
+      <div className="hm-hermes-stream" ref={streamRef} aria-live="polite">
+        {messages.length === 0 ? (
+          <div className="hm-lane-empty">No board chatter yet.</div>
+        ) : (
+          messages.map((m) => <HermesTurn key={m.id} turn={m} />)
+        )}
       </div>
 
-      <AskHermesComposer onSpawnMission={onSpawnMission} onAsk={onAsk} focusedCardId={focusedCardId} />
+      <AskHermesComposer
+        onSpawnMission={onSpawnMission}
+        onAsk={(text) => ask(text, relatedPr)}
+        focusedCardId={focusedCard?.id ?? null}
+      />
     </aside>
   );
 }

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, within } from "@testing-library/react";
+import { HermesTurn } from "./HermesTurn.js";
+import type { CollaborationMessage } from "../../lib/monitor/collaboration.js";
+
+afterEach(cleanup);
+
+const base: CollaborationMessage = {
+  id: "1",
+  ts: Date.parse("2026-05-28T10:00:00Z"),
+  author: "hermes",
+  kind: "status",
+  text: "Pre-check passed on #548.",
+  addressedTo: "operator",
+};
+
+describe("HermesTurn", () => {
+  test("renders actor label, kind, and body", () => {
+    const { container, getByText } = render(<HermesTurn turn={base} />);
+    expect(getByText("Hermes")).toBeTruthy();
+    expect(getByText(/status/)).toBeTruthy();
+    expect(getByText("Pre-check passed on #548.")).toBeTruthy();
+    expect((container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--hermes");
+  });
+
+  test("operator turns are labelled Pascal", () => {
+    const { getByText } = render(<HermesTurn turn={{ ...base, id: "2", author: "operator" }} />);
+    expect(getByText("Pascal")).toBeTruthy();
+  });
+
+  test("a relatedPr renders a real GitHub PR link", () => {
+    const { container } = render(
+      <HermesTurn turn={{ ...base, id: "3", relatedPr: { repo: "depre-dev/agent", number: 548 } }} />,
+    );
+    const link = within(container).getByRole("link") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("https://github.com/depre-dev/agent/pull/548");
+    expect(link.textContent).toContain("#548");
+  });
+
+  test("no link when there is no relatedPr", () => {
+    const { queryByRole } = render(<HermesTurn turn={base} />);
+    expect(queryByRole("link")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
@@ -1,0 +1,30 @@
+// Hermes Handoff Monitor — a single collaboration turn (M8').
+
+import type { CollaborationMessage } from "../../lib/monitor/collaboration.js";
+import { actorLabel, formatTurnTime } from "../../lib/monitor/collaboration.js";
+
+export function HermesTurn({ turn }: { turn: CollaborationMessage }) {
+  const prHref = turn.relatedPr
+    ? `https://github.com/${turn.relatedPr.repo}/pull/${turn.relatedPr.number}`
+    : undefined;
+
+  return (
+    <div className={"hm-turn hm-turn--" + turn.author}>
+      <div className="hm-turn-head">
+        <span className="hm-turn-actor">
+          <span className="actor-dot" aria-hidden />
+          {actorLabel(turn.author)}
+        </span>
+        <span style={{ marginLeft: 4, opacity: 0.7, fontWeight: 500, letterSpacing: 0 }}>· {turn.kind}</span>
+        <span className="hm-turn-time">{formatTurnTime(turn.ts)}</span>
+      </div>
+      <div className="hm-turn-body">{turn.text}</div>
+      {turn.relatedPr ? (
+        <a className="hm-turn-pin" href={prHref} target="_blank" rel="noreferrer">
+          <span className="pin-id">#{turn.relatedPr.number}</span>
+          <span className="pin-title">{turn.relatedPr.repo}</span>
+        </a>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
+++ b/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { ReactNode } from "react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { useCollaboration } from "./useCollaboration.js";
+import type { CollaborationMessage } from "../lib/monitor/collaboration.js";
+
+afterEach(cleanup);
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
+
+function msg(id: string, author: CollaborationMessage["author"], text: string): CollaborationMessage {
+  return { id, ts: Date.parse("2026-05-28T10:00:00Z"), author, kind: "chat", text, addressedTo: "everyone" };
+}
+
+describe("useCollaboration", () => {
+  test("loads the collaboration feed", async () => {
+    const fetcher = vi.fn(async () => [msg("1", "hermes", "watching the board")]);
+    const { result } = renderHook(() => useCollaboration({ fetcher, refreshIntervalMs: 0 }), { wrapper });
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    expect(result.current.messages[0]?.text).toBe("watching the board");
+  });
+
+  test("ask posts the question (scoped) and revalidates the feed", async () => {
+    let turns: CollaborationMessage[] = [];
+    const fetcher = vi.fn(async () => turns);
+    const poster = vi.fn(async () => {
+      turns = [msg("q", "operator", "what's blocking?"), msg("a", "hermes", "CI is still running")];
+    });
+    const { result } = renderHook(() => useCollaboration({ fetcher, poster, refreshIntervalMs: 0 }), { wrapper });
+    await waitFor(() => expect(fetcher).toHaveBeenCalled());
+
+    await act(async () => {
+      result.current.ask("what's blocking?", { repo: "depre-dev/agent", number: 548 });
+    });
+
+    expect(poster).toHaveBeenCalledWith({ text: "what's blocking?", relatedPr: { repo: "depre-dev/agent", number: 548 } });
+    await waitFor(() => expect(result.current.messages.map((m) => m.id)).toEqual(["q", "a"]));
+  });
+
+  test("a blank question does not post", async () => {
+    const poster = vi.fn(async () => {});
+    const { result } = renderHook(() => useCollaboration({ fetcher: async () => [], poster, refreshIntervalMs: 0 }), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.messages).toEqual([]));
+    act(() => result.current.ask("   "));
+    expect(poster).not.toHaveBeenCalled();
+  });
+
+  test("enabled:false neither fetches nor polls", async () => {
+    const fetcher = vi.fn(async () => [msg("1", "hermes", "x")]);
+    const { result } = renderHook(() => useCollaboration({ enabled: false, fetcher }), { wrapper });
+    await Promise.resolve();
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.messages).toEqual([]);
+  });
+});

--- a/packages/monitor-ui/src/hooks/useCollaboration.ts
+++ b/packages/monitor-ui/src/hooks/useCollaboration.ts
@@ -1,0 +1,91 @@
+// Hermes Handoff Monitor — co-pilot collaboration feed (M8').
+//
+// Polls slack-operator's /monitor/collaboration for the operator ↔ Hermes
+// ↔ Codex turn stream, and posts operator questions back. Posting a
+// question records it and schedules an async Hermes reply server-side; the
+// reply shows up on the next poll, so the rail "answers" without any
+// bespoke streaming. Dependency-injected (fetcher, poster) for tests.
+
+import { useCallback } from "react";
+import useSWR from "swr";
+import type { CollaborationMessage, CollaborationRelatedPr } from "../lib/monitor/collaboration.js";
+
+const DEFAULT_URL = "/monitor/collaboration";
+const DEFAULT_REFRESH_MS = 4000;
+
+export interface AskInput {
+  text: string;
+  relatedPr?: CollaborationRelatedPr;
+}
+
+export interface UseCollaborationOptions {
+  /** When false the hook neither fetches nor polls (rail stays inert). Default true. */
+  enabled?: boolean;
+  url?: string;
+  fetcher?: (url: string) => Promise<CollaborationMessage[]>;
+  poster?: (input: AskInput) => Promise<void>;
+  refreshIntervalMs?: number;
+  limit?: number;
+}
+
+export interface CollaborationState {
+  messages: CollaborationMessage[];
+  /** Ask Hermes; optionally scoped to a PR. Records + triggers a revalidate. */
+  ask: (text: string, relatedPr?: CollaborationRelatedPr) => void;
+  isLoading: boolean;
+  error: unknown;
+}
+
+async function defaultFetcher(url: string): Promise<CollaborationMessage[]> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`collaboration fetch failed: ${res.status}`);
+  const body = (await res.json()) as { messages?: CollaborationMessage[] };
+  return Array.isArray(body.messages) ? body.messages : [];
+}
+
+function makeDefaultPoster(url: string): (input: AskInput) => Promise<void> {
+  return async (input) => {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        author: "operator",
+        kind: "chat",
+        addressedTo: "hermes",
+        text: input.text,
+        ...(input.relatedPr ? { relatedPr: input.relatedPr } : {}),
+      }),
+    });
+  };
+}
+
+export function useCollaboration(opts: UseCollaborationOptions = {}): CollaborationState {
+  const enabled = opts.enabled ?? true;
+  const url = opts.url ?? DEFAULT_URL;
+  const fetcher = opts.fetcher ?? defaultFetcher;
+  const poster = opts.poster ?? makeDefaultPoster(url);
+  const refreshInterval = opts.refreshIntervalMs ?? DEFAULT_REFRESH_MS;
+
+  // A null key disables SWR entirely — no fetch, no poll.
+  const key = enabled ? (opts.limit ? `${url}?limit=${opts.limit}` : url) : null;
+
+  const { data, error, isLoading, mutate } = useSWR<CollaborationMessage[]>(key, fetcher, {
+    refreshInterval,
+    revalidateOnFocus: false,
+  });
+
+  const ask = useCallback(
+    (text: string, relatedPr?: CollaborationRelatedPr) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      void poster({ text: trimmed, ...(relatedPr ? { relatedPr } : {}) })
+        .then(() => mutate())
+        .catch(() => {
+          /* surfaced via the feed / error state, not thrown */
+        });
+    },
+    [poster, mutate],
+  );
+
+  return { messages: data ?? [], ask, isLoading, error };
+}

--- a/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
@@ -1,0 +1,28 @@
+import { test, assert } from "vitest";
+
+import { actorLabel, formatTurnTime, relatedPrForCard } from "./collaboration.js";
+import type { BoardCard } from "./card-types.js";
+
+test("actorLabel maps authors to display names", () => {
+  assert.equal(actorLabel("hermes"), "Hermes");
+  assert.equal(actorLabel("operator"), "Pascal");
+  assert.equal(actorLabel("codex"), "Codex");
+  assert.equal(actorLabel("system"), "System");
+});
+
+test("formatTurnTime renders HH:MM and tolerates a bad timestamp", () => {
+  assert.match(formatTurnTime(Date.parse("2026-05-28T09:05:00")), /^\d\d:\d\d$/);
+  assert.equal(formatTurnTime(Number.NaN, () => Date.parse("2026-05-28T01:02:00")), "01:02");
+});
+
+test("relatedPrForCard derives {repo, number} from a #-numbered card", () => {
+  const pr = { id: "agent #548", repo: "depre-dev/agent" } as BoardCard;
+  assert.deepEqual(relatedPrForCard(pr), { repo: "depre-dev/agent", number: 548 });
+});
+
+test("relatedPrForCard returns undefined for cards without a # number or repo", () => {
+  assert.equal(relatedPrForCard({ id: "mission browser-onboard-04", repo: "depre-dev/site" } as BoardCard), undefined);
+  assert.equal(relatedPrForCard({ id: "task starter-coding-014", repo: "depre-dev/agent" } as BoardCard), undefined);
+  assert.equal(relatedPrForCard({ id: "agent #5", repo: "" } as BoardCard), undefined);
+  assert.equal(relatedPrForCard(undefined), undefined);
+});

--- a/packages/monitor-ui/src/lib/monitor/collaboration.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.ts
@@ -1,0 +1,58 @@
+// Hermes Handoff Monitor — collaboration feed types + helpers (M8').
+//
+// The co-pilot rail renders the operator ↔ Hermes ↔ Codex collaboration
+// feed served by slack-operator's /monitor/collaboration. This is the
+// frontend's copy of the contract (they cross an HTTP/JSON boundary, so
+// the declarations are intentionally independent, like card-types.ts).
+
+import type { BoardCard } from "./card-types.js";
+
+export type CollaborationAuthor = "codex" | "hermes" | "operator" | "system";
+export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
+export type CollaborationTarget = "everyone" | "codex" | "hermes" | "operator";
+
+export interface CollaborationRelatedPr {
+  repo: string;
+  number: number;
+}
+
+export interface CollaborationMessage {
+  id: string;
+  ts: number;
+  author: CollaborationAuthor;
+  kind: CollaborationKind;
+  text: string;
+  addressedTo: CollaborationTarget;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+/** Display name for a turn's author (operator → "Pascal", else the role). */
+export function actorLabel(author: CollaborationAuthor): string {
+  if (author === "hermes") return "Hermes";
+  if (author === "operator") return "Pascal";
+  if (author === "codex") return "Codex";
+  return "System";
+}
+
+/** Short clock label (HH:MM) for a turn timestamp. */
+export function formatTurnTime(ts: number, now: () => number = Date.now): string {
+  const ms = Number.isFinite(ts) ? ts : now();
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+/**
+ * Scope a Hermes question to a focused card. Only cards with a `#<number>`
+ * identity (PRs, deploys, ext) map to a relatedPr; missions and Codex
+ * tasks have no PR number, so a question about them is board-scoped.
+ */
+export function relatedPrForCard(card: BoardCard | undefined | null): CollaborationRelatedPr | undefined {
+  if (!card || typeof card.repo !== "string" || !card.repo) return undefined;
+  const m = /#(\d+)/.exec(card.id);
+  if (!m) return undefined;
+  const number = Number.parseInt(m[1] as string, 10);
+  return Number.isFinite(number) ? { repo: card.repo, number } : undefined;
+}

--- a/packages/monitor-ui/src/lib/monitor/index.ts
+++ b/packages/monitor-ui/src/lib/monitor/index.ts
@@ -15,4 +15,5 @@ export * from "./drawer-routing.js";
 export * from "./snapshot-store.js";
 export * from "./live-stream.js";
 export * from "./hermes-commands.js";
+export * from "./collaboration.js";
 export * from "./fixtures.js";


### PR DESCRIPTION
## Summary
- **M8'** of the Hermes Handoff Monitor redesign: fills the rail stub with the **live collaboration feed** and a **focused-card-scoped Ask-Hermes** flow. Acceptance: *ask a question scoped to the focused card; the reply renders.*

## What's in it
- **`collaboration.ts`** — frontend mirror of the `CollaborationMessage` contract + `relatedPrForCard()` (scope a question to a card's `#PR`) + actor/time label helpers.
- **`useCollaboration`** — SWR-polls `GET /monitor/collaboration` for the operator ↔ Hermes ↔ Codex turn stream; `ask()` POSTs an operator question (`author=operator`, `addressedTo=hermes`, optional `relatedPr`) and revalidates. The server records it and schedules an **async Hermes reply** that lands on the next poll — so the rail "answers" with no bespoke streaming. An `enabled:false` seam keeps the rail inert where it isn't wired.
- **`HermesTurn`** — renders a turn (actor / kind / time / body + a real GitHub PR link when `relatedPr` is set).
- **`CoPilotRail`** — replaces the stub: the turn stream (`aria-live="polite"`, auto-scrolls) + the composer wired to `ask(text, relatedPrForCard(focusedCard))`. `/mission` spawn (M7') still flows through the same composer.
- **`BoardView` / `MonitorPage`** thread the focused card + collaboration wiring; the page enables the live feed by default.

## Real data, honest boundary
The feed and replies come from the existing `/monitor/collaboration` backend (operator/Hermes/Codex turns + `synthesizeHermesReplyFor`) — not fabricated turns. The reply is server-side and async; the rail surfaces it on the poll.

## Deferred
- Notifications / tab badge / audio → **M9'**
- Degraded `TopStrip` ("?" KPIs) → **M11'**

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **294/294** (collaboration helpers, `useCollaboration` load/ask+revalidate/disabled, `HermesTurn`, and `CoPilotRail` incl. the acceptance: scoped ask posts `relatedPr` and the reply renders)
- [x] `npm test` (full repo) → **639/639**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)