### PR TITLE
Constrain B2 testbed self-healing inputs

### DIFF
--- a/docs/testbed-mission-failure-triage-2026-06-01.md
+++ b/docs/testbed-mission-failure-triage-2026-06-01.md
@@ -1,6 +1,6 @@
 # Testbed Mission Failure Triage — 2026-06-01
 
-Scope: classify the failed `testbed-mission-*` runs that have been feeding B2 self-healing, then add a safe stale-input guard without changing product state or task authority.
+Scope: classify the failed `testbed-mission-*` runs that have been feeding B2 self-healing, then explain why some dispatched self-healing fixes failed. The cleanup is input/routing only: no product-state mutation and no authority change.
 
 ## Findings
 
@@ -12,12 +12,28 @@ Scope: classify the failed `testbed-mission-*` runs that have been feeding B2 se
 | `testbed-mission-mptmzrcn-6` | 2026-05-31T10:28:27.575Z | REAL until superseded | Fresh enough to be post-wiring. Keep eligible unless a newer same-target mission supersedes it or it ages beyond the stale-input window. |
 | `testbed-mission-mptpfgmh-8` | 2026-05-31T11:36:39.401Z | REAL until superseded | Fresh enough to be post-wiring. Keep eligible unless a newer same-target mission supersedes it or it ages beyond the stale-input window. |
 
+## Layer 2 — why self-healing fix tasks failed
+
+B2 was turning every recent latest-per-target failed testbed mission into a code-agent proposal when a repo was configured. That was too broad.
+
+Evidence in code:
+
+- `services/slack-operator/src/monitor-testbed-missions.ts` has two different failure layers: `mission_report_needs_fix` means a browser-agent product report exists; `mission_runner_failed` means the runner/report pipeline failed before a trustworthy product report existed.
+- `services/slack-operator/src/index.ts` collected both kinds into the same `FailureSignal` with `repo`, so the self-healing core treated runner/report failures as routable code work.
+- The generic B2 prompt only included a board URL as evidence. The hosted board is Cloudflare-protected from a fresh agent context, so a Claude worker could receive a vague "testbed mission failed" task with no durable product evidence it can act on.
+- `testbedMissionCodexFollowupPrompt()` already contains the richer product-fix prompt, but B2 was not using it for self-healing proposals.
+
+Conclusion: some self-healing tasks were doomed because the target was not a real code task yet. Runner/report-pipeline failures need human/operator diagnosis; structured browser-agent product failures can still become a code-agent fix.
+
 ## Code decision
 
-B2 should not delete or rewrite mission history. Instead, its input now filters failed testbed missions before self-healing sees them:
+B2 should not delete or rewrite mission history. Instead, its input now filters and classifies failed testbed missions before self-healing can dispatch work:
 
 - Keep only the newest mission per target surface.
 - Drop a failed mission once a newer mission for that target exists, including a pass, requested, ready, or running rerun.
 - Drop failed missions older than `B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS` (default: 72).
+- For the remaining failed missions, propose a self-healing code task only when the run has a structured browser-agent product report.
+- Use the structured testbed follow-up prompt for product-fixable missions so the worker gets blocker, UX gap, proof, and evidence without relying on a protected board link.
+- Escalate runner/report-pipeline failures as `not_auto_fixable` instead of dispatching a doomed code-agent task.
 
 This is a read-only input guard. It does not create, approve, dismiss, or mutate product work.

--- a/packages/monitor-ui/src/lib/monitor/signal-labels.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/signal-labels.test.ts
@@ -14,6 +14,8 @@ describe("signal-labels", () => {
     expect(humanizeSignalCode("duplicate_signal"))
       .toBe("Skipped - duplicate of an existing fix");
     expect(humanizeSignalCode("routed_fix")).toBe("Routed fix proposal");
+    expect(humanizeSignalCode("not_auto_fixable"))
+      .toBe("Needs human diagnosis - not a code-agent fix");
   });
 
   test("keeps unknown enum-like codes readable without dropping the raw token", () => {

--- a/packages/monitor-ui/src/lib/monitor/signal-labels.ts
+++ b/packages/monitor-ui/src/lib/monitor/signal-labels.ts
@@ -8,6 +8,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   open_fix_cap_reached: "Self-healing fix cap reached - won't propose more",
   duplicate_signal: "Skipped - duplicate of an existing fix",
   routed_fix: "Routed fix proposal",
+  not_auto_fixable: "Needs human diagnosis - not a code-agent fix",
 };
 
 const ENUM_TOKEN = /\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -149,6 +149,7 @@ import {
   testbedMissionCodexFollowupPrompt,
   testbedMissionReportValidationCoaching,
   testbedMissionResultCoaching,
+  testbedMissionSelfHealingDisposition,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
 import {
@@ -1844,15 +1845,18 @@ async function collectSelfHealingSignals(boardUrl: string): Promise<FailureSigna
       maxAgeHours: routineConfig.selfHealing.testbedFailureMaxAgeHours,
     });
     for (const m of missions) {
+      const disposition = testbedMissionSelfHealingDisposition(m);
       signals.push({
         // Stable per-target surface (NOT the per-run mission id), so re-runs of
         // the same failing mission dedup/cooldown instead of swarming the queue.
         surface: testbedSurfaceKey(m.targetUrl),
         source: "testbed_mission",
-        summary: `Testbed mission for ${m.targetUrl} failed: ${m.failureReason ?? m.statusReason ?? "no reason recorded"}`,
+        summary: disposition.summary,
         evidence: `${boardUrl}?mission=${encodeURIComponent(m.id)}`,
-        ...(fixRepo ? { repo: fixRepo } : {}),
+        ...(disposition.autoFixable && fixRepo ? { repo: fixRepo } : {}),
         area: `testbed ${m.targetUrl}`,
+        ...(disposition.autoFixable ? {} : { autoFixable: false, nonAutoFixableReason: disposition.reason }),
+        ...(disposition.fixPrompt ? { fixPrompt: disposition.fixPrompt } : {}),
       });
     }
   } catch (error) {

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -135,6 +135,19 @@ export interface TestbedMissionFixBrief {
   evidence: string[];
 }
 
+export type TestbedMissionSelfHealingReason =
+  | "product_signal"
+  | "runner_failed"
+  | "invalid_report"
+  | "missing_product_report";
+
+export interface TestbedMissionSelfHealingDisposition {
+  autoFixable: boolean;
+  reason: TestbedMissionSelfHealingReason;
+  summary: string;
+  fixPrompt?: string;
+}
+
 export interface TestbedMissionStoreDeps {
   path?: string;
   now?: Date;
@@ -673,6 +686,42 @@ export function testbedMissionCodexFollowupPrompt(run: TestbedMissionRun): strin
   ].join("\n");
 }
 
+export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): TestbedMissionSelfHealingDisposition {
+  const reason = run.failureReason ?? run.statusReason ?? "no reason recorded";
+  if (run.history.some((entry) => entry.event === "mission_runner_failed")) {
+    return {
+      autoFixable: false,
+      reason: "runner_failed",
+      summary: `Testbed mission ${run.id} failed in the runner/report pipeline for ${run.targetUrl}: ${reason}`,
+    };
+  }
+  if (reportValidationFailure(reason)) {
+    return {
+      autoFixable: false,
+      reason: "invalid_report",
+      summary: `Testbed mission ${run.id} has invalid browser-agent evidence for ${run.targetUrl}: ${reason}`,
+    };
+  }
+
+  const structuredReport = testbedMissionStructuredReport(run);
+  if (!structuredReport || !run.result) {
+    return {
+      autoFixable: false,
+      reason: "missing_product_report",
+      summary: `Testbed mission ${run.id} failed without an attached product report for ${run.targetUrl}: ${reason}`,
+    };
+  }
+
+  const fixBrief = testbedMissionFixBrief(run);
+  const fixPrompt = testbedMissionCodexFollowupPrompt(run);
+  return {
+    autoFixable: Boolean(fixPrompt),
+    reason: fixPrompt ? "product_signal" : "missing_product_report",
+    summary: `Testbed mission ${run.id} found a product blocker on ${run.targetUrl}: ${fixBrief.primaryBlocker}`,
+    ...(fixPrompt ? { fixPrompt } : {}),
+  };
+}
+
 export function testbedMissionFixBrief(run: TestbedMissionRun): TestbedMissionFixBrief {
   const result = run.result ?? {};
   const blockers = stringArray(result.blockers);
@@ -694,6 +743,10 @@ export function testbedMissionFixBrief(run: TestbedMissionRun): TestbedMissionFi
     rerunProof: `run this same testbed mission again and verify whether "${primaryBlocker}" is gone, unchanged, or replaced`,
     evidence,
   };
+}
+
+function reportValidationFailure(reason: string): boolean {
+  return /valid structured mission report|missing structured mission report|invalid browser-agent report/i.test(reason);
 }
 
 export function testbedMissionRerunPrompt(run: TestbedMissionRun): string | undefined {

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -40,6 +40,12 @@ export interface FailureSignal {
   area?: string;
   /** A rollback is ALWAYS operator-confirmed — escalate, never propose. */
   isRollback?: boolean;
+  /** False when the signal needs human diagnosis instead of a code-agent fix. */
+  autoFixable?: boolean;
+  /** Operator-facing explanation for why B2 must not dispatch a code task. */
+  nonAutoFixableReason?: string;
+  /** Source-specific prompt with enough context for a code agent to act. */
+  fixPrompt?: string;
 }
 
 export interface HealingClassification {
@@ -54,6 +60,7 @@ export type HealingReason =
   | "autopilot_suspended"
   | "halt_present"
   | "rollback_operator_confirmed"
+  | "not_auto_fixable"
   | "no_target_repo"
   | "unclassified"
   | "high_risk_surface"
@@ -104,6 +111,8 @@ export function decideHealingAction(
   if (gates.suspended) return { action: "escalate", reason: "autopilot_suspended" };
   // Rollback is always operator-confirmed.
   if (signal.isRollback) return { action: "escalate", reason: "rollback_operator_confirmed" };
+  // Some signals are real alerts but not code-agent-fixable.
+  if (signal.autoFixable === false) return { action: "escalate", reason: "not_auto_fixable" };
   // Can't route a build without a repo.
   if (!signal.repo) return { action: "escalate", reason: "no_target_repo" };
   if (!classification) return { action: "escalate", reason: "unclassified" };
@@ -116,6 +125,8 @@ export function decideHealingAction(
 
 /** A clear, bounded fix-task prompt describing the failure + an evidence link. */
 export function buildFixPrompt(signal: FailureSignal): string {
+  const specificPrompt = signal.fixPrompt?.trim();
+  if (specificPrompt) return specificPrompt;
   const lines = [
     `A ${humanSource(signal.source)} failed and Hermes self-healing is proposing a fix.`,
     "",
@@ -152,6 +163,8 @@ export function buildHealingEscalationAlert(
       ? "A rollback is always operator-confirmed — Hermes will not auto-act.\n"
       : decision.reason === "high_risk_surface"
         ? "High-risk surface — Hermes escalates instead of auto-proposing a fix.\n"
+        : decision.reason === "not_auto_fixable"
+          ? `Needs human diagnosis — B2 will not dispatch a code-agent fix${signal.nonAutoFixableReason ? ` (${signal.nonAutoFixableReason})` : ""}.\n`
         : "") +
     `Board: ${boardUrl}`;
   return { count: 1, items: [{ id: signal.surface, title: `self-healing: ${signal.surface}` }], boardUrl, text };
@@ -160,6 +173,7 @@ export function buildHealingEscalationAlert(
 function escalationHeadline(reason: HealingReason): string {
   switch (reason) {
     case "rollback_operator_confirmed": return "a rollback needs your confirmation";
+    case "not_auto_fixable": return "a failure is not code-agent-fixable";
     case "high_risk_surface": return "a high-risk surface failed";
     case "halt_present": return "a failure tripped while HALT is set";
     case "autopilot_suspended": return "a failure tripped while autopilot is suspended (D3)";
@@ -275,7 +289,7 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
 
     // Classify only when a build is even possible (else the decision escalates).
     const classification =
-      !suspended && !halt && !signal.isRollback && signal.repo ? deps.classify(signal) : undefined;
+      !suspended && !halt && !signal.isRollback && signal.autoFixable !== false && signal.repo ? deps.classify(signal) : undefined;
     let decision = decideHealingAction(signal, classification, { suspended, halt });
 
     // Backstops: don't propose past the per-tick cap, daily cap, nor past the

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -16,6 +16,7 @@ import {
   testbedMissionRerunPrompt,
   testbedMissionResultCoaching,
   testbedMissionRunToMonitorItem,
+  testbedMissionSelfHealingDisposition,
   testbedMissionStructuredReport,
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
 
@@ -485,6 +486,53 @@ describe("monitor testbed mission runs", () => {
     expect(coaching).toContain("Set confidence to a number from 0 to 1.");
     expect(coaching).toContain("Smallest next move");
     expect(coaching).toContain("do not ask Codex to change the product until the evidence is attached");
+  });
+
+  it("marks structured failed browser reports as code-agent-fixable for B2", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: run!.id,
+        text: JSON.stringify({
+          verdict: "fail",
+          confidence: 0.7,
+          stoppedBeforeMutation: true,
+          mutationBoundaryNotes: ["Stopped before signing."],
+          completedPath: ["opened app", "looked for claim button"],
+          blockers: ["Could not find the claim button."],
+          confusingMoments: ["Primary action looked disabled without explanation."],
+          recommendations: ["Make the claim action visible with a blocked-state reason."],
+          evidence: ["Agent searched the main panel and command area."],
+          scores: { orientation: 2 },
+        }),
+      },
+      Date.parse("2026-05-22T10:05:00.000Z"),
+    );
+
+    const disposition = testbedMissionSelfHealingDisposition(updated!);
+    expect(disposition).toMatchObject({
+      autoFixable: true,
+      reason: "product_signal",
+    });
+    expect(disposition.summary).toContain("Could not find the claim button.");
+    expect(disposition.fixPrompt ?? "").toContain(`Fix the testbed page for mission ${run!.id}`);
+    expect(disposition.fixPrompt ?? "").toContain("Smallest product move: Make the claim action visible with a blocked-state reason.");
+  });
+
+  it("marks runner/report-pipeline failures as human-review, not auto-fixable", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    const failed = failTestbedMissionRun(run!.id, {
+      now: new Date("2026-05-22T10:05:00.000Z"),
+      failureReason: "Hermes testbed runner finished, but the output did not contain a valid structured mission report.",
+    });
+
+    const disposition = testbedMissionSelfHealingDisposition(failed!);
+    expect(disposition).toMatchObject({
+      autoFixable: false,
+      reason: "runner_failed",
+    });
+    expect(disposition.summary).toContain("runner/report pipeline");
+    expect(disposition.fixPrompt).toBeUndefined();
   });
 
   it("feeds B2 only the latest failed mission per target", () => {

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -45,6 +45,10 @@ describe("decideHealingAction — propose only the safe path; everything else es
     expect(decideHealingAction(signal({ isRollback: true }), LOW, open)).toMatchObject({ action: "escalate", reason: "rollback_operator_confirmed" });
   });
 
+  it("not auto-fixable → escalate before routing a build", () => {
+    expect(decideHealingAction(signal({ autoFixable: false }), LOW, open)).toMatchObject({ action: "escalate", reason: "not_auto_fixable" });
+  });
+
   it("D3 interlock: suspended → escalate only", () => {
     expect(decideHealingAction(signal(), LOW, { suspended: true, halt: false })).toMatchObject({ action: "escalate", reason: "autopilot_suspended" });
   });
@@ -69,11 +73,24 @@ describe("buildFixPrompt / escalation alert", () => {
     expect(p).toContain("Evidence: https://board.example?mission=sweep-1");
     expect(p).toMatch(/do not merge or deploy/i);
   });
+  it("uses a source-specific prompt when the collector has enough evidence", () => {
+    expect(buildFixPrompt(signal({ fixPrompt: "Fix mission m1 with attached evidence." }))).toBe("Fix mission m1 with attached evidence.");
+  });
   it("the escalation alert names the surface + reason", () => {
     const alert = buildHealingEscalationAlert(signal({ isRollback: true }), { action: "escalate", reason: "rollback_operator_confirmed" }, "https://board.example");
     expect(alert.text).toMatch(/rollback/i);
     expect(alert.text).toContain("testbed:sweep-1");
     expect(alert.items[0]?.id).toBe("testbed:sweep-1");
+  });
+  it("the not-auto-fixable escalation says it needs human diagnosis", () => {
+    const alert = buildHealingEscalationAlert(
+      signal({ autoFixable: false, nonAutoFixableReason: "runner_failed" }),
+      { action: "escalate", reason: "not_auto_fixable" },
+      "https://board.example",
+    );
+    expect(alert.text).toContain("not code-agent-fixable");
+    expect(alert.text).toContain("Needs human diagnosis");
+    expect(alert.text).toContain("runner_failed");
   });
 });
 
@@ -155,6 +172,16 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     expect(h.proposed).toHaveLength(0);
     expect(h.alerts).toBe(1);
     expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "rollback_operator_confirmed" });
+  });
+
+  it("a non-auto-fixable failure escalates without calling the classifier", async () => {
+    const classify = vi.fn(() => LOW);
+    const h = harness([signal({ autoFixable: false, nonAutoFixableReason: "runner_failed" })], { classify });
+    await runSelfHealingOnce(h.deps);
+    expect(classify).not.toHaveBeenCalled();
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "not_auto_fixable" });
   });
 
   it("dedup: an already-open fix task for the surface → skip (no second proposal)", async () => {


### PR DESCRIPTION
## What changed & why

- Added a testbed mission self-healing disposition step that separates structured product failures from runner/report-pipeline failures.
- B2 now only proposes a code-agent self-heal for testbed missions with structured browser-agent evidence, and uses the richer testbed follow-up prompt for those proposals.
- Runner/report-pipeline failures now escalate as `not_auto_fixable` instead of dispatching a doomed Claude task.
- Extended the 2026-06-01 triage note with the Layer 2 root cause and cleanup decision.

Root cause: B2 treated every recent latest-per-target failed testbed mission as a routable code task when a repo was configured. That included mission-runner/report-shape failures and generic prompts that depended on a Cloudflare-protected board link.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No ops, compose, migrations, image pin, or secret/config changes. Rollback is reverting this PR; B2 returns to its previous collector behavior.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- This PR does not fix any product/testbed page bug. Structured product failures still become separate code-fix work.
- The live monitor endpoint was protected by Cloudflare Access from this environment, so the named mission classification is captured in the existing triage note and the code-level cleanup is verified with unit tests.