### PR TITLE
Add proactive Hermes activity feed

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -313,6 +313,7 @@ export function BoardView({
           onCreateTask={onCreateTask}
           backlogSuggestions={backlogSuggestions}
           boardCards={cards}
+          boardBanner={state.banner}
           focusedCard={scopeCard}
           onCardClick={onCardClick}
           collaboration={collaboration}

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -7,6 +7,7 @@ import { CoPilotRail } from "./CoPilotRail.js";
 import { FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
 import type { CollaborationMessage } from "../../lib/monitor/collaboration.js";
+import type { BoardNowBanner } from "../../lib/monitor/board-state.js";
 
 afterEach(cleanup);
 
@@ -19,17 +20,24 @@ function msg(id: string, author: CollaborationMessage["author"], text: string): 
 }
 
 const card548 = FIXTURE_CARDS.find((c) => c.id === "agent #548") as BoardCard;
+const banner: BoardNowBanner = {
+  tone: "action",
+  eyebrow: "Board now",
+  headline: "1 card needs your review decision; automation has gone as far as it safely can.",
+  sub: "Most urgent: agent #548.",
+  primaryActionId: "agent #548",
+};
 
 describe("CoPilotRail", () => {
   test("renders the collaboration feed as turns", async () => {
     const fetcher = vi.fn(async () => [msg("1", "hermes", "Pre-check passed on #548.")]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
-    await waitFor(() => expect(within(container).getByText("Pre-check passed on #548.")).toBeTruthy());
+    await waitFor(() => expect(within(container).getByText(/Pre-check passed on #548/)).toBeTruthy());
   });
 
   test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
     const { getByText } = render(<CoPilotRail />, { wrapper });
-    expect(getByText(/Nothing asked yet/)).toBeTruthy();
+    expect(getByText(/No real Hermes activity has been logged yet/)).toBeTruthy();
   });
 
   test("the scope chip reflects the focused card", async () => {
@@ -51,7 +59,7 @@ describe("CoPilotRail", () => {
       <CoPilotRail focusedCard={card548} collaboration={{ fetcher, poster, refreshIntervalMs: 0 }} />,
       { wrapper },
     );
-    await waitFor(() => expect(within(container).getByText(/Nothing asked yet/)).toBeTruthy());
+    await waitFor(() => expect(within(container).getByText(/No real Hermes activity has been logged yet/)).toBeTruthy());
 
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     fireEvent.change(input, { target: { value: "what's blocking?" } });
@@ -63,7 +71,7 @@ describe("CoPilotRail", () => {
     });
     // Hermes's reply lands on the revalidate triggered by ask().
     await waitFor(() =>
-      expect(within(container).getByText("CI is still running — 1 check left.")).toBeTruthy(),
+      expect(within(container).getByText(/CI is still running/)).toBeTruthy(),
     );
   });
 
@@ -77,5 +85,33 @@ describe("CoPilotRail", () => {
     fireEvent.change(input, { target: { value: "/mission https://staging.averray.com/x" } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/x");
+  });
+
+  test("shows proactive board activity and links it back to a card", () => {
+    const onCardClick = vi.fn();
+    const taskCard: BoardCard = {
+      ...card548,
+      id: "task-activity-1",
+      type: "task",
+      agentType: "codex",
+      title: "Repair failed mission",
+      summary: "Hermes self-healing proposal for a failed testbed mission.",
+      lane: "codex-needed",
+      prompt: "Repair the failed mission.",
+      taskStatus: "proposed",
+      riskTier: "low",
+    };
+    const { getByText, getByRole } = render(
+      <CoPilotRail
+        boardCards={[taskCard]}
+        boardBanner={banner}
+        onCardClick={onCardClick}
+        collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }}
+      />,
+      { wrapper },
+    );
+    expect(getByText(/Proposed Codex work for Repair failed mission/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Open card task-activity-1" }));
+    expect(onCardClick).toHaveBeenCalledWith("task-activity-1");
   });
 });

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -9,10 +9,14 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../../lib/monitor/backlog-suggestions.js";
+import type { BoardNowBanner as BoardNowBannerData } from "../../lib/monitor/board-state.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
+import {
+  buildHermesActivityFeed,
+  type HermesActivityEntry,
+} from "../../lib/monitor/activity-feed.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
-import { HermesTurn } from "./HermesTurn.js";
 
 export interface CoPilotRailProps {
   onSpawnMission?: (url: string) => void;
@@ -24,6 +28,8 @@ export interface CoPilotRailProps {
   backlogSuggestions?: BacklogSuggestionsResponse;
   /** Board cards used to link suggestions to their source card. */
   boardCards?: readonly BoardCard[];
+  /** Current board "what needs you" summary. Appended to the activity feed. */
+  boardBanner?: BoardNowBannerData;
   /** Focused card — scopes Ask-Hermes questions + the scope chip. */
   focusedCard?: BoardCard;
   /** Open a related card from a linked follow-up suggestion. */
@@ -52,6 +58,7 @@ export function CoPilotRail({
   onCreateTask,
   backlogSuggestions,
   boardCards,
+  boardBanner,
   focusedCard,
   onCardClick,
   collaboration,
@@ -66,12 +73,26 @@ export function CoPilotRail({
   const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
   const relatedPr = relatedPrForCard(focusedCard);
   const streamRef = useRef<HTMLDivElement>(null);
+  const activity = useMemo(
+    () => buildHermesActivityFeed({
+      cards: boardCards ?? [],
+      messages,
+      banner: boardBanner ?? {
+        tone: "calm",
+        eyebrow: "Board now",
+        headline: "Nothing waits on you. Hermes will narrate real board events when they arrive.",
+        sub: "No current board summary was provided to the rail.",
+        primaryActionId: undefined,
+      },
+    }),
+    [boardBanner, boardCards, messages],
+  );
 
   // Keep the newest turn in view as the feed grows.
   useEffect(() => {
     const el = streamRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [messages.length]);
+  }, [activity.length]);
 
   return (
     <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
@@ -84,7 +105,7 @@ export function CoPilotRail({
           <div className="hm-hermes-title">Hermes co-pilot</div>
           <div className="hm-hermes-sub">
             <span className="pulse" aria-hidden />
-            Ask about any card · context: {focusedCard?.id ?? "whole board"}
+            Live activity · context: {focusedCard?.id ?? "whole board"}
           </div>
         </div>
       </div>
@@ -95,15 +116,17 @@ export function CoPilotRail({
         onCardClick={onCardClick}
       />
 
-      <div className="hm-hermes-stream" ref={streamRef} aria-live="polite">
-        {messages.length === 0 ? (
-          <div className="hm-lane-empty">
-            Nothing asked yet. Ask Hermes about a card or the board below — replies show up here.
-          </div>
-        ) : (
-          messages.map((m) => <HermesTurn key={m.id} turn={m} />)
-        )}
-      </div>
+      <section className="hm-activity" aria-label="Hermes activity">
+        <div className="hm-activity-head">
+          <span className="hm-kicker">Activity</span>
+          <strong>What Hermes sees</strong>
+        </div>
+        <div className="hm-hermes-stream hm-activity-stream" ref={streamRef} aria-live="polite">
+          {activity.map((entry) => (
+            <ActivityEntryRow entry={entry} onCardClick={onCardClick} key={entry.id} />
+          ))}
+        </div>
+      </section>
 
       <AskHermesComposer
         onSpawnMission={onSpawnMission}
@@ -120,6 +143,43 @@ export function CoPilotRail({
         focusToken={composerFocusToken}
       />
     </aside>
+  );
+}
+
+function ActivityEntryRow({
+  entry,
+  onCardClick,
+}: {
+  entry: HermesActivityEntry;
+  onCardClick?: (id: string) => void;
+}) {
+  const body = (
+    <>
+      <span className="hm-activity-dot" aria-hidden />
+      <span>
+        <strong>{entry.text}</strong>
+        {entry.meta ? <small>{entry.meta}</small> : null}
+      </span>
+    </>
+  );
+  if (entry.cardId && onCardClick) {
+    return (
+      <button
+        type="button"
+        className={`hm-activity-row hm-activity-row--${entry.tone}`}
+        onClick={() => onCardClick(entry.cardId!)}
+        aria-label={`Open card ${entry.cardId}`}
+      >
+        {body}
+        <span className="hm-activity-link">{entry.cardId}</span>
+      </button>
+    );
+  }
+  return (
+    <div className={`hm-activity-row hm-activity-row--${entry.tone}`}>
+      {body}
+      {entry.cardId ? <span className="hm-activity-link">{entry.cardId}</span> : null}
+    </div>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+import { buildHermesActivityFeed } from "./activity-feed.js";
+import type { BoardNowBanner } from "./board-state.js";
+import type { BoardCard, HermesDecisionRecord } from "./card-types.js";
+import type { CollaborationMessage } from "./collaboration.js";
+
+const banner: BoardNowBanner = {
+  tone: "action",
+  eyebrow: "Board now",
+  headline: "1 card needs your review decision; automation has gone as far as it safely can.",
+  sub: "Most urgent: Self-healing fix.",
+  primaryActionId: "task-1",
+};
+
+function task(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "task-1",
+    lane: "codex-needed",
+    type: "task",
+    agentType: "codex",
+    title: "Self-healing fix",
+    summary: "Hermes self-healing proposal for a failed testbed mission.",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 3,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "warn" },
+    prompt: "Fix the failed mission.",
+    taskStatus: "proposed",
+    riskTier: "low",
+    ...overrides,
+  };
+}
+
+function decision(overrides: Partial<HermesDecisionRecord> = {}): HermesDecisionRecord {
+  return {
+    schemaVersion: 1,
+    recordType: "hermes_decision_record",
+    id: "hdr-routing-task-1",
+    kind: "routing",
+    subject: { type: "task", id: "task-1" },
+    decision: "codex",
+    reasons: ["The failure is low-risk and maps to Codex."],
+    inputs: { riskTier: "low", routingReason: "testbed failure" },
+    outcome: { summary: "Task proposed.", waitingNext: "Operator dispatch approval." },
+    safety: { readOnly: true, mutates: false },
+    generatedAt: "2026-05-28T10:01:00Z",
+    ...overrides,
+  };
+}
+
+function message(overrides: Partial<CollaborationMessage> = {}): CollaborationMessage {
+  return {
+    id: "msg-1",
+    ts: Date.parse("2026-05-28T10:02:00Z"),
+    author: "codex",
+    kind: "request_help",
+    addressedTo: "operator",
+    text: "I need a second review before this moves forward.",
+    relatedPr: { repo: "depre-dev/averray-reference-agent", number: 316 },
+    ...overrides,
+  };
+}
+
+describe("buildHermesActivityFeed", () => {
+  test("turns real task state, decision records, and collaboration turns into activity", () => {
+    const entries = buildHermesActivityFeed({
+      cards: [task({ decisionRecord: decision() })],
+      messages: [message()],
+      banner,
+      boardAt: "2026-05-28T10:04:00Z",
+      now: () => Date.parse("2026-05-28T10:05:00Z"),
+    });
+    const text = entries.map((entry) => entry.text).join("\n");
+    expect(text).toContain("Proposed Codex work for Self-healing fix");
+    expect(text).toContain("Routed Self-healing fix");
+    expect(text).toContain("Codex asked for help on depre-dev/averray-reference-agent#316");
+    expect(entries.at(-1)).toMatchObject({
+      source: "summary",
+      text: "Needs you: review the current action lane, starting with task-1.",
+      cardId: "task-1",
+    });
+  });
+
+  test("says so when no real activity exists and still ends with the board summary", () => {
+    const entries = buildHermesActivityFeed({
+      cards: [],
+      messages: [],
+      banner: { ...banner, tone: "calm", headline: "Nothing waits on you.", primaryActionId: undefined },
+      now: () => Date.parse("2026-05-28T10:05:00Z"),
+    });
+    expect(entries[0]?.text).toContain("No real Hermes activity has been logged yet");
+    expect(entries.at(-1)?.text).toBe("Needs you: nothing right now.");
+  });
+
+  test("narrates review-panel responses without creating pretend chatter", () => {
+    const entries = buildHermesActivityFeed({
+      cards: [task({
+        reviewRequests: [{
+          id: "review-codex",
+          requestedBy: "hermes",
+          reviewer: "codex",
+          reason: "High-risk work needs a panel.",
+          status: "responded",
+          reviewMode: "panel",
+          panelId: "panel-1",
+          panelSize: 3,
+          response: {
+            verdict: "block",
+            reasoning: "Codex found an unresolved deploy risk.",
+            respondedAt: "2026-05-28T10:03:00Z",
+          },
+          createdAt: "2026-05-28T10:00:00Z",
+          updatedAt: "2026-05-28T10:03:00Z",
+        }],
+      })],
+      messages: [],
+      banner,
+      now: () => Date.parse("2026-05-28T10:05:00Z"),
+    });
+    expect(entries.map((entry) => entry.text).join("\n")).toContain(
+      "Codex returned a block review on Self-healing fix: Codex found an unresolved deploy risk.",
+    );
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -1,0 +1,298 @@
+import type { BoardNowBanner } from "./board-state.js";
+import type {
+  AgentType,
+  BoardCard,
+  CardReviewRequest,
+  HermesDecisionRecord,
+} from "./card-types.js";
+import type { CollaborationMessage } from "./collaboration.js";
+import { actorLabel, formatTurnTime } from "./collaboration.js";
+
+export type ActivityTone = "neutral" | "info" | "action" | "success" | "warning";
+
+export interface HermesActivityEntry {
+  id: string;
+  atMs: number;
+  source: "board" | "decision" | "collaboration" | "review" | "summary";
+  tone: ActivityTone;
+  text: string;
+  meta?: string;
+  cardId?: string;
+}
+
+export interface BuildHermesActivityFeedInput {
+  cards: readonly BoardCard[];
+  messages: readonly CollaborationMessage[];
+  banner: BoardNowBanner;
+  boardAt?: string;
+  now?: () => number;
+  limit?: number;
+}
+
+const DEFAULT_LIMIT = 12;
+
+export function buildHermesActivityFeed(input: BuildHermesActivityFeedInput): HermesActivityEntry[] {
+  const now = input.now ?? Date.now;
+  const boardAtMs = parseTime(input.boardAt) ?? now();
+  const entries: HermesActivityEntry[] = [];
+
+  for (const card of input.cards) {
+    entries.push(...cardActivity(card, boardAtMs));
+    if (card.decisionRecord) entries.push(decisionRecordActivity(card, card.decisionRecord, boardAtMs));
+    entries.push(...reviewRequestActivity(card));
+  }
+
+  for (const message of input.messages) {
+    entries.push(collaborationActivity(message));
+  }
+
+  const deduped = dedupeEntries(entries)
+    .sort((a, b) => a.atMs - b.atMs)
+    .slice(-clampLimit(input.limit));
+
+  if (deduped.length === 0) {
+    deduped.push({
+      id: "activity-empty",
+      atMs: boardAtMs,
+      source: "summary",
+      tone: "neutral",
+      text: "No real Hermes activity has been logged yet. New board events and card-scoped coordination will appear here.",
+      meta: "waiting for events",
+    });
+  }
+
+  deduped.push(summaryActivity(input.banner, now()));
+  return deduped;
+}
+
+function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[] {
+  const atMs = estimateCardTime(card, boardAtMs);
+  const entries: HermesActivityEntry[] = [];
+  if (card.type === "task" && card.taskStatus) {
+    const label = agentLabel(card.agentType);
+    const title = cardTitle(card);
+    if (card.taskStatus === "proposed") {
+      entries.push({
+        id: `task:${card.id}:proposed`,
+        atMs,
+        source: "board",
+        tone: "action",
+        text: `Proposed ${label} work for ${title}; waiting on your dispatch decision.`,
+        meta: card.riskTier ? `${card.riskTier} risk` : "task proposed",
+        cardId: card.id,
+      });
+    } else if (card.taskStatus === "approved") {
+      entries.push({
+        id: `task:${card.id}:approved`,
+        atMs,
+        source: "board",
+        tone: "info",
+        text: `Dispatched ${label} work for ${title}; the runner can claim it when available.`,
+        meta: "dispatch approved",
+        cardId: card.id,
+      });
+    } else if (card.taskStatus === "running") {
+      entries.push({
+        id: `task:${card.id}:running`,
+        atMs,
+        source: "board",
+        tone: "info",
+        text: `${label} is working on ${title}; Hermes is watching for progress or a PR.`,
+        meta: "runner active",
+        cardId: card.id,
+      });
+    } else if (card.taskStatus === "failed") {
+      entries.push({
+        id: `task:${card.id}:failed`,
+        atMs,
+        source: "board",
+        tone: "warning",
+        text: `${label} work failed on ${title}; operator triage is needed before retrying or splitting it.`,
+        meta: card.failureReason ?? "task failed",
+        cardId: card.id,
+      });
+    }
+  }
+
+  if (card.isAction && card.lane === "needs-attention") {
+    entries.push({
+      id: `action:${card.id}:${card.summary}`,
+      atMs,
+      source: "board",
+      tone: "action",
+      text: `Escalated ${cardTitle(card)} to you: ${plain(card.summary) || "Hermes needs an operator decision."}`,
+      meta: "needs your call",
+      cardId: card.id,
+    });
+  }
+
+  if (card.type === "done" && card.mergeStatus) {
+    entries.push({
+      id: `done:${card.id}:${card.mergeStatus}`,
+      atMs,
+      source: "board",
+      tone: card.mergeStatus === "MERGED" ? "success" : "neutral",
+      text: `${card.mergeStatus === "MERGED" ? "Merged" : "Closed"} ${cardTitle(card)}; it is now release history.`,
+      meta: card.closedAt ? formatDateMeta(card.closedAt) : "done",
+      cardId: card.id,
+    });
+  }
+
+  return entries;
+}
+
+function decisionRecordActivity(
+  card: BoardCard,
+  record: HermesDecisionRecord,
+  boardAtMs: number,
+): HermesActivityEntry {
+  const atMs = parseTime(record.generatedAt) ?? boardAtMs;
+  const reason = record.reasons[0] ?? record.outcome.summary;
+  const waiting = record.outcome.waitingNext ? ` Waiting next: ${record.outcome.waitingNext}` : "";
+  return {
+    id: `decision:${record.id}`,
+    atMs,
+    source: "decision",
+    tone: toneForDecision(record),
+    text: `${decisionVerb(record)} ${cardTitle(card)}: ${plain(reason)}.${waiting}`,
+    meta: record.kind.replace(/_/g, " "),
+    cardId: card.id,
+  };
+}
+
+function reviewRequestActivity(card: BoardCard): HermesActivityEntry[] {
+  const requests = card.reviewRequests ?? [];
+  return requests.map((request) => {
+    const panel = request.reviewMode === "panel" || (request.panelSize ?? 0) > 1;
+    const atMs = parseTime(request.response?.respondedAt ?? request.updatedAt ?? request.createdAt) ?? Date.now();
+    if (request.response) {
+      return {
+        id: `review:${request.id}:response:${request.response.respondedAt}`,
+        atMs,
+        source: "review",
+        tone: request.response.verdict === "block" ? "action" : request.response.verdict === "concern" ? "warning" : "success",
+        text: `${agentLabel(request.reviewer)} returned a ${request.response.verdict} review on ${cardTitle(card)}: ${plain(request.response.reasoning)}`,
+        meta: panel ? "reviewer panel" : "review response",
+        cardId: card.id,
+      };
+    }
+    return {
+      id: `review:${request.id}:requested`,
+      atMs,
+      source: "review",
+      tone: panel ? "action" : "info",
+      text: `${agentLabel(request.requestedBy)} requested ${panel ? "a reviewer panel" : `${agentLabel(request.reviewer)} review`} for ${cardTitle(card)}: ${plain(request.reason)}`,
+      meta: panel ? "panel requested" : "review requested",
+      cardId: card.id,
+    };
+  });
+}
+
+function collaborationActivity(message: CollaborationMessage): HermesActivityEntry {
+  const actor = actorLabel(message.author);
+  const target = message.addressedTo === "everyone" ? "the room" : actorLabel(message.addressedTo);
+  const scope = message.relatedPr
+    ? ` on ${message.relatedPr.repo}#${message.relatedPr.number}`
+    : message.relatedCorrelationId
+      ? ` for ${message.relatedCorrelationId}`
+      : "";
+  const verb =
+    message.kind === "request_help"
+      ? "asked for help"
+      : message.kind === "proposal"
+        ? "proposed"
+        : message.kind === "status"
+          ? "reported"
+          : "said";
+  return {
+    id: `collaboration:${message.id}`,
+    atMs: message.ts,
+    source: "collaboration",
+    tone: message.kind === "request_help" ? "action" : message.kind === "proposal" ? "info" : "neutral",
+    text: `${actor} ${verb}${scope} to ${target}: ${plain(message.text)}`,
+    meta: `${message.kind} · ${formatTurnTime(message.ts)}`,
+  };
+}
+
+function summaryActivity(banner: BoardNowBanner, nowMs: number): HermesActivityEntry {
+  const text =
+    banner.tone === "action"
+      ? `Needs you: review the current action lane${banner.primaryActionId ? `, starting with ${banner.primaryActionId}` : ""}.`
+      : banner.tone === "degraded"
+        ? "Needs you: reconnect or verify freshness before approving anything."
+        : "Needs you: nothing right now.";
+  return {
+    id: "activity-current-summary",
+    atMs: nowMs,
+    source: "summary",
+    tone: banner.tone === "action" ? "action" : banner.tone === "degraded" ? "warning" : "success",
+    text,
+    meta: banner.sub,
+    ...(banner.primaryActionId ? { cardId: banner.primaryActionId } : {}),
+  };
+}
+
+function decisionVerb(record: HermesDecisionRecord): string {
+  switch (record.kind) {
+    case "routing": return "Routed";
+    case "auto_approval": return record.decision.toLowerCase().includes("approved") ? "Approved dispatch for" : "Checked dispatch for";
+    case "escalation": return "Escalated";
+    case "anomaly_pause": return "Paused automation around";
+    case "away_digest": return "Reported";
+  }
+}
+
+function toneForDecision(record: HermesDecisionRecord): ActivityTone {
+  if (record.kind === "escalation" || record.kind === "anomaly_pause") return "action";
+  if (record.kind === "auto_approval" && record.safety.mutates) return "info";
+  if (record.kind === "away_digest") return "neutral";
+  return "info";
+}
+
+function estimateCardTime(card: BoardCard, boardAtMs: number): number {
+  const freshnessMs = Math.max(0, card.freshness || 0) * 60_000;
+  return boardAtMs - freshnessMs;
+}
+
+function dedupeEntries(entries: readonly HermesActivityEntry[]): HermesActivityEntry[] {
+  const byId = new Map<string, HermesActivityEntry>();
+  for (const entry of entries) {
+    const existing = byId.get(entry.id);
+    if (!existing || existing.atMs <= entry.atMs) byId.set(entry.id, entry);
+  }
+  return [...byId.values()];
+}
+
+function parseTime(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
+function plain(value: string | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function cardTitle(card: BoardCard): string {
+  return card.title || card.id;
+}
+
+function agentLabel(agent: AgentType | CardReviewRequest["requestedBy"] | CardReviewRequest["reviewer"]): string {
+  if (agent === "hermes") return "Hermes";
+  if (agent === "operator") return "Pascal";
+  if (agent === "claude") return "Claude";
+  if (agent === "test-writer") return "Test-writer";
+  if (agent === "ext") return "external agent";
+  return "Codex";
+}
+
+function formatDateMeta(value: string): string {
+  const ms = parseTime(value);
+  if (ms === undefined) return "done";
+  return formatTurnTime(ms);
+}
+
+function clampLimit(value: number | undefined): number {
+  if (!Number.isFinite(value ?? NaN)) return DEFAULT_LIMIT;
+  return Math.min(24, Math.max(4, Math.floor(value!)));
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1118,6 +1118,87 @@ body { margin: 0; }
 .hm-hermes-stream::-webkit-scrollbar { width: 6px; }
 .hm-hermes-stream::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
 
+.hm-activity {
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-bottom: 1px solid var(--hm-line-soft);
+  background: linear-gradient(180deg, var(--hm-paper-2), var(--hm-paper));
+}
+.hm-activity-head {
+  padding: 12px 16px 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+.hm-activity-head strong {
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--hm-ink);
+}
+.hm-activity-stream {
+  max-height: min(44vh, 520px);
+  padding-top: 10px;
+}
+.hm-activity-row {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 9px 1fr auto;
+  gap: 9px;
+  align-items: start;
+  padding: 10px 11px;
+  border-radius: var(--hm-radius);
+  border: 1px solid var(--hm-line);
+  background: var(--hm-paper);
+  color: var(--hm-ink-soft);
+  font: inherit;
+  text-align: left;
+}
+button.hm-activity-row {
+  cursor: pointer;
+}
+button.hm-activity-row:hover {
+  border-color: var(--hm-line-strong);
+  background: var(--hm-paper-3);
+}
+.hm-activity-row strong {
+  display: block;
+  color: var(--hm-ink);
+  font-size: 12.5px;
+  line-height: 1.45;
+  font-weight: 600;
+}
+.hm-activity-row small {
+  display: block;
+  margin-top: 4px;
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
+.hm-activity-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  margin-top: 5px;
+  background: var(--hm-muted-soft);
+}
+.hm-activity-row--info .hm-activity-dot { background: var(--hm-hermes); }
+.hm-activity-row--action .hm-activity-dot { background: var(--hm-amber); }
+.hm-activity-row--success .hm-activity-dot { background: var(--hm-sage); }
+.hm-activity-row--warning .hm-activity-dot { background: var(--hm-clay); }
+.hm-activity-link {
+  justify-self: end;
+  max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+
 /* Hermes turn (card-stream) */
 .hm-turn {
   display: grid;


### PR DESCRIPTION
## What changed & why

Added a proactive Hermes activity feed to the co-pilot rail so operators can see real board movement without asking a question first. The feed is built only from existing real signals: board card state, card-scoped D2 decision records, review requests/responses, and C4 collaboration messages. It also ends with the current operator-summary line derived from the existing board banner logic.

The reactive Ask Hermes composer stays intact. New Q&A and card-scoped coordination now appear in the same activity stream alongside proactive board events.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm --workspace @avg/monitor-ui run build`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Monitor UI only. Roll out with the normal Docker image/monitor deploy. Rollback is reverting this PR; no schema, queue, env, or authority changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

This slice narrates existing logged/serialized monitor signals only. It does not create synthetic agent chatter, does not enqueue work, and does not change approval/merge authority.
