### PR TITLE
[claude] Add inter-agent collaboration channel support

### DIFF
--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -38,7 +38,7 @@
 | C1 | Cross-agent review (default) | design done |
 | C2 | Reviewer panel (high-risk) | design done |
 | C3 | Specialist agents (test-writer/security/docs) | design done |
-| C4 | Inter-agent chat | design done |
+| C4 | Inter-agent chat | 🟡 in review — Claude author/target + card-scoped agent messages |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
 | T2 | Pre-seeded session (authed sweep) | design done |
 | T3 | Signer sidecar + SIWE mission (multi-role) | 🟡 in review — signer sidecar done (#283); SIWE role-gating mission follow-up |
@@ -47,7 +47,7 @@
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | in review — manifest endpoint; platform helper follow-up |
 
-*(Status as of 2026-05-31 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), T3 (signer sidecar foundation), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D3 (anomaly auto-pause — unblocks O4-PR3) and T7 reference-agent manifest endpoint. **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C4, D1–D2, T2, T4–T6, and the T7 platform helper/AGENTS pointer. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
+*(Status as of 2026-05-31 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), T3 (signer sidecar foundation), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D3 (anomaly auto-pause — unblocks O4-PR3), C4 (inter-agent chat channel), and T7 reference-agent manifest endpoint. **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C3, D1–D2, T2, T4–T6, and the T7 platform helper/AGENTS pointer. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
@@ -29,6 +29,14 @@ describe("HermesTurn", () => {
     expect(getByText("Pascal")).toBeTruthy();
   });
 
+  test("Claude turns are attributed as agent messages", () => {
+    const { container, getByText } = render(
+      <HermesTurn turn={{ ...base, id: "claude-1", author: "claude", addressedTo: "codex" }} />,
+    );
+    expect(getByText("Claude")).toBeTruthy();
+    expect((container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--claude");
+  });
+
   test("a relatedPr renders a real GitHub PR link", () => {
     const { container } = render(
       <HermesTurn turn={{ ...base, id: "3", relatedPr: { repo: "depre-dev/agent", number: 548 } }} />,

--- a/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
@@ -6,6 +6,7 @@ import type { BoardCard } from "./card-types.js";
 test("actorLabel maps authors to display names", () => {
   assert.equal(actorLabel("hermes"), "Hermes");
   assert.equal(actorLabel("operator"), "Pascal");
+  assert.equal(actorLabel("claude"), "Claude");
   assert.equal(actorLabel("codex"), "Codex");
   assert.equal(actorLabel("system"), "System");
 });

--- a/packages/monitor-ui/src/lib/monitor/collaboration.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.ts
@@ -1,15 +1,15 @@
 // Hermes Handoff Monitor — collaboration feed types + helpers (M8').
 //
-// The co-pilot rail renders the operator ↔ Hermes ↔ Codex collaboration
+// The co-pilot rail renders the operator ↔ Hermes ↔ Codex/Claude collaboration
 // feed served by slack-operator's /monitor/collaboration. This is the
 // frontend's copy of the contract (they cross an HTTP/JSON boundary, so
 // the declarations are intentionally independent, like card-types.ts).
 
 import type { BoardCard } from "./card-types.js";
 
-export type CollaborationAuthor = "codex" | "hermes" | "operator" | "system";
+export type CollaborationAuthor = "claude" | "codex" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
-export type CollaborationTarget = "everyone" | "codex" | "hermes" | "operator";
+export type CollaborationTarget = "everyone" | "claude" | "codex" | "hermes" | "operator";
 
 export interface CollaborationRelatedPr {
   repo: string;
@@ -31,6 +31,7 @@ export interface CollaborationMessage {
 export function actorLabel(author: CollaborationAuthor): string {
   if (author === "hermes") return "Hermes";
   if (author === "operator") return "Pascal";
+  if (author === "claude") return "Claude";
   if (author === "codex") return "Codex";
   return "System";
 }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -943,7 +943,9 @@ body { margin: 0; }
 .hm-turn-actor .actor-dot { width: 7px; height: 7px; border-radius: 999px; }
 .hm-turn--hermes  .actor-dot { background: var(--hm-hermes); }
 .hm-turn--operator .actor-dot { background: var(--hm-ink); }
-.hm-turn--codex   .actor-dot { background: var(--hm-clay); }
+.hm-turn--codex   .actor-dot { background: #6b8a4e; }
+.hm-turn--claude  .actor-dot { background: var(--hm-clay); }
+.hm-turn--system  .actor-dot { background: var(--hm-muted-soft); }
 .hm-turn-time {
   margin-left: auto;
   font-family: var(--font-mono);

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -32,13 +32,13 @@ const SOFT_TTL_MS = 24 * 60 * 60 * 1000;
 const HERMES_MEMORY_MAX_NOTES = 120;
 const HERMES_MEMORY_NOTE_MAX_CHARS = 320;
 
-const KNOWN_AUTHORS = new Set(["codex", "hermes", "operator", "system"] as const);
+const KNOWN_AUTHORS = new Set(["claude", "codex", "hermes", "operator", "system"] as const);
 const KNOWN_KINDS = new Set(["chat", "proposal", "request_help", "status"] as const);
-const KNOWN_TARGETS = new Set(["everyone", "codex", "hermes", "operator"] as const);
+const KNOWN_TARGETS = new Set(["everyone", "claude", "codex", "hermes", "operator"] as const);
 
-export type CollaborationAuthor = "codex" | "hermes" | "operator" | "system";
+export type CollaborationAuthor = "claude" | "codex" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
-export type CollaborationTarget = "everyone" | "codex" | "hermes" | "operator";
+export type CollaborationTarget = "everyone" | "claude" | "codex" | "hermes" | "operator";
 
 export interface CollaborationRelatedPr {
   repo: string;
@@ -115,7 +115,7 @@ export function recordCollaborationMessage(
   if (!author) {
     throw new CollaborationValidationError(
       "invalid_author",
-      "author must be one of: codex, hermes, operator, system."
+      "author must be one of: claude, codex, hermes, operator, system."
     );
   }
 
@@ -128,7 +128,13 @@ export function recordCollaborationMessage(
   }
 
   const kind = normalizeKind(input.kind) ?? "chat";
-  const addressedTo = normalizeTarget(input.addressedTo) ?? "everyone";
+  const addressedTo = normalizeTarget(input.addressedTo);
+  if (addressedTo === null && hasExplicitTarget(input.addressedTo)) {
+    throw new CollaborationValidationError(
+      "invalid_target",
+      "addressedTo must be one of: everyone, claude, codex, hermes, operator."
+    );
+  }
   const relatedPr = normalizeRelatedPr(input.relatedPr);
   const relatedCorrelationId = normalizeCorrelationId(input.relatedCorrelationId);
 
@@ -138,7 +144,7 @@ export function recordCollaborationMessage(
     author,
     kind,
     text,
-    addressedTo,
+    addressedTo: addressedTo ?? "everyone",
     ...(relatedPr ? { relatedPr } : {}),
     ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
   };
@@ -229,6 +235,12 @@ function normalizeTarget(value: unknown): CollaborationTarget | null {
   if (typeof value !== "string") return null;
   const v = value.trim().toLowerCase();
   return (KNOWN_TARGETS as Set<string>).has(v) ? (v as CollaborationTarget) : null;
+}
+
+function hasExplicitTarget(value: unknown): boolean {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  return true;
 }
 
 function normalizeText(value: unknown): string {

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -54,6 +54,32 @@ describe("monitor collaboration channel", () => {
     });
   });
 
+  it("accepts Claude as a card-scoped agent author and target", () => {
+    const message = recordCollaborationMessage(
+      {
+        author: "Claude",
+        kind: "status",
+        addressedTo: "Codex",
+        text: "Codex, I reviewed this card and need a smaller repro before I can continue.",
+        relatedPr: { repo: "averray-agent/agent", number: 214 },
+      },
+      NOW
+    );
+
+    expect(message).toMatchObject({
+      author: "claude",
+      kind: "status",
+      addressedTo: "codex",
+      text: expect.stringContaining("smaller repro"),
+      relatedPr: { repo: "averray-agent/agent", number: 214 },
+    });
+    expect(listCollaborationMessages({ limit: 1 }, NOW + 1)[0]).toMatchObject({
+      author: "claude",
+      addressedTo: "codex",
+      relatedPr: { repo: "averray-agent/agent", number: 214 },
+    });
+  });
+
   it("preserves relatedPr and relatedCorrelationId when well-formed", () => {
     const message = recordCollaborationMessage(
       {
@@ -101,13 +127,22 @@ describe("monitor collaboration channel", () => {
     expect(message.text).toHaveLength(4_000);
   });
 
-  it("falls back to chat/everyone when kind/addressedTo are unknown", () => {
+  it("falls back to chat when kind is unknown", () => {
     const message = recordCollaborationMessage(
-      { author: "operator", text: "hi", kind: "rant", addressedTo: "everybody" },
+      { author: "operator", text: "hi", kind: "rant" },
       NOW
     );
     expect(message.kind).toBe("chat");
     expect(message.addressedTo).toBe("everyone");
+  });
+
+  it("rejects unknown targets instead of silently broadcasting", () => {
+    expect(() =>
+      recordCollaborationMessage(
+        { author: "claude", text: "Codex, can you clarify this?", addressedTo: "everybody" },
+        NOW
+      )
+    ).toThrowError(CollaborationValidationError);
   });
 
   it("lists messages newest-last and respects limit", () => {
@@ -505,6 +540,14 @@ describe("synthesizeHermesReplyFor", () => {
   it("does not reply to messages from non-operator authors", () => {
     const m = recordCollaborationMessage(
       { author: "codex", text: "I picked up #1.", addressedTo: "hermes" },
+      NOW
+    );
+    expect(synthesizeHermesReplyFor(m)).toBeNull();
+  });
+
+  it("does not auto-reply to Claude agent messages", () => {
+    const m = recordCollaborationMessage(
+      { author: "claude", text: "Hermes, please hold this until Codex replies.", addressedTo: "hermes" },
       NOW
     );
     expect(synthesizeHermesReplyFor(m)).toBeNull();


### PR DESCRIPTION
## What changed
- Added Claude as a first-class collaboration author and target in the monitor channel contract.
- Tightened collaboration target validation so unknown addressedTo values are rejected instead of silently broadcasting to everyone.
- Updated the co-pilot turn attribution/coloring so Claude-authored messages render as Claude, while preserving operator/Hermes behavior.
- Updated the C4 roadmap row to in-review.

## Checks
- npm run typecheck
- npm test
- git diff --check

## Surface
- Backend: slack-operator collaboration validation/model only
- Frontend: monitor collaboration turn attribution only
- Ops/contracts/indexer/public site: no changes

## Notes
- No authority change: this only enables card-scoped agent-authored messages in the collaboration channel. It does not add auto-replies or autonomous agent behavior.