### PR TITLE
fix: label Hermes live and templated replies

### DIFF
--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -51,6 +51,17 @@ describe("CoPilotRail", () => {
     expect(container.querySelector(".hm-turn-time")).toBeTruthy();
   });
 
+  test("shows one template-mode banner and labels offline Hermes replies", async () => {
+    const fetcher = vi.fn(async () => [
+      msg("1", "hermes", "Template answer from the board.", { hermesMode: "templated" }),
+      msg("2", "hermes", "Another template answer.", { hermesMode: "templated" }),
+    ]);
+    const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
+    await waitFor(() => expect(within(container).getByText(/Template answer from the board/)).toBeTruthy());
+    expect(within(container).getAllByText("Hermes (offline — templated)").length).toBeGreaterThan(0);
+    expect(within(container).getAllByText(/replies are templated/)).toHaveLength(1);
+  });
+
   test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
     const { getByText } = render(<CoPilotRail />, { wrapper });
     expect(getByText(/No real Hermes activity has been logged yet/)).toBeTruthy();

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -109,6 +109,10 @@ export function CoPilotRail({
     () => hasScopedConversation(messages, focusedCard),
     [focusedCard, messages],
   );
+  const templateModeObserved = useMemo(
+    () => messages.some((message) => message.author === "hermes" && message.hermesMode === "templated"),
+    [messages],
+  );
   useEffect(() => {
     onScopedConversationChange?.(scopedConversationActive);
   }, [onScopedConversationChange, scopedConversationActive]);
@@ -141,6 +145,12 @@ export function CoPilotRail({
         onCardClick={onCardClick}
         onUseInComposer={fillComposer}
       />
+
+      {templateModeObserved ? (
+        <div className="hm-hermes-mode-banner" role="status">
+          Hermes is offline — replies are templated until the live model key is configured.
+        </div>
+      ) : null}
 
       <section className="hm-activity" aria-label="Hermes activity">
         <div className="hm-activity-head">
@@ -219,7 +229,7 @@ function ActivityEntryRow({
       <div className="hm-turn-head">
         <span className="hm-turn-actor">
           <span className="actor-dot" aria-hidden />
-          {actorLabel(entry.actor)}
+          {entry.actorDisplay ?? actorLabel(entry.actor)}
         </span>
         <span className="hm-turn-kind">· {entry.kindLabel}</span>
         <span className="hm-turn-time">{formatTurnTime(entry.atMs)}</span>

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
@@ -24,6 +24,15 @@ describe("HermesTurn", () => {
     expect((container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--hermes");
   });
 
+  test("labels live and templated Hermes turns honestly", () => {
+    const live = render(<HermesTurn turn={{ ...base, id: "live", hermesMode: "live" }} />);
+    expect(live.getByText("Hermes (live)")).toBeTruthy();
+    live.unmount();
+
+    const templated = render(<HermesTurn turn={{ ...base, id: "templated", hermesMode: "templated" }} />);
+    expect(templated.getByText("Hermes (offline — templated)")).toBeTruthy();
+  });
+
   test("operator turns are labelled Pascal", () => {
     const { getByText } = render(<HermesTurn turn={{ ...base, id: "2", author: "operator" }} />);
     expect(getByText("Pascal")).toBeTruthy();

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
@@ -1,7 +1,7 @@
 // Hermes Handoff Monitor — a single collaboration turn (M8').
 
 import type { CollaborationMessage } from "../../lib/monitor/collaboration.js";
-import { actorLabel, formatTurnTime } from "../../lib/monitor/collaboration.js";
+import { actorLabelForMessage, formatTurnTime } from "../../lib/monitor/collaboration.js";
 
 export function HermesTurn({ turn }: { turn: CollaborationMessage }) {
   const prHref = turn.relatedPr
@@ -13,7 +13,7 @@ export function HermesTurn({ turn }: { turn: CollaborationMessage }) {
       <div className="hm-turn-head">
         <span className="hm-turn-actor">
           <span className="actor-dot" aria-hidden />
-          {actorLabel(turn.author)}
+          {actorLabelForMessage(turn)}
         </span>
         <span style={{ marginLeft: 4, opacity: 0.7, fontWeight: 500, letterSpacing: 0 }}>· {turn.kind}</span>
         <span className="hm-turn-time">{formatTurnTime(turn.ts)}</span>

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
@@ -120,6 +120,25 @@ describe("buildHermesActivityFeed", () => {
     });
   });
 
+  test("labels templated Hermes collaboration turns in activity", () => {
+    const entries = buildHermesActivityFeed({
+      cards: [],
+      messages: [message({
+        id: "hermes-template",
+        author: "hermes",
+        kind: "chat",
+        addressedTo: "operator",
+        text: "Template reply based on the board.",
+        hermesMode: "templated",
+        relatedPr: undefined,
+      })],
+      banner,
+      now: () => Date.parse("2026-05-28T10:05:00Z"),
+    });
+    const collaboration = entries.find((entry) => entry.id === "collaboration:hermes-template");
+    expect(collaboration?.text).toContain("Hermes (offline — templated) said");
+  });
+
   test("narrates review-panel responses without creating pretend chatter", () => {
     const entries = buildHermesActivityFeed({
       cards: [task({

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -6,7 +6,7 @@ import type {
   HermesDecisionRecord,
 } from "./card-types.js";
 import type { CollaborationAuthor, CollaborationMessage } from "./collaboration.js";
-import { actorLabel, formatTurnTime, relatedPrForCard } from "./collaboration.js";
+import { actorLabel, actorLabelForMessage, formatTurnTime, relatedPrForCard } from "./collaboration.js";
 import { humanizeSignalText } from "./signal-labels.js";
 
 export type ActivityTone = "neutral" | "info" | "action" | "success" | "warning";
@@ -17,6 +17,7 @@ export interface HermesActivityEntry {
   source: "board" | "decision" | "collaboration" | "review" | "summary";
   tone: ActivityTone;
   actor: CollaborationAuthor;
+  actorDisplay?: string;
   kindLabel: "narration" | "question" | "reply" | "proposal" | "request" | "status";
   text: string;
   meta?: string;
@@ -219,7 +220,7 @@ function reviewRequestActivity(card: BoardCard): HermesActivityEntry[] {
 }
 
 function collaborationActivity(message: CollaborationMessage, cardId: string | undefined): HermesActivityEntry {
-  const actor = actorLabel(message.author);
+  const actor = actorLabelForMessage(message);
   const target = message.addressedTo === "everyone" ? "the room" : actorLabel(message.addressedTo);
   const scope = message.relatedPr
     ? ` on ${message.relatedPr.repo}#${message.relatedPr.number}`
@@ -240,6 +241,7 @@ function collaborationActivity(message: CollaborationMessage, cardId: string | u
     source: "collaboration",
     tone: message.kind === "request_help" ? "action" : message.kind === "proposal" ? "info" : "neutral",
     actor: message.author,
+    actorDisplay: actor,
     kindLabel: collaborationKindLabel(message),
     text: `${actor} ${verb}${scope} to ${target}: ${plain(message.text)}`,
     meta: `${message.kind} · ${formatTurnTime(message.ts)}`,

--- a/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.test.ts
@@ -1,6 +1,6 @@
 import { test, assert } from "vitest";
 
-import { actorLabel, formatTurnTime, relatedPrForCard } from "./collaboration.js";
+import { actorLabel, actorLabelForMessage, formatTurnTime, relatedPrForCard } from "./collaboration.js";
 import type { BoardCard } from "./card-types.js";
 
 test("actorLabel maps authors to display names", () => {
@@ -10,6 +10,13 @@ test("actorLabel maps authors to display names", () => {
   assert.equal(actorLabel("test-writer"), "Test-writer");
   assert.equal(actorLabel("codex"), "Codex");
   assert.equal(actorLabel("system"), "System");
+});
+
+test("actorLabelForMessage labels Hermes live vs templated provenance", () => {
+  assert.equal(actorLabelForMessage({ author: "hermes", hermesMode: "live" }), "Hermes (live)");
+  assert.equal(actorLabelForMessage({ author: "hermes", hermesMode: "templated" }), "Hermes (offline — templated)");
+  assert.equal(actorLabelForMessage({ author: "hermes" }), "Hermes");
+  assert.equal(actorLabelForMessage({ author: "operator" }), "Pascal");
 });
 
 test("formatTurnTime renders HH:MM and tolerates a bad timestamp", () => {

--- a/packages/monitor-ui/src/lib/monitor/collaboration.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.ts
@@ -10,6 +10,7 @@ import type { BoardCard } from "./card-types.js";
 export type CollaborationAuthor = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
 export type CollaborationTarget = "everyone" | "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "operator";
+export type HermesReplyMode = "live" | "templated";
 
 export interface CollaborationRelatedPr {
   repo: string;
@@ -27,6 +28,7 @@ export interface CollaborationMessage {
   kind: CollaborationKind;
   text: string;
   addressedTo: CollaborationTarget;
+  hermesMode?: HermesReplyMode;
   relatedPr?: CollaborationRelatedPr;
   relatedCorrelationId?: string;
 }
@@ -54,6 +56,14 @@ export function actorLabel(author: CollaborationAuthor): string {
   if (author === "docs") return "Docs";
   if (author === "codex") return "Codex";
   return "System";
+}
+
+/** Display name for a concrete collaboration turn, including Hermes reply provenance. */
+export function actorLabelForMessage(message: Pick<CollaborationMessage, "author" | "hermesMode">): string {
+  if (message.author !== "hermes") return actorLabel(message.author);
+  if (message.hermesMode === "live") return "Hermes (live)";
+  if (message.hermesMode === "templated") return "Hermes (offline — templated)";
+  return "Hermes";
 }
 
 /** Short clock label (HH:MM) for a turn timestamp. */

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1123,6 +1123,17 @@ body { margin: 0; }
   vertical-align: 0;
   animation: hm-pulse 2s infinite;
 }
+.hm-hermes-mode-banner {
+  margin: 10px 16px 0;
+  padding: 9px 11px;
+  border-radius: var(--hm-radius-sm);
+  border: 1px solid rgba(157, 105, 54, 0.26);
+  background: rgba(245, 236, 220, 0.72);
+  color: var(--hm-ink-soft);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
 .hm-hermes-tools {
   margin-left: auto;
   display: flex; gap: 6px;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -1199,13 +1199,13 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
 
   const timer = setTimeout(async () => {
     let text = draft.text;
+    let hermesMode: "live" | "templated" = "templated";
     const memoryNotes = listHermesMemoryNotes({
       ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
       ...(operatorMessage.relatedCorrelationId ? { relatedCorrelationId: operatorMessage.relatedCorrelationId } : {}),
       limit: 8,
     }).map((note) => note.text);
-    const shouldLoadBoard = Boolean(apiKey) || memoryNotes.length > 0;
-    const board = shouldLoadBoard ? await loadHermesBoardSnapshotForReply(operatorMessage) : undefined;
+    const board = await loadHermesBoardSnapshotForReply(operatorMessage);
     const replyContext = {
       operatorMessage: {
         text: operatorMessage.text,
@@ -1239,6 +1239,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
         });
         if (llmText) {
           text = llmText;
+          hermesMode = "live";
         } else {
           logger.info({ id: operatorMessage.id }, "monitor_collaboration_llm_reply_unavailable_fell_back");
         }
@@ -1254,6 +1255,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
         author: "hermes",
         kind: "chat",
         text,
+        hermesMode,
         addressedTo: draft.addressedTo,
         ...(draft.relatedPr ? { relatedPr: draft.relatedPr } : {}),
         ...(draft.relatedCorrelationId ? { relatedCorrelationId: draft.relatedCorrelationId } : {}),
@@ -2982,6 +2984,7 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
       fallbackHermesBoardNarration(board, { memoryNotes }),
       narrationContext
     );
+    let hermesMode: "live" | "templated" = "templated";
     const apiKey = optionalEnv("OLLAMA_API_KEY");
     const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
     const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";
@@ -2995,7 +2998,10 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
           taskId: "monitor-board-narration",
           runId: decision.signature,
         });
-        if (llmText) text = llmText;
+        if (llmText) {
+          text = llmText;
+          hermesMode = "live";
+        }
       } catch (error) {
         logger.warn({ err: error }, "monitor_collaboration_board_narration_llm_threw");
       }
@@ -3008,6 +3014,7 @@ function scheduleHermesBoardNarration(snapshot: unknown): void {
         kind: "status",
         addressedTo: targetForHermesBoardNarration(board),
         text,
+        hermesMode,
         ...(relatedPr ? { relatedPr } : {}),
       });
       lastHermesBoardNarrationSignature = decision.signature;

--- a/services/slack-operator/src/monitor-collab.ts
+++ b/services/slack-operator/src/monitor-collab.ts
@@ -49,6 +49,7 @@ const KNOWN_TARGETS = new Set(["everyone", "claude", "codex", "test-writer", "se
 export type CollaborationAuthor = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "operator" | "system";
 export type CollaborationKind = "chat" | "proposal" | "request_help" | "status";
 export type CollaborationTarget = "everyone" | "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "operator";
+export type HermesReplyMode = "live" | "templated";
 export type ReviewRequester = "hermes" | "operator" | "codex" | "claude" | "test-writer" | "security" | "docs";
 export type ReviewRequestReviewer = "codex" | "claude" | "test-writer" | "security" | "docs" | "hermes" | "operator";
 export type ReviewRequestStatus = "requested" | "responded" | "cancelled";
@@ -69,6 +70,7 @@ export interface CollaborationMessage {
   kind: CollaborationKind;
   text: string;
   addressedTo: CollaborationTarget;
+  hermesMode?: HermesReplyMode;
   relatedPr?: CollaborationRelatedPr;
   relatedCorrelationId?: string;
 }
@@ -110,6 +112,7 @@ export interface RecordCollaborationInput {
   kind?: unknown;
   text?: unknown;
   addressedTo?: unknown;
+  hermesMode?: unknown;
   relatedPr?: unknown;
   relatedCorrelationId?: unknown;
 }
@@ -235,6 +238,7 @@ export function recordCollaborationMessage(
   }
   const relatedPr = normalizeRelatedPr(input.relatedPr);
   const relatedCorrelationId = normalizeCorrelationId(input.relatedCorrelationId);
+  const hermesMode = author === "hermes" ? normalizeHermesReplyMode(input.hermesMode) : undefined;
 
   const message: CollaborationMessage = {
     id: nextId(nowMs),
@@ -243,6 +247,7 @@ export function recordCollaborationMessage(
     kind,
     text,
     addressedTo: addressedTo ?? "everyone",
+    ...(hermesMode ? { hermesMode } : {}),
     ...(relatedPr ? { relatedPr } : {}),
     ...(relatedCorrelationId ? { relatedCorrelationId } : {}),
   };
@@ -562,6 +567,13 @@ function normalizeReviewStatus(value: unknown): ReviewRequestStatus | null {
   const v = value.trim().toLowerCase();
   if (v === "requested" || v === "responded" || v === "cancelled") return v;
   return null;
+}
+
+function normalizeHermesReplyMode(value: unknown): HermesReplyMode | undefined {
+  if (typeof value !== "string") return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "live" || v === "templated") return v;
+  return undefined;
 }
 
 function normalizeReviewVerdict(value: unknown): ReviewPanelVerdict | null {

--- a/test/unit/monitor-collab.test.ts
+++ b/test/unit/monitor-collab.test.ts
@@ -122,6 +122,30 @@ describe("monitor collaboration channel", () => {
     expect(message.relatedCorrelationId).toBe("smoke-2026-05-18-abc");
   });
 
+  it("records Hermes reply provenance but does not let non-Hermes turns claim it", () => {
+    const hermes = recordCollaborationMessage(
+      {
+        author: "hermes",
+        kind: "chat",
+        text: "The board says Codex owns the next move.",
+        addressedTo: "operator",
+        hermesMode: "LIVE",
+      },
+      NOW
+    );
+    const operator = recordCollaborationMessage(
+      {
+        author: "operator",
+        text: "ok",
+        hermesMode: "templated",
+      },
+      NOW + 1
+    );
+
+    expect(hermes.hermesMode).toBe("live");
+    expect(operator.hermesMode).toBeUndefined();
+  });
+
   it("drops malformed relatedPr without failing the record", () => {
     const message = recordCollaborationMessage(
       {


### PR DESCRIPTION
## What changed
- Added explicit Hermes reply provenance on collaboration messages: hermesMode = live or templated.
- Mark Hermes replies and board narrations as live only when an LLM response is actually used; fallback/template paths are templated.
- Load board context for Hermes auto-replies even when OLLAMA_API_KEY is unset, so templated replies still get current-board evidence.
- Label Hermes turns as Hermes (live) or Hermes (offline — templated) in the rail/activity feed.
- Show a single template-mode banner when offline templated Hermes replies are observed.

## Checks
- npm run typecheck
- npm test

## Surfaces
- Slack operator collaboration metadata/reply scheduling.
- Monitor UI co-pilot rail labels/banner.
- No env, deploy, contracts, or runner authority changes.

## Truth boundary
The operator can now distinguish inference from deterministic fallback templates. Live is claimed only when the model produced the text; otherwise the UI says offline/templated.