### PR TITLE
Persist monitor card dismiss and snooze

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -6,6 +6,7 @@ import { SWRConfig } from "swr";
 import { MonitorPage } from "./MonitorPage.js";
 import { FIXTURE_CARDS } from "./lib/monitor/fixtures.js";
 import type { MonitorBoard } from "./lib/monitor/board-cache.js";
+import type { BoardCard } from "./lib/monitor/card-types.js";
 import type { StorageLike } from "./lib/monitor/snapshot-store.js";
 
 afterEach(cleanup);
@@ -40,6 +41,24 @@ function memStorage(): StorageLike {
 
 function wrapper({ children }: { children: ReactNode }) {
   return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
+
+function taskCard(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "codex-task-1",
+    lane: "codex-needed",
+    type: "task",
+    agentType: "codex",
+    title: "Investigate board card",
+    summary: "A proposed task is waiting for operator action.",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 1,
+    state: "fresh",
+    risk: ["workflow"],
+    waitingOn: { actor: "operator", tone: "warn" },
+    taskStatus: "proposed",
+    ...overrides,
+  } as BoardCard;
 }
 
 beforeEach(() => {
@@ -185,6 +204,102 @@ describe("MonitorPage — container", () => {
       expect(calledUrl).toBe("/monitor/testbed-missions/testbed-mission-requested-1/approve");
       expect(init.method).toBe("POST");
     } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("the default dismiss POSTs task cards to the durable codex-task endpoint", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [taskCard()],
+      at: "2026-05-28T10:30:00Z",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Dismiss" })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/codex-tasks/codex-task-1/dismiss");
+      expect(init.method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("the default dismiss POSTs self-healing cards to the suppression-aware endpoint", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [taskCard({
+        id: "codex-task-self-heal-1",
+        title: "Self-healing: failed mission",
+        correlationId: "self-heal:testbed_mission:testbed:sweep-1",
+      })],
+      at: "2026-05-28T10:30:00Z",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Dismiss" })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/self-healing-proposals/codex-task-self-heal-1/dismiss");
+      expect(init.method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("the default snooze POSTs a durable until timestamp", async () => {
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-28T10:30:00.000Z"));
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [taskCard()],
+      at: "2026-05-28T10:30:00Z",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Snooze" })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: "Snooze" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/codex-tasks/codex-task-1/snooze");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(String(init.body))).toEqual({
+        untilMs: Date.parse("2026-05-28T11:00:00.000Z"),
+      });
+    } finally {
+      nowSpy.mockRestore();
       fetchSpy.mockRestore();
     }
   });

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -28,12 +28,13 @@ import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
 import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonomyMode.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
-import type { CreateTaskInput } from "./lib/monitor/card-types.js";
+import type { BoardCard, CreateTaskInput } from "./lib/monitor/card-types.js";
 import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
 const MISSIONS_URL = "/monitor/testbed-missions";
 const CODEX_TASKS_URL = "/monitor/codex-tasks";
+const SELF_HEALING_PROPOSALS_URL = "/monitor/self-healing-proposals";
 const ALERT_MUTE_URL = "/monitor/alert-mute";
 
 export type AlertMuteBody = { untilMs: number } | { muted: false };
@@ -51,6 +52,10 @@ export interface MonitorPageProps {
   onCreateTask?: (input: CreateTaskInput) => void;
   /** Override the approve dispatch (defaults to POST /monitor/codex-tasks approve). */
   onApproveTask?: (id: string) => void;
+  /** Override persisted card dismiss. */
+  onDismissCard?: (card: BoardCard) => void;
+  /** Override persisted card snooze. */
+  onSnoozeCard?: (card: BoardCard, untilMs: number) => void;
   /** Override the tester mission approval (defaults to POST /monitor/testbed-missions/:id/approve). */
   onApproveMission?: (id: string) => void;
   /** Override the drawer mission re-run (defaults to POST /monitor/testbed-missions). */
@@ -72,6 +77,8 @@ export function MonitorPage({
   onSpawnClaudeTask = defaultSpawnClaudeTask,
   onCreateTask = defaultCreateTask,
   onApproveTask = defaultApproveTask,
+  onDismissCard = defaultDismissCard,
+  onSnoozeCard = defaultSnoozeCard,
   onApproveMission = defaultApproveMission,
   onRerunMission = defaultRerunMission,
   collaboration = {},
@@ -117,6 +124,8 @@ export function MonitorPage({
         onSpawnClaudeTask={onSpawnClaudeTask}
         onCreateTask={onCreateTask}
         onApproveTask={onApproveTask}
+        onDismissCard={onDismissCard}
+        onSnoozeCard={onSnoozeCard}
         onApproveMission={onApproveMission}
         onRerunMission={onRerunMission}
         collaboration={collaboration}
@@ -213,6 +222,34 @@ function defaultApproveTask(id: string): void {
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
   });
+}
+
+function defaultDismissCard(card: BoardCard): void {
+  const base = monitorCardActionBase(card);
+  if (!base) return;
+  void fetch(`${base}/${encodeURIComponent(card.id)}/dismiss`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* optimistic local hide already applied; next poll is the source of truth */
+  });
+}
+
+function defaultSnoozeCard(card: BoardCard, untilMs: number): void {
+  const base = monitorCardActionBase(card);
+  if (!base) return;
+  void fetch(`${base}/${encodeURIComponent(card.id)}/snooze`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ untilMs }),
+  }).catch(() => {
+    /* optimistic local hide already applied; next poll is the source of truth */
+  });
+}
+
+function monitorCardActionBase(card: BoardCard): string | undefined {
+  if (card.type !== "task") return undefined;
+  return card.correlationId?.startsWith("self-heal:") ? SELF_HEALING_PROPOSALS_URL : CODEX_TASKS_URL;
 }
 
 /**

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -103,6 +103,10 @@ export interface BoardViewProps {
   onApproveTask?: (id: string) => void;
   /** Approve a requested tester mission — the operator human gate (T6). */
   onApproveMission?: (id: string) => void;
+  /** Persist operator dismissal for cards backed by server-side state. */
+  onDismissCard?: (card: BoardCard) => void;
+  /** Persist operator snooze for cards backed by server-side state. */
+  onSnoozeCard?: (card: BoardCard, untilMs: number) => void;
   /** Re-run a mission (drawer footer) via POST /monitor/testbed-missions. */
   onRerunMission?: (targetUrl: string, freshness: "fresh" | "memory") => void;
   collaboration?: UseCollaborationOptions;
@@ -133,6 +137,8 @@ export function BoardView({
   onCreateTask,
   onApproveTask,
   onApproveMission,
+  onDismissCard: persistDismissCard,
+  onSnoozeCard: persistSnoozeCard,
   onRerunMission,
   collaboration,
   onMute,
@@ -279,21 +285,24 @@ export function BoardView({
     });
   }, []);
 
-  const onDismissCard = useCallback((id: string) => {
+  const onDismissCard = useCallback((card: BoardCard) => {
     setDismissedCardIds((prev) => {
       const next = new Set(prev);
-      next.add(id);
+      next.add(card.id);
       return next;
     });
-  }, []);
+    persistDismissCard?.(card);
+  }, [persistDismissCard]);
 
-  const onSnoozeCard = useCallback((id: string) => {
+  const onSnoozeCard = useCallback((card: BoardCard) => {
+    const untilMs = Date.now() + OPERATOR_CARD_SNOOZE_MS;
     setSnoozedUntilById((prev) => {
       const next = new Map(prev);
-      next.set(id, Date.now() + OPERATOR_CARD_SNOOZE_MS);
+      next.set(card.id, untilMs);
       return next;
     });
-  }, []);
+    persistSnoozeCard?.(card, untilMs);
+  }, [persistSnoozeCard]);
 
   const onKeepWatchingCard = useCallback((id: string) => {
     setKeptCardIds((prev) => {
@@ -436,8 +445,8 @@ export function BoardView({
                 onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
                 onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
                 onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
-                onDismiss={(c) => onDismissCard(c.id)}
-                onSnooze={(c) => onSnoozeCard(c.id)}
+                onDismiss={onDismissCard}
+                onSnooze={onSnoozeCard}
                 onKeepWatching={(c) => onKeepWatchingCard(c.id)}
                 onInvestigate={onCardClick ? (c) => onCardClick(c.id) : undefined}
               />

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -368,7 +368,7 @@ function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
 
 // ── Operator actions ────────────────────────────────────────────────
 // Approve is only shown when it maps to an existing human gate. Dismiss and
-// snooze are local monitor controls; they do not mutate task authority.
+// snooze persist for task-backed cards; they do not grant runner authority.
 
 function OperatorActions({
   card,

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -90,6 +90,10 @@ export interface CodexTask extends CodexTaskInput {
   retryCount?: number;
   selfManagementEscalatedAt?: string;
   selfManagementEscalationReason?: string;
+  operatorDismissedAt?: string;
+  operatorDismissedBy?: string;
+  operatorSnoozedUntil?: string;
+  operatorSnoozedBy?: string;
   events?: CodexTaskEvent[];
 }
 
@@ -274,7 +278,11 @@ export async function claimNextApprovedCodexTask(
   // A per-agent runner claims only its own tasks; an unfiltered call (no
   // `agent`) claims any approved task, preserving the current behavior.
   const existing = tasks
-    .filter((task) => task.status === "approved" && (deps.agent === undefined || taskAgent(task) === deps.agent))
+    .filter((task) =>
+      task.status === "approved"
+      && !isTaskSnoozed(task, deps.now ?? new Date())
+      && (deps.agent === undefined || taskAgent(task) === deps.agent)
+    )
     .sort((a, b) => Date.parse(a.approvedAt ?? a.updatedAt) - Date.parse(b.approvedAt ?? b.updatedAt))[0];
   if (!existing) return undefined;
   const now = (deps.now ?? new Date()).toISOString();
@@ -505,6 +513,59 @@ export async function escalateCodexTask(
   return task;
 }
 
+export async function dismissCodexTask(
+  id: string,
+  deps: CodexTaskQueueDeps & { dismissedBy?: string } = {}
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  const now = (deps.now ?? new Date()).toISOString();
+  const shouldCancel = !TERMINAL_STATUSES.has(existing.status) && existing.status !== "running";
+  const task: CodexTask = {
+    ...existing,
+    ...(shouldCancel ? { status: "cancelled" as const, cancelledAt: existing.cancelledAt ?? now, cancelledBy: deps.dismissedBy ?? existing.cancelledBy ?? "operator" } : {}),
+    operatorDismissedAt: existing.operatorDismissedAt ?? now,
+    operatorDismissedBy: deps.dismissedBy ?? existing.operatorDismissedBy ?? "operator",
+    events: appendTaskEvent(existing, {
+      at: now,
+      status: shouldCancel ? "cancelled" : "progress",
+      message: shouldCancel
+        ? "Operator dismissed this card; task dispatch was cancelled."
+        : "Operator dismissed this card.",
+    }),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
+export async function snoozeCodexTask(
+  id: string,
+  deps: CodexTaskQueueDeps & { snoozedUntil: Date; snoozedBy?: string }
+): Promise<CodexTask | undefined> {
+  const path = queuePath(deps.path);
+  const tasks = await readCodexTasks(path);
+  const existing = tasks.find((task) => task.id === id);
+  if (!existing) return undefined;
+  const now = (deps.now ?? new Date()).toISOString();
+  const snoozedUntil = deps.snoozedUntil.toISOString();
+  const task: CodexTask = {
+    ...existing,
+    operatorSnoozedUntil: snoozedUntil,
+    operatorSnoozedBy: deps.snoozedBy ?? "operator",
+    events: appendTaskEvent(existing, {
+      at: now,
+      status: "progress",
+      message: `Operator snoozed this card until ${snoozedUntil}.`,
+    }),
+    updatedAt: now,
+  };
+  await writeCodexTasks(path, replaceTask(tasks, task));
+  return task;
+}
+
 export async function readCodexRunnerHeartbeat(
   deps: CodexTaskQueueDeps = {}
 ): Promise<CodexRunnerHeartbeat | undefined> {
@@ -643,6 +704,16 @@ function codexRunnerStatusMessage(status: CodexRunnerHeartbeatStatus): string {
     case "error":
       return "Codex task runner hit an error.";
   }
+}
+
+export function isTaskDismissed(task: Pick<CodexTask, "operatorDismissedAt">): boolean {
+  return Boolean(task.operatorDismissedAt);
+}
+
+export function isTaskSnoozed(task: Pick<CodexTask, "operatorSnoozedUntil">, now: Date = new Date()): boolean {
+  if (!task.operatorSnoozedUntil) return false;
+  const untilMs = Date.parse(task.operatorSnoozedUntil);
+  return Number.isFinite(untilMs) && untilMs > now.getTime();
 }
 
 function makeCodexTaskId(repo: string, pullRequestNumber: number | undefined, timestamp: string): string {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -82,6 +82,8 @@ import {
 import {
   runSelfHealingOnce,
   createCooldown,
+  isSelfHealingTargetSuppressed,
+  suppressSelfHealingTarget,
   testbedSurfaceKey,
   type FailureSignal,
 } from "./self-healing.js";
@@ -133,11 +135,13 @@ import {
   annotateCodexTaskDecisionRecord,
   cancelCodexTask,
   deferCodexTaskRetry,
+  dismissCodexTask,
   escalateCodexTask,
   listCodexTasks,
   proposeCodexTask,
   readCodexRunnerHeartbeat,
   retryCodexTask,
+  snoozeCodexTask,
   summarizeCodexTasks,
   taskAgent,
   type CodexTask,
@@ -418,6 +422,10 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           "/monitor/command",
           "/monitor/recheck",
           "/monitor/codex-tasks",
+          "/monitor/codex-tasks/:id/dismiss",
+          "/monitor/codex-tasks/:id/snooze",
+          "/monitor/self-healing-proposals/:id/dismiss",
+          "/monitor/self-healing-proposals/:id/snooze",
           "/monitor/backlog-suggestions",
           "/monitor/decision-records",
           "/monitor/agents",
@@ -646,6 +654,19 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorCodexTaskRequest(request, response);
+    return;
+  }
+  const cardActionRoute = monitorCardActionRoute(url.pathname);
+  if (request.method === "POST" && cardActionRoute) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorCardActionRequest(cardActionRoute, request, response);
     return;
   }
   if (request.method === "POST" && url.pathname === "/monitor/recheck") {
@@ -2118,6 +2139,100 @@ async function handleMonitorCodexTaskRequest(request: http.IncomingMessage, resp
   }
 }
 
+interface MonitorCardActionRoute {
+  collection: "codex-tasks" | "self-healing-proposals";
+  id: string;
+  action: "dismiss" | "snooze";
+}
+
+function monitorCardActionRoute(pathname: string): MonitorCardActionRoute | undefined {
+  const match = /^\/monitor\/(codex-tasks|self-healing-proposals)\/([^/]+)\/(dismiss|snooze)$/.exec(pathname);
+  if (!match) return undefined;
+  return {
+    collection: match[1] as MonitorCardActionRoute["collection"],
+    id: decodeURIComponent(match[2] ?? ""),
+    action: match[3] as MonitorCardActionRoute["action"],
+  };
+}
+
+async function handleMonitorCardActionRequest(
+  route: MonitorCardActionRoute,
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+) {
+  try {
+    if (route.action === "dismiss") {
+      const task = await dismissCodexTask(route.id, { dismissedBy: "operator" });
+      if (!task) {
+        writeJson(response, 404, { error: "codex_task_not_found", id: route.id });
+        return;
+      }
+      const suppression = await maybeSuppressSelfHealingTarget(route.collection, task);
+      writeJson(response, 200, {
+        ok: true,
+        action: "dismiss",
+        task,
+        ...(suppression ? { selfHealingSuppression: suppression } : {}),
+        queue: await loadCodexTaskQueueSummary(),
+      });
+      return;
+    }
+
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const untilMs = numberField(payload, "untilMs");
+    if (untilMs === undefined || !Number.isFinite(untilMs) || untilMs <= Date.now()) {
+      writeJson(response, 400, {
+        error: "invalid_snooze_until",
+        message: "untilMs must be a future epoch millisecond timestamp.",
+      });
+      return;
+    }
+    const task = await snoozeCodexTask(route.id, {
+      snoozedUntil: new Date(untilMs),
+      snoozedBy: "operator",
+    });
+    if (!task) {
+      writeJson(response, 404, { error: "codex_task_not_found", id: route.id });
+      return;
+    }
+    writeJson(response, 200, {
+      ok: true,
+      action: "snooze",
+      task,
+      queue: await loadCodexTaskQueueSummary(),
+    });
+  } catch (error) {
+    logger.error({ err: error, id: route.id, action: route.action }, "monitor_card_action_failed");
+    writeJson(response, 500, {
+      error: "monitor_card_action_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function maybeSuppressSelfHealingTarget(
+  collection: MonitorCardActionRoute["collection"],
+  task: CodexTask,
+) {
+  const targetSignature = selfHealingTargetSignatureFromTask(task);
+  if (!targetSignature) return undefined;
+  if (collection !== "self-healing-proposals" && task.requester !== "hermes-self-healing") return undefined;
+  return suppressSelfHealingTarget(targetSignature, {
+    dismissedBy: "operator",
+    sourceTaskId: task.id,
+  });
+}
+
+function selfHealingTargetSignatureFromTask(task: CodexTask): string | undefined {
+  const prefix = "self-heal:";
+  return task.correlationId?.startsWith(prefix) ? task.correlationId.slice(prefix.length) : undefined;
+}
+
 function startOperatorRoutines() {
   const channelRoutineEnabled = routineConfig.dailyBrief.enabled
     || routineConfig.dailyGithubBrief.enabled
@@ -2482,6 +2597,7 @@ function startOperatorRoutines() {
             (t) => t.correlationId === corr && !["completed", "failed", "cancelled"].includes(t.status),
           );
         },
+        isSuppressedTarget: (targetSignature) => isSelfHealingTargetSuppressed(targetSignature),
         proposalsToday: async () => {
           const today = new Date().toISOString().slice(0, 10);
           const tasks = await listCodexTasks();

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -1275,6 +1275,10 @@ export function synthesizeTaskCards(
     if (!task) continue;
     const status = asString(task.status);
     if (!status || SYNTH_TERMINAL_TASK_STATUSES.has(status)) continue;
+    if (asString(task.operatorDismissedAt)) continue;
+    const operatorSnoozedUntil = asString(task.operatorSnoozedUntil);
+    const operatorSnoozedUntilMs = operatorSnoozedUntil ? Date.parse(operatorSnoozedUntil) : NaN;
+    if (Number.isFinite(operatorSnoozedUntilMs) && operatorSnoozedUntilMs > now.getTime()) continue;
     // PR-bound tasks surface (and get their status overlaid) via the PR card.
     if (task.pullRequestNumber !== undefined && task.pullRequestNumber !== null) continue;
     const id = asString(task.id);

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -22,6 +22,8 @@
 
 import type { AlertPayload } from "./alert-bridge.js";
 import type { TaskAgent } from "./codex-task-queue.js";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 
 export type HealingRiskTier = "high" | "low";
 export type HealingSource = "testbed_mission" | "post_deploy_verification" | "ci_main" | "ops_health";
@@ -67,6 +69,7 @@ export type HealingReason =
   | "dispatch_budget_exhausted"
   | "open_fix_cap_reached"
   | "tick_budget_exhausted"
+  | "operator_dismissed"
   | "routed_fix";
 
 /**
@@ -216,6 +219,8 @@ export interface SelfHealingDeps {
   classify: (signal: FailureSignal) => HealingClassification;
   /** Durable dedup: is there already a non-terminal fix task for this target? */
   hasOpenFixTask: (targetSignature: string) => Promise<boolean> | boolean;
+  /** Durable suppression: operator dismissed this target, so B2 must not recreate it. */
+  isSuppressedTarget?: (targetSignature: string) => Promise<boolean> | boolean;
   /** B2 fix tasks already proposed today (for the daily budget backstop). */
   proposalsToday: () => Promise<number> | number;
   maxProposalsPerDay: number;
@@ -271,6 +276,15 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
       continue;
     }
     seenTargets.add(targetSignature);
+
+    // Operator dismissal is durable: once the operator says "clear this
+    // proposal", B2 must not recreate the same target on the next tick.
+    if (await deps.isSuppressedTarget?.(targetSignature)) {
+      deps.markHandled(targetSignature, nowMs);
+      await deps.audit({ surface: signal.surface, targetSignature, source: signal.source, action: "skip", reason: "operator_dismissed" });
+      handled.push({ surface: signal.surface, action: "skip", reason: "operator_dismissed" });
+      continue;
+    }
 
     // Durable dedup: one open fix task per target, checked before cooldown so
     // the audit reason stays truthful after restarts or operator-created tasks.
@@ -352,6 +366,55 @@ export async function runSelfHealingOnce(deps: SelfHealingDeps): Promise<SelfHea
   return { handled };
 }
 
+export interface SelfHealingTargetSuppression {
+  schemaVersion: 1;
+  kind: "self_healing_target_suppression";
+  targetSignature: string;
+  dismissedAt: string;
+  dismissedBy: string;
+  sourceTaskId?: string;
+}
+
+export interface SelfHealingSuppressionDeps {
+  path?: string;
+  now?: Date;
+  dismissedBy?: string;
+  sourceTaskId?: string;
+}
+
+export async function suppressSelfHealingTarget(
+  targetSignature: string,
+  deps: SelfHealingSuppressionDeps = {}
+): Promise<SelfHealingTargetSuppression> {
+  const path = selfHealingSuppressionPath(deps.path);
+  const items = await readSelfHealingSuppressions(path);
+  const normalized = normalizeTargetSignature(targetSignature);
+  const now = (deps.now ?? new Date()).toISOString();
+  const suppression: SelfHealingTargetSuppression = {
+    schemaVersion: 1,
+    kind: "self_healing_target_suppression",
+    targetSignature: normalized,
+    dismissedAt: now,
+    dismissedBy: deps.dismissedBy ?? "operator",
+    ...(deps.sourceTaskId ? { sourceTaskId: deps.sourceTaskId } : {}),
+  };
+  const next = [
+    ...items.filter((item) => item.targetSignature !== normalized),
+    suppression,
+  ];
+  await writeSelfHealingSuppressions(path, next);
+  return suppression;
+}
+
+export async function isSelfHealingTargetSuppressed(
+  targetSignature: string,
+  deps: Pick<SelfHealingSuppressionDeps, "path"> = {}
+): Promise<boolean> {
+  const normalized = normalizeTargetSignature(targetSignature);
+  const items = await readSelfHealingSuppressions(selfHealingSuppressionPath(deps.path));
+  return items.some((item) => item.targetSignature === normalized);
+}
+
 /** A simple in-memory per-surface cooldown the routine closure holds. */
 export function createCooldown(cooldownMs: number) {
   const last = new Map<string, number>();
@@ -364,4 +427,43 @@ export function createCooldown(cooldownMs: number) {
       last.set(surface, nowMs);
     },
   };
+}
+
+async function readSelfHealingSuppressions(path: string): Promise<SelfHealingTargetSuppression[]> {
+  try {
+    const content = await readFile(path, "utf8");
+    const value: unknown = JSON.parse(content);
+    if (!Array.isArray(value)) return [];
+    return value.filter(isSelfHealingTargetSuppression);
+  } catch (error) {
+    const code = typeof error === "object" && error !== null && "code" in error ? (error as { code?: unknown }).code : undefined;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+}
+
+async function writeSelfHealingSuppressions(path: string, items: SelfHealingTargetSuppression[]): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(items, null, 2)}\n`);
+}
+
+function selfHealingSuppressionPath(path?: string): string {
+  return path
+    ?? process.env.SELF_HEALING_SUPPRESSIONS_PATH
+    ?? `${process.env.AVERRAY_CODEX_TASKS_PATH ?? "/tmp/averray-reference-agent/codex-tasks.json"}.self-healing-suppressions.json`;
+}
+
+function normalizeTargetSignature(value: string): string {
+  return value.trim();
+}
+
+function isSelfHealingTargetSuppression(value: unknown): value is SelfHealingTargetSuppression {
+  return typeof value === "object"
+    && value !== null
+    && !Array.isArray(value)
+    && (value as SelfHealingTargetSuppression).schemaVersion === 1
+    && (value as SelfHealingTargetSuppression).kind === "self_healing_target_suppression"
+    && typeof (value as SelfHealingTargetSuppression).targetSignature === "string"
+    && typeof (value as SelfHealingTargetSuppression).dismissedAt === "string"
+    && typeof (value as SelfHealingTargetSuppression).dismissedBy === "string";
 }

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -8,11 +8,13 @@ import {
   cancelCodexTask,
   claimNextApprovedCodexTask,
   completeCodexTask,
+  dismissCodexTask,
   failCodexTask,
   listCodexTasks,
   proposeCodexTask,
   readCodexRunnerHeartbeat,
   retryCodexTask,
+  snoozeCodexTask,
   summarizeCodexTasks,
   taskAgent,
   updateCodexTaskProgress,
@@ -316,6 +318,87 @@ describe("codex task queue", () => {
         ageMs: 10_000,
         stale: false,
       },
+    });
+  });
+
+  it("persists operator dismissal across a reload and cancels unclaimed dispatch", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      prompt: "Fix the stale board card.",
+      requester: "hermes-self-healing",
+      correlationId: "self-heal:testbed:overview",
+    }, { path, now: new Date("2026-05-17T15:00:00.000Z") });
+
+    const dismissed = await dismissCodexTask(proposed.task.id, {
+      path,
+      dismissedBy: "operator",
+      now: new Date("2026-05-17T15:01:00.000Z"),
+    });
+
+    expect(dismissed).toMatchObject({
+      id: proposed.task.id,
+      status: "cancelled",
+      cancelledBy: "operator",
+      operatorDismissedAt: "2026-05-17T15:01:00.000Z",
+      operatorDismissedBy: "operator",
+    });
+    expect(dismissed?.events?.at(-1)).toMatchObject({
+      status: "cancelled",
+      message: "Operator dismissed this card; task dispatch was cancelled.",
+    });
+
+    const [reloaded] = await listCodexTasks({ path });
+    expect(reloaded).toMatchObject({
+      id: proposed.task.id,
+      status: "cancelled",
+      operatorDismissedAt: "2026-05-17T15:01:00.000Z",
+    });
+    expect(summarizeCodexTasks(await listCodexTasks({ path })).counts).toMatchObject({
+      total: 1,
+      terminal: 1,
+    });
+  });
+
+  it("snoozes approved tasks until the snooze timestamp expires", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      prompt: "Fix after a short pause.",
+    }, { path, now: new Date("2026-05-17T16:00:00.000Z") });
+    await approveCodexTask(proposed.task.id, {
+      path,
+      approvedBy: "operator",
+      now: new Date("2026-05-17T16:01:00.000Z"),
+    });
+
+    const snoozed = await snoozeCodexTask(proposed.task.id, {
+      path,
+      snoozedBy: "operator",
+      snoozedUntil: new Date("2026-05-17T16:30:00.000Z"),
+      now: new Date("2026-05-17T16:02:00.000Z"),
+    });
+    expect(snoozed).toMatchObject({
+      id: proposed.task.id,
+      status: "approved",
+      operatorSnoozedUntil: "2026-05-17T16:30:00.000Z",
+      operatorSnoozedBy: "operator",
+    });
+
+    await expect(claimNextApprovedCodexTask({
+      path,
+      runnerId: "runner-before-expiry",
+      now: new Date("2026-05-17T16:15:00.000Z"),
+    })).resolves.toBeUndefined();
+
+    await expect(claimNextApprovedCodexTask({
+      path,
+      runnerId: "runner-after-expiry",
+      now: new Date("2026-05-17T16:31:00.000Z"),
+    })).resolves.toMatchObject({
+      id: proposed.task.id,
+      status: "running",
+      runnerId: "runner-after-expiry",
     });
   });
 });

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1138,6 +1138,38 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     });
   });
 
+  it("hides operator-dismissed task cards across reloads", () => {
+    const cards = synthesizeTaskCards({
+      codexTasks: {
+        items: [{
+          ...proposedClaude,
+          operatorDismissedAt: "2026-05-31T11:55:00.000Z",
+          operatorDismissedBy: "operator",
+        }],
+      },
+    }, undefined, { now: new Date("2026-05-31T12:00:00.000Z") });
+
+    expect(cards).toEqual([]);
+  });
+
+  it("hides snoozed task cards until the snooze timestamp expires", () => {
+    const raw = {
+      codexTasks: {
+        items: [{
+          ...proposedClaude,
+          operatorSnoozedUntil: "2026-05-31T12:30:00.000Z",
+          operatorSnoozedBy: "operator",
+        }],
+      },
+    };
+
+    expect(synthesizeTaskCards(raw, undefined, { now: new Date("2026-05-31T12:00:00.000Z") })).toEqual([]);
+    expect(synthesizeTaskCards(raw, undefined, { now: new Date("2026-05-31T12:31:00.000Z") })[0]).toMatchObject({
+      id: "claude-task-x1",
+      taskStatus: "proposed",
+    });
+  });
+
   it("promotes failed greenfield tasks to needs-attention with retry context", () => {
     const [card] = synthesizeTaskCards(
       {

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   decideHealingAction,
@@ -6,8 +9,10 @@ import {
   buildFixPrompt,
   buildHealingEscalationAlert,
   createCooldown,
+  isSelfHealingTargetSuppressed,
   testbedSurfaceKey,
   selfHealingTargetSignature,
+  suppressSelfHealingTarget,
   type FailureSignal,
   type HealingClassification,
   type SelfHealingDeps,
@@ -15,6 +20,18 @@ import {
 
 const LOW: HealingClassification = { agent: "claude", riskTier: "low", reason: "UI surface, low-risk" };
 const HIGH: HealingClassification = { agent: "codex", riskTier: "high", reason: "deploy/settlement, high-risk" };
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+async function tempSuppressionPath(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "averray-self-healing-"));
+  tempDirs.push(dir);
+  return join(dir, "suppressions.json");
+}
 
 function signal(over: Partial<FailureSignal> = {}): FailureSignal {
   return {
@@ -189,6 +206,37 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     await runSelfHealingOnce(h.deps);
     expect(h.proposed).toHaveLength(0);
     expect(h.audits[0]).toMatchObject({ action: "skip", reason: "open_fix_exists" });
+  });
+
+  it("operator-dismissed self-healing targets suppress re-proposal", async () => {
+    const h = harness([signal()], {
+      isSuppressedTarget: (targetSignature) => targetSignature === "testbed_mission:testbed:sweep-1",
+    });
+    const r = await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(0);
+    expect(r.handled[0]).toMatchObject({ action: "skip", reason: "operator_dismissed" });
+    expect(h.audits[0]).toMatchObject({ action: "skip", reason: "operator_dismissed" });
+  });
+
+  it("persists self-healing target suppressions durably", async () => {
+    const path = await tempSuppressionPath();
+    await expect(isSelfHealingTargetSuppressed("testbed_mission:testbed:sweep-1", { path })).resolves.toBe(false);
+
+    const suppression = await suppressSelfHealingTarget("testbed_mission:testbed:sweep-1", {
+      path,
+      dismissedBy: "operator",
+      sourceTaskId: "codex-task-self-heal-1",
+      now: new Date("2026-05-31T12:05:00.000Z"),
+    });
+
+    expect(suppression).toMatchObject({
+      targetSignature: "testbed_mission:testbed:sweep-1",
+      dismissedAt: "2026-05-31T12:05:00.000Z",
+      dismissedBy: "operator",
+      sourceTaskId: "codex-task-self-heal-1",
+    });
+    await expect(isSelfHealingTargetSuppressed("testbed_mission:testbed:sweep-1", { path })).resolves.toBe(true);
   });
 
   it("dedup: duplicate signals for the same failing target in one tick → proposed once", async () => {


### PR DESCRIPTION
## What changed & why

- Added durable dismiss/snooze state to the Codex task queue and monitor board synthesis, so cleared cards stay gone across refresh/poll cycles.
- Added POST endpoints for `/monitor/codex-tasks/:id/dismiss`, `/monitor/codex-tasks/:id/snooze`, `/monitor/self-healing-proposals/:id/dismiss`, and `/monitor/self-healing-proposals/:id/snooze`.
- Wired the board Dismiss/Snooze buttons to those endpoints with optimistic local hiding.
- Added self-healing target suppression so dismissed B2 proposals are not recreated on the next routine tick.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback
No env or deploy-script changes. Rollback by reverting this PR; the persisted task metadata is additive and ignored by older readers.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups
- Dismiss/snooze is persisted for task-backed monitor cards. Other card types keep their existing local-only behavior unless/until they gain a server-side state owner.
