### PR TITLE
Polish monitor mission drawer

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -82,14 +82,21 @@ describe("DetailDrawer — shell", () => {
 describe("DetailDrawer — variants", () => {
   test("action PR shows the risk eyebrow, Hermes verdict, files, and CTA", () => {
     const card = fixture("agent #548");
-    const { getByText } = render(
+    const { getByRole, getByText } = render(
       <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
     );
     expect(getByText("Operator review · risk decision")).toBeTruthy();
     expect(getByText("Hermes verdict")).toBeTruthy();
     expect(getByText("agent/contracts/AgentAccountCore.sol")).toBeTruthy();
-    expect(getByText("Approve & merge")).toBeTruthy();
-    expect(getByText("Send back to Codex")).toBeTruthy();
+    const author = getByText("author").parentElement;
+    expect(author?.textContent).toContain("codex");
+    expect(getByRole("link", { name: /open on github/i }).getAttribute("href")).toBe(
+      "https://github.com/depre-dev/agent/pull/548",
+    );
+    const approve = getByRole("button", { name: /Approve & merge\s*A/i });
+    const sendBack = getByRole("button", { name: /Send back to Codex\s*B/i });
+    expect(within(approve).getByText("A")).toBeTruthy();
+    expect(within(sendBack).getByText("B")).toBeTruthy();
   });
 
   test("rich PR statuses: per-check breakdown, risk signals, and colored file diff render", () => {
@@ -180,6 +187,11 @@ describe("DetailDrawer — variants", () => {
     expect(getByText(/Read-only mission/)).toBeTruthy();
     // Recommendations
     expect(getByText("Hermes recommends")).toBeTruthy();
+    // Static mission contract reference
+    expect(getByText("Spec · /mission spawn flow")).toBeTruthy();
+    expect(getByText(/A mission is a first-class work item/)).toBeTruthy();
+    expect(getByText("POST /missions")).toBeTruthy();
+    expect(getByText("GET /missions/:id")).toBeTruthy();
     expect(container.querySelectorAll(".hm-mpath .step").length).toBe(6);
   });
 
@@ -270,6 +282,7 @@ describe("DetailDrawer — variants", () => {
     );
     expect(getByText("Mission · no report yet")).toBeTruthy();
     expect(getByText(/no structured report yet/i)).toBeTruthy();
+    expect(getByText("Spec · /mission spawn flow")).toBeTruthy();
   });
 });
 

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
@@ -33,10 +33,34 @@ export interface DetailDrawerProps {
   footerDeps?: Pick<DrawerFooterDeps, "openUrl" | "copy">;
 }
 
+function githubBranchPath(branch: string): string {
+  return branch.split("/").map(encodeURIComponent).join("/");
+}
+
+function githubUrlForCard(card: BoardCard): string | undefined {
+  if (!/^[^/\s]+\/[^/\s]+$/.test(card.repo)) return undefined;
+  const pullRequestNumber =
+    card.decisionRecord?.subject.pullRequestNumber ?? Number.parseInt(card.id.match(/#(\d+)/)?.[1] ?? "", 10);
+  if (Number.isFinite(pullRequestNumber)) {
+    return `https://github.com/${card.repo}/pull/${pullRequestNumber}`;
+  }
+  if (card.branch) {
+    return `https://github.com/${card.repo}/tree/${githubBranchPath(card.branch)}`;
+  }
+  return `https://github.com/${card.repo}`;
+}
+
+function footerHint(key: string): "A" | "B" | undefined {
+  if (key === "approve-merge") return "A";
+  if (key === "send-back-codex") return "B";
+  return undefined;
+}
+
 export function DetailDrawer({ card, cards, onClose, onNavigate, actions, footerDeps }: DetailDrawerProps) {
   const variant = drawerVariant(card);
   const accent = DRAWER_ACCENT[variant];
   const asideRef = useRef<HTMLElement | null>(null);
+  const githubUrl = githubUrlForCard(card);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -119,6 +143,14 @@ export function DetailDrawer({ card, cards, onClose, onNavigate, actions, footer
                   <span className="hm-muted">waiting on</span> {card.waitingOn.actor}
                 </span>
               ) : null}
+              <span>
+                <span className="hm-muted">author</span> {card.agentType}
+              </span>
+              {githubUrl ? (
+                <a href={githubUrl} target="_blank" rel="noreferrer">
+                  open on github ↗
+                </a>
+              ) : null}
             </div>
           </header>
 
@@ -127,15 +159,22 @@ export function DetailDrawer({ card, cards, onClose, onNavigate, actions, footer
           </div>
 
           <footer className="hm-drawer-foot">
-            {footerButtons.map((btn) =>
-              btn.run ? (
+            {footerButtons.map((btn) => {
+              const hint = footerHint(btn.key);
+              const label = (
+                <>
+                  <span>{btn.label}</span>
+                  {hint ? <span className="hm-kbd">{hint}</span> : null}
+                </>
+              );
+              return btn.run ? (
                 <button
                   key={btn.key}
                   type="button"
                   className={`hm-btn hm-btn--${btn.kind}`}
                   onClick={btn.run}
                 >
-                  {btn.label}
+                  {label}
                 </button>
               ) : (
                 // Truth-boundary: no real action ⇒ visibly disabled WITH a reason.
@@ -147,10 +186,10 @@ export function DetailDrawer({ card, cards, onClose, onNavigate, actions, footer
                   aria-disabled="true"
                   title={btn.disabledReason}
                 >
-                  {btn.label}
+                  {label}
                 </button>
-              ),
-            )}
+              );
+            })}
             <span className="spacer" />
             <span className="hm-mono hm-muted">j ‹ prev · k › next · esc close</span>
           </footer>

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -371,15 +371,53 @@ function DoneBody({ card }: { card: DoneCard }) {
   );
 }
 
+function MissionSpecDetails() {
+  return (
+    <details className="hm-spec" open>
+      <summary>Spec · /mission spawn flow</summary>
+      <div className="body">
+        <p style={{ margin: "0 0 8px" }}>
+          A mission is a first-class work item, not a side-effect of a PR. The flow is symmetric to PR review but
+          operates against a live URL, not a diff.
+        </p>
+        <p style={{ margin: "4px 0" }}>
+          <span className="endpoint">POST /missions</span> ·{" "}
+          <code>{`{ prompt, target_url, freshness: 'fresh' | 'memory', memory_seed? }`}</code> →{" "}
+          <code>{`{ mission_id }`}</code>
+        </p>
+        <p style={{ margin: "4px 0" }}>
+          <span className="endpoint">GET /missions/:id</span> · streams structured report fields as they arrive (
+          <code>verdict</code>, <code>confidence</code>, <code>path</code>, <code>blockers</code>, <code>evidence</code>,{" "}
+          <code>mutation_boundary</code>, <code>recommendations</code>).
+        </p>
+        <p style={{ margin: "4px 0" }}>
+          <b>Fresh run:</b> new agent, no prior context. Reseeds confidence scoring from zero.
+        </p>
+        <p style={{ margin: "4px 0" }}>
+          <b>Memory run:</b> agent reads the last terminal report as context. Faster, more biased.
+        </p>
+        <p style={{ margin: "4px 0" }}>
+          <b>Create product fix:</b> takes the top recommendation and posts to{" "}
+          <span className="endpoint">POST /codex/tasks</span> with the mission report appended as evidence. Operator
+          approves before dispatch.
+        </p>
+      </div>
+    </details>
+  );
+}
+
 function MissionBody({ card }: { card: MissionCard }) {
   // `mission` is required on the type, but a live mission card has no
   // structured report until the browser agent posts one. Read defensively.
   const m = (card as { mission?: MissionCard["mission"] }).mission;
   if (!m) {
     return (
-      <VerdictBlock head="Mission · no report yet" accent="var(--hm-hermes-deep)">
-        {card.summary || "No structured report yet — the browser agent hasn't posted one."}
-      </VerdictBlock>
+      <>
+        <VerdictBlock head="Mission · no report yet" accent="var(--hm-hermes-deep)">
+          {card.summary || "No structured report yet — the browser agent hasn't posted one."}
+        </VerdictBlock>
+        <MissionSpecDetails />
+      </>
     );
   }
   const verdictColor =
@@ -525,6 +563,7 @@ function MissionBody({ card }: { card: MissionCard }) {
           </div>
         </section>
       ) : null}
+      <MissionSpecDetails />
     </>
   );
 }


### PR DESCRIPTION
## What changed & why

This is the second narrow monitor UI polish slice from the Hermes v2 handoff.

- Adds the mission drawer's `Spec · /mission spawn flow` disclosure from the design handoff so mission cards explain the real `/missions` and `/codex/tasks` flow.
- Adds drawer header author attribution and a real GitHub link derived from card repo/PR/branch data.
- Adds `[A]` / `[B]` key hints to the drawer footer action buttons.
- Extends drawer tests for the new mission spec, author/GitHub metadata, and footer hints.

No authority changes; this is display/control polish only.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Normal frontend rollout. Roll back by reverting this PR.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

Follow-up slices still open from the handoff: co-pilot per-turn anatomy and suggestion chips.
