### PR TITLE
fix: keep self-heal behind operator gate

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -2629,9 +2629,8 @@ function startOperatorRoutines() {
             requester: "hermes-self-healing",
             correlationId: `self-heal:${targetSignature}`,
           });
-          // Flow through the EXISTING approval/autopilot gate (B2 never approves).
           if (created && task.status === "proposed") {
-            await autoApproveProposedTask(task);
+            logger.info({ taskId: task.id, targetSignature }, "b2_self_healing_proposed_waiting_for_operator");
           }
           return { taskId: task.id };
         },

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -137,6 +137,7 @@ export interface TestbedMissionFixBrief {
 
 export type TestbedMissionSelfHealingReason =
   | "product_signal"
+  | "environment_or_auth_failure"
   | "runner_failed"
   | "invalid_report"
   | "missing_product_report";
@@ -712,6 +713,14 @@ export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): Te
     };
   }
 
+  if (testbedMissionEnvironmentOrAuthFailure(run, structuredReport)) {
+    return {
+      autoFixable: false,
+      reason: "environment_or_auth_failure",
+      summary: `Testbed mission ${run.id} failed on an environment/auth/runner boundary for ${run.targetUrl}: ${reason}`,
+    };
+  }
+
   const fixBrief = testbedMissionFixBrief(run);
   const fixPrompt = testbedMissionCodexFollowupPrompt(run);
   return {
@@ -723,6 +732,30 @@ export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): Te
     summary: `Testbed mission ${run.id} found a product blocker on ${run.targetUrl}: ${fixBrief.primaryBlocker}`,
     ...(fixPrompt ? { fixPrompt } : {}),
   };
+}
+
+function testbedMissionEnvironmentOrAuthFailure(
+  run: TestbedMissionRun,
+  report: TestbedMissionStructuredReport,
+): boolean {
+  const haystack = [
+    run.failureReason,
+    run.statusReason,
+    report.summary,
+    ...report.blockers,
+    ...report.confusingMoments,
+    ...report.recommendations,
+    ...report.evidence,
+    ...report.completedPath,
+  ].filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    .join("\n");
+
+  return [
+    /\b(?:http\s*)?(?:401|403)\b/i,
+    /unauthori[sz]ed|forbidden|access denied|authentication required|login required|sign[ -]?in required/i,
+    /cloudflare access|net::err_|err_name_not_resolved|econnrefused|connection refused/i,
+    /page load failed|navigation failed|browser context closed|target closed|timed out/i,
+  ].some((pattern) => pattern.test(haystack));
 }
 
 export function testbedMissionFixBrief(run: TestbedMissionRun): TestbedMissionFixBrief {

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -247,7 +247,7 @@ export interface SelfHealingDeps {
   /** In-memory cooldown: has this target been handled within the window? */
   inCooldown: (targetSignature: string, nowMs: number) => boolean;
   markHandled: (targetSignature: string, nowMs: number) => void;
-  /** Propose a `proposed` fix task and run it through the EXISTING gate. */
+  /** Propose a `proposed` fix task; operator/autopilot approval happens elsewhere. */
   propose: (input: {
     signal: FailureSignal;
     targetSignature: string;

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -520,6 +520,36 @@ describe("monitor testbed mission runs", () => {
     expect(disposition.fixPrompt ?? "").toContain("Smallest product move: Make the claim action visible with a blocked-state reason.");
   });
 
+  it("keeps auth/environment browser failures triage-only with no code-fix prompt", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: run!.id,
+        text: JSON.stringify({
+          verdict: "fail",
+          confidence: 0.9,
+          stoppedBeforeMutation: true,
+          mutationBoundaryNotes: ["Stopped before signing."],
+          completedPath: ["opened target URL", "HTTP 401 while loading the page"],
+          blockers: ["HTTP 401 Unauthorized before the app rendered."],
+          confusingMoments: ["The browser could not authenticate to the environment."],
+          recommendations: ["Have the operator re-run with a valid hosted session."],
+          evidence: ["GET https://testbed.example/app returned HTTP 401."],
+          scores: { orientation: 0 },
+        }),
+      },
+      Date.parse("2026-05-22T10:05:00.000Z"),
+    );
+
+    const disposition = testbedMissionSelfHealingDisposition(updated!);
+    expect(disposition).toMatchObject({
+      autoFixable: false,
+      reason: "environment_or_auth_failure",
+    });
+    expect(disposition.summary).toContain("environment/auth/runner boundary");
+    expect(disposition.fixPrompt).toBeUndefined();
+  });
+
   it("marks runner/report-pipeline failures as human-review, not auto-fixable", () => {
     const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
     const failed = failTestbedMissionRun(run!.id, {


### PR DESCRIPTION
## Summary
- classify auth/environment browser failures like HTTP 401 as non-auto-fixable mission triage with no Codex fix prompt
- stop B2 self-healing from auto-approving its own proposed fix tasks; proposals now remain proposed for operator/autopilot gate handling
- add regression coverage for the 401 testbed mission disposition

## Checks
- npm run typecheck
- npm test

## Affected surfaces
- slack-operator self-healing/testbed mission disposition
- unit tests

## Rollout / rollback
- No env, secrets, ops, or deployment changes. Roll back by reverting this PR if self-healing proposal routing needs to be restored.

## Notes
- Board-gated: agents can propose but not run fixes directly from B2; nothing reaches branch/PR without an approval gate.