### PR TITLE
fix(monitor): preserve LLM usage in live board cache

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/board-cache.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.test.ts
@@ -15,6 +15,33 @@ function baseBoard() {
   };
 }
 
+function llmUsage() {
+  return {
+    status: "not_recorded",
+    message: "No LLM usage counters have been recorded yet.",
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    costUsd: null,
+    costStatus: "not_recorded",
+    runs: 0,
+    byModel: [],
+    byDay: [],
+    sourceStatus: [
+      { agent: "codex", status: "not_reported", reason: "Codex CLI does not report usage." },
+    ],
+    activeCalls: [],
+  };
+}
+
+function baseBoardWithMetadata() {
+  return {
+    ...baseBoard(),
+    llmUsage: llmUsage(),
+    automationHealth: { selfHealingOpen: 2, dispatchUsedToday: 4, dispatchPerDayCap: 5 },
+  };
+}
+
 // ── board.snapshot — replace everything ─────────────────────────────
 
 test("board.snapshot: replaces the cache wholesale", () => {
@@ -55,16 +82,30 @@ test("board.snapshot: carries automation-health gauge data when present", () => 
   assert.deepEqual(next.automationHealth, { selfHealingOpen: 2, dispatchUsedToday: 4, dispatchPerDayCap: 5 });
 });
 
+test("board.snapshot: carries LLM usage metadata when present", () => {
+  const usage = llmUsage();
+  const next = applyEventToBoard(baseBoard(), {
+    type: "board.snapshot",
+    at: "2026-05-27T17:35:00Z",
+    cards: [],
+    llmUsage: usage,
+  });
+  assert.deepEqual(next.llmUsage, usage);
+});
+
 // ── board.card.added ────────────────────────────────────────────────
 
 test("board.card.added: appends a new card", () => {
-  const next = applyEventToBoard(baseBoard(), {
+  const prev = baseBoardWithMetadata();
+  const next = applyEventToBoard(prev, {
     type: "board.card.added",
     card: { id: "c", lane: "release-queue", type: "pr" },
     at: "2026-05-27T17:35:00Z",
   });
   assert.equal(next.cards.length, 3);
   assert.equal(next.cards[2].id, "c");
+  assert.deepEqual(next.llmUsage, prev.llmUsage);
+  assert.deepEqual(next.automationHealth, prev.automationHealth);
 });
 
 test("board.card.added: same id is treated as an update (idempotent)", () => {
@@ -90,7 +131,8 @@ test("board.card.added: skipped when prev is undefined (no base to add into)", (
 // ── board.card.updated ──────────────────────────────────────────────
 
 test("board.card.updated: patches the matching card by id", () => {
-  const next = applyEventToBoard(baseBoard(), {
+  const prev = baseBoardWithMetadata();
+  const next = applyEventToBoard(prev, {
     type: "board.card.updated",
     id: "a",
     partial: { freshness: 42, state: "stale" },
@@ -100,6 +142,8 @@ test("board.card.updated: patches the matching card by id", () => {
   assert.equal(card.state, "stale");
   // Untouched fields preserved.
   assert.equal(card.lane, "operator-review");
+  assert.deepEqual(next.llmUsage, prev.llmUsage);
+  assert.deepEqual(next.automationHealth, prev.automationHealth);
 });
 
 test("board.card.updated: unknown id is a no-op (does not append)", () => {
@@ -126,13 +170,16 @@ test("board.card.updated: id mismatch in partial is overridden (id is the truth)
 // ── board.card.moved ────────────────────────────────────────────────
 
 test("board.card.moved: updates the matching card's lane", () => {
-  const next = applyEventToBoard(baseBoard(), {
+  const prev = baseBoardWithMetadata();
+  const next = applyEventToBoard(prev, {
     type: "board.card.moved",
     id: "a",
     fromLane: "operator-review",
     toLane: "release-queue",
   });
   assert.equal(next.cards.find(c => c.id === "a").lane, "release-queue");
+  assert.deepEqual(next.llmUsage, prev.llmUsage);
+  assert.deepEqual(next.automationHealth, prev.automationHealth);
 });
 
 test("board.card.moved: replaces stale card details when the stream supplies the fresh card", () => {
@@ -171,13 +218,16 @@ test("board.card.moved: missing toLane is a no-op (safer than landing in undefin
 // ── board.card.archived ────────────────────────────────────────────
 
 test("board.card.archived: removes the matching card", () => {
-  const next = applyEventToBoard(baseBoard(), {
+  const prev = baseBoardWithMetadata();
+  const next = applyEventToBoard(prev, {
     type: "board.card.archived",
     id: "a",
     reason: "stale > 48h",
   });
   assert.equal(next.cards.length, 1);
   assert.equal(next.cards[0].id, "b");
+  assert.deepEqual(next.llmUsage, prev.llmUsage);
+  assert.deepEqual(next.automationHealth, prev.automationHealth);
 });
 
 test("board.card.archived: unknown id is a no-op (length unchanged)", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -104,7 +104,14 @@ export function applyEventToBoard(
       const automationHealth = isAutomationHealth(event.automationHealth)
         ? event.automationHealth
         : undefined;
-      return { cards, at, ...(calmMetrics ? { calmMetrics } : {}), ...(automationHealth ? { automationHealth } : {}) };
+      const llmUsage = isLlmUsageAggregate(event.llmUsage) ? event.llmUsage : undefined;
+      return {
+        cards,
+        at,
+        ...(llmUsage ? { llmUsage } : {}),
+        ...(calmMetrics ? { calmMetrics } : {}),
+        ...(automationHealth ? { automationHealth } : {}),
+      };
     }
     case "board.card.added": {
       if (!prev) return prev;
@@ -114,9 +121,9 @@ export function applyEventToBoard(
       if (idx >= 0) {
         const next = prev.cards.slice();
         next[idx] = card;
-        return { cards: next, at: typeof event.at === "string" ? event.at : prev.at };
+        return { ...prev, cards: next, at: typeof event.at === "string" ? event.at : prev.at };
       }
-      return { cards: [...prev.cards, card], at: typeof event.at === "string" ? event.at : prev.at };
+      return { ...prev, cards: [...prev.cards, card], at: typeof event.at === "string" ? event.at : prev.at };
     }
     case "board.card.updated": {
       if (!prev) return prev;
@@ -127,7 +134,7 @@ export function applyEventToBoard(
       if (idx < 0) return prev;
       const next = prev.cards.slice();
       next[idx] = { ...next[idx], ...partial, id } as BoardCard;
-      return { cards: next, at: typeof event.at === "string" ? event.at : prev.at };
+      return { ...prev, cards: next, at: typeof event.at === "string" ? event.at : prev.at };
     }
     case "board.card.moved": {
       if (!prev) return prev;
@@ -139,13 +146,15 @@ export function applyEventToBoard(
       const card = isRecord(event.card) ? (event.card as unknown as BoardCard) : undefined;
       const next = prev.cards.slice();
       next[idx] = card?.id === id ? { ...card, lane: toLane } : ({ ...next[idx], lane: toLane } as BoardCard);
-      return { cards: next, at: typeof event.at === "string" ? event.at : prev.at };
+      return { ...prev, cards: next, at: typeof event.at === "string" ? event.at : prev.at };
     }
     case "board.card.archived": {
       if (!prev) return prev;
       const id = event.id as string | undefined;
       if (!id) return prev;
+      if (!prev.cards.some((c) => c.id === id)) return prev;
       return {
+        ...prev,
         cards: prev.cards.filter((c) => c.id !== id),
         at: typeof event.at === "string" ? event.at : prev.at,
       };
@@ -167,4 +176,15 @@ function isAutomationHealth(value: unknown): value is AutomationHealth {
   return Number.isFinite(value.selfHealingOpen)
     && Number.isFinite(value.dispatchUsedToday)
     && Number.isFinite(value.dispatchPerDayCap);
+}
+
+function isLlmUsageAggregate(value: unknown): value is LlmUsageAggregate {
+  if (!isRecord(value)) return false;
+  return (value.status === "recorded" || value.status === "not_recorded")
+    && Number.isFinite(value.inputTokens)
+    && Number.isFinite(value.outputTokens)
+    && Number.isFinite(value.totalTokens)
+    && Number.isFinite(value.runs)
+    && Array.isArray(value.byModel)
+    && Array.isArray(value.byDay);
 }


### PR DESCRIPTION
## What changed & why

The monitor's live SSE cache patcher was dropping board-level metadata whenever it applied a `board.snapshot` or card event. That meant the HTTP snapshot could contain `llmUsage` and source-status reasons, but the live board cache would collapse back to `{ cards, at }`, making the LLM usage panel show the vague empty fallback.

This preserves `llmUsage` on full board snapshots and keeps existing board-level metadata (`llmUsage`, automation health, calm metrics) across card add/update/move/archive patches. It does **not** invent token counts; real usage still only appears when a runner/provider emits whitelisted counters.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback
Normal frontend/monitor rollout. Rollback by reverting this PR; no env, secret, migration, or ops changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

This fixes the UI/cache reason the LLM usage panel loses its metadata. If token totals still read `not reported`, that is expected until a real provider/runner emits whitelisted counters into `/data/llm-usage.jsonl`.
