### PR TITLE
monitor-ui: degraded states + error boundary + a11y pass (M11')

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -27,6 +27,7 @@ import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import { BoardView } from "./components/BoardView.js";
+import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
 const MISSIONS_URL = "/monitor/testbed-missions";
 
@@ -55,20 +56,22 @@ export function MonitorPage({
   const { muted, mute, unmute } = useActionAlerts(actionCount, alerts);
 
   return (
-    <BoardView
-      board={board}
-      status={status}
-      onRefresh={refresh}
-      focusedCardId={cardId}
-      onCardClick={setCard}
-      onCardClose={clearCard}
-      onCardNavigate={setCard}
-      onSpawnMission={onSpawnMission}
-      collaboration={collaboration}
-      onMute={mute}
-      onUnmute={unmute}
-      muted={muted}
-    />
+    <ErrorBoundary>
+      <BoardView
+        board={board}
+        status={status}
+        onRefresh={refresh}
+        focusedCardId={cardId}
+        onCardClick={setCard}
+        onCardClose={clearCard}
+        onCardNavigate={setCard}
+        onSpawnMission={onSpawnMission}
+        collaboration={collaboration}
+        onMute={mute}
+        onUnmute={unmute}
+        muted={muted}
+      />
+    </ErrorBoundary>
   );
 }
 

--- a/packages/monitor-ui/src/components/BoardView.degraded.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.degraded.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { BoardView } from "./BoardView.js";
+import { FIXTURE_CARDS } from "../lib/monitor/fixtures.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+
+afterEach(cleanup);
+
+const board: MonitorBoard = { cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" };
+const emptyBoard: MonitorBoard = { cards: [], at: "2026-05-28T10:30:00Z" };
+
+describe("BoardView — degraded top strip", () => {
+  test("open stream → normal top strip (no degraded header)", () => {
+    const { container } = render(<BoardView board={board} status="open" keyboard={false} />);
+    expect(container.querySelector(".hm-top--degraded")).toBeNull();
+    expect(container.querySelector(".hm-top")).toBeTruthy();
+  });
+
+  test("reconnecting / closed → degraded header replaces the normal strip", () => {
+    const reconnecting = render(<BoardView board={board} status="reconnecting" keyboard={false} />);
+    expect(reconnecting.container.querySelector(".hm-top--degraded")).toBeTruthy();
+    expect(reconnecting.getByText("UNTRUSTED")).toBeTruthy();
+
+    const closed = render(<BoardView board={board} status="closed" keyboard={false} />);
+    expect(closed.container.querySelector(".hm-top--degraded")).toBeTruthy();
+  });
+});
+
+describe("BoardView — action announcement (§14)", () => {
+  test("announces the action 0→>0 edge in an assertive live region", () => {
+    const { container, rerender } = render(<BoardView board={emptyBoard} status="open" keyboard={false} />);
+    const live = container.querySelector(".hm-sr-only") as HTMLElement;
+    expect(live.getAttribute("aria-live")).toBe("assertive");
+    expect(live.textContent).toBe(""); // baseline — no announcement on first paint
+
+    // Live data arrives with two action cards (#548, #542 → needs-attention).
+    rerender(<BoardView board={board} status="open" keyboard={false} />);
+    expect(container.querySelector(".hm-sr-only")?.textContent).toMatch(/need your review/);
+  });
+});

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -65,12 +65,14 @@ describe("BoardView — rich-mix board (open stream)", () => {
 });
 
 describe("BoardView — degraded + transient states", () => {
-  test("a reconnecting stream renders the degraded banner and a dimmed LIVE", () => {
+  test("a reconnecting stream swaps in the degraded top strip + UNTRUSTED banner", () => {
     const { container, getByText } = render(<BoardView board={richBoard} status="reconnecting" />);
+    // BoardNow banner goes degraded…
     expect(container.querySelector(".hm-now--degraded")).toBeTruthy();
-    expect(getByText(/Live stream disconnected/)).toBeTruthy();
-    // LIVE indicator only lights on a confirmed open stream.
-    expect(getByText(/Live · —/)).toBeTruthy();
+    // …and the top strip swaps to the §16 degraded header.
+    expect(container.querySelector(".hm-top--degraded")).toBeTruthy();
+    expect(getByText("Hermes — degraded mode")).toBeTruthy();
+    expect(getByText("UNTRUSTED")).toBeTruthy();
   });
 
   test("a closed stream is degraded too", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -25,6 +25,7 @@ import { LANES, type BoardCard } from "../lib/monitor/card-types.js";
 import { laneFor } from "../lib/monitor/lane-rules.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
+import { TopStripDegraded } from "./TopStripDegraded.js";
 import { BoardNowBanner } from "./BoardNowBanner.js";
 import { LanesBar } from "./LanesBar.js";
 import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
@@ -111,6 +112,22 @@ export function BoardView({
   const [askToken, setAskToken] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
+  // §14: announce the action-needed 0→>0 edge once, assertively, for
+  // screen-reader users (the visual cue is the amber banner).
+  const [announcement, setAnnouncement] = useState("");
+  const prevActionRef = useRef<number | null>(null);
+  useEffect(() => {
+    const prev = prevActionRef.current;
+    prevActionRef.current = state.counts.action;
+    if (prev !== null && prev <= 0 && state.counts.action > 0) {
+      setAnnouncement(
+        state.counts.action === 1
+          ? "1 card now needs your review."
+          : `${state.counts.action} cards now need your review.`,
+      );
+    }
+  }, [state.counts.action]);
+
   // Controlled lane expansion: seed from the mode preset, re-apply when
   // the board mode flips (e.g. empty→action as live data arrives), but
   // keep manual toggles / spotlight within a stable mode.
@@ -180,11 +197,28 @@ export function BoardView({
 
   return (
     <div className="hm-board">
-      <TopStrip
-        counts={state.counts}
-        liveAt={status === "open" ? liveLabel || undefined : undefined}
-        onRefresh={onRefresh}
-      />
+      {/* §14: assertive announcement of the action 0→>0 edge. */}
+      <div className="hm-sr-only" role="status" aria-live="assertive">
+        {announcement}
+      </div>
+
+      {degraded ? (
+        <TopStripDegraded
+          lastKnownAt={liveLabel || undefined}
+          reason={
+            liveLabel
+              ? `Live SSE ${status} · last good read ${liveLabel} · KPIs unknown until reconnect · auto-reconnecting`
+              : `Live SSE ${status} · no good read yet · KPIs unknown until reconnect · auto-reconnecting`
+          }
+          onReconnect={onRefresh}
+        />
+      ) : (
+        <TopStrip
+          counts={state.counts}
+          liveAt={status === "open" ? liveLabel || undefined : undefined}
+          onRefresh={onRefresh}
+        />
+      )}
 
       <BoardNowBanner banner={state.banner} />
 

--- a/packages/monitor-ui/src/components/ErrorBoundary.test.tsx
+++ b/packages/monitor-ui/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, afterAll, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { ErrorBoundary } from "./ErrorBoundary.js";
+
+afterEach(cleanup);
+
+// React logs the caught error to console.error; silence it so the
+// expected-failure test doesn't spam the run.
+let errSpy: ReturnType<typeof vi.spyOn>;
+beforeAll(() => {
+  errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => errSpy.mockRestore());
+
+function Boom(): never {
+  throw new Error("kaboom");
+}
+
+describe("ErrorBoundary", () => {
+  test("renders children when nothing throws", () => {
+    const { getByText } = render(
+      <ErrorBoundary>
+        <div>all good</div>
+      </ErrorBoundary>,
+    );
+    expect(getByText("all good")).toBeTruthy();
+  });
+
+  test("catches a render crash and shows a recoverable alert (not a blank screen)", () => {
+    const onReload = vi.fn();
+    const { getByRole } = render(
+      <ErrorBoundary onReload={onReload}>
+        <Boom />
+      </ErrorBoundary>,
+    );
+    const alert = getByRole("alert");
+    expect(within(alert).getByText("CRASHED")).toBeTruthy();
+    expect(within(alert).getByText(/kaboom/)).toBeTruthy();
+    fireEvent.click(within(alert).getByRole("button", { name: "Reload" }));
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/monitor-ui/src/components/ErrorBoundary.tsx
+++ b/packages/monitor-ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,62 @@
+// Hermes Handoff Monitor — top-level error boundary (M11', §16).
+//
+// A render crash must never leave the operator staring at a blank screen
+// with no idea what happened. This catches it and shows what broke + how
+// to recover, in the same "untrusted" visual language as a degraded
+// stream. Error boundaries must be class components.
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Optional override for the reload action (tests). */
+  onReload?: () => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (typeof console !== "undefined") {
+      console.error("Hermes monitor crashed:", error, info.componentStack);
+    }
+  }
+
+  private handleReload = (): void => {
+    if (this.props.onReload) {
+      this.props.onReload();
+    } else if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    return (
+      <div className="hm-board">
+        <div className="hm-degraded-banner" role="alert">
+          <span className="pill">CRASHED</span>
+          <span className="reasons">
+            The monitor hit an unexpected error: <code>{error.message || "unknown"}</code>. Live data is unaffected —
+            reload to recover.
+          </span>
+          <span className="right">
+            <button type="button" onClick={this.handleReload}>
+              Reload
+            </button>
+          </span>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/monitor-ui/src/components/TopStripDegraded.test.tsx
+++ b/packages/monitor-ui/src/components/TopStripDegraded.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { TopStripDegraded } from "./TopStripDegraded.js";
+
+afterEach(cleanup);
+
+describe("TopStripDegraded (§16)", () => {
+  test("shows `?` KPIs — never a stale cached number — plus the last-known time", () => {
+    const { container, getByText } = render(
+      <TopStripDegraded lastKnownAt="14:32:08" reason="Live SSE reconnecting · auto-reconnecting" />,
+    );
+    expect(container.querySelector(".hm-top--degraded")).toBeTruthy();
+    expect(getByText("Hermes — degraded mode")).toBeTruthy();
+    // Both KPI pips read "?" and none read "0".
+    const pips = Array.from(container.querySelectorAll(".hm-kpi .n")).map((n) => n.textContent);
+    expect(pips.length).toBeGreaterThan(0);
+    expect(pips.every((p) => p === "?")).toBe(true);
+    expect(getByText(/last known · 14:32:08/)).toBeTruthy();
+  });
+
+  test("spells out the reason in an alert banner", () => {
+    const { getByText, getByRole } = render(
+      <TopStripDegraded reason="Live SSE closed · last good read 14:32:08 · auto-reconnecting" />,
+    );
+    expect(getByText("UNTRUSTED")).toBeTruthy();
+    const alert = getByRole("alert");
+    expect(within(alert).getByText(/last good read 14:32:08/)).toBeTruthy();
+  });
+
+  test("the reconnect controls fire onReconnect", () => {
+    const onReconnect = vi.fn();
+    const { getByRole, getByText } = render(<TopStripDegraded reason="x" onReconnect={onReconnect} />);
+    fireEvent.click(getByRole("button", { name: "Reconnect" }));
+    fireEvent.click(getByText("Reconnect now"));
+    expect(onReconnect).toHaveBeenCalledTimes(2);
+  });
+
+  test("without a handler the reconnect button is disabled", () => {
+    const { getByRole } = render(<TopStripDegraded reason="x" />);
+    expect((getByRole("button", { name: "Reconnect" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/packages/monitor-ui/src/components/TopStripDegraded.tsx
+++ b/packages/monitor-ui/src/components/TopStripDegraded.tsx
@@ -1,0 +1,85 @@
+// Hermes Handoff Monitor — degraded top strip (M11', §16).
+//
+// Swaps in for <TopStrip> when the SSE stream drops. The §16 hard rule:
+// zero tolerance for hiding "we don't know if there's action needed." So
+// the KPIs show `?` — never the last cached number — and an UNTRUSTED
+// banner spells out *why* and *what to do*. The reason is built from what
+// we actually know (the stream status + last-good read); we don't invent
+// an upstream error code we never received.
+
+export interface TopStripDegradedProps {
+  /** Last known-good snapshot clock (e.g. "14:32:08"), if any. */
+  lastKnownAt?: string;
+  /** Operator-facing reason the data is untrusted. */
+  reason: string;
+  /** Reconnect / refresh handler. */
+  onReconnect?: () => void;
+}
+
+const ROSE = "var(--hm-rose)";
+const ROSE_WASH = "#fbf0ee";
+const ROSE_BORDER = "rgba(162,58,58,0.32)";
+const ROSE_PIP = "rgba(162,58,58,0.18)";
+
+export function TopStripDegraded({ lastKnownAt, reason, onReconnect }: TopStripDegradedProps) {
+  return (
+    <>
+      <div className="hm-top hm-top--degraded" role="banner">
+        <div className="hm-brand">
+          <div className="hm-brand-mark" style={{ background: ROSE, color: "#fffdf7" }} aria-hidden>
+            !
+          </div>
+          <div>
+            <div className="hm-brand-name">Hermes — degraded mode</div>
+            <div className="hm-brand-sub" style={{ color: ROSE }}>
+              {lastKnownAt ? `Live stream disconnected · last good ${lastKnownAt}` : "Live stream disconnected"}
+            </div>
+          </div>
+        </div>
+
+        <div className="hm-kpis" role="status" aria-live="polite" aria-label="Board KPI counts — unavailable">
+          <UnknownKpi label="Action needed" />
+          <UnknownKpi label="Operator review" />
+          <span className="hm-kpi hm-kpi--zero">last known · {lastKnownAt || "—"}</span>
+        </div>
+
+        <div className="hm-top-right">
+          <span
+            className="hm-deploy-pill"
+            style={{ background: ROSE_WASH, borderColor: ROSE_BORDER, color: ROSE }}
+            aria-label="Stream offline"
+          >
+            <span className="ledge" style={{ background: ROSE }} aria-hidden />
+            OFFLINE
+          </span>
+          <button type="button" className="hm-refresh" onClick={onReconnect} disabled={!onReconnect} aria-label="Reconnect">
+            ⟳ Reconnect
+          </button>
+        </div>
+      </div>
+
+      <div className="hm-degraded-banner" role="alert">
+        <span className="pill">UNTRUSTED</span>
+        <span className="reasons">{reason}</span>
+        {onReconnect ? (
+          <span className="right">
+            <button type="button" onClick={onReconnect}>
+              Reconnect now
+            </button>
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+}
+
+function UnknownKpi({ label }: { label: string }) {
+  return (
+    <span className="hm-kpi" style={{ background: ROSE_WASH, borderColor: ROSE_BORDER, color: ROSE }}>
+      <span className="n" style={{ background: ROSE_PIP, color: ROSE }}>
+        ?
+      </span>{" "}
+      {label} · unknown
+    </span>
+  );
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1997,3 +1997,28 @@ body { margin: 0; }
   background: var(--hm-rail);
   border-radius: 4px;
 }
+
+/* ── M11' accessibility pass (§14) ──────────────────────────────────
+   Appended to the verbatim bundle CSS: the design prototype shipped no
+   focus-visible ring and no screen-reader utility, both of which the
+   WCAG AA pass requires. */
+
+/* Visible keyboard focus everywhere: sage 2px ring at 2px offset. */
+.hm-board :is(button, a, input, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--hm-sage);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Screen-reader-only: present to assistive tech, invisible on screen. */
+.hm-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- **M11'** — the final frontend milestone: the **§16 degraded-mode** patterns, a top-level **error boundary**, and the **§14 accessibility pass**.

## §16 — degraded states
- **`TopStripDegraded`** swaps in for `<TopStrip>` when the SSE stream drops (status `reconnecting`/`closed`). KPIs render **`?`** — never the last cached number — and an **UNTRUSTED** banner spells out *why* + *how to recover*. The reason is built from what we actually know (stream status + last-good read); **no fabricated upstream error code** we never received.
- The `failed-fetch` (rose) / `source-offline` (neutral) `DegradedCard` paths from M4' already cover broken cards; this completes the page-level story so the operator always sees *that* and *why* data is untrusted.

## Error boundary
- **`ErrorBoundary`** wraps the board: a render crash shows what broke + a **Reload** action in the same untrusted visual language — never a blank screen.

## §14 — accessibility pass
- **Assertive `aria-live`** announcement on the action-needed **0→>0** edge (screen-reader twin of the amber banner).
- Appended a **`:focus-visible`** ring (sage 2px @ 2px offset) and an **`.hm-sr-only`** utility to the bundle CSS — both required by WCAG AA and absent from the design prototype.
- Landmarks (banner / region / dialog / complementary) and the M10' keyboard coverage round out "operable without a mouse, legible to a screen reader."

## Test plan
- [x] `npx vitest run packages/monitor-ui` → **347/347** (`TopStripDegraded`, `ErrorBoundary`, `BoardView` degraded swap + action announcement)
- [x] `npm test` (full repo) → **692/692**
- [x] `npm run typecheck` (`tsc -b`) → clean
- [x] `npm run build` (`tsc -b`) → clean
- [x] `npm --workspace packages/monitor-ui run build` (Vite) → bundles `dist/`

Manual follow-ups per the acceptance: the full **WCAG AA contrast audit** (every text pair) and the **stream-down end-to-end** against a live backend — neither is exercisable in jsdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)