### PR TITLE
monitor: unique id for identity-less cards (fix deploy-card collision)

### DIFF
--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -53,6 +53,7 @@ function boardCardFromItem(
   const title = titleForItem(item, summary, prState, identity);
   if (!title && !identity.repo) return undefined;
   const why = reasonForItem(item, summary, prState, codexTaskStatus);
+  const correlationId = textProp(item, "correlationId");
   return {
     ...identity,
     title: title || "Untitled handoff",
@@ -63,6 +64,7 @@ function boardCardFromItem(
     ...(why ? { why } : {}),
     next: classification.next,
     tags: tagsForItem(item, summary),
+    ...(correlationId ? { correlationId } : {}),
   };
 }
 

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -64,6 +64,13 @@ export interface HermesBoardCardSnapshot {
   why?: string;
   next?: string;
   tags?: ReadonlyArray<string>;
+  /**
+   * Stable correlation id for items without PR identity (deploy
+   * verifications, missions, tasks). The classifier already keys these
+   * by correlationId; forwarding it lets the v2 mapper build a unique
+   * card id instead of colliding distinct items onto one title slug.
+   */
+  correlationId?: string;
 }
 
 export interface HermesBoardSnapshot {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -262,12 +262,25 @@ export function cardId(item: HermesBoardCardSnapshot): string {
   if (item.repo && typeof item.number === "number") {
     return `${shortRepo(item.repo)} #${item.number}`;
   }
-  const slug = (item.title ?? "card")
+  const slug = slugify(item.title ?? "card").slice(0, 40);
+  // Identity-less cards (deploy verifications, missions, tasks) often
+  // share a generic title — e.g. every "post-deploy verification" card.
+  // Without a discriminator they'd collapse onto one id, which breaks
+  // React keys, SSE card diffing, and drawer routing. Append a short,
+  // stable suffix from the classifier correlationId so distinct items
+  // get distinct ids.
+  if (item.correlationId) {
+    const suffix = slugify(item.correlationId).slice(-12);
+    if (suffix) return (slug ? `${slug}-${suffix}` : suffix).slice(0, 64);
+  }
+  return slug || "card";
+}
+
+function slugify(value: string): string {
+  return value
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 40);
-  return slug || "card";
+    .replace(/^-+|-+$/g, "");
 }
 
 function shortRepo(repo: string): string {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -174,6 +174,27 @@ describe("cardId", () => {
     const longTitle = "a".repeat(80);
     expect(cardId(slim({ repo: undefined, number: undefined, title: longTitle })).length).toBeLessThanOrEqual(40);
   });
+
+  it("appends a stable correlationId suffix for identity-less cards", () => {
+    const id = cardId(slim({
+      repo: undefined,
+      number: undefined,
+      title: "post-production-deploy verification after workflow run",
+      correlationId: "github-deploy-1099-abc1234",
+    }));
+    expect(id.startsWith("post-production-deploy-verification-afte")).toBe(true);
+    expect(id.endsWith("1099-abc1234")).toBe(true);
+  });
+
+  it("gives same-title deploy cards distinct ids by correlationId", () => {
+    const a = cardId(slim({ repo: undefined, number: undefined, title: "post-deploy verification", correlationId: "github-deploy-1099-aaa" }));
+    const b = cardId(slim({ repo: undefined, number: undefined, title: "post-deploy verification", correlationId: "github-deploy-1100-bbb" }));
+    expect(a).not.toBe(b);
+  });
+
+  it("ignores correlationId when PR identity exists", () => {
+    expect(cardId(slim({ repo: "depre-dev/agent", number: 548, correlationId: "github-deploy-1-x" }))).toBe("agent #548");
+  });
 });
 
 describe("toBoardCard", () => {


### PR DESCRIPTION
## Summary

The board showed several **"post-production-deploy verification"** cards that are *genuinely distinct deploys* (distinct `correlationId`/`sha`) but all collapsed onto **one card id**: `cardId()` slugs the title when there's no `repo`+`number`, and these share the generic title. Identical ids break React keys, SSE card diffing, and drawer routing (clicking one opened another's drawer).

The classifier already keys these items by `correlationId`, but the slim `HermesBoardCardSnapshot` dropped it before the v2 mapper. This threads it through and has `cardId()` append a short, stable `correlationId` suffix for identity-less cards (deploy / mission / task). **PR cards (`repo`+`number`) are unchanged.**

## What this does NOT do (and why)

- **Does not collapse the cards into one** — they're distinct deploys; collapsing would hide real deploys (truth-boundary).
- **Does not reduce the count.** The cards *linger* in "Deploying" because the producer (`packages/averray-mcp/handoff-events.ts`) never emits the terminal `completed` event, so they stay `status:"running"` past the active window with no age-out. That's a **producer/classifier lifecycle bug, not a serialize/enrich concern** — flagged for Codex (whose `deploy-card-title-context` branch is already in that area). Inventing an age-out here would mean guessing deploy semantics in another lane.

## Verification

- `npm run typecheck` → clean
- `npm test` → **722 pass** (+3 cardId tests: correlationId suffix, distinct ids for same-title deploys, PR identity still wins)

## Coordination

Touches the shared classifier (`monitor-hermes-board.ts` / `monitor-hermes-voice.ts`) additively (one optional field forwarded). No overlap with `codex/deploy-card-title-context` (that edits `renderMonitorHtml` in `monitor.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)