### PR TITLE
fix(monitor): attach readable mission reports to completed cards

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -326,6 +326,30 @@ describe("DetailDrawer — variants", () => {
     expect(getByText(/no structured report yet/i)).toBeTruthy();
     expect(getByText("Spec · /mission spawn flow")).toBeTruthy();
   });
+
+  test("completed mission with NO report renders honest report-unavailable coaching", () => {
+    const card = {
+      id: "mission browser-completed-no-report",
+      lane: "done",
+      type: "mission",
+      missionStatus: "completed",
+      agentType: "hermes",
+      title: "Fresh-agent browser mission",
+      summary: "Run finished without a structured report — see recent output.",
+      repo: "testbed/mission",
+      freshness: 15,
+      state: "fresh",
+      risk: ["testbed"],
+      waitingOn: { actor: "agent", tone: "neutral" },
+    } as unknown as BoardCard;
+    const { getByText, queryByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Mission · report unavailable")).toBeTruthy();
+    expect(getByText(/run finished without a structured report/i)).toBeTruthy();
+    expect(queryByText("Mission · no report yet")).toBeNull();
+    expect(queryByText("FAILED")).toBeNull();
+  });
 });
 
 describe("DetailDrawer — footer actions (G2)", () => {

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -460,10 +460,17 @@ function MissionBody({ card }: { card: MissionCard }) {
   // structured report until the browser agent posts one. Read defensively.
   const m = (card as { mission?: MissionCard["mission"] }).mission;
   if (!m) {
+    const finished = card.missionStatus === "completed" || card.missionStatus === "failed";
     return (
       <>
-        <VerdictBlock head="Mission · no report yet" accent="var(--hm-hermes-deep)">
-          {card.summary || "No structured report yet — the browser agent hasn't posted one."}
+        <VerdictBlock
+          head={finished ? "Mission · report unavailable" : "Mission · no report yet"}
+          accent="var(--hm-hermes-deep)"
+        >
+          {card.summary
+            || (finished
+              ? "Run finished without a structured report — see recent output."
+              : "No structured report yet — the browser agent hasn't posted one.")}
         </VerdictBlock>
         <MissionSpecDetails />
       </>

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -374,7 +374,7 @@ export function mapTagsToRisk(tags: ReadonlyArray<string> | undefined): RiskTag[
 
 /**
  * Infer the card type from the classifier output. Heuristics:
- *   - testbed tag or "mission" in the id → mission
+ *   - testbed tag or "mission" in the title → mission
  *   - codex-needed lane or owner Codex with a task shape → task
  *   - done lane → done
  *   - a deploy-flavored title/owner → deploy
@@ -383,8 +383,8 @@ export function mapTagsToRisk(tags: ReadonlyArray<string> | undefined): RiskTag[
 export function inferCardType(item: HermesBoardCardSnapshot, lane: Lane): CardType {
   const tags = (item.tags ?? []).map((t) => String(t).toLowerCase());
   const title = (item.title ?? "").toLowerCase();
-  if (lane === "done") return "done";
   if (tags.includes("testbed") || /\bmission\b/.test(title)) return "mission";
+  if (lane === "done") return "done";
   if (lane === "codex-needed") return "task";
   if (lane === "deploying" || /post-merge verify|deploy verif/.test(title)) return "deploy";
   if (lane === "drafts") return "draft";
@@ -1245,6 +1245,37 @@ function reportSource(run: Record<string, unknown>): Record<string, unknown> {
   return structured ?? result ?? {};
 }
 
+function missionReportMode(source: Record<string, unknown>, run: Record<string, unknown>): string {
+  const raw = firstString(
+    source.mode,
+    source.runnerMode,
+    source.executor,
+    source.pathName,
+    source.kind,
+    run.mode,
+    run.environment,
+  );
+  return raw ? raw.replace(/_/g, "-") : "mission";
+}
+
+function conciseMissionDetail(value: string): string {
+  const singleLine = value.replace(/\s+/g, " ").trim();
+  return singleLine.length <= 96 ? singleLine : `${singleLine.slice(0, 93)}...`;
+}
+
+function missionReportOneLine(run: Record<string, unknown>): string | undefined {
+  const report = testbedMissionStructuredReport(run as unknown as TestbedMissionRun);
+  if (!report) return undefined;
+  const source = reportSource(run);
+  const verdict = report.verdict.toUpperCase();
+  const mode = missionReportMode(source, run);
+  const blockerCount = report.blockers.length + report.confusingMoments.length;
+  const blockerLabel = blockerCount === 1 ? "blocker" : "blockers";
+  const topBlocker = report.blockers[0] ?? report.confusingMoments[0];
+  const base = `${verdict} · ${mode} · ${blockerCount} ${blockerLabel}`;
+  return topBlocker ? `${base} · ${conciseMissionDetail(topBlocker)}` : base;
+}
+
 function reportArrayEntry(source: Record<string, unknown>, key: string, index: number): Record<string, unknown> | undefined {
   const entry = asArray(source[key])[index];
   return asRecord(entry);
@@ -1447,7 +1478,11 @@ export function enrichBoardCard(
     const status = asString(ctx.missionRun.status);
     if (status) card.missionStatus = status as MissionStatus;
     const mission = mapMissionReport(ctx.missionRun);
-    if (mission) card.mission = mission;
+    if (mission) {
+      card.mission = mission;
+      const oneLine = missionReportOneLine(ctx.missionRun);
+      if (oneLine) card.summary = oneLine;
+    }
     const workingNow = workingNowFromMissionRun(ctx.missionRun);
     if (workingNow) card.workingNow = workingNow;
   }

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -91,6 +91,10 @@ describe("inferCardType", () => {
   it("done lane → done", () => {
     expect(inferCardType(slim({ lane: "Done" }), "done")).toBe("done");
   });
+  it("done-lane testbed mission → mission", () => {
+    expect(inferCardType(slim({ lane: "Done", tags: ["testbed"], title: "Fresh-agent browser mission" }), "done"))
+      .toBe("mission");
+  });
   it("testbed tag → mission", () => {
     expect(inferCardType(slim({ tags: ["testbed"] }), "hermes-checking")).toBe("mission");
   });
@@ -1077,6 +1081,50 @@ describe("buildV2BoardSnapshot — enrichment integration", () => {
     expect(mission?.mission?.verdict).toBe("PARTIAL");
     expect(mission?.mission?.target).toBe("https://staging.averray.com/onboarding");
     expect(mission?.mission?.path).toHaveLength(2);
+  });
+
+  it("keeps completed mission runs as mission cards and attaches their report", () => {
+    const raw = {
+      active: [],
+      recent: [],
+      testbedMissions: [
+        {
+          id: "mission-completed-1",
+          status: "completed",
+          title: "Fresh-agent browser mission",
+          targetUrl: "https://app.averray.com",
+          createdAt: "2026-06-01T22:01:00.000Z",
+          updatedAt: "2026-06-01T22:03:00.000Z",
+          statusReason: "gold path completed",
+          freshMemory: true,
+          allowTestMutations: false,
+          result: {
+            structuredReport: {
+              verdict: "pass",
+              confidence: 0.94,
+              mode: "gold_path",
+              scores: { success: 5, clarity: 4, latency: 4 },
+              blockers: [],
+              confusingMoments: [],
+              mutationBoundaryNotes: ["Read-only mission completed without mutation."],
+              stoppedBeforeMutation: true,
+              completedPath: ["Loaded app shell", "Opened the work lane"],
+              recommendations: ["Keep this as the baseline before changing the page again."],
+              evidence: ["trace: /tmp/mission-completed-1/trace.zip"],
+            },
+          },
+        },
+      ],
+    };
+
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const mission = snap.cards.find((c) => c.correlationId === "mission-completed-1");
+    expect(mission?.lane).toBe("done");
+    expect(mission?.type).toBe("mission");
+    expect(mission?.missionStatus).toBe("completed");
+    expect(mission?.mission?.verdict).toBe("OK");
+    expect(mission?.mission?.target).toBe("https://app.averray.com");
+    expect(mission?.summary).toBe("PASS · gold-path · 0 blockers");
   });
 
   it("names Hermes as working now for a running mission backed by a mission run", () => {


### PR DESCRIPTION
## What changed
- Keep testbed mission cards typed as `mission` even when the classifier places them in the Done lane, so the correlationId -> testbed mission run join resolves.
- Attach the structured mission report to completed cards and project a concise one-line summary like `PASS · gold-path · 0 blockers` onto the card.
- Make the mission drawer fallback honest for finished runs with no structured report: it now says the report is unavailable instead of implying it is still pending.

## Diagnosis
The structured report was already written to `run.result.structuredReport` and mission items already carried `correlationId = run.id`. The live failure was the v2 card type inference: `lane === done` returned a generic `done` card before mission/testbed signals were checked, so enrichment skipped `missionIndex.get(correlationId)` and the drawer rendered generic CLOSED content.

## Checks
- `npm run build`
- `npm test -- test/unit/monitor-v2.test.ts`
- `npm test -- packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx`
- `npm run typecheck`
- `npm test`

## Scope / invariants
- Monitor UI + mapper only.
- No authority change, no auto-actions, no runner behavior change.
- Truth-boundary preserved: no verdict is fabricated; no-report finished runs show explicit coaching text.