### PR TITLE
Tester: install Playwright Chromium + ffmpeg in the runner image

### DIFF
--- a/ops/Dockerfile.node
+++ b/ops/Dockerfile.node
@@ -26,5 +26,19 @@ COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/packages ./packages
 COPY --from=build /app/services ./services
 COPY --from=build /app/scripts ./scripts
+
+# Playwright browser + ffmpeg for the testbed-mission-runner's browser-agent.
+# The gold-path tester drives Playwright-MCP, which launches Playwright's OWN
+# managed Chromium from PLAYWRIGHT_BROWSERS_PATH (not /usr/bin/chromium), and
+# surface-sweep video capture needs Playwright's bundled ffmpeg — both live in
+# /home/appuser/.cache/ms-playwright. install-deps pulls Chromium's system libs
+# (root); the browser + ffmpeg binaries are installed AS appuser so they land
+# in that cache (where the runner looks). Version follows the playwright-core
+# pinned in package.json (we invoke the installed node_modules CLI, no re-pin).
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/appuser/.cache/ms-playwright
+RUN apt-get update \
+  && node node_modules/playwright-core/cli.js install-deps chromium \
+  && rm -rf /var/lib/apt/lists/*
 USER appuser
+RUN node node_modules/playwright-core/cli.js install chromium ffmpeg
 CMD ["node", "packages/trace-mcp/dist/index.js"]


### PR DESCRIPTION
## What changed & why
Basic Auth (#371) let browser-agent missions authenticate and reach the BROWSER stage, but they then failed:
- `Executable doesn't exist at /home/appuser/.cache/ms-playwright/…`
- `Video rendering requires ffmpeg binary … npx playwright install ffmpeg`

The runtime image (`ops/Dockerfile.node`, `AVERRAY_IMAGE`) shipped apt `chromium` — used by the **surface-sweep** (`executablePath: /usr/bin/chromium`) and the **test-wallet-signer** — but not **Playwright's own managed Chromium**, which the gold-path tester's **Playwright-MCP** launches from `~/.cache/ms-playwright`, nor Playwright's **bundled ffmpeg** used for surface-sweep video capture.

Fix — `ops/Dockerfile.node` runtime stage:
- `ENV PLAYWRIGHT_BROWSERS_PATH=/home/appuser/.cache/ms-playwright` so install **and** runtime resolve to the exact path the runner looks in.
- **root:** `playwright-core install-deps chromium` → Chromium's system libraries.
- **appuser:** `playwright-core install chromium ffmpeg` → the browser + ffmpeg binaries land in **appuser's** ms-playwright cache (missions run as appuser, which is why the error pointed at `/home/appuser/.cache`).
- Invoked through the **installed `node_modules/playwright-core` CLI**, so the downloaded browser build matches the `playwright-core` version pinned in `package.json` (1.60.0) — nothing to drift or re-pin.

apt `chromium` is **kept**: the surface-sweep and signer launch `/usr/bin/chromium` directly, and it supplies Chromium's shared libs.

**Accept:** a browser-agent mission against `app.averray.com` loads the page (Basic Auth) **and** launches the browser with no "Executable doesn't exist"/ffmpeg error, producing a real structured report.

## Affected surfaces
- [x] ops / compose / Dockerfile / Hermes image pin
- [x] Worker runners / task queue (testbed-mission-runner image)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (full **1377 passed** — no application code changed)
- [x] **Docker build** (CI job) — actually builds `Dockerfile.node`, so the `install-deps` + browser/ffmpeg download are exercised in CI; a bad command or missing dep fails the build there. (Docker isn't available in my build sandbox, so I verified the `playwright-core` CLI supports `install` + `install-deps` at v1.60.0 and relied on the CI image build.)

## Rollout / rollback
Next image build of `AVERRAY_IMAGE` carries the browser + ffmpeg (~adds Chromium/ffmpeg to image size). Rollback = revert this Dockerfile change. No runtime config or secret change. `PLAYWRIGHT_BROWSERS_PATH` is baked into the image (overridable via env if a deploy relocates the cache).

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy
- [x] Wallet testnet-only; `HALT_FILE`; no new ungated agent power — image dependency only
- [x] No secrets committed/printed/logged — pure build-time binaries
- [x] Truth-boundary: this lets the browser agent actually run and report; it doesn't fake or mask failures

## Known limits / follow-ups
Installed into the single shared runtime image for simplicity. The task allows scoping to a dedicated testbed-runner stage/image if image size matters (the claude/codex task-runners don't need browsers) — a clean follow-up if the size bump is a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)