### PR TITLE
test: fix CI time-bomb in useMonitorBoard snapshot test

### DIFF
--- a/packages/monitor-ui/src/hooks/useMonitorBoard.test.tsx
+++ b/packages/monitor-ui/src/hooks/useMonitorBoard.test.tsx
@@ -80,7 +80,12 @@ describe("useMonitorBoard", () => {
   test("an SSE board.snapshot replaces the board and persists to storage", async () => {
     const storage = memStorage();
     const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
-    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage }), { wrapper });
+    // Pin the snapshot-eviction clock to the snapshot's own time. Without
+    // this the writer uses real Date.now(), and once wall-clock passes the
+    // hard-coded `at` + 24h TTL the just-written snapshot is evicted on
+    // write and this assertion flips from pass to fail — a time-bomb.
+    const now = () => Date.parse("2026-05-28T11:00:00Z");
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage, now }), { wrapper });
 
     await waitFor(() => expect(result.current.board).toBeDefined());
     const es = FakeEventSource.instances.at(-1) as FakeEventSource;


### PR DESCRIPTION
## Urgent — this is currently red on `main` for every PR

The `useMonitorBoard` test *"an SSE board.snapshot replaces the board and persists to storage"* asserts a snapshot hard-coded at `2026-05-28T11:00:00Z` is persisted — but lets the writer use the real `Date.now()`. `writeSnapshot()` evicts entries older than the 24h TTL on every write, so once wall-clock passed **2026-05-29T11:00Z** the just-written snapshot got evicted immediately and the assertion flipped green→red. It passed earlier today (PR #241 CI ran before 11:00Z) and now fails for everyone regardless of their diff.

**Fix:** inject a fixed `now` pinned to the snapshot's own timestamp so eviction is deterministic. **Test-only — no source change.**

## Verification

- The previously-failing test: 6/6 pass, run 3× — deterministic.
- `npm run typecheck` → clean; `npm test` → **723 pass / 79 files**.

Merge this first; it unblocks CI for all in-flight PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)