### PR TITLE
fix(testbed): apply edge auth to browser missions

### DIFF
--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -19,6 +19,8 @@ import {
 import { executeSiweAuthMission, type SiweAuthMissionDeps } from "./testbed-auth-mission.js";
 import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
 import {
+  basicAuthHttpCredentialsForUrl,
+  cloudflareAccessHeaders,
   parseSweepSessionConfig,
   parseCloudflareAccessServiceToken,
   parseTestbedBasicAuth,
@@ -414,13 +416,9 @@ export async function createPlaywrightContextPageWithVideoFallback(input: {
   browser: Browser;
   captureVideo: boolean;
   videoDir: string;
-  viewport: NonNullable<BrowserContextOptions["viewport"]>;
-  userAgent: string;
+  contextOptions: BrowserContextOptions;
 }): Promise<{ context: BrowserContext; page: Page; videoDisabledReason?: string }> {
-  const baseOptions: BrowserContextOptions = {
-    viewport: input.viewport,
-    userAgent: input.userAgent,
-  };
+  const baseOptions = input.contextOptions;
   if (!input.captureVideo) {
     const context = await input.browser.newContext(baseOptions);
     return { context, page: await context.newPage() };
@@ -431,7 +429,10 @@ export async function createPlaywrightContextPageWithVideoFallback(input: {
   try {
     videoContext = await input.browser.newContext({
       ...baseOptions,
-      recordVideo: { dir: input.videoDir, size: input.viewport },
+      recordVideo: {
+        dir: input.videoDir,
+        size: resolveVideoSize(input.contextOptions.viewport),
+      },
     });
     return { context: videoContext, page: await videoContext.newPage() };
   } catch (error) {
@@ -449,6 +450,12 @@ export async function createPlaywrightContextPageWithVideoFallback(input: {
 export function isPlaywrightFfmpegMissing(error: unknown): boolean {
   const detail = error instanceof Error ? error.message : String(error);
   return /ffmpeg|video rendering requires/i.test(detail);
+}
+
+function resolveVideoSize(
+  viewport: BrowserContextOptions["viewport"],
+): { width: number; height: number } {
+  return viewport ?? { width: 1365, height: 900 };
 }
 
 /** Default session resolver: pull from the env-configured sidecar or manual
@@ -502,12 +509,18 @@ export async function executePlaywrightTestbedMission(
       args: ["--no-sandbox", "--disable-dev-shm-usage"],
     });
     const videoDir = join(artifactsDir, "videos");
+    const httpCredentials = basicAuthHttpCredentialsForUrl(mission.targetUrl, config.basicAuth);
+    const extraHTTPHeaders = cloudflareAccessHeaders(config.cloudflareAccess);
     const contextAndPage = await createPlaywrightContextPageWithVideoFallback({
       browser,
       captureVideo: config.captureVideo !== false,
       videoDir,
-      viewport: { width: 1365, height: 900 },
-      userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
+      contextOptions: {
+        viewport: { width: 1365, height: 900 },
+        userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
+        ...(Object.keys(extraHTTPHeaders).length > 0 ? { extraHTTPHeaders } : {}),
+        ...(httpCredentials ? { httpCredentials } : {}),
+      },
     });
     context = contextAndPage.context;
     page = contextAndPage.page;

--- a/test/unit/testbed-mission-runner.test.ts
+++ b/test/unit/testbed-mission-runner.test.ts
@@ -364,8 +364,12 @@ describe("testbed mission runner", () => {
       browser,
       captureVideo: true,
       videoDir: join(mkdtempSync(join(tmpdir(), "averray-testbed-video-")), "videos"),
-      viewport: { width: 1365, height: 900 },
-      userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
+      contextOptions: {
+        viewport: { width: 1365, height: 900 },
+        userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
+        extraHTTPHeaders: { "CF-Access-Client-Id": "cf-client-id" },
+        httpCredentials: { username: "operator", password: "secret", origin: "https://app.averray.com" },
+      },
     });
 
     expect(result).toMatchObject({
@@ -376,9 +380,39 @@ describe("testbed mission runner", () => {
     expect(videoContext.close).toHaveBeenCalledOnce();
     expect(newContext).toHaveBeenCalledTimes(2);
     expect(newContext.mock.calls[0]?.[0]).toMatchObject({
+      extraHTTPHeaders: { "CF-Access-Client-Id": "cf-client-id" },
+      httpCredentials: { username: "operator", password: "secret", origin: "https://app.averray.com" },
       recordVideo: { size: { width: 1365, height: 900 } },
     });
+    expect(newContext.mock.calls[1]?.[0]).toMatchObject({
+      extraHTTPHeaders: { "CF-Access-Client-Id": "cf-client-id" },
+      httpCredentials: { username: "operator", password: "secret", origin: "https://app.averray.com" },
+    });
     expect(newContext.mock.calls[1]?.[0]).not.toHaveProperty("recordVideo");
+  });
+
+  it("passes Basic Auth credentials to a non-video browser context", async () => {
+    const page = {} as Page;
+    const context = {
+      newPage: vi.fn(async () => page),
+    } as unknown as BrowserContext;
+    const newContext = vi.fn(async () => context);
+    const browser = { newContext } as unknown as Browser;
+
+    await createPlaywrightContextPageWithVideoFallback({
+      browser,
+      captureVideo: false,
+      videoDir: join(mkdtempSync(join(tmpdir(), "averray-testbed-video-")), "videos"),
+      contextOptions: {
+        viewport: { width: 1365, height: 900 },
+        userAgent: "Averray-Hermes-Testbed-Playwright/1.0",
+        httpCredentials: { username: "operator", password: "secret", origin: "https://app.averray.com" },
+      },
+    });
+
+    expect(newContext).toHaveBeenCalledWith(expect.objectContaining({
+      httpCredentials: { username: "operator", password: "secret", origin: "https://app.averray.com" },
+    }));
   });
 
   it("recognizes Playwright ffmpeg-missing errors", () => {


### PR DESCRIPTION
## What changed & why

- Applies existing gated-host auth helpers to the single-URL Playwright browser mission path.
- Browser missions now pass scoped `httpCredentials` for Caddy Basic Auth on `app.averray.com` and include Cloudflare Access headers when configured.
- Keeps those context options when the ffmpeg fallback recreates the browser context without video.
- Adds unit coverage for Basic Auth context wiring and auth preservation across video fallback.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [ ] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No env or secret changes. The runner already has valid `TESTBED_BASIC_AUTH_USER/PASS`; this change makes the browser mission consume them. Roll forward with the normal human merge/deploy gate. Rollback is reverting this commit; fresh missions against `app.averray.com` would go back to 401/invalid credentials.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

This only authenticates the edge gate so the page can load. Product-level SIWE/session flows remain separate T2/T3/gold-path behavior.