### PR TITLE
O4-PR2: routing taxonomy — pure, overridable codex/claude + risk default

### DIFF
--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -26,6 +26,7 @@ import {
   evaluateDispatchPolicy,
   type DispatchPolicyConfig,
 } from "./dispatch-policy.js";
+import { classifyTask, type RiskTier } from "./dispatch-routing.js";
 
 export type AgentInvocationIntent =
   | "operator_command"
@@ -45,6 +46,9 @@ export interface ProposedAgentTask {
   requester: string;
   pullRequestNumber?: number;
   reason?: string;
+  /** O4-PR2 routing: persisted risk tier (PR3's autopilot reads it) + why. */
+  riskTier?: RiskTier;
+  routingReason?: string;
 }
 
 /** A queued task, as returned by GET /monitor/codex-tasks (for the daily budget). */
@@ -77,7 +81,10 @@ export interface AgentInvocationInput {
   confidenceThreshold?: number;
   /** enqueue_agent_task: the task prompt + which agent to propose it to. */
   prompt?: string;
+  /** Explicit agent; when omitted it's DERIVED from the routing taxonomy (overridable). */
   agent?: "codex" | "claude";
+  /** Optional surface hint for routing (e.g. "contracts", "ui"). */
+  area?: string;
 }
 
 export interface AgentInvocationDeps {
@@ -827,9 +834,17 @@ async function invokeEnqueueAgentTask(
 ): Promise<unknown> {
   const repo = (input.repo ?? "").trim();
   const prompt = (input.prompt ?? "").trim();
-  const agent = ((input.agent ?? "codex").trim() || "codex") as "codex" | "claude";
   if (!repo) return blockedInvocation(invocation, startedAt, "repo_required");
   if (!prompt) return blockedInvocation(invocation, startedAt, "prompt_required");
+
+  // Routing taxonomy (O4-PR2): a pure, overridable default. An explicit agent in
+  // the request wins; otherwise derive it. The riskTier is ALWAYS computed and
+  // persisted (PR3's autopilot reads it). The operator can still flip the agent
+  // at approval — unchanged. No authority is granted here.
+  const routing = classifyTask({ repo, prompt, ...(input.area ? { area: input.area } : {}) });
+  const explicitAgent = (input.agent ?? "").trim();
+  const agent: "codex" | "claude" =
+    explicitAgent === "codex" || explicitAgent === "claude" ? explicitAgent : routing.agent;
 
   // (a) HALT kill-switch — block cleanly rather than crash.
   const assertKill = deps.assertNoKillSwitchFn ?? assertNoKillSwitch;
@@ -872,6 +887,8 @@ async function invokeEnqueueAgentTask(
     agent,
     prompt,
     requester: "hermes",
+    riskTier: routing.riskTier,
+    routingReason: routing.reason,
     ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
     ...(input.reason ? { reason: input.reason } : {}),
   });
@@ -885,6 +902,9 @@ async function invokeEnqueueAgentTask(
       proposedTaskId: created.id ?? null,
       repo,
       agent,
+      agentExplicit: explicitAgent === "codex" || explicitAgent === "claude",
+      riskTier: routing.riskTier,
+      routingReason: routing.reason,
       requester: "hermes",
       note: "Task proposed; it lands on the board and awaits operator approval. Never auto-approved or auto-run.",
     },

--- a/packages/averray-mcp/src/dispatch-routing.ts
+++ b/packages/averray-mcp/src/dispatch-routing.ts
@@ -1,0 +1,115 @@
+// O4-PR2 — the routing taxonomy.
+//
+// A PURE, overridable default Hermes uses to (a) pick codex vs claude for a
+// proposed task and (b) tag its risk tier. It grants NO authority: the operator
+// still approves every task; this only makes the proposals smart, and gives
+// PR3's autopilot the riskTier it reads to decide what may auto-approve vs must
+// escalate.
+//
+// Static per docs/HERMES_ORCHESTRATION_DESIGN.md §O4-C. Learned/data-driven
+// routing is A2 (needs the A1 scorecard); this is the static default only.
+//
+// CONSERVATIVE / escalate-safe: any high-risk signal wins over a Claude signal,
+// and a genuinely ambiguous task defaults to claude+low — but anything that
+// looks correctness-critical is treated as high-risk → Codex. Never
+// under-classify risk.
+
+export type RoutingAgent = "codex" | "claude";
+export type RiskTier = "high" | "low";
+
+export interface RoutingInput {
+  repo?: string;
+  prompt?: string;
+  /** Optional explicit surface label (e.g. "contracts", "ui"). */
+  area?: string;
+  /** Optional explicit tags. */
+  tags?: string[];
+}
+
+export interface RoutingDecision {
+  agent: RoutingAgent;
+  riskTier: RiskTier;
+  /** Short human string for the board + the off-device alert. */
+  reason: string;
+}
+
+interface SurfaceGroup {
+  surface: string;
+  keywords: string[];
+}
+
+// Codex surfaces — correctness-critical, hard to reverse ⇒ HIGH risk (§O4-C).
+const HIGH_RISK_SURFACES: SurfaceGroup[] = [
+  { surface: "contracts", keywords: ["contract", "contracts", "solidity", ".sol", "abi"] },
+  { surface: "chain/settlement", keywords: ["settle", "settlement", "escrow", "on-chain", "onchain", "chain", "reputation sbt", "sbt", "arbitration", "dispute", "substrate", "polkadot", "evm"] },
+  { surface: "indexer", keywords: ["indexer", "subquery", "subgraph"] },
+  { surface: "XCM", keywords: ["xcm", "cross-chain", "crosschain", "bridge", "relay"] },
+  { surface: "treasury/policy", keywords: ["treasury", "policy", "budget", "spend cap"] },
+  { surface: "payments", keywords: ["payment", "payout", "reward", "fee", "invoice", "billing"] },
+  { surface: "DB migrations", keywords: ["migration", "migrations", "schema change", "alter table", "ddl"] },
+  { surface: "deploy/ops", keywords: ["deploy", "deployment", "ops", "infra", "compose", "dockerfile", "ci/cd", "pipeline", "release"] },
+  { surface: "secrets/config", keywords: ["secret", "private key", "api key", "mnemonic", "wallet", "signer", "siwe", "credential", "env var", ".env", "token rotation"] },
+];
+
+// Claude surfaces — breadth + readability ⇒ low/medium risk (§O4-C).
+const CLAUDE_SURFACES: SurfaceGroup[] = [
+  { surface: "UI/frontend", keywords: ["ui", "frontend", "front-end", "component", "css", "styling", "layout", "tooltip", "badge", "label", "accessibility", "a11y", "responsive"] },
+  { surface: "the monitor", keywords: ["monitor", "board", "drawer", "co-pilot", "copilot", "lane"] },
+  { surface: "docs/copy", keywords: ["docs", "documentation", "readme", "copy", "comment", "changelog", "guide"] },
+  { surface: "tests", keywords: ["test", "tests", "spec", "vitest", "coverage"] },
+  { surface: "refactor/DX", keywords: ["refactor", "cleanup", "rename", "dx", "lint", "typo", "formatting", "tidy"] },
+  { surface: "MCP tooling", keywords: ["mcp tool", "tool ergonomics", "tool schema"] },
+];
+
+function matchesKeyword(haystack: string, keyword: string): boolean {
+  // Keywords with non-word chars (".sol", ".env", "on-chain", "ci/cd") match as
+  // literal substrings; plain words match on word boundaries to avoid
+  // false hits (e.g. "ops" inside "props").
+  if (/[^a-z0-9 ]/.test(keyword) || keyword.includes(" ")) {
+    return haystack.includes(keyword);
+  }
+  return new RegExp(`\\b${keyword}\\b`, "i").test(haystack);
+}
+
+function firstSurface(haystack: string, groups: SurfaceGroup[]): string | undefined {
+  for (const group of groups) {
+    if (group.keywords.some((k) => matchesKeyword(haystack, k))) return group.surface;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a proposed task into a default agent + risk tier. Pure + deterministic.
+ * High-risk surfaces win (escalate-safe); a recognized Claude surface → claude+low;
+ * anything else (ambiguous/general) → claude+low default.
+ */
+export function classifyTask(input: RoutingInput): RoutingDecision {
+  const haystack = [input.prompt, input.area, input.repo, ...(input.tags ?? [])]
+    .filter((s): s is string => typeof s === "string" && s.length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  const highSurface = firstSurface(haystack, HIGH_RISK_SURFACES);
+  if (highSurface) {
+    return {
+      agent: "codex",
+      riskTier: "high",
+      reason: `${highSurface} (correctness-critical) → codex, high-risk`,
+    };
+  }
+
+  const claudeSurface = firstSurface(haystack, CLAUDE_SURFACES);
+  if (claudeSurface) {
+    return {
+      agent: "claude",
+      riskTier: "low",
+      reason: `${claudeSurface} → claude, low-risk`,
+    };
+  }
+
+  return {
+    agent: "claude",
+    riskTier: "low",
+    reason: "general/ambiguous → claude, low-risk (default)",
+  };
+}

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -188,6 +188,8 @@ export interface CodexTaskCard extends CardBase {
   action?: CardAction;
   /** Lifecycle status — drives the board's approve affordance (proposed only). */
   taskStatus?: TaskStatus;
+  /** O4 routing risk tier (PR3's autopilot reads it; surfaced in the summary too). */
+  riskTier?: "high" | "low";
   runnerHeartbeat?: { lastSeen: string; online: boolean };
   output?: string;
   failureReason?: string;

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -46,6 +46,10 @@ export interface CodexTaskInput {
   prompt: string;
   reason?: string;
   requester?: string;
+  /** O4-PR2 routing: the static-default risk tier (PR3 autopilot reads it). */
+  riskTier?: "high" | "low";
+  /** O4-PR2 routing: the one-line reason for the agent + tier (board + alert). */
+  routingReason?: string;
 }
 
 export interface CodexTaskEvent {
@@ -145,6 +149,8 @@ export async function proposeCodexTask(
     prompt: input.prompt,
     ...(input.reason ? { reason: input.reason } : {}),
     ...(input.requester ? { requester: input.requester } : {}),
+    ...(input.riskTier ? { riskTier: input.riskTier } : {}),
+    ...(input.routingReason ? { routingReason: input.routingReason } : {}),
     createdAt: now,
     updatedAt: now,
     events: [{

--- a/services/slack-operator/src/codex-task-request.ts
+++ b/services/slack-operator/src/codex-task-request.ts
@@ -82,6 +82,11 @@ export function parseProposeTaskPayload(payload: unknown): ParseProposeResult {
   const correlationId = str(payload, "correlationId");
   const title = str(payload, "title");
   const reason = str(payload, "reason");
+  // O4-PR2 routing metadata (set by Hermes's enqueue handler). Only a valid
+  // "high"/"low" tier is accepted; anything else is ignored.
+  const riskTierRaw = str(payload, "riskTier");
+  const riskTier = riskTierRaw === "high" || riskTierRaw === "low" ? riskTierRaw : undefined;
+  const routingReason = str(payload, "routingReason");
 
   const input: CodexTaskInput = {
     repo,
@@ -91,6 +96,8 @@ export function parseProposeTaskPayload(payload: unknown): ParseProposeResult {
     ...(correlationId ? { correlationId } : {}),
     ...(title ? { title } : {}),
     ...(reason ? { reason } : {}),
+    ...(riskTier ? { riskTier } : {}),
+    ...(routingReason ? { routingReason } : {}),
     requester: str(payload, "requester") ?? "monitor",
   };
   return { ok: true, input };

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -184,6 +184,8 @@ export interface BoardCard {
   /** Codex/Claude task cards: lifecycle status (drives the board's
    *  approve affordance — only `proposed` tasks show "Approve"). */
   taskStatus?: TaskStatus;
+  /** Task cards: O4 routing risk tier (PR3's autopilot reads it). */
+  riskTier?: "high" | "low";
   /** Codex task cards: the dispatched prompt. */
   prompt?: string;
   /** Codex task cards: tail of stdout / completion summary. */
@@ -820,13 +822,19 @@ export function synthesizeTaskCards(
     if (!id) continue;
     const agent: AgentType = task.agent === "claude" ? "claude" : "codex";
     const prompt = asString(task.prompt);
+    const riskTierRaw = asString(task.riskTier);
+    const riskTier = riskTierRaw === "high" || riskTierRaw === "low" ? riskTierRaw : undefined;
+    const routingReason = asString(task.routingReason);
+    // O4-PR2: surface the routing decision — the reason (incl. the tier) on the
+    // card face, and a riskSignal for the drawer. Persist riskTier (PR3 reads it).
+    const summary = [routingReason, asString(task.reason)].filter(Boolean).join(" · ");
     const card: BoardCard = {
       id,
       lane: "codex-needed",
       type: "task",
       agentType: agent,
       title: asString(task.title) ?? `${agent} task`,
-      summary: asString(task.reason) ?? "",
+      summary,
       repo: asString(task.repo) ?? "",
       freshness: 0,
       state: "fresh",
@@ -837,6 +845,10 @@ export function synthesizeTaskCards(
           ? { actor: "operator", tone: "warn" }
           : { actor: "agent", tone: "info" },
       taskStatus: status as TaskStatus,
+      ...(riskTier ? { riskTier } : {}),
+      ...(routingReason
+        ? { riskSignals: [{ severity: riskTier === "high" ? "high" : "low", code: "routing", message: routingReason }] }
+        : {}),
       ...(prompt ? { prompt } : {}),
     };
     if (status === "running" && runner) {

--- a/test/unit/dispatch-routing.test.ts
+++ b/test/unit/dispatch-routing.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { classifyTask } from "../../packages/averray-mcp/src/dispatch-routing.js";
+import {
+  invokeAgentTask,
+  type AgentInvocationDeps,
+  type AgentInvocationInput,
+  type ProposedAgentTask,
+} from "../../packages/averray-mcp/src/agent-invocation.js";
+import type { DispatchPolicyConfig } from "../../packages/averray-mcp/src/dispatch-policy.js";
+
+describe("classifyTask — the routing taxonomy (§O4-C)", () => {
+  const high: Array<[string, string]> = [
+    ["update the escrow Solidity contract", "contracts"],
+    ["fix settlement on-chain payout finality", "chain/settlement"],
+    ["the indexer is missing events", "indexer"],
+    ["wire the XCM cross-chain transfer", "XCM"],
+    ["raise the treasury policy spend cap", "treasury/policy"],
+    ["reconcile the payment payout amounts", "payments"],
+    ["add a DB migration for the new column", "DB migrations"],
+    ["fix the deploy pipeline / ops compose", "deploy/ops"],
+    ["rotate the API key secret in config", "secrets/config"],
+  ];
+  it.each(high)("high-risk surface %j → codex + high", (prompt) => {
+    const r = classifyTask({ repo: "averray-agent/agent", prompt });
+    expect(r.agent).toBe("codex");
+    expect(r.riskTier).toBe("high");
+    expect(r.reason).toMatch(/high-risk/);
+  });
+
+  const low: string[] = [
+    "tweak the onboarding UI component styling",
+    "fix a bug in the monitor board drawer",
+    "update the README docs",
+    "add a vitest spec for the parser",
+    "refactor and rename a helper for clarity",
+  ];
+  it.each(low)("Claude surface %j → claude + low", (prompt) => {
+    const r = classifyTask({ repo: "depre-dev/averray-reference-agent", prompt });
+    expect(r.agent).toBe("claude");
+    expect(r.riskTier).toBe("low");
+    expect(r.reason).toMatch(/low-risk/);
+  });
+
+  it("ambiguous/general → claude + low (default)", () => {
+    const r = classifyTask({ repo: "averray-agent/agent", prompt: "make the thing a bit nicer" });
+    expect(r).toMatchObject({ agent: "claude", riskTier: "low" });
+    expect(r.reason).toMatch(/default/);
+  });
+
+  it("escalate-safe: a high-risk signal wins over a Claude signal", () => {
+    // "refactor" is a Claude surface, but the escrow contract is high-risk → codex.
+    const r = classifyTask({ repo: "averray-agent/agent", prompt: "refactor the escrow settlement contract" });
+    expect(r).toMatchObject({ agent: "codex", riskTier: "high" });
+  });
+
+  it("honors an explicit area hint", () => {
+    expect(classifyTask({ area: "contracts" })).toMatchObject({ agent: "codex", riskTier: "high" });
+    expect(classifyTask({ area: "ui" })).toMatchObject({ agent: "claude", riskTier: "low" });
+  });
+
+  it("word boundaries: 'props' does not trip the 'ops' (deploy/ops) keyword", () => {
+    const r = classifyTask({ repo: "depre-dev/averray-reference-agent", prompt: "pass the component props down" });
+    expect(r.agent).toBe("claude"); // UI component, not deploy/ops
+    expect(r.riskTier).toBe("low");
+  });
+});
+
+// ── enqueue uses routing as an overridable default ──────────────────
+
+const ALLOWED: DispatchPolicyConfig = {
+  allowedRepos: ["averray-agent/agent"],
+  allowedAgents: ["codex", "claude"],
+  perDayMax: 10,
+  perRepoPerDayMax: 5,
+};
+
+function baseDeps(proposeTaskFn: (t: ProposedAgentTask) => Promise<{ id?: string }>): AgentInvocationDeps {
+  return {
+    query: (async () => []) as AgentInvocationDeps["query"],
+    workflowDeps: {} as AgentInvocationDeps["workflowDeps"],
+    handoffEventRecorder: vi.fn(async () => ({})),
+    assertNoKillSwitchFn: async () => {},
+    dispatchPolicyConfig: ALLOWED,
+    listQueuedTasksFn: async () => [],
+    proposeTaskFn,
+    now: new Date("2026-05-31T12:00:00Z"),
+  };
+}
+
+const enqueue = (over: Partial<AgentInvocationInput> = {}): AgentInvocationInput => ({
+  requester: "hermes",
+  intent: "enqueue_agent_task",
+  repo: "averray-agent/agent",
+  prompt: "tweak the onboarding UI component",
+  ...over,
+});
+
+describe("enqueue_agent_task — routing as an overridable default", () => {
+  it("derives the agent + risk tier when no agent is given (UI → claude/low)", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "t1" }));
+    const result = (await invokeAgentTask(enqueue(), baseDeps(proposeTaskFn))) as {
+      status: string; result?: { agent?: string; riskTier?: string; agentExplicit?: boolean };
+    };
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task.agent).toBe("claude");
+    expect(task.riskTier).toBe("low");
+    expect(task.routingReason).toMatch(/claude, low-risk/);
+    expect(result.result?.agentExplicit).toBe(false);
+  });
+
+  it("high-risk surface with no agent → codex/high persisted", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "t2" }));
+    await invokeAgentTask(enqueue({ prompt: "update the escrow settlement contract" }), baseDeps(proposeTaskFn));
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task.agent).toBe("codex");
+    expect(task.riskTier).toBe("high");
+  });
+
+  it("an explicit agent OVERRIDES the routed default — but the risk tier is still computed", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "t3" }));
+    // Explicit claude on a high-risk contracts task: agent honored, tier still high.
+    const result = (await invokeAgentTask(
+      enqueue({ agent: "claude", prompt: "update the escrow settlement contract" }),
+      baseDeps(proposeTaskFn),
+    )) as { result?: { agent?: string; riskTier?: string; agentExplicit?: boolean } };
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task.agent).toBe("claude"); // override wins
+    expect(task.riskTier).toBe("high"); // tier never under-classified
+    expect(result.result?.agentExplicit).toBe(true);
+  });
+
+  it("persists riskTier + routingReason on the proposed task (PR3 reads the tier)", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "t4" }));
+    await invokeAgentTask(enqueue({ prompt: "add a DB migration" }), baseDeps(proposeTaskFn));
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task).toMatchObject({ riskTier: "high", requester: "hermes" });
+    expect(typeof task.routingReason).toBe("string");
+    // proposes-only invariant — never approves
+    expect(JSON.stringify(task)).not.toMatch(/approv/i);
+  });
+});


### PR DESCRIPTION
## What changed & why

Makes Hermes's proposals **smart**. Grants **no authority**: the operator still
approves every task; this just **derives a sensible agent** + **tags a risk
tier** on a proposed task. It's also the input PR3's autopilot reads to decide
what may auto-approve vs must escalate.

- **`dispatch-routing.ts`** (NEW, **pure**, fully unit-tested): `classifyTask({ repo, prompt, area?, tags? }) → { agent, riskTier, reason }`, per §O4-C:
  - **Codex surfaces ⇒ codex + HIGH:** contracts, chain/settlement, indexer, XCM, treasury/policy, payments, DB migrations, deploy/ops, secrets/config.
  - **Claude surfaces ⇒ claude + low:** UI/frontend, the monitor, docs, tests, refactors/DX, MCP tooling.
  - **Ambiguous/general ⇒ claude + low** (default). (Learned/data-driven routing is A2 — needs the A1 scorecard; this is the static default only.)
  - **CONSERVATIVE / escalate-safe:** a high-risk signal wins over a Claude signal (e.g. *"refactor the escrow contract"* → codex+high); word-boundary matching so "props" doesn't trip "ops". **Never under-classify risk.**
- **Wired into the enqueue handler (O4-PR1):** when no explicit agent is given, the agent is **defaulted** from `classifyTask`; the **riskTier is ALWAYS computed + persisted**. An explicit `agent` **wins** (override), and the operator can still flip it at approval (unchanged) — but the tier is never under-classified.
- **Persisted:** `riskTier` + `routingReason` on `CodexTaskInput`/`CodexTask` + the propose-payload parser. The board surfaces them — the routing reason (which names the tier) in the card **summary** + a **riskSignal** in the drawer; `riskTier` is a first-class field PR3 reads.

**Invariant:** pure default + a tag. No auto-approval, no new authority. The operator approves every task.

## Affected surfaces
- [x] MCP servers (averray) — routing module + enqueue default
- [x] Worker runners / task queue (riskTier/routingReason fields)
- [x] Monitor board / slack-operator (serializer surfaces the tier + reason)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` — 905 pass / 88 files (+22)
- [x] `vite build` (monitor-ui) compiles
- [ ] compose config — n/a (no ops/ touched)

Tests: each surface → expected agent+tier; high-risk surfaces → codex+high;
escalate-safe (high beats claude); word-boundary; area hint; ambiguous→default;
enqueue uses the default when agent unspecified; explicit agent overrides (tier
still computed); riskTier + routingReason persisted; never approves.

## Rollout / rollback
Additive + behavior-preserving: an explicitly-agented proposal is unchanged;
only the *default* agent (when unspecified) and the new riskTier/reason fields
are added. No auto-approval. Rollback = revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy / auto-approve — proposes-only; operator gate untouched
- [x] No new authority — a pure classifier + a persisted tag
- [x] Codex owns chain/settlement: high-risk/correctness-critical surfaces route to **codex** by default
- [x] No secrets committed/printed/logged

## Acceptance
A proposed task with no explicit agent gets a sensible codex/claude default + a
risk tier + a one-line reason, visible on the board; high-risk surfaces classify
as **codex + high**; an explicit agent / operator override still wins; **nothing
is auto-approved**.

## Scope / follow-ups
- Static overridable default; **data-driven A2** (learned per-agent success) comes later with the A1 scorecard.
- **O4-PR3** (autonomy mode + autopilot auto-approval) **reads this `riskTier`** but stays **gated behind D3** (anomaly auto-pause). No auto-approval is added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)