### PR TITLE
feat: add cross-agent review requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,10 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   redacts command output, and **opens a PR but never merges**. The Claude
   worker is greenfield (creates the branch + opens the PR); the Codex worker
   iterates an existing PR.
+- **Cross-agent review requests are advisory records.** Hermes, the operator,
+  Codex, or Claude may request a second-agent review on a card, but the request
+  only records/displays coordination context; it does **not** enqueue a task,
+  auto-run a reviewer, approve dispatch, merge, or deploy.
 
 ---
 

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -38,7 +38,7 @@
 | D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
 | B1 | Backlog generation (roadmap auto-flow; net-new escalates) | design done |
 | B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
-| C1 | Cross-agent review (default) | design done |
+| C1 | Cross-agent review (default) | 🟡 in build — first slice records/displays review requests only; no auto-run or authority change |
 | C2 | Reviewer panel (high-risk) | design done |
 | C3 | Specialist agents (test-writer/security/docs) | design done |
 | C4 | Inter-agent chat | ✅ done (#291) — Claude author/target + card-scoped agent messages v1 |

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -53,6 +53,25 @@ describe("Card — type coverage", () => {
     expect(container.querySelector(".hm-checks-bar")).toBeNull();
   });
 
+  test("card shows a small cross-agent review request indicator", () => {
+    const card: BoardCard = {
+      ...fixture("agent #547"),
+      reviewRequests: [{
+        id: "review-1",
+        requestedBy: "hermes",
+        reviewer: "claude",
+        reason: "Second-agent review before this moves forward.",
+        status: "requested",
+        createdAt: "2026-05-31T12:00:00.000Z",
+        updatedAt: "2026-05-31T12:00:00.000Z",
+      }],
+    };
+    const { container } = render(<Card card={card} />);
+    expect(within(container).getByText("Review requested")).toBeTruthy();
+    expect(within(container).getByText("Claude")).toBeTruthy();
+    expect(container.querySelector(".hm-review-request")).toBeTruthy();
+  });
+
   test("draft PR shows the draft pill", () => {
     const { container } = render(<Card card={fixture("agent #550")} />);
     expect(within(container).getByText("draft")).toBeTruthy();

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -117,6 +117,10 @@ export function Card({ card, focused = false, onClick, onApprove }: CardProps) {
         </div>
       ) : null}
 
+      {!isClosed && card.reviewRequests?.some((request) => request.status === "requested") ? (
+        <ReviewRequestedLine card={card} />
+      ) : null}
+
       {isClosed && verdictText ? (
         <div className="hm-card-meta">
           <span className="hm-mono">{closedAt}</span>
@@ -223,6 +227,27 @@ function CardHead({ card, isStale, isClosed }: { card: BoardCard; isStale: boole
       </span>
     </div>
   );
+}
+
+function ReviewRequestedLine({ card }: { card: BoardCard }) {
+  const active = card.reviewRequests?.filter((request) => request.status === "requested") ?? [];
+  const first = active[0];
+  if (!first) return null;
+  const suffix = active.length > 1 ? ` +${active.length - 1}` : "";
+  return (
+    <div className="hm-review-request" aria-label={`Review requested from ${actorDisplayName(first.reviewer)}`}>
+      <span className="hm-review-request-dot" aria-hidden />
+      <span>Review requested</span>
+      <strong>{actorDisplayName(first.reviewer)}{suffix}</strong>
+    </div>
+  );
+}
+
+function actorDisplayName(actor: "hermes" | "operator" | "codex" | "claude"): string {
+  if (actor === "hermes") return "Hermes";
+  if (actor === "operator") return "Pascal";
+  if (actor === "claude") return "Claude";
+  return "Codex";
 }
 
 // ── Checks label (e.g. "5/6 · 1 running") ──────────────────────────

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -77,6 +77,16 @@ export interface CardRiskSignal {
   message: string;
 }
 
+export interface CardReviewRequest {
+  id: string;
+  requestedBy: "hermes" | "operator" | "codex" | "claude";
+  reviewer: "codex" | "claude" | "hermes" | "operator";
+  reason: string;
+  status: "requested" | "responded" | "cancelled";
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface HermesDecisionSubject {
   type: "task" | "card" | "repo" | "pr" | "mission" | "digest" | "autopilot_session";
   id: string;
@@ -142,8 +152,12 @@ export interface CardBase {
   archiveHint?: boolean;
   /** free-form "next action" copy from the classifier */
   next?: string;
+  /** Stable correlation id for non-PR cards (mission/task/deploy), when present. */
+  correlationId?: string;
   /** D2: latest durable explanation associated with the card. */
   decisionRecord?: HermesDecisionRecord;
+  /** C1: active cross-agent review requests scoped to this card. */
+  reviewRequests?: CardReviewRequest[];
 }
 
 /** PR card — file changes, Hermes verdict, operator-review action. */

--- a/packages/monitor-ui/src/lib/monitor/collaboration.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.ts
@@ -16,6 +16,10 @@ export interface CollaborationRelatedPr {
   number: number;
 }
 
+export interface CollaborationRelatedMission {
+  id: string;
+}
+
 export interface CollaborationMessage {
   id: string;
   ts: number;
@@ -25,6 +29,19 @@ export interface CollaborationMessage {
   addressedTo: CollaborationTarget;
   relatedPr?: CollaborationRelatedPr;
   relatedCorrelationId?: string;
+}
+
+export interface ReviewRequest {
+  id: string;
+  relatedPr?: CollaborationRelatedPr;
+  relatedMission?: CollaborationRelatedMission;
+  correlationId?: string;
+  requestedBy: Exclude<CollaborationAuthor, "system">;
+  reviewer: Exclude<CollaborationTarget, "everyone">;
+  reason: string;
+  status: "requested" | "responded" | "cancelled";
+  createdAt: string;
+  updatedAt: string;
 }
 
 /** Display name for a turn's author (operator → "Pascal", else the role). */

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -736,6 +736,35 @@ body { margin: 0; }
 .hm-card-meta .sep { color: var(--hm-muted-soft); }
 .hm-card-meta .repo { color: var(--hm-ink-soft); }
 
+.hm-review-request {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: var(--hm-blue-soft);
+  border: 1px solid rgba(70, 111, 157, 0.22);
+  color: var(--hm-blue);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.hm-review-request strong {
+  color: var(--hm-ink);
+  font-weight: 800;
+  letter-spacing: 0 !important;
+  text-transform: none;
+}
+.hm-review-request-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--hm-blue);
+}
+
 .hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }
 .hm-pill {
   display: inline-flex; align-items: center; gap: 5px;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -39,9 +39,12 @@ import {
   classifyHermesMemoryRequest,
   listCollaborationMessages,
   listHermesMemoryNotes,
+  listReviewRequests,
   recordCollaborationMessage,
   recordHermesMemoryNote,
+  recordReviewRequest,
   synthesizeHermesReplyFor,
+  type ReviewRequestStatus,
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
 import { buildV2BoardSnapshot } from "./monitor-v2.js";
@@ -388,6 +391,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/decision-records",
           "/monitor/agents",
           "/monitor/collaboration",
+          "/monitor/review-requests",
           "/monitor/tester/capabilities",
           "/monitor/testbed-missions",
           "/monitor/manifest.webmanifest",
@@ -737,6 +741,37 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     });
     return;
   }
+  if (request.method === "GET" && url.pathname === "/monitor/review-requests") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const limit = parseOptionalInteger(url.searchParams.get("limit"));
+    const status = parseReviewRequestStatus(url.searchParams.get("status"));
+    writeJson(response, 200, {
+      reviewRequests: listReviewRequests({
+        ...(limit !== undefined ? { limit } : {}),
+        ...(status ? { status } : {}),
+      }),
+    });
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/monitor/review-requests") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorReviewRequest(request, response);
+    return;
+  }
   if (request.method === "POST" && url.pathname === "/monitor/collaboration") {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
@@ -785,6 +820,38 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     return;
   }
   writeJson(response, 404, { error: "not_found" });
+}
+
+async function handleMonitorReviewRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const reviewRequest = recordReviewRequest(payload);
+    logger.info(
+      {
+        id: reviewRequest.id,
+        requestedBy: reviewRequest.requestedBy,
+        reviewer: reviewRequest.reviewer,
+        status: reviewRequest.status,
+      },
+      "monitor_review_request_recorded"
+    );
+    writeJson(response, 200, { ok: true, reviewRequest });
+  } catch (error) {
+    if (error instanceof CollaborationValidationError) {
+      writeJson(response, 400, { error: error.code, message: error.message });
+      return;
+    }
+    logger.error({ err: error }, "monitor_review_request_failed");
+    writeJson(response, 500, {
+      error: "monitor_review_request_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 }
 
 async function runSocketModeForever() {
@@ -2147,6 +2214,7 @@ async function loadMonitorSnapshot(
     testbedMissionRunner: summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat()),
     llmUsageEvents,
     collaborationMessages: listCollaborationMessages({ limit: 200 }),
+    reviewRequests: listReviewRequests({ limit: 200 }),
     diagnostics,
   };
   if (!options.suppressNarration) {
@@ -2448,6 +2516,12 @@ function parseOptionalBoolean(value: string | null): boolean | undefined {
   const normalized = value.trim().toLowerCase();
   if (["1", "true", "yes", "on"].includes(normalized)) return true;
   if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function parseReviewRequestStatus(value: string | null): ReviewRequestStatus | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "requested" || normalized === "responded" || normalized === "cancelled") return normalized;
   return undefined;
 }
 

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -28,6 +28,7 @@ import { dirname } from "node:path";
  */
 
 const MAX_MESSAGES = 500;
+const MAX_REVIEW_REQUESTS = 300;
 const SOFT_TTL_MS = 24 * 60 * 60 * 1000;
 const HERMES_MEMORY_MAX_NOTES = 120;
 const HERMES_MEMORY_NOTE_MAX_CHARS = 320;
@@ -39,10 +40,17 @@ const KNOWN_TARGETS = new Set(["everyone", "claude", "codex", "hermes", "operato
 export type CollaborationAuthor = "claude" | "codex" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
 export type CollaborationTarget = "everyone" | "claude" | "codex" | "hermes" | "operator";
+export type ReviewRequester = "hermes" | "operator" | "codex" | "claude";
+export type ReviewRequestReviewer = "codex" | "claude" | "hermes" | "operator";
+export type ReviewRequestStatus = "requested" | "responded" | "cancelled";
 
 export interface CollaborationRelatedPr {
   repo: string;
   number: number;
+}
+
+export interface CollaborationRelatedMission {
+  id: string;
 }
 
 export interface CollaborationMessage {
@@ -54,6 +62,19 @@ export interface CollaborationMessage {
   addressedTo: CollaborationTarget;
   relatedPr?: CollaborationRelatedPr;
   relatedCorrelationId?: string;
+}
+
+export interface ReviewRequest {
+  id: string;
+  relatedPr?: CollaborationRelatedPr;
+  relatedMission?: CollaborationRelatedMission;
+  correlationId?: string;
+  requestedBy: ReviewRequester;
+  reviewer: ReviewRequestReviewer;
+  reason: string;
+  status: ReviewRequestStatus;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface HermesMemoryNote {
@@ -76,9 +97,25 @@ export interface RecordCollaborationInput {
   relatedCorrelationId?: unknown;
 }
 
+export interface RecordReviewRequestInput {
+  relatedPr?: unknown;
+  relatedMission?: unknown;
+  correlationId?: unknown;
+  relatedCorrelationId?: unknown;
+  requestedBy?: unknown;
+  reviewer?: unknown;
+  reason?: unknown;
+  status?: unknown;
+}
+
 export interface ListCollaborationOptions {
   sinceMs?: number;
   limit?: number;
+}
+
+export interface ListReviewRequestsOptions {
+  limit?: number;
+  status?: ReviewRequestStatus;
 }
 
 export interface ListHermesMemoryOptions {
@@ -102,8 +139,10 @@ export class CollaborationValidationError extends Error {
 }
 
 const store: CollaborationMessage[] = [];
+const reviewRequests: ReviewRequest[] = [];
 const hermesMemoryNotes: HermesMemoryNote[] = [];
 let idSeq = 0;
+let reviewRequestSeq = 0;
 let memorySeq = 0;
 let memoryLoaded = false;
 
@@ -168,6 +207,79 @@ export function listCollaborationMessages(
   return filtered.slice(-limit);
 }
 
+export function recordReviewRequest(
+  input: RecordReviewRequestInput,
+  nowMs: number = Date.now()
+): ReviewRequest {
+  const requestedBy = normalizeRequester(input.requestedBy);
+  if (!requestedBy) {
+    throw new CollaborationValidationError(
+      "invalid_requested_by",
+      "requestedBy must be one of: hermes, operator, codex, claude."
+    );
+  }
+
+  const reviewer = normalizeReviewer(input.reviewer);
+  if (!reviewer) {
+    throw new CollaborationValidationError(
+      "invalid_reviewer",
+      "reviewer must be one of: codex, claude, hermes, operator."
+    );
+  }
+
+  const reason = normalizeText(input.reason);
+  if (!reason) {
+    throw new CollaborationValidationError(
+      "invalid_reason",
+      "reason is required and must be a non-empty string (max 4000 chars)."
+    );
+  }
+
+  const relatedPr = normalizeRelatedPr(input.relatedPr);
+  const relatedMission = normalizeRelatedMission(input.relatedMission);
+  const correlationId = normalizeCorrelationId(input.correlationId) ?? normalizeCorrelationId(input.relatedCorrelationId);
+  if (!relatedPr && !relatedMission && !correlationId) {
+    throw new CollaborationValidationError(
+      "missing_review_scope",
+      "review request must include relatedPr, relatedMission, or correlationId."
+    );
+  }
+
+  const status = normalizeReviewStatus(input.status);
+  if (status === null && hasExplicitTarget(input.status)) {
+    throw new CollaborationValidationError(
+      "invalid_review_status",
+      "status must be one of: requested, responded, cancelled."
+    );
+  }
+  const at = new Date(nowMs).toISOString();
+  const request: ReviewRequest = {
+    id: nextReviewRequestId(nowMs),
+    ...(relatedPr ? { relatedPr } : {}),
+    ...(relatedMission ? { relatedMission } : {}),
+    ...(correlationId ? { correlationId } : {}),
+    requestedBy,
+    reviewer,
+    reason,
+    status: status ?? "requested",
+    createdAt: at,
+    updatedAt: at,
+  };
+
+  reviewRequests.push(request);
+  while (reviewRequests.length > MAX_REVIEW_REQUESTS) reviewRequests.shift();
+  recordReviewRequestCollaborationTurn(request, nowMs);
+  return request;
+}
+
+export function listReviewRequests(options: ListReviewRequestsOptions = {}): ReviewRequest[] {
+  const limit = clampLimit(options.limit, MAX_REVIEW_REQUESTS);
+  const filtered = options.status
+    ? reviewRequests.filter((request) => request.status === options.status)
+    : reviewRequests;
+  return filtered.slice(-limit);
+}
+
 export function listHermesMemoryNotes(options: ListHermesMemoryOptions = {}): HermesMemoryNote[] {
   loadHermesMemoryIfNeeded();
   const limit = clampLimit(options.limit, HERMES_MEMORY_MAX_NOTES);
@@ -211,8 +323,10 @@ export function classifyHermesMemoryRequest(message: Pick<CollaborationMessage, 
 
 export function __resetCollaborationStoreForTests(): void {
   store.length = 0;
+  reviewRequests.length = 0;
   hermesMemoryNotes.length = 0;
   idSeq = 0;
+  reviewRequestSeq = 0;
   memorySeq = 0;
   memoryLoaded = false;
 }
@@ -243,6 +357,26 @@ function hasExplicitTarget(value: unknown): boolean {
   return true;
 }
 
+function normalizeRequester(value: unknown): ReviewRequester | null {
+  const author = normalizeAuthor(value);
+  if (author === "system" || !author) return null;
+  return author;
+}
+
+function normalizeReviewer(value: unknown): ReviewRequestReviewer | null {
+  const target = normalizeTarget(value);
+  if (target === "everyone" || !target) return null;
+  return target;
+}
+
+function normalizeReviewStatus(value: unknown): ReviewRequestStatus | null {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") return null;
+  const v = value.trim().toLowerCase();
+  if (v === "requested" || v === "responded" || v === "cancelled") return v;
+  return null;
+}
+
 function normalizeText(value: unknown): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
@@ -257,6 +391,13 @@ function normalizeRelatedPr(value: unknown): CollaborationRelatedPr | undefined 
   const number = typeof obj.number === "number" && Number.isInteger(obj.number) ? obj.number : NaN;
   if (!repo || !Number.isFinite(number) || number < 1) return undefined;
   return { repo, number };
+}
+
+function normalizeRelatedMission(value: unknown): CollaborationRelatedMission | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const obj = value as Record<string, unknown>;
+  const id = typeof obj.id === "string" ? obj.id.trim().slice(0, 256) : "";
+  return id ? { id } : undefined;
 }
 
 function normalizeCorrelationId(value: unknown): string | undefined {
@@ -277,9 +418,41 @@ function nextId(nowMs: number): string {
   return `collab-${nowMs.toString(36)}-${idSeq.toString(36)}`;
 }
 
+function nextReviewRequestId(nowMs: number): string {
+  reviewRequestSeq = (reviewRequestSeq + 1) % 1_000_000;
+  return `review-${nowMs.toString(36)}-${reviewRequestSeq.toString(36)}`;
+}
+
 function nextMemoryId(nowMs: number): string {
   memorySeq = (memorySeq + 1) % 1_000_000;
   return `hermes-memory-${nowMs.toString(36)}-${memorySeq.toString(36)}`;
+}
+
+function recordReviewRequestCollaborationTurn(request: ReviewRequest, nowMs: number): void {
+  const scope = reviewRequestScopeLabel(request);
+  const reviewer = actorDisplayName(request.reviewer);
+  const relatedCorrelationId = request.correlationId ?? request.relatedMission?.id;
+  recordCollaborationMessage({
+    author: request.requestedBy,
+    kind: "request_help",
+    addressedTo: request.reviewer,
+    text: `Review requested from ${reviewer}${scope ? ` on ${scope}` : ""}: ${request.reason}`,
+    ...(request.relatedPr ? { relatedPr: request.relatedPr } : {}),
+    ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
+  }, nowMs);
+}
+
+function reviewRequestScopeLabel(request: ReviewRequest): string {
+  if (request.relatedPr) return `${request.relatedPr.repo}#${request.relatedPr.number}`;
+  if (request.relatedMission) return `mission ${request.relatedMission.id}`;
+  return request.correlationId ?? "";
+}
+
+function actorDisplayName(actor: ReviewRequester | ReviewRequestReviewer): string {
+  if (actor === "hermes") return "Hermes";
+  if (actor === "operator") return "Pascal";
+  if (actor === "claude") return "Claude";
+  return "Codex";
 }
 
 function learnHermesMemoryFromMessage(message: CollaborationMessage): void {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -109,6 +109,16 @@ export interface CardRiskSignal {
   message: string;
 }
 
+export interface CardReviewRequest {
+  id: string;
+  requestedBy: "hermes" | "operator" | "codex" | "claude";
+  reviewer: "codex" | "claude" | "hermes" | "operator";
+  reason: string;
+  status: "requested" | "responded" | "cancelled";
+  createdAt: string;
+  updatedAt: string;
+}
+
 // ── Mission report (testbed browser missions) ───────────────────────
 // Mirrors the UI MissionReport. The optional numeric fields (runs,
 // latency, the 0–10 scores) are NOT carried by the agent's structured
@@ -165,6 +175,8 @@ export interface BoardCard {
   archiveHint?: boolean;
   /** Free-form "next action" copy carried from the classifier. */
   next?: string;
+  /** Stable correlation id for non-PR cards (mission/task/deploy), when present. */
+  correlationId?: string;
   /** Hermes verdict / reasoning carried from the classifier. */
   verdict?: string;
 
@@ -207,6 +219,8 @@ export interface BoardCard {
   mission?: CardMissionReport;
   /** D2: latest durable explanation associated with this card. */
   decisionRecord?: HermesDecisionRecord;
+  /** C1: active cross-agent review requests scoped to this card. */
+  reviewRequests?: CardReviewRequest[];
 }
 
 export interface BoardSnapshotV2 {
@@ -425,6 +439,7 @@ export function toBoardCard(item: HermesBoardCardSnapshot): BoardCard {
   if (item.next) card.next = item.next;
   if (item.verdict) card.verdict = item.verdict;
   if (item.headBranch) card.branch = item.headBranch;
+  if (item.correlationId) card.correlationId = item.correlationId;
 
   return card;
 }
@@ -640,6 +655,71 @@ export function indexTestbedMissions(rawSnapshot: unknown): Map<string, Record<s
     if (id && run && !map.has(id)) map.set(id, run);
   }
   return map;
+}
+
+function reviewRequestsFromSnapshot(rawSnapshot: unknown): CardReviewRequestWithScope[] {
+  const root = asRecord(rawSnapshot);
+  const requests: CardReviewRequestWithScope[] = [];
+  for (const entry of asArray(root?.reviewRequests)) {
+    const request = asRecord(entry);
+    if (!request) continue;
+    const id = asString(request.id);
+    const requestedBy = asReviewActor(request.requestedBy);
+    const reviewer = asReviewActor(request.reviewer);
+    const reason = asString(request.reason);
+    const status = asReviewStatus(request.status);
+    const createdAt = asString(request.createdAt);
+    const updatedAt = asString(request.updatedAt);
+    if (!id || !requestedBy || !reviewer || !reason || !status || !createdAt || !updatedAt) continue;
+    const relatedPr = asRecord(request.relatedPr);
+    const relatedMission = asRecord(request.relatedMission);
+    requests.push({
+      id,
+      requestedBy,
+      reviewer,
+      reason,
+      status,
+      createdAt,
+      updatedAt,
+      relatedPrKey: prKey(asString(relatedPr?.repo), asFiniteNumber(relatedPr?.number)),
+      relatedMissionId: asString(relatedMission?.id),
+      correlationId: asString(request.correlationId),
+    });
+  }
+  return requests;
+}
+
+interface CardReviewRequestWithScope extends CardReviewRequest {
+  relatedPrKey?: string;
+  relatedMissionId?: string;
+  correlationId?: string;
+}
+
+function asReviewActor(value: unknown): CardReviewRequest["requestedBy"] | undefined {
+  if (value === "hermes" || value === "operator" || value === "codex" || value === "claude") return value;
+  return undefined;
+}
+
+function asReviewStatus(value: unknown): CardReviewRequest["status"] | undefined {
+  if (value === "requested" || value === "responded" || value === "cancelled") return value;
+  return undefined;
+}
+
+function attachReviewRequests(
+  card: BoardCard,
+  requests: readonly CardReviewRequestWithScope[],
+  scope: { relatedPrKey?: string; relatedMissionId?: string; correlationId?: string }
+): BoardCard {
+  const active = requests
+    .filter((request) => request.status === "requested")
+    .filter((request) =>
+      (scope.relatedPrKey !== undefined && request.relatedPrKey === scope.relatedPrKey)
+      || (scope.relatedMissionId !== undefined && request.relatedMissionId === scope.relatedMissionId)
+      || (scope.correlationId !== undefined && request.correlationId === scope.correlationId)
+      || (request.correlationId !== undefined && request.correlationId === card.id)
+    )
+    .map(({ relatedPrKey, relatedMissionId, correlationId, ...request }) => request);
+  return active.length > 0 ? { ...card, reviewRequests: active } : card;
 }
 
 const EVIDENCE_KINDS = new Set(["screenshot", "trace", "console", "video"]);
@@ -898,6 +978,7 @@ export function synthesizeTaskCards(
       ...(riskTier ? { riskTier } : {}),
       ...(riskSignals.length > 0 ? { riskSignals } : {}),
       ...(prompt ? { prompt } : {}),
+      ...(asString(task.correlationId) ? { correlationId: asString(task.correlationId) } : {}),
       ...(decisionRecord ? { decisionRecord } : {}),
     };
     if (status === "running" && runner) {
@@ -1076,11 +1157,12 @@ export function buildV2BoardSnapshot(
   const summaryIndex = indexRawSummaries(rawSnapshot);
   const codexIndex = indexCodexTasks(rawSnapshot);
   const missionIndex = indexTestbedMissions(rawSnapshot);
+  const reviewRequests = reviewRequestsFromSnapshot(rawSnapshot);
   const runner = readRunner(rawSnapshot);
   const cards = items.map((item) => {
     const base = toBoardCard(item);
     const key = prKey(item.repo, item.number);
-    return enrichBoardCard(base, item, {
+    const enriched = enrichBoardCard(base, item, {
       summary: key ? summaryIndex.get(key) : undefined,
       codexTask: key ? codexIndex.get(key) : undefined,
       runner,
@@ -1089,11 +1171,20 @@ export function buildV2BoardSnapshot(
           ? missionIndex.get(item.correlationId)
           : undefined,
     });
+    return attachReviewRequests(enriched, reviewRequests, {
+      ...(key ? { relatedPrKey: key } : {}),
+      ...(base.type === "mission" && item.correlationId ? { relatedMissionId: item.correlationId } : {}),
+      ...(item.correlationId ? { correlationId: item.correlationId } : {}),
+    });
   });
   // Surface queued greenfield tasks the classifier can't (no PR ⇒ no event),
   // skipping any already represented (e.g. by a PR card).
   const existingIds = new Set(cards.map((c) => c.id));
-  const taskCards = synthesizeTaskCards(rawSnapshot, runner, { now: snapshotAt }).filter((c) => !existingIds.has(c.id));
+  const taskCards = synthesizeTaskCards(rawSnapshot, runner, { now: snapshotAt })
+    .filter((c) => !existingIds.has(c.id))
+    .map((card) => attachReviewRequests(card, reviewRequests, {
+      correlationId: card.correlationId ?? card.id,
+    }));
 
   return {
     cards: [...cards, ...taskCards],

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -9,10 +9,13 @@ import {
   classifyHermesMemoryRequest,
   listCollaborationMessages,
   listHermesMemoryNotes,
+  listReviewRequests,
   recordCollaborationMessage,
   recordHermesMemoryNote,
+  recordReviewRequest,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
+import { listCodexTasks } from "../../services/slack-operator/src/codex-task-queue.js";
 
 const NOW = Date.UTC(2026, 4, 18, 12, 0, 0);
 
@@ -183,6 +186,108 @@ describe("monitor collaboration channel", () => {
     // The first 100 should have been evicted.
     expect(listed[0].text).toBe("m100");
     expect(listed[499].text).toBe("m599");
+  });
+});
+
+describe("monitor review requests", () => {
+  beforeEach(() => {
+    __resetCollaborationStoreForTests();
+  });
+
+  it("creates a card-scoped cross-agent review request", () => {
+    const request = recordReviewRequest(
+      {
+        relatedPr: { repo: "depre-dev/averray-reference-agent", number: 298 },
+        requestedBy: "hermes",
+        reviewer: "claude",
+        reason: "Second-agent review before this O5 board-health slice moves forward.",
+      },
+      NOW
+    );
+
+    expect(request).toMatchObject({
+      requestedBy: "hermes",
+      reviewer: "claude",
+      status: "requested",
+      relatedPr: { repo: "depre-dev/averray-reference-agent", number: 298 },
+      reason: expect.stringContaining("Second-agent review"),
+      createdAt: "2026-05-18T12:00:00.000Z",
+      updatedAt: "2026-05-18T12:00:00.000Z",
+    });
+    expect(request.id).toMatch(/^review-/);
+  });
+
+  it("rejects invalid review authors and reviewers", () => {
+    expect(() =>
+      recordReviewRequest({
+        relatedPr: { repo: "depre-dev/averray-reference-agent", number: 298 },
+        requestedBy: "system",
+        reviewer: "claude",
+        reason: "system cannot request this advisory review",
+      }, NOW)
+    ).toThrowError(CollaborationValidationError);
+
+    expect(() =>
+      recordReviewRequest({
+        relatedPr: { repo: "depre-dev/averray-reference-agent", number: 298 },
+        requestedBy: "hermes",
+        reviewer: "everyone",
+        reason: "reviewer must be a concrete actor",
+      }, NOW)
+    ).toThrowError(CollaborationValidationError);
+  });
+
+  it("lists requests with attribution and preserves collaboration context", () => {
+    recordCollaborationMessage(
+      { author: "operator", text: "Hermes, keep this card parked until review lands." },
+      NOW - 1
+    );
+    const request = recordReviewRequest(
+      {
+        correlationId: "agent-task-42",
+        requestedBy: "operator",
+        reviewer: "codex",
+        reason: "Please review Claude's plan before work proceeds.",
+      },
+      NOW
+    );
+
+    expect(listReviewRequests({ limit: 5 })).toEqual([request]);
+    expect(listReviewRequests({ status: "requested" })[0]).toMatchObject({
+      requestedBy: "operator",
+      reviewer: "codex",
+      correlationId: "agent-task-42",
+    });
+    expect(listCollaborationMessages({ limit: 5 }, NOW + 1).map((message) => message.text)).toEqual([
+      "Hermes, keep this card parked until review lands.",
+      expect.stringContaining("Review requested from Codex"),
+    ]);
+  });
+
+  it("requires a card scope and never creates a task as a side effect", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "review-request-task-queue-"));
+    const queuePath = join(dir, "tasks.json");
+    try {
+      await expect(listCodexTasks({ path: queuePath })).resolves.toEqual([]);
+      expect(() =>
+        recordReviewRequest({
+          requestedBy: "hermes",
+          reviewer: "claude",
+          reason: "missing relatedPr, relatedMission, or correlationId",
+        }, NOW)
+      ).toThrowError(CollaborationValidationError);
+
+      recordReviewRequest({
+        relatedMission: { id: "mission-browser-123" },
+        requestedBy: "hermes",
+        reviewer: "claude",
+        reason: "Review the mission evidence before follow-up work.",
+      }, NOW);
+
+      await expect(listCodexTasks({ path: queuePath })).resolves.toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/unit/monitor-spa.test.ts
+++ b/test/unit/monitor-spa.test.ts
@@ -45,6 +45,7 @@ describe("resolveSpaRequest", () => {
     expect(resolveSpaRequest("/monitor/events").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/codex-tasks").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/collaboration").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/review-requests").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/testbed-missions").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/legacy").kind).toBe("miss");
     // The old preview path is a miss here (index.ts 302s it to /monitor/).

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -652,6 +652,60 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     expect(card?.files).toEqual([{ path: "ops/deploy.staging.yml", diff: "", critical: false }]);
   });
 
+  it("attaches active cross-agent review requests to matching cards", () => {
+    const raw = {
+      active: [
+        {
+          title: "Allow operator override of agent claim-stake floor",
+          status: "needs_review",
+          intent: "operator_review",
+          ageLabel: "4m",
+          summary: {
+            pullRequest: { repo: "depre-dev/agent", number: 548, state: "open" },
+            currentPullRequest: { repo: "depre-dev/agent", number: 548, state: "open" },
+          },
+        },
+      ],
+      recent: [],
+      reviewRequests: [
+        {
+          id: "review-1",
+          relatedPr: { repo: "depre-dev/agent", number: 548 },
+          requestedBy: "hermes",
+          reviewer: "claude",
+          reason: "Second-agent review before this moves forward.",
+          status: "requested",
+          createdAt: "2026-05-31T12:00:00.000Z",
+          updatedAt: "2026-05-31T12:00:00.000Z",
+        },
+        {
+          id: "review-2",
+          relatedPr: { repo: "depre-dev/agent", number: 548 },
+          requestedBy: "hermes",
+          reviewer: "codex",
+          reason: "Old request already answered.",
+          status: "responded",
+          createdAt: "2026-05-31T11:00:00.000Z",
+          updatedAt: "2026-05-31T11:30:00.000Z",
+        },
+      ],
+    };
+
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const card = snap.cards.find((c) => c.id === "agent #548");
+    expect(card?.reviewRequests).toEqual([
+      {
+        id: "review-1",
+        requestedBy: "hermes",
+        reviewer: "claude",
+        reason: "Second-agent review before this moves forward.",
+        status: "requested",
+        createdAt: "2026-05-31T12:00:00.000Z",
+        updatedAt: "2026-05-31T12:00:00.000Z",
+      },
+    ]);
+  });
+
   it("enriches a mission card with the browser agent's structured report (by correlationId)", () => {
     // A classified mission item carries correlationId = run.id and no PR
     // number; the run with its report is bundled at snapshot.testbedMissions.


### PR DESCRIPTION
## Summary
- Adds card-scoped cross-agent review request records with requestedBy/reviewer/status/scope metadata.
- Wires read/write monitor endpoints at GET/POST /monitor/review-requests.
- Emits review requests into the existing collaboration thread and shows active requests as a small card indicator.
- Updates the C1 roadmap row and AGENTS working agreement to keep the advisory boundary clear.

## Authority boundary
review coordination only; no authority change.

This PR does not enqueue Codex/Claude, does not auto-run a reviewer, does not approve tasks, and does not change merge/deploy authority.

## Checks
- npm install (fresh worktree dependency setup)
- npm run build
- npx vitest run test/unit/monitor-collab.test.ts test/unit/monitor-v2.test.ts packages/monitor-ui/src/components/cards/Card.test.tsx test/unit/monitor-spa.test.ts
- npm run typecheck
- npm test
- git diff --check

## Affected surfaces
- slack-operator monitor endpoints/collaboration store
- monitor v2 board card payload
- monitor UI card rendering
- docs/tests only otherwise