### PR TITLE
B2: self-healing — propose routed fixes / escalate on failure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,13 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   not merge, deploy, submit work, or run guarded live mutations during a handoff:
   its powers stay inside the **Durable invariants** above — gated, budgeted, and
   never extending to auto-merge or auto-deploy.
+- **Self-healing (B2, off by default).** On a failure signal (failed testbed
+  mission, failed deploy/verification), Hermes auto-**proposes** a routed fix
+  task (non-high-risk) — which still lands `proposed` and flows through the same
+  approval/autopilot gate; B2 never auto-approves or runs it — or **escalates**
+  (high-risk surface, any rollback, or while D3-suspended / HALT is set; rollback
+  is always operator-confirmed). Deduped + cooldown'd; depends on D3 as the loop
+  fail-safe. Same invariant #6 guardrail — it only proposes.
 - **Humans own approval.** A PASS verdict is a release *signal*, not a merge order.
   Merge and deploy are human-gated. No auto-merge.
 - **Per-agent task runners** (`codex-task-runner`, `claude-task-runner`) claim

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -241,6 +241,18 @@ HERMES_DISPATCH_PER_REPO_PER_DAY_MAX=5
 # When enabled, it only blocks when both today's recorded spend and the selected
 # agent's recorded average cost are present; missing cost data stays neutral.
 HERMES_DISPATCH_PER_DAY_USD_MAX=0
+# B2 — self-healing / incident response. Default OFF. When on, a failure signal
+# (failed testbed mission, failed deploy/verification) makes Hermes PROPOSE a
+# routed fix task (non-high-risk) — which still flows through the normal
+# approval/autopilot gate; B2 never auto-approves or runs it — or ESCALATE
+# (high-risk surface, rollback, or while D3-suspended / HALT is set). Deduped
+# (one open fix per surface) + cooldown'd. Depends on D3 as the loop fail-safe.
+# B2_SELF_HEALING_REPO is the repo a proposed fix targets (falls back to
+# GITHUB_DEFAULT_REPO); leave empty to escalate instead of propose.
+B2_SELF_HEALING_ENABLED=0
+B2_SELF_HEALING_INTERVAL_MINUTES=5
+B2_SELF_HEALING_COOLDOWN_MINUTES=30
+B2_SELF_HEALING_REPO=
 # Mission-spawn role gate (§21.5). Comma/space-separated Cloudflare Access
 # emails allowed to POST /monitor/testbed-missions. Leave both empty to keep
 # mission spawn unrestricted (relies on the edge gate + token only).

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -182,6 +182,15 @@ services:
       HERMES_DISPATCH_ALLOWED_REPOS: ${HERMES_DISPATCH_ALLOWED_REPOS:-}
       HERMES_DISPATCH_PER_REPO_PER_DAY_MAX: ${HERMES_DISPATCH_PER_REPO_PER_DAY_MAX:-5}
       HERMES_DISPATCH_PER_DAY_USD_MAX: ${HERMES_DISPATCH_PER_DAY_USD_MAX:-0}
+      # B2 — self-healing. On a failure: PROPOSE a routed fix (non-high-risk) that
+      # still flows through the approval/autopilot gate, or ESCALATE (high-risk /
+      # rollback / D3-suspended / HALT). Off by default; never auto-approves.
+      # Deduped (one open fix per surface) + cooldown'd. B2_SELF_HEALING_REPO is
+      # the repo a proposed fix targets (falls back to GITHUB_DEFAULT_REPO).
+      B2_SELF_HEALING_ENABLED: ${B2_SELF_HEALING_ENABLED:-0}
+      B2_SELF_HEALING_INTERVAL_MINUTES: ${B2_SELF_HEALING_INTERVAL_MINUTES:-5}
+      B2_SELF_HEALING_COOLDOWN_MINUTES: ${B2_SELF_HEALING_COOLDOWN_MINUTES:-30}
+      B2_SELF_HEALING_REPO: ${B2_SELF_HEALING_REPO:-}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}
       SLACK_OPERATOR_MONITOR_TOKEN: ${SLACK_OPERATOR_MONITOR_TOKEN:-}
       SLACK_ALLOWED_USER_IDS: ${SLACK_ALLOWED_USER_IDS:-}

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -41,6 +41,10 @@
       "types": "./dist/dispatch-policy.d.ts",
       "import": "./dist/dispatch-policy.js"
     },
+    "./dispatch-routing": {
+      "types": "./dist/dispatch-routing.d.ts",
+      "import": "./dist/dispatch-routing.js"
+    },
     "./decision-records": {
       "types": "./dist/decision-records.d.ts",
       "import": "./dist/decision-records.js"

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -6,7 +6,8 @@ import { readFile } from "node:fs/promises";
 import { logger, optionalEnv, query } from "@avg/mcp-common";
 import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
 import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
-import { getHandoffMonitor } from "@avg/averray-mcp/handoff-events";
+import { getHandoffMonitor, recordHandoffEvent } from "@avg/averray-mcp/handoff-events";
+import { classifyTask } from "@avg/averray-mcp/dispatch-routing";
 import { buildAgentScorecard } from "@avg/averray-mcp/agent-scorecard";
 import { readLlmUsageEvents } from "@avg/averray-mcp/llm-usage";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
@@ -76,6 +77,11 @@ import {
   clearAutopilotSuspended,
   readAutopilotSuspendState,
 } from "./autopilot-state.js";
+import {
+  runSelfHealingOnce,
+  createCooldown,
+  type FailureSignal,
+} from "./self-healing.js";
 import {
   readAutonomyState,
   setAutonomyMode,
@@ -1701,6 +1707,59 @@ async function computeAutopilotCountsToday(repo: string): Promise<{ todayCount: 
   return { todayCount: dispatched.length, todayRepoCount: dispatched.filter((t) => t.repo === repo).length };
 }
 
+// B2 — collect failure signals for self-healing. Concrete sources wired today:
+// failed testbed missions (usually a non-high-risk surface regression → propose)
+// and failed/blocked deploy-or-verification handoff correlations (a deploy
+// surface → high-risk → escalate; a rollback always escalates). CI-on-main and
+// ops-health are additional sources to wire when their failed-status is exposed
+// as cleanly; the self-healing core treats every signal source identically.
+const SELF_HEAL_DEPLOY_PHASE_RE = /(deploy|post[_-]?deploy|verif|release|rollback)/i;
+
+async function collectSelfHealingSignals(boardUrl: string): Promise<FailureSignal[]> {
+  const signals: FailureSignal[] = [];
+  const fixRepo = optionalEnv("B2_SELF_HEALING_REPO") || optionalEnv("GITHUB_DEFAULT_REPO");
+
+  try {
+    const missions = listTestbedMissionRuns({ limit: 25 }).filter((m) => m.status === "failed");
+    for (const m of missions) {
+      signals.push({
+        surface: `testbed:${m.id}`,
+        source: "testbed_mission",
+        summary: `Testbed mission for ${m.targetUrl} failed: ${m.failureReason ?? m.statusReason ?? "no reason recorded"}`,
+        evidence: `${boardUrl}?mission=${encodeURIComponent(m.id)}`,
+        ...(fixRepo ? { repo: fixRepo } : {}),
+        area: `testbed ${m.targetUrl}`,
+      });
+    }
+  } catch (error) {
+    logger.warn({ err: error }, "b2_collect_testbed_signals_failed");
+  }
+
+  try {
+    const monitor = await getHandoffMonitor({ limit: 50, activeWindowMinutes: 24 * 60 });
+    for (const c of monitor.recent ?? []) {
+      const failed = c.status === "failed" || c.status === "blocked";
+      const phase = String(c.phase ?? "");
+      const deployish = SELF_HEAL_DEPLOY_PHASE_RE.test(phase) || SELF_HEAL_DEPLOY_PHASE_RE.test(String(c.intent ?? ""));
+      if (!failed || !deployish) continue;
+      const rollback = /rollback/i.test(phase) || /rollback/i.test(String(c.reason ?? ""));
+      signals.push({
+        surface: `deploy-verify:${c.correlationId}`,
+        source: "post_deploy_verification",
+        summary: `Post-deploy verification (${phase || "deploy"}) ${c.status}${c.reason ? `: ${c.reason}` : ""}`,
+        evidence: c.pullRequestUrl ?? boardUrl,
+        ...(c.repo ? { repo: c.repo } : {}),
+        area: "deploy", // a deploy surface → high-risk → escalate
+        ...(rollback ? { isRollback: true } : {}),
+      });
+    }
+  } catch (error) {
+    logger.warn({ err: error }, "b2_collect_deploy_signals_failed");
+  }
+
+  return signals;
+}
+
 // O4-PR3b — run a freshly-proposed task through the autopilot gate. Returns the
 // (possibly approved) task + the decision. Supervised → silent no-op.
 async function autoApproveProposedTask(task: CodexTask) {
@@ -2122,6 +2181,98 @@ function startOperatorRoutines() {
     }
   };
 
+  // B2 — self-healing. On a failure signal: auto-PROPOSE a routed fix (non-high-
+  // risk) that flows through the existing approval/autopilot gate, or ESCALATE
+  // (high-risk / rollback / D3-suspended / HALT). Never auto-approves or runs.
+  let selfHealingRunning = false;
+  const selfHealingCooldown = createCooldown(routineConfig.selfHealing.cooldownMs);
+  const selfHealingBoardUrl = optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ?? "https://monitor.averray.com/monitor";
+  const checkSelfHealing = async () => {
+    if (selfHealingRunning || !routineConfig.selfHealing.enabled) return;
+    selfHealingRunning = true;
+    try {
+      const result = await runSelfHealingOnce({
+        getSignals: () => collectSelfHealingSignals(selfHealingBoardUrl),
+        isSuspended: () => isAutopilotSuspended(),
+        isHalt: () => isHaltFilePresent(),
+        classify: (signal) => {
+          const r = classifyTask({
+            ...(signal.repo ? { repo: signal.repo } : {}),
+            prompt: signal.summary,
+            ...(signal.area ? { area: signal.area } : {}),
+          });
+          return { agent: r.agent, riskTier: r.riskTier, reason: r.reason };
+        },
+        hasOpenFixTask: async (surface) => {
+          const corr = `self-heal:${surface}`;
+          const tasks = await listCodexTasks();
+          return tasks.some(
+            (t) => t.correlationId === corr && !["completed", "failed", "cancelled"].includes(t.status),
+          );
+        },
+        proposalsToday: async () => {
+          const today = new Date().toISOString().slice(0, 10);
+          const tasks = await listCodexTasks();
+          return tasks.filter(
+            (t) => t.requester === "hermes-self-healing" && (t.createdAt ?? "").slice(0, 10) === today,
+          ).length;
+        },
+        maxProposalsPerDay: dispatchPerDayCap,
+        inCooldown: (surface, nowMs) => selfHealingCooldown.inCooldown(surface, nowMs),
+        markHandled: (surface, nowMs) => selfHealingCooldown.markHandled(surface, nowMs),
+        propose: async ({ signal, agent, riskTier, prompt, routingReason }) => {
+          const { task, created } = await proposeCodexTask({
+            repo: signal.repo!,
+            agent,
+            riskTier,
+            routingReason,
+            prompt,
+            title: `Self-healing fix: ${signal.surface}`,
+            reason: `Hermes self-healing proposal for a ${signal.source} failure`,
+            requester: "hermes-self-healing",
+            correlationId: `self-heal:${signal.surface}`,
+          });
+          // Flow through the EXISTING approval/autopilot gate (B2 never approves).
+          if (created && task.status === "proposed") {
+            await autoApproveProposedTask(task);
+          }
+          return { taskId: task.id };
+        },
+        alert: (payload) => alertChannel.dispatch(payload),
+        audit: async (record) => {
+          await recordHandoffEvent({
+            correlationId: `self-heal:${record.surface}`,
+            requester: "hermes-self-healing",
+            intent: "self_healing",
+            phase: "self_healing",
+            status: record.action === "propose" ? "completed" : record.action === "escalate" ? "needs_review" : "completed",
+            reason: `b2 ${record.action}: ${record.reason}`,
+            summary: {
+              kind: "self_healing",
+              action: record.action,
+              source: record.source,
+              ...(record.riskTier ? { riskTier: record.riskTier } : {}),
+              ...(record.agent ? { agent: record.agent } : {}),
+              ...(record.taskId ? { taskId: record.taskId } : {}),
+              ...(record.evidence ? { evidence: record.evidence } : {}),
+            },
+            safety: { readOnly: record.action !== "propose", mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+          }).catch((error) => logger.warn({ err: error }, "b2_self_healing_audit_failed"));
+        },
+        boardUrl: selfHealingBoardUrl,
+        now: () => new Date(),
+      });
+      const acted = result.handled.filter((h) => h.action !== "skip");
+      if (acted.length > 0) {
+        logger.info({ handled: acted }, "b2_self_healing_acted");
+      }
+    } catch (error) {
+      logger.error({ err: error }, "b2_self_healing_failed");
+    } finally {
+      selfHealingRunning = false;
+    }
+  };
+
   if (routineConfig.dailyBrief.enabled) {
     setTimeout(() => void checkDailyBrief(), 5_000);
     setInterval(() => void checkDailyBrief(), 60_000);
@@ -2149,6 +2300,10 @@ function startOperatorRoutines() {
   if (routineConfig.anomalyPause.enabled) {
     setTimeout(() => void checkAnomalies(), 11_000);
     setInterval(() => void checkAnomalies(), routineConfig.anomalyPause.intervalMs);
+  }
+  if (routineConfig.selfHealing.enabled) {
+    setTimeout(() => void checkSelfHealing(), 13_000);
+    setInterval(() => void checkSelfHealing(), routineConfig.selfHealing.intervalMs);
   }
 }
 

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -36,6 +36,12 @@ export interface SlackRoutineConfig {
     enabled: boolean;
     intervalMs: number;
   };
+  /** B2 — self-healing: propose routed fixes / escalate on failure. Off by default. */
+  selfHealing: {
+    enabled: boolean;
+    intervalMs: number;
+    cooldownMs: number;
+  };
 }
 
 export function parseSlackRoutineConfig(
@@ -88,6 +94,12 @@ export function parseSlackRoutineConfig(
       // Off by default — the operator enables D3 before turning on autopilot.
       enabled: env.D3_ANOMALY_PAUSE_ENABLED === "1",
       intervalMs: Math.max(30_000, (positiveNumber(env.D3_ANOMALY_PAUSE_INTERVAL_MINUTES) || 1) * 60_000),
+    },
+    selfHealing: {
+      // Off by default — proposes fixes / escalates only once the operator turns it on.
+      enabled: env.B2_SELF_HEALING_ENABLED === "1",
+      intervalMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_INTERVAL_MINUTES) || 5) * 60_000),
+      cooldownMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_COOLDOWN_MINUTES) || 30) * 60_000),
     },
   };
 }

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -1,0 +1,281 @@
+// B2 — self-healing / incident response.
+//
+// A server-side routine: when a failure signal trips, Hermes either
+//   - auto-PROPOSES a routed fix task (non-high-risk), which lands `proposed`
+//     and flows through the EXISTING approval/autopilot gate — B2 NEVER
+//     auto-approves or auto-runs, or
+//   - ESCALATES to the operator (high-risk surface, or any rollback) via a D4
+//     alert. Rollback is ALWAYS operator-confirmed — "deploy is human."
+//
+// Depends on D3 (anomaly auto-pause) as the loop fail-safe: while autopilot is
+// suspended (D3) or HALT is set, B2 does NOT propose — it only escalates. That
+// interlock is what makes self-healing safe to build (no fix-fail-fix spiral).
+//
+// Storm control: dedup (at most one OPEN fix task per failing surface — checked
+// against the queue, so it survives a restart) + a cooldown (a flapping check
+// can't spawn a swarm) + a daily proposal budget backstop. Read-only except the
+// proposal itself, which is just a `proposed` queue entry. Never logs secrets.
+//
+// Pure decision (decideHealingAction) + effect-injected orchestrator
+// (runSelfHealingOnce) so the matrix is unit-tested with no fs/network.
+
+import type { AlertPayload } from "./alert-bridge.js";
+
+export type HealingRiskTier = "high" | "low";
+export type HealingSource = "testbed_mission" | "post_deploy_verification" | "ci_main" | "ops_health";
+
+export interface FailureSignal {
+  /** Stable per-surface key for dedup + cooldown, e.g. "testbed:sweep-7". */
+  surface: string;
+  source: HealingSource;
+  /** Human summary of the failure — feeds the fix prompt + the escalation. */
+  summary: string;
+  /** A link/id the operator (or the fix agent) can follow. */
+  evidence?: string;
+  /** The repo a fix would target. Absent ⇒ can't route a build → escalate. */
+  repo?: string;
+  /** Routing hint passed to the classifier (surface/area). */
+  area?: string;
+  /** A rollback is ALWAYS operator-confirmed — escalate, never propose. */
+  isRollback?: boolean;
+}
+
+export interface HealingClassification {
+  agent: "codex" | "claude";
+  riskTier: HealingRiskTier;
+  reason: string;
+}
+
+export type HealingAction = "propose" | "escalate" | "skip";
+
+export type HealingReason =
+  | "autopilot_suspended"
+  | "halt_present"
+  | "rollback_operator_confirmed"
+  | "no_target_repo"
+  | "unclassified"
+  | "high_risk_surface"
+  | "dispatch_budget_exhausted"
+  | "routed_fix";
+
+export interface HealingDecision {
+  action: HealingAction;
+  reason: HealingReason;
+  riskTier?: HealingRiskTier;
+  agent?: "codex" | "claude";
+}
+
+/**
+ * Pure: decide what to do with one failure signal. Fail-safe ordering — the D3
+ * interlock and rollback win first, then risk, then route. The ONLY path that
+ * proposes a build task is a non-high-risk, non-rollback signal with a target
+ * repo while autopilot is neither suspended nor halted.
+ */
+export function decideHealingAction(
+  signal: FailureSignal,
+  classification: HealingClassification | undefined,
+  gates: { suspended: boolean; halt: boolean },
+): HealingDecision {
+  // D3 interlock: never propose while paused/halted — escalate only.
+  if (gates.halt) return { action: "escalate", reason: "halt_present" };
+  if (gates.suspended) return { action: "escalate", reason: "autopilot_suspended" };
+  // Rollback is always operator-confirmed.
+  if (signal.isRollback) return { action: "escalate", reason: "rollback_operator_confirmed" };
+  // Can't route a build without a repo.
+  if (!signal.repo) return { action: "escalate", reason: "no_target_repo" };
+  if (!classification) return { action: "escalate", reason: "unclassified" };
+  // High-risk surfaces (deploy/settlement/contract/secrets/migration) escalate.
+  if (classification.riskTier === "high") {
+    return { action: "escalate", reason: "high_risk_surface", riskTier: "high" };
+  }
+  return { action: "propose", reason: "routed_fix", riskTier: classification.riskTier, agent: classification.agent };
+}
+
+/** A clear, bounded fix-task prompt describing the failure + an evidence link. */
+export function buildFixPrompt(signal: FailureSignal): string {
+  const lines = [
+    `A ${humanSource(signal.source)} failed and Hermes self-healing is proposing a fix.`,
+    "",
+    `Surface: ${signal.surface}`,
+    `What failed: ${signal.summary}`,
+    ...(signal.evidence ? [`Evidence: ${signal.evidence}`] : []),
+    "",
+    "Diagnose the root cause and open a minimal, reviewable fix. Read-only investigation first; keep the change narrow. Do not merge or deploy — a human owns that.",
+  ];
+  return lines.join("\n");
+}
+
+export function buildHealingEscalationAlert(
+  signal: FailureSignal,
+  decision: HealingDecision,
+  boardUrl: string,
+): AlertPayload {
+  const why = escalationHeadline(decision.reason);
+  const text =
+    `🚑 Hermes self-healing needs you — ${why}\n` +
+    `Surface: ${signal.surface} (${humanSource(signal.source)})\n` +
+    `What failed: ${signal.summary}\n` +
+    (signal.evidence ? `Evidence: ${signal.evidence}\n` : "") +
+    (decision.reason === "rollback_operator_confirmed"
+      ? "A rollback is always operator-confirmed — Hermes will not auto-act.\n"
+      : decision.reason === "high_risk_surface"
+        ? "High-risk surface — Hermes escalates instead of auto-proposing a fix.\n"
+        : "") +
+    `Board: ${boardUrl}`;
+  return { count: 1, items: [{ id: signal.surface, title: `self-healing: ${signal.surface}` }], boardUrl, text };
+}
+
+function escalationHeadline(reason: HealingReason): string {
+  switch (reason) {
+    case "rollback_operator_confirmed": return "a rollback needs your confirmation";
+    case "high_risk_surface": return "a high-risk surface failed";
+    case "halt_present": return "a failure tripped while HALT is set";
+    case "autopilot_suspended": return "a failure tripped while autopilot is suspended (D3)";
+    case "no_target_repo": return "a failure with no routable fix target";
+    case "dispatch_budget_exhausted": return "a failure, but the dispatch budget is exhausted";
+    default: return "a failure needs your attention";
+  }
+}
+
+function humanSource(source: HealingSource): string {
+  switch (source) {
+    case "testbed_mission": return "testbed mission";
+    case "post_deploy_verification": return "post-deploy verification";
+    case "ci_main": return "CI on main";
+    case "ops_health": return "ops-health check";
+  }
+}
+
+// ── Orchestrator (effect-injected) ──────────────────────────────────
+
+export interface HealingAuditRecord {
+  surface: string;
+  source: HealingSource;
+  action: "propose" | "escalate" | "skip";
+  reason: HealingReason | "cooldown" | "open_fix_exists";
+  riskTier?: HealingRiskTier;
+  agent?: "codex" | "claude";
+  taskId?: string;
+  evidence?: string;
+}
+
+export interface SelfHealingDeps {
+  getSignals: () => Promise<FailureSignal[]> | FailureSignal[];
+  isSuspended: () => boolean;
+  isHalt: () => boolean;
+  /** Classify a signal's surface → agent + riskTier (the routing taxonomy). */
+  classify: (signal: FailureSignal) => HealingClassification;
+  /** Durable dedup: is there already a non-terminal fix task for this surface? */
+  hasOpenFixTask: (surface: string) => Promise<boolean> | boolean;
+  /** B2 fix tasks already proposed today (for the daily budget backstop). */
+  proposalsToday: () => Promise<number> | number;
+  maxProposalsPerDay: number;
+  /** In-memory cooldown: has this surface been handled within the window? */
+  inCooldown: (surface: string, nowMs: number) => boolean;
+  markHandled: (surface: string, nowMs: number) => void;
+  /** Propose a `proposed` fix task and run it through the EXISTING gate. */
+  propose: (input: {
+    signal: FailureSignal;
+    agent: "codex" | "claude";
+    riskTier: HealingRiskTier;
+    prompt: string;
+    routingReason: string;
+  }) => Promise<{ taskId?: string }>;
+  alert: (payload: AlertPayload) => Promise<boolean>;
+  audit: (record: HealingAuditRecord) => Promise<unknown> | unknown;
+  boardUrl: string;
+  now: () => Date;
+}
+
+export interface SelfHealingResult {
+  handled: Array<{ surface: string; action: HealingAction; reason: string }>;
+}
+
+export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHealingResult> {
+  const signals = await deps.getSignals();
+  const nowMs = deps.now().getTime();
+  const suspended = deps.isSuspended();
+  const halt = deps.isHalt();
+  const handled: SelfHealingResult["handled"] = [];
+  const proposalsToday = await deps.proposalsToday();
+  let proposedThisRun = 0;
+
+  for (const signal of signals) {
+    // Cooldown: a flapping surface can't spawn a swarm of fixes/alerts.
+    if (deps.inCooldown(signal.surface, nowMs)) {
+      handled.push({ surface: signal.surface, action: "skip", reason: "cooldown" });
+      continue;
+    }
+
+    // Classify only when a build is even possible (else the decision escalates).
+    const classification =
+      !suspended && !halt && !signal.isRollback && signal.repo ? deps.classify(signal) : undefined;
+    let decision = decideHealingAction(signal, classification, { suspended, halt });
+
+    // Budget backstop: don't propose past the daily cap — escalate instead.
+    if (decision.action === "propose" && proposalsToday + proposedThisRun >= deps.maxProposalsPerDay) {
+      decision = { action: "escalate", reason: "dispatch_budget_exhausted", ...(decision.riskTier ? { riskTier: decision.riskTier } : {}) };
+    }
+
+    if (decision.action === "propose") {
+      // Durable dedup: one open fix task per surface.
+      if (await deps.hasOpenFixTask(signal.surface)) {
+        deps.markHandled(signal.surface, nowMs);
+        await deps.audit({ surface: signal.surface, source: signal.source, action: "skip", reason: "open_fix_exists" });
+        handled.push({ surface: signal.surface, action: "skip", reason: "open_fix_exists" });
+        continue;
+      }
+      const prompt = buildFixPrompt(signal);
+      const { taskId } = await deps.propose({
+        signal,
+        agent: decision.agent!,
+        riskTier: decision.riskTier!,
+        prompt,
+        routingReason: classification!.reason,
+      });
+      proposedThisRun += 1;
+      deps.markHandled(signal.surface, nowMs);
+      await deps.audit({
+        surface: signal.surface,
+        source: signal.source,
+        action: "propose",
+        reason: decision.reason,
+        ...(decision.riskTier ? { riskTier: decision.riskTier } : {}),
+        ...(decision.agent ? { agent: decision.agent } : {}),
+        ...(taskId ? { taskId } : {}),
+        ...(signal.evidence ? { evidence: signal.evidence } : {}),
+      });
+      handled.push({ surface: signal.surface, action: "propose", reason: decision.reason });
+      continue;
+    }
+
+    // Escalate.
+    await deps.alert(buildHealingEscalationAlert(signal, decision, deps.boardUrl));
+    deps.markHandled(signal.surface, nowMs);
+    await deps.audit({
+      surface: signal.surface,
+      source: signal.source,
+      action: "escalate",
+      reason: decision.reason,
+      ...(decision.riskTier ? { riskTier: decision.riskTier } : {}),
+      ...(signal.evidence ? { evidence: signal.evidence } : {}),
+    });
+    handled.push({ surface: signal.surface, action: "escalate", reason: decision.reason });
+  }
+
+  return { handled };
+}
+
+/** A simple in-memory per-surface cooldown the routine closure holds. */
+export function createCooldown(cooldownMs: number) {
+  const last = new Map<string, number>();
+  return {
+    inCooldown(surface: string, nowMs: number): boolean {
+      const at = last.get(surface);
+      return at !== undefined && nowMs - at < cooldownMs;
+    },
+    markHandled(surface: string, nowMs: number): void {
+      last.set(surface, nowMs);
+    },
+  };
+}

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  decideHealingAction,
+  runSelfHealingOnce,
+  buildFixPrompt,
+  buildHealingEscalationAlert,
+  createCooldown,
+  type FailureSignal,
+  type HealingClassification,
+  type SelfHealingDeps,
+} from "../../services/slack-operator/src/self-healing.js";
+
+const LOW: HealingClassification = { agent: "claude", riskTier: "low", reason: "UI surface, low-risk" };
+const HIGH: HealingClassification = { agent: "codex", riskTier: "high", reason: "deploy/settlement, high-risk" };
+
+function signal(over: Partial<FailureSignal> = {}): FailureSignal {
+  return {
+    surface: "testbed:sweep-1",
+    source: "testbed_mission",
+    summary: "Testbed mission for https://app.example/overview failed: 503 on /overview",
+    evidence: "https://board.example?mission=sweep-1",
+    repo: "averray-agent/agent",
+    area: "testbed overview",
+    ...over,
+  };
+}
+
+// ── pure decision matrix ────────────────────────────────────────────
+
+describe("decideHealingAction — propose only the safe path; everything else escalates", () => {
+  const open = { suspended: false, halt: false };
+
+  it("non-high-risk + repo + classified → propose with the routed agent", () => {
+    expect(decideHealingAction(signal(), LOW, open)).toMatchObject({ action: "propose", agent: "claude", riskTier: "low", reason: "routed_fix" });
+  });
+
+  it("high-risk surface → escalate (never propose a build)", () => {
+    expect(decideHealingAction(signal(), HIGH, open)).toMatchObject({ action: "escalate", reason: "high_risk_surface" });
+  });
+
+  it("rollback → escalate even when it would classify low-risk", () => {
+    expect(decideHealingAction(signal({ isRollback: true }), LOW, open)).toMatchObject({ action: "escalate", reason: "rollback_operator_confirmed" });
+  });
+
+  it("D3 interlock: suspended → escalate only", () => {
+    expect(decideHealingAction(signal(), LOW, { suspended: true, halt: false })).toMatchObject({ action: "escalate", reason: "autopilot_suspended" });
+  });
+
+  it("HALT set → escalate only", () => {
+    expect(decideHealingAction(signal(), LOW, { suspended: false, halt: true })).toMatchObject({ action: "escalate", reason: "halt_present" });
+  });
+
+  it("no target repo → escalate (can't route a build)", () => {
+    expect(decideHealingAction(signal({ repo: undefined }), undefined, open)).toMatchObject({ action: "escalate", reason: "no_target_repo" });
+  });
+
+  it("HALT/suspend win over a high-risk classification (interlock first)", () => {
+    expect(decideHealingAction(signal(), HIGH, { suspended: true, halt: false }).reason).toBe("autopilot_suspended");
+  });
+});
+
+describe("buildFixPrompt / escalation alert", () => {
+  it("the fix prompt carries the failure + evidence and says don't merge/deploy", () => {
+    const p = buildFixPrompt(signal());
+    expect(p).toContain("503 on /overview");
+    expect(p).toContain("Evidence: https://board.example?mission=sweep-1");
+    expect(p).toMatch(/do not merge or deploy/i);
+  });
+  it("the escalation alert names the surface + reason", () => {
+    const alert = buildHealingEscalationAlert(signal({ isRollback: true }), { action: "escalate", reason: "rollback_operator_confirmed" }, "https://board.example");
+    expect(alert.text).toMatch(/rollback/i);
+    expect(alert.text).toContain("testbed:sweep-1");
+    expect(alert.items[0]?.id).toBe("testbed:sweep-1");
+  });
+});
+
+// ── injected orchestrator ───────────────────────────────────────────
+
+interface Harness {
+  deps: SelfHealingDeps;
+  proposed: Array<{ surface: string; agent: string; riskTier: string }>;
+  alerts: number;
+  audits: Array<{ surface: string; action: string; reason: string; agent?: string; taskId?: string }>;
+}
+
+function harness(signals: FailureSignal[], over: Partial<SelfHealingDeps> = {}, classification: HealingClassification = LOW): Harness {
+  const proposed: Harness["proposed"] = [];
+  const alerts = { n: 0 };
+  const audits: Harness["audits"] = [];
+  const cooldown = createCooldown(30 * 60_000);
+  const deps: SelfHealingDeps = {
+    getSignals: () => signals,
+    isSuspended: () => false,
+    isHalt: () => false,
+    classify: () => classification,
+    hasOpenFixTask: () => false,
+    proposalsToday: () => 0,
+    maxProposalsPerDay: 10,
+    inCooldown: (s, n) => cooldown.inCooldown(s, n),
+    markHandled: (s, n) => cooldown.markHandled(s, n),
+    propose: async ({ signal: s, agent, riskTier }) => {
+      proposed.push({ surface: s.surface, agent, riskTier });
+      return { taskId: `task-${s.surface}` };
+    },
+    alert: async () => {
+      alerts.n += 1;
+      return true;
+    },
+    audit: (record) => {
+      audits.push({ surface: record.surface, action: record.action, reason: String(record.reason), ...(record.agent ? { agent: record.agent } : {}), ...(record.taskId ? { taskId: record.taskId } : {}) });
+    },
+    boardUrl: "https://board.example",
+    now: () => new Date("2026-05-31T12:00:00.000Z"),
+    ...over,
+  };
+  return { deps, proposed, get alerts() { return alerts.n; }, audits };
+}
+
+describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", () => {
+  it("no signals (normal load) → nothing proposed, nothing alerted, nothing audited", async () => {
+    const h = harness([]);
+    const r = await runSelfHealingOnce(h.deps);
+    expect(r.handled).toHaveLength(0);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(0);
+    expect(h.audits).toHaveLength(0);
+  });
+
+  it("a non-high-risk failure → ONE proposed fix task with the routed agent, audited", async () => {
+    const h = harness([signal()]);
+    const r = await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toEqual([{ surface: "testbed:sweep-1", agent: "claude", riskTier: "low" }]);
+    expect(h.alerts).toBe(0);
+    expect(h.audits[0]).toMatchObject({ action: "propose", agent: "claude", taskId: "task-testbed:sweep-1" });
+    expect(r.handled[0]).toMatchObject({ action: "propose" });
+  });
+
+  it("a high-risk failure → escalate, NO build task", async () => {
+    const h = harness([signal()], {}, HIGH);
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "high_risk_surface" });
+  });
+
+  it("a rollback → escalate, NO build task", async () => {
+    const h = harness([signal({ isRollback: true })]);
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "rollback_operator_confirmed" });
+  });
+
+  it("dedup: an already-open fix task for the surface → skip (no second proposal)", async () => {
+    const h = harness([signal()], { hasOpenFixTask: () => true });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.audits[0]).toMatchObject({ action: "skip", reason: "open_fix_exists" });
+  });
+
+  it("cooldown: a surface handled within the window is skipped", async () => {
+    const cd = createCooldown(30 * 60_000);
+    cd.markHandled("testbed:sweep-1", Date.parse("2026-05-31T11:50:00.000Z")); // 10m before now
+    const h = harness([signal()], { inCooldown: (s, n) => cd.inCooldown(s, n), markHandled: (s, n) => cd.markHandled(s, n) });
+    const r = await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(0);
+    expect(r.handled[0]).toMatchObject({ action: "skip", reason: "cooldown" });
+  });
+
+  it("D3 interlock: suspended → escalate only (no proposal)", async () => {
+    const h = harness([signal()], { isSuspended: () => true });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "autopilot_suspended" });
+  });
+
+  it("HALT → escalate only (no proposal)", async () => {
+    const h = harness([signal()], { isHalt: () => true });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "halt_present" });
+  });
+
+  it("budget backstop: at the daily cap → escalate instead of propose", async () => {
+    const h = harness([signal()], { proposalsToday: () => 10, maxProposalsPerDay: 10 });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "dispatch_budget_exhausted" });
+  });
+
+  it("mixed batch: one low-risk proposes, one high-risk escalates, deduped surface skips", async () => {
+    const signals = [
+      signal({ surface: "testbed:a" }),
+      signal({ surface: "deploy-verify:b", source: "post_deploy_verification", area: "deploy" }),
+      signal({ surface: "testbed:c" }),
+    ];
+    const h = harness(signals, {
+      classify: (s) => (s.area === "deploy" ? HIGH : LOW),
+      hasOpenFixTask: (surface) => surface === "testbed:c",
+    });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:a"]);
+    expect(h.alerts).toBe(1); // deploy-verify:b escalated
+    expect(h.audits.find((a) => a.surface === "testbed:c")).toMatchObject({ action: "skip", reason: "open_fix_exists" });
+  });
+});


### PR DESCRIPTION
## What changed & why

**Self-healing / incident response** (per `docs/HERMES_PHASE3_DESIGN.md` §B2). When a failure signal trips, Hermes either auto-**proposes** a routed fix task (non-high-risk) or **escalates** (high-risk / rollback). It **only proposes** — the existing approval/autopilot gate (O4-PR3) still decides whether it runs. **B2 never auto-approves or auto-runs.** Ships **after D3 (#286)**, which is the loop fail-safe that makes this safe (no fix-fail-fix spiral).

### Core — `services/slack-operator/src/self-healing.ts` (new, kept separate from the routine file)
- **`decideHealingAction`** (pure, fail-safe ordering): `HALT` / D3-suspend → escalate; **rollback → escalate** (always operator-confirmed); no target repo → escalate; **high-risk surface → escalate**; otherwise → **propose** the routed fix.
- **`runSelfHealingOnce`** (effect-injected orchestrator): per signal — cooldown → classify → decide → propose-or-escalate, with **durable dedup** (one OPEN fix task per surface, checked against the queue → survives restart) and a **daily proposal budget backstop**. Audits every proposal/escalation.
- `buildFixPrompt` / `buildHealingEscalationAlert`; `createCooldown`.

### Routine — `index.ts` `checkSelfHealing` (off by default)
- **Signals wired:** failed testbed missions (usually a non-high-risk surface regression → propose) and failed/blocked **deploy-or-verification** handoff correlations (deploy surface → high-risk → escalate; rollback phrasing → escalate). CI-on-main / ops-health are additional sources to wire when their failed-status is exposed; the core treats every source identically.
- **classify** via the O4-PR2 routing taxonomy (`classifyTask`).
- **propose** via `proposeCodexTask` (`requester: "hermes-self-healing"`, `correlationId: "self-heal:<surface>"`) then runs the **existing autopilot gate** (`autoApproveProposedTask`) — so a B2 fix is treated like any other proposal; B2 itself never approves.
- **escalate** via the D4 alert channel; **audit** via a handoff event.
- **storm control:** dedup on the correlationId marker + an in-memory cooldown; budget backstop = `HERMES_DISPATCH_PER_DAY_MAX`. Respects `HALT_FILE` + D3 suspend (**escalate-only** while either holds).

### Plumbing
Adds `@avg/averray-mcp/dispatch-routing` export. slack-operator gains `B2_SELF_HEALING_*` env (off by default) + `B2_SELF_HEALING_REPO`. AGENTS.md documents the new (proposes-only, gated) self-healing behavior.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue (proposes into the queue)
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1100 passed; new: full propose/escalate matrix — pure + orchestrated)
- [x] compose validated by parsing `ops/compose.yml` (CI runs the real `docker compose … config`)

## Rollout / rollback
- **Off by default** (`B2_SELF_HEALING_ENABLED=0`). Enabling proposes only; whether a proposal *runs* is still the operator's (supervised) or autopilot's (if the operator turned it on) decision — and autopilot is itself doubly-gated + off by default.
- New env (slack-operator): `B2_SELF_HEALING_ENABLED`, `B2_SELF_HEALING_INTERVAL_MINUTES` (5), `B2_SELF_HEALING_COOLDOWN_MINUTES` (30), `B2_SELF_HEALING_REPO` (empty ⇒ escalate instead of propose).
- **Rollback:** set `B2_SELF_HEALING_ENABLED=0` and redeploy, or revert the PR.

## Durable invariants (AGENTS.md)
- [x] **No auto-merge / auto-deploy** — B2 only proposes; rollback always escalates (operator-confirmed); high-risk always escalates
- [x] **New power → guardrail:** proposes-only into the canonical queue, deduped + cooldown'd + daily-budget-backstopped; the approval/autopilot gate is unchanged
- [x] `HALT_FILE` honored + **D3 interlock** (suspended/HALT ⇒ escalate-only, never propose)
- [x] No secrets committed/printed/logged
- [x] **AGENTS.md updated in this PR** (the new self-healing behavior)

## Known limits / follow-ups
- Concrete signal sources wired now: failed testbed missions + failed deploy/verification handoffs. CI-on-main and ops-health slot into the same `collectSelfHealingSignals` when their failed status is exposed as cleanly — the self-healing core is signal-source-agnostic.
- Escalation dedup uses an in-memory cooldown (a restart may re-alert once); proposal dedup is durable (queue-backed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)