### PR TITLE
Group 3: wire the co-pilot composer chips + suggestion fill (truth-boundary)

### DIFF
--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -80,7 +80,8 @@ describe("AskHermesComposer", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     type(input, "what's blocking #548?");
     fireEvent.click(getByRole("button", { name: /Send/ }));
-    expect(onAsk).toHaveBeenCalledWith("what's blocking #548?");
+    // No focused card → the question is board-scoped.
+    expect(onAsk).toHaveBeenCalledWith("what's blocking #548?", { scope: "board" });
     expect(input.value).toBe("");
   });
 
@@ -155,5 +156,40 @@ describe("AskHermesComposer", () => {
     fireEvent.click(getByRole("button", { name: /Send/ }));
     expect(onCreateTask).not.toHaveBeenCalled();
     expect(within(container).getByRole("alert").textContent).toMatch(/not a valid agent/i);
+  });
+});
+
+describe("AskHermesComposer — G3 compose chips + prefill", () => {
+  test("scope chip toggles the scope passed to onAsk", () => {
+    const onAsk = vi.fn();
+    const { container, getByRole, getByText } = render(
+      <AskHermesComposer onAsk={onAsk} focusedCardId="agent #548" />,
+    );
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    // Default: scoped to the focused card.
+    type(input, "why did this fail?");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onAsk).toHaveBeenLastCalledWith("why did this fail?", { scope: "card" });
+    // Toggle the scope chip → whole board.
+    fireEvent.click(getByText(/^scope ·/).closest("button") as HTMLElement);
+    type(input, "board status?");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onAsk).toHaveBeenLastCalledWith("board status?", { scope: "board" });
+  });
+
+  test("the 'to' chip is an honest recipient label, not a fake toggle", () => {
+    const { getByText } = render(<AskHermesComposer onAsk={vi.fn()} />);
+    const to = getByText("to · Hermes");
+    expect(to.tagName).toBe("SPAN"); // informational, not a button
+  });
+
+  test("prefill drops suggestion text into the composer when the token bumps", () => {
+    const { container, rerender } = render(
+      <AskHermesComposer onAsk={vi.fn()} prefill="" prefillToken={0} />,
+    );
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    expect(input.value).toBe("");
+    rerender(<AskHermesComposer onAsk={vi.fn()} prefill="Investigate the flaky test" prefillToken={1} />);
+    expect(input.value).toBe("Investigate the flaky test");
   });
 });

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -19,8 +19,12 @@ export interface AskHermesComposerProps {
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Propose a task (/task <agent> [<repo>#<pr>] <prompt>). */
   onCreateTask?: (input: CreateTaskInput) => void;
-  /** Ask Hermes a free-form question. */
-  onAsk?: (text: string) => void;
+  /** Ask Hermes a free-form question, scoped to the focused card or the whole board. */
+  onAsk?: (text: string, opts?: { scope: "card" | "board" }) => void;
+  /** Prefill the composer with this text (e.g. a suggestion chip). */
+  prefill?: string;
+  /** Bump to (re)apply `prefill` into the input + focus it. */
+  prefillToken?: number;
   /** Mute action alerts until an absolute timestamp (/mute). */
   onMute?: (untilMs: number) => void;
   /** Clear the mute (/unmute). */
@@ -50,17 +54,34 @@ export function AskHermesComposer({
   onSetAutopilot,
   onSetSupervised,
   autonomyMode,
+  prefill,
+  prefillToken,
   focusedCardId,
   focusToken,
 }: AskHermesComposerProps) {
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Scope a question to the focused card or the whole board. When no card is
+  // focused there's nothing to scope to, so it's board-only.
+  const [scopeToCard, setScopeToCard] = useState(true);
+  const effectiveScope: "card" | "board" = focusedCardId && scopeToCard ? "card" : "board";
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // The board's `a` shortcut bumps focusToken to bring focus here.
   useEffect(() => {
     if (focusToken) inputRef.current?.focus();
   }, [focusToken]);
+
+  // A suggestion chip / prefill bumps prefillToken to drop its text in + focus.
+  useEffect(() => {
+    if (prefillToken) {
+      setValue(prefill ?? "");
+      setError(null);
+      inputRef.current?.focus();
+    }
+    // Only re-apply when the token changes (an explicit prefill action).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefillToken]);
 
   const send = () => {
     const command = parseHermesInput(value);
@@ -128,7 +149,7 @@ export function AskHermesComposer({
         return;
       case "ask":
         if (onAsk) {
-          onAsk(command.text);
+          onAsk(command.text, { scope: effectiveScope });
           setValue("");
           setError(null);
         } else {
@@ -148,8 +169,25 @@ export function AskHermesComposer({
   return (
     <div className="hm-compose">
       <div className="hm-compose-toolbar">
-        <span className="hm-compose-chip is-on">to · operator</span>
-        <span className="hm-compose-chip">scope · {focusedCardId ?? "board"}</span>
+        {/* Honest recipient label: a question posts to the Hermes collaboration
+            channel as the operator. Targeting other agents isn't a wired action,
+            so this is informational, not a fake toggle. */}
+        <span className="hm-compose-chip is-on">to · Hermes</span>
+        {/* Scope toggle: actually controls whether a question is scoped to the
+            focused card or the whole board on send. Board-only with no card. */}
+        {focusedCardId ? (
+          <button
+            type="button"
+            className={"hm-compose-chip" + (scopeToCard ? " is-on" : "")}
+            aria-pressed={scopeToCard}
+            title={scopeToCard ? "Scoped to this card — click for the whole board" : "Whole board — click to scope to this card"}
+            onClick={() => setScopeToCard((s) => !s)}
+          >
+            scope · {scopeToCard ? focusedCardId : "board"}
+          </button>
+        ) : (
+          <span className="hm-compose-chip">scope · board</span>
+        )}
         {onSetAutopilot && onSetSupervised ? (
           <button
             type="button"

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -115,3 +115,32 @@ describe("CoPilotRail", () => {
     expect(onCardClick).toHaveBeenCalledWith("task-activity-1");
   });
 });
+
+describe("CoPilotRail — G3 suggestion → composer", () => {
+  test("'Use in composer' fills the Ask-Hermes input with the suggested prompt", () => {
+    const backlogSuggestions = {
+      generatedAt: "2026-06-01T00:00:00Z",
+      suggestions: [
+        {
+          id: "sug-1",
+          title: "Add a regression test for the claim flow",
+          reason: "the last mission flagged it",
+          suggestedOwner: "test-writer" as const,
+          riskTier: "low" as const,
+          related: { cardId: "agent #548" },
+          suggestedPrompt: "Write a vitest covering the claim-stake floor override",
+          confidence: 0.7,
+        },
+      ],
+    };
+    const { container, getByText } = render(
+      <CoPilotRail backlogSuggestions={backlogSuggestions} boardCards={[card548]} />,
+      { wrapper },
+    );
+    // Open the suggestions block, then click "Use in composer".
+    fireEvent.click(getByText(/Suggested follow-ups/));
+    fireEvent.click(getByText("Use in composer"));
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    expect(input.value).toBe("Write a vitest covering the claim-stake floor override");
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -73,6 +73,13 @@ export function CoPilotRail({
   const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
   const relatedPr = relatedPrForCard(focusedCard);
   const streamRef = useRef<HTMLDivElement>(null);
+  // Suggestion chips fill the composer: hold the text + a bump token.
+  const [prefill, setPrefill] = useState("");
+  const [prefillToken, setPrefillToken] = useState(0);
+  const fillComposer = (text: string) => {
+    setPrefill(text);
+    setPrefillToken((t) => t + 1);
+  };
   const activity = useMemo(
     () => buildHermesActivityFeed({
       cards: boardCards ?? [],
@@ -114,6 +121,7 @@ export function CoPilotRail({
         response={backlogSuggestions}
         boardCards={boardCards ?? []}
         onCardClick={onCardClick}
+        onUseInComposer={fillComposer}
       />
 
       <section className="hm-activity" aria-label="Hermes activity">
@@ -132,13 +140,15 @@ export function CoPilotRail({
         onSpawnMission={onSpawnMission}
         onSpawnClaudeTask={onSpawnClaudeTask}
         onCreateTask={onCreateTask}
-        onAsk={(text) => ask(text, relatedPr)}
+        onAsk={(text, opts) => ask(text, opts?.scope === "board" ? undefined : relatedPr)}
         onMute={onMute}
         onUnmute={onUnmute}
         muted={muted}
         onSetAutopilot={onSetAutopilot}
         onSetSupervised={onSetSupervised}
         autonomyMode={autonomyMode}
+        prefill={prefill}
+        prefillToken={prefillToken}
         focusedCardId={focusedCard?.id ?? null}
         focusToken={composerFocusToken}
       />
@@ -187,10 +197,12 @@ function BacklogSuggestionsRailBlock({
   response,
   boardCards,
   onCardClick,
+  onUseInComposer,
 }: {
   response?: BacklogSuggestionsResponse;
   boardCards: readonly BoardCard[];
   onCardClick?: (id: string) => void;
+  onUseInComposer?: (text: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const bodyId = useId();
@@ -222,6 +234,7 @@ function BacklogSuggestionsRailBlock({
               suggestion={suggestion}
               relatedCard={cardsById.get(suggestion.related.cardId)}
               onCardClick={onCardClick}
+              onUseInComposer={onUseInComposer}
               key={suggestion.id}
             />
           )) : (
@@ -237,10 +250,12 @@ function BacklogSuggestionRow({
   suggestion,
   relatedCard,
   onCardClick,
+  onUseInComposer,
 }: {
   suggestion: BacklogSuggestion;
   relatedCard?: BoardCard;
   onCardClick?: (id: string) => void;
+  onUseInComposer?: (text: string) => void;
 }) {
   const copyPrompt = () => {
     if (!suggestion.suggestedPrompt || typeof navigator === "undefined") return;
@@ -268,6 +283,15 @@ function BacklogSuggestionRow({
         ) : (
           <span className="hm-backlog-link">linked card</span>
         )
+      ) : null}
+      {suggestion.suggestedPrompt && onUseInComposer ? (
+        <button
+          type="button"
+          className="hm-backlog-use"
+          onClick={() => onUseInComposer(suggestion.suggestedPrompt!)}
+        >
+          Use in composer
+        </button>
       ) : null}
       {suggestion.suggestedPrompt ? (
         <button type="button" className="hm-backlog-copy" onClick={copyPrompt}>


### PR DESCRIPTION
## What changed & why

**Dead controls fixed (truth-boundary).** Against the **shipped** rail — which diverged from the v2 mock — the only live-but-no-op controls are the composer's static chips. The shipped rail **already** wires suggestion "Copy prompt" / "Open card" and activity→card links, and has **no** no-op `⌖`/`⌫`/`↗` icons, so there are none to fix or omit.

- **Scope chip → real toggle.** It now controls whether an Ask-Hermes question is scoped to the **focused card** (`relatedPr`) or the **whole board** on send. `onAsk` takes `{ scope }`; `CoPilotRail` passes `relatedPr` only for card scope. Board-only when no card is focused.
- **"to" chip → honest, non-interactive label** (`to · Hermes` — the real recipient of a posted question). Targeting other agents isn't a wired send path (`ask()` has no target argument), so per *"omit any you won't truly implement"* it's informational, **not a fake toggle**.
- **Suggestion chips → fill the composer.** Backlog suggestion rows gain a **"Use in composer"** action that drops the suggested prompt into the input and focuses it (a `prefill` token on `AskHermesComposer`). "Copy prompt" stays.
- **Pin / card links** are already real in the shipped rail (activity rows + "Open card" call `onCardClick`) — left as-is; nothing to fix.

## Affected surfaces
- [x] Monitor board / slack-operator (frontend only — `packages/monitor-ui`)
- [x] Docs / tests only (no backend/endpoint/authority change)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1200 passed; new tests below)
- [x] `vite build` (monitor-ui)

### Tests (per newly-wired control)
- Scope chip toggles the `scope` passed to `onAsk` (`card` ↔ `board`).
- The "to" chip is a `<span>` (informational), not a button — no fake toggle.
- `prefill` drops text into the input when the token bumps.
- `CoPilotRail` "Use in composer" fills the Ask-Hermes input with the suggested prompt.

## Durable invariants (AGENTS.md)
- [x] **Truth-boundary:** every composer chip either performs its real action (scope toggle, suggestion fill) or is an honest informational label — no active-but-no-op control, and no no-op icons added.
- [x] **No new authority:** scope only changes the `relatedPr` on an existing question post; no new endpoint, no merge/deploy, no agent targeting that the backend can't honor.
- [x] No secrets; operator-private data unaffected.

## Known limits / follow-ups
- The shipped `CoPilotRail` diverged from the mock's `⌖`/`⌫`/`↗` rail tools — those elements don't exist in the shipped component, so there was nothing to wire or remove. If that toolset is wanted, it's a separate design-add (and `clear`/`detach` would need real behavior or be omitted).
- Agent-target send (`to · Codex`/operator) needs a backend `target` on the collaboration post; deferred rather than faked.
- Group 3 of 4 (G1 filter chips #328, G2 drawer actions #330 merged/open). G4 (keep-watching + operator notes persistence) follows as its own PR(s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)