### PR TITLE
monitor-ui: keyboard shortcuts + overlay (M10')

### DIFF
--- a/packages/monitor-ui/src/components/Board.tsx
+++ b/packages/monitor-ui/src/components/Board.tsx
@@ -52,23 +52,43 @@ export const ACTION_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
 export type BoardProps = {
   /** Lane → card[] grouping from `groupByLane(cards)`. */
   grouped: Record<LaneKey, BoardCard[]>;
-  /** Lanes that should render expanded (rest collapse to mini-rails). */
+  /** Initial expansion when Board is uncontrolled. */
   initialExpanded?: ReadonlySet<LaneId>;
+  /** Controlled expansion. When provided, Board defers to the parent
+   *  (pair with onToggleLane) — used for keyboard spotlight (M10'). */
+  expanded?: ReadonlySet<LaneId>;
+  /** Toggle handler when controlled. */
+  onToggleLane?: (id: LaneId) => void;
   /** Optional renderer for a single card. M4' supplies the card components. */
   renderCard?: (card: BoardCard) => ReactNode;
 };
 
-export function Board({ grouped, initialExpanded = DEFAULT_EXPANDED, renderCard }: BoardProps) {
-  const [expanded, setExpanded] = useState<Set<LaneId>>(() => new Set(initialExpanded));
+export function Board({
+  grouped,
+  initialExpanded = DEFAULT_EXPANDED,
+  expanded: controlledExpanded,
+  onToggleLane,
+  renderCard,
+}: BoardProps) {
+  const [internalExpanded, setInternalExpanded] = useState<Set<LaneId>>(() => new Set(initialExpanded));
+  const isControlled = controlledExpanded !== undefined;
+  const expanded = isControlled ? controlledExpanded : internalExpanded;
 
-  const onToggle = useCallback((id: LaneId) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  }, []);
+  const onToggle = useCallback(
+    (id: LaneId) => {
+      if (isControlled) {
+        onToggleLane?.(id);
+        return;
+      }
+      setInternalExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      });
+    },
+    [isControlled, onToggleLane],
+  );
 
   return (
     <div className="hm-lanes" role="region" aria-label="Lane grid">

--- a/packages/monitor-ui/src/components/BoardView.keyboard.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.keyboard.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { act, cleanup, fireEvent, render, within } from "@testing-library/react";
+import { BoardView } from "./BoardView.js";
+import { FIXTURE_CARDS } from "../lib/monitor/fixtures.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+
+afterEach(cleanup);
+
+const board: MonitorBoard = { cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" };
+
+function press(key: string) {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+  });
+}
+
+describe("BoardView — keyboard (§12)", () => {
+  test("? toggles the keyboard overlay", () => {
+    const { queryByRole } = render(<BoardView board={board} status="open" />);
+    expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+    press("?");
+    expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeTruthy();
+    press("?");
+    expect(queryByRole("dialog", { name: "Keyboard shortcuts" })).toBeNull();
+  });
+
+  test("j focuses a card; Enter opens its drawer", () => {
+    const onCardClick = vi.fn();
+    const { container } = render(<BoardView board={board} status="open" onCardClick={onCardClick} />);
+    expect(container.querySelector(".hm-card.is-focused")).toBeNull();
+    press("j");
+    expect(container.querySelector(".hm-card.is-focused")).toBeTruthy();
+    press("Enter");
+    expect(onCardClick).toHaveBeenCalledTimes(1);
+  });
+
+  test("/ focuses the search input", () => {
+    const { container } = render(<BoardView board={board} status="open" />);
+    press("/");
+    expect(document.activeElement).toBe(container.querySelector(".hm-search input"));
+  });
+
+  test("typing in search filters the board", () => {
+    const { container } = render(<BoardView board={board} status="open" />);
+    const view = within(container);
+    const input = container.querySelector(".hm-search input") as HTMLInputElement;
+    expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: "onboarding" } });
+    expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
+    expect(view.queryByText("Docs: add receipt drawer screenshots + glossary for cosigner")).toBeNull();
+  });
+
+  test("o opens the focused card's PR on GitHub", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    try {
+      render(<BoardView board={board} status="open" />);
+      press("j"); // focus the first card (a needs-attention PR)
+      press("o");
+      expect(openSpy).toHaveBeenCalledTimes(1);
+      expect(String(openSpy.mock.calls[0]?.[0])).toMatch(/^https:\/\/github\.com\/.+\/pull\/\d+$/);
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -1,10 +1,10 @@
-// Hermes Handoff Monitor — BoardView (presentational board)
+// Hermes Handoff Monitor — BoardView (presentational board + keyboard).
 //
-// Pure render of the Direction A board from a MonitorBoard + stream
-// status. No data fetching — the live wiring lives in useMonitorBoard()
-// and the page container passes the result down. Keeping this component
-// data-free makes it deterministic to test and storybook against
-// fixtures.
+// Renders the Direction A board from a MonitorBoard + stream status, and
+// owns the board's view interaction: keyboard navigation (§12), the
+// cheat-sheet overlay, lane spotlight, and client-side search filtering.
+// Data fetching stays in the page container; this component takes the
+// result + callbacks and is deterministic to test against fixtures.
 //
 //   <div.hm-board>
 //     <TopStrip />               KPI pills + LIVE indicator + refresh
@@ -13,13 +13,17 @@
 //       <div.hm-lanes-wrap>
 //         <LanesBar />           search + filter chips + urgency label
 //         <Board renderCard />   the eight lanes, cards via <CardRouter>
-//       <aside.hm-hermes>        co-pilot rail chrome (full rail = M8')
+//       <CoPilotRail />          live narration + Ask-Hermes
+//   <DetailDrawer />             when ?card= resolves
+//   <KeyboardOverlay />          when ? is pressed
 
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
 import type { MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard } from "../lib/monitor/card-types.js";
+import { laneFor } from "../lib/monitor/lane-rules.js";
+import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
 import { BoardNowBanner } from "./BoardNowBanner.js";
 import { LanesBar } from "./LanesBar.js";
@@ -28,7 +32,9 @@ import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
 import { DetailDrawer } from "./drawer/DetailDrawer.js";
 import { CoPilotRail } from "./hermes/CoPilotRail.js";
+import { KeyboardOverlay } from "./shortcuts/KeyboardOverlay.js";
 import type { UseCollaborationOptions } from "../hooks/useCollaboration.js";
+import { useBoardKeyboard } from "../hooks/useBoardKeyboard.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
 // action preset expands that lane (not operator-review) to keep the
@@ -47,29 +53,29 @@ function expandedForMode(mode: BoardMode): ReadonlySet<LaneId> {
   return ACTION_EXPANDED;
 }
 
+function matchesQuery(card: BoardCard, q: string): boolean {
+  if (!q) return true;
+  const hay = `${card.id} ${card.title} ${card.repo} ${card.branch ?? ""} ${card.summary ?? ""}`.toLowerCase();
+  return hay.includes(q);
+}
+
 export interface BoardViewProps {
   board: MonitorBoard | undefined;
   status: StreamStatus;
-  /** Refresh handler (the top-strip Refresh button). */
   onRefresh?: () => void;
   /** Focused card id (drives the detail drawer); null/undefined = closed. */
   focusedCardId?: string | null;
-  /** A card was clicked — open its drawer (sets ?card=). */
+  /** A card was clicked / Enter pressed — open its drawer (sets ?card=). */
   onCardClick?: (id: string) => void;
-  /** Close the drawer (esc / scrim). */
   onCardClose?: () => void;
-  /** j/k traversal target within the drawer. */
   onCardNavigate?: (id: string) => void;
-  /** Spawn a browser mission via the Hermes composer (/mission <url>). */
   onSpawnMission?: (url: string) => void;
-  /** Co-pilot collaboration wiring. Omit to keep the rail inert. */
   collaboration?: UseCollaborationOptions;
-  /** Mute action alerts until a timestamp (/mute). */
   onMute?: (untilMs: number) => void;
-  /** Clear the alert mute (/unmute). */
   onUnmute?: () => void;
-  /** Whether action alerts are currently muted. */
   muted?: boolean;
+  /** Disable the global keyboard handler (tests rendering many boards). */
+  keyboard?: boolean;
 }
 
 export function BoardView({
@@ -85,32 +91,92 @@ export function BoardView({
   onMute,
   onUnmute,
   muted,
+  keyboard = true,
 }: BoardViewProps) {
-  // The stream is "degraded" only on a real drop (reconnecting/closed);
-  // idle/connecting are pre-live transients, not disconnections. The
-  // LIVE indicator, by contrast, only lights on a confirmed open stream.
   const degraded = status === "reconnecting" || status === "closed";
   const streamOnline = !degraded;
   const cards = board?.cards ?? [];
   const liveLabel = useMemo(() => formatClock(board?.at), [board?.at]);
 
+  // KPIs / banner / mode reflect the whole board, regardless of search.
   const state = useMemo(
-    () =>
-      deriveBoardState(cards, {
-        streamOnline,
-        nowLabel: liveLabel,
-        lastGoodLabel: liveLabel || undefined,
-      }),
+    () => deriveBoardState(cards, { streamOnline, nowLabel: liveLabel, lastGoodLabel: liveLabel || undefined }),
     [cards, streamOnline, liveLabel],
   );
 
-  // Cards in display (lane) order — the traversal list for the drawer's
-  // j/k, and the lookup for the focused card.
+  // ── view state ──────────────────────────────────────────────────
+  const [query, setQuery] = useState("");
+  const [boardFocusId, setBoardFocusId] = useState<string | null>(null);
+  const [overlayOpen, setOverlayOpen] = useState(false);
+  const [askToken, setAskToken] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // Controlled lane expansion: seed from the mode preset, re-apply when
+  // the board mode flips (e.g. empty→action as live data arrives), but
+  // keep manual toggles / spotlight within a stable mode.
+  const [expanded, setExpanded] = useState<ReadonlySet<LaneId>>(() => new Set(expandedForMode(state.mode)));
+  const modeRef = useRef(state.mode);
+  useEffect(() => {
+    if (modeRef.current !== state.mode) {
+      modeRef.current = state.mode;
+      setExpanded(new Set(expandedForMode(state.mode)));
+    }
+  }, [state.mode]);
+
+  // Search filters what's shown + focusable (not the KPI counts).
+  const q = query.trim().toLowerCase();
+  const displayGrouped = useMemo(() => {
+    if (!q) return state.grouped;
+    const out = {} as Record<LaneId, BoardCard[]>;
+    for (const lane of LANES) out[lane] = (state.grouped[lane] ?? []).filter((c) => matchesQuery(c, q));
+    return out;
+  }, [state.grouped, q]);
+
   const orderedCards = useMemo<BoardCard[]>(
-    () => LANES.flatMap((lane) => state.grouped[lane] ?? []),
-    [state.grouped],
+    () => LANES.flatMap((lane) => displayGrouped[lane] ?? []),
+    [displayGrouped],
   );
-  const focusedCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
+
+  const drawerCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
+  const boardFocusedCard = boardFocusId ? orderedCards.find((c) => c.id === boardFocusId) : undefined;
+  const scopeCard = drawerCard ?? boardFocusedCard;
+
+  const onToggleLane = useCallback((id: LaneId) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  // ── keyboard (§12) ──────────────────────────────────────────────
+  useBoardKeyboard({
+    enabled: keyboard,
+    cards: orderedCards,
+    focusedId: boardFocusId,
+    drawerOpen: Boolean(drawerCard),
+    overlayOpen,
+    onFocusChange: setBoardFocusId,
+    onToggleOverlay: () => setOverlayOpen((o) => !o),
+    onCloseOverlay: () => setOverlayOpen(false),
+    onFocusSearch: () => searchInputRef.current?.focus(),
+    onOpenFocused: (id) => onCardClick?.(id),
+    onSpotlight: (id) => {
+      const card = orderedCards.find((c) => c.id === id);
+      if (card) setExpanded(new Set<LaneId>([laneFor(card), "done"]));
+    },
+    onOpenPr: (id) => {
+      const pr = relatedPrForCard(orderedCards.find((c) => c.id === id));
+      if (pr && typeof window !== "undefined") {
+        window.open(`https://github.com/${pr.repo}/pull/${pr.number}`, "_blank", "noopener,noreferrer");
+      }
+    },
+    onAsk: (id) => {
+      setBoardFocusId(id);
+      setAskToken((t) => t + 1);
+    },
+  });
 
   return (
     <div className="hm-board">
@@ -124,20 +190,22 @@ export function BoardView({
 
       <div className="hm-main">
         <div className="hm-lanes-wrap">
-          <LanesBar counts={state.counts} mode={state.mode} />
-          {/* Key by mode: <Board> seeds its expansion state from
-              initialExpanded only on mount, so when the board transitions
-              (e.g. empty→action as live data arrives) we remount to apply
-              the new preset. Manual collapse/expand toggles persist within
-              a mode; a mode change is a significant enough event to reset. */}
+          <LanesBar
+            counts={state.counts}
+            mode={state.mode}
+            searchValue={query}
+            onSearchChange={setQuery}
+            searchInputRef={searchInputRef}
+          />
           <Board
-            key={state.mode}
-            grouped={state.grouped}
-            initialExpanded={expandedForMode(state.mode)}
+            grouped={displayGrouped}
+            expanded={expanded}
+            onToggleLane={onToggleLane}
             renderCard={(card) => (
               <CardRouter
                 key={card.id}
                 card={card}
+                focused={card.id === boardFocusId}
                 onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
               />
             )}
@@ -146,22 +214,25 @@ export function BoardView({
 
         <CoPilotRail
           onSpawnMission={onSpawnMission}
-          focusedCard={focusedCard}
+          focusedCard={scopeCard}
           collaboration={collaboration}
           onMute={onMute}
           onUnmute={onUnmute}
           muted={muted}
+          composerFocusToken={askToken}
         />
       </div>
 
-      {focusedCard ? (
+      {drawerCard ? (
         <DetailDrawer
-          card={focusedCard}
+          card={drawerCard}
           cards={orderedCards}
           onClose={() => onCardClose?.()}
           onNavigate={(id) => onCardNavigate?.(id)}
         />
       ) : null}
+
+      {overlayOpen ? <KeyboardOverlay onClose={() => setOverlayOpen(false)} /> : null}
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/LanesBar.test.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, test } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { LanesBar } from "./LanesBar.js";
 import type { KPICounts } from "../lib/monitor/board-state.js";
 
@@ -18,13 +18,23 @@ const counts: KPICounts = {
 };
 
 describe("LanesBar", () => {
-  test("renders a disabled, read-only search input with the / hint", () => {
+  test("read-only search input (no handler) with the / hint", () => {
     const { container, getByText } = render(<LanesBar counts={counts} mode="calm" />);
     const input = container.querySelector(".hm-search input") as HTMLInputElement;
     expect(input).toBeTruthy();
-    expect(input.disabled).toBe(true);
-    expect(input.readOnly).toBe(true);
+    expect(input.readOnly).toBe(true); // no onSearchChange → read-only
     expect(getByText("/")).toBeTruthy();
+  });
+
+  test("an interactive search input reports changes", () => {
+    const onSearchChange = vi.fn();
+    const { container } = render(
+      <LanesBar counts={counts} mode="calm" searchValue="" onSearchChange={onSearchChange} />,
+    );
+    const input = container.querySelector(".hm-search input") as HTMLInputElement;
+    expect(input.readOnly).toBe(false);
+    fireEvent.change(input, { target: { value: "xcm" } });
+    expect(onSearchChange).toHaveBeenCalledWith("xcm");
   });
 
   test("tip text follows board mode", () => {

--- a/packages/monitor-ui/src/components/LanesBar.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.tsx
@@ -12,6 +12,7 @@
 // via URL params). Filter chips render count-only and are
 // non-interactive. The tip is derived from the board mode.
 
+import type { Ref } from "react";
 import type { KPICounts, BoardMode } from "../lib/monitor/board-state.js";
 
 const TIPS: Record<BoardMode, string> = {
@@ -23,11 +24,15 @@ const TIPS: Record<BoardMode, string> = {
 export type LanesBarProps = {
   counts: KPICounts;
   mode: BoardMode;
-  /** Search value (M5' wires this; M3' is read-only). */
+  /** Current search query. */
   searchValue?: string;
+  /** Search change handler. When omitted the input is read-only. */
+  onSearchChange?: (value: string) => void;
+  /** Ref to the search input so `/` can focus it (M10'). */
+  searchInputRef?: Ref<HTMLInputElement>;
 };
 
-export function LanesBar({ counts, mode, searchValue = "" }: LanesBarProps) {
+export function LanesBar({ counts, mode, searchValue = "", onSearchChange, searchInputRef }: LanesBarProps) {
   const tip = TIPS[mode];
   const filters: Array<[label: string, count: number]> = [
     ["All", counts.total],
@@ -46,12 +51,13 @@ export function LanesBar({ counts, mode, searchValue = "" }: LanesBarProps) {
             ⌕
           </span>
           <input
+            ref={searchInputRef}
             type="search"
             placeholder="search PR, repo, correlation id…"
             value={searchValue}
-            disabled
-            aria-label="Search PRs, repos, or correlation IDs (wired in M5')"
-            readOnly
+            onChange={onSearchChange ? (e) => onSearchChange(e.target.value) : undefined}
+            readOnly={!onSearchChange}
+            aria-label="Search PRs, repos, or correlation IDs"
           />
           <kbd>/</kbd>
         </span>

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -7,7 +7,7 @@
 // Enter sends, Shift+Enter inserts a newline. Parsing lives in the pure
 // hermes-commands helper; this component owns only input + dispatch.
 
-import { useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
 
 export interface AskHermesComposerProps {
@@ -23,6 +23,8 @@ export interface AskHermesComposerProps {
   muted?: boolean;
   /** Focused card id, shown in the scope chip. */
   focusedCardId?: string | null;
+  /** Bump to programmatically focus the input (the board's `a` shortcut). */
+  focusToken?: number;
 }
 
 export function AskHermesComposer({
@@ -32,9 +34,16 @@ export function AskHermesComposer({
   onUnmute,
   muted,
   focusedCardId,
+  focusToken,
 }: AskHermesComposerProps) {
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // The board's `a` shortcut bumps focusToken to bring focus here.
+  useEffect(() => {
+    if (focusToken) inputRef.current?.focus();
+  }, [focusToken]);
 
   const send = () => {
     const command = parseHermesInput(value);
@@ -92,6 +101,7 @@ export function AskHermesComposer({
       </div>
       <div className="hm-compose-row">
         <textarea
+          ref={inputRef}
           className="hm-compose-input"
           placeholder="Ask Hermes · /mission <url> · /mute 1h"
           aria-label="Ask Hermes, spawn a mission, or mute alerts"

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -25,6 +25,8 @@ export interface CoPilotRailProps {
   onUnmute?: () => void;
   /** Whether action alerts are currently muted. */
   muted?: boolean;
+  /** Bump to focus the composer (the board's `a` shortcut). */
+  composerFocusToken?: number;
 }
 
 export function CoPilotRail({
@@ -34,6 +36,7 @@ export function CoPilotRail({
   onMute,
   onUnmute,
   muted,
+  composerFocusToken,
 }: CoPilotRailProps) {
   const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
   const relatedPr = relatedPrForCard(focusedCard);
@@ -76,6 +79,7 @@ export function CoPilotRail({
         onUnmute={onUnmute}
         muted={muted}
         focusedCardId={focusedCard?.id ?? null}
+        focusToken={composerFocusToken}
       />
     </aside>
   );

--- a/packages/monitor-ui/src/components/shortcuts/KeyboardOverlay.test.tsx
+++ b/packages/monitor-ui/src/components/shortcuts/KeyboardOverlay.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { KeyboardOverlay } from "./KeyboardOverlay.js";
+
+afterEach(cleanup);
+
+describe("KeyboardOverlay", () => {
+  test("is a labelled modal dialog grouped by scope, with wired + 'soon' bindings", () => {
+    const { getByRole } = render(<KeyboardOverlay onClose={() => {}} />);
+    const dialog = getByRole("dialog", { name: "Keyboard shortcuts" });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    const view = within(dialog);
+    expect(view.getByText("Anywhere")).toBeTruthy();
+    expect(view.getByText("On the board")).toBeTruthy();
+    expect(view.getByText("next card")).toBeTruthy();
+    // a still-deferred binding is tagged so the sheet doesn't over-promise
+    expect(view.getByText(/approve · soon/)).toBeTruthy();
+  });
+
+  test("the close button calls onClose", () => {
+    const onClose = vi.fn();
+    const { getByRole } = render(<KeyboardOverlay onClose={onClose} />);
+    fireEvent.click(getByRole("button", { name: "Close keyboard shortcuts" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/monitor-ui/src/components/shortcuts/KeyboardOverlay.tsx
+++ b/packages/monitor-ui/src/components/shortcuts/KeyboardOverlay.tsx
@@ -1,0 +1,86 @@
+// Hermes Handoff Monitor — keyboard cheat sheet (M10', §12).
+//
+// Reads the binding contract directly (keyboard-map.ts) so what the
+// operator sees is exactly what the handlers listen for — no hand-kept
+// duplicate list. Toggled by `?`, dismissed by `?` / Escape / click.
+// Bindings not yet wired are shown dimmed and tagged "soon" so the sheet
+// never over-promises.
+
+import { KEYBOARD_BINDINGS, type ShortcutScope, visibleBindings } from "../../lib/monitor/keyboard-map.js";
+
+const SCOPE_ORDER: ShortcutScope[] = ["global", "board", "drawer", "hermes"];
+const SCOPE_LABEL: Record<ShortcutScope, string> = {
+  global: "Anywhere",
+  board: "On the board",
+  drawer: "In the drawer",
+  hermes: "Hermes composer",
+};
+
+/** Pretty key cap for a KeyboardEvent.key value. */
+function keyCap(key: string): string {
+  if (key === "Enter") return "↵";
+  if (key === "ArrowUp") return "↑";
+  if (key === "ArrowDown") return "↓";
+  if (key === "Escape") return "esc";
+  return key.length === 1 ? key.toUpperCase() : key;
+}
+
+export interface KeyboardOverlayProps {
+  onClose: () => void;
+}
+
+export function KeyboardOverlay({ onClose }: KeyboardOverlayProps) {
+  const bindings = visibleBindings();
+
+  return (
+    <div className="hm-keys" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+      <div className="title" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span>Keyboard · press ? to toggle</span>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close keyboard shortcuts"
+          style={{
+            marginLeft: "auto",
+            cursor: "pointer",
+            color: "var(--hm-muted-soft)",
+            fontWeight: 500,
+            fontSize: 11,
+            background: "none",
+            border: "none",
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      {SCOPE_ORDER.map((scope) => {
+        const rows = bindings.filter((b) => b.scope === scope);
+        if (rows.length === 0) return null;
+        return (
+          <div key={scope} className="hm-keys-group">
+            <div className="hm-keys-group-title hm-mono hm-muted">{SCOPE_LABEL[scope]}</div>
+            {rows.map((b) => (
+              <div
+                className="row"
+                key={`${b.scope}:${b.key}:${b.action}`}
+                style={b.wired ? undefined : { opacity: 0.45 }}
+              >
+                <span className="key">
+                  <span className="hm-kbd">{keyCap(b.key)}</span>
+                </span>
+                <span>
+                  {b.label}
+                  {b.wired ? "" : " · soon"}
+                </span>
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Re-export so callers can show only the live bindings if they prefer. */
+export { KEYBOARD_BINDINGS };

--- a/packages/monitor-ui/src/hooks/useBoardKeyboard.test.tsx
+++ b/packages/monitor-ui/src/hooks/useBoardKeyboard.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, renderHook } from "@testing-library/react";
+import { useBoardKeyboard, type UseBoardKeyboardOptions } from "./useBoardKeyboard.js";
+
+afterEach(cleanup);
+
+const cards = [{ id: "a" }, { id: "b" }, { id: "c" }];
+
+function press(key: string, target?: EventTarget) {
+  (target ?? window).dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true }));
+}
+
+function baseOpts(over: Partial<UseBoardKeyboardOptions> = {}): UseBoardKeyboardOptions {
+  return {
+    cards,
+    focusedId: "b",
+    drawerOpen: false,
+    overlayOpen: false,
+    onFocusChange: vi.fn(),
+    onToggleOverlay: vi.fn(),
+    onCloseOverlay: vi.fn(),
+    onFocusSearch: vi.fn(),
+    onOpenFocused: vi.fn(),
+    onSpotlight: vi.fn(),
+    onOpenPr: vi.fn(),
+    onAsk: vi.fn(),
+    ...over,
+  };
+}
+
+describe("useBoardKeyboard", () => {
+  test("global keys (?, /) fire anywhere", () => {
+    const opts = baseOpts();
+    renderHook(() => useBoardKeyboard(opts));
+    press("?");
+    expect(opts.onToggleOverlay).toHaveBeenCalledTimes(1);
+    press("/");
+    expect(opts.onFocusSearch).toHaveBeenCalledTimes(1);
+  });
+
+  test("board nav: j/k move focus; Enter/o/a/f act on the focused card", () => {
+    const opts = baseOpts();
+    renderHook(() => useBoardKeyboard(opts));
+    press("j");
+    expect(opts.onFocusChange).toHaveBeenCalledWith("c"); // b → next
+    press("k");
+    expect(opts.onFocusChange).toHaveBeenCalledWith("a"); // b → prev
+    press("Enter");
+    expect(opts.onOpenFocused).toHaveBeenCalledWith("b");
+    press("o");
+    expect(opts.onOpenPr).toHaveBeenCalledWith("b");
+    press("a");
+    expect(opts.onAsk).toHaveBeenCalledWith("b");
+    press("f");
+    expect(opts.onSpotlight).toHaveBeenCalledWith("b");
+  });
+
+  test("arrow keys alias j/k", () => {
+    const opts = baseOpts();
+    renderHook(() => useBoardKeyboard(opts));
+    press("ArrowDown");
+    expect(opts.onFocusChange).toHaveBeenCalledWith("c");
+    press("ArrowUp");
+    expect(opts.onFocusChange).toHaveBeenCalledWith("a");
+  });
+
+  test("board keys stand down while a drawer is open; global keys still fire", () => {
+    const opts = baseOpts({ drawerOpen: true });
+    renderHook(() => useBoardKeyboard(opts));
+    press("j");
+    press("Enter");
+    expect(opts.onFocusChange).not.toHaveBeenCalled();
+    expect(opts.onOpenFocused).not.toHaveBeenCalled();
+    press("?");
+    expect(opts.onToggleOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  test("Escape closes the overlay when open", () => {
+    const opts = baseOpts({ overlayOpen: true });
+    renderHook(() => useBoardKeyboard(opts));
+    press("Escape");
+    expect(opts.onCloseOverlay).toHaveBeenCalledTimes(1);
+  });
+
+  test("typing in an input suppresses every key but Escape", () => {
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const opts = baseOpts({ overlayOpen: true });
+    renderHook(() => useBoardKeyboard(opts));
+    press("j", input);
+    press("?", input);
+    expect(opts.onFocusChange).not.toHaveBeenCalled();
+    expect(opts.onToggleOverlay).not.toHaveBeenCalled();
+    press("Escape", input);
+    expect(opts.onCloseOverlay).toHaveBeenCalledTimes(1);
+    input.remove();
+  });
+
+  test("enabled:false is inert", () => {
+    const opts = baseOpts({ enabled: false });
+    renderHook(() => useBoardKeyboard(opts));
+    press("j");
+    press("?");
+    expect(opts.onFocusChange).not.toHaveBeenCalled();
+    expect(opts.onToggleOverlay).not.toHaveBeenCalled();
+  });
+});

--- a/packages/monitor-ui/src/hooks/useBoardKeyboard.ts
+++ b/packages/monitor-ui/src/hooks/useBoardKeyboard.ts
@@ -1,0 +1,119 @@
+// Hermes Handoff Monitor — board + global keyboard shortcuts (M10', §12).
+//
+// One window-level keydown handler drives the "mouse unplugged" flow.
+// Scope precedence and the input-focus rule come straight from §12:
+//   - an <input>/<textarea> with focus suppresses everything but Escape
+//   - global keys (?, /, Escape) work anywhere
+//   - board keys (j/k/↑/↓, Enter, f, o, a) only when no drawer/overlay
+//     is open — the drawer owns j/k/Esc while it's up (M6')
+//
+// Drawer-scope and hermes-scope keys are handled by their own components;
+// this hook owns global + board.
+
+import { useEffect, useRef } from "react";
+import { traverseDrawerCard } from "../lib/monitor/drawer-routing.js";
+
+export interface UseBoardKeyboardOptions {
+  enabled?: boolean;
+  /** Ordered visible cards for j/k focus traversal. */
+  cards: ReadonlyArray<{ id: string }>;
+  focusedId: string | null;
+  /** When a drawer is open it owns j/k/Esc, so board nav stands down. */
+  drawerOpen: boolean;
+  overlayOpen: boolean;
+  onFocusChange: (id: string | null) => void;
+  onToggleOverlay: () => void;
+  onCloseOverlay: () => void;
+  onFocusSearch: () => void;
+  onOpenFocused: (id: string) => void;
+  onSpotlight: (id: string) => void;
+  onOpenPr: (id: string) => void;
+  onAsk: (id: string) => void;
+}
+
+export function useBoardKeyboard(opts: UseBoardKeyboardOptions): void {
+  const ref = useRef(opts);
+  ref.current = opts;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const o = ref.current;
+      if (o.enabled === false) return;
+
+      const target = e.target as HTMLElement | null;
+      const typing = !!target && /^(INPUT|TEXTAREA)$/.test(target.tagName);
+      if (typing) {
+        // Only Escape escapes an input — blur it (and close the overlay).
+        if (e.key === "Escape") {
+          target.blur();
+          if (o.overlayOpen) o.onCloseOverlay();
+        }
+        return;
+      }
+
+      // Global scope — works anywhere.
+      if (e.key === "?") {
+        e.preventDefault();
+        o.onToggleOverlay();
+        return;
+      }
+      if (e.key === "Escape") {
+        if (o.overlayOpen) {
+          e.preventDefault();
+          o.onCloseOverlay();
+        }
+        return; // drawer Escape is handled by the drawer itself
+      }
+      if (e.key === "/") {
+        e.preventDefault();
+        o.onFocusSearch();
+        return;
+      }
+
+      // Board scope — yield to an open drawer or overlay.
+      if (o.drawerOpen || o.overlayOpen) return;
+
+      switch (e.key) {
+        case "j":
+        case "ArrowDown":
+          e.preventDefault();
+          o.onFocusChange(traverseDrawerCard(o.cards, o.focusedId, "next"));
+          return;
+        case "k":
+        case "ArrowUp":
+          e.preventDefault();
+          o.onFocusChange(traverseDrawerCard(o.cards, o.focusedId, "prev"));
+          return;
+        case "Enter":
+          if (o.focusedId) {
+            e.preventDefault();
+            o.onOpenFocused(o.focusedId);
+          }
+          return;
+        case "f":
+          if (o.focusedId) {
+            e.preventDefault();
+            o.onSpotlight(o.focusedId);
+          }
+          return;
+        case "o":
+          if (o.focusedId) {
+            e.preventDefault();
+            o.onOpenPr(o.focusedId);
+          }
+          return;
+        case "a":
+          if (o.focusedId) {
+            e.preventDefault();
+            o.onAsk(o.focusedId);
+          }
+          return;
+        default:
+          return;
+      }
+    };
+
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+}

--- a/packages/monitor-ui/src/lib/monitor/keyboard-map.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/keyboard-map.test.ts
@@ -131,16 +131,18 @@ test("visibleBindings: with no options returns the full ordered list", () => {
   }
 });
 
-test("visibleBindings: wiredOnly filters to just the M1-wired shortcuts", () => {
+test("visibleBindings: wiredOnly returns only wired bindings", () => {
   const visible = visibleBindings({ wiredOnly: true });
-  // Every entry in the filtered list must have wired: true
+  // Every entry in the filtered list must have wired: true.
   for (const b of visible) {
     assert.equal(b.wired, true, `wiredOnly should filter unwired bindings: ${b.action}`);
   }
-  // And the M9 board entries (`o` and `a`) must NOT be present
   const actions = visible.map((b) => b.action);
-  assert.ok(!actions.includes("open_pr_for_focused"), "o should be filtered by wiredOnly");
-  assert.ok(!actions.includes("ask_hermes_about_focused"), "a should be filtered by wiredOnly");
+  // M10' wired the board o/a shortcuts, so they're now included…
+  assert.ok(actions.includes("open_pr_for_focused"), "o is wired in M10'");
+  assert.ok(actions.includes("ask_hermes_about_focused"), "a is wired in M10'");
+  // …while still-deferred drawer action keys remain filtered out.
+  assert.ok(!actions.includes("drawer_action_approve"), "drawer approve is still unwired");
 });
 
 // ── Specific M1 contract assertions ─────────────────────────────────
@@ -160,11 +162,19 @@ test("the eight keys wired by the prototype are all marked wired=true", () => {
   }
 });
 
-test("the M9 additions (o, a) are present but marked wired=false", () => {
+test("the board o/a shortcuts are wired in M10'", () => {
   const o = KEYBOARD_BINDINGS.find((b) => b.scope === "board" && b.key === "o");
   const a = KEYBOARD_BINDINGS.find((b) => b.scope === "board" && b.key === "a");
   assert.ok(o, "binding for 'o' must exist");
   assert.ok(a, "binding for 'a' must exist");
-  assert.equal(o.wired, false);
-  assert.equal(a.wired, false);
+  assert.equal(o.wired, true);
+  assert.equal(a.wired, true);
+});
+
+test("drawer action keys (A/B/R/M/C) remain deferred (wired=false)", () => {
+  for (const key of ["A", "B", "R", "M", "C"]) {
+    const b = KEYBOARD_BINDINGS.find((x) => x.scope === "drawer" && x.key === key);
+    assert.ok(b, `binding for drawer '${key}' must exist`);
+    assert.equal(b.wired, false);
+  }
 });

--- a/packages/monitor-ui/src/lib/monitor/keyboard-map.ts
+++ b/packages/monitor-ui/src/lib/monitor/keyboard-map.ts
@@ -38,12 +38,12 @@ export const KEYBOARD_BINDINGS: readonly ShortcutBinding[] = Object.freeze([
   { key: "Enter", action: "open_drawer_for_focused", label: "open focused card", scope: "board", wired: true },
   { key: "f", action: "spotlight_focused_lane", label: "focus / spotlight lane", scope: "board", wired: true },
   // M10' additions
-  { key: "o", action: "open_pr_for_focused", label: "open PR on GitHub", scope: "board", wired: false },
-  { key: "a", action: "ask_hermes_about_focused", label: "ask Hermes about focused card", scope: "board", wired: false },
+  { key: "o", action: "open_pr_for_focused", label: "open PR on GitHub", scope: "board", wired: true },
+  { key: "a", action: "ask_hermes_about_focused", label: "ask Hermes about focused card", scope: "board", wired: true },
 
   // Drawer
-  { key: "j", action: "drawer_next_card", label: "next card (in drawer)", scope: "drawer", wired: false },
-  { key: "k", action: "drawer_prev_card", label: "previous card (in drawer)", scope: "drawer", wired: false },
+  { key: "j", action: "drawer_next_card", label: "next card (in drawer)", scope: "drawer", wired: true },
+  { key: "k", action: "drawer_prev_card", label: "previous card (in drawer)", scope: "drawer", wired: true },
   { key: "Enter", action: "drawer_primary_action", label: "trigger primary action", scope: "drawer", wired: false },
   { key: "A", action: "drawer_action_approve", label: "approve", scope: "drawer", wired: false },
   { key: "B", action: "drawer_action_send_back", label: "send back to Codex", scope: "drawer", wired: false },
@@ -52,7 +52,7 @@ export const KEYBOARD_BINDINGS: readonly ShortcutBinding[] = Object.freeze([
   { key: "C", action: "drawer_copy_report", label: "copy report", scope: "drawer", wired: false },
 
   // Hermes co-pilot composer
-  { key: "Enter", action: "hermes_send_message", label: "send message", scope: "hermes", wired: false },
+  { key: "Enter", action: "hermes_send_message", label: "send message", scope: "hermes", wired: true },
   { key: "ArrowUp", action: "hermes_history_prev", label: "previous question", scope: "hermes", wired: false },
   { key: "ArrowDown", action: "hermes_history_next", label: "next question", scope: "hermes", wired: false },
 ]);


### PR DESCRIPTION
## Summary
- **M10'**: wires the full **§12 keyboard map** so an operator can run a shift with the mouse unplugged, plus the **`<KeyboardOverlay>`** cheat sheet.

## Shortcuts (`useBoardKeyboard`)
One window-level handler for **global + board** scope, honoring §12's rules:
- **Input-focus rule** — only `Escape` escapes an `<input>`/`<textarea>`.
- **Scope yielding** — board keys stand down while a drawer or overlay is open (the drawer owns `j`/`k`/`Esc` from M6').
- **Global:** `?` toggle overlay · `/` jump to search · `Esc` close overlay.
- **Board:** `j`/`k`/`↑`/`↓` move focus · `Enter` open the focused card's drawer · `f` spotlight its lane · `o` open its PR on GitHub · `a` focus the Ask-Hermes composer (scoped to it).

## Overlay
`<KeyboardOverlay>` renders **straight from `keyboard-map.ts`** (single source of truth), grouped by scope. Still-deferred bindings (drawer `A/B/R/M/C`) are dimmed and tagged **"soon"** so the sheet never over-promises.

## Supporting changes
- `<Board>` gains an optional **controlled-expansion** mode (`expanded` + `onToggleLane`) used for the `f` spotlight; uncontrolled behaviour (and its tests) is unchanged.
- `BoardView` lifts expansion to controlled state with a mode-reset effect (replacing the M5' `key={mode}` remount), owns the board focus / overlay / search state, and wires **client-side search filtering** — so the now-enabled search box actually filters instead of sitting inert.
- `keyboard-map`: `o`/`a` (board), drawer `j`/`k`, and hermes `Enter` flipped to `wired:true` to match reality; drawer action keys stay deferred.

## Deferred
- Drawer action shortcuts (`A`/`B`/`R`/`M`/`C`) — depend on real approve/send-back/rerun actions (a later milestone); shown as "soon".
- Degraded states + error boundaries + WCAG AA pass → **M11'**.

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **338/338** (`KeyboardOverlay`; `useBoardKeyboard` global/board/drawer-yield/input-suppression/disabled; `BoardView` integration: `?`, `j`+`Enter`, `/` focus, search filter, `o`→PR)
- [x] `npm test` (full repo) → **683/683**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)