### PR TITLE
monitor: cut over — redesigned board becomes the default at /monitor

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,9 +1,10 @@
 # Deploy runbook — Hermes monitor stack
 
 The `slack-operator` (and its sibling Node services) run from one image,
-`avg-node-runtime`, built by `ops/Dockerfile.node`. That image now also
-contains the redesigned monitor SPA (served at `/monitor/next`; the legacy
-HTML monitor stays at `/monitor`).
+`avg-node-runtime`, built by `ops/Dockerfile.node`. That image serves the
+redesigned monitor SPA as the **default board at `/monitor`**. The legacy
+HTML monitor was demoted to `/monitor/legacy` (kept as a transition
+fallback; `/monitor/next` 302s to `/monitor/`).
 
 There are two ways to deploy. **Registry-pull is recommended**;
 build-on-server is the fallback.
@@ -73,13 +74,14 @@ docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.y
 
 ## After deploy
 
-- New board (preview): `https://monitor.averray.com/monitor/next`
-- Legacy monitor (unchanged): `https://monitor.averray.com/monitor`
+- Board (redesigned, default): `https://monitor.averray.com/monitor`
+- Legacy monitor (deprecated fallback): `https://monitor.averray.com/monitor/legacy`
 - Health/manifest (lists active routes): `GET /health`
 
-The legacy monitor stays the default until the redesign is validated on a
-real shift; cutover (mounting the new UI at `/monitor` and retiring the
-legacy HTML) is a separate, deliberate change.
+The redesigned board is now the default at `/monitor`. The legacy HTML
+monitor is demoted to `/monitor/legacy` as a transition fallback; its
+renderer (`renderMonitorHtml`) is slated for removal once nothing depends
+on it. `/monitor/next` (the old preview path) 302s to `/monitor/`.
 
 ---
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -113,9 +113,9 @@ const authConfig = {
 const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedChannelIds);
 const monitorConfig = parseMonitorConfig(process.env);
 const missionSpawnRoles = parseMissionSpawnRoles(process.env);
-// The Vite-built redesigned monitor SPA, served at /monitor/next. At
-// runtime index.js lives in services/slack-operator/dist, so the bundle
-// is three levels up under packages/monitor-ui/dist.
+// The Vite-built redesigned monitor SPA, served as the default board at
+// /monitor. At runtime index.js lives in services/slack-operator/dist, so
+// the bundle is three levels up under packages/monitor-ui/dist.
 const MONITOR_SPA_DIST = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../packages/monitor-ui/dist");
 const monitorNarrationMinIntervalMs = Math.max(
   5_000,
@@ -206,11 +206,11 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         missionSpawnRestricted: missionSpawnRestricted(missionSpawnRoles),
         paths: monitorConfig.enabled ? [
           "/monitor",
+          "/monitor/legacy",
           "/monitor/events",
           "/monitor/stream",
           "/monitor/v2/board",
           "/monitor/v2/stream",
-          "/monitor/next",
           ...(isDebugSpawnEnabled() ? ["/monitor/v2/debug/spawn"] : []),
           "/monitor/command",
           "/monitor/recheck",
@@ -228,7 +228,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     writeRedirect(response, "/monitor");
     return;
   }
-  if (request.method === "GET" && (url.pathname === "/monitor" || url.pathname === "/monitor/events" || url.pathname === "/monitor/stream" || url.pathname === "/monitor/manifest.webmanifest")) {
+  if (request.method === "GET" && (url.pathname === "/monitor/legacy" || url.pathname === "/monitor/events" || url.pathname === "/monitor/stream" || url.pathname === "/monitor/manifest.webmanifest")) {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
       return;
@@ -237,7 +237,9 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       writeJson(response, 401, { error: "monitor_unauthorized" });
       return;
     }
-    if (url.pathname === "/monitor") {
+    if (url.pathname === "/monitor/legacy") {
+      // Legacy HTML monitor — demoted from /monitor at the cutover, kept
+      // as a transition fallback. Slated for removal.
       writeHtml(response, 200, renderMonitorHtml());
       return;
     }
@@ -309,60 +311,68 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     writeJson(response, 201, { ok: true, card, at: new Date().toISOString() });
     return;
   }
-  // Redesigned monitor SPA, served side-by-side with the legacy HTML
-  // monitor (which keeps /monitor) until the cutover. The bundle's API
-  // calls hit the absolute /monitor/v2/* routes, so it works at this
-  // mount unchanged.
-  if (request.method === "GET" && (url.pathname === MONITOR_SPA_MOUNT || url.pathname.startsWith(`${MONITOR_SPA_MOUNT}/`))) {
-    if (!monitorConfig.enabled) {
-      writeJson(response, 404, { error: "monitor_disabled" });
-      return;
-    }
-    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
-      writeJson(response, 401, { error: "monitor_unauthorized" });
-      return;
-    }
-    const resolution = resolveSpaRequest(url.pathname);
-    if (resolution.kind === "redirect") {
-      writeRedirect(response, resolution.location);
-      return;
-    }
-    if (resolution.kind === "miss") {
-      writeJson(response, 404, { error: "not_found" });
-      return;
-    }
-    const relPath = resolution.kind === "index" ? "index.html" : resolution.relPath;
-    const filePath = path.join(MONITOR_SPA_DIST, relPath);
-    // Defense-in-depth: never read outside the bundle dir.
-    if (filePath !== MONITOR_SPA_DIST && !filePath.startsWith(MONITOR_SPA_DIST + path.sep)) {
-      writeJson(response, 403, { error: "forbidden" });
-      return;
-    }
-    try {
-      const body = await readFile(filePath);
-      const isIndex = resolution.kind === "index";
-      response.writeHead(200, {
-        "content-type": isIndex ? "text/html; charset=utf-8" : resolution.contentType,
-        // index.html must never be cached (it points at hashed assets);
-        // the hashed assets are immutable.
-        "cache-control": isIndex ? "no-cache" : "public, max-age=31536000, immutable",
-      });
-      response.end(body);
-    } catch {
-      if (resolution.kind === "index") {
-        writeHtml(
-          response,
-          200,
-          "<!doctype html><meta charset=\"utf-8\"><title>Hermes monitor</title>" +
-            "<p style=\"font-family:system-ui;padding:24px\">The redesigned monitor UI is not built in this image. " +
-            "Run <code>npm --workspace packages/monitor-ui run build</code>, or use the legacy monitor at " +
-            "<a href=\"/monitor\">/monitor</a>.</p>",
-        );
-      } else {
-        writeJson(response, 404, { error: "asset_not_found" });
-      }
-    }
+  // Back-compat: the redesign previewed at /monitor/next before the
+  // cutover; it's now the default board at /monitor. 302 the old path.
+  if (request.method === "GET" && (url.pathname === "/monitor/next" || url.pathname.startsWith("/monitor/next/"))) {
+    writeRedirect(response, "/monitor/");
     return;
+  }
+  // Redesigned monitor SPA — the default board at /monitor (the legacy
+  // HTML monitor moved to /monitor/legacy). The guard only fires for the
+  // SPA's own paths (/monitor, /monitor/, /monitor/assets/*); every other
+  // /monitor/* path (the /monitor/v2/* APIs, /monitor/codex-tasks,
+  // /monitor/collaboration, …) resolves to "miss" and falls through to
+  // its own handler below. The bundle's API calls hit the absolute
+  // /monitor/v2/* routes; its assets are relative, so they resolve under
+  // the mount.
+  if (request.method === "GET") {
+    const resolution = resolveSpaRequest(url.pathname);
+    if (resolution.kind !== "miss") {
+      if (!monitorConfig.enabled) {
+        writeJson(response, 404, { error: "monitor_disabled" });
+        return;
+      }
+      if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+        writeJson(response, 401, { error: "monitor_unauthorized" });
+        return;
+      }
+      if (resolution.kind === "redirect") {
+        writeRedirect(response, resolution.location);
+        return;
+      }
+      const relPath = resolution.kind === "index" ? "index.html" : resolution.relPath;
+      const filePath = path.join(MONITOR_SPA_DIST, relPath);
+      // Defense-in-depth: never read outside the bundle dir.
+      if (filePath !== MONITOR_SPA_DIST && !filePath.startsWith(MONITOR_SPA_DIST + path.sep)) {
+        writeJson(response, 403, { error: "forbidden" });
+        return;
+      }
+      try {
+        const body = await readFile(filePath);
+        const isIndex = resolution.kind === "index";
+        response.writeHead(200, {
+          "content-type": isIndex ? "text/html; charset=utf-8" : resolution.contentType,
+          // index.html must never be cached (it points at hashed assets);
+          // the hashed assets are immutable.
+          "cache-control": isIndex ? "no-cache" : "public, max-age=31536000, immutable",
+        });
+        response.end(body);
+      } catch {
+        if (resolution.kind === "index") {
+          writeHtml(
+            response,
+            200,
+            "<!doctype html><meta charset=\"utf-8\"><title>Hermes monitor</title>" +
+              "<p style=\"font-family:system-ui;padding:24px\">The redesigned monitor UI is not built in this image. " +
+              "Run <code>npm --workspace packages/monitor-ui run build</code>, or use the legacy monitor at " +
+              "<a href=\"/monitor/legacy\">/monitor/legacy</a>.</p>",
+          );
+        } else {
+          writeJson(response, 404, { error: "asset_not_found" });
+        }
+      }
+      return;
+    }
   }
   if (request.method === "GET" && url.pathname === "/monitor/codex-tasks") {
     if (!monitorConfig.enabled) {

--- a/services/slack-operator/src/monitor-spa.ts
+++ b/services/slack-operator/src/monitor-spa.ts
@@ -1,14 +1,15 @@
 // Hermes Handoff Monitor — static serving of the redesigned SPA (§20).
 //
 // slack-operator serves the Vite-built bundle (packages/monitor-ui/dist)
-// alongside the legacy HTML monitor. The new board mounts at
-// /monitor/next while the legacy monitor keeps /monitor, so the redesign
-// can be previewed in production before the cutover.
+// as the default board at /monitor. The legacy HTML monitor was demoted
+// to /monitor/legacy at the cutover (it stays reachable as a transition
+// fallback; its renderer is slated for removal once nothing depends on
+// it). The old preview path /monitor/next now 302s to /monitor/.
 //
 // This module is the pure request → resolution mapping (tested); the
 // HTTP handler in index.ts does the filesystem read + response.
 
-export const MONITOR_SPA_MOUNT = "/monitor/next";
+export const MONITOR_SPA_MOUNT = "/monitor";
 
 export type SpaResolution =
   | { kind: "redirect"; location: string }
@@ -18,11 +19,13 @@ export type SpaResolution =
 
 /**
  * Map a request path under the SPA mount to what should be served.
- *   /monitor/next            → redirect to /monitor/next/ (so the SPA's
- *                              relative asset URLs resolve correctly)
- *   /monitor/next/           → index.html
- *   /monitor/next/assets/... → the hashed asset
- *   anything else            → miss
+ *   /monitor            → redirect to /monitor/ (so the SPA's relative
+ *                         asset URLs resolve correctly)
+ *   /monitor/           → index.html
+ *   /monitor/assets/... → the hashed asset
+ *   anything else       → miss (so /monitor/v2/*, /monitor/codex-tasks,
+ *                         /monitor/legacy, … fall through to their own
+ *                         handlers)
  */
 export function resolveSpaRequest(pathname: string, mount: string = MONITOR_SPA_MOUNT): SpaResolution {
   if (pathname === mount) return { kind: "redirect", location: `${mount}/` };

--- a/test/unit/monitor-spa.test.ts
+++ b/test/unit/monitor-spa.test.ts
@@ -7,37 +7,49 @@ import {
 } from "../../services/slack-operator/src/monitor-spa.js";
 
 describe("resolveSpaRequest", () => {
+  it("mounts at /monitor (the default board after cutover)", () => {
+    expect(MONITOR_SPA_MOUNT).toBe("/monitor");
+  });
+
   it("redirects the bare mount to a trailing slash (so relative asset URLs resolve)", () => {
     expect(resolveSpaRequest(MONITOR_SPA_MOUNT)).toEqual({
       kind: "redirect",
-      location: "/monitor/next/",
+      location: "/monitor/",
     });
   });
 
   it("serves index.html at the mount root", () => {
-    expect(resolveSpaRequest("/monitor/next/")).toEqual({ kind: "index" });
+    expect(resolveSpaRequest("/monitor/")).toEqual({ kind: "index" });
   });
 
   it("serves hashed assets with a content type", () => {
-    expect(resolveSpaRequest("/monitor/next/assets/index-abc123.js")).toEqual({
+    expect(resolveSpaRequest("/monitor/assets/index-abc123.js")).toEqual({
       kind: "asset",
       relPath: "assets/index-abc123.js",
       contentType: "text/javascript; charset=utf-8",
     });
-    expect(resolveSpaRequest("/monitor/next/assets/index-abc123.css").contentType).toBe("text/css; charset=utf-8");
+    expect(resolveSpaRequest("/monitor/assets/index-abc123.css").contentType).toBe("text/css; charset=utf-8");
   });
 
   it("rejects traversal, nested paths, and NUL", () => {
-    expect(resolveSpaRequest("/monitor/next/assets/../../etc/passwd").kind).toBe("miss");
-    expect(resolveSpaRequest("/monitor/next/assets/sub/dir.js").kind).toBe("miss");
-    expect(resolveSpaRequest("/monitor/next/assets/x\0.js").kind).toBe("miss");
-    expect(resolveSpaRequest("/monitor/next/assets/").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/assets/../../etc/passwd").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/assets/sub/dir.js").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/assets/x\0.js").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/assets/").kind).toBe("miss");
   });
 
-  it("misses paths outside the mount", () => {
-    expect(resolveSpaRequest("/monitor").kind).toBe("miss");
-    expect(resolveSpaRequest("/monitor/next-other").kind).toBe("miss");
+  it("misses sibling API + legacy paths so they fall through to their handlers", () => {
+    // These must NOT be claimed by the SPA — they have their own routes.
     expect(resolveSpaRequest("/monitor/v2/board").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/v2/stream").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/events").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/codex-tasks").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/collaboration").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/testbed-missions").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/legacy").kind).toBe("miss");
+    // The old preview path is a miss here (index.ts 302s it to /monitor/).
+    expect(resolveSpaRequest("/monitor/next").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor-other").kind).toBe("miss");
   });
 });
 


### PR DESCRIPTION
## Summary

Sunsets the legacy HTML monitor as the default. The redesigned SPA (validated live at `/monitor/next`) now serves at **`/monitor`**; the legacy monitor moves to `/monitor/legacy`.

**Routing only — no behavior change to the legacy renderer or the `/monitor` APIs:**
- SPA mounts at `/monitor` (`MONITOR_SPA_MOUNT`). The bundle uses **relative** assets + **absolute** `/monitor/v2/*` API calls, so the remount is transparent.
- Legacy `renderMonitorHtml` demoted to `/monitor/legacy` — kept as a transition fallback. **The renderer itself is untouched** (Codex is mid-flight on it in `codex/deploy-card-title-context`); full removal is a later, coordinated step.
- `/monitor/next` 302s to `/monitor/` for back-compat.
- The SPA handler now only claims its own paths (`/monitor`, `/monitor/`, `/monitor/assets/*`); every other `/monitor/*` resolves to `miss` and **falls through** to its existing handler (previously it 404'd inside the block — which would have swallowed the API routes at the new mount).

## Verification

- `npm run typecheck` → clean
- `npm test` → **720 pass**
- **Runtime smoke test** (booted the built operator, curled every route):

| Route | Result |
|---|---|
| `GET /monitor` | 302 → `/monitor/` |
| `GET /monitor/` | 200 html — SPA |
| `GET /monitor/legacy` | 200 html — legacy |
| `GET /monitor/next` | 302 → `/monitor/` |
| `GET /monitor/v2/board` | 200 JSON |
| `GET /monitor/codex-tasks` | 200 JSON (fall-through) |
| `GET /monitor/collaboration` | 200 JSON (fall-through) |
| `GET /monitor/assets/…js` | 200 JS |

## Follow-up

Once Codex's in-flight `renderMonitorHtml` work lands and `/monitor/legacy` has gone unused for a release, delete the legacy renderer entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)