### PR TITLE
Reconcile Hermes roadmap status

### DIFF
--- a/docs/HERMES_AGENT_MODELS_AND_EFFORT.md
+++ b/docs/HERMES_AGENT_MODELS_AND_EFFORT.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Agent Models & Effort Policy
 
-- **Status:** Planning / handoff. Pins down which model each agent role runs, the tester's LLM, and how reasoning **effort** is chosen.
+- **Status:** Reconciled 2026-05-31. A4 riskTier→effort/model + operator override shipped in #292. A3b cost-aware routing/budget and the multi-backend tester follow-up remain separate work; do not confuse that with the shipped T5 env-binding slice (#297).
 - **Date:** 2026-05-31
 - **Companions:** [`HERMES_ORCHESTRATION_DESIGN.md`](./HERMES_ORCHESTRATION_DESIGN.md) (routing/riskTier), [`HERMES_PHASE2_DESIGN.md`](./HERMES_PHASE2_DESIGN.md) (A-stream/cost), [`HERMES_E2E_TESTER_DESIGN.md`](./HERMES_E2E_TESTER_DESIGN.md) (T4), [`HERMES_WORKER_AUTH_BILLING.md`](./HERMES_WORKER_AUTH_BILLING.md) (billing).
 
@@ -38,8 +38,8 @@ The workers and tester pick reasoning effort from the task's `riskTier` (O4-PR2)
 | **low / medium** (UI / docs / tests / refactors / general) | **medium** reasoning | **Sonnet** | routine; medium is plenty and keeps cost down |
 
 - **Operator override:** an effort selector on the board next to the agent picker, so the operator can push effort up (or down) per task when they know better. The risk-tier value is the *default*, not a hard rule.
-- **Cost link (A3):** effort is the main cost lever, so this policy *is* the practical core of cost-aware routing — high effort only where risk justifies it. A3's $-budget rides on top.
-- **Until wired:** set worker defaults **Codex = medium, Claude = Sonnet**, and bump the high-risk lane to **high / Opus** manually.
+- **Cost link (A3):** effort is the main cost lever, so this policy *is* the practical core of cost-aware routing — high effort only where risk justifies it. A3a cost visibility has shipped; A3b's $-budget rides on top.
+- **Wiring status:** A4 shipped in #292. Worker defaults still preserve the invariant that high-risk work gets high effort / Opus-class treatment.
 
 **Invariant:** high-risk work always gets high effort — never under-power the dangerous lane (the same spirit as "high-risk → Codex, rule-bound"). Effort/model never bypasses the safety gates (guardrail, approval, HALT).
 
@@ -72,4 +72,4 @@ This is the one genuinely open call here — flagged for the operator.
 
 ---
 
-*End. Planning/handoff only — the policy is recorded; A4 wires it, and Hermes's model is an operator decision.*
+*End. Reconciled 2026-05-31: A4 shipped in #292; Hermes's own model tiering remains an operator decision.*

--- a/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
+++ b/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
@@ -1,6 +1,6 @@
 # Agent-Requested Tester Runs + the Operator Alert Bridge
 
-- **Status:** Partly implemented. The reference-agent now exposes the tester capabilities manifest endpoint in review; the platform helper, board approval gate for agent-requested missions, and off-device alert bridge remain follow-up work.
+- **Status:** Reconciled 2026-05-31. D4 off-device alert bridge shipped earlier (#279) and D1 operator digest/reporting shipped in #294. T6 board-gated agent-requested tester runs and T7 capabilities/platform-helper work remain follow-up/design unless code evidence proves otherwise.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_E2E_TESTER_DESIGN.md`](./HERMES_E2E_TESTER_DESIGN.md), [`HERMES_TESTER_AUTH_DESIGN.md`](./HERMES_TESTER_AUTH_DESIGN.md), [`HERMES_ROADMAP.md`](./HERMES_ROADMAP.md).
 - **Problem:** the code-building agents (the ones opening `app:` PRs in `averray-agent/agent`) can't currently start a tester run, don't know the tester's capabilities, and there's no way to reach the operator for approval when they're away from the Mac.
@@ -53,7 +53,7 @@ Today the board only has **browser** notifications (#232: tab badge, desktop not
 
 ## Build sequence
 
-1. **Alert bridge (Slack)** — highest leverage: unblocks "step away," and it's the O4 prerequisite. *(reference-agent)*
+1. **Alert bridge (Slack)** — highest leverage: unblocks "step away," and it's the O4 prerequisite. *(Shipped as D4 in #279; D1 operator reporting shipped in #294.)*
 2. **Agent-requested run endpoint + the proposed-mission approval gate** on the board. *(reference-agent)*
 3. **Capabilities manifest** + the **platform-repo helper** + the **platform `AGENTS.md`** pointer. *(manifest endpoint = reference-agent; helper + AGENTS.md = platform repo follow-up)*
 
@@ -71,4 +71,4 @@ Today the board only has **browser** notifications (#232: tab badge, desktop not
 
 ---
 
-*End. The manifest endpoint is now implemented in the reference-agent; remaining items are still planning/handoff until their PRs land.*
+*End. Reconciled 2026-05-31: D4 and D1 are shipped; T6/T7 stay follow-up/design here.*

--- a/docs/HERMES_E2E_TESTER_DESIGN.md
+++ b/docs/HERMES_E2E_TESTER_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes E2E Tester — Design (the product tester)
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.** Design-level spec.
+- **Status:** Reconciled 2026-05-31. T2 pre-seeded session (#293), T3 SIWE role-gating (#290), and T5 env→mutation binding/enhancements (#297) have shipped. T4 Tier-2 agent, T6 agent-requested runs, and T7 capabilities/helper work remain follow-up/design unless code evidence proves otherwise.
 - **Date:** 2026-05-29
 - **Lives in:** this repo (`depre-dev/averray-reference-agent`) — the testbed/mission code is here.
 - **Tests:** the platform product `averray-agent/agent` — the Polkadot Agent Platform ("Averray"): an agent-first job/treasury runtime on Polkadot Hub TestNet.
@@ -104,10 +104,10 @@ Each mission's verdict is LLM-judged (Tier 2) or rule-checked (Tier 1); both rec
 
 ## Build sequencing
 
-1. **Tier 1 hardening** — broaden the heuristic executor to all surfaces + add the boundary-honesty check + add a **pre-seeded session** so it can reach authed pages. (Cheap, immediate value, no LLM.)
-2. **Signer sidecar + SIWE mission** — the keystone unlock for authed testing.
+1. **Tier 1 hardening** — broaden the heuristic executor to all surfaces + add the boundary-honesty check + add a **pre-seeded session** so it can reach authed pages. (T2 pre-seeded session shipped in #293.)
+2. **Signer sidecar + SIWE mission** — the keystone unlock for authed testing. (T3 role-gating mission shipped in #290; sidecar foundation shipped earlier in #283.)
 3. **Tier-2 agent executor** (Agent SDK + Playwright-MCP + HTTP/wallet) via the `command` hook — the gold-path missions.
-4. **Env→mutation-profile binding** (do before any mainnet exists).
+4. **Env→mutation-profile binding** (do before any mainnet exists). (T5 shipped in #297.)
 5. **Enhancements** — trace/video, regression baselines, B2 self-healing hook.
 
 ## Invariants / safety
@@ -119,4 +119,4 @@ Each mission's verdict is LLM-judged (Tier 2) or rule-checked (Tier 1); both rec
 
 ---
 
-*End of E2E tester design. Planning/handoff only — not implemented.*
+*End of E2E tester design. Reconciled 2026-05-31: T2, T3, and T5 have shipped; T4/T6/T7 remain follow-up/design.*

--- a/docs/HERMES_ORCHESTRATION_DESIGN.md
+++ b/docs/HERMES_ORCHESTRATION_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Execution Design (per-phase build specs)
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.** This is the build spec a future agent follows; it does not apply changes.
+- **Status:** Reconciled 2026-05-31. This is the historical execution spec for O1-O5; O1-O4 have shipped, including O4 autonomy mode (#288) and autopilot auto-approval (#289). O5 self-management hardening remains follow-up.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md) (the why + phases), [`HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md) (the confirmed source map).
 - **Decisions:** all nine open decisions are **resolved** (see the table at the end). They're baked into the specs below. `path:line` references are local to this repo; code blocks are illustrative sketches, not applied diffs.
@@ -147,6 +147,8 @@ interface AutonomyState {
 
 **Risk: HIGH** — this is the authority change and the autonomy surface. Treat as security-reviewed work; ships only with (A)+(B)+(C)+(D) together.
 
+Implementation note: O4 shipped across #280, #281, #288, and #289. Merge/deploy remain human-gated.
+
 ---
 
 ## P5 — Self-management hardening  ·  ongoing
@@ -181,4 +183,4 @@ interface AutonomyState {
 
 ---
 
-*End of execution design. Planning/handoff only — not implemented.*
+*End of execution design. Reconciled 2026-05-31: O1-O4 have shipped; O5 remains follow-up.*

--- a/docs/HERMES_PHASE2_DESIGN.md
+++ b/docs/HERMES_PHASE2_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Phase 2 Design (Intelligence + Trust)
 
-- **Status:** Phase-2 implementation has started. A1 now has a read-only scorecard spine/API/MCP slice in review; A2 learned routing is in review; A3 and D1-D3 remain design-level.
+- **Status:** Reconciled 2026-05-31. A1 (#285), A2 (#287), A3a cost visibility (#295), D1 (#294), D2 (#296), and D3 (#286) have shipped. A3b cost-aware routing/budget remains in progress; remaining product-depth follow-ups are not marked shipped here.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md), [`HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md), [`HERMES_ORCHESTRATION_DESIGN.md`](./HERMES_ORCHESTRATION_DESIGN.md) (the core P1–P5).
 - **Position:** **Phase 2.** Builds on the core — it consumes agent attribution (P1), dispatch + the autonomy mode (P3/P4), and the handoff-event log. Do not start until the core ships.
@@ -45,7 +45,7 @@ Per-agent, per-surface metrics from the spine:
 
 Surface: a board panel + `averray_agent_scorecard` MCP tool. **This is the first Phase-2 build** (decision #1) — the spine + its first visible payoff together.
 
-Implementation note: the first A1 slice exposes `/monitor/agents` and `averray_agent_scorecard` from existing monitor events, codex/Claude task queue state, and browser mission reports. It deliberately marks cost/tokens, autopilot auto-approval rework, time-to-PR, and time-to-merge as `not_recorded` until those signals exist in durable events. Board-panel polish and `/monitor/sessions/:id` are follow-ups.
+Implementation note: A1 shipped in #285. The first slice exposes `/monitor/agents` and `averray_agent_scorecard` from existing monitor events, codex/Claude task queue state, and browser mission reports. A3a later added cost/token visibility in #295; unavailable provider signals still render as `not_recorded`. Board-panel polish and `/monitor/sessions/:id` are follow-ups.
 
 ### A2 — Learned routing  ·  acts · risk: medium · **data-driven within non-high-risk** (decision #2)
 Stats fully drive routing for non-high-risk surfaces — with safeguards so "data-driven" doesn't become brittle or self-entrenching:
@@ -57,10 +57,10 @@ Stats fully drive routing for non-high-risk surfaces — with safeguards so "dat
 - **Always explained:** every routing decision carries its rationale ("Claude — 92% merge on UI vs Codex 70%"), recorded in D2 and shown in the rail.
 - Coheres with autopilot: autopilot only auto-approves non-high-risk anyway, so data-driven routing of non-high-risk and autopilot auto-approval line up cleanly.
 
-Implementation note: A2 is wired only as the default agent choice for proposed tasks with no explicit agent. It reads the A1 scorecard defensively, ignores `not_recorded` signals as neutral, keeps high-risk routing rule-bound to Codex, and leaves the operator approval gate unchanged.
+Implementation note: A2 shipped in #287. It is wired only as the default agent choice for proposed tasks with no explicit agent. It reads the A1 scorecard defensively, ignores `not_recorded` signals as neutral, keeps high-risk routing rule-bound to Codex, and leaves the operator approval gate unchanged.
 
-### A3 — Cost  ·  later
-Visibility first (cost is on the scorecard from A1). Cost-as-a-routing-factor and a $-based dispatch budget come once throughput data is meaningful — don't optimize cost before you can measure value.
+### A3 — Cost  ·  split
+A3a cost visibility shipped in #295: reported token/cost signals populate the scorecard/board where available, while providers that do not report usage stay `not_recorded`. A3b cost-as-a-routing-factor and a $-based dispatch budget remain in progress — don't optimize cost before value and safety data are meaningful.
 
 ---
 
@@ -71,8 +71,12 @@ When autopilot ends (timer/safety-cap expiry or you return), aggregate that sess
 - **Delivery:** board panel **+ push to Slack/the messaging gateway** (`SLACK_WEBHOOK_URL` already wired) — you were away from the board by definition, so push is how you actually see it.
 - **Reuse:** the existing operator-report shape (it already produces "daily operator brief"); the digest is the same machinery scoped to one autopilot session.
 
+Implementation note: D1 shipped in #294 as the session/digest operator-report surface.
+
 ### D2 — Explainability / audit replay  ·  read · risk: low
 Every dispatch logs a structured **decision record**: `{ taskId, routedTo, reason, riskTier, mode, guardrailCheck (allowlist + budget remaining), approvedBy }`. A board view reconstructs "why did Hermes route/approve/escalate X" by correlation id — reusing the existing correlation-id discipline. Governance + debugging + the backbone of trust.
+
+Implementation note: D2 shipped in #296 with dispatch decision records and replay/explainability.
 
 ### D3 — Anomaly auto-pause  ·  acts · risk: medium · **tiered: soft then hard** (decision #3)
 Watch the task/event stream against configurable thresholds:
@@ -81,6 +85,8 @@ Watch the task/event stream against configurable thresholds:
 - **Hard trip (severe — budget blowout, multi-task runaway, destructive diff):** touch `HALT_FILE` — everything mutating stops immediately.
 - Every trip writes a decision/anomaly record (D2) and pushes an alert (D1 channel). Thresholds live in config alongside the dispatch guardrail.
 This is the fail-safe that makes handing over the wheel sane: you hand off knowing it stops itself if something's wrong.
+
+Implementation note: D3 shipped in #286 and owns the autopilot-suspended flag.
 
 ---
 
@@ -106,4 +112,4 @@ All sits *after* the core P1–P4. Each ships as a narrow PR per [AGENTS.md](../
 
 ---
 
-*End of Phase 2 design. A1 read-only scorecard implementation has started; A2 learned routing is in review with guardrails; remaining acting layers stay design-level until their guardrails are built.*
+*End of Phase 2 design. Reconciled 2026-05-31: A1, A2, A3a, and D1-D3 have shipped; A3b cost-aware routing/budget remains in progress.*

--- a/docs/HERMES_PHASE3_DESIGN.md
+++ b/docs/HERMES_PHASE3_DESIGN.md
@@ -1,9 +1,9 @@
 # Hermes Orchestration — Phase 3 Design (Hermes as Planner)
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.** Design-level spec for the autonomy payoff layer.
+- **Status:** Reconciled 2026-05-31. B1/B2 remain planning/handoff only. The enabling A/D/O prerequisites have advanced, but no B-stream item is marked shipped here.
 - **Date:** 2026-05-29
 - **Companions:** the core [`HERMES_ORCHESTRATION_DESIGN.md`](./HERMES_ORCHESTRATION_DESIGN.md) (P1–P5) and [`HERMES_PHASE2_DESIGN.md`](./HERMES_PHASE2_DESIGN.md) (themes A + D).
-- **Position:** **Phase 3 (Theme B).** The leap from *Hermes routes work you define* → *Hermes decides what's next*. Builds on the core (P1–P4) **and** Phase 2 — it needs the scorecard (prioritization), D2 (explain why it proposed something), **D3 (the loop fail-safe)**, and D1 (report what it planned while you were away). Do not start before those exist.
+- **Position:** **Phase 3 (Theme B).** The leap from *Hermes routes work you define* → *Hermes decides what's next*. Builds on the core (P1–P4) **and** Phase 2 — it needs the scorecard (prioritization), D2 (explain why it proposed something), **D3 (the loop fail-safe)**, and D1 (report what it planned while you were away). Those prerequisites are now shipped, but B1/B2 still need their own implementation.
 
 > **The principle that makes it safe:** separate *deciding scope* from *executing sanctioned scope*. The roadmap (and you) sanction *what* gets built; autopilot may *execute* sanctioned work unattended, but *inventing new scope* always returns to you. This single line keeps an autonomous planner from becoming "agent builds whatever."
 
@@ -60,4 +60,4 @@ Build B1 before B2 (B1 is the core "what's next" loop; B2 adds incident response
 
 ---
 
-*End of Phase 3 design. Planning/handoff only — not implemented.*
+*End of Phase 3 design. Reconciled 2026-05-31: B1/B2 remain design/follow-up.*

--- a/docs/HERMES_PHASE4_DESIGN.md
+++ b/docs/HERMES_PHASE4_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Phase 4 Design (Multi-Agent Collaboration)
 
-- **Status:** Planning / handoff only. **Nothing here is implemented.** Design-level spec.
+- **Status:** Reconciled 2026-05-31. C4 inter-agent chat v1 shipped in #291. C1-C3 and remaining C follow-ups stay design/follow-up.
 - **Date:** 2026-05-29
 - **Companions:** the core [`HERMES_ORCHESTRATION_DESIGN.md`](./HERMES_ORCHESTRATION_DESIGN.md) (P1–P5), [`HERMES_PHASE2_DESIGN.md`](./HERMES_PHASE2_DESIGN.md) (A + D), [`HERMES_PHASE3_DESIGN.md`](./HERMES_PHASE3_DESIGN.md) (B).
 - **Position:** **Phase 4 (Theme C).** Today agents work in *parallel but isolated* — each builds its own PR; only Hermes reviews. C makes them work *together* and lets the roster grow. **Modular:** it builds on the core's multi-worker (P2) + the existing review machinery, and is independent of B — it can land alongside Phase 2/3 rather than strictly after.
@@ -28,6 +28,8 @@ Any unresolved disagreement — a panel split, or a reviewer that blocks — **p
 
 Extend the board's collaboration channel (today: `codex | hermes | operator | system`; note `claude` isn't yet a collaboration author) so agents can coordinate directly on a card — e.g. a reviewer asking the builder to clarify, or Hermes brokering a disagreement before escalating. A data-model extension (`CollaborationAuthor`/`Target`) + UI; low-risk and immediately useful once there are ≥2 builders.
 
+Implementation note: C4 v1 shipped in #291 with Claude author/target and card-scoped agent messages. Broader collaboration/review follow-ups are still governed by C1-C3.
+
 ---
 
 ## Dependencies & sequencing
@@ -47,4 +49,4 @@ Extend the board's collaboration channel (today: `codex | hermes | operator | sy
 
 ---
 
-*End of Phase 4 design. Planning/handoff only — not implemented.*
+*End of Phase 4 design. Reconciled 2026-05-31: C4 v1 has shipped; C1-C3 and remaining collaboration follow-ups are still design/follow-up.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -1,9 +1,11 @@
 # Hermes Orchestration — Roadmap & Naming Index (canonical)
 
 - **Status:** Planning index. This is the **single source of truth for work-item IDs and order.** It supersedes the old `P#` / `Phase #` labels.
-- **Date:** 2026-05-29
+- **Date:** 2026-05-31
 
 > **Naming:** one prefix per stream, numbered within it. **`P#` and `Phase #` are retired** — they collided (`P2` Claude worker vs `Phase 2` A+D). Use the IDs below in all handoff prompts and discussion.
+
+> **Reconciliation note (2026-05-31):** This index was reconciled against landed PRs #285-#297. It marks only code-backed shipped slices as done; A3b cost-aware routing/budget remains in progress, and T4/T6/T7 plus the remaining B/O5/C follow-ups stay design/follow-up unless code evidence proves otherwise. Current `main` has an O5 first slice in build, but O5 is not marked complete.
 
 ## Streams
 
@@ -24,41 +26,41 @@
 | O1 | Agent attribution (branch-prefix → agentType) | ✅ done (#252) |
 | O2 | Claude Code worker (greenfield, Agent SDK) | ✅ done (#256 queue · #259 auth · #260 runner · #262 worker · #263 ops) |
 | O3 | Board-driven dispatch | ✅ done — create/approve form (agent picker) + `/task` verb live on the board (#271) |
-| O4 | Hermes enqueue + dispatch guardrail + autonomy mode | 🟡 in build — PR1 enqueue+guardrail ✅ (#280) · PR2 routing taxonomy ✅ (#281) · PR3 autopilot auto-approval **blocked on D3** |
+| O4 | Hermes enqueue + dispatch guardrail + autonomy mode | ✅ done — PR1 enqueue+guardrail (#280) · PR2 routing taxonomy (#281) · PR3a autonomy mode (#288) · PR3b autopilot auto-approval (#289); merge/deploy remain human-gated |
 | O5 | Self-management hardening | 🟡 in build — first slice surfaces failed/stale agent tasks in `needs-attention` |
-| A1 | Agent scorecard | 🟡 in review — read-only `/monitor/agents` + `averray_agent_scorecard` scorecard slice |
-| A2 | Learned routing (data-driven, non-high-risk) | 🟡 in review — scorecard-backed default routing, high-risk rule-bound |
-| A3 | Cost visibility / cost-aware routing | design done |
-| A4 | Agent model & effort policy — riskTier→effort/model + operator override (tester LLM; Hermes model = open) | design done (see `HERMES_AGENT_MODELS_AND_EFFORT.md`) |
-| D1 | "While you were away" digest (board + Slack/push) | 🟡 in review — autopilot session-end digest + alert-bridge push |
-| D2 | Explainability / decision records | design done |
-| D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | 🟡 in build (prompt out — unblocks O4-PR3) |
+| A1 | Agent scorecard | ✅ done (#285) — read-only `/monitor/agents` + `averray_agent_scorecard` scorecard slice |
+| A2 | Learned routing (data-driven, non-high-risk) | ✅ done (#287) — scorecard-backed default routing, high-risk rule-bound |
+| A3 | Cost visibility / cost-aware routing | 🟡 split — A3a cost visibility ✅ (#295); A3b cost-aware routing/budget in progress |
+| A4 | Agent model & effort policy — riskTier→effort/model + operator override (tester LLM; Hermes model = open) | ✅ done (#292) — riskTier→effort/model + operator override |
+| D1 | "While you were away" digest (board + Slack/push) | ✅ done (#294) — autopilot/session digest + operator report surface |
+| D2 | Explainability / decision records | ✅ done (#296) — dispatch decision records and replay surface |
+| D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | ✅ done (#286) — anomaly auto-pause owns autopilot-suspended flag |
 | D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
 | B1 | Backlog generation (roadmap auto-flow; net-new escalates) | design done |
 | B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
 | C1 | Cross-agent review (default) | design done |
 | C2 | Reviewer panel (high-risk) | design done |
 | C3 | Specialist agents (test-writer/security/docs) | design done |
-| C4 | Inter-agent chat | 🟡 in review — Claude author/target + card-scoped agent messages |
+| C4 | Inter-agent chat | ✅ done (#291) — Claude author/target + card-scoped agent messages v1 |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
-| T2 | Pre-seeded session (authed sweep) | design done |
-| T3 | Signer sidecar + SIWE mission (multi-role) | 🟡 in review — signer sidecar done (#283); SIWE role-gating mission follow-up |
+| T2 | Pre-seeded session (authed sweep) | ✅ done (#293) |
+| T3 | Signer sidecar + SIWE mission (multi-role) | ✅ done — signer sidecar foundation (#283) + SIWE role-gating mission (#290) |
 | T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
-| T5 | Env→mutation binding + enhancements (trace/video, baselines) | 🟡 in review — env-bound mutation profile + Playwright trace/video + baseline comparison slice |
+| T5 | Env→mutation binding + enhancements (trace/video, baselines) | ✅ done (#297) — env-bound mutation profile + Playwright trace/video + baseline comparison slice |
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |
-| T7 | Tester capabilities manifest (+ platform-repo request helper) | in review — manifest endpoint; platform helper follow-up |
+| T7 | Tester capabilities manifest (+ platform-repo request helper) | design/follow-up — do not mark shipped here without code evidence; platform helper remains follow-up |
 
-*(Status as of 2026-05-31 — **shipped:** O0–O3 (operator-driven loop), T1 (per-deploy surface sweep), T3 (signer sidecar foundation), D4 (alert bridge), O4-PR1+PR2 (Hermes proposes smart risk-tagged work; supervised). **In build:** D1 (autopilot away digest), D3 (anomaly auto-pause — unblocks O4-PR3), C4 (inter-agent chat channel), and T7 reference-agent manifest endpoint. **Design-only / remaining:** O4-PR3 (autopilot, gated on D3), O5, A1–A3, B1–B2, C1–C3, D2, T2, T4–T6, and the T7 platform helper/AGENTS pointer. **Critical path to autopilot:** D3 → O4-PR3 → supervised burn-in → flip on. Everything else is depth/enhancement.)*
+*(Status as of 2026-05-31 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget and the O5 first slice. **Design / follow-up:** remaining O5 hardening, B1–B2, C1–C3 and remaining C follow-ups, T4, T6, T7, plus any platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 
 1. **The self-feeding loop:** **O1 → O2 → O3.** Once this exists you stop hand-writing prompts; work is enqueued from the board and you just approve. Highest-leverage effort.
    - **T1** runs in parallel with O1 (independent, both runner/board TS).
-2. **The safety net:** **D4** (off-device alert bridge — build first; delivers "step away" now + the O4 prerequisite), **T1** (+ **T6/T7** agent-requested runs + capabilities), **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause). This is what makes autonomy safe to trust.
-3. **Autonomy:** **O4** (enqueue + guardrail + autonomy mode) → set "Hermes in charge," read the digest. Lowest-effort end state.
-4. **Depth, anytime after:** **A1 → A2** (performance/learned routing), **B** (planner), **C** (collaboration), **T4/T5** (agentic missions + enhancements), **O5** (hardening), **A3**.
+2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6/T7** remain follow-up for agent-requested runs + capabilities.
+3. **Autonomy:** **O4** (enqueue + guardrail + autonomy mode) has shipped; supervised burn-in and monitoring decide when to rely on it more heavily.
+4. **Depth, anytime after:** **A1 → A2** shipped; **A3b** is in progress. Remaining depth is **B** (planner), **C1–C3** plus C follow-ups, **T4/T6/T7**, and **O5** hardening.
 
-**Dependencies to respect:** B2 needs D3 (loop fail-safe); A2 needs A1 (baselines); O4 is the authority change (ships only with its guardrail) **and needs D4** (escalations must reach the operator off-device); T6 needs the proposed-mission approval gate; T-missions that mutate stay on testnet (env→mutation binding before any mainnet).
+**Dependencies to respect:** B2 needs D3 (loop fail-safe); A2 needs A1 (baselines); O4 is the authority change and needs D4 (escalations must reach the operator off-device); T6 needs the proposed-mission approval gate; T-missions that mutate stay on testnet (env→mutation binding before any mainnet).
 
 ## Old → new mapping (so prior references resolve)
 

--- a/docs/HERMES_TESTER_AUTH_DESIGN.md
+++ b/docs/HERMES_TESTER_AUTH_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes E2E Tester — Auth & Session Layer (build spec for steps 2–3)
 
-- **Status:** T3 signer sidecar merged (#283); SIWE mission/role-gating coverage is being wired as the T3 follow-up.
+- **Status:** Reconciled 2026-05-31. T3 signer sidecar foundation (#283) and SIWE mission/role-gating coverage (#290) have shipped.
 - **Date:** 2026-05-29
 - **Companion to:** [`HERMES_E2E_TESTER_DESIGN.md`](./HERMES_E2E_TESTER_DESIGN.md) — this details build steps **(2) pre-seeded session** and **(3) signer sidecar + SIWE mission**, which are the keystone that lets the tester reach the authed product instead of only public pages.
 - **Tests:** `averray-agent/agent` — SIWE auth (`/auth/nonce` → `personal_sign` → `/auth/verify` → JWT; roles `admin`/`verifier` pinned at sign-in via `AUTH_ADMIN_WALLETS`/`AUTH_VERIFIER_WALLETS`).
@@ -66,9 +66,9 @@ The payoff of separate role wallets — a mission that exercises auth as a first
 
 ## Build sequence
 
-1. **Step 2 — pre-seeded session:** runner accepts a session input; authed routes join the surface sweep; works with a manually-provided `storageState` first. *(One narrow PR.)*
-2. **Step 3a — signer sidecar service:** a thin multi-role mint+cache service in `ops/` that **wraps the existing `siweLogin()`** for three **fixed, pre-funded** keys; keys isolated. Mostly wiring, not new SIWE. *(One narrow PR.)*
-3. **Step 3b — SIWE mission + role-gating checks:** the auth mission that drives the sidecar and asserts happy-path + 401/403. *(One narrow PR.)*
+1. **Step 2 — pre-seeded session:** runner accepts a session input; authed routes join the surface sweep; works with a manually-provided `storageState` first. *(Shipped in #293.)*
+2. **Step 3a — signer sidecar service:** a thin multi-role mint+cache service in `ops/` that **wraps the existing `siweLogin()`** for three **fixed, pre-funded** keys; keys isolated. Mostly wiring, not new SIWE. *(Shipped in #283.)*
+3. **Step 3b — SIWE mission + role-gating checks:** the auth mission that drives the sidecar and asserts happy-path + 401/403. *(Shipped in #290.)*
 
 ## Security / invariants
 
@@ -78,4 +78,4 @@ The payoff of separate role wallets — a mission that exercises auth as a first
 
 ---
 
-*End of tester auth/session design. Step 3a shipped in #283; step 3b wires the SIWE role-gating mission against that sidecar.*
+*End of tester auth/session design. Reconciled 2026-05-31: step 3a shipped in #283 and step 3b shipped in #290.*

--- a/docs/HERMES_WORKER_AUTH_BILLING.md
+++ b/docs/HERMES_WORKER_AUTH_BILLING.md
@@ -1,7 +1,7 @@
 # Worker Model Auth & Billing (Claude / Codex)
 
-- **Status:** Planning / handoff. Operational note for whoever builds **O2** (Claude worker) and **T4** (Tier-2 tester agent), and for the operator who provisions credentials.
-- **Date:** 2026-05-29
+- **Status:** Reconciled 2026-05-31. O2 has shipped; this remains the operational billing/auth note for the live Claude worker and the still-design T4 Tier-2 tester agent.
+- **Date:** 2026-05-31
 - **Scope:** how the agent *workers* authenticate to their **model providers** (Anthropic / OpenAI) and how that **bills**. This is **not** product auth (that's SIWE via the signer sidecar — see `HERMES_TESTER_AUTH_DESIGN.md`) and **not** the dispatch guardrail (though the spend cap below *is* the budget half of AGENTS invariant #6).
 
 > Time-sensitive: Anthropic unbundles programmatic Claude from the subscription on **June 15, 2026** (see below). Design O2/T4 for that reality, not for "free on the sub forever."
@@ -36,7 +36,7 @@ Authenticates via **"Sign in with ChatGPT"** — usage is **included in the Chat
 | Now / dev / low-volume (next ~2 weeks) | Claude: sub OAuth token (no API key in env). Codex: ChatGPT sub. | **~$0 extra** — bundled in existing subs; from June 15 the $100/$200 credit covers low volume. |
 | Autopilot / higher volume / production | API key + **spend cap** (Console) | metered, predictable, capped; clean ToS for shared automation. |
 
-**Cost projection (next 2 weeks): ~$0 extra**, running on the subs — provided the route is verified (footguns above) and you stay within Max usage limits (subs throttle, they don't surprise-bill). Autopilot (O4) isn't built yet, so volume is manual-dispatch-bounded. *Metered-equivalent would plausibly be low-tens-of-dollars to ≈$100 worst case (Opus, no caching, many reruns) — but it's moot on the sub.*
+**Cost projection (next 2 weeks): ~$0 extra**, running on the subs — provided the route is verified (footguns above) and you stay within Max usage limits (subs throttle, they don't surprise-bill). O4 autopilot has shipped, so keep dispatch budgets and A3a cost visibility active while A3b cost-aware routing/budget is in progress. *Metered-equivalent would plausibly be low-tens-of-dollars to ≈$100 worst case (Opus, no caching, many reruns) — but it's moot on the sub.*
 
 ---
 
@@ -46,7 +46,7 @@ Authenticates via **"Sign in with ChatGPT"** — usage is **included in the Chat
 - **Route-verification health check on worker startup** — assert the *intended* route is the *active* one (e.g. equivalent of `claude /status`; if intending sub but `ANTHROPIC_API_KEY` is present in the env, **fail loud**, don't silently API-bill). This defuses both footguns.
 - **Spend cap when on API key** — set a Console cap per runner; this is the budget half of AGENTS invariant #6 (new power ⇒ allowlist + **budget** + human approval).
 - **Operator provisions tokens/keys**; agents never handle the secret. Never log tokens/keys (existing invariant; output sanitization is a backstop, not a license).
-- **Do this now (O2 is in build):** run `claude /status` + check `echo $ANTHROPIC_API_KEY` in the worker env to confirm you're not already silently API-billing.
+- **Operator check:** run `claude /status` + check `echo $ANTHROPIC_API_KEY` in the worker env to confirm you're not silently API-billing when sub OAuth is intended.
 
 ## Sources
 [Claude Code auth](https://code.claude.com/docs/en/authentication) · [Claude Code headless](https://code.claude.com/docs/en/headless) · [Agent SDK with your Claude plan](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) · [Codex auth](https://developers.openai.com/codex/auth) · [Codex pricing](https://developers.openai.com/codex/pricing)


### PR DESCRIPTION
## Summary
- reconcile HERMES_ROADMAP against landed PRs #285-#297
- add 2026-05-31 reconciliation notes to nearby Hermes phase/status docs
- keep A3b, T4/T6/T7, B/O5, and remaining C follow-ups explicitly open

## Checks
- docs-only; no runtime/typecheck run

## Impact
- Docs only
- No backend/frontend/indexer/contracts/public-site changes
- No env or VPS secret changes