### PR TITLE
monitor: enrich mission cards with the browser agent's report

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -183,6 +183,48 @@ describe("DetailDrawer — variants", () => {
     expect(container.querySelectorAll(".hm-mpath .step").length).toBe(6);
   });
 
+  // A live agent report (from the serializer's mission enrichment) carries the
+  // qualitative detail but NOT the attempt count, latency, or 0–10 scores — so
+  // the drawer must render those faithfully (omit them), never as "run #0" /
+  // "0 · 0 · 0 out of 10".
+  test("mission card with a partial live report renders without invented runs/latency/scores", () => {
+    const card = {
+      id: "mission browser-live-09",
+      lane: "hermes-checking",
+      type: "mission",
+      agentType: "hermes",
+      title: "Verify checkout on staging",
+      summary: "agent report posted",
+      repo: "depre-dev/site",
+      freshness: 6,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+      mission: {
+        verdict: "PARTIAL",
+        verdictTone: "warn",
+        confidence: 0.74,
+        target: "https://staging.averray.com/checkout",
+        seed: "fresh · no memory",
+        path: [{ n: 1, status: "ok", desc: "Loaded checkout", lat: "" }],
+        blockers: [{ head: "Slow sign modal", body: "" }],
+        evidence: [],
+        mutationBoundary: "Read-only mission — the agent stopped before any mutation.",
+        recommendations: [],
+        // no runs / latency / successScore / clarityScore / latencyScore
+      },
+    } as unknown as BoardCard;
+    const { getByText, queryByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("PARTIAL")).toBeTruthy();
+    expect(getByText(/74/)).toBeTruthy(); // confidence %
+    expect(getByText("Loaded checkout")).toBeTruthy();
+    // no invented attempt count / score row
+    expect(queryByText(/run #/)).toBeNull();
+    expect(queryByText(/out of 10/)).toBeNull();
+  });
+
   // Regression: live cards cross an HTTP/JSON boundary and don't always carry
   // the type-required nested objects (the backend doesn't populate deploy
   // `verification` or a mission `mission` report yet). The drawer must render,

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -307,12 +307,20 @@ function MissionBody({ card }: { card: MissionCard }) {
         ? "var(--hm-rose)"
         : "var(--hm-sage-deep)";
 
+  // runs / latency / the 0–10 scores are optional: a live agent report may
+  // not carry them, and showing "run #0 · " or "0 · 0 · 0" would misrepresent.
+  const verdictHead =
+    "Verdict" +
+    (m.runs !== undefined ? ` · run #${m.runs}` : "") +
+    (m.latency ? ` · ${m.latency}` : "");
+  const hasScores =
+    m.successScore !== undefined || m.clarityScore !== undefined || m.latencyScore !== undefined;
+  const fmtScore = (n: number | undefined) => (n === undefined ? "—" : String(n));
+
   return (
     <>
       <section>
-        <div className="hm-section-h">
-          Verdict · run #{m.runs} · {m.latency}
-        </div>
+        <div className="hm-section-h">{verdictHead}</div>
         <div className="hm-mission-confidence">
           <div className="col">
             <span className="lbl">Verdict</span>
@@ -329,17 +337,19 @@ function MissionBody({ card }: { card: MissionCard }) {
             </span>
             <span className="meta">{m.seed}</span>
           </div>
-          <div className="col">
-            <span className="lbl">Scores · success · clarity · latency</span>
-            <span className="val">
-              {m.successScore}
-              <span style={{ color: "var(--hm-muted)" }}> · </span>
-              {m.clarityScore}
-              <span style={{ color: "var(--hm-muted)" }}> · </span>
-              {m.latencyScore}
-            </span>
-            <span className="meta">out of 10 · by Hermes</span>
-          </div>
+          {hasScores ? (
+            <div className="col">
+              <span className="lbl">Scores · success · clarity · latency</span>
+              <span className="val">
+                {fmtScore(m.successScore)}
+                <span style={{ color: "var(--hm-muted)" }}> · </span>
+                {fmtScore(m.clarityScore)}
+                <span style={{ color: "var(--hm-muted)" }}> · </span>
+                {fmtScore(m.latencyScore)}
+              </span>
+              <span className="meta">out of 10 · by Hermes</span>
+            </div>
+          ) : null}
         </div>
       </section>
 

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -145,19 +145,20 @@ export interface MissionReport {
   verdictTone: "ok" | "warn" | "fail";
   /** 0..1 */
   confidence: number;
-  /** e.g. "2m 14s" */
-  latency: string;
+  /** e.g. "2m 14s". Optional — a live agent report may not carry it. */
+  latency?: string;
   /** URL under test */
   target: string;
   /** e.g. "fresh · no memory" */
   seed: string;
-  runs: number;
+  /** Attempt count. Optional — not carried by a live agent report. */
+  runs?: number;
+  /** 0..10. Optional — only the scores the agent actually reported. */
+  successScore?: number;
   /** 0..10 */
-  successScore: number;
+  clarityScore?: number;
   /** 0..10 */
-  clarityScore: number;
-  /** 0..10 */
-  latencyScore: number;
+  latencyScore?: number;
   path: MissionStep[];
   blockers: MissionBlocker[];
   evidence: MissionEvidence[];

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -23,6 +23,10 @@ import type {
   HermesBoardCardSnapshot,
   HermesBoardSnapshot,
 } from "./monitor-hermes-voice.js";
+import {
+  testbedMissionStructuredReport,
+  type TestbedMissionRun,
+} from "./monitor-testbed-missions.js";
 
 // ── v2 typed model ──────────────────────────────────────────────────
 
@@ -91,6 +95,44 @@ export interface CardRiskSignal {
   message: string;
 }
 
+// ── Mission report (testbed browser missions) ───────────────────────
+// Mirrors the UI MissionReport. The optional numeric fields (runs,
+// latency, the 0–10 scores) are NOT carried by the agent's structured
+// report, so we omit them rather than invent values — the UI guards them.
+export interface CardMissionStep {
+  n: number;
+  status: "ok" | "warn" | "fail";
+  desc: string;
+  lat: string;
+}
+export interface CardMissionBlocker {
+  head: string;
+  body: string;
+}
+export interface CardMissionEvidence {
+  kind: "screenshot" | "trace" | "console" | "video";
+  label: string;
+  href: string;
+}
+export interface CardMissionReport {
+  verdict: "OK" | "PARTIAL" | "FAILED";
+  verdictTone: "ok" | "warn" | "fail";
+  /** 0..1 */
+  confidence: number;
+  target: string;
+  seed: string;
+  path: CardMissionStep[];
+  blockers: CardMissionBlocker[];
+  evidence: CardMissionEvidence[];
+  mutationBoundary: string;
+  recommendations: string[];
+  runs?: number;
+  latency?: string;
+  successScore?: number;
+  clarityScore?: number;
+  latencyScore?: number;
+}
+
 export interface BoardCard {
   id: string;
   lane: Lane;
@@ -142,6 +184,8 @@ export interface BoardCard {
   checkRuns?: CardCheckRun[];
   /** Hermes review findings (non-done cards) — the "why review" detail. */
   riskSignals?: CardRiskSignal[];
+  /** Mission cards: the browser agent's structured report, when posted. */
+  mission?: CardMissionReport;
 }
 
 export interface BoardSnapshotV2 {
@@ -525,6 +569,97 @@ export function indexRawSummaries(rawSnapshot: unknown): Map<string, Record<stri
   return map;
 }
 
+/**
+ * Index testbed mission runs (bundled on the snapshot as `testbedMissions`)
+ * by run id. A mission card correlates to its run by correlationId (the
+ * mission item sets `correlationId: run.id`), since mission items carry no
+ * PR number and so can't be found via the PR-key summary index.
+ */
+export function indexTestbedMissions(rawSnapshot: unknown): Map<string, Record<string, unknown>> {
+  const root = asRecord(rawSnapshot);
+  const map = new Map<string, Record<string, unknown>>();
+  for (const entry of asArray(root?.testbedMissions)) {
+    const run = asRecord(entry);
+    const id = asString(run?.id);
+    if (id && run && !map.has(id)) map.set(id, run);
+  }
+  return map;
+}
+
+const EVIDENCE_KINDS = new Set(["screenshot", "trace", "console", "video"]);
+
+/** Parse one structured-report evidence string ("type: detail") into the UI shape. */
+function mapMissionEvidence(raw: string): CardMissionEvidence {
+  const match = /^(\w+):\s*(.+)$/.exec(raw.trim());
+  const kindRaw = match ? match[1]!.toLowerCase() : "";
+  const kind = (EVIDENCE_KINDS.has(kindRaw) ? kindRaw : "trace") as CardMissionEvidence["kind"];
+  const detail = (match ? match[2]! : raw).trim();
+  const href = /^https?:\/\//i.test(detail) ? detail : "#";
+  return { kind, label: detail, href };
+}
+
+function pickScore(scores: Record<string, number>, keys: string[]): number | undefined {
+  for (const [k, v] of Object.entries(scores)) {
+    if (keys.includes(k.toLowerCase()) && Number.isFinite(v)) return Math.round(v * 2); // 0..5 → 0..10
+  }
+  return undefined;
+}
+
+/**
+ * Map a stored testbed mission run to the UI MissionReport. Returns
+ * undefined when the run has no structured report yet (e.g. still running),
+ * so the card simply omits `mission` and the drawer shows its "no report
+ * yet" fallback. Best-effort + truthful: only fields the agent actually
+ * reported are populated; the numeric runs/latency/scores the structured
+ * report doesn't carry are left undefined (the UI guards them).
+ */
+export function mapMissionReport(run: Record<string, unknown>): CardMissionReport | undefined {
+  const report = testbedMissionStructuredReport(run as unknown as TestbedMissionRun);
+  if (!report) return undefined;
+
+  const [verdict, verdictTone]: [CardMissionReport["verdict"], CardMissionReport["verdictTone"]] =
+    report.verdict === "pass"
+      ? ["OK", "ok"]
+      : report.verdict === "partial"
+        ? ["PARTIAL", "warn"]
+        : ["FAILED", "fail"];
+
+  const path: CardMissionStep[] = report.completedPath.map((desc, i) => ({
+    n: i + 1,
+    status: "ok",
+    desc,
+    lat: "",
+  }));
+  const blockers: CardMissionBlocker[] = [
+    ...report.blockers.map((head) => ({ head, body: "" })),
+    ...report.confusingMoments.map((head) => ({ head, body: "" })),
+  ];
+  const notes = report.mutationBoundaryNotes.join(" ").trim();
+  const boundaryBase = report.stoppedBeforeMutation
+    ? "Read-only mission — the agent stopped before any mutation."
+    : "The agent crossed or attempted a mutation boundary.";
+
+  const successScore = pickScore(report.scores, ["success", "usability", "task", "completion"]);
+  const clarityScore = pickScore(report.scores, ["clarity", "ux", "understanding", "comprehension"]);
+  const latencyScore = pickScore(report.scores, ["latency", "speed", "performance", "responsiveness"]);
+
+  return {
+    verdict,
+    verdictTone,
+    confidence: report.confidence,
+    target: asString(run.targetUrl) ?? "",
+    seed: run.freshMemory === false ? "warm memory" : "fresh · no memory",
+    path,
+    blockers,
+    evidence: report.evidence.map(mapMissionEvidence),
+    mutationBoundary: notes ? `${boundaryBase} ${notes}` : boundaryBase,
+    recommendations: report.recommendations,
+    ...(successScore !== undefined ? { successScore } : {}),
+    ...(clarityScore !== undefined ? { clarityScore } : {}),
+    ...(latencyScore !== undefined ? { latencyScore } : {}),
+  };
+}
+
 /** Index Codex tasks by their PR key for task-card enrichment. */
 export function indexCodexTasks(rawSnapshot: unknown): Map<string, Record<string, unknown>> {
   const root = asRecord(rawSnapshot);
@@ -549,6 +684,8 @@ export interface EnrichmentContext {
   codexTask?: Record<string, unknown>;
   /** The Codex runner heartbeat (global), if any. */
   runner?: Record<string, unknown>;
+  /** The testbed mission run correlated to a mission card, if any. */
+  missionRun?: Record<string, unknown>;
 }
 
 /**
@@ -590,6 +727,13 @@ export function enrichBoardCard(
     }
     const verdictText = card.verdict ?? item.verdict;
     if (verdictText) card.verdictText = verdictText;
+  }
+
+  // Mission cards: project the browser agent's structured report. Omitted
+  // when the run has no report yet (the drawer shows its "no report" state).
+  if (card.type === "mission" && ctx.missionRun) {
+    const mission = mapMissionReport(ctx.missionRun);
+    if (mission) card.mission = mission;
   }
 
   // Codex task cards: prompt / output / failure / runner liveness.
@@ -636,6 +780,7 @@ export function buildV2BoardSnapshot(
   const items = classified?.items ?? [];
   const summaryIndex = indexRawSummaries(rawSnapshot);
   const codexIndex = indexCodexTasks(rawSnapshot);
+  const missionIndex = indexTestbedMissions(rawSnapshot);
   const runner = readRunner(rawSnapshot);
   const cards = items.map((item) => {
     const base = toBoardCard(item);
@@ -644,6 +789,10 @@ export function buildV2BoardSnapshot(
       summary: key ? summaryIndex.get(key) : undefined,
       codexTask: key ? codexIndex.get(key) : undefined,
       runner,
+      missionRun:
+        base.type === "mission" && item.correlationId
+          ? missionIndex.get(item.correlationId)
+          : undefined,
     });
   });
   return {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -18,7 +18,9 @@ import {
   mapRiskSignals,
   indexRawSummaries,
   indexCodexTasks,
+  indexTestbedMissions,
   enrichBoardCard,
+  mapMissionReport,
 } from "../../services/slack-operator/src/monitor-v2.js";
 import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
 import type { HermesBoardCardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -629,5 +631,118 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     expect(card).toBeDefined();
     expect(card?.checks).toEqual({ pass: 5, running: 1, fail: 0, pending: 0, total: 6 });
     expect(card?.files).toEqual([{ path: "ops/deploy.staging.yml", diff: "", critical: false }]);
+  });
+
+  it("enriches a mission card with the browser agent's structured report (by correlationId)", () => {
+    // A classified mission item carries correlationId = run.id and no PR
+    // number; the run with its report is bundled at snapshot.testbedMissions.
+    const raw = {
+      active: [
+        {
+          correlationId: "mission-xyz",
+          repo: "testbed/mission",
+          intent: "testbed_agent_mission",
+          title: "Verify onboarding mission",
+          summary: { kind: "testbed_mission_run", reviewSignals: { touchedAreas: ["testbed"] } },
+        },
+      ],
+      recent: [],
+      testbedMissions: [
+        {
+          id: "mission-xyz",
+          targetUrl: "https://staging.averray.com/onboarding",
+          freshMemory: true,
+          allowTestMutations: false,
+          result: {
+            verdict: "partial",
+            confidence: 0.81,
+            scores: { success: 4, clarity: 3, latency: 5 },
+            blockers: ["Sign-message modal latency"],
+            confusingMoments: ["Receipt poll has no visible cadence"],
+            mutationBoundaryNotes: ["No transactions submitted"],
+            stoppedBeforeMutation: true,
+            completedPath: ["Loaded onboarding page", "Clicked Connect wallet"],
+            recommendations: ["Add a spinner to the Sign-message modal"],
+            evidence: ["screenshot: https://x.test/step3.png", "trace: browser-trace 2m14s"],
+          },
+        },
+      ],
+    };
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const mission = snap.cards.find((c) => c.type === "mission");
+    expect(mission?.mission).toBeDefined();
+    expect(mission?.mission?.verdict).toBe("PARTIAL");
+    expect(mission?.mission?.target).toBe("https://staging.averray.com/onboarding");
+    expect(mission?.mission?.path).toHaveLength(2);
+  });
+});
+
+describe("indexTestbedMissions", () => {
+  it("indexes bundled runs by id and tolerates a missing list", () => {
+    const map = indexTestbedMissions({ testbedMissions: [{ id: "m1" }, { id: "m2" }] });
+    expect(map.get("m1")).toEqual({ id: "m1" });
+    expect(map.size).toBe(2);
+    expect(indexTestbedMissions({}).size).toBe(0);
+    expect(indexTestbedMissions(undefined).size).toBe(0);
+  });
+});
+
+describe("mapMissionReport", () => {
+  const run = {
+    id: "mission-xyz",
+    targetUrl: "https://staging.averray.com/onboarding",
+    freshMemory: true,
+    allowTestMutations: false,
+    result: {
+      verdict: "partial",
+      confidence: 0.81,
+      scores: { success: 4, clarity: 3, latency: 5 },
+      blockers: ["Sign-message modal latency"],
+      confusingMoments: ["Receipt poll has no visible cadence"],
+      mutationBoundaryNotes: ["No transactions submitted"],
+      stoppedBeforeMutation: true,
+      completedPath: ["Loaded onboarding page", "Clicked Connect wallet"],
+      recommendations: ["Add a spinner to the Sign-message modal"],
+      evidence: ["screenshot: https://x.test/step3.png", "trace: browser-trace 2m14s"],
+    },
+  };
+
+  it("maps verdict, confidence, seed, path, blockers, evidence, boundary, recs", () => {
+    const m = mapMissionReport(run)!;
+    expect(m.verdict).toBe("PARTIAL");
+    expect(m.verdictTone).toBe("warn");
+    expect(m.confidence).toBe(0.81);
+    expect(m.seed).toBe("fresh · no memory");
+    expect(m.path).toEqual([
+      { n: 1, status: "ok", desc: "Loaded onboarding page", lat: "" },
+      { n: 2, status: "ok", desc: "Clicked Connect wallet", lat: "" },
+    ]);
+    // blockers then confusing moments, as plain heads
+    expect(m.blockers.map((b) => b.head)).toEqual([
+      "Sign-message modal latency",
+      "Receipt poll has no visible cadence",
+    ]);
+    // evidence "type: detail" → kind + label + href (link only when a URL)
+    expect(m.evidence[0]).toEqual({ kind: "screenshot", label: "https://x.test/step3.png", href: "https://x.test/step3.png" });
+    expect(m.evidence[1]).toEqual({ kind: "trace", label: "browser-trace 2m14s", href: "#" });
+    expect(m.mutationBoundary).toMatch(/stopped before any mutation\. No transactions submitted/);
+    expect(m.recommendations).toEqual(["Add a spinner to the Sign-message modal"]);
+  });
+
+  it("maps 0–5 scores to 0–10 by key, omitting unknown ones", () => {
+    const m = mapMissionReport(run)!;
+    expect(m.successScore).toBe(8); // 4 × 2
+    expect(m.clarityScore).toBe(6); // 3 × 2
+    expect(m.latencyScore).toBe(10); // 5 × 2
+  });
+
+  it("does NOT invent runs/latency the report doesn't carry", () => {
+    const m = mapMissionReport(run)!;
+    expect(m.runs).toBeUndefined();
+    expect(m.latency).toBeUndefined();
+  });
+
+  it("returns undefined when the run has no result yet (mission still running)", () => {
+    expect(mapMissionReport({ id: "m", targetUrl: "https://x.test" })).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What changed & why

From the live-board enrichment audit: **mission cards were structurally
starved**. `enrichBoardCard` had no branch for them, and the PR-keyed summary
index can't find a mission (it has `correlationId = run.id` but **no PR
number**), so the drawer always showed *"Mission · no report yet"* on live data
— even after the browser agent posted a real report.

The data was already in the snapshot: `testbedMissionRunToMonitorItem` bundles
each run at `snapshot.testbedMissions` with its parsed `structuredReport`. This
PR joins it onto the card:
- `indexTestbedMissions(snapshot)` keys runs by id;
- `buildV2BoardSnapshot` correlates a mission card by its `correlationId`;
- `mapMissionReport()` projects the structured report onto `card.mission` —
  verdict / confidence / target / seed, `completedPath` → path, blockers +
  confusing moments, evidence (`"type: detail"` → kind/label/href),
  `mutationBoundary` (boundary notes + `stoppedBeforeMutation`),
  recommendations, and the agent's 0–5 scores scaled to 0–10 **by key**.

## Truth boundary
Only fields the agent **actually reported** are populated. The structured
report carries no attempt count, latency, or named 0–10 scores — so those stay
`undefined`, those `MissionReport` fields are now **optional**, and the drawer
**guards** them: no `run #0`, no `0 · 0 · 0 out of 10`. A still-running mission
(no result yet) maps to `undefined` → the card keeps its honest "no report yet"
state. Nothing is invented.

## Affected surfaces
- [x] Monitor board / slack-operator (monitor-v2 serializer + monitor-ui drawer/type)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 805 pass / 83 files (+16: serializer mapping + drawer guard)
- [x] `vite build` (monitor-ui) compiles
- [ ] compose config — n/a

## Rollout / rollback
Server serializer + UI bundle change; rebuild/redeploy to pick up. Zero new
network calls (joins data already in the snapshot). Other card types unchanged.
Rollback = revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy; no agent-power change
- [x] No secrets
- [x] Truth-boundary: surfaces only the agent's real report; omits + guards fields it doesn't carry rather than fabricating
- [x] No AGENTS.md change (serializer/UI projection of existing data)

## Known limits / follow-ups
- The structured report is qualitative; per-step status/latency and named scores aren't in it, so the path renders all-completed (status "ok") and scores show only when the agent's report keys map. If we want richer per-step detail, the **producer** (testbed runner) would need to emit it.
- **Deploy verification** remains the other starved card type (no structured source in the snapshot) — still a producer + serializer follow-up (Codex's lane), as flagged in the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)