### PR TITLE
claude-task-runner: per-agent runner with billing-route gate (O2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,16 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   auto-merge or auto-deploy. Update this section when that lands.
 - **Humans own approval.** A PASS verdict is a release *signal*, not a merge order.
   Merge and deploy are human-gated. No auto-merge.
+- **Per-agent task runners** (`codex-task-runner`, `claude-task-runner`) claim
+  work from the shared task queue and execute the matching worker. They are the
+  dispatch path, so they carry invariant #6's guardrail: they claim **only
+  operator-`approved` tasks** (never self-approve), filtered by `agent`
+  (codex/claude). The Claude runner additionally runs a **billing-route
+  verification** at startup (`claude-worker-auth`) — on a mismatch it writes a
+  `misconfigured` heartbeat and **refuses to claim** rather than silently
+  API-bill — and honors the **api-mode daily budget** cap and the **`HALT_FILE`**
+  kill switch before claiming. Both runners are off by default and
+  operator-enabled per ops profile (`codex-runner` / `claude-runner`).
 
 ---
 

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -61,6 +61,17 @@ ANTHROPIC_API_KEY=
 # the Anthropic Console cap alone.
 CLAUDE_WORKER_DAILY_BUDGET=
 
+# Claude task runner (O2 per-agent runner; ops profile "claude-runner").
+# Claims approved agent="claude" tasks and runs the Claude worker. Disabled
+# by default. Set CLAUDE_TASK_RUNNER_COMMAND to the Claude worker entrypoint
+# once it lands (until then an enabled runner reports "misconfigured").
+CLAUDE_TASK_RUNNER_ENABLED=0
+CLAUDE_TASK_RUNNER_ID=vps-claude-task-runner
+CLAUDE_TASK_RUNNER_COMMAND=
+CLAUDE_TASK_RUNNER_ARGS=
+CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS=10000
+CLAUDE_TASK_RUNNER_TIMEOUT_MS=1800000
+
 # Optional read-only GitHub operator helper.
 GITHUB_TOKEN=
 # Optional token maps for repositories that live under different GitHub owners.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -255,6 +255,55 @@ services:
       - avg-data:/data
     networks: [avg-internal]
 
+  # Claude task runner (O2). Mirrors codex-task-runner; claims approved
+  # agent="claude" tasks. The startup route gate (claude-worker-auth) refuses
+  # to claim on a billing-route mismatch. Disabled by default; the operator
+  # enables it, sets CLAUDE_TASK_RUNNER_COMMAND to the Claude worker once it
+  # lands, and provisions the auth secrets in .env.prod. For SUB billing,
+  # leave ANTHROPIC_API_KEY UNSET (an empty value is treated as absent).
+  claude-task-runner:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
+    profiles: ["claude-runner"]
+    restart: unless-stopped
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+      mcp-bundle:
+        condition: service_completed_successfully
+    command: ["node", "services/slack-operator/dist/claude-task-runner.js"]
+    environment:
+      AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
+      CLAUDE_TASK_RUNNER_ENABLED: ${CLAUDE_TASK_RUNNER_ENABLED:-0}
+      CLAUDE_TASK_RUNNER_ID: ${CLAUDE_TASK_RUNNER_ID:-vps-claude-task-runner}
+      # Point at the Claude worker (claude-branch-worker) once it lands; until
+      # then, leaving this empty makes the runner report "misconfigured"
+      # rather than run nothing.
+      CLAUDE_TASK_RUNNER_COMMAND: ${CLAUDE_TASK_RUNNER_COMMAND:-}
+      CLAUDE_TASK_RUNNER_ARGS: ${CLAUDE_TASK_RUNNER_ARGS:-}
+      CLAUDE_TASK_RUNNER_CWD: ${CLAUDE_TASK_RUNNER_CWD:-}
+      CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS: ${CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS:-10000}
+      CLAUDE_TASK_RUNNER_TIMEOUT_MS: ${CLAUDE_TASK_RUNNER_TIMEOUT_MS:-1800000}
+      CLAUDE_TASK_RUNNER_OUTPUT_TAIL_BYTES: ${CLAUDE_TASK_RUNNER_OUTPUT_TAIL_BYTES:-12000}
+      # Auth/billing (claude-worker-auth). Secrets sourced from .env.prod.
+      CLAUDE_WORKER_AUTH_MODE: ${CLAUDE_WORKER_AUTH_MODE:-sub}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CLAUDE_WORKER_DAILY_BUDGET: ${CLAUDE_WORKER_DAILY_BUDGET:-}
+      HALT_FILE: ${HALT_FILE:-/data/HALT}
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      GITHUB_OWNER_TOKENS: ${GITHUB_OWNER_TOKENS:-}
+      GITHUB_REPO_TOKENS: ${GITHUB_REPO_TOKENS:-}
+      GITHUB_DEFAULT_REPO: ${GITHUB_DEFAULT_REPO:-}
+      GITHUB_HELPER_REPOS: ${GITHUB_HELPER_REPOS:-}
+      GITHUB_API_BASE_URL: ${GITHUB_API_BASE_URL:-https://api.github.com}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - avg-data:/data
+    networks: [avg-internal]
+
   hermes:
     image: ${HERMES_IMAGE}
     restart: unless-stopped

--- a/services/slack-operator/src/claude-task-runner.ts
+++ b/services/slack-operator/src/claude-task-runner.ts
@@ -1,0 +1,406 @@
+// Claude task runner (O2) — the per-agent runner that claims approved
+// `agent: "claude"` tasks and executes the Claude worker. Mirrors
+// codex-task-runner.ts (poll → claim → execute → heartbeat) and ADOPTS the
+// auth/billing layer (claude-worker-auth.ts): the route-verification health
+// check gates the loop so Claude work never runs on the wrong billing route.
+//
+// Load-bearing safety, in order, before any task is claimed:
+//   1. Route gate — verifyAuthRoute(); on mismatch/misconfig, write a
+//      "misconfigured" heartbeat and DO NOT CLAIM (never silently API-bill).
+//   2. HALT_FILE — the kill switch; when present, don't claim.
+//   3. Budget — in api mode, stop claiming past CLAUDE_WORKER_DAILY_BUDGET.
+//   4. Claim — only approved tasks where agent === "claude" (codex tasks are
+//      left to the codex runner via the queue's agent filter).
+//
+// The executor is command-agnostic (like the codex runner): it spawns the
+// configured CLAUDE_TASK_RUNNER_COMMAND (the claude-branch-worker, once it
+// lands) with the auth-resolved env — buildClaudeInvocationEnv strips
+// ANTHROPIC_API_KEY in sub mode so no key leaks into the child. Tests inject
+// a fake executor; no real provider calls here.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { hostname } from "node:os";
+import { fileURLToPath } from "node:url";
+
+import {
+  budgetGate,
+  buildClaudeInvocationEnv,
+  verifyAuthRoute,
+  type ActiveAuthRoute,
+  type ClaudeWorkerAuthEnv,
+  type ClaudeWorkerAuthMode,
+} from "./claude-worker-auth.js";
+import type { CodexTask } from "./codex-task-queue.js";
+import {
+  claimNextApprovedCodexTask,
+  completeCodexTask,
+  failCodexTask,
+  updateCodexTaskProgress,
+  updateCodexRunnerHeartbeat,
+} from "./codex-task-queue.js";
+import { sanitizeOutput, sanitizeTail, tail } from "./codex-task-runner.js";
+
+export interface ClaudeTaskRunnerConfig {
+  enabled: boolean;
+  path?: string;
+  runnerId: string;
+  command?: string;
+  args: string[];
+  cwd?: string;
+  pollIntervalMs: number;
+  timeoutMs: number;
+  outputTailBytes: number;
+  /** CLAUDE_WORKER_* auth/billing vars the route gate + budget read. */
+  authEnv: ClaudeWorkerAuthEnv;
+  /** Kill-switch file; when present the runner refuses to claim. */
+  haltFile?: string;
+}
+
+export interface ClaudeTaskRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  summary?: string;
+}
+
+export type ClaudeTaskExecutor = (
+  task: CodexTask,
+  config: ClaudeTaskRunnerConfig,
+  ctx: { mode: ClaudeWorkerAuthMode }
+) => Promise<ClaudeTaskRunResult>;
+
+export type ClaudeTaskRunnerOnceResult =
+  | { status: "disabled" }
+  | { status: "misconfigured"; reason: string }
+  | { status: "halted" }
+  | { status: "budget_exhausted"; reason: string }
+  | { status: "idle" }
+  | { status: "completed"; task: CodexTask }
+  | { status: "failed"; task: CodexTask; reason: string };
+
+export interface ClaudeTaskRunnerDeps {
+  /** Injected for tests; defaults to spawning config.command. */
+  executor?: ClaudeTaskExecutor;
+  /** Live route probe (`claude /status` equiv) for the silent-billing footgun. */
+  probeRoute?: () => Promise<ActiveAuthRoute> | ActiveAuthRoute;
+  /** Today's API spend (USD) for the budget gate; defaults to 0 until a real spend tracker is wired. */
+  spentTodayUsd?: number;
+  /** Override the HALT_FILE existence check (tests). */
+  isHalted?: (haltFile: string) => boolean;
+  now?: Date;
+  log?: (message: string) => void;
+}
+
+export function parseClaudeTaskRunnerConfig(env: NodeJS.ProcessEnv = process.env): ClaudeTaskRunnerConfig {
+  const runnerId = env.CLAUDE_TASK_RUNNER_ID || `claude-${hostname()}-${process.pid}`;
+  return {
+    enabled: env.CLAUDE_TASK_RUNNER_ENABLED === "1" || env.CLAUDE_TASK_RUNNER_ENABLED === "true",
+    ...(env.AVERRAY_CODEX_TASKS_PATH ? { path: env.AVERRAY_CODEX_TASKS_PATH } : {}),
+    runnerId,
+    ...(env.CLAUDE_TASK_RUNNER_COMMAND ? { command: env.CLAUDE_TASK_RUNNER_COMMAND } : {}),
+    args: parseArgs(env.CLAUDE_TASK_RUNNER_ARGS),
+    ...(env.CLAUDE_TASK_RUNNER_CWD ? { cwd: env.CLAUDE_TASK_RUNNER_CWD } : {}),
+    pollIntervalMs: positiveInt(env.CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS, 10_000),
+    timeoutMs: positiveInt(env.CLAUDE_TASK_RUNNER_TIMEOUT_MS, 30 * 60_000),
+    outputTailBytes: positiveInt(env.CLAUDE_TASK_RUNNER_OUTPUT_TAIL_BYTES, 12_000),
+    authEnv: {
+      ...(env.CLAUDE_WORKER_AUTH_MODE !== undefined ? { CLAUDE_WORKER_AUTH_MODE: env.CLAUDE_WORKER_AUTH_MODE } : {}),
+      ...(env.ANTHROPIC_API_KEY !== undefined ? { ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY } : {}),
+      ...(env.CLAUDE_CODE_OAUTH_TOKEN !== undefined ? { CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN } : {}),
+      ...(env.CLAUDE_WORKER_DAILY_BUDGET !== undefined ? { CLAUDE_WORKER_DAILY_BUDGET: env.CLAUDE_WORKER_DAILY_BUDGET } : {}),
+    },
+    ...(env.HALT_FILE ? { haltFile: env.HALT_FILE } : {}),
+  };
+}
+
+export async function runClaudeTaskRunnerOnce(
+  config: ClaudeTaskRunnerConfig,
+  deps: ClaudeTaskRunnerDeps = {}
+): Promise<ClaudeTaskRunnerOnceResult> {
+  const log = deps.log ?? ((m: string) => console.info(m));
+
+  if (!config.enabled) {
+    await heartbeat(config, "disabled", "Claude task runner is disabled.", deps.now);
+    return { status: "disabled" };
+  }
+
+  // 1. ROUTE GATE — never claim/execute on the wrong billing route.
+  const probedRoute = deps.probeRoute ? await deps.probeRoute() : undefined;
+  const verification = verifyAuthRoute(config.authEnv, probedRoute ? { probedRoute } : {});
+  if (!verification.ok) {
+    const reason = `auth route check failed: ${verification.reason}`;
+    log(`[claude-task-runner] REFUSING TO CLAIM (${config.runnerId}): ${verification.reason}`);
+    await heartbeat(config, "misconfigured", reason, deps.now);
+    return { status: "misconfigured", reason: verification.reason };
+  }
+  const mode = verification.mode;
+  log(`[claude-task-runner] ${config.runnerId}: ${verification.message}`);
+
+  // Executor must be configured (mirror codex: command required when live).
+  const executor = deps.executor ?? executeClaudeTaskCommand;
+  if (!config.command && executor === executeClaudeTaskCommand) {
+    const reason = "CLAUDE_TASK_RUNNER_COMMAND is required when the Claude task runner is enabled.";
+    await heartbeat(config, "misconfigured", reason, deps.now);
+    return { status: "misconfigured", reason };
+  }
+
+  // 2. HALT_FILE — the kill switch.
+  if (config.haltFile) {
+    const halted = deps.isHalted ? deps.isHalted(config.haltFile) : existsSync(config.haltFile);
+    if (halted) {
+      await heartbeat(config, "idle", "HALT_FILE present — not claiming Claude tasks.", deps.now);
+      return { status: "halted" };
+    }
+  }
+
+  // 3. BUDGET — in api mode, stop claiming past the daily cap.
+  const gate = budgetGate(mode, deps.spentTodayUsd ?? 0, config.authEnv);
+  if (!gate.allowClaim) {
+    await heartbeat(config, "idle", gate.reason ?? "Daily budget reached — not claiming.", deps.now);
+    return { status: "budget_exhausted", reason: gate.reason ?? "daily budget reached" };
+  }
+
+  // 4. CLAIM — only approved agent="claude" tasks.
+  const claimed = await claimNextApprovedCodexTask({
+    path: config.path,
+    runnerId: config.runnerId,
+    agent: "claude",
+    now: deps.now,
+  });
+  if (!claimed) {
+    await heartbeat(config, "idle", "Claude runner is online; no approved Claude task is waiting.", deps.now);
+    return { status: "idle" };
+  }
+
+  await heartbeat(config, "running", `Claude runner claimed ${taskLabel(claimed)}.`, deps.now, claimed.id);
+
+  try {
+    const result = await executor(claimed, config, { mode });
+    if (result.exitCode === 0) {
+      const summary = sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout));
+      const task = await completeCodexTask(claimed.id, {
+        path: config.path,
+        completionSummary: summary,
+        exitCode: result.exitCode,
+        stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
+        stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+      });
+      await heartbeat(config, "completed", summary || `Claude runner completed ${taskLabel(claimed)}.`, undefined, claimed.id);
+      return { status: "completed", task: task ?? claimed };
+    }
+    const reason = summarizeFailure(result);
+    const task = await failCodexTask(claimed.id, {
+      path: config.path,
+      failureReason: reason,
+      exitCode: result.exitCode,
+      stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
+      stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+    });
+    await heartbeat(config, "failed", reason, undefined, claimed.id);
+    return { status: "failed", task: task ?? claimed, reason };
+  } catch (error) {
+    const reason = sanitizeOutput(error instanceof Error ? error.message : String(error));
+    const task = await failCodexTask(claimed.id, { path: config.path, failureReason: reason });
+    await heartbeat(config, "error", reason, undefined, claimed.id);
+    return { status: "failed", task: task ?? claimed, reason };
+  }
+}
+
+export async function runClaudeTaskRunnerForever(
+  config: ClaudeTaskRunnerConfig,
+  deps: ClaudeTaskRunnerDeps & { signal?: AbortSignal } = {}
+): Promise<void> {
+  while (!deps.signal?.aborted) {
+    const result = await runClaudeTaskRunnerOnce(config, deps);
+    if (result.status === "misconfigured") {
+      console.warn(`[claude-task-runner] ${result.reason}`);
+    } else if (result.status === "completed") {
+      console.info(`[claude-task-runner] completed ${result.task.id}`);
+    } else if (result.status === "failed") {
+      console.warn(`[claude-task-runner] failed ${result.task.id}: ${result.reason}`);
+    }
+    await sleep(config.pollIntervalMs, deps.signal);
+  }
+}
+
+export async function executeClaudeTaskCommand(
+  task: CodexTask,
+  config: ClaudeTaskRunnerConfig,
+  ctx: { mode: ClaudeWorkerAuthMode }
+): Promise<ClaudeTaskRunResult> {
+  if (!config.command) {
+    throw new Error("CLAUDE_TASK_RUNNER_COMMAND is not configured.");
+  }
+  // Auth-resolved env: strip ANTHROPIC_API_KEY in sub mode so it cannot
+  // silently win in the child invocation.
+  const childEnv = buildClaudeInvocationEnv(taskEnvironment(task), ctx.mode);
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(config.command as string, renderArgs(config.args, task), {
+      cwd: config.cwd,
+      env: childEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let finished = false;
+    let lastProgressWrite = 0;
+    let progressWrites: Promise<unknown> = Promise.resolve();
+    const publishProgress = (message: string) => {
+      const now = Date.now();
+      if (now - lastProgressWrite < 2_000) return;
+      lastProgressWrite = now;
+      progressWrites = progressWrites
+        .then(() => updateCodexTaskProgress(task.id, {
+          path: config.path,
+          progressMessage: message,
+          stdoutTail: sanitizeTail(stdout, config.outputTailBytes),
+          stderrTail: sanitizeTail(stderr, config.outputTailBytes),
+        }))
+        .catch(() => undefined);
+    };
+    const timeout = setTimeout(() => {
+      if (finished) return;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!finished) child.kill("SIGKILL");
+      }, 5_000).unref();
+      reject(new Error(`Claude task command timed out after ${config.timeoutMs}ms.`));
+    }, config.timeoutMs);
+    timeout.unref();
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout = tail(stdout + chunk.toString("utf8"), config.outputTailBytes);
+      publishProgress(lastMeaningfulLine(stdout) || "Claude runner emitted output.");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr = tail(stderr + chunk.toString("utf8"), config.outputTailBytes);
+      publishProgress(lastMeaningfulLine(stderr) || "Claude runner emitted stderr.");
+    });
+    child.on("error", (error) => {
+      finished = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      finished = true;
+      clearTimeout(timeout);
+      progressWrites.finally(() => {
+        resolve({
+          exitCode: code ?? 1,
+          stdout,
+          stderr,
+          summary: summarizeCommandResult(stdout) || summarizeCommandResult(stderr),
+        });
+      });
+    });
+  });
+}
+
+function taskEnvironment(task: CodexTask): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    CLAUDE_TASK_ID: task.id,
+    CLAUDE_TASK_REPO: task.repo,
+    CLAUDE_TASK_PR: task.pullRequestNumber != null ? String(task.pullRequestNumber) : "",
+    CLAUDE_TASK_TITLE: task.title ?? "",
+    CLAUDE_TASK_CORRELATION_ID: task.correlationId ?? "",
+    CLAUDE_TASK_REASON: task.reason ?? "",
+    CLAUDE_TASK_REQUESTER: task.requester ?? "",
+    CLAUDE_TASK_PROMPT: task.prompt,
+  };
+}
+
+function taskLabel(task: CodexTask): string {
+  return task.pullRequestNumber != null ? `${task.repo}#${task.pullRequestNumber}` : `${task.repo} (greenfield)`;
+}
+
+async function heartbeat(
+  config: ClaudeTaskRunnerConfig,
+  status: Parameters<typeof updateCodexRunnerHeartbeat>[0]["status"],
+  message: string,
+  now?: Date,
+  activeTaskId?: string
+): Promise<void> {
+  await updateCodexRunnerHeartbeat({
+    path: config.path,
+    runnerId: config.runnerId,
+    status,
+    message,
+    ...(activeTaskId ? { activeTaskId } : {}),
+    ...(now ? { now } : {}),
+  }).catch(() => undefined);
+}
+
+function summarizeFailure(result: ClaudeTaskRunResult): string {
+  const stderr = sanitizeOutput(summarizeCommandResult(result.stderr));
+  const stdout = sanitizeOutput(summarizeCommandResult(result.stdout));
+  return stderr || stdout || `Claude task command exited with ${result.exitCode}.`;
+}
+
+function summarizeCommandResult(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-3).join("\n").trim();
+}
+
+function lastMeaningfulLine(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-1)[0]?.trim() ?? "";
+}
+
+function parseArgs(value: string | undefined): string[] {
+  const trimmed = value?.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("CLAUDE_TASK_RUNNER_ARGS must be a JSON string array when it starts with '['.");
+    }
+    return parsed;
+  }
+  return trimmed.split(/\s+/);
+}
+
+export function renderArgs(args: string[], task: CodexTask): string[] {
+  const replacements: Record<string, string> = {
+    "{taskId}": task.id,
+    "{repo}": task.repo,
+    "{pr}": task.pullRequestNumber != null ? String(task.pullRequestNumber) : "",
+    "{title}": task.title ?? "",
+    "{correlationId}": task.correlationId ?? "",
+    "{prompt}": task.prompt,
+  };
+  return args.map((arg) => {
+    let value = arg;
+    for (const [token, replacement] of Object.entries(replacements)) {
+      value = value.split(token).join(replacement);
+    }
+    return value;
+  });
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    signal?.addEventListener("abort", () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  const controller = new AbortController();
+  process.once("SIGINT", () => controller.abort());
+  process.once("SIGTERM", () => controller.abort());
+  runClaudeTaskRunnerForever(parseClaudeTaskRunnerConfig(), { signal: controller.signal })
+    .catch((error) => {
+      console.error("[claude-task-runner] fatal", error);
+      process.exitCode = 1;
+    });
+}

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -308,12 +308,14 @@ export function renderCodexTaskRunnerArgs(args: string[], task: CodexTask): stri
   });
 }
 
-function sanitizeTail(value: string, maxBytes: number): string | undefined {
+// Exported so the Claude task runner reuses the exact same secret
+// sanitization (AGENTS.md: never log tokens/keys) instead of duplicating it.
+export function sanitizeTail(value: string, maxBytes: number): string | undefined {
   const output = sanitizeOutput(tail(value, maxBytes));
   return output ? output : undefined;
 }
 
-function sanitizeOutput(value: string): string {
+export function sanitizeOutput(value: string): string {
   return value
     .replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[redacted private key]")
     .replace(/\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g, "[redacted jwt]")
@@ -326,7 +328,7 @@ function positiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
 }
 
-function tail(value: string, maxBytes: number): string {
+export function tail(value: string, maxBytes: number): string {
   if (Buffer.byteLength(value, "utf8") <= maxBytes) return value;
   return Buffer.from(value, "utf8").subarray(-maxBytes).toString("utf8");
 }

--- a/test/unit/claude-task-runner.test.ts
+++ b/test/unit/claude-task-runner.test.ts
@@ -1,0 +1,172 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  approveCodexTask,
+  listCodexTasks,
+  proposeCodexTask,
+  readCodexRunnerHeartbeat,
+} from "../../services/slack-operator/src/codex-task-queue.js";
+import {
+  runClaudeTaskRunnerOnce,
+  type ClaudeTaskRunnerConfig,
+} from "../../services/slack-operator/src/claude-task-runner.js";
+
+const FAKE_KEY = "sk-ant-FAKE-do-not-log";
+
+describe("claude task runner", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  async function tempQueuePath(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "averray-claude-runner-"));
+    tempDirs.push(dir);
+    return join(dir, "tasks.json");
+  }
+
+  // Default config: confirmed sub route (OAuth token, no API key), executor injected.
+  function config(path: string, overrides: Partial<ClaudeTaskRunnerConfig> = {}): ClaudeTaskRunnerConfig {
+    return {
+      enabled: true,
+      path,
+      runnerId: "test-claude-runner",
+      args: [],
+      pollIntervalMs: 10,
+      timeoutMs: 1_000,
+      outputTailBytes: 1_000,
+      authEnv: { CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: "oauth-FAKE" },
+      ...overrides,
+    };
+  }
+
+  async function approvedClaudeTask(path: string, prompt = "Build the thing"): Promise<string> {
+    const { task } = await proposeCodexTask({ repo: "averray-agent/agent", agent: "claude", prompt }, { path });
+    await approveCodexTask(task.id, { path, approvedBy: "operator" });
+    return task.id;
+  }
+
+  async function approvedCodexTask(path: string, pr = 390): Promise<string> {
+    const { task } = await proposeCodexTask({ repo: "averray-agent/agent", pullRequestNumber: pr, prompt: "codex work" }, { path });
+    await approveCodexTask(task.id, { path, approvedBy: "operator" });
+    return task.id;
+  }
+
+  it("ROUTE GATE: mismatch (intent sub + ANTHROPIC_API_KEY) → refuses to claim, writes misconfigured heartbeat", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+    const executor = vi.fn();
+
+    const result = await runClaudeTaskRunnerOnce(
+      config(path, { authEnv: { CLAUDE_WORKER_AUTH_MODE: "sub", CLAUDE_CODE_OAUTH_TOKEN: "oauth-FAKE", ANTHROPIC_API_KEY: FAKE_KEY } }),
+      { executor, log: () => {} },
+    );
+
+    expect(result.status).toBe("misconfigured");
+    expect(executor).not.toHaveBeenCalled();
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({ id, status: "approved" }); // NOT claimed
+    const hb = await readCodexRunnerHeartbeat({ path });
+    expect(hb).toMatchObject({ runnerId: "test-claude-runner", status: "misconfigured" });
+    // never leaks the key value
+    expect(JSON.stringify(hb)).not.toContain(FAKE_KEY);
+  });
+
+  it("claims only agent=claude approved tasks, leaving codex tasks for the codex runner", async () => {
+    const path = await tempQueuePath();
+    const codexId = await approvedCodexTask(path); // approved first (older)
+    const claudeId = await approvedClaudeTask(path);
+    const seen: string[] = [];
+
+    const result = await runClaudeTaskRunnerOnce(config(path), {
+      executor: async (task) => {
+        seen.push(task.id);
+        return { exitCode: 0, stdout: "opened PR", stderr: "", summary: "opened PR" };
+      },
+      log: () => {},
+    });
+
+    expect(result.status).toBe("completed");
+    expect(seen).toEqual([claudeId]); // claimed the claude task, skipped the older codex one
+    const tasks = await listCodexTasks({ path });
+    expect(tasks.find((t) => t.id === claudeId)?.status).toBe("completed");
+    expect(tasks.find((t) => t.id === codexId)?.status).toBe("approved"); // untouched
+  });
+
+  it("happy path: claim → execute → completeCodexTask + completed heartbeat", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+
+    const result = await runClaudeTaskRunnerOnce(config(path), {
+      executor: async () => ({ exitCode: 0, stdout: "branch pushed\nPR opened\n", stderr: "", summary: "PR opened" }),
+      log: () => {},
+    });
+
+    expect(result.status).toBe("completed");
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({ id, status: "completed", completionSummary: "PR opened" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
+      runnerId: "test-claude-runner",
+      status: "completed",
+    });
+  });
+
+  it("failure path: non-zero exit → failCodexTask + failed heartbeat", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+
+    const result = await runClaudeTaskRunnerOnce(config(path), {
+      executor: async () => ({ exitCode: 1, stdout: "", stderr: "worker blew up", summary: undefined }),
+      log: () => {},
+    });
+
+    expect(result.status).toBe("failed");
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({ id, status: "failed" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({ status: "failed" });
+  });
+
+  it("HALT_FILE present → does not claim (kill switch)", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+    const executor = vi.fn();
+
+    const result = await runClaudeTaskRunnerOnce(config(path, { haltFile: "/data/HALT" }), {
+      executor,
+      isHalted: () => true,
+      log: () => {},
+    });
+
+    expect(result.status).toBe("halted");
+    expect(executor).not.toHaveBeenCalled();
+    expect((await listCodexTasks({ path }))[0]).toMatchObject({ id, status: "approved" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({ status: "idle" });
+  });
+
+  it("api mode with the daily budget exhausted → does not claim", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+    const executor = vi.fn();
+
+    const result = await runClaudeTaskRunnerOnce(
+      config(path, { authEnv: { CLAUDE_WORKER_AUTH_MODE: "api", ANTHROPIC_API_KEY: FAKE_KEY, CLAUDE_WORKER_DAILY_BUDGET: "10" } }),
+      { executor, spentTodayUsd: 10, log: () => {} },
+    );
+
+    expect(result.status).toBe("budget_exhausted");
+    expect(executor).not.toHaveBeenCalled();
+    expect((await listCodexTasks({ path }))[0]).toMatchObject({ id, status: "approved" });
+  });
+
+  it("disabled runner does not claim", async () => {
+    const path = await tempQueuePath();
+    await approvedClaudeTask(path);
+    const result = await runClaudeTaskRunnerOnce(config(path, { enabled: false }), { executor: vi.fn(), log: () => {} });
+    expect(result.status).toBe("disabled");
+  });
+});


### PR DESCRIPTION
## What changed & why

The **per-agent `claude-task-runner`** for O2 — claims approved `agent: "claude"` tasks and executes the Claude worker. Mirrors `codex-task-runner` and **adopts the auth/billing layer** (#259) so Claude work can never run on the wrong billing route. This is where Claude usage first goes live, so the **startup route gate is load-bearing**.

Guards run in order **before any task is claimed**:
1. **Route gate** — `verifyAuthRoute()`. On mismatch (intent `sub` + `ANTHROPIC_API_KEY` present, or a live probe reporting API) it writes a `misconfigured` heartbeat and **does not claim** — never silently API-bills. Only a confirmed route enters the poll loop.
2. **HALT_FILE** — kill switch; present ⇒ no claim.
3. **Budget** — api mode stops claiming past `CLAUDE_WORKER_DAILY_BUDGET`.
4. **Claim** — only approved `agent === "claude"` tasks (queue agent filter, #256); codex tasks stay with the codex runner.

Execution is command-agnostic (like the codex runner): spawns `CLAUDE_TASK_RUNNER_COMMAND` with the **auth-resolved env** (`buildClaudeInvocationEnv` strips `ANTHROPIC_API_KEY` in sub mode), streams progress, and **reuses the codex runner's secret-output sanitization** (now exported, not duplicated). Heartbeat states match the codex runner so the board shows runner health.

## Affected surfaces
- [x] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin (`claude-task-runner` service + `.env.example`)
- [x] Secrets / config / env (reads only; operator provisions)
- [x] Docs / tests only (AGENTS.md, tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — **764 pass** (+7 runner tests: route-mismatch refuses + misconfigured heartbeat; claims only `claude` tasks; happy → complete; failure → fail; HALT → no claim; budget exhausted → no claim). Injected executor + fake env, **no provider calls**.
- [ ] `docker compose … config` — couldn't run locally (no Compose v2 plugin); YAML validated as well-formed (service `claude-task-runner`, profile `claude-runner`, 21 env keys). CI's compose-config gate validates substitution.

## Rollout / rollback
New compose service **disabled by default** (`CLAUDE_TASK_RUNNER_ENABLED=0`, profile `claude-runner`). Operator enables it, sets `CLAUDE_TASK_RUNNER_COMMAND` to the Claude worker (once it lands), and provisions auth in `.env.prod`. For **sub** billing, leave `ANTHROPIC_API_KEY` unset (empty ⇒ treated as absent; the gate refuses to start otherwise). Revert = drop the runner + service + test; the codex runner/queue are unaffected (only additive exports).

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy
- [x] **Invariant #6 (new power ⇒ guardrail):** the runner is the dispatch path — it claims **only operator-`approved`** tasks (never self-approves), gated by the **route check + api-mode budget + HALT_FILE**. AGENTS.md updated to document this.
- [x] **HALT_FILE honored** before claiming
- [x] No secrets committed/printed/logged — auth values never logged; `buildClaudeInvocationEnv` strips the key in sub mode; sanitization reused; a test asserts no key leaks into the heartbeat
- [x] `AGENTS.md` updated (new runner + dispatch path + guardrail) per invariant #8

## Known limits / follow-ups
- **Executor:** command-agnostic; the real `claude-branch-worker` (greenfield branch→commit→open-PR via the Agent SDK) + its dependency is the next O2 PR. Until `CLAUDE_TASK_RUNNER_COMMAND` is set, an enabled runner reports `misconfigured`.
- **Live route probe** (`probeRoute`) is injectable; the real `claude /status`/SDK probe is wired with the executor. Without it, the static env check still defuses the key-precedence footgun.
- **Heartbeat file is shared** per queue path (`*.runner.json`, last-writer-wins) with the codex runner; the Claude runner records its own `runnerId`. Per-runner heartbeat files are a small follow-up if the board needs to show both simultaneously.
- **Spend tracking** for the budget gate is injected (`spentTodayUsd`, default 0); real accumulation lands with the executor (Console cap is the hard backstop meanwhile).

## Acceptance
An approved `agent="claude"` task is claimed by the claude-task-runner (not codex); the worker runs on the confirmed billing route; on a route mismatch the runner refuses + reports `misconfigured` instead of silently API-billing. Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)