### PR TITLE
[codex] Add T3 test-wallet signer sidecar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ that SSH in to invoke Hermes. Don't edit the platform repo from here.
 | `packages/{mcp-common,schemas}/` | Shared helpers + Zod schemas |
 | `services/slack-operator/` | Serves the `/monitor` board, the Codex task queue + runner, testbed mission runner |
 | `services/skills-observer/` | Sidecar ingesting Hermes skill files |
+| `services/test-wallet-signer/` | T3 test-wallet signer sidecar; mints cached API/browser sessions without exposing keys to agents |
 | `ops/` | Docker Compose stack (`compose.yml`, `compose.prod.yml`, `compose.command-center.yml`, `compose.cloudflare-access.yml`), migrations |
 | `hermes/` | Hermes config (`hermes.yaml`, `policy.yaml`) + trace plugin |
 | `test/unit/` | Vitest suites (alongside `*.test.ts(x)` colocated in packages) |
@@ -182,6 +183,11 @@ security-sensitive surface.
   `DATABASE_URL`, `AGENT_WALLET_PRIVATE_KEY`, gateway/API keys, SSH keys. Output is
   scrubbed for keys/tokens in some paths, but **never rely on sanitization** — don't
   emit secrets in the first place.
+- **T3 test wallets stay inside the signer sidecar.** `TEST_WALLET_*_PRIVATE_KEY`
+  values are operator-provisioned secrets, mounted only into the opt-in
+  `test-wallet-signer` service, and must never be copied into prompts, logs, test
+  mission reports, or model context. Testnet may expose `agent` / `admin` /
+  `verifier`; mainnet is structurally limited to a read-only `agent` session.
 - **The agent wallet is testnet-only.** Never configure a mainnet key here, never
   move real funds, never raise policy budgets to enable spend without explicit
   operator sign-off.

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -41,7 +41,7 @@
 | C4 | Inter-agent chat | design done |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
 | T2 | Pre-seeded session (authed sweep) | design done |
-| T3 | Signer sidecar + SIWE mission (multi-role) | design done |
+| T3 | Signer sidecar + SIWE mission (multi-role) | in review — signer sidecar implementation |
 | T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
 | T5 | Env→mutation binding + enhancements (trace/video, baselines) | design done |
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |

--- a/docs/HERMES_TESTER_AUTH_DESIGN.md
+++ b/docs/HERMES_TESTER_AUTH_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes E2E Tester — Auth & Session Layer (build spec for steps 2–3)
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.**
+- **Status:** T3 signer sidecar implementation in review; SIWE mission/role-gating coverage remains follow-up work.
 - **Date:** 2026-05-29
 - **Companion to:** [`HERMES_E2E_TESTER_DESIGN.md`](./HERMES_E2E_TESTER_DESIGN.md) — this details build steps **(2) pre-seeded session** and **(3) signer sidecar + SIWE mission**, which are the keystone that lets the tester reach the authed product instead of only public pages.
 - **Tests:** `averray-agent/agent` — SIWE auth (`/auth/nonce` → `personal_sign` → `/auth/verify` → JWT; roles `admin`/`verifier` pinned at sign-in via `AUTH_ADMIN_WALLETS`/`AUTH_VERIFIER_WALLETS`).
@@ -78,4 +78,4 @@ The payoff of separate role wallets — a mission that exercises auth as a first
 
 ---
 
-*End of tester auth/session design. Planning/handoff only — not implemented.*
+*End of tester auth/session design. Step 3a is now in review; later SIWE mission and role-gating checks still follow this design.*

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -62,6 +62,21 @@ TESTBED_MISSION_MAX_BROWSER_STEPS=12
 # is non-production so data-bearing surfaces must carry that marker.
 AVERRAY_TESTBED_EXPECTED_BOUNDARY=
 
+# T3 signer sidecar (ops profile "test-wallet-signer"; off by default).
+# Holds fixed, operator-provisioned testnet role wallets and returns cached API
+# JWTs or Playwright browser storageState. These are secrets: never log them.
+# Testnet exposes agent/admin/verifier. Mainnet exposes only read-only agent.
+TEST_WALLET_SIGNER_ENABLED=0
+TEST_WALLET_SIGNER_ENVIRONMENT=testnet
+TEST_WALLET_SIGNER_HOST=0.0.0.0
+TEST_WALLET_SIGNER_PORT=8791
+TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS=60
+TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+AUTH_TOKEN_TTL_SECONDS=3600
+TEST_WALLET_AGENT_PRIVATE_KEY=
+TEST_WALLET_ADMIN_PRIVATE_KEY=
+TEST_WALLET_VERIFIER_PRIVATE_KEY=
+
 # Claude worker (O2) model-provider auth & billing. See
 # docs/HERMES_WORKER_AUTH_BILLING.md. The worker verifies the active route
 # matches this intent at startup and FAILS LOUD on mismatch — it never

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -230,6 +230,35 @@ services:
       - avg-data:/data
     networks: [avg-internal]
 
+  test-wallet-signer:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
+    profiles: ["test-wallet-signer"]
+    restart: unless-stopped
+    depends_on:
+      mcp-bundle:
+        condition: service_completed_successfully
+    command: ["node", "services/test-wallet-signer/dist/index.js"]
+    environment:
+      TEST_WALLET_SIGNER_ENABLED: ${TEST_WALLET_SIGNER_ENABLED:-0}
+      TEST_WALLET_SIGNER_ENVIRONMENT: ${TEST_WALLET_SIGNER_ENVIRONMENT:-testnet}
+      TEST_WALLET_SIGNER_HOST: ${TEST_WALLET_SIGNER_HOST:-0.0.0.0}
+      TEST_WALLET_SIGNER_PORT: ${TEST_WALLET_SIGNER_PORT:-8791}
+      TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS: ${TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS:-60}
+      TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH: ${TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH:-/usr/bin/chromium}
+      AUTH_TOKEN_TTL_SECONDS: ${AUTH_TOKEN_TTL_SECONDS:-3600}
+      AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
+      AVERRAY_APP_BASE_URL: ${AVERRAY_APP_BASE_URL}
+      TEST_WALLET_AGENT_PRIVATE_KEY: ${TEST_WALLET_AGENT_PRIVATE_KEY:-}
+      TEST_WALLET_ADMIN_PRIVATE_KEY: ${TEST_WALLET_ADMIN_PRIVATE_KEY:-}
+      TEST_WALLET_VERIFIER_PRIVATE_KEY: ${TEST_WALLET_VERIFIER_PRIVATE_KEY:-}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    networks: [avg-internal]
+    ports:
+      - "127.0.0.1:${TEST_WALLET_SIGNER_PORT:-8791}:${TEST_WALLET_SIGNER_PORT:-8791}"
+
   codex-task-runner:
     build:
       context: ..

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,10 @@
       "resolved": "services/slack-operator",
       "link": true
     },
+    "node_modules/@avg/test-wallet-signer": {
+      "resolved": "services/test-wallet-signer",
+      "link": true
+    },
     "node_modules/@avg/trace-mcp": {
       "resolved": "packages/trace-mcp",
       "link": true
@@ -5256,6 +5260,15 @@
       "dependencies": {
         "@avg/averray-mcp": "0.1.0",
         "@avg/mcp-common": "0.1.0"
+      }
+    },
+    "services/test-wallet-signer": {
+      "name": "@avg/test-wallet-signer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@avg/mcp-common": "0.1.0",
+        "playwright-core": "^1.60.0",
+        "viem": "^2.23.7"
       }
     }
   }

--- a/packages/mcp-common/src/auth.ts
+++ b/packages/mcp-common/src/auth.ts
@@ -7,32 +7,68 @@ export interface AuthSession {
   expiresAt?: string;
 }
 
+export interface SiweSigner {
+  address: string;
+  signMessage(args: { message: string }): Promise<string>;
+}
+
+export interface SiwePostJsonResult {
+  ok: boolean;
+  status: number;
+  payload: any;
+}
+
+export type SiwePostJson = (path: string, body: unknown) => Promise<SiwePostJsonResult>;
+
 export async function siweLogin(baseUrl = optionalEnv("AVERRAY_API_BASE_URL")): Promise<AuthSession> {
   const privateKey = requiredEnv("AGENT_WALLET_PRIVATE_KEY") as `0x${string}`;
-  const account = privateKeyToAccount(privateKey);
-  const nonceResponse = await fetch(`${trimTrailingSlash(baseUrl)}/auth/nonce`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ wallet: account.address })
-  });
-  const noncePayload = await nonceResponse.json().catch(() => ({}));
+  return siweLoginWithPrivateKey(privateKey, { baseUrl });
+}
+
+export async function siweLoginWithPrivateKey(
+  privateKey: `0x${string}`,
+  options: { baseUrl?: string; postJson?: SiwePostJson } = {}
+): Promise<AuthSession> {
+  return siweLoginWithSigner(privateKeyToAccount(privateKey), options);
+}
+
+export async function siweLoginWithSigner(
+  signer: SiweSigner,
+  options: { baseUrl?: string; postJson?: SiwePostJson } = {}
+): Promise<AuthSession> {
+  const baseUrl = options.baseUrl ?? optionalEnv("AVERRAY_API_BASE_URL");
+  const postJson = options.postJson ?? createFetchPostJson(baseUrl);
+  const nonceResponse = await postJson("/auth/nonce", { wallet: signer.address });
   if (!nonceResponse.ok) {
-    throw new Error(`/auth/nonce failed ${nonceResponse.status}: ${noncePayload?.message ?? "unknown_error"}`);
+    throw new Error(`/auth/nonce failed ${nonceResponse.status}: ${nonceResponse.payload?.message ?? "unknown_error"}`);
   }
-  const signature = await account.signMessage({ message: noncePayload.message });
-  const verifyResponse = await fetch(`${trimTrailingSlash(baseUrl)}/auth/verify`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ message: noncePayload.message, signature })
+  const signature = await signer.signMessage({ message: nonceResponse.payload.message });
+  const verifyResponse = await postJson("/auth/verify", {
+    message: nonceResponse.payload.message,
+    signature
   });
-  const verifyPayload = await verifyResponse.json().catch(() => ({}));
   if (!verifyResponse.ok) {
-    throw new Error(`/auth/verify failed ${verifyResponse.status}: ${verifyPayload?.message ?? "unknown_error"}`);
+    throw new Error(`/auth/verify failed ${verifyResponse.status}: ${verifyResponse.payload?.message ?? "unknown_error"}`);
   }
   return {
-    wallet: verifyPayload.wallet ?? account.address,
-    token: verifyPayload.token,
-    expiresAt: verifyPayload.expiresAt
+    wallet: verifyResponse.payload.wallet ?? signer.address,
+    token: verifyResponse.payload.token,
+    expiresAt: verifyResponse.payload.expiresAt
+  };
+}
+
+function createFetchPostJson(baseUrl: string): SiwePostJson {
+  return async (path, body) => {
+    const response = await fetch(`${trimTrailingSlash(baseUrl)}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body)
+    });
+    return {
+      ok: response.ok,
+      status: response.status,
+      payload: await response.json().catch(() => ({}))
+    };
   };
 }
 

--- a/scripts/bootstrap-wallet.sh
+++ b/scripts/bootstrap-wallet.sh
@@ -13,8 +13,12 @@ node --input-type=module <<'NODE' > "${ENV_FILE}"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
 import { randomUUID } from "node:crypto";
 
-const privateKey = generatePrivateKey();
-const account = privateKeyToAccount(privateKey);
+const agentPrivateKey = generatePrivateKey();
+const adminPrivateKey = generatePrivateKey();
+const verifierPrivateKey = generatePrivateKey();
+const agentAccount = privateKeyToAccount(agentPrivateKey);
+const adminAccount = privateKeyToAccount(adminPrivateKey);
+const verifierAccount = privateKeyToAccount(verifierPrivateKey);
 
 console.log(`HERMES_IMAGE=nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33`);
 console.log(`POSTGRES_USER=avg_agent`);
@@ -23,8 +27,20 @@ console.log(`POSTGRES_DB=avg_agent`);
 console.log(`DATABASE_URL=postgres://avg_agent:REPLACE_PASSWORD@postgres:5432/avg_agent`);
 console.log(`AVERRAY_API_BASE_URL=https://api.averray.com`);
 console.log(`AVERRAY_APP_BASE_URL=https://app.averray.com`);
-console.log(`AGENT_WALLET_PRIVATE_KEY=${privateKey}`);
-console.log(`AGENT_WALLET_ADDRESS=${account.address}`);
+console.log(`AGENT_WALLET_PRIVATE_KEY=${agentPrivateKey}`);
+console.log(`AGENT_WALLET_ADDRESS=${agentAccount.address}`);
+console.log(`TEST_WALLET_SIGNER_ENABLED=0`);
+console.log(`TEST_WALLET_SIGNER_ENVIRONMENT=testnet`);
+console.log(`TEST_WALLET_SIGNER_PORT=8791`);
+console.log(`TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS=60`);
+console.log(`TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium`);
+console.log(`AUTH_TOKEN_TTL_SECONDS=3600`);
+console.log(`TEST_WALLET_AGENT_PRIVATE_KEY=${agentPrivateKey}`);
+console.log(`TEST_WALLET_AGENT_ADDRESS=${agentAccount.address}`);
+console.log(`TEST_WALLET_ADMIN_PRIVATE_KEY=${adminPrivateKey}`);
+console.log(`TEST_WALLET_ADMIN_ADDRESS=${adminAccount.address}`);
+console.log(`TEST_WALLET_VERIFIER_PRIVATE_KEY=${verifierPrivateKey}`);
+console.log(`TEST_WALLET_VERIFIER_ADDRESS=${verifierAccount.address}`);
 console.log(`OLLAMA_API_KEY=`);
 console.log(`OLLAMA_BASE_URL=https://ollama.com/v1`);
 console.log(`HERMES_DEFAULT_MODEL=deepseek-v4-pro:cloud`);
@@ -41,3 +57,4 @@ chmod 600 "${ENV_FILE}"
 
 echo "Wrote ${ENV_FILE} with mode 600."
 grep '^AGENT_WALLET_ADDRESS=' "${ENV_FILE}"
+grep '^TEST_WALLET_.*_ADDRESS=' "${ENV_FILE}"

--- a/services/test-wallet-signer/package.json
+++ b/services/test-wallet-signer/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@avg/test-wallet-signer",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@avg/mcp-common": "0.1.0",
+    "playwright-core": "^1.60.0",
+    "viem": "^2.23.7"
+  }
+}

--- a/services/test-wallet-signer/src/browser-session.ts
+++ b/services/test-wallet-signer/src/browser-session.ts
@@ -1,0 +1,50 @@
+import { chromium, type APIRequestContext } from "playwright-core";
+import { siweLoginWithSigner, trimTrailingSlash, type SiwePostJson } from "@avg/mcp-common";
+
+import type { BrowserMintResult, RoleWallet, TestWalletSignerConfig } from "./sessions.js";
+
+export async function mintBrowserSessionWithPlaywright(
+  wallet: RoleWallet,
+  config: TestWalletSignerConfig
+): Promise<BrowserMintResult> {
+  const browser = await chromium.launch({
+    headless: true,
+    ...(config.browserExecutablePath ? { executablePath: config.browserExecutablePath } : {})
+  });
+  try {
+    const context = await browser.newContext();
+    try {
+      const page = await context.newPage();
+      await page.goto(config.appBaseUrl, { waitUntil: "domcontentloaded", timeout: 30_000 });
+      await page.close();
+
+      const session = await siweLoginWithSigner(wallet.account, {
+        baseUrl: config.apiBaseUrl,
+        postJson: createPlaywrightPostJson(context.request, config.apiBaseUrl)
+      });
+      return {
+        wallet: session.wallet,
+        storageState: await context.storageState(),
+        expiresAt: session.expiresAt
+      };
+    } finally {
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+function createPlaywrightPostJson(request: APIRequestContext, baseUrl: string): SiwePostJson {
+  return async (path, body) => {
+    const response = await request.post(`${trimTrailingSlash(baseUrl)}${path}`, {
+      data: body,
+      headers: { "content-type": "application/json" }
+    });
+    return {
+      ok: response.ok(),
+      status: response.status(),
+      payload: await response.json().catch(() => ({}))
+    };
+  };
+}

--- a/services/test-wallet-signer/src/index.ts
+++ b/services/test-wallet-signer/src/index.ts
@@ -1,0 +1,25 @@
+import { mintBrowserSessionWithPlaywright } from "./browser-session.js";
+import { createTestWalletSignerHttpServer } from "./server.js";
+import { loadTestWalletSignerConfig, redactSensitive, TestWalletSessionBroker } from "./sessions.js";
+
+const config = loadTestWalletSignerConfig();
+
+if (!config.enabled) {
+  console.info("[test-wallet-signer] disabled; set TEST_WALLET_SIGNER_ENABLED=1 to serve sessions");
+  process.exit(0);
+}
+
+const broker = new TestWalletSessionBroker(config, {
+  browserMinter: mintBrowserSessionWithPlaywright
+});
+const server = createTestWalletSignerHttpServer(broker, config);
+
+server.listen(config.port, config.host, () => {
+  const roles = Object.keys(config.wallets).sort().join(",");
+  console.info(`[test-wallet-signer] listening on ${config.host}:${config.port}; environment=${config.environment}; roles=${roles}`);
+});
+
+server.on("error", (error) => {
+  console.error(`[test-wallet-signer] ${redactSensitive(error.message)}`);
+  process.exitCode = 1;
+});

--- a/services/test-wallet-signer/src/server.ts
+++ b/services/test-wallet-signer/src/server.ts
@@ -1,0 +1,87 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+
+import {
+  parseSessionRole,
+  parseSessionType,
+  redactSensitive,
+  TestWalletSignerError,
+  type SessionType,
+  type TestWalletRole,
+  type TestWalletSession,
+  type TestWalletSessionBroker,
+  type TestWalletSignerConfig
+} from "./sessions.js";
+
+export interface SessionBrokerLike {
+  getSession(role: TestWalletRole, type: SessionType): Promise<TestWalletSession>;
+}
+
+export function createTestWalletSignerHttpServer(
+  broker: TestWalletSessionBroker | SessionBrokerLike,
+  config: Pick<TestWalletSignerConfig, "environment">
+): Server {
+  return createServer(async (request, response) => {
+    try {
+      await routeRequest(request, response, broker, config);
+    } catch (error) {
+      writeError(response, error);
+    }
+  });
+}
+
+async function routeRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  broker: TestWalletSessionBroker | SessionBrokerLike,
+  config: Pick<TestWalletSignerConfig, "environment">
+): Promise<void> {
+  if (request.method !== "GET") {
+    writeJson(response, 405, { error: "method_not_allowed" });
+    return;
+  }
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "localhost"}`);
+  if (url.pathname === "/health") {
+    writeJson(response, 200, {
+      status: "ok",
+      service: "test-wallet-signer",
+      environment: config.environment
+    });
+    return;
+  }
+
+  const match = /^\/session\/([^/]+)$/u.exec(url.pathname);
+  if (!match) {
+    writeJson(response, 404, { error: "not_found" });
+    return;
+  }
+
+  const role = parseSessionRole(match[1]);
+  if (!role) {
+    writeJson(response, 404, { error: "unknown_role" });
+    return;
+  }
+  const type = parseSessionType(url.searchParams.get("type"));
+  if (!type) {
+    writeJson(response, 400, { error: "invalid_session_type", allowed: ["api", "browser"] });
+    return;
+  }
+
+  writeJson(response, 200, await broker.getSession(role, type));
+}
+
+function writeError(response: ServerResponse, error: unknown): void {
+  const statusCode = error instanceof TestWalletSignerError ? error.statusCode : 500;
+  const message = error instanceof Error ? error.message : String(error);
+  writeJson(response, statusCode, {
+    error: statusCode >= 500 ? "session_mint_failed" : "session_unavailable",
+    message: redactSensitive(message)
+  });
+}
+
+function writeJson(response: ServerResponse, statusCode: number, payload: unknown): void {
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store"
+  });
+  response.end(JSON.stringify(payload));
+}

--- a/services/test-wallet-signer/src/sessions.ts
+++ b/services/test-wallet-signer/src/sessions.ts
@@ -1,0 +1,267 @@
+import { privateKeyToAccount, type PrivateKeyAccount } from "viem/accounts";
+import { siweLoginWithPrivateKey } from "@avg/mcp-common";
+
+export const TEST_WALLET_ROLES = ["agent", "admin", "verifier"] as const;
+export const SESSION_TYPES = ["api", "browser"] as const;
+
+export type TestWalletRole = (typeof TEST_WALLET_ROLES)[number];
+export type SessionType = (typeof SESSION_TYPES)[number];
+export type SignerEnvironment = "testnet" | "mainnet";
+
+export interface BrowserStorageState {
+  cookies: Array<Record<string, unknown>>;
+  origins: Array<Record<string, unknown>>;
+}
+
+export interface RoleWallet {
+  role: TestWalletRole;
+  roles: string[];
+  privateKey: `0x${string}`;
+  account: PrivateKeyAccount;
+}
+
+export interface TestWalletSignerConfig {
+  enabled: boolean;
+  host: string;
+  port: number;
+  environment: SignerEnvironment;
+  apiBaseUrl: string;
+  appBaseUrl: string;
+  authTokenTtlSeconds: number;
+  refreshSkewSeconds: number;
+  browserExecutablePath?: string;
+  wallets: Partial<Record<TestWalletRole, RoleWallet>>;
+}
+
+export interface ApiSessionPayload {
+  type: "api";
+  role: TestWalletRole;
+  roles: string[];
+  wallet: string;
+  token: string;
+  expiresAt: string;
+  environment: SignerEnvironment;
+  readOnly: boolean;
+}
+
+export interface BrowserSessionPayload {
+  type: "browser";
+  role: TestWalletRole;
+  roles: string[];
+  wallet: string;
+  storageState: BrowserStorageState;
+  expiresAt: string;
+  environment: SignerEnvironment;
+  readOnly: boolean;
+}
+
+export type TestWalletSession = ApiSessionPayload | BrowserSessionPayload;
+
+export interface ApiMintResult {
+  wallet: string;
+  token: string;
+  expiresAt?: string;
+}
+
+export interface BrowserMintResult {
+  wallet: string;
+  storageState: BrowserStorageState;
+  expiresAt?: string;
+}
+
+export type ApiSessionMinter = (wallet: RoleWallet, config: TestWalletSignerConfig) => Promise<ApiMintResult>;
+export type BrowserSessionMinter = (wallet: RoleWallet, config: TestWalletSignerConfig) => Promise<BrowserMintResult>;
+
+export interface TestWalletSessionBrokerDeps {
+  apiMinter?: ApiSessionMinter;
+  browserMinter?: BrowserSessionMinter;
+  now?: () => Date;
+}
+
+export class TestWalletSignerError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode = 500
+  ) {
+    super(message);
+    this.name = "TestWalletSignerError";
+  }
+}
+
+export class TestWalletSessionBroker {
+  private readonly cache = new Map<string, TestWalletSession>();
+  private readonly apiMinter: ApiSessionMinter;
+  private readonly browserMinter: BrowserSessionMinter;
+  private readonly now: () => Date;
+
+  constructor(
+    private readonly config: TestWalletSignerConfig,
+    deps: TestWalletSessionBrokerDeps = {}
+  ) {
+    this.apiMinter = deps.apiMinter ?? mintApiSessionWithSiwe;
+    this.browserMinter = deps.browserMinter ?? missingBrowserMinter;
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  async getSession(role: TestWalletRole, type: SessionType): Promise<TestWalletSession> {
+    const wallet = this.walletForRole(role);
+    const cacheKey = `${role}:${type}`;
+    const cached = this.cache.get(cacheKey);
+    if (cached && !this.isNearExpiry(cached.expiresAt)) return cached;
+
+    const minted = type === "api"
+      ? await this.mintApiSession(wallet)
+      : await this.mintBrowserSession(wallet);
+    this.cache.set(cacheKey, minted);
+    return minted;
+  }
+
+  private walletForRole(role: TestWalletRole): RoleWallet {
+    const wallet = this.config.wallets[role];
+    if (!wallet) {
+      if (this.config.environment === "mainnet" && role !== "agent") {
+        throw new TestWalletSignerError("mainnet signer profile only allows a read-only agent session", 403);
+      }
+      throw new TestWalletSignerError(`test wallet role is not configured: ${role}`, 503);
+    }
+    return wallet;
+  }
+
+  private async mintApiSession(wallet: RoleWallet): Promise<ApiSessionPayload> {
+    const minted = await this.apiMinter(wallet, this.config);
+    return {
+      type: "api",
+      role: wallet.role,
+      roles: wallet.roles,
+      wallet: minted.wallet,
+      token: minted.token,
+      expiresAt: this.normalizedExpiresAt(minted.expiresAt),
+      environment: this.config.environment,
+      readOnly: isReadOnlyEnvironment(this.config.environment)
+    };
+  }
+
+  private async mintBrowserSession(wallet: RoleWallet): Promise<BrowserSessionPayload> {
+    const minted = await this.browserMinter(wallet, this.config);
+    return {
+      type: "browser",
+      role: wallet.role,
+      roles: wallet.roles,
+      wallet: minted.wallet,
+      storageState: minted.storageState,
+      expiresAt: this.normalizedExpiresAt(minted.expiresAt),
+      environment: this.config.environment,
+      readOnly: isReadOnlyEnvironment(this.config.environment)
+    };
+  }
+
+  private normalizedExpiresAt(expiresAt?: string): string {
+    const parsed = expiresAt ? Date.parse(expiresAt) : NaN;
+    if (Number.isFinite(parsed)) return new Date(parsed).toISOString();
+    return new Date(this.now().getTime() + this.config.authTokenTtlSeconds * 1000).toISOString();
+  }
+
+  private isNearExpiry(expiresAt: string): boolean {
+    const expiresMs = Date.parse(expiresAt);
+    if (!Number.isFinite(expiresMs)) return true;
+    return this.now().getTime() + this.config.refreshSkewSeconds * 1000 >= expiresMs;
+  }
+}
+
+export async function mintApiSessionWithSiwe(
+  wallet: RoleWallet,
+  config: TestWalletSignerConfig
+): Promise<ApiMintResult> {
+  return siweLoginWithPrivateKey(wallet.privateKey, { baseUrl: config.apiBaseUrl });
+}
+
+export function loadTestWalletSignerConfig(env: NodeJS.ProcessEnv = process.env): TestWalletSignerConfig {
+  const enabled = parseBoolean(env.TEST_WALLET_SIGNER_ENABLED, false);
+  const environment = parseEnvironment(env.TEST_WALLET_SIGNER_ENVIRONMENT);
+  const requiredRoles = environment === "mainnet" ? ["agent"] as const : TEST_WALLET_ROLES;
+  const wallets: Partial<Record<TestWalletRole, RoleWallet>> = {};
+  if (enabled) {
+    for (const role of requiredRoles) {
+      wallets[role] = parseRoleWallet(role, requiredKey(env, keyEnvName(role)));
+    }
+  }
+
+  return {
+    enabled,
+    host: env.TEST_WALLET_SIGNER_HOST || "0.0.0.0",
+    port: positiveInt(env.TEST_WALLET_SIGNER_PORT, 8791),
+    environment,
+    apiBaseUrl: env.AVERRAY_API_BASE_URL || "https://api.averray.com",
+    appBaseUrl: env.AVERRAY_APP_BASE_URL || "https://app.averray.com",
+    authTokenTtlSeconds: positiveInt(env.AUTH_TOKEN_TTL_SECONDS, 3600),
+    refreshSkewSeconds: positiveInt(env.TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS, 60),
+    ...(env.TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH
+      ? { browserExecutablePath: env.TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH }
+      : {}),
+    wallets
+  };
+}
+
+export function parseSessionRole(value: string | undefined): TestWalletRole | null {
+  return TEST_WALLET_ROLES.includes(value as TestWalletRole) ? value as TestWalletRole : null;
+}
+
+export function parseSessionType(value: string | null): SessionType | null {
+  const normalized = value || "api";
+  return SESSION_TYPES.includes(normalized as SessionType) ? normalized as SessionType : null;
+}
+
+export function redactSensitive(value: string): string {
+  return value
+    .replace(/0x[a-fA-F0-9]{64}/gu, "[redacted-private-key]")
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/-]+=*/gu, "Bearer [redacted-token]")
+    .replace(/\beyJ[A-Za-z0-9._~+/-]+=*/gu, "[redacted-jwt]");
+}
+
+function parseRoleWallet(role: TestWalletRole, privateKey: string): RoleWallet {
+  try {
+    const typedKey = privateKey as `0x${string}`;
+    return {
+      role,
+      roles: [role],
+      privateKey: typedKey,
+      account: privateKeyToAccount(typedKey)
+    };
+  } catch {
+    throw new TestWalletSignerError(`${keyEnvName(role)} is not a valid private key`, 500);
+  }
+}
+
+function keyEnvName(role: TestWalletRole): string {
+  return `TEST_WALLET_${role.toUpperCase()}_PRIVATE_KEY`;
+}
+
+function requiredKey(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (!value) throw new TestWalletSignerError(`Missing required environment variable ${name}`, 500);
+  return value;
+}
+
+function parseEnvironment(value: string | undefined): SignerEnvironment {
+  if (!value || value === "testnet") return "testnet";
+  if (value === "mainnet") return "mainnet";
+  throw new TestWalletSignerError("TEST_WALLET_SIGNER_ENVIRONMENT must be testnet or mainnet", 500);
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value === "") return fallback;
+  return value === "1" || value === "true";
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(String(value ?? ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isReadOnlyEnvironment(environment: SignerEnvironment): boolean {
+  return environment === "mainnet";
+}
+
+async function missingBrowserMinter(): Promise<BrowserMintResult> {
+  throw new TestWalletSignerError("browser session minter is not configured", 500);
+}

--- a/services/test-wallet-signer/tsconfig.json
+++ b/services/test-wallet-signer/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "references": [
+    { "path": "../../packages/mcp-common" }
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/test/unit/compose-env.test.ts
+++ b/test/unit/compose-env.test.ts
@@ -28,4 +28,24 @@ describe("compose environment wiring", () => {
     expect(envExample).toContain("HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud");
     expect(bootstrap).toContain("HERMES_MONITOR_REPLY_MODEL=deepseek-v4-pro:cloud");
   });
+
+  it("wires the T3 test-wallet signer sidecar behind an opt-in localhost profile", () => {
+    const compose = parse(readText("../../ops/compose.yml")) as {
+      services?: Record<string, { profiles?: string[]; ports?: string[]; environment?: Record<string, string> }>;
+    };
+    const service = compose.services?.["test-wallet-signer"];
+
+    expect(service?.profiles).toEqual(["test-wallet-signer"]);
+    expect(service?.ports).toEqual(["127.0.0.1:${TEST_WALLET_SIGNER_PORT:-8791}:${TEST_WALLET_SIGNER_PORT:-8791}"]);
+    expect(service?.environment?.TEST_WALLET_SIGNER_ENABLED).toBe("${TEST_WALLET_SIGNER_ENABLED:-0}");
+    expect(service?.environment?.TEST_WALLET_ADMIN_PRIVATE_KEY).toBe("${TEST_WALLET_ADMIN_PRIVATE_KEY:-}");
+
+    const envExample = readText("../../ops/.env.example");
+    const bootstrap = readText("../../scripts/bootstrap-wallet.sh");
+    expect(envExample).toContain("TEST_WALLET_SIGNER_ENABLED=0");
+    expect(envExample).toContain("TEST_WALLET_VERIFIER_PRIVATE_KEY=");
+    expect(bootstrap).toContain("TEST_WALLET_AGENT_PRIVATE_KEY=");
+    expect(bootstrap).toContain("TEST_WALLET_ADMIN_PRIVATE_KEY=");
+    expect(bootstrap).toContain("TEST_WALLET_VERIFIER_PRIVATE_KEY=");
+  });
 });

--- a/test/unit/test-wallet-signer.test.ts
+++ b/test/unit/test-wallet-signer.test.ts
@@ -1,0 +1,217 @@
+import { once } from "node:events";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createTestWalletSignerHttpServer } from "../../services/test-wallet-signer/src/server.js";
+import {
+  loadTestWalletSignerConfig,
+  redactSensitive,
+  TestWalletSessionBroker,
+  TestWalletSignerError,
+  type ApiSessionMinter,
+  type BrowserSessionMinter,
+  type TestWalletRole,
+  type TestWalletSignerConfig
+} from "../../services/test-wallet-signer/src/sessions.js";
+
+const KEYS = {
+  agent: testPrivateKey(1),
+  admin: testPrivateKey(2),
+  verifier: testPrivateKey(3)
+} as const;
+
+describe("test-wallet signer sidecar", () => {
+  it("mints API and browser sessions per testnet role", async () => {
+    const config = configFromEnv();
+    const apiCalls: string[] = [];
+    const browserCalls: string[] = [];
+    const broker = new TestWalletSessionBroker(config, {
+      apiMinter: async (wallet) => {
+        apiCalls.push(wallet.role);
+        return {
+          wallet: wallet.account.address,
+          token: `jwt-${wallet.role}`,
+          expiresAt: "2026-05-31T12:00:00.000Z"
+        };
+      },
+      browserMinter: async (wallet) => {
+        browserCalls.push(wallet.role);
+        return {
+          wallet: wallet.account.address,
+          storageState: { cookies: [{ name: `refresh-${wallet.role}` }], origins: [] },
+          expiresAt: "2026-05-31T12:00:00.000Z"
+        };
+      }
+    });
+
+    for (const role of ["agent", "admin", "verifier"] as const) {
+      const api = await broker.getSession(role, "api");
+      expect(api).toMatchObject({
+        type: "api",
+        role,
+        roles: [role],
+        token: `jwt-${role}`,
+        environment: "testnet",
+        readOnly: false
+      });
+      const browser = await broker.getSession(role, "browser");
+      expect(browser).toMatchObject({
+        type: "browser",
+        role,
+        roles: [role],
+        storageState: { cookies: [{ name: `refresh-${role}` }], origins: [] },
+        environment: "testnet",
+        readOnly: false
+      });
+    }
+    expect(apiCalls).toEqual(["agent", "admin", "verifier"]);
+    expect(browserCalls).toEqual(["agent", "admin", "verifier"]);
+  });
+
+  it("caches sessions until refresh skew, then remints", async () => {
+    let nowMs = Date.parse("2026-05-31T11:00:00.000Z");
+    let count = 0;
+    const broker = new TestWalletSessionBroker(configFromEnv({ TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS: "60" }), {
+      now: () => new Date(nowMs),
+      apiMinter: async (wallet) => ({
+        wallet: wallet.account.address,
+        token: `jwt-${++count}`,
+        expiresAt: "2026-05-31T12:00:00.000Z"
+      })
+    });
+
+    const first = await broker.getSession("agent", "api");
+    const second = await broker.getSession("agent", "api");
+    expect(first).toBe(second);
+    expect(count).toBe(1);
+
+    nowMs = Date.parse("2026-05-31T11:59:30.000Z");
+    const third = await broker.getSession("agent", "api");
+    expect(third).not.toBe(first);
+    expect(third).toMatchObject({ token: "jwt-2" });
+    expect(count).toBe(2);
+  });
+
+  it("mainnet profile only exposes a read-only agent session", async () => {
+    const config = configFromEnv({
+      TEST_WALLET_SIGNER_ENVIRONMENT: "mainnet",
+      TEST_WALLET_ADMIN_PRIVATE_KEY: "",
+      TEST_WALLET_VERIFIER_PRIVATE_KEY: ""
+    });
+    expect(Object.keys(config.wallets)).toEqual(["agent"]);
+
+    const broker = new TestWalletSessionBroker(config, {
+      apiMinter: async (wallet) => ({
+        wallet: wallet.account.address,
+        token: "jwt-agent",
+        expiresAt: "2026-05-31T12:00:00.000Z"
+      })
+    });
+
+    const agent = await broker.getSession("agent", "api");
+    expect(agent).toMatchObject({ role: "agent", readOnly: true, environment: "mainnet" });
+    await expect(broker.getSession("admin", "api")).rejects.toMatchObject({
+      statusCode: 403,
+      message: "mainnet signer profile only allows a read-only agent session"
+    });
+    await expect(broker.getSession("verifier", "browser")).rejects.toMatchObject({
+      statusCode: 403
+    });
+  });
+
+  it("does not require role keys while disabled", () => {
+    const config = loadTestWalletSignerConfig({
+      TEST_WALLET_SIGNER_ENABLED: "0",
+      TEST_WALLET_SIGNER_ENVIRONMENT: "testnet"
+    });
+
+    expect(config.enabled).toBe(false);
+    expect(config.wallets).toEqual({});
+  });
+
+  it("never reflects private keys or bearer tokens in error output", async () => {
+    const secret = KEYS.agent;
+    const server = createTestWalletSignerHttpServer({
+      async getSession() {
+        throw new TestWalletSignerError(`bad key ${secret} and Bearer secret-token`, 500);
+      }
+    }, { environment: "testnet" });
+    await listen(server);
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const response = await fetch(`http://127.0.0.1:${port}/session/agent?type=api`);
+      const text = await response.text();
+      expect(response.status).toBe(500);
+      expect(text).not.toContain(secret);
+      expect(text).not.toContain("secret-token");
+      expect(text).toContain("[redacted-private-key]");
+      expect(text).toContain("Bearer [redacted-token]");
+      expect(redactSensitive(`jwt ${secret}`)).not.toContain(secret);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it("HTTP endpoint serves cached sessions without logging secrets", async () => {
+    const apiMinter = vi.fn<ApiSessionMinter>(async (wallet) => ({
+      wallet: wallet.account.address,
+      token: "jwt-agent",
+      expiresAt: "2026-05-31T12:00:00.000Z"
+    }));
+    const browserMinter = vi.fn<BrowserSessionMinter>(async (wallet) => ({
+      wallet: wallet.account.address,
+      storageState: { cookies: [{ name: "refresh" }], origins: [] },
+      expiresAt: "2026-05-31T12:00:00.000Z"
+    }));
+    const config = configFromEnv();
+    const broker = new TestWalletSessionBroker(config, { apiMinter, browserMinter });
+    const server = createTestWalletSignerHttpServer(broker, config);
+    await listen(server);
+    try {
+      const port = (server.address() as AddressInfo).port;
+      const api = await getJson(`http://127.0.0.1:${port}/session/agent?type=api`);
+      expect(api).toMatchObject({ type: "api", role: "agent", token: "jwt-agent" });
+      const browser = await getJson(`http://127.0.0.1:${port}/session/admin?type=browser`);
+      expect(browser).toMatchObject({ type: "browser", role: "admin", storageState: { cookies: [{ name: "refresh" }], origins: [] } });
+      expect(apiMinter).toHaveBeenCalledTimes(1);
+      expect(browserMinter).toHaveBeenCalledTimes(1);
+    } finally {
+      await close(server);
+    }
+  });
+});
+
+function configFromEnv(overrides: Record<string, string> = {}): TestWalletSignerConfig {
+  return loadTestWalletSignerConfig({
+    TEST_WALLET_SIGNER_ENABLED: "1",
+    TEST_WALLET_SIGNER_ENVIRONMENT: "testnet",
+    AVERRAY_API_BASE_URL: "https://api.test.invalid",
+    AVERRAY_APP_BASE_URL: "https://app.test.invalid",
+    TEST_WALLET_AGENT_PRIVATE_KEY: KEYS.agent,
+    TEST_WALLET_ADMIN_PRIVATE_KEY: KEYS.admin,
+    TEST_WALLET_VERIFIER_PRIVATE_KEY: KEYS.verifier,
+    ...overrides
+  });
+}
+
+async function listen(server: Server): Promise<void> {
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+}
+
+async function close(server: Server): Promise<void> {
+  server.close();
+  await once(server, "close");
+}
+
+async function getJson(url: string): Promise<any> {
+  const response = await fetch(url);
+  expect(response.ok).toBe(true);
+  return response.json();
+}
+
+function testPrivateKey(index: number): `0x${string}` {
+  return `0x${index.toString(16).padStart(64, "0")}`;
+}


### PR DESCRIPTION
## What changed
- Added a profile-gated `test-wallet-signer` service that holds operator-provisioned fixed testnet wallets and exposes localhost-only `GET /session/:role?type=api|browser`.
- Reused the existing SIWE helper through new per-key/per-signer entry points, with API JWT and Playwright browser storageState session caching by role and type.
- Added the mainnet guard now: only the agent role is loaded and served under `TEST_WALLET_SIGNER_ENVIRONMENT=mainnet`, and it is marked read-only.
- Extended wallet bootstrap, env, docs, and tests for the three role wallets without committing literal key material.

## Security / ops notes
- `TEST_WALLET_*_PRIVATE_KEY` values are operator-provisioned secrets and should only be mounted into the opt-in signer sidecar.
- The sidecar logs only host, port, environment, and role names; error output redacts private keys, Bearer tokens, and JWT-looking values.
- New ops profile: `test-wallet-signer`; port binding is `127.0.0.1:${TEST_WALLET_SIGNER_PORT:-8791}:${TEST_WALLET_SIGNER_PORT:-8791}`.
- Required env when enabled: `TEST_WALLET_AGENT_PRIVATE_KEY`, `TEST_WALLET_ADMIN_PRIVATE_KEY`, `TEST_WALLET_VERIFIER_PRIVATE_KEY`; mainnet requires only agent.

## Checks
- `npm run typecheck`
- `npm test -- test/unit/test-wallet-signer.test.ts test/unit/compose-env.test.ts`
- `npm test` (89 files / 912 tests)
- `git diff --cached --check`
- Compose CLI validation attempted, but this Mac has Docker engine without Compose plugin: `docker compose version` => unknown command; `docker-compose` not installed. Compose wiring is covered by `test/unit/compose-env.test.ts` until CI/VPS can run the config check.

## Impact
- Affects ops service config, shared SIWE auth helper, test-wallet bootstrap, and docs only.
- No production deploy or contract changes. Human merge/deploy required after review.