### PR TITLE
feat(monitor): show live worker attribution

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -208,6 +208,38 @@ describe("Card — state coverage", () => {
     expect(container.querySelector(".running")).toBeTruthy();
   });
 
+  test("in-flight cards render the live worker separately from branch attribution", () => {
+    const running: PRCard = {
+      id: "agent #561",
+      lane: "hermes-checking",
+      type: "pr",
+      agentType: "claude",
+      title: "Claude-authored PR under Codex repair",
+      summary: "runner active",
+      repo: "depre-dev/agent",
+      freshness: 2,
+      state: "running",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+      files: [],
+      workingNow: {
+        agent: "codex",
+        label: "Codex fixing",
+        source: "runner",
+        runnerId: "codex-task-runner",
+        taskId: "task-pr-561",
+      },
+    };
+
+    const { container } = render(<Card card={running} />);
+    const view = within(container);
+    expect(view.getByText("claude")).toBeTruthy();
+    expect(view.getByText(/working now/i)).toBeTruthy();
+    expect(view.getByText("Codex fixing")).toBeTruthy();
+    expect(container.querySelector(".hm-working-now")).toBeTruthy();
+    expect(container.querySelector(".hm-working-now")?.getAttribute("title")).toContain("runner: codex-task-runner");
+  });
+
   test("focused prop adds is-focused", () => {
     const { container } = render(<Card card={fixture("agent #547")} focused />);
     expect(container.querySelector(".hm-card.is-focused")).toBeTruthy();

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -19,7 +19,15 @@
 //   - archiveHint = true → "archive in 4h?" tail line
 
 import { useState } from "react";
-import type { BoardCard, CardChecks, WaitingOn, RiskTag, AgentType, HermesDecisionRecord } from "../../lib/monitor/card-types.js";
+import type {
+  BoardCard,
+  CardChecks,
+  WaitingOn,
+  RiskTag,
+  AgentType,
+  HermesDecisionRecord,
+  CardWorkingNow,
+} from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
@@ -153,6 +161,8 @@ export function Card({
       ) : null}
 
       {!isClosed ? <AgentDiscussion messages={card.discussion} compact /> : null}
+
+      {!isClosed && card.workingNow ? <WorkingNowLine workingNow={card.workingNow} /> : null}
 
       {isClosed && verdictText ? (
         <div className="hm-card-meta">
@@ -302,6 +312,23 @@ function actorDisplayName(actor: "hermes" | "operator" | "codex" | "claude" | "t
   if (actor === "security") return "Security";
   if (actor === "docs") return "Docs";
   return "Codex";
+}
+
+function WorkingNowLine({ workingNow }: { workingNow: CardWorkingNow }) {
+  const details = [
+    workingNow.runnerId ? `runner: ${workingNow.runnerId}` : undefined,
+    workingNow.taskId ? `task: ${workingNow.taskId}` : undefined,
+    workingNow.since ? `since: ${workingNow.since}` : undefined,
+    `source: ${workingNow.source}`,
+  ].filter(Boolean).join(" · ");
+
+  return (
+    <div className="hm-working-now" aria-label={`Working now: ${workingNow.label}`} title={details || undefined}>
+      <span className={`agent-dot agent-dot--${workingNow.agent}`} aria-hidden />
+      working now
+      <span className="target">{workingNow.label}</span>
+    </div>
+  );
 }
 
 // ── Checks label (e.g. "5/6 · 1 running") ──────────────────────────

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -114,6 +114,15 @@ export interface CardSourceFailure {
   lastGoodAt?: string;
 }
 
+export interface CardWorkingNow {
+  agent: AgentType;
+  label: string;
+  source: "runner" | "mission" | "classifier";
+  runnerId?: string;
+  taskId?: string;
+  since?: string;
+}
+
 export interface HermesDecisionSubject {
   type: "task" | "card" | "repo" | "pr" | "mission" | "digest" | "autopilot_session";
   id: string;
@@ -189,6 +198,8 @@ export interface CardBase {
   discussion?: CardDiscussionMessage[];
   /** Source read / heartbeat failure behind a degraded card. */
   sourceFailure?: CardSourceFailure;
+  /** Agent currently working this in-flight card, backed by live runner/classifier state. */
+  workingNow?: CardWorkingNow;
 }
 
 /** PR card — file changes, Hermes verdict, operator-review action. */

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -839,13 +839,13 @@ body { margin: 0; }
 .hm-card-id .agent-dot {
   width: 6px; height: 6px; border-radius: 999px;
 }
-.hm-card-id .agent-dot--codex  { background: #6b8a4e; }
-.hm-card-id .agent-dot--claude { background: var(--hm-clay); }
-.hm-card-id .agent-dot--test-writer { background: #2f7fb8; }
-.hm-card-id .agent-dot--security { background: #a3414f; }
-.hm-card-id .agent-dot--docs { background: #6b5b9a; }
-.hm-card-id .agent-dot--hermes { background: var(--hm-sage); }
-.hm-card-id .agent-dot--ext    { background: var(--hm-muted); }
+.agent-dot--codex  { background: #6b8a4e; }
+.agent-dot--claude { background: var(--hm-clay); }
+.agent-dot--test-writer { background: #2f7fb8; }
+.agent-dot--security { background: #a3414f; }
+.agent-dot--docs { background: #6b5b9a; }
+.agent-dot--hermes { background: var(--hm-sage); }
+.agent-dot--ext    { background: var(--hm-muted); }
 .hm-card-id strong {
   font-weight: 600;
   color: var(--hm-ink);
@@ -987,6 +987,38 @@ body { margin: 0; }
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--hm-muted);
+}
+
+.hm-working-now {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  max-width: 100%;
+  color: var(--hm-muted);
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase;
+  margin-top: 2px;
+}
+.hm-working-now .agent-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 3px rgba(30,102,66,0.12);
+  flex: 0 0 auto;
+}
+.hm-working-now .target {
+  min-width: 0;
+  background: var(--hm-sage-soft);
+  color: var(--hm-sage-deep);
+  padding: 2px 8px;
+  border-radius: 999px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -63,6 +63,13 @@ export interface CodexTaskEvent {
   message: string;
 }
 
+export interface CodexTaskWorkingNow {
+  agent: TaskAgent;
+  runnerId: string;
+  label: string;
+  since: string;
+}
+
 export interface CodexTask extends CodexTaskInput {
   schemaVersion: 1;
   kind: "codex_task";
@@ -86,6 +93,7 @@ export interface CodexTask extends CodexTaskInput {
   stderrTail?: string;
   progressMessage?: string;
   progressAt?: string;
+  workingNow?: CodexTaskWorkingNow;
   retryAfter?: string;
   retryCount?: number;
   selfManagementEscalatedAt?: string;
@@ -199,6 +207,15 @@ function taskAgentEventLabel(agent: TaskAgent): string {
   return agent;
 }
 
+function taskAgentWorkingNowLabel(agent: TaskAgent): string {
+  if (agent === "codex") return "Codex fixing";
+  if (agent === "claude") return "Claude fixing";
+  if (agent === "test-writer") return "Test-writer writing tests";
+  if (agent === "security") return "Security reviewing";
+  if (agent === "docs") return "Docs updating";
+  return `${agent} working`;
+}
+
 export async function approveCodexTask(
   id: string,
   deps: CodexTaskQueueDeps & { approvedBy?: string } = {}
@@ -259,6 +276,7 @@ export async function cancelCodexTask(
     status: "cancelled",
     cancelledAt: now,
     cancelledBy: deps.cancelledBy ?? "monitor",
+    workingNow: undefined,
     events: appendTaskEvent(existing, {
       at: now,
       status: "cancelled",
@@ -286,18 +304,26 @@ export async function claimNextApprovedCodexTask(
     .sort((a, b) => Date.parse(a.approvedAt ?? a.updatedAt) - Date.parse(b.approvedAt ?? b.updatedAt))[0];
   if (!existing) return undefined;
   const now = (deps.now ?? new Date()).toISOString();
+  const agent = taskAgent(existing);
+  const runnerId = deps.runnerId ?? existing.runnerId ?? "codex-task-runner";
   const task: CodexTask = {
     ...existing,
     status: "running",
     startedAt: now,
-    runnerId: deps.runnerId ?? existing.runnerId ?? "codex-task-runner",
+    runnerId,
     attemptCount: (existing.attemptCount ?? 0) + 1,
-    progressMessage: `${taskAgentEventLabel(taskAgent(existing))} runner claimed the task.`,
+    progressMessage: `${taskAgentEventLabel(agent)} runner claimed the task.`,
     progressAt: now,
+    workingNow: {
+      agent,
+      runnerId,
+      label: taskAgentWorkingNowLabel(agent),
+      since: now,
+    },
     events: appendTaskEvent(existing, {
       at: now,
       status: "running",
-      message: `${taskAgentEventLabel(taskAgent(existing))} runner ${(deps.runnerId ?? existing.runnerId ?? "codex-task-runner")} claimed the task.`,
+      message: `${taskAgentEventLabel(agent)} runner ${runnerId} claimed the task.`,
     }),
     updatedAt: now,
   };
@@ -356,6 +382,7 @@ export async function completeCodexTask(
     ...existing,
     status: "completed",
     completedAt: now,
+    workingNow: undefined,
     ...(deps.completionSummary ? { completionSummary: deps.completionSummary } : {}),
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
@@ -392,6 +419,7 @@ export async function failCodexTask(
     ...existing,
     status: "failed",
     failedAt: now,
+    workingNow: undefined,
     failureReason: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
@@ -426,6 +454,7 @@ export async function retryCodexTask(
     retryAfter: _retryAfter,
     selfManagementEscalatedAt: _escalatedAt,
     selfManagementEscalationReason: _escalationReason,
+    workingNow: _workingNow,
     runnerId: _runnerId,
     startedAt: _startedAt,
     failedAt: _failedAt,

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -124,6 +124,15 @@ export interface CardRunnerHeartbeat {
   online: boolean;
 }
 
+export interface CardWorkingNow {
+  agent: AgentType;
+  label: string;
+  source: "runner" | "mission" | "classifier";
+  runnerId?: string;
+  taskId?: string;
+  since?: string;
+}
+
 /** One CI check run, for the per-check breakdown under the checks bar. */
 export interface CardCheckRun {
   name: string;
@@ -270,6 +279,8 @@ export interface BoardCard {
   runnerHeartbeat?: CardRunnerHeartbeat;
   /** Real task lifecycle events recorded by the queue, used for Hermes timeline narration. */
   taskEvents?: TaskTimelineEvent[];
+  /** Agent currently working this in-flight card, backed by live runner/classifier state. */
+  workingNow?: CardWorkingNow;
   /** Per-check CI breakdown (non-done cards) — the list under the bar. */
   checkRuns?: CardCheckRun[];
   /** Hermes review findings (non-done cards) — the "why review" detail. */
@@ -585,6 +596,84 @@ function asTaskTimelineStatus(value: unknown): TaskTimelineEvent["status"] | und
     return value;
   }
   return undefined;
+}
+
+const WATCH_LANES = new Set<Lane>(["codex-needed", "hermes-checking", "release-queue", "deploying"]);
+
+function isWatchLane(lane: Lane): boolean {
+  return WATCH_LANES.has(lane);
+}
+
+function defaultWorkingNowLabel(agent: AgentType): string {
+  if (agent === "codex") return "Codex fixing";
+  if (agent === "claude") return "Claude fixing";
+  if (agent === "test-writer") return "Test-writer writing tests";
+  if (agent === "security") return "Security reviewing";
+  if (agent === "docs") return "Docs updating";
+  if (agent === "hermes") return "Hermes reviewing";
+  return "External agent working";
+}
+
+function workingNowFromRunningTask(
+  task: Record<string, unknown>,
+  runner: Record<string, unknown> | undefined,
+): CardWorkingNow | undefined {
+  if (asString(task.status) !== "running") return undefined;
+  if (!runner || asString(runner.status) !== "running") return undefined;
+  const taskId = asString(task.id);
+  if (!taskId || asString(runner.activeTaskId) !== taskId) return undefined;
+  const persisted = asRecord(task.workingNow);
+  const agent = agentTypeFromTaskAgent(asString(persisted?.agent) ?? task.agent);
+  const label = asString(persisted?.label) ?? defaultWorkingNowLabel(agent);
+  const runnerId = asString(persisted?.runnerId) ?? asString(task.runnerId) ?? asString(runner.runnerId);
+  const since = asString(persisted?.since) ?? asString(task.startedAt) ?? asString(runner.updatedAt);
+  return {
+    agent,
+    label,
+    source: "runner",
+    taskId,
+    ...(runnerId ? { runnerId } : {}),
+    ...(since ? { since } : {}),
+  };
+}
+
+function workingNowFromMissionRun(run: Record<string, unknown> | undefined): CardWorkingNow | undefined {
+  if (!run || asString(run.status) !== "running") return undefined;
+  const taskId = asString(run.id);
+  const runnerId = asString(run.runnerId) ?? asString(run.agentName);
+  const since = asString(run.startedAt) ?? asString(run.claimedAt) ?? asString(run.updatedAt);
+  return {
+    agent: "hermes",
+    label: "Hermes reviewing",
+    source: "mission",
+    ...(taskId ? { taskId } : {}),
+    ...(runnerId ? { runnerId } : {}),
+    ...(since ? { since } : {}),
+  };
+}
+
+function workingNowAgentFromOwner(owner: string | undefined): AgentType | undefined {
+  const value = (owner ?? "").toLowerCase();
+  if (value.includes("codex")) return "codex";
+  if (value.includes("claude")) return "claude";
+  if (value.includes("test-writer") || value.includes("test writer")) return "test-writer";
+  if (value.includes("security")) return "security";
+  if (value.includes("docs")) return "docs";
+  if (value.includes("hermes")) return "hermes";
+  return undefined;
+}
+
+function workingNowFromClassifier(card: BoardCard, item: HermesBoardCardSnapshot): CardWorkingNow | undefined {
+  if (!isWatchLane(card.lane) || card.type === "task" || card.type === "mission" || card.lane === "codex-needed") {
+    return undefined;
+  }
+  const agent = workingNowAgentFromOwner(item.owner);
+  if (!agent) return undefined;
+  return {
+    agent,
+    label: defaultWorkingNowLabel(agent),
+    source: "classifier",
+  };
 }
 
 // Self-healing task titles embed the namespaced surface key
@@ -1359,6 +1448,13 @@ export function enrichBoardCard(
     if (status) card.missionStatus = status as MissionStatus;
     const mission = mapMissionReport(ctx.missionRun);
     if (mission) card.mission = mission;
+    const workingNow = workingNowFromMissionRun(ctx.missionRun);
+    if (workingNow) card.workingNow = workingNow;
+  }
+
+  const taskWorkingNow = ctx.codexTask ? workingNowFromRunningTask(ctx.codexTask, ctx.runner) : undefined;
+  if (taskWorkingNow && isWatchLane(card.lane)) {
+    card.workingNow = taskWorkingNow;
   }
 
   // Codex task cards: prompt / output / failure / runner liveness.
@@ -1395,6 +1491,11 @@ export function enrichBoardCard(
       card.state = "source-offline";
       card.sourceFailure = runnerFailure;
     }
+  }
+
+  if (!card.workingNow) {
+    const classifierWorkingNow = workingNowFromClassifier(card, item);
+    if (classifierWorkingNow) card.workingNow = classifierWorkingNow;
   }
 
   return card;
@@ -1496,6 +1597,8 @@ export function synthesizeTaskCards(
         card.runnerHeartbeat = { lastSeen, online: rStatus === "running" || rStatus === "idle" };
       }
     }
+    const workingNow = workingNowFromRunningTask(task, runner);
+    if (workingNow) card.workingNow = workingNow;
     out.push(card);
   }
   return out;

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -175,6 +175,12 @@ describe("codex task queue", () => {
       runnerId: "runner-a",
       attemptCount: 1,
       progressMessage: "Codex runner claimed the task.",
+      workingNow: {
+        agent: "codex",
+        runnerId: "runner-a",
+        label: "Codex fixing",
+        since: "2026-05-17T12:04:00.000Z",
+      },
     });
 
     const progress = await updateCodexTaskProgress(second.task.id, {
@@ -205,6 +211,7 @@ describe("codex task queue", () => {
       exitCode: 0,
       stdoutTail: "ok",
     });
+    expect(completed?.workingNow).toBeUndefined();
     expect(completed?.events?.map((entry) => entry.status)).toEqual([
       "proposed",
       "approved",
@@ -243,6 +250,7 @@ describe("codex task queue", () => {
       exitCode: 2,
       stderrTail: "failed",
     });
+    expect(failed?.workingNow).toBeUndefined();
     expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
   });
 
@@ -272,6 +280,7 @@ describe("codex task queue", () => {
     });
     expect(requeued?.runnerId).toBeUndefined();
     expect(requeued?.startedAt).toBeUndefined();
+    expect(requeued?.workingNow).toBeUndefined();
 
     const rehydrated = await listCodexTasks({ path });
     expect(rehydrated).toHaveLength(1);
@@ -287,6 +296,12 @@ describe("codex task queue", () => {
       status: "running",
       runnerId: "runner-after-restart",
       attemptCount: 2,
+      workingNow: {
+        agent: "codex",
+        runnerId: "runner-after-restart",
+        label: "Codex fixing",
+        since: "2026-05-17T13:46:00.000Z",
+      },
     });
     expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
   });

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -625,15 +625,90 @@ describe("enrichBoardCard", () => {
     const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
       codexTask: {
         id: "task-1",
+        status: "running",
         prompt: "Coalesce repeated policy-attach entries",
         stdoutTail: "ran ok",
         failureReason: undefined,
+        workingNow: {
+          agent: "codex",
+          runnerId: "runner-a",
+          label: "Codex fixing",
+          since: "2026-05-28T11:55:00Z",
+        },
       },
-      runner: { status: "running", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "task-1" },
+      runner: { status: "running", runnerId: "runner-a", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "task-1" },
     });
     expect(card.prompt).toMatch(/Coalesce/);
     expect(card.output).toBe("ran ok");
     expect(card.runnerHeartbeat).toEqual({ lastSeen: "2026-05-28T12:00:00Z", online: true });
+    expect(card.workingNow).toEqual({
+      agent: "codex",
+      label: "Codex fixing",
+      source: "runner",
+      taskId: "task-1",
+      runnerId: "runner-a",
+      since: "2026-05-28T11:55:00Z",
+    });
+  });
+
+  it("shows the runner currently working a PR separately from branch author attribution", () => {
+    const card = enrichBoardCard(
+      base({ type: "pr", lane: "hermes-checking", agentType: "claude", branch: "claude/ui-polish" }),
+      slim({ lane: "Hermes Checking", owner: "Hermes", headBranch: "claude/ui-polish" }),
+      {
+        codexTask: {
+          id: "task-pr-1",
+          status: "running",
+          agent: "codex",
+          repo: "depre-dev/agent",
+          pullRequestNumber: 548,
+          startedAt: "2026-05-28T11:57:00Z",
+          workingNow: {
+            agent: "codex",
+            runnerId: "codex-task-runner",
+            label: "Codex fixing",
+            since: "2026-05-28T11:57:00Z",
+          },
+        },
+        runner: {
+          status: "running",
+          runnerId: "codex-task-runner",
+          activeTaskId: "task-pr-1",
+          updatedAt: "2026-05-28T12:00:00Z",
+        },
+      },
+    );
+
+    expect(card.agentType).toBe("claude");
+    expect(card.workingNow).toMatchObject({
+      agent: "codex",
+      label: "Codex fixing",
+      source: "runner",
+      taskId: "task-pr-1",
+    });
+  });
+
+  it("does not show a task worker when runner heartbeat points elsewhere", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: { id: "task-1", status: "running", agent: "codex", prompt: "x" },
+      runner: { status: "running", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "other-task" },
+    });
+
+    expect(card.workingNow).toBeUndefined();
+  });
+
+  it("uses the classifier owner as a Hermes working-now source for watch cards", () => {
+    const card = enrichBoardCard(
+      base({ type: "pr", lane: "hermes-checking", agentType: "hermes", waitingOn: { actor: "agent", tone: "info" } }),
+      slim({ lane: "Hermes Checking", owner: "Hermes" }),
+      {},
+    );
+
+    expect(card.workingNow).toEqual({
+      agent: "hermes",
+      label: "Hermes reviewing",
+      source: "classifier",
+    });
   });
 
   it("projects real task timeline events onto task cards", () => {
@@ -1004,6 +1079,41 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     expect(mission?.mission?.path).toHaveLength(2);
   });
 
+  it("names Hermes as working now for a running mission backed by a mission run", () => {
+    const raw = {
+      active: [
+        {
+          correlationId: "mission-running-1",
+          repo: "testbed/mission",
+          intent: "testbed_agent_mission",
+          title: "Verify settings flow mission",
+          summary: { kind: "testbed_mission_run" },
+        },
+      ],
+      recent: [],
+      testbedMissions: [
+        {
+          id: "mission-running-1",
+          status: "running",
+          runnerId: "hermes-browser-runner",
+          targetUrl: "https://staging.averray.com/settings",
+          startedAt: "2026-05-31T10:01:00.000Z",
+        },
+      ],
+    };
+
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const mission = snap.cards.find((c) => c.correlationId === "mission-running-1");
+    expect(mission?.workingNow).toEqual({
+      agent: "hermes",
+      label: "Hermes reviewing",
+      source: "mission",
+      taskId: "mission-running-1",
+      runnerId: "hermes-browser-runner",
+      since: "2026-05-31T10:01:00.000Z",
+    });
+  });
+
   it("surfaces requested tester missions as board-gated operator approvals", () => {
     const raw = {
       active: [],
@@ -1195,6 +1305,71 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
     expect(card?.taskEvents).toEqual(events);
     // proposed → waiting on the operator to approve
     expect(card?.waitingOn).toEqual({ actor: "operator", tone: "warn" });
+  });
+
+  it("names the active runner on an in-flight task card only when heartbeat matches", () => {
+    const [card] = synthesizeTaskCards(
+      {
+        codexTasks: {
+          items: [{
+            id: "running-claude-task",
+            status: "running",
+            agent: "claude",
+            repo: "a/b",
+            prompt: "x",
+            startedAt: "2026-05-31T11:55:00.000Z",
+            workingNow: {
+              agent: "claude",
+              runnerId: "claude-task-runner",
+              label: "Claude fixing",
+              since: "2026-05-31T11:55:00.000Z",
+            },
+          }],
+        },
+      },
+      {
+        status: "running",
+        runnerId: "claude-task-runner",
+        activeTaskId: "running-claude-task",
+        updatedAt: "2026-05-31T12:00:00.000Z",
+      },
+      { now: new Date("2026-05-31T12:00:00.000Z") },
+    );
+
+    expect(card).toMatchObject({
+      id: "running-claude-task",
+      state: "running",
+      workingNow: {
+        agent: "claude",
+        label: "Claude fixing",
+        source: "runner",
+        taskId: "running-claude-task",
+        runnerId: "claude-task-runner",
+      },
+    });
+
+    const [mismatched] = synthesizeTaskCards(
+      {
+        codexTasks: {
+          items: [{
+            id: "running-claude-task",
+            status: "running",
+            agent: "claude",
+            repo: "a/b",
+            prompt: "x",
+            startedAt: "2026-05-31T11:55:00.000Z",
+          }],
+        },
+      },
+      {
+        status: "running",
+        runnerId: "claude-task-runner",
+        activeTaskId: "other-task",
+        updatedAt: "2026-05-31T12:00:00.000Z",
+      },
+      { now: new Date("2026-05-31T12:00:00.000Z") },
+    );
+    expect(mismatched?.workingNow).toBeUndefined();
   });
 
   it("skips PR-bound tasks (they surface via their PR card) and terminal tasks", () => {


### PR DESCRIPTION
## What changed & why

- Added a `workingNow` snapshot to task queue records when a runner claims work, and clear it on terminal/retry transitions.
- Enriched `/monitor/v2/board` cards with current-worker attribution from live runner heartbeats, running mission state, or classifier-owned Hermes watch state.
- Rendered a compact "working now" line on in-flight cards so branch author attribution stays separate from the agent currently acting.
- No authority changes: this is display/state only; no auto-merge, dispatch, or approval behavior changed.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Normal monitor/slack-operator deploy. Rollback by reverting this PR; it only adds optional board/task metadata and UI rendering.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- `docs/HERMES_BOARD_WORKFLOW_REDESIGN.md` on current `origin/main` does not yet include the P1-6 row text, so this PR follows the operator prompt as the source for P1-6 scope.
