### PR TITLE
Show real LLM usage activity

### DIFF
--- a/packages/averray-mcp/src/agent-scorecard.ts
+++ b/packages/averray-mcp/src/agent-scorecard.ts
@@ -470,6 +470,7 @@ function usageEvents(value: unknown): LlmUsageEvent[] {
       if (!agent || !model || !ts || inputTokens === undefined || outputTokens === undefined) return undefined;
       if (!Number.isInteger(inputTokens) || !Number.isInteger(outputTokens) || inputTokens < 0 || outputTokens < 0) return undefined;
       const costUsd = numberField(event, "costUsd");
+      const cacheTokens = numberField(event, "cacheTokens");
       return {
         agent,
         model,
@@ -477,6 +478,7 @@ function usageEvents(value: unknown): LlmUsageEvent[] {
         ...(stringField(event, "taskId") ? { taskId: stringField(event, "taskId") } : {}),
         inputTokens,
         outputTokens,
+        ...(cacheTokens !== undefined && Number.isInteger(cacheTokens) && cacheTokens >= 0 ? { cacheTokens } : {}),
         ...(costUsd !== undefined ? { costUsd } : {}),
         ts,
       };

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -8,6 +8,7 @@ export interface LlmUsageEvent {
   taskId?: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens?: number;
   costUsd?: number;
   ts: string;
 }
@@ -17,20 +18,24 @@ export interface LlmUsageModelRollup {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens: number;
   totalTokens: number;
   costUsd: number | null;
   costStatus: "recorded" | "not_recorded";
   runs: number;
+  lastActiveAt: string | null;
 }
 
 export interface LlmUsageDayRollup {
   day: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens: number;
   totalTokens: number;
   costUsd: number | null;
   costStatus: "recorded" | "not_recorded";
   runs: number;
+  lastActiveAt: string | null;
   byModel: LlmUsageModelRollup[];
 }
 
@@ -40,18 +45,30 @@ export interface LlmUsageSourceStatus {
   reason?: string;
 }
 
+export interface LlmUsageActiveCall {
+  id: string;
+  agent: string;
+  model: string;
+  startedAt: string;
+  runId?: string;
+  taskId?: string;
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
   message: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens: number;
   totalTokens: number;
   costUsd: number | null;
   costStatus: "recorded" | "not_recorded";
   runs: number;
+  lastActiveAt: string | null;
   byModel: LlmUsageModelRollup[];
   byDay: LlmUsageDayRollup[];
   sourceStatus: LlmUsageSourceStatus[];
+  activeCalls: LlmUsageActiveCall[];
 }
 
 export interface LlmUsageCaptureInput {
@@ -66,6 +83,15 @@ export interface LlmUsageCaptureInput {
 export interface LlmUsageAggregateOptions {
   expectedAgents?: readonly string[];
   sourceReasons?: Readonly<Record<string, string>>;
+  activeCalls?: readonly LlmUsageActiveCall[];
+}
+
+export interface LlmUsageActiveCallInput {
+  agent: string;
+  model?: string;
+  runId?: string;
+  taskId?: string;
+  startedAt?: Date;
 }
 
 const DEFAULT_USAGE_LOG_PATH = "/data/llm-usage.jsonl";
@@ -73,9 +99,12 @@ const DEFAULT_EXPECTED_AGENTS = ["claude", "test-writer", "codex", "hermes"] as 
 const DEFAULT_SOURCE_REASONS: Readonly<Record<string, string>> = {
   claude: "Claude Agent SDK usage counters have not arrived from runner output yet.",
   "test-writer": "Test-writer SDK usage counters have not arrived from runner output yet.",
-  codex: "Codex usage is not reported by the CLI yet.",
+  codex: "Codex CLI does not report usage.",
   hermes: "Hermes/Ollama responses have not exposed usage counters yet.",
 };
+
+const activeCalls = new Map<string, LlmUsageActiveCall>();
+let nextActiveCallId = 0;
 
 export function llmUsageLogPath(env: NodeJS.ProcessEnv = process.env): string {
   return env.LLM_USAGE_LOG_PATH?.trim() || env.AVERRAY_LLM_USAGE_LOG_PATH?.trim() || DEFAULT_USAGE_LOG_PATH;
@@ -116,6 +145,28 @@ export async function recordLlmUsageFromResult(
   return event;
 }
 
+export function beginLlmUsageCall(input: LlmUsageActiveCallInput): () => void {
+  const agent = input.agent.trim();
+  if (!agent) return () => undefined;
+  const id = `llm-call-${Date.now()}-${++nextActiveCallId}`;
+  const call: LlmUsageActiveCall = {
+    id,
+    agent,
+    model: input.model?.trim() || `${agent} model pending`,
+    startedAt: (input.startedAt ?? new Date()).toISOString(),
+    ...(input.runId ? { runId: input.runId.trim() } : {}),
+    ...(input.taskId ? { taskId: input.taskId.trim() } : {}),
+  };
+  activeCalls.set(id, call);
+  return () => {
+    activeCalls.delete(id);
+  };
+}
+
+export function listActiveLlmUsageCalls(): LlmUsageActiveCall[] {
+  return Array.from(activeCalls.values()).sort((a, b) => a.startedAt.localeCompare(b.startedAt));
+}
+
 export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEvent | undefined {
   const usageSource = firstUsageSource(
     tokenUsageSource(input.result),
@@ -132,12 +183,17 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
   const inputTokens = integerField(usage, "inputTokens")
     ?? integerField(usage, "input_tokens")
     ?? integerField(usage, "promptTokens")
-    ?? integerField(usage, "prompt_tokens");
+    ?? integerField(usage, "prompt_tokens")
+    ?? integerField(usage, "prompt_eval_count")
+    ?? integerField(usage, "promptEvalCount");
   const outputTokens = integerField(usage, "outputTokens")
     ?? integerField(usage, "output_tokens")
     ?? integerField(usage, "completionTokens")
-    ?? integerField(usage, "completion_tokens");
+    ?? integerField(usage, "completion_tokens")
+    ?? integerField(usage, "eval_count")
+    ?? integerField(usage, "evalCount");
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
+  const cacheTokens = cacheTokensFromUsage(usage);
 
   const model = stringField(usage, "model")
     ?? stringField(carrier, "model")
@@ -146,17 +202,6 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
     ?? stringField(input.result, "modelId")
     ?? input.model
     ?? "not_recorded";
-  const costUsd = numberField(usage, "costUsd")
-    ?? numberField(usage, "cost_usd")
-    ?? numberField(usage, "total_cost_usd")
-    ?? numberField(carrier, "costUsd")
-    ?? numberField(carrier, "cost_usd")
-    ?? numberField(carrier, "totalCostUsd")
-    ?? numberField(carrier, "total_cost_usd")
-    ?? numberField(input.result, "costUsd")
-    ?? numberField(input.result, "cost_usd")
-    ?? numberField(input.result, "totalCostUsd")
-    ?? numberField(input.result, "total_cost_usd");
 
   const event: LlmUsageEvent = {
     agent: input.agent,
@@ -165,7 +210,7 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
     ...(input.taskId ? { taskId: input.taskId } : {}),
     inputTokens,
     outputTokens,
-    ...(costUsd !== undefined ? { costUsd } : {}),
+    ...(cacheTokens > 0 ? { cacheTokens } : {}),
     ts: (input.ts ?? new Date()).toISOString(),
   };
   return sanitizeUsageEvent(event);
@@ -183,13 +228,14 @@ export function aggregateLlmUsage(
   return {
     status,
     message: status === "recorded"
-      ? "LLM usage includes only runner results that emitted whitelisted cost/token counters."
+      ? "LLM usage includes only runner results that emitted whitelisted token counters."
       : "No runner has reported LLM usage counters yet. Claude/test-writer counters depend on SDK output; Codex CLI and Hermes/Ollama do not reliably report usage today.",
     ...total,
     runs: events.length,
     byModel,
     byDay,
     sourceStatus,
+    activeCalls: [...(options.activeCalls ?? [])],
   };
 }
 
@@ -203,14 +249,15 @@ export function aggregateLlmUsageForAgent(
     model: entry.model,
     inputTokens: entry.inputTokens,
     outputTokens: entry.outputTokens,
+    ...(entry.cacheTokens > 0 ? { cacheTokens: entry.cacheTokens } : {}),
     ...(entry.costUsd !== null ? { costUsd: entry.costUsd } : {}),
-    ts: "1970-01-01T00:00:00.000Z",
+    ts: entry.lastActiveAt ?? "1970-01-01T00:00:00.000Z",
   }));
   const total = totalsFor(events);
   return {
     status: byModel.length > 0 ? "recorded" : "not_recorded",
     message: byModel.length > 0
-      ? "LLM usage includes only runner results that emitted whitelisted cost/token counters."
+      ? "LLM usage includes only runner results that emitted whitelisted token counters."
       : sourceReason(agent, undefined),
     ...total,
     runs: byModel.reduce((sum, entry) => sum + entry.runs, 0),
@@ -221,6 +268,7 @@ export function aggregateLlmUsageForAgent(
       status: byModel.length > 0 ? "recorded" : "not_reported",
       ...(byModel.length > 0 ? {} : { reason: sourceReason(agent, undefined) }),
     }],
+    activeCalls: aggregate.activeCalls.filter((call) => call.agent === agent),
   };
 }
 
@@ -280,9 +328,10 @@ function rollupByDay(events: readonly LlmUsageEvent[]): LlmUsageDayRollup[] {
     .sort((a, b) => b.day.localeCompare(a.day));
 }
 
-function totalsFor(events: readonly Pick<LlmUsageEvent, "inputTokens" | "outputTokens" | "costUsd">[]) {
+function totalsFor(events: readonly Pick<LlmUsageEvent, "inputTokens" | "outputTokens" | "cacheTokens" | "costUsd" | "ts">[]) {
   const inputTokens = events.reduce((sum, event) => sum + event.inputTokens, 0);
   const outputTokens = events.reduce((sum, event) => sum + event.outputTokens, 0);
+  const cacheTokens = events.reduce((sum, event) => sum + (event.cacheTokens ?? 0), 0);
   const costEvents = events.filter((event) => typeof event.costUsd === "number");
   const costUsd = costEvents.length > 0
     ? round(costEvents.reduce((sum, event) => sum + (event.costUsd ?? 0), 0), 6)
@@ -290,9 +339,11 @@ function totalsFor(events: readonly Pick<LlmUsageEvent, "inputTokens" | "outputT
   return {
     inputTokens,
     outputTokens,
-    totalTokens: inputTokens + outputTokens,
+    cacheTokens,
+    totalTokens: inputTokens + outputTokens + cacheTokens,
     costUsd,
     costStatus: costEvents.length > 0 ? "recorded" as const : "not_recorded" as const,
+    lastActiveAt: lastActiveAtFor(events),
   };
 }
 
@@ -300,6 +351,7 @@ function sanitizeUsageEvent(event: LlmUsageEvent): LlmUsageEvent | undefined {
   if (!event.agent.trim() || !event.model.trim()) return undefined;
   if (!Number.isInteger(event.inputTokens) || event.inputTokens < 0) return undefined;
   if (!Number.isInteger(event.outputTokens) || event.outputTokens < 0) return undefined;
+  if (event.cacheTokens !== undefined && (!Number.isInteger(event.cacheTokens) || event.cacheTokens < 0)) return undefined;
   if (event.costUsd !== undefined && (!Number.isFinite(event.costUsd) || event.costUsd < 0)) return undefined;
   if (!Number.isFinite(Date.parse(event.ts))) return undefined;
   return {
@@ -309,6 +361,7 @@ function sanitizeUsageEvent(event: LlmUsageEvent): LlmUsageEvent | undefined {
     ...(event.taskId ? { taskId: event.taskId.trim() } : {}),
     inputTokens: event.inputTokens,
     outputTokens: event.outputTokens,
+    ...(event.cacheTokens !== undefined ? { cacheTokens: event.cacheTokens } : {}),
     ...(event.costUsd !== undefined ? { costUsd: round(event.costUsd, 6) } : {}),
     ts: new Date(event.ts).toISOString(),
   };
@@ -325,6 +378,7 @@ function parseUsageLine(line: string): LlmUsageEvent | undefined {
       ...(stringField(parsed, "taskId") ? { taskId: stringField(parsed, "taskId") } : {}),
       inputTokens: integerField(parsed, "inputTokens") ?? -1,
       outputTokens: integerField(parsed, "outputTokens") ?? -1,
+      ...(integerField(parsed, "cacheTokens") !== undefined ? { cacheTokens: integerField(parsed, "cacheTokens") } : {}),
       ...(numberField(parsed, "costUsd") !== undefined ? { costUsd: numberField(parsed, "costUsd") } : {}),
       ts: stringField(parsed, "ts") ?? "",
     });
@@ -360,19 +414,37 @@ function usageSourceFromArrayField(value: unknown, key: string): UsageSource | u
 
 function explicitUsageSource(value: unknown): UsageSource | undefined {
   const usage = explicitUsageJson(value);
-  return usage ? { usage, carrier: usage } : undefined;
+  if (usage) return { usage, carrier: usage };
+  const parsed = explicitUsageText(value);
+  return parsed ? { usage: parsed, carrier: parsed } : undefined;
 }
 
 function hasTokenCounts(record: Record<string, unknown>): boolean {
   const inputTokens = integerField(record, "inputTokens")
     ?? integerField(record, "input_tokens")
     ?? integerField(record, "promptTokens")
-    ?? integerField(record, "prompt_tokens");
+    ?? integerField(record, "prompt_tokens")
+    ?? integerField(record, "prompt_eval_count")
+    ?? integerField(record, "promptEvalCount");
   const outputTokens = integerField(record, "outputTokens")
     ?? integerField(record, "output_tokens")
     ?? integerField(record, "completionTokens")
-    ?? integerField(record, "completion_tokens");
+    ?? integerField(record, "completion_tokens")
+    ?? integerField(record, "eval_count")
+    ?? integerField(record, "evalCount");
   return inputTokens !== undefined && outputTokens !== undefined;
+}
+
+function cacheTokensFromUsage(usage: Record<string, unknown>): number {
+  const explicit = integerField(usage, "cacheTokens")
+    ?? integerField(usage, "cache_tokens");
+  if (explicit !== undefined) return explicit;
+  return [
+    integerField(usage, "cacheReadInputTokens"),
+    integerField(usage, "cache_read_input_tokens"),
+    integerField(usage, "cacheCreationInputTokens"),
+    integerField(usage, "cache_creation_input_tokens"),
+  ].reduce<number>((sum, value) => sum + (value ?? 0), 0);
 }
 
 function explicitUsageJson(value: unknown): Record<string, unknown> | undefined {
@@ -386,6 +458,28 @@ function explicitUsageJson(value: unknown): Record<string, unknown> | undefined 
   } catch {
     return undefined;
   }
+}
+
+function explicitUsageText(value: unknown): Record<string, unknown> | undefined {
+  const stdout = isRecord(value) && typeof value.stdout === "string" ? value.stdout : "";
+  const stderr = isRecord(value) && typeof value.stderr === "string" ? value.stderr : "";
+  const text = `${stdout}\n${stderr}`;
+  const inputTokens = tokenCountFromText(text, /(?:input|prompt)\s+tokens?\D+([\d,]+)/i);
+  const outputTokens = tokenCountFromText(text, /(?:output|completion)\s+tokens?\D+([\d,]+)/i);
+  if (inputTokens === undefined || outputTokens === undefined) return undefined;
+  const model = text.match(/\bmodel(?:\s+id)?\s*[:=]\s*([A-Za-z0-9_.:\/-]+)/i)?.[1];
+  return {
+    inputTokens,
+    outputTokens,
+    ...(model ? { model } : {}),
+  };
+}
+
+function tokenCountFromText(text: string, pattern: RegExp): number | undefined {
+  const match = text.match(pattern);
+  if (!match?.[1]) return undefined;
+  const parsed = Number.parseInt(match[1].replace(/,/g, ""), 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
 }
 
 function firstUsageSource(...values: Array<UsageSource | undefined>): UsageSource | undefined {
@@ -411,6 +505,14 @@ function numberField(record: unknown, key: string): number | undefined {
 function integerField(record: unknown, key: string): number | undefined {
   const value = numberField(record, key);
   return value !== undefined && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+function lastActiveAtFor(events: readonly Pick<LlmUsageEvent, "ts">[]): string | null {
+  let latest = "";
+  for (const event of events) {
+    if (event.ts > latest) latest = event.ts;
+  }
+  return latest || null;
 }
 
 function round(value: number, digits: number): number {

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -76,50 +76,68 @@ describe("BoardView — rich-mix board (open stream)", () => {
       ...richBoard,
       llmUsage: {
         status: "recorded",
-        inputTokens: 100,
-        outputTokens: 40,
-        totalTokens: 140,
-        costUsd: 0.0123,
-        costStatus: "recorded",
-        runs: 1,
-        message: "LLM usage includes only runner results that emitted whitelisted cost/token counters.",
-        byModel: [],
+        inputTokens: 48_000,
+        outputTokens: 9_000,
+        cacheTokens: 2_000,
+        totalTokens: 59_000,
+        costUsd: null,
+        costStatus: "not_recorded",
+        runs: 12,
+        lastActiveAt: "2026-05-31T10:28:00.000Z",
+        message: "LLM usage includes only runner results that emitted whitelisted token counters.",
+        byModel: [
+          {
+            agent: "claude",
+            model: "claude-sonnet-4-5",
+            inputTokens: 48_000,
+            outputTokens: 9_000,
+            cacheTokens: 2_000,
+            totalTokens: 59_000,
+            costUsd: null,
+            costStatus: "not_recorded",
+            runs: 12,
+            lastActiveAt: "2026-05-31T10:28:00.000Z",
+          },
+        ],
         byDay: [
           {
             day: "2026-05-31",
-            inputTokens: 100,
-            outputTokens: 40,
-            totalTokens: 140,
-            costUsd: 0.0123,
-            costStatus: "recorded",
-            runs: 1,
-            byModel: [
-              {
-                agent: "claude",
-                model: "claude-sonnet-4-5",
-                inputTokens: 100,
-                outputTokens: 40,
-                totalTokens: 140,
-                costUsd: 0.0123,
-                costStatus: "recorded",
-                runs: 1,
-              },
-            ],
+            inputTokens: 48_000,
+            outputTokens: 9_000,
+            cacheTokens: 2_000,
+            totalTokens: 59_000,
+            costUsd: null,
+            costStatus: "not_recorded",
+            runs: 12,
+            lastActiveAt: "2026-05-31T10:28:00.000Z",
+            byModel: [],
           },
         ],
         sourceStatus: [
           { agent: "claude", status: "recorded" },
-          { agent: "codex", status: "not_reported", reason: "Codex usage is not reported by the CLI yet." },
+          { agent: "codex", status: "not_reported", reason: "Codex CLI does not report usage." },
+        ],
+        activeCalls: [
+          {
+            id: "call-1",
+            agent: "claude",
+            model: "claude-sonnet-4-5",
+            taskId: "task-1",
+            startedAt: "2026-05-31T10:29:00.000Z",
+          },
         ],
       },
     };
-    const { getByRole, getByText } = render(<BoardView board={board} status="open" />);
+    const { getAllByText, getByRole, getByText } = render(<BoardView board={board} status="open" />);
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
-    expect(getByText("2026-05-31")).toBeTruthy();
-    expect(getByText("140 tokens")).toBeTruthy();
-    expect(getByText("claude-sonnet-4-5")).toBeTruthy();
-    expect(getByText("$0.0123")).toBeTruthy();
-    expect(getByText("Codex usage is not reported by the CLI yet.")).toBeTruthy();
+    expect(getByText("12 calls in board window")).toBeTruthy();
+    expect(getByText("59K tokens total")).toBeTruthy();
+    expect(getAllByText("claude · claude-sonnet-4-5").length).toBeGreaterThan(0);
+    expect(getByText("12 calls")).toBeTruthy();
+    expect(getByText("48K in")).toBeTruthy();
+    expect(getByText("9K out")).toBeTruthy();
+    expect(getByText("59K total")).toBeTruthy();
+    expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
   });
 
   test("renders a plain-language usage explanation when no source emits counters", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -382,10 +382,11 @@ function formatClock(iso: string | undefined): string {
 
 function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
   const latestDay = usage?.byDay?.[0];
-  const models = latestDay?.byModel?.slice(0, 4) ?? [];
+  const models = (usage?.byModel?.length ? usage.byModel : latestDay?.byModel ?? []).slice(0, 5);
   const missingSources = (usage?.sourceStatus ?? [])
     .filter((entry) => entry.status === "not_reported")
-    .slice(0, Math.max(0, 4 - models.length));
+    .slice(0, Math.max(0, 5 - models.length));
+  const activeCalls = usage?.activeCalls ?? [];
   const hasRows = models.length > 0 || missingSources.length > 0;
   const emptyMessage = usage?.message
     ?? "No runner has reported LLM usage counters yet. Claude/test-writer counters depend on SDK output; Codex CLI and Hermes/Ollama do not reliably report usage today.";
@@ -394,11 +395,19 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
       <div className="hm-llm-usage-head">
         <div>
           <span className="hm-kicker">LLM usage</span>
-          <strong>{latestDay?.day ?? "usage not reported"}</strong>
+          <strong>{usage?.status === "recorded" ? `${formatNumber(usage.runs)} calls in board window` : "usage not reported"}</strong>
         </div>
         <span className="hm-llm-usage-total">
-          {usage?.status === "recorded" ? `${formatNumber(latestDay?.totalTokens ?? 0)} tokens` : "not reported"}
+          {usage?.status === "recorded" ? `${formatCompactNumber(usage.totalTokens)} tokens total` : "not reported"}
         </span>
+      </div>
+      <div className="hm-llm-usage-active">
+        <span>What's running now</span>
+        {activeCalls.length > 0 ? (
+          <strong>{activeCalls.map((call) => `${call.agent} · ${call.model}`).join(" · ")}</strong>
+        ) : (
+          <strong>No in-flight LLM calls</strong>
+        )}
       </div>
       <div className="hm-llm-usage-grid">
         {hasRows ? (
@@ -406,11 +415,13 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
             {models.map((entry) => (
               <div className="hm-llm-usage-row" key={`${entry.agent}:${entry.model}`}>
                 <span>
-                  <strong>{entry.agent}</strong>
-                  <small>{entry.model}</small>
+                  <strong>{entry.agent} · {entry.model}</strong>
+                  <small>Last active {formatRelativeTime(entry.lastActiveAt)}</small>
                 </span>
-                <span>{formatNumber(entry.totalTokens)} tok</span>
-                <span>{entry.costStatus === "recorded" && entry.costUsd !== null ? `$${entry.costUsd.toFixed(4)}` : "cost not reported"}</span>
+                <span>{formatNumber(entry.runs)} calls</span>
+                <span>{formatCompactNumber(entry.inputTokens)} in</span>
+                <span>{formatCompactNumber(entry.outputTokens)} out</span>
+                <span>{formatCompactNumber(entry.totalTokens)} total</span>
               </div>
             ))}
             {missingSources.map((entry) => (
@@ -420,7 +431,8 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
                   <small>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</small>
                 </span>
                 <span>not reported</span>
-                <span>no live metric</span>
+                <span>0 calls</span>
+                <span>0 tokens</span>
               </div>
             ))}
           </>
@@ -434,4 +446,22 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat("en-US").format(value);
+}
+
+function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return "last active unknown";
+  const time = Date.parse(iso);
+  if (!Number.isFinite(time)) return "last active unknown";
+  const seconds = Math.max(0, Math.round((Date.now() - time) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
 }

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -19,20 +19,24 @@ export interface LlmUsageModelRollup {
   model: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens?: number;
   totalTokens: number;
   costUsd: number | null;
   costStatus: "recorded" | "not_recorded";
   runs: number;
+  lastActiveAt?: string | null;
 }
 
 export interface LlmUsageDayRollup {
   day: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens?: number;
   totalTokens: number;
   costUsd: number | null;
   costStatus: "recorded" | "not_recorded";
   runs: number;
+  lastActiveAt?: string | null;
   byModel: LlmUsageModelRollup[];
 }
 
@@ -42,18 +46,30 @@ export interface LlmUsageSourceStatus {
   reason?: string;
 }
 
+export interface LlmUsageActiveCall {
+  id: string;
+  agent: string;
+  model: string;
+  startedAt: string;
+  runId?: string;
+  taskId?: string;
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
   message?: string;
   inputTokens: number;
   outputTokens: number;
+  cacheTokens?: number;
   totalTokens: number;
   costUsd: number | null;
   costStatus: "recorded" | "not_recorded";
   runs: number;
+  lastActiveAt?: string | null;
   byModel: LlmUsageModelRollup[];
   byDay: LlmUsageDayRollup[];
   sourceStatus?: LlmUsageSourceStatus[];
+  activeCalls?: LlmUsageActiveCall[];
 }
 
 export interface MonitorEvent {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -392,10 +392,22 @@ body { margin: 0; }
 }
 .hm-llm-usage-total,
 .hm-llm-usage-row,
+.hm-llm-usage-active,
 .hm-llm-usage-empty {
   font-family: var(--font-mono);
   font-size: 11.5px;
   color: var(--hm-muted);
+}
+.hm-llm-usage-active {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 6px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-llm-usage-active strong {
+  color: var(--hm-ink);
+  text-align: right;
 }
 .hm-llm-usage-grid {
   display: grid;
@@ -404,6 +416,7 @@ body { margin: 0; }
 .hm-llm-usage-row {
   padding-top: 6px;
   border-top: 1px solid var(--hm-line-soft);
+  flex-wrap: wrap;
 }
 .hm-llm-usage-row--muted strong {
   color: var(--hm-muted);

--- a/services/slack-operator/src/claude-task-runner.ts
+++ b/services/slack-operator/src/claude-task-runner.ts
@@ -23,7 +23,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
-import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
+import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 import {
   budgetGate,
@@ -54,6 +54,7 @@ export interface ClaudeTaskRunnerConfig {
   command?: string;
   args: string[];
   cwd?: string;
+  model?: string;
   pollIntervalMs: number;
   timeoutMs: number;
   outputTailBytes: number;
@@ -112,6 +113,7 @@ export function parseClaudeTaskRunnerConfig(env: NodeJS.ProcessEnv = process.env
     ...(env.CLAUDE_TASK_RUNNER_COMMAND ? { command: env.CLAUDE_TASK_RUNNER_COMMAND } : {}),
     args: parseArgs(env.CLAUDE_TASK_RUNNER_ARGS),
     ...(env.CLAUDE_TASK_RUNNER_CWD ? { cwd: env.CLAUDE_TASK_RUNNER_CWD } : {}),
+    ...(env.CLAUDE_TASK_RUNNER_MODEL ? { model: env.CLAUDE_TASK_RUNNER_MODEL } : {}),
     pollIntervalMs: positiveInt(env.CLAUDE_TASK_RUNNER_POLL_INTERVAL_MS, 10_000),
     timeoutMs: positiveInt(env.CLAUDE_TASK_RUNNER_TIMEOUT_MS, 30 * 60_000),
     outputTailBytes: positiveInt(env.CLAUDE_TASK_RUNNER_OUTPUT_TAIL_BYTES, 12_000),
@@ -186,10 +188,17 @@ export async function runClaudeTaskRunnerOnce(
 
   await heartbeat(config, "running", `${taskAgentLabel(config.agent)} runner claimed ${taskLabel(claimed)}.`, deps.now, claimed.id);
 
+  const endLlmUsageCall = beginLlmUsageCall({
+    agent: config.agent,
+    model: config.model,
+    taskId: claimed.id,
+    ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
+  });
   try {
     const result = await executor(claimed, config, { mode });
     await recordLlmUsageFromResult({
       agent: config.agent,
+      ...(config.model ? { model: config.model } : {}),
       taskId: claimed.id,
       ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
       result,
@@ -221,6 +230,8 @@ export async function runClaudeTaskRunnerOnce(
     const task = await failCodexTask(claimed.id, { path: config.path, failureReason: reason });
     await heartbeat(config, "error", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
+  } finally {
+    endLlmUsageCall();
   }
 }
 

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
-import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
+import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 import type { CodexTask } from "./codex-task-queue.js";
 import {
@@ -19,6 +19,7 @@ export interface CodexTaskRunnerConfig {
   command?: string;
   args: string[];
   cwd?: string;
+  model?: string;
   pollIntervalMs: number;
   timeoutMs: number;
   outputTailBytes: number;
@@ -56,6 +57,7 @@ export function parseCodexTaskRunnerConfig(env: NodeJS.ProcessEnv = process.env)
     ...(env.CODEX_TASK_RUNNER_COMMAND ? { command: env.CODEX_TASK_RUNNER_COMMAND } : {}),
     args: parseArgs(env.CODEX_TASK_RUNNER_ARGS),
     ...(env.CODEX_TASK_RUNNER_CWD ? { cwd: env.CODEX_TASK_RUNNER_CWD } : {}),
+    ...(env.CODEX_TASK_RUNNER_MODEL ? { model: env.CODEX_TASK_RUNNER_MODEL } : {}),
     pollIntervalMs: positiveInt(env.CODEX_TASK_RUNNER_POLL_INTERVAL_MS, 10_000),
     timeoutMs: positiveInt(env.CODEX_TASK_RUNNER_TIMEOUT_MS, 30 * 60_000),
     outputTailBytes: positiveInt(env.CODEX_TASK_RUNNER_OUTPUT_TAIL_BYTES, 12_000),
@@ -102,10 +104,17 @@ export async function runCodexTaskRunnerOnce(
     claimed.id
   );
 
+  const endLlmUsageCall = beginLlmUsageCall({
+    agent: "codex",
+    model: config.model ?? "Codex CLI model not reported",
+    taskId: claimed.id,
+    ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
+  });
   try {
     const result = await executor(claimed, config);
     await recordLlmUsageFromResult({
       agent: "codex",
+      ...(config.model ? { model: config.model } : {}),
       taskId: claimed.id,
       ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
       result,
@@ -146,6 +155,8 @@ export async function runCodexTaskRunnerOnce(
     });
     await updateRunnerHeartbeat(config, "error", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
+  } finally {
+    endLlmUsageCall();
   }
 }
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -1176,7 +1176,14 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       try {
         // replyContext carries the recent thread oldest-first so the
         // model sees the conversation in natural order rather than reversed.
-        const llmText = await generateHermesReply(replyContext, { apiKey, baseUrl, model });
+        const llmText = await generateHermesReply(replyContext, {
+          apiKey,
+          baseUrl,
+          model,
+          taskId: operatorMessage.id,
+          runId: operatorMessage.relatedCorrelationId
+            ?? (operatorMessage.relatedPr ? `${operatorMessage.relatedPr.repo}#${operatorMessage.relatedPr.number}` : operatorMessage.id),
+        });
         if (llmText) {
           text = llmText;
         } else {
@@ -2711,7 +2718,14 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
     const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";
     if (apiKey) {
       try {
-        const llmText = await generateHermesBoardNarration(narrationContext, { apiKey, baseUrl, model, timeoutMs: 6_000 });
+        const llmText = await generateHermesBoardNarration(narrationContext, {
+          apiKey,
+          baseUrl,
+          model,
+          timeoutMs: 6_000,
+          taskId: "monitor-board-narration",
+          runId: decision.signature,
+        });
         if (llmText) text = llmText;
       } catch (error) {
         logger.warn({ err: error }, "monitor_collaboration_board_narration_llm_threw");

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -22,6 +22,7 @@
  */
 
 import type { CollaborationMessage } from "./monitor-collab.js";
+import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 export const HERMES_PERSONA = `You are Hermes, the board orchestrator for the Averray platform.
 
@@ -119,6 +120,11 @@ export interface GenerateHermesReplyOptions {
   timeoutMs?: number;
   /** Injection point so tests don't need to hit the network. */
   fetchFn?: typeof fetch;
+  /** Optional usage identity for durable LLM activity events. */
+  runId?: string;
+  taskId?: string;
+  /** Test/ops override for the durable usage JSONL path. */
+  usageLogPath?: string;
 }
 
 export interface HermesWhyTraceContext {
@@ -170,6 +176,12 @@ export async function generateHermesReply(
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const endLlmUsageCall = beginLlmUsageCall({
+    agent: "hermes",
+    model,
+    ...(options.runId ? { runId: options.runId } : {}),
+    ...(options.taskId ? { taskId: options.taskId } : {}),
+  });
   try {
     const response = await fetchImpl(url, {
       method: "POST",
@@ -182,12 +194,20 @@ export async function generateHermesReply(
     });
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
+    await recordLlmUsageFromResult({
+      agent: "hermes",
+      model,
+      ...(options.runId ? { runId: options.runId } : {}),
+      ...(options.taskId ? { taskId: options.taskId } : {}),
+      result: json,
+    }, options.usageLogPath ? { path: options.usageLogPath } : {}).catch(() => undefined);
     const text = extractReplyText(json);
     return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
   } catch {
     return null;
   } finally {
     clearTimeout(timer);
+    endLlmUsageCall();
   }
 }
 
@@ -215,6 +235,12 @@ export async function generateHermesBoardNarration(
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const endLlmUsageCall = beginLlmUsageCall({
+    agent: "hermes",
+    model,
+    ...(options.runId ? { runId: options.runId } : {}),
+    ...(options.taskId ? { taskId: options.taskId } : {}),
+  });
   try {
     const response = await fetchImpl(url, {
       method: "POST",
@@ -227,12 +253,20 @@ export async function generateHermesBoardNarration(
     });
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
+    await recordLlmUsageFromResult({
+      agent: "hermes",
+      model,
+      ...(options.runId ? { runId: options.runId } : {}),
+      ...(options.taskId ? { taskId: options.taskId } : {}),
+      result: json,
+    }, options.usageLogPath ? { path: options.usageLogPath } : {}).catch(() => undefined);
     const text = extractReplyText(json);
     return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
   } catch {
     return null;
   } finally {
     clearTimeout(timer);
+    endLlmUsageCall();
   }
 }
 

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -19,7 +19,12 @@
 // SSE `board.snapshot` event carries.
 
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
-import { aggregateLlmUsage, type LlmUsageAggregate, type LlmUsageEvent } from "@avg/averray-mcp/llm-usage";
+import {
+  aggregateLlmUsage,
+  listActiveLlmUsageCalls,
+  type LlmUsageAggregate,
+  type LlmUsageEvent,
+} from "@avg/averray-mcp/llm-usage";
 import type {
   HermesBoardCardSnapshot,
   HermesBoardSnapshot,
@@ -514,6 +519,7 @@ function usageEvents(value: unknown): LlmUsageEvent[] {
       if (!agent || !model || !ts || inputTokens === undefined || outputTokens === undefined) return undefined;
       if (!Number.isInteger(inputTokens) || !Number.isInteger(outputTokens)) return undefined;
       const costUsd = asFiniteNumber(event.costUsd);
+      const cacheTokens = asFiniteNumber(event.cacheTokens);
       return {
         agent,
         model,
@@ -521,6 +527,7 @@ function usageEvents(value: unknown): LlmUsageEvent[] {
         ...(asString(event.taskId) ? { taskId: asString(event.taskId) } : {}),
         inputTokens,
         outputTokens,
+        ...(cacheTokens !== undefined && Number.isInteger(cacheTokens) ? { cacheTokens } : {}),
         ...(costUsd !== undefined ? { costUsd } : {}),
         ts,
       };
@@ -1326,6 +1333,8 @@ export function buildV2BoardSnapshot(
     cards: [...cards, ...taskCards],
     at: snapshotAt.toISOString(),
     repo: opts.repo ?? "",
-    llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents)),
+    llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents), {
+      activeCalls: listActiveLlmUsageCalls(),
+    }),
   };
 }

--- a/test/unit/claude-task-runner.test.ts
+++ b/test/unit/claude-task-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -144,6 +144,41 @@ describe("claude task runner", () => {
     await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
       runnerId: "test-claude-runner",
       status: "completed",
+    });
+  });
+
+  it("records Claude SDK usage counters for completed tasks", async () => {
+    const path = await tempQueuePath();
+    const usagePath = join(path.replace(/tasks\.json$/, ""), "llm-usage.jsonl");
+    const previousUsagePath = process.env.LLM_USAGE_LOG_PATH;
+    process.env.LLM_USAGE_LOG_PATH = usagePath;
+    const id = await approvedClaudeTask(path);
+
+    const result = await runClaudeTaskRunnerOnce(config(path, { model: "claude-sonnet-4-5" }), {
+      executor: async () => ({
+        exitCode: 0,
+        stdout: "opened PR",
+        stderr: "",
+        summary: "opened PR",
+        usage: {
+          input_tokens: 120,
+          output_tokens: 30,
+          cache_read_input_tokens: 15,
+        },
+      }),
+      log: () => {},
+    });
+    if (previousUsagePath === undefined) delete process.env.LLM_USAGE_LOG_PATH;
+    else process.env.LLM_USAGE_LOG_PATH = previousUsagePath;
+
+    expect(result.status).toBe("completed");
+    await expect(readFile(usagePath, "utf8").then((line) => JSON.parse(line))).resolves.toMatchObject({
+      agent: "claude",
+      model: "claude-sonnet-4-5",
+      taskId: id,
+      inputTokens: 120,
+      outputTokens: 30,
+      cacheTokens: 15,
     });
   });
 

--- a/test/unit/llm-usage.test.ts
+++ b/test/unit/llm-usage.test.ts
@@ -24,7 +24,8 @@ describe("LLM usage tracker", () => {
           usage: {
             input_tokens: 100,
             output_tokens: 25,
-            cost_usd: 0.0123456,
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 5,
           },
         },
       }, { path });
@@ -36,7 +37,7 @@ describe("LLM usage tracker", () => {
         taskId: "task-1",
         inputTokens: 100,
         outputTokens: 25,
-        costUsd: 0.012346,
+        cacheTokens: 15,
         ts: "2026-05-31T12:00:00.000Z",
       });
       expect(JSON.parse((await readFile(path, "utf8")).trim())).toEqual(event);
@@ -45,7 +46,7 @@ describe("LLM usage tracker", () => {
     }
   });
 
-  it("aggregates per agent/model/day and leaves bundled cost as not_recorded", () => {
+  it("aggregates per agent/model/day with call counts, cache tokens, and last-active time", () => {
     const aggregate = aggregateLlmUsage([
       {
         agent: "codex",
@@ -61,7 +62,7 @@ describe("LLM usage tracker", () => {
         taskId: "claude-task",
         inputTokens: 20,
         outputTokens: 7,
-        costUsd: 0.02,
+        cacheTokens: 4,
         ts: "2026-05-31T02:00:00.000Z",
       },
       {
@@ -70,7 +71,6 @@ describe("LLM usage tracker", () => {
         taskId: "claude-task-2",
         inputTokens: 3,
         outputTokens: 2,
-        costUsd: 0.01,
         ts: "2026-06-01T02:00:00.000Z",
       },
     ]);
@@ -79,21 +79,25 @@ describe("LLM usage tracker", () => {
       status: "recorded",
       inputTokens: 33,
       outputTokens: 14,
-      totalTokens: 47,
-      costUsd: 0.03,
-      costStatus: "recorded",
+      cacheTokens: 4,
+      totalTokens: 51,
+      costUsd: null,
+      costStatus: "not_recorded",
       runs: 3,
+      lastActiveAt: "2026-06-01T02:00:00.000Z",
     });
     expect(aggregate.byModel.find((entry) => entry.agent === "codex")).toMatchObject({
       model: "gpt-5-codex",
       totalTokens: 15,
+      runs: 1,
+      lastActiveAt: "2026-05-31T01:00:00.000Z",
       costUsd: null,
       costStatus: "not_recorded",
     });
     expect(aggregate.byDay.map((day) => day.day)).toEqual(["2026-06-01", "2026-05-31"]);
     expect(aggregate.byDay.find((day) => day.day === "2026-05-31")).toMatchObject({
-      totalTokens: 42,
-      costUsd: 0.02,
+      totalTokens: 46,
+      costUsd: null,
     });
     expect(aggregate.sourceStatus.find((entry) => entry.agent === "claude")).toMatchObject({
       status: "recorded",
@@ -104,7 +108,7 @@ describe("LLM usage tracker", () => {
     });
   });
 
-  it("extracts Claude SDK-style message usage and total cost aliases", () => {
+  it("extracts Claude SDK-style message usage and cache token aliases", () => {
     const event = llmUsageEventFromResult({
       agent: "claude",
       taskId: "task-sdk",
@@ -117,8 +121,8 @@ describe("LLM usage tracker", () => {
             usage: {
               input_tokens: 75,
               output_tokens: 18,
+              cache_read_input_tokens: 11,
             },
-            total_cost_usd: 0.0042,
           },
         ],
       },
@@ -130,7 +134,53 @@ describe("LLM usage tracker", () => {
       taskId: "task-sdk",
       inputTokens: 75,
       outputTokens: 18,
-      costUsd: 0.0042,
+      cacheTokens: 11,
+      ts: "2026-05-31T12:00:00.000Z",
+    });
+  });
+
+  it("extracts Ollama response token counts", () => {
+    const event = llmUsageEventFromResult({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      runId: "chat-1",
+      ts: new Date("2026-05-31T12:00:00.000Z"),
+      result: {
+        model: "deepseek-v4-pro:cloud",
+        response: "Watching it.",
+        prompt_eval_count: 44,
+        eval_count: 12,
+      },
+    });
+
+    expect(event).toEqual({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      runId: "chat-1",
+      inputTokens: 44,
+      outputTokens: 12,
+      ts: "2026-05-31T12:00:00.000Z",
+    });
+  });
+
+  it("extracts best-effort token counts from Codex CLI output when present", () => {
+    const event = llmUsageEventFromResult({
+      agent: "codex",
+      model: "gpt-5-codex",
+      taskId: "codex-task",
+      ts: new Date("2026-05-31T12:00:00.000Z"),
+      result: {
+        stdout: "Model: gpt-5-codex\nInput tokens: 1,200\nOutput tokens: 340\n",
+        stderr: "",
+      },
+    });
+
+    expect(event).toEqual({
+      agent: "codex",
+      model: "gpt-5-codex",
+      taskId: "codex-task",
+      inputTokens: 1200,
+      outputTokens: 340,
       ts: "2026-05-31T12:00:00.000Z",
     });
   });
@@ -144,7 +194,7 @@ describe("LLM usage tracker", () => {
     });
     expect(aggregate.sourceStatus.find((entry) => entry.agent === "codex")).toMatchObject({
       status: "not_reported",
-      reason: "Codex usage is not reported by the CLI yet.",
+      reason: "Codex CLI does not report usage.",
     });
   });
 

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -550,6 +553,42 @@ describe("generateHermesReply", () => {
       fetchFn: fetchFn as typeof fetch,
     });
     expect(capturedModel).toBe("gpt-oss-120b");
+  });
+
+  it("records Ollama token counters from Hermes chat responses", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-hermes-usage-"));
+    try {
+      const usageLogPath = join(dir, "llm-usage.jsonl");
+      const fetchFn = async () =>
+        jsonResponse({
+          model: "deepseek-v4-pro:cloud",
+          choices: [{ message: { content: "Watching it." } }],
+          prompt_eval_count: 44,
+          eval_count: 12,
+        });
+
+      const text = await generateHermesReply(baseContext(), {
+        apiKey,
+        baseUrl,
+        model: "deepseek-v4-pro:cloud",
+        runId: "chat-correlation-1",
+        taskId: "chat-message-1",
+        usageLogPath,
+        fetchFn: fetchFn as typeof fetch,
+      });
+
+      expect(text).toContain("Watching it.");
+      await expect(readFile(usageLogPath, "utf8").then((line) => JSON.parse(line))).resolves.toMatchObject({
+        agent: "hermes",
+        model: "deepseek-v4-pro:cloud",
+        runId: "chat-correlation-1",
+        taskId: "chat-message-1",
+        inputTokens: 44,
+        outputTokens: 12,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("strips a trailing slash from baseUrl before appending the path", async () => {


### PR DESCRIPTION
## What changed & why

- Capture token/call usage from Claude and test-writer runner results, Hermes/Ollama chat responses, and best-effort Codex CLI output when token lines are present.
- Store durable usage JSONL events with agent, model, run/task identity, input tokens, output tokens, optional cache tokens, and timestamp only. Prompts, secrets, and pricing data are not copied.
- Feed active in-flight calls plus durable rollups into the monitor board so the LLM usage panel shows model, agent, calls, token totals, last-active time, and honest not-reported source lines.

## Affected surfaces
- [x] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] npm run typecheck
- [x] npm test
- [ ] docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config (only if ops/Docker/compose touched)

## Rollout / rollback

No ops, compose, migration, Hermes pin, or secret/config changes. Rollback is reverting this PR; missing usage data remains truthfully shown as not reported.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power
- [x] No secrets committed/printed/logged
- [x] Updated AGENTS.md / affected docs if this changes how agents work

## Known limits / follow-ups

- Codex CLI usage remains best-effort: if the CLI emits no token counters, the panel shows the explicit Codex CLI does not report usage line.
- No routing, budget, cost, pricing, or dollar logic is included in this slice.