### PR TITLE
O4-PR1: Hermes enqueue capability + dispatch guardrail (proposes-only)

### DIFF
--- a/hermes/config/policy.yaml
+++ b/hermes/config/policy.yaml
@@ -11,4 +11,15 @@ budget:
   per_run_usd_max: 0.5
   per_day_usd_max: 1.0
   max_browser_steps: 80
+# O4 dispatch guardrail — which repos/agents Hermes may PROPOSE tasks for, and
+# how many per day. Proposes-only: every proposed task still needs operator
+# approval on the board (O4-PR1 adds no auto-approval). FAIL-CLOSED: an empty
+# allowed_repos means Hermes can propose nothing — the operator opts repos in.
+dispatch:
+  allowed_repos: []
+  allowed_agents:
+    - codex
+    - claude
+  per_day_max: 10
+  per_repo_per_day_max: 5
 

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -20,6 +20,12 @@ import {
   summarizeHandoffResult,
   type HandoffEventInput,
 } from "./handoff-events.js";
+import { assertNoKillSwitch } from "@avg/mcp-common";
+import {
+  loadDispatchPolicyConfig,
+  evaluateDispatchPolicy,
+  type DispatchPolicyConfig,
+} from "./dispatch-policy.js";
 
 export type AgentInvocationIntent =
   | "operator_command"
@@ -28,7 +34,25 @@ export type AgentInvocationIntent =
   | "testbed_case"
   | "pr_code_review"
   | "pr_handoff"
-  | "post_deploy_verification";
+  | "post_deploy_verification"
+  | "enqueue_agent_task";
+
+/** A task Hermes proposed (O4). Proposes-only: status is "proposed", never approved. */
+export interface ProposedAgentTask {
+  repo: string;
+  agent: "codex" | "claude";
+  prompt: string;
+  requester: string;
+  pullRequestNumber?: number;
+  reason?: string;
+}
+
+/** A queued task, as returned by GET /monitor/codex-tasks (for the daily budget). */
+export interface QueuedTaskSummary {
+  requester?: string;
+  createdAt?: string;
+  repo?: string;
+}
 
 export interface AgentInvocationInput {
   requester: string;
@@ -51,6 +75,9 @@ export interface AgentInvocationInput {
   defaultDryRun?: boolean;
   maxEvidenceUrls?: number;
   confidenceThreshold?: number;
+  /** enqueue_agent_task: the task prompt + which agent to propose it to. */
+  prompt?: string;
+  agent?: "codex" | "claude";
 }
 
 export interface AgentInvocationDeps {
@@ -61,6 +88,17 @@ export interface AgentInvocationDeps {
   healthFetchFn?: typeof fetch;
   handoffEventRecorder?: (event: HandoffEventInput) => Promise<unknown>;
   now?: Date;
+  // ── enqueue_agent_task (O4) — all injectable for tests (no network). ──
+  /** Dispatch guardrail config; defaults to loadDispatchPolicyConfig(env). */
+  dispatchPolicyConfig?: DispatchPolicyConfig;
+  /** POST a PROPOSED task to the queue; defaults to the slack-operator endpoint. */
+  proposeTaskFn?: (task: ProposedAgentTask) => Promise<{ id?: string }>;
+  /** List queued tasks for the daily budget; defaults to GET the queue endpoint. */
+  listQueuedTasksFn?: () => Promise<QueuedTaskSummary[]>;
+  /** HALT kill-switch check; defaults to assertNoKillSwitch. */
+  assertNoKillSwitchFn?: (toolName: string) => Promise<void>;
+  /** Env for the default enqueue transport + policy load. */
+  enqueueEnv?: NodeJS.ProcessEnv;
 }
 
 const POST_DEPLOY_TEST_CASES = [
@@ -167,6 +205,10 @@ async function invokeAgentTaskInner(
 
   if (intent === "post_deploy_verification") {
     return invokePostDeployVerification(input, deps, invocation, startedAt);
+  }
+
+  if (intent === "enqueue_agent_task") {
+    return invokeEnqueueAgentTask(input, deps, invocation, startedAt);
   }
 
   if (intent === "testbed_case") {
@@ -771,6 +813,116 @@ function opsSignalsFromSuite(run: unknown) {
 
 function firstPresent(values: Array<string | undefined>): string | undefined {
   return values.find((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+// O4 — Hermes proposes an agent task (proposes-only; never approves/runs).
+// Order: HALT kill-switch → dispatch guardrail (allowlist + budget) → create a
+// `proposed` task on the queue. The handoff event is recorded by the
+// invokeAgentTask wrapper. The operator approval gate is untouched.
+async function invokeEnqueueAgentTask(
+  input: AgentInvocationInput,
+  deps: AgentInvocationDeps,
+  invocation: Record<string, unknown>,
+  startedAt: Date
+): Promise<unknown> {
+  const repo = (input.repo ?? "").trim();
+  const prompt = (input.prompt ?? "").trim();
+  const agent = ((input.agent ?? "codex").trim() || "codex") as "codex" | "claude";
+  if (!repo) return blockedInvocation(invocation, startedAt, "repo_required");
+  if (!prompt) return blockedInvocation(invocation, startedAt, "prompt_required");
+
+  // (a) HALT kill-switch — block cleanly rather than crash.
+  const assertKill = deps.assertNoKillSwitchFn ?? assertNoKillSwitch;
+  try {
+    await assertKill("enqueue_agent_task");
+  } catch {
+    return blockedInvocation(invocation, startedAt, "halt_file_present", undefined, {
+      mutates: false,
+      localCheckpoint: false,
+    });
+  }
+
+  // (b) Dispatch guardrail — allowlist + per-day budget. Fail-closed.
+  const env = deps.enqueueEnv ?? process.env;
+  const policy = deps.dispatchPolicyConfig ?? loadDispatchPolicyConfig(env);
+  const queued = await (deps.listQueuedTasksFn ?? defaultListQueuedTasks(env))().catch(
+    () => [] as QueuedTaskSummary[],
+  );
+  const today = (deps.now ?? new Date()).toISOString().slice(0, 10);
+  const hermesToday = queued.filter(
+    (t) => (t.requester ?? "").toLowerCase() === "hermes" && (t.createdAt ?? "").slice(0, 10) === today,
+  );
+  const decision = evaluateDispatchPolicy(policy, {
+    repo,
+    agent,
+    todayCount: hermesToday.length,
+    todayRepoCount: hermesToday.filter((t) => t.repo === repo).length,
+  });
+  if (!decision.allowed) {
+    return blockedInvocation(invocation, startedAt, decision.reason, undefined, {
+      mutates: false,
+      localCheckpoint: false,
+    });
+  }
+
+  // (c) Create a PROPOSED task — never approved. The operator approves on the board.
+  const proposeTask = deps.proposeTaskFn ?? defaultProposeTask(env);
+  const created = await proposeTask({
+    repo,
+    agent,
+    prompt,
+    requester: "hermes",
+    ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
+    ...(input.reason ? { reason: input.reason } : {}),
+  });
+
+  return completedInvocation(
+    invocation,
+    startedAt,
+    {
+      kind: "enqueue_agent_task",
+      status: "proposed", // proposes-only — this PR never approves or runs a task
+      proposedTaskId: created.id ?? null,
+      repo,
+      agent,
+      requester: "hermes",
+      note: "Task proposed; it lands on the board and awaits operator approval. Never auto-approved or auto-run.",
+    },
+    { mutates: false, localCheckpoint: false },
+  );
+}
+
+// enqueue transport — POST/GET the slack-operator queue endpoint. Injected in
+// tests; in prod reads the internal monitor base URL + token from env.
+function monitorBase(env: NodeJS.ProcessEnv): string {
+  return (env.AVERRAY_MONITOR_BASE_URL?.trim() || "http://slack-operator:8790").replace(/\/+$/, "");
+}
+
+function monitorAuthHeaders(env: NodeJS.ProcessEnv): Record<string, string> {
+  const token = env.SLACK_OPERATOR_MONITOR_TOKEN?.trim();
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+function defaultProposeTask(env: NodeJS.ProcessEnv): (task: ProposedAgentTask) => Promise<{ id?: string }> {
+  return async (task) => {
+    const res = await fetch(`${monitorBase(env)}/monitor/codex-tasks`, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...monitorAuthHeaders(env) },
+      body: JSON.stringify({ action: "propose", ...task }),
+    });
+    if (!res.ok) throw new Error(`enqueue_propose_failed:${res.status}`);
+    const json = (await res.json().catch(() => ({}))) as { task?: { id?: string } };
+    return { id: json.task?.id };
+  };
+}
+
+function defaultListQueuedTasks(env: NodeJS.ProcessEnv): () => Promise<QueuedTaskSummary[]> {
+  return async () => {
+    const res = await fetch(`${monitorBase(env)}/monitor/codex-tasks`, { headers: monitorAuthHeaders(env) });
+    if (!res.ok) return [];
+    const json = (await res.json().catch(() => ({}))) as { items?: QueuedTaskSummary[] };
+    return Array.isArray(json.items) ? json.items : [];
+  };
 }
 
 function completedInvocation(

--- a/packages/averray-mcp/src/dispatch-policy.ts
+++ b/packages/averray-mcp/src/dispatch-policy.ts
@@ -1,0 +1,113 @@
+// O4 — the dispatch guardrail (NEW; deliberately separate from
+// mutation-policy.ts, which governs claim/submit).
+//
+// Hermes gains the power to PROPOSE agent tasks (enqueue_agent_task). Per
+// AGENTS.md invariant #6, a new power ships with an allowlist + budget + human
+// approval. This module is the allowlist + budget half; the human-approval half
+// is the unchanged operator gate (approveCodexTask) — this PR proposes only,
+// never approves.
+//
+// FAIL-CLOSED: an empty/malformed allowlist denies everything (Hermes can
+// propose nothing until the operator opts repos in) — never allow-all.
+
+import { optionalEnv, readYamlFile } from "@avg/mcp-common";
+
+export interface DispatchPolicyConfig {
+  /** Repos Hermes may propose work in. EMPTY ⇒ deny everything (fail-closed). */
+  allowedRepos: string[];
+  /** Agents Hermes may propose to. Defaults to codex + claude. */
+  allowedAgents: string[];
+  /** Max Hermes-proposed tasks per day across all repos. */
+  perDayMax: number;
+  /** Max per repo per day. 0 ⇒ no per-repo cap (only the global cap applies). */
+  perRepoPerDayMax: number;
+}
+
+export interface DispatchPolicyInput {
+  repo: string;
+  agent: string;
+  /** Hermes-proposed tasks already created today (all repos). */
+  todayCount: number;
+  /** Hermes-proposed tasks already created today for `repo`. */
+  todayRepoCount: number;
+}
+
+export interface DispatchPolicyDecision {
+  allowed: boolean;
+  reason: string;
+}
+
+interface DispatchYamlBlock {
+  allowed_repos?: unknown;
+  allowed_agents?: unknown;
+  per_day_max?: unknown;
+  per_repo_per_day_max?: unknown;
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((v) => (typeof v === "string" ? v.trim() : ""))
+    .filter((v) => v.length > 0);
+}
+
+function positiveIntOr(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Load the dispatch guardrail from the `dispatch:` block of policy.yaml, with
+ * env overrides. Defaults are fail-closed: an absent/empty allowed_repos denies
+ * everything. allowed_agents defaults to codex + claude.
+ */
+export function loadDispatchPolicyConfig(env: NodeJS.ProcessEnv = process.env): DispatchPolicyConfig {
+  const yaml = readYamlFile<{ dispatch?: DispatchYamlBlock }>(
+    optionalEnv("POLICY_CONFIG_PATH", "/config/policy.yaml") ?? "/config/policy.yaml",
+    {},
+  );
+  const block = yaml.dispatch ?? {};
+
+  // Env override for repos (comma/space-separated) when present; else the yaml.
+  const envRepos = env.HERMES_DISPATCH_ALLOWED_REPOS;
+  const allowedRepos = envRepos !== undefined
+    ? envRepos.split(/[\s,]+/).map((r) => r.trim()).filter(Boolean)
+    : stringArray(block.allowed_repos);
+
+  const allowedAgents = stringArray(block.allowed_agents);
+  return {
+    allowedRepos,
+    allowedAgents: allowedAgents.length > 0 ? allowedAgents : ["codex", "claude"],
+    perDayMax: positiveIntOr(env.HERMES_DISPATCH_PER_DAY_MAX ?? block.per_day_max, 10),
+    perRepoPerDayMax: positiveIntOr(env.HERMES_DISPATCH_PER_REPO_PER_DAY_MAX ?? block.per_repo_per_day_max, 5),
+  };
+}
+
+/**
+ * Decide whether Hermes may propose this task. Pure: the caller supplies the
+ * already-counted daily totals (derived from the task queue). Fail-closed.
+ */
+export function evaluateDispatchPolicy(
+  config: DispatchPolicyConfig,
+  input: DispatchPolicyInput,
+): DispatchPolicyDecision {
+  if (!Array.isArray(config.allowedRepos) || config.allowedRepos.length === 0) {
+    return { allowed: false, reason: "dispatch_allowlist_empty" };
+  }
+  const repo = (input.repo ?? "").trim();
+  if (!repo) return { allowed: false, reason: "repo_required" };
+  if (!config.allowedRepos.includes(repo)) {
+    return { allowed: false, reason: "repo_not_allowed" };
+  }
+  const agent = (input.agent ?? "").trim();
+  if (!config.allowedAgents.includes(agent)) {
+    return { allowed: false, reason: "agent_not_allowed" };
+  }
+  if (input.todayCount >= config.perDayMax) {
+    return { allowed: false, reason: "daily_budget_exhausted" };
+  }
+  if (config.perRepoPerDayMax > 0 && input.todayRepoCount >= config.perRepoPerDayMax) {
+    return { allowed: false, reason: "repo_daily_budget_exhausted" };
+  }
+  return { allowed: true, reason: "dispatch_allowed" };
+}

--- a/test/unit/o4-enqueue-guardrail.test.ts
+++ b/test/unit/o4-enqueue-guardrail.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  loadDispatchPolicyConfig,
+  evaluateDispatchPolicy,
+  type DispatchPolicyConfig,
+} from "../../packages/averray-mcp/src/dispatch-policy.js";
+import {
+  invokeAgentTask,
+  type AgentInvocationDeps,
+  type AgentInvocationInput,
+  type QueuedTaskSummary,
+} from "../../packages/averray-mcp/src/agent-invocation.js";
+
+const ALLOWED: DispatchPolicyConfig = {
+  allowedRepos: ["averray-agent/agent"],
+  allowedAgents: ["codex", "claude"],
+  perDayMax: 10,
+  perRepoPerDayMax: 5,
+};
+
+describe("dispatch-policy — allowlist + budget (fail-closed)", () => {
+  it("empty allowlist denies everything (never allow-all)", () => {
+    const cfg: DispatchPolicyConfig = { ...ALLOWED, allowedRepos: [] };
+    expect(evaluateDispatchPolicy(cfg, { repo: "averray-agent/agent", agent: "codex", todayCount: 0, todayRepoCount: 0 }))
+      .toEqual({ allowed: false, reason: "dispatch_allowlist_empty" });
+  });
+
+  it("allows a repo + agent that are on the allowlist and under budget", () => {
+    expect(evaluateDispatchPolicy(ALLOWED, { repo: "averray-agent/agent", agent: "claude", todayCount: 3, todayRepoCount: 1 }))
+      .toEqual({ allowed: true, reason: "dispatch_allowed" });
+  });
+
+  it("rejects a repo not on the allowlist", () => {
+    expect(evaluateDispatchPolicy(ALLOWED, { repo: "evil/repo", agent: "codex", todayCount: 0, todayRepoCount: 0 }).reason)
+      .toBe("repo_not_allowed");
+  });
+
+  it("rejects an agent not on the allowlist", () => {
+    expect(evaluateDispatchPolicy(ALLOWED, { repo: "averray-agent/agent", agent: "gpt5", todayCount: 0, todayRepoCount: 0 }).reason)
+      .toBe("agent_not_allowed");
+  });
+
+  it("enforces the per-day budget (under / at / over)", () => {
+    const at = evaluateDispatchPolicy(ALLOWED, { repo: "averray-agent/agent", agent: "codex", todayCount: 10, todayRepoCount: 0 });
+    expect(at).toEqual({ allowed: false, reason: "daily_budget_exhausted" });
+    const under = evaluateDispatchPolicy(ALLOWED, { repo: "averray-agent/agent", agent: "codex", todayCount: 9, todayRepoCount: 0 });
+    expect(under.allowed).toBe(true);
+  });
+
+  it("enforces the per-repo daily budget", () => {
+    const r = evaluateDispatchPolicy(ALLOWED, { repo: "averray-agent/agent", agent: "codex", todayCount: 3, todayRepoCount: 5 });
+    expect(r).toEqual({ allowed: false, reason: "repo_daily_budget_exhausted" });
+  });
+
+  it("loadDispatchPolicyConfig: fail-closed default repos + env override + default agents", () => {
+    // No POLICY_CONFIG_PATH / yaml ⇒ empty repos (fail-closed); agents default codex+claude.
+    const bare = loadDispatchPolicyConfig({ POLICY_CONFIG_PATH: "/does/not/exist.yaml" } as NodeJS.ProcessEnv);
+    expect(bare.allowedRepos).toEqual([]);
+    expect(bare.allowedAgents).toEqual(["codex", "claude"]);
+    const overridden = loadDispatchPolicyConfig({
+      POLICY_CONFIG_PATH: "/does/not/exist.yaml",
+      HERMES_DISPATCH_ALLOWED_REPOS: "averray-agent/agent, depre-dev/site",
+      HERMES_DISPATCH_PER_DAY_MAX: "3",
+    } as NodeJS.ProcessEnv);
+    expect(overridden.allowedRepos).toEqual(["averray-agent/agent", "depre-dev/site"]);
+    expect(overridden.perDayMax).toBe(3);
+  });
+});
+
+// ── enqueue_agent_task handler (proposes-only) ──────────────────────
+
+function baseDeps(over: Partial<AgentInvocationDeps> = {}): AgentInvocationDeps {
+  return {
+    query: (async () => []) as AgentInvocationDeps["query"],
+    workflowDeps: {} as AgentInvocationDeps["workflowDeps"],
+    handoffEventRecorder: vi.fn(async () => ({})),
+    assertNoKillSwitchFn: async () => {},
+    dispatchPolicyConfig: ALLOWED,
+    listQueuedTasksFn: async () => [],
+    proposeTaskFn: vi.fn(async () => ({ id: "claude-task-1" })),
+    now: new Date("2026-05-31T12:00:00Z"),
+    ...over,
+  };
+}
+
+const enqueue = (over: Partial<AgentInvocationInput> = {}): AgentInvocationInput => ({
+  requester: "hermes",
+  intent: "enqueue_agent_task",
+  repo: "averray-agent/agent",
+  prompt: "Add a HEALTHCHECK.md",
+  agent: "claude",
+  ...over,
+});
+
+describe("enqueue_agent_task — proposes-only handler", () => {
+  it("HALT blocks: kill-switch throws → blocked, no task proposed", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "x" }));
+    const result = (await invokeAgentTask(enqueue(), baseDeps({
+      assertNoKillSwitchFn: async () => { throw new Error("HALT_FILE present"); },
+      proposeTaskFn,
+    }))) as { status: string; reason?: string };
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("halt_file_present");
+    expect(proposeTaskFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects a disallowed repo with a clear reason (no task proposed)", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "x" }));
+    const result = (await invokeAgentTask(enqueue({ repo: "evil/repo" }), baseDeps({ proposeTaskFn }))) as { status: string; reason?: string };
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("repo_not_allowed");
+    expect(proposeTaskFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects when over the daily budget", async () => {
+    const overBudget: QueuedTaskSummary[] = Array.from({ length: 10 }, () => ({
+      requester: "hermes",
+      createdAt: "2026-05-31T09:00:00Z",
+      repo: "averray-agent/agent",
+    }));
+    const proposeTaskFn = vi.fn(async () => ({ id: "x" }));
+    const result = (await invokeAgentTask(enqueue(), baseDeps({ listQueuedTasksFn: async () => overBudget, proposeTaskFn }))) as { status: string; reason?: string };
+    expect(result.status).toBe("blocked");
+    expect(result.reason).toBe("daily_budget_exhausted");
+    expect(proposeTaskFn).not.toHaveBeenCalled();
+  });
+
+  it("requires repo + prompt", async () => {
+    const r1 = (await invokeAgentTask(enqueue({ repo: "" }), baseDeps())) as { reason?: string };
+    expect(r1.reason).toBe("repo_required");
+    const r2 = (await invokeAgentTask(enqueue({ prompt: "" }), baseDeps())) as { reason?: string };
+    expect(r2.reason).toBe("prompt_required");
+  });
+
+  it("allowed → proposes a task (requester=hermes), records a handoff event, NEVER approves", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "claude-task-9" }));
+    const handoff = vi.fn(async () => ({}));
+    const result = (await invokeAgentTask(
+      enqueue({ reason: "Hermes saw a gap" }),
+      baseDeps({ proposeTaskFn, handoffEventRecorder: handoff }),
+    )) as { status: string; result?: { status?: string; proposedTaskId?: string; requester?: string } };
+
+    // proposed task posted with the right payload
+    expect(proposeTaskFn).toHaveBeenCalledTimes(1);
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task).toMatchObject({
+      repo: "averray-agent/agent",
+      agent: "claude",
+      prompt: "Add a HEALTHCHECK.md",
+      requester: "hermes",
+      reason: "Hermes saw a gap",
+    });
+    // proposes-only: the payload never asks to approve/run
+    expect(JSON.stringify(task)).not.toMatch(/approv/i);
+    expect("status" in task).toBe(false);
+
+    // result is a completed, proposed-only invocation
+    expect(result.status).toBe("completed");
+    expect(result.result?.status).toBe("proposed");
+    expect(result.result?.proposedTaskId).toBe("claude-task-9");
+
+    // handoff event recorded (audit). The wrapper records started + completed.
+    expect(handoff).toHaveBeenCalled();
+    const phases = handoff.mock.calls.map((c) => (c[0] as { phase?: string }).phase);
+    expect(phases).toContain("completed");
+  });
+
+  it("only today's Hermes tasks count toward budget (not other requesters / other days)", async () => {
+    const queued: QueuedTaskSummary[] = [
+      { requester: "operator", createdAt: "2026-05-31T08:00:00Z", repo: "averray-agent/agent" }, // not hermes
+      { requester: "hermes", createdAt: "2026-05-30T08:00:00Z", repo: "averray-agent/agent" }, // yesterday
+      { requester: "hermes", createdAt: "2026-05-31T08:00:00Z", repo: "averray-agent/agent" }, // counts (1)
+    ];
+    const proposeTaskFn = vi.fn(async () => ({ id: "ok" }));
+    const result = (await invokeAgentTask(enqueue(), baseDeps({ listQueuedTasksFn: async () => queued, proposeTaskFn }))) as { status: string };
+    expect(result.status).toBe("completed"); // 1 < perDayMax(10) → allowed
+    expect(proposeTaskFn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What changed & why

The **authority change**, shipped as the **safe supervised slice**: Hermes can
now **propose** agent work, gated — but **the operator still approves every task
on the board**. There is **no auto-approval** in this PR (that's O4-PR3, gated
behind D3). Per AGENTS.md **invariant #6**, this new power ships with an
**allowlist + budget + the unchanged human-approval gate**.

### (A) `enqueue_agent_task` intent (`agent-invocation.ts`)
Given `{ repo, prompt, agent, optional pr, reason }`, in order:
1. **`assertNoKillSwitch("enqueue_agent_task")`** — HALT blocks it (clean block, not a crash);
2. **`evaluateDispatchPolicy`** — reject with a reason if not allowed / over budget;
3. **POST a `status:"proposed"` task** to `/monitor/codex-tasks` (`requester="hermes"`) — **proposed only, never approved**;
4. the **handoff event** is recorded by the `invokeAgentTask` wrapper (audit trail).

The transport (the POST + the GET used to count today's budget) is
**dependency-injected**, so the whole handler is unit-tested with **no network**.

### (B) `dispatch-policy.ts` (NEW — separate from `mutation-policy.ts`) + a `dispatch:` block in `hermes/config/policy.yaml`
- **Allowlist**: repo ∈ `allowed_repos`, agent ∈ `[codex, claude]`.
- **Budget**: `per_day_max` + optional per-repo cap, counted from today's Hermes-proposed tasks in the queue.
- **FAIL-CLOSED**: empty `allowed_repos` ⇒ Hermes can propose **nothing** (the default). The operator opts repos in — never allow-all.

**Proposes-only is the invariant of this PR:** nothing here approves or runs a
task. `approveCodexTask` (`approvedBy:"operator"`) is untouched; merge/deploy
stays human, always.

## Affected surfaces
- [x] MCP servers (averray) — new intent + dispatch guardrail
- [x] Worker runners / task queue (proposes into the existing queue; no queue change)
- [x] Secrets / config / env (policy.yaml `dispatch:` block; env overrides)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 883 pass / 87 files (+13)
- [ ] compose config — n/a (no ops/ touched; policy.yaml is in hermes/config/)

Tests: allowlist in/out, per-day budget under/at/over, per-repo cap,
**empty-allowlist fail-closed**, **HALT blocks**, disallowed repo rejected,
allowed → **proposes a `proposed` task + records a handoff event + never
approves**, and the today/requester budget filter.

## Rollout / rollback
**Inert by default:** `allowed_repos` ships empty, so Hermes can propose nothing
until the operator opts a repo in. The intent is additive; no existing flow
changes. Rollback = revert. The default monitor base URL targets the internal
`slack-operator:8790` (override via `AVERRAY_MONITOR_BASE_URL`); the GET/POST
use `SLACK_OPERATOR_MONITOR_TOKEN`.

## Durable invariants (AGENTS.md)
- [x] **#6** — new power ⇒ **allowlist + budget + human approval**: all three present; fail-closed allowlist
- [x] No auto-merge / auto-deploy / auto-approve — **proposes-only**; the operator gate is untouched
- [x] `HALT_FILE` honored (`assertNoKillSwitch`)
- [x] No secrets committed/printed/logged (token read from env at call time)

## Acceptance
With `allowed_repos` set, `enqueue_agent_task` proposes a task that appears on
the board as **`proposed` (needs your approval)**. With an empty allowlist, over
budget, or HALT present, it's **rejected with a clear reason**. **No task is
ever auto-approved or auto-run by this PR.**

## Scope / follow-ups
- **O4-PR2** — routing taxonomy (surface + risk) as an overridable default.
- **O4-PR3** — autonomy mode incl. autopilot auto-approval; its enable stays **gated until D3** (anomaly auto-pause) ships. No auto-approval is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)