### PR TITLE
fix: dedupe B2 self-healing proposals

### DIFF
--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -5,7 +5,7 @@
 
 > **Naming:** one prefix per stream, numbered within it. **`P#` and `Phase #` are retired** — they collided (`P2` Claude worker vs `Phase 2` A+D). Use the IDs below in all handoff prompts and discussion.
 
-> **Reconciliation note (2026-05-31):** This index was reconciled against landed PRs #285-#297. It marks only code-backed shipped slices as done; A3b cost-aware routing/budget remains in progress, and T4/T6/T7 plus the remaining B/O5/C follow-ups stay design/follow-up unless code evidence proves otherwise. Current `main` has an O5 first slice in build, but O5 is not marked complete.
+> **Reconciliation note (2026-06-01):** This index was reconciled against landed PRs #285-#312. It marks only code-backed shipped slices as done; A3b cost-aware routing/budget remains in progress, and T4/T6/T7 plus the remaining B/O5/C follow-ups stay design/follow-up unless code evidence proves otherwise. B2's first self-healing slice is shipped and opt-in (#309): it proposes routed fixes for non-high-risk failures or escalates high-risk/rollback/D3/HALT cases, with env wiring in `ops/compose.yml`; it does not approve, run, merge, deploy, or roll back work.
 
 ## Streams
 
@@ -37,7 +37,7 @@
 | D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | ✅ done (#286) — anomaly auto-pause owns autopilot-suspended flag |
 | D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
 | B1 | Backlog generation (roadmap auto-flow; net-new escalates) | 🟡 in review — first planner-only/read-only backlog suggestions slice |
-| B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
+| B2 | Self-healing (auto-fix non-high-risk; rollback human) | ✅ first slice shipped (#309) — opt-in B2 routine collects failed testbed/deploy-verification signals, proposes routed non-high-risk fix tasks only, escalates high-risk/rollback/D3/HALT cases, and is guarded by open-proposal dedupe, cooldown, per-tick cap, and daily cap; approval/run/merge/deploy remain unchanged |
 | C1 | Cross-agent review (default) | 🟡 in build — first slice records/displays review requests only; no auto-run or authority change |
 | C2 | Reviewer panel (high-risk) | 🟡 in build — panel requests, verdict recording, and block/disagreement action-needed bridge |
 | C3 | Specialist agents (test-writer/security/docs) | 🟡 in build — first `test-writer` specialist template |
@@ -50,7 +50,7 @@
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | in flight — first slice adds `requested` missions, `/monitor/testbed-missions/request`, `/approve`, board approve UI, and runner-ready gating (this PR) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | design/follow-up — do not mark shipped here without code evidence; platform helper remains follow-up |
 
-*(Status as of 2026-05-31 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget, the O5 first slice, C3's first internal `test-writer` specialist template, and T6's first board-gated request/approve slice. **Design / follow-up:** remaining O5 hardening, B1–B2, C1–C2, remaining C follow-ups, T4, T7, and platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
+*(Status as of 2026-06-01 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, B2 first self-healing slice (#309), C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget, the O5 first slice, B1 first planner-only/read-only backlog suggestions slice, C3's first internal `test-writer` specialist template, and T6's first board-gated request/approve slice. **Design / follow-up:** remaining O5 hardening, B1 follow-ons, C1–C2, remaining C follow-ups, T4, T7, and platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; B2 proposes only and autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -185,14 +185,17 @@ services:
       # B2 — self-healing. On a failure: PROPOSE a routed fix (non-high-risk) that
       # still flows through the approval/autopilot gate, or ESCALATE (high-risk /
       # rollback / D3-suspended / HALT). Off by default; never auto-approves.
-      # Deduped (one open fix per surface) + cooldown'd. B2_SELF_HEALING_REPO is
-      # the repo a proposed fix targets (falls back to GITHUB_DEFAULT_REPO).
+      # Deduped (one open fix per target signature) + cooldown'd + capped per
+      # tick. B2_SELF_HEALING_REPO is the repo a proposed fix targets (falls
+      # back to GITHUB_DEFAULT_REPO).
       B2_SELF_HEALING_ENABLED: ${B2_SELF_HEALING_ENABLED:-0}
       B2_SELF_HEALING_INTERVAL_MINUTES: ${B2_SELF_HEALING_INTERVAL_MINUTES:-5}
       B2_SELF_HEALING_COOLDOWN_MINUTES: ${B2_SELF_HEALING_COOLDOWN_MINUTES:-30}
       # Concurrent open-fix cap: stops a batch of distinct failures from swarming
       # the queue even within the daily budget (escalates past the cap).
       B2_SELF_HEALING_MAX_OPEN_FIXES: ${B2_SELF_HEALING_MAX_OPEN_FIXES:-3}
+      # Per-tick proposal cap: stops one scan from proposing a burst.
+      B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK: ${B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK:-2}
       B2_SELF_HEALING_REPO: ${B2_SELF_HEALING_REPO:-}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}
       SLACK_OPERATOR_MONITOR_TOKEN: ${SLACK_OPERATOR_MONITOR_TOKEN:-}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -2296,8 +2296,8 @@ function startOperatorRoutines() {
           });
           return { agent: r.agent, riskTier: r.riskTier, reason: r.reason };
         },
-        hasOpenFixTask: async (surface) => {
-          const corr = `self-heal:${surface}`;
+        hasOpenFixTask: async (targetSignature) => {
+          const corr = `self-heal:${targetSignature}`;
           const tasks = await listCodexTasks();
           return tasks.some(
             (t) => t.correlationId === corr && !["completed", "failed", "cancelled"].includes(t.status),
@@ -2318,9 +2318,10 @@ function startOperatorRoutines() {
           ).length;
         },
         maxOpenFixTasks: routineConfig.selfHealing.maxOpenFixTasks,
-        inCooldown: (surface, nowMs) => selfHealingCooldown.inCooldown(surface, nowMs),
-        markHandled: (surface, nowMs) => selfHealingCooldown.markHandled(surface, nowMs),
-        propose: async ({ signal, agent, riskTier, prompt, routingReason }) => {
+        maxProposalsPerTick: routineConfig.selfHealing.maxProposalsPerTick,
+        inCooldown: (targetSignature, nowMs) => selfHealingCooldown.inCooldown(targetSignature, nowMs),
+        markHandled: (targetSignature, nowMs) => selfHealingCooldown.markHandled(targetSignature, nowMs),
+        propose: async ({ signal, targetSignature, agent, riskTier, prompt, routingReason }) => {
           const { task, created } = await proposeCodexTask({
             repo: signal.repo!,
             agent,
@@ -2330,7 +2331,7 @@ function startOperatorRoutines() {
             title: `Self-healing fix: ${signal.surface}`,
             reason: `Hermes self-healing proposal for a ${signal.source} failure`,
             requester: "hermes-self-healing",
-            correlationId: `self-heal:${signal.surface}`,
+            correlationId: `self-heal:${targetSignature}`,
           });
           // Flow through the EXISTING approval/autopilot gate (B2 never approves).
           if (created && task.status === "proposed") {
@@ -2341,7 +2342,7 @@ function startOperatorRoutines() {
         alert: (payload) => alertChannel.dispatch(payload),
         audit: async (record) => {
           await recordHandoffEvent({
-            correlationId: `self-heal:${record.surface}`,
+            correlationId: `self-heal:${record.targetSignature ?? `${record.source}:${record.surface}`}`,
             requester: "hermes-self-healing",
             intent: "self_healing",
             phase: "self_healing",

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -43,6 +43,8 @@ export interface SlackRoutineConfig {
     cooldownMs: number;
     /** Concurrent open-fix cap — stops a batch of failures swarming the queue. */
     maxOpenFixTasks: number;
+    /** Per-tick cap — stops one scan from proposing a burst. */
+    maxProposalsPerTick: number;
   };
 }
 
@@ -103,6 +105,7 @@ export function parseSlackRoutineConfig(
       intervalMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_INTERVAL_MINUTES) || 5) * 60_000),
       cooldownMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_COOLDOWN_MINUTES) || 30) * 60_000),
       maxOpenFixTasks: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_OPEN_FIXES) || 3),
+      maxProposalsPerTick: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK) || 2),
     },
   };
 }

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -11,10 +11,11 @@
 // suspended (D3) or HALT is set, B2 does NOT propose — it only escalates. That
 // interlock is what makes self-healing safe to build (no fix-fail-fix spiral).
 //
-// Storm control: dedup (at most one OPEN fix task per failing surface — checked
-// against the queue, so it survives a restart) + a cooldown (a flapping check
-// can't spawn a swarm) + a daily proposal budget backstop. Read-only except the
-// proposal itself, which is just a `proposed` queue entry. Never logs secrets.
+// Storm control: dedup (at most one OPEN fix task per failing target signature
+// — checked against the queue, so it survives a restart) + a cooldown (a
+// flapping check can't spawn a swarm) + per-tick/open-fix/daily proposal
+// backstops. Read-only except the proposal itself, which is just a `proposed`
+// queue entry. Never logs secrets.
 //
 // Pure decision (decideHealingAction) + effect-injected orchestrator
 // (runSelfHealingOnce) so the matrix is unit-tested with no fs/network.
@@ -58,6 +59,7 @@ export type HealingReason =
   | "high_risk_surface"
   | "dispatch_budget_exhausted"
   | "open_fix_cap_reached"
+  | "tick_budget_exhausted"
   | "routed_fix";
 
 /**
@@ -126,6 +128,15 @@ export function buildFixPrompt(signal: FailureSignal): string {
   return lines.join("\n");
 }
 
+/**
+ * Stable per-target signature for B2 storm control. Keep this tied to the
+ * failing task/mission identity, not volatile failure text, so refreshed error
+ * wording does not re-open the same fix every interval.
+ */
+export function selfHealingTargetSignature(signal: FailureSignal): string {
+  return `${signal.source}:${signal.surface}`;
+}
+
 export function buildHealingEscalationAlert(
   signal: FailureSignal,
   decision: HealingDecision,
@@ -155,6 +166,7 @@ function escalationHeadline(reason: HealingReason): string {
     case "no_target_repo": return "a failure with no routable fix target";
     case "dispatch_budget_exhausted": return "a failure, but the dispatch budget is exhausted";
     case "open_fix_cap_reached": return "a failure, but too many self-healing fixes are already open";
+    case "tick_budget_exhausted": return "a failure, but this tick's proposal cap is exhausted";
     default: return "a failure needs your attention";
   }
 }
@@ -172,6 +184,7 @@ function humanSource(source: HealingSource): string {
 
 export interface HealingAuditRecord {
   surface: string;
+  targetSignature?: string;
   source: HealingSource;
   action: "propose" | "escalate" | "skip";
   reason: HealingReason | "cooldown" | "open_fix_exists";
@@ -187,8 +200,8 @@ export interface SelfHealingDeps {
   isHalt: () => boolean;
   /** Classify a signal's surface → agent + riskTier (the routing taxonomy). */
   classify: (signal: FailureSignal) => HealingClassification;
-  /** Durable dedup: is there already a non-terminal fix task for this surface? */
-  hasOpenFixTask: (surface: string) => Promise<boolean> | boolean;
+  /** Durable dedup: is there already a non-terminal fix task for this target? */
+  hasOpenFixTask: (targetSignature: string) => Promise<boolean> | boolean;
   /** B2 fix tasks already proposed today (for the daily budget backstop). */
   proposalsToday: () => Promise<number> | number;
   maxProposalsPerDay: number;
@@ -197,12 +210,15 @@ export interface SelfHealingDeps {
    *  even within the daily budget. */
   openFixCount: () => Promise<number> | number;
   maxOpenFixTasks: number;
-  /** In-memory cooldown: has this surface been handled within the window? */
-  inCooldown: (surface: string, nowMs: number) => boolean;
-  markHandled: (surface: string, nowMs: number) => void;
+  /** Per-tick cap: prevents a noisy batch from proposing a burst of fixes. */
+  maxProposalsPerTick: number;
+  /** In-memory cooldown: has this target been handled within the window? */
+  inCooldown: (targetSignature: string, nowMs: number) => boolean;
+  markHandled: (targetSignature: string, nowMs: number) => void;
   /** Propose a `proposed` fix task and run it through the EXISTING gate. */
   propose: (input: {
     signal: FailureSignal;
+    targetSignature: string;
     agent: TaskAgent;
     riskTier: HealingRiskTier;
     prompt: string;
@@ -229,8 +245,9 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
   let proposedThisRun = 0;
 
   for (const signal of signals) {
+    const targetSignature = selfHealingTargetSignature(signal);
     // Cooldown: a flapping surface can't spawn a swarm of fixes/alerts.
-    if (deps.inCooldown(signal.surface, nowMs)) {
+    if (deps.inCooldown(targetSignature, nowMs)) {
       handled.push({ surface: signal.surface, action: "skip", reason: "cooldown" });
       continue;
     }
@@ -247,27 +264,32 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
     } else if (decision.action === "propose" && openFixCount + proposedThisRun >= deps.maxOpenFixTasks) {
       decision = { action: "escalate", reason: "open_fix_cap_reached", ...(decision.riskTier ? { riskTier: decision.riskTier } : {}) };
     }
+    if (decision.action === "propose" && proposedThisRun >= deps.maxProposalsPerTick) {
+      decision = { action: "escalate", reason: "tick_budget_exhausted", ...(decision.riskTier ? { riskTier: decision.riskTier } : {}) };
+    }
 
     if (decision.action === "propose") {
-      // Durable dedup: one open fix task per surface.
-      if (await deps.hasOpenFixTask(signal.surface)) {
-        deps.markHandled(signal.surface, nowMs);
-        await deps.audit({ surface: signal.surface, source: signal.source, action: "skip", reason: "open_fix_exists" });
+      // Durable dedup: one open fix proposal per failing target.
+      if (await deps.hasOpenFixTask(targetSignature)) {
+        deps.markHandled(targetSignature, nowMs);
+        await deps.audit({ surface: signal.surface, targetSignature, source: signal.source, action: "skip", reason: "open_fix_exists" });
         handled.push({ surface: signal.surface, action: "skip", reason: "open_fix_exists" });
         continue;
       }
       const prompt = buildFixPrompt(signal);
       const { taskId } = await deps.propose({
         signal,
+        targetSignature,
         agent: decision.agent!,
         riskTier: decision.riskTier!,
         prompt,
         routingReason: classification!.reason,
       });
       proposedThisRun += 1;
-      deps.markHandled(signal.surface, nowMs);
+      deps.markHandled(targetSignature, nowMs);
       await deps.audit({
         surface: signal.surface,
+        targetSignature,
         source: signal.source,
         action: "propose",
         reason: decision.reason,
@@ -282,9 +304,10 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
 
     // Escalate.
     await deps.alert(buildHealingEscalationAlert(signal, decision, deps.boardUrl));
-    deps.markHandled(signal.surface, nowMs);
+    deps.markHandled(targetSignature, nowMs);
     await deps.audit({
       surface: signal.surface,
+      targetSignature,
       source: signal.source,
       action: "escalate",
       reason: decision.reason,

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -7,6 +7,7 @@ import {
   buildHealingEscalationAlert,
   createCooldown,
   testbedSurfaceKey,
+  selfHealingTargetSignature,
   type FailureSignal,
   type HealingClassification,
   type SelfHealingDeps,
@@ -100,6 +101,7 @@ function harness(signals: FailureSignal[], over: Partial<SelfHealingDeps> = {}, 
     maxProposalsPerDay: 10,
     openFixCount: () => 0,
     maxOpenFixTasks: 3,
+    maxProposalsPerTick: 10,
     inCooldown: (s, n) => cooldown.inCooldown(s, n),
     markHandled: (s, n) => cooldown.markHandled(s, n),
     propose: async ({ signal: s, agent, riskTier }) => {
@@ -156,20 +158,45 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
   });
 
   it("dedup: an already-open fix task for the surface → skip (no second proposal)", async () => {
-    const h = harness([signal()], { hasOpenFixTask: () => true });
+    const h = harness([signal()], { hasOpenFixTask: (targetSignature) => targetSignature === "testbed_mission:testbed:sweep-1" });
     await runSelfHealingOnce(h.deps);
     expect(h.proposed).toHaveLength(0);
     expect(h.audits[0]).toMatchObject({ action: "skip", reason: "open_fix_exists" });
   });
 
-  it("cooldown: a surface handled within the window is skipped", async () => {
+  it("cooldown: a target handled within the window is skipped", async () => {
     const cd = createCooldown(30 * 60_000);
-    cd.markHandled("testbed:sweep-1", Date.parse("2026-05-31T11:50:00.000Z")); // 10m before now
+    cd.markHandled("testbed_mission:testbed:sweep-1", Date.parse("2026-05-31T11:50:00.000Z")); // 10m before now
     const h = harness([signal()], { inCooldown: (s, n) => cd.inCooldown(s, n), markHandled: (s, n) => cd.markHandled(s, n) });
     const r = await runSelfHealingOnce(h.deps);
     expect(h.proposed).toHaveLength(0);
     expect(h.alerts).toBe(0);
     expect(r.handled[0]).toMatchObject({ action: "skip", reason: "cooldown" });
+  });
+
+  it("same failure twice within cooldown → proposed once", async () => {
+    const cooldown = createCooldown(30 * 60_000);
+    const now = { value: Date.parse("2026-05-31T12:00:00.000Z") };
+    const first = harness([signal()], {
+      inCooldown: (target, n) => cooldown.inCooldown(target, n),
+      markHandled: (target, n) => cooldown.markHandled(target, n),
+      now: () => new Date(now.value),
+    });
+    const second = harness([signal({ summary: "same mission failed again: 503 on /overview" })], {
+      inCooldown: (target, n) => cooldown.inCooldown(target, n),
+      markHandled: (target, n) => cooldown.markHandled(target, n),
+      now: () => new Date(now.value + 5 * 60_000),
+    });
+
+    await runSelfHealingOnce(first.deps);
+    await runSelfHealingOnce(second.deps);
+
+    expect(first.proposed).toHaveLength(1);
+    expect(second.proposed).toHaveLength(0);
+  });
+
+  it("uses a stable target signature based on the failing mission identity, not refreshed failure text", () => {
+    expect(selfHealingTargetSignature(signal())).toBe(selfHealingTargetSignature(signal({ summary: "updated failure text" })));
   });
 
   it("D3 interlock: suspended → escalate only (no proposal)", async () => {
@@ -196,6 +223,17 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "dispatch_budget_exhausted" });
   });
 
+  it("per-tick cap: extra same-tick proposals escalate instead of bursting", async () => {
+    const h = harness([
+      signal({ surface: "testbed:a" }),
+      signal({ surface: "testbed:b" }),
+    ], { maxProposalsPerTick: 1 });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:a"]);
+    expect(h.alerts).toBe(1);
+    expect(h.audits.find((a) => a.surface === "testbed:b")).toMatchObject({ action: "escalate", reason: "tick_budget_exhausted" });
+  });
+
   it("mixed batch: one low-risk proposes, one high-risk escalates, deduped surface skips", async () => {
     const signals = [
       signal({ surface: "testbed:a" }),
@@ -204,7 +242,7 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     ];
     const h = harness(signals, {
       classify: (s) => (s.area === "deploy" ? HIGH : LOW),
-      hasOpenFixTask: (surface) => surface === "testbed:c",
+      hasOpenFixTask: (targetSignature) => targetSignature === "testbed_mission:testbed:c",
     });
     await runSelfHealingOnce(h.deps);
     expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:a"]);

--- a/test/unit/slack-routines.test.ts
+++ b/test/unit/slack-routines.test.ts
@@ -22,6 +22,8 @@ describe("slack operator routines", () => {
       SLACK_OPERATOR_SAFE_WORK_SCAN_INTERVAL_MINUTES: "15",
       SLACK_OPERATOR_STALE_PR_ALERT_INTERVAL_MINUTES: "20",
       SLACK_OPERATOR_STALE_PR_ALERT_AFTER_MINUTES: "180",
+      B2_SELF_HEALING_ENABLED: "1",
+      B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK: "3",
     }, new Set(["C1"]));
 
     expect(config.channelId).toBe("C1");
@@ -38,6 +40,8 @@ describe("slack operator routines", () => {
     expect(config.stalePrAlerts.enabled).toBe(true);
     expect(config.stalePrAlerts.intervalMs).toBe(20 * 60_000);
     expect(config.stalePrAlerts.staleAfterMinutes).toBe(180);
+    expect(config.selfHealing.enabled).toBe(true);
+    expect(config.selfHealing.maxProposalsPerTick).toBe(3);
   });
 
   it("lets an explicit routine channel override the allowed-channel fallback", () => {


### PR DESCRIPTION
## What changed & why

- Hardened B2 self-healing storm control around a stable failing-target signature (`source:surface`) so refreshed failure text does not create the same fix again every interval.
- Moved cooldown/open-proposal checks to that stable target signature, kept proposals routed through the existing proposed-task gate, and added `B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK` with a conservative default of 2.
- Reconciled `docs/HERMES_ROADMAP.md`: B2 is no longer only design done; the code-backed first slice shipped in #309 and is opt-in/proposes-only with D3/HALT/high-risk/rollback escalation.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

Compose note: attempted local compose parsing, but this Mac Docker install has neither the `docker compose` plugin nor `docker-compose`; `npm test` includes `test/unit/compose-env.test.ts`, which passed.

## Rollout / rollback

- New optional env: `B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK`, defaulting to `2` in compose when unset.
- Rollback is the normal revert: removing this PR returns B2 to the prior surface-level dedupe/cooldown and daily cap behavior.
- No secret changes required.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- This does not change B2 approval/run authority. B2 still only proposes tasks or escalates; the existing O4 approval/autopilot gate remains unchanged.
