### PR TITLE
Make waiting operator cards actionable

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -147,6 +147,42 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(queryByText("not_recorded")).toBeNull();
   });
 
+  test("waiting-on-operator card actions are real board controls", () => {
+    const onApproveTask = vi.fn();
+    const onCardClick = vi.fn();
+    const board: MonitorBoard = {
+      at: "2026-05-28T10:30:00Z",
+      cards: [{
+        id: "task-action-1",
+        lane: "codex-needed",
+        type: "task",
+        agentType: "codex",
+        title: "Fix the failed mission",
+        summary: "Self-healing proposal awaiting a human dispatch call.",
+        repo: "depre-dev/averray-reference-agent",
+        freshness: 1,
+        state: "fresh",
+        risk: [],
+        waitingOn: { actor: "operator", tone: "warn" },
+        taskStatus: "proposed",
+        prompt: "Fix the failed mission.",
+      }],
+    };
+    const { getByRole, getByText, queryByText } = render(
+      <BoardView board={board} status="open" onApproveTask={onApproveTask} onCardClick={onCardClick} keyboard={false} />,
+    );
+    expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Investigate" }));
+    expect(onCardClick).toHaveBeenCalledWith("task-action-1");
+    fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
+    fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+    expect(onApproveTask).toHaveBeenCalledWith("task-action-1");
+
+    expect(getByText("Fix the failed mission")).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    expect(queryByText("Fix the failed mission")).toBeNull();
+  });
+
   test("renders backlog suggestions as a collapsed planner-only rail block", () => {
     const onCardClick = vi.fn();
     const { container, getByRole, getByText, queryByText } = render(

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -49,6 +49,7 @@ const ACTION_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
   "deploying",
   "done",
 ]);
+const OPERATOR_CARD_SNOOZE_MS = 30 * 60_000;
 
 function expandedForMode(mode: BoardMode): ReadonlySet<LaneId> {
   if (mode === "calm") return CALM_EXPANDED;
@@ -143,7 +144,17 @@ export function BoardView({
   // so the operator can propose the first task even when the lane is empty.
   const alwaysOpen: readonly LaneId[] = onCreateTask ? ["codex-needed"] : [];
   const streamOnline = !degraded;
-  const cards = board?.cards ?? [];
+  const rawCards = board?.cards ?? [];
+  const [dismissedCardIds, setDismissedCardIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [snoozedUntilById, setSnoozedUntilById] = useState<ReadonlyMap<string, number>>(() => new Map());
+  const cards = useMemo(() => {
+    const nowMs = Date.now();
+    return rawCards.filter((card) => {
+      if (dismissedCardIds.has(card.id)) return false;
+      const snoozedUntil = snoozedUntilById.get(card.id);
+      return snoozedUntil === undefined || snoozedUntil <= nowMs;
+    });
+  }, [dismissedCardIds, rawCards, snoozedUntilById]);
   const liveLabel = useMemo(() => formatClock(board?.at), [board?.at]);
 
   // KPIs / banner / mode reflect the whole board, regardless of search.
@@ -216,6 +227,22 @@ export function BoardView({
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const onDismissCard = useCallback((id: string) => {
+    setDismissedCardIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+  }, []);
+
+  const onSnoozeCard = useCallback((id: string) => {
+    setSnoozedUntilById((prev) => {
+      const next = new Map(prev);
+      next.set(id, Date.now() + OPERATOR_CARD_SNOOZE_MS);
       return next;
     });
   }, []);
@@ -302,6 +329,9 @@ export function BoardView({
                 onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
                 onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
                 onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
+                onDismiss={(c) => onDismissCard(c.id)}
+                onSnooze={(c) => onSnoozeCard(c.id)}
+                onInvestigate={onCardClick ? (c) => onCardClick(c.id) : undefined}
               />
             )}
           />

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -218,6 +218,43 @@ describe("Card — task approve (O3 dispatch)", () => {
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
   });
 
+  test("a waiting-on-operator task exposes real inline controls", () => {
+    const onApprove = vi.fn();
+    const onDismiss = vi.fn();
+    const onSnooze = vi.fn();
+    const onInvestigate = vi.fn();
+    const { getByRole } = render(
+      <Card
+        card={proposed}
+        onApprove={onApprove}
+        onDismiss={onDismiss}
+        onSnooze={onSnooze}
+        onInvestigate={onInvestigate}
+      />,
+    );
+    expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    fireEvent.click(getByRole("button", { name: "Snooze" }));
+    fireEvent.click(getByRole("button", { name: "Investigate" }));
+    expect(onApprove).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledWith(proposed);
+    expect(onSnooze).toHaveBeenCalledWith(proposed);
+    expect(onInvestigate).toHaveBeenCalledWith(proposed);
+  });
+
+  test("humanizes guardrail enum codes while preserving raw codes on hover", () => {
+    const card = {
+      ...proposed,
+      summary: "dispatch_budget_exhausted then duplicate_signal",
+    } as unknown as BoardCard;
+    const { getByText, getByTitle, queryByText } = render(<Card card={card} onApprove={vi.fn()} />);
+    expect(getByText("Dispatch budget used up - paused until reset")).toBeTruthy();
+    expect(getByText("Skipped - duplicate of an existing fix")).toBeTruthy();
+    expect(getByTitle("raw code: dispatch_budget_exhausted")).toBeTruthy();
+    expect(getByTitle("raw code: duplicate_signal")).toBeTruthy();
+    expect(queryByText(/dispatch_budget_exhausted/)).toBeNull();
+  });
+
   test("a proposed test-writer card shows specialist attribution", () => {
     const card = { ...proposed, id: "test-writer-task-x1", agentType: "test-writer" } as unknown as BoardCard;
     const { getByText, getByRole } = render(<Card card={card} onApprove={vi.fn()} />);

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -21,6 +21,7 @@
 import { useState } from "react";
 import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
+import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
 import { ChecksBar } from "./ChecksBar.js";
 
 export type CardProps = {
@@ -31,6 +32,12 @@ export type CardProps = {
   onApprove?: (card: BoardCard) => void;
   /** Approve a requested tester mission (T6). Operator-only; runs through a confirm. */
   onApproveMission?: (card: BoardCard) => void;
+  /** Hide this card from the current monitor view. Local UI-only control. */
+  onDismiss?: (card: BoardCard) => void;
+  /** Temporarily hide this card from the current monitor view. Local UI-only control. */
+  onSnooze?: (card: BoardCard) => void;
+  /** Open the card's detail surface from an inline action. */
+  onInvestigate?: (card: BoardCard) => void;
 };
 
 // ── Helpers (mirror the bundle's small inline helpers) ──────────────
@@ -69,7 +76,16 @@ function riskPillClass(tag: RiskTag): string {
 
 // ── Card ───────────────────────────────────────────────────────────
 
-export function Card({ card, focused = false, onClick, onApprove, onApproveMission }: CardProps) {
+export function Card({
+  card,
+  focused = false,
+  onClick,
+  onApprove,
+  onApproveMission,
+  onDismiss,
+  onSnooze,
+  onInvestigate,
+}: CardProps) {
   const isAction = Boolean(card.isAction);
   const isStale = card.state === "stale";
   const isClosed = card.type === "done";
@@ -114,7 +130,7 @@ export function Card({ card, focused = false, onClick, onApprove, onApproveMissi
       {card.summary && !isClosed ? (
         <div className="hm-card-meta" style={{ lineHeight: 1.5 }}>
           <span style={{ color: "var(--hm-ink-soft)", fontFamily: "var(--font-body)", fontSize: 12 }}>
-            {card.summary}
+            <HumanizedText text={card.summary} />
           </span>
         </div>
       ) : null}
@@ -155,10 +171,6 @@ export function Card({ card, focused = false, onClick, onApprove, onApproveMissi
           cards, so gate it here rather than relying on the source. */}
       {!isClosed && card.waitingOn ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
 
-      {card.type === "task" && (card as { taskStatus?: string }).taskStatus === "proposed" && onApprove ? (
-        <TaskApprove card={card} onApprove={onApprove} />
-      ) : null}
-
       {card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "requested" ? (
         <div className="hm-waiting hm-waiting--neutral">
           not started
@@ -166,14 +178,21 @@ export function Card({ card, focused = false, onClick, onApprove, onApproveMissi
         </div>
       ) : null}
 
-      {card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "requested" && onApproveMission ? (
-        <MissionApprove card={card} onApprove={onApproveMission} />
+      {!isClosed && card.waitingOn?.actor === "operator" ? (
+        <OperatorActions
+          card={card}
+          onApprove={onApprove}
+          onApproveMission={onApproveMission}
+          onDismiss={onDismiss}
+          onSnooze={onSnooze}
+          onInvestigate={onInvestigate ?? onClick}
+        />
       ) : null}
 
       {isAction && verdict ? (
         <div className="hm-verdict">
           <span className="label">Hermes verdict</span>
-          {verdict}
+          <HumanizedText text={verdict} />
         </div>
       ) : null}
 
@@ -184,7 +203,7 @@ export function Card({ card, focused = false, onClick, onApprove, onApproveMissi
             className="hm-btn hm-btn--action hm-btn--sm"
             onClick={(e) => e.stopPropagation()}
           >
-            {action.primary}
+            <HumanizedText text={action.primary} />
             <span className="hm-kbd">A</span>
           </button>
           {action.secondary ? (
@@ -193,7 +212,7 @@ export function Card({ card, focused = false, onClick, onApprove, onApproveMissi
               className="hm-btn hm-btn--ghost hm-btn--sm"
               onClick={(e) => e.stopPropagation()}
             >
-              {action.secondary}
+              <HumanizedText text={action.secondary} />
             </button>
           ) : null}
         </div>
@@ -290,6 +309,24 @@ function ChecksLabel({ checks }: { checks: CardChecks }) {
   );
 }
 
+function HumanizedText({ text }: { text: string | undefined }) {
+  const parts = humanizedSignalParts(text);
+  if (parts.length === 0) return null;
+  return (
+    <>
+      {parts.map((part, index) => (
+        part.rawCode ? (
+          <span className="hm-signal-code" title={`raw code: ${part.rawCode}`} key={`${part.rawCode}:${index}`}>
+            {part.text}
+          </span>
+        ) : (
+          <span key={`text:${index}`}>{part.text}</span>
+        )
+      ))}
+    </>
+  );
+}
+
 // ── Waiting-on line ────────────────────────────────────────────────
 
 function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
@@ -301,36 +338,82 @@ function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
   );
 }
 
-// ── Task approve (O3 dispatch) ──────────────────────────────────────
-// Approving a proposed task is a real mutation (it lets a runner claim the
-// work), so per MONITOR_ACTION_PARITY.md it goes through an explicit confirm
-// step — never a single click. The operator is the only one who approves
-// (proposed → approved); the lifecycle then flows from the board feed.
+// ── Operator actions ────────────────────────────────────────────────
+// Approve is only shown when it maps to an existing human gate. Dismiss and
+// snooze are local monitor controls; they do not mutate task authority.
 
-function TaskApprove({ card, onApprove }: { card: BoardCard; onApprove: (card: BoardCard) => void }) {
+function OperatorActions({
+  card,
+  onApprove,
+  onApproveMission,
+  onDismiss,
+  onSnooze,
+  onInvestigate,
+}: {
+  card: BoardCard;
+  onApprove?: (card: BoardCard) => void;
+  onApproveMission?: (card: BoardCard) => void;
+  onDismiss?: (card: BoardCard) => void;
+  onSnooze?: (card: BoardCard) => void;
+  onInvestigate?: (card: BoardCard) => void;
+}) {
   const [confirming, setConfirming] = useState(false);
   const agent = agentLabel(card.agentType);
   const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
+  const taskStatus = (card as { taskStatus?: string }).taskStatus;
+  const missionStatus = (card as { missionStatus?: string }).missionStatus;
+  const canApproveTask = card.type === "task" && taskStatus === "proposed" && Boolean(onApprove);
+  const canApproveMission = card.type === "mission" && missionStatus === "requested" && Boolean(onApproveMission);
+  const canApprove = canApproveTask || canApproveMission;
+  const approveLabel = canApproveMission ? "Approve tester run" : "Approve & dispatch";
+  const confirmLabel = canApproveMission ? "Queue runner now?" : `Dispatch to ${agent}?`;
+  const approve = canApproveMission ? onApproveMission : onApprove;
+
+  if (!canApprove && !onDismiss && !onSnooze && !onInvestigate) return null;
+
+  const action = (handler: ((card: BoardCard) => void) | undefined) => (e: { stopPropagation: () => void }) => {
+    stop(e);
+    handler?.(card);
+  };
+
   if (!confirming) {
     return (
-      <div className="hm-card-cta">
-        <button
-          type="button"
-          className="hm-btn hm-btn--action hm-btn--sm"
-          onClick={(e) => {
-            stop(e);
-            setConfirming(true);
-          }}
-        >
-          Approve & dispatch
-        </button>
+      <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Operator actions">
+        {canApprove ? (
+          <button
+            type="button"
+            className="hm-btn hm-btn--action hm-btn--sm"
+            onClick={(e) => {
+              stop(e);
+              setConfirming(true);
+            }}
+          >
+            {approveLabel}
+          </button>
+        ) : null}
+        {onDismiss ? (
+          <button type="button" className="hm-btn hm-btn--ghost hm-btn--sm" onClick={action(onDismiss)}>
+            Dismiss
+          </button>
+        ) : null}
+        {onSnooze ? (
+          <button type="button" className="hm-btn hm-btn--ghost hm-btn--sm" onClick={action(onSnooze)}>
+            Snooze
+          </button>
+        ) : null}
+        {onInvestigate ? (
+          <button type="button" className="hm-btn hm-btn--ghost hm-btn--sm" onClick={action(onInvestigate)}>
+            Investigate
+          </button>
+        ) : null}
       </div>
     );
   }
+
   return (
-    <div className="hm-card-cta" role="group" aria-label="Confirm task dispatch">
+    <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Confirm operator action">
       <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
-        Dispatch to {agent}?
+        {confirmLabel}
       </span>
       <button
         type="button"
@@ -338,61 +421,7 @@ function TaskApprove({ card, onApprove }: { card: BoardCard; onApprove: (card: B
         onClick={(e) => {
           stop(e);
           setConfirming(false);
-          onApprove(card);
-        }}
-      >
-        Confirm
-      </button>
-      <button
-        type="button"
-        className="hm-btn hm-btn--ghost hm-btn--sm"
-        onClick={(e) => {
-          stop(e);
-          setConfirming(false);
-        }}
-      >
-        Cancel
-      </button>
-    </div>
-  );
-}
-
-// ── Mission approve (T6 tester request gate) ───────────────────────
-// Agent-requested tester runs are proposals only. The runner ignores
-// `requested`; this button performs the explicit operator gate
-// (requested → ready), after a confirm step.
-
-function MissionApprove({ card, onApprove }: { card: BoardCard; onApprove: (card: BoardCard) => void }) {
-  const [confirming, setConfirming] = useState(false);
-  const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
-  if (!confirming) {
-    return (
-      <div className="hm-card-cta">
-        <button
-          type="button"
-          className="hm-btn hm-btn--action hm-btn--sm"
-          onClick={(e) => {
-            stop(e);
-            setConfirming(true);
-          }}
-        >
-          Approve tester run
-        </button>
-      </div>
-    );
-  }
-  return (
-    <div className="hm-card-cta" role="group" aria-label="Confirm tester mission approval">
-      <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
-        Queue runner now?
-      </span>
-      <button
-        type="button"
-        className="hm-btn hm-btn--action hm-btn--sm"
-        onClick={(e) => {
-          stop(e);
-          setConfirming(false);
-          onApprove(card);
+          approve?.(card);
         }}
       >
         Confirm

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -21,9 +21,25 @@ export type CardRouterProps = {
   onApprove?: (card: BoardCard) => void;
   /** Approve a board-gated requested tester mission (T6). */
   onApproveMission?: (card: BoardCard) => void;
+  /** Hide a waiting-on-operator card from the current monitor view. */
+  onDismiss?: (card: BoardCard) => void;
+  /** Temporarily hide a waiting-on-operator card from the current monitor view. */
+  onSnooze?: (card: BoardCard) => void;
+  /** Open the card's detail surface from an inline action. */
+  onInvestigate?: (card: BoardCard) => void;
 };
 
-export function CardRouter({ card, focused, onClick, onDegradedAction, onApprove, onApproveMission }: CardRouterProps) {
+export function CardRouter({
+  card,
+  focused,
+  onClick,
+  onDegradedAction,
+  onApprove,
+  onApproveMission,
+  onDismiss,
+  onSnooze,
+  onInvestigate,
+}: CardRouterProps) {
   const renderer = pickRenderer(card);
 
   if (renderer === "degraded") {
@@ -40,5 +56,16 @@ export function CardRouter({ card, focused, onClick, onDegradedAction, onApprove
     );
   }
 
-  return <Card card={card} focused={focused} onClick={onClick} onApprove={onApprove} onApproveMission={onApproveMission} />;
+  return (
+    <Card
+      card={card}
+      focused={focused}
+      onClick={onClick}
+      onApprove={onApprove}
+      onApproveMission={onApproveMission}
+      onDismiss={onDismiss}
+      onSnooze={onSnooze}
+      onInvestigate={onInvestigate}
+    />
+  );
 }

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -16,6 +16,7 @@ import type {
   HermesDecisionRecord,
   MissionCard,
 } from "../../lib/monitor/card-types.js";
+import { humanizeSignalText } from "../../lib/monitor/signal-labels.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
 
 export type DrawerVariant = "mission" | "action" | "done" | "draft" | "task" | "deploy" | "pr";
@@ -191,9 +192,11 @@ function RiskSignalsSection({ signals }: { signals: CardRiskSignal[] | undefined
         {signals.map((s) => (
           <div className="row" key={s.code}>
             <span className="path" style={{ whiteSpace: "normal" }}>
-              {s.message}
+              {humanizeSignalText(s.message)}
             </span>
-            <span className={RISK_PILL[s.severity]}>{s.severity}</span>
+            <span className={RISK_PILL[s.severity]} title={`raw code: ${s.code}`}>
+              {s.severity}
+            </span>
           </div>
         ))}
       </div>

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
@@ -122,4 +122,20 @@ describe("buildHermesActivityFeed", () => {
       "Codex returned a block review on Self-healing fix: Codex found an unresolved deploy risk.",
     );
   });
+
+  test("humanizes guardrail enums in proactive narration", () => {
+    const entries = buildHermesActivityFeed({
+      cards: [task({
+        lane: "needs-attention",
+        isAction: true,
+        summary: "dispatch_budget_exhausted",
+      })],
+      messages: [],
+      banner,
+      now: () => Date.parse("2026-05-28T10:05:00Z"),
+    });
+    const text = entries.map((entry) => entry.text).join("\n");
+    expect(text).toContain("Dispatch budget used up - paused until reset");
+    expect(text).not.toContain("dispatch_budget_exhausted");
+  });
 });

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -7,6 +7,7 @@ import type {
 } from "./card-types.js";
 import type { CollaborationMessage } from "./collaboration.js";
 import { actorLabel, formatTurnTime } from "./collaboration.js";
+import { humanizeSignalText } from "./signal-labels.js";
 
 export type ActivityTone = "neutral" | "info" | "action" | "success" | "warning";
 
@@ -270,7 +271,7 @@ function parseTime(value: string | undefined): number | undefined {
 }
 
 function plain(value: string | undefined): string {
-  return (value ?? "").replace(/\s+/g, " ").trim();
+  return humanizeSignalText(value).replace(/\s+/g, " ").trim();
 }
 
 function cardTitle(card: BoardCard): string {

--- a/packages/monitor-ui/src/lib/monitor/signal-labels.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/signal-labels.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import {
+  humanizeSignalCode,
+  humanizedSignalParts,
+  humanizeSignalText,
+} from "./signal-labels.js";
+
+describe("signal-labels", () => {
+  test("maps known guardrail enum codes to exact human labels", () => {
+    expect(humanizeSignalCode("dispatch_budget_exhausted"))
+      .toBe("Dispatch budget used up - paused until reset");
+    expect(humanizeSignalCode("open_fix_cap_reached"))
+      .toBe("Self-healing fix cap reached - won't propose more");
+    expect(humanizeSignalCode("duplicate_signal"))
+      .toBe("Skipped - duplicate of an existing fix");
+    expect(humanizeSignalCode("routed_fix")).toBe("Routed fix proposal");
+  });
+
+  test("keeps unknown enum-like codes readable without dropping the raw token", () => {
+    expect(humanizeSignalCode("runner_active_task_mismatch")).toBe("runner active task mismatch");
+    expect(humanizedSignalParts("runner_active_task_mismatch")).toEqual([
+      { text: "runner active task mismatch", rawCode: "runner_active_task_mismatch" },
+    ]);
+  });
+
+  test("humanizes enum tokens inside sentences", () => {
+    expect(humanizeSignalText("Reason: dispatch_budget_exhausted; next duplicate_signal."))
+      .toBe("Reason: Dispatch budget used up - paused until reset; next Skipped - duplicate of an existing fix.");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/signal-labels.ts
+++ b/packages/monitor-ui/src/lib/monitor/signal-labels.ts
@@ -1,0 +1,36 @@
+export interface HumanizedSignalPart {
+  text: string;
+  rawCode?: string;
+}
+
+const SIGNAL_LABELS: Record<string, string> = {
+  dispatch_budget_exhausted: "Dispatch budget used up - paused until reset",
+  open_fix_cap_reached: "Self-healing fix cap reached - won't propose more",
+  duplicate_signal: "Skipped - duplicate of an existing fix",
+  routed_fix: "Routed fix proposal",
+};
+
+const ENUM_TOKEN = /\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g;
+
+export function humanizeSignalCode(code: string): string {
+  return SIGNAL_LABELS[code] ?? code.replace(/_/g, " ");
+}
+
+export function humanizeSignalText(value: string | undefined): string {
+  return humanizedSignalParts(value).map((part) => part.text).join("");
+}
+
+export function humanizedSignalParts(value: string | undefined): HumanizedSignalPart[] {
+  if (!value) return [];
+  const parts: HumanizedSignalPart[] = [];
+  let lastIndex = 0;
+  for (const match of value.matchAll(ENUM_TOKEN)) {
+    const rawCode = match[0] ?? "";
+    const index = match.index ?? 0;
+    if (index > lastIndex) parts.push({ text: value.slice(lastIndex, index) });
+    parts.push({ text: humanizeSignalCode(rawCode), rawCode });
+    lastIndex = index + rawCode.length;
+  }
+  if (lastIndex < value.length) parts.push({ text: value.slice(lastIndex) });
+  return parts;
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1553,6 +1553,12 @@ button.hm-activity-row:hover {
 .hm-card-cta {
   display: flex; gap: 6px; margin-top: 2px;
 }
+.hm-card-cta--operator { flex-wrap: wrap; }
+.hm-signal-code {
+  text-decoration: underline dotted rgba(40,60,80,0.45);
+  text-underline-offset: 2px;
+  cursor: help;
+}
 
 /* ============================================================
    KEYBOARD SHORTCUTS OVERLAY

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -1286,7 +1286,7 @@ export function buildV2BoardSnapshot(
   const missionIndex = indexTestbedMissions(rawSnapshot);
   const reviewRequests = reviewRequestsFromSnapshot(rawSnapshot);
   const runner = readRunner(rawSnapshot);
-  const cards = items.map((item) => {
+  const sourceCards = items.map((item) => {
     const base = toBoardCard(item);
     const key = prKey(item.repo, item.number);
     const enriched = enrichBoardCard(base, item, {
@@ -1305,13 +1305,22 @@ export function buildV2BoardSnapshot(
     });
   });
   // Surface queued greenfield tasks the classifier can't (no PR ⇒ no event),
-  // skipping any already represented (e.g. by a PR card).
-  const existingIds = new Set(cards.map((c) => c.id));
+  // skipping any already represented (e.g. by a PR card). When the same
+  // self-healing event also produced a task, keep the task card because it
+  // owns the real approve/dispatch control; the handoff event is context.
+  const existingIds = new Set(sourceCards.map((c) => c.id));
   const taskCards = synthesizeTaskCards(rawSnapshot, runner, { now: snapshotAt })
     .filter((c) => !existingIds.has(c.id))
     .map((card) => attachReviewRequests(card, reviewRequests, {
       correlationId: card.correlationId ?? card.id,
     }));
+  const actionableTaskCorrelationIds = new Set(
+    taskCards.map((card) => card.correlationId).filter((value): value is string => Boolean(value)),
+  );
+  const cards = sourceCards.filter((card) => {
+    if (!card.correlationId || card.type === "task") return true;
+    return !actionableTaskCorrelationIds.has(card.correlationId);
+  });
 
   return {
     cards: [...cards, ...taskCards],

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1175,6 +1175,45 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     expect(task?.type).toBe("task");
     expect(task?.taskStatus).toBe("proposed");
   });
+
+  it("dedupes self-healing handoff cards when an actionable task exists for the same correlation", () => {
+    const correlationId = "self-heal:testbed:failed-mission";
+    const snap = buildV2BoardSnapshot(
+      {
+        active: [{
+          title: "Self-healing: failed browser mission",
+          status: "failed",
+          intent: "self_healing",
+          reason: "dispatch_budget_exhausted",
+          correlationId,
+          ageLabel: "1m",
+        }],
+        recent: [],
+        codexTasks: {
+          items: [{
+            id: "codex-task-self-heal-1",
+            status: "proposed",
+            agent: "codex",
+            repo: "depre-dev/averray-reference-agent",
+            title: "Self-healing: failed browser mission",
+            prompt: "Investigate and propose the smallest fix.",
+            correlationId,
+            reason: "routed_fix",
+          }],
+        },
+      },
+      { repo: "depre-dev/averray-reference-agent" },
+    );
+
+    const correlated = snap.cards.filter((card) => card.correlationId === correlationId);
+    expect(correlated).toHaveLength(1);
+    expect(correlated[0]).toMatchObject({
+      id: "codex-task-self-heal-1",
+      type: "task",
+      taskStatus: "proposed",
+      waitingOn: { actor: "operator", tone: "warn" },
+    });
+  });
 });
 
 describe("enrichBoardCard — task status", () => {


### PR DESCRIPTION
## What changed & why

Waiting-on-operator cards now carry real inline monitor controls instead of leaving the operator in a dead end. Proposed task and requested mission approval still use the existing explicit confirm gates; Dismiss and Snooze are local monitor visibility controls; Investigate opens the card detail surface.

Self-healing handoff cards now dedupe against actionable task cards with the same correlation id, so a failed-mission fix appears as one actionable card instead of a passive needs-attention copy plus an actionable task copy.

Raw guardrail reason codes are humanized in card copy, drawer risk-signal copy, and Hermes activity narration while preserving the raw code in hover/debug metadata.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm --workspace @avg/monitor-ui run build`
- [x] Browser smoke: Vite monitor UI loaded locally with no console errors; backend-dependent board stayed degraded because no local slack-operator API was running.
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Frontend/monitor mapper only. Roll back by reverting this PR if the board controls or dedupe behavior regress.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work** (not needed; UI control wiring only)

## Known limits / follow-ups

Dismiss and Snooze are intentionally monitor-local visibility controls in this slice. They do not persist to the server or change task authority.
