### PR TITLE
Constrain B2 testbed mission self-heals

### DIFF
--- a/docs/testbed-mission-failure-triage-2026-06-01.md
+++ b/docs/testbed-mission-failure-triage-2026-06-01.md
@@ -21,9 +21,9 @@ Evidence in code:
 - `services/slack-operator/src/monitor-testbed-missions.ts` has two different failure layers: `mission_report_needs_fix` means a browser-agent product report exists; `mission_runner_failed` means the runner/report pipeline failed before a trustworthy product report existed.
 - `services/slack-operator/src/index.ts` collected both kinds into the same `FailureSignal` with `repo`, so the self-healing core treated runner/report failures as routable code work.
 - The generic B2 prompt only included a board URL as evidence. The hosted board is Cloudflare-protected from a fresh agent context, so a Claude worker could receive a vague "testbed mission failed" task with no durable product evidence it can act on.
-- `testbedMissionCodexFollowupPrompt()` already contains the richer product-fix prompt, but B2 was not using it for self-healing proposals.
+- `testbedMissionCodexFollowupPrompt()` contains a richer product-fix prompt, but a browser mission still points at product evidence rather than a concrete PR, branch, or code surface.
 
-Conclusion: some self-healing tasks were doomed because the target was not a real code task yet. Runner/report-pipeline failures need human/operator diagnosis; structured browser-agent product failures can still become a code-agent fix.
+Conclusion: some self-healing tasks were doomed because the target was not a real code task yet. Runner/report-pipeline failures need human/operator diagnosis. Structured browser-agent product failures are useful evidence, but they should not be dispatched by B2 until a human or another monitor surface maps them to a concrete code-agent target.
 
 ## Code decision
 
@@ -32,8 +32,13 @@ B2 should not delete or rewrite mission history. Instead, its input now filters 
 - Keep only the newest mission per target surface.
 - Drop a failed mission once a newer mission for that target exists, including a pass, requested, ready, or running rerun.
 - Drop failed missions older than `B2_SELF_HEALING_TESTBED_FAILURE_MAX_AGE_HOURS` (default: 72).
-- For the remaining failed missions, propose a self-healing code task only when the run has a structured browser-agent product report.
-- Use the structured testbed follow-up prompt for product-fixable missions so the worker gets blocker, UX gap, proof, and evidence without relying on a protected board link.
+- For the remaining failed missions, escalate structured browser-agent product reports as `not_auto_fixable` because the mission is product evidence, not by itself a routable code surface.
+- Preserve the structured testbed follow-up prompt on the disposition so an operator can copy/handoff the blocker, UX gap, proof, and evidence without relying on a protected board link.
 - Escalate runner/report-pipeline failures as `not_auto_fixable` instead of dispatching a doomed code-agent task.
+- Keep true code surfaces, such as a real PR/branch CI failure with a configured repo target, eligible for B2 proposals.
 
 This is a read-only input guard. It does not create, approve, dismiss, or mutate product work.
+
+## Reconciliation note — 2026-06-01
+
+After the stale-input guard and dismiss suppression landed, the remaining loop cause was the structured product-report path: B2 still treated a failed browser mission as code-agent-actionable whenever a repo was configured. This update keeps those missions in the operator evidence lane and only lets B2 propose for concrete code surfaces, so re-arming B2 should stop the mission-failure → self-heal-failure loop without hiding real PR/CI failures.

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -715,7 +715,10 @@ export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): Te
   const fixBrief = testbedMissionFixBrief(run);
   const fixPrompt = testbedMissionCodexFollowupPrompt(run);
   return {
-    autoFixable: Boolean(fixPrompt),
+    // A browser mission failure is product evidence, not a concrete code target.
+    // Keep the prompt for operator handoff, but do not let B2 dispatch a doomed
+    // code task without a real PR/branch/CI surface to act on.
+    autoFixable: false,
     reason: fixPrompt ? "product_signal" : "missing_product_report",
     summary: `Testbed mission ${run.id} found a product blocker on ${run.targetUrl}: ${fixBrief.primaryBlocker}`,
     ...(fixPrompt ? { fixPrompt } : {}),

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -488,7 +488,7 @@ describe("monitor testbed mission runs", () => {
     expect(coaching).toContain("do not ask Codex to change the product until the evidence is attached");
   });
 
-  it("marks structured failed browser reports as code-agent-fixable for B2", () => {
+  it("marks structured failed browser reports as operator-review evidence, not B2 code-agent work", () => {
     const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
     const updated = recordTestbedMissionReportFromMessage(
       {
@@ -511,10 +511,11 @@ describe("monitor testbed mission runs", () => {
 
     const disposition = testbedMissionSelfHealingDisposition(updated!);
     expect(disposition).toMatchObject({
-      autoFixable: true,
+      autoFixable: false,
       reason: "product_signal",
     });
     expect(disposition.summary).toContain("Could not find the claim button.");
+    expect(disposition.summary).toContain("product blocker");
     expect(disposition.fixPrompt ?? "").toContain(`Fix the testbed page for mission ${run!.id}`);
     expect(disposition.fixPrompt ?? "").toContain("Smallest product move: Make the claim action visible with a blocked-state reason.");
   });

--- a/test/unit/self-healing.test.ts
+++ b/test/unit/self-healing.test.ts
@@ -218,6 +218,40 @@ describe("runSelfHealingOnce — orchestration (injected deps, no fs/network)", 
     expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "not_auto_fixable" });
   });
 
+  it("a testbed product signal escalates for human diagnosis instead of dispatching a code task", async () => {
+    const classify = vi.fn(() => LOW);
+    const h = harness([
+      signal({
+        autoFixable: false,
+        nonAutoFixableReason: "product_signal",
+        fixPrompt: "Fix mission m1 after a human maps the product evidence to a code surface.",
+      }),
+    ], { classify });
+    await runSelfHealingOnce(h.deps);
+    expect(classify).not.toHaveBeenCalled();
+    expect(h.proposed).toHaveLength(0);
+    expect(h.alerts).toBe(1);
+    expect(h.audits[0]).toMatchObject({ action: "escalate", reason: "not_auto_fixable" });
+  });
+
+  it("a real PR CI failure remains code-agent-actionable", async () => {
+    const h = harness([
+      signal({
+        surface: "pr:304",
+        source: "ci_main",
+        summary: "CI failed on PR #304 after tests started.",
+        evidence: "https://github.com/depre-dev/averray-reference-agent/pull/304",
+        repo: "depre-dev/averray-reference-agent",
+        area: "ci pr",
+      }),
+    ]);
+    const r = await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toEqual([{ surface: "pr:304", agent: "claude", riskTier: "low" }]);
+    expect(h.alerts).toBe(0);
+    expect(h.audits[0]).toMatchObject({ action: "propose", reason: "routed_fix", agent: "claude" });
+    expect(r.handled[0]).toMatchObject({ action: "propose", reason: "routed_fix" });
+  });
+
   it("dedup: an already-open fix task for the surface → skip (no second proposal)", async () => {
     const h = harness([signal()], { hasOpenFixTask: (targetSignature) => targetSignature === "testbed_mission:testbed:sweep-1" });
     await runSelfHealingOnce(h.deps);


### PR DESCRIPTION
## What changed & why

Root-caused the B2 self-healing loop and tightened the remaining unsafe path: structured testbed browser-mission product failures are now treated as operator-review evidence, not automatic code-agent fix targets. The richer testbed follow-up prompt is preserved for human handoff, but B2 only proposes for concrete code surfaces such as real PR/branch CI failures.

Updated the 2026-06-01 mission triage note with the Layer 1 / Layer 2 diagnosis and the new safe constraint.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No env, ops, migration, or runtime authority change. Rollback is reverting this PR. B2 remains proposal/escalation-only and human merge/deploy gates are unchanged.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

This PR intentionally does not fix any product/testbed blocker. If a failed mission is a real product regression, the operator should map it to a concrete issue/PR target before handing it to a code agent. Polkadot MCP double-check was not applicable: this change makes no chain/runtime claims.
