### PR TITLE
docs: state the canonical mission-queue path (POST /monitor/testbed-missions)

### DIFF
--- a/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
+++ b/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
@@ -21,7 +21,7 @@
 
 **Scope/safety:** agent-requested runs are **read-only by default** — surface sweep (T1) or a **targeted read-only mission** against the changed route/feature. Mutating/gold-path missions stay **operator-initiated** (an agent can't request a mutation). Testnet/preview env only; under `HALT_FILE`.
 
-**Entry point (closes the interface gap):** the building agents work in `averray-agent/agent` and likely don't have the Averray MCP. So ship a thin **platform-repo helper** (e.g. `scripts/request-tester-run.sh` / an npm script) that POSTs the request to the monitor's mission-request endpoint (in this repo) and prints the board link. The reference-agent exposes the endpoint + the gate; the platform repo ships the helper so agents have it in-context.
+**Entry point (closes the interface gap):** the building agents work in `averray-agent/agent` and likely don't have the Averray MCP. So ship a thin **platform-repo helper** (e.g. `scripts/request-tester-run.sh` / an npm script) that POSTs the request to the canonical queue endpoint **`POST /monitor/testbed-missions`** (slack-operator `:8790`) and prints the board link — **not** the `averray_testbed_agent_mission` MCP tool, which only returns a prompt packet. The reference-agent adds the **proposed → approve gate** on top of that endpoint for agent-requested runs; the platform repo ships the helper so agents have it in-context.
 
 ## 2. Tester capabilities manifest — always known
 

--- a/docs/HERMES_E2E_TESTER_DESIGN.md
+++ b/docs/HERMES_E2E_TESTER_DESIGN.md
@@ -43,6 +43,8 @@ A real LLM agent with a dedicated testnet wallet attempts the actual journeys li
 - **Wiring:** runs through the existing **`command` executor hook** (`testbed-mission-runner.ts:191`) — the runner passes the mission + a `reportPath`; the agent writes its structured report there; the runner ingests it. No pipeline rewrite — bring the agent.
 - **Reuse the P2 worker pattern:** the Tier-2 agent is a specialized per-agent runner (its own command + heartbeat), so it slots into the multi-agent model rather than being a bespoke thing.
 
+> **Canonical queue path (don't get this wrong):** missions are queued via **`POST /monitor/testbed-missions`** (slack-operator, `:8790`) — that's the path that supports `mode` (e.g. `surface_sweep`) + `routes`. The `averray_testbed_agent_mission` MCP tool only returns a *prompt packet* (`targetUrl`/`goal`, no `mode`/`routes`, no queueing) — **do not use it to start a run.** (Confirmed while wiring the post-deploy sweep — platform PR #604.)
+
 ---
 
 ## Wallet & auth  (decision #3): real SIWE via a signer sidecar

--- a/docs/HERMES_INTEGRATION_MAP.md
+++ b/docs/HERMES_INTEGRATION_MAP.md
@@ -95,7 +95,7 @@ Two existing guardrail layers, **both about job/mission execution, neither about
 
 ## Q5 — Full MCP tool surface + `invoke_agent_task` intents ✅ CONFIRMED
 
-`averray_*` tools registered in `packages/averray-mcp/src/index.ts` (selected): `list_jobs`, `get_definition`, `operator_status`, `daily_operator_brief`, `find_safe_work`, `agent_usefulness_plan`, `project_memory`, `project_runbook`, `admin_readiness`, `admin_action_proposal`, `ops_health`, `github_status`, `github_brief`, `approve_github_merge_steward_candidate`, `testbed_agent_mission`, `testbed_e2e_suite`, `run_testbed_e2e_read_only`, `handoff_monitor`, **`invoke_agent_task`** (`:328`), **`handle_operator_command`** (`:358`), `run_wikipedia_citation_repair`, `claim`, `save_draft_submission`, …
+`averray_*` tools registered in `packages/averray-mcp/src/index.ts` (selected): `list_jobs`, `get_definition`, `operator_status`, `daily_operator_brief`, `find_safe_work`, `agent_usefulness_plan`, `project_memory`, `project_runbook`, `admin_readiness`, `admin_action_proposal`, `ops_health`, `github_status`, `github_brief`, `approve_github_merge_steward_candidate`, `testbed_agent_mission` *(prompt packet only — to **queue** a mission use `POST /monitor/testbed-missions` on slack-operator `:8790`)*, `testbed_e2e_suite`, `run_testbed_e2e_read_only`, `handoff_monitor`, **`invoke_agent_task`** (`:328`), **`handle_operator_command`** (`:358`), `run_wikipedia_citation_repair`, `claim`, `save_draft_submission`, …
 
 `AgentInvocationIntent` (`packages/averray-mcp/src/agent-invocation.ts:24`):
 ```


### PR DESCRIPTION
## What changed

Captures the catch from wiring the post-deploy surface sweep (platform PR #604): `averray_testbed_agent_mission` only returns a **prompt packet** (targetUrl/goal, no mode/routes, no queueing). The path that actually **queues** a mission — and supports `mode=surface_sweep` + `routes` — is **`POST /monitor/testbed-missions`** (slack-operator `:8790`).

The design docs never stated this, which is how the wrong path slipped into handoff prompts. Now made explicit in:
- `HERMES_E2E_TESTER_DESIGN.md` — a "canonical queue path" callout.
- `HERMES_AGENT_REQUESTS_AND_ALERTS.md` — the agent helper POSTs to the real endpoint (gate added on top).
- `HERMES_INTEGRATION_MAP.md` — clarifier on the `testbed_agent_mission` tool.

Docs-only. (The curl-example docs — CODEX_HANDOFF_PROTOCOL, MONITOR_ACTION_PARITY — were already correct.)

## Checks run

None — documentation only.