### PR TITLE
feat: narrate real task handoff events

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
@@ -87,6 +87,31 @@ describe("buildHermesActivityFeed", () => {
     });
   });
 
+  test("narrates task lifecycle events once as plain card-tied moves", () => {
+    const entries = buildHermesActivityFeed({
+      cards: [task({
+        id: "agent #549",
+        agentType: "codex",
+        summary: "contract suite red · operator delegated",
+        taskEvents: [
+          { at: "2026-06-01T12:00:00.000Z", status: "proposed", message: "Hermes proposed a bounded Codex task." },
+          { at: "2026-06-01T12:00:12.000Z", status: "running", message: "Codex runner runner-1 claimed the task." },
+          { at: "2026-06-01T12:00:12.000Z", status: "running", message: "Codex runner runner-1 claimed the task." },
+        ],
+      })],
+      messages: [],
+      banner,
+      now: () => Date.parse("2026-06-01T12:00:24.000Z"),
+    });
+    const lines = entries.map((entry) => entry.text);
+    expect(lines).toContain("Moved #549 to Codex — contract suite red.");
+    expect(lines.filter((line) => line === "Codex picked up #549 — 12s ago.")).toHaveLength(1);
+    expect(entries.find((entry) => entry.text === "Moved #549 to Codex — contract suite red.")).toMatchObject({
+      cardId: "agent #549",
+      meta: "route recorded",
+    });
+  });
+
   test("says so when no real activity exists and still ends with the board summary", () => {
     const entries = buildHermesActivityFeed({
       cards: [],

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -4,6 +4,7 @@ import type {
   BoardCard,
   CardReviewRequest,
   HermesDecisionRecord,
+  TaskTimelineEvent,
 } from "./card-types.js";
 import type { CollaborationAuthor, CollaborationMessage } from "./collaboration.js";
 import { actorLabel, actorLabelForMessage, formatTurnTime, relatedPrForCard } from "./collaboration.js";
@@ -76,6 +77,7 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
   const atMs = estimateCardTime(card, boardAtMs);
   const entries: HermesActivityEntry[] = [];
   if (card.type === "task" && card.taskStatus) {
+    if (card.taskEvents?.length) return card.taskEvents.flatMap((event) => taskTimelineActivity(card, event, boardAtMs));
     const label = agentLabel(card.agentType);
     const title = cardTitle(card);
     if (card.taskStatus === "proposed") {
@@ -161,6 +163,66 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
   }
 
   return entries;
+}
+
+function taskTimelineActivity(card: BoardCard, event: TaskTimelineEvent, nowMs: number): HermesActivityEntry[] {
+  const atMs = parseTime(event.at);
+  if (atMs === undefined) return [];
+  const ref = cardRef(card);
+  const agent = agentLabel(card.agentType);
+  const reason = compactReason(card.summary) || plain(event.message) || "task routed by Hermes";
+  const common = {
+    id: `task-event:${card.id}:${event.status}:${event.at}`,
+    atMs,
+    source: "board" as const,
+    actor: "hermes" as const,
+    kindLabel: "narration" as const,
+    cardId: card.id,
+  };
+
+  if (event.status === "proposed") {
+    return [{
+      ...common,
+      tone: "action",
+      text: `Moved ${ref} to ${agent} — ${sentence(reason)}`,
+      meta: "route recorded",
+      suggestions: ["Why this route?", "Show dispatch guardrails"],
+    }];
+  }
+  if (event.status === "approved") {
+    return [{
+      ...common,
+      tone: "info",
+      text: `Released ${ref} to ${agent} — operator approved dispatch.`,
+      meta: "handoff recorded",
+    }];
+  }
+  if (event.status === "running") {
+    return [{
+      ...common,
+      tone: "info",
+      text: `${agent} picked up ${ref} — ${relativeAge(atMs, nowMs)}.`,
+      meta: "pickup recorded",
+    }];
+  }
+  if (event.status === "completed") {
+    return [{
+      ...common,
+      tone: "success",
+      text: `${agent} returned ${ref} — ${sentence(plain(event.message))}`,
+      meta: "completion recorded",
+    }];
+  }
+  if (event.status === "failed") {
+    return [{
+      ...common,
+      tone: "warning",
+      text: `${agent} hit a blocker on ${ref} — ${sentence(plain(event.message))}`,
+      meta: "failure recorded",
+      suggestions: ["Show failure evidence", "Should this be split?"],
+    }];
+  }
+  return [];
 }
 
 function decisionRecordActivity(
@@ -339,6 +401,31 @@ function parseTime(value: string | undefined): number | undefined {
 
 function plain(value: string | undefined): string {
   return humanizeSignalText(value).replace(/\s+/g, " ").trim();
+}
+
+function sentence(value: string): string {
+  const text = value.trim();
+  if (!text) return "recorded by Hermes.";
+  return /[.!?]$/.test(text) ? text : `${text}.`;
+}
+
+function compactReason(value: string | undefined): string {
+  const [first] = plain(value).split(/\s+·\s+|;\s+|\.\s+/);
+  return first?.trim() ?? "";
+}
+
+function cardRef(card: BoardCard): string {
+  const pr = /#\d+/.exec(card.id);
+  return pr?.[0] ?? cardTitle(card);
+}
+
+function relativeAge(atMs: number, nowMs: number): string {
+  const diffSeconds = Math.max(0, Math.round((nowMs - atMs) / 1000));
+  if (diffSeconds < 60) return `${diffSeconds}s ago`;
+  const diffMinutes = Math.round(diffSeconds / 60);
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.round(diffMinutes / 60);
+  return `${diffHours}h ago`;
 }
 
 function cardTitle(card: BoardCard): string {

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -247,6 +247,12 @@ export type TaskStatus =
   | "failed"
   | "cancelled";
 
+export interface TaskTimelineEvent {
+  at: string;
+  status: TaskStatus | "progress";
+  message: string;
+}
+
 /** Codex/Claude task card. Lifecycle: proposed → approved → running → succeeded/failed. */
 export interface CodexTaskCard extends CardBase {
   type: "task";
@@ -257,6 +263,8 @@ export interface CodexTaskCard extends CardBase {
   /** O4 routing risk tier (PR3's autopilot reads it; surfaced in the summary too). */
   riskTier?: "high" | "low";
   runnerHeartbeat?: { lastSeen: string; online: boolean };
+  /** Real task lifecycle events recorded by the queue, used for Hermes timeline narration. */
+  taskEvents?: TaskTimelineEvent[];
   output?: string;
   failureReason?: string;
 }

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -85,6 +85,12 @@ export type TaskStatus =
   | "failed"
   | "cancelled";
 
+export interface TaskTimelineEvent {
+  at: string;
+  status: TaskStatus | "progress";
+  message: string;
+}
+
 export type MissionStatus =
   | "requested"
   | "ready"
@@ -250,6 +256,8 @@ export interface BoardCard {
   sourceFailure?: CardSourceFailure;
   /** Codex task cards: runner liveness. */
   runnerHeartbeat?: CardRunnerHeartbeat;
+  /** Real task lifecycle events recorded by the queue, used for Hermes timeline narration. */
+  taskEvents?: TaskTimelineEvent[];
   /** Per-check CI breakdown (non-done cards) — the list under the bar. */
   checkRuns?: CardCheckRun[];
   /** Hermes review findings (non-done cards) — the "why review" detail. */
@@ -531,6 +539,32 @@ function asArray(value: unknown): unknown[] {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function mapTaskEvents(task: Record<string, unknown>): TaskTimelineEvent[] {
+  return asArray(task.events).flatMap((entry) => {
+    const event = asRecord(entry);
+    if (!event) return [];
+    const at = asString(event.at);
+    const status = asTaskTimelineStatus(event.status);
+    const message = asString(event.message);
+    return at && status && message ? [{ at, status, message }] : [];
+  });
+}
+
+function asTaskTimelineStatus(value: unknown): TaskTimelineEvent["status"] | undefined {
+  if (
+    value === "proposed"
+    || value === "approved"
+    || value === "running"
+    || value === "completed"
+    || value === "failed"
+    || value === "cancelled"
+    || value === "progress"
+  ) {
+    return value;
+  }
+  return undefined;
 }
 
 // Self-healing task titles embed the namespaced surface key
@@ -1245,6 +1279,8 @@ export function enrichBoardCard(
     if (output) card.output = output;
     const failureReason = asString(task.failureReason);
     if (failureReason) card.failureReason = failureReason;
+    const taskEvents = mapTaskEvents(task);
+    if (taskEvents.length > 0) card.taskEvents = taskEvents;
     if (isHermesDecisionRecord(task.decisionRecord)) {
       card.decisionRecord = task.decisionRecord;
     }
@@ -1321,6 +1357,7 @@ export function synthesizeTaskCards(
     if (!id) continue;
     const agent = agentTypeFromTaskAgent(task.agent);
     const prompt = asString(task.prompt);
+    const taskEvents = mapTaskEvents(task);
     const riskTierRaw = asString(task.riskTier);
     const riskTier = riskTierRaw === "high" || riskTierRaw === "low" ? riskTierRaw : undefined;
     const routingReason = asString(task.routingReason);
@@ -1354,6 +1391,7 @@ export function synthesizeTaskCards(
       ...(riskSignals.length > 0 ? { riskSignals } : {}),
       ...(health.sourceFailure ? { sourceFailure: health.sourceFailure } : {}),
       ...(prompt ? { prompt } : {}),
+      ...(taskEvents.length > 0 ? { taskEvents } : {}),
       ...(asString(task.correlationId) ? { correlationId: asString(task.correlationId) } : {}),
       ...(decisionRecord ? { decisionRecord } : {}),
     };

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -635,6 +635,25 @@ describe("enrichBoardCard", () => {
     expect(card.runnerHeartbeat).toEqual({ lastSeen: "2026-05-28T12:00:00Z", online: true });
   });
 
+  it("projects real task timeline events onto task cards", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: {
+        id: "task-1",
+        prompt: "Fix contract tests",
+        events: [
+          { at: "2026-06-01T12:00:00.000Z", status: "proposed", message: "Hermes proposed a bounded Codex task." },
+          { at: "2026-06-01T12:00:12.000Z", status: "running", message: "Codex runner claimed the task." },
+          { at: "", status: "running", message: "missing timestamp ignored" },
+        ],
+      },
+    });
+
+    expect(card.taskEvents).toEqual([
+      { at: "2026-06-01T12:00:00.000Z", status: "proposed", message: "Hermes proposed a bounded Codex task." },
+      { at: "2026-06-01T12:00:12.000Z", status: "running", message: "Codex runner claimed the task." },
+    ]);
+  });
+
   it("falls back to completionSummary for output and marks a stopped runner offline", () => {
     const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
       codexTask: { id: "task-2", status: "approved", prompt: "p", completionSummary: "done summary" },
@@ -1073,8 +1092,11 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
       safety: { readOnly: true, mutates: false },
       generatedAt: "2026-05-31T12:00:00.000Z",
     });
+    const events = [
+      { at: "2026-05-31T12:00:00.000Z", status: "proposed", message: "Hermes proposed a bounded Claude task." },
+    ];
     const [card, ...rest] = synthesizeTaskCards({
-      codexTasks: { items: [{ ...proposedClaude, decisionRecord }] },
+      codexTasks: { items: [{ ...proposedClaude, decisionRecord, events }] },
     }, undefined);
     expect(rest).toHaveLength(0);
     expect(card).toMatchObject({
@@ -1090,6 +1112,7 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
         decision: "routed to claude",
       },
     });
+    expect(card?.taskEvents).toEqual(events);
     // proposed → waiting on the operator to approve
     expect(card?.waitingOn).toEqual({ actor: "operator", tone: "warn" });
   });


### PR DESCRIPTION
## Summary
- project real codex-task-queue lifecycle events onto monitor task cards as taskEvents
- narrate one stable activity-feed line per real route, handoff, pickup, completion, or failure event
- keep legacy status-based task narration only as fallback when a card has no recorded task events

## Validation
- npm run typecheck
- npm test -- test/unit/monitor-v2.test.ts packages/monitor-ui/src/lib/monitor/activity-feed.test.ts
- npm test

## Surfaces
- Monitor board model and monitor UI activity feed only.
- No backend contract, deployment, environment, or authority changes.

## Notes
- Current docs/HERMES_BOARD_WORKFLOW_REDESIGN.md did not contain a P1-8 row on origin/main; this PR follows the P1-8 acceptance text from the task prompt.
- Narration is tied to recorded queue events, not snapshot diffs, so repeated snapshots dedupe into a clean timeline.