### PR TITLE
ops: publish runtime image to GHCR + registry-pull deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: write # publish the runtime image to GHCR on main
 
 jobs:
   node:
@@ -38,8 +39,39 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build Node runtime image
-        run: docker build -f ops/Dockerfile.node .
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Push only happens for main; on PRs this just logs in is skipped.
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      # On PRs: build only (validates the Dockerfile, incl. the in-image
+      # Vite SPA build). On main: build + push the sha + latest tags.
+      - name: Build (and push on main) the runtime image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ops/Dockerfile.node
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Validate Compose file
         run: docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,95 @@
+# Deploy runbook — Hermes monitor stack
+
+The `slack-operator` (and its sibling Node services) run from one image,
+`avg-node-runtime`, built by `ops/Dockerfile.node`. That image now also
+contains the redesigned monitor SPA (served at `/monitor/next`; the legacy
+HTML monitor stays at `/monitor`).
+
+There are two ways to deploy. **Registry-pull is recommended**;
+build-on-server is the fallback.
+
+> Compose invocation below uses `-f ops/compose.yml -f ops/compose.prod.yml`
+> and `--env-file ops/.env.prod`. Adjust to your actual prod overlay set
+> (e.g. add `-f ops/compose.cloudflare-access.yml`) and env file.
+
+---
+
+## 1. Registry-pull (recommended)
+
+CI builds `avg-node-runtime` on every push to `main` and pushes it to GHCR
+as:
+
+- `ghcr.io/depre-dev/averray-reference-agent:latest`
+- `ghcr.io/depre-dev/averray-reference-agent:sha-<short-sha>` (immutable —
+  use this for reproducible deploys + rollback)
+
+The compose services pull whatever `AVERRAY_IMAGE` points at
+(`image: ${AVERRAY_IMAGE:-avg-node-runtime}`).
+
+### One-time VPS setup
+
+If the GHCR package is **private** (the default for org packages), log the
+VPS's Docker in once with a PAT that has `read:packages`:
+
+```sh
+echo "$GHCR_PAT" | docker login ghcr.io -u <github-user> --password-stdin
+```
+
+(Or make the package public in the repo's *Packages* settings and skip this.)
+
+### Deploy
+
+Pin to the SHA you want to ship (find it on the merged PR / Actions run):
+
+```sh
+export AVERRAY_IMAGE=ghcr.io/depre-dev/averray-reference-agent:sha-<short-sha>
+docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml pull
+docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml up -d
+```
+
+No build runs on the box; you ship the exact artifact CI built and tested.
+Putting `AVERRAY_IMAGE=...` in `ops/.env.prod` instead of exporting it makes
+the value sticky across deploys.
+
+### Rollback
+
+Point `AVERRAY_IMAGE` at a previous `sha-…` tag and re-run `pull` + `up -d`.
+No rebuild, seconds to recover.
+
+---
+
+## 2. Build-on-server (fallback)
+
+Unchanged from before — leave `AVERRAY_IMAGE` unset so compose uses the
+locally-built `avg-node-runtime`:
+
+```sh
+git pull
+docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml build
+docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml up -d
+```
+
+---
+
+## After deploy
+
+- New board (preview): `https://monitor.averray.com/monitor/next`
+- Legacy monitor (unchanged): `https://monitor.averray.com/monitor`
+- Health/manifest (lists active routes): `GET /health`
+
+The legacy monitor stays the default until the redesign is validated on a
+real shift; cutover (mounting the new UI at `/monitor` and retiring the
+legacy HTML) is a separate, deliberate change.
+
+---
+
+## Assumptions / things to confirm in your environment
+
+- The image name assumes the GitHub org is `depre-dev` (i.e.
+  `ghcr.io/<owner>/averray-reference-agent`). CI derives it from
+  `github.repository`, so it tracks the repo automatically.
+- GHCR push uses the workflow's `GITHUB_TOKEN` with `packages: write`. The
+  org/repo must allow Actions to create packages (Settings → Actions →
+  Workflow permissions, and the package's access settings).
+- The first push to `main` creates the package; set its visibility +
+  link it to the repo as desired.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -1,5 +1,11 @@
 # Copy to ../.env.prod, fill secrets, then chmod 600 ../.env.prod.
 
+# Runtime image for the Node services. Leave unset to build locally
+# (image: avg-node-runtime). For registry-pull deploys, set to a GHCR tag,
+# e.g. ghcr.io/depre-dev/averray-reference-agent:sha-<short-sha> — see
+# docs/DEPLOY.md.
+# AVERRAY_IMAGE=
+
 # Pinned Hermes Agent v0.14.0 / v2026.5.16 multi-arch image digest.
 # Refresh intentionally after testing a new Hermes release.
 HERMES_IMAGE=nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -50,7 +50,7 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
-    image: avg-node-runtime
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
     depends_on:
       hermes-permissions:
         condition: service_completed_successfully
@@ -104,7 +104,7 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
-    image: avg-node-runtime
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
     depends_on:
       hermes-permissions:
@@ -124,7 +124,7 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
-    image: avg-node-runtime
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -186,7 +186,7 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
-    image: avg-node-runtime
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["testbed-runner"]
     restart: unless-stopped
     depends_on:
@@ -218,7 +218,7 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
-    image: avg-node-runtime
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["codex-runner"]
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Summary
Replaces build-on-server with a **pull-an-artifact** deploy: CI builds the image once (the same artifact it tested) and the VPS **pulls** it, instead of compiling on the production box. Faster, reproducible, and rollback is a one-tag change.

## Changes
- **`.github/workflows/ci.yml`** — on push to `main`, log into **GHCR** and **build + push** `avg-node-runtime` as `ghcr.io/<repo>` tagged **`sha-<short>`** + **`latest`** (`docker/login` + `metadata` + `build-push-action`, buildx + gha cache). PRs still **build for validation** (`push: false`) — which exercises the in-image Vite SPA build — and the `docker compose config` check is unchanged. Adds `packages: write`.
- **`ops/compose.yml`** — the five Node services now use `image: ${AVERRAY_IMAGE:-avg-node-runtime}`:
  - unset → **build locally** (the existing flow, untouched)
  - set to a GHCR tag → **pull** that exact image
  The `build:` blocks stay, so both paths work.
- **`docs/DEPLOY.md`** — the runbook: registry-pull (pin a sha, `docker login ghcr.io` if the package is private, `pull` + `up -d`), rollback to a prior `sha-…`, and the build-on-server fallback. Documents the new board at `/monitor/next`.
- **`ops/.env.example`** — documents `AVERRAY_IMAGE`.

## Deploy (once this + the SPA PR are on main)
```sh
export AVERRAY_IMAGE=ghcr.io/depre-dev/averray-reference-agent:sha-<short>
docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml pull
docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml up -d
# preview the redesign at /monitor/next; legacy stays at /monitor
```

## Assumptions to confirm in your environment (flagged honestly)
- **GHCR push** uses the workflow `GITHUB_TOKEN` + `packages: write`. The org/repo must allow Actions to create/write packages (Settings → Actions → Workflow permissions). The **first push to main creates the package** — set its visibility then.
- If the package is **private**, the VPS needs a one-time `docker login ghcr.io` with a `read:packages` PAT (documented in the runbook).
- Image name derives from `github.repository`, so it tracks the repo (`ghcr.io/depre-dev/averray-reference-agent`) automatically.
- No code changes → typecheck/test unaffected. **The push only activates after this merges to `main`** (PR runs validate-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)