### PR TITLE
test: use portable codex worker temp root

### DIFF
--- a/test/unit/codex-branch-worker.test.ts
+++ b/test/unit/codex-branch-worker.test.ts
@@ -164,7 +164,6 @@ describe("codex branch worker", () => {
     const config = parseCodexWorkerConfig({
       CODEX_TASK_REPO: "averray-agent/agent",
       CODEX_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent",
-      CODEX_BRANCH_WORKER_ROOT: "/private/tmp/averray-test-codex-worker",
       CODEX_BRANCH_WORKER_CODEX_COMMAND: "codex",
       CODEX_BRANCH_WORKER_CODEX_ARGS: "[\"exec\",\"{prompt}\"]",
     });


### PR DESCRIPTION
## Summary
- remove the macOS-only /private/tmp override from the Codex greenfield worker unit test
- let the worker config use its cross-platform tmpdir() default so Ubuntu CI can create the test worktree

## Why
PR #368 merged the worker fix but the Typecheck and test check failed on Ubuntu with EACCES: permission denied, mkdir /private. This follow-up keeps the implementation unchanged and fixes the test portability issue only.

## Checks
- npm run typecheck
- npm test -- test/unit/codex-branch-worker.test.ts
- npm test

## Impact
- Test-only change. No runtime, env, deploy, contract, or secret changes.