### PR TITLE
feat: add Hermes backlog planner

### DIFF
--- a/packages/averray-mcp/src/hermes-backlog.ts
+++ b/packages/averray-mcp/src/hermes-backlog.ts
@@ -1,0 +1,389 @@
+export type HermesBacklogStream = "O" | "A" | "B" | "C" | "D" | "T";
+export type HermesBacklogPriority = "near" | "next" | "later";
+export type HermesBacklogRiskTier = "low" | "medium" | "high";
+export type HermesBacklogAgent = "codex" | "claude" | "hermes";
+export type HermesBacklogTrustLevel = "roadmap_sanctioned" | "discovery_requires_operator";
+
+export interface HermesBacklogBoardGateInput {
+  actionNeeded?: number;
+  codexNeeded?: number;
+  hermesChecking?: number;
+  operatorReview?: number;
+  releaseQueue?: number;
+  deploying?: number;
+  running?: number;
+  drafts?: number;
+}
+
+export interface HermesBacklogItem {
+  id: string;
+  title: string;
+  stream: HermesBacklogStream;
+  priority: HermesBacklogPriority;
+  status: "design_done" | "follow_up";
+  owner: HermesBacklogAgent;
+  lane: "codex_needed" | "operator_review" | "hermes_checking";
+  riskTier: HermesBacklogRiskTier;
+  trustLevel: HermesBacklogTrustLevel;
+  score: number;
+  scoreSignals: string[];
+  dependencyStatus: "ready" | "blocked" | "watch";
+  dependencies: string[];
+  closeCriteria: string[];
+  verificationPath: string[];
+  prompt: string;
+  source: {
+    roadmap: "docs/HERMES_ROADMAP.md";
+    designDoc: string;
+  };
+  autoFlowEligible: boolean;
+  requiresOperatorApproval: boolean;
+}
+
+export interface HermesBacklogPlan {
+  schemaVersion: 1;
+  kind: "hermes_backlog_plan";
+  generatedAt: string;
+  mutates: false;
+  headline: string;
+  source: {
+    roadmap: "docs/HERMES_ROADMAP.md";
+    mode: "roadmap_static_catalog";
+    note: string;
+  };
+  cadence: {
+    onDemand: true;
+    idleEligible: boolean;
+    dailyBriefEligible: true;
+  };
+  boardGate: {
+    status: "quiet" | "busy" | "not_supplied";
+    reason: string;
+    liveWork: HermesBacklogBoardGateInput;
+  };
+  items: HermesBacklogItem[];
+  nextOperatorStep: string;
+  safety: {
+    proposesOnly: true;
+    netNewDiscoveryEscalates: true;
+    highRiskRemainsRuleBound: true;
+    autoApprovalUnchanged: true;
+  };
+}
+
+const ROADMAP = "docs/HERMES_ROADMAP.md" as const;
+
+const CATALOG: HermesBacklogItem[] = [
+  {
+    id: "C1",
+    title: "Cross-agent review by default",
+    stream: "C",
+    priority: "near",
+    status: "design_done",
+    owner: "claude",
+    lane: "codex_needed",
+    riskTier: "medium",
+    trustLevel: "roadmap_sanctioned",
+    score: 92,
+    scoreSignals: [
+      "C4 inter-agent chat is shipped, so reviewer/builder handoff has a channel",
+      "O4 dispatch guardrails are shipped, so the default review path can stay proposes-only",
+      "Raises confidence before more autonomy work",
+    ],
+    dependencyStatus: "ready",
+    dependencies: ["O3", "O4", "C4"],
+    closeCriteria: [
+      "Every eligible builder PR receives an independent cross-agent review request",
+      "Review result is attached to the card/thread with clear pass/block language",
+      "High-risk surfaces remain on the stricter reviewer-panel path",
+    ],
+    verificationPath: [
+      "Unit-test review request generation and card attribution",
+      "Run one synthetic low/medium-risk PR through builder -> reviewer -> Hermes verdict",
+      "Confirm no merge/deploy authority changes",
+    ],
+    prompt:
+      "Build C1 cross-agent review default for averray-reference-agent. Use the shipped C4 card-scoped collaboration channel, keep it proposes-only, request an independent review for eligible non-high-risk builder PRs, attach the verdict to the monitor card/thread, and leave merge/deploy human-gated.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_PHASE4_DESIGN.md" },
+    autoFlowEligible: true,
+    requiresOperatorApproval: true,
+  },
+  {
+    id: "T6",
+    title: "Agent-requested tester runs",
+    stream: "T",
+    priority: "near",
+    status: "design_done",
+    owner: "codex",
+    lane: "codex_needed",
+    riskTier: "medium",
+    trustLevel: "roadmap_sanctioned",
+    score: 88,
+    scoreSignals: [
+      "T1-T5 are shipped, including auth/session and env-bound mutation profile",
+      "Gives builder agents a safe way to ask Hermes for evidence before review",
+      "Approval gate keeps browser missions from becoming hidden authority",
+    ],
+    dependencyStatus: "ready",
+    dependencies: ["T1", "T2", "T3", "T5"],
+    closeCriteria: [
+      "Agents can request a tester run from a card without directly launching it",
+      "Operator/Hermes approval is required before the run starts",
+      "The mission report returns to the requesting card/thread",
+    ],
+    verificationPath: [
+      "Unit-test request -> approve -> mission creation state changes",
+      "Run one read-only approved mission and confirm report attachment",
+      "Confirm denied/unapproved requests do not run",
+    ],
+    prompt:
+      "Build T6 agent-requested tester runs for averray-reference-agent. Agents may request a read-only browser mission from a card, but Hermes/operator approval must happen before launch; attach the structured report back to the card/thread and do not change merge/deploy authority.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md" },
+    autoFlowEligible: true,
+    requiresOperatorApproval: true,
+  },
+  {
+    id: "T4",
+    title: "Tier-2 browser agent runner",
+    stream: "T",
+    priority: "next",
+    status: "design_done",
+    owner: "codex",
+    lane: "codex_needed",
+    riskTier: "medium",
+    trustLevel: "roadmap_sanctioned",
+    score: 82,
+    scoreSignals: [
+      "Playwright evidence capture exists, but runner remains shallow compared with a real browsing agent",
+      "Improves external-agent realism before broader E2E claims",
+      "Depends on the T3/T5 safety shell that is already shipped",
+    ],
+    dependencyStatus: "ready",
+    dependencies: ["T3", "T5"],
+    closeCriteria: [
+      "A browser-capable tier-2 tester can execute the mission prompt with screenshots and trace evidence",
+      "Mutation boundaries are enforced by environment profile",
+      "Report schema remains the canonical mission report shape",
+    ],
+    verificationPath: [
+      "Run a fresh-memory mission on a public target",
+      "Run an authed testnet mission with preseeded storage state",
+      "Inspect trace/screenshot artifacts and structured verdict",
+    ],
+    prompt:
+      "Build T4 tier-2 browser agent runner for averray-reference-agent. Reuse the shipped mission schema, T3 auth session support, and T5 mutation binding; produce Playwright evidence and structured reports without exposing secrets to the model.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_E2E_TESTER_DESIGN.md" },
+    autoFlowEligible: true,
+    requiresOperatorApproval: true,
+  },
+  {
+    id: "B2",
+    title: "Self-healing for non-high-risk failures",
+    stream: "B",
+    priority: "next",
+    status: "design_done",
+    owner: "codex",
+    lane: "codex_needed",
+    riskTier: "medium",
+    trustLevel: "roadmap_sanctioned",
+    score: 76,
+    scoreSignals: [
+      "D3 anomaly pause exists, so loops have a fail-safe",
+      "Useful once backlog proposals and reviewer feedback are visible",
+      "Must stay scoped to non-high-risk fixes with operator-visible evidence",
+    ],
+    dependencyStatus: "ready",
+    dependencies: ["D3", "O4"],
+    closeCriteria: [
+      "Hermes can propose a bounded retry/fix for non-high-risk failures",
+      "High-risk, merge, deploy, rollback, secrets, contracts, and migrations are excluded",
+      "D3 suspends autopilot if retries loop or worsen the board state",
+    ],
+    verificationPath: [
+      "Unit-test excluded surfaces and retry limits",
+      "Run a synthetic failed low-risk task through one proposed retry",
+      "Confirm D3 blocks repeated failure loops",
+    ],
+    prompt:
+      "Build B2 self-healing for non-high-risk failures in averray-reference-agent. Keep it proposes-only and bounded: no high-risk surfaces, no merge/deploy/rollback/secrets/contracts/migrations; use D3 anomaly pause as the loop fail-safe.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_PHASE3_DESIGN.md" },
+    autoFlowEligible: true,
+    requiresOperatorApproval: true,
+  },
+  {
+    id: "C2",
+    title: "Reviewer panel for high-risk work",
+    stream: "C",
+    priority: "next",
+    status: "design_done",
+    owner: "claude",
+    lane: "operator_review",
+    riskTier: "high",
+    trustLevel: "roadmap_sanctioned",
+    score: 70,
+    scoreSignals: [
+      "High-risk surfaces are rule-bound and should not be learned-routed",
+      "Operator needs richer review context before sign-off",
+      "Pairs naturally with C1 after default review is stable",
+    ],
+    dependencyStatus: "watch",
+    dependencies: ["C1", "D2"],
+    closeCriteria: [
+      "High-risk cards show reviewer evidence grouped by concern",
+      "Operator can see why automation stopped and what decision is requested",
+      "No line-by-line re-review requirement is implied when code-level checks already ran",
+    ],
+    verificationPath: [
+      "Unit-test panel data shape for secrets/deploy/backend risk",
+      "Render monitor panel with synthetic high-risk card",
+      "Confirm operator decision remains explicit",
+    ],
+    prompt:
+      "Build C2 reviewer panel for high-risk Hermes cards. Use D2 decision records and existing risk taxonomy to group evidence for operator sign-off; do not change the high-risk rule-bound routing or human approval requirement.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_PHASE4_DESIGN.md" },
+    autoFlowEligible: false,
+    requiresOperatorApproval: true,
+  },
+  {
+    id: "C3",
+    title: "Specialist agents for tests, security, and docs",
+    stream: "C",
+    priority: "later",
+    status: "design_done",
+    owner: "claude",
+    lane: "codex_needed",
+    riskTier: "medium",
+    trustLevel: "roadmap_sanctioned",
+    score: 58,
+    scoreSignals: [
+      "Useful after C1/C2 establish reviewer flow",
+      "Can increase review quality without expanding authority",
+      "Needs capability manifest and attribution to avoid opaque agents",
+    ],
+    dependencyStatus: "watch",
+    dependencies: ["C1", "T7"],
+    closeCriteria: [
+      "Specialist request types are explicit and attributable",
+      "Each specialist has bounded inputs, expected outputs, and no hidden authority",
+      "Specialist results attach to the card thread",
+    ],
+    verificationPath: [
+      "Unit-test specialist routing taxonomy",
+      "Run one synthetic docs/test/security request each",
+      "Confirm results appear in collaboration thread with agent attribution",
+    ],
+    prompt:
+      "Build C3 specialist-agent request foundation for averray-reference-agent: tests, security, and docs specialists as attributed, bounded reviewers that post results to card threads. No authority change.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_PHASE4_DESIGN.md" },
+    autoFlowEligible: true,
+    requiresOperatorApproval: true,
+  },
+  {
+    id: "T7",
+    title: "Tester capabilities manifest follow-up",
+    stream: "T",
+    priority: "later",
+    status: "follow_up",
+    owner: "codex",
+    lane: "codex_needed",
+    riskTier: "low",
+    trustLevel: "roadmap_sanctioned",
+    score: 54,
+    scoreSignals: [
+      "Capabilities manifest is still marked design/follow-up in the roadmap",
+      "Would help agents know which tester modes are available before requesting runs",
+      "Low-risk documentation/API surface if kept read-only",
+    ],
+    dependencyStatus: "ready",
+    dependencies: ["T1", "T3", "T5"],
+    closeCriteria: [
+      "Manifest lists available mission types, auth modes, mutation modes, and evidence artifacts",
+      "Monitor and MCP expose the same read-only contract",
+      "Platform helper remains a separate follow-up unless code evidence exists",
+    ],
+    verificationPath: [
+      "Unit-test manifest shape",
+      "Confirm monitor and MCP responses agree",
+      "Run one tester mission and confirm advertised evidence fields are present",
+    ],
+    prompt:
+      "Build T7 tester capabilities manifest follow-up for averray-reference-agent. Expose a read-only manifest of mission types, auth modes, mutation modes, and evidence artifacts through monitor/MCP; do not overclaim platform-helper pieces.",
+    source: { roadmap: ROADMAP, designDoc: "docs/HERMES_AGENT_REQUESTS_AND_ALERTS.md" },
+    autoFlowEligible: true,
+    requiresOperatorApproval: true,
+  },
+];
+
+export function getHermesBacklogPlan(input: {
+  now?: Date;
+  limit?: number;
+  board?: HermesBacklogBoardGateInput;
+} = {}): HermesBacklogPlan {
+  const generatedAt = (input.now ?? new Date()).toISOString();
+  const boardGate = summarizeBoardGate(input.board);
+  const items = [...CATALOG]
+    .sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+    .slice(0, clampLimit(input.limit));
+
+  return {
+    schemaVersion: 1,
+    kind: "hermes_backlog_plan",
+    generatedAt,
+    mutates: false,
+    headline: boardGate.status === "busy"
+      ? "Hermes has roadmap proposals ready, but live board work should finish first."
+      : "Hermes can propose the next roadmap-backed work without changing authority.",
+    source: {
+      roadmap: ROADMAP,
+      mode: "roadmap_static_catalog",
+      note: "B1 first slice uses a curated roadmap catalog so runtime containers do not need docs mounted.",
+    },
+    cadence: {
+      onDemand: true,
+      idleEligible: boardGate.status !== "busy",
+      dailyBriefEligible: true,
+    },
+    boardGate,
+    items,
+    nextOperatorStep: "Pick one item, copy its prompt into a proposed task, and approve only when you want an agent to start.",
+    safety: {
+      proposesOnly: true,
+      netNewDiscoveryEscalates: true,
+      highRiskRemainsRuleBound: true,
+      autoApprovalUnchanged: true,
+    },
+  };
+}
+
+function summarizeBoardGate(board: HermesBacklogBoardGateInput | undefined): HermesBacklogPlan["boardGate"] {
+  if (!board) {
+    return {
+      status: "not_supplied",
+      reason: "No live board snapshot was supplied; this is an on-demand roadmap shortlist only.",
+      liveWork: {},
+    };
+  }
+  const active = (board.actionNeeded ?? 0)
+    + (board.codexNeeded ?? 0)
+    + (board.hermesChecking ?? 0)
+    + (board.operatorReview ?? 0)
+    + (board.deploying ?? 0)
+    + (board.running ?? 0);
+  if (active > 0) {
+    return {
+      status: "busy",
+      reason: `${active} live card${active === 1 ? "" : "s"} should resolve before Hermes feeds more work.`,
+      liveWork: board,
+    };
+  }
+  return {
+    status: "quiet",
+    reason: "No live blocking/running/review cards were supplied; backlog proposals are eligible.",
+    liveWork: board,
+  };
+}
+
+function clampLimit(value: number | undefined): number {
+  if (!Number.isFinite(value)) return 3;
+  return Math.max(1, Math.min(8, Math.trunc(value ?? 3)));
+}

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -54,6 +54,7 @@ import { getTestbedAgentMission, getTestbedE2eSuite, runTestbedE2eReadOnly } fro
 import { invokeAgentTask } from "./agent-invocation.js";
 import { getHandoffMonitor } from "./handoff-events.js";
 import { getAgentScorecard } from "./agent-scorecard.js";
+import { getHermesBacklogPlan } from "./hermes-backlog.js";
 
 const server = new McpServer({
   name: "averray-mcp",
@@ -338,6 +339,17 @@ server.tool(
 );
 
 server.tool(
+  "averray_hermes_backlog_plan",
+  "Read-only B1 Hermes backlog planner. Returns a ranked roadmap-backed shortlist with owner, lane, close criteria, verification path, and a copyable prompt. It proposes only: it does not enqueue tasks, approve work, merge PRs, deploy, edit GitHub, or mutate any external system.",
+  {
+    limit: z.number().int().min(1).max(8).default(3)
+  },
+  async ({ limit }) => {
+    return jsonContent(getHermesBacklogPlan({ limit }));
+  }
+);
+
+server.tool(
   "averray_invoke_agent_task",
   "Stable agent-to-agent hook for trusted deploy scripts, backend agents, Codex, and other operator agents. Runs a named safe operator command, the full read-only testbed E2E suite, one testbed testcase by ID, a post-deploy verification workflow, a read-only PR code-review verifier, or a PR handoff workflow that reviews GitHub PR metadata/checks/files and then runs requested tests with requester/correlation metadata. Uses structured operator/MCP workflows instead of free-form Hermes prompts. Fails closed for unknown commands, live mutation cases, local checkpoint writes, and PRs that are not merge-ready unless the caller explicitly opts into that class of action. PR handoff and PR code review only recommend merge state; they never merge. If GITHUB_PR_HANDOFF_COMMENTS_ENABLED=1, PR handoff may upsert one idempotent GitHub verdict comment.",
   {
@@ -369,7 +381,7 @@ server.tool(
 
 server.tool(
   "averray_handle_operator_command",
-  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'codex handoff protocol', 'what should Codex do when Hermes blocks', 'runbook for deploy averray-agent/agent', 'merge runbook for averray-agent/agent', 'secret rotation runbook', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github steward', 'merge steward', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed agent mission', 'agent browser mission https://testbed.example/app goal: complete onboarding', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized agent mission commands call averray_testbed_agent_mission directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/project-memory/project-runbook/codex-handoff-protocol/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
+  "Direct router for trusted Slack/operator/command-center messages. Use this for short commands like 'what can you do for us', 'hermes backlog', 'what should Hermes build next', 'project memory', 'known projects', 'how do we deploy averray-agent/agent', 'codex handoff protocol', 'what should Codex do when Hermes blocks', 'runbook for deploy averray-agent/agent', 'merge runbook for averray-agent/agent', 'secret rotation runbook', 'admin readiness', 'admin proposal', 'propose merge for averray-agent/agent#123', 'propose deploy for averray-agent/agent sha abc1234', 'business ledger', 'ops health', 'github status', 'github steward', 'merge steward', 'github brief', 'daily github brief', 'what changed since last time', 'github open prs', 'github ci failures', 'testbed agent mission', 'agent browser mission https://testbed.example/app goal: complete onboarding', 'testbed e2e suite', 'platform e2e suite', 'run testbed e2e read-only', 'handoff monitor', 'what is Hermes doing', 'daily operator brief', 'find safe work', 'operator status', 'operator status details', 'run one wikipedia citation repair if safe', and 'status last wikipedia citation repair' instead of sending them through a free-form Hermes prompt. Recognized repair run commands call averray_run_wikipedia_citation_repair directly; recognized agent mission commands call averray_testbed_agent_mission directly; recognized read-only E2E run commands call averray_run_testbed_e2e_read_only directly. Recognized status/help/brief/work-discovery/usefulness/backlog/project-memory/project-runbook/codex-handoff-protocol/admin-readiness/admin-proposal/ledger/health/github/testbed/handoff-monitor commands are read-only against external systems except GitHub brief, which persists a local checkpoint timestamp. Human surfaces may compact identifiers by default; add 'details' for full audit identifiers.",
   {
     text: z.string().min(1),
     source: z.enum(["slack", "operator", "command_center", "hermes", "agent"]).default("operator"),

--- a/packages/averray-mcp/src/operator-commands.ts
+++ b/packages/averray-mcp/src/operator-commands.ts
@@ -44,6 +44,12 @@ export type ParsedOperatorCommand =
     }
   | {
       handled: true;
+      kind: "hermes_backlog_plan";
+      source: OperatorCommandSource;
+      detailed: boolean;
+    }
+  | {
+      handled: true;
       kind: "project_memory";
       source: OperatorCommandSource;
       detailed: boolean;
@@ -208,6 +214,9 @@ const EXAMPLES = [
   "handoff monitor",
   "hermes handoff monitor",
   "what is hermes doing",
+  "hermes backlog",
+  "what should Hermes build next",
+  "roadmap backlog",
   "find safe work",
   "operator status",
   "operator status details",
@@ -241,6 +250,10 @@ export function parseOperatorCommand(
 
   if (isAgentUsefulnessPlanCommand(normalizedText)) {
     return { handled: true, kind: "agent_usefulness_plan", source, detailed };
+  }
+
+  if (isHermesBacklogPlanCommand(normalizedText)) {
+    return { handled: true, kind: "hermes_backlog_plan", source, detailed };
   }
 
   const projectMemory = projectMemoryTarget(text, normalizedText);
@@ -461,6 +474,10 @@ function isFindSafeWorkCommand(text: string): boolean {
 
 function isAgentUsefulnessPlanCommand(text: string): boolean {
   return /^(what can you do|what can you do for us|how can you help|how can you work for us|work for us|agent usefulness|agent usefulness plan|agent plan|usefulness plan|show use cases|show agent use cases)( details?| full| audit)?$/.test(text);
+}
+
+function isHermesBacklogPlanCommand(text: string): boolean {
+  return /^(hermes backlog|backlog plan|roadmap backlog|roadmap plan|hermes roadmap|hermes roadmap plan|what should hermes build next|what should we build next|plan next hermes work|next hermes work)( details?| full| audit)?$/.test(text);
 }
 
 function projectMemoryTarget(

--- a/packages/averray-mcp/src/operator-handler.ts
+++ b/packages/averray-mcp/src/operator-handler.ts
@@ -19,6 +19,7 @@ import { getProjectRunbook } from "./operator-project-runbook.js";
 import { getCodexHandoffProtocol } from "./codex-handoff-protocol.js";
 import { getTestbedAgentMission, getTestbedE2eSuite, runTestbedE2eReadOnly } from "./operator-testbed.js";
 import { getAgentUsefulnessPlan } from "./operator-usefulness.js";
+import { getHermesBacklogPlan } from "./hermes-backlog.js";
 import { runWikipediaCitationRepairWorkflow } from "./job-workflows.js";
 import { getHandoffMonitor } from "./handoff-events.js";
 
@@ -66,6 +67,10 @@ export async function handleOperatorCommandText(
   }
   if (command.kind === "agent_usefulness_plan") {
     const plan = await getAgentUsefulnessPlan({ query: deps.query, workflowDeps: deps.workflowDeps });
+    return { ...command, plan };
+  }
+  if (command.kind === "hermes_backlog_plan") {
+    const plan = getHermesBacklogPlan();
     return { ...command, plan };
   }
   if (command.kind === "project_memory") {

--- a/packages/averray-mcp/src/operator-usefulness.ts
+++ b/packages/averray-mcp/src/operator-usefulness.ts
@@ -41,6 +41,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
           "project memory",
           "runbook for deploy averray-agent/agent",
           "admin readiness",
+          "hermes backlog",
           "what should i do next",
           "run one wikipedia citation repair dry run only",
           "run one wikipedia citation repair if safe",
@@ -61,6 +62,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
           "project memory",
           "merge runbook for averray-agent/agent",
           "admin readiness",
+          "hermes backlog",
           "find safe work",
         ],
       },
@@ -69,6 +71,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         use: "Canonical structured contract any compatible agent can call without learning Slack or Workspace.",
         tools: [
           "averray_agent_usefulness_plan",
+          "averray_hermes_backlog_plan",
           "averray_project_memory",
           "averray_project_runbook",
           "averray_admin_readiness",
@@ -102,6 +105,12 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
         nextStep: "Add a read-only GitHub digest command before allowing any write actions.",
       },
       {
+        id: "hermes_planner",
+        status: "enabled",
+        value: "Can rank the next roadmap-backed Hermes work with owner, lane, close criteria, verification path, and a copyable task prompt.",
+        commands: ["hermes backlog", "what should Hermes build next"],
+      },
+      {
         id: "project_admin_copilot",
         status: "readiness_enabled",
         value: "Can explain the staged path from operator copilot to approval-gated project admin, including denied actions and required controls.",
@@ -128,6 +137,7 @@ export async function getAgentUsefulnessPlan(deps: OperatorStatusDeps) {
     ],
     nextImplementationTracks: [
       "GitHub PR/issue digest and CI failure explainer",
+      "Idle-triggered Hermes backlog proposal routine using the B1 planner",
       "Admin action registry with project allowlists, approvals, audit receipts, and rollback notes",
       "Host-level ops routine for disk/log/WAL checks and stale sessions",
       "Reward ledger with chain/accounting reconciliation once payout data is exposed",

--- a/services/slack-operator/src/monitor.ts
+++ b/services/slack-operator/src/monitor.ts
@@ -60,6 +60,7 @@ function isAllowedMonitorCommand(text: string): boolean {
     /^(handoff monitor|agent handoff monitor|hermes handoff monitor|hermes monitor|what is hermes doing|current handoffs|active handoffs|handoff status)( details?| full| audit)?$/.test(text)
     || /^(github status|github open prs|github ci failures|github issue digest|merge steward|take care of open prs)( details?| full| audit)?$/.test(text)
     || /^(operator status|ops health|business ledger|daily operator brief|find safe work|admin readiness|project memory|known projects|codex handoff protocol)( details?| full| audit)?$/.test(text)
+    || /^(hermes backlog|backlog plan|roadmap backlog|roadmap plan|hermes roadmap|hermes roadmap plan|what should hermes build next|what should we build next|plan next hermes work|next hermes work)( details?| full| audit)?$/.test(text)
     || /^what (can|should) (i|we) do next( details?| full| audit)?$/.test(text)
     || /^what is happening now( details?| full| audit)?$/.test(text)
     || /^what is (codex|hermes) doing( right now)?( details?| full| audit)?$/.test(text)

--- a/services/slack-operator/src/slack.ts
+++ b/services/slack-operator/src/slack.ts
@@ -173,6 +173,30 @@ export function formatOperatorResultForSlack(result: unknown): string {
       "Read-only plan. Use `what can you do for us details` in MCP/Workspace for the full structured JSON.",
     ].filter(Boolean).join("\n");
   }
+  if (result.kind === "hermes_backlog_plan") {
+    const plan = isRecord(result.plan) ? result.plan : {};
+    const source = isRecord(plan.source) ? plan.source : {};
+    const cadence = isRecord(plan.cadence) ? plan.cadence : {};
+    const boardGate = isRecord(plan.boardGate) ? plan.boardGate : {};
+    const safety = isRecord(plan.safety) ? plan.safety : {};
+    const items = Array.isArray(plan.items) ? plan.items : [];
+    const itemLines = items.slice(0, 5).map(formatBacklogItem).join("\n");
+    return [
+      "*Hermes backlog plan*",
+      stringField(plan, "headline") ?? "Hermes has roadmap-backed proposals ready.",
+      "",
+      "*Gate*",
+      `• board: \`${stringField(boardGate, "status") ?? "unknown"}\` - ${stringField(boardGate, "reason") ?? "no reason recorded"}`,
+      `• idle eligible: \`${String(cadence.idleEligible === true)}\``,
+      "*Shortlist*",
+      itemLines || "No roadmap proposals are currently available.",
+      "*Safety*",
+      `• proposes only: \`${String(safety.proposesOnly !== false)}\``,
+      `• auto-approval unchanged: \`${String(safety.autoApprovalUnchanged !== false)}\``,
+      `• source: \`${stringField(source, "roadmap") ?? "docs/HERMES_ROADMAP.md"}\``,
+      stringField(plan, "nextOperatorStep") ?? "Pick one item and approve only when you want an agent to start.",
+    ].filter(Boolean).join("\n");
+  }
   if (result.kind === "project_memory") {
     const memory = isRecord(result.memory) ? result.memory : {};
     const selected = isRecord(memory.selectedProject) ? memory.selectedProject : undefined;
@@ -480,6 +504,18 @@ function formatUseCase(value: unknown): string {
   const status = stringField(value, "status") ?? "unknown";
   const summary = stringField(value, "value") ?? "";
   return `• \`${id}\` - ${status}${summary ? `: ${summary}` : ""}`;
+}
+
+function formatBacklogItem(value: unknown): string {
+  if (!isRecord(value)) return "• unknown";
+  const id = stringField(value, "id") ?? "unknown";
+  const title = stringField(value, "title") ?? "untitled";
+  const owner = stringField(value, "owner") ?? "unknown";
+  const riskTier = stringField(value, "riskTier") ?? "unknown";
+  const score = numberField(value, "score") ?? 0;
+  const signals = arrayField(value, "scoreSignals").slice(0, 2).map(String).join("; ");
+  const verification = arrayField(value, "verificationPath").slice(0, 2).map(String).join("; ");
+  return `• \`${id}\` ${title} - owner \`${owner}\`, risk \`${riskTier}\`, score \`${score}\`${signals ? `; why: ${signals}` : ""}${verification ? `; verify: ${verification}` : ""}`;
 }
 
 function formatAdminStage(value: unknown): string {

--- a/test/unit/hermes-backlog.test.ts
+++ b/test/unit/hermes-backlog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { getHermesBacklogPlan } from "../../packages/averray-mcp/src/hermes-backlog.js";
+
+describe("Hermes backlog plan", () => {
+  it("returns a ranked roadmap-backed shortlist without mutating", () => {
+    const plan = getHermesBacklogPlan({ now: new Date("2026-05-31T12:00:00Z"), limit: 3 });
+
+    expect(plan).toMatchObject({
+      schemaVersion: 1,
+      kind: "hermes_backlog_plan",
+      generatedAt: "2026-05-31T12:00:00.000Z",
+      mutates: false,
+      safety: {
+        proposesOnly: true,
+        autoApprovalUnchanged: true,
+      },
+      source: {
+        roadmap: "docs/HERMES_ROADMAP.md",
+      },
+    });
+    expect(plan.items).toHaveLength(3);
+    expect(plan.items.map((item) => item.id)).toEqual(["C1", "T6", "T4"]);
+    expect(plan.items[0]).toMatchObject({
+      owner: "claude",
+      riskTier: "medium",
+      trustLevel: "roadmap_sanctioned",
+      requiresOperatorApproval: true,
+    });
+    expect(plan.items[0].closeCriteria.length).toBeGreaterThan(0);
+    expect(plan.items[0].verificationPath.length).toBeGreaterThan(0);
+    expect(plan.items[0].prompt).toContain("Build C1");
+  });
+
+  it("keeps backlog idle-ineligible while live board work is active", () => {
+    const plan = getHermesBacklogPlan({
+      board: {
+        actionNeeded: 1,
+        operatorReview: 1,
+        drafts: 3,
+      },
+    });
+
+    expect(plan.cadence.idleEligible).toBe(false);
+    expect(plan.boardGate).toMatchObject({
+      status: "busy",
+      reason: "2 live cards should resolve before Hermes feeds more work.",
+    });
+    expect(plan.items[0].autoFlowEligible).toBe(true);
+  });
+
+  it("treats external drafts alone as quiet for roadmap proposals", () => {
+    const plan = getHermesBacklogPlan({
+      board: {
+        drafts: 5,
+      },
+    });
+
+    expect(plan.cadence.idleEligible).toBe(true);
+    expect(plan.boardGate.status).toBe("quiet");
+  });
+});

--- a/test/unit/operator-commands.test.ts
+++ b/test/unit/operator-commands.test.ts
@@ -124,6 +124,18 @@ describe("operator commands", () => {
       source: "command_center",
       detailed: true,
     });
+    expect(parseOperatorCommand("what should Hermes build next?", { source: "operator" })).toEqual({
+      handled: true,
+      kind: "hermes_backlog_plan",
+      source: "operator",
+      detailed: false,
+    });
+    expect(parseOperatorCommand("roadmap backlog details", { source: "command_center" })).toEqual({
+      handled: true,
+      kind: "hermes_backlog_plan",
+      source: "command_center",
+      detailed: true,
+    });
     expect(parseOperatorCommand("project memory", { source: "operator" })).toEqual({
       handled: true,
       kind: "project_memory",

--- a/test/unit/slack-monitor.test.ts
+++ b/test/unit/slack-monitor.test.ts
@@ -42,6 +42,7 @@ describe("slack operator personal monitor", () => {
   it("guards the monitor command console to read-only and proposal commands", () => {
     expect(guardMonitorCommand("merge steward details")).toMatchObject({ allowed: true });
     expect(guardMonitorCommand("ops health")).toMatchObject({ allowed: true });
+    expect(guardMonitorCommand("what should Hermes build next")).toMatchObject({ allowed: true });
     expect(guardMonitorCommand("propose deploy for averray-agent/agent sha abc1234")).toMatchObject({ allowed: true });
     expect(guardMonitorCommand("agent browser mission https://testbed.example/app goal: complete onboarding")).toMatchObject({ allowed: true });
     expect(guardMonitorCommand("agent browser mission https://testbed.example/app goal: complete onboarding test mode allow test mutations")).toMatchObject({ allowed: true });

--- a/test/unit/slack-operator.test.ts
+++ b/test/unit/slack-operator.test.ts
@@ -346,6 +346,39 @@ describe("slack operator bridge", () => {
     expect(text).toContain("GitHub PR/issue digest");
   });
 
+  it("formats Hermes backlog replies", () => {
+    const text = formatOperatorResultForSlack({
+      handled: true,
+      kind: "hermes_backlog_plan",
+      plan: {
+        headline: "Hermes can propose the next roadmap-backed work without changing authority.",
+        source: { roadmap: "docs/HERMES_ROADMAP.md" },
+        cadence: { idleEligible: true },
+        boardGate: { status: "quiet", reason: "No live cards." },
+        safety: { proposesOnly: true, autoApprovalUnchanged: true },
+        items: [
+          {
+            id: "C1",
+            title: "Cross-agent review by default",
+            owner: "claude",
+            riskTier: "medium",
+            score: 92,
+            scoreSignals: ["C4 inter-agent chat is shipped"],
+            verificationPath: ["Run one synthetic PR"],
+          },
+        ],
+        nextOperatorStep: "Pick one item and approve only when you want an agent to start.",
+      },
+    });
+
+    expect(text).toContain("*Hermes backlog plan*");
+    expect(text).toContain("board: `quiet`");
+    expect(text).toContain("`C1` Cross-agent review by default");
+    expect(text).toContain("owner `claude`");
+    expect(text).toContain("auto-approval unchanged: `true`");
+    expect(text).toContain("docs/HERMES_ROADMAP.md");
+  });
+
   it("formats project memory replies", () => {
     const list = formatOperatorResultForSlack({
       handled: true,


### PR DESCRIPTION
## What changed
- Added a read-only B1 Hermes backlog planner with ranked roadmap-backed proposals, owner/lane, close criteria, verification path, safety flags, and copyable prompts.
- Exposed the planner through MCP (`averray_hermes_backlog_plan`) and operator commands (`hermes backlog`, `what should Hermes build next`, `roadmap backlog`).
- Added Slack/monitor formatting and allowlist coverage so the board can ask Hermes what to build next without enqueueing or approving work.

## Checks
- `npm run typecheck`
- `npm test`

## Surfaces
- Backend/operator MCP and Slack monitor command surfaces.
- No frontend layout, ops, contracts, indexer, Caddy, or public site changes.

## Safety
- Read-only/proposes-only. No task enqueue, approvals, GitHub mutation, deploy, merge, or external mutation.
- Net-new discovery remains operator-escalated; high-risk work remains rule-bound.
