### PR TITLE
Restore co-pilot activity turn anatomy

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -15,7 +15,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
     const view = within(container);
     expect(view.getByRole("banner")).toBeTruthy();
-    expect(view.getByText("Hermes")).toBeTruthy();
+    expect(container.querySelector(".hm-brand-name")?.textContent).toBe("Hermes");
     // action tone — the fixtures include action cards
     expect(container.querySelector(".hm-now--action")).toBeTruthy();
     expect(view.getByText(/your review decision/)).toBeTruthy();

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -15,8 +15,21 @@ function wrapper({ children }: { children: ReactNode }) {
   return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
 }
 
-function msg(id: string, author: CollaborationMessage["author"], text: string): CollaborationMessage {
-  return { id, ts: Date.parse("2026-05-28T10:00:00Z"), author, kind: "chat", text, addressedTo: "everyone" };
+function msg(
+  id: string,
+  author: CollaborationMessage["author"],
+  text: string,
+  overrides: Partial<CollaborationMessage> = {},
+): CollaborationMessage {
+  return {
+    id,
+    ts: Date.parse("2026-05-28T10:00:00Z"),
+    author,
+    kind: "chat",
+    text,
+    addressedTo: "everyone",
+    ...overrides,
+  };
 }
 
 const card548 = FIXTURE_CARDS.find((c) => c.id === "agent #548") as BoardCard;
@@ -33,6 +46,9 @@ describe("CoPilotRail", () => {
     const fetcher = vi.fn(async () => [msg("1", "hermes", "Pre-check passed on #548.")]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
     await waitFor(() => expect(within(container).getByText(/Pre-check passed on #548/)).toBeTruthy());
+    expect(within(container).getAllByText("Hermes").length).toBeGreaterThan(0);
+    expect(within(container).getAllByText(/reply/).length).toBeGreaterThan(0);
+    expect(container.querySelector(".hm-turn-time")).toBeTruthy();
   });
 
   test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
@@ -101,7 +117,7 @@ describe("CoPilotRail", () => {
       taskStatus: "proposed",
       riskTier: "low",
     };
-    const { getByText, getByRole } = render(
+    const { container, getAllByText, getByText, getByRole } = render(
       <CoPilotRail
         boardCards={[taskCard]}
         boardBanner={banner}
@@ -111,8 +127,34 @@ describe("CoPilotRail", () => {
       { wrapper },
     );
     expect(getByText(/Proposed Codex work for Repair failed mission/)).toBeTruthy();
-    fireEvent.click(getByRole("button", { name: "Open card task-activity-1" }));
+    expect(getAllByText(/narration/).length).toBeGreaterThan(0);
+    fireEvent.click(getByRole("button", { name: "Open referenced card task-activity-1" }));
     expect(onCardClick).toHaveBeenCalledWith("task-activity-1");
+    fireEvent.click(getByRole("button", { name: "Why this route?" }));
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    expect(input.value).toBe("Why this route?");
+  });
+
+  test("card-scoped collaboration messages render with a real card pin", async () => {
+    const onCardClick = vi.fn();
+    const fetcher = vi.fn(async () => [
+      msg("operator-question", "operator", "What is still blocking this?", {
+        relatedPr: { repo: "depre-dev/agent", number: 548 },
+      }),
+    ]);
+    const { container, getByRole } = render(
+      <CoPilotRail
+        boardCards={[card548]}
+        onCardClick={onCardClick}
+        collaboration={{ fetcher, refreshIntervalMs: 0 }}
+      />,
+      { wrapper },
+    );
+    await waitFor(() => expect(within(container).getByText(/What is still blocking this/)).toBeTruthy());
+    expect(within(container).getByText("Pascal")).toBeTruthy();
+    expect(within(container).getByText(/question/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Open referenced card agent #548" }));
+    expect(onCardClick).toHaveBeenCalledWith("agent #548");
   });
 });
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -10,7 +10,12 @@ import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../../lib/monitor/backlog-suggestions.js";
 import type { BoardNowBanner as BoardNowBannerData } from "../../lib/monitor/board-state.js";
-import { relatedPrForCard, type CollaborationMessage } from "../../lib/monitor/collaboration.js";
+import {
+  actorLabel,
+  formatTurnTime,
+  relatedPrForCard,
+  type CollaborationMessage,
+} from "../../lib/monitor/collaboration.js";
 import {
   buildHermesActivityFeed,
   type HermesActivityEntry,
@@ -142,7 +147,12 @@ export function CoPilotRail({
         </div>
         <div className="hm-hermes-stream hm-activity-stream" ref={streamRef} aria-live="polite">
           {activity.map((entry) => (
-            <ActivityEntryRow entry={entry} onCardClick={onCardClick} key={entry.id} />
+            <ActivityEntryRow
+              entry={entry}
+              onCardClick={onCardClick}
+              onUseInComposer={fillComposer}
+              key={entry.id}
+            />
           ))}
         </div>
       </section>
@@ -193,37 +203,76 @@ function messageMatchesCard(message: CollaborationMessage, card: BoardCard): boo
 function ActivityEntryRow({
   entry,
   onCardClick,
+  onUseInComposer,
 }: {
   entry: HermesActivityEntry;
   onCardClick?: (id: string) => void;
+  onUseInComposer?: (text: string) => void;
 }) {
-  const body = (
-    <>
-      <span className="hm-activity-dot" aria-hidden />
-      <span>
-        <strong>{entry.text}</strong>
+  return (
+    <div className={`hm-turn hm-turn--${entry.actor} hm-turn--activity-${entry.tone}`}>
+      <div className="hm-turn-head">
+        <span className="hm-turn-actor">
+          <span className="actor-dot" aria-hidden />
+          {actorLabel(entry.actor)}
+        </span>
+        <span className="hm-turn-kind">· {entry.kindLabel}</span>
+        <span className="hm-turn-time">{formatTurnTime(entry.atMs)}</span>
+      </div>
+      <div className="hm-turn-body">
+        {entry.text}
         {entry.meta ? <small>{entry.meta}</small> : null}
-      </span>
+      </div>
+      {entry.cardId ? (
+        <ActivityPin
+          cardId={entry.cardId}
+          onCardClick={onCardClick}
+        />
+      ) : null}
+      {onUseInComposer && entry.suggestions?.length ? (
+        <div className="hm-turn-actions" aria-label="Suggested prompts">
+          {entry.suggestions.map((suggestion) => (
+            <button
+              type="button"
+              className="hm-turn-suggest"
+              onClick={() => onUseInComposer(suggestion)}
+              key={suggestion}
+            >
+              {suggestion}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ActivityPin({
+  cardId,
+  onCardClick,
+}: {
+  cardId: string;
+  onCardClick?: (id: string) => void;
+}) {
+  const content = (
+    <>
+      <span className="pin-id">{cardId}</span>
+      <span className="pin-title">Referenced card</span>
+      <span className="pin-arrow">{onCardClick ? "open ›" : "referenced"}</span>
     </>
   );
-  if (entry.cardId && onCardClick) {
-    return (
-      <button
-        type="button"
-        className={`hm-activity-row hm-activity-row--${entry.tone}`}
-        onClick={() => onCardClick(entry.cardId!)}
-        aria-label={`Open card ${entry.cardId}`}
-      >
-        {body}
-        <span className="hm-activity-link">{entry.cardId}</span>
-      </button>
-    );
+  if (!onCardClick) {
+    return <div className="hm-turn-pin">{content}</div>;
   }
   return (
-    <div className={`hm-activity-row hm-activity-row--${entry.tone}`}>
-      {body}
-      {entry.cardId ? <span className="hm-activity-link">{entry.cardId}</span> : null}
-    </div>
+    <button
+      type="button"
+      className="hm-turn-pin"
+      onClick={() => onCardClick(cardId)}
+      aria-label={`Open referenced card ${cardId}`}
+    >
+      {content}
+    </button>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
@@ -75,6 +75,11 @@ describe("buildHermesActivityFeed", () => {
     expect(text).toContain("Proposed Codex work for Self-healing fix");
     expect(text).toContain("Routed Self-healing fix");
     expect(text).toContain("Codex asked for help on depre-dev/averray-reference-agent#316");
+    expect(entries.find((entry) => entry.text.includes("Proposed Codex work"))).toMatchObject({
+      actor: "hermes",
+      kindLabel: "narration",
+      suggestions: ["Why this route?", "Show dispatch guardrails"],
+    });
     expect(entries.at(-1)).toMatchObject({
       source: "summary",
       text: "Needs you: review the current action lane, starting with task-1.",
@@ -90,7 +95,29 @@ describe("buildHermesActivityFeed", () => {
       now: () => Date.parse("2026-05-28T10:05:00Z"),
     });
     expect(entries[0]?.text).toContain("No real Hermes activity has been logged yet");
+    expect(entries[0]).toMatchObject({ actor: "hermes", kindLabel: "narration" });
     expect(entries.at(-1)?.text).toBe("Needs you: nothing right now.");
+  });
+
+  test("pins card-scoped collaboration messages to their board card", () => {
+    const card = task({ id: "agent #316", repo: "depre-dev/averray-reference-agent" });
+    const entries = buildHermesActivityFeed({
+      cards: [card],
+      messages: [message({
+        id: "operator-q",
+        author: "operator",
+        kind: "chat",
+        text: "What blocks this?",
+      })],
+      banner,
+      now: () => Date.parse("2026-05-28T10:05:00Z"),
+    });
+    const collaboration = entries.find((entry) => entry.id === "collaboration:operator-q");
+    expect(collaboration).toMatchObject({
+      actor: "operator",
+      kindLabel: "question",
+      cardId: "agent #316",
+    });
   });
 
   test("narrates review-panel responses without creating pretend chatter", () => {

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -5,8 +5,8 @@ import type {
   CardReviewRequest,
   HermesDecisionRecord,
 } from "./card-types.js";
-import type { CollaborationMessage } from "./collaboration.js";
-import { actorLabel, formatTurnTime } from "./collaboration.js";
+import type { CollaborationAuthor, CollaborationMessage } from "./collaboration.js";
+import { actorLabel, formatTurnTime, relatedPrForCard } from "./collaboration.js";
 import { humanizeSignalText } from "./signal-labels.js";
 
 export type ActivityTone = "neutral" | "info" | "action" | "success" | "warning";
@@ -16,9 +16,12 @@ export interface HermesActivityEntry {
   atMs: number;
   source: "board" | "decision" | "collaboration" | "review" | "summary";
   tone: ActivityTone;
+  actor: CollaborationAuthor;
+  kindLabel: "narration" | "question" | "reply" | "proposal" | "request" | "status";
   text: string;
   meta?: string;
   cardId?: string;
+  suggestions?: string[];
 }
 
 export interface BuildHermesActivityFeedInput {
@@ -44,7 +47,7 @@ export function buildHermesActivityFeed(input: BuildHermesActivityFeedInput): He
   }
 
   for (const message of input.messages) {
-    entries.push(collaborationActivity(message));
+    entries.push(collaborationActivity(message, cardIdForMessage(message, input.cards)));
   }
 
   const deduped = dedupeEntries(entries)
@@ -57,6 +60,8 @@ export function buildHermesActivityFeed(input: BuildHermesActivityFeedInput): He
       atMs: boardAtMs,
       source: "summary",
       tone: "neutral",
+      actor: "hermes",
+      kindLabel: "narration",
       text: "No real Hermes activity has been logged yet. New board events and card-scoped coordination will appear here.",
       meta: "waiting for events",
     });
@@ -78,9 +83,12 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
         atMs,
         source: "board",
         tone: "action",
+        actor: "hermes",
+        kindLabel: "narration",
         text: `Proposed ${label} work for ${title}; waiting on your dispatch decision.`,
         meta: card.riskTier ? `${card.riskTier} risk` : "task proposed",
         cardId: card.id,
+        suggestions: ["Why this route?", "Show dispatch guardrails"],
       });
     } else if (card.taskStatus === "approved") {
       entries.push({
@@ -88,6 +96,8 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
         atMs,
         source: "board",
         tone: "info",
+        actor: "hermes",
+        kindLabel: "narration",
         text: `Dispatched ${label} work for ${title}; the runner can claim it when available.`,
         meta: "dispatch approved",
         cardId: card.id,
@@ -98,6 +108,8 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
         atMs,
         source: "board",
         tone: "info",
+        actor: "hermes",
+        kindLabel: "narration",
         text: `${label} is working on ${title}; Hermes is watching for progress or a PR.`,
         meta: "runner active",
         cardId: card.id,
@@ -108,9 +120,12 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
         atMs,
         source: "board",
         tone: "warning",
+        actor: "hermes",
+        kindLabel: "narration",
         text: `${label} work failed on ${title}; operator triage is needed before retrying or splitting it.`,
         meta: card.failureReason ?? "task failed",
         cardId: card.id,
+        suggestions: ["Show failure evidence", "Should this be split?"],
       });
     }
   }
@@ -121,9 +136,12 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
       atMs,
       source: "board",
       tone: "action",
+      actor: "hermes",
+      kindLabel: "narration",
       text: `Escalated ${cardTitle(card)} to you: ${plain(card.summary) || "Hermes needs an operator decision."}`,
       meta: "needs your call",
       cardId: card.id,
+      suggestions: ["Summarize what needs review", "What happens if I dismiss this?"],
     });
   }
 
@@ -133,6 +151,8 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
       atMs,
       source: "board",
       tone: card.mergeStatus === "MERGED" ? "success" : "neutral",
+      actor: "hermes",
+      kindLabel: "narration",
       text: `${card.mergeStatus === "MERGED" ? "Merged" : "Closed"} ${cardTitle(card)}; it is now release history.`,
       meta: card.closedAt ? formatDateMeta(card.closedAt) : "done",
       cardId: card.id,
@@ -155,9 +175,12 @@ function decisionRecordActivity(
     atMs,
     source: "decision",
     tone: toneForDecision(record),
+    actor: "hermes",
+    kindLabel: "narration",
     text: `${decisionVerb(record)} ${cardTitle(card)}: ${plain(reason)}.${waiting}`,
     meta: record.kind.replace(/_/g, " "),
     cardId: card.id,
+    suggestions: ["Why this decision?", "What would change it?"],
   };
 }
 
@@ -172,9 +195,12 @@ function reviewRequestActivity(card: BoardCard): HermesActivityEntry[] {
         atMs,
         source: "review",
         tone: request.response.verdict === "block" ? "action" : request.response.verdict === "concern" ? "warning" : "success",
+        actor: "hermes",
+        kindLabel: "narration",
         text: `${agentLabel(request.reviewer)} returned a ${request.response.verdict} review on ${cardTitle(card)}: ${plain(request.response.reasoning)}`,
         meta: panel ? "reviewer panel" : "review response",
         cardId: card.id,
+        suggestions: request.response.verdict === "block" ? ["What blocks this?", "Summarize panel verdicts"] : undefined,
       };
     }
     return {
@@ -182,14 +208,17 @@ function reviewRequestActivity(card: BoardCard): HermesActivityEntry[] {
       atMs,
       source: "review",
       tone: panel ? "action" : "info",
+      actor: "hermes",
+      kindLabel: "narration",
       text: `${agentLabel(request.requestedBy)} requested ${panel ? "a reviewer panel" : `${agentLabel(request.reviewer)} review`} for ${cardTitle(card)}: ${plain(request.reason)}`,
       meta: panel ? "panel requested" : "review requested",
       cardId: card.id,
+      suggestions: ["Why request review?", "What should I check?"],
     };
   });
 }
 
-function collaborationActivity(message: CollaborationMessage): HermesActivityEntry {
+function collaborationActivity(message: CollaborationMessage, cardId: string | undefined): HermesActivityEntry {
   const actor = actorLabel(message.author);
   const target = message.addressedTo === "everyone" ? "the room" : actorLabel(message.addressedTo);
   const scope = message.relatedPr
@@ -210,8 +239,11 @@ function collaborationActivity(message: CollaborationMessage): HermesActivityEnt
     atMs: message.ts,
     source: "collaboration",
     tone: message.kind === "request_help" ? "action" : message.kind === "proposal" ? "info" : "neutral",
+    actor: message.author,
+    kindLabel: collaborationKindLabel(message),
     text: `${actor} ${verb}${scope} to ${target}: ${plain(message.text)}`,
     meta: `${message.kind} · ${formatTurnTime(message.ts)}`,
+    ...(cardId ? { cardId } : {}),
   };
 }
 
@@ -229,10 +261,41 @@ function summaryActivity(banner: BoardNowBanner, nowMs: number): HermesActivityE
     atMs: nowMs,
     source: "summary",
     tone: banner.tone === "action" || banner.tone === "hermes-focus" ? "action" : banner.tone === "degraded" ? "warning" : "success",
+    actor: "hermes",
+    kindLabel: "narration",
     text,
     meta: banner.sub,
     ...(banner.primaryActionId ? { cardId: banner.primaryActionId } : {}),
+    ...(banner.primaryActionId && (banner.tone === "action" || banner.tone === "hermes-focus")
+      ? { suggestions: ["Summarize the top card", "What decision is pending?"] }
+      : {}),
   };
+}
+
+function collaborationKindLabel(message: CollaborationMessage): HermesActivityEntry["kindLabel"] {
+  if (message.author === "operator") return "question";
+  if (message.author === "hermes") return "reply";
+  if (message.kind === "proposal") return "proposal";
+  if (message.kind === "request_help") return "request";
+  return "status";
+}
+
+function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCard[]): string | undefined {
+  for (const card of cards) {
+    const relatedPr = relatedPrForCard(card);
+    if (
+      relatedPr
+      && message.relatedPr?.repo === relatedPr.repo
+      && message.relatedPr.number === relatedPr.number
+    ) {
+      return card.id;
+    }
+    const correlation = card.correlationId ?? card.id;
+    if (message.relatedCorrelationId && message.relatedCorrelationId === correlation) {
+      return card.id;
+    }
+  }
+  return undefined;
 }
 
 function decisionVerb(record: HermesDecisionRecord): string {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1246,6 +1246,12 @@ button.hm-activity-row:hover {
   display: inline-flex; align-items: center; gap: 5px;
   color: var(--hm-ink);
 }
+.hm-turn-kind {
+  margin-left: 4px;
+  opacity: 0.7;
+  font-weight: 500;
+  letter-spacing: 0 !important;
+}
 .hm-turn-actor .actor-dot { width: 7px; height: 7px; border-radius: 999px; }
 .hm-turn--hermes  .actor-dot { background: var(--hm-hermes); }
 .hm-turn--operator .actor-dot { background: var(--hm-ink); }
@@ -1264,6 +1270,14 @@ button.hm-activity-row:hover {
 
 .hm-turn-body { color: var(--hm-ink-soft); }
 .hm-turn-body b { color: var(--hm-ink); font-weight: 600; }
+.hm-turn-body small {
+  display: block;
+  margin-top: 4px;
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.4;
+}
 .hm-turn-body code {
   font-family: var(--font-mono);
   font-size: 11.5px;
@@ -1287,6 +1301,11 @@ button.hm-activity-row:hover {
   font-size: 12px;
   color: var(--hm-ink-soft);
   text-decoration: none;
+  width: 100%;
+  text-align: left;
+}
+button.hm-turn-pin {
+  cursor: pointer;
 }
 .hm-turn-pin:hover { border-color: var(--hm-line-strong); }
 .hm-turn-pin .pin-id {
@@ -1321,6 +1340,7 @@ button.hm-activity-row:hover {
   letter-spacing: 0.04em !important;
   cursor: pointer;
   border: 1px solid rgba(30,102,66,0.14);
+  font: inherit;
 }
 .hm-turn-suggest:hover { background: var(--hm-sage-soft); }
 


### PR DESCRIPTION
## What changed & why

This is the third narrow monitor UI polish slice from the Hermes v2 handoff.

- Renders proactive activity feed entries with the design's turn anatomy: actor dot/name, kind label, timestamp, body/meta, and card pin.
- Keeps pins real: clicking a pin jumps to the referenced board card via the existing `onCardClick` path.
- Adds per-turn suggestion chips that fill the Ask Hermes composer only; they do not dispatch work or create actions.
- Pins existing card-scoped collaboration messages by matching their PR/correlation scope to board cards.
- Extends tests for turn anatomy, card pins, suggestion-prefill behavior, and the activity-feed metadata.

No authority changes; this is presentation/wiring only.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Normal frontend rollout. Roll back by reverting this PR.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

None for this slice. The suggestion chips are intentionally composer-prefill only.
