### PR TITLE
fix: capture Hermes LLM usage shapes

### DIFF
--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -173,6 +173,9 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
   const usageSource = firstUsageSource(
     tokenUsageSource(input.result),
     usageSourceFromRecord(input.result),
+    usageSourceFromRecord(recordField(input.result, "message")),
+    usageSourceFromArrayField(input.result, "choices"),
+    usageSourceFromNestedArrayField(input.result, "choices", "message"),
     usageSourceFromRecord(recordField(input.result, "response")),
     usageSourceFromRecord(recordField(input.result, "result")),
     usageSourceFromArrayField(input.result, "messages"),
@@ -184,14 +187,18 @@ export function llmUsageEventFromResult(input: LlmUsageCaptureInput): LlmUsageEv
 
   const inputTokens = integerField(usage, "inputTokens")
     ?? integerField(usage, "input_tokens")
+    ?? integerField(usage, "inputTokenCount")
     ?? integerField(usage, "promptTokens")
     ?? integerField(usage, "prompt_tokens")
+    ?? integerField(usage, "promptTokenCount")
     ?? integerField(usage, "prompt_eval_count")
     ?? integerField(usage, "promptEvalCount");
   const outputTokens = integerField(usage, "outputTokens")
     ?? integerField(usage, "output_tokens")
+    ?? integerField(usage, "outputTokenCount")
     ?? integerField(usage, "completionTokens")
     ?? integerField(usage, "completion_tokens")
+    ?? integerField(usage, "completionTokenCount")
     ?? integerField(usage, "eval_count")
     ?? integerField(usage, "evalCount");
   if (inputTokens === undefined || outputTokens === undefined) return undefined;
@@ -397,7 +404,7 @@ interface UsageSource {
 function usageSourceFromRecord(value: unknown): UsageSource | undefined {
   if (!isRecord(value)) return undefined;
   const usage = recordField(value, "usage");
-  return usage ? { usage, carrier: value } : undefined;
+  return usage && hasTokenCounts(usage) ? { usage, carrier: value } : undefined;
 }
 
 function tokenUsageSource(value: unknown): UsageSource | undefined {
@@ -414,6 +421,15 @@ function usageSourceFromArrayField(value: unknown, key: string): UsageSource | u
   return undefined;
 }
 
+function usageSourceFromNestedArrayField(value: unknown, key: string, nestedKey: string): UsageSource | undefined {
+  if (!isRecord(value) || !Array.isArray(value[key])) return undefined;
+  for (const item of value[key]) {
+    const source = usageSourceFromRecord(recordField(item, nestedKey)) ?? tokenUsageSource(recordField(item, nestedKey));
+    if (source) return source;
+  }
+  return undefined;
+}
+
 function explicitUsageSource(value: unknown): UsageSource | undefined {
   const usage = explicitUsageJson(value);
   if (usage) return { usage, carrier: usage };
@@ -424,14 +440,18 @@ function explicitUsageSource(value: unknown): UsageSource | undefined {
 function hasTokenCounts(record: Record<string, unknown>): boolean {
   const inputTokens = integerField(record, "inputTokens")
     ?? integerField(record, "input_tokens")
+    ?? integerField(record, "inputTokenCount")
     ?? integerField(record, "promptTokens")
     ?? integerField(record, "prompt_tokens")
+    ?? integerField(record, "promptTokenCount")
     ?? integerField(record, "prompt_eval_count")
     ?? integerField(record, "promptEvalCount");
   const outputTokens = integerField(record, "outputTokens")
     ?? integerField(record, "output_tokens")
+    ?? integerField(record, "outputTokenCount")
     ?? integerField(record, "completionTokens")
     ?? integerField(record, "completion_tokens")
+    ?? integerField(record, "completionTokenCount")
     ?? integerField(record, "eval_count")
     ?? integerField(record, "evalCount");
   return inputTokens !== undefined && outputTokens !== undefined;
@@ -441,11 +461,14 @@ function cacheTokensFromUsage(usage: Record<string, unknown>): number {
   const explicit = integerField(usage, "cacheTokens")
     ?? integerField(usage, "cache_tokens");
   if (explicit !== undefined) return explicit;
+  const detailsCache = integerField(recordField(usage, "prompt_tokens_details"), "cached_tokens")
+    ?? integerField(recordField(usage, "input_tokens_details"), "cached_tokens");
   return [
     integerField(usage, "cacheReadInputTokens"),
     integerField(usage, "cache_read_input_tokens"),
     integerField(usage, "cacheCreationInputTokens"),
     integerField(usage, "cache_creation_input_tokens"),
+    detailsCache,
   ].reduce<number>((sum, value) => sum + (value ?? 0), 0);
 }
 
@@ -501,7 +524,10 @@ function stringField(record: unknown, key: string): string | undefined {
 function numberField(record: unknown, key: string): number | undefined {
   if (!isRecord(record)) return undefined;
   const value = record[key];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || !/^\d+(?:\.\d+)?$/.test(value.trim())) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
 }
 
 function integerField(record: unknown, key: string): number | undefined {

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -23,6 +23,7 @@
 
 import type { CollaborationMessage } from "./monitor-collab.js";
 import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
+import { logger } from "@avg/mcp-common";
 
 export const HERMES_PERSONA = `You are Hermes, the board orchestrator for the Averray platform.
 
@@ -152,6 +153,8 @@ export interface HermesOwnerAsk {
   waitingFor: string;
 }
 
+let llmUsageDebugLogged = false;
+
 export async function generateHermesReply(
   context: HermesReplyContext,
   options: GenerateHermesReplyOptions
@@ -194,6 +197,7 @@ export async function generateHermesReply(
     });
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
+    maybeLogHermesUsageShape(json);
     await recordLlmUsageFromResult({
       agent: "hermes",
       model,
@@ -253,6 +257,7 @@ export async function generateHermesBoardNarration(
     });
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
+    maybeLogHermesUsageShape(json);
     await recordLlmUsageFromResult({
       agent: "hermes",
       model,
@@ -554,6 +559,83 @@ export function hermesOwnerAskForCard(item: HermesBoardCardSnapshot): HermesOwne
   }
 
   return null;
+}
+
+export function summarizeHermesUsageDebugShape(value: unknown): Record<string, unknown> {
+  const root = asRecord(value);
+  return {
+    topLevelKeys: root ? Object.keys(root).sort() : [],
+    usageType: typeof root?.usage,
+    present: {
+      ...debugPath(root, "usage"),
+      ...debugPath(root, "prompt_eval_count"),
+      ...debugPath(root, "eval_count"),
+      ...debugPath(root, "prompt_tokens"),
+      ...debugPath(root, "completion_tokens"),
+      ...debugPath(asRecord(root?.message), "usage", "message.usage"),
+      ...debugPath(asRecord(asArray(root?.choices)[0]), "usage", "choices[0].usage"),
+      ...debugPath(asRecord(asRecord(asArray(root?.choices)[0])?.message), "usage", "choices[0].message.usage"),
+    },
+  };
+}
+
+function maybeLogHermesUsageShape(value: unknown): void {
+  if (llmUsageDebugLogged || process.env.LLM_USAGE_DEBUG !== "1") return;
+  llmUsageDebugLogged = true;
+  logger.info(summarizeHermesUsageDebugShape(value), "llm_usage_debug_shape");
+}
+
+function debugPath(record: Record<string, unknown> | undefined, key: string, label = key): Record<string, unknown> {
+  if (!record || !(key in record)) return {};
+  return { [label]: redactUsageDebugValue(record[key]) };
+}
+
+function redactUsageDebugValue(value: unknown): unknown {
+  const record = asRecord(value);
+  if (!record) return value;
+  const allowedKeys = [
+    "model",
+    "inputTokens",
+    "input_tokens",
+    "inputTokenCount",
+    "outputTokens",
+    "output_tokens",
+    "outputTokenCount",
+    "promptTokens",
+    "prompt_tokens",
+    "promptTokenCount",
+    "completionTokens",
+    "completion_tokens",
+    "completionTokenCount",
+    "prompt_eval_count",
+    "promptEvalCount",
+    "eval_count",
+    "evalCount",
+    "cacheTokens",
+    "cache_tokens",
+    "cacheReadInputTokens",
+    "cache_read_input_tokens",
+    "cacheCreationInputTokens",
+    "cache_creation_input_tokens",
+    "prompt_tokens_details",
+    "input_tokens_details",
+  ];
+  return Object.fromEntries(
+    allowedKeys
+      .filter((allowedKey) => allowedKey in record)
+      .map((allowedKey) => [
+        allowedKey,
+        asRecord(record[allowedKey]) ? redactUsageDebugValue(record[allowedKey]) : record[allowedKey],
+      ]),
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : undefined;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
 }
 
 function hermesWhyTrace(context: HermesWhyTraceContext): string | null {

--- a/test/unit/llm-usage.test.ts
+++ b/test/unit/llm-usage.test.ts
@@ -163,6 +163,106 @@ describe("LLM usage tracker", () => {
     });
   });
 
+  it("extracts top-level Ollama token counts from numeric strings and appends the event", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-llm-usage-"));
+    try {
+      const path = join(dir, "llm-usage.jsonl");
+      const nativeOllamaChatShape = {
+        model: "deepseek-v4-pro:cloud",
+        created_at: "2026-06-01T09:00:00.000Z",
+        message: {
+          role: "assistant",
+          content: "redacted in usage events",
+        },
+        done: true,
+        prompt_eval_count: "181",
+        eval_count: "37",
+      };
+
+      const event = await recordLlmUsageFromResult({
+        agent: "hermes",
+        model: "deepseek-v4-pro:cloud",
+        runId: "board-narration-1",
+        ts: new Date("2026-06-01T09:00:00.000Z"),
+        result: nativeOllamaChatShape,
+      }, { path });
+
+      expect(event).toEqual({
+        agent: "hermes",
+        model: "deepseek-v4-pro:cloud",
+        runId: "board-narration-1",
+        inputTokens: 181,
+        outputTokens: 37,
+        ts: "2026-06-01T09:00:00.000Z",
+      });
+      await expect(readFile(path, "utf8").then((line) => JSON.parse(line))).resolves.toEqual(event);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("extracts OpenAI-compatible usage from choices[0].usage", () => {
+    const event = llmUsageEventFromResult({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      ts: new Date("2026-06-01T09:05:00.000Z"),
+      result: {
+        model: "deepseek-v4-pro:cloud",
+        choices: [
+          {
+            index: 0,
+            message: { role: "assistant", content: "not copied" },
+            usage: {
+              prompt_tokens: 93,
+              completion_tokens: 21,
+              prompt_tokens_details: { cached_tokens: 7 },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(event).toEqual({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      inputTokens: 93,
+      outputTokens: 21,
+      cacheTokens: 7,
+      ts: "2026-06-01T09:05:00.000Z",
+    });
+  });
+
+  it("extracts nested message.usage from provider chat responses", () => {
+    const event = llmUsageEventFromResult({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      ts: new Date("2026-06-01T09:10:00.000Z"),
+      result: {
+        model: "deepseek-v4-pro:cloud",
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "also not copied",
+              usage: {
+                prompt_eval_count: 64,
+                eval_count: 15,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(event).toEqual({
+      agent: "hermes",
+      model: "deepseek-v4-pro:cloud",
+      inputTokens: 64,
+      outputTokens: 15,
+      ts: "2026-06-01T09:10:00.000Z",
+    });
+  });
+
   it("extracts best-effort token counts from Codex CLI output when present", () => {
     const event = llmUsageEventFromResult({
       agent: "codex",

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -14,6 +14,7 @@ import {
   hermesDecisionCoachForCard,
   hermesMemoryInfluence,
   hermesOwnerAskForCard,
+  summarizeHermesUsageDebugShape,
   type HermesReplyContext,
 } from "../../services/slack-operator/src/monitor-hermes-voice.js";
 
@@ -589,6 +590,37 @@ describe("generateHermesReply", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  it("summarizes usage debug shape without logging message content", () => {
+    const summary = summarizeHermesUsageDebugShape({
+      id: "chatcmpl-1",
+      model: "deepseek-v4-pro:cloud",
+      choices: [
+        {
+          message: {
+            role: "assistant",
+            content: "operator message content must stay redacted",
+            usage: {
+              prompt_eval_count: 44,
+              eval_count: 12,
+            },
+          },
+        },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      topLevelKeys: ["choices", "id", "model"],
+      usageType: "undefined",
+      present: {
+        "choices[0].message.usage": {
+          prompt_eval_count: 44,
+          eval_count: 12,
+        },
+      },
+    });
+    expect(JSON.stringify(summary)).not.toContain("operator message content");
   });
 
   it("strips a trailing slash from baseUrl before appending the path", async () => {

--- a/test/unit/testbed-mission-runner.test.ts
+++ b/test/unit/testbed-mission-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -26,42 +26,64 @@ describe("testbed mission runner", () => {
 
   it("claims a ready mission and completes it from a structured report", async () => {
     const path = tempMissionStorePath();
+    const usagePath = join(path.replace(/missions\.json$/, ""), "llm-usage.jsonl");
+    const previousUsagePath = process.env.LLM_USAGE_LOG_PATH;
+    process.env.LLM_USAGE_LOG_PATH = usagePath;
     process.env.AVERRAY_TESTBED_MISSIONS_PATH = path;
     const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-24T10:00:00.000Z"));
     expect(run).toBeDefined();
 
-    const result = await runTestbedMissionRunnerOnce(
-      {
-        enabled: true,
-        path,
-        runnerId: "test-runner",
-        command: "fake",
-        args: [],
-        pollIntervalMs: 1000,
-        timeoutMs: 1000,
-        outputTailBytes: 4000,
-      },
-      {
-        executor: async (mission) => ({
-          exitCode: 0,
-          stdout: "mission complete",
-          stderr: "",
-          reportText: JSON.stringify({
-            verdict: "pass",
-            confidence: 0.86,
-            stoppedBeforeMutation: true,
-            mutationBoundaryNotes: ["Stopped before any real mutation boundary."],
-            completedPath: ["opened page", "verified first-run onboarding"],
-            blockers: [],
-            evidence: [{ type: "visible_text", value: "Welcome to the testbed" }],
-            scores: { orientation: 5, mutationSafety: 5 },
-            missionId: mission.id,
+    let result: Awaited<ReturnType<typeof runTestbedMissionRunnerOnce>>;
+    try {
+      result = await runTestbedMissionRunnerOnce(
+        {
+          enabled: true,
+          path,
+          runnerId: "test-runner",
+          command: "fake",
+          args: [],
+          pollIntervalMs: 1000,
+          timeoutMs: 1000,
+          outputTailBytes: 4000,
+        },
+        {
+          executor: async (mission) => ({
+            exitCode: 0,
+            stdout: "mission complete",
+            stderr: "",
+            reportText: JSON.stringify({
+              verdict: "pass",
+              confidence: 0.86,
+              stoppedBeforeMutation: true,
+              mutationBoundaryNotes: ["Stopped before any real mutation boundary."],
+              completedPath: ["opened page", "verified first-run onboarding"],
+              blockers: [],
+              evidence: [{ type: "visible_text", value: "Welcome to the testbed" }],
+              scores: { orientation: 5, mutationSafety: 5 },
+              missionId: mission.id,
+            }),
+            usage: {
+              model: "browser-agent",
+              inputTokens: 50,
+              outputTokens: 11,
+            },
           }),
-        }),
-      }
-    );
+        }
+      );
+    } finally {
+      if (previousUsagePath === undefined) delete process.env.LLM_USAGE_LOG_PATH;
+      else process.env.LLM_USAGE_LOG_PATH = previousUsagePath;
+    }
 
     expect(result.status).toBe("completed");
+    expect(JSON.parse(readFileSync(usagePath, "utf8").trim())).toMatchObject({
+      agent: "hermes",
+      model: "browser-agent",
+      taskId: run!.id,
+      runId: run!.id,
+      inputTokens: 50,
+      outputTokens: 11,
+    });
     const [updated] = listTestbedMissionRuns({ path });
     expect(updated).toMatchObject({
       id: run!.id,


### PR DESCRIPTION
## What changed & why

Fixes the LLM usage capture path that left the board showing `usage not reported` even though Hermes/Ollama calls were wired to `recordLlmUsageFromResult`.

Root cause: `llmUsageEventFromResult` only accepted a narrow usage carrier shape. Live-compatible Ollama/OpenAI-style responses can carry counters at the top level, `message.usage`, `choices[0].usage`, or `choices[0].message.usage`, and some counters arrive as numeric strings. When the parser missed those carriers, no `/data/llm-usage.jsonl` event was appended.

This PR:

- broadens usage extraction to top-level native Ollama counters, root/message/choice usage objects, and common token-count aliases
- keeps the truth boundary: if no input/output counter pair exists, extraction still returns `undefined`
- adds a one-shot `LLM_USAGE_DEBUG=1` Hermes response-shape log that reports top-level keys and only redacted usage/counter fields, never message content
- verifies Codex/Claude/testbed successful paths append usage events when successful runner output includes counters

Request variant note: I did not change the Hermes request endpoint/body in this PR because the parser now covers the native Ollama and OpenAI-compatible usage carriers described by the bug, and there is not yet evidence that the deployed endpoint returns no counters at all. The new `LLM_USAGE_DEBUG=1` flag is the safe proof path for the VPS; if that log shows no counters anywhere, the next operator step is to switch the Hermes request to the endpoint/option that emits counters rather than fabricating usage.

## Affected surfaces

- [x] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Rollout: merge and deploy normally. To inspect the live shape once, set `LLM_USAGE_DEBUG=1` for one run and look for the `llm_usage_debug_shape` structured log; it is one-shot per process and redacts message content.

Rollback: revert this PR. The board returns to the old honest `not reported` behavior when no usage events are written.

## Durable invariants (AGENTS.md)

- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- This PR does not invent counts. If `LLM_USAGE_DEBUG=1` proves the deployed provider returns no counters in any supported carrier, switch the Hermes request variant in a follow-up and capture that evidence.
