### PR TITLE
monitor-ui: fix drawer crash on live deploy/mission cards

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -182,4 +182,51 @@ describe("DetailDrawer — variants", () => {
     expect(getByText("Hermes recommends")).toBeTruthy();
     expect(container.querySelectorAll(".hm-mpath .step").length).toBe(6);
   });
+
+  // Regression: live cards cross an HTTP/JSON boundary and don't always carry
+  // the type-required nested objects (the backend doesn't populate deploy
+  // `verification` or a mission `mission` report yet). The drawer must render,
+  // not crash — this is the bug that took the live board down on card click.
+  test("deploy card with NO verification (live shape) renders without crashing", () => {
+    const card = {
+      id: "post-production-deploy-verification-afte-3e4a",
+      lane: "deploying",
+      type: "deploy",
+      agentType: "ext",
+      title: "post-production-deploy verification after workflow run",
+      summary: "post_deploy_healthy",
+      repo: "averray-agent/agent",
+      freshness: 180,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "branch-protection", tone: "neutral" },
+    } as unknown as BoardCard;
+    const { getByText, queryByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Deploying · post-merge verification")).toBeTruthy();
+    expect(getByText("post_deploy_healthy")).toBeTruthy();
+    expect(queryByText("Verification progress")).toBeNull(); // omitted, not crashed
+  });
+
+  test("mission card with NO report (live shape) renders a fallback, not a crash", () => {
+    const card = {
+      id: "mission browser-live-01",
+      lane: "hermes-checking",
+      type: "mission",
+      agentType: "hermes",
+      title: "Verify onboarding on staging",
+      summary: "Fresh agent running; no structured report yet.",
+      repo: "depre-dev/site",
+      freshness: 5,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+    } as unknown as BoardCard;
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Mission · no report yet")).toBeTruthy();
+    expect(getByText(/no structured report yet/i)).toBeTruthy();
+  });
 });

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -242,28 +242,42 @@ function TaskBody({ card }: { card: BoardCard }) {
 }
 
 function DeployBody({ card }: { card: DeployCard }) {
-  const { verification } = card;
+  // `verification`/`deployId` are required on the UI type, but the live
+  // backend doesn't always populate them (deploy verification is not wired
+  // yet). They cross an HTTP/JSON boundary, so read defensively — a
+  // verification-less deploy card must render, not crash the drawer.
+  const verification = (card as { verification?: DeployCard["verification"] }).verification;
+  const deployId = (card as { deployId?: string }).deployId;
   return (
     <>
       <VerdictBlock head="Post-merge verification">{card.summary || "Verifying the deploy."}</VerdictBlock>
-      <section>
-        <div className="hm-section-h">Verification progress</div>
-        <div className="hm-verdict-block">
-          <div className="head">
-            {verification.current}/{verification.total} · {verification.label}
+      {verification ? (
+        <section>
+          <div className="hm-section-h">Verification progress</div>
+          <div className="hm-verdict-block">
+            <div className="head">
+              {verification.current}/{verification.total} · {verification.label}
+            </div>
+            {deployId ? <div className="body">Deploy {deployId}.</div> : null}
           </div>
-          <div className="body">Deploy {card.deployId}.</div>
-        </div>
-      </section>
+        </section>
+      ) : null}
       <ChecksSection checks={card.checks} checkRuns={card.checkRuns} />
     </>
   );
 }
 
 function DoneBody({ card }: { card: DoneCard }) {
+  const closedAt = (card as { closedAt?: string }).closedAt;
   return (
     <VerdictBlock head="Final verdict · release history" accent="var(--hm-sage-deep)">
-      {card.mergeStatus === "MERGED" ? "MERGED" : "CLOSED"} · closed at <b>{card.closedAt}</b>.
+      {card.mergeStatus === "MERGED" ? "MERGED" : "CLOSED"}
+      {closedAt ? (
+        <>
+          {" "}· closed at <b>{closedAt}</b>
+        </>
+      ) : null}
+      .
       {card.verdictText ? (
         <>
           <br />
@@ -276,7 +290,16 @@ function DoneBody({ card }: { card: DoneCard }) {
 }
 
 function MissionBody({ card }: { card: MissionCard }) {
-  const m = card.mission;
+  // `mission` is required on the type, but a live mission card has no
+  // structured report until the browser agent posts one. Read defensively.
+  const m = (card as { mission?: MissionCard["mission"] }).mission;
+  if (!m) {
+    return (
+      <VerdictBlock head="Mission · no report yet" accent="var(--hm-hermes-deep)">
+        {card.summary || "No structured report yet — the browser agent hasn't posted one."}
+      </VerdictBlock>
+    );
+  }
   const verdictColor =
     m.verdictTone === "warn"
       ? "var(--hm-amber-deep)"


### PR DESCRIPTION
## What changed & why

**Clicking any card on the live board crashed the monitor** — the error-boundary "CRASHED" banner with `undefined is not an object (evaluating 't.current')`.

**Root cause** (reproduced in a real browser with a dev build): `DeployBody` destructured `card.verification` and read `verification.current` unconditionally. The live backend **doesn't populate `verification`/`deployId` on deploy cards** (deploy verification isn't wired yet — deferred in #238). The UI type marks them required, but they cross an HTTP/JSON boundary **absent**, so `verification.current` threw (minified `verification.current` → `t.current`). The deploying lane cards the operator clicked hit exactly this. `MissionBody` had the same latent bug (`card.mission` absent on live mission cards with no report); `DoneBody` printed "closed at undefined".

**Fix:** read those type-required-but-runtime-optional nested objects defensively and degrade gracefully — `DeployBody` omits the verification-progress section, `MissionBody` shows a "no report yet" fallback, `DoneBody` drops the close-time clause when absent. The rich content reappears automatically once the backend populates the fields (the deferred enrichment follow-ups).

## Affected surfaces
- [x] Monitor board / slack-operator (the SPA drawer)
- [x] Docs / tests only (tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — **759 pass** (+2 regression tests)
- [x] **Real-browser repro** (Vite dev + a verification-less deploy card): crashed before, renders cleanly after.

## How it was verified
Built a standalone repro of `DetailDrawer` rendering a live-shaped (verification-less) deploy card, ran it in a real browser, captured the `<DeployBody>` crash, applied the fix, and confirmed it renders. Then added jsdom regression tests for the exact live shapes — these would have caught it (the existing tests only used the *rich fixture* deploy/mission cards, which carry the nested objects).

## Rollout / rollback
Pure UI hardening; no backend/ops/config change. Revert = the single commit. **Recommend a fast merge + redeploy** — the live board currently crashes on every card click.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy; no new power; no secrets; `AGENTS.md` unchanged (UI bug fix)

## Known limits / follow-ups
- The underlying data gap (backend doesn't emit deploy `verification` or mission reports yet) is the existing deferred enrichment work; this PR makes the UI robust to it either way. The deploy-card pile-up itself is the separately-tracked producer issue.

## Acceptance
Clicking a live deploy/mission card opens the drawer and renders instead of crashing the board. Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)