### PR TITLE
Group 4b: operator checklist + private note (server-persisted, operator-private)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -262,6 +262,9 @@ HERMES_DISPATCH_PER_DAY_MAX=10
 # high-risk ALWAYS escalates to you. FAIL-CLOSED: empty allowlist ⇒ auto-approves
 # nothing. Run a SUPERVISED burn-in before you turn autopilot on.
 AVERRAY_AUTONOMY_MODE_PATH=/data/autonomy-mode.json
+# Operator-private per-card notes (checklist + note). Operator-only; never sent
+# to any agent. Stored on the /data volume.
+AVERRAY_OPERATOR_CARD_NOTES_PATH=/data/operator-card-notes.json
 HERMES_DISPATCH_ALLOWED_REPOS=
 HERMES_DISPATCH_PER_REPO_PER_DAY_MAX=5
 # A3 dollar cap for Hermes-dispatched agent work. 0 disables the dollar gate.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -179,6 +179,9 @@ services:
       # empty allowlist means autopilot can auto-approve NOTHING — the operator
       # opts repos in here before turning autopilot on. high-risk always escalates.
       AVERRAY_AUTONOMY_MODE_PATH: ${AVERRAY_AUTONOMY_MODE_PATH:-/data/autonomy-mode.json}
+      # Operator-private per-card notes (checklist + note). Operator-only; never
+      # part of any agent payload. Persisted on /data so notes survive a restart.
+      AVERRAY_OPERATOR_CARD_NOTES_PATH: ${AVERRAY_OPERATOR_CARD_NOTES_PATH:-/data/operator-card-notes.json}
       HERMES_DISPATCH_ALLOWED_REPOS: ${HERMES_DISPATCH_ALLOWED_REPOS:-}
       HERMES_DISPATCH_PER_REPO_PER_DAY_MAX: ${HERMES_DISPATCH_PER_REPO_PER_DAY_MAX:-5}
       HERMES_DISPATCH_PER_DAY_USD_MAX: ${HERMES_DISPATCH_PER_DAY_USD_MAX:-0}

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -18,6 +18,7 @@ import type {
 } from "../../lib/monitor/card-types.js";
 import { humanizeSignalText } from "../../lib/monitor/signal-labels.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
+import { OperatorNotes } from "./OperatorNotes.js";
 
 export type DrawerVariant = "mission" | "action" | "done" | "draft" | "task" | "deploy" | "pr";
 
@@ -76,6 +77,7 @@ export function DrawerBody({ card, variant }: { card: BoardCard; variant: Drawer
     <>
       {body}
       <DecisionRecordSection record={card.decisionRecord} />
+      <OperatorNotes cardId={card.id} />
     </>
   );
 }

--- a/packages/monitor-ui/src/components/drawer/OperatorNotes.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/OperatorNotes.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, waitFor, within } from "@testing-library/react";
+import { OperatorNotes } from "./OperatorNotes.js";
+import type { OperatorCardNotesValue } from "../../hooks/useOperatorNotes.js";
+
+afterEach(cleanup);
+
+const saved: OperatorCardNotesValue = {
+  checklist: [
+    { id: "read-diff", label: "Read the diff / report", done: false },
+    { id: "ci-green", label: "CI is green", done: true },
+  ],
+  note: "watch the rollback path",
+};
+
+describe("OperatorNotes — checklist + private note (G4)", () => {
+  test("loads + renders the persisted checklist and note", async () => {
+    const fetchNotes = vi.fn(async () => saved);
+    const { container } = render(
+      <OperatorNotes cardId="agent #548" options={{ fetchNotes, saveNotes: vi.fn(async () => saved) }} />,
+    );
+    await waitFor(() => expect(within(container).getByText("Read the diff / report")).toBeTruthy());
+    expect(fetchNotes).toHaveBeenCalledWith("agent #548");
+    const note = container.querySelector(".hm-operator-note") as HTMLTextAreaElement;
+    expect(note.value).toBe("watch the rollback path");
+    // It announces the privacy boundary.
+    expect(within(container).getByText(/never shared with agents/i)).toBeTruthy();
+  });
+
+  test("toggling a checklist item persists via saveNotes", async () => {
+    const fetchNotes = vi.fn(async () => saved);
+    const saveNotes = vi.fn(async (_id: string, v: OperatorCardNotesValue) => v);
+    const { container } = render(
+      <OperatorNotes cardId="agent #548" options={{ fetchNotes, saveNotes }} />,
+    );
+    await waitFor(() => expect(within(container).getByLabelText("Read the diff / report")).toBeTruthy());
+    fireEvent.click(within(container).getByLabelText("Read the diff / report"));
+    await waitFor(() => expect(saveNotes).toHaveBeenCalled());
+    const [, value] = saveNotes.mock.calls[0]!;
+    expect(value.checklist.find((i) => i.id === "read-diff")?.done).toBe(true);
+  });
+
+  test("editing the note + Save persists the new text", async () => {
+    const fetchNotes = vi.fn(async () => saved);
+    const saveNotes = vi.fn(async (_id: string, v: OperatorCardNotesValue) => v);
+    const { container, getByRole } = render(
+      <OperatorNotes cardId="agent #548" options={{ fetchNotes, saveNotes }} />,
+    );
+    await waitFor(() => expect(container.querySelector(".hm-operator-note")).toBeTruthy());
+    const note = container.querySelector(".hm-operator-note") as HTMLTextAreaElement;
+    fireEvent.change(note, { target: { value: "new private note" } });
+    fireEvent.click(getByRole("button", { name: /Save note/ }));
+    await waitFor(() => expect(saveNotes).toHaveBeenCalled());
+    const lastCall = saveNotes.mock.calls.at(-1)!;
+    expect(lastCall[1].note).toBe("new private note");
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/OperatorNotes.tsx
+++ b/packages/monitor-ui/src/components/drawer/OperatorNotes.tsx
@@ -1,0 +1,67 @@
+// Operator checklist + private note (G4). Persisted per card via
+// /monitor/cards/:id/operator-notes. OPERATOR-PRIVATE: the note is the
+// operator's own scratchpad — it is never included in any agent-facing payload.
+
+import { useOperatorNotes, type UseOperatorNotesOptions } from "../../hooks/useOperatorNotes.js";
+
+export interface OperatorNotesProps {
+  cardId: string;
+  /** Override the notes wiring (GET/PUT) for tests. */
+  options?: UseOperatorNotesOptions;
+}
+
+export function OperatorNotes({ cardId, options }: OperatorNotesProps) {
+  const { notes, loading, saving, toggleItem, setNote, save } = useOperatorNotes(cardId, options ?? {});
+
+  return (
+    <section className="hm-operator-notes" aria-label="Operator checklist and private note">
+      <div className="hm-section-h">Operator checklist &amp; note</div>
+      <p className="hm-muted" style={{ fontSize: 11, margin: "0 0 8px" }}>
+        Operator-private — never shared with agents.
+      </p>
+
+      {loading ? (
+        <div className="hm-muted" style={{ fontSize: 12 }}>Loading your notes…</div>
+      ) : (
+        <>
+          <ul className="hm-operator-checklist" style={{ listStyle: "none", padding: 0, margin: "0 0 10px" }}>
+            {(notes?.checklist ?? []).map((item) => (
+              <li key={item.id} style={{ marginBottom: 4 }}>
+                <label style={{ display: "flex", gap: 8, alignItems: "center", cursor: "pointer" }}>
+                  <input
+                    type="checkbox"
+                    checked={item.done}
+                    onChange={() => toggleItem(item.id)}
+                    aria-label={item.label}
+                  />
+                  <span style={item.done ? { textDecoration: "line-through", color: "var(--hm-muted)" } : undefined}>
+                    {item.label}
+                  </span>
+                </label>
+              </li>
+            ))}
+          </ul>
+
+          <label className="hm-muted" style={{ fontSize: 11, display: "block", marginBottom: 4 }}>
+            Private note
+          </label>
+          <textarea
+            className="hm-operator-note"
+            aria-label="Operator-private note"
+            value={notes?.note ?? ""}
+            placeholder="Private note for yourself — never sent to any agent…"
+            onChange={(e) => setNote(e.target.value)}
+            onBlur={save}
+            rows={3}
+            style={{ width: "100%", resize: "vertical" }}
+          />
+          <div style={{ marginTop: 6, display: "flex", alignItems: "center", gap: 8 }}>
+            <button type="button" className="hm-btn hm-btn--ghost" onClick={save} disabled={saving}>
+              {saving ? "Saving…" : "Save note"}
+            </button>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/packages/monitor-ui/src/hooks/useOperatorNotes.ts
+++ b/packages/monitor-ui/src/hooks/useOperatorNotes.ts
@@ -1,0 +1,127 @@
+// Operator-private per-card notes hook (G4).
+//
+// GETs the card's checklist + note on mount and PUTs on save, against
+// /monitor/cards/:id/operator-notes. OPERATOR-PRIVATE: this data is the
+// operator's own; it is never part of any agent-facing payload. Network is
+// guarded + injectable so it's inert in tests that don't wire it.
+
+import { useCallback, useEffect, useState } from "react";
+
+export interface OperatorChecklistItem {
+  id: string;
+  label: string;
+  done: boolean;
+}
+
+export interface OperatorCardNotesValue {
+  checklist: OperatorChecklistItem[];
+  note: string;
+}
+
+export interface UseOperatorNotesOptions {
+  fetchNotes?: (cardId: string) => Promise<OperatorCardNotesValue | null>;
+  saveNotes?: (cardId: string, value: OperatorCardNotesValue) => Promise<OperatorCardNotesValue | null>;
+}
+
+export interface UseOperatorNotes {
+  notes: OperatorCardNotesValue | null;
+  loading: boolean;
+  saving: boolean;
+  toggleItem: (id: string) => void;
+  setNote: (note: string) => void;
+  save: () => void;
+}
+
+function url(cardId: string): string {
+  return `/monitor/cards/${encodeURIComponent(cardId)}/operator-notes`;
+}
+
+function canFetch(): boolean {
+  return typeof fetch === "function";
+}
+
+async function defaultFetchNotes(cardId: string): Promise<OperatorCardNotesValue | null> {
+  if (!canFetch()) return null;
+  try {
+    const res = await fetch(url(cardId), { method: "GET" });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { notes?: OperatorCardNotesValue };
+    return json.notes ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultSaveNotes(cardId: string, value: OperatorCardNotesValue): Promise<OperatorCardNotesValue | null> {
+  if (!canFetch()) return null;
+  try {
+    const res = await fetch(url(cardId), {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(value),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { notes?: OperatorCardNotesValue };
+    return json.notes ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function useOperatorNotes(cardId: string, options: UseOperatorNotesOptions = {}): UseOperatorNotes {
+  const fetchNotes = options.fetchNotes ?? defaultFetchNotes;
+  const saveNotes = options.saveNotes ?? defaultSaveNotes;
+  const [notes, setNotes] = useState<OperatorCardNotesValue | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    void fetchNotes(cardId).then((value) => {
+      if (!active) return;
+      setNotes(value);
+      setLoading(false);
+    });
+    return () => {
+      active = false;
+    };
+    // Re-fetch when the card changes; fetchNotes is stable for the page lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cardId]);
+
+  const persist = useCallback(
+    (value: OperatorCardNotesValue) => {
+      setSaving(true);
+      void saveNotes(cardId, value).then((saved) => {
+        if (saved) setNotes(saved);
+        setSaving(false);
+      });
+    },
+    [cardId, saveNotes],
+  );
+
+  const toggleItem = useCallback((id: string) => {
+    setNotes((prev) => {
+      if (!prev) return prev;
+      const next = { ...prev, checklist: prev.checklist.map((i) => (i.id === id ? { ...i, done: !i.done } : i)) };
+      // A checkbox toggle persists immediately.
+      setSaving(true);
+      void saveNotes(cardId, next).then((saved) => {
+        setNotes((cur) => saved ?? cur);
+        setSaving(false);
+      });
+      return next;
+    });
+  }, [cardId, saveNotes]);
+
+  const setNote = useCallback((note: string) => {
+    setNotes((prev) => (prev ? { ...prev, note } : { checklist: [], note }));
+  }, []);
+
+  const save = useCallback(() => {
+    if (notes) persist(notes);
+  }, [notes, persist]);
+
+  return { notes, loading, saving, toggleItem, setNote, save };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -93,6 +93,7 @@ import {
   type AutonomyMode,
   type AutonomyState,
 } from "./autonomy-mode.js";
+import { readOperatorCardNotes, writeOperatorCardNotes } from "./operator-card-notes.js";
 import { runAutoApproval } from "./autopilot-approve.js";
 import {
   deliverAutopilotAwayDigest,
@@ -706,6 +707,21 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     }
     await handleMonitorAutonomyModeRequest(request, response);
     return;
+  }
+  {
+    const operatorNotesCardId = monitorOperatorNotesCardId(url.pathname);
+    if (operatorNotesCardId && (request.method === "GET" || request.method === "PUT")) {
+      if (!monitorConfig.enabled) {
+        writeJson(response, 404, { error: "monitor_disabled" });
+        return;
+      }
+      if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+        writeJson(response, 401, { error: "monitor_unauthorized" });
+        return;
+      }
+      await handleMonitorOperatorNotesRequest(operatorNotesCardId, request, response);
+      return;
+    }
   }
   if (request.method === "POST" && url.pathname === "/monitor/testbed-missions/request") {
     if (!monitorConfig.enabled) {
@@ -1757,6 +1773,47 @@ async function handleMonitorAutonomyModeRequest(request: http.IncomingMessage, r
     logger.error({ err: error }, "o4_autonomy_mode_failed");
     writeJson(response, 500, {
       error: "autonomy_mode_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// Operator-private per-card notes (checklist + free-text note). GET returns the
+// saved notes (or the default checklist); PUT persists them. OPERATOR-PRIVATE:
+// this never feeds any agent payload — it lives in its own store.
+async function handleMonitorOperatorNotesRequest(
+  cardId: string,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+) {
+  try {
+    if (request.method === "GET") {
+      writeJson(response, 200, { ok: true, cardId, notes: readOperatorCardNotes(cardId) });
+      return;
+    }
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const note = typeof payload.note === "string" ? payload.note : "";
+    const checklist = Array.isArray(payload.checklist)
+      ? payload.checklist
+          .filter(isRecord)
+          .map((item) => ({
+            id: typeof item.id === "string" && item.id ? item.id : "item",
+            label: typeof item.label === "string" ? item.label : "",
+            done: item.done === true,
+          }))
+      : undefined;
+    const saved = writeOperatorCardNotes(cardId, { note, ...(checklist ? { checklist } : {}) });
+    logger.info({ cardId, items: saved.checklist.length, hasNote: saved.note.length > 0 }, "operator_card_notes_saved");
+    writeJson(response, 200, { ok: true, cardId, notes: saved });
+  } catch (error) {
+    logger.error({ err: error }, "operator_card_notes_failed");
+    writeJson(response, 500, {
+      error: "operator_card_notes_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }
@@ -2997,6 +3054,15 @@ function monitorTestbedMissionId(pathname: string): string | undefined {
   if (!pathname.startsWith(prefix)) return undefined;
   const id = decodeURIComponent(pathname.slice(prefix.length)).trim();
   return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+/** Parse the card id from /monitor/cards/:id/operator-notes. */
+function monitorOperatorNotesCardId(pathname: string): string | undefined {
+  const prefix = "/monitor/cards/";
+  const suffix = "/operator-notes";
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return undefined;
+  const raw = decodeURIComponent(pathname.slice(prefix.length, -suffix.length)).trim();
+  return raw.length > 0 && !raw.includes("/") ? raw : undefined;
 }
 
 function monitorTestbedMissionApproveId(pathname: string): string | undefined {

--- a/services/slack-operator/src/operator-card-notes.ts
+++ b/services/slack-operator/src/operator-card-notes.ts
@@ -1,0 +1,101 @@
+// Operator-private per-card notes (checklist + free-text note).
+//
+// PRIVACY INVARIANT — load-bearing: this store is OPERATOR-PRIVATE. It is read
+// and written ONLY by the monitor's operator-notes endpoint (the operator's own
+// browser). It is NEVER imported into any agent-facing payload — not the board
+// snapshot an agent/Hermes reads, not the collaboration channel, not a handoff
+// event, not an MCP context. Keeping it in its own file/module (never merged
+// into a card or a mission/agent payload) is what guarantees that. A test
+// asserts the note is absent from the agent-facing board snapshot.
+//
+// File-backed on /data so it survives a restart (mirrors autonomy-mode.ts).
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { optionalEnv } from "@avg/mcp-common";
+
+export interface OperatorChecklistItem {
+  id: string;
+  label: string;
+  done: boolean;
+}
+
+export interface OperatorCardNotes {
+  checklist: OperatorChecklistItem[];
+  /** Operator-private free-text note. NEVER sent to any agent. */
+  note: string;
+  updatedAt?: string;
+}
+
+/** The default operator-review checklist offered for a card with no saved state. */
+export const DEFAULT_OPERATOR_CHECKLIST: ReadonlyArray<Omit<OperatorChecklistItem, "done">> = [
+  { id: "read-diff", label: "Read the diff / report" },
+  { id: "ci-green", label: "CI is green" },
+  { id: "risk-intent", label: "Risk + intent are clear" },
+  { id: "safe-to-proceed", label: "Safe to dispatch / merge" },
+];
+
+export function defaultOperatorCardNotes(): OperatorCardNotes {
+  return { checklist: DEFAULT_OPERATOR_CHECKLIST.map((i) => ({ ...i, done: false })), note: "" };
+}
+
+function notesPath(path?: string): string {
+  return (
+    path ??
+    optionalEnv("AVERRAY_OPERATOR_CARD_NOTES_PATH", "/data/operator-card-notes.json") ??
+    "/data/operator-card-notes.json"
+  );
+}
+
+type NotesFile = Record<string, OperatorCardNotes>;
+
+function readFile(path?: string): NotesFile {
+  const p = notesPath(path);
+  try {
+    if (!existsSync(p)) return {};
+    const raw = JSON.parse(readFileSync(p, "utf8")) as unknown;
+    return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as NotesFile) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Read a card's operator notes, or the default template when none are saved. */
+export function readOperatorCardNotes(cardId: string, path?: string): OperatorCardNotes {
+  const stored = readFile(path)[cardId];
+  if (!stored) return defaultOperatorCardNotes();
+  return {
+    checklist: Array.isArray(stored.checklist) ? stored.checklist.map(normalizeItem) : defaultOperatorCardNotes().checklist,
+    note: typeof stored.note === "string" ? stored.note : "",
+    ...(stored.updatedAt ? { updatedAt: stored.updatedAt } : {}),
+  };
+}
+
+/** Persist a card's operator notes. Returns the stored value. */
+export function writeOperatorCardNotes(
+  cardId: string,
+  value: { checklist?: OperatorChecklistItem[]; note?: string },
+  now: () => Date = () => new Date(),
+  path?: string,
+): OperatorCardNotes {
+  const file = readFile(path);
+  const next: OperatorCardNotes = {
+    checklist: Array.isArray(value.checklist) ? value.checklist.map(normalizeItem) : defaultOperatorCardNotes().checklist,
+    note: typeof value.note === "string" ? value.note : "",
+    updatedAt: now().toISOString(),
+  };
+  file[cardId] = next;
+  const p = notesPath(path);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, `${JSON.stringify(file, null, 2)}\n`);
+  return next;
+}
+
+function normalizeItem(item: unknown): OperatorChecklistItem {
+  const record = (item && typeof item === "object" ? item : {}) as Partial<OperatorChecklistItem>;
+  return {
+    id: typeof record.id === "string" && record.id ? record.id : "item",
+    label: typeof record.label === "string" ? record.label : "",
+    done: record.done === true,
+  };
+}

--- a/test/unit/operator-card-notes.test.ts
+++ b/test/unit/operator-card-notes.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readOperatorCardNotes,
+  writeOperatorCardNotes,
+  defaultOperatorCardNotes,
+} from "../../services/slack-operator/src/operator-card-notes.js";
+import { buildV2BoardSnapshot } from "../../services/slack-operator/src/monitor-v2.js";
+
+describe("operator-card-notes — per-card persistence", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-operator-notes-"));
+    path = join(dir, "operator-card-notes.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns the default checklist + empty note when nothing is saved", () => {
+    const notes = readOperatorCardNotes("agent #548", path);
+    expect(notes.note).toBe("");
+    expect(notes.checklist.length).toBeGreaterThan(0);
+    expect(notes.checklist.every((i) => i.done === false)).toBe(true);
+    expect(notes).toEqual(expect.objectContaining(defaultOperatorCardNotes()));
+  });
+
+  it("round-trips a checklist toggle + note per card", () => {
+    const checklist = defaultOperatorCardNotes().checklist.map((i, idx) => ({ ...i, done: idx === 0 }));
+    writeOperatorCardNotes("agent #548", { checklist, note: "double-check the migration rollback" }, () => new Date("2026-06-01T00:00:00Z"), path);
+
+    const read = readOperatorCardNotes("agent #548", path);
+    expect(read.note).toBe("double-check the migration rollback");
+    expect(read.checklist[0]!.done).toBe(true);
+    expect(read.updatedAt).toBe("2026-06-01T00:00:00.000Z");
+
+    // Scoped per card — a different card is unaffected.
+    expect(readOperatorCardNotes("agent #999", path).note).toBe("");
+  });
+
+  it("PRIVACY: the operator note NEVER appears in the agent-facing board snapshot", () => {
+    const SECRET = "OPERATOR-ONLY-SENTINEL-do-not-leak-7f3a";
+    // The operator saves a private note on the card.
+    writeOperatorCardNotes(
+      "depre-dev/agent#548",
+      { checklist: [], note: SECRET },
+      () => new Date("2026-06-01T00:00:00Z"),
+      path,
+    );
+
+    // Build the SAME board snapshot an agent / Hermes consumes for that card.
+    const raw = {
+      active: [
+        {
+          title: "Allow operator override of agent claim-stake floor",
+          status: "needs_review",
+          intent: "operator_review",
+          summary: { pullRequest: { repo: "depre-dev/agent", number: 548, state: "open" }, finalVerdict: "operator_review" },
+          ageLabel: "4m",
+        },
+      ],
+      recent: [],
+    };
+    const snapshot = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+
+    // The note is stored (operator can read it back)…
+    expect(readOperatorCardNotes("depre-dev/agent#548", path).note).toBe(SECRET);
+    // …but it is structurally absent from the agent-facing payload — the store
+    // is never merged into the board snapshot.
+    expect(JSON.stringify(snapshot)).not.toContain(SECRET);
+  });
+});


### PR DESCRIPTION
## What changed & why

Builds the drawer's **operator checklist + private note** as a real, persisted feature (the drawer had no such surface). The note is **operator-private** — never included in any agent-facing payload.

### Server
- **`operator-card-notes.ts`** — a file-backed per-card store `{ checklist[], note, updatedAt }` on `/data` (mirrors `autonomy-mode.ts`). It's its **own module**, imported **only** by the operator-notes endpoint — never by any board / collaboration / handoff / MCP builder. That separation is what guarantees the note can't reach an agent. Returns a default operator-review checklist when a card has no saved state.
- **`index.ts`** — `GET`/`PUT /monitor/cards/:id/operator-notes` (monitor-auth gated). GET returns saved notes (or the default checklist); PUT persists `{ checklist, note }`.

### Frontend
- **`useOperatorNotes`** hook (GET on mount, PUT on save; injectable + network-guarded).
- **`OperatorNotes`** component: a checkable checklist + an editable private note, labelled **"Operator-private — never shared with agents"**, rendered at the bottom of every `DrawerBody`.

### Ops
`AVERRAY_OPERATOR_CARD_NOTES_PATH` (default `/data/operator-card-notes.json`) in `compose.yml` + `.env.example`.

## Affected surfaces
- [x] Monitor board / slack-operator (new endpoint + frontend)
- [x] Secrets / config / env (the operator-private store path)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (1232 passed; tests below)
- [x] `vite build` (monitor-ui)
- [x] compose parses (CI runs the real `docker compose … config`)

### Tests (incl. the privacy guarantee)
- **Server round-trip**: write → read; per-card scope; default template when unsaved.
- **PRIVACY**: store a sentinel note on a card, build the agent-facing `buildV2BoardSnapshot` for that card, and assert the sentinel **is readable back by the operator** but **absent from the snapshot JSON** — the store is never merged into the agent payload.
- **Frontend**: loads + renders the persisted checklist/note; toggling an item and saving the note persist via the injected PUT.

## Durable invariants (AGENTS.md)
- [x] **Operator-private data never leaks to agents** — the note lives in its own store, imported only by the operator endpoint; a test asserts it's absent from the agent-facing board snapshot.
- [x] **No new authority / no merge-deploy** — a per-card scratchpad behind monitor auth; nothing dispatches, merges, or deploys.
- [x] No secrets committed/printed/logged.

## Known limits / follow-ups
- The checklist is a fixed default template whose `done` state + the note persist; operator-defined custom items could be a later add.
- Completes the dead-control audit: G1 filter chips (#328), G2 drawer actions (#330), G3 co-pilot rail (#332), G4a keep-watching (#334), **G4b operator notes (this PR)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)