### PR TITLE
claude-branch-worker: greenfield Claude executor (O2)

### DIFF
--- a/services/slack-operator/src/claude-branch-worker.ts
+++ b/services/slack-operator/src/claude-branch-worker.ts
@@ -1,0 +1,413 @@
+// Claude branch worker (O2) — the greenfield executor the claude-task-runner
+// spawns per approved `agent:"claude"` task. Mirrors codex-branch-worker, but
+// instead of working on an existing PR it:
+//   create a `claude/<slug>` branch off a fresh base → run Claude in an
+//   isolated worktree → commit → push → OPEN a pull request.
+// The opened PR is auto-attributed to "claude" by O1 (branch prefix) and
+// flows into Operator review through the existing Hermes handoff.
+//
+// Auth: the runner already resolved the billing route and handed us an env
+// with the right credential (and, in sub mode, no ANTHROPIC_API_KEY) — we
+// just inherit it for the `claude` invocation. We never read or log the
+// token/key here; the GitHub token is used only for git push + PR open.
+//
+// Guardrails (this is an unattended agent with push rights):
+//   - repo allow-list (CLAUDE_BRANCH_WORKER_ALLOWED_REPOS) — refuse others;
+//   - never the base/protected branch — we only ever push `claude/<slug>`;
+//   - forbidden secret-like files are rejected before commit (reused guard);
+//   - all command output is secret-redacted (reused sanitizer);
+//   - the worker only ever runs tasks the runner already claimed at
+//     status:"approved" (the runner enforces that).
+//
+// exec + GitHub fetch are injected so the whole flow is unit-testable with
+// no real git, network, or provider calls.
+
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertNoForbiddenFiles, redact } from "./codex-branch-worker.js";
+
+export interface ClaudeWorkerTask {
+  id: string;
+  repo: string;
+  /** Greenfield tasks have no PR yet; Claude opens its own. */
+  pullRequestNumber?: number;
+  title?: string;
+  prompt: string;
+  correlationId?: string;
+}
+
+export interface ClaudeWorkerConfig {
+  apiBaseUrl: string;
+  githubToken?: string;
+  allowedRepos: string[];
+  workRoot: string;
+  keepWorktree: boolean;
+  gitUserName: string;
+  gitUserEmail: string;
+  baseBranch: string;
+  claudeCommand: string;
+  claudeArgs: string[];
+  commandTimeoutMs: number;
+}
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run a command. Injected in tests; `defaultExec` spawns for real. */
+export type ExecFn = (
+  command: string,
+  args: string[],
+  options: { cwd?: string; timeoutMs?: number; token?: string }
+) => Promise<CommandResult>;
+
+export interface OpenedPullRequest {
+  number: number;
+  html_url?: string;
+}
+
+export interface ClaudeBranchWorkerDeps {
+  exec?: ExecFn;
+  /** Opens the PR; injected in tests. Defaults to the GitHub REST API. */
+  openPullRequest?: (
+    task: ClaudeWorkerTask,
+    config: ClaudeWorkerConfig,
+    input: { head: string; base: string; title: string; body: string }
+  ) => Promise<OpenedPullRequest>;
+}
+
+const PROTECTED_BRANCHES = new Set(["main", "master", "production", "prod"]);
+// `claude -p "<prompt>"` headless. The operator should tune permission /
+// allowed-tools flags for their security posture (Claude Code headless docs);
+// the worktree isolation + guards below are the in-code backstop regardless.
+const DEFAULT_CLAUDE_ARGS = ["-p", "{prompt}"];
+
+export function parseClaudeWorkerTask(env: NodeJS.ProcessEnv = process.env): ClaudeWorkerTask {
+  const prRaw = env.CLAUDE_TASK_PR?.trim();
+  const pullRequestNumber = prRaw ? Number(prRaw) : undefined;
+  if (prRaw && (!Number.isInteger(pullRequestNumber) || (pullRequestNumber as number) < 1)) {
+    throw new Error("CLAUDE_TASK_PR, when set, must be a positive integer.");
+  }
+  return {
+    id: requiredEnv(env, "CLAUDE_TASK_ID"),
+    repo: requiredEnv(env, "CLAUDE_TASK_REPO"),
+    ...(pullRequestNumber ? { pullRequestNumber } : {}),
+    ...(env.CLAUDE_TASK_TITLE ? { title: env.CLAUDE_TASK_TITLE } : {}),
+    prompt: requiredEnv(env, "CLAUDE_TASK_PROMPT"),
+    ...(env.CLAUDE_TASK_CORRELATION_ID ? { correlationId: env.CLAUDE_TASK_CORRELATION_ID } : {}),
+  };
+}
+
+export function parseClaudeWorkerConfig(env: NodeJS.ProcessEnv = process.env): ClaudeWorkerConfig {
+  return {
+    apiBaseUrl: env.GITHUB_API_BASE_URL?.trim() || "https://api.github.com",
+    githubToken: resolveGithubTokenForRepo(env.CLAUDE_TASK_REPO ?? "", env),
+    allowedRepos: parseCsv(env.CLAUDE_BRANCH_WORKER_ALLOWED_REPOS || env.GITHUB_HELPER_REPOS || env.GITHUB_DEFAULT_REPO),
+    workRoot: env.CLAUDE_BRANCH_WORKER_ROOT?.trim() || join(tmpdir(), "averray-claude-worker"),
+    keepWorktree: env.CLAUDE_BRANCH_WORKER_KEEP_WORKTREE === "1" || env.CLAUDE_BRANCH_WORKER_KEEP_WORKTREE === "true",
+    gitUserName: env.CLAUDE_BRANCH_WORKER_GIT_USER_NAME?.trim() || "Averray Claude Worker",
+    gitUserEmail: env.CLAUDE_BRANCH_WORKER_GIT_USER_EMAIL?.trim() || "claude-worker@averray.local",
+    baseBranch: env.CLAUDE_BRANCH_WORKER_BASE_BRANCH?.trim() || "main",
+    claudeCommand: env.CLAUDE_BRANCH_WORKER_CLAUDE_COMMAND?.trim() || "claude",
+    claudeArgs: parseArgs(env.CLAUDE_BRANCH_WORKER_CLAUDE_ARGS, DEFAULT_CLAUDE_ARGS),
+    commandTimeoutMs: positiveInt(env.CLAUDE_BRANCH_WORKER_TIMEOUT_MS, 30 * 60_000),
+  };
+}
+
+/** Deterministic `claude/<slug>-<idtail>` head branch for the task. */
+export function claudeBranchName(task: ClaudeWorkerTask): string {
+  const base = (task.title || task.prompt || "task")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  const tail = task.id.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(-8);
+  return `claude/${[base, tail].filter(Boolean).join("-") || "task"}`;
+}
+
+export function validateClaudeWorkerTask(task: ClaudeWorkerTask, branch: string, config: ClaudeWorkerConfig): void {
+  if (config.allowedRepos.length === 0) {
+    throw new Error("No Claude worker allowed repos configured (CLAUDE_BRANCH_WORKER_ALLOWED_REPOS).");
+  }
+  if (!config.allowedRepos.includes(task.repo)) {
+    throw new Error(`Repo ${task.repo} is not allowed for Claude worker dispatch.`);
+  }
+  if (PROTECTED_BRANCHES.has(branch.toLowerCase()) || branch === config.baseBranch) {
+    throw new Error(`Refusing to let Claude push to protected/base branch ${branch}.`);
+  }
+}
+
+export function buildGuardedClaudePrompt(task: ClaudeWorkerTask, branch: string): string {
+  return [
+    "You are Claude working for Hermes on an approved Averray task.",
+    "",
+    "Hard boundaries:",
+    `- Work only in this checked-out worktree on branch ${branch}.`,
+    "- Do NOT merge, deploy, rotate secrets, claim jobs, submit platform work, or push to main.",
+    "- Do NOT add or print secrets, JWTs, private keys, or provider tokens; never edit .env files.",
+    "- Keep the change minimal and specific to the task; run the smallest relevant local checks.",
+    "- Do NOT open the pull request yourself — the harness commits, pushes, and opens it.",
+    "- Leave merge/deploy decisions to Hermes and the operator.",
+    "",
+    `Repository: ${task.repo}`,
+    `Title: ${task.title || "untitled"}`,
+    task.correlationId ? `Correlation ID: ${task.correlationId}` : "",
+    "",
+    "Task from Hermes:",
+    task.prompt,
+  ].filter(Boolean).join("\n");
+}
+
+export function renderClaudeWorkerArgs(args: string[], prompt: string, task: ClaudeWorkerTask): string[] {
+  const replacements: Record<string, string> = {
+    "{prompt}": prompt,
+    "{taskId}": task.id,
+    "{repo}": task.repo,
+    "{title}": task.title ?? "",
+    "{correlationId}": task.correlationId ?? "",
+  };
+  return args.map((arg) => {
+    let value = arg;
+    for (const [token, replacement] of Object.entries(replacements)) {
+      value = value.split(token).join(replacement);
+    }
+    return value;
+  });
+}
+
+export function buildPullRequestBody(task: ClaudeWorkerTask): string {
+  return [
+    "Opened by the Averray **Claude worker** for an approved Hermes task.",
+    "",
+    "**Task**",
+    task.prompt,
+    "",
+    task.correlationId ? `Correlation ID: \`${task.correlationId}\`` : "",
+    "",
+    "_Automated change on a fresh branch. Review + merge are human-gated (AGENTS.md)._",
+  ].filter(Boolean).join("\n");
+}
+
+export async function runClaudeBranchWorker(
+  task: ClaudeWorkerTask = parseClaudeWorkerTask(),
+  config: ClaudeWorkerConfig = parseClaudeWorkerConfig(),
+  deps: ClaudeBranchWorkerDeps = {}
+): Promise<void> {
+  const exec = deps.exec ?? defaultExec;
+  const openPullRequest = deps.openPullRequest ?? openPullRequestViaApi;
+  const branch = claudeBranchName(task);
+  validateClaudeWorkerTask(task, branch, config);
+
+  const cloneUrl = `https://github.com/${task.repo}.git`;
+  await mkdir(config.workRoot, { recursive: true });
+  const workdir = await mkdtemp(join(config.workRoot, `${slug(task.id)}-`));
+  try {
+    await exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    await exec("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
+    await exec("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
+    await exec("git", ["fetch", "origin", config.baseBranch], { cwd: workdir, token: config.githubToken });
+    await exec("git", ["checkout", "-B", branch, `origin/${config.baseBranch}`], { cwd: workdir });
+
+    const prompt = buildGuardedClaudePrompt(task, branch);
+    console.log(`Claude worker starting ${task.repo} on ${branch}.`);
+    const claude = await exec(config.claudeCommand, renderClaudeWorkerArgs(config.claudeArgs, prompt, task), {
+      cwd: workdir,
+      timeoutMs: config.commandTimeoutMs,
+    });
+    if (claude.exitCode !== 0) {
+      throw new Error(lastNonEmptyLine(claude.stderr) || lastNonEmptyLine(claude.stdout) || `claude exited with ${claude.exitCode}.`);
+    }
+
+    const changedFiles = await listChangedFiles(exec, workdir);
+    assertNoForbiddenFiles(changedFiles, "Claude");
+    if (changedFiles.length === 0) {
+      console.log(`Claude produced no changes for ${task.repo}; not opening a PR.`);
+      return;
+    }
+
+    await exec("git", ["add", "-A"], { cwd: workdir });
+    await exec("git", ["commit", "-m", commitMessage(task)], { cwd: workdir });
+    await exec("git", ["push", "origin", `HEAD:${branch}`], { cwd: workdir, token: config.githubToken });
+
+    const pr = await openPullRequest(task, config, {
+      head: branch,
+      base: config.baseBranch,
+      title: pullRequestTitle(task),
+      body: buildPullRequestBody(task),
+    });
+    console.log(`Claude opened PR #${pr.number} on ${task.repo} (${branch})${pr.html_url ? ` — ${pr.html_url}` : ""}.`);
+  } finally {
+    if (!config.keepWorktree) await rm(workdir, { recursive: true, force: true });
+  }
+}
+
+async function openPullRequestViaApi(
+  task: ClaudeWorkerTask,
+  config: ClaudeWorkerConfig,
+  input: { head: string; base: string; title: string; body: string }
+): Promise<OpenedPullRequest> {
+  const response = await fetch(`${config.apiBaseUrl.replace(/\/$/, "")}/repos/${task.repo}/pulls`, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      "content-type": "application/json",
+      "user-agent": "averray-claude-branch-worker",
+      ...(config.githubToken ? { authorization: `Bearer ${config.githubToken}` } : {}),
+    },
+    body: JSON.stringify({ title: input.title, head: input.head, base: input.base, body: input.body, maintainer_can_modify: true }),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub PR creation failed for ${task.repo} (${input.head} → ${input.base}): HTTP ${response.status}`);
+  }
+  const json = await response.json() as OpenedPullRequest;
+  return { number: json.number, ...(json.html_url ? { html_url: json.html_url } : {}) };
+}
+
+export async function listChangedFiles(exec: ExecFn, cwd: string): Promise<string[]> {
+  const result = await exec("git", ["status", "--porcelain"], { cwd });
+  // Porcelain v1: 2 status chars + a space, then the path. Slice the fixed
+  // 3-char prefix off the RAW line (don't trim first, or a worktree-modified
+  // " M path" loses a character and the secret-file guard sees a wrong path).
+  return result.stdout
+    .split(/\r?\n/)
+    .filter((line) => line.length > 3)
+    .map((line) => {
+      const entry = line.slice(3).trim();
+      const arrow = entry.lastIndexOf(" -> "); // rename → keep the new path
+      return (arrow >= 0 ? entry.slice(arrow + 4) : entry).trim();
+    })
+    .filter(Boolean);
+}
+
+const defaultExec: ExecFn = (command, args, options) =>
+  new Promise<CommandResult>((resolve, reject) => {
+    const child = spawn(command, gitArgsWithAuth(command, args, options.token), {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timeout = options.timeoutMs
+      ? setTimeout(() => {
+        if (settled) return;
+        child.kill("SIGTERM");
+        setTimeout(() => {
+          if (!settled) child.kill("SIGKILL");
+        }, 5_000).unref();
+        reject(new Error(`${command} timed out after ${options.timeoutMs}ms.`));
+      }, options.timeoutMs)
+      : undefined;
+    timeout?.unref();
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stdout += text;
+      process.stdout.write(redact(text));
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf8");
+      stderr += text;
+      process.stderr.write(redact(text));
+    });
+    child.on("error", (error) => {
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+  });
+
+function gitArgsWithAuth(command: string, args: string[], token?: string): string[] {
+  if (command !== "git" || !token) return args;
+  return ["-c", `http.https://github.com/.extraheader=AUTHORIZATION: Bearer ${token}`, ...args];
+}
+
+function resolveGithubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {
+  const [owner, name] = repo.split("/");
+  const repoToken = owner && name ? parseTokenMap(env.GITHUB_REPO_TOKENS).get(`${owner}/${name}`) : undefined;
+  const ownerToken = owner ? parseTokenMap(env.GITHUB_OWNER_TOKENS).get(owner) : undefined;
+  const envRepoToken = owner && name ? env[`GITHUB_TOKEN_${toEnvKey(owner)}_${toEnvKey(name)}`]?.trim() : undefined;
+  const envOwnerToken = owner ? env[`GITHUB_TOKEN_${toEnvKey(owner)}`]?.trim() : undefined;
+  return repoToken ?? ownerToken ?? envRepoToken ?? envOwnerToken ?? env.GITHUB_TOKEN?.trim() ?? undefined;
+}
+
+function parseTokenMap(value: string | undefined): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const entry of (value ?? "").split(/[\n,;]+/)) {
+    const [rawKey, ...rest] = entry.split("=");
+    const key = rawKey?.trim();
+    const token = rest.join("=").trim();
+    if (key && token) map.set(key, token);
+  }
+  return map;
+}
+
+function parseCsv(value: string | undefined): string[] {
+  return (value ?? "").split(/[\n,;]+/).map((entry) => entry.trim()).filter(Boolean);
+}
+
+function parseArgs(value: string | undefined, fallback: string[]): string[] {
+  const trimmed = value?.trim();
+  if (!trimmed) return fallback;
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("CLAUDE_BRANCH_WORKER_CLAUDE_ARGS must be a JSON string array when it starts with '['.");
+    }
+    return parsed;
+  }
+  return trimmed.split(/\s+/);
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = env[key]?.trim();
+  if (!value) throw new Error(`${key} is required.`);
+  return value;
+}
+
+function toEnvKey(value: string): string {
+  return value.replace(/[^A-Za-z0-9]/g, "_").toUpperCase();
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "task";
+}
+
+function commitMessage(task: ClaudeWorkerTask): string {
+  const title = (task.title || task.prompt || "Claude task").replace(/\s+/g, " ").trim();
+  return `Claude task: ${title}`.slice(0, 72);
+}
+
+function pullRequestTitle(task: ClaudeWorkerTask): string {
+  const title = (task.title || task.prompt || "Claude task").replace(/\s+/g, " ").trim();
+  return title.slice(0, 80);
+}
+
+function lastNonEmptyLine(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-1)[0]?.trim() ?? "";
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  runClaudeBranchWorker()
+    .catch((error) => {
+      console.error(redact(error instanceof Error ? error.message : String(error)));
+      process.exitCode = 1;
+    });
+}

--- a/services/slack-operator/src/codex-branch-worker.ts
+++ b/services/slack-operator/src/codex-branch-worker.ts
@@ -247,10 +247,13 @@ async function gitChangedFiles(cwd: string): Promise<string[]> {
     .filter(Boolean);
 }
 
-function assertNoForbiddenFiles(paths: string[]): void {
+// Exported so the Claude branch worker reuses the exact same secret-file
+// guard + output sanitization (AGENTS.md: never log/commit secrets) rather
+// than maintaining a second copy that could drift.
+export function assertNoForbiddenFiles(paths: string[], who = "Codex"): void {
   const forbidden = paths.filter((path) => DEFAULT_DENY_PATTERNS.some((pattern) => pattern.test(path)));
   if (forbidden.length > 0) {
-    throw new Error(`Codex touched forbidden secret-like file(s): ${forbidden.join(", ")}`);
+    throw new Error(`${who} touched forbidden secret-like file(s): ${forbidden.join(", ")}`);
   }
 }
 
@@ -379,7 +382,7 @@ function lastNonEmptyLine(value: string): string {
   return value.trim().split(/\r?\n/).filter(Boolean).slice(-1)[0]?.trim() ?? "";
 }
 
-function redact(value: string): string {
+export function redact(value: string): string {
   return value
     .replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[redacted private key]")
     .replace(/\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\b/g, "[redacted jwt]")

--- a/test/unit/claude-branch-worker.test.ts
+++ b/test/unit/claude-branch-worker.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  buildGuardedClaudePrompt,
+  claudeBranchName,
+  parseClaudeWorkerConfig,
+  parseClaudeWorkerTask,
+  renderClaudeWorkerArgs,
+  runClaudeBranchWorker,
+  validateClaudeWorkerTask,
+  type ClaudeWorkerConfig,
+  type ClaudeWorkerTask,
+  type CommandResult,
+  type ExecFn,
+} from "../../services/slack-operator/src/claude-branch-worker.js";
+
+const task: ClaudeWorkerTask = {
+  id: "claude-task-averray-agent-agent-new-20260530-abc123",
+  repo: "averray-agent/agent",
+  title: "Add a health endpoint",
+  prompt: "Add GET /healthz returning 200.",
+  correlationId: "corr-1",
+};
+
+describe("claude branch worker — pure functions", () => {
+  it("parses a greenfield task (no PR) and a PR-bearing task", () => {
+    const green = parseClaudeWorkerTask({ CLAUDE_TASK_ID: "t1", CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "do x" });
+    expect(green).toMatchObject({ id: "t1", repo: "a/b", prompt: "do x" });
+    expect(green.pullRequestNumber).toBeUndefined();
+    const withPr = parseClaudeWorkerTask({ CLAUDE_TASK_ID: "t1", CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "x", CLAUDE_TASK_PR: "42" });
+    expect(withPr.pullRequestNumber).toBe(42);
+    expect(() => parseClaudeWorkerTask({ CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "x" } as NodeJS.ProcessEnv)).toThrow(/CLAUDE_TASK_ID/);
+  });
+
+  it("config defaults + allow-list", () => {
+    const c = parseClaudeWorkerConfig({ CLAUDE_BRANCH_WORKER_ALLOWED_REPOS: "a/b, c/d" });
+    expect(c.baseBranch).toBe("main");
+    expect(c.claudeCommand).toBe("claude");
+    expect(c.claudeArgs).toEqual(["-p", "{prompt}"]);
+    expect(c.allowedRepos).toEqual(["a/b", "c/d"]);
+  });
+
+  it("derives a claude/<slug>-<idtail> branch", () => {
+    const b = claudeBranchName(task);
+    expect(b.startsWith("claude/add-a-health-endpoint")).toBe(true);
+    expect(b).toMatch(/^claude\/[a-z0-9-]+$/);
+  });
+
+  it("validate: rejects empty allow-list, disallowed repo, and protected/base branch", () => {
+    const ok = parseClaudeWorkerConfig({ CLAUDE_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent" });
+    expect(() => validateClaudeWorkerTask(task, "claude/x", parseClaudeWorkerConfig({}))).toThrow(/allowed repos/i);
+    expect(() => validateClaudeWorkerTask({ ...task, repo: "evil/repo" }, "claude/x", ok)).toThrow(/not allowed/i);
+    expect(() => validateClaudeWorkerTask(task, "main", ok)).toThrow(/protected\/base/i);
+    expect(() => validateClaudeWorkerTask(task, "claude/x", ok)).not.toThrow();
+  });
+
+  it("guarded prompt forbids merge/secrets and tells Claude NOT to open the PR itself", () => {
+    const p = buildGuardedClaudePrompt(task, "claude/x");
+    expect(p).toMatch(/Do NOT merge, deploy/i);
+    expect(p).toMatch(/never edit \.env/i);
+    expect(p).toMatch(/Do NOT open the pull request yourself/i);
+    expect(p).toContain(task.prompt);
+  });
+
+  it("renders {prompt} into the claude args", () => {
+    expect(renderClaudeWorkerArgs(["-p", "{prompt}"], "hello", task)).toEqual(["-p", "hello"]);
+  });
+});
+
+describe("claude branch worker — orchestration (injected exec + PR open)", () => {
+  const tempDirs: string[] = [];
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((d) => rm(d, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+  async function workRoot(): Promise<string> {
+    const d = await mkdtemp(join(tmpdir(), "claude-worker-test-"));
+    tempDirs.push(d);
+    return d;
+  }
+  async function config(overrides: Partial<ClaudeWorkerConfig> = {}): Promise<ClaudeWorkerConfig> {
+    return {
+      apiBaseUrl: "https://api.github.com",
+      githubToken: "ghp_FAKE",
+      allowedRepos: ["averray-agent/agent"],
+      workRoot: await workRoot(),
+      keepWorktree: false,
+      gitUserName: "Averray Claude Worker",
+      gitUserEmail: "claude-worker@averray.local",
+      baseBranch: "main",
+      claudeCommand: "claude",
+      claudeArgs: ["-p", "{prompt}"],
+      commandTimeoutMs: 1_000,
+      ...overrides,
+    };
+  }
+
+  function fakeExec(opts: { claudeExit?: number; changed?: string[]; claudeStderr?: string } = {}) {
+    const calls: { command: string; args: string[] }[] = [];
+    const exec: ExecFn = async (command, args) => {
+      calls.push({ command, args });
+      if (command === "git" && args[0] === "status") {
+        const lines = (opts.changed ?? ["src/healthz.ts"]).map((f) => ` M ${f}`).join("\n");
+        return { exitCode: 0, stdout: lines, stderr: "" } satisfies CommandResult;
+      }
+      if (command === "claude") {
+        return { exitCode: opts.claudeExit ?? 0, stdout: "edited files", stderr: opts.claudeStderr ?? "" } satisfies CommandResult;
+      }
+      return { exitCode: 0, stdout: "", stderr: "" } satisfies CommandResult;
+    };
+    return { exec, calls };
+  }
+
+  it("happy path: creates the branch, runs Claude, commits, pushes, and OPENS a PR", async () => {
+    const { exec, calls } = fakeExec();
+    const prInputs: unknown[] = [];
+    await runClaudeBranchWorker(task, await config(), {
+      exec,
+      openPullRequest: async (_t, _c, input) => {
+        prInputs.push(input);
+        return { number: 777, html_url: "https://github.com/averray-agent/agent/pull/777" };
+      },
+    });
+    const seq = calls.map((c) => `${c.command} ${c.args[0] ?? ""}`.trim());
+    expect(seq).toContain("git clone");
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "checkout" && c.args.includes("-B"))).toBe(true);
+    expect(calls.some((c) => c.command === "claude")).toBe(true);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "commit")).toBe(true);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "push")).toBe(true);
+    expect(prInputs).toHaveLength(1);
+    expect(prInputs[0]).toMatchObject({ base: "main" });
+    expect((prInputs[0] as { head: string }).head).toMatch(/^claude\//);
+  });
+
+  it("no changes → does NOT commit, push, or open a PR", async () => {
+    const { exec, calls } = fakeExec({ changed: [] });
+    let opened = 0;
+    await runClaudeBranchWorker(task, await config(), {
+      exec,
+      openPullRequest: async () => { opened += 1; return { number: 1 }; },
+    });
+    expect(opened).toBe(0);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "commit")).toBe(false);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "push")).toBe(false);
+  });
+
+  it("rejects forbidden secret-like files before committing", async () => {
+    const { exec } = fakeExec({ changed: ["src/ok.ts", ".env.production"] });
+    await expect(
+      runClaudeBranchWorker(task, await config(), { exec, openPullRequest: async () => ({ number: 1 }) }),
+    ).rejects.toThrow(/forbidden secret-like file/i);
+  });
+
+  it("a non-zero Claude exit fails the task (no commit/push/PR)", async () => {
+    const { exec, calls } = fakeExec({ claudeExit: 2, claudeStderr: "claude blew up" });
+    let opened = 0;
+    await expect(
+      runClaudeBranchWorker(task, await config(), { exec, openPullRequest: async () => { opened += 1; return { number: 1 }; } }),
+    ).rejects.toThrow(/claude blew up|claude exited/i);
+    expect(opened).toBe(0);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "push")).toBe(false);
+  });
+
+  it("refuses a repo outside the allow-list (before any git)", async () => {
+    const { exec, calls } = fakeExec();
+    await expect(
+      runClaudeBranchWorker({ ...task, repo: "evil/repo" }, await config(), { exec, openPullRequest: async () => ({ number: 1 }) }),
+    ).rejects.toThrow(/not allowed/i);
+    expect(calls).toHaveLength(0); // validated before cloning
+  });
+});


### PR DESCRIPTION
## What changed & why

The **executor** the `claude-task-runner` (#260) spawns per approved
`agent:"claude"` task. It's the greenfield sibling of `codex-branch-worker`:
instead of working an existing PR, it creates a `claude/<slug>` branch off a
fresh base, runs Claude in an isolated worktree, commits, pushes, and **opens
a pull request** — which O1 auto-attributes to `claude` and flows into the
normal Operator-review lane on the board. This is the piece that makes the O2
pipeline actually *runnable* (queue → runner → **worker** → PR → review).

**Guardrails** (this is an unattended agent with push rights — new power, so
it's allow-listed + branch-scoped + secret-guarded):
- **repo allow-list** (`CLAUDE_BRANCH_WORKER_ALLOWED_REPOS`) — refuses any repo
  not on it, *before* cloning;
- only ever pushes `claude/<slug>`; **refuses protected/base branches**;
- **forbidden secret-like files rejected before commit**, and all command
  output **secret-redacted** — both REUSED from `codex-branch-worker` (I
  exported `redact` + `assertNoForbiddenFiles` rather than re-implementing, so
  the security logic can't drift between the two workers);
- the harness opens the PR, **never Claude from inside** the run; the guarded
  prompt also forbids merge/deploy/secret edits;
- runs only tasks the runner already claimed at `status:"approved"` — it never
  self-approves;
- **auth**: inherits the runner-resolved env (sub mode carries no
  `ANTHROPIC_API_KEY`); never reads or logs the token/key.

`exec` and `openPullRequest` are dependency-injected, so the whole flow is
unit-tested with **no real git / network / provider** calls. Also fixed the
git-porcelain parse to slice the fixed 3-char prefix off the *raw* line (a
leading trim could drop a character and feed the secret-file guard a wrong
path).

## Affected surfaces
- [x] Worker runners / task queue
- [x] Docs / tests only (new module + tests; no behavior wired yet)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 777 pass / 82 files (+11 new worker tests)
- [ ] compose config — n/a (no ops/Docker/compose touched in this PR)

## Rollout / rollback
**Nothing spawns this yet.** No `CLAUDE_TASK_RUNNER_COMMAND` points at it and
the image has no Claude CLI, so merging is inert. A thin follow-on PR wires it
live (Dockerfile adds `@anthropic-ai/claude-code`, compose sets the runner
command + `CLAUDE_BRANCH_WORKER_ALLOWED_REPOS`, `.env.example`) and **that PR
carries the `AGENTS.md` note** for the now-live unattended push power. Rollback
= revert; nothing downstream depends on it until wiring lands.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — the worker only opens a PR; a human still owns merge + deploy
- [x] Wallet testnet-only / `HALT_FILE` honored; the new push power is gated (allow-list + protected-branch refusal + approved-only); runner already enforces budget + HALT
- [x] No secrets committed/printed/logged — output redacted; forbidden-file guard; no key/token read or logged
- [x] `AGENTS.md` note deferred to the wiring PR (this module is inert until then)

## Known limits / follow-ups
- **Follow-on (next):** Dockerfile (Claude CLI) + compose runner command + allow-list env + `.env.example` + `AGENTS.md` — makes it live, then deploy + provision.
- PR-bearing (non-greenfield) Claude tasks are parsed (`CLAUDE_TASK_PR`) but this worker's orchestration is greenfield-first; working an existing PR with Claude can come later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)