### PR TITLE
Polish: humanize self-healing titles at display time (fix legacy leak)

### DIFF
--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -33,7 +33,7 @@ import {
   testbedMissionStructuredReport,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
-import { testbedSurfaceKey } from "./self-healing.js";
+import { testbedSurfaceKey, surfaceLabel } from "./self-healing.js";
 import {
   isHermesDecisionRecord,
   type HermesDecisionRecord,
@@ -514,6 +514,19 @@ function asArray(value: unknown): unknown[] {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+// Self-healing task titles embed the namespaced surface key
+// ("Self-healing fix: testbed:testbed-mission-7"). Tasks persist their title
+// at creation time, so already-stored tasks keep the raw, doubled-looking
+// form. Strip the internal "<namespace>:" at display time so every card —
+// old or new — reads cleanly, matching how new proposals are now titled
+// (surfaceLabel in self-healing.ts).
+function humanizeTaskTitle(title: string): string {
+  return title.replace(
+    /^(Self-healing fix:\s*)(\S+)/,
+    (_match, prefix: string, surface: string) => `${prefix}${surfaceLabel(surface)}`,
+  );
 }
 
 function asFiniteNumber(value: unknown): number | undefined {
@@ -1304,7 +1317,7 @@ export function synthesizeTaskCards(
       lane: health.lane,
       type: "task",
       agentType: agent,
-      title: asString(task.title) ?? `${agent} task`,
+      title: humanizeTaskTitle(asString(task.title) ?? `${agent} task`),
       summary,
       repo: asString(task.repo) ?? "",
       freshness: health.freshness,

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1170,6 +1170,28 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     });
   });
 
+  it("humanizes persisted self-healing titles so the doubled surface namespace doesn't leak", () => {
+    const [card] = synthesizeTaskCards(
+      {
+        codexTasks: {
+          items: [{
+            id: "self-heal-x1",
+            status: "proposed",
+            agent: "claude",
+            repo: "a/b",
+            prompt: "fix it",
+            // Stored by an older build: "testbed:" namespace doubled with the
+            // "testbed-mission-…" key. The board must present it cleanly.
+            title: "Self-healing fix: testbed:testbed-mission-mpmo4ff2-1",
+          }],
+        },
+      },
+      undefined,
+    );
+    expect(card?.title).toBe("Self-healing fix: testbed-mission-mpmo4ff2-1");
+    expect(card?.title).not.toContain("testbed:testbed");
+  });
+
   it("promotes failed greenfield tasks to needs-attention with retry context", () => {
     const [card] = synthesizeTaskCards(
       {


### PR DESCRIPTION
Follow-up to #343. After #343 deployed, the board still showed `Self-healing fix: testbed:testbed-mission-…` — the doubled internal namespace.

**Why #343 didn't fully fix it:** #343 cleaned the title via `surfaceLabel()` **at task-creation time**. But a codex task persists its title when it's created, so every task stored by an older build keeps the raw `testbed:testbed-mission-…` form. Changing write-time code never rewrites existing rows — so the leak survived on all pre-existing cards (and in the co-pilot narration, which reads `card.title`).

**Fix — humanize at display/read time.** The board-snapshot builder (`monitor-v2.ts`) now runs every codex-task card title through `humanizeTaskTitle()`, which strips the internal `<namespace>:` from the embedded surface key (reusing `surfaceLabel()` from #343). This cleans **every** card — old and new — and, because the co-pilot activity feed derives its narration from `card.title`, the right rail is fixed too.

```
Self-healing fix: testbed:testbed-mission-mpmo4ff2-1   →   Self-healing fix: testbed-mission-mpmo4ff2-1
```

The stored `task.title`, correlation ids, and dedup keys are untouched — this is presentation only.

## Tests
- `synthesizeTaskCards` renders a persisted doubled-prefix title as `Self-healing fix: testbed-mission-…` and asserts `testbed:testbed` no longer appears.
- Full suite green (**1279 passed**), typecheck clean, `@avg/monitor-ui` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)