### PR TITLE
fix(monitor): make "Ask Hermes" visibly respond (P0-4)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -131,10 +131,51 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(onMute.mock.calls[0]?.[0]).toBeGreaterThan(Date.now() + 59 * 60_000);
   });
 
-  test("Ask Hermes float focuses the composer when no drawer is open", () => {
-    const { getByRole } = render(<BoardView board={richBoard} status="open" keyboard={false} />);
+  test("Ask Hermes float gives immediate feedback and focuses the composer (collaboration on)", () => {
+    const { getByRole, getByText } = render(
+      <BoardView
+        board={richBoard}
+        status="open"
+        keyboard={false}
+        collaboration={{ fetcher: async () => [], poster: async () => {}, refreshIntervalMs: 0 }}
+      />,
+    );
     fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
+    // P0-4: the action is visibly acknowledged (transient status line)…
+    expect(getByText(/Asking Hermes/)).toBeTruthy();
+    // …and the (enabled) composer takes focus.
     expect(getByRole("textbox", { name: "Ask Hermes, propose a task, spawn a mission, or mute alerts" })).toBe(document.activeElement);
+  });
+
+  test("Ask Hermes is honestly unavailable when collaboration is off — but wired commands still work (no silent drop)", () => {
+    // Wire a command handler (/mute) so the composer isn't Ask-only: the
+    // input must stay usable for commands while the free-form Ask path is
+    // honestly unavailable.
+    const onMute = vi.fn();
+    const { getByRole, getByText, container } = render(
+      <BoardView board={richBoard} status="open" keyboard={false} onMute={onMute} />,
+    );
+    fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
+    expect(getByText(/Ask Hermes unavailable/)).toBeTruthy();
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    expect(input.disabled).toBe(false);
+    // A free-form question reports unavailable instead of silently dropping…
+    fireEvent.change(input, { target: { value: "what's blocking?" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(getByRole("alert").textContent).toMatch(/Ask Hermes unavailable/);
+    // …but a wired command still dispatches.
+    fireEvent.change(input, { target: { value: "/mute 1h" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onMute).toHaveBeenCalledTimes(1);
+  });
+
+  test("Ask Hermes composer is fully disabled when it is Ask-only and collaboration is off", () => {
+    // No command handlers wired → Ask-only → the input is honestly disabled.
+    const { getByRole, container } = render(<BoardView board={richBoard} status="open" keyboard={false} />);
+    fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    expect(input.disabled).toBe(true);
+    expect(input.getAttribute("aria-label")).toMatch(/Ask Hermes unavailable/);
   });
 
   test("an open stream lights the LIVE indicator with the snapshot clock", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -180,6 +180,29 @@ export function BoardView({
   const [askToken, setAskToken] = useState(0);
   const [hermesFocusConversationActive, setHermesFocusConversationActive] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  // P0-4: every Ask-Hermes trigger must produce immediate visible feedback.
+  // We bump askToken (focuses the composer, which scrolls it into view),
+  // explicitly scroll the composer into view, and show a transient
+  // aria-live line ("Asking Hermes about {card}").
+  const [askStatus, setAskStatus] = useState<string | null>(null);
+  const askStatusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triggerAsk = useCallback((focusId: string | null, label?: string) => {
+    if (focusId) setBoardFocusId(focusId);
+    setAskToken((t) => t + 1);
+    // Scroll the composer into view so the operator sees where their
+    // question lands. Guarded + querySelector so it doesn't depend on the
+    // rail's internal structure and is a safe no-op under jsdom/tests.
+    if (typeof document !== "undefined") {
+      const composer = document.querySelector(".hm-compose-input");
+      (composer as HTMLElement | null)?.scrollIntoView?.({ behavior: "smooth", block: "nearest" });
+    }
+    setAskStatus(label ? `Asking Hermes about ${label}` : "Asking Hermes…");
+    if (askStatusTimer.current) clearTimeout(askStatusTimer.current);
+    askStatusTimer.current = setTimeout(() => setAskStatus(null), 4000);
+  }, []);
+  useEffect(() => () => {
+    if (askStatusTimer.current) clearTimeout(askStatusTimer.current);
+  }, []);
 
   // KPIs / banner / mode reflect the whole board, regardless of search.
   const state = useMemo(
@@ -335,8 +358,8 @@ export function BoardView({
       }
     },
     onAsk: (id) => {
-      setBoardFocusId(id);
-      setAskToken((t) => t + 1);
+      const card = orderedCards.find((c) => c.id === id);
+      triggerAsk(id, card?.title ?? id);
     },
   });
 
@@ -347,11 +370,12 @@ export function BoardView({
   // proposes / approves / opens GitHub through paths the board already uses.
   const drawerActions = useMemo<DrawerActionHandlers>(() => {
     const a: DrawerActionHandlers = {
-      // Ask Hermes: close the modal drawer, scope the rail composer to the card.
+      // Ask Hermes: close the modal drawer, scope the rail composer to the
+      // card, scroll it into view, and surface immediate "Asking Hermes
+      // about {card}" feedback (P0-4 — the action used to be silent).
       onAskHermes: (card) => {
         onCardClose?.();
-        setBoardFocusId(card.id);
-        setAskToken((t) => t + 1);
+        triggerAsk(card.id, card.title ?? card.id);
       },
     };
     if (onRerunMission) {
@@ -475,6 +499,14 @@ export function BoardView({
         />
       </div>
 
+      {/* P0-4: transient confirmation that an Ask-Hermes action was received.
+          aria-live so it's announced; visually a small floating toast. It
+          self-clears after a few seconds (the composer carries the durable
+          thinking/error state). */}
+      <div className="hm-ask-status" role="status" aria-live="polite">
+        {askStatus ? <span className="hm-ask-status-toast">{askStatus}</span> : null}
+      </div>
+
       {drawerCard ? (
         <DetailDrawer
           card={drawerCard}
@@ -491,8 +523,8 @@ export function BoardView({
           className="hm-ask-float"
           onClick={() => {
             const nextFocusId = boardFocusId ?? state.banner.primaryActionId ?? state.mostUrgent?.id ?? orderedCards[0]?.id ?? null;
-            if (nextFocusId) setBoardFocusId(nextFocusId);
-            setAskToken((t) => t + 1);
+            const card = nextFocusId ? orderedCards.find((c) => c.id === nextFocusId) : undefined;
+            triggerAsk(nextFocusId, card?.title ?? card?.id);
           }}
           aria-label="Ask Hermes"
         >

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -193,3 +193,45 @@ describe("AskHermesComposer — G3 compose chips + prefill", () => {
     expect(input.value).toBe("Investigate the flaky test");
   });
 });
+
+describe("AskHermesComposer — P0-4 feedback + honest disabled state", () => {
+  test("disables the input + send and never drops text when collaboration is off", () => {
+    const onAsk = vi.fn();
+    const { container, getByRole, getByText } = render(
+      <AskHermesComposer onAsk={onAsk} collaborationEnabled={false} />,
+    );
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    expect(input.disabled).toBe(true);
+    expect((getByRole("button", { name: /Send/ }) as HTMLButtonElement).disabled).toBe(true);
+    expect(getByText(/Ask Hermes unavailable/)).toBeTruthy();
+    // Even if a keyDown sneaks through, send() is a guarded no-op — no silent drop.
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onAsk).not.toHaveBeenCalled();
+  });
+
+  test("shows a 'Hermes thinking…' indicator while a question is pending", () => {
+    const { getByText, queryByText, rerender } = render(
+      <AskHermesComposer onAsk={vi.fn()} pending={false} />,
+    );
+    expect(queryByText(/Hermes thinking/)).toBeNull();
+    rerender(<AskHermesComposer onAsk={vi.fn()} pending />);
+    expect(getByText(/Hermes thinking/)).toBeTruthy();
+  });
+
+  test("shows an inline error when the POST failed (sendError)", () => {
+    const { getByRole } = render(
+      <AskHermesComposer onAsk={vi.fn()} sendError="Couldn't reach Hermes — your question wasn't sent. Try again." />,
+    );
+    expect(getByRole("alert").textContent).toMatch(/wasn't sent/);
+  });
+
+  test("a local parse error takes precedence over a stale sendError", () => {
+    const { container, getByRole } = render(
+      <AskHermesComposer onSpawnMission={vi.fn()} sendError="old send failure" />,
+    );
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/mission"); // invalid → local parse error
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(getByRole("alert").textContent).toMatch(/needs a target URL/);
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -41,6 +41,13 @@ export interface AskHermesComposerProps {
   focusedCardId?: string | null;
   /** Bump to programmatically focus the input (the board's `a` shortcut). */
   focusToken?: number;
+  /** When false the collaboration channel is off: the input is disabled
+   *  with an honest "Ask Hermes unavailable" message (no silent drop). */
+  collaborationEnabled?: boolean;
+  /** True while a posted question is awaiting Hermes's reply. */
+  pending?: boolean;
+  /** Inline error when the POST itself failed (question didn't send). */
+  sendError?: string | null;
 }
 
 export function AskHermesComposer({
@@ -58,7 +65,19 @@ export function AskHermesComposer({
   prefillToken,
   focusedCardId,
   focusToken,
+  collaborationEnabled = true,
+  pending = false,
+  sendError = null,
 }: AskHermesComposerProps) {
+  // The composer is a multi-purpose command line: /mission, /task, /mute,
+  // and autopilot dispatch to their own handlers and work regardless of the
+  // collaboration channel. So we only fully disable the input when Ask is
+  // the *only* thing it could do (no other command handler wired) and the
+  // channel is off. Otherwise the input stays usable and only the free-form
+  // Ask branch reports "unavailable" (never a silent drop).
+  const askOnly =
+    !onSpawnMission && !onSpawnClaudeTask && !onCreateTask && !onMute && !onUnmute && !onSetAutopilot && !onSetSupervised;
+  const inputDisabled = !collaborationEnabled && askOnly;
   const [value, setValue] = useState("");
   const [error, setError] = useState<string | null>(null);
   // Scope a question to the focused card or the whole board. When no card is
@@ -148,7 +167,12 @@ export function AskHermesComposer({
         }
         return;
       case "ask":
-        if (onAsk) {
+        // Honest unavailable state: when the collaboration channel is off we
+        // never silently drop a free-form question — we say so and keep the
+        // text so the operator can retry / use a command instead.
+        if (!collaborationEnabled) {
+          setError("Ask Hermes unavailable — the collaboration channel is offline.");
+        } else if (onAsk) {
           onAsk(command.text, { scope: effectiveScope });
           setValue("");
           setError(null);
@@ -213,22 +237,54 @@ export function AskHermesComposer({
         <textarea
           ref={inputRef}
           className="hm-compose-input"
-          placeholder="Ask Hermes · /task <agent> <repo> <prompt> · /mission <url> · /mute 1h"
-          aria-label="Ask Hermes, propose a task, spawn a mission, or mute alerts"
+          placeholder={
+            inputDisabled
+              ? "Ask Hermes unavailable — collaboration channel is offline"
+              : "Ask Hermes · /task <agent> <repo> <prompt> · /mission <url> · /mute 1h"
+          }
+          aria-label={
+            inputDisabled
+              ? "Ask Hermes unavailable — collaboration channel is offline"
+              : "Ask Hermes, propose a task, spawn a mission, or mute alerts"
+          }
           value={value}
+          disabled={inputDisabled}
           onChange={(e) => {
             setValue(e.target.value);
             if (error) setError(null);
           }}
           onKeyDown={onKeyDown}
         />
-        <button type="button" className="hm-compose-send" onClick={send}>
+        <button
+          type="button"
+          className="hm-compose-send"
+          onClick={send}
+          disabled={inputDisabled}
+          title={inputDisabled ? "Ask Hermes unavailable" : undefined}
+        >
           Send <span className="hm-kbd">⏎</span>
         </button>
       </div>
+      {!collaborationEnabled ? (
+        <div className="hm-compose-note" role="note" style={{ color: "var(--hm-muted)", fontSize: 12, marginTop: 6 }}>
+          Ask Hermes unavailable — the collaboration channel is offline.{!askOnly ? " Commands like /mission and /mute still work." : ""}
+        </div>
+      ) : pending ? (
+        <div className="hm-compose-thinking" role="status" aria-live="polite" style={{ color: "var(--hm-muted)", fontSize: 12, marginTop: 6 }}>
+          <span className="pulse" aria-hidden /> Hermes thinking…
+        </div>
+      ) : null}
+      {/* A failed local parse error and a failed POST are distinct: the
+          parse error is the composer's own state; sendError comes from the
+          hook. Show whichever is active (parse takes precedence as it
+          blocks the send entirely). */}
       {error ? (
         <div className="hm-compose-error" role="alert" style={{ color: "var(--hm-rose)", fontSize: 12, marginTop: 6 }}>
           {error}
+        </div>
+      ) : sendError ? (
+        <div className="hm-compose-error" role="alert" style={{ color: "var(--hm-rose)", fontSize: 12, marginTop: 6 }}>
+          {sendError}
         </div>
       ) : null}
     </div>

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -78,7 +78,9 @@ export function CoPilotRail({
   composerFocusToken,
   onScopedConversationChange,
 }: CoPilotRailProps) {
-  const { messages, ask } = useCollaboration(collaboration ?? { enabled: false });
+  const { messages, ask, enabled, pending, sendError } = useCollaboration(
+    collaboration ?? { enabled: false },
+  );
   const relatedPr = relatedPrForCard(focusedCard);
   const streamRef = useRef<HTMLDivElement>(null);
   // Suggestion chips fill the composer: hold the text + a bump token.
@@ -172,6 +174,9 @@ export function CoPilotRail({
         prefillToken={prefillToken}
         focusedCardId={focusedCard?.id ?? null}
         focusToken={composerFocusToken}
+        collaborationEnabled={enabled}
+        pending={pending}
+        sendError={sendError}
       />
     </aside>
   );

--- a/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
+++ b/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
@@ -57,5 +57,84 @@ describe("useCollaboration", () => {
     await Promise.resolve();
     expect(fetcher).not.toHaveBeenCalled();
     expect(result.current.messages).toEqual([]);
+    expect(result.current.enabled).toBe(false);
+  });
+
+  // P0-4: Ask-Hermes must produce immediate visible feedback.
+  test("ask optimistically renders the operator's message before the reply", async () => {
+    // A poster that never resolves: the optimistic message must show anyway.
+    let release: () => void = () => {};
+    const poster = vi.fn(() => new Promise<void>((res) => (release = res)));
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [], poster, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.ask("what's blocking?"));
+
+    // Optimistic operator message is present, and pending is true, with no error.
+    expect(result.current.messages.map((m) => m.text)).toContain("what's blocking?");
+    expect(result.current.messages.at(-1)?.author).toBe("operator");
+    expect(result.current.pending).toBe(true);
+    expect(result.current.sendError).toBeNull();
+    await act(async () => {
+      release();
+    });
+    await waitFor(() => expect(result.current.pending).toBe(false));
+  });
+
+  test("ask surfaces a send error (does NOT silently swallow) and rolls back the optimistic message", async () => {
+    const poster = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [], poster, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      result.current.ask("did CI pass?");
+    });
+
+    await waitFor(() => expect(result.current.sendError).toBeTruthy());
+    expect(result.current.pending).toBe(false);
+    // Rolled back: the un-sent question is not left dangling as if it landed.
+    expect(result.current.messages.map((m) => m.text)).not.toContain("did CI pass?");
+    expect(result.current.error).toBeFalsy(); // POST failure is sendError, not the feed error
+  });
+
+  test("ask does nothing when collaboration is disabled (honest no-op, not a silent post)", () => {
+    const poster = vi.fn(async () => {});
+    const { result } = renderHook(
+      () => useCollaboration({ enabled: false, fetcher: async () => [], poster }),
+      { wrapper },
+    );
+    act(() => result.current.ask("hello?"));
+    expect(poster).not.toHaveBeenCalled();
+    expect(result.current.pending).toBe(false);
+  });
+
+  test("optimistic message is reconciled away once the server feed echoes it", async () => {
+    let turns: CollaborationMessage[] = [];
+    const fetcher = vi.fn(async () => turns);
+    const poster = vi.fn(async () => {
+      turns = [msg("q", "operator", "status?"), msg("a", "hermes", "all green")];
+    });
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher, poster, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(fetcher).toHaveBeenCalled());
+
+    await act(async () => {
+      result.current.ask("status?");
+    });
+
+    // After the server echoes the operator message, we render exactly one
+    // copy (server's), not the optimistic duplicate.
+    await waitFor(() => expect(result.current.messages.map((m) => m.id)).toEqual(["q", "a"]));
+    expect(result.current.messages.filter((m) => m.text === "status?")).toHaveLength(1);
   });
 });

--- a/packages/monitor-ui/src/hooks/useCollaboration.ts
+++ b/packages/monitor-ui/src/hooks/useCollaboration.ts
@@ -6,7 +6,7 @@
 // reply shows up on the next poll, so the rail "answers" without any
 // bespoke streaming. Dependency-injected (fetcher, poster) for tests.
 
-import { useCallback } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
 import type { CollaborationMessage, CollaborationRelatedPr } from "../lib/monitor/collaboration.js";
 
@@ -34,6 +34,16 @@ export interface CollaborationState {
   ask: (text: string, relatedPr?: CollaborationRelatedPr) => void;
   isLoading: boolean;
   error: unknown;
+  /** Whether the rail is wired to a live collaboration channel at all. */
+  enabled: boolean;
+  /** True from the moment a question is posted until Hermes's reply lands
+   *  (or the post fails) — drives the "Hermes thinking…" indicator. */
+  pending: boolean;
+  /** Set when the POST itself failed; surfaced inline so the operator
+   *  knows the question did not reach Hermes (no silent drop). */
+  sendError: string | null;
+  /** Clear a prior send error (e.g. when the operator edits the input). */
+  clearSendError: () => void;
 }
 
 async function defaultFetcher(url: string): Promise<CollaborationMessage[]> {
@@ -74,18 +84,68 @@ export function useCollaboration(opts: UseCollaborationOptions = {}): Collaborat
     revalidateOnFocus: false,
   });
 
+  // Optimistic operator messages: rendered immediately so an Ask-Hermes
+  // action never sits silent for a poll interval. Each is reconciled away
+  // once the same text shows up in the fetched feed (server is the source
+  // of truth); on POST failure it's dropped and `sendError` is set.
+  const [optimistic, setOptimistic] = useState<CollaborationMessage[]>([]);
+  const [pending, setPending] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+  const seq = useRef(0);
+
+  const serverMessages = data ?? [];
+
+  // Drop any optimistic message the server feed has now echoed back, so we
+  // don't render the operator's question twice.
+  const pendingOptimistic = optimistic.filter(
+    (o) => !serverMessages.some((m) => m.author === "operator" && m.text === o.text),
+  );
+  const messages = useMemo(
+    () => [...serverMessages, ...pendingOptimistic],
+    [serverMessages, pendingOptimistic],
+  );
+
+  const clearSendError = useCallback(() => setSendError(null), []);
+
   const ask = useCallback(
     (text: string, relatedPr?: CollaborationRelatedPr) => {
       const trimmed = text.trim();
-      if (!trimmed) return;
+      if (!trimmed || !enabled) return;
+      seq.current += 1;
+      const optimisticId = `optimistic-${seq.current}`;
+      const optimisticMessage: CollaborationMessage = {
+        id: optimisticId,
+        ts: Date.now(), // "now" so the feed (sorted ascending by ts) renders it newest/last
+        author: "operator",
+        kind: "chat",
+        text: trimmed,
+        addressedTo: "hermes",
+        ...(relatedPr ? { relatedPr } : {}),
+      };
+      setOptimistic((prev) => [...prev, optimisticMessage]);
+      setSendError(null);
+      setPending(true);
       void poster({ text: trimmed, ...(relatedPr ? { relatedPr } : {}) })
         .then(() => mutate())
         .catch(() => {
-          /* surfaced via the feed / error state, not thrown */
-        });
+          // Do NOT swallow: roll back the optimistic message and surface
+          // the failure inline so the operator knows it didn't send.
+          setOptimistic((prev) => prev.filter((m) => m.id !== optimisticId));
+          setSendError("Couldn't reach Hermes — your question wasn't sent. Try again.");
+        })
+        .finally(() => setPending(false));
     },
-    [poster, mutate],
+    [enabled, poster, mutate],
   );
 
-  return { messages: data ?? [], ask, isLoading, error };
+  return {
+    messages,
+    ask,
+    isLoading,
+    error,
+    enabled,
+    pending,
+    sendError,
+    clearSendError,
+  };
 }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2366,3 +2366,32 @@ button.hm-turn-pin {
   white-space: nowrap;
   border: 0;
 }
+
+/* P0-4 · Ask-Hermes feedback.
+   A transient confirmation toast for any Ask-Hermes trigger, plus the
+   composer's "Hermes thinking…" indicator. The toast self-clears; the
+   durable pending/error state lives in the composer. */
+.hm-ask-status {
+  position: absolute;
+  right: 22px;
+  bottom: 72px; /* sits just above the .hm-ask-float pill */
+  pointer-events: none;
+  z-index: 20;
+}
+.hm-ask-status-toast {
+  display: inline-block;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--hm-ink);
+  color: #fffdf7;
+  box-shadow: var(--hm-shadow-pop);
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 12px;
+}
+.hm-compose-thinking .pulse,
+.hm-compose-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}


### PR DESCRIPTION
## What changed & why

`docs/HERMES_BOARD_WORKFLOW_REDESIGN.md` **P0-4** (BUG): "Ask Hermes" posted but gave **zero feedback** — the operator couldn't tell anything happened, and a failed POST was silently swallowed. Every Ask-Hermes action now produces immediate visible feedback, or an honest disabled state.

- **`useCollaboration` hook** — `ask()` now:
  - **optimistically renders** the operator's message immediately (no more silent ~4s wait for the next poll),
  - exposes **`pending`** (drives "Hermes thinking…") and **`sendError`** — the POST failure is **no longer swallowed**; the optimistic message is **rolled back** so a failed send never looks delivered,
  - reconciles the optimistic message away once the server feed echoes it,
  - exposes **`enabled`** so the composer knows the channel state.
- **`AskHermesComposer`** — "Hermes thinking…" indicator while pending; inline error on send failure. When collaboration is off, the free-form **Ask path is honestly unavailable** (sets the message, keeps the text — never a silent drop). The input is **fully disabled only when the composer is Ask-only**; `/mission`, `/task`, `/mute`, and autopilot still work when wired (they don't depend on the collaboration channel).
- **`BoardView`** — every Ask-Hermes trigger (card drawer action `~351-355`, keyboard `a`, float button) **scrolls the composer into view** and shows an immediate `aria-live` **"Asking Hermes about {card}"** confirmation.
- **`monitor.css`** — styles for the confirmation toast + thinking indicator.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Docs / tests only (tests)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (113 files, **1291** tests pass)
- [ ] docker compose config (n/a — no ops/Docker/compose touched)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new ungated agent power (UI-only feedback; introduces no new capability/authority)
- [x] No secrets committed/printed/logged
- [x] No change to how agents work → no `AGENTS.md` edit needed

## Truth-boundary
Feedback reflects **real** state and never fakes a healthier one: optimistic vs settled (reconciled against the server feed), pending vs replied, **send-failed vs delivered** (rolled back + surfaced), available vs offline. A templated/offline channel reads as unavailable, not as a silent success.

## Known limits / follow-ups
- The "Hermes thinking…" indicator clears when the **POST** resolves (the question reached the channel); the reply itself still arrives on the next poll, as before. A future change could keep "thinking" until the *reply* lands (would need a correlation id on the posted message).
- Honest reply labeling (live vs templated) is **P2-2**, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)