### PR TITLE
T2: pre-seeded session — authed surface sweep

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -69,6 +69,21 @@ TESTBED_AUTH_ADMIN_JOBS_PATH=/admin/jobs
 TESTBED_AUTH_VERIFIER_RUN_PATH=/verifier/run
 TESTBED_AUTH_PROTECTED_PATH=/admin/jobs
 
+# T2 pre-seeded session: lets the surface sweep reach the AUTHED operator pages
+# (overview/runs/sessions/receipts/treasury/disputes/policies/agents/audit-log/
+# capabilities), not just public ones. Two sources, either works:
+#   (a) the T3 signer sidecar — set SIGNER_URL (+ ROLE/TYPE); the key stays in
+#       the sidecar, never here. e.g. http://test-wallet-signer:8791
+#   (b) a manually-provided storageState file and/or Bearer token (decoupled for
+#       landing, before the sidecar is wired). These are SECRETS — never logged.
+# ALL EMPTY ⇒ the sweep runs public-only (it never fails just for a missing
+# session). Read-only throughout.
+TESTBED_SESSION_SIGNER_URL=
+TESTBED_SESSION_ROLE=agent
+TESTBED_SESSION_TYPE=browser
+TESTBED_SESSION_STORAGE_STATE_PATH=
+TESTBED_SESSION_TOKEN=
+
 # T3 signer sidecar (ops profile "test-wallet-signer"; off by default).
 # Holds fixed, operator-provisioned testnet role wallets and returns cached API
 # JWTs or Playwright browser storageState. These are secrets: never log them.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -241,10 +241,20 @@ services:
       AVERRAY_APP_BASE_URL: ${AVERRAY_APP_BASE_URL:-}
       AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL:-}
       AVERRAY_TESTBED_EXPECTED_BOUNDARY: ${AVERRAY_TESTBED_EXPECTED_BOUNDARY:-}
+      # T3b SIWE auth mission: the sidecar base URL + the role-gated probe paths.
       TEST_WALLET_SIGNER_BASE_URL: ${TEST_WALLET_SIGNER_BASE_URL:-http://test-wallet-signer:8791}
       TESTBED_AUTH_ADMIN_JOBS_PATH: ${TESTBED_AUTH_ADMIN_JOBS_PATH:-/admin/jobs}
       TESTBED_AUTH_VERIFIER_RUN_PATH: ${TESTBED_AUTH_VERIFIER_RUN_PATH:-/verifier/run}
       TESTBED_AUTH_PROTECTED_PATH: ${TESTBED_AUTH_PROTECTED_PATH:-/admin/jobs}
+      # T2 pre-seeded session: lets the surface sweep reach the AUTHED operator
+      # pages. Source (a) the T3 signer sidecar (SIGNER_URL + ROLE), or (b) a
+      # manually-provided storageState path / Bearer token. ALL EMPTY ⇒ the
+      # sweep runs public-only (graceful fallback). Read-only; never logs secrets.
+      TESTBED_SESSION_SIGNER_URL: ${TESTBED_SESSION_SIGNER_URL:-}
+      TESTBED_SESSION_ROLE: ${TESTBED_SESSION_ROLE:-agent}
+      TESTBED_SESSION_TYPE: ${TESTBED_SESSION_TYPE:-browser}
+      TESTBED_SESSION_STORAGE_STATE_PATH: ${TESTBED_SESSION_STORAGE_STATE_PATH:-}
+      TESTBED_SESSION_TOKEN: ${TESTBED_SESSION_TOKEN:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-data:/data

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -16,6 +16,12 @@ import {
 } from "./monitor-testbed-missions.js";
 import { executeSiweAuthMission, type SiweAuthMissionDeps } from "./testbed-auth-mission.js";
 import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
+import {
+  parseSweepSessionConfig,
+  resolveSweepSession,
+  type SweepSession,
+  type SweepSessionConfig,
+} from "./testbed-session.js";
 
 export interface TestbedMissionRunnerConfig {
   enabled: boolean;
@@ -42,6 +48,13 @@ export interface TestbedMissionRunnerConfig {
   authProtectedPath?: string;
   /** The env's truth boundary the sweep asserts surfaces label (demo/testnet/local-simulation/production). */
   expectedBoundary?: string;
+  /** T2 pre-seeded session source (sidecar URL and/or manual storageState path/token). */
+  session?: SweepSessionConfig;
+}
+
+/** Injected session resolution for tests (defaults to the env-config resolver). */
+export interface BrowserMissionDeps extends SurfaceSweepDeps {
+  resolveSession?: (config: TestbedMissionRunnerConfig) => Promise<SweepSession | undefined>;
 }
 
 export interface TestbedMissionRunResult {
@@ -90,6 +103,7 @@ export function parseTestbedMissionRunnerConfig(
     authVerifierRunPath: env.TESTBED_AUTH_VERIFIER_RUN_PATH || "/verifier/run",
     authProtectedPath: env.TESTBED_AUTH_PROTECTED_PATH || env.TESTBED_AUTH_ADMIN_JOBS_PATH || "/admin/jobs",
     ...(env.AVERRAY_TESTBED_EXPECTED_BOUNDARY ? { expectedBoundary: env.AVERRAY_TESTBED_EXPECTED_BOUNDARY } : {}),
+    session: parseSweepSessionConfig(env),
   };
 }
 
@@ -292,15 +306,35 @@ export async function executeTestbedMissionCommand(
 export async function executeBrowserTestbedMission(
   mission: TestbedMissionRun,
   config: TestbedMissionRunnerConfig,
-  deps: SurfaceSweepDeps & SiweAuthMissionDeps = {}
+  deps: BrowserMissionDeps & SiweAuthMissionDeps = {}
 ): Promise<TestbedMissionRunResult> {
   if (mission.mode === "surface_sweep") {
-    return executeSurfaceSweep(mission, config, deps);
+    // T2: resolve the pre-seeded session (sidecar or manual) so the sweep can
+    // reach authed routes. No session → public-only (graceful fallback).
+    const resolveSession = deps.resolveSession ?? defaultResolveSweepSession;
+    const session = await resolveSession(config);
+    // Drop the SweepSessionConfig (env source) and pass the RESOLVED session.
+    const { session: _sessionConfig, ...sweepConfig } = config;
+    return executeSurfaceSweep(mission, { ...sweepConfig, ...(session ? { session } : {}) }, deps);
   }
   if (mission.mode === "siwe_auth") {
     return executeSiweAuthMission(mission, config, deps);
   }
   return executePlaywrightTestbedMission(mission, config);
+}
+
+/** Default session resolver: pull from the env-configured sidecar or manual
+ *  storageState path/token. Never throws — degrades to undefined (public-only). */
+async function defaultResolveSweepSession(
+  config: TestbedMissionRunnerConfig,
+): Promise<SweepSession | undefined> {
+  if (!config.session) return undefined;
+  return resolveSweepSession(config.session, {
+    readFileImpl: async (path) => {
+      const { readFile } = await import("node:fs/promises");
+      return readFile(path, "utf8");
+    },
+  });
 }
 
 export async function executePlaywrightTestbedMission(

--- a/services/slack-operator/src/testbed-session.ts
+++ b/services/slack-operator/src/testbed-session.ts
@@ -1,0 +1,218 @@
+// Hermes e2e tester — T2 pre-seeded session.
+//
+// Wires a real auth session into the surface sweep so the per-deploy tester can
+// reach the AUTHED operator app, not just public pages. READ-ONLY: the session
+// only authenticates navigation; nothing is mutated.
+//
+// Two session sources, decoupled for landing (per the auth design):
+//   (a) the T3 signer sidecar — GET /session/:role?type=browser → storageState
+//       (and ?type=api → Bearer JWT); the key never enters this process.
+//   (b) a manually-provided storageState (a file path) and/or Bearer token, so
+//       authed sweep works before the sidecar is wired in a given env.
+//
+// Graceful by design: with NO session configured, resolution returns undefined
+// and the sweep runs public-only. A malformed/unreachable source degrades to
+// undefined too — never throws, never fails the sweep just because a session is
+// absent. Secrets (storageState cookies, Bearer tokens) are NEVER logged.
+
+export type SweepSessionRole = "agent" | "admin" | "verifier";
+
+/** A Playwright storageState (cookies + origins). Kept structural so this module
+ *  doesn't couple to the signer service's types. */
+export interface SweepStorageState {
+  cookies: unknown[];
+  origins: unknown[];
+}
+
+/** A resolved session the sweep can use: storageState for the browser context,
+ *  and/or a Bearer token for API checks. */
+export interface SweepSession {
+  role: SweepSessionRole;
+  storageState?: SweepStorageState;
+  token?: string;
+}
+
+export interface SweepSessionConfig {
+  /** Which role's session to use (default "agent"). */
+  role?: string;
+  /** "browser" (storageState, default) or "api" (Bearer) when pulling from the sidecar. */
+  sessionType?: "browser" | "api";
+  /** T3 signer sidecar base URL, e.g. http://test-wallet-signer:8791. */
+  signerBaseUrl?: string;
+  /** Manual storageState file path (decoupled-for-landing source). */
+  storageStatePath?: string;
+  /** Manual Bearer token (secret; never logged). */
+  token?: string;
+}
+
+export interface SweepSessionDeps {
+  /** Injected for tests. Defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Injected for tests. Defaults to fs/promises readFile (utf8). */
+  readFileImpl?: (path: string) => Promise<string>;
+  /** Non-throwing warning sink (never receives secrets). */
+  warn?: (message: string, detail?: Record<string, unknown>) => void;
+}
+
+/** The default AUTHED operator routes the sweep covers once a session is present
+ *  (per docs/HERMES_E2E_TESTER_DESIGN.md). Override per-mission with `routes`. */
+export const DEFAULT_AUTHED_ROUTES = [
+  "/overview",
+  "/runs",
+  "/sessions",
+  "/receipts",
+  "/treasury",
+  "/disputes",
+  "/policies",
+  "/agents",
+  "/audit-log",
+  "/capabilities",
+];
+
+export function parseSweepSessionRole(value: string | undefined): SweepSessionRole {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "admin":
+      return "admin";
+    case "verifier":
+      return "verifier";
+    case "agent":
+    default:
+      return "agent";
+  }
+}
+
+export function parseSweepSessionConfig(env: NodeJS.ProcessEnv = process.env): SweepSessionConfig {
+  return {
+    ...(env.TESTBED_SESSION_ROLE ? { role: env.TESTBED_SESSION_ROLE } : {}),
+    sessionType: env.TESTBED_SESSION_TYPE === "api" ? "api" : "browser",
+    ...(env.TESTBED_SESSION_SIGNER_URL ? { signerBaseUrl: env.TESTBED_SESSION_SIGNER_URL } : {}),
+    ...(env.TESTBED_SESSION_STORAGE_STATE_PATH ? { storageStatePath: env.TESTBED_SESSION_STORAGE_STATE_PATH } : {}),
+    ...(env.TESTBED_SESSION_TOKEN ? { token: env.TESTBED_SESSION_TOKEN } : {}),
+  };
+}
+
+/** Whether any session source is configured. When false, the sweep runs
+ *  public-only (no fetch / no fs touched). */
+export function isSweepSessionConfigured(config: SweepSessionConfig): boolean {
+  return Boolean(config.signerBaseUrl || config.storageStatePath || config.token);
+}
+
+/** Validate an unknown value as a Playwright storageState ({ cookies[], origins[] }). */
+export function normalizeStorageState(value: unknown): SweepStorageState | undefined {
+  if (typeof value !== "object" || value === null) return undefined;
+  const record = value as Record<string, unknown>;
+  const cookies = record.cookies;
+  const origins = record.origins;
+  if (!Array.isArray(cookies) || !Array.isArray(origins)) return undefined;
+  return { cookies, origins };
+}
+
+/**
+ * Resolve a session from the configured source(s). Manual path/token take
+ * precedence (no network), then the sidecar. Returns undefined when nothing is
+ * configured or any source degrades — NEVER throws.
+ */
+export async function resolveSweepSession(
+  config: SweepSessionConfig,
+  deps: SweepSessionDeps = {},
+): Promise<SweepSession | undefined> {
+  if (!isSweepSessionConfigured(config)) return undefined;
+  const warn = deps.warn ?? (() => {});
+  const role = parseSweepSessionRole(config.role);
+
+  // (b) Manual storageState file — decoupled-for-landing source.
+  if (config.storageStatePath) {
+    const storageState = await readManualStorageState(config.storageStatePath, deps, warn);
+    if (storageState) {
+      return { role, storageState, ...(config.token ? { token: config.token } : {}) };
+    }
+    // Fall through: a bad manual file shouldn't strand a configured token/sidecar.
+  }
+
+  // (b) Manual token only (API checks) — no storageState available.
+  if (config.token && !config.signerBaseUrl) {
+    return { role, token: config.token };
+  }
+
+  // (a) The T3 signer sidecar.
+  if (config.signerBaseUrl) {
+    return fetchSidecarSession(config, role, deps, warn);
+  }
+
+  return undefined;
+}
+
+async function readManualStorageState(
+  path: string,
+  deps: SweepSessionDeps,
+  warn: NonNullable<SweepSessionDeps["warn"]>,
+): Promise<SweepStorageState | undefined> {
+  try {
+    const readFileImpl = deps.readFileImpl ?? (async (p: string) => {
+      const { readFile } = await import("node:fs/promises");
+      return readFile(p, "utf8");
+    });
+    const raw = await readFileImpl(path);
+    const storageState = normalizeStorageState(JSON.parse(raw));
+    if (!storageState) {
+      warn("testbed_session_manual_storage_state_malformed"); // no path/secret in the log
+      return undefined;
+    }
+    return storageState;
+  } catch {
+    warn("testbed_session_manual_storage_state_unreadable");
+    return undefined;
+  }
+}
+
+async function fetchSidecarSession(
+  config: SweepSessionConfig,
+  role: SweepSessionRole,
+  deps: SweepSessionDeps,
+  warn: NonNullable<SweepSessionDeps["warn"]>,
+): Promise<SweepSession | undefined> {
+  const type = config.sessionType === "api" ? "api" : "browser";
+  const base = (config.signerBaseUrl ?? "").replace(/\/+$/, "");
+  const url = `${base}/session/${role}?type=${type}`;
+  try {
+    const fetchImpl = deps.fetchImpl ?? fetch;
+    const res = await fetchImpl(url);
+    if (!res.ok) {
+      warn("testbed_session_sidecar_non_ok", { status: res.status, role });
+      return undefined;
+    }
+    const body = (await res.json()) as Record<string, unknown>;
+    if (type === "browser") {
+      const storageState = normalizeStorageState(body.storageState);
+      if (!storageState) {
+        warn("testbed_session_sidecar_missing_storage_state", { role });
+        return undefined;
+      }
+      return { role, storageState };
+    }
+    const token = typeof body.token === "string" && body.token.length > 0 ? body.token : undefined;
+    if (!token) {
+      warn("testbed_session_sidecar_missing_token", { role });
+      return undefined;
+    }
+    return { role, token };
+  } catch {
+    // Unreachable sidecar must not fail the sweep — degrade to public-only.
+    warn("testbed_session_sidecar_unreachable", { role });
+    return undefined;
+  }
+}
+
+/**
+ * Build the Playwright newContext() options for a sweep, layering in the
+ * session: storageState rehydrates the authed browser; a Bearer token is
+ * attached so the page's same-origin API calls are authed too. Pure + tested.
+ */
+export function buildSweepContextOptions(session?: SweepSession): Record<string, unknown> {
+  return {
+    viewport: { width: 1365, height: 900 },
+    userAgent: "Averray-Hermes-Surface-Sweep/1.0",
+    ...(session?.storageState ? { storageState: session.storageState } : {}),
+    ...(session?.token ? { extraHTTPHeaders: { Authorization: `Bearer ${session.token}` } } : {}),
+  };
+}

--- a/services/slack-operator/src/testbed-surface-sweep.ts
+++ b/services/slack-operator/src/testbed-surface-sweep.ts
@@ -15,6 +15,11 @@
 
 import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
 import type { TestbedMissionRunResult } from "./testbed-mission-runner.js";
+import {
+  DEFAULT_AUTHED_ROUTES,
+  buildSweepContextOptions,
+  type SweepSession,
+} from "./testbed-session.js";
 
 /** The environment's truth — what marker a data-bearing surface must carry. */
 export type SweepBoundary =
@@ -176,13 +181,18 @@ export function sweepVerdict(captures: RouteCapture[], findings: HonestyFinding[
   return "pass";
 }
 
-/** Resolve the routes to sweep. mission.routes overrides the public default;
- *  relative routes are joined to the configured app base URL. */
+/** Resolve the routes to sweep. mission.routes overrides the default; otherwise
+ *  the default is the public routes, plus the AUTHED operator routes when a
+ *  session is present (`includeAuthed`). Relative routes join the app base URL. */
 export function resolveSweepRoutes(
   routes: string[] | undefined,
   baseUrl: string | undefined,
+  opts: { includeAuthed?: boolean } = {},
 ): Array<{ route: string; url: string }> {
-  const list = routes && routes.length > 0 ? routes : DEFAULT_PUBLIC_ROUTES;
+  const defaults = opts.includeAuthed
+    ? [...DEFAULT_PUBLIC_ROUTES, ...DEFAULT_AUTHED_ROUTES]
+    : DEFAULT_PUBLIC_ROUTES;
+  const list = routes && routes.length > 0 ? routes : defaults;
   const base = (baseUrl ?? "").replace(/\/+$/, "");
   return list.map((route) => {
     if (/^https?:\/\//i.test(route)) return { route, url: route };
@@ -321,11 +331,18 @@ export function resolveExpectedBoundary(value: string | undefined): SweepBoundar
  */
 export async function executeSurfaceSweep(
   mission: TestbedMissionRun,
-  config: { appBaseUrl?: string; expectedBoundary?: string; browserExecutablePath?: string; timeoutMs?: number; artifactsDir?: string },
+  config: { appBaseUrl?: string; expectedBoundary?: string; browserExecutablePath?: string; timeoutMs?: number; artifactsDir?: string; session?: SweepSession },
   deps: SurfaceSweepDeps = {},
 ): Promise<TestbedMissionRunResult> {
   const expectedBoundary = resolveExpectedBoundary(config.expectedBoundary);
-  const resolved = resolveSweepRoutes(mission.routes, config.appBaseUrl ?? originOf(mission.targetUrl));
+  // With a session, the default route set extends to the authed operator pages;
+  // without one, the sweep stays public-only (graceful fallback — never fails
+  // just because a session is absent).
+  const resolved = resolveSweepRoutes(
+    mission.routes,
+    config.appBaseUrl ?? originOf(mission.targetUrl),
+    { includeAuthed: Boolean(config.session) },
+  );
   const capture = deps.captureRoute ?? makeBrowserCapture(config);
 
   const captures: RouteCapture[] = [];
@@ -372,6 +389,7 @@ function originOf(url: string | undefined): string | undefined {
 function makeBrowserCapture(config: {
   browserExecutablePath?: string;
   timeoutMs?: number;
+  session?: SweepSession;
 }): (url: string, route: string) => Promise<RouteCapture> {
   return async (url, route) => {
     const { chromium } = await import("playwright-core");
@@ -384,10 +402,9 @@ function makeBrowserCapture(config: {
     const networkFailures: string[] = [];
     const badResponses: string[] = [];
     try {
-      const context = await browser.newContext({
-        viewport: { width: 1365, height: 900 },
-        userAgent: "Averray-Hermes-Surface-Sweep/1.0",
-      });
+      // Pre-seeded session (T2): storageState rehydrates the authed browser; a
+      // Bearer (if any) authes the page's same-origin API calls. Read-only.
+      const context = await browser.newContext(buildSweepContextOptions(config.session));
       const page = await context.newPage();
       page.on("console", (m) => {
         if (m.type() === "error") consoleErrors.push(m.text());

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -1,4 +1,5 @@
 import type { TestbedMissionRunnerHeartbeat } from "./monitor-testbed-missions.js";
+import { isSweepSessionConfigured, parseSweepSessionConfig } from "./testbed-session.js";
 
 export interface TesterCapabilitiesDeps {
   now?: Date;
@@ -12,6 +13,10 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
   const runnerEnabled = truthy(env.TESTBED_MISSION_RUNNER_ENABLED);
   const signerEnabled = truthy(env.TEST_WALLET_SIGNER_ENABLED);
   const runnerExecutor = env.TESTBED_MISSION_RUNNER_EXECUTOR || "playwright";
+  // T2: the runner now injects a pre-seeded session into the sweep. The authed
+  // sweep is genuinely available once a session SOURCE is configured (the
+  // signer sidecar URL, or a manual storageState path / token).
+  const sessionConfigured = isSweepSessionConfigured(parseSweepSessionConfig(env as NodeJS.ProcessEnv));
 
   return {
     schemaVersion: 1,
@@ -45,7 +50,10 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
       runnerExecutor,
       runner: deps.runner ?? null,
       signerSidecarEnabled: signerEnabled,
-      authedSessionSource: signerEnabled ? "test-wallet-signer sidecar" : "not currently advertised",
+      authedSessionConfigured: sessionConfigured,
+      authedSessionSource: sessionConfigured
+        ? (env.TESTBED_SESSION_SIGNER_URL ? "test-wallet-signer sidecar" : "manual storageState/token")
+        : (signerEnabled ? "signer sidecar available; set TESTBED_SESSION_SIGNER_URL on the runner" : "not configured"),
     },
     safety: {
       agentRequestedDefault: "read_only",
@@ -93,15 +101,21 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
       },
       {
         id: "authed_surface_sweep",
-        status: signerEnabled ? "session_source_available" : "planned",
+        status: sessionConfigured ? "available" : "ready_needs_session",
         tier: 1,
         scope: "read_only",
         mutation: "never",
         supportedEnvs: ["testnet", "mainnet-read-only"],
-        dependsOn: ["T2 pre-seeded session runner wiring", "T3 signer sidecar"],
-        note: signerEnabled
-          ? "The signer sidecar can mint sessions, but runner session injection is still a separate capability."
-          : "Requires the signer sidecar and runner session injection before agents should rely on it.",
+        request: {
+          body: {
+            mode: "surface_sweep",
+            targetUrl: "https://app.example",
+            requester: "agent-name",
+          },
+        },
+        note: sessionConfigured
+          ? "Runner session injection (T2) is wired and a session source is configured: the sweep covers the authed operator pages (overview/runs/sessions/receipts/treasury/disputes/policies/agents/audit-log/capabilities) and applies the boundary-honesty check there. Read-only."
+          : "Runner session injection (T2) is wired; set a session source on the runner (TESTBED_SESSION_SIGNER_URL via the T3 sidecar, or a manual TESTBED_SESSION_STORAGE_STATE_PATH/TOKEN). Until then the sweep runs public-only.",
       },
       {
         id: "siwe_auth_role_gating",

--- a/test/unit/testbed-session.test.ts
+++ b/test/unit/testbed-session.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  parseSweepSessionConfig,
+  parseSweepSessionRole,
+  isSweepSessionConfigured,
+  normalizeStorageState,
+  resolveSweepSession,
+  buildSweepContextOptions,
+  DEFAULT_AUTHED_ROUTES,
+  type SweepStorageState,
+} from "../../services/slack-operator/src/testbed-session.js";
+
+const STORAGE: SweepStorageState = {
+  cookies: [{ name: "session", value: "x", domain: "app.example", path: "/" }],
+  origins: [],
+};
+
+function okJson(body: unknown): typeof fetch {
+  return vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })) as unknown as typeof fetch;
+}
+
+describe("parseSweepSessionConfig / role", () => {
+  it("reads the env source fields; defaults type=browser", () => {
+    const cfg = parseSweepSessionConfig({
+      TESTBED_SESSION_SIGNER_URL: "http://signer:8791",
+      TESTBED_SESSION_ROLE: "admin",
+    });
+    expect(cfg).toMatchObject({ signerBaseUrl: "http://signer:8791", role: "admin", sessionType: "browser" });
+  });
+  it("role parse defaults to agent and is case-insensitive", () => {
+    expect(parseSweepSessionRole(undefined)).toBe("agent");
+    expect(parseSweepSessionRole("ADMIN")).toBe("admin");
+    expect(parseSweepSessionRole("verifier")).toBe("verifier");
+    expect(parseSweepSessionRole("nonsense")).toBe("agent");
+  });
+  it("isSweepSessionConfigured is false with no source (→ public-only)", () => {
+    expect(isSweepSessionConfigured({})).toBe(false);
+    expect(isSweepSessionConfigured({ signerBaseUrl: "http://x" })).toBe(true);
+    expect(isSweepSessionConfigured({ storageStatePath: "/p" })).toBe(true);
+    expect(isSweepSessionConfigured({ token: "t" })).toBe(true);
+  });
+});
+
+describe("normalizeStorageState", () => {
+  it("accepts {cookies[],origins[]}; rejects anything else", () => {
+    expect(normalizeStorageState(STORAGE)).toEqual(STORAGE);
+    expect(normalizeStorageState({ cookies: [] , origins: [] })).toEqual({ cookies: [], origins: [] });
+    expect(normalizeStorageState({ cookies: [] })).toBeUndefined();
+    expect(normalizeStorageState("nope")).toBeUndefined();
+    expect(normalizeStorageState(null)).toBeUndefined();
+  });
+});
+
+describe("resolveSweepSession — no source / fallback", () => {
+  it("returns undefined when nothing is configured (no fetch / no fs touched)", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const readFileImpl = vi.fn();
+    const session = await resolveSweepSession({}, { fetchImpl, readFileImpl });
+    expect(session).toBeUndefined();
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(readFileImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveSweepSession — manual source (decoupled for landing)", () => {
+  it("reads a storageState file and returns it (with token if provided)", async () => {
+    const readFileImpl = vi.fn(async () => JSON.stringify(STORAGE));
+    const session = await resolveSweepSession(
+      { storageStatePath: "/data/state.json", token: "bearer-xyz", role: "admin" },
+      { readFileImpl },
+    );
+    expect(session).toEqual({ role: "admin", storageState: STORAGE, token: "bearer-xyz" });
+  });
+
+  it("token-only manual session (API checks, no storageState)", async () => {
+    const session = await resolveSweepSession({ token: "bearer-only" }, {});
+    expect(session).toEqual({ role: "agent", token: "bearer-only" });
+  });
+
+  it("malformed storageState file degrades cleanly (no throw, no session) and warns without the path", async () => {
+    const warn = vi.fn();
+    const readFileImpl = vi.fn(async () => "{ not json");
+    const session = await resolveSweepSession({ storageStatePath: "/data/state.json" }, { readFileImpl, warn });
+    expect(session).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    // never log the path/secret
+    expect(warn.mock.calls.flat().join(" ")).not.toContain("/data/state.json");
+  });
+
+  it("unreadable file degrades cleanly", async () => {
+    const readFileImpl = vi.fn(async () => { throw new Error("ENOENT"); });
+    const session = await resolveSweepSession({ storageStatePath: "/nope.json" }, { readFileImpl });
+    expect(session).toBeUndefined();
+  });
+});
+
+describe("resolveSweepSession — T3 sidecar source", () => {
+  it("fetches GET /session/:role?type=browser and returns storageState", async () => {
+    const fetchImpl = okJson({ type: "browser", role: "agent", storageState: STORAGE });
+    const session = await resolveSweepSession({ signerBaseUrl: "http://signer:8791/", role: "agent" }, { fetchImpl });
+    expect(session).toEqual({ role: "agent", storageState: STORAGE });
+    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      "http://signer:8791/session/agent?type=browser",
+    );
+  });
+
+  it("type=api returns the Bearer token", async () => {
+    const fetchImpl = okJson({ type: "api", role: "admin", token: "jwt-abc" });
+    const session = await resolveSweepSession(
+      { signerBaseUrl: "http://signer:8791", role: "admin", sessionType: "api" },
+      { fetchImpl },
+    );
+    expect(session).toEqual({ role: "admin", token: "jwt-abc" });
+  });
+
+  it("a non-OK sidecar response degrades cleanly", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 503 })) as unknown as typeof fetch;
+    const session = await resolveSweepSession({ signerBaseUrl: "http://signer:8791" }, { fetchImpl });
+    expect(session).toBeUndefined();
+  });
+
+  it("an unreachable sidecar (throws) degrades cleanly — never fails the sweep", async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    const session = await resolveSweepSession({ signerBaseUrl: "http://signer:8791" }, { fetchImpl });
+    expect(session).toBeUndefined();
+  });
+
+  it("a browser session missing storageState degrades cleanly", async () => {
+    const fetchImpl = okJson({ type: "browser", role: "agent" });
+    const session = await resolveSweepSession({ signerBaseUrl: "http://signer:8791" }, { fetchImpl });
+    expect(session).toBeUndefined();
+  });
+});
+
+describe("buildSweepContextOptions", () => {
+  it("no session → just viewport + UA (no storageState, no auth header)", () => {
+    const opts = buildSweepContextOptions(undefined);
+    expect(opts.storageState).toBeUndefined();
+    expect(opts.extraHTTPHeaders).toBeUndefined();
+    expect(opts.userAgent).toContain("Surface-Sweep");
+  });
+  it("storageState session → passed to newContext", () => {
+    const opts = buildSweepContextOptions({ role: "agent", storageState: STORAGE });
+    expect(opts.storageState).toEqual(STORAGE);
+  });
+  it("token session → Authorization Bearer attached for the page's API calls", () => {
+    const opts = buildSweepContextOptions({ role: "agent", token: "jwt-abc" });
+    expect(opts.extraHTTPHeaders).toEqual({ Authorization: "Bearer jwt-abc" });
+  });
+});
+
+describe("DEFAULT_AUTHED_ROUTES", () => {
+  it("covers the documented operator pages", () => {
+    expect(DEFAULT_AUTHED_ROUTES).toEqual(
+      expect.arrayContaining(["/overview", "/runs", "/sessions", "/receipts", "/treasury", "/disputes", "/policies", "/agents", "/audit-log", "/capabilities"]),
+    );
+  });
+});

--- a/test/unit/testbed-surface-sweep.test.ts
+++ b/test/unit/testbed-surface-sweep.test.ts
@@ -218,3 +218,68 @@ describe("executeBrowserTestbedMission — dispatch (single-URL explore stays in
     expect(sweepMission.mode === "surface_sweep").toBe(true);
   });
 });
+
+// ── T2 pre-seeded session ───────────────────────────────────────────
+
+const AGENT_SESSION = { role: "agent" as const, storageState: { cookies: [], origins: [] } };
+
+describe("T2: authed routes + session-gated coverage", () => {
+  it("resolveSweepRoutes adds the authed routes only when includeAuthed", () => {
+    const pub = resolveSweepRoutes(undefined, "https://app.example.test", {});
+    expect(pub.map((r) => r.route)).toEqual(["/", "/onboarding", "/jobs", "/strategies"]);
+
+    const authed = resolveSweepRoutes(undefined, "https://app.example.test", { includeAuthed: true });
+    expect(authed.map((r) => r.route)).toEqual(
+      expect.arrayContaining(["/", "/overview", "/runs", "/receipts", "/audit-log", "/capabilities"]),
+    );
+
+    // An explicit mission.routes list overrides the default regardless of includeAuthed.
+    const explicit = resolveSweepRoutes(["/x"], "https://app.example.test", { includeAuthed: true });
+    expect(explicit.map((r) => r.route)).toEqual(["/x"]);
+  });
+
+  it("with a session, the authed operator routes join the sweep", async () => {
+    const seen: string[] = [];
+    const fake = vi.fn(async (url: string, route: string) => { seen.push(route); return capture({ route, url }); });
+    const result = await executeSurfaceSweep(mission(), { ...config, session: AGENT_SESSION }, { captureRoute: fake });
+    expect(seen).toEqual(expect.arrayContaining(["/overview", "/runs", "/treasury", "/audit-log"]));
+    expect(JSON.parse(result.reportText ?? "{}").verdict).toBe("pass");
+  });
+
+  it("without a session, the sweep stays public-only (graceful fallback, no crash)", async () => {
+    const seen: string[] = [];
+    const fake = vi.fn(async (url: string, route: string) => { seen.push(route); return capture({ route, url }); });
+    await executeSurfaceSweep(mission(), config, { captureRoute: fake });
+    expect(seen).toEqual(["/", "/onboarding", "/jobs", "/strategies"]);
+    expect(seen).not.toContain("/overview");
+  });
+
+  it("the boundary-honesty check applies to authed pages too", async () => {
+    const fake = vi.fn(async (url: string, route: string) =>
+      route === "/receipts"
+        ? capture({ route, url, consoleErrors: ["TypeError: x"], visibleText: "Your receipts are all here, lots of healthy detail." })
+        : capture({ route, url }),
+    );
+    const result = await executeSurfaceSweep(mission(), { ...config, session: AGENT_SESSION }, { captureRoute: fake });
+    const report = JSON.parse(result.reportText ?? "{}");
+    expect(report.honestyFindings.some((f: { route: string; code: string }) => f.route === "/receipts" && f.code === "errored_but_silent")).toBe(true);
+  });
+
+  it("the runner resolves a session and the authed routes join the sweep", async () => {
+    const seen: string[] = [];
+    const fake = vi.fn(async (url: string, route: string) => { seen.push(route); return capture({ route, url }); });
+    await executeBrowserTestbedMission(mission(), config, {
+      captureRoute: fake,
+      resolveSession: async () => AGENT_SESSION,
+    });
+    expect(seen).toContain("/overview");
+  });
+
+  it("the runner with no configured session source sweeps public-only", async () => {
+    const seen: string[] = [];
+    const fake = vi.fn(async (url: string, route: string) => { seen.push(route); return capture({ route, url }); });
+    await executeBrowserTestbedMission(mission(), config, { captureRoute: fake });
+    expect(seen).not.toContain("/overview");
+    expect(seen).toContain("/");
+  });
+});

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -65,22 +65,32 @@ describe("tester capabilities manifest", () => {
     });
   });
 
-  it("marks authed sweep as session-source available only when the signer sidecar is enabled", () => {
-    const withoutSigner = buildTesterCapabilitiesManifest({
-      env: { TEST_WALLET_SIGNER_ENABLED: "0" },
-    });
-    expect(withoutSigner.missionTypes.find((mission) => mission.id === "authed_surface_sweep")).toMatchObject({
-      status: "planned",
+  it("authed sweep is ready-but-needs-session until a session SOURCE is configured (T2)", () => {
+    // No runner session source → ready_needs_session, even with the sidecar up.
+    const noSource = buildTesterCapabilitiesManifest({ env: { TEST_WALLET_SIGNER_ENABLED: "1" } });
+    expect(noSource.runtime.signerSidecarEnabled).toBe(true);
+    expect(noSource.runtime.authedSessionConfigured).toBe(false);
+    expect(noSource.missionTypes.find((m) => m.id === "authed_surface_sweep")).toMatchObject({
+      status: "ready_needs_session",
     });
 
-    const withSigner = buildTesterCapabilitiesManifest({
-      env: { TEST_WALLET_SIGNER_ENABLED: "1" },
+    // Sidecar URL on the runner → available, sourced from the sidecar.
+    const viaSidecar = buildTesterCapabilitiesManifest({
+      env: { TESTBED_SESSION_SIGNER_URL: "http://test-wallet-signer:8791" },
     });
-    expect(withSigner.runtime.signerSidecarEnabled).toBe(true);
-    expect(withSigner.missionTypes.find((mission) => mission.id === "authed_surface_sweep")).toMatchObject({
-      status: "session_source_available",
+    expect(viaSidecar.runtime.authedSessionConfigured).toBe(true);
+    expect(viaSidecar.runtime.authedSessionSource).toBe("test-wallet-signer sidecar");
+    expect(viaSidecar.missionTypes.find((m) => m.id === "authed_surface_sweep")).toMatchObject({
+      status: "available",
     });
-    expect(withSigner.missionTypes.find((mission) => mission.id === "siwe_auth_role_gating")).toMatchObject({
+
+    // Manual storageState path → available, sourced manually (decoupled landing).
+    const viaManual = buildTesterCapabilitiesManifest({
+      env: { TESTBED_SESSION_STORAGE_STATE_PATH: "/data/agent-storage-state.json" },
+    });
+    expect(viaManual.runtime.authedSessionConfigured).toBe(true);
+    expect(viaManual.runtime.authedSessionSource).toBe("manual storageState/token");
+    expect(viaManual.missionTypes.find((m) => m.id === "authed_surface_sweep")).toMatchObject({
       status: "available",
     });
   });


### PR DESCRIPTION
## What changed & why

Wires a real auth **session** into the T1 surface sweep so the per-deploy tester finally covers the **authed operator app**, not just public pages. **Read-only** throughout. Per `docs/HERMES_TESTER_AUTH_DESIGN.md` ("Pre-seeded session in the runner — build step 2").

### New module — `services/slack-operator/src/testbed-session.ts`
Kept **distinct** from the sweep/runner files to minimise rebase churn with T3b (SIWE mission), per the task note.
- `SweepSession { role, storageState?, token? }` + parse/role helpers.
- `resolveSweepSession` — **two sources, decoupled for landing**:
  - **(a) the T3 signer sidecar:** `GET /session/:role?type=browser` → storageState (`type=api` → Bearer). The key never enters this process.
  - **(b) a manually-provided** storageState file path and/or Bearer token, so authed sweep works **before** the sidecar is wired in a given env.
  - **Never throws:** an absent / unreachable / malformed source degrades to `undefined` (→ public-only). Secrets (cookies, tokens, file paths) are **never logged**.
- `buildSweepContextOptions` — storageState → `newContext({ storageState })`; a Bearer is attached as `Authorization` for the page's same-origin API calls.
- `DEFAULT_AUTHED_ROUTES` — the documented operator pages: overview, runs, sessions, receipts, treasury, disputes, policies, agents, audit-log, capabilities.

### Sweep + runner
- `executeSurfaceSweep` accepts a resolved `session`. **With one**, the default route set extends to the authed routes and the T1 error-capture + boundary-honesty check apply to those pages too. **Without one**, it stays **public-only** (graceful fallback — never fails just because a session is absent). `resolveSweepRoutes` gains an `includeAuthed` option; an explicit `mission.routes` still overrides.
- The runner (`executeBrowserTestbedMission`) resolves the session from its env config before the sweep; resolution is injectable for tests.

### Ops + manifest
- The `testbed-mission-runner` service gains `TESTBED_SESSION_*` (sidecar URL + role/type, or manual storageState path/token). **All empty ⇒ public-only.**
- Capabilities manifest: `authed_surface_sweep` is now `"available"` when a session **source** is configured, else `"ready_needs_session"` — honest, not over-claimed.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue (the testbed runner)
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1020 passed; new: session resolution from sidecar/manual/none/malformed, context storageState+Bearer, authed routes join / public-only, honesty on authed pages, runner wiring)
- [x] compose validated by parsing `ops/compose.yml` (CI runs the real `docker compose … config`)

## Rollout / rollback
- **Off by default:** no `TESTBED_SESSION_*` set ⇒ the sweep is exactly as before (public-only). Enabling is one of: point the runner at the T3 sidecar (`TESTBED_SESSION_SIGNER_URL`), or drop a manual `TESTBED_SESSION_STORAGE_STATE_PATH` / `TESTBED_SESSION_TOKEN`.
- **Rollback:** unset the env (instant public-only) or revert the PR.

## Durable invariants (AGENTS.md)
- [x] **Read-only:** the session only authenticates navigation; the sweep navigates + reads, never clicks a mutating control. No new mutating power.
- [x] `HALT_FILE` honored (the runner is unchanged in that respect); wallet untouched (keys stay in the T3 sidecar, never in this process or logs)
- [x] **No secrets committed/printed/logged** — storageState/token/paths are never logged; a malformed source warns without the value
- [x] Truth-boundary preserved: a missing session degrades honestly to public-only; the manifest advertises authed sweep as available only when a source is configured

## Known limits / follow-ups
- Authed route paths are the documented operator pages; a deploy can override per-mission via `routes`.
- Session source is runner-env-driven (keeps secrets out of the mission queue); a per-mission session override could come later if needed.
- T3b (SIWE mission + role-gating) builds on the same sidecar; intentionally kept in separate files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)