### PR TITLE
feat: add Hermes decision records

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -36,6 +36,10 @@
     "./dispatch-policy": {
       "types": "./dist/dispatch-policy.d.ts",
       "import": "./dist/dispatch-policy.js"
+    },
+    "./decision-records": {
+      "types": "./dist/decision-records.d.ts",
+      "import": "./dist/decision-records.js"
     }
   },
   "scripts": {

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -33,6 +33,11 @@ import {
   parseLearnedRoutingConfig,
   type LearnedRoutingConfig,
 } from "./learned-routing.js";
+import {
+  createHermesDecisionRecord,
+  extendHermesDecisionRecord,
+  type HermesDecisionRecord,
+} from "./decision-records.js";
 
 export type AgentInvocationIntent =
   | "operator_command"
@@ -55,6 +60,8 @@ export interface ProposedAgentTask {
   /** O4-PR2 routing: persisted risk tier (PR3's autopilot reads it) + why. */
   riskTier?: RiskTier;
   routingReason?: string;
+  /** D2: durable explanation for the Hermes routing decision. */
+  decisionRecord?: HermesDecisionRecord;
 }
 
 /** A queued task, as returned by GET /monitor/codex-tasks (for the daily budget). */
@@ -872,7 +879,33 @@ async function invokeEnqueueAgentTask(
 
   const env = deps.enqueueEnv ?? process.env;
   const routing = agentExplicit
-    ? staticRouting
+    ? {
+      ...staticRouting,
+      decisionRecord: createHermesDecisionRecord({
+        kind: "routing",
+        subject: { type: "repo", id: repo, repo },
+        decision: `routed to ${explicitAgent}`,
+        reasons: [
+          `The request explicitly selected ${explicitAgent}.`,
+          `Hermes still classified the task as ${staticRouting.riskTier}-risk for operator gates.`,
+          staticRouting.reason,
+        ],
+        inputs: {
+          riskTier: staticRouting.riskTier,
+          routingReason: staticRouting.reason,
+          staticDecision: staticRouting,
+          explicitAgent: true,
+          wouldChangeDecision: "A different explicit agent in the request would change the selected agent; the risk tier still comes from the static classifier.",
+          policyGates: { dispatchEvaluated: false },
+        },
+        outcome: {
+          summary: `${explicitAgent} selected from the explicit request; task still waits on operator gates.`,
+          waitingNext: "Operator dispatch gate or the autopilot gate.",
+        },
+        safety: { readOnly: true, mutates: false },
+        generatedAt: deps.now ?? startedAt,
+      }),
+    }
     : await resolveLearnedRouting(routingInput, staticRouting, deps, env);
   const agent: "codex" | "claude" = agentExplicit ? explicitAgent : routing.agent;
 
@@ -891,8 +924,36 @@ async function invokeEnqueueAgentTask(
     todayCount: hermesToday.length,
     todayRepoCount: hermesToday.filter((t) => t.repo === repo).length,
   });
+  const decisionRecord = routing.decisionRecord
+    ? extendHermesDecisionRecord(routing.decisionRecord, {
+      inputs: {
+        policyGates: {
+          dispatchEvaluated: true,
+          dispatchAllowed: decision.allowed,
+          dispatchReason: decision.reason,
+          allowedRepos: policy.allowedRepos,
+          allowedAgents: policy.allowedAgents,
+        },
+        budgetGates: {
+          perDayMax: policy.perDayMax,
+          perRepoPerDayMax: policy.perRepoPerDayMax,
+          todayCount: hermesToday.length,
+          todayRepoCount: hermesToday.filter((t) => t.repo === repo).length,
+        },
+        wouldChangeDecision: decision.allowed
+          ? "A dispatch policy block, exhausted budget, or explicit operator override would prevent this proposed task from moving forward."
+          : "Allowlisting the repo/agent or restoring budget would let Hermes propose this task.",
+      },
+      outcome: {
+        summary: decision.allowed
+          ? `Task proposed for ${agent}; it is waiting at the dispatch gate.`
+          : `Task was not proposed because the dispatch gate returned ${decision.reason}.`,
+        waitingNext: decision.allowed ? "Operator dispatch gate or the autopilot gate." : "Operator policy review.",
+      },
+    })
+    : undefined;
   if (!decision.allowed) {
-    return blockedInvocation(invocation, startedAt, decision.reason, undefined, {
+    return blockedInvocation(invocation, startedAt, decision.reason, decisionRecord, {
       mutates: false,
       localCheckpoint: false,
     });
@@ -907,6 +968,7 @@ async function invokeEnqueueAgentTask(
     requester: "hermes",
     riskTier: routing.riskTier,
     routingReason: routing.reason,
+    ...(decisionRecord ? { decisionRecord } : {}),
     ...(input.pullRequestNumber ? { pullRequestNumber: input.pullRequestNumber } : {}),
     ...(input.reason ? { reason: input.reason } : {}),
   });
@@ -923,6 +985,7 @@ async function invokeEnqueueAgentTask(
       agentExplicit,
       riskTier: routing.riskTier,
       routingReason: routing.reason,
+      ...(decisionRecord ? { decisionRecord } : {}),
       requester: "hermes",
       note: "Task proposed; it lands on the board and awaits operator approval. Never auto-approved or auto-run.",
     },

--- a/packages/averray-mcp/src/decision-records.ts
+++ b/packages/averray-mcp/src/decision-records.ts
@@ -1,0 +1,221 @@
+export type HermesDecisionKind =
+  | "routing"
+  | "auto_approval"
+  | "escalation"
+  | "anomaly_pause"
+  | "away_digest";
+
+export type HermesDecisionSubjectType =
+  | "task"
+  | "card"
+  | "repo"
+  | "pr"
+  | "mission"
+  | "digest"
+  | "autopilot_session";
+
+export interface HermesDecisionSubject {
+  type: HermesDecisionSubjectType;
+  id: string;
+  repo?: string;
+  pullRequestNumber?: number;
+}
+
+export interface HermesDecisionOutcome {
+  summary: string;
+  waitingNext?: string;
+  changed?: string[];
+}
+
+export interface HermesDecisionSafety {
+  readOnly: boolean;
+  mutates: boolean;
+  mutatesGithub?: boolean;
+  mutatesAverray?: boolean;
+  editsWikipedia?: boolean;
+}
+
+export interface HermesDecisionRecord {
+  schemaVersion: 1;
+  recordType: "hermes_decision_record";
+  id: string;
+  kind: HermesDecisionKind;
+  subject: HermesDecisionSubject;
+  decision: string;
+  reasons: string[];
+  inputs: Record<string, unknown>;
+  outcome: HermesDecisionOutcome;
+  safety: HermesDecisionSafety;
+  generatedAt: string;
+}
+
+export interface CreateHermesDecisionRecordInput {
+  kind: HermesDecisionKind;
+  subject: HermesDecisionSubject;
+  decision: string;
+  reasons: string[];
+  inputs?: Record<string, unknown>;
+  outcome: HermesDecisionOutcome;
+  safety: HermesDecisionSafety;
+  generatedAt?: Date | string;
+}
+
+export interface ExtendHermesDecisionRecordInput {
+  inputs?: Record<string, unknown>;
+  reasons?: string[];
+  outcome?: HermesDecisionOutcome;
+  safety?: HermesDecisionSafety;
+}
+
+const SECRET_KEY_PATTERN = /(token|secret|private.?key|password|credential|mnemonic|authorization|cookie|webhook|api.?key|bearer)/i;
+const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
+const PRIVATE_KEY_PATTERN = /\b(?:private[_ -]?key|secret|token|password)\s*[:=]\s*([^\s,;]+)/gi;
+const OPENAI_KEY_PATTERN = /\bsk-[A-Za-z0-9_-]{16,}\b/g;
+
+export function createHermesDecisionRecord(input: CreateHermesDecisionRecordInput): HermesDecisionRecord {
+  const generatedAt = normalizeGeneratedAt(input.generatedAt);
+  const subject = sanitizeSubject(input.subject);
+  return {
+    schemaVersion: 1,
+    recordType: "hermes_decision_record",
+    id: decisionRecordId(input.kind, subject, generatedAt),
+    kind: input.kind,
+    subject,
+    decision: sanitizeText(input.decision) || input.kind,
+    reasons: normalizeReasons(input.reasons),
+    inputs: sanitizeDecisionValue(input.inputs ?? {}) as Record<string, unknown>,
+    outcome: sanitizeOutcome(input.outcome),
+    safety: sanitizeSafety(input.safety),
+    generatedAt,
+  };
+}
+
+export function extendHermesDecisionRecord(
+  record: HermesDecisionRecord,
+  patch: ExtendHermesDecisionRecordInput,
+): HermesDecisionRecord {
+  const next = createHermesDecisionRecord({
+    kind: record.kind,
+    subject: record.subject,
+    decision: record.decision,
+    reasons: patch.reasons ?? record.reasons,
+    inputs: {
+      ...record.inputs,
+      ...(patch.inputs ?? {}),
+    },
+    outcome: patch.outcome ?? record.outcome,
+    safety: patch.safety ?? record.safety,
+    generatedAt: record.generatedAt,
+  });
+  return { ...next, id: record.id };
+}
+
+export function whyHermesLine(record: HermesDecisionRecord): string {
+  const reason = record.reasons[0] ?? record.outcome.summary;
+  return `Why Hermes did this: ${reason}`;
+}
+
+export function isHermesDecisionRecord(value: unknown): value is HermesDecisionRecord {
+  if (!isRecord(value)) return false;
+  return value.schemaVersion === 1
+    && value.recordType === "hermes_decision_record"
+    && typeof value.id === "string"
+    && isDecisionKind(value.kind)
+    && isRecord(value.subject)
+    && typeof value.decision === "string"
+    && Array.isArray(value.reasons)
+    && isRecord(value.inputs)
+    && isRecord(value.outcome)
+    && isRecord(value.safety)
+    && typeof value.generatedAt === "string";
+}
+
+export function sanitizeDecisionValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.slice(0, 50).map((item) => sanitizeDecisionValue(item));
+  }
+  if (isRecord(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, field] of Object.entries(value)) {
+      out[key] = SECRET_KEY_PATTERN.test(key) ? "[redacted]" : sanitizeDecisionValue(field);
+    }
+    return out;
+  }
+  if (typeof value === "string") return sanitizeText(value);
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "boolean" || value === null || value === undefined) return value ?? null;
+  return String(value);
+}
+
+function normalizeGeneratedAt(value: Date | string | undefined): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string" && Number.isFinite(Date.parse(value))) return new Date(value).toISOString();
+  return new Date().toISOString();
+}
+
+function sanitizeSubject(subject: HermesDecisionSubject): HermesDecisionSubject {
+  return {
+    type: subject.type,
+    id: sanitizeText(subject.id) || "unknown",
+    ...(subject.repo ? { repo: sanitizeText(subject.repo) } : {}),
+    ...(typeof subject.pullRequestNumber === "number" && Number.isFinite(subject.pullRequestNumber)
+      ? { pullRequestNumber: subject.pullRequestNumber }
+      : {}),
+  };
+}
+
+function normalizeReasons(reasons: string[]): string[] {
+  const normalized = reasons
+    .map(sanitizeText)
+    .map((reason) => reason.trim())
+    .filter(Boolean)
+    .slice(0, 8);
+  return normalized.length > 0 ? normalized : ["Hermes recorded the decision for operator review."];
+}
+
+function sanitizeOutcome(outcome: HermesDecisionOutcome): HermesDecisionOutcome {
+  return {
+    summary: sanitizeText(outcome.summary) || "Decision recorded.",
+    ...(outcome.waitingNext ? { waitingNext: sanitizeText(outcome.waitingNext) } : {}),
+    ...(outcome.changed ? { changed: outcome.changed.map(sanitizeText).filter(Boolean).slice(0, 10) } : {}),
+  };
+}
+
+function sanitizeSafety(safety: HermesDecisionSafety): HermesDecisionSafety {
+  return {
+    readOnly: safety.readOnly === true,
+    mutates: safety.mutates === true,
+    ...(safety.mutatesGithub !== undefined ? { mutatesGithub: safety.mutatesGithub === true } : {}),
+    ...(safety.mutatesAverray !== undefined ? { mutatesAverray: safety.mutatesAverray === true } : {}),
+    ...(safety.editsWikipedia !== undefined ? { editsWikipedia: safety.editsWikipedia === true } : {}),
+  };
+}
+
+function sanitizeText(value: string): string {
+  return value
+    .replace(BEARER_PATTERN, "Bearer [redacted]")
+    .replace(PRIVATE_KEY_PATTERN, (match) => match.replace(/[:=]\s*[^\s,;]+/, ": [redacted]"))
+    .replace(OPENAI_KEY_PATTERN, "sk-[redacted]")
+    .slice(0, 2_000);
+}
+
+function decisionRecordId(kind: HermesDecisionKind, subject: HermesDecisionSubject, generatedAt: string): string {
+  const slug = `${kind}-${subject.type}-${subject.id}-${generatedAt}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 120);
+  return `hdr-${slug || "decision"}`;
+}
+
+function isDecisionKind(value: unknown): value is HermesDecisionKind {
+  return value === "routing"
+    || value === "auto_approval"
+    || value === "escalation"
+    || value === "anomaly_pause"
+    || value === "away_digest";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/averray-mcp/src/dispatch-routing.ts
+++ b/packages/averray-mcp/src/dispatch-routing.ts
@@ -14,6 +14,8 @@
 // looks correctness-critical is treated as high-risk → Codex. Never
 // under-classify risk.
 
+import type { HermesDecisionRecord } from "./decision-records.js";
+
 export type RoutingAgent = "codex" | "claude";
 export type RiskTier = "high" | "low";
 
@@ -31,6 +33,8 @@ export interface RoutingDecision {
   riskTier: RiskTier;
   /** Short human string for the board + the off-device alert. */
   reason: string;
+  /** D2 explainability record, when a dynamic router generated one. */
+  decisionRecord?: HermesDecisionRecord;
 }
 
 interface SurfaceGroup {

--- a/packages/averray-mcp/src/learned-routing.ts
+++ b/packages/averray-mcp/src/learned-routing.ts
@@ -1,4 +1,5 @@
 import type { RoutingAgent, RoutingDecision, RoutingInput } from "./dispatch-routing.js";
+import { createHermesDecisionRecord } from "./decision-records.js";
 
 export interface LearnedRoutingConfig {
   minSamples: number;
@@ -74,37 +75,123 @@ export function applyLearnedRouting(
   staticDecision: RoutingDecision,
   options: LearnedRoutingOptions = {}
 ): RoutingDecision {
-  if (staticDecision.riskTier === "high") {
-    return {
-      agent: "codex",
-      riskTier: staticDecision.riskTier,
-      reason: `A2 high-risk rule-bound → codex; scorecard ignored (${staticDecision.reason})`,
-    };
-  }
-
   const config = parseLearnedRoutingConfig(undefined, options.config);
   const now = options.now ?? new Date();
   const rng = options.rng ?? Math.random;
   const surface = targetSurface(input, staticDecision);
+
+  if (staticDecision.riskTier === "high") {
+    const reason = `A2 high-risk rule-bound → codex; scorecard ignored (${staticDecision.reason})`;
+    return {
+      agent: "codex",
+      riskTier: staticDecision.riskTier,
+      reason,
+      decisionRecord: createHermesDecisionRecord({
+        kind: "routing",
+        subject: routingSubject(input, surface),
+        decision: "routed to codex",
+        reasons: [
+          "The static classifier marked this task high-risk.",
+          "High-risk tasks are rule-bound to Codex and cannot be changed by scorecard evidence.",
+          staticDecision.reason,
+        ],
+        inputs: {
+          riskTier: staticDecision.riskTier,
+          surface,
+          routingReason: reason,
+          staticDecision,
+          scorecardUsed: false,
+          wouldChangeDecision: "Only changing the static risk classifier could route high-risk work away from Codex.",
+          policyGates: { dispatchEvaluated: false },
+        },
+        outcome: {
+          summary: "Codex selected for the proposed task; dispatch still waits on the normal operator gates.",
+          waitingNext: "Operator dispatch gate or the autopilot gate.",
+        },
+        safety: { readOnly: true, mutates: false },
+        generatedAt: now,
+      }),
+    };
+  }
+
   const candidates = ROUTING_AGENTS
     .map((agent) => scoreAgentForSurface(agent, surface, options.scorecard, config, now))
     .filter((candidate) => candidate.effectiveSamples >= config.minSamples)
     .sort((a, b) => b.score - a.score || b.effectiveSamples - a.effectiveSamples || agentSort(a.agent) - agentSort(b.agent));
 
   if (candidates.length === 0) {
+    const reason = `A2 cold start on ${surface} → static default (${staticDecision.reason})`;
     return {
       ...staticDecision,
-      reason: `A2 cold start on ${surface} → static default (${staticDecision.reason})`,
+      reason,
+      decisionRecord: createHermesDecisionRecord({
+        kind: "routing",
+        subject: routingSubject(input, surface),
+        decision: `routed to ${staticDecision.agent}`,
+        reasons: [
+          `Hermes has fewer than ${config.minSamples} effective samples for ${surface}.`,
+          "Cold-start routing uses the static default until scorecard evidence is ready.",
+          staticDecision.reason,
+        ],
+        inputs: {
+          riskTier: staticDecision.riskTier,
+          surface,
+          mode: "cold_start",
+          routingReason: reason,
+          staticDecision,
+          wouldChangeDecision: `At least ${config.minSamples} effective samples for another agent on ${surface} would let learned routing choose differently.`,
+          scorecardSnapshot: ROUTING_AGENTS.map((agent) =>
+            candidateSnapshot(scoreAgentForSurface(agent, surface, options.scorecard, config, now))
+          ),
+          policyGates: { dispatchEvaluated: false },
+        },
+        outcome: {
+          summary: `${staticDecision.agent} selected from the static routing rule; task still waits on operator gates.`,
+          waitingNext: "Operator dispatch gate or the autopilot gate.",
+        },
+        safety: { readOnly: true, mutates: false },
+        generatedAt: now,
+      }),
     };
   }
 
   const best = candidates[0]!;
   const chosen = shouldExplore(candidates, config, rng) ? candidates[1]! : best;
   const mode = chosen.agent === best.agent ? "learned" : "exploration";
+  const reason = `${reasonPrefix(mode, chosen, surface)}; ${comparisonSummary(candidates, surface)}; static default ${staticDecision.agent}`;
   return {
     agent: chosen.agent,
     riskTier: staticDecision.riskTier,
-    reason: `${reasonPrefix(mode, chosen, surface)}; ${comparisonSummary(candidates, surface)}; static default ${staticDecision.agent}`,
+    reason,
+    decisionRecord: createHermesDecisionRecord({
+      kind: "routing",
+      subject: routingSubject(input, surface),
+      decision: `routed to ${chosen.agent}`,
+      reasons: [
+        mode === "exploration"
+          ? `Hermes intentionally explored ${chosen.agent} despite ${best.agent} having the strongest score.`
+          : `${chosen.agent} had the strongest current score for ${surface}.`,
+        comparisonSummary(candidates, surface),
+        `The static default would have selected ${staticDecision.agent}.`,
+      ],
+      inputs: {
+        riskTier: staticDecision.riskTier,
+        surface,
+        mode,
+        routingReason: reason,
+        staticDecision,
+        learnedRoutingConfig: config,
+        scorecardSnapshot: candidates.map(candidateSnapshot),
+        wouldChangeDecision: "Different scorecard quality, enough recency decay, or exploration RNG could choose the other candidate.",
+        policyGates: { dispatchEvaluated: false },
+      },
+      outcome: {
+        summary: `${chosen.agent} selected for the proposed task; task still waits on operator gates.`,
+        waitingNext: "Operator dispatch gate or the autopilot gate.",
+      },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: now,
+    }),
   };
 }
 
@@ -126,6 +213,25 @@ function comparisonSummary(candidates: CandidateScore[], surface: string): strin
       return `${agent} ${percent(candidate.readyRate)} ready, score ${formatNumber(candidate.score)}, n=${candidate.samples}, effective=${formatNumber(candidate.effectiveSamples)}`;
     })
     .join(" vs ");
+}
+
+function routingSubject(input: RoutingInput, surface: string) {
+  const repo = input.repo?.trim();
+  return {
+    type: repo ? "repo" as const : "task" as const,
+    id: repo || surface || "unknown-routing-surface",
+    ...(repo ? { repo } : {}),
+  };
+}
+
+function candidateSnapshot(candidate: CandidateScore) {
+  return {
+    agent: candidate.agent,
+    score: Number.isFinite(candidate.score) ? Number(candidate.score.toFixed(3)) : "not_enough_data",
+    samples: candidate.samples,
+    effectiveSamples: Number(candidate.effectiveSamples.toFixed(2)),
+    readyRate: candidate.readyRate === null ? "not_recorded" : Number(candidate.readyRate.toFixed(3)),
+  };
 }
 
 function scoreAgentForSurface(

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -12,6 +12,7 @@ import type {
   CardRiskSignal,
   DeployCard,
   DoneCard,
+  HermesDecisionRecord,
   MissionCard,
 } from "../../lib/monitor/card-types.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
@@ -49,20 +50,32 @@ export function drawerVariant(card: BoardCard): DrawerVariant {
 }
 
 export function DrawerBody({ card, variant }: { card: BoardCard; variant: DrawerVariant }) {
+  let body: React.ReactNode;
   switch (variant) {
     case "mission":
-      return <MissionBody card={card as MissionCard} />;
+      body = <MissionBody card={card as MissionCard} />;
+      break;
     case "done":
-      return <DoneBody card={card as DoneCard} />;
+      body = <DoneBody card={card as DoneCard} />;
+      break;
     case "deploy":
-      return <DeployBody card={card as DeployCard} />;
+      body = <DeployBody card={card as DeployCard} />;
+      break;
     case "task":
-      return <TaskBody card={card} />;
+      body = <TaskBody card={card} />;
+      break;
     case "draft":
-      return <DraftBody card={card} />;
+      body = <DraftBody card={card} />;
+      break;
     default:
-      return <PrBody card={card} />;
+      body = <PrBody card={card} />;
   }
+  return (
+    <>
+      {body}
+      <DecisionRecordSection record={card.decisionRecord} />
+    </>
+  );
 }
 
 // ── Shared building blocks ──────────────────────────────────────────
@@ -175,6 +188,36 @@ function RiskSignalsSection({ signals }: { signals: CardRiskSignal[] | undefined
             <span className={RISK_PILL[s.severity]}>{s.severity}</span>
           </div>
         ))}
+      </div>
+    </section>
+  );
+}
+
+function DecisionRecordSection({ record }: { record: HermesDecisionRecord | undefined }) {
+  if (!record) return null;
+  const changed = record.outcome.changed?.join(", ");
+  return (
+    <section>
+      <div className="hm-section-h">Why Hermes did this</div>
+      <div className="hm-verdict-block">
+        <div className="head">
+          {record.kind} · {record.decision}
+        </div>
+        <div className="body">
+          <div>{record.outcome.summary}</div>
+          {record.reasons.length > 0 ? (
+            <ul style={{ margin: "8px 0 0", paddingLeft: 18 }}>
+              {record.reasons.slice(0, 4).map((reason) => (
+                <li key={reason}>{reason}</li>
+              ))}
+            </ul>
+          ) : null}
+          <div style={{ marginTop: 8, color: "var(--hm-muted)" }}>
+            {record.safety.readOnly ? "Read-only" : "Operational"} · {record.safety.mutates ? "mutates state" : "no state mutation"}
+            {record.outcome.waitingNext ? ` · Next: ${record.outcome.waitingNext}` : ""}
+            {changed ? ` · Changed: ${changed}` : ""}
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -77,6 +77,37 @@ export interface CardRiskSignal {
   message: string;
 }
 
+export interface HermesDecisionSubject {
+  type: "task" | "card" | "repo" | "pr" | "mission" | "digest" | "autopilot_session";
+  id: string;
+  repo?: string;
+  pullRequestNumber?: number;
+}
+
+export interface HermesDecisionRecord {
+  schemaVersion: 1;
+  recordType: "hermes_decision_record";
+  id: string;
+  kind: "routing" | "auto_approval" | "escalation" | "anomaly_pause" | "away_digest";
+  subject: HermesDecisionSubject;
+  decision: string;
+  reasons: string[];
+  inputs: Record<string, unknown>;
+  outcome: {
+    summary: string;
+    waitingNext?: string;
+    changed?: string[];
+  };
+  safety: {
+    readOnly: boolean;
+    mutates: boolean;
+    mutatesGithub?: boolean;
+    mutatesAverray?: boolean;
+    editsWikipedia?: boolean;
+  };
+  generatedAt: string;
+}
+
 export interface CardAction {
   kind: "operator-review" | "codex-approve" | "deploy-verify" | "mission-rerun";
   primary: string;
@@ -111,6 +142,8 @@ export interface CardBase {
   archiveHint?: boolean;
   /** free-form "next action" copy from the classifier */
   next?: string;
+  /** D2: latest durable explanation associated with the card. */
+  decisionRecord?: HermesDecisionRecord;
 }
 
 /** PR card — file changes, Hermes verdict, operator-review action. */

--- a/services/slack-operator/src/anomaly-pause.ts
+++ b/services/slack-operator/src/anomaly-pause.ts
@@ -16,6 +16,10 @@ import { mkdirSync, writeFileSync, existsSync } from "node:fs";
 import { dirname } from "node:path";
 import { optionalEnv, readYamlFile } from "@avg/mcp-common";
 import type { AlertChannel, AlertPayload } from "./alert-bridge.js";
+import {
+  createHermesDecisionRecord,
+  type HermesDecisionRecord,
+} from "@avg/averray-mcp/decision-records";
 
 // ── Signals + thresholds ────────────────────────────────────────────
 
@@ -192,7 +196,13 @@ export interface AnomalyPauseDeps {
   setSuspended: (info: { reason: string; signal: string; tier: "soft" | "hard"; setAt: string }) => void;
   touchHalt: (reason: string) => void;
   alert: (payload: AlertPayload) => Promise<boolean>;
-  audit: (record: { tier: AnomalyTier; action: AnomalyAction; signals: string; reason: string }) => Promise<unknown> | unknown;
+  audit: (record: {
+    tier: AnomalyTier;
+    action: AnomalyAction;
+    signals: string;
+    reason: string;
+    decisionRecord?: HermesDecisionRecord;
+  }) => Promise<unknown> | unknown;
   boardUrl: string;
   now: () => Date;
 }
@@ -222,6 +232,64 @@ export async function runAnomalyPauseOnce(deps: AnomalyPauseDeps): Promise<Anoma
   }
 
   await deps.alert(buildAnomalyAlert(evaluation, action, deps.boardUrl));
-  await deps.audit({ tier: evaluation.tier, action, signals: signalList, reason });
+  await deps.audit({
+    tier: evaluation.tier,
+    action,
+    signals: signalList,
+    reason,
+    decisionRecord: buildAnomalyPauseDecisionRecord({
+      evaluation,
+      action,
+      signals,
+      config: deps.config,
+      generatedAt: setAt,
+    }),
+  });
   return { action, evaluation };
+}
+
+function buildAnomalyPauseDecisionRecord(input: {
+  evaluation: AnomalyEvaluation;
+  action: Exclude<AnomalyAction, "none">;
+  signals: AnomalySignals;
+  config: AnomalyConfig;
+  generatedAt: string;
+}): HermesDecisionRecord {
+  const { reason, signals } = summarizeTrips(input.evaluation);
+  return createHermesDecisionRecord({
+    kind: "anomaly_pause",
+    subject: { type: "autopilot_session", id: "hermes-autopilot" },
+    decision: input.action === "hard" ? "paused_hard" : "paused_soft",
+    reasons: [
+      ...input.evaluation.trips.map((trip) => `[${trip.tier}] ${trip.signal}: ${trip.detail}`),
+      input.action === "hard"
+        ? "A hard trip touches HALT and suspends autopilot."
+        : "A soft trip suspends autopilot without touching HALT.",
+    ],
+    inputs: {
+      riskTier: input.evaluation.tier,
+      anomalySignals: input.signals,
+      anomalySignalList: signals,
+      anomalyReason: reason,
+      thresholds: input.config,
+      wouldChangeDecision: "Lower signal values, a higher configured threshold, or an already-suspended soft state would avoid a new pause.",
+    },
+    outcome: {
+      summary: input.action === "hard"
+        ? "HALT was touched and autopilot was suspended."
+        : "Autopilot was suspended.",
+      waitingNext: "Operator inspection and resume decision.",
+      changed: input.action === "hard"
+        ? ["HALT_FILE touched", "autopilot suspended"]
+        : ["autopilot suspended"],
+    },
+    safety: {
+      readOnly: false,
+      mutates: true,
+      mutatesGithub: false,
+      mutatesAverray: false,
+      editsWikipedia: false,
+    },
+    generatedAt: input.generatedAt,
+  });
 }

--- a/services/slack-operator/src/autopilot-approve.ts
+++ b/services/slack-operator/src/autopilot-approve.ts
@@ -20,6 +20,11 @@
 
 import type { AlertPayload } from "./alert-bridge.js";
 import { evaluateDispatchPolicy, type DispatchPolicyConfig } from "@avg/averray-mcp/dispatch-policy";
+import {
+  createHermesDecisionRecord,
+  whyHermesLine,
+  type HermesDecisionRecord,
+} from "@avg/averray-mcp/decision-records";
 
 export interface AutoApprovalSignals {
   /** mode==autopilot AND now<until (PR3a isAutopilotEngaged). */
@@ -91,6 +96,7 @@ export interface AutoApprovalAudit {
   reason: AutoApprovalReason;
   detail?: string;
   riskTier?: "high" | "low";
+  decisionRecord?: HermesDecisionRecord;
 }
 
 export interface AutoApprovalDeps {
@@ -156,30 +162,144 @@ export async function runAutoApproval(deps: AutoApprovalDeps): Promise<AutoAppro
     ...(decision.detail ? { detail: decision.detail } : {}),
     ...(deps.task.riskTier ? { riskTier: deps.task.riskTier } : {}),
   };
+  const decisionRecord = buildAutoApprovalDecisionRecord({
+    task: deps.task,
+    decision,
+    dispatch,
+    policy: deps.policy,
+    todayCount,
+    todayRepoCount,
+    suspended,
+    halt,
+  });
 
   if (decision.approve) {
     await deps.approve(deps.task.id, AUTOPILOT_APPROVER);
-    await deps.audit({ ...baseAudit, action: "approved" });
+    await deps.audit({ ...baseAudit, action: "approved", decisionRecord });
     return { action: "approved", reason: decision.reason };
   }
 
   if (decision.escalate) {
-    await deps.audit({ ...baseAudit, action: "escalated" });
-    await deps.alert(buildHighRiskEscalationAlert(deps.task, deps.boardUrl));
+    await deps.audit({ ...baseAudit, action: "escalated", decisionRecord });
+    await deps.alert(buildHighRiskEscalationAlert(deps.task, deps.boardUrl, decisionRecord));
     return { action: "escalated", reason: decision.reason, ...(decision.detail ? { detail: decision.detail } : {}) };
   }
 
   // Engaged but a gate blocked a low-risk task (suspended / halt / over-budget).
-  await deps.audit({ ...baseAudit, action: "left_proposed" });
+  await deps.audit({ ...baseAudit, action: "left_proposed", decisionRecord });
   return { action: "left_proposed", reason: decision.reason, ...(decision.detail ? { detail: decision.detail } : {}) };
 }
 
-export function buildHighRiskEscalationAlert(task: AutoApprovalTask, boardUrl: string): AlertPayload {
+export function buildHighRiskEscalationAlert(
+  task: AutoApprovalTask,
+  boardUrl: string,
+  decisionRecord?: HermesDecisionRecord,
+): AlertPayload {
   const label = task.title ? `"${task.title}"` : task.id;
   const text =
     `⚠️ Autopilot escalated a HIGH-RISK task to you — ${label} in ${task.repo} (${task.agent}). ` +
     `Autopilot never auto-approves high-risk dispatch; approve or cancel it on the board.\n` +
+    (decisionRecord ? `${whyHermesLine(decisionRecord)}\n` : "") +
     (task.routingReason ? `Why high-risk: ${task.routingReason}\n` : "") +
     `Board: ${boardUrl}`;
   return { count: 1, items: [], boardUrl, text };
+}
+
+function buildAutoApprovalDecisionRecord(input: {
+  task: AutoApprovalTask;
+  decision: AutoApprovalDecision;
+  dispatch: { allowed: boolean; reason: string };
+  policy: DispatchPolicyConfig;
+  todayCount: number;
+  todayRepoCount: number;
+  suspended: boolean;
+  halt: boolean;
+}): HermesDecisionRecord {
+  const action = input.decision.approve
+    ? "approved"
+    : input.decision.escalate
+      ? "escalated"
+      : "left_proposed";
+  return createHermesDecisionRecord({
+    kind: input.decision.escalate ? "escalation" : "auto_approval",
+    subject: { type: "task", id: input.task.id, repo: input.task.repo },
+    decision: action,
+    reasons: autoApprovalReasons(input),
+    inputs: {
+      riskTier: input.task.riskTier ?? "unset",
+      routingReason: input.task.routingReason,
+      policyGates: {
+        dispatchAllowed: input.dispatch.allowed,
+        dispatchReason: input.dispatch.reason,
+        allowedRepos: input.policy.allowedRepos,
+        allowedAgents: input.policy.allowedAgents,
+      },
+      budgetGates: {
+        todayCount: input.todayCount,
+        todayRepoCount: input.todayRepoCount,
+        perDayMax: input.policy.perDayMax,
+        perRepoPerDayMax: input.policy.perRepoPerDayMax,
+      },
+      anomalySignals: {
+        autopilotSuspended: input.suspended,
+        haltPresent: input.halt,
+      },
+      wouldChangeDecision: input.decision.approve
+        ? "Any failed gate, exhausted budget, HALT, suspension, or high-risk tier would have left the task proposed."
+        : "A low-risk tier, no suspension/HALT, allowed dispatch policy, and remaining budget are required for auto-approval.",
+    },
+    outcome: {
+      summary: input.decision.approve
+        ? "Hermes approved the proposed task for dispatch."
+        : input.decision.escalate
+          ? "Hermes left the task proposed and alerted the operator."
+          : "Hermes left the task proposed for operator action.",
+      waitingNext: input.decision.approve
+        ? "The runner can claim the task."
+        : "The operator can approve or cancel the task on the board.",
+      changed: input.decision.approve ? ["task status: proposed -> approved"] : undefined,
+    },
+    safety: {
+      readOnly: false,
+      mutates: input.decision.approve,
+      mutatesGithub: false,
+      mutatesAverray: input.decision.approve,
+      editsWikipedia: false,
+    },
+  });
+}
+
+function autoApprovalReasons(input: {
+  task: AutoApprovalTask;
+  decision: AutoApprovalDecision;
+  dispatch: { allowed: boolean; reason: string };
+  policy: DispatchPolicyConfig;
+  todayCount: number;
+  todayRepoCount: number;
+  suspended: boolean;
+  halt: boolean;
+}): string[] {
+  if (input.decision.approve) {
+    return [
+      "Autopilot is engaged and the task is low-risk.",
+      "The dispatch policy allowed this repo and agent.",
+      `Daily budget remaining after this decision: ${Math.max(0, input.policy.perDayMax - input.todayCount)} global, ${Math.max(0, input.policy.perRepoPerDayMax - input.todayRepoCount)} for this repo.`,
+    ];
+  }
+  if (input.decision.escalate) {
+    return [
+      "Autopilot never auto-approves high-risk or unclassified tasks.",
+      input.task.routingReason ?? input.decision.detail ?? "The task did not carry a low-risk classification.",
+      "The operator must approve or cancel the task manually.",
+    ];
+  }
+  if (input.suspended) return ["The D3 anomaly guard suspended autopilot.", "Hermes left the task proposed until the operator resumes autopilot."];
+  if (input.halt) return ["HALT is present.", "Hermes left the task proposed because mutating work is stopped."];
+  if (!input.dispatch.allowed) {
+    return [
+      `The dispatch policy blocked approval: ${input.dispatch.reason}.`,
+      "Hermes left the task proposed so the operator can inspect the policy or budget.",
+    ];
+  }
+  return ["A required approval gate did not pass.", "Hermes left the task proposed for operator review."];
 }

--- a/services/slack-operator/src/away-digest.ts
+++ b/services/slack-operator/src/away-digest.ts
@@ -2,6 +2,11 @@ import type { AlertChannel, AlertPayload } from "./alert-bridge.js";
 import type { AutonomyState } from "./autonomy-mode.js";
 import { taskAgent, type CodexTask } from "./codex-task-queue.js";
 import type { BoardCard } from "./monitor-v2.js";
+import {
+  createHermesDecisionRecord,
+  whyHermesLine,
+  type HermesDecisionRecord,
+} from "@avg/averray-mcp/decision-records";
 
 export interface AutopilotAwayDigestTrackerState {
   active?: AutopilotAwaySession;
@@ -75,6 +80,7 @@ export interface AutopilotAwayDigest {
   d3Suspends: AutopilotAwayDigestItem[];
   waitingOnOperator: AutopilotAwayDigestItem[];
   recommendedNextActions: string[];
+  decisionRecord: HermesDecisionRecord;
   safety: {
     readOnly: true;
     mutatesGithub: false;
@@ -207,6 +213,39 @@ export function buildAutopilotAwayDigest(input: BuildAutopilotAwayDigestInput): 
     waitingOnOperator: waitingOnOperator.length,
   };
 
+  const recommendedNextActions = recommendedNextActionsFor({ waitingOnOperator, escalated, failures, openedPrs, autoApproved });
+  const decisionRecord = createHermesDecisionRecord({
+    kind: "away_digest",
+    subject: { type: "autopilot_session", id: input.session.sessionId },
+    decision: "reported",
+    reasons: [
+      `Autopilot session ended because ${input.session.endedBy}.`,
+      `Hermes summarized ${counts.routed} routed, ${counts.autoApproved} auto-approved, ${counts.escalated} escalated, and ${counts.waitingOnOperator} waiting item(s).`,
+      recommendedNextActions[0] ?? "Nothing needs operator action right now.",
+    ],
+    inputs: {
+      counts,
+      session: input.session,
+      waitingOnOperator: waitingOnOperator.slice(0, 5),
+      escalated: escalated.slice(0, 5),
+      failures: failures.slice(0, 5),
+      d3Suspends: d3Suspends.slice(0, 5),
+      wouldChangeDecision: "No digest would be emitted until the autopilot session ended or was interrupted.",
+    },
+    outcome: {
+      summary: "Hermes emitted an away digest for the operator.",
+      waitingNext: recommendedNextActions[0] ?? "Nothing needs operator action right now.",
+    },
+    safety: {
+      readOnly: true,
+      mutates: false,
+      mutatesGithub: false,
+      mutatesAverray: false,
+      editsWikipedia: false,
+    },
+    generatedAt: input.generatedAt,
+  });
+
   return {
     schemaVersion: 1,
     kind: "autopilot_away_digest",
@@ -222,7 +261,8 @@ export function buildAutopilotAwayDigest(input: BuildAutopilotAwayDigestInput): 
     failures,
     d3Suspends,
     waitingOnOperator,
-    recommendedNextActions: recommendedNextActionsFor({ waitingOnOperator, escalated, failures, openedPrs, autoApproved }),
+    recommendedNextActions,
+    decisionRecord,
     safety: {
       readOnly: true,
       mutatesGithub: false,
@@ -237,6 +277,7 @@ export function formatAutopilotAwayDigestForOperator(digest: AutopilotAwayDigest
     digest.headline,
     `Window: ${digest.session.startedAt} -> ${digest.session.endedAt} (${digest.session.endedBy}).`,
     `Hermes routed ${digest.counts.routed}, auto-approved ${digest.counts.autoApproved}, escalated ${digest.counts.escalated}, opened/updated ${digest.counts.openedPrs} PR task(s), and left ${digest.counts.waitingOnOperator} item(s) waiting on you.`,
+    whyHermesLine(digest.decisionRecord),
   ];
 
   if (digest.autoApproved.length > 0) {

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
+import type { HermesDecisionRecord } from "@avg/averray-mcp/decision-records";
 
 export type CodexTaskStatus =
   | "proposed"
@@ -50,6 +51,8 @@ export interface CodexTaskInput {
   riskTier?: "high" | "low";
   /** O4-PR2 routing: the one-line reason for the agent + tier (board + alert). */
   routingReason?: string;
+  /** D2: why Hermes routed/proposed this task. */
+  decisionRecord?: HermesDecisionRecord;
 }
 
 export interface CodexTaskEvent {
@@ -130,6 +133,7 @@ export async function proposeCodexTask(
       prompt: input.prompt || existing.prompt,
       reason: input.reason ?? existing.reason,
       requester: input.requester ?? existing.requester,
+      decisionRecord: input.decisionRecord ?? existing.decisionRecord,
       updatedAt: now,
     };
     await writeCodexTasks(path, replaceTask(tasks, updated));
@@ -151,6 +155,7 @@ export async function proposeCodexTask(
     ...(input.requester ? { requester: input.requester } : {}),
     ...(input.riskTier ? { riskTier: input.riskTier } : {}),
     ...(input.routingReason ? { routingReason: input.routingReason } : {}),
+    ...(input.decisionRecord ? { decisionRecord: input.decisionRecord } : {}),
     createdAt: now,
     updatedAt: now,
     events: [{
@@ -194,6 +199,25 @@ export async function approveCodexTask(
       status: "approved",
       message: "Operator approved Codex dispatch.",
     }),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function annotateCodexTaskDecisionRecord(
+  id: string,
+  decisionRecord: HermesDecisionRecord,
+  deps: CodexTaskQueueDeps = {}
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  const now = (deps.now ?? new Date()).toISOString();
+  const task: CodexTask = {
+    ...existing,
+    decisionRecord,
     updatedAt: now,
   };
   await writeCodexTasks(path, replaceTask(tasks, task));

--- a/services/slack-operator/src/decision-record-store.ts
+++ b/services/slack-operator/src/decision-record-store.ts
@@ -1,0 +1,84 @@
+import {
+  isHermesDecisionRecord,
+  type HermesDecisionRecord,
+} from "@avg/averray-mcp/decision-records";
+import type { CodexTask } from "./codex-task-queue.js";
+
+export type DecisionRecordQueryFn = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[],
+) => Promise<T[]>;
+
+export interface DecisionRecordsMonitorResponse {
+  schemaVersion: 1;
+  kind: "hermes_decision_records";
+  generatedAt: string;
+  limit: number;
+  records: HermesDecisionRecord[];
+  safety: {
+    readOnly: true;
+    mutates: false;
+    mutatesGithub: false;
+    mutatesAverray: false;
+    editsWikipedia: false;
+  };
+}
+
+export async function listDecisionRecordsForMonitor(input: {
+  query: DecisionRecordQueryFn;
+  tasks?: CodexTask[];
+  limit?: number;
+  now?: Date;
+}): Promise<DecisionRecordsMonitorResponse> {
+  const limit = clampLimit(input.limit);
+  const rows = await input.query<{ decision_record: unknown }>(
+    `select result->'decisionRecord' as decision_record
+       from operator_command_events
+      where result ? 'decisionRecord'
+      order by updated_at desc
+      limit $1`,
+    [Math.max(limit, 50)],
+  );
+  return buildDecisionRecordsMonitorResponse({
+    records: [
+      ...rows.map((row) => row.decision_record).filter(isHermesDecisionRecord),
+      ...(input.tasks ?? []).map((task) => task.decisionRecord).filter(isHermesDecisionRecord),
+    ],
+    limit,
+    now: input.now,
+  });
+}
+
+export function buildDecisionRecordsMonitorResponse(input: {
+  records: HermesDecisionRecord[];
+  limit?: number;
+  now?: Date;
+}): DecisionRecordsMonitorResponse {
+  const limit = clampLimit(input.limit);
+  const recordsById = new Map<string, HermesDecisionRecord>();
+  for (const record of input.records) {
+    recordsById.set(record.id, record);
+  }
+  const records = [...recordsById.values()]
+    .sort((a, b) => Date.parse(b.generatedAt) - Date.parse(a.generatedAt))
+    .slice(0, limit);
+  return {
+    schemaVersion: 1,
+    kind: "hermes_decision_records",
+    generatedAt: (input.now ?? new Date()).toISOString(),
+    limit,
+    records,
+    safety: {
+      readOnly: true,
+      mutates: false,
+      mutatesGithub: false,
+      mutatesAverray: false,
+      editsWikipedia: false,
+    },
+  };
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit ?? NaN)) return 50;
+  return Math.min(100, Math.max(1, Math.floor(limit!)));
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -44,6 +44,7 @@ import {
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
 import { buildV2BoardSnapshot } from "./monitor-v2.js";
+import { listDecisionRecordsForMonitor } from "./decision-record-store.js";
 import {
   evaluateAlertBridge,
   initialAlertBridgeState,
@@ -113,6 +114,7 @@ import {
 } from "./monitor-hermes-voice.js";
 import {
   approveCodexTask,
+  annotateCodexTaskDecisionRecord,
   cancelCodexTask,
   listCodexTasks,
   proposeCodexTask,
@@ -382,6 +384,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/command",
           "/monitor/recheck",
           "/monitor/codex-tasks",
+          "/monitor/decision-records",
           "/monitor/agents",
           "/monitor/collaboration",
           "/monitor/tester/capabilities",
@@ -546,6 +549,26 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     writeJson(response, 200, await loadCodexTaskQueueSummary());
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/decision-records") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    writeJson(
+      response,
+      200,
+      await listDecisionRecordsForMonitor({
+        query,
+        tasks: await listCodexTasks().catch(() => []),
+        limit: parseOptionalInteger(url.searchParams.get("limit")),
+      }),
+    );
     return;
   }
   if (request.method === "GET" && url.pathname === "/monitor/agents") {
@@ -1481,6 +1504,10 @@ async function autoApproveProposedTask(task: CodexTask) {
           safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
         },
       }, query).catch((error) => logger.warn({ err: error }, "o4_autopilot_audit_failed"));
+      if (record.decisionRecord) {
+        await annotateCodexTaskDecisionRecord(record.taskId, record.decisionRecord)
+          .catch((error) => logger.warn({ err: error, taskId: record.taskId }, "o4_autopilot_decision_record_annotation_failed"));
+      }
     },
     boardUrl,
   });
@@ -1844,6 +1871,7 @@ function startOperatorRoutines() {
                 action: record.action,
                 signals: record.signals,
                 reason: record.reason,
+                ...(record.decisionRecord ? { decisionRecord: record.decisionRecord } : {}),
                 safety: { readOnly: false, mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
               },
             },

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -27,6 +27,10 @@ import {
   testbedMissionStructuredReport,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
+import {
+  isHermesDecisionRecord,
+  type HermesDecisionRecord,
+} from "@avg/averray-mcp/decision-records";
 
 // ── v2 typed model ──────────────────────────────────────────────────
 
@@ -200,6 +204,8 @@ export interface BoardCard {
   riskSignals?: CardRiskSignal[];
   /** Mission cards: the browser agent's structured report, when posted. */
   mission?: CardMissionReport;
+  /** D2: latest durable explanation associated with this card. */
+  decisionRecord?: HermesDecisionRecord;
 }
 
 export interface BoardSnapshotV2 {
@@ -768,6 +774,9 @@ export function enrichBoardCard(
     if (output) card.output = output;
     const failureReason = asString(task.failureReason);
     if (failureReason) card.failureReason = failureReason;
+    if (isHermesDecisionRecord(task.decisionRecord)) {
+      card.decisionRecord = task.decisionRecord;
+    }
     const runner = ctx.runner;
     if (runner) {
       const lastSeen = asString(runner.updatedAt);
@@ -825,6 +834,7 @@ export function synthesizeTaskCards(
     const riskTierRaw = asString(task.riskTier);
     const riskTier = riskTierRaw === "high" || riskTierRaw === "low" ? riskTierRaw : undefined;
     const routingReason = asString(task.routingReason);
+    const decisionRecord = isHermesDecisionRecord(task.decisionRecord) ? task.decisionRecord : undefined;
     // O4-PR2: surface the routing decision — the reason (incl. the tier) on the
     // card face, and a riskSignal for the drawer. Persist riskTier (PR3 reads it).
     const summary = [routingReason, asString(task.reason)].filter(Boolean).join(" · ");
@@ -850,6 +860,7 @@ export function synthesizeTaskCards(
         ? { riskSignals: [{ severity: riskTier === "high" ? "high" : "low", code: "routing", message: routingReason }] }
         : {}),
       ...(prompt ? { prompt } : {}),
+      ...(decisionRecord ? { decisionRecord } : {}),
     };
     if (status === "running" && runner) {
       const lastSeen = asString(runner.updatedAt);

--- a/test/unit/anomaly-pause.test.ts
+++ b/test/unit/anomaly-pause.test.ts
@@ -136,7 +136,7 @@ describe("buildAnomalyAlert", () => {
 interface Harness {
   deps: AnomalyPauseDeps;
   alerts: AlertPayload[];
-  audits: Array<{ tier: string; action: string; signals: string; reason: string }>;
+  audits: Array<Parameters<AnomalyPauseDeps["audit"]>[0]>;
   suspended: { current: boolean; info?: { reason: string; signal: string; tier: "soft" | "hard"; setAt: string } };
   halt: { touched: boolean; reason?: string };
 }
@@ -234,6 +234,15 @@ describe("runAnomalyPauseOnce — tiered action", () => {
     expect(rec).toMatchObject({ tier: "hard", action: "hard" });
     expect(rec.signals).toMatch(/hard:task_runaway/);
     expect(rec.reason).toMatch(/attempt #6/);
+    expect(rec.decisionRecord).toMatchObject({
+      kind: "anomaly_pause",
+      decision: "paused_hard",
+      inputs: {
+        riskTier: "hard",
+        anomalySignals: { maxTaskAttemptCount: 6 },
+      },
+      safety: { mutates: true },
+    });
   });
 
   it("re-evaluates after an operator resume: a still-present soft condition trips again", async () => {

--- a/test/unit/autopilot-approve.test.ts
+++ b/test/unit/autopilot-approve.test.ts
@@ -63,7 +63,7 @@ interface Harness {
   deps: AutoApprovalDeps;
   approved: Array<{ id: string; approvedBy: string }>;
   alerts: number;
-  audits: Array<{ action: string; reason: string; taskId: string }>;
+  audits: Array<Parameters<AutoApprovalDeps["audit"]>[0]>;
 }
 
 function harness(over: Partial<AutoApprovalDeps> = {}, task: AutoApprovalTask = TASK): Harness {
@@ -86,7 +86,7 @@ function harness(over: Partial<AutoApprovalDeps> = {}, task: AutoApprovalTask = 
       return true;
     },
     audit: (record) => {
-      audits.push({ action: record.action, reason: record.reason, taskId: record.taskId });
+      audits.push(record);
     },
     boardUrl: "https://board.example/monitor",
     ...over,
@@ -109,7 +109,17 @@ describe("runAutoApproval — orchestration (injected effects, no fs/network)", 
     const r = await runAutoApproval(h.deps);
     expect(r.action).toBe("approved");
     expect(h.approved).toEqual([{ id: "codex-task-1", approvedBy: "hermes-autopilot" }]);
-    expect(h.audits).toEqual([{ action: "approved", reason: "auto_approved", taskId: "codex-task-1" }]);
+    expect(h.audits[0]).toMatchObject({ action: "approved", reason: "auto_approved", taskId: "codex-task-1" });
+    expect(h.audits[0]?.decisionRecord).toMatchObject({
+      kind: "auto_approval",
+      decision: "approved",
+      inputs: {
+        riskTier: "low",
+        policyGates: { dispatchAllowed: true },
+        budgetGates: { todayCount: 0, todayRepoCount: 0 },
+      },
+      safety: { mutates: true, mutatesAverray: true },
+    });
     expect(h.alerts).toBe(0); // routine auto-approval doesn't spam the operator
   });
 
@@ -119,6 +129,11 @@ describe("runAutoApproval — orchestration (injected effects, no fs/network)", 
     expect(r.action).toBe("escalated");
     expect(h.approved).toHaveLength(0);
     expect(h.audits[0]).toMatchObject({ action: "escalated", reason: "high_risk_escalated" });
+    expect(h.audits[0]?.decisionRecord).toMatchObject({
+      kind: "escalation",
+      decision: "escalated",
+      inputs: { riskTier: "high" },
+    });
     expect(h.alerts).toBe(1);
   });
 

--- a/test/unit/away-digest.test.ts
+++ b/test/unit/away-digest.test.ts
@@ -219,9 +219,16 @@ describe("autopilot away digest aggregation", () => {
       id: "card-review",
       status: "operator-review",
     });
+    expect(digest.decisionRecord).toMatchObject({
+      kind: "away_digest",
+      decision: "reported",
+      inputs: { counts: digest.counts },
+      safety: { readOnly: true, mutates: false },
+    });
 
     const text = formatAutopilotAwayDigestForOperator(digest);
     expect(text).toContain("While you were away");
+    expect(text).toContain("Why Hermes did this:");
     expect(text).toContain("auto-approved 1");
     expect(text).toContain("Waiting on you");
   });

--- a/test/unit/decision-records.test.ts
+++ b/test/unit/decision-records.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createHermesDecisionRecord,
+} from "../../packages/averray-mcp/src/decision-records.js";
+import {
+  buildDecisionRecordsMonitorResponse,
+  listDecisionRecordsForMonitor,
+} from "../../services/slack-operator/src/decision-record-store.js";
+import type { CodexTask } from "../../services/slack-operator/src/codex-task-queue.js";
+
+describe("Hermes decision records", () => {
+  it("creates a human-readable, sanitized record", () => {
+    const record = createHermesDecisionRecord({
+      kind: "routing",
+      subject: { type: "task", id: "task-1", repo: "owner/repo" },
+      decision: "routed to claude",
+      reasons: ["Claude had the best UI score.", "Bearer abc.def.ghi was never supposed to appear."],
+      inputs: {
+        riskTier: "low",
+        scorecardSnapshot: [{ agent: "claude", score: 0.91 }],
+        privateKey: "0x".padEnd(66, "a"),
+        nested: { apiToken: "secret-token" },
+      },
+      outcome: { summary: "Task proposed.", waitingNext: "Operator approval." },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: "2026-05-31T12:00:00.000Z",
+    });
+
+    expect(record).toMatchObject({
+      schemaVersion: 1,
+      recordType: "hermes_decision_record",
+      kind: "routing",
+      decision: "routed to claude",
+      subject: { type: "task", id: "task-1", repo: "owner/repo" },
+      outcome: { summary: "Task proposed." },
+    });
+    expect(record.reasons.join(" ")).not.toContain("abc.def.ghi");
+    expect(record.inputs.privateKey).toBe("[redacted]");
+    expect((record.inputs.nested as Record<string, unknown>).apiToken).toBe("[redacted]");
+  });
+
+  it("monitor response returns newest records and respects limit", () => {
+    const oldRecord = createHermesDecisionRecord({
+      kind: "auto_approval",
+      subject: { type: "task", id: "old" },
+      decision: "approved",
+      reasons: ["older"],
+      outcome: { summary: "older" },
+      safety: { readOnly: false, mutates: true },
+      generatedAt: "2026-05-31T10:00:00.000Z",
+    });
+    const newRecord = createHermesDecisionRecord({
+      kind: "anomaly_pause",
+      subject: { type: "autopilot_session", id: "hermes" },
+      decision: "paused_soft",
+      reasons: ["newer"],
+      outcome: { summary: "newer" },
+      safety: { readOnly: false, mutates: true },
+      generatedAt: "2026-05-31T12:00:00.000Z",
+    });
+
+    const response = buildDecisionRecordsMonitorResponse({
+      records: [oldRecord, newRecord],
+      limit: 1,
+      now: new Date("2026-05-31T13:00:00.000Z"),
+    });
+
+    expect(response.records).toEqual([newRecord]);
+    expect(response.limit).toBe(1);
+    expect(response.safety).toMatchObject({ readOnly: true, mutates: false });
+  });
+
+  it("combines durable audit records with task routing records", async () => {
+    const auditRecord = createHermesDecisionRecord({
+      kind: "escalation",
+      subject: { type: "task", id: "task-escalated" },
+      decision: "escalated",
+      reasons: ["high risk"],
+      outcome: { summary: "operator alerted" },
+      safety: { readOnly: false, mutates: false },
+      generatedAt: "2026-05-31T11:00:00.000Z",
+    });
+    const taskRecord = createHermesDecisionRecord({
+      kind: "routing",
+      subject: { type: "task", id: "task-routed" },
+      decision: "routed to claude",
+      reasons: ["scorecard"],
+      outcome: { summary: "task proposed" },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: "2026-05-31T12:00:00.000Z",
+    });
+    const task: CodexTask = {
+      schemaVersion: 1,
+      kind: "codex_task",
+      id: "task-routed",
+      repo: "owner/repo",
+      prompt: "Do work",
+      status: "proposed",
+      createdAt: "2026-05-31T12:00:00.000Z",
+      updatedAt: "2026-05-31T12:00:00.000Z",
+      decisionRecord: taskRecord,
+    };
+
+    const response = await listDecisionRecordsForMonitor({
+      query: async () => [{ decision_record: auditRecord }],
+      tasks: [task],
+      limit: 2,
+      now: new Date("2026-05-31T13:00:00.000Z"),
+    });
+
+    expect(response.records.map((record) => record.subject.id)).toEqual(["task-routed", "task-escalated"]);
+  });
+});

--- a/test/unit/learned-routing.test.ts
+++ b/test/unit/learned-routing.test.ts
@@ -45,6 +45,12 @@ describe("A2 learned routing", () => {
     expect(decision).toMatchObject({ agent: "codex", riskTier: "high" });
     expect(decision.reason).toMatch(/rule-bound/);
     expect(decision.reason).toMatch(/scorecard ignored/);
+    expect(decision.decisionRecord).toMatchObject({
+      kind: "routing",
+      decision: "routed to codex",
+      inputs: { riskTier: "high", scorecardUsed: false },
+      safety: { readOnly: true, mutates: false },
+    });
   });
 
   it("routes non-high-risk work to the agent with stronger surface evidence", () => {
@@ -66,6 +72,18 @@ describe("A2 learned routing", () => {
     expect(decision.reason).toMatch(/A2 learned routing/);
     expect(decision.reason).toMatch(/claude 92% ready/);
     expect(decision.reason).toMatch(/codex 70% ready/);
+    expect(decision.decisionRecord).toMatchObject({
+      kind: "routing",
+      decision: "routed to claude",
+      inputs: {
+        mode: "learned",
+        riskTier: "low",
+        scorecardSnapshot: [
+          expect.objectContaining({ agent: "claude" }),
+          expect.objectContaining({ agent: "codex" }),
+        ],
+      },
+    });
   });
 
   it("falls back to the static default during cold start", () => {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../../services/slack-operator/src/monitor-v2.js";
 import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
 import type { HermesBoardCardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
+import { createHermesDecisionRecord } from "../../packages/averray-mcp/src/decision-records.js";
 
 function slim(overrides: Partial<HermesBoardCardSnapshot> = {}): HermesBoardCardSnapshot {
   return {
@@ -776,7 +777,18 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
   };
 
   it("surfaces a proposed greenfield task as a codex-needed card with its agent + status", () => {
-    const [card, ...rest] = synthesizeTaskCards({ codexTasks: { items: [proposedClaude] } }, undefined);
+    const decisionRecord = createHermesDecisionRecord({
+      kind: "routing",
+      subject: { type: "task", id: "claude-task-x1", repo: "averray-agent/agent" },
+      decision: "routed to claude",
+      reasons: ["Claude had the strongest UI evidence."],
+      outcome: { summary: "Task proposed." },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: "2026-05-31T12:00:00.000Z",
+    });
+    const [card, ...rest] = synthesizeTaskCards({
+      codexTasks: { items: [{ ...proposedClaude, decisionRecord }] },
+    }, undefined);
     expect(rest).toHaveLength(0);
     expect(card).toMatchObject({
       id: "claude-task-x1",
@@ -786,6 +798,10 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
       taskStatus: "proposed",
       repo: "averray-agent/agent",
       prompt: "Add a top-level HEALTHCHECK.md.",
+      decisionRecord: {
+        kind: "routing",
+        decision: "routed to claude",
+      },
     });
     // proposed → waiting on the operator to approve
     expect(card?.waitingOn).toEqual({ actor: "operator", tone: "warn" });


### PR DESCRIPTION
## Summary
- add shared Hermes decision-record types with sanitization and monitor response helpers
- persist routing, autopilot approval/escalation, anomaly pause, and away-digest records
- surface decision records in task cards/drawers and expose GET /monitor/decision-records

## Checks
- npm run typecheck
- npm test

## Impact
- Backend/slack-operator: adds read-only monitor endpoint and records audit metadata
- Monitor UI: shows a small 'Why Hermes did this' drawer section when a record is available
- Authority: no auto-approval or routing authority changes