### PR TITLE
Full-height co-pilot rail

### DIFF
--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1151,11 +1151,13 @@ body { margin: 0; }
 .hm-hermes-stream::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
 
 .hm-activity {
+  flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid var(--hm-line-soft);
   background: linear-gradient(180deg, var(--hm-paper-2), var(--hm-paper));
+  overflow: hidden;
 }
 .hm-activity-head {
   padding: 12px 16px 0;
@@ -1170,7 +1172,8 @@ body { margin: 0; }
   color: var(--hm-ink);
 }
 .hm-activity-stream {
-  max-height: min(44vh, 520px);
+  flex: 1;
+  min-height: 0;
   padding-top: 10px;
 }
 .hm-activity-row {
@@ -1357,10 +1360,14 @@ button.hm-turn-pin {
 
 /* Compose */
 .hm-compose {
+  flex: 0 0 auto;
   padding: 10px 14px 14px;
   background: var(--hm-paper);
   border-top: 1px solid var(--hm-line-soft);
   display: grid; gap: 8px;
+  position: sticky;
+  bottom: 0;
+  z-index: 1;
 }
 .hm-compose-row {
   display: grid;


### PR DESCRIPTION
## What changed & why

- Removed the hard max-height cap from the Hermes activity stream.
- Let the activity section flex to fill the rail and scroll independently.
- Kept the composer pinned as the bottom rail control.

This implements docs/HERMES_BOARD_WORKFLOW_REDESIGN.md P2-1 so the co-pilot rail can show more turns without forcing page scroll.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] npm run typecheck
- [x] npm test
- [ ] docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config (only if ops/Docker/compose touched)

## Rollout / rollback

CSS-only monitor change. Roll back by reverting this commit.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power
- [x] No secrets committed/printed/logged
- [x] Updated AGENTS.md / affected docs if this changes how agents work

## Known limits / follow-ups

- Local preview was checked in degraded/offline mode; the CSS contract verified max-height: none, flex-grow: 1, independent stream scroll, and sticky composer.