### PR TITLE
Make LLM usage panel source-honest

### DIFF
--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -34,8 +34,15 @@ export interface LlmUsageDayRollup {
   byModel: LlmUsageModelRollup[];
 }
 
+export interface LlmUsageSourceStatus {
+  agent: string;
+  status: "recorded" | "not_reported";
+  reason?: string;
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
+  message: string;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -44,6 +51,7 @@ export interface LlmUsageAggregate {
   runs: number;
   byModel: LlmUsageModelRollup[];
   byDay: LlmUsageDayRollup[];
+  sourceStatus: LlmUsageSourceStatus[];
 }
 
 export interface LlmUsageCaptureInput {
@@ -55,7 +63,19 @@ export interface LlmUsageCaptureInput {
   result: unknown;
 }
 
+export interface LlmUsageAggregateOptions {
+  expectedAgents?: readonly string[];
+  sourceReasons?: Readonly<Record<string, string>>;
+}
+
 const DEFAULT_USAGE_LOG_PATH = "/data/llm-usage.jsonl";
+const DEFAULT_EXPECTED_AGENTS = ["claude", "test-writer", "codex", "hermes"] as const;
+const DEFAULT_SOURCE_REASONS: Readonly<Record<string, string>> = {
+  claude: "Claude Agent SDK usage counters have not arrived from runner output yet.",
+  "test-writer": "Test-writer SDK usage counters have not arrived from runner output yet.",
+  codex: "Codex usage is not reported by the CLI yet.",
+  hermes: "Hermes/Ollama responses have not exposed usage counters yet.",
+};
 
 export function llmUsageLogPath(env: NodeJS.ProcessEnv = process.env): string {
   return env.LLM_USAGE_LOG_PATH?.trim() || env.AVERRAY_LLM_USAGE_LOG_PATH?.trim() || DEFAULT_USAGE_LOG_PATH;
@@ -97,13 +117,17 @@ export async function recordLlmUsageFromResult(
 }
 
 export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEvent | undefined {
-  const usage = firstRecord(
-    recordField(input.result, "usage"),
-    recordField(recordField(input.result, "response"), "usage"),
-    recordField(recordField(input.result, "result"), "usage"),
-    explicitUsageJson(input.result)
+  const usageSource = firstUsageSource(
+    tokenUsageSource(input.result),
+    usageSourceFromRecord(input.result),
+    usageSourceFromRecord(recordField(input.result, "response")),
+    usageSourceFromRecord(recordField(input.result, "result")),
+    usageSourceFromArrayField(input.result, "messages"),
+    usageSourceFromArrayField(input.result, "events"),
+    explicitUsageSource(input.result)
   );
-  if (!usage) return undefined;
+  if (!usageSource) return undefined;
+  const { usage, carrier } = usageSource;
 
   const inputTokens = integerField(usage, "inputTokens")
     ?? integerField(usage, "input_tokens")
@@ -116,14 +140,23 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
 
   const model = stringField(usage, "model")
+    ?? stringField(carrier, "model")
+    ?? stringField(carrier, "modelId")
     ?? stringField(input.result, "model")
     ?? stringField(input.result, "modelId")
     ?? input.model
     ?? "not_recorded";
   const costUsd = numberField(usage, "costUsd")
     ?? numberField(usage, "cost_usd")
+    ?? numberField(usage, "total_cost_usd")
+    ?? numberField(carrier, "costUsd")
+    ?? numberField(carrier, "cost_usd")
+    ?? numberField(carrier, "totalCostUsd")
+    ?? numberField(carrier, "total_cost_usd")
     ?? numberField(input.result, "costUsd")
-    ?? numberField(input.result, "totalCostUsd");
+    ?? numberField(input.result, "cost_usd")
+    ?? numberField(input.result, "totalCostUsd")
+    ?? numberField(input.result, "total_cost_usd");
 
   const event: LlmUsageEvent = {
     agent: input.agent,
@@ -138,16 +171,25 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
   return sanitizeUsageEvent(event);
 }
 
-export function aggregateLlmUsage(events: readonly LlmUsageEvent[] = []): LlmUsageAggregate {
+export function aggregateLlmUsage(
+  events: readonly LlmUsageEvent[] = [],
+  options: LlmUsageAggregateOptions = {}
+): LlmUsageAggregate {
   const byModel = rollupByModel(events);
   const byDay = rollupByDay(events);
   const total = totalsFor(events);
+  const sourceStatus = sourceStatuses(events, options);
+  const status = events.length > 0 ? "recorded" : "not_recorded";
   return {
-    status: events.length > 0 ? "recorded" : "not_recorded",
+    status,
+    message: status === "recorded"
+      ? "LLM usage includes only runner results that emitted whitelisted cost/token counters."
+      : "No runner has reported LLM usage counters yet. Claude/test-writer counters depend on SDK output; Codex CLI and Hermes/Ollama do not reliably report usage today.",
     ...total,
     runs: events.length,
     byModel,
     byDay,
+    sourceStatus,
   };
 }
 
@@ -167,11 +209,45 @@ export function aggregateLlmUsageForAgent(
   const total = totalsFor(events);
   return {
     status: byModel.length > 0 ? "recorded" : "not_recorded",
+    message: byModel.length > 0
+      ? "LLM usage includes only runner results that emitted whitelisted cost/token counters."
+      : sourceReason(agent, undefined),
     ...total,
     runs: byModel.reduce((sum, entry) => sum + entry.runs, 0),
     byModel,
     byDay: [],
+    sourceStatus: [{
+      agent,
+      status: byModel.length > 0 ? "recorded" : "not_reported",
+      ...(byModel.length > 0 ? {} : { reason: sourceReason(agent, undefined) }),
+    }],
   };
+}
+
+function sourceStatuses(
+  events: readonly LlmUsageEvent[],
+  options: LlmUsageAggregateOptions
+): LlmUsageSourceStatus[] {
+  const recorded = new Set(events.map((event) => event.agent));
+  const expectedAgents = uniqueStrings([
+    ...(options.expectedAgents ?? DEFAULT_EXPECTED_AGENTS),
+    ...recorded,
+  ]);
+  return expectedAgents.map((agent) => ({
+    agent,
+    status: recorded.has(agent) ? "recorded" as const : "not_reported" as const,
+    ...(recorded.has(agent) ? {} : { reason: sourceReason(agent, options.sourceReasons) }),
+  }));
+}
+
+function sourceReason(agent: string, overrides?: Readonly<Record<string, string>>): string {
+  return overrides?.[agent]
+    ?? DEFAULT_SOURCE_REASONS[agent]
+    ?? `${agent} usage counters have not arrived from runner output yet.`;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean))).sort();
 }
 
 function rollupByModel(events: readonly LlmUsageEvent[]): LlmUsageModelRollup[] {
@@ -257,6 +333,48 @@ function parseUsageLine(line: string): LlmUsageEvent | undefined {
   }
 }
 
+interface UsageSource {
+  usage: Record<string, unknown>;
+  carrier: Record<string, unknown>;
+}
+
+function usageSourceFromRecord(value: unknown): UsageSource | undefined {
+  if (!isRecord(value)) return undefined;
+  const usage = recordField(value, "usage");
+  return usage ? { usage, carrier: value } : undefined;
+}
+
+function tokenUsageSource(value: unknown): UsageSource | undefined {
+  if (!isRecord(value)) return undefined;
+  return hasTokenCounts(value) ? { usage: value, carrier: value } : undefined;
+}
+
+function usageSourceFromArrayField(value: unknown, key: string): UsageSource | undefined {
+  if (!isRecord(value) || !Array.isArray(value[key])) return undefined;
+  for (const item of value[key]) {
+    const source = usageSourceFromRecord(item) ?? tokenUsageSource(item);
+    if (source) return source;
+  }
+  return undefined;
+}
+
+function explicitUsageSource(value: unknown): UsageSource | undefined {
+  const usage = explicitUsageJson(value);
+  return usage ? { usage, carrier: usage } : undefined;
+}
+
+function hasTokenCounts(record: Record<string, unknown>): boolean {
+  const inputTokens = integerField(record, "inputTokens")
+    ?? integerField(record, "input_tokens")
+    ?? integerField(record, "promptTokens")
+    ?? integerField(record, "prompt_tokens");
+  const outputTokens = integerField(record, "outputTokens")
+    ?? integerField(record, "output_tokens")
+    ?? integerField(record, "completionTokens")
+    ?? integerField(record, "completion_tokens");
+  return inputTokens !== undefined && outputTokens !== undefined;
+}
+
 function explicitUsageJson(value: unknown): Record<string, unknown> | undefined {
   const stdout = isRecord(value) && typeof value.stdout === "string" ? value.stdout : "";
   const stderr = isRecord(value) && typeof value.stderr === "string" ? value.stderr : "";
@@ -270,8 +388,8 @@ function explicitUsageJson(value: unknown): Record<string, unknown> | undefined 
   }
 }
 
-function firstRecord(...values: Array<Record<string, unknown> | undefined>): Record<string, unknown> | undefined {
-  return values.find((value): value is Record<string, unknown> => Boolean(value));
+function firstUsageSource(...values: Array<UsageSource | undefined>): UsageSource | undefined {
+  return values.find((value): value is UsageSource => Boolean(value));
 }
 
 function recordField(value: unknown, key: string): Record<string, unknown> | undefined {

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -79,9 +79,10 @@ describe("BoardView — rich-mix board (open stream)", () => {
         inputTokens: 100,
         outputTokens: 40,
         totalTokens: 140,
-        costUsd: null,
-        costStatus: "not_recorded",
+        costUsd: 0.0123,
+        costStatus: "recorded",
         runs: 1,
+        message: "LLM usage includes only runner results that emitted whitelisted cost/token counters.",
         byModel: [],
         byDay: [
           {
@@ -89,22 +90,26 @@ describe("BoardView — rich-mix board (open stream)", () => {
             inputTokens: 100,
             outputTokens: 40,
             totalTokens: 140,
-            costUsd: null,
-            costStatus: "not_recorded",
+            costUsd: 0.0123,
+            costStatus: "recorded",
             runs: 1,
             byModel: [
               {
-                agent: "codex",
-                model: "gpt-5-codex",
+                agent: "claude",
+                model: "claude-sonnet-4-5",
                 inputTokens: 100,
                 outputTokens: 40,
                 totalTokens: 140,
-                costUsd: null,
-                costStatus: "not_recorded",
+                costUsd: 0.0123,
+                costStatus: "recorded",
                 runs: 1,
               },
             ],
           },
+        ],
+        sourceStatus: [
+          { agent: "claude", status: "recorded" },
+          { agent: "codex", status: "not_reported", reason: "Codex usage is not reported by the CLI yet." },
         ],
       },
     };
@@ -112,8 +117,34 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
     expect(getByText("2026-05-31")).toBeTruthy();
     expect(getByText("140 tokens")).toBeTruthy();
-    expect(getByText("gpt-5-codex")).toBeTruthy();
-    expect(getByText("not_recorded")).toBeTruthy();
+    expect(getByText("claude-sonnet-4-5")).toBeTruthy();
+    expect(getByText("$0.0123")).toBeTruthy();
+    expect(getByText("Codex usage is not reported by the CLI yet.")).toBeTruthy();
+  });
+
+  test("renders a plain-language usage explanation when no source emits counters", () => {
+    const board: MonitorBoard = {
+      ...richBoard,
+      llmUsage: {
+        status: "not_recorded",
+        message: "No runner has reported LLM usage counters yet. Claude/test-writer counters depend on SDK output; Codex CLI and Hermes/Ollama do not reliably report usage today.",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        costUsd: null,
+        costStatus: "not_recorded",
+        runs: 0,
+        byModel: [],
+        byDay: [],
+        sourceStatus: [],
+      },
+    };
+
+    const { getByRole, getByText, queryByText } = render(<BoardView board={board} status="open" />);
+    expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
+    expect(getByText("usage not reported")).toBeTruthy();
+    expect(getByText(/No runner has reported LLM usage counters yet/)).toBeTruthy();
+    expect(queryByText("not_recorded")).toBeNull();
   });
 
   test("renders backlog suggestions as a collapsed planner-only rail block", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -352,29 +352,49 @@ function formatClock(iso: string | undefined): string {
 function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
   const latestDay = usage?.byDay?.[0];
   const models = latestDay?.byModel?.slice(0, 4) ?? [];
+  const missingSources = (usage?.sourceStatus ?? [])
+    .filter((entry) => entry.status === "not_reported")
+    .slice(0, Math.max(0, 4 - models.length));
+  const hasRows = models.length > 0 || missingSources.length > 0;
+  const emptyMessage = usage?.message
+    ?? "No runner has reported LLM usage counters yet. Claude/test-writer counters depend on SDK output; Codex CLI and Hermes/Ollama do not reliably report usage today.";
   return (
     <section className="hm-llm-usage" aria-label="LLM usage">
       <div className="hm-llm-usage-head">
         <div>
           <span className="hm-kicker">LLM usage</span>
-          <strong>{latestDay?.day ?? "not recorded"}</strong>
+          <strong>{latestDay?.day ?? "usage not reported"}</strong>
         </div>
         <span className="hm-llm-usage-total">
-          {usage?.status === "recorded" ? `${formatNumber(latestDay?.totalTokens ?? 0)} tokens` : "not_recorded"}
+          {usage?.status === "recorded" ? `${formatNumber(latestDay?.totalTokens ?? 0)} tokens` : "not reported"}
         </span>
       </div>
       <div className="hm-llm-usage-grid">
-        {models.length > 0 ? models.map((entry) => (
-          <div className="hm-llm-usage-row" key={`${entry.agent}:${entry.model}`}>
-            <span>
-              <strong>{entry.agent}</strong>
-              <small>{entry.model}</small>
-            </span>
-            <span>{formatNumber(entry.totalTokens)} tok</span>
-            <span>{entry.costStatus === "recorded" && entry.costUsd !== null ? `$${entry.costUsd.toFixed(4)}` : "not_recorded"}</span>
-          </div>
-        )) : (
-          <div className="hm-llm-usage-empty">Reported usage counters have not arrived yet.</div>
+        {hasRows ? (
+          <>
+            {models.map((entry) => (
+              <div className="hm-llm-usage-row" key={`${entry.agent}:${entry.model}`}>
+                <span>
+                  <strong>{entry.agent}</strong>
+                  <small>{entry.model}</small>
+                </span>
+                <span>{formatNumber(entry.totalTokens)} tok</span>
+                <span>{entry.costStatus === "recorded" && entry.costUsd !== null ? `$${entry.costUsd.toFixed(4)}` : "cost not reported"}</span>
+              </div>
+            ))}
+            {missingSources.map((entry) => (
+              <div className="hm-llm-usage-row hm-llm-usage-row--muted" key={`missing:${entry.agent}`}>
+                <span>
+                  <strong>{entry.agent}</strong>
+                  <small>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</small>
+                </span>
+                <span>not reported</span>
+                <span>no live metric</span>
+              </div>
+            ))}
+          </>
+        ) : (
+          <div className="hm-llm-usage-empty">{emptyMessage}</div>
         )}
       </div>
     </section>

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -36,8 +36,15 @@ export interface LlmUsageDayRollup {
   byModel: LlmUsageModelRollup[];
 }
 
+export interface LlmUsageSourceStatus {
+  agent: string;
+  status: "recorded" | "not_reported";
+  reason?: string;
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
+  message?: string;
   inputTokens: number;
   outputTokens: number;
   totalTokens: number;
@@ -46,6 +53,7 @@ export interface LlmUsageAggregate {
   runs: number;
   byModel: LlmUsageModelRollup[];
   byDay: LlmUsageDayRollup[];
+  sourceStatus?: LlmUsageSourceStatus[];
 }
 
 export interface MonitorEvent {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -405,6 +405,9 @@ body { margin: 0; }
   padding-top: 6px;
   border-top: 1px solid var(--hm-line-soft);
 }
+.hm-llm-usage-row--muted strong {
+  color: var(--hm-muted);
+}
 .hm-llm-usage-row span:first-child {
   min-width: 0;
   display: grid;

--- a/test/unit/llm-usage.test.ts
+++ b/test/unit/llm-usage.test.ts
@@ -95,6 +95,57 @@ describe("LLM usage tracker", () => {
       totalTokens: 42,
       costUsd: 0.02,
     });
+    expect(aggregate.sourceStatus.find((entry) => entry.agent === "claude")).toMatchObject({
+      status: "recorded",
+    });
+    expect(aggregate.sourceStatus.find((entry) => entry.agent === "hermes")).toMatchObject({
+      status: "not_reported",
+      reason: "Hermes/Ollama responses have not exposed usage counters yet.",
+    });
+  });
+
+  it("extracts Claude SDK-style message usage and total cost aliases", () => {
+    const event = llmUsageEventFromResult({
+      agent: "claude",
+      taskId: "task-sdk",
+      ts: new Date("2026-05-31T12:00:00.000Z"),
+      result: {
+        messages: [
+          {
+            type: "assistant",
+            model: "claude-sonnet-4-5",
+            usage: {
+              input_tokens: 75,
+              output_tokens: 18,
+            },
+            total_cost_usd: 0.0042,
+          },
+        ],
+      },
+    });
+
+    expect(event).toEqual({
+      agent: "claude",
+      model: "claude-sonnet-4-5",
+      taskId: "task-sdk",
+      inputTokens: 75,
+      outputTokens: 18,
+      costUsd: 0.0042,
+      ts: "2026-05-31T12:00:00.000Z",
+    });
+  });
+
+  it("explains missing sources instead of exposing a dead not_recorded enum", () => {
+    const aggregate = aggregateLlmUsage([]);
+
+    expect(aggregate).toMatchObject({
+      status: "not_recorded",
+      message: "No runner has reported LLM usage counters yet. Claude/test-writer counters depend on SDK output; Codex CLI and Hermes/Ollama do not reliably report usage today.",
+    });
+    expect(aggregate.sourceStatus.find((entry) => entry.agent === "codex")).toMatchObject({
+      status: "not_reported",
+      reason: "Codex usage is not reported by the CLI yet.",
+    });
   });
 
   it("does not copy prompts or secrets into usage events", () => {


### PR DESCRIPTION
## Summary
- capture SDK-style LLM usage shapes from runner structured output, including messages[].usage and total_cost_usd aliases
- extend the usage aggregate with source-specific status/reasons so missing providers are labeled honestly
- update the monitor LLM usage panel to show real cost/tokens when present and plain-language missing-source reasons when absent

## Checks
- npm run typecheck
- npm test

## Surfaces
- Monitor board UI
- MCP usage/scorecard aggregate
- Runner usage capture plumbing

## Notes
- Data plumbing and labeling only; no routing, budget, queue, GitHub, Slack, or authority changes.
- No secrets/prompts are logged; usage events still whitelist token/cost/model/task identifiers only.