### PR TITLE
[claude] Add A2 learned routing default

### DIFF
--- a/docs/HERMES_PHASE2_DESIGN.md
+++ b/docs/HERMES_PHASE2_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Phase 2 Design (Intelligence + Trust)
 
-- **Status:** Phase-2 implementation has started. A1 now has a read-only scorecard spine/API/MCP slice in review; A2/A3 and D1-D3 remain design-level.
+- **Status:** Phase-2 implementation has started. A1 now has a read-only scorecard spine/API/MCP slice in review; A2 learned routing is in review; A3 and D1-D3 remain design-level.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md), [`HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md), [`HERMES_ORCHESTRATION_DESIGN.md`](./HERMES_ORCHESTRATION_DESIGN.md) (the core P1–P5).
 - **Position:** **Phase 2.** Builds on the core — it consumes agent attribution (P1), dispatch + the autonomy mode (P3/P4), and the handoff-event log. Do not start until the core ships.
@@ -57,6 +57,8 @@ Stats fully drive routing for non-high-risk surfaces — with safeguards so "dat
 - **Always explained:** every routing decision carries its rationale ("Claude — 92% merge on UI vs Codex 70%"), recorded in D2 and shown in the rail.
 - Coheres with autopilot: autopilot only auto-approves non-high-risk anyway, so data-driven routing of non-high-risk and autopilot auto-approval line up cleanly.
 
+Implementation note: A2 is wired only as the default agent choice for proposed tasks with no explicit agent. It reads the A1 scorecard defensively, ignores `not_recorded` signals as neutral, keeps high-risk routing rule-bound to Codex, and leaves the operator approval gate unchanged.
+
 ### A3 — Cost  ·  later
 Visibility first (cost is on the scorecard from A1). Cost-as-a-routing-factor and a $-based dispatch budget come once throughput data is meaningful — don't optimize cost before you can measure value.
 
@@ -104,4 +106,4 @@ All sits *after* the core P1–P4. Each ships as a narrow PR per [AGENTS.md](../
 
 ---
 
-*End of Phase 2 design. A1 read-only scorecard implementation has started; acting layers remain design-level until their guardrails are built.*
+*End of Phase 2 design. A1 read-only scorecard implementation has started; A2 learned routing is in review with guardrails; remaining acting layers stay design-level until their guardrails are built.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -27,7 +27,7 @@
 | O4 | Hermes enqueue + dispatch guardrail + autonomy mode | 🟡 in build — PR1 enqueue+guardrail ✅ (#280) · PR2 routing taxonomy ✅ (#281) · PR3 autopilot auto-approval **blocked on D3** |
 | O5 | Self-management hardening | design done |
 | A1 | Agent scorecard | 🟡 in review — read-only `/monitor/agents` + `averray_agent_scorecard` scorecard slice |
-| A2 | Learned routing (data-driven, non-high-risk) | design done |
+| A2 | Learned routing (data-driven, non-high-risk) | 🟡 in review — scorecard-backed default routing, high-risk rule-bound |
 | A3 | Cost visibility / cost-aware routing | design done |
 | D1 | "While you were away" digest (board + Slack/push) | design done |
 | D2 | Explainability / decision records | design done |

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -27,6 +27,12 @@ import {
   type DispatchPolicyConfig,
 } from "./dispatch-policy.js";
 import { classifyTask, type RiskTier } from "./dispatch-routing.js";
+import { getAgentScorecard } from "./agent-scorecard.js";
+import {
+  applyLearnedRouting,
+  parseLearnedRoutingConfig,
+  type LearnedRoutingConfig,
+} from "./learned-routing.js";
 
 export type AgentInvocationIntent =
   | "operator_command"
@@ -104,6 +110,12 @@ export interface AgentInvocationDeps {
   listQueuedTasksFn?: () => Promise<QueuedTaskSummary[]>;
   /** HALT kill-switch check; defaults to assertNoKillSwitch. */
   assertNoKillSwitchFn?: (toolName: string) => Promise<void>;
+  /** A1 scorecard source for A2 learned routing; defaults to getAgentScorecard. */
+  agentScorecardFn?: () => Promise<unknown>;
+  /** A2 learned routing config override; defaults to env + conservative defaults. */
+  learnedRoutingConfig?: Partial<LearnedRoutingConfig>;
+  /** Injectable RNG for deterministic A2 exploration tests. */
+  routingRandomFn?: () => number;
   /** Env for the default enqueue transport + policy load. */
   enqueueEnv?: NodeJS.ProcessEnv;
 }
@@ -837,14 +849,15 @@ async function invokeEnqueueAgentTask(
   if (!repo) return blockedInvocation(invocation, startedAt, "repo_required");
   if (!prompt) return blockedInvocation(invocation, startedAt, "prompt_required");
 
-  // Routing taxonomy (O4-PR2): a pure, overridable default. An explicit agent in
-  // the request wins; otherwise derive it. The riskTier is ALWAYS computed and
-  // persisted (PR3's autopilot reads it). The operator can still flip the agent
-  // at approval — unchanged. No authority is granted here.
-  const routing = classifyTask({ repo, prompt, ...(input.area ? { area: input.area } : {}) });
+  // Routing taxonomy (O4-PR2) + A2 learned default: explicit agent wins;
+  // otherwise A2 may refine the low-risk default from the A1 scorecard. The
+  // riskTier is ALWAYS computed by the static taxonomy and persisted (PR3's
+  // autopilot reads it). The operator can still flip the agent at approval —
+  // unchanged. No authority is granted here.
+  const routingInput = { repo, prompt, ...(input.area ? { area: input.area } : {}) };
+  const staticRouting = classifyTask(routingInput);
   const explicitAgent = (input.agent ?? "").trim();
-  const agent: "codex" | "claude" =
-    explicitAgent === "codex" || explicitAgent === "claude" ? explicitAgent : routing.agent;
+  const agentExplicit = explicitAgent === "codex" || explicitAgent === "claude";
 
   // (a) HALT kill-switch — block cleanly rather than crash.
   const assertKill = deps.assertNoKillSwitchFn ?? assertNoKillSwitch;
@@ -857,8 +870,13 @@ async function invokeEnqueueAgentTask(
     });
   }
 
-  // (b) Dispatch guardrail — allowlist + per-day budget. Fail-closed.
   const env = deps.enqueueEnv ?? process.env;
+  const routing = agentExplicit
+    ? staticRouting
+    : await resolveLearnedRouting(routingInput, staticRouting, deps, env);
+  const agent: "codex" | "claude" = agentExplicit ? explicitAgent : routing.agent;
+
+  // (b) Dispatch guardrail — allowlist + per-day budget. Fail-closed.
   const policy = deps.dispatchPolicyConfig ?? loadDispatchPolicyConfig(env);
   const queued = await (deps.listQueuedTasksFn ?? defaultListQueuedTasks(env))().catch(
     () => [] as QueuedTaskSummary[],
@@ -902,7 +920,7 @@ async function invokeEnqueueAgentTask(
       proposedTaskId: created.id ?? null,
       repo,
       agent,
-      agentExplicit: explicitAgent === "codex" || explicitAgent === "claude",
+      agentExplicit,
       riskTier: routing.riskTier,
       routingReason: routing.reason,
       requester: "hermes",
@@ -910,6 +928,37 @@ async function invokeEnqueueAgentTask(
     },
     { mutates: false, localCheckpoint: false },
   );
+}
+
+async function resolveLearnedRouting(
+  routingInput: { repo: string; prompt: string; area?: string },
+  staticRouting: ReturnType<typeof classifyTask>,
+  deps: AgentInvocationDeps,
+  env: NodeJS.ProcessEnv
+): Promise<ReturnType<typeof classifyTask>> {
+  const config = parseLearnedRoutingConfig(env, deps.learnedRoutingConfig);
+  if (staticRouting.riskTier === "high") {
+    return applyLearnedRouting(routingInput, staticRouting, {
+      config,
+      now: deps.now,
+      ...(deps.routingRandomFn ? { rng: deps.routingRandomFn } : {}),
+    });
+  }
+
+  try {
+    const scorecard = await (deps.agentScorecardFn ?? (() => getAgentScorecard({ now: deps.now })))();
+    return applyLearnedRouting(routingInput, staticRouting, {
+      scorecard,
+      config,
+      now: deps.now,
+      ...(deps.routingRandomFn ? { rng: deps.routingRandomFn } : {}),
+    });
+  } catch {
+    return {
+      ...staticRouting,
+      reason: `A2 scorecard unavailable → static default (${staticRouting.reason})`,
+    };
+  }
 }
 
 // enqueue transport — POST/GET the slack-operator queue endpoint. Injected in

--- a/packages/averray-mcp/src/learned-routing.ts
+++ b/packages/averray-mcp/src/learned-routing.ts
@@ -1,0 +1,341 @@
+import type { RoutingAgent, RoutingDecision, RoutingInput } from "./dispatch-routing.js";
+
+export interface LearnedRoutingConfig {
+  minSamples: number;
+  decayHalfLifeDays: number;
+  explorationRate: number;
+}
+
+export interface LearnedRoutingOptions {
+  scorecard?: unknown;
+  config?: Partial<LearnedRoutingConfig>;
+  now?: Date;
+  rng?: () => number;
+}
+
+interface CandidateScore {
+  agent: RoutingAgent;
+  score: number;
+  samples: number;
+  effectiveSamples: number;
+  readyRate: number | null;
+}
+
+interface SurfaceSignal {
+  count: number;
+  readyRate: number | null;
+  ciPassRate: number | null;
+  blockedRate: number | null;
+  reworkRate: number | null;
+  revertRate: number | null;
+  operatorOverrideRate: number | null;
+  observedAt: string | null;
+}
+
+interface AgentBaseline {
+  mergeRate: number | null;
+  ciPassRate: number | null;
+  taskSuccessRate: number | null;
+  reworkRate: number | null;
+  revertRate: number | null;
+  operatorOverrideRate: number | null;
+}
+
+export const DEFAULT_LEARNED_ROUTING_CONFIG: LearnedRoutingConfig = {
+  minSamples: 8,
+  decayHalfLifeDays: 14,
+  explorationRate: 0.02,
+};
+
+const ROUTING_AGENTS: RoutingAgent[] = ["codex", "claude"];
+
+export function parseLearnedRoutingConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  overrides: Partial<LearnedRoutingConfig> = {}
+): LearnedRoutingConfig {
+  const config = {
+    minSamples: intFromEnv(env.A2_LEARNED_ROUTING_MIN_SAMPLES, DEFAULT_LEARNED_ROUTING_CONFIG.minSamples),
+    decayHalfLifeDays: numberFromEnv(
+      env.A2_LEARNED_ROUTING_DECAY_HALF_LIFE_DAYS,
+      DEFAULT_LEARNED_ROUTING_CONFIG.decayHalfLifeDays
+    ),
+    explorationRate: numberFromEnv(env.A2_LEARNED_ROUTING_EXPLORATION_RATE, DEFAULT_LEARNED_ROUTING_CONFIG.explorationRate),
+    ...overrides,
+  };
+  return {
+    minSamples: Math.max(1, Math.floor(config.minSamples)),
+    decayHalfLifeDays: Math.max(1, config.decayHalfLifeDays),
+    explorationRate: clamp(config.explorationRate, 0, 1),
+  };
+}
+
+export function applyLearnedRouting(
+  input: RoutingInput,
+  staticDecision: RoutingDecision,
+  options: LearnedRoutingOptions = {}
+): RoutingDecision {
+  if (staticDecision.riskTier === "high") {
+    return {
+      agent: "codex",
+      riskTier: staticDecision.riskTier,
+      reason: `A2 high-risk rule-bound → codex; scorecard ignored (${staticDecision.reason})`,
+    };
+  }
+
+  const config = parseLearnedRoutingConfig(undefined, options.config);
+  const now = options.now ?? new Date();
+  const rng = options.rng ?? Math.random;
+  const surface = targetSurface(input, staticDecision);
+  const candidates = ROUTING_AGENTS
+    .map((agent) => scoreAgentForSurface(agent, surface, options.scorecard, config, now))
+    .filter((candidate) => candidate.effectiveSamples >= config.minSamples)
+    .sort((a, b) => b.score - a.score || b.effectiveSamples - a.effectiveSamples || agentSort(a.agent) - agentSort(b.agent));
+
+  if (candidates.length === 0) {
+    return {
+      ...staticDecision,
+      reason: `A2 cold start on ${surface} → static default (${staticDecision.reason})`,
+    };
+  }
+
+  const best = candidates[0]!;
+  const chosen = shouldExplore(candidates, config, rng) ? candidates[1]! : best;
+  const mode = chosen.agent === best.agent ? "learned" : "exploration";
+  return {
+    agent: chosen.agent,
+    riskTier: staticDecision.riskTier,
+    reason: `${reasonPrefix(mode, chosen, surface)}; ${comparisonSummary(candidates, surface)}; static default ${staticDecision.agent}`,
+  };
+}
+
+function shouldExplore(candidates: CandidateScore[], config: LearnedRoutingConfig, rng: () => number): boolean {
+  return candidates.length > 1 && config.explorationRate > 0 && rng() < config.explorationRate;
+}
+
+function reasonPrefix(mode: "learned" | "exploration", chosen: CandidateScore, surface: string): string {
+  const label = mode === "exploration" ? "A2 exploration" : "A2 learned routing";
+  return `${label}: ${chosen.agent} on ${surface}`;
+}
+
+function comparisonSummary(candidates: CandidateScore[], surface: string): string {
+  return ROUTING_AGENTS
+    .map((agent) => candidates.find((candidate) => candidate.agent === agent))
+    .map((candidate, index) => {
+      const agent = ROUTING_AGENTS[index]!;
+      if (!candidate) return `${agent} cold start on ${surface}`;
+      return `${agent} ${percent(candidate.readyRate)} ready, score ${formatNumber(candidate.score)}, n=${candidate.samples}, effective=${formatNumber(candidate.effectiveSamples)}`;
+    })
+    .join(" vs ");
+}
+
+function scoreAgentForSurface(
+  agent: RoutingAgent,
+  surface: string,
+  scorecard: unknown,
+  config: LearnedRoutingConfig,
+  now: Date
+): CandidateScore {
+  const agentRecord = records(isRecord(scorecard) ? scorecard.agents : undefined)
+    .find((item) => stringField(item, "agent") === agent);
+  if (!agentRecord) return emptyCandidate(agent);
+
+  const baseline = agentBaseline(agentRecord);
+  const matchingSignals = records(agentRecord.surfaces)
+    .filter((entry) => surfaceMatches(surface, stringField(entry, "surface") ?? ""))
+    .map((entry) => surfaceSignal(entry, baseline));
+
+  if (matchingSignals.length === 0) return emptyCandidate(agent);
+
+  let weightedScore = 0;
+  let weightedReadyRate = 0;
+  let readyRateWeight = 0;
+  let samples = 0;
+  let effectiveSamples = 0;
+
+  for (const signal of matchingSignals) {
+    if (signal.count <= 0) continue;
+    const weight = recencyWeight(signal.observedAt, now, config.decayHalfLifeDays);
+    const weightedSamples = signal.count * weight;
+    samples += signal.count;
+    effectiveSamples += weightedSamples;
+    const score = signalScore(signal);
+    weightedScore += score * weightedSamples;
+    if (signal.readyRate !== null) {
+      weightedReadyRate += signal.readyRate * weightedSamples;
+      readyRateWeight += weightedSamples;
+    }
+  }
+
+  if (effectiveSamples <= 0) return emptyCandidate(agent);
+
+  return {
+    agent,
+    score: weightedScore / effectiveSamples,
+    samples,
+    effectiveSamples,
+    readyRate: readyRateWeight > 0 ? weightedReadyRate / readyRateWeight : null,
+  };
+}
+
+function emptyCandidate(agent: RoutingAgent): CandidateScore {
+  return { agent, score: Number.NEGATIVE_INFINITY, samples: 0, effectiveSamples: 0, readyRate: null };
+}
+
+function surfaceSignal(entry: Record<string, unknown>, baseline: AgentBaseline): SurfaceSignal {
+  const count = numberField(entry, "count") ?? numberField(entry, "samples") ?? numberField(entry, "total") ?? 0;
+  const ready = numberField(entry, "ready") ?? numberField(entry, "merged") ?? numberField(entry, "completed");
+  const blocked = numberField(entry, "blocked") ?? numberField(entry, "failed");
+  return {
+    count,
+    readyRate: rateField(entry, ["mergeRate", "readyRate", "successRate"])
+      ?? rateFromCount(ready, count)
+      ?? baseline.mergeRate
+      ?? baseline.taskSuccessRate,
+    ciPassRate: rateField(entry, ["ciFirstPassRate", "latestPassRate"]) ?? baseline.ciPassRate,
+    blockedRate: rateField(entry, ["blockedRate", "failureRate"]) ?? rateFromCount(blocked, count),
+    reworkRate: rateField(entry, ["reworkRate", "laterHumanReworkRate"]) ?? baseline.reworkRate,
+    revertRate: rateField(entry, ["revertRate", "rollbackRate"]) ?? baseline.revertRate,
+    operatorOverrideRate: rateField(entry, ["operatorOverrideRate", "overrideRate", "operatorOverridesRate"])
+      ?? baseline.operatorOverrideRate,
+    observedAt: stringField(entry, "observedAt") ?? stringField(entry, "updatedAt") ?? stringField(entry, "lastSeenAt") ?? null,
+  };
+}
+
+function signalScore(signal: SurfaceSignal): number {
+  const positive = signal.readyRate ?? 0;
+  const ciBonus = signal.ciPassRate !== null ? signal.ciPassRate * 0.15 : 0;
+  const blockedPenalty = signal.blockedRate ?? 0;
+  const reworkPenalty = signal.reworkRate ?? 0;
+  const revertPenalty = signal.revertRate ?? 0;
+  const overridePenalty = signal.operatorOverrideRate ?? 0;
+  return positive + ciBonus - blockedPenalty - reworkPenalty - revertPenalty - overridePenalty;
+}
+
+function agentBaseline(agentRecord: Record<string, unknown>): AgentBaseline {
+  const quality = recordField(agentRecord, "quality");
+  const pullRequests = recordField(quality, "pullRequests");
+  const checks = recordField(quality, "checks");
+  const tasks = recordField(agentRecord, "tasks");
+  const trust = recordField(agentRecord, "trust");
+  const routingSignal = recordField(agentRecord, "routingSignal");
+  return {
+    mergeRate: rateField(pullRequests ?? {}, ["mergeRate"]),
+    ciPassRate: rateField(checks ?? {}, ["ciFirstPassRate", "latestPassRate"]),
+    taskSuccessRate: rateField(tasks ?? {}, ["successRate"]),
+    reworkRate: rateField(trust ?? {}, ["laterHumanReworkRate", "reworkRate"]),
+    revertRate: rateField(trust ?? {}, ["revertRate", "rollbackRate"]),
+    operatorOverrideRate: rateField(routingSignal ?? {}, ["operatorOverrideRate", "overrideRate", "operatorOverridesRate"])
+      ?? rateField(agentRecord, ["operatorOverrideRate", "overrideRate", "operatorOverridesRate"]),
+  };
+}
+
+function recencyWeight(observedAt: string | null, now: Date, halfLifeDays: number): number {
+  if (!observedAt) return 1;
+  const observedMs = Date.parse(observedAt);
+  if (!Number.isFinite(observedMs)) return 1;
+  const ageMs = Math.max(0, now.getTime() - observedMs);
+  const halfLifeMs = halfLifeDays * 24 * 60 * 60 * 1000;
+  return 0.5 ** (ageMs / halfLifeMs);
+}
+
+function targetSurface(input: RoutingInput, staticDecision: RoutingDecision): string {
+  const reasonSurface = staticDecision.reason.match(/^(.+?)\s*→/)?.[1]?.trim();
+  if (reasonSurface && reasonSurface !== "general/ambiguous") return reasonSurface;
+  return input.area?.trim() || reasonSurface || "general/ambiguous";
+}
+
+function surfaceMatches(target: string, observed: string): boolean {
+  const targetAliases = surfaceAliases(target);
+  const observedAliases = surfaceAliases(observed);
+  for (const alias of targetAliases) {
+    if (observedAliases.has(alias)) return true;
+  }
+  return false;
+}
+
+function surfaceAliases(value: string): Set<string> {
+  const normalized = normalizeSurface(value);
+  const aliases = new Set([normalized]);
+  const aliasMap: Record<string, string[]> = {
+    uifrontend: ["ui", "frontend", "front", "app", "operatorapp"],
+    frontend: ["ui", "uifrontend", "front", "app", "operatorapp"],
+    themonitor: ["monitor", "board", "drawer"],
+    monitor: ["themonitor", "board", "drawer"],
+    docscopy: ["docs", "documentation", "copy"],
+    docs: ["docscopy", "documentation", "copy"],
+    tests: ["test", "spec", "vitest"],
+    refactordx: ["refactor", "dx", "cleanup"],
+    mcptooling: ["mcp", "tooling", "tools"],
+    generalambiguous: ["general", "ambiguous", "other"],
+    other: ["generalambiguous", "general", "ambiguous"],
+  };
+  for (const alias of aliasMap[normalized] ?? []) aliases.add(alias);
+  return aliases;
+}
+
+function normalizeSurface(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function rateField(record: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    const value = numberField(record, key);
+    if (value !== undefined) return clamp(value, 0, 1);
+  }
+  return null;
+}
+
+function rateFromCount(value: number | undefined, count: number): number | null {
+  if (value === undefined || count <= 0) return null;
+  return clamp(value / count, 0, 1);
+}
+
+function percent(value: number | null): string {
+  if (value === null) return "not recorded";
+  return `${Math.round(value * 100)}%`;
+}
+
+function formatNumber(value: number): string {
+  if (!Number.isFinite(value)) return "n/a";
+  return value.toFixed(2).replace(/\.?0+$/, "");
+}
+
+function intFromEnv(value: string | undefined, fallback: number): number {
+  const parsed = value ? Number.parseInt(value, 10) : NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function numberFromEnv(value: string | undefined, fallback: number): number {
+  const parsed = value ? Number(value) : NaN;
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function agentSort(agent: RoutingAgent): number {
+  return agent === "codex" ? 0 : 1;
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | undefined {
+  return isRecord(value) && isRecord(value[key]) ? value[key] : undefined;
+}
+
+function stringField(record: Record<string, unknown> | undefined, key: string): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberField(record: Record<string, unknown> | undefined, key: string): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function records(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value) ? value.filter(isRecord) : [];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/test/unit/dispatch-routing.test.ts
+++ b/test/unit/dispatch-routing.test.ts
@@ -84,6 +84,7 @@ function baseDeps(proposeTaskFn: (t: ProposedAgentTask) => Promise<{ id?: string
     dispatchPolicyConfig: ALLOWED,
     listQueuedTasksFn: async () => [],
     proposeTaskFn,
+    agentScorecardFn: async () => ({ kind: "averray_agent_scorecard", agents: [] }),
     now: new Date("2026-05-31T12:00:00Z"),
   };
 }
@@ -109,6 +110,26 @@ describe("enqueue_agent_task — routing as an overridable default", () => {
     expect(result.result?.agentExplicit).toBe(false);
   });
 
+  it("uses A2 scorecard data as the low-risk default when enough samples exist", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "t1b" }));
+    await invokeAgentTask(enqueue(), {
+      ...baseDeps(proposeTaskFn),
+      learnedRoutingConfig: { minSamples: 5, explorationRate: 0 },
+      agentScorecardFn: async () => ({
+        kind: "averray_agent_scorecard",
+        agents: [
+          { agent: "codex", surfaces: [{ surface: "frontend", count: 10, ready: 9, blocked: 0 }] },
+          { agent: "claude", surfaces: [{ surface: "frontend", count: 10, ready: 5, blocked: 2 }] },
+        ],
+      }),
+    });
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task.agent).toBe("codex");
+    expect(task.riskTier).toBe("low");
+    expect(task.routingReason).toMatch(/A2 learned routing/);
+    expect(task.routingReason).toMatch(/codex 90% ready/);
+  });
+
   it("high-risk surface with no agent → codex/high persisted", async () => {
     const proposeTaskFn = vi.fn(async () => ({ id: "t2" }));
     await invokeAgentTask(enqueue({ prompt: "update the escrow settlement contract" }), baseDeps(proposeTaskFn));
@@ -128,6 +149,25 @@ describe("enqueue_agent_task — routing as an overridable default", () => {
     expect(task.agent).toBe("claude"); // override wins
     expect(task.riskTier).toBe("high"); // tier never under-classified
     expect(result.result?.agentExplicit).toBe(true);
+  });
+
+  it("explicit agent still wins even when A2 would pick another low-risk agent", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "t3b" }));
+    await invokeAgentTask(enqueue({ agent: "claude" }), {
+      ...baseDeps(proposeTaskFn),
+      learnedRoutingConfig: { minSamples: 5, explorationRate: 0 },
+      agentScorecardFn: async () => ({
+        kind: "averray_agent_scorecard",
+        agents: [
+          { agent: "codex", surfaces: [{ surface: "frontend", count: 10, ready: 10, blocked: 0 }] },
+          { agent: "claude", surfaces: [{ surface: "frontend", count: 10, ready: 1, blocked: 5 }] },
+        ],
+      }),
+    });
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task.agent).toBe("claude");
+    expect(task.routingReason).toMatch(/UI\/frontend/);
+    expect(task.routingReason).not.toMatch(/A2 learned routing/);
   });
 
   it("persists riskTier + routingReason on the proposed task (PR3 reads the tier)", async () => {

--- a/test/unit/learned-routing.test.ts
+++ b/test/unit/learned-routing.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyTask } from "../../packages/averray-mcp/src/dispatch-routing.js";
+import {
+  applyLearnedRouting,
+  parseLearnedRoutingConfig,
+} from "../../packages/averray-mcp/src/learned-routing.js";
+
+const NOW = new Date("2026-05-31T12:00:00Z");
+
+function scorecard(agents: unknown[]) {
+  return {
+    schemaVersion: 1,
+    kind: "averray_agent_scorecard",
+    agents,
+  };
+}
+
+function agent(agentName: "codex" | "claude", surfaces: unknown[]) {
+  return {
+    agent: agentName,
+    sampleCount: 100,
+    cost: { status: "not_recorded" },
+    trust: { status: "not_recorded" },
+    surfaces,
+  };
+}
+
+describe("A2 learned routing", () => {
+  it("keeps high-risk tasks rule-bound to codex regardless of scorecard stats", () => {
+    const staticDecision = classifyTask({ prompt: "update the escrow settlement contract" });
+    const decision = applyLearnedRouting(
+      { prompt: "update the escrow settlement contract" },
+      staticDecision,
+      {
+        now: NOW,
+        config: { minSamples: 2, explorationRate: 0 },
+        scorecard: scorecard([
+          agent("codex", [{ surface: "contracts", count: 10, ready: 1, blocked: 8 }]),
+          agent("claude", [{ surface: "contracts", count: 10, ready: 10, blocked: 0 }]),
+        ]),
+      },
+    );
+
+    expect(decision).toMatchObject({ agent: "codex", riskTier: "high" });
+    expect(decision.reason).toMatch(/rule-bound/);
+    expect(decision.reason).toMatch(/scorecard ignored/);
+  });
+
+  it("routes non-high-risk work to the agent with stronger surface evidence", () => {
+    const staticDecision = classifyTask({ prompt: "polish the onboarding UI component" });
+    const decision = applyLearnedRouting(
+      { prompt: "polish the onboarding UI component" },
+      staticDecision,
+      {
+        now: NOW,
+        config: { minSamples: 5, explorationRate: 0 },
+        scorecard: scorecard([
+          agent("codex", [{ surface: "frontend", count: 10, ready: 7, blocked: 2 }]),
+          agent("claude", [{ surface: "frontend", count: 12, ready: 11, blocked: 0 }]),
+        ]),
+      },
+    );
+
+    expect(decision).toMatchObject({ agent: "claude", riskTier: "low" });
+    expect(decision.reason).toMatch(/A2 learned routing/);
+    expect(decision.reason).toMatch(/claude 92% ready/);
+    expect(decision.reason).toMatch(/codex 70% ready/);
+  });
+
+  it("falls back to the static default during cold start", () => {
+    const staticDecision = classifyTask({ prompt: "polish the onboarding UI component" });
+    const decision = applyLearnedRouting(
+      { prompt: "polish the onboarding UI component" },
+      staticDecision,
+      {
+        now: NOW,
+        config: { minSamples: 8, explorationRate: 0 },
+        scorecard: scorecard([
+          agent("codex", [{ surface: "frontend", count: 2, ready: 2, blocked: 0 }]),
+          agent("claude", [{ surface: "frontend", count: 3, ready: 2, blocked: 1 }]),
+        ]),
+      },
+    );
+
+    expect(decision).toMatchObject({ agent: "claude", riskTier: "low" });
+    expect(decision.reason).toMatch(/cold start/);
+    expect(decision.reason).toMatch(/static default/);
+  });
+
+  it("recency-decays stale wins so recent evidence can take over", () => {
+    const staticDecision = classifyTask({ prompt: "polish the onboarding UI component" });
+    const decision = applyLearnedRouting(
+      { prompt: "polish the onboarding UI component" },
+      staticDecision,
+      {
+        now: NOW,
+        config: { minSamples: 2, decayHalfLifeDays: 1, explorationRate: 0 },
+        scorecard: scorecard([
+          agent("codex", [{ surface: "frontend", count: 8, ready: 6, blocked: 0, observedAt: "2026-05-31T11:00:00Z" }]),
+          agent("claude", [{ surface: "frontend", count: 80, ready: 80, blocked: 0, observedAt: "2026-05-21T12:00:00Z" }]),
+        ]),
+      },
+    );
+
+    expect(decision.agent).toBe("codex");
+    expect(decision.reason).toMatch(/codex/);
+  });
+
+  it("uses injected RNG for deterministic exploration", () => {
+    const staticDecision = classifyTask({ prompt: "polish the onboarding UI component" });
+    const decision = applyLearnedRouting(
+      { prompt: "polish the onboarding UI component" },
+      staticDecision,
+      {
+        now: NOW,
+        rng: () => 0,
+        config: { minSamples: 5, explorationRate: 1 },
+        scorecard: scorecard([
+          agent("codex", [{ surface: "frontend", count: 10, ready: 6, blocked: 1 }]),
+          agent("claude", [{ surface: "frontend", count: 10, ready: 10, blocked: 0 }]),
+        ]),
+      },
+    );
+
+    expect(decision.agent).toBe("codex");
+    expect(decision.reason).toMatch(/exploration/);
+  });
+
+  it("treats not_recorded and missing signals as neutral, not as free good score", () => {
+    const staticDecision = classifyTask({ prompt: "polish the onboarding UI component" });
+    const decision = applyLearnedRouting(
+      { prompt: "polish the onboarding UI component" },
+      staticDecision,
+      {
+        now: NOW,
+        config: { minSamples: 5, explorationRate: 0 },
+        scorecard: scorecard([
+          agent("codex", [{ surface: "frontend", count: 5 }]),
+          agent("claude", [{ surface: "frontend", count: 5, ready: 3, blocked: 0 }]),
+        ]),
+      },
+    );
+
+    expect(decision.agent).toBe("claude");
+    expect(decision.reason).toMatch(/codex not recorded ready/);
+  });
+
+  it("parses conservative config from env with bounds", () => {
+    const config = parseLearnedRoutingConfig({
+      A2_LEARNED_ROUTING_MIN_SAMPLES: "3.8",
+      A2_LEARNED_ROUTING_DECAY_HALF_LIFE_DAYS: "7",
+      A2_LEARNED_ROUTING_EXPLORATION_RATE: "2",
+    });
+
+    expect(config).toEqual({ minSamples: 3, decayHalfLifeDays: 7, explorationRate: 1 });
+  });
+});


### PR DESCRIPTION
## What changed
- Added a pure A2 learned-routing module that scores codex vs claude per low-risk surface from the A1 scorecard.
- Kept high-risk routing rule-bound to Codex and ignored scorecard stats on those surfaces.
- Wired learned routing only into the proposed-task default when no explicit agent is supplied; explicit agent and operator approval behavior are unchanged.
- Added conservative env-backed config: A2_LEARNED_ROUTING_MIN_SAMPLES, A2_LEARNED_ROUTING_DECAY_HALF_LIFE_DAYS, A2_LEARNED_ROUTING_EXPLORATION_RATE.
- Updated Hermes roadmap/design docs to mark A2 in review.

## Safety / scope
- Proposes-only: this does not approve, run, merge, or deploy anything.
- Missing / not_recorded A1 fields are neutral, never treated as good signal.
- Cold-start falls back to the static O4 routing taxonomy.
- Small exploration rate is injectable and defaults low.

## Checks
- npm run typecheck
- npm test
- git diff --check

## Surfaces
- MCP package routing/enqueue logic
- Unit tests
- Hermes docs

## Env / VPS
- No required secret changes. Optional env overrides listed above; safe defaults are built in.