### PR TITLE
fix: support greenfield codex task runs

### DIFF
--- a/services/slack-operator/src/codex-branch-worker.ts
+++ b/services/slack-operator/src/codex-branch-worker.ts
@@ -3,11 +3,13 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { taskAgentBranchPrefix, taskAgentCommitPrefix, taskAgentPrBodyLabel } from "./specialist-agents.js";
 
 export interface CodexWorkerTask {
   id: string;
   repo: string;
-  pullRequestNumber: number;
+  /** Existing-PR mode. Greenfield tasks omit this and the worker opens a new PR. */
+  pullRequestNumber?: number;
   title?: string;
   prompt: string;
   correlationId?: string;
@@ -21,6 +23,7 @@ export interface CodexWorkerConfig {
   keepWorktree: boolean;
   gitUserName: string;
   gitUserEmail: string;
+  baseBranch: string;
   codexCommand: string;
   codexArgs: string[];
   commandTimeoutMs: number;
@@ -55,6 +58,26 @@ interface CommandResult {
   stderr: string;
 }
 
+export type ExecFn = (
+  command: string,
+  args: string[],
+  options?: { cwd?: string; timeoutMs?: number; token?: string }
+) => Promise<CommandResult>;
+
+export interface OpenedPullRequest {
+  number: number;
+  html_url?: string;
+}
+
+export interface CodexBranchWorkerDeps {
+  exec?: ExecFn;
+  openPullRequest?: (
+    task: CodexWorkerTask,
+    config: CodexWorkerConfig,
+    input: { head: string; base: string; title: string; body: string }
+  ) => Promise<OpenedPullRequest>;
+}
+
 const DEFAULT_CODEX_ARGS = ["exec", "--full-auto", "{prompt}"];
 const PROTECTED_BRANCHES = new Set(["main", "master", "production", "prod"]);
 const DEFAULT_DENY_PATTERNS = [
@@ -69,14 +92,15 @@ const DEFAULT_DENY_PATTERNS = [
 
 export function parseCodexWorkerTask(env: NodeJS.ProcessEnv = process.env): CodexWorkerTask {
   const repo = requiredEnv(env, "CODEX_TASK_REPO");
-  const pullRequestNumber = Number(env.CODEX_TASK_PR);
-  if (!Number.isInteger(pullRequestNumber) || pullRequestNumber < 1) {
-    throw new Error("CODEX_TASK_PR must be a positive integer.");
+  const prRaw = env.CODEX_TASK_PR?.trim();
+  const pullRequestNumber = prRaw ? Number(prRaw) : undefined;
+  if (prRaw && (!Number.isInteger(pullRequestNumber) || (pullRequestNumber as number) < 1)) {
+    throw new Error("CODEX_TASK_PR, when set, must be a positive integer.");
   }
   return {
     id: requiredEnv(env, "CODEX_TASK_ID"),
     repo,
-    pullRequestNumber,
+    ...(pullRequestNumber ? { pullRequestNumber } : {}),
     ...(env.CODEX_TASK_TITLE ? { title: env.CODEX_TASK_TITLE } : {}),
     prompt: requiredEnv(env, "CODEX_TASK_PROMPT"),
     ...(env.CODEX_TASK_CORRELATION_ID ? { correlationId: env.CODEX_TASK_CORRELATION_ID } : {}),
@@ -92,6 +116,7 @@ export function parseCodexWorkerConfig(env: NodeJS.ProcessEnv = process.env): Co
     keepWorktree: env.CODEX_BRANCH_WORKER_KEEP_WORKTREE === "1" || env.CODEX_BRANCH_WORKER_KEEP_WORKTREE === "true",
     gitUserName: env.CODEX_BRANCH_WORKER_GIT_USER_NAME?.trim() || "Averray Codex Worker",
     gitUserEmail: env.CODEX_BRANCH_WORKER_GIT_USER_EMAIL?.trim() || "codex-worker@averray.local",
+    baseBranch: env.CODEX_BRANCH_WORKER_BASE_BRANCH?.trim() || "main",
     codexCommand: env.CODEX_BRANCH_WORKER_CODEX_COMMAND?.trim() || "codex",
     codexArgs: parseArgs(env.CODEX_BRANCH_WORKER_CODEX_ARGS, DEFAULT_CODEX_ARGS),
     commandTimeoutMs: positiveInt(env.CODEX_BRANCH_WORKER_TIMEOUT_MS, 30 * 60_000),
@@ -108,6 +133,9 @@ export function validatePullRequestForCodexWorker(
   }
   if (config.allowedRepos.length > 0 && !config.allowedRepos.includes(task.repo)) {
     throw new Error(`Repo ${task.repo} is not allowed for Codex worker dispatch.`);
+  }
+  if (task.pullRequestNumber === undefined) {
+    throw new Error("validatePullRequestForCodexWorker requires an existing PR task.");
   }
   if (pr.state !== "open") {
     throw new Error(`PR #${task.pullRequestNumber} is not open (${pr.state}).`);
@@ -127,6 +155,29 @@ export function validatePullRequestForCodexWorker(
   const baseRef = pr.base?.ref;
   if (baseRepo === headRepo && baseRef && baseRef === headRef) {
     throw new Error(`Refusing to let Codex work on the base branch ${baseRef}.`);
+  }
+}
+
+export function codexBranchName(task: CodexWorkerTask): string {
+  const base = (task.title || task.prompt || "task")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  const tail = task.id.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(-8);
+  return `${taskAgentBranchPrefix("codex")}/${[base, tail].filter(Boolean).join("-") || "task"}`;
+}
+
+export function validateGreenfieldCodexWorkerTask(task: CodexWorkerTask, branch: string, config: CodexWorkerConfig): void {
+  if (config.allowedRepos.length === 0) {
+    throw new Error("No Codex worker allowed repos configured.");
+  }
+  if (!config.allowedRepos.includes(task.repo)) {
+    throw new Error(`Repo ${task.repo} is not allowed for Codex worker dispatch.`);
+  }
+  if (PROTECTED_BRANCHES.has(branch.toLowerCase()) || branch === config.baseBranch) {
+    throw new Error(`Refusing to let Codex push to protected/base branch ${branch}.`);
   }
 }
 
@@ -156,12 +207,35 @@ export function buildGuardedCodexPrompt(task: CodexWorkerTask, pr: GithubPullReq
   ].filter(Boolean).join("\n");
 }
 
+export function buildGuardedCodexGreenfieldPrompt(task: CodexWorkerTask, branch: string): string {
+  const correlation = task.correlationId ? `\nCorrelation ID: ${task.correlationId}` : "";
+  return [
+    "You are Codex working for Hermes on an approved Averray monitor task.",
+    "",
+    "Hard boundaries:",
+    `- Work only in this checked-out worktree on branch ${branch}.`,
+    "- Do not merge, deploy, rotate secrets, claim jobs, submit platform work, or edit production state.",
+    "- Do not add or print secrets, JWTs, private keys, or provider tokens.",
+    "- Keep the change minimal and specific to the task.",
+    "- Run the smallest relevant local checks you can before finishing.",
+    "- Do not open the pull request yourself; the harness commits, pushes, and opens it.",
+    "- Leave GitHub merge/deploy decisions to Hermes and the operator.",
+    "",
+    `Repository: ${task.repo}`,
+    `Title: ${task.title || "untitled"}`,
+    correlation.trim(),
+    "",
+    "Task from Hermes:",
+    task.prompt,
+  ].filter(Boolean).join("\n");
+}
+
 export function renderCodexWorkerArgs(args: string[], prompt: string, task: CodexWorkerTask): string[] {
   const replacements: Record<string, string> = {
     "{prompt}": prompt,
     "{taskId}": task.id,
     "{repo}": task.repo,
-    "{pr}": String(task.pullRequestNumber),
+    "{pr}": task.pullRequestNumber != null ? String(task.pullRequestNumber) : "",
     "{title}": task.title ?? "",
     "{correlationId}": task.correlationId ?? "",
   };
@@ -176,8 +250,14 @@ export function renderCodexWorkerArgs(args: string[], prompt: string, task: Code
 
 export async function runCodexBranchWorker(
   task: CodexWorkerTask = parseCodexWorkerTask(),
-  config: CodexWorkerConfig = parseCodexWorkerConfig()
+  config: CodexWorkerConfig = parseCodexWorkerConfig(),
+  deps: CodexBranchWorkerDeps = {}
 ): Promise<void> {
+  const exec = deps.exec ?? run;
+  const openPullRequest = deps.openPullRequest ?? openPullRequestViaApi;
+  if (task.pullRequestNumber === undefined) {
+    return runGreenfieldCodexBranchWorker(task, config, { exec, openPullRequest });
+  }
   const pr = await fetchPullRequest(task, config);
   validatePullRequestForCodexWorker(task, pr, config);
   const headRepo = pr.head.repo?.full_name as string;
@@ -186,31 +266,31 @@ export async function runCodexBranchWorker(
   const workdir = await mkdtemp(join(config.workRoot, `${task.id}-`));
   let cleanup = !config.keepWorktree;
   try {
-    await run("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
-    await run("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
-    await run("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
-    await run("git", ["fetch", "origin", `${pr.head.ref}:${pr.head.ref}`], { cwd: workdir, token: config.githubToken });
-    await run("git", ["checkout", pr.head.ref], { cwd: workdir });
-    const beforeSha = (await run("git", ["rev-parse", "HEAD"], { cwd: workdir })).stdout.trim();
+    await exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    await exec("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
+    await exec("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
+    await exec("git", ["fetch", "origin", `${pr.head.ref}:${pr.head.ref}`], { cwd: workdir, token: config.githubToken });
+    await exec("git", ["checkout", pr.head.ref], { cwd: workdir });
+    const beforeSha = (await exec("git", ["rev-parse", "HEAD"], { cwd: workdir })).stdout.trim();
     const prompt = buildGuardedCodexPrompt(task, pr);
     console.log(`Codex worker claimed ${task.repo}#${task.pullRequestNumber} on ${pr.head.ref}.`);
-    const codex = await run(config.codexCommand, renderCodexWorkerArgs(config.codexArgs, prompt, task), {
+    const codex = await exec(config.codexCommand, renderCodexWorkerArgs(config.codexArgs, prompt, task), {
       cwd: workdir,
       timeoutMs: config.commandTimeoutMs,
     });
     if (codex.exitCode !== 0) {
       throw new Error(lastNonEmptyLine(codex.stderr) || lastNonEmptyLine(codex.stdout) || `Codex exited with ${codex.exitCode}.`);
     }
-    const changedFiles = await gitChangedFiles(workdir);
+    const changedFiles = await gitChangedFiles(workdir, exec);
     assertNoForbiddenFiles(changedFiles);
     const hasChanges = changedFiles.length > 0;
     if (hasChanges) {
-      await run("git", ["add", "-A"], { cwd: workdir });
-      await run("git", ["commit", "-m", commitMessage(task)], { cwd: workdir });
+      await exec("git", ["add", "-A"], { cwd: workdir });
+      await exec("git", ["commit", "-m", commitMessage(task)], { cwd: workdir });
     }
-    const afterSha = (await run("git", ["rev-parse", "HEAD"], { cwd: workdir })).stdout.trim();
+    const afterSha = (await exec("git", ["rev-parse", "HEAD"], { cwd: workdir })).stdout.trim();
     if (afterSha !== beforeSha) {
-      await run("git", ["push", "origin", `HEAD:${pr.head.ref}`], { cwd: workdir, token: config.githubToken });
+      await exec("git", ["push", "origin", `HEAD:${pr.head.ref}`], { cwd: workdir, token: config.githubToken });
       console.log(`Codex pushed ${afterSha.slice(0, 12)} to ${headRepo}:${pr.head.ref}.`);
     } else {
       console.log("Codex completed without producing a new commit.");
@@ -223,7 +303,64 @@ export async function runCodexBranchWorker(
   }
 }
 
+async function runGreenfieldCodexBranchWorker(
+  task: CodexWorkerTask,
+  config: CodexWorkerConfig,
+  deps: {
+    exec: ExecFn;
+    openPullRequest: NonNullable<CodexBranchWorkerDeps["openPullRequest"]>;
+  }
+): Promise<void> {
+  const branch = codexBranchName(task);
+  validateGreenfieldCodexWorkerTask(task, branch, config);
+
+  const cloneUrl = `https://github.com/${task.repo}.git`;
+  await mkdir(config.workRoot, { recursive: true });
+  const workdir = await mkdtemp(join(config.workRoot, `${slug(task.id)}-`));
+  try {
+    await deps.exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    await deps.exec("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
+    await deps.exec("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
+    await deps.exec("git", ["fetch", "origin", config.baseBranch], { cwd: workdir, token: config.githubToken });
+    await deps.exec("git", ["checkout", "-B", branch, `origin/${config.baseBranch}`], { cwd: workdir });
+
+    const prompt = buildGuardedCodexGreenfieldPrompt(task, branch);
+    console.log(`Codex worker starting greenfield ${task.repo} on ${branch}.`);
+    const codex = await deps.exec(config.codexCommand, renderCodexWorkerArgs(config.codexArgs, prompt, task), {
+      cwd: workdir,
+      timeoutMs: config.commandTimeoutMs,
+    });
+    if (codex.exitCode !== 0) {
+      throw new Error(lastNonEmptyLine(codex.stderr) || lastNonEmptyLine(codex.stdout) || `Codex exited with ${codex.exitCode}.`);
+    }
+
+    const changedFiles = await gitChangedFiles(workdir, deps.exec);
+    assertNoForbiddenFiles(changedFiles);
+    if (changedFiles.length === 0) {
+      console.log(`Codex produced no changes for ${task.repo}; not opening a PR.`);
+      return;
+    }
+
+    await deps.exec("git", ["add", "-A"], { cwd: workdir });
+    await deps.exec("git", ["commit", "-m", commitMessage(task)], { cwd: workdir });
+    await deps.exec("git", ["push", "origin", `HEAD:${branch}`], { cwd: workdir, token: config.githubToken });
+
+    const pr = await deps.openPullRequest(task, config, {
+      head: branch,
+      base: config.baseBranch,
+      title: pullRequestTitle(task),
+      body: buildPullRequestBody(task),
+    });
+    console.log(`Codex opened PR #${pr.number} on ${task.repo} (${branch})${pr.html_url ? ` - ${pr.html_url}` : ""}.`);
+  } finally {
+    if (!config.keepWorktree) await rm(workdir, { recursive: true, force: true });
+  }
+}
+
 async function fetchPullRequest(task: CodexWorkerTask, config: CodexWorkerConfig): Promise<GithubPullRequestForWorker> {
+  if (task.pullRequestNumber === undefined) {
+    throw new Error("fetchPullRequest requires an existing PR task.");
+  }
   const response = await fetch(`${config.apiBaseUrl.replace(/\/$/, "")}/repos/${task.repo}/pulls/${task.pullRequestNumber}`, {
     headers: {
       accept: "application/vnd.github+json",
@@ -237,8 +374,30 @@ async function fetchPullRequest(task: CodexWorkerTask, config: CodexWorkerConfig
   return await response.json() as GithubPullRequestForWorker;
 }
 
-async function gitChangedFiles(cwd: string): Promise<string[]> {
-  const result = await run("git", ["status", "--porcelain"], { cwd });
+async function openPullRequestViaApi(
+  task: CodexWorkerTask,
+  config: CodexWorkerConfig,
+  input: { head: string; base: string; title: string; body: string }
+): Promise<OpenedPullRequest> {
+  const response = await fetch(`${config.apiBaseUrl.replace(/\/$/, "")}/repos/${task.repo}/pulls`, {
+    method: "POST",
+    headers: {
+      accept: "application/vnd.github+json",
+      "content-type": "application/json",
+      "user-agent": "averray-codex-branch-worker",
+      ...(config.githubToken ? { authorization: `Bearer ${config.githubToken}` } : {}),
+    },
+    body: JSON.stringify({ title: input.title, head: input.head, base: input.base, body: input.body, maintainer_can_modify: true }),
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub PR creation failed for ${task.repo} (${input.head} → ${input.base}): HTTP ${response.status}`);
+  }
+  const json = await response.json() as OpenedPullRequest;
+  return { number: json.number, ...(json.html_url ? { html_url: json.html_url } : {}) };
+}
+
+async function gitChangedFiles(cwd: string, exec: ExecFn = run): Promise<string[]> {
+  const result = await exec("git", ["status", "--porcelain"], { cwd });
   return result.stdout
     .split(/\r?\n/)
     .map((line) => line.trim())
@@ -258,8 +417,30 @@ export function assertNoForbiddenFiles(paths: string[], who = "Codex"): void {
 }
 
 function commitMessage(task: CodexWorkerTask): string {
-  const title = (task.title || `PR ${task.pullRequestNumber}`).replace(/\s+/g, " ").trim();
-  return `Codex task: ${title}`.slice(0, 72);
+  const title = (task.title || (task.pullRequestNumber ? `PR ${task.pullRequestNumber}` : "greenfield task")).replace(/\s+/g, " ").trim();
+  return `${taskAgentCommitPrefix("codex")}: ${title}`.slice(0, 72);
+}
+
+function pullRequestTitle(task: CodexWorkerTask): string {
+  const title = (task.title || task.prompt || "Hermes Codex task").replace(/\s+/g, " ").trim();
+  return `codex: ${title}`.slice(0, 120);
+}
+
+function buildPullRequestBody(task: CodexWorkerTask): string {
+  return [
+    `Opened by the Averray **${taskAgentPrBodyLabel("codex")}** for an approved Hermes task.`,
+    "",
+    "**Task**",
+    task.prompt,
+    "",
+    task.correlationId ? `Correlation ID: \`${task.correlationId}\`` : "",
+    "",
+    "_Automated change on a fresh branch. Review + merge are human-gated (AGENTS.md)._",
+  ].filter(Boolean).join("\n");
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "task";
 }
 
 async function run(

--- a/services/slack-operator/src/codex-task-request.ts
+++ b/services/slack-operator/src/codex-task-request.ts
@@ -2,9 +2,8 @@
 //
 // Extracted from the HTTP handler so the agent-aware payload rules can be
 // unit-tested without standing up the server. The rule that matters:
-//   - Codex tasks iterate an EXISTING PR, so a valid pullRequestNumber is
-//     required.
-//   - Claude/specialist tasks are GREENFIELD (the worker opens its own PR), so
+//   - Codex can either iterate an existing PR or start GREENFIELD work.
+//   - Claude/specialist tasks are also GREENFIELD (the worker opens its own PR), so
 //     the PR is optional — and only validated when the caller supplies one.
 // The queue layer (proposeCodexTask) already supports both shapes; this is the
 // untrusted-input gate in front of it, and it decides which agent runs.
@@ -45,7 +44,7 @@ function num(field: unknown): number | undefined {
 function requiredFieldsMessage(agent: TaskAgent): string {
   return isGreenfieldTaskAgent(agent)
     ? `repo and prompt are required to propose ${taskAgentLabel(agent)} work; pullRequestNumber is optional.`
-    : "repo, pullRequestNumber, and prompt are required to propose Codex work.";
+    : `repo, pullRequestNumber, and prompt are required to propose ${taskAgentLabel(agent)} work.`;
 }
 
 export function parseProposeTaskPayload(payload: unknown): ParseProposeResult {

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -89,6 +89,7 @@ export async function runCodexTaskRunnerOnce(
   const claimed = await claimNextApprovedCodexTask({
     path: config.path,
     runnerId: config.runnerId,
+    agent: "codex",
     now: deps.now,
   });
   if (!claimed) {
@@ -99,7 +100,7 @@ export async function runCodexTaskRunnerOnce(
   await updateRunnerHeartbeat(
     config,
     "running",
-    `Codex runner claimed ${claimed.repo}#${claimed.pullRequestNumber}.`,
+    `Codex runner claimed ${taskLabel(claimed)}.`,
     deps.now,
     claimed.id
   );
@@ -131,7 +132,7 @@ export async function runCodexTaskRunnerOnce(
       await updateRunnerHeartbeat(
         config,
         "completed",
-        summary || `Codex runner completed ${claimed.repo}#${claimed.pullRequestNumber}.`,
+        summary || `Codex runner completed ${taskLabel(claimed)}.`,
         undefined,
         claimed.id
       );
@@ -252,7 +253,7 @@ function taskEnvironment(task: CodexTask): NodeJS.ProcessEnv {
     ...process.env,
     CODEX_TASK_ID: task.id,
     CODEX_TASK_REPO: task.repo,
-    CODEX_TASK_PR: String(task.pullRequestNumber),
+    CODEX_TASK_PR: task.pullRequestNumber != null ? String(task.pullRequestNumber) : "",
     CODEX_TASK_TITLE: task.title ?? "",
     CODEX_TASK_CORRELATION_ID: task.correlationId ?? "",
     CODEX_TASK_REASON: task.reason ?? "",
@@ -309,13 +310,13 @@ export function renderCodexTaskRunnerArgs(args: string[], task: CodexTask): stri
   const replacements: Record<string, string> = {
     "{taskId}": task.id,
     "{repo}": task.repo,
-    "{pr}": String(task.pullRequestNumber),
+    "{pr}": task.pullRequestNumber != null ? String(task.pullRequestNumber) : "",
     "{title}": task.title ?? "",
     "{correlationId}": task.correlationId ?? "",
     "{prompt}": task.prompt,
     "{CODEX_TASK_ID}": task.id,
     "{CODEX_TASK_REPO}": task.repo,
-    "{CODEX_TASK_PR}": String(task.pullRequestNumber),
+    "{CODEX_TASK_PR}": task.pullRequestNumber != null ? String(task.pullRequestNumber) : "",
     "{CODEX_TASK_TITLE}": task.title ?? "",
     "{CODEX_TASK_CORRELATION_ID}": task.correlationId ?? "",
     "{CODEX_TASK_PROMPT}": task.prompt,
@@ -327,6 +328,10 @@ export function renderCodexTaskRunnerArgs(args: string[], task: CodexTask): stri
     }
     return value;
   });
+}
+
+function taskLabel(task: CodexTask): string {
+  return task.pullRequestNumber != null ? `${task.repo}#${task.pullRequestNumber}` : `${task.repo} (greenfield)`;
 }
 
 // Exported so the Claude task runner reuses the exact same secret

--- a/services/slack-operator/src/specialist-agents.ts
+++ b/services/slack-operator/src/specialist-agents.ts
@@ -97,7 +97,7 @@ export const TASK_AGENT_DEFINITIONS: readonly TaskAgentDefinition[] = [
     id: "codex",
     label: "Codex",
     branchPrefix: "codex",
-    greenfield: false,
+    greenfield: true,
     prBodyLabel: "Codex worker",
     commitPrefix: "Codex task",
   },

--- a/test/unit/codex-branch-worker.test.ts
+++ b/test/unit/codex-branch-worker.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildGuardedCodexGreenfieldPrompt,
   buildGuardedCodexPrompt,
+  codexBranchName,
+  type ExecFn,
   parseCodexWorkerConfig,
   parseCodexWorkerTask,
   renderCodexWorkerArgs,
+  runCodexBranchWorker,
+  validateGreenfieldCodexWorkerTask,
   validatePullRequestForCodexWorker,
   type CodexWorkerTask,
   type GithubPullRequestForWorker,
@@ -40,7 +45,7 @@ describe("codex branch worker", () => {
     },
   };
 
-  it("parses task and worker config from environment", () => {
+  it("parses PR-mode and greenfield tasks plus worker config from environment", () => {
     expect(parseCodexWorkerTask({
       CODEX_TASK_ID: "task-1",
       CODEX_TASK_REPO: "averray-agent/agent",
@@ -54,6 +59,21 @@ describe("codex branch worker", () => {
       prompt: "Fix it.",
       correlationId: "corr-1",
     });
+    expect(parseCodexWorkerTask({
+      CODEX_TASK_ID: "task-2",
+      CODEX_TASK_REPO: "averray-agent/agent",
+      CODEX_TASK_PROMPT: "Build the missing thing.",
+    })).toMatchObject({
+      id: "task-2",
+      repo: "averray-agent/agent",
+      prompt: "Build the missing thing.",
+    });
+    expect(() => parseCodexWorkerTask({
+      CODEX_TASK_ID: "task-3",
+      CODEX_TASK_REPO: "averray-agent/agent",
+      CODEX_TASK_PR: "nope",
+      CODEX_TASK_PROMPT: "Fix it.",
+    })).toThrow(/positive integer/);
 
     expect(parseCodexWorkerConfig({
       CODEX_TASK_REPO: "averray-agent/agent",
@@ -66,6 +86,7 @@ describe("codex branch worker", () => {
       allowedRepos: ["averray-agent/agent", "depre-dev/averray-reference-agent"],
       codexCommand: "codex",
       codexArgs: ["exec", "{prompt}"],
+      baseBranch: "main",
     });
   });
 
@@ -111,5 +132,73 @@ describe("codex branch worker", () => {
       "--pr=381",
       "github-pr-381",
     ]);
+  });
+
+  it("builds and validates a greenfield branch for Codex tasks without a PR", () => {
+    const greenfield: CodexWorkerTask = {
+      id: "codex-task-greenfield-123456",
+      repo: "averray-agent/agent",
+      title: "Add runner guard",
+      prompt: "Add the missing guard.",
+    };
+    const branch = codexBranchName(greenfield);
+    const config = parseCodexWorkerConfig({
+      CODEX_TASK_REPO: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent",
+    });
+
+    expect(branch).toMatch(/^codex\/add-runner-guard-[a-z0-9-]+$/);
+    expect(() => validateGreenfieldCodexWorkerTask(greenfield, branch, config)).not.toThrow();
+    expect(buildGuardedCodexGreenfieldPrompt(greenfield, branch)).toContain("the harness commits, pushes, and opens it");
+    expect(renderCodexWorkerArgs(["--pr={pr}", "{prompt}"], "Prompt", greenfield)).toEqual(["--pr=", "Prompt"]);
+  });
+
+  it("runs a greenfield Codex task by branching from base and opening a new PR", async () => {
+    const greenfield: CodexWorkerTask = {
+      id: "codex-task-greenfield-abcdef",
+      repo: "averray-agent/agent",
+      title: "Add runner guard",
+      prompt: "Add the missing guard.",
+      correlationId: "mission-1",
+    };
+    const config = parseCodexWorkerConfig({
+      CODEX_TASK_REPO: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_ROOT: "/private/tmp/averray-test-codex-worker",
+      CODEX_BRANCH_WORKER_CODEX_COMMAND: "codex",
+      CODEX_BRANCH_WORKER_CODEX_ARGS: "[\"exec\",\"{prompt}\"]",
+    });
+    const commands: Array<{ command: string; args: string[]; cwd?: string }> = [];
+    const exec: ExecFn = async (command, args, options) => {
+      commands.push({ command, args, ...(options?.cwd ? { cwd: options.cwd } : {}) });
+      if (command === "git" && args[0] === "status") {
+        return { exitCode: 0, stdout: " M services/slack-operator/src/codex-branch-worker.ts\n", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+    const opened: Array<{ head: string; base: string; title: string; body: string }> = [];
+
+    await runCodexBranchWorker(greenfield, config, {
+      exec,
+      openPullRequest: async (_task, _config, input) => {
+        opened.push(input);
+        return { number: 606, html_url: "https://github.com/averray-agent/agent/pull/606" };
+      },
+    });
+
+    const branch = codexBranchName(greenfield);
+    expect(commands).toEqual(expect.arrayContaining([
+      expect.objectContaining({ command: "git", args: ["clone", "--no-tags", "--depth=50", "https://github.com/averray-agent/agent.git", expect.any(String)] }),
+      expect.objectContaining({ command: "git", args: ["fetch", "origin", "main"] }),
+      expect.objectContaining({ command: "git", args: ["checkout", "-B", branch, "origin/main"] }),
+      expect.objectContaining({ command: "codex", args: ["exec", expect.stringContaining("Task from Hermes:")] }),
+      expect.objectContaining({ command: "git", args: ["push", "origin", `HEAD:${branch}`] }),
+    ]));
+    expect(opened).toEqual([expect.objectContaining({
+      head: branch,
+      base: "main",
+      title: "codex: Add runner guard",
+      body: expect.stringContaining("Review + merge are human-gated"),
+    })]);
   });
 });

--- a/test/unit/codex-task-request.test.ts
+++ b/test/unit/codex-task-request.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseProposeTaskPayload } from "../../services/slack-operator/src/codex-task-request.js";
 
-describe("parseProposeTaskPayload — codex (existing-PR) tasks", () => {
+describe("parseProposeTaskPayload — codex tasks", () => {
   it("accepts a valid repo + PR + prompt and defaults agent/requester", () => {
     const r = parseProposeTaskPayload({ repo: "averray-agent/agent", pullRequestNumber: 402, prompt: "fix it" });
     expect(r.ok).toBe(true);
@@ -21,11 +21,16 @@ describe("parseProposeTaskPayload — codex (existing-PR) tasks", () => {
     expect(r.ok && r.input.pullRequestNumber).toBe(402);
   });
 
-  it("rejects codex work with no PR (codex iterates an existing PR)", () => {
+  it("accepts greenfield Codex work with no PR", () => {
     const r = parseProposeTaskPayload({ repo: "a/b", prompt: "x" });
-    expect(r.ok).toBe(false);
-    if (r.ok) return;
-    expect(r.message).toMatch(/pullRequestNumber.*required.*Codex/i);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input).toMatchObject({
+      repo: "a/b",
+      agent: "codex",
+      prompt: "x",
+    });
+    expect(r.input.pullRequestNumber).toBeUndefined();
   });
 
   it("rejects a non-positive / non-integer PR", () => {

--- a/test/unit/codex-task-runner.test.ts
+++ b/test/unit/codex-task-runner.test.ts
@@ -104,6 +104,68 @@ describe("codex task runner", () => {
     });
   });
 
+  it("claims only Codex-routed tasks and leaves Claude-routed tasks for Claude", async () => {
+    const path = await tempQueuePath();
+    const claude = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      agent: "claude",
+      title: "Claude task",
+      prompt: "Build a frontend refinement.",
+    }, { path, now: new Date("2026-06-01T10:00:00.000Z") });
+    const codex = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      agent: "codex",
+      title: "Codex task",
+      prompt: "Fix the runner guard.",
+    }, { path, now: new Date("2026-06-01T10:01:00.000Z") });
+    await approveCodexTask(claude.task.id, { path, now: new Date("2026-06-01T10:02:00.000Z") });
+    await approveCodexTask(codex.task.id, { path, now: new Date("2026-06-01T10:03:00.000Z") });
+
+    const seen: string[] = [];
+    const result = await runCodexTaskRunnerOnce(config(path), {
+      executor: async (task) => {
+        seen.push(task.id);
+        return { exitCode: 0, stdout: "done\n", stderr: "", summary: "done" };
+      },
+      now: new Date("2026-06-01T10:04:00.000Z"),
+    });
+
+    expect(result.status).toBe("completed");
+    expect(seen).toEqual([codex.task.id]);
+    const tasks = await listCodexTasks({ path });
+    expect(tasks.find((task) => task.id === codex.task.id)).toMatchObject({ status: "completed", agent: "codex" });
+    expect(tasks.find((task) => task.id === claude.task.id)).toMatchObject({ status: "approved", agent: "claude" });
+  });
+
+  it("executes greenfield Codex tasks without requiring CODEX_TASK_PR", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      agent: "codex",
+      title: "Add runner guard",
+      prompt: "Fix the greenfield runner path.",
+      correlationId: "greenfield-1",
+    }, { path });
+    await approveCodexTask(proposed.task.id, { path });
+
+    const result = await runCodexTaskRunnerOnce(config(path), {
+      executor: async (task) => {
+        expect(task.pullRequestNumber).toBeUndefined();
+        expect(renderCodexTaskRunnerArgs(["--pr={pr}", "{CODEX_TASK_PR}"], task)).toEqual(["--pr=", ""]);
+        return { exitCode: 0, stdout: "opened pr\n", stderr: "", summary: "opened pr" };
+      },
+    });
+
+    expect(result.status).toBe("completed");
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      id: proposed.task.id,
+      status: "completed",
+      agent: "codex",
+    });
+    expect(task.pullRequestNumber).toBeUndefined();
+  });
+
   it("marks an approved task failed when the executor exits nonzero", async () => {
     const path = await tempQueuePath();
     const proposed = await proposeCodexTask({
@@ -198,6 +260,23 @@ describe("codex task runner", () => {
       "Continue PR #393.",
       "--pr=393",
       "averray-agent/agent",
+    ]);
+  });
+
+  it("renders empty PR placeholders for greenfield task command args", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      agent: "codex",
+      title: "New task",
+      prompt: "Build new task.",
+    }, { path });
+
+    expect(renderCodexTaskRunnerArgs(["exec", "--pr={pr}", "{CODEX_TASK_PR}", "{prompt}"], proposed.task)).toEqual([
+      "exec",
+      "--pr=",
+      "",
+      "Build new task.",
     ]);
   });
 });

--- a/test/unit/specialist-agents.test.ts
+++ b/test/unit/specialist-agents.test.ts
@@ -6,6 +6,7 @@ import {
   INTERNAL_SPECIALIST_AGENTS,
   SECURITY_AGENT_ID,
   SECURITY_ROLE_PROMPT,
+  taskAgentDefinition,
   specialistAgentDefinition,
 } from "../../services/slack-operator/src/specialist-agents.js";
 import { buildGuardedClaudePrompt, claudeBranchName, type ClaudeWorkerTask } from "../../services/slack-operator/src/claude-branch-worker.js";
@@ -18,6 +19,16 @@ const baseTask: ClaudeWorkerTask = {
 };
 
 describe("C3 specialist agent templates", () => {
+  it("keeps Codex registered as a greenfield-capable worker", () => {
+    expect(taskAgentDefinition("codex")).toMatchObject({
+      id: "codex",
+      label: "Codex",
+      branchPrefix: "codex",
+      greenfield: true,
+      prBodyLabel: "Codex worker",
+    });
+  });
+
   it("registers the security specialist as proposes-only with operator escalation", () => {
     const specialist = specialistAgentDefinition(SECURITY_AGENT_ID);
 


### PR DESCRIPTION
## Summary
- allow Codex worker tasks with no CODEX_TASK_PR to branch from the configured base branch and open a new PR
- keep existing PR-mode behavior intact while registering Codex as greenfield-capable
- make the Codex task runner claim only agent=codex tasks so Claude/specialist work remains for their runners

## Root cause
- Codex branch worker parsed CODEX_TASK_PR as mandatory, so greenfield tasks failed before doing any work.
- Codex task runner claimed approved tasks without an agent filter, so it could steal Claude-routed work.

## Checks
- npm run typecheck
- npm test

## Impact
- Backend/service worker code only. No env, deploy, contract, or production secret changes.

board-gated; agents can request but not run tests directly. Merge/deploy remains human-gated.