### PR TITLE
Polish pass 1: collapse the LLM usage panel to a one-line summary

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -259,9 +259,13 @@ describe("BoardView — rich-mix board (open stream)", () => {
     };
     const { getAllByText, getByRole, getByText, queryByText, queryAllByText } = render(<BoardView board={board} status="open" />);
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
-    // Leads with the headline: total tokens + call count.
+    // Collapsed by default: leads with the headline (total tokens + call count)…
     expect(getByText("59K tokens · 12 calls")).toBeTruthy();
-    // Active source is prominent (also surfaced as the in-flight call).
+    // …and the detail (per-source rows, idle line) is hidden until expanded.
+    expect(queryByText("48K in · 9K out")).toBeNull();
+    expect(queryByText(/source idle/)).toBeNull();
+    // Expand the panel to reveal the active source detail + collapsed idle line.
+    fireEvent.click(getByText("59K tokens · 12 calls"));
     expect(getAllByText("claude · claude-sonnet-4-5").length).toBeGreaterThan(0);
     expect(getByText("59K tokens")).toBeTruthy();
     expect(getByText("48K in · 9K out")).toBeTruthy();
@@ -270,7 +274,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(queryByText("Codex CLI does not report usage.")).toBeNull();
     // No flat per-source "not reported" row.
     expect(queryAllByText("not reported").length).toBe(0);
-    // Expanding reveals the honest reason (truth-boundary preserved).
+    // Expanding the idle line reveals the honest reason (truth-boundary preserved).
     fireEvent.click(getByText(/1 source idle: codex/));
     expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
   });
@@ -295,7 +299,10 @@ describe("BoardView — rich-mix board (open stream)", () => {
 
     const { getByRole, getByText, queryByText } = render(<BoardView board={board} status="open" />);
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
+    // The one-line summary states "usage not reported" honestly without expanding.
     expect(getByText("usage not reported")).toBeTruthy();
+    // The full plain-language explanation is reachable on expand (truth-boundary).
+    fireEvent.click(getByText("usage not reported"));
     expect(getByText(/No LLM usage counters have been recorded yet/)).toBeTruthy();
     expect(queryByText("not_recorded")).toBeNull();
   });

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -634,6 +634,10 @@ function formatClock(iso: string | undefined): string {
 }
 
 function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
+  // Collapsed to a single line by default — the panel used to eat a full band
+  // of vertical space across the board. The headline (total · calls · live)
+  // stays glanceable; per-source detail + idle reasons are one click away.
+  const [expanded, setExpanded] = useState(false);
   const [showIdle, setShowIdle] = useState(false);
   const recorded = usage?.status === "recorded";
   const latestDay = usage?.byDay?.[0];
@@ -644,24 +648,32 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
   const activeCalls = usage?.activeCalls ?? [];
   const emptyMessage = usage?.message
     ?? "No LLM usage counters have been recorded yet. Sources stay not reported until a real provider or runner emits whitelisted counters.";
+  const headline = recorded
+    ? `${formatCompactNumber(usage!.totalTokens)} tokens · ${formatNumber(usage!.runs)} calls`
+    : "usage not reported";
+  const lastLabel = recorded && usage!.lastActiveAt ? `last ${formatRelativeTime(usage!.lastActiveAt)}` : "";
+  // Keep the live signal glanceable without expanding.
+  const flightLabel = activeCalls.length > 0 ? `${activeCalls.length} in flight` : "idle";
 
   return (
     <section className="hm-llm-usage" aria-label="LLM usage">
-      {/* Headline: total tokens · calls, with the window/last-active context. */}
-      <div className="hm-llm-usage-head">
+      {/* One-line summary — leads with the total; the rest is behind the toggle. */}
+      <button
+        type="button"
+        className="hm-llm-usage-summary"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        <span aria-hidden>{expanded ? "▾" : "▸"}</span>
         <span className="hm-kicker">LLM usage</span>
-        <strong className="hm-llm-usage-headline">
-          {recorded
-            ? `${formatCompactNumber(usage!.totalTokens)} tokens · ${formatNumber(usage!.runs)} calls`
-            : "usage not reported"}
-        </strong>
-        {recorded ? (
-          <span className="hm-llm-usage-window">
-            board window{usage!.lastActiveAt ? ` · last ${formatRelativeTime(usage!.lastActiveAt)}` : ""}
-          </span>
-        ) : null}
-      </div>
+        <strong className="hm-llm-usage-headline">{headline}</strong>
+        <span className="hm-llm-usage-summary-meta">
+          {[flightLabel, lastLabel].filter(Boolean).join(" · ")}
+        </span>
+      </button>
 
+      {expanded ? (
+      <div className="hm-llm-usage-detail">
       {/* What's running now (in-flight). */}
       <div className="hm-llm-usage-active">
         <span>What's running now</span>
@@ -730,6 +742,8 @@ function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
       {/* Truth-boundary explanation when nothing reported and no idle list to carry it. */}
       {!recorded && models.length === 0 ? (
         <div className="hm-llm-usage-empty">{emptyMessage}</div>
+      ) : null}
+      </div>
       ) : null}
     </section>
   );

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -450,6 +450,43 @@ body { margin: 0; }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Collapsed-by-default summary: one line (toggle) → detail on expand. */
+.hm-llm-usage-summary {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  text-align: left;
+}
+.hm-llm-usage-summary .hm-kicker {
+  flex: none;
+}
+.hm-llm-usage-summary .hm-llm-usage-headline {
+  font-size: 13px;
+}
+.hm-llm-usage-summary-meta {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hm-muted);
+}
+.hm-llm-usage-detail {
+  display: grid;
+  gap: 9px;
+  margin-top: 9px;
+  padding-top: 9px;
+  border-top: 1px solid var(--hm-line-soft);
+}
+.hm-llm-usage-detail .hm-llm-usage-active,
+.hm-llm-usage-detail .hm-llm-usage-sources {
+  border-top: 0;
+  padding-top: 0;
+}
 /* Compact panel (smart summary): headline + active sources + collapsed idle. */
 .hm-llm-usage-head {
   display: grid;


### PR DESCRIPTION
## What changed & why
First of several polish passes. This one tackles the explicit ask: **the LLM usage panel still uses too much space.** Even after the prior compaction it sat as a full-width band above the lanes (~150px) for what is, at a glance, one number.

Now it **collapses to a single toggle line by default**:
- **Collapsed:** `▸ LLM usage · 59K tokens · 12 calls · … · idle · last 10h` — leads with the total + call count, keeps the live signal glanceable (`N in flight` / `idle`) and last-active, no expansion needed.
- **Expanded:** the existing detail — *what's running now*, per-`(agent, model)` tokens with the in/out bar, and the collapsed idle-sources line (each source's reason one more click away).

Truth-boundary unchanged: `usage not reported` still shows in the collapsed line; the plain-language explanation and each idle source's honest reason stay reachable on expand — they just no longer occupy the board.

## Affected surfaces
- [x] Monitor board / slack-operator (frontend `@avg/monitor-ui` only)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (`@avg/monitor-ui` **529 passed**; both LLM-usage BoardView tests updated for collapse-by-default)
- [ ] docker compose config (no ops change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — presentational only
- [x] No secrets/config/authority changes
- [x] Truth-boundary preserved: nothing hidden — collapsed line stays honest, reasons reachable on expand

## Audit punch-list (for the next runs)
While here I audited every interactive control across the board (top strip, banner, lanes bar, cards, create-task form, drawer, co-pilot rail). Wiring is broadly solid (disabled controls carry honest reasons). The real issues to fix next, in priority order:
1. **Drawer footer primary is wrong for failed/no-PR tasks.** A failed `task` card (`isAction=true`) renders the **"action"** drawer variant whose primary is **"Approve & merge"** — which is disabled (no PR) and semantically wrong for a failed task. It needs a working primary (Send back / Retry / Dismiss). *(P1-3 territory.)*
2. **Operator-review PRs with `isAction=false` mislabel as "Automation in flight"** and show only "Open on github" — no Approve/Send-back, even though they're awaiting the operator's risk decision. `drawerVariant()` keys on `card.isAction`, which isn't set for these.
3. **Failed-task STATUS box uses the green/"ok" verdict block** ("Task failed in the runner." in a sage box) — tone should reflect failure.
These need a small design call on the per-card primary, so I've left them for a focused follow-up rather than guessing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)