### PR TITLE
Add calm empty board state

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -406,9 +406,23 @@ describe("BoardView — degraded + transient states", () => {
   test("no board yet (connecting) renders the calm empty layout, not degraded", () => {
     const { container, getByText } = render(<BoardView board={undefined} status="connecting" />);
     expect(container.querySelector(".hm-now--degraded")).toBeNull();
-    expect(getByText(/Nothing waits on you/)).toBeTruthy();
+    expect(getByText(/Nothing needs you right now/)).toBeTruthy();
     // Still eight lanes, all empty.
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+  });
+
+  test("zero-decision board renders a deliberate success empty state", () => {
+    const board: MonitorBoard = { cards: [], at: "2026-06-01T10:00:00Z" };
+    const { container, getByText } = render(<BoardView board={board} status="open" />);
+    expect(container.querySelector(".hm-now--calm")).toBeTruthy();
+    expect(container.querySelector(".hm-now--degraded")).toBeNull();
+    expect(getByText(/Nothing needs you right now/)).toBeTruthy();
+    expect(getByText(/The board is quiet on purpose/)).toBeTruthy();
+    expect(
+      getByText("No active decisions, dispatches, or release work. Hermes is watching; you can step away.", {
+        selector: ".hm-now-sub",
+      }),
+    ).toBeTruthy();
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -197,11 +197,13 @@ test("boardNowBanner: Hermes focus mode uses the scoped review card", () => {
   assert.equal(banner.primaryActionId, "agent #548");
 });
 
-test("boardNowBanner: calm board with nothing in flight reads 'nothing waits on you'", () => {
+test("boardNowBanner: zero-decision board renders the first-class calm empty state", () => {
   const banner = boardNowBanner([], { nowLabel: "17:48:02 utc" });
   assert.equal(banner.tone, "calm");
   assert.match(banner.eyebrow, /you're done for now/);
-  assert.match(banner.headline, /Nothing waits on you/);
+  assert.match(banner.headline, /Nothing needs you right now/);
+  assert.match(banner.headline, /quiet on purpose/);
+  assert.match(banner.sub, /No active decisions, dispatches, or release work/);
 });
 
 test("boardNowBanner: calm sub only includes metrics the board model provides", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -206,7 +206,7 @@ export function boardNowBanner(cards: BoardCard[], opts: DeriveBoardOpts = {}): 
 
 function calmHeadline(counts: KPICounts): string {
   if (counts.total === 0) {
-    return "Nothing waits on you. Everything in flight is automation; the day's release history is below.";
+    return "Nothing needs you right now. The board is quiet on purpose.";
   }
 
   const automationCount = counts.checking + counts.queue + counts.deploying;
@@ -221,7 +221,12 @@ function calmHeadline(counts: KPICounts): string {
 }
 
 function calmSub(counts: KPICounts, metrics?: CalmBoardMetrics): string {
-  const base = counts.done > 0 ? `${counts.done} card(s) shipped today` : "No releases yet today";
+  const base =
+    counts.total === 0 && counts.done === 0
+      ? "No active decisions, dispatches, or release work"
+      : counts.done > 0
+        ? `${counts.done} card(s) shipped today`
+        : "No releases yet today";
   const parts = [base];
   if (metrics?.avgTimeToDecision) parts.push(`avg time-to-decision ${metrics.avgTimeToDecision}`);
   if (typeof metrics?.disputes === "number") parts.push(`${metrics.disputes} dispute(s)`);


### PR DESCRIPTION
## What changed & why

- Updated the calm zero-decision board copy to say "Nothing needs you right now" and frame the empty board as a deliberate success state.
- Adjusted the calm subline so a truly empty board does not imply hidden automation or missing release data.
- Added selector and BoardView coverage for the zero-decision empty state.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test`
- [x] `npm test -- packages/monitor-ui/src/lib/monitor/board-state.test.ts packages/monitor-ui/src/components/BoardView.test.tsx`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Monitor UI copy/test only. Roll back by reverting this PR if the empty-state wording needs another pass.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

No behavior or authority changes; this only clarifies the calm empty board state.