### PR TITLE
feat: add test-writer specialist agent template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,12 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
 
 ## Agent roles
 
-- **Codex and Claude are builders.** Each works in its own branch/worktree, edits
-  code, opens PRs, responds to review, and fixes failures. **Codex owns
-  chain/settlement-adjacent work**; Claude takes UI, docs, and general code.
+- **Codex, Claude, and internal specialists are builders.** Each works in its
+  own branch/worktree, edits code, opens PRs, responds to review, and fixes
+  failures. **Codex owns chain/settlement-adjacent work**; Claude takes UI,
+  docs, and general code. C3 specialist agents are scoped internal variants of
+  the Claude runner; the first is **test-writer**, which takes low-risk
+  test-writing tasks and opens normal human-reviewed PRs.
 - **Hermes reviews and operates** — observes GitHub, reviews PR risk, runs
   read-only checks, reports to the PR/Slack/monitor, and proposes operator actions.
   Hermes proposes + routes tasks, and — when the operator turns on **autopilot**
@@ -123,18 +126,22 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   dispatch path, so they carry invariant #6's guardrail: they claim **only
   `approved` tasks** — approved by the operator **or** by `hermes-autopilot`
   within its rules — and **never self-approve**, filtered by `agent`
-  (codex/claude). The Claude runner additionally runs a **billing-route
+  (codex/claude/test-writer). The Claude runner additionally runs a **billing-route
   verification** at startup (`claude-worker-auth`) — on a mismatch it writes a
   `misconfigured` heartbeat and **refuses to claim** rather than silently
   API-bill — and honors the **api-mode daily budget** cap and the **`HALT_FILE`**
   kill switch before claiming. Both runners are off by default and
-  operator-enabled per ops profile (`codex-runner` / `claude-runner`).
+  operator-enabled per ops profile (`codex-runner` / `claude-runner`). Internal
+  specialists reuse the Claude-family runner by setting
+  `CLAUDE_TASK_RUNNER_AGENT` and a role-aware worker prompt; they do not add
+  auto-approval, auto-merge, or deploy authority.
 - **Branch workers** (`codex-branch-worker`, `claude-branch-worker`) are the
   matching workers the runners spawn. They have **unattended push rights**, so
   each is gated by a **repo allow-list** (`CODEX_BRANCH_WORKER_ALLOWED_REPOS` /
   `CLAUDE_BRANCH_WORKER_ALLOWED_REPOS`) that is **empty by default and fails
   closed** — the operator opts each `owner/repo` in explicitly. A worker only
-  ever pushes its own `codex/<slug>` / `claude/<slug>` branch (it **refuses
+  ever pushes its own `codex/<slug>` / `claude/<slug>` / specialist-prefixed
+  branch such as `test-writer/<slug>` (it **refuses
   protected/base branches**), rejects secret-like files before committing,
   redacts command output, and **opens a PR but never merges**. The Claude
   worker is greenfield (creates the branch + opens the PR); the Codex worker

--- a/docs/HERMES_PHASE4_DESIGN.md
+++ b/docs/HERMES_PHASE4_DESIGN.md
@@ -24,6 +24,8 @@ Any unresolved disagreement — a panel split, or a reviewer that blocks — **p
 - **Internal specialists now:** add role-specific agents — a **test-writer**, a **security-review** agent, a **docs** agent — via the per-agent-runner pattern from P2. Adding one is modular: a new runner + a new `agentType` + a routing-taxonomy entry. The risk taxonomy decides what each is trusted with (e.g. the security-review agent is a reviewer, not a builder, on high-risk surfaces).
 - **External/3rd-party agents later:** defer the generic external-agent interface (via the `ext` type) until internal collaboration is solid — external agents add a real trust/security surface (sandboxing, credential scope, allowlisting) that's better handled once the internal model is proven.
 
+Implementation note: C3 first slice adds the `test-writer` internal specialist as the template. It reuses the Claude-family per-agent runner/branch-worker with `CLAUDE_TASK_RUNNER_AGENT=test-writer`, a role prompt, `test-writer/*` branch attribution, and the normal PR review/human merge gate. Adding the next internal specialist should be config + prompt + routing taxonomy entry, not a new authority path.
+
 ## C4 — Inter-agent communication
 
 Extend the board's collaboration channel (today: `codex | hermes | operator | system`; note `claude` isn't yet a collaboration author) so agents can coordinate directly on a card — e.g. a reviewer asking the builder to clarify, or Hermes brokering a disagreement before escalating. A data-model extension (`CollaborationAuthor`/`Target`) + UI; low-risk and immediately useful once there are ≥2 builders.

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -40,7 +40,7 @@
 | B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
 | C1 | Cross-agent review (default) | 🟡 in build — first slice records/displays review requests only; no auto-run or authority change |
 | C2 | Reviewer panel (high-risk) | design done |
-| C3 | Specialist agents (test-writer/security/docs) | design done |
+| C3 | Specialist agents (test-writer/security/docs) | 🟡 in build — first `test-writer` specialist template |
 | C4 | Inter-agent chat | ✅ done (#291) — Claude author/target + card-scoped agent messages v1 |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
 | T2 | Pre-seeded session (authed sweep) | ✅ done (#293) |
@@ -50,7 +50,7 @@
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | in flight — first slice adds `requested` missions, `/monitor/testbed-missions/request`, `/approve`, board approve UI, and runner-ready gating (this PR) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | design/follow-up — do not mark shipped here without code evidence; platform helper remains follow-up |
 
-*(Status as of 2026-05-31 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget, the O5 first slice, and T6's first board-gated request/approve slice. **Design / follow-up:** remaining O5 hardening, B1–B2, C1–C3 and remaining C follow-ups, T4, T7, and platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
+*(Status as of 2026-05-31 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget, the O5 first slice, C3's first internal `test-writer` specialist template, and T6's first board-gated request/approve slice. **Design / follow-up:** remaining O5 hardening, B1–B2, C1–C2, remaining C follow-ups, T4, T7, and platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 

--- a/hermes/config/policy.yaml
+++ b/hermes/config/policy.yaml
@@ -20,6 +20,7 @@ dispatch:
   allowed_agents:
     - codex
     - claude
+    - test-writer
   per_day_max: 10
   per_repo_per_day_max: 5
 # D3 anomaly auto-pause — the fail-safe for autopilot. Tiered: a SOFT trip
@@ -33,4 +34,3 @@ anomaly:
   budget_spike_ratio: 0.8  # ≥80% of the per-day dispatch cap → soft
   budget_blowout_ratio: 1.0 # ≥100% of the cap → hard
   heartbeat_gap_sec: 600   # runner heartbeat 10min+ stale → soft
-

--- a/packages/averray-mcp/src/agent-invocation.ts
+++ b/packages/averray-mcp/src/agent-invocation.ts
@@ -26,7 +26,7 @@ import {
   evaluateDispatchPolicy,
   type DispatchPolicyConfig,
 } from "./dispatch-policy.js";
-import { classifyTask, type RiskTier } from "./dispatch-routing.js";
+import { classifyTask, type RiskTier, type RoutingAgent } from "./dispatch-routing.js";
 import { getAgentScorecard } from "./agent-scorecard.js";
 import {
   applyLearnedRouting,
@@ -52,7 +52,7 @@ export type AgentInvocationIntent =
 /** A task Hermes proposed (O4). Proposes-only: status is "proposed", never approved. */
 export interface ProposedAgentTask {
   repo: string;
-  agent: "codex" | "claude";
+  agent: RoutingAgent;
   prompt: string;
   requester: string;
   pullRequestNumber?: number;
@@ -95,7 +95,7 @@ export interface AgentInvocationInput {
   /** enqueue_agent_task: the task prompt + which agent to propose it to. */
   prompt?: string;
   /** Explicit agent; when omitted it's DERIVED from the routing taxonomy (overridable). */
-  agent?: "codex" | "claude";
+  agent?: RoutingAgent;
   /** Optional surface hint for routing (e.g. "contracts", "ui"). */
   area?: string;
 }
@@ -864,7 +864,7 @@ async function invokeEnqueueAgentTask(
   const routingInput = { repo, prompt, ...(input.area ? { area: input.area } : {}) };
   const staticRouting = classifyTask(routingInput);
   const explicitAgent = (input.agent ?? "").trim();
-  const agentExplicit = explicitAgent === "codex" || explicitAgent === "claude";
+  const agentExplicit = isExplicitRoutingAgent(explicitAgent);
 
   // (a) HALT kill-switch — block cleanly rather than crash.
   const assertKill = deps.assertNoKillSwitchFn ?? assertNoKillSwitch;
@@ -912,7 +912,7 @@ async function invokeEnqueueAgentTask(
       }),
     }
     : await resolveLearnedRouting(routingInput, staticRouting, deps, env, loadScorecard);
-  const agent: "codex" | "claude" = agentExplicit ? explicitAgent : routing.agent;
+  const agent: RoutingAgent = agentExplicit ? explicitAgent : routing.agent;
 
   // (b) Dispatch guardrail — allowlist + per-day budget. Fail-closed.
   const policy = deps.dispatchPolicyConfig ?? loadDispatchPolicyConfig(env);
@@ -1051,7 +1051,7 @@ function disabledCostBudgetSnapshot(): DispatchCostBudgetSnapshot {
 
 async function dispatchCostBudgetSnapshot(
   capUsd: number,
-  agent: "codex" | "claude",
+  agent: RoutingAgent,
   today: string,
   loadScorecard: () => Promise<unknown>
 ): Promise<DispatchCostBudgetSnapshot> {
@@ -1069,7 +1069,7 @@ async function dispatchCostBudgetSnapshot(
 
 function dispatchCostBudgetSnapshotFromScorecard(
   scorecard: unknown,
-  agent: "codex" | "claude",
+  agent: RoutingAgent,
   today: string
 ): DispatchCostBudgetSnapshot {
   if (!isRecord(scorecard)) return { status: "not_recorded", todayCostUsd: null, estimatedTaskCostUsd: null };
@@ -1096,6 +1096,10 @@ function estimatedCostForAgent(agentRecord: Record<string, unknown> | undefined)
   const totalUsd = numberField(cost, "totalUsd");
   const runs = recordsFrom(cost, "byModel").reduce((sum, entry) => sum + (numberField(entry, "runs") ?? 0), 0);
   return totalUsd !== undefined && runs > 0 ? totalUsd / runs : null;
+}
+
+function isExplicitRoutingAgent(value: string): value is RoutingAgent {
+  return value === "codex" || value === "claude" || value === "test-writer";
 }
 
 // enqueue transport — POST/GET the slack-operator queue endpoint. Injected in

--- a/packages/averray-mcp/src/agent-scorecard.ts
+++ b/packages/averray-mcp/src/agent-scorecard.ts
@@ -8,7 +8,7 @@ import {
   type LlmUsageEvent,
 } from "./llm-usage.js";
 
-export type ScorecardAgent = "codex" | "claude" | "hermes" | "browser" | "unknown";
+export type ScorecardAgent = "codex" | "claude" | "test-writer" | "hermes" | "browser" | "unknown";
 export type ScorecardConfidence = "none" | "low" | "medium" | "high";
 
 export interface AgentScorecardOptions {
@@ -445,6 +445,7 @@ function agentFromBranch(branch: string | undefined): ScorecardAgent | undefined
   const normalized = branch?.trim().toLowerCase() ?? "";
   if (normalized.startsWith("codex/")) return "codex";
   if (normalized.startsWith("claude/")) return "claude";
+  if (normalized.startsWith("test-writer/")) return "test-writer";
   return undefined;
 }
 
@@ -452,6 +453,7 @@ function scorecardAgent(value: string): ScorecardAgent {
   const agent = value.trim().toLowerCase();
   if (agent === "codex") return "codex";
   if (agent === "claude") return "claude";
+  if (agent === "test-writer" || agent === "test writer") return "test-writer";
   if (agent === "hermes") return "hermes";
   if (agent === "browser" || agent === "tester" || agent === "testbed") return "browser";
   return "unknown";
@@ -521,9 +523,10 @@ function agentSortKey(agent: ScorecardAgent): number {
   switch (agent) {
     case "codex": return 0;
     case "claude": return 1;
-    case "hermes": return 2;
-    case "browser": return 3;
-    case "unknown": return 4;
+    case "test-writer": return 2;
+    case "hermes": return 3;
+    case "browser": return 4;
+    case "unknown": return 5;
   }
 }
 

--- a/packages/averray-mcp/src/dispatch-policy.ts
+++ b/packages/averray-mcp/src/dispatch-policy.ts
@@ -15,7 +15,7 @@ import { optionalEnv, readYamlFile } from "@avg/mcp-common";
 export interface DispatchPolicyConfig {
   /** Repos Hermes may propose work in. EMPTY ⇒ deny everything (fail-closed). */
   allowedRepos: string[];
-  /** Agents Hermes may propose to. Defaults to codex + claude. */
+  /** Agents Hermes may propose to. Defaults to codex + claude + internal specialists. */
   allowedAgents: string[];
   /** Max Hermes-proposed tasks per day across all repos. */
   perDayMax: number;
@@ -66,7 +66,7 @@ function positiveIntOr(value: unknown, fallback: number): number {
 /**
  * Load the dispatch guardrail from the `dispatch:` block of policy.yaml, with
  * env overrides. Defaults are fail-closed: an absent/empty allowed_repos denies
- * everything. allowed_agents defaults to codex + claude.
+ * everything. allowed_agents defaults to codex + claude + internal specialists.
  */
 export function loadDispatchPolicyConfig(env: NodeJS.ProcessEnv = process.env): DispatchPolicyConfig {
   const yaml = readYamlFile<{ dispatch?: DispatchYamlBlock }>(
@@ -84,7 +84,7 @@ export function loadDispatchPolicyConfig(env: NodeJS.ProcessEnv = process.env): 
   const allowedAgents = stringArray(block.allowed_agents);
   return {
     allowedRepos,
-    allowedAgents: allowedAgents.length > 0 ? allowedAgents : ["codex", "claude"],
+    allowedAgents: allowedAgents.length > 0 ? allowedAgents : ["codex", "claude", "test-writer"],
     perDayMax: positiveIntOr(env.HERMES_DISPATCH_PER_DAY_MAX ?? block.per_day_max, 10),
     perRepoPerDayMax: positiveIntOr(env.HERMES_DISPATCH_PER_REPO_PER_DAY_MAX ?? block.per_repo_per_day_max, 5),
     perDayUsdMax: positiveNumberOr(env.HERMES_DISPATCH_PER_DAY_USD_MAX ?? block.per_day_usd_max, 0),

--- a/packages/averray-mcp/src/dispatch-routing.ts
+++ b/packages/averray-mcp/src/dispatch-routing.ts
@@ -16,7 +16,7 @@
 
 import type { HermesDecisionRecord } from "./decision-records.js";
 
-export type RoutingAgent = "codex" | "claude";
+export type RoutingAgent = "codex" | "claude" | "test-writer" | (string & {});
 export type RiskTier = "high" | "low";
 
 export interface RoutingInput {
@@ -60,9 +60,12 @@ const CLAUDE_SURFACES: SurfaceGroup[] = [
   { surface: "UI/frontend", keywords: ["ui", "frontend", "front-end", "component", "css", "styling", "layout", "tooltip", "badge", "label", "accessibility", "a11y", "responsive"] },
   { surface: "the monitor", keywords: ["monitor", "board", "drawer", "co-pilot", "copilot", "lane"] },
   { surface: "docs/copy", keywords: ["docs", "documentation", "readme", "copy", "comment", "changelog", "guide"] },
-  { surface: "tests", keywords: ["test", "tests", "spec", "vitest", "coverage"] },
   { surface: "refactor/DX", keywords: ["refactor", "cleanup", "rename", "dx", "lint", "typo", "formatting", "tidy"] },
   { surface: "MCP tooling", keywords: ["mcp tool", "tool ergonomics", "tool schema"] },
+];
+
+const SPECIALIST_SURFACES: SurfaceGroup[] = [
+  { surface: "tests", keywords: ["test", "tests", "spec", "vitest", "coverage", "test-writing", "playwright"] },
 ];
 
 function matchesKeyword(haystack: string, keyword: string): boolean {
@@ -99,6 +102,15 @@ export function classifyTask(input: RoutingInput): RoutingDecision {
       agent: "codex",
       riskTier: "high",
       reason: `${highSurface} (correctness-critical) → codex, high-risk`,
+    };
+  }
+
+  const specialistSurface = firstSurface(haystack, SPECIALIST_SURFACES);
+  if (specialistSurface) {
+    return {
+      agent: "test-writer",
+      riskTier: "low",
+      reason: `${specialistSurface} → test-writer specialist, low-risk`,
     };
   }
 

--- a/packages/averray-mcp/src/learned-routing.ts
+++ b/packages/averray-mcp/src/learned-routing.ts
@@ -57,7 +57,7 @@ export const DEFAULT_LEARNED_ROUTING_CONFIG: LearnedRoutingConfig = {
   costTieMaxScoreDelta: 0.05,
 };
 
-const ROUTING_AGENTS: RoutingAgent[] = ["codex", "claude"];
+const LEARNED_ROUTING_AGENTS = ["codex", "claude"] as const satisfies readonly RoutingAgent[];
 
 export function parseLearnedRoutingConfig(
   env: NodeJS.ProcessEnv = process.env,
@@ -132,7 +132,40 @@ export function applyLearnedRouting(
     };
   }
 
-  const candidates = ROUTING_AGENTS
+  if (!isLearnedRoutingAgent(staticDecision.agent)) {
+    const reason = `C3 specialist route → ${staticDecision.agent}; scorecard ignored (${staticDecision.reason})`;
+    return {
+      ...staticDecision,
+      reason,
+      decisionRecord: createHermesDecisionRecord({
+        kind: "routing",
+        subject: routingSubject(input, surface),
+        decision: `routed to ${staticDecision.agent}`,
+        reasons: [
+          `${staticDecision.agent} is an internal specialist selected by the static routing taxonomy.`,
+          "Specialist routes are fixed until a future scorecard model is explicitly taught to compare specialists.",
+          staticDecision.reason,
+        ],
+        inputs: {
+          riskTier: staticDecision.riskTier,
+          surface,
+          routingReason: reason,
+          staticDecision,
+          scorecardUsed: false,
+          wouldChangeDecision: "Changing the specialist routing taxonomy or adding an explicit operator-selected agent would change this decision.",
+          policyGates: { dispatchEvaluated: false },
+        },
+        outcome: {
+          summary: `${staticDecision.agent} selected for the proposed task; task still waits on operator gates.`,
+          waitingNext: "Operator dispatch gate or the autopilot gate.",
+        },
+        safety: { readOnly: true, mutates: false },
+        generatedAt: now,
+      }),
+    };
+  }
+
+  const candidates = LEARNED_ROUTING_AGENTS
     .map((agent) => scoreAgentForSurface(agent, surface, options.scorecard, config, now))
     .filter((candidate) => candidate.effectiveSamples >= config.minSamples)
     .sort((a, b) => b.score - a.score || b.effectiveSamples - a.effectiveSamples || agentSort(a.agent) - agentSort(b.agent));
@@ -158,7 +191,7 @@ export function applyLearnedRouting(
           routingReason: reason,
           staticDecision,
           wouldChangeDecision: `At least ${config.minSamples} effective samples for another agent on ${surface} would let learned routing choose differently.`,
-          scorecardSnapshot: ROUTING_AGENTS.map((agent) =>
+          scorecardSnapshot: LEARNED_ROUTING_AGENTS.map((agent) =>
             candidateSnapshot(scoreAgentForSurface(agent, surface, options.scorecard, config, now))
           ),
           policyGates: { dispatchEvaluated: false },
@@ -280,14 +313,18 @@ function costSummary(
 }
 
 function comparisonSummary(candidates: CandidateScore[], surface: string): string {
-  return ROUTING_AGENTS
+  return LEARNED_ROUTING_AGENTS
     .map((agent) => candidates.find((candidate) => candidate.agent === agent))
     .map((candidate, index) => {
-      const agent = ROUTING_AGENTS[index]!;
+      const agent = LEARNED_ROUTING_AGENTS[index]!;
       if (!candidate) return `${agent} cold start on ${surface}`;
       return `${agent} ${percent(candidate.readyRate)} ready, score ${formatNumber(candidate.score)}, n=${candidate.samples}, effective=${formatNumber(candidate.effectiveSamples)}`;
     })
     .join(" vs ");
+}
+
+function isLearnedRoutingAgent(agent: RoutingAgent): agent is typeof LEARNED_ROUTING_AGENTS[number] {
+  return (LEARNED_ROUTING_AGENTS as readonly string[]).includes(agent);
 }
 
 function routingSubject(input: RoutingInput, surface: string) {

--- a/packages/monitor-ui/src/components/CreateTaskForm.test.tsx
+++ b/packages/monitor-ui/src/components/CreateTaskForm.test.tsx
@@ -48,6 +48,17 @@ describe("CreateTaskForm (O3 board dispatch)", () => {
     expect(onCreate).toHaveBeenCalledWith({ agent: "codex", repo: "a/b", prompt: "x" });
   });
 
+  test("can propose a test-writer specialist task via the agent select", () => {
+    const onCreate = vi.fn();
+    const { container } = render(<CreateTaskForm onCreate={onCreate} />);
+    const f = fields(container);
+    fireEvent.change(f.agent, { target: { value: "test-writer" } });
+    fireEvent.change(f.repo, { target: { value: "a/b" } });
+    fireEvent.change(f.prompt, { target: { value: "add tests" } });
+    fireEvent.click(f.submit);
+    expect(onCreate).toHaveBeenCalledWith({ agent: "test-writer", repo: "a/b", prompt: "add tests" });
+  });
+
   test("a malformed repo blocks submit with an error", () => {
     const onCreate = vi.fn();
     const { container } = render(<CreateTaskForm onCreate={onCreate} />);

--- a/packages/monitor-ui/src/components/CreateTaskForm.tsx
+++ b/packages/monitor-ui/src/components/CreateTaskForm.tsx
@@ -11,7 +11,7 @@ import type { CreateTaskInput } from "../lib/monitor/card-types.js";
 const REPO_RE = /^[\w.-]+\/[\w.-]+$/;
 
 export function CreateTaskForm({ onCreate }: { onCreate?: (input: CreateTaskInput) => void }) {
-  const [agent, setAgent] = useState<"codex" | "claude">("claude");
+  const [agent, setAgent] = useState<CreateTaskInput["agent"]>("claude");
   const [repo, setRepo] = useState("");
   const [prompt, setPrompt] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -49,10 +49,11 @@ export function CreateTaskForm({ onCreate }: { onCreate?: (input: CreateTaskInpu
         <select
           aria-label="Agent"
           value={agent}
-          onChange={(e) => setAgent(e.target.value === "codex" ? "codex" : "claude")}
+          onChange={(e) => setAgent(parseTaskAgent(e.target.value))}
           style={{ fontSize: 12 }}
         >
           <option value="claude">claude</option>
+          <option value="test-writer">test-writer</option>
           <option value="codex">codex</option>
         </select>
         <input
@@ -93,4 +94,10 @@ export function CreateTaskForm({ onCreate }: { onCreate?: (input: CreateTaskInpu
       </div>
     </form>
   );
+}
+
+function parseTaskAgent(value: string): CreateTaskInput["agent"] {
+  if (value === "codex") return "codex";
+  if (value === "test-writer") return "test-writer";
+  return "claude";
 }

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -218,6 +218,14 @@ describe("Card — task approve (O3 dispatch)", () => {
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
   });
 
+  test("a proposed test-writer card shows specialist attribution", () => {
+    const card = { ...proposed, id: "test-writer-task-x1", agentType: "test-writer" } as unknown as BoardCard;
+    const { getByText, getByRole } = render(<Card card={card} onApprove={vi.fn()} />);
+    expect(getByText("test-writer")).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
+    expect(getByText(/Dispatch to test-writer\?/)).toBeTruthy();
+  });
+
   test("approving requires a confirm step before onApprove fires (no single-click dispatch)", () => {
     const onApprove = vi.fn();
     const { getByRole, getByText } = render(<Card card={proposed} onApprove={onApprove} />);

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -36,7 +36,7 @@ export type CardProps = {
 // ── Helpers (mirror the bundle's small inline helpers) ──────────────
 
 function agentLabel(t: AgentType | undefined): string {
-  if (t === "codex" || t === "claude" || t === "hermes") return t;
+  if (t === "codex" || t === "claude" || t === "test-writer" || t === "hermes") return t;
   return "ext";
 }
 
@@ -54,7 +54,7 @@ function freshClass(card: BoardCard): string {
  * badge. `agent #548` → `#548`, `mission browser-X` → `browser-X`.
  */
 function shortId(id: string): string {
-  return id.replace(/^[a-z]+ /, "");
+  return id.replace(/^[a-z-]+ /, "");
 }
 
 // Risk-tag pill classification — matches the bundle's branching.
@@ -260,10 +260,11 @@ function ReviewRequestedLine({ card }: { card: BoardCard }) {
   );
 }
 
-function actorDisplayName(actor: "hermes" | "operator" | "codex" | "claude"): string {
+function actorDisplayName(actor: "hermes" | "operator" | "codex" | "claude" | "test-writer"): string {
   if (actor === "hermes") return "Hermes";
   if (actor === "operator") return "Pascal";
   if (actor === "claude") return "Claude";
+  if (actor === "test-writer") return "Test-writer";
   return "Codex";
 }
 

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -21,7 +21,7 @@ export type Lane =
 
 export type CardType = "pr" | "mission" | "task" | "deploy" | "draft" | "done";
 
-export type AgentType = "claude" | "codex" | "hermes" | "ext";
+export type AgentType = "claude" | "codex" | "test-writer" | "hermes" | "ext";
 
 export type RiskTag =
   | "workflow"
@@ -79,8 +79,8 @@ export interface CardRiskSignal {
 
 export interface CardReviewRequest {
   id: string;
-  requestedBy: "hermes" | "operator" | "codex" | "claude";
-  reviewer: "codex" | "claude" | "hermes" | "operator";
+  requestedBy: "hermes" | "operator" | "codex" | "claude" | "test-writer";
+  reviewer: "codex" | "claude" | "test-writer" | "hermes" | "operator";
   reason: string;
   status: "requested" | "responded" | "cancelled";
   reviewMode?: "single" | "panel";
@@ -254,7 +254,7 @@ export interface CodexTaskCard extends CardBase {
 
 /** Payload for proposing a task from the board (O3 dispatch). */
 export interface CreateTaskInput {
-  agent: "codex" | "claude";
+  agent: "codex" | "claude" | "test-writer";
   repo: string;
   prompt: string;
   pullRequestNumber?: number;

--- a/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
@@ -7,6 +7,7 @@ test("actorLabel maps authors to display names", () => {
   assert.equal(actorLabel("hermes"), "Hermes");
   assert.equal(actorLabel("operator"), "Pascal");
   assert.equal(actorLabel("claude"), "Claude");
+  assert.equal(actorLabel("test-writer"), "Test-writer");
   assert.equal(actorLabel("codex"), "Codex");
   assert.equal(actorLabel("system"), "System");
 });

--- a/packages/monitor-ui/src/lib/monitor/collaboration.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.ts
@@ -7,9 +7,9 @@
 
 import type { BoardCard } from "./card-types.js";
 
-export type CollaborationAuthor = "claude" | "codex" | "hermes" | "operator" | "system";
+export type CollaborationAuthor = "claude" | "codex" | "test-writer" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
-export type CollaborationTarget = "everyone" | "claude" | "codex" | "hermes" | "operator";
+export type CollaborationTarget = "everyone" | "claude" | "codex" | "test-writer" | "hermes" | "operator";
 
 export interface CollaborationRelatedPr {
   repo: string;
@@ -49,6 +49,7 @@ export function actorLabel(author: CollaborationAuthor): string {
   if (author === "hermes") return "Hermes";
   if (author === "operator") return "Pascal";
   if (author === "claude") return "Claude";
+  if (author === "test-writer") return "Test-writer";
   if (author === "codex") return "Codex";
   return "System";
 }

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.test.ts
@@ -120,6 +120,15 @@ test("parseHermesInput: /task claude <repo> <prompt> → greenfield claude task 
   });
 });
 
+test("parseHermesInput: /task test-writer <repo> <prompt> → specialist greenfield task", () => {
+  assert.deepEqual(parseHermesInput("/task test-writer averray-agent/agent Add parser coverage"), {
+    kind: "task",
+    agent: "test-writer",
+    repo: "averray-agent/agent",
+    prompt: "Add parser coverage",
+  });
+});
+
 test("parseHermesInput: /task codex <repo>#<pr> <prompt> → codex task with PR", () => {
   assert.deepEqual(parseHermesInput("/task codex averray-agent/agent#123 tighten the validator"), {
     kind: "task",

--- a/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
+++ b/packages/monitor-ui/src/lib/monitor/hermes-commands.ts
@@ -3,7 +3,7 @@
 // The Hermes composer is a single text input that doubles as a command
 // line:
 //   /mission <url>                        spawn a browser mission (M7')
-//   /task <agent> [<repo>#<pr>] <prompt>  propose a codex|claude task (O3)
+//   /task <agent> [<repo>#<pr>] <prompt>  propose a codex|claude|specialist task (O3/C3)
 //   /claude <repo> <…>                    propose a greenfield Claude task (O2 shortcut)
 //   /mute [1h|9am|…]                      silence action alerts; /unmute clears it
 //   anything else                         a question routed to Hermes
@@ -12,7 +12,7 @@
 
 import { parseMuteArg } from "./notifications.js";
 
-export type TaskAgent = "codex" | "claude";
+export type TaskAgent = "codex" | "claude" | "test-writer";
 
 export type HermesCommand =
   | { kind: "mission"; url: string }
@@ -62,12 +62,12 @@ export function parseHermesInput(raw: string, now: () => number = Date.now): Her
   if (task) {
     const arg = (task[1] ?? "").trim();
     if (!arg) {
-      return { kind: "error", message: "/task needs an agent, repo, and a prompt, e.g. /task claude averray-agent/agent Add a HEALTHCHECK.md" };
+      return { kind: "error", message: "/task needs an agent, repo, and a prompt, e.g. /task test-writer averray-agent/agent Add parser tests" };
     }
     const agentGap = arg.search(/\s/);
     const agentRaw = (agentGap === -1 ? arg : arg.slice(0, agentGap)).toLowerCase();
-    if (agentRaw !== "codex" && agentRaw !== "claude") {
-      return { kind: "error", message: `"${agentRaw}" is not a valid agent (expected codex or claude).` };
+    if (!isTaskAgent(agentRaw)) {
+      return { kind: "error", message: `"${agentRaw}" is not a valid agent (expected codex, claude, or test-writer).` };
     }
     const rest = (agentGap === -1 ? "" : arg.slice(agentGap + 1)).trim();
     const targetGap = rest.search(/\s/);
@@ -124,6 +124,10 @@ export function parseHermesInput(raw: string, now: () => number = Date.now): Her
   if (autonomy) return autonomy;
 
   return { kind: "ask", text };
+}
+
+function isTaskAgent(value: string): value is TaskAgent {
+  return value === "codex" || value === "claude" || value === "test-writer";
 }
 
 // ── O4-PR3a autonomy-mode NL parsing ────────────────────────────────

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -761,6 +761,7 @@ body { margin: 0; }
 }
 .hm-card-id .agent-dot--codex  { background: #6b8a4e; }
 .hm-card-id .agent-dot--claude { background: var(--hm-clay); }
+.hm-card-id .agent-dot--test-writer { background: #2f7fb8; }
 .hm-card-id .agent-dot--hermes { background: var(--hm-sage); }
 .hm-card-id .agent-dot--ext    { background: var(--hm-muted); }
 .hm-card-id strong {
@@ -1096,6 +1097,7 @@ body { margin: 0; }
 .hm-turn--operator .actor-dot { background: var(--hm-ink); }
 .hm-turn--codex   .actor-dot { background: #6b8a4e; }
 .hm-turn--claude  .actor-dot { background: var(--hm-clay); }
+.hm-turn--test-writer .actor-dot { background: #2f7fb8; }
 .hm-turn--system  .actor-dot { background: var(--hm-muted-soft); }
 .hm-turn-time {
   margin-left: auto;

--- a/services/slack-operator/src/autopilot-approve.ts
+++ b/services/slack-operator/src/autopilot-approve.ts
@@ -82,7 +82,7 @@ export function decideAutoApproval(s: AutoApprovalSignals): AutoApprovalDecision
 export interface AutoApprovalTask {
   id: string;
   repo: string;
-  agent: "codex" | "claude";
+  agent: string;
   riskTier?: "high" | "low";
   routingReason?: string;
   title?: string;

--- a/services/slack-operator/src/claude-branch-worker.ts
+++ b/services/slack-operator/src/claude-branch-worker.ts
@@ -1,9 +1,9 @@
-// Claude branch worker (O2) — the greenfield executor the claude-task-runner
-// spawns per approved `agent:"claude"` task. Mirrors codex-branch-worker, but
+// Claude branch worker (O2/C3) — the greenfield executor the claude-task-runner
+// spawns per approved Claude-family task. Mirrors codex-branch-worker, but
 // instead of working on an existing PR it:
-//   create a `claude/<slug>` branch off a fresh base → run Claude in an
+//   create an agent-prefixed branch off a fresh base → run Claude in an
 //   isolated worktree → commit → push → OPEN a pull request.
-// The opened PR is auto-attributed to "claude" by O1 (branch prefix) and
+// The opened PR is auto-attributed by O1 (branch prefix) and
 // flows into Operator review through the existing Hermes handoff.
 //
 // Auth: the runner already resolved the billing route and handed us an env
@@ -29,9 +29,18 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { assertNoForbiddenFiles, redact } from "./codex-branch-worker.js";
+import {
+  specialistAgentDefinition,
+  taskAgentBranchPrefix,
+  taskAgentCommitPrefix,
+  taskAgentLabel,
+  taskAgentPrBodyLabel,
+} from "./specialist-agents.js";
 
 export interface ClaudeWorkerTask {
   id: string;
+  /** Queue agent identity. "claude" by default; C3 specialists set e.g. "test-writer". */
+  agent?: string;
   repo: string;
   /** Greenfield tasks have no PR yet; Claude opens its own. */
   pullRequestNumber?: number;
@@ -96,6 +105,7 @@ export function parseClaudeWorkerTask(env: NodeJS.ProcessEnv = process.env): Cla
   }
   return {
     id: requiredEnv(env, "CLAUDE_TASK_ID"),
+    agent: env.CLAUDE_TASK_AGENT?.trim() || "claude",
     repo: requiredEnv(env, "CLAUDE_TASK_REPO"),
     ...(pullRequestNumber ? { pullRequestNumber } : {}),
     ...(env.CLAUDE_TASK_TITLE ? { title: env.CLAUDE_TASK_TITLE } : {}),
@@ -120,7 +130,7 @@ export function parseClaudeWorkerConfig(env: NodeJS.ProcessEnv = process.env): C
   };
 }
 
-/** Deterministic `claude/<slug>-<idtail>` head branch for the task. */
+/** Deterministic `<agent-prefix>/<slug>-<idtail>` head branch for the task. */
 export function claudeBranchName(task: ClaudeWorkerTask): string {
   const base = (task.title || task.prompt || "task")
     .toLowerCase()
@@ -129,15 +139,16 @@ export function claudeBranchName(task: ClaudeWorkerTask): string {
     .slice(0, 40)
     .replace(/-+$/g, "");
   const tail = task.id.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(-8);
-  return `claude/${[base, tail].filter(Boolean).join("-") || "task"}`;
+  return `${taskAgentBranchPrefix(task.agent ?? "claude")}/${[base, tail].filter(Boolean).join("-") || "task"}`;
 }
 
 export function validateClaudeWorkerTask(task: ClaudeWorkerTask, branch: string, config: ClaudeWorkerConfig): void {
+  const label = taskAgentLabel(task.agent ?? "claude");
   if (config.allowedRepos.length === 0) {
-    throw new Error("No Claude worker allowed repos configured (CLAUDE_BRANCH_WORKER_ALLOWED_REPOS).");
+    throw new Error(`No ${label} worker allowed repos configured (CLAUDE_BRANCH_WORKER_ALLOWED_REPOS).`);
   }
   if (!config.allowedRepos.includes(task.repo)) {
-    throw new Error(`Repo ${task.repo} is not allowed for Claude worker dispatch.`);
+    throw new Error(`Repo ${task.repo} is not allowed for ${label} worker dispatch.`);
   }
   if (PROTECTED_BRANCHES.has(branch.toLowerCase()) || branch === config.baseBranch) {
     throw new Error(`Refusing to let Claude push to protected/base branch ${branch}.`);
@@ -145,8 +156,11 @@ export function validateClaudeWorkerTask(task: ClaudeWorkerTask, branch: string,
 }
 
 export function buildGuardedClaudePrompt(task: ClaudeWorkerTask, branch: string): string {
+  const specialist = specialistAgentDefinition(task.agent);
+  const label = taskAgentLabel(task.agent ?? "claude");
   return [
-    "You are Claude working for Hermes on an approved Averray task.",
+    `You are ${label} working for Hermes on an approved Averray task.`,
+    specialist?.rolePrompt ?? "",
     "",
     "Hard boundaries:",
     `- Work only in this checked-out worktree on branch ${branch}.`,
@@ -172,6 +186,8 @@ export function renderClaudeWorkerArgs(args: string[], prompt: string, task: Cla
     "{repo}": task.repo,
     "{title}": task.title ?? "",
     "{correlationId}": task.correlationId ?? "",
+    "{agent}": task.agent ?? "claude",
+    "{agentLabel}": taskAgentLabel(task.agent ?? "claude"),
   };
   return args.map((arg) => {
     let value = arg;
@@ -183,8 +199,11 @@ export function renderClaudeWorkerArgs(args: string[], prompt: string, task: Cla
 }
 
 export function buildPullRequestBody(task: ClaudeWorkerTask): string {
+  const label = taskAgentPrBodyLabel(task.agent ?? "claude");
+  const specialist = specialistAgentDefinition(task.agent);
   return [
-    "Opened by the Averray **Claude worker** for an approved Hermes task.",
+    `Opened by the Averray **${label}** for an approved Hermes task.`,
+    specialist ? `Specialist role: **${specialist.roleTitle}**.` : "",
     "",
     "**Task**",
     task.prompt,
@@ -216,7 +235,7 @@ export async function runClaudeBranchWorker(
     await exec("git", ["checkout", "-B", branch, `origin/${config.baseBranch}`], { cwd: workdir });
 
     const prompt = buildGuardedClaudePrompt(task, branch);
-    console.log(`Claude worker starting ${task.repo} on ${branch}.`);
+    console.log(`${taskAgentLabel(task.agent ?? "claude")} worker starting ${task.repo} on ${branch}.`);
     const claude = await exec(config.claudeCommand, renderClaudeWorkerArgs(config.claudeArgs, prompt, task), {
       cwd: workdir,
       timeoutMs: config.commandTimeoutMs,
@@ -226,9 +245,9 @@ export async function runClaudeBranchWorker(
     }
 
     const changedFiles = await listChangedFiles(exec, workdir);
-    assertNoForbiddenFiles(changedFiles, "Claude");
+    assertNoForbiddenFiles(changedFiles, taskAgentLabel(task.agent ?? "claude"));
     if (changedFiles.length === 0) {
-      console.log(`Claude produced no changes for ${task.repo}; not opening a PR.`);
+      console.log(`${taskAgentLabel(task.agent ?? "claude")} produced no changes for ${task.repo}; not opening a PR.`);
       return;
     }
 
@@ -242,7 +261,7 @@ export async function runClaudeBranchWorker(
       title: pullRequestTitle(task),
       body: buildPullRequestBody(task),
     });
-    console.log(`Claude opened PR #${pr.number} on ${task.repo} (${branch})${pr.html_url ? ` — ${pr.html_url}` : ""}.`);
+    console.log(`${taskAgentLabel(task.agent ?? "claude")} opened PR #${pr.number} on ${task.repo} (${branch})${pr.html_url ? ` — ${pr.html_url}` : ""}.`);
   } finally {
     if (!config.keepWorktree) await rm(workdir, { recursive: true, force: true });
   }
@@ -391,8 +410,8 @@ function slug(value: string): string {
 }
 
 function commitMessage(task: ClaudeWorkerTask): string {
-  const title = (task.title || task.prompt || "Claude task").replace(/\s+/g, " ").trim();
-  return `Claude task: ${title}`.slice(0, 72);
+  const title = (task.title || task.prompt || `${taskAgentLabel(task.agent ?? "claude")} task`).replace(/\s+/g, " ").trim();
+  return `${taskAgentCommitPrefix(task.agent ?? "claude")}: ${title}`.slice(0, 72);
 }
 
 function pullRequestTitle(task: ClaudeWorkerTask): string {

--- a/services/slack-operator/src/claude-task-runner.ts
+++ b/services/slack-operator/src/claude-task-runner.ts
@@ -1,5 +1,6 @@
-// Claude task runner (O2) — the per-agent runner that claims approved
-// `agent: "claude"` tasks and executes the Claude worker. Mirrors
+// Claude task runner (O2/C3) — the per-agent runner that claims approved
+// Claude-family tasks (default `agent: "claude"`, or a configured internal
+// specialist such as `agent: "test-writer"`) and executes the worker. Mirrors
 // codex-task-runner.ts (poll → claim → execute → heartbeat) and ADOPTS the
 // auth/billing layer (claude-worker-auth.ts): the route-verification health
 // check gates the loop so Claude work never runs on the wrong billing route.
@@ -9,8 +10,8 @@
 //      "misconfigured" heartbeat and DO NOT CLAIM (never silently API-bill).
 //   2. HALT_FILE — the kill switch; when present, don't claim.
 //   3. Budget — in api mode, stop claiming past CLAUDE_WORKER_DAILY_BUDGET.
-//   4. Claim — only approved tasks where agent === "claude" (codex tasks are
-//      left to the codex runner via the queue's agent filter).
+//   4. Claim — only approved tasks for this runner's configured agent (codex
+//      tasks are left to the codex runner via the queue's agent filter).
 //
 // The executor is command-agnostic (like the codex runner): it spawns the
 // configured CLAUDE_TASK_RUNNER_COMMAND (the claude-branch-worker, once it
@@ -32,18 +33,22 @@ import {
   type ClaudeWorkerAuthEnv,
   type ClaudeWorkerAuthMode,
 } from "./claude-worker-auth.js";
-import type { CodexTask } from "./codex-task-queue.js";
+import type { CodexTask, TaskAgent } from "./codex-task-queue.js";
 import {
   claimNextApprovedCodexTask,
   completeCodexTask,
   failCodexTask,
+  taskAgent,
   updateCodexTaskProgress,
   updateCodexRunnerHeartbeat,
 } from "./codex-task-queue.js";
 import { sanitizeOutput, sanitizeTail, tail } from "./codex-task-runner.js";
+import { taskAgentLabel } from "./specialist-agents.js";
 
 export interface ClaudeTaskRunnerConfig {
   enabled: boolean;
+  /** Queue agent claimed by this runner. Defaults to "claude"; C3 specialists configure this. */
+  agent: TaskAgent;
   path?: string;
   runnerId: string;
   command?: string;
@@ -97,9 +102,11 @@ export interface ClaudeTaskRunnerDeps {
 }
 
 export function parseClaudeTaskRunnerConfig(env: NodeJS.ProcessEnv = process.env): ClaudeTaskRunnerConfig {
-  const runnerId = env.CLAUDE_TASK_RUNNER_ID || `claude-${hostname()}-${process.pid}`;
+  const agent = (env.CLAUDE_TASK_RUNNER_AGENT?.trim() || "claude") as TaskAgent;
+  const runnerId = env.CLAUDE_TASK_RUNNER_ID || `${agent}-${hostname()}-${process.pid}`;
   return {
     enabled: env.CLAUDE_TASK_RUNNER_ENABLED === "1" || env.CLAUDE_TASK_RUNNER_ENABLED === "true",
+    agent,
     ...(env.AVERRAY_CODEX_TASKS_PATH ? { path: env.AVERRAY_CODEX_TASKS_PATH } : {}),
     runnerId,
     ...(env.CLAUDE_TASK_RUNNER_COMMAND ? { command: env.CLAUDE_TASK_RUNNER_COMMAND } : {}),
@@ -125,7 +132,7 @@ export async function runClaudeTaskRunnerOnce(
   const log = deps.log ?? ((m: string) => console.info(m));
 
   if (!config.enabled) {
-    await heartbeat(config, "disabled", "Claude task runner is disabled.", deps.now);
+    await heartbeat(config, "disabled", `${taskAgentLabel(config.agent)} task runner is disabled.`, deps.now);
     return { status: "disabled" };
   }
 
@@ -134,17 +141,17 @@ export async function runClaudeTaskRunnerOnce(
   const verification = verifyAuthRoute(config.authEnv, probedRoute ? { probedRoute } : {});
   if (!verification.ok) {
     const reason = `auth route check failed: ${verification.reason}`;
-    log(`[claude-task-runner] REFUSING TO CLAIM (${config.runnerId}): ${verification.reason}`);
+    log(`[claude-task-runner] REFUSING TO CLAIM (${config.runnerId}/${config.agent}): ${verification.reason}`);
     await heartbeat(config, "misconfigured", reason, deps.now);
     return { status: "misconfigured", reason: verification.reason };
   }
   const mode = verification.mode;
-  log(`[claude-task-runner] ${config.runnerId}: ${verification.message}`);
+  log(`[claude-task-runner] ${config.runnerId}/${config.agent}: ${verification.message}`);
 
   // Executor must be configured (mirror codex: command required when live).
   const executor = deps.executor ?? executeClaudeTaskCommand;
   if (!config.command && executor === executeClaudeTaskCommand) {
-    const reason = "CLAUDE_TASK_RUNNER_COMMAND is required when the Claude task runner is enabled.";
+    const reason = "CLAUDE_TASK_RUNNER_COMMAND is required when the Claude-family task runner is enabled.";
     await heartbeat(config, "misconfigured", reason, deps.now);
     return { status: "misconfigured", reason };
   }
@@ -153,7 +160,7 @@ export async function runClaudeTaskRunnerOnce(
   if (config.haltFile) {
     const halted = deps.isHalted ? deps.isHalted(config.haltFile) : existsSync(config.haltFile);
     if (halted) {
-      await heartbeat(config, "idle", "HALT_FILE present — not claiming Claude tasks.", deps.now);
+      await heartbeat(config, "idle", `HALT_FILE present — not claiming ${taskAgentLabel(config.agent)} tasks.`, deps.now);
       return { status: "halted" };
     }
   }
@@ -165,24 +172,24 @@ export async function runClaudeTaskRunnerOnce(
     return { status: "budget_exhausted", reason: gate.reason ?? "daily budget reached" };
   }
 
-  // 4. CLAIM — only approved agent="claude" tasks.
+  // 4. CLAIM — only approved tasks for this runner's configured agent.
   const claimed = await claimNextApprovedCodexTask({
     path: config.path,
     runnerId: config.runnerId,
-    agent: "claude",
+    agent: config.agent,
     now: deps.now,
   });
   if (!claimed) {
-    await heartbeat(config, "idle", "Claude runner is online; no approved Claude task is waiting.", deps.now);
+    await heartbeat(config, "idle", `${taskAgentLabel(config.agent)} runner is online; no approved ${config.agent} task is waiting.`, deps.now);
     return { status: "idle" };
   }
 
-  await heartbeat(config, "running", `Claude runner claimed ${taskLabel(claimed)}.`, deps.now, claimed.id);
+  await heartbeat(config, "running", `${taskAgentLabel(config.agent)} runner claimed ${taskLabel(claimed)}.`, deps.now, claimed.id);
 
   try {
     const result = await executor(claimed, config, { mode });
     await recordLlmUsageFromResult({
-      agent: "claude",
+      agent: config.agent,
       taskId: claimed.id,
       ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
       result,
@@ -196,7 +203,7 @@ export async function runClaudeTaskRunnerOnce(
         stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
         stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
       });
-      await heartbeat(config, "completed", summary || `Claude runner completed ${taskLabel(claimed)}.`, undefined, claimed.id);
+      await heartbeat(config, "completed", summary || `${taskAgentLabel(config.agent)} runner completed ${taskLabel(claimed)}.`, undefined, claimed.id);
       return { status: "completed", task: task ?? claimed };
     }
     const reason = summarizeFailure(result);
@@ -318,6 +325,7 @@ function taskEnvironment(task: CodexTask): NodeJS.ProcessEnv {
     CLAUDE_TASK_CORRELATION_ID: task.correlationId ?? "",
     CLAUDE_TASK_REASON: task.reason ?? "",
     CLAUDE_TASK_REQUESTER: task.requester ?? "",
+    CLAUDE_TASK_AGENT: taskAgent(task),
     CLAUDE_TASK_PROMPT: task.prompt,
   };
 }

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -22,14 +22,16 @@ export type CodexRunnerHeartbeatStatus =
 /**
  * Which agent a task is dispatched to. Defaults to "codex" everywhere so
  * existing tasks and callers keep working unchanged; "claude" is the
- * greenfield Claude-worker path (P2). Resolve a possibly-absent value via
- * {@link taskAgent}.
+ * greenfield Claude-worker path (P2), and C3 specialists (for example
+ * "test-writer") use the same per-agent filter. Resolve a possibly-absent
+ * value via {@link taskAgent}.
  */
-export type TaskAgent = "codex" | "claude";
+export type TaskAgent = "codex" | "claude" | "test-writer" | (string & {});
 
 /** Resolve a task's agent, defaulting legacy/undefined tasks to "codex". */
-export function taskAgent(task: { agent?: TaskAgent }): TaskAgent {
-  return task.agent === "claude" ? "claude" : "codex";
+export function taskAgent(task: { agent?: TaskAgent | string }): TaskAgent {
+  const agent = typeof task.agent === "string" ? task.agent.trim() : "";
+  return agent ? (agent as TaskAgent) : "codex";
 }
 
 export interface CodexTaskInput {
@@ -170,13 +172,21 @@ export async function proposeCodexTask(
 
 function initialCodexTaskEventMessage(input: CodexTaskInput): string {
   const reason = (input.reason ?? "").toLowerCase();
+  const agent = taskAgent(input);
   if (reason.includes("operator sent review back")) {
     return "Operator sent review back to Codex from the monitor.";
   }
   if (reason.includes("operator explicitly delegated")) {
     return "Operator delegated Codex takeover from the monitor.";
   }
-  return "Hermes proposed a bounded Codex task.";
+  return `Hermes proposed a bounded ${taskAgentEventLabel(agent)} task.`;
+}
+
+function taskAgentEventLabel(agent: TaskAgent): string {
+  if (agent === "codex") return "Codex";
+  if (agent === "claude") return "Claude";
+  if (agent === "test-writer") return "test-writer";
+  return agent;
 }
 
 export async function approveCodexTask(
@@ -197,7 +207,7 @@ export async function approveCodexTask(
     events: appendTaskEvent(existing, {
       at: now,
       status: "approved",
-      message: "Operator approved Codex dispatch.",
+      message: `Operator approved ${taskAgentEventLabel(taskAgent(existing))} dispatch.`,
     }),
     updatedAt: now,
   };
@@ -268,12 +278,12 @@ export async function claimNextApprovedCodexTask(
     startedAt: now,
     runnerId: deps.runnerId ?? existing.runnerId ?? "codex-task-runner",
     attemptCount: (existing.attemptCount ?? 0) + 1,
-    progressMessage: "Codex runner claimed the task.",
+    progressMessage: `${taskAgentEventLabel(taskAgent(existing))} runner claimed the task.`,
     progressAt: now,
     events: appendTaskEvent(existing, {
       at: now,
       status: "running",
-      message: `Codex runner ${(deps.runnerId ?? existing.runnerId ?? "codex-task-runner")} claimed the task.`,
+      message: `${taskAgentEventLabel(taskAgent(existing))} runner ${(deps.runnerId ?? existing.runnerId ?? "codex-task-runner")} claimed the task.`,
     }),
     updatedAt: now,
   };
@@ -295,7 +305,7 @@ export async function updateCodexTaskProgress(
   if (!existing) return undefined;
   if (TERMINAL_STATUSES.has(existing.status)) return existing;
   const now = (deps.now ?? new Date()).toISOString();
-  const progressMessage = deps.progressMessage ?? existing.progressMessage ?? "Codex runner is still working.";
+  const progressMessage = deps.progressMessage ?? existing.progressMessage ?? `${taskAgentEventLabel(taskAgent(existing))} runner is still working.`;
   const task: CodexTask = {
     ...existing,
     progressMessage,
@@ -336,12 +346,12 @@ export async function completeCodexTask(
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
     ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
-    progressMessage: deps.completionSummary ?? "Codex runner completed the task.",
+    progressMessage: deps.completionSummary ?? `${taskAgentEventLabel(taskAgent(existing))} runner completed the task.`,
     progressAt: now,
     events: appendTaskEvent(existing, {
       at: now,
       status: "completed",
-      message: deps.completionSummary ?? "Codex runner completed the task.",
+      message: deps.completionSummary ?? `${taskAgentEventLabel(taskAgent(existing))} runner completed the task.`,
     }),
     updatedAt: now,
   };
@@ -368,16 +378,16 @@ export async function failCodexTask(
     ...existing,
     status: "failed",
     failedAt: now,
-    failureReason: deps.failureReason ?? "Codex task runner failed.",
+    failureReason: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
     ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
-    progressMessage: deps.failureReason ?? "Codex task runner failed.",
+    progressMessage: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
     progressAt: now,
     events: appendTaskEvent(existing, {
       at: now,
       status: "failed",
-      message: deps.failureReason ?? "Codex task runner failed.",
+      message: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
     }),
     updatedAt: now,
   };

--- a/services/slack-operator/src/codex-task-request.ts
+++ b/services/slack-operator/src/codex-task-request.ts
@@ -4,13 +4,19 @@
 // unit-tested without standing up the server. The rule that matters:
 //   - Codex tasks iterate an EXISTING PR, so a valid pullRequestNumber is
 //     required.
-//   - Claude tasks are GREENFIELD (the worker opens its own PR), so the PR is
-//     optional — and only validated when the caller supplies one.
+//   - Claude/specialist tasks are GREENFIELD (the worker opens its own PR), so
+//     the PR is optional — and only validated when the caller supplies one.
 // The queue layer (proposeCodexTask) already supports both shapes; this is the
 // untrusted-input gate in front of it, and it decides which agent runs.
 import type { CodexTaskInput, TaskAgent } from "./codex-task-queue.js";
+import {
+  isGreenfieldTaskAgent,
+  knownTaskAgent,
+  taskAgentIds,
+  taskAgentLabel,
+} from "./specialist-agents.js";
 
-const TASK_AGENTS: readonly TaskAgent[] = ["codex", "claude"];
+const TASK_AGENTS: readonly string[] = taskAgentIds();
 
 export type ParseProposeResult =
   | { ok: true; input: CodexTaskInput }
@@ -37,8 +43,8 @@ function num(field: unknown): number | undefined {
 }
 
 function requiredFieldsMessage(agent: TaskAgent): string {
-  return agent === "claude"
-    ? "repo and prompt are required to propose Claude work; pullRequestNumber is optional."
+  return isGreenfieldTaskAgent(agent)
+    ? `repo and prompt are required to propose ${taskAgentLabel(agent)} work; pullRequestNumber is optional.`
     : "repo, pullRequestNumber, and prompt are required to propose Codex work.";
 }
 
@@ -51,9 +57,9 @@ export function parseProposeTaskPayload(payload: unknown): ParseProposeResult {
   const prompt = str(payload, "prompt");
 
   const agentField = typeof payload.agent === "string" ? payload.agent.trim() : "";
-  const agent = (agentField || "codex") as TaskAgent;
-  if (!TASK_AGENTS.includes(agent)) {
-    return { ok: false, message: `Unknown agent "${agentField}". Expected "codex" or "claude".` };
+  const agent = (agentField ? knownTaskAgent(agentField) : "codex") as TaskAgent | undefined;
+  if (!agent) {
+    return { ok: false, message: `Unknown agent "${agentField}". Expected ${TASK_AGENTS.map((entry) => `"${entry}"`).join(", ")}.` };
   }
 
   // A PR number is "supplied" only when the caller sent a non-empty value.
@@ -70,8 +76,8 @@ export function parseProposeTaskPayload(payload: unknown): ParseProposeResult {
   if (!repo || !prompt) {
     return { ok: false, message: requiredFieldsMessage(agent) };
   }
-  // Codex must target an existing PR.
-  if (agent === "codex" && !prValid) {
+  // Non-greenfield agents must target an existing PR.
+  if (!isGreenfieldTaskAgent(agent) && !prValid) {
     return { ok: false, message: requiredFieldsMessage(agent) };
   }
   // Any supplied PR (either agent) must be a positive integer.

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -38,15 +38,15 @@ const SOFT_TTL_MS = 24 * 60 * 60 * 1000;
 const HERMES_MEMORY_MAX_NOTES = 120;
 const HERMES_MEMORY_NOTE_MAX_CHARS = 320;
 
-const KNOWN_AUTHORS = new Set(["claude", "codex", "hermes", "operator", "system"] as const);
+const KNOWN_AUTHORS = new Set(["claude", "codex", "test-writer", "hermes", "operator", "system"] as const);
 const KNOWN_KINDS = new Set(["chat", "proposal", "request_help", "status"] as const);
-const KNOWN_TARGETS = new Set(["everyone", "claude", "codex", "hermes", "operator"] as const);
+const KNOWN_TARGETS = new Set(["everyone", "claude", "codex", "test-writer", "hermes", "operator"] as const);
 
-export type CollaborationAuthor = "claude" | "codex" | "hermes" | "operator" | "system";
+export type CollaborationAuthor = "claude" | "codex" | "test-writer" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
-export type CollaborationTarget = "everyone" | "claude" | "codex" | "hermes" | "operator";
-export type ReviewRequester = "hermes" | "operator" | "codex" | "claude";
-export type ReviewRequestReviewer = "codex" | "claude" | "hermes" | "operator";
+export type CollaborationTarget = "everyone" | "claude" | "codex" | "test-writer" | "hermes" | "operator";
+export type ReviewRequester = "hermes" | "operator" | "codex" | "claude" | "test-writer";
+export type ReviewRequestReviewer = "codex" | "claude" | "test-writer" | "hermes" | "operator";
 export type ReviewRequestStatus = "requested" | "responded" | "cancelled";
 
 export interface CollaborationRelatedPr {
@@ -190,7 +190,7 @@ export function recordCollaborationMessage(
   if (!author) {
     throw new CollaborationValidationError(
       "invalid_author",
-      "author must be one of: claude, codex, hermes, operator, system."
+      "author must be one of: claude, codex, test-writer, hermes, operator, system."
     );
   }
 
@@ -207,7 +207,7 @@ export function recordCollaborationMessage(
   if (addressedTo === null && hasExplicitTarget(input.addressedTo)) {
     throw new CollaborationValidationError(
       "invalid_target",
-      "addressedTo must be one of: everyone, claude, codex, hermes, operator."
+      "addressedTo must be one of: everyone, claude, codex, test-writer, hermes, operator."
     );
   }
   const relatedPr = normalizeRelatedPr(input.relatedPr);
@@ -251,7 +251,7 @@ export function recordReviewRequest(
   if (!requestedBy) {
     throw new CollaborationValidationError(
       "invalid_requested_by",
-      "requestedBy must be one of: hermes, operator, codex, claude."
+      "requestedBy must be one of: hermes, operator, codex, claude, test-writer."
     );
   }
 
@@ -259,7 +259,7 @@ export function recordReviewRequest(
   if (!reviewer) {
     throw new CollaborationValidationError(
       "invalid_reviewer",
-      "reviewer must be one of: codex, claude, hermes, operator."
+      "reviewer must be one of: codex, claude, test-writer, hermes, operator."
     );
   }
 
@@ -577,6 +577,7 @@ function actorDisplayName(actor: ReviewRequester | ReviewRequestReviewer): strin
   if (actor === "hermes") return "Hermes";
   if (actor === "operator") return "Pascal";
   if (actor === "claude") return "Claude";
+  if (actor === "test-writer") return "Test-writer";
   return "Codex";
 }
 

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -14,7 +14,7 @@ const MAX_MISSION_RUNS = 50;
 export type TestbedMissionStatus = "requested" | "ready" | "running" | "completed" | "failed";
 export type TestbedMissionVerdict = "pass" | "partial" | "fail";
 export type TestbedMissionMode = "explore" | "surface_sweep" | "siwe_auth";
-export type TestbedMissionRequesterAgent = "codex" | "claude" | "hermes" | "operator";
+export type TestbedMissionRequesterAgent = "codex" | "claude" | "test-writer" | "hermes" | "operator";
 export type TestbedMissionRunnerHeartbeatStatus =
   | "idle"
   | "running"

--- a/services/slack-operator/src/monitor-v2-debug.ts
+++ b/services/slack-operator/src/monitor-v2-debug.ts
@@ -39,7 +39,7 @@ const LANES: readonly Lane[] = [
   "done",
 ];
 const CARD_TYPES: readonly CardType[] = ["pr", "mission", "task", "deploy", "draft", "done"];
-const AGENT_TYPES: readonly AgentType[] = ["claude", "codex", "hermes", "ext"];
+const AGENT_TYPES: readonly AgentType[] = ["claude", "codex", "test-writer", "hermes", "ext"];
 const CARD_STATES: readonly CardState[] = ["fresh", "stale", "failed-fetch", "source-offline", "running"];
 const RISK_TAGS: readonly RiskTag[] = [
   "workflow",

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -47,7 +47,7 @@ export type Lane =
 
 export type CardType = "pr" | "mission" | "task" | "deploy" | "draft" | "done";
 
-export type AgentType = "claude" | "codex" | "hermes" | "ext";
+export type AgentType = "claude" | "codex" | "test-writer" | "hermes" | "ext";
 
 export type CardState = "fresh" | "stale" | "failed-fetch" | "source-offline" | "running";
 
@@ -118,8 +118,8 @@ export interface CardRiskSignal {
 
 export interface CardReviewRequest {
   id: string;
-  requestedBy: "hermes" | "operator" | "codex" | "claude";
-  reviewer: "codex" | "claude" | "hermes" | "operator";
+  requestedBy: "hermes" | "operator" | "codex" | "claude" | "test-writer";
+  reviewer: "codex" | "claude" | "test-writer" | "hermes" | "operator";
   reason: string;
   status: "requested" | "responded" | "cancelled";
   reviewMode?: "single" | "panel";
@@ -324,6 +324,7 @@ export function agentTypeFromBranch(headBranch?: string): AgentType | undefined 
   const b = (headBranch ?? "").trim().toLowerCase();
   if (b.startsWith("codex/")) return "codex";
   if (b.startsWith("claude/")) return "claude";
+  if (b.startsWith("test-writer/")) return "test-writer";
   return undefined;
 }
 
@@ -341,6 +342,7 @@ export function inferAgentType(item: HermesBoardCardSnapshot, type: CardType): A
   if (owner.includes("codex")) return "codex";
   if (owner.includes("hermes")) return "hermes";
   if (owner.includes("claude")) return "claude";
+  if (owner.includes("test-writer") || owner.includes("test writer")) return "test-writer";
   return "ext";
 }
 
@@ -721,7 +723,7 @@ interface CardReviewRequestWithScope extends CardReviewRequest {
 }
 
 function asReviewActor(value: unknown): CardReviewRequest["requestedBy"] | undefined {
-  if (value === "hermes" || value === "operator" || value === "codex" || value === "claude") return value;
+  if (value === "hermes" || value === "operator" || value === "codex" || value === "claude" || value === "test-writer") return value;
   return undefined;
 }
 
@@ -987,7 +989,7 @@ export function synthesizeTaskCards(
     if (task.pullRequestNumber !== undefined && task.pullRequestNumber !== null) continue;
     const id = asString(task.id);
     if (!id) continue;
-    const agent: AgentType = task.agent === "claude" ? "claude" : "codex";
+    const agent = agentTypeFromTaskAgent(task.agent);
     const prompt = asString(task.prompt);
     const riskTierRaw = asString(task.riskTier);
     const riskTier = riskTierRaw === "high" || riskTierRaw === "low" ? riskTierRaw : undefined;
@@ -1034,6 +1036,14 @@ export function synthesizeTaskCards(
     out.push(card);
   }
   return out;
+}
+
+function agentTypeFromTaskAgent(value: unknown): AgentType {
+  if (value === "claude") return "claude";
+  if (value === "test-writer") return "test-writer";
+  if (value === "hermes") return "hermes";
+  if (value === "ext") return "ext";
+  return "codex";
 }
 
 interface TaskHealthForBoard {

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -20,6 +20,7 @@
 // (runSelfHealingOnce) so the matrix is unit-tested with no fs/network.
 
 import type { AlertPayload } from "./alert-bridge.js";
+import type { TaskAgent } from "./codex-task-queue.js";
 
 export type HealingRiskTier = "high" | "low";
 export type HealingSource = "testbed_mission" | "post_deploy_verification" | "ci_main" | "ops_health";
@@ -41,7 +42,7 @@ export interface FailureSignal {
 }
 
 export interface HealingClassification {
-  agent: "codex" | "claude";
+  agent: TaskAgent;
   riskTier: HealingRiskTier;
   reason: string;
 }
@@ -62,7 +63,7 @@ export interface HealingDecision {
   action: HealingAction;
   reason: HealingReason;
   riskTier?: HealingRiskTier;
-  agent?: "codex" | "claude";
+  agent?: TaskAgent;
 }
 
 /**
@@ -154,7 +155,7 @@ export interface HealingAuditRecord {
   action: "propose" | "escalate" | "skip";
   reason: HealingReason | "cooldown" | "open_fix_exists";
   riskTier?: HealingRiskTier;
-  agent?: "codex" | "claude";
+  agent?: TaskAgent;
   taskId?: string;
   evidence?: string;
 }
@@ -176,7 +177,7 @@ export interface SelfHealingDeps {
   /** Propose a `proposed` fix task and run it through the EXISTING gate. */
   propose: (input: {
     signal: FailureSignal;
-    agent: "codex" | "claude";
+    agent: TaskAgent;
     riskTier: HealingRiskTier;
     prompt: string;
     routingReason: string;

--- a/services/slack-operator/src/specialist-agents.ts
+++ b/services/slack-operator/src/specialist-agents.ts
@@ -1,0 +1,129 @@
+export interface TaskAgentDefinition {
+  id: string;
+  label: string;
+  branchPrefix: string;
+  greenfield: boolean;
+  prBodyLabel: string;
+  commitPrefix: string;
+}
+
+export interface SpecialistAgentDefinition extends TaskAgentDefinition {
+  roleTitle: string;
+  rolePrompt: string;
+}
+
+export const TEST_WRITER_AGENT_ID = "test-writer";
+
+export const TEST_WRITER_ROLE_PROMPT = [
+  "TEST-WRITER ROLE:",
+  "- You are the internal Averray test-writer specialist.",
+  "- Prefer adding or tightening tests, fixtures, and small test harness helpers.",
+  "- Do not broaden production behavior unless a compile failure or test seam requires the smallest supporting change.",
+  "- Keep edits scoped to the requested test-writing task and explain any non-test edit in the PR body.",
+  "- Run the smallest relevant checks and leave merge/deploy decisions to the human gate.",
+].join("\n");
+
+export function defineSpecialistAgent(input: SpecialistAgentDefinition): SpecialistAgentDefinition {
+  const id = normalizeId(input.id);
+  const branchPrefix = normalizeBranchPrefix(input.branchPrefix);
+  if (!id) throw new Error("Specialist agent id is required.");
+  if (!branchPrefix) throw new Error(`Specialist agent ${input.id} needs a branchPrefix.`);
+  if (!input.rolePrompt.trim()) throw new Error(`Specialist agent ${input.id} needs a rolePrompt.`);
+  return {
+    ...input,
+    id,
+    branchPrefix,
+  };
+}
+
+export const INTERNAL_SPECIALIST_AGENTS = [
+  defineSpecialistAgent({
+    id: TEST_WRITER_AGENT_ID,
+    label: "Test-writer",
+    branchPrefix: "test-writer",
+    greenfield: true,
+    prBodyLabel: "test-writer specialist",
+    commitPrefix: "Test-writer task",
+    roleTitle: "TEST-WRITER",
+    rolePrompt: TEST_WRITER_ROLE_PROMPT,
+  }),
+] as const;
+
+export const TASK_AGENT_DEFINITIONS: readonly TaskAgentDefinition[] = [
+  {
+    id: "codex",
+    label: "Codex",
+    branchPrefix: "codex",
+    greenfield: false,
+    prBodyLabel: "Codex worker",
+    commitPrefix: "Codex task",
+  },
+  {
+    id: "claude",
+    label: "Claude",
+    branchPrefix: "claude",
+    greenfield: true,
+    prBodyLabel: "Claude worker",
+    commitPrefix: "Claude task",
+  },
+  ...INTERNAL_SPECIALIST_AGENTS,
+];
+
+export function taskAgentIds(): string[] {
+  return TASK_AGENT_DEFINITIONS.map((agent) => agent.id);
+}
+
+export function knownTaskAgent(value: unknown): string | undefined {
+  const id = normalizeId(value);
+  return id && TASK_AGENT_DEFINITIONS.some((agent) => agent.id === id) ? id : undefined;
+}
+
+export function taskAgentDefinition(value: unknown): TaskAgentDefinition | undefined {
+  const id = normalizeId(value);
+  return id ? TASK_AGENT_DEFINITIONS.find((agent) => agent.id === id) : undefined;
+}
+
+export function specialistAgentDefinition(value: unknown): SpecialistAgentDefinition | undefined {
+  const id = normalizeId(value);
+  return id ? INTERNAL_SPECIALIST_AGENTS.find((agent) => agent.id === id) : undefined;
+}
+
+export function isGreenfieldTaskAgent(value: unknown): boolean {
+  return taskAgentDefinition(value)?.greenfield === true;
+}
+
+export function taskAgentLabel(value: unknown): string {
+  const id = normalizeId(value) || "codex";
+  return taskAgentDefinition(id)?.label ?? labelFromId(id);
+}
+
+export function taskAgentBranchPrefix(value: unknown): string {
+  const id = normalizeId(value) || "claude";
+  return taskAgentDefinition(id)?.branchPrefix ?? normalizeBranchPrefix(id) ?? "agent";
+}
+
+export function taskAgentPrBodyLabel(value: unknown): string {
+  const id = normalizeId(value) || "claude";
+  return taskAgentDefinition(id)?.prBodyLabel ?? `${labelFromId(id)} worker`;
+}
+
+export function taskAgentCommitPrefix(value: unknown): string {
+  const id = normalizeId(value) || "claude";
+  return taskAgentDefinition(id)?.commitPrefix ?? `${labelFromId(id)} task`;
+}
+
+function normalizeId(value: unknown): string {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function normalizeBranchPrefix(value: unknown): string {
+  return normalizeId(value).replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function labelFromId(id: string): string {
+  return id
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join("-");
+}

--- a/services/slack-operator/src/test-writer-branch-worker.ts
+++ b/services/slack-operator/src/test-writer-branch-worker.ts
@@ -1,0 +1,24 @@
+import { fileURLToPath } from "node:url";
+
+import { redact } from "./codex-branch-worker.js";
+import {
+  parseClaudeWorkerConfig,
+  parseClaudeWorkerTask,
+  runClaudeBranchWorker,
+} from "./claude-branch-worker.js";
+import { TEST_WRITER_AGENT_ID } from "./specialist-agents.js";
+
+export async function runTestWriterBranchWorker(): Promise<void> {
+  await runClaudeBranchWorker(
+    { ...parseClaudeWorkerTask(), agent: TEST_WRITER_AGENT_ID },
+    parseClaudeWorkerConfig()
+  );
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTestWriterBranchWorker()
+    .catch((error) => {
+      console.error(redact(error instanceof Error ? error.message : String(error)));
+      process.exitCode = 1;
+    });
+}

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -260,10 +260,10 @@ function parseAgentRequestedTestbedMission(input: AgentRequestedTestbedMissionIn
 
 function parseRequesterAgent(value: unknown): TestbedMissionRequesterAgent {
   const agent = cleanString(value);
-  if (agent === "codex" || agent === "claude" || agent === "hermes" || agent === "operator") return agent;
+  if (agent === "codex" || agent === "claude" || agent === "test-writer" || agent === "hermes" || agent === "operator") return agent;
   throw new TestbedMissionRequestValidationError(
     "invalid_requester_agent",
-    "requesterAgent must be one of codex, claude, hermes, or operator."
+    "requesterAgent must be one of codex, claude, test-writer, hermes, or operator."
   );
 }
 

--- a/test/unit/agent-scorecard.test.ts
+++ b/test/unit/agent-scorecard.test.ts
@@ -212,6 +212,51 @@ describe("A1 agent scorecard", () => {
     });
   });
 
+  it("attributes test-writer specialist branches and tasks separately", () => {
+    const scorecard = buildAgentScorecard({
+      active: [],
+      recent: [{
+        requester: "github-actions",
+        status: "completed",
+        summary: {
+          finalVerdict: "ok_to_merge",
+          currentPullRequest: {
+            repo: "averray-agent/agent",
+            number: 201,
+            merged: false,
+            draft: false,
+            headBranch: "test-writer/parser-coverage",
+          },
+          reviewSignals: { touchedAreas: ["tests"] },
+        },
+      }],
+      codexTasks: {
+        items: [{
+          id: "test-writer-task-1",
+          agent: "test-writer",
+          status: "completed",
+        }],
+      },
+      llmUsageEvents: [{
+        agent: "test-writer",
+        model: "claude-sonnet-4-5",
+        taskId: "test-writer-task-1",
+        inputTokens: 120,
+        outputTokens: 40,
+        ts: "2026-05-31T10:00:00.000Z",
+      }],
+    }, { now: new Date("2026-05-31T12:00:00.000Z") });
+
+    const specialist = scorecard.agents.find((agent) => agent.agent === "test-writer");
+    expect(specialist).toMatchObject({
+      agent: "test-writer",
+      sampleCount: 2,
+      tasks: { total: 1, completed: 1 },
+      quality: { pullRequests: { opened: 1 } },
+      surfaces: [{ surface: "tests", count: 1 }],
+    });
+  });
+
   it("keeps empty snapshots explicit instead of inventing routing confidence", () => {
     const scorecard = buildAgentScorecard({}, { now: new Date("2026-05-31T12:00:00.000Z") });
 

--- a/test/unit/claude-branch-worker.test.ts
+++ b/test/unit/claude-branch-worker.test.ts
@@ -16,6 +16,7 @@ import {
   type CommandResult,
   type ExecFn,
 } from "../../services/slack-operator/src/claude-branch-worker.js";
+import { defineSpecialistAgent, TEST_WRITER_ROLE_PROMPT } from "../../services/slack-operator/src/specialist-agents.js";
 
 const task: ClaudeWorkerTask = {
   id: "claude-task-averray-agent-agent-new-20260530-abc123",
@@ -29,9 +30,11 @@ describe("claude branch worker — pure functions", () => {
   it("parses a greenfield task (no PR) and a PR-bearing task", () => {
     const green = parseClaudeWorkerTask({ CLAUDE_TASK_ID: "t1", CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "do x" });
     expect(green).toMatchObject({ id: "t1", repo: "a/b", prompt: "do x" });
+    expect(green.agent).toBe("claude");
     expect(green.pullRequestNumber).toBeUndefined();
-    const withPr = parseClaudeWorkerTask({ CLAUDE_TASK_ID: "t1", CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "x", CLAUDE_TASK_PR: "42" });
+    const withPr = parseClaudeWorkerTask({ CLAUDE_TASK_ID: "t1", CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "x", CLAUDE_TASK_PR: "42", CLAUDE_TASK_AGENT: "test-writer" });
     expect(withPr.pullRequestNumber).toBe(42);
+    expect(withPr.agent).toBe("test-writer");
     expect(() => parseClaudeWorkerTask({ CLAUDE_TASK_REPO: "a/b", CLAUDE_TASK_PROMPT: "x" } as NodeJS.ProcessEnv)).toThrow(/CLAUDE_TASK_ID/);
   });
 
@@ -49,6 +52,12 @@ describe("claude branch worker — pure functions", () => {
     expect(b).toMatch(/^claude\/[a-z0-9-]+$/);
   });
 
+  it("derives a specialist-prefixed branch for the test-writer", () => {
+    const b = claudeBranchName({ ...task, agent: "test-writer" });
+    expect(b.startsWith("test-writer/add-a-health-endpoint")).toBe(true);
+    expect(b).toMatch(/^test-writer\/[a-z0-9-]+$/);
+  });
+
   it("validate: rejects empty allow-list, disallowed repo, and protected/base branch", () => {
     const ok = parseClaudeWorkerConfig({ CLAUDE_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent" });
     expect(() => validateClaudeWorkerTask(task, "claude/x", parseClaudeWorkerConfig({}))).toThrow(/allowed repos/i);
@@ -63,6 +72,32 @@ describe("claude branch worker — pure functions", () => {
     expect(p).toMatch(/never edit \.env/i);
     expect(p).toMatch(/Do NOT open the pull request yourself/i);
     expect(p).toContain(task.prompt);
+  });
+
+  it("injects the TEST-WRITER specialist role prompt", () => {
+    const p = buildGuardedClaudePrompt({ ...task, agent: "test-writer" }, "test-writer/x");
+    expect(p).toContain("TEST-WRITER ROLE");
+    expect(p).toContain(TEST_WRITER_ROLE_PROMPT);
+    expect(p).toContain("Prefer adding or tightening tests");
+  });
+
+  it("keeps the next specialist config-only at the worker seam", () => {
+    const docs = defineSpecialistAgent({
+      id: "docs",
+      label: "Docs",
+      branchPrefix: "docs",
+      greenfield: true,
+      prBodyLabel: "docs specialist",
+      commitPrefix: "Docs task",
+      roleTitle: "DOCS",
+      rolePrompt: "DOCS ROLE: improve docs only.",
+    });
+
+    expect(docs).toMatchObject({
+      id: "docs",
+      branchPrefix: "docs",
+      rolePrompt: "DOCS ROLE: improve docs only.",
+    });
   });
 
   it("renders {prompt} into the claude args", () => {
@@ -133,6 +168,24 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
     expect(prInputs).toHaveLength(1);
     expect(prInputs[0]).toMatchObject({ base: "main" });
     expect((prInputs[0] as { head: string }).head).toMatch(/^claude\//);
+  });
+
+  it("test-writer specialist opens a normal PR through the same harness", async () => {
+    const { exec, calls } = fakeExec();
+    const prInputs: unknown[] = [];
+    await runClaudeBranchWorker({ ...task, agent: "test-writer", title: "Add parser tests" }, await config(), {
+      exec,
+      openPullRequest: async (_t, _c, input) => {
+        prInputs.push(input);
+        return { number: 778, html_url: "https://github.com/averray-agent/agent/pull/778" };
+      },
+    });
+
+    expect(calls.some((c) => c.command === "claude")).toBe(true);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "push")).toBe(true);
+    expect((prInputs[0] as { head: string }).head).toMatch(/^test-writer\//);
+    expect((prInputs[0] as { body: string }).body).toContain("test-writer specialist");
+    expect((prInputs[0] as { body: string }).body).toContain("human-gated");
   });
 
   it("no changes → does NOT commit, push, or open a PR", async () => {

--- a/test/unit/claude-task-runner.test.ts
+++ b/test/unit/claude-task-runner.test.ts
@@ -34,6 +34,7 @@ describe("claude task runner", () => {
   function config(path: string, overrides: Partial<ClaudeTaskRunnerConfig> = {}): ClaudeTaskRunnerConfig {
     return {
       enabled: true,
+      agent: "claude",
       path,
       runnerId: "test-claude-runner",
       args: [],
@@ -47,6 +48,12 @@ describe("claude task runner", () => {
 
   async function approvedClaudeTask(path: string, prompt = "Build the thing"): Promise<string> {
     const { task } = await proposeCodexTask({ repo: "averray-agent/agent", agent: "claude", prompt }, { path });
+    await approveCodexTask(task.id, { path, approvedBy: "operator" });
+    return task.id;
+  }
+
+  async function approvedTestWriterTask(path: string, prompt = "Add parser tests"): Promise<string> {
+    const { task } = await proposeCodexTask({ repo: "averray-agent/agent", agent: "test-writer", prompt }, { path });
     await approveCodexTask(task.id, { path, approvedBy: "operator" });
     return task.id;
   }
@@ -96,6 +103,30 @@ describe("claude task runner", () => {
     const tasks = await listCodexTasks({ path });
     expect(tasks.find((t) => t.id === claudeId)?.status).toBe("completed");
     expect(tasks.find((t) => t.id === codexId)?.status).toBe("approved"); // untouched
+  });
+
+  it("can be configured as the C3 test-writer specialist runner", async () => {
+    const path = await tempQueuePath();
+    const claudeId = await approvedClaudeTask(path, "general Claude work");
+    const testWriterId = await approvedTestWriterTask(path);
+    const seen: Array<{ id: string; agent?: string }> = [];
+
+    const result = await runClaudeTaskRunnerOnce(config(path, {
+      agent: "test-writer",
+      runnerId: "test-writer-runner",
+    }), {
+      executor: async (task) => {
+        seen.push({ id: task.id, agent: task.agent });
+        return { exitCode: 0, stdout: "opened PR", stderr: "", summary: "opened PR" };
+      },
+      log: () => {},
+    });
+
+    expect(result.status).toBe("completed");
+    expect(seen).toEqual([{ id: testWriterId, agent: "test-writer" }]);
+    const tasks = await listCodexTasks({ path });
+    expect(tasks.find((t) => t.id === testWriterId)?.status).toBe("completed");
+    expect(tasks.find((t) => t.id === claudeId)?.status).toBe("approved");
   });
 
   it("happy path: claim → execute → completeCodexTask + completed heartbeat", async () => {

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -361,6 +361,25 @@ describe("codex task queue — multi-agent (P2)", () => {
     expect(await claimNextApprovedCodexTask({ path, agent: "codex" })).toBeUndefined();
   });
 
+  it("stores and filters a specialist agent", async () => {
+    const path = await tempQueuePath();
+    const specialist = await proposeCodexTask(
+      { repo: "r", agent: "test-writer", prompt: "add tests" },
+      { path, now: new Date("2026-05-17T10:00:00.000Z") },
+    );
+    await approveCodexTask(specialist.task.id, { path, approvedBy: "operator", now: new Date("2026-05-17T10:01:00.000Z") });
+
+    const claimed = await claimNextApprovedCodexTask({
+      path,
+      agent: "test-writer",
+      runnerId: "test-writer-runner",
+      now: new Date("2026-05-17T10:02:00.000Z"),
+    });
+
+    expect(claimed?.id).toBe(specialist.task.id);
+    expect(taskAgent(claimed!)).toBe("test-writer");
+  });
+
   it("an unfiltered claim still takes any approved task (back-compat)", async () => {
     const path = await tempQueuePath();
     const claude = await proposeCodexTask(

--- a/test/unit/codex-task-request.test.ts
+++ b/test/unit/codex-task-request.test.ts
@@ -62,6 +62,16 @@ describe("parseProposeTaskPayload — claude (greenfield) tasks", () => {
   });
 });
 
+describe("parseProposeTaskPayload — specialist greenfield tasks", () => {
+  it("accepts test-writer work with no PR", () => {
+    const r = parseProposeTaskPayload({ repo: "averray-agent/agent", agent: "test-writer", prompt: "add parser tests" });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.agent).toBe("test-writer");
+    expect(r.input.pullRequestNumber).toBeUndefined();
+  });
+});
+
 describe("parseProposeTaskPayload — rejection paths", () => {
   it("rejects an unknown agent", () => {
     const r = parseProposeTaskPayload({ repo: "a/b", agent: "gpt5", prompt: "x" });

--- a/test/unit/dispatch-routing.test.ts
+++ b/test/unit/dispatch-routing.test.ts
@@ -32,7 +32,6 @@ describe("classifyTask — the routing taxonomy (§O4-C)", () => {
     "tweak the onboarding UI component styling",
     "fix a bug in the monitor board drawer",
     "update the README docs",
-    "add a vitest spec for the parser",
     "refactor and rename a helper for clarity",
   ];
   it.each(low)("Claude surface %j → claude + low", (prompt) => {
@@ -40,6 +39,13 @@ describe("classifyTask — the routing taxonomy (§O4-C)", () => {
     expect(r.agent).toBe("claude");
     expect(r.riskTier).toBe("low");
     expect(r.reason).toMatch(/low-risk/);
+  });
+
+  it("routes test-writing work to the test-writer specialist", () => {
+    const r = classifyTask({ repo: "depre-dev/averray-reference-agent", prompt: "add a vitest spec for the parser" });
+    expect(r.agent).toBe("test-writer");
+    expect(r.riskTier).toBe("low");
+    expect(r.reason).toMatch(/test-writer specialist/);
   });
 
   it("ambiguous/general → claude + low (default)", () => {
@@ -70,7 +76,7 @@ describe("classifyTask — the routing taxonomy (§O4-C)", () => {
 
 const ALLOWED: DispatchPolicyConfig = {
   allowedRepos: ["averray-agent/agent"],
-  allowedAgents: ["codex", "claude"],
+  allowedAgents: ["codex", "claude", "test-writer"],
   perDayMax: 10,
   perRepoPerDayMax: 5,
   perDayUsdMax: 0,
@@ -109,6 +115,22 @@ describe("enqueue_agent_task — routing as an overridable default", () => {
     expect(task.riskTier).toBe("low");
     expect(task.routingReason).toMatch(/claude, low-risk/);
     expect(result.result?.agentExplicit).toBe(false);
+  });
+
+  it("derives the test-writer specialist for low-risk test-writing tasks", async () => {
+    const proposeTaskFn = vi.fn(async () => ({ id: "tw1" }));
+    const result = (await invokeAgentTask(
+      enqueue({ prompt: "add a vitest spec for the parser" }),
+      baseDeps(proposeTaskFn)
+    )) as {
+      status: string; result?: { agent?: string; riskTier?: string; agentExplicit?: boolean; routingReason?: string };
+    };
+    const task = proposeTaskFn.mock.calls[0]![0];
+    expect(task.agent).toBe("test-writer");
+    expect(task.riskTier).toBe("low");
+    expect(task.routingReason).toMatch(/C3 specialist route/);
+    expect(result.result?.agentExplicit).toBe(false);
+    expect(result.result?.agent).toBe("test-writer");
   });
 
   it("uses A2 scorecard data as the low-risk default when enough samples exist", async () => {

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -84,6 +84,26 @@ describe("monitor collaboration channel", () => {
     });
   });
 
+  it("accepts the test-writer specialist as a card-scoped author and target", () => {
+    const message = recordCollaborationMessage(
+      {
+        author: "test-writer",
+        kind: "status",
+        addressedTo: "Claude",
+        text: "Claude, I added the failing parser coverage.",
+        relatedPr: { repo: "averray-agent/agent", number: 214 },
+      },
+      NOW
+    );
+
+    expect(message).toMatchObject({
+      author: "test-writer",
+      addressedTo: "claude",
+      text: expect.stringContaining("parser coverage"),
+      relatedPr: { repo: "averray-agent/agent", number: 214 },
+    });
+  });
+
   it("preserves relatedPr and relatedCorrelationId when well-formed", () => {
     const message = recordCollaborationMessage(
       {
@@ -263,6 +283,30 @@ describe("monitor review requests", () => {
       "Hermes, keep this card parked until review lands.",
       expect.stringContaining("Review requested from Codex"),
     ]);
+  });
+
+  it("creates review requests involving the test-writer specialist", () => {
+    const request = recordReviewRequest(
+      {
+        correlationId: "agent-task-99",
+        requestedBy: "hermes",
+        reviewer: "test-writer",
+        reason: "Please add coverage before this card moves forward.",
+      },
+      NOW
+    );
+
+    expect(request).toMatchObject({
+      requestedBy: "hermes",
+      reviewer: "test-writer",
+      correlationId: "agent-task-99",
+      status: "requested",
+    });
+    expect(listCollaborationMessages({ limit: 1 }, NOW + 1)[0]).toMatchObject({
+      author: "hermes",
+      addressedTo: "test-writer",
+      text: expect.stringContaining("Test-writer"),
+    });
   });
 
   it("requires a card scope and never creates a task as a side effect", async () => {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -113,9 +113,10 @@ describe("inferCardType", () => {
 });
 
 describe("agentTypeFromBranch", () => {
-  it("maps codex/* and claude/* prefixes (case-insensitive)", () => {
+  it("maps codex/*, claude/*, and specialist prefixes (case-insensitive)", () => {
     expect(agentTypeFromBranch("codex/foo")).toBe("codex");
     expect(agentTypeFromBranch("claude/bar")).toBe("claude");
+    expect(agentTypeFromBranch("test-writer/bar")).toBe("test-writer");
     expect(agentTypeFromBranch("Codex/Foo")).toBe("codex");
     expect(agentTypeFromBranch("  CLAUDE/Bar  ")).toBe("claude");
   });
@@ -138,6 +139,7 @@ describe("inferAgentType", () => {
   it("codex/* and claude/* attribute, case-insensitive", () => {
     expect(inferAgentType(slim({ owner: "ext", headBranch: "codex/feat" }), "pr")).toBe("codex");
     expect(inferAgentType(slim({ owner: "ext", headBranch: "Claude/Feat" }), "pr")).toBe("claude");
+    expect(inferAgentType(slim({ owner: "ext", headBranch: "test-writer/coverage" }), "pr")).toBe("test-writer");
   });
   it("non-agent branch falls back to the owner heuristic", () => {
     expect(inferAgentType(slim({ owner: "Codex", headBranch: "feature/x" }), "pr")).toBe("codex");
@@ -148,6 +150,9 @@ describe("inferAgentType", () => {
   });
   it("owner contains hermes → hermes", () => {
     expect(inferAgentType(slim({ owner: "Hermes", headBranch: undefined }), "pr")).toBe("hermes");
+  });
+  it("owner contains test-writer → test-writer", () => {
+    expect(inferAgentType(slim({ owner: "Test-writer", headBranch: undefined }), "pr")).toBe("test-writer");
   });
   it("unknown owner → ext", () => {
     expect(inferAgentType(slim({ owner: "Merge steward", headBranch: undefined }), "pr")).toBe("ext");
@@ -966,6 +971,27 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     expect(card?.taskStatus).toBe("approved");
     expect(synthesizeTaskCards({}, undefined)).toEqual([]);
     expect(synthesizeTaskCards(undefined, undefined)).toEqual([]);
+  });
+
+  it("surfaces test-writer task cards with specialist attribution", () => {
+    const [card] = synthesizeTaskCards({
+      codexTasks: {
+        items: [{
+          id: "test-writer-task-x1",
+          status: "proposed",
+          agent: "test-writer",
+          repo: "a/b",
+          prompt: "add parser tests",
+        }],
+      },
+    }, undefined);
+
+    expect(card).toMatchObject({
+      id: "test-writer-task-x1",
+      agentType: "test-writer",
+      title: "test-writer task",
+      taskStatus: "proposed",
+    });
   });
 
   it("promotes failed greenfield tasks to needs-attention with retry context", () => {

--- a/test/unit/o4-enqueue-guardrail.test.ts
+++ b/test/unit/o4-enqueue-guardrail.test.ts
@@ -14,7 +14,7 @@ import {
 
 const ALLOWED: DispatchPolicyConfig = {
   allowedRepos: ["averray-agent/agent"],
-  allowedAgents: ["codex", "claude"],
+  allowedAgents: ["codex", "claude", "test-writer"],
   perDayMax: 10,
   perRepoPerDayMax: 5,
   perDayUsdMax: 0,
@@ -75,10 +75,10 @@ describe("dispatch-policy — allowlist + budget (fail-closed)", () => {
   });
 
   it("loadDispatchPolicyConfig: fail-closed default repos + env override + default agents", () => {
-    // No POLICY_CONFIG_PATH / yaml ⇒ empty repos (fail-closed); agents default codex+claude.
+    // No POLICY_CONFIG_PATH / yaml ⇒ empty repos (fail-closed); agents default codex+claude+internal specialists.
     const bare = loadDispatchPolicyConfig({ POLICY_CONFIG_PATH: "/does/not/exist.yaml" } as NodeJS.ProcessEnv);
     expect(bare.allowedRepos).toEqual([]);
-    expect(bare.allowedAgents).toEqual(["codex", "claude"]);
+    expect(bare.allowedAgents).toEqual(["codex", "claude", "test-writer"]);
     const overridden = loadDispatchPolicyConfig({
       POLICY_CONFIG_PATH: "/does/not/exist.yaml",
       HERMES_DISPATCH_ALLOWED_REPOS: "averray-agent/agent, depre-dev/site",


### PR DESCRIPTION
## What changed
- Added a shared specialist-agent registry plus the first internal specialist, `test-writer`, with TEST-WRITER role prompt metadata.
- Reused the Claude-family per-agent runner/branch-worker harness so test-writing tasks route to `test-writer`, run with the specialist prompt, and open normal PRs through the existing human review gate.
- Extended attribution across dispatch policy/routing, task queue/request parsing, monitor cards, collaboration authors, commands, and scorecards.
- Documented the C3 implementation note and roadmap status.

## Safety / authority
- No authority change: specialist dispatch still creates proposed/approved tasks through the existing gates.
- No auto-merge, deploy, or approval path was added; the specialist opens a normal PR for human review.
- Adding another internal specialist is modeled as config + prompt + routing entry using the shared definition seam.

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check`

## Affected surfaces
- Hermes MCP dispatch/routing/policy
- Slack operator task runner, branch worker, queue, and monitor surfaces
- Monitor UI attribution/collaboration labels
- Docs and vitest coverage