### PR TITLE
Add advisory reviewer panel verdict escalation

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -406,6 +406,8 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/agents",
           "/monitor/collaboration",
           "/monitor/review-requests",
+          "/monitor/review-panels",
+          "/monitor/review-responses",
           "/monitor/tester/capabilities",
           "/monitor/testbed-missions",
           "/monitor/manifest.webmanifest",
@@ -830,7 +832,10 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     await handleMonitorReviewRequest(request, response);
     return;
   }
-  if (request.method === "POST" && url.pathname === "/monitor/review-requests/respond") {
+  if (request.method === "POST" && (
+    url.pathname === "/monitor/review-requests/respond"
+    || url.pathname === "/monitor/review-responses"
+  )) {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
       return;
@@ -944,18 +949,38 @@ async function handleMonitorReviewResponse(request: http.IncomingMessage, respon
       writeJson(response, 400, { error: "invalid_payload" });
       return;
     }
-    const result = recordReviewResponse(payload);
+    const result = recordReviewResponse(payload, Date.now(), {
+      boardUrl: optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor"),
+    });
+    const alertSent = result.panelEvaluation?.alert
+      ? await slackAlertChannel().dispatch(result.panelEvaluation.alert)
+      : false;
     logger.info(
       {
         id: result.reviewRequest.id,
         reviewer: result.reviewRequest.reviewer,
         verdict: result.reviewRequest.response?.verdict,
         panelId: result.reviewRequest.panelId,
-        escalated: result.panelEvaluation?.escalate === true,
+        panelAgreement: result.panelEvaluation?.agreement,
+        panelEscalated: result.panelEvaluation?.escalate ?? false,
+        alertSent,
       },
       "monitor_review_response_recorded"
     );
-    writeJson(response, 200, { ok: true, ...result });
+    writeJson(response, 200, {
+      ok: true,
+      reviewRequest: result.reviewRequest,
+      ...(result.panelEvaluation ? { panelEvaluation: result.panelEvaluation } : {}),
+      alertSent,
+      safety: {
+        advisoryOnly: true,
+        createsTasks: false,
+        approvesTasks: false,
+        mutatesGithub: false,
+        mutatesTaskQueue: false,
+        changesMergeAuthority: false,
+      },
+    });
   } catch (error) {
     if (error instanceof CollaborationValidationError) {
       writeJson(response, 400, { error: error.code, message: error.message });

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -142,11 +142,16 @@ export interface RecordReviewPanelInput {
 
 export interface RecordReviewResponseInput {
   id?: unknown;
+  requestId?: unknown;
   panelId?: unknown;
   reviewer?: unknown;
   verdict?: unknown;
   reasoning?: unknown;
   respondedAt?: unknown;
+}
+
+export interface RecordReviewResponseOptions {
+  boardUrl?: string;
 }
 
 export interface RecordReviewPanelResult {
@@ -387,9 +392,10 @@ export function recordReviewPanelRequests(
 
 export function recordReviewResponse(
   input: RecordReviewResponseInput,
-  nowMs: number = Date.now()
+  nowMs: number = Date.now(),
+  options: RecordReviewResponseOptions = {}
 ): RecordReviewResponseResult {
-  const id = normalizeCorrelationId(input.id);
+  const id = normalizeCorrelationId(input.id) ?? normalizeCorrelationId(input.requestId);
   const panelId = normalizeCorrelationId(input.panelId);
   const reviewer = normalizeReviewer(input.reviewer);
   if (!id && (!panelId || !reviewer)) {
@@ -443,7 +449,10 @@ export function recordReviewResponse(
   reviewRequests[index] = updated;
   recordReviewResponseCollaborationTurn(updated, nowMs);
 
-  const panelEvaluation = evaluateReviewPanelForRequest(updated);
+  const panelEvaluation = evaluateReviewPanelForRequest(updated, options);
+  if (panelEvaluation?.escalate) {
+    recordPanelEscalationCollaborationTurn(panelEvaluation, updated, nowMs);
+  }
   return {
     reviewRequest: updated,
     ...(panelEvaluation ? { panelEvaluation } : {}),
@@ -670,15 +679,34 @@ function recordReviewResponseCollaborationTurn(request: ReviewRequest, nowMs: nu
   const relatedCorrelationId = request.correlationId ?? request.relatedMission?.id;
   recordCollaborationMessage({
     author: request.reviewer,
-    kind: "status",
-    addressedTo: "operator",
+    kind: request.response.verdict === "block" ? "request_help" : "status",
+    addressedTo: request.response.verdict === "block" ? "operator" : "hermes",
     text: `${actor} review verdict${scope ? ` on ${scope}` : ""}: ${request.response.verdict} — ${request.response.reasoning}`,
     ...(request.relatedPr ? { relatedPr: request.relatedPr } : {}),
     ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
   }, nowMs);
 }
 
-function evaluateReviewPanelForRequest(request: ReviewRequest): ReviewPanelEvaluation | undefined {
+function recordPanelEscalationCollaborationTurn(
+  evaluation: ReviewPanelEvaluation,
+  request: ReviewRequest,
+  nowMs: number
+): void {
+  const relatedCorrelationId = request.correlationId ?? request.relatedMission?.id;
+  recordCollaborationMessage({
+    author: "hermes",
+    kind: "request_help",
+    addressedTo: "operator",
+    text: `${evaluation.summary} Advisory only: no agent may merge, approve, or change authority from this panel result.`,
+    ...(request.relatedPr ? { relatedPr: request.relatedPr } : {}),
+    ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
+  }, nowMs + 1);
+}
+
+function evaluateReviewPanelForRequest(
+  request: ReviewRequest,
+  options: RecordReviewResponseOptions
+): ReviewPanelEvaluation | undefined {
   if (!request.panelId) return undefined;
   const panelRequests = reviewRequests.filter((candidate) => candidate.panelId === request.panelId);
   if (!panelRequests.some((candidate) => candidate.reviewMode === "panel")) return undefined;
@@ -702,6 +730,7 @@ function evaluateReviewPanelForRequest(request: ReviewRequest): ReviewPanelEvalu
     relatedLabel: reviewRequestScopeLabel(request),
     reviewers: uniqueReviewers,
     responses,
+    ...(options.boardUrl ? { boardUrl: options.boardUrl } : {}),
   });
 }
 

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -15,6 +15,7 @@ import {
   recordReviewPanelRequests,
   recordReviewResponse,
   recordReviewRequest,
+  recordReviewResponse,
   synthesizeHermesReplyFor,
 } from "../../services/slack-operator/src/monitor-collab.js";
 import { listCodexTasks } from "../../services/slack-operator/src/codex-task-queue.js";
@@ -361,6 +362,139 @@ describe("monitor review requests", () => {
     ]);
   });
 
+  it("records panel verdicts without escalating while the panel is incomplete", () => {
+    const panel = recordReviewPanelRequests(
+      {
+        relatedPr: { repo: "depre-dev/averray-reference-agent", number: 304 },
+        requestedBy: "hermes",
+        riskTier: "high",
+        builder: "codex",
+        reason: "High-risk tester mission gate touched deploy-ops.",
+      },
+      NOW
+    );
+
+    const result = recordReviewResponse(
+      {
+        panelId: panel.panelId,
+        reviewer: "hermes",
+        verdict: "pass",
+        reasoning: "Hermes sees the gate as advisory-only.",
+      },
+      NOW + 1
+    );
+
+    expect(result.reviewRequest).toMatchObject({
+      reviewer: "hermes",
+      status: "responded",
+      response: {
+        verdict: "pass",
+        reasoning: "Hermes sees the gate as advisory-only.",
+      },
+    });
+    expect(result.panelEvaluation).toMatchObject({
+      agreement: "pending",
+      panelVerdict: "pending",
+      escalate: false,
+    });
+  });
+
+  it("escalates high-risk panel disagreement as action-needed without creating tasks", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "review-panel-task-queue-"));
+    const queuePath = join(dir, "tasks.json");
+    try {
+      const panel = recordReviewPanelRequests(
+        {
+          relatedPr: { repo: "depre-dev/averray-reference-agent", number: 304 },
+          requestedBy: "hermes",
+          riskTier: "high",
+          builder: "codex",
+          reason: "High-risk tester mission gate touched deploy-ops.",
+        },
+        NOW
+      );
+
+      recordReviewResponse({
+        panelId: panel.panelId,
+        reviewer: "hermes",
+        verdict: "pass",
+        reasoning: "Hermes sees the gate as advisory-only.",
+      }, NOW + 1);
+      recordReviewResponse({
+        panelId: panel.panelId,
+        reviewer: "codex",
+        verdict: "pass",
+        reasoning: "Codex confirms no merge authority changed.",
+      }, NOW + 2);
+      const final = recordReviewResponse({
+        panelId: panel.panelId,
+        reviewer: "claude",
+        verdict: "concern",
+        reasoning: "Claude wants operator review before this moves forward.",
+      }, NOW + 3, { boardUrl: "https://monitor.example/monitor" });
+
+      expect(final.panelEvaluation).toMatchObject({
+        agreement: "majority",
+        panelVerdict: "pass",
+        escalate: true,
+        alert: {
+          boardUrl: "https://monitor.example/monitor",
+        },
+      });
+      expect(final.panelEvaluation?.alert?.text).toContain("Claude: concern");
+      expect(listCollaborationMessages({ limit: 10 }, NOW + 10)).toContainEqual(expect.objectContaining({
+        author: "hermes",
+        addressedTo: "operator",
+        kind: "request_help",
+        text: expect.stringContaining("Advisory only"),
+      }));
+      await expect(listCodexTasks({ path: queuePath })).resolves.toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("escalates any blocking panel verdict with every reviewer verdict attached", () => {
+    const panel = recordReviewPanelRequests(
+      {
+        relatedPr: { repo: "depre-dev/averray-reference-agent", number: 305 },
+        requestedBy: "hermes",
+        riskTier: "high",
+        builder: "claude",
+        reason: "High-risk chain-settlement behavior changed.",
+      },
+      NOW
+    );
+
+    recordReviewResponse({
+      panelId: panel.panelId,
+      reviewer: "hermes",
+      verdict: "pass",
+      reasoning: "Hermes confirms this is only a review record.",
+    }, NOW + 1);
+    recordReviewResponse({
+      panelId: panel.panelId,
+      reviewer: "codex",
+      verdict: "block",
+      reasoning: "Codex blocks until operator checks the chain-surface reasoning.",
+    }, NOW + 2);
+    const final = recordReviewResponse({
+      panelId: panel.panelId,
+      reviewer: "claude",
+      verdict: "concern",
+      reasoning: "Claude flags migration rollback ambiguity.",
+    }, NOW + 3);
+
+    expect(final.panelEvaluation).toMatchObject({
+      agreement: "blocked",
+      panelVerdict: "block",
+      escalate: true,
+    });
+    expect(final.panelEvaluation?.alert?.text).toContain("Hermes: pass");
+    expect(final.panelEvaluation?.alert?.text).toContain("Codex: block");
+    expect(final.panelEvaluation?.alert?.text).toContain("Claude: concern");
+  });
+
   it("keeps non-high-risk review panels on the single C1 cross-agent path", () => {
     const panel = recordReviewPanelRequests(
       {
@@ -424,9 +558,10 @@ describe("monitor review requests", () => {
       });
       expect(listReviewRequests({ status: "responded" })).toHaveLength(1);
       expect(listCollaborationMessages({ limit: 1 }, NOW + 2_000)[0]).toMatchObject({
-        author: "codex",
+        author: "hermes",
         addressedTo: "operator",
-        text: expect.stringContaining("block"),
+        kind: "request_help",
+        text: expect.stringContaining("Advisory only"),
       });
       await expect(listCodexTasks({ path: queuePath })).resolves.toEqual([]);
     } finally {


### PR DESCRIPTION
## Summary
- Add a read-only reviewer response endpoint for C2 high-risk panels.
- Record each panel reviewer verdict and evaluate the panel as responses arrive.
- Escalate any blocking verdict or any panel disagreement to the D4 alert bridge/action-needed path for operator decision.
- Update AGENTS/roadmap status to make the advisory-only boundary explicit.

## Safety / authority
- Planner/review evidence only: no auto-run, no auto-merge, no approval, no GitHub mutation, no task-queue mutation.
- Human merge gate is unchanged.
- High-risk work remains rule-bound to Codex worker lane; panel output only informs the operator.
- No chain facts or chain-state claims were introduced; invariant #8 remains unchanged.

## Checks
- npm run typecheck
- npm test

## Affected areas
- Slack/operator monitor backend
- Hermes roadmap docs
- Tests