### PR TITLE
Hermes replies: clean answer, not raw chain-of-thought

### DIFF
--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -124,6 +124,14 @@ export interface GenerateHermesReplyOptions {
   model?: string;
   /** Hard cap so a slow LLM call can't wedge the chat. Default 6000ms. */
   timeoutMs?: number;
+  /**
+   * OpenAI-compat reasoning budget sent to ollama.com/v1. Defaults to "low"
+   * so the model spends its tokens on the answer (in `content`) rather than
+   * chain-of-thought (which lands in `reasoning` and used to leak as the
+   * reply). The strip-the-planning fallback in extractReplyText handles any
+   * residual reasoning-only responses.
+   */
+  reasoningEffort?: "low" | "medium" | "high";
   /** Injection point so tests don't need to hit the network. */
   fetchFn?: typeof fetch;
   /** Optional usage identity for durable LLM activity events. */
@@ -180,6 +188,8 @@ export async function generateHermesReply(
     stream: false,
     max_tokens: 220,
     temperature: 0.7,
+    // Keep the token budget on the answer, not chain-of-thought (ollama.com/v1).
+    reasoning_effort: options.reasoningEffort ?? "low",
   };
 
   const controller = new AbortController();
@@ -240,6 +250,8 @@ export async function generateHermesBoardNarration(
     stream: false,
     max_tokens: 180,
     temperature: 0.65,
+    // Keep the token budget on the answer, not chain-of-thought (ollama.com/v1).
+    reasoning_effort: options.reasoningEffort ?? "low",
   };
 
   const controller = new AbortController();
@@ -839,7 +851,73 @@ function extractReplyText(json: unknown): string | null {
   if (!first || typeof first !== "object") return null;
   const message = (first as { message?: unknown }).message;
   if (!message || typeof message !== "object") return null;
-  return firstNonEmptyTextField(message, ["content", "reasoning", "reasoning_content"], 1200);
+
+  // Content-first: a clean answer in `content` is always preferred and is
+  // returned verbatim.
+  const content = firstNonEmptyTextField(message, ["content"], 1200);
+  if (content) return content;
+
+  // DeepSeek-style fallback: the model emitted only chain-of-thought into
+  // `reasoning` / `reasoning_content` with an empty `content`. Distill the
+  // actual answer out so we never surface the model's meta-planning
+  // ("I should acknowledge… keep it under 4 sentences") as Hermes's reply.
+  const reasoning = firstNonEmptyTextField(message, ["reasoning", "reasoning_content"], 4000);
+  if (!reasoning) return null;
+  const distilled = distillAnswerFromReasoning(reasoning);
+  return distilled ? distilled.slice(0, 1200) : null;
+}
+
+// Sentence openers that mark a chain-of-thought planning line rather than the
+// answer itself (anchored at the start so they don't trip on real answers that
+// merely contain the word mid-sentence).
+const PLANNING_SENTENCE =
+  /^(?:let me\b|let's\b|i'(?:ll|m|d)\b|i (?:will|am|would|should|need to|want to|can|could|must|have to|think)\b|first,|next,|then,|okay,|ok,|so,|now,|alright,|the user\b|the operator\b|they(?:'re| are)\b|maybe i\b|keep it\b|keep this\b|keep things\b|make sure\b|remember\b)/i;
+
+// Phrases that betray the model planning the *shape* of its reply (length /
+// voice / format constraints) wherever they appear in the sentence.
+const PLANNING_HINT =
+  /\b(?:under \d+ words|\d+\s*(?:-|–|to)\s*\d+ sentences?|in hermes'?s? voice|chain[- ]of[- ]thought|stay (?:concise|brief|short)|be (?:concise|brief)|keep it (?:short|brief|concise|under)|don'?t (?:over|ramble|repeat))\b/i;
+
+function isPlanningSentence(sentence: string): boolean {
+  const s = sentence.trim();
+  if (!s) return true;
+  return PLANNING_SENTENCE.test(s) || PLANNING_HINT.test(s);
+}
+
+function splitSentences(text: string): string[] {
+  return text
+    .replace(/\s+/g, " ")
+    .split(/(?<=[.!?])\s+(?=[A-Z0-9"'(])/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Pull the answer out of a reasoning-only response. Reasoners typically plan
+ * ("I should…", "keep it under 4 sentences") and then write the answer last,
+ * so we prefer the final paragraph, drop the meta-planning sentences, and keep
+ * the answer-like tail. A response that is *only* planning (e.g. truncated
+ * mid-thought) yields "" so the caller falls back to the labeled template
+ * rather than leaking chain-of-thought.
+ */
+function distillAnswerFromReasoning(text: string): string {
+  const normalized = text.replace(/\r\n/g, "\n").trim();
+  if (!normalized) return "";
+  const paragraphs = normalized.split(/\n{2,}/).map((p) => p.trim()).filter(Boolean);
+  const candidates = paragraphs.length > 1
+    ? [paragraphs[paragraphs.length - 1]!, normalized]
+    : [normalized];
+  for (const candidate of candidates) {
+    const sentences = splitSentences(candidate);
+    if (sentences.length === 0) continue;
+    const answerLike = sentences.filter((s) => !isPlanningSentence(s));
+    if (answerLike.length === 0) continue;
+    // No planning detected ⇒ it's already a clean answer; keep it whole.
+    if (answerLike.length === sentences.length) return candidate.trim();
+    // Planning was present and stripped ⇒ keep the concise answer tail.
+    return answerLike.slice(-3).join(" ").trim();
+  }
+  return "";
 }
 
 function firstNonEmptyTextField(record: object, keys: readonly string[], max: number): string | null {

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -564,6 +564,60 @@ describe("generateHermesReply", () => {
     expect(text).toContain("live reply");
   });
 
+  it("strips chain-of-thought planning and returns the answer when content is empty (deepseek-v4-pro)", async () => {
+    const fetchFn = async () =>
+      jsonResponse({
+        choices: [{
+          message: {
+            role: "assistant",
+            content: "",
+            reasoning:
+              "I should acknowledge Pascal and keep it under 4 sentences. I'll mention the board is quiet and reassure him. Everything's quiet, Pascal — no decisions are waiting on you right now.",
+          },
+        }],
+      });
+    const text = await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
+    expect(text).toContain("Everything's quiet, Pascal");
+    // The meta-planning never reaches the operator.
+    expect(text).not.toContain("I should");
+    expect(text).not.toContain("I'll mention");
+    expect(text).not.toContain("under 4 sentences");
+  });
+
+  it("returns null when the reasoning is pure planning with no answer (no chain-of-thought leak)", async () => {
+    const fetchFn = async () =>
+      jsonResponse({
+        choices: [{
+          message: {
+            content: "",
+            reasoning: "I should keep it under 4 sentences. Let me think about how to phrase this for Pascal.",
+          },
+        }],
+      });
+    const text = await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
+    expect(text).toBeNull();
+  });
+
+  it("requests a low reasoning budget so the answer lands in content (ollama.com/v1)", async () => {
+    let sentBody: Record<string, unknown> | undefined;
+    const fetchFn = async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+      return jsonResponse({ choices: [{ message: { content: "Watching it." } }] });
+    };
+    await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });
+    expect(sentBody?.reasoning_effort).toBe("low");
+  });
+
+  it("honors an explicit reasoningEffort override", async () => {
+    let sentBody: Record<string, unknown> | undefined;
+    const fetchFn = async (_url: string, init: RequestInit) => {
+      sentBody = JSON.parse(String(init.body)) as Record<string, unknown>;
+      return jsonResponse({ choices: [{ message: { content: "Watching it." } }] });
+    };
+    await generateHermesReply(baseContext(), { apiKey, baseUrl, reasoningEffort: "high", fetchFn: fetchFn as typeof fetch });
+    expect(sentBody?.reasoning_effort).toBe("high");
+  });
+
   it("returns null when the fetch throws", async () => {
     const fetchFn = async () => { throw new Error("network down"); };
     const text = await generateHermesReply(baseContext(), { apiKey, baseUrl, fetchFn: fetchFn as typeof fetch });


### PR DESCRIPTION
## What changed & why
Hermes is live, but `deepseek-v4-pro:cloud` (ollama.com/v1) can return the answer in `reasoning` with an **empty `content`**, so `extractReplyText` surfaced the model's raw chain-of-thought (*"I should acknowledge… keep it under 4 sentences"*) as the reply. Two layers fix it:

**1. Preferred — suppress reasoning at the source.** Both LLM calls now send `reasoning_effort: "low"` (the OpenAI-compat lever `ollama.com/v1` supports) so the token budget goes to the **answer in `content`** instead of chain-of-thought. Configurable via `options.reasoningEffort` (default `"low"`).

**2. Fallback — distill the answer when only reasoning comes back.** `extractReplyText` stays **content-first**; when `content` is empty it reads `reasoning` / `reasoning_content` and runs `distillAnswerFromReasoning()`:
- prefer the final paragraph (reasoners conclude with the answer),
- drop meta-planning sentences (`"I should…"`, `"Let me…"`, `"keep it under N words"`, `"in Hermes's voice"`),
- keep the answer-like tail (≤3 sentences).
- A clean reasoning answer is returned whole; a response that is **only** planning yields `null` so the caller falls back to the labeled template — never a chain-of-thought leak.

Usage recording is unchanged (it runs before extraction).

> **Live-call caveat:** the `reasoning_effort` suppression couldn't be confirmed against a live ollama.com call from the build sandbox (no network/API key). The distill fallback guarantees a clean answer regardless of how much the model still reasons — so the fix holds even if the param has no effect on this model.

**Accept:** a co-pilot question returns a clean 1–3 sentence answer in Hermes's voice with no visible chain-of-thought; usage still records. ✅

## Affected surfaces
- [x] Monitor board / slack-operator (`monitor-hermes-voice.ts`)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (full suite **1368 passed**; hermes-voice 41 incl. 4 new)
- [ ] docker compose config (no ops/Docker/compose change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — reply formatting only
- [x] Wallet testnet-only / `HALT_FILE` / no new ungated agent power — unaffected
- [x] No secrets committed/printed/logged
- [x] Truth-boundary upheld: a reasoning-only or pure-planning response degrades to the labeled template, never a faked/leaked answer; usage still recorded

## Known limits / follow-ups
The distiller is heuristic (planning-sentence patterns). It's only on the degraded reasoning-only path; the common case is now the clean `content` answer. If a future model phrases planning differently, extend `PLANNING_SENTENCE` / `PLANNING_HINT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)