### PR TITLE
Wire monitor banner controls

### DIFF
--- a/packages/monitor-ui/src/components/BoardNowBanner.test.tsx
+++ b/packages/monitor-ui/src/components/BoardNowBanner.test.tsx
@@ -31,6 +31,13 @@ describe("BoardNowBanner", () => {
     expect(getByText("!")).toBeTruthy();
   });
 
+  test("Hermes focus tone → action wash + H glyph", () => {
+    const { container, getByText } = render(<BoardNowBanner banner={banner("hermes-focus")} />);
+    expect(container.querySelector(".hm-now--action")).toBeTruthy();
+    expect(container.querySelector(".hm-now--hermes-focus")).toBeTruthy();
+    expect(getByText("H")).toBeTruthy();
+  });
+
   test("degraded tone → rose class + ‼ glyph", () => {
     const { container, getByText } = render(<BoardNowBanner banner={banner("degraded")} />);
     expect(container.querySelector(".hm-now--degraded")).toBeTruthy();

--- a/packages/monitor-ui/src/components/BoardNowBanner.tsx
+++ b/packages/monitor-ui/src/components/BoardNowBanner.tsx
@@ -13,7 +13,7 @@
 import type { ReactNode } from "react";
 
 export type BannerData = {
-  tone: "action" | "calm" | "degraded";
+  tone: "action" | "calm" | "hermes-focus" | "degraded";
   eyebrow: string;
   headline: string;
   sub: string;
@@ -29,6 +29,7 @@ export type BoardNowBannerProps = {
 const GLYPHS: Record<BannerData["tone"], string> = {
   action: "!",
   calm: "✓",
+  "hermes-focus": "H",
   degraded: "‼",
 };
 
@@ -36,6 +37,8 @@ export function BoardNowBanner({ banner, cta }: BoardNowBannerProps) {
   const toneClass =
     banner.tone === "action"
       ? "hm-now hm-now--action"
+      : banner.tone === "hermes-focus"
+        ? "hm-now hm-now--action hm-now--hermes-focus"
       : banner.tone === "calm"
         ? "hm-now hm-now--calm"
         : "hm-now hm-now--degraded";

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
 import { BoardView } from "./BoardView.js";
 import { FIXTURE_CARDS } from "../lib/monitor/fixtures.js";
 import type { MonitorBoard } from "../lib/monitor/board-cache.js";
+import type { BoardCard } from "../lib/monitor/card-types.js";
 
 afterEach(cleanup);
 
@@ -43,6 +44,50 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(view.getByText("Hermes verdict")).toBeTruthy();
   });
 
+  test("action banner CTA opens the real review card", () => {
+    const onCardClick = vi.fn();
+    const board: MonitorBoard = {
+      at: "2026-05-28T10:30:00Z",
+      cards: [reviewCard({ id: "agent #548", title: "Review relay hang fix" })],
+    };
+    const { getByRole } = render(<BoardView board={board} status="open" onCardClick={onCardClick} keyboard={false} />);
+
+    fireEvent.click(getByRole("button", { name: /Jump to agent #548/ }));
+    expect(onCardClick).toHaveBeenCalledWith("agent #548");
+
+    fireEvent.click(getByRole("button", { name: "Open review checklist" }));
+    expect(onCardClick).toHaveBeenCalledWith("agent #548");
+  });
+
+  test("Hermes focus banner appears only for a real scoped conversation on the pending review card", async () => {
+    const board: MonitorBoard = {
+      at: "2026-05-28T10:30:00Z",
+      cards: [reviewCard({ id: "agent #548", title: "Review relay hang fix" })],
+    };
+    const { getByText } = render(
+      <BoardView
+        board={board}
+        status="open"
+        focusedCardId="agent #548"
+        onCardClick={() => {}}
+        keyboard={false}
+        collaboration={{
+          fetcher: async () => [{
+            id: "msg-1",
+            ts: Date.now(),
+            author: "operator",
+            kind: "chat",
+            addressedTo: "hermes",
+            text: "What is the blast radius?",
+            relatedPr: { repo: "depre-dev/averray-reference-agent", number: 548 },
+          }],
+        }}
+      />,
+    );
+
+    await waitFor(() => expect(getByText(/Hermes has the floor/)).toBeTruthy());
+  });
+
   test("renders a spread of card types (mission, deploy, done)", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
     const view = within(container);
@@ -64,6 +109,32 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelectorAll("section.hm-lane").length).toBe(2); // deploying + done
     // …and the six empty lanes are mini-rails — not everything-but-Done collapsed.
     expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(6);
+  });
+
+  test("calm banner CTA filters to today's done cards and mutes alerts for one hour", () => {
+    const onMute = vi.fn();
+    const board: MonitorBoard = {
+      at: "2026-06-01T12:00:00.000Z",
+      cards: [
+        doneCard({ id: "done-today", title: "Merged today", closedAt: "2026-06-01T08:00:00.000Z" }),
+        doneCard({ id: "done-old", title: "Merged yesterday", closedAt: "2026-05-31T08:00:00.000Z" }),
+      ],
+    };
+    const { getByRole, queryByText } = render(<BoardView board={board} status="open" onMute={onMute} keyboard={false} />);
+
+    fireEvent.click(getByRole("button", { name: /Review today/ }));
+    expect(queryByText("Merged today")).toBeTruthy();
+    expect(queryByText("Merged yesterday")).toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Mute for 1 hour" }));
+    expect(onMute).toHaveBeenCalledTimes(1);
+    expect(onMute.mock.calls[0]?.[0]).toBeGreaterThan(Date.now() + 59 * 60_000);
+  });
+
+  test("Ask Hermes float focuses the composer when no drawer is open", () => {
+    const { getByRole } = render(<BoardView board={richBoard} status="open" keyboard={false} />);
+    fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
+    expect(getByRole("textbox", { name: "Ask Hermes, propose a task, spawn a mission, or mute alerts" })).toBe(document.activeElement);
   });
 
   test("an open stream lights the LIVE indicator with the snapshot clock", () => {
@@ -310,3 +381,41 @@ describe("BoardView — filter chips (G1)", () => {
     expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
   });
 });
+
+function reviewCard(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "agent #548",
+    lane: "operator-review",
+    type: "pr",
+    agentType: "codex",
+    title: "Review relay hang fix",
+    summary: "Hermes needs an operator review decision.",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 1,
+    state: "fresh",
+    risk: ["review-gated"],
+    waitingOn: { actor: "operator", tone: "warn" },
+    files: [],
+    isAction: true,
+    ...overrides,
+  } as BoardCard;
+}
+
+function doneCard(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "done-today",
+    lane: "done",
+    type: "done",
+    agentType: "codex",
+    title: "Merged today",
+    summary: "Merged",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 1,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "CI", tone: "neutral" },
+    closedAt: "2026-06-01T08:00:00.000Z",
+    mergeStatus: "MERGED",
+    ...overrides,
+  } as BoardCard;
+}

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -157,19 +157,28 @@ export function BoardView({
   }, [dismissedCardIds, rawCards, snoozedUntilById]);
   const liveLabel = useMemo(() => formatClock(board?.at), [board?.at]);
 
-  // KPIs / banner / mode reflect the whole board, regardless of search.
-  const state = useMemo(
-    () => deriveBoardState(cards, { streamOnline, nowLabel: liveLabel, lastGoodLabel: liveLabel || undefined }),
-    [cards, streamOnline, liveLabel],
-  );
-
   // ── view state ──────────────────────────────────────────────────
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<BoardFilter>("all");
   const [boardFocusId, setBoardFocusId] = useState<string | null>(null);
   const [overlayOpen, setOverlayOpen] = useState(false);
   const [askToken, setAskToken] = useState(0);
+  const [hermesFocusConversationActive, setHermesFocusConversationActive] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // KPIs / banner / mode reflect the whole board, regardless of search.
+  const state = useMemo(
+    () => deriveBoardState(cards, {
+      streamOnline,
+      nowLabel: liveLabel,
+      lastGoodLabel: liveLabel || undefined,
+      ...(hermesFocusConversationActive && scopeCandidateId(cards, focusedCardId, boardFocusId)
+        ? { hermesFocusCardId: scopeCandidateId(cards, focusedCardId, boardFocusId) }
+        : {}),
+      ...(board?.calmMetrics ? { calmMetrics: board.calmMetrics } : {}),
+    }),
+    [board?.calmMetrics, boardFocusId, cards, focusedCardId, hermesFocusConversationActive, streamOnline, liveLabel],
+  );
 
   // §14: announce the action-needed 0→>0 edge once, assertively, for
   // screen-reader users (the visual cue is the amber banner).
@@ -213,11 +222,11 @@ export function BoardView({
     const out = {} as Record<LaneId, BoardCard[]>;
     for (const lane of LANES) {
       out[lane] = (state.grouped[lane] ?? []).filter(
-        (c) => (!q || matchesQuery(c, q)) && matchesBoardFilter(c, filter),
+        (c) => (!q || matchesQuery(c, q)) && matchesBoardFilter(c, filter, { todayIso: board?.at }),
       );
     }
     return out;
-  }, [state.grouped, q, filter]);
+  }, [board?.at, state.grouped, q, filter]);
 
   // A non-"all" filter reveals every lane that has a match, regardless of the
   // operator's manual collapse state, so chip results are never hidden. Clearing
@@ -235,6 +244,22 @@ export function BoardView({
   const drawerCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
   const boardFocusedCard = boardFocusId ? orderedCards.find((c) => c.id === boardFocusId) : undefined;
   const scopeCard = drawerCard ?? boardFocusedCard;
+  const bannerCta = renderBannerCta({
+    bannerMode: state.banner.tone,
+    primaryActionId: state.banner.primaryActionId,
+    cards,
+    onOpenCard: onCardClick ? (card) => {
+      setFilter("all");
+      setBoardFocusId(card.id);
+      setExpanded(new Set<LaneId>([laneFor(card), "done"]));
+      onCardClick(card.id);
+    } : undefined,
+    onReviewToday: () => {
+      setFilter("today-done");
+      setExpanded(new Set<LaneId>(["done"]));
+    },
+    onMuteOneHour: onMute ? () => onMute(Date.now() + 60 * 60_000) : undefined,
+  });
 
   const onToggleLane = useCallback((id: LaneId) => {
     setExpanded((prev) => {
@@ -314,7 +339,7 @@ export function BoardView({
         />
       )}
 
-      <BoardNowBanner banner={state.banner} />
+      <BoardNowBanner banner={state.banner} cta={bannerCta} />
 
       <div className="hm-main">
         <div className="hm-lanes-wrap">
@@ -370,6 +395,7 @@ export function BoardView({
           onSetSupervised={onSetSupervised}
           autonomyMode={autonomyMode}
           composerFocusToken={askToken}
+          onScopedConversationChange={setHermesFocusConversationActive}
         />
       </div>
 
@@ -382,8 +408,82 @@ export function BoardView({
         />
       ) : null}
 
+      {!drawerCard ? (
+        <button
+          type="button"
+          className="hm-ask-float"
+          onClick={() => {
+            const nextFocusId = boardFocusId ?? state.banner.primaryActionId ?? state.mostUrgent?.id ?? orderedCards[0]?.id ?? null;
+            if (nextFocusId) setBoardFocusId(nextFocusId);
+            setAskToken((t) => t + 1);
+          }}
+          aria-label="Ask Hermes"
+        >
+          <span className="mark" aria-hidden>H</span>
+          Ask Hermes <span className="hm-kbd">A</span>
+        </button>
+      ) : null}
+
       {overlayOpen ? <KeyboardOverlay onClose={() => setOverlayOpen(false)} /> : null}
     </div>
+  );
+}
+
+function scopeCandidateId(cards: BoardCard[], focusedCardId: string | null | undefined, boardFocusId: string | null): string | undefined {
+  const id = focusedCardId ?? boardFocusId ?? undefined;
+  if (!id) return undefined;
+  return cards.some((card) => card.id === id) ? id : undefined;
+}
+
+function renderBannerCta({
+  bannerMode,
+  primaryActionId,
+  cards,
+  onOpenCard,
+  onReviewToday,
+  onMuteOneHour,
+}: {
+  bannerMode: BoardMode;
+  primaryActionId: string | undefined;
+  cards: readonly BoardCard[];
+  onOpenCard?: (card: BoardCard) => void;
+  onReviewToday: () => void;
+  onMuteOneHour?: () => void;
+}) {
+  if (bannerMode === "degraded") return null;
+  if (bannerMode === "calm") {
+    return (
+      <>
+        <div className="button-row">
+          <button type="button" className="hm-btn hm-btn--primary" onClick={onReviewToday}>
+            Review today <span className="hm-kbd">R</span>
+          </button>
+          {onMuteOneHour ? (
+            <button type="button" className="hm-btn hm-btn--ghost" onClick={onMuteOneHour}>
+              Mute for 1 hour
+            </button>
+          ) : null}
+        </div>
+        <span className="hm-now-quick">Hermes will tone an alert if action goes from 0 to 1</span>
+      </>
+    );
+  }
+
+  const card = primaryActionId ? cards.find((candidate) => candidate.id === primaryActionId) : undefined;
+  if (!card || !onOpenCard) return null;
+  const openCard = () => onOpenCard(card);
+  return (
+    <>
+      <div className="button-row">
+        <button type="button" className="hm-btn hm-btn--action" onClick={openCard}>
+          Jump to {card.id} <span className="hm-kbd">↵</span>
+        </button>
+        <button type="button" className="hm-btn hm-btn--ghost" onClick={openCard}>
+          Open review checklist
+        </button>
+      </div>
+      <span className="hm-now-quick">scoped to the current review decision</span>
+    </>
   );
 }
 

--- a/packages/monitor-ui/src/components/LanesBar.tsx
+++ b/packages/monitor-ui/src/components/LanesBar.tsx
@@ -17,6 +17,7 @@ import type { KPICounts, BoardMode, BoardFilter } from "../lib/monitor/board-sta
 
 const TIPS: Record<BoardMode, string> = {
   action: "· focus on the lane that needs you",
+  "hermes-focus": "· Hermes is answering the active review thread",
   calm: "· everything quiet · history below",
   degraded: "· data may be stale; auto-reconnecting",
 };

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -10,7 +10,7 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../../lib/monitor/backlog-suggestions.js";
 import type { BoardNowBanner as BoardNowBannerData } from "../../lib/monitor/board-state.js";
-import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
+import { relatedPrForCard, type CollaborationMessage } from "../../lib/monitor/collaboration.js";
 import {
   buildHermesActivityFeed,
   type HermesActivityEntry,
@@ -50,6 +50,8 @@ export interface CoPilotRailProps {
   autonomyMode?: "supervised" | "autopilot";
   /** Bump to focus the composer (the board's `a` shortcut). */
   composerFocusToken?: number;
+  /** True only when real collaboration messages are scoped to a pending review card. */
+  onScopedConversationChange?: (active: boolean) => void;
 }
 
 export function CoPilotRail({
@@ -69,6 +71,7 @@ export function CoPilotRail({
   onSetSupervised,
   autonomyMode,
   composerFocusToken,
+  onScopedConversationChange,
 }: CoPilotRailProps) {
   const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
   const relatedPr = relatedPrForCard(focusedCard);
@@ -87,6 +90,14 @@ export function CoPilotRail({
     }),
     [boardBanner, boardCards, messages],
   );
+
+  const scopedConversationActive = useMemo(
+    () => hasScopedConversation(messages, focusedCard),
+    [focusedCard, messages],
+  );
+  useEffect(() => {
+    onScopedConversationChange?.(scopedConversationActive);
+  }, [onScopedConversationChange, scopedConversationActive]);
 
   // Keep the newest turn in view as the feed grows.
   useEffect(() => {
@@ -144,6 +155,29 @@ export function CoPilotRail({
       />
     </aside>
   );
+}
+
+function hasScopedConversation(messages: readonly CollaborationMessage[], card: BoardCard | undefined): boolean {
+  if (!card || card.waitingOn?.actor !== "operator" || (card.lane !== "operator-review" && card.isAction !== true)) {
+    return false;
+  }
+  return messages.some((message) => (
+    (message.author === "operator" || message.author === "hermes")
+    && messageMatchesCard(message, card)
+  ));
+}
+
+function messageMatchesCard(message: CollaborationMessage, card: BoardCard): boolean {
+  const relatedPr = relatedPrForCard(card);
+  if (
+    relatedPr
+    && message.relatedPr?.repo === relatedPr.repo
+    && message.relatedPr.number === relatedPr.number
+  ) {
+    return true;
+  }
+  const correlation = card.correlationId ?? card.id;
+  return Boolean(message.relatedCorrelationId && message.relatedCorrelationId === correlation);
 }
 
 function ActivityEntryRow({

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -219,6 +219,8 @@ function summaryActivity(banner: BoardNowBanner, nowMs: number): HermesActivityE
   const text =
     banner.tone === "action"
       ? `Needs you: review the current action lane${banner.primaryActionId ? `, starting with ${banner.primaryActionId}` : ""}.`
+      : banner.tone === "hermes-focus"
+        ? `Hermes is answering the active review thread${banner.primaryActionId ? ` for ${banner.primaryActionId}` : ""}.`
       : banner.tone === "degraded"
         ? "Needs you: reconnect or verify freshness before approving anything."
         : "Needs you: nothing right now.";
@@ -226,7 +228,7 @@ function summaryActivity(banner: BoardNowBanner, nowMs: number): HermesActivityE
     id: "activity-current-summary",
     atMs: nowMs,
     source: "summary",
-    tone: banner.tone === "action" ? "action" : banner.tone === "degraded" ? "warning" : "success",
+    tone: banner.tone === "action" || banner.tone === "hermes-focus" ? "action" : banner.tone === "degraded" ? "warning" : "success",
     text,
     meta: banner.sub,
     ...(banner.primaryActionId ? { cardId: banner.primaryActionId } : {}),

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -6,12 +6,15 @@
 // refetch when SSE events arrive. Never mutates the input.
 
 import type { BoardCard, Lane } from "./card-types.js";
+import type { CalmBoardMetrics } from "./board-state.js";
 
 export interface MonitorBoard {
   cards: BoardCard[];
   /** ISO timestamp from the server */
   at: string;
   llmUsage?: LlmUsageAggregate;
+  /** Optional board-summary metrics; omitted means the UI must not fabricate them. */
+  calmMetrics?: CalmBoardMetrics;
 }
 
 export interface LlmUsageModelRollup {
@@ -86,7 +89,8 @@ export function applyEventToBoard(
     case "board.snapshot": {
       const cards = Array.isArray(event.cards) ? (event.cards as BoardCard[]) : [];
       const at = typeof event.at === "string" ? event.at : new Date().toISOString();
-      return { cards, at };
+      const calmMetrics = isRecord(event.calmMetrics) ? (event.calmMetrics as CalmBoardMetrics) : undefined;
+      return { cards, at, ...(calmMetrics ? { calmMetrics } : {}) };
     }
     case "board.card.added": {
       if (!prev) return prev;
@@ -137,4 +141,8 @@ export function applyEventToBoard(
     default:
       return prev;
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -131,6 +131,13 @@ test("boardMode: a single action card → action mode", () => {
   assert.equal(boardMode(cards), "action");
 });
 
+test("boardMode: scoped Hermes conversation on pending review card → hermes-focus", () => {
+  const cards = [
+    card({ id: "agent #548", lane: "operator-review", isAction: true, waitingOn: { actor: "operator", tone: "warn" } }),
+  ];
+  assert.equal(boardMode(cards, { hermesFocusCardId: "agent #548" }), "hermes-focus");
+});
+
 test("boardMode: blocked cards force degraded mode (overrides action)", () => {
   // A failed-fetch card means we can't trust the data — even if
   // something looks like it needs action, the truthful UI mode is
@@ -177,11 +184,43 @@ test("boardNowBanner: multiple action cards pluralize correctly", () => {
   assert.match(banner.headline, /2 cards need your review decision/);
 });
 
+test("boardNowBanner: Hermes focus mode uses the scoped review card", () => {
+  const cards = [
+    card({ id: "agent #548", lane: "operator-review", isAction: true, title: "Review relay hang fix", waitingOn: { actor: "operator", tone: "warn" } }),
+  ];
+  const banner = boardNowBanner(cards, { nowLabel: "14:32:43 utc", hermesFocusCardId: "agent #548" });
+  assert.equal(banner.tone, "hermes-focus");
+  assert.match(banner.eyebrow, /in conversation with Hermes/);
+  assert.match(banner.headline, /Hermes has the floor/);
+  assert.match(banner.headline, /1 review decision pending/);
+  assert.match(banner.sub, /Review relay hang fix/);
+  assert.equal(banner.primaryActionId, "agent #548");
+});
+
 test("boardNowBanner: calm board with nothing in flight reads 'nothing waits on you'", () => {
   const banner = boardNowBanner([], { nowLabel: "17:48:02 utc" });
   assert.equal(banner.tone, "calm");
   assert.match(banner.eyebrow, /you're done for now/);
   assert.match(banner.headline, /Nothing waits on you/);
+});
+
+test("boardNowBanner: calm sub only includes metrics the board model provides", () => {
+  const cards = [
+    card({ id: "done-1", type: "done", lane: "done", closedAt: "2026-05-27", mergeStatus: "MERGED" }),
+  ];
+  const banner = boardNowBanner(cards, {
+    calmMetrics: {
+      avgTimeToDecision: "4m 12s",
+      disputes: 0,
+      lastDeploy: { id: "#246", verifiedAt: "17:42:11" },
+    },
+  });
+  assert.match(banner.sub, /avg time-to-decision 4m 12s/);
+  assert.match(banner.sub, /0 dispute/);
+  assert.match(banner.sub, /last deploy #246 verified at 17:42:11/);
+
+  const withoutMetrics = boardNowBanner(cards);
+  assert.notMatch(withoutMetrics.sub, /avg time-to-decision|dispute|last deploy/);
 });
 
 test("boardNowBanner: calm board with in-flight automation reads correctly", () => {
@@ -251,6 +290,13 @@ test("deriveBoardState: bundles every selector together", () => {
   assert.equal(state.grouped["needs-attention"].length, 1);
   assert.equal(state.grouped["operator-review"].length, 1);
   assert.equal(state.grouped["done"].length, 1);
+});
+
+test("matchesBoardFilter: today-done keeps only done cards closed on the snapshot date", () => {
+  const today = card({ id: "today", type: "done", lane: "done", closedAt: "2026-06-01T08:00:00.000Z", mergeStatus: "MERGED" });
+  const yesterday = card({ id: "yesterday", type: "done", lane: "done", closedAt: "2026-05-31T22:00:00.000Z", mergeStatus: "MERGED" });
+  assert.equal(matchesBoardFilter(today, "today-done", { todayIso: "2026-06-01T12:00:00.000Z" }), true);
+  assert.equal(matchesBoardFilter(yesterday, "today-done", { todayIso: "2026-06-01T12:00:00.000Z" }), false);
 });
 
 test("matchesBoardFilter — chips narrow by the same lane derivation as the counts", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -11,7 +11,7 @@ import { groupByLane, laneCounts, laneFor } from "./lane-rules.js";
 import { sortByUrgency } from "./urgency.js";
 
 /** The state a LanesBar filter chip narrows the board to. */
-export type BoardFilter = "all" | "blocked" | "review" | "ready" | "running" | "done";
+export type BoardFilter = "all" | "blocked" | "review" | "ready" | "running" | "done" | "today-done";
 
 /**
  * Whether a card belongs to a filter chip's state. Lane-based chips reuse the
@@ -19,7 +19,11 @@ export type BoardFilter = "all" | "blocked" | "review" | "ready" | "running" | "
  * the count on the chip always agree. "blocked" is the cross-lane stale/offline
  * state (matching kpiCounts.blocked). "all" matches everything.
  */
-export function matchesBoardFilter(card: BoardCard, filter: BoardFilter): boolean {
+export function matchesBoardFilter(
+  card: BoardCard,
+  filter: BoardFilter,
+  opts: { todayIso?: string } = {},
+): boolean {
   if (filter === "all") return true;
   if (filter === "blocked") return card?.state === "failed-fetch" || card?.state === "source-offline";
   const lane = laneFor(card);
@@ -32,6 +36,8 @@ export function matchesBoardFilter(card: BoardCard, filter: BoardFilter): boolea
       return lane === "hermes-checking";
     case "done":
       return lane === "done";
+    case "today-done":
+      return lane === "done" && isSameUtcDay(doneClosedAt(card), opts.todayIso);
     default:
       return true;
   }
@@ -49,7 +55,16 @@ export interface KPICounts {
   total: number;
 }
 
-export type BoardMode = "calm" | "action" | "degraded";
+export type BoardMode = "calm" | "action" | "hermes-focus" | "degraded";
+
+export interface CalmBoardMetrics {
+  avgTimeToDecision?: string;
+  disputes?: number;
+  lastDeploy?: {
+    id?: string;
+    verifiedAt?: string;
+  };
+}
 
 export interface BoardNowBanner {
   tone: BoardMode;
@@ -63,6 +78,8 @@ export interface DeriveBoardOpts {
   streamOnline?: boolean;
   nowLabel?: string;
   lastGoodLabel?: string;
+  hermesFocusCardId?: string;
+  calmMetrics?: CalmBoardMetrics;
 }
 
 export interface DerivedBoardState {
@@ -118,6 +135,9 @@ export function boardMode(cards: BoardCard[], opts: DeriveBoardOpts = {}): Board
   if (!Array.isArray(cards) || cards.length === 0) return "calm";
   const counts = kpiCounts(cards);
   if (counts.blocked > 0) return "degraded";
+  if (opts.hermesFocusCardId && cards.some((card) => card.id === opts.hermesFocusCardId && isPendingReviewCard(card))) {
+    return "hermes-focus";
+  }
   if (counts.action > 0) return "action";
   return "calm";
 }
@@ -161,14 +181,25 @@ export function boardNowBanner(cards: BoardCard[], opts: DeriveBoardOpts = {}): 
     };
   }
 
+  if (mode === "hermes-focus") {
+    const focusCard = cards.find((card) => card.id === opts.hermesFocusCardId);
+    const pendingCount = pendingReviewCount(cards);
+    return {
+      tone: "hermes-focus",
+      eyebrow: now ? `Board now · ${now} · in conversation with Hermes` : "Board now · in conversation with Hermes",
+      headline: `Hermes has the floor — ${pendingCount} review ${pendingCount === 1 ? "decision" : "decisions"} pending, blast radius assessed.`,
+      sub: focusCard
+        ? `Conversation is scoped to ${focusCard.title}. Open the checklist when the risk and intent are clear.`
+        : "Conversation is scoped to the current review card. Open the checklist when the risk and intent are clear.",
+      primaryActionId: focusCard?.id,
+    };
+  }
+
   return {
     tone: "calm",
     eyebrow: now ? `Board now · ${now} · you're done for now` : `Board now · you're done for now`,
     headline: calmHeadline(counts),
-    sub:
-      counts.done > 0
-        ? `${counts.done} card(s) shipped today; you can step away.`
-        : `No releases yet today; you can step away.`,
+    sub: calmSub(counts, opts.calmMetrics),
     primaryActionId: undefined,
   };
 }
@@ -187,6 +218,39 @@ function calmHeadline(counts: KPICounts): string {
     return `${counts.total} card(s) are still in flight; Hermes is watching.`;
   }
   return `No operator decision needed. ${parts.join(" and ")} are still in flight; Hermes is watching.`;
+}
+
+function calmSub(counts: KPICounts, metrics?: CalmBoardMetrics): string {
+  const base = counts.done > 0 ? `${counts.done} card(s) shipped today` : "No releases yet today";
+  const parts = [base];
+  if (metrics?.avgTimeToDecision) parts.push(`avg time-to-decision ${metrics.avgTimeToDecision}`);
+  if (typeof metrics?.disputes === "number") parts.push(`${metrics.disputes} dispute(s)`);
+  if (metrics?.lastDeploy?.id || metrics?.lastDeploy?.verifiedAt) {
+    const id = metrics.lastDeploy.id ? ` ${metrics.lastDeploy.id}` : "";
+    const verified = metrics.lastDeploy.verifiedAt ? ` verified at ${metrics.lastDeploy.verifiedAt}` : "";
+    parts.push(`last deploy${id}${verified}`);
+  }
+  return `${parts.join(" · ")}. Hermes is watching; you can step away.`;
+}
+
+function pendingReviewCount(cards: BoardCard[]): number {
+  return cards.filter(isPendingReviewCard).length || 1;
+}
+
+function isPendingReviewCard(card: BoardCard): boolean {
+  return card.waitingOn?.actor === "operator" && (card.lane === "operator-review" || card.isAction === true);
+}
+
+function doneClosedAt(card: BoardCard): string | undefined {
+  return card.type === "done" ? card.closedAt : undefined;
+}
+
+function isSameUtcDay(iso: string | undefined, todayIso: string | undefined): boolean {
+  if (!iso || !todayIso) return false;
+  const at = new Date(iso);
+  const today = new Date(todayIso);
+  if (Number.isNaN(at.getTime()) || Number.isNaN(today.getTime())) return false;
+  return at.toISOString().slice(0, 10) === today.toISOString().slice(0, 10);
 }
 
 /** Aggregate selector — everything the board page needs in one call. */

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -73,6 +73,7 @@ body { margin: 0; }
    ROOT BOARD CONTAINER — fills the artboard
    ============================================================ */
 .hm-board {
+  position: relative;
   width: 100%;
   height: 100%;
   background: var(--hm-paper-3);
@@ -234,6 +235,9 @@ body { margin: 0; }
   background: linear-gradient(180deg, var(--hm-amber-wash) 0%, var(--hm-paper) 92%);
   border-bottom-color: var(--hm-amber-ring);
 }
+.hm-now--hermes-focus {
+  background: linear-gradient(180deg, rgba(244, 227, 207, 0.92) 0%, var(--hm-paper) 92%);
+}
 .hm-now--calm {
   background: linear-gradient(180deg, var(--hm-sage-wash) 0%, var(--hm-paper) 92%);
 }
@@ -303,6 +307,9 @@ body { margin: 0; }
 .hm-now--action .hm-now-glyph {
   background: var(--hm-amber-soft);
   border-color: var(--hm-amber-ring);
+}
+.hm-now--hermes-focus .hm-now-glyph {
+  color: var(--hm-amber-deep);
 }
 .hm-now--calm .hm-now-glyph {
   background: var(--hm-sage-soft);
@@ -1624,6 +1631,7 @@ button.hm-activity-row:hover {
   font-family: var(--font-display);
   font-weight: 700;
   font-size: 12.5px;
+  border: 0;
 }
 .hm-ask-float .mark {
   width: 22px; height: 22px;
@@ -1632,6 +1640,10 @@ button.hm-activity-row:hover {
   color: #fffdf7;
   display: grid; place-items: center;
   font-size: 11px; font-weight: 800;
+}
+.hm-ask-float .hm-kbd {
+  background: rgba(255,253,247,0.18);
+  color: #fffdf7;
 }
 
 /* ============================================================


### PR DESCRIPTION
## What changed & why

- Added the real `hermes-focus` board mode/banner, triggered only when the co-pilot has real operator/Hermes collaboration messages scoped to the pending review card.
- Wired `BoardNowBanner` CTAs instead of leaving the slot unused: action/focus banners open the real review card; calm banners filter to today’s done cards and can mute alerts for one hour through the existing mute callback.
- Added optional calm metrics support (`avgTimeToDecision`, `disputes`, `lastDeploy`) without fabricating values when the board model omits them.
- Added the styled `hm-ask-float` Ask Hermes button when the drawer is closed; clicking it focuses the composer.

This is the first narrow frontend PR from the handoff. No controls are decorative: controls either call existing behavior or are omitted.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Frontend-only monitor UI change. Rollback is reverting this PR; no data migration, env, ops, or secret changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- Next PR should cover mission drawer polish and drawer footer kbd hints.
- Co-pilot per-turn anatomy/chips remains a separate narrow PR so this banner/control slice stays reviewable.