### PR TITLE
task-queue: generalize for multi-agent + greenfield (P2 foundation)

### DIFF
--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -18,9 +18,29 @@ export type CodexRunnerHeartbeatStatus =
   | "misconfigured"
   | "error";
 
+/**
+ * Which agent a task is dispatched to. Defaults to "codex" everywhere so
+ * existing tasks and callers keep working unchanged; "claude" is the
+ * greenfield Claude-worker path (P2). Resolve a possibly-absent value via
+ * {@link taskAgent}.
+ */
+export type TaskAgent = "codex" | "claude";
+
+/** Resolve a task's agent, defaulting legacy/undefined tasks to "codex". */
+export function taskAgent(task: { agent?: TaskAgent }): TaskAgent {
+  return task.agent === "claude" ? "claude" : "codex";
+}
+
 export interface CodexTaskInput {
   repo: string;
-  pullRequestNumber: number;
+  /**
+   * The PR this task acts on. Optional: greenfield tasks (Claude opens
+   * its own PR) have no PR number yet. When present, propose dedupes on
+   * repo + PR; when absent each task is distinct.
+   */
+  pullRequestNumber?: number;
+  /** Which agent runs this task. Defaults to "codex". */
+  agent?: TaskAgent;
   correlationId?: string;
   title?: string;
   prompt: string;
@@ -89,11 +109,15 @@ export async function proposeCodexTask(
   const path = queuePath(deps.path);
   const tasks = await readCodexTasks(path);
   const now = (deps.now ?? new Date()).toISOString();
-  const existing = tasks.find((task) =>
-    !TERMINAL_STATUSES.has(task.status)
-    && task.repo === input.repo
-    && task.pullRequestNumber === input.pullRequestNumber
-  );
+  // Dedupe only when the task targets a specific PR. Greenfield tasks
+  // (no PR yet) are each distinct, so they always create a new entry.
+  const existing = input.pullRequestNumber === undefined
+    ? undefined
+    : tasks.find((task) =>
+        !TERMINAL_STATUSES.has(task.status)
+        && task.repo === input.repo
+        && task.pullRequestNumber === input.pullRequestNumber
+      );
   if (existing) {
     const updated: CodexTask = {
       ...existing,
@@ -114,7 +138,8 @@ export async function proposeCodexTask(
     id: makeCodexTaskId(input.repo, input.pullRequestNumber, now),
     status: "proposed",
     repo: input.repo,
-    pullRequestNumber: input.pullRequestNumber,
+    agent: input.agent ?? "codex",
+    ...(input.pullRequestNumber !== undefined ? { pullRequestNumber: input.pullRequestNumber } : {}),
     ...(input.correlationId ? { correlationId: input.correlationId } : {}),
     ...(input.title ? { title: input.title } : {}),
     prompt: input.prompt,
@@ -196,12 +221,14 @@ export async function cancelCodexTask(
 }
 
 export async function claimNextApprovedCodexTask(
-  deps: CodexTaskQueueDeps & { runnerId?: string } = {}
+  deps: CodexTaskQueueDeps & { runnerId?: string; agent?: TaskAgent } = {}
 ): Promise<CodexTask | undefined> {
   const path = queuePath(deps.path);
   const tasks = await readCodexTasks(path);
+  // A per-agent runner claims only its own tasks; an unfiltered call (no
+  // `agent`) claims any approved task, preserving the current behavior.
   const existing = tasks
-    .filter((task) => task.status === "approved")
+    .filter((task) => task.status === "approved" && (deps.agent === undefined || taskAgent(task) === deps.agent))
     .sort((a, b) => Date.parse(a.approvedAt ?? a.updatedAt) - Date.parse(b.approvedAt ?? b.updatedAt))[0];
   if (!existing) return undefined;
   const now = (deps.now ?? new Date()).toISOString();
@@ -422,7 +449,8 @@ function isCodexTask(value: unknown): value is CodexTask {
     && value.schemaVersion === 1
     && typeof value.id === "string"
     && typeof value.repo === "string"
-    && typeof value.pullRequestNumber === "number"
+    // Optional: greenfield tasks have no PR yet. Reject only a wrong type.
+    && (value.pullRequestNumber === undefined || typeof value.pullRequestNumber === "number")
     && typeof value.prompt === "string"
     && typeof value.status === "string"
     && typeof value.createdAt === "string"
@@ -467,10 +495,11 @@ function codexRunnerStatusMessage(status: CodexRunnerHeartbeatStatus): string {
   }
 }
 
-function makeCodexTaskId(repo: string, pullRequestNumber: number, timestamp: string): string {
+function makeCodexTaskId(repo: string, pullRequestNumber: number | undefined, timestamp: string): string {
   const safeRepo = repo.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
   const stamp = timestamp.replace(/[^0-9A-Za-z]/g, "");
-  return `codex-task-${safeRepo}-${pullRequestNumber}-${stamp}-${Math.random().toString(36).slice(2, 8)}`;
+  const prPart = pullRequestNumber ?? "new"; // greenfield tasks have no PR yet
+  return `codex-task-${safeRepo}-${prPart}-${stamp}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 function isCodexRunnerHeartbeat(value: unknown): value is CodexRunnerHeartbeat {

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -13,6 +13,7 @@ import {
   proposeCodexTask,
   readCodexRunnerHeartbeat,
   summarizeCodexTasks,
+  taskAgent,
   updateCodexTaskProgress,
   updateCodexRunnerHeartbeat,
 } from "../../services/slack-operator/src/codex-task-queue.js";
@@ -270,5 +271,104 @@ describe("codex task queue", () => {
         stale: false,
       },
     });
+  });
+});
+
+describe("codex task queue — multi-agent (P2)", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  async function tempQueuePath(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "averray-codex-tasks-"));
+    tempDirs.push(dir);
+    return join(dir, "tasks.json");
+  }
+
+  it("defaults agent to codex and stores an explicit claude agent", async () => {
+    const path = await tempQueuePath();
+    const codex = await proposeCodexTask(
+      { repo: "averray-agent/agent", pullRequestNumber: 401, prompt: "x" },
+      { path, now: new Date("2026-05-17T10:00:00.000Z") },
+    );
+    const claude = await proposeCodexTask(
+      { repo: "averray-agent/agent", pullRequestNumber: 402, agent: "claude", prompt: "y" },
+      { path, now: new Date("2026-05-17T10:01:00.000Z") },
+    );
+    expect(codex.task.agent).toBe("codex");
+    expect(claude.task.agent).toBe("claude");
+    expect(taskAgent(codex.task)).toBe("codex");
+    expect(taskAgent(claude.task)).toBe("claude");
+    // taskAgent defaults a legacy task with no agent field to codex.
+    expect(taskAgent({})).toBe("codex");
+  });
+
+  it("creates greenfield tasks (no PR) and does not dedupe them", async () => {
+    const path = await tempQueuePath();
+    const first = await proposeCodexTask(
+      { repo: "averray-agent/agent", agent: "claude", prompt: "build a thing" },
+      { path, now: new Date("2026-05-17T10:00:00.000Z") },
+    );
+    const second = await proposeCodexTask(
+      { repo: "averray-agent/agent", agent: "claude", prompt: "build another thing" },
+      { path, now: new Date("2026-05-17T10:01:00.000Z") },
+    );
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(true); // greenfield: distinct, not deduped
+    expect(first.task.id).not.toBe(second.task.id);
+    expect(first.task.pullRequestNumber).toBeUndefined();
+    const all = await listCodexTasks({ path });
+    expect(all).toHaveLength(2);
+  });
+
+  it("claims only tasks matching the runner's agent filter", async () => {
+    const path = await tempQueuePath();
+    const codex = await proposeCodexTask(
+      { repo: "r", pullRequestNumber: 1, prompt: "c" },
+      { path, now: new Date("2026-05-17T10:00:00.000Z") },
+    );
+    const claude = await proposeCodexTask(
+      { repo: "r", agent: "claude", prompt: "k" },
+      { path, now: new Date("2026-05-17T10:01:00.000Z") },
+    );
+    await approveCodexTask(codex.task.id, { path, approvedBy: "operator", now: new Date("2026-05-17T10:02:00.000Z") });
+    await approveCodexTask(claude.task.id, { path, approvedBy: "operator", now: new Date("2026-05-17T10:03:00.000Z") });
+
+    // The claude runner skips the (older, approved-first) codex task.
+    const claimedByClaude = await claimNextApprovedCodexTask({
+      path,
+      agent: "claude",
+      runnerId: "claude-task-runner",
+      now: new Date("2026-05-17T10:04:00.000Z"),
+    });
+    expect(claimedByClaude?.id).toBe(claude.task.id);
+    expect(taskAgent(claimedByClaude!)).toBe("claude");
+
+    // The codex runner claims the remaining codex task.
+    const claimedByCodex = await claimNextApprovedCodexTask({
+      path,
+      agent: "codex",
+      runnerId: "codex-task-runner",
+      now: new Date("2026-05-17T10:05:00.000Z"),
+    });
+    expect(claimedByCodex?.id).toBe(codex.task.id);
+
+    // No more tasks for either agent.
+    expect(await claimNextApprovedCodexTask({ path, agent: "claude" })).toBeUndefined();
+    expect(await claimNextApprovedCodexTask({ path, agent: "codex" })).toBeUndefined();
+  });
+
+  it("an unfiltered claim still takes any approved task (back-compat)", async () => {
+    const path = await tempQueuePath();
+    const claude = await proposeCodexTask(
+      { repo: "r", agent: "claude", prompt: "k" },
+      { path, now: new Date("2026-05-17T10:00:00.000Z") },
+    );
+    await approveCodexTask(claude.task.id, { path, approvedBy: "operator", now: new Date("2026-05-17T10:01:00.000Z") });
+    const claimed = await claimNextApprovedCodexTask({ path, now: new Date("2026-05-17T10:02:00.000Z") });
+    expect(claimed?.id).toBe(claude.task.id);
   });
 });


### PR DESCRIPTION
## What changed & why

First, foundational slice of Hermes orchestration **P2** (Claude Code worker). This is the **queue generalization** bullet from the design doc — **pure data-model, backward-compatible, no new agent power**. It unblocks the greenfield Claude worker without yet adding the worker, runner, or SDK (those follow as separate, security-reviewed PRs).

- Add `agent: "codex" | "claude"` (defaults to `"codex"`) + a `taskAgent()` helper that resolves legacy/absent values to `"codex"`.
- Make `pullRequestNumber` **optional** so a task can be greenfield (Claude opens its own PR — no PR number yet). `proposeCodexTask` dedupes on repo+PR only when a PR is present; greenfield tasks are each distinct. The read-side validator (`isCodexTask`) now tolerates an absent PR number.
- Add an optional `agent` filter to `claimNextApprovedCodexTask` so a per-agent runner claims only its own tasks; an **unfiltered call still claims any approved task** (current behavior preserved).

**No behavior change for existing Codex tasks**: agent defaults to codex; PR-bearing tasks dedupe + claim exactly as before. Typecheck confirmed the optional-PR change rippled into **zero** type errors (consumers already access the field tolerantly), and it stays entirely within `slack-operator` (the `CodexTask` type isn't used in the MCP packages).

## Affected surfaces
- [x] Worker runners / task queue

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — **728 pass** (+4 multi-agent queue tests; existing 7 queue tests unchanged & green). No ops/Docker touched.

## Rollout / rollback
N/A — additive, backward-compatible schema. Existing on-disk tasks (no `agent` field) read back as `codex` via `taskAgent()`. Revert = the single commit.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy
- [x] **No new agent power** — this is queue data-model only; nothing here lets an agent *act*. The Claude worker (which creates branches + pushes) is the next PR and ships **with** its allowlist/approval guardrail + the AGENTS.md update.
- [x] No secrets committed/printed/logged
- [x] `AGENTS.md` unchanged — no new runner/dispatch/role yet

## Known limits / follow-ups (rest of P2)
- **P2b** — `claude-branch-worker.ts`: greenfield branch create → commit → open PR, reusing the protected-branch guard + secret sanitization (SDK call dependency-injected/stubbed for testability).
- **P2c** — Agent SDK invocation (restricted permission mode + allowed-tools, `ANTHROPIC_API_KEY` managed secret), the `claude-task-runner` process + `ops/` compose service, **+ the new-power guardrail and AGENTS.md update**. New dependency (Claude Agent SDK) will carry supply-chain notes.

## Acceptance (this slice)
Queue stores `agent`, defaults to codex; greenfield (no-PR) tasks create + don't dedupe; per-agent claim filter works; existing Codex flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)