### PR TITLE
monitor: surface in-flight lanes + honest co-pilot empty state

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -24,10 +24,15 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
 
-  test("action mode expands five lanes; the other three are mini-rails", () => {
+  test("every lane that holds cards is expanded; only empty lanes stay mini-rails", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(5);
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(3);
+    // 7 of 8 lanes hold cards after grouping (the lone operator-review PR is an
+    // action card, promoted to needs-attention) → 7 expanded, 1 empty rail.
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(7);
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(1);
+    // drafts/codex-needed hold cards but aren't in the action preset — pre-fix
+    // they were hidden behind rails; now their card bodies render.
+    expect(within(container).getByText(/governance dispute UI/)).toBeTruthy();
   });
 
   test("renders the action card with its CTA and Hermes verdict", () => {
@@ -46,9 +51,19 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
   });
 
-  test("collapsed lanes hide their card bodies (drafts is a mini-rail)", () => {
-    const { container } = render(<BoardView board={richBoard} status="open" />);
-    expect(within(container).queryByText(/governance dispute UI/)).toBeNull();
+  test("a calm board still expands lanes holding in-flight cards (regression: action==0 used to hide all but Done)", () => {
+    const calm: MonitorBoard = {
+      at: "2026-05-28T10:30:00Z",
+      cards: FIXTURE_CARDS.filter((c) => c.type === "deploy" || c.type === "done"),
+    };
+    const { container } = render(<BoardView board={calm} status="open" />);
+    // No needs-attention card → calm tone.
+    expect(container.querySelector(".hm-now--calm")).toBeTruthy();
+    // The deploying lane (in-flight automation) is expanded and shows its body…
+    expect(within(container).getByText(/Post-merge verify/)).toBeTruthy();
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(2); // deploying + done
+    // …and the six empty lanes are mini-rails — not everything-but-Done collapsed.
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(6);
   });
 
   test("an open stream lights the LIVE indicator with the snapshot clock", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -54,6 +54,24 @@ function expandedForMode(mode: BoardMode): ReadonlySet<LaneId> {
   return ACTION_EXPANDED;
 }
 
+const ALL_LANES = LANES as readonly LaneId[];
+
+/** Lanes that currently hold at least one card. */
+function lanesWithCards(grouped: Partial<Record<LaneId, BoardCard[]>>): LaneId[] {
+  return ALL_LANES.filter((lane) => (grouped[lane]?.length ?? 0) > 0);
+}
+
+// A lane with cards is always shown — only empty lanes collapse to rails. The
+// mode preset just decides which EMPTY lanes stay open (e.g. Done as release
+// history). This is why a calm board with automation in flight still shows
+// those lanes' cards instead of hiding everything but Done.
+function expandedForBoard(
+  mode: BoardMode,
+  grouped: Partial<Record<LaneId, BoardCard[]>>,
+): Set<LaneId> {
+  return new Set<LaneId>([...expandedForMode(mode), ...lanesWithCards(grouped)]);
+}
+
 function matchesQuery(card: BoardCard, q: string): boolean {
   if (!q) return true;
   const hay = `${card.id} ${card.title} ${card.repo} ${card.branch ?? ""} ${card.summary ?? ""}`.toLowerCase();
@@ -128,17 +146,22 @@ export function BoardView({
     }
   }, [state.counts.action]);
 
-  // Controlled lane expansion: seed from the mode preset, re-apply when
-  // the board mode flips (e.g. empty→action as live data arrives), but
-  // keep manual toggles / spotlight within a stable mode.
-  const [expanded, setExpanded] = useState<ReadonlySet<LaneId>>(() => new Set(expandedForMode(state.mode)));
-  const modeRef = useRef(state.mode);
+  // Controlled lane expansion: seed so every lane WITH cards is open (plus the
+  // mode preset's empty lanes, e.g. Done). Re-seed when the mode flips OR the
+  // set of lanes-with-cards changes — so in-flight work that arrives while the
+  // board stays "calm" (action == 0) still surfaces instead of hiding behind a
+  // rail. Manual toggles / spotlight persist until the next such change.
+  const [expanded, setExpanded] = useState<ReadonlySet<LaneId>>(
+    () => expandedForBoard(state.mode, state.grouped),
+  );
+  const seedRef = useRef<string>("");
   useEffect(() => {
-    if (modeRef.current !== state.mode) {
-      modeRef.current = state.mode;
-      setExpanded(new Set(expandedForMode(state.mode)));
+    const sig = `${state.mode}|${lanesWithCards(state.grouped).join(",")}`;
+    if (seedRef.current !== sig) {
+      seedRef.current = sig;
+      setExpanded(expandedForBoard(state.mode, state.grouped));
     }
-  }, [state.mode]);
+  }, [state.mode, state.grouped]);
 
   // Search filters what's shown + focusable (not the KPI counts).
   const q = query.trim().toLowerCase();

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -29,7 +29,7 @@ describe("CoPilotRail", () => {
 
   test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
     const { getByText } = render(<CoPilotRail />, { wrapper });
-    expect(getByText("No board chatter yet.")).toBeTruthy();
+    expect(getByText(/Nothing asked yet/)).toBeTruthy();
   });
 
   test("the scope chip reflects the focused card", async () => {
@@ -51,7 +51,7 @@ describe("CoPilotRail", () => {
       <CoPilotRail focusedCard={card548} collaboration={{ fetcher, poster, refreshIntervalMs: 0 }} />,
       { wrapper },
     );
-    await waitFor(() => expect(within(container).getByText("No board chatter yet.")).toBeTruthy());
+    await waitFor(() => expect(within(container).getByText(/Nothing asked yet/)).toBeTruthy());
 
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     fireEvent.change(input, { target: { value: "what's blocking?" } });

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -59,14 +59,16 @@ export function CoPilotRail({
           <div className="hm-hermes-title">Hermes co-pilot</div>
           <div className="hm-hermes-sub">
             <span className="pulse" aria-hidden />
-            Live · narrating the board · context: {focusedCard?.id ?? "everywhere"}
+            Ask about any card · context: {focusedCard?.id ?? "whole board"}
           </div>
         </div>
       </div>
 
       <div className="hm-hermes-stream" ref={streamRef} aria-live="polite">
         {messages.length === 0 ? (
-          <div className="hm-lane-empty">No board chatter yet.</div>
+          <div className="hm-lane-empty">
+            Nothing asked yet. Ask Hermes about a card or the board below — replies show up here.
+          </div>
         ) : (
           messages.map((m) => <HermesTurn key={m.id} turn={m} />)
         )}


### PR DESCRIPTION
## What changed & why

Two truth-boundary fixes to what the board *shows*, both spotted on the live board.

### 1) In-flight lanes were hidden behind rails
`boardMode()` returns **"calm"** whenever `needs-attention == 0`, and calm seeded
expansion to `CALM_EXPANDED` (**only Done**). So a healthy board with 7 cards in
flight (operator-review, release-queue, deploying) but zero action items
collapsed every live lane to a rail and showed only the release history — the
operator couldn't see the work actually running. Worse, the seed only
re-applied on a mode **flip**, so a board that started empty (calm) and filled
with non-action cards (still calm) kept the Done-only seed *forever*.

**Fix:** a lane **with cards is always expanded**; only **empty** lanes collapse
to rails. The mode preset now only decides which *empty* lanes stay open (e.g.
Done as history). Re-seed when the mode flips **or** the set of lanes-with-cards
changes, so newly-arrived in-flight work surfaces. Manual toggles / keyboard
spotlight still persist until the next such change.

### 2) The co-pilot rail oversold itself
It read **"Live · narrating the board"** and **"No board chatter yet"** — implying
a proactive narration that doesn't exist. That feed only logs operator↔Hermes
**Q&A**. Reworded to "Ask about any card" + an empty state that says replies
appear once you ask. No behavior change; honest copy per the truth-boundary rule.

This is from the live-board review (alongside "PRs are starving of detail" — see
follow-ups: that's largely a *consequence* of #1, since the rich operator-review
/ deploying cards were the ones hidden).

## Affected surfaces
- [x] Monitor board / slack-operator (monitor-ui SPA only)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 789 pass / 83 files
- [x] `vite build` (monitor-ui) compiles
- [ ] compose config — n/a

## Rollout / rollback
Ships in the monitor-ui bundle (rebuild/redeploy to pick up). Pure
view-state + copy change; no data/contract change. Rollback = revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy; no agent-power change
- [x] No secrets
- [x] Truth-boundary: makes the board show *less* of a false "live narration" and *more* of the real in-flight state — both toward honesty
- [x] No AGENTS.md change (UI view behavior only)

## Known limits / follow-ups
- **"PRs starving of detail":** once in-flight lanes are visible, the rich cards (checks/files/risk/verdict) render. If a *live* card still looks thin, that's a backend-enrichment gap (monitor-v2 serializer / ingestion) — I can verify the live `/monitor/v2/board` payload next and chase any missing fields.
- **Done cards stay compact** by design (release history). If you want richer Done rows (merged-by, lane journey), that's a separate enrichment.
- **Real Hermes board narration** (proactive, not just Q&A) would be a backend/Hermes feature — flagged, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)