### PR TITLE
[codex] Add tester capabilities manifest

### DIFF
--- a/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
+++ b/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
@@ -1,6 +1,6 @@
 # Agent-Requested Tester Runs + the Operator Alert Bridge
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.**
+- **Status:** Partly implemented. The reference-agent now exposes the tester capabilities manifest endpoint in review; the platform helper, board approval gate for agent-requested missions, and off-device alert bridge remain follow-up work.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_E2E_TESTER_DESIGN.md`](./HERMES_E2E_TESTER_DESIGN.md), [`HERMES_TESTER_AUTH_DESIGN.md`](./HERMES_TESTER_AUTH_DESIGN.md), [`HERMES_ROADMAP.md`](./HERMES_ROADMAP.md).
 - **Problem:** the code-building agents (the ones opening `app:` PRs in `averray-agent/agent`) can't currently start a tester run, don't know the tester's capabilities, and there's no way to reach the operator for approval when they're away from the Mac.
@@ -26,7 +26,7 @@
 ## 2. Tester capabilities manifest — always known
 
 So agents *at all times* know what's possible (no guessing):
-- **A machine-readable manifest** the agent fetches — e.g. `GET /monitor/tester/capabilities` (or folded into the existing discovery-manifest / `agent-tools.json` pattern). Contents: mission types (`surface_sweep`, `targeted_read_only`, `gold_path` [operator-only]), per-type **scope** (read-only vs mutating), supported **envs**, **how to request** (the helper/endpoint), the **approval gate**, and the **result shape** (verdict + findings + evidence links).
+- **A machine-readable manifest** the agent fetches at `GET /monitor/tester/capabilities` on the monitor. Contents: mission types (`surface_sweep`, `targeted_read_only`, `gold_path` [operator-only]), per-type **scope** (read-only vs mutating), supported **envs**, **how to request** (the helper/endpoint), the **approval gate**, and the **result shape** (verdict + findings + evidence links). The manifest is authenticated like the monitor and is intentionally honest about what is available now versus planned.
 - **A human/agent-readable pointer in the platform `AGENTS.md`** ("How to get hard evidence for your change") so the building agents *discover* it without being told.
 
 ## 3. The operator alert bridge — off-device
@@ -55,7 +55,7 @@ Today the board only has **browser** notifications (#232: tab badge, desktop not
 
 1. **Alert bridge (Slack)** — highest leverage: unblocks "step away," and it's the O4 prerequisite. *(reference-agent)*
 2. **Agent-requested run endpoint + the proposed-mission approval gate** on the board. *(reference-agent)*
-3. **Capabilities manifest** + the **platform-repo helper** + the **platform `AGENTS.md`** pointer. *(manifest = reference-agent; helper + AGENTS.md = platform repo)*
+3. **Capabilities manifest** + the **platform-repo helper** + the **platform `AGENTS.md`** pointer. *(manifest endpoint = reference-agent; helper + AGENTS.md = platform repo follow-up)*
 
 ## Roadmap fit
 
@@ -71,4 +71,4 @@ Today the board only has **browser** notifications (#232: tab badge, desktop not
 
 ---
 
-*End. Planning/handoff only — not implemented.*
+*End. The manifest endpoint is now implemented in the reference-agent; remaining items are still planning/handoff until their PRs land.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -41,13 +41,13 @@
 | C4 | Inter-agent chat | design done |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
 | T2 | Pre-seeded session (authed sweep) | design done |
-| T3 | Signer sidecar + SIWE mission (multi-role) | in review — signer sidecar implementation |
+| T3 | Signer sidecar + SIWE mission (multi-role) | ✅ done (#283) |
 | T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
 | T5 | Env→mutation binding + enhancements (trace/video, baselines) | design done |
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |
-| T7 | Tester capabilities manifest (+ platform-repo request helper) | design done (#274) |
+| T7 | Tester capabilities manifest (+ platform-repo request helper) | in review — manifest endpoint; platform helper follow-up |
 
-*(Status as of 2026-05-29 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D3 (anomaly auto-pause — unblocks O4-PR3). **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C4, D1–D2, T2–T7. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
+*(Status as of 2026-05-31 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), T3 (signer sidecar foundation), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D3 (anomaly auto-pause — unblocks O4-PR3) and T7 reference-agent manifest endpoint. **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C4, D1–D2, T2, T4–T6, and the T7 platform helper/AGENTS pointer. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -106,6 +106,7 @@ import {
   getTestbedMissionForAgent,
   listTestbedMissionsForAgent,
 } from "./testbed-agent-entrypoint.js";
+import { buildTesterCapabilitiesManifest } from "./tester-capabilities.js";
 import {
   formatStalePrAlertForSlack,
   shouldPostStalePrAlert,
@@ -228,6 +229,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/recheck",
           "/monitor/codex-tasks",
           "/monitor/collaboration",
+          "/monitor/tester/capabilities",
           "/monitor/testbed-missions",
           "/monitor/manifest.webmanifest",
         ] : [],
@@ -437,6 +439,20 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorAlertMuteRequest(request, response);
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/tester/capabilities") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    writeJson(response, 200, buildTesterCapabilitiesManifest({
+      runner: readTestbedMissionRunnerHeartbeat() ?? null,
+    }));
     return;
   }
   const testbedMissionId = monitorTestbedMissionId(url.pathname);

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -1,0 +1,141 @@
+import type { TestbedMissionRunnerHeartbeat } from "./monitor-testbed-missions.js";
+
+export interface TesterCapabilitiesDeps {
+  now?: Date;
+  env?: Record<string, string | undefined>;
+  runner?: TestbedMissionRunnerHeartbeat | null;
+}
+
+export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {}) {
+  const env = deps.env ?? process.env;
+  const now = deps.now ?? new Date();
+  const runnerEnabled = truthy(env.TESTBED_MISSION_RUNNER_ENABLED);
+  const signerEnabled = truthy(env.TEST_WALLET_SIGNER_ENABLED);
+  const runnerExecutor = env.TESTBED_MISSION_RUNNER_EXECUTOR || "playwright";
+
+  return {
+    schemaVersion: 1,
+    kind: "hermes_tester_capabilities",
+    generatedAt: now.toISOString(),
+    owner: "Hermes tester",
+    truthBoundary: "This manifest lists only tester paths the reference-agent stack can currently request or observe.",
+    endpoints: {
+      capabilities: {
+        method: "GET",
+        path: "/monitor/tester/capabilities",
+        auth: "same monitor auth as /monitor",
+      },
+      requestMission: {
+        method: "POST",
+        path: "/monitor/testbed-missions",
+        auth: "monitor auth plus the mission-spawn role gate when configured",
+        contentType: "application/json",
+      },
+      listMissions: {
+        method: "GET",
+        path: "/monitor/testbed-missions?limit=20",
+      },
+      missionDetail: {
+        method: "GET",
+        path: "/monitor/testbed-missions/{id}",
+      },
+    },
+    runtime: {
+      runnerEnabled,
+      runnerExecutor,
+      runner: deps.runner ?? null,
+      signerSidecarEnabled: signerEnabled,
+      authedSessionSource: signerEnabled ? "test-wallet-signer sidecar" : "not currently advertised",
+    },
+    safety: {
+      agentRequestedDefault: "read_only",
+      mutationRule: "Agents may request read-only runs only. Testbed mutation and gold-path runs are operator-only.",
+      mainnetRule: "mainnet is read-only by design",
+      haltFile: "all runners remain subject to HALT_FILE",
+      privateContextRule: "browser missions must use page-visible evidence, not private repo or monitor internals",
+    },
+    missionTypes: [
+      {
+        id: "surface_sweep",
+        status: "available",
+        tier: 1,
+        scope: "read_only",
+        mutation: "never",
+        supportedEnvs: ["local", "preview", "testnet", "mainnet-read-only"],
+        request: {
+          body: {
+            mode: "surface_sweep",
+            targetUrl: "https://app-or-site.example",
+            routes: ["/", "/jobs", "/agents"],
+            requester: "agent-name",
+          },
+        },
+        evidence: ["http status", "screenshots", "visible text", "console errors", "network failures", "artifact manifest"],
+        result: "structured mission report with verdict, scores, blockers, findings, and evidence links",
+      },
+      {
+        id: "targeted_read_only",
+        status: "available",
+        tier: 1,
+        scope: "read_only",
+        mutation: "stop_before_mutation",
+        supportedEnvs: ["local", "preview", "testnet", "mainnet-read-only"],
+        request: {
+          body: {
+            targetUrl: "https://app-or-site.example/path",
+            goal: "Inspect the changed route like a new outside agent; stop before mutation.",
+            allowTestMutations: false,
+            requester: "agent-name",
+          },
+        },
+        evidence: ["http status", "screenshots", "visible text", "console errors", "network failures", "artifact manifest"],
+        result: "structured mission report with verdict, blockers, confusing moments, mutation boundary notes, and evidence links",
+      },
+      {
+        id: "authed_surface_sweep",
+        status: signerEnabled ? "session_source_available" : "planned",
+        tier: 1,
+        scope: "read_only",
+        mutation: "never",
+        supportedEnvs: ["testnet", "mainnet-read-only"],
+        dependsOn: ["T2 pre-seeded session runner wiring", "T3 signer sidecar"],
+        note: signerEnabled
+          ? "The signer sidecar can mint sessions, but runner session injection is still a separate capability."
+          : "Requires the signer sidecar and runner session injection before agents should rely on it.",
+      },
+      {
+        id: "gold_path",
+        status: "operator_only_design",
+        tier: 2,
+        scope: "testbed_mutation_only",
+        mutation: "testnet-only, never mainnet",
+        supportedEnvs: ["testnet"],
+        dependsOn: ["T3 signer sidecar", "T4 tier-2 agent executor", "T5 env-to-mutation binding"],
+        note: "Not agent-requestable from this manifest yet.",
+      },
+    ],
+    approvalGate: {
+      agentRequestedRuns: "read-only requests are monitor-gated; mutating missions remain operator-only",
+      currentEnforcement: "POST /monitor/testbed-missions requires monitor auth and, when configured, a Cloudflare Access mission operator/admin allowlist",
+      proposedMissionApproval: "planned T6 board approval flow; not advertised as automatic here",
+    },
+    resultShape: {
+      verdict: "pass | partial | fail",
+      scores: "mission-specific numeric scores",
+      blockers: "visible blockers or empty array",
+      confusingMoments: "where the page required guessing",
+      mutationBoundaryNotes: "what the tester stopped before or safely exercised",
+      evidence: "bounded screenshots, URLs, console/network findings, visible text, and artifact manifest links",
+      recommendations: "smallest product changes that help the next outside agent",
+    },
+    platformHelper: {
+      status: "planned",
+      repository: "averray-agent/agent",
+      expectedShape: "thin helper that POSTs to /monitor/testbed-missions and prints the board link",
+    },
+  };
+}
+
+function truthy(value: string | undefined): boolean {
+  return value === "1" || value === "true";
+}

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTesterCapabilitiesManifest } from "../../services/slack-operator/src/tester-capabilities.js";
+
+describe("tester capabilities manifest", () => {
+  it("publishes the monitor-native request contract and honest available mission types", () => {
+    const manifest = buildTesterCapabilitiesManifest({
+      now: new Date("2026-05-31T12:00:00.000Z"),
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TESTBED_MISSION_RUNNER_EXECUTOR: "playwright",
+      },
+      runner: {
+        schemaVersion: 1,
+        kind: "testbed_mission_runner_heartbeat",
+        runnerId: "runner-1",
+        status: "idle",
+        message: "ready",
+        updatedAt: "2026-05-31T11:59:55.000Z",
+      },
+    });
+
+    expect(manifest).toMatchObject({
+      schemaVersion: 1,
+      kind: "hermes_tester_capabilities",
+      generatedAt: "2026-05-31T12:00:00.000Z",
+      endpoints: {
+        capabilities: { method: "GET", path: "/monitor/tester/capabilities" },
+        requestMission: { method: "POST", path: "/monitor/testbed-missions" },
+      },
+      runtime: {
+        runnerEnabled: true,
+        runnerExecutor: "playwright",
+        signerSidecarEnabled: false,
+      },
+    });
+
+    const surfaceSweep = manifest.missionTypes.find((mission) => mission.id === "surface_sweep");
+    expect(surfaceSweep).toMatchObject({
+      status: "available",
+      scope: "read_only",
+      mutation: "never",
+    });
+    const targeted = manifest.missionTypes.find((mission) => mission.id === "targeted_read_only");
+    expect(targeted).toMatchObject({
+      status: "available",
+      scope: "read_only",
+      mutation: "stop_before_mutation",
+    });
+    const goldPath = manifest.missionTypes.find((mission) => mission.id === "gold_path");
+    expect(goldPath).toMatchObject({
+      status: "operator_only_design",
+      scope: "testbed_mutation_only",
+    });
+  });
+
+  it("marks authed sweep as session-source available only when the signer sidecar is enabled", () => {
+    const withoutSigner = buildTesterCapabilitiesManifest({
+      env: { TEST_WALLET_SIGNER_ENABLED: "0" },
+    });
+    expect(withoutSigner.missionTypes.find((mission) => mission.id === "authed_surface_sweep")).toMatchObject({
+      status: "planned",
+    });
+
+    const withSigner = buildTesterCapabilitiesManifest({
+      env: { TEST_WALLET_SIGNER_ENABLED: "1" },
+    });
+    expect(withSigner.runtime.signerSidecarEnabled).toBe(true);
+    expect(withSigner.missionTypes.find((mission) => mission.id === "authed_surface_sweep")).toMatchObject({
+      status: "session_source_available",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- add authenticated `GET /monitor/tester/capabilities` to publish the tester contract from the monitor
- include current read-only mission types, planned/authed mission status, runtime runner/signer status, request endpoints, approval gate, and expected result shape
- update Hermes docs so T3 is marked done via #283 and T7 is in review for the manifest endpoint while the platform helper remains follow-up

## Validation

- `npm run typecheck`
- `npm test`

## Impact

- Backend/monitor only; no contracts, indexer, Caddy, or public site changes.
- No new environment variables or VPS secrets required.
