### PR TITLE
T4: Tier-2 gold-path tester executor (scaffold + fake driver; live LLM follow-up)

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -172,6 +172,42 @@ and writes a `misconfigured` heartbeat rather than running on the wrong route.
 
 ---
 
+## Optional: the T4 Tier-2 gold-path tester (`command` executor)
+
+Off by default. The Tier-2 LLM gold-path tester drives the product's agent gold
+path (onboard → claim → submit → verify → payout/SBT → receipt) and judges it
+honestly. It runs through the testbed runner's **`command` executor** — point a
+testbed runner at the gold-path entry:
+
+```
+TESTBED_MISSION_RUNNER_ENABLED=1
+TESTBED_MISSION_RUNNER_EXECUTOR=command
+TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/gold-path-mission-entry.js
+TESTBED_MISSION_ENVIRONMENT=testnet      # T5 binds mutation; mainnet is read-only by construction
+TESTBED_SESSION_SIGNER_URL=http://test-wallet-signer:8791   # T3 session (API Bearer); key never enters the model
+TESTBED_GOLDPATH_DEEP=0                   # opus for deep/critical; sonnet otherwise (A4)
+TESTBED_GOLDPATH_LIVE=0                   # see note below
+```
+
+Gold-path missions are queued with `mode: "gold_path"` and **land `requested`** —
+they stay behind the operator approve gate (`POST /monitor/testbed-missions/{id}/approve`)
+and never auto-run. Mutation is bound by T5: only `local/testnet/staging` may
+mutate; **mainnet is structurally read-only**.
+
+> **The runner claims ALL ready missions** (no per-mode filter yet), so run the
+> gold-path command executor in a deployment whose queue contains only
+> `gold_path` missions, or wait for the per-mode-claim follow-up. A mixed queue
+> would route surface-sweep missions through the gold-path entry.
+
+> **Live driver is a follow-up.** This PR ships the executor — the T5 mutation
+> binding, T3 session, A4 model policy, the honest self-judge, the report, and
+> the approve-gate wiring — with a deterministic fake driver for CI. The live
+> **Claude Agent SDK + Playwright-MCP** driver is not wired yet: with
+> `TESTBED_GOLDPATH_LIVE` unset (or set, until the driver lands) the runner emits
+> an honest **"not executed"** report rather than a fake pass.
+
+---
+
 ## Assumptions / things to confirm in your environment
 
 - The image name assumes the GitHub org is `depre-dev` (i.e.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -62,6 +62,19 @@ TESTBED_MISSION_MAX_BROWSER_STEPS=12
 TESTBED_MISSION_ENVIRONMENT=
 TESTBED_MISSION_CAPTURE_TRACE=1
 TESTBED_MISSION_CAPTURE_VIDEO=1
+# T4 Tier-2 gold-path tester. Runs via the `command` executor: point a testbed
+# runner at the gold-path entry (EXECUTOR=command, ARGS below) in an env that
+# only queues gold_path missions. gold_path missions land `requested` (behind
+# the T6 approve gate; never auto-run). Mutation is bound by T5 (mainnet is
+# structurally read-only). The live Claude Agent SDK + Playwright-MCP driver is
+# a follow-up: until TESTBED_GOLDPATH_LIVE=1 AND that driver is wired, the runner
+# emits an honest "not executed" report (never a fake pass).
+#   TESTBED_MISSION_RUNNER_EXECUTOR=command
+#   TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/gold-path-mission-entry.js
+TESTBED_GOLDPATH_LIVE=0
+# Model per A4: sonnet (routine, default) / opus (deep). DEEP forces opus.
+TESTBED_GOLDPATH_DEEP=0
+TESTBED_GOLDPATH_MODEL=
 # T1 surface sweep: env's truth boundary the honesty check asserts surfaces
 # label. Empty ⇒ self-consistency checks only (errored-but-silent /
 # empty-unlabeled). Set to testnet/demo/local-simulation when the deployed env

--- a/services/slack-operator/src/gold-path-mission-entry.ts
+++ b/services/slack-operator/src/gold-path-mission-entry.ts
@@ -1,0 +1,115 @@
+// T4 — Tier-2 gold-path mission command entrypoint.
+//
+// Spawned by the testbed mission runner's `command` executor (the runner passes
+// the mission via TESTBED_* env + a TESTBED_MISSION_REPORT_PATH; this writes the
+// structured report there and the runner ingests it). This is glue: it resolves
+// the T5 mutation binding, the T3 session, the A4 model, picks a driver, runs the
+// gold path, and writes the report.
+//
+// CI never reaches the live path: the live Claude Agent SDK + Playwright-MCP
+// driver is opt-in (TESTBED_GOLDPATH_LIVE=1) and is a follow-up — until it's
+// wired it FAILS CLOSED (an honest "not executed" report), never a fake pass.
+
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { redact } from "./codex-branch-worker.js";
+import {
+  resolveTestbedMutationBinding,
+  testbedEnvironmentFromEnv,
+} from "./testbed-mutation-binding.js";
+import { resolveSweepSession, parseSweepSessionConfig } from "./testbed-session.js";
+import {
+  runGoldPathMissionOnce,
+  pickGoldPathModel,
+  createUnavailableGoldPathDriver,
+  type GoldPathDriver,
+  type GoldPathMissionResult,
+} from "./gold-path-mission.js";
+
+interface GoldPathMissionEnv {
+  id: string;
+  targetUrl: string;
+  goal: string;
+  freshMemory: boolean;
+  requestedAllowTestMutations: boolean;
+  environment?: string;
+}
+
+function readMissionFromEnv(env: NodeJS.ProcessEnv): GoldPathMissionEnv {
+  return {
+    id: env.TESTBED_MISSION_ID || "gold-path-mission",
+    targetUrl: env.TESTBED_TARGET_URL || "",
+    goal: env.TESTBED_MISSION_GOAL || "Attempt the agent gold path as an outside agent and judge honestly.",
+    freshMemory: env.TESTBED_FRESH_MEMORY !== "false",
+    requestedAllowTestMutations: env.TESTBED_REQUESTED_TEST_MUTATIONS === "true",
+    ...(env.TESTBED_MISSION_ENVIRONMENT ? { environment: env.TESTBED_MISSION_ENVIRONMENT } : {}),
+  };
+}
+
+/**
+ * Choose the driver. The live LLM driver is opt-in and not wired in this build,
+ * so both branches currently return the honest non-run driver — a deploy can
+ * never silently emit a fake pass. The live adapter plugs into this seam.
+ */
+function selectGoldPathDriver(env: NodeJS.ProcessEnv): GoldPathDriver {
+  if (env.TESTBED_GOLDPATH_LIVE === "1") {
+    return createUnavailableGoldPathDriver(
+      "Live gold-path driver (Claude Agent SDK + Playwright-MCP) is not wired in this build — no real run performed. " +
+        "This is a deliberate follow-up; the executor, safety binding, session, model policy, judge, and report are in place.",
+    );
+  }
+  return createUnavailableGoldPathDriver(
+    "Gold-path runner is not in live mode (set TESTBED_GOLDPATH_LIVE=1 once the live LLM driver is wired); no real run performed.",
+  );
+}
+
+export async function runGoldPathMissionEntry(
+  env: NodeJS.ProcessEnv = process.env,
+  deps: { driver?: GoldPathDriver } = {},
+): Promise<GoldPathMissionResult> {
+  const mission = readMissionFromEnv(env);
+
+  // T5: re-resolve the mutation binding from the env here too, so the safety
+  // boundary is enforced at the executor regardless of upstream — mainnet (and
+  // any non-mutating env) is read-only, making a mutating gold-path against
+  // mainnet structurally impossible.
+  const binding = resolveTestbedMutationBinding({
+    targetUrl: mission.targetUrl,
+    mode: "gold_path",
+    requestedAllowTestMutations: mission.requestedAllowTestMutations,
+    configuredEnvironment: mission.environment ?? testbedEnvironmentFromEnv(env),
+  });
+
+  const model = pickGoldPathModel({
+    deep: env.TESTBED_GOLDPATH_DEEP === "1",
+    ...(env.TESTBED_GOLDPATH_MODEL ? { override: env.TESTBED_GOLDPATH_MODEL } : {}),
+  });
+
+  const driver = deps.driver ?? selectGoldPathDriver(env);
+
+  const result = await runGoldPathMissionOnce({
+    mission: { id: mission.id, targetUrl: mission.targetUrl, goal: mission.goal, freshMemory: mission.freshMemory },
+    binding,
+    driver,
+    model,
+    // T3: the API Bearer (and/or browser storageState) from the signer sidecar —
+    // the wallet key never enters this process. Undefined when unconfigured.
+    resolveSession: () => resolveSweepSession({ ...parseSweepSessionConfig(env), sessionType: "api" }),
+  });
+
+  const reportPath = env.TESTBED_MISSION_REPORT_PATH;
+  if (reportPath) {
+    await writeFile(reportPath, result.reportText);
+  } else {
+    process.stdout.write(result.reportText);
+  }
+  return result;
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  runGoldPathMissionEntry().catch((error) => {
+    console.error(redact(error instanceof Error ? error.message : String(error)));
+    process.exitCode = 1;
+  });
+}

--- a/services/slack-operator/src/gold-path-mission.ts
+++ b/services/slack-operator/src/gold-path-mission.ts
@@ -1,0 +1,399 @@
+// T4 — Tier-2 LLM gold-path tester (core).
+//
+// Drives the platform product's AGENT GOLD PATH as a customer would:
+//   onboard → discover → claim → submit → verify → payout + reputation-SBT → receipt
+// and judges "could an outside agent succeed, and was the product HONEST about
+// its state?". The verdict + structured report feed the existing testbed mission
+// store (same shape Tier-1 emits).
+//
+// This module is the SAFE, deterministic core: the model pick (A4 policy), the
+// honest judge, the report builder, and an effect-injected orchestrator. The
+// actual product-driving "driver" is INJECTED (`GoldPathDriver`) — so CI runs a
+// scripted fake and NEVER calls a live LLM. The live driver (Claude Agent SDK +
+// Playwright-MCP) plugs into the same seam.
+//
+// Safety invariants enforced here:
+//   - Mutation profile is resolved via the T5 env→mutation binding. On mainnet
+//     (and any non-mutating env) the binding is read-only, so the driver is told
+//     `allowMutations: false` — a mutating gold-path against mainnet is
+//     STRUCTURALLY impossible (it never receives permission to mutate).
+//   - Truth-boundary honesty: the judge reports real / degraded / empty / blocked
+//     exactly as observed and NEVER fakes a pass (a blocked/errored required step
+//     can't be a pass; a degraded/empty surface is at best "partial").
+//   - Read-mostly: a mutating step skipped because mutations aren't allowed is
+//     expected (stoppedBeforeMutation), not a failure.
+
+import type { TestbedMutationBinding } from "./testbed-mutation-binding.js";
+
+export type GoldPathStep =
+  | "onboard"
+  | "discover"
+  | "claim"
+  | "submit"
+  | "verify"
+  | "payout_sbt"
+  | "receipt";
+
+/** The canonical gold path, in order. */
+export const GOLD_PATH_STEPS: readonly GoldPathStep[] = [
+  "onboard",
+  "discover",
+  "claim",
+  "submit",
+  "verify",
+  "payout_sbt",
+  "receipt",
+] as const;
+
+/** Steps that MUTATE product state — only attempted when the binding allows it. */
+export const GOLD_PATH_MUTATING_STEPS: ReadonlySet<GoldPathStep> = new Set<GoldPathStep>([
+  "claim",
+  "submit",
+  "payout_sbt",
+]);
+
+/** What the agent observed at a step. Honest by construction — `degraded`/`empty`
+ *  are first-class, distinct from a clean `ok`. */
+export type GoldPathStepStatus = "ok" | "degraded" | "empty" | "blocked" | "skipped" | "error";
+
+export interface GoldPathStepResult {
+  step: GoldPathStep;
+  status: GoldPathStepStatus;
+  detail: string;
+  /** A page-visible evidence pointer (url / selector text / receipt id). Never secrets. */
+  evidence?: string;
+  /** True if this observation involved a (testbed-only) mutation. */
+  mutating?: boolean;
+}
+
+export interface GoldPathObservation {
+  steps: GoldPathStepResult[];
+  notes: string[];
+  /** Mutations the agent actually attempted (must be empty in read-only mode). */
+  mutationsAttempted: string[];
+  /** Whether the agent stopped at every mutation boundary it wasn't allowed to cross. */
+  stoppedBeforeMutation: boolean;
+}
+
+export type GoldPathModel = "sonnet" | "opus";
+
+export interface GoldPathDriverInput {
+  targetUrl: string;
+  goal: string;
+  steps: readonly GoldPathStep[];
+  /** From the T5 binding. The driver MUST NOT mutate when false. */
+  allowMutations: boolean;
+  mutationScope: string;
+  model: GoldPathModel;
+  freshMemory: boolean;
+  /** T3 session (Bearer for the API gold path, storageState for browser). Opaque here. */
+  session?: { role?: string; token?: string; storageState?: unknown };
+}
+
+/** The injected product driver. Real impl = Claude Agent SDK + Playwright-MCP;
+ *  CI/tests inject a scripted fake. NEVER call a live LLM from the core. */
+export interface GoldPathDriver {
+  run(input: GoldPathDriverInput): Promise<GoldPathObservation>;
+}
+
+// ── A4 model policy ─────────────────────────────────────────────────
+
+/**
+ * Sonnet for routine runs; Opus for deep/critical (per A4 §2). riskTier `high`
+ * or an explicit `deep` flag → Opus; an operator override wins. Read-mostly
+ * gold-path runs are low/medium → Sonnet by default.
+ */
+export function pickGoldPathModel(input: { riskTier?: "high" | "low"; deep?: boolean; override?: string } = {}): GoldPathModel {
+  const override = (input.override ?? "").trim().toLowerCase();
+  if (override === "opus" || override === "sonnet") return override;
+  if (input.deep || input.riskTier === "high") return "opus";
+  return "sonnet";
+}
+
+// ── honest judge ────────────────────────────────────────────────────
+
+export type GoldPathVerdict = "pass" | "partial" | "fail";
+
+export interface GoldPathJudgement {
+  verdict: GoldPathVerdict;
+  confidence: number;
+  scores: {
+    goalCompletion: number;
+    honesty: number;
+    recoverability: number;
+  };
+  blockers: string[];
+  confusingMoments: string[];
+  recommendations: string[];
+}
+
+const TERMINAL_STEP_LABEL: Record<GoldPathStep, string> = {
+  onboard: "onboarding",
+  discover: "job discovery",
+  claim: "claim",
+  submit: "submit",
+  verify: "verification",
+  payout_sbt: "payout + reputation SBT",
+  receipt: "receipt",
+};
+
+/**
+ * Pure, deterministic verdict from the observed outcomes. Truth-boundary:
+ *  - any required step `error`/`blocked` → FAIL (the path could not be walked);
+ *  - any `degraded`/`empty` surface, or an UNEXPECTED skip → at best PARTIAL
+ *    (the product was honest about a degraded state, but the journey wasn't clean);
+ *  - a mutating step `skipped` because mutations aren't allowed is EXPECTED in a
+ *    read-mostly run — it does not lower the verdict;
+ *  - all clean → PASS.
+ * Never returns PASS while any blocker/error exists — it cannot fake a pass.
+ */
+export function judgeGoldPath(
+  observation: GoldPathObservation,
+  opts: { allowMutations: boolean } = { allowMutations: false },
+): GoldPathJudgement {
+  const blockers: string[] = [];
+  const confusingMoments: string[] = [];
+  const recommendations: string[] = [];
+
+  for (const s of observation.steps) {
+    const label = TERMINAL_STEP_LABEL[s.step] ?? s.step;
+    if (s.status === "error" || s.status === "blocked") {
+      blockers.push(`${label}: ${s.detail}`);
+    } else if (s.status === "degraded") {
+      confusingMoments.push(`${label} rendered a degraded state: ${s.detail}`);
+    } else if (s.status === "empty") {
+      confusingMoments.push(`${label} was empty: ${s.detail}`);
+    } else if (s.status === "skipped") {
+      // A read-only run is EXPECTED to skip mutating steps. Only an unexpected
+      // skip (a mutating step skipped while mutations WERE allowed, or a
+      // non-mutating step skipped) is noteworthy.
+      const expectedReadOnlySkip = !opts.allowMutations && GOLD_PATH_MUTATING_STEPS.has(s.step);
+      if (!expectedReadOnlySkip) {
+        confusingMoments.push(`${label} was skipped: ${s.detail}`);
+      }
+    }
+  }
+
+  if (!observation.stoppedBeforeMutation && !opts.allowMutations) {
+    // The driver crossed a mutation boundary it was NOT allowed to — a hard fault.
+    blockers.push("Agent attempted a mutation while the mission was read-only.");
+  }
+
+  const verdict: GoldPathVerdict = blockers.length > 0
+    ? "fail"
+    : confusingMoments.length > 0
+      ? "partial"
+      : "pass";
+
+  if (blockers.length > 0) recommendations.push("Fix the blocked gold-path step(s) so an outside agent can complete the journey.");
+  if (confusingMoments.some((m) => /degraded|empty/.test(m))) {
+    recommendations.push("Surface a clearer state (or honest empty/degraded label) on the affected step(s).");
+  }
+
+  const cleanSteps = observation.steps.filter((s) => s.status === "ok").length;
+  const total = observation.steps.length || 1;
+  const score = (n: number) => Math.max(0, Math.min(5, Math.round(n)));
+  return {
+    verdict,
+    confidence: verdict === "pass" ? 0.85 : verdict === "fail" ? 0.8 : 0.6,
+    scores: {
+      goalCompletion: score((cleanSteps / total) * 5),
+      honesty: blockers.length === 0 ? 5 : confusingMoments.length === 0 ? 2 : 3,
+      recoverability: blockers.length === 0 ? 4 : 2,
+    },
+    blockers,
+    confusingMoments,
+    recommendations,
+  };
+}
+
+// ── report (matches normalizeTestbedMissionStructuredReport) ────────
+
+export interface GoldPathReportInput {
+  missionId: string;
+  goal: string;
+  targetUrl: string;
+  model: GoldPathModel;
+  binding: TestbedMutationBinding;
+  observation: GoldPathObservation;
+  judgement: GoldPathJudgement;
+}
+
+export function buildGoldPathReport(input: GoldPathReportInput): Record<string, unknown> {
+  const { missionId, goal, targetUrl, model, binding, observation, judgement } = input;
+  const completedPath = observation.steps.map(
+    (s) => `${s.step} → ${s.status}${s.detail ? ` (${s.detail})` : ""}`,
+  );
+  const evidence: Array<{ type: string; value: string }> = [
+    { type: "executor", value: "gold_path" },
+    { type: "model", value: model },
+    { type: "environment", value: binding.environment },
+    { type: "mutation_mode", value: binding.mutationMode },
+  ];
+  for (const s of observation.steps) {
+    if (s.evidence) evidence.push({ type: `step:${s.step}`, value: s.evidence });
+  }
+
+  const mutationBoundaryNotes = [
+    `Mutation profile: ${binding.environment} / ${binding.mutationMode}. ${binding.reason}`,
+    binding.allowTestMutations
+      ? `Testbed mutations were permitted (${binding.mutationScope}).`
+      : "Read-only run: the agent stopped before every mutation boundary.",
+  ];
+
+  return {
+    missionId,
+    verdict: judgement.verdict,
+    confidence: judgement.confidence,
+    executor: "gold_path",
+    runnerMode: "gold_path",
+    mode: "gold_path",
+    goal,
+    targetUrl,
+    environment: binding.environment,
+    model,
+    stoppedBeforeMutation: observation.stoppedBeforeMutation,
+    mutationMode: binding.mutationMode,
+    mutationScope: binding.mutationScope,
+    mutationBindingReason: binding.reason,
+    mutationsAttempted: observation.mutationsAttempted,
+    completedPath,
+    blockers: judgement.blockers,
+    confusingMoments: judgement.confusingMoments,
+    mutationBoundaryNotes,
+    recommendations: judgement.recommendations,
+    evidence,
+    scores: judgement.scores,
+    steps: observation.steps,
+    notes: observation.notes,
+    summary: `gold_path ${judgement.verdict}: ${observation.steps.filter((s) => s.status === "ok").length}/${observation.steps.length} steps clean on ${binding.environment} (${binding.mutationMode}), ${judgement.blockers.length} blocker(s)`,
+  };
+}
+
+// ── orchestrator (effect-injected; never calls a live LLM directly) ──
+
+export interface GoldPathMissionDeps {
+  mission: {
+    id: string;
+    targetUrl: string;
+    goal: string;
+    freshMemory?: boolean;
+  };
+  binding: TestbedMutationBinding;
+  driver: GoldPathDriver;
+  model: GoldPathModel;
+  resolveSession?: () => Promise<GoldPathDriverInput["session"] | undefined> | GoldPathDriverInput["session"] | undefined;
+  steps?: readonly GoldPathStep[];
+}
+
+export interface GoldPathMissionResult {
+  report: Record<string, unknown>;
+  reportText: string;
+  verdict: GoldPathVerdict;
+}
+
+export async function runGoldPathMissionOnce(deps: GoldPathMissionDeps): Promise<GoldPathMissionResult> {
+  const session = deps.resolveSession ? await deps.resolveSession() : undefined;
+  const steps = deps.steps ?? GOLD_PATH_STEPS;
+  const allowMutations = deps.binding.allowTestMutations === true;
+
+  const observation = await deps.driver.run({
+    targetUrl: deps.mission.targetUrl,
+    goal: deps.mission.goal,
+    steps,
+    allowMutations,
+    mutationScope: deps.binding.mutationScope,
+    model: deps.model,
+    freshMemory: deps.mission.freshMemory !== false,
+    ...(session ? { session } : {}),
+  });
+
+  // Defense in depth: if a read-only run somehow returned attempted mutations,
+  // surface it as a hard fault (the judge will fail it) rather than trusting the
+  // driver's own `stoppedBeforeMutation` flag.
+  const stoppedBeforeMutation = allowMutations
+    ? observation.stoppedBeforeMutation
+    : observation.mutationsAttempted.length === 0 && observation.stoppedBeforeMutation;
+  const safeObservation: GoldPathObservation = { ...observation, stoppedBeforeMutation };
+
+  const judgement = judgeGoldPath(safeObservation, { allowMutations });
+  const report = buildGoldPathReport({
+    missionId: deps.mission.id,
+    goal: deps.mission.goal,
+    targetUrl: deps.mission.targetUrl,
+    model: deps.model,
+    binding: deps.binding,
+    observation: safeObservation,
+    judgement,
+  });
+  return { report, reportText: `${JSON.stringify(report, null, 2)}\n`, verdict: judgement.verdict };
+}
+
+// ── scripted fake driver (the CI / default-safe driver) ─────────────
+
+/**
+ * An HONEST non-run driver: marks every step `error` with `reason`, so a deploy
+ * that enabled the gold-path runner WITHOUT wiring the live LLM driver reports a
+ * truthful "not executed" FAIL — never a fake pass. (Truth-boundary: absence of
+ * a real run must never read as a passing run.)
+ */
+export function createUnavailableGoldPathDriver(reason: string): GoldPathDriver {
+  return {
+    async run(input: GoldPathDriverInput): Promise<GoldPathObservation> {
+      return {
+        steps: input.steps.map((step) => ({ step, status: "error" as const, detail: reason })),
+        notes: [reason],
+        mutationsAttempted: [],
+        stoppedBeforeMutation: true,
+      };
+    },
+  };
+}
+
+export interface ScriptedGoldPathStep {
+  step: GoldPathStep;
+  status: GoldPathStepStatus;
+  detail?: string;
+  evidence?: string;
+}
+
+/**
+ * A deterministic, no-network driver. The default for CI and for any run that
+ * hasn't opted into the live LLM driver. Honors read-only mode: mutating steps
+ * become `skipped` (read-only) unless `allowMutations`, and it never records an
+ * attempted mutation it wasn't allowed to make.
+ */
+export function createScriptedGoldPathDriver(script?: ScriptedGoldPathStep[]): GoldPathDriver {
+  return {
+    async run(input: GoldPathDriverInput): Promise<GoldPathObservation> {
+      const byStep = new Map((script ?? []).map((s) => [s.step, s]));
+      const steps: GoldPathStepResult[] = [];
+      const mutationsAttempted: string[] = [];
+      for (const step of input.steps) {
+        const scripted = byStep.get(step);
+        const mutating = GOLD_PATH_MUTATING_STEPS.has(step);
+        if (mutating && !input.allowMutations) {
+          steps.push({ step, status: "skipped", detail: "read-only run — stopped before mutation", mutating: true });
+          continue;
+        }
+        const status: GoldPathStepStatus = scripted?.status ?? "ok";
+        steps.push({
+          step,
+          status,
+          detail: scripted?.detail ?? `${TERMINAL_STEP_LABEL[step]} observed (${status})`,
+          ...(scripted?.evidence ? { evidence: scripted.evidence } : {}),
+          ...(mutating ? { mutating: true } : {}),
+        });
+        if (mutating && input.allowMutations && status === "ok") {
+          mutationsAttempted.push(`${step}: testbed mutation (${input.mutationScope})`);
+        }
+      }
+      return {
+        steps,
+        notes: [`scripted gold-path driver (no live LLM); model=${input.model}, allowMutations=${input.allowMutations}`],
+        mutationsAttempted,
+        stoppedBeforeMutation: true,
+      };
+    },
+  };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -1398,10 +1398,13 @@ async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage,
       ...(booleanField(payload, "allowTestMutations") !== undefined ? { allowTestMutations: booleanField(payload, "allowTestMutations") } : {}),
       ...(numberField(payload, "maxBrowserSteps") !== undefined ? { maxBrowserSteps: numberField(payload, "maxBrowserSteps") } : {}),
       ...(numberField(payload, "maxMinutes") !== undefined ? { maxMinutes: numberField(payload, "maxMinutes") } : {}),
-      ...(mode === "surface_sweep" || mode === "siwe_auth" ? { mode } : {}),
+      ...(mode === "surface_sweep" || mode === "siwe_auth" || mode === "gold_path" ? { mode } : {}),
       ...(Array.isArray(payload.routes)
         ? { routes: payload.routes.filter((r): r is string => typeof r === "string" && r.length > 0) }
         : {}),
+      // T4: a gold-path (Tier-2 LLM) mission is mutation-capable and deep, so it
+      // always lands `requested` — behind the operator approve gate, never auto-run.
+      ...(mode === "gold_path" ? { requireApproval: true } : {}),
     });
     recordTestbedMissionCollaboration(created.run);
     logger.info(

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -13,7 +13,7 @@ const MAX_MISSION_RUNS = 50;
 
 export type TestbedMissionStatus = "requested" | "ready" | "running" | "completed" | "failed";
 export type TestbedMissionVerdict = "pass" | "partial" | "fail";
-export type TestbedMissionMode = "explore" | "surface_sweep" | "siwe_auth";
+export type TestbedMissionMode = "explore" | "surface_sweep" | "siwe_auth" | "gold_path";
 export type TestbedMissionRequesterAgent = "codex" | "claude" | "test-writer" | "hermes" | "operator";
 export type TestbedMissionRunnerHeartbeatStatus =
   | "idle"

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -33,6 +33,10 @@ export interface AgentTestbedMissionInput {
   mode?: TestbedMissionMode;
   /** T1: routes for a surface sweep (relative to the app base URL, or absolute). */
   routes?: string[];
+  /** When true, create the mission as `requested` (operator must approve before a
+   *  runner can claim it) rather than auto-`ready`. T4 gold-path uses this so the
+   *  Tier-2 agent never auto-runs — it stays behind the T6 request→approve gate. */
+  requireApproval?: boolean;
 }
 
 export type AgentRequestedTestbedMissionMode = "fresh" | "memory";
@@ -81,7 +85,10 @@ export function createTestbedMissionFromAgent(
   input: AgentTestbedMissionInput = {},
   nowMs: number = Date.now()
 ): AgentTestbedMissionResult {
-  return createTestbedMissionRecord(input, nowMs, { initialStatus: "ready" });
+  // A gold-path (or any approval-required) mission lands as `requested` so it
+  // stays behind the operator approve gate — no auto-run.
+  const initialStatus = input.requireApproval ? "requested" : "ready";
+  return createTestbedMissionRecord(input, nowMs, { initialStatus });
 }
 
 export function requestTestbedMissionFromAgent(

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -155,13 +155,22 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
       },
       {
         id: "gold_path",
-        status: "operator_only_design",
+        status: "executor_scaffolded_awaiting_live_driver",
         tier: 2,
         scope: "testbed_mutation_only",
-        mutation: "testnet-only, never mainnet",
-        supportedEnvs: ["testnet"],
-        dependsOn: ["T3 signer sidecar", "T4 tier-2 agent executor", "T5 env-to-mutation binding"],
-        note: "Not agent-requestable from this manifest yet.",
+        mutation: "testnet-only, never mainnet (T5 env→mutation binding; mainnet is structurally read-only)",
+        supportedEnvs: ["local", "testnet", "staging"],
+        dependsOn: ["T3 signer sidecar", "T5 env-to-mutation binding"],
+        request: {
+          body: {
+            mode: "gold_path",
+            targetUrl: "https://app.testnet.example",
+            goal: "Attempt the agent gold path (onboard → claim → submit → verify → payout/SBT → receipt) and judge honestly.",
+            allowTestMutations: true,
+            requester: "agent-name",
+          },
+        },
+        note: "T4: the Tier-2 executor is built (mutation binding + session + A4 model policy + honest judge + report) behind the command hook and the T6 request→approve gate (gold_path missions land `requested`, never auto-run). The live Claude Agent SDK + Playwright-MCP driver is a follow-up; until it's wired the runner emits an honest \"not executed\" report rather than a fake pass.",
       },
     ],
     approvalGate: {

--- a/test/unit/gold-path-mission.test.ts
+++ b/test/unit/gold-path-mission.test.ts
@@ -1,0 +1,186 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  GOLD_PATH_STEPS,
+  pickGoldPathModel,
+  judgeGoldPath,
+  runGoldPathMissionOnce,
+  createScriptedGoldPathDriver,
+  createUnavailableGoldPathDriver,
+  type GoldPathObservation,
+  type GoldPathStepResult,
+} from "../../services/slack-operator/src/gold-path-mission.js";
+import { runGoldPathMissionEntry } from "../../services/slack-operator/src/gold-path-mission-entry.js";
+import { resolveTestbedMutationBinding, type TestbedMutationBinding } from "../../services/slack-operator/src/testbed-mutation-binding.js";
+
+function obs(steps: GoldPathStepResult[], over: Partial<GoldPathObservation> = {}): GoldPathObservation {
+  return { steps, notes: [], mutationsAttempted: [], stoppedBeforeMutation: true, ...over };
+}
+
+// ── A4 model policy ─────────────────────────────────────────────────
+
+describe("pickGoldPathModel — Sonnet routine / Opus deep (A4)", () => {
+  it("defaults to sonnet", () => {
+    expect(pickGoldPathModel()).toBe("sonnet");
+    expect(pickGoldPathModel({ riskTier: "low" })).toBe("sonnet");
+  });
+  it("deep or high-risk → opus", () => {
+    expect(pickGoldPathModel({ deep: true })).toBe("opus");
+    expect(pickGoldPathModel({ riskTier: "high" })).toBe("opus");
+  });
+  it("operator override wins either way", () => {
+    expect(pickGoldPathModel({ deep: true, override: "sonnet" })).toBe("sonnet");
+    expect(pickGoldPathModel({ override: "opus" })).toBe("opus");
+    expect(pickGoldPathModel({ override: "nonsense" })).toBe("sonnet");
+  });
+});
+
+// ── honest judge ────────────────────────────────────────────────────
+
+describe("judgeGoldPath — never fakes a pass", () => {
+  const all = (status: GoldPathStepResult["status"]) =>
+    GOLD_PATH_STEPS.map((step) => ({ step, status, detail: `${step} ${status}` }));
+
+  it("all clean → pass", () => {
+    expect(judgeGoldPath(obs(all("ok")), { allowMutations: true }).verdict).toBe("pass");
+  });
+  it("a blocked required step → fail (cannot pass with a blocker)", () => {
+    const steps = all("ok");
+    steps[2] = { step: "claim", status: "blocked", detail: "claim button 500s" };
+    const j = judgeGoldPath(obs(steps), { allowMutations: true });
+    expect(j.verdict).toBe("fail");
+    expect(j.blockers.join(" ")).toMatch(/claim/);
+  });
+  it("a degraded surface → partial (honest, but not clean)", () => {
+    const steps = all("ok");
+    steps[1] = { step: "discover", status: "degraded", detail: "jobs list shows stale data banner" };
+    expect(judgeGoldPath(obs(steps), { allowMutations: true }).verdict).toBe("partial");
+  });
+  it("an empty surface → partial", () => {
+    const steps = all("ok");
+    steps[1] = { step: "discover", status: "empty", detail: "no jobs and no empty-state label" };
+    expect(judgeGoldPath(obs(steps), { allowMutations: true }).verdict).toBe("partial");
+  });
+  it("read-only run: skipping mutating steps is EXPECTED → still pass", () => {
+    const steps = GOLD_PATH_STEPS.map((step) =>
+      (step === "claim" || step === "submit" || step === "payout_sbt")
+        ? { step, status: "skipped" as const, detail: "read-only" }
+        : { step, status: "ok" as const, detail: "ok" },
+    );
+    expect(judgeGoldPath(obs(steps), { allowMutations: false }).verdict).toBe("pass");
+  });
+  it("crossing a mutation boundary while read-only → fail (hard fault)", () => {
+    const j = judgeGoldPath(obs(all("ok"), { stoppedBeforeMutation: false }), { allowMutations: false });
+    expect(j.verdict).toBe("fail");
+    expect(j.blockers.join(" ")).toMatch(/mutation while the mission was read-only/i);
+  });
+});
+
+// ── orchestrator + structural mainnet read-only ─────────────────────
+
+const TESTNET: TestbedMutationBinding = resolveTestbedMutationBinding({
+  mode: "gold_path",
+  configuredEnvironment: "testnet",
+  requestedAllowTestMutations: true,
+});
+const MAINNET: TestbedMutationBinding = resolveTestbedMutationBinding({
+  mode: "gold_path",
+  configuredEnvironment: "mainnet",
+  requestedAllowTestMutations: true,
+});
+
+describe("runGoldPathMissionOnce", () => {
+  const mission = { id: "gp-1", targetUrl: "https://app.testnet.example", goal: "gold path", freshMemory: true };
+
+  it("testnet + requested mutations → mutating steps run, report carries the shape", async () => {
+    const result = await runGoldPathMissionOnce({
+      mission,
+      binding: TESTNET,
+      driver: createScriptedGoldPathDriver(),
+      model: "sonnet",
+    });
+    expect(result.verdict).toBe("pass");
+    const r = result.report;
+    expect(r.executor).toBe("gold_path");
+    expect(r.mode).toBe("gold_path");
+    expect(r.mutationMode).toBe("testbed_mutation_allowed");
+    expect(r.environment).toBe("testnet");
+    expect(Array.isArray(r.mutationsAttempted) && (r.mutationsAttempted as unknown[]).length).toBeGreaterThan(0);
+    expect(r.stoppedBeforeMutation).toBe(true);
+    expect(typeof r.summary).toBe("string");
+    expect(Array.isArray(r.completedPath)).toBe(true);
+    expect(r.scores).toBeTruthy();
+  });
+
+  it("MAINNET + requested mutations → STRUCTURALLY read-only (no mutation attempted)", async () => {
+    expect(MAINNET.mutationMode).toBe("read_only");
+    expect(MAINNET.allowTestMutations).toBe(false);
+    // Even with an all-"ok" scripted driver, the binding forbids mutation, so
+    // the mutating steps are skipped and nothing is mutated.
+    const result = await runGoldPathMissionOnce({
+      mission: { ...mission, targetUrl: "https://app.averray.com" },
+      binding: MAINNET,
+      driver: createScriptedGoldPathDriver(),
+      model: "sonnet",
+    });
+    const r = result.report;
+    expect(r.mutationMode).toBe("read_only");
+    expect(r.stoppedBeforeMutation).toBe(true);
+    expect((r.mutationsAttempted as unknown[]).length).toBe(0);
+    // The mutating steps are recorded as skipped (read-only), not failed.
+    const steps = r.steps as GoldPathStepResult[];
+    expect(steps.find((s) => s.step === "claim")?.status).toBe("skipped");
+    expect(result.verdict).toBe("pass"); // read-only journey was clean + honest
+  });
+
+  it("a blocked step from the driver → fail verdict in the report", async () => {
+    const result = await runGoldPathMissionOnce({
+      mission,
+      binding: TESTNET,
+      driver: createScriptedGoldPathDriver([{ step: "verify", status: "blocked", detail: "verify endpoint 500" }]),
+      model: "opus",
+    });
+    expect(result.verdict).toBe("fail");
+    expect((result.report.blockers as string[]).join(" ")).toMatch(/verif/i);
+  });
+
+  it("unavailable driver (no live LLM wired) → honest FAIL, never a fake pass", async () => {
+    const result = await runGoldPathMissionOnce({
+      mission,
+      binding: TESTNET,
+      driver: createUnavailableGoldPathDriver("live driver not wired"),
+      model: "sonnet",
+    });
+    expect(result.verdict).toBe("fail");
+    expect((result.report.summary as string)).toMatch(/gold_path fail/);
+  });
+});
+
+// ── entry: env → binding → orchestrator (mainnet stays read-only) ───
+
+describe("runGoldPathMissionEntry — env wiring keeps mainnet read-only", () => {
+  let dir: string;
+  beforeEach(async () => { dir = await mkdtemp(join(tmpdir(), "averray-goldpath-")); });
+  afterEach(async () => { await rm(dir, { recursive: true, force: true }); });
+
+  it("mainnet env + requested mutations + all-ok driver → no mutation, read-only report", async () => {
+    const result = await runGoldPathMissionEntry(
+      {
+        TESTBED_MISSION_ID: "gp-entry-1",
+        TESTBED_TARGET_URL: "https://app.averray.com",
+        TESTBED_MISSION_GOAL: "gold path",
+        TESTBED_MISSION_ENVIRONMENT: "mainnet",
+        TESTBED_REQUESTED_TEST_MUTATIONS: "true",
+        TESTBED_MISSION_REPORT_PATH: join(dir, "report.json"),
+      } as NodeJS.ProcessEnv,
+      { driver: createScriptedGoldPathDriver() },
+    );
+    expect(result.report.environment).toBe("mainnet");
+    expect(result.report.mutationMode).toBe("read_only");
+    expect((result.report.mutationsAttempted as unknown[]).length).toBe(0);
+    expect(result.report.stoppedBeforeMutation).toBe(true);
+  });
+});

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -51,7 +51,7 @@ describe("tester capabilities manifest", () => {
     });
     const goldPath = manifest.missionTypes.find((mission) => mission.id === "gold_path");
     expect(goldPath).toMatchObject({
-      status: "operator_only_design",
+      status: "executor_scaffolded_awaiting_live_driver",
       scope: "testbed_mutation_only",
     });
     const siweAuth = manifest.missionTypes.find((mission) => mission.id === "siwe_auth_role_gating");


### PR DESCRIPTION
## What changed & why

Builds the **Tier-2 LLM gold-path tester executor** (per `docs/HERMES_E2E_TESTER_DESIGN.md` §Tier-2 + `docs/HERMES_AGENT_MODELS_AND_EFFORT.md` §2) — the framework that drives the product's agent gold path (onboard → discover → claim → submit → verify → payout/SBT → receipt) and judges it **honestly** — wired into the testbed runner's **`command` hook**, behind the **existing T6 request→approve gate**. **Report-only, no authority change. CI never calls a live LLM.**

### Core — `gold-path-mission.ts` (new)
- `GoldPathDriver` is **injected** (real = Claude Agent SDK + Playwright-MCP; CI = scripted fake) — the core never calls an LLM.
- `pickGoldPathModel` — **A4 policy**: Sonnet routine, Opus for deep/high-risk, operator override wins.
- `judgeGoldPath` — pure + **truth-boundary honest**: a blocked/errored required step can't be a pass; degraded/empty → at best `partial`; a read-only run that *skips* mutating steps is expected (not penalised); crossing a mutation boundary while read-only is a hard fail. **Never fakes a pass.**
- `buildGoldPathReport` — the existing structured report shape (verdict / scores / blockers / completedPath / evidence / mutation* / stoppedBeforeMutation / summary), so the mission store ingests it like Tier-1.
- `runGoldPathMissionOnce` — orchestrator (binding + session + model + driver → judge → report), with defense-in-depth: a read-only run that reports attempted mutations is failed regardless of the driver's own flag.
- `createScriptedGoldPathDriver` (deterministic CI driver) + `createUnavailableGoldPathDriver` (a non-live deploy emits an honest "not executed" **fail**, never a fake pass).

### Wiring
- `gold-path-mission-entry.ts` — the `command` entrypoint: re-resolves the **T5** mutation binding from env (**mainnet → read-only by construction**; a mutating gold-path against mainnet is *structurally impossible*), resolves the **T3** signer session (API Bearer; key never enters the process), picks the **A4** model, selects the driver, writes the report to `TESTBED_MISSION_REPORT_PATH`.
- `gold_path` added to `TestbedMissionMode`; `POST /monitor/testbed-missions` accepts it and forces `requireApproval` → the mission lands **`requested`** (behind the T6 approve gate, never auto-run).
- `ops/.env.example` + `docs/DEPLOY.md`: how to point the command executor at the entry (+ the "runner claims all ready missions" caveat) and the live/deep/model knobs. Capabilities manifest: `gold_path` → `executor_scaffolded_awaiting_live_driver`.

### Live driver scope (honest)
The executor, safety binding, session, model policy, judge, report, and approve-gate wiring are **built + tested**. The **live Claude Agent SDK + Playwright-MCP driver is a deliberate follow-up** — it needs the SDK deps + a real env to validate and must never run in CI. Until it's wired, the runner **fails closed honestly** ("not executed") rather than emitting a fake pass.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue (testbed mission runner `command` hook)
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1150 passed; new: A4 model policy, judge-honesty matrix, orchestrator report shape, **testnet-mutates vs mainnet-structurally-read-only**, entry env→binding wiring, unavailable-driver honest fail)
- [x] `docker compose … config` — no compose **service** added (T4 reuses the existing `command` executor); only `.env.example` knobs + a DEPLOY note. CI's Docker-build job validates compose.

## Rollout / rollback
- **Off by default**: gold_path missions land `requested` (operator must approve); no runner is configured for the command executor by default; the live driver is opt-in and not wired (honest non-run until then).
- **Enable** (testnet): point a testbed runner at `gold-path-mission-entry.js` via `TESTBED_MISSION_RUNNER_EXECUTOR=command` + the T3 session env (see DEPLOY.md), approve the mission on the board.
- **Rollback**: revert; or stop queuing `gold_path` missions / point the executor back at the playwright runner.

## Durable invariants (AGENTS.md)
- [x] **No auto-run / no auto-merge/deploy** — gold_path is `requested`-gated; report-only; merge/deploy stay human
- [x] **Testnet-only mutation** — T5 binding makes a mutating gold-path against mainnet structurally impossible (proven by test); read-mostly stops before every mutation boundary it isn't allowed to cross
- [x] Stays under the dispatch guardrail + `HALT_FILE` (same testbed runner); wallet key stays in the T3 sidecar, never in the model context / logs
- [x] **Invariant #8** — introduces **no new Polkadot/chain assertion**; the gold-path step names mirror the existing E2E design doc (no chain behavior/address/fee/settlement claim to verify)
- [x] No secrets committed/printed/logged (session token never logged; `redact` on error)
- [x] **CI never calls a live LLM** — the driver is injected; tests use the scripted/unavailable drivers only

## Known limits / follow-ups
- **Live driver** (Claude Agent SDK + Playwright-MCP + HTTP/wallet tool) plugs into the `GoldPathDriver` seam — the main follow-up; adds the SDK deps + the real self-judging loop.
- The testbed runner **claims all ready missions** (no per-mode filter), so the gold-path command executor should run where only `gold_path` missions are queued — a mode-filtered claim is a sensible next step.
- Second backend (Codex/GPT tester) is a T5 enhancement per the models doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)