### PR TITLE
feat: harden O5 task health recovery

### DIFF
--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -80,8 +80,13 @@ The monitor treats task completion as a handoff edge, not a release approval. If
 a Codex task is `completed` and that completion is newer than the latest Hermes
 PR verdict, the card moves to **Hermes Checking** with a `HERMES RECHECK`
 verdict until Hermes/GitHub Actions publish a newer review. If the task is
-`failed`, the card moves to **Needs Attention** with a Codex-owned retry/fix
-action. Draft PRs always stay Codex-owned until GitHub reports `draft=false`.
+`failed`, O5 task health gets one conservative self-management pass before the
+card becomes operator action: a bounded retry can be scheduled after backoff,
+and the card stays Codex-owned while that retry is pending. Once the retry
+budget is spent, dispatch is blocked, D3/HALT is active, or a running/approved
+task stays stale past the configured threshold, the card moves to **Needs
+Attention** for operator triage. Draft PRs always stay Codex-owned until GitHub
+reports `draft=false`.
 The monitor's **Ask Hermes to re-check** action runs a private, read-only
 `pr_code_review` + `pr_handoff` re-check for the PR and records fresh handoff
 events; it intentionally disables PR comment writes so the private command
@@ -105,6 +110,12 @@ Task state is stored in `AVERRAY_CODEX_TASKS_PATH`, defaulting to
 `/data/codex-tasks.json` in Docker so the monitor and runner share durable state.
 The runner redacts common private keys, JWTs, GitHub tokens, and API keys from
 captured output before persisting tails in the queue.
+
+The O5 task-health routine also reads that durable queue on slack-operator
+restart. If it finds a stale `running` task that the runner heartbeat no longer
+owns, it requeues the same task for one bounded retry instead of creating a
+duplicate task. It still honors `HALT_FILE`, the D3 suspended flag, and the
+dispatch allowlist/budget before retrying.
 
 The branch worker has hard guardrails:
 

--- a/docs/HERMES_ORCHESTRATION_DESIGN.md
+++ b/docs/HERMES_ORCHESTRATION_DESIGN.md
@@ -1,6 +1,6 @@
 # Hermes Orchestration — Execution Design (per-phase build specs)
 
-- **Status:** Reconciled 2026-05-31. This is the historical execution spec for O1-O5; O1-O4 have shipped, including O4 autonomy mode (#288) and autopilot auto-approval (#289). O5 self-management hardening remains follow-up.
+- **Status:** Reconciled 2026-06-01. This is the historical execution spec for O1-O5; O1-O4 have shipped, including O4 autonomy mode (#288) and autopilot auto-approval (#289). O5 first surfaced failed/stale tasks in #298, and the bounded retry / stale escalation / restart reconciliation hardening is tracked by #336.
 - **Date:** 2026-05-29
 - **Companions:** [`HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`](./HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md) (the why + phases), [`HERMES_INTEGRATION_MAP.md`](./HERMES_INTEGRATION_MAP.md) (the confirmed source map).
 - **Decisions:** all nine open decisions are **resolved** (see the table at the end). They're baked into the specs below. `path:line` references are local to this repo; code blocks are illustrative sketches, not applied diffs.
@@ -183,4 +183,4 @@ Implementation note: O4 shipped across #280, #281, #288, and #289. Merge/deploy 
 
 ---
 
-*End of execution design. Reconciled 2026-05-31: O1-O4 have shipped; O5 remains follow-up.*
+*End of execution design. Reconciled 2026-06-01: O1-O4 have shipped; O5 first surfaced failed/stale tasks in #298, and #336 adds the bounded retry / stale escalation / restart recovery hardening.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -27,7 +27,7 @@
 | O2 | Claude Code worker (greenfield, Agent SDK) | ✅ done (#256 queue · #259 auth · #260 runner · #262 worker · #263 ops) |
 | O3 | Board-driven dispatch | ✅ done — create/approve form (agent picker) + `/task` verb live on the board (#271) |
 | O4 | Hermes enqueue + dispatch guardrail + autonomy mode | ✅ done — PR1 enqueue+guardrail (#280) · PR2 routing taxonomy (#281) · PR3a autonomy mode (#288) · PR3b autopilot auto-approval (#289); merge/deploy remain human-gated |
-| O5 | Self-management hardening | ✅ first slice done — failed/stale agent tasks surface in `needs-attention` (#298; `services/slack-operator/src/monitor-v2.ts`, tests in `test/unit/monitor-v2.test.ts`); board liveness truth fix landed in #307. Broader retries/escalation hardening remains follow-up; no open PR as of 2026-06-01 |
+| O5 | Self-management hardening | ✅ done — failed/stale agent tasks surface in `needs-attention` (#298; `services/slack-operator/src/monitor-v2.ts`, tests in `test/unit/monitor-v2.test.ts`), board liveness truth fix landed in #307, and bounded retry / stale escalation / restart reconciliation hardening landed in #336 (`services/slack-operator/src/task-health.ts`, queue retry fields in `services/slack-operator/src/codex-task-queue.ts`, O5 env wiring in `ops/compose.yml`) |
 | A1 | Agent scorecard | ✅ done (#285) — read-only `/monitor/agents` + `averray_agent_scorecard` scorecard slice |
 | A2 | Learned routing (data-driven, non-high-risk) | ✅ done (#287) — scorecard-backed default routing, high-risk rule-bound |
 | A3 | Cost visibility / cost-aware routing | ✅ done — A3a cost visibility (#295) + A3b cost-aware routing (#301; `packages/averray-mcp/src/learned-routing.ts`, `test/unit/learned-routing.test.ts`) + dispatch USD budget gate (`packages/averray-mcp/src/dispatch-policy.ts`) |
@@ -50,7 +50,7 @@
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | ✅ first slice done (#304; `POST /monitor/testbed-missions/request`, `/approve`, board approve UI, and runner ignores `requested` until approval) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | ✅ reference-agent manifest done (#284; `GET /monitor/tester/capabilities`, `services/slack-operator/src/tester-capabilities.ts`). Platform-repo request helper remains follow-up outside this repo |
 
-*(Status as of 2026-06-01 — **shipped/code-backed:** O0–O4, O5 first slice, A1–A4, D1–D4, B1 first slices, B2 proposes-only self-healing, C1 first slice, C2, C3 test-writer slice, C4 v1, T1–T3, T5, T6 first slice, and the T7 reference-agent manifest. **In progress:** none by open PR check on 2026-06-01. **Design / follow-up:** remaining O5 hardening, B1 idle-triggered auto-flow, C1 automatic/default reviewer dispatch, C3 security/docs specialists, T4 Tier-2 browser agent, and the T7 platform helper. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
+*(Status as of 2026-06-01 — **shipped/code-backed:** O0–O5, A1–A4, D1–D4, B1 first slices, B2 proposes-only self-healing, C1 first slice, C2, C3 test-writer slice, C4 v1, T1–T3, T5, T6 first slice, and the T7 reference-agent manifest. **In progress:** none after #336 merges. **Design / follow-up:** B1 idle-triggered auto-flow, C1 automatic/default reviewer dispatch, C3 security/docs specialists, T4 Tier-2 browser agent, and the T7 platform helper. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 
@@ -58,7 +58,7 @@
    - **T1** runs in parallel with O1 (independent, both runner/board TS).
 2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6** has its first request/approve gate slice, and **T7** has the reference-agent manifest. The platform helper remains follow-up.
 3. **Autonomy:** **O4** (enqueue + guardrail + autonomy mode) has shipped; supervised burn-in and monitoring decide when to rely on it more heavily.
-4. **Depth, anytime after:** **A1 → A3** shipped, and **B1/B2** now have code-backed first slices. Remaining depth is B1 idle auto-flow, C1 automatic/default reviewer dispatch, C3 additional specialists, **T4**, T7 platform helper polish, and broader **O5** hardening.
+4. **Depth, anytime after:** **A1 → A3** shipped, **O5** hardening is code-backed, and **B1/B2** now have code-backed first slices. Remaining depth is B1 idle auto-flow, C1 automatic/default reviewer dispatch, C3 additional specialists, **T4**, and T7 platform helper polish.
 
 **Dependencies to respect:** B2 needs D3 (loop fail-safe); A2 needs A1 (baselines); O4 is the authority change and needs D4 (escalations must reach the operator off-device); T6 needs the proposed-mission approval gate; T-missions that mutate stay on testnet (env→mutation binding before any mainnet).
 

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -268,6 +268,16 @@ HERMES_DISPATCH_PER_REPO_PER_DAY_MAX=5
 # When enabled, it only blocks when both today's recorded spend and the selected
 # agent's recorded average cost are present; missing cost data stays neutral.
 HERMES_DISPATCH_PER_DAY_USD_MAX=0
+# O5 — task health self-management. Default ON but conservative: one bounded
+# retry after backoff, then operator escalation. Reuses the dispatch guardrail
+# and D3/HALT interlocks; no merge/deploy authority is added.
+O5_TASK_HEALTH_ENABLED=1
+O5_TASK_HEALTH_INTERVAL_MINUTES=5
+O5_TASK_HEALTH_MAX_RETRIES=1
+O5_TASK_HEALTH_RETRY_BACKOFF_MINUTES=15
+O5_TASK_HEALTH_APPROVED_STALE_MINUTES=30
+O5_TASK_HEALTH_RUNNING_STALE_MINUTES=20
+O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES=10
 # B2 — self-healing / incident response. Default OFF. When on, a failure signal
 # (failed testbed mission, failed deploy/verification) makes Hermes PROPOSE a
 # routed fix task (non-high-risk) — which still flows through the normal

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -182,6 +182,16 @@ services:
       HERMES_DISPATCH_ALLOWED_REPOS: ${HERMES_DISPATCH_ALLOWED_REPOS:-}
       HERMES_DISPATCH_PER_REPO_PER_DAY_MAX: ${HERMES_DISPATCH_PER_REPO_PER_DAY_MAX:-5}
       HERMES_DISPATCH_PER_DAY_USD_MAX: ${HERMES_DISPATCH_PER_DAY_USD_MAX:-0}
+      # O5 — task health self-management. Reconciles the durable JSON queue
+      # after failed tasks / stale runner state: bounded retries first, then
+      # operator escalation. Still respects D3/HALT and the dispatch guardrail.
+      O5_TASK_HEALTH_ENABLED: ${O5_TASK_HEALTH_ENABLED:-1}
+      O5_TASK_HEALTH_INTERVAL_MINUTES: ${O5_TASK_HEALTH_INTERVAL_MINUTES:-5}
+      O5_TASK_HEALTH_MAX_RETRIES: ${O5_TASK_HEALTH_MAX_RETRIES:-1}
+      O5_TASK_HEALTH_RETRY_BACKOFF_MINUTES: ${O5_TASK_HEALTH_RETRY_BACKOFF_MINUTES:-15}
+      O5_TASK_HEALTH_APPROVED_STALE_MINUTES: ${O5_TASK_HEALTH_APPROVED_STALE_MINUTES:-30}
+      O5_TASK_HEALTH_RUNNING_STALE_MINUTES: ${O5_TASK_HEALTH_RUNNING_STALE_MINUTES:-20}
+      O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES: ${O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES:-10}
       # B2 — self-healing. On a failure: PROPOSE a routed fix (non-high-risk) that
       # still flows through the approval/autopilot gate, or ESCALATE (high-risk /
       # rollback / D3-suspended / HALT). Off by default; never auto-approves.

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -86,6 +86,10 @@ export interface CodexTask extends CodexTaskInput {
   stderrTail?: string;
   progressMessage?: string;
   progressAt?: string;
+  retryAfter?: string;
+  retryCount?: number;
+  selfManagementEscalatedAt?: string;
+  selfManagementEscalationReason?: string;
   events?: CodexTaskEvent[];
 }
 
@@ -388,6 +392,110 @@ export async function failCodexTask(
       at: now,
       status: "failed",
       message: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
+    }),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function retryCodexTask(
+  id: string,
+  deps: CodexTaskQueueDeps & {
+    approvedBy?: string;
+    reason?: string;
+  } = {}
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  if (existing.status !== "failed" && existing.status !== "running") return existing;
+  const now = (deps.now ?? new Date()).toISOString();
+  const {
+    retryAfter: _retryAfter,
+    selfManagementEscalatedAt: _escalatedAt,
+    selfManagementEscalationReason: _escalationReason,
+    runnerId: _runnerId,
+    startedAt: _startedAt,
+    failedAt: _failedAt,
+    failureReason: _failureReason,
+    exitCode: _exitCode,
+    ...rest
+  } = existing;
+  const message = deps.reason ?? `${taskAgentEventLabel(taskAgent(existing))} task scheduled for bounded retry.`;
+  const task: CodexTask = {
+    ...rest,
+    status: "approved",
+    approvedAt: now,
+    approvedBy: deps.approvedBy ?? "o5-self-management",
+    retryCount: (existing.retryCount ?? 0) + 1,
+    progressMessage: message,
+    progressAt: now,
+    events: appendTaskEvent(existing, {
+      at: now,
+      status: "approved",
+      message,
+    }),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function deferCodexTaskRetry(
+  id: string,
+  deps: CodexTaskQueueDeps & {
+    retryAfter: Date;
+    reason?: string;
+  }
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  if (existing.status !== "failed") return existing;
+  const now = (deps.now ?? new Date()).toISOString();
+  const retryAfter = deps.retryAfter.toISOString();
+  const message = deps.reason ?? `${taskAgentEventLabel(taskAgent(existing))} task will be retried after ${retryAfter}.`;
+  const task: CodexTask = {
+    ...existing,
+    retryAfter,
+    progressMessage: message,
+    progressAt: now,
+    events: appendTaskEvent(existing, {
+      at: now,
+      status: "progress",
+      message,
+    }),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function escalateCodexTask(
+  id: string,
+  deps: CodexTaskQueueDeps & {
+    reason: string;
+  }
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  if (existing.selfManagementEscalatedAt && existing.selfManagementEscalationReason === deps.reason) return existing;
+  const now = (deps.now ?? new Date()).toISOString();
+  const task: CodexTask = {
+    ...existing,
+    selfManagementEscalatedAt: now,
+    selfManagementEscalationReason: deps.reason,
+    progressMessage: deps.reason,
+    progressAt: now,
+    events: appendTaskEvent(existing, {
+      at: now,
+      status: "progress",
+      message: deps.reason,
     }),
     updatedAt: now,
   };

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -85,6 +85,7 @@ import {
   testbedSurfaceKey,
   type FailureSignal,
 } from "./self-healing.js";
+import { runTaskHealthOnce } from "./task-health.js";
 import {
   readAutonomyState,
   setAutonomyMode,
@@ -101,7 +102,7 @@ import {
   type AutopilotAuditEvent,
   type EndedAutopilotAwaySession,
 } from "./away-digest.js";
-import { loadDispatchPolicyConfig } from "@avg/averray-mcp/dispatch-policy";
+import { evaluateDispatchPolicy, loadDispatchPolicyConfig } from "@avg/averray-mcp/dispatch-policy";
 import {
   isDebugSpawnEnabled,
   mergeDebugCards,
@@ -130,9 +131,12 @@ import {
   approveCodexTask,
   annotateCodexTaskDecisionRecord,
   cancelCodexTask,
+  deferCodexTaskRetry,
+  escalateCodexTask,
   listCodexTasks,
   proposeCodexTask,
   readCodexRunnerHeartbeat,
+  retryCodexTask,
   summarizeCodexTasks,
   taskAgent,
   type CodexTask,
@@ -213,6 +217,7 @@ logger.info({
     safeWorkScanIntervalMs: routineConfig.safeWorkScan.enabled ? routineConfig.safeWorkScan.intervalMs : 0,
     stalePrAlertIntervalMs: routineConfig.stalePrAlerts.enabled ? routineConfig.stalePrAlerts.intervalMs : 0,
     stalePrAlertAfterMinutes: routineConfig.stalePrAlerts.staleAfterMinutes,
+    taskHealthIntervalMs: routineConfig.taskHealth.enabled ? routineConfig.taskHealth.intervalMs : 0,
   },
   monitor: {
     enabled: monitorConfig.enabled,
@@ -387,6 +392,15 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           enabled: routineConfig.stalePrAlerts.enabled,
           intervalMs: routineConfig.stalePrAlerts.enabled ? routineConfig.stalePrAlerts.intervalMs : 0,
           staleAfterMinutes: routineConfig.stalePrAlerts.staleAfterMinutes,
+        },
+        taskHealth: {
+          enabled: routineConfig.taskHealth.enabled,
+          intervalMs: routineConfig.taskHealth.enabled ? routineConfig.taskHealth.intervalMs : 0,
+          maxRetries: routineConfig.taskHealth.maxRetries,
+          retryBackoffMs: routineConfig.taskHealth.retryBackoffMs,
+          approvedStaleMs: routineConfig.taskHealth.approvedStaleMs,
+          runningStaleMs: routineConfig.taskHealth.runningStaleMs,
+          restartRecoveryMs: routineConfig.taskHealth.restartRecoveryMs,
         },
       },
       monitor: {
@@ -1835,6 +1849,18 @@ async function computeAutopilotCountsToday(repo: string): Promise<{ todayCount: 
   return { todayCount: dispatched.length, todayRepoCount: dispatched.filter((t) => t.repo === repo).length };
 }
 
+async function computeSelfManagedDispatchCountsToday(repo: string): Promise<{ todayCount: number; todayRepoCount: number }> {
+  const tasks = await listCodexTasks();
+  const today = new Date().toISOString().slice(0, 10);
+  const dispatched = tasks.filter(
+    (t) =>
+      (t.approvedBy === "hermes-autopilot" || t.approvedBy === "o5-self-management") &&
+      typeof t.approvedAt === "string" &&
+      t.approvedAt.slice(0, 10) === today,
+  );
+  return { todayCount: dispatched.length, todayRepoCount: dispatched.filter((t) => t.repo === repo).length };
+}
+
 // B2 — collect failure signals for self-healing. Concrete sources wired today:
 // failed testbed missions (usually a non-high-risk surface regression → propose)
 // and failed/blocked deploy-or-verification handoff correlations (a deploy
@@ -2036,17 +2062,21 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
 }
 
 function startOperatorRoutines() {
+  const channelRoutineEnabled = routineConfig.dailyBrief.enabled
+    || routineConfig.dailyGithubBrief.enabled
+    || routineConfig.opsHealth.enabled
+    || routineConfig.safeWorkScan.enabled
+    || routineConfig.stalePrAlerts.enabled;
+  const serverRoutineEnabled = routineConfig.alertBridge.enabled
+    || routineConfig.anomalyPause.enabled
+    || routineConfig.taskHealth.enabled
+    || routineConfig.selfHealing.enabled;
+
   if (!routineConfig.channelId) {
-    if (
-      routineConfig.dailyBrief.enabled
-      || routineConfig.dailyGithubBrief.enabled
-      || routineConfig.opsHealth.enabled
-      || routineConfig.safeWorkScan.enabled
-      || routineConfig.stalePrAlerts.enabled
-    ) {
+    if (channelRoutineEnabled) {
       logger.warn("slack_operator_routines_no_channel");
     }
-    return;
+    if (!serverRoutineEnabled) return;
   }
 
   let lastDailyBriefDateKey: string | undefined;
@@ -2063,6 +2093,7 @@ function startOperatorRoutines() {
   let alertBridgeState: AlertBridgeState = initialAlertBridgeState();
   const alertChannel: AlertChannel = slackAlertChannel();
   let anomalyPauseRunning = false;
+  let taskHealthRunning = false;
   const anomalyConfig = loadAnomalyConfig();
   const dispatchPerDayCap = Number(process.env.HERMES_DISPATCH_PER_DAY_MAX) || 10;
 
@@ -2316,6 +2347,55 @@ function startOperatorRoutines() {
     }
   };
 
+  // O5 — task health self-management. Reconciles the durable JSON queue after
+  // runner failures or restarts: bounded failed-task retries, stale approved /
+  // running escalation, and stale running-task requeue when the heartbeat is no
+  // longer claiming the task. No merge/deploy authority is added.
+  const checkTaskHealth = async () => {
+    if (taskHealthRunning || !routineConfig.taskHealth.enabled) return;
+    taskHealthRunning = true;
+    try {
+      const result = await runTaskHealthOnce(routineConfig.taskHealth, {
+        listTasks: () => listCodexTasks(),
+        readRunner: () => readCodexRunnerHeartbeat(),
+        retryTask: (id, reason) => retryCodexTask(id, { approvedBy: "o5-self-management", reason }),
+        deferRetry: (id, retryAfter, reason) => deferCodexTaskRetry(id, { retryAfter, reason }),
+        escalateTask: (id, reason) => escalateCodexTask(id, { reason }),
+        isSuspended: () => isAutopilotSuspended(),
+        isHalt: () => isHaltFilePresent(),
+        dispatchAllowed: async (task) => {
+          const counts = await computeSelfManagedDispatchCountsToday(task.repo);
+          return evaluateDispatchPolicy(loadDispatchPolicyConfig(), {
+            repo: task.repo,
+            agent: taskAgent(task),
+            todayCount: counts.todayCount,
+            todayRepoCount: counts.todayRepoCount,
+          });
+        },
+        audit: async (action) => {
+          await recordOperatorCommandEvent({
+            source: "slack_routine",
+            commandText: `task health ${action.action}: ${action.taskId}`,
+            ...(routineConfig.channelId ? { channelId: routineConfig.channelId } : {}),
+            result: {
+              kind: "o5_task_health",
+              ...action,
+              safety: { readOnly: action.action !== "retry", mutatesGithub: false, mutatesAverray: false, editsWikipedia: false },
+            },
+          }, query).catch((error) => logger.warn({ err: error, action }, "o5_task_health_audit_failed"));
+        },
+        now: () => new Date(),
+      });
+      if (result.actions.length > 0) {
+        logger.info({ actions: result.actions }, "o5_task_health_reconciled");
+      }
+    } catch (error) {
+      logger.error({ err: error }, "o5_task_health_failed");
+    } finally {
+      taskHealthRunning = false;
+    }
+  };
+
   // B2 — self-healing. On a failure signal: auto-PROPOSE a routed fix (non-high-
   // risk) that flows through the existing approval/autopilot gate, or ESCALATE
   // (high-risk / rollback / D3-suspended / HALT). Never auto-approves or runs.
@@ -2416,23 +2496,23 @@ function startOperatorRoutines() {
     }
   };
 
-  if (routineConfig.dailyBrief.enabled) {
+  if (routineConfig.channelId && routineConfig.dailyBrief.enabled) {
     setTimeout(() => void checkDailyBrief(), 5_000);
     setInterval(() => void checkDailyBrief(), 60_000);
   }
-  if (routineConfig.dailyGithubBrief.enabled) {
+  if (routineConfig.channelId && routineConfig.dailyGithubBrief.enabled) {
     setTimeout(() => void checkDailyGithubBrief(), 7_500);
     setInterval(() => void checkDailyGithubBrief(), 60_000);
   }
-  if (routineConfig.opsHealth.enabled) {
+  if (routineConfig.channelId && routineConfig.opsHealth.enabled) {
     setTimeout(() => void checkOpsHealth(), 7_000);
     setInterval(() => void checkOpsHealth(), 60_000);
   }
-  if (routineConfig.safeWorkScan.enabled) {
+  if (routineConfig.channelId && routineConfig.safeWorkScan.enabled) {
     setTimeout(() => void checkSafeWork(), 10_000);
     setInterval(() => void checkSafeWork(), routineConfig.safeWorkScan.intervalMs);
   }
-  if (routineConfig.stalePrAlerts.enabled) {
+  if (routineConfig.channelId && routineConfig.stalePrAlerts.enabled) {
     setTimeout(() => void checkStalePrAlerts(), 12_000);
     setInterval(() => void checkStalePrAlerts(), routineConfig.stalePrAlerts.intervalMs);
   }
@@ -2443,6 +2523,10 @@ function startOperatorRoutines() {
   if (routineConfig.anomalyPause.enabled) {
     setTimeout(() => void checkAnomalies(), 11_000);
     setInterval(() => void checkAnomalies(), routineConfig.anomalyPause.intervalMs);
+  }
+  if (routineConfig.taskHealth.enabled) {
+    setTimeout(() => void checkTaskHealth(), 12_000);
+    setInterval(() => void checkTaskHealth(), routineConfig.taskHealth.intervalMs);
   }
   if (routineConfig.selfHealing.enabled) {
     setTimeout(() => void checkSelfHealing(), 13_000);

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -1356,6 +1356,19 @@ export function taskHealthForBoard(
   const runnerState = runnerHealthForTask(task, runner, now);
 
   if (status === "failed") {
+    const retryAfter = asString(task.retryAfter);
+    const retryAfterMs = retryAfter ? Date.parse(retryAfter) : NaN;
+    if (!asString(task.selfManagementEscalatedAt) && Number.isFinite(retryAfterMs) && retryAfterMs > now.getTime()) {
+      const waitMinutes = Math.max(1, Math.ceil((retryAfterMs - now.getTime()) / 60_000));
+      return {
+        lane: "codex-needed",
+        state: "stale",
+        waitingOn: { actor: "agent", tone: "info" },
+        risk: [],
+        freshness: minutesSince(asString(task.failedAt) ?? asString(task.updatedAt), now),
+        summary: `Task failed; O5 has scheduled a bounded retry in ${waitMinutes}m.`,
+      };
+    }
     const repeated = attemptCount >= REPEATED_FAILURE_ATTEMPTS;
     return attentionHealth({
       state: "stale",

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -36,6 +36,16 @@ export interface SlackRoutineConfig {
     enabled: boolean;
     intervalMs: number;
   };
+  /** O5 — task health self-management: bounded retries + stale escalation. */
+  taskHealth: {
+    enabled: boolean;
+    intervalMs: number;
+    maxRetries: number;
+    retryBackoffMs: number;
+    approvedStaleMs: number;
+    runningStaleMs: number;
+    restartRecoveryMs: number;
+  };
   /** B2 — self-healing: propose routed fixes / escalate on failure. Off by default. */
   selfHealing: {
     enabled: boolean;
@@ -100,6 +110,15 @@ export function parseSlackRoutineConfig(
       // Off by default — the operator enables D3 before turning on autopilot.
       enabled: env.D3_ANOMALY_PAUSE_ENABLED === "1",
       intervalMs: Math.max(30_000, (positiveNumber(env.D3_ANOMALY_PAUSE_INTERVAL_MINUTES) || 1) * 60_000),
+    },
+    taskHealth: {
+      enabled: env.O5_TASK_HEALTH_ENABLED !== "0",
+      intervalMs: Math.max(60_000, (positiveNumber(env.O5_TASK_HEALTH_INTERVAL_MINUTES) || 5) * 60_000),
+      maxRetries: env.O5_TASK_HEALTH_MAX_RETRIES === "0" ? 0 : Math.max(0, positiveNumber(env.O5_TASK_HEALTH_MAX_RETRIES) || 1),
+      retryBackoffMs: Math.max(60_000, (positiveNumber(env.O5_TASK_HEALTH_RETRY_BACKOFF_MINUTES) || 15) * 60_000),
+      approvedStaleMs: Math.max(60_000, (positiveNumber(env.O5_TASK_HEALTH_APPROVED_STALE_MINUTES) || 30) * 60_000),
+      runningStaleMs: Math.max(60_000, (positiveNumber(env.O5_TASK_HEALTH_RUNNING_STALE_MINUTES) || 20) * 60_000),
+      restartRecoveryMs: Math.max(60_000, (positiveNumber(env.O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES) || 10) * 60_000),
     },
     selfHealing: {
       // Off by default — proposes fixes / escalates only once the operator turns it on.

--- a/services/slack-operator/src/task-health.ts
+++ b/services/slack-operator/src/task-health.ts
@@ -1,0 +1,172 @@
+import type { DispatchPolicyDecision } from "@avg/averray-mcp/dispatch-policy";
+
+import type { CodexRunnerHeartbeat, CodexTask } from "./codex-task-queue.js";
+
+export interface TaskHealthConfig {
+  enabled: boolean;
+  intervalMs: number;
+  maxRetries: number;
+  retryBackoffMs: number;
+  approvedStaleMs: number;
+  runningStaleMs: number;
+  restartRecoveryMs: number;
+}
+
+export interface TaskHealthAction {
+  taskId: string;
+  action: "retry" | "defer_retry" | "escalate" | "none";
+  reason: string;
+  retryAfter?: Date;
+}
+
+export interface TaskHealthDeps {
+  listTasks: () => Promise<CodexTask[]> | CodexTask[];
+  readRunner: () => Promise<CodexRunnerHeartbeat | undefined> | CodexRunnerHeartbeat | undefined;
+  retryTask: (id: string, reason: string) => Promise<unknown> | unknown;
+  deferRetry: (id: string, retryAfter: Date, reason: string) => Promise<unknown> | unknown;
+  escalateTask: (id: string, reason: string) => Promise<unknown> | unknown;
+  isSuspended: () => boolean;
+  isHalt: () => boolean;
+  dispatchAllowed: (task: CodexTask) => Promise<DispatchPolicyDecision> | DispatchPolicyDecision;
+  audit?: (action: TaskHealthAction) => Promise<unknown> | unknown;
+  now: () => Date;
+}
+
+export interface TaskHealthResult {
+  actions: TaskHealthAction[];
+}
+
+const TERMINAL_NO_ACTION = new Set(["completed", "cancelled"]);
+
+export async function runTaskHealthOnce(
+  config: TaskHealthConfig,
+  deps: TaskHealthDeps,
+): Promise<TaskHealthResult> {
+  if (!config.enabled) return { actions: [] };
+  const now = deps.now();
+  const tasks = await deps.listTasks();
+  const runner = await deps.readRunner();
+  const actions: TaskHealthAction[] = [];
+
+  for (const task of tasks) {
+    const action = await decideTaskHealthAction(task, {
+      config,
+      now,
+      runner,
+      suspended: deps.isSuspended(),
+      halt: deps.isHalt(),
+      dispatch: task.status === "failed" || task.status === "running"
+        ? await deps.dispatchAllowed(task)
+        : { allowed: true, reason: "dispatch_not_needed" },
+    });
+    if (action.action === "none") continue;
+    actions.push(action);
+    if (action.action === "retry") {
+      await deps.retryTask(action.taskId, action.reason);
+    } else if (action.action === "defer_retry" && action.retryAfter) {
+      await deps.deferRetry(action.taskId, action.retryAfter, action.reason);
+    } else if (action.action === "escalate") {
+      await deps.escalateTask(action.taskId, action.reason);
+    }
+    await deps.audit?.(action);
+  }
+
+  return { actions };
+}
+
+export async function decideTaskHealthAction(
+  task: CodexTask,
+  ctx: {
+    config: TaskHealthConfig;
+    now: Date;
+    runner?: CodexRunnerHeartbeat;
+    suspended: boolean;
+    halt: boolean;
+    dispatch: DispatchPolicyDecision;
+  },
+): Promise<TaskHealthAction> {
+  const base = { taskId: task.id };
+  if (TERMINAL_NO_ACTION.has(task.status)) return { ...base, action: "none", reason: "terminal" };
+  if (task.selfManagementEscalatedAt) return { ...base, action: "none", reason: "already_escalated" };
+
+  if (task.status === "failed") {
+    const scheduledRetry = parseDate(task.retryAfter);
+    if (scheduledRetry && scheduledRetry.getTime() > ctx.now.getTime()) {
+      return { ...base, action: "none", reason: "retry_backoff_pending" };
+    }
+    if (!mayRetry(task, ctx.config)) return { ...base, action: "escalate", reason: "retry_budget_exhausted" };
+    if (ctx.halt) return { ...base, action: "escalate", reason: "halt_present" };
+    if (ctx.suspended) return { ...base, action: "escalate", reason: "autopilot_suspended" };
+    if (!ctx.dispatch.allowed) return { ...base, action: "escalate", reason: `dispatch_blocked:${ctx.dispatch.reason}` };
+
+    const retryAfter = nextRetryAfter(task, ctx.config, ctx.now);
+    if (retryAfter.getTime() > ctx.now.getTime()) {
+      return { ...base, action: "defer_retry", reason: "retry_backoff_wait", retryAfter };
+    }
+    return { ...base, action: "retry", reason: "bounded_retry" };
+  }
+
+  if (task.status === "approved") {
+    const approvedAgeMs = ageMs(task.approvedAt ?? task.updatedAt, ctx.now);
+    if (approvedAgeMs >= ctx.config.approvedStaleMs) {
+      return { ...base, action: "escalate", reason: "approved_task_stale" };
+    }
+    return { ...base, action: "none", reason: "approved_fresh" };
+  }
+
+  if (task.status === "running") {
+    const staleAgeMs = ageMs(task.progressAt ?? task.startedAt ?? task.updatedAt, ctx.now);
+    const runner = runnerStateForTask(task, ctx.runner, ctx.now);
+    if (runner.unavailable && staleAgeMs >= ctx.config.restartRecoveryMs) {
+      if (!mayRetry(task, ctx.config)) return { ...base, action: "escalate", reason: "restart_recovery_retry_budget_exhausted" };
+      if (ctx.halt) return { ...base, action: "escalate", reason: "halt_present" };
+      if (ctx.suspended) return { ...base, action: "escalate", reason: "autopilot_suspended" };
+      if (!ctx.dispatch.allowed) return { ...base, action: "escalate", reason: `dispatch_blocked:${ctx.dispatch.reason}` };
+      return { ...base, action: "retry", reason: "restart_recovery_requeue" };
+    }
+    if (staleAgeMs >= ctx.config.runningStaleMs) {
+      return { ...base, action: "escalate", reason: runner.activeTaskMismatch ? "runner_active_task_mismatch" : "running_task_stale" };
+    }
+    return { ...base, action: "none", reason: "running_fresh" };
+  }
+
+  return { ...base, action: "none", reason: "not_managed" };
+}
+
+function mayRetry(task: CodexTask, config: TaskHealthConfig): boolean {
+  return Math.max(0, Math.floor(task.retryCount ?? 0)) < config.maxRetries;
+}
+
+function nextRetryAfter(task: CodexTask, config: TaskHealthConfig, now: Date): Date {
+  const failedAt = Date.parse(task.failedAt ?? task.updatedAt);
+  const start = Number.isFinite(failedAt) ? failedAt : now.getTime();
+  const retryCount = Math.max(0, Math.floor(task.retryCount ?? 0));
+  const backoff = config.retryBackoffMs * Math.max(1, 2 ** retryCount);
+  return new Date(start + backoff);
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? new Date(parsed) : undefined;
+}
+
+function runnerStateForTask(
+  task: CodexTask,
+  runner: CodexRunnerHeartbeat | undefined,
+  now: Date,
+): { unavailable: boolean; activeTaskMismatch: boolean } {
+  if (!runner) return { unavailable: true, activeTaskMismatch: false };
+  const heartbeatAgeMs = ageMs(runner.updatedAt, now);
+  const stale = heartbeatAgeMs > 90_000;
+  const unavailable = stale || runner.status === "disabled" || runner.status === "misconfigured" || runner.status === "error" || runner.status === "failed";
+  const activeTaskMismatch = Boolean(runner.activeTaskId && runner.activeTaskId !== task.id);
+  return { unavailable: unavailable || activeTaskMismatch, activeTaskMismatch };
+}
+
+function ageMs(value: string | undefined, now: Date): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return Math.max(0, now.getTime() - parsed);
+}

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -12,6 +12,7 @@ import {
   listCodexTasks,
   proposeCodexTask,
   readCodexRunnerHeartbeat,
+  retryCodexTask,
   summarizeCodexTasks,
   taskAgent,
   updateCodexTaskProgress,
@@ -239,6 +240,51 @@ describe("codex task queue", () => {
       failureReason: "CI stayed red.",
       exitCode: 2,
       stderrTail: "failed",
+    });
+    expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
+  });
+
+  it("rehydrates and requeues one orphaned running task after runner restart", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 390,
+      prompt: "Fix PR #390.",
+    }, { path, now: new Date("2026-05-17T13:30:00.000Z") });
+    await approveCodexTask(proposed.task.id, { path, now: new Date("2026-05-17T13:31:00.000Z") });
+    await claimNextApprovedCodexTask({ path, runnerId: "runner-before-restart", now: new Date("2026-05-17T13:32:00.000Z") });
+
+    const requeued = await retryCodexTask(proposed.task.id, {
+      path,
+      approvedBy: "o5-self-management",
+      reason: "restart_recovery_requeue",
+      now: new Date("2026-05-17T13:45:00.000Z"),
+    });
+
+    expect(requeued).toMatchObject({
+      id: proposed.task.id,
+      status: "approved",
+      approvedBy: "o5-self-management",
+      retryCount: 1,
+      progressMessage: "restart_recovery_requeue",
+    });
+    expect(requeued?.runnerId).toBeUndefined();
+    expect(requeued?.startedAt).toBeUndefined();
+
+    const rehydrated = await listCodexTasks({ path });
+    expect(rehydrated).toHaveLength(1);
+    expect(rehydrated[0]).toMatchObject({ status: "approved", retryCount: 1 });
+
+    const claimedAgain = await claimNextApprovedCodexTask({
+      path,
+      runnerId: "runner-after-restart",
+      now: new Date("2026-05-17T13:46:00.000Z"),
+    });
+    expect(claimedAgain).toMatchObject({
+      id: proposed.task.id,
+      status: "running",
+      runnerId: "runner-after-restart",
+      attemptCount: 2,
     });
     expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
   });

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1178,6 +1178,37 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     expect(card?.riskSignals?.[0]?.message).toContain("tests failed");
   });
 
+  it("keeps failed tasks with a scheduled O5 retry out of action-needed until backoff expires", () => {
+    const [card] = synthesizeTaskCards(
+      {
+        codexTasks: {
+          items: [{
+            id: "failed-waiting-retry",
+            status: "failed",
+            agent: "codex",
+            repo: "a/b",
+            prompt: "x",
+            attemptCount: 1,
+            failedAt: "2026-05-31T11:55:00.000Z",
+            updatedAt: "2026-05-31T11:55:00.000Z",
+            retryAfter: "2026-05-31T12:05:00.000Z",
+          }],
+        },
+      },
+      { status: "idle", updatedAt: "2026-05-31T11:59:30.000Z" },
+      { now: new Date("2026-05-31T12:00:00.000Z") },
+    );
+
+    expect(card).toMatchObject({
+      id: "failed-waiting-retry",
+      lane: "codex-needed",
+      waitingOn: { actor: "agent", tone: "info" },
+      risk: [],
+    });
+    expect(card?.isAction).toBeUndefined();
+    expect(card?.summary).toContain("scheduled a bounded retry in 5m");
+  });
+
   it("promotes stale approved tasks when no runner can claim them", () => {
     const [card] = synthesizeTaskCards(
       {

--- a/test/unit/slack-routines.test.ts
+++ b/test/unit/slack-routines.test.ts
@@ -40,6 +40,15 @@ describe("slack operator routines", () => {
     expect(config.stalePrAlerts.enabled).toBe(true);
     expect(config.stalePrAlerts.intervalMs).toBe(20 * 60_000);
     expect(config.stalePrAlerts.staleAfterMinutes).toBe(180);
+    expect(config.taskHealth).toMatchObject({
+      enabled: true,
+      intervalMs: 5 * 60_000,
+      maxRetries: 1,
+      retryBackoffMs: 15 * 60_000,
+      approvedStaleMs: 30 * 60_000,
+      runningStaleMs: 20 * 60_000,
+      restartRecoveryMs: 10 * 60_000,
+    });
     expect(config.selfHealing.enabled).toBe(true);
     expect(config.selfHealing.maxProposalsPerTick).toBe(3);
   });
@@ -69,6 +78,28 @@ describe("slack operator routines", () => {
     expect(config.selfHealing.maxProposalsPerTick).toBe(2);
     expect(config.selfHealing.maxOpenFixTasks).toBe(4);
     expect(config.selfHealing.testbedFailureMaxAgeHours).toBe(12);
+  });
+
+  it("parses O5 task health retry and stale thresholds", () => {
+    const config = parseSlackRoutineConfig({
+      O5_TASK_HEALTH_ENABLED: "0",
+      O5_TASK_HEALTH_INTERVAL_MINUTES: "2",
+      O5_TASK_HEALTH_MAX_RETRIES: "3",
+      O5_TASK_HEALTH_RETRY_BACKOFF_MINUTES: "4",
+      O5_TASK_HEALTH_APPROVED_STALE_MINUTES: "12",
+      O5_TASK_HEALTH_RUNNING_STALE_MINUTES: "8",
+      O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES: "6",
+    }, new Set(["C1"]));
+
+    expect(config.taskHealth).toMatchObject({
+      enabled: false,
+      intervalMs: 2 * 60_000,
+      maxRetries: 3,
+      retryBackoffMs: 4 * 60_000,
+      approvedStaleMs: 12 * 60_000,
+      runningStaleMs: 8 * 60_000,
+      restartRecoveryMs: 6 * 60_000,
+    });
   });
 
   it("runs the daily brief once per UTC date after the target time", () => {

--- a/test/unit/task-health.test.ts
+++ b/test/unit/task-health.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { CodexTask } from "../../services/slack-operator/src/codex-task-queue.js";
+import {
+  decideTaskHealthAction,
+  runTaskHealthOnce,
+  type TaskHealthConfig,
+} from "../../services/slack-operator/src/task-health.js";
+
+const config: TaskHealthConfig = {
+  enabled: true,
+  intervalMs: 60_000,
+  maxRetries: 1,
+  retryBackoffMs: 10 * 60_000,
+  approvedStaleMs: 30 * 60_000,
+  runningStaleMs: 20 * 60_000,
+  restartRecoveryMs: 10 * 60_000,
+};
+
+function task(overrides: Partial<CodexTask>): CodexTask {
+  return {
+    schemaVersion: 1,
+    kind: "codex_task",
+    id: "task-1",
+    status: "failed",
+    repo: "depre-dev/averray-reference-agent",
+    agent: "codex",
+    prompt: "fix it",
+    createdAt: "2026-06-01T10:00:00.000Z",
+    updatedAt: "2026-06-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("task health self-management", () => {
+  it("retries a failed task once after backoff, then escalates when retry budget is spent", async () => {
+    const now = new Date("2026-06-01T10:30:00.000Z");
+    const retry = await decideTaskHealthAction(
+      task({
+        id: "retry-me",
+        failedAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      }),
+      {
+        config,
+        now,
+        suspended: false,
+        halt: false,
+        dispatch: { allowed: true, reason: "dispatch_allowed" },
+      },
+    );
+
+    expect(retry).toMatchObject({
+      taskId: "retry-me",
+      action: "retry",
+      reason: "bounded_retry",
+    });
+
+    const exhausted = await decideTaskHealthAction(
+      task({
+        id: "escalate-me",
+        retryCount: 1,
+        failedAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      }),
+      {
+        config,
+        now,
+        suspended: false,
+        halt: false,
+        dispatch: { allowed: true, reason: "dispatch_allowed" },
+      },
+    );
+
+    expect(exhausted).toMatchObject({
+      taskId: "escalate-me",
+      action: "escalate",
+      reason: "retry_budget_exhausted",
+    });
+  });
+
+  it("schedules backoff once and does not emit duplicate retry proposals while waiting", async () => {
+    const now = new Date("2026-06-01T10:05:00.000Z");
+    const failed = task({
+      failedAt: "2026-06-01T10:00:00.000Z",
+      updatedAt: "2026-06-01T10:00:00.000Z",
+    });
+
+    const first = await decideTaskHealthAction(failed, {
+      config,
+      now,
+      suspended: false,
+      halt: false,
+      dispatch: { allowed: true, reason: "dispatch_allowed" },
+    });
+    expect(first).toMatchObject({
+      action: "defer_retry",
+      reason: "retry_backoff_wait",
+      retryAfter: new Date("2026-06-01T10:10:00.000Z"),
+    });
+
+    const second = await decideTaskHealthAction({ ...failed, retryAfter: "2026-06-01T10:10:00.000Z" }, {
+      config,
+      now,
+      suspended: false,
+      halt: false,
+      dispatch: { allowed: true, reason: "dispatch_allowed" },
+    });
+    expect(second).toMatchObject({
+      action: "none",
+      reason: "retry_backoff_pending",
+    });
+  });
+
+  it("escalates approved tasks that sit past the stale threshold", async () => {
+    const action = await decideTaskHealthAction(
+      task({
+        id: "approved-stale",
+        status: "approved",
+        approvedAt: "2026-06-01T09:00:00.000Z",
+        updatedAt: "2026-06-01T09:00:00.000Z",
+      }),
+      {
+        config,
+        now: new Date("2026-06-01T10:00:00.000Z"),
+        suspended: false,
+        halt: false,
+        dispatch: { allowed: true, reason: "dispatch_not_needed" },
+      },
+    );
+
+    expect(action).toMatchObject({
+      taskId: "approved-stale",
+      action: "escalate",
+      reason: "approved_task_stale",
+    });
+  });
+
+  it("requeues stale running tasks after a restart when the runner heartbeat no longer owns them", async () => {
+    const retryTask = vi.fn();
+    const escalateTask = vi.fn();
+
+    const result = await runTaskHealthOnce(config, {
+      listTasks: () => [
+        task({
+          id: "running-orphan",
+          status: "running",
+          startedAt: "2026-06-01T09:40:00.000Z",
+          progressAt: "2026-06-01T09:40:00.000Z",
+          updatedAt: "2026-06-01T09:40:00.000Z",
+          attemptCount: 1,
+        }),
+      ],
+      readRunner: () => undefined,
+      retryTask,
+      deferRetry: vi.fn(),
+      escalateTask,
+      isSuspended: () => false,
+      isHalt: () => false,
+      dispatchAllowed: () => ({ allowed: true, reason: "dispatch_allowed" }),
+      now: () => new Date("2026-06-01T10:00:00.000Z"),
+    });
+
+    expect(result.actions).toEqual([
+      {
+        taskId: "running-orphan",
+        action: "retry",
+        reason: "restart_recovery_requeue",
+      },
+    ]);
+    expect(retryTask).toHaveBeenCalledWith("running-orphan", "restart_recovery_requeue");
+    expect(escalateTask).not.toHaveBeenCalled();
+  });
+
+  it("respects D3 anomaly pause before retrying into another dispatch", async () => {
+    const result = await decideTaskHealthAction(
+      task({
+        failedAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      }),
+      {
+        config,
+        now: new Date("2026-06-01T10:30:00.000Z"),
+        suspended: true,
+        halt: false,
+        dispatch: { allowed: true, reason: "dispatch_allowed" },
+      },
+    );
+
+    expect(result).toMatchObject({
+      action: "escalate",
+      reason: "autopilot_suspended",
+    });
+  });
+});


### PR DESCRIPTION
## What changed & why

Hardened O5 task health self-management beyond the first needs-attention slice:

- added a config-driven task-health routine for bounded failed-task retries with backoff before operator escalation
- escalates stale `approved` / `running` tasks instead of letting them sit silently
- reconciles stale in-flight JSON queue state after slack-operator restart by requeuing the same orphaned running task, not creating a duplicate
- keeps retries D3/HALT/dispatch-guardrail interlocked and adds O5 env wiring
- updates the board so failed tasks with a scheduled bounded retry do not immediately look action-needed
- updates the O5 roadmap/design docs with PR #336 and code evidence

## Affected surfaces

- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [ ] Docs / tests only

## Checks run

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

Compose note: attempted locally, but this host's `docker` CLI does not support the Compose v2 subcommand (`unknown flag: --env-file`) and `docker-compose` is not installed. The repo's `compose-env` unit test passed as part of `npm test`.

## Rollout / rollback

Rollout: merge and deploy normally. O5 task health defaults on with conservative settings: one retry after 15m backoff, then escalation. Operators can disable with `O5_TASK_HEALTH_ENABLED=0` or tune the `O5_TASK_HEALTH_*` thresholds in ops env.

Rollback: revert this PR or set `O5_TASK_HEALTH_ENABLED=0`; existing manual approve/claim runner behavior remains intact.

## Durable invariants (AGENTS.md)

- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- O5 still does not merge, deploy, or create new tasks; it only requeues the same task within the configured retry budget or escalates.
