### PR TITLE
Surface agent discussion on monitor cards

### DIFF
--- a/packages/monitor-ui/src/components/cards/AgentDiscussion.tsx
+++ b/packages/monitor-ui/src/components/cards/AgentDiscussion.tsx
@@ -1,0 +1,41 @@
+import type { CardDiscussionMessage } from "../../lib/monitor/card-types.js";
+import { actorLabel, formatTurnTime } from "../../lib/monitor/collaboration.js";
+
+export function AgentDiscussion({
+  messages,
+  compact = false,
+}: {
+  messages?: readonly CardDiscussionMessage[];
+  compact?: boolean;
+}) {
+  if (!messages || messages.length === 0) return null;
+  const visible = compact ? messages.slice(-2) : messages;
+  const hidden = messages.length - visible.length;
+
+  return (
+    <section className={`hm-agent-discussion${compact ? " hm-agent-discussion--compact" : ""}`} aria-label="Agent discussion">
+      <div className="hm-agent-discussion-head">
+        <span className="hm-agent-discussion-dot" aria-hidden />
+        <span>Agent discussion</span>
+      </div>
+      <div className="hm-agent-discussion-list">
+        {visible.map((message) => (
+          <article className={`hm-agent-discussion-row hm-agent-discussion-row--${message.author}`} key={message.id}>
+            <div className="hm-agent-discussion-meta">
+              <strong>{discussionActorLabel(message)}</strong>
+              <span>{formatTurnTime(message.ts)}</span>
+            </div>
+            <p>{message.text}</p>
+          </article>
+        ))}
+      </div>
+      {hidden > 0 ? <div className="hm-agent-discussion-more">+{hidden} more in drawer</div> : null}
+    </section>
+  );
+}
+
+function discussionActorLabel(message: CardDiscussionMessage): string {
+  if (message.author === "hermes" && message.hermesMode === "live") return "Hermes (live)";
+  if (message.author === "hermes" && message.hermesMode === "templated") return "Hermes (offline - templated)";
+  return actorLabel(message.author);
+}

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -94,6 +94,45 @@ describe("Card — type coverage", () => {
     expect(within(container).getByText("Hermes, Codex, Claude")).toBeTruthy();
   });
 
+  test("card shows real scoped Hermes/agent discussion inline", () => {
+    const card: BoardCard = {
+      ...fixture("agent #547"),
+      discussion: [
+        {
+          id: "hermes-1",
+          ts: Date.parse("2026-06-01T10:01:00.000Z"),
+          author: "hermes",
+          kind: "status",
+          text: "Contract test X is red.",
+          addressedTo: "codex",
+          hermesMode: "live",
+        },
+        {
+          id: "codex-1",
+          ts: Date.parse("2026-06-01T10:02:00.000Z"),
+          author: "codex",
+          kind: "chat",
+          text: "Fixing via Y.",
+          addressedTo: "hermes",
+        },
+      ],
+    };
+
+    const { container } = render(<Card card={card} />);
+    const discussion = container.querySelector(".hm-agent-discussion");
+    expect(discussion).toBeTruthy();
+    expect(within(discussion as HTMLElement).getByText("Agent discussion")).toBeTruthy();
+    expect(within(discussion as HTMLElement).getByText("Hermes (live)")).toBeTruthy();
+    expect(within(discussion as HTMLElement).getByText("Contract test X is red.")).toBeTruthy();
+    expect(within(discussion as HTMLElement).getByText("Codex")).toBeTruthy();
+    expect(within(discussion as HTMLElement).getByText("Fixing via Y.")).toBeTruthy();
+  });
+
+  test("card without discussion stays clean", () => {
+    const { container } = render(<Card card={fixture("agent #547")} />);
+    expect(container.querySelector(".hm-agent-discussion")).toBeNull();
+  });
+
   test("draft PR shows the draft pill", () => {
     const { container } = render(<Card card={fixture("agent #550")} />);
     expect(within(container).getByText("draft")).toBeTruthy();

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -25,6 +25,7 @@ import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { ChecksBar } from "./ChecksBar.js";
+import { AgentDiscussion } from "./AgentDiscussion.js";
 
 export type CardProps = {
   card: BoardCard;
@@ -150,6 +151,8 @@ export function Card({
       {!isClosed && card.reviewRequests?.some((request) => request.status === "requested") ? (
         <ReviewRequestedLine card={card} />
       ) : null}
+
+      {!isClosed ? <AgentDiscussion messages={card.discussion} compact /> : null}
 
       {isClosed && verdictText ? (
         <div className="hm-card-meta">

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -99,6 +99,48 @@ describe("DetailDrawer — variants", () => {
     expect(within(sendBack).getByText("B")).toBeTruthy();
   });
 
+  test("shows the scoped Hermes/agent discussion in the drawer when present", () => {
+    const card: BoardCard = {
+      ...fixture("agent #548"),
+      discussion: [
+        {
+          id: "hermes-1",
+          ts: Date.parse("2026-06-01T10:01:00.000Z"),
+          author: "hermes",
+          kind: "status",
+          text: "Contract test X is red.",
+          addressedTo: "codex",
+          hermesMode: "live",
+        },
+        {
+          id: "codex-1",
+          ts: Date.parse("2026-06-01T10:02:00.000Z"),
+          author: "codex",
+          kind: "chat",
+          text: "Fixing via Y.",
+          addressedTo: "hermes",
+        },
+      ],
+    };
+
+    const { getByRole } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    const discussion = within(getByRole("dialog")).getByRole("region", { name: "Agent discussion" });
+    expect(within(discussion).getByText("Hermes (live)")).toBeTruthy();
+    expect(within(discussion).getByText("Contract test X is red.")).toBeTruthy();
+    expect(within(discussion).getByText("Codex")).toBeTruthy();
+    expect(within(discussion).getByText("Fixing via Y.")).toBeTruthy();
+  });
+
+  test("cards without discussion do not render an empty thread in the drawer", () => {
+    const card = fixture("agent #548");
+    const { queryByRole } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(queryByRole("region", { name: "Agent discussion" })).toBeNull();
+  });
+
   test("rich PR statuses: per-check breakdown, risk signals, and colored file diff render", () => {
     const card: BoardCard = {
       id: "agent #590",

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
@@ -19,6 +19,7 @@ import type { BoardCard } from "../../lib/monitor/card-types.js";
 import { traverseDrawerCard } from "../../lib/monitor/drawer-routing.js";
 import { buildDrawerFooter, type DrawerActionHandlers, type DrawerFooterDeps } from "../../lib/monitor/drawer-footer.js";
 import { DRAWER_ACCENT, DrawerBody, drawerVariant } from "./DrawerBody.js";
+import { AgentDiscussion } from "../cards/AgentDiscussion.js";
 
 export interface DetailDrawerProps {
   card: BoardCard;
@@ -156,6 +157,7 @@ export function DetailDrawer({ card, cards, onClose, onNavigate, actions, footer
 
           <div className="hm-drawer-body">
             <DrawerBody card={card} variant={variant} />
+            <AgentDiscussion messages={card.discussion} />
           </div>
 
           <footer className="hm-drawer-foot">

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -95,6 +95,18 @@ export interface CardReviewRequest {
   updatedAt: string;
 }
 
+export type CardDiscussionAuthor = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes";
+
+export interface CardDiscussionMessage {
+  id: string;
+  ts: number;
+  author: CardDiscussionAuthor;
+  kind: "chat" | "proposal" | "request_help" | "status";
+  text: string;
+  addressedTo: "everyone" | "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "operator";
+  hermesMode?: "live" | "templated";
+}
+
 export interface CardSourceFailure {
   code: string;
   source: "github" | "runner" | "deploy" | "codex";
@@ -173,6 +185,8 @@ export interface CardBase {
   decisionRecord?: HermesDecisionRecord;
   /** C1: active cross-agent review requests scoped to this card. */
   reviewRequests?: CardReviewRequest[];
+  /** C4: real Hermes/agent discussion scoped to this card. */
+  discussion?: CardDiscussionMessage[];
   /** Source read / heartbeat failure behind a degraded card. */
   sourceFailure?: CardSourceFailure;
 }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -918,6 +918,77 @@ body { margin: 0; }
   background: var(--hm-blue);
 }
 
+.hm-agent-discussion {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid rgba(30, 102, 66, 0.16);
+  border-radius: 8px;
+  background: rgba(30, 102, 66, 0.045);
+}
+.hm-agent-discussion--compact {
+  gap: 6px;
+  padding: 8px 10px;
+}
+.hm-agent-discussion-head {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage-deep);
+}
+.hm-agent-discussion-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--hm-sage);
+}
+.hm-agent-discussion-list {
+  display: grid;
+  gap: 7px;
+}
+.hm-agent-discussion-row {
+  display: grid;
+  gap: 3px;
+}
+.hm-agent-discussion-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hm-muted);
+}
+.hm-agent-discussion-meta strong {
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0 !important;
+}
+.hm-agent-discussion-row p {
+  margin: 0;
+  color: var(--hm-ink-soft);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.hm-agent-discussion--compact .hm-agent-discussion-row p {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.hm-agent-discussion-more {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hm-muted);
+}
+
 .hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }
 .hm-pill {
   display: inline-flex; align-items: center; gap: 5px;

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -149,6 +149,18 @@ export interface CardReviewRequest {
   updatedAt: string;
 }
 
+export type CardDiscussionAuthor = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes";
+
+export interface CardDiscussionMessage {
+  id: string;
+  ts: number;
+  author: CardDiscussionAuthor;
+  kind: "chat" | "proposal" | "request_help" | "status";
+  text: string;
+  addressedTo: "everyone" | "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "operator";
+  hermesMode?: "live" | "templated";
+}
+
 export interface CardSourceFailure {
   code: string;
   source: "github" | "runner" | "deploy" | "codex";
@@ -262,6 +274,8 @@ export interface BoardCard {
   decisionRecord?: HermesDecisionRecord;
   /** C1: active cross-agent review requests scoped to this card. */
   reviewRequests?: CardReviewRequest[];
+  /** C4: real Hermes/agent discussion scoped to this card. */
+  discussion?: CardDiscussionMessage[];
 }
 
 export interface BoardSnapshotV2 {
@@ -919,6 +933,79 @@ function asReviewResponse(value: unknown): CardReviewRequest["response"] | undef
   return { verdict, reasoning, respondedAt };
 }
 
+interface CardDiscussionMessageWithScope extends CardDiscussionMessage {
+  relatedPrKey?: string;
+  correlationId?: string;
+}
+
+function discussionMessagesFromSnapshot(rawSnapshot: unknown): CardDiscussionMessageWithScope[] {
+  const root = asRecord(rawSnapshot);
+  const messages: CardDiscussionMessageWithScope[] = [];
+  for (const entry of asArray(root?.collaborationMessages)) {
+    const message = asRecord(entry);
+    if (!message) continue;
+    const id = asString(message.id);
+    const ts = asFiniteNumber(message.ts);
+    const author = asDiscussionAuthor(message.author);
+    const kind = asDiscussionKind(message.kind);
+    const text = asString(message.text);
+    const addressedTo = asDiscussionTarget(message.addressedTo);
+    if (!id || ts === undefined || !author || !kind || !text || !addressedTo) continue;
+    const relatedPr = asRecord(message.relatedPr);
+    const hermesMode = author === "hermes" ? asHermesMode(message.hermesMode) : undefined;
+    messages.push({
+      id,
+      ts,
+      author,
+      kind,
+      text,
+      addressedTo,
+      ...(hermesMode ? { hermesMode } : {}),
+      relatedPrKey: prKey(asString(relatedPr?.repo), asFiniteNumber(relatedPr?.number)),
+      correlationId: asString(message.relatedCorrelationId),
+    });
+  }
+  return messages;
+}
+
+function attachDiscussion(
+  card: BoardCard,
+  messages: readonly CardDiscussionMessageWithScope[],
+  scope: { relatedPrKey?: string; correlationId?: string }
+): BoardCard {
+  const scoped = messages
+    .filter((message) =>
+      (scope.relatedPrKey !== undefined && message.relatedPrKey === scope.relatedPrKey)
+      || (scope.correlationId !== undefined && message.correlationId === scope.correlationId)
+      || (message.correlationId !== undefined && message.correlationId === card.id)
+    )
+    .sort((a, b) => a.ts - b.ts)
+    .slice(-CARD_DISCUSSION_LIMIT)
+    .map(({ relatedPrKey, correlationId, ...message }) => message);
+  if (scoped.length === 0) return card;
+  return { ...card, discussion: scoped };
+}
+
+function asDiscussionAuthor(value: unknown): CardDiscussionAuthor | undefined {
+  if (value === "claude" || value === "codex" || value === "test-writer" || value === "security" || value === "docs" || value === "hermes") return value;
+  return undefined;
+}
+
+function asDiscussionKind(value: unknown): CardDiscussionMessage["kind"] | undefined {
+  if (value === "chat" || value === "proposal" || value === "request_help" || value === "status") return value;
+  return undefined;
+}
+
+function asDiscussionTarget(value: unknown): CardDiscussionMessage["addressedTo"] | undefined {
+  if (value === "everyone" || value === "claude" || value === "codex" || value === "test-writer" || value === "security" || value === "docs" || value === "hermes" || value === "operator") return value;
+  return undefined;
+}
+
+function asHermesMode(value: unknown): CardDiscussionMessage["hermesMode"] | undefined {
+  if (value === "live" || value === "templated") return value;
+  return undefined;
+}
+
 function attachReviewRequests(
   card: BoardCard,
   requests: readonly CardReviewRequestWithScope[],
@@ -1285,6 +1372,7 @@ const APPROVED_STALE_MINUTES = 30;
 const RUNNING_STALE_MINUTES = 20;
 const REPEATED_FAILURE_ATTEMPTS = 2;
 const AUTOMATION_TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "cancelled"]);
+const CARD_DISCUSSION_LIMIT = 4;
 
 /**
  * Synthesize `codex-needed` cards for queued tasks the classifier won't
@@ -1565,6 +1653,7 @@ export function buildV2BoardSnapshot(
   const codexIndex = indexCodexTasks(rawSnapshot);
   const missionIndex = indexTestbedMissions(rawSnapshot);
   const reviewRequests = reviewRequestsFromSnapshot(rawSnapshot);
+  const discussionMessages = discussionMessagesFromSnapshot(rawSnapshot);
   const runner = readRunner(rawSnapshot);
   const quietSelfHealingCapacitySignals = countValue(classified?.counts?.selfHealingCapacitySignals);
   const quietTaskHealthCapacitySignals = countQuietTaskHealthCapacitySignals(rawSnapshot);
@@ -1580,9 +1669,13 @@ export function buildV2BoardSnapshot(
           ? missionIndex.get(item.correlationId)
           : undefined,
     });
-    return attachReviewRequests(enriched, reviewRequests, {
+    const withReviews = attachReviewRequests(enriched, reviewRequests, {
       ...(key ? { relatedPrKey: key } : {}),
       ...(base.type === "mission" && item.correlationId ? { relatedMissionId: item.correlationId } : {}),
+      ...(item.correlationId ? { correlationId: item.correlationId } : {}),
+    });
+    return attachDiscussion(withReviews, discussionMessages, {
+      ...(key ? { relatedPrKey: key } : {}),
       ...(item.correlationId ? { correlationId: item.correlationId } : {}),
     });
   });
@@ -1593,9 +1686,14 @@ export function buildV2BoardSnapshot(
   const existingIds = new Set(sourceCards.map((c) => c.id));
   const taskCards = synthesizeTaskCards(rawSnapshot, runner, { now: snapshotAt })
     .filter((c) => !existingIds.has(c.id))
-    .map((card) => attachReviewRequests(card, reviewRequests, {
-      correlationId: card.correlationId ?? card.id,
-    }));
+    .map((card) => {
+      const scope = { correlationId: card.correlationId ?? card.id };
+      return attachDiscussion(
+        attachReviewRequests(card, reviewRequests, scope),
+        discussionMessages,
+        scope,
+      );
+    });
   const actionableTaskCorrelationIds = new Set(
     taskCards.map((card) => card.correlationId).filter((value): value is string => Boolean(value)),
   );

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -782,6 +782,85 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     ]);
   });
 
+  it("attaches real card-scoped Hermes/agent discussion and ignores operator/unrelated messages", () => {
+    const raw = {
+      active: [
+        {
+          title: "Allow operator override of agent claim-stake floor",
+          status: "needs_review",
+          intent: "operator_review",
+          ageLabel: "4m",
+          summary: {
+            pullRequest: { repo: "depre-dev/agent", number: 548, state: "open" },
+            currentPullRequest: { repo: "depre-dev/agent", number: 548, state: "open" },
+          },
+        },
+      ],
+      recent: [],
+      collaborationMessages: [
+        {
+          id: "operator-1",
+          ts: Date.parse("2026-06-01T10:00:00.000Z"),
+          author: "operator",
+          kind: "chat",
+          text: "what is happening?",
+          addressedTo: "hermes",
+          relatedPr: { repo: "depre-dev/agent", number: 548 },
+        },
+        {
+          id: "hermes-1",
+          ts: Date.parse("2026-06-01T10:01:00.000Z"),
+          author: "hermes",
+          kind: "status",
+          text: "Contract test X is red.",
+          addressedTo: "codex",
+          hermesMode: "live",
+          relatedPr: { repo: "depre-dev/agent", number: 548 },
+        },
+        {
+          id: "codex-1",
+          ts: Date.parse("2026-06-01T10:02:00.000Z"),
+          author: "codex",
+          kind: "chat",
+          text: "Fixing via Y.",
+          addressedTo: "hermes",
+          relatedPr: { repo: "depre-dev/agent", number: 548 },
+        },
+        {
+          id: "claude-unrelated",
+          ts: Date.parse("2026-06-01T10:03:00.000Z"),
+          author: "claude",
+          kind: "chat",
+          text: "Different card.",
+          addressedTo: "hermes",
+          relatedPr: { repo: "depre-dev/agent", number: 999 },
+        },
+      ],
+    };
+
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const card = snap.cards.find((c) => c.id === "agent #548");
+    expect(card?.discussion).toEqual([
+      {
+        id: "hermes-1",
+        ts: Date.parse("2026-06-01T10:01:00.000Z"),
+        author: "hermes",
+        kind: "status",
+        text: "Contract test X is red.",
+        addressedTo: "codex",
+        hermesMode: "live",
+      },
+      {
+        id: "codex-1",
+        ts: Date.parse("2026-06-01T10:02:00.000Z"),
+        author: "codex",
+        kind: "chat",
+        text: "Fixing via Y.",
+        addressedTo: "hermes",
+      },
+    ]);
+  });
+
   it("promotes a blocked high-risk reviewer panel to needs-attention for the D4 bridge", () => {
     const raw = {
       active: [


### PR DESCRIPTION
## What changed & why

- Attached real card-scoped C4 collaboration messages from the monitor snapshot onto matching board cards.
- Added an Agent discussion block on live cards and in the drawer so the operator can read Hermes ↔ agent context in place.
- Kept cards without scoped discussion clean; operator/system messages and unrelated card messages are not surfaced as inter-agent discussion.
- Note: current main's docs/HERMES_BOARD_WORKFLOW_REDESIGN.md does not yet contain a P1-7 row, but this implements the requested P1-7 behavior against the shipped C4 message model.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm install` (fresh worktree dependencies)
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm test -- test/unit/monitor-v2.test.ts packages/monitor-ui/src/components/cards/Card.test.tsx packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Monitor board serialization + UI only. Roll back by reverting this PR if the card discussion surface needs to be withdrawn.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

Shows the bounded recent scoped thread carried by the monitor snapshot. It does not create or mutate collaboration messages.