### PR TITLE
feat: complete high-risk reviewer panel escalation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,12 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   redacts command output, and **opens a PR but never merges**. The Claude
   worker is greenfield (creates the branch + opens the PR); the Codex worker
   iterates an existing PR.
-- **Cross-agent review requests are advisory records.** Hermes, the operator,
-  Codex, or Claude may request a second-agent review on a card, but the request
-  only records/displays coordination context; it does **not** enqueue a task,
-  auto-run a reviewer, approve dispatch, merge, or deploy.
+- **Cross-agent review requests and C2 reviewer panels are advisory records.**
+  Hermes, the operator, Codex, or Claude may request a second-agent review on a
+  card. High-risk work uses a panel of independent Hermes/Codex/Claude verdicts;
+  any block or disagreement parks the card in action-needed for the operator and
+  the D4 bridge. These requests do **not** enqueue a task, auto-run a reviewer,
+  approve dispatch, merge, or deploy.
 
 ---
 

--- a/docs/HERMES_PHASE4_DESIGN.md
+++ b/docs/HERMES_PHASE4_DESIGN.md
@@ -19,6 +19,12 @@
 
 Any unresolved disagreement — a panel split, or a reviewer that blocks — **parks the PR for the operator**, showing each reviewer's verdict + reasoning side by side. The human owns the call. Consistent with every other gate in the system; no agent quietly overrides another. (Decision records from D2 make the disagreement legible.)
 
+Implementation note: C2 is advisory only. A high-risk panel records independent
+Hermes/Codex/Claude review requests and verdicts. A `block` verdict escalates as
+soon as it lands; any completed non-unanimous panel also parks the card in
+`needs-attention`, which lets the existing D4 alert bridge notify the operator.
+No panel path merges, deploys, approves dispatch, or changes high-risk routing.
+
 ## C3 — Roster growth  ·  **internal specialists now, external later** (decision #3)
 
 - **Internal specialists now:** add role-specific agents — a **test-writer**, a **security-review** agent, a **docs** agent — via the per-agent-runner pattern from P2. Adding one is modular: a new runner + a new `agentType` + a routing-taxonomy entry. The risk taxonomy decides what each is trusted with (e.g. the security-review agent is a reviewer, not a builder, on high-risk surfaces).

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -39,7 +39,7 @@
 | B1 | Backlog generation (roadmap auto-flow; net-new escalates) | 🟡 in review — first planner-only/read-only backlog suggestions slice |
 | B2 | Self-healing (auto-fix non-high-risk; rollback human) | design done |
 | C1 | Cross-agent review (default) | 🟡 in build — first slice records/displays review requests only; no auto-run or authority change |
-| C2 | Reviewer panel (high-risk) | design done |
+| C2 | Reviewer panel (high-risk) | 🟡 in build — panel requests, verdict recording, and block/disagreement action-needed bridge |
 | C3 | Specialist agents (test-writer/security/docs) | 🟡 in build — first `test-writer` specialist template |
 | C4 | Inter-agent chat | ✅ done (#291) — Claude author/target + card-scoped agent messages v1 |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -44,6 +44,7 @@ import {
   recordCollaborationMessage,
   recordHermesMemoryNote,
   recordReviewPanelRequests,
+  recordReviewResponse,
   recordReviewRequest,
   synthesizeHermesReplyFor,
   type ReviewRequestStatus,
@@ -829,6 +830,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     await handleMonitorReviewRequest(request, response);
     return;
   }
+  if (request.method === "POST" && url.pathname === "/monitor/review-requests/respond") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorReviewResponse(request, response);
+    return;
+  }
   if (request.method === "POST" && url.pathname === "/monitor/review-panels") {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
@@ -918,6 +931,39 @@ async function handleMonitorReviewRequest(request: http.IncomingMessage, respons
     logger.error({ err: error }, "monitor_review_request_failed");
     writeJson(response, 500, {
       error: "monitor_review_request_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorReviewResponse(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const result = recordReviewResponse(payload);
+    logger.info(
+      {
+        id: result.reviewRequest.id,
+        reviewer: result.reviewRequest.reviewer,
+        verdict: result.reviewRequest.response?.verdict,
+        panelId: result.reviewRequest.panelId,
+        escalated: result.panelEvaluation?.escalate === true,
+      },
+      "monitor_review_response_recorded"
+    );
+    writeJson(response, 200, { ok: true, ...result });
+  } catch (error) {
+    if (error instanceof CollaborationValidationError) {
+      writeJson(response, 400, { error: error.code, message: error.message });
+      return;
+    }
+    logger.error({ err: error }, "monitor_review_response_failed");
+    writeJson(response, 500, {
+      error: "monitor_review_response_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -1,8 +1,12 @@
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import {
+  evaluateReviewPanel,
   planReviewForRisk,
+  type ReviewPanelEvaluation,
   type ReviewPanelMode,
+  type ReviewPanelResponse,
+  type ReviewPanelReviewer,
   type ReviewPanelVerdict,
 } from "./reviewer-panel.js";
 
@@ -136,12 +140,26 @@ export interface RecordReviewPanelInput {
   reason?: unknown;
 }
 
+export interface RecordReviewResponseInput {
+  id?: unknown;
+  panelId?: unknown;
+  reviewer?: unknown;
+  verdict?: unknown;
+  reasoning?: unknown;
+  respondedAt?: unknown;
+}
+
 export interface RecordReviewPanelResult {
   panelId: string;
   mode: ReviewPanelMode;
   reviewers: ReviewRequestReviewer[];
   requests: ReviewRequest[];
   reason: string;
+}
+
+export interface RecordReviewResponseResult {
+  reviewRequest: ReviewRequest;
+  panelEvaluation?: ReviewPanelEvaluation;
 }
 
 export interface ListCollaborationOptions {
@@ -367,6 +385,71 @@ export function recordReviewPanelRequests(
   };
 }
 
+export function recordReviewResponse(
+  input: RecordReviewResponseInput,
+  nowMs: number = Date.now()
+): RecordReviewResponseResult {
+  const id = normalizeCorrelationId(input.id);
+  const panelId = normalizeCorrelationId(input.panelId);
+  const reviewer = normalizeReviewer(input.reviewer);
+  if (!id && (!panelId || !reviewer)) {
+    throw new CollaborationValidationError(
+      "missing_review_response_target",
+      "review response must include either id, or panelId + reviewer."
+    );
+  }
+
+  const verdict = normalizeReviewVerdict(input.verdict);
+  if (!verdict) {
+    throw new CollaborationValidationError(
+      "invalid_review_verdict",
+      "verdict must be one of: pass, concern, block."
+    );
+  }
+
+  const reasoning = normalizeText(input.reasoning);
+  if (!reasoning) {
+    throw new CollaborationValidationError(
+      "invalid_review_reasoning",
+      "reasoning is required and must be a non-empty string (max 4000 chars)."
+    );
+  }
+
+  const index = id
+    ? reviewRequests.findIndex((request) => request.id === id)
+    : findReviewRequestIndexByPanel(panelId!, reviewer!);
+  if (index < 0) {
+    throw new CollaborationValidationError(
+      "review_request_not_found",
+      "review request was not found."
+    );
+  }
+
+  const existing = reviewRequests[index]!;
+  if (existing.status === "cancelled") {
+    throw new CollaborationValidationError(
+      "review_request_cancelled",
+      "cancelled review requests cannot be answered."
+    );
+  }
+
+  const respondedAt = normalizeCorrelationId(input.respondedAt) ?? new Date(nowMs).toISOString();
+  const updated: ReviewRequest = {
+    ...existing,
+    status: "responded",
+    response: { verdict, reasoning, respondedAt },
+    updatedAt: new Date(nowMs).toISOString(),
+  };
+  reviewRequests[index] = updated;
+  recordReviewResponseCollaborationTurn(updated, nowMs);
+
+  const panelEvaluation = evaluateReviewPanelForRequest(updated);
+  return {
+    reviewRequest: updated,
+    ...(panelEvaluation ? { panelEvaluation } : {}),
+  };
+}
+
 export function listReviewRequests(options: ListReviewRequestsOptions = {}): ReviewRequest[] {
   const limit = clampLimit(options.limit, MAX_REVIEW_REQUESTS);
   const filtered = options.status
@@ -472,6 +555,11 @@ function normalizeReviewStatus(value: unknown): ReviewRequestStatus | null {
   return null;
 }
 
+function normalizeReviewVerdict(value: unknown): ReviewPanelVerdict | null {
+  if (value === "pass" || value === "concern" || value === "block") return value;
+  return null;
+}
+
 function normalizeReviewMode(value: unknown): ReviewPanelMode | undefined {
   if (value == null || value === "") return undefined;
   if (value === "single" || value === "panel") return value;
@@ -553,6 +641,14 @@ function nextMemoryId(nowMs: number): string {
   return `hermes-memory-${nowMs.toString(36)}-${memorySeq.toString(36)}`;
 }
 
+function findReviewRequestIndexByPanel(panelId: string, reviewer: ReviewRequestReviewer): number {
+  for (let i = reviewRequests.length - 1; i >= 0; i -= 1) {
+    const request = reviewRequests[i]!;
+    if (request.panelId === panelId && request.reviewer === reviewer) return i;
+  }
+  return -1;
+}
+
 function recordReviewRequestCollaborationTurn(request: ReviewRequest, nowMs: number): void {
   const scope = reviewRequestScopeLabel(request);
   const reviewer = actorDisplayName(request.reviewer);
@@ -565,6 +661,52 @@ function recordReviewRequestCollaborationTurn(request: ReviewRequest, nowMs: num
     ...(request.relatedPr ? { relatedPr: request.relatedPr } : {}),
     ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
   }, nowMs);
+}
+
+function recordReviewResponseCollaborationTurn(request: ReviewRequest, nowMs: number): void {
+  if (!request.response) return;
+  const scope = reviewRequestScopeLabel(request);
+  const actor = actorDisplayName(request.reviewer);
+  const relatedCorrelationId = request.correlationId ?? request.relatedMission?.id;
+  recordCollaborationMessage({
+    author: request.reviewer,
+    kind: "status",
+    addressedTo: "operator",
+    text: `${actor} review verdict${scope ? ` on ${scope}` : ""}: ${request.response.verdict} — ${request.response.reasoning}`,
+    ...(request.relatedPr ? { relatedPr: request.relatedPr } : {}),
+    ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
+  }, nowMs);
+}
+
+function evaluateReviewPanelForRequest(request: ReviewRequest): ReviewPanelEvaluation | undefined {
+  if (!request.panelId) return undefined;
+  const panelRequests = reviewRequests.filter((candidate) => candidate.panelId === request.panelId);
+  if (!panelRequests.some((candidate) => candidate.reviewMode === "panel")) return undefined;
+  const reviewers = panelRequests
+    .map((candidate) => candidate.reviewer)
+    .filter(isReviewPanelReviewer);
+  const uniqueReviewers = Array.from(new Set(reviewers));
+  if (uniqueReviewers.length < 2) return undefined;
+  const responses: ReviewPanelResponse[] = panelRequests
+    .filter((candidate): candidate is ReviewRequest & {
+      reviewer: ReviewPanelReviewer;
+      response: NonNullable<ReviewRequest["response"]>;
+    } => Boolean(candidate.response) && isReviewPanelReviewer(candidate.reviewer))
+    .map((candidate) => ({
+      reviewer: candidate.reviewer,
+      verdict: candidate.response.verdict,
+      reasoning: candidate.response.reasoning,
+    }));
+  return evaluateReviewPanel({
+    panelId: request.panelId,
+    relatedLabel: reviewRequestScopeLabel(request),
+    reviewers: uniqueReviewers,
+    responses,
+  });
+}
+
+function isReviewPanelReviewer(value: ReviewRequestReviewer): value is ReviewPanelReviewer {
+  return value === "hermes" || value === "codex" || value === "claude";
 }
 
 function reviewRequestScopeLabel(request: ReviewRequest): string {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -32,6 +32,12 @@ import {
   isHermesDecisionRecord,
   type HermesDecisionRecord,
 } from "@avg/averray-mcp/decision-records";
+import {
+  evaluateReviewPanel,
+  type ReviewPanelEvaluation,
+  type ReviewPanelResponse,
+  type ReviewPanelReviewer,
+} from "./reviewer-panel.js";
 
 // ── v2 typed model ──────────────────────────────────────────────────
 
@@ -762,7 +768,75 @@ function attachReviewRequests(
       || (request.correlationId !== undefined && request.correlationId === card.id)
     )
     .map(({ relatedPrKey, relatedMissionId, correlationId, ...request }) => request);
-  return active.length > 0 ? { ...card, reviewRequests: active } : card;
+  if (active.length === 0) return card;
+  return promoteCardForReviewPanelEscalation({ ...card, reviewRequests: active }, active);
+}
+
+function promoteCardForReviewPanelEscalation(
+  card: BoardCard,
+  requests: readonly CardReviewRequest[]
+): BoardCard {
+  const escalation = firstReviewPanelEscalation(card, requests);
+  if (!escalation) return card;
+  const riskSignals = [
+    ...(card.riskSignals ?? []),
+    {
+      severity: "high" as const,
+      code: escalation.agreement === "blocked" ? "review_panel_blocked" : "review_panel_disagreement",
+      message: escalation.summary,
+    },
+  ];
+  const risk = Array.from(new Set([...card.risk, "workflow", "review-gated"] as RiskTag[]));
+  return {
+    ...card,
+    lane: "needs-attention",
+    isAction: true,
+    waitingOn: { actor: "operator", tone: "warn" },
+    risk,
+    riskSignals,
+    summary: card.summary ? `${escalation.summary} · ${card.summary}` : escalation.summary,
+  };
+}
+
+function firstReviewPanelEscalation(
+  card: BoardCard,
+  requests: readonly CardReviewRequest[]
+): ReviewPanelEvaluation | undefined {
+  const panelIds = Array.from(new Set(
+    requests
+      .filter((request) => request.reviewMode === "panel" && request.panelId)
+      .map((request) => request.panelId!)
+  ));
+  for (const panelId of panelIds) {
+    const panelRequests = requests.filter((request) => request.panelId === panelId);
+    const reviewers = panelRequests
+      .map((request) => request.reviewer)
+      .filter(isReviewPanelReviewer);
+    const uniqueReviewers = Array.from(new Set(reviewers));
+    if (uniqueReviewers.length < 2) continue;
+    const responses: ReviewPanelResponse[] = panelRequests
+      .filter((request): request is CardReviewRequest & {
+        reviewer: ReviewPanelReviewer;
+        response: NonNullable<CardReviewRequest["response"]>;
+      } => Boolean(request.response) && isReviewPanelReviewer(request.reviewer))
+      .map((request) => ({
+        reviewer: request.reviewer,
+        verdict: request.response.verdict,
+        reasoning: request.response.reasoning,
+      }));
+    const evaluation = evaluateReviewPanel({
+      panelId,
+      relatedLabel: card.id,
+      reviewers: uniqueReviewers,
+      responses,
+    });
+    if (evaluation.escalate) return evaluation;
+  }
+  return undefined;
+}
+
+function isReviewPanelReviewer(value: CardReviewRequest["reviewer"]): value is ReviewPanelReviewer {
+  return value === "hermes" || value === "codex" || value === "claude";
 }
 
 const EVIDENCE_KINDS = new Set(["screenshot", "trace", "console", "video"]);

--- a/services/slack-operator/src/reviewer-panel.ts
+++ b/services/slack-operator/src/reviewer-panel.ts
@@ -71,6 +71,17 @@ export function evaluateReviewPanel(input: ReviewPanelEvaluationInput): ReviewPa
   const reviewers = input.reviewers.map((reviewer) => responsesByReviewer.get(reviewer)).filter(Boolean) as ReviewPanelResponse[];
   const pendingCount = input.reviewers.length - reviewers.length;
 
+  // A block is actionable as soon as it lands; the operator should not wait for
+  // the rest of the panel to answer before seeing the card.
+  const blocker = reviewers.find((reviewer) => reviewer.verdict === "block");
+  if (blocker) {
+    return withEscalation(input, reviewers, {
+      agreement: "blocked",
+      panelVerdict: "block",
+      summary: `${displayName(blocker.reviewer)} blocked ${input.relatedLabel}; operator decision required.`,
+    });
+  }
+
   if (pendingCount > 0) {
     return {
       panelId: input.panelId,
@@ -81,15 +92,6 @@ export function evaluateReviewPanel(input: ReviewPanelEvaluationInput): ReviewPa
       reviewers,
       summary: `Panel is waiting on ${pendingCount} reviewer${pendingCount === 1 ? "" : "s"} for ${input.relatedLabel}.`,
     };
-  }
-
-  const blocker = reviewers.find((reviewer) => reviewer.verdict === "block");
-  if (blocker) {
-    return withEscalation(input, reviewers, {
-      agreement: "blocked",
-      panelVerdict: "block",
-      summary: `${displayName(blocker.reviewer)} blocked ${input.relatedLabel}; operator decision required.`,
-    });
   }
 
   const counts = verdictCounts(reviewers);
@@ -108,15 +110,11 @@ export function evaluateReviewPanel(input: ReviewPanelEvaluationInput): ReviewPa
   }
 
   if (top.count > reviewers.length / 2) {
-    return {
-      panelId: input.panelId,
-      relatedLabel: input.relatedLabel,
+    return withEscalation(input, reviewers, {
       agreement: "majority",
       panelVerdict: top.verdict,
-      escalate: false,
-      reviewers,
-      summary: `Reviewer panel majority: ${top.verdict} for ${input.relatedLabel}; minority reasoning remains attached for the operator.`,
-    };
+      summary: `Reviewer panel disagrees on ${input.relatedLabel}; majority is ${top.verdict}, operator decision required.`,
+    });
   }
 
   return withEscalation(input, reviewers, {

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -13,6 +13,7 @@ import {
   recordCollaborationMessage,
   recordHermesMemoryNote,
   recordReviewPanelRequests,
+  recordReviewResponse,
   recordReviewRequest,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
@@ -381,6 +382,56 @@ describe("monitor review requests", () => {
       reviewMode: "single",
       panelSize: 1,
     });
+  });
+
+  it("records panel reviewer verdicts against existing requests without creating tasks", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "review-panel-response-task-queue-"));
+    const queuePath = join(dir, "tasks.json");
+    try {
+      const panel = recordReviewPanelRequests(
+        {
+          relatedPr: { repo: "depre-dev/averray-reference-agent", number: 302 },
+          requestedBy: "hermes",
+          riskTier: "high",
+          builder: "codex",
+          reason: "High-risk contract-adjacent surface.",
+        },
+        NOW
+      );
+
+      const codex = recordReviewResponse(
+        {
+          panelId: panel.panelId,
+          reviewer: "codex",
+          verdict: "block",
+          reasoning: "Settlement path needs operator proof before merge.",
+        },
+        NOW + 1_000
+      );
+
+      expect(codex.reviewRequest).toMatchObject({
+        reviewer: "codex",
+        status: "responded",
+        response: {
+          verdict: "block",
+          reasoning: "Settlement path needs operator proof before merge.",
+        },
+      });
+      expect(codex.panelEvaluation).toMatchObject({
+        agreement: "blocked",
+        panelVerdict: "block",
+        escalate: true,
+      });
+      expect(listReviewRequests({ status: "responded" })).toHaveLength(1);
+      expect(listCollaborationMessages({ limit: 1 }, NOW + 2_000)[0]).toMatchObject({
+        author: "codex",
+        addressedTo: "operator",
+        text: expect.stringContaining("block"),
+      });
+      await expect(listCodexTasks({ path: queuePath })).resolves.toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -752,6 +752,86 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     ]);
   });
 
+  it("promotes a blocked high-risk reviewer panel to needs-attention for the D4 bridge", () => {
+    const raw = {
+      active: [
+        {
+          title: "Change settlement deploy path",
+          status: "needs_review",
+          intent: "operator_review",
+          ageLabel: "4m",
+          summary: {
+            pullRequest: { repo: "depre-dev/agent", number: 601, state: "open" },
+            currentPullRequest: { repo: "depre-dev/agent", number: 601, state: "open" },
+            finalVerdict: "operator_review",
+          },
+        },
+      ],
+      recent: [],
+      reviewRequests: [
+        {
+          id: "review-hermes",
+          relatedPr: { repo: "depre-dev/agent", number: 601 },
+          requestedBy: "hermes",
+          reviewer: "hermes",
+          reason: "High-risk reviewer panel.",
+          status: "responded",
+          reviewMode: "panel",
+          panelId: "panel-601",
+          panelSize: 3,
+          response: {
+            verdict: "pass",
+            reasoning: "Checks are green.",
+            respondedAt: "2026-05-31T12:04:00.000Z",
+          },
+          createdAt: "2026-05-31T12:00:00.000Z",
+          updatedAt: "2026-05-31T12:04:00.000Z",
+        },
+        {
+          id: "review-codex",
+          relatedPr: { repo: "depre-dev/agent", number: 601 },
+          requestedBy: "hermes",
+          reviewer: "codex",
+          reason: "High-risk reviewer panel.",
+          status: "responded",
+          reviewMode: "panel",
+          panelId: "panel-601",
+          panelSize: 3,
+          response: {
+            verdict: "block",
+            reasoning: "Settlement rollback proof is missing.",
+            respondedAt: "2026-05-31T12:05:00.000Z",
+          },
+          createdAt: "2026-05-31T12:00:00.000Z",
+          updatedAt: "2026-05-31T12:05:00.000Z",
+        },
+        {
+          id: "review-claude",
+          relatedPr: { repo: "depre-dev/agent", number: 601 },
+          requestedBy: "hermes",
+          reviewer: "claude",
+          reason: "High-risk reviewer panel.",
+          status: "requested",
+          reviewMode: "panel",
+          panelId: "panel-601",
+          panelSize: 3,
+          createdAt: "2026-05-31T12:00:00.000Z",
+          updatedAt: "2026-05-31T12:00:00.000Z",
+        },
+      ],
+    };
+
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const card = snap.cards.find((c) => c.id === "agent #601");
+    expect(card).toMatchObject({
+      lane: "needs-attention",
+      isAction: true,
+      waitingOn: { actor: "operator", tone: "warn" },
+    });
+    expect(card?.summary).toContain("Codex blocked agent #601");
+    expect(card?.riskSignals?.some((signal) => signal.code === "review_panel_blocked")).toBe(true);
+  });
+
   it("enriches a mission card with the browser agent's structured report (by correlationId)", () => {
     // A classified mission item carries correlationId = run.id and no PR
     // number; the run with its report is bundled at snapshot.testbedMissions.

--- a/test/unit/reviewer-panel.test.ts
+++ b/test/unit/reviewer-panel.test.ts
@@ -42,7 +42,7 @@ describe("C2 reviewer panel", () => {
     });
   });
 
-  it("allows a no-block majority while keeping minority reasoning attached", () => {
+  it("escalates any no-block disagreement while keeping every verdict attached", () => {
     const evaluation = evaluateReviewPanel({
       panelId: "panel-2",
       relatedLabel: "agent#405",
@@ -53,9 +53,10 @@ describe("C2 reviewer panel", () => {
     expect(evaluation).toMatchObject({
       agreement: "majority",
       panelVerdict: "pass",
-      escalate: false,
+      escalate: true,
     });
     expect(evaluation.reviewers).toHaveLength(3);
+    expect(evaluation.summary).toMatch(/operator decision required/);
   });
 
   it("escalates disagreement with every reviewer verdict in the D4 alert payload", () => {
@@ -98,6 +99,22 @@ describe("C2 reviewer panel", () => {
       panelVerdict: "pending",
       escalate: false,
     });
+  });
+
+  it("escalates a block immediately even when other panelists are pending", () => {
+    const evaluation = evaluateReviewPanel({
+      panelId: "panel-5",
+      relatedLabel: "agent#408",
+      reviewers: ["hermes", "codex", "claude"],
+      responses: [{ reviewer: "codex", verdict: "block", reasoning: "contract deploy path is unsafe" }],
+    });
+
+    expect(evaluation).toMatchObject({
+      agreement: "blocked",
+      panelVerdict: "block",
+      escalate: true,
+    });
+    expect(evaluation.alert?.text).toContain("Codex: block");
   });
 });
 


### PR DESCRIPTION
## What changed
- Completed the C2 high-risk reviewer panel semantics on top of the shipped C1/C4 review/collaboration surfaces.
- Added a response path for existing review requests: reviewers can record pass/concern/block verdicts against a request or a panel reviewer slot.
- Tightened panel evaluation so any block escalates immediately and any completed non-unanimous panel is operator-needed.
- Promoted escalated panel cards into the monitor `needs-attention` lane so the existing D4 alert bridge sees them and alerts through the normal board action-needed path.
- Updated AGENTS/roadmap/design docs to state the advisory-only panel contract.

## Safety / authority
- Advisory only: no auto-run, no auto-merge, no deploy, no dispatch approval changes.
- High-risk routing stays rule-bound to Codex through the existing routing taxonomy; this PR only records reviewer evidence and surfaces operator-needed disagreement.
- Invariant #8 honored: no new Polkadot/chain behavior claims were introduced.

## Checks
- `npm run typecheck`
- `npm test`
- `git diff --check origin/main...HEAD`

## Affected surfaces
- slack-operator monitor review endpoints, collaboration store, reviewer-panel evaluation, v2 board enrichment
- monitor/docs/test coverage
- No ops/compose changes