### PR TITLE
fix(testbed): keep public sweeps off gated app

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -98,6 +98,10 @@ runner". It's a profile-gated service, mirroring `codex-runner` /
 **`.env.prod` edits:**
 ```
 TESTBED_MISSION_RUNNER_ENABLED=1
+# Public-only T1 route sweeps should target the public site. Keep
+# AVERRAY_APP_BASE_URL pointed at the gated operator app for signed-in T2/T3
+# sessions.
+TESTBED_SURFACE_SWEEP_BASE_URL=https://averray.com
 # Optional: the env's truth boundary the honesty check asserts. Set to
 # testnet / demo / local-simulation when the deployed env is non-production so
 # data-bearing surfaces must carry that marker; leave empty otherwise.

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -78,6 +78,10 @@ TESTBED_GOLDPATH_MODEL=
 # label. Empty ⇒ self-consistency checks only (errored-but-silent /
 # empty-unlabeled). Set to testnet/demo/local-simulation when the deployed env
 # is non-production so data-bearing surfaces must carry that marker.
+#
+# Public-only T1 sweeps should use the public site. app.averray.com is the
+# gated operator app; keep AVERRAY_APP_BASE_URL for signed-in T2/T3 sessions.
+TESTBED_SURFACE_SWEEP_BASE_URL=https://averray.com
 AVERRAY_TESTBED_EXPECTED_BOUNDARY=
 # T3 SIWE auth mission: runner reaches the signer sidecar over the compose
 # network and probes protected platform routes read-only (wrong-role requests

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -284,12 +284,13 @@ services:
       CLAUDE_WORKER_AUTH_MODE: ${CLAUDE_WORKER_AUTH_MODE:-sub}
       CLAUDE_CODE_OAUTH_TOKEN: ${CLAUDE_CODE_OAUTH_TOKEN:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # T1 surface sweep: base URL for relative routes (falls back to the
-      # mission's targetUrl when unset) + the env's truth boundary the honesty
-      # check asserts. Leave EXPECTED_BOUNDARY empty for the self-consistency
-      # checks only (errored-but-silent / empty-unlabeled); set demo / testnet /
-      # local-simulation to ALSO require that marker on data-bearing surfaces.
+      # T1 surface sweep: public base URL for relative public routes + the env's
+      # truth boundary the honesty check asserts. Leave EXPECTED_BOUNDARY empty
+      # for the self-consistency checks only (errored-but-silent /
+      # empty-unlabeled); set demo / testnet / local-simulation to ALSO require
+      # that marker on data-bearing surfaces.
       AVERRAY_APP_BASE_URL: ${AVERRAY_APP_BASE_URL:-}
+      TESTBED_SURFACE_SWEEP_BASE_URL: ${TESTBED_SURFACE_SWEEP_BASE_URL:-https://averray.com}
       AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL:-}
       AVERRAY_TESTBED_EXPECTED_BOUNDARY: ${AVERRAY_TESTBED_EXPECTED_BOUNDARY:-}
       # T3b SIWE auth mission: the sidecar base URL + the role-gated probe paths.

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -689,6 +689,14 @@ export function testbedMissionCodexFollowupPrompt(run: TestbedMissionRun): strin
 
 export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): TestbedMissionSelfHealingDisposition {
   const reason = run.failureReason ?? run.statusReason ?? "no reason recorded";
+  const structuredReport = testbedMissionStructuredReport(run);
+  if (testbedMissionEnvironmentOrAuthFailure(run, structuredReport)) {
+    return {
+      autoFixable: false,
+      reason: "environment_or_auth_failure",
+      summary: `Testbed mission ${run.id} failed on an environment/auth/runner boundary for ${run.targetUrl}: ${reason}`,
+    };
+  }
   if (run.history.some((entry) => entry.event === "mission_runner_failed")) {
     return {
       autoFixable: false,
@@ -704,20 +712,11 @@ export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): Te
     };
   }
 
-  const structuredReport = testbedMissionStructuredReport(run);
   if (!structuredReport || !run.result) {
     return {
       autoFixable: false,
       reason: "missing_product_report",
       summary: `Testbed mission ${run.id} failed without an attached product report for ${run.targetUrl}: ${reason}`,
-    };
-  }
-
-  if (testbedMissionEnvironmentOrAuthFailure(run, structuredReport)) {
-    return {
-      autoFixable: false,
-      reason: "environment_or_auth_failure",
-      summary: `Testbed mission ${run.id} failed on an environment/auth/runner boundary for ${run.targetUrl}: ${reason}`,
     };
   }
 
@@ -736,25 +735,36 @@ export function testbedMissionSelfHealingDisposition(run: TestbedMissionRun): Te
 
 function testbedMissionEnvironmentOrAuthFailure(
   run: TestbedMissionRun,
-  report: TestbedMissionStructuredReport,
+  report?: TestbedMissionStructuredReport,
 ): boolean {
   const haystack = [
     run.failureReason,
     run.statusReason,
-    report.summary,
-    ...report.blockers,
-    ...report.confusingMoments,
-    ...report.recommendations,
-    ...report.evidence,
-    ...report.completedPath,
+    run.stdoutTail,
+    run.stderrTail,
+    ...run.history.map((entry) => entry.message),
+    ...(report
+      ? [
+        report.summary,
+        ...report.blockers,
+        ...report.confusingMoments,
+        ...report.recommendations,
+        ...report.evidence,
+        ...report.completedPath,
+      ]
+      : []),
   ].filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
     .join("\n");
 
   return [
-    /\b(?:http\s*)?(?:401|403)\b/i,
+    /\b(?:http\s*)?(?:401|403|5\d\d)\b/i,
+    /\bstatus[=:\s]+(?:401|403|5\d\d)\b/i,
     /unauthori[sz]ed|forbidden|access denied|authentication required|login required|sign[ -]?in required/i,
-    /cloudflare access|net::err_|err_name_not_resolved|econnrefused|connection refused/i,
-    /page load failed|navigation failed|browser context closed|target closed|timed out/i,
+    /www-authenticate|basic realm|basic auth|cloudflare access/i,
+    /bad gateway|service unavailable|gateway timeout|internal server error/i,
+    /net::err_|err_name_not_resolved|econnrefused|connection refused/i,
+    /page load failed|navigation failed|browser context closed|target closed|timed out|timeout/i,
+    /runner[-\s]?(?:killed|terminated)|\bexit(?:ed)?\b|exit code|sig(?:term|kill)/i,
   ].some((pattern) => pattern.test(haystack));
 }
 

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -39,8 +39,10 @@ export interface TestbedMissionRunnerConfig {
   browserExecutablePath?: string;
   artifactsDir?: string;
   maxBrowserSteps?: number;
-  /** Base URL the surface sweep (T1) joins relative routes to. */
+  /** Base URL the authenticated app/session helpers use. */
   appBaseUrl?: string;
+  /** Public base URL the surface sweep (T1) joins relative routes to. */
+  surfaceSweepBaseUrl?: string;
   /** Base URL for platform API role-gating probes (T3 SIWE mission). */
   apiBaseUrl?: string;
   /** Local signer sidecar URL for T3 SIWE mission sessions. */
@@ -106,6 +108,9 @@ export function parseTestbedMissionRunnerConfig(
     maxBrowserSteps: positiveInt(env.TESTBED_MISSION_MAX_BROWSER_STEPS, 8),
     ...(env.AVERRAY_APP_BASE_URL || env.AVERRAY_API_BASE_URL
       ? { appBaseUrl: env.AVERRAY_APP_BASE_URL || env.AVERRAY_API_BASE_URL }
+      : {}),
+    ...(env.TESTBED_SURFACE_SWEEP_BASE_URL || env.AVERRAY_PUBLIC_BASE_URL
+      ? { surfaceSweepBaseUrl: env.TESTBED_SURFACE_SWEEP_BASE_URL || env.AVERRAY_PUBLIC_BASE_URL }
       : {}),
     ...(env.AVERRAY_API_BASE_URL ? { apiBaseUrl: env.AVERRAY_API_BASE_URL } : {}),
     signerBaseUrl: env.TEST_WALLET_SIGNER_BASE_URL || "http://127.0.0.1:8791",
@@ -335,8 +340,18 @@ export async function executeBrowserTestbedMission(
     const resolveSession = deps.resolveSession ?? defaultResolveSweepSession;
     const session = await resolveSession(config);
     // Drop the SweepSessionConfig (env source) and pass the RESOLVED session.
-    const { session: _sessionConfig, ...sweepConfig } = config;
-    return executeSurfaceSweep(mission, { ...sweepConfig, ...(session ? { session } : {}) }, deps);
+    // T1 public sweeps use the public sweep base; the gated app base remains
+    // available to T2/T3 session flows.
+    const { session: _sessionConfig, surfaceSweepBaseUrl, ...sweepConfig } = config;
+    return executeSurfaceSweep(
+      mission,
+      {
+        ...sweepConfig,
+        appBaseUrl: session ? config.appBaseUrl : (surfaceSweepBaseUrl ?? config.appBaseUrl),
+        ...(session ? { session } : {}),
+      },
+      deps,
+    );
   }
   if (mission.mode === "siwe_auth") {
     return executeSiweAuthMission(mission, config, deps);

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -550,6 +550,65 @@ describe("monitor testbed mission runs", () => {
     expect(disposition.fixPrompt).toBeUndefined();
   });
 
+  it("keeps Caddy Basic-auth surface sweep failures triage-only", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ mode: "surface_sweep", targetUrl: "https://app.averray.com" }),
+      Date.parse("2026-06-01T10:00:00.000Z"),
+    );
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: run!.id,
+        text: JSON.stringify({
+          verdict: "fail",
+          confidence: 0.95,
+          stoppedBeforeMutation: true,
+          mutationBoundaryNotes: ["Read-only surface sweep stopped before the app rendered."],
+          completedPath: ["swept / -> https://app.averray.com/ (status 401)"],
+          blockers: ["/ failed to load cleanly (status 401)."],
+          confusingMoments: ["The hosted operator app asked for Basic auth before any product surface loaded."],
+          recommendations: ["Run public-only T1 sweeps against the public site, or provide the correct authenticated session path for app routes."],
+          evidence: [
+            "route / :: status=401 title=\"\" errors=1",
+            "www-authenticate: Basic realm=\"Averray Operator\"",
+            "server: Caddy",
+          ],
+          scores: { orientation: 0 },
+        }),
+      },
+      Date.parse("2026-06-01T10:05:00.000Z"),
+    );
+
+    const disposition = testbedMissionSelfHealingDisposition(updated!);
+    expect(disposition).toMatchObject({
+      autoFixable: false,
+      reason: "environment_or_auth_failure",
+    });
+    expect(disposition.summary).toContain("environment/auth/runner boundary");
+    expect(disposition.fixPrompt).toBeUndefined();
+  });
+
+  it("classifies 5xx, timeouts, and runner exits as environment failures before self-healing", () => {
+    for (const failureReason of [
+      "Browser-agent report returned fail; blocker: HTTP 503 Service Unavailable while loading the route.",
+      "Hermes testbed runner command timed out after 1200000ms.",
+      "runner-killed EXIT 137 before Playwright produced a report.",
+    ]) {
+      __resetTestbedMissionRunsForTests();
+      const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-06-01T10:00:00.000Z"));
+      const failed = failTestbedMissionRun(run!.id, {
+        now: new Date("2026-06-01T10:05:00.000Z"),
+        failureReason,
+      });
+
+      const disposition = testbedMissionSelfHealingDisposition(failed!);
+      expect(disposition).toMatchObject({
+        autoFixable: false,
+        reason: "environment_or_auth_failure",
+      });
+      expect(disposition.fixPrompt).toBeUndefined();
+    }
+  });
+
   it("marks runner/report-pipeline failures as human-review, not auto-fixable", () => {
     const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
     const failed = failTestbedMissionRun(run!.id, {

--- a/test/unit/testbed-surface-sweep.test.ts
+++ b/test/unit/testbed-surface-sweep.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../services/slack-operator/src/testbed-surface-sweep.js";
 import {
   executeBrowserTestbedMission,
+  parseTestbedMissionRunnerConfig,
   type TestbedMissionRunnerConfig,
 } from "../../services/slack-operator/src/testbed-mission-runner.js";
 import type { TestbedMissionRun } from "../../services/slack-operator/src/monitor-testbed-missions.js";
@@ -199,6 +200,18 @@ describe("buildSweepReport + executeSurfaceSweep (injected capture)", () => {
 });
 
 describe("executeBrowserTestbedMission — dispatch (single-URL explore stays intact)", () => {
+  it("parses a dedicated public surface sweep base without changing the gated app base", () => {
+    const parsed = parseTestbedMissionRunnerConfig({
+      TESTBED_MISSION_RUNNER_ENABLED: "1",
+      AVERRAY_APP_BASE_URL: "https://app.averray.com",
+      AVERRAY_API_BASE_URL: "https://api.averray.com",
+      TESTBED_SURFACE_SWEEP_BASE_URL: "https://averray.com",
+    });
+
+    expect(parsed.appBaseUrl).toBe("https://app.averray.com");
+    expect(parsed.surfaceSweepBaseUrl).toBe("https://averray.com");
+  });
+
   it("routes a surface_sweep mission to the sweep (uses the injected capture)", async () => {
     const fake = vi.fn(async (url: string, route: string) => capture({ route, url }));
     const result = await executeBrowserTestbedMission(mission({ mode: "surface_sweep", routes: ["/"] }), config, {
@@ -206,6 +219,26 @@ describe("executeBrowserTestbedMission — dispatch (single-URL explore stays in
     });
     expect(fake).toHaveBeenCalledTimes(1);
     expect(JSON.parse(result.reportText ?? "{}").executor).toBe("surface_sweep");
+  });
+
+  it("routes public surface_sweep URLs through the dedicated public base", async () => {
+    const fake = vi.fn(async (url: string, route: string) => capture({ route, url }));
+    await executeBrowserTestbedMission(
+      mission({ mode: "surface_sweep" }),
+      {
+        ...config,
+        appBaseUrl: "https://app.averray.com",
+        surfaceSweepBaseUrl: "https://averray.com",
+      },
+      { captureRoute: fake },
+    );
+
+    expect(fake.mock.calls.map((call) => call[0])).toEqual([
+      "https://averray.com/",
+      "https://averray.com/onboarding",
+      "https://averray.com/jobs",
+      "https://averray.com/strategies",
+    ]);
   });
 
   it("an explore mission never reaches the sweep capture (dispatch gates on mode)", async () => {
@@ -273,6 +306,24 @@ describe("T2: authed routes + session-gated coverage", () => {
       resolveSession: async () => AGENT_SESSION,
     });
     expect(seen).toContain("/overview");
+  });
+
+  it("a resolved session keeps the sweep on the gated app base for operator routes", async () => {
+    const fake = vi.fn(async (url: string, route: string) => capture({ route, url }));
+    await executeBrowserTestbedMission(
+      mission(),
+      {
+        ...config,
+        appBaseUrl: "https://app.averray.com",
+        surfaceSweepBaseUrl: "https://averray.com",
+      },
+      {
+        captureRoute: fake,
+        resolveSession: async () => AGENT_SESSION,
+      },
+    );
+
+    expect(fake.mock.calls.map((call) => call[0])).toContain("https://app.averray.com/overview");
   });
 
   it("the runner with no configured session source sweeps public-only", async () => {


### PR DESCRIPTION
## What changed & why

- Added `TESTBED_SURFACE_SWEEP_BASE_URL` so public T1 surface sweeps join relative public routes against `https://averray.com` instead of the Basic-auth gated operator app.
- Kept `AVERRAY_APP_BASE_URL` as the gated app/session base for signed-in T2/T3 flows.
- Hardened testbed mission disposition so 401/403/5xx, Basic-auth/Caddy, network, timeout, and runner-exit failures are classified as environment/auth/runner boundaries with `autoFixable: false` and no code-fix prompt.

Root cause: live headers show `https://app.averray.com/` returns Caddy Basic Auth `401` (`www-authenticate: Basic realm="Averray Operator"`), while `https://averray.com/` returns `200`. This is not a Cloudflare Access service-token issue.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (blocked locally: Docker CLI has no compose subcommand here; `docker-compose` is not installed)
- [x] `curl -sI https://averray.com/` -> HTTP 200
- [x] `curl -sI https://app.averray.com/` -> HTTP 401 Caddy Basic Auth

## Rollout / rollback

Rollout: set/keep `TESTBED_SURFACE_SWEEP_BASE_URL=https://averray.com` in the hosted runner environment. No secret is required for the public T1 path. Existing signed-in sessions continue using `AVERRAY_APP_BASE_URL`.

Rollback: unset `TESTBED_SURFACE_SWEEP_BASE_URL` or revert this PR; T1 will fall back to the previous app-base behavior.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new ungated agent power
- [x] No secrets committed/printed/logged
- [x] Updated affected docs because this changes how T1 runner env works

## Known limits / follow-ups

- This does not add Basic-auth or Cloudflare Access token handling; the current failure is solved by pointing public-only T1 sweeps at public routes. Authed app sweeps still require an explicit authenticated path/session decision.