### PR TITLE
enqueue: let the propose route create greenfield Claude tasks (O2)

### DIFF
--- a/services/slack-operator/src/codex-task-request.ts
+++ b/services/slack-operator/src/codex-task-request.ts
@@ -1,0 +1,97 @@
+// Pure validation for the POST /monitor/codex-tasks "propose" action.
+//
+// Extracted from the HTTP handler so the agent-aware payload rules can be
+// unit-tested without standing up the server. The rule that matters:
+//   - Codex tasks iterate an EXISTING PR, so a valid pullRequestNumber is
+//     required.
+//   - Claude tasks are GREENFIELD (the worker opens its own PR), so the PR is
+//     optional — and only validated when the caller supplies one.
+// The queue layer (proposeCodexTask) already supports both shapes; this is the
+// untrusted-input gate in front of it, and it decides which agent runs.
+import type { CodexTaskInput, TaskAgent } from "./codex-task-queue.js";
+
+const TASK_AGENTS: readonly TaskAgent[] = ["codex", "claude"];
+
+export type ParseProposeResult =
+  | { ok: true; input: CodexTaskInput }
+  | { ok: false; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Non-empty string field (mirrors the HTTP handler's stringField). */
+function str(rec: Record<string, unknown>, key: string): string | undefined {
+  const field = rec[key];
+  return typeof field === "string" && field.length > 0 ? field : undefined;
+}
+
+/** Numeric field, tolerating a numeric string (mirrors numberField). */
+function num(field: unknown): number | undefined {
+  if (typeof field === "number" && Number.isFinite(field)) return field;
+  if (typeof field === "string" && field.trim().length > 0) {
+    const parsed = Number.parseInt(field, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function requiredFieldsMessage(agent: TaskAgent): string {
+  return agent === "claude"
+    ? "repo and prompt are required to propose Claude work; pullRequestNumber is optional."
+    : "repo, pullRequestNumber, and prompt are required to propose Codex work.";
+}
+
+export function parseProposeTaskPayload(payload: unknown): ParseProposeResult {
+  if (!isRecord(payload)) {
+    return { ok: false, message: "Request body must be a JSON object." };
+  }
+
+  const repo = str(payload, "repo");
+  const prompt = str(payload, "prompt");
+
+  const agentField = typeof payload.agent === "string" ? payload.agent.trim() : "";
+  const agent = (agentField || "codex") as TaskAgent;
+  if (!TASK_AGENTS.includes(agent)) {
+    return { ok: false, message: `Unknown agent "${agentField}". Expected "codex" or "claude".` };
+  }
+
+  // A PR number is "supplied" only when the caller sent a non-empty value.
+  const prSupplied =
+    payload.pullRequestNumber !== undefined &&
+    payload.pullRequestNumber !== null &&
+    payload.pullRequestNumber !== "";
+  const pullRequestNumber = prSupplied ? num(payload.pullRequestNumber) : undefined;
+  const prValid =
+    typeof pullRequestNumber === "number" &&
+    Number.isInteger(pullRequestNumber) &&
+    pullRequestNumber >= 1;
+
+  if (!repo || !prompt) {
+    return { ok: false, message: requiredFieldsMessage(agent) };
+  }
+  // Codex must target an existing PR.
+  if (agent === "codex" && !prValid) {
+    return { ok: false, message: requiredFieldsMessage(agent) };
+  }
+  // Any supplied PR (either agent) must be a positive integer.
+  if (prSupplied && !prValid) {
+    return { ok: false, message: "pullRequestNumber must be a positive integer." };
+  }
+
+  const correlationId = str(payload, "correlationId");
+  const title = str(payload, "title");
+  const reason = str(payload, "reason");
+
+  const input: CodexTaskInput = {
+    repo,
+    prompt,
+    agent,
+    ...(prValid ? { pullRequestNumber } : {}),
+    ...(correlationId ? { correlationId } : {}),
+    ...(title ? { title } : {}),
+    ...(reason ? { reason } : {}),
+    requester: str(payload, "requester") ?? "monitor",
+  };
+  return { ok: true, input };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -75,6 +75,7 @@ import {
   readCodexRunnerHeartbeat,
   summarizeCodexTasks,
 } from "./codex-task-queue.js";
+import { parseProposeTaskPayload } from "./codex-task-request.js";
 import {
   diagnoseTestbedMissionReportFromMessage,
   listTestbedMissionRuns,
@@ -1085,25 +1086,17 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
     }
     const action = stringField(payload, "action") ?? "propose";
     if (action === "propose") {
-      const repo = stringField(payload, "repo");
-      const pullRequestNumber = numberField(payload, "pullRequestNumber");
-      const prompt = stringField(payload, "prompt");
-      if (!repo || typeof pullRequestNumber !== "number" || !Number.isInteger(pullRequestNumber) || pullRequestNumber < 1 || !prompt) {
+      // Codex tasks need an existing PR; Claude tasks are greenfield (PR
+      // optional). The agent-aware validation lives in a pure, tested parser.
+      const parsed = parseProposeTaskPayload(payload);
+      if (!parsed.ok) {
         writeJson(response, 400, {
           error: "invalid_codex_task",
-          message: "repo, pullRequestNumber, and prompt are required to propose Codex work.",
+          message: parsed.message,
         });
         return;
       }
-      const result = await proposeCodexTask({
-        repo,
-        pullRequestNumber,
-        prompt,
-        ...(stringField(payload, "correlationId") ? { correlationId: stringField(payload, "correlationId") } : {}),
-        ...(stringField(payload, "title") ? { title: stringField(payload, "title") } : {}),
-        ...(stringField(payload, "reason") ? { reason: stringField(payload, "reason") } : {}),
-        requester: stringField(payload, "requester") ?? "monitor",
-      });
+      const result = await proposeCodexTask(parsed.input);
       writeJson(response, 200, {
         ok: true,
         action,

--- a/test/unit/codex-task-request.test.ts
+++ b/test/unit/codex-task-request.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { parseProposeTaskPayload } from "../../services/slack-operator/src/codex-task-request.js";
+
+describe("parseProposeTaskPayload — codex (existing-PR) tasks", () => {
+  it("accepts a valid repo + PR + prompt and defaults agent/requester", () => {
+    const r = parseProposeTaskPayload({ repo: "averray-agent/agent", pullRequestNumber: 402, prompt: "fix it" });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input).toMatchObject({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 402,
+      prompt: "fix it",
+      agent: "codex",
+      requester: "monitor",
+    });
+  });
+
+  it("coerces a numeric-string PR", () => {
+    const r = parseProposeTaskPayload({ repo: "a/b", pullRequestNumber: "402", prompt: "x" });
+    expect(r.ok && r.input.pullRequestNumber).toBe(402);
+  });
+
+  it("rejects codex work with no PR (codex iterates an existing PR)", () => {
+    const r = parseProposeTaskPayload({ repo: "a/b", prompt: "x" });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toMatch(/pullRequestNumber.*required.*Codex/i);
+  });
+
+  it("rejects a non-positive / non-integer PR", () => {
+    expect(parseProposeTaskPayload({ repo: "a/b", pullRequestNumber: 0, prompt: "x" }).ok).toBe(false);
+    expect(parseProposeTaskPayload({ repo: "a/b", pullRequestNumber: -3, prompt: "x" }).ok).toBe(false);
+  });
+});
+
+describe("parseProposeTaskPayload — claude (greenfield) tasks", () => {
+  it("accepts greenfield Claude work with NO PR", () => {
+    const r = parseProposeTaskPayload({ repo: "averray-agent/agent", agent: "claude", prompt: "build a healthz endpoint" });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.agent).toBe("claude");
+    expect(r.input.pullRequestNumber).toBeUndefined();
+    expect(r.input.prompt).toBe("build a healthz endpoint");
+  });
+
+  it("accepts Claude work WITH a valid PR (optional, validated when present)", () => {
+    const r = parseProposeTaskPayload({ repo: "a/b", agent: "claude", pullRequestNumber: 7, prompt: "x" });
+    expect(r.ok && r.input.pullRequestNumber).toBe(7);
+  });
+
+  it("rejects a supplied-but-invalid PR even for Claude", () => {
+    const r = parseProposeTaskPayload({ repo: "a/b", agent: "claude", pullRequestNumber: "nope", prompt: "x" });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toMatch(/positive integer/i);
+  });
+
+  it("trims whitespace around the agent name", () => {
+    const r = parseProposeTaskPayload({ repo: "a/b", agent: " claude ", prompt: "x" });
+    expect(r.ok && r.input.agent).toBe("claude");
+  });
+});
+
+describe("parseProposeTaskPayload — rejection paths", () => {
+  it("rejects an unknown agent", () => {
+    const r = parseProposeTaskPayload({ repo: "a/b", agent: "gpt5", prompt: "x" });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.message).toMatch(/unknown agent "gpt5"/i);
+  });
+
+  it("rejects missing repo or prompt", () => {
+    expect(parseProposeTaskPayload({ agent: "claude", prompt: "x" }).ok).toBe(false);
+    expect(parseProposeTaskPayload({ repo: "a/b", agent: "claude" }).ok).toBe(false);
+  });
+
+  it("rejects a non-object body", () => {
+    expect(parseProposeTaskPayload(null).ok).toBe(false);
+    expect(parseProposeTaskPayload("nope").ok).toBe(false);
+    expect(parseProposeTaskPayload([1, 2]).ok).toBe(false);
+  });
+
+  it("passes through optional metadata and honors an explicit requester", () => {
+    const r = parseProposeTaskPayload({
+      repo: "a/b",
+      agent: "claude",
+      prompt: "x",
+      correlationId: "corr-9",
+      title: "Add healthz",
+      reason: "operator delegated",
+      requester: "pkuriger",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input).toMatchObject({
+      correlationId: "corr-9",
+      title: "Add healthz",
+      reason: "operator delegated",
+      requester: "pkuriger",
+    });
+  });
+});


### PR DESCRIPTION
## What changed & why

The O2 pipeline (**queue → claude-task-runner → claude-branch-worker → PR →
review**) is fully wired, but **nothing could create a Claude task**:
`POST /monitor/codex-tasks` (action `propose`) hard-required a
`pullRequestNumber` and always defaulted `agent` to `codex`. The queue layer
already supports `agent:"claude"` + greenfield (no PR) — so this route was the
one missing link that left the Claude lane unreachable from any running
surface. This unblocks the first end-to-end smoke test.

Extracts the propose-payload validation into a **pure, tested parser**
(`codex-task-request.ts`) with the agent-aware rule:
- **Codex** iterates an *existing* PR → a valid `pullRequestNumber` is required (unchanged).
- **Claude** is *greenfield* → the PR is optional, validated only when supplied.

Unknown agents are rejected; a supplied-but-invalid PR is rejected for either
agent; `repo` + `prompt` stay required. The `index.ts` handler now just calls
the parser, so the branching is unit-tested without standing up the server.

**Back-compat:** a payload with no `agent` behaves exactly as before (codex, PR
required).

## Affected surfaces
- [x] Monitor board / slack-operator (the `propose` action-flow handler)
- [x] Worker runners / task queue (enables the Claude lane's create path)
- [x] Docs / tests only (new pure parser + 12 tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 789 pass / 83 files (+12 parser tests)
- [ ] compose config — n/a (no ops/Docker/compose touched)

## Rollout / rollback
Pure request-validation change; no migration, no config. On deploy, the
monitor can create Claude tasks; until one is approved, nothing runs (runner
claims only `approved` tasks). Rollback = revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — this only *enqueues*; approval + the worker's PR-only behavior are unchanged, humans still own merge
- [x] No new ungated power — the worker's repo allow-list + approved-only claim still gate execution; this just lets an operator *propose* a Claude task
- [x] No secrets committed/printed/logged
- [x] No agent-behavior doc change needed (AGENTS.md already documents the runners/workers; this is the create path into the same queue)

## Known limits / follow-ups
- **Coordination — Codex lane:** this edits `handleMonitorCodexTaskRequest` in `index.ts` (the action-flow handler). It's a thin call-site swap to the new parser; the codex/PR path's request contract is unchanged.
- After merge + deploy: smoke-test via `POST /monitor/codex-tasks {"agent":"claude","repo":"averray-agent/agent","prompt":"…"}` → `{"action":"approve","id":…}` → watch the runner open a PR. (The monitor composer UI still only builds Codex/PR proposals — a follow-on can add a Claude/greenfield affordance there; the API is enough for the smoke test.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)