### PR TITLE
Group 4a: wire "Keep watching" on the archive hint (truth-boundary)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -419,3 +419,15 @@ function doneCard(overrides: Partial<BoardCard> = {}): BoardCard {
     ...overrides,
   } as BoardCard;
 }
+
+describe("BoardView — keep watching (G4)", () => {
+  test("'Keep watching' cancels the card's archive hint", () => {
+    const { container } = render(<BoardView board={richBoard} status="open" />);
+    const view = within(container);
+    // The archiveHint fixture (agent #542) shows the "Keep watching" affordance.
+    const keep = view.getByRole("button", { name: "Keep watching" });
+    fireEvent.click(keep);
+    // The archive prompt is suppressed for that card.
+    expect(view.queryByRole("button", { name: "Keep watching" })).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -151,14 +151,19 @@ export function BoardView({
   const rawCards = board?.cards ?? [];
   const [dismissedCardIds, setDismissedCardIds] = useState<ReadonlySet<string>>(() => new Set());
   const [snoozedUntilById, setSnoozedUntilById] = useState<ReadonlyMap<string, number>>(() => new Map());
+  // "Keep watching" cancels a card's archive hint for this session — the
+  // operator opted to keep it, so we suppress the "archive in 4h?" prompt.
+  const [keptCardIds, setKeptCardIds] = useState<ReadonlySet<string>>(() => new Set());
   const cards = useMemo(() => {
     const nowMs = Date.now();
-    return rawCards.filter((card) => {
-      if (dismissedCardIds.has(card.id)) return false;
-      const snoozedUntil = snoozedUntilById.get(card.id);
-      return snoozedUntil === undefined || snoozedUntil <= nowMs;
-    });
-  }, [dismissedCardIds, rawCards, snoozedUntilById]);
+    return rawCards
+      .filter((card) => {
+        if (dismissedCardIds.has(card.id)) return false;
+        const snoozedUntil = snoozedUntilById.get(card.id);
+        return snoozedUntil === undefined || snoozedUntil <= nowMs;
+      })
+      .map((card) => (card.archiveHint && keptCardIds.has(card.id) ? { ...card, archiveHint: false } : card));
+  }, [dismissedCardIds, rawCards, snoozedUntilById, keptCardIds]);
   const liveLabel = useMemo(() => formatClock(board?.at), [board?.at]);
 
   // ── view state ──────────────────────────────────────────────────
@@ -286,6 +291,14 @@ export function BoardView({
     setSnoozedUntilById((prev) => {
       const next = new Map(prev);
       next.set(id, Date.now() + OPERATOR_CARD_SNOOZE_MS);
+      return next;
+    });
+  }, []);
+
+  const onKeepWatchingCard = useCallback((id: string) => {
+    setKeptCardIds((prev) => {
+      const next = new Set(prev);
+      next.add(id);
       return next;
     });
   }, []);
@@ -425,6 +438,7 @@ export function BoardView({
                 onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
                 onDismiss={(c) => onDismissCard(c.id)}
                 onSnooze={(c) => onSnoozeCard(c.id)}
+                onKeepWatching={(c) => onKeepWatchingCard(c.id)}
                 onInvestigate={onCardClick ? (c) => onCardClick(c.id) : undefined}
               />
             )}

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -324,3 +324,17 @@ describe("Card — requested tester mission approve (T6)", () => {
     expect(onApproveMission.mock.calls[0]?.[0]?.id).toBe("testbed-mission-requested-1");
   });
 });
+
+describe("Card — archive hint 'Keep watching' (G4)", () => {
+  test("calls onKeepWatching when wired; renders an honest disabled label otherwise", () => {
+    const card = fixture("agent #542"); // archiveHint: true
+    const onKeepWatching = vi.fn();
+    const { getByRole, rerender, getByText } = render(<Card card={card} onKeepWatching={onKeepWatching} />);
+    fireEvent.click(getByRole("button", { name: "Keep watching" }));
+    expect(onKeepWatching).toHaveBeenCalledWith(card);
+
+    // No handler ⇒ informational label, not a fake link.
+    rerender(<Card card={card} />);
+    expect(getByText("Keep watching").tagName).toBe("SPAN");
+  });
+});

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -36,6 +36,8 @@ export type CardProps = {
   onDismiss?: (card: BoardCard) => void;
   /** Temporarily hide this card from the current monitor view. Local UI-only control. */
   onSnooze?: (card: BoardCard) => void;
+  /** "Keep watching" on the archive hint — cancel/extend this card's auto-archive. */
+  onKeepWatching?: (card: BoardCard) => void;
   /** Open the card's detail surface from an inline action. */
   onInvestigate?: (card: BoardCard) => void;
 };
@@ -84,6 +86,7 @@ export function Card({
   onApproveMission,
   onDismiss,
   onSnooze,
+  onKeepWatching,
   onInvestigate,
 }: CardProps) {
   const isAction = Boolean(card.isAction);
@@ -230,9 +233,32 @@ export function Card({
             }}
           >
             Hermes: archive in 4h?{" "}
-            <span style={{ color: "var(--hm-sage-deep)", cursor: "pointer", borderBottom: "1px dotted" }}>
-              Keep watching
-            </span>
+            {onKeepWatching ? (
+              <button
+                type="button"
+                className="hm-keep-watching"
+                style={{
+                  color: "var(--hm-sage-deep)",
+                  cursor: "pointer",
+                  borderBottom: "1px dotted",
+                  background: "none",
+                  border: 0,
+                  padding: 0,
+                  font: "inherit",
+                }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onKeepWatching(card);
+                }}
+              >
+                Keep watching
+              </button>
+            ) : (
+              // No handler wired ⇒ honest disabled label, not a fake link.
+              <span style={{ color: "var(--hm-muted)" }} aria-disabled="true">
+                Keep watching
+              </span>
+            )}
           </span>
         </div>
       ) : null}

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -25,6 +25,8 @@ export type CardRouterProps = {
   onDismiss?: (card: BoardCard) => void;
   /** Temporarily hide a waiting-on-operator card from the current monitor view. */
   onSnooze?: (card: BoardCard) => void;
+  /** "Keep watching" on the archive hint — cancel this card's auto-archive. */
+  onKeepWatching?: (card: BoardCard) => void;
   /** Open the card's detail surface from an inline action. */
   onInvestigate?: (card: BoardCard) => void;
 };
@@ -38,6 +40,7 @@ export function CardRouter({
   onApproveMission,
   onDismiss,
   onSnooze,
+  onKeepWatching,
   onInvestigate,
 }: CardRouterProps) {
   const renderer = pickRenderer(card);
@@ -65,6 +68,7 @@ export function CardRouter({
       onApproveMission={onApproveMission}
       onDismiss={onDismiss}
       onSnooze={onSnooze}
+      onKeepWatching={onKeepWatching}
       onInvestigate={onInvestigate}
     />
   );


### PR DESCRIPTION
## What changed & why

**Dead control fixed (truth-boundary):** the archive-hint **"Keep watching"** affordance (`Card.tsx`) rendered as a `cursor:pointer` span with no handler. It now cancels that card's auto-archive.

Auto-archive is currently a **display-only hint** (real archiving is "a later refinement"; dismiss/snooze are client-side view state), so "Keep watching" honestly means *the operator opted to keep the card*: it **suppresses that card's "archive in 4h?" prompt** for the session.

- **`Card.tsx`** — "Keep watching" is a real `<button>` calling `onKeepWatching(card)` (stops propagation so it doesn't also open the drawer). With **no handler wired it renders an honest disabled label**, not a fake link.
- **`CardRouter`** threads `onKeepWatching`.
- **`BoardView`** — a `keptCardIds` set; `onKeepWatchingCard(id)` adds to it; kept cards render with `archiveHint` cleared (the prompt disappears). Mirrors the existing client-side dismiss/snooze model; lane/counts unaffected.

## Affected surfaces
- [x] Monitor board / slack-operator (frontend only — `packages/monitor-ui`)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1198 passed; new tests below)
- [x] `vite build` (monitor-ui)

### Tests
- `Card`: "Keep watching" calls `onKeepWatching` when wired; renders an honest `<span>` label (not a button) with no handler.
- `BoardView` integration: clicking "Keep watching" removes the archive prompt for that card.

## Durable invariants (AGENTS.md)
- [x] **Truth-boundary:** the control performs its real action (cancel the archive prompt) or is an honest disabled label — no live-but-no-op.
- [x] **No new authority / no backend:** client-side view state only, mirroring dismiss/snooze. No endpoint, no merge/deploy, no agent data.

## Known limits / follow-ups
- "Keep watching" is **session-local** (like dismiss/snooze) because auto-archive isn't yet a server action. When a real archive job/endpoint lands, this can persist the operator's "keep" server-side.
- This is **Group 4a**. Group 4b — the **operator checklist + private note with server persistence** (`GET/PUT /monitor/cards/:id/operator-notes`, operator-private, never in agent payloads) — is a separate PR (server feature + security test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)