### PR TITLE
fix: give operator cards one primary action

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -195,8 +195,8 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
-      await waitFor(() => expect(getByRole("button", { name: /Approve tester run/ })).toBeTruthy());
-      fireEvent.click(getByRole("button", { name: /Approve tester run/ }));
+      await waitFor(() => expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
       fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -208,14 +208,14 @@ describe("MonitorPage — container", () => {
     }
   });
 
-  test("the default dismiss POSTs task cards to the durable codex-task endpoint", async () => {
+  test("operator task cards do not expose secondary dismiss/snooze buttons", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
       cards: [taskCard()],
       at: "2026-05-28T10:30:00Z",
     }));
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
     try {
-      const { getByRole } = render(
+      const { getByRole, queryByRole } = render(
         <MonitorPage
           options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
           backlogSuggestions={{ enabled: false }}
@@ -225,81 +225,12 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
-      await waitFor(() => expect(getByRole("button", { name: "Dismiss" })).toBeTruthy());
-      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+      await waitFor(() => expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy());
+      expect(queryByRole("button", { name: "Dismiss" })).toBeNull();
+      expect(queryByRole("button", { name: "Snooze" })).toBeNull();
 
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(calledUrl).toBe("/monitor/codex-tasks/codex-task-1/dismiss");
-      expect(init.method).toBe("POST");
+      expect(fetchSpy).not.toHaveBeenCalled();
     } finally {
-      fetchSpy.mockRestore();
-    }
-  });
-
-  test("the default dismiss POSTs self-healing cards to the suppression-aware endpoint", async () => {
-    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
-      cards: [taskCard({
-        id: "codex-task-self-heal-1",
-        title: "Self-healing: failed mission",
-        correlationId: "self-heal:testbed_mission:testbed:sweep-1",
-      })],
-      at: "2026-05-28T10:30:00Z",
-    }));
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
-    try {
-      const { getByRole } = render(
-        <MonitorPage
-          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
-          backlogSuggestions={{ enabled: false }}
-          collaboration={{ enabled: false }}
-          alerts={{ enabled: false }}
-          autonomy={{ fetchMode: async () => null }}
-        />,
-        { wrapper },
-      );
-      await waitFor(() => expect(getByRole("button", { name: "Dismiss" })).toBeTruthy());
-      fireEvent.click(getByRole("button", { name: "Dismiss" }));
-
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(calledUrl).toBe("/monitor/self-healing-proposals/codex-task-self-heal-1/dismiss");
-      expect(init.method).toBe("POST");
-    } finally {
-      fetchSpy.mockRestore();
-    }
-  });
-
-  test("the default snooze POSTs a durable until timestamp", async () => {
-    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-05-28T10:30:00.000Z"));
-    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
-      cards: [taskCard()],
-      at: "2026-05-28T10:30:00Z",
-    }));
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
-    try {
-      const { getByRole } = render(
-        <MonitorPage
-          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
-          backlogSuggestions={{ enabled: false }}
-          collaboration={{ enabled: false }}
-          alerts={{ enabled: false }}
-          autonomy={{ fetchMode: async () => null }}
-        />,
-        { wrapper },
-      );
-      await waitFor(() => expect(getByRole("button", { name: "Snooze" })).toBeTruthy());
-      fireEvent.click(getByRole("button", { name: "Snooze" }));
-
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-      expect(calledUrl).toBe("/monitor/codex-tasks/codex-task-1/snooze");
-      expect(init.method).toBe("POST");
-      expect(JSON.parse(String(init.body))).toEqual({
-        untilMs: Date.parse("2026-05-28T11:00:00.000Z"),
-      });
-    } finally {
-      nowSpy.mockRestore();
       fetchSpy.mockRestore();
     }
   });

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -36,11 +36,12 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(within(container).getByText(/governance dispute UI/)).toBeTruthy();
   });
 
-  test("renders the action card with its CTA and Hermes verdict", () => {
+  test("renders the action card with one primary and Hermes verdict", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
     const view = within(container);
     expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
-    expect(view.getByText("Approve & merge")).toBeTruthy();
+    expect(view.getAllByRole("button", { name: "Approve merge" }).length).toBeGreaterThan(0);
+    expect(view.queryByText("Send back to Codex")).toBeNull();
     expect(view.getByText("Hermes verdict")).toBeTruthy();
   });
 
@@ -236,9 +237,8 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(queryByText("not_recorded")).toBeNull();
   });
 
-  test("waiting-on-operator card actions are real board controls", () => {
+  test("waiting-on-operator task card exposes one dispatch primary", () => {
     const onApproveTask = vi.fn();
-    const onCardClick = vi.fn();
     const board: MonitorBoard = {
       at: "2026-05-28T10:30:00Z",
       cards: [{
@@ -258,18 +258,17 @@ describe("BoardView — rich-mix board (open stream)", () => {
       }],
     };
     const { getByRole, getByText, queryByText } = render(
-      <BoardView board={board} status="open" onApproveTask={onApproveTask} onCardClick={onCardClick} keyboard={false} />,
+      <BoardView board={board} status="open" onApproveTask={onApproveTask} keyboard={false} />,
     );
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
-    fireEvent.click(getByRole("button", { name: "Investigate" }));
-    expect(onCardClick).toHaveBeenCalledWith("task-action-1");
+    expect(queryByText("Dismiss")).toBeNull();
+    expect(queryByText("Snooze")).toBeNull();
+    expect(queryByText("Investigate")).toBeNull();
     fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onApproveTask).toHaveBeenCalledWith("task-action-1");
 
     expect(getByText("Fix the failed mission")).toBeTruthy();
-    fireEvent.click(getByRole("button", { name: "Dismiss" }));
-    expect(queryByText("Fix the failed mission")).toBeNull();
   });
 
   test("renders backlog suggestions as a collapsed planner-only rail block", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -312,6 +312,13 @@ export function BoardView({
     });
   }, []);
 
+  const onApproveMergeCard = useCallback((card: BoardCard) => {
+    const pr = relatedPrForCard(card);
+    if (pr && typeof window !== "undefined") {
+      window.open(`https://github.com/${pr.repo}/pull/${pr.number}`, "_blank", "noopener,noreferrer");
+    }
+  }, []);
+
   // ── keyboard (§12) ──────────────────────────────────────────────
   useBoardKeyboard({
     enabled: keyboard,
@@ -445,10 +452,12 @@ export function BoardView({
                 onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
                 onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
                 onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
-                onDismiss={onDismissCard}
-                onSnooze={onSnoozeCard}
+                onApproveMerge={onApproveMergeCard}
+                onRerunMission={onRerunMission ? (c, freshness) => {
+                  const target = c.type === "mission" ? c.mission?.target : undefined;
+                  if (target) onRerunMission(target, freshness);
+                } : undefined}
                 onKeepWatching={(c) => onKeepWatchingCard(c.id)}
-                onInvestigate={onCardClick ? (c) => onCardClick(c.id) : undefined}
               />
             )}
           />

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -14,8 +14,8 @@ function fixture(id: string): BoardCard {
 }
 
 describe("Card — type coverage", () => {
-  test("PR action card: title, FRESH pip, risk pills, checks, verdict, CTA", () => {
-    const { container } = render(<Card card={fixture("agent #548")} />);
+  test("PR action card: title, FRESH pip, risk pills, checks, verdict, one working primary", () => {
+    const { container } = render(<Card card={fixture("agent #548")} onApproveMerge={vi.fn()} />);
     const view = within(container);
     expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
     expect(container.querySelector(".hm-card--action")).toBeTruthy();
@@ -27,8 +27,8 @@ describe("Card — type coverage", () => {
     expect(container.querySelector(".hm-checks-bar")).toBeTruthy();
     // Hermes verdict + CTA
     expect(view.getByText("Hermes verdict")).toBeTruthy();
-    expect(view.getByText("Approve & merge")).toBeTruthy();
-    expect(view.getByText("Send back to Codex")).toBeTruthy();
+    expect(view.getByRole("button", { name: "Approve merge" })).toBeTruthy();
+    expect(view.queryByText("Send back to Codex")).toBeNull();
   });
 
   test("mission card renders its summary and checks bar", () => {
@@ -178,15 +178,17 @@ describe("Card — state coverage", () => {
 describe("Card — interactivity", () => {
   test("with onClick: role button, fires on click, CTA buttons don't bubble", () => {
     const onClick = vi.fn();
-    const { container } = render(<Card card={fixture("agent #548")} onClick={onClick} />);
+    const onApproveMerge = vi.fn();
+    const { container } = render(<Card card={fixture("agent #548")} onClick={onClick} onApproveMerge={onApproveMerge} />);
     const root = container.querySelector(".hm-card") as HTMLElement;
     expect(root.getAttribute("role")).toBe("button");
     fireEvent.click(root);
     expect(onClick).toHaveBeenCalledTimes(1);
 
     // Clicking the primary CTA must not also trigger the card's onClick.
-    fireEvent.click(within(container).getByText("Approve & merge"));
+    fireEvent.click(within(container).getByText("Approve merge"));
     expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onApproveMerge).not.toHaveBeenCalled(); // first click only arms confirm
   });
 
   test("without onClick: role article", () => {
@@ -218,28 +220,25 @@ describe("Card — task approve (O3 dispatch)", () => {
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
   });
 
-  test("a waiting-on-operator task exposes real inline controls", () => {
+  test("a waiting-on-operator task exposes exactly one dispatch primary", () => {
     const onApprove = vi.fn();
     const onDismiss = vi.fn();
     const onSnooze = vi.fn();
     const onInvestigate = vi.fn();
-    const { getByRole } = render(
+    const { getByRole, queryByRole } = render(
       <Card
         card={proposed}
         onApprove={onApprove}
-        onDismiss={onDismiss}
-        onSnooze={onSnooze}
-        onInvestigate={onInvestigate}
       />,
     );
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
-    fireEvent.click(getByRole("button", { name: "Dismiss" }));
-    fireEvent.click(getByRole("button", { name: "Snooze" }));
-    fireEvent.click(getByRole("button", { name: "Investigate" }));
+    expect(queryByRole("button", { name: "Dismiss" })).toBeNull();
+    expect(queryByRole("button", { name: "Snooze" })).toBeNull();
+    expect(queryByRole("button", { name: "Investigate" })).toBeNull();
     expect(onApprove).not.toHaveBeenCalled();
-    expect(onDismiss).toHaveBeenCalledWith(proposed);
-    expect(onSnooze).toHaveBeenCalledWith(proposed);
-    expect(onInvestigate).toHaveBeenCalledWith(proposed);
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(onSnooze).not.toHaveBeenCalled();
+    expect(onInvestigate).not.toHaveBeenCalled();
   });
 
   test("humanizes guardrail enum codes while preserving raw codes on hover", () => {
@@ -288,6 +287,24 @@ describe("Card — task approve (O3 dispatch)", () => {
     const { queryByRole } = render(<Card card={running} onApprove={vi.fn()} />);
     expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
   });
+
+  test("watch-only in-flight cards show no action buttons even with handlers wired", () => {
+    const running = {
+      ...proposed,
+      waitingOn: { actor: "agent", tone: "info" },
+      taskStatus: "running",
+      state: "running",
+    } as unknown as BoardCard;
+    const { container } = render(
+      <Card
+        card={running}
+        onApprove={vi.fn()}
+        onApproveMerge={vi.fn()}
+        onRerunMission={vi.fn()}
+      />,
+    );
+    expect(within(container).queryAllByRole("button")).toHaveLength(0);
+  });
 });
 
 describe("Card — requested tester mission approve (T6)", () => {
@@ -310,18 +327,48 @@ describe("Card — requested tester mission approve (T6)", () => {
     const { getByRole, getByText } = render(<Card card={requestedMission} onApproveMission={vi.fn()} />);
     expect(getByText("Tester run requested")).toBeTruthy();
     expect(getByText("not started")).toBeTruthy();
-    expect(getByRole("button", { name: /Approve tester run/ })).toBeTruthy();
+    expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
   });
 
   test("approving a tester mission requires confirm before dispatching to the runner queue", () => {
     const onApproveMission = vi.fn();
     const { getByRole, getByText } = render(<Card card={requestedMission} onApproveMission={onApproveMission} />);
-    fireEvent.click(getByRole("button", { name: /Approve tester run/ }));
+    fireEvent.click(getByRole("button", { name: /Approve & dispatch/ }));
     expect(onApproveMission).not.toHaveBeenCalled();
-    expect(getByText(/Queue runner now\?/)).toBeTruthy();
+    expect(getByText(/Dispatch tester runner\?/)).toBeTruthy();
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onApproveMission).toHaveBeenCalledTimes(1);
     expect(onApproveMission.mock.calls[0]?.[0]?.id).toBe("testbed-mission-requested-1");
+  });
+
+  test("failed mission triage exposes exactly one Re-run primary", () => {
+    const failedMission = {
+      ...requestedMission,
+      id: "testbed-mission-failed-1",
+      lane: "needs-attention",
+      missionStatus: "failed",
+      isAction: true,
+      mission: {
+        verdict: "FAILED",
+        verdictTone: "fail",
+        confidence: 0.8,
+        target: "https://staging.example.test",
+        seed: "fresh",
+        path: [],
+        blockers: [],
+        evidence: [],
+        mutationBoundary: "No mutation crossed.",
+        recommendations: [],
+      },
+    } as unknown as BoardCard;
+    const onRerunMission = vi.fn();
+    const { getByRole, getByText, queryByRole } = render(<Card card={failedMission} onRerunMission={onRerunMission} />);
+    expect(getByRole("button", { name: "Re-run" })).toBeTruthy();
+    expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Re-run" }));
+    expect(getByText(/Re-run as a fresh mission\?/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+    expect(onRerunMission).toHaveBeenCalledWith(failedMission, "fresh");
   });
 });
 

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -22,6 +22,7 @@ import { useState } from "react";
 import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
+import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { ChecksBar } from "./ChecksBar.js";
 
 export type CardProps = {
@@ -32,14 +33,12 @@ export type CardProps = {
   onApprove?: (card: BoardCard) => void;
   /** Approve a requested tester mission (T6). Operator-only; runs through a confirm. */
   onApproveMission?: (card: BoardCard) => void;
-  /** Hide this card from the current monitor view. Local UI-only control. */
-  onDismiss?: (card: BoardCard) => void;
-  /** Temporarily hide this card from the current monitor view. Local UI-only control. */
-  onSnooze?: (card: BoardCard) => void;
+  /** Approve a PR for merge review. Opens/records only; humans still merge. */
+  onApproveMerge?: (card: BoardCard) => void;
+  /** Re-run a failed tester mission. */
+  onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
   /** "Keep watching" on the archive hint — cancel/extend this card's auto-archive. */
   onKeepWatching?: (card: BoardCard) => void;
-  /** Open the card's detail surface from an inline action. */
-  onInvestigate?: (card: BoardCard) => void;
 };
 
 // ── Helpers (mirror the bundle's small inline helpers) ──────────────
@@ -84,10 +83,9 @@ export function Card({
   onClick,
   onApprove,
   onApproveMission,
-  onDismiss,
-  onSnooze,
+  onApproveMerge,
+  onRerunMission,
   onKeepWatching,
-  onInvestigate,
 }: CardProps) {
   const isAction = Boolean(card.isAction);
   const isStale = card.state === "stale";
@@ -106,7 +104,6 @@ export function Card({
   // discriminated union means these are narrow per branch; we read them
   // defensively because the same Card renders every type.
   const verdict = (card as { verdict?: string }).verdict;
-  const action = (card as { action?: { primary: string; secondary?: string } }).action;
   const checks: CardChecks | undefined = card.checks;
   const closedAt = (card as { closedAt?: string }).closedAt;
   const verdictText = (card as { verdictText?: string }).verdictText;
@@ -186,9 +183,8 @@ export function Card({
           card={card}
           onApprove={onApprove}
           onApproveMission={onApproveMission}
-          onDismiss={onDismiss}
-          onSnooze={onSnooze}
-          onInvestigate={onInvestigate ?? onClick}
+          onApproveMerge={onApproveMerge}
+          onRerunMission={onRerunMission}
         />
       ) : null}
 
@@ -196,28 +192,6 @@ export function Card({
         <div className="hm-verdict">
           <span className="label">Hermes verdict</span>
           <HumanizedText text={verdict} />
-        </div>
-      ) : null}
-
-      {isAction && action ? (
-        <div className="hm-card-cta">
-          <button
-            type="button"
-            className="hm-btn hm-btn--action hm-btn--sm"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <HumanizedText text={action.primary} />
-            <span className="hm-kbd">A</span>
-          </button>
-          {action.secondary ? (
-            <button
-              type="button"
-              className="hm-btn hm-btn--ghost hm-btn--sm"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <HumanizedText text={action.secondary} />
-            </button>
-          ) : null}
         </div>
       ) : null}
 
@@ -374,66 +348,64 @@ function OperatorActions({
   card,
   onApprove,
   onApproveMission,
-  onDismiss,
-  onSnooze,
-  onInvestigate,
+  onApproveMerge,
+  onRerunMission,
 }: {
   card: BoardCard;
   onApprove?: (card: BoardCard) => void;
   onApproveMission?: (card: BoardCard) => void;
-  onDismiss?: (card: BoardCard) => void;
-  onSnooze?: (card: BoardCard) => void;
-  onInvestigate?: (card: BoardCard) => void;
+  onApproveMerge?: (card: BoardCard) => void;
+  onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
 }) {
   const [confirming, setConfirming] = useState(false);
   const agent = agentLabel(card.agentType);
   const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
   const taskStatus = (card as { taskStatus?: string }).taskStatus;
   const missionStatus = (card as { missionStatus?: string }).missionStatus;
-  const canApproveTask = card.type === "task" && taskStatus === "proposed" && Boolean(onApprove);
-  const canApproveMission = card.type === "mission" && missionStatus === "requested" && Boolean(onApproveMission);
-  const canApprove = canApproveTask || canApproveMission;
-  const approveLabel = canApproveMission ? "Approve tester run" : "Approve & dispatch";
-  const confirmLabel = canApproveMission ? "Queue runner now?" : `Dispatch to ${agent}?`;
-  const approve = canApproveMission ? onApproveMission : onApprove;
+  const missionTarget = card.type === "mission" ? card.mission?.target : undefined;
+  const relatedPr = card.type === "pr" ? relatedPrForCard(card) : undefined;
+  const primary =
+    card.type === "task" && taskStatus === "proposed" && onApprove
+      ? {
+          label: "Approve & dispatch",
+          confirm: `Dispatch to ${agent}?`,
+          run: () => onApprove(card),
+        }
+      : card.type === "mission" && missionStatus === "requested" && onApproveMission
+        ? {
+            label: "Approve & dispatch",
+            confirm: "Dispatch tester runner?",
+            run: () => onApproveMission(card),
+          }
+        : card.type === "mission" && missionStatus === "failed" && missionTarget && onRerunMission
+          ? {
+              label: "Re-run",
+              confirm: "Re-run as a fresh mission?",
+              run: () => onRerunMission(card, "fresh" as const),
+            }
+          : card.type === "pr" && card.isAction && relatedPr && onApproveMerge
+            ? {
+                label: "Approve merge",
+                confirm: "Open GitHub merge review?",
+                run: () => onApproveMerge(card),
+              }
+            : undefined;
 
-  if (!canApprove && !onDismiss && !onSnooze && !onInvestigate) return null;
-
-  const action = (handler: ((card: BoardCard) => void) | undefined) => (e: { stopPropagation: () => void }) => {
-    stop(e);
-    handler?.(card);
-  };
+  if (!primary) return null;
 
   if (!confirming) {
     return (
       <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Operator actions">
-        {canApprove ? (
-          <button
-            type="button"
-            className="hm-btn hm-btn--action hm-btn--sm"
-            onClick={(e) => {
-              stop(e);
-              setConfirming(true);
-            }}
-          >
-            {approveLabel}
-          </button>
-        ) : null}
-        {onDismiss ? (
-          <button type="button" className="hm-btn hm-btn--ghost hm-btn--sm" onClick={action(onDismiss)}>
-            Dismiss
-          </button>
-        ) : null}
-        {onSnooze ? (
-          <button type="button" className="hm-btn hm-btn--ghost hm-btn--sm" onClick={action(onSnooze)}>
-            Snooze
-          </button>
-        ) : null}
-        {onInvestigate ? (
-          <button type="button" className="hm-btn hm-btn--ghost hm-btn--sm" onClick={action(onInvestigate)}>
-            Investigate
-          </button>
-        ) : null}
+        <button
+          type="button"
+          className="hm-btn hm-btn--action hm-btn--sm"
+          onClick={(e) => {
+            stop(e);
+            setConfirming(true);
+          }}
+        >
+          {primary.label}
+        </button>
       </div>
     );
   }
@@ -441,7 +413,7 @@ function OperatorActions({
   return (
     <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Confirm operator action">
       <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
-        {confirmLabel}
+        {primary.confirm}
       </span>
       <button
         type="button"
@@ -449,7 +421,7 @@ function OperatorActions({
         onClick={(e) => {
           stop(e);
           setConfirming(false);
-          approve?.(card);
+          primary.run();
         }}
       >
         Confirm

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -21,14 +21,12 @@ export type CardRouterProps = {
   onApprove?: (card: BoardCard) => void;
   /** Approve a board-gated requested tester mission (T6). */
   onApproveMission?: (card: BoardCard) => void;
-  /** Hide a waiting-on-operator card from the current monitor view. */
-  onDismiss?: (card: BoardCard) => void;
-  /** Temporarily hide a waiting-on-operator card from the current monitor view. */
-  onSnooze?: (card: BoardCard) => void;
+  /** Approve a PR for merge review. Opens/records only; humans still merge. */
+  onApproveMerge?: (card: BoardCard) => void;
+  /** Re-run a failed tester mission. */
+  onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
   /** "Keep watching" on the archive hint — cancel this card's auto-archive. */
   onKeepWatching?: (card: BoardCard) => void;
-  /** Open the card's detail surface from an inline action. */
-  onInvestigate?: (card: BoardCard) => void;
 };
 
 export function CardRouter({
@@ -38,10 +36,9 @@ export function CardRouter({
   onDegradedAction,
   onApprove,
   onApproveMission,
-  onDismiss,
-  onSnooze,
+  onApproveMerge,
+  onRerunMission,
   onKeepWatching,
-  onInvestigate,
 }: CardRouterProps) {
   const renderer = pickRenderer(card);
 
@@ -66,10 +63,9 @@ export function CardRouter({
       onClick={onClick}
       onApprove={onApprove}
       onApproveMission={onApproveMission}
-      onDismiss={onDismiss}
-      onSnooze={onSnooze}
+      onApproveMerge={onApproveMerge}
+      onRerunMission={onRerunMission}
       onKeepWatching={onKeepWatching}
-      onInvestigate={onInvestigate}
     />
   );
 }


### PR DESCRIPTION
## What changed
- Enforced one resolving primary action per operator-facing card: Approve & dispatch, Approve merge, or Re-run.
- Removed secondary inline controls from cards and removed action buttons from watch-only/in-flight cards.
- Kept the merge gate explicit: Approve & dispatch only authorizes an agent/runner to start; Approve merge opens the GitHub merge review for a concrete PR and does not merge automatically.
- Updated monitor UI tests around proposed tasks, requested tester missions, failed mission triage, PR merge actions, and watch-only cards.

## Checks
- npm run typecheck
- npm test

## Surfaces
- Frontend monitor UI only.
- No backend, contracts, indexer, env, VPS secret, or deploy changes.

## Notes
- Board-gated flow is preserved: operator keeps dispatch and merge gates.