### PR TITLE
monitor: enrich v2 board cards from already-fetched data (checks/files/done/codex)

### DIFF
--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -52,6 +52,32 @@ export interface WaitingOn {
   tone: "warn" | "info" | "neutral";
 }
 
+/** CI check rollup for the card's checks bar. Mirrors the UI CardChecks. */
+export interface CardChecks {
+  pass: number;
+  running: number;
+  fail: number;
+  pending: number;
+  total: number;
+}
+
+/**
+ * One changed file + its risk classification. `diff` is the "+N -M" line;
+ * it is left empty when the upstream review signal didn't capture
+ * additions/deletions (the monitor fetch keeps only the filename).
+ */
+export interface CardFile {
+  path: string;
+  diff: string;
+  critical: boolean;
+}
+
+/** Codex runner liveness for a task card. */
+export interface CardRunnerHeartbeat {
+  lastSeen: string;
+  online: boolean;
+}
+
 export interface BoardCard {
   id: string;
   lane: Lane;
@@ -72,6 +98,33 @@ export interface BoardCard {
   next?: string;
   /** Hermes verdict / reasoning carried from the classifier. */
   verdict?: string;
+
+  // ── Enriched fields ─────────────────────────────────────────────
+  // Populated by enrichBoardCard() from the raw monitor snapshot.
+  // All optional and omitted when the underlying real data isn't
+  // present, so a card never claims detail it doesn't actually have.
+  /** CI checks rollup (non-done cards, when GitHub checks were fetched). */
+  checks?: CardChecks;
+  /** Changed files + risk flags (non-done cards). */
+  files?: CardFile[];
+  /** Done cards: merged vs. closed-without-merge. */
+  mergeStatus?: "MERGED" | "CLOSED";
+  /**
+   * Done cards: when the PR last changed. This is the PR's updatedAt —
+   * the monitor PR state doesn't carry an exact merged/closed timestamp,
+   * and for a terminal PR updatedAt is the closest real signal.
+   */
+  closedAt?: string;
+  /** Done cards: short verdict line ("merged" / "closed"). */
+  verdictText?: string;
+  /** Codex task cards: the dispatched prompt. */
+  prompt?: string;
+  /** Codex task cards: tail of stdout / completion summary. */
+  output?: string;
+  /** Codex task cards: failure reason when the task failed. */
+  failureReason?: string;
+  /** Codex task cards: runner liveness. */
+  runnerHeartbeat?: CardRunnerHeartbeat;
 }
 
 export interface BoardSnapshotV2 {
@@ -257,9 +310,218 @@ export function toBoardCard(item: HermesBoardCardSnapshot): BoardCard {
   return card;
 }
 
+// ── Card enrichment ─────────────────────────────────────────────────
+//
+// The slim classified card (HermesBoardCardSnapshot) drops the rich
+// per-PR detail that the raw monitor snapshot already carries on each
+// item's `summary` (githubLive check totals, reviewSignals touched
+// files, the PR merge state) and on the top-level `codexTasks`. The
+// redesigned UI can render all of it. We project that already-fetched
+// data onto the BoardCard here — zero new network calls — so the live
+// board shows real checks bars, file lists, merge verdicts, and Codex
+// task detail instead of bare cards.
+//
+// Everything is best-effort + defensive: the raw snapshot is `unknown`,
+// so each field is guarded and simply omitted when absent.
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+/**
+ * High-risk file predicate. Mirrors the "high" branch of
+ * github-pr-state.ts `highRiskForFile` (which is module-private), so the
+ * `critical` flag on a card file matches the review-gating logic.
+ */
+export function isCriticalFile(path: string): boolean {
+  const p = path.toLowerCase();
+  return (
+    p.includes("secret") ||
+    p.endsWith(".env") ||
+    p.includes(".env.") ||
+    p.includes("migration") ||
+    p.startsWith("contracts/") ||
+    p.endsWith(".sol")
+  );
+}
+
+/**
+ * Map a raw item `summary.githubLive.checkTotals`
+ * ({total,passed,failed,active,neutral}) to the UI CardChecks shape.
+ * Returns undefined when there are no checks to show (no totals object,
+ * or a zero total) so we don't render an empty "0/0" bar.
+ */
+export function mapChecks(summary: Record<string, unknown> | undefined): CardChecks | undefined {
+  const githubLive = asRecord(summary?.githubLive);
+  const totals = asRecord(githubLive?.checkTotals);
+  if (!totals) return undefined;
+  const total = asFiniteNumber(totals.total);
+  if (total === undefined || total <= 0) return undefined;
+  return {
+    pass: asFiniteNumber(totals.passed) ?? 0,
+    running: asFiniteNumber(totals.active) ?? 0,
+    fail: asFiniteNumber(totals.failed) ?? 0,
+    pending: asFiniteNumber(totals.neutral) ?? 0,
+    total,
+  };
+}
+
+/**
+ * Map a raw item `summary.reviewSignals.touchedFiles` ([{path,area}]) to
+ * the UI CardFile shape. `diff` is left empty: the monitor file fetch
+ * keeps only the filename, not additions/deletions.
+ */
+export function mapFiles(summary: Record<string, unknown> | undefined): CardFile[] {
+  const reviewSignals = asRecord(summary?.reviewSignals);
+  const touched = asArray(reviewSignals?.touchedFiles);
+  const files: CardFile[] = [];
+  for (const entry of touched) {
+    const file = asRecord(entry);
+    const path = asString(file?.path);
+    if (!path) continue;
+    files.push({ path, diff: "", critical: isCriticalFile(path) });
+  }
+  return files;
+}
+
+/** Stable per-PR correlation key: `<full-repo>#<number>`. */
+function prKey(repo: string | undefined, number: number | undefined): string | undefined {
+  if (!repo || typeof number !== "number" || !Number.isFinite(number)) return undefined;
+  return `${repo}#${number}`;
+}
+
+/**
+ * Index every raw monitor item (active + recent) by its PR key so a
+ * classified card can find its source `summary`. github-live entries
+ * carry the rich `githubLive`/`reviewSignals`/`currentPullRequest`
+ * detail we want to project.
+ */
+export function indexRawSummaries(rawSnapshot: unknown): Map<string, Record<string, unknown>> {
+  const root = asRecord(rawSnapshot);
+  const map = new Map<string, Record<string, unknown>>();
+  if (!root) return map;
+  for (const entry of [...asArray(root.active), ...asArray(root.recent)]) {
+    const item = asRecord(entry);
+    const summary = asRecord(item?.summary);
+    if (!summary) continue;
+    const pr = asRecord(summary.pullRequest) ?? asRecord(summary.currentPullRequest);
+    const keys = [
+      prKey(asString(pr?.repo), asFiniteNumber(pr?.number)),
+      prKey(asString(item?.repo), asFiniteNumber(item?.pullRequestNumber)),
+    ];
+    for (const key of keys) {
+      if (key && !map.has(key)) map.set(key, summary);
+    }
+  }
+  return map;
+}
+
+/** Index Codex tasks by their PR key for task-card enrichment. */
+export function indexCodexTasks(rawSnapshot: unknown): Map<string, Record<string, unknown>> {
+  const root = asRecord(rawSnapshot);
+  const codexTasks = asRecord(root?.codexTasks);
+  const map = new Map<string, Record<string, unknown>>();
+  for (const entry of asArray(codexTasks?.items)) {
+    const task = asRecord(entry);
+    const key = prKey(asString(task?.repo), asFiniteNumber(task?.pullRequestNumber));
+    if (key && !map.has(key)) map.set(key, task!);
+  }
+  return map;
+}
+
+function readRunner(rawSnapshot: unknown): Record<string, unknown> | undefined {
+  return asRecord(asRecord(asRecord(rawSnapshot)?.codexTasks)?.runner);
+}
+
+export interface EnrichmentContext {
+  /** The raw monitor item `summary` correlated to this card, if any. */
+  summary?: Record<string, unknown>;
+  /** The Codex task correlated to this card, if any. */
+  codexTask?: Record<string, unknown>;
+  /** The Codex runner heartbeat (global), if any. */
+  runner?: Record<string, unknown>;
+}
+
+/**
+ * Enrich a slim BoardCard with the rich detail already present in the
+ * raw monitor snapshot. Mutates and returns the card. Honest by
+ * construction: every field is omitted when its real source is absent.
+ */
+export function enrichBoardCard(
+  card: BoardCard,
+  item: HermesBoardCardSnapshot,
+  ctx: EnrichmentContext
+): BoardCard {
+  const { summary } = ctx;
+  const isDone = card.type === "done";
+
+  // Checks + files: live (non-done) cards only. Done cards render in the
+  // compressed historical layout (no checks bar / file list), matching
+  // the design.
+  if (summary && !isDone) {
+    const checks = mapChecks(summary);
+    if (checks) card.checks = checks;
+    const files = mapFiles(summary);
+    if (files.length > 0) card.files = files;
+  }
+
+  // Done cards: merge verdict + close timestamp from the PR state.
+  if (isDone && summary) {
+    const pr = asRecord(summary.currentPullRequest) ?? asRecord(summary.pullRequest);
+    if (pr) {
+      if (typeof pr.merged === "boolean") {
+        card.mergeStatus = pr.merged ? "MERGED" : "CLOSED";
+      }
+      const updatedAt = asString(pr.updatedAt);
+      if (updatedAt) card.closedAt = updatedAt;
+    }
+    const verdictText = card.verdict ?? item.verdict;
+    if (verdictText) card.verdictText = verdictText;
+  }
+
+  // Codex task cards: prompt / output / failure / runner liveness.
+  if (card.type === "task" && ctx.codexTask) {
+    const task = ctx.codexTask;
+    const prompt = asString(task.prompt);
+    if (prompt) card.prompt = prompt;
+    const output = asString(task.stdoutTail) ?? asString(task.completionSummary);
+    if (output) card.output = output;
+    const failureReason = asString(task.failureReason);
+    if (failureReason) card.failureReason = failureReason;
+    const runner = ctx.runner;
+    if (runner) {
+      const lastSeen = asString(runner.updatedAt);
+      const status = asString(runner.status);
+      if (lastSeen) {
+        card.runnerHeartbeat = {
+          lastSeen,
+          online: status === "running" || status === "idle",
+        };
+      }
+    }
+  }
+
+  return card;
+}
+
 /**
  * Build the full v2 board snapshot from the raw monitor snapshot.
- * Reuses the existing classifier, then enriches every card.
+ * Reuses the existing classifier, then enriches every card with the
+ * rich detail the raw snapshot already carries (zero new network calls).
  *
  * @param rawSnapshot the object returned by loadMonitorSnapshot()
  * @param opts.repo   the configured AVERRAY_REPO (single-repo per §21.6)
@@ -273,7 +535,18 @@ export function buildV2BoardSnapshot(
   const classified: HermesBoardSnapshot | undefined =
     buildHermesBoardSnapshotFromMonitor(rawSnapshot);
   const items = classified?.items ?? [];
-  const cards = items.map((item) => toBoardCard(item));
+  const summaryIndex = indexRawSummaries(rawSnapshot);
+  const codexIndex = indexCodexTasks(rawSnapshot);
+  const runner = readRunner(rawSnapshot);
+  const cards = items.map((item) => {
+    const base = toBoardCard(item);
+    const key = prKey(item.repo, item.number);
+    return enrichBoardCard(base, item, {
+      summary: key ? summaryIndex.get(key) : undefined,
+      codexTask: key ? codexIndex.get(key) : undefined,
+      runner,
+    });
+  });
   return {
     cards,
     at: now().toISOString(),

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -10,7 +10,14 @@ import {
   cardId,
   toBoardCard,
   buildV2BoardSnapshot,
+  isCriticalFile,
+  mapChecks,
+  mapFiles,
+  indexRawSummaries,
+  indexCodexTasks,
+  enrichBoardCard,
 } from "../../services/slack-operator/src/monitor-v2.js";
+import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
 import type { HermesBoardCardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
 
 function slim(overrides: Partial<HermesBoardCardSnapshot> = {}): HermesBoardCardSnapshot {
@@ -263,5 +270,228 @@ describe("buildV2BoardSnapshot", () => {
   it("includes the configured repo on the envelope", () => {
     const snap = buildV2BoardSnapshot({ active: [], recent: [] }, { repo: "depre-dev/site" });
     expect(snap.repo).toBe("depre-dev/site");
+  });
+});
+
+// ── Enrichment ──────────────────────────────────────────────────────
+
+describe("isCriticalFile", () => {
+  it("flags secrets, env, migrations, contracts, .sol", () => {
+    expect(isCriticalFile("ops/secrets.yml")).toBe(true);
+    expect(isCriticalFile(".env")).toBe(true);
+    expect(isCriticalFile("config/.env.prod")).toBe(true);
+    expect(isCriticalFile("db/0042_migration.sql")).toBe(true);
+    expect(isCriticalFile("contracts/Foo.sol")).toBe(true);
+    expect(isCriticalFile("agent/Token.sol")).toBe(true);
+  });
+  it("treats ordinary files as non-critical", () => {
+    expect(isCriticalFile("docs/readme.md")).toBe(false);
+    expect(isCriticalFile("packages/monitor-ui/src/App.tsx")).toBe(false);
+  });
+});
+
+describe("mapChecks", () => {
+  it("maps githubLive.checkTotals to the UI shape", () => {
+    const summary = {
+      githubLive: { checkTotals: { total: 6, passed: 5, failed: 0, active: 1, neutral: 0 } },
+    };
+    expect(mapChecks(summary)).toEqual({ pass: 5, running: 1, fail: 0, pending: 0, total: 6 });
+  });
+  it("maps neutral → pending and failed → fail", () => {
+    const summary = {
+      githubLive: { checkTotals: { total: 7, passed: 4, failed: 2, active: 0, neutral: 1 } },
+    };
+    expect(mapChecks(summary)).toEqual({ pass: 4, running: 0, fail: 2, pending: 1, total: 7 });
+  });
+  it("returns undefined when there are no checks (no totals / zero total)", () => {
+    expect(mapChecks(undefined)).toBeUndefined();
+    expect(mapChecks({})).toBeUndefined();
+    expect(mapChecks({ githubLive: {} })).toBeUndefined();
+    expect(mapChecks({ githubLive: { checkTotals: { total: 0 } } })).toBeUndefined();
+  });
+});
+
+describe("mapFiles", () => {
+  it("maps touchedFiles to path + critical (diff left empty)", () => {
+    const summary = {
+      reviewSignals: {
+        touchedFiles: [
+          { path: "contracts/AgentAccountCore.sol", area: "contracts" },
+          { path: "ops/deploy.staging.yml", area: "ops" },
+          { path: "docs/operator/claim-stake.md", area: "docs" },
+        ],
+      },
+    };
+    expect(mapFiles(summary)).toEqual([
+      { path: "contracts/AgentAccountCore.sol", diff: "", critical: true },
+      { path: "ops/deploy.staging.yml", diff: "", critical: false },
+      { path: "docs/operator/claim-stake.md", diff: "", critical: false },
+    ]);
+  });
+  it("skips entries without a path and returns [] when absent", () => {
+    expect(mapFiles(undefined)).toEqual([]);
+    expect(mapFiles({ reviewSignals: { touchedFiles: [{ area: "ops" }, { path: "" }] } })).toEqual([]);
+  });
+});
+
+describe("indexRawSummaries", () => {
+  it("indexes active + recent items by <repo>#<number>", () => {
+    const raw = {
+      active: [{ summary: { pullRequest: { repo: "depre-dev/agent", number: 548 }, foo: 1 } }],
+      recent: [{ summary: { currentPullRequest: { repo: "depre-dev/site", number: 547 }, bar: 2 } }],
+    };
+    const index = indexRawSummaries(raw);
+    expect(index.get("depre-dev/agent#548")).toMatchObject({ foo: 1 });
+    expect(index.get("depre-dev/site#547")).toMatchObject({ bar: 2 });
+  });
+  it("falls back to item-level repo + pullRequestNumber", () => {
+    const raw = { active: [{ repo: "depre-dev/agent", pullRequestNumber: 999, summary: { z: 3 } }] };
+    expect(indexRawSummaries(raw).get("depre-dev/agent#999")).toMatchObject({ z: 3 });
+  });
+  it("returns an empty map for a non-record snapshot", () => {
+    expect(indexRawSummaries(undefined).size).toBe(0);
+    expect(indexRawSummaries("nope").size).toBe(0);
+  });
+});
+
+describe("indexCodexTasks", () => {
+  it("indexes codexTasks.items by <repo>#<number>", () => {
+    const raw = {
+      codexTasks: {
+        items: [
+          { repo: "depre-dev/agent", pullRequestNumber: 100, prompt: "do the thing" },
+          { repo: "depre-dev/agent", pullRequestNumber: 101, prompt: "other" },
+        ],
+      },
+    };
+    const index = indexCodexTasks(raw);
+    expect(index.get("depre-dev/agent#100")).toMatchObject({ prompt: "do the thing" });
+    expect(index.get("depre-dev/agent#101")).toMatchObject({ prompt: "other" });
+  });
+  it("returns an empty map when codexTasks is absent", () => {
+    expect(indexCodexTasks({}).size).toBe(0);
+  });
+});
+
+describe("enrichBoardCard", () => {
+  function base(overrides: Partial<BoardCard> = {}): BoardCard {
+    return {
+      id: "agent #548",
+      lane: "operator-review",
+      type: "pr",
+      agentType: "codex",
+      title: "T",
+      summary: "S",
+      repo: "depre-dev/agent",
+      freshness: 4,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "operator", tone: "warn" },
+      ...overrides,
+    };
+  }
+
+  it("adds checks + files to a live (non-done) card", () => {
+    const card = enrichBoardCard(base(), slim(), {
+      summary: {
+        githubLive: { checkTotals: { total: 6, passed: 5, failed: 0, active: 1, neutral: 0 } },
+        reviewSignals: { touchedFiles: [{ path: "contracts/Foo.sol" }] },
+      },
+    });
+    expect(card.checks).toEqual({ pass: 5, running: 1, fail: 0, pending: 0, total: 6 });
+    expect(card.files).toEqual([{ path: "contracts/Foo.sol", diff: "", critical: true }]);
+  });
+
+  it("does NOT add checks / files to done cards (compressed layout)", () => {
+    const card = enrichBoardCard(base({ type: "done", lane: "done" }), slim({ lane: "Done" }), {
+      summary: {
+        githubLive: { checkTotals: { total: 6, passed: 6, failed: 0, active: 0, neutral: 0 } },
+        reviewSignals: { touchedFiles: [{ path: "docs/x.md" }] },
+      },
+    });
+    expect(card.checks).toBeUndefined();
+    expect(card.files).toBeUndefined();
+  });
+
+  it("sets mergeStatus / closedAt / verdictText on done cards", () => {
+    const card = enrichBoardCard(
+      base({ type: "done", lane: "done", verdict: "merged" }),
+      slim({ lane: "Done", verdict: "merged" }),
+      {
+        summary: {
+          currentPullRequest: { repo: "depre-dev/agent", number: 546, merged: true, updatedAt: "2026-05-27T16:28:00Z" },
+        },
+      }
+    );
+    expect(card.mergeStatus).toBe("MERGED");
+    expect(card.closedAt).toBe("2026-05-27T16:28:00Z");
+    expect(card.verdictText).toBe("merged");
+  });
+
+  it("marks an unmerged closed PR as CLOSED", () => {
+    const card = enrichBoardCard(base({ type: "done", lane: "done" }), slim({ lane: "Done" }), {
+      summary: { currentPullRequest: { merged: false } },
+    });
+    expect(card.mergeStatus).toBe("CLOSED");
+  });
+
+  it("adds Codex task detail + runner liveness to task cards", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: {
+        id: "task-1",
+        prompt: "Coalesce repeated policy-attach entries",
+        stdoutTail: "ran ok",
+        failureReason: undefined,
+      },
+      runner: { status: "running", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "task-1" },
+    });
+    expect(card.prompt).toMatch(/Coalesce/);
+    expect(card.output).toBe("ran ok");
+    expect(card.runnerHeartbeat).toEqual({ lastSeen: "2026-05-28T12:00:00Z", online: true });
+  });
+
+  it("falls back to completionSummary for output and marks a stopped runner offline", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: { id: "task-2", prompt: "p", completionSummary: "done summary" },
+      runner: { status: "disabled", updatedAt: "2026-05-28T12:00:00Z" },
+    });
+    expect(card.output).toBe("done summary");
+    expect(card.runnerHeartbeat).toEqual({ lastSeen: "2026-05-28T12:00:00Z", online: false });
+  });
+
+  it("is a no-op when no enrichment context is present", () => {
+    const card = enrichBoardCard(base(), slim(), {});
+    expect(card.checks).toBeUndefined();
+    expect(card.files).toBeUndefined();
+    expect(card.mergeStatus).toBeUndefined();
+    expect(card.prompt).toBeUndefined();
+  });
+});
+
+describe("buildV2BoardSnapshot — enrichment integration", () => {
+  it("projects githubLive checks onto a classified card", () => {
+    const raw = {
+      active: [
+        {
+          title: "Allow operator override of agent claim-stake floor",
+          status: "needs_review",
+          intent: "operator_review",
+          ageLabel: "4m",
+          summary: {
+            pullRequest: { repo: "depre-dev/agent", number: 548, state: "open" },
+            currentPullRequest: { repo: "depre-dev/agent", number: 548, state: "open" },
+            finalVerdict: "operator_review",
+            githubLive: { checkTotals: { total: 6, passed: 5, failed: 0, active: 1, neutral: 0 } },
+            reviewSignals: { touchedFiles: [{ path: "ops/deploy.staging.yml" }] },
+          },
+        },
+      ],
+      recent: [],
+    };
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const card = snap.cards.find((c) => c.id === "agent #548");
+    expect(card).toBeDefined();
+    expect(card?.checks).toEqual({ pass: 5, running: 1, fail: 0, pending: 0, total: 6 });
+    expect(card?.files).toEqual([{ path: "ops/deploy.staging.yml", diff: "", critical: false }]);
   });
 });


### PR DESCRIPTION
## Summary

Closes the "where are the rich details" gap on live `/monitor/next`. The redesigned UI can render checks bars, changed-file lists, merge verdicts, and Codex task detail — but the v2 serializer was only filling the slim classifier fields. All that rich data was **already on the raw monitor snapshot**, just dropped.

`toBoardCard` now correlates each classified card to its raw item by `<repo>#<number>` and projects the data onto the card — **zero new network calls**:

- **`checks`** ← `summary.githubLive.checkTotals` (non-done cards) — the board's CI checks bar
- **`files`** ← `summary.reviewSignals.touchedFiles` (path + `critical` via the same high-risk rule as `github-pr-state`; `diff` omitted — the fetch keeps only filenames)
- **done cards** ← `mergeStatus` / `closedAt` / `verdictText` from the PR state
- **Codex task cards** ← `prompt` / `output` / `failureReason` / `runnerHeartbeat` from `codexTasks`

## Truth-boundary

Honest by construction — every enriched field is **omitted when its real source is absent**, so a card never shows detail it doesn't have. Deliberately deferred to separate, reviewed follow-ups:
- **Action CTAs** — the board's Approve/merge buttons are non-functional; emitting them would imply a capability the board doesn't have.
- **Mission reports** — the structured-report → UI mapping defaults too many fields (per-step status, latency, evidence kind/href).
- **Deploy `verification`** — would be synthesized from suite counts, not a native progress field.

## Verification

- `npm run typecheck` → clean
- `npm test` → **718 pass** (+20 new enrichment tests covering each mapper, the index builders, and a `buildV2BoardSnapshot` integration)

## Test plan

- [ ] Redeploy; confirm operator-review / hermes-checking PR cards show a real checks bar and the drawer lists changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)