### PR TITLE
O3: board-driven dispatch — surface, create, and approve tasks from the board

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -26,6 +26,7 @@ import { useCardParam } from "./hooks/useCardParam.js";
 import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
+import type { CreateTaskInput } from "./lib/monitor/card-types.js";
 import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
@@ -39,6 +40,10 @@ export interface MonitorPageProps {
   onSpawnMission?: (url: string) => void;
   /** Override the /claude propose (defaults to POST /monitor/codex-tasks). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
+  /** Override the create-task dispatch (defaults to POST /monitor/codex-tasks propose). */
+  onCreateTask?: (input: CreateTaskInput) => void;
+  /** Override the approve dispatch (defaults to POST /monitor/codex-tasks approve). */
+  onApproveTask?: (id: string) => void;
   /** Override the co-pilot collaboration wiring (defaults to live polling). */
   collaboration?: UseCollaborationOptions;
   /** Override the action-alert wiring (audio/notification/storage) for tests. */
@@ -49,6 +54,8 @@ export function MonitorPage({
   options,
   onSpawnMission = defaultSpawnMission,
   onSpawnClaudeTask = defaultSpawnClaudeTask,
+  onCreateTask = defaultCreateTask,
+  onApproveTask = defaultApproveTask,
   collaboration = {},
   alerts,
 }: MonitorPageProps = {}) {
@@ -71,6 +78,8 @@ export function MonitorPage({
         onCardNavigate={setCard}
         onSpawnMission={onSpawnMission}
         onSpawnClaudeTask={onSpawnClaudeTask}
+        onCreateTask={onCreateTask}
+        onApproveTask={onApproveTask}
         collaboration={collaboration}
         onMute={mute}
         onUnmute={unmute}
@@ -110,6 +119,39 @@ function defaultSpawnClaudeTask(repo: string, prompt: string): void {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ action: "propose", agent: "claude", repo, prompt }),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+/**
+ * Propose a task (O3 board dispatch). POSTs `{ action: "propose", agent, repo,
+ * prompt, pullRequestNumber? }` to /monitor/codex-tasks. Like /claude it only
+ * PROPOSES — the task lands `proposed` in codex-needed and the operator must
+ * approve before any runner claims it. Fire-and-forget; the board feed drives
+ * the UI.
+ */
+function defaultCreateTask(input: CreateTaskInput): void {
+  void fetch(CODEX_TASKS_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "propose", ...input }),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+/**
+ * Approve a proposed task — the human gate (proposed → approved). POSTs
+ * `{ action: "approve", id }`. Only the operator triggers this; never
+ * auto-approved. The runner claims it after approval and the board feed
+ * reflects the lifecycle.
+ */
+function defaultApproveTask(id: string): void {
+  void fetch(CODEX_TASKS_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ action: "approve", id }),
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
   });

--- a/packages/monitor-ui/src/components/Board.tsx
+++ b/packages/monitor-ui/src/components/Board.tsx
@@ -61,6 +61,8 @@ export type BoardProps = {
   onToggleLane?: (id: LaneId) => void;
   /** Optional renderer for a single card. M4' supplies the card components. */
   renderCard?: (card: BoardCard) => ReactNode;
+  /** Optional per-lane header content (e.g. the codex-needed create form, O3). */
+  renderLaneHeader?: (id: LaneId) => ReactNode;
 };
 
 export function Board({
@@ -69,6 +71,7 @@ export function Board({
   expanded: controlledExpanded,
   onToggleLane,
   renderCard,
+  renderLaneHeader,
 }: BoardProps) {
   const [internalExpanded, setInternalExpanded] = useState<Set<LaneId>>(() => new Set(initialExpanded));
   const isControlled = controlledExpanded !== undefined;
@@ -96,7 +99,14 @@ export function Board({
         const cards = grouped[lane.id] ?? [];
         const isExpanded = expanded.has(lane.id);
         return (
-          <Lane key={lane.id} lane={lane} expanded={isExpanded} count={cards.length} onToggle={onToggle}>
+          <Lane
+            key={lane.id}
+            lane={lane}
+            expanded={isExpanded}
+            count={cards.length}
+            onToggle={onToggle}
+            headerAccessory={renderLaneHeader?.(lane.id)}
+          >
             {renderCard ? cards.map(renderCard) : null}
           </Lane>
         );

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -21,7 +21,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
 import type { MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
-import { LANES, type BoardCard } from "../lib/monitor/card-types.js";
+import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
+import { CreateTaskForm } from "./CreateTaskForm.js";
 import { laneFor } from "../lib/monitor/lane-rules.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
@@ -68,8 +69,9 @@ function lanesWithCards(grouped: Partial<Record<LaneId, BoardCard[]>>): LaneId[]
 function expandedForBoard(
   mode: BoardMode,
   grouped: Partial<Record<LaneId, BoardCard[]>>,
+  alwaysOpen: readonly LaneId[] = [],
 ): Set<LaneId> {
-  return new Set<LaneId>([...expandedForMode(mode), ...lanesWithCards(grouped)]);
+  return new Set<LaneId>([...expandedForMode(mode), ...lanesWithCards(grouped), ...alwaysOpen]);
 }
 
 function matchesQuery(card: BoardCard, q: string): boolean {
@@ -91,6 +93,10 @@ export interface BoardViewProps {
   onSpawnMission?: (url: string) => void;
   /** Propose a greenfield Claude task (/claude <repo> <task>). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
+  /** Propose a task — /task verb + the codex-needed create form (O3). */
+  onCreateTask?: (input: CreateTaskInput) => void;
+  /** Approve a proposed task card — the operator human gate (O3). */
+  onApproveTask?: (id: string) => void;
   collaboration?: UseCollaborationOptions;
   onMute?: (untilMs: number) => void;
   onUnmute?: () => void;
@@ -109,6 +115,8 @@ export function BoardView({
   onCardNavigate,
   onSpawnMission,
   onSpawnClaudeTask,
+  onCreateTask,
+  onApproveTask,
   collaboration,
   onMute,
   onUnmute,
@@ -116,6 +124,9 @@ export function BoardView({
   keyboard = true,
 }: BoardViewProps) {
   const degraded = status === "reconnecting" || status === "closed";
+  // Keep the dispatch lane (codex-needed) open when its create form is wired,
+  // so the operator can propose the first task even when the lane is empty.
+  const alwaysOpen: readonly LaneId[] = onCreateTask ? ["codex-needed"] : [];
   const streamOnline = !degraded;
   const cards = board?.cards ?? [];
   const liveLabel = useMemo(() => formatClock(board?.at), [board?.at]);
@@ -155,16 +166,17 @@ export function BoardView({
   // board stays "calm" (action == 0) still surfaces instead of hiding behind a
   // rail. Manual toggles / spotlight persist until the next such change.
   const [expanded, setExpanded] = useState<ReadonlySet<LaneId>>(
-    () => expandedForBoard(state.mode, state.grouped),
+    () => expandedForBoard(state.mode, state.grouped, alwaysOpen),
   );
   const seedRef = useRef<string>("");
   useEffect(() => {
-    const sig = `${state.mode}|${lanesWithCards(state.grouped).join(",")}`;
+    const sig = `${state.mode}|${lanesWithCards(state.grouped).join(",")}|${alwaysOpen.join(",")}`;
     if (seedRef.current !== sig) {
       seedRef.current = sig;
-      setExpanded(expandedForBoard(state.mode, state.grouped));
+      setExpanded(expandedForBoard(state.mode, state.grouped, alwaysOpen));
     }
-  }, [state.mode, state.grouped]);
+    // alwaysOpen is derived from the stable onCreateTask prop.
+  }, [state.mode, state.grouped, onCreateTask]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Search filters what's shown + focusable (not the KPI counts).
   const q = query.trim().toLowerCase();
@@ -261,12 +273,18 @@ export function BoardView({
             grouped={displayGrouped}
             expanded={expanded}
             onToggleLane={onToggleLane}
+            renderLaneHeader={
+              onCreateTask
+                ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
+                : undefined
+            }
             renderCard={(card) => (
               <CardRouter
                 key={card.id}
                 card={card}
                 focused={card.id === boardFocusId}
                 onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
+                onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
               />
             )}
           />
@@ -275,6 +293,7 @@ export function BoardView({
         <CoPilotRail
           onSpawnMission={onSpawnMission}
           onSpawnClaudeTask={onSpawnClaudeTask}
+          onCreateTask={onCreateTask}
           focusedCard={scopeCard}
           collaboration={collaboration}
           onMute={onMute}

--- a/packages/monitor-ui/src/components/CreateTaskForm.test.tsx
+++ b/packages/monitor-ui/src/components/CreateTaskForm.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { CreateTaskForm } from "./CreateTaskForm.js";
+
+afterEach(cleanup);
+
+function fields(container: HTMLElement) {
+  return {
+    agent: within(container).getByLabelText("Agent") as HTMLSelectElement,
+    repo: within(container).getByLabelText("Repository (owner/repo)") as HTMLInputElement,
+    prompt: within(container).getByLabelText("Task prompt") as HTMLTextAreaElement,
+    submit: within(container).getByRole("button", { name: /Propose task/ }),
+  };
+}
+
+describe("CreateTaskForm (O3 board dispatch)", () => {
+  test("renders nothing when no handler is wired", () => {
+    const { container } = render(<CreateTaskForm />);
+    expect(container.querySelector("form")).toBeNull();
+  });
+
+  test("a valid submission posts { agent, repo, prompt } and clears the inputs", () => {
+    const onCreate = vi.fn();
+    const { container } = render(<CreateTaskForm onCreate={onCreate} />);
+    const f = fields(container);
+    fireEvent.change(f.agent, { target: { value: "claude" } });
+    fireEvent.change(f.repo, { target: { value: "averray-agent/agent" } });
+    fireEvent.change(f.prompt, { target: { value: "Add a HEALTHCHECK.md" } });
+    fireEvent.click(f.submit);
+    expect(onCreate).toHaveBeenCalledWith({
+      agent: "claude",
+      repo: "averray-agent/agent",
+      prompt: "Add a HEALTHCHECK.md",
+    });
+    expect(f.repo.value).toBe("");
+    expect(f.prompt.value).toBe("");
+  });
+
+  test("can propose a codex task via the agent select", () => {
+    const onCreate = vi.fn();
+    const { container } = render(<CreateTaskForm onCreate={onCreate} />);
+    const f = fields(container);
+    fireEvent.change(f.agent, { target: { value: "codex" } });
+    fireEvent.change(f.repo, { target: { value: "a/b" } });
+    fireEvent.change(f.prompt, { target: { value: "x" } });
+    fireEvent.click(f.submit);
+    expect(onCreate).toHaveBeenCalledWith({ agent: "codex", repo: "a/b", prompt: "x" });
+  });
+
+  test("a malformed repo blocks submit with an error", () => {
+    const onCreate = vi.fn();
+    const { container } = render(<CreateTaskForm onCreate={onCreate} />);
+    const f = fields(container);
+    fireEvent.change(f.repo, { target: { value: "not-a-repo" } });
+    fireEvent.change(f.prompt, { target: { value: "x" } });
+    fireEvent.click(f.submit);
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(within(container).getByRole("alert").textContent).toMatch(/valid owner\/repo/i);
+  });
+
+  test("an empty prompt blocks submit with an error", () => {
+    const onCreate = vi.fn();
+    const { container } = render(<CreateTaskForm onCreate={onCreate} />);
+    const f = fields(container);
+    fireEvent.change(f.repo, { target: { value: "a/b" } });
+    fireEvent.click(f.submit);
+    expect(onCreate).not.toHaveBeenCalled();
+    expect(within(container).getByRole("alert").textContent).toMatch(/prompt/i);
+  });
+});

--- a/packages/monitor-ui/src/components/CreateTaskForm.tsx
+++ b/packages/monitor-ui/src/components/CreateTaskForm.tsx
@@ -1,0 +1,96 @@
+// Hermes Handoff Monitor — create-task form (O3 board dispatch)
+//
+// The codex-needed lane's create affordance: pick an agent, a repo, and a
+// prompt, and propose a task from the board. It only PROPOSES — the task
+// lands `proposed` and the operator still approves it (on the card) before
+// any runner claims it. The board feed, not this form, drives the result.
+
+import { useState } from "react";
+import type { CreateTaskInput } from "../lib/monitor/card-types.js";
+
+const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+
+export function CreateTaskForm({ onCreate }: { onCreate?: (input: CreateTaskInput) => void }) {
+  const [agent, setAgent] = useState<"codex" | "claude">("claude");
+  const [repo, setRepo] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  if (!onCreate) return null;
+
+  const submit = () => {
+    const r = repo.trim();
+    const p = prompt.trim();
+    if (!REPO_RE.test(r)) {
+      setError("Enter a valid owner/repo.");
+      return;
+    }
+    if (!p) {
+      setError("Enter a task prompt.");
+      return;
+    }
+    onCreate({ agent, repo: r, prompt: p });
+    setRepo("");
+    setPrompt("");
+    setError(null);
+  };
+
+  return (
+    <form
+      className="hm-task-form"
+      aria-label="Propose a task"
+      style={{ display: "grid", gap: 6, marginBottom: 10 }}
+      onSubmit={(e) => {
+        e.preventDefault();
+        submit();
+      }}
+    >
+      <div style={{ display: "flex", gap: 6 }}>
+        <select
+          aria-label="Agent"
+          value={agent}
+          onChange={(e) => setAgent(e.target.value === "codex" ? "codex" : "claude")}
+          style={{ fontSize: 12 }}
+        >
+          <option value="claude">claude</option>
+          <option value="codex">codex</option>
+        </select>
+        <input
+          aria-label="Repository (owner/repo)"
+          placeholder="owner/repo"
+          value={repo}
+          onChange={(e) => {
+            setRepo(e.target.value);
+            if (error) setError(null);
+          }}
+          style={{ flex: 1, fontSize: 12 }}
+        />
+      </div>
+      <textarea
+        aria-label="Task prompt"
+        placeholder="Describe the task…"
+        value={prompt}
+        rows={2}
+        onChange={(e) => {
+          setPrompt(e.target.value);
+          if (error) setError(null);
+        }}
+        style={{ fontSize: 12, resize: "vertical" }}
+      />
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <button type="submit" className="hm-btn hm-btn--action hm-btn--sm">
+          Propose task
+        </button>
+        {error ? (
+          <span role="alert" style={{ color: "var(--hm-rose)", fontSize: 12 }}>
+            {error}
+          </span>
+        ) : (
+          <span style={{ fontSize: 11, color: "var(--hm-muted-soft)" }}>
+            Lands proposed — you approve before any runner claims it.
+          </span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/packages/monitor-ui/src/components/Lane.tsx
+++ b/packages/monitor-ui/src/components/Lane.tsx
@@ -23,11 +23,14 @@ export type LaneProps = {
   count: number;
   /** Cards rendered into the body slot. M4' wires the <Card /> renders. */
   children?: ReactNode;
+  /** Optional content at the top of the expanded body, above the cards
+   *  (e.g. the codex-needed create-task form, O3). */
+  headerAccessory?: ReactNode;
   /** Click handler to toggle this lane's expand/collapse state. */
   onToggle?: (id: LaneId) => void;
 };
 
-export function Lane({ lane, expanded, count, children, onToggle }: LaneProps) {
+export function Lane({ lane, expanded, count, children, headerAccessory, onToggle }: LaneProps) {
   if (!expanded) {
     return <MiniRail lane={lane} count={count} onToggle={onToggle} />;
   }
@@ -60,6 +63,7 @@ export function Lane({ lane, expanded, count, children, onToggle }: LaneProps) {
         {lane.action ? <div className="hm-lane-action">{lane.action}</div> : null}
       </div>
       <div className="hm-lane-body">
+        {headerAccessory}
         {count === 0 ? (
           <div className="hm-lane-empty">No {lane.name.toLowerCase()} right now.</div>
         ) : (

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -153,3 +153,53 @@ describe("Card — interactivity", () => {
     expect((container.querySelector(".hm-card") as HTMLElement).getAttribute("role")).toBe("article");
   });
 });
+
+describe("Card — task approve (O3 dispatch)", () => {
+  const proposed = {
+    id: "claude-task-x1",
+    lane: "codex-needed",
+    type: "task",
+    agentType: "claude",
+    title: "Add a HEALTHCHECK.md",
+    summary: "operator delegated",
+    repo: "averray-agent/agent",
+    freshness: 1,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "warn" },
+    taskStatus: "proposed",
+    prompt: "Add a top-level HEALTHCHECK.md.",
+  } as unknown as BoardCard;
+
+  test("a proposed task card shows the agent badge and an Approve & dispatch CTA", () => {
+    const { getByText, getByRole } = render(<Card card={proposed} onApprove={vi.fn()} />);
+    expect(getByText("claude")).toBeTruthy(); // agent badge
+    expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
+  });
+
+  test("approving requires a confirm step before onApprove fires (no single-click dispatch)", () => {
+    const onApprove = vi.fn();
+    const { getByRole, getByText } = render(<Card card={proposed} onApprove={onApprove} />);
+    fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
+    expect(onApprove).not.toHaveBeenCalled(); // first click only arms the confirm
+    expect(getByText(/Dispatch to claude\?/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+    expect(onApprove.mock.calls[0]?.[0]?.id).toBe("claude-task-x1");
+  });
+
+  test("Cancel aborts the confirm without dispatching", () => {
+    const onApprove = vi.fn();
+    const { getByRole } = render(<Card card={proposed} onApprove={onApprove} />);
+    fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
+    fireEvent.click(getByRole("button", { name: /Cancel/ }));
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
+  });
+
+  test("a non-proposed task card shows no approve CTA", () => {
+    const running = { ...proposed, taskStatus: "running" } as unknown as BoardCard;
+    const { queryByRole } = render(<Card card={running} onApprove={vi.fn()} />);
+    expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -18,6 +18,7 @@
 //   - isAction = true   → amber wash + Hermes verdict + CTA buttons
 //   - archiveHint = true → "archive in 4h?" tail line
 
+import { useState } from "react";
 import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { ChecksBar } from "./ChecksBar.js";
@@ -26,6 +27,8 @@ export type CardProps = {
   card: BoardCard;
   focused?: boolean;
   onClick?: (card: BoardCard) => void;
+  /** Approve a proposed task card (O3). Operator-only; runs through a confirm. */
+  onApprove?: (card: BoardCard) => void;
 };
 
 // ── Helpers (mirror the bundle's small inline helpers) ──────────────
@@ -64,7 +67,7 @@ function riskPillClass(tag: RiskTag): string {
 
 // ── Card ───────────────────────────────────────────────────────────
 
-export function Card({ card, focused = false, onClick }: CardProps) {
+export function Card({ card, focused = false, onClick, onApprove }: CardProps) {
   const isAction = Boolean(card.isAction);
   const isStale = card.state === "stale";
   const isClosed = card.type === "done";
@@ -145,6 +148,10 @@ export function Card({ card, focused = false, onClick }: CardProps) {
           matching the design. Live data still carries a waitingOn on done
           cards, so gate it here rather than relying on the source. */}
       {!isClosed && card.waitingOn ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
+
+      {card.type === "task" && (card as { taskStatus?: string }).taskStatus === "proposed" && onApprove ? (
+        <TaskApprove card={card} onApprove={onApprove} />
+      ) : null}
 
       {isAction && verdict ? (
         <div className="hm-verdict">
@@ -247,6 +254,62 @@ function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
     <div className={`hm-waiting hm-waiting--${waitingOn.tone}`}>
       waiting on
       <span className="target">→ {waitingOn.actor}</span>
+    </div>
+  );
+}
+
+// ── Task approve (O3 dispatch) ──────────────────────────────────────
+// Approving a proposed task is a real mutation (it lets a runner claim the
+// work), so per MONITOR_ACTION_PARITY.md it goes through an explicit confirm
+// step — never a single click. The operator is the only one who approves
+// (proposed → approved); the lifecycle then flows from the board feed.
+
+function TaskApprove({ card, onApprove }: { card: BoardCard; onApprove: (card: BoardCard) => void }) {
+  const [confirming, setConfirming] = useState(false);
+  const agent = agentLabel(card.agentType);
+  const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
+  if (!confirming) {
+    return (
+      <div className="hm-card-cta">
+        <button
+          type="button"
+          className="hm-btn hm-btn--action hm-btn--sm"
+          onClick={(e) => {
+            stop(e);
+            setConfirming(true);
+          }}
+        >
+          Approve & dispatch
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="hm-card-cta" role="group" aria-label="Confirm task dispatch">
+      <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
+        Dispatch to {agent}?
+      </span>
+      <button
+        type="button"
+        className="hm-btn hm-btn--action hm-btn--sm"
+        onClick={(e) => {
+          stop(e);
+          setConfirming(false);
+          onApprove(card);
+        }}
+      >
+        Confirm
+      </button>
+      <button
+        type="button"
+        className="hm-btn hm-btn--ghost hm-btn--sm"
+        onClick={(e) => {
+          stop(e);
+          setConfirming(false);
+        }}
+      >
+        Cancel
+      </button>
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -17,9 +17,11 @@ export type CardRouterProps = {
   onClick?: (card: BoardCard) => void;
   /** Click handler for the degraded card's primary action (Retry / View last known). */
   onDegradedAction?: (card: BoardCard) => void;
+  /** Approve a proposed task card (O3 dispatch). */
+  onApprove?: (card: BoardCard) => void;
 };
 
-export function CardRouter({ card, focused, onClick, onDegradedAction }: CardRouterProps) {
+export function CardRouter({ card, focused, onClick, onDegradedAction, onApprove }: CardRouterProps) {
   const renderer = pickRenderer(card);
 
   if (renderer === "degraded") {
@@ -36,5 +38,5 @@ export function CardRouter({ card, focused, onClick, onDegradedAction }: CardRou
     );
   }
 
-  return <Card card={card} focused={focused} onClick={onClick} />;
+  return <Card card={card} focused={focused} onClick={onClick} onApprove={onApprove} />;
 }

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -118,4 +118,42 @@ describe("AskHermesComposer", () => {
     const { getByText } = render(<AskHermesComposer muted />);
     expect(getByText("alerts muted")).toBeTruthy();
   });
+
+  test("/task <agent> <repo> <prompt> dispatches onCreateTask and clears the input", () => {
+    const onCreateTask = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onCreateTask={onCreateTask} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/task claude averray-agent/agent Add a HEALTHCHECK.md");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onCreateTask).toHaveBeenCalledWith({
+      agent: "claude",
+      repo: "averray-agent/agent",
+      prompt: "Add a HEALTHCHECK.md",
+    });
+    expect(input.value).toBe("");
+  });
+
+  test("/task codex <repo>#<pr> forwards the pullRequestNumber", () => {
+    const onCreateTask = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onCreateTask={onCreateTask} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/task codex averray-agent/agent#42 tighten it");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onCreateTask).toHaveBeenCalledWith({
+      agent: "codex",
+      repo: "averray-agent/agent",
+      prompt: "tighten it",
+      pullRequestNumber: 42,
+    });
+  });
+
+  test("/task with an invalid agent shows an error and does not dispatch", () => {
+    const onCreateTask = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onCreateTask={onCreateTask} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/task gpt5 a/b do x");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onCreateTask).not.toHaveBeenCalled();
+    expect(within(container).getByRole("alert").textContent).toMatch(/not a valid agent/i);
+  });
 });

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -10,12 +10,15 @@
 
 import { useEffect, useRef, useState, type KeyboardEvent } from "react";
 import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
+import type { CreateTaskInput } from "../../lib/monitor/card-types.js";
 
 export interface AskHermesComposerProps {
   /** Spawn a browser mission against a URL (/mission <url>). */
   onSpawnMission?: (url: string) => void;
   /** Propose a greenfield Claude task (/claude <repo> <task>). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
+  /** Propose a task (/task <agent> [<repo>#<pr>] <prompt>). */
+  onCreateTask?: (input: CreateTaskInput) => void;
   /** Ask Hermes a free-form question. */
   onAsk?: (text: string) => void;
   /** Mute action alerts until an absolute timestamp (/mute). */
@@ -33,6 +36,7 @@ export interface AskHermesComposerProps {
 export function AskHermesComposer({
   onSpawnMission,
   onSpawnClaudeTask,
+  onCreateTask,
   onAsk,
   onMute,
   onUnmute,
@@ -69,6 +73,20 @@ export function AskHermesComposer({
           setError(null);
         } else {
           setError("Proposing Claude tasks isn't wired here.");
+        }
+        return;
+      case "task":
+        if (onCreateTask) {
+          onCreateTask({
+            agent: command.agent,
+            repo: command.repo,
+            prompt: command.prompt,
+            ...(command.pullRequestNumber !== undefined ? { pullRequestNumber: command.pullRequestNumber } : {}),
+          });
+          setValue("");
+          setError(null);
+        } else {
+          setError("Proposing tasks isn't wired here.");
         }
         return;
       case "mute":
@@ -116,8 +134,8 @@ export function AskHermesComposer({
         <textarea
           ref={inputRef}
           className="hm-compose-input"
-          placeholder="Ask Hermes · /mission <url> · /claude <repo> <task> · /mute 1h"
-          aria-label="Ask Hermes, spawn a mission, propose a Claude task, or mute alerts"
+          placeholder="Ask Hermes · /task <agent> <repo> <prompt> · /mission <url> · /mute 1h"
+          aria-label="Ask Hermes, propose a task, spawn a mission, or mute alerts"
           value={value}
           onChange={(e) => {
             setValue(e.target.value);

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -7,7 +7,7 @@
 // mission (M7').
 
 import { useEffect, useRef } from "react";
-import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
@@ -17,6 +17,8 @@ export interface CoPilotRailProps {
   onSpawnMission?: (url: string) => void;
   /** Propose a greenfield Claude task (/claude <repo> <task>). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
+  /** Propose a task (/task <agent> [<repo>#<pr>] <prompt>). */
+  onCreateTask?: (input: CreateTaskInput) => void;
   /** Focused card — scopes Ask-Hermes questions + the scope chip. */
   focusedCard?: BoardCard;
   /** Collaboration wiring. Omit to keep the rail inert (e.g. in BoardView tests). */
@@ -34,6 +36,7 @@ export interface CoPilotRailProps {
 export function CoPilotRail({
   onSpawnMission,
   onSpawnClaudeTask,
+  onCreateTask,
   focusedCard,
   collaboration,
   onMute,
@@ -80,6 +83,7 @@ export function CoPilotRail({
       <AskHermesComposer
         onSpawnMission={onSpawnMission}
         onSpawnClaudeTask={onSpawnClaudeTask}
+        onCreateTask={onCreateTask}
         onAsk={(text) => ask(text, relatedPr)}
         onMute={onMute}
         onUnmute={onUnmute}

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -172,14 +172,33 @@ export interface MissionCard extends CardBase {
   mission: MissionReport;
 }
 
-/** Codex task card. Lifecycle: proposed → approved → running → succeeded/failed. */
+/** Task lifecycle status (mirrors the serializer's TaskStatus). */
+export type TaskStatus =
+  | "proposed"
+  | "approved"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
+/** Codex/Claude task card. Lifecycle: proposed → approved → running → succeeded/failed. */
 export interface CodexTaskCard extends CardBase {
   type: "task";
   prompt: string;
   action?: CardAction;
+  /** Lifecycle status — drives the board's approve affordance (proposed only). */
+  taskStatus?: TaskStatus;
   runnerHeartbeat?: { lastSeen: string; online: boolean };
   output?: string;
   failureReason?: string;
+}
+
+/** Payload for proposing a task from the board (O3 dispatch). */
+export interface CreateTaskInput {
+  agent: "codex" | "claude";
+  repo: string;
+  prompt: string;
+  pullRequestNumber?: number;
 }
 
 /** Deploy verification card. */

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
@@ -109,3 +109,52 @@ test("parseHermesInput: /unmute → unmute", () => {
 test("parseHermesInput: an unparseable /mute argument → error", () => {
   assert.equal(parseHermesInput("/mute whenever").kind, "error");
 });
+
+// ── /task <agent> [<repo>#<pr>] <prompt> (O3) ──────────────────────
+test("parseHermesInput: /task claude <repo> <prompt> → greenfield claude task (no PR)", () => {
+  assert.deepEqual(parseHermesInput("/task claude averray-agent/agent Add a HEALTHCHECK.md at the root"), {
+    kind: "task",
+    agent: "claude",
+    repo: "averray-agent/agent",
+    prompt: "Add a HEALTHCHECK.md at the root",
+  });
+});
+
+test("parseHermesInput: /task codex <repo>#<pr> <prompt> → codex task with PR", () => {
+  assert.deepEqual(parseHermesInput("/task codex averray-agent/agent#123 tighten the validator"), {
+    kind: "task",
+    agent: "codex",
+    repo: "averray-agent/agent",
+    pullRequestNumber: 123,
+    prompt: "tighten the validator",
+  });
+});
+
+test("parseHermesInput: /task is case-insensitive and trims", () => {
+  const out = parseHermesInput("  /TASK   claude   owner/repo   do the thing  ");
+  assert.deepEqual(out, { kind: "task", agent: "claude", repo: "owner/repo", prompt: "do the thing" });
+});
+
+test("parseHermesInput: /task with an unknown agent → error", () => {
+  assert.equal(parseHermesInput("/task gpt5 owner/repo do x").kind, "error");
+});
+
+test("parseHermesInput: /task codex without a PR → error (codex iterates an existing PR)", () => {
+  assert.equal(parseHermesInput("/task codex owner/repo do x").kind, "error");
+});
+
+test("parseHermesInput: /task with a malformed repo → error", () => {
+  assert.equal(parseHermesInput("/task claude not-a-repo do x").kind, "error");
+});
+
+test("parseHermesInput: /task with no prompt → error", () => {
+  assert.equal(parseHermesInput("/task claude owner/repo").kind, "error");
+});
+
+test("parseHermesInput: bare /task → error", () => {
+  assert.equal(parseHermesInput("/task").kind, "error");
+});
+
+test("parseHermesInput: a word starting with task but not the command is an ask", () => {
+  assert.equal(parseHermesInput("tasks for today?").kind, "ask");
+});

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
@@ -2,18 +2,22 @@
 //
 // The Hermes composer is a single text input that doubles as a command
 // line:
-//   /mission <url>      spawn a browser mission against a live URL
-//   /claude <repo> <…>  propose a greenfield Claude task (O2); opens a PR
-//   /mute [1h|9am|…]    silence action alerts (M9'); /unmute clears it
-//   anything else       a question routed to Hermes
+//   /mission <url>                        spawn a browser mission (M7')
+//   /task <agent> [<repo>#<pr>] <prompt>  propose a codex|claude task (O3)
+//   /claude <repo> <…>                    propose a greenfield Claude task (O2 shortcut)
+//   /mute [1h|9am|…]                      silence action alerts; /unmute clears it
+//   anything else                         a question routed to Hermes
 // Parsing lives here as a pure function so the composer stays dumb and
 // the contract is tested.
 
 import { parseMuteArg } from "./notifications.js";
 
+export type TaskAgent = "codex" | "claude";
+
 export type HermesCommand =
   | { kind: "mission"; url: string }
   | { kind: "claude"; repo: string; prompt: string }
+  | { kind: "task"; agent: TaskAgent; repo: string; pullRequestNumber?: number; prompt: string }
   | { kind: "mute"; untilMs: number }
   | { kind: "unmute" }
   | { kind: "ask"; text: string }
@@ -21,11 +25,14 @@ export type HermesCommand =
   | { kind: "empty" };
 
 const MISSION_RE = /^\/mission\b\s*(.*)$/is;
+const TASK_RE = /^\/task\b\s*(.*)$/is;
 const CLAUDE_RE = /^\/claude\b\s*(.*)$/is;
 const MUTE_RE = /^\/mute\b\s*(.*)$/is;
 const UNMUTE_RE = /^\/unmute\b/i;
 const URL_RE = /^https?:\/\/\S+$/i;
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
+// owner/repo  or  owner/repo#123
+const TASK_TARGET_RE = /^([\w.-]+\/[\w.-]+)(?:#(\d+))?$/;
 
 export function parseHermesInput(raw: string, now: () => number = Date.now): HermesCommand {
   const text = (raw ?? "").trim();
@@ -42,6 +49,42 @@ export function parseHermesInput(raw: string, now: () => number = Date.now): Her
       return { kind: "error", message: `"${url}" is not a valid http(s) URL.` };
     }
     return { kind: "mission", url };
+  }
+
+  const task = TASK_RE.exec(text);
+  if (task) {
+    const arg = (task[1] ?? "").trim();
+    if (!arg) {
+      return { kind: "error", message: "/task needs an agent, repo, and a prompt, e.g. /task claude averray-agent/agent Add a HEALTHCHECK.md" };
+    }
+    const agentGap = arg.search(/\s/);
+    const agentRaw = (agentGap === -1 ? arg : arg.slice(0, agentGap)).toLowerCase();
+    if (agentRaw !== "codex" && agentRaw !== "claude") {
+      return { kind: "error", message: `"${agentRaw}" is not a valid agent (expected codex or claude).` };
+    }
+    const rest = (agentGap === -1 ? "" : arg.slice(agentGap + 1)).trim();
+    const targetGap = rest.search(/\s/);
+    const target = (targetGap === -1 ? rest : rest.slice(0, targetGap)).trim();
+    const prompt = (targetGap === -1 ? "" : rest.slice(targetGap + 1)).trim();
+    const matched = TASK_TARGET_RE.exec(target);
+    if (!matched) {
+      return { kind: "error", message: `"${target || "(none)"}" is not a valid owner/repo or owner/repo#pr.` };
+    }
+    const repo = matched[1] ?? "";
+    const pullRequestNumber = matched[2] ? Number(matched[2]) : undefined;
+    if (!prompt) {
+      return { kind: "error", message: "/task needs a prompt after the repo." };
+    }
+    if (agentRaw === "codex" && pullRequestNumber === undefined) {
+      return { kind: "error", message: "/task codex needs an existing PR, e.g. /task codex averray-agent/agent#123 <prompt>." };
+    }
+    return {
+      kind: "task",
+      agent: agentRaw,
+      repo,
+      ...(pullRequestNumber !== undefined ? { pullRequestNumber } : {}),
+      prompt,
+    };
   }
 
   const claude = CLAUDE_RE.exec(text);

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -56,6 +56,15 @@ export interface WaitingOn {
   tone: "warn" | "info" | "neutral";
 }
 
+/** Task lifecycle status, mirrors codex-task-queue CodexTaskStatus. */
+export type TaskStatus =
+  | "proposed"
+  | "approved"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled";
+
 /** CI check rollup for the card's checks bar. Mirrors the UI CardChecks. */
 export interface CardChecks {
   pass: number;
@@ -172,6 +181,9 @@ export interface BoardCard {
   closedAt?: string;
   /** Done cards: short verdict line ("merged" / "closed"). */
   verdictText?: string;
+  /** Codex/Claude task cards: lifecycle status (drives the board's
+   *  approve affordance — only `proposed` tasks show "Approve"). */
+  taskStatus?: TaskStatus;
   /** Codex task cards: the dispatched prompt. */
   prompt?: string;
   /** Codex task cards: tail of stdout / completion summary. */
@@ -746,6 +758,8 @@ export function enrichBoardCard(
   // Codex task cards: prompt / output / failure / runner liveness.
   if (card.type === "task" && ctx.codexTask) {
     const task = ctx.codexTask;
+    const status = asString(task.status);
+    if (status) card.taskStatus = status as TaskStatus;
     const prompt = asString(task.prompt);
     if (prompt) card.prompt = prompt;
     const output = asString(task.stdoutTail) ?? asString(task.completionSummary);
@@ -777,6 +791,66 @@ export function enrichBoardCard(
  * @param opts.repo   the configured AVERRAY_REPO (single-repo per §21.6)
  * @param opts.now    clock injection for tests
  */
+const SYNTH_TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "cancelled"]);
+
+/**
+ * Synthesize `codex-needed` cards for queued tasks the classifier won't
+ * surface on its own. Greenfield tasks (no PR yet) emit no monitor/handoff
+ * event, so without this a freshly-proposed task never appears on the board
+ * and the operator could never see or approve it — the O3 dispatch loop
+ * depends on this. PR-bound tasks are intentionally skipped (they surface via
+ * their PR card). Terminal tasks are dropped. Zero new network calls — reads
+ * the `codexTasks` already bundled on the snapshot.
+ */
+export function synthesizeTaskCards(
+  rawSnapshot: unknown,
+  runner: Record<string, unknown> | undefined,
+): BoardCard[] {
+  const root = asRecord(rawSnapshot);
+  const codexTasks = asRecord(root?.codexTasks);
+  const out: BoardCard[] = [];
+  for (const entry of asArray(codexTasks?.items)) {
+    const task = asRecord(entry);
+    if (!task) continue;
+    const status = asString(task.status);
+    if (!status || SYNTH_TERMINAL_TASK_STATUSES.has(status)) continue;
+    // PR-bound tasks surface (and get their status overlaid) via the PR card.
+    if (task.pullRequestNumber !== undefined && task.pullRequestNumber !== null) continue;
+    const id = asString(task.id);
+    if (!id) continue;
+    const agent: AgentType = task.agent === "claude" ? "claude" : "codex";
+    const prompt = asString(task.prompt);
+    const card: BoardCard = {
+      id,
+      lane: "codex-needed",
+      type: "task",
+      agentType: agent,
+      title: asString(task.title) ?? `${agent} task`,
+      summary: asString(task.reason) ?? "",
+      repo: asString(task.repo) ?? "",
+      freshness: 0,
+      state: "fresh",
+      risk: [],
+      // Proposed → operator must approve; approved/running → with the runner.
+      waitingOn:
+        status === "proposed"
+          ? { actor: "operator", tone: "warn" }
+          : { actor: "agent", tone: "info" },
+      taskStatus: status as TaskStatus,
+      ...(prompt ? { prompt } : {}),
+    };
+    if (status === "running" && runner) {
+      const lastSeen = asString(runner.updatedAt);
+      const rStatus = asString(runner.status);
+      if (lastSeen) {
+        card.runnerHeartbeat = { lastSeen, online: rStatus === "running" || rStatus === "idle" };
+      }
+    }
+    out.push(card);
+  }
+  return out;
+}
+
 export function buildV2BoardSnapshot(
   rawSnapshot: unknown,
   opts: { repo?: string; now?: () => Date } = {}
@@ -802,8 +876,13 @@ export function buildV2BoardSnapshot(
           : undefined,
     });
   });
+  // Surface queued greenfield tasks the classifier can't (no PR ⇒ no event),
+  // skipping any already represented (e.g. by a PR card).
+  const existingIds = new Set(cards.map((c) => c.id));
+  const taskCards = synthesizeTaskCards(rawSnapshot, runner).filter((c) => !existingIds.has(c.id));
+
   return {
-    cards,
+    cards: [...cards, ...taskCards],
     at: now().toISOString(),
     repo: opts.repo ?? "",
   };

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -21,6 +21,7 @@ import {
   indexTestbedMissions,
   enrichBoardCard,
   mapMissionReport,
+  synthesizeTaskCards,
 } from "../../services/slack-operator/src/monitor-v2.js";
 import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
 import type { HermesBoardCardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -760,5 +761,75 @@ describe("mapMissionReport", () => {
 
   it("returns undefined when the run has no result yet (mission still running)", () => {
     expect(mapMissionReport({ id: "m", targetUrl: "https://x.test" })).toBeUndefined();
+  });
+});
+
+describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
+  const proposedClaude = {
+    id: "claude-task-x1",
+    status: "proposed",
+    agent: "claude",
+    repo: "averray-agent/agent",
+    title: "Add a HEALTHCHECK.md",
+    prompt: "Add a top-level HEALTHCHECK.md.",
+    reason: "operator delegated",
+  };
+
+  it("surfaces a proposed greenfield task as a codex-needed card with its agent + status", () => {
+    const [card, ...rest] = synthesizeTaskCards({ codexTasks: { items: [proposedClaude] } }, undefined);
+    expect(rest).toHaveLength(0);
+    expect(card).toMatchObject({
+      id: "claude-task-x1",
+      lane: "codex-needed",
+      type: "task",
+      agentType: "claude",
+      taskStatus: "proposed",
+      repo: "averray-agent/agent",
+      prompt: "Add a top-level HEALTHCHECK.md.",
+    });
+    // proposed → waiting on the operator to approve
+    expect(card?.waitingOn).toEqual({ actor: "operator", tone: "warn" });
+  });
+
+  it("skips PR-bound tasks (they surface via their PR card) and terminal tasks", () => {
+    const cards = synthesizeTaskCards(
+      {
+        codexTasks: {
+          items: [
+            { id: "a", status: "proposed", agent: "codex", repo: "a/b", pullRequestNumber: 5, prompt: "x" },
+            { id: "b", status: "completed", agent: "claude", repo: "a/b", prompt: "x" },
+            { id: "c", status: "cancelled", agent: "claude", repo: "a/b", prompt: "x" },
+          ],
+        },
+      },
+      undefined,
+    );
+    expect(cards).toHaveLength(0);
+  });
+
+  it("defaults a missing agent to codex and tolerates an absent task list", () => {
+    const [card] = synthesizeTaskCards({ codexTasks: { items: [{ id: "z", status: "approved", repo: "a/b", prompt: "x" }] } }, undefined);
+    expect(card?.agentType).toBe("codex");
+    expect(card?.taskStatus).toBe("approved");
+    expect(synthesizeTaskCards({}, undefined)).toEqual([]);
+    expect(synthesizeTaskCards(undefined, undefined)).toEqual([]);
+  });
+
+  it("buildV2BoardSnapshot appends synthesized task cards", () => {
+    const snap = buildV2BoardSnapshot({ active: [], recent: [], codexTasks: { items: [proposedClaude] } }, { repo: "averray-agent/agent" });
+    const task = snap.cards.find((c) => c.id === "claude-task-x1");
+    expect(task?.type).toBe("task");
+    expect(task?.taskStatus).toBe("proposed");
+  });
+});
+
+describe("enrichBoardCard — task status", () => {
+  it("carries the task lifecycle status onto a task card", () => {
+    const base = toBoardCard(slim({ lane: "Codex needed", owner: "Hermes", title: "Reduce log noise" }));
+    expect(base.type).toBe("task");
+    const enriched = enrichBoardCard(base, slim({ lane: "Codex needed" }), {
+      codexTask: { status: "approved", prompt: "do it" },
+    });
+    expect(enriched.taskStatus).toBe("approved");
   });
 });


### PR DESCRIPTION
## What changed & why

The last piece of the self-feeding loop (O3): work is enqueued **from the board**
(or `/task`) instead of by hand, and the live Claude/Codex runners pick it up
after an explicit operator approval.

> **Item 1 of the O3 brief — the endpoint accepting `agent` + optional PR — was
> already shipped in #266.** This PR is the surface that drives it. While
> building, I found the loop was actually broken at the *surfacing* step:
> proposing a task emits no monitor event and the classifier never injects codex
> tasks, so a freshly-proposed greenfield task **never appeared as a card** —
> nothing to see or approve. Fixing that is the keystone below.

- **SURFACE** (serializer, `monitor-v2`): `buildV2BoardSnapshot` now synthesizes
  `codex-needed` cards from the snapshot's `codexTasks` (greenfield, non-terminal;
  PR-bound tasks still surface via their PR card), and carries the task **`agent`**
  (badge) + lifecycle **`taskStatus`** onto task cards. Zero new network calls.
- **`/task` verb**: `/task <agent> [<repo>#<pr>] <prompt>` for codex|claude
  (codex requires a PR; claude is greenfield), mirroring the `/mission` parser
  and its error messages.
- **CREATE form** (`CreateTaskForm`) in the `codex-needed` lane: agent + repo +
  prompt → propose. The lane stays open even when empty so the first task can be
  created.
- **APPROVE** on proposed task cards: per `MONITOR_ACTION_PARITY.md` dispatch is
  a real mutation, so it goes through an explicit confirm (*"Dispatch to
  <agent>?"* → Confirm / Cancel) — never a single click. Result flows from the
  SSE board feed.

## Human gate (invariant #6) — preserved
Created tasks are `proposed`; **only the operator approves** (proposed →
approved). Nothing auto-approves; the endpoint's existing auth is untouched (no
endpoint change in this PR). Autopilot auto-approval is the separate **P4**.

## Affected surfaces
- [x] Monitor board / slack-operator (monitor-ui SPA + monitor-v2 serializer)
- [x] Worker runners / task queue (drives the existing queue + runners; no queue change)
- [x] Docs / tests only (new component + parser/serializer tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 833 pass / 84 files (+26)
- [x] `vite build` (monitor-ui) compiles
- [ ] compose config — n/a (no ops/ touched)

## Rollout / rollback
Server serializer + UI bundle change; rebuild/redeploy to pick up. Purely
additive — existing card types, `/mission`, `/claude`, `/mute` unchanged.
Rollback = revert. Depends on #266 (merged) for the endpoint.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — the worker opens a PR; approval + merge stay human; the board approve is the *proposed→approved* gate only, behind a confirm
- [x] No new ungated power — the worker's allow-list + approved-only claim still gate execution; this is the operator's enqueue/approve surface
- [x] No secrets committed/printed/logged
- [x] No `AGENTS.md` change (UI/serializer surface over the existing queue + endpoints)

## Acceptance (the loop closes)
`/task claude averray-agent/agent <prompt>` (or the codex-needed form) → lands
`proposed` in codex-needed → operator clicks Approve & dispatch → confirm → the
live claude-task-runner (O2) claims it → the worker opens a PR attributed to
`claude` (O1) → Hermes review. No hand-written prompt in that path.

## Known limits / follow-ups
- **Task-card synthesis lives in the v2 serializer** (`monitor-v2`) to stay in-lane; the cleaner long-term home is the classifier (`monitor-hermes-board`) alongside the mission injection — a later refactor (Codex's lane).
- The create **form** is greenfield-shaped (agent + repo + prompt); codex+PR tasks go through `/task codex <repo>#<pr>`. A PR field on the form can come later.
- PR-bound task **approval** from the board (vs greenfield) is out of scope here — those surface as a PR-card overlay, not a codex-needed task card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)