### PR TITLE
Group 2: wire the drawer footer actions (truth-boundary)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -53,6 +53,8 @@ export interface MonitorPageProps {
   onApproveTask?: (id: string) => void;
   /** Override the tester mission approval (defaults to POST /monitor/testbed-missions/:id/approve). */
   onApproveMission?: (id: string) => void;
+  /** Override the drawer mission re-run (defaults to POST /monitor/testbed-missions). */
+  onRerunMission?: (targetUrl: string, freshness: "fresh" | "memory") => void;
   /** Override the co-pilot collaboration wiring (defaults to live polling). */
   collaboration?: UseCollaborationOptions;
   /** Override the action-alert wiring (audio/notification/storage) for tests. */
@@ -71,6 +73,7 @@ export function MonitorPage({
   onCreateTask = defaultCreateTask,
   onApproveTask = defaultApproveTask,
   onApproveMission = defaultApproveMission,
+  onRerunMission = defaultRerunMission,
   collaboration = {},
   alerts,
   onAlertMute = defaultPostAlertMute,
@@ -115,6 +118,7 @@ export function MonitorPage({
         onCreateTask={onCreateTask}
         onApproveTask={onApproveTask}
         onApproveMission={onApproveMission}
+        onRerunMission={onRerunMission}
         collaboration={collaboration}
         onMute={muteEverywhere}
         onUnmute={unmuteEverywhere}
@@ -139,6 +143,22 @@ function defaultSpawnMission(url: string): void {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ targetUrl: url }),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+/**
+ * Re-run a mission from the drawer footer. Same endpoint as a spawn, plus a
+ * freshness flag: "fresh" → a new agent with no prior context (freshMemory),
+ * "memory" → the agent reads the last terminal report as context. Fire-and-
+ * forget; the new mission card arrives on the board feed.
+ */
+function defaultRerunMission(targetUrl: string, freshness: "fresh" | "memory"): void {
+  void fetch(MISSIONS_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ targetUrl, freshMemory: freshness === "fresh" }),
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
   });

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -34,6 +34,7 @@ import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
 import { DetailDrawer } from "./drawer/DetailDrawer.js";
+import { missionReportText, type DrawerActionHandlers } from "../lib/monitor/drawer-footer.js";
 import { CoPilotRail } from "./hermes/CoPilotRail.js";
 import { KeyboardOverlay } from "./shortcuts/KeyboardOverlay.js";
 import type { UseCollaborationOptions } from "../hooks/useCollaboration.js";
@@ -102,6 +103,8 @@ export interface BoardViewProps {
   onApproveTask?: (id: string) => void;
   /** Approve a requested tester mission — the operator human gate (T6). */
   onApproveMission?: (id: string) => void;
+  /** Re-run a mission (drawer footer) via POST /monitor/testbed-missions. */
+  onRerunMission?: (targetUrl: string, freshness: "fresh" | "memory") => void;
   collaboration?: UseCollaborationOptions;
   onMute?: (untilMs: number) => void;
   onUnmute?: () => void;
@@ -130,6 +133,7 @@ export function BoardView({
   onCreateTask,
   onApproveTask,
   onApproveMission,
+  onRerunMission,
   collaboration,
   onMute,
   onUnmute,
@@ -275,6 +279,55 @@ export function BoardView({
     },
   });
 
+  // G2: compose the drawer footer's backend actions from the EXISTING board
+  // handlers. A handler is provided only when its real action is wired (and the
+  // footer further disables a button when the card lacks the data it needs) —
+  // so a footer button is never live-but-no-op. No new authority: it only
+  // proposes / approves / opens GitHub through paths the board already uses.
+  const drawerActions = useMemo<DrawerActionHandlers>(() => {
+    const a: DrawerActionHandlers = {
+      // Ask Hermes: close the modal drawer, scope the rail composer to the card.
+      onAskHermes: (card) => {
+        onCardClose?.();
+        setBoardFocusId(card.id);
+        setAskToken((t) => t + 1);
+      },
+    };
+    if (onRerunMission) {
+      a.onRerunMission = (card, freshness) => {
+        const target = card.type === "mission" ? card.mission?.target : undefined;
+        if (target) onRerunMission(target, freshness);
+      };
+    }
+    if (onApproveTask) {
+      // Records operator approval; the merge itself happens on GitHub (the
+      // footer opens it). The board never merges.
+      a.onApproveAndMerge = (card) => onApproveTask(card.id);
+    }
+    if (onCreateTask) {
+      a.onCreateProductFix = (card) => {
+        const report = missionReportText(card);
+        onCreateTask({
+          agent: "claude", // greenfield product fix — the worker opens its own PR
+          repo: card.repo,
+          prompt: `Product fix proposed from a failed testbed mission.\n\n${card.title}\n\n${report ?? card.summary}`,
+        });
+      };
+      a.onSendBackToCodex = (card) => {
+        const pr = "pullRequestNumber" in card ? (card as { pullRequestNumber?: number }).pullRequestNumber : undefined;
+        if (typeof pr === "number") {
+          onCreateTask({
+            agent: "codex",
+            repo: card.repo,
+            pullRequestNumber: pr,
+            prompt: `Operator sent this PR back to Codex for another pass: ${card.title}`,
+          });
+        }
+      };
+    }
+    return a;
+  }, [onRerunMission, onApproveTask, onCreateTask, onCardClose]);
+
   return (
     <div className="hm-board">
       {/* §14: assertive announcement of the action 0→>0 edge. */}
@@ -363,6 +416,7 @@ export function BoardView({
           cards={orderedCards}
           onClose={() => onCardClose?.()}
           onNavigate={(id) => onCardNavigate?.(id)}
+          actions={drawerActions}
         />
       ) : null}
 

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -272,3 +272,40 @@ describe("DetailDrawer — variants", () => {
     expect(getByText(/no structured report yet/i)).toBeTruthy();
   });
 });
+
+describe("DetailDrawer — footer actions (G2)", () => {
+  test("truth-boundary: an action lacking a backend renders DISABLED with a tooltip reason", () => {
+    const card = fixture("agent #548"); // action PR card
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    // No `actions` wired → Send back to Codex + Ask Hermes are disabled with a reason.
+    const sendBack = getByText("Send back to Codex").closest("button") as HTMLButtonElement;
+    expect(sendBack.disabled).toBe(true);
+    expect(sendBack.getAttribute("title")).toMatch(/isn't available/i);
+    const ask = getByText("Ask Hermes").closest("button") as HTMLButtonElement;
+    expect(ask.disabled).toBe(true);
+    expect(ask.getAttribute("title")).toMatch(/isn't available/i);
+  });
+
+  test("Approve & merge opens the GitHub PR and records approval — never merges in-board", () => {
+    const card = fixture("agent #548");
+    const openUrl = vi.fn();
+    const onApproveAndMerge = vi.fn();
+    const { getByText } = render(
+      <DetailDrawer
+        card={card}
+        cards={[{ id: card.id }]}
+        onClose={noop}
+        onNavigate={noop}
+        actions={{ onApproveAndMerge }}
+        footerDeps={{ openUrl }}
+      />,
+    );
+    const btn = getByText("Approve & merge").closest("button") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(openUrl).toHaveBeenCalledWith("https://github.com/depre-dev/agent/pull/548");
+    expect(onApproveAndMerge).toHaveBeenCalledWith(card);
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
@@ -17,6 +17,7 @@ import { useEffect, useRef } from "react";
 import { FocusTrap } from "focus-trap-react";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
 import { traverseDrawerCard } from "../../lib/monitor/drawer-routing.js";
+import { buildDrawerFooter, type DrawerActionHandlers, type DrawerFooterDeps } from "../../lib/monitor/drawer-footer.js";
 import { DRAWER_ACCENT, DrawerBody, drawerVariant } from "./DrawerBody.js";
 
 export interface DetailDrawerProps {
@@ -26,9 +27,13 @@ export interface DetailDrawerProps {
   onClose: () => void;
   /** Navigate the drawer to another card id (j/k). */
   onNavigate: (id: string) => void;
+  /** Backend-touching footer actions. Buttons without a handler/data disable. */
+  actions?: DrawerActionHandlers;
+  /** Override clipboard / open-url for tests. */
+  footerDeps?: Pick<DrawerFooterDeps, "openUrl" | "copy">;
 }
 
-export function DetailDrawer({ card, cards, onClose, onNavigate }: DetailDrawerProps) {
+export function DetailDrawer({ card, cards, onClose, onNavigate, actions, footerDeps }: DetailDrawerProps) {
   const variant = drawerVariant(card);
   const accent = DRAWER_ACCENT[variant];
   const asideRef = useRef<HTMLElement | null>(null);
@@ -60,7 +65,10 @@ export function DetailDrawer({ card, cards, onClose, onNavigate }: DetailDrawerP
     return () => window.removeEventListener("keydown", onKey);
   }, [card.id, cards, onClose, onNavigate]);
 
-  const action = "action" in card ? card.action : undefined;
+  const footerButtons = buildDrawerFooter(card, {
+    ...(actions ? { handlers: actions } : {}),
+    ...(footerDeps ?? {}),
+  });
 
   return (
     <FocusTrap
@@ -119,21 +127,30 @@ export function DetailDrawer({ card, cards, onClose, onNavigate }: DetailDrawerP
           </div>
 
           <footer className="hm-drawer-foot">
-            {action ? (
-              <>
-                <button type="button" className="hm-btn hm-btn--action">
-                  {action.primary}
+            {footerButtons.map((btn) =>
+              btn.run ? (
+                <button
+                  key={btn.key}
+                  type="button"
+                  className={`hm-btn hm-btn--${btn.kind}`}
+                  onClick={btn.run}
+                >
+                  {btn.label}
                 </button>
-                {action.secondary ? (
-                  <button type="button" className="hm-btn hm-btn--ghost">
-                    {action.secondary}
-                  </button>
-                ) : null}
-              </>
-            ) : null}
-            <button type="button" className="hm-btn hm-btn--ghost">
-              Ask Hermes
-            </button>
+              ) : (
+                // Truth-boundary: no real action ⇒ visibly disabled WITH a reason.
+                <button
+                  key={btn.key}
+                  type="button"
+                  className={`hm-btn hm-btn--${btn.kind}`}
+                  disabled
+                  aria-disabled="true"
+                  title={btn.disabledReason}
+                >
+                  {btn.label}
+                </button>
+              ),
+            )}
             <span className="spacer" />
             <span className="hm-mono hm-muted">j ‹ prev · k › next · esc close</span>
           </footer>

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildDrawerFooter,
+  githubUrlForCard,
+  missionReportText,
+  type DrawerActionHandlers,
+} from "./drawer-footer.js";
+import type { BoardCard } from "./card-types.js";
+
+function card(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "card-1",
+    lane: "operator-review",
+    type: "pr",
+    agentType: "codex",
+    title: "Test card",
+    summary: "summary",
+    repo: "averray-agent/agent",
+    freshness: 5,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "warn" },
+    files: [],
+    ...over,
+  } as BoardCard;
+}
+
+const missionCard = card({
+  type: "mission",
+  id: "testbed-mission-1",
+  title: "Verify onboarding",
+  mission: {
+    verdict: "PARTIAL",
+    verdictTone: "warn",
+    confidence: 0.6,
+    target: "https://app.testnet.example/onboarding",
+    seed: "fresh · no memory",
+    path: [],
+    blockers: [{ head: "claim", body: "claim button 500s" }],
+    evidence: [],
+    mutationBoundary: "read-only",
+    recommendations: ["Fix the claim endpoint"],
+  },
+});
+// PR number is parsed from the id (#NNN) by relatedPrForCard.
+const actionCard = card({ type: "pr", id: "agent #548", isAction: true });
+const actionCardNoPr = card({ type: "pr", id: "action-no-pr", isAction: true });
+const doneCard = card({ type: "done", id: "rcpt-9", closedAt: "2026-06-01", mergeStatus: "MERGED" });
+const genericPr = card({ type: "pr", id: "agent #12", isAction: false });
+
+function find(buttons: ReturnType<typeof buildDrawerFooter>, key: string) {
+  return buttons.find((b) => b.key === key)!;
+}
+
+describe("githubUrlForCard / missionReportText", () => {
+  it("PR url when a number is present, else the repo url", () => {
+    expect(githubUrlForCard(actionCard)).toBe("https://github.com/averray-agent/agent/pull/548");
+    expect(githubUrlForCard(doneCard)).toBe("https://github.com/averray-agent/agent");
+  });
+  it("mission report text includes target, verdict, blockers, recommendations", () => {
+    const t = missionReportText(missionCard)!;
+    expect(t).toMatch(/app.testnet.example\/onboarding/);
+    expect(t).toMatch(/PARTIAL/);
+    expect(t).toMatch(/claim button 500s/);
+    expect(t).toMatch(/Fix the claim endpoint/);
+    expect(missionReportText(actionCard)).toBeUndefined();
+  });
+});
+
+describe("buildDrawerFooter — mission variant", () => {
+  it("Fresh/Memory run call onRerunMission with the freshness; Copy report copies; Create fix proposes", () => {
+    const copy = vi.fn();
+    const handlers: DrawerActionHandlers = {
+      onRerunMission: vi.fn(),
+      onCreateProductFix: vi.fn(),
+    };
+    const f = buildDrawerFooter(missionCard, { handlers, copy });
+    find(f, "fresh-run").run!();
+    expect(handlers.onRerunMission).toHaveBeenLastCalledWith(missionCard, "fresh");
+    find(f, "memory-run").run!();
+    expect(handlers.onRerunMission).toHaveBeenLastCalledWith(missionCard, "memory");
+    find(f, "copy-report").run!();
+    expect(copy).toHaveBeenCalledWith(expect.stringContaining("Mission report"));
+    find(f, "create-product-fix").run!();
+    expect(handlers.onCreateProductFix).toHaveBeenCalledWith(missionCard);
+  });
+
+  it("disables rerun / create-fix (with a reason) when no handler is wired", () => {
+    const f = buildDrawerFooter(missionCard, {});
+    expect(find(f, "fresh-run").run).toBeUndefined();
+    expect(find(f, "fresh-run").disabledReason).toMatch(/isn't available/i);
+    expect(find(f, "create-product-fix").disabledReason).toMatch(/isn't available/i);
+  });
+
+  it("disables Copy report when the mission has no report", () => {
+    const f = buildDrawerFooter(card({ type: "mission", id: "m2", title: "x" }), {});
+    expect(find(f, "copy-report").run).toBeUndefined();
+    expect(find(f, "copy-report").disabledReason).toMatch(/no mission report/i);
+  });
+});
+
+describe("buildDrawerFooter — action (PR) variant", () => {
+  it("Approve & merge OPENS GitHub and records approval — the board never merges", () => {
+    const openUrl = vi.fn();
+    const onApproveAndMerge = vi.fn();
+    const f = buildDrawerFooter(actionCard, { openUrl, handlers: { onApproveAndMerge } });
+    find(f, "approve-merge").run!();
+    expect(openUrl).toHaveBeenCalledWith("https://github.com/averray-agent/agent/pull/548");
+    expect(onApproveAndMerge).toHaveBeenCalledWith(actionCard);
+  });
+
+  it("Approve & merge disables when there's no linked PR (no silent no-op)", () => {
+    const f = buildDrawerFooter(actionCardNoPr, { handlers: { onApproveAndMerge: vi.fn() } });
+    expect(find(f, "approve-merge").run).toBeUndefined();
+    expect(find(f, "approve-merge").disabledReason).toMatch(/no linked PR/i);
+  });
+
+  it("Send back to Codex requires a handler AND a PR number", () => {
+    const onSendBackToCodex = vi.fn();
+    const withPr = buildDrawerFooter(actionCard, { handlers: { onSendBackToCodex } });
+    find(withPr, "send-back-codex").run!();
+    expect(onSendBackToCodex).toHaveBeenCalledWith(actionCard);
+
+    const noPr = buildDrawerFooter(actionCardNoPr, { handlers: { onSendBackToCodex } });
+    expect(find(noPr, "send-back-codex").run).toBeUndefined();
+    expect(find(noPr, "send-back-codex").disabledReason).toMatch(/no linked PR/i);
+  });
+});
+
+describe("buildDrawerFooter — done + generic variants", () => {
+  it("View on github opens, Copy receipt id copies the card id", () => {
+    const openUrl = vi.fn();
+    const copy = vi.fn();
+    const f = buildDrawerFooter(doneCard, { openUrl, copy });
+    find(f, "view-github").run!();
+    expect(openUrl).toHaveBeenCalledWith("https://github.com/averray-agent/agent");
+    find(f, "copy-receipt").run!();
+    expect(copy).toHaveBeenCalledWith("rcpt-9");
+  });
+
+  it("generic card → Open on github (enabled when a PR url exists)", () => {
+    const openUrl = vi.fn();
+    const f = buildDrawerFooter(genericPr, { openUrl });
+    find(f, "open-github").run!();
+    expect(openUrl).toHaveBeenCalledWith("https://github.com/averray-agent/agent/pull/12");
+  });
+});
+
+describe("buildDrawerFooter — Ask Hermes on every variant", () => {
+  it("calls onAskHermes when wired; disables with a reason otherwise", () => {
+    const onAskHermes = vi.fn();
+    for (const c of [missionCard, actionCard, doneCard, genericPr]) {
+      const wired = buildDrawerFooter(c, { handlers: { onAskHermes } });
+      find(wired, "ask-hermes").run!();
+      expect(onAskHermes).toHaveBeenLastCalledWith(c);
+      const unwired = buildDrawerFooter(c, {});
+      expect(find(unwired, "ask-hermes").run).toBeUndefined();
+      expect(find(unwired, "ask-hermes").disabledReason).toMatch(/isn't available/i);
+    }
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
@@ -1,0 +1,176 @@
+// Hermes Handoff Monitor — drawer footer actions (truth-boundary).
+//
+// The DetailDrawer footer rendered active buttons that silently no-op'd. This
+// turns each into either a REAL action (existing endpoints / client-side
+// clipboard+GitHub) or a button DISABLED with a tooltip reason — never a live
+// control that does nothing.
+//
+// Pure + dependency-injected (openUrl / copy / backend handlers) so every button
+// is unit-tested without a DOM or network. The board never merges/deploys: the
+// merge button only OPENS GitHub (the human merges there) and optionally records
+// operator approval.
+
+import type { BoardCard } from "./card-types.js";
+import { relatedPrForCard } from "./collaboration.js";
+import { drawerVariant } from "../../components/drawer/DrawerBody.js";
+
+export type FooterButtonKind = "primary" | "action" | "ghost";
+
+export interface FooterButton {
+  key: string;
+  label: string;
+  kind: FooterButtonKind;
+  /** Present ⇒ the button is enabled and this is its action. */
+  run?: () => void;
+  /** Present ⇒ the button is disabled and this is the tooltip reason. */
+  disabledReason?: string;
+}
+
+export interface DrawerActionHandlers {
+  /** Re-run a mission via POST /monitor/testbed-missions (fresh = no memory). */
+  onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
+  /** Propose a product-fix task with the report appended (operator approves). */
+  onCreateProductFix?: (card: BoardCard) => void;
+  /** Record operator approval on the board (the merge itself stays on GitHub). */
+  onApproveAndMerge?: (card: BoardCard) => void;
+  /** Return the item to the codex-needed/dispatch path. */
+  onSendBackToCodex?: (card: BoardCard) => void;
+  /** Focus the co-pilot composer scoped to this card. */
+  onAskHermes?: (card: BoardCard) => void;
+}
+
+export interface DrawerFooterDeps {
+  handlers?: DrawerActionHandlers;
+  /** Open a URL (default: window.open new tab). Injected for tests. */
+  openUrl?: (url: string) => void;
+  /** Copy text to the clipboard. Injected for tests. */
+  copy?: (text: string) => void;
+}
+
+/** The PR-specific GitHub URL for a card (number parsed from the id), or undefined. */
+export function pullRequestUrlForCard(card: BoardCard): string | undefined {
+  const pr = relatedPrForCard(card);
+  return pr ? `https://github.com/${pr.repo}/pull/${pr.number}` : undefined;
+}
+
+/** The GitHub URL for a card: the PR when it resolves, else the repo. */
+export function githubUrlForCard(card: BoardCard): string | undefined {
+  return pullRequestUrlForCard(card) ?? (card.repo ? `https://github.com/${card.repo}` : undefined);
+}
+
+/** A human-readable mission report for clipboard / fix-task evidence. */
+export function missionReportText(card: BoardCard): string | undefined {
+  if (card.type !== "mission" || !card.mission) return undefined;
+  const m = card.mission;
+  const lines = [
+    `Mission report — ${card.title}`,
+    `Target: ${m.target}`,
+    `Verdict: ${m.verdict} (confidence ${Math.round((m.confidence ?? 0) * 100)}%)`,
+    ...(m.blockers.length ? ["", "Blockers:", ...m.blockers.map((b) => `- ${b.head}: ${b.body}`)] : []),
+    ...(m.recommendations.length ? ["", "Recommendations:", ...m.recommendations.map((r) => `- ${r}`)] : []),
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Build the variant-specific footer buttons. Each is either enabled (`run`) or
+ * disabled with a `disabledReason`. Lazily references deps so tests can assert
+ * exactly which side-effect a click triggers.
+ */
+export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}): FooterButton[] {
+  const h = deps.handlers ?? {};
+  const openUrl = deps.openUrl ?? ((url: string) => { if (typeof window !== "undefined") window.open(url, "_blank", "noopener,noreferrer"); });
+  const copy = deps.copy ?? ((text: string) => { void navigator?.clipboard?.writeText?.(text); });
+  const variant = drawerVariant(card);
+  const url = githubUrlForCard(card);
+  const buttons: FooterButton[] = [];
+
+  if (variant === "mission") {
+    buttons.push({
+      key: "fresh-run",
+      label: "Fresh run",
+      kind: "primary",
+      ...(h.onRerunMission
+        ? { run: () => h.onRerunMission!(card, "fresh") }
+        : { disabledReason: "Re-running a mission isn't available here." }),
+    });
+    buttons.push({
+      key: "memory-run",
+      label: "Memory run",
+      kind: "ghost",
+      ...(h.onRerunMission
+        ? { run: () => h.onRerunMission!(card, "memory") }
+        : { disabledReason: "Re-running a mission isn't available here." }),
+    });
+    const report = missionReportText(card);
+    buttons.push({
+      key: "copy-report",
+      label: "Copy report",
+      kind: "ghost",
+      ...(report ? { run: () => copy(report) } : { disabledReason: "No mission report to copy yet." }),
+    });
+    buttons.push({
+      key: "create-product-fix",
+      label: "Create product fix → Codex",
+      kind: "action",
+      ...(h.onCreateProductFix
+        ? { run: () => h.onCreateProductFix!(card) }
+        : { disabledReason: "Proposing a fix task isn't available here." }),
+    });
+  } else if (variant === "action") {
+    // Merging needs the SPECIFIC PR (the repo url isn't enough), so this path
+    // requires a resolved pull-request url — never the repo fallback.
+    const prUrl = pullRequestUrlForCard(card);
+    buttons.push({
+      key: "approve-merge",
+      label: "Approve & merge",
+      kind: "action",
+      // The board NEVER merges — it opens the GitHub merge UI (human merges)
+      // and records operator approval if that path is wired.
+      ...(prUrl
+        ? { run: () => { openUrl(prUrl); h.onApproveAndMerge?.(card); } }
+        : { disabledReason: "No linked PR to merge on GitHub." }),
+    });
+    const hasPr = Boolean(relatedPrForCard(card));
+    buttons.push({
+      key: "send-back-codex",
+      label: "Send back to Codex",
+      kind: "ghost",
+      // Codex iterates an existing PR, so send-back needs a linked PR number.
+      ...(h.onSendBackToCodex && hasPr
+        ? { run: () => h.onSendBackToCodex!(card) }
+        : { disabledReason: h.onSendBackToCodex ? "No linked PR to send back to Codex." : "Sending back to Codex isn't available here." }),
+    });
+  } else if (variant === "done") {
+    buttons.push({
+      key: "view-github",
+      label: "View on github",
+      kind: "ghost",
+      ...(url ? { run: () => openUrl(url) } : { disabledReason: "No GitHub link for this card." }),
+    });
+    buttons.push({
+      key: "copy-receipt",
+      label: "Copy receipt id",
+      kind: "ghost",
+      run: () => copy(card.id),
+    });
+  } else {
+    buttons.push({
+      key: "open-github",
+      label: "Open on github",
+      kind: "primary",
+      ...(url ? { run: () => openUrl(url) } : { disabledReason: "No GitHub link for this card." }),
+    });
+  }
+
+  buttons.push({
+    key: "ask-hermes",
+    label: "Ask Hermes",
+    kind: "ghost",
+    ...(h.onAskHermes
+      ? { run: () => h.onAskHermes!(card) }
+      : { disabledReason: "Ask Hermes isn't available here." }),
+  });
+
+  return buttons;
+}


### PR DESCRIPTION
## What changed & why

**Dead controls fixed (truth-boundary):** the `DetailDrawer` footer rendered active buttons that silently no-op'd. Each is now either a **real action** (via the endpoints the board already uses, or client-side clipboard/GitHub) or a button **disabled with a tooltip reason** — never live-but-no-op.

### Pure builder — `lib/monitor/drawer-footer.ts`
`buildDrawerFooter(card, deps)` returns the variant's footer buttons, each either enabled (`run`) or disabled (`disabledReason`). Dependency-injected (`openUrl` / `copy` / `handlers`) so every button is unit-tested with no DOM/network. PR URLs resolve via the canonical `relatedPrForCard` (`#NNN` from the card id).

- **Mission:** **Fresh run** / **Memory run** → `onRerunMission(card, freshness)` (POST `/monitor/testbed-missions`, `freshMemory` flag); **Copy report** → clipboard; **Create product fix → Codex** → proposes a greenfield task with the report appended (operator approves; **never auto-dispatched**).
- **Action / PR:** **Approve & merge** → **opens the GitHub PR** (the human merges there) **and** records operator approval via `onApproveTask`. **The board never merges** (AGENTS invariant) — disabled when no PR resolves. **Send back to Codex** → proposes a codex task for the PR (needs a PR number, else disabled with a reason).
- **Closed:** **View on github** → opens; **Copy receipt id** → clipboard (the card id).
- **Generic:** **Open on github** → opens the PR/repo url.
- **Ask Hermes** (all variants): closes the modal + focuses the rail composer scoped to the card.

Every disabled button carries an honest `title` reason ("No linked PR to merge on GitHub.", "Re-running a mission isn't available here.", …).

### Wiring
`BoardView` composes the footer handlers from its **existing** props (`onCreateTask`, `onApproveTask`, `onRerunMission`) — **no new authority**, only paths the board already uses (propose / approve / open GitHub). `MonitorPage` adds a default `onRerunMission` (same `/monitor/testbed-missions` endpoint + `freshMemory`).

## Affected surfaces
- [x] Monitor board / slack-operator (frontend only — `packages/monitor-ui`)
- [x] Docs / tests only (reuses existing endpoints; no new backend, no authority change)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1194 passed; new tests below)
- [x] `vite build` (monitor-ui)

### Tests (one per newly-wired control)
- `drawer-footer` pure builder, per variant: each enabled button's click triggers the right injected dep/handler (`openUrl` / `copy` / `onRerunMission` / `onCreateProductFix` / `onApproveAndMerge` / `onSendBackToCodex` / `onAskHermes`); each disables with a reason when its handler/data is missing.
- `DetailDrawer` render: an action lacking a backend renders **disabled with a `title` reason** (truth-boundary); **Approve & merge** opens the GitHub PR url + records approval (never merges in-board).

## Durable invariants (AGENTS.md)
- [x] **Merge/deploy stays human** — Approve & merge only *opens* GitHub and records operator approval; the board performs no merge.
- [x] **Truth-boundary** — every footer button performs its real action or is visibly disabled with a reason; no active-but-no-op control remains.
- [x] **No new authority** — composes existing propose/approve/open-GitHub paths; "Create product fix" and "Send back to Codex" only *propose* (operator approves), never auto-dispatch.
- [x] No secrets; operator-private data unaffected (this group adds none).

## Known limits / follow-ups
- "Create product fix" proposes a **greenfield** fix (no existing PR) so it routes to the Claude worker; the "→ Codex" label reflects the codex-needed dispatch lane it lands in.
- Group 2 of 4 from the dead-control audit (Group 1 = filter chips, #328). Groups 3–4 (co-pilot rail, keep-watching + operator notes) follow as their own narrow PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)