### PR TITLE
O4-PR3a: autonomy mode — state + toggle (no auto-approval yet)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -117,7 +117,7 @@ describe("MonitorPage — container", () => {
     // the global fetch — so spying on it isolates the spawn call.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
     try {
-      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} />, {
+      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} autonomy={{ fetchMode: async () => null }} />, {
         wrapper,
       });
       await waitFor(() =>
@@ -158,5 +158,33 @@ describe("MonitorPage — container", () => {
     // The mute flows command → CoPilotRail → useActionAlerts → muted chip.
     await waitFor(() => expect(within(container).getByText("alerts muted")).toBeTruthy());
     expect(storage.getItem("monitor.mute.until")).toBeTruthy();
+  });
+
+  test("the board toggle posts autopilot, and the NL command reverts to supervised", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
+    const postMode = vi.fn(async (body: { mode: string }) => (body.mode === "autopilot" ? "autopilot" as const : "supervised" as const));
+    const { container } = render(
+      <MonitorPage
+        options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+        collaboration={{ enabled: false }}
+        alerts={{ enabled: false }}
+        autonomy={{ fetchMode: async () => "supervised", postMode }}
+      />,
+      { wrapper },
+    );
+    await waitFor(() => expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy());
+
+    // Toggle chip starts supervised; clicking engages autopilot (open-ended → server cap).
+    const toggle = within(container).getByText("○ supervised").closest("button") as HTMLButtonElement;
+    fireEvent.click(toggle);
+    await waitFor(() => expect(postMode).toHaveBeenCalledWith({ mode: "autopilot" }));
+    await waitFor(() => expect(within(container).getByText("● autopilot")).toBeTruthy());
+
+    // The NL command "I'm back" reverts to supervised.
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "I'm back" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(postMode).toHaveBeenCalledWith({ mode: "supervised" }));
+    await waitFor(() => expect(within(container).getByText("○ supervised")).toBeTruthy());
   });
 });

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -25,6 +25,7 @@ import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitor
 import { useCardParam } from "./hooks/useCardParam.js";
 import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
+import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonomyMode.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import type { CreateTaskInput } from "./lib/monitor/card-types.js";
 import { BoardView } from "./components/BoardView.js";
@@ -53,6 +54,8 @@ export interface MonitorPageProps {
   alerts?: UseActionAlertsOptions;
   /** Override the server-side mute POST (D4 off-device alerts) for tests. */
   onAlertMute?: (body: AlertMuteBody) => void;
+  /** Override the autonomy-mode wiring (GET/POST /monitor/autonomy-mode) for tests. */
+  autonomy?: UseAutonomyModeOptions;
 }
 
 export function MonitorPage({
@@ -64,9 +67,11 @@ export function MonitorPage({
   collaboration = {},
   alerts,
   onAlertMute = defaultPostAlertMute,
+  autonomy,
 }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
   const { cardId, setCard, clearCard } = useCardParam();
+  const { mode: autonomyMode, setAutopilot, setSupervised } = useAutonomyMode(autonomy);
 
   // The action-needed count drives all three notification tiers (§17).
   const actionCount = useMemo(() => kpiCounts(board?.cards ?? []).action, [board?.cards]);
@@ -104,6 +109,9 @@ export function MonitorPage({
         onMute={muteEverywhere}
         onUnmute={unmuteEverywhere}
         muted={muted}
+        onSetAutopilot={setAutopilot}
+        onSetSupervised={setSupervised}
+        autonomyMode={autonomyMode}
       />
     </ErrorBoundary>
   );

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -101,6 +101,12 @@ export interface BoardViewProps {
   onMute?: (untilMs: number) => void;
   onUnmute?: () => void;
   muted?: boolean;
+  /** Engage autopilot until `untilMs` (undefined → server 4h cap). */
+  onSetAutopilot?: (untilMs?: number) => void;
+  /** Revert to supervised. */
+  onSetSupervised?: () => void;
+  /** Current autonomy mode (drives the composer toggle chip). */
+  autonomyMode?: "supervised" | "autopilot";
   /** Disable the global keyboard handler (tests rendering many boards). */
   keyboard?: boolean;
 }
@@ -121,6 +127,9 @@ export function BoardView({
   onMute,
   onUnmute,
   muted,
+  onSetAutopilot,
+  onSetSupervised,
+  autonomyMode,
   keyboard = true,
 }: BoardViewProps) {
   const degraded = status === "reconnecting" || status === "closed";
@@ -299,6 +308,9 @@ export function BoardView({
           onMute={onMute}
           onUnmute={onUnmute}
           muted={muted}
+          onSetAutopilot={onSetAutopilot}
+          onSetSupervised={onSetSupervised}
+          autonomyMode={autonomyMode}
           composerFocusToken={askToken}
         />
       </div>

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -27,6 +27,12 @@ export interface AskHermesComposerProps {
   onUnmute?: () => void;
   /** Whether alerts are currently muted (shown as a chip). */
   muted?: boolean;
+  /** Engage autopilot until `untilMs` (undefined → server applies the 4h cap). */
+  onSetAutopilot?: (untilMs?: number) => void;
+  /** Revert to supervised. */
+  onSetSupervised?: () => void;
+  /** Current autonomy mode (drives the toggle chip). */
+  autonomyMode?: "supervised" | "autopilot";
   /** Focused card id, shown in the scope chip. */
   focusedCardId?: string | null;
   /** Bump to programmatically focus the input (the board's `a` shortcut). */
@@ -41,6 +47,9 @@ export function AskHermesComposer({
   onMute,
   onUnmute,
   muted,
+  onSetAutopilot,
+  onSetSupervised,
+  autonomyMode,
   focusedCardId,
   focusToken,
 }: AskHermesComposerProps) {
@@ -99,6 +108,24 @@ export function AskHermesComposer({
         setValue("");
         setError(null);
         return;
+      case "autopilot":
+        if (onSetAutopilot) {
+          onSetAutopilot(command.untilMs);
+          setValue("");
+          setError(null);
+        } else {
+          setError("Autonomy mode isn't wired here.");
+        }
+        return;
+      case "supervised":
+        if (onSetSupervised) {
+          onSetSupervised();
+          setValue("");
+          setError(null);
+        } else {
+          setError("Autonomy mode isn't wired here.");
+        }
+        return;
       case "ask":
         if (onAsk) {
           onAsk(command.text);
@@ -123,6 +150,20 @@ export function AskHermesComposer({
       <div className="hm-compose-toolbar">
         <span className="hm-compose-chip is-on">to · operator</span>
         <span className="hm-compose-chip">scope · {focusedCardId ?? "board"}</span>
+        {onSetAutopilot && onSetSupervised ? (
+          <button
+            type="button"
+            className="hm-compose-chip"
+            aria-pressed={autonomyMode === "autopilot"}
+            title={autonomyMode === "autopilot"
+              ? "Hermes is in autopilot — click to take back control (supervised)"
+              : "Supervised — click to put Hermes in charge (autopilot, 4h cap)"}
+            onClick={() => (autonomyMode === "autopilot" ? onSetSupervised() : onSetAutopilot(undefined))}
+            style={autonomyMode === "autopilot" ? { color: "var(--hm-emerald, #34d399)" } : undefined}
+          >
+            {autonomyMode === "autopilot" ? "● autopilot" : "○ supervised"}
+          </button>
+        ) : null}
         {muted ? (
           <span className="hm-compose-chip" style={{ color: "var(--hm-muted)" }}>
             alerts muted

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -29,6 +29,12 @@ export interface CoPilotRailProps {
   onUnmute?: () => void;
   /** Whether action alerts are currently muted. */
   muted?: boolean;
+  /** Engage autopilot until `untilMs` (undefined → server 4h cap). */
+  onSetAutopilot?: (untilMs?: number) => void;
+  /** Revert to supervised. */
+  onSetSupervised?: () => void;
+  /** Current autonomy mode (drives the toggle chip). */
+  autonomyMode?: "supervised" | "autopilot";
   /** Bump to focus the composer (the board's `a` shortcut). */
   composerFocusToken?: number;
 }
@@ -42,6 +48,9 @@ export function CoPilotRail({
   onMute,
   onUnmute,
   muted,
+  onSetAutopilot,
+  onSetSupervised,
+  autonomyMode,
   composerFocusToken,
 }: CoPilotRailProps) {
   const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
@@ -88,6 +97,9 @@ export function CoPilotRail({
         onMute={onMute}
         onUnmute={onUnmute}
         muted={muted}
+        onSetAutopilot={onSetAutopilot}
+        onSetSupervised={onSetSupervised}
+        autonomyMode={autonomyMode}
         focusedCardId={focusedCard?.id ?? null}
         focusToken={composerFocusToken}
       />

--- a/packages/monitor-ui/src/hooks/useAutonomyMode.ts
+++ b/packages/monitor-ui/src/hooks/useAutonomyMode.ts
@@ -1,0 +1,95 @@
+// O4-PR3a — autonomy mode hook for the board container.
+//
+// Reads the current mode from GET /monitor/autonomy-mode on mount and exposes
+// setAutopilot/setSupervised that POST the change. Best-effort + optimistic:
+// the board toggle reflects the operator's click immediately; the server is the
+// source of truth (and re-caps any window) on the next read. Network/fetch is
+// guarded so this is inert in tests that don't wire it.
+
+import { useCallback, useEffect, useState } from "react";
+
+export type AutonomyMode = "supervised" | "autopilot";
+
+const AUTONOMY_URL = "/monitor/autonomy-mode";
+
+export interface UseAutonomyModeOptions {
+  /** Override the network for tests. Return the current mode, or null to skip. */
+  fetchMode?: () => Promise<AutonomyMode | null>;
+  /** Override the setter for tests. */
+  postMode?: (body: { mode: AutonomyMode; untilMs?: number }) => Promise<AutonomyMode | null>;
+}
+
+export interface UseAutonomyMode {
+  mode: AutonomyMode;
+  setAutopilot: (untilMs?: number) => void;
+  setSupervised: () => void;
+}
+
+function canFetch(): boolean {
+  return typeof fetch === "function";
+}
+
+async function defaultFetchMode(): Promise<AutonomyMode | null> {
+  if (!canFetch()) return null;
+  try {
+    const res = await fetch(AUTONOMY_URL, { method: "GET" });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { autonomy?: { mode?: string } };
+    return json.autonomy?.mode === "autopilot" ? "autopilot" : "supervised";
+  } catch {
+    return null;
+  }
+}
+
+async function defaultPostMode(body: { mode: AutonomyMode; untilMs?: number }): Promise<AutonomyMode | null> {
+  if (!canFetch()) return null;
+  try {
+    const res = await fetch(AUTONOMY_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { autonomy?: { mode?: string } };
+    return json.autonomy?.mode === "autopilot" ? "autopilot" : "supervised";
+  } catch {
+    return null;
+  }
+}
+
+export function useAutonomyMode(options: UseAutonomyModeOptions = {}): UseAutonomyMode {
+  const fetchMode = options.fetchMode ?? defaultFetchMode;
+  const postMode = options.postMode ?? defaultPostMode;
+  const [mode, setMode] = useState<AutonomyMode>("supervised");
+
+  useEffect(() => {
+    let active = true;
+    void fetchMode().then((m) => {
+      if (active && m) setMode(m);
+    });
+    return () => {
+      active = false;
+    };
+    // fetchMode is stable for the lifetime of the page (default or test override).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const setAutopilot = useCallback(
+    (untilMs?: number) => {
+      setMode("autopilot"); // optimistic
+      void postMode({ mode: "autopilot", ...(untilMs !== undefined ? { untilMs } : {}) }).then((m) => {
+        if (m) setMode(m);
+      });
+    },
+    [postMode],
+  );
+
+  const setSupervised = useCallback(() => {
+    setMode("supervised"); // optimistic
+    void postMode({ mode: "supervised" }).then((m) => {
+      if (m) setMode(m);
+    });
+  }, [postMode]);
+
+  return { mode, setAutopilot, setSupervised };
+}

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
@@ -158,3 +158,72 @@ test("parseHermesInput: bare /task → error", () => {
 test("parseHermesInput: a word starting with task but not the command is an ask", () => {
   assert.equal(parseHermesInput("tasks for today?").kind, "ask");
 });
+
+// ── O4-PR3a autonomy-mode NL parsing ────────────────────────────────
+
+const NOW = new Date("2026-05-31T09:00:00.000Z").getTime();
+const at = () => NOW;
+const HOUR = 3_600_000;
+
+test("autonomy: open-ended 'you're in charge' → autopilot capped at now+4h", () => {
+  assert.deepEqual(parseHermesInput("Hermes, you're in charge", at), {
+    kind: "autopilot",
+    untilMs: NOW + 4 * HOUR,
+  });
+});
+
+test("autonomy: 'take over for 2h' → autopilot at now+2h", () => {
+  assert.deepEqual(parseHermesInput("take over for 2h", at), {
+    kind: "autopilot",
+    untilMs: NOW + 2 * HOUR,
+  });
+});
+
+test("autonomy: 'for 90 minutes' duration honored", () => {
+  assert.deepEqual(parseHermesInput("you're in charge for 90 minutes", at), {
+    kind: "autopilot",
+    untilMs: NOW + 90 * 60_000,
+  });
+});
+
+test("autonomy: a stated duration beyond 4h is honored (not re-capped)", () => {
+  assert.deepEqual(parseHermesInput("you're in charge for 8h", at), {
+    kind: "autopilot",
+    untilMs: NOW + 8 * HOUR,
+  });
+});
+
+test("autonomy: 'until 5pm' → autopilot with a future clock time", () => {
+  const cmd = parseHermesInput("you're in charge until 5pm", at);
+  assert.equal(cmd.kind, "autopilot");
+  if (cmd.kind === "autopilot") {
+    assert.ok(cmd.untilMs > NOW, "until is in the future");
+    const d = new Date(cmd.untilMs);
+    assert.equal(d.getMinutes(), 0);
+    assert.equal(d.getHours(), 17); // 5pm local
+  }
+});
+
+test("autonomy: 'I'm back' → supervised", () => {
+  assert.deepEqual(parseHermesInput("I'm back", at), { kind: "supervised" });
+});
+
+test("autonomy: 'stand down' / 'autopilot off' → supervised", () => {
+  assert.deepEqual(parseHermesInput("stand down", at), { kind: "supervised" });
+  assert.deepEqual(parseHermesInput("autopilot off", at), { kind: "supervised" });
+});
+
+test("autonomy: slash forms /autopilot and /supervised", () => {
+  assert.equal(parseHermesInput("/autopilot until 3pm", at).kind, "autopilot");
+  assert.deepEqual(parseHermesInput("/supervised", at), { kind: "supervised" });
+});
+
+test("autonomy: 'take back' reverts (does not match the autopilot 'take' trigger)", () => {
+  assert.deepEqual(parseHermesInput("ok I'll take back control", at), { kind: "supervised" });
+});
+
+test("autonomy: an unrelated sentence is still an ask, not a mode change", () => {
+  assert.equal(parseHermesInput("what is the charge for this task?", at).kind, "ask");
+  // "are you in charge…" doesn't match a delegation trigger → no false positive.
+  assert.equal(parseHermesInput("are you in charge of the indexer?", at).kind, "ask");
+});

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
@@ -20,9 +20,16 @@ export type HermesCommand =
   | { kind: "task"; agent: TaskAgent; repo: string; pullRequestNumber?: number; prompt: string }
   | { kind: "mute"; untilMs: number }
   | { kind: "unmute" }
+  // O4-PR3a — autonomy mode. "autopilot" delegates approval to Hermes until
+  // `untilMs` (a stated time, else the now+4h safety cap); "supervised" reverts.
+  | { kind: "autopilot"; untilMs: number }
+  | { kind: "supervised" }
   | { kind: "ask"; text: string }
   | { kind: "error"; message: string }
   | { kind: "empty" };
+
+/** A forgotten autopilot can't run forever: the open-ended end-of-autopilot cap. */
+export const AUTOPILOT_SAFETY_CAP_MS = 4 * 60 * 60 * 1000;
 
 const MISSION_RE = /^\/mission\b\s*(.*)$/is;
 const TASK_RE = /^\/task\b\s*(.*)$/is;
@@ -113,5 +120,58 @@ export function parseHermesInput(raw: string, now: () => number = Date.now): Her
     return parsed.ok ? { kind: "mute", untilMs: parsed.untilMs } : { kind: "error", message: parsed.error };
   }
 
+  const autonomy = parseAutonomyDirective(text, now);
+  if (autonomy) return autonomy;
+
   return { kind: "ask", text };
+}
+
+// ── O4-PR3a autonomy-mode NL parsing ────────────────────────────────
+//
+// "Hermes, you're in charge until 5pm" / "for 2h" / open-ended → autopilot
+// (open-ended gets the now+4h safety cap). "I'm back" / "stand down" /
+// "autopilot off" → supervised. Slash forms /autopilot and /supervised too.
+
+// Revert-to-supervised triggers (checked first — "take back" must not match the
+// "take ..." autopilot trigger).
+const SUPERVISED_RE = /(^\/supervised\b|\bi'?m back\b|\bi am back\b|\bstand down\b|\bautopilot\s+off\b|\btake\s+back\b|\bi'?ve got it\b|\byou'?re off\b)/i;
+// Engage-autopilot triggers.
+const AUTOPILOT_RE = /(^\/autopilot\b|\byou'?re in charge\b|\byou are in charge\b|\byou'?ve got (?:it|the wheel|this)\b|\btake (?:over|the wheel|the lead)\b|\bautopilot\s+on\b)/i;
+// Window extraction within the directive.
+const FOR_DUR_RE = /\bfor\s+(\d+)\s*(m|min|mins|minute|minutes|h|hr|hrs|hour|hours)\b/i;
+const UNTIL_CLOCK_RE = /\buntil\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)?\b/i;
+
+function parseAutonomyDirective(text: string, now: () => number): HermesCommand | null {
+  if (SUPERVISED_RE.test(text)) return { kind: "supervised" };
+  if (!AUTOPILOT_RE.test(text)) return null;
+  return { kind: "autopilot", untilMs: parseAutonomyWindow(text, now) };
+}
+
+/** Stated time honored; absent/unparseable → the now+4h safety cap. */
+function parseAutonomyWindow(text: string, now: () => number): number {
+  const nowMs = now();
+  const dur = FOR_DUR_RE.exec(text);
+  if (dur) {
+    const n = Number.parseInt(dur[1] as string, 10);
+    if (n > 0) {
+      const ms = (dur[2] as string).toLowerCase().startsWith("m") ? n * 60_000 : n * 3_600_000;
+      return nowMs + ms;
+    }
+  }
+  const clock = UNTIL_CLOCK_RE.exec(text);
+  if (clock) {
+    let hour = Number.parseInt(clock[1] as string, 10);
+    const min = clock[2] ? Number.parseInt(clock[2], 10) : 0;
+    const ap = clock[3]?.toLowerCase();
+    if (ap === "pm" && hour < 12) hour += 12;
+    if (ap === "am" && hour === 12) hour = 0;
+    if (hour <= 23 && min <= 59) {
+      const d = new Date(nowMs);
+      d.setHours(hour, min, 0, 0);
+      let untilMs = d.getTime();
+      if (untilMs <= nowMs) untilMs += 24 * 60 * 60 * 1000;
+      return untilMs;
+    }
+  }
+  return nowMs + AUTOPILOT_SAFETY_CAP_MS;
 }

--- a/services/slack-operator/src/autonomy-mode.ts
+++ b/services/slack-operator/src/autonomy-mode.ts
@@ -1,0 +1,137 @@
+// O4-PR3a — autonomy mode: the master control for autopilot.
+//
+// Default is "supervised": Hermes proposes, the operator approves. Setting
+// "autopilot" is an explicit operator action (board switch or NL command) that
+// delegates approval to Hermes WITHIN the guardrail — and only until a stated
+// time, else a `now + 4h` safety cap so a forgotten autopilot can't run forever.
+//
+// This module owns the mode STATE + the expiry. It is harmless on its own: the
+// auto-approval that READS this state ships in PR3b (isAutopilotEngaged is the
+// gate). Persisted on the shared /data volume so the mode SURVIVES a restart —
+// a restart must not silently drop the operator into (or out of) autopilot
+// without the expiry being honored.
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { optionalEnv } from "@avg/mcp-common";
+
+export type AutonomyMode = "supervised" | "autopilot";
+
+export interface AutonomyState {
+  mode: AutonomyMode;
+  /** ISO; autopilot reverts to supervised at/after this. Always set in autopilot. */
+  until?: string;
+  /** Who set the mode (operator id / "monitor" / NL author), for the audit. */
+  setBy?: string;
+  /** ISO timestamp the mode was set. */
+  setAt?: string;
+}
+
+/** A forgotten autopilot can't run forever: the default end-of-autopilot cap. */
+export const AUTOPILOT_SAFETY_CAP_MS = 4 * 60 * 60 * 1000;
+
+const SUPERVISED: AutonomyState = { mode: "supervised" };
+
+function statePath(path?: string): string {
+  return (
+    path ??
+    optionalEnv("AVERRAY_AUTONOMY_MODE_PATH", "/data/autonomy-mode.json") ??
+    "/data/autonomy-mode.json"
+  );
+}
+
+/**
+ * Pure: resolve the stored state against the clock. Autopilot is ACTIVE only
+ * while it has a valid future `until`; an expired or missing `until` resolves
+ * to supervised (fail-safe — autopilot never lingers past its window).
+ */
+export function resolveAutonomyState(raw: AutonomyState | undefined, nowMs: number): AutonomyState {
+  if (!raw || raw.mode !== "autopilot") return SUPERVISED;
+  const untilMs = raw.until ? Date.parse(raw.until) : NaN;
+  if (!Number.isFinite(untilMs) || untilMs <= nowMs) return SUPERVISED;
+  return raw;
+}
+
+function readRawState(path?: string): AutonomyState | undefined {
+  const p = statePath(path);
+  try {
+    if (!existsSync(p)) return undefined;
+    const raw = JSON.parse(readFileSync(p, "utf8")) as Partial<AutonomyState>;
+    const mode: AutonomyMode = raw.mode === "autopilot" ? "autopilot" : "supervised";
+    return {
+      mode,
+      ...(raw.until ? { until: raw.until } : {}),
+      ...(raw.setBy ? { setBy: raw.setBy } : {}),
+      ...(raw.setAt ? { setAt: raw.setAt } : {}),
+    };
+  } catch {
+    // Unreadable state: fail safe to supervised (autopilot never engages on a
+    // corrupt file). Never throw from a read.
+    return undefined;
+  }
+}
+
+/** The current, clock-resolved mode. Lazy-expires autopilot to supervised. */
+export function readAutonomyState(now: () => Date = () => new Date(), path?: string): AutonomyState {
+  return resolveAutonomyState(readRawState(path), now().getTime());
+}
+
+/** The gate PR3b's auto-approval reads: is autopilot engaged right now? */
+export function isAutopilotEngaged(now: () => Date = () => new Date(), path?: string): boolean {
+  return readAutonomyState(now, path).mode === "autopilot";
+}
+
+function writeState(state: AutonomyState, path?: string): void {
+  const p = statePath(path);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+/**
+ * Set the mode. Supervised clears any window. Autopilot ALWAYS gets a bounded
+ * `until`: a stated time is honored; an absent/past time falls back to the
+ * `now + 4h` safety cap. Returns the persisted state.
+ */
+export function setAutonomyMode(
+  input: { mode: AutonomyMode; untilMs?: number; setBy?: string },
+  now: () => Date = () => new Date(),
+  path?: string,
+): AutonomyState {
+  const nowMs = now().getTime();
+  const setAt = new Date(nowMs).toISOString();
+  if (input.mode !== "autopilot") {
+    const state: AutonomyState = { mode: "supervised", setAt, ...(input.setBy ? { setBy: input.setBy } : {}) };
+    writeState(state, path);
+    return state;
+  }
+  const requested = typeof input.untilMs === "number" && Number.isFinite(input.untilMs) ? input.untilMs : NaN;
+  // Honor a stated future time; otherwise (absent or already-past) cap at now+4h.
+  const untilMs = Number.isFinite(requested) && requested > nowMs ? requested : nowMs + AUTOPILOT_SAFETY_CAP_MS;
+  const state: AutonomyState = {
+    mode: "autopilot",
+    until: new Date(untilMs).toISOString(),
+    setAt,
+    ...(input.setBy ? { setBy: input.setBy } : {}),
+  };
+  writeState(state, path);
+  return state;
+}
+
+/**
+ * Expire autopilot if its window has passed. Idempotent: returns
+ * `{ expired: true, previous }` exactly on the transition (stored autopilot →
+ * resolves supervised), persisting supervised so the caller can alert ONCE.
+ * Returns `{ expired: false }` otherwise.
+ */
+export function expireAutonomyIfDue(
+  now: () => Date = () => new Date(),
+  path?: string,
+): { expired: boolean; previous?: AutonomyState } {
+  const raw = readRawState(path);
+  if (!raw || raw.mode !== "autopilot") return { expired: false };
+  const resolved = resolveAutonomyState(raw, now().getTime());
+  if (resolved.mode === "autopilot") return { expired: false };
+  // Stored autopilot has lapsed: persist the revert so this fires only once.
+  writeState({ mode: "supervised", setAt: now().toISOString(), setBy: "autopilot-expiry" }, path);
+  return { expired: true, previous: raw };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -71,6 +71,12 @@ import {
   readAutopilotSuspendState,
 } from "./autopilot-state.js";
 import {
+  readAutonomyState,
+  setAutonomyMode,
+  expireAutonomyIfDue,
+  type AutonomyMode,
+} from "./autonomy-mode.js";
+import {
   isDebugSpawnEnabled,
   mergeDebugCards,
   onDebugCardSpawned,
@@ -195,6 +201,44 @@ if (!enabled) {
     logger.warn("slack_operator_enabled_without_socket_or_signing_secret");
   }
   startOperatorRoutines();
+  // O4-PR3a — always-on safety revert: lazy-resolve already treats an expired
+  // autopilot as supervised, but this persists the revert + alerts ONCE when the
+  // window lapses (a forgotten autopilot ends on its own). Independent of the
+  // routine channel; the alert rides the D4 bridge (SLACK_WEBHOOK_URL).
+  setInterval(() => void checkAutonomyExpiry(), 60_000);
+}
+
+let autonomyExpiryRunning = false;
+async function checkAutonomyExpiry() {
+  if (autonomyExpiryRunning) return;
+  autonomyExpiryRunning = true;
+  try {
+    const result = expireAutonomyIfDue();
+    if (!result.expired) return;
+    logger.info({ until: result.previous?.until }, "o4_autonomy_expired_to_supervised");
+    const boardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
+    await slackAlertChannel().dispatch({
+      count: 0,
+      items: [],
+      boardUrl,
+      text: `⏱️ Hermes autopilot window ended — back to SUPERVISED. Every dispatch needs your approval again.\nBoard: ${boardUrl}`,
+    }).catch((error) => logger.warn({ err: error }, "o4_autonomy_expiry_alert_failed"));
+    await recordOperatorCommandEvent({
+      source: "slack_routine",
+      commandText: "autonomy autopilot window expired",
+      result: {
+        kind: "autonomy_mode_change",
+        from: "autopilot",
+        to: "supervised",
+        setBy: "autopilot-expiry",
+        safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+      },
+    }, query).catch((error) => logger.warn({ err: error }, "o4_autonomy_expiry_record_failed"));
+  } catch (error) {
+    logger.warn({ err: error }, "o4_autonomy_expiry_failed");
+  } finally {
+    autonomyExpiryRunning = false;
+  }
 }
 
 async function handleHttpRequest(request: http.IncomingMessage, response: http.ServerResponse) {
@@ -493,6 +537,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorAutopilotResumeRequest(request, response);
+    return;
+  }
+  if (url.pathname === "/monitor/autonomy-mode" && (request.method === "GET" || request.method === "POST")) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorAutonomyModeRequest(request, response);
     return;
   }
   const testbedMissionId = monitorTestbedMissionId(url.pathname);
@@ -1151,6 +1207,66 @@ async function handleMonitorAutopilotResumeRequest(_request: http.IncomingMessag
   } catch (error) {
     writeJson(response, 500, {
       error: "autopilot_resume_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// O4-PR3a — autonomy mode. GET returns the current (clock-resolved) mode; POST
+// sets it (supervised | autopilot[, untilMs]). Setting autopilot is an explicit
+// operator action; an absent/past `untilMs` falls back to the now+4h safety cap.
+// Every mode change is alerted (D4) + audited. The auto-approval that READS this
+// mode ships in PR3b — until then this only records the operator's intent.
+async function handleMonitorAutonomyModeRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    if (request.method === "GET") {
+      writeJson(response, 200, { ok: true, autonomy: readAutonomyState() });
+      return;
+    }
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const modeRaw = stringField(payload, "mode");
+    if (modeRaw !== "supervised" && modeRaw !== "autopilot") {
+      writeJson(response, 400, { error: "invalid_mode", message: "mode must be 'supervised' or 'autopilot'." });
+      return;
+    }
+    const mode: AutonomyMode = modeRaw;
+    const untilMs = typeof payload.untilMs === "number" && Number.isFinite(payload.untilMs) ? payload.untilMs : undefined;
+    const setBy = stringField(payload, "setBy") ?? "monitor";
+    const before = readAutonomyState();
+    const after = setAutonomyMode({ mode, ...(untilMs !== undefined ? { untilMs } : {}), setBy });
+    const changed = before.mode !== after.mode || before.until !== after.until;
+    logger.info({ from: before.mode, to: after.mode, until: after.until, setBy }, "o4_autonomy_mode_set");
+
+    if (changed) {
+      const boardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
+      const text = after.mode === "autopilot"
+        ? `🟢 Hermes is in AUTOPILOT until ${after.until ?? "—"} — low/medium-risk dispatch within budget auto-approves; high-risk still escalates to you. Merge/deploy stays human.\nBoard: ${boardUrl}`
+        : `⏸️ Hermes is back to SUPERVISED — every dispatch needs your approval again.\nBoard: ${boardUrl}`;
+      await slackAlertChannel().dispatch({ count: 0, items: [], boardUrl, text }).catch((error) => logger.warn({ err: error }, "o4_autonomy_alert_failed"));
+      await recordOperatorCommandEvent({
+        source: "monitor",
+        commandText: `autonomy mode → ${after.mode}`,
+        result: {
+          kind: "autonomy_mode_change",
+          from: before.mode,
+          to: after.mode,
+          until: after.until ?? null,
+          setBy,
+          safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+        },
+      }, query).catch((error) => logger.warn({ err: error }, "o4_autonomy_record_failed"));
+    }
+
+    writeJson(response, 200, { ok: true, changed, autonomy: after });
+  } catch (error) {
+    logger.error({ err: error }, "o4_autonomy_mode_failed");
+    writeJson(response, 500, {
+      error: "autonomy_mode_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }

--- a/test/unit/autonomy-mode.test.ts
+++ b/test/unit/autonomy-mode.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  resolveAutonomyState,
+  readAutonomyState,
+  isAutopilotEngaged,
+  setAutonomyMode,
+  expireAutonomyIfDue,
+  AUTOPILOT_SAFETY_CAP_MS,
+  type AutonomyState,
+} from "../../services/slack-operator/src/autonomy-mode.js";
+
+const T0 = Date.parse("2026-05-31T09:00:00.000Z");
+const HOUR = 3_600_000;
+const clock = (ms: number) => () => new Date(ms);
+
+describe("resolveAutonomyState — pure clock resolution (fail-safe to supervised)", () => {
+  it("supervised stays supervised", () => {
+    expect(resolveAutonomyState({ mode: "supervised" }, T0)).toEqual({ mode: "supervised" });
+  });
+  it("undefined → supervised", () => {
+    expect(resolveAutonomyState(undefined, T0).mode).toBe("supervised");
+  });
+  it("autopilot with a future until is active", () => {
+    const s: AutonomyState = { mode: "autopilot", until: new Date(T0 + HOUR).toISOString() };
+    expect(resolveAutonomyState(s, T0)).toEqual(s);
+  });
+  it("autopilot with an expired until → supervised", () => {
+    const s: AutonomyState = { mode: "autopilot", until: new Date(T0 - 1).toISOString() };
+    expect(resolveAutonomyState(s, T0).mode).toBe("supervised");
+  });
+  it("autopilot WITHOUT until → supervised (never lingers open-ended in storage)", () => {
+    expect(resolveAutonomyState({ mode: "autopilot" }, T0).mode).toBe("supervised");
+  });
+});
+
+describe("autonomy-mode — file-backed state (temp dir, injected clock)", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-autonomy-"));
+    path = join(dir, "autonomy-mode.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("defaults to supervised when no file exists", () => {
+    expect(readAutonomyState(clock(T0), path)).toEqual({ mode: "supervised" });
+    expect(isAutopilotEngaged(clock(T0), path)).toBe(false);
+  });
+
+  it("setting autopilot with a stated time persists + engages, and survives a re-read", () => {
+    const untilMs = T0 + 2 * HOUR;
+    const state = setAutonomyMode({ mode: "autopilot", untilMs, setBy: "operator" }, clock(T0), path);
+    expect(state.mode).toBe("autopilot");
+    expect(state.until).toBe(new Date(untilMs).toISOString());
+    expect(existsSync(path)).toBe(true);
+    expect(isAutopilotEngaged(clock(T0 + HOUR), path)).toBe(true); // still within window
+  });
+
+  it("open-ended autopilot gets the now+4h safety cap", () => {
+    const state = setAutonomyMode({ mode: "autopilot", setBy: "operator" }, clock(T0), path);
+    expect(state.until).toBe(new Date(T0 + AUTOPILOT_SAFETY_CAP_MS).toISOString());
+  });
+
+  it("a past untilMs is rejected in favor of the 4h cap (no instantly-expired autopilot)", () => {
+    const state = setAutonomyMode({ mode: "autopilot", untilMs: T0 - HOUR }, clock(T0), path);
+    expect(state.until).toBe(new Date(T0 + AUTOPILOT_SAFETY_CAP_MS).toISOString());
+  });
+
+  it("a stated time beyond 4h is honored (the operator's explicit window)", () => {
+    const untilMs = T0 + 8 * HOUR;
+    const state = setAutonomyMode({ mode: "autopilot", untilMs }, clock(T0), path);
+    expect(state.until).toBe(new Date(untilMs).toISOString());
+  });
+
+  it("lazy-expires: autopilot reads as supervised once the window passes", () => {
+    setAutonomyMode({ mode: "autopilot", untilMs: T0 + HOUR }, clock(T0), path);
+    expect(isAutopilotEngaged(clock(T0 + 30 * 60_000), path)).toBe(true);  // 30m in
+    expect(isAutopilotEngaged(clock(T0 + 2 * HOUR), path)).toBe(false);    // past window
+  });
+
+  it("setting supervised clears the window", () => {
+    setAutonomyMode({ mode: "autopilot", untilMs: T0 + HOUR }, clock(T0), path);
+    const state = setAutonomyMode({ mode: "supervised", setBy: "operator" }, clock(T0 + 5 * 60_000), path);
+    expect(state.mode).toBe("supervised");
+    expect(state.until).toBeUndefined();
+    expect(isAutopilotEngaged(clock(T0 + 5 * 60_000), path)).toBe(false);
+  });
+
+  it("a corrupt state file reads as supervised (never throws, never auto-engages)", async () => {
+    await writeFile(path, "{ not json");
+    expect(isAutopilotEngaged(clock(T0), path)).toBe(false);
+  });
+});
+
+describe("expireAutonomyIfDue — one-shot revert + alert hook", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-autonomy-exp-"));
+    path = join(dir, "autonomy-mode.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("no-op while autopilot is still within its window", () => {
+    setAutonomyMode({ mode: "autopilot", untilMs: T0 + HOUR }, clock(T0), path);
+    expect(expireAutonomyIfDue(clock(T0 + 30 * 60_000), path)).toEqual({ expired: false });
+  });
+
+  it("no-op when already supervised", () => {
+    expect(expireAutonomyIfDue(clock(T0), path)).toEqual({ expired: false });
+  });
+
+  it("fires exactly once on the transition, then persists supervised", async () => {
+    setAutonomyMode({ mode: "autopilot", untilMs: T0 + HOUR }, clock(T0), path);
+    const first = expireAutonomyIfDue(clock(T0 + 2 * HOUR), path);
+    expect(first.expired).toBe(true);
+    expect(first.previous?.mode).toBe("autopilot");
+    // Second call after the revert is a no-op (the alert won't double-fire).
+    expect(expireAutonomyIfDue(clock(T0 + 3 * HOUR), path)).toEqual({ expired: false });
+    const persisted = JSON.parse(await readFile(path, "utf8")) as AutonomyState;
+    expect(persisted.mode).toBe("supervised");
+  });
+});


### PR DESCRIPTION
## What changed & why

The **master control for autopilot**, shipped deliberately **harmless**: this PR is the autonomy-mode **state + the toggle only**. The auto-approval that *reads* this mode is **PR3b** (stacked on this). Until PR3b lands, setting autopilot changes **nothing** about how tasks are approved — every dispatch still needs the operator. Safe to merge.

This is part 1 of O4-PR3 (autonomy mode + autopilot auto-approval), per `docs/HERMES_ORCHESTRATION_DESIGN.md` §O4-D.

### State — `services/slack-operator/src/autonomy-mode.ts` (new)
- `AutonomyState { mode: "supervised" | "autopilot", until?, setBy, setAt }`, persisted on the `/data` volume so the mode **survives a restart**. **Default supervised.**
- Autopilot **always** gets a bounded `until`: a **stated time is honored**; an absent/past time falls back to the **`now + 4h` safety cap** — a forgotten autopilot can't run forever.
- `resolveAutonomyState` is pure + **fail-safe**: an expired or missing `until` resolves to supervised; a corrupt state file reads as supervised (autopilot never auto-engages on bad input).
- `isAutopilotEngaged()` is the gate **PR3b** will read.

### Toggle — two ways (mirrors `/mission` `/mute` `/task`)
- **NL command** in `hermes-commands.ts`: *"Hermes, you're in charge until 5pm"* / *"for 2h"* / open-ended (→ 4h cap); *"I'm back"* / *"stand down"* / *"autopilot off"* → supervised. Slash `/autopilot` and `/supervised` too.
- **Board switch** in the composer toolbar (`● autopilot` / `○ supervised`).
- Both POST `/monitor/autonomy-mode`; GET returns the clock-resolved mode (`useAutonomyMode` hook).

### Expiry
Lazy-resolve treats an expired autopilot as supervised on every read, **and** an always-on 60s routine persists the revert + alerts **once** when the window lapses. Every mode change + the expiry are **alerted** (D4 bridge) and **audited** (operator-command event). Never logs secrets.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Docs / tests only (state + UI + tests; no ops/secret changes)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (970 passed; new: NL parse matrix, server state/cap/expiry, board-toggle + NL-revert wiring)
- [x] `vite build` (monitor-ui) — composer toggle + hook compile and bundle

## Rollout / rollback
- **Off by default end-to-end:** supervised is the default; autopilot is an explicit operator action; **nothing auto-approves until PR3b**.
- Optional env (new): `AVERRAY_AUTONOMY_MODE_PATH` (defaults to `/data/autonomy-mode.json`). No compose change required for default behavior.
- **Rollback:** revert the PR, or `POST /monitor/autonomy-mode {mode:"supervised"}` / delete the state file to force supervised.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — unaffected (this PR adds no approval power)
- [x] `HALT_FILE` honored; **no new ungated agent power** — the auto-approval authority is gated and ships separately in PR3b; this PR only records operator intent
- [x] No secrets committed/printed/logged
- [x] AGENTS.md power-change update deferred to **PR3b** (where Hermes's powers actually change)

## Known limits / follow-ups
- **PR3b** wires `isAutopilotEngaged()` + `!isAutopilotSuspended()` + dispatch-policy + `riskTier != high` into the actual auto-approval at the propose seam, with per-approval audit + high-risk escalation alerts, and updates AGENTS.md.
- A stated time beyond 4h is honored as the operator's explicit window (only open-ended is capped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)