### PR TITLE
Fix failed mission triage actions

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -208,6 +208,71 @@ describe("MonitorPage — container", () => {
     }
   });
 
+  test("failed mission triage posts accept/open-issue actions to real mission endpoints", async () => {
+    const failedMission = {
+      id: "surface-sweep-t1-testbed-mission-failed-1",
+      correlationId: "testbed-mission-failed-1",
+      lane: "needs-attention",
+      type: "mission",
+      agentType: "hermes",
+      title: "Surface sweep (T1)",
+      summary: "Browser-agent report returned fail.",
+      repo: "testbed/mission",
+      freshness: 1,
+      state: "fresh",
+      risk: ["testbed"],
+      waitingOn: { actor: "operator", tone: "warn" },
+      missionStatus: "failed",
+      isAction: true,
+      mission: {
+        verdict: "FAILED",
+        verdictTone: "fail",
+        confidence: 0.4,
+        target: "https://staging.example.test",
+        seed: "fresh",
+        path: [],
+        blockers: [],
+        evidence: [],
+        mutationBoundary: "No mutation crossed.",
+        recommendations: [],
+      },
+    } as unknown as MonitorBoard["cards"][number];
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [failedMission],
+      at: "2026-05-28T10:30:00Z",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole, getByText } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Accept failure" })).toBeTruthy());
+
+      fireEvent.click(getByRole("button", { name: "Accept failure" }));
+      expect(getByText(/Accept this failed mission/)).toBeTruthy();
+      fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+
+      fireEvent.click(getByRole("button", { name: "Open issue" }));
+      expect(getByText(/File a GitHub issue/)).toBeTruthy();
+      fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect((fetchSpy.mock.calls[0] as [string, RequestInit])[0]).toBe("/monitor/testbed-missions/testbed-mission-failed-1/accept-failure");
+      expect((fetchSpy.mock.calls[1] as [string, RequestInit])[0]).toBe("/monitor/testbed-missions/testbed-mission-failed-1/open-issue");
+      expect((fetchSpy.mock.calls[0] as [string, RequestInit])[1].method).toBe("POST");
+      expect((fetchSpy.mock.calls[1] as [string, RequestInit])[1].method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   test("operator task cards do not expose secondary dismiss/snooze buttons", async () => {
     const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
       cards: [taskCard()],

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -60,6 +60,10 @@ export interface MonitorPageProps {
   onApproveMission?: (id: string) => void;
   /** Override the drawer mission re-run (defaults to POST /monitor/testbed-missions). */
   onRerunMission?: (targetUrl: string, freshness: "fresh" | "memory") => void;
+  /** Override failed-mission acknowledgement (defaults to POST /monitor/testbed-missions/:id/accept-failure). */
+  onAcceptMissionFailure?: (id: string) => void;
+  /** Override failed-mission issue creation (defaults to POST /monitor/testbed-missions/:id/open-issue). */
+  onOpenMissionIssue?: (id: string) => void;
   /** Override the co-pilot collaboration wiring (defaults to live polling). */
   collaboration?: UseCollaborationOptions;
   /** Override the action-alert wiring (audio/notification/storage) for tests. */
@@ -81,6 +85,8 @@ export function MonitorPage({
   onSnoozeCard = defaultSnoozeCard,
   onApproveMission = defaultApproveMission,
   onRerunMission = defaultRerunMission,
+  onAcceptMissionFailure = defaultAcceptMissionFailure,
+  onOpenMissionIssue = defaultOpenMissionIssue,
   collaboration = {},
   alerts,
   onAlertMute = defaultPostAlertMute,
@@ -128,6 +134,8 @@ export function MonitorPage({
         onSnoozeCard={onSnoozeCard}
         onApproveMission={onApproveMission}
         onRerunMission={onRerunMission}
+        onAcceptMissionFailure={onAcceptMissionFailure}
+        onOpenMissionIssue={onOpenMissionIssue}
         collaboration={collaboration}
         onMute={muteEverywhere}
         onUnmute={unmuteEverywhere}
@@ -259,6 +267,24 @@ function monitorCardActionBase(card: BoardCard): string | undefined {
  */
 function defaultApproveMission(id: string): void {
   void fetch(`${MISSIONS_URL}/${encodeURIComponent(id)}/approve`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+function defaultAcceptMissionFailure(id: string): void {
+  void fetch(`${MISSIONS_URL}/${encodeURIComponent(id)}/accept-failure`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+function defaultOpenMissionIssue(id: string): void {
+  void fetch(`${MISSIONS_URL}/${encodeURIComponent(id)}/open-issue`, {
     method: "POST",
     headers: { "content-type": "application/json" },
   }).catch(() => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -110,6 +110,10 @@ export interface BoardViewProps {
   onSnoozeCard?: (card: BoardCard, untilMs: number) => void;
   /** Re-run a mission (drawer footer) via POST /monitor/testbed-missions. */
   onRerunMission?: (targetUrl: string, freshness: "fresh" | "memory") => void;
+  /** Accept/acknowledge a failed mission via POST /monitor/testbed-missions/:id/accept-failure. */
+  onAcceptMissionFailure?: (id: string) => void;
+  /** File a GitHub issue for a failed mission via POST /monitor/testbed-missions/:id/open-issue. */
+  onOpenMissionIssue?: (id: string) => void;
   collaboration?: UseCollaborationOptions;
   onMute?: (untilMs: number) => void;
   onUnmute?: () => void;
@@ -141,6 +145,8 @@ export function BoardView({
   onDismissCard: persistDismissCard,
   onSnoozeCard: persistSnoozeCard,
   onRerunMission,
+  onAcceptMissionFailure,
+  onOpenMissionIssue,
   collaboration,
   onMute,
   onUnmute,
@@ -295,6 +301,8 @@ export function BoardView({
         const target = c.type === "mission" ? c.mission?.target : undefined;
         if (target) onRerunMission(target, freshness);
       } : undefined}
+      onAcceptMissionFailure={onAcceptMissionFailure ? (c) => onAcceptMissionFailure(c.correlationId ?? c.id) : undefined}
+      onOpenMissionIssue={onOpenMissionIssue ? (c) => onOpenMissionIssue(c.correlationId ?? c.id) : undefined}
       onKeepWatching={(c) => onKeepWatchingCard(c.id)}
     />
   );

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -412,7 +412,7 @@ describe("Card — requested tester mission approve (T6)", () => {
     expect(onApproveMission.mock.calls[0]?.[0]?.id).toBe("testbed-mission-requested-1");
   });
 
-  test("failed mission triage exposes exactly one Re-run primary", () => {
+  test("failed mission triage exposes operator Re-run, Accept failure, and Open issue actions", () => {
     const failedMission = {
       ...requestedMission,
       id: "testbed-mission-failed-1",
@@ -433,13 +433,26 @@ describe("Card — requested tester mission approve (T6)", () => {
       },
     } as unknown as BoardCard;
     const onRerunMission = vi.fn();
-    const { getByRole, getByText, queryByRole } = render(<Card card={failedMission} onRerunMission={onRerunMission} />);
+    const onAcceptMissionFailure = vi.fn();
+    const onOpenMissionIssue = vi.fn();
+    const { getByRole, getByText, queryByRole } = render(
+      <Card
+        card={failedMission}
+        onRerunMission={onRerunMission}
+        onAcceptMissionFailure={onAcceptMissionFailure}
+        onOpenMissionIssue={onOpenMissionIssue}
+      />,
+    );
     expect(getByRole("button", { name: "Re-run" })).toBeTruthy();
+    expect(getByRole("button", { name: "Accept failure" })).toBeTruthy();
+    expect(getByRole("button", { name: "Open issue" })).toBeTruthy();
     expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
     fireEvent.click(getByRole("button", { name: "Re-run" }));
     expect(getByText(/Re-run as a fresh mission\?/)).toBeTruthy();
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onRerunMission).toHaveBeenCalledWith(failedMission, "fresh");
+    expect(onAcceptMissionFailure).not.toHaveBeenCalled();
+    expect(onOpenMissionIssue).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -47,6 +47,10 @@ export type CardProps = {
   onApproveMerge?: (card: BoardCard) => void;
   /** Re-run a failed tester mission. */
   onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
+  /** Accept/acknowledge a failed tester mission without dispatching code work. */
+  onAcceptMissionFailure?: (card: BoardCard) => void;
+  /** File a GitHub issue for a failed tester mission. */
+  onOpenMissionIssue?: (card: BoardCard) => void;
   /** "Keep watching" on the archive hint — cancel/extend this card's auto-archive. */
   onKeepWatching?: (card: BoardCard) => void;
 };
@@ -95,6 +99,8 @@ export function Card({
   onApproveMission,
   onApproveMerge,
   onRerunMission,
+  onAcceptMissionFailure,
+  onOpenMissionIssue,
   onKeepWatching,
 }: CardProps) {
   const isAction = Boolean(card.isAction);
@@ -210,6 +216,8 @@ export function Card({
           onApproveMission={onApproveMission}
           onApproveMerge={onApproveMerge}
           onRerunMission={onRerunMission}
+          onAcceptMissionFailure={onAcceptMissionFailure}
+          onOpenMissionIssue={onOpenMissionIssue}
         />
       ) : null}
 
@@ -425,62 +433,106 @@ function OperatorActions({
   onApproveMission,
   onApproveMerge,
   onRerunMission,
+  onAcceptMissionFailure,
+  onOpenMissionIssue,
 }: {
   card: BoardCard;
   onApprove?: (card: BoardCard) => void;
   onApproveMission?: (card: BoardCard) => void;
   onApproveMerge?: (card: BoardCard) => void;
   onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
+  onAcceptMissionFailure?: (card: BoardCard) => void;
+  onOpenMissionIssue?: (card: BoardCard) => void;
 }) {
-  const [confirming, setConfirming] = useState(false);
+  const [confirmingKey, setConfirmingKey] = useState<string | null>(null);
   const agent = agentLabel(card.agentType);
   const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
   const taskStatus = (card as { taskStatus?: string }).taskStatus;
   const missionStatus = (card as { missionStatus?: string }).missionStatus;
   const missionTarget = card.type === "mission" ? card.mission?.target : undefined;
   const relatedPr = card.type === "pr" ? relatedPrForCard(card) : undefined;
-  const primary =
+  const actions =
     card.type === "task" && taskStatus === "proposed" && onApprove
-      ? {
+      ? [{
+          key: "approve",
           label: "Approve & dispatch",
           confirm: `Dispatch to ${agent}?`,
           run: () => onApprove(card),
-        }
+          kind: "action" as const,
+        }]
       : card.type === "mission" && missionStatus === "requested" && onApproveMission
-        ? {
+        ? [{
+            key: "approve-mission",
             label: "Approve & dispatch",
             confirm: "Dispatch tester runner?",
             run: () => onApproveMission(card),
-          }
-        : card.type === "mission" && missionStatus === "failed" && missionTarget && onRerunMission
-          ? {
-              label: "Re-run",
-              confirm: "Re-run as a fresh mission?",
-              run: () => onRerunMission(card, "fresh" as const),
-            }
+            kind: "action" as const,
+          }]
+        : card.type === "mission" && missionStatus === "failed"
+          ? [
+              missionTarget && onRerunMission
+                ? {
+                    key: "rerun-mission",
+                    label: "Re-run",
+                    confirm: "Re-run as a fresh mission?",
+                    run: () => onRerunMission(card, "fresh" as const),
+                    kind: "action" as const,
+                  }
+                : undefined,
+              onAcceptMissionFailure
+                ? {
+                    key: "accept-failure",
+                    label: "Accept failure",
+                    confirm: "Accept this failed mission and clear the triage card?",
+                    run: () => onAcceptMissionFailure(card),
+                    kind: "ghost" as const,
+                  }
+                : undefined,
+              onOpenMissionIssue
+                ? {
+                    key: "open-issue",
+                    label: "Open issue",
+                    confirm: "File a GitHub issue for this failed mission?",
+                    run: () => onOpenMissionIssue(card),
+                    kind: "ghost" as const,
+                  }
+                : undefined,
+            ].filter((action): action is {
+              key: string;
+              label: string;
+              confirm: string;
+              run: () => void;
+              kind: "action" | "ghost";
+            } => Boolean(action))
           : card.type === "pr" && card.isAction && relatedPr && onApproveMerge
-            ? {
+            ? [{
+                key: "approve-merge",
                 label: "Approve merge",
                 confirm: "Open GitHub merge review?",
                 run: () => onApproveMerge(card),
-              }
-            : undefined;
+                kind: "action" as const,
+              }]
+            : [];
 
-  if (!primary) return null;
+  if (actions.length === 0) return null;
+  const confirming = confirmingKey ? actions.find((action) => action.key === confirmingKey) : undefined;
 
   if (!confirming) {
     return (
       <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Operator actions">
-        <button
-          type="button"
-          className="hm-btn hm-btn--action hm-btn--sm"
-          onClick={(e) => {
-            stop(e);
-            setConfirming(true);
-          }}
-        >
-          {primary.label}
-        </button>
+        {actions.map((action) => (
+          <button
+            type="button"
+            className={`hm-btn ${action.kind === "action" ? "hm-btn--action" : "hm-btn--ghost"} hm-btn--sm`}
+            key={action.key}
+            onClick={(e) => {
+              stop(e);
+              setConfirmingKey(action.key);
+            }}
+          >
+            {action.label}
+          </button>
+        ))}
       </div>
     );
   }
@@ -488,15 +540,15 @@ function OperatorActions({
   return (
     <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Confirm operator action">
       <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
-        {primary.confirm}
+        {confirming.confirm}
       </span>
       <button
         type="button"
         className="hm-btn hm-btn--action hm-btn--sm"
         onClick={(e) => {
           stop(e);
-          setConfirming(false);
-          primary.run();
+          setConfirmingKey(null);
+          confirming.run();
         }}
       >
         Confirm
@@ -506,7 +558,7 @@ function OperatorActions({
         className="hm-btn hm-btn--ghost hm-btn--sm"
         onClick={(e) => {
           stop(e);
-          setConfirming(false);
+          setConfirmingKey(null);
         }}
       >
         Cancel

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -25,6 +25,10 @@ export type CardRouterProps = {
   onApproveMerge?: (card: BoardCard) => void;
   /** Re-run a failed tester mission. */
   onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
+  /** Accept/acknowledge a failed tester mission. */
+  onAcceptMissionFailure?: (card: BoardCard) => void;
+  /** File a GitHub issue for a failed tester mission. */
+  onOpenMissionIssue?: (card: BoardCard) => void;
   /** "Keep watching" on the archive hint — cancel this card's auto-archive. */
   onKeepWatching?: (card: BoardCard) => void;
 };
@@ -38,6 +42,8 @@ export function CardRouter({
   onApproveMission,
   onApproveMerge,
   onRerunMission,
+  onAcceptMissionFailure,
+  onOpenMissionIssue,
   onKeepWatching,
 }: CardRouterProps) {
   const renderer = pickRenderer(card);
@@ -65,6 +71,8 @@ export function CardRouter({
       onApproveMission={onApproveMission}
       onApproveMerge={onApproveMerge}
       onRerunMission={onRerunMission}
+      onAcceptMissionFailure={onAcceptMissionFailure}
+      onOpenMissionIssue={onOpenMissionIssue}
       onKeepWatching={onKeepWatching}
     />
   );

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -149,10 +149,12 @@ import {
 } from "./codex-task-queue.js";
 import { parseProposeTaskPayload } from "./codex-task-request.js";
 import {
+  acceptTestbedMissionFailure,
   diagnoseTestbedMissionReportFromMessage,
   failedTestbedMissionsForSelfHealing,
   listTestbedMissionRuns,
   readTestbedMissionRunnerHeartbeat,
+  recordTestbedMissionIssueOpened,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
   summarizeTestbedMissionRunnerHeartbeat,
@@ -787,6 +789,42 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorTestbedMissionApprovalRequest(testbedMissionApprovalId, response);
+    return;
+  }
+  const testbedMissionAcceptFailureId = monitorTestbedMissionActionId(url.pathname, "accept-failure");
+  if (request.method === "POST" && testbedMissionAcceptFailureId) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "mission_accept_failure_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedMissionAcceptFailureRequest(testbedMissionAcceptFailureId, response);
+    return;
+  }
+  const testbedMissionOpenIssueId = monitorTestbedMissionActionId(url.pathname, "open-issue");
+  if (request.method === "POST" && testbedMissionOpenIssueId) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "mission_open_issue_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedMissionOpenIssueRequest(testbedMissionOpenIssueId, request, response);
     return;
   }
   const testbedMissionId = monitorTestbedMissionId(url.pathname);
@@ -1638,6 +1676,106 @@ async function handleMonitorTestbedMissionApprovalRequest(id: string, response: 
   }
 }
 
+async function handleMonitorTestbedMissionAcceptFailureRequest(id: string, response: http.ServerResponse) {
+  try {
+    const result = acceptTestbedMissionFailure(id, { acceptedBy: "operator" });
+    if (!result.ok) {
+      if (result.error === "not_found") {
+        writeJson(response, 404, { error: "testbed_mission_not_found", id });
+        return;
+      }
+      writeJson(response, 409, {
+        error: "testbed_mission_not_failed",
+        id,
+        status: result.run?.status,
+      });
+      return;
+    }
+    recordTestbedMissionFailureAcceptedCollaboration(result.run);
+    logger.info({ missionId: id }, "monitor_testbed_mission_failure_accepted");
+    writeJson(response, 200, {
+      ok: true,
+      run: result.run,
+    });
+  } catch (error) {
+    logger.error({ err: error, missionId: id }, "monitor_testbed_mission_accept_failure_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_mission_accept_failure_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorTestbedMissionOpenIssueRequest(
+  id: string,
+  request: http.IncomingMessage,
+  response: http.ServerResponse
+) {
+  try {
+    const run = listTestbedMissionRuns({ limit: 50 }).find((candidate) => candidate.id === id);
+    if (!run) {
+      writeJson(response, 404, { error: "testbed_mission_not_found", id });
+      return;
+    }
+    if (run.status !== "failed") {
+      writeJson(response, 409, { error: "testbed_mission_not_failed", id, status: run.status });
+      return;
+    }
+
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+
+    const repo = stringField(payload, "repo")
+      ?? optionalEnv("TESTBED_MISSION_ISSUE_REPO")
+      ?? optionalEnv("B2_SELF_HEALING_REPO")
+      ?? optionalEnv("GITHUB_DEFAULT_REPO")
+      ?? optionalEnv("AVERRAY_REPO");
+    if (!repo || !/^[^/\s]+\/[^/\s]+$/.test(repo)) {
+      writeJson(response, 400, {
+        error: "missing_issue_repo",
+        message: "Set TESTBED_MISSION_ISSUE_REPO or pass { repo: \"owner/name\" } to file a mission issue.",
+      });
+      return;
+    }
+    const token = githubTokenForRepo(repo, process.env);
+    if (!token) {
+      writeJson(response, 503, {
+        error: "github_token_missing",
+        message: `No GitHub token is configured for ${repo}; the mission was not marked resolved.`,
+      });
+      return;
+    }
+
+    const issue = await createGithubIssueForMission(repo, token, run);
+    const recorded = recordTestbedMissionIssueOpened(id, {
+      issueUrl: issue.htmlUrl,
+      ...(issue.number !== undefined ? { issueNumber: issue.number } : {}),
+      openedBy: "operator",
+    });
+    if (!recorded.ok) {
+      writeJson(response, 409, { error: "testbed_mission_issue_record_failed", id, state: recorded.error });
+      return;
+    }
+    recordTestbedMissionIssueOpenedCollaboration(recorded.run, issue.htmlUrl);
+    logger.info({ missionId: id, repo, issueNumber: issue.number }, "monitor_testbed_mission_issue_opened");
+    writeJson(response, 200, {
+      ok: true,
+      issue,
+      run: recorded.run,
+    });
+  } catch (error) {
+    logger.error({ err: error, missionId: id }, "monitor_testbed_mission_open_issue_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_mission_open_issue_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 function recordTestbedMissionCollaboration(run: TestbedMissionRun): void {
   try {
     const runner = summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat());
@@ -1692,6 +1830,41 @@ function recordTestbedMissionApprovalCollaboration(run: TestbedMissionRun): void
     });
   } catch (error) {
     logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_approval_collaboration_failed");
+  }
+}
+
+function recordTestbedMissionFailureAcceptedCollaboration(run: TestbedMissionRun): void {
+  try {
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "status",
+      addressedTo: "operator",
+      relatedCorrelationId: run.id,
+      text: [
+        `Operator accepted failed tester mission ${run.id}.`,
+        "No code task was dispatched; this card can move out of needs-attention.",
+      ].join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_failure_accept_collaboration_failed");
+  }
+}
+
+function recordTestbedMissionIssueOpenedCollaboration(run: TestbedMissionRun, issueUrl: string): void {
+  try {
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "status",
+      addressedTo: "operator",
+      relatedCorrelationId: run.id,
+      text: [
+        `Operator filed a GitHub issue for failed tester mission ${run.id}.`,
+        issueUrl,
+        "No code task was dispatched by this triage action.",
+      ].join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_issue_open_collaboration_failed");
   }
 }
 
@@ -3290,6 +3463,99 @@ function monitorTestbedMissionApproveId(pathname: string): string | undefined {
   const raw = pathname.slice(prefix.length, -suffix.length);
   const id = decodeURIComponent(raw).trim();
   return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+function monitorTestbedMissionActionId(pathname: string, action: "accept-failure" | "open-issue"): string | undefined {
+  const prefix = "/monitor/testbed-missions/";
+  const suffix = `/${action}`;
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return undefined;
+  const raw = pathname.slice(prefix.length, -suffix.length);
+  const id = decodeURIComponent(raw).trim();
+  return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+async function createGithubIssueForMission(
+  repo: string,
+  token: string,
+  run: TestbedMissionRun,
+): Promise<{ number?: number; htmlUrl: string }> {
+  const apiBase = (optionalEnv("GITHUB_API_BASE_URL") ?? "https://api.github.com").replace(/\/+$/g, "");
+  const title = `Testbed mission failed: ${run.title}`;
+  const body = missionIssueBody(run);
+  const response = await fetch(`${apiBase}/repos/${repo}/issues`, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": "averray-reference-agent-monitor",
+      "x-github-api-version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      title,
+      body,
+    }),
+  });
+  const text = await response.text();
+  let payload: unknown;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = {};
+  }
+  if (!response.ok) {
+    throw new Error(`GitHub issue creation failed for ${repo}: HTTP ${response.status}`);
+  }
+  const record = isRecord(payload) ? payload : {};
+  const htmlUrl = stringField(record, "html_url");
+  if (!htmlUrl) {
+    throw new Error(`GitHub issue creation for ${repo} did not return html_url.`);
+  }
+  return {
+    htmlUrl,
+    ...(numberField(record, "number") !== undefined ? { number: numberField(record, "number") } : {}),
+  };
+}
+
+function missionIssueBody(run: TestbedMissionRun): string {
+  const structured = isRecord(run.result) && isRecord(run.result.structuredReport)
+    ? run.result.structuredReport
+    : undefined;
+  const blockers = Array.isArray(structured?.blockers)
+    ? structured.blockers.filter((value): value is string => typeof value === "string" && value.length > 0)
+    : [];
+  const recommendations = Array.isArray(structured?.recommendations)
+    ? structured.recommendations.filter((value): value is string => typeof value === "string" && value.length > 0)
+    : [];
+  const evidence = Array.isArray(structured?.evidence)
+    ? structured.evidence.filter((value): value is string => typeof value === "string" && value.length > 0)
+    : [];
+  return [
+    "Filed from the Hermes monitor failed-mission triage action.",
+    "",
+    `Mission id: ${run.id}`,
+    `Target: ${run.targetUrl}`,
+    `Goal: ${run.goal}`,
+    `Status reason: ${run.statusReason}`,
+    run.failureReason ? `Failure reason: ${run.failureReason}` : "",
+    "",
+    blockers.length ? `Blockers:\n${blockers.map((item) => `- ${item}`).join("\n")}` : "Blockers: not recorded",
+    recommendations.length ? `Recommendations:\n${recommendations.map((item) => `- ${item}`).join("\n")}` : "Recommendations: not recorded",
+    evidence.length ? `Evidence:\n${evidence.map((item) => `- ${item}`).join("\n")}` : "Evidence: see the mission run record in Hermes.",
+    "",
+    "No code task was auto-dispatched by this action.",
+  ].filter(Boolean).join("\n");
+}
+
+function githubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {
+  const [owner, name] = repo.split("/", 2);
+  const repoToken = owner && name ? env[`GITHUB_TOKEN_${toEnvKey(owner)}_${toEnvKey(name)}`]?.trim() : undefined;
+  const ownerToken = owner ? env[`GITHUB_TOKEN_${toEnvKey(owner)}`]?.trim() : undefined;
+  return repoToken || ownerToken || env.GITHUB_TOKEN?.trim() || undefined;
+}
+
+function toEnvKey(value: string): string {
+  return value.toUpperCase().replace(/[^A-Z0-9]+/g, "_");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -153,7 +153,7 @@ function classifyItem(
     if (failed) {
       return {
         lane: "Needs Attention",
-        owner: "Hermes",
+        owner: "Operator",
         verdict: "mission failed",
         next: "inspect the browser-agent report and decide whether the page or the mission prompt needs the next fix",
       };

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -70,6 +70,12 @@ export interface TestbedMissionRun {
   completedAt?: string;
   failedAt?: string;
   failureReason?: string;
+  operatorAcceptedAt?: string;
+  operatorAcceptedBy?: string;
+  operatorIssueOpenedAt?: string;
+  operatorIssueOpenedBy?: string;
+  operatorIssueUrl?: string;
+  operatorIssueNumber?: number;
   stdoutTail?: string;
   stderrTail?: string;
   progressMessage?: string;
@@ -163,6 +169,10 @@ export interface RecordTestbedMissionRunOptions {
 export type ApproveTestbedMissionRunResult =
   | { ok: true; run: TestbedMissionRun }
   | { ok: false; error: "not_found" | "not_requested"; run?: TestbedMissionRun };
+
+export type TestbedMissionFailureTriageResult =
+  | { ok: true; run: TestbedMissionRun }
+  | { ok: false; error: "not_found" | "not_failed"; run?: TestbedMissionRun };
 
 export interface TestbedMissionRunnerHeartbeat {
   schemaVersion: 1;
@@ -312,6 +322,66 @@ export function approveTestbedMissionRun(
     status: "ready",
     event: "mission_approved",
     message: `Operator approved the requested tester run; ${existing.statusReason}`,
+  });
+  trimMissionHistory(existing);
+  persistMissionStore(deps.path);
+  return { ok: true, run: cloneRun(existing) };
+}
+
+export function acceptTestbedMissionFailure(
+  id: string,
+  deps: TestbedMissionStoreDeps & { acceptedBy?: string } = {}
+): TestbedMissionFailureTriageResult {
+  ensureMissionStoreLoaded(deps.path, { force: true });
+  const existing = missionRuns.find((run) => run.id === id);
+  if (!existing) return { ok: false, error: "not_found" };
+  if (existing.status !== "failed") {
+    return { ok: false, error: "not_failed", run: cloneRun(existing) };
+  }
+  const now = (deps.now ?? new Date()).toISOString();
+  existing.operatorAcceptedAt = now;
+  existing.operatorAcceptedBy = deps.acceptedBy ?? "operator";
+  existing.updatedAt = now;
+  existing.statusReason = `Operator accepted the failed mission outcome for triage; no code task was dispatched.`;
+  existing.history.push({
+    at: now,
+    status: "failed",
+    event: "mission_failure_accepted",
+    message: existing.statusReason,
+  });
+  trimMissionHistory(existing);
+  persistMissionStore(deps.path);
+  return { ok: true, run: cloneRun(existing) };
+}
+
+export function recordTestbedMissionIssueOpened(
+  id: string,
+  deps: TestbedMissionStoreDeps & {
+    issueUrl: string;
+    issueNumber?: number;
+    openedBy?: string;
+  }
+): TestbedMissionFailureTriageResult {
+  ensureMissionStoreLoaded(deps.path, { force: true });
+  const existing = missionRuns.find((run) => run.id === id);
+  if (!existing) return { ok: false, error: "not_found" };
+  if (existing.status !== "failed") {
+    return { ok: false, error: "not_failed", run: cloneRun(existing) };
+  }
+  const now = (deps.now ?? new Date()).toISOString();
+  existing.operatorIssueOpenedAt = now;
+  existing.operatorIssueOpenedBy = deps.openedBy ?? "operator";
+  existing.operatorIssueUrl = deps.issueUrl;
+  if (deps.issueNumber !== undefined) existing.operatorIssueNumber = deps.issueNumber;
+  existing.updatedAt = now;
+  existing.statusReason = `Operator filed a GitHub issue for this failed mission; no code task was dispatched.`;
+  existing.history.push({
+    at: now,
+    status: "failed",
+    event: "mission_failure_issue_opened",
+    message: deps.issueNumber !== undefined
+      ? `Operator filed issue #${deps.issueNumber}: ${deps.issueUrl}`
+      : `Operator filed issue: ${deps.issueUrl}`,
   });
   trimMissionHistory(existing);
   persistMissionStore(deps.path);
@@ -543,10 +613,13 @@ export function diagnoseTestbedMissionReportFromMessage(input: MissionReportInpu
 
 export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<string, unknown> {
   const active = run.status === "requested" || run.status === "ready" || run.status === "running";
+  const failureTriaged = run.status === "failed" && Boolean(run.operatorAcceptedAt || run.operatorIssueOpenedAt);
   const terminalStatus = run.status === "requested"
     ? "requested"
     : run.status === "completed"
       ? "completed"
+      : failureTriaged
+        ? "completed"
       : run.status === "failed"
         ? "failed"
         : "running";
@@ -580,6 +653,15 @@ export function testbedMissionRunToMonitorItem(run: TestbedMissionRun): Record<s
       missionStatus: run.status,
       finalReason: run.statusReason,
       finalVerdict: verdict,
+      ...(run.operatorAcceptedAt ? { operatorAcceptedAt: run.operatorAcceptedAt, operatorAcceptedBy: run.operatorAcceptedBy } : {}),
+      ...(run.operatorIssueUrl
+        ? {
+            operatorIssueUrl: run.operatorIssueUrl,
+            operatorIssueNumber: run.operatorIssueNumber,
+            operatorIssueOpenedAt: run.operatorIssueOpenedAt,
+            operatorIssueOpenedBy: run.operatorIssueOpenedBy,
+          }
+        : {}),
       mergeRecommendation: "not_applicable",
       ...(structuredReport ? { structuredReport } : {}),
       reviewSignals: {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, beforeEach } from "vitest";
 
 import {
   __resetTestbedMissionRunsForTests,
+  acceptTestbedMissionFailure,
   diagnoseTestbedMissionReportFromMessage,
   failedTestbedMissionsForSelfHealing,
   failTestbedMissionRun,
   listTestbedMissionRuns,
+  recordTestbedMissionIssueOpened,
   recordTestbedMissionReportFromMessage,
   recordTestbedMissionRunFromOperatorResult,
   testbedMissionBaselinePrompt,
@@ -625,6 +627,51 @@ describe("monitor testbed mission runs", () => {
       now: new Date("2026-05-25T12:00:00.000Z"),
       maxAgeHours: 24,
     }).map((run) => run.id)).toEqual([fresh.id]);
+  });
+
+  it("marks accepted or issue-filed failed missions as triaged history for the board", () => {
+    const accepted = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/accepted" }),
+      Date.parse("2026-05-25T10:00:00.000Z"),
+    )!;
+    failTestbedMissionRun(accepted.id, {
+      now: new Date("2026-05-25T10:05:00.000Z"),
+      failureReason: "operator reviewed this known failure",
+    });
+    const acceptedResult = acceptTestbedMissionFailure(accepted.id, {
+      now: new Date("2026-05-25T10:06:00.000Z"),
+      acceptedBy: "operator",
+    });
+    expect(acceptedResult).toMatchObject({ ok: true });
+    expect(testbedMissionRunToMonitorItem(acceptedResult.ok ? acceptedResult.run : accepted)).toMatchObject({
+      status: "completed",
+      summary: {
+        operatorAcceptedAt: "2026-05-25T10:06:00.000Z",
+      },
+    });
+
+    const issue = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/issue" }),
+      Date.parse("2026-05-25T11:00:00.000Z"),
+    )!;
+    failTestbedMissionRun(issue.id, {
+      now: new Date("2026-05-25T11:05:00.000Z"),
+      failureReason: "needs product tracking",
+    });
+    const issueResult = recordTestbedMissionIssueOpened(issue.id, {
+      now: new Date("2026-05-25T11:06:00.000Z"),
+      issueUrl: "https://github.com/depre-dev/averray-reference-agent/issues/123",
+      issueNumber: 123,
+      openedBy: "operator",
+    });
+    expect(issueResult).toMatchObject({ ok: true });
+    expect(testbedMissionRunToMonitorItem(issueResult.ok ? issueResult.run : issue)).toMatchObject({
+      status: "completed",
+      summary: {
+        operatorIssueUrl: "https://github.com/depre-dev/averray-reference-agent/issues/123",
+        operatorIssueNumber: 123,
+      },
+    });
   });
 });
 

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1858,6 +1858,55 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
       waitingOn: { actor: "operator", tone: "warn" },
     });
   });
+
+  it("surfaces a failed testbed mission as operator-waiting triage, not agent work", () => {
+    const missionId = "testbed-mission-surface-sweep-1";
+    const snap = buildV2BoardSnapshot(
+      {
+        active: [],
+        recent: [],
+        testbedMissions: [{
+          schemaVersion: 1,
+          kind: "testbed_mission_run",
+          id: missionId,
+          status: "failed",
+          title: "Surface sweep (T1)",
+          targetUrl: "https://averray.com/",
+          goal: "Sweep the public surface.",
+          agentName: "Hermes",
+          freshMemory: true,
+          allowTestMutations: false,
+          createdAt: "2026-06-01T10:00:00.000Z",
+          updatedAt: "2026-06-01T10:05:00.000Z",
+          failedAt: "2026-06-01T10:05:00.000Z",
+          statusReason: "Browser-agent report returned fail.",
+          failureReason: "Browser-agent report returned fail.",
+          result: {
+            verdict: "fail",
+            confidence: 0.4,
+            stoppedBeforeMutation: true,
+            blockers: ["primary action unclear"],
+            confusingMoments: [],
+            evidence: [],
+            scores: {},
+            recommendations: ["Fix the visible call to action, then rerun the mission."],
+          },
+        }],
+        codexTasks: { items: [] },
+      },
+      { repo: "depre-dev/averray-reference-agent", now: () => new Date("2026-06-01T10:06:00.000Z") },
+    );
+
+    expect(snap.cards).toHaveLength(1);
+    expect(snap.cards[0]).toMatchObject({
+      lane: "needs-attention",
+      type: "mission",
+      missionStatus: "failed",
+      waitingOn: { actor: "operator", tone: "warn" },
+      isAction: true,
+    });
+    expect(snap.cards.some((card) => card.type === "task")).toBe(false);
+  });
 });
 
 describe("enrichBoardCard — task status", () => {


### PR DESCRIPTION
## What changed
- Reclassify failed testbed mission monitor cards as waiting on Operator instead of Hermes/agent.
- Add failed-mission card actions for Re-run, Accept failure, and Open issue.
- Add persisted monitor endpoints for accepting failed missions and filing GitHub issues; both record operator triage and explicitly do not dispatch code tasks.
- Keep triaged failed missions out of needs-attention while preserving the underlying missionStatus as failed in the summary.

## Checks run
- npm install
- npm run build
- npm run typecheck
- npm test
- npm test -- test/unit/monitor-testbed-missions.test.ts test/unit/monitor-v2.test.ts packages/monitor-ui/src/components/cards/Card.test.tsx packages/monitor-ui/src/MonitorPage.test.tsx

## Surfaces affected
- slack-operator monitor backend
- monitor UI
- tests

## Environment / ops
- Open issue uses TESTBED_MISSION_ISSUE_REPO, B2_SELF_HEALING_REPO, GITHUB_DEFAULT_REPO, or AVERRAY_REPO as the repo fallback.
- GitHub issue creation requires an appropriate GitHub token env var; missing token fails closed without marking the mission triaged.

## Safety
- Advisory/operator-triage only.
- No auto-dispatch of Codex/Claude/code tasks from failed mission triage actions.