### PR TITLE
C3: wire the test-writer specialist runner (off by default)

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -126,6 +126,52 @@ note flips to online.
 
 ---
 
+## Optional: the C3 test-writer specialist runner (`test-writer-runner` profile)
+
+Off by default. The `test-writer` agent/role already ships; this is the runner
+instance that **claims and executes** approved `agent="test-writer"` tasks. It
+is a second Claude-family runner pinned to the test-writer agent, so it claims
+ONLY test-writer tasks — the queue's per-agent claim filter keeps it isolated
+from the `claude-runner` (and vice-versa). Without it, approved test-writer
+tasks queue forever. Same gates as the `claude-runner`: the startup
+billing-route verification (fails loud on a mismatch and refuses to claim), the
+**fail-closed** worker repo allow-list (`CLAUDE_BRANCH_WORKER_ALLOWED_REPOS`,
+shared), `HALT_FILE`, and the heartbeat. It opens a normal `test-writer/*` PR
+through the usual human review gate — no auto-merge/approve.
+
+**`.env.prod` edits:**
+```
+TEST_WRITER_TASK_RUNNER_ENABLED=1
+# Shared with the claude-runner; still fails closed when empty. Opt repos in:
+CLAUDE_BRANCH_WORKER_ALLOWED_REPOS=owner/repo
+# Plus the same Claude worker auth/billing you use for the claude-runner
+# (CLAUDE_WORKER_AUTH_MODE + CLAUDE_CODE_OAUTH_TOKEN, or api-mode ANTHROPIC_API_KEY
+# + CLAUDE_WORKER_DAILY_BUDGET). The runner verifies the route at startup.
+```
+
+**Bring it up under its profile** (shares the `avg-data` volume, so it reads the
+same task queue the operator/autopilot approves into):
+```
+docker compose --env-file ops/.env.prod --profile test-writer-runner \
+  -f ops/compose.yml -f ops/compose.prod.yml up -d test-writer-task-runner
+```
+
+It is controlled independently of the `claude-runner`:
+`TEST_WRITER_TASK_RUNNER_ENABLED` maps to that container's own
+`CLAUDE_TASK_RUNNER_ENABLED`, so enabling the claude-runner does not enable this
+one (and the agent pin means neither claims the other's tasks).
+
+**Verify it's online** (no secrets printed):
+```
+docker compose --env-file ops/.env.prod -f ops/compose.yml -f ops/compose.prod.yml \
+  logs --since 5m test-writer-task-runner | grep -iE "test-writer|online|idle|claimed|REFUSING|disabled" | tail -10
+```
+A healthy runner logs `test-writer runner is online; no approved test-writer
+task is waiting` (idle). On a billing-route mismatch it logs `REFUSING TO CLAIM`
+and writes a `misconfigured` heartbeat rather than running on the wrong route.
+
+---
+
 ## Assumptions / things to confirm in your environment
 
 - The image name assumes the GitHub org is `depre-dev` (i.e.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -133,6 +133,20 @@ CLAUDE_TASK_RUNNER_ARGS=services/slack-operator/dist/claude-branch-worker.js
 CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS=10000
 CLAUDE_TASK_RUNNER_TIMEOUT_MS=1800000
 
+# C3 test-writer specialist runner (ops profile "test-writer-runner").
+# A second Claude-family runner pinned to the internal "test-writer" agent: it
+# claims ONLY approved agent="test-writer" tasks (the queue's per-agent filter
+# isolates it from claude/codex) and runs the dedicated test-writer worker.
+# Independent of the claude-runner — these map to the runner's own
+# CLAUDE_TASK_RUNNER_ENABLED/ID inside that container. Off by default; to go live
+# the operator sets TEST_WRITER_TASK_RUNNER_ENABLED=1, runs under the
+# "test-writer-runner" profile, and populates CLAUDE_BRANCH_WORKER_ALLOWED_REPOS
+# (shared with the claude-runner; still fails closed when empty). Reuses the same
+# billing-route check + HALT + worker auth as the claude-runner.
+TEST_WRITER_TASK_RUNNER_ENABLED=0
+TEST_WRITER_TASK_RUNNER_ID=vps-test-writer-task-runner
+TEST_WRITER_TASK_RUNNER_ARGS=services/slack-operator/dist/test-writer-branch-worker.js
+
 # Claude branch worker (the greenfield executor the runner spawns). It creates
 # a claude/<slug> branch, runs Claude, pushes, and opens a PR for review.
 # ALLOWED_REPOS is the gate on this unattended push power: empty = refuse every

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -403,6 +403,69 @@ services:
       - avg-data:/data
     networks: [avg-internal]
 
+  # C3 test-writer specialist runner — a copy of claude-task-runner pinned to the
+  # internal "test-writer" agent, so it claims ONLY approved agent=="test-writer"
+  # tasks (the queue's per-agent claim filter isolates it from claude/codex). It
+  # reuses the Claude-family billing-route check, the fail-closed worker repo
+  # allow-list, HALT, and the heartbeat — the same gates as claude-task-runner.
+  # OFF by default and independently controlled: needs the "test-writer-runner"
+  # profile AND TEST_WRITER_TASK_RUNNER_ENABLED=1 (mapped to the runner's own
+  # CLAUDE_TASK_RUNNER_ENABLED inside the container, so it can't be flipped on by
+  # the claude-runner's flag). The worker still refuses every task until
+  # CLAUDE_BRANCH_WORKER_ALLOWED_REPOS is populated.
+  test-writer-task-runner:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
+    profiles: ["test-writer-runner"]
+    restart: unless-stopped
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+      mcp-bundle:
+        condition: service_completed_successfully
+    command: ["node", "services/slack-operator/dist/claude-task-runner.js"]
+    environment:
+      AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
+      # Independent enable + id, remapped to the runner's own env var names so this
+      # service is controlled separately from the claude-runner.
+      CLAUDE_TASK_RUNNER_ENABLED: ${TEST_WRITER_TASK_RUNNER_ENABLED:-0}
+      CLAUDE_TASK_RUNNER_ID: ${TEST_WRITER_TASK_RUNNER_ID:-vps-test-writer-task-runner}
+      # Pin the agent identity so this runner claims ONLY test-writer tasks.
+      CLAUDE_TASK_RUNNER_AGENT: test-writer
+      # The dedicated test-writer worker entrypoint (hardcodes agent=test-writer;
+      # the runner also exports CLAUDE_TASK_AGENT=test-writer for the branch prefix).
+      CLAUDE_TASK_RUNNER_COMMAND: ${CLAUDE_TASK_RUNNER_COMMAND:-node}
+      CLAUDE_TASK_RUNNER_ARGS: ${TEST_WRITER_TASK_RUNNER_ARGS:-services/slack-operator/dist/test-writer-branch-worker.js}
+      CLAUDE_TASK_RUNNER_CWD: ${CLAUDE_TASK_RUNNER_CWD:-}
+      CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS: ${CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS:-10000}
+      CLAUDE_TASK_RUNNER_TIMEOUT_MS: ${CLAUDE_TASK_RUNNER_TIMEOUT_MS:-1800000}
+      CLAUDE_TASK_RUNNER_OUTPUT_TAIL_BYTES: ${CLAUDE_TASK_RUNNER_OUTPUT_TAIL_BYTES:-12000}
+      # Same fail-closed worker allow-list + auth/billing as the claude-runner.
+      CLAUDE_BRANCH_WORKER_ROOT: ${CLAUDE_BRANCH_WORKER_ROOT:-/data/claude-worker}
+      CLAUDE_BRANCH_WORKER_ALLOWED_REPOS: ${CLAUDE_BRANCH_WORKER_ALLOWED_REPOS:-}
+      CLAUDE_BRANCH_WORKER_BASE_BRANCH: ${CLAUDE_BRANCH_WORKER_BASE_BRANCH:-main}
+      CLAUDE_BRANCH_WORKER_CLAUDE_COMMAND: ${CLAUDE_BRANCH_WORKER_CLAUDE_COMMAND:-claude}
+      CLAUDE_BRANCH_WORKER_CLAUDE_ARGS: ${CLAUDE_BRANCH_WORKER_CLAUDE_ARGS:-}
+      CLAUDE_BRANCH_WORKER_GIT_USER_NAME: ${CLAUDE_BRANCH_WORKER_GIT_USER_NAME:-Averray Claude Worker}
+      CLAUDE_BRANCH_WORKER_GIT_USER_EMAIL: ${CLAUDE_BRANCH_WORKER_GIT_USER_EMAIL:-claude-worker@averray.local}
+      CLAUDE_WORKER_AUTH_MODE: ${CLAUDE_WORKER_AUTH_MODE:-sub}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CLAUDE_WORKER_DAILY_BUDGET: ${CLAUDE_WORKER_DAILY_BUDGET:-}
+      HALT_FILE: ${HALT_FILE:-/data/HALT}
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      GITHUB_OWNER_TOKENS: ${GITHUB_OWNER_TOKENS:-}
+      GITHUB_REPO_TOKENS: ${GITHUB_REPO_TOKENS:-}
+      GITHUB_DEFAULT_REPO: ${GITHUB_DEFAULT_REPO:-}
+      GITHUB_HELPER_REPOS: ${GITHUB_HELPER_REPOS:-}
+      GITHUB_API_BASE_URL: ${GITHUB_API_BASE_URL:-https://api.github.com}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - avg-data:/data
+    networks: [avg-internal]
+
   hermes:
     image: ${HERMES_IMAGE}
     restart: unless-stopped

--- a/test/unit/test-writer-runner.test.ts
+++ b/test/unit/test-writer-runner.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { parseClaudeTaskRunnerConfig } from "../../services/slack-operator/src/claude-task-runner.js";
+import {
+  approveCodexTask,
+  claimNextApprovedCodexTask,
+  proposeCodexTask,
+  taskAgent,
+} from "../../services/slack-operator/src/codex-task-queue.js";
+
+// C3 test-writer RUNNER wiring: a Claude-family runner pinned to agent
+// "test-writer" via CLAUDE_TASK_RUNNER_AGENT (the compose service sets it). It
+// must claim ONLY approved agent=="test-writer" tasks, and the claude-runner
+// (agent "claude") must never claim them — the queue's per-agent filter is the
+// isolation seam.
+
+describe("test-writer runner config", () => {
+  it("pins agent=test-writer from CLAUDE_TASK_RUNNER_AGENT", () => {
+    const config = parseClaudeTaskRunnerConfig({
+      CLAUDE_TASK_RUNNER_AGENT: "test-writer",
+      CLAUDE_TASK_RUNNER_ENABLED: "1",
+      CLAUDE_TASK_RUNNER_ID: "vps-test-writer-task-runner",
+    });
+    expect(config.agent).toBe("test-writer");
+    expect(config.enabled).toBe(true);
+    expect(config.runnerId).toBe("vps-test-writer-task-runner");
+  });
+
+  it("trims/normalizes the agent value", () => {
+    expect(parseClaudeTaskRunnerConfig({ CLAUDE_TASK_RUNNER_AGENT: "  test-writer  " }).agent).toBe("test-writer");
+  });
+
+  it("existing claude-runner behavior is unchanged: default agent is claude", () => {
+    expect(parseClaudeTaskRunnerConfig({}).agent).toBe("claude");
+    expect(parseClaudeTaskRunnerConfig({ CLAUDE_TASK_RUNNER_AGENT: "" }).agent).toBe("claude");
+  });
+});
+
+describe("test-writer runner claim isolation", () => {
+  let dir: string;
+  let path: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-test-writer-runner-"));
+    path = join(dir, "codex-tasks.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  async function seedApprovedTasks() {
+    const codex = await proposeCodexTask(
+      { repo: "averray-agent/agent", pullRequestNumber: 11, agent: "codex", prompt: "iterate PR" },
+      { path },
+    );
+    const claude = await proposeCodexTask(
+      { repo: "averray-agent/agent", agent: "claude", prompt: "build a thing" },
+      { path },
+    );
+    const testWriter = await proposeCodexTask(
+      { repo: "averray-agent/agent", agent: "test-writer", prompt: "add tests for the parser" },
+      { path },
+    );
+    // Approve codex + claude FIRST (older) so a naive claimer would grab them.
+    await approveCodexTask(codex.task.id, { path, approvedBy: "operator", now: new Date("2026-05-31T10:00:00.000Z") });
+    await approveCodexTask(claude.task.id, { path, approvedBy: "operator", now: new Date("2026-05-31T10:01:00.000Z") });
+    await approveCodexTask(testWriter.task.id, { path, approvedBy: "operator", now: new Date("2026-05-31T10:02:00.000Z") });
+    return { codexId: codex.task.id, claudeId: claude.task.id, testWriterId: testWriter.task.id };
+  }
+
+  it("the test-writer runner claims ONLY the test-writer task (skips older codex/claude)", async () => {
+    const { testWriterId } = await seedApprovedTasks();
+    const claimed = await claimNextApprovedCodexTask({
+      path,
+      runnerId: "vps-test-writer-task-runner",
+      agent: "test-writer",
+      now: new Date("2026-05-31T10:03:00.000Z"),
+    });
+    expect(claimed?.id).toBe(testWriterId);
+    expect(taskAgent(claimed!)).toBe("test-writer");
+  });
+
+  it("the claude runner never claims a test-writer task (and vice-versa)", async () => {
+    const { claudeId, testWriterId } = await seedApprovedTasks();
+
+    const claudeClaim = await claimNextApprovedCodexTask({
+      path,
+      runnerId: "vps-claude-task-runner",
+      agent: "claude",
+      now: new Date("2026-05-31T10:03:00.000Z"),
+    });
+    expect(claudeClaim?.id).toBe(claudeId);
+    expect(claudeClaim?.id).not.toBe(testWriterId);
+
+    // The test-writer task remains for the test-writer runner.
+    const testWriterClaim = await claimNextApprovedCodexTask({
+      path,
+      runnerId: "vps-test-writer-task-runner",
+      agent: "test-writer",
+      now: new Date("2026-05-31T10:04:00.000Z"),
+    });
+    expect(testWriterClaim?.id).toBe(testWriterId);
+  });
+
+  it("a test-writer runner finds nothing when only codex/claude tasks are approved", async () => {
+    const codex = await proposeCodexTask(
+      { repo: "averray-agent/agent", pullRequestNumber: 12, agent: "codex", prompt: "x" },
+      { path },
+    );
+    await approveCodexTask(codex.task.id, { path, approvedBy: "operator", now: new Date("2026-05-31T10:00:00.000Z") });
+    const claimed = await claimNextApprovedCodexTask({ path, agent: "test-writer", now: new Date("2026-05-31T10:01:00.000Z") });
+    expect(claimed).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed & why

The C3 `test-writer` agent/role already shipped (#310); what was missing is a **runner instance** to claim + execute its tasks — without it, approved `test-writer` tasks queue forever. This is the **ops/config wiring only**: a new profile-gated compose service, off by default, gated exactly like the other runners. No new code paths, no authority change.

- **New `test-writer-task-runner` service** (`ops/compose.yml`), `--profile test-writer-runner`, **off by default**. A copy of `claude-task-runner` pinned to the internal agent via a **literal** `CLAUDE_TASK_RUNNER_AGENT: test-writer`, so the queue's per-agent claim filter isolates it to approved `agent=="test-writer"` tasks. It runs the dedicated `test-writer-branch-worker` entrypoint and opens a normal `test-writer/*` PR through the human gate.
- **Independently controlled:** `TEST_WRITER_TASK_RUNNER_ENABLED` / `_ID` / `_ARGS` map to that container's own `CLAUDE_TASK_RUNNER_*`, so enabling the `claude-runner` can't flip this one on, and the agent pin keeps the claim sets disjoint. No `${CLAUDE_TASK_RUNNER_AGENT}` interpolation is added to the claude-runner — it still defaults to `claude`.
- **Same inherited gates** as the claude-runner: startup **billing-route verification** (fail-loud + refuse-to-claim on mismatch), the **fail-closed** worker repo allow-list (`CLAUDE_BRANCH_WORKER_ALLOWED_REPOS`, shared), `HALT_FILE`, and the heartbeat.
- **`ops/.env.example`:** `TEST_WRITER_TASK_RUNNER_*` defaults (off). **`docs/DEPLOY.md`:** an enable section mirroring the testbed-runner (profile up + env + redeploy + verify), including the independent-flag and shared-allow-list notes.
- **prod overlay:** `compose.prod.yml` only scopes `postgres`; the `claude-runner` has no prod overlay, so the test-writer runner needs none either (it's inherited from the base compose, and the deploy invocation already merges both files).

## Affected surfaces
- [x] Worker runners / task queue (new runner service)
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1131 passed; new: runner config pins `agent=test-writer` / default stays `claude`; claim filter returns ONLY `test-writer` approved tasks for it and never the claude/codex ones, both directions)
- [x] compose parses (both files); **CI's Docker-build job runs the real `docker compose … config`** — the gate for a new service

## Rollout / rollback
- **Off by default**, doubly gated: the `test-writer-runner` profile must be up **and** `TEST_WRITER_TASK_RUNNER_ENABLED=1`, **and** the worker still refuses every task until `CLAUDE_BRANCH_WORKER_ALLOWED_REPOS` is populated (fail-closed).
- **Enable:** `docker compose --env-file ops/.env.prod --profile test-writer-runner -f ops/compose.yml -f ops/compose.prod.yml up -d test-writer-task-runner` (see DEPLOY.md).
- **Rollback:** set `TEST_WRITER_TASK_RUNNER_ENABLED=0` (or drop the profile) and redeploy.

## Durable invariants (AGENTS.md)
- [x] No auto-merge/deploy — the runner opens a normal PR for human review; approval/autopilot gate unchanged
- [x] New runner carries the existing guardrail: fail-closed repo allow-list + billing-route check + HALT; off by default, operator-enabled per ops profile
- [x] No secrets committed/printed/logged (auth sourced from `.env.prod`)
- [x] Mirrors the `codex-runner` / `claude-runner` pattern per AGENTS.md

## Known limits / follow-ups
- Shares `CLAUDE_BRANCH_WORKER_ALLOWED_REPOS` and the Claude worker auth with the claude-runner (same billing route) — intentional; a separate allow-list/budget can be split out later if a specialist needs a narrower scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)