### PR TITLE
[codex] Add A1 agent scorecard

### DIFF
--- a/docs/HERMES_PHASE2_DESIGN.md
+++ b/docs/HERMES_PHASE2_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Phase 2 Design (Intelligence + Trust)
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.** Design-level spec for the next layer after the core orchestration.
+- **Status:** Phase-2 implementation has started. A1 now has a read-only scorecard spine/API/MCP slice in review; A2/A3 and D1-D3 remain design-level.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md), [`HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md), [`HERMES_ORCHESTRATION_DESIGN.md`](./HERMES_ORCHESTRATION_DESIGN.md) (the core P1–P5).
 - **Position:** **Phase 2.** Builds on the core — it consumes agent attribution (P1), dispatch + the autonomy mode (P3/P4), and the handoff-event log. Do not start until the core ships.
@@ -44,6 +44,8 @@ Per-agent, per-surface metrics from the spine:
 - **The trust metric:** autopilot auto-approvals that *later needed human rework* — the direct measure of whether autopilot's judgment holds up.
 
 Surface: a board panel + `averray_agent_scorecard` MCP tool. **This is the first Phase-2 build** (decision #1) — the spine + its first visible payoff together.
+
+Implementation note: the first A1 slice exposes `/monitor/agents` and `averray_agent_scorecard` from existing monitor events, codex/Claude task queue state, and browser mission reports. It deliberately marks cost/tokens, autopilot auto-approval rework, time-to-PR, and time-to-merge as `not_recorded` until those signals exist in durable events. Board-panel polish and `/monitor/sessions/:id` are follow-ups.
 
 ### A2 — Learned routing  ·  acts · risk: medium · **data-driven within non-high-risk** (decision #2)
 Stats fully drive routing for non-high-risk surfaces — with safeguards so "data-driven" doesn't become brittle or self-entrenching:
@@ -102,4 +104,4 @@ All sits *after* the core P1–P4. Each ships as a narrow PR per [AGENTS.md](../
 
 ---
 
-*End of Phase 2 design. Planning/handoff only — not implemented.*
+*End of Phase 2 design. A1 read-only scorecard implementation has started; acting layers remain design-level until their guardrails are built.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -26,7 +26,7 @@
 | O3 | Board-driven dispatch | ✅ done — create/approve form (agent picker) + `/task` verb live on the board (#271) |
 | O4 | Hermes enqueue + dispatch guardrail + autonomy mode | 🟡 in build — PR1 enqueue+guardrail ✅ (#280) · PR2 routing taxonomy ✅ (#281) · PR3 autopilot auto-approval **blocked on D3** |
 | O5 | Self-management hardening | design done |
-| A1 | Agent scorecard | design done |
+| A1 | Agent scorecard | 🟡 in review — read-only `/monitor/agents` + `averray_agent_scorecard` scorecard slice |
 | A2 | Learned routing (data-driven, non-high-risk) | design done |
 | A3 | Cost visibility / cost-aware routing | design done |
 | D1 | "While you were away" digest (board + Slack/push) | design done |

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -25,6 +25,10 @@
       "types": "./dist/handoff-events.d.ts",
       "import": "./dist/handoff-events.js"
     },
+    "./agent-scorecard": {
+      "types": "./dist/agent-scorecard.d.ts",
+      "import": "./dist/agent-scorecard.js"
+    },
     "./agent-invocation": {
       "types": "./dist/agent-invocation.d.ts",
       "import": "./dist/agent-invocation.js"

--- a/packages/averray-mcp/src/agent-scorecard.ts
+++ b/packages/averray-mcp/src/agent-scorecard.ts
@@ -1,0 +1,502 @@
+import { readFile } from "node:fs/promises";
+import { getHandoffMonitor } from "./handoff-events.js";
+
+export type ScorecardAgent = "codex" | "claude" | "hermes" | "browser" | "unknown";
+export type ScorecardConfidence = "none" | "low" | "medium" | "high";
+
+export interface AgentScorecardOptions {
+  now?: Date;
+  limit?: number;
+  activeWindowMinutes?: number;
+  eventLogPath?: string;
+  codexTasksPath?: string;
+  testbedMissionsPath?: string;
+}
+
+interface MutableAgentStats {
+  agent: ScorecardAgent;
+  handoffs: number;
+  taskTotal: number;
+  taskCompleted: number;
+  taskFailed: number;
+  taskCancelled: number;
+  taskRunning: number;
+  taskProposed: number;
+  taskAttempts: number;
+  taskDurationMsTotal: number;
+  taskDurationCount: number;
+  missionTotal: number;
+  missionPassed: number;
+  missionPartial: number;
+  missionFailed: number;
+  prOpened: number;
+  prMerged: number;
+  prMergeReady: number;
+  prNeedsReview: number;
+  prBlocked: number;
+  prDraft: number;
+  checkPass: number;
+  checkFail: number;
+  checkRunning: number;
+  checkNeutral: number;
+  verdicts: Record<string, number>;
+  surfaces: Map<string, { count: number; ready: number; blocked: number }>;
+  seenPrKeys: Set<string>;
+}
+
+export async function getAgentScorecard(options: AgentScorecardOptions = {}) {
+  const now = options.now ?? new Date();
+  const monitor = await getHandoffMonitor({
+    limit: options.limit ?? 100,
+    activeWindowMinutes: options.activeWindowMinutes,
+    eventLogPath: options.eventLogPath,
+    now,
+  });
+  const codexTasks = await readCodexTasks(options.codexTasksPath);
+  const testbedMissions = await readTestbedMissions(options.testbedMissionsPath);
+  return buildAgentScorecard({
+    ...monitor,
+    codexTasks: {
+      schemaVersion: 1,
+      kind: "codex_task_queue",
+      items: codexTasks,
+    },
+    testbedMissions,
+  }, { now });
+}
+
+export function buildAgentScorecard(snapshot: unknown, options: { now?: Date } = {}) {
+  const now = options.now ?? new Date();
+  const root = isRecord(snapshot) ? snapshot : {};
+  const agents = new Map<ScorecardAgent, MutableAgentStats>();
+
+  for (const item of [...records(root.active), ...records(root.recent)]) {
+    recordHandoffItem(agents, item);
+  }
+
+  const codexTasks = isRecord(root.codexTasks) ? root.codexTasks : {};
+  for (const task of records(codexTasks.items)) {
+    recordTask(agents, task);
+  }
+
+  for (const mission of records(root.testbedMissions)) {
+    recordMission(agents, mission);
+  }
+
+  const items = Array.from(agents.values())
+    .map(finalizeAgent)
+    .sort((a, b) => agentSortKey(a.agent) - agentSortKey(b.agent) || b.sampleCount - a.sampleCount);
+
+  const totals = items.reduce(
+    (acc, item) => {
+      acc.agents += 1;
+      acc.samples += item.sampleCount;
+      acc.tasks += item.tasks.total;
+      acc.pullRequests += item.quality.pullRequests.opened;
+      acc.missions += item.missions.total;
+      return acc;
+    },
+    { agents: 0, samples: 0, tasks: 0, pullRequests: 0, missions: 0 }
+  );
+
+  return {
+    schemaVersion: 1,
+    kind: "averray_agent_scorecard",
+    generatedAt: now.toISOString(),
+    truthBoundary: "Read-only A1 scorecard from monitor events, task queue state, and browser mission reports. Missing cost and autopilot-rework signals are marked as not recorded, not inferred.",
+    totals,
+    agents: items,
+    gaps: [
+      "Cost and token totals are not present in the current runner events.",
+      "Autopilot auto-approval rework is not yet emitted as a durable signal.",
+      "Time-to-PR and time-to-merge need GitHub timeline evidence before they become routing inputs.",
+    ],
+    safety: {
+      readOnly: true,
+      mutatesGithub: false,
+      mutatesRunnerQueue: false,
+      routingInfluence: "A1 only observes. A2 may use these baselines later with high-risk surfaces still rule-bound.",
+    },
+  };
+}
+
+function recordHandoffItem(agents: Map<ScorecardAgent, MutableAgentStats>, item: Record<string, unknown>): void {
+  const agent = agentForHandoff(item);
+  const stats = ensureAgent(agents, agent);
+  stats.handoffs += 1;
+
+  const summary = recordField(item, "summary");
+  const currentPr = firstRecord(
+    recordField(summary, "currentPullRequest"),
+    recordField(summary, "pullRequest"),
+    recordField(item, "currentPullRequest"),
+    recordField(item, "pullRequest")
+  );
+  if (currentPr) {
+    const repo = stringField(currentPr, "repo") ?? stringField(item, "repo") ?? "unknown";
+    const number = numberField(currentPr, "number") ?? numberField(item, "pullRequestNumber") ?? 0;
+    const prKey = `${repo}#${number}`;
+    if (!stats.seenPrKeys.has(prKey)) {
+      stats.seenPrKeys.add(prKey);
+      stats.prOpened += 1;
+      if (booleanField(currentPr, "merged")) stats.prMerged += 1;
+      if (booleanField(currentPr, "draft")) stats.prDraft += 1;
+    }
+  }
+
+  const finalVerdict = normalizedVerdict(
+    stringField(summary, "finalVerdict")
+      ?? stringField(summary, "mergeRecommendation")
+      ?? stringField(item, "reason")
+      ?? stringField(item, "status")
+  );
+  if (finalVerdict) {
+    stats.verdicts[finalVerdict] = (stats.verdicts[finalVerdict] ?? 0) + 1;
+    if (isReadyVerdict(finalVerdict)) stats.prMergeReady += 1;
+    if (isReviewVerdict(finalVerdict)) stats.prNeedsReview += 1;
+    if (isBlockVerdict(finalVerdict)) stats.prBlocked += 1;
+  }
+
+  for (const check of records(summary?.checks)) {
+    const status = stringField(check, "status");
+    const conclusion = stringField(check, "conclusion");
+    if (status === "completed" && conclusion === "success") stats.checkPass += 1;
+    else if (status === "completed" && conclusion && conclusion !== "success" && conclusion !== "neutral") stats.checkFail += 1;
+    else if (status === "in_progress" || status === "queued" || status === "waiting") stats.checkRunning += 1;
+    else stats.checkNeutral += 1;
+  }
+
+  for (const surface of surfacesForHandoff(summary)) {
+    const surfaceStats = stats.surfaces.get(surface) ?? { count: 0, ready: 0, blocked: 0 };
+    surfaceStats.count += 1;
+    if (finalVerdict && isReadyVerdict(finalVerdict)) surfaceStats.ready += 1;
+    if (finalVerdict && isBlockVerdict(finalVerdict)) surfaceStats.blocked += 1;
+    stats.surfaces.set(surface, surfaceStats);
+  }
+}
+
+function recordTask(agents: Map<ScorecardAgent, MutableAgentStats>, task: Record<string, unknown>): void {
+  const agent = taskAgent(task);
+  const stats = ensureAgent(agents, agent);
+  stats.taskTotal += 1;
+  const status = stringField(task, "status");
+  if (status === "completed") stats.taskCompleted += 1;
+  else if (status === "failed") stats.taskFailed += 1;
+  else if (status === "cancelled") stats.taskCancelled += 1;
+  else if (status === "running") stats.taskRunning += 1;
+  else if (status === "proposed" || status === "approved") stats.taskProposed += 1;
+
+  stats.taskAttempts += Math.max(0, numberField(task, "attemptCount") ?? 0);
+  const started = stringField(task, "startedAt");
+  const ended = stringField(task, "completedAt") ?? stringField(task, "failedAt");
+  const durationMs = durationBetween(started, ended);
+  if (durationMs !== undefined) {
+    stats.taskDurationMsTotal += durationMs;
+    stats.taskDurationCount += 1;
+  }
+}
+
+function recordMission(agents: Map<ScorecardAgent, MutableAgentStats>, mission: Record<string, unknown>): void {
+  const agent = agentForMission(mission);
+  const stats = ensureAgent(agents, agent);
+  stats.missionTotal += 1;
+  const result = recordField(mission, "result");
+  const verdict = normalizedVerdict(stringField(result, "verdict") ?? stringField(mission, "status"));
+  if (verdict === "pass" || verdict === "ok_to_merge") stats.missionPassed += 1;
+  else if (verdict === "partial" || verdict === "needs_review" || verdict === "operator_review") stats.missionPartial += 1;
+  else if (verdict === "fail" || verdict === "failed" || verdict === "block") stats.missionFailed += 1;
+}
+
+function finalizeAgent(stats: MutableAgentStats) {
+  const terminalTasks = stats.taskCompleted + stats.taskFailed + stats.taskCancelled;
+  const checkTotal = stats.checkPass + stats.checkFail + stats.checkRunning + stats.checkNeutral;
+  const sampleCount = stats.handoffs + stats.taskTotal + stats.missionTotal;
+  const successNumerator = stats.prMerged + stats.prMergeReady + stats.taskCompleted + stats.missionPassed;
+  const outcomeDenominator = Math.max(
+    1,
+    stats.prOpened + terminalTasks + stats.missionPassed + stats.missionPartial + stats.missionFailed
+  );
+  const successRate = round(successNumerator / outcomeDenominator, 3);
+  const checkPassRate = checkTotal > 0 ? round(stats.checkPass / checkTotal, 3) : null;
+  const failurePenalty = round((stats.prBlocked + stats.taskFailed + stats.missionFailed) / outcomeDenominator, 3);
+  const routingScore = sampleCount > 0
+    ? clamp(Math.round((successRate * 0.65 + (checkPassRate ?? successRate) * 0.25 + (1 - failurePenalty) * 0.10) * 100), 0, 100)
+    : null;
+
+  return {
+    agent: stats.agent,
+    sampleCount,
+    confidence: confidenceFor(sampleCount),
+    routingSignal: {
+      score: routingScore,
+      status: sampleCount >= 4 ? "baseline_available" : sampleCount > 0 ? "cold_start" : "no_signal",
+      note: sampleCount >= 4
+        ? "Enough read-only signal for humans to compare; A2 still needs safeguards before acting on it."
+        : "Treat this as orientation only; static routing should still win.",
+    },
+    quality: {
+      pullRequests: {
+        opened: stats.prOpened,
+        merged: stats.prMerged,
+        mergeReady: stats.prMergeReady,
+        needsReview: stats.prNeedsReview,
+        blocked: stats.prBlocked,
+        draft: stats.prDraft,
+        mergeRate: stats.prOpened > 0 ? round(stats.prMerged / stats.prOpened, 3) : null,
+      },
+      checks: {
+        pass: stats.checkPass,
+        fail: stats.checkFail,
+        running: stats.checkRunning,
+        neutral: stats.checkNeutral,
+        latestPassRate: checkPassRate,
+      },
+      verdicts: stats.verdicts,
+    },
+    tasks: {
+      total: stats.taskTotal,
+      completed: stats.taskCompleted,
+      failed: stats.taskFailed,
+      cancelled: stats.taskCancelled,
+      running: stats.taskRunning,
+      proposedOrApproved: stats.taskProposed,
+      attempts: stats.taskAttempts,
+      successRate: terminalTasks > 0 ? round(stats.taskCompleted / terminalTasks, 3) : null,
+    },
+    missions: {
+      total: stats.missionTotal,
+      passed: stats.missionPassed,
+      partial: stats.missionPartial,
+      failed: stats.missionFailed,
+    },
+    speed: {
+      avgTaskDurationMinutes: stats.taskDurationCount > 0
+        ? round((stats.taskDurationMsTotal / stats.taskDurationCount) / 60_000, 2)
+        : null,
+      timeToPrMinutes: null,
+      timeToMergeMinutes: null,
+      status: stats.taskDurationCount > 0 ? "task_duration_available" : "timeline_not_recorded",
+    },
+    cost: {
+      status: "not_recorded",
+      totalUsd: null,
+      totalTokens: null,
+      averageUsdPerTask: null,
+    },
+    trust: {
+      autopilotAutoApprovals: 0,
+      laterHumanRework: 0,
+      status: "not_recorded",
+    },
+    surfaces: Array.from(stats.surfaces.entries())
+      .map(([surface, value]) => ({ surface, ...value }))
+      .sort((a, b) => b.count - a.count || a.surface.localeCompare(b.surface))
+      .slice(0, 8),
+  };
+}
+
+function ensureAgent(agents: Map<ScorecardAgent, MutableAgentStats>, agent: ScorecardAgent): MutableAgentStats {
+  const existing = agents.get(agent);
+  if (existing) return existing;
+  const next: MutableAgentStats = {
+    agent,
+    handoffs: 0,
+    taskTotal: 0,
+    taskCompleted: 0,
+    taskFailed: 0,
+    taskCancelled: 0,
+    taskRunning: 0,
+    taskProposed: 0,
+    taskAttempts: 0,
+    taskDurationMsTotal: 0,
+    taskDurationCount: 0,
+    missionTotal: 0,
+    missionPassed: 0,
+    missionPartial: 0,
+    missionFailed: 0,
+    prOpened: 0,
+    prMerged: 0,
+    prMergeReady: 0,
+    prNeedsReview: 0,
+    prBlocked: 0,
+    prDraft: 0,
+    checkPass: 0,
+    checkFail: 0,
+    checkRunning: 0,
+    checkNeutral: 0,
+    verdicts: {},
+    surfaces: new Map(),
+    seenPrKeys: new Set(),
+  };
+  agents.set(agent, next);
+  return next;
+}
+
+async function readCodexTasks(path?: string): Promise<Record<string, unknown>[]> {
+  const taskPath = path ?? process.env.AVERRAY_CODEX_TASKS_PATH ?? "/tmp/averray-reference-agent/codex-tasks.json";
+  try {
+    const content = await readFile(taskPath, "utf8");
+    const value: unknown = JSON.parse(content);
+    if (Array.isArray(value)) return value.filter(isRecord);
+    if (isRecord(value)) return records(value.items);
+    return [];
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function readTestbedMissions(path?: string): Promise<Record<string, unknown>[]> {
+  const missionPath = path ?? process.env.AVERRAY_TESTBED_MISSIONS_PATH;
+  if (!missionPath) return [];
+  try {
+    const content = await readFile(missionPath, "utf8");
+    const value: unknown = JSON.parse(content);
+    if (Array.isArray(value)) return value.filter(isRecord);
+    if (isRecord(value)) return records(value.runs);
+    return [];
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+function agentForHandoff(item: Record<string, unknown>): ScorecardAgent {
+  const summary = recordField(item, "summary");
+  const pr = firstRecord(
+    recordField(summary, "currentPullRequest"),
+    recordField(summary, "pullRequest"),
+    recordField(item, "currentPullRequest"),
+    recordField(item, "pullRequest")
+  );
+  const branchAgent = agentFromBranch(stringField(pr, "headBranch") ?? stringField(item, "headBranch"));
+  if (branchAgent) return branchAgent;
+  const requester = (stringField(item, "requester") ?? "").toLowerCase();
+  const source = (stringField(summary, "source") ?? "").toLowerCase();
+  const intent = (stringField(item, "intent") ?? "").toLowerCase();
+  if (intent.includes("testbed") || source.includes("testbed")) return "browser";
+  if (requester.includes("github-live") || requester.includes("hermes") || source.includes("github_live")) return "hermes";
+  return "unknown";
+}
+
+function taskAgent(task: Record<string, unknown>): ScorecardAgent {
+  const agent = (stringField(task, "agent") ?? "").toLowerCase();
+  if (agent === "claude") return "claude";
+  if (agent === "codex") return "codex";
+  if (agent === "hermes") return "hermes";
+  return "codex";
+}
+
+function agentForMission(mission: Record<string, unknown>): ScorecardAgent {
+  const name = (stringField(mission, "agentName") ?? "").toLowerCase();
+  if (name.includes("codex")) return "codex";
+  if (name.includes("claude")) return "claude";
+  if (name.includes("hermes")) return "hermes";
+  return "browser";
+}
+
+function agentFromBranch(branch: string | undefined): ScorecardAgent | undefined {
+  const normalized = branch?.trim().toLowerCase() ?? "";
+  if (normalized.startsWith("codex/")) return "codex";
+  if (normalized.startsWith("claude/")) return "claude";
+  return undefined;
+}
+
+function surfacesForHandoff(summary: Record<string, unknown> | undefined): string[] {
+  const reviewSignals = recordField(summary, "reviewSignals");
+  const touchedAreas = arrayStrings(reviewSignals?.touchedAreas);
+  if (touchedAreas.length > 0) return touchedAreas;
+  const touchedFiles = records(reviewSignals?.touchedFiles)
+    .map((file) => stringField(file, "area"))
+    .filter((area): area is string => Boolean(area));
+  if (touchedFiles.length > 0) return Array.from(new Set(touchedFiles));
+  return [];
+}
+
+function normalizedVerdict(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+}
+
+function isReadyVerdict(verdict: string): boolean {
+  return verdict === "ok_to_merge" || verdict === "pass" || verdict === "passed" || verdict === "completed" || verdict === "github_ok_to_merge";
+}
+
+function isReviewVerdict(verdict: string): boolean {
+  return verdict === "needs_review" || verdict === "human_review" || verdict === "operator_review" || verdict === "review";
+}
+
+function isBlockVerdict(verdict: string): boolean {
+  return verdict === "block" || verdict === "blocked" || verdict === "hold" || verdict === "failed" || verdict === "fail" || verdict === "github_hold";
+}
+
+function confidenceFor(sampleCount: number): ScorecardConfidence {
+  if (sampleCount <= 0) return "none";
+  if (sampleCount < 4) return "low";
+  if (sampleCount < 10) return "medium";
+  return "high";
+}
+
+function agentSortKey(agent: ScorecardAgent): number {
+  switch (agent) {
+    case "codex": return 0;
+    case "claude": return 1;
+    case "hermes": return 2;
+    case "browser": return 3;
+    case "unknown": return 4;
+  }
+}
+
+function durationBetween(start: string | undefined, end: string | undefined): number | undefined {
+  if (!start || !end) return undefined;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return undefined;
+  return endMs - startMs;
+}
+
+function firstRecord(...values: Array<Record<string, unknown> | undefined>): Record<string, unknown> | undefined {
+  return values.find((value): value is Record<string, unknown> => Boolean(value));
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | undefined {
+  return isRecord(value) && isRecord(value[key]) ? value[key] : undefined;
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberField(record: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function booleanField(record: Record<string, unknown> | undefined, key: string): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function arrayStrings(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0) : [];
+}
+
+function round(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -53,6 +53,7 @@ import { approveGithubMergeStewardCandidate, getGithubOperatorBrief, getGithubOp
 import { getTestbedAgentMission, getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { invokeAgentTask } from "./agent-invocation.js";
 import { getHandoffMonitor } from "./handoff-events.js";
+import { getAgentScorecard } from "./agent-scorecard.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -321,6 +322,18 @@ server.tool(
   },
   async ({ correlationId, limit, activeWindowMinutes }) => {
     return jsonContent(await getHandoffMonitor({ correlationId, limit, activeWindowMinutes }));
+  }
+);
+
+server.tool(
+  "averray_agent_scorecard",
+  "Read-only A1 agent scorecard for Codex, Claude, Hermes, and browser missions. Aggregates monitor handoffs, task queue state, and browser mission reports into performance/trust baselines. Missing cost, token, and autopilot rework signals are explicitly marked not_recorded. This observes only: it does not route tasks, approve work, merge PRs, deploy, claim jobs, edit queues, or mutate external systems.",
+  {
+    limit: z.number().int().min(1).max(100).default(100),
+    activeWindowMinutes: z.number().int().min(1).max(1440).default(240)
+  },
+  async ({ limit, activeWindowMinutes }) => {
+    return jsonContent(await getAgentScorecard({ limit, activeWindowMinutes }));
   }
 );
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -7,6 +7,7 @@ import { logger, optionalEnv, query } from "@avg/mcp-common";
 import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
 import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
 import { getHandoffMonitor } from "@avg/averray-mcp/handoff-events";
+import { buildAgentScorecard } from "@avg/averray-mcp/agent-scorecard";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
 import {
   formatOperatorResultForSlack,
@@ -228,6 +229,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/command",
           "/monitor/recheck",
           "/monitor/codex-tasks",
+          "/monitor/agents",
           "/monitor/collaboration",
           "/monitor/tester/capabilities",
           "/monitor/testbed-missions",
@@ -391,6 +393,19 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     writeJson(response, 200, await loadCodexTaskQueueSummary());
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/agents") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
+    writeJson(response, 200, buildAgentScorecard(raw));
     return;
   }
   if (request.method === "POST" && url.pathname === "/monitor/codex-tasks") {

--- a/test/unit/agent-scorecard.test.ts
+++ b/test/unit/agent-scorecard.test.ts
@@ -1,0 +1,236 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildAgentScorecard, getAgentScorecard } from "../../packages/averray-mcp/src/agent-scorecard.js";
+
+describe("A1 agent scorecard", () => {
+  it("aggregates PR, task, check, surface, and mission signals per agent", () => {
+    const scorecard = buildAgentScorecard({
+      active: [],
+      recent: [
+        {
+          requester: "github-actions",
+          status: "completed",
+          summary: {
+            finalVerdict: "ok_to_merge",
+            currentPullRequest: {
+              repo: "averray-agent/agent",
+              number: 101,
+              merged: true,
+              draft: false,
+              headBranch: "codex/agent-scorecard",
+            },
+            checks: [
+              { name: "Backend", status: "completed", conclusion: "success" },
+              { name: "Frontend", status: "completed", conclusion: "success" },
+            ],
+            reviewSignals: {
+              touchedAreas: ["frontend"],
+            },
+          },
+        },
+        {
+          requester: "github-actions",
+          status: "completed",
+          summary: {
+            finalVerdict: "needs_review",
+            currentPullRequest: {
+              repo: "averray-agent/agent",
+              number: 102,
+              merged: false,
+              draft: false,
+              headBranch: "claude/docs-followup",
+            },
+            checks: [
+              { name: "Backend", status: "completed", conclusion: "failure" },
+            ],
+            reviewSignals: {
+              touchedAreas: ["docs", "backend"],
+            },
+          },
+        },
+      ],
+      codexTasks: {
+        items: [
+          {
+            id: "codex-task-1",
+            agent: "codex",
+            status: "completed",
+            attemptCount: 1,
+            startedAt: "2026-05-31T10:00:00.000Z",
+            completedAt: "2026-05-31T10:10:00.000Z",
+          },
+          {
+            id: "claude-task-1",
+            agent: "claude",
+            status: "failed",
+            attemptCount: 2,
+            startedAt: "2026-05-31T10:00:00.000Z",
+            failedAt: "2026-05-31T10:05:00.000Z",
+          },
+        ],
+      },
+      testbedMissions: [
+        {
+          id: "testbed-mission-1",
+          agentName: "Hermes",
+          status: "completed",
+          result: { verdict: "pass" },
+        },
+      ],
+    }, { now: new Date("2026-05-31T12:00:00.000Z") });
+
+    expect(scorecard).toMatchObject({
+      schemaVersion: 1,
+      kind: "averray_agent_scorecard",
+      generatedAt: "2026-05-31T12:00:00.000Z",
+      totals: {
+        agents: 3,
+        samples: 5,
+        tasks: 2,
+        pullRequests: 2,
+        missions: 1,
+      },
+      safety: {
+        readOnly: true,
+        mutatesGithub: false,
+        mutatesRunnerQueue: false,
+      },
+    });
+
+    const codex = scorecard.agents.find((agent) => agent.agent === "codex");
+    expect(codex).toMatchObject({
+      sampleCount: 2,
+      quality: {
+        pullRequests: {
+          opened: 1,
+          merged: 1,
+          mergeReady: 1,
+        },
+        checks: {
+          pass: 2,
+          latestPassRate: 1,
+        },
+      },
+      tasks: {
+        total: 1,
+        completed: 1,
+        attempts: 1,
+        successRate: 1,
+      },
+      speed: {
+        avgTaskDurationMinutes: 10,
+      },
+      cost: {
+        status: "not_recorded",
+        totalUsd: null,
+      },
+      trust: {
+        status: "not_recorded",
+      },
+      surfaces: [
+        {
+          surface: "frontend",
+          count: 1,
+          ready: 1,
+        },
+      ],
+    });
+
+    const claude = scorecard.agents.find((agent) => agent.agent === "claude");
+    expect(claude).toMatchObject({
+      sampleCount: 2,
+      quality: {
+        pullRequests: {
+          opened: 1,
+          needsReview: 1,
+        },
+        checks: {
+          fail: 1,
+          latestPassRate: 0,
+        },
+      },
+      tasks: {
+        total: 1,
+        failed: 1,
+        attempts: 2,
+        successRate: 0,
+      },
+    });
+
+    const hermes = scorecard.agents.find((agent) => agent.agent === "hermes");
+    expect(hermes).toMatchObject({
+      sampleCount: 1,
+      missions: {
+        total: 1,
+        passed: 1,
+      },
+    });
+  });
+
+  it("keeps empty snapshots explicit instead of inventing routing confidence", () => {
+    const scorecard = buildAgentScorecard({}, { now: new Date("2026-05-31T12:00:00.000Z") });
+
+    expect(scorecard.totals).toEqual({
+      agents: 0,
+      samples: 0,
+      tasks: 0,
+      pullRequests: 0,
+      missions: 0,
+    });
+    expect(scorecard.agents).toEqual([]);
+    expect(scorecard.gaps).toContain("Cost and token totals are not present in the current runner events.");
+    expect(scorecard.safety.routingInfluence).toContain("A1 only observes");
+  });
+
+  it("reads task and browser mission stores without needing monitor internals", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-agent-scorecard-"));
+    try {
+      const codexTasksPath = join(dir, "codex-tasks.json");
+      const testbedMissionsPath = join(dir, "testbed-missions.json");
+      await writeFile(codexTasksPath, JSON.stringify({
+        items: [
+          {
+            id: "codex-task-2",
+            agent: "codex",
+            status: "completed",
+            attemptCount: 1,
+          },
+        ],
+      }));
+      await writeFile(testbedMissionsPath, JSON.stringify({
+        runs: [
+          {
+            id: "testbed-mission-2",
+            agentName: "Hermes",
+            status: "completed",
+            result: { verdict: "partial" },
+          },
+        ],
+      }));
+
+      const scorecard = await getAgentScorecard({
+        eventLogPath: join(dir, "missing-events.jsonl"),
+        codexTasksPath,
+        testbedMissionsPath,
+        now: new Date("2026-05-31T12:00:00.000Z"),
+      });
+
+      expect(scorecard.totals).toMatchObject({
+        agents: 2,
+        tasks: 1,
+        missions: 1,
+      });
+      expect(scorecard.agents.find((agent) => agent.agent === "codex")).toMatchObject({
+        tasks: { completed: 1 },
+      });
+      expect(scorecard.agents.find((agent) => agent.agent === "hermes")).toMatchObject({
+        missions: { partial: 1 },
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- Adds the A1 read-only agent scorecard aggregator for Codex, Claude, Hermes, browser missions, and unknown agents.
- Exposes the scorecard through:
  - monitor API: `GET /monitor/agents`
  - MCP tool: `averray_agent_scorecard`
- Tracks PR/check/task/mission/surface baselines from existing monitor data, codex/Claude task stores, and browser mission reports.
- Keeps truth boundaries explicit: cost/tokens, autopilot rework, time-to-PR, and time-to-merge are marked `not_recorded` until durable signals exist.
- Updates Hermes docs/roadmap to show A1 as in review.

## Safety / scope

- Read-only only; no task routing, queue mutation, GitHub mutation, deploy, or approval behavior.
- A2 learned routing still remains design-level and must build on this with guardrails.
- Affects monitor + MCP backend only.

## Checks run

- `npm run typecheck`
- `npm test`
- `git diff --check HEAD~1..HEAD`

## Env / deploy notes

- No new environment variables or VPS secrets required.
- No contracts, indexer, Caddy, public site, or generated static output changes.
