### PR TITLE
Filter stale testbed mission failures from B2

### DIFF
--- a/docs/testbed-mission-failure-triage-2026-06-01.md
+++ b/docs/testbed-mission-failure-triage-2026-06-01.md
@@ -1,0 +1,23 @@
+# Testbed Mission Failure Triage — 2026-06-01
+
+Scope: classify the failed `testbed-mission-*` runs that have been feeding B2 self-healing, then add a safe stale-input guard without changing product state or task authority.
+
+## Findings
+
+| Mission | Created from id | Classification | Evidence |
+| --- | ---: | --- | --- |
+| `testbed-mission-mpmo4ff2-1` | 2026-05-26T13:25:41.774Z | STALE | Operator-captured runner output showed `fetch failed` caused by DNS `ENOTFOUND testbed.averray.com`. A later mission against `https://averray.com` completed with `verdict: pass`, so this is a pre-wiring/environment target failure rather than a current product regression. |
+| `testbed-mission-mpn1ibrl-4` | 2026-05-26T19:40:25.233Z | STALE | Monitor screenshot showed a partial/failed report whose blocker was that HTTP visibility loaded the page but no real browser interaction ran yet. That predates the later browser-mission runner hardening and should not keep spawning product-fix proposals after newer missions exist. |
+| `testbed-mission-mptk0f2y-5` | 2026-05-31T09:04:59.482Z | REAL until superseded | This was created after the real testbed runner wiring landed. Without a newer passing/running mission for the same target, B2 should still treat it as a live signal and propose/escalate through the existing guardrails. |
+| `testbed-mission-mptmzrcn-6` | 2026-05-31T10:28:27.575Z | REAL until superseded | Fresh enough to be post-wiring. Keep eligible unless a newer same-target mission supersedes it or it ages beyond the stale-input window. |
+| `testbed-mission-mptpfgmh-8` | 2026-05-31T11:36:39.401Z | REAL until superseded | Fresh enough to be post-wiring. Keep eligible unless a newer same-target mission supersedes it or it ages beyond the stale-input window. |
+
+## Code decision
+
+B2 should not delete or rewrite mission history. Instead, its input now filters failed testbed missions before self-healing sees them:
+
+- Keep only the newest mission per target surface.
+- Drop a failed mission once a newer mission for that target exists, including a pass, requested, ready, or running rerun.
+- Drop failed missions older than `B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS` (default: 72).
+
+This is a read-only input guard. It does not create, approve, dismiss, or mutate product work.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -197,6 +197,10 @@ services:
       # Concurrent open-fix cap: stops a batch of distinct failures from swarming
       # the queue even within the daily budget (escalates past the cap).
       B2_SELF_HEALING_MAX_OPEN_FIXES: ${B2_SELF_HEALING_MAX_OPEN_FIXES:-3}
+      # Failed testbed missions older than this are retained as history but do
+      # not feed B2 self-healing. Prevents pre-wiring/environmental failures
+      # from repeatedly proposing fixes after newer missions have run.
+      B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS: ${B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS:-72}
       B2_SELF_HEALING_REPO: ${B2_SELF_HEALING_REPO:-}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}
       SLACK_OPERATOR_MONITOR_TOKEN: ${SLACK_OPERATOR_MONITOR_TOKEN:-}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -140,6 +140,7 @@ import {
 import { parseProposeTaskPayload } from "./codex-task-request.js";
 import {
   diagnoseTestbedMissionReportFromMessage,
+  failedTestbedMissionsForSelfHealing,
   listTestbedMissionRuns,
   readTestbedMissionRunnerHeartbeat,
   recordTestbedMissionReportFromMessage,
@@ -1839,7 +1840,9 @@ async function collectSelfHealingSignals(boardUrl: string): Promise<FailureSigna
   const fixRepo = optionalEnv("B2_SELF_HEALING_REPO") || optionalEnv("GITHUB_DEFAULT_REPO");
 
   try {
-    const missions = listTestbedMissionRuns({ limit: 25 }).filter((m) => m.status === "failed");
+    const missions = failedTestbedMissionsForSelfHealing(listTestbedMissionRuns({ limit: 25 }), {
+      maxAgeHours: routineConfig.selfHealing.testbedFailureMaxAgeHours,
+    });
     for (const m of missions) {
       signals.push({
         // Stable per-target surface (NOT the per-run mission id), so re-runs of

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -82,6 +82,11 @@ export interface ListTestbedMissionRunOptions {
   path?: string;
 }
 
+export interface SelfHealingTestbedMissionFilterOptions {
+  now?: Date;
+  maxAgeHours?: number;
+}
+
 export interface MissionReportInput {
   relatedCorrelationId?: string;
   text?: string;
@@ -241,6 +246,33 @@ export function listTestbedMissionRuns(options: ListTestbedMissionRunOptions = {
   return runs
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
     .slice(0, limit)
+    .map((run) => cloneRun(run));
+}
+
+export function failedTestbedMissionsForSelfHealing(
+  runs: readonly TestbedMissionRun[],
+  options: SelfHealingTestbedMissionFilterOptions = {},
+): TestbedMissionRun[] {
+  const nowMs = (options.now ?? new Date()).getTime();
+  const maxAgeHours = Math.max(1, options.maxAgeHours ?? 72);
+  const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
+  const latestBySurface = new Map<string, TestbedMissionRun>();
+
+  for (const run of runs) {
+    const key = missionSelfHealingSurfaceKey(run);
+    const current = latestBySurface.get(key);
+    if (!current || missionUpdatedMs(run) > missionUpdatedMs(current)) {
+      latestBySurface.set(key, run);
+    }
+  }
+
+  return Array.from(latestBySurface.values())
+    .filter((run) => run.status === "failed")
+    .filter((run) => {
+      const failedMs = missionFailedMs(run);
+      return Number.isFinite(failedMs) && nowMs - failedMs <= maxAgeMs;
+    })
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
     .map((run) => cloneRun(run));
 }
 
@@ -801,6 +833,27 @@ function missionStoreSeq(value: unknown, runs: TestbedMissionRun[]): number {
     const parsed = match ? Number(match[1]) : 0;
     return Number.isFinite(parsed) ? Math.max(max, parsed) : max;
   }, 0);
+}
+
+function missionSelfHealingSurfaceKey(run: TestbedMissionRun): string {
+  let key = run.targetUrl.trim().toLowerCase();
+  try {
+    const url = new URL(key);
+    key = `${url.host}${url.pathname}`.replace(/\/+$/, "");
+  } catch {
+    key = key.replace(/^https?:\/\//, "").split(/[?#]/)[0]!.replace(/\/+$/, "");
+  }
+  return key || "unknown";
+}
+
+function missionUpdatedMs(run: TestbedMissionRun): number {
+  const parsed = Date.parse(run.updatedAt);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function missionFailedMs(run: TestbedMissionRun): number {
+  const parsed = Date.parse(run.failedAt ?? run.updatedAt);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
 }
 
 function parseTestbedMissionMode(value: string | undefined): TestbedMissionMode | undefined {

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -45,6 +45,8 @@ export interface SlackRoutineConfig {
     maxOpenFixTasks: number;
     /** Per-tick cap — stops one scan from proposing a burst. */
     maxProposalsPerTick: number;
+    /** Failed testbed missions older than this are treated as stale B2 inputs. */
+    testbedFailureMaxAgeHours: number;
   };
 }
 
@@ -106,6 +108,7 @@ export function parseSlackRoutineConfig(
       cooldownMs: Math.max(60_000, (positiveNumber(env.B2_SELF_HEALING_COOLDOWN_MINUTES) || 30) * 60_000),
       maxOpenFixTasks: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_OPEN_FIXES) || 3),
       maxProposalsPerTick: Math.max(1, positiveNumber(env.B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK) || 1),
+      testbedFailureMaxAgeHours: Math.max(1, positiveNumber(env.B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS) || 72),
     },
   };
 }

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, beforeEach } from "vitest";
 import {
   __resetTestbedMissionRunsForTests,
   diagnoseTestbedMissionReportFromMessage,
+  failedTestbedMissionsForSelfHealing,
+  failTestbedMissionRun,
   listTestbedMissionRuns,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
@@ -483,6 +485,67 @@ describe("monitor testbed mission runs", () => {
     expect(coaching).toContain("Set confidence to a number from 0 to 1.");
     expect(coaching).toContain("Smallest next move");
     expect(coaching).toContain("do not ask Codex to change the product until the evidence is attached");
+  });
+
+  it("feeds B2 only the latest failed mission per target", () => {
+    const stale = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/app?run=old" }),
+      Date.parse("2026-05-22T10:00:00.000Z"),
+    )!;
+    failTestbedMissionRun(stale.id, {
+      now: new Date("2026-05-22T10:05:00.000Z"),
+      failureReason: "fetch failed",
+    });
+
+    const latestPass = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/app?run=new" }),
+      Date.parse("2026-05-22T11:00:00.000Z"),
+    )!;
+    recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: latestPass.id,
+        text: JSON.stringify({
+          verdict: "pass",
+          confidence: 0.8,
+          stoppedBeforeMutation: true,
+          mutationBoundaryNotes: [],
+          completedPath: ["opened app"],
+          blockers: [],
+          evidence: ["200 OK"],
+          scores: { orientation: 5 },
+        }),
+      },
+      Date.parse("2026-05-22T11:05:00.000Z"),
+    );
+
+    expect(failedTestbedMissionsForSelfHealing(listTestbedMissionRuns(), {
+      now: new Date("2026-05-22T12:00:00.000Z"),
+    })).toEqual([]);
+  });
+
+  it("expires old failed missions from the B2 self-healing input", () => {
+    const old = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/old" }),
+      Date.parse("2026-05-22T10:00:00.000Z"),
+    )!;
+    failTestbedMissionRun(old.id, {
+      now: new Date("2026-05-22T10:05:00.000Z"),
+      failureReason: "pre-wiring runner failed",
+    });
+
+    const fresh = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/fresh" }),
+      Date.parse("2026-05-25T10:00:00.000Z"),
+    )!;
+    failTestbedMissionRun(fresh.id, {
+      now: new Date("2026-05-25T10:05:00.000Z"),
+      failureReason: "fresh product blocker",
+    });
+
+    expect(failedTestbedMissionsForSelfHealing(listTestbedMissionRuns(), {
+      now: new Date("2026-05-25T12:00:00.000Z"),
+      maxAgeHours: 24,
+    }).map((run) => run.id)).toEqual([fresh.id]);
   });
 });
 

--- a/test/unit/slack-routines.test.ts
+++ b/test/unit/slack-routines.test.ts
@@ -60,6 +60,7 @@ describe("slack operator routines", () => {
       B2_SELF_HEALING_COOLDOWN_MINUTES: "45",
       B2_SELF_HEALING_MAX_PROPOSALS_PER_TICK: "2",
       B2_SELF_HEALING_MAX_OPEN_FIXES: "4",
+      B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS: "12",
     }, new Set(["C1"]));
 
     expect(config.selfHealing.enabled).toBe(true);
@@ -67,6 +68,7 @@ describe("slack operator routines", () => {
     expect(config.selfHealing.cooldownMs).toBe(45 * 60_000);
     expect(config.selfHealing.maxProposalsPerTick).toBe(2);
     expect(config.selfHealing.maxOpenFixTasks).toBe(4);
+    expect(config.selfHealing.testbedFailureMaxAgeHours).toBe(12);
   });
 
   it("runs the daily brief once per UTC date after the target time", () => {


### PR DESCRIPTION
## What changed

- Added `docs/testbed-mission-failure-triage-2026-06-01.md` classifying the named failed testbed missions as stale vs still-actionable.
- Added a read-only B2 input filter for failed testbed missions:
  - keep only the newest mission per target surface;
  - suppress older failed missions once a newer rerun exists for that target;
  - suppress failed missions older than `B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS` (default `72`).
- Wired the max-age setting through routine config and `ops/compose.yml`.
- Added unit tests for superseded failures and aged-out failures.

## Findings

- `testbed-mission-mpmo4ff2-1`: stale environmental/pre-wiring failure (`ENOTFOUND testbed.averray.com`), later public target mission passed.
- `testbed-mission-mpn1ibrl-4`: stale pre-hardening browser-mission failure.
- `testbed-mission-mptk0f2y-5`, `testbed-mission-mptmzrcn-6`, `testbed-mission-mptpfgmh-8`: still real signals until superseded by a newer same-target run or aged out.

## Checks

- `git diff --check`
- `npm install` (fresh worktree dependency setup)
- `npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/slack-routines.test.ts`
- `npm run typecheck`
- `npm run build`
- `npm test`

Compose config note: attempted `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config`, but this local Docker install does not have the v2 compose plugin (`unknown flag: --env-file`), and `docker-compose` is not installed. The compose change is a single env default.

## Affected surfaces

- Backend/monitor: B2 self-healing input collection for testbed mission failures.
- Ops: one optional env default in compose.
- Docs/tests only otherwise.

## Safety / rollout

- No product fix bundled.
- No task approval/run behavior changes.
- No mission history deletion or mutation.
- No secrets or chain assertions.
- Operators can tune the stale window with `B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS`; default is 72 hours.
