### PR TITLE
fix(task-health): escalate invalid self-heal targets

### DIFF
--- a/services/slack-operator/src/task-health.ts
+++ b/services/slack-operator/src/task-health.ts
@@ -88,6 +88,9 @@ export async function decideTaskHealthAction(
   const base = { taskId: task.id };
   if (TERMINAL_NO_ACTION.has(task.status)) return { ...base, action: "none", reason: "terminal" };
   if (task.selfManagementEscalatedAt) return { ...base, action: "none", reason: "already_escalated" };
+  if (isInvalidSelfHealingTarget(task)) {
+    return { ...base, action: "escalate", reason: "invalid_self_healing_target:testbed_mission_not_a_repo" };
+  }
 
   if (task.status === "failed") {
     const scheduledRetry = parseDate(task.retryAfter);
@@ -131,6 +134,10 @@ export async function decideTaskHealthAction(
   }
 
   return { ...base, action: "none", reason: "not_managed" };
+}
+
+function isInvalidSelfHealingTarget(task: CodexTask): boolean {
+  return task.requester === "hermes-self-healing" && task.repo === "testbed/mission";
 }
 
 function mayRetry(task: CodexTask, config: TaskHealthConfig): boolean {

--- a/test/unit/task-health.test.ts
+++ b/test/unit/task-health.test.ts
@@ -112,6 +112,74 @@ describe("task health self-management", () => {
     });
   });
 
+  it("escalates invalid self-healing tasks that target the placeholder testbed mission repo instead of retrying", async () => {
+    const action = await decideTaskHealthAction(
+      task({
+        id: "bad-self-heal",
+        requester: "hermes-self-healing",
+        repo: "testbed/mission",
+        agent: "claude",
+        failedAt: "2026-06-01T10:00:00.000Z",
+        updatedAt: "2026-06-01T10:00:00.000Z",
+      }),
+      {
+        config,
+        now: new Date("2026-06-01T10:30:00.000Z"),
+        suspended: false,
+        halt: false,
+        dispatch: { allowed: true, reason: "dispatch_allowed" },
+      },
+    );
+
+    expect(action).toMatchObject({
+      taskId: "bad-self-heal",
+      action: "escalate",
+      reason: "invalid_self_healing_target:testbed_mission_not_a_repo",
+    });
+  });
+
+  it("escalates stale running placeholder self-healing tasks before restart recovery", async () => {
+    const retryTask = vi.fn();
+    const escalateTask = vi.fn();
+
+    const result = await runTaskHealthOnce(config, {
+      listTasks: () => [
+        task({
+          id: "running-bad-self-heal",
+          status: "running",
+          requester: "hermes-self-healing",
+          repo: "testbed/mission",
+          agent: "claude",
+          startedAt: "2026-06-01T09:40:00.000Z",
+          progressAt: "2026-06-01T09:40:00.000Z",
+          updatedAt: "2026-06-01T09:40:00.000Z",
+          attemptCount: 1,
+        }),
+      ],
+      readRunner: () => undefined,
+      retryTask,
+      deferRetry: vi.fn(),
+      escalateTask,
+      isSuspended: () => false,
+      isHalt: () => false,
+      dispatchAllowed: () => ({ allowed: true, reason: "dispatch_allowed" }),
+      now: () => new Date("2026-06-01T10:00:00.000Z"),
+    });
+
+    expect(result.actions).toEqual([
+      {
+        taskId: "running-bad-self-heal",
+        action: "escalate",
+        reason: "invalid_self_healing_target:testbed_mission_not_a_repo",
+      },
+    ]);
+    expect(retryTask).not.toHaveBeenCalled();
+    expect(escalateTask).toHaveBeenCalledWith(
+      "running-bad-self-heal",
+      "invalid_self_healing_target:testbed_mission_not_a_repo",
+    );
+  });
+
   it("escalates approved tasks that sit past the stale threshold", async () => {
     const action = await decideTaskHealthAction(
       task({


### PR DESCRIPTION
## What changed & why

- O5 task health now escalates Hermes self-healing tasks that target the placeholder repo `testbed/mission`.
- This prevents stale/failed self-healing tasks from being retried or restart-recovered into the Claude worker, where they fail because `testbed/mission` is not a real allowed repo.
- Added tests for both failed and stale-running placeholder self-heal tasks.

This matches the board symptom from the screenshot: the producer path already avoids creating new code tasks for testbed product evidence, but old persisted `testbed/mission` self-heal tasks still needed cleanup behavior.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

Rollout: after deploy, O5 will mark old invalid self-healing tasks as escalated with `invalid_self_healing_target:testbed_mission_not_a_repo`; it will not retry/requeue them.

Rollback: revert this PR to restore previous O5 retry/stale handling.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- This does not auto-dismiss existing cards. It makes the next O5 pass escalate them once instead of looping. Operator can then dismiss/accept them from the board.
- New testbed product failures already stay non-auto-fixable via the existing testbed mission disposition path.