### PR TITLE
monitor: deploy cards never wait on branch protection (post-merge → CI)

### DIFF
--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -375,7 +375,14 @@ export function toBoardCard(item: HermesBoardCardSnapshot): BoardCard {
   const type = inferCardType(item, lane);
   const isAction = lane === "needs-attention";
   const isDraft = lane === "drafts";
-  const waitingOn = mapOwnerToWaitingOn(item.owner, isAction);
+  let waitingOn = mapOwnerToWaitingOn(item.owner, isAction);
+  // A deploy card is post-merge (verifying the deploy), so it can never be
+  // waiting on branch protection — that owner label is a pre-merge artifact
+  // from the producer. Correct it to CI (the post-merge verification it
+  // actually awaits). Other owners (operator / agent) are left untouched.
+  if (type === "deploy" && waitingOn.actor === "branch-protection") {
+    waitingOn = { actor: "CI", tone: "info" };
+  }
 
   const card: BoardCard = {
     id: cardId(item),

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -271,6 +271,22 @@ describe("toBoardCard", () => {
     expect(card.type).toBe("draft");
   });
 
+  it("corrects a deploy card's waiting-on: branch-protection (pre-merge) → CI (post-merge verify)", () => {
+    const card = toBoardCard(slim({
+      lane: "Deploying",
+      owner: "Merge steward", // would map to branch-protection
+      title: "post-production-deploy verification after workflow run",
+    }));
+    expect(card.type).toBe("deploy");
+    expect(card.waitingOn).toEqual({ actor: "CI", tone: "info" });
+  });
+
+  it("leaves a non-deploy branch-protection waiting-on untouched (release-queue still awaits branch protection)", () => {
+    const card = toBoardCard(slim({ lane: "Release Queue", owner: "Merge steward" }));
+    expect(card.type).toBe("pr");
+    expect(card.waitingOn).toEqual({ actor: "branch-protection", tone: "neutral" });
+  });
+
   it("classifies a testbed mission card", () => {
     const card = toBoardCard(slim({
       lane: "Hermes Checking",


### PR DESCRIPTION
## What changed & why

Live deploy cards showed **`WAITING ON → BRANCH-PROTECTION`**, which is provably
wrong: a card in the **Deploying** lane is *post-merge* (verifying the deploy),
so it can't be awaiting a pre-merge branch-protection gate. The label comes from
the producer's "merge steward" owner flowing through `mapOwnerToWaitingOn`.

**Serializer fix (my lane):** in `toBoardCard`, when a **deploy-type** card's
owner-derived waiting-on is `branch-protection`, correct it to **`CI`** — the
post-merge verification it actually awaits. Other owners (operator / agent) are
left untouched, and non-deploy cards (e.g. release-queue) still legitimately
await branch protection.

This is the **serializer slice** of the Deploying-lane cleanup spotted on the
live board.

## Affected surfaces
- [x] Monitor board / slack-operator (monitor-v2 serializer)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 807 pass / 83 files (+2)
- [ ] compose config — n/a

## Rollout / rollback
Server serializer change; rebuild/redeploy to pick up. Pure label correction,
no data/contract change. Rollback = revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy; no agent-power change
- [x] No secrets
- [x] Truth-boundary: removes a provably-wrong "branch-protection" label; "CI" is the post-merge gate the deploy card actually awaits — no fabrication
- [x] No AGENTS.md change

## Codex handoff — the producer side of the Deploying lane
The remaining deploy-card issues root in the deploy **producer** (`monitor.ts`
ingestion / deploy-card emission — Codex's lane). To fully fix the lane:

1. **Verification progress + deployId.** Emit structured verification on the
   deploy item summary (e.g. `{ current, total, label }` + a `deployId`/workflow
   run id). The serializer's `enrichBoardCard` can then project it onto
   `card.verification` / `card.deployId` (the UI `DeployBody` already renders a
   progress bar when present — today it's omitted because the source data isn't
   there). I'll wire the serializer projection as soon as the field exists.
2. **Distinct titles.** Every card reads *"post-production-deploy verification
   after workflow run"*. Include the deploy target / PR # / commit so they're
   tellable apart.
3. **Pile-up / dedup.** Three near-identical cards stack up. Either coalesce
   completed-and-healthy verifications into one (with a count) or age them out
   of the Deploying lane once `post_deploy_healthy`.
4. **Owner accuracy.** Set the deploy item's owner to the real awaited actor
   (relay/indexer/CI) so this serializer correction becomes unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)