### PR TITLE
P0-3: disable "Open on github" for no-PR cards (no repo-root fallback)

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
@@ -145,6 +145,16 @@ describe("buildDrawerFooter — done + generic variants", () => {
     find(f, "open-github").run!();
     expect(openUrl).toHaveBeenCalledWith("https://github.com/averray-agent/agent/pull/12");
   });
+
+  it("no-PR task card → Open on github is DISABLED, never the repo-root fallback (P0-3)", () => {
+    // A proposed task has a repo but no resolved PR yet. The old code fell back
+    // to githubUrlForCard()'s repo root; now it must be disabled with a reason.
+    const taskNoPr = card({ type: "task", id: "claude-task-x1", taskStatus: "proposed" });
+    const f = buildDrawerFooter(taskNoPr, {});
+    const open = find(f, "open-github");
+    expect(open.run).toBeUndefined();
+    expect(open.disabledReason).toBe("No PR yet — opens once the task proposes a change.");
+  });
 });
 
 describe("buildDrawerFooter — Ask Hermes on every variant", () => {

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
@@ -155,11 +155,17 @@ export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}):
       run: () => copy(card.id),
     });
   } else {
+    // Open the SPECIFIC PR — never the repo-root fallback. A task with no
+    // resolved PR has nothing to open yet; silently linking to the repo root
+    // sends the operator to the wrong target, so disable with an honest reason.
+    const prUrl = pullRequestUrlForCard(card);
     buttons.push({
       key: "open-github",
       label: "Open on github",
       kind: "primary",
-      ...(url ? { run: () => openUrl(url) } : { disabledReason: "No GitHub link for this card." }),
+      ...(prUrl
+        ? { run: () => openUrl(prUrl) }
+        : { disabledReason: "No PR yet — opens once the task proposes a change." }),
     });
   }
 


### PR DESCRIPTION
## What changed & why
Fixes **P0-3** (`docs/HERMES_BOARD_WORKFLOW_REDESIGN.md`). In the drawer footer's **default/task** variant, *"Open on github"* used `githubUrlForCard()`, which falls back to the **repo root** when a card has no resolved PR — silently linking the operator to the wrong target. That's a truth-boundary violation: the button looks like it opens *this* item but goes somewhere else.

Now the default/task variant requires `pullRequestUrlForCard()` (the specific PR). With no resolved PR the button is **disabled with an honest reason**: *"No PR yet — opens once the task proposes a change."*

- The **merge (action)** variant already required a PR-specific url — **not touched**.
- The **done** variant's *"View on github"* is unchanged (release-history cards legitimately link to the repo/PR).

**Accept:** no card silently links to the repo root; no-PR cards show a disabled, explained button.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (`@avg/monitor-ui` 464 passed; drawer-footer 12 passed incl. new no-PR case)
- [ ] docker compose config (no ops/Docker/compose change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate (this only changes whether a *link* renders; merge path untouched)
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new ungated agent power
- [x] No secrets committed/printed/logged
- [x] No change to how agents work — operator-facing copy/affordance only

## Known limits / follow-ups
Scoped strictly to P0-3. The sibling P0-4 ("Ask Hermes" visible response) is a separate task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)