### PR TITLE
D3: tiered anomaly auto-pause (the autopilot fail-safe)

### DIFF
--- a/hermes/config/policy.yaml
+++ b/hermes/config/policy.yaml
@@ -22,4 +22,15 @@ dispatch:
     - claude
   per_day_max: 10
   per_repo_per_day_max: 5
+# D3 anomaly auto-pause — the fail-safe for autopilot. Tiered: a SOFT trip
+# suspends autopilot (no new auto-approvals) + alerts; a HARD trip touches
+# HALT_FILE (everything mutating stops) + alerts. The operator resumes via
+# POST /monitor/autopilot-resume. Thresholds live here, beside the guardrail.
+anomaly:
+  task_retry_soft: 3       # a task at attempt #3+ → soft
+  task_runaway_hard: 6     # a task at attempt #6+ → hard
+  failing_tasks_hard: 3    # 3+ tasks failing/retrying → hard (multi-task runaway)
+  budget_spike_ratio: 0.8  # ≥80% of the per-day dispatch cap → soft
+  budget_blowout_ratio: 1.0 # ≥100% of the cap → hard
+  heartbeat_gap_sec: 600   # runner heartbeat 10min+ stale → soft
 

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -186,6 +186,19 @@ D4_ALERT_QUIET_HOURS=
 D4_ALERT_QUIET_TZ_OFFSET_MIN=0
 # Board base URL used in the alert deep link.
 SLACK_OPERATOR_MONITOR_URL=https://monitor.averray.com/monitor
+# D3 — tiered anomaly auto-pause: the automatic fail-safe for autopilot. A SOFT
+# trip suspends autopilot (no new auto-approvals; in-flight finishes) + alerts; a
+# HARD trip also touches HALT_FILE (all mutating work stops) + alerts. The
+# operator resumes via POST /monitor/autopilot-resume. Off by default — enable it
+# BEFORE turning on autopilot. The suspended flag persists on /data so a trip
+# survives a restart. Detection thresholds live in hermes/config/policy.yaml
+# (anomaly: block); the D3_* env vars there override per-threshold if needed.
+D3_ANOMALY_PAUSE_ENABLED=0
+D3_ANOMALY_PAUSE_INTERVAL_MINUTES=1
+AVERRAY_AUTOPILOT_SUSPENDED_PATH=/data/autopilot-suspended.json
+# Per-day dispatch cap the budget-spike/blowout signals measure against (matches
+# the dispatch guardrail's per_day_max). Spike ≥80% → soft; blowout ≥100% → hard.
+HERMES_DISPATCH_PER_DAY_MAX=10
 # Mission-spawn role gate (§21.5). Comma/space-separated Cloudflare Access
 # emails allowed to POST /monitor/testbed-missions. Leave both empty to keep
 # mission spawn unrestricted (relies on the edge gate + token only).

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -165,6 +165,14 @@ services:
       D4_ALERT_QUIET_HOURS: ${D4_ALERT_QUIET_HOURS:-}
       D4_ALERT_QUIET_TZ_OFFSET_MIN: ${D4_ALERT_QUIET_TZ_OFFSET_MIN:-0}
       SLACK_OPERATOR_MONITOR_URL: ${SLACK_OPERATOR_MONITOR_URL:-https://monitor.averray.com/monitor}
+      # D3 — tiered anomaly auto-pause (the autopilot fail-safe). Off by default;
+      # the operator enables it BEFORE turning on autopilot. A soft trip suspends
+      # autopilot (flag persisted on /data so it survives a restart); a hard trip
+      # also touches HALT_FILE. Thresholds live in hermes/config/policy.yaml.
+      D3_ANOMALY_PAUSE_ENABLED: ${D3_ANOMALY_PAUSE_ENABLED:-0}
+      D3_ANOMALY_PAUSE_INTERVAL_MINUTES: ${D3_ANOMALY_PAUSE_INTERVAL_MINUTES:-1}
+      AVERRAY_AUTOPILOT_SUSPENDED_PATH: ${AVERRAY_AUTOPILOT_SUSPENDED_PATH:-/data/autopilot-suspended.json}
+      HERMES_DISPATCH_PER_DAY_MAX: ${HERMES_DISPATCH_PER_DAY_MAX:-10}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}
       SLACK_OPERATOR_MONITOR_TOKEN: ${SLACK_OPERATOR_MONITOR_TOKEN:-}
       SLACK_ALLOWED_USER_IDS: ${SLACK_ALLOWED_USER_IDS:-}

--- a/services/slack-operator/src/anomaly-pause.ts
+++ b/services/slack-operator/src/anomaly-pause.ts
@@ -1,0 +1,227 @@
+// D3 — tiered anomaly auto-pause.
+//
+// The automatic fail-safe that lets a misbehaving autopilot be stopped without
+// a human watching. SERVER-SIDE (runs with no tab open). It owns the
+// autopilot-suspended flag (autopilot-state.ts) that O4-PR3 will respect.
+//
+//   SOFT trip (medium) → set autopilot-suspended + push a D4 alert. No new
+//     auto-approvals while suspended; in-flight work finishes.
+//   HARD trip (severe)  → touch HALT_FILE (everything mutating stops) + alert.
+//
+// This module is the pure decision (evaluateAnomalies / decideAnomalyAction)
+// plus an effect-injected orchestrator (runAnomalyPauseOnce) — so detection +
+// the tiered action are unit-tested with no fs/network.
+
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { optionalEnv, readYamlFile } from "@avg/mcp-common";
+import type { AlertChannel, AlertPayload } from "./alert-bridge.js";
+
+// ── Signals + thresholds ────────────────────────────────────────────
+
+export interface AnomalySignals {
+  /** Highest attemptCount among non-terminal tasks (retry-loop detection). */
+  maxTaskAttemptCount: number;
+  /** Tasks currently in a failed/retrying state (multi-task runaway). */
+  failingTaskCount: number;
+  /** Hermes-proposed/approved tasks created today (budget spike). */
+  hermesTasksToday: number;
+  /** The per-day dispatch cap (from the dispatch guardrail). */
+  perDayCap: number;
+  /** Age of the most recent runner heartbeat, seconds (gap detection). */
+  runnerHeartbeatAgeSec?: number;
+}
+
+export interface AnomalyConfig {
+  /** attemptCount ≥ this → SOFT (task retry loop). */
+  taskRetrySoft: number;
+  /** attemptCount ≥ this → HARD (single-task runaway). */
+  taskRunawayHard: number;
+  /** failing tasks ≥ this → HARD (multi-task runaway). */
+  failingTasksHard: number;
+  /** today/cap ratio ≥ this → SOFT (budget spike). */
+  budgetSpikeRatio: number;
+  /** today/cap ratio ≥ this → HARD (budget blowout). */
+  budgetBlowoutRatio: number;
+  /** runner heartbeat age (s) ≥ this → SOFT (heartbeat gap). */
+  heartbeatGapSec: number;
+}
+
+export type AnomalyTier = "none" | "soft" | "hard";
+export interface AnomalyTrip {
+  signal: string;
+  tier: "soft" | "hard";
+  detail: string;
+}
+export interface AnomalyEvaluation {
+  tier: AnomalyTier;
+  trips: AnomalyTrip[];
+}
+
+const DEFAULTS: AnomalyConfig = {
+  taskRetrySoft: 3,
+  taskRunawayHard: 6,
+  failingTasksHard: 3,
+  budgetSpikeRatio: 0.8,
+  budgetBlowoutRatio: 1.0,
+  heartbeatGapSec: 600,
+};
+
+function num(value: unknown, fallback: number): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+interface AnomalyYamlBlock {
+  task_retry_soft?: unknown;
+  task_runaway_hard?: unknown;
+  failing_tasks_hard?: unknown;
+  budget_spike_ratio?: unknown;
+  budget_blowout_ratio?: unknown;
+  heartbeat_gap_sec?: unknown;
+}
+
+/** Load thresholds from the `anomaly:` block of policy.yaml, with env overrides. */
+export function loadAnomalyConfig(env: NodeJS.ProcessEnv = process.env): AnomalyConfig {
+  const yaml = readYamlFile<{ anomaly?: AnomalyYamlBlock }>(
+    optionalEnv("POLICY_CONFIG_PATH", "/config/policy.yaml") ?? "/config/policy.yaml",
+    {},
+  );
+  const a = yaml.anomaly ?? {};
+  return {
+    taskRetrySoft: num(env.D3_TASK_RETRY_SOFT ?? a.task_retry_soft, DEFAULTS.taskRetrySoft),
+    taskRunawayHard: num(env.D3_TASK_RUNAWAY_HARD ?? a.task_runaway_hard, DEFAULTS.taskRunawayHard),
+    failingTasksHard: num(env.D3_FAILING_TASKS_HARD ?? a.failing_tasks_hard, DEFAULTS.failingTasksHard),
+    budgetSpikeRatio: num(env.D3_BUDGET_SPIKE_RATIO ?? a.budget_spike_ratio, DEFAULTS.budgetSpikeRatio),
+    budgetBlowoutRatio: num(env.D3_BUDGET_BLOWOUT_RATIO ?? a.budget_blowout_ratio, DEFAULTS.budgetBlowoutRatio),
+    heartbeatGapSec: num(env.D3_HEARTBEAT_GAP_SEC ?? a.heartbeat_gap_sec, DEFAULTS.heartbeatGapSec),
+  };
+}
+
+/** Pure: evaluate signals against thresholds. Conservative — hard wins over soft. */
+export function evaluateAnomalies(s: AnomalySignals, c: AnomalyConfig): AnomalyEvaluation {
+  const trips: AnomalyTrip[] = [];
+
+  if (s.maxTaskAttemptCount >= c.taskRunawayHard) {
+    trips.push({ signal: "task_runaway", tier: "hard", detail: `a task reached attempt #${s.maxTaskAttemptCount} (≥ ${c.taskRunawayHard})` });
+  } else if (s.maxTaskAttemptCount >= c.taskRetrySoft) {
+    trips.push({ signal: "task_retry_loop", tier: "soft", detail: `a task reached attempt #${s.maxTaskAttemptCount} (≥ ${c.taskRetrySoft})` });
+  }
+
+  if (s.failingTaskCount >= c.failingTasksHard) {
+    trips.push({ signal: "multi_task_runaway", tier: "hard", detail: `${s.failingTaskCount} tasks failing/retrying (≥ ${c.failingTasksHard})` });
+  }
+
+  if (s.perDayCap > 0) {
+    const ratio = s.hermesTasksToday / s.perDayCap;
+    if (ratio >= c.budgetBlowoutRatio) {
+      trips.push({ signal: "budget_blowout", tier: "hard", detail: `${s.hermesTasksToday}/${s.perDayCap} dispatched today (≥ ${Math.round(c.budgetBlowoutRatio * 100)}% of cap)` });
+    } else if (ratio >= c.budgetSpikeRatio) {
+      trips.push({ signal: "budget_spike", tier: "soft", detail: `${s.hermesTasksToday}/${s.perDayCap} dispatched today (≥ ${Math.round(c.budgetSpikeRatio * 100)}% of cap)` });
+    }
+  }
+
+  if (s.runnerHeartbeatAgeSec !== undefined && s.runnerHeartbeatAgeSec >= c.heartbeatGapSec) {
+    trips.push({ signal: "runner_heartbeat_gap", tier: "soft", detail: `runner heartbeat ${Math.round(s.runnerHeartbeatAgeSec)}s old (≥ ${c.heartbeatGapSec}s)` });
+  }
+
+  const tier: AnomalyTier = trips.some((t) => t.tier === "hard")
+    ? "hard"
+    : trips.some((t) => t.tier === "soft")
+      ? "soft"
+      : "none";
+  return { tier, trips };
+}
+
+export type AnomalyAction = "none" | "soft" | "hard";
+
+/**
+ * Pure: pick the action, with de-dup. A hard tier always acts (the caller skips
+ * when HALT is already present, so it can't re-fire). A soft tier is suppressed
+ * while already suspended — re-evaluated naturally once the operator resumes.
+ */
+export function decideAnomalyAction(evaluation: AnomalyEvaluation, alreadySuspended: boolean): AnomalyAction {
+  if (evaluation.tier === "hard") return "hard";
+  if (evaluation.tier === "soft") return alreadySuspended ? "none" : "soft";
+  return "none";
+}
+
+export function summarizeTrips(evaluation: AnomalyEvaluation): { reason: string; signals: string } {
+  return {
+    reason: evaluation.trips.map((t) => `${t.signal}: ${t.detail}`).join(" | "),
+    signals: evaluation.trips.map((t) => `${t.tier}:${t.signal}`).join(","),
+  };
+}
+
+export function buildAnomalyAlert(evaluation: AnomalyEvaluation, action: AnomalyAction, boardUrl: string): AlertPayload {
+  const head = action === "hard"
+    ? "🛑 Hermes HARD-paused — HALT_FILE set, all mutating work stopped"
+    : "⏸️ Hermes autopilot suspended (soft) — no new auto-approvals until you resume";
+  const lines = evaluation.trips.map((t) => `• [${t.tier}] ${t.signal}: ${t.detail}`).join("\n");
+  const text = `${head}\n${lines}\nResume / inspect: ${boardUrl}`;
+  return { count: evaluation.trips.length, items: [], boardUrl, text };
+}
+
+function haltPath(path?: string): string {
+  return path ?? optionalEnv("HALT_FILE", "/data/HALT") ?? "/data/HALT";
+}
+
+/** Touch the HALT_FILE (hard trip). Same path assertNoKillSwitch reads. */
+export function touchHaltFile(reason: string, path?: string): void {
+  const p = haltPath(path);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, `${reason}\n`);
+}
+
+/** Whether HALT_FILE is already present (so the routine doesn't re-fire). */
+export function isHaltFilePresent(path?: string): boolean {
+  try {
+    return existsSync(haltPath(path));
+  } catch {
+    return false;
+  }
+}
+
+// ── Orchestrator (effect-injected; the index.ts routine wires real impls) ──
+
+export interface AnomalyPauseDeps {
+  config: AnomalyConfig;
+  getSignals: () => Promise<AnomalySignals> | AnomalySignals;
+  isHaltPresent: () => boolean;
+  isSuspended: () => boolean;
+  setSuspended: (info: { reason: string; signal: string; tier: "soft" | "hard"; setAt: string }) => void;
+  touchHalt: (reason: string) => void;
+  alert: (payload: AlertPayload) => Promise<boolean>;
+  audit: (record: { tier: AnomalyTier; action: AnomalyAction; signals: string; reason: string }) => Promise<unknown> | unknown;
+  boardUrl: string;
+  now: () => Date;
+}
+
+export interface AnomalyPauseResult {
+  action: AnomalyAction | "halted";
+  evaluation?: AnomalyEvaluation;
+}
+
+export async function runAnomalyPauseOnce(deps: AnomalyPauseDeps): Promise<AnomalyPauseResult> {
+  // Already halted ⇒ nothing more to stop; don't re-fire.
+  if (deps.isHaltPresent()) return { action: "halted" };
+
+  const signals = await deps.getSignals();
+  const evaluation = evaluateAnomalies(signals, deps.config);
+  const action = decideAnomalyAction(evaluation, deps.isSuspended());
+  if (action === "none") return { action: "none", evaluation };
+
+  const { reason, signals: signalList } = summarizeTrips(evaluation);
+  const setAt = deps.now().toISOString();
+
+  if (action === "hard") {
+    deps.touchHalt(`D3 hard anomaly trip: ${reason}`);
+    deps.setSuspended({ reason, signal: signalList, tier: "hard", setAt }); // also suspend autopilot
+  } else {
+    deps.setSuspended({ reason, signal: signalList, tier: "soft", setAt });
+  }
+
+  await deps.alert(buildAnomalyAlert(evaluation, action, deps.boardUrl));
+  await deps.audit({ tier: evaluation.tier, action, signals: signalList, reason });
+  return { action, evaluation };
+}

--- a/services/slack-operator/src/autopilot-state.ts
+++ b/services/slack-operator/src/autopilot-state.ts
@@ -1,0 +1,75 @@
+// D3 — the autopilot-suspended flag.
+//
+// D3 OWNS this gate. It is set by the anomaly auto-pause (a soft or hard trip)
+// and CLEARED only by the operator (POST /monitor/autopilot-resume). O4-PR3's
+// autopilot auto-approval MUST check `!isAutopilotSuspended()` before approving
+// anything — until PR3 lands the flag is simply inert.
+//
+// Persisted on the shared data volume so a trip SURVIVES a restart: a fail-safe
+// that forgets it tripped is not a fail-safe. A hard trip also touches
+// HALT_FILE (separate, also persistent).
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { dirname } from "node:path";
+import { optionalEnv } from "@avg/mcp-common";
+
+export interface AutopilotSuspendState {
+  suspended: boolean;
+  /** Why it tripped (signal + threshold), for the board + audit. */
+  reason?: string;
+  signal?: string;
+  tier?: "soft" | "hard";
+  setAt?: string;
+}
+
+function suspendStatePath(path?: string): string {
+  return (
+    path ??
+    optionalEnv("AVERRAY_AUTOPILOT_SUSPENDED_PATH", "/data/autopilot-suspended.json") ??
+    "/data/autopilot-suspended.json"
+  );
+}
+
+export function readAutopilotSuspendState(path?: string): AutopilotSuspendState {
+  const p = suspendStatePath(path);
+  try {
+    if (!existsSync(p)) return { suspended: false };
+    const raw = JSON.parse(readFileSync(p, "utf8")) as Partial<AutopilotSuspendState>;
+    return {
+      suspended: raw.suspended === true,
+      ...(raw.reason ? { reason: raw.reason } : {}),
+      ...(raw.signal ? { signal: raw.signal } : {}),
+      ...(raw.tier === "soft" || raw.tier === "hard" ? { tier: raw.tier } : {}),
+      ...(raw.setAt ? { setAt: raw.setAt } : {}),
+    };
+  } catch {
+    // Unreadable state: treat as not-suspended (the flag is inert until PR3, and
+    // a hard trip's HALT_FILE is the real stop). Never throw from a read.
+    return { suspended: false };
+  }
+}
+
+/** The gate PR3's autopilot reads before auto-approving. */
+export function isAutopilotSuspended(path?: string): boolean {
+  return readAutopilotSuspendState(path).suspended;
+}
+
+export function setAutopilotSuspended(
+  info: { reason?: string; signal?: string; tier?: "soft" | "hard"; setAt: string },
+  path?: string,
+): void {
+  const p = suspendStatePath(path);
+  mkdirSync(dirname(p), { recursive: true });
+  const state: AutopilotSuspendState = { suspended: true, ...info };
+  writeFileSync(p, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+/** Operator-only: clear the suspension (POST /monitor/autopilot-resume). */
+export function clearAutopilotSuspended(path?: string): void {
+  const p = suspendStatePath(path);
+  try {
+    if (existsSync(p)) rmSync(p);
+  } catch {
+    /* best-effort; an absent file is already "not suspended" */
+  }
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -58,6 +58,19 @@ import {
   type AlertItem,
 } from "./alert-bridge.js";
 import {
+  runAnomalyPauseOnce,
+  loadAnomalyConfig,
+  touchHaltFile,
+  isHaltFilePresent,
+  type AnomalySignals,
+} from "./anomaly-pause.js";
+import {
+  isAutopilotSuspended,
+  setAutopilotSuspended,
+  clearAutopilotSuspended,
+  readAutopilotSuspendState,
+} from "./autopilot-state.js";
+import {
   isDebugSpawnEnabled,
   mergeDebugCards,
   onDebugCardSpawned,
@@ -468,6 +481,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     writeJson(response, 200, buildTesterCapabilitiesManifest({
       runner: readTestbedMissionRunnerHeartbeat() ?? null,
     }));
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/monitor/autopilot-resume") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorAutopilotResumeRequest(request, response);
     return;
   }
   const testbedMissionId = monitorTestbedMissionId(url.pathname);
@@ -1109,6 +1134,28 @@ async function handleMonitorAlertMuteRequest(request: http.IncomingMessage, resp
   }
 }
 
+// D3 — operator-only resume: clears the autopilot-suspended flag a soft trip
+// set. (A hard trip also touched HALT_FILE; clearing HALT stays a separate,
+// deliberate operator action — this only lifts the autopilot suspension.)
+async function handleMonitorAutopilotResumeRequest(_request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const before = readAutopilotSuspendState();
+    clearAutopilotSuspended();
+    logger.info({ wasSuspended: before.suspended, tier: before.tier, signal: before.signal }, "d3_autopilot_resumed");
+    writeJson(response, 200, {
+      ok: true,
+      resumed: true,
+      wasSuspended: before.suspended,
+      ...(before.reason ? { clearedReason: before.reason } : {}),
+    });
+  } catch (error) {
+    writeJson(response, 500, {
+      error: "autopilot_resume_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 async function handleMonitorRecheckRequest(request: http.IncomingMessage, response: http.ServerResponse) {
   try {
     const rawBody = await readBody(request);
@@ -1278,6 +1325,9 @@ function startOperatorRoutines() {
   let alertBridgeRunning = false;
   let alertBridgeState: AlertBridgeState = initialAlertBridgeState();
   const alertChannel: AlertChannel = slackAlertChannel();
+  let anomalyPauseRunning = false;
+  const anomalyConfig = loadAnomalyConfig();
+  const dispatchPerDayCap = Number(process.env.HERMES_DISPATCH_PER_DAY_MAX) || 10;
 
   const checkDailyBrief = async () => {
     if (dailyBriefRunning) return;
@@ -1457,6 +1507,77 @@ function startOperatorRoutines() {
     }
   };
 
+  // D3 — tiered anomaly auto-pause. Server-side fail-safe: a soft trip suspends
+  // autopilot (the flag PR3 will honor) + alerts; a hard trip touches HALT_FILE
+  // (everything mutating stops) + alerts. De-duped + skipped once HALT is set.
+  const checkAnomalies = async () => {
+    if (anomalyPauseRunning || !routineConfig.anomalyPause.enabled) return;
+    anomalyPauseRunning = true;
+    try {
+      const result = await runAnomalyPauseOnce({
+        config: anomalyConfig,
+        getSignals: async (): Promise<AnomalySignals> => {
+          const summary = (await loadCodexTaskQueueSummary()) as unknown as { items?: Array<Record<string, unknown>>; runner?: Record<string, unknown> };
+          const items = Array.isArray(summary.items) ? summary.items : [];
+          const nonTerminal = items.filter((t) => {
+            const s = typeof t.status === "string" ? t.status : "";
+            return s !== "completed" && s !== "failed" && s !== "cancelled";
+          });
+          const attempt = (t: Record<string, unknown>) => (typeof t.attemptCount === "number" ? t.attemptCount : 0);
+          const today = new Date().toISOString().slice(0, 10);
+          const runnerUpdatedAt =
+            summary.runner && typeof summary.runner.updatedAt === "string" ? Date.parse(summary.runner.updatedAt) : NaN;
+          const runnerHeartbeatAgeSec = Number.isFinite(runnerUpdatedAt)
+            ? Math.max(0, (Date.now() - runnerUpdatedAt) / 1000)
+            : undefined;
+          return {
+            maxTaskAttemptCount: nonTerminal.reduce((m, t) => Math.max(m, attempt(t)), 0),
+            failingTaskCount: nonTerminal.filter((t) => attempt(t) >= 2).length,
+            hermesTasksToday: items.filter(
+              (t) =>
+                (typeof t.requester === "string" ? t.requester.toLowerCase() : "") === "hermes" &&
+                (typeof t.createdAt === "string" ? t.createdAt.slice(0, 10) : "") === today,
+            ).length,
+            perDayCap: dispatchPerDayCap,
+            ...(runnerHeartbeatAgeSec !== undefined ? { runnerHeartbeatAgeSec } : {}),
+          };
+        },
+        isHaltPresent: () => isHaltFilePresent(),
+        isSuspended: () => isAutopilotSuspended(),
+        setSuspended: (info) => setAutopilotSuspended(info),
+        touchHalt: (reason) => touchHaltFile(reason),
+        alert: (payload) => alertChannel.dispatch(payload),
+        audit: async (record) => {
+          await recordOperatorCommandEvent(
+            {
+              source: "slack_routine",
+              commandText: "anomaly auto-pause trip",
+              ...(routineConfig.channelId ? { channelId: routineConfig.channelId } : {}),
+              result: {
+                kind: "anomaly_autopause",
+                tier: record.tier,
+                action: record.action,
+                signals: record.signals,
+                reason: record.reason,
+                safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+              },
+            },
+            query,
+          );
+        },
+        boardUrl: optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor",
+        now: () => new Date(),
+      });
+      if (result.action !== "none" && result.action !== "halted") {
+        logger.warn({ action: result.action, trips: result.evaluation?.trips }, "d3_anomaly_autopause_tripped");
+      }
+    } catch (error) {
+      logger.error({ err: error }, "d3_anomaly_autopause_failed");
+    } finally {
+      anomalyPauseRunning = false;
+    }
+  };
+
   if (routineConfig.dailyBrief.enabled) {
     setTimeout(() => void checkDailyBrief(), 5_000);
     setInterval(() => void checkDailyBrief(), 60_000);
@@ -1480,6 +1601,10 @@ function startOperatorRoutines() {
   if (routineConfig.alertBridge.enabled) {
     setTimeout(() => void checkAlertBridge(), 9_000);
     setInterval(() => void checkAlertBridge(), routineConfig.alertBridge.intervalMs);
+  }
+  if (routineConfig.anomalyPause.enabled) {
+    setTimeout(() => void checkAnomalies(), 11_000);
+    setInterval(() => void checkAnomalies(), routineConfig.anomalyPause.intervalMs);
   }
 }
 

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -31,6 +31,11 @@ export interface SlackRoutineConfig {
     quietHours?: { startMinute: number; endMinute: number };
     quietHoursTzOffsetMin: number;
   };
+  /** D3 — tiered anomaly auto-pause (soft suspend → hard HALT). Off by default. */
+  anomalyPause: {
+    enabled: boolean;
+    intervalMs: number;
+  };
 }
 
 export function parseSlackRoutineConfig(
@@ -78,6 +83,11 @@ export function parseSlackRoutineConfig(
       cooldownMs: Math.max(0, (positiveNumber(env.D4_ALERT_BRIDGE_COOLDOWN_MINUTES) || 30) * 60_000),
       ...(parseQuietHoursRange(env.D4_ALERT_QUIET_HOURS) ? { quietHours: parseQuietHoursRange(env.D4_ALERT_QUIET_HOURS) } : {}),
       quietHoursTzOffsetMin: Number.isFinite(Number(env.D4_ALERT_QUIET_TZ_OFFSET_MIN)) ? Number(env.D4_ALERT_QUIET_TZ_OFFSET_MIN) : 0,
+    },
+    anomalyPause: {
+      // Off by default — the operator enables D3 before turning on autopilot.
+      enabled: env.D3_ANOMALY_PAUSE_ENABLED === "1",
+      intervalMs: Math.max(30_000, (positiveNumber(env.D3_ANOMALY_PAUSE_INTERVAL_MINUTES) || 1) * 60_000),
     },
   };
 }

--- a/test/unit/anomaly-pause.test.ts
+++ b/test/unit/anomaly-pause.test.ts
@@ -1,0 +1,324 @@
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  evaluateAnomalies,
+  decideAnomalyAction,
+  summarizeTrips,
+  buildAnomalyAlert,
+  runAnomalyPauseOnce,
+  touchHaltFile,
+  isHaltFilePresent,
+  type AnomalyConfig,
+  type AnomalySignals,
+  type AnomalyPauseDeps,
+} from "../../services/slack-operator/src/anomaly-pause.js";
+import {
+  readAutopilotSuspendState,
+  isAutopilotSuspended,
+  setAutopilotSuspended,
+  clearAutopilotSuspended,
+} from "../../services/slack-operator/src/autopilot-state.js";
+import type { AlertPayload } from "../../services/slack-operator/src/alert-bridge.js";
+
+const CONFIG: AnomalyConfig = {
+  taskRetrySoft: 3,
+  taskRunawayHard: 6,
+  failingTasksHard: 3,
+  budgetSpikeRatio: 0.8,
+  budgetBlowoutRatio: 1.0,
+  heartbeatGapSec: 600,
+};
+
+// Normal, healthy load — should never trip.
+const QUIET: AnomalySignals = {
+  maxTaskAttemptCount: 1,
+  failingTaskCount: 0,
+  hermesTasksToday: 2,
+  perDayCap: 10,
+  runnerHeartbeatAgeSec: 30,
+};
+
+describe("evaluateAnomalies — each signal trips at its threshold, not below", () => {
+  it("no false positives under normal load", () => {
+    expect(evaluateAnomalies(QUIET, CONFIG).tier).toBe("none");
+  });
+
+  it("task retry loop: soft at the soft threshold, not one below", () => {
+    expect(evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 2 }, CONFIG).tier).toBe("none");
+    const e = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 3 }, CONFIG);
+    expect(e.tier).toBe("soft");
+    expect(e.trips.map((t) => t.signal)).toContain("task_retry_loop");
+  });
+
+  it("single-task runaway: hard at the hard threshold (and never double-counts as soft)", () => {
+    const e = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 6 }, CONFIG);
+    expect(e.tier).toBe("hard");
+    const signals = e.trips.map((t) => t.signal);
+    expect(signals).toContain("task_runaway");
+    expect(signals).not.toContain("task_retry_loop");
+  });
+
+  it("multi-task runaway: hard when enough tasks are failing", () => {
+    expect(evaluateAnomalies({ ...QUIET, failingTaskCount: 2 }, CONFIG).tier).toBe("none");
+    const e = evaluateAnomalies({ ...QUIET, failingTaskCount: 3 }, CONFIG);
+    expect(e.tier).toBe("hard");
+    expect(e.trips.map((t) => t.signal)).toContain("multi_task_runaway");
+  });
+
+  it("budget spike: soft at ≥80% of cap; blowout: hard at ≥100%", () => {
+    expect(evaluateAnomalies({ ...QUIET, hermesTasksToday: 7 }, CONFIG).tier).toBe("none"); // 70%
+    const spike = evaluateAnomalies({ ...QUIET, hermesTasksToday: 8 }, CONFIG); // 80%
+    expect(spike.tier).toBe("soft");
+    expect(spike.trips.map((t) => t.signal)).toContain("budget_spike");
+    const blowout = evaluateAnomalies({ ...QUIET, hermesTasksToday: 10 }, CONFIG); // 100%
+    expect(blowout.tier).toBe("hard");
+    expect(blowout.trips.map((t) => t.signal)).toContain("budget_blowout");
+  });
+
+  it("budget signals are inert when the cap is unknown (0)", () => {
+    expect(evaluateAnomalies({ ...QUIET, perDayCap: 0, hermesTasksToday: 99 }, CONFIG).tier).toBe("none");
+  });
+
+  it("runner heartbeat gap: soft when stale, ignored when the age is unknown", () => {
+    expect(evaluateAnomalies({ ...QUIET, runnerHeartbeatAgeSec: 599 }, CONFIG).tier).toBe("none");
+    const e = evaluateAnomalies({ ...QUIET, runnerHeartbeatAgeSec: 600 }, CONFIG);
+    expect(e.tier).toBe("soft");
+    expect(e.trips.map((t) => t.signal)).toContain("runner_heartbeat_gap");
+    const { runnerHeartbeatAgeSec, ...noHeartbeat } = QUIET;
+    expect(evaluateAnomalies(noHeartbeat, CONFIG).tier).toBe("none");
+  });
+
+  it("hard wins over a co-occurring soft", () => {
+    const e = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 3, failingTaskCount: 3 }, CONFIG);
+    expect(e.tier).toBe("hard");
+  });
+});
+
+describe("decideAnomalyAction — de-dup", () => {
+  const soft = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 3 }, CONFIG);
+  const hard = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 6 }, CONFIG);
+  const none = evaluateAnomalies(QUIET, CONFIG);
+
+  it("a soft trip acts once, then is suppressed while already suspended", () => {
+    expect(decideAnomalyAction(soft, false)).toBe("soft");
+    expect(decideAnomalyAction(soft, true)).toBe("none");
+  });
+
+  it("a hard trip always acts (the caller skips when HALT is already present)", () => {
+    expect(decideAnomalyAction(hard, false)).toBe("hard");
+    expect(decideAnomalyAction(hard, true)).toBe("hard");
+  });
+
+  it("none stays none", () => {
+    expect(decideAnomalyAction(none, false)).toBe("none");
+  });
+});
+
+describe("buildAnomalyAlert", () => {
+  it("hard alert names the HALT; soft alert names the suspension; both link the board", () => {
+    const hard = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 6 }, CONFIG);
+    const hardAlert = buildAnomalyAlert(hard, "hard", "https://board.example/monitor");
+    expect(hardAlert.text).toMatch(/HALT_FILE/);
+    expect(hardAlert.text).toContain("https://board.example/monitor");
+
+    const soft = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 3 }, CONFIG);
+    const softAlert = buildAnomalyAlert(soft, "soft", "https://board.example/monitor");
+    expect(softAlert.text).toMatch(/suspend/i);
+  });
+});
+
+// ── orchestrator with injected effects (no fs/network) ───────────────
+
+interface Harness {
+  deps: AnomalyPauseDeps;
+  alerts: AlertPayload[];
+  audits: Array<{ tier: string; action: string; signals: string; reason: string }>;
+  suspended: { current: boolean; info?: { reason: string; signal: string; tier: "soft" | "hard"; setAt: string } };
+  halt: { touched: boolean; reason?: string };
+}
+
+function harness(signals: AnomalySignals, over: Partial<AnomalyPauseDeps> = {}): Harness {
+  const alerts: Harness["alerts"] = [];
+  const audits: Harness["audits"] = [];
+  const suspended: Harness["suspended"] = { current: false };
+  const halt: Harness["halt"] = { touched: false };
+  const deps: AnomalyPauseDeps = {
+    config: CONFIG,
+    getSignals: () => signals,
+    isHaltPresent: () => halt.touched,
+    isSuspended: () => suspended.current,
+    setSuspended: (info) => {
+      suspended.current = true;
+      suspended.info = info;
+    },
+    touchHalt: (reason) => {
+      halt.touched = true;
+      halt.reason = reason;
+    },
+    alert: async (payload) => {
+      alerts.push(payload);
+      return true;
+    },
+    audit: (record) => {
+      audits.push(record);
+    },
+    boardUrl: "https://board.example/monitor",
+    now: () => new Date("2026-05-31T12:00:00.000Z"),
+    ...over,
+  };
+  return { deps, alerts, audits, suspended, halt };
+}
+
+describe("runAnomalyPauseOnce — tiered action", () => {
+  it("a soft trip suspends autopilot + alerts + audits, but does NOT touch HALT", async () => {
+    const h = harness({ ...QUIET, maxTaskAttemptCount: 3 });
+    const r = await runAnomalyPauseOnce(h.deps);
+    expect(r.action).toBe("soft");
+    expect(h.suspended.current).toBe(true);
+    expect(h.suspended.info?.tier).toBe("soft");
+    expect(h.suspended.info?.setAt).toBe("2026-05-31T12:00:00.000Z");
+    expect(h.halt.touched).toBe(false);
+    expect(h.alerts).toHaveLength(1);
+    expect(h.audits).toHaveLength(1);
+  });
+
+  it("a hard trip touches HALT_FILE AND suspends + alerts + audits", async () => {
+    const h = harness({ ...QUIET, maxTaskAttemptCount: 6 });
+    const r = await runAnomalyPauseOnce(h.deps);
+    expect(r.action).toBe("hard");
+    expect(h.halt.touched).toBe(true);
+    expect(h.halt.reason).toMatch(/D3 hard anomaly trip/);
+    expect(h.suspended.current).toBe(true);
+    expect(h.suspended.info?.tier).toBe("hard");
+    expect(h.alerts).toHaveLength(1);
+    expect(h.alerts[0]!.text).toMatch(/HALT_FILE/);
+  });
+
+  it("does nothing under normal load", async () => {
+    const h = harness(QUIET);
+    const r = await runAnomalyPauseOnce(h.deps);
+    expect(r.action).toBe("none");
+    expect(h.suspended.current).toBe(false);
+    expect(h.halt.touched).toBe(false);
+    expect(h.alerts).toHaveLength(0);
+    expect(h.audits).toHaveLength(0);
+  });
+
+  it("de-dup: a soft trip does not re-fire while already suspended", async () => {
+    const h = harness({ ...QUIET, maxTaskAttemptCount: 3 });
+    h.suspended.current = true; // pretend a prior soft trip set it
+    const r = await runAnomalyPauseOnce(h.deps);
+    expect(r.action).toBe("none");
+    expect(h.alerts).toHaveLength(0);
+    expect(h.audits).toHaveLength(0);
+  });
+
+  it("respects HALT_FILE: if already halted, it short-circuits with no new effects", async () => {
+    const h = harness({ ...QUIET, maxTaskAttemptCount: 6 });
+    h.halt.touched = true; // HALT already present
+    const r = await runAnomalyPauseOnce(h.deps);
+    expect(r.action).toBe("halted");
+    expect(h.alerts).toHaveLength(0);
+    expect(h.audits).toHaveLength(0);
+    expect(h.suspended.current).toBe(false);
+  });
+
+  it("audit record carries the signal, tier, and threshold detail", async () => {
+    const h = harness({ ...QUIET, maxTaskAttemptCount: 6 });
+    await runAnomalyPauseOnce(h.deps);
+    const rec = h.audits[0]!;
+    expect(rec).toMatchObject({ tier: "hard", action: "hard" });
+    expect(rec.signals).toMatch(/hard:task_runaway/);
+    expect(rec.reason).toMatch(/attempt #6/);
+  });
+
+  it("re-evaluates after an operator resume: a still-present soft condition trips again", async () => {
+    const h = harness({ ...QUIET, maxTaskAttemptCount: 3 });
+    await runAnomalyPauseOnce(h.deps); // first soft trip
+    expect(h.alerts).toHaveLength(1);
+    h.suspended.current = false; // operator resumed
+    await runAnomalyPauseOnce(h.deps); // condition persists → trips again
+    expect(h.alerts).toHaveLength(2);
+  });
+
+  it("summarizeTrips renders signal + threshold without secrets", () => {
+    const e = evaluateAnomalies({ ...QUIET, maxTaskAttemptCount: 6 }, CONFIG);
+    const { reason, signals } = summarizeTrips(e);
+    expect(reason).toContain("task_runaway");
+    expect(signals).toContain("hard:task_runaway");
+  });
+});
+
+// ── file-backed state (real temp dir, no /data, no network) ──────────
+
+describe("autopilot-suspended flag — set by D3, cleared by the operator, survives a read", () => {
+  let dir: string;
+  let statePath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-d3-state-"));
+    statePath = join(dir, "autopilot-suspended.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to not-suspended when no file exists", () => {
+    expect(isAutopilotSuspended(statePath)).toBe(false);
+    expect(readAutopilotSuspendState(statePath)).toEqual({ suspended: false });
+  });
+
+  it("set then read round-trips the trip metadata", () => {
+    setAutopilotSuspended(
+      { reason: "task_runaway: a task reached attempt #6", signal: "hard:task_runaway", tier: "hard", setAt: "2026-05-31T12:00:00.000Z" },
+      statePath,
+    );
+    expect(isAutopilotSuspended(statePath)).toBe(true);
+    const state = readAutopilotSuspendState(statePath);
+    expect(state).toMatchObject({ suspended: true, tier: "hard", signal: "hard:task_runaway" });
+  });
+
+  it("operator-resume clears the flag", () => {
+    setAutopilotSuspended({ reason: "r", signal: "soft:budget_spike", tier: "soft", setAt: "2026-05-31T12:00:00.000Z" }, statePath);
+    expect(isAutopilotSuspended(statePath)).toBe(true);
+    clearAutopilotSuspended(statePath);
+    expect(isAutopilotSuspended(statePath)).toBe(false);
+  });
+
+  it("clearing an already-absent flag is a no-op (idempotent)", () => {
+    expect(() => clearAutopilotSuspended(statePath)).not.toThrow();
+    expect(isAutopilotSuspended(statePath)).toBe(false);
+  });
+
+  it("an unreadable/corrupt state reads as not-suspended (never throws)", async () => {
+    await rm(statePath, { force: true });
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(statePath, "{ not json");
+    expect(isAutopilotSuspended(statePath)).toBe(false);
+  });
+});
+
+describe("HALT_FILE helpers — same path the kill switch reads", () => {
+  let dir: string;
+  let haltPath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-d3-halt-"));
+    haltPath = join(dir, "nested", "HALT");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("touch creates the file (and parent dirs); presence check sees it", async () => {
+    expect(isHaltFilePresent(haltPath)).toBe(false);
+    touchHaltFile("D3 hard anomaly trip: test", haltPath);
+    expect(existsSync(haltPath)).toBe(true);
+    expect(isHaltFilePresent(haltPath)).toBe(true);
+    expect(await readFile(haltPath, "utf8")).toMatch(/D3 hard anomaly trip/);
+  });
+});


### PR DESCRIPTION
## What changed & why

The automatic fail-safe that lets a **misbehaving autopilot be stopped without a human watching** — the prerequisite that unblocks O4-PR3 (autopilot auto-approval). D3 ships **before** auto-approval exists and **owns the pause mechanism PR3 will respect** (the autopilot-suspended flag). The flag is inert until PR3 reads it.

A new server-side routine, `checkAnomalies` (off by default), evaluates signals every interval with no tab open:

- **task retry loop** (`attemptCount` ≥ soft) → soft; **single-task runaway** (≥ hard) → hard
- **multi-task runaway** (count of failing/retrying tasks ≥ threshold) → hard
- **dispatch budget spike** (today's Hermes count ≥ 80% of per-day cap) → soft; **blowout** (≥ 100%) → hard
- **runner heartbeat gap** (heartbeat age ≥ threshold) → soft

Thresholds live in `hermes/config/policy.yaml` (`anomaly:` block), env-overridable (`D3_*`).

**Tiered action:**
- **SOFT** → set the autopilot-suspended flag + push a D4 alert. No new auto-approvals while suspended; in-flight work finishes.
- **HARD** → touch `HALT_FILE` (all mutating work stops) + suspend + alert.

**The suspended flag** is file-backed on `/data` so a trip **survives a restart** — a fail-safe that forgets it tripped is not a fail-safe. It is set only by D3 and **cleared only by the operator** via `POST /monitor/autopilot-resume` (monitor-gated, mirrors the other monitor routes).

**De-dup / safety:** a soft trip is suppressed while already suspended and re-evaluated naturally on resume; if `HALT_FILE` is already present the routine short-circuits (nothing left to stop). Each trip writes a handoff-event audit record (signal, tier, threshold reason). Secrets are never logged.

**Scope:** D3 owns detection + the tiered action + the suspended flag. It does **not** build autopilot — O4-PR3 does (its auto-approval will gate on `mode==autopilot AND !suspended AND within budget/cap AND not high-risk`).

Design: pure core (`evaluateAnomalies` / `decideAnomalyAction`) + effect-injected orchestrator (`runAnomalyPauseOnce`) so detection and the tiered action are unit-tested with injected clock + fake signals/queue + fake alert adapter + temp files — no fs/network.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (943 passed; 26 new D3 tests)
- [x] compose validated by parsing `ops/compose.yml` with the `yaml` lib (Compose v2 unavailable locally; CI runs the real `docker compose ... config`)

## Rollout / rollback
- **Off by default** (`D3_ANOMALY_PAUSE_ENABLED=0`). The operator enables D3 **before** turning on autopilot, so there are no surprise HALTs.
- Env wired into `ops/compose.yml` + `ops/.env.example`: `D3_ANOMALY_PAUSE_ENABLED`, `D3_ANOMALY_PAUSE_INTERVAL_MINUTES`, `AVERRAY_AUTOPILOT_SUSPENDED_PATH` (on the `/data` volume), `HERMES_DISPATCH_PER_DAY_MAX`.
- **Rollback:** set `D3_ANOMALY_PAUSE_ENABLED=0` and redeploy; delete `autopilot-suspended.json` (or `POST /monitor/autopilot-resume`) to clear any lingering suspension. A hard trip's `HALT_FILE` is cleared by the existing operator procedure.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate (resume is operator-only)
- [x] Wallet remains testnet-only; `HALT_FILE` honored (hard trip writes it, routine respects it); no new ungated agent power — this only **removes** power (pauses autopilot)
- [x] No secrets committed/printed/logged
- [x] No agent-behavior doc change needed yet — the flag is inert until O4-PR3 wires it into auto-approval

## Known limits / follow-ups
- The suspended flag is **inert until O4-PR3** reads `!isAutopilotSuspended()` in its auto-approval gate.
- Oversized-diff anomaly signal is left as a hook for later (not wired).
- If `policy.yaml` isn't mounted into slack-operator, thresholds fall back to defaults identical to the committed `anomaly:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)