### PR TITLE
Group 1: wire the LanesBar filter chips (truth-boundary)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -266,3 +266,29 @@ describe("BoardView — degraded + transient states", () => {
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
   });
 });
+
+describe("BoardView — filter chips (G1)", () => {
+  test("clicking a filter chip narrows the visible board to that state", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    const view = within(container);
+    // Baseline: the action card is visible.
+    expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+
+    // Click the "Done" filter chip (a real button now).
+    const doneChip = Array.from(container.querySelectorAll(".hm-filter-chip"))
+      .find((c) => c.textContent?.includes("Done")) as HTMLElement;
+    expect(doneChip.tagName).toBe("BUTTON");
+    fireEvent.click(doneChip);
+
+    // The live action card is filtered out; done-lane (CLOSED) cards remain.
+    expect(view.queryByText("Allow operator override of agent claim-stake floor")).toBeNull();
+    expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
+    expect(doneChip.getAttribute("aria-pressed")).toBe("true");
+
+    // Clicking "All" restores the full board.
+    const allChip = Array.from(container.querySelectorAll(".hm-filter-chip"))
+      .find((c) => c.textContent?.includes("All")) as HTMLElement;
+    fireEvent.click(allChip);
+    expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -18,7 +18,7 @@
 //   <KeyboardOverlay />          when ? is pressed
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { deriveBoardState, type BoardMode } from "../lib/monitor/board-state.js";
+import { deriveBoardState, matchesBoardFilter, type BoardMode, type BoardFilter } from "../lib/monitor/board-state.js";
 import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
@@ -165,6 +165,7 @@ export function BoardView({
 
   // ── view state ──────────────────────────────────────────────────
   const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<BoardFilter>("all");
   const [boardFocusId, setBoardFocusId] = useState<string | null>(null);
   const [overlayOpen, setOverlayOpen] = useState(false);
   const [askToken, setAskToken] = useState(0);
@@ -204,14 +205,27 @@ export function BoardView({
     // alwaysOpen is derived from the stable onCreateTask prop.
   }, [state.mode, state.grouped, onCreateTask]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Search filters what's shown + focusable (not the KPI counts).
+  // Search + filter chip narrow what's shown + focusable (not the KPI counts —
+  // the chip counts stay live off the whole board).
   const q = query.trim().toLowerCase();
   const displayGrouped = useMemo(() => {
-    if (!q) return state.grouped;
+    if (!q && filter === "all") return state.grouped;
     const out = {} as Record<LaneId, BoardCard[]>;
-    for (const lane of LANES) out[lane] = (state.grouped[lane] ?? []).filter((c) => matchesQuery(c, q));
+    for (const lane of LANES) {
+      out[lane] = (state.grouped[lane] ?? []).filter(
+        (c) => (!q || matchesQuery(c, q)) && matchesBoardFilter(c, filter),
+      );
+    }
     return out;
-  }, [state.grouped, q]);
+  }, [state.grouped, q, filter]);
+
+  // A non-"all" filter reveals every lane that has a match, regardless of the
+  // operator's manual collapse state, so chip results are never hidden. Clearing
+  // back to "all" restores the normal expansion.
+  const effectiveExpanded = useMemo<ReadonlySet<LaneId>>(() => {
+    if (filter === "all") return expanded;
+    return new Set(LANES.filter((lane) => (displayGrouped[lane]?.length ?? 0) > 0));
+  }, [filter, expanded, displayGrouped]);
 
   const orderedCards = useMemo<BoardCard[]>(
     () => LANES.flatMap((lane) => displayGrouped[lane] ?? []),
@@ -310,11 +324,13 @@ export function BoardView({
             searchValue={query}
             onSearchChange={setQuery}
             searchInputRef={searchInputRef}
+            activeFilter={filter}
+            onFilterChange={setFilter}
           />
           <LlmUsagePanel usage={board?.llmUsage} />
           <Board
             grouped={displayGrouped}
-            expanded={expanded}
+            expanded={effectiveExpanded}
             onToggleLane={onToggleLane}
             renderLaneHeader={
               onCreateTask

--- a/packages/monitor-ui/src/components/LanesBar.test.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.test.tsx
@@ -61,10 +61,39 @@ describe("LanesBar", () => {
     expect(chips[5].querySelector(".ct")?.textContent).toBe("9");
   });
 
-  test("filter chips are non-interactive in M3'", () => {
+  test("read-only fallback (no onFilterChange): chips are count-only, aria-disabled", () => {
     const { container } = render(<LanesBar counts={counts} mode="calm" />);
     const chip = container.querySelector(".hm-filter-chip") as HTMLElement;
     expect(chip.getAttribute("aria-disabled")).toBe("true");
+    expect(chip.tagName).toBe("SPAN");
+  });
+
+  test("interactive chips: clicking a chip calls onFilterChange with its filter key", () => {
+    const onFilterChange = vi.fn();
+    const { container } = render(
+      <LanesBar counts={counts} mode="calm" activeFilter="all" onFilterChange={onFilterChange} />,
+    );
+    const chips = container.querySelectorAll(".hm-filter-chip");
+    // Each chip is a real button (not aria-disabled) and reports its filter key.
+    expect((chips[0] as HTMLElement).tagName).toBe("BUTTON");
+    expect((chips[0] as HTMLElement).getAttribute("aria-disabled")).toBeNull();
+    const keys = ["all", "blocked", "review", "ready", "running", "done"] as const;
+    keys.forEach((key, i) => {
+      fireEvent.click(chips[i] as HTMLElement);
+      expect(onFilterChange).toHaveBeenLastCalledWith(key);
+    });
+  });
+
+  test("interactive chips: the active chip reflects activeFilter (aria-pressed)", () => {
+    const { container } = render(
+      <LanesBar counts={counts} mode="calm" activeFilter="review" onFilterChange={vi.fn()} />,
+    );
+    const chips = Array.from(container.querySelectorAll(".hm-filter-chip")) as HTMLElement[];
+    const review = chips.find((c) => c.textContent?.includes("Review"))!;
+    expect(review.className).toContain("is-active");
+    expect(review.getAttribute("aria-pressed")).toBe("true");
+    // The All chip is no longer active.
+    expect(chips[0].className).not.toContain("is-active");
   });
 
   test("shows the urgency-sort label", () => {

--- a/packages/monitor-ui/src/components/LanesBar.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.tsx
@@ -13,7 +13,7 @@
 // non-interactive. The tip is derived from the board mode.
 
 import type { Ref } from "react";
-import type { KPICounts, BoardMode } from "../lib/monitor/board-state.js";
+import type { KPICounts, BoardMode, BoardFilter } from "../lib/monitor/board-state.js";
 
 const TIPS: Record<BoardMode, string> = {
   action: "· focus on the lane that needs you",
@@ -30,17 +30,29 @@ export type LanesBarProps = {
   onSearchChange?: (value: string) => void;
   /** Ref to the search input so `/` can focus it (M10'). */
   searchInputRef?: Ref<HTMLInputElement>;
+  /** Active filter chip. Defaults to "all". */
+  activeFilter?: BoardFilter;
+  /** Filter change handler. When omitted the chips render count-only (read-only). */
+  onFilterChange?: (filter: BoardFilter) => void;
 };
 
-export function LanesBar({ counts, mode, searchValue = "", onSearchChange, searchInputRef }: LanesBarProps) {
+export function LanesBar({
+  counts,
+  mode,
+  searchValue = "",
+  onSearchChange,
+  searchInputRef,
+  activeFilter = "all",
+  onFilterChange,
+}: LanesBarProps) {
   const tip = TIPS[mode];
-  const filters: Array<[label: string, count: number]> = [
-    ["All", counts.total],
-    ["Blocked", counts.blocked],
-    ["Review", counts.review],
-    ["Ready", counts.queue],
-    ["Running", counts.checking],
-    ["Done", counts.done],
+  const filters: Array<[label: string, count: number, key: BoardFilter]> = [
+    ["All", counts.total, "all"],
+    ["Blocked", counts.blocked, "blocked"],
+    ["Review", counts.review, "review"],
+    ["Ready", counts.queue, "ready"],
+    ["Running", counts.checking, "running"],
+    ["Done", counts.done, "done"],
   ];
 
   return (
@@ -68,11 +80,26 @@ export function LanesBar({ counts, mode, searchValue = "", onSearchChange, searc
 
       <div className="hm-lanes-tools">
         <span className="hm-mono hm-muted">sorted by next-action urgency</span>
-        {filters.map(([label, n], i) => (
-          <span key={label} className={"hm-filter-chip " + (i === 0 ? "is-active" : "")} aria-disabled="true">
-            {label} <span className="ct">{n}</span>
-          </span>
-        ))}
+        {filters.map(([label, n, key]) => {
+          const active = activeFilter === key;
+          const className = "hm-filter-chip " + (active ? "is-active" : "");
+          // Interactive when a handler is wired; otherwise count-only (read-only).
+          return onFilterChange ? (
+            <button
+              key={label}
+              type="button"
+              className={className}
+              aria-pressed={active}
+              onClick={() => onFilterChange(key)}
+            >
+              {label} <span className="ct">{n}</span>
+            </button>
+          ) : (
+            <span key={label} className={className} aria-disabled="true">
+              {label} <span className="ct">{n}</span>
+            </span>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -9,6 +9,7 @@ import {
   boardMode,
   boardNowBanner,
   deriveBoardState,
+  matchesBoardFilter,
 } from "./board-state.js";
 
 // Reused fixture factory — keep card shapes minimal but realistic.
@@ -250,4 +251,28 @@ test("deriveBoardState: bundles every selector together", () => {
   assert.equal(state.grouped["needs-attention"].length, 1);
   assert.equal(state.grouped["operator-review"].length, 1);
   assert.equal(state.grouped["done"].length, 1);
+});
+
+test("matchesBoardFilter — chips narrow by the same lane derivation as the counts", () => {
+  const action = card({ id: "a", isAction: true });
+  const review = card({ id: "r", lane: "operator-review" });
+  const ready = card({ id: "q", lane: "release-queue" });
+  const running = card({ id: "c", lane: "hermes-checking" });
+  const done = card({ id: "d", type: "done", lane: "done" });
+  const blocked = card({ id: "b", state: "source-offline" });
+
+  // "all" matches everything.
+  for (const c of [action, review, ready, running, done, blocked]) {
+    assert.equal(matchesBoardFilter(c, "all"), true);
+  }
+  // Lane-based chips match only their lane.
+  assert.equal(matchesBoardFilter(review, "review"), true);
+  assert.equal(matchesBoardFilter(running, "review"), false);
+  assert.equal(matchesBoardFilter(ready, "ready"), true);
+  assert.equal(matchesBoardFilter(running, "running"), true);
+  assert.equal(matchesBoardFilter(done, "done"), true);
+  assert.equal(matchesBoardFilter(review, "done"), false);
+  // "blocked" is the cross-lane stale/offline state.
+  assert.equal(matchesBoardFilter(blocked, "blocked"), true);
+  assert.equal(matchesBoardFilter(running, "blocked"), false);
 });

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -7,8 +7,35 @@
 // Per §5/§16 of docs/HERMES_MONITOR_REDESIGN_SPEC.md.
 
 import type { BoardCard, Lane } from "./card-types.js";
-import { groupByLane, laneCounts } from "./lane-rules.js";
+import { groupByLane, laneCounts, laneFor } from "./lane-rules.js";
 import { sortByUrgency } from "./urgency.js";
+
+/** The state a LanesBar filter chip narrows the board to. */
+export type BoardFilter = "all" | "blocked" | "review" | "ready" | "running" | "done";
+
+/**
+ * Whether a card belongs to a filter chip's state. Lane-based chips reuse the
+ * SAME lane derivation (`laneFor`) the chip COUNTS use, so the filtered view and
+ * the count on the chip always agree. "blocked" is the cross-lane stale/offline
+ * state (matching kpiCounts.blocked). "all" matches everything.
+ */
+export function matchesBoardFilter(card: BoardCard, filter: BoardFilter): boolean {
+  if (filter === "all") return true;
+  if (filter === "blocked") return card?.state === "failed-fetch" || card?.state === "source-offline";
+  const lane = laneFor(card);
+  switch (filter) {
+    case "review":
+      return lane === "operator-review";
+    case "ready":
+      return lane === "release-queue";
+    case "running":
+      return lane === "hermes-checking";
+    case "done":
+      return lane === "done";
+    default:
+      return true;
+  }
+}
 
 export interface KPICounts {
   action: number;


### PR DESCRIPTION
## What changed & why

**Dead control fixed (truth-boundary):** the six LanesBar filter chips (All / Blocked / Review / Ready / Running / Done) rendered active but `aria-disabled` and silently no-op'd. A control that looks active and does nothing is a truth-boundary violation — now they actually filter the visible board.

- **`board-state.ts`** — `matchesBoardFilter(card, filter)`. Lane-based chips reuse the **same lane derivation (`laneFor`) the chip counts use**, so the filtered view and the count on each chip always agree. `blocked` is the cross-lane stale/offline state (matches `kpiCounts.blocked`); `all` matches everything.
- **`LanesBar.tsx`** — chips become real `<button>`s (`aria-pressed`) when an `onFilterChange` handler is wired: `onClick` fires the chip's filter key and the active chip reflects `activeFilter`. The count-only **read-only span fallback** (with `aria-disabled`) is preserved for callers that don't wire a handler. `aria-disabled` is removed on the interactive path.
- **`BoardView.tsx`** — a `filter` state composes with the search query in `displayGrouped`; a non-`all` filter also **force-reveals every lane with a match** (results are never hidden behind a collapsed rail), and clearing back to `all` restores the normal expansion. **Counts stay live off the whole board** (the filter narrows the view, not the KPIs).

## Affected surfaces
- [x] Monitor board / slack-operator (frontend only — `packages/monitor-ui`)
- [x] Docs / tests only (no backend, no endpoints, no authority change)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1185 passed; new tests below)
- [x] `vite build` (monitor-ui)

### Tests (one per newly-wired control)
- `matchesBoardFilter` predicate — each chip narrows by the same lane derivation as its count; `blocked` is cross-lane; `all` matches all.
- `LanesBar` interactive chips — clicking each chip calls `onFilterChange` with the right key; the active chip reflects `activeFilter` (`aria-pressed`); the read-only fallback (no handler) is still `aria-disabled`.
- `BoardView` integration — clicking **Done** narrows the board to done-lane cards (the live action card disappears); clicking **All** restores the full board.

## Durable invariants (AGENTS.md)
- [x] **Truth-boundary:** every chip now performs its real action (or, with no handler wired, renders the honest count-only read-only fallback). No active-but-no-op control remains.
- [x] **No new authority** — pure client-side view filtering; no new endpoint, no merge/deploy, no agent-facing data.
- [x] No secrets; merge/deploy stay human (unaffected).

## Known limits / follow-ups
- Filter state is component-local (not URL-synced); a `?filter=` param could follow the existing `?card=` pattern later if deep-linking a filtered view is wanted.
- This is **Group 1 of 4** from the dead-control audit; Groups 2–4 (drawer footer actions, co-pilot rail, keep-watching + operator notes) land as their own narrow PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)