### PR TITLE
monitor: /claude composer command to propose greenfield Claude tasks (O2)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -30,12 +30,15 @@ import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
 const MISSIONS_URL = "/monitor/testbed-missions";
+const CODEX_TASKS_URL = "/monitor/codex-tasks";
 
 export interface MonitorPageProps {
   /** Override the live wiring (fetcher, EventSource, storage) for tests. */
   options?: UseMonitorBoardOptions;
   /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
   onSpawnMission?: (url: string) => void;
+  /** Override the /claude propose (defaults to POST /monitor/codex-tasks). */
+  onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Override the co-pilot collaboration wiring (defaults to live polling). */
   collaboration?: UseCollaborationOptions;
   /** Override the action-alert wiring (audio/notification/storage) for tests. */
@@ -45,6 +48,7 @@ export interface MonitorPageProps {
 export function MonitorPage({
   options,
   onSpawnMission = defaultSpawnMission,
+  onSpawnClaudeTask = defaultSpawnClaudeTask,
   collaboration = {},
   alerts,
 }: MonitorPageProps = {}) {
@@ -66,6 +70,7 @@ export function MonitorPage({
         onCardClose={clearCard}
         onCardNavigate={setCard}
         onSpawnMission={onSpawnMission}
+        onSpawnClaudeTask={onSpawnClaudeTask}
         collaboration={collaboration}
         onMute={mute}
         onUnmute={unmute}
@@ -87,6 +92,24 @@ function defaultSpawnMission(url: string): void {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ targetUrl: url }),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+/**
+ * Propose a greenfield Claude task. POSTs `{ agent: "claude", repo, prompt }`
+ * to the slack-operator's /monitor/codex-tasks (the propose action), which
+ * enqueues it as a `proposed` task card on the v2 board. This only PROPOSES:
+ * the task still needs an explicit operator approval before the Claude runner
+ * claims it and opens a PR — the human gate is unchanged. Fire-and-forget; the
+ * board feed, not this call, drives the UI.
+ */
+function defaultSpawnClaudeTask(repo: string, prompt: string): void {
+  void fetch(CODEX_TASKS_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "propose", agent: "claude", repo, prompt }),
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
   });

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -71,6 +71,8 @@ export interface BoardViewProps {
   onCardClose?: () => void;
   onCardNavigate?: (id: string) => void;
   onSpawnMission?: (url: string) => void;
+  /** Propose a greenfield Claude task (/claude <repo> <task>). */
+  onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   collaboration?: UseCollaborationOptions;
   onMute?: (untilMs: number) => void;
   onUnmute?: () => void;
@@ -88,6 +90,7 @@ export function BoardView({
   onCardClose,
   onCardNavigate,
   onSpawnMission,
+  onSpawnClaudeTask,
   collaboration,
   onMute,
   onUnmute,
@@ -248,6 +251,7 @@ export function BoardView({
 
         <CoPilotRail
           onSpawnMission={onSpawnMission}
+          onSpawnClaudeTask={onSpawnClaudeTask}
           focusedCard={scopeCard}
           collaboration={collaboration}
           onMute={onMute}

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -45,6 +45,35 @@ describe("AskHermesComposer", () => {
     expect(input.value).toBe("/mission");
   });
 
+  test("/claude <repo> <task> proposes a Claude task and clears the input", () => {
+    const onSpawnClaudeTask = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onSpawnClaudeTask={onSpawnClaudeTask} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/claude averray-agent/agent Add a HEALTHCHECK.md");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onSpawnClaudeTask).toHaveBeenCalledWith("averray-agent/agent", "Add a HEALTHCHECK.md");
+    expect(input.value).toBe("");
+  });
+
+  test("/claude with a malformed repo shows an error and does not propose", () => {
+    const onSpawnClaudeTask = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onSpawnClaudeTask={onSpawnClaudeTask} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/claude not-a-repo do the thing");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onSpawnClaudeTask).not.toHaveBeenCalled();
+    expect(within(container).getByRole("alert").textContent).toMatch(/not a valid owner\/repo/);
+    expect(input.value).toBe("/claude not-a-repo do the thing");
+  });
+
+  test("/claude without an onSpawnClaudeTask handler surfaces a hint", () => {
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={vi.fn()} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/claude averray-agent/agent do x");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(within(container).getByRole("alert").textContent).toMatch(/isn't wired here/);
+  });
+
   test("a plain question calls onAsk when a handler is provided", () => {
     const onAsk = vi.fn();
     const { container, getByRole } = render(<AskHermesComposer onAsk={onAsk} />);

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -1,9 +1,10 @@
 // Hermes Handoff Monitor — Ask-Hermes composer (M7'/M9').
 //
 // A single text input that doubles as a command line:
-//   /mission <url>   spawn a browser mission (M7')
-//   /mute [1h|9am]   silence action alerts; /unmute clears it (M9')
-//   anything else    a question for Hermes
+//   /mission <url>        spawn a browser mission (M7')
+//   /claude <repo> <task> propose a greenfield Claude task (O2)
+//   /mute [1h|9am]        silence action alerts; /unmute clears it (M9')
+//   anything else         a question for Hermes
 // Enter sends, Shift+Enter inserts a newline. Parsing lives in the pure
 // hermes-commands helper; this component owns only input + dispatch.
 
@@ -13,6 +14,8 @@ import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
 export interface AskHermesComposerProps {
   /** Spawn a browser mission against a URL (/mission <url>). */
   onSpawnMission?: (url: string) => void;
+  /** Propose a greenfield Claude task (/claude <repo> <task>). */
+  onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Ask Hermes a free-form question. */
   onAsk?: (text: string) => void;
   /** Mute action alerts until an absolute timestamp (/mute). */
@@ -29,6 +32,7 @@ export interface AskHermesComposerProps {
 
 export function AskHermesComposer({
   onSpawnMission,
+  onSpawnClaudeTask,
   onAsk,
   onMute,
   onUnmute,
@@ -58,6 +62,15 @@ export function AskHermesComposer({
         setValue("");
         setError(null);
         return;
+      case "claude":
+        if (onSpawnClaudeTask) {
+          onSpawnClaudeTask(command.repo, command.prompt);
+          setValue("");
+          setError(null);
+        } else {
+          setError("Proposing Claude tasks isn't wired here.");
+        }
+        return;
       case "mute":
         onMute?.(command.untilMs);
         setValue("");
@@ -74,7 +87,7 @@ export function AskHermesComposer({
           setValue("");
           setError(null);
         } else {
-          setError("Ask Hermes isn't wired here. Use /mission <url> or /mute.");
+          setError("Ask Hermes isn't wired here. Use /mission <url>, /claude <repo> <task>, or /mute.");
         }
         return;
     }
@@ -103,8 +116,8 @@ export function AskHermesComposer({
         <textarea
           ref={inputRef}
           className="hm-compose-input"
-          placeholder="Ask Hermes · /mission <url> · /mute 1h"
-          aria-label="Ask Hermes, spawn a mission, or mute alerts"
+          placeholder="Ask Hermes · /mission <url> · /claude <repo> <task> · /mute 1h"
+          aria-label="Ask Hermes, spawn a mission, propose a Claude task, or mute alerts"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -15,6 +15,8 @@ import { HermesTurn } from "./HermesTurn.js";
 
 export interface CoPilotRailProps {
   onSpawnMission?: (url: string) => void;
+  /** Propose a greenfield Claude task (/claude <repo> <task>). */
+  onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Focused card — scopes Ask-Hermes questions + the scope chip. */
   focusedCard?: BoardCard;
   /** Collaboration wiring. Omit to keep the rail inert (e.g. in BoardView tests). */
@@ -31,6 +33,7 @@ export interface CoPilotRailProps {
 
 export function CoPilotRail({
   onSpawnMission,
+  onSpawnClaudeTask,
   focusedCard,
   collaboration,
   onMute,
@@ -74,6 +77,7 @@ export function CoPilotRail({
 
       <AskHermesComposer
         onSpawnMission={onSpawnMission}
+        onSpawnClaudeTask={onSpawnClaudeTask}
         onAsk={(text) => ask(text, relatedPr)}
         onMute={onMute}
         onUnmute={onUnmute}

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
@@ -40,6 +40,38 @@ test("parseHermesInput: /mission with a non-URL arg → error", () => {
   assert.equal(out.kind, "error");
 });
 
+test("parseHermesInput: /claude <repo> <task> → claude (repo + full prompt)", () => {
+  assert.deepEqual(parseHermesInput("/claude averray-agent/agent Add a HEALTHCHECK.md at the repo root"), {
+    kind: "claude",
+    repo: "averray-agent/agent",
+    prompt: "Add a HEALTHCHECK.md at the repo root",
+  });
+});
+
+test("parseHermesInput: /claude is case-insensitive and trims surrounding whitespace", () => {
+  assert.deepEqual(parseHermesInput("  /CLAUDE   owner/repo   do the thing  "), {
+    kind: "claude",
+    repo: "owner/repo",
+    prompt: "do the thing",
+  });
+});
+
+test("parseHermesInput: /claude with no args → error", () => {
+  assert.equal(parseHermesInput("/claude").kind, "error");
+});
+
+test("parseHermesInput: /claude with a repo but no task → error", () => {
+  assert.equal(parseHermesInput("/claude averray-agent/agent").kind, "error");
+});
+
+test("parseHermesInput: /claude with a malformed repo → error", () => {
+  assert.equal(parseHermesInput("/claude not-a-repo do something").kind, "error");
+});
+
+test("parseHermesInput: a word starting with claude but not the command is an ask", () => {
+  assert.equal(parseHermesInput("claudette asked about #548").kind, "ask");
+});
+
 test("parseHermesInput: plain text → ask", () => {
   assert.deepEqual(parseHermesInput("what's blocking #548?"), {
     kind: "ask",

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
@@ -3,6 +3,7 @@
 // The Hermes composer is a single text input that doubles as a command
 // line:
 //   /mission <url>      spawn a browser mission against a live URL
+//   /claude <repo> <…>  propose a greenfield Claude task (O2); opens a PR
 //   /mute [1h|9am|…]    silence action alerts (M9'); /unmute clears it
 //   anything else       a question routed to Hermes
 // Parsing lives here as a pure function so the composer stays dumb and
@@ -12,6 +13,7 @@ import { parseMuteArg } from "./notifications.js";
 
 export type HermesCommand =
   | { kind: "mission"; url: string }
+  | { kind: "claude"; repo: string; prompt: string }
   | { kind: "mute"; untilMs: number }
   | { kind: "unmute" }
   | { kind: "ask"; text: string }
@@ -19,9 +21,11 @@ export type HermesCommand =
   | { kind: "empty" };
 
 const MISSION_RE = /^\/mission\b\s*(.*)$/is;
+const CLAUDE_RE = /^\/claude\b\s*(.*)$/is;
 const MUTE_RE = /^\/mute\b\s*(.*)$/is;
 const UNMUTE_RE = /^\/unmute\b/i;
 const URL_RE = /^https?:\/\/\S+$/i;
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 
 export function parseHermesInput(raw: string, now: () => number = Date.now): HermesCommand {
   const text = (raw ?? "").trim();
@@ -38,6 +42,24 @@ export function parseHermesInput(raw: string, now: () => number = Date.now): Her
       return { kind: "error", message: `"${url}" is not a valid http(s) URL.` };
     }
     return { kind: "mission", url };
+  }
+
+  const claude = CLAUDE_RE.exec(text);
+  if (claude) {
+    const arg = (claude[1] ?? "").trim();
+    if (!arg) {
+      return { kind: "error", message: "/claude needs a repo and a task, e.g. /claude averray-agent/agent Add a HEALTHCHECK.md" };
+    }
+    const gap = arg.search(/\s/);
+    const repo = (gap === -1 ? arg : arg.slice(0, gap)).trim();
+    const prompt = (gap === -1 ? "" : arg.slice(gap + 1)).trim();
+    if (!REPO_RE.test(repo)) {
+      return { kind: "error", message: `"${repo}" is not a valid owner/repo (e.g. averray-agent/agent).` };
+    }
+    if (!prompt) {
+      return { kind: "error", message: "/claude needs a task description after the repo." };
+    }
+    return { kind: "claude", repo, prompt };
   }
 
   if (UNMUTE_RE.test(text)) return { kind: "unmute" };


### PR DESCRIPTION
## What changed & why

Adds a **board-native way to propose a Claude task**, so the O2 loop can be
driven from the monitor instead of curl. New composer command, mirroring the
existing `/mission`:

```
/claude <owner/repo> <task…>
```
e.g. `/claude averray-agent/agent Add a HEALTHCHECK.md at the repo root`

The pure parser (`hermes-commands`) gains a `claude` kind: it splits the first
token as the repo (validated as `owner/repo`) and the remainder as the prompt,
with clear errors for a missing/invalid repo or an empty task. The composer
dispatches to a new `onSpawnClaudeTask`, threaded
`MonitorPage → BoardView → CoPilotRail → AskHermesComposer`. `MonitorPage`'s
default POSTs `{action:"propose", agent:"claude", repo, prompt}` to
`/monitor/codex-tasks` — the route #266 taught to accept greenfield Claude work.

This is the follow-on offered after #266; together they let the smoke test run
entirely from the board.

## Truth boundary
This **only proposes.** The task lands as a `proposed` card and still needs an
**explicit operator approval** before the Claude runner claims it and opens a
PR. The human gate is unchanged and the composer cannot approve — proposing and
approving stay distinct, deliberate steps.

## Affected surfaces
- [x] Monitor board / slack-operator (monitor-ui SPA only)
- [x] Docs / tests only (+ pure parser)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 798 pass / 83 files (+9: 6 parser, 3 composer)
- [x] `vite build` (monitor-ui) compiles — it ships in the image bundle
- [ ] compose config — n/a (no ops/Docker/compose touched)

## Rollout / rollback
Ships in the monitor-ui bundle (rebuild/redeploy the image to pick it up).
Purely additive — no behavior changes for `/mission`, `/mute`, or Ask-Hermes.
Rollback = revert. Depends on #266 (already merged) for the backend route.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — composer only *proposes*; approval + the worker's PR-only behavior are unchanged
- [x] No new ungated power — the worker's repo allow-list + approved-only claim still gate execution; this is just an enqueue affordance
- [x] No secrets committed/printed/logged
- [x] No agent-behavior doc change needed (no change to how agents run; this is an operator input surface into the existing queue)

## Known limits / follow-ups
- The composer proposes; **approval still happens via the existing path** (the action-flow approve, Codex's lane, or the API). A one-click approve on a `proposed` Claude card would round this out — separate, and deliberately gated.
- No autocomplete for the repo allow-list; the operator types `owner/repo`. A picker could come later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)