### PR TITLE
docs(roadmap): O3 done — board dispatch + /task live

### DIFF
--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -23,7 +23,7 @@
 | O0 | Discovery (integration map) | ✅ done |
 | O1 | Agent attribution (branch-prefix → agentType) | ✅ done (#252) |
 | O2 | Claude Code worker (greenfield, Agent SDK) | ✅ done (#256 queue · #259 auth · #260 runner · #262 worker · #263 ops) |
-| O3 | Board-driven dispatch | 🟡 partial — multi-agent queue ✅ (#256); board dispatch UI / `/task` verb + recheck wiring (spec #244) TBD |
+| O3 | Board-driven dispatch | ✅ done — create/approve form (agent picker) + `/task` verb live on the board (#271) |
 | O4 | Hermes enqueue + dispatch guardrail + autonomy mode | design done |
 | O5 | Self-management hardening | design done |
 | A1 | Agent scorecard | design done |
@@ -44,7 +44,7 @@
 | T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
 | T5 | Env→mutation binding + enhancements (trace/video, baselines) | design done |
 
-*(Status as of 2026-05-29: **O0–O2 shipped, O3 partial**; the monitor redesign + board (PRs #225–#247) is fully shipped as the foundation; A/B/C/D and T1–T5 are design-only (T1 prompt out). Tell me as things land and I'll flip statuses.)*
+*(Status as of 2026-05-29: **O0–O3 shipped — the loop is operator-driven from the board** (create → approve → runner → worker → PR → Hermes review); the monitor redesign + board (PRs #225–#247) is the foundation; A/B/C/D and T1–T5 are design-only (T1 prompt out). **Next: the safety net (T1 + D1/D3) before O4 autopilot.** Tell me as things land and I'll flip statuses.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 


### PR DESCRIPTION
Flip O3 to done: the live board shows the create/approve form (agent picker + Propose task + the human-approval gate copy) and the `/task` co-pilot verb (#271). O0–O3 shipped; loop is operator-driven. Next: safety net (T1 + D1/D3) before O4. Docs-only.