### PR TITLE
Parse Hermes reasoning replies and confirm usage writes

### DIFF
--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -22,7 +22,12 @@
  */
 
 import type { CollaborationMessage } from "./monitor-collab.js";
-import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
+import {
+  beginLlmUsageCall,
+  llmUsageLogPath,
+  recordLlmUsageFromResult,
+  type LlmUsageEvent,
+} from "@avg/averray-mcp/llm-usage";
 import { logger } from "@avg/mcp-common";
 
 export const HERMES_PERSONA = `You are Hermes, the board orchestrator for the Averray platform.
@@ -198,13 +203,13 @@ export async function generateHermesReply(
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
     maybeLogHermesUsageShape(json);
-    await recordLlmUsageFromResult({
+    await recordHermesLlmUsage({
       agent: "hermes",
       model,
       ...(options.runId ? { runId: options.runId } : {}),
       ...(options.taskId ? { taskId: options.taskId } : {}),
       result: json,
-    }, options.usageLogPath ? { path: options.usageLogPath } : {}).catch(() => undefined);
+    }, options);
     const text = extractReplyText(json);
     return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
   } catch {
@@ -258,13 +263,13 @@ export async function generateHermesBoardNarration(
     if (!response.ok) return null;
     const json = await response.json().catch(() => null) as unknown;
     maybeLogHermesUsageShape(json);
-    await recordLlmUsageFromResult({
+    await recordHermesLlmUsage({
       agent: "hermes",
       model,
       ...(options.runId ? { runId: options.runId } : {}),
       ...(options.taskId ? { taskId: options.taskId } : {}),
       result: json,
-    }, options.usageLogPath ? { path: options.usageLogPath } : {}).catch(() => undefined);
+    }, options);
     const text = extractReplyText(json);
     return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
   } catch {
@@ -585,6 +590,32 @@ function maybeLogHermesUsageShape(value: unknown): void {
   logger.info(summarizeHermesUsageDebugShape(value), "llm_usage_debug_shape");
 }
 
+async function recordHermesLlmUsage(
+  input: Parameters<typeof recordLlmUsageFromResult>[0],
+  options: Pick<GenerateHermesReplyOptions, "usageLogPath">
+): Promise<LlmUsageEvent | undefined> {
+  const path = options.usageLogPath ?? llmUsageLogPath();
+  try {
+    const event = await recordLlmUsageFromResult(input, { path });
+    if (!event) {
+      logger.debug({
+        agent: input.agent,
+        model: input.model,
+        path,
+      }, "monitor_collaboration_llm_usage_not_recorded");
+    }
+    return event;
+  } catch (error) {
+    logger.warn({
+      err: error,
+      agent: input.agent,
+      model: input.model,
+      path,
+    }, "monitor_collaboration_llm_usage_record_failed");
+    return undefined;
+  }
+}
+
 function debugPath(record: Record<string, unknown> | undefined, key: string, label = key): Record<string, unknown> {
   if (!record || !(key in record)) return {};
   return { [label]: redactUsageDebugValue(record[key]) };
@@ -808,11 +839,17 @@ function extractReplyText(json: unknown): string | null {
   if (!first || typeof first !== "object") return null;
   const message = (first as { message?: unknown }).message;
   if (!message || typeof message !== "object") return null;
-  const content = (message as { content?: unknown }).content;
-  if (typeof content !== "string") return null;
-  const trimmed = content.trim();
-  if (!trimmed) return null;
-  return trimmed.slice(0, 1200);
+  return firstNonEmptyTextField(message, ["content", "reasoning", "reasoning_content"], 1200);
+}
+
+function firstNonEmptyTextField(record: object, keys: readonly string[], max: number): string | null {
+  for (const key of keys) {
+    const value = (record as Record<string, unknown>)[key];
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed.slice(0, max);
+  }
+  return null;
 }
 
 function truncate(text: string, max: number): string {

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -502,6 +502,68 @@ describe("generateHermesReply", () => {
     expect(text).toBeNull();
   });
 
+  it("uses DeepSeek reasoning text when content is empty and records OpenAI-style usage", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-hermes-reasoning-usage-"));
+    try {
+      const usageLogPath = join(dir, "llm-usage.jsonl");
+      const fetchFn = async () =>
+        jsonResponse({
+          model: "deepseek-v4-pro:cloud",
+          choices: [
+            {
+              message: {
+                role: "assistant",
+                content: "",
+                reasoning: "Pascal, this is live Hermes. The board has one operator triage item and I am not dispatching code work.",
+              },
+            },
+          ],
+          usage: {
+            prompt_tokens: 93,
+            completion_tokens: 21,
+          },
+        });
+
+      const text = await generateHermesReply(baseContext(), {
+        apiKey,
+        baseUrl,
+        model: "deepseek-v4-pro:cloud",
+        runId: "deepseek-reasoning-1",
+        taskId: "chat-message-2",
+        usageLogPath,
+        fetchFn: fetchFn as typeof fetch,
+      });
+
+      expect(text).toContain("this is live Hermes");
+      expect(text).not.toContain("content");
+      await expect(readFile(usageLogPath, "utf8").then((line) => JSON.parse(line))).resolves.toMatchObject({
+        agent: "hermes",
+        model: "deepseek-v4-pro:cloud",
+        runId: "deepseek-reasoning-1",
+        taskId: "chat-message-2",
+        inputTokens: 93,
+        outputTokens: 21,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses reasoning_content when content and reasoning are empty", async () => {
+    const fetchFn = async () =>
+      jsonResponse({
+        choices: [{
+          message: {
+            content: "",
+            reasoning: "   ",
+            reasoning_content: "I have the live reply now.",
+          },
+        }],
+      });
+    const text = await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
+    expect(text).toContain("live reply");
+  });
+
   it("returns null when the fetch throws", async () => {
     const fetchFn = async () => { throw new Error("network down"); };
     const text = await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
@@ -671,6 +733,55 @@ describe("generateHermesBoardNarration", () => {
     expect(text).toMatch(/averray-agent\/agent#438/);
     expect(body.max_tokens).toBe(180);
     expect(body.messages[1].content).toContain("Speak proactively as Hermes");
+  });
+
+  it("uses DeepSeek reasoning text for proactive narration when content is empty", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "averray-hermes-narration-usage-"));
+    try {
+      const usageLogPath = join(dir, "llm-usage.jsonl");
+      const fetchFn = async () =>
+        jsonResponse({
+          choices: [{
+            message: {
+              content: "",
+              reasoning: "Pascal, Hermes is live on narration too; one release card needs a merge steward.",
+            },
+          }],
+          usage: {
+            prompt_tokens: 55,
+            completion_tokens: 13,
+          },
+        });
+      const text = await generateHermesBoardNarration(
+        {
+          board: {
+            headline: "Board now: 1 release item.",
+            counts: { release: 1 },
+            items: [
+              {
+                repo: "averray-agent/agent",
+                number: 440,
+                title: "Ready to merge.",
+                lane: "Release Queue",
+                owner: "Merge steward",
+              },
+            ],
+          },
+          recentMessages: [],
+        },
+        { apiKey, baseUrl, usageLogPath, fetchFn: fetchFn as typeof fetch }
+      );
+
+      expect(text).toContain("Hermes is live on narration");
+      await expect(readFile(usageLogPath, "utf8").then((line) => JSON.parse(line))).resolves.toMatchObject({
+        agent: "hermes",
+        model: "deepseek-v4-pro:cloud",
+        inputTokens: 55,
+        outputTokens: 13,
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it("adds a why trace when board narration receives relevant memory", async () => {


### PR DESCRIPTION
## What changed
- Hermes co-pilot and proactive narration now parse DeepSeek reasoning responses when message.content is empty, falling back through message.reasoning and message.reasoning_content with the same 1200-char cap.
- Replaced the silent usage-recording catch with explicit Hermes usage write handling: records the event when counters are present, logs a safe debug signal when counters are absent, and logs a warning when the durable append fails.
- Added tests for empty-content DeepSeek replies with reasoning text plus usage.prompt_tokens / usage.completion_tokens, confirming JSONL usage records are written for both chat replies and board narration.

## Checks run
- npm install
- npm run typecheck
- npm test -- test/unit/monitor-hermes-voice.test.ts test/unit/llm-usage.test.ts
- npm test

## Surfaces affected
- slack-operator Hermes voice/narration
- LLM usage recording diagnostics
- unit tests

## Safety
- Truth-boundary preserved: Hermes still returns null on network/API/malformed failures so the existing fallback path remains intact.
- No prompts, keys, or message content are logged in usage diagnostics; only agent/model/path/error metadata is logged for write failures.