### PR TITLE
docs(roadmap): sync status — O4-PR1/PR2 + D4 shipped, D3 in build

### DIFF
--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -24,15 +24,15 @@
 | O1 | Agent attribution (branch-prefix → agentType) | ✅ done (#252) |
 | O2 | Claude Code worker (greenfield, Agent SDK) | ✅ done (#256 queue · #259 auth · #260 runner · #262 worker · #263 ops) |
 | O3 | Board-driven dispatch | ✅ done — create/approve form (agent picker) + `/task` verb live on the board (#271) |
-| O4 | Hermes enqueue + dispatch guardrail + autonomy mode | design done |
+| O4 | Hermes enqueue + dispatch guardrail + autonomy mode | 🟡 in build — PR1 enqueue+guardrail ✅ (#280) · PR2 routing taxonomy ✅ (#281) · PR3 autopilot auto-approval **blocked on D3** |
 | O5 | Self-management hardening | design done |
 | A1 | Agent scorecard | design done |
 | A2 | Learned routing (data-driven, non-high-risk) | design done |
 | A3 | Cost visibility / cost-aware routing | design done |
 | D1 | "While you were away" digest (board + Slack/push) | design done |
 | D2 | Explainability / decision records | design done |
-| D3 | Anomaly auto-pause (tiered soft→hard) | design done |
-| D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | design done (#274) |
+| D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | 🟡 in build (prompt out — unblocks O4-PR3) |
+| D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
 | B1 | Backlog generation (roadmap auto-flow; net-new escalates) | design done |
 | B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
 | C1 | Cross-agent review (default) | design done |
@@ -47,7 +47,7 @@
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | design done (#274) |
 
-*(Status as of 2026-05-29: **O0–O3 + T1 shipped** — the loop is operator-driven from the board, and T1 runs a report-only surface sweep per deploy; the monitor redesign + board (PRs #225–#247) is the foundation; T2–T7, A/B/C, D1–D4 are design-only. **Next: D4 alert bridge (the O4 prerequisite), then T6/T7 + D1/D3 — before O4 autopilot.** Tell me as things land and I'll flip statuses.)*
+*(Status as of 2026-05-29 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D3 (anomaly auto-pause — unblocks O4-PR3). **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C4, D1–D2, T2–T7. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 


### PR DESCRIPTION
Trues up the canonical roadmap: D4 done (#279); O4 in build (PR1 #280 + PR2 #281; PR3 gated on D3); D3 in build. Refreshes the status note with the critical path to autopilot. Docs-only.