### PR TITLE
fix(testbed): retry browser missions without video when ffmpeg is missing

### DIFF
--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
-import type { BrowserContext, Locator, Page } from "playwright-core";
+import type { Browser, BrowserContext, BrowserContextOptions, Locator, Page } from "playwright-core";
 
 import { runGoldPathMissionEntry } from "./gold-path-mission-entry.js";
 import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
@@ -410,6 +410,47 @@ export async function executeGoldPathTestbedMission(
   };
 }
 
+export async function createPlaywrightContextPageWithVideoFallback(input: {
+  browser: Browser;
+  captureVideo: boolean;
+  videoDir: string;
+  viewport: NonNullable<BrowserContextOptions["viewport"]>;
+  userAgent: string;
+}): Promise<{ context: BrowserContext; page: Page; videoDisabledReason?: string }> {
+  const baseOptions: BrowserContextOptions = {
+    viewport: input.viewport,
+    userAgent: input.userAgent,
+  };
+  if (!input.captureVideo) {
+    const context = await input.browser.newContext(baseOptions);
+    return { context, page: await context.newPage() };
+  }
+
+  await mkdir(input.videoDir, { recursive: true });
+  let videoContext: BrowserContext | undefined;
+  try {
+    videoContext = await input.browser.newContext({
+      ...baseOptions,
+      recordVideo: { dir: input.videoDir, size: input.viewport },
+    });
+    return { context: videoContext, page: await videoContext.newPage() };
+  } catch (error) {
+    if (!isPlaywrightFfmpegMissing(error)) throw error;
+    await videoContext?.close().catch(() => undefined);
+    const context = await input.browser.newContext(baseOptions);
+    return {
+      context,
+      page: await context.newPage(),
+      videoDisabledReason: "Video capture disabled: Playwright ffmpeg is unavailable in the runner.",
+    };
+  }
+}
+
+export function isPlaywrightFfmpegMissing(error: unknown): boolean {
+  const detail = error instanceof Error ? error.message : String(error);
+  return /ffmpeg|video rendering requires/i.test(detail);
+}
+
 /** Default session resolver: pull from the env-configured sidecar or manual
  *  storageState path/token. Never throws — degrades to undefined (public-only). */
 async function defaultResolveSweepSession(
@@ -461,18 +502,25 @@ export async function executePlaywrightTestbedMission(
       args: ["--no-sandbox", "--disable-dev-shm-usage"],
     });
     const videoDir = join(artifactsDir, "videos");
-    if (config.captureVideo !== false) await mkdir(videoDir, { recursive: true });
-    context = await browser.newContext({
+    const contextAndPage = await createPlaywrightContextPageWithVideoFallback({
+      browser,
+      captureVideo: config.captureVideo !== false,
+      videoDir,
       viewport: { width: 1365, height: 900 },
       userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
-      ...(config.captureVideo !== false ? { recordVideo: { dir: videoDir, size: { width: 1365, height: 900 } } } : {}),
     });
+    context = contextAndPage.context;
+    page = contextAndPage.page;
+    if (contextAndPage.videoDisabledReason) {
+      whatITried.push(contextAndPage.videoDisabledReason);
+      evidence.push({ type: "runner_warning", value: contextAndPage.videoDisabledReason });
+      recommendations.push("Install Playwright ffmpeg in the runner image for video evidence; this run continued with screenshots and trace only.");
+    }
     if (config.captureTrace !== false) {
       tracePath = join(artifactsDir, "trace.zip");
       await context.tracing.start({ screenshots: true, snapshots: true, sources: false });
       traceRunning = true;
     }
-    page = await context.newPage();
     page.on("console", (message) => {
       if (message.type() === "error") consoleErrors.push(message.text());
     });

--- a/test/unit/testbed-mission-runner.test.ts
+++ b/test/unit/testbed-mission-runner.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Browser, BrowserContext, Page } from "playwright-core";
 
 import {
   __resetTestbedMissionRunsForTests,
@@ -13,6 +14,8 @@ import {
 import { requestTestbedMissionFromAgent } from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
 import {
   appendPlaywrightEvidenceTrail,
+  createPlaywrightContextPageWithVideoFallback,
+  isPlaywrightFfmpegMissing,
   parseTestbedMissionRunnerConfig,
   renderTestbedMissionRunnerArgs,
   runTestbedMissionRunnerOnce,
@@ -340,6 +343,47 @@ describe("testbed mission runner", () => {
       expect.objectContaining({ type: "trace", value: expect.stringContaining("trace.zip") }),
       expect.objectContaining({ type: "video", value: expect.stringContaining("video.webm") }),
     ]);
+  });
+
+  it("retries without video when Playwright ffmpeg is missing", async () => {
+    const page = {} as Page;
+    const videoContext = {
+      newPage: vi.fn(async () => {
+        throw new Error("Executable doesn't exist at /home/appuser/.cache/ms-playwright/ffmpeg-1011/ffmpeg-linux. Video rendering requires ffmpeg binary.");
+      }),
+      close: vi.fn(async () => undefined),
+    } as unknown as BrowserContext;
+    const fallbackContext = {
+      newPage: vi.fn(async () => page),
+    } as unknown as BrowserContext;
+    const contexts = [videoContext, fallbackContext];
+    const newContext = vi.fn(async () => contexts.shift() ?? fallbackContext);
+    const browser = { newContext } as unknown as Browser;
+
+    const result = await createPlaywrightContextPageWithVideoFallback({
+      browser,
+      captureVideo: true,
+      videoDir: join(mkdtempSync(join(tmpdir(), "averray-testbed-video-")), "videos"),
+      viewport: { width: 1365, height: 900 },
+      userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
+    });
+
+    expect(result).toMatchObject({
+      context: fallbackContext,
+      page,
+      videoDisabledReason: expect.stringContaining("ffmpeg"),
+    });
+    expect(videoContext.close).toHaveBeenCalledOnce();
+    expect(newContext).toHaveBeenCalledTimes(2);
+    expect(newContext.mock.calls[0]?.[0]).toMatchObject({
+      recordVideo: { size: { width: 1365, height: 900 } },
+    });
+    expect(newContext.mock.calls[1]?.[0]).not.toHaveProperty("recordVideo");
+  });
+
+  it("recognizes Playwright ffmpeg-missing errors", () => {
+    expect(isPlaywrightFfmpegMissing(new Error("Video rendering requires ffmpeg binary"))).toBe(true);
+    expect(isPlaywrightFfmpegMissing(new Error("net::ERR_NAME_NOT_RESOLVED"))).toBe(false);
   });
 });
 


### PR DESCRIPTION
## What changed & why

- Added a Playwright browser-context helper that retries once without `recordVideo` when Playwright reports a missing ffmpeg binary during page creation.
- Records the downgrade as runner evidence and a recommendation, so the mission keeps producing screenshots/trace instead of failing before navigation.
- Added unit coverage for the exact hosted failure shape and the ffmpeg detector.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [ ] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No env, ops, Docker, migration, or secret changes. Roll forward with the normal human merge/deploy gate. Rollback is reverting this runner fallback; missions would again require video ffmpeg when video capture is enabled.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

The runner image should still include Playwright ffmpeg for video artifacts. This PR makes video optional at runtime so a missing binary cannot block browser mission evidence capture.