### PR TITLE
Keep capacity signals off Hermes board

### DIFF
--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -14,6 +14,15 @@ interface BoardClassification {
 }
 
 const TERMINAL_CODEX_STATUSES = new Set(["completed", "cancelled", "failed", "terminal"]);
+const QUIET_AUTOMATION_REASONS = [
+  "dispatch_budget_exhausted",
+  "open_fix_cap_reached",
+  "retry_budget_exhausted",
+  "tick_budget_exhausted",
+  "halt_present",
+  "autopilot_suspended",
+  "dispatch_blocked",
+];
 
 export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBoardSnapshot | undefined {
   if (!isRecord(snapshot)) return undefined;
@@ -21,13 +30,15 @@ export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBo
   const activeTasks = activeCodexTaskMap(snapshot);
   const missionItems = arrayRecords(snapshot.testbedMissions)
     .map((run) => testbedMissionRunToMonitorItem(run as unknown as TestbedMissionRun));
-  const rawItems = dedupeItems([...arrayRecords(snapshot.active), ...arrayRecords(snapshot.recent), ...missionItems]);
+  const allRawItems = [...arrayRecords(snapshot.active), ...arrayRecords(snapshot.recent), ...missionItems];
+  const quietSelfHealingCapacitySignals = allRawItems.filter(isQuietSelfHealingCapacityEvent).length;
+  const rawItems = dedupeItems(allRawItems.filter((item) => !isQuietSelfHealingCapacityEvent(item)));
   const cards = rawItems
     .map((item) => boardCardFromItem(item, snapshot, activeTasks))
     .filter((item): item is HermesBoardCardSnapshot => Boolean(item))
     .slice(0, 10);
 
-  const counts = boardCounts(cards, snapshot);
+  const counts = boardCounts(cards, snapshot, { quietSelfHealingCapacitySignals });
   const runner = runnerSummary(snapshot);
   return {
     ...stringProp(snapshot, "generatedAt", "generatedAt"),
@@ -37,6 +48,21 @@ export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBo
     ...(runner ? { runner } : {}),
     items: cards,
   };
+}
+
+export function isQuietAutomationCapacityReason(value: unknown): boolean {
+  const text = String(value || "").toLowerCase();
+  return QUIET_AUTOMATION_REASONS.some((reason) => text.includes(reason));
+}
+
+function isQuietSelfHealingCapacityEvent(item: Record<string, unknown>): boolean {
+  const summary = recordProp(item, "summary") ?? {};
+  return normalize(textProp(item, "intent")) === "self_healing"
+    && isQuietAutomationCapacityReason([
+      textProp(item, "reason"),
+      textProp(summary, "reason"),
+      textProp(summary, "finalReason"),
+    ].filter(Boolean).join(" "));
 }
 
 function boardCardFromItem(
@@ -323,7 +349,8 @@ function tagsForItem(item: Record<string, unknown>, summary: Record<string, unkn
 
 function boardCounts(
   cards: ReadonlyArray<HermesBoardCardSnapshot>,
-  snapshot: Record<string, unknown>
+  snapshot: Record<string, unknown>,
+  opts: { quietSelfHealingCapacitySignals?: number } = {},
 ): Record<string, number | string | boolean> {
   const counts: Record<string, number | string | boolean> = {
     attention: countLane(cards, "Needs Attention"),
@@ -352,6 +379,9 @@ function boardCounts(
     if (proposed !== undefined) counts.codexTasksProposed = proposed;
     if (approved !== undefined) counts.codexTasksApproved = approved;
     if (taskRunning !== undefined) counts.codexTasksRunning = taskRunning;
+  }
+  if (opts.quietSelfHealingCapacitySignals !== undefined) {
+    counts.selfHealingCapacitySignals = opts.quietSelfHealingCapacitySignals;
   }
   return counts;
 }

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -18,7 +18,10 @@
 // The output is what `GET /monitor/v2/board` serializes and what the
 // SSE `board.snapshot` event carries.
 
-import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
+import {
+  buildHermesBoardSnapshotFromMonitor,
+  isQuietAutomationCapacityReason,
+} from "./monitor-hermes-board.js";
 import {
   aggregateLlmUsage,
   listActiveLlmUsageCalls,
@@ -266,6 +269,11 @@ export interface BoardSnapshotV2 {
   at: string;
   repo: string;
   llmUsage: LlmUsageAggregate;
+  automationHealth?: {
+    quietSignalCount: number;
+    selfHealingCapacitySignals: number;
+    taskHealthCapacitySignals: number;
+  };
 }
 
 // ── Lane normalization ──────────────────────────────────────────────
@@ -531,6 +539,10 @@ function humanizeTaskTitle(title: string): string {
 
 function asFiniteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function countValue(value: unknown): number {
+  return Math.max(0, Math.floor(asFiniteNumber(value) ?? 0));
 }
 
 function asNonEmptyString(value: unknown): string | undefined {
@@ -1286,6 +1298,7 @@ export function synthesizeTaskCards(
   for (const entry of asArray(codexTasks?.items)) {
     const task = asRecord(entry);
     if (!task) continue;
+    if (isQuietTaskHealthCapacityTask(task)) continue;
     const status = asString(task.status);
     if (!status || SYNTH_TERMINAL_TASK_STATUSES.has(status)) continue;
     if (asString(task.operatorDismissedAt)) continue;
@@ -1543,6 +1556,8 @@ export function buildV2BoardSnapshot(
   const missionIndex = indexTestbedMissions(rawSnapshot);
   const reviewRequests = reviewRequestsFromSnapshot(rawSnapshot);
   const runner = readRunner(rawSnapshot);
+  const quietSelfHealingCapacitySignals = countValue(classified?.counts?.selfHealingCapacitySignals);
+  const quietTaskHealthCapacitySignals = countQuietTaskHealthCapacitySignals(rawSnapshot);
   const sourceCards = items.map((item) => {
     const base = toBoardCard(item);
     const key = prKey(item.repo, item.number);
@@ -1588,7 +1603,44 @@ export function buildV2BoardSnapshot(
     llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents), {
       activeCalls: listActiveLlmUsageCalls(),
     }),
+    ...automationHealthProp(quietSelfHealingCapacitySignals, quietTaskHealthCapacitySignals),
   };
+}
+
+function automationHealthProp(
+  selfHealingCapacitySignals: number,
+  taskHealthCapacitySignals: number,
+): Pick<BoardSnapshotV2, "automationHealth"> | {} {
+  const quietSignalCount = selfHealingCapacitySignals + taskHealthCapacitySignals;
+  return quietSignalCount > 0
+    ? {
+        automationHealth: {
+          quietSignalCount,
+          selfHealingCapacitySignals,
+          taskHealthCapacitySignals,
+        },
+      }
+    : {};
+}
+
+function countQuietTaskHealthCapacitySignals(rawSnapshot: unknown): number {
+  const root = asRecord(rawSnapshot);
+  const codexTasks = asRecord(root?.codexTasks);
+  return asArray(codexTasks?.items)
+    .map((entry) => asRecord(entry))
+    .filter((task): task is Record<string, unknown> => Boolean(task))
+    .filter(isQuietTaskHealthCapacityTask)
+    .length;
+}
+
+function isQuietTaskHealthCapacityTask(task: Record<string, unknown>): boolean {
+  if (!asString(task.selfManagementEscalatedAt)) return false;
+  return isQuietAutomationCapacityReason([
+    asString(task.selfManagementEscalationReason),
+    asString(task.progressMessage),
+    asString(task.failureReason),
+    asString(task.reason),
+  ].filter(Boolean).join(" "));
 }
 
 function sourceCardCorrelationIdsForDedupe(

--- a/test/unit/monitor-hermes-board.test.ts
+++ b/test/unit/monitor-hermes-board.test.ts
@@ -123,6 +123,47 @@ describe("buildHermesBoardSnapshotFromMonitor", () => {
     });
   });
 
+  it("keeps self-healing capacity signals off the board and counts them quietly", () => {
+    const board = buildHermesBoardSnapshotFromMonitor({
+      generatedAt: "2026-06-01T10:00:00.000Z",
+      active: [
+        {
+          correlationId: "self-heal:testbed:overview",
+          title: "Self-healing budget exhausted",
+          intent: "self_healing",
+          status: "needs_review",
+          reason: "Escalated to operator: dispatch_budget_exhausted",
+          updatedAt: "2026-06-01T09:59:00.000Z",
+          summary: { kind: "self_healing", action: "escalate" },
+        },
+        {
+          correlationId: "self-heal:testbed:runs",
+          title: "Self-healing halted",
+          intent: "self_healing",
+          status: "needs_review",
+          reason: "Escalated to operator: halt_present",
+          updatedAt: "2026-06-01T09:58:00.000Z",
+          summary: { kind: "self_healing", action: "escalate" },
+        },
+        {
+          correlationId: "self-heal:testbed:agents",
+          title: "Self-healing dispatch blocked",
+          intent: "self_healing",
+          status: "needs_review",
+          reason: "Escalated to operator: dispatch_blocked:daily_budget_exhausted",
+          updatedAt: "2026-06-01T09:57:00.000Z",
+          summary: { kind: "self_healing", action: "escalate" },
+        },
+      ],
+      recent: [],
+    });
+
+    expect(board?.items).toEqual([]);
+    expect(board?.counts?.attention).toBe(0);
+    expect(board?.counts?.selfHealingCapacitySignals).toBe(3);
+    expect(board?.headline).toContain("no active PR handoffs need attention");
+  });
+
   it("forwards the PR head branch (flat headBranch and nested head.ref)", () => {
     const board = buildHermesBoardSnapshotFromMonitor({
       generatedAt: "2026-05-20T08:54:42.000Z",

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1371,6 +1371,91 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     });
   });
 
+  it("does not render self-healing capacity handoff events as cards", () => {
+    const snap = buildV2BoardSnapshot(
+      {
+        active: [{
+          title: "Self-healing cap reached",
+          status: "needs_review",
+          intent: "self_healing",
+          reason: "Escalated to operator: open_fix_cap_reached",
+          correlationId: "self-heal:testbed:overview",
+          ageLabel: "1m",
+          summary: { kind: "self_healing", action: "escalate" },
+        }],
+        recent: [],
+      },
+      { repo: "depre-dev/averray-reference-agent" },
+    );
+
+    expect(snap.cards).toEqual([]);
+    expect(snap.automationHealth).toMatchObject({
+      quietSignalCount: 1,
+      selfHealingCapacitySignals: 1,
+      taskHealthCapacitySignals: 0,
+    });
+  });
+
+  it("does not synthesize task-health capacity escalations as board cards", () => {
+    const snap = buildV2BoardSnapshot(
+      {
+        active: [],
+        recent: [],
+        codexTasks: {
+          items: [{
+            id: "codex-task-retry-exhausted",
+            status: "failed",
+            agent: "codex",
+            repo: "depre-dev/averray-reference-agent",
+            title: "Retry exhausted",
+            prompt: "Investigate this task.",
+            selfManagementEscalatedAt: "2026-06-01T09:58:00.000Z",
+            selfManagementEscalationReason: "retry_budget_exhausted",
+            updatedAt: "2026-06-01T09:58:00.000Z",
+          }],
+        },
+      },
+      { repo: "depre-dev/averray-reference-agent" },
+    );
+
+    expect(snap.cards).toEqual([]);
+    expect(snap.automationHealth).toMatchObject({
+      quietSignalCount: 1,
+      selfHealingCapacitySignals: 0,
+      taskHealthCapacitySignals: 1,
+    });
+  });
+
+  it("still renders ordinary failed tasks that need operator triage", () => {
+    const snap = buildV2BoardSnapshot(
+      {
+        active: [],
+        recent: [],
+        codexTasks: {
+          items: [{
+            id: "codex-task-real-failure",
+            status: "failed",
+            agent: "codex",
+            repo: "depre-dev/averray-reference-agent",
+            title: "Real failed task",
+            prompt: "Investigate this task.",
+            failureReason: "Claude work failed on a code change.",
+            updatedAt: "2026-06-01T09:58:00.000Z",
+          }],
+        },
+      },
+      { repo: "depre-dev/averray-reference-agent" },
+    );
+
+    expect(snap.cards).toHaveLength(1);
+    expect(snap.cards[0]).toMatchObject({
+      id: "codex-task-real-failure",
+      lane: "needs-attention",
+      type: "task",
+    });
+    expect(snap.automationHealth).toBeUndefined();
+  });
+
   it("collapses a failed testbed mission and its self-healing task into one actionable card", () => {
     const missionId = "testbed-mission-failed-1";
     const snap = buildV2BoardSnapshot(


### PR DESCRIPTION
## What changed & why

Implemented P0-1 from `docs/HERMES_BOARD_WORKFLOW_REDESIGN.md`: internal capacity/escalation signals no longer render as board cards.

- Self-healing handoff events with capacity reasons (`dispatch_budget_exhausted`, `open_fix_cap_reached`, `halt_present`, `autopilot_suspended`, `dispatch_blocked:*`, etc.) are filtered out before card classification.
- The legacy board snapshot keeps a quiet `counts.selfHealingCapacitySignals` counter instead of a work card.
- The v2 board also suppresses O5 task-health capacity escalations such as `retry_budget_exhausted`, and exposes a quiet `automationHealth` counter for the header/rail follow-up.
- Ordinary failed tasks still render as operator-triage cards; only capacity/backstop machinery is removed from the worklist.

Slack/D4 alert behavior is not changed by this PR.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No env, ops, migration, or authority change. Rollback by reverting this PR. The board will stop showing these internal machinery cards after deploy; Slack alerting remains the escalation channel.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

This is the subtractive P0-1 fix only. P1-4 can decide how to render the quiet automation-health counter in the existing header/rail. Polkadot MCP verification was not applicable: no chain/runtime facts or settlement behavior changed.
