### PR TITLE
P1-1: hermes-checking stops being a junk drawer

### DIFF
--- a/packages/monitor-ui/src/components/Board.tsx
+++ b/packages/monitor-ui/src/components/Board.tsx
@@ -63,6 +63,10 @@ export type BoardProps = {
   renderCard?: (card: BoardCard) => ReactNode;
   /** Optional per-lane header content (e.g. the codex-needed create form, O3). */
   renderLaneHeader?: (id: LaneId) => ReactNode;
+  /** Optional whole-body renderer for a lane. When it returns a node, it
+   *  replaces the default `cards.map(renderCard)` (P1-1 uses this to group
+   *  the hermes-checking lane). Return `undefined` to use the default. */
+  renderLaneBody?: (id: LaneId, cards: BoardCard[]) => ReactNode | undefined;
 };
 
 export function Board({
@@ -72,6 +76,7 @@ export function Board({
   onToggleLane,
   renderCard,
   renderLaneHeader,
+  renderLaneBody,
 }: BoardProps) {
   const [internalExpanded, setInternalExpanded] = useState<Set<LaneId>>(() => new Set(initialExpanded));
   const isControlled = controlledExpanded !== undefined;
@@ -98,6 +103,7 @@ export function Board({
       {LANE_DESCRIPTORS.map((lane) => {
         const cards = grouped[lane.id] ?? [];
         const isExpanded = expanded.has(lane.id);
+        const customBody = renderLaneBody?.(lane.id, cards);
         return (
           <Lane
             key={lane.id}
@@ -107,7 +113,7 @@ export function Board({
             onToggle={onToggle}
             headerAccessory={renderLaneHeader?.(lane.id)}
           >
-            {renderCard ? cards.map(renderCard) : null}
+            {customBody !== undefined ? customBody : renderCard ? cards.map(renderCard) : null}
           </Lane>
         );
       })}

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -33,6 +33,7 @@ import { LanesBar } from "./LanesBar.js";
 import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
+import { HermesCheckingBody } from "./HermesCheckingBody.js";
 import { DetailDrawer } from "./drawer/DetailDrawer.js";
 import { missionReportText, type DrawerActionHandlers } from "../lib/monitor/drawer-footer.js";
 import { CoPilotRail } from "./hermes/CoPilotRail.js";
@@ -279,6 +280,25 @@ export function BoardView({
     [displayGrouped],
   );
 
+  // Shared per-card renderer — used directly by most lanes and re-used by the
+  // hermes-checking lane body (P1-1) so unrouted cards still render the same way.
+  const renderCard = (card: BoardCard) => (
+    <CardRouter
+      key={card.id}
+      card={card}
+      focused={card.id === boardFocusId}
+      onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
+      onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
+      onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
+      onApproveMerge={onApproveMergeCard}
+      onRerunMission={onRerunMission ? (c, freshness) => {
+        const target = c.type === "mission" ? c.mission?.target : undefined;
+        if (target) onRerunMission(target, freshness);
+      } : undefined}
+      onKeepWatching={(c) => onKeepWatchingCard(c.id)}
+    />
+  );
+
   const drawerCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
   const boardFocusedCard = boardFocusId ? orderedCards.find((c) => c.id === boardFocusId) : undefined;
   const scopeCard = drawerCard ?? boardFocusedCard;
@@ -469,22 +489,12 @@ export function BoardView({
                 ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
                 : undefined
             }
-            renderCard={(card) => (
-              <CardRouter
-                key={card.id}
-                card={card}
-                focused={card.id === boardFocusId}
-                onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
-                onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
-                onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
-                onApproveMerge={onApproveMergeCard}
-                onRerunMission={onRerunMission ? (c, freshness) => {
-                  const target = c.type === "mission" ? c.mission?.target : undefined;
-                  if (target) onRerunMission(target, freshness);
-                } : undefined}
-                onKeepWatching={(c) => onKeepWatchingCard(c.id)}
-              />
-            )}
+            renderCard={renderCard}
+            renderLaneBody={(id, laneCards) =>
+              id === "hermes-checking"
+                ? <HermesCheckingBody cards={laneCards} renderCard={renderCard} />
+                : undefined
+            }
           />
         </div>
 

--- a/packages/monitor-ui/src/components/HermesCheckingBody.test.tsx
+++ b/packages/monitor-ui/src/components/HermesCheckingBody.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { HermesCheckingBody } from "./HermesCheckingBody.js";
+import type { BoardCard } from "../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function card(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "card-x",
+    lane: "hermes-checking",
+    type: "pr",
+    agentType: "codex",
+    title: "Pre-checking the change",
+    summary: "summary",
+    repo: "depre-dev/agent",
+    freshness: 5,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "agent", tone: "info" },
+    files: [],
+    ...over,
+  } as BoardCard;
+}
+
+// A minimal renderer standing in for CardRouter — emits the card id as text.
+const renderCard = (c: BoardCard) => <div key={c.id} data-testid="card">{c.id}</div>;
+
+describe("HermesCheckingBody (P1-1)", () => {
+  test("every legit in-flight card shows a human status label + its title", () => {
+    const mission = card({ id: "m1", type: "mission", title: "Verify onboarding" });
+    const prCheck = card({ id: "pr1", waitingOn: { actor: "agent", tone: "info" } });
+    const ci = card({ id: "ci1", waitingOn: { actor: "CI", tone: "info" } });
+    const { getByText } = render(<HermesCheckingBody cards={[mission, prCheck, ci]} renderCard={renderCard} />);
+    expect(getByText("Mission running")).toBeTruthy();
+    expect(getByText("Pre-check")).toBeTruthy();
+    expect(getByText("CI watching")).toBeTruthy();
+    // The cards themselves still render.
+    expect(getByText("m1")).toBeTruthy();
+    expect(getByText("pr1")).toBeTruthy();
+  });
+
+  test("unrouted cards collapse into ONE quiet summary with a count, closed by default", () => {
+    const routed = card({ id: "routed-1", lane: "hermes-checking" });
+    const u1 = card({ id: "u1", lane: undefined as unknown as BoardCard["lane"] });
+    const u2 = card({ id: "u2", lane: undefined as unknown as BoardCard["lane"] });
+    const u3 = card({ id: "u3", lane: undefined as unknown as BoardCard["lane"] });
+    const { getByText, container } = render(
+      <HermesCheckingBody cards={[routed, u1, u2, u3]} renderCard={renderCard} />,
+    );
+    // A single de-emphasized summary with the count — not three loose cards.
+    expect(getByText("3 unrouted — source may be offline")).toBeTruthy();
+    const details = container.querySelector("details.hm-unrouted") as HTMLDetailsElement;
+    expect(details).toBeTruthy();
+    // Collapsed by default (no `open` attribute).
+    expect(details.open).toBe(false);
+    // The routed card is NOT inside the collapsed group.
+    expect(container.querySelector(".hm-unrouted")!.contains(getByText("routed-1"))).toBe(false);
+  });
+
+  test("no unrouted cards → no summary at all (a clean lane stays clean)", () => {
+    const { queryByText, container } = render(
+      <HermesCheckingBody cards={[card({ id: "ok-1" })]} renderCard={renderCard} />,
+    );
+    expect(container.querySelector("details.hm-unrouted")).toBeNull();
+    expect(queryByText(/unrouted/)).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/HermesCheckingBody.tsx
+++ b/packages/monitor-ui/src/components/HermesCheckingBody.tsx
@@ -1,0 +1,82 @@
+// Hermes Handoff Monitor — Hermes-checking lane body (P1-1)
+//
+// The `hermes-checking` lane used to be a junk drawer: every legitimately
+// in-flight card (a pre-check, a CI watch, a running mission) sat next to
+// any *unrouted* card that only landed here through laneFor()'s fallback —
+// all visually equal, none explained.
+//
+// This body splits the two:
+//   - Legit in-flight cards each get a status label ("Pre-check" /
+//     "CI watching" / "Mission running") so the operator reads them as
+//     deliberate progress with a reason.
+//   - Unrouted cards (a bug — the classifier/source dropped the lane) are
+//     rolled into ONE de-emphasized, collapsed-by-default summary with a
+//     count ("3 unrouted — source may be offline"). Honest, but quiet: the
+//     cards are still inspectable on expand, they just don't shout.
+
+import type { CSSProperties, ReactNode } from "react";
+import type { BoardCard } from "../lib/monitor/card-types.js";
+import { isUnroutedCard, inflightStatus } from "../lib/monitor/lane-rules.js";
+
+export type HermesCheckingBodyProps = {
+  cards: BoardCard[];
+  /** The shared per-card renderer (CardRouter) supplied by BoardView. */
+  renderCard: (card: BoardCard) => ReactNode;
+};
+
+const STATUS_LABEL_STYLE: CSSProperties = {
+  display: "block",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: "0.04em",
+  color: "var(--hm-muted)",
+  margin: "0 0 2px 2px",
+};
+
+const SUMMARY_STYLE: CSSProperties = {
+  cursor: "pointer",
+  listStyle: "none",
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  fontSize: 12,
+  color: "var(--hm-muted)",
+  padding: "6px 8px",
+  borderRadius: 8,
+  border: "1px dashed var(--hm-border, rgba(255,255,255,0.12))",
+};
+
+export function HermesCheckingBody({ cards, renderCard }: HermesCheckingBodyProps) {
+  const routed = cards.filter((card) => !isUnroutedCard(card));
+  const unrouted = cards.filter((card) => isUnroutedCard(card));
+
+  return (
+    <>
+      {routed.map((card) => (
+        <div key={card.id} className="hm-inflight">
+          <span className="hm-inflight-status" style={STATUS_LABEL_STYLE}>
+            {inflightStatus(card)}
+          </span>
+          {renderCard(card)}
+        </div>
+      ))}
+
+      {unrouted.length > 0 ? (
+        // Collapsed by default — native <details> with no `open` attribute.
+        <details className="hm-unrouted">
+          <summary className="hm-unrouted-summary" style={SUMMARY_STYLE}>
+            <span
+              className="fresh-dot"
+              style={{ background: "var(--hm-offline)" }}
+              aria-hidden
+            />
+            {unrouted.length} unrouted — source may be offline
+          </summary>
+          <div className="hm-unrouted-cards" style={{ marginTop: 6 }}>
+            {unrouted.map((card) => renderCard(card))}
+          </div>
+        </details>
+      ) : null}
+    </>
+  );
+}

--- a/packages/monitor-ui/src/lib/monitor/lane-rules.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/lane-rules.test.ts
@@ -3,7 +3,7 @@
 
 import { test, assert } from "vitest";
 
-import { laneFor, groupByLane, laneCounts } from "./lane-rules.js";
+import { laneFor, groupByLane, laneCounts, isUnroutedCard, inflightStatus } from "./lane-rules.js";
 import { LANES } from "./card-types.js";
 
 // ── Test fixtures ───────────────────────────────────────────────────
@@ -177,6 +177,52 @@ test("laneFor: card with no lane field defaults to hermes-checking", () => {
   const card = prCard({});
   delete card.lane;
   assert.equal(laneFor(card), "hermes-checking");
+});
+
+// ── isUnroutedCard: P1-1 — the fallback case is a bug, surfaced quietly ──
+
+test("isUnroutedCard: a card with no routing (no lane, generic type) is unrouted", () => {
+  const card = prCard({});
+  delete card.lane;
+  assert.equal(isUnroutedCard(card), true);
+});
+
+test("isUnroutedCard: null/undefined (the laneFor null fallback) is unrouted", () => {
+  assert.equal(isUnroutedCard(undefined), true);
+  assert.equal(isUnroutedCard(null), true);
+});
+
+test("isUnroutedCard: a card with an explicit hermes-checking lane is routed (legit in-flight)", () => {
+  assert.equal(isUnroutedCard(prCard({ lane: "hermes-checking" })), false);
+  assert.equal(isUnroutedCard(missionCard({ lane: "hermes-checking" })), false);
+});
+
+test("isUnroutedCard: typed/flagged cards are never unrouted (they route by type/flag)", () => {
+  const noLaneTask = taskCard({}); delete noLaneTask.lane;
+  const noLaneDeploy = deployCard({}); delete noLaneDeploy.lane;
+  const noLaneDone = doneCard({}); delete noLaneDone.lane;
+  const action = prCard({ isAction: true }); delete action.lane;
+  const draft = draftCard({ isDraft: true }); delete draft.lane;
+  assert.equal(isUnroutedCard(noLaneTask), false);
+  assert.equal(isUnroutedCard(noLaneDeploy), false);
+  assert.equal(isUnroutedCard(noLaneDone), false);
+  assert.equal(isUnroutedCard(action), false);
+  assert.equal(isUnroutedCard(draft), false);
+});
+
+// ── inflightStatus: every legit in-flight card gets a human reason ──
+
+test("inflightStatus: mission → 'Mission running'", () => {
+  assert.equal(inflightStatus(missionCard({ lane: "hermes-checking" })), "Mission running");
+});
+
+test("inflightStatus: CI signal (waitingOn CI or running checks) → 'CI watching'", () => {
+  assert.equal(inflightStatus(prCard({ lane: "hermes-checking", waitingOn: { actor: "CI", tone: "info" } })), "CI watching");
+  assert.equal(inflightStatus(prCard({ lane: "hermes-checking", checks: { pass: 1, running: 2, fail: 0, pending: 0, total: 3 } })), "CI watching");
+});
+
+test("inflightStatus: default PR pre-check → 'Pre-check'", () => {
+  assert.equal(inflightStatus(prCard({ lane: "hermes-checking", waitingOn: { actor: "agent", tone: "info" } })), "Pre-check");
 });
 
 // ── groupByLane ────────────────────────────────────────────────────

--- a/packages/monitor-ui/src/lib/monitor/lane-rules.ts
+++ b/packages/monitor-ui/src/lib/monitor/lane-rules.ts
@@ -29,6 +29,36 @@ export function laneFor(card: BoardCard | undefined | null): Lane {
 }
 
 /**
+ * P1-1: an "unrouted" card is one that only lands in `hermes-checking`
+ * through `laneFor()`'s fallback — it carries no routing (it isn't an
+ * action/draft, isn't a task/deploy/done, and has no explicit `lane`).
+ * That's a bug (the classifier or an upstream source dropped the lane),
+ * not a legitimate in-flight resident, so the UI renders these as a quiet,
+ * collapsed "N unrouted" summary instead of loose junk-drawer cards. They
+ * still appear in `hermes-checking` (laneFor is unchanged) — they're just
+ * no longer loud.
+ */
+export function isUnroutedCard(card: BoardCard | undefined | null): boolean {
+  if (!card) return true;
+  if (card.isAction || card.isDraft) return false;
+  if (card.type === "task" || card.type === "deploy" || card.type === "done") return false;
+  return !card.lane;
+}
+
+export type InflightStatus = "Pre-check" | "CI watching" | "Mission running";
+
+/**
+ * Human status label for a legitimate in-flight `hermes-checking` card, so
+ * every card in the lane reads as deliberate progress with a reason rather
+ * than mystery noise.
+ */
+export function inflightStatus(card: BoardCard): InflightStatus {
+  if (card.type === "mission") return "Mission running";
+  if (card.waitingOn?.actor === "CI" || (card.checks?.running ?? 0) > 0) return "CI watching";
+  return "Pre-check";
+}
+
+/**
  * Group cards by lane. Every lane appears in the result, even empty
  * ones — UI code can iterate the full LANES list and trust [].
  */


### PR DESCRIPTION
## What changed & why
Fixes **P1-1** (`docs/HERMES_BOARD_WORKFLOW_REDESIGN.md`). The `hermes-checking` lane was a junk drawer: legitimately in-flight cards (pre-check / CI watch / running mission) sat next to **unrouted** cards that only land here via `laneFor()`'s fallback (the classifier or an upstream source dropped the lane) — all visually equal, none explained.

This separates the two:

**`lane-rules.ts` — two pure helpers (heavily tested):**
- `isUnroutedCard(card)` — mirrors `laneFor()`'s fallback: a card with no routing (not action/draft, not task/deploy/done, no explicit `lane`). These are a **bug**, not a silent resident. `laneFor()` itself is unchanged — unrouted cards still belong to `hermes-checking`, they're just no longer loud.
- `inflightStatus(card)` — a human status label: **"Mission running"** / **"CI watching"** / **"Pre-check"**.

**`HermesCheckingBody` (new component) — the lane body:**
- Each legit in-flight card renders with its status label, so every card reads as deliberate progress with a reason.
- Unrouted cards roll into **one** de-emphasized, **collapsed-by-default** `<details>` summary with a count: *"3 unrouted — source may be offline"*. Honest but quiet — the cards are still inspectable on expand, they just don't shout.

**Wiring:** `Board` gains an optional `renderLaneBody` seam; `BoardView` uses it for `hermes-checking` only. Every other lane keeps the existing `cards.map(renderCard)` path.

**Accept:** every hermes-checking card has a human title + reason; unrouted noise is collapsed, not loud. ✅

## Affected surfaces
- [x] Monitor board / slack-operator (frontend `@avg/monitor-ui` only)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (`@avg/monitor-ui` 473 passed; lane-rules 23 + HermesCheckingBody 3 new)
- [ ] docker compose config (no ops/Docker/compose change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — purely presentational lane grouping
- [x] Wallet testnet-only / `HALT_FILE` / no new ungated agent power — unaffected
- [x] No secrets committed/printed/logged
- [x] Truth-boundary upheld: unrouted cards are surfaced honestly (a counted, expandable summary), not hidden, and not faked as healthy

## Known limits / follow-ups
Scoped to P1-1. The status labels use light inline styling (no `monitor.css` churn); a later pass can promote them to CSS classes if desired. Sibling items P1-2/P1-3/P1-4 are separate tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)