### PR TITLE
Deduplicate self-healing mission cards

### DIFF
--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -28,6 +28,7 @@ import {
   testbedMissionStructuredReport,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
+import { testbedSurfaceKey } from "./self-healing.js";
 import {
   isHermesDecisionRecord,
   type HermesDecisionRecord,
@@ -1318,8 +1319,10 @@ export function buildV2BoardSnapshot(
     taskCards.map((card) => card.correlationId).filter((value): value is string => Boolean(value)),
   );
   const cards = sourceCards.filter((card) => {
-    if (!card.correlationId || card.type === "task") return true;
-    return !actionableTaskCorrelationIds.has(card.correlationId);
+    if (card.type === "task") return true;
+    const correlationIds = sourceCardCorrelationIdsForDedupe(card, missionIndex);
+    if (correlationIds.length === 0) return true;
+    return !correlationIds.some((id) => actionableTaskCorrelationIds.has(id));
   });
 
   return {
@@ -1328,4 +1331,20 @@ export function buildV2BoardSnapshot(
     repo: opts.repo ?? "",
     llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents)),
   };
+}
+
+function sourceCardCorrelationIdsForDedupe(
+  card: BoardCard,
+  missionIndex: ReadonlyMap<string, Record<string, unknown>>,
+): string[] {
+  const ids = new Set<string>();
+  if (card.correlationId) ids.add(card.correlationId);
+  if (card.type === "mission" && card.correlationId) {
+    const missionRun = missionIndex.get(card.correlationId);
+    const targetUrl = asString(missionRun?.targetUrl);
+    if (targetUrl) {
+      ids.add(`self-heal:testbed_mission:${testbedSurfaceKey(targetUrl)}`);
+    }
+  }
+  return Array.from(ids);
 }

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1214,6 +1214,66 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
       waitingOn: { actor: "operator", tone: "warn" },
     });
   });
+
+  it("collapses a failed testbed mission and its self-healing task into one actionable card", () => {
+    const missionId = "testbed-mission-failed-1";
+    const snap = buildV2BoardSnapshot(
+      {
+        active: [],
+        recent: [],
+        testbedMissions: [{
+          schemaVersion: 1,
+          kind: "testbed_mission_run",
+          id: missionId,
+          status: "failed",
+          title: "Fresh-agent browser mission",
+          targetUrl: "https://averray.com/",
+          goal: "Test the main flow like a new outside agent.",
+          agentName: "Hermes",
+          freshMemory: true,
+          allowTestMutations: false,
+          createdAt: "2026-06-01T10:00:00.000Z",
+          updatedAt: "2026-06-01T10:05:00.000Z",
+          failedAt: "2026-06-01T10:05:00.000Z",
+          statusReason: "Browser-agent report returned fail.",
+          failureReason: "Browser-agent report returned fail.",
+          result: {
+            verdict: "fail",
+            confidence: 0.4,
+            stoppedBeforeMutation: true,
+            blockers: ["primary action unclear"],
+            confusingMoments: [],
+            evidence: [],
+            scores: {},
+            recommendations: [],
+          },
+        }],
+        codexTasks: {
+          items: [{
+            id: "codex-task-self-heal-averray",
+            status: "proposed",
+            agent: "codex",
+            repo: "depre-dev/averray-reference-agent",
+            title: "Self-healing fix: testbed:averray.com",
+            prompt: "Investigate the failed mission and propose the smallest fix.",
+            requester: "hermes-self-healing",
+            correlationId: "self-heal:testbed_mission:testbed:averray.com",
+            reason: "Hermes self-healing proposal for a testbed_mission failure",
+          }],
+        },
+      },
+      { repo: "depre-dev/averray-reference-agent", now: () => new Date("2026-06-01T10:06:00.000Z") },
+    );
+
+    expect(snap.cards).toHaveLength(1);
+    expect(snap.cards[0]).toMatchObject({
+      id: "codex-task-self-heal-averray",
+      lane: "codex-needed",
+      type: "task",
+      taskStatus: "proposed",
+      waitingOn: { actor: "operator", tone: "warn" },
+    });
+  });
 });
 
 describe("enrichBoardCard — task status", () => {


### PR DESCRIPTION
## What changed

- Collapses duplicate self-healing display cards when a failed testbed mission has an active self-healing task for the same target.
- The board now treats a failed mission card and a `self-heal:testbed_mission:<target-surface>` task as the same operator decision.
- Keeps the synthesized task card when present, so the operator sees the full action set on one card: approve/dispatch, dismiss, snooze, investigate.
- Leaves authority unchanged: this is placement/dedupe only; no approval, dispatch, mission, or product mutation behavior changed.

## Tests

- `git diff --check`
- `npm install`
- `npm run build`
- `npm test -- test/unit/monitor-v2.test.ts packages/monitor-ui/src/components/cards/Card.test.tsx packages/monitor-ui/src/components/BoardView.test.tsx`
- `npm run typecheck`
- `npm test`

## Affected surfaces

- Monitor board snapshot generation.
- Monitor board/card tests.

## Rollout / safety

- No environment or VPS secret changes.
- No ops/compose changes.
- No authority change: one visible decision card, same existing controls.
