### PR TITLE
fix: make monitor board liveness truthful

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -166,9 +166,16 @@ describe("MonitorPage — container", () => {
     }));
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
     try {
-      const { getByRole } = render(<MonitorPage options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }} collaboration={{ enabled: false }} alerts={{ enabled: false }} autonomy={{ fetchMode: async () => null }} />, {
-        wrapper,
-      });
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
       await waitFor(() => expect(getByRole("button", { name: /Approve tester run/ })).toBeTruthy());
       fireEvent.click(getByRole("button", { name: /Approve tester run/ }));
       fireEvent.click(getByRole("button", { name: /^Confirm$/ }));

--- a/packages/monitor-ui/src/components/LanesBar.test.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.test.tsx
@@ -8,6 +8,7 @@ afterEach(cleanup);
 
 const counts: KPICounts = {
   action: 1,
+  codex: 0,
   review: 2,
   checking: 3,
   queue: 1,

--- a/packages/monitor-ui/src/components/TopStrip.test.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.test.tsx
@@ -8,6 +8,7 @@ afterEach(cleanup);
 
 const calmCounts: KPICounts = {
   action: 0,
+  codex: 0,
   review: 0,
   checking: 0,
   queue: 0,
@@ -19,6 +20,7 @@ const calmCounts: KPICounts = {
 
 const busyCounts: KPICounts = {
   action: 2,
+  codex: 2,
   review: 1,
   checking: 3,
   queue: 1,
@@ -40,6 +42,7 @@ describe("TopStrip", () => {
     const { getByText } = render(<TopStrip counts={busyCounts} />);
     // Each KPI label is present; the count lives in the sibling `.n` span.
     expect(getByText("Action needed")).toBeTruthy();
+    expect(getByText("Codex needed")).toBeTruthy();
     expect(getByText("Operator review")).toBeTruthy();
     expect(getByText("Hermes checking")).toBeTruthy();
     expect(getByText("Release queue")).toBeTruthy();

--- a/packages/monitor-ui/src/components/TopStrip.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.tsx
@@ -37,6 +37,7 @@ export function TopStrip({ counts, liveAt, deployHealth = "OK", onRefresh }: Top
 
       <div className="hm-kpis" role="status" aria-live="polite" aria-label="Board KPI counts">
         <Kpi count={counts.action} label="Action needed" tone={counts.action ? "action" : "zero"} />
+        <Kpi count={counts.codex} label="Codex needed" tone={counts.codex ? "default" : "zero"} />
         <Kpi count={counts.review} label="Operator review" tone={counts.review ? "action" : "zero"} />
         <Kpi count={counts.checking} label="Hermes checking" tone={counts.checking ? "default" : "zero"} />
         <Kpi count={counts.queue} label="Release queue" tone={counts.queue ? "default" : "zero"} />

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -36,6 +36,7 @@ test("kpiCounts: empty list returns zeros across the board", () => {
   const result = kpiCounts([]);
   assert.deepEqual(result, {
     action: 0,
+    codex: 0,
     review: 0,
     checking: 0,
     queue: 0,
@@ -51,6 +52,7 @@ test("kpiCounts: realistic mix counts each KPI correctly", () => {
     card({ id: "act-1", isAction: true }),
     card({ id: "rev-1", lane: "operator-review" }),
     card({ id: "rev-2", lane: "operator-review" }),
+    card({ id: "codex-1", type: "task", lane: "codex-needed" }),
     card({ id: "chk-1", lane: "hermes-checking" }),
     card({ id: "queue-1", lane: "release-queue" }),
     card({ id: "deploy-1", type: "deploy", deployId: "#1", verification: { current: 0, total: 1, label: "" } }),
@@ -59,13 +61,14 @@ test("kpiCounts: realistic mix counts each KPI correctly", () => {
   ];
   const result = kpiCounts(cards);
   assert.equal(result.action, 1);
+  assert.equal(result.codex, 1);
   assert.equal(result.review, 2);
   assert.equal(result.checking, 1);
   assert.equal(result.queue, 1);
   assert.equal(result.deploying, 1);
   assert.equal(result.done, 2);
-  // total = all live lanes (1+2+1+1+1) = 6
-  assert.equal(result.total, 6);
+  // total = all live lanes (1+1+2+1+1+1) = 7
+  assert.equal(result.total, 7);
   assert.equal(result.blocked, 0);
 });
 
@@ -187,9 +190,22 @@ test("boardNowBanner: calm board with in-flight automation reads correctly", () 
   ];
   const banner = boardNowBanner(cards);
   assert.equal(banner.tone, "calm");
-  assert.match(banner.headline, /automation in flight/);
+  assert.match(banner.headline, /automation\/release card/);
   // 1 checking + 1 deploying = 2
-  assert.match(banner.headline, /2 card/);
+  assert.match(banner.headline, /2 automation\/release card/);
+});
+
+test("boardNowBanner: calm board names Codex-owned work instead of claiming the board is empty", () => {
+  const cards = [
+    card({ id: "codex-1", type: "task", lane: "codex-needed", title: "Fix a failing check" }),
+    card({ id: "deploy-1", type: "deploy", deployId: "#1", verification: { current: 1, total: 3, label: "" } }),
+  ];
+  const banner = boardNowBanner(cards);
+  assert.equal(banner.tone, "calm");
+  assert.match(banner.headline, /No operator decision needed/);
+  assert.match(banner.headline, /1 Codex-owned card/);
+  assert.match(banner.headline, /1 automation\/release card/);
+  assert.notMatch(banner.headline, /Nothing in your queue/);
 });
 
 test("boardNowBanner: degraded mode (stream offline)", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -12,6 +12,7 @@ import { sortByUrgency } from "./urgency.js";
 
 export interface KPICounts {
   action: number;
+  codex: number;
   review: number;
   checking: number;
   queue: number;
@@ -61,6 +62,7 @@ export function kpiCounts(cards: BoardCard[]): KPICounts {
     counts["deploying"];
   return {
     action: counts["needs-attention"],
+    codex: counts["codex-needed"],
     review: counts["operator-review"],
     checking: counts["hermes-checking"],
     queue: counts["release-queue"],
@@ -135,16 +137,29 @@ export function boardNowBanner(cards: BoardCard[], opts: DeriveBoardOpts = {}): 
   return {
     tone: "calm",
     eyebrow: now ? `Board now · ${now} · you're done for now` : `Board now · you're done for now`,
-    headline:
-      counts.total === 0
-        ? `Nothing waits on you. Everything in flight is automation; the day's release history is below.`
-        : `Nothing in your queue right now. ${counts.checking + counts.queue + counts.deploying} card(s) are still automation in flight; Hermes is watching.`,
+    headline: calmHeadline(counts),
     sub:
       counts.done > 0
         ? `${counts.done} card(s) shipped today; you can step away.`
         : `No releases yet today; you can step away.`,
     primaryActionId: undefined,
   };
+}
+
+function calmHeadline(counts: KPICounts): string {
+  if (counts.total === 0) {
+    return "Nothing waits on you. Everything in flight is automation; the day's release history is below.";
+  }
+
+  const automationCount = counts.checking + counts.queue + counts.deploying;
+  const parts = [
+    counts.codex > 0 ? `${counts.codex} Codex-owned card(s)` : "",
+    automationCount > 0 ? `${automationCount} automation/release card(s)` : "",
+  ].filter(Boolean);
+  if (parts.length === 0) {
+    return `${counts.total} card(s) are still in flight; Hermes is watching.`;
+  }
+  return `No operator decision needed. ${parts.join(" and ")} are still in flight; Hermes is watching.`;
 }
 
 /** Aggregate selector — everything the board page needs in one call. */

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -1045,7 +1045,9 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       ...(board ? { board } : {}),
     };
     const memoryRequest = classifyHermesMemoryRequest(operatorMessage);
-    if (memoryRequest !== "none") {
+    if (draft.force) {
+      text = draft.text;
+    } else if (memoryRequest !== "none") {
       text = hermesMemoryGovernanceReply(operatorMessage, memoryRequest, memoryNotes);
     } else if (apiKey) {
       try {

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -726,6 +726,8 @@ export interface HermesReplyDraft {
   addressedTo: CollaborationTarget;
   relatedPr?: CollaborationRelatedPr;
   relatedCorrelationId?: string;
+  /** Skip LLM rewrite because this draft guards a truth boundary. */
+  force?: boolean;
 }
 
 export function synthesizeHermesReplyFor(message: CollaborationMessage): HermesReplyDraft | null {
@@ -738,6 +740,16 @@ export function synthesizeHermesReplyFor(message: CollaborationMessage): HermesR
   const prRef = message.relatedPr
     ? `${message.relatedPr.repo}#${message.relatedPr.number}`
     : null;
+  const dispatchGuard = codexDispatchGuardReply(message.text, prRef);
+  if (dispatchGuard) {
+    return {
+      text: dispatchGuard,
+      addressedTo: "operator",
+      ...(message.relatedPr ? { relatedPr: message.relatedPr } : {}),
+      ...(message.relatedCorrelationId ? { relatedCorrelationId: message.relatedCorrelationId } : {}),
+      force: true,
+    };
+  }
 
   let text: string;
   if (message.kind === "request_help") {
@@ -764,4 +776,23 @@ export function synthesizeHermesReplyFor(message: CollaborationMessage): HermesR
     ...(message.relatedPr ? { relatedPr: message.relatedPr } : {}),
     ...(message.relatedCorrelationId ? { relatedCorrelationId: message.relatedCorrelationId } : {}),
   };
+}
+
+function codexDispatchGuardReply(text: string, prRef: string | null): string | null {
+  const lower = text.toLowerCase();
+  const namesCodex = /\bcodex\b/.test(lower);
+  const dispatchVerb = /\b(send|hand|assign|route|delegate|move|pass|give)\b/.test(lower)
+    || /\btake\s+(?:this|it|over|on)\b/.test(lower)
+    || /\bpick\s+(?:this|it|up)\b/.test(lower);
+  if (!namesCodex || !dispatchVerb) return null;
+
+  return prRef
+    ? [
+      `I can help route ${prRef}, but plain chat does not dispatch Codex.`,
+      `Use \`/task codex ${prRef} <concrete prompt>\` or the card approval control; until then no runner has been queued.`,
+    ].join(" ")
+    : [
+      'I cannot dispatch "it" from board-scoped chat.',
+      "Select a card or use `/task codex owner/repo#PR <concrete prompt>`; until then no runner has been queued.",
+    ].join(" ");
 }

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -691,6 +691,32 @@ describe("synthesizeHermesReplyFor", () => {
     expect(reply?.relatedPr).toEqual({ repo: "averray-agent/agent", number: 137 });
   });
 
+  it("does not imply plain chat dispatched Codex work", () => {
+    const m = opMessage({
+      addressedTo: "hermes",
+      text: "send it to codex",
+    });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply?.text).toContain("board-scoped chat");
+    expect(reply?.text).toContain("/task codex owner/repo#PR");
+    expect(reply?.text).toContain("no runner has been queued");
+    expect(reply?.force).toBe(true);
+  });
+
+  it("gives the exact slash-command shape when a Codex dispatch ask is scoped to a PR", () => {
+    const m = opMessage({
+      addressedTo: "hermes",
+      text: "please hand this back to Codex",
+      relatedPr: { repo: "depre-dev/averray-reference-agent", number: 301 },
+    });
+    const reply = synthesizeHermesReplyFor(m);
+    expect(reply?.text).toContain("depre-dev/averray-reference-agent#301");
+    expect(reply?.text).toContain("/task codex depre-dev/averray-reference-agent#301");
+    expect(reply?.text).toContain("no runner has been queued");
+    expect(reply?.relatedPr).toEqual({ repo: "depre-dev/averray-reference-agent", number: 301 });
+    expect(reply?.force).toBe(true);
+  });
+
   it("uses a help-specific reply for request_help intent", () => {
     const m = opMessage({ kind: "request_help" });
     const reply = synthesizeHermesReplyFor(m);


### PR DESCRIPTION
## Summary
- expose Codex-owned work in the board KPI strip so a board with Codex-needed cards no longer reads as empty
- make the calm banner describe Codex-owned and automation/release cards instead of saying there is nothing in the queue
- add a truth-boundary guard for Hermes chat so free-form requests like "send it to Codex" explain that only `/task codex ...` or card approval queues a runner

## Root cause
The monitor counted `codex-needed` cards in the lane total but did not expose them in the KPI strip or calm headline, so the screenshot could show visible Codex cards while the top summary said there was nothing to do. Separately, Hermes free-form chat replies could be rewritten as if a dispatch happened even though plain chat does not mutate runner state.

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`
- Local visual smoke at `http://127.0.0.1:5177/` (degraded mode locally because the live SSE backend is not attached here)

## Affected surfaces
- Monitor UI board summary/top strip
- Hermes co-pilot collaboration reply guardrail
- Tests only for monitor page backlog suggestion fetch isolation

## Env / deploy notes
- No env or secret changes.
- Frontend/monitor-service behavior only; no production deploy action from this PR.