### PR TITLE
monitor-ui: notifications + tab badge + audio (M9')

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -50,7 +50,7 @@ beforeEach(() => {
 describe("MonitorPage — container", () => {
   test("wires fetched live board data into the BoardView", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
-    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} />, {
       wrapper,
     });
 
@@ -64,7 +64,7 @@ describe("MonitorPage — container", () => {
 
   test("clicking a card opens the drawer and sets ?card=; esc closes it and clears the param", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
-    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} />, {
       wrapper,
     });
 
@@ -86,7 +86,7 @@ describe("MonitorPage — container", () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => {
       throw new Error("no backend");
     });
-    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
+    const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} />, {
       wrapper,
     });
 
@@ -100,7 +100,7 @@ describe("MonitorPage — container", () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
     const onSpawnMission = vi.fn();
     const { container } = render(
-      <MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} onSpawnMission={onSpawnMission} collaboration={{ enabled: false }} />,
+      <MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} onSpawnMission={onSpawnMission} collaboration={{ enabled: false }} alerts={{ enabled: false }} />,
       { wrapper },
     );
     await waitFor(() => expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy());
@@ -117,7 +117,7 @@ describe("MonitorPage — container", () => {
     // the global fetch — so spying on it isolates the spawn call.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
     try {
-      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} />, {
+      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} />, {
         wrapper,
       });
       await waitFor(() =>
@@ -136,5 +136,27 @@ describe("MonitorPage — container", () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+
+  test("the composer's /mute command mutes alerts end-to-end", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
+    const storage = memStorage();
+    const { container } = render(
+      <MonitorPage
+        options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+        collaboration={{ enabled: false }}
+        alerts={{ enabled: false, storage, now: () => 1_000 }}
+      />,
+      { wrapper },
+    );
+    await waitFor(() => expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy());
+
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "/mute 1h" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // The mute flows command → CoPilotRail → useActionAlerts → muted chip.
+    await waitFor(() => expect(within(container).getByText("alerts muted")).toBeTruthy());
+    expect(storage.getItem("monitor.mute.until")).toBeTruthy();
   });
 });

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -20,9 +20,12 @@
 // Deferred, by milestone:
 //   - the degraded TopStrip ("?" KPIs) → M11'
 
+import { useMemo } from "react";
 import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitorBoard.js";
 import { useCardParam } from "./hooks/useCardParam.js";
 import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
+import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
+import { kpiCounts } from "./lib/monitor/board-state.js";
 import { BoardView } from "./components/BoardView.js";
 
 const MISSIONS_URL = "/monitor/testbed-missions";
@@ -34,15 +37,22 @@ export interface MonitorPageProps {
   onSpawnMission?: (url: string) => void;
   /** Override the co-pilot collaboration wiring (defaults to live polling). */
   collaboration?: UseCollaborationOptions;
+  /** Override the action-alert wiring (audio/notification/storage) for tests. */
+  alerts?: UseActionAlertsOptions;
 }
 
 export function MonitorPage({
   options,
   onSpawnMission = defaultSpawnMission,
   collaboration = {},
+  alerts,
 }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
   const { cardId, setCard, clearCard } = useCardParam();
+
+  // The action-needed count drives all three notification tiers (§17).
+  const actionCount = useMemo(() => kpiCounts(board?.cards ?? []).action, [board?.cards]);
+  const { muted, mute, unmute } = useActionAlerts(actionCount, alerts);
 
   return (
     <BoardView
@@ -55,6 +65,9 @@ export function MonitorPage({
       onCardNavigate={setCard}
       onSpawnMission={onSpawnMission}
       collaboration={collaboration}
+      onMute={mute}
+      onUnmute={unmute}
+      muted={muted}
     />
   );
 }

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -64,6 +64,12 @@ export interface BoardViewProps {
   onSpawnMission?: (url: string) => void;
   /** Co-pilot collaboration wiring. Omit to keep the rail inert. */
   collaboration?: UseCollaborationOptions;
+  /** Mute action alerts until a timestamp (/mute). */
+  onMute?: (untilMs: number) => void;
+  /** Clear the alert mute (/unmute). */
+  onUnmute?: () => void;
+  /** Whether action alerts are currently muted. */
+  muted?: boolean;
 }
 
 export function BoardView({
@@ -76,6 +82,9 @@ export function BoardView({
   onCardNavigate,
   onSpawnMission,
   collaboration,
+  onMute,
+  onUnmute,
+  muted,
 }: BoardViewProps) {
   // The stream is "degraded" only on a real drop (reconnecting/closed);
   // idle/connecting are pre-live transients, not disconnections. The
@@ -135,7 +144,14 @@ export function BoardView({
           />
         </div>
 
-        <CoPilotRail onSpawnMission={onSpawnMission} focusedCard={focusedCard} collaboration={collaboration} />
+        <CoPilotRail
+          onSpawnMission={onSpawnMission}
+          focusedCard={focusedCard}
+          collaboration={collaboration}
+          onMute={onMute}
+          onUnmute={onUnmute}
+          muted={muted}
+        />
       </div>
 
       {focusedCard ? (

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -55,16 +55,38 @@ describe("AskHermesComposer", () => {
     expect(input.value).toBe("");
   });
 
-  test("a plain question without an onAsk handler surfaces the M8' hint", () => {
+  test("a plain question without an onAsk handler surfaces a hint", () => {
     const { container, getByRole } = render(<AskHermesComposer onSpawnMission={vi.fn()} />);
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     type(input, "hello hermes");
     fireEvent.click(getByRole("button", { name: /Send/ }));
-    expect(within(container).getByRole("alert").textContent).toMatch(/lands in M8'/);
+    expect(within(container).getByRole("alert").textContent).toMatch(/isn't wired here/);
   });
 
   test("the scope chip reflects the focused card", () => {
     const { getByText } = render(<AskHermesComposer focusedCardId="agent #548" />);
     expect(getByText("scope · agent #548")).toBeTruthy();
+  });
+
+  test("/mute and /unmute dispatch to their handlers", () => {
+    const onMute = vi.fn();
+    const onUnmute = vi.fn();
+    const { container } = render(<AskHermesComposer onMute={onMute} onUnmute={onUnmute} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+
+    type(input, "/mute 1h");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onMute).toHaveBeenCalledTimes(1);
+    expect(typeof onMute.mock.calls[0]?.[0]).toBe("number");
+    expect(input.value).toBe("");
+
+    type(input, "/unmute");
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onUnmute).toHaveBeenCalledTimes(1);
+  });
+
+  test("a muted state shows the muted chip", () => {
+    const { getByText } = render(<AskHermesComposer muted />);
+    expect(getByText("alerts muted")).toBeTruthy();
   });
 });

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -1,13 +1,11 @@
-// Hermes Handoff Monitor — Ask-Hermes composer (M7').
+// Hermes Handoff Monitor — Ask-Hermes composer (M7'/M9').
 //
-// A single text input that doubles as a command line. `/mission <url>`
-// spawns a browser mission; anything else is a question for Hermes.
+// A single text input that doubles as a command line:
+//   /mission <url>   spawn a browser mission (M7')
+//   /mute [1h|9am]   silence action alerts; /unmute clears it (M9')
+//   anything else    a question for Hermes
 // Enter sends, Shift+Enter inserts a newline. Parsing lives in the pure
 // hermes-commands helper; this component owns only input + dispatch.
-//
-// In M7' the mission-spawn path is wired end-to-end; the free-form "ask
-// Hermes" reply stream is M8'. When no onAsk handler is supplied, a plain
-// message surfaces a short hint rather than silently doing nothing.
 
 import { useState, type KeyboardEvent } from "react";
 import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
@@ -15,13 +13,26 @@ import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
 export interface AskHermesComposerProps {
   /** Spawn a browser mission against a URL (/mission <url>). */
   onSpawnMission?: (url: string) => void;
-  /** Ask Hermes a free-form question (M8'). */
+  /** Ask Hermes a free-form question. */
   onAsk?: (text: string) => void;
+  /** Mute action alerts until an absolute timestamp (/mute). */
+  onMute?: (untilMs: number) => void;
+  /** Clear the mute (/unmute). */
+  onUnmute?: () => void;
+  /** Whether alerts are currently muted (shown as a chip). */
+  muted?: boolean;
   /** Focused card id, shown in the scope chip. */
   focusedCardId?: string | null;
 }
 
-export function AskHermesComposer({ onSpawnMission, onAsk, focusedCardId }: AskHermesComposerProps) {
+export function AskHermesComposer({
+  onSpawnMission,
+  onAsk,
+  onMute,
+  onUnmute,
+  muted,
+  focusedCardId,
+}: AskHermesComposerProps) {
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -38,13 +49,23 @@ export function AskHermesComposer({ onSpawnMission, onAsk, focusedCardId }: AskH
         setValue("");
         setError(null);
         return;
+      case "mute":
+        onMute?.(command.untilMs);
+        setValue("");
+        setError(null);
+        return;
+      case "unmute":
+        onUnmute?.();
+        setValue("");
+        setError(null);
+        return;
       case "ask":
         if (onAsk) {
           onAsk(command.text);
           setValue("");
           setError(null);
         } else {
-          setError("Ask Hermes lands in M8'. For now: /mission <url> spawns a browser mission.");
+          setError("Ask Hermes isn't wired here. Use /mission <url> or /mute.");
         }
         return;
     }
@@ -61,15 +82,19 @@ export function AskHermesComposer({ onSpawnMission, onAsk, focusedCardId }: AskH
     <div className="hm-compose">
       <div className="hm-compose-toolbar">
         <span className="hm-compose-chip is-on">to · operator</span>
-        <span className="hm-compose-chip">intent · mission spawn</span>
         <span className="hm-compose-chip">scope · {focusedCardId ?? "board"}</span>
+        {muted ? (
+          <span className="hm-compose-chip" style={{ color: "var(--hm-muted)" }}>
+            alerts muted
+          </span>
+        ) : null}
         <span style={{ marginLeft: "auto", color: "var(--hm-muted-soft)" }}>⏎ send · ⇧⏎ newline</span>
       </div>
       <div className="hm-compose-row">
         <textarea
           className="hm-compose-input"
-          placeholder="Ask Hermes, or spawn a mission · /mission https://staging.averray.com/onboarding"
-          aria-label="Ask Hermes or spawn a browser mission"
+          placeholder="Ask Hermes · /mission <url> · /mute 1h"
+          aria-label="Ask Hermes, spawn a mission, or mute alerts"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -19,9 +19,22 @@ export interface CoPilotRailProps {
   focusedCard?: BoardCard;
   /** Collaboration wiring. Omit to keep the rail inert (e.g. in BoardView tests). */
   collaboration?: UseCollaborationOptions;
+  /** Mute action alerts until a timestamp (/mute). */
+  onMute?: (untilMs: number) => void;
+  /** Clear the mute (/unmute). */
+  onUnmute?: () => void;
+  /** Whether action alerts are currently muted. */
+  muted?: boolean;
 }
 
-export function CoPilotRail({ onSpawnMission, focusedCard, collaboration }: CoPilotRailProps) {
+export function CoPilotRail({
+  onSpawnMission,
+  focusedCard,
+  collaboration,
+  onMute,
+  onUnmute,
+  muted,
+}: CoPilotRailProps) {
   const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
   const relatedPr = relatedPrForCard(focusedCard);
   const streamRef = useRef<HTMLDivElement>(null);
@@ -59,6 +72,9 @@ export function CoPilotRail({ onSpawnMission, focusedCard, collaboration }: CoPi
       <AskHermesComposer
         onSpawnMission={onSpawnMission}
         onAsk={(text) => ask(text, relatedPr)}
+        onMute={onMute}
+        onUnmute={onUnmute}
+        muted={muted}
         focusedCardId={focusedCard?.id ?? null}
       />
     </aside>

--- a/packages/monitor-ui/src/hooks/useActionAlerts.test.tsx
+++ b/packages/monitor-ui/src/hooks/useActionAlerts.test.tsx
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { useActionAlerts, type UseActionAlertsOptions } from "./useActionAlerts.js";
+import { MUTE_STORAGE_KEY } from "../lib/monitor/notifications.js";
+import type { MinimalAudioContext } from "../lib/monitor/alert-audio.js";
+import type { StorageLike } from "../lib/monitor/snapshot-store.js";
+
+afterEach(cleanup);
+
+beforeAll(() => {
+  // Silence jsdom's "canvas getContext not implemented" log; the favicon
+  // badge no-ops without a 2D context, which a null return models exactly.
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+});
+
+function memStorage(seed?: Record<string, string>): StorageLike {
+  const m = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    getItem: (k) => (m.has(k) ? (m.get(k) as string) : null),
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+    get length() {
+      return m.size;
+    },
+    key: (i) => Array.from(m.keys())[i] ?? null,
+  };
+}
+
+function fakeAudio() {
+  let plays = 0;
+  class FakeCtx implements MinimalAudioContext {
+    currentTime = 0;
+    destination = {} as AudioNode;
+    createOscillator() {
+      plays += 1;
+      return {
+        type: "",
+        frequency: { value: 0 },
+        connect() {},
+        start() {},
+        stop() {},
+      } as unknown as OscillatorNode;
+    }
+    createGain() {
+      return {
+        gain: { value: 0, setValueAtTime() {}, exponentialRampToValueAtTime() {} },
+        connect() {},
+      } as unknown as GainNode;
+    }
+  }
+  return { Ctor: FakeCtx as unknown as new () => MinimalAudioContext, plays: () => plays };
+}
+
+function fakeNotification(permission: string) {
+  const built: string[] = [];
+  const Ctor = function (this: unknown, title: string) {
+    built.push(title);
+  } as unknown as UseActionAlertsOptions["notificationCtor"] & { permission: string; requestPermission: () => void };
+  (Ctor as unknown as { permission: string }).permission = permission;
+  (Ctor as unknown as { requestPermission: () => void }).requestPermission = vi.fn();
+  return { Ctor, built };
+}
+
+function baseOpts(over: Partial<UseActionAlertsOptions> = {}): UseActionAlertsOptions {
+  return {
+    storage: memStorage(),
+    isVisible: () => true,
+    now: () => 1_000,
+    ...over,
+  };
+}
+
+describe("useActionAlerts — passive badge/title", () => {
+  test("title tracks the count on every change", () => {
+    const { rerender } = renderHook((count: number) => useActionAlerts(count, baseOpts()), { initialProps: 0 });
+    expect(document.title).toBe("Hermes — Averray");
+    rerender(3);
+    expect(document.title).toBe("(3) Hermes — Averray");
+    rerender(0);
+    expect(document.title).toBe("Hermes — Averray");
+  });
+});
+
+describe("useActionAlerts — chime (visible)", () => {
+  test("plays on the 0→>0 edge, not on the initial observation or 1→2", () => {
+    const audio = fakeAudio();
+    const opts = baseOpts({ audioContextCtor: audio.Ctor, isVisible: () => true });
+    const { rerender } = renderHook((count: number) => useActionAlerts(count, opts), { initialProps: 2 });
+    // First observation establishes the baseline — no chime even though >0.
+    expect(audio.plays()).toBe(0);
+    rerender(3); // 2→3, still >0, no fresh edge
+    expect(audio.plays()).toBe(0);
+    rerender(0); // cleared
+    rerender(1); // 0→1 edge → chime
+    expect(audio.plays()).toBe(1);
+  });
+
+  test("does not chime while muted, but the title still updates", () => {
+    const audio = fakeAudio();
+    const opts = baseOpts({
+      audioContextCtor: audio.Ctor,
+      storage: memStorage({ [MUTE_STORAGE_KEY]: "999999" }), // muted until far future
+      now: () => 1_000,
+    });
+    const { rerender } = renderHook((count: number) => useActionAlerts(count, opts), { initialProps: 0 });
+    rerender(2);
+    expect(audio.plays()).toBe(0);
+    expect(document.title).toBe("(2) Hermes — Averray");
+  });
+});
+
+describe("useActionAlerts — desktop notification (hidden)", () => {
+  test("fires when hidden + permission granted, on the 0→>0 edge", () => {
+    const notif = fakeNotification("granted");
+    const opts = baseOpts({ notificationCtor: notif.Ctor, isVisible: () => false });
+    const { rerender } = renderHook((count: number) => useActionAlerts(count, opts), { initialProps: 0 });
+    rerender(1);
+    expect(notif.built).toEqual(["Hermes — action needed"]);
+  });
+
+  test("does not fire without granted permission", () => {
+    const notif = fakeNotification("default");
+    const opts = baseOpts({ notificationCtor: notif.Ctor, isVisible: () => false });
+    const { rerender } = renderHook((count: number) => useActionAlerts(count, opts), { initialProps: 0 });
+    rerender(1);
+    expect(notif.built).toEqual([]);
+  });
+});
+
+describe("useActionAlerts — mute controls", () => {
+  test("mute/unmute persist and reflect in `muted`", () => {
+    const storage = memStorage();
+    const { result } = renderHook(() => useActionAlerts(0, baseOpts({ storage, now: () => 1_000 })));
+    expect(result.current.muted).toBe(false);
+
+    act(() => result.current.mute(5_000));
+    expect(result.current.muted).toBe(true);
+    expect(result.current.muteUntil).toBe(5_000);
+    expect(storage.getItem(MUTE_STORAGE_KEY)).toBe("5000");
+
+    act(() => result.current.unmute());
+    expect(result.current.muted).toBe(false);
+    expect(storage.getItem(MUTE_STORAGE_KEY)).toBeNull();
+  });
+
+  test("hydrates the muted state from storage", () => {
+    const { result } = renderHook(() =>
+      useActionAlerts(0, baseOpts({ storage: memStorage({ [MUTE_STORAGE_KEY]: "9999" }), now: () => 1_000 })),
+    );
+    expect(result.current.muted).toBe(true);
+  });
+});

--- a/packages/monitor-ui/src/hooks/useActionAlerts.ts
+++ b/packages/monitor-ui/src/hooks/useActionAlerts.ts
@@ -1,0 +1,171 @@
+// Hermes Handoff Monitor — action-needed alerts (M9', §17).
+//
+// Watches the action-needed count and drives all three notification
+// tiers on the 0 → >0 edge:
+//   1. in-app: a procedural Web Audio chime when the tab is visible
+//   2. tab badge + title: document.title + canvas favicon + Badging API
+//      (these track the count on every change, not just the edge)
+//   3. desktop Notification when the tab is hidden (permission granted)
+//
+// Mute is honoured for tiers 1 & 3 (the operator silenced alerts) but the
+// passive tab badge/title still reflect reality — muting shouldn't hide
+// that action is pending. Everything is dependency-injected so the whole
+// orchestration is testable without real audio/notification/DOM backends.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { playAlertTone, type MinimalAudioContext } from "../lib/monitor/alert-audio.js";
+import { setAppBadge, setFaviconBadge } from "../lib/monitor/favicon.js";
+import {
+  DEFAULT_TITLE,
+  documentTitleFor,
+  isMuted,
+  readMuteUntil,
+  shouldAlert,
+  writeMuteUntil,
+} from "../lib/monitor/notifications.js";
+import type { StorageLike } from "../lib/monitor/snapshot-store.js";
+
+interface NotificationCtorLike {
+  new (title: string, options?: { body?: string }): unknown;
+  permission: string;
+  requestPermission?: () => Promise<string> | void;
+}
+
+export interface UseActionAlertsOptions {
+  enabled?: boolean;
+  now?: () => number;
+  storage?: StorageLike;
+  audioContextCtor?: new () => MinimalAudioContext;
+  notificationCtor?: NotificationCtorLike;
+  /** Is the tab visible? Default reads document.visibilityState. */
+  isVisible?: () => boolean;
+  doc?: Document;
+  nav?: Navigator;
+  baseTitle?: string;
+}
+
+export interface ActionAlertsState {
+  muted: boolean;
+  muteUntil: number | null;
+  /** Mute until an absolute timestamp (from parseMuteArg). */
+  mute: (untilMs: number) => void;
+  unmute: () => void;
+  /** Best-effort desktop-notification permission prompt (needs a gesture). */
+  requestPermission: () => void;
+}
+
+function noopStorage(): StorageLike {
+  return { getItem: () => null, setItem: () => undefined, removeItem: () => undefined, length: 0, key: () => null };
+}
+
+function resolveStorage(override?: StorageLike): StorageLike {
+  if (override) return override;
+  const ls = typeof globalThis !== "undefined" ? (globalThis as { localStorage?: unknown }).localStorage : undefined;
+  // Only trust it if it actually conforms — some environments expose a
+  // non-Storage value here, which would crash on getItem.
+  if (ls && typeof (ls as StorageLike).getItem === "function" && typeof (ls as StorageLike).setItem === "function") {
+    return ls as StorageLike;
+  }
+  return noopStorage();
+}
+
+export function useActionAlerts(actionCount: number, opts: UseActionAlertsOptions = {}): ActionAlertsState {
+  const enabled = opts.enabled ?? true;
+  // Date.now is a stable reference (unlike `() => Date.now()`), so it
+  // won't churn the alert effect's dependency array.
+  const now = opts.now ?? Date.now;
+  const base = opts.baseTitle ?? DEFAULT_TITLE;
+
+  // Latest-value refs so the alert effect depends only on the count.
+  const optsRef = useRef(opts);
+  optsRef.current = opts;
+  const storage = resolveStorage(opts.storage);
+  const storageRef = useRef(storage);
+  storageRef.current = storage;
+
+  const [muteUntil, setMuteUntil] = useState<number | null>(() => readMuteUntil(storage));
+  const muteUntilRef = useRef(muteUntil);
+  muteUntilRef.current = muteUntil;
+
+  // Skip the very first observed count so opening the page with pending
+  // action doesn't fire an alert — only live transitions do.
+  const prevRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const o = optsRef.current;
+    const doc = o.doc ?? (typeof document !== "undefined" ? document : undefined);
+    const nav = o.nav ?? (typeof navigator !== "undefined" ? navigator : undefined);
+
+    // Tiers 2: passive badge/title — always reflect the count.
+    if (doc) doc.title = documentTitleFor(actionCount, base);
+    setFaviconBadge(actionCount, doc);
+    setAppBadge(actionCount, nav);
+
+    const prev = prevRef.current;
+    prevRef.current = actionCount;
+    if (prev === null) return; // first observation — establish baseline only
+
+    if (!shouldAlert(prev, actionCount)) return;
+    if (isMuted(muteUntilRef.current, now)) return;
+
+    const visible = (o.isVisible ?? defaultIsVisible)();
+    if (visible) {
+      const Ctor = o.audioContextCtor ?? defaultAudioContextCtor();
+      if (Ctor) {
+        try {
+          playAlertTone(new Ctor());
+        } catch {
+          /* autoplay blocked / unsupported */
+        }
+      }
+    } else {
+      fireDesktopNotification(actionCount, o.notificationCtor ?? defaultNotificationCtor());
+    }
+  }, [actionCount, enabled, base, now]);
+
+  const mute = useCallback((untilMs: number) => {
+    writeMuteUntil(storageRef.current, untilMs);
+    setMuteUntil(untilMs);
+  }, []);
+
+  const unmute = useCallback(() => {
+    writeMuteUntil(storageRef.current, null);
+    setMuteUntil(null);
+  }, []);
+
+  const requestPermission = useCallback(() => {
+    const Ctor = optsRef.current.notificationCtor ?? defaultNotificationCtor();
+    if (Ctor && typeof Ctor.requestPermission === "function" && Ctor.permission === "default") {
+      void Ctor.requestPermission();
+    }
+  }, []);
+
+  return { muted: isMuted(muteUntil, now), muteUntil, mute, unmute, requestPermission };
+}
+
+function fireDesktopNotification(count: number, Ctor: NotificationCtorLike | undefined): void {
+  if (!Ctor || Ctor.permission !== "granted") return;
+  try {
+    new Ctor("Hermes — action needed", {
+      body: count === 1 ? "1 card needs your review." : `${count} cards need your review.`,
+    });
+  } catch {
+    /* unsupported */
+  }
+}
+
+function defaultIsVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
+}
+
+function defaultAudioContextCtor(): (new () => MinimalAudioContext) | undefined {
+  if (typeof window === "undefined") return undefined;
+  const w = window as unknown as { AudioContext?: new () => MinimalAudioContext; webkitAudioContext?: new () => MinimalAudioContext };
+  return w.AudioContext ?? w.webkitAudioContext;
+}
+
+function defaultNotificationCtor(): NotificationCtorLike | undefined {
+  if (typeof window === "undefined") return undefined;
+  return (window as unknown as { Notification?: NotificationCtorLike }).Notification;
+}

--- a/packages/monitor-ui/src/lib/monitor/alert-audio.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/alert-audio.test.ts
@@ -1,0 +1,44 @@
+import { test, assert } from "vitest";
+
+import { playAlertTone, type MinimalAudioContext } from "./alert-audio.js";
+
+function fakeCtx() {
+  const calls: string[] = [];
+  const osc = {
+    type: "",
+    frequency: { value: 0 },
+    connect: () => calls.push("osc.connect"),
+    start: () => calls.push("osc.start"),
+    stop: () => calls.push("osc.stop"),
+  };
+  const gain = {
+    gain: {
+      value: 0,
+      setValueAtTime: () => calls.push("gain.setValueAtTime"),
+      exponentialRampToValueAtTime: () => calls.push("gain.ramp"),
+    },
+    connect: () => calls.push("gain.connect"),
+  };
+  const ctx = {
+    currentTime: 0,
+    destination: {},
+    createOscillator: () => osc,
+    createGain: () => gain,
+  };
+  return { ctx: ctx as unknown as MinimalAudioContext, osc, gain, calls };
+}
+
+test("playAlertTone routes a 880Hz sine through a decaying gain to the destination", () => {
+  const { ctx, osc, calls } = fakeCtx();
+  playAlertTone(ctx);
+  assert.equal(osc.type, "sine");
+  assert.equal(osc.frequency.value, 880);
+  // Envelope: an initial set + an attack ramp + a decay ramp.
+  assert.ok(calls.includes("gain.setValueAtTime"));
+  assert.equal(calls.filter((c) => c === "gain.ramp").length, 2);
+  // Routed and scheduled.
+  assert.ok(calls.includes("osc.connect"));
+  assert.ok(calls.includes("gain.connect"));
+  assert.ok(calls.includes("osc.start"));
+  assert.ok(calls.includes("osc.stop"));
+});

--- a/packages/monitor-ui/src/lib/monitor/alert-audio.ts
+++ b/packages/monitor-ui/src/lib/monitor/alert-audio.ts
@@ -1,0 +1,39 @@
+// Hermes Handoff Monitor — procedural alert tone (§21.3).
+//
+// A soft sine-wave chime, ~200ms, exponential decay — generated with the
+// Web Audio API rather than shipping an audio asset (per the §21.3
+// decision; the operator can swap in an uploaded file later). The
+// AudioContext is injected so the tone is testable without a real audio
+// backend and so the caller controls context lifecycle / autoplay-policy
+// resume.
+
+/** The slice of AudioContext this tone needs (keeps tests fake-able). */
+export interface MinimalAudioContext {
+  readonly currentTime: number;
+  readonly destination: AudioNode;
+  createOscillator(): OscillatorNode;
+  createGain(): GainNode;
+}
+
+const PEAK_GAIN = 0.18;
+const FLOOR_GAIN = 0.0001;
+const DURATION_S = 0.2;
+
+/** Play the alert chime on the given context. */
+export function playAlertTone(ctx: MinimalAudioContext): void {
+  const osc = ctx.createOscillator();
+  const gain = ctx.createGain();
+
+  osc.type = "sine";
+  osc.frequency.value = 880; // a calm, mid-high chime
+
+  const t0 = ctx.currentTime;
+  gain.gain.setValueAtTime(FLOOR_GAIN, t0);
+  gain.gain.exponentialRampToValueAtTime(PEAK_GAIN, t0 + 0.02); // quick attack
+  gain.gain.exponentialRampToValueAtTime(FLOOR_GAIN, t0 + DURATION_S); // exp decay
+
+  osc.connect(gain);
+  gain.connect(ctx.destination);
+  osc.start(t0);
+  osc.stop(t0 + DURATION_S + 0.02);
+}

--- a/packages/monitor-ui/src/lib/monitor/favicon.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/favicon.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { setAppBadge, setFaviconBadge } from "./favicon.js";
+
+beforeAll(() => {
+  // jsdom has no 2D canvas; return null quietly (matches real jsdom
+  // behaviour) instead of letting it log a "Not implemented" error.
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(null);
+});
+
+afterEach(() => {
+  document.querySelectorAll('link[rel="icon"]').forEach((n) => n.remove());
+});
+
+describe("setAppBadge", () => {
+  test("sets the badge for a positive count", () => {
+    const setAppBadgeSpy = vi.fn();
+    const clearAppBadgeSpy = vi.fn();
+    setAppBadge(3, { setAppBadge: setAppBadgeSpy, clearAppBadge: clearAppBadgeSpy } as unknown as Navigator);
+    expect(setAppBadgeSpy).toHaveBeenCalledWith(3);
+    expect(clearAppBadgeSpy).not.toHaveBeenCalled();
+  });
+
+  test("clears the badge at zero", () => {
+    const setAppBadgeSpy = vi.fn();
+    const clearAppBadgeSpy = vi.fn();
+    setAppBadge(0, { setAppBadge: setAppBadgeSpy, clearAppBadge: clearAppBadgeSpy } as unknown as Navigator);
+    expect(clearAppBadgeSpy).toHaveBeenCalledTimes(1);
+    expect(setAppBadgeSpy).not.toHaveBeenCalled();
+  });
+
+  test("no-ops (no throw) when the Badging API is unavailable", () => {
+    expect(() => setAppBadge(2, {} as Navigator)).not.toThrow();
+  });
+});
+
+describe("setFaviconBadge", () => {
+  test("ensures an icon link and does not throw without a 2D canvas context", () => {
+    // jsdom returns null from canvas.getContext('2d') → the canvas path
+    // is skipped, but the icon link is still ensured.
+    expect(() => setFaviconBadge(2, document)).not.toThrow();
+    expect(document.querySelector('link[rel="icon"]')).toBeTruthy();
+  });
+
+  test("no-ops without a document", () => {
+    expect(() => setFaviconBadge(1, undefined)).not.toThrow();
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/favicon.ts
+++ b/packages/monitor-ui/src/lib/monitor/favicon.ts
@@ -1,0 +1,89 @@
+// Hermes Handoff Monitor — tab badge (§17 tier 2, §21.2).
+//
+// Two badge surfaces, both best-effort and feature-detected:
+//   - the OS/taskbar badge via the Badging API (navigator.setAppBadge)
+//   - a canvas-rendered favicon with a count bubble (the dock/tab dot)
+//
+// Everything degrades to a no-op where unsupported (e.g. jsdom has no 2D
+// canvas context), so callers can fire-and-forget on every count change.
+
+interface BadgingNavigator {
+  setAppBadge?: (count?: number) => Promise<void> | void;
+  clearAppBadge?: () => Promise<void> | void;
+}
+
+/** OS/taskbar badge via the Badging API. */
+export function setAppBadge(count: number, nav: Navigator | undefined = globalNavigator()): void {
+  const n = nav as (Navigator & BadgingNavigator) | undefined;
+  if (!n) return;
+  try {
+    if (count > 0 && typeof n.setAppBadge === "function") void n.setAppBadge(Math.floor(count));
+    else if (count <= 0 && typeof n.clearAppBadge === "function") void n.clearAppBadge();
+  } catch {
+    /* unsupported / blocked */
+  }
+}
+
+/** Canvas-rendered favicon with a count bubble. No-op without a 2D context. */
+export function setFaviconBadge(count: number, doc: Document | undefined = globalDocument()): void {
+  if (!doc) return;
+  const link = ensureIconLink(doc);
+  if (!link) return;
+
+  let canvas: HTMLCanvasElement;
+  try {
+    canvas = doc.createElement("canvas");
+  } catch {
+    return;
+  }
+  canvas.width = 64;
+  canvas.height = 64;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return; // e.g. jsdom — leave the static favicon in place
+
+  // Base brand dot (sage).
+  ctx.clearRect(0, 0, 64, 64);
+  ctx.fillStyle = "#0f6b5a";
+  ctx.beginPath();
+  ctx.arc(32, 32, 30, 0, Math.PI * 2);
+  ctx.fill();
+
+  const n = Math.floor(count);
+  if (n > 0) {
+    // Amber count bubble.
+    ctx.fillStyle = "#d98324";
+    ctx.beginPath();
+    ctx.arc(46, 18, 16, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.fillStyle = "#fffdf7";
+    ctx.font = "bold 22px sans-serif";
+    ctx.textAlign = "center";
+    ctx.textBaseline = "middle";
+    ctx.fillText(n > 9 ? "9+" : String(n), 46, 19);
+  }
+
+  try {
+    link.href = canvas.toDataURL("image/png");
+  } catch {
+    /* tainted / unsupported */
+  }
+}
+
+function ensureIconLink(doc: Document): HTMLLinkElement | null {
+  const existing = doc.querySelector<HTMLLinkElement>('link[rel="icon"]');
+  if (existing) return existing;
+  const head = doc.head ?? doc.querySelector("head");
+  if (!head) return null;
+  const link = doc.createElement("link");
+  link.rel = "icon";
+  head.appendChild(link);
+  return link;
+}
+
+function globalDocument(): Document | undefined {
+  return typeof document !== "undefined" ? document : undefined;
+}
+
+function globalNavigator(): Navigator | undefined {
+  return typeof navigator !== "undefined" ? navigator : undefined;
+}

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
@@ -56,3 +56,24 @@ test("parseHermesInput: empty / whitespace → empty", () => {
 test("parseHermesInput: a word starting with mission but not the command is an ask", () => {
   assert.equal(parseHermesInput("missionary work").kind, "ask");
 });
+
+test("parseHermesInput: /mute with a duration → mute with a future expiry", () => {
+  const now = () => 1_000;
+  const out = parseHermesInput("/mute 1h", now);
+  assert.equal(out.kind, "mute");
+  if (out.kind === "mute") assert.equal(out.untilMs, 1_000 + 3_600_000);
+});
+
+test("parseHermesInput: bare /mute defaults to one hour", () => {
+  const out = parseHermesInput("/mute", () => 0);
+  assert.equal(out.kind, "mute");
+  if (out.kind === "mute") assert.equal(out.untilMs, 3_600_000);
+});
+
+test("parseHermesInput: /unmute → unmute", () => {
+  assert.equal(parseHermesInput("/unmute").kind, "unmute");
+});
+
+test("parseHermesInput: an unparseable /mute argument → error", () => {
+  assert.equal(parseHermesInput("/mute whenever").kind, "error");
+});

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
@@ -1,26 +1,35 @@
-// Hermes Handoff Monitor — co-pilot composer command parsing (M7').
+// Hermes Handoff Monitor — co-pilot composer command parsing (M7'/M9').
 //
 // The Hermes composer is a single text input that doubles as a command
-// line. `/mission <url>` spawns a browser mission against a live URL;
-// anything else is a question routed to Hermes. Parsing lives here as a
-// pure function so the composer stays dumb and the contract is tested.
+// line:
+//   /mission <url>      spawn a browser mission against a live URL
+//   /mute [1h|9am|…]    silence action alerts (M9'); /unmute clears it
+//   anything else       a question routed to Hermes
+// Parsing lives here as a pure function so the composer stays dumb and
+// the contract is tested.
+
+import { parseMuteArg } from "./notifications.js";
 
 export type HermesCommand =
   | { kind: "mission"; url: string }
+  | { kind: "mute"; untilMs: number }
+  | { kind: "unmute" }
   | { kind: "ask"; text: string }
   | { kind: "error"; message: string }
   | { kind: "empty" };
 
 const MISSION_RE = /^\/mission\b\s*(.*)$/is;
+const MUTE_RE = /^\/mute\b\s*(.*)$/is;
+const UNMUTE_RE = /^\/unmute\b/i;
 const URL_RE = /^https?:\/\/\S+$/i;
 
-export function parseHermesInput(raw: string): HermesCommand {
+export function parseHermesInput(raw: string, now: () => number = Date.now): HermesCommand {
   const text = (raw ?? "").trim();
   if (!text) return { kind: "empty" };
 
-  const m = MISSION_RE.exec(text);
-  if (m) {
-    const arg = (m[1] ?? "").trim();
+  const mission = MISSION_RE.exec(text);
+  if (mission) {
+    const arg = (mission[1] ?? "").trim();
     if (!arg) {
       return { kind: "error", message: "/mission needs a target URL, e.g. /mission https://staging.averray.com/onboarding" };
     }
@@ -29,6 +38,14 @@ export function parseHermesInput(raw: string): HermesCommand {
       return { kind: "error", message: `"${url}" is not a valid http(s) URL.` };
     }
     return { kind: "mission", url };
+  }
+
+  if (UNMUTE_RE.test(text)) return { kind: "unmute" };
+
+  const mute = MUTE_RE.exec(text);
+  if (mute) {
+    const parsed = parseMuteArg(mute[1] ?? "", now);
+    return parsed.ok ? { kind: "mute", untilMs: parsed.untilMs } : { kind: "error", message: parsed.error };
   }
 
   return { kind: "ask", text };

--- a/packages/monitor-ui/src/lib/monitor/index.ts
+++ b/packages/monitor-ui/src/lib/monitor/index.ts
@@ -16,4 +16,7 @@ export * from "./snapshot-store.js";
 export * from "./live-stream.js";
 export * from "./hermes-commands.js";
 export * from "./collaboration.js";
+export * from "./notifications.js";
+export * from "./alert-audio.js";
+export * from "./favicon.js";
 export * from "./fixtures.js";

--- a/packages/monitor-ui/src/lib/monitor/notifications.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/notifications.test.ts
@@ -1,0 +1,91 @@
+import { test, assert } from "vitest";
+
+import {
+  DEFAULT_TITLE,
+  MUTE_STORAGE_KEY,
+  documentTitleFor,
+  isMuted,
+  parseMuteArg,
+  readMuteUntil,
+  shouldAlert,
+  writeMuteUntil,
+} from "./notifications.js";
+import type { StorageLike } from "./snapshot-store.js";
+
+function memStorage(): StorageLike {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => (m.has(k) ? (m.get(k) as string) : null),
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+    get length() {
+      return m.size;
+    },
+    key: (i) => Array.from(m.keys())[i] ?? null,
+  };
+}
+
+test("documentTitleFor prefixes a count only when action is needed", () => {
+  assert.equal(documentTitleFor(0), DEFAULT_TITLE);
+  assert.equal(documentTitleFor(3), `(3) ${DEFAULT_TITLE}`);
+  assert.equal(documentTitleFor(-1), DEFAULT_TITLE);
+  assert.equal(documentTitleFor(2, "X"), "(2) X");
+});
+
+test("shouldAlert fires only on the 0 → >0 edge", () => {
+  assert.equal(shouldAlert(0, 1), true);
+  assert.equal(shouldAlert(0, 3), true);
+  assert.equal(shouldAlert(1, 2), false); // already alerting
+  assert.equal(shouldAlert(2, 0), false); // cleared
+  assert.equal(shouldAlert(0, 0), false);
+});
+
+test("parseMuteArg: bare mute defaults to one hour", () => {
+  const now = () => 1_000_000;
+  const r = parseMuteArg("", now);
+  assert.ok(r.ok && r.untilMs === 1_000_000 + 3_600_000);
+});
+
+test("parseMuteArg: relative durations", () => {
+  const now = () => 0;
+  const m30 = parseMuteArg("30m", now);
+  assert.ok(m30.ok && m30.untilMs === 30 * 60_000);
+  const h2 = parseMuteArg("2h", now);
+  assert.ok(h2.ok && h2.untilMs === 2 * 3_600_000);
+});
+
+test("parseMuteArg: clock times resolve to a future instant within 24h", () => {
+  const now = () => Date.parse("2026-05-28T12:00:00");
+  const am9 = parseMuteArg("until 9am", now);
+  assert.ok(am9.ok);
+  if (am9.ok) {
+    // 9am already passed at noon → next day's 9am.
+    assert.ok(am9.untilMs > now());
+    assert.ok(am9.untilMs - now() <= 24 * 3_600_000);
+    assert.equal(new Date(am9.untilMs).getHours(), 9);
+  }
+});
+
+test("parseMuteArg: rejects nonsense", () => {
+  assert.equal(parseMuteArg("soon").ok, false);
+  assert.equal(parseMuteArg("0h").ok, false);
+  assert.equal(parseMuteArg("until 99:99").ok, false);
+});
+
+test("isMuted reflects the expiry vs now", () => {
+  const now = () => 100;
+  assert.equal(isMuted(200, now), true);
+  assert.equal(isMuted(50, now), false);
+  assert.equal(isMuted(null, now), false);
+  assert.equal(isMuted(undefined, now), false);
+});
+
+test("read/write mute round-trips and clears", () => {
+  const s = memStorage();
+  assert.equal(readMuteUntil(s), null);
+  writeMuteUntil(s, 12345);
+  assert.equal(s.getItem(MUTE_STORAGE_KEY), "12345");
+  assert.equal(readMuteUntil(s), 12345);
+  writeMuteUntil(s, null);
+  assert.equal(readMuteUntil(s), null);
+});

--- a/packages/monitor-ui/src/lib/monitor/notifications.ts
+++ b/packages/monitor-ui/src/lib/monitor/notifications.ts
@@ -1,0 +1,87 @@
+// Hermes Handoff Monitor — notification + mute pure logic (M9', §17/§21).
+//
+// The three notification tiers (in-app audio+visual, tab badge+title,
+// desktop notification) all fire on the same trigger: the action-needed
+// count crossing 0 → >0. This module owns the framework-free decisions —
+// when to alert, the title string, and the mute schedule — so the React
+// orchestrator (useActionAlerts) stays thin and the contract is tested.
+
+import type { StorageLike } from "./snapshot-store.js";
+
+export const DEFAULT_TITLE = "Hermes — Averray";
+export const MUTE_STORAGE_KEY = "monitor.mute.until";
+
+/** Tab title: "(N) Hermes — Averray" when action is needed, else the base. */
+export function documentTitleFor(actionCount: number, base: string = DEFAULT_TITLE): string {
+  const n = Number.isFinite(actionCount) && actionCount > 0 ? Math.floor(actionCount) : 0;
+  return n > 0 ? `(${n}) ${base}` : base;
+}
+
+/** Alert only on the 0 → >0 edge (the moment the operator newly must act). */
+export function shouldAlert(prev: number, next: number): boolean {
+  const p = Number.isFinite(prev) ? prev : 0;
+  const n = Number.isFinite(next) ? next : 0;
+  return p <= 0 && n > 0;
+}
+
+export type ParsedMute = { ok: true; untilMs: number } | { ok: false; error: string };
+
+/**
+ * Parse a mute argument into an absolute expiry timestamp.
+ *   ""              → 1 hour (the bare /mute default)
+ *   "30m" / "2h"    → relative duration
+ *   "9am" / "until 9am" / "14:30" → the next occurrence of that clock time
+ */
+export function parseMuteArg(arg: string, now: () => number = Date.now): ParsedMute {
+  const text = (arg ?? "").trim().toLowerCase();
+  if (!text) return { ok: true, untilMs: now() + 60 * 60 * 1000 };
+
+  const dur = /^(\d+)\s*(m|min|mins|h|hr|hrs|hour|hours)$/.exec(text);
+  if (dur) {
+    const n = Number.parseInt(dur[1] as string, 10);
+    if (n <= 0) return { ok: false, error: `"${arg}" must be a positive duration.` };
+    const ms = (dur[2] as string).startsWith("m") ? n * 60_000 : n * 3_600_000;
+    return { ok: true, untilMs: now() + ms };
+  }
+
+  const clock = /^(?:until\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm)?$/.exec(text);
+  if (clock) {
+    let hour = Number.parseInt(clock[1] as string, 10);
+    const min = clock[2] ? Number.parseInt(clock[2], 10) : 0;
+    const ap = clock[3];
+    if (ap === "pm" && hour < 12) hour += 12;
+    if (ap === "am" && hour === 12) hour = 0;
+    if (hour > 23 || min > 59) return { ok: false, error: `"${arg}" is not a valid time.` };
+    const nowMs = now();
+    const d = new Date(nowMs);
+    d.setHours(hour, min, 0, 0);
+    let untilMs = d.getTime();
+    if (untilMs <= nowMs) untilMs += 24 * 60 * 60 * 1000;
+    return { ok: true, untilMs };
+  }
+
+  return { ok: false, error: `Couldn't parse mute "${arg}". Try "/mute 1h" or "/mute until 9am".` };
+}
+
+/** Is the operator currently muted? */
+export function isMuted(untilMs: number | null | undefined, now: () => number = Date.now): boolean {
+  return typeof untilMs === "number" && untilMs > now();
+}
+
+/** Read the persisted mute expiry (ms), or null. */
+export function readMuteUntil(storage: StorageLike): number | null {
+  const raw = storage.getItem(MUTE_STORAGE_KEY);
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Persist (or clear, with null) the mute expiry. */
+export function writeMuteUntil(storage: StorageLike, untilMs: number | null): void {
+  try {
+    if (untilMs == null) storage.removeItem(MUTE_STORAGE_KEY);
+    else storage.setItem(MUTE_STORAGE_KEY, String(untilMs));
+  } catch {
+    /* best-effort persistence */
+  }
+}


### PR DESCRIPTION
## Summary
- **M9'** of the Hermes Handoff Monitor redesign: the three **§17 notification tiers** — all firing on the action-needed count crossing **0 → >0** — plus operator **mute** controls.

## Pure logic (`lib/monitor`)
- **`notifications.ts`** — `documentTitleFor` (the `(N) Hermes — Averray` title), `shouldAlert` (the 0→>0 edge), and the mute schedule: `parseMuteArg` (`1h` / `until 9am` / `14:30`), `isMuted`, localStorage read/write.
- **`alert-audio.ts`** — `playAlertTone`: the §21.3 procedural chime (sine, ~200ms, exponential decay) over an **injected** `AudioContext`.
- **`favicon.ts`** — `setAppBadge` (Badging API) + `setFaviconBadge` (canvas favicon with a count bubble), both feature-detected, no-op where unsupported (e.g. jsdom).

## Orchestration
- **`useActionAlerts(actionCount)`** — always reflects the count in the **title + favicon + app badge**; on the **0→>0 edge** (and unmuted) it **chimes when the tab is visible**, else fires a **desktop `Notification`** (when permission is granted). The first observed count only establishes a baseline, so opening the page with pending action doesn't alert. Fully dependency-injected (clock, storage, AudioContext, Notification, visibility, document, navigator).

## Mute via the co-pilot (§17)
- `/mute [1h|until 9am]` and `/unmute` commands → `AskHermesComposer` → `CoPilotRail` → `useActionAlerts`; a **muted chip** shows the state. Mute silences tiers 1 & 3, but the passive tab badge/title still reflect reality — **muting must not hide that action is pending** (truth-boundary).

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **322/322** (notifications/audio/favicon units; `useActionAlerts` edge/baseline/mute/visible-vs-hidden; composer + parser mute cases; `MonitorPage` end-to-end `/mute` → muted)
- [x] `npm test` (full repo) → **667/667**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

Per the acceptance, **cross-browser (Chrome / Safari / Firefox) verification** of the live audio + notification surfaces is a manual step (jsdom can't exercise Web Audio / Notifications / canvas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)