### PR TITLE
[codex] Add live T4 gold-path tester driver

### DIFF
--- a/docs/HERMES_E2E_TESTER_DESIGN.md
+++ b/docs/HERMES_E2E_TESTER_DESIGN.md
@@ -1,12 +1,12 @@
 # Hermes E2E Tester — Design (the product tester)
 
-- **Status:** Reconciled 2026-05-31. T2 pre-seeded session (#293), T3 SIWE role-gating (#290), and T5 env→mutation binding/enhancements (#297) have shipped. T6's first board-gated request/approve slice is in flight here. T4 Tier-2 agent and T7 capabilities/helper work remain follow-up/design unless code evidence proves otherwise.
+- **Status:** Reconciled 2026-06-01. T2 pre-seeded session (#293), T3 SIWE role-gating (#290), T5 env→mutation binding/enhancements (#297), and T6's first board-gated request/approve slice have shipped. T4 live-driver wiring is in progress here: the fake/default CI path remains, and the opt-in Claude + Playwright-MCP driver must still be proved by a hosted run.
 - **Date:** 2026-05-29
 - **Lives in:** this repo (`depre-dev/averray-reference-agent`) — the testbed/mission code is here.
 - **Tests:** the platform product `averray-agent/agent` — the Polkadot Agent Platform ("Averray"): an agent-first job/treasury runtime on Polkadot Hub TestNet.
 - **Roadmap fit:** matures the existing testbed missions into a real product tester. The Tier-2 agent is **Theme C's first specialized agent** (built on the P2 per-agent-runner pattern), and failed missions are a **Theme B2 self-healing trigger**.
 
-> Honest starting point: the mission *pipeline* is ~80% built (queue, lifecycle, heartbeat, structured report, evidence/screenshots, board MissionDrawer, two executors, MCP entry). What's thin is the *brain* — the Playwright executor (`services/slack-operator/src/testbed-mission-runner.ts:265`) is a single-step heuristic smoke test; the `command` executor (`:191`, passes the mission + a `reportPath`) is an empty hook where the real agent belongs; missions run a clean browser with **no wallet**, so they can only see public pages.
+> Honest starting point: the mission *pipeline* is built enough to run gated missions (queue, lifecycle, heartbeat, structured report, evidence/screenshots, board MissionDrawer, approval gate, and runners). This PR wires the Tier-2 brain as an opt-in Claude + Playwright-MCP driver behind `TESTBED_GOLDPATH_LIVE`; CI and default deploys keep the fake path, and hosted run proof remains the next evidence step.
 
 ---
 
@@ -106,7 +106,7 @@ Each mission's verdict is LLM-judged (Tier 2) or rule-checked (Tier 1); both rec
 
 1. **Tier 1 hardening** — broaden the heuristic executor to all surfaces + add the boundary-honesty check + add a **pre-seeded session** so it can reach authed pages. (T2 pre-seeded session shipped in #293.)
 2. **Signer sidecar + SIWE mission** — the keystone unlock for authed testing. (T3 role-gating mission shipped in #290; sidecar foundation shipped earlier in #283.)
-3. **Tier-2 agent executor** (Agent SDK + Playwright-MCP + HTTP/wallet) via the `command` hook — the gold-path missions.
+3. **Tier-2 agent executor** (Agent SDK + Playwright-MCP + HTTP/wallet) — the gold-path missions. This PR wires the opt-in live driver behind `TESTBED_GOLDPATH_LIVE`; hosted run proof remains follow-up.
 4. **Env→mutation-profile binding** (do before any mainnet exists). (T5 shipped in #297.)
 5. **Enhancements** — trace/video, regression baselines, B2 self-healing hook.
 
@@ -119,4 +119,4 @@ Each mission's verdict is LLM-judged (Tier 2) or rule-checked (Tier 1); both rec
 
 ---
 
-*End of E2E tester design. Reconciled 2026-05-31: T2, T3, and T5 have shipped; T6 first slice is in flight; T4/T7 remain follow-up/design.*
+*End of E2E tester design. Reconciled 2026-06-01: T2, T3, T5, and T6 first slice have shipped; T4 live-driver wiring is in progress here; T7 platform helper remains follow-up.*

--- a/docs/HERMES_ROADMAP.md
+++ b/docs/HERMES_ROADMAP.md
@@ -45,12 +45,12 @@
 | T1 | Surface sweep + truth-boundary honesty | ✅ done — executor #273; deploy-wire (platform #604) + runner #277; runs per-deploy (report-only) |
 | T2 | Pre-seeded session (authed sweep) | ✅ done (#293) |
 | T3 | Signer sidecar + SIWE mission (multi-role) | ✅ done — signer sidecar foundation (#283) + SIWE role-gating mission (#290) |
-| T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | design done |
+| T4 | Tier-2 agent (Agent SDK + Playwright-MCP) | 🚧 live driver wired in this PR — opt-in Claude + Playwright-MCP driver behind `TESTBED_GOLDPATH_LIVE`; fake/default path remains for CI; hosted run proof remains follow-up |
 | T5 | Env→mutation binding + enhancements (trace/video, baselines) | ✅ done (#297) — env-bound mutation profile + Playwright trace/video + baseline comparison slice |
 | T6 | Agent-requested tester runs — board-gated (request → approve → read-only run) | ✅ first slice done (#304; `POST /monitor/testbed-missions/request`, `/approve`, board approve UI, and runner ignores `requested` until approval) |
 | T7 | Tester capabilities manifest (+ platform-repo request helper) | ✅ reference-agent manifest done (#284; `GET /monitor/tester/capabilities`, `services/slack-operator/src/tester-capabilities.ts`). Platform-repo request helper remains follow-up outside this repo |
 
-*(Status as of 2026-06-01 — **shipped/code-backed:** O0–O5, A1–A4, D1–D4, B1 first slices, B2 proposes-only self-healing, C1 first slice, C2, C3 test-writer slice, C4 v1, T1–T3, T5, T6 first slice, and the T7 reference-agent manifest. **In progress:** none after #336 merges. **Design / follow-up:** B1 idle-triggered auto-flow, C1 automatic/default reviewer dispatch, C3 security/docs specialists, T4 Tier-2 browser agent, and the T7 platform helper. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
+*(Status as of 2026-06-01 — **shipped/code-backed:** O0–O5, A1–A4, D1–D4, B1 first slices, B2 proposes-only self-healing, C1 first slice, C2, C3 test-writer slice, C4 v1, T1–T3, T5, T6 first slice, and the T7 reference-agent manifest. **In progress:** T4 live gold-path driver wiring. **Design / follow-up:** B1 idle-triggered auto-flow, C1 automatic/default reviewer dispatch, C3 security/docs specialists, T4 hosted run proof, and the T7 platform helper. Merge/deploy remain human-gated; autopilot approves dispatch only inside O4 guardrails.)*
 
 ## Recommended build order (the smooth, low-effort ramp)
 
@@ -58,7 +58,7 @@
    - **T1** runs in parallel with O1 (independent, both runner/board TS).
 2. **The safety net:** **D4** (off-device alert bridge), **T1**, **T2 + T3** (tester reaches authed product), **D1 + D3** (digest + anomaly auto-pause), and **T5** (env-bound mutation profile). This foundation has shipped; **T6** has its first request/approve gate slice, and **T7** has the reference-agent manifest. The platform helper remains follow-up.
 3. **Autonomy:** **O4** (enqueue + guardrail + autonomy mode) has shipped; supervised burn-in and monitoring decide when to rely on it more heavily.
-4. **Depth, anytime after:** **A1 → A3** shipped, **O5** hardening is code-backed, and **B1/B2** now have code-backed first slices. Remaining depth is B1 idle auto-flow, C1 automatic/default reviewer dispatch, C3 additional specialists, **T4**, and T7 platform helper polish.
+4. **Depth, anytime after:** **A1 → A3** shipped, **O5** hardening is code-backed, and **B1/B2** now have code-backed first slices. Remaining depth is B1 idle auto-flow, C1 automatic/default reviewer dispatch, C3 additional specialists, **T4 hosted run proof**, and T7 platform helper polish.
 
 **Dependencies to respect:** B2 needs D3 (loop fail-safe); A2 needs A1 (baselines); O4 is the authority change and needs D4 (escalations must reach the operator off-device); T6 needs the proposed-mission approval gate; T-missions that mutate stay on testnet (env→mutation binding before any mainnet).
 

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -62,16 +62,15 @@ TESTBED_MISSION_MAX_BROWSER_STEPS=12
 TESTBED_MISSION_ENVIRONMENT=
 TESTBED_MISSION_CAPTURE_TRACE=1
 TESTBED_MISSION_CAPTURE_VIDEO=1
-# T4 Tier-2 gold-path tester. Runs via the `command` executor: point a testbed
-# runner at the gold-path entry (EXECUTOR=command, ARGS below) in an env that
-# only queues gold_path missions. gold_path missions land `requested` (behind
-# the T6 approve gate; never auto-run). Mutation is bound by T5 (mainnet is
-# structurally read-only). The live Claude Agent SDK + Playwright-MCP driver is
-# a follow-up: until TESTBED_GOLDPATH_LIVE=1 AND that driver is wired, the runner
-# emits an honest "not executed" report (never a fake pass).
-#   TESTBED_MISSION_RUNNER_EXECUTOR=command
-#   TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/gold-path-mission-entry.js
+# T4 Tier-2 gold-path tester. gold_path missions land `requested` behind the T6
+# approve gate and are claimed by the normal testbed runner. Default stays fake
+# for CI; set TESTBED_GOLDPATH_LIVE=1 to invoke Claude + Playwright-MCP. Mutation
+# is bound by T5 (mainnet is structurally read-only).
 TESTBED_GOLDPATH_LIVE=0
+TESTBED_GOLDPATH_CLAUDE_COMMAND=claude
+TESTBED_GOLDPATH_CLAUDE_ARGS=["-p","{prompt}"]
+TESTBED_GOLDPATH_TIMEOUT_MS=1200000
+TESTBED_GOLDPATH_AUTH_PROBED_ROUTE=
 # Model per A4: sonnet (routine, default) / opus (deep). DEEP forces opus.
 TESTBED_GOLDPATH_DEEP=0
 TESTBED_GOLDPATH_MODEL=

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -271,6 +271,19 @@ services:
       TESTBED_MISSION_ENVIRONMENT: ${TESTBED_MISSION_ENVIRONMENT:-}
       TESTBED_MISSION_CAPTURE_TRACE: ${TESTBED_MISSION_CAPTURE_TRACE:-1}
       TESTBED_MISSION_CAPTURE_VIDEO: ${TESTBED_MISSION_CAPTURE_VIDEO:-1}
+      # T4 live gold-path driver. Default is off so CI/test deploys keep the
+      # deterministic fake path; when enabled the runner invokes Claude with
+      # Playwright-MCP/browser tooling and writes a structured report.
+      TESTBED_GOLDPATH_LIVE: ${TESTBED_GOLDPATH_LIVE:-0}
+      TESTBED_GOLDPATH_CLAUDE_COMMAND: ${TESTBED_GOLDPATH_CLAUDE_COMMAND:-claude}
+      TESTBED_GOLDPATH_CLAUDE_ARGS: '${TESTBED_GOLDPATH_CLAUDE_ARGS:-["-p","{prompt}"]}'
+      TESTBED_GOLDPATH_TIMEOUT_MS: ${TESTBED_GOLDPATH_TIMEOUT_MS:-1200000}
+      TESTBED_GOLDPATH_AUTH_PROBED_ROUTE: ${TESTBED_GOLDPATH_AUTH_PROBED_ROUTE:-}
+      TESTBED_GOLDPATH_DEEP: ${TESTBED_GOLDPATH_DEEP:-0}
+      TESTBED_GOLDPATH_MODEL: ${TESTBED_GOLDPATH_MODEL:-}
+      CLAUDE_WORKER_AUTH_MODE: ${CLAUDE_WORKER_AUTH_MODE:-sub}
+      CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       # T1 surface sweep: base URL for relative routes (falls back to the
       # mission's targetUrl when unset) + the env's truth boundary the honesty
       # check asserts. Leave EXPECTED_BOUNDARY empty for the self-consistency

--- a/services/slack-operator/src/gold-path-live-driver.ts
+++ b/services/slack-operator/src/gold-path-live-driver.ts
@@ -1,0 +1,435 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  assertAuthRouteOrHalt,
+  buildClaudeInvocationEnv,
+  resolveAuthMode,
+  type ActiveAuthRoute,
+  type ClaudeWorkerAuthEnv,
+} from "./claude-worker-auth.js";
+import {
+  GOLD_PATH_STEPS,
+  type GoldPathDriver,
+  type GoldPathDriverInput,
+  type GoldPathObservation,
+  type GoldPathStep,
+  type GoldPathStepResult,
+  type GoldPathStepStatus,
+} from "./gold-path-mission.js";
+import { redact } from "./codex-branch-worker.js";
+
+export interface ClaudeGoldPathDriverConfig {
+  enabled: boolean;
+  command: string;
+  args: string[];
+  timeoutMs: number;
+  cwd?: string;
+  signerBaseUrl?: string;
+  probedRoute?: ActiveAuthRoute;
+}
+
+export interface ClaudeGoldPathDriverDeps {
+  exec?: ExecClaudeFn;
+  now?: () => number;
+}
+
+export interface ExecClaudeInput {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env: NodeJS.ProcessEnv;
+  timeoutMs: number;
+}
+
+export interface ExecClaudeResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type ExecClaudeFn = (input: ExecClaudeInput) => Promise<ExecClaudeResult>;
+
+const DEFAULT_CLAUDE_ARGS = ["-p", "{prompt}"];
+
+export function parseClaudeGoldPathDriverConfig(
+  env: NodeJS.ProcessEnv = process.env
+): ClaudeGoldPathDriverConfig {
+  return {
+    enabled: env.TESTBED_GOLDPATH_LIVE === "1" || env.TESTBED_GOLDPATH_LIVE === "true",
+    command: env.TESTBED_GOLDPATH_CLAUDE_COMMAND?.trim() || "claude",
+    args: parseArgs(env.TESTBED_GOLDPATH_CLAUDE_ARGS, DEFAULT_CLAUDE_ARGS),
+    timeoutMs: positiveInt(env.TESTBED_GOLDPATH_TIMEOUT_MS, 20 * 60_000),
+    ...(env.TESTBED_GOLDPATH_CWD ? { cwd: env.TESTBED_GOLDPATH_CWD } : {}),
+    ...(env.TEST_WALLET_SIGNER_BASE_URL || env.TESTBED_SESSION_SIGNER_URL
+      ? { signerBaseUrl: env.TEST_WALLET_SIGNER_BASE_URL || env.TESTBED_SESSION_SIGNER_URL }
+      : {}),
+    ...(parseProbedRoute(env.TESTBED_GOLDPATH_AUTH_PROBED_ROUTE) ? { probedRoute: parseProbedRoute(env.TESTBED_GOLDPATH_AUTH_PROBED_ROUTE) } : {}),
+  };
+}
+
+export function createClaudeGoldPathDriver(
+  config: ClaudeGoldPathDriverConfig = parseClaudeGoldPathDriverConfig(),
+  env: NodeJS.ProcessEnv = process.env,
+  deps: ClaudeGoldPathDriverDeps = {},
+): GoldPathDriver {
+  const exec = deps.exec ?? execClaudeCommand;
+  return {
+    async run(input: GoldPathDriverInput): Promise<GoldPathObservation> {
+      if (!config.enabled) {
+        return failedObservation(input, "Live gold-path driver is disabled; TESTBED_GOLDPATH_LIVE is not set.");
+      }
+      if (!input.allowMutations && input.mutationScope !== "none; stop at mutation boundary") {
+        // Defense-in-depth wording for read-only envs; not a failure by itself.
+      }
+      const routeEnv = claudeAuthEnv(env);
+      const authMode = resolveAuthMode(routeEnv);
+      if ("error" in authMode) return failedObservation(input, authMode.error);
+      try {
+        await assertAuthRouteOrHalt(routeEnv, "testbed-gold-path-live-driver", {
+          probedRoute: config.probedRoute,
+          log: () => undefined,
+        });
+      } catch (error) {
+        return failedObservation(input, error instanceof Error ? error.message : String(error));
+      }
+
+      const runDir = await mkdtemp(join(tmpdir(), "averray-gold-path-live-"));
+      const observationPath = join(runDir, "observation.json");
+      const prompt = buildClaudeGoldPathPrompt(input, {
+        observationPath,
+        signerBaseUrl: input.signerBaseUrl ?? config.signerBaseUrl,
+      });
+      const childEnv = buildClaudeInvocationEnv({
+        ...env,
+        TESTBED_GOLDPATH_OBSERVATION_PATH: observationPath,
+        TESTBED_TARGET_URL: input.targetUrl,
+        TESTBED_MISSION_GOAL: input.goal,
+        TESTBED_GOLDPATH_MODEL: input.model,
+        TESTBED_ALLOW_TEST_MUTATIONS: String(input.allowMutations),
+        TESTBED_MUTATION_SCOPE: input.mutationScope,
+        ...(input.signerBaseUrl ?? config.signerBaseUrl
+          ? { TEST_WALLET_SIGNER_BASE_URL: input.signerBaseUrl ?? config.signerBaseUrl }
+          : {}),
+      }, authMode.mode);
+
+      const started = deps.now?.() ?? Date.now();
+      const result = await exec({
+        command: config.command,
+        args: renderClaudeArgs(config.args, prompt),
+        cwd: config.cwd,
+        env: childEnv,
+        timeoutMs: config.timeoutMs,
+      });
+      const elapsedMs = Math.max(0, (deps.now?.() ?? Date.now()) - started);
+      const rawObservation = await readFile(observationPath, "utf8").catch(() => result.stdout);
+      if (result.exitCode !== 0) {
+        const reason = lastNonEmptyLine(result.stderr) || lastNonEmptyLine(result.stdout) || `Claude live driver exited with ${result.exitCode}.`;
+        return failedObservation(input, redact(reason), elapsedMs, result);
+      }
+      const parsed = parseClaudeGoldPathObservation(rawObservation, input, elapsedMs);
+      if (!parsed) {
+        return failedObservation(
+          input,
+          "Claude live driver finished without a valid gold-path observation JSON.",
+          elapsedMs,
+          result,
+        );
+      }
+      return parsed;
+    },
+  };
+}
+
+function claudeAuthEnv(env: NodeJS.ProcessEnv): ClaudeWorkerAuthEnv {
+  return {
+    ...(env.CLAUDE_WORKER_AUTH_MODE !== undefined ? { CLAUDE_WORKER_AUTH_MODE: env.CLAUDE_WORKER_AUTH_MODE } : {}),
+    ...(env.ANTHROPIC_API_KEY !== undefined ? { ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY } : {}),
+    ...(env.CLAUDE_CODE_OAUTH_TOKEN !== undefined ? { CLAUDE_CODE_OAUTH_TOKEN: env.CLAUDE_CODE_OAUTH_TOKEN } : {}),
+    ...(env.CLAUDE_WORKER_DAILY_BUDGET !== undefined ? { CLAUDE_WORKER_DAILY_BUDGET: env.CLAUDE_WORKER_DAILY_BUDGET } : {}),
+  };
+}
+
+export function buildClaudeGoldPathPrompt(
+  input: GoldPathDriverInput,
+  opts: { observationPath: string; signerBaseUrl?: string }
+): string {
+  const mutationLine = input.allowMutations
+    ? `Mutation profile: TESTNET/STAGING test-only mutations are allowed only inside clearly fake/sandbox Averray flows. Scope: ${input.mutationScope}`
+    : "Mutation profile: READ ONLY. Stop before claim, submit, payout/SBT, wallet signature, payment, deploy, merge, or any irreversible action.";
+  return [
+    "You are Hermes running the Averray Tier-2 gold-path tester as a normal browser-capable outside agent.",
+    "Use the Claude Agent SDK browser tooling / Playwright MCP tools available in this runtime. Do not use private repo state, Slack, GitHub, SSH, databases, or Averray monitor internals.",
+    "Reuse T3 only through the local signer sidecar when you need authentication. The wallet private keys must never enter your prompt, output, logs, screenshots, or report.",
+    opts.signerBaseUrl ? `Signer sidecar: ${opts.signerBaseUrl}. Request browser/api sessions by role as needed; do not print returned tokens.` : "No signer sidecar URL was provided; report that as a blocker if authentication is required.",
+    mutationLine,
+    `Target URL: ${input.targetUrl}`,
+    `Goal: ${input.goal}`,
+    `Model/effort policy selected: ${input.model}.`,
+    `Fresh memory: ${input.freshMemory ? "yes" : "returning-agent memory allowed"}.`,
+    "",
+    "Drive this gold path honestly: onboard -> discover -> claim -> submit -> verify -> payout_sbt -> receipt.",
+    "If the run is read-only, mark mutating steps as skipped and stop before them. If the run is testnet-mutating, attempt only clearly safe testbed actions.",
+    "Capture real evidence: screenshot/trace paths, URL path, visible text, console errors, network failures, and what you tried.",
+    "Write ONLY the observation JSON to this path:",
+    opts.observationPath,
+    "",
+    "Observation JSON schema:",
+    JSON.stringify({
+      steps: GOLD_PATH_STEPS.map((step) => ({
+        step,
+        status: "ok | degraded | empty | blocked | skipped | error",
+        detail: "visible, concrete outcome",
+        evidence: "optional screenshot/trace/url/visible text reference",
+        latencyMs: "number, omit if not measured",
+        mutating: "boolean, true only for claim/submit/payout_sbt attempts",
+      })),
+      notes: ["what I tried, bounded and non-secret"],
+      evidence: [{ type: "screenshot | trace | console | network | observation | url", value: "bounded reference" }],
+      blockers: [{ head: "short blocker", body: "real detail from the run", evidence: ["optional evidence refs"] }],
+      confusingMoments: [{ head: "short confusion", body: "real detail from the run" }],
+      runs: 1,
+      latencyMs: "total run latency in ms",
+      scores: { success: "0-5", clarity: "0-5", latency: "0-5" },
+      mutationsAttempted: ["test-only mutation descriptions, or []"],
+      stoppedBeforeMutation: true,
+    }, null, 2),
+    "",
+    "Truth boundary: never fabricate a pass, score, latency, screenshot, trace, or successful mutation. Omit fields you did not produce.",
+  ].join("\n");
+}
+
+export function parseClaudeGoldPathObservation(
+  text: string,
+  input: GoldPathDriverInput,
+  fallbackLatencyMs?: number,
+): GoldPathObservation | undefined {
+  const json = extractJsonObject(text);
+  if (!json) return undefined;
+  let value: unknown;
+  try {
+    value = JSON.parse(json);
+  } catch {
+    return undefined;
+  }
+  if (!isRecord(value)) return undefined;
+  const steps = normalizeSteps(value.steps, input);
+  if (!steps.length) return undefined;
+  const latencyMs = finiteNumber(value.latencyMs) ?? finiteNumber(value.durationMs) ?? fallbackLatencyMs;
+  return {
+    steps,
+    notes: stringArray(value.notes),
+    evidence: evidenceArray(value.evidence),
+    blockers: findingArray(value.blockers),
+    confusingMoments: findingArray(value.confusingMoments),
+    ...(finiteNumber(value.runs) !== undefined ? { runs: finiteNumber(value.runs) } : {}),
+    ...(latencyMs !== undefined ? { latencyMs } : {}),
+    scores: scoreObject(value.scores),
+    ...(isRecord(value.usage) ? { usage: value.usage } : {}),
+    mutationsAttempted: stringArray(value.mutationsAttempted),
+    stoppedBeforeMutation: typeof value.stoppedBeforeMutation === "boolean"
+      ? value.stoppedBeforeMutation
+      : !input.allowMutations,
+  };
+}
+
+function failedObservation(
+  input: GoldPathDriverInput,
+  reason: string,
+  latencyMs?: number,
+  result?: ExecClaudeResult,
+): GoldPathObservation {
+  return {
+    steps: input.steps.map((step) => ({ step, status: "error", detail: reason })),
+    notes: [reason],
+    evidence: [
+      ...(result?.stderr ? [{ type: "stderr", value: redact(lastNonEmptyLine(result.stderr)) }] : []),
+      ...(result?.stdout ? [{ type: "stdout", value: redact(lastNonEmptyLine(result.stdout)) }] : []),
+    ],
+    blockers: [{ head: "Live gold-path driver did not complete", body: reason }],
+    ...(latencyMs !== undefined ? { latencyMs } : {}),
+    mutationsAttempted: [],
+    stoppedBeforeMutation: true,
+  };
+}
+
+async function execClaudeCommand(input: ExecClaudeInput): Promise<ExecClaudeResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(input.command, input.args, {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      child.kill("SIGTERM");
+      setTimeout(() => {
+        if (!settled) child.kill("SIGKILL");
+      }, 5_000).unref();
+      reject(new Error(`Claude gold-path driver timed out after ${input.timeoutMs}ms.`));
+    }, input.timeoutMs);
+    timeout.unref();
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (error) => {
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ exitCode: code ?? 1, stdout: redact(stdout), stderr: redact(stderr) });
+    });
+  });
+}
+
+function normalizeSteps(value: unknown, input: GoldPathDriverInput): GoldPathStepResult[] {
+  if (!Array.isArray(value)) return [];
+  const allowed = new Set<GoldPathStep>(input.steps as GoldPathStep[]);
+  return value
+    .map((entry) => {
+      if (!isRecord(entry)) return undefined;
+      const step = typeof entry.step === "string" && allowed.has(entry.step as GoldPathStep)
+        ? entry.step as GoldPathStep
+        : undefined;
+      if (!step) return undefined;
+      const status = normalizeStepStatus(entry.status);
+      const detail = firstString(entry.detail, entry.description, entry.body, entry.message) ?? `${step} ${status}`;
+      const latencyMs = finiteNumber(entry.latencyMs) ?? finiteNumber(entry.durationMs) ?? finiteNumber(entry.elapsedMs);
+      return {
+        step,
+        status,
+        detail,
+        ...(firstString(entry.evidence, entry.url, entry.screenshot, entry.trace) ? { evidence: firstString(entry.evidence, entry.url, entry.screenshot, entry.trace) } : {}),
+        ...(latencyMs !== undefined ? { latencyMs } : {}),
+        ...(entry.mutating === true ? { mutating: true } : {}),
+      };
+    })
+    .filter((step): step is GoldPathStepResult => Boolean(step));
+}
+
+function normalizeStepStatus(value: unknown): GoldPathStepStatus {
+  const status = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (status === "ok" || status === "degraded" || status === "empty" || status === "blocked" || status === "skipped" || status === "error") {
+    return status;
+  }
+  if (status === "warn" || status === "warning") return "degraded";
+  if (status === "err" || status === "failed" || status === "fail") return "error";
+  return "error";
+}
+
+function evidenceArray(value: unknown): Array<{ type: string; value: string }> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const entries = value.map((entry) => {
+    if (typeof entry === "string" && entry.trim()) return { type: "observation", value: entry.trim() };
+    if (!isRecord(entry)) return undefined;
+    const detail = firstString(entry.value, entry.url, entry.href, entry.path, entry.detail);
+    if (!detail) return undefined;
+    return { type: firstString(entry.type, entry.kind) ?? "evidence", value: detail };
+  }).filter((entry): entry is { type: string; value: string } => Boolean(entry));
+  return entries.length ? entries : undefined;
+}
+
+function findingArray(value: unknown): Array<{ head: string; body?: string; evidence?: string[] }> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const entries = value.map((entry) => {
+    if (typeof entry === "string" && entry.trim()) return { head: entry.trim() };
+    if (!isRecord(entry)) return undefined;
+    const head = firstString(entry.head, entry.title, entry.summary, entry.label, entry.message);
+    if (!head) return undefined;
+    const body = firstString(entry.body, entry.detail, entry.details, entry.description);
+    const evidence = stringArray(entry.evidence);
+    return { head, ...(body ? { body } : {}), ...(evidence.length ? { evidence } : {}) };
+  }).filter((entry): entry is { head: string; body?: string; evidence?: string[] } => Boolean(entry));
+  return entries.length ? entries : undefined;
+}
+
+function scoreObject(value: unknown): GoldPathObservation["scores"] {
+  if (!isRecord(value)) return undefined;
+  return {
+    ...(finiteNumber(value.success) !== undefined ? { success: clampScore(value.success) } : {}),
+    ...(finiteNumber(value.successScore) !== undefined ? { success: clampScore(value.successScore) } : {}),
+    ...(finiteNumber(value.clarity) !== undefined ? { clarity: clampScore(value.clarity) } : {}),
+    ...(finiteNumber(value.clarityScore) !== undefined ? { clarity: clampScore(value.clarityScore) } : {}),
+    ...(finiteNumber(value.latency) !== undefined ? { latency: clampScore(value.latency) } : {}),
+    ...(finiteNumber(value.latencyScore) !== undefined ? { latency: clampScore(value.latencyScore) } : {}),
+  };
+}
+
+function renderClaudeArgs(args: string[], prompt: string): string[] {
+  return args.map((arg) => arg.split("{prompt}").join(prompt));
+}
+
+function parseArgs(value: string | undefined, fallback: string[]): string[] {
+  const trimmed = value?.trim();
+  if (!trimmed) return fallback;
+  if (trimmed.startsWith("[")) {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (!Array.isArray(parsed) || parsed.some((item) => typeof item !== "string")) {
+      throw new Error("TESTBED_GOLDPATH_CLAUDE_ARGS must be a JSON string array when it starts with '['.");
+    }
+    return parsed;
+  }
+  return trimmed.split(/\s+/);
+}
+
+function parseProbedRoute(value: string | undefined): ActiveAuthRoute | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === "api" || normalized === "sub" || normalized === "none") return normalized;
+  return undefined;
+}
+
+function extractJsonObject(text: string): string | undefined {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const source = fenced ? fenced[1]?.trim() ?? "" : text;
+  const first = source.indexOf("{");
+  const last = source.lastIndexOf("}");
+  if (first < 0 || last <= first) return undefined;
+  return source.slice(first, last + 1);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map((entry) => String(entry ?? "").trim()).filter(Boolean)
+    : [];
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  const num = typeof value === "number" ? value : typeof value === "string" ? Number(value) : NaN;
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function clampScore(value: unknown): number {
+  const score = finiteNumber(value) ?? 0;
+  return Math.max(0, Math.min(5, score));
+}
+
+function positiveInt(value: string | undefined, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function lastNonEmptyLine(value: string): string {
+  return value.trim().split(/\r?\n/).filter(Boolean).slice(-1)[0]?.trim() ?? "";
+}

--- a/services/slack-operator/src/gold-path-mission-entry.ts
+++ b/services/slack-operator/src/gold-path-mission-entry.ts
@@ -6,9 +6,9 @@
 // the T5 mutation binding, the T3 session, the A4 model, picks a driver, runs the
 // gold path, and writes the report.
 //
-// CI never reaches the live path: the live Claude Agent SDK + Playwright-MCP
-// driver is opt-in (TESTBED_GOLDPATH_LIVE=1) and is a follow-up — until it's
-// wired it FAILS CLOSED (an honest "not executed" report), never a fake pass.
+// CI never reaches the live path: the live Claude Agent SDK / Claude Code +
+// Playwright-MCP driver is opt-in (TESTBED_GOLDPATH_LIVE=1). The default stays
+// fake/unavailable so tests never call a live model.
 
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -26,6 +26,10 @@ import {
   type GoldPathDriver,
   type GoldPathMissionResult,
 } from "./gold-path-mission.js";
+import {
+  createClaudeGoldPathDriver,
+  parseClaudeGoldPathDriverConfig,
+} from "./gold-path-live-driver.js";
 
 interface GoldPathMissionEnv {
   id: string;
@@ -47,20 +51,13 @@ function readMissionFromEnv(env: NodeJS.ProcessEnv): GoldPathMissionEnv {
   };
 }
 
-/**
- * Choose the driver. The live LLM driver is opt-in and not wired in this build,
- * so both branches currently return the honest non-run driver — a deploy can
- * never silently emit a fake pass. The live adapter plugs into this seam.
- */
-function selectGoldPathDriver(env: NodeJS.ProcessEnv): GoldPathDriver {
+/** Choose the driver. Live LLM is opt-in; default remains the honest fake. */
+export function selectGoldPathDriver(env: NodeJS.ProcessEnv): GoldPathDriver {
   if (env.TESTBED_GOLDPATH_LIVE === "1") {
-    return createUnavailableGoldPathDriver(
-      "Live gold-path driver (Claude Agent SDK + Playwright-MCP) is not wired in this build — no real run performed. " +
-        "This is a deliberate follow-up; the executor, safety binding, session, model policy, judge, and report are in place.",
-    );
+    return createClaudeGoldPathDriver(parseClaudeGoldPathDriverConfig(env), env);
   }
   return createUnavailableGoldPathDriver(
-    "Gold-path runner is not in live mode (set TESTBED_GOLDPATH_LIVE=1 once the live LLM driver is wired); no real run performed.",
+    "Gold-path runner is not in live mode (set TESTBED_GOLDPATH_LIVE=1 to use the Claude + Playwright-MCP driver); no real run performed.",
   );
 }
 
@@ -93,6 +90,7 @@ export async function runGoldPathMissionEntry(
     binding,
     driver,
     model,
+    signerBaseUrl: env.TEST_WALLET_SIGNER_BASE_URL || env.TESTBED_SESSION_SIGNER_URL,
     // T3: the API Bearer (and/or browser storageState) from the signer sidecar —
     // the wallet key never enters this process. Undefined when unconfigured.
     resolveSession: () => resolveSweepSession({ ...parseSweepSessionConfig(env), sessionType: "api" }),

--- a/services/slack-operator/src/gold-path-mission.ts
+++ b/services/slack-operator/src/gold-path-mission.ts
@@ -62,13 +62,34 @@ export interface GoldPathStepResult {
   detail: string;
   /** A page-visible evidence pointer (url / selector text / receipt id). Never secrets. */
   evidence?: string;
+  /** Real elapsed time for this step, when the live driver captured it. */
+  latencyMs?: number;
   /** True if this observation involved a (testbed-only) mutation. */
   mutating?: boolean;
+}
+
+export interface GoldPathFinding {
+  head: string;
+  body?: string;
+  evidence?: string[];
 }
 
 export interface GoldPathObservation {
   steps: GoldPathStepResult[];
   notes: string[];
+  /** Evidence artifacts from the live browser driver: screenshots, traces, console/network notes. */
+  evidence?: Array<{ type: string; value: string }>;
+  /** Structured blockers with body text for the monitor drawer. */
+  blockers?: GoldPathFinding[];
+  /** Structured confusing moments with body text for the monitor drawer. */
+  confusingMoments?: GoldPathFinding[];
+  /** Attempt count and elapsed time captured by the live driver. */
+  runs?: number;
+  latencyMs?: number;
+  /** Optional 0..5 score overrides from the self-judge. */
+  scores?: Partial<Record<"success" | "clarity" | "latency", number>>;
+  /** Provider usage captured by the live driver, when the Claude SDK exposes it. */
+  usage?: Record<string, unknown>;
   /** Mutations the agent actually attempted (must be empty in read-only mode). */
   mutationsAttempted: string[];
   /** Whether the agent stopped at every mutation boundary it wasn't allowed to cross. */
@@ -88,6 +109,8 @@ export interface GoldPathDriverInput {
   freshMemory: boolean;
   /** T3 session (Bearer for the API gold path, storageState for browser). Opaque here. */
   session?: { role?: string; token?: string; storageState?: unknown };
+  /** Local T3 signer sidecar URL. The driver may request sessions; wallet keys never leave the sidecar. */
+  signerBaseUrl?: string;
 }
 
 /** The injected product driver. Real impl = Claude Agent SDK + Playwright-MCP;
@@ -173,6 +196,12 @@ export function judgeGoldPath(
       }
     }
   }
+  for (const blocker of observation.blockers ?? []) {
+    if (blocker.head.trim()) blockers.push(blocker.body ? `${blocker.head}: ${blocker.body}` : blocker.head);
+  }
+  for (const moment of observation.confusingMoments ?? []) {
+    if (moment.head.trim()) confusingMoments.push(moment.body ? `${moment.head}: ${moment.body}` : moment.head);
+  }
 
   if (!observation.stoppedBeforeMutation && !opts.allowMutations) {
     // The driver crossed a mutation boundary it was NOT allowed to — a hard fault.
@@ -213,6 +242,7 @@ export interface GoldPathReportInput {
   missionId: string;
   goal: string;
   targetUrl: string;
+  freshMemory?: boolean;
   model: GoldPathModel;
   binding: TestbedMutationBinding;
   observation: GoldPathObservation;
@@ -220,10 +250,16 @@ export interface GoldPathReportInput {
 }
 
 export function buildGoldPathReport(input: GoldPathReportInput): Record<string, unknown> {
-  const { missionId, goal, targetUrl, model, binding, observation, judgement } = input;
+  const { missionId, goal, targetUrl, freshMemory, model, binding, observation, judgement } = input;
   const completedPath = observation.steps.map(
     (s) => `${s.step} → ${s.status}${s.detail ? ` (${s.detail})` : ""}`,
   );
+  const path = observation.steps.map((s, index) => ({
+    n: index + 1,
+    status: stepStatusForDrawer(s.status),
+    desc: `${s.step}: ${s.detail}`,
+    ...(Number.isFinite(s.latencyMs) ? { latencyMs: s.latencyMs } : {}),
+  }));
   const evidence: Array<{ type: string; value: string }> = [
     { type: "executor", value: "gold_path" },
     { type: "model", value: model },
@@ -233,6 +269,7 @@ export function buildGoldPathReport(input: GoldPathReportInput): Record<string, 
   for (const s of observation.steps) {
     if (s.evidence) evidence.push({ type: `step:${s.step}`, value: s.evidence });
   }
+  if (observation.evidence?.length) evidence.push(...observation.evidence);
 
   const mutationBoundaryNotes = [
     `Mutation profile: ${binding.environment} / ${binding.mutationMode}. ${binding.reason}`,
@@ -241,33 +278,58 @@ export function buildGoldPathReport(input: GoldPathReportInput): Record<string, 
       : "Read-only run: the agent stopped before every mutation boundary.",
   ];
 
+  const scores = {
+    ...judgement.scores,
+    ...(observation.scores?.success !== undefined ? { success: observation.scores.success } : {}),
+    ...(observation.scores?.clarity !== undefined ? { clarity: observation.scores.clarity } : {}),
+    ...(observation.scores?.latency !== undefined ? { latency: observation.scores.latency } : {}),
+  };
+  const blockers = observation.blockers?.length ? observation.blockers : judgement.blockers;
+  const confusingMoments = observation.confusingMoments?.length ? observation.confusingMoments : judgement.confusingMoments;
+
   return {
     missionId,
     verdict: judgement.verdict,
+    verdictTone: judgement.verdict === "pass" ? "ok" : judgement.verdict === "partial" ? "warn" : "fail",
     confidence: judgement.confidence,
     executor: "gold_path",
     runnerMode: "gold_path",
     mode: "gold_path",
     goal,
     targetUrl,
+    target: targetUrl,
+    seed: freshMemory === false ? "memory" : "fresh",
     environment: binding.environment,
     model,
+    runs: observation.runs ?? 1,
+    ...(Number.isFinite(observation.latencyMs) ? { latencyMs: observation.latencyMs } : {}),
     stoppedBeforeMutation: observation.stoppedBeforeMutation,
     mutationMode: binding.mutationMode,
     mutationScope: binding.mutationScope,
     mutationBindingReason: binding.reason,
     mutationsAttempted: observation.mutationsAttempted,
     completedPath,
-    blockers: judgement.blockers,
-    confusingMoments: judgement.confusingMoments,
+    path,
+    blockers,
+    confusingMoments,
     mutationBoundaryNotes,
     recommendations: judgement.recommendations,
     evidence,
-    scores: judgement.scores,
+    scores,
+    successScore: observation.scores?.success,
+    clarityScore: observation.scores?.clarity,
+    latencyScore: observation.scores?.latency,
+    ...(observation.usage ? { usage: observation.usage } : {}),
     steps: observation.steps,
     notes: observation.notes,
     summary: `gold_path ${judgement.verdict}: ${observation.steps.filter((s) => s.status === "ok").length}/${observation.steps.length} steps clean on ${binding.environment} (${binding.mutationMode}), ${judgement.blockers.length} blocker(s)`,
   };
+}
+
+function stepStatusForDrawer(status: GoldPathStepStatus): "ok" | "warn" | "err" {
+  if (status === "ok" || status === "skipped") return "ok";
+  if (status === "degraded" || status === "empty") return "warn";
+  return "err";
 }
 
 // ── orchestrator (effect-injected; never calls a live LLM directly) ──
@@ -283,6 +345,7 @@ export interface GoldPathMissionDeps {
   driver: GoldPathDriver;
   model: GoldPathModel;
   resolveSession?: () => Promise<GoldPathDriverInput["session"] | undefined> | GoldPathDriverInput["session"] | undefined;
+  signerBaseUrl?: string;
   steps?: readonly GoldPathStep[];
 }
 
@@ -306,6 +369,7 @@ export async function runGoldPathMissionOnce(deps: GoldPathMissionDeps): Promise
     model: deps.model,
     freshMemory: deps.mission.freshMemory !== false,
     ...(session ? { session } : {}),
+    ...(deps.signerBaseUrl ? { signerBaseUrl: deps.signerBaseUrl } : {}),
   });
 
   // Defense in depth: if a read-only run somehow returned attempted mutations,
@@ -321,6 +385,7 @@ export async function runGoldPathMissionOnce(deps: GoldPathMissionDeps): Promise
     missionId: deps.mission.id,
     goal: deps.mission.goal,
     targetUrl: deps.mission.targetUrl,
+    freshMemory: deps.mission.freshMemory,
     model: deps.model,
     binding: deps.binding,
     observation: safeObservation,

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -7,6 +7,7 @@ import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
 import type { BrowserContext, Locator, Page } from "playwright-core";
 
+import { runGoldPathMissionEntry } from "./gold-path-mission-entry.js";
 import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
 import {
   claimNextReadyTestbedMission,
@@ -340,7 +341,40 @@ export async function executeBrowserTestbedMission(
   if (mission.mode === "siwe_auth") {
     return executeSiweAuthMission(mission, config, deps);
   }
+  if (mission.mode === "gold_path") {
+    return executeGoldPathTestbedMission(mission, config);
+  }
   return executePlaywrightTestbedMission(mission, config);
+}
+
+export async function executeGoldPathTestbedMission(
+  mission: TestbedMissionRun,
+  config: TestbedMissionRunnerConfig
+): Promise<TestbedMissionRunResult> {
+  const result = await runGoldPathMissionEntry({
+    ...process.env,
+    TESTBED_MISSION_ID: mission.id,
+    TESTBED_TARGET_URL: mission.targetUrl,
+    TESTBED_MISSION_GOAL: mission.goal,
+    TESTBED_AGENT_NAME: mission.agentName,
+    TESTBED_FRESH_MEMORY: String(mission.freshMemory),
+    TESTBED_REQUESTED_TEST_MUTATIONS: String(mission.requestedAllowTestMutations === true),
+    TESTBED_MISSION_ENVIRONMENT: mission.environment ?? config.missionEnvironment ?? "",
+    TESTBED_MUTATION_MODE: mission.mutationMode ?? (mission.allowTestMutations ? "testbed_mutation_allowed" : "read_only"),
+    TESTBED_MUTATION_SCOPE: mission.mutationScope ?? "none; stop at mutation boundary",
+    TESTBED_MUTATION_BINDING_REASON: mission.mutationBindingReason ?? "",
+    TEST_WALLET_SIGNER_BASE_URL: config.signerBaseUrl ?? process.env.TEST_WALLET_SIGNER_BASE_URL ?? "",
+    TESTBED_SESSION_SIGNER_URL: config.signerBaseUrl ?? process.env.TESTBED_SESSION_SIGNER_URL ?? "",
+  });
+  return {
+    exitCode: 0,
+    stdout: `Gold-path mission completed for ${mission.id}: ${result.verdict}\n`,
+    stderr: "",
+    reportText: result.reportText,
+    summary: typeof result.report.summary === "string" ? result.report.summary : result.verdict,
+    model: typeof result.report.model === "string" ? result.report.model : undefined,
+    usage: result.report.usage,
+  };
 }
 
 /** Default session resolver: pull from the env-configured sidecar or manual

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -13,6 +13,7 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
   const runnerEnabled = truthy(env.TESTBED_MISSION_RUNNER_ENABLED);
   const signerEnabled = truthy(env.TEST_WALLET_SIGNER_ENABLED);
   const runnerExecutor = env.TESTBED_MISSION_RUNNER_EXECUTOR || "playwright";
+  const goldPathLive = truthy(env.TESTBED_GOLDPATH_LIVE);
   const missionEnvironment = env.TESTBED_MISSION_ENVIRONMENT || env.AVERRAY_TESTBED_ENVIRONMENT || "inferred_from_target_url";
   // T2: the runner now injects a pre-seeded session into the sweep. The authed
   // sweep is genuinely available once a session SOURCE is configured (the
@@ -155,7 +156,7 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
       },
       {
         id: "gold_path",
-        status: "executor_scaffolded_awaiting_live_driver",
+        status: goldPathLive ? "available_live_driver" : "available_fake_default",
         tier: 2,
         scope: "testbed_mutation_only",
         mutation: "testnet-only, never mainnet (T5 env→mutation binding; mainnet is structurally read-only)",
@@ -170,7 +171,9 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
             requester: "agent-name",
           },
         },
-        note: "T4: the Tier-2 executor is built (mutation binding + session + A4 model policy + honest judge + report) behind the command hook and the T6 request→approve gate (gold_path missions land `requested`, never auto-run). The live Claude Agent SDK + Playwright-MCP driver is a follow-up; until it's wired the runner emits an honest \"not executed\" report rather than a fake pass.",
+        note: goldPathLive
+          ? "T4: the live Claude + Playwright-MCP gold-path driver is enabled. It still sits behind the T6 request→approve gate, uses the T3 signer sidecar for sessions, and obeys T5 mutation binding (mainnet read-only)."
+          : "T4: the live Claude + Playwright-MCP driver is wired but disabled by default. Until TESTBED_GOLDPATH_LIVE=1, the runner emits an honest \"not executed\" report rather than a fake pass.",
       },
     ],
     approvalGate: {

--- a/test/unit/gold-path-mission.test.ts
+++ b/test/unit/gold-path-mission.test.ts
@@ -14,6 +14,11 @@ import {
   type GoldPathStepResult,
 } from "../../services/slack-operator/src/gold-path-mission.js";
 import { runGoldPathMissionEntry } from "../../services/slack-operator/src/gold-path-mission-entry.js";
+import {
+  buildClaudeGoldPathPrompt,
+  createClaudeGoldPathDriver,
+  parseClaudeGoldPathObservation,
+} from "../../services/slack-operator/src/gold-path-live-driver.js";
 import { resolveTestbedMutationBinding, type TestbedMutationBinding } from "../../services/slack-operator/src/testbed-mutation-binding.js";
 
 function obs(steps: GoldPathStepResult[], over: Partial<GoldPathObservation> = {}): GoldPathObservation {
@@ -112,7 +117,47 @@ describe("runGoldPathMissionOnce", () => {
     expect(r.stoppedBeforeMutation).toBe(true);
     expect(typeof r.summary).toBe("string");
     expect(Array.isArray(r.completedPath)).toBe(true);
+    expect(Array.isArray(r.path)).toBe(true);
     expect(r.scores).toBeTruthy();
+  });
+
+  it("carries live driver path latency and blocker body into the report", async () => {
+    const result = await runGoldPathMissionOnce({
+      mission,
+      binding: TESTNET,
+      driver: {
+        async run() {
+          return {
+            steps: [
+              { step: "onboard", status: "ok", detail: "signed in", latencyMs: 1200, evidence: "screenshot:onboard.png" },
+              { step: "discover", status: "blocked", detail: "jobs list 500", latencyMs: 800 },
+            ],
+            notes: ["real browser run"],
+            evidence: [{ type: "trace", value: "/tmp/trace.zip" }],
+            blockers: [{ head: "Jobs list failed", body: "GET /jobs returned 500 after onboarding.", evidence: ["/tmp/trace.zip"] }],
+            runs: 1,
+            latencyMs: 2000,
+            scores: { success: 2, clarity: 3, latency: 4 },
+            mutationsAttempted: [],
+            stoppedBeforeMutation: true,
+          };
+        },
+      },
+      model: "sonnet",
+    });
+    expect(result.verdict).toBe("fail");
+    expect(result.report).toMatchObject({
+      latencyMs: 2000,
+      path: [
+        expect.objectContaining({ desc: "onboard: signed in", latencyMs: 1200 }),
+        expect.objectContaining({ desc: "discover: jobs list 500", latencyMs: 800 }),
+      ],
+      blockers: [
+        expect.objectContaining({ head: "Jobs list failed", body: "GET /jobs returned 500 after onboarding." }),
+      ],
+      scores: expect.objectContaining({ success: 2, clarity: 3, latency: 4 }),
+      evidence: expect.arrayContaining([expect.objectContaining({ type: "trace", value: "/tmp/trace.zip" })]),
+    });
   });
 
   it("MAINNET + requested mutations → STRUCTURALLY read-only (no mutation attempted)", async () => {
@@ -182,5 +227,137 @@ describe("runGoldPathMissionEntry — env wiring keeps mainnet read-only", () =>
     expect(result.report.mutationMode).toBe("read_only");
     expect((result.report.mutationsAttempted as unknown[]).length).toBe(0);
     expect(result.report.stoppedBeforeMutation).toBe(true);
+  });
+
+  it("fake path remains the default even when no live LLM is configured", async () => {
+    const result = await runGoldPathMissionEntry(
+      {
+        TESTBED_MISSION_ID: "gp-entry-2",
+        TESTBED_TARGET_URL: "https://app.testnet.example",
+        TESTBED_MISSION_GOAL: "gold path",
+        TESTBED_MISSION_ENVIRONMENT: "testnet",
+        TESTBED_REQUESTED_TEST_MUTATIONS: "true",
+        TESTBED_MISSION_REPORT_PATH: join(dir, "report-default.json"),
+      } as NodeJS.ProcessEnv,
+    );
+    expect(result.verdict).toBe("fail");
+    expect((result.report.summary as string)).toMatch(/gold_path fail/);
+    expect(JSON.stringify(result.report)).toContain("not in live mode");
+  });
+});
+
+describe("Claude live gold-path driver", () => {
+  const input = {
+    targetUrl: "https://testbed.example",
+    goal: "gold path",
+    steps: GOLD_PATH_STEPS,
+    allowMutations: true,
+    mutationScope: "testbed-only",
+    model: "sonnet" as const,
+    freshMemory: true,
+    signerBaseUrl: "http://test-wallet-signer:8791",
+  };
+
+  it("builds a prompt that uses the signer sidecar without exposing wallet keys", () => {
+    const prompt = buildClaudeGoldPathPrompt(input, {
+      observationPath: "/tmp/observation.json",
+      signerBaseUrl: "http://test-wallet-signer:8791",
+    });
+    expect(prompt).toContain("Signer sidecar: http://test-wallet-signer:8791");
+    expect(prompt).toContain("Write ONLY the observation JSON");
+    expect(prompt).not.toMatch(/TEST_WALLET_.*PRIVATE/i);
+  });
+
+  it("parses the live observation shape with real latency and blocker body", () => {
+    const observation = parseClaudeGoldPathObservation(JSON.stringify({
+      steps: [
+        { step: "onboard", status: "ok", detail: "session loaded", latencyMs: 101 },
+        { step: "claim", status: "blocked", detail: "claim button disabled", latencyMs: 202 },
+      ],
+      notes: ["tried visible CTA"],
+      blockers: [{ head: "Claim disabled", body: "The button stayed disabled after selecting a job." }],
+      evidence: [{ type: "screenshot", value: "/tmp/claim.png" }],
+      runs: 1,
+      latencyMs: 303,
+      scores: { success: 2, clarity: 3, latency: 4 },
+      usage: { inputTokens: 11, outputTokens: 7 },
+      mutationsAttempted: [],
+      stoppedBeforeMutation: true,
+    }), input);
+
+    expect(observation).toMatchObject({
+      latencyMs: 303,
+      steps: [
+        expect.objectContaining({ step: "onboard", latencyMs: 101 }),
+        expect.objectContaining({ step: "claim", status: "blocked", latencyMs: 202 }),
+      ],
+      blockers: [expect.objectContaining({ head: "Claim disabled", body: "The button stayed disabled after selecting a job." })],
+      usage: { inputTokens: 11, outputTokens: 7 },
+    });
+  });
+
+  it("refuses a live sub-mode run when an API key would silently override billing", async () => {
+    const driver = createClaudeGoldPathDriver(
+      {
+        enabled: true,
+        command: "claude",
+        args: ["-p", "{prompt}"],
+        timeoutMs: 1000,
+        signerBaseUrl: "http://test-wallet-signer:8791",
+      },
+      {
+        TESTBED_GOLDPATH_LIVE: "1",
+        CLAUDE_WORKER_AUTH_MODE: "sub",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+        ANTHROPIC_API_KEY: "sk-test-should-refuse",
+      } as NodeJS.ProcessEnv,
+      {
+        exec: async () => {
+          throw new Error("exec should not be called");
+        },
+      },
+    );
+
+    const observation = await driver.run(input);
+    expect(observation.steps[0]).toMatchObject({ status: "error" });
+    expect(observation.blockers?.[0]?.body).toMatch(/ANTHROPIC_API_KEY is set/);
+  });
+
+  it("runs the live command behind the flag and parses its report", async () => {
+    const driver = createClaudeGoldPathDriver(
+      {
+        enabled: true,
+        command: "claude",
+        args: ["-p", "{prompt}"],
+        timeoutMs: 1000,
+        signerBaseUrl: "http://test-wallet-signer:8791",
+      },
+      {
+        TESTBED_GOLDPATH_LIVE: "1",
+        CLAUDE_WORKER_AUTH_MODE: "sub",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      } as NodeJS.ProcessEnv,
+      {
+        exec: async ({ args }) => {
+          expect(args.join(" ")).toContain("test-wallet-signer");
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              steps: [{ step: "onboard", status: "ok", detail: "loaded", latencyMs: 50 }],
+              notes: ["ok"],
+              usage: { inputTokens: 12, outputTokens: 8 },
+              mutationsAttempted: [],
+              stoppedBeforeMutation: true,
+            }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await expect(driver.run(input)).resolves.toMatchObject({
+      steps: [expect.objectContaining({ step: "onboard", latencyMs: 50 })],
+      usage: { inputTokens: 12, outputTokens: 8 },
+    });
   });
 });

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -51,7 +51,7 @@ describe("tester capabilities manifest", () => {
     });
     const goldPath = manifest.missionTypes.find((mission) => mission.id === "gold_path");
     expect(goldPath).toMatchObject({
-      status: "executor_scaffolded_awaiting_live_driver",
+      status: "available_fake_default",
       scope: "testbed_mutation_only",
     });
     const siweAuth = manifest.missionTypes.find((mission) => mission.id === "siwe_auth_role_gating");


### PR DESCRIPTION
## What changed & why

- Added the opt-in live T4 gold-path driver that invokes Claude/Claude Code with Playwright-MCP/browser tooling behind `TESTBED_GOLDPATH_LIVE=1`.
- Kept the #318 fake/unavailable driver as the default path so CI never calls a live LLM.
- Wired `gold_path` missions through the normal testbed mission runner, reusing the existing T6 request/approve gate and T5 mutation binding.
- Reused T3 signer sidecar context without exposing wallet keys to the model prompt; mainnet remains structurally read-only through the existing mutation profile.
- Extended the structured gold-path report with real driver fields: path latency, blockers/confusing bodies, evidence, scores, seed, target, and optional usage for the LLM usage tracker.
- Added Claude auth route verification/fail-loud handling for sub-vs-API-key mode and ops/env wiring for live-driver configuration.
- Updated Hermes tester docs/roadmap to reflect live-driver wiring while leaving hosted run proof as follow-up.

## Affected surfaces

- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [ ] Docs / tests only

## Checks run

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (not run locally: Docker CLI is present but the Compose plugin / docker-compose command is unavailable in this environment)

## Rollout / rollback

- Default rollout is inert: `TESTBED_GOLDPATH_LIVE=0` keeps the fake/unavailable path.
- To enable live T4 on a testnet runner, set `TESTBED_GOLDPATH_LIVE=1`, provide the Claude auth mode/token or API key consistently, and ensure the T3 signer sidecar URL is reachable.
- Rollback is flipping `TESTBED_GOLDPATH_LIVE=0` or reverting this PR; no schema/data migration.

## Durable invariants (AGENTS.md)

- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability remains behind existing T6 approval + live-driver env flag)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- Hosted live-run proof remains the next step after merge/deploy.
- Multi-backend Codex/GPT tester remains out of scope for this PR.
