### PR TITLE
Fix tester mission approval test isolation

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -166,9 +166,16 @@ describe("MonitorPage — container", () => {
     }));
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
     try {
-      const { getByRole } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} autonomy={{ fetchMode: async () => null }} />, {
-        wrapper,
-      });
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
       await waitFor(() => expect(getByRole("button", { name: /Approve tester run/ })).toBeTruthy());
       fireEvent.click(getByRole("button", { name: /Approve tester run/ }));
       fireEvent.click(getByRole("button", { name: /^Confirm$/ }));


### PR DESCRIPTION
## Summary
- fix the post-merge CI failure from #304 by isolating the tester mission approval test from the passive read-only backlog suggestions fetch
- keep the assertion focused on the approval POST to /monitor/testbed-missions/:id/approve

## Root cause
- #303 added a passive GET /monitor/backlog-suggestions fetch in MonitorPage
- #304 added a test that spies on global fetch and expected exactly one call
- after both landed on main, the passive GET became the second fetch call and failed CI

## Checks
- npm test -- packages/monitor-ui/src/MonitorPage.test.tsx
- npm run typecheck
- npm test

## Impact
- tests only
- no runtime behavior change
- no env or VPS secret changes