### PR TITLE
feat(monitor): hoist the decision onto operator cards (P1-2)

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -338,3 +338,54 @@ describe("Card — archive hint 'Keep watching' (G4)", () => {
     expect(getByText("Keep watching").tagName).toBe("SPAN");
   });
 });
+
+describe("Card — decision hoist (P1-2)", () => {
+  test("needs-attention card surfaces the decision summary + top reason in the body", () => {
+    const card = fixture("agent #542"); // needs-attention, has a decisionRecord
+    const { container } = render(<Card card={card} />);
+    const block = container.querySelector(".hm-card-decision");
+    expect(block).toBeTruthy();
+    const view = within(block as HTMLElement);
+    expect(view.getByText("Hermes decided")).toBeTruthy();
+    expect(view.getByText(/Escalated for triage/)).toBeTruthy();
+    // Top reason only — the full reason list stays in the drawer.
+    expect(view.getByText(/no reviewer assigned/)).toBeTruthy();
+    expect(view.queryByText(/no activity for 48h/)).toBeNull();
+  });
+
+  test("codex-needed card surfaces the decision in the body", () => {
+    const card = fixture("task starter-coding-014"); // codex-needed, has a decisionRecord
+    const { container } = render(<Card card={card} />);
+    const block = container.querySelector(".hm-card-decision");
+    expect(block).toBeTruthy();
+    expect(within(block as HTMLElement).getByText(/Proposed a bounded Codex task/)).toBeTruthy();
+  });
+
+  test("a card without a decision record shows no hoist (no fabricated rationale)", () => {
+    const card = fixture("agent #549"); // hermes-checking, no decisionRecord
+    const { container } = render(<Card card={card} />);
+    expect(container.querySelector(".hm-card-decision")).toBeNull();
+  });
+
+  test("the hoist is gated on the operator-decision lanes, not merely on having a record", () => {
+    const base = fixture("agent #547"); // release-queue
+    const withRecord = {
+      ...base,
+      decisionRecord: {
+        schemaVersion: 1 as const,
+        recordType: "hermes_decision_record" as const,
+        id: "dr-test",
+        kind: "routing" as const,
+        subject: { type: "pr" as const, id: base.id, repo: base.repo },
+        decision: "queue",
+        reasons: ["all checks green"],
+        inputs: {},
+        outcome: { summary: "Merge-ready; queued behind branch protection." },
+        safety: { readOnly: true, mutates: false },
+        generatedAt: "2026-05-29T10:00:00Z",
+      },
+    } as unknown as BoardCard;
+    const { container } = render(<Card card={withRecord} />);
+    expect(container.querySelector(".hm-card-decision")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -19,8 +19,9 @@
 //   - archiveHint = true → "archive in 4h?" tail line
 
 import { useState } from "react";
-import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType } from "../../lib/monitor/card-types.js";
+import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType, HermesDecisionRecord } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
+import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
 import { ChecksBar } from "./ChecksBar.js";
 
@@ -136,6 +137,17 @@ export function Card({
             <HumanizedText text={card.summary} />
           </span>
         </div>
+      ) : null}
+
+      {/* P1-2: hoist the decision onto operator-facing cards. On the two
+          lanes where the operator decides (needs-attention, codex-needed),
+          surface Hermes's outcome summary + top reason in the body so they
+          read *what they're deciding* without opening the drawer. The full
+          record (all reasons, safety, changed) still lives in the drawer's
+          "Why Hermes did this". Renders nothing when there's no decision
+          record — never a fabricated rationale. */}
+      {!isClosed && card.decisionRecord && isDecisionLane(card) ? (
+        <CardDecisionLine record={card.decisionRecord} />
       ) : null}
 
       {!isClosed && card.reviewRequests?.some((request) => request.status === "requested") ? (
@@ -352,6 +364,39 @@ function HumanizedText({ text }: { text: string | undefined }) {
         )
       ))}
     </>
+  );
+}
+
+// ── Decision hoist (P1-2) ───────────────────────────────────────────
+// The operator decides on cards in the needs-attention and codex-needed
+// lanes. We use laneFor() (the authoritative classifier) rather than
+// reading card.lane directly, per lane-rules.ts.
+
+function isDecisionLane(card: BoardCard): boolean {
+  const lane = laneFor(card);
+  return lane === "needs-attention" || lane === "codex-needed";
+}
+
+function CardDecisionLine({ record }: { record: HermesDecisionRecord }) {
+  const summary = record.outcome.summary?.trim();
+  const topReason = record.reasons.find((reason) => reason.trim().length > 0)?.trim();
+  // Nothing meaningful to hoist → render nothing rather than an empty box.
+  if (!summary && !topReason) return null;
+  return (
+    <div className="hm-card-decision" aria-label="Hermes decision">
+      <span className="hm-card-decision-label">Hermes decided</span>
+      {summary ? (
+        <span className="hm-card-decision-summary">
+          <HumanizedText text={summary} />
+        </span>
+      ) : null}
+      {topReason ? (
+        <span className="hm-card-decision-reason">
+          <span className="hm-card-decision-reason-dot" aria-hidden />
+          <HumanizedText text={topReason} />
+        </span>
+      ) : null}
+    </div>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/fixtures.ts
@@ -79,6 +79,27 @@ export const FIXTURE_CARDS: BoardCard[] = [
     prompt:
       "Coalesce repeated policy-attach entries into a single rolled-up row with a count and a 'last applied' timestamp. Do not change the on-chain audit record.",
     action: { kind: "codex-approve", primary: "Dispatch to Codex", secondary: "Edit prompt" },
+    decisionRecord: {
+      schemaVersion: 1,
+      recordType: "hermes_decision_record",
+      id: "dr-task-starter-coding-014",
+      kind: "routing",
+      subject: { type: "task", id: "task starter-coding-014", repo: "depre-dev/agent" },
+      decision: "propose Codex task",
+      reasons: [
+        "14 near-identical policy-attach entries on ops/schema-dual-sign in the last hour",
+        "Bounded, low-risk cleanup with a clear acceptance check",
+        "No on-chain audit record is touched",
+      ],
+      inputs: {},
+      outcome: {
+        summary:
+          "Proposed a bounded Codex task to roll up repeated policy-attach audit rows; awaiting operator approval to dispatch.",
+        waitingNext: "operator approval",
+      },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: "2026-05-29T11:40:00Z",
+    },
   },
 
   // ── Drafts (author hasn't finished) ──
@@ -203,6 +224,27 @@ export const FIXTURE_CARDS: BoardCard[] = [
     archiveHint: true,
     isAction: true,
     files: [],
+    decisionRecord: {
+      schemaVersion: 1,
+      recordType: "hermes_decision_record",
+      id: "dr-agent-542",
+      kind: "escalation",
+      subject: { type: "pr", id: "agent #542", repo: "depre-dev/agent", pullRequestNumber: 542 },
+      decision: "escalate to operator",
+      reasons: [
+        "Author marked ready 2 days ago with no reviewer assigned",
+        "Dependency bump touches the indexer — not auto-mergeable",
+        "Stale: no activity for 48h",
+      ],
+      inputs: {},
+      outcome: {
+        summary:
+          "Escalated for triage: a ready indexer dependency bump has sat 2 days with no reviewer; needs an operator to assign or close it.",
+        waitingNext: "operator triage",
+      },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: "2026-05-29T09:15:00Z",
+    },
   },
 
   // ── Done / release history — keep a representative slice ──

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2366,3 +2366,47 @@ button.hm-turn-pin {
   white-space: nowrap;
   border: 0;
 }
+
+/* P1-2 · Decision hoist on operator-facing cards.
+   Surfaces Hermes's outcome summary + top reason in the card body for the
+   needs-attention / codex-needed lanes, so the operator reads what they're
+   deciding without opening the drawer. A quiet sage-washed block — present
+   only when a decision record exists. */
+.hm-card-decision {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-left: 2px solid var(--hm-sage);
+  background: var(--hm-sage-wash);
+  border-radius: 0 8px 8px 0;
+  font-family: var(--font-body);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.hm-card-decision-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--hm-sage-deep);
+  font-weight: 600;
+}
+.hm-card-decision-summary {
+  color: var(--hm-ink-soft);
+}
+.hm-card-decision-reason {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--hm-muted);
+}
+.hm-card-decision-reason-dot {
+  flex: none;
+  width: 4px;
+  height: 4px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: var(--hm-sage);
+}


### PR DESCRIPTION
## What changed & why

`docs/HERMES_BOARD_WORKFLOW_REDESIGN.md` **P1-2** (REDESIGN): the operator should read *what they're deciding* without opening anything. Today `decisionRecord.outcome.summary` + reasons live only in the drawer's "Why Hermes did this".

On the two lanes where the operator decides — **needs-attention** and **codex-needed** — the card body now surfaces Hermes's **outcome summary + top reason** inline.

- **`Card.tsx`** — a quiet, sage-washed `CardDecisionLine`, rendered only when **both** hold: `laneFor(card)` is `needs-attention`/`codex-needed` (using the authoritative classifier per `lane-rules.ts`, not raw `card.lane`) **and** `card.decisionRecord` exists. It shows `outcome.summary` + `reasons[0]` only — the **full** record (all reasons, safety, changed) stays in the drawer, so this condenses rather than duplicates.
- **`monitor.css`** — styles for the decision block.
- **`fixtures.ts`** — added a `decisionRecord` to one needs-attention card (`agent #542`, escalation) and one codex-needed card (`task starter-coding-014`, routing) so the hoist is grounded and demonstrable.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Docs / tests only (tests + fixtures)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (113 files, **1285** tests pass; Card.test +4 P1-2 cases)
- [ ] docker compose config (n/a — no ops/Docker/compose touched)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet testnet-only; `HALT_FILE` honored; no new ungated agent power (read-only surfacing; introduces no capability/authority)
- [x] No secrets committed/printed/logged
- [x] No change to how agents work → no `AGENTS.md` edit needed

## Truth-boundary
Renders **nothing** when a card has no decision record — never a fabricated rationale. The hoist is gated on the operator-decision lanes (tested), so watch-only/in-flight cards don't sprout a decision block. The drawer remains the source of the full explanation; the card shows a faithful condensation.

## Known limits / follow-ups
- Surfaces `reasons[0]` as "the top reason" (reasons are emitted most-significant-first by the decision-record producer). If a future producer changes that ordering, this would need a ranking signal.
- The one-primary-action redesign is **P1-3**, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)