### PR TITLE
feat: gate agent-requested tester missions

### DIFF
--- a/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
+++ b/docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md
@@ -1,6 +1,6 @@
 # Agent-Requested Tester Runs + the Operator Alert Bridge
 
-- **Status:** Reconciled 2026-05-31. D4 off-device alert bridge shipped earlier (#279) and D1 operator digest/reporting shipped in #294. T6 board-gated agent-requested tester runs and T7 capabilities/platform-helper work remain follow-up/design unless code evidence proves otherwise.
+- **Status:** Reconciled 2026-05-31. D4 off-device alert bridge shipped earlier (#279) and D1 operator digest/reporting shipped in #294. T6's first narrow slice is in flight here: agent requests land as board-gated `requested` missions and must be operator-approved before the runner can claim. T7 capabilities/platform-helper work remains follow-up/design unless code evidence proves otherwise.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_E2E_TESTER_DESIGN.md`](./HERMES_E2E_TESTER_DESIGN.md), [`HERMES_TESTER_AUTH_DESIGN.md`](./HERMES_TESTER_AUTH_DESIGN.md), [`HERMES_ROADMAP.md`](./HERMES_ROADMAP.md).
 - **Problem:** the code-building agents (the ones opening `app:` PRs in `averray-agent/agent`) can't currently start a tester run, don't know the tester's capabilities, and there's no way to reach the operator for approval when they're away from the Mac.
@@ -15,13 +15,13 @@
 
 **Flow (reuses the O3 `proposed → approve → run` gate, for missions):**
 1. The agent submits a **run request** (mission type + target route(s)/feature + a one-line "why").
-2. It lands on the board as a **proposed mission — needs approval** (a new pending state for agent-requested missions; operator-spawned + deploy-triggered missions stay auto).
+2. It lands on the board as a **requested mission — needs approval** (`status: "requested"`; operator-spawned + deploy-triggered missions still create `ready` missions).
 3. The **operator accepts it on the board** (the gate you asked for).
 4. The `testbed-mission-runner` runs it; the verdict + per-route findings + evidence come back as a mission card.
 
 **Scope/safety:** agent-requested runs are **read-only by default** — surface sweep (T1) or a **targeted read-only mission** against the changed route/feature. Mutating/gold-path missions stay **operator-initiated** (an agent can't request a mutation). Testnet/preview env only; under `HALT_FILE`.
 
-**Entry point (closes the interface gap):** the building agents work in `averray-agent/agent` and likely don't have the Averray MCP. So ship a thin **platform-repo helper** (e.g. `scripts/request-tester-run.sh` / an npm script) that POSTs the request to the canonical queue endpoint **`POST /monitor/testbed-missions`** (slack-operator `:8790`) and prints the board link — **not** the `averray_testbed_agent_mission` MCP tool, which only returns a prompt packet. The reference-agent adds the **proposed → approve gate** on top of that endpoint for agent-requested runs; the platform repo ships the helper so agents have it in-context.
+**Entry point (closes the interface gap):** the building agents work in `averray-agent/agent` and likely don't have the Averray MCP. The reference-agent now exposes the board-gated request endpoint **`POST /monitor/testbed-missions/request`** with `{ requesterAgent, targetUrl, goal, reason, mode: "fresh" | "memory" }`. It records `requested` only; the runner ignores it until an operator clicks approve, which calls **`POST /monitor/testbed-missions/{id}/approve`** and moves the mission to `ready`. The platform repo helper (T7 follow-up) should POST to this request endpoint and print the board link.
 
 ## 2. Tester capabilities manifest — always known
 
@@ -54,7 +54,7 @@ Today the board only has **browser** notifications (#232: tab badge, desktop not
 ## Build sequence
 
 1. **Alert bridge (Slack)** — highest leverage: unblocks "step away," and it's the O4 prerequisite. *(Shipped as D4 in #279; D1 operator reporting shipped in #294.)*
-2. **Agent-requested run endpoint + the proposed-mission approval gate** on the board. *(reference-agent)*
+2. **Agent-requested run endpoint + the requested-mission approval gate** on the board. *(reference-agent first slice in flight: request creates `requested`, approve moves to `ready`, runner claims only `ready`.)*
 3. **Capabilities manifest** + the **platform-repo helper** + the **platform `AGENTS.md`** pointer. *(manifest endpoint = reference-agent; helper + AGENTS.md = platform repo follow-up)*
 
 ## Roadmap fit
@@ -71,4 +71,4 @@ Today the board only has **browser** notifications (#232: tab badge, desktop not
 
 ---
 
-*End. Reconciled 2026-05-31: D4 and D1 are shipped; T6/T7 stay follow-up/design here.*
+*End. Reconciled 2026-05-31: D4 and D1 are shipped; T6 first slice is in flight here; T7 stays follow-up/design.*

--- a/docs/HERMES_E2E_TESTER_DESIGN.md
+++ b/docs/HERMES_E2E_TESTER_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes E2E Tester — Design (the product tester)
 
-- **Status:** Reconciled 2026-05-31. T2 pre-seeded session (#293), T3 SIWE role-gating (#290), and T5 env→mutation binding/enhancements (#297) have shipped. T4 Tier-2 agent, T6 agent-requested runs, and T7 capabilities/helper work remain follow-up/design unless code evidence proves otherwise.
+- **Status:** Reconciled 2026-05-31. T2 pre-seeded session (#293), T3 SIWE role-gating (#290), and T5 env→mutation binding/enhancements (#297) have shipped. T6's first board-gated request/approve slice is in flight here. T4 Tier-2 agent and T7 capabilities/helper work remain follow-up/design unless code evidence proves otherwise.
 - **Date:** 2026-05-29
 - **Lives in:** this repo (`depre-dev/averray-reference-agent`) — the testbed/mission code is here.
 - **Tests:** the platform product `averray-agent/agent` — the Polkadot Agent Platform ("Averray"): an agent-first job/treasury runtime on Polkadot Hub TestNet.
@@ -119,4 +119,4 @@ Each mission's verdict is LLM-judged (Tier 2) or rule-checked (Tier 1); both rec
 
 ---
 
-*End of E2E tester design. Reconciled 2026-05-31: T2, T3, and T5 have shipped; T4/T6/T7 remain follow-up/design.*
+*End of E2E tester design. Reconciled 2026-05-31: T2, T3, and T5 have shipped; T6 first slice is in flight; T4/T7 remain follow-up/design.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -47,18 +47,18 @@
 | T3 | Signer sidecar + SIWE mission (multi-role) | ✅ done — signer sidecar foundation (#283) + SIWE role-gating mission (#290) |
 | T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
 | T5 | Env→mutation binding + enhancements (trace/video, baselines) | ✅ done (#297) — env-bound mutation profile + Playwright trace/video + baseline comparison slice |
-| T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | design done (#274) |
+| T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | in flight — first slice adds `requested` missions, `/monitor/testbed-missions/request`, `/approve`, board approve UI, and runner-ready gating (this PR) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | design/follow-up — do not mark shipped here without code evidence; platform helper remains follow-up |
 
-*(Status as of 2026-05-31 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget and the O5 first slice. **Design / follow-up:** remaining O5 hardening, B1–B2, C1–C3 and remaining C follow-ups, T4, T6, T7, plus any platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
+*(Status as of 2026-05-31 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget, the O5 first slice, and T6's first board-gated request/approve slice. **Design / follow-up:** remaining O5 hardening, B1–B2, C1–C3 and remaining C follow-ups, T4, T7, and platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 
 1. **The self-feeding loop:** **O1 → O2 → O3.** Once this exists you stop hand-writing prompts; work is enqueued from the board and you just approve. Highest-leverage effort.
    - **T1** runs in parallel with O1 (independent, both runner/board TS).
-2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6/T7** remain follow-up for agent-requested runs + capabilities.
+2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6** is receiving its first request/approve gate slice, while **T7** remains follow-up for platform helper/capability discovery.
 3. **Autonomy:** **O4** (enqueue + guardrail + autonomy mode) has shipped; supervised burn-in and monitoring decide when to rely on it more heavily.
-4. **Depth, anytime after:** **A1 → A2** shipped; **A3b** is in progress. Remaining depth is **B** (planner), **C1–C3** plus C follow-ups, **T4/T6/T7**, and **O5** hardening.
+4. **Depth, anytime after:** **A1 → A2** shipped; **A3b** is in progress. Remaining depth is **B** (planner), **C1–C3** plus C follow-ups, **T4/T7**, T6 follow-on helper polish, and **O5** hardening.
 
 **Dependencies to respect:** B2 needs D3 (loop fail-safe); A2 needs A1 (baselines); O4 is the authority change and needs D4 (escalations must reach the operator off-device); T6 needs the proposed-mission approval gate; T-missions that mutate stay on testnet (env→mutation binding before any mainnet).
 

--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -138,6 +138,43 @@ describe("MonitorPage — container", () => {
     }
   });
 
+  test("the default mission approval POSTs to /monitor/testbed-missions/:id/approve", async () => {
+    const requestedMission = {
+      id: "testbed-mission-requested-1",
+      lane: "operator-review",
+      type: "mission",
+      agentType: "hermes",
+      title: "Tester run requested",
+      summary: "Tester run requested by codex; it has not started and remains board-gated until the operator approves it.",
+      repo: "testbed/mission",
+      freshness: 1,
+      state: "fresh",
+      risk: ["testbed"],
+      waitingOn: { actor: "operator", tone: "neutral" },
+      missionStatus: "requested",
+    } as unknown as MonitorBoard["cards"][number];
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [requestedMission],
+      at: "2026-05-28T10:30:00Z",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} autonomy={{ fetchMode: async () => null }} />, {
+        wrapper,
+      });
+      await waitFor(() => expect(getByRole("button", { name: /Approve tester run/ })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: /Approve tester run/ }));
+      fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/testbed-missions/testbed-mission-requested-1/approve");
+      expect(init.method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   test("the composer's /mute command mutes alerts end-to-end", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" }));
     const storage = memStorage();

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -48,6 +48,8 @@ export interface MonitorPageProps {
   onCreateTask?: (input: CreateTaskInput) => void;
   /** Override the approve dispatch (defaults to POST /monitor/codex-tasks approve). */
   onApproveTask?: (id: string) => void;
+  /** Override the tester mission approval (defaults to POST /monitor/testbed-missions/:id/approve). */
+  onApproveMission?: (id: string) => void;
   /** Override the co-pilot collaboration wiring (defaults to live polling). */
   collaboration?: UseCollaborationOptions;
   /** Override the action-alert wiring (audio/notification/storage) for tests. */
@@ -64,6 +66,7 @@ export function MonitorPage({
   onSpawnClaudeTask = defaultSpawnClaudeTask,
   onCreateTask = defaultCreateTask,
   onApproveTask = defaultApproveTask,
+  onApproveMission = defaultApproveMission,
   collaboration = {},
   alerts,
   onAlertMute = defaultPostAlertMute,
@@ -105,6 +108,7 @@ export function MonitorPage({
         onSpawnClaudeTask={onSpawnClaudeTask}
         onCreateTask={onCreateTask}
         onApproveTask={onApproveTask}
+        onApproveMission={onApproveMission}
         collaboration={collaboration}
         onMute={muteEverywhere}
         onUnmute={unmuteEverywhere}
@@ -180,6 +184,20 @@ function defaultApproveTask(id: string): void {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ action: "approve", id }),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+/**
+ * Approve a requested tester mission — the T6 board gate (requested → ready).
+ * Agents can request a run, but only this operator action lets the runner
+ * claim it. Fire-and-forget; the board feed reflects the lifecycle.
+ */
+function defaultApproveMission(id: string): void {
+  void fetch(`${MISSIONS_URL}/${encodeURIComponent(id)}/approve`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
   });

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -97,6 +97,8 @@ export interface BoardViewProps {
   onCreateTask?: (input: CreateTaskInput) => void;
   /** Approve a proposed task card — the operator human gate (O3). */
   onApproveTask?: (id: string) => void;
+  /** Approve a requested tester mission — the operator human gate (T6). */
+  onApproveMission?: (id: string) => void;
   collaboration?: UseCollaborationOptions;
   onMute?: (untilMs: number) => void;
   onUnmute?: () => void;
@@ -123,6 +125,7 @@ export function BoardView({
   onSpawnClaudeTask,
   onCreateTask,
   onApproveTask,
+  onApproveMission,
   collaboration,
   onMute,
   onUnmute,
@@ -295,6 +298,7 @@ export function BoardView({
                 focused={card.id === boardFocusId}
                 onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
                 onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
+                onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
               />
             )}
           />

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -203,3 +203,38 @@ describe("Card — task approve (O3 dispatch)", () => {
     expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
   });
 });
+
+describe("Card — requested tester mission approve (T6)", () => {
+  const requestedMission = {
+    id: "testbed-mission-requested-1",
+    lane: "operator-review",
+    type: "mission",
+    agentType: "hermes",
+    title: "Tester run requested",
+    summary: "Tester run requested by codex; it has not started and remains board-gated until the operator approves it.",
+    repo: "testbed/mission",
+    freshness: 1,
+    state: "fresh",
+    risk: ["testbed"],
+    waitingOn: { actor: "operator", tone: "neutral" },
+    missionStatus: "requested",
+  } as unknown as BoardCard;
+
+  test("shows that the mission has not started and requires approval", () => {
+    const { getByRole, getByText } = render(<Card card={requestedMission} onApproveMission={vi.fn()} />);
+    expect(getByText("Tester run requested")).toBeTruthy();
+    expect(getByText("not started")).toBeTruthy();
+    expect(getByRole("button", { name: /Approve tester run/ })).toBeTruthy();
+  });
+
+  test("approving a tester mission requires confirm before dispatching to the runner queue", () => {
+    const onApproveMission = vi.fn();
+    const { getByRole, getByText } = render(<Card card={requestedMission} onApproveMission={onApproveMission} />);
+    fireEvent.click(getByRole("button", { name: /Approve tester run/ }));
+    expect(onApproveMission).not.toHaveBeenCalled();
+    expect(getByText(/Queue runner now\?/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+    expect(onApproveMission).toHaveBeenCalledTimes(1);
+    expect(onApproveMission.mock.calls[0]?.[0]?.id).toBe("testbed-mission-requested-1");
+  });
+});

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -29,6 +29,8 @@ export type CardProps = {
   onClick?: (card: BoardCard) => void;
   /** Approve a proposed task card (O3). Operator-only; runs through a confirm. */
   onApprove?: (card: BoardCard) => void;
+  /** Approve a requested tester mission (T6). Operator-only; runs through a confirm. */
+  onApproveMission?: (card: BoardCard) => void;
 };
 
 // ── Helpers (mirror the bundle's small inline helpers) ──────────────
@@ -67,7 +69,7 @@ function riskPillClass(tag: RiskTag): string {
 
 // ── Card ───────────────────────────────────────────────────────────
 
-export function Card({ card, focused = false, onClick, onApprove }: CardProps) {
+export function Card({ card, focused = false, onClick, onApprove, onApproveMission }: CardProps) {
   const isAction = Boolean(card.isAction);
   const isStale = card.state === "stale";
   const isClosed = card.type === "done";
@@ -151,6 +153,17 @@ export function Card({ card, focused = false, onClick, onApprove }: CardProps) {
 
       {card.type === "task" && (card as { taskStatus?: string }).taskStatus === "proposed" && onApprove ? (
         <TaskApprove card={card} onApprove={onApprove} />
+      ) : null}
+
+      {card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "requested" ? (
+        <div className="hm-waiting hm-waiting--neutral">
+          not started
+          <span className="target">→ awaiting operator approval</span>
+        </div>
+      ) : null}
+
+      {card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "requested" && onApproveMission ? (
+        <MissionApprove card={card} onApprove={onApproveMission} />
       ) : null}
 
       {isAction && verdict ? (
@@ -288,6 +301,60 @@ function TaskApprove({ card, onApprove }: { card: BoardCard; onApprove: (card: B
     <div className="hm-card-cta" role="group" aria-label="Confirm task dispatch">
       <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
         Dispatch to {agent}?
+      </span>
+      <button
+        type="button"
+        className="hm-btn hm-btn--action hm-btn--sm"
+        onClick={(e) => {
+          stop(e);
+          setConfirming(false);
+          onApprove(card);
+        }}
+      >
+        Confirm
+      </button>
+      <button
+        type="button"
+        className="hm-btn hm-btn--ghost hm-btn--sm"
+        onClick={(e) => {
+          stop(e);
+          setConfirming(false);
+        }}
+      >
+        Cancel
+      </button>
+    </div>
+  );
+}
+
+// ── Mission approve (T6 tester request gate) ───────────────────────
+// Agent-requested tester runs are proposals only. The runner ignores
+// `requested`; this button performs the explicit operator gate
+// (requested → ready), after a confirm step.
+
+function MissionApprove({ card, onApprove }: { card: BoardCard; onApprove: (card: BoardCard) => void }) {
+  const [confirming, setConfirming] = useState(false);
+  const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
+  if (!confirming) {
+    return (
+      <div className="hm-card-cta">
+        <button
+          type="button"
+          className="hm-btn hm-btn--action hm-btn--sm"
+          onClick={(e) => {
+            stop(e);
+            setConfirming(true);
+          }}
+        >
+          Approve tester run
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="hm-card-cta" role="group" aria-label="Confirm tester mission approval">
+      <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
+        Queue runner now?
       </span>
       <button
         type="button"

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -19,9 +19,11 @@ export type CardRouterProps = {
   onDegradedAction?: (card: BoardCard) => void;
   /** Approve a proposed task card (O3 dispatch). */
   onApprove?: (card: BoardCard) => void;
+  /** Approve a board-gated requested tester mission (T6). */
+  onApproveMission?: (card: BoardCard) => void;
 };
 
-export function CardRouter({ card, focused, onClick, onDegradedAction, onApprove }: CardRouterProps) {
+export function CardRouter({ card, focused, onClick, onDegradedAction, onApprove, onApproveMission }: CardRouterProps) {
   const renderer = pickRenderer(card);
 
   if (renderer === "degraded") {
@@ -38,5 +40,5 @@ export function CardRouter({ card, focused, onClick, onDegradedAction, onApprove
     );
   }
 
-  return <Card card={card} focused={focused} onClick={onClick} onApprove={onApprove} />;
+  return <Card card={card} focused={focused} onClick={onClick} onApprove={onApprove} onApproveMission={onApproveMission} />;
 }

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -202,7 +202,9 @@ export interface MissionReport {
 /** Browser mission card (testbed). */
 export interface MissionCard extends CardBase {
   type: "mission";
-  mission: MissionReport;
+  mission?: MissionReport;
+  /** requested missions are board-gated and cannot be claimed until approved. */
+  missionStatus?: "requested" | "ready" | "running" | "completed" | "failed";
 }
 
 /** Task lifecycle status (mirrors the serializer's TaskStatus). */

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -138,9 +138,12 @@ import {
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
 import {
+  approveRequestedTestbedMission,
   createTestbedMissionFromAgent,
   getTestbedMissionForAgent,
   listTestbedMissionsForAgent,
+  requestTestbedMissionFromAgent,
+  TestbedMissionRequestValidationError,
 } from "./testbed-agent-entrypoint.js";
 import { buildTesterCapabilitiesManifest } from "./tester-capabilities.js";
 import {
@@ -669,6 +672,36 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorAutonomyModeRequest(request, response);
+    return;
+  }
+  if (request.method === "POST" && url.pathname === "/monitor/testbed-missions/request") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorTestbedMissionRequestProposal(request, response);
+    return;
+  }
+  const testbedMissionApprovalId = monitorTestbedMissionApproveId(url.pathname);
+  if (request.method === "POST" && testbedMissionApprovalId) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "mission_approval_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedMissionApprovalRequest(testbedMissionApprovalId, response);
     return;
   }
   const testbedMissionId = monitorTestbedMissionId(url.pathname);
@@ -1256,6 +1289,82 @@ async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage,
   }
 }
 
+async function handleMonitorTestbedMissionRequestProposal(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+
+    const created = requestTestbedMissionFromAgent({
+      requesterAgent: payload.requesterAgent,
+      targetUrl: payload.targetUrl,
+      goal: payload.goal,
+      reason: payload.reason,
+      mode: payload.mode,
+    });
+    recordTestbedMissionRequestCollaboration(created.run);
+    logger.info(
+      {
+        missionId: created.run.id,
+        requesterAgent: created.run.requesterAgent,
+        targetUrl: created.run.targetUrl,
+      },
+      "monitor_testbed_mission_requested"
+    );
+    writeJson(response, 200, {
+      ok: true,
+      boardGated: true,
+      ...created,
+    });
+  } catch (error) {
+    if (error instanceof TestbedMissionRequestValidationError) {
+      writeJson(response, 400, {
+        error: error.code,
+        message: error.message,
+      });
+      return;
+    }
+    logger.error({ err: error }, "monitor_testbed_mission_request_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_mission_request_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorTestbedMissionApprovalRequest(id: string, response: http.ServerResponse) {
+  try {
+    const result = approveRequestedTestbedMission(id, { approvedBy: "operator" });
+    if (!result.ok) {
+      if (result.error === "not_found") {
+        writeJson(response, 404, { error: "testbed_mission_not_found", id });
+        return;
+      }
+      writeJson(response, 409, {
+        error: "testbed_mission_not_requested",
+        id,
+        status: result.run?.status,
+      });
+      return;
+    }
+    recordTestbedMissionApprovalCollaboration(result.run);
+    logger.info({ missionId: id }, "monitor_testbed_mission_approved");
+    writeJson(response, 200, {
+      ok: true,
+      run: result.run,
+    });
+  } catch (error) {
+    logger.error({ err: error, missionId: id }, "monitor_testbed_mission_approval_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_mission_approval_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 function recordTestbedMissionCollaboration(run: TestbedMissionRun): void {
   try {
     const runner = summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat());
@@ -1275,6 +1384,41 @@ function recordTestbedMissionCollaboration(run: TestbedMissionRun): void {
     });
   } catch (error) {
     logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_collaboration_failed");
+  }
+}
+
+function recordTestbedMissionRequestCollaboration(run: TestbedMissionRun): void {
+  try {
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "proposal",
+      addressedTo: "operator",
+      relatedCorrelationId: run.id,
+      text: [
+        `Tester run requested by ${run.requesterAgent ?? "agent"} for ${run.targetUrl}.`,
+        "It has not started; the Hermes testbed runner will ignore it until you approve it on the board.",
+        run.requestReason ? `Reason: ${run.requestReason}` : "",
+      ].filter(Boolean).join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_request_collaboration_failed");
+  }
+}
+
+function recordTestbedMissionApprovalCollaboration(run: TestbedMissionRun): void {
+  try {
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "status",
+      addressedTo: "operator",
+      relatedCorrelationId: run.id,
+      text: [
+        `Operator approved tester run ${run.id}.`,
+        "It is now ready; the Hermes testbed runner may claim it on the next poll.",
+      ].join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_approval_collaboration_failed");
   }
 }
 
@@ -2455,6 +2599,15 @@ function monitorTestbedMissionId(pathname: string): string | undefined {
   const prefix = "/monitor/testbed-missions/";
   if (!pathname.startsWith(prefix)) return undefined;
   const id = decodeURIComponent(pathname.slice(prefix.length)).trim();
+  return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+function monitorTestbedMissionApproveId(pathname: string): string | undefined {
+  const prefix = "/monitor/testbed-missions/";
+  const suffix = "/approve";
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return undefined;
+  const raw = pathname.slice(prefix.length, -suffix.length);
+  const id = decodeURIComponent(raw).trim();
   return id.length > 0 && !id.includes("/") ? id : undefined;
 }
 

--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -114,6 +114,14 @@ function classifyItem(
   const mergeRecommendation = normalize(textProp(summary, "mergeRecommendation"));
   const intent = normalize(textProp(item, "intent"));
   if (intent === "testbed_agent_mission") {
+    if (status === "requested" || finalVerdict === "requested") {
+      return {
+        lane: "Operator Review",
+        owner: "Operator",
+        verdict: "Tester run requested",
+        next: "approve the requested tester run before the Hermes runner is allowed to claim it",
+      };
+    }
     const failed = status === "failed" || includesAny(finalVerdict, ["failed", "failure", "block"]);
     const completed = status === "completed" || includesAny(finalVerdict, ["pass", "completed"]);
     if (failed) {

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -11,9 +11,10 @@ import {
 
 const MAX_MISSION_RUNS = 50;
 
-export type TestbedMissionStatus = "ready" | "running" | "completed" | "failed";
+export type TestbedMissionStatus = "requested" | "ready" | "running" | "completed" | "failed";
 export type TestbedMissionVerdict = "pass" | "partial" | "fail";
 export type TestbedMissionMode = "explore" | "surface_sweep" | "siwe_auth";
+export type TestbedMissionRequesterAgent = "codex" | "claude" | "hermes" | "operator";
 export type TestbedMissionRunnerHeartbeatStatus =
   | "idle"
   | "running"
@@ -39,6 +40,8 @@ export interface TestbedMissionRun {
   targetUrl: string;
   goal: string;
   agentName: string;
+  requesterAgent?: TestbedMissionRequesterAgent;
+  requestReason?: string;
   freshMemory: boolean;
   allowTestMutations: boolean;
   requestedAllowTestMutations?: boolean;
@@ -58,6 +61,9 @@ export interface TestbedMissionRun {
   history: TestbedMissionHistoryEntry[];
   createdAt: string;
   updatedAt: string;
+  requestedAt?: string;
+  approvedAt?: string;
+  approvedBy?: string;
   statusReason: string;
   runnerId?: string;
   claimedAt?: string;
@@ -129,6 +135,16 @@ export interface TestbedMissionStoreDeps {
   now?: Date;
 }
 
+export interface RecordTestbedMissionRunOptions {
+  initialStatus?: "ready" | "requested";
+  requesterAgent?: TestbedMissionRequesterAgent;
+  requestReason?: string;
+}
+
+export type ApproveTestbedMissionRunResult =
+  | { ok: true; run: TestbedMissionRun }
+  | { ok: false; error: "not_found" | "not_requested"; run?: TestbedMissionRun };
+
 export interface TestbedMissionRunnerHeartbeat {
   schemaVersion: 1;
   kind: "testbed_mission_runner_heartbeat";
@@ -146,7 +162,8 @@ let loadedMissionStorePath: string | undefined;
 export function recordTestbedMissionRunFromOperatorResult(
   result: unknown,
   nowMs: number = Date.now(),
-  path?: string
+  path?: string,
+  options: RecordTestbedMissionRunOptions = {}
 ): TestbedMissionRun | undefined {
   ensureMissionStoreLoaded(path, { force: true });
   if (!isRecord(result) || result.kind !== "testbed_agent_mission") return undefined;
@@ -169,16 +186,19 @@ export function recordTestbedMissionRunFromOperatorResult(
   });
   const mission = annotateMissionWithMutationBinding(rawMission, binding);
   const routes = Array.isArray(target.routes) ? stringArray(target.routes) : [];
+  const initialStatus = options.initialStatus ?? "ready";
   const run: TestbedMissionRun = {
     schemaVersion: 1,
     kind: "testbed_mission_run",
     id: nextMissionId(nowMs),
-    status: "ready",
-    title: testbedMissionTitle(mode),
+    status: initialStatus,
+    title: initialStatus === "requested" ? "Tester run requested" : testbedMissionTitle(mode),
     targetUrl: stringField(target, "url") ?? "[TESTBED_URL]",
     goal: stringField(target, "goal")
       ?? "Test whether a normal outside agent can understand and use the page.",
     agentName: stringField(target, "agentName") ?? "Hermes",
+    ...(options.requesterAgent ? { requesterAgent: options.requesterAgent } : {}),
+    ...(options.requestReason ? { requestReason: options.requestReason } : {}),
     freshMemory: target.freshMemory !== false,
     allowTestMutations: binding.allowTestMutations,
     requestedAllowTestMutations: binding.requestedAllowTestMutations,
@@ -192,14 +212,19 @@ export function recordTestbedMissionRunFromOperatorResult(
     history: [
       {
         at: createdAt,
-        status: "ready",
-        event: "mission_packet_ready",
-        message: testbedMissionReadyMessage(mode, binding),
+        status: initialStatus,
+        event: initialStatus === "requested" ? "mission_requested" : "mission_packet_ready",
+        message: initialStatus === "requested"
+          ? testbedMissionRequestedMessage(options.requesterAgent, options.requestReason)
+          : testbedMissionReadyMessage(mode, binding),
       },
     ],
     createdAt,
     updatedAt: createdAt,
-    statusReason: testbedMissionReadyReason(mode, binding),
+    ...(initialStatus === "requested" ? { requestedAt: createdAt } : {}),
+    statusReason: initialStatus === "requested"
+      ? testbedMissionRequestedReason(options.requesterAgent, options.requestReason)
+      : testbedMissionReadyReason(mode, binding),
   };
   missionRuns.push(run);
   while (missionRuns.length > MAX_MISSION_RUNS) missionRuns.shift();
@@ -211,12 +236,40 @@ export function listTestbedMissionRuns(options: ListTestbedMissionRunOptions = {
   ensureMissionStoreLoaded(options.path, { force: true });
   const limit = clampInt(options.limit, 1, MAX_MISSION_RUNS, 20);
   const runs = options.activeOnly
-    ? missionRuns.filter((run) => run.status === "ready" || run.status === "running")
+    ? missionRuns.filter((run) => run.status === "requested" || run.status === "ready" || run.status === "running")
     : missionRuns.slice();
   return runs
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
     .slice(0, limit)
     .map((run) => cloneRun(run));
+}
+
+export function approveTestbedMissionRun(
+  id: string,
+  deps: TestbedMissionStoreDeps & { approvedBy?: string } = {}
+): ApproveTestbedMissionRunResult {
+  ensureMissionStoreLoaded(deps.path, { force: true });
+  const existing = missionRuns.find((run) => run.id === id);
+  if (!existing) return { ok: false, error: "not_found" };
+  if (existing.status !== "requested") {
+    return { ok: false, error: "not_requested", run: cloneRun(existing) };
+  }
+  const now = (deps.now ?? new Date()).toISOString();
+  existing.status = "ready";
+  existing.title = testbedMissionTitle(existing.mode);
+  existing.approvedAt = now;
+  existing.approvedBy = deps.approvedBy ?? "operator";
+  existing.updatedAt = now;
+  existing.statusReason = testbedMissionReadyReasonForRun(existing);
+  existing.history.push({
+    at: now,
+    status: "ready",
+    event: "mission_approved",
+    message: `Operator approved the requested tester run; ${existing.statusReason}`,
+  });
+  trimMissionHistory(existing);
+  persistMissionStore(deps.path);
+  return { ok: true, run: cloneRun(existing) };
 }
 
 export function recordTestbedMissionReportFromMessage(
@@ -443,15 +496,24 @@ export function diagnoseTestbedMissionReportFromMessage(input: MissionReportInpu
 }
 
 export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<string, unknown> {
-  const active = run.status === "ready" || run.status === "running";
-  const terminalStatus = run.status === "completed" ? "completed" : run.status === "failed" ? "failed" : "running";
+  const active = run.status === "requested" || run.status === "ready" || run.status === "running";
+  const terminalStatus = run.status === "requested"
+    ? "requested"
+    : run.status === "completed"
+      ? "completed"
+      : run.status === "failed"
+        ? "failed"
+        : "running";
   const structuredReport = testbedMissionStructuredReport(run);
   const verdict = run.status === "completed"
     ? "pass"
     : run.status === "failed"
       ? structuredReport?.verdict ?? "failed"
-      : "running";
+      : run.status === "requested"
+        ? "requested"
+        : "running";
   const reportAttached = Boolean(run.result);
+  const requested = run.status === "requested";
   return {
     correlationId: run.id,
     requester: "monitor",
@@ -469,6 +531,7 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
       kind: "testbed_mission_run",
       title: run.title,
       status: run.status,
+      missionStatus: run.status,
       finalReason: run.statusReason,
       finalVerdict: verdict,
       mergeRecommendation: "not_applicable",
@@ -476,14 +539,18 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
       reviewSignals: {
         touchedAreas: ["testbed"],
         testSignals: [
-          "mission packet ready",
+          requested ? "tester run requested" : "mission packet ready",
           ...(run.status === "running" ? ["browser mission runner claimed"] : []),
           ...(run.environment ? [`mission environment: ${run.environment}`] : []),
           ...(run.mutationMode ? [`mutation profile: ${run.mutationMode}`] : []),
           ...(run.allowTestMutations ? ["test-mode page mutation allowed"] : []),
           ...(reportAttached ? ["browser agent report attached"] : []),
         ],
-        missingTestSignals: reportAttached ? [] : ["browser-agent report"],
+        missingTestSignals: reportAttached
+          ? []
+          : requested
+            ? ["operator approval", "browser-agent report"]
+            : ["browser-agent report"],
       },
       reviewReasons: run.status === "failed"
         ? [{ severity: "high", code: "testbed_mission_failed", message: run.statusReason }]
@@ -823,6 +890,41 @@ function onlyActiveMissionRun(): TestbedMissionRun | undefined {
     .filter((run) => run.status === "ready" || run.status === "running")
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   return activeRuns.length === 1 ? activeRuns[0] : undefined;
+}
+
+function testbedMissionRequestedMessage(
+  requesterAgent: TestbedMissionRequesterAgent | undefined,
+  reason: string | undefined
+): string {
+  const requester = requesterAgent ?? "agent";
+  return [
+    `Tester run requested by ${requester}; waiting for operator approval before the runner can claim it.`,
+    reason ? `Reason: ${reason}` : "",
+  ].filter(Boolean).join(" ");
+}
+
+function testbedMissionRequestedReason(
+  requesterAgent: TestbedMissionRequesterAgent | undefined,
+  reason: string | undefined
+): string {
+  const requester = requesterAgent ?? "agent";
+  return [
+    `Tester run requested by ${requester}; it has not started and remains board-gated until the operator approves it.`,
+    reason ? `Reason: ${reason}` : "",
+  ].filter(Boolean).join(" ");
+}
+
+function testbedMissionReadyReasonForRun(run: TestbedMissionRun): string {
+  if (run.mode === "siwe_auth") {
+    return "SIWE auth mission is ready; waiting for signer-sidecar role sessions and structured role-gating evidence.";
+  }
+  if (run.allowTestMutations) {
+    return `Mission packet is ready with ${run.environment ?? "testbed"} testbed mutations allowed; waiting for a browser-only test-mode run and structured report.`;
+  }
+  if (run.requestedAllowTestMutations) {
+    return `Mission packet is ready, but env→mutation binding forced read-only: ${run.mutationBindingReason ?? "testbed mutations denied"}.`;
+  }
+  return "Mission packet is ready; waiting for a browser-only agent run and structured report.";
 }
 
 function cloneRun(run: TestbedMissionRun): TestbedMissionRun {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -70,6 +70,13 @@ export type TaskStatus =
   | "failed"
   | "cancelled";
 
+export type MissionStatus =
+  | "requested"
+  | "ready"
+  | "running"
+  | "completed"
+  | "failed";
+
 /** CI check rollup for the card's checks bar. Mirrors the UI CardChecks. */
 export interface CardChecks {
   pass: number;
@@ -205,6 +212,8 @@ export interface BoardCard {
   riskSignals?: CardRiskSignal[];
   /** Mission cards: the browser agent's structured report, when posted. */
   mission?: CardMissionReport;
+  /** Mission lifecycle status; requested missions are board-gated and not runner-claimable. */
+  missionStatus?: MissionStatus;
   /** D2: latest durable explanation associated with this card. */
   decisionRecord?: HermesDecisionRecord;
 }
@@ -788,6 +797,8 @@ export function enrichBoardCard(
   // Mission cards: project the browser agent's structured report. Omitted
   // when the run has no report yet (the drawer shows its "no report" state).
   if (card.type === "mission" && ctx.missionRun) {
+    const status = asString(ctx.missionRun.status);
+    if (status) card.missionStatus = status as MissionStatus;
     const mission = mapMissionReport(ctx.missionRun);
     if (mission) card.mission = mission;
   }

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -1,11 +1,13 @@
-import { getTestbedAgentMission, type TestbedAgentMissionInput } from "@avg/averray-mcp/operator-testbed";
+import { getTestbedAgentMission } from "@avg/averray-mcp/operator-testbed";
 
 import {
+  approveTestbedMissionRun,
   listTestbedMissionRuns,
   readTestbedMissionRunnerHeartbeat,
   recordTestbedMissionRunFromOperatorResult,
   summarizeTestbedMissionRunnerHeartbeat,
   type TestbedMissionMode,
+  type TestbedMissionRequesterAgent,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
 import {
@@ -15,7 +17,14 @@ import {
   type TestbedMissionEnvironment,
 } from "./testbed-mutation-binding.js";
 
-export interface AgentTestbedMissionInput extends TestbedAgentMissionInput {
+export interface AgentTestbedMissionInput {
+  targetUrl?: string;
+  goal?: string;
+  agentName?: string;
+  freshMemory?: boolean;
+  allowTestMutations?: boolean;
+  maxBrowserSteps?: number;
+  maxMinutes?: number;
   requester?: string;
   path?: string;
   /** Explicit environment binding; absent ⇒ infer from URL / runner env. */
@@ -24,6 +33,17 @@ export interface AgentTestbedMissionInput extends TestbedAgentMissionInput {
   mode?: TestbedMissionMode;
   /** T1: routes for a surface sweep (relative to the app base URL, or absolute). */
   routes?: string[];
+}
+
+export type AgentRequestedTestbedMissionMode = "fresh" | "memory";
+
+export interface AgentRequestedTestbedMissionInput {
+  requesterAgent?: unknown;
+  targetUrl?: unknown;
+  goal?: unknown;
+  reason?: unknown;
+  mode?: unknown;
+  path?: string;
 }
 
 export interface AgentTestbedMissionListInput {
@@ -47,9 +67,62 @@ export interface AgentTestbedMissionResult {
   nextStep: string;
 }
 
+export class TestbedMissionRequestValidationError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string
+  ) {
+    super(message);
+    this.name = "TestbedMissionRequestValidationError";
+  }
+}
+
 export function createTestbedMissionFromAgent(
   input: AgentTestbedMissionInput = {},
   nowMs: number = Date.now()
+): AgentTestbedMissionResult {
+  return createTestbedMissionRecord(input, nowMs, { initialStatus: "ready" });
+}
+
+export function requestTestbedMissionFromAgent(
+  input: AgentRequestedTestbedMissionInput,
+  nowMs: number = Date.now()
+): AgentTestbedMissionResult {
+  const request = parseAgentRequestedTestbedMission(input);
+  const missionInput: AgentTestbedMissionInput = {
+    requester: request.requesterAgent,
+    targetUrl: request.targetUrl,
+    goal: request.goal,
+    freshMemory: request.mode === "fresh",
+    allowTestMutations: false,
+  };
+  if (input.path) missionInput.path = input.path;
+  return createTestbedMissionRecord(
+    missionInput,
+    nowMs,
+    {
+      initialStatus: "requested",
+      requesterAgent: request.requesterAgent,
+      requestReason: request.reason,
+    }
+  );
+}
+
+export function approveRequestedTestbedMission(
+  id: string,
+  input: { path?: string; approvedBy?: string; now?: Date } = {}
+) {
+  return approveTestbedMissionRun(id, input);
+}
+
+function createTestbedMissionRecord(
+  input: AgentTestbedMissionInput,
+  nowMs: number,
+  options: {
+    initialStatus: "ready" | "requested";
+    requesterAgent?: TestbedMissionRequesterAgent;
+    requestReason?: string;
+  }
 ): AgentTestbedMissionResult {
   const binding = resolveTestbedMutationBinding({
     targetUrl: input.targetUrl,
@@ -79,7 +152,8 @@ export function createTestbedMissionFromAgent(
       mission,
     },
     nowMs,
-    input.path
+    input.path,
+    options
   );
   if (!run) {
     throw new Error("Hermes testbed mission could not be recorded.");
@@ -95,9 +169,11 @@ export function createTestbedMissionFromAgent(
     mission,
     runner,
     statusUrlHint: `/monitor/testbed-missions?limit=20`,
-    nextStep: runnerReady
-      ? "Hermes testbed runner can claim this mission; poll /monitor/testbed-missions or watch the board for the structured report."
-      : "Mission is queued, but no healthy automatic runner is visible; use the mission prompt manually or start the testbed runner.",
+    nextStep: run.status === "requested"
+      ? "Tester run request is board-gated; the operator must approve it before the Hermes testbed runner can claim it."
+      : runnerReady
+        ? "Hermes testbed runner can claim this mission; poll /monitor/testbed-missions or watch the board for the structured report."
+        : "Mission is queued, but no healthy automatic runner is visible; use the mission prompt manually or start the testbed runner.",
   };
 }
 
@@ -130,6 +206,7 @@ export function getTestbedMissionForAgent(id: string, input: AgentTestbedMission
 function summarizeMissionCounts(runs: TestbedMissionRun[]) {
   return {
     total: runs.length,
+    requested: runs.filter((run) => run.status === "requested").length,
     ready: runs.filter((run) => run.status === "ready").length,
     running: runs.filter((run) => run.status === "running").length,
     completed: runs.filter((run) => run.status === "completed").length,
@@ -150,6 +227,9 @@ function nextStepForRun(
   if (run.status === "running") {
     return "Hermes testbed runner is working; poll this mission until it records a structured report or failure.";
   }
+  if (run.status === "requested") {
+    return "Tester run request is waiting for operator approval; the runner will ignore it until it moves to ready.";
+  }
   const runnerReady = runner && !runner.stale && runner.status !== "disabled" && runner.status !== "misconfigured";
   return runnerReady
     ? "Mission is ready; Hermes testbed runner should claim it on its next poll."
@@ -158,4 +238,53 @@ function nextStepForRun(
 
 function cleanString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseAgentRequestedTestbedMission(input: AgentRequestedTestbedMissionInput): {
+  requesterAgent: TestbedMissionRequesterAgent;
+  targetUrl: string;
+  goal: string;
+  reason: string;
+  mode: AgentRequestedTestbedMissionMode;
+} {
+  const requesterAgent = parseRequesterAgent(input.requesterAgent);
+  const targetUrl = parseHttpUrl(input.targetUrl);
+  const goal = cleanString(input.goal);
+  if (!goal) {
+    throw new TestbedMissionRequestValidationError("missing_goal", "goal is required for an agent-requested tester run.");
+  }
+  const reason = cleanString(input.reason) ?? "Agent requested a board-gated tester run.";
+  const mode = parseRequestMode(input.mode);
+  return { requesterAgent, targetUrl, goal, reason, mode };
+}
+
+function parseRequesterAgent(value: unknown): TestbedMissionRequesterAgent {
+  const agent = cleanString(value);
+  if (agent === "codex" || agent === "claude" || agent === "hermes" || agent === "operator") return agent;
+  throw new TestbedMissionRequestValidationError(
+    "invalid_requester_agent",
+    "requesterAgent must be one of codex, claude, hermes, or operator."
+  );
+}
+
+function parseRequestMode(value: unknown): AgentRequestedTestbedMissionMode {
+  const mode = cleanString(value) ?? "fresh";
+  if (mode === "fresh" || mode === "memory") return mode;
+  throw new TestbedMissionRequestValidationError("invalid_mode", "mode must be fresh or memory.");
+}
+
+function parseHttpUrl(value: unknown): string {
+  const raw = cleanString(value);
+  if (!raw) {
+    throw new TestbedMissionRequestValidationError("missing_target_url", "targetUrl is required.");
+  }
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    // fall through to the validation error below
+  }
+  throw new TestbedMissionRequestValidationError("invalid_target_url", "targetUrl must be a valid http or https URL.");
 }

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -37,6 +37,17 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
         auth: "monitor auth plus the mission-spawn role gate when configured",
         contentType: "application/json",
       },
+      requestBoardGatedMission: {
+        method: "POST",
+        path: "/monitor/testbed-missions/request",
+        auth: "same monitor auth as /monitor",
+        contentType: "application/json",
+      },
+      approveRequestedMission: {
+        method: "POST",
+        path: "/monitor/testbed-missions/{id}/approve",
+        auth: "monitor auth plus the mission-spawn role gate when configured",
+      },
       listMissions: {
         method: "GET",
         path: "/monitor/testbed-missions?limit=20",
@@ -154,9 +165,9 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
       },
     ],
     approvalGate: {
-      agentRequestedRuns: "read-only requests are monitor-gated; mutating missions remain operator-only",
-      currentEnforcement: "POST /monitor/testbed-missions requires monitor auth and, when configured, a Cloudflare Access mission operator/admin allowlist",
-      proposedMissionApproval: "planned T6 board approval flow; not advertised as automatic here",
+      agentRequestedRuns: "read-only requests use /monitor/testbed-missions/request and land as requested; runners ignore them until operator approval",
+      currentEnforcement: "POST /monitor/testbed-missions still creates ready operator missions; POST /monitor/testbed-missions/{id}/approve is the T6 requested -> ready gate",
+      proposedMissionApproval: "available; board-gated and never automatic from agent request",
     },
     resultShape: {
       verdict: "pass | partial | fail",

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -694,6 +694,47 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     expect(mission?.mission?.target).toBe("https://staging.averray.com/onboarding");
     expect(mission?.mission?.path).toHaveLength(2);
   });
+
+  it("surfaces requested tester missions as board-gated operator approvals", () => {
+    const raw = {
+      active: [],
+      recent: [],
+      testbedMissions: [
+        {
+          schemaVersion: 1,
+          kind: "testbed_mission_run",
+          id: "testbed-mission-requested-1",
+          status: "requested",
+          title: "Tester run requested",
+          targetUrl: "https://staging.averray.com/onboarding",
+          goal: "check onboarding",
+          agentName: "Hermes",
+          requesterAgent: "codex",
+          freshMemory: true,
+          allowTestMutations: false,
+          mission: {},
+          history: [],
+          createdAt: "2026-05-31T10:00:00.000Z",
+          updatedAt: "2026-05-31T10:00:00.000Z",
+          statusReason: "Tester run requested by codex; it has not started and remains board-gated until the operator approves it.",
+        },
+      ],
+      generatedAt: "2026-05-31T10:02:00.000Z",
+    };
+
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent", now: () => new Date("2026-05-31T10:02:00.000Z") });
+    const mission = snap.cards.find((c) => c.type === "mission");
+
+    expect(mission).toMatchObject({
+      title: "Tester run requested",
+      lane: "operator-review",
+      waitingOn: { actor: "operator" },
+      verdict: "Tester run requested",
+      missionStatus: "requested",
+      summary: expect.stringContaining("not started"),
+    });
+    expect(mission?.mission).toBeUndefined();
+  });
 });
 
 describe("indexTestbedMissions", () => {

--- a/test/unit/testbed-agent-entrypoint.test.ts
+++ b/test/unit/testbed-agent-entrypoint.test.ts
@@ -11,6 +11,9 @@ import {
   createTestbedMissionFromAgent,
   getTestbedMissionForAgent,
   listTestbedMissionsForAgent,
+  requestTestbedMissionFromAgent,
+  approveRequestedTestbedMission,
+  TestbedMissionRequestValidationError,
 } from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
 
 vi.mock("@avg/averray-mcp/operator-testbed", () => ({
@@ -86,6 +89,104 @@ describe("testbed agent entrypoint", () => {
     expect(String(result.mission.missionPrompt)).toContain("try the onboarding flow");
   });
 
+  it("lets an agent request a board-gated tester run without making it claimable", () => {
+    const result = requestTestbedMissionFromAgent(
+      {
+        path,
+        requesterAgent: "codex",
+        targetUrl: "https://testbed.example/onboarding",
+        goal: "check whether the onboarding page is understandable to a fresh browser agent",
+        reason: "Codex changed onboarding copy and wants independent browser evidence.",
+        mode: "fresh",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    expect(result).toMatchObject({
+      kind: "hermes_testbed_agent_entrypoint",
+      requester: "codex",
+      run: {
+        status: "requested",
+        title: "Tester run requested",
+        requesterAgent: "codex",
+        requestReason: "Codex changed onboarding copy and wants independent browser evidence.",
+        targetUrl: "https://testbed.example/onboarding",
+        goal: "check whether the onboarding page is understandable to a fresh browser agent",
+        freshMemory: true,
+        allowTestMutations: false,
+      },
+    });
+    expect(result.nextStep).toContain("board-gated");
+
+    const list = listTestbedMissionsForAgent({ path, limit: 10 });
+    expect(list.counts).toMatchObject({
+      requested: 1,
+      ready: 0,
+      running: 0,
+    });
+  });
+
+  it("rejects invalid requested tester run URLs and missing goals", () => {
+    expect(() => requestTestbedMissionFromAgent({
+      path,
+      requesterAgent: "codex",
+      targetUrl: "not-a-url",
+      goal: "check onboarding",
+      reason: "needs browser proof",
+      mode: "fresh",
+    })).toThrow(TestbedMissionRequestValidationError);
+
+    try {
+      requestTestbedMissionFromAgent({
+        path,
+        requesterAgent: "codex",
+        targetUrl: "https://testbed.example/onboarding",
+        reason: "needs browser proof",
+        mode: "fresh",
+      });
+      throw new Error("expected missing goal rejection");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TestbedMissionRequestValidationError);
+      expect((error as TestbedMissionRequestValidationError).code).toBe("missing_goal");
+    }
+  });
+
+  it("approves a requested tester run into the existing ready mission flow", () => {
+    const created = requestTestbedMissionFromAgent(
+      {
+        path,
+        requesterAgent: "claude",
+        targetUrl: "https://testbed.example/onboarding",
+        goal: "check onboarding",
+        reason: "verify the changed page",
+        mode: "memory",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    const approved = approveRequestedTestbedMission(created.run.id, {
+      path,
+      approvedBy: "operator",
+      now: new Date("2026-05-25T10:03:00.000Z"),
+    });
+
+    expect(approved).toMatchObject({
+      ok: true,
+      run: {
+        id: created.run.id,
+        status: "ready",
+        title: "Fresh-agent browser mission",
+        freshMemory: false,
+        approvedAt: "2026-05-25T10:03:00.000Z",
+        approvedBy: "operator",
+      },
+    });
+    expect(listTestbedMissionsForAgent({ path, limit: 10 }).counts).toMatchObject({
+      requested: 0,
+      ready: 1,
+    });
+  });
+
   it("keeps agent-requested mutations read-only when the target is production", () => {
     const result = createTestbedMissionFromAgent(
       {
@@ -144,6 +245,7 @@ describe("testbed agent entrypoint", () => {
       kind: "hermes_testbed_agent_mission_list",
       counts: {
         total: 1,
+        requested: 0,
         ready: 1,
         running: 0,
         completed: 0,

--- a/test/unit/testbed-mission-runner.test.ts
+++ b/test/unit/testbed-mission-runner.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   __resetTestbedMissionRunsForTests,
@@ -10,6 +10,7 @@ import {
   recordTestbedMissionRunFromOperatorResult,
   readTestbedMissionRunnerHeartbeat,
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import { requestTestbedMissionFromAgent } from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
 import {
   appendPlaywrightEvidenceTrail,
   parseTestbedMissionRunnerConfig,
@@ -137,6 +138,47 @@ describe("testbed mission runner", () => {
       status: "completed",
       runnerId: "test-runner",
     });
+  });
+
+  it("ignores requested missions until the operator approves them", async () => {
+    const path = tempMissionStorePath();
+    process.env.AVERRAY_TESTBED_MISSIONS_PATH = path;
+    requestTestbedMissionFromAgent(
+      {
+        path,
+        requesterAgent: "codex",
+        targetUrl: "https://testbed.example/app",
+        goal: "check the app like a fresh browser agent",
+        reason: "needs independent tester evidence",
+        mode: "fresh",
+      },
+      Date.parse("2026-05-24T10:00:00.000Z")
+    );
+    const executor = vi.fn(async () => ({
+      exitCode: 0,
+      stdout: "",
+      stderr: "",
+    }));
+
+    const result = await runTestbedMissionRunnerOnce(
+      {
+        enabled: true,
+        path,
+        runnerId: "test-runner",
+        command: "fake",
+        args: [],
+        pollIntervalMs: 1000,
+        timeoutMs: 1000,
+        outputTailBytes: 4000,
+      },
+      { executor }
+    );
+
+    expect(result.status).toBe("idle");
+    expect(executor).not.toHaveBeenCalled();
+    const [updated] = listTestbedMissionRuns({ path });
+    expect(updated).toMatchObject({ status: "requested" });
+    expect(updated?.runnerId).toBeUndefined();
   });
 
   it("fails the mission when the runner output is not a valid report", async () => {

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -27,6 +27,8 @@ describe("tester capabilities manifest", () => {
       endpoints: {
         capabilities: { method: "GET", path: "/monitor/tester/capabilities" },
         requestMission: { method: "POST", path: "/monitor/testbed-missions" },
+        requestBoardGatedMission: { method: "POST", path: "/monitor/testbed-missions/request" },
+        approveRequestedMission: { method: "POST", path: "/monitor/testbed-missions/{id}/approve" },
       },
       runtime: {
         runnerEnabled: true,


### PR DESCRIPTION
## Summary
- add a `requested` testbed mission state plus board-gated request/approve monitor endpoints
- keep existing operator mission creation as ready, while agent-requested missions require operator approval before runner claim
- surface requested tester runs in the monitor UI with an approve-confirm action and update tester capability/docs

This is board-gated; agents can request but not run tests directly.

## Checks
- npm run typecheck
- npm test

## Affected surfaces
- slack-operator monitor/testbed mission API
- testbed mission runner queue semantics
- monitor UI mission cards
- tester capability manifest/docs

## Rollout / rollback
- additive endpoints/state; existing POST /monitor/testbed-missions still creates ready missions
- rollback by reverting this PR; no env or data migration required