### PR TITLE
worker-auth: Claude worker model-provider auth + billing-route guard (O2)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -45,6 +45,22 @@ TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/testbed-mission-http-ru
 TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS=10000
 TESTBED_MISSION_RUNNER_TIMEOUT_MS=1200000
 
+# Claude worker (O2) model-provider auth & billing. See
+# docs/HERMES_WORKER_AUTH_BILLING.md. The worker verifies the active route
+# matches this intent at startup and FAILS LOUD on mismatch — it never
+# silently API-bills.
+#   sub: run on the Max subscription via CLAUDE_CODE_OAUTH_TOKEN
+#        (claude setup-token). For sub billing there must be NO
+#        ANTHROPIC_API_KEY in this worker's env (it would silently win).
+#   api: metered API billing via ANTHROPIC_API_KEY (the scale path); set
+#        CLAUDE_WORKER_DAILY_BUDGET as the in-process cap + a Console cap.
+CLAUDE_WORKER_AUTH_MODE=sub
+CLAUDE_CODE_OAUTH_TOKEN=
+ANTHROPIC_API_KEY=
+# USD/day in-process cap; only enforced in api mode. Leave unset to rely on
+# the Anthropic Console cap alone.
+CLAUDE_WORKER_DAILY_BUDGET=
+
 # Optional read-only GitHub operator helper.
 GITHUB_TOKEN=
 # Optional token maps for repositories that live under different GitHub owners.

--- a/services/slack-operator/src/claude-worker-auth.ts
+++ b/services/slack-operator/src/claude-worker-auth.ts
@@ -1,0 +1,270 @@
+// Claude worker — model-provider auth & billing wiring (O2).
+//
+// Resolves how the Claude worker authenticates to Anthropic and guards the
+// billing route so the worker can never *silently* bill the API when the
+// operator intended to run on the subscription. See
+// docs/HERMES_WORKER_AUTH_BILLING.md for the policy ("sub now → API key at
+// scale"), the June 15 2026 unbundling, and the two footguns this defuses:
+//
+//   1. Key precedence — ANTHROPIC_API_KEY > CLAUDE_CODE_OAUTH_TOKEN >
+//      interactive login. An API key in the worker env silently wins and
+//      bypasses the subscription → API billing.
+//   2. Silent-billing — headless `claude -p` has billed the API for some
+//      users even with no key set. A live route probe (claude /status
+//      equivalent) catches this; pass it in via `probedRoute`.
+//
+// SECRETS: this module reads token/key env vars but NEVER logs or returns
+// their values — only whether each is present and which route is active.
+// The operator provisions CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY; the
+// worker only reads them. The worker's *command* output is sanitized by the
+// runner's existing sanitizeTail (codex-task-runner.ts); this module emits
+// no secret-bearing output of its own.
+//
+// Invocation-agnostic: whether the worker calls Claude via `claude -p` or
+// the Agent SDK, auth resolves through this same logic, and
+// buildClaudeInvocationEnv() guarantees no API key leaks into the child env
+// when the intent is "sub".
+
+/** What the operator INTENDS — the source of truth for the billing route. */
+export type ClaudeWorkerAuthMode = "sub" | "api";
+
+/** The route auth would actually take. "none" = no usable credential. */
+export type ActiveAuthRoute = "api" | "sub" | "none";
+
+/** Just the env vars this module reads (keeps callers + tests honest). */
+export interface ClaudeWorkerAuthEnv {
+  CLAUDE_WORKER_AUTH_MODE?: string;
+  ANTHROPIC_API_KEY?: string;
+  CLAUDE_CODE_OAUTH_TOKEN?: string;
+  CLAUDE_WORKER_DAILY_BUDGET?: string;
+}
+
+export class ClaudeWorkerAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClaudeWorkerAuthError";
+  }
+}
+
+function present(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Resolve the intended auth mode. Defaults to "sub" (per policy) when
+ * unset/empty. An explicit unrecognized value is a configuration error, not
+ * a silent fallback — fail loud so the operator's intent is never guessed.
+ */
+export function resolveAuthMode(
+  env: ClaudeWorkerAuthEnv
+): { mode: ClaudeWorkerAuthMode } | { error: string } {
+  const raw = (env.CLAUDE_WORKER_AUTH_MODE ?? "").trim().toLowerCase();
+  if (raw === "" || raw === "sub") return { mode: "sub" };
+  if (raw === "api") return { mode: "api" };
+  return { error: `CLAUDE_WORKER_AUTH_MODE must be "sub" or "api" (got "${env.CLAUDE_WORKER_AUTH_MODE}")` };
+}
+
+/**
+ * The route auth takes purely from the env, by Anthropic's key precedence:
+ * API key > OAuth token > interactive/none. This is the *static* read; the
+ * live probe (claude /status) can override it to catch the silent-billing
+ * footgun — see verifyAuthRoute's `probedRoute`.
+ */
+export function activeAuthRoute(env: ClaudeWorkerAuthEnv): ActiveAuthRoute {
+  if (present(env.ANTHROPIC_API_KEY)) return "api";
+  if (present(env.CLAUDE_CODE_OAUTH_TOKEN)) return "sub";
+  return "none";
+}
+
+export type RouteVerification =
+  | { ok: true; mode: ClaudeWorkerAuthMode; activeRoute: ActiveAuthRoute; message: string }
+  | { ok: false; mode?: ClaudeWorkerAuthMode; reason: string };
+
+/**
+ * Route-verification health check (the core safeguard). Asserts the ACTIVE
+ * route matches the INTENDED mode; on mismatch returns ok:false with a clear
+ * reason. Pure + synchronous so it's trivially testable.
+ *
+ * @param opts.probedRoute optional live route from `claude /status` (or the
+ *   SDK). When provided it is authoritative for the active route — this is
+ *   what catches the silent-billing footgun where headless billing diverges
+ *   from what the env implies.
+ */
+export function verifyAuthRoute(
+  env: ClaudeWorkerAuthEnv,
+  opts: { probedRoute?: ActiveAuthRoute } = {}
+): RouteVerification {
+  const resolved = resolveAuthMode(env);
+  if ("error" in resolved) return { ok: false, reason: resolved.error };
+  const mode = resolved.mode;
+  const route = opts.probedRoute ?? activeAuthRoute(env);
+
+  if (mode === "sub") {
+    // Footgun 1 (static): an API key in the env would silently win and bill
+    // the API. Refuse regardless of what the probe says — its mere presence
+    // is the hazard.
+    if (present(env.ANTHROPIC_API_KEY)) {
+      return {
+        ok: false,
+        mode,
+        reason:
+          "CLAUDE_WORKER_AUTH_MODE=sub but ANTHROPIC_API_KEY is set in the worker env — " +
+          "it takes precedence and would silently bypass the subscription and bill the API. " +
+          "Unset ANTHROPIC_API_KEY for this worker.",
+      };
+    }
+    // Footgun 2 (live): the probe reports the worker is actually billing the
+    // API despite no key in env (the silent-billing bug).
+    if (route === "api") {
+      return {
+        ok: false,
+        mode,
+        reason:
+          "CLAUDE_WORKER_AUTH_MODE=sub but the live route probe reports the active billing route is API — " +
+          "refusing to run rather than silently API-bill. Verify `claude /status` shows the subscription.",
+      };
+    }
+    // Must actually hold a subscription credential, or it would fall through
+    // to interactive/headless (where the silent-billing bug lives).
+    if (!present(env.CLAUDE_CODE_OAUTH_TOKEN) && route !== "sub") {
+      return {
+        ok: false,
+        mode,
+        reason:
+          "CLAUDE_WORKER_AUTH_MODE=sub but no CLAUDE_CODE_OAUTH_TOKEN is set and the route is not confirmed as " +
+          "subscription — cannot confirm the sub route. Provision CLAUDE_CODE_OAUTH_TOKEN (claude setup-token).",
+      };
+    }
+    return {
+      ok: true,
+      mode,
+      activeRoute: "sub",
+      message: "auth route confirmed: subscription (CLAUDE_CODE_OAUTH_TOKEN); no ANTHROPIC_API_KEY present",
+    };
+  }
+
+  // mode === "api"
+  if (!present(env.ANTHROPIC_API_KEY)) {
+    return {
+      ok: false,
+      mode,
+      reason: "CLAUDE_WORKER_AUTH_MODE=api but ANTHROPIC_API_KEY is not set in the worker env.",
+    };
+  }
+  return {
+    ok: true,
+    mode,
+    activeRoute: "api",
+    message: "auth route confirmed: API key (ANTHROPIC_API_KEY) — metered billing; cap enforced via budget + Console",
+  };
+}
+
+export interface AuthGuardDeps {
+  /**
+   * Persist a "misconfigured" runner heartbeat on failure (wire to
+   * updateCodexRunnerHeartbeat). Injected so the guard is testable without
+   * touching the queue file.
+   */
+  writeMisconfiguredHeartbeat?: (input: { runnerId: string; reason: string }) => Promise<void> | void;
+  /** Logger (defaults to console.error). Never receives secret values. */
+  log?: (message: string) => void;
+  /** Live route from a `claude /status` / SDK probe (see verifyAuthRoute). */
+  probedRoute?: ActiveAuthRoute;
+}
+
+/**
+ * Startup guard the worker/runner calls before claiming any work. On a route
+ * mismatch it FAILS LOUD: logs the reason, writes a "misconfigured"
+ * heartbeat, and throws ClaudeWorkerAuthError — it never silently falls
+ * through to API billing. On success it logs the confirmed route and returns
+ * the verification.
+ */
+export async function assertAuthRouteOrHalt(
+  env: ClaudeWorkerAuthEnv,
+  runnerId: string,
+  deps: AuthGuardDeps = {}
+): Promise<Extract<RouteVerification, { ok: true }>> {
+  const log = deps.log ?? ((m: string) => console.error(m));
+  const result = verifyAuthRoute(env, { probedRoute: deps.probedRoute });
+  if (!result.ok) {
+    log(`[claude-worker-auth] REFUSING TO RUN (${runnerId}): ${result.reason}`);
+    if (deps.writeMisconfiguredHeartbeat) {
+      await deps.writeMisconfiguredHeartbeat({ runnerId, reason: `auth route check failed: ${result.reason}` });
+    }
+    throw new ClaudeWorkerAuthError(result.reason);
+  }
+  log(`[claude-worker-auth] ${runnerId}: ${result.message}`);
+  return result;
+}
+
+// ── Budget (the in-process half of AGENTS invariant #6) ─────────────────
+
+/** Parse CLAUDE_WORKER_DAILY_BUDGET (USD). Returns undefined when unset/invalid. */
+export function parseDailyBudgetUsd(env: ClaudeWorkerAuthEnv): number | undefined {
+  const raw = (env.CLAUDE_WORKER_DAILY_BUDGET ?? "").trim();
+  if (raw === "") return undefined;
+  const value = Number(raw);
+  return Number.isFinite(value) && value > 0 ? value : undefined;
+}
+
+export interface BudgetGate {
+  mode: ClaudeWorkerAuthMode;
+  capUsd?: number;
+  /** Whether the runner may claim more work right now. */
+  allowClaim: boolean;
+  /** Human-readable note (cap reached, or no cap configured). */
+  reason?: string;
+}
+
+/**
+ * Gate the runner's claim loop on spend. In "api" mode, stop claiming new
+ * work once today's spend reaches CLAUDE_WORKER_DAILY_BUDGET. In "sub" mode
+ * there is no per-token charge (the plan throttles, it doesn't surprise-
+ * bill), so claiming is always allowed. When api mode has no in-process cap
+ * configured, claiming is allowed but flagged — the Anthropic Console cap is
+ * then the only hard backstop.
+ */
+export function budgetGate(
+  mode: ClaudeWorkerAuthMode,
+  spentTodayUsd: number,
+  env: ClaudeWorkerAuthEnv
+): BudgetGate {
+  if (mode === "sub") return { mode, allowClaim: true };
+  const capUsd = parseDailyBudgetUsd(env);
+  if (capUsd === undefined) {
+    return {
+      mode,
+      allowClaim: true,
+      reason: "api mode but no CLAUDE_WORKER_DAILY_BUDGET set — relying on the Anthropic Console cap only",
+    };
+  }
+  const allowClaim = spentTodayUsd < capUsd;
+  return {
+    mode,
+    capUsd,
+    allowClaim,
+    reason: allowClaim
+      ? undefined
+      : `daily budget reached: $${spentTodayUsd.toFixed(2)} ≥ cap $${capUsd.toFixed(2)} — not claiming new work`,
+  };
+}
+
+// ── Child-invocation env (requirement: no API key leaks under intent=sub) ─
+
+/**
+ * Build the environment to pass to the Claude invocation (`claude -p` or the
+ * Agent SDK). In "sub" mode ANTHROPIC_API_KEY is stripped so it can never
+ * silently win in the child process; in "api" mode it is passed through.
+ * Defense-in-depth — verifyAuthRoute already refuses to start a sub worker
+ * that has an API key in its env.
+ */
+export function buildClaudeInvocationEnv<T extends NodeJS.ProcessEnv>(
+  baseEnv: T,
+  mode: ClaudeWorkerAuthMode
+): NodeJS.ProcessEnv {
+  const next: NodeJS.ProcessEnv = { ...baseEnv };
+  if (mode === "sub") {
+    delete next.ANTHROPIC_API_KEY;
+  }
+  return next;
+}

--- a/test/unit/claude-worker-auth.test.ts
+++ b/test/unit/claude-worker-auth.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ClaudeWorkerAuthError,
+  activeAuthRoute,
+  assertAuthRouteOrHalt,
+  budgetGate,
+  buildClaudeInvocationEnv,
+  parseDailyBudgetUsd,
+  resolveAuthMode,
+  verifyAuthRoute,
+  type ClaudeWorkerAuthEnv,
+} from "../../services/slack-operator/src/claude-worker-auth.js";
+
+// A throwaway placeholder so a leaked value would be obvious in an assertion.
+const FAKE_KEY = "sk-ant-FAKE-do-not-log";
+const FAKE_TOKEN = "oauth-FAKE-do-not-log";
+
+describe("resolveAuthMode", () => {
+  it("defaults to sub when unset or empty", () => {
+    expect(resolveAuthMode({})).toEqual({ mode: "sub" });
+    expect(resolveAuthMode({ CLAUDE_WORKER_AUTH_MODE: "" })).toEqual({ mode: "sub" });
+    expect(resolveAuthMode({ CLAUDE_WORKER_AUTH_MODE: "  SUB " })).toEqual({ mode: "sub" });
+  });
+  it("accepts explicit api (case-insensitive)", () => {
+    expect(resolveAuthMode({ CLAUDE_WORKER_AUTH_MODE: "api" })).toEqual({ mode: "api" });
+    expect(resolveAuthMode({ CLAUDE_WORKER_AUTH_MODE: "API" })).toEqual({ mode: "api" });
+  });
+  it("fails loud on an unrecognized mode (never guesses intent)", () => {
+    const r = resolveAuthMode({ CLAUDE_WORKER_AUTH_MODE: "subscription" });
+    expect("error" in r).toBe(true);
+  });
+});
+
+describe("activeAuthRoute (key precedence)", () => {
+  it("API key wins over the OAuth token", () => {
+    expect(activeAuthRoute({ ANTHROPIC_API_KEY: FAKE_KEY, CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN })).toBe("api");
+  });
+  it("OAuth token → sub; nothing → none", () => {
+    expect(activeAuthRoute({ CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN })).toBe("sub");
+    expect(activeAuthRoute({})).toBe("none");
+  });
+});
+
+describe("verifyAuthRoute", () => {
+  it("sub (default) with an OAuth token and no API key → confirmed sub", () => {
+    const r = verifyAuthRoute({ CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN });
+    expect(r).toMatchObject({ ok: true, mode: "sub", activeRoute: "sub" });
+  });
+
+  it("FOOTGUN 1: intent sub + ANTHROPIC_API_KEY present → fails loud", () => {
+    const r = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN, ANTHROPIC_API_KEY: FAKE_KEY });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/ANTHROPIC_API_KEY is set/i);
+  });
+
+  it("FOOTGUN 2: intent sub + live probe says api (silent billing) → fails loud", () => {
+    const r = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN }, { probedRoute: "api" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/live route probe|active billing route is API/i);
+  });
+
+  it("sub with no OAuth token and no confirming probe → cannot confirm sub", () => {
+    const r = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "sub" });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/CLAUDE_CODE_OAUTH_TOKEN/);
+  });
+
+  it("sub with no token but a probe confirming sub → ok", () => {
+    const r = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "sub" }, { probedRoute: "sub" });
+    expect(r).toMatchObject({ ok: true, mode: "sub" });
+  });
+
+  it("api with a key → confirmed api", () => {
+    const r = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "api", ANTHROPIC_API_KEY: FAKE_KEY });
+    expect(r).toMatchObject({ ok: true, mode: "api", activeRoute: "api" });
+  });
+
+  it("api with no key → fails loud", () => {
+    const r = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "api" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("never leaks the secret VALUE into the reason/message", () => {
+    const confirmed = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "api", ANTHROPIC_API_KEY: FAKE_KEY });
+    const mismatch = verifyAuthRoute({ CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN, ANTHROPIC_API_KEY: FAKE_KEY });
+    const text = JSON.stringify(confirmed) + JSON.stringify(mismatch);
+    expect(text).not.toContain(FAKE_KEY);
+    expect(text).not.toContain(FAKE_TOKEN);
+  });
+});
+
+describe("assertAuthRouteOrHalt", () => {
+  it("on mismatch: refuses (throws), writes a misconfigured heartbeat, logs — no secret leak", async () => {
+    const writeMisconfiguredHeartbeat = vi.fn();
+    const logs: string[] = [];
+    const env: ClaudeWorkerAuthEnv = { CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN, ANTHROPIC_API_KEY: FAKE_KEY };
+    await expect(
+      assertAuthRouteOrHalt(env, "claude-task-runner", { writeMisconfiguredHeartbeat, log: (m) => logs.push(m) }),
+    ).rejects.toBeInstanceOf(ClaudeWorkerAuthError);
+    expect(writeMisconfiguredHeartbeat).toHaveBeenCalledTimes(1);
+    expect(writeMisconfiguredHeartbeat.mock.calls[0][0]).toMatchObject({ runnerId: "claude-task-runner" });
+    expect(writeMisconfiguredHeartbeat.mock.calls[0][0].reason).toMatch(/auth route check failed/);
+    expect(logs.join("\n")).toMatch(/REFUSING TO RUN/);
+    expect(logs.join("\n") + JSON.stringify(writeMisconfiguredHeartbeat.mock.calls)).not.toContain(FAKE_KEY);
+  });
+
+  it("on match: logs the confirmed route, returns the verification, no heartbeat write", async () => {
+    const writeMisconfiguredHeartbeat = vi.fn();
+    const logs: string[] = [];
+    const result = await assertAuthRouteOrHalt(
+      { CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN },
+      "claude-task-runner",
+      { writeMisconfiguredHeartbeat, log: (m) => logs.push(m) },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.mode).toBe("sub");
+    expect(writeMisconfiguredHeartbeat).not.toHaveBeenCalled();
+    expect(logs.join("\n")).toMatch(/auth route confirmed: subscription/);
+  });
+});
+
+describe("parseDailyBudgetUsd", () => {
+  it("parses a positive number; rejects unset / non-positive / non-numeric", () => {
+    expect(parseDailyBudgetUsd({ CLAUDE_WORKER_DAILY_BUDGET: "25" })).toBe(25);
+    expect(parseDailyBudgetUsd({ CLAUDE_WORKER_DAILY_BUDGET: "12.5" })).toBe(12.5);
+    expect(parseDailyBudgetUsd({})).toBeUndefined();
+    expect(parseDailyBudgetUsd({ CLAUDE_WORKER_DAILY_BUDGET: "0" })).toBeUndefined();
+    expect(parseDailyBudgetUsd({ CLAUDE_WORKER_DAILY_BUDGET: "-5" })).toBeUndefined();
+    expect(parseDailyBudgetUsd({ CLAUDE_WORKER_DAILY_BUDGET: "lots" })).toBeUndefined();
+  });
+});
+
+describe("budgetGate", () => {
+  it("sub mode always allows claiming (no per-token charge)", () => {
+    expect(budgetGate("sub", 9999, { CLAUDE_WORKER_DAILY_BUDGET: "1" })).toMatchObject({ allowClaim: true });
+  });
+  it("api mode under the cap allows; at/over the cap stops claiming", () => {
+    const env = { CLAUDE_WORKER_DAILY_BUDGET: "20" };
+    expect(budgetGate("api", 19.99, env)).toMatchObject({ allowClaim: true, capUsd: 20 });
+    const stopped = budgetGate("api", 20, env);
+    expect(stopped.allowClaim).toBe(false);
+    expect(stopped.reason).toMatch(/daily budget reached/);
+  });
+  it("api mode with no budget set allows but flags reliance on the Console cap", () => {
+    const gate = budgetGate("api", 100, {});
+    expect(gate.allowClaim).toBe(true);
+    expect(gate.reason).toMatch(/no CLAUDE_WORKER_DAILY_BUDGET set|Console cap/);
+  });
+});
+
+describe("buildClaudeInvocationEnv", () => {
+  it("strips ANTHROPIC_API_KEY in sub mode (no key leaks into the child)", () => {
+    const out = buildClaudeInvocationEnv({ ANTHROPIC_API_KEY: FAKE_KEY, CLAUDE_CODE_OAUTH_TOKEN: FAKE_TOKEN, PATH: "/usr/bin" }, "sub");
+    expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(out.CLAUDE_CODE_OAUTH_TOKEN).toBe(FAKE_TOKEN);
+    expect(out.PATH).toBe("/usr/bin");
+  });
+  it("passes ANTHROPIC_API_KEY through in api mode", () => {
+    const out = buildClaudeInvocationEnv({ ANTHROPIC_API_KEY: FAKE_KEY }, "api");
+    expect(out.ANTHROPIC_API_KEY).toBe(FAKE_KEY);
+  });
+});


### PR DESCRIPTION
## What changed & why

Completes the model-provider **auth & billing** wiring for **O2** (the Claude worker), per `docs/HERMES_WORKER_AUTH_BILLING.md`. It makes the worker authenticate "the new way" and adds the safeguards that stop it from ever **silently API-billing** when the operator intended the subscription.

Self-contained, dependency-injected module (`services/slack-operator/src/claude-worker-auth.ts`) — **no live provider calls**; the O2 runner calls `assertAuthRouteOrHalt()` at startup. (No Claude runner exists on `main` yet, so this lands as the tested building block it wires into.)

- **Two env-driven modes, default `sub`:** `CLAUDE_WORKER_AUTH_MODE = sub | api`. `sub` → `CLAUDE_CODE_OAUTH_TOKEN` (Max subscription); `api` → `ANTHROPIC_API_KEY` (metered). The mode is the source of truth for operator intent.
- **Route-verification health check (the core ask):** determines the *active* route by Anthropic's key precedence (`ANTHROPIC_API_KEY` > `CLAUDE_CODE_OAUTH_TOKEN`), with an optional **live probe** (`claude /status` equivalent, injected) to catch the silent-billing footgun. On mismatch — intent `sub` but `ANTHROPIC_API_KEY` present, or the probe reports API billing — it **FAILS LOUD**: refuses to run, writes a `"misconfigured"` runner heartbeat with the reason, logs clearly. **Never** silently falls through to API.
- **api-mode budget gate:** `CLAUDE_WORKER_DAILY_BUDGET` stops claiming new work past the cap — the in-process **budget half of AGENTS invariant #6** (Console cap is the hard backstop). `sub` mode is throttled, not per-token billed.
- **Secrets:** reads token/key env but never logs/returns their **values** (presence + route only — a test asserts no value leaks). `buildClaudeInvocationEnv` strips `ANTHROPIC_API_KEY` in `sub` mode so no key leaks into the child invocation.
- **Invocation-agnostic:** same resolution whether the worker calls `claude -p` or the Agent SDK.
- `ops/.env.example`: documents the operator-provisioned env contract.

## Affected surfaces
- [x] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin (`.env.example` doc only)
- [x] Secrets / config / env (reads only; operator provisions)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — **757 pass** (+21 new auth tests; fake env / injected probe + heartbeat, **no network**)
- [ ] `docker compose … config` — couldn't run locally (no Compose v2 plugin in this shell). The new vars are **not referenced by any compose service**, so substitution is unaffected; CI's compose-config gate validates it.

## Rollout / rollback
Operator provisions `CLAUDE_CODE_OAUTH_TOKEN` (sub) **or** `ANTHROPIC_API_KEY` (api) + `CLAUDE_WORKER_DAILY_BUDGET`. For sub billing, ensure **no** `ANTHROPIC_API_KEY` in the worker env (the guard refuses to start otherwise). Revert = drop the module + its test + the `.env.example` block; nothing consumes it yet.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy
- [x] **Budget guardrail (#6):** this is the in-process budget half + the route guard; the worker only *acts* once the runner wires it in (that PR carries the rest of the guardrail).
- [x] No secrets committed/printed/logged — module never emits token/key values; `.env.example` keeps them empty
- [x] Polkadot-MCP verify rule — N/A (no Polkadot/chain facts); billing facts verified against Anthropic docs (June 15 2026 split)
- [x] `AGENTS.md` unchanged — module is inert until the O2 runner adopts it; the runner PR updates AGENTS.md when the dispatch power lands

## Known limits / follow-ups
- The live `probedRoute` (the real `claude /status` / SDK auth probe) is injected; the O2 runner supplies it when wired. Without a probe, the static env precedence check still defuses footgun #1; footgun #2 (silent billing) needs the probe.
- Wiring `assertAuthRouteOrHalt` + `budgetGate` into the `claude-task-runner` startup/claim-loop is the follow-on (with the runner itself).

## Operator note
Run the **secret-safe** route check in the worker's env before first run: `claude /status` and a *presence* check (`[ -n "$ANTHROPIC_API_KEY" ] && echo set`) — don't `echo` the key value (invariant #7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)