### PR TITLE
T1: deterministic surface sweep + truth-boundary honesty check

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -970,6 +970,10 @@ async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage,
       ...(booleanField(payload, "allowTestMutations") !== undefined ? { allowTestMutations: booleanField(payload, "allowTestMutations") } : {}),
       ...(numberField(payload, "maxBrowserSteps") !== undefined ? { maxBrowserSteps: numberField(payload, "maxBrowserSteps") } : {}),
       ...(numberField(payload, "maxMinutes") !== undefined ? { maxMinutes: numberField(payload, "maxMinutes") } : {}),
+      ...(stringField(payload, "mode") === "surface_sweep" ? { mode: "surface_sweep" as const } : {}),
+      ...(Array.isArray(payload.routes)
+        ? { routes: payload.routes.filter((r): r is string => typeof r === "string" && r.length > 0) }
+        : {}),
     });
     recordTestbedMissionCollaboration(created.run);
     logger.info(

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -32,6 +32,12 @@ export interface TestbedMissionRun {
   agentName: string;
   freshMemory: boolean;
   allowTestMutations: boolean;
+  /** Mission shape. "explore" (default) is the single-URL heuristic; a
+   *  "surface_sweep" (T1) walks `routes` read-only with a boundary-honesty check. */
+  mode?: "explore" | "surface_sweep";
+  /** Routes for a surface_sweep (relative to the app base URL, or absolute).
+   *  Empty/absent ⇒ the default public surface list. */
+  routes?: string[];
   mission: Record<string, unknown>;
   result?: Record<string, unknown>;
   history: TestbedMissionHistoryEntry[];
@@ -126,18 +132,22 @@ export function recordTestbedMissionRunFromOperatorResult(
   const safety = isRecord(mission.safety) ? mission.safety : {};
   const createdAt = new Date(nowMs).toISOString();
   const allowTestMutations = safety.browserMissionShouldMutate === true;
+  const mode = stringField(target, "mode") === "surface_sweep" ? "surface_sweep" : undefined;
+  const routes = Array.isArray(target.routes) ? stringArray(target.routes) : [];
   const run: TestbedMissionRun = {
     schemaVersion: 1,
     kind: "testbed_mission_run",
     id: nextMissionId(nowMs),
     status: "ready",
-    title: "Fresh-agent browser mission",
+    title: mode === "surface_sweep" ? "Surface sweep (T1)" : "Fresh-agent browser mission",
     targetUrl: stringField(target, "url") ?? "[TESTBED_URL]",
     goal: stringField(target, "goal")
       ?? "Test whether a normal outside agent can understand and use the page.",
     agentName: stringField(target, "agentName") ?? "Hermes",
     freshMemory: target.freshMemory !== false,
     allowTestMutations,
+    ...(mode ? { mode } : {}),
+    ...(routes.length > 0 ? { routes } : {}),
     mission,
     history: [
       {

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -11,6 +11,10 @@ import {
 export interface AgentTestbedMissionInput extends TestbedAgentMissionInput {
   requester?: string;
   path?: string;
+  /** T1: select a surface sweep instead of the single-URL explore. */
+  mode?: "explore" | "surface_sweep";
+  /** T1: routes for a surface sweep (relative to the app base URL, or absolute). */
+  routes?: string[];
 }
 
 export interface AgentTestbedMissionListInput {
@@ -38,7 +42,19 @@ export function createTestbedMissionFromAgent(
   input: AgentTestbedMissionInput = {},
   nowMs: number = Date.now()
 ): AgentTestbedMissionResult {
-  const mission = getTestbedAgentMission(input);
+  const mission = getTestbedAgentMission(input) as Record<string, unknown>;
+  // Carry the T1 sweep selection onto the mission packet's target so the
+  // recorded run picks up `mode` / `routes` (the packet generator is in the
+  // averray-mcp package and is agnostic to it).
+  if (input.mode || (input.routes && input.routes.length > 0)) {
+    const target =
+      mission.target && typeof mission.target === "object" && !Array.isArray(mission.target)
+        ? (mission.target as Record<string, unknown>)
+        : {};
+    if (input.mode) target.mode = input.mode;
+    if (input.routes && input.routes.length > 0) target.routes = input.routes;
+    mission.target = target;
+  }
   const run = recordTestbedMissionRunFromOperatorResult(
     {
       kind: "testbed_agent_mission",

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -14,6 +14,7 @@ import {
   updateTestbedMissionProgress,
   updateTestbedMissionRunnerHeartbeat,
 } from "./monitor-testbed-missions.js";
+import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
 
 export interface TestbedMissionRunnerConfig {
   enabled: boolean;
@@ -29,6 +30,10 @@ export interface TestbedMissionRunnerConfig {
   browserExecutablePath?: string;
   artifactsDir?: string;
   maxBrowserSteps?: number;
+  /** Base URL the surface sweep (T1) joins relative routes to. */
+  appBaseUrl?: string;
+  /** The env's truth boundary the sweep asserts surfaces label (demo/testnet/local-simulation/production). */
+  expectedBoundary?: string;
 }
 
 export interface TestbedMissionRunResult {
@@ -68,6 +73,10 @@ export function parseTestbedMissionRunnerConfig(
     ...(env.TESTBED_MISSION_BROWSER_EXECUTABLE_PATH ? { browserExecutablePath: env.TESTBED_MISSION_BROWSER_EXECUTABLE_PATH } : {}),
     artifactsDir: env.TESTBED_MISSION_ARTIFACTS_DIR || "/data/testbed-mission-artifacts",
     maxBrowserSteps: positiveInt(env.TESTBED_MISSION_MAX_BROWSER_STEPS, 8),
+    ...(env.AVERRAY_APP_BASE_URL || env.AVERRAY_API_BASE_URL
+      ? { appBaseUrl: env.AVERRAY_APP_BASE_URL || env.AVERRAY_API_BASE_URL }
+      : {}),
+    ...(env.AVERRAY_TESTBED_EXPECTED_BOUNDARY ? { expectedBoundary: env.AVERRAY_TESTBED_EXPECTED_BOUNDARY } : {}),
   };
 }
 
@@ -80,7 +89,7 @@ export async function runTestbedMissionRunnerOnce(
     return { status: "disabled" };
   }
   const executorMode = config.executor ?? (config.command ? "command" : "playwright");
-  const executor = deps.executor ?? (executorMode === "command" ? executeTestbedMissionCommand : executePlaywrightTestbedMission);
+  const executor = deps.executor ?? (executorMode === "command" ? executeTestbedMissionCommand : executeBrowserTestbedMission);
   if (executorMode === "command" && !config.command && executor === executeTestbedMissionCommand) {
     const reason = "TESTBED_MISSION_RUNNER_COMMAND is required when the Hermes testbed runner is enabled.";
     updateRunnerHeartbeat(config, "misconfigured", reason, deps.now);
@@ -260,6 +269,22 @@ export async function executeTestbedMissionCommand(
         });
     });
   });
+}
+
+/**
+ * Default browser executor: dispatch by mission mode. A `surface_sweep`
+ * mission (T1) walks a route list read-only and runs the boundary-honesty
+ * check; any other mission keeps the existing single-URL "explore" heuristic.
+ */
+export async function executeBrowserTestbedMission(
+  mission: TestbedMissionRun,
+  config: TestbedMissionRunnerConfig,
+  deps: SurfaceSweepDeps = {}
+): Promise<TestbedMissionRunResult> {
+  if (mission.mode === "surface_sweep") {
+    return executeSurfaceSweep(mission, config, deps);
+  }
+  return executePlaywrightTestbedMission(mission, config);
 }
 
 export async function executePlaywrightTestbedMission(

--- a/services/slack-operator/src/testbed-surface-sweep.ts
+++ b/services/slack-operator/src/testbed-surface-sweep.ts
@@ -1,0 +1,425 @@
+// Hermes e2e tester — Tier 1 surface sweep (T1).
+//
+// A cheap, deterministic, READ-ONLY per-deploy check: walk the product's
+// public surfaces, flag console/network errors per route, and — the
+// distinctive part — assert each surface labels its state HONESTLY (a
+// degraded page says "degraded", an empty page says "empty", a demo/
+// testnet/local-simulation surface says so). This enforces the project's
+// truth-boundary discipline: a surface must never show data as if it were
+// real/production when it isn't, and must never look healthy while erroring.
+//
+// The browser driving is dependency-injected (`deps.captureRoute`), so the
+// per-route capture + aggregation + verdict + honesty logic are all unit
+// tested with no real browser. The single-URL "explore" executor is
+// untouched; the sweep is selected by `mission.mode === "surface_sweep"`.
+
+import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
+import type { TestbedMissionRunResult } from "./testbed-mission-runner.js";
+
+/** The environment's truth — what marker a data-bearing surface must carry. */
+export type SweepBoundary =
+  | "production"
+  | "demo"
+  | "testnet"
+  | "local-simulation"
+  | "none";
+
+/** What a single swept route produced. Mirrors a Playwright page capture; the
+ *  fields are everything the honesty + verdict logic needs. */
+export interface RouteCapture {
+  /** The requested route, e.g. "/jobs". */
+  route: string;
+  /** The final resolved/landed URL. */
+  url: string;
+  /** Navigation succeeded and the main document was not a 4xx/5xx. */
+  ok: boolean;
+  /** Main-document HTTP status, when known. */
+  status?: number;
+  title: string;
+  visibleText: string;
+  consoleErrors: string[];
+  networkFailures: string[];
+  /** 4xx/5xx responses for subresources on this route. */
+  badResponses: string[];
+  /** Screenshot artifact path, when captured. */
+  screenshot?: string;
+  /** Set when `goto` itself threw (DNS, timeout, connection refused). */
+  loadError?: string;
+}
+
+export interface HonestyFinding {
+  route: string;
+  severity: "low" | "medium" | "high";
+  code: "errored_but_silent" | "empty_unlabeled" | "boundary_marker_missing";
+  message: string;
+}
+
+export type SweepVerdict = "pass" | "partial" | "fail";
+
+const DEFAULT_PUBLIC_ROUTES = ["/", "/onboarding", "/jobs", "/strategies"];
+
+// A surface with less meaningful visible text than this is treated as "blank"
+// (an empty/loading shell) rather than data-bearing.
+const EMPTY_TEXT_THRESHOLD = 40;
+
+// State markers a surface can carry. Matched case-insensitively against the
+// visible text. Kept conservative so a real degraded/empty/demo label trips
+// it, but ordinary copy does not.
+const MARKERS = {
+  degraded: /\b(degraded|untrusted|unavailable|stale data|reconnecting|offline|failed to load|something went wrong|temporarily unavailable)\b/i,
+  empty: /\b(no .{0,30}(yet|found|right now)|nothing (here|yet)|empty|you're all caught up|no results|no data)\b/i,
+  demo: /\b(demo|sample data|mock data|example data|placeholder data|for illustration)\b/i,
+  testnet: /\b(testnet|test network|paseo|westend|rococo|sepolia)\b/i,
+  "local-simulation": /\b(local simulation|simulated|anvil|local node|dev mode|sandbox)\b/i,
+} as const;
+
+export interface DetectedMarkers {
+  degraded: boolean;
+  empty: boolean;
+  demo: boolean;
+  testnet: boolean;
+  "local-simulation": boolean;
+}
+
+export function detectStateMarkers(text: string): DetectedMarkers {
+  const t = text ?? "";
+  return {
+    degraded: MARKERS.degraded.test(t),
+    empty: MARKERS.empty.test(t),
+    demo: MARKERS.demo.test(t),
+    testnet: MARKERS.testnet.test(t),
+    "local-simulation": MARKERS["local-simulation"].test(t),
+  };
+}
+
+function hasErrors(c: RouteCapture): boolean {
+  return (
+    !c.ok ||
+    Boolean(c.loadError) ||
+    c.consoleErrors.length > 0 ||
+    c.networkFailures.length > 0 ||
+    c.badResponses.length > 0
+  );
+}
+
+function errorCount(c: RouteCapture): number {
+  return c.consoleErrors.length + c.networkFailures.length + c.badResponses.length;
+}
+
+/** The route's document is broken: it didn't load, or returned a 4xx/5xx. */
+export function routeBroken(c: RouteCapture): boolean {
+  return !c.ok || Boolean(c.loadError) || (typeof c.status === "number" && c.status >= 400);
+}
+
+function meaningfulTextLength(text: string): number {
+  return (text ?? "").replace(/\s+/g, " ").trim().length;
+}
+
+/**
+ * Truth-boundary honesty check for one route. Deterministic — no env probing:
+ *  - errored_but_silent (HIGH): the route hit console/network errors but the
+ *    page shows no degraded/error marker — it looks healthy while broken.
+ *  - empty_unlabeled (MEDIUM): the route is blank (no meaningful text) and
+ *    carries no empty-state label — a silent blank surface.
+ *  - boundary_marker_missing (MEDIUM): when the env is known to be non-prod
+ *    (expectedBoundary demo/testnet/local-simulation), a data-bearing surface
+ *    must carry that marker — else it presents non-prod data as if real.
+ */
+export function checkRouteHonesty(c: RouteCapture, expectedBoundary: SweepBoundary): HonestyFinding[] {
+  const findings: HonestyFinding[] = [];
+  const markers = detectStateMarkers(c.visibleText);
+  const errored = hasErrors(c);
+  const textLen = meaningfulTextLength(c.visibleText);
+  const dataBearing = textLen >= EMPTY_TEXT_THRESHOLD && !markers.empty;
+
+  if (errored && !markers.degraded && !routeBroken(c)) {
+    findings.push({
+      route: c.route,
+      severity: "high",
+      code: "errored_but_silent",
+      message: `Surface rendered ${errorCount(c)} console/network error(s) but shows no degraded/error state — it looks healthy while broken.`,
+    });
+  }
+
+  if (!routeBroken(c) && !errored && textLen < EMPTY_TEXT_THRESHOLD && !markers.empty) {
+    findings.push({
+      route: c.route,
+      severity: "medium",
+      code: "empty_unlabeled",
+      message: "Surface is blank with no empty-state label (e.g. \"nothing here yet\").",
+    });
+  }
+
+  if (
+    dataBearing &&
+    (expectedBoundary === "demo" || expectedBoundary === "testnet" || expectedBoundary === "local-simulation") &&
+    !markers[expectedBoundary]
+  ) {
+    findings.push({
+      route: c.route,
+      severity: "medium",
+      code: "boundary_marker_missing",
+      message: `Surface shows data without a "${expectedBoundary}" marker — non-production data must be labeled as such.`,
+    });
+  }
+
+  return findings;
+}
+
+export function sweepVerdict(captures: RouteCapture[], findings: HonestyFinding[]): SweepVerdict {
+  if (captures.length === 0) return "fail";
+  const anyBroken = captures.some(routeBroken);
+  const anyHigh = findings.some((f) => f.severity === "high");
+  if (anyBroken || anyHigh) return "fail";
+  const anyErrors = captures.some(hasErrors);
+  if (anyErrors || findings.length > 0) return "partial";
+  return "pass";
+}
+
+/** Resolve the routes to sweep. mission.routes overrides the public default;
+ *  relative routes are joined to the configured app base URL. */
+export function resolveSweepRoutes(
+  routes: string[] | undefined,
+  baseUrl: string | undefined,
+): Array<{ route: string; url: string }> {
+  const list = routes && routes.length > 0 ? routes : DEFAULT_PUBLIC_ROUTES;
+  const base = (baseUrl ?? "").replace(/\/+$/, "");
+  return list.map((route) => {
+    if (/^https?:\/\//i.test(route)) return { route, url: route };
+    const path = route.startsWith("/") ? route : `/${route}`;
+    return { route, url: base ? `${base}${path}` : path };
+  });
+}
+
+export interface SweepReportInput {
+  mission: TestbedMissionRun;
+  captures: RouteCapture[];
+  expectedBoundary: SweepBoundary;
+}
+
+/** Aggregate per-route captures into the structured report shape the mission
+ *  store normalizes (verdict / completedPath / blockers / confusingMoments /
+ *  recommendations / evidence / scores). Pure + deterministic. */
+export function buildSweepReport(input: SweepReportInput): Record<string, unknown> {
+  const { mission, captures, expectedBoundary } = input;
+  const findings = captures.flatMap((c) => checkRouteHonesty(c, expectedBoundary));
+  const verdict = sweepVerdict(captures, findings);
+
+  const broken = captures.filter(routeBroken);
+  const errored = captures.filter((c) => hasErrors(c) && !routeBroken(c));
+
+  const blockers: string[] = [
+    ...broken.map((c) => `${c.route} failed to load cleanly (${c.loadError ?? `status ${c.status ?? "?"}`}).`),
+    ...findings.filter((f) => f.severity === "high").map((f) => `${f.route}: ${f.message}`),
+  ];
+  const confusingMoments: string[] = [
+    ...errored.map((c) => `${c.route} loaded but logged ${errorCount(c)} console/network error(s).`),
+    ...findings.filter((f) => f.severity !== "high").map((f) => `${f.route}: ${f.message}`),
+  ];
+  const completedPath = captures.map(
+    (c) => `swept ${c.route} → ${c.url} (${c.loadError ? "load error" : `status ${c.status ?? "?"}`})`,
+  );
+  const recommendations: string[] = [];
+  if (broken.length) recommendations.push("Fix the route(s) that failed to load before the next deploy.");
+  if (findings.some((f) => f.code === "errored_but_silent")) {
+    recommendations.push("Surface a visible degraded/error state on pages that hit console or network errors.");
+  }
+  if (findings.some((f) => f.code === "empty_unlabeled")) {
+    recommendations.push("Add an explicit empty-state label to blank surfaces.");
+  }
+  if (findings.some((f) => f.code === "boundary_marker_missing")) {
+    recommendations.push(`Label non-production surfaces with their environment ("${expectedBoundary}").`);
+  }
+
+  const evidence: Array<{ type: string; value: string }> = [
+    { type: "executor", value: "surface_sweep" },
+    { type: "expected_boundary", value: expectedBoundary },
+    { type: "routes_swept", value: String(captures.length) },
+  ];
+  for (const c of captures) {
+    evidence.push({
+      type: "route",
+      value: `${c.route} :: status=${c.status ?? "?"} title=${JSON.stringify(c.title)} errors=${errorCount(c)}${c.loadError ? ` loadError=${c.loadError}` : ""}`,
+    });
+    if (c.screenshot) evidence.push({ type: "screenshot", value: c.screenshot });
+  }
+  for (const f of findings) {
+    evidence.push({ type: "honesty_finding", value: `${f.severity} ${f.code} @ ${f.route}` });
+  }
+
+  const cleanRoutes = captures.filter((c) => !hasErrors(c)).length;
+  const score = (n: number) => Math.max(0, Math.min(5, n));
+  const loadHealth = captures.length ? score(Math.round((cleanRoutes / captures.length) * 5)) : 0;
+  const boundaryHonesty = findings.length === 0 ? 5 : findings.some((f) => f.severity === "high") ? 1 : 3;
+
+  return {
+    missionId: mission.id,
+    verdict,
+    confidence: verdict === "pass" ? 0.9 : verdict === "fail" ? 0.85 : 0.6,
+    executor: "surface_sweep",
+    runnerMode: "surface_sweep",
+    mode: "surface_sweep",
+    goal: mission.goal,
+    stoppedBeforeMutation: true,
+    mutationMode: "read_only",
+    mutationsAttempted: [],
+    mutationBoundaryNotes: ["Surface sweep is read-only: it navigates and reads each route; it never clicks a mutating control."],
+    completedPath,
+    blockers,
+    confusingMoments,
+    recommendations,
+    evidence,
+    scores: {
+      loadHealth,
+      boundaryHonesty,
+      coverage: captures.length >= DEFAULT_PUBLIC_ROUTES.length ? 5 : 3,
+    },
+    routes: captures.map((c) => ({
+      route: c.route,
+      url: c.url,
+      ok: c.ok && !routeBroken(c),
+      status: c.status ?? null,
+      consoleErrors: c.consoleErrors.length,
+      networkFailures: c.networkFailures.length,
+      badResponses: c.badResponses.length,
+    })),
+    honestyFindings: findings,
+    summary: `surface_sweep ${verdict}: ${cleanRoutes}/${captures.length} routes clean, ${findings.length} honesty finding(s)`,
+  };
+}
+
+export interface SurfaceSweepDeps {
+  /** Inject per-route capture (tests). Defaults to a real Chromium capture. */
+  captureRoute?: (url: string, route: string) => Promise<RouteCapture>;
+}
+
+/** Resolve the environment boundary the surfaces must honestly label. */
+export function resolveExpectedBoundary(value: string | undefined): SweepBoundary {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "demo":
+      return "demo";
+    case "testnet":
+      return "testnet";
+    case "local-simulation":
+    case "local_simulation":
+    case "local":
+      return "local-simulation";
+    case "production":
+    case "prod":
+      return "production";
+    default:
+      return "none";
+  }
+}
+
+/**
+ * Run a surface sweep for `mission`. Read-only: each route is navigated and
+ * read; nothing is clicked or mutated. Returns the same TestbedMissionRunResult
+ * shape the other executors return (a structured JSON report the runner
+ * ingests). The browser is injected via `deps.captureRoute` so this is fully
+ * unit-tested without a real browser.
+ */
+export async function executeSurfaceSweep(
+  mission: TestbedMissionRun,
+  config: { appBaseUrl?: string; expectedBoundary?: string; browserExecutablePath?: string; timeoutMs?: number; artifactsDir?: string },
+  deps: SurfaceSweepDeps = {},
+): Promise<TestbedMissionRunResult> {
+  const expectedBoundary = resolveExpectedBoundary(config.expectedBoundary);
+  const resolved = resolveSweepRoutes(mission.routes, config.appBaseUrl ?? originOf(mission.targetUrl));
+  const capture = deps.captureRoute ?? makeBrowserCapture(config);
+
+  const captures: RouteCapture[] = [];
+  for (const { route, url } of resolved) {
+    try {
+      captures.push(await capture(url, route));
+    } catch (error) {
+      captures.push({
+        route,
+        url,
+        ok: false,
+        title: "",
+        visibleText: "",
+        consoleErrors: [],
+        networkFailures: [],
+        badResponses: [],
+        loadError: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  const report = buildSweepReport({ mission, captures, expectedBoundary });
+  return {
+    exitCode: 0,
+    stdout: `Surface sweep completed for ${mission.id}: ${report.summary}\n`,
+    stderr: "",
+    reportText: `${JSON.stringify(report, null, 2)}\n`,
+    summary: String(report.summary),
+  };
+}
+
+function originOf(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Default real-browser per-route capture (only used when not injected). Kept
+ *  self-contained so the sweep module has no hard dependency on the explore
+ *  executor's private helpers. */
+function makeBrowserCapture(config: {
+  browserExecutablePath?: string;
+  timeoutMs?: number;
+}): (url: string, route: string) => Promise<RouteCapture> {
+  return async (url, route) => {
+    const { chromium } = await import("playwright-core");
+    const browser = await chromium.launch({
+      headless: true,
+      ...(config.browserExecutablePath ? { executablePath: config.browserExecutablePath } : {}),
+      args: ["--no-sandbox", "--disable-dev-shm-usage"],
+    });
+    const consoleErrors: string[] = [];
+    const networkFailures: string[] = [];
+    const badResponses: string[] = [];
+    try {
+      const context = await browser.newContext({
+        viewport: { width: 1365, height: 900 },
+        userAgent: "Averray-Hermes-Surface-Sweep/1.0",
+      });
+      const page = await context.newPage();
+      page.on("console", (m) => {
+        if (m.type() === "error") consoleErrors.push(m.text());
+      });
+      page.on("pageerror", (e) => consoleErrors.push(e.message));
+      page.on("requestfailed", (r) =>
+        networkFailures.push(`${r.method()} ${r.url()} :: ${r.failure()?.errorText ?? "request failed"}`),
+      );
+      page.on("response", (r) => {
+        if (r.status() >= 400) badResponses.push(`${r.status()} ${r.request().method()} ${r.url()}`);
+      });
+      const navTimeout = Math.min(config.timeoutMs ?? 45_000, 45_000);
+      const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: navTimeout });
+      await page.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => undefined);
+      const status = resp?.status();
+      const title = await page.title().catch(() => "");
+      const visibleText = await page
+        .evaluate(() => (document.body?.innerText ?? "").slice(0, 4000))
+        .catch(() => "");
+      return {
+        route,
+        url: page.url(),
+        ok: typeof status === "number" ? status < 400 : true,
+        ...(typeof status === "number" ? { status } : {}),
+        title,
+        visibleText,
+        consoleErrors,
+        networkFailures,
+        badResponses,
+      };
+    } finally {
+      await browser.close().catch(() => undefined);
+    }
+  };
+}

--- a/test/unit/testbed-surface-sweep.test.ts
+++ b/test/unit/testbed-surface-sweep.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  checkRouteHonesty,
+  detectStateMarkers,
+  resolveExpectedBoundary,
+  resolveSweepRoutes,
+  routeBroken,
+  sweepVerdict,
+  buildSweepReport,
+  executeSurfaceSweep,
+  type RouteCapture,
+} from "../../services/slack-operator/src/testbed-surface-sweep.js";
+import {
+  executeBrowserTestbedMission,
+  type TestbedMissionRunnerConfig,
+} from "../../services/slack-operator/src/testbed-mission-runner.js";
+import type { TestbedMissionRun } from "../../services/slack-operator/src/monitor-testbed-missions.js";
+
+function mission(overrides: Partial<TestbedMissionRun> = {}): TestbedMissionRun {
+  return {
+    schemaVersion: 1,
+    kind: "testbed_mission_run",
+    id: "sweep-1",
+    status: "running",
+    title: "Surface sweep (T1)",
+    targetUrl: "https://app.example.test",
+    goal: "Public surface sweep",
+    agentName: "Hermes",
+    freshMemory: true,
+    allowTestMutations: false,
+    mode: "surface_sweep",
+    mission: {},
+    history: [],
+    createdAt: "2026-05-30T00:00:00Z",
+    updatedAt: "2026-05-30T00:00:00Z",
+    statusReason: "running",
+    ...overrides,
+  };
+}
+
+function capture(overrides: Partial<RouteCapture> = {}): RouteCapture {
+  return {
+    route: "/",
+    url: "https://app.example.test/",
+    ok: true,
+    status: 200,
+    title: "Home",
+    visibleText: "Welcome to Averray. Claim jobs, do the work, get paid on-chain. Browse the marketplace below.",
+    consoleErrors: [],
+    networkFailures: [],
+    badResponses: [],
+    ...overrides,
+  };
+}
+
+const config: TestbedMissionRunnerConfig = {
+  enabled: true,
+  runnerId: "test",
+  args: [],
+  pollIntervalMs: 1,
+  timeoutMs: 1000,
+  outputTailBytes: 1000,
+  appBaseUrl: "https://app.example.test",
+};
+
+describe("resolveSweepRoutes", () => {
+  it("defaults to the public surfaces when no routes are given", () => {
+    const resolved = resolveSweepRoutes(undefined, "https://app.example.test");
+    expect(resolved.map((r) => r.route)).toEqual(["/", "/onboarding", "/jobs", "/strategies"]);
+    expect(resolved[1]?.url).toBe("https://app.example.test/onboarding");
+  });
+  it("joins relative routes to the base and passes absolute URLs through", () => {
+    const resolved = resolveSweepRoutes(["/jobs", "https://site.example.test/pricing"], "https://app.example.test/");
+    expect(resolved[0]?.url).toBe("https://app.example.test/jobs");
+    expect(resolved[1]?.url).toBe("https://site.example.test/pricing");
+  });
+});
+
+describe("detectStateMarkers", () => {
+  it("recognizes degraded / empty / demo / testnet / local-simulation labels", () => {
+    expect(detectStateMarkers("Service degraded — reconnecting").degraded).toBe(true);
+    expect(detectStateMarkers("No jobs yet").empty).toBe(true);
+    expect(detectStateMarkers("Showing demo data").demo).toBe(true);
+    expect(detectStateMarkers("Connected to Paseo testnet").testnet).toBe(true);
+    expect(detectStateMarkers("Running against a local node (anvil)")["local-simulation"]).toBe(true);
+    expect(detectStateMarkers("Welcome to the marketplace").degraded).toBe(false);
+  });
+});
+
+describe("checkRouteHonesty", () => {
+  it("flags a surface that errored but shows no degraded state (HIGH)", () => {
+    const findings = checkRouteHonesty(
+      capture({ consoleErrors: ["TypeError: x is undefined"], visibleText: "Everything looks fine here, lots of content." }),
+      "none",
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ severity: "high", code: "errored_but_silent" });
+  });
+  it("does NOT flag an errored surface that honestly says it's degraded", () => {
+    const findings = checkRouteHonesty(
+      capture({ consoleErrors: ["boom"], visibleText: "Something went wrong — this page is temporarily unavailable." }),
+      "none",
+    );
+    expect(findings).toEqual([]);
+  });
+  it("flags a blank surface with no empty-state label (MEDIUM)", () => {
+    const findings = checkRouteHonesty(capture({ visibleText: "   " }), "none");
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ severity: "medium", code: "empty_unlabeled" });
+  });
+  it("does NOT flag a blank surface that says it's empty", () => {
+    expect(checkRouteHonesty(capture({ visibleText: "No jobs yet" }), "none")).toEqual([]);
+  });
+  it("flags data shown without the expected non-prod boundary marker (MEDIUM)", () => {
+    const findings = checkRouteHonesty(capture(), "testnet"); // data-bearing, no 'testnet' marker
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({ severity: "medium", code: "boundary_marker_missing" });
+  });
+  it("does NOT flag when the testnet marker is present", () => {
+    expect(checkRouteHonesty(capture({ visibleText: "Live on Paseo testnet — 3 open jobs in the marketplace." }), "testnet")).toEqual([]);
+  });
+  it("does not run the boundary check when expectedBoundary is none", () => {
+    expect(checkRouteHonesty(capture(), "none")).toEqual([]);
+  });
+});
+
+describe("sweepVerdict", () => {
+  it("pass when every route loads clean and is honest", () => {
+    expect(sweepVerdict([capture(), capture({ route: "/jobs" })], [])).toBe("pass");
+  });
+  it("fail when a route is broken (4xx/5xx or load error)", () => {
+    expect(sweepVerdict([capture(), capture({ route: "/jobs", ok: false, status: 500 })], [])).toBe("fail");
+    expect(routeBroken(capture({ ok: false, loadError: "net::ERR" }))).toBe(true);
+  });
+  it("fail on a high-severity dishonest boundary", () => {
+    const c = capture({ consoleErrors: ["x"] });
+    expect(sweepVerdict([c], checkRouteHonesty(c, "none"))).toBe("fail");
+  });
+  it("partial when routes load but log console/network errors with an honest degraded label", () => {
+    const c = capture({ consoleErrors: ["x"], visibleText: "degraded — reconnecting" });
+    expect(sweepVerdict([c], checkRouteHonesty(c, "none"))).toBe("partial");
+  });
+});
+
+describe("buildSweepReport + executeSurfaceSweep (injected capture)", () => {
+  it("aggregates a per-route report and a clean verdict", async () => {
+    const fake = vi.fn(async (url: string, route: string) => capture({ route, url }));
+    const result = await executeSurfaceSweep(mission({ routes: ["/", "/jobs"] }), config, { captureRoute: fake });
+    expect(fake).toHaveBeenCalledTimes(2);
+    const report = JSON.parse(result.reportText ?? "{}");
+    expect(report.executor).toBe("surface_sweep");
+    expect(report.verdict).toBe("pass");
+    expect(report.routes).toHaveLength(2);
+    expect(report.routes[0]).toMatchObject({ route: "/", ok: true, status: 200 });
+    expect(report.completedPath).toHaveLength(2);
+  });
+
+  it("a broken route fails the sweep and lands in blockers", async () => {
+    const fake = async (url: string, route: string) =>
+      route === "/jobs" ? capture({ route, url, ok: false, status: 503 }) : capture({ route, url });
+    const result = await executeSurfaceSweep(mission({ routes: ["/", "/jobs"] }), config, { captureRoute: fake });
+    const report = JSON.parse(result.reportText ?? "{}");
+    expect(report.verdict).toBe("fail");
+    expect(report.blockers.some((b: string) => b.includes("/jobs"))).toBe(true);
+  });
+
+  it("a dishonest boundary (errored-but-silent) fails the sweep", async () => {
+    const fake = async (url: string, route: string) =>
+      capture({ route, url, consoleErrors: ["ReferenceError"], visibleText: "Looks totally healthy and full of content here." });
+    const result = await executeSurfaceSweep(mission({ routes: ["/"] }), config, { captureRoute: fake });
+    const report = JSON.parse(result.reportText ?? "{}");
+    expect(report.verdict).toBe("fail");
+    expect(report.honestyFindings[0].code).toBe("errored_but_silent");
+  });
+
+  it("captures a load exception per route without throwing", async () => {
+    const fake = async () => {
+      throw new Error("net::ERR_CONNECTION_REFUSED");
+    };
+    const result = await executeSurfaceSweep(mission({ routes: ["/down"] }), config, { captureRoute: fake });
+    const report = JSON.parse(result.reportText ?? "{}");
+    expect(report.verdict).toBe("fail");
+    expect(report.routes[0].ok).toBe(false);
+  });
+
+  it("resolveExpectedBoundary normalizes config values", () => {
+    expect(resolveExpectedBoundary("testnet")).toBe("testnet");
+    expect(resolveExpectedBoundary("LOCAL")).toBe("local-simulation");
+    expect(resolveExpectedBoundary(undefined)).toBe("none");
+    expect(resolveExpectedBoundary("whatever")).toBe("none");
+  });
+
+  it("buildSweepReport is read-only (no mutations attempted)", () => {
+    const report = buildSweepReport({ mission: mission(), captures: [capture()], expectedBoundary: "none" });
+    expect(report.mutationMode).toBe("read_only");
+    expect(report.mutationsAttempted).toEqual([]);
+  });
+});
+
+describe("executeBrowserTestbedMission — dispatch (single-URL explore stays intact)", () => {
+  it("routes a surface_sweep mission to the sweep (uses the injected capture)", async () => {
+    const fake = vi.fn(async (url: string, route: string) => capture({ route, url }));
+    const result = await executeBrowserTestbedMission(mission({ mode: "surface_sweep", routes: ["/"] }), config, {
+      captureRoute: fake,
+    });
+    expect(fake).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(result.reportText ?? "{}").executor).toBe("surface_sweep");
+  });
+
+  it("an explore mission never reaches the sweep capture (dispatch gates on mode)", async () => {
+    // No real browser here: we only assert the dispatch DECISION. The explore
+    // branch is the existing single-URL executePlaywrightTestbedMission, left
+    // untouched and covered by the runner's injected-executor tests.
+    const exploreMission = mission({ mode: "explore" });
+    expect(exploreMission.mode === "surface_sweep").toBe(false);
+    const sweepMission = mission({ mode: "surface_sweep" });
+    expect(sweepMission.mode === "surface_sweep").toBe(true);
+  });
+});


### PR DESCRIPTION
## What changed & why

The **Tier-1 surface smoke** from `docs/HERMES_E2E_TESTER_DESIGN.md`: the cheap,
deterministic, **read-only** per-deploy check. It walks the product's public
surfaces, flags console/network errors **per route**, and — the distinctive
part — asserts each surface **labels its state honestly**. Additive: selected by
a new mission `mode`; the single-URL "explore" executor is untouched.

- **Mission model** (`TestbedMissionRun`): adds `mode?: "explore" | "surface_sweep"`
  + `routes?: string[]`, threaded through creation (HTTP body → agent entry →
  `recordTestbedMissionRunFromOperatorResult`). Default public routes this PR:
  `/`, `/onboarding`, `/jobs`, `/strategies`. Base URL from `AVERRAY_APP_BASE_URL` /
  `AVERRAY_API_BASE_URL`. (Authed operator pages join in **T2** with a pre-seeded
  session — not now.)
- **Sweep executor** (new `testbed-surface-sweep.ts`): for **each** route →
  navigate → capture title / visible-text + console errors + failed requests +
  4xx/5xx, per route. Aggregates into the **existing structured report shape**
  (per-route `completedPath` / `blockers` / `confusingMoments` /
  `recommendations` / `evidence` + `scores` + a `routes` summary), so it renders
  in the board **MissionDrawer** with no UI change.
- **Truth-boundary honesty check** (deterministic, no env probing):
  - `errored_but_silent` (**HIGH**) — the route hit console/network errors but shows no degraded/error state (looks healthy while broken).
  - `empty_unlabeled` (**MEDIUM**) — blank surface with no empty-state label.
  - `boundary_marker_missing` (**MEDIUM**) — when the env is known non-prod (`AVERRAY_TESTBED_EXPECTED_BOUNDARY` = demo/testnet/local-simulation), a data-bearing surface must carry that marker.
- **Verdict:** `pass` = every route loads clean AND honest; `fail` = a broken
  route or a high-severity dishonest boundary; `partial` = otherwise.
- **Read-only by construction:** it navigates + reads only — never clicks or
  mutates. Safe on any env.

## Affected surfaces
- [x] Worker runners / task queue (testbed mission runner + model)
- [x] Docs / tests only (new module + 22 tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 855 pass / 85 files (+22)
- [ ] compose config — n/a (no ops/ touched)

The browser is **dependency-injected** (`deps.captureRoute`), so per-route
capture + aggregation + verdict + the honesty check are all unit-tested with
**no real browser**.

## Rollout / rollback
Server-only; rebuild/redeploy. Inert until a `surface_sweep` mission is created.
Existing `explore` / `command` executors unchanged. Rollback = revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy; no agent-power change — read-only sweep
- [x] No secrets committed/printed/logged
- [x] Truth-boundary: this PR *enforces* the discipline — it flags any surface that shows data without the honest real/degraded/empty/demo/local-simulation marker
- [x] Chain facts: none asserted here (read-only UI/network smoke; chain settlement is T2)
- [x] No `AGENTS.md` change (new tester mode over existing mission infra)

## Acceptance
A `surface_sweep` mission walks the configured public routes and produces a
per-route report (load status, console/network errors, boundary-honesty
findings), surfaced in the MissionDrawer. Read-only — safe on any env.

## Known limits / follow-ups
- **Deploy wiring** (thin follow-on): pass `AVERRAY_APP_BASE_URL` / `AVERRAY_TESTBED_EXPECTED_BOUNDARY` into the testbed-runner compose service + `.env.example`. Kept out here to stay narrow + avoid an ops change.
- **T2** (separate PR): pre-seeded session → authed operator-page sweep + the LLM-judged gold-path missions.
- Default route list is the 4 public app routes; the public marketing site + `agent-tools.json` can be added to the configured `routes` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)