### PR TITLE
docs: Hermes orchestration — plan + Phase 0 map + execution design

### DIFF
--- a/docs/HERMES_INTEGRATION_MAP.md
+++ b/docs/HERMES_INTEGRATION_MAP.md
@@ -1,0 +1,140 @@
+# Hermes Orchestration — Confirmed Integration Map (Phase 0)
+
+- **Status:** Phase 0 discovery output for [`docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md). **Confirmed from source**, not assumed.
+- **Date:** 2026-05-29
+
+> ## Repo orientation
+> This doc lives in the **implementation repo** (`depre-dev/averray-reference-agent`). Every `path:line` citation below is **local to this repo** unless prefixed `[platform]`, which marks a file in the sibling `averray-agent/agent` repo (the Averray product + the GitHub workflows that invoke Hermes).
+
+This map confirms or corrects the six `[assumed]` items in §6 of the plan. Where reality differs from the plan's assumption, it's flagged **⚠ REFINEMENT**.
+
+> Note: paths like `monitor-memory-aware-narration/packages/...` that appeared in an earlier draft do **not** exist. The real layout is `packages/` + `services/` + `ops/` + `hermes/`. Use the paths in this doc.
+
+---
+
+## Repo shape (this repo)
+
+```
+packages/
+  averray-mcp/      ← the main MCP server Hermes calls (tools + invoke_agent_task + operator commands)
+  policy-mcp/  receipt-mcp/  trace-mcp/  wallet-mcp/   ← the other 4 MCP servers
+  monitor-ui/       ← the redesigned board SPA (MonitorPage.tsx, card-types, lane-rules)
+  mcp-common/  schemas/
+services/
+  slack-operator/   ← serves the live /monitor board, the Codex task queue + runner, testbed mission runner
+  skills-observer/  ← sidecar ingesting Hermes skill files
+ops/                ← Docker compose stack (base, prod, command-center, cloudflare-access)
+hermes/             ← Hermes config (hermes.yaml, policy.yaml) + trace plugin
+```
+
+---
+
+## Q1 — How is `agentType` set today? Why is every card `ext`? ✅ CONFIRMED
+
+`agentType` is derived by `inferAgentType()` in `services/slack-operator/src/monitor-v2.ts:208` from the classifier's **`owner` string**, not from the PR branch:
+
+```ts
+export function inferAgentType(item, type): AgentType {
+  const owner = (item.owner ?? "").toLowerCase();
+  if (type === "mission") return "hermes";
+  if (owner.includes("codex"))  return "codex";
+  if (owner.includes("hermes")) return "hermes";
+  if (owner.includes("claude")) return "claude";
+  return "ext";                          // ← default
+}
+```
+
+The board's `owner` field is set to things like `operator`, `PR author`, `merge steward`, `history` (see `mapOwnerToWaitingOn`, `monitor-v2.ts:222`) — **never `codex`/`claude`** for ordinary external PRs. So they all fall through to `ext`. The `AgentType` union is `"claude" | "codex" | "hermes" | "ext"` (`packages/monitor-ui/src/lib/monitor/card-types.ts:24`).
+
+**⚠ REFINEMENT to plan P1.** The plan assumed "map branch prefix → agentType." But `monitor-v2.ts:321` explicitly notes **the slim board model does not carry the head branch** (`// branch not in slim model`). The raw GitHub snapshot *does* have it — `packages/averray-mcp/src/operator-github.ts:1432` attaches `headBranch` from `pull.head.ref` — but it's dropped before `toBoardCard`. So **P1 is two small steps, not one**:
+1. Thread `headBranch` through the slim classified card into `toBoardCard`.
+2. In `inferAgentType`, prefer the branch prefix (`codex/*`→codex, `claude/*`→claude) and fall back to the owner-string logic.
+
+---
+
+## Q2 — Codex task queue + runner: schema, storage, lifecycle, executor ✅ CONFIRMED
+
+**Queue** — `services/slack-operator/src/codex-task-queue.ts`. JSON-file backed (`readFile`/`writeFile`), path from `AVERRAY_CODEX_TASKS_PATH` (fallback `/tmp/averray-reference-agent/codex-tasks.json`, `:435`).
+
+- `CodexTask` shape (`:37`): `{ schemaVersion:1, kind:"codex_task", id, repo, pullRequestNumber, correlationId?, title?, prompt, reason?, requester?, status, createdAt, updatedAt, approvedAt?/By?, cancelledAt?/By?, startedAt?, runnerId?, attemptCount?, completedAt?, completionSummary?, failedAt?, failureReason?, exitCode?, stdoutTail?, stderrTail?, progressMessage?, progressAt?, events?[] }`.
+- **State machine** (`:4`): `proposed → approved → running → completed | failed | cancelled`.
+- **Heartbeat** `CodexRunnerHeartbeat` (`:63`): `{ runnerId, status: idle|running|completed|failed|disabled|misconfigured|error, message, updatedAt, activeTaskId? }`.
+
+**Enqueue path** — via the **slack-operator HTTP API**, not an MCP tool: `POST /monitor/codex-tasks` (`services/slack-operator/src/index.ts:389`) → `proposeCodexTask` (`:1107`); approval → `approveCodexTask(id, { approvedBy: "operator" })` (`:1132`). This is the board's `CREATE / APPROVE TASK` lane.
+
+**Runner** — `services/slack-operator/src/codex-task-runner.ts`. `runCodexTaskRunnerForever` polls (`CODEX_TASK_RUNNER_POLL_INTERVAL_MS`, default **10s**) → `claimNextApprovedCodexTask` → run executor → `completeCodexTask`/`failCodexTask` + heartbeat. Timeout `CODEX_TASK_RUNNER_TIMEOUT_MS` default **30 min** (SIGTERM→SIGKILL). Output is **secret-sanitized** before storage (`:316` — strips private keys, JWTs, GitHub tokens, `sk-` keys).
+
+**⚠ KEY FINDING — the runner is command-agnostic.** `executeCodexTaskCommand` (`:159`) just `spawn`s `CODEX_TASK_RUNNER_COMMAND` with templated args (`{prompt}`, `{repo}`, `{pr}`, …) and passes `CODEX_TASK_*` env (incl. `CODEX_TASK_PROMPT`). It is "Codex" only by env config. The actual Codex behavior lives in `codex-branch-worker.ts`, which: defaults its CLI to `codex` (`:95`), **refuses protected branches** (`:123`), and **checks out the PR's existing head branch** to work on it (`:192`).
+
+**⚠ REFINEMENT to plan P2.** Two consequences:
+- The current model is **PR-centric**: a task is bound to an existing `pullRequestNumber` and the worker iterates on that PR's branch. It is *not* a greenfield "build feature X from scratch → open new PR" flow. A Claude worker either (a) follows the same iterate-on-PR model, or (b) the schema/worker are extended to support originating a branch+PR.
+- A Claude runner can reuse the **same queue + runner harness**; the cleanest path is to (1) generalize the queue from `codex_task` to an agent-tagged task (add an `agent: "codex" | "claude"` field), and (2) add a `claude-branch-worker` mirroring `codex-branch-worker` with `claude -p`/Agent-SDK as the command. The poll/claim/heartbeat/timeout/sanitize machinery is already done.
+
+---
+
+## Q3 — Is `claude` wired beyond the card-type union? ✅ CONFIRMED (recognized, not executed)
+
+- **Recognized:** `AgentType` union (`card-types.ts:24`); `inferAgentType` maps owner `claude`→claude (`monitor-v2.ts:213`); `AGENT_TYPES` allowlist incl. claude (`monitor-v2-debug.ts:42`); debug endpoint defaults to `claude` (`:96`); fixtures use `claude` cards (`packages/monitor-ui/src/lib/monitor/fixtures.ts`).
+- **NOT executed:** there is **no Claude runner or worker**. Only `codex-task-runner.ts` + `codex-branch-worker.ts` exist. Collaboration authors are `codex | hermes | operator | system` only (`packages/monitor-ui/src/lib/monitor/collaboration.ts:10`) — **claude is not a collaboration author**, so Hermes↔Claude board chatter has no type yet.
+
+This matches the plan: Claude is modeled but is the missing worker. **Confirmed: P2 (Claude runner) is the real net-new build.**
+
+---
+
+## Q4 — Policy / mutation guardrails: what governs what? ✅ CONFIRMED (and they do NOT cover dispatch)
+
+Two existing guardrail layers, **both about job/mission execution, neither about code dispatch**:
+
+1. **Marketplace claim/submit policy** — `packages/averray-mcp/src/mutation-policy.ts`. Governs the Wikipedia citation-repair *job* mutations (`averray_claim`/`averray_submit`): requires a `runId`, caps attempts (`maxClaimAttempts`/`maxSubmitAttempts`, default 1), enforces job/session allowlists, optional fail-open, backed by a Postgres `submissions` table. Pure economic/idempotency safety for marketplace work.
+2. **Agent budget policy** — `hermes/config/policy.yaml`: `claim.allowed_task_types: [citation_repair, freshness_check]`, `submit.require_approval_if_confidence_lt: 0.7`, `budget.per_run_usd_max: 0.5`, `per_day_usd_max: 1.0`, `max_browser_steps: 80`.
+3. **Global kill switch** — `HALT_FILE` env + `assertNoKillSwitch()` (`packages/averray-mcp/src/index.ts:409`) blocks mutating tools when a halt file exists.
+
+**⚠ KEY FINDING for plan §7 (authority).** There is **no policy layer over code dispatch**. Proposing/approving a Codex task is gated only by (a) the slack-operator HTTP endpoint's auth and (b) `approveCodexTask` requiring `approvedBy: "operator"`. So a future *Hermes-driven* dispatch capability (Rung B/C) **cannot reuse `mutation-policy.ts`** — it needs a **new guardrail** (e.g. an allowlist of repos/intents Hermes may enqueue, a per-day task budget, and keeping the human `approved` gate). This is the security boundary to design before P4.
+
+---
+
+## Q5 — Full MCP tool surface + `invoke_agent_task` intents ✅ CONFIRMED
+
+`averray_*` tools registered in `packages/averray-mcp/src/index.ts` (selected): `list_jobs`, `get_definition`, `operator_status`, `daily_operator_brief`, `find_safe_work`, `agent_usefulness_plan`, `project_memory`, `project_runbook`, `admin_readiness`, `admin_action_proposal`, `ops_health`, `github_status`, `github_brief`, `approve_github_merge_steward_candidate`, `testbed_agent_mission`, `testbed_e2e_suite`, `run_testbed_e2e_read_only`, `handoff_monitor`, **`invoke_agent_task`** (`:328`), **`handle_operator_command`** (`:358`), `run_wikipedia_citation_repair`, `claim`, `save_draft_submission`, …
+
+`AgentInvocationIntent` (`packages/averray-mcp/src/agent-invocation.ts:24`):
+```
+operator_command | testbed_e2e_read_only | testbed_suite | testbed_case
+| pr_code_review | pr_handoff | post_deploy_verification
+```
+
+**⚠ KEY FINDING.** There is **no dispatch/enqueue intent** — `invoke_agent_task` only reviews and tests. Today Hermes literally **cannot enqueue a worker task through MCP**; tasks enter only via the monitor HTTP endpoint (Q2). So Rung B/C requires either a **new intent** (e.g. `enqueue_agent_task`) or a Hermes path to the `POST /monitor/codex-tasks` endpoint — gated by the new guardrail from Q4.
+
+---
+
+## Q6 — Monitor deployment: standalone or in the operator app? ✅ CONFIRMED
+
+The **Averray Handoff Monitor board** (the screenshot) is served by the **`slack-operator` service** at `/monitor/*` (`services/slack-operator/src/monitor.ts`, `monitor-spa.ts`, `monitor-v2.ts`), rendering the `packages/monitor-ui` SPA. Public exposure is via Cloudflare Access (`ops/compose.cloudflare-access.yml`). The Direction-A redesign is implemented **in this same `packages/monitor-ui`** per `docs/HERMES_MONITOR_REDESIGN_SPEC.md`.
+
+Separately there is an **optional "command center" overlay** (`ops/compose.command-center.yml`, `--profile command-center`, runbook `docs/COMMAND_CENTER.md`) that adds:
+- **`hermes-gateway`** — a Hermes process exposing an **HTTP API on `:8642`** (`API_SERVER_ENABLED`, `API_SERVER_KEY`).
+- **`hermes-workspace`** — the Hermes Workspace UI on `:3000` (`ghcr.io/outsourc-e/hermes-workspace`).
+- The built-in **Hermes dashboard on `:9119`**.
+
+**⚠ KEY FINDING for orchestration entry points.** There are **two ways to drive Hermes**, not one:
+1. The **SSH + `hermes chat -q "<prompt>"`** path used by the `[platform]` GitHub workflows (one-shot, prompt-driven).
+2. The **Hermes gateway HTTP API on `:8642`** (command-center overlay) — a programmatic, session-capable entry point better suited to an orchestration loop than shelling `hermes chat`.
+
+---
+
+## Net effect on the plan (what Phase 0 changes)
+
+| Plan item | Confirmed reality | Action |
+|---|---|---|
+| **P1 attribution** | Branch is dropped before the board model; agentType comes from `owner` string. | Thread `headBranch` into the slim card, then prefer branch-prefix in `inferAgentType`. Slightly bigger than "one mapping," still small. |
+| **P2 Claude runner** | Runner harness is command-agnostic and reusable; only `codex-branch-worker` is Codex-specific; tasks are PR-centric. | Generalize queue (`agent` field) + add `claude-branch-worker`. Decide PR-centric vs greenfield. |
+| **P3 dispatch** | Enqueue is an HTTP endpoint (`POST /monitor/codex-tasks`), human-approved; no MCP enqueue intent. | Add Claude path to the endpoint + a co-pilot verb; keep human `approved` gate. |
+| **P4 routing** | Hermes has no enqueue capability and no dispatch policy. | Add `enqueue_agent_task` intent (or gateway call) **plus** a new dispatch guardrail (Q4). |
+| **§7 authority** | `mutation-policy.ts` covers marketplace/missions only. | Design a **separate** dispatch guardrail; do not reuse the marketplace policy. |
+| **Entry point** | Gateway API on `:8642` exists. | Prefer the gateway API over SSH `hermes chat` for the Rung-C loop. |
+
+**Bottom line:** the plan holds. The cheapest first PR (P1 attribution) is confirmed small. The Claude runner (P2) is real but rides on existing, command-agnostic plumbing. The one genuinely new design surface for autonomy is a **dispatch guardrail + an enqueue capability for Hermes** — neither exists today, and that is the security-relevant decision to make before Rung C.
+
+---
+
+*End of integration map. Confirmed from this repo (`depre-dev/averray-reference-agent`) @ main on 2026-05-29.*

--- a/docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md
+++ b/docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md
@@ -1,0 +1,199 @@
+# Hermes Multi-Agent Orchestration — Feasibility Plan & Handoff
+
+- **Status:** Feasibility / planning only. **Nothing here is approved implementation.** No code in this plan has been written or merged. It exists to be handed off to another agent for refinement and execution planning.
+- **Date:** 2026-05-29
+- **Author:** Claude (feasibility study session)
+
+> ## Repo orientation (read first)
+> **This is the implementation repo.** You are in `depre-dev/averray-reference-agent` — the Hermes deployment that runs on the VPS (the agent runtime, the MCP servers, the monitor backend, the worker runners). **Build the orchestration work here.**
+>
+> The **platform repo** is the *sibling* `averray-agent/agent` — the Averray product (operator app, contracts, indexer, SDK) plus the GitHub workflows that SSH into this deployment to invoke Hermes. Throughout this doc, files tagged `[platform]` live in that repo; unprefixed source paths are **local to this repo**. You generally do **not** edit the platform repo for this effort.
+
+- **Scope of evidence:** Sections marked **[verified]** were read directly from source — `[platform]` items from `averray-agent/agent`, local items from this repo. Sections marked **[assumed]** were confirmed in **Phase 0 (now complete)** — see the companion [`docs/HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md), which supersedes the assumptions with source-cited findings.
+
+---
+
+## 0. One-paragraph summary
+
+We already run a multi-agent system without calling it one: **Codex** and **Claude** build code in their own git worktrees and open PRs; **Hermes** (this deployment) reviews PRs and reports; a **human operator** approves merges and deploys; and a live **kanban monitor** ("Hermes Handoff Monitor") makes it all legible. The goal is to evolve this from *Hermes-reviews-after-the-fact* into *Hermes-orchestrates*: an intelligent, partly self-managing workflow where Hermes decides what work is needed, routes each task to the best worker agent (Codex or Claude), tracks it, reviews it, and escalates to the human only at the merge/deploy gate — all visible and controllable from the monitor board.
+
+---
+
+## 1. What we want to achieve (goals)
+
+### North star
+An **intelligent, self-managing multi-agent workflow** with:
+- **Hermes as orchestrator** — plans/triages work, routes tasks to agents, narrates decisions, learns which agent is good at what.
+- **Codex and Claude Code as worker agents** — headless builders that take a task, work in an isolated worktree, and open a PR.
+- **The monitor board as the control plane** — every task and PR visible by agent, with the operator able to create/approve/redirect work and Hermes narrating live.
+- **The human in the loop only where it matters** — merge and deploy stay human-gated; everything up to the gate can run autonomously.
+
+### Three rungs (the path, not three separate products)
+| Rung | What Hermes does | State |
+|---|---|---|
+| **A — Reviewer/Reporter** | Reviews PRs post-CI, verifies deploys, files scheduled reports. Recommendation-only. | **This is today.** |
+| **B — Dispatcher** | Work is enqueued (by operator or Hermes); Codex/Claude runners claim and execute it; PRs flow back through review. | **Primary near-term target.** |
+| **C — Self-managing planner** | Hermes reads the board + roadmap, decides what's needed, routes each task to the best agent, tracks heartbeats, narrates, escalates only at gates. Improves routing over time via skills + memory. | **End state.** |
+
+---
+
+## 2. Current state (verified topology)
+
+```
+        CODE AGENTS                  OPERATOR AGENT              HUMAN
+   ┌──────────────────┐           ┌─────────────────┐      ┌──────────┐
+   │ Codex   (codex/*) │  opens   │     Hermes      │      │ Operator │
+   │ Claude  (claude/*)│  ──PR──▶  │  (this repo)    │      │  (you)   │
+   └──────────────────┘           └─────────────────┘      └──────────┘
+        build code                  reviews + reports        approves
+     in git worktrees              (recommendation-only)    merge/deploy
+            │                              ▲                      ▲
+            └──── CI is the merge gate ────┘                      │
+                          │                                       │
+                  Hermes Monitor (kanban board) ──── you watch & command ───┘
+```
+
+**[verified] — read in the platform repo (`averray-agent/agent`):**
+- **Two code agents are first-class.** `scripts/ops/start-agent-worktree.sh` routes `codex/<task>` → `.codex/worktrees/` and `claude/<task>` → `.claude/worktrees/`. `AGENTS.md` treats them as peers: one branch per task, narrow PRs, never push to `main`, CI is the merge gate.
+- **Hermes is invoked over SSH:** the platform's `.github/workflows/hermes-pr-handoff.yml` runs `ssh … docker compose … exec -T hermes hermes chat --provider ollama-cloud -m deepseek-v4-pro:cloud -q "$PROMPT"`. The prompt always says *"Use Averray MCP tools only."*
+- **Three Hermes routines, all recommendation/evidence-only (Hermes never merges or mutates GitHub):**
+  1. **PR handoff** (post-CI) → `averray_invoke_agent_task(intent='pr_handoff', TBE2E-004)`.
+  2. **Post-deploy verification** → `intent='testbed_suite'` (in the platform's `.github/workflows/deploy-production.yml`).
+  3. **Scheduled operator self-reports** → daily 07:17 UTC → `averray_handle_operator_command('ops health' | 'daily operator brief')` (platform's `.github/workflows/hermes-operator-report.yml`).
+- **The integration bus is MCP.** Two tool families: `averray_invoke_agent_task` and `averray_handle_operator_command` (both served by this repo's `packages/averray-mcp`).
+
+**[verified from the live monitor screenshot]:**
+- The monitor is **live and running** (not just a spec). 8-lane pipeline: `needs-attention → drafts → codex-needed → hermes-checking → operator-review → release-queue → deploying → done`. KPI strip, LIVE clock, calm/empty "Board Now" state, a persistent **Hermes co-pilot rail** with `/mission <url>` and `/mute 1h` slash commands.
+- **Today, work enters at "Operator review"** (Hermes already ran its check; cards show `WAITING ON → OPERATOR`, 9/9 checks) and exits via **Deploying → Done**. The left half of the pipeline (drafts, codex-needed, hermes-checking) is **empty**.
+- **Every card is `agentType: ext`** — generic external PR. The data model supports `claude | codex | hermes | ext`, but in production no card is attributed to a specific agent.
+- The **Codex-needed lane** exists with the subtitle `CREATE / APPROVE TASK` but is **dormant** (no orchestrator enqueues work). The co-pilot exposes `/mission` and `/mute`, but no dispatch verb, and narrates nothing yet ("No board chatter yet").
+
+### The two gaps that separate "today" from the goal
+1. **Attribution gap** — the board can't see *which* agent did what; everything is `ext`.
+2. **Dispatch gap** — the lanes/UI for assigning work to agents exist but nothing drives them.
+
+---
+
+## 3. What the Hermes framework already gives us (no build needed)
+
+**[assumed — from `nousresearch/hermes-agent` README]** — versions/availability to confirm against the running image:
+- **Agent loop + tool calling** (already wired to Averray MCP).
+- **Subagent spawning** — Hermes can fan out its own isolated subagents.
+- **Cron scheduler** — already used for the daily reports.
+- **Skills framework** (agentskills.io) — Hermes can create/improve reusable procedures. This is the hook for a learnable routing playbook.
+- **Memory layer** (SQLite FTS5 + summarization + user profile) — persistent routing decisions and per-agent performance history.
+- **MCP client + multiple terminal backends** (local, Docker, SSH, Modal, Daytona) — the mechanism by which Hermes could launch worker runs.
+- **Messaging gateways** (Slack, Telegram, …) — operator approvals from anywhere.
+
+**Implication:** Hermes already has the *capability* to orchestrate. The work is wiring behaviors, not adding engine features.
+
+---
+
+## 4. Target architecture (Rung C)
+
+```
+   ┌──────────────────────────── Hermes (orchestrator) ───────────────────────────┐
+   │  reads: board state + roadmap + memory                                        │
+   │  decides: what work is needed                                                 │
+   │  routes:  task → best agent (taxonomy + learned performance)                  │
+   │  narrates: decision in the co-pilot rail                                      │
+   └───────────────┬───────────────────────────────────────────┬──────────────────┘
+                   │ enqueue task (policy-gated)                 │ review verdict
+                   ▼                                             ▲
+            ┌──────────────┐        claim & run        ┌──────────────────┐
+            │  Task queue  │ ───────────────────────▶  │  PR handoff      │
+            └──────────────┘                           │  (existing)      │
+              │          │                             └──────────────────┘
+     ┌────────▼───┐  ┌───▼─────────┐                            ▲
+     │codex-runner│  │claude-runner│  headless build in worktree │
+     │ codex/*    │  │ claude/*    │ ───────── opens PR ─────────┘
+     └────────────┘  └─────────────┘
+                   │
+                   ▼
+        Monitor board (control plane) — operator creates/approves/redirects;
+        every card attributed to its agent; human owns merge/deploy gate.
+```
+
+---
+
+## 5. Workstreams / phases
+
+> **Repo legend:** `[ref-agent]` = work lands **here** (`depre-dev/averray-reference-agent`, this repo). `[platform]` = work lands in the sibling `averray-agent/agent`. **Almost everything is `[ref-agent]`;** the platform repo changes only if new MCP intents/tools or workflow hooks must surface there.
+
+| Phase | Goal | Repo | Depends on | Rough effort | Acceptance |
+|---|---|---|---|---|---|
+| **P0 — Discovery** | Confirm the [assumed] internals so later phases are exact, not approximate. | both (read-only) | — | 0.5–1 day | **DONE** — see [`docs/HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md). |
+| **P1 — Agent attribution** | Board derives `agentType` from PR head-branch prefix (`codex/*`→codex, `claude/*`→claude, else ext/human). Board stops showing everything as `ext`. | `[ref-agent]` | P0 | ~0.5 day | Live board shows correct per-agent attribution on existing PRs. |
+| **P2 — Claude Code worker runner** | A `claude-branch-worker` mirroring the Codex one, riding the existing command-agnostic runner: claim task → worktree → run `claude -p "<prompt>"` (or Agent SDK) headless → open PR → heartbeat. | `[ref-agent]` | P0 | 2–4 days | A queued Claude task produces a PR that flows into Operator review via existing handoff, unchanged. |
+| **P3 — Board-driven dispatch** | Light up the `codex-needed` lane (`CREATE / APPROVE TASK`) for both agents + a co-pilot `/task` verb. Operator (and later Hermes) enqueues; runners claim. | `[ref-agent]` | P1, P2 | 2–3 days | Operator creates a task from the board → it appears in `codex-needed` → runner picks it up → PR appears attributed to the agent. |
+| **P4 — Hermes as router (Rung C core)** | A Hermes skill that reads board + roadmap, decides what's needed, routes by task taxonomy (Codex owns chain/settlement; Claude takes UI/docs), enqueues (policy-gated), and **narrates the decision** in the rail. | `[ref-agent]` / Hermes skills | P3 | 3–6 days | Given a backlog, Hermes proposes + routes ≥1 task end-to-end and narrates why; operator can veto from the board. |
+| **P5 — Self-management hardening** | Heartbeats, stale-task detection, retries, escalation rules, **a dispatch guardrail** (see map Q4), per-agent performance memory, observability. | `[ref-agent]` | P4 | ongoing | Stuck/failed tasks surface in `needs-attention`; dispatch respects policy budgets; routing improves with logged performance. |
+
+### Sequencing rationale
+- **P1 first** because it's the smallest change, the highest signal, and a prerequisite for any routing intelligence (you can't route by agent if you can't attribute by agent).
+- **P2 before P3** because dispatch needs at least one new runner to dispatch *to*; the Codex worker already exists, so Claude is the missing one.
+- **P4/P5 are mostly prompt/skill/policy work**, not plumbing — they sit on top of P1–P3.
+
+---
+
+## 6. Phase 0 questions — now answered
+
+These six were the load-bearing unknowns. They are **answered with source citations in [`docs/HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md)**:
+
+1. Board aggregator — agentType logic (why all `ext`).
+2. Codex task queue + runner — schema, storage, lifecycle, executor.
+3. Claude agentType handling — recognized vs executed.
+4. Policy / mutation guardrails — what they cover (and that they do **not** cover dispatch).
+5. MCP tool surface + `invoke_agent_task` intents (no enqueue intent exists).
+6. Monitor deployment (served by `slack-operator`; optional Hermes gateway API on `:8642`).
+
+See the map's "Net effect on the plan" table for the refinements each answer implies for P1–P4.
+
+---
+
+## 7. Constraints & invariants (must not break)
+
+- **Human owns the merge/deploy gate.** Platform `AGENTS.md`: no direct pushes to `main`, deploys serialized, CI is the merge gate. "Self-managing" means *self-managing up to the gate* — **no auto-merge**, at least until explicitly revisited.
+- **Authority change is the real risk.** Today Hermes is recommendation-only and never mutates GitHub. Giving it a *dispatch* (enqueue) capability must go through a **new** dispatch guardrail (the existing marketplace mutation policy does not cover this — see map Q4) — never free-form prompt authority.
+- **Two-repo split.** Worker/runner/monitor/orchestration work lands **here** (`averray-reference-agent`). The platform repo changes only for new MCP intents/tools or workflow hooks.
+- **Codex owns chain/settlement.** Per existing coordination rules, routing logic (P4) must keep chain/settlement tasks with Codex; Claude takes UI/docs/etc.
+- **Truth-boundary discipline.** The board must keep its honest real/degraded/empty signaling (KPIs show `?` not `0` when a source is down). Don't make orchestration look more autonomous/live than it is.
+- **Narrow PRs, one branch per task** — every phase ships as small, independently reviewable PRs.
+
+---
+
+## 8. Immediate next steps (for the handoff agent)
+
+Phase 0 is done. Next is execution-level design (still planning), or starting P1.
+
+1. **Read [`docs/HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md)** — it has the confirmed source map and the refinements per phase.
+2. **Write the P1 design** (thread `headBranch` into the slim board model → prefer branch prefix in `inferAgentType`), then either spike it or implement it as one narrow PR.
+3. **Write the P2 runner design** (Claude headless: `claude -p` vs Agent SDK; auth; sandboxing; worktree lifecycle; generalize the queue with an `agent` field).
+4. **Design the dispatch authority model + guardrail** for P3/P4 with the operator: what Hermes may enqueue autonomously vs. what needs operator approval in the `codex-needed` lane.
+5. **Bring the result back to the operator** to choose how far to push toward Rung C and on what timeline.
+
+---
+
+## 9. Key references
+
+**This repo (`depre-dev/averray-reference-agent`) — source:**
+- `packages/averray-mcp/` — the MCP server Hermes calls (`index.ts`, `agent-invocation.ts`, `mutation-policy.ts`, `operator-commands.ts`).
+- `services/slack-operator/` — the live `/monitor` board + Codex task queue/runner (`monitor-v2.ts`, `codex-task-queue.ts`, `codex-task-runner.ts`, `codex-branch-worker.ts`).
+- `packages/monitor-ui/` — the board SPA (`card-types.ts`, `lane-rules.ts`, `MonitorPage.tsx`).
+- `hermes/config/` — `hermes.yaml`, `policy.yaml`.
+- `docs/HERMES_MONITOR_REDESIGN_SPEC.md` — the monitor board redesign spec.
+- [`docs/HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md) — the Phase 0 confirmed map.
+
+**Platform repo (`averray-agent/agent`) — [verified]:**
+- `AGENTS.md` — multi-agent coordination rules.
+- `scripts/ops/start-agent-worktree.sh` — `codex/*` / `claude/*` worktree convention.
+- `.github/workflows/hermes-pr-handoff.yml`, `hermes-operator-report.yml`, `deploy-production.yml` — how Hermes is invoked.
+- `docs/HERMES_OPERATOR_REPORTS.md` — the Hermes routines + evidence/correlation-id model.
+- `docs/PROJECT_ROADMAP.md` — canonical roadmap (Hermes would read this in Rung C).
+
+**External:**
+- `github.com/nousresearch/hermes-agent` — the Hermes framework (agent loop, subagents, cron, skills, memory, MCP).
+
+---
+
+*End of plan. Feasibility/planning only — not approved implementation.*

--- a/docs/HERMES_ORCHESTRATION_DESIGN.md
+++ b/docs/HERMES_ORCHESTRATION_DESIGN.md
@@ -1,0 +1,202 @@
+# Hermes Orchestration — Execution Design (per-phase build specs)
+
+- **Status:** Planning / handoff only. **Nothing here is implemented.** This is the build spec a future agent follows; it does not apply changes.
+- **Date:** 2026-05-29
+- **Companions:** [`HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md) (the why + phases), [`HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md) (the confirmed source map).
+- **Scope:** turns plan phases P1–P5 + the dispatch guardrail into concrete, file-level build specs. All `path:line` references are local to this repo. Code blocks are **illustrative sketches of the intended change**, not applied diffs.
+
+> Build order: **P1 → P2 → P3 → P4 (+ guardrail) → P5.** P1 has no open decisions and is ready. P2/P3 have a few decisions flagged for operator sign-off. P4 is the authority change and must not ship without the guardrail. Every phase is one narrow PR per [AGENTS.md](../AGENTS.md), with `npm run typecheck` + `npm test` green and the PR template's invariant checks.
+
+---
+
+## P1 — Agent attribution  ·  ready to build · no open decisions · risk: low
+
+**Goal:** the board stops labelling every card `ext`. Attribute each card to the agent that opened the PR via the branch convention (`codex/*`, `claude/*`).
+
+**Why it's the first build:** smallest change, highest signal, and a prerequisite for routing (you can't route by agent if you can't attribute by agent). It's a pure read-path enrichment — no lane logic, no mutation.
+
+**Confirmed data flow:**
+```
+raw monitor snapshot
+  → boardCardFromItem()          services/slack-operator/src/monitor-hermes-board.ts:42
+      builds the slim HermesBoardCardSnapshot (drops the branch today)
+  → toBoardCard()                services/slack-operator/src/monitor-v2.ts:313
+      → inferAgentType()         services/slack-operator/src/monitor-v2.ts:225  ← uses `owner`, defaults "ext"
+  → BoardCard.agentType
+```
+The branch *is* available upstream (`packages/averray-mcp/src/operator-github.ts:1432` sets `headBranch` from `pull.head.ref`; `services/slack-operator/src/github-pr-state.ts:180,280` too) but the slim card drops it (`monitor-v2.ts:338` — `// branch not in slim model`).
+
+**Change set (3 files):**
+
+1. **`services/slack-operator/src/monitor-hermes-voice.ts`** — add a field to `HermesBoardCardSnapshot` (after `correlationId?`):
+   ```ts
+   /** PR head branch (e.g. "codex/foo"); forwarded so the v2 mapper can
+       attribute the card by branch prefix instead of the owner string. */
+   headBranch?: string;
+   ```
+
+2. **`services/slack-operator/src/monitor-hermes-board.ts`** — in `boardCardFromItem` (≈:57), resolve and forward the branch:
+   ```ts
+   const headBranch = headBranchForPr(prState, summary, item);
+   return { ...,
+     ...(correlationId ? { correlationId } : {}),
+     ...(headBranch ? { headBranch } : {}),
+   };
+   ```
+   Add a helper next to `pullRequestState` (≈:393) that tolerates a flat `headBranch` or a nested `head.ref` across `currentPullRequest` / `pullRequest` / `item.pullRequest`:
+   ```ts
+   function headBranchForPr(prState, summary, item): string {
+     for (const src of [prState, recordProp(summary, "pullRequest"), recordProp(item, "pullRequest")]) {
+       if (!src) continue;
+       const flat = textProp(src, "headBranch"); if (flat) return flat;
+       const head = recordProp(src, "head"); const ref = head ? textProp(head, "ref") : "";
+       if (ref) return ref;
+     }
+     return "";
+   }
+   ```
+
+3. **`services/slack-operator/src/monitor-v2.ts`** — `inferAgentType` (:225) prefers the branch prefix, then falls back to the existing owner-string logic; add an exported helper; and populate `card.branch` in `toBoardCard` (:338):
+   ```ts
+   export function inferAgentType(item, type): AgentType {
+     if (type === "mission") return "hermes";
+     const fromBranch = agentTypeFromBranch(item.headBranch);
+     if (fromBranch) return fromBranch;
+     const owner = (item.owner ?? "").toLowerCase();
+     if (owner.includes("codex")) return "codex";
+     if (owner.includes("hermes")) return "hermes";
+     if (owner.includes("claude")) return "claude";
+     return "ext";
+   }
+   export function agentTypeFromBranch(headBranch?: string): AgentType | undefined {
+     const b = (headBranch ?? "").trim().toLowerCase();
+     if (b.startsWith("codex/"))  return "codex";
+     if (b.startsWith("claude/")) return "claude";
+     return undefined;
+   }
+   // toBoardCard:  replace the `branch not in slim model` line with:
+   if (item.headBranch) card.branch = item.headBranch;
+   ```
+
+**Tests** (`test/unit/monitor-v2.test.ts`, reuse the existing `slim()` helper; `test/unit/monitor-hermes-board.test.ts` for forwarding):
+- branch prefix wins over a conflicting `owner` (`owner:"Codex"`, `headBranch:"claude/x"` → `claude`);
+- `codex/*`→codex, `claude/*`→claude, case-insensitive;
+- non-agent branch (`main`, `feature/x`) falls back to the owner string;
+- `mission` type stays `hermes` regardless of branch;
+- `toBoardCard` populates `branch` and `agentType` together;
+- board forwarding: `headBranch` from `currentPullRequest.headBranch` and from nested `head.ref`.
+
+**Acceptance:** live board attributes `codex/*` and `claude/*` PRs correctly; non-prefixed PRs remain `ext`; typecheck + tests green.
+
+**Note (out of scope):** human-authored PRs on non-prefixed branches stay `ext`. A distinct `human` agent type can come later; not needed now.
+
+---
+
+## P2 — Claude Code worker  ·  concrete · 3 decisions · risk: medium
+
+**Goal:** a Claude worker symmetric to the Codex one, so an approved Claude task runs headless and opens/updates a PR.
+
+**Confirmed reuse surface:**
+- `services/slack-operator/src/codex-task-queue.ts` — JSON queue, `proposed→approved→running→completed/failed/cancelled`.
+- `services/slack-operator/src/codex-task-runner.ts` — **command-agnostic** poll/claim/execute/heartbeat (spawns `CODEX_TASK_RUNNER_COMMAND` with templated args; 10s poll; 30m timeout; secret-sanitized output).
+- `services/slack-operator/src/codex-branch-worker.ts` — the Codex-specific part: refuses protected branches (:123), checks out the PR head branch (:192), runs the `codex` CLI, pushes (:213).
+
+**Design:**
+- **Generalize the queue:** add `agent: "codex" | "claude"` to `CodexTaskInput`/`CodexTask` (default `"codex"` for back-compat). Add an `agent` filter to `claimNextApprovedCodexTask` so each runner claims only its agent's tasks.
+- **Worker:** `claude-branch-worker.ts` mirroring `codex-branch-worker.ts` — same protected-branch guard, checkout, push, and output sanitization, but the command is `claude -p "<prompt>"` (headless print mode) or the Claude Agent SDK.
+- **Runner:** run a second `claude-task-runner` process (filters `agent==="claude"`, its own `CLAUDE_TASK_RUNNER_COMMAND` + heartbeat id), mirroring the Codex runner. Compose service added in `ops/`.
+
+**Tests:** queue `agent` default + claim filter; `claude-branch-worker` refuses protected branches; runner claims only its agent's approved tasks.
+
+**Acceptance:** an approved `claude` task → `claude-branch-worker` runs headless in the PR's worktree → pushes → the PR flows into Operator review via the existing Hermes handoff, unchanged.
+
+**Open decisions (operator):**
+1. **PR-centric vs greenfield.** Codex today iterates on an *existing* PR's branch (`pullRequestNumber` is required). Same for Claude (smallest delta, recommended to start), or extend the schema/worker to originate a branch + PR?
+2. **Invocation:** `claude -p` headless (parity with the Codex CLI worker, recommended) vs the Agent SDK. Plus auth (API key env), sandbox, network, and whether the worker gets MCP access.
+3. **Runner topology:** a per-agent runner (recommended — clean heartbeats/isolation) vs one generalized runner routing by `task.agent`.
+
+**Risk:** medium — this worker executes code and pushes branches. It must reuse the protected-branch guard, secret sanitization, timeout, **and** the human approval gate (tasks run only at `status:"approved"`, `approvedBy:"operator"`).
+
+---
+
+## P3 — Board-driven dispatch  ·  concrete · 1 decision · risk: low–medium
+
+**Goal:** make the dormant `codex-needed` lane (`CREATE / APPROVE TASK`) work for both agents, drivable from the board.
+
+**Confirmed surface:** enqueue is `POST /monitor/codex-tasks` (`services/slack-operator/src/index.ts:389` → `proposeCodexTask` :1107); approval → `approveCodexTask(id, { approvedBy:"operator" })` (:1132). Co-pilot composer already parses `/mission`, `/mute`.
+
+**Design:**
+- Extend the create-task endpoint + UI form to accept `agent` (`codex|claude`), defaulting to `codex`.
+- Add a co-pilot `/task <agent> <repo>#<pr> <prompt>` slash verb (mirror the `/mission` parser).
+- Render the task card's agent (depends on P1 attribution).
+- **Keep the human approve step** (`proposed → approved` by operator) — invariant.
+
+**Tests:** endpoint validates/stores `agent`; task card renders the agent; slash-verb parsing.
+
+**Acceptance:** operator creates a `claude` task from the board → it lands in `codex-needed` → the Claude runner claims it → the resulting PR is attributed to `claude`.
+
+**Open decision:** dispatch surface — form, `/task` slash verb, or both (recommend both).
+
+**Risk:** low–medium — no new authority beyond the existing operator-authed endpoint + human approve.
+
+---
+
+## P4 — Hermes as router + the dispatch guardrail  ·  the authority change · risk: HIGH
+
+**Goal:** Hermes proposes and routes work itself; the human still approves.
+
+**Confirmed gap:** `invoke_agent_task` has **no enqueue intent** (`packages/averray-mcp/src/agent-invocation.ts:24`), and `mutation-policy.ts` covers marketplace claim/submit **only** — there is no policy over code dispatch. A global `HALT_FILE` kill switch exists (`packages/averray-mcp/src/index.ts:409`).
+
+**Design — three parts, all required together:**
+
+1. **Enqueue capability (proposes-only).** Add an `enqueue_agent_task` intent to the `AgentInvocationIntent` union, wired to `proposeCodexTask`. It must write `status:"proposed"` **only — never `approved`.** (Alternative: Hermes calls `POST /monitor/codex-tasks` via the gateway. Recommend the MCP intent so it lands in the existing handoff-event audit trail.)
+
+2. **A NEW dispatch guardrail** (do **not** reuse `mutation-policy.ts`):
+   - **Allowlist** — which repos + task kinds Hermes may propose.
+   - **Budget** — max proposed tasks per day (and per repo), in the style of `hermes/config/policy.yaml`'s budget block; counters persisted in the data dir.
+   - **Human-approval invariant** — Hermes proposes; `approveCodexTask` stays operator-only.
+   - **Honors `HALT_FILE`.**
+   - Lives as a `dispatch:` block in `policy.yaml` + a `dispatch-policy.ts` mirroring `mutation-policy.ts`.
+
+3. **Routing logic (a Hermes skill).** Reads the board (`averray_handoff_monitor`) + roadmap, decides what's needed, routes by **task taxonomy** (Codex owns chain/settlement; Claude takes UI/docs/general), proposes the (gated) task, and **narrates the decision** in the co-pilot rail (a collaboration message). Taxonomy + narration are skill/prompt work.
+
+**Tests:** dispatch-policy unit (allowlist / budget / halt); enqueue intent proposes-only (never approves); routing taxonomy mapping.
+
+**Acceptance:** given a backlog, Hermes proposes ≥1 correctly-routed task (gated), narrates why, and the operator approves it from the board.
+
+**Open decisions (operator):** enqueue via MCP intent vs gateway HTTP; where the dispatch policy config lives; the exact Codex-vs-Claude taxonomy (needs operator input).
+
+**Risk: HIGH — this is the authority change.** It must ship with the guardrail + proposes-only + human approve + `HALT_FILE`. This is the gate before any autonomy; treat it as security-reviewed work.
+
+---
+
+## P5 — Self-management hardening  ·  ongoing
+
+- Heartbeat-staleness detection → surface stuck/stale tasks in `needs-attention`.
+- Retries via `attemptCount`; escalation rules when a task fails repeatedly.
+- Per-agent performance memory (Hermes memory) feeding the routing skill so attribution → routing improves over time.
+- Observability: a handoff event per dispatch decision; no silent caps (log anything dropped by the budget).
+
+---
+
+## Cross-cutting rules (every phase)
+
+- One narrow PR; branch `codex/<task>` or `claude/<task>`; `npm run typecheck` + `npm test` green; complete the PR template, including the durable-invariants checks.
+- **Update [AGENTS.md](../AGENTS.md) in the same PR** when a phase changes how agents work (e.g. P2 adds a worker, P4 changes Hermes's powers). This is a durable invariant.
+- Preserve the board's honest real/degraded/empty signaling — never make orchestration look more autonomous/live than it is.
+
+## Open-decisions summary (for operator sign-off)
+
+| # | Decision | Phase | Recommendation |
+|---|---|---|---|
+| 1 | Claude worker: iterate-on-PR vs greenfield branch+PR | P2 | Start PR-centric (smallest delta) |
+| 2 | Claude invocation: `claude -p` vs Agent SDK (+ auth/sandbox/MCP) | P2 | `claude -p` headless first |
+| 3 | Runner topology: per-agent vs one generalized | P2 | Per-agent runner |
+| 4 | Dispatch surface: form vs `/task` slash vs both | P3 | Both |
+| 5 | Hermes enqueue: new MCP intent vs gateway HTTP | P4 | MCP intent (auditable) |
+| 6 | Where the dispatch policy config lives | P4 | `dispatch:` in `policy.yaml` + `dispatch-policy.ts` |
+| 7 | Codex-vs-Claude task taxonomy | P4 | Needs operator input |
+
+---
+
+*End of execution design. Planning/handoff only — not implemented.*


### PR DESCRIPTION
## What changed

Three **docs-only** planning/handoff artifacts (no code, no behavior change). Together they take the multi-agent orchestration effort from idea → confirmed → buildable, for handoff to an implementing agent:

- **`docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`** — the why + the three rungs (reviewer → dispatcher → self-managing planner) + phases P0–P5 + safety constraints.
- **`docs/HERMES_INTEGRATION_MAP.md`** — Phase 0 discovery, confirmed from this repo's source with `path:line` citations (agentType comes from the `owner` string → all cards `ext`; the runner is command-agnostic; `claude` modeled but unbuilt; `invoke_agent_task` has no enqueue intent; mutation policy doesn't cover dispatch).
- **`docs/HERMES_ORCHESTRATION_DESIGN.md`** — per-phase, file-level build specs: confirmed data flow, the change set, tests, acceptance, risk, and the open decisions for operator sign-off. **P1 (agent attribution) is fully specified and unblocked.**

## Why here

These live in the implementation repo on purpose — the runners, queue, monitor backend, and MCP servers are all here, so the build happens here. The sibling `averray-agent/agent` only holds the workflows that invoke Hermes.

## Status

Planning only — none of this is implemented. Build order P1 → P2 → P3 → P4 (+ guardrail) → P5; P4 (Hermes gains enqueue authority) must not ship without the new dispatch guardrail.

## Checks run

None — documentation only.