### PR TITLE
O4-PR3b: autopilot auto-approval — the authority change (gated, default-off)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,15 @@ how things work **today** and must be updated as phases land (see the last bulle
    add a bypass.
 6. **New power comes with a new guardrail.** Any capability that lets an agent
    (including Hermes) act on the world — dispatch/enqueue work, mutate GitHub, spend,
-   submit — must ship with an explicit allowlist + budget **and** keep a human
-   approval step. No ungated agent authority.
+   submit — must ship with an explicit allowlist + budget. Approval may be the
+   operator **or** Hermes autopilot *within its rules* — never ungated agent
+   authority. Autopilot (O4-PR3) auto-approves **dispatch only**, and only when
+   ALL hold: mode `autopilot` and within its time window (stated, else a 4h safety
+   cap), **not** D3-suspended, `HALT_FILE` absent, the dispatch allowlist+budget
+   allows, and `riskTier != high` (**high-risk always escalates to the operator**).
+   It is **off by default** (supervised), reverts on expiry/suspend/HALT, and
+   **never** merges or deploys (invariant #1). Every auto-approval + escalation is
+   audited and alerted.
 7. **Secrets are never committed, printed, or logged.**
 8. **Verify chain facts before asserting them.** For any Polkadot / Substrate /
    Asset Hub behavior, address, runtime, fee, XCM, or settlement claim, check the
@@ -95,17 +102,20 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   chain/settlement-adjacent work**; Claude takes UI, docs, and general code.
 - **Hermes reviews and operates** — observes GitHub, reviews PR risk, runs
   read-only checks, reports to the PR/Slack/monitor, and proposes operator actions.
-  Today Hermes is **recommendation-only**: it must not merge, deploy, submit work, or
-  run guarded live mutations during a handoff. As Hermes gains orchestration powers
-  (routing and dispatching tasks per the orchestration plan), those powers stay
-  inside the **Durable invariants** above — gated, budgeted, and never extending to
-  auto-merge or auto-deploy. Update this section when that lands.
+  Hermes proposes + routes tasks, and — when the operator turns on **autopilot**
+  (O4-PR3) — may **auto-approve dispatch** within the invariant-#6 gate (allowlist,
+  budget, not-suspended, HALT-absent, low/medium-risk only; high-risk always
+  escalates). Default is **supervised** (operator approves). Either way Hermes must
+  not merge, deploy, submit work, or run guarded live mutations during a handoff:
+  its powers stay inside the **Durable invariants** above — gated, budgeted, and
+  never extending to auto-merge or auto-deploy.
 - **Humans own approval.** A PASS verdict is a release *signal*, not a merge order.
   Merge and deploy are human-gated. No auto-merge.
 - **Per-agent task runners** (`codex-task-runner`, `claude-task-runner`) claim
   work from the shared task queue and execute the matching worker. They are the
   dispatch path, so they carry invariant #6's guardrail: they claim **only
-  operator-`approved` tasks** (never self-approve), filtered by `agent`
+  `approved` tasks** — approved by the operator **or** by `hermes-autopilot`
+  within its rules — and **never self-approve**, filtered by `agent`
   (codex/claude). The Claude runner additionally runs a **billing-route
   verification** at startup (`claude-worker-auth`) — on a mismatch it writes a
   `misconfigured` heartbeat and **refuses to claim** rather than silently

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -199,6 +199,16 @@ AVERRAY_AUTOPILOT_SUSPENDED_PATH=/data/autopilot-suspended.json
 # Per-day dispatch cap the budget-spike/blowout signals measure against (matches
 # the dispatch guardrail's per_day_max). Spike ≥80% → soft; blowout ≥100% → hard.
 HERMES_DISPATCH_PER_DAY_MAX=10
+# O4-PR3 — autopilot auto-approval. Default OFF (supervised): autopilot is set by
+# the operator (board switch or "Hermes, you're in charge until 5pm"), bounded by
+# a stated time else a 4h safety cap, and reverts on expiry / D3-suspend / HALT.
+# When engaged it auto-approves DISPATCH only (never merge/deploy), and only for
+# repos on this allowlist, within the per-day/per-repo budget, low/medium-risk;
+# high-risk ALWAYS escalates to you. FAIL-CLOSED: empty allowlist ⇒ auto-approves
+# nothing. Run a SUPERVISED burn-in before you turn autopilot on.
+AVERRAY_AUTONOMY_MODE_PATH=/data/autonomy-mode.json
+HERMES_DISPATCH_ALLOWED_REPOS=
+HERMES_DISPATCH_PER_REPO_PER_DAY_MAX=5
 # Mission-spawn role gate (§21.5). Comma/space-separated Cloudflare Access
 # emails allowed to POST /monitor/testbed-missions. Leave both empty to keep
 # mission spawn unrestricted (relies on the edge gate + token only).

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -173,6 +173,14 @@ services:
       D3_ANOMALY_PAUSE_INTERVAL_MINUTES: ${D3_ANOMALY_PAUSE_INTERVAL_MINUTES:-1}
       AVERRAY_AUTOPILOT_SUSPENDED_PATH: ${AVERRAY_AUTOPILOT_SUSPENDED_PATH:-/data/autopilot-suspended.json}
       HERMES_DISPATCH_PER_DAY_MAX: ${HERMES_DISPATCH_PER_DAY_MAX:-10}
+      # O4-PR3 — autopilot auto-approval. Mode persisted on /data (default
+      # supervised). The auto-approval reuses the O4-PR1 dispatch guardrail, so
+      # slack-operator needs the allowlist + per-repo cap too. FAIL-CLOSED: an
+      # empty allowlist means autopilot can auto-approve NOTHING — the operator
+      # opts repos in here before turning autopilot on. high-risk always escalates.
+      AVERRAY_AUTONOMY_MODE_PATH: ${AVERRAY_AUTONOMY_MODE_PATH:-/data/autonomy-mode.json}
+      HERMES_DISPATCH_ALLOWED_REPOS: ${HERMES_DISPATCH_ALLOWED_REPOS:-}
+      HERMES_DISPATCH_PER_REPO_PER_DAY_MAX: ${HERMES_DISPATCH_PER_REPO_PER_DAY_MAX:-5}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}
       SLACK_OPERATOR_MONITOR_TOKEN: ${SLACK_OPERATOR_MONITOR_TOKEN:-}
       SLACK_ALLOWED_USER_IDS: ${SLACK_ALLOWED_USER_IDS:-}

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -32,6 +32,10 @@
     "./agent-invocation": {
       "types": "./dist/agent-invocation.d.ts",
       "import": "./dist/agent-invocation.js"
+    },
+    "./dispatch-policy": {
+      "types": "./dist/dispatch-policy.d.ts",
+      "import": "./dist/dispatch-policy.js"
     }
   },
   "scripts": {

--- a/services/slack-operator/src/autopilot-approve.ts
+++ b/services/slack-operator/src/autopilot-approve.ts
@@ -1,0 +1,185 @@
+// O4-PR3b — autopilot auto-approval: THE AUTHORITY CHANGE.
+//
+// When Hermes proposes a task, autopilot may approve it (proposed → approved,
+// approvedBy "hermes-autopilot") — but ONLY dispatch, and ONLY when every gate
+// holds. It NEVER merges or deploys (those stay human, always), and high-risk
+// surfaces ALWAYS escalate to the operator.
+//
+// Auto-approve iff ALL hold:
+//   - autopilot engaged (mode==autopilot AND now<until)            [PR3a]
+//   - NOT D3-suspended                                             [D3]
+//   - HALT_FILE absent                                             [kill switch]
+//   - dispatch policy allows (allowlist + within daily budget)     [O4-PR1]
+//   - riskTier != "high"  (high ALWAYS escalates)                  [O4-PR2]
+// Otherwise the task is LEFT PROPOSED for the operator. Supervised (autopilot
+// not engaged) is the silent default — no decision is recorded, every task just
+// waits for the operator exactly as before.
+//
+// Pure decision (decideAutoApproval) + effect-injected orchestrator
+// (runAutoApproval) so the authority matrix is unit-tested with no fs/network.
+
+import type { AlertPayload } from "./alert-bridge.js";
+import { evaluateDispatchPolicy, type DispatchPolicyConfig } from "@avg/averray-mcp/dispatch-policy";
+
+export interface AutoApprovalSignals {
+  /** mode==autopilot AND now<until (PR3a isAutopilotEngaged). */
+  engaged: boolean;
+  /** D3 autopilot-suspended flag. */
+  suspended: boolean;
+  /** HALT_FILE present. */
+  halt: boolean;
+  /** evaluateDispatchPolicy(...).allowed (allowlist + within daily budget). */
+  dispatchAllowed: boolean;
+  /** The machine reason from the dispatch policy (for the audit when blocked). */
+  dispatchReason?: string;
+  /** O4-PR2 routing tier. Anything other than "low" is treated as high (fail-safe). */
+  riskTier?: "high" | "low";
+}
+
+export type AutoApprovalReason =
+  | "supervised"
+  | "auto_approved"
+  | "high_risk_escalated"
+  | "autopilot_suspended"
+  | "halt_present"
+  | "dispatch_blocked";
+
+export interface AutoApprovalDecision {
+  /** Approve the task now (proposed → approved by hermes-autopilot). */
+  approve: boolean;
+  /** High-risk: always left for the operator AND alerted. */
+  escalate: boolean;
+  reason: AutoApprovalReason;
+  detail?: string;
+}
+
+/**
+ * Pure: the auto-approval authority matrix. High-risk is checked first so it
+ * ALWAYS escalates (and alerts) whenever autopilot is engaged. Everything else
+ * fails closed — any single failed gate leaves the task proposed.
+ */
+export function decideAutoApproval(s: AutoApprovalSignals): AutoApprovalDecision {
+  if (!s.engaged) return { approve: false, escalate: false, reason: "supervised" };
+  // High-risk surfaces (contracts/chain/settlement/secrets/migrations/deploy)
+  // ALWAYS escalate — autopilot never auto-approves them. Treat any non-"low"
+  // tier as high (fail-safe: an unclassified task is not auto-approved).
+  if (s.riskTier !== "low") {
+    return { approve: false, escalate: true, reason: "high_risk_escalated", detail: `riskTier=${s.riskTier ?? "unset"}` };
+  }
+  if (s.suspended) return { approve: false, escalate: false, reason: "autopilot_suspended" };
+  if (s.halt) return { approve: false, escalate: false, reason: "halt_present" };
+  if (!s.dispatchAllowed) {
+    return { approve: false, escalate: false, reason: "dispatch_blocked", detail: s.dispatchReason };
+  }
+  return { approve: true, escalate: false, reason: "auto_approved" };
+}
+
+export interface AutoApprovalTask {
+  id: string;
+  repo: string;
+  agent: "codex" | "claude";
+  riskTier?: "high" | "low";
+  routingReason?: string;
+  title?: string;
+}
+
+export interface AutoApprovalAudit {
+  taskId: string;
+  repo: string;
+  agent: string;
+  action: "approved" | "escalated" | "left_proposed";
+  reason: AutoApprovalReason;
+  detail?: string;
+  riskTier?: "high" | "low";
+}
+
+export interface AutoApprovalDeps {
+  task: AutoApprovalTask;
+  isEngaged: () => boolean;
+  isSuspended: () => boolean;
+  isHalt: () => boolean;
+  policy: DispatchPolicyConfig;
+  /** Autopilot-dispatched-today counts for the budget gate (global + per repo). */
+  counts: () => Promise<{ todayCount: number; todayRepoCount: number }>;
+  /** proposed → approved, approvedBy "hermes-autopilot". */
+  approve: (id: string, approvedBy: string) => Promise<unknown>;
+  /** D4 alert (fired ONLY on high-risk escalation). */
+  alert: (payload: AlertPayload) => Promise<boolean>;
+  /** Handoff/decision audit (every engaged decision). */
+  audit: (record: AutoApprovalAudit) => Promise<unknown> | unknown;
+  boardUrl: string;
+}
+
+export interface AutoApprovalResult {
+  action: "approved" | "escalated" | "left_proposed";
+  reason: AutoApprovalReason;
+  detail?: string;
+}
+
+const AUTOPILOT_APPROVER = "hermes-autopilot";
+
+/**
+ * Orchestrate a single proposed task through the autopilot gate. Supervised is
+ * a silent no-op (the task simply waits for the operator). When engaged: a
+ * passing low-risk task is auto-approved + audited; a high-risk task is left
+ * proposed + audited + ALERTED; any gate-block is left proposed + audited
+ * (no silent caps — the operator can see why autopilot didn't act).
+ */
+export async function runAutoApproval(deps: AutoApprovalDeps): Promise<AutoApprovalResult> {
+  const engaged = deps.isEngaged();
+  if (!engaged) return { action: "left_proposed", reason: "supervised" };
+
+  const suspended = deps.isSuspended();
+  const halt = deps.isHalt();
+  const { todayCount, todayRepoCount } = await deps.counts();
+  const dispatch = evaluateDispatchPolicy(deps.policy, {
+    repo: deps.task.repo,
+    agent: deps.task.agent,
+    todayCount,
+    todayRepoCount,
+  });
+
+  const decision = decideAutoApproval({
+    engaged,
+    suspended,
+    halt,
+    dispatchAllowed: dispatch.allowed,
+    dispatchReason: dispatch.reason,
+    ...(deps.task.riskTier ? { riskTier: deps.task.riskTier } : {}),
+  });
+
+  const baseAudit = {
+    taskId: deps.task.id,
+    repo: deps.task.repo,
+    agent: deps.task.agent,
+    reason: decision.reason,
+    ...(decision.detail ? { detail: decision.detail } : {}),
+    ...(deps.task.riskTier ? { riskTier: deps.task.riskTier } : {}),
+  };
+
+  if (decision.approve) {
+    await deps.approve(deps.task.id, AUTOPILOT_APPROVER);
+    await deps.audit({ ...baseAudit, action: "approved" });
+    return { action: "approved", reason: decision.reason };
+  }
+
+  if (decision.escalate) {
+    await deps.audit({ ...baseAudit, action: "escalated" });
+    await deps.alert(buildHighRiskEscalationAlert(deps.task, deps.boardUrl));
+    return { action: "escalated", reason: decision.reason, ...(decision.detail ? { detail: decision.detail } : {}) };
+  }
+
+  // Engaged but a gate blocked a low-risk task (suspended / halt / over-budget).
+  await deps.audit({ ...baseAudit, action: "left_proposed" });
+  return { action: "left_proposed", reason: decision.reason, ...(decision.detail ? { detail: decision.detail } : {}) };
+}
+
+export function buildHighRiskEscalationAlert(task: AutoApprovalTask, boardUrl: string): AlertPayload {
+  const label = task.title ? `"${task.title}"` : task.id;
+  const text =
+    `⚠️ Autopilot escalated a HIGH-RISK task to you — ${label} in ${task.repo} (${task.agent}). ` +
+    `Autopilot never auto-approves high-risk dispatch; approve or cancel it on the board.\n` +
+    (task.routingReason ? `Why high-risk: ${task.routingReason}\n` : "") +
+    `Board: ${boardUrl}`;
+  return { count: 1, items: [], boardUrl, text };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -74,8 +74,11 @@ import {
   readAutonomyState,
   setAutonomyMode,
   expireAutonomyIfDue,
+  isAutopilotEngaged,
   type AutonomyMode,
 } from "./autonomy-mode.js";
+import { runAutoApproval } from "./autopilot-approve.js";
+import { loadDispatchPolicyConfig } from "@avg/averray-mcp/dispatch-policy";
 import {
   isDebugSpawnEnabled,
   mergeDebugCards,
@@ -107,6 +110,8 @@ import {
   proposeCodexTask,
   readCodexRunnerHeartbeat,
   summarizeCodexTasks,
+  taskAgent,
+  type CodexTask,
 } from "./codex-task-queue.js";
 import { parseProposeTaskPayload } from "./codex-task-request.js";
 import {
@@ -1333,6 +1338,63 @@ async function handleMonitorRecheckRequest(request: http.IncomingMessage, respon
   }
 }
 
+// O4-PR3b — count tasks AUTOPILOT has dispatched today (global + per repo), for
+// the daily-budget gate. Only autopilot's own approvals count against its cap;
+// operator approvals are unbounded.
+async function computeAutopilotCountsToday(repo: string): Promise<{ todayCount: number; todayRepoCount: number }> {
+  const tasks = await listCodexTasks();
+  const today = new Date().toISOString().slice(0, 10);
+  const dispatched = tasks.filter(
+    (t) => t.approvedBy === "hermes-autopilot" && typeof t.approvedAt === "string" && t.approvedAt.slice(0, 10) === today,
+  );
+  return { todayCount: dispatched.length, todayRepoCount: dispatched.filter((t) => t.repo === repo).length };
+}
+
+// O4-PR3b — run a freshly-proposed task through the autopilot gate. Returns the
+// (possibly approved) task + the decision. Supervised → silent no-op.
+async function autoApproveProposedTask(task: CodexTask) {
+  let approvedTask: CodexTask | undefined;
+  const boardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
+  const autopilot = await runAutoApproval({
+    task: {
+      id: task.id,
+      repo: task.repo,
+      agent: taskAgent(task),
+      ...(task.riskTier ? { riskTier: task.riskTier } : {}),
+      ...(task.routingReason ? { routingReason: task.routingReason } : {}),
+      ...(task.title ? { title: task.title } : {}),
+    },
+    isEngaged: () => isAutopilotEngaged(),
+    isSuspended: () => isAutopilotSuspended(),
+    isHalt: () => isHaltFilePresent(),
+    policy: loadDispatchPolicyConfig(),
+    counts: () => computeAutopilotCountsToday(task.repo),
+    approve: async (id, approvedBy) => {
+      approvedTask = await approveCodexTask(id, { approvedBy });
+      return approvedTask;
+    },
+    alert: (payload) => slackAlertChannel().dispatch(payload),
+    audit: async (record) => {
+      await recordOperatorCommandEvent({
+        source: "slack_routine",
+        commandText: `autopilot ${record.action}: ${record.taskId}`,
+        result: {
+          kind: "autopilot_auto_approval",
+          ...record,
+          safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+        },
+      }, query).catch((error) => logger.warn({ err: error }, "o4_autopilot_audit_failed"));
+    },
+    boardUrl,
+  });
+  if (autopilot.action === "approved") {
+    logger.info({ taskId: task.id, repo: task.repo, agent: taskAgent(task) }, "o4_autopilot_auto_approved");
+  } else if (autopilot.action === "escalated") {
+    logger.info({ taskId: task.id, reason: autopilot.reason }, "o4_autopilot_escalated_high_risk");
+  }
+  return { task: approvedTask ?? task, autopilot };
+}
+
 async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, response: http.ServerResponse) {
   try {
     const rawBody = await readBody(request);
@@ -1354,11 +1416,21 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
         return;
       }
       const result = await proposeCodexTask(parsed.input);
+      // O4-PR3b — the authority: if autopilot is engaged, a passing low/medium-
+      // risk task auto-approves here; high-risk escalates; supervised is a no-op.
+      let task = result.task;
+      let autopilot: Awaited<ReturnType<typeof autoApproveProposedTask>>["autopilot"] | undefined;
+      if (result.created && task.status === "proposed") {
+        const outcome = await autoApproveProposedTask(task);
+        task = outcome.task;
+        autopilot = outcome.autopilot;
+      }
       writeJson(response, 200, {
         ok: true,
         action,
         created: result.created,
-        task: result.task,
+        task,
+        ...(autopilot ? { autopilot } : {}),
         queue: await loadCodexTaskQueueSummary(),
       });
       return;

--- a/test/unit/autopilot-approve.test.ts
+++ b/test/unit/autopilot-approve.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  decideAutoApproval,
+  runAutoApproval,
+  buildHighRiskEscalationAlert,
+  type AutoApprovalDeps,
+  type AutoApprovalTask,
+} from "../../services/slack-operator/src/autopilot-approve.js";
+import type { DispatchPolicyConfig } from "../../packages/averray-mcp/src/dispatch-policy.js";
+
+// ── pure decision matrix ────────────────────────────────────────────
+
+const base = { engaged: true, suspended: false, halt: false, dispatchAllowed: true, riskTier: "low" as const };
+
+describe("decideAutoApproval — the authority matrix (fail-closed)", () => {
+  it("supervised (not engaged) → never auto-approves, not an escalation", () => {
+    expect(decideAutoApproval({ ...base, engaged: false })).toMatchObject({ approve: false, escalate: false, reason: "supervised" });
+  });
+
+  it("engaged + low-risk + all gates pass → auto-approve", () => {
+    expect(decideAutoApproval(base)).toMatchObject({ approve: true, escalate: false, reason: "auto_approved" });
+  });
+
+  it("high-risk ALWAYS escalates — even with every other gate green", () => {
+    expect(decideAutoApproval({ ...base, riskTier: "high" })).toMatchObject({ approve: false, escalate: true, reason: "high_risk_escalated" });
+  });
+
+  it("an unclassified (missing) risk tier is treated as high → escalate (fail-safe)", () => {
+    expect(decideAutoApproval({ ...base, riskTier: undefined })).toMatchObject({ approve: false, escalate: true, reason: "high_risk_escalated" });
+  });
+
+  it("D3-suspended (low-risk) → left proposed, no escalation alert", () => {
+    expect(decideAutoApproval({ ...base, suspended: true })).toMatchObject({ approve: false, escalate: false, reason: "autopilot_suspended" });
+  });
+
+  it("HALT present (low-risk) → left proposed", () => {
+    expect(decideAutoApproval({ ...base, halt: true })).toMatchObject({ approve: false, escalate: false, reason: "halt_present" });
+  });
+
+  it("dispatch blocked (over-budget / not-allowlisted) → left proposed with the policy reason", () => {
+    expect(decideAutoApproval({ ...base, dispatchAllowed: false, dispatchReason: "daily_budget_exhausted" }))
+      .toMatchObject({ approve: false, escalate: false, reason: "dispatch_blocked", detail: "daily_budget_exhausted" });
+  });
+
+  it("high-risk wins over a suspended/halt low gate (still escalates)", () => {
+    expect(decideAutoApproval({ ...base, riskTier: "high", suspended: true, halt: true })).toMatchObject({ escalate: true, reason: "high_risk_escalated" });
+  });
+});
+
+// ── injected orchestrator ───────────────────────────────────────────
+
+const POLICY: DispatchPolicyConfig = {
+  allowedRepos: ["owner/repo"],
+  allowedAgents: ["codex", "claude"],
+  perDayMax: 10,
+  perRepoPerDayMax: 5,
+};
+
+const TASK: AutoApprovalTask = { id: "codex-task-1", repo: "owner/repo", agent: "claude", riskTier: "low", title: "tweak the UI" };
+
+interface Harness {
+  deps: AutoApprovalDeps;
+  approved: Array<{ id: string; approvedBy: string }>;
+  alerts: number;
+  audits: Array<{ action: string; reason: string; taskId: string }>;
+}
+
+function harness(over: Partial<AutoApprovalDeps> = {}, task: AutoApprovalTask = TASK): Harness {
+  const approved: Harness["approved"] = [];
+  const alerts = { n: 0 };
+  const audits: Harness["audits"] = [];
+  const deps: AutoApprovalDeps = {
+    task,
+    isEngaged: () => true,
+    isSuspended: () => false,
+    isHalt: () => false,
+    policy: POLICY,
+    counts: async () => ({ todayCount: 0, todayRepoCount: 0 }),
+    approve: async (id, approvedBy) => {
+      approved.push({ id, approvedBy });
+      return { id, status: "approved" };
+    },
+    alert: async () => {
+      alerts.n += 1;
+      return true;
+    },
+    audit: (record) => {
+      audits.push({ action: record.action, reason: record.reason, taskId: record.taskId });
+    },
+    boardUrl: "https://board.example/monitor",
+    ...over,
+  };
+  return { deps, approved, get alerts() { return alerts.n; }, audits };
+}
+
+describe("runAutoApproval — orchestration (injected effects, no fs/network)", () => {
+  it("supervised → SILENT no-op: no approve, no alert, no audit", async () => {
+    const h = harness({ isEngaged: () => false });
+    const r = await runAutoApproval(h.deps);
+    expect(r).toMatchObject({ action: "left_proposed", reason: "supervised" });
+    expect(h.approved).toHaveLength(0);
+    expect(h.alerts).toBe(0);
+    expect(h.audits).toHaveLength(0);
+  });
+
+  it("engaged + low-risk + within budget → auto-approve by hermes-autopilot, audited, NO alert", async () => {
+    const h = harness();
+    const r = await runAutoApproval(h.deps);
+    expect(r.action).toBe("approved");
+    expect(h.approved).toEqual([{ id: "codex-task-1", approvedBy: "hermes-autopilot" }]);
+    expect(h.audits).toEqual([{ action: "approved", reason: "auto_approved", taskId: "codex-task-1" }]);
+    expect(h.alerts).toBe(0); // routine auto-approval doesn't spam the operator
+  });
+
+  it("high-risk → escalate: NOT approved, audited, AND alerted", async () => {
+    const h = harness({}, { ...TASK, riskTier: "high" });
+    const r = await runAutoApproval(h.deps);
+    expect(r.action).toBe("escalated");
+    expect(h.approved).toHaveLength(0);
+    expect(h.audits[0]).toMatchObject({ action: "escalated", reason: "high_risk_escalated" });
+    expect(h.alerts).toBe(1);
+  });
+
+  it("D3-suspended → left proposed, no approve, no alert, audited with the reason", async () => {
+    const h = harness({ isSuspended: () => true });
+    const r = await runAutoApproval(h.deps);
+    expect(r).toMatchObject({ action: "left_proposed", reason: "autopilot_suspended" });
+    expect(h.approved).toHaveLength(0);
+    expect(h.alerts).toBe(0);
+    expect(h.audits[0]).toMatchObject({ action: "left_proposed", reason: "autopilot_suspended" });
+  });
+
+  it("HALT present → left proposed (no approve)", async () => {
+    const h = harness({ isHalt: () => true });
+    const r = await runAutoApproval(h.deps);
+    expect(r.reason).toBe("halt_present");
+    expect(h.approved).toHaveLength(0);
+  });
+
+  it("over the daily budget → left proposed via the real dispatch policy", async () => {
+    const h = harness({ counts: async () => ({ todayCount: 10, todayRepoCount: 5 }) });
+    const r = await runAutoApproval(h.deps);
+    expect(r.action).toBe("left_proposed");
+    expect(r.reason).toBe("dispatch_blocked");
+    expect(h.approved).toHaveLength(0);
+  });
+
+  it("a repo not on the allowlist → left proposed (fail-closed)", async () => {
+    const h = harness({}, { ...TASK, repo: "owner/not-allowed" });
+    const r = await runAutoApproval(h.deps);
+    expect(r.action).toBe("left_proposed");
+    expect(r.reason).toBe("dispatch_blocked");
+    expect(h.approved).toHaveLength(0);
+  });
+
+  it("the only mutation autopilot performs is dispatch approval — never merge/deploy", async () => {
+    const h = harness();
+    await runAutoApproval(h.deps);
+    // The sole effect is approveCodexTask(approvedBy hermes-autopilot); there is
+    // no merge/deploy effect in the deps surface at all.
+    expect(h.approved).toEqual([{ id: "codex-task-1", approvedBy: "hermes-autopilot" }]);
+  });
+});
+
+describe("buildHighRiskEscalationAlert", () => {
+  it("names the task + repo and says autopilot won't auto-approve high-risk", () => {
+    const alert = buildHighRiskEscalationAlert({ ...TASK, riskTier: "high", routingReason: "touches settlement" }, "https://board.example/monitor");
+    expect(alert.text).toMatch(/HIGH-RISK/);
+    expect(alert.text).toContain("owner/repo");
+    expect(alert.text).toContain("touches settlement");
+    expect(alert.text).toContain("https://board.example/monitor");
+  });
+});


### PR DESCRIPTION
## What changed & why

**The authority change** — and the final piece of O4. When Hermes proposes a task, **autopilot may now auto-approve it** (`proposed → approved`, `approvedBy: "hermes-autopilot"`) — but only **dispatch**, and only when **every gate** holds. It **never** merges or deploys (invariant #1), and **high-risk always escalates** to the operator.

Builds on **O4-PR3a (#288, merged)** — autonomy mode state + toggle. Per `docs/HERMES_ORCHESTRATION_DESIGN.md` §O4-D.

### The gate — `services/slack-operator/src/autopilot-approve.ts` (new)
Pure `decideAutoApproval` — **auto-approve iff ALL hold**:
- autopilot **engaged** (`mode==autopilot AND now<until`) — PR3a `isAutopilotEngaged`
- **not** D3-suspended — D3 `isAutopilotSuspended`
- `HALT_FILE` **absent** — kill switch
- dispatch policy **allows**: allowlist + within daily/per-repo budget — O4-PR1 `evaluateDispatchPolicy`
- `riskTier == "low"` — **high (or unset/unclassified) ALWAYS escalates** — O4-PR2

Fail-closed at every branch. `runAutoApproval` is the effect-injected orchestrator (approve / alert / audit).

### Wiring — the propose seam (`index.ts`)
Every freshly-proposed task runs the gate. **Supervised (the default) is a silent no-op** — the task waits for the operator exactly as before. The **autopilot daily budget** counts only autopilot's own approvals (`approvedBy: hermes-autopilot` today), reusing the O4-PR1 policy.

### Audit + alert
Every *engaged* decision writes a handoff/operator-command event (`approved` / `escalated` / `left_proposed` + reason). A **D4 alert fires on high-risk escalation** (mode-change alerts are PR3a's). Routine auto-approvals are audited, not alerted (no spam). Never logs secrets.

### Ops
slack-operator gains the dispatch **allowlist + per-repo cap + autonomy-mode path** so the gate has real config where the auto-approval runs. **FAIL-CLOSED:** empty `HERMES_DISPATCH_ALLOWED_REPOS` ⇒ autopilot auto-approves **nothing** until the operator opts repos in.

### AGENTS.md
Invariant #6 + the Hermes-powers + runner sections updated: dispatch-approval may be operator **or** autopilot *within rules*; merge/deploy stays human; high-risk always escalates; default off.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue (approval source)
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (996 passed; new: full authority matrix — pure + orchestrated)
- [x] compose validated by parsing `ops/compose.yml` (CI runs the real `docker compose … config`)

## Rollout / rollback
- **Default OFF, doubly gated:** supervised is the default (nothing auto-approves), **and** the dispatch allowlist is empty by default (autopilot can approve nothing even if engaged). Two explicit operator actions are needed: opt repos in **and** engage autopilot.
- **Burn-in discipline (operator, not this PR):** do NOT flip autopilot on immediately. Run supervised, watch Hermes's proposal + routing quality, then enable autopilot deliberately.
- New env (slack-operator): `HERMES_DISPATCH_ALLOWED_REPOS` (empty=deny), `HERMES_DISPATCH_PER_REPO_PER_DAY_MAX` (5), `AVERRAY_AUTONOMY_MODE_PATH` (`/data/autonomy-mode.json`).
- **Rollback:** `POST /monitor/autonomy-mode {mode:"supervised"}` (or let the window expire / clear the allowlist) → instant revert; or revert the PR.

## Durable invariants (AGENTS.md)
- [x] **No auto-merge / auto-deploy** — autopilot approves **dispatch only**; merge/deploy stays human (no merge/deploy effect exists in the deps surface)
- [x] `HALT_FILE` honored (present → never auto-approves); D3-suspend honored; high-risk always escalates; wallet untouched
- [x] **New power → new guardrail:** allowlist + budget + suspend/HALT/expiry + high-risk escalation; default off — invariant #6 updated
- [x] No secrets committed/printed/logged
- [x] **AGENTS.md updated in this PR** (the power change)

## Known limits / follow-ups
- The dispatch policy is read fresh per decision, so allowlist/budget changes take effect without a restart.
- Autopilot's daily budget is its own approvals only; operator approvals remain unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)