### PR TITLE
monitor-ui: suppress waiting-on line on closed cards (1:1 fidelity)

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -58,13 +58,42 @@ describe("Card — type coverage", () => {
     expect(within(container).getByText("draft")).toBeTruthy();
   });
 
-  test("done/closed card: CLOSED pip, no risk pills, no checks bar", () => {
+  test("done/closed card: CLOSED pip, no risk pills, no checks bar, no waiting-on", () => {
     const done = FIXTURE_CARDS.find((c) => c.type === "done");
     if (!done) throw new Error("no done fixture");
     const { container } = render(<Card card={done} />);
     expect(within(container).getByText("CLOSED")).toBeTruthy();
     expect(container.querySelector(".hm-pillrow")).toBeNull();
     expect(container.querySelector(".hm-checks-bar")).toBeNull();
+    // Closed cards never render a waiting-on line (compressed layout).
+    expect(container.querySelector(".hm-waiting")).toBeNull();
+  });
+
+  test("done card with a live waitingOn still suppresses the waiting-on line", () => {
+    // Live backend data carries a waitingOn on done cards; the card must
+    // not leak it into the compressed historical layout.
+    const done: BoardCard = {
+      id: "agent #588",
+      lane: "done",
+      type: "done",
+      agentType: "ext",
+      title: "Refresh mainnet audit package",
+      summary: "",
+      repo: "depre-dev/agent",
+      freshness: 0,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "operator", tone: "neutral" },
+      closedAt: "2026-05-28T22:15:52Z",
+      mergeStatus: "MERGED",
+      verdictText: "merged",
+    };
+    const { container } = render(<Card card={done} />);
+    const view = within(container);
+    expect(view.getByText("CLOSED")).toBeTruthy();
+    expect(view.getByText("merged")).toBeTruthy();
+    expect(container.querySelector(".hm-waiting")).toBeNull();
+    expect(view.queryByText(/waiting on/i)).toBeNull();
   });
 });
 

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -140,7 +140,11 @@ export function Card({ card, focused = false, onClick }: CardProps) {
         </div>
       ) : null}
 
-      {card.waitingOn ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
+      {/* Closed cards use the compressed historical layout (header +
+          close-time + verdict only) — they never show a waiting-on line,
+          matching the design. Live data still carries a waitingOn on done
+          cards, so gate it here rather than relying on the source. */}
+      {!isClosed && card.waitingOn ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
 
       {isAction && verdict ? (
         <div className="hm-verdict">


### PR DESCRIPTION
## Summary

On the live board, every **Done** card showed a stray `WAITING ON → OPERATOR` line. The design's closed cards use a compressed historical layout — header + close-time + verdict only, no waiting-on. Live backend data still carries a `waitingOn` on done cards, and `Card.tsx` rendered it ungated.

Gate the waiting-on line with `!isClosed` so closed cards stay compressed regardless of the source data.

## Verification

- `npm run typecheck` → clean
- `npm test` → **719 pass** (+1 new test: a done card with a live `waitingOn` must still suppress the line)

## Test plan

- [ ] Redeploy; confirm Done lane cards show only `<time> · merged` and no waiting-on line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)