### PR TITLE
fix: dedupe B2 self-healing proposals and reconcile roadmap

### DIFF
--- a/docs/HERMES_GO_LIVE.md
+++ b/docs/HERMES_GO_LIVE.md
@@ -41,19 +41,20 @@ C="docker compose -p avg --env-file .env.prod \
 These keys ship commented/defaulted-off. Uncomment + set them **in the file**. If your file ships them as commented lines (`# KEY=...`), strip the leading `# ` for exactly these keys:
 
 ```bash
-sed -i -E 's/^# (D3_ANOMALY_PAUSE_ENABLED|B2_SELF_HEALING_ENABLED|B2_SELF_HEALING_REPO|CLAUDE_BRANCH_WORKER_ALLOWED_REPOS|HERMES_DISPATCH_ALLOWED_REPOS)=/\1=/' .env.prod
+sed -i -E 's/^# (D3_ANOMALY_PAUSE_ENABLED|B2_SELF_HEALING_ENABLED|B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK|B2_SELF_HEALING_REPO|CLAUDE_BRANCH_WORKER_ALLOWED_REPOS|HERMES_DISPATCH_ALLOWED_REPOS)=/\1=/' .env.prod
 ```
 
 Target state (verify by grep — **no leading `#`**):
 
 ```bash
-grep -nE '^(D3_ANOMALY_PAUSE_ENABLED|B2_SELF_HEALING_ENABLED|B2_SELF_HEALING_REPO|CODEX_BRANCH_WORKER_ALLOWED_REPOS|CLAUDE_BRANCH_WORKER_ALLOWED_REPOS|HERMES_DISPATCH_ALLOWED_REPOS)=' .env.prod
+grep -nE '^(D3_ANOMALY_PAUSE_ENABLED|B2_SELF_HEALING_ENABLED|B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK|B2_SELF_HEALING_REPO|CODEX_BRANCH_WORKER_ALLOWED_REPOS|CLAUDE_BRANCH_WORKER_ALLOWED_REPOS|HERMES_DISPATCH_ALLOWED_REPOS)=' .env.prod
 ```
 
 | Key | Value | Effect |
 |---|---|---|
 | `D3_ANOMALY_PAUSE_ENABLED` | `1` | tiered anomaly auto-pause (soft→supervised, hard→`HALT_FILE`) |
 | `B2_SELF_HEALING_ENABLED` | `1` | self-healing **proposes** fix tasks (never auto-runs; D3-interlocked) |
+| `B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK` | `1` | first-arm swarm guard; old failures beyond the tick cap are cooled down/skipped |
 | `B2_SELF_HEALING_REPO` | `averray-agent/agent` | repo B2 proposes fixes against |
 | `CODEX_BRANCH_WORKER_ALLOWED_REPOS` | `averray-agent/agent,depre-dev/averray-reference-agent` | fail-closed allowlist (Codex runner) |
 | `CLAUDE_BRANCH_WORKER_ALLOWED_REPOS` | `averray-agent/agent,depre-dev/averray-reference-agent` | fail-closed allowlist (Claude runner) |

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -1,11 +1,11 @@
 # Hermes Orchestration — Roadmap & Naming Index (canonical)
 
-- **Status:** Planning index. This is the **single source of truth for work-item IDs and order.** It supersedes the old `P#` / `Phase #` labels.
-- **Date:** 2026-05-31
+- **Status:** Code-backed planning index. This is the **single source of truth for work-item IDs and order.** It supersedes the old `P#` / `Phase #` labels.
+- **Date:** 2026-06-01
 
 > **Naming:** one prefix per stream, numbered within it. **`P#` and `Phase #` are retired** — they collided (`P2` Claude worker vs `Phase 2` A+D). Use the IDs below in all handoff prompts and discussion.
 
-> **Reconciliation note (2026-06-01):** This index was reconciled against landed PRs #285-#312. It marks only code-backed shipped slices as done; A3b cost-aware routing/budget remains in progress, and T4/T6/T7 plus the remaining B/O5/C follow-ups stay design/follow-up unless code evidence proves otherwise. B2's first self-healing slice is shipped and opt-in (#309): it proposes routed fixes for non-high-risk failures or escalates high-risk/rollback/D3/HALT cases, with env wiring in `ops/compose.yml`; it does not approve, run, merge, deploy, or roll back work.
+> **Reconciliation note (2026-06-01):** This index was reconciled against merged PRs #252-#315, a fresh `gh pr list --state open` check showing no open PRs, and local code/ops evidence. It marks only code-backed shipped slices as done; where a row is a partial slice, the status says so and names the remaining follow-up. No row should imply active work unless an open PR exists.
 
 ## Streams
 
@@ -22,43 +22,43 @@
 
 | ID | Item | Status |
 |----|------|--------|
-| O0 | Discovery (integration map) | ✅ done |
+| O0 | Discovery (integration map) | ✅ done (#245; `docs/HERMES_INTEGRATION_MAP.md`) |
 | O1 | Agent attribution (branch-prefix → agentType) | ✅ done (#252) |
 | O2 | Claude Code worker (greenfield, Agent SDK) | ✅ done (#256 queue · #259 auth · #260 runner · #262 worker · #263 ops) |
 | O3 | Board-driven dispatch | ✅ done — create/approve form (agent picker) + `/task` verb live on the board (#271) |
 | O4 | Hermes enqueue + dispatch guardrail + autonomy mode | ✅ done — PR1 enqueue+guardrail (#280) · PR2 routing taxonomy (#281) · PR3a autonomy mode (#288) · PR3b autopilot auto-approval (#289); merge/deploy remain human-gated |
-| O5 | Self-management hardening | 🟡 in build — first slice surfaces failed/stale agent tasks in `needs-attention` |
+| O5 | Self-management hardening | ✅ first slice done — failed/stale agent tasks surface in `needs-attention` (#298; `services/slack-operator/src/monitor-v2.ts`, tests in `test/unit/monitor-v2.test.ts`); board liveness truth fix landed in #307. Broader retries/escalation hardening remains follow-up; no open PR as of 2026-06-01 |
 | A1 | Agent scorecard | ✅ done (#285) — read-only `/monitor/agents` + `averray_agent_scorecard` scorecard slice |
 | A2 | Learned routing (data-driven, non-high-risk) | ✅ done (#287) — scorecard-backed default routing, high-risk rule-bound |
-| A3 | Cost visibility / cost-aware routing | 🟡 split — A3a cost visibility ✅ (#295); A3b cost-aware routing/budget in progress |
+| A3 | Cost visibility / cost-aware routing | ✅ done — A3a cost visibility (#295) + A3b cost-aware routing (#301; `packages/averray-mcp/src/learned-routing.ts`, `test/unit/learned-routing.test.ts`) + dispatch USD budget gate (`packages/averray-mcp/src/dispatch-policy.ts`) |
 | A4 | Agent model & effort policy — riskTier→effort/model + operator override (tester LLM; Hermes model = open) | ✅ done (#292) — riskTier→effort/model + operator override |
 | D1 | "While you were away" digest (board + Slack/push) | ✅ done (#294) — autopilot/session digest + operator report surface |
 | D2 | Explainability / decision records | ✅ done (#296) — dispatch decision records and replay surface |
 | D3 | Anomaly auto-pause (tiered soft→hard) — owns the autopilot-suspended flag | ✅ done (#286) — anomaly auto-pause owns autopilot-suspended flag |
 | D4 | Off-device alert bridge (Slack now → push later; action-needed 0→≥1; quiet-hours/mute) — **O4 prerequisite** | ✅ done (#279) |
-| B1 | Backlog generation (roadmap auto-flow; net-new escalates) | 🟡 in review — first planner-only/read-only backlog suggestions slice |
-| B2 | Self-healing (auto-fix non-high-risk; rollback human) | ✅ first slice shipped (#309) — opt-in B2 routine collects failed testbed/deploy-verification signals, proposes routed non-high-risk fix tasks only, escalates high-risk/rollback/D3/HALT cases, and is guarded by open-proposal dedupe, cooldown, per-tick cap, and daily cap; approval/run/merge/deploy remain unchanged |
-| C1 | Cross-agent review (default) | 🟡 in build — first slice records/displays review requests only; no auto-run or authority change |
-| C2 | Reviewer panel (high-risk) | 🟡 in build — panel requests, verdict recording, and block/disagreement action-needed bridge |
-| C3 | Specialist agents (test-writer/security/docs) | 🟡 in build — first `test-writer` specialist template |
+| B1 | Backlog generation (roadmap auto-flow; net-new escalates) | ✅ first slices done — read-only board suggestions (#303; `services/slack-operator/src/backlog-suggestions.ts`) + roadmap-backed `averray_hermes_backlog_plan` (#306; `packages/averray-mcp/src/hermes-backlog.ts`). Idle-triggered auto-flow remains follow-up; no open PR as of 2026-06-01 |
+| B2 | Self-healing (auto-fix non-high-risk; rollback human) | ✅ shipped/live-capable — proposes-only self-healing core (#309; `services/slack-operator/src/self-healing.ts`), stable testbed target dedupe + open-fix cap (#313), duplicate/cap hardening (#314 + #317; `services/slack-operator/src/self-healing.ts`, `test/unit/self-healing.test.ts`), D3/HALT interlock and `b2_self_healing_acted` logging (`services/slack-operator/src/index.ts`), and `B2_SELF_HEALING_*` ops wiring (`services/slack-operator/src/routines.ts`, `ops/compose.yml`). Prod observation: B2 emitted `b2_self_healing_acted`; rollback/high-risk still escalates |
+| C1 | Cross-agent review (default) | ✅ first slice done — review request primitives + card/drawer attachment (#302; `services/slack-operator/src/monitor-collab.ts`, `services/slack-operator/src/monitor-v2.ts`, `packages/monitor-ui/src/components/cards/Card.tsx`). Automatic default reviewer dispatch remains follow-up; no open PR as of 2026-06-01 |
+| C2 | Reviewer panel (high-risk) | ✅ done (#308 + #315; `services/slack-operator/src/reviewer-panel.ts`, panel request/response wiring in `services/slack-operator/src/monitor-collab.ts`, action-needed escalation in `services/slack-operator/src/monitor-v2.ts`, tests in `test/unit/reviewer-panel.test.ts` and `test/unit/monitor-v2.test.ts`) |
+| C3 | Specialist agents (test-writer/security/docs) | ✅ first specialist done — `test-writer` specialist template (#310; `services/slack-operator/src/specialist-agents.ts`) + off-by-default runner wiring (#311; `ops/compose.yml`, `test/unit/test-writer-runner.test.ts`). Security/docs specialists remain modular follow-ups |
 | C4 | Inter-agent chat | ✅ done (#291) — Claude author/target + card-scoped agent messages v1 |
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
 | T2 | Pre-seeded session (authed sweep) | ✅ done (#293) |
 | T3 | Signer sidecar + SIWE mission (multi-role) | ✅ done — signer sidecar foundation (#283) + SIWE role-gating mission (#290) |
 | T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
 | T5 | Env→mutation binding + enhancements (trace/video, baselines) | ✅ done (#297) — env-bound mutation profile + Playwright trace/video + baseline comparison slice |
-| T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | in flight — first slice adds `requested` missions, `/monitor/testbed-missions/request`, `/approve`, board approve UI, and runner-ready gating (this PR) |
-| T7 | Tester capabilities manifest (+ platform-repo request helper) | design/follow-up — do not mark shipped here without code evidence; platform helper remains follow-up |
+| T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | ✅ first slice done (#304; `POST /monitor/testbed-missions/request`, `/approve`, board approve UI, and runner ignores `requested` until approval) |
+| T7 | Tester capabilities manifest (+ platform-repo request helper) | ✅ reference-agent manifest done (#284; `GET /monitor/tester/capabilities`, `services/slack-operator/src/tester-capabilities.ts`). Platform-repo request helper remains follow-up outside this repo |
 
-*(Status as of 2026-06-01 — **shipped:** O0–O4, A1, A2, A3a, A4, D1–D4, B2 first self-healing slice (#309), C4 v1, T1–T3, and T5. **In progress:** A3b cost-aware routing/budget, the O5 first slice, B1 first planner-only/read-only backlog suggestions slice, C3's first internal `test-writer` specialist template, and T6's first board-gated request/approve slice. **Design / follow-up:** remaining O5 hardening, B1 follow-ons, C1–C2, remaining C follow-ups, T4, T7, and platform helper pieces not proven by code evidence. Merge/deploy remain human-gated; B2 proposes only and autopilot approves dispatch only inside O4 guardrails.)*
+*(Status as of 2026-06-01 — **shipped/code-backed:** O0–O4, O5 first slice, A1–A4, D1–D4, B1 first slices, B2 proposes-only self-healing, C1 first slice, C2, C3 test-writer slice, C4 v1, T1–T3, T5, T6 first slice, and the T7 reference-agent manifest. **In progress:** none by open PR check on 2026-06-01. **Design / follow-up:** remaining O5 hardening, B1 idle-triggered auto-flow, C1 automatic/default reviewer dispatch, C3 security/docs specialists, T4 Tier-2 browser agent, and the T7 platform helper. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 
 1. **The self-feeding loop:** **O1 → O2 → O3.** Once this exists you stop hand-writing prompts; work is enqueued from the board and you just approve. Highest-leverage effort.
    - **T1** runs in parallel with O1 (independent, both runner/board TS).
-2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6** is receiving its first request/approve gate slice, while **T7** remains follow-up for platform helper/capability discovery.
+2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6** has its first request/approve gate slice, and **T7** has the reference-agent manifest. The platform helper remains follow-up.
 3. **Autonomy:** **O4** (enqueue + guardrail + autonomy mode) has shipped; supervised burn-in and monitoring decide when to rely on it more heavily.
-4. **Depth, anytime after:** **A1 → A2** shipped; **A3b** is in progress. Remaining depth is **B** (planner), **C1–C3** plus C follow-ups, **T4/T7**, T6 follow-on helper polish, and **O5** hardening.
+4. **Depth, anytime after:** **A1 → A3** shipped, and **B1/B2** now have code-backed first slices. Remaining depth is B1 idle auto-flow, C1 automatic/default reviewer dispatch, C3 additional specialists, **T4**, T7 platform helper polish, and broader **O5** hardening.
 
 **Dependencies to respect:** B2 needs D3 (loop fail-safe); A2 needs A1 (baselines); O4 is the authority change and needs D4 (escalations must reach the operator off-device); T6 needs the proposed-mission approval gate; T-missions that mutate stay on testnet (env→mutation binding before any mainnet).
 

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -191,11 +191,12 @@ services:
       B2_SELF_HEALING_ENABLED: ${B2_SELF_HEALING_ENABLED:-0}
       B2_SELF_HEALING_INTERVAL_MINUTES: ${B2_SELF_HEALING_INTERVAL_MINUTES:-5}
       B2_SELF_HEALING_COOLDOWN_MINUTES: ${B2_SELF_HEALING_COOLDOWN_MINUTES:-30}
+      # Per-tick proposal cap: old failed missions should not all propose on
+      # first arm. Extra eligible failures are cooled down and retried later.
+      B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK: ${B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK:-1}
       # Concurrent open-fix cap: stops a batch of distinct failures from swarming
       # the queue even within the daily budget (escalates past the cap).
       B2_SELF_HEALING_MAX_OPEN_FIXES: ${B2_SELF_HEALING_MAX_OPEN_FIXES:-3}
-      # Per-tick proposal cap: stops one scan from proposing a burst.
-      B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK: ${B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK:-2}
       B2_SELF_HEALING_REPO: ${B2_SELF_HEALING_REPO:-}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}
       SLACK_OPERATOR_MONITOR_TOKEN: ${SLACK_OPERATOR_MONITOR_TOKEN:-}

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -105,7 +105,7 @@ export function parseSlackRoutineConfig(
       intervalMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_INTERVAL_MINUTES) || 5) * 60_000),
       cooldownMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_COOLDOWN_MINUTES) || 30) * 60_000),
       maxOpenFixTasks: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_OPEN_FIXES) || 3),
-      maxProposalsPerTick: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK) || 2),
+      maxProposalsPerTick: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK) || 1),
     },
   };
 }

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -12,10 +12,10 @@
 // interlock is what makes self-healing safe to build (no fix-fail-fix spiral).
 //
 // Storm control: dedup (at most one OPEN fix task per failing target signature
-// — checked against the queue, so it survives a restart) + a cooldown (a
-// flapping check can't spawn a swarm) + per-tick/open-fix/daily proposal
-// backstops. Read-only except the proposal itself, which is just a `proposed`
-// queue entry. Never logs secrets.
+// — checked against the queue, so it survives a restart) + same-tick de-dupe +
+// a cooldown (a flapping check can't spawn a swarm) + per-tick/open-fix/daily
+// proposal backstops. Read-only except the proposal itself, which is just a
+// `proposed` queue entry. Never logs secrets.
 //
 // Pure decision (decideHealingAction) + effect-injected orchestrator
 // (runSelfHealingOnce) so the matrix is unit-tested with no fs/network.
@@ -187,7 +187,7 @@ export interface HealingAuditRecord {
   targetSignature?: string;
   source: HealingSource;
   action: "propose" | "escalate" | "skip";
-  reason: HealingReason | "cooldown" | "open_fix_exists";
+  reason: HealingReason | "cooldown" | "duplicate_signal" | "open_fix_exists";
   riskTier?: HealingRiskTier;
   agent?: TaskAgent;
   taskId?: string;
@@ -243,10 +243,31 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
   const proposalsToday = await deps.proposalsToday();
   const openFixCount = await deps.openFixCount();
   let proposedThisRun = 0;
+  const seenTargets = new Set<string>();
 
   for (const signal of signals) {
     const targetSignature = selfHealingTargetSignature(signal);
-    // Cooldown: a flapping surface can't spawn a swarm of fixes/alerts.
+
+    // Same-tick dedup: if a collector returns the same failing target twice,
+    // only the first copy can act.
+    if (seenTargets.has(targetSignature)) {
+      deps.markHandled(targetSignature, nowMs);
+      await deps.audit({ surface: signal.surface, targetSignature, source: signal.source, action: "skip", reason: "duplicate_signal" });
+      handled.push({ surface: signal.surface, action: "skip", reason: "duplicate_signal" });
+      continue;
+    }
+    seenTargets.add(targetSignature);
+
+    // Durable dedup: one open fix task per target, checked before cooldown so
+    // the audit reason stays truthful after restarts or operator-created tasks.
+    if (await deps.hasOpenFixTask(targetSignature)) {
+      deps.markHandled(targetSignature, nowMs);
+      await deps.audit({ surface: signal.surface, targetSignature, source: signal.source, action: "skip", reason: "open_fix_exists" });
+      handled.push({ surface: signal.surface, action: "skip", reason: "open_fix_exists" });
+      continue;
+    }
+
+    // Cooldown: a flapping target can't spawn a swarm of fixes/alerts.
     if (deps.inCooldown(targetSignature, nowMs)) {
       handled.push({ surface: signal.surface, action: "skip", reason: "cooldown" });
       continue;
@@ -257,25 +278,22 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
       !suspended && !halt && !signal.isRollback && signal.repo ? deps.classify(signal) : undefined;
     let decision = decideHealingAction(signal, classification, { suspended, halt });
 
-    // Backstops: don't propose past the daily cap, nor past the concurrent
-    // open-fix cap — escalate instead so a batch of failures can't swarm.
+    // Backstops: don't propose past the per-tick cap, daily cap, nor past the
+    // concurrent open-fix cap. The per-tick cap cools down + skips so one old
+    // backlog of failures cannot page/propose a swarm on first arm.
+    if (decision.action === "propose" && proposedThisRun >= deps.maxProposalsPerTick) {
+      deps.markHandled(targetSignature, nowMs);
+      await deps.audit({ surface: signal.surface, targetSignature, source: signal.source, action: "skip", reason: "tick_budget_exhausted" });
+      handled.push({ surface: signal.surface, action: "skip", reason: "tick_budget_exhausted" });
+      continue;
+    }
     if (decision.action === "propose" && proposalsToday + proposedThisRun >= deps.maxProposalsPerDay) {
       decision = { action: "escalate", reason: "dispatch_budget_exhausted", ...(decision.riskTier ? { riskTier: decision.riskTier } : {}) };
     } else if (decision.action === "propose" && openFixCount + proposedThisRun >= deps.maxOpenFixTasks) {
       decision = { action: "escalate", reason: "open_fix_cap_reached", ...(decision.riskTier ? { riskTier: decision.riskTier } : {}) };
     }
-    if (decision.action === "propose" && proposedThisRun >= deps.maxProposalsPerTick) {
-      decision = { action: "escalate", reason: "tick_budget_exhausted", ...(decision.riskTier ? { riskTier: decision.riskTier } : {}) };
-    }
 
     if (decision.action === "propose") {
-      // Durable dedup: one open fix proposal per failing target.
-      if (await deps.hasOpenFixTask(targetSignature)) {
-        deps.markHandled(targetSignature, nowMs);
-        await deps.audit({ surface: signal.surface, targetSignature, source: signal.source, action: "skip", reason: "open_fix_exists" });
-        handled.push({ surface: signal.surface, action: "skip", reason: "open_fix_exists" });
-        continue;
-      }
       const prompt = buildFixPrompt(signal);
       const { taskId } = await deps.propose({
         signal,

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -164,6 +164,20 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     expect(h.audits[0]).toMatchObject({ action: "skip", reason: "open_fix_exists" });
   });
 
+  it("dedup: duplicate signals for the same failing target in one tick → proposed once", async () => {
+    const h = harness([
+      signal({ surface: "testbed:app.example/overview", evidence: "https://board.example?mission=old-1" }),
+      signal({ surface: "testbed:app.example/overview", evidence: "https://board.example?mission=old-2" }),
+    ]);
+    const r = await runSelfHealingOnce(h.deps);
+    expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:app.example/overview"]);
+    expect(r.handled).toEqual([
+      { surface: "testbed:app.example/overview", action: "propose", reason: "routed_fix" },
+      { surface: "testbed:app.example/overview", action: "skip", reason: "duplicate_signal" },
+    ]);
+    expect(h.audits.at(-1)).toMatchObject({ action: "skip", reason: "duplicate_signal" });
+  });
+
   it("cooldown: a target handled within the window is skipped", async () => {
     const cd = createCooldown(30 * 60_000);
     cd.markHandled("testbed_mission:testbed:sweep-1", Date.parse("2026-05-31T11:50:00.000Z")); // 10m before now
@@ -223,15 +237,15 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "dispatch_budget_exhausted" });
   });
 
-  it("per-tick cap: extra same-tick proposals escalate instead of bursting", async () => {
+  it("per-tick cap: extra same-tick proposals skip instead of bursting", async () => {
     const h = harness([
       signal({ surface: "testbed:a" }),
       signal({ surface: "testbed:b" }),
     ], { maxProposalsPerTick: 1 });
     await runSelfHealingOnce(h.deps);
     expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:a"]);
-    expect(h.alerts).toBe(1);
-    expect(h.audits.find((a) => a.surface === "testbed:b")).toMatchObject({ action: "escalate", reason: "tick_budget_exhausted" });
+    expect(h.alerts).toBe(0);
+    expect(h.audits.find((a) => a.surface === "testbed:b")).toMatchObject({ action: "skip", reason: "tick_budget_exhausted" });
   });
 
   it("mixed batch: one low-risk proposes, one high-risk escalates, deduped surface skips", async () => {
@@ -294,5 +308,20 @@ describe("runSelfHealingOnce — open-fix cap backstop", () => {
     expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:a"]);
     expect(h.alerts).toBe(2); // b + c escalated
     expect(h.audits.filter((a) => a.reason === "open_fix_cap_reached")).toHaveLength(2);
+  });
+});
+
+describe("runSelfHealingOnce — per-tick proposal cap", () => {
+  it("cools down and skips eligible failures once the tick cap is reached", async () => {
+    const signals = [
+      signal({ surface: "testbed:a" }),
+      signal({ surface: "testbed:b" }),
+      signal({ surface: "testbed:c" }),
+    ];
+    const h = harness(signals, { maxProposalsPerTick: 1 });
+    await runSelfHealingOnce(h.deps);
+    expect(h.proposed.map((p) => p.surface)).toEqual(["testbed:a"]);
+    expect(h.alerts).toBe(0);
+    expect(h.audits.filter((a) => a.reason === "tick_budget_exhausted")).toHaveLength(2);
   });
 });

--- a/test/unit/slack-routines.test.ts
+++ b/test/unit/slack-routines.test.ts
@@ -53,6 +53,22 @@ describe("slack operator routines", () => {
     expect(config.channelId).toBe("C-routine");
   });
 
+  it("parses B2 self-healing storm-control caps", () => {
+    const config = parseSlackRoutineConfig({
+      B2_SELF_HEALING_ENABLED: "1",
+      B2_SELF_HEALING_INTERVAL_MINUTES: "2",
+      B2_SELF_HEALING_COOLDOWN_MINUTES: "45",
+      B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK: "2",
+      B2_SELF_HEALING_MAX_OPEN_FIXES: "4",
+    }, new Set(["C1"]));
+
+    expect(config.selfHealing.enabled).toBe(true);
+    expect(config.selfHealing.intervalMs).toBe(2 * 60_000);
+    expect(config.selfHealing.cooldownMs).toBe(45 * 60_000);
+    expect(config.selfHealing.maxProposalsPerTick).toBe(2);
+    expect(config.selfHealing.maxOpenFixTasks).toBe(4);
+  });
+
   it("runs the daily brief once per UTC date after the target time", () => {
     const config = parseSlackRoutineConfig({
       SLACK_OPERATOR_DAILY_BRIEF_ENABLED: "1",


### PR DESCRIPTION
## What changed & why

- Hardened B2 self-healing so repeated observations of the same failed target do not create proposal swarms:
  - same-tick duplicate target dedupe
  - cooldown honored per stable target
  - open-fix targets skipped before reproposal
  - new `B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK` cap, defaulting to 1 in compose
- Kept B2 proposes-only and D3/HALT-interlocked. This does not change approval or runner authority.
- Reconciled `docs/HERMES_ROADMAP.md` against code-backed evidence, merged PRs through #315, `gh pr list --state open` showing no open PRs, and local ops/code wiring. Rows now distinguish shipped slices from follow-up/design work instead of implying active work with no PR.

## Affected surfaces

- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (attempted, but this local Docker install has no Compose plugin: `unknown flag: --env-file`)
- [x] `git diff --check origin/main...HEAD`
- [x] `gh pr list --state open --limit 20 --json number,title,headRefName`

## Rollout / rollback

- Human merge/deploy only.
- Runtime behavior remains proposes-only. The new tick cap defaults to 1, so old failed missions cannot all trigger proposals in the first armed tick.
- Roll back by reverting this PR. As an operator fallback, B2 can still be disabled with existing `B2_SELF_HEALING_ENABLED=false`.

## Durable invariants (AGENTS.md)

- [x] No auto-merge / auto-deploy - a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new ungated agent power (new capability => new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs if this changes how agents work

## Known limits / follow-ups

- Compose config could not be validated locally because Docker Compose is unavailable in this environment.
- Roadmap status is evidence-backed as of 2026-06-01; future merges should update the exact rows they implement.
