### PR TITLE
feat(monitor): clarify tester mission cards

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -37,6 +37,15 @@ describe("Card — type coverage", () => {
     expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
     expect(view.getByText("testbed")).toBeTruthy();
     expect(container.querySelector(".hm-checks-bar")).toBeTruthy();
+    const run = container.querySelector(".hm-mission-run");
+    expect(run).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("Tester run")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("PARTIAL 81%")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("staging.averray.com/onboarding")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("2 screenshots")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("trace")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("console")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText(/Read-only mission/)).toBeTruthy();
   });
 
   test("deploy card renders its verification summary", () => {
@@ -535,5 +544,22 @@ describe("Card — failed mission readable summary", () => {
     expect(text).not.toContain("|");
     expect(text).not.toMatch(/[─-▟]/);
     expect(text).not.toContain("ms-playwright");
+  });
+
+  test("renders failed tester runs as a compact report, without raw runner output", () => {
+    const card = fixture("mission browser-checkout-12");
+    const { container } = render(<Card card={card} />);
+    const run = container.querySelector(".hm-mission-run");
+    expect(run).toBeTruthy();
+    const text = run?.textContent ?? "";
+    expect(within(run as HTMLElement).getByText("Tester run")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("FAILED 0%")).toBeTruthy();
+    expect(within(run as HTMLElement).getByText("staging.averray.com/checkout")).toBeTruthy();
+    expect(text).toContain("browser binary not installed");
+    expect(text).toContain("no artifacts captured");
+    expect(text).toContain("No mutation");
+    expect(text).not.toContain("ms-playwright");
+    expect(text).not.toContain("npx playwright install");
+    expect(text).not.toContain("|");
   });
 });

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -27,6 +27,8 @@ import type {
   AgentType,
   HermesDecisionRecord,
   CardWorkingNow,
+  MissionCard,
+  MissionReport,
 } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor } from "../../lib/monitor/lane-rules.js";
@@ -157,6 +159,8 @@ export function Card({
           </span>
         </div>
       ) : null}
+
+      {!isClosed && card.type === "mission" ? <MissionRunSummary card={card} /> : null}
 
       {/* P1-2: hoist the decision onto operator-facing cards. On the two
           lanes where the operator decides (needs-attention, codex-needed),
@@ -344,6 +348,106 @@ function WorkingNowLine({ workingNow }: { workingNow: CardWorkingNow }) {
       <span className="target">{workingNow.label}</span>
     </div>
   );
+}
+
+function MissionRunSummary({ card }: { card: MissionCard }) {
+  const mission = card.mission;
+  const status = missionRunStatus(card, mission);
+  const tone = missionRunTone(card, mission);
+  const target = mission?.target ? shortMissionTarget(mission.target) : undefined;
+  const blocker = mission ? missionPrimaryBlocker(card, mission) : undefined;
+  const evidence = mission ? missionEvidenceSummary(mission) : [];
+  const boundary = mission?.mutationBoundary ? compactSentence(mission.mutationBoundary, 92) : undefined;
+
+  return (
+    <div className={`hm-mission-run hm-mission-run--${tone}`} aria-label={`Tester run ${status}`}>
+      <div className="hm-mission-run-top">
+        <span className="hm-mission-run-kicker">Tester run</span>
+        <span className={`hm-mission-run-verdict hm-mission-run-verdict--${tone}`}>{status}</span>
+        {target ? <span className="hm-mission-run-target">{target}</span> : null}
+      </div>
+
+      {blocker ? (
+        <div className="hm-mission-run-blocker">
+          <span>Blocker</span>
+          <strong>
+            <HumanizedText text={blocker} />
+          </strong>
+        </div>
+      ) : null}
+
+      {mission ? (
+        <div className="hm-mission-run-facts">
+          <span>{mission.seed || "fresh agent"}</span>
+          {mission.latency ? <span>{mission.latency}</span> : null}
+          {evidence.length > 0 ? (
+            evidence.map((item) => <span key={item}>{item}</span>)
+          ) : (
+            <span>no artifacts captured</span>
+          )}
+        </div>
+      ) : (
+        <div className="hm-mission-run-facts">
+          <span>waiting for operator approval</span>
+        </div>
+      )}
+
+      {boundary ? <div className="hm-mission-run-boundary">{boundary}</div> : null}
+    </div>
+  );
+}
+
+function missionRunStatus(card: MissionCard, mission: MissionReport | undefined): string {
+  if (mission) {
+    const confidence = Math.round(mission.confidence * 100);
+    return `${mission.verdict} ${confidence}%`;
+  }
+  if (card.missionStatus === "requested") return "REQUESTED";
+  if (card.missionStatus === "running") return "RUNNING";
+  if (card.missionStatus === "completed") return "COMPLETED";
+  if (card.missionStatus === "failed") return "FAILED";
+  return "QUEUED";
+}
+
+function missionRunTone(card: MissionCard, mission: MissionReport | undefined): "ok" | "warn" | "fail" | "neutral" {
+  if (mission?.verdictTone) return mission.verdictTone;
+  if (card.missionStatus === "failed") return "fail";
+  if (card.missionStatus === "completed") return "ok";
+  if (card.missionStatus === "running") return "warn";
+  return "neutral";
+}
+
+function shortMissionTarget(target: string): string {
+  try {
+    const parsed = new URL(target);
+    const path = parsed.pathname === "/" ? "" : parsed.pathname;
+    return `${parsed.hostname}${path}`;
+  } catch {
+    return compactSentence(target, 64);
+  }
+}
+
+function missionPrimaryBlocker(card: MissionCard, mission: MissionReport): string | undefined {
+  const cleanFailure = missionFailureCardSummary(card)?.replace(/^Mission failed\s+—\s+/i, "").trim();
+  if (cleanFailure) return cleanFailure;
+  const first = mission.blockers[0];
+  if (!first) return undefined;
+  return compactSentence([first.head, first.body].filter(Boolean).join(" — "), 118);
+}
+
+function missionEvidenceSummary(mission: MissionReport): string[] {
+  const counts = new Map<string, number>();
+  for (const item of mission.evidence) counts.set(item.kind, (counts.get(item.kind) ?? 0) + 1);
+  return Array.from(counts.entries()).map(([kind, count]) => (count > 1 ? `${count} ${kind}s` : kind));
+}
+
+function compactSentence(value: string, maxLength: number): string {
+  const firstLine = value
+    .replace(/[│║╔╗╚╝═]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (firstLine.length <= maxLength) return firstLine;
+  return `${firstLine.slice(0, Math.max(0, maxLength - 1)).trim()}…`;
 }
 
 // ── Checks label (e.g. "5/6 · 1 running") ──────────────────────────

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1021,6 +1021,113 @@ body { margin: 0; }
   white-space: nowrap;
 }
 
+.hm-mission-run {
+  display: grid;
+  gap: 6px;
+  padding: 8px 0 2px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-mission-run-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.hm-mission-run-kicker {
+  flex: 0 0 auto;
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage-deep);
+}
+.hm-mission-run-verdict {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  min-height: 19px;
+  padding: 0 7px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+.hm-mission-run-verdict--ok {
+  background: var(--hm-sage-soft);
+  color: var(--hm-sage-deep);
+}
+.hm-mission-run-verdict--warn {
+  background: var(--hm-amber-soft);
+  color: var(--hm-amber-deep);
+}
+.hm-mission-run-verdict--fail {
+  background: var(--hm-rose-soft);
+  color: var(--hm-rose);
+}
+.hm-mission-run-verdict--neutral {
+  background: var(--hm-rail);
+  color: var(--hm-muted);
+}
+.hm-mission-run-target {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-mission-run-blocker {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 6px;
+  align-items: baseline;
+  min-width: 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+.hm-mission-run-blocker span {
+  font-family: var(--font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-mission-run-blocker strong {
+  min-width: 0;
+  font-weight: 700;
+  color: var(--hm-ink);
+}
+.hm-mission-run-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.hm-mission-run-facts span {
+  display: inline-flex;
+  min-height: 18px;
+  align-items: center;
+  padding: 0 6px;
+  border-radius: 999px;
+  background: rgba(255, 253, 247, 0.72);
+  border: 1px solid var(--hm-line-soft);
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+}
+.hm-mission-run-boundary {
+  color: var(--hm-sage-deep);
+  font-family: var(--font-body);
+  font-size: 11px;
+  line-height: 1.35;
+}
+.hm-mission-run--fail .hm-mission-run-boundary {
+  color: var(--hm-muted);
+}
+
 .hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }
 .hm-pill {
   display: inline-flex; align-items: center; gap: 5px;


### PR DESCRIPTION
## What changed & why
- Added a compact tester-run summary strip to mission cards so browser/testbed runs show verdict, target, blocker, evidence artifacts, and mutation-boundary context directly on the board.
- Kept raw Playwright/runner output out of the lane card; deep raw evidence remains in the drawer/report.
- Added card tests for partial and failed tester runs so repeated testing failures render as readable operator signals, not stack-trace noise.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm --workspace @avg/monitor-ui run build`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback
- UI-only monitor change. Rollback by reverting this PR.
- No env, secrets, runner, deploy, or authority changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups
- Local standalone Vite visual smoke loads the existing degraded board without the slack-operator backend; the mission-card fixture behavior is covered by component tests and the production Vite build.