### PR TITLE
feat: add high-risk reviewer panel

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -72,6 +72,28 @@ describe("Card — type coverage", () => {
     expect(container.querySelector(".hm-review-request")).toBeTruthy();
   });
 
+  test("card shows high-risk reviewer panels as a panel, not a single reviewer", () => {
+    const card: BoardCard = {
+      ...fixture("agent #547"),
+      reviewRequests: ["hermes", "codex", "claude"].map((reviewer) => ({
+        id: `review-${reviewer}`,
+        requestedBy: "hermes",
+        reviewer: reviewer as "hermes" | "codex" | "claude",
+        reason: "High-risk panel before operator decision.",
+        status: "requested",
+        reviewMode: "panel",
+        panelId: "panel-1",
+        panelSize: 3,
+        createdAt: "2026-05-31T12:00:00.000Z",
+        updatedAt: "2026-05-31T12:00:00.000Z",
+      })),
+    };
+
+    const { container } = render(<Card card={card} />);
+    expect(within(container).getByText("Panel review")).toBeTruthy();
+    expect(within(container).getByText("Hermes, Codex, Claude")).toBeTruthy();
+  });
+
   test("draft PR shows the draft pill", () => {
     const { container } = render(<Card card={fixture("agent #550")} />);
     expect(within(container).getByText("draft")).toBeTruthy();

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -246,12 +246,16 @@ function ReviewRequestedLine({ card }: { card: BoardCard }) {
   const active = card.reviewRequests?.filter((request) => request.status === "requested") ?? [];
   const first = active[0];
   if (!first) return null;
-  const suffix = active.length > 1 ? ` +${active.length - 1}` : "";
+  const isPanel = active.length > 1 || first.reviewMode === "panel";
+  const label = isPanel ? "Panel review" : "Review requested";
+  const reviewers = isPanel
+    ? active.map((request) => actorDisplayName(request.reviewer)).join(", ")
+    : actorDisplayName(first.reviewer);
   return (
-    <div className="hm-review-request" aria-label={`Review requested from ${actorDisplayName(first.reviewer)}`}>
+    <div className="hm-review-request" aria-label={`${label} from ${reviewers}`}>
       <span className="hm-review-request-dot" aria-hidden />
-      <span>Review requested</span>
-      <strong>{actorDisplayName(first.reviewer)}{suffix}</strong>
+      <span>{label}</span>
+      <strong>{reviewers}</strong>
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -9,6 +9,7 @@ import type {
   CardCheckRun,
   CardChecks,
   CardFile,
+  CardReviewRequest,
   CardRiskSignal,
   DeployCard,
   DoneCard,
@@ -174,6 +175,13 @@ const RISK_PILL: Record<CardRiskSignal["severity"], string> = {
   low: "hm-pill hm-pill--neutral",
 };
 
+function actorDisplayName(actor: CardReviewRequest["reviewer"]): string {
+  if (actor === "hermes") return "Hermes";
+  if (actor === "operator") return "Pascal";
+  if (actor === "claude") return "Claude";
+  return "Codex";
+}
+
 function RiskSignalsSection({ signals }: { signals: CardRiskSignal[] | undefined }) {
   if (!signals || signals.length === 0) return null;
   return (
@@ -186,6 +194,33 @@ function RiskSignalsSection({ signals }: { signals: CardRiskSignal[] | undefined
               {s.message}
             </span>
             <span className={RISK_PILL[s.severity]}>{s.severity}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function ReviewRequestsSection({ requests }: { requests: CardReviewRequest[] | undefined }) {
+  const active = requests?.filter((request) => request.status === "requested" || request.response) ?? [];
+  if (active.length === 0) return null;
+  const isPanel = active.length > 1 || active.some((request) => request.reviewMode === "panel");
+  return (
+    <section>
+      <div className="hm-section-h">{isPanel ? "Reviewer panel" : "Cross-agent review"}</div>
+      <div className="hm-files">
+        {active.map((request) => (
+          <div className="row" key={request.id}>
+            <span className="path" style={{ whiteSpace: "normal" }}>
+              <b>{actorDisplayName(request.reviewer)}</b>
+              {" · "}
+              {request.response
+                ? `${request.response.verdict}: ${request.response.reasoning}`
+                : request.reason}
+            </span>
+            <span className={request.response?.verdict === "block" ? "hm-pill hm-pill--risk" : "hm-pill hm-pill--neutral"}>
+              {request.response?.verdict ?? "requested"}
+            </span>
           </div>
         ))}
       </div>
@@ -235,6 +270,7 @@ function PrBody({ card }: { card: BoardCard }) {
       ) : (
         <VerdictBlock head="Status">{card.summary || "No additional context yet."}</VerdictBlock>
       )}
+      <ReviewRequestsSection requests={card.reviewRequests} />
       <RiskSignalsSection signals={card.riskSignals} />
       <FilesSection files={files} />
       <ChecksSection checks={card.checks} checkRuns={card.checkRuns} />

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -83,6 +83,14 @@ export interface CardReviewRequest {
   reviewer: "codex" | "claude" | "hermes" | "operator";
   reason: string;
   status: "requested" | "responded" | "cancelled";
+  reviewMode?: "single" | "panel";
+  panelId?: string;
+  panelSize?: number;
+  response?: {
+    verdict: "pass" | "concern" | "block";
+    reasoning: string;
+    respondedAt: string;
+  };
   createdAt: string;
   updatedAt: string;
 }

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -42,6 +42,7 @@ import {
   listReviewRequests,
   recordCollaborationMessage,
   recordHermesMemoryNote,
+  recordReviewPanelRequests,
   recordReviewRequest,
   synthesizeHermesReplyFor,
   type ReviewRequestStatus,
@@ -821,6 +822,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     await handleMonitorReviewRequest(request, response);
     return;
   }
+  if (request.method === "POST" && url.pathname === "/monitor/review-panels") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorReviewPanelRequest(request, response);
+    return;
+  }
   if (request.method === "POST" && url.pathname === "/monitor/collaboration") {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
@@ -898,6 +911,37 @@ async function handleMonitorReviewRequest(request: http.IncomingMessage, respons
     logger.error({ err: error }, "monitor_review_request_failed");
     writeJson(response, 500, {
       error: "monitor_review_request_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorReviewPanelRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const panel = recordReviewPanelRequests(payload);
+    logger.info(
+      {
+        panelId: panel.panelId,
+        mode: panel.mode,
+        reviewers: panel.reviewers,
+      },
+      "monitor_review_panel_recorded"
+    );
+    writeJson(response, 200, { ok: true, panel });
+  } catch (error) {
+    if (error instanceof CollaborationValidationError) {
+      writeJson(response, 400, { error: error.code, message: error.message });
+      return;
+    }
+    logger.error({ err: error }, "monitor_review_panel_failed");
+    writeJson(response, 500, {
+      error: "monitor_review_panel_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -1,5 +1,10 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
+import {
+  planReviewForRisk,
+  type ReviewPanelMode,
+  type ReviewPanelVerdict,
+} from "./reviewer-panel.js";
 
 /**
  * In-memory collaboration channel for the Hermes Handoff Monitor.
@@ -73,6 +78,14 @@ export interface ReviewRequest {
   reviewer: ReviewRequestReviewer;
   reason: string;
   status: ReviewRequestStatus;
+  reviewMode?: ReviewPanelMode;
+  panelId?: string;
+  panelSize?: number;
+  response?: {
+    verdict: ReviewPanelVerdict;
+    reasoning: string;
+    respondedAt: string;
+  };
   createdAt: string;
   updatedAt: string;
 }
@@ -106,6 +119,29 @@ export interface RecordReviewRequestInput {
   reviewer?: unknown;
   reason?: unknown;
   status?: unknown;
+  reviewMode?: unknown;
+  panelId?: unknown;
+  panelSize?: unknown;
+  response?: unknown;
+}
+
+export interface RecordReviewPanelInput {
+  relatedPr?: unknown;
+  relatedMission?: unknown;
+  correlationId?: unknown;
+  relatedCorrelationId?: unknown;
+  requestedBy?: unknown;
+  riskTier?: unknown;
+  builder?: unknown;
+  reason?: unknown;
+}
+
+export interface RecordReviewPanelResult {
+  panelId: string;
+  mode: ReviewPanelMode;
+  reviewers: ReviewRequestReviewer[];
+  requests: ReviewRequest[];
+  reason: string;
 }
 
 export interface ListCollaborationOptions {
@@ -253,6 +289,10 @@ export function recordReviewRequest(
     );
   }
   const at = new Date(nowMs).toISOString();
+  const reviewMode = normalizeReviewMode(input.reviewMode);
+  const panelId = normalizeCorrelationId(input.panelId);
+  const panelSize = normalizePositiveInteger(input.panelSize);
+  const response = normalizeReviewResponse(input.response, at);
   const request: ReviewRequest = {
     id: nextReviewRequestId(nowMs),
     ...(relatedPr ? { relatedPr } : {}),
@@ -262,6 +302,10 @@ export function recordReviewRequest(
     reviewer,
     reason,
     status: status ?? "requested",
+    ...(reviewMode ? { reviewMode } : {}),
+    ...(panelId ? { panelId } : {}),
+    ...(panelSize ? { panelSize } : {}),
+    ...(response ? { response } : {}),
     createdAt: at,
     updatedAt: at,
   };
@@ -270,6 +314,57 @@ export function recordReviewRequest(
   while (reviewRequests.length > MAX_REVIEW_REQUESTS) reviewRequests.shift();
   recordReviewRequestCollaborationTurn(request, nowMs);
   return request;
+}
+
+export function recordReviewPanelRequests(
+  input: RecordReviewPanelInput,
+  nowMs: number = Date.now()
+): RecordReviewPanelResult {
+  const requestedBy = normalizeRequester(input.requestedBy);
+  if (!requestedBy) {
+    throw new CollaborationValidationError(
+      "invalid_requested_by",
+      "requestedBy must be one of: hermes, operator, codex, claude."
+    );
+  }
+
+  const relatedPr = normalizeRelatedPr(input.relatedPr);
+  const relatedMission = normalizeRelatedMission(input.relatedMission);
+  const correlationId = normalizeCorrelationId(input.correlationId) ?? normalizeCorrelationId(input.relatedCorrelationId);
+  if (!relatedPr && !relatedMission && !correlationId) {
+    throw new CollaborationValidationError(
+      "missing_review_scope",
+      "review panel must include relatedPr, relatedMission, or correlationId."
+    );
+  }
+
+  const plan = planReviewForRisk({
+    riskTier: typeof input.riskTier === "string" ? input.riskTier : undefined,
+    builder: typeof input.builder === "string" ? input.builder : undefined,
+    reason: normalizeText(input.reason),
+  });
+  const panelId = nextReviewPanelId(nowMs);
+  const requests = plan.reviewers.map((reviewer) =>
+    recordReviewRequest({
+      ...(relatedPr ? { relatedPr } : {}),
+      ...(relatedMission ? { relatedMission } : {}),
+      ...(correlationId ? { correlationId } : {}),
+      requestedBy,
+      reviewer,
+      reason: plan.reason,
+      reviewMode: plan.mode,
+      panelId,
+      panelSize: plan.reviewers.length,
+    }, nowMs)
+  );
+
+  return {
+    panelId,
+    mode: plan.mode,
+    reviewers: requests.map((request) => request.reviewer),
+    requests,
+    reason: plan.reason,
+  };
 }
 
 export function listReviewRequests(options: ListReviewRequestsOptions = {}): ReviewRequest[] {
@@ -377,6 +472,25 @@ function normalizeReviewStatus(value: unknown): ReviewRequestStatus | null {
   return null;
 }
 
+function normalizeReviewMode(value: unknown): ReviewPanelMode | undefined {
+  if (value == null || value === "") return undefined;
+  if (value === "single" || value === "panel") return value;
+  return undefined;
+}
+
+function normalizeReviewResponse(value: unknown, fallbackRespondedAt: string): ReviewRequest["response"] | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const obj = value as Record<string, unknown>;
+  const verdict = obj.verdict;
+  if (verdict !== "pass" && verdict !== "concern" && verdict !== "block") return undefined;
+  const reasoning = normalizeText(obj.reasoning);
+  if (!reasoning) return undefined;
+  const respondedAt = typeof obj.respondedAt === "string" && obj.respondedAt.trim()
+    ? obj.respondedAt.trim()
+    : fallbackRespondedAt;
+  return { verdict, reasoning, respondedAt };
+}
+
 function normalizeText(value: unknown): string {
   if (typeof value !== "string") return "";
   const trimmed = value.trim();
@@ -406,6 +520,12 @@ function normalizeCorrelationId(value: unknown): string | undefined {
   return trimmed ? trimmed.slice(0, 256) : undefined;
 }
 
+function normalizePositiveInteger(value: unknown): number | undefined {
+  const number = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  if (!Number.isInteger(number) || number < 1) return undefined;
+  return number;
+}
+
 function clampLimit(value: unknown, max: number = MAX_MESSAGES): number {
   if (!Number.isFinite(value as number)) return max;
   const n = Math.floor(Number(value));
@@ -421,6 +541,11 @@ function nextId(nowMs: number): string {
 function nextReviewRequestId(nowMs: number): string {
   reviewRequestSeq = (reviewRequestSeq + 1) % 1_000_000;
   return `review-${nowMs.toString(36)}-${reviewRequestSeq.toString(36)}`;
+}
+
+function nextReviewPanelId(nowMs: number): string {
+  reviewRequestSeq = (reviewRequestSeq + 1) % 1_000_000;
+  return `review-panel-${nowMs.toString(36)}-${reviewRequestSeq.toString(36)}`;
 }
 
 function nextMemoryId(nowMs: number): string {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -122,6 +122,14 @@ export interface CardReviewRequest {
   reviewer: "codex" | "claude" | "hermes" | "operator";
   reason: string;
   status: "requested" | "responded" | "cancelled";
+  reviewMode?: "single" | "panel";
+  panelId?: string;
+  panelSize?: number;
+  response?: {
+    verdict: "pass" | "concern" | "block";
+    reasoning: string;
+    respondedAt: string;
+  };
   createdAt: string;
   updatedAt: string;
 }
@@ -677,6 +685,10 @@ function reviewRequestsFromSnapshot(rawSnapshot: unknown): CardReviewRequestWith
     const reviewer = asReviewActor(request.reviewer);
     const reason = asString(request.reason);
     const status = asReviewStatus(request.status);
+    const reviewMode = asReviewMode(request.reviewMode);
+    const panelId = asString(request.panelId);
+    const panelSize = asFiniteNumber(request.panelSize);
+    const response = asReviewResponse(request.response);
     const createdAt = asString(request.createdAt);
     const updatedAt = asString(request.updatedAt);
     if (!id || !requestedBy || !reviewer || !reason || !status || !createdAt || !updatedAt) continue;
@@ -688,6 +700,10 @@ function reviewRequestsFromSnapshot(rawSnapshot: unknown): CardReviewRequestWith
       reviewer,
       reason,
       status,
+      ...(reviewMode ? { reviewMode } : {}),
+      ...(panelId ? { panelId } : {}),
+      ...(panelSize ? { panelSize } : {}),
+      ...(response ? { response } : {}),
       createdAt,
       updatedAt,
       relatedPrKey: prKey(asString(relatedPr?.repo), asFiniteNumber(relatedPr?.number)),
@@ -714,13 +730,29 @@ function asReviewStatus(value: unknown): CardReviewRequest["status"] | undefined
   return undefined;
 }
 
+function asReviewMode(value: unknown): CardReviewRequest["reviewMode"] | undefined {
+  if (value === "single" || value === "panel") return value;
+  return undefined;
+}
+
+function asReviewResponse(value: unknown): CardReviewRequest["response"] | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const verdict = record.verdict;
+  if (verdict !== "pass" && verdict !== "concern" && verdict !== "block") return undefined;
+  const reasoning = asString(record.reasoning);
+  const respondedAt = asString(record.respondedAt);
+  if (!reasoning || !respondedAt) return undefined;
+  return { verdict, reasoning, respondedAt };
+}
+
 function attachReviewRequests(
   card: BoardCard,
   requests: readonly CardReviewRequestWithScope[],
   scope: { relatedPrKey?: string; relatedMissionId?: string; correlationId?: string }
 ): BoardCard {
   const active = requests
-    .filter((request) => request.status === "requested")
+    .filter((request) => request.status === "requested" || request.response !== undefined)
     .filter((request) =>
       (scope.relatedPrKey !== undefined && request.relatedPrKey === scope.relatedPrKey)
       || (scope.relatedMissionId !== undefined && request.relatedMissionId === scope.relatedMissionId)

--- a/services/slack-operator/src/reviewer-panel.ts
+++ b/services/slack-operator/src/reviewer-panel.ts
@@ -1,0 +1,174 @@
+export type ReviewPanelRiskTier = "low" | "medium" | "high";
+export type ReviewPanelBuilder = "codex" | "claude";
+export type ReviewPanelReviewer = "hermes" | "codex" | "claude";
+export type ReviewPanelMode = "single" | "panel";
+export type ReviewPanelVerdict = "pass" | "concern" | "block";
+export type ReviewPanelAgreement = "pending" | "agreement" | "majority" | "split" | "blocked";
+
+export interface ReviewPanelPlanInput {
+  riskTier?: ReviewPanelRiskTier | string;
+  builder?: ReviewPanelBuilder | string;
+  reason?: string;
+}
+
+export interface ReviewPanelPlan {
+  mode: ReviewPanelMode;
+  reviewers: ReviewPanelReviewer[];
+  reason: string;
+}
+
+export interface ReviewPanelResponse {
+  reviewer: ReviewPanelReviewer;
+  verdict: ReviewPanelVerdict;
+  reasoning: string;
+}
+
+export interface ReviewPanelEvaluationInput {
+  panelId: string;
+  relatedLabel: string;
+  reviewers: ReviewPanelReviewer[];
+  responses: ReviewPanelResponse[];
+  boardUrl?: string;
+}
+
+export interface ReviewPanelEvaluation {
+  panelId: string;
+  relatedLabel: string;
+  agreement: ReviewPanelAgreement;
+  panelVerdict: ReviewPanelVerdict | "pending";
+  escalate: boolean;
+  summary: string;
+  reviewers: ReviewPanelResponse[];
+  alert?: {
+    count: number;
+    items: Array<{ id: string; title: string }>;
+    boardUrl: string;
+    text: string;
+  };
+}
+
+export const HIGH_RISK_REVIEW_PANEL: ReviewPanelReviewer[] = ["hermes", "codex", "claude"];
+
+export function planReviewForRisk(input: ReviewPanelPlanInput): ReviewPanelPlan {
+  if (input.riskTier === "high") {
+    return {
+      mode: "panel",
+      reviewers: [...HIGH_RISK_REVIEW_PANEL],
+      reason: input.reason || "High-risk surface: request independent Hermes, Codex, and Claude review before operator decision.",
+    };
+  }
+
+  const reviewer = nonBuilderReviewer(input.builder);
+  return {
+    mode: "single",
+    reviewers: [reviewer],
+    reason: input.reason || `Cross-agent review: ${displayName(reviewer)} reviews the builder's PR before Hermes/operator sign-off.`,
+  };
+}
+
+export function evaluateReviewPanel(input: ReviewPanelEvaluationInput): ReviewPanelEvaluation {
+  const responsesByReviewer = new Map(input.responses.map((response) => [response.reviewer, response]));
+  const reviewers = input.reviewers.map((reviewer) => responsesByReviewer.get(reviewer)).filter(Boolean) as ReviewPanelResponse[];
+  const pendingCount = input.reviewers.length - reviewers.length;
+
+  if (pendingCount > 0) {
+    return {
+      panelId: input.panelId,
+      relatedLabel: input.relatedLabel,
+      agreement: "pending",
+      panelVerdict: "pending",
+      escalate: false,
+      reviewers,
+      summary: `Panel is waiting on ${pendingCount} reviewer${pendingCount === 1 ? "" : "s"} for ${input.relatedLabel}.`,
+    };
+  }
+
+  const blocker = reviewers.find((reviewer) => reviewer.verdict === "block");
+  if (blocker) {
+    return withEscalation(input, reviewers, {
+      agreement: "blocked",
+      panelVerdict: "block",
+      summary: `${displayName(blocker.reviewer)} blocked ${input.relatedLabel}; operator decision required.`,
+    });
+  }
+
+  const counts = verdictCounts(reviewers);
+  const top = topVerdict(counts);
+  const unanimous = top.count === reviewers.length;
+  if (unanimous) {
+    return {
+      panelId: input.panelId,
+      relatedLabel: input.relatedLabel,
+      agreement: "agreement",
+      panelVerdict: top.verdict,
+      escalate: false,
+      reviewers,
+      summary: `Reviewer panel agrees: ${top.verdict} for ${input.relatedLabel}.`,
+    };
+  }
+
+  if (top.count > reviewers.length / 2) {
+    return {
+      panelId: input.panelId,
+      relatedLabel: input.relatedLabel,
+      agreement: "majority",
+      panelVerdict: top.verdict,
+      escalate: false,
+      reviewers,
+      summary: `Reviewer panel majority: ${top.verdict} for ${input.relatedLabel}; minority reasoning remains attached for the operator.`,
+    };
+  }
+
+  return withEscalation(input, reviewers, {
+    agreement: "split",
+    panelVerdict: "concern",
+    summary: `Reviewer panel split on ${input.relatedLabel}; operator decision required.`,
+  });
+}
+
+function withEscalation(
+  input: ReviewPanelEvaluationInput,
+  reviewers: ReviewPanelResponse[],
+  result: Pick<ReviewPanelEvaluation, "agreement" | "panelVerdict" | "summary">
+): ReviewPanelEvaluation {
+  const boardUrl = input.boardUrl || "/monitor";
+  return {
+    panelId: input.panelId,
+    relatedLabel: input.relatedLabel,
+    ...result,
+    escalate: true,
+    reviewers,
+    alert: {
+      count: 1,
+      items: [{ id: input.panelId, title: `Reviewer panel needs operator decision: ${input.relatedLabel}` }],
+      boardUrl,
+      text: `${result.summary}\n${reviewers.map((reviewer) =>
+        `${displayName(reviewer.reviewer)}: ${reviewer.verdict} — ${reviewer.reasoning}`
+      ).join("\n")}`,
+    },
+  };
+}
+
+function nonBuilderReviewer(builder: unknown): ReviewPanelReviewer {
+  if (builder === "codex") return "claude";
+  if (builder === "claude") return "codex";
+  return "claude";
+}
+
+function verdictCounts(responses: ReviewPanelResponse[]): Array<{ verdict: ReviewPanelVerdict; count: number }> {
+  const counts: Record<ReviewPanelVerdict, number> = { pass: 0, concern: 0, block: 0 };
+  for (const response of responses) counts[response.verdict] += 1;
+  return (Object.entries(counts) as Array<[ReviewPanelVerdict, number]>)
+    .map(([verdict, count]) => ({ verdict, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+function topVerdict(counts: Array<{ verdict: ReviewPanelVerdict; count: number }>): { verdict: ReviewPanelVerdict; count: number } {
+  return counts[0] ?? { verdict: "concern", count: 0 };
+}
+
+function displayName(reviewer: ReviewPanelReviewer): string {
+  if (reviewer === "hermes") return "Hermes";
+  if (reviewer === "claude") return "Claude";
+  return "Codex";
+}

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -12,6 +12,7 @@ import {
   listReviewRequests,
   recordCollaborationMessage,
   recordHermesMemoryNote,
+  recordReviewPanelRequests,
   recordReviewRequest,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
@@ -288,6 +289,54 @@ describe("monitor review requests", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("fans a high-risk panel into independent Hermes, Codex, and Claude review requests", () => {
+    const panel = recordReviewPanelRequests(
+      {
+        relatedPr: { repo: "depre-dev/averray-reference-agent", number: 302 },
+        requestedBy: "hermes",
+        riskTier: "high",
+        builder: "codex",
+        reason: "High-risk deploy and secret surface touched.",
+      },
+      NOW
+    );
+
+    expect(panel.mode).toBe("panel");
+    expect(panel.reviewers).toEqual(["hermes", "codex", "claude"]);
+    expect(panel.requests).toHaveLength(3);
+    expect(new Set(panel.requests.map((request) => request.panelId))).toEqual(new Set([panel.panelId]));
+    expect(panel.requests.map((request) => request.reviewMode)).toEqual(["panel", "panel", "panel"]);
+    expect(listReviewRequests({ status: "requested" })).toHaveLength(3);
+    expect(listCollaborationMessages({ limit: 5 }, NOW + 1).map((message) => message.addressedTo)).toEqual([
+      "hermes",
+      "codex",
+      "claude",
+    ]);
+  });
+
+  it("keeps non-high-risk review panels on the single C1 cross-agent path", () => {
+    const panel = recordReviewPanelRequests(
+      {
+        correlationId: "github-pr-302",
+        requestedBy: "hermes",
+        riskTier: "low",
+        builder: "codex",
+      },
+      NOW
+    );
+
+    expect(panel).toMatchObject({
+      mode: "single",
+      reviewers: ["claude"],
+    });
+    expect(panel.requests).toHaveLength(1);
+    expect(panel.requests[0]).toMatchObject({
+      reviewer: "claude",
+      reviewMode: "single",
+      panelSize: 1,
+    });
   });
 });
 

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -652,7 +652,7 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     expect(card?.files).toEqual([{ path: "ops/deploy.staging.yml", diff: "", critical: false }]);
   });
 
-  it("attaches active cross-agent review requests to matching cards", () => {
+  it("attaches active and responded panel review requests to matching cards", () => {
     const raw = {
       active: [
         {
@@ -675,6 +675,9 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
           reviewer: "claude",
           reason: "Second-agent review before this moves forward.",
           status: "requested",
+          reviewMode: "panel",
+          panelId: "panel-1",
+          panelSize: 3,
           createdAt: "2026-05-31T12:00:00.000Z",
           updatedAt: "2026-05-31T12:00:00.000Z",
         },
@@ -688,6 +691,24 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
           createdAt: "2026-05-31T11:00:00.000Z",
           updatedAt: "2026-05-31T11:30:00.000Z",
         },
+        {
+          id: "review-3",
+          relatedPr: { repo: "depre-dev/agent", number: 548 },
+          requestedBy: "hermes",
+          reviewer: "hermes",
+          reason: "Hermes panel response.",
+          status: "responded",
+          reviewMode: "panel",
+          panelId: "panel-1",
+          panelSize: 3,
+          response: {
+            verdict: "pass",
+            reasoning: "Hermes sees the checks and rollout notes as sufficient.",
+            respondedAt: "2026-05-31T12:05:00.000Z",
+          },
+          createdAt: "2026-05-31T12:00:00.000Z",
+          updatedAt: "2026-05-31T12:05:00.000Z",
+        },
       ],
     };
 
@@ -700,8 +721,28 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
         reviewer: "claude",
         reason: "Second-agent review before this moves forward.",
         status: "requested",
+        reviewMode: "panel",
+        panelId: "panel-1",
+        panelSize: 3,
         createdAt: "2026-05-31T12:00:00.000Z",
         updatedAt: "2026-05-31T12:00:00.000Z",
+      },
+      {
+        id: "review-3",
+        requestedBy: "hermes",
+        reviewer: "hermes",
+        reason: "Hermes panel response.",
+        status: "responded",
+        reviewMode: "panel",
+        panelId: "panel-1",
+        panelSize: 3,
+        response: {
+          verdict: "pass",
+          reasoning: "Hermes sees the checks and rollout notes as sufficient.",
+          respondedAt: "2026-05-31T12:05:00.000Z",
+        },
+        createdAt: "2026-05-31T12:00:00.000Z",
+        updatedAt: "2026-05-31T12:05:00.000Z",
       },
     ]);
   });

--- a/test/unit/reviewer-panel.test.ts
+++ b/test/unit/reviewer-panel.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateReviewPanel,
+  planReviewForRisk,
+  type ReviewPanelResponse,
+} from "../../services/slack-operator/src/reviewer-panel.js";
+
+describe("C2 reviewer panel", () => {
+  it("fans high-risk work out to Hermes plus both builder agents", () => {
+    const plan = planReviewForRisk({ riskTier: "high", reason: "contracts touched" });
+
+    expect(plan).toEqual({
+      mode: "panel",
+      reviewers: ["hermes", "codex", "claude"],
+      reason: "contracts touched",
+    });
+  });
+
+  it("keeps low/medium work on the single non-builder C1 review path", () => {
+    expect(planReviewForRisk({ riskTier: "low", builder: "codex" })).toMatchObject({
+      mode: "single",
+      reviewers: ["claude"],
+    });
+    expect(planReviewForRisk({ riskTier: "medium", builder: "claude" })).toMatchObject({
+      mode: "single",
+      reviewers: ["codex"],
+    });
+  });
+
+  it("returns panel PASS when all independent reviewers agree", () => {
+    const evaluation = evaluateReviewPanel({
+      panelId: "panel-1",
+      relatedLabel: "agent#404",
+      reviewers: ["hermes", "codex", "claude"],
+      responses: responses("pass", "pass", "pass"),
+    });
+
+    expect(evaluation).toMatchObject({
+      agreement: "agreement",
+      panelVerdict: "pass",
+      escalate: false,
+    });
+  });
+
+  it("allows a no-block majority while keeping minority reasoning attached", () => {
+    const evaluation = evaluateReviewPanel({
+      panelId: "panel-2",
+      relatedLabel: "agent#405",
+      reviewers: ["hermes", "codex", "claude"],
+      responses: responses("pass", "pass", "concern"),
+    });
+
+    expect(evaluation).toMatchObject({
+      agreement: "majority",
+      panelVerdict: "pass",
+      escalate: false,
+    });
+    expect(evaluation.reviewers).toHaveLength(3);
+  });
+
+  it("escalates disagreement with every reviewer verdict in the D4 alert payload", () => {
+    const evaluation = evaluateReviewPanel({
+      panelId: "panel-3",
+      relatedLabel: "agent#406",
+      reviewers: ["hermes", "codex", "claude"],
+      responses: [
+        { reviewer: "hermes", verdict: "pass", reasoning: "checks are green" },
+        { reviewer: "codex", verdict: "concern", reasoning: "migration rollback unclear" },
+        { reviewer: "claude", verdict: "block", reasoning: "secret boundary changed" },
+      ],
+      boardUrl: "https://monitor.example/monitor",
+    });
+
+    expect(evaluation).toMatchObject({
+      agreement: "blocked",
+      panelVerdict: "block",
+      escalate: true,
+      alert: {
+        count: 1,
+        boardUrl: "https://monitor.example/monitor",
+      },
+    });
+    expect(evaluation.alert?.text).toContain("Hermes: pass");
+    expect(evaluation.alert?.text).toContain("Codex: concern");
+    expect(evaluation.alert?.text).toContain("Claude: block");
+  });
+
+  it("waits instead of escalating while a panelist has not responded", () => {
+    const evaluation = evaluateReviewPanel({
+      panelId: "panel-4",
+      relatedLabel: "agent#407",
+      reviewers: ["hermes", "codex", "claude"],
+      responses: [{ reviewer: "hermes", verdict: "pass", reasoning: "ok" }],
+    });
+
+    expect(evaluation).toMatchObject({
+      agreement: "pending",
+      panelVerdict: "pending",
+      escalate: false,
+    });
+  });
+});
+
+function responses(
+  hermes: ReviewPanelResponse["verdict"],
+  codex: ReviewPanelResponse["verdict"],
+  claude: ReviewPanelResponse["verdict"]
+): ReviewPanelResponse[] {
+  return [
+    { reviewer: "hermes", verdict: hermes, reasoning: "Hermes reasoning" },
+    { reviewer: "codex", verdict: codex, reasoning: "Codex reasoning" },
+    { reviewer: "claude", verdict: claude, reasoning: "Claude reasoning" },
+  ];
+}


### PR DESCRIPTION
## Summary
- add a pure C2 reviewer-panel planner/evaluator for high-risk PR review panels
- add a monitor-native /monitor/review-panels endpoint that fans high-risk work out to Hermes, Codex, and Claude using the existing C1 review-request store
- surface panel review requests and responded panel reasoning on monitor cards/drawers without changing merge authority

## Checks
- npm run typecheck
- npm test

## Surface
- Backend: slack-operator monitor endpoints/collaboration store
- Frontend: monitor card/drawer review display
- Ops/env/VPS secrets: none
- Contracts/indexer/public site: none

## Notes
- Advisory only: this creates and displays panel evidence; it does not auto-merge or change approval authority.
- Low/medium-risk work remains on the single cross-agent C1 path.