### PR TITLE
fix(testbed): authenticate gated app missions

### DIFF
--- a/docs/CODEX_HANDOFF_PROTOCOL.md
+++ b/docs/CODEX_HANDOFF_PROTOCOL.md
@@ -198,13 +198,28 @@ available, stops before risky mutation controls, writes a structured report, and
 lets the monitor attach the result.
 
 Custom external runners are still supported for comparing other agents or a
-more autonomous Hermes browser invocation:
+more autonomous Hermes browser invocation. The lightweight HTTP visibility
+runner is for genuinely public URLs only; do not point it at
+`https://app.averray.com`, which is gated and requires a browser-capable
+executor plus auth.
 
 ```env
 TESTBED_MISSION_RUNNER_EXECUTOR=command
 TESTBED_MISSION_RUNNER_COMMAND=node
 TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/testbed-mission-http-runner.js
 ```
+
+For the hosted operator app, use the Playwright surface sweep or the T4
+gold-path command executor with:
+
+```env
+TESTBED_CF_ACCESS_CLIENT_ID=<from ops secrets>
+TESTBED_CF_ACCESS_CLIENT_SECRET=<from ops secrets>
+TESTBED_SESSION_SIGNER_URL=http://test-wallet-signer:8791
+```
+
+Those values are service-token/session secrets. They stay in ops env only and
+must not be pasted into prompts, logs, or mission reports.
 
 Supported command placeholders are:
 

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -102,6 +102,10 @@ TESTBED_MISSION_RUNNER_ENABLED=1
 # AVERRAY_APP_BASE_URL pointed at the gated operator app for signed-in T2/T3
 # sessions.
 TESTBED_SURFACE_SWEEP_BASE_URL=https://averray.com
+# Required when sweeping https://app.averray.com with a T2/T3 session.
+TESTBED_CF_ACCESS_CLIENT_ID=<from ops secrets>
+TESTBED_CF_ACCESS_CLIENT_SECRET=<from ops secrets>
+TESTBED_SESSION_SIGNER_URL=http://test-wallet-signer:8791
 # Optional: the env's truth boundary the honesty check asserts. Set to
 # testnet / demo / local-simulation when the deployed env is non-production so
 # data-bearing surfaces must carry that marker; leave empty otherwise.
@@ -207,8 +211,10 @@ TESTBED_MISSION_RUNNER_EXECUTOR=command
 TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/gold-path-mission-entry.js
 TESTBED_MISSION_ENVIRONMENT=testnet      # T5 binds mutation; mainnet is read-only by construction
 TESTBED_SESSION_SIGNER_URL=http://test-wallet-signer:8791   # T3 session (API Bearer); key never enters the model
+TESTBED_CF_ACCESS_CLIENT_ID=<from ops secrets>              # Cloudflare Access service token
+TESTBED_CF_ACCESS_CLIENT_SECRET=<from ops secrets>          # never logged / never in prompts
 TESTBED_GOLDPATH_DEEP=0                   # opus for deep/critical; sonnet otherwise (A4)
-TESTBED_GOLDPATH_LIVE=0                   # see note below
+TESTBED_GOLDPATH_LIVE=1                   # invokes the live Claude + Playwright-MCP driver
 ```
 
 Gold-path missions are queued with `mode: "gold_path"` and **land `requested`** —
@@ -221,12 +227,11 @@ mutate; **mainnet is structurally read-only**.
 > `gold_path` missions, or wait for the per-mode-claim follow-up. A mixed queue
 > would route surface-sweep missions through the gold-path entry.
 
-> **Live driver is a follow-up.** This PR ships the executor — the T5 mutation
-> binding, T3 session, A4 model policy, the honest self-judge, the report, and
-> the approve-gate wiring — with a deterministic fake driver for CI. The live
-> **Claude Agent SDK + Playwright-MCP** driver is not wired yet: with
-> `TESTBED_GOLDPATH_LIVE` unset (or set, until the driver lands) the runner emits
-> an honest **"not executed"** report rather than a fake pass.
+> **Auth for the hosted app has two layers.** Cloudflare Access is satisfied by
+> `TESTBED_CF_ACCESS_CLIENT_ID` / `TESTBED_CF_ACCESS_CLIENT_SECRET`; product auth
+> is satisfied through the T2/T3 session source. The live driver prompt may name
+> the header/env names, but it must never print service-token values, wallet
+> keys, JWTs, or storageState contents.
 
 ---
 

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -48,8 +48,8 @@ TESTBED_MISSION_RUNNER_ID=vps-hermes-testbed-runner
 # "playwright" drives a headless Chromium (the surface sweep needs this);
 # "command" shells out to TESTBED_MISSION_RUNNER_COMMAND/ARGS instead.
 TESTBED_MISSION_RUNNER_EXECUTOR=playwright
-TESTBED_MISSION_RUNNER_COMMAND=node
-TESTBED_MISSION_RUNNER_ARGS=services/slack-operator/dist/testbed-mission-http-runner.js
+TESTBED_MISSION_RUNNER_COMMAND=
+TESTBED_MISSION_RUNNER_ARGS=
 TESTBED_MISSION_RUNNER_POLL_INTERVAL_MS=10000
 TESTBED_MISSION_RUNNER_TIMEOUT_MS=1200000
 # Browser binary the playwright executor launches. The runtime image installs
@@ -63,6 +63,10 @@ TESTBED_MISSION_MAX_BROWSER_STEPS=12
 TESTBED_MISSION_ENVIRONMENT=
 TESTBED_MISSION_CAPTURE_TRACE=1
 TESTBED_MISSION_CAPTURE_VIDEO=1
+# Cloudflare Access service token for gated hosted app routes. Store real
+# values only in ops secrets/.env.prod; never put them in prompts or reports.
+TESTBED_CF_ACCESS_CLIENT_ID=
+TESTBED_CF_ACCESS_CLIENT_SECRET=
 # T4 Tier-2 gold-path tester. gold_path missions land `requested` behind the T6
 # approve gate and are claimed by the normal testbed runner. Default stays fake
 # for CI; set TESTBED_GOLDPATH_LIVE=1 to invoke Claude + Playwright-MCP. Mutation

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -273,6 +273,10 @@ services:
       TESTBED_MISSION_ENVIRONMENT: ${TESTBED_MISSION_ENVIRONMENT:-}
       TESTBED_MISSION_CAPTURE_TRACE: ${TESTBED_MISSION_CAPTURE_TRACE:-1}
       TESTBED_MISSION_CAPTURE_VIDEO: ${TESTBED_MISSION_CAPTURE_VIDEO:-1}
+      # Cloudflare Access edge auth for app.averray.com. Values are service
+      # token secrets and must never appear in logs, prompts, or reports.
+      TESTBED_CF_ACCESS_CLIENT_ID: ${TESTBED_CF_ACCESS_CLIENT_ID:-}
+      TESTBED_CF_ACCESS_CLIENT_SECRET: ${TESTBED_CF_ACCESS_CLIENT_SECRET:-}
       # T4 live gold-path driver. Default is off so CI/test deploys keep the
       # deterministic fake path; when enabled the runner invokes Claude with
       # Playwright-MCP/browser tooling and writes a structured report.
@@ -332,6 +336,8 @@ services:
       TEST_WALLET_SIGNER_PORT: ${TEST_WALLET_SIGNER_PORT:-8791}
       TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS: ${TEST_WALLET_SIGNER_REFRESH_SKEW_SECONDS:-60}
       TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH: ${TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH:-/usr/bin/chromium}
+      TESTBED_CF_ACCESS_CLIENT_ID: ${TESTBED_CF_ACCESS_CLIENT_ID:-}
+      TESTBED_CF_ACCESS_CLIENT_SECRET: ${TESTBED_CF_ACCESS_CLIENT_SECRET:-}
       AUTH_TOKEN_TTL_SECONDS: ${AUTH_TOKEN_TTL_SECONDS:-3600}
       AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
       AVERRAY_APP_BASE_URL: ${AVERRAY_APP_BASE_URL}

--- a/services/slack-operator/src/gold-path-live-driver.ts
+++ b/services/slack-operator/src/gold-path-live-driver.ts
@@ -124,10 +124,12 @@ export function createClaudeGoldPathDriver(
         timeoutMs: config.timeoutMs,
       });
       const elapsedMs = Math.max(0, (deps.now?.() ?? Date.now()) - started);
-      const rawObservation = await readFile(observationPath, "utf8").catch(() => result.stdout);
+      const rawObservation = await readFile(observationPath, "utf8")
+        .then((text) => redactGoldPathOutput(text, childEnv))
+        .catch(() => result.stdout);
       if (result.exitCode !== 0) {
         const reason = lastNonEmptyLine(result.stderr) || lastNonEmptyLine(result.stdout) || `Claude live driver exited with ${result.exitCode}.`;
-        return failedObservation(input, redact(reason), elapsedMs, result);
+        return failedObservation(input, redactGoldPathOutput(reason, childEnv), elapsedMs, redactExecResult(result, childEnv));
       }
       const parsed = parseClaudeGoldPathObservation(rawObservation, input, elapsedMs);
       if (!parsed) {
@@ -135,7 +137,7 @@ export function createClaudeGoldPathDriver(
           input,
           "Claude live driver finished without a valid gold-path observation JSON.",
           elapsedMs,
-          result,
+          redactExecResult(result, childEnv),
         );
       }
       return parsed;
@@ -159,10 +161,14 @@ export function buildClaudeGoldPathPrompt(
   const mutationLine = input.allowMutations
     ? `Mutation profile: TESTNET/STAGING test-only mutations are allowed only inside clearly fake/sandbox Averray flows. Scope: ${input.mutationScope}`
     : "Mutation profile: READ ONLY. Stop before claim, submit, payout/SBT, wallet signature, payment, deploy, merge, or any irreversible action.";
+  const edgeAuthLine = input.cloudflareAccess
+    ? "Cloudflare Access edge auth is configured in this process environment. When loading the gated app or its API, attach CF-Access-Client-Id and CF-Access-Client-Secret headers from env; never print, screenshot, or report their values."
+    : "No Cloudflare Access service token was configured; if the target is behind Cloudflare Access, report that as an auth blocker instead of treating the product as broken.";
   return [
     "You are Hermes running the Averray Tier-2 gold-path tester as a normal browser-capable outside agent.",
     "Use the Claude Agent SDK browser tooling / Playwright MCP tools available in this runtime. Do not use private repo state, Slack, GitHub, SSH, databases, or Averray monitor internals.",
     "Reuse T3 only through the local signer sidecar when you need authentication. The wallet private keys must never enter your prompt, output, logs, screenshots, or report.",
+    edgeAuthLine,
     opts.signerBaseUrl ? `Signer sidecar: ${opts.signerBaseUrl}. Request browser/api sessions by role as needed; do not print returned tokens.` : "No signer sidecar URL was provided; report that as a blocker if authentication is required.",
     mutationLine,
     `Target URL: ${input.targetUrl}`,
@@ -288,9 +294,38 @@ async function execClaudeCommand(input: ExecClaudeInput): Promise<ExecClaudeResu
     child.on("close", (code) => {
       settled = true;
       clearTimeout(timeout);
-      resolve({ exitCode: code ?? 1, stdout: redact(stdout), stderr: redact(stderr) });
+      resolve({
+        exitCode: code ?? 1,
+        stdout: redactGoldPathOutput(stdout, input.env),
+        stderr: redactGoldPathOutput(stderr, input.env),
+      });
     });
   });
+}
+
+function redactExecResult(result: ExecClaudeResult, env: NodeJS.ProcessEnv): ExecClaudeResult {
+  return {
+    ...result,
+    stdout: redactGoldPathOutput(result.stdout, env),
+    stderr: redactGoldPathOutput(result.stderr, env),
+  };
+}
+
+function redactGoldPathOutput(value: string, env: NodeJS.ProcessEnv): string {
+  let next = redact(value);
+  for (const secret of [
+    env.TESTBED_CF_ACCESS_CLIENT_ID,
+    env.TESTBED_CF_ACCESS_CLIENT_SECRET,
+    env.CF_ACCESS_CLIENT_ID,
+    env.CF_ACCESS_CLIENT_SECRET,
+    env.CLOUDFLARE_ACCESS_CLIENT_ID,
+    env.CLOUDFLARE_ACCESS_CLIENT_SECRET,
+  ]) {
+    if (secret && secret.length >= 6) {
+      next = next.split(secret).join("[redacted-cloudflare-access]");
+    }
+  }
+  return next;
 }
 
 function normalizeSteps(value: unknown, input: GoldPathDriverInput): GoldPathStepResult[] {

--- a/services/slack-operator/src/gold-path-mission-entry.ts
+++ b/services/slack-operator/src/gold-path-mission-entry.ts
@@ -18,7 +18,11 @@ import {
   resolveTestbedMutationBinding,
   testbedEnvironmentFromEnv,
 } from "./testbed-mutation-binding.js";
-import { resolveSweepSession, parseSweepSessionConfig } from "./testbed-session.js";
+import {
+  parseCloudflareAccessServiceToken,
+  resolveSweepSession,
+  parseSweepSessionConfig,
+} from "./testbed-session.js";
 import {
   runGoldPathMissionOnce,
   pickGoldPathModel,
@@ -84,6 +88,7 @@ export async function runGoldPathMissionEntry(
   });
 
   const driver = deps.driver ?? selectGoldPathDriver(env);
+  const cloudflareAccess = parseCloudflareAccessServiceToken(env);
 
   const result = await runGoldPathMissionOnce({
     mission: { id: mission.id, targetUrl: mission.targetUrl, goal: mission.goal, freshMemory: mission.freshMemory },
@@ -91,6 +96,7 @@ export async function runGoldPathMissionEntry(
     driver,
     model,
     signerBaseUrl: env.TEST_WALLET_SIGNER_BASE_URL || env.TESTBED_SESSION_SIGNER_URL,
+    ...(cloudflareAccess ? { cloudflareAccess } : {}),
     // T3: the API Bearer (and/or browser storageState) from the signer sidecar —
     // the wallet key never enters this process. Undefined when unconfigured.
     resolveSession: () => resolveSweepSession({ ...parseSweepSessionConfig(env), sessionType: "api" }),

--- a/services/slack-operator/src/gold-path-mission.ts
+++ b/services/slack-operator/src/gold-path-mission.ts
@@ -24,6 +24,7 @@
 //     expected (stoppedBeforeMutation), not a failure.
 
 import type { TestbedMutationBinding } from "./testbed-mutation-binding.js";
+import type { CloudflareAccessServiceToken } from "./testbed-session.js";
 
 export type GoldPathStep =
   | "onboard"
@@ -109,6 +110,8 @@ export interface GoldPathDriverInput {
   freshMemory: boolean;
   /** T3 session (Bearer for the API gold path, storageState for browser). Opaque here. */
   session?: { role?: string; token?: string; storageState?: unknown };
+  /** Edge auth for Cloudflare-Access-gated app routes. Values are never report content. */
+  cloudflareAccess?: CloudflareAccessServiceToken;
   /** Local T3 signer sidecar URL. The driver may request sessions; wallet keys never leave the sidecar. */
   signerBaseUrl?: string;
 }
@@ -345,6 +348,7 @@ export interface GoldPathMissionDeps {
   driver: GoldPathDriver;
   model: GoldPathModel;
   resolveSession?: () => Promise<GoldPathDriverInput["session"] | undefined> | GoldPathDriverInput["session"] | undefined;
+  cloudflareAccess?: CloudflareAccessServiceToken;
   signerBaseUrl?: string;
   steps?: readonly GoldPathStep[];
 }
@@ -369,6 +373,7 @@ export async function runGoldPathMissionOnce(deps: GoldPathMissionDeps): Promise
     model: deps.model,
     freshMemory: deps.mission.freshMemory !== false,
     ...(session ? { session } : {}),
+    ...(deps.cloudflareAccess ? { cloudflareAccess: deps.cloudflareAccess } : {}),
     ...(deps.signerBaseUrl ? { signerBaseUrl: deps.signerBaseUrl } : {}),
   });
 

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -843,6 +843,7 @@ function testbedMissionEnvironmentOrAuthFailure(
     /\bstatus[=:\s]+(?:401|403|5\d\d)\b/i,
     /unauthori[sz]ed|forbidden|access denied|authentication required|login required|sign[ -]?in required/i,
     /www-authenticate|basic realm|basic auth|cloudflare access/i,
+    /gated (?:app|target)|browser-capable executor|http_visibility_check is public-only/i,
     /bad gateway|service unavailable|gateway timeout|internal server error/i,
     /net::err_|err_name_not_resolved|econnrefused|connection refused/i,
     /page load failed|navigation failed|browser context closed|target closed|timed out|timeout/i,

--- a/services/slack-operator/src/testbed-mission-http-runner.ts
+++ b/services/slack-operator/src/testbed-mission-http-runner.ts
@@ -19,6 +19,33 @@ interface HttpMissionReport {
 export async function runHttpTestbedMission(env: NodeJS.ProcessEnv = process.env): Promise<HttpMissionReport> {
   const targetUrl = requiredEnv(env, "TESTBED_TARGET_URL");
   const goal = env.TESTBED_MISSION_GOAL || "test first-contact usability";
+  if (isGatedAppTarget(targetUrl, env)) {
+    return {
+      verdict: "fail",
+      confidence: 0,
+      executor: "http_visibility_check",
+      runnerMode: "non_browser_fetch",
+      stoppedBeforeMutation: true,
+      mutationBoundaryNotes: ["HTTP visibility check is public-only and refused the gated app before sending a request."],
+      blockers: [
+        `http_visibility_check is public-only; gated target ${targetUrl} requires the browser-capable executor with Cloudflare Access edge auth and a T2/T3 authenticated session.`,
+      ],
+      confusingMoments: [],
+      evidence: [
+        { type: "executor", value: "http_visibility_check; refused gated target before network request" },
+        { type: "target_classification", value: "gated_app" },
+      ],
+      scores: {
+        pageLoads: 0,
+        orientation: 0,
+        mutationSafety: 5,
+        evidenceQuality: 3,
+      },
+      recommendations: [
+        "Use the Playwright surface-sweep executor with TESTBED_CF_ACCESS_CLIENT_ID/SECRET plus a T2/T3 session, or run a T4 gold-path mission with TESTBED_GOLDPATH_LIVE=1.",
+      ],
+    };
+  }
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15_000);
   timeout.unref();
@@ -94,6 +121,20 @@ export async function runHttpTestbedMission(env: NodeJS.ProcessEnv = process.env
     };
   } finally {
     clearTimeout(timeout);
+  }
+}
+
+function isGatedAppTarget(targetUrl: string, env: NodeJS.ProcessEnv): boolean {
+  const hosts = (env.TESTBED_HTTP_GATED_HOSTS || "app.averray.com")
+    .split(",")
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean);
+  if (hosts.length === 0) return false;
+  try {
+    const url = new URL(targetUrl);
+    return hosts.includes(url.hostname.toLowerCase());
+  } catch {
+    return false;
   }
 }
 

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -20,7 +20,9 @@ import { executeSiweAuthMission, type SiweAuthMissionDeps } from "./testbed-auth
 import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
 import {
   parseSweepSessionConfig,
+  parseCloudflareAccessServiceToken,
   resolveSweepSession,
+  type CloudflareAccessServiceToken,
   type SweepSession,
   type SweepSessionConfig,
 } from "./testbed-session.js";
@@ -59,6 +61,8 @@ export interface TestbedMissionRunnerConfig {
   captureVideo?: boolean;
   /** T2 pre-seeded session source (sidecar URL and/or manual storageState path/token). */
   session?: SweepSessionConfig;
+  /** Cloudflare Access service-token headers for gated hosted app routes. */
+  cloudflareAccess?: CloudflareAccessServiceToken;
 }
 
 /** Injected session resolution for tests (defaults to the env-config resolver). */
@@ -92,6 +96,7 @@ export type TestbedMissionRunnerOnceResult =
 export function parseTestbedMissionRunnerConfig(
   env: NodeJS.ProcessEnv = process.env
 ): TestbedMissionRunnerConfig {
+  const cloudflareAccess = parseCloudflareAccessServiceToken(env);
   return {
     enabled: env.TESTBED_MISSION_RUNNER_ENABLED === "1" || env.TESTBED_MISSION_RUNNER_ENABLED === "true",
     ...(env.AVERRAY_TESTBED_MISSIONS_PATH ? { path: env.AVERRAY_TESTBED_MISSIONS_PATH } : {}),
@@ -124,6 +129,7 @@ export function parseTestbedMissionRunnerConfig(
     captureTrace: env.TESTBED_MISSION_CAPTURE_TRACE !== "0" && env.TESTBED_MISSION_CAPTURE_TRACE !== "false",
     captureVideo: env.TESTBED_MISSION_CAPTURE_VIDEO !== "0" && env.TESTBED_MISSION_CAPTURE_VIDEO !== "false",
     session: parseSweepSessionConfig(env),
+    ...(cloudflareAccess ? { cloudflareAccess } : {}),
   };
 }
 
@@ -380,6 +386,12 @@ export async function executeGoldPathTestbedMission(
     TESTBED_MUTATION_BINDING_REASON: mission.mutationBindingReason ?? "",
     TEST_WALLET_SIGNER_BASE_URL: config.signerBaseUrl ?? process.env.TEST_WALLET_SIGNER_BASE_URL ?? "",
     TESTBED_SESSION_SIGNER_URL: config.signerBaseUrl ?? process.env.TESTBED_SESSION_SIGNER_URL ?? "",
+    ...(config.cloudflareAccess
+      ? {
+        TESTBED_CF_ACCESS_CLIENT_ID: config.cloudflareAccess.clientId,
+        TESTBED_CF_ACCESS_CLIENT_SECRET: config.cloudflareAccess.clientSecret,
+      }
+      : {}),
   });
   return {
     exitCode: 0,

--- a/services/slack-operator/src/testbed-session.ts
+++ b/services/slack-operator/src/testbed-session.ts
@@ -32,6 +32,11 @@ export interface SweepSession {
   token?: string;
 }
 
+export interface CloudflareAccessServiceToken {
+  clientId: string;
+  clientSecret: string;
+}
+
 export interface SweepSessionConfig {
   /** Which role's session to use (default "agent"). */
   role?: string;
@@ -89,6 +94,33 @@ export function parseSweepSessionConfig(env: NodeJS.ProcessEnv = process.env): S
     ...(env.TESTBED_SESSION_STORAGE_STATE_PATH ? { storageStatePath: env.TESTBED_SESSION_STORAGE_STATE_PATH } : {}),
     ...(env.TESTBED_SESSION_TOKEN ? { token: env.TESTBED_SESSION_TOKEN } : {}),
   };
+}
+
+export function parseCloudflareAccessServiceToken(
+  env: NodeJS.ProcessEnv = process.env,
+): CloudflareAccessServiceToken | undefined {
+  const clientId = firstNonEmpty(
+    env.TESTBED_CF_ACCESS_CLIENT_ID,
+    env.CF_ACCESS_CLIENT_ID,
+    env.CLOUDFLARE_ACCESS_CLIENT_ID,
+  );
+  const clientSecret = firstNonEmpty(
+    env.TESTBED_CF_ACCESS_CLIENT_SECRET,
+    env.CF_ACCESS_CLIENT_SECRET,
+    env.CLOUDFLARE_ACCESS_CLIENT_SECRET,
+  );
+  return clientId && clientSecret ? { clientId, clientSecret } : undefined;
+}
+
+export function cloudflareAccessHeaders(
+  token?: CloudflareAccessServiceToken,
+): Record<string, string> {
+  return token
+    ? {
+      "CF-Access-Client-Id": token.clientId,
+      "CF-Access-Client-Secret": token.clientSecret,
+    }
+    : {};
 }
 
 /** Whether any session source is configured. When false, the sweep runs
@@ -208,11 +240,26 @@ async function fetchSidecarSession(
  * session: storageState rehydrates the authed browser; a Bearer token is
  * attached so the page's same-origin API calls are authed too. Pure + tested.
  */
-export function buildSweepContextOptions(session?: SweepSession): Record<string, unknown> {
+export function buildSweepContextOptions(
+  session?: SweepSession,
+  cloudflareAccess?: CloudflareAccessServiceToken,
+): Record<string, unknown> {
+  const extraHTTPHeaders = {
+    ...cloudflareAccessHeaders(cloudflareAccess),
+    ...(session?.token ? { Authorization: `Bearer ${session.token}` } : {}),
+  };
   return {
     viewport: { width: 1365, height: 900 },
     userAgent: "Averray-Hermes-Surface-Sweep/1.0",
     ...(session?.storageState ? { storageState: session.storageState } : {}),
-    ...(session?.token ? { extraHTTPHeaders: { Authorization: `Bearer ${session.token}` } } : {}),
+    ...(Object.keys(extraHTTPHeaders).length > 0 ? { extraHTTPHeaders } : {}),
   };
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
 }

--- a/services/slack-operator/src/testbed-surface-sweep.ts
+++ b/services/slack-operator/src/testbed-surface-sweep.ts
@@ -18,6 +18,7 @@ import type { TestbedMissionRunResult } from "./testbed-mission-runner.js";
 import {
   DEFAULT_AUTHED_ROUTES,
   buildSweepContextOptions,
+  type CloudflareAccessServiceToken,
   type SweepSession,
 } from "./testbed-session.js";
 
@@ -331,7 +332,15 @@ export function resolveExpectedBoundary(value: string | undefined): SweepBoundar
  */
 export async function executeSurfaceSweep(
   mission: TestbedMissionRun,
-  config: { appBaseUrl?: string; expectedBoundary?: string; browserExecutablePath?: string; timeoutMs?: number; artifactsDir?: string; session?: SweepSession },
+  config: {
+    appBaseUrl?: string;
+    expectedBoundary?: string;
+    browserExecutablePath?: string;
+    timeoutMs?: number;
+    artifactsDir?: string;
+    session?: SweepSession;
+    cloudflareAccess?: CloudflareAccessServiceToken;
+  },
   deps: SurfaceSweepDeps = {},
 ): Promise<TestbedMissionRunResult> {
   const expectedBoundary = resolveExpectedBoundary(config.expectedBoundary);
@@ -390,6 +399,7 @@ function makeBrowserCapture(config: {
   browserExecutablePath?: string;
   timeoutMs?: number;
   session?: SweepSession;
+  cloudflareAccess?: CloudflareAccessServiceToken;
 }): (url: string, route: string) => Promise<RouteCapture> {
   return async (url, route) => {
     const { chromium } = await import("playwright-core");
@@ -404,7 +414,7 @@ function makeBrowserCapture(config: {
     try {
       // Pre-seeded session (T2): storageState rehydrates the authed browser; a
       // Bearer (if any) authes the page's same-origin API calls. Read-only.
-      const context = await browser.newContext(buildSweepContextOptions(config.session));
+      const context = await browser.newContext(buildSweepContextOptions(config.session, config.cloudflareAccess));
       const page = await context.newPage();
       page.on("console", (m) => {
         if (m.type() === "error") consoleErrors.push(m.text());

--- a/services/test-wallet-signer/src/browser-session.ts
+++ b/services/test-wallet-signer/src/browser-session.ts
@@ -12,7 +12,10 @@ export async function mintBrowserSessionWithPlaywright(
     ...(config.browserExecutablePath ? { executablePath: config.browserExecutablePath } : {})
   });
   try {
-    const context = await browser.newContext();
+      const edgeHeaders = cloudflareAccessHeaders(config);
+      const context = await browser.newContext(
+        Object.keys(edgeHeaders).length ? { extraHTTPHeaders: edgeHeaders } : undefined,
+      );
     try {
       const page = await context.newPage();
       await page.goto(config.appBaseUrl, { waitUntil: "domcontentloaded", timeout: 30_000 });
@@ -20,7 +23,7 @@ export async function mintBrowserSessionWithPlaywright(
 
       const session = await siweLoginWithSigner(wallet.account, {
         baseUrl: config.apiBaseUrl,
-        postJson: createPlaywrightPostJson(context.request, config.apiBaseUrl)
+        postJson: createPlaywrightPostJson(context.request, config.apiBaseUrl, edgeHeaders)
       });
       return {
         wallet: session.wallet,
@@ -35,11 +38,15 @@ export async function mintBrowserSessionWithPlaywright(
   }
 }
 
-function createPlaywrightPostJson(request: APIRequestContext, baseUrl: string): SiwePostJson {
+function createPlaywrightPostJson(
+  request: APIRequestContext,
+  baseUrl: string,
+  edgeHeaders: Record<string, string> = {},
+): SiwePostJson {
   return async (path, body) => {
     const response = await request.post(`${trimTrailingSlash(baseUrl)}${path}`, {
       data: body,
-      headers: { "content-type": "application/json" }
+      headers: { "content-type": "application/json", ...edgeHeaders }
     });
     return {
       ok: response.ok(),
@@ -47,4 +54,13 @@ function createPlaywrightPostJson(request: APIRequestContext, baseUrl: string): 
       payload: await response.json().catch(() => ({}))
     };
   };
+}
+
+function cloudflareAccessHeaders(config: TestWalletSignerConfig): Record<string, string> {
+  return config.cfAccessClientId && config.cfAccessClientSecret
+    ? {
+      "CF-Access-Client-Id": config.cfAccessClientId,
+      "CF-Access-Client-Secret": config.cfAccessClientSecret,
+    }
+    : {};
 }

--- a/services/test-wallet-signer/src/sessions.ts
+++ b/services/test-wallet-signer/src/sessions.ts
@@ -30,6 +30,8 @@ export interface TestWalletSignerConfig {
   authTokenTtlSeconds: number;
   refreshSkewSeconds: number;
   browserExecutablePath?: string;
+  cfAccessClientId?: string;
+  cfAccessClientSecret?: string;
   wallets: Partial<Record<TestWalletRole, RoleWallet>>;
 }
 
@@ -179,6 +181,8 @@ export function loadTestWalletSignerConfig(env: NodeJS.ProcessEnv = process.env)
   const enabled = parseBoolean(env.TEST_WALLET_SIGNER_ENABLED, false);
   const environment = parseEnvironment(env.TEST_WALLET_SIGNER_ENVIRONMENT);
   const requiredRoles = environment === "mainnet" ? ["agent"] as const : TEST_WALLET_ROLES;
+  const cfAccessClientId = firstNonEmpty(env.TESTBED_CF_ACCESS_CLIENT_ID, env.CF_ACCESS_CLIENT_ID, env.CLOUDFLARE_ACCESS_CLIENT_ID);
+  const cfAccessClientSecret = firstNonEmpty(env.TESTBED_CF_ACCESS_CLIENT_SECRET, env.CF_ACCESS_CLIENT_SECRET, env.CLOUDFLARE_ACCESS_CLIENT_SECRET);
   const wallets: Partial<Record<TestWalletRole, RoleWallet>> = {};
   if (enabled) {
     for (const role of requiredRoles) {
@@ -198,6 +202,8 @@ export function loadTestWalletSignerConfig(env: NodeJS.ProcessEnv = process.env)
     ...(env.TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH
       ? { browserExecutablePath: env.TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH }
       : {}),
+    ...(cfAccessClientId ? { cfAccessClientId } : {}),
+    ...(cfAccessClientSecret ? { cfAccessClientSecret } : {}),
     wallets
   };
 }
@@ -260,6 +266,14 @@ function positiveInt(value: string | undefined, fallback: number): number {
 
 function isReadOnlyEnvironment(environment: SignerEnvironment): boolean {
   return environment === "mainnet";
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const trimmed = value?.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
 }
 
 async function missingBrowserMinter(): Promise<BrowserMintResult> {

--- a/test/unit/gold-path-mission.test.ts
+++ b/test/unit/gold-path-mission.test.ts
@@ -259,13 +259,19 @@ describe("Claude live gold-path driver", () => {
   };
 
   it("builds a prompt that uses the signer sidecar without exposing wallet keys", () => {
-    const prompt = buildClaudeGoldPathPrompt(input, {
+    const prompt = buildClaudeGoldPathPrompt({
+      ...input,
+      cloudflareAccess: { clientId: "cf-client-id", clientSecret: "cf-client-secret" },
+    }, {
       observationPath: "/tmp/observation.json",
       signerBaseUrl: "http://test-wallet-signer:8791",
     });
     expect(prompt).toContain("Signer sidecar: http://test-wallet-signer:8791");
+    expect(prompt).toContain("CF-Access-Client-Id");
     expect(prompt).toContain("Write ONLY the observation JSON");
     expect(prompt).not.toMatch(/TEST_WALLET_.*PRIVATE/i);
+    expect(prompt).not.toContain("cf-client-id");
+    expect(prompt).not.toContain("cf-client-secret");
   });
 
   it("parses the live observation shape with real latency and blocker body", () => {
@@ -359,5 +365,44 @@ describe("Claude live gold-path driver", () => {
       steps: [expect.objectContaining({ step: "onboard", latencyMs: 50 })],
       usage: { inputTokens: 12, outputTokens: 8 },
     });
+  });
+
+  it("passes Cloudflare Access env to the live command but redacts it from failed observations", async () => {
+    const driver = createClaudeGoldPathDriver(
+      {
+        enabled: true,
+        command: "claude",
+        args: ["-p", "{prompt}"],
+        timeoutMs: 1000,
+        signerBaseUrl: "http://test-wallet-signer:8791",
+      },
+      {
+        TESTBED_GOLDPATH_LIVE: "1",
+        CLAUDE_WORKER_AUTH_MODE: "sub",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+        TESTBED_CF_ACCESS_CLIENT_ID: "cf-client-id",
+        TESTBED_CF_ACCESS_CLIENT_SECRET: "cf-client-secret",
+      } as NodeJS.ProcessEnv,
+      {
+        exec: async ({ env, args }) => {
+          expect(env.TESTBED_CF_ACCESS_CLIENT_ID).toBe("cf-client-id");
+          expect(env.TESTBED_CF_ACCESS_CLIENT_SECRET).toBe("cf-client-secret");
+          expect(args.join(" ")).not.toContain("cf-client-secret");
+          return {
+            exitCode: 1,
+            stdout: "stdout leaked cf-client-id",
+            stderr: "stderr leaked cf-client-secret",
+          };
+        },
+      },
+    );
+
+    const observation = await driver.run({
+      ...input,
+      cloudflareAccess: { clientId: "cf-client-id", clientSecret: "cf-client-secret" },
+    });
+    expect(JSON.stringify(observation)).not.toContain("cf-client-id");
+    expect(JSON.stringify(observation)).not.toContain("cf-client-secret");
+    expect(JSON.stringify(observation)).toContain("[redacted-cloudflare-access]");
   });
 });

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -611,6 +611,40 @@ describe("monitor testbed mission runs", () => {
     }
   });
 
+  it("classifies refused non-browser gated-app checks as environment setup, not code work", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://app.averray.com" }),
+      Date.parse("2026-06-01T10:00:00.000Z"),
+    );
+    const updated = recordTestbedMissionReportFromMessage(
+      {
+        relatedCorrelationId: run!.id,
+        text: JSON.stringify({
+          verdict: "fail",
+          confidence: 0,
+          stoppedBeforeMutation: true,
+          mutationBoundaryNotes: ["HTTP visibility check refused a gated app target."],
+          completedPath: [],
+          blockers: [
+            "http_visibility_check is public-only; gated target https://app.averray.com requires the browser-capable executor with Cloudflare Access edge auth and a T2/T3 authenticated session.",
+          ],
+          confusingMoments: [],
+          recommendations: ["Use the Playwright surface-sweep executor with CF Access and T2/T3 auth."],
+          evidence: ["executor: http_visibility_check; refused gated target before network request"],
+          scores: { orientation: 0 },
+        }),
+      },
+      Date.parse("2026-06-01T10:05:00.000Z"),
+    );
+
+    const disposition = testbedMissionSelfHealingDisposition(updated!);
+    expect(disposition).toMatchObject({
+      autoFixable: false,
+      reason: "environment_or_auth_failure",
+    });
+    expect(disposition.fixPrompt).toBeUndefined();
+  });
+
   it("marks runner/report-pipeline failures as human-review, not auto-fixable", () => {
     const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
     const failed = failTestbedMissionRun(run!.id, {

--- a/test/unit/test-wallet-signer.test.ts
+++ b/test/unit/test-wallet-signer.test.ts
@@ -131,6 +131,18 @@ describe("test-wallet signer sidecar", () => {
     expect(config.wallets).toEqual({});
   });
 
+  it("loads Cloudflare Access service token refs without treating them as wallet keys", () => {
+    const config = loadTestWalletSignerConfig({
+      TEST_WALLET_SIGNER_ENABLED: "0",
+      TESTBED_CF_ACCESS_CLIENT_ID: "cf-client-id",
+      TESTBED_CF_ACCESS_CLIENT_SECRET: "cf-client-secret"
+    });
+
+    expect(config.cfAccessClientId).toBe("cf-client-id");
+    expect(config.cfAccessClientSecret).toBe("cf-client-secret");
+    expect(config.wallets).toEqual({});
+  });
+
   it("never reflects private keys or bearer tokens in error output", async () => {
     const secret = KEYS.agent;
     const server = createTestWalletSignerHttpServer({

--- a/test/unit/testbed-mission-http-runner.test.ts
+++ b/test/unit/testbed-mission-http-runner.test.ts
@@ -61,4 +61,27 @@ describe("testbed mission HTTP runner", () => {
       ]),
     });
   });
+
+  it("refuses the gated operator app before making a non-browser HTTP probe", async () => {
+    const fetchImpl = vi.fn();
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const report = await runHttpTestbedMission({
+      TESTBED_TARGET_URL: "https://app.averray.com",
+      TESTBED_MISSION_GOAL: "Load the operator app",
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(report).toMatchObject({
+      verdict: "fail",
+      executor: "http_visibility_check",
+      blockers: [
+        expect.stringContaining("gated target https://app.averray.com requires the browser-capable executor"),
+      ],
+      evidence: expect.arrayContaining([
+        { type: "target_classification", value: "gated_app" },
+      ]),
+    });
+    expect(report.blockers.join(" ")).not.toContain("HTTP 401");
+  });
 });

--- a/test/unit/testbed-session.test.ts
+++ b/test/unit/testbed-session.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   parseSweepSessionConfig,
+  parseCloudflareAccessServiceToken,
   parseSweepSessionRole,
   isSweepSessionConfigured,
   normalizeStorageState,
   resolveSweepSession,
   buildSweepContextOptions,
+  cloudflareAccessHeaders,
   DEFAULT_AUTHED_ROUTES,
   type SweepStorageState,
 } from "../../services/slack-operator/src/testbed-session.js";
@@ -147,6 +149,25 @@ describe("buildSweepContextOptions", () => {
   it("token session → Authorization Bearer attached for the page's API calls", () => {
     const opts = buildSweepContextOptions({ role: "agent", token: "jwt-abc" });
     expect(opts.extraHTTPHeaders).toEqual({ Authorization: "Bearer jwt-abc" });
+  });
+
+  it("Cloudflare Access service token headers compose with the app session", () => {
+    const token = parseCloudflareAccessServiceToken({
+      TESTBED_CF_ACCESS_CLIENT_ID: "cf-client-id",
+      TESTBED_CF_ACCESS_CLIENT_SECRET: "cf-client-secret",
+    });
+    expect(token).toEqual({ clientId: "cf-client-id", clientSecret: "cf-client-secret" });
+    expect(cloudflareAccessHeaders(token)).toEqual({
+      "CF-Access-Client-Id": "cf-client-id",
+      "CF-Access-Client-Secret": "cf-client-secret",
+    });
+
+    const opts = buildSweepContextOptions({ role: "agent", token: "jwt-abc" }, token);
+    expect(opts.extraHTTPHeaders).toEqual({
+      "CF-Access-Client-Id": "cf-client-id",
+      "CF-Access-Client-Secret": "cf-client-secret",
+      Authorization: "Bearer jwt-abc",
+    });
   });
 });
 

--- a/test/unit/testbed-surface-sweep.test.ts
+++ b/test/unit/testbed-surface-sweep.test.ts
@@ -206,10 +206,13 @@ describe("executeBrowserTestbedMission — dispatch (single-URL explore stays in
       AVERRAY_APP_BASE_URL: "https://app.averray.com",
       AVERRAY_API_BASE_URL: "https://api.averray.com",
       TESTBED_SURFACE_SWEEP_BASE_URL: "https://averray.com",
+      TESTBED_CF_ACCESS_CLIENT_ID: "cf-id",
+      TESTBED_CF_ACCESS_CLIENT_SECRET: "cf-secret",
     });
 
     expect(parsed.appBaseUrl).toBe("https://app.averray.com");
     expect(parsed.surfaceSweepBaseUrl).toBe("https://averray.com");
+    expect(parsed.cloudflareAccess).toEqual({ clientId: "cf-id", clientSecret: "cf-secret" });
   });
 
   it("routes a surface_sweep mission to the sweep (uses the injected capture)", async () => {


### PR DESCRIPTION
## What changed & why

- Added Cloudflare Access service-token support for browser-capable testbed runs via `TESTBED_CF_ACCESS_CLIENT_ID` / `TESTBED_CF_ACCESS_CLIENT_SECRET`.
- Surface sweeps now pass CF Access headers into the Playwright browser context and keep T2/T3 app sessions layered on top.
- The T3 test-wallet signer uses the same CF Access headers when minting browser sessions for the gated app.
- Gold-path live runs receive the edge-auth context without placing secret values in prompts, and live-driver output/report parsing redacts configured CF Access values if a tool leaks them.
- `http_visibility_check` now refuses gated app hosts before fetch, so it never reports the expected app-edge 401 as a product mission failure.
- Removed the dangerous `.env.example` default that pointed command mode at the HTTP visibility runner; command mode now has to be intentionally configured.

Root cause: `https://app.averray.com` is a gated operator app. A non-browser unauthenticated fetch is the wrong executor there; it will always produce transport/auth noise instead of real product evidence.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [x] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (rerun after the parallel typecheck/test race; final run passed 115 files / 1355 tests)
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (blocked locally: Docker CLI here has no Compose subcommand and `docker-compose` is not installed)
- [x] `git diff --check`

## Rollout / rollback

Rollout: provision the CF Access service token in ops env as `TESTBED_CF_ACCESS_CLIENT_ID` and `TESTBED_CF_ACCESS_CLIENT_SECRET` for both `testbed-mission-runner` and `test-wallet-signer`. Keep `TESTBED_SESSION_SIGNER_URL=http://test-wallet-signer:8791` for app product auth. For T4, use `TESTBED_GOLDPATH_LIVE=1` and `services/slack-operator/dist/gold-path-mission-entry.js`.

Rollback: revert this PR or clear the new CF Access env vars. Public-only sweeps still work through `TESTBED_SURFACE_SWEEP_BASE_URL`; gated app missions will again require operator-side auth setup before they can produce real browser evidence.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new ungated agent power
- [x] No secrets committed/printed/logged
- [x] Updated affected docs because this changes how app-auth testbed runs work

## Known limits / follow-ups

- This PR wires service-token headers and safe runner selection. It does not create the Cloudflare Access service token; the operator must provision it in ops secrets.
- No live app mission was executed from this local machine because the CF Access token/session secrets are intentionally not present here.