### PR TITLE
Add read-only backlog suggestions

### DIFF
--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -36,7 +36,7 @@
 | D2 | Explainability / decision records | ✅ done (#296) — dispatch decision records and replay surface |
 | D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | ✅ done (#286) — anomaly auto-pause owns autopilot-suspended flag |
 | D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
-| B1 | Backlog generation (roadmap auto-flow; net-new escalates) | design done |
+| B1 | Backlog generation (roadmap auto-flow; net-new escalates) | 🟡 in review — first planner-only/read-only backlog suggestions slice |
 | B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
 | C1 | Cross-agent review (default) | design done |
 | C2 | Reviewer panel (high-risk) | design done |

--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -117,9 +117,16 @@ describe("MonitorPage — container", () => {
     // the global fetch — so spying on it isolates the spawn call.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
     try {
-      const { container } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} autonomy={{ fetchMode: async () => null }} />, {
-        wrapper,
-      });
+      const { container } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
       await waitFor(() =>
         expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy(),
       );

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -22,6 +22,7 @@
 
 import { useCallback, useMemo } from "react";
 import { useMonitorBoard, type UseMonitorBoardOptions } from "./hooks/useMonitorBoard.js";
+import { useBacklogSuggestions, type UseBacklogSuggestionsOptions } from "./hooks/useBacklogSuggestions.js";
 import { useCardParam } from "./hooks/useCardParam.js";
 import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
@@ -40,6 +41,8 @@ export type AlertMuteBody = { untilMs: number } | { muted: false };
 export interface MonitorPageProps {
   /** Override the live wiring (fetcher, EventSource, storage) for tests. */
   options?: UseMonitorBoardOptions;
+  /** Override the read-only backlog-suggestions endpoint wiring for tests. */
+  backlogSuggestions?: UseBacklogSuggestionsOptions;
   /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
   onSpawnMission?: (url: string) => void;
   /** Override the /claude propose (defaults to POST /monitor/codex-tasks). */
@@ -60,6 +63,7 @@ export interface MonitorPageProps {
 
 export function MonitorPage({
   options,
+  backlogSuggestions,
   onSpawnMission = defaultSpawnMission,
   onSpawnClaudeTask = defaultSpawnClaudeTask,
   onCreateTask = defaultCreateTask,
@@ -70,6 +74,7 @@ export function MonitorPage({
   autonomy,
 }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
+  const { data: backlogSuggestionsData } = useBacklogSuggestions(backlogSuggestions);
   const { cardId, setCard, clearCard } = useCardParam();
   const { mode: autonomyMode, setAutopilot, setSupervised } = useAutonomyMode(autonomy);
 
@@ -95,6 +100,7 @@ export function MonitorPage({
     <ErrorBoundary>
       <BoardView
         board={board}
+        backlogSuggestions={backlogSuggestionsData}
         status={status}
         onRefresh={refresh}
         focusedCardId={cardId}

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -116,6 +116,45 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getByText("not_recorded")).toBeTruthy();
   });
 
+  test("renders backlog suggestions as planner-only read-only prompts", () => {
+    const { getByRole, getByText } = render(
+      <BoardView
+        board={richBoard}
+        status="open"
+        backlogSuggestions={{
+          generatedAt: "2026-05-31T12:00:00.000Z",
+          safety: {
+            readOnly: true,
+            createsTasks: false,
+            approvesTasks: false,
+            mutatesGithub: false,
+            mutatesSlack: false,
+            mutatesTaskQueue: false,
+          },
+          source: { cardsRead: 1, source: "monitor_v2_board" },
+          suggestions: [
+            {
+              id: "failed-mission:mission-1",
+              title: "Follow up failed mission",
+              reason: "A browser mission failed and needs a narrow fix plan.",
+              suggestedOwner: "claude",
+              riskTier: "low",
+              related: { cardId: "mission-1" },
+              suggestedPrompt: "Investigate the failed mission.",
+              confidence: 0.82,
+              evidence: ["missionVerdict:FAILED"],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(getByRole("region", { name: "Suggested follow-ups" })).toBeTruthy();
+    expect(getByText("planner-only · read-only")).toBeTruthy();
+    expect(getByText("no tasks created")).toBeTruthy();
+    expect(getByText("Follow up failed mission")).toBeTruthy();
+    expect(getByRole("button", { name: "Copy prompt" })).toBeTruthy();
+  });
+
   test("Refresh button is wired to onRefresh", () => {
     const onRefresh = vi.fn();
     const { getByRole } = render(<BoardView board={richBoard} status="open" onRefresh={onRefresh} />);

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -20,6 +20,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
 import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache.js";
+import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
 import { CreateTaskForm } from "./CreateTaskForm.js";
@@ -82,6 +83,7 @@ function matchesQuery(card: BoardCard, q: string): boolean {
 
 export interface BoardViewProps {
   board: MonitorBoard | undefined;
+  backlogSuggestions?: BacklogSuggestionsResponse;
   status: StreamStatus;
   onRefresh?: () => void;
   /** Focused card id (drives the detail drawer); null/undefined = closed. */
@@ -113,6 +115,7 @@ export interface BoardViewProps {
 
 export function BoardView({
   board,
+  backlogSuggestions,
   status,
   onRefresh,
   focusedCardId,
@@ -279,6 +282,7 @@ export function BoardView({
             searchInputRef={searchInputRef}
           />
           <LlmUsagePanel usage={board?.llmUsage} />
+          <BacklogSuggestionsPanel response={backlogSuggestions} />
           <Board
             grouped={displayGrouped}
             expanded={expanded}
@@ -368,6 +372,50 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
         )}
       </div>
     </section>
+  );
+}
+
+function BacklogSuggestionsPanel({ response }: { response?: BacklogSuggestionsResponse }) {
+  const suggestions = response?.suggestions?.slice(0, 3) ?? [];
+  if (suggestions.length === 0) return null;
+  return (
+    <section className="hm-backlog-suggestions" aria-label="Suggested follow-ups">
+      <div className="hm-backlog-suggestions-head">
+        <div>
+          <span className="hm-kicker">Suggested follow-ups</span>
+          <strong>planner-only · read-only</strong>
+        </div>
+        <span className="hm-backlog-suggestions-safety">no tasks created</span>
+      </div>
+      <div className="hm-backlog-suggestions-grid">
+        {suggestions.map((suggestion) => (
+          <BacklogSuggestionRow suggestion={suggestion} key={suggestion.id} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BacklogSuggestionRow({ suggestion }: { suggestion: BacklogSuggestion }) {
+  const copyPrompt = () => {
+    if (!suggestion.suggestedPrompt || typeof navigator === "undefined") return;
+    void navigator.clipboard?.writeText(suggestion.suggestedPrompt);
+  };
+  return (
+    <div className="hm-backlog-suggestion-row">
+      <span>
+        <strong>{suggestion.title}</strong>
+        <small>{suggestion.reason}</small>
+      </span>
+      <span className="hm-backlog-suggestion-meta">
+        {suggestion.suggestedOwner} · {suggestion.riskTier} · {Math.round(suggestion.confidence * 100)}%
+      </span>
+      {suggestion.suggestedPrompt ? (
+        <button type="button" className="hm-backlog-copy" onClick={copyPrompt}>
+          Copy prompt
+        </button>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/monitor-ui/src/hooks/useBacklogSuggestions.ts
+++ b/packages/monitor-ui/src/hooks/useBacklogSuggestions.ts
@@ -1,0 +1,36 @@
+import useSWR from "swr";
+import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
+
+const DEFAULT_BACKLOG_SUGGESTIONS_URL = "/monitor/backlog-suggestions";
+
+export interface UseBacklogSuggestionsOptions {
+  url?: string;
+  fetcher?: (url: string) => Promise<BacklogSuggestionsResponse>;
+  enabled?: boolean;
+}
+
+export interface BacklogSuggestionsState {
+  data: BacklogSuggestionsResponse | undefined;
+  error: unknown;
+  isLoading: boolean;
+}
+
+async function defaultFetcher(url: string): Promise<BacklogSuggestionsResponse> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`backlog suggestions fetch failed: ${res.status}`);
+  return (await res.json()) as BacklogSuggestionsResponse;
+}
+
+export function useBacklogSuggestions(options: UseBacklogSuggestionsOptions = {}): BacklogSuggestionsState {
+  const url = options.url ?? DEFAULT_BACKLOG_SUGGESTIONS_URL;
+  const fetcher = options.fetcher ?? defaultFetcher;
+  const { data, error, isLoading } = useSWR<BacklogSuggestionsResponse>(
+    options.enabled === false ? null : url,
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  );
+  return { data, error, isLoading };
+}

--- a/packages/monitor-ui/src/lib/monitor/backlog-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/backlog-suggestions.ts
@@ -1,0 +1,40 @@
+export type BacklogSuggestionOwner = "codex" | "claude" | "operator" | "hermes";
+export type BacklogSuggestionRiskTier = "low" | "high";
+
+export interface BacklogSuggestionRelated {
+  cardId: string;
+  repo?: string;
+  pullRequestNumber?: number;
+  correlationId?: string;
+  missionTarget?: string;
+  missionVerdict?: string;
+}
+
+export interface BacklogSuggestion {
+  id: string;
+  title: string;
+  reason: string;
+  suggestedOwner: BacklogSuggestionOwner;
+  riskTier: BacklogSuggestionRiskTier;
+  related: BacklogSuggestionRelated;
+  suggestedPrompt?: string;
+  confidence: number;
+  evidence: string[];
+}
+
+export interface BacklogSuggestionsResponse {
+  generatedAt: string;
+  suggestions: BacklogSuggestion[];
+  safety: {
+    readOnly: true;
+    createsTasks: false;
+    approvesTasks: false;
+    mutatesGithub: false;
+    mutatesSlack: false;
+    mutatesTaskQueue: false;
+  };
+  source: {
+    cardsRead: number;
+    source: "monitor_v2_board";
+  };
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -420,6 +420,76 @@ body { margin: 0; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.hm-backlog-suggestions {
+  margin: 0 22px 10px;
+  padding: 10px 12px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  display: grid;
+  gap: 9px;
+}
+.hm-backlog-suggestions-head,
+.hm-backlog-suggestion-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hm-backlog-suggestions-head strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--hm-ink);
+}
+.hm-backlog-suggestions-safety,
+.hm-backlog-suggestion-row,
+.hm-backlog-suggestion-row small {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-backlog-suggestions-grid {
+  display: grid;
+  gap: 6px;
+}
+.hm-backlog-suggestion-row {
+  padding-top: 6px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-backlog-suggestion-row span:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+.hm-backlog-suggestion-row strong {
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--hm-ink);
+}
+.hm-backlog-suggestion-row small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-backlog-suggestion-meta {
+  white-space: nowrap;
+}
+.hm-backlog-copy {
+  flex: 0 0 auto;
+  border: 1px solid var(--hm-line);
+  border-radius: 7px;
+  background: var(--hm-paper-2);
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 700;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+.hm-backlog-copy:hover {
+  border-color: var(--hm-sage);
+}
 .hm-filter-chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 6px 10px;

--- a/services/slack-operator/src/backlog-suggestions.ts
+++ b/services/slack-operator/src/backlog-suggestions.ts
@@ -1,0 +1,242 @@
+import type { BoardCard, RiskTag } from "./monitor-v2.js";
+
+export type BacklogSuggestionOwner = "codex" | "claude" | "operator" | "hermes";
+export type BacklogSuggestionRiskTier = "low" | "high";
+
+export interface BacklogSuggestionRelated {
+  cardId: string;
+  repo?: string;
+  pullRequestNumber?: number;
+  correlationId?: string;
+  missionTarget?: string;
+  missionVerdict?: string;
+}
+
+export interface BacklogSuggestion {
+  id: string;
+  title: string;
+  reason: string;
+  suggestedOwner: BacklogSuggestionOwner;
+  riskTier: BacklogSuggestionRiskTier;
+  related: BacklogSuggestionRelated;
+  suggestedPrompt?: string;
+  confidence: number;
+  evidence: string[];
+}
+
+export interface BacklogSuggestionsSafety {
+  readOnly: true;
+  createsTasks: false;
+  approvesTasks: false;
+  mutatesGithub: false;
+  mutatesSlack: false;
+  mutatesTaskQueue: false;
+}
+
+export interface BacklogSuggestionsResponse {
+  generatedAt: string;
+  suggestions: BacklogSuggestion[];
+  safety: BacklogSuggestionsSafety;
+  source: {
+    cardsRead: number;
+    source: "monitor_v2_board";
+  };
+}
+
+const HIGH_RISK_TAGS = new Set<RiskTag>(["contracts", "secrets", "indexer", "xcm", "config"]);
+
+export function buildBacklogSuggestionsResponse(
+  cards: readonly BoardCard[],
+  options: { now?: Date; limit?: number } = {},
+): BacklogSuggestionsResponse {
+  const suggestions = suggestBacklogFromCards(cards, { limit: options.limit });
+  return {
+    generatedAt: (options.now ?? new Date()).toISOString(),
+    suggestions,
+    safety: {
+      readOnly: true,
+      createsTasks: false,
+      approvesTasks: false,
+      mutatesGithub: false,
+      mutatesSlack: false,
+      mutatesTaskQueue: false,
+    },
+    source: {
+      cardsRead: cards.length,
+      source: "monitor_v2_board",
+    },
+  };
+}
+
+export function suggestBacklogFromCards(
+  cards: readonly BoardCard[],
+  options: { limit?: number } = {},
+): BacklogSuggestion[] {
+  const limit = Math.max(1, Math.min(options.limit ?? 5, 10));
+  const suggestions: BacklogSuggestion[] = [];
+
+  for (const card of cards) {
+    if (card.type === "done") continue;
+    const suggestion =
+      highRiskReviewSuggestion(card) ??
+      failedMissionSuggestion(card) ??
+      staleDraftSuggestion(card) ??
+      failedTaskSuggestion(card);
+    if (suggestion) suggestions.push(suggestion);
+  }
+
+  return suggestions
+    .sort((a, b) => scoreSuggestion(b) - scoreSuggestion(a))
+    .slice(0, limit);
+}
+
+function highRiskReviewSuggestion(card: BoardCard): BacklogSuggestion | undefined {
+  if (!isHighRiskCard(card)) return undefined;
+  return {
+    id: suggestionId("operator-review", card),
+    title: `Review high-risk follow-up for ${card.title}`,
+    reason: "The card touches a high-risk surface, so backlog planning should escalate to the operator before any agent work is proposed.",
+    suggestedOwner: "operator",
+    riskTier: "high",
+    related: relatedFor(card),
+    confidence: 0.9,
+    evidence: compact([
+      `card:${card.id}`,
+      `risk:${card.risk.join(",") || "high"}`,
+      card.riskTier ? `riskTier:${card.riskTier}` : undefined,
+      highSeveritySignal(card),
+      criticalFileEvidence(card),
+    ]),
+  };
+}
+
+function failedMissionSuggestion(card: BoardCard): BacklogSuggestion | undefined {
+  if (card.type !== "mission") return undefined;
+  const mission = card.mission;
+  if (!mission) return undefined;
+  const verdict = card.mission?.verdict;
+  if (verdict !== "FAILED" && verdict !== "PARTIAL") return undefined;
+  const blocker = mission.blockers[0];
+  const recommendation = mission.recommendations[0];
+  const target = mission.target;
+  const prompt = [
+    `Investigate and propose a product fix for the failed testbed mission "${card.title}".`,
+    target ? `Target: ${target}.` : undefined,
+    blocker ? `Top blocker: ${blocker.head} — ${blocker.body}` : undefined,
+    recommendation ? `Recommendation from mission: ${recommendation}` : undefined,
+    "Keep the work narrow, preserve the product truth boundary, and open a PR for operator review.",
+  ].filter(Boolean).join("\n");
+
+  return {
+    id: suggestionId("failed-mission", card),
+    title: `Follow up failed mission: ${card.title}`,
+    reason: `The latest testbed mission verdict is ${verdict}; a human-readable fix or rerun plan would keep the evidence loop moving.`,
+    suggestedOwner: "claude",
+    riskTier: "low",
+    related: relatedFor(card),
+    suggestedPrompt: prompt,
+    confidence: verdict === "FAILED" ? 0.86 : 0.76,
+    evidence: compact([
+      `card:${card.id}`,
+      `missionVerdict:${verdict}`,
+      target ? `target:${target}` : undefined,
+      blocker ? `blocker:${blocker.head}` : undefined,
+    ]),
+  };
+}
+
+function staleDraftSuggestion(card: BoardCard): BacklogSuggestion | undefined {
+  if (card.type !== "draft" && !card.isDraft) return undefined;
+  if (card.state !== "stale" && !card.archiveHint && card.freshness < 24 * 60) return undefined;
+  return {
+    id: suggestionId("stale-draft", card),
+    title: `Decide stale draft next step: ${card.title}`,
+    reason: "This draft is stale. The safe next step is to ask the PR author for status or explicitly approve a takeover; Hermes should not auto-create agent work.",
+    suggestedOwner: "operator",
+    riskTier: isHighRiskCard(card) ? "high" : "low",
+    related: relatedFor(card),
+    confidence: 0.72,
+    evidence: compact([
+      `card:${card.id}`,
+      `freshnessMinutes:${card.freshness}`,
+      card.archiveHint ? "archiveHint:true" : undefined,
+      `waitingOn:${card.waitingOn.actor}`,
+    ]),
+  };
+}
+
+function failedTaskSuggestion(card: BoardCard): BacklogSuggestion | undefined {
+  if (card.type !== "task" || card.taskStatus !== "failed") return undefined;
+  const owner = card.agentType === "claude" ? "claude" : "codex";
+  return {
+    id: suggestionId("failed-task", card),
+    title: `Plan retry for failed task: ${card.title}`,
+    reason: "A dispatched task failed. Suggest a narrow retry plan, but leave task creation and approval to the operator.",
+    suggestedOwner: owner,
+    riskTier: card.riskTier === "high" ? "high" : "low",
+    related: relatedFor(card),
+    suggestedPrompt: [
+      `Investigate the failed task "${card.title}" and propose the smallest safe fix.`,
+      card.failureReason ? `Failure reason: ${card.failureReason}` : undefined,
+      card.output ? `Recent output: ${card.output.slice(0, 800)}` : undefined,
+      "Do not merge or deploy; open a PR for operator review if code changes are needed.",
+    ].filter(Boolean).join("\n"),
+    confidence: 0.78,
+    evidence: compact([
+      `card:${card.id}`,
+      `taskStatus:${card.taskStatus}`,
+      card.failureReason ? `failure:${card.failureReason}` : undefined,
+    ]),
+  };
+}
+
+function scoreSuggestion(suggestion: BacklogSuggestion): number {
+  const riskBoost = suggestion.riskTier === "high" ? 0.2 : 0;
+  const ownerBoost = suggestion.suggestedOwner === "operator" ? 0.1 : 0;
+  return suggestion.confidence + riskBoost + ownerBoost;
+}
+
+function isHighRiskCard(card: BoardCard): boolean {
+  return card.riskTier === "high"
+    || card.risk.some((risk) => HIGH_RISK_TAGS.has(risk))
+    || (card.files ?? []).some((file) => file.critical)
+    || (card.riskSignals ?? []).some((signal) => signal.severity === "high");
+}
+
+function relatedFor(card: BoardCard): BacklogSuggestionRelated {
+  return {
+    cardId: card.id,
+    ...(card.repo ? { repo: card.repo } : {}),
+    ...(pullRequestNumberFor(card) ? { pullRequestNumber: pullRequestNumberFor(card) } : {}),
+    ...(card.decisionRecord?.id ? { correlationId: card.decisionRecord.id } : {}),
+    ...(card.type === "mission" && card.mission?.target ? { missionTarget: card.mission.target } : {}),
+    ...(card.type === "mission" && card.mission?.verdict ? { missionVerdict: card.mission.verdict } : {}),
+  };
+}
+
+function pullRequestNumberFor(card: BoardCard): number | undefined {
+  const subjectNumber = card.decisionRecord?.subject.pullRequestNumber;
+  if (typeof subjectNumber === "number" && Number.isInteger(subjectNumber) && subjectNumber > 0) return subjectNumber;
+  const match = card.id.match(/#(\d+)\b/);
+  if (!match) return undefined;
+  const parsed = Number(match[1]);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function suggestionId(prefix: string, card: BoardCard): string {
+  return `${prefix}:${card.id}`.toLowerCase().replace(/[^a-z0-9:#-]+/g, "-").slice(0, 96);
+}
+
+function highSeveritySignal(card: BoardCard): string | undefined {
+  const signal = (card.riskSignals ?? []).find((entry) => entry.severity === "high");
+  return signal ? `riskSignal:${signal.code}` : undefined;
+}
+
+function criticalFileEvidence(card: BoardCard): string | undefined {
+  const file = (card.files ?? []).find((entry) => entry.critical);
+  return file ? `criticalFile:${file.path}` : undefined;
+}
+
+function compact(values: Array<string | undefined>): string[] {
+  return values.filter((value): value is string => Boolean(value));
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -45,6 +45,7 @@ import {
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
 import { buildV2BoardSnapshot } from "./monitor-v2.js";
+import { buildBacklogSuggestionsResponse } from "./backlog-suggestions.js";
 import { listDecisionRecordsForMonitor } from "./decision-record-store.js";
 import {
   evaluateAlertBridge,
@@ -385,6 +386,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/command",
           "/monitor/recheck",
           "/monitor/codex-tasks",
+          "/monitor/backlog-suggestions",
           "/monitor/decision-records",
           "/monitor/agents",
           "/monitor/collaboration",
@@ -570,6 +572,20 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         limit: parseOptionalInteger(url.searchParams.get("limit")),
       }),
     );
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/backlog-suggestions") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
+    const board = mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }));
+    writeJson(response, 200, buildBacklogSuggestionsResponse(board.cards));
     return;
   }
   if (request.method === "GET" && url.pathname === "/monitor/agents") {

--- a/test/unit/backlog-suggestions.test.ts
+++ b/test/unit/backlog-suggestions.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBacklogSuggestionsResponse,
+  suggestBacklogFromCards,
+} from "../../services/slack-operator/src/backlog-suggestions.js";
+import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
+
+function card(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "agent #123",
+    lane: "hermes-checking",
+    type: "pr",
+    agentType: "claude",
+    title: "Polish onboarding layout",
+    summary: "All checks passing",
+    repo: "depre-dev/agent",
+    freshness: 8,
+    state: "fresh",
+    risk: ["ui-only"],
+    waitingOn: { actor: "agent", tone: "info" },
+    ...overrides,
+  } as BoardCard;
+}
+
+describe("backlog suggestions", () => {
+  it("returns no suggestions for an empty or healthy board", () => {
+    expect(suggestBacklogFromCards([])).toEqual([]);
+    expect(suggestBacklogFromCards([
+      card(),
+      card({ id: "agent #124", type: "done", lane: "done" }),
+    ])).toEqual([]);
+  });
+
+  it("turns a failed mission into a product-fix prompt without mutating", () => {
+    const suggestions = suggestBacklogFromCards([
+      card({
+        id: "mission onboarding-001",
+        type: "mission",
+        agentType: "hermes",
+        title: "Fresh-agent onboarding mission",
+        risk: ["testbed"],
+        mission: {
+          verdict: "FAILED",
+          verdictTone: "fail",
+          confidence: 0.88,
+          target: "https://app.averray.com/onboarding",
+          seed: "fresh",
+          path: [],
+          blockers: [{ head: "Wallet copy unclear", body: "The page did not explain the required signer." }],
+          evidence: [],
+          mutationBoundary: "Read-only mission",
+          recommendations: ["Clarify the signer step."],
+        },
+      }),
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      suggestedOwner: "claude",
+      riskTier: "low",
+      related: {
+        cardId: "mission onboarding-001",
+        missionTarget: "https://app.averray.com/onboarding",
+        missionVerdict: "FAILED",
+      },
+    });
+    expect(suggestions[0]?.suggestedPrompt).toContain("Investigate and propose a product fix");
+    expect(suggestions[0]?.evidence).toContain("missionVerdict:FAILED");
+  });
+
+  it("keeps stale drafts with the operator instead of auto-routing Codex", () => {
+    const suggestions = suggestBacklogFromCards([
+      card({
+        id: "agent #777",
+        type: "draft",
+        lane: "drafts",
+        title: "Draft governance policy cleanup",
+        isDraft: true,
+        freshness: 60 * 30,
+        state: "stale",
+        waitingOn: { actor: "author", tone: "neutral" },
+      }),
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      suggestedOwner: "operator",
+      riskTier: "low",
+    });
+    expect(suggestions[0]?.suggestedPrompt).toBeUndefined();
+    expect(suggestions[0]?.reason).toContain("explicitly approve a takeover");
+  });
+
+  it("escalates high-risk cards to operator review, not an agent", () => {
+    const suggestions = suggestBacklogFromCards([
+      card({
+        id: "agent #900",
+        risk: ["contracts"],
+        files: [{ path: "contracts/EscrowCore.sol", diff: "+8 -2", critical: true }],
+      }),
+    ]);
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]).toMatchObject({
+      suggestedOwner: "operator",
+      riskTier: "high",
+    });
+    expect(suggestions[0]?.suggestedPrompt).toBeUndefined();
+    expect(suggestions[0]?.evidence).toContain("criticalFile:contracts/EscrowCore.sol");
+  });
+
+  it("returns read-only endpoint safety metadata", () => {
+    const response = buildBacklogSuggestionsResponse([], {
+      now: new Date("2026-05-31T12:00:00.000Z"),
+    });
+
+    expect(response).toEqual({
+      generatedAt: "2026-05-31T12:00:00.000Z",
+      suggestions: [],
+      safety: {
+        readOnly: true,
+        createsTasks: false,
+        approvesTasks: false,
+        mutatesGithub: false,
+        mutatesSlack: false,
+        mutatesTaskQueue: false,
+      },
+      source: {
+        cardsRead: 0,
+        source: "monitor_v2_board",
+      },
+    });
+  });
+});

--- a/test/unit/monitor-spa.test.ts
+++ b/test/unit/monitor-spa.test.ts
@@ -44,6 +44,7 @@ describe("resolveSpaRequest", () => {
     expect(resolveSpaRequest("/monitor/v2/stream").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/events").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/codex-tasks").kind).toBe("miss");
+    expect(resolveSpaRequest("/monitor/backlog-suggestions").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/collaboration").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/testbed-missions").kind).toBe("miss");
     expect(resolveSpaRequest("/monitor/legacy").kind).toBe("miss");


### PR DESCRIPTION
## Summary
- add a pure backlog suggestion planner from monitor board cards
- expose GET /monitor/backlog-suggestions with read-only safety metadata
- surface Suggested follow-ups in the monitor board with copy-prompt only, no task creation
- mark B1 first planner-only slice as in review

## Safety
- planner-only, read-only, no authority change
- does not create Codex or Claude tasks
- does not approve anything
- does not mutate GitHub, Slack, or the task queue

## Checks
- npm run typecheck
- npm test

## Impact
- slack-operator monitor API
- monitor UI
- docs/tests

## Env / rollout
- no env or VPS secret changes