### PR TITLE
[codex] Stream real board card lane movement

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/board-cache.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.test.ts
@@ -135,6 +135,20 @@ test("board.card.moved: updates the matching card's lane", () => {
   assert.equal(next.cards.find(c => c.id === "a").lane, "release-queue");
 });
 
+test("board.card.moved: replaces stale card details when the stream supplies the fresh card", () => {
+  const next = applyEventToBoard(baseBoard(), {
+    type: "board.card.moved",
+    id: "a",
+    fromLane: "operator-review",
+    toLane: "hermes-checking",
+    card: { id: "a", lane: "hermes-checking", type: "pr", title: "Re-reviewing current head", summary: "fresh" },
+  });
+  const card = next.cards.find(c => c.id === "a");
+  assert.equal(card.lane, "hermes-checking");
+  assert.equal(card.title, "Re-reviewing current head");
+  assert.equal(card.summary, "fresh");
+});
+
 test("board.card.moved: unknown id is a no-op", () => {
   const next = applyEventToBoard(baseBoard(), {
     type: "board.card.moved",

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -136,8 +136,9 @@ export function applyEventToBoard(
       if (!id || !toLane) return prev;
       const idx = prev.cards.findIndex((c) => c.id === id);
       if (idx < 0) return prev;
+      const card = isRecord(event.card) ? (event.card as unknown as BoardCard) : undefined;
       const next = prev.cards.slice();
-      next[idx] = { ...next[idx], lane: toLane } as BoardCard;
+      next[idx] = card?.id === id ? { ...card, lane: toLane } : ({ ...next[idx], lane: toLane } as BoardCard);
       return { cards: next, at: typeof event.at === "string" ? event.at : prev.at };
     }
     case "board.card.archived": {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -50,7 +50,7 @@ import {
   type ReviewRequestStatus,
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
-import { buildV2BoardSnapshot } from "./monitor-v2.js";
+import { buildV2BoardSnapshot, diffBoardSnapshots, type BoardSnapshotV2 } from "./monitor-v2.js";
 import { buildBacklogSuggestionsResponse } from "./backlog-suggestions.js";
 import { listDecisionRecordsForMonitor } from "./decision-record-store.js";
 import {
@@ -3143,23 +3143,21 @@ function monitorV2Repo(): string {
 }
 
 /**
- * v2 SSE stream — emits the typed BoardSnapshotV2 as a `board.snapshot`
- * event on each interval. Mirrors writeMonitorStream's polling model
- * (re-derive + push) rather than a true pub-sub; the redesigned client
- * treats every snapshot as a full-state replace, so a periodic
- * snapshot keeps it in sync. Per-card diff events
- * (board.card.added/updated/moved/archived) are a later refinement;
- * for M1' the snapshot cadence is the contract.
+ * v2 SSE stream — emits typed card-level events derived from consecutive
+ * real BoardSnapshotV2 reads, followed by a reconciliation snapshot. Lane
+ * movement is never simulated: a `board.card.moved` means the card's real
+ * lane changed in the monitor source between two snapshots.
  */
 async function writeMonitorV2Stream(
   request: http.IncomingMessage,
   response: http.ServerResponse,
   url: URL
 ): Promise<void> {
-  const intervalMs = Math.max(1_000, parseOptionalInteger(url.searchParams.get("intervalMs")) ?? 5_000);
+  const intervalMs = Math.max(1_000, parseOptionalInteger(url.searchParams.get("intervalMs")) ?? 2_000);
   let closed = false;
   let inFlight = false;
   let timer: ReturnType<typeof setInterval> | undefined;
+  let lastSnapshot: BoardSnapshotV2 | undefined;
 
   response.writeHead(200, {
     "content-type": "text/event-stream; charset=utf-8",
@@ -3174,7 +3172,12 @@ async function writeMonitorV2Stream(
     inFlight = true;
     try {
       const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
-      writeSseEvent(response, "board.snapshot", mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() })));
+      const snapshot = mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }));
+      for (const event of diffBoardSnapshots(lastSnapshot, snapshot)) {
+        writeSseEvent(response, event.type, event);
+      }
+      writeSseEvent(response, "board.snapshot", snapshot);
+      lastSnapshot = snapshot;
     } catch (error) {
       writeSseEvent(response, "error", {
         error: "monitor_v2_snapshot_failed",

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -272,6 +272,12 @@ export interface BoardSnapshotV2 {
   automationHealth?: AutomationHealth;
 }
 
+export type BoardCardStreamEvent =
+  | { type: "board.card.added"; card: BoardCard; at: string }
+  | { type: "board.card.updated"; id: string; partial: BoardCard; card: BoardCard; at: string }
+  | { type: "board.card.moved"; id: string; fromLane: Lane; toLane: Lane; card: BoardCard; at: string }
+  | { type: "board.card.archived"; id: string; fromLane?: Lane; at: string };
+
 export interface AutomationHealth {
   /** Non-terminal self-healing fix proposals currently open. */
   selfHealingOpen: number;
@@ -1618,6 +1624,56 @@ export function buildV2BoardSnapshot(
       taskHealthCapacitySignals: quietTaskHealthCapacitySignals,
     }),
   };
+}
+
+/**
+ * Compare two real board snapshots and emit the card-level events the v2 SSE
+ * stream can send before the reconciliation snapshot. These are not synthetic
+ * animations: every event is derived from two consecutive source snapshots.
+ */
+export function diffBoardSnapshots(
+  previous: BoardSnapshotV2 | undefined,
+  next: BoardSnapshotV2,
+): BoardCardStreamEvent[] {
+  if (!previous) return [];
+  const at = next.at;
+  const previousById = new Map(previous.cards.map((card) => [card.id, card]));
+  const nextById = new Map(next.cards.map((card) => [card.id, card]));
+  const events: BoardCardStreamEvent[] = [];
+
+  for (const card of previous.cards) {
+    if (!nextById.has(card.id)) {
+      events.push({ type: "board.card.archived", id: card.id, fromLane: card.lane, at });
+    }
+  }
+
+  for (const card of next.cards) {
+    const before = previousById.get(card.id);
+    if (!before) {
+      events.push({ type: "board.card.added", card, at });
+      continue;
+    }
+    if (before.lane !== card.lane) {
+      events.push({
+        type: "board.card.moved",
+        id: card.id,
+        fromLane: before.lane,
+        toLane: card.lane,
+        card,
+        at,
+      });
+      continue;
+    }
+    if (!sameBoardCard(before, card)) {
+      events.push({ type: "board.card.updated", id: card.id, partial: card, card, at });
+    }
+  }
+
+  return events;
+}
+
+function sameBoardCard(a: BoardCard, b: BoardCard): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
 }
 
 function countQuietTaskHealthCapacitySignals(rawSnapshot: unknown): number {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -24,6 +24,7 @@ import {
   synthesizeTaskCards,
   taskHealthForBoard,
   automationHealthForBoard,
+  diffBoardSnapshots,
 } from "../../services/slack-operator/src/monitor-v2.js";
 import type { BoardCard } from "../../services/slack-operator/src/monitor-v2.js";
 import type { HermesBoardCardSnapshot } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -1590,5 +1591,81 @@ describe("enrichBoardCard — task status", () => {
       codexTask: { status: "approved", prompt: "do it" },
     });
     expect(enriched.taskStatus).toBe("approved");
+  });
+});
+
+describe("diffBoardSnapshots", () => {
+  function card(overrides: Partial<BoardCard> = {}): BoardCard {
+    return {
+      id: "agent #548",
+      lane: "codex-needed",
+      type: "pr",
+      agentType: "codex",
+      title: "Fix failing workflow",
+      summary: "CI is still running.",
+      repo: "depre-dev/agent",
+      freshness: 1,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+      ...overrides,
+    };
+  }
+
+  function snapshot(cards: BoardCard[], at: string) {
+    return {
+      cards,
+      at,
+      repo: "depre-dev/agent",
+      llmUsage: {
+        status: "not_recorded",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        costUsd: null,
+        costStatus: "not_recorded",
+        runs: 0,
+        byModel: [],
+        byDay: [],
+      },
+    };
+  }
+
+  it("emits a moved event with the full fresh card when the lane changes", () => {
+    const previous = snapshot([card({ lane: "codex-needed", summary: "Fix assigned." })], "2026-06-01T10:00:00Z");
+    const nextCard = card({
+      lane: "hermes-checking",
+      summary: "Fix returned; Hermes is re-reviewing the current head.",
+      freshness: 0,
+      checks: { total: 5, pass: 5, fail: 0, running: 0, pending: 0 },
+    });
+    const next = snapshot([nextCard], "2026-06-01T10:00:02Z");
+
+    expect(diffBoardSnapshots(previous, next)).toEqual([
+      {
+        type: "board.card.moved",
+        id: "agent #548",
+        fromLane: "codex-needed",
+        toLane: "hermes-checking",
+        card: nextCard,
+        at: "2026-06-01T10:00:02Z",
+      },
+    ]);
+  });
+
+  it("emits add/update/archive events from real snapshot differences", () => {
+    const previous = snapshot([
+      card({ id: "agent #1", summary: "old" }),
+      card({ id: "agent #2", lane: "operator-review" }),
+    ], "2026-06-01T10:00:00Z");
+    const updated = card({ id: "agent #1", summary: "new evidence arrived" });
+    const added = card({ id: "agent #3", lane: "release-queue" });
+    const next = snapshot([updated, added], "2026-06-01T10:00:02Z");
+
+    expect(diffBoardSnapshots(previous, next)).toEqual([
+      { type: "board.card.archived", id: "agent #2", fromLane: "operator-review", at: "2026-06-01T10:00:02Z" },
+      { type: "board.card.updated", id: "agent #1", partial: updated, card: updated, at: "2026-06-01T10:00:02Z" },
+      { type: "board.card.added", card: added, at: "2026-06-01T10:00:02Z" },
+    ]);
   });
 });


### PR DESCRIPTION
## What changed & why

Implements P1-5 real-time lane movement for the redesigned Hermes board. The v2 SSE stream now diffs consecutive real BoardSnapshotV2 reads and emits card added, updated, moved, and archived events before the reconciliation board snapshot.

Moved events carry the full fresh card payload, and the monitor UI cache now replaces stale card details on move instead of only changing the lane. The stream cadence is tightened to 2s by default so Loop 1 transitions show up promptly without simulating motion.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] npm run typecheck
- [x] npm test
- [ ] docker compose config, only if ops/Docker/compose touched

## Rollout / rollback

No ops, env, migration, or secret changes. Rollback is reverting this PR; the full board snapshot stream remains the reconciliation backstop.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy. A human still owns the gate.
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power.
- [x] No secrets committed, printed, or logged.
- [x] No docs update needed; behavior still mirrors real board events only.

## Known limits / follow-ups

This mirrors real state changes only. It does not create synthetic animation or infer lane motion without a source snapshot change.