### PR TITLE
fix: initialize autonomy maintenance before startup check

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -209,6 +209,10 @@ server.listen(httpPort, "0.0.0.0", () => {
   logger.info({ httpPort }, "slack_operator_http_listening");
 });
 
+let autonomyMaintenanceRunning = false;
+let awayDigestTrackerState = initialAutopilotAwayDigestTrackerState();
+let pendingAwayDigestEnd: { endedAutonomy: AutonomyState; endedBy?: string } | undefined;
+
 if (!enabled) {
   logger.info("slack_operator_disabled");
 } else {
@@ -223,10 +227,6 @@ if (!enabled) {
   setInterval(() => void checkAutonomyMaintenance(), 60_000);
   void checkAutonomyMaintenance();
 }
-
-let autonomyMaintenanceRunning = false;
-let awayDigestTrackerState = initialAutopilotAwayDigestTrackerState();
-let pendingAwayDigestEnd: { endedAutonomy: AutonomyState; endedBy?: string } | undefined;
 
 async function checkAutonomyMaintenance(endedAutonomy?: AutonomyState, endedBy?: string) {
   if (autonomyMaintenanceRunning) {


### PR DESCRIPTION
## What changed
- Moves Slack operator autonomy-maintenance state declarations above the startup call to `checkAutonomyMaintenance()`.
- Fixes the production crash loop: `ReferenceError: Cannot access autonomyMaintenanceRunning before initialization`.

## Checks
- `npm run typecheck`
- `npm run build`
- `npm test -- --run test/unit/slack-operator.test.ts`
- `npm test -- --run test/unit/autopilot-approve.test.ts test/unit/anomaly-pause.test.ts test/unit/slack-operator.test.ts`
- `npm test -- --run test/unit/away-digest.test.ts`

## Impact
- Affects slack-operator / monitor startup only.
- No env or VPS secret changes.
