### PR TITLE
ops: complete the testbed-runner for T1 surface sweeps + document enabling it

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -87,6 +87,45 @@ Codex dispatch) are tracked for wiring onto the new board in
 
 ---
 
+## Optional: the Tier-1 surface-sweep runner (`testbed-runner` profile)
+
+Off by default. Enable it so queued `surface_sweep` missions (e.g. the
+post-deploy step in the platform repo's `deploy-production.yml`) actually
+execute — without it they queue forever and the board shows "no healthy
+runner". It's a profile-gated service, mirroring `codex-runner` /
+`claude-runner`.
+
+**`.env.prod` edits:**
+```
+TESTBED_MISSION_RUNNER_ENABLED=1
+# Optional: the env's truth boundary the honesty check asserts. Set to
+# testnet / demo / local-simulation when the deployed env is non-production so
+# data-bearing surfaces must carry that marker; leave empty otherwise.
+AVERRAY_TESTBED_EXPECTED_BOUNDARY=
+```
+
+**Bring it up under its profile** (shares the `avg-data` volume, so it reads
+the same mission queue the `/monitor/testbed-missions` endpoint writes):
+```
+docker compose --env-file ops/.env.prod --profile testbed-runner \
+  -f ops/compose.yml -f ops/compose.prod.yml up -d testbed-mission-runner
+```
+
+The runtime image already ships system Chromium at `/usr/bin/chromium`
+(`ops/Dockerfile.node`), and the service points the Playwright executor at it
+via `TESTBED_MISSION_BROWSER_EXECUTABLE_PATH` — no extra browser install.
+
+**Verify it's online** (no secrets printed):
+```
+docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml \
+  logs --since 5m testbed-mission-runner | grep -iE "online|idle|claimed|chromium|disabled" | tail -10
+```
+A healthy runner logs `idle` (online, waiting). Once it claims a sweep, the
+per-route report appears on the board and the entrypoint's "no healthy runner"
+note flips to online.
+
+---
+
 ## Assumptions / things to confirm in your environment
 
 - The image name assumes the GitHub org is `depre-dev` (i.e.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -37,13 +37,30 @@ HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud
 HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud
 HERMES_MONITOR_MEMORY_PATH=/data/hermes-monitor-memory.json
 HERMES_COMPARISON_MODEL=qwen3.5:cloud
+# Hermes testbed-mission runner (ops profile "testbed-runner"; off by default).
+# Claims queued testbed missions — incl. T1 surface_sweep — and runs them in a
+# headless browser. To enable: run under the "testbed-runner" profile and set
+# TESTBED_MISSION_RUNNER_ENABLED=1 (see docs/DEPLOY.md).
 AVERRAY_TESTBED_MISSIONS_PATH=/data/testbed-missions.json
 TESTBED_MISSION_RUNNER_ENABLED=0
 TESTBED_MISSION_RUNNER_ID=vps-hermes-testbed-runner
+# "playwright" drives a headless Chromium (the surface sweep needs this);
+# "command" shells out to TESTBED_MISSION_RUNNER_COMMAND/ARGS instead.
+TESTBED_MISSION_RUNNER_EXECUTOR=playwright
 TESTBED_MISSION_RUNNER_COMMAND=node
 TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/testbed-mission-http-runner.js
 TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS=10000
 TESTBED_MISSION_RUNNER_TIMEOUT_MS=1200000
+# Browser binary the playwright executor launches. The runtime image installs
+# system chromium at /usr/bin/chromium (ops/Dockerfile.node).
+TESTBED_MISSION_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+TESTBED_MISSION_ARTIFACTS_DIR=/data/testbed-mission-artifacts
+TESTBED_MISSION_MAX_BROWSER_STEPS=12
+# T1 surface sweep: env's truth boundary the honesty check asserts surfaces
+# label. Empty ⇒ self-consistency checks only (errored-but-silent /
+# empty-unlabeled). Set to testnet/demo/local-simulation when the deployed env
+# is non-production so data-bearing surfaces must carry that marker.
+AVERRAY_TESTBED_EXPECTED_BOUNDARY=
 
 # Claude worker (O2) model-provider auth & billing. See
 # docs/HERMES_WORKER_AUTH_BILLING.md. The worker verifies the active route

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -209,6 +209,14 @@ services:
       TESTBED_MISSION_BROWSER_EXECUTABLE_PATH: ${TESTBED_MISSION_BROWSER_EXECUTABLE_PATH:-/usr/bin/chromium}
       TESTBED_MISSION_ARTIFACTS_DIR: ${TESTBED_MISSION_ARTIFACTS_DIR:-/data/testbed-mission-artifacts}
       TESTBED_MISSION_MAX_BROWSER_STEPS: ${TESTBED_MISSION_MAX_BROWSER_STEPS:-12}
+      # T1 surface sweep: base URL for relative routes (falls back to the
+      # mission's targetUrl when unset) + the env's truth boundary the honesty
+      # check asserts. Leave EXPECTED_BOUNDARY empty for the self-consistency
+      # checks only (errored-but-silent / empty-unlabeled); set demo / testnet /
+      # local-simulation to ALSO require that marker on data-bearing surfaces.
+      AVERRAY_APP_BASE_URL: ${AVERRAY_APP_BASE_URL:-}
+      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL:-}
+      AVERRAY_TESTBED_EXPECTED_BOUNDARY: ${AVERRAY_TESTBED_EXPECTED_BOUNDARY:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-data:/data


### PR DESCRIPTION
## What changed & why

So queued `surface_sweep` missions (the platform repo's post-deploy step, #604)
**actually execute** instead of queuing forever / showing "no healthy runner".

**Honest scope — what already existed (no rebuild):** the
`testbed-mission-runner` compose service was already present (profile
`testbed-runner`, off by default, shared `avg-data` volume + the **same mission
path the `/monitor/testbed-missions` endpoint writes**), and the runtime image
already ships **system Chromium at `/usr/bin/chromium`** (`ops/Dockerfile.node`)
with `TESTBED_MISSION_BROWSER_EXECUTABLE_PATH` pointing at it. So the
load-bearing browser bit was done — **no service added, no Dockerfile change**
(Chromium is in the one shared image; nothing bloats).

This PR fills the remaining gaps:
- **compose:** pass the T1 sweep env to the service — `AVERRAY_APP_BASE_URL` /
  `AVERRAY_API_BASE_URL` (base for relative routes; falls back to the mission's
  `targetUrl` when unset) + `AVERRAY_TESTBED_EXPECTED_BOUNDARY` (the honesty
  check's boundary marker; empty ⇒ self-consistency checks only).
- **.env.example:** document the full testbed-runner surface (executor, browser
  path, artifacts, max steps, expected boundary) + an enable note.
- **docs/DEPLOY.md:** a "testbed-runner profile" section — the `.env.prod` flag,
  the profile-up command, the online/idle log check — mirroring the codex /
  claude runner enablement.

Heartbeat is already wired (`runTestbedMissionRunnerOnce` writes
`idle`/`running`/…), so once enabled the board's "no healthy runner" flips to
online.

## Affected surfaces
- [x] ops / compose / Dockerfile / image (compose env passthrough; no Dockerfile change)
- [x] Worker runners / task queue (the testbed runner)
- [x] Secrets / config / env (env wiring; no secret values)
- [x] Docs / tests only (DEPLOY.md, .env.example)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 855 pass (config/docs only; no source change)
- [~] `docker compose … config` — Compose v2 unavailable on this box; YAML +
  `${VAR:-default}` interpolation validated via the `yaml` parser (service
  present, profile `testbed-runner`, `ENABLED` default `0`, shared volume).
  **CI runs the real check.**

## Rollout / rollback
Still **off by default**. The VPS turn-on stays an operator action per AGENTS.md:
set `TESTBED_MISSION_RUNNER_ENABLED=1`, bring it up under `--profile
testbed-runner`, redeploy. Rollback = drop the profile / revert. No state change.

## Durable invariants (AGENTS.md)
- [x] Off-by-default, operator-enabled per ops profile — mirrors codex/claude runners
- [x] Read-only runner (surface sweep is public-surfaces, no mutations); agents don't redeploy prod
- [x] No secrets committed/printed/logged
- [x] Docs updated (DEPLOY.md enable steps)

## Acceptance
With the `testbed-runner` profile up + `TESTBED_MISSION_RUNNER_ENABLED=1`, a
queued `surface_sweep` is claimed, runs headless Chromium against the routes,
and its per-route report appears on the board; the runner heartbeat shows
online. (Operator flips it on; local profile-up smoke isn't feasible without the
full stack + Compose v2.)

## Known limits / follow-ups
- Closes the T1 loop with #604 (post-deploy trigger) + #273 (the executor). After this merges + the operator enables the profile, the surface sweep runs per-deploy.
- `AVERRAY_TESTBED_EXPECTED_BOUNDARY` defaults empty (self-consistency only). The deployed env is testnet-backed per the design — consider setting it to `testnet` so the honesty check asserts surfaces label that; left to the operator to avoid a false-positive if the env's labeling differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)