### PR TITLE
Add standalone LLM usage tracker

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/agent-scorecard.d.ts",
       "import": "./dist/agent-scorecard.js"
     },
+    "./llm-usage": {
+      "types": "./dist/llm-usage.d.ts",
+      "import": "./dist/llm-usage.js"
+    },
     "./agent-invocation": {
       "types": "./dist/agent-invocation.d.ts",
       "import": "./dist/agent-invocation.js"

--- a/packages/averray-mcp/src/agent-scorecard.ts
+++ b/packages/averray-mcp/src/agent-scorecard.ts
@@ -1,5 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { getHandoffMonitor } from "./handoff-events.js";
+import {
+  aggregateLlmUsage,
+  aggregateLlmUsageForAgent,
+  llmUsageLogPath,
+  readLlmUsageEvents,
+  type LlmUsageEvent,
+} from "./llm-usage.js";
 
 export type ScorecardAgent = "codex" | "claude" | "hermes" | "browser" | "unknown";
 export type ScorecardConfidence = "none" | "low" | "medium" | "high";
@@ -11,6 +18,8 @@ export interface AgentScorecardOptions {
   eventLogPath?: string;
   codexTasksPath?: string;
   testbedMissionsPath?: string;
+  llmUsageLogPath?: string;
+  llmUsageEvents?: LlmUsageEvent[];
 }
 
 interface MutableAgentStats {
@@ -54,6 +63,7 @@ export async function getAgentScorecard(options: AgentScorecardOptions = {}) {
   });
   const codexTasks = await readCodexTasks(options.codexTasksPath);
   const testbedMissions = await readTestbedMissions(options.testbedMissionsPath);
+  const llmUsageEvents = options.llmUsageEvents ?? await readLlmUsageEvents(options.llmUsageLogPath ?? llmUsageLogPath());
   return buildAgentScorecard({
     ...monitor,
     codexTasks: {
@@ -62,6 +72,7 @@ export async function getAgentScorecard(options: AgentScorecardOptions = {}) {
       items: codexTasks,
     },
     testbedMissions,
+    llmUsageEvents,
   }, { now });
 }
 
@@ -82,9 +93,14 @@ export function buildAgentScorecard(snapshot: unknown, options: { now?: Date } =
   for (const mission of records(root.testbedMissions)) {
     recordMission(agents, mission);
   }
+  const llmUsageEvents = usageEvents(root.llmUsageEvents);
+  const llmUsage = aggregateLlmUsage(llmUsageEvents);
+  for (const item of llmUsage.byModel) {
+    ensureAgent(agents, scorecardAgent(item.agent));
+  }
 
   const items = Array.from(agents.values())
-    .map(finalizeAgent)
+    .map((agent) => finalizeAgent(agent, llmUsage))
     .sort((a, b) => agentSortKey(a.agent) - agentSortKey(b.agent) || b.sampleCount - a.sampleCount);
 
   const totals = items.reduce(
@@ -103,11 +119,14 @@ export function buildAgentScorecard(snapshot: unknown, options: { now?: Date } =
     schemaVersion: 1,
     kind: "averray_agent_scorecard",
     generatedAt: now.toISOString(),
-    truthBoundary: "Read-only A1 scorecard from monitor events, task queue state, and browser mission reports. Missing cost and autopilot-rework signals are marked as not recorded, not inferred.",
+    truthBoundary: "Read-only A1 scorecard from monitor events, task queue state, browser mission reports, and whitelisted LLM usage counters. Missing cost/token/autopilot-rework signals are marked as not_recorded, not inferred.",
     totals,
+    llmUsage,
     agents: items,
     gaps: [
-      "Cost and token totals are not present in the current runner events.",
+      llmUsage.status === "recorded"
+        ? "LLM usage only includes providers/runs that report whitelisted counters; missing providers stay not_recorded."
+        : "Cost and token totals are not present in the current runner events.",
       "Autopilot auto-approval rework is not yet emitted as a durable signal.",
       "Time-to-PR and time-to-merge need GitHub timeline evidence before they become routing inputs.",
     ],
@@ -207,7 +226,7 @@ function recordMission(agents: Map<ScorecardAgent, MutableAgentStats>, mission: 
   else if (verdict === "fail" || verdict === "failed" || verdict === "block") stats.missionFailed += 1;
 }
 
-function finalizeAgent(stats: MutableAgentStats) {
+function finalizeAgent(stats: MutableAgentStats, llmUsage: ReturnType<typeof aggregateLlmUsage>) {
   const terminalTasks = stats.taskCompleted + stats.taskFailed + stats.taskCancelled;
   const checkTotal = stats.checkPass + stats.checkFail + stats.checkRunning + stats.checkNeutral;
   const sampleCount = stats.handoffs + stats.taskTotal + stats.missionTotal;
@@ -222,6 +241,8 @@ function finalizeAgent(stats: MutableAgentStats) {
   const routingScore = sampleCount > 0
     ? clamp(Math.round((successRate * 0.65 + (checkPassRate ?? successRate) * 0.25 + (1 - failurePenalty) * 0.10) * 100), 0, 100)
     : null;
+  const agentUsage = aggregateLlmUsageForAgent(llmUsage, stats.agent);
+  const tokensRecorded = agentUsage.status === "recorded";
 
   return {
     agent: stats.agent,
@@ -278,10 +299,34 @@ function finalizeAgent(stats: MutableAgentStats) {
       status: stats.taskDurationCount > 0 ? "task_duration_available" : "timeline_not_recorded",
     },
     cost: {
-      status: "not_recorded",
-      totalUsd: null,
-      totalTokens: null,
-      averageUsdPerTask: null,
+      status: agentUsage.costStatus,
+      totalUsd: agentUsage.costUsd,
+      totalTokens: tokensRecorded ? agentUsage.totalTokens : null,
+      averageUsdPerTask: agentUsage.costUsd !== null && stats.taskTotal > 0
+        ? round(agentUsage.costUsd / stats.taskTotal, 6)
+        : null,
+      byModel: agentUsage.byModel.map((entry) => ({
+        model: entry.model,
+        inputTokens: entry.inputTokens,
+        outputTokens: entry.outputTokens,
+        totalTokens: entry.totalTokens,
+        costUsd: entry.costUsd,
+        costStatus: entry.costStatus,
+        runs: entry.runs,
+      })),
+    },
+    tokens: {
+      status: tokensRecorded ? "recorded" : "not_recorded",
+      inputTokens: tokensRecorded ? agentUsage.inputTokens : null,
+      outputTokens: tokensRecorded ? agentUsage.outputTokens : null,
+      totalTokens: tokensRecorded ? agentUsage.totalTokens : null,
+      byModel: agentUsage.byModel.map((entry) => ({
+        model: entry.model,
+        inputTokens: entry.inputTokens,
+        outputTokens: entry.outputTokens,
+        totalTokens: entry.totalTokens,
+        runs: entry.runs,
+      })),
     },
     trust: {
       autopilotAutoApprovals: 0,
@@ -383,9 +428,8 @@ function agentForHandoff(item: Record<string, unknown>): ScorecardAgent {
 
 function taskAgent(task: Record<string, unknown>): ScorecardAgent {
   const agent = (stringField(task, "agent") ?? "").toLowerCase();
-  if (agent === "claude") return "claude";
-  if (agent === "codex") return "codex";
-  if (agent === "hermes") return "hermes";
+  const scorecard = scorecardAgent(agent);
+  if (scorecard !== "unknown") return scorecard;
   return "codex";
 }
 
@@ -402,6 +446,40 @@ function agentFromBranch(branch: string | undefined): ScorecardAgent | undefined
   if (normalized.startsWith("codex/")) return "codex";
   if (normalized.startsWith("claude/")) return "claude";
   return undefined;
+}
+
+function scorecardAgent(value: string): ScorecardAgent {
+  const agent = value.trim().toLowerCase();
+  if (agent === "codex") return "codex";
+  if (agent === "claude") return "claude";
+  if (agent === "hermes") return "hermes";
+  if (agent === "browser" || agent === "tester" || agent === "testbed") return "browser";
+  return "unknown";
+}
+
+function usageEvents(value: unknown): LlmUsageEvent[] {
+  return records(value)
+    .map((event) => {
+      const inputTokens = numberField(event, "inputTokens");
+      const outputTokens = numberField(event, "outputTokens");
+      const agent = stringField(event, "agent");
+      const model = stringField(event, "model");
+      const ts = stringField(event, "ts");
+      if (!agent || !model || !ts || inputTokens === undefined || outputTokens === undefined) return undefined;
+      if (!Number.isInteger(inputTokens) || !Number.isInteger(outputTokens) || inputTokens < 0 || outputTokens < 0) return undefined;
+      const costUsd = numberField(event, "costUsd");
+      return {
+        agent,
+        model,
+        ...(stringField(event, "runId") ? { runId: stringField(event, "runId") } : {}),
+        ...(stringField(event, "taskId") ? { taskId: stringField(event, "taskId") } : {}),
+        inputTokens,
+        outputTokens,
+        ...(costUsd !== undefined ? { costUsd } : {}),
+        ts,
+      };
+    })
+    .filter((event): event is LlmUsageEvent => Boolean(event));
 }
 
 function surfacesForHandoff(summary: Record<string, unknown> | undefined): string[] {

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -1,0 +1,305 @@
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export interface LlmUsageEvent {
+  agent: string;
+  model: string;
+  runId?: string;
+  taskId?: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd?: number;
+  ts: string;
+}
+
+export interface LlmUsageModelRollup {
+  agent: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+  costStatus: "recorded" | "not_recorded";
+  runs: number;
+}
+
+export interface LlmUsageDayRollup {
+  day: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+  costStatus: "recorded" | "not_recorded";
+  runs: number;
+  byModel: LlmUsageModelRollup[];
+}
+
+export interface LlmUsageAggregate {
+  status: "recorded" | "not_recorded";
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+  costStatus: "recorded" | "not_recorded";
+  runs: number;
+  byModel: LlmUsageModelRollup[];
+  byDay: LlmUsageDayRollup[];
+}
+
+export interface LlmUsageCaptureInput {
+  agent: string;
+  model?: string;
+  runId?: string;
+  taskId?: string;
+  ts?: Date;
+  result: unknown;
+}
+
+const DEFAULT_USAGE_LOG_PATH = "/data/llm-usage.jsonl";
+
+export function llmUsageLogPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.LLM_USAGE_LOG_PATH?.trim() || env.AVERRAY_LLM_USAGE_LOG_PATH?.trim() || DEFAULT_USAGE_LOG_PATH;
+}
+
+export async function appendLlmUsageEvent(
+  event: LlmUsageEvent,
+  options: { path?: string } = {}
+): Promise<void> {
+  const path = options.path ?? llmUsageLogPath();
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+export async function readLlmUsageEvents(path: string = llmUsageLogPath()): Promise<LlmUsageEvent[]> {
+  try {
+    const content = await readFile(path, "utf8");
+    return content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => parseUsageLine(line))
+      .filter((event): event is LlmUsageEvent => Boolean(event));
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+export async function recordLlmUsageFromResult(
+  input: LlmUsageCaptureInput,
+  options: { path?: string } = {}
+): Promise<LlmUsageEvent | undefined> {
+  const event = llmUsageEventFromResult(input);
+  if (!event) return undefined;
+  await appendLlmUsageEvent(event, options);
+  return event;
+}
+
+export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEvent | undefined {
+  const usage = firstRecord(
+    recordField(input.result, "usage"),
+    recordField(recordField(input.result, "response"), "usage"),
+    recordField(recordField(input.result, "result"), "usage"),
+    explicitUsageJson(input.result)
+  );
+  if (!usage) return undefined;
+
+  const inputTokens = integerField(usage, "inputTokens")
+    ?? integerField(usage, "input_tokens")
+    ?? integerField(usage, "promptTokens")
+    ?? integerField(usage, "prompt_tokens");
+  const outputTokens = integerField(usage, "outputTokens")
+    ?? integerField(usage, "output_tokens")
+    ?? integerField(usage, "completionTokens")
+    ?? integerField(usage, "completion_tokens");
+  if (inputTokens === undefined || outputTokens === undefined) return undefined;
+
+  const model = stringField(usage, "model")
+    ?? stringField(input.result, "model")
+    ?? stringField(input.result, "modelId")
+    ?? input.model
+    ?? "not_recorded";
+  const costUsd = numberField(usage, "costUsd")
+    ?? numberField(usage, "cost_usd")
+    ?? numberField(input.result, "costUsd")
+    ?? numberField(input.result, "totalCostUsd");
+
+  const event: LlmUsageEvent = {
+    agent: input.agent,
+    model,
+    ...(input.runId ? { runId: input.runId } : {}),
+    ...(input.taskId ? { taskId: input.taskId } : {}),
+    inputTokens,
+    outputTokens,
+    ...(costUsd !== undefined ? { costUsd } : {}),
+    ts: (input.ts ?? new Date()).toISOString(),
+  };
+  return sanitizeUsageEvent(event);
+}
+
+export function aggregateLlmUsage(events: readonly LlmUsageEvent[] = []): LlmUsageAggregate {
+  const byModel = rollupByModel(events);
+  const byDay = rollupByDay(events);
+  const total = totalsFor(events);
+  return {
+    status: events.length > 0 ? "recorded" : "not_recorded",
+    ...total,
+    runs: events.length,
+    byModel,
+    byDay,
+  };
+}
+
+export function aggregateLlmUsageForAgent(
+  aggregate: LlmUsageAggregate,
+  agent: string
+): LlmUsageAggregate {
+  const byModel = aggregate.byModel.filter((entry) => entry.agent === agent);
+  const events = byModel.map((entry) => ({
+    agent: entry.agent,
+    model: entry.model,
+    inputTokens: entry.inputTokens,
+    outputTokens: entry.outputTokens,
+    ...(entry.costUsd !== null ? { costUsd: entry.costUsd } : {}),
+    ts: "1970-01-01T00:00:00.000Z",
+  }));
+  const total = totalsFor(events);
+  return {
+    status: byModel.length > 0 ? "recorded" : "not_recorded",
+    ...total,
+    runs: byModel.reduce((sum, entry) => sum + entry.runs, 0),
+    byModel,
+    byDay: [],
+  };
+}
+
+function rollupByModel(events: readonly LlmUsageEvent[]): LlmUsageModelRollup[] {
+  const groups = new Map<string, LlmUsageEvent[]>();
+  for (const event of events) {
+    const key = `${event.agent}\u0000${event.model}`;
+    groups.set(key, [...(groups.get(key) ?? []), event]);
+  }
+  return Array.from(groups.entries())
+    .map(([key, group]) => {
+      const [agent = "unknown", model = "not_recorded"] = key.split("\u0000");
+      return { agent, model, ...totalsFor(group), runs: group.length };
+    })
+    .sort((a, b) => b.totalTokens - a.totalTokens || a.agent.localeCompare(b.agent) || a.model.localeCompare(b.model));
+}
+
+function rollupByDay(events: readonly LlmUsageEvent[]): LlmUsageDayRollup[] {
+  const groups = new Map<string, LlmUsageEvent[]>();
+  for (const event of events) {
+    const day = event.ts.slice(0, 10);
+    groups.set(day, [...(groups.get(day) ?? []), event]);
+  }
+  return Array.from(groups.entries())
+    .map(([day, group]) => ({
+      day,
+      ...totalsFor(group),
+      runs: group.length,
+      byModel: rollupByModel(group),
+    }))
+    .sort((a, b) => b.day.localeCompare(a.day));
+}
+
+function totalsFor(events: readonly Pick<LlmUsageEvent, "inputTokens" | "outputTokens" | "costUsd">[]) {
+  const inputTokens = events.reduce((sum, event) => sum + event.inputTokens, 0);
+  const outputTokens = events.reduce((sum, event) => sum + event.outputTokens, 0);
+  const costEvents = events.filter((event) => typeof event.costUsd === "number");
+  const costUsd = costEvents.length > 0
+    ? round(costEvents.reduce((sum, event) => sum + (event.costUsd ?? 0), 0), 6)
+    : null;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    costUsd,
+    costStatus: costEvents.length > 0 ? "recorded" as const : "not_recorded" as const,
+  };
+}
+
+function sanitizeUsageEvent(event: LlmUsageEvent): LlmUsageEvent | undefined {
+  if (!event.agent.trim() || !event.model.trim()) return undefined;
+  if (!Number.isInteger(event.inputTokens) || event.inputTokens < 0) return undefined;
+  if (!Number.isInteger(event.outputTokens) || event.outputTokens < 0) return undefined;
+  if (event.costUsd !== undefined && (!Number.isFinite(event.costUsd) || event.costUsd < 0)) return undefined;
+  if (!Number.isFinite(Date.parse(event.ts))) return undefined;
+  return {
+    agent: event.agent.trim(),
+    model: event.model.trim(),
+    ...(event.runId ? { runId: event.runId.trim() } : {}),
+    ...(event.taskId ? { taskId: event.taskId.trim() } : {}),
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    ...(event.costUsd !== undefined ? { costUsd: round(event.costUsd, 6) } : {}),
+    ts: new Date(event.ts).toISOString(),
+  };
+}
+
+function parseUsageLine(line: string): LlmUsageEvent | undefined {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    if (!isRecord(parsed)) return undefined;
+    return sanitizeUsageEvent({
+      agent: stringField(parsed, "agent") ?? "",
+      model: stringField(parsed, "model") ?? "",
+      ...(stringField(parsed, "runId") ? { runId: stringField(parsed, "runId") } : {}),
+      ...(stringField(parsed, "taskId") ? { taskId: stringField(parsed, "taskId") } : {}),
+      inputTokens: integerField(parsed, "inputTokens") ?? -1,
+      outputTokens: integerField(parsed, "outputTokens") ?? -1,
+      ...(numberField(parsed, "costUsd") !== undefined ? { costUsd: numberField(parsed, "costUsd") } : {}),
+      ts: stringField(parsed, "ts") ?? "",
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function explicitUsageJson(value: unknown): Record<string, unknown> | undefined {
+  const stdout = isRecord(value) && typeof value.stdout === "string" ? value.stdout : "";
+  const stderr = isRecord(value) && typeof value.stderr === "string" ? value.stderr : "";
+  const match = `${stdout}\n${stderr}`.match(/(?:^|\n)LLM_USAGE_JSON:\s*(\{[^\n]+\})/);
+  if (!match?.[1]) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(match[1]);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function firstRecord(...values: Array<Record<string, unknown> | undefined>): Record<string, unknown> | undefined {
+  return values.find((value): value is Record<string, unknown> => Boolean(value));
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | undefined {
+  return isRecord(value) && isRecord(value[key]) ? value[key] : undefined;
+}
+
+function stringField(record: unknown, key: string): string | undefined {
+  if (!isRecord(record)) return undefined;
+  const value = record[key];
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function numberField(record: unknown, key: string): number | undefined {
+  if (!isRecord(record)) return undefined;
+  const value = record[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function integerField(record: unknown, key: string): number | undefined {
+  const value = numberField(record, key);
+  return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function round(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -71,6 +71,51 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getByText(/Live · 10:30:00/)).toBeTruthy();
   });
 
+  test("renders LLM usage when the monitor snapshot reports counters", () => {
+    const board: MonitorBoard = {
+      ...richBoard,
+      llmUsage: {
+        status: "recorded",
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+        costUsd: null,
+        costStatus: "not_recorded",
+        runs: 1,
+        byModel: [],
+        byDay: [
+          {
+            day: "2026-05-31",
+            inputTokens: 100,
+            outputTokens: 40,
+            totalTokens: 140,
+            costUsd: null,
+            costStatus: "not_recorded",
+            runs: 1,
+            byModel: [
+              {
+                agent: "codex",
+                model: "gpt-5-codex",
+                inputTokens: 100,
+                outputTokens: 40,
+                totalTokens: 140,
+                costUsd: null,
+                costStatus: "not_recorded",
+                runs: 1,
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const { getByRole, getByText } = render(<BoardView board={board} status="open" />);
+    expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
+    expect(getByText("2026-05-31")).toBeTruthy();
+    expect(getByText("140 tokens")).toBeTruthy();
+    expect(getByText("gpt-5-codex")).toBeTruthy();
+    expect(getByText("not_recorded")).toBeTruthy();
+  });
+
   test("Refresh button is wired to onRefresh", () => {
     const onRefresh = vi.fn();
     const { getByRole } = render(<BoardView board={richBoard} status="open" onRefresh={onRefresh} />);

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -19,7 +19,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
-import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
 import { CreateTaskForm } from "./CreateTaskForm.js";
@@ -278,6 +278,7 @@ export function BoardView({
             onSearchChange={setQuery}
             searchInputRef={searchInputRef}
           />
+          <LlmUsagePanel usage={board?.llmUsage} />
           <Board
             grouped={displayGrouped}
             expanded={expanded}
@@ -336,4 +337,40 @@ function formatClock(iso: string | undefined): string {
   if (Number.isNaN(d.getTime())) return "";
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
+}
+
+function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
+  const latestDay = usage?.byDay?.[0];
+  const models = latestDay?.byModel?.slice(0, 4) ?? [];
+  return (
+    <section className="hm-llm-usage" aria-label="LLM usage">
+      <div className="hm-llm-usage-head">
+        <div>
+          <span className="hm-kicker">LLM usage</span>
+          <strong>{latestDay?.day ?? "not recorded"}</strong>
+        </div>
+        <span className="hm-llm-usage-total">
+          {usage?.status === "recorded" ? `${formatNumber(latestDay?.totalTokens ?? 0)} tokens` : "not_recorded"}
+        </span>
+      </div>
+      <div className="hm-llm-usage-grid">
+        {models.length > 0 ? models.map((entry) => (
+          <div className="hm-llm-usage-row" key={`${entry.agent}:${entry.model}`}>
+            <span>
+              <strong>{entry.agent}</strong>
+              <small>{entry.model}</small>
+            </span>
+            <span>{formatNumber(entry.totalTokens)} tok</span>
+            <span>{entry.costStatus === "recorded" && entry.costUsd !== null ? `$${entry.costUsd.toFixed(4)}` : "not_recorded"}</span>
+          </div>
+        )) : (
+          <div className="hm-llm-usage-empty">Reported usage counters have not arrived yet.</div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
 }

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -11,6 +11,41 @@ export interface MonitorBoard {
   cards: BoardCard[];
   /** ISO timestamp from the server */
   at: string;
+  llmUsage?: LlmUsageAggregate;
+}
+
+export interface LlmUsageModelRollup {
+  agent: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+  costStatus: "recorded" | "not_recorded";
+  runs: number;
+}
+
+export interface LlmUsageDayRollup {
+  day: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+  costStatus: "recorded" | "not_recorded";
+  runs: number;
+  byModel: LlmUsageModelRollup[];
+}
+
+export interface LlmUsageAggregate {
+  status: "recorded" | "not_recorded";
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  costUsd: number | null;
+  costStatus: "recorded" | "not_recorded";
+  runs: number;
+  byModel: LlmUsageModelRollup[];
+  byDay: LlmUsageDayRollup[];
 }
 
 export interface MonitorEvent {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -368,6 +368,58 @@ body { margin: 0; }
   color: var(--hm-muted);
   letter-spacing: 0 !important;
 }
+.hm-llm-usage {
+  margin: 0 22px 10px;
+  padding: 10px 12px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  display: grid;
+  gap: 9px;
+}
+.hm-llm-usage-head,
+.hm-llm-usage-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hm-llm-usage-head strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--hm-ink);
+}
+.hm-llm-usage-total,
+.hm-llm-usage-row,
+.hm-llm-usage-empty {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-llm-usage-grid {
+  display: grid;
+  gap: 6px;
+}
+.hm-llm-usage-row {
+  padding-top: 6px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-llm-usage-row span:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 1px;
+}
+.hm-llm-usage-row strong {
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--hm-ink);
+}
+.hm-llm-usage-row small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .hm-filter-chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 6px 10px;

--- a/services/slack-operator/src/claude-task-runner.ts
+++ b/services/slack-operator/src/claude-task-runner.ts
@@ -22,6 +22,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
+import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 import {
   budgetGate,
@@ -62,6 +63,9 @@ export interface ClaudeTaskRunResult {
   stdout: string;
   stderr: string;
   summary?: string;
+  usage?: unknown;
+  model?: string;
+  costUsd?: number;
 }
 
 export type ClaudeTaskExecutor = (
@@ -177,6 +181,12 @@ export async function runClaudeTaskRunnerOnce(
 
   try {
     const result = await executor(claimed, config, { mode });
+    await recordLlmUsageFromResult({
+      agent: "claude",
+      taskId: claimed.id,
+      ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
+      result,
+    }).catch(() => undefined);
     if (result.exitCode === 0) {
       const summary = sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout));
       const task = await completeCodexTask(claimed.id, {

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
+import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 import type { CodexTask } from "./codex-task-queue.js";
 import {
@@ -28,6 +29,9 @@ export interface CodexTaskRunResult {
   stdout: string;
   stderr: string;
   summary?: string;
+  usage?: unknown;
+  model?: string;
+  costUsd?: number;
 }
 
 export type CodexTaskExecutor = (
@@ -100,6 +104,12 @@ export async function runCodexTaskRunnerOnce(
 
   try {
     const result = await executor(claimed, config);
+    await recordLlmUsageFromResult({
+      agent: "codex",
+      taskId: claimed.id,
+      ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
+      result,
+    }).catch(() => undefined);
     if (result.exitCode === 0) {
       const summary = sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout));
       const task = await completeCodexTask(claimed.id, {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -8,6 +8,7 @@ import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-run
 import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
 import { getHandoffMonitor } from "@avg/averray-mcp/handoff-events";
 import { buildAgentScorecard } from "@avg/averray-mcp/agent-scorecard";
+import { readLlmUsageEvents } from "@avg/averray-mcp/llm-usage";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
 import {
   formatOperatorResultForSlack,
@@ -2081,7 +2082,25 @@ async function loadMonitorSnapshot(
       error: error instanceof Error ? error.message : String(error),
     });
   }
-  const degraded = phases.some((phase) => phase.status !== "ok");
+  const llmUsageStartedAt = Date.now();
+  let llmUsageEvents: Awaited<ReturnType<typeof readLlmUsageEvents>> = [];
+  try {
+    llmUsageEvents = await readLlmUsageEvents();
+    phases.push({
+      name: "llm_usage_log",
+      status: "ok",
+      durationMs: Date.now() - llmUsageStartedAt,
+    });
+  } catch (error) {
+    logger.warn({ err: error }, "monitor_llm_usage_skipped");
+    phases.push({
+      name: "llm_usage_log",
+      status: "skipped",
+      durationMs: Date.now() - llmUsageStartedAt,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+  const degraded = phases.some((phase) => phase.status !== "ok" && phase.name !== "llm_usage_log");
   const diagnostics = {
     monitorSnapshot: {
       status: degraded ? "degraded" : "ok",
@@ -2097,6 +2116,7 @@ async function loadMonitorSnapshot(
     codexTasks,
     testbedMissions: listTestbedMissionRuns({ limit: 20 }),
     testbedMissionRunner: summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat()),
+    llmUsageEvents,
     collaborationMessages: listCollaborationMessages({ limit: 200 }),
     diagnostics,
   };

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -19,6 +19,7 @@
 // SSE `board.snapshot` event carries.
 
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
+import { aggregateLlmUsage, type LlmUsageAggregate, type LlmUsageEvent } from "@avg/averray-mcp/llm-usage";
 import type {
   HermesBoardCardSnapshot,
   HermesBoardSnapshot,
@@ -206,6 +207,7 @@ export interface BoardSnapshotV2 {
   cards: BoardCard[];
   at: string;
   repo: string;
+  llmUsage: LlmUsageAggregate;
 }
 
 // ── Lane normalization ──────────────────────────────────────────────
@@ -451,6 +453,33 @@ function asString(value: unknown): string | undefined {
 
 function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function usageEvents(value: unknown): LlmUsageEvent[] {
+  return asArray(value)
+    .map((entry) => {
+      const event = asRecord(entry);
+      if (!event) return undefined;
+      const agent = asString(event.agent);
+      const model = asString(event.model);
+      const ts = asString(event.ts);
+      const inputTokens = asFiniteNumber(event.inputTokens);
+      const outputTokens = asFiniteNumber(event.outputTokens);
+      if (!agent || !model || !ts || inputTokens === undefined || outputTokens === undefined) return undefined;
+      if (!Number.isInteger(inputTokens) || !Number.isInteger(outputTokens)) return undefined;
+      const costUsd = asFiniteNumber(event.costUsd);
+      return {
+        agent,
+        model,
+        ...(asString(event.runId) ? { runId: asString(event.runId) } : {}),
+        ...(asString(event.taskId) ? { taskId: asString(event.taskId) } : {}),
+        inputTokens,
+        outputTokens,
+        ...(costUsd !== undefined ? { costUsd } : {}),
+        ts,
+      };
+    })
+    .filter((event): event is LlmUsageEvent => Boolean(event));
 }
 
 /**
@@ -897,5 +926,6 @@ export function buildV2BoardSnapshot(
     cards: [...cards, ...taskCards],
     at: now().toISOString(),
     repo: opts.repo ?? "",
+    llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents)),
   };
 }

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 import type { Locator, Page } from "playwright-core";
 
@@ -63,6 +64,9 @@ export interface TestbedMissionRunResult {
   stderr: string;
   reportText?: string;
   summary?: string;
+  usage?: unknown;
+  model?: string;
+  costUsd?: number;
 }
 
 export type TestbedMissionExecutor = (
@@ -143,6 +147,12 @@ export async function runTestbedMissionRunnerOnce(
 
   try {
     const result = await executor(mission, config);
+    await recordLlmUsageFromResult({
+      agent: "hermes",
+      taskId: mission.id,
+      runId: mission.id,
+      result,
+    }).catch(() => undefined);
     if (result.exitCode !== 0) {
       const reason = summarizeFailure(result);
       const failed = failTestbedMissionRun(mission.id, {

--- a/test/unit/agent-scorecard.test.ts
+++ b/test/unit/agent-scorecard.test.ts
@@ -80,6 +80,25 @@ describe("A1 agent scorecard", () => {
           result: { verdict: "pass" },
         },
       ],
+      llmUsageEvents: [
+        {
+          agent: "codex",
+          model: "gpt-5-codex",
+          taskId: "codex-task-1",
+          inputTokens: 300,
+          outputTokens: 70,
+          ts: "2026-05-31T10:11:00.000Z",
+        },
+        {
+          agent: "claude",
+          model: "claude-sonnet-4-5",
+          taskId: "claude-task-1",
+          inputTokens: 200,
+          outputTokens: 80,
+          costUsd: 0.04,
+          ts: "2026-05-31T10:06:00.000Z",
+        },
+      ],
     }, { now: new Date("2026-05-31T12:00:00.000Z") });
 
     expect(scorecard).toMatchObject({
@@ -98,6 +117,13 @@ describe("A1 agent scorecard", () => {
         mutatesGithub: false,
         mutatesRunnerQueue: false,
       },
+    });
+    expect(scorecard.llmUsage).toMatchObject({
+      status: "recorded",
+      inputTokens: 500,
+      outputTokens: 150,
+      totalTokens: 650,
+      costUsd: 0.04,
     });
 
     const codex = scorecard.agents.find((agent) => agent.agent === "codex");
@@ -126,6 +152,13 @@ describe("A1 agent scorecard", () => {
       cost: {
         status: "not_recorded",
         totalUsd: null,
+        totalTokens: 370,
+      },
+      tokens: {
+        status: "recorded",
+        inputTokens: 300,
+        outputTokens: 70,
+        totalTokens: 370,
       },
       trust: {
         status: "not_recorded",
@@ -157,6 +190,15 @@ describe("A1 agent scorecard", () => {
         failed: 1,
         attempts: 2,
         successRate: 0,
+      },
+      cost: {
+        status: "recorded",
+        totalUsd: 0.04,
+        totalTokens: 280,
+      },
+      tokens: {
+        status: "recorded",
+        totalTokens: 280,
       },
     });
 
@@ -190,6 +232,7 @@ describe("A1 agent scorecard", () => {
     try {
       const codexTasksPath = join(dir, "codex-tasks.json");
       const testbedMissionsPath = join(dir, "testbed-missions.json");
+      const llmUsageLogPath = join(dir, "llm-usage.jsonl");
       await writeFile(codexTasksPath, JSON.stringify({
         items: [
           {
@@ -210,11 +253,20 @@ describe("A1 agent scorecard", () => {
           },
         ],
       }));
+      await writeFile(llmUsageLogPath, JSON.stringify({
+        agent: "codex",
+        model: "gpt-5-codex",
+        taskId: "codex-task-2",
+        inputTokens: 10,
+        outputTokens: 4,
+        ts: "2026-05-31T11:00:00.000Z",
+      }) + "\n");
 
       const scorecard = await getAgentScorecard({
         eventLogPath: join(dir, "missing-events.jsonl"),
         codexTasksPath,
         testbedMissionsPath,
+        llmUsageLogPath,
         now: new Date("2026-05-31T12:00:00.000Z"),
       });
 
@@ -225,6 +277,7 @@ describe("A1 agent scorecard", () => {
       });
       expect(scorecard.agents.find((agent) => agent.agent === "codex")).toMatchObject({
         tasks: { completed: 1 },
+        tokens: { totalTokens: 14 },
       });
       expect(scorecard.agents.find((agent) => agent.agent === "hermes")).toMatchObject({
         missions: { partial: 1 },

--- a/test/unit/codex-task-runner.test.ts
+++ b/test/unit/codex-task-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
@@ -46,6 +46,9 @@ describe("codex task runner", () => {
 
   it("claims an approved task, executes it, and marks it completed", async () => {
     const path = await tempQueuePath();
+    const usagePath = join(path.replace(/tasks\.json$/, ""), "llm-usage.jsonl");
+    const previousUsagePath = process.env.LLM_USAGE_LOG_PATH;
+    process.env.LLM_USAGE_LOG_PATH = usagePath;
     const proposed = await proposeCodexTask({
       repo: "averray-agent/agent",
       pullRequestNumber: 390,
@@ -64,11 +67,26 @@ describe("codex task runner", () => {
           stdout: "branch pushed\nready for Hermes\n",
           stderr: "",
           summary: "ready for Hermes",
+          usage: {
+            model: "gpt-5-codex",
+            inputTokens: 20,
+            outputTokens: 8,
+          },
         };
       },
     });
+    if (previousUsagePath === undefined) delete process.env.LLM_USAGE_LOG_PATH;
+    else process.env.LLM_USAGE_LOG_PATH = previousUsagePath;
 
     expect(result.status).toBe("completed");
+    await expect(readFile(usagePath, "utf8").then((line) => JSON.parse(line))).resolves.toMatchObject({
+      agent: "codex",
+      model: "gpt-5-codex",
+      taskId: proposed.task.id,
+      runId: "github-pr-390",
+      inputTokens: 20,
+      outputTokens: 8,
+    });
     const [task] = await listCodexTasks({ path });
     expect(task).toMatchObject({
       id: proposed.task.id,

--- a/test/unit/llm-usage.test.ts
+++ b/test/unit/llm-usage.test.ts
@@ -1,0 +1,130 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateLlmUsage,
+  llmUsageEventFromResult,
+  recordLlmUsageFromResult,
+} from "../../packages/averray-mcp/src/llm-usage.js";
+
+describe("LLM usage tracker", () => {
+  it("records a whitelisted usage event with the expected shape", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-llm-usage-"));
+    try {
+      const path = join(dir, "llm-usage.jsonl");
+      const event = await recordLlmUsageFromResult({
+        agent: "claude",
+        model: "claude-sonnet-4-5",
+        runId: "run-1",
+        taskId: "task-1",
+        ts: new Date("2026-05-31T12:00:00.000Z"),
+        result: {
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cost_usd: 0.0123456,
+          },
+        },
+      }, { path });
+
+      expect(event).toEqual({
+        agent: "claude",
+        model: "claude-sonnet-4-5",
+        runId: "run-1",
+        taskId: "task-1",
+        inputTokens: 100,
+        outputTokens: 25,
+        costUsd: 0.012346,
+        ts: "2026-05-31T12:00:00.000Z",
+      });
+      expect(JSON.parse((await readFile(path, "utf8")).trim())).toEqual(event);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("aggregates per agent/model/day and leaves bundled cost as not_recorded", () => {
+    const aggregate = aggregateLlmUsage([
+      {
+        agent: "codex",
+        model: "gpt-5-codex",
+        taskId: "codex-task",
+        inputTokens: 10,
+        outputTokens: 5,
+        ts: "2026-05-31T01:00:00.000Z",
+      },
+      {
+        agent: "claude",
+        model: "claude-sonnet-4-5",
+        taskId: "claude-task",
+        inputTokens: 20,
+        outputTokens: 7,
+        costUsd: 0.02,
+        ts: "2026-05-31T02:00:00.000Z",
+      },
+      {
+        agent: "claude",
+        model: "claude-sonnet-4-5",
+        taskId: "claude-task-2",
+        inputTokens: 3,
+        outputTokens: 2,
+        costUsd: 0.01,
+        ts: "2026-06-01T02:00:00.000Z",
+      },
+    ]);
+
+    expect(aggregate).toMatchObject({
+      status: "recorded",
+      inputTokens: 33,
+      outputTokens: 14,
+      totalTokens: 47,
+      costUsd: 0.03,
+      costStatus: "recorded",
+      runs: 3,
+    });
+    expect(aggregate.byModel.find((entry) => entry.agent === "codex")).toMatchObject({
+      model: "gpt-5-codex",
+      totalTokens: 15,
+      costUsd: null,
+      costStatus: "not_recorded",
+    });
+    expect(aggregate.byDay.map((day) => day.day)).toEqual(["2026-06-01", "2026-05-31"]);
+    expect(aggregate.byDay.find((day) => day.day === "2026-05-31")).toMatchObject({
+      totalTokens: 42,
+      costUsd: 0.02,
+    });
+  });
+
+  it("does not copy prompts or secrets into usage events", () => {
+    const event = llmUsageEventFromResult({
+      agent: "hermes",
+      taskId: "mission-1",
+      ts: new Date("2026-05-31T12:00:00.000Z"),
+      result: {
+        model: "deepseek-v4-pro:cloud",
+        prompt: "private operator prompt",
+        apiKey: "sk-should-never-appear",
+        usage: {
+          inputTokens: 12,
+          outputTokens: 8,
+          secret: "also-nope",
+        },
+      },
+    });
+
+    const serialized = JSON.stringify(event);
+    expect(event).toEqual({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      taskId: "mission-1",
+      inputTokens: 12,
+      outputTokens: 8,
+      ts: "2026-05-31T12:00:00.000Z",
+    });
+    expect(serialized).not.toContain("private operator prompt");
+    expect(serialized).not.toContain("sk-should-never-appear");
+    expect(serialized).not.toContain("also-nope");
+  });
+});


### PR DESCRIPTION
## What changed & why

Adds a standalone LLM usage tracker for the monitor board:

- captures whitelisted per-run usage counters from runner/tester results when runtimes report them
- appends durable JSONL usage events to `LLM_USAGE_LOG_PATH` / `AVERRAY_LLM_USAGE_LOG_PATH` (default `/data/llm-usage.jsonl`)
- aggregates usage by agent/model/day and feeds the existing agent scorecard cost/token fields
- exposes the aggregate through `/monitor/agents` and `/monitor/v2/board`, with a small monitor board LLM usage panel
- keeps providers without reported cost/token data as `not_recorded`; no prompts, messages, keys, or secrets are persisted

## Affected surfaces
- [x] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No ops/compose changes. Rollout can use the default `/data/llm-usage.jsonl` path or set `LLM_USAGE_LOG_PATH` / `AVERRAY_LLM_USAGE_LOG_PATH` if the deployment wants a different durable mount. Rollback is normal revert; missing/unreadable usage logs do not block runner completion and do not degrade the monitor board.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

Usage is recorded only when the runtime/command result exposes token counters. Codex bundled cost stays `not_recorded`; Hermes/deepseek stays `not_recorded` unless a response includes usage counters. This intentionally avoids estimating or inventing pricing.