### PR TITLE
Tester: send HTTP Basic Auth (the real Caddy gate on app.averray.com)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -67,6 +67,13 @@ TESTBED_MISSION_CAPTURE_VIDEO=1
 # values only in ops secrets/.env.prod; never put them in prompts or reports.
 TESTBED_CF_ACCESS_CLIENT_ID=
 TESTBED_CF_ACCESS_CLIENT_SECRET=
+# Caddy HTTP Basic Auth — the REAL edge gate on app.averray.com (401, Basic
+# realm "Averray Operator"). The tester sends Authorization: Basic / Playwright
+# httpCredentials ONLY to the hosts below so a sweep can load the gated pages.
+# Secrets: store real values only in ops secrets/.env.prod; never in reports.
+TESTBED_BASIC_AUTH_USER=
+TESTBED_BASIC_AUTH_PASS=
+TESTBED_BASIC_AUTH_HOSTS=app.averray.com
 # T4 Tier-2 gold-path tester. gold_path missions land `requested` behind the T6
 # approve gate and are claimed by the normal testbed runner. Default stays fake
 # for CI; set TESTBED_GOLDPATH_LIVE=1 to invoke Claude + Playwright-MCP. Mutation

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -277,6 +277,12 @@ services:
       # token secrets and must never appear in logs, prompts, or reports.
       TESTBED_CF_ACCESS_CLIENT_ID: ${TESTBED_CF_ACCESS_CLIENT_ID:-}
       TESTBED_CF_ACCESS_CLIENT_SECRET: ${TESTBED_CF_ACCESS_CLIENT_SECRET:-}
+      # Caddy HTTP Basic Auth — the REAL edge gate on app.averray.com. Secrets;
+      # never logged, prompted, or written to a report. Sent only to the gated
+      # host(s) listed in TESTBED_BASIC_AUTH_HOSTS.
+      TESTBED_BASIC_AUTH_USER: ${TESTBED_BASIC_AUTH_USER:-}
+      TESTBED_BASIC_AUTH_PASS: ${TESTBED_BASIC_AUTH_PASS:-}
+      TESTBED_BASIC_AUTH_HOSTS: ${TESTBED_BASIC_AUTH_HOSTS:-app.averray.com}
       # T4 live gold-path driver. Default is off so CI/test deploys keep the
       # deterministic fake path; when enabled the runner invokes Claude with
       # Playwright-MCP/browser tooling and writes a structured report.
@@ -338,6 +344,12 @@ services:
       TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH: ${TEST_WALLET_SIGNER_BROWSER_EXECUTABLE_PATH:-/usr/bin/chromium}
       TESTBED_CF_ACCESS_CLIENT_ID: ${TESTBED_CF_ACCESS_CLIENT_ID:-}
       TESTBED_CF_ACCESS_CLIENT_SECRET: ${TESTBED_CF_ACCESS_CLIENT_SECRET:-}
+      # Caddy HTTP Basic Auth — the REAL edge gate on app.averray.com. Secrets;
+      # never logged, prompted, or written to a report. Sent only to the gated
+      # host(s) listed in TESTBED_BASIC_AUTH_HOSTS.
+      TESTBED_BASIC_AUTH_USER: ${TESTBED_BASIC_AUTH_USER:-}
+      TESTBED_BASIC_AUTH_PASS: ${TESTBED_BASIC_AUTH_PASS:-}
+      TESTBED_BASIC_AUTH_HOSTS: ${TESTBED_BASIC_AUTH_HOSTS:-app.averray.com}
       AUTH_TOKEN_TTL_SECONDS: ${AUTH_TOKEN_TTL_SECONDS:-3600}
       AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
       AVERRAY_APP_BASE_URL: ${AVERRAY_APP_BASE_URL}

--- a/services/slack-operator/src/gold-path-live-driver.ts
+++ b/services/slack-operator/src/gold-path-live-driver.ts
@@ -164,11 +164,15 @@ export function buildClaudeGoldPathPrompt(
   const edgeAuthLine = input.cloudflareAccess
     ? "Cloudflare Access edge auth is configured in this process environment. When loading the gated app or its API, attach CF-Access-Client-Id and CF-Access-Client-Secret headers from env; never print, screenshot, or report their values."
     : "No Cloudflare Access service token was configured; if the target is behind Cloudflare Access, report that as an auth blocker instead of treating the product as broken.";
+  const basicAuthLine = input.basicAuth
+    ? "The gated host is behind Caddy HTTP Basic Auth. Open the browser context with httpCredentials { username, password } from TESTBED_BASIC_AUTH_USER / TESTBED_BASIC_AUTH_PASS in this environment so the 401 challenge is answered automatically; never print, screenshot, or report the username or password. (Basic Auth only loads the pages — authed claim/submit/verify still needs the SIWE session via the signer sidecar.)"
+    : "No HTTP Basic Auth credential was configured; if the host returns 401 with a Basic realm, report that as an auth blocker instead of treating the product as broken.";
   return [
     "You are Hermes running the Averray Tier-2 gold-path tester as a normal browser-capable outside agent.",
     "Use the Claude Agent SDK browser tooling / Playwright MCP tools available in this runtime. Do not use private repo state, Slack, GitHub, SSH, databases, or Averray monitor internals.",
     "Reuse T3 only through the local signer sidecar when you need authentication. The wallet private keys must never enter your prompt, output, logs, screenshots, or report.",
     edgeAuthLine,
+    basicAuthLine,
     opts.signerBaseUrl ? `Signer sidecar: ${opts.signerBaseUrl}. Request browser/api sessions by role as needed; do not print returned tokens.` : "No signer sidecar URL was provided; report that as a blocker if authentication is required.",
     mutationLine,
     `Target URL: ${input.targetUrl}`,
@@ -323,6 +327,12 @@ function redactGoldPathOutput(value: string, env: NodeJS.ProcessEnv): string {
   ]) {
     if (secret && secret.length >= 6) {
       next = next.split(secret).join("[redacted-cloudflare-access]");
+    }
+  }
+  // Caddy HTTP Basic Auth — never let the credential surface in a report/log.
+  for (const secret of [env.TESTBED_BASIC_AUTH_PASS, env.TESTBED_BASIC_AUTH_USER]) {
+    if (secret && secret.length >= 4) {
+      next = next.split(secret).join("[redacted-basic-auth]");
     }
   }
   return next;

--- a/services/slack-operator/src/gold-path-mission-entry.ts
+++ b/services/slack-operator/src/gold-path-mission-entry.ts
@@ -20,6 +20,8 @@ import {
 } from "./testbed-mutation-binding.js";
 import {
   parseCloudflareAccessServiceToken,
+  parseTestbedBasicAuth,
+  basicAuthAppliesToUrl,
   resolveSweepSession,
   parseSweepSessionConfig,
 } from "./testbed-session.js";
@@ -89,6 +91,10 @@ export async function runGoldPathMissionEntry(
 
   const driver = deps.driver ?? selectGoldPathDriver(env);
   const cloudflareAccess = parseCloudflareAccessServiceToken(env);
+  // Caddy HTTP Basic Auth (the real gate on app.averray.com). The credential
+  // reaches the browser subprocess via env passthrough; only the presence flag
+  // is forwarded to the driver to shape its prompt guidance.
+  const basicAuth = basicAuthAppliesToUrl(mission.targetUrl, parseTestbedBasicAuth(env));
 
   const result = await runGoldPathMissionOnce({
     mission: { id: mission.id, targetUrl: mission.targetUrl, goal: mission.goal, freshMemory: mission.freshMemory },
@@ -97,6 +103,7 @@ export async function runGoldPathMissionEntry(
     model,
     signerBaseUrl: env.TEST_WALLET_SIGNER_BASE_URL || env.TESTBED_SESSION_SIGNER_URL,
     ...(cloudflareAccess ? { cloudflareAccess } : {}),
+    ...(basicAuth ? { basicAuth: true } : {}),
     // T3: the API Bearer (and/or browser storageState) from the signer sidecar —
     // the wallet key never enters this process. Undefined when unconfigured.
     resolveSession: () => resolveSweepSession({ ...parseSweepSessionConfig(env), sessionType: "api" }),

--- a/services/slack-operator/src/gold-path-mission.ts
+++ b/services/slack-operator/src/gold-path-mission.ts
@@ -112,6 +112,10 @@ export interface GoldPathDriverInput {
   session?: { role?: string; token?: string; storageState?: unknown };
   /** Edge auth for Cloudflare-Access-gated app routes. Values are never report content. */
   cloudflareAccess?: CloudflareAccessServiceToken;
+  /** True ⇒ Caddy HTTP Basic Auth is configured (the real gate on app.averray.com).
+   *  The credential reaches the browser subprocess via env; only this flag drives
+   *  the driver's prompt guidance — never the credential value. */
+  basicAuth?: boolean;
   /** Local T3 signer sidecar URL. The driver may request sessions; wallet keys never leave the sidecar. */
   signerBaseUrl?: string;
 }
@@ -349,6 +353,8 @@ export interface GoldPathMissionDeps {
   model: GoldPathModel;
   resolveSession?: () => Promise<GoldPathDriverInput["session"] | undefined> | GoldPathDriverInput["session"] | undefined;
   cloudflareAccess?: CloudflareAccessServiceToken;
+  /** Caddy HTTP Basic Auth configured for the gated host (flag only). */
+  basicAuth?: boolean;
   signerBaseUrl?: string;
   steps?: readonly GoldPathStep[];
 }
@@ -374,6 +380,7 @@ export async function runGoldPathMissionOnce(deps: GoldPathMissionDeps): Promise
     freshMemory: deps.mission.freshMemory !== false,
     ...(session ? { session } : {}),
     ...(deps.cloudflareAccess ? { cloudflareAccess: deps.cloudflareAccess } : {}),
+    ...(deps.basicAuth ? { basicAuth: true } : {}),
     ...(deps.signerBaseUrl ? { signerBaseUrl: deps.signerBaseUrl } : {}),
   });
 

--- a/services/slack-operator/src/testbed-mission-http-runner.ts
+++ b/services/slack-operator/src/testbed-mission-http-runner.ts
@@ -1,5 +1,10 @@
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
+import {
+  parseTestbedBasicAuth,
+  basicAuthAppliesToUrl,
+  basicAuthHeaderValue,
+} from "./testbed-session.js";
 
 interface HttpMissionReport {
   verdict: "pass" | "partial" | "fail";
@@ -19,16 +24,21 @@ interface HttpMissionReport {
 export async function runHttpTestbedMission(env: NodeJS.ProcessEnv = process.env): Promise<HttpMissionReport> {
   const targetUrl = requiredEnv(env, "TESTBED_TARGET_URL");
   const goal = env.TESTBED_MISSION_GOAL || "test first-contact usability";
-  if (isGatedAppTarget(targetUrl, env)) {
+  // The real edge gate on app.averray.com is Caddy HTTP Basic Auth. With the
+  // credential configured we send `Authorization: Basic …` and load the page;
+  // only when we genuinely can't authenticate do we refuse before the request.
+  const basicAuth = parseTestbedBasicAuth(env);
+  const useBasicAuth = basicAuthAppliesToUrl(targetUrl, basicAuth);
+  if (isGatedAppTarget(targetUrl, env) && !useBasicAuth) {
     return {
       verdict: "fail",
       confidence: 0,
       executor: "http_visibility_check",
       runnerMode: "non_browser_fetch",
       stoppedBeforeMutation: true,
-      mutationBoundaryNotes: ["HTTP visibility check is public-only and refused the gated app before sending a request."],
+      mutationBoundaryNotes: ["HTTP visibility check refused the gated app: no Basic Auth credential configured for this host."],
       blockers: [
-        `http_visibility_check is public-only; gated target ${targetUrl} requires the browser-capable executor with Cloudflare Access edge auth and a T2/T3 authenticated session.`,
+        `gated target ${targetUrl} is behind Caddy HTTP Basic Auth; set TESTBED_BASIC_AUTH_USER/TESTBED_BASIC_AUTH_PASS for this host to load it.`,
       ],
       confusingMoments: [],
       evidence: [
@@ -42,7 +52,7 @@ export async function runHttpTestbedMission(env: NodeJS.ProcessEnv = process.env
         evidenceQuality: 3,
       },
       recommendations: [
-        "Use the Playwright surface-sweep executor with TESTBED_CF_ACCESS_CLIENT_ID/SECRET plus a T2/T3 session, or run a T4 gold-path mission with TESTBED_GOLDPATH_LIVE=1.",
+        "Set TESTBED_BASIC_AUTH_USER/TESTBED_BASIC_AUTH_PASS (Caddy Basic Auth) so the sweep loads the gated app; authed gold-path flows additionally need the T2/T3 SIWE session.",
       ],
     };
   }
@@ -55,6 +65,8 @@ export async function runHttpTestbedMission(env: NodeJS.ProcessEnv = process.env
       signal: controller.signal,
       headers: {
         "User-Agent": "Averray-Hermes-Testbed-Runner/1.0",
+        // Basic Auth only for the configured gated host; never logged/reported.
+        ...(useBasicAuth && basicAuth ? { Authorization: basicAuthHeaderValue(basicAuth.credential) } : {}),
       },
     });
     const contentType = response.headers.get("content-type") ?? "";

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -21,10 +21,12 @@ import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sw
 import {
   parseSweepSessionConfig,
   parseCloudflareAccessServiceToken,
+  parseTestbedBasicAuth,
   resolveSweepSession,
   type CloudflareAccessServiceToken,
   type SweepSession,
   type SweepSessionConfig,
+  type TestbedBasicAuth,
 } from "./testbed-session.js";
 
 export interface TestbedMissionRunnerConfig {
@@ -63,6 +65,8 @@ export interface TestbedMissionRunnerConfig {
   session?: SweepSessionConfig;
   /** Cloudflare Access service-token headers for gated hosted app routes. */
   cloudflareAccess?: CloudflareAccessServiceToken;
+  /** Caddy HTTP Basic Auth credential for the real edge gate (app.averray.com). */
+  basicAuth?: TestbedBasicAuth;
 }
 
 /** Injected session resolution for tests (defaults to the env-config resolver). */
@@ -97,6 +101,7 @@ export function parseTestbedMissionRunnerConfig(
   env: NodeJS.ProcessEnv = process.env
 ): TestbedMissionRunnerConfig {
   const cloudflareAccess = parseCloudflareAccessServiceToken(env);
+  const basicAuth = parseTestbedBasicAuth(env);
   return {
     enabled: env.TESTBED_MISSION_RUNNER_ENABLED === "1" || env.TESTBED_MISSION_RUNNER_ENABLED === "true",
     ...(env.AVERRAY_TESTBED_MISSIONS_PATH ? { path: env.AVERRAY_TESTBED_MISSIONS_PATH } : {}),
@@ -130,6 +135,7 @@ export function parseTestbedMissionRunnerConfig(
     captureVideo: env.TESTBED_MISSION_CAPTURE_VIDEO !== "0" && env.TESTBED_MISSION_CAPTURE_VIDEO !== "false",
     session: parseSweepSessionConfig(env),
     ...(cloudflareAccess ? { cloudflareAccess } : {}),
+    ...(basicAuth ? { basicAuth } : {}),
   };
 }
 

--- a/services/slack-operator/src/testbed-session.ts
+++ b/services/slack-operator/src/testbed-session.ts
@@ -123,6 +123,87 @@ export function cloudflareAccessHeaders(
     : {};
 }
 
+// ── HTTP Basic Auth (the REAL edge gate on app.averray.com) ──────────
+//
+// app.averray.com is gated by Caddy HTTP Basic Auth (401, www-authenticate:
+// Basic realm="Averray Operator") — NOT Cloudflare Access. The tester sends
+// `Authorization: Basic base64(user:pass)` (fetch executors) or Playwright
+// httpCredentials (browser executors) so a sweep can LOAD the gated pages.
+// The credential is applied ONLY to the configured gated host(s) and is never
+// logged or written to a report. (Authed gold-path flows still need the SIWE
+// session on top — separate follow-up.)
+
+export interface TestbedBasicAuthCredential {
+  username: string;
+  password: string;
+}
+
+export interface TestbedBasicAuth {
+  credential: TestbedBasicAuthCredential;
+  /** Lowercased hostnames the credential is allowed to be sent to. */
+  hosts: string[];
+}
+
+/** Default gated host when TESTBED_BASIC_AUTH_HOSTS is unset (confirmed gate). */
+export const DEFAULT_BASIC_AUTH_HOSTS = ["app.averray.com"];
+
+export function parseTestbedBasicAuth(
+  env: NodeJS.ProcessEnv = process.env,
+): TestbedBasicAuth | undefined {
+  const username = firstNonEmpty(env.TESTBED_BASIC_AUTH_USER);
+  const password = firstNonEmpty(env.TESTBED_BASIC_AUTH_PASS);
+  if (!username || !password) return undefined;
+  const hosts = parseHostList(env.TESTBED_BASIC_AUTH_HOSTS) ?? DEFAULT_BASIC_AUTH_HOSTS;
+  return { credential: { username, password }, hosts };
+}
+
+function parseHostList(value: string | undefined): string[] | undefined {
+  if (!value) return undefined;
+  const hosts = value.split(",").map((h) => h.trim().toLowerCase()).filter(Boolean);
+  return hosts.length > 0 ? hosts : undefined;
+}
+
+/** Whether the gated-host Basic Auth applies to `targetUrl` (host allowlisted). */
+export function basicAuthAppliesToUrl(
+  targetUrl: string,
+  basicAuth: TestbedBasicAuth | undefined,
+): boolean {
+  if (!basicAuth) return false;
+  try {
+    return basicAuth.hosts.includes(new URL(targetUrl).hostname.toLowerCase());
+  } catch {
+    return false;
+  }
+}
+
+/** `Basic base64(user:pass)` header value — for fetch-based executors. */
+export function basicAuthHeaderValue(credential: TestbedBasicAuthCredential): string {
+  const token = Buffer.from(`${credential.username}:${credential.password}`, "utf8").toString("base64");
+  return `Basic ${token}`;
+}
+
+/**
+ * Playwright newContext() httpCredentials scoped to the gated origin, so the
+ * credential is answered ONLY to a 401 from that origin and never leaks to
+ * third-party origins the page might touch. Returns undefined when Basic Auth
+ * doesn't apply to the target.
+ */
+export function basicAuthHttpCredentialsForUrl(
+  targetUrl: string,
+  basicAuth: TestbedBasicAuth | undefined,
+): { username: string; password: string; origin: string } | undefined {
+  if (!basicAuthAppliesToUrl(targetUrl, basicAuth) || !basicAuth) return undefined;
+  try {
+    return {
+      username: basicAuth.credential.username,
+      password: basicAuth.credential.password,
+      origin: new URL(targetUrl).origin,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 /** Whether any session source is configured. When false, the sweep runs
  *  public-only (no fetch / no fs touched). */
 export function isSweepSessionConfigured(config: SweepSessionConfig): boolean {
@@ -243,6 +324,7 @@ async function fetchSidecarSession(
 export function buildSweepContextOptions(
   session?: SweepSession,
   cloudflareAccess?: CloudflareAccessServiceToken,
+  httpCredentials?: { username: string; password: string; origin?: string },
 ): Record<string, unknown> {
   const extraHTTPHeaders = {
     ...cloudflareAccessHeaders(cloudflareAccess),
@@ -253,6 +335,9 @@ export function buildSweepContextOptions(
     userAgent: "Averray-Hermes-Surface-Sweep/1.0",
     ...(session?.storageState ? { storageState: session.storageState } : {}),
     ...(Object.keys(extraHTTPHeaders).length > 0 ? { extraHTTPHeaders } : {}),
+    // Caddy HTTP Basic Auth on the gated host — Playwright answers the 401
+    // challenge with these creds, scoped to `origin` so they never leak.
+    ...(httpCredentials ? { httpCredentials } : {}),
   };
 }
 

--- a/services/slack-operator/src/testbed-surface-sweep.ts
+++ b/services/slack-operator/src/testbed-surface-sweep.ts
@@ -18,8 +18,10 @@ import type { TestbedMissionRunResult } from "./testbed-mission-runner.js";
 import {
   DEFAULT_AUTHED_ROUTES,
   buildSweepContextOptions,
+  basicAuthHttpCredentialsForUrl,
   type CloudflareAccessServiceToken,
   type SweepSession,
+  type TestbedBasicAuth,
 } from "./testbed-session.js";
 
 /** The environment's truth — what marker a data-bearing surface must carry. */
@@ -340,9 +342,13 @@ export async function executeSurfaceSweep(
     artifactsDir?: string;
     session?: SweepSession;
     cloudflareAccess?: CloudflareAccessServiceToken;
+    basicAuth?: TestbedBasicAuth;
   },
   deps: SurfaceSweepDeps = {},
 ): Promise<TestbedMissionRunResult> {
+  // Caddy Basic Auth gate: scope the credential to the gated origin so the
+  // browser answers the host's 401 and loads the pages (no creds elsewhere).
+  const httpCredentials = basicAuthHttpCredentialsForUrl(mission.targetUrl, config.basicAuth);
   const expectedBoundary = resolveExpectedBoundary(config.expectedBoundary);
   // With a session, the default route set extends to the authed operator pages;
   // without one, the sweep stays public-only (graceful fallback — never fails
@@ -352,7 +358,7 @@ export async function executeSurfaceSweep(
     config.appBaseUrl ?? originOf(mission.targetUrl),
     { includeAuthed: Boolean(config.session) },
   );
-  const capture = deps.captureRoute ?? makeBrowserCapture(config);
+  const capture = deps.captureRoute ?? makeBrowserCapture({ ...config, httpCredentials });
 
   const captures: RouteCapture[] = [];
   for (const { route, url } of resolved) {
@@ -400,6 +406,7 @@ function makeBrowserCapture(config: {
   timeoutMs?: number;
   session?: SweepSession;
   cloudflareAccess?: CloudflareAccessServiceToken;
+  httpCredentials?: { username: string; password: string; origin?: string };
 }): (url: string, route: string) => Promise<RouteCapture> {
   return async (url, route) => {
     const { chromium } = await import("playwright-core");
@@ -414,7 +421,7 @@ function makeBrowserCapture(config: {
     try {
       // Pre-seeded session (T2): storageState rehydrates the authed browser; a
       // Bearer (if any) authes the page's same-origin API calls. Read-only.
-      const context = await browser.newContext(buildSweepContextOptions(config.session, config.cloudflareAccess));
+      const context = await browser.newContext(buildSweepContextOptions(config.session, config.cloudflareAccess, config.httpCredentials));
       const page = await context.newPage();
       page.on("console", (m) => {
         if (m.type() === "error") consoleErrors.push(m.text());

--- a/test/unit/testbed-mission-http-runner.test.ts
+++ b/test/unit/testbed-mission-http-runner.test.ts
@@ -62,7 +62,7 @@ describe("testbed mission HTTP runner", () => {
     });
   });
 
-  it("refuses the gated operator app before making a non-browser HTTP probe", async () => {
+  it("refuses the gated operator app when NO Basic Auth credential is configured", async () => {
     const fetchImpl = vi.fn();
     vi.stubGlobal("fetch", fetchImpl);
 
@@ -76,12 +76,55 @@ describe("testbed mission HTTP runner", () => {
       verdict: "fail",
       executor: "http_visibility_check",
       blockers: [
-        expect.stringContaining("gated target https://app.averray.com requires the browser-capable executor"),
+        expect.stringContaining("behind Caddy HTTP Basic Auth"),
       ],
       evidence: expect.arrayContaining([
         { type: "target_classification", value: "gated_app" },
       ]),
     });
     expect(report.blockers.join(" ")).not.toContain("HTTP 401");
+  });
+
+  it("loads the gated app with Authorization: Basic when the credential IS configured", async () => {
+    const fetchImpl = vi.fn(async () => new Response(
+      "<html><body>Averray Operator overview</body></html>",
+      { status: 200, statusText: "OK", headers: { "content-type": "text/html" } },
+    ));
+    vi.stubGlobal("fetch", fetchImpl);
+
+    const report = await runHttpTestbedMission({
+      TESTBED_TARGET_URL: "https://app.averray.com/overview",
+      TESTBED_MISSION_GOAL: "Load the operator app",
+      TESTBED_BASIC_AUTH_USER: "op",
+      TESTBED_BASIC_AUTH_PASS: "s3cr3t-pass",
+    });
+
+    // It sent the request (no refusal) carrying the Basic Auth header.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization)
+      .toBe(`Basic ${Buffer.from("op:s3cr3t-pass").toString("base64")}`);
+    expect(report).toMatchObject({ verdict: "partial", executor: "http_visibility_check" });
+    // The credential never appears in the report.
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain("s3cr3t-pass");
+    expect(serialized).not.toContain(Buffer.from("op:s3cr3t-pass").toString("base64"));
+  });
+
+  it("only sends Basic Auth to the configured gated host, never to other origins", async () => {
+    const fetchImpl = vi.fn(async () => new Response("<html><body>public</body></html>", {
+      status: 200, statusText: "OK", headers: { "content-type": "text/html" },
+    }));
+    vi.stubGlobal("fetch", fetchImpl);
+
+    await runHttpTestbedMission({
+      TESTBED_TARGET_URL: "https://public.averray.com/",
+      TESTBED_MISSION_GOAL: "Load a public page",
+      TESTBED_BASIC_AUTH_USER: "op",
+      TESTBED_BASIC_AUTH_PASS: "s3cr3t-pass",
+    });
+
+    const init = fetchImpl.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Record<string, string>).Authorization).toBeUndefined();
   });
 });

--- a/test/unit/testbed-session.test.ts
+++ b/test/unit/testbed-session.test.ts
@@ -9,6 +9,10 @@ import {
   resolveSweepSession,
   buildSweepContextOptions,
   cloudflareAccessHeaders,
+  parseTestbedBasicAuth,
+  basicAuthAppliesToUrl,
+  basicAuthHeaderValue,
+  basicAuthHttpCredentialsForUrl,
   DEFAULT_AUTHED_ROUTES,
   type SweepStorageState,
 } from "../../services/slack-operator/src/testbed-session.js";
@@ -176,5 +180,52 @@ describe("DEFAULT_AUTHED_ROUTES", () => {
     expect(DEFAULT_AUTHED_ROUTES).toEqual(
       expect.arrayContaining(["/overview", "/runs", "/sessions", "/receipts", "/treasury", "/disputes", "/policies", "/agents", "/audit-log", "/capabilities"]),
     );
+  });
+});
+
+describe("Caddy HTTP Basic Auth (the real edge gate)", () => {
+  it("parses user/pass and defaults the host allowlist to app.averray.com", () => {
+    const basic = parseTestbedBasicAuth({ TESTBED_BASIC_AUTH_USER: "op", TESTBED_BASIC_AUTH_PASS: "pw" } as NodeJS.ProcessEnv);
+    expect(basic).toEqual({ credential: { username: "op", password: "pw" }, hosts: ["app.averray.com"] });
+  });
+
+  it("returns undefined unless BOTH user and pass are set", () => {
+    expect(parseTestbedBasicAuth({ TESTBED_BASIC_AUTH_USER: "op" } as NodeJS.ProcessEnv)).toBeUndefined();
+    expect(parseTestbedBasicAuth({ TESTBED_BASIC_AUTH_PASS: "pw" } as NodeJS.ProcessEnv)).toBeUndefined();
+    expect(parseTestbedBasicAuth({} as NodeJS.ProcessEnv)).toBeUndefined();
+  });
+
+  it("honors an explicit, comma-separated host allowlist (lowercased)", () => {
+    const basic = parseTestbedBasicAuth({
+      TESTBED_BASIC_AUTH_USER: "op",
+      TESTBED_BASIC_AUTH_PASS: "pw",
+      TESTBED_BASIC_AUTH_HOSTS: "App.Averray.com, staging.averray.com",
+    } as NodeJS.ProcessEnv);
+    expect(basic?.hosts).toEqual(["app.averray.com", "staging.averray.com"]);
+  });
+
+  it("applies ONLY to allowlisted hosts (never leaks to other origins)", () => {
+    const basic = parseTestbedBasicAuth({ TESTBED_BASIC_AUTH_USER: "op", TESTBED_BASIC_AUTH_PASS: "pw" } as NodeJS.ProcessEnv);
+    expect(basicAuthAppliesToUrl("https://app.averray.com/overview", basic)).toBe(true);
+    expect(basicAuthAppliesToUrl("https://evil.example/overview", basic)).toBe(false);
+    expect(basicAuthAppliesToUrl("https://app.averray.com", undefined)).toBe(false);
+  });
+
+  it("builds a correct Basic header value", () => {
+    expect(basicAuthHeaderValue({ username: "op", password: "pw" }))
+      .toBe(`Basic ${Buffer.from("op:pw").toString("base64")}`);
+  });
+
+  it("builds Playwright httpCredentials scoped to the gated origin", () => {
+    const basic = parseTestbedBasicAuth({ TESTBED_BASIC_AUTH_USER: "op", TESTBED_BASIC_AUTH_PASS: "pw" } as NodeJS.ProcessEnv);
+    expect(basicAuthHttpCredentialsForUrl("https://app.averray.com/runs", basic))
+      .toEqual({ username: "op", password: "pw", origin: "https://app.averray.com" });
+    // Non-gated host → no credentials.
+    expect(basicAuthHttpCredentialsForUrl("https://public.averray.com/", basic)).toBeUndefined();
+  });
+
+  it("buildSweepContextOptions attaches httpCredentials when provided", () => {
+    const opts = buildSweepContextOptions(undefined, undefined, { username: "op", password: "pw", origin: "https://app.averray.com" });
+    expect(opts.httpCredentials).toEqual({ username: "op", password: "pw", origin: "https://app.averray.com" });
   });
 });


### PR DESCRIPTION
## What changed & why
**Live `curl` confirmed `app.averray.com` is gated by Caddy HTTP Basic Auth** — `401`, `server: Caddy`, `www-authenticate: Basic realm="Averray Operator"`. It is **not** Cloudflare Access and not SIWE at the edge. The existing tester auth (#367) was built for Cloudflare Access service tokens — the wrong mechanism for this host — so missions still `401`'d.

This sends HTTP Basic Auth (scoped to the gated host) so a sweep can **load** the gated pages:

- **`testbed-session.ts`** — `TestbedBasicAuth` model + `parseTestbedBasicAuth` (`TESTBED_BASIC_AUTH_USER` / `_PASS`; host allowlist `TESTBED_BASIC_AUTH_HOSTS`, default `app.averray.com`). Helpers: `basicAuthHeaderValue` (`Basic base64(user:pass)`) for fetch executors; `basicAuthHttpCredentialsForUrl` (Playwright `httpCredentials` **scoped to the gated origin** so the credential is answered only to that host's 401 and never leaks); `basicAuthAppliesToUrl`. `buildSweepContextOptions` now attaches `httpCredentials`.
- **`testbed-surface-sweep.ts`** — passes origin-scoped `httpCredentials` for the gated host into the browser context → the sweep loads the app instead of `401`.
- **`testbed-mission-http-runner.ts`** — removed the *"public-only … requires Cloudflare Access"* hard reject. With Basic Auth configured for the host it fetches with `Authorization: Basic …` and returns a real report; it only refuses when no credential is configured (with a Basic-Auth-oriented message).
- **`gold-path-live-driver.ts`** — prompt guidance to open the browser context with `httpCredentials` from env; **redacts `TESTBED_BASIC_AUTH_USER`/`_PASS`** from all driver output. `gold-path-mission(-entry)` forward a presence flag, never the value (the credential reaches the subprocess via existing env passthrough).
- **`ops/compose.yml` + `ops/.env.example`** — `TESTBED_BASIC_AUTH_USER` / `_PASS` / `_HOSTS` wired to **both** testbed services; secrets, never logged.

The Cloudflare Access path is left in place; Basic Auth is the path actually used for `app.averray.com`. Credentials are applied **only to the configured gated host(s)** and redacted from reports/logs.

> **Scope note (from the task):** Basic Auth gets *past the gate to load pages* (fixes the 401). The authed gold-path (claim/submit/verify) **also** needs the SIWE session on top — separate follow-up.
>
> **Reconciliation note:** the brief asked for an `Authorization: Basic` header on the surface-sweep; since that executor runs in a Playwright context, I used Playwright `httpCredentials` **origin-scoped to the gated host** instead — same Basic Auth, but it can't leak to third-party origins the page touches (a context-global header would). The fetch-based http runner uses the literal `Authorization: Basic` header.

**Accept:** a surface sweep against `app.averray.com` answers the 401 and returns a real report (no 401); the credential never appears in logs/reports.

## Affected surfaces
- [x] Monitor board / slack-operator (tester runners/session)
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Secrets / config / env

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (full **1377 passed**; +new Basic Auth tests in testbed-session / http-runner)
- [ ] `docker compose … config` — docker unavailable in the build sandbox; CI "Validate Compose file" covers it. New keys verified at the same 6-space indent as the existing testbed env block.

## Rollout / rollback
Set `TESTBED_BASIC_AUTH_USER` / `TESTBED_BASIC_AUTH_PASS` (and optionally `TESTBED_BASIC_AUTH_HOSTS`) in ops secrets/`.env.prod`. Unset ⇒ behavior is unchanged (gated host still refuses, exactly as before). Rollback = unset the vars / revert.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy
- [x] Wallet testnet-only; `HALT_FILE` honored; **no new ungated agent power** — this only attaches an operator-provided credential to a configured host so the read-only sweep can load pages
- [x] **No secrets committed/printed/logged** — creds come from env, sent only to allowlisted host(s), redacted from gold-path output, never written to a report (test asserts absence)
- [x] Truth-boundary: a host with no credential still refuses honestly; nothing is faked

🤖 Generated with [Claude Code](https://claude.com/claude-code)