### PR TITLE
monitor: attribute board cards to the agent via branch prefix (P1)

### DIFF
--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -54,6 +54,7 @@ function boardCardFromItem(
   if (!title && !identity.repo) return undefined;
   const why = reasonForItem(item, summary, prState, codexTaskStatus);
   const correlationId = textProp(item, "correlationId");
+  const headBranch = headBranchForPr(prState, summary, item);
   return {
     ...identity,
     title: title || "Untitled handoff",
@@ -65,7 +66,40 @@ function boardCardFromItem(
     next: classification.next,
     tags: tagsForItem(item, summary),
     ...(correlationId ? { correlationId } : {}),
+    ...(headBranch ? { headBranch } : {}),
   };
+}
+
+/** Read a PR's head branch, tolerating a flat `headBranch` or a nested `head.ref`. */
+function headBranchFromPr(pr: Record<string, unknown> | undefined): string {
+  if (!pr) return "";
+  const flat = textProp(pr, "headBranch");
+  if (flat) return flat;
+  const head = recordProp(pr, "head");
+  return head ? textProp(head, "ref") : "";
+}
+
+/**
+ * Resolve the PR head branch across the candidate PR objects
+ * (currentPullRequest / pullRequest / item.pullRequest). Used to
+ * attribute the card to the agent that opened the PR (codex/*, claude/*).
+ */
+function headBranchForPr(
+  prState: Record<string, unknown> | undefined,
+  summary: Record<string, unknown>,
+  item: Record<string, unknown>
+): string {
+  const candidates = [
+    prState,
+    recordProp(summary, "currentPullRequest"),
+    recordProp(summary, "pullRequest"),
+    recordProp(item, "pullRequest"),
+  ];
+  for (const pr of candidates) {
+    const branch = headBranchFromPr(pr);
+    if (branch) return branch;
+  }
+  return "";
 }
 
 function classifyItem(

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -71,6 +71,12 @@ export interface HermesBoardCardSnapshot {
    * card id instead of colliding distinct items onto one title slug.
    */
   correlationId?: string;
+  /**
+   * The PR's head branch (e.g. "codex/foo", "claude/bar"). Forwarded so
+   * the v2 mapper can attribute the card to the agent that opened the PR
+   * via the branch-prefix convention. Absent for non-PR cards.
+   */
+  headBranch?: string;
 }
 
 export interface HermesBoardSnapshot {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -218,13 +218,29 @@ export function inferCardType(item: HermesBoardCardSnapshot, lane: Lane): CardTy
 }
 
 /**
- * Infer the agent that owns the card from the classifier `owner`
- * field + lane. The slim model doesn't carry agentType, so this is
- * best-effort and defaults to "ext" (external / unknown).
+ * Map a PR head branch to the agent that opened it via the branch-prefix
+ * convention (codex/* → codex, claude/* → claude, case-insensitive).
+ * Returns undefined for non-agent branches so callers fall back to the
+ * owner heuristic.
+ */
+export function agentTypeFromBranch(headBranch?: string): AgentType | undefined {
+  const b = (headBranch ?? "").trim().toLowerCase();
+  if (b.startsWith("codex/")) return "codex";
+  if (b.startsWith("claude/")) return "claude";
+  return undefined;
+}
+
+/**
+ * Infer the agent that owns the card. Missions are always Hermes; then
+ * the PR head branch wins (codex/*, claude/*) since the branch-prefix
+ * convention is authoritative for who opened the PR; otherwise fall back
+ * to the classifier `owner` heuristic, defaulting to "ext".
  */
 export function inferAgentType(item: HermesBoardCardSnapshot, type: CardType): AgentType {
-  const owner = (item.owner ?? "").toLowerCase();
   if (type === "mission") return "hermes";
+  const fromBranch = agentTypeFromBranch(item.headBranch);
+  if (fromBranch) return fromBranch;
+  const owner = (item.owner ?? "").toLowerCase();
   if (owner.includes("codex")) return "codex";
   if (owner.includes("hermes")) return "hermes";
   if (owner.includes("claude")) return "claude";
@@ -335,7 +351,7 @@ export function toBoardCard(item: HermesBoardCardSnapshot): BoardCard {
   if (isDraft) card.isDraft = true;
   if (item.next) card.next = item.next;
   if (item.verdict) card.verdict = item.verdict;
-  if (typeof item.number === "number") card.branch = undefined; // branch not in slim model
+  if (item.headBranch) card.branch = item.headBranch;
 
   return card;
 }

--- a/test/unit/monitor-hermes-board.test.ts
+++ b/test/unit/monitor-hermes-board.test.ts
@@ -122,4 +122,47 @@ describe("buildHermesBoardSnapshotFromMonitor", () => {
       why: "Codex task is approved.",
     });
   });
+
+  it("forwards the PR head branch (flat headBranch and nested head.ref)", () => {
+    const board = buildHermesBoardSnapshotFromMonitor({
+      generatedAt: "2026-05-20T08:54:42.000Z",
+      recent: [
+        {
+          correlationId: "github-live-pr-flat",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 501,
+          status: "completed",
+          summary: {
+            currentPullRequest: {
+              repo: "averray-agent/agent",
+              number: 501,
+              state: "open",
+              title: "Codex PR (flat headBranch)",
+              headBranch: "codex/widen-claim",
+            },
+          },
+        },
+        {
+          correlationId: "github-live-pr-nested",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 502,
+          status: "completed",
+          summary: {
+            pullRequest: {
+              repo: "averray-agent/agent",
+              number: 502,
+              state: "open",
+              title: "Claude PR (nested head.ref)",
+              head: { ref: "claude/board-polish" },
+            },
+          },
+        },
+      ],
+    });
+
+    const flat = board?.items?.find((item) => item.number === 501);
+    const nested = board?.items?.find((item) => item.number === 502);
+    expect(flat?.headBranch).toBe("codex/widen-claim");
+    expect(nested?.headBranch).toBe("claude/board-polish");
+  });
 });

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -9,6 +9,7 @@ import {
   parseAgeToMinutes,
   cardId,
   toBoardCard,
+  agentTypeFromBranch,
   buildV2BoardSnapshot,
   isCriticalFile,
   mapChecks,
@@ -106,18 +107,45 @@ describe("inferCardType", () => {
   });
 });
 
-describe("inferAgentType", () => {
-  it("mission type → hermes", () => {
-    expect(inferAgentType(slim({ owner: "Operator" }), "mission")).toBe("hermes");
+describe("agentTypeFromBranch", () => {
+  it("maps codex/* and claude/* prefixes (case-insensitive)", () => {
+    expect(agentTypeFromBranch("codex/foo")).toBe("codex");
+    expect(agentTypeFromBranch("claude/bar")).toBe("claude");
+    expect(agentTypeFromBranch("Codex/Foo")).toBe("codex");
+    expect(agentTypeFromBranch("  CLAUDE/Bar  ")).toBe("claude");
   });
-  it("owner contains codex → codex", () => {
-    expect(inferAgentType(slim({ owner: "Codex" }), "pr")).toBe("codex");
+  it("returns undefined for non-agent / missing branches", () => {
+    expect(agentTypeFromBranch("feature/x")).toBeUndefined();
+    expect(agentTypeFromBranch("codexish/x")).toBeUndefined(); // prefix must be "codex/"
+    expect(agentTypeFromBranch("")).toBeUndefined();
+    expect(agentTypeFromBranch(undefined)).toBeUndefined();
+  });
+});
+
+describe("inferAgentType", () => {
+  it("mission type → hermes (even with a non-hermes branch)", () => {
+    expect(inferAgentType(slim({ owner: "Operator", headBranch: "codex/x" }), "mission")).toBe("hermes");
+  });
+  it("branch prefix wins over a conflicting owner", () => {
+    expect(inferAgentType(slim({ owner: "Codex", headBranch: "claude/x" }), "pr")).toBe("claude");
+    expect(inferAgentType(slim({ owner: "Merge steward", headBranch: "codex/x" }), "pr")).toBe("codex");
+  });
+  it("codex/* and claude/* attribute, case-insensitive", () => {
+    expect(inferAgentType(slim({ owner: "ext", headBranch: "codex/feat" }), "pr")).toBe("codex");
+    expect(inferAgentType(slim({ owner: "ext", headBranch: "Claude/Feat" }), "pr")).toBe("claude");
+  });
+  it("non-agent branch falls back to the owner heuristic", () => {
+    expect(inferAgentType(slim({ owner: "Codex", headBranch: "feature/x" }), "pr")).toBe("codex");
+    expect(inferAgentType(slim({ owner: "Merge steward", headBranch: "feature/x" }), "pr")).toBe("ext");
+  });
+  it("owner contains codex → codex (no branch)", () => {
+    expect(inferAgentType(slim({ owner: "Codex", headBranch: undefined }), "pr")).toBe("codex");
   });
   it("owner contains hermes → hermes", () => {
-    expect(inferAgentType(slim({ owner: "Hermes" }), "pr")).toBe("hermes");
+    expect(inferAgentType(slim({ owner: "Hermes", headBranch: undefined }), "pr")).toBe("hermes");
   });
   it("unknown owner → ext", () => {
-    expect(inferAgentType(slim({ owner: "Merge steward" }), "pr")).toBe("ext");
+    expect(inferAgentType(slim({ owner: "Merge steward", headBranch: undefined }), "pr")).toBe("ext");
   });
 });
 
@@ -215,6 +243,16 @@ describe("toBoardCard", () => {
     expect(card.waitingOn).toEqual({ actor: "operator", tone: "neutral" });
     expect(card.verdict).toBe("Hermes pre-check passed");
     expect(card.next).toBe("Approve & merge");
+  });
+
+  it("sets branch + agentType together from headBranch", () => {
+    const card = toBoardCard(slim({ owner: "Operator", headBranch: "claude/monitor-agent-attribution" }));
+    expect(card.branch).toBe("claude/monitor-agent-attribution");
+    expect(card.agentType).toBe("claude"); // branch wins over the "Operator" owner
+  });
+
+  it("leaves branch undefined when no headBranch is present", () => {
+    expect(toBoardCard(slim({ headBranch: undefined })).branch).toBeUndefined();
   });
 
   it("flags needs-attention cards as isAction with warn tone", () => {


### PR DESCRIPTION
## What changed & why

Hermes orchestration **P1 — agent attribution** (per `docs/HERMES_ORCHESTRATION_DESIGN.md`). Today the board labels every card `ext`; this attributes each card to the agent that opened the PR via the branch-prefix convention (`codex/*`, `claude/*`). **Pure read-path enrichment — no lane logic, no mutation.**

- `monitor-hermes-voice.ts` — add `headBranch?` to `HermesBoardCardSnapshot` (after `correlationId`).
- `monitor-hermes-board.ts` — `boardCardFromItem` forwards the PR head branch via a new `headBranchForPr()` helper, tolerating a flat `headBranch` or a nested `head.ref` across `currentPullRequest` / `pullRequest` / `item.pullRequest`.
- `monitor-v2.ts` — `inferAgentType` keeps `mission → hermes` first, then prefers the branch prefix via a new exported `agentTypeFromBranch()` before the owner-string fallback; `toBoardCard` sets `card.branch = item.headBranch`.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Docs / tests only (tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — **732 pass** (extended `monitor-v2.test.ts` + `monitor-hermes-board.test.ts`; no ops/Docker touched, so compose validation N/A)

## Rollout / rollback
N/A — no ops/compose/migrations/Hermes-pin/secret surfaces. Pure read-path; revert is the single commit.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — human still owns the gate
- [x] Wallet testnet-only; `HALT_FILE` honored; **no new agent power** (read-only attribution, nothing to gate)
- [x] No secrets committed/printed/logged
- [x] `AGENTS.md` unchanged — this does not change *how agents work* (no new runner/dispatch/gate/role); display attribution only

## Known limits / follow-ups
- Prefix match is exact (`codex/`, `claude/`); other prefixes correctly stay `ext` (fall back to the owner heuristic).
- Scope is **P1 only** — P2 (Claude Code worker), P3 (board-driven dispatch), P4 (autonomy mode), P5 are separate follow-up handoffs per the design doc.

## Acceptance
`codex/*` and `claude/*` PRs attribute correctly; non-prefixed PRs stay `ext`; tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)