### PR TITLE
fix(testbed): pre-send Basic Auth for browser missions

### DIFF
--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -19,6 +19,7 @@ import {
 import { executeSiweAuthMission, type SiweAuthMissionDeps } from "./testbed-auth-mission.js";
 import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
 import {
+  basicAuthHeadersForUrl,
   basicAuthHttpCredentialsForUrl,
   cloudflareAccessHeaders,
   parseSweepSessionConfig,
@@ -524,6 +525,12 @@ export async function executePlaywrightTestbedMission(
     });
     context = contextAndPage.context;
     page = contextAndPage.page;
+    if (config.basicAuth) {
+      await page.route("**/*", (route) => {
+        const headers = basicAuthHeadersForUrl(route.request().url(), config.basicAuth, route.request().headers());
+        return headers ? route.continue({ headers }) : route.continue();
+      });
+    }
     if (contextAndPage.videoDisabledReason) {
       whatITried.push(contextAndPage.videoDisabledReason);
       evidence.push({ type: "runner_warning", value: contextAndPage.videoDisabledReason });

--- a/services/slack-operator/src/testbed-session.ts
+++ b/services/slack-operator/src/testbed-session.ts
@@ -183,6 +183,24 @@ export function basicAuthHeaderValue(credential: TestbedBasicAuthCredential): st
 }
 
 /**
+ * Build request headers for an allowlisted gated-host request. This mirrors
+ * `curl --user` by pre-sending the Basic header, but only for configured hosts.
+ * Returns undefined when the request URL is not allowlisted, so callers can
+ * continue the request unchanged and never leak credentials to third parties.
+ */
+export function basicAuthHeadersForUrl(
+  requestUrl: string,
+  basicAuth: TestbedBasicAuth | undefined,
+  existingHeaders: Record<string, string> = {},
+): Record<string, string> | undefined {
+  if (!basicAuthAppliesToUrl(requestUrl, basicAuth) || !basicAuth) return undefined;
+  const next = { ...existingHeaders };
+  delete next.Authorization;
+  next.authorization = basicAuthHeaderValue(basicAuth.credential);
+  return next;
+}
+
+/**
  * Playwright newContext() httpCredentials scoped to the gated origin, so the
  * credential is answered ONLY to a 401 from that origin and never leaks to
  * third-party origins the page might touch. Returns undefined when Basic Auth

--- a/services/slack-operator/src/testbed-surface-sweep.ts
+++ b/services/slack-operator/src/testbed-surface-sweep.ts
@@ -18,6 +18,7 @@ import type { TestbedMissionRunResult } from "./testbed-mission-runner.js";
 import {
   DEFAULT_AUTHED_ROUTES,
   buildSweepContextOptions,
+  basicAuthHeadersForUrl,
   basicAuthHttpCredentialsForUrl,
   type CloudflareAccessServiceToken,
   type SweepSession,
@@ -406,6 +407,7 @@ function makeBrowserCapture(config: {
   timeoutMs?: number;
   session?: SweepSession;
   cloudflareAccess?: CloudflareAccessServiceToken;
+  basicAuth?: TestbedBasicAuth;
   httpCredentials?: { username: string; password: string; origin?: string };
 }): (url: string, route: string) => Promise<RouteCapture> {
   return async (url, route) => {
@@ -423,6 +425,12 @@ function makeBrowserCapture(config: {
       // Bearer (if any) authes the page's same-origin API calls. Read-only.
       const context = await browser.newContext(buildSweepContextOptions(config.session, config.cloudflareAccess, config.httpCredentials));
       const page = await context.newPage();
+      if (config.basicAuth) {
+        await page.route("**/*", (route) => {
+          const headers = basicAuthHeadersForUrl(route.request().url(), config.basicAuth, route.request().headers());
+          return headers ? route.continue({ headers }) : route.continue();
+        });
+      }
       page.on("console", (m) => {
         if (m.type() === "error") consoleErrors.push(m.text());
       });

--- a/test/unit/testbed-session.test.ts
+++ b/test/unit/testbed-session.test.ts
@@ -11,6 +11,7 @@ import {
   cloudflareAccessHeaders,
   parseTestbedBasicAuth,
   basicAuthAppliesToUrl,
+  basicAuthHeadersForUrl,
   basicAuthHeaderValue,
   basicAuthHttpCredentialsForUrl,
   DEFAULT_AUTHED_ROUTES,
@@ -214,6 +215,15 @@ describe("Caddy HTTP Basic Auth (the real edge gate)", () => {
   it("builds a correct Basic header value", () => {
     expect(basicAuthHeaderValue({ username: "op", password: "pw" }))
       .toBe(`Basic ${Buffer.from("op:pw").toString("base64")}`);
+  });
+
+  it("prebuilds Basic headers only for allowlisted gated hosts", () => {
+    const basic = parseTestbedBasicAuth({ TESTBED_BASIC_AUTH_USER: "op", TESTBED_BASIC_AUTH_PASS: "pw" } as NodeJS.ProcessEnv);
+    expect(basicAuthHeadersForUrl("https://app.averray.com/", basic, { accept: "text/html" })).toEqual({
+      accept: "text/html",
+      authorization: `Basic ${Buffer.from("op:pw").toString("base64")}`,
+    });
+    expect(basicAuthHeadersForUrl("https://evil.example/", basic, { accept: "text/html" })).toBeUndefined();
   });
 
   it("builds Playwright httpCredentials scoped to the gated origin", () => {


### PR DESCRIPTION
## What changed & why

Fresh-agent browser missions are still failing before the app can load with `net::ERR_INVALID_AUTH_CREDENTIALS` against `https://app.averray.com/`. The VPS curl check proves the Caddy gate accepts `curl --user`, so this makes the Playwright browser path mirror that behavior: pre-send the Basic `Authorization` header for allowlisted gated hosts, while keeping the existing Playwright `httpCredentials` challenge fallback.

The header is scoped by the existing `TESTBED_BASIC_AUTH_HOSTS` allowlist and is never added for third-party origins.

This does not wire SIWE. It only clears the Caddy/basic-auth layer so the next gold-path SIWE session work can run on top.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [ ] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Normal testbed-runner/slack-operator rollout. Rollback by reverting this PR. No env or secret changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

The authed gold-path still needs the SIWE browser storageState + API Bearer from the `test-wallet-signer` sidecar on top of Basic Auth. This PR only fixes the edge gate load failure.
