### PR TITLE
[claude] Add autopilot away digest

### DIFF
--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -30,7 +30,7 @@
 | A2 | Learned routing (data-driven, non-high-risk) | 🟡 in review — scorecard-backed default routing, high-risk rule-bound |
 | A3 | Cost visibility / cost-aware routing | design done |
 | A4 | Agent model & effort policy — riskTier→effort/model + operator override (tester LLM; Hermes model = open) | design done (see `HERMES_AGENT_MODELS_AND_EFFORT.md`) |
-| D1 | "While you were away" digest (board + Slack/push) | design done |
+| D1 | "While you were away" digest (board + Slack/push) | 🟡 in review — autopilot session-end digest + alert-bridge push |
 | D2 | Explainability / decision records | design done |
 | D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | 🟡 in build (prompt out — unblocks O4-PR3) |
 | D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
@@ -48,7 +48,7 @@
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | in review — manifest endpoint; platform helper follow-up |
 
-*(Status as of 2026-05-31 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), T3 (signer sidecar foundation), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D3 (anomaly auto-pause — unblocks O4-PR3), C4 (inter-agent chat channel), and T7 reference-agent manifest endpoint. **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C3, D1–D2, T2, T4–T6, and the T7 platform helper/AGENTS pointer. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
+*(Status as of 2026-05-31 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), T3 (signer sidecar foundation), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D1 (autopilot away digest), D3 (anomaly auto-pause — unblocks O4-PR3), C4 (inter-agent chat channel), and T7 reference-agent manifest endpoint. **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C3, D2, T2, T4–T6, and the T7 platform helper/AGENTS pointer. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 

--- a/services/slack-operator/src/away-digest.ts
+++ b/services/slack-operator/src/away-digest.ts
@@ -1,0 +1,385 @@
+import type { AlertChannel, AlertPayload } from "./alert-bridge.js";
+import type { AutonomyState } from "./autonomy-mode.js";
+import { taskAgent, type CodexTask } from "./codex-task-queue.js";
+import type { BoardCard } from "./monitor-v2.js";
+
+export interface AutopilotAwayDigestTrackerState {
+  active?: AutopilotAwaySession;
+  emittedSessionIds: string[];
+}
+
+export interface AutopilotAwaySession {
+  sessionId: string;
+  startedAt: string;
+  setBy?: string;
+  until?: string;
+}
+
+export interface EndedAutopilotAwaySession extends AutopilotAwaySession {
+  endedAt: string;
+  endedBy: string;
+}
+
+export interface AutopilotAwayDigestObservation {
+  now: Date;
+  autonomy: AutonomyState;
+  suspended?: boolean;
+  halt?: boolean;
+  endedAutonomy?: AutonomyState;
+  endedBy?: string;
+}
+
+export interface AutopilotAuditEvent {
+  at: string;
+  commandText?: string;
+  result?: Record<string, unknown>;
+}
+
+export type AwayDigestBoardCard = Pick<
+  BoardCard,
+  "id" | "lane" | "title" | "summary" | "repo" | "agentType" | "waitingOn" | "state" | "next"
+>;
+
+export interface AutopilotAwayDigestItem {
+  id: string;
+  title: string;
+  repo?: string;
+  agent?: string;
+  riskTier?: string;
+  reason?: string;
+  status?: string;
+  at?: string;
+}
+
+export interface AutopilotAwayDigest {
+  schemaVersion: 1;
+  kind: "autopilot_away_digest";
+  generatedAt: string;
+  mutates: false;
+  session: EndedAutopilotAwaySession;
+  headline: string;
+  counts: {
+    routed: number;
+    autoApproved: number;
+    escalated: number;
+    openedPrs: number;
+    failures: number;
+    d3Suspends: number;
+    waitingOnOperator: number;
+  };
+  routed: AutopilotAwayDigestItem[];
+  autoApproved: AutopilotAwayDigestItem[];
+  escalated: AutopilotAwayDigestItem[];
+  openedPrs: AutopilotAwayDigestItem[];
+  failures: AutopilotAwayDigestItem[];
+  d3Suspends: AutopilotAwayDigestItem[];
+  waitingOnOperator: AutopilotAwayDigestItem[];
+  recommendedNextActions: string[];
+  safety: {
+    readOnly: true;
+    mutatesGithub: false;
+    mutatesAverray: false;
+    editsWikipedia: false;
+  };
+}
+
+export interface BuildAutopilotAwayDigestInput {
+  session: EndedAutopilotAwaySession;
+  generatedAt: Date;
+  tasks: CodexTask[];
+  auditEvents: AutopilotAuditEvent[];
+  boardCards: AwayDigestBoardCard[];
+}
+
+export interface DeliverAutopilotAwayDigestDeps {
+  session: EndedAutopilotAwaySession;
+  now: () => Date;
+  boardUrl: string;
+  loadTasks: () => Promise<CodexTask[]>;
+  loadAuditEvents: (startedAt: string, endedAt: string) => Promise<AutopilotAuditEvent[]>;
+  loadBoardCards: () => Promise<AwayDigestBoardCard[]>;
+  recordBoardDigest: (digest: AutopilotAwayDigest, text: string) => Promise<void>;
+  alert: AlertChannel;
+  auditDigest: (digest: AutopilotAwayDigest) => Promise<void>;
+}
+
+export function initialAutopilotAwayDigestTrackerState(): AutopilotAwayDigestTrackerState {
+  return { emittedSessionIds: [] };
+}
+
+export function observeAutopilotAwayDigestSession(
+  state: AutopilotAwayDigestTrackerState,
+  observation: AutopilotAwayDigestObservation,
+): { state: AutopilotAwayDigestTrackerState; ended?: EndedAutopilotAwaySession } {
+  const nowIso = observation.now.toISOString();
+  const activeAutopilot = observation.autonomy.mode === "autopilot" && !observation.suspended && !observation.halt;
+
+  if (activeAutopilot) {
+    const active = sessionFromAutonomy(observation.autonomy, nowIso);
+    return {
+      state: {
+        ...state,
+        active,
+      },
+    };
+  }
+
+  const active = state.active ?? (
+    observation.endedAutonomy && observation.endedAutonomy.mode === "autopilot"
+      ? sessionFromAutonomy(observation.endedAutonomy, nowIso)
+      : undefined
+  );
+  if (!active) return { state: { ...state, active: undefined } };
+
+  if (state.emittedSessionIds.includes(active.sessionId)) {
+    return { state: { ...state, active: undefined } };
+  }
+
+  const ended: EndedAutopilotAwaySession = {
+    ...active,
+    endedAt: nowIso,
+    endedBy: observation.endedBy ?? inferEndedBy(observation),
+  };
+  return {
+    state: {
+      active: undefined,
+      emittedSessionIds: [...state.emittedSessionIds, active.sessionId],
+    },
+    ended,
+  };
+}
+
+export function buildAutopilotAwayDigest(input: BuildAutopilotAwayDigestInput): AutopilotAwayDigest {
+  const startMs = Date.parse(input.session.startedAt);
+  const endMs = Date.parse(input.session.endedAt);
+  const tasksById = new Map(input.tasks.map((task) => [task.id, task]));
+
+  const routed = input.tasks
+    .filter((task) => inWindow(task.createdAt, startMs, endMs))
+    .map(taskItem);
+
+  const autoApproved = input.tasks
+    .filter((task) => task.approvedBy === "hermes-autopilot" && inWindow(task.approvedAt, startMs, endMs))
+    .map(taskItem);
+
+  const escalated = input.auditEvents
+    .filter((event) => inWindow(event.at, startMs, endMs) && event.result?.kind === "autopilot_auto_approval" && event.result.action === "escalated")
+    .map((event) => auditTaskItem(event, tasksById));
+
+  const d3Suspends = input.auditEvents
+    .filter((event) => inWindow(event.at, startMs, endMs) && event.result?.kind === "anomaly_autopause")
+    .map((event) => ({
+      id: stringValue(event.result?.reason) ?? event.commandText ?? "d3-suspend",
+      title: stringValue(event.result?.message) ?? stringValue(event.result?.reason) ?? "Autopilot suspended by anomaly guard",
+      reason: stringValue(event.result?.reason),
+      at: event.at,
+    }));
+
+  const failures = input.tasks
+    .filter((task) => inWindow(task.failedAt, startMs, endMs))
+    .map(taskItem);
+
+  const openedPrs = input.tasks
+    .filter((task) => task.status === "completed" && inWindow(task.completedAt ?? task.updatedAt, startMs, endMs) && taskPullNumber(task) !== undefined)
+    .map((task) => ({
+      ...taskItem(task),
+      title: `${task.repo}#${taskPullNumber(task)} opened/updated by ${taskAgent(task)}`,
+    }));
+
+  const waitingOnOperator = input.boardCards
+    .filter((card) => card.lane === "needs-attention" || card.lane === "operator-review" || card.waitingOn?.actor === "operator")
+    .map((card) => ({
+      id: card.id,
+      title: card.title,
+      repo: card.repo,
+      agent: card.agentType,
+      status: card.lane,
+      reason: card.next ?? card.summary,
+    }));
+
+  const counts = {
+    routed: routed.length,
+    autoApproved: autoApproved.length,
+    escalated: escalated.length,
+    openedPrs: openedPrs.length,
+    failures: failures.length,
+    d3Suspends: d3Suspends.length,
+    waitingOnOperator: waitingOnOperator.length,
+  };
+
+  return {
+    schemaVersion: 1,
+    kind: "autopilot_away_digest",
+    generatedAt: input.generatedAt.toISOString(),
+    mutates: false,
+    session: input.session,
+    headline: headlineFor(counts),
+    counts,
+    routed,
+    autoApproved,
+    escalated,
+    openedPrs,
+    failures,
+    d3Suspends,
+    waitingOnOperator,
+    recommendedNextActions: recommendedNextActionsFor({ waitingOnOperator, escalated, failures, openedPrs, autoApproved }),
+    safety: {
+      readOnly: true,
+      mutatesGithub: false,
+      mutatesAverray: false,
+      editsWikipedia: false,
+    },
+  };
+}
+
+export function formatAutopilotAwayDigestForOperator(digest: AutopilotAwayDigest): string {
+  const lines = [
+    digest.headline,
+    `Window: ${digest.session.startedAt} -> ${digest.session.endedAt} (${digest.session.endedBy}).`,
+    `Hermes routed ${digest.counts.routed}, auto-approved ${digest.counts.autoApproved}, escalated ${digest.counts.escalated}, opened/updated ${digest.counts.openedPrs} PR task(s), and left ${digest.counts.waitingOnOperator} item(s) waiting on you.`,
+  ];
+
+  if (digest.autoApproved.length > 0) {
+    lines.push(`Auto-approved: ${digest.autoApproved.slice(0, 3).map(shortItem).join("; ")}`);
+  }
+  if (digest.escalated.length > 0) {
+    lines.push(`Escalated: ${digest.escalated.slice(0, 3).map(shortItem).join("; ")}`);
+  }
+  if (digest.failures.length > 0 || digest.d3Suspends.length > 0) {
+    lines.push(`Interruptions: ${[...digest.failures, ...digest.d3Suspends].slice(0, 3).map(shortItem).join("; ")}`);
+  }
+  if (digest.waitingOnOperator.length > 0) {
+    lines.push(`Waiting on you: ${digest.waitingOnOperator.slice(0, 3).map(shortItem).join("; ")}`);
+  }
+  lines.push(`Next: ${digest.recommendedNextActions[0] ?? "Nothing needs you right now."}`);
+  return lines.join("\n");
+}
+
+export function buildAutopilotAwayDigestAlertPayload(digest: AutopilotAwayDigest, boardUrl: string): AlertPayload {
+  return {
+    count: digest.counts.waitingOnOperator + digest.counts.escalated + digest.counts.failures + digest.counts.d3Suspends,
+    items: digest.waitingOnOperator.slice(0, 5).map((item) => ({ id: item.id, title: item.title })),
+    boardUrl,
+    text: `${formatAutopilotAwayDigestForOperator(digest)}\nBoard: ${boardUrl}`,
+  };
+}
+
+export async function deliverAutopilotAwayDigest(deps: DeliverAutopilotAwayDigestDeps): Promise<AutopilotAwayDigest> {
+  const [tasks, auditEvents, boardCards] = await Promise.all([
+    deps.loadTasks(),
+    deps.loadAuditEvents(deps.session.startedAt, deps.session.endedAt),
+    deps.loadBoardCards(),
+  ]);
+  const digest = buildAutopilotAwayDigest({
+    session: deps.session,
+    generatedAt: deps.now(),
+    tasks,
+    auditEvents,
+    boardCards,
+  });
+  const text = formatAutopilotAwayDigestForOperator(digest);
+  await deps.recordBoardDigest(digest, text);
+  await deps.alert.dispatch(buildAutopilotAwayDigestAlertPayload(digest, deps.boardUrl));
+  await deps.auditDigest(digest);
+  return digest;
+}
+
+function sessionFromAutonomy(autonomy: AutonomyState, fallbackStartedAt: string): AutopilotAwaySession {
+  const startedAt = autonomy.setAt ?? fallbackStartedAt;
+  return {
+    sessionId: `autopilot:${startedAt}`,
+    startedAt,
+    ...(autonomy.setBy ? { setBy: autonomy.setBy } : {}),
+    ...(autonomy.until ? { until: autonomy.until } : {}),
+  };
+}
+
+function inferEndedBy(observation: AutopilotAwayDigestObservation): string {
+  if (observation.suspended) return "d3-suspend";
+  if (observation.halt) return "halt";
+  return observation.autonomy.setBy ?? "supervised";
+}
+
+function inWindow(value: string | undefined, startMs: number, endMs: number): boolean {
+  if (!value) return false;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) && ms >= startMs && ms <= endMs;
+}
+
+function taskItem(task: CodexTask): AutopilotAwayDigestItem {
+  return {
+    id: task.id,
+    title: task.title ?? task.reason ?? firstLine(task.prompt),
+    repo: task.repo,
+    agent: taskAgent(task),
+    ...(task.riskTier ? { riskTier: task.riskTier } : {}),
+    ...((task.routingReason ?? task.reason) ? { reason: task.routingReason ?? task.reason } : {}),
+    status: task.status,
+    at: task.approvedAt ?? task.completedAt ?? task.failedAt ?? task.createdAt,
+  };
+}
+
+function auditTaskItem(event: AutopilotAuditEvent, tasksById: Map<string, CodexTask>): AutopilotAwayDigestItem {
+  const taskId = stringValue(event.result?.taskId) ?? event.commandText ?? "autopilot-escalation";
+  const task = tasksById.get(taskId);
+  if (task) {
+    return {
+      ...taskItem(task),
+      reason: stringValue(event.result?.detail) ?? stringValue(event.result?.reason) ?? task.routingReason ?? task.reason,
+      at: event.at,
+    };
+  }
+  return {
+    id: taskId,
+    title: stringValue(event.result?.title) ?? taskId,
+    repo: stringValue(event.result?.repo),
+    agent: stringValue(event.result?.agent),
+    riskTier: stringValue(event.result?.riskTier),
+    reason: stringValue(event.result?.detail) ?? stringValue(event.result?.reason),
+    status: stringValue(event.result?.action),
+    at: event.at,
+  };
+}
+
+function taskPullNumber(task: CodexTask): number | undefined {
+  const fromSummary = task.completionSummary?.match(/(?:pull\/|#)(\d{1,6})\b/i)?.[1];
+  if (fromSummary) return Number.parseInt(fromSummary, 10);
+  return task.pullRequestNumber;
+}
+
+function firstLine(text: string): string {
+  return text.trim().split(/\r?\n/, 1)[0]?.slice(0, 120) || "Codex task";
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function headlineFor(counts: AutopilotAwayDigest["counts"]): string {
+  const total = counts.routed + counts.autoApproved + counts.escalated + counts.openedPrs + counts.failures + counts.d3Suspends + counts.waitingOnOperator;
+  if (total === 0) return "While you were away: autopilot ended, and nothing needed action.";
+  return `While you were away: autopilot ended with ${counts.autoApproved} auto-approved, ${counts.escalated} escalated, and ${counts.waitingOnOperator} waiting on you.`;
+}
+
+function recommendedNextActionsFor(input: {
+  waitingOnOperator: AutopilotAwayDigestItem[];
+  escalated: AutopilotAwayDigestItem[];
+  failures: AutopilotAwayDigestItem[];
+  openedPrs: AutopilotAwayDigestItem[];
+  autoApproved: AutopilotAwayDigestItem[];
+}): string[] {
+  const firstWaiting = input.waitingOnOperator[0];
+  if (firstWaiting) return [`Review ${firstWaiting.title}; it is waiting on ${firstWaiting.status ?? "operator action"}.`];
+  const firstEscalated = input.escalated[0];
+  if (firstEscalated) return [`Decide the escalated item ${firstEscalated.title}.`];
+  const firstFailure = input.failures[0];
+  if (firstFailure) return [`Inspect the failed task ${firstFailure.title}.`];
+  if (input.openedPrs.length > 0) return ["Review the PRs opened while autopilot was engaged."];
+  if (input.autoApproved.length > 0) return ["No operator action is waiting; skim the auto-approved work when convenient."];
+  return ["Nothing needs you right now."];
+}
+
+function shortItem(item: AutopilotAwayDigestItem): string {
+  const suffix = item.reason ? ` (${item.reason})` : "";
+  return `${item.title}${suffix}`;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -76,8 +76,16 @@ import {
   expireAutonomyIfDue,
   isAutopilotEngaged,
   type AutonomyMode,
+  type AutonomyState,
 } from "./autonomy-mode.js";
 import { runAutoApproval } from "./autopilot-approve.js";
+import {
+  deliverAutopilotAwayDigest,
+  initialAutopilotAwayDigestTrackerState,
+  observeAutopilotAwayDigestSession,
+  type AutopilotAuditEvent,
+  type EndedAutopilotAwaySession,
+} from "./away-digest.js";
 import { loadDispatchPolicyConfig } from "@avg/averray-mcp/dispatch-policy";
 import {
   isDebugSpawnEnabled,
@@ -207,42 +215,125 @@ if (!enabled) {
   }
   startOperatorRoutines();
   // O4-PR3a — always-on safety revert: lazy-resolve already treats an expired
-  // autopilot as supervised, but this persists the revert + alerts ONCE when the
-  // window lapses (a forgotten autopilot ends on its own). Independent of the
-  // routine channel; the alert rides the D4 bridge (SLACK_WEBHOOK_URL).
-  setInterval(() => void checkAutonomyExpiry(), 60_000);
+  // autopilot as supervised, but this persists the revert + emits the D1
+  // "while you were away" digest exactly once when the window lapses.
+  setInterval(() => void checkAutonomyMaintenance(), 60_000);
+  void checkAutonomyMaintenance();
 }
 
-let autonomyExpiryRunning = false;
-async function checkAutonomyExpiry() {
-  if (autonomyExpiryRunning) return;
-  autonomyExpiryRunning = true;
+let autonomyMaintenanceRunning = false;
+let awayDigestTrackerState = initialAutopilotAwayDigestTrackerState();
+let pendingAwayDigestEnd: { endedAutonomy: AutonomyState; endedBy?: string } | undefined;
+
+async function checkAutonomyMaintenance(endedAutonomy?: AutonomyState, endedBy?: string) {
+  if (autonomyMaintenanceRunning) {
+    if (endedAutonomy) pendingAwayDigestEnd = { endedAutonomy, ...(endedBy ? { endedBy } : {}) };
+    return;
+  }
+  autonomyMaintenanceRunning = true;
   try {
+    const pending = pendingAwayDigestEnd;
+    pendingAwayDigestEnd = undefined;
     const result = expireAutonomyIfDue();
-    if (!result.expired) return;
-    logger.info({ until: result.previous?.until }, "o4_autonomy_expired_to_supervised");
-    const boardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
-    await slackAlertChannel().dispatch({
-      count: 0,
-      items: [],
-      boardUrl,
-      text: `⏱️ Hermes autopilot window ended — back to SUPERVISED. Every dispatch needs your approval again.\nBoard: ${boardUrl}`,
-    }).catch((error) => logger.warn({ err: error }, "o4_autonomy_expiry_alert_failed"));
-    await recordOperatorCommandEvent({
-      source: "slack_routine",
-      commandText: "autonomy autopilot window expired",
-      result: {
-        kind: "autonomy_mode_change",
-        from: "autopilot",
-        to: "supervised",
-        setBy: "autopilot-expiry",
-        safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
-      },
-    }, query).catch((error) => logger.warn({ err: error }, "o4_autonomy_expiry_record_failed"));
+    if (result.expired) {
+      logger.info({ until: result.previous?.until }, "o4_autonomy_expired_to_supervised");
+      await recordOperatorCommandEvent({
+        source: "slack_routine",
+        commandText: "autonomy autopilot window expired",
+        result: {
+          kind: "autonomy_mode_change",
+          from: "autopilot",
+          to: "supervised",
+          setBy: "autopilot-expiry",
+          safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+        },
+      }, query).catch((error) => logger.warn({ err: error }, "o4_autonomy_expiry_record_failed"));
+    }
+    const effectiveEndedAutonomy = endedAutonomy ?? result.previous ?? pending?.endedAutonomy;
+    const effectiveEndedBy = endedBy ?? (result.expired ? "autopilot-expiry" : undefined) ?? pending?.endedBy;
+    await checkAutopilotAwayDigest(effectiveEndedAutonomy, effectiveEndedBy);
   } catch (error) {
-    logger.warn({ err: error }, "o4_autonomy_expiry_failed");
+    logger.warn({ err: error }, "o4_autonomy_maintenance_failed");
   } finally {
-    autonomyExpiryRunning = false;
+    autonomyMaintenanceRunning = false;
+    if (pendingAwayDigestEnd) void checkAutonomyMaintenance();
+  }
+}
+
+async function checkAutopilotAwayDigest(endedAutonomy?: AutonomyState, endedBy?: string) {
+  const observed = observeAutopilotAwayDigestSession(awayDigestTrackerState, {
+    now: new Date(),
+    autonomy: readAutonomyState(),
+    suspended: isAutopilotSuspended(),
+    halt: isHaltFilePresent(),
+    ...(endedAutonomy ? { endedAutonomy } : {}),
+    ...(endedBy ? { endedBy } : {}),
+  });
+  awayDigestTrackerState = observed.state;
+  if (!observed.ended) return;
+  await emitAutopilotAwayDigest(observed.ended);
+}
+
+async function emitAutopilotAwayDigest(session: EndedAutopilotAwaySession) {
+  const boardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
+  const digest = await deliverAutopilotAwayDigest({
+    session,
+    now: () => new Date(),
+    boardUrl,
+    loadTasks: () => listCodexTasks(),
+    loadAuditEvents: loadAutopilotAwayAuditEvents,
+    loadBoardCards: async () => {
+      const raw = await loadMonitorSnapshot(new URL("http://localhost/monitor/events?limit=50&activeWindowMinutes=240"), { suppressNarration: true });
+      return buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }).cards;
+    },
+    recordBoardDigest: async (_digest, text) => {
+      recordCollaborationMessage({
+        author: "hermes",
+        kind: "status",
+        addressedTo: "operator",
+        text,
+      });
+    },
+    alert: slackAlertChannel(),
+    auditDigest: (entry) => recordOperatorCommandEvent({
+      source: "slack_routine",
+      commandText: `autopilot away digest: ${session.sessionId}`,
+      result: entry,
+    }, query),
+  });
+  logger.info({ sessionId: session.sessionId, counts: digest.counts }, "d1_autopilot_away_digest_emitted");
+}
+
+async function loadAutopilotAwayAuditEvents(startedAt: string, endedAt: string): Promise<AutopilotAuditEvent[]> {
+  const rows = await query<{ command_text?: string; result?: unknown; updated_at?: string | Date }>(
+    `select command_text, result, updated_at
+     from operator_command_events
+     where updated_at >= $1::timestamptz
+       and updated_at <= $2::timestamptz
+       and (
+         result->>'kind' in ('autopilot_auto_approval', 'anomaly_autopause', 'autonomy_mode_change')
+         or normalized_text like 'autopilot %'
+       )
+     order by updated_at asc`,
+    [startedAt, endedAt]
+  );
+  return rows
+    .map((row) => ({
+      at: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at ?? ""),
+      ...(row.command_text ? { commandText: row.command_text } : {}),
+      ...(parseJsonRecord(row.result) ? { result: parseJsonRecord(row.result) } : {}),
+    }))
+    .filter((event) => event.at);
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value && typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed as Record<string, unknown> : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -1250,10 +1341,10 @@ async function handleMonitorAutonomyModeRequest(request: http.IncomingMessage, r
 
     if (changed) {
       const boardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
-      const text = after.mode === "autopilot"
-        ? `🟢 Hermes is in AUTOPILOT until ${after.until ?? "—"} — low/medium-risk dispatch within budget auto-approves; high-risk still escalates to you. Merge/deploy stays human.\nBoard: ${boardUrl}`
-        : `⏸️ Hermes is back to SUPERVISED — every dispatch needs your approval again.\nBoard: ${boardUrl}`;
-      await slackAlertChannel().dispatch({ count: 0, items: [], boardUrl, text }).catch((error) => logger.warn({ err: error }, "o4_autonomy_alert_failed"));
+      if (after.mode === "autopilot") {
+        const text = `Hermes is in AUTOPILOT until ${after.until ?? "-"} - low/medium-risk dispatch within budget auto-approves; high-risk still escalates to you. Merge/deploy stays human.\nBoard: ${boardUrl}`;
+        await slackAlertChannel().dispatch({ count: 0, items: [], boardUrl, text }).catch((error) => logger.warn({ err: error }, "o4_autonomy_alert_failed"));
+      }
       await recordOperatorCommandEvent({
         source: "monitor",
         commandText: `autonomy mode → ${after.mode}`,
@@ -1266,6 +1357,11 @@ async function handleMonitorAutonomyModeRequest(request: http.IncomingMessage, r
           safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
         },
       }, query).catch((error) => logger.warn({ err: error }, "o4_autonomy_record_failed"));
+      if (before.mode === "autopilot" && after.mode === "supervised") {
+        void checkAutonomyMaintenance(before, setBy || "operator-return");
+      } else {
+        void checkAutonomyMaintenance();
+      }
     }
 
     writeJson(response, 200, { ok: true, changed, autonomy: after });

--- a/test/unit/away-digest.test.ts
+++ b/test/unit/away-digest.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildAutopilotAwayDigest,
+  deliverAutopilotAwayDigest,
+  formatAutopilotAwayDigestForOperator,
+  initialAutopilotAwayDigestTrackerState,
+  observeAutopilotAwayDigestSession,
+  type AwayDigestBoardCard,
+  type AutopilotAuditEvent,
+} from "../../services/slack-operator/src/away-digest.js";
+import type { CodexTask } from "../../services/slack-operator/src/codex-task-queue.js";
+
+const START = "2026-05-31T08:00:00.000Z";
+const END = "2026-05-31T09:00:00.000Z";
+const NOW = new Date(END);
+
+function task(overrides: Partial<CodexTask>): CodexTask {
+  return {
+    schemaVersion: 1,
+    kind: "codex_task",
+    id: "task-1",
+    repo: "depre-dev/averray-reference-agent",
+    status: "proposed",
+    title: "Default task",
+    prompt: "Do the thing.",
+    createdAt: START,
+    updatedAt: START,
+    ...overrides,
+  };
+}
+
+describe("autopilot away digest session tracking", () => {
+  it("does not emit while supervised from the start", () => {
+    const result = observeAutopilotAwayDigestSession(initialAutopilotAwayDigestTrackerState(), {
+      now: NOW,
+      autonomy: { mode: "supervised", setAt: END, setBy: "operator" },
+    });
+
+    expect(result.ended).toBeUndefined();
+    expect(result.state.active).toBeUndefined();
+  });
+
+  it("emits exactly once when autopilot transitions back to supervised", () => {
+    let state = initialAutopilotAwayDigestTrackerState();
+
+    let result = observeAutopilotAwayDigestSession(state, {
+      now: new Date(START),
+      autonomy: { mode: "autopilot", setAt: START, until: END, setBy: "operator" },
+    });
+    state = result.state;
+
+    result = observeAutopilotAwayDigestSession(state, {
+      now: NOW,
+      autonomy: { mode: "supervised", setAt: END, setBy: "operator-return" },
+    });
+
+    expect(result.ended).toMatchObject({
+      sessionId: `autopilot:${START}`,
+      startedAt: START,
+      endedAt: END,
+      endedBy: "operator-return",
+    });
+
+    const duplicate = observeAutopilotAwayDigestSession(result.state, {
+      now: new Date("2026-05-31T09:01:00.000Z"),
+      autonomy: { mode: "supervised", setAt: END, setBy: "operator-return" },
+    });
+    expect(duplicate.ended).toBeUndefined();
+  });
+
+  it("treats a D3 suspend as a session end", () => {
+    let state = observeAutopilotAwayDigestSession(initialAutopilotAwayDigestTrackerState(), {
+      now: new Date(START),
+      autonomy: { mode: "autopilot", setAt: START, until: END, setBy: "operator" },
+    }).state;
+
+    const result = observeAutopilotAwayDigestSession(state, {
+      now: NOW,
+      autonomy: { mode: "autopilot", setAt: START, until: "2026-05-31T12:00:00.000Z", setBy: "operator" },
+      suspended: true,
+    });
+
+    expect(result.ended).toMatchObject({ endedBy: "d3-suspend" });
+  });
+
+  it("can emit from an expiry transition even if the process missed the active tick", () => {
+    const result = observeAutopilotAwayDigestSession(initialAutopilotAwayDigestTrackerState(), {
+      now: NOW,
+      autonomy: { mode: "supervised", setAt: END, setBy: "autopilot-expiry" },
+      endedAutonomy: { mode: "autopilot", setAt: START, until: END, setBy: "operator" },
+      endedBy: "autopilot-expiry",
+    });
+
+    expect(result.ended).toMatchObject({
+      sessionId: `autopilot:${START}`,
+      endedBy: "autopilot-expiry",
+    });
+  });
+});
+
+describe("autopilot away digest aggregation", () => {
+  const tasks: CodexTask[] = [
+    task({
+      id: "task-auto",
+      title: "Tweak monitor copy",
+      agent: "claude",
+      riskTier: "low",
+      routingReason: "claude had better UI score",
+      approvedAt: "2026-05-31T08:05:00.000Z",
+      approvedBy: "hermes-autopilot",
+      status: "approved",
+    }),
+    task({
+      id: "task-high",
+      title: "Touch deploy secrets",
+      riskTier: "high",
+      routingReason: "deploy/secrets are high-risk",
+      createdAt: "2026-05-31T08:10:00.000Z",
+    }),
+    task({
+      id: "task-pr",
+      title: "Open a follow-up PR",
+      agent: "claude",
+      status: "completed",
+      completedAt: "2026-05-31T08:30:00.000Z",
+      completionSummary: "Opened https://github.com/depre-dev/averray-reference-agent/pull/321",
+    }),
+    task({
+      id: "task-failed",
+      title: "Try flaky fix",
+      status: "failed",
+      failedAt: "2026-05-31T08:40:00.000Z",
+      failureReason: "CI failed",
+    }),
+  ];
+
+  const auditEvents: AutopilotAuditEvent[] = [
+    {
+      at: "2026-05-31T08:11:00.000Z",
+      commandText: "autopilot escalated: task-high",
+      result: {
+        kind: "autopilot_auto_approval",
+        action: "escalated",
+        taskId: "task-high",
+        riskTier: "high",
+        reason: "high_risk_escalated",
+        detail: "deploy/secrets are high-risk",
+      },
+    },
+    {
+      at: "2026-05-31T08:45:00.000Z",
+      commandText: "anomaly autopause",
+      result: {
+        kind: "anomaly_autopause",
+        reason: "runner failures spiked",
+        message: "Autopilot paused after runner failures spiked.",
+      },
+    },
+  ];
+
+  const boardCards: AwayDigestBoardCard[] = [
+    {
+      id: "card-review",
+      lane: "operator-review",
+      title: "Approve high-risk deploy change",
+      summary: "Needs operator risk decision.",
+      repo: "depre-dev/averray-reference-agent",
+      agentType: "codex",
+      waitingOn: { actor: "operator", tone: "warn" },
+      state: "fresh",
+      next: "Operator should approve or send back.",
+    },
+    {
+      id: "card-checking",
+      lane: "hermes-checking",
+      title: "Hermes checking",
+      summary: "No action.",
+      repo: "depre-dev/averray-reference-agent",
+      agentType: "hermes",
+      waitingOn: { actor: "agent", tone: "neutral" },
+      state: "fresh",
+    },
+  ];
+
+  it("counts routed, auto-approved, escalated, opened PRs, failures, D3 suspends, and waiting work", () => {
+    const digest = buildAutopilotAwayDigest({
+      session: {
+        sessionId: `autopilot:${START}`,
+        startedAt: START,
+        endedAt: END,
+        endedBy: "operator-return",
+      },
+      generatedAt: NOW,
+      tasks,
+      auditEvents,
+      boardCards,
+    });
+
+    expect(digest.counts).toEqual({
+      routed: 4,
+      autoApproved: 1,
+      escalated: 1,
+      openedPrs: 1,
+      failures: 1,
+      d3Suspends: 1,
+      waitingOnOperator: 1,
+    });
+    expect(digest.autoApproved[0]).toMatchObject({
+      title: "Tweak monitor copy",
+      riskTier: "low",
+      reason: "claude had better UI score",
+    });
+    expect(digest.escalated[0]).toMatchObject({
+      id: "task-high",
+      reason: "deploy/secrets are high-risk",
+    });
+    expect(digest.waitingOnOperator[0]).toMatchObject({
+      id: "card-review",
+      status: "operator-review",
+    });
+
+    const text = formatAutopilotAwayDigestForOperator(digest);
+    expect(text).toContain("While you were away");
+    expect(text).toContain("auto-approved 1");
+    expect(text).toContain("Waiting on you");
+  });
+
+  it("returns a minimal digest for an empty session", () => {
+    const digest = buildAutopilotAwayDigest({
+      session: {
+        sessionId: `autopilot:${START}`,
+        startedAt: START,
+        endedAt: END,
+        endedBy: "autopilot-expiry",
+      },
+      generatedAt: NOW,
+      tasks: [],
+      auditEvents: [],
+      boardCards: [],
+    });
+
+    expect(digest.headline).toContain("nothing needed action");
+    expect(digest.recommendedNextActions).toEqual(["Nothing needs you right now."]);
+  });
+
+  it("delivers to board, alert bridge, and audit sinks", async () => {
+    const recordBoardDigest = vi.fn(async () => undefined);
+    const auditDigest = vi.fn(async () => undefined);
+    const dispatch = vi.fn(async () => true);
+
+    const digest = await deliverAutopilotAwayDigest({
+      session: {
+        sessionId: `autopilot:${START}`,
+        startedAt: START,
+        endedAt: END,
+        endedBy: "operator-return",
+      },
+      now: () => NOW,
+      boardUrl: "https://monitor.averray.com/monitor",
+      loadTasks: async () => tasks,
+      loadAuditEvents: async () => auditEvents,
+      loadBoardCards: async () => boardCards,
+      recordBoardDigest,
+      alert: { name: "test", dispatch },
+      auditDigest,
+    });
+
+    expect(digest.counts.autoApproved).toBe(1);
+    expect(recordBoardDigest).toHaveBeenCalledOnce();
+    expect(dispatch).toHaveBeenCalledOnce();
+    expect(auditDigest).toHaveBeenCalledOnce();
+    expect(dispatch.mock.calls[0]?.[0].text).toContain("While you were away");
+  });
+});


### PR DESCRIPTION
## What changed
- Added a D1 autopilot session-end digest module that aggregates routed tasks, Hermes auto-approvals, escalations, PR-bearing completions, D3 suspends, failures, and current operator-waiting board cards.
- Wired slack-operator autonomy maintenance so autopilot expiry, operator return, or D3/halt suspension emits one board collaboration digest plus one D4 alert-bridge push.
- Updated the Hermes roadmap D1 row from design-only to in review.

## Checks run
- npm run typecheck
- npm test

## Blast radius
- Affects backend/slack-operator monitor routines only.
- No frontend, indexer, Caddy, contracts, public site, or VPS secret changes.
- Reuses existing SLACK_WEBHOOK_URL/D4 alert bridge; no new env required.

## Safety
- Read-only aggregation and notification only; no task approval, GitHub mutation, deploy, or product mutation behavior changed.
- Existing autopilot-start alert is preserved; autopilot-end alert is replaced by the richer D1 digest.