### PR TITLE
feat(testbed): wire SIWE sessions into gold path

### DIFF
--- a/services/slack-operator/src/gold-path-live-driver.ts
+++ b/services/slack-operator/src/gold-path-live-driver.ts
@@ -54,6 +54,12 @@ export type ExecClaudeFn = (input: ExecClaudeInput) => Promise<ExecClaudeResult>
 
 const DEFAULT_CLAUDE_ARGS = ["-p", "{prompt}"];
 
+interface GoldPathSessionArtifacts {
+  role?: string;
+  token?: string;
+  storageStatePath?: string;
+}
+
 export function parseClaudeGoldPathDriverConfig(
   env: NodeJS.ProcessEnv = process.env
 ): ClaudeGoldPathDriverConfig {
@@ -98,9 +104,13 @@ export function createClaudeGoldPathDriver(
 
       const runDir = await mkdtemp(join(tmpdir(), "averray-gold-path-live-"));
       const observationPath = join(runDir, "observation.json");
+      const sessionArtifacts = await materializeGoldPathSession(input.session, runDir);
       const prompt = buildClaudeGoldPathPrompt(input, {
         observationPath,
         signerBaseUrl: input.signerBaseUrl ?? config.signerBaseUrl,
+        hasSessionToken: Boolean(sessionArtifacts.token),
+        ...(sessionArtifacts.role ? { sessionRole: sessionArtifacts.role } : {}),
+        ...(sessionArtifacts.storageStatePath ? { sessionStorageStatePath: sessionArtifacts.storageStatePath } : {}),
       });
       const childEnv = buildClaudeInvocationEnv({
         ...env,
@@ -112,6 +122,17 @@ export function createClaudeGoldPathDriver(
         TESTBED_MUTATION_SCOPE: input.mutationScope,
         ...(input.signerBaseUrl ?? config.signerBaseUrl
           ? { TEST_WALLET_SIGNER_BASE_URL: input.signerBaseUrl ?? config.signerBaseUrl }
+          : {}),
+        ...(input.signerBaseUrl ?? config.signerBaseUrl
+          ? { TESTBED_SESSION_SIGNER_URL: input.signerBaseUrl ?? config.signerBaseUrl }
+          : {}),
+        ...(sessionArtifacts.role ? { TESTBED_SESSION_ROLE: sessionArtifacts.role } : {}),
+        ...(sessionArtifacts.token ? { TESTBED_SESSION_TOKEN: sessionArtifacts.token } : {}),
+        ...(sessionArtifacts.storageStatePath
+          ? {
+            TESTBED_SESSION_TYPE: "browser",
+            TESTBED_SESSION_STORAGE_STATE_PATH: sessionArtifacts.storageStatePath,
+          }
           : {}),
       }, authMode.mode);
 
@@ -154,9 +175,33 @@ function claudeAuthEnv(env: NodeJS.ProcessEnv): ClaudeWorkerAuthEnv {
   };
 }
 
+async function materializeGoldPathSession(
+  session: GoldPathDriverInput["session"] | undefined,
+  runDir: string,
+): Promise<GoldPathSessionArtifacts> {
+  if (!session) return {};
+  const artifacts: GoldPathSessionArtifacts = {};
+  if (session.role) artifacts.role = session.role;
+  if (typeof session.token === "string" && session.token.trim()) {
+    artifacts.token = session.token;
+  }
+  if (session.storageState !== undefined) {
+    const storageStatePath = join(runDir, "siwe-storage-state.json");
+    await writeFile(storageStatePath, `${JSON.stringify(session.storageState, null, 2)}\n`, "utf8");
+    artifacts.storageStatePath = storageStatePath;
+  }
+  return artifacts;
+}
+
 export function buildClaudeGoldPathPrompt(
   input: GoldPathDriverInput,
-  opts: { observationPath: string; signerBaseUrl?: string }
+  opts: {
+    observationPath: string;
+    signerBaseUrl?: string;
+    sessionRole?: string;
+    hasSessionToken?: boolean;
+    sessionStorageStatePath?: string;
+  }
 ): string {
   const mutationLine = input.allowMutations
     ? `Mutation profile: TESTNET/STAGING test-only mutations are allowed only inside clearly fake/sandbox Averray flows. Scope: ${input.mutationScope}`
@@ -167,12 +212,25 @@ export function buildClaudeGoldPathPrompt(
   const basicAuthLine = input.basicAuth
     ? "The gated host is behind Caddy HTTP Basic Auth. Open the browser context with httpCredentials { username, password } from TESTBED_BASIC_AUTH_USER / TESTBED_BASIC_AUTH_PASS in this environment so the 401 challenge is answered automatically; never print, screenshot, or report the username or password. (Basic Auth only loads the pages — authed claim/submit/verify still needs the SIWE session via the signer sidecar.)"
     : "No HTTP Basic Auth credential was configured; if the host returns 401 with a Basic realm, report that as an auth blocker instead of treating the product as broken.";
+  const siweSessionLine = opts.sessionStorageStatePath || opts.hasSessionToken
+    ? [
+      `A SIWE session is already minted for role ${opts.sessionRole ?? input.session?.role ?? "agent"}.`,
+      opts.sessionStorageStatePath
+        ? `For browser work, create the Playwright context with storageState loaded from TESTBED_SESSION_STORAGE_STATE_PATH (${opts.sessionStorageStatePath}).`
+        : "No browser storageState file was materialized; request a browser session from the signer sidecar if the UI requires it.",
+      opts.hasSessionToken
+        ? "For same-origin API checks, use the Bearer token from TESTBED_SESSION_TOKEN. Never print or report the token."
+        : "No API Bearer token was materialized; request an API session from the signer sidecar if the API requires it.",
+      "When the host is Basic-Auth-gated, combine the SIWE storageState with Basic Auth httpCredentials in the same browser context.",
+    ].join(" ")
+    : "No pre-minted SIWE session was resolved; if authentication is required, request a browser/api session from the signer sidecar or report the missing session as an auth blocker.";
   return [
     "You are Hermes running the Averray Tier-2 gold-path tester as a normal browser-capable outside agent.",
     "Use the Claude Agent SDK browser tooling / Playwright MCP tools available in this runtime. Do not use private repo state, Slack, GitHub, SSH, databases, or Averray monitor internals.",
     "Reuse T3 only through the local signer sidecar when you need authentication. The wallet private keys must never enter your prompt, output, logs, screenshots, or report.",
     edgeAuthLine,
     basicAuthLine,
+    siweSessionLine,
     opts.signerBaseUrl ? `Signer sidecar: ${opts.signerBaseUrl}. Request browser/api sessions by role as needed; do not print returned tokens.` : "No signer sidecar URL was provided; report that as a blocker if authentication is required.",
     mutationLine,
     `Target URL: ${input.targetUrl}`,
@@ -334,6 +392,9 @@ function redactGoldPathOutput(value: string, env: NodeJS.ProcessEnv): string {
     if (secret && secret.length >= 4) {
       next = next.split(secret).join("[redacted-basic-auth]");
     }
+  }
+  if (env.TESTBED_SESSION_TOKEN && env.TESTBED_SESSION_TOKEN.length >= 6) {
+    next = next.split(env.TESTBED_SESSION_TOKEN).join("[redacted-session-token]");
   }
   return next;
 }

--- a/services/slack-operator/src/gold-path-mission-entry.ts
+++ b/services/slack-operator/src/gold-path-mission-entry.ts
@@ -30,12 +30,14 @@ import {
   pickGoldPathModel,
   createUnavailableGoldPathDriver,
   type GoldPathDriver,
+  type GoldPathDriverInput,
   type GoldPathMissionResult,
 } from "./gold-path-mission.js";
 import {
   createClaudeGoldPathDriver,
   parseClaudeGoldPathDriverConfig,
 } from "./gold-path-live-driver.js";
+import type { SweepSessionDeps } from "./testbed-session.js";
 
 interface GoldPathMissionEnv {
   id: string;
@@ -69,7 +71,11 @@ export function selectGoldPathDriver(env: NodeJS.ProcessEnv): GoldPathDriver {
 
 export async function runGoldPathMissionEntry(
   env: NodeJS.ProcessEnv = process.env,
-  deps: { driver?: GoldPathDriver } = {},
+  deps: {
+    driver?: GoldPathDriver;
+    resolveSession?: () => Promise<GoldPathDriverInput["session"] | undefined> | GoldPathDriverInput["session"] | undefined;
+    sessionDeps?: SweepSessionDeps;
+  } = {},
 ): Promise<GoldPathMissionResult> {
   const mission = readMissionFromEnv(env);
 
@@ -106,7 +112,7 @@ export async function runGoldPathMissionEntry(
     ...(basicAuth ? { basicAuth: true } : {}),
     // T3: the API Bearer (and/or browser storageState) from the signer sidecar —
     // the wallet key never enters this process. Undefined when unconfigured.
-    resolveSession: () => resolveSweepSession({ ...parseSweepSessionConfig(env), sessionType: "api" }),
+    resolveSession: deps.resolveSession ?? (() => resolveGoldPathSessionFromEnv(env, binding, deps.sessionDeps)),
   });
 
   const reportPath = env.TESTBED_MISSION_REPORT_PATH;
@@ -116,6 +122,34 @@ export async function runGoldPathMissionEntry(
     process.stdout.write(result.reportText);
   }
   return result;
+}
+
+export async function resolveGoldPathSessionFromEnv(
+  env: NodeJS.ProcessEnv,
+  binding: { environment: string },
+  deps: SweepSessionDeps = {},
+): Promise<GoldPathDriverInput["session"] | undefined> {
+  const parsed = parseSweepSessionConfig(env);
+  const signerBaseUrl = parsed.signerBaseUrl || env.TEST_WALLET_SIGNER_BASE_URL;
+  const role = binding.environment === "mainnet" ? "agent" : parsed.role;
+  const base = {
+    ...parsed,
+    ...(signerBaseUrl ? { signerBaseUrl } : {}),
+    ...(role ? { role } : {}),
+  };
+  const [api, browser] = await Promise.all([
+    resolveSweepSession({ ...base, sessionType: "api" }, deps),
+    resolveSweepSession({ ...base, sessionType: "browser" }, deps),
+  ]);
+  const token = api?.token ?? browser?.token;
+  const storageState = browser?.storageState ?? api?.storageState;
+  const resolvedRole = api?.role ?? browser?.role ?? role;
+  if (!token && storageState === undefined) return undefined;
+  return {
+    ...(resolvedRole ? { role: resolvedRole } : {}),
+    ...(token ? { token } : {}),
+    ...(storageState !== undefined ? { storageState } : {}),
+  };
 }
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/test/unit/gold-path-mission.test.ts
+++ b/test/unit/gold-path-mission.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -10,10 +10,11 @@ import {
   runGoldPathMissionOnce,
   createScriptedGoldPathDriver,
   createUnavailableGoldPathDriver,
+  type GoldPathDriverInput,
   type GoldPathObservation,
   type GoldPathStepResult,
 } from "../../services/slack-operator/src/gold-path-mission.js";
-import { runGoldPathMissionEntry } from "../../services/slack-operator/src/gold-path-mission-entry.js";
+import { resolveGoldPathSessionFromEnv, runGoldPathMissionEntry } from "../../services/slack-operator/src/gold-path-mission-entry.js";
 import {
   buildClaudeGoldPathPrompt,
   createClaudeGoldPathDriver,
@@ -23,6 +24,15 @@ import { resolveTestbedMutationBinding, type TestbedMutationBinding } from "../.
 
 function obs(steps: GoldPathStepResult[], over: Partial<GoldPathObservation> = {}): GoldPathObservation {
   return { steps, notes: [], mutationsAttempted: [], stoppedBeforeMutation: true, ...over };
+}
+
+const STORAGE_STATE = { cookies: [{ name: "refresh" }], origins: [] };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
 }
 
 // ── A4 model policy ─────────────────────────────────────────────────
@@ -244,6 +254,85 @@ describe("runGoldPathMissionEntry — env wiring keeps mainnet read-only", () =>
     expect((result.report.summary as string)).toMatch(/gold_path fail/);
     expect(JSON.stringify(result.report)).toContain("not in live mode");
   });
+
+  it("resolves API Bearer + browser storageState from the signer sidecar and passes both to the driver", async () => {
+    let seenSession: GoldPathDriverInput["session"];
+    const fetchedUrls: string[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      fetchedUrls.push(url);
+      if (url.endsWith("/session/agent?type=api")) {
+        return jsonResponse({ type: "api", role: "agent", token: "jwt-agent" });
+      }
+      if (url.endsWith("/session/agent?type=browser")) {
+        return jsonResponse({ type: "browser", role: "agent", storageState: STORAGE_STATE });
+      }
+      return jsonResponse({ error: "not found" }, 404);
+    };
+
+    await runGoldPathMissionEntry(
+      {
+        TESTBED_MISSION_ID: "gp-entry-session",
+        TESTBED_TARGET_URL: "https://app.testnet.example",
+        TESTBED_MISSION_GOAL: "gold path",
+        TESTBED_MISSION_ENVIRONMENT: "testnet",
+        TESTBED_REQUESTED_TEST_MUTATIONS: "true",
+        TESTBED_MISSION_REPORT_PATH: join(dir, "report-session.json"),
+        TEST_WALLET_SIGNER_BASE_URL: "http://signer.local",
+        TESTBED_SESSION_ROLE: "agent",
+      } as NodeJS.ProcessEnv,
+      {
+        sessionDeps: { fetchImpl },
+        driver: {
+          async run(input) {
+            seenSession = input.session;
+            return createScriptedGoldPathDriver().run(input);
+          },
+        },
+      },
+    );
+
+    expect(fetchedUrls).toEqual(expect.arrayContaining([
+      "http://signer.local/session/agent?type=api",
+      "http://signer.local/session/agent?type=browser",
+    ]));
+    expect(seenSession).toEqual({
+      role: "agent",
+      token: "jwt-agent",
+      storageState: STORAGE_STATE,
+    });
+  });
+
+  it("mainnet session resolution forces the read-only agent role", async () => {
+    const fetchedUrls: string[] = [];
+    const fetchImpl: typeof fetch = async (input) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      fetchedUrls.push(url);
+      if (url.endsWith("/session/agent?type=api")) {
+        return jsonResponse({ type: "api", role: "agent", token: "jwt-agent" });
+      }
+      if (url.endsWith("/session/agent?type=browser")) {
+        return jsonResponse({ type: "browser", role: "agent", storageState: STORAGE_STATE });
+      }
+      return jsonResponse({ error: "not found" }, 404);
+    };
+
+    const session = await resolveGoldPathSessionFromEnv(
+      {
+        TESTBED_SESSION_ROLE: "admin",
+        TEST_WALLET_SIGNER_BASE_URL: "http://signer.local",
+      } as NodeJS.ProcessEnv,
+      { environment: "mainnet" },
+      { fetchImpl },
+    );
+
+    expect(fetchedUrls).toEqual(expect.arrayContaining([
+      "http://signer.local/session/agent?type=api",
+      "http://signer.local/session/agent?type=browser",
+    ]));
+    expect(fetchedUrls.some((url) => url.includes("/session/admin?"))).toBe(false);
+    expect(session).toEqual({ role: "agent", token: "jwt-agent", storageState: STORAGE_STATE });
+  });
 });
 
 describe("Claude live gold-path driver", () => {
@@ -367,6 +456,56 @@ describe("Claude live gold-path driver", () => {
     });
   });
 
+  it("materializes SIWE session state for the live command without exposing the token in the prompt", async () => {
+    const driver = createClaudeGoldPathDriver(
+      {
+        enabled: true,
+        command: "claude",
+        args: ["-p", "{prompt}"],
+        timeoutMs: 1000,
+        signerBaseUrl: "http://test-wallet-signer:8791",
+      },
+      {
+        TESTBED_GOLDPATH_LIVE: "1",
+        CLAUDE_WORKER_AUTH_MODE: "sub",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      } as NodeJS.ProcessEnv,
+      {
+        exec: async ({ env, args }) => {
+          expect(env.TESTBED_SESSION_ROLE).toBe("agent");
+          expect(env.TESTBED_SESSION_TOKEN).toBe("jwt-secret-token");
+          expect(env.TESTBED_SESSION_TYPE).toBe("browser");
+          expect(env.TESTBED_SESSION_STORAGE_STATE_PATH).toMatch(/siwe-storage-state\.json$/);
+          const storageState = JSON.parse(await readFile(String(env.TESTBED_SESSION_STORAGE_STATE_PATH), "utf8"));
+          expect(storageState).toEqual(STORAGE_STATE);
+
+          const prompt = args.join(" ");
+          expect(prompt).toContain("A SIWE session is already minted for role agent");
+          expect(prompt).toContain("TESTBED_SESSION_STORAGE_STATE_PATH");
+          expect(prompt).not.toContain("jwt-secret-token");
+          expect(prompt).not.toContain("refresh");
+          return {
+            exitCode: 0,
+            stdout: JSON.stringify({
+              steps: [{ step: "onboard", status: "ok", detail: "loaded with SIWE", latencyMs: 50 }],
+              notes: ["ok"],
+              mutationsAttempted: [],
+              stoppedBeforeMutation: true,
+            }),
+            stderr: "",
+          };
+        },
+      },
+    );
+
+    await expect(driver.run({
+      ...input,
+      session: { role: "agent", token: "jwt-secret-token", storageState: STORAGE_STATE },
+    })).resolves.toMatchObject({
+      steps: [expect.objectContaining({ step: "onboard", detail: "loaded with SIWE" })],
+    });
+  });
+
   it("passes Cloudflare Access env to the live command but redacts it from failed observations", async () => {
     const driver = createClaudeGoldPathDriver(
       {
@@ -404,5 +543,39 @@ describe("Claude live gold-path driver", () => {
     expect(JSON.stringify(observation)).not.toContain("cf-client-id");
     expect(JSON.stringify(observation)).not.toContain("cf-client-secret");
     expect(JSON.stringify(observation)).toContain("[redacted-cloudflare-access]");
+  });
+
+  it("redacts SIWE session tokens from failed live-driver observations", async () => {
+    const driver = createClaudeGoldPathDriver(
+      {
+        enabled: true,
+        command: "claude",
+        args: ["-p", "{prompt}"],
+        timeoutMs: 1000,
+        signerBaseUrl: "http://test-wallet-signer:8791",
+      },
+      {
+        TESTBED_GOLDPATH_LIVE: "1",
+        CLAUDE_WORKER_AUTH_MODE: "sub",
+        CLAUDE_CODE_OAUTH_TOKEN: "oauth-token",
+      } as NodeJS.ProcessEnv,
+      {
+        exec: async ({ env }) => {
+          expect(env.TESTBED_SESSION_TOKEN).toBe("siwe-token-secret");
+          return {
+            exitCode: 1,
+            stdout: "stdout leaked siwe-token-secret",
+            stderr: "stderr leaked siwe-token-secret",
+          };
+        },
+      },
+    );
+
+    const observation = await driver.run({
+      ...input,
+      session: { role: "agent", token: "siwe-token-secret", storageState: STORAGE_STATE },
+    });
+    expect(JSON.stringify(observation)).not.toContain("siwe-token-secret");
+    expect(JSON.stringify(observation)).toContain("[redacted-session-token]");
   });
 });


### PR DESCRIPTION
## What changed & why

- Gold-path missions now resolve both T3 signer-sidecar session types: API Bearer (`type=api`) and browser Playwright `storageState` (`type=browser`).
- `TEST_WALLET_SIGNER_BASE_URL` is honored as a session source, matching the mission runner wiring.
- Mainnet session resolution forces the read-only `agent` role even if env asks for admin/verifier.
- The live gold-path driver materializes browser storage state to a temp file and passes only env/path handles to the spawned browser-capable runner; SIWE tokens are redacted from failed observations.

This is auth/session wiring only. It does not change dispatch authority, merge authority, or the testnet/mainnet mutation binding.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [x] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Rollout: after merge/deploy, the gold-path runner can use the existing `test-wallet-signer` sidecar for both API and browser sessions. Required runtime config is the existing signer URL plus already-managed Basic Auth env for the gated app.

Rollback: revert this PR. The gold-path entry returns to API-only session resolution and the live driver stops passing materialized SIWE session artifacts.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- This does not create signer-sidecar secrets or deploy config; it consumes the existing T3 sidecar/session contract.
- The current screenshot with `net::ERR_INVALID_AUTH_CREDENTIALS` is still a Basic Auth edge failure. This PR fixes the next layer: the app session after the page can load.