### PR TITLE
Move B1 follow-ups into Hermes rail

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -116,11 +116,13 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getByText("not_recorded")).toBeTruthy();
   });
 
-  test("renders backlog suggestions as planner-only read-only prompts", () => {
-    const { getByRole, getByText } = render(
+  test("renders backlog suggestions as a collapsed planner-only rail block", () => {
+    const onCardClick = vi.fn();
+    const { container, getByRole, getByText, queryByText } = render(
       <BoardView
         board={richBoard}
         status="open"
+        onCardClick={onCardClick}
         backlogSuggestions={{
           generatedAt: "2026-05-31T12:00:00.000Z",
           safety: {
@@ -139,7 +141,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
               reason: "A browser mission failed and needs a narrow fix plan.",
               suggestedOwner: "claude",
               riskTier: "low",
-              related: { cardId: "mission-1" },
+              related: { cardId: "mission browser-onboard-04" },
               suggestedPrompt: "Investigate the failed mission.",
               confidence: 0.82,
               evidence: ["missionVerdict:FAILED"],
@@ -149,10 +151,20 @@ describe("BoardView — rich-mix board (open stream)", () => {
       />,
     );
     expect(getByRole("region", { name: "Suggested follow-ups" })).toBeTruthy();
+    expect(container.querySelector(".hm-lanes-wrap .hm-backlog-suggestions")).toBeFalsy();
+    const toggle = getByRole("button", { name: /Suggested follow-ups \(1\)/ });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
     expect(getByText("planner-only · read-only")).toBeTruthy();
     expect(getByText("no tasks created")).toBeTruthy();
+    expect(queryByText("Follow up failed mission")).toBeFalsy();
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(getByText("Follow up failed mission")).toBeTruthy();
     expect(getByRole("button", { name: "Copy prompt" })).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Open related card mission browser-onboard-04" }));
+    expect(onCardClick).toHaveBeenCalledWith("mission browser-onboard-04");
   });
 
   test("Refresh button is wired to onRefresh", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -20,7 +20,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
 import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache.js";
-import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
+import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
 import { CreateTaskForm } from "./CreateTaskForm.js";
@@ -285,7 +285,6 @@ export function BoardView({
             searchInputRef={searchInputRef}
           />
           <LlmUsagePanel usage={board?.llmUsage} />
-          <BacklogSuggestionsPanel response={backlogSuggestions} />
           <Board
             grouped={displayGrouped}
             expanded={expanded}
@@ -312,7 +311,10 @@ export function BoardView({
           onSpawnMission={onSpawnMission}
           onSpawnClaudeTask={onSpawnClaudeTask}
           onCreateTask={onCreateTask}
+          backlogSuggestions={backlogSuggestions}
+          boardCards={cards}
           focusedCard={scopeCard}
+          onCardClick={onCardClick}
           collaboration={collaboration}
           onMute={onMute}
           onUnmute={onUnmute}
@@ -376,50 +378,6 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
         )}
       </div>
     </section>
-  );
-}
-
-function BacklogSuggestionsPanel({ response }: { response?: BacklogSuggestionsResponse }) {
-  const suggestions = response?.suggestions?.slice(0, 3) ?? [];
-  if (suggestions.length === 0) return null;
-  return (
-    <section className="hm-backlog-suggestions" aria-label="Suggested follow-ups">
-      <div className="hm-backlog-suggestions-head">
-        <div>
-          <span className="hm-kicker">Suggested follow-ups</span>
-          <strong>planner-only · read-only</strong>
-        </div>
-        <span className="hm-backlog-suggestions-safety">no tasks created</span>
-      </div>
-      <div className="hm-backlog-suggestions-grid">
-        {suggestions.map((suggestion) => (
-          <BacklogSuggestionRow suggestion={suggestion} key={suggestion.id} />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function BacklogSuggestionRow({ suggestion }: { suggestion: BacklogSuggestion }) {
-  const copyPrompt = () => {
-    if (!suggestion.suggestedPrompt || typeof navigator === "undefined") return;
-    void navigator.clipboard?.writeText(suggestion.suggestedPrompt);
-  };
-  return (
-    <div className="hm-backlog-suggestion-row">
-      <span>
-        <strong>{suggestion.title}</strong>
-        <small>{suggestion.reason}</small>
-      </span>
-      <span className="hm-backlog-suggestion-meta">
-        {suggestion.suggestedOwner} · {suggestion.riskTier} · {Math.round(suggestion.confidence * 100)}%
-      </span>
-      {suggestion.suggestedPrompt ? (
-        <button type="button" className="hm-backlog-copy" onClick={copyPrompt}>
-          Copy prompt
-        </button>
-      ) : null}
-    </div>
   );
 }
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -6,8 +6,9 @@
 // shows up on the next poll. `/mission <url>` still spawns a browser
 // mission (M7').
 
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
+import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../../lib/monitor/backlog-suggestions.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
@@ -19,8 +20,14 @@ export interface CoPilotRailProps {
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Propose a task (/task <agent> [<repo>#<pr>] <prompt>). */
   onCreateTask?: (input: CreateTaskInput) => void;
+  /** Planner-only B1 follow-up suggestions. Read-only; never creates tasks. */
+  backlogSuggestions?: BacklogSuggestionsResponse;
+  /** Board cards used to link suggestions to their source card. */
+  boardCards?: readonly BoardCard[];
   /** Focused card — scopes Ask-Hermes questions + the scope chip. */
   focusedCard?: BoardCard;
+  /** Open a related card from a linked follow-up suggestion. */
+  onCardClick?: (id: string) => void;
   /** Collaboration wiring. Omit to keep the rail inert (e.g. in BoardView tests). */
   collaboration?: UseCollaborationOptions;
   /** Mute action alerts until a timestamp (/mute). */
@@ -43,7 +50,10 @@ export function CoPilotRail({
   onSpawnMission,
   onSpawnClaudeTask,
   onCreateTask,
+  backlogSuggestions,
+  boardCards,
   focusedCard,
+  onCardClick,
   collaboration,
   onMute,
   onUnmute,
@@ -79,6 +89,12 @@ export function CoPilotRail({
         </div>
       </div>
 
+      <BacklogSuggestionsRailBlock
+        response={backlogSuggestions}
+        boardCards={boardCards ?? []}
+        onCardClick={onCardClick}
+      />
+
       <div className="hm-hermes-stream" ref={streamRef} aria-live="polite">
         {messages.length === 0 ? (
           <div className="hm-lane-empty">
@@ -104,5 +120,100 @@ export function CoPilotRail({
         focusToken={composerFocusToken}
       />
     </aside>
+  );
+}
+
+function BacklogSuggestionsRailBlock({
+  response,
+  boardCards,
+  onCardClick,
+}: {
+  response?: BacklogSuggestionsResponse;
+  boardCards: readonly BoardCard[];
+  onCardClick?: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const bodyId = useId();
+  const suggestions = response?.suggestions?.slice(0, 3) ?? [];
+  const cardsById = useMemo(() => new Map(boardCards.map((card) => [card.id, card])), [boardCards]);
+
+  if (!response) return null;
+
+  return (
+    <section className="hm-backlog-suggestions hm-backlog-suggestions--rail" aria-label="Suggested follow-ups">
+      <button
+        type="button"
+        className="hm-backlog-suggestions-toggle"
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span aria-hidden>{open ? "▾" : "▸"}</span>
+        <span>
+          <span className="hm-kicker">Suggested follow-ups ({suggestions.length})</span>
+          <strong>planner-only · read-only</strong>
+        </span>
+        <span className="hm-backlog-suggestions-safety">no tasks created</span>
+      </button>
+      {open ? (
+        <div className="hm-backlog-suggestions-grid" id={bodyId}>
+          {suggestions.length > 0 ? suggestions.map((suggestion) => (
+            <BacklogSuggestionRow
+              suggestion={suggestion}
+              relatedCard={cardsById.get(suggestion.related.cardId)}
+              onCardClick={onCardClick}
+              key={suggestion.id}
+            />
+          )) : (
+            <div className="hm-backlog-suggestion-empty">No follow-up suggestions right now.</div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function BacklogSuggestionRow({
+  suggestion,
+  relatedCard,
+  onCardClick,
+}: {
+  suggestion: BacklogSuggestion;
+  relatedCard?: BoardCard;
+  onCardClick?: (id: string) => void;
+}) {
+  const copyPrompt = () => {
+    if (!suggestion.suggestedPrompt || typeof navigator === "undefined") return;
+    void navigator.clipboard?.writeText(suggestion.suggestedPrompt);
+  };
+  return (
+    <div className="hm-backlog-suggestion-row">
+      <span>
+        <strong>{suggestion.title}</strong>
+        <small>{suggestion.reason}</small>
+      </span>
+      <span className="hm-backlog-suggestion-meta">
+        {suggestion.suggestedOwner} · {suggestion.riskTier} · {Math.round(suggestion.confidence * 100)}%
+      </span>
+      {relatedCard ? (
+        onCardClick ? (
+          <button
+            type="button"
+            className="hm-backlog-link"
+            onClick={() => onCardClick(relatedCard.id)}
+            aria-label={`Open related card ${relatedCard.id}`}
+          >
+            Open card
+          </button>
+        ) : (
+          <span className="hm-backlog-link">linked card</span>
+        )
+      ) : null}
+      {suggestion.suggestedPrompt ? (
+        <button type="button" className="hm-backlog-copy" onClick={copyPrompt}>
+          Copy prompt
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -429,6 +429,12 @@ body { margin: 0; }
   display: grid;
   gap: 9px;
 }
+.hm-backlog-suggestions--rail {
+  margin: 12px 16px 0;
+  padding: 0;
+  overflow: hidden;
+  background: rgba(255,253,247,0.56);
+}
 .hm-backlog-suggestions-head,
 .hm-backlog-suggestion-row {
   display: flex;
@@ -442,9 +448,29 @@ body { margin: 0; }
   font-size: 13px;
   color: var(--hm-ink);
 }
+.hm-backlog-suggestions-toggle {
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  padding: 10px 12px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+  text-align: left;
+  cursor: pointer;
+}
+.hm-backlog-suggestions-toggle strong {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--hm-ink);
+}
 .hm-backlog-suggestions-safety,
 .hm-backlog-suggestion-row,
-.hm-backlog-suggestion-row small {
+.hm-backlog-suggestion-row small,
+.hm-backlog-suggestion-empty {
   font-family: var(--font-mono);
   font-size: 11.5px;
   color: var(--hm-muted);
@@ -456,6 +482,15 @@ body { margin: 0; }
 .hm-backlog-suggestion-row {
   padding-top: 6px;
   border-top: 1px solid var(--hm-line-soft);
+}
+.hm-backlog-suggestions--rail .hm-backlog-suggestions-grid {
+  padding: 0 12px 10px;
+}
+.hm-backlog-suggestions--rail .hm-backlog-suggestion-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  align-items: start;
+  gap: 7px;
 }
 .hm-backlog-suggestion-row span:first-child {
   min-width: 0;
@@ -475,7 +510,8 @@ body { margin: 0; }
 .hm-backlog-suggestion-meta {
   white-space: nowrap;
 }
-.hm-backlog-copy {
+.hm-backlog-copy,
+.hm-backlog-link {
   flex: 0 0 auto;
   border: 1px solid var(--hm-line);
   border-radius: 7px;
@@ -487,8 +523,22 @@ body { margin: 0; }
   padding: 6px 8px;
   cursor: pointer;
 }
+.hm-backlog-link {
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+  text-decoration: none;
+}
+.hm-backlog-suggestion-row span.hm-backlog-link {
+  display: inline-flex;
+  align-items: center;
+  cursor: default;
+}
 .hm-backlog-copy:hover {
   border-color: var(--hm-sage);
+}
+.hm-backlog-link:hover {
+  border-color: var(--hm-cyan-ring);
+  color: var(--hm-ink);
 }
 .hm-filter-chip {
   display: inline-flex; align-items: center; gap: 6px;


### PR DESCRIPTION
## What changed & why

- Moved B1 Suggested follow-ups out of the full-width kanban banner and into the Hermes co-pilot rail.
- The rail block is collapsed by default, shows a count, and keeps the exact truth-boundary labels: "planner-only · read-only" and "no tasks created".
- Expanded suggestions keep the existing Copy prompt button and link back to the related board card when one exists, so the advisory item is not presented as a separate competing board card.
- No B1 suggestion generation, queue, approval, or dispatch authority changed.

## Affected surfaces

- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Frontend monitor UI only. Roll back by reverting this PR; no env, ops, data, or authority change.

## Durable invariants (AGENTS.md)

- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- This is placement and presentation only. B1 remains planner-only and read-only; it still creates no tasks.
