### PR TITLE
LLM usage panel: compact smart summary, not a flat table

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -257,15 +257,21 @@ describe("BoardView — rich-mix board (open stream)", () => {
         ],
       },
     };
-    const { getAllByText, getByRole, getByText } = render(<BoardView board={board} status="open" />);
+    const { getAllByText, getByRole, getByText, queryByText, queryAllByText } = render(<BoardView board={board} status="open" />);
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
-    expect(getByText("12 calls in board window")).toBeTruthy();
-    expect(getByText("59K tokens total")).toBeTruthy();
+    // Leads with the headline: total tokens + call count.
+    expect(getByText("59K tokens · 12 calls")).toBeTruthy();
+    // Active source is prominent (also surfaced as the in-flight call).
     expect(getAllByText("claude · claude-sonnet-4-5").length).toBeGreaterThan(0);
-    expect(getByText("12 calls")).toBeTruthy();
-    expect(getByText("48K in")).toBeTruthy();
-    expect(getByText("9K out")).toBeTruthy();
-    expect(getByText("59K total")).toBeTruthy();
+    expect(getByText("59K tokens")).toBeTruthy();
+    expect(getByText("48K in · 9K out")).toBeTruthy();
+    // Idle sources collapse into ONE muted line; the reason is hidden until expand.
+    expect(getByText(/1 source idle: codex/)).toBeTruthy();
+    expect(queryByText("Codex CLI does not report usage.")).toBeNull();
+    // No flat per-source "not reported" row.
+    expect(queryAllByText("not reported").length).toBe(0);
+    // Expanding reveals the honest reason (truth-boundary preserved).
+    fireEvent.click(getByText(/1 source idle: codex/));
     expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
   });
 

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -634,26 +634,35 @@ function formatClock(iso: string | undefined): string {
 }
 
 function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
+  const [showIdle, setShowIdle] = useState(false);
+  const recorded = usage?.status === "recorded";
   const latestDay = usage?.byDay?.[0];
-  const models = (usage?.byModel?.length ? usage.byModel : latestDay?.byModel ?? []).slice(0, 5);
-  const missingSources = (usage?.sourceStatus ?? [])
-    .filter((entry) => entry.status === "not_reported")
-    .slice(0, Math.max(0, 5 - models.length));
+  // Active sources get the space — every (agent, model) that actually reported.
+  const models = usage?.byModel?.length ? usage.byModel : latestDay?.byModel ?? [];
+  // Idle sources collapse into ONE line; their honest reasons stay reachable on expand.
+  const idleSources = (usage?.sourceStatus ?? []).filter((entry) => entry.status === "not_reported");
   const activeCalls = usage?.activeCalls ?? [];
-  const hasRows = models.length > 0 || missingSources.length > 0;
   const emptyMessage = usage?.message
     ?? "No LLM usage counters have been recorded yet. Sources stay not reported until a real provider or runner emits whitelisted counters.";
+
   return (
     <section className="hm-llm-usage" aria-label="LLM usage">
+      {/* Headline: total tokens · calls, with the window/last-active context. */}
       <div className="hm-llm-usage-head">
-        <div>
-          <span className="hm-kicker">LLM usage</span>
-          <strong>{usage?.status === "recorded" ? `${formatNumber(usage.runs)} calls in board window` : "usage not reported"}</strong>
-        </div>
-        <span className="hm-llm-usage-total">
-          {usage?.status === "recorded" ? `${formatCompactNumber(usage.totalTokens)} tokens total` : "not reported"}
-        </span>
+        <span className="hm-kicker">LLM usage</span>
+        <strong className="hm-llm-usage-headline">
+          {recorded
+            ? `${formatCompactNumber(usage!.totalTokens)} tokens · ${formatNumber(usage!.runs)} calls`
+            : "usage not reported"}
+        </strong>
+        {recorded ? (
+          <span className="hm-llm-usage-window">
+            board window{usage!.lastActiveAt ? ` · last ${formatRelativeTime(usage!.lastActiveAt)}` : ""}
+          </span>
+        ) : null}
       </div>
+
+      {/* What's running now (in-flight). */}
       <div className="hm-llm-usage-active">
         <span>What's running now</span>
         {activeCalls.length > 0 ? (
@@ -662,37 +671,66 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
           <strong>No in-flight LLM calls</strong>
         )}
       </div>
-      <div className="hm-llm-usage-grid">
-        {hasRows ? (
-          <>
-            {models.map((entry) => (
-              <div className="hm-llm-usage-row" key={`${entry.agent}:${entry.model}`}>
-                <span>
+
+      {/* Active sources — prominent: per-(agent, model) tokens + in/out bar. */}
+      {recorded && models.length > 0 ? (
+        <div className="hm-llm-usage-sources">
+          {models.map((entry) => {
+            const split = Math.max(1, entry.inputTokens + entry.outputTokens);
+            const inPct = Math.round((entry.inputTokens / split) * 100);
+            return (
+              <div className="hm-llm-usage-source" key={`${entry.agent}:${entry.model}`}>
+                <div className="hm-llm-usage-source-head">
                   <strong>{entry.agent} · {entry.model}</strong>
-                  <small>Last active {formatRelativeTime(entry.lastActiveAt)}</small>
-                </span>
-                <span>{formatNumber(entry.runs)} calls</span>
-                <span>{formatCompactNumber(entry.inputTokens)} in</span>
-                <span>{formatCompactNumber(entry.outputTokens)} out</span>
-                <span>{formatCompactNumber(entry.totalTokens)} total</span>
+                  <span>{formatCompactNumber(entry.totalTokens)} tokens</span>
+                </div>
+                <div
+                  className="hm-llm-usage-bar"
+                  role="img"
+                  aria-label={`${formatCompactNumber(entry.inputTokens)} in, ${formatCompactNumber(entry.outputTokens)} out`}
+                >
+                  <span className="hm-llm-usage-bar-in" style={{ width: `${inPct}%` }} />
+                  <span className="hm-llm-usage-bar-out" style={{ width: `${100 - inPct}%` }} />
+                </div>
+                <div className="hm-llm-usage-source-foot">
+                  <small>{formatCompactNumber(entry.inputTokens)} in · {formatCompactNumber(entry.outputTokens)} out</small>
+                  <small>{formatNumber(entry.runs)} calls · last {formatRelativeTime(entry.lastActiveAt)}</small>
+                </div>
               </div>
-            ))}
-            {missingSources.map((entry) => (
-              <div className="hm-llm-usage-row hm-llm-usage-row--muted" key={`missing:${entry.agent}`}>
-                <span>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {/* Idle sources — one muted, expandable line; reasons honest but quiet. */}
+      {idleSources.length > 0 ? (
+        <div className="hm-llm-usage-idle">
+          <button
+            type="button"
+            className="hm-llm-usage-idle-toggle"
+            aria-expanded={showIdle}
+            onClick={() => setShowIdle((value) => !value)}
+          >
+            <span aria-hidden>{showIdle ? "▾" : "▸"}</span>
+            {idleSources.length} source{idleSources.length === 1 ? "" : "s"} idle: {idleSources.map((entry) => entry.agent).join(" · ")}
+          </button>
+          {showIdle ? (
+            <ul className="hm-llm-usage-idle-list">
+              {idleSources.map((entry) => (
+                <li key={entry.agent}>
                   <strong>{entry.agent}</strong>
-                  <small>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</small>
-                </span>
-                <span>not reported</span>
-                <span>0 calls</span>
-                <span>0 tokens</span>
-              </div>
-            ))}
-          </>
-        ) : (
-          <div className="hm-llm-usage-empty">{emptyMessage}</div>
-        )}
-      </div>
+                  <span>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Truth-boundary explanation when nothing reported and no idle list to carry it. */}
+      {!recorded && models.length === 0 ? (
+        <div className="hm-llm-usage-empty">{emptyMessage}</div>
+      ) : null}
     </section>
   );
 }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -450,6 +450,101 @@ body { margin: 0; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Compact panel (smart summary): headline + active sources + collapsed idle. */
+.hm-llm-usage-head {
+  display: grid;
+  gap: 1px;
+}
+.hm-llm-usage-headline {
+  font-family: var(--font-display);
+  font-size: 15px;
+  color: var(--hm-ink);
+}
+.hm-llm-usage-window {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+}
+.hm-llm-usage-sources {
+  display: grid;
+  gap: 9px;
+  padding-top: 6px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-llm-usage-source {
+  display: grid;
+  gap: 3px;
+}
+.hm-llm-usage-source-head,
+.hm-llm-usage-source-foot {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+.hm-llm-usage-source-head strong {
+  font-family: var(--font-display);
+  font-size: 12px;
+  color: var(--hm-ink);
+}
+.hm-llm-usage-source-head span {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-ink);
+}
+.hm-llm-usage-source-foot small {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-llm-usage-bar {
+  display: flex;
+  height: 5px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--hm-line-soft);
+}
+.hm-llm-usage-bar-in { background: var(--hm-blue); }
+.hm-llm-usage-bar-out { background: var(--hm-blue-soft); }
+.hm-llm-usage-idle {
+  padding-top: 6px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-llm-usage-idle-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+}
+.hm-llm-usage-idle-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+}
+.hm-llm-usage-idle-list li {
+  display: grid;
+  gap: 1px;
+}
+.hm-llm-usage-idle-list strong {
+  font-family: var(--font-display);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-llm-usage-idle-list span {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
 .hm-backlog-suggestions {
   margin: 0 22px 10px;
   padding: 10px 12px;


### PR DESCRIPTION
## What changed & why
The LLM usage panel was a verbose flat table — hermes/claude/codex/docs/security rows, each with calls/in/out/total — where most rows read "not reported · 0 calls". Noisy and space-heavy. Reworked into a compact, scannable summary:

- **Headline leads** with the total: `59K tokens · 12 calls`, plus the board-window / last-active context.
- **Active sources are prominent** — per-`(agent, model)` total tokens with a small **in/out bar** (input vs output split), and calls + last-active underneath.
- **Idle / "not reported" sources collapse into ONE muted, expandable line** — e.g. `1 source idle: codex` — instead of a full near-empty row each.
- **Kept** "What's running now" (in-flight) and last-active.

**Truth-boundary:** each idle source's honest "not reported" reason stays **reachable on expand** — it just no longer dominates the panel. The not-recorded state still leads with `usage not reported` + the plain-language explanation.

**Accept:** panel leads with total + active source; idle sources = one collapsed line; no five near-empty rows. ✅

## Affected surfaces
- [x] Monitor board / slack-operator (frontend `@avg/monitor-ui` only)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (`@avg/monitor-ui` **529 passed**; BoardView LLM-usage test updated for the new layout)
- [ ] docker compose config (no ops/Docker/compose change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — presentational panel only
- [x] Wallet testnet-only / `HALT_FILE` / no new ungated agent power — unaffected
- [x] No secrets committed/printed/logged
- [x] Truth-boundary: idle sources keep their honest "not reported" reason (reachable on expand); a fully-unreported window still says so and shows the explanation — nothing is hidden or faked, just no longer noisy

## Known limits / follow-ups
The in/out bar is a simple input-vs-output split (not a time sparkline); a per-call sparkline could come later if the aggregate grows a time series. Old `.hm-llm-usage-grid` / `-row` CSS is now unused but left in place (harmless) — a later sweep can drop it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)