### PR TITLE
Polish: de-jargon board copy (titles, plurals, empty states, labels)

### DIFF
--- a/packages/monitor-ui/src/components/Lane.test.tsx
+++ b/packages/monitor-ui/src/components/Lane.test.tsx
@@ -18,9 +18,17 @@ describe("Lane", () => {
   test("expanded empty lane shows the empty placeholder", () => {
     const { container, getByText } = render(<Lane lane={lane} expanded count={0} />);
     expect(container.querySelector("section.hm-lane")).toBeTruthy();
-    expect(getByText("No operator review right now.")).toBeTruthy();
+    expect(getByText("Nothing waiting on your risk decision.")).toBeTruthy();
     // Empty lane is not the --expanded variant.
     expect((container.querySelector(".hm-lane") as HTMLElement).className).not.toContain("hm-lane--expanded");
+  });
+
+  test("empty copy is per-lane, not the awkward 'No {name} right now.' template", () => {
+    const done: LaneDescriptor = { id: "done", name: "Done", action: "Release history" };
+    const { getByText, queryByText } = render(<Lane lane={done} expanded count={0} />);
+    expect(getByText("Nothing shipped yet.")).toBeTruthy();
+    // The old auto-generated "No done right now." is gone.
+    expect(queryByText("No done right now.")).toBeNull();
   });
 
   test("expanded populated lane renders children and the --expanded variant", () => {

--- a/packages/monitor-ui/src/components/Lane.tsx
+++ b/packages/monitor-ui/src/components/Lane.tsx
@@ -15,6 +15,25 @@ import { MiniRail, type LaneDescriptor, type LaneId } from "./MiniRail.js";
 
 export type { LaneDescriptor, LaneId };
 
+// Per-lane empty copy. The generic "No {lane} right now." reads wrong for
+// several lanes ("No done right now.", "No deploying right now."), so each
+// lane gets a sentence that fits its meaning. Falls back to the generic
+// form for any lane id not listed.
+const LANE_EMPTY_COPY: Partial<Record<LaneId, string>> = {
+  "needs-attention": "Nothing needs your review right now.",
+  drafts: "No drafts in progress.",
+  "codex-needed": "No tasks waiting to be created.",
+  "hermes-checking": "Nothing in pre-check right now.",
+  "operator-review": "Nothing waiting on your risk decision.",
+  "release-queue": "Release queue is empty.",
+  deploying: "Nothing deploying right now.",
+  done: "Nothing shipped yet.",
+};
+
+function laneEmptyMessage(lane: LaneDescriptor): string {
+  return LANE_EMPTY_COPY[lane.id] ?? `No ${lane.name.toLowerCase()} right now.`;
+}
+
 export type LaneProps = {
   lane: LaneDescriptor;
   /** Whether the lane is expanded (default) or collapsed to a mini-rail. */
@@ -65,7 +84,7 @@ export function Lane({ lane, expanded, count, children, headerAccessory, onToggl
       <div className="hm-lane-body">
         {headerAccessory}
         {count === 0 ? (
-          <div className="hm-lane-empty">No {lane.name.toLowerCase()} right now.</div>
+          <div className="hm-lane-empty">{laneEmptyMessage(lane)}</div>
         ) : (
           children
         )}

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -248,8 +248,8 @@ describe("Card — task approve (O3 dispatch)", () => {
       summary: "dispatch_budget_exhausted then duplicate_signal",
     } as unknown as BoardCard;
     const { getByText, getByTitle, queryByText } = render(<Card card={card} onApprove={vi.fn()} />);
-    expect(getByText("Dispatch budget used up - paused until reset")).toBeTruthy();
-    expect(getByText("Skipped - duplicate of an existing fix")).toBeTruthy();
+    expect(getByText("Dispatch budget used up — paused until reset")).toBeTruthy();
+    expect(getByText("Skipped — duplicate of an existing fix")).toBeTruthy();
     expect(getByTitle("raw code: dispatch_budget_exhausted")).toBeTruthy();
     expect(getByTitle("raw code: duplicate_signal")).toBeTruthy();
     expect(queryByText(/dispatch_budget_exhausted/)).toBeNull();

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
@@ -162,7 +162,7 @@ describe("buildHermesActivityFeed", () => {
       now: () => Date.parse("2026-05-28T10:05:00Z"),
     });
     const text = entries.map((entry) => entry.text).join("\n");
-    expect(text).toContain("Dispatch budget used up - paused until reset");
+    expect(text).toContain("Dispatch budget used up — paused until reset");
     expect(text).not.toContain("dispatch_budget_exhausted");
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/signal-labels.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/signal-labels.test.ts
@@ -8,14 +8,14 @@ import {
 describe("signal-labels", () => {
   test("maps known guardrail enum codes to exact human labels", () => {
     expect(humanizeSignalCode("dispatch_budget_exhausted"))
-      .toBe("Dispatch budget used up - paused until reset");
+      .toBe("Dispatch budget used up — paused until reset");
     expect(humanizeSignalCode("open_fix_cap_reached"))
-      .toBe("Self-healing fix cap reached - won't propose more");
+      .toBe("Self-healing fix cap reached — won't propose more");
     expect(humanizeSignalCode("duplicate_signal"))
-      .toBe("Skipped - duplicate of an existing fix");
+      .toBe("Skipped — duplicate of an existing fix");
     expect(humanizeSignalCode("routed_fix")).toBe("Routed fix proposal");
     expect(humanizeSignalCode("not_auto_fixable"))
-      .toBe("Needs human diagnosis - not a code-agent fix");
+      .toBe("Needs human diagnosis — not a code-agent fix");
   });
 
   test("keeps unknown enum-like codes readable without dropping the raw token", () => {
@@ -27,6 +27,6 @@ describe("signal-labels", () => {
 
   test("humanizes enum tokens inside sentences", () => {
     expect(humanizeSignalText("Reason: dispatch_budget_exhausted; next duplicate_signal."))
-      .toBe("Reason: Dispatch budget used up - paused until reset; next Skipped - duplicate of an existing fix.");
+      .toBe("Reason: Dispatch budget used up — paused until reset; next Skipped — duplicate of an existing fix.");
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/signal-labels.ts
+++ b/packages/monitor-ui/src/lib/monitor/signal-labels.ts
@@ -4,11 +4,11 @@ export interface HumanizedSignalPart {
 }
 
 const SIGNAL_LABELS: Record<string, string> = {
-  dispatch_budget_exhausted: "Dispatch budget used up - paused until reset",
-  open_fix_cap_reached: "Self-healing fix cap reached - won't propose more",
-  duplicate_signal: "Skipped - duplicate of an existing fix",
+  dispatch_budget_exhausted: "Dispatch budget used up — paused until reset",
+  open_fix_cap_reached: "Self-healing fix cap reached — won't propose more",
+  duplicate_signal: "Skipped — duplicate of an existing fix",
   routed_fix: "Routed fix proposal",
-  not_auto_fixable: "Needs human diagnosis - not a code-agent fix",
+  not_auto_fixable: "Needs human diagnosis — not a code-agent fix",
 };
 
 const ENUM_TOKEN = /\b[a-z][a-z0-9]*(?:_[a-z0-9]+)+\b/g;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -83,6 +83,7 @@ import {
   runSelfHealingOnce,
   createCooldown,
   testbedSurfaceKey,
+  surfaceLabel,
   type FailureSignal,
 } from "./self-healing.js";
 import { runTaskHealthOnce } from "./task-health.js";
@@ -2507,7 +2508,7 @@ function startOperatorRoutines() {
             riskTier,
             routingReason,
             prompt,
-            title: `Self-healing fix: ${signal.surface}`,
+            title: `Self-healing fix: ${surfaceLabel(signal.surface)}`,
             reason: `Hermes self-healing proposal for a ${signal.source} failure`,
             requester: "hermes-self-healing",
             correlationId: `self-heal:${targetSignature}`,
@@ -2520,13 +2521,21 @@ function startOperatorRoutines() {
         },
         alert: (payload) => alertChannel.dispatch(payload),
         audit: async (record) => {
+          // Operator-facing phrasing — the internal "b2" stream codename and
+          // the raw action verb leak into board cards otherwise.
+          const actionPhrase =
+            record.action === "propose"
+              ? "Proposed a fix"
+              : record.action === "escalate"
+                ? "Escalated to operator"
+                : "Skipped";
           await recordHandoffEvent({
             correlationId: `self-heal:${record.targetSignature ?? `${record.source}:${record.surface}`}`,
             requester: "hermes-self-healing",
             intent: "self_healing",
             phase: "self_healing",
             status: record.action === "propose" ? "completed" : record.action === "escalate" ? "needs_review" : "completed",
-            reason: `b2 ${record.action}: ${record.reason}`,
+            reason: `${actionPhrase}: ${record.reason}`,
             summary: {
               kind: "self_healing",
               action: record.action,

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -1376,18 +1376,19 @@ export function taskHealthForBoard(
       };
     }
     const repeated = attemptCount >= REPEATED_FAILURE_ATTEMPTS;
+    const attemptsLabel = `${attemptCount} runner attempt${attemptCount === 1 ? "" : "s"}`;
     return attentionHealth({
       state: "stale",
       freshness: minutesSince(asString(task.failedAt) ?? asString(task.updatedAt), now),
       summary: repeated
-        ? `Task failed after ${attemptCount} runner attempt(s).`
+        ? `Task failed after ${attemptsLabel}.`
         : "Task failed in the runner.",
       riskSignal: {
         severity: repeated ? "high" : "medium",
         code: repeated ? "task_failed_repeatedly" : "task_failed",
         message: [
           repeated
-            ? `The task failed after ${attemptCount} runner attempt(s); operator should decide whether to split, retry, or cancel.`
+            ? `The task failed after ${attemptsLabel}; operator should decide whether to split, retry, or cancel.`
             : "The task failed and needs operator triage before it disappears from the queue.",
           failureReason,
         ].filter(Boolean).join(" "),

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -88,6 +88,19 @@ export function testbedSurfaceKey(targetUrl: string): string {
   return `testbed:${key || "unknown"}`;
 }
 
+/**
+ * Operator-facing label for a surface key. Surface keys are namespaced for
+ * dedup (e.g. "testbed:testbed-mission-7", "deploy-verify:abc123"); the
+ * leading "<namespace>:" is internal plumbing and only confuses operators
+ * (it produces titles like "testbed:testbed-mission-7"). Strip the first
+ * namespace segment for display, keeping the meaningful remainder.
+ */
+export function surfaceLabel(surface: string): string {
+  const value = (surface ?? "").trim();
+  const stripped = value.replace(/^[a-z0-9_-]+:/i, "");
+  return stripped || value;
+}
+
 export interface HealingDecision {
   action: HealingAction;
   reason: HealingReason;

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -7,6 +7,7 @@ import {
   buildHealingEscalationAlert,
   createCooldown,
   testbedSurfaceKey,
+  surfaceLabel,
   selfHealingTargetSignature,
   type FailureSignal,
   type HealingClassification,
@@ -27,6 +28,22 @@ function signal(over: Partial<FailureSignal> = {}): FailureSignal {
     ...over,
   };
 }
+
+// ── surface label (operator-facing display) ─────────────────────────
+
+describe("surfaceLabel — strips the internal namespace from a surface key", () => {
+  it("drops a doubled testbed prefix so titles aren't 'testbed:testbed-mission-…'", () => {
+    expect(surfaceLabel("testbed:testbed-mission-mpmo4ff2-1")).toBe("testbed-mission-mpmo4ff2-1");
+  });
+  it("drops other namespaces (deploy-verify, etc.) keeping the remainder", () => {
+    expect(surfaceLabel("deploy-verify:abc123")).toBe("abc123");
+    expect(surfaceLabel("testbed:app.example/overview")).toBe("app.example/overview");
+  });
+  it("leaves an unnamespaced value untouched and tolerates empty input", () => {
+    expect(surfaceLabel("app.example/overview")).toBe("app.example/overview");
+    expect(surfaceLabel("")).toBe("");
+  });
+});
 
 // ── pure decision matrix ────────────────────────────────────────────
 


### PR DESCRIPTION
Operator-facing **copy polish** on the Hermes monitor board, from a review of the live board screenshot. Display strings only — **no behavior, routing, or dedup-key changes**.

## What changed

**A — De-jargon titles** *(server display strings)*
- Self-healing card titles showed a doubled internal key: `Self-healing fix: testbed:testbed-mission-…`. `testbedSurfaceKey()` namespaces the dedup key as `testbed:<key>`, and the key itself is a mission id (`testbed-mission-…`), so the namespace doubled up. New `surfaceLabel()` strips the leading `<namespace>:` **for display only** → `Self-healing fix: testbed-mission-…`. The dedup/cooldown key is untouched.
- Self-healing audit reasons leaked the internal **`b2`** stream codename + raw action verb (`b2 escalate: …`). Now operator-readable: `Escalated to operator: …` / `Proposed a fix: …` / `Skipped: …`.

**B — Fix `(s)` plurals** *(monitor-v2.ts)*
- `Task failed after 2 runner attempt(s)` → proper `1 runner attempt` / `2 runner attempts`.

**C — Per-lane empty states** *(Lane.tsx, frontend)*
- The generic `No {lane} right now.` rendered as `No done right now.` / `No deploying right now.`. Each lane now gets fitting empty copy (`Nothing shipped yet.`, `Release queue is empty.`, …) with the generic form as fallback.

**D — Em-dash labels** *(signal-labels.ts, frontend)*
- Guardrail labels used ` - ` (`cap reached - won't propose more`) → em-dash ` — `.

## Truth-boundary / authority
No new authority, no merge/deploy behavior, no change to what data agents see. `surfaceLabel()` is presentation-only; the underlying surface key, correlation ids, and dedup logic are unchanged.

## Tests
- New `surfaceLabel` unit tests (namespace stripping, fallthrough, empty input).
- New per-lane empty-state test (`done` → `Nothing shipped yet.`, old template gone).
- Updated signal-label / Card / activity-feed / Lane assertions to the new copy.
- Full suite green (**1265 passed**), typecheck clean, `@avg/monitor-ui` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)