### PR TITLE
Add quiet automation health status line

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -184,6 +184,22 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getByText(/Live · 10:30:00/)).toBeTruthy();
   });
 
+  test("automation health stays a header gauge, not a decision-lane card", () => {
+    const board: MonitorBoard = {
+      at: "2026-06-01T12:00:00.000Z",
+      cards: [],
+      automationHealth: { selfHealingOpen: 2, dispatchUsedToday: 4, dispatchPerDayCap: 5 },
+    };
+    const { container, getByLabelText, getByText, queryByRole } = render(
+      <BoardView board={board} status="open" keyboard={false} />,
+    );
+
+    expect(getByText("Self-heal 2 open · dispatch 4/5")).toBeTruthy();
+    expect(getByLabelText("Automation health: Self-heal 2 open · dispatch 4/5")).toBeTruthy();
+    expect(queryByRole("article")).toBeNull();
+    expect(container.querySelector(".hm-lane--needs-attention .hm-card")).toBeNull();
+  });
+
   test("renders LLM usage when the monitor snapshot reports counters", () => {
     const board: MonitorBoard = {
       ...richBoard,

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -441,6 +441,7 @@ export function BoardView({
         <TopStrip
           counts={state.counts}
           liveAt={status === "open" ? liveLabel || undefined : undefined}
+          automationHealth={board?.automationHealth}
           onRefresh={onRefresh}
         />
       )}

--- a/packages/monitor-ui/src/components/TopStrip.test.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.test.tsx
@@ -91,4 +91,33 @@ describe("TopStrip", () => {
     const { getByText } = render(<TopStrip counts={calmCounts} deployHealth="DEGRADED" />);
     expect(getByText(/Deploy DEGRADED/)).toBeTruthy();
   });
+
+  test("renders one quiet automation-health gauge when provided", () => {
+    const { getByLabelText, getByText } = render(
+      <TopStrip
+        counts={calmCounts}
+        automationHealth={{ selfHealingOpen: 2, dispatchUsedToday: 4, dispatchPerDayCap: 5 }}
+      />,
+    );
+    expect(getByText("Self-heal 2 open · dispatch 4/5")).toBeTruthy();
+    expect(getByLabelText("Automation health: Self-heal 2 open · dispatch 4/5")).toBeTruthy();
+  });
+
+  test("folds Slack-only capacity signals into the same gauge line", () => {
+    const { getByLabelText, getByText } = render(
+      <TopStrip
+        counts={calmCounts}
+        automationHealth={{
+          selfHealingOpen: 2,
+          dispatchUsedToday: 4,
+          dispatchPerDayCap: 5,
+          quietSignalCount: 1,
+          selfHealingCapacitySignals: 1,
+          taskHealthCapacitySignals: 0,
+        }}
+      />,
+    );
+    expect(getByText("Self-heal 2 open · dispatch 4/5 · quiet 1")).toBeTruthy();
+    expect(getByLabelText("Automation health: Self-heal 2 open · dispatch 4/5 · quiet 1")).toBeTruthy();
+  });
 });

--- a/packages/monitor-ui/src/components/TopStrip.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.tsx
@@ -10,6 +10,7 @@
 // Visual contract is the bundle's `hm-top` block in styles/monitor.css.
 
 import type { KPICounts } from "../lib/monitor/board-state.js";
+import type { AutomationHealth } from "../lib/monitor/board-cache.js";
 
 export type TopStripProps = {
   /** Current KPI counts from `kpiCounts(cards)`. */
@@ -18,11 +19,13 @@ export type TopStripProps = {
   liveAt?: string;
   /** Deploy-health label shown in the rightmost KPI pill. Default "OK". */
   deployHealth?: "OK" | "DEGRADED" | "UNKNOWN";
+  /** Optional quiet gauge for Slack-only automation capacity signals. */
+  automationHealth?: AutomationHealth;
   /** Click handler for the refresh button (M5' wires the actual refresh). */
   onRefresh?: () => void;
 };
 
-export function TopStrip({ counts, liveAt, deployHealth = "OK", onRefresh }: TopStripProps) {
+export function TopStrip({ counts, liveAt, deployHealth = "OK", automationHealth, onRefresh }: TopStripProps) {
   return (
     <div className="hm-top" role="banner">
       <div className="hm-brand">
@@ -46,6 +49,7 @@ export function TopStrip({ counts, liveAt, deployHealth = "OK", onRefresh }: Top
           <span className="dot" aria-hidden />
           Deploy {deployHealth}
         </span>
+        {automationHealth ? <AutomationHealthPill health={automationHealth} /> : null}
       </div>
 
       <div className="hm-top-right">
@@ -64,6 +68,21 @@ export function TopStrip({ counts, liveAt, deployHealth = "OK", onRefresh }: Top
         </button>
       </div>
     </div>
+  );
+}
+
+function AutomationHealthPill({ health }: { health: AutomationHealth }) {
+  const quietSignals = Math.max(0, Math.floor(health.quietSignalCount ?? 0));
+  const text = [
+    `Self-heal ${health.selfHealingOpen} open`,
+    `dispatch ${health.dispatchUsedToday}/${health.dispatchPerDayCap}`,
+    quietSignals > 0 ? `quiet ${quietSignals}` : "",
+  ].filter(Boolean).join(" · ");
+  return (
+    <span className="hm-kpi hm-kpi--automation" aria-label={`Automation health: ${text}`}>
+      <span className="dot" aria-hidden />
+      {text}
+    </span>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/board-cache.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.test.ts
@@ -45,6 +45,16 @@ test("board.snapshot: missing cards array becomes []", () => {
   assert.deepEqual(next.cards, []);
 });
 
+test("board.snapshot: carries automation-health gauge data when present", () => {
+  const next = applyEventToBoard(baseBoard(), {
+    type: "board.snapshot",
+    at: "2026-05-27T17:35:00Z",
+    cards: [],
+    automationHealth: { selfHealingOpen: 2, dispatchUsedToday: 4, dispatchPerDayCap: 5 },
+  });
+  assert.deepEqual(next.automationHealth, { selfHealingOpen: 2, dispatchUsedToday: 4, dispatchPerDayCap: 5 });
+});
+
 // ── board.card.added ────────────────────────────────────────────────
 
 test("board.card.added: appends a new card", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -15,6 +15,17 @@ export interface MonitorBoard {
   llmUsage?: LlmUsageAggregate;
   /** Optional board-summary metrics; omitted means the UI must not fabricate them. */
   calmMetrics?: CalmBoardMetrics;
+  /** Quiet automation-capacity gauge. Omitted means the UI must omit it. */
+  automationHealth?: AutomationHealth;
+}
+
+export interface AutomationHealth {
+  selfHealingOpen: number;
+  dispatchUsedToday: number;
+  dispatchPerDayCap: number;
+  quietSignalCount?: number;
+  selfHealingCapacitySignals?: number;
+  taskHealthCapacitySignals?: number;
 }
 
 export interface LlmUsageModelRollup {
@@ -90,7 +101,10 @@ export function applyEventToBoard(
       const cards = Array.isArray(event.cards) ? (event.cards as BoardCard[]) : [];
       const at = typeof event.at === "string" ? event.at : new Date().toISOString();
       const calmMetrics = isRecord(event.calmMetrics) ? (event.calmMetrics as CalmBoardMetrics) : undefined;
-      return { cards, at, ...(calmMetrics ? { calmMetrics } : {}) };
+      const automationHealth = isAutomationHealth(event.automationHealth)
+        ? event.automationHealth
+        : undefined;
+      return { cards, at, ...(calmMetrics ? { calmMetrics } : {}), ...(automationHealth ? { automationHealth } : {}) };
     }
     case "board.card.added": {
       if (!prev) return prev;
@@ -145,4 +159,11 @@ export function applyEventToBoard(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isAutomationHealth(value: unknown): value is AutomationHealth {
+  if (!isRecord(value)) return false;
+  return Number.isFinite(value.selfHealingOpen)
+    && Number.isFinite(value.dispatchUsedToday)
+    && Number.isFinite(value.dispatchPerDayCap);
 }

--- a/packages/monitor-ui/src/lib/monitor/live-stream.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/live-stream.test.ts
@@ -151,7 +151,7 @@ function freshStream() {
 }
 
 test("LiveStream: tags a typeless named-event payload with the event name", () => {
-  // The M1' BoardSnapshotV2 body is `{ cards, at, repo }` — no `type`.
+  // The v2 BoardSnapshot body has board fields but no `type`.
   const { received, source } = freshStream();
   source.emitNamed("board.snapshot", JSON.stringify({ cards: [], at: "2026-05-28T00:00:00Z", repo: "x/y" }));
   assert.equal(received.length, 1);

--- a/packages/monitor-ui/src/lib/monitor/live-stream.ts
+++ b/packages/monitor-ui/src/lib/monitor/live-stream.ts
@@ -180,11 +180,12 @@ export class LiveStream {
       return;
     }
     // The server tags updates with the SSE event name (`event: board.snapshot`)
-    // but the JSON payload itself may omit a `type` discriminator — the M1'
-    // BoardSnapshotV2 is just `{ cards, at, repo }`. Recover the type from the
-    // event name so board-cache's applyEventToBoard() can dispatch on it. A
-    // `type` already in the payload always wins; the default "message" event
-    // (unnamed data) is not a meaningful board type, so we ignore it.
+    // but the JSON payload itself may omit a `type` discriminator — the v2
+    // BoardSnapshot body carries board state fields, not its own event type.
+    // Recover the type from the event name so board-cache's applyEventToBoard()
+    // can dispatch on it. A `type` already in the payload always wins; the
+    // default "message" event (unnamed data) is not a meaningful board type,
+    // so we ignore it.
     if (typeof parsed.type !== "string" && typeof e.type === "string" && e.type !== "message") {
       parsed = { ...parsed, type: e.type };
     }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -168,6 +168,13 @@ body { margin: 0; }
 .hm-kpi--ok .n    { background: var(--hm-sage-soft); color: var(--hm-sage-deep); }
 .hm-kpi--action   { background: var(--hm-amber-wash); border-color: var(--hm-amber-ring); color: var(--hm-amber-deep); }
 .hm-kpi--action .n{ background: var(--hm-amber-soft); color: var(--hm-amber-deep); }
+.hm-kpi--automation {
+  background: transparent;
+  border-color: var(--hm-line);
+  color: var(--hm-muted);
+  text-transform: none;
+  letter-spacing: 0.02em !important;
+}
 .hm-kpi--zero     { opacity: 0.55; }
 .hm-kpi .dot { width: 6px; height: 6px; border-radius: 999px; background: currentColor; opacity: 0.7; }
 

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -269,11 +269,20 @@ export interface BoardSnapshotV2 {
   at: string;
   repo: string;
   llmUsage: LlmUsageAggregate;
-  automationHealth?: {
-    quietSignalCount: number;
-    selfHealingCapacitySignals: number;
-    taskHealthCapacitySignals: number;
-  };
+  automationHealth?: AutomationHealth;
+}
+
+export interface AutomationHealth {
+  /** Non-terminal self-healing fix proposals currently open. */
+  selfHealingOpen: number;
+  /** Hermes/system-managed task proposals created today. */
+  dispatchUsedToday: number;
+  /** Same cap used by the dispatch/self-healing backstops. */
+  dispatchPerDayCap: number;
+  /** Slack-only capacity/escalation signals kept off the decision lanes. */
+  quietSignalCount: number;
+  selfHealingCapacitySignals: number;
+  taskHealthCapacitySignals: number;
 }
 
 // ── Lane normalization ──────────────────────────────────────────────
@@ -1275,6 +1284,7 @@ const SYNTH_TERMINAL_TASK_STATUSES = new Set(["completed", "cancelled"]);
 const APPROVED_STALE_MINUTES = 30;
 const RUNNING_STALE_MINUTES = 20;
 const REPEATED_FAILURE_ATTEMPTS = 2;
+const AUTOMATION_TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "cancelled"]);
 
 /**
  * Synthesize `codex-needed` cards for queued tasks the classifier won't
@@ -1603,24 +1613,11 @@ export function buildV2BoardSnapshot(
     llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents), {
       activeCalls: listActiveLlmUsageCalls(),
     }),
-    ...automationHealthProp(quietSelfHealingCapacitySignals, quietTaskHealthCapacitySignals),
+    automationHealth: automationHealthForBoard(rawSnapshot, snapshotAt, process.env, {
+      selfHealingCapacitySignals: quietSelfHealingCapacitySignals,
+      taskHealthCapacitySignals: quietTaskHealthCapacitySignals,
+    }),
   };
-}
-
-function automationHealthProp(
-  selfHealingCapacitySignals: number,
-  taskHealthCapacitySignals: number,
-): Pick<BoardSnapshotV2, "automationHealth"> | {} {
-  const quietSignalCount = selfHealingCapacitySignals + taskHealthCapacitySignals;
-  return quietSignalCount > 0
-    ? {
-        automationHealth: {
-          quietSignalCount,
-          selfHealingCapacitySignals,
-          taskHealthCapacitySignals,
-        },
-      }
-    : {};
 }
 
 function countQuietTaskHealthCapacitySignals(rawSnapshot: unknown): number {
@@ -1641,6 +1638,56 @@ function isQuietTaskHealthCapacityTask(task: Record<string, unknown>): boolean {
     asString(task.failureReason),
     asString(task.reason),
   ].filter(Boolean).join(" "));
+}
+
+interface AutomationCapacitySignalCounts {
+  selfHealingCapacitySignals?: number;
+  taskHealthCapacitySignals?: number;
+}
+
+export function automationHealthForBoard(
+  rawSnapshot: unknown,
+  now: Date = new Date(),
+  env: { HERMES_DISPATCH_PER_DAY_MAX?: string | undefined } = process.env,
+  capacitySignals: AutomationCapacitySignalCounts = {},
+): AutomationHealth {
+  const selfHealingCapacitySignals = Math.max(0, Math.floor(capacitySignals.selfHealingCapacitySignals ?? 0));
+  const taskHealthCapacitySignals = Math.max(0, Math.floor(capacitySignals.taskHealthCapacitySignals ?? 0));
+  const quietSignalCount = selfHealingCapacitySignals + taskHealthCapacitySignals;
+  const tasks = asArray(asRecord(asRecord(rawSnapshot)?.codexTasks)?.items)
+    .map(asRecord)
+    .filter((task): task is Record<string, unknown> => Boolean(task));
+  const today = now.toISOString().slice(0, 10);
+  const selfHealingOpen = tasks.filter((task) =>
+    asString(task.requester) === "hermes-self-healing"
+    && !AUTOMATION_TERMINAL_TASK_STATUSES.has(asString(task.status) ?? "")
+  ).length;
+  const dispatchUsedToday = tasks.filter((task) =>
+    isAutomationDispatchTask(task)
+    && asString(task.createdAt)?.slice(0, 10) === today
+  ).length;
+  return {
+    selfHealingOpen,
+    dispatchUsedToday,
+    dispatchPerDayCap: dispatchPerDayCap(env),
+    quietSignalCount,
+    selfHealingCapacitySignals,
+    taskHealthCapacitySignals,
+  };
+}
+
+function isAutomationDispatchTask(task: Record<string, unknown>): boolean {
+  const requester = asString(task.requester);
+  const approvedBy = asString(task.approvedBy);
+  return requester === "hermes"
+    || requester === "hermes-self-healing"
+    || approvedBy === "hermes-autopilot"
+    || approvedBy === "o5-self-management";
+}
+
+function dispatchPerDayCap(env: { HERMES_DISPATCH_PER_DAY_MAX?: string | undefined }): number {
+  const parsed = Number.parseInt(env.HERMES_DISPATCH_PER_DAY_MAX ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
 }
 
 function sourceCardCorrelationIdsForDedupe(

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -23,6 +23,7 @@ import {
   mapMissionReport,
   synthesizeTaskCards,
   taskHealthForBoard,
+  automationHealthForBoard,
 } from "../../services/slack-operator/src/monitor-v2.js";
 import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
 import type { HermesBoardCardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -1330,6 +1331,66 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     const task = snap.cards.find((c) => c.id === "claude-task-x1");
     expect(task?.type).toBe("task");
     expect(task?.taskStatus).toBe("proposed");
+    expect(snap.automationHealth).toMatchObject({
+      selfHealingOpen: 0,
+      dispatchPerDayCap: 10,
+    });
+  });
+
+  it("derives a quiet automation-health gauge from real task queue capacity", () => {
+    const raw = {
+      codexTasks: {
+        items: [
+          {
+            id: "self-heal-open",
+            status: "proposed",
+            requester: "hermes-self-healing",
+            createdAt: "2026-06-01T09:00:00.000Z",
+          },
+          {
+            id: "self-heal-done",
+            status: "completed",
+            requester: "hermes-self-healing",
+            createdAt: "2026-06-01T08:00:00.000Z",
+          },
+          {
+            id: "hermes-proposed",
+            status: "proposed",
+            requester: "hermes",
+            createdAt: "2026-06-01T07:00:00.000Z",
+          },
+          {
+            id: "o5-approved",
+            status: "approved",
+            approvedBy: "o5-self-management",
+            createdAt: "2026-06-01T06:00:00.000Z",
+          },
+          {
+            id: "operator-task",
+            status: "proposed",
+            requester: "operator",
+            createdAt: "2026-06-01T05:00:00.000Z",
+          },
+          {
+            id: "old-hermes-task",
+            status: "proposed",
+            requester: "hermes",
+            createdAt: "2026-05-31T23:00:00.000Z",
+          },
+        ],
+      },
+    };
+
+    expect(automationHealthForBoard(raw, new Date("2026-06-01T12:00:00.000Z"), {
+      HERMES_DISPATCH_PER_DAY_MAX: "5",
+    })).toEqual({
+      selfHealingOpen: 1,
+      dispatchUsedToday: 4,
+      dispatchPerDayCap: 5,
+      quietSignalCount: 0,
+      selfHealingCapacitySignals: 0,
+      taskHealthCapacitySignals: 0,
+    });
   });
 
   it("dedupes self-healing handoff cards when an actionable task exists for the same correlation", () => {
@@ -1453,7 +1514,11 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
       lane: "needs-attention",
       type: "task",
     });
-    expect(snap.automationHealth).toBeUndefined();
+    expect(snap.automationHealth).toMatchObject({
+      quietSignalCount: 0,
+      selfHealingCapacitySignals: 0,
+      taskHealthCapacitySignals: 0,
+    });
   });
 
   it("collapses a failed testbed mission and its self-healing task into one actionable card", () => {


### PR DESCRIPTION
## What changed & why

- Added a real `automationHealth` gauge to the v2 monitor board snapshot, derived from the Codex task queue: open Hermes self-healing fixes plus today's Hermes/system-managed dispatch usage against `HERMES_DISPATCH_PER_DAY_MAX`.
- Preserved that gauge through the live `board.snapshot` cache path.
- Rendered one quiet TopStrip status pill: `Self-heal N open · dispatch X/Y`.
- Added tests proving the gauge renders in the header and does not create decision-lane cards.

This implements `docs/HERMES_BOARD_WORKFLOW_REDESIGN.md` P1-4: automation health is visible in one quiet place, not as a worklist or a new view.

## Affected surfaces

- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run

- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Normal monitor/slack-operator deploy. Rollback by reverting this PR; it only adds an optional snapshot field and a quiet header pill.

## Durable invariants (AGENTS.md)

- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- No diagnostics view and no worklist by design.
- The status line is display-only: it does not approve, dispatch, merge, deploy, or mutate queue state.