### PR TITLE
feat(monitor): readable mission-failure summary on card + rail, raw detail in drawer

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -520,3 +520,20 @@ describe("Card — decision hoist (P1-2)", () => {
     expect(container.querySelector(".hm-card-decision")).toBeNull();
   });
 });
+
+describe("Card — failed mission readable summary", () => {
+  test("renders a clean one-liner, never raw stderr / box-drawing / pipes", () => {
+    const card = fixture("mission browser-checkout-12"); // failed mission, raw dump in summary + blocker
+    const { container } = render(<Card card={card} />);
+    const meta = container.querySelector(".hm-card-meta");
+    expect(meta).toBeTruthy();
+    const text = meta?.textContent ?? "";
+    // Clean, mapped one-liner.
+    expect(text).toContain("Mission failed — browser binary not installed");
+    // Zero raw noise on the card.
+    expect(text).not.toContain("\n");
+    expect(text).not.toContain("|");
+    expect(text).not.toMatch(/[─-▟]/);
+    expect(text).not.toContain("ms-playwright");
+  });
+});

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -31,6 +31,7 @@ import type {
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
+import { missionFailureCardSummary } from "../../lib/monitor/mission-failure.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { ChecksBar } from "./ChecksBar.js";
 import { AgentDiscussion } from "./AgentDiscussion.js";
@@ -124,6 +125,12 @@ export function Card({
   const closedAt = (card as { closedAt?: string }).closedAt;
   const verdictText = (card as { verdictText?: string }).verdictText;
 
+  // A failed/partial browser mission must show a CLEAN one-liner here, not
+  // the raw multi-line Playwright/runner dump. The full raw detail lives in
+  // the drawer (MissionBody blockers + Evidence). Falls back to the normal
+  // summary for every other card.
+  const cardSummary = missionFailureCardSummary(card) ?? card.summary;
+
   const onCardClick = onClick ? () => onClick(card) : undefined;
 
   return (
@@ -143,10 +150,10 @@ export function Card({
 
       <div className="hm-card-title">{card.title}</div>
 
-      {card.summary && !isClosed ? (
+      {cardSummary && !isClosed ? (
         <div className="hm-card-meta" style={{ lineHeight: 1.5 }}>
           <span style={{ color: "var(--hm-ink-soft)", fontFamily: "var(--font-body)", fontSize: 12 }}>
-            <HumanizedText text={card.summary} />
+            <HumanizedText text={cardSummary} />
           </span>
         </div>
       ) : null}

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -364,3 +364,26 @@ describe("DetailDrawer — footer actions (G2)", () => {
     expect(onApproveAndMerge).toHaveBeenCalledWith(card);
   });
 });
+
+describe("DetailDrawer — failed mission blocker (raw reachable, cleaned by default)", () => {
+  test("shows a cleaned blocker head and keeps the raw runner output one click deep", () => {
+    const card = fixture("mission browser-claim-09"); // failed mission, raw dump in blocker
+    const { container, getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    const blocker = container.querySelector(".hm-mblock");
+    expect(blocker).toBeTruthy();
+    // The head is shown CLEANED — no box-drawing / pipes in the visible head.
+    const head = blocker?.querySelector(".head");
+    expect(head?.textContent ?? "").not.toMatch(/[─-▟]/);
+    expect(head?.textContent ?? "").not.toContain("|");
+    // The raw runner output is preserved, reachable under a disclosure.
+    const raw = blocker?.querySelector("details.hm-mblock-raw");
+    expect(raw).toBeTruthy();
+    expect(getByText("Show raw runner output")).toBeTruthy();
+    // The raw <pre> still contains the real, unredacted failure text.
+    const pre = raw?.querySelector("pre");
+    expect(pre?.textContent ?? "").toContain("ms-playwright");
+    expect(pre?.textContent ?? "").toContain("ffmpeg");
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -14,9 +14,11 @@ import type {
   DeployCard,
   DoneCard,
   HermesDecisionRecord,
+  MissionBlocker,
   MissionCard,
 } from "../../lib/monitor/card-types.js";
 import { humanizeSignalText } from "../../lib/monitor/signal-labels.js";
+import { cleanFailureText } from "../../lib/monitor/mission-failure.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
 import { OperatorNotes } from "./OperatorNotes.js";
 
@@ -408,6 +410,51 @@ function MissionSpecDetails() {
   );
 }
 
+/**
+ * A single mission blocker. The head/body are shown CLEANED (ANSI,
+ * box-drawing, pipes stripped) so they're readable. When cleaning
+ * actually changed the text — i.e. the runner left a raw multi-line dump —
+ * the original is preserved under a collapsible "raw runner output", one
+ * click deep. Truth-boundary: the real failure text is never dropped, just
+ * de-emphasized.
+ */
+function MissionBlockerBlock({ blocker }: { blocker: MissionBlocker }) {
+  const rawCombined = [blocker.head, blocker.body].filter(Boolean).join("\n");
+  const cleanedHead = cleanFailureText(blocker.head) || blocker.head;
+  const cleanedBody = cleanFailureText(blocker.body);
+  // Show the raw disclosure only when cleaning meaningfully changed things
+  // (otherwise it's redundant noise).
+  const rawDiffers = rawCombined.trim() !== `${cleanedHead}${cleanedBody ? ` ${cleanedBody}` : ""}`.trim();
+  return (
+    <div className="hm-mblock">
+      <div className="head">{cleanedHead}</div>
+      {cleanedBody ? <div className="body">{cleanedBody}</div> : null}
+      {rawDiffers && rawCombined.trim() ? (
+        <details className="hm-mblock-raw" style={{ marginTop: 6 }}>
+          <summary style={{ cursor: "pointer", color: "var(--hm-muted)", fontSize: 12 }}>
+            Show raw runner output
+          </summary>
+          <pre
+            style={{
+              margin: "6px 0 0",
+              padding: 8,
+              background: "var(--hm-paper-3)",
+              borderRadius: 6,
+              fontSize: 11,
+              lineHeight: 1.4,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              overflowX: "auto",
+            }}
+          >
+            {rawCombined}
+          </pre>
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
 function MissionBody({ card }: { card: MissionCard }) {
   // `mission` is required on the type, but a live mission card has no
   // structured report until the browser agent posts one. Read defensively.
@@ -503,10 +550,7 @@ function MissionBody({ card }: { card: MissionCard }) {
           <div className="hm-section-h">Blockers · confusing moments</div>
           <div style={{ display: "grid", gap: 10 }}>
             {m.blockers.map((b, i) => (
-              <div className="hm-mblock" key={i}>
-                <div className="head">{b.head}</div>
-                <div className="body">{b.body}</div>
-              </div>
+              <MissionBlockerBlock blocker={b} key={i} />
             ))}
           </div>
         </section>

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -9,6 +9,7 @@ import type {
 import type { CollaborationAuthor, CollaborationMessage } from "./collaboration.js";
 import { actorLabel, actorLabelForMessage, formatTurnTime, relatedPrForCard } from "./collaboration.js";
 import { humanizeSignalText } from "./signal-labels.js";
+import { cleanFailureText } from "./mission-failure.js";
 
 export type ActivityTone = "neutral" | "info" | "action" | "success" | "warning";
 
@@ -126,7 +127,7 @@ function cardActivity(card: BoardCard, boardAtMs: number): HermesActivityEntry[]
         actor: "hermes",
         kindLabel: "narration",
         text: `${label} work failed on ${title}; operator triage is needed before retrying or splitting it.`,
-        meta: card.failureReason ?? "task failed",
+        meta: plain(card.failureReason) || "task failed",
         cardId: card.id,
         suggestions: ["Show failure evidence", "Should this be split?"],
       });
@@ -400,7 +401,11 @@ function parseTime(value: string | undefined): number | undefined {
 }
 
 function plain(value: string | undefined): string {
-  return humanizeSignalText(value).replace(/\s+/g, " ").trim();
+  // cleanFailureText first strips ANSI / box-drawing / pipe noise from raw
+  // runner output (a failed mission's message can be a multi-line dump), so
+  // rail narration never echoes the raw stderr. Then humanize enum codes
+  // and collapse whitespace.
+  return humanizeSignalText(cleanFailureText(value)).replace(/\s+/g, " ").trim();
 }
 
 function sentence(value: string): string {

--- a/packages/monitor-ui/src/lib/monitor/fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/fixtures.ts
@@ -247,6 +247,44 @@ export const FIXTURE_CARDS: BoardCard[] = [
     },
   },
 
+  // Failed browser mission that renders through the live <Card> (not the
+  // degraded path): the runner left a raw multi-line Playwright dump. The
+  // card/rail must show a CLEAN one-liner; the drawer keeps the raw text.
+  {
+    id: "mission browser-checkout-12",
+    lane: "hermes-checking",
+    type: "mission",
+    agentType: "hermes",
+    title: "Verify checkout flow on staging",
+    summary:
+      "Executable doesn't exist at /home/appuser/.cache/ms-playwright/chromium-1140/chrome-linux/chrome\n│ Video rendering requires ffmpeg binary │\n╔════════════════════╗\n║ npx playwright install ffmpeg ║\n╚════════════════════╝\n| | |",
+    repo: "depre-dev/site",
+    freshness: 7,
+    state: "fresh",
+    risk: ["testbed"],
+    missionStatus: "failed",
+    waitingOn: { actor: "operator", tone: "warn" },
+    mission: {
+      verdict: "FAILED",
+      verdictTone: "fail",
+      confidence: 0,
+      latency: "—",
+      target: "https://staging.averray.com/checkout",
+      seed: "fresh · no memory",
+      runs: 1,
+      path: [],
+      blockers: [
+        {
+          head: "Executable doesn't exist at /home/appuser/.cache/ms-playwright/chromium-1140/chrome-linux/chrome",
+          body: "│ Video rendering requires ffmpeg binary │\n╔════════════════════╗\n║ npx playwright install ffmpeg ║\n╚════════════════════╝",
+        },
+      ],
+      evidence: [],
+      mutationBoundary: "No mutation — mission failed before it reached the page.",
+      recommendations: [],
+    },
+  },
+
   // ── Done / release history — keep a representative slice ──
   ...buildDoneHistory(),
 ];
@@ -304,11 +342,16 @@ export const DEGRADED_FIXTURE_CARDS: BoardCard[] = [
     type: "mission",
     agentType: "hermes",
     title: "Verify claim flow on staging — third pass after the modal fix",
-    summary: "",
+    // Raw runner failure dump — multi-line with box-drawing + pipes. The
+    // card/rail must render a CLEAN one-liner from this; the drawer keeps
+    // the raw text reachable under the blocker's "raw runner output".
+    summary:
+      "Executable doesn't exist at /home/appuser/.cache/ms-playwright/chromium-1140/chrome-linux/chrome\n│ Video rendering requires ffmpeg binary │\n╔════════════════════╗\n║ npx playwright install ffmpeg ║\n╚════════════════════╝\n| | |",
     repo: "depre-dev/site",
     freshness: 42,
     state: "source-offline",
     risk: ["testbed"],
+    missionStatus: "failed",
     waitingOn: { actor: "agent", tone: "neutral" },
     mission: {
       verdict: "FAILED",
@@ -322,7 +365,12 @@ export const DEGRADED_FIXTURE_CARDS: BoardCard[] = [
       clarityScore: 0,
       latencyScore: 0,
       path: [],
-      blockers: [],
+      blockers: [
+        {
+          head: "Executable doesn't exist at /home/appuser/.cache/ms-playwright/chromium-1140/chrome-linux/chrome",
+          body: "│ Video rendering requires ffmpeg binary │\n╔════════════════════╗\n║ npx playwright install ffmpeg ║\n╚════════════════════╝",
+        },
+      ],
       evidence: [],
       mutationBoundary: "Mission did not run — runner pool offline.",
       recommendations: [],

--- a/packages/monitor-ui/src/lib/monitor/mission-failure.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-failure.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "vitest";
+import {
+  cleanFailureText,
+  summarizeMissionFailure,
+  missionFailureLine,
+} from "./mission-failure.js";
+
+// The real-world dump shape from the task: multi-line, pipes, box-drawing.
+const RAW_PLAYWRIGHT =
+  "Executable doesn't exist at /home/appuser/.cache/ms-playwright/chromium-1140/chrome-linux/chrome\n" +
+  "│ Video rendering requires ffmpeg binary │\n" +
+  "╔══════════════════════╗\n" +
+  "║ npx playwright install ffmpeg ║\n" +
+  "╚══════════════════════╝\n" +
+  "| | |";
+
+describe("cleanFailureText", () => {
+  test("strips box-drawing, pipes, and collapses whitespace/newlines", () => {
+    const cleaned = cleanFailureText(RAW_PLAYWRIGHT);
+    // No box-drawing, no pipes, no newlines survive.
+    expect(cleaned).not.toMatch(/[─-▟]/);
+    expect(cleaned).not.toContain("|");
+    expect(cleaned).not.toContain("\n");
+    expect(cleaned).not.toMatch(/\s{2,}/); // whitespace collapsed
+    expect(cleaned.startsWith("Executable doesn't exist")).toBe(true);
+  });
+
+  test("strips ANSI escape sequences", () => {
+    const ansi = "\x1b[31mError:\x1b[0m navigation \x1b[1mtimed out\x1b[0m";
+    expect(cleanFailureText(ansi)).toBe("Error: navigation timed out");
+  });
+
+  test("strips other control characters", () => {
+    expect(cleanFailureText("a\x00b\x07c\x7f")).toBe("a b c");
+  });
+
+  test("handles empty / non-string input", () => {
+    expect(cleanFailureText("")).toBe("");
+    expect(cleanFailureText(undefined)).toBe("");
+    expect(cleanFailureText(null)).toBe("");
+  });
+});
+
+describe("summarizeMissionFailure — known-failure mapping", () => {
+  const cases: { raw: string; reason: string }[] = [
+    { raw: RAW_PLAYWRIGHT, reason: "browser binary not installed" },
+    { raw: "Error: Video rendering requires ffmpeg binary; run npx playwright install ffmpeg", reason: "ffmpeg not installed (video capture)" },
+    { raw: "page.goto failed: server responded 401 Unauthorized", reason: "authentication failed (401)" },
+    { raw: "Request failed with status 403 Forbidden", reason: "access forbidden (403)" },
+    { raw: "Timeout 30000ms exceeded waiting for navigation", reason: "timed out" },
+    { raw: "<--- Last few GCs ---> JavaScript heap out of memory", reason: "runner ran out of memory" },
+    { raw: "Mission did not run — runner pool offline.", reason: "runner offline — mission did not run" },
+    { raw: "net::ERR_CONNECTION_REFUSED at https://staging.averray.com", reason: "could not reach the target" },
+  ];
+  for (const { raw, reason } of cases) {
+    test(`maps "${raw.slice(0, 32)}…" → ${reason}`, () => {
+      const summary = summarizeMissionFailure(raw);
+      expect(summary.reason).toBe(reason);
+      expect(summary.friendly).toBe(true);
+    });
+  }
+
+  test("browser-binary check wins over the ffmpeg check when both appear", () => {
+    // The canonical dump mentions ffmpeg too; the primary failure is the
+    // missing browser binary, which must win (ordering).
+    expect(summarizeMissionFailure(RAW_PLAYWRIGHT).reason).toBe("browser binary not installed");
+  });
+});
+
+describe("summarizeMissionFailure — fallback", () => {
+  test("unknown failure → cleaned (no box-drawing), not friendly; first sentence kept", () => {
+    const raw = "Some novel failure happened here. Extra detail │ more noise";
+    const summary = summarizeMissionFailure(raw);
+    expect(summary.friendly).toBe(false);
+    // First sentence is the readable lead-in.
+    expect(summary.reason).toBe("Some novel failure happened here.");
+    expect(summary.reason).not.toContain("│");
+  });
+
+  test("unknown single-line failure keeps the cleaned text (box-drawing gone), capped", () => {
+    const raw = "Weird runner state │ partial output │ retry advised";
+    const summary = summarizeMissionFailure(raw);
+    expect(summary.friendly).toBe(false);
+    expect(summary.reason).not.toContain("│");
+    // No sentence boundary → the whole cleaned line is the reason.
+    expect(summary.reason).toBe("Weird runner state partial output retry advised");
+  });
+
+  test("strips a leading stderr:/error: label in the fallback", () => {
+    expect(summarizeMissionFailure("stderr: something broke unexpectedly").reason).toBe(
+      "something broke unexpectedly",
+    );
+  });
+
+  test("caps an overlong reason", () => {
+    const long = `A${"x".repeat(400)}`;
+    const summary = summarizeMissionFailure(long);
+    expect(summary.reason.length).toBeLessThanOrEqual(120);
+    expect(summary.reason.endsWith("…")).toBe(true);
+  });
+
+  test("empty input → honest placeholder, not fabricated", () => {
+    expect(summarizeMissionFailure("").reason).toBe("no failure detail reported");
+    expect(summarizeMissionFailure("   \n  ").reason).toBe("no failure detail reported");
+  });
+});
+
+describe("missionFailureLine", () => {
+  test("renders verdict + clean reason, single line, no raw chars", () => {
+    const line = missionFailureLine(RAW_PLAYWRIGHT);
+    expect(line).toBe("Mission failed — browser binary not installed");
+    expect(line).not.toContain("\n");
+    expect(line).not.toMatch(/[─-▟]/);
+    expect(line).not.toContain("|");
+  });
+
+  test("accepts a custom verdict label (e.g. PARTIAL)", () => {
+    expect(missionFailureLine("Timeout 30000ms exceeded", "Mission incomplete")).toBe(
+      "Mission incomplete — timed out",
+    );
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/mission-failure.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-failure.ts
@@ -1,0 +1,172 @@
+// Hermes Handoff Monitor — mission-failure text cleaning + summarization.
+//
+// A failed browser-mission's raw runner/Playwright output is multi-line and
+// full of ANSI escapes, box-drawing characters, and pipe separators, e.g.:
+//
+//   "Executable doesn't exist at /home/appuser/.cache/ms-playwright/... |
+//    Video rendering requires ffmpeg binary | ... npx playwright install
+//    ffmpeg | | |"
+//
+// That is unreadable on a card or in rail narration. These pure helpers
+// produce a clean one-liner for those surfaces while the RAW text stays
+// reachable, structured, one click deep in the drawer (truth-boundary:
+// we never hide the real failure, we just stop shouting it).
+
+// ANSI / VT100 escape sequence: ESC [ ... final byte.
+// eslint-disable-next-line no-control-regex
+const ANSI = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
+// C0 control chars (\x00-\x1f) + DEL (\x7f) -> space.
+// eslint-disable-next-line no-control-regex
+const CONTROL = /[\x00-\x1f\x7f]/g;
+// Box-drawing (U+2500-U+257F) + block elements (U+2580-U+259F) -> space.
+const BOX_DRAWING = /[\u2500-\u259f]/g;
+
+/**
+ * Strip ANSI escape sequences, control chars, box-drawing / block
+ * characters, and pipe separators from runner output; collapse all
+ * whitespace (including newlines) to single spaces; trim. Pure
+ * formatting -- no meaning change.
+ */
+export function cleanFailureText(raw: string | undefined | null): string {
+  if (typeof raw !== "string") return "";
+  return raw
+    .replace(ANSI, "")
+    .replace(CONTROL, " ")
+    .replace(BOX_DRAWING, " ")
+    .replace(/\|/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export interface MissionFailureSummary {
+  /** Clean, human-readable reason. Never multi-line, never raw stderr. */
+  reason: string;
+  /** True when we matched a known failure to a friendly phrase. */
+  friendly: boolean;
+}
+
+/**
+ * Known failure signatures → friendly reasons. Matched against the
+ * CLEANED text (case-insensitive). Ordered: first match wins, so the more
+ * specific patterns come first.
+ */
+const KNOWN_FAILURES: { test: RegExp; reason: string }[] = [
+  // Playwright browser binary missing.
+  {
+    test: /executable doesn'?t exist|playwright install(?!\s+ffmpeg)|browser(?:Type)?\.launch|chromium.*not.*found|install the browsers/i,
+    reason: "browser binary not installed",
+  },
+  // ffmpeg missing (video rendering).
+  {
+    test: /ffmpeg|video rendering requires/i,
+    reason: "ffmpeg not installed (video capture)",
+  },
+  // Auth gate.
+  {
+    test: /\b401\b|unauthor(?:ized|ised)|http basic auth|authentication (?:failed|required)/i,
+    reason: "authentication failed (401)",
+  },
+  { test: /\b403\b|forbidden/i, reason: "access forbidden (403)" },
+  // Timeouts.
+  { test: /timed?\s*out|timeout (?:of )?\d|exceeded.*timeout|navigation timeout/i, reason: "timed out" },
+  // Runner out-of-memory / crash.
+  {
+    test: /out of memory|\boom\b|heap out of memory|killed.*signal|sigkill|enomem/i,
+    reason: "runner ran out of memory",
+  },
+  // Runner pool offline / never ran.
+  { test: /runner pool offline|did not run|no runner|runner.*unavailable/i, reason: "runner offline — mission did not run" },
+  // Network / DNS.
+  { test: /econnrefused|enotfound|\bdns\b|net::err|connection refused/i, reason: "could not reach the target" },
+];
+
+/** Cap so a one-liner never grows into a paragraph on the card. */
+const MAX_REASON_LENGTH = 120;
+
+function capLength(text: string, max = MAX_REASON_LENGTH): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1).trimEnd()}…`;
+}
+
+/**
+ * Take a card's raw failure text (summary / blocker / statusReason) and
+ * return a clean, capped, human-readable reason — mapping known failures
+ * to friendly phrases, otherwise falling back to the cleaned PRIMARY
+ * segment of the raw text (first sentence / segment before a separator).
+ */
+export function summarizeMissionFailure(raw: string | undefined | null): MissionFailureSummary {
+  const cleaned = cleanFailureText(raw);
+  if (!cleaned) return { reason: "no failure detail reported", friendly: false };
+
+  for (const { test, reason } of KNOWN_FAILURES) {
+    if (test.test(cleaned)) return { reason, friendly: true };
+  }
+
+  // Fallback: strip a leading "stderr:"/"error:" label, take the first
+  // sentence/clause (before a sentence end or a semicolon — pipe and
+  // box-drawing separators are already spaces by now, so we don't rely on
+  // them), and cap. We keep the cleaned remainder reachable in the drawer;
+  // here we only need a readable lead-in, never the whole dump.
+  const delabeled = cleaned.replace(/^\s*(?:stderr|stdout|error|err)\s*[:-]\s*/i, "");
+  const primary = delabeled.split(/;\s+|(?<=[.!?])\s+/)[0]?.trim() || delabeled;
+  return { reason: capLength(primary), friendly: false };
+}
+
+/**
+ * The card / rail one-liner for a failed mission: verdict + cleaned
+ * reason, e.g. "Mission failed — browser binary not installed".
+ *
+ * `verdictLabel` lets callers say "Mission failed" vs a softer
+ * "Mission incomplete" for a PARTIAL; defaults to "Mission failed".
+ */
+export function missionFailureLine(
+  raw: string | undefined | null,
+  verdictLabel = "Mission failed",
+): string {
+  const { reason } = summarizeMissionFailure(raw);
+  return `${verdictLabel} — ${reason}`;
+}
+
+/** Minimal shape we read off a mission card — kept structural so this
+ *  module stays free of the heavier card-types import cycle. */
+interface MissionFailureCardLike {
+  type?: string;
+  summary?: string;
+  missionStatus?: string;
+  mission?: {
+    verdict?: string;
+    verdictTone?: string;
+    blockers?: { head?: string; body?: string }[];
+  };
+}
+
+/**
+ * The raw failure text the runner left on a mission card, in priority
+ * order: the first blocker (head + body), else the card summary. This is
+ * the multi-line/boxed text we must clean before showing it.
+ */
+export function rawMissionFailureText(card: MissionFailureCardLike): string {
+  const blocker = card.mission?.blockers?.[0];
+  if (blocker) {
+    return [blocker.head, blocker.body].filter(Boolean).join(" — ");
+  }
+  return card.summary ?? "";
+}
+
+/**
+ * Card/rail one-liner for a FAILED mission card, or `null` when the card
+ * isn't a failed mission (caller falls back to the normal summary). Reads
+ * the structured report's verdict to pick the label, then cleans the raw
+ * failure text. The full raw detail stays in the drawer.
+ */
+export function missionFailureCardSummary(card: MissionFailureCardLike): string | null {
+  if (card.type !== "mission") return null;
+  const verdict = card.mission?.verdict;
+  const failed =
+    card.missionStatus === "failed" ||
+    card.mission?.verdictTone === "fail" ||
+    verdict === "FAILED";
+  if (!failed && verdict !== "PARTIAL") return null;
+  const label = verdict === "PARTIAL" ? "Mission incomplete" : "Mission failed";
+  return missionFailureLine(rawMissionFailureText(card), label);
+}


### PR DESCRIPTION
## What changed & why

Failed browser-mission cards **and** their rail narration dumped the raw agent/Playwright error verbatim — multi-line, with ANSI / box-drawing / pipe noise:

> Executable doesn't exist at /home/appuser/.cache/… │ Video rendering requires ffmpeg binary │ … npx playwright install ffmpeg │ │ │

Unreadable. This restores the v2 design path (MissionBody): a **clean summary on the card**, **structured detail in the drawer**, and the **raw text one click deep** — never on the card or in narration.

- **`lib/monitor/mission-failure.ts`** *(new, + 20 tests)* — pure helpers:
  - `cleanFailureText()` strips ANSI escapes, box-drawing/block chars (U+2500–259F), and pipes; collapses whitespace/newlines.
  - `summarizeMissionFailure()` maps **known** failures → friendly reasons (browser binary / ffmpeg missing, 401/403, timeout, runner OOM, runner offline, network), else falls back to the cleaned primary segment (length-capped).
  - `missionFailureCardSummary()` → the card one-liner, e.g. **"Mission failed — browser binary not installed"**.
- **`Card.tsx`** — a failed/partial mission renders the clean one-liner instead of raw `card.summary`. Never raw multi-line on the card.
- **`drawer/DrawerBody.tsx`** — `MissionBlockerBlock` shows the **cleaned** head/body and keeps the **raw** runner output reachable under a collapsible *"Show raw runner output"* `<details>`.
- **`activity-feed.ts`** — `plain()` now runs `cleanFailureText()` first, so **rail narration** of a failed mission uses the same clean one-liner (covers the failed-mission/task narration + meta).
- **`fixtures.ts`** — a failed mission with a realistic raw dump (one live `<Card>` path + one degraded), so the behavior is grounded.

## Affected surfaces
- [x] Monitor board / slack-operator
- [x] Docs / tests only (tests + fixtures)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (116 files, **1399** tests pass)
- [ ] docker compose config (n/a — no ops/Docker/compose touched)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy
- [x] Wallet testnet-only; `HALT_FILE` honored; no new ungated agent power (display-only)
- [x] No secrets committed/printed/logged
- [x] No change to how agents work → no `AGENTS.md` edit needed

## Truth-boundary
The humanized summary must not hide the real failure. The raw detail stays reachable, structured, one click deep in the drawer (tested: the raw `<pre>` still contains the unredacted `ms-playwright` / `ffmpeg` text). The card and narration carry **zero** raw stderr / box-drawing / pipes (tested).

## Known limits / follow-ups
- Cleaning happens at the **monitor-ui render layer** (per the v2 design framing). The backend (`failTestbedMissionRun`) still stores the raw `stderrTail`/`failureReason`, which is correct — the raw text must be preserved server-side; we clean for display.
- The known-failure map is heuristic (regex on the cleaned text); unknown failures fall back to the cleaned primary line, so a novel failure is still readable, just not re-phrased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)