### PR TITLE
monitor: rich operator-review statuses (file diffs, per-check list, risk signals)

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -92,6 +92,44 @@ describe("DetailDrawer — variants", () => {
     expect(getByText("Send back to Codex")).toBeTruthy();
   });
 
+  test("rich PR statuses: per-check breakdown, risk signals, and colored file diff render", () => {
+    const card: BoardCard = {
+      id: "agent #590",
+      lane: "operator-review",
+      type: "pr",
+      agentType: "codex",
+      title: "ops: add KMS CloudWatch alarm proof validator",
+      summary: "2 changed files touch review-gated surfaces (ops).",
+      repo: "averray-agent/agent",
+      freshness: 6,
+      state: "fresh",
+      risk: [],
+      isAction: true,
+      waitingOn: { actor: "operator", tone: "warn" },
+      verdict: "needs review",
+      files: [{ path: "scripts/ops/check-kms-cloudwatch-alarm-proof.mjs", diff: "+120 -0", critical: false }],
+      checks: { pass: 9, running: 0, fail: 0, pending: 0, total: 9 },
+      checkRuns: [
+        { name: "CI · lint", status: "pass" },
+        { name: "CI · deploy plan", status: "running" },
+      ],
+      riskSignals: [
+        { severity: "medium", code: "pr_review_risk_files", message: "2 changed file(s) touch review-gated surfaces (ops)." },
+      ],
+    };
+    const { getByText, container } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    // per-check breakdown (names from summary.checks)
+    expect(getByText("CI · lint")).toBeTruthy();
+    expect(getByText("CI · deploy plan")).toBeTruthy();
+    // risk-signals section
+    expect(getByText("Risk signals · why Hermes flagged this")).toBeTruthy();
+    expect(getByText(/2 changed file\(s\) touch review-gated/)).toBeTruthy();
+    // colored "+A -D" diff
+    expect(container.querySelector(".hm-files .row .diff .add")).toBeTruthy();
+  });
+
   test("done card shows the release-history eyebrow", () => {
     const done = FIXTURE_CARDS.find((c) => c.type === "done") as BoardCard;
     const { getByText } = render(

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -6,8 +6,10 @@
 
 import type {
   BoardCard,
+  CardCheckRun,
   CardChecks,
   CardFile,
+  CardRiskSignal,
   DeployCard,
   DoneCard,
   MissionCard,
@@ -78,6 +80,20 @@ function VerdictBlock({ head, children, accent }: { head: string; children: Reac
   );
 }
 
+/** Render a "+A -B" diff line as colored add/rm spans (matches the design). */
+function DiffLine({ diff }: { diff: string }) {
+  if (!diff) return null;
+  return (
+    <span className="diff">
+      {diff.split(/(?=[+-])/).map((part, i) => (
+        <span key={i} className={part.trim().startsWith("+") ? "add" : "rm"}>
+          {part}{" "}
+        </span>
+      ))}
+    </span>
+  );
+}
+
 function FilesSection({ files }: { files: CardFile[] | undefined }) {
   if (!files || files.length === 0) return null;
   return (
@@ -87,7 +103,7 @@ function FilesSection({ files }: { files: CardFile[] | undefined }) {
         {files.map((f) => (
           <div className="row" key={f.path}>
             <span className="path">{f.path}</span>
-            <span className="diff">{f.diff}</span>
+            <DiffLine diff={f.diff} />
             {f.critical ? (
               <span className="hm-pill hm-pill--risk">review-gated</span>
             ) : (
@@ -100,7 +116,20 @@ function FilesSection({ files }: { files: CardFile[] | undefined }) {
   );
 }
 
-function ChecksSection({ checks }: { checks: CardChecks | undefined }) {
+const CHECK_RUN_PILL: Record<CardCheckRun["status"], string> = {
+  pass: "hm-pill hm-pill--ok",
+  fail: "hm-pill hm-pill--risk",
+  running: "hm-pill hm-pill--running",
+  neutral: "hm-pill hm-pill--neutral",
+};
+
+function ChecksSection({
+  checks,
+  checkRuns,
+}: {
+  checks: CardChecks | undefined;
+  checkRuns?: CardCheckRun[] | undefined;
+}) {
   if (!checks || checks.total <= 0) return null;
   return (
     <section>
@@ -111,6 +140,41 @@ function ChecksSection({ checks }: { checks: CardChecks | undefined }) {
       </div>
       <div className="hm-checks">
         <ChecksBar checks={checks} />
+      </div>
+      {checkRuns && checkRuns.length > 0 ? (
+        <div className="hm-files" style={{ marginTop: 8 }}>
+          {checkRuns.map((c) => (
+            <div className="row" key={c.name}>
+              <span className="path">{c.name}</span>
+              <span className={CHECK_RUN_PILL[c.status]}>{c.status}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+const RISK_PILL: Record<CardRiskSignal["severity"], string> = {
+  high: "hm-pill hm-pill--risk",
+  medium: "hm-pill hm-pill--running",
+  low: "hm-pill hm-pill--neutral",
+};
+
+function RiskSignalsSection({ signals }: { signals: CardRiskSignal[] | undefined }) {
+  if (!signals || signals.length === 0) return null;
+  return (
+    <section>
+      <div className="hm-section-h">Risk signals · why Hermes flagged this</div>
+      <div className="hm-files">
+        {signals.map((s) => (
+          <div className="row" key={s.code}>
+            <span className="path" style={{ whiteSpace: "normal" }}>
+              {s.message}
+            </span>
+            <span className={RISK_PILL[s.severity]}>{s.severity}</span>
+          </div>
+        ))}
       </div>
     </section>
   );
@@ -128,8 +192,9 @@ function PrBody({ card }: { card: BoardCard }) {
       ) : (
         <VerdictBlock head="Status">{card.summary || "No additional context yet."}</VerdictBlock>
       )}
+      <RiskSignalsSection signals={card.riskSignals} />
       <FilesSection files={files} />
-      <ChecksSection checks={card.checks} />
+      <ChecksSection checks={card.checks} checkRuns={card.checkRuns} />
     </>
   );
 }
@@ -190,7 +255,7 @@ function DeployBody({ card }: { card: DeployCard }) {
           <div className="body">Deploy {card.deployId}.</div>
         </div>
       </section>
-      <ChecksSection checks={card.checks} />
+      <ChecksSection checks={card.checks} checkRuns={card.checkRuns} />
     </>
   );
 }

--- a/packages/monitor-ui/src/hooks/useMonitorBoard.test.tsx
+++ b/packages/monitor-ui/src/hooks/useMonitorBoard.test.tsx
@@ -80,7 +80,12 @@ describe("useMonitorBoard", () => {
   test("an SSE board.snapshot replaces the board and persists to storage", async () => {
     const storage = memStorage();
     const fetcher = vi.fn(async () => board([{ id: "agent #1" }], "2026-05-28T10:00:00Z"));
-    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage }), { wrapper });
+    // Pin the snapshot-eviction clock to the snapshot's own time. Without
+    // this the writer uses real Date.now(), and once wall-clock passes the
+    // hard-coded `at` + 24h TTL the just-written snapshot is evicted on
+    // write and this assertion flips from pass to fail — a time-bomb.
+    const now = () => Date.parse("2026-05-28T11:00:00Z");
+    const { result } = renderHook(() => useMonitorBoard({ fetcher, EventSourceCtor: ES, storage, now }), { wrapper });
 
     await waitFor(() => expect(result.current.board).toBeDefined());
     const es = FakeEventSource.instances.at(-1) as FakeEventSource;

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -64,6 +64,19 @@ export interface CardFile {
   critical: boolean;
 }
 
+/** One CI check run, for the per-check breakdown under the checks bar. */
+export interface CardCheckRun {
+  name: string;
+  status: "pass" | "fail" | "running" | "neutral";
+}
+
+/** A Hermes review finding — the "why this needs review" detail. */
+export interface CardRiskSignal {
+  severity: "low" | "medium" | "high";
+  code: string;
+  message: string;
+}
+
 export interface CardAction {
   kind: "operator-review" | "codex-approve" | "deploy-verify" | "mission-rerun";
   primary: string;
@@ -85,6 +98,10 @@ export interface CardBase {
   state: CardState;
   risk: RiskTag[];
   checks?: CardChecks;
+  /** Per-check CI breakdown — the list under the checks bar. */
+  checkRuns?: CardCheckRun[];
+  /** Hermes review findings — the "why this needs review" detail. */
+  riskSignals?: CardRiskSignal[];
   waitingOn: WaitingOn;
   /** true ⇒ this card drives the needs-attention lane */
   isAction?: boolean;

--- a/services/slack-operator/src/github-pr-state.ts
+++ b/services/slack-operator/src/github-pr-state.ts
@@ -55,6 +55,8 @@ interface GithubApiPullRequest {
 
 interface GithubApiPullRequestFile {
   filename?: string;
+  additions?: number;
+  deletions?: number;
 }
 
 interface GithubApiCheckRun {
@@ -339,6 +341,10 @@ function buildLiveReviewSignals(
   const touchedFiles = files.map((file) => ({
     path: file.filename ?? "",
     area: inferTouchedArea(file.filename ?? ""),
+    // Captured from the same /pulls/:n/files response (no extra fetch) so
+    // the board can show a real "+A -D" diff line per file.
+    ...(typeof file.additions === "number" ? { additions: file.additions } : {}),
+    ...(typeof file.deletions === "number" ? { deletions: file.deletions } : {}),
   })).filter((file) => file.path);
   const touchedAreas = [...new Set(touchedFiles.map((file) => file.area))].filter(Boolean);
   const testSignals = [

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -78,6 +78,19 @@ export interface CardRunnerHeartbeat {
   online: boolean;
 }
 
+/** One CI check run, for the per-check breakdown under the checks bar. */
+export interface CardCheckRun {
+  name: string;
+  status: "pass" | "fail" | "running" | "neutral";
+}
+
+/** A Hermes review finding — the "why this needs review" detail. */
+export interface CardRiskSignal {
+  severity: "low" | "medium" | "high";
+  code: string;
+  message: string;
+}
+
 export interface BoardCard {
   id: string;
   lane: Lane;
@@ -125,6 +138,10 @@ export interface BoardCard {
   failureReason?: string;
   /** Codex task cards: runner liveness. */
   runnerHeartbeat?: CardRunnerHeartbeat;
+  /** Per-check CI breakdown (non-done cards) — the list under the bar. */
+  checkRuns?: CardCheckRun[];
+  /** Hermes review findings (non-done cards) — the "why review" detail. */
+  riskSignals?: CardRiskSignal[];
 }
 
 export interface BoardSnapshotV2 {
@@ -394,9 +411,9 @@ export function mapChecks(summary: Record<string, unknown> | undefined): CardChe
 }
 
 /**
- * Map a raw item `summary.reviewSignals.touchedFiles` ([{path,area}]) to
- * the UI CardFile shape. `diff` is left empty: the monitor file fetch
- * keeps only the filename, not additions/deletions.
+ * Map a raw item `summary.reviewSignals.touchedFiles`
+ * ([{path,area,additions?,deletions?}]) to the UI CardFile shape. `diff`
+ * is a "+A -D" line when the fetch captured additions/deletions, else "".
  */
 export function mapFiles(summary: Record<string, unknown> | undefined): CardFile[] {
   const reviewSignals = asRecord(summary?.reviewSignals);
@@ -406,9 +423,58 @@ export function mapFiles(summary: Record<string, unknown> | undefined): CardFile
     const file = asRecord(entry);
     const path = asString(file?.path);
     if (!path) continue;
-    files.push({ path, diff: "", critical: isCriticalFile(path) });
+    const additions = asFiniteNumber(file?.additions);
+    const deletions = asFiniteNumber(file?.deletions);
+    const diff =
+      additions !== undefined || deletions !== undefined
+        ? `+${additions ?? 0} -${deletions ?? 0}`
+        : "";
+    files.push({ path, diff, critical: isCriticalFile(path) });
   }
   return files;
+}
+
+/**
+ * Map a raw item `summary.checks` ([{name,status,conclusion}]) to the
+ * per-check breakdown. Same status logic as summarizeGithubChecks: not
+ * completed → running; success → pass; failure-ish → fail; else neutral.
+ */
+export function mapCheckRuns(summary: Record<string, unknown> | undefined): CardCheckRun[] {
+  const FAIL = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure"]);
+  const runs: CardCheckRun[] = [];
+  for (const entry of asArray(summary?.checks)) {
+    const check = asRecord(entry);
+    const name = asString(check?.name);
+    if (!name) continue;
+    const status = (asString(check?.status) ?? "").toLowerCase();
+    const conclusion = (asString(check?.conclusion) ?? "").toLowerCase();
+    let mapped: CardCheckRun["status"];
+    if (status !== "completed") mapped = "running";
+    else if (conclusion === "success") mapped = "pass";
+    else if (FAIL.has(conclusion)) mapped = "fail";
+    else mapped = "neutral";
+    runs.push({ name, status: mapped });
+  }
+  return runs;
+}
+
+/**
+ * Map a raw item `summary.reviewReasons`
+ * ([{severity,code,message}]) to the UI risk-signal list. Drops the
+ * all-clear "pr_review_green" sentinel so a green PR shows no findings.
+ */
+export function mapRiskSignals(summary: Record<string, unknown> | undefined): CardRiskSignal[] {
+  const SEVERITIES = new Set(["low", "medium", "high"]);
+  const signals: CardRiskSignal[] = [];
+  for (const entry of asArray(summary?.reviewReasons)) {
+    const reason = asRecord(entry);
+    const code = asString(reason?.code);
+    const message = asString(reason?.message);
+    if (!code || !message || code === "pr_review_green") continue;
+    const sev = (asString(reason?.severity) ?? "").toLowerCase();
+    signals.push({ severity: SEVERITIES.has(sev) ? (sev as CardRiskSignal["severity"]) : "low", code, message });
+  }
+  return signals;
 }
 
 /** Stable per-PR correlation key: `<full-repo>#<number>`. */
@@ -482,14 +548,18 @@ export function enrichBoardCard(
   const { summary } = ctx;
   const isDone = card.type === "done";
 
-  // Checks + files: live (non-done) cards only. Done cards render in the
-  // compressed historical layout (no checks bar / file list), matching
-  // the design.
+  // Checks + files + per-check breakdown + risk findings: live (non-done)
+  // cards only. Done cards render in the compressed historical layout (no
+  // checks bar / file list), matching the design.
   if (summary && !isDone) {
     const checks = mapChecks(summary);
     if (checks) card.checks = checks;
     const files = mapFiles(summary);
     if (files.length > 0) card.files = files;
+    const checkRuns = mapCheckRuns(summary);
+    if (checkRuns.length > 0) card.checkRuns = checkRuns;
+    const riskSignals = mapRiskSignals(summary);
+    if (riskSignals.length > 0) card.riskSignals = riskSignals;
   }
 
   // Done cards: merge verdict + close timestamp from the PR state.

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -13,6 +13,8 @@ import {
   isCriticalFile,
   mapChecks,
   mapFiles,
+  mapCheckRuns,
+  mapRiskSignals,
   indexRawSummaries,
   indexCodexTasks,
   enrichBoardCard,
@@ -349,9 +351,69 @@ describe("mapFiles", () => {
       { path: "docs/operator/claim-stake.md", diff: "", critical: false },
     ]);
   });
+  it("builds a +A -D diff line when additions/deletions are present", () => {
+    const summary = {
+      reviewSignals: {
+        touchedFiles: [
+          { path: "contracts/Foo.sol", area: "contracts", additions: 18, deletions: 4 },
+          { path: "docs/x.md", area: "docs", additions: 34, deletions: 0 },
+          { path: "ops/only-adds.yml", area: "ops", additions: 9 },
+        ],
+      },
+    };
+    expect(mapFiles(summary)).toEqual([
+      { path: "contracts/Foo.sol", diff: "+18 -4", critical: true },
+      { path: "docs/x.md", diff: "+34 -0", critical: false },
+      { path: "ops/only-adds.yml", diff: "+9 -0", critical: false },
+    ]);
+  });
   it("skips entries without a path and returns [] when absent", () => {
     expect(mapFiles(undefined)).toEqual([]);
     expect(mapFiles({ reviewSignals: { touchedFiles: [{ area: "ops" }, { path: "" }] } })).toEqual([]);
+  });
+});
+
+describe("mapCheckRuns", () => {
+  it("maps summary.checks to pass/fail/running/neutral", () => {
+    const summary = {
+      checks: [
+        { name: "CI · lint", status: "completed", conclusion: "success" },
+        { name: "CI · unit", status: "completed", conclusion: "failure" },
+        { name: "CI · deploy plan", status: "in_progress", conclusion: null },
+        { name: "CI · skipped", status: "completed", conclusion: "skipped" },
+      ],
+    };
+    expect(mapCheckRuns(summary)).toEqual([
+      { name: "CI · lint", status: "pass" },
+      { name: "CI · unit", status: "fail" },
+      { name: "CI · deploy plan", status: "running" },
+      { name: "CI · skipped", status: "neutral" },
+    ]);
+  });
+  it("skips nameless checks and returns [] when absent", () => {
+    expect(mapCheckRuns(undefined)).toEqual([]);
+    expect(mapCheckRuns({ checks: [{ status: "completed" }] })).toEqual([]);
+  });
+});
+
+describe("mapRiskSignals", () => {
+  it("maps reviewReasons, dropping the all-clear sentinel", () => {
+    const summary = {
+      reviewReasons: [
+        { severity: "high", code: "pr_critical_files", message: "1 changed file touches secrets." },
+        { severity: "medium", code: "pr_test_signal_missing", message: "No matching test files." },
+        { severity: "low", code: "pr_review_green", message: "Looks merge-ready." },
+      ],
+    };
+    expect(mapRiskSignals(summary)).toEqual([
+      { severity: "high", code: "pr_critical_files", message: "1 changed file touches secrets." },
+      { severity: "medium", code: "pr_test_signal_missing", message: "No matching test files." },
+    ]);
+  });
+  it("defaults an unknown severity to low and returns [] when absent", () => {
+    expect(mapRiskSignals({ reviewReasons: [{ code: "x", message: "m", severity: "bogus" }] }))
+      .toEqual([{ severity: "low", code: "x", message: "m" }]);
+    expect(mapRiskSignals(undefined)).toEqual([]);
   });
 });
 
@@ -412,15 +474,30 @@ describe("enrichBoardCard", () => {
     };
   }
 
-  it("adds checks + files to a live (non-done) card", () => {
+  it("adds checks + files + per-check breakdown + risk signals to a live card", () => {
     const card = enrichBoardCard(base(), slim(), {
       summary: {
         githubLive: { checkTotals: { total: 6, passed: 5, failed: 0, active: 1, neutral: 0 } },
-        reviewSignals: { touchedFiles: [{ path: "contracts/Foo.sol" }] },
+        reviewSignals: { touchedFiles: [{ path: "contracts/Foo.sol", additions: 18, deletions: 4 }] },
+        checks: [
+          { name: "CI · lint", status: "completed", conclusion: "success" },
+          { name: "CI · deploy plan", status: "in_progress" },
+        ],
+        reviewReasons: [
+          { severity: "high", code: "pr_critical_files", message: "1 changed file touches contracts." },
+          { severity: "low", code: "pr_review_green", message: "merge-ready" },
+        ],
       },
     });
     expect(card.checks).toEqual({ pass: 5, running: 1, fail: 0, pending: 0, total: 6 });
-    expect(card.files).toEqual([{ path: "contracts/Foo.sol", diff: "", critical: true }]);
+    expect(card.files).toEqual([{ path: "contracts/Foo.sol", diff: "+18 -4", critical: true }]);
+    expect(card.checkRuns).toEqual([
+      { name: "CI · lint", status: "pass" },
+      { name: "CI · deploy plan", status: "running" },
+    ]);
+    expect(card.riskSignals).toEqual([
+      { severity: "high", code: "pr_critical_files", message: "1 changed file touches contracts." },
+    ]);
   });
 
   it("does NOT add checks / files to done cards (compressed layout)", () => {


### PR DESCRIPTION
## Summary

Closes the "far from rich statuses" gap (see screenshot — the drawer had files with no diff, a "9/9 PASSED" bar with no per-check list, and a terse one-line verdict). All three are filled from data the backend **already fetches but dropped** — zero new network calls.

**Backend:**
- Capture `additions`/`deletions` from the `/pulls/:n/files` response already fetched (`github-pr-state`) → `BoardCard.files[].diff = "+A -D"`.
- `mapCheckRuns`: `summary.checks` → per-check `pass`/`fail`/`running`/`neutral` list.
- `mapRiskSignals`: `summary.reviewReasons` → the "why Hermes flagged this" findings (drops the all-clear sentinel).

**UI drawer:**
- Colored `+A -D` diff per file row.
- Per-check breakdown list under the checks bar.
- A "Risk signals" section under the verdict.

Honest by construction: every field omitted when its real source is absent.

## Stacking / CI
This branch **includes #242** (the one-line `useMonitorBoard` time-bomb fix) so its CI is green standalone. Merge #242 first; this then rebases onto `main` cleanly (identical commit drops out).

## Verification
- `npm run typecheck` → clean
- `npm test` → **729 pass** (new: `mapCheckRuns`, `mapRiskSignals`, file-diff mapping, enrich integration, and a drawer test asserting the per-check list + risk signals + colored diff render)

## Test plan
- [ ] Redeploy; open an operator-review card → drawer shows per-file `+A -D`, a per-check list, and the risk-signal findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)