### PR TITLE
Polish pass 2: drawer action-variant consistency + failed-task primary

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -412,6 +412,12 @@ export function BoardView({
         onCardClose?.();
         triggerAsk(card.id, card.title ?? card.id);
       },
+      // Triage a stuck/failed card off the board, then close the drawer (the
+      // card is filtered out, so leaving it open would show a stale shell).
+      onDismiss: (card) => {
+        onDismissCard(card);
+        onCardClose?.();
+      },
     };
     if (onRerunMission) {
       a.onRerunMission = (card, freshness) => {
@@ -446,7 +452,7 @@ export function BoardView({
       };
     }
     return a;
-  }, [onRerunMission, onApproveTask, onCreateTask, onCardClose]);
+  }, [onRerunMission, onApproveTask, onCreateTask, onCardClose, onDismissCard]);
 
   return (
     <div className="hm-board">

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
@@ -52,7 +52,9 @@ function githubUrlForCard(card: BoardCard): string | undefined {
 }
 
 function footerHint(key: string): "A" | "B" | undefined {
-  if (key === "approve-merge") return "A";
+  // The action variant's primary is "approve-merge" (PR present) or "dismiss"
+  // (no PR) — they're mutually exclusive, so both take the "A" badge.
+  if (key === "approve-merge" || key === "dismiss") return "A";
   if (key === "send-back-codex") return "B";
   return undefined;
 }

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -19,6 +19,7 @@ import type {
 } from "../../lib/monitor/card-types.js";
 import { humanizeSignalText } from "../../lib/monitor/signal-labels.js";
 import { cleanFailureText } from "../../lib/monitor/mission-failure.js";
+import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
 import { OperatorNotes } from "./OperatorNotes.js";
 
@@ -43,10 +44,16 @@ export const DRAWER_ACCENT: Record<DrawerVariant, DrawerAccent> = {
   pr: { border: "var(--hm-sage)", pill: "hm-pill--ok", label: "Automation in flight" },
 };
 
-/** Pick the drawer variant. isAction wins, then closed, draft, and type. */
+/** Pick the drawer variant. Missions render their report; then any card that
+ *  is awaiting the operator's decision (isAction, or sitting in an
+ *  operator-decision lane) gets the "action" risk-decision treatment — so a
+ *  PR in operator-review no longer mislabels as "Automation in flight". Then
+ *  closed, draft, and type. */
 export function drawerVariant(card: BoardCard): DrawerVariant {
   if (card.type === "mission") return "mission";
   if (card.isAction) return "action";
+  const lane = laneFor(card);
+  if (lane === "operator-review" || lane === "needs-attention") return "action";
   if (card.type === "done") return "done";
   if (card.isDraft) return "draft"; // DraftCard always has isDraft:true; covers PRCards flagged draft too
   if (card.type === "task") return "task";
@@ -86,17 +93,35 @@ export function DrawerBody({ card, variant }: { card: BoardCard; variant: Drawer
 
 // ── Shared building blocks ──────────────────────────────────────────
 
-function VerdictBlock({ head, children, accent }: { head: string; children: React.ReactNode; accent?: string }) {
+function VerdictBlock({
+  head,
+  children,
+  accent,
+  tone,
+}: {
+  head: string;
+  children: React.ReactNode;
+  accent?: string;
+  /** "warn"/"fail" tint the block so a failure doesn't read as the green "ok" box. */
+  tone?: "warn" | "fail";
+}) {
   return (
     <section>
       <div className="hm-section-h" style={accent ? { color: accent } : undefined}>
         {head}
       </div>
-      <div className="hm-verdict-block">
+      <div className={"hm-verdict-block" + (tone ? ` hm-verdict-block--${tone}` : "")}>
         <div className="body">{children}</div>
       </div>
     </section>
   );
+}
+
+/** A card that represents a failure — its status box must not read as green/ok. */
+function isFailureCard(card: BoardCard): boolean {
+  if ("taskStatus" in card && (card as { taskStatus?: string }).taskStatus === "failed") return true;
+  if ("missionStatus" in card && (card as { missionStatus?: string }).missionStatus === "failed") return true;
+  return card.state === "failed-fetch";
 }
 
 /** Render a "+A -B" diff line as colored add/rm spans (matches the design). */
@@ -275,7 +300,9 @@ function PrBody({ card }: { card: BoardCard }) {
       {verdict ? (
         <VerdictBlock head="Hermes verdict">{verdict}</VerdictBlock>
       ) : (
-        <VerdictBlock head="Status">{card.summary || "No additional context yet."}</VerdictBlock>
+        <VerdictBlock head="Status" tone={isFailureCard(card) ? "warn" : undefined}>
+          {card.summary || "No additional context yet."}
+        </VerdictBlock>
       )}
       <ReviewRequestsSection requests={card.reviewRequests} />
       <RiskSignalsSection signals={card.riskSignals} />

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DrawerBody, drawerVariant } from "./DrawerBody.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function card(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "card-1",
+    lane: "hermes-checking",
+    type: "pr",
+    agentType: "codex",
+    title: "Test card",
+    summary: "summary",
+    repo: "depre-dev/agent",
+    freshness: 5,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "agent", tone: "info" },
+    files: [],
+    ...over,
+  } as BoardCard;
+}
+
+describe("drawerVariant — operator-decision lanes get the risk-decision treatment (P1-1/P0)", () => {
+  test("a PR in operator-review (isAction=false) is 'action', not 'pr'/'Automation in flight'", () => {
+    expect(drawerVariant(card({ type: "pr", lane: "operator-review", isAction: false }))).toBe("action");
+  });
+
+  test("a card in needs-attention is 'action'", () => {
+    expect(drawerVariant(card({ type: "pr", lane: "needs-attention", isAction: false }))).toBe("action");
+  });
+
+  test("isAction still wins, missions still render their report", () => {
+    expect(drawerVariant(card({ isAction: true, lane: "hermes-checking" }))).toBe("action");
+    expect(drawerVariant(card({ type: "mission", lane: "needs-attention" }))).toBe("mission");
+  });
+
+  test("a proposed codex task (codex-needed) stays the 'task' variant", () => {
+    expect(drawerVariant(card({ type: "task", lane: "codex-needed", isAction: false }))).toBe("task");
+  });
+
+  test("a plain in-flight PR (hermes-checking) stays 'pr'", () => {
+    expect(drawerVariant(card({ type: "pr", lane: "hermes-checking", isAction: false }))).toBe("pr");
+  });
+});
+
+describe("DrawerBody — a failed status doesn't render as the green 'ok' box (tone)", () => {
+  test("a failed task's Status block carries the warn modifier", () => {
+    const failed = card({ type: "task", taskStatus: "failed", lane: "needs-attention", summary: "Task failed in the runner." });
+    const { container, getByText } = render(<DrawerBody card={failed} variant="action" />);
+    expect(getByText("Task failed in the runner.")).toBeTruthy();
+    expect(container.querySelector(".hm-verdict-block--warn")).toBeTruthy();
+  });
+
+  test("a healthy card's Status block stays the default (no warn tint)", () => {
+    const ok = card({ type: "pr", lane: "operator-review", isAction: false, summary: "Waiting on your review." });
+    const { container } = render(<DrawerBody card={ok} variant="action" />);
+    expect(container.querySelector(".hm-verdict-block--warn")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
@@ -47,7 +47,8 @@ const missionCard = card({
 const actionCard = card({ type: "pr", id: "agent #548", isAction: true });
 const actionCardNoPr = card({ type: "pr", id: "action-no-pr", isAction: true });
 const doneCard = card({ type: "done", id: "rcpt-9", closedAt: "2026-06-01", mergeStatus: "MERGED" });
-const genericPr = card({ type: "pr", id: "agent #12", isAction: false });
+// A plain in-flight PR (NOT in an operator-decision lane) → the "pr" variant.
+const genericPr = card({ type: "pr", id: "agent #12", isAction: false, lane: "hermes-checking" });
 
 function find(buttons: ReturnType<typeof buildDrawerFooter>, key: string) {
   return buttons.find((b) => b.key === key)!;
@@ -110,10 +111,22 @@ describe("buildDrawerFooter — action (PR) variant", () => {
     expect(onApproveAndMerge).toHaveBeenCalledWith(actionCard);
   });
 
-  it("Approve & merge disables when there's no linked PR (no silent no-op)", () => {
-    const f = buildDrawerFooter(actionCardNoPr, { handlers: { onApproveAndMerge: vi.fn() } });
-    expect(find(f, "approve-merge").run).toBeUndefined();
-    expect(find(f, "approve-merge").disabledReason).toMatch(/no linked PR/i);
+  it("no-PR action card has NO dead 'Approve & merge' — it leads with a working 'Dismiss' primary", () => {
+    const onDismiss = vi.fn();
+    const f = buildDrawerFooter(actionCardNoPr, { handlers: { onDismiss } });
+    // The misleading "Approve & merge" is gone entirely (nothing to merge).
+    expect(f.find((b) => b.key === "approve-merge")).toBeUndefined();
+    // The working primary is Dismiss (triage it off the board).
+    const dismiss = find(f, "dismiss");
+    expect(dismiss.kind).toBe("action");
+    dismiss.run!();
+    expect(onDismiss).toHaveBeenCalledWith(actionCardNoPr);
+  });
+
+  it("Dismiss disables with a reason when no handler is wired (no silent no-op)", () => {
+    const f = buildDrawerFooter(actionCardNoPr, {});
+    expect(find(f, "dismiss").run).toBeUndefined();
+    expect(find(f, "dismiss").disabledReason).toMatch(/dismiss/i);
   });
 
   it("Send back to Codex requires a handler AND a PR number", () => {

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
@@ -35,6 +35,8 @@ export interface DrawerActionHandlers {
   onApproveAndMerge?: (card: BoardCard) => void;
   /** Return the item to the codex-needed/dispatch path. */
   onSendBackToCodex?: (card: BoardCard) => void;
+  /** Triage a stuck/failed card off the board (server-persisted dismiss). */
+  onDismiss?: (card: BoardCard) => void;
   /** Focus the co-pilot composer scoped to this card. */
   onAskHermes?: (card: BoardCard) => void;
 }
@@ -118,20 +120,31 @@ export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}):
         : { disabledReason: "Proposing a fix task isn't available here." }),
     });
   } else if (variant === "action") {
-    // Merging needs the SPECIFIC PR (the repo url isn't enough), so this path
-    // requires a resolved pull-request url — never the repo fallback.
+    // The operator's one resolving primary depends on what's actually possible:
+    //   - a card with a real PR → "Approve & merge" (opens GitHub; the board
+    //     NEVER merges — the human merges there, we just record approval);
+    //   - a card with NO PR (e.g. a failed task that can't be merged) → never
+    //     show a dead "Approve & merge"; lead with "Dismiss" to triage it off
+    //     the board, which is the honest resolving action.
     const prUrl = pullRequestUrlForCard(card);
-    buttons.push({
-      key: "approve-merge",
-      label: "Approve & merge",
-      kind: "action",
-      // The board NEVER merges — it opens the GitHub merge UI (human merges)
-      // and records operator approval if that path is wired.
-      ...(prUrl
-        ? { run: () => { openUrl(prUrl); h.onApproveAndMerge?.(card); } }
-        : { disabledReason: "No linked PR to merge on GitHub." }),
-    });
     const hasPr = Boolean(relatedPrForCard(card));
+    if (prUrl) {
+      buttons.push({
+        key: "approve-merge",
+        label: "Approve & merge",
+        kind: "action",
+        run: () => { openUrl(prUrl); h.onApproveAndMerge?.(card); },
+      });
+    } else {
+      buttons.push({
+        key: "dismiss",
+        label: "Dismiss",
+        kind: "action",
+        ...(h.onDismiss
+          ? { run: () => h.onDismiss!(card) }
+          : { disabledReason: "Dismissing isn't available here." }),
+      });
+    }
     buttons.push({
       key: "send-back-codex",
       label: "Send back to Codex",
@@ -139,7 +152,7 @@ export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}):
       // Codex iterates an existing PR, so send-back needs a linked PR number.
       ...(h.onSendBackToCodex && hasPr
         ? { run: () => h.onSendBackToCodex!(card) }
-        : { disabledReason: h.onSendBackToCodex ? "No linked PR to send back to Codex." : "Sending back to Codex isn't available here." }),
+        : { disabledReason: hasPr ? "Sending back to Codex isn't available here." : "No linked PR to send back to Codex." }),
     });
   } else if (variant === "done") {
     buttons.push({

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1896,6 +1896,17 @@ button.hm-turn-pin {
   color: var(--hm-ink-soft);
 }
 .hm-verdict-block .body b { color: var(--hm-ink); font-weight: 600; }
+/* Failure/warn tint — a failed status must not read as the green "ok" box. */
+.hm-verdict-block--warn {
+  background: var(--hm-amber-wash, rgba(176,122,0,0.10));
+  border-color: var(--hm-amber, rgba(176,122,0,0.35));
+}
+.hm-verdict-block--warn .head { color: var(--hm-amber-deep, #8a5d00); }
+.hm-verdict-block--fail {
+  background: var(--hm-rose-wash, rgba(176,0,32,0.08));
+  border-color: var(--hm-rose, rgba(176,0,32,0.30));
+}
+.hm-verdict-block--fail .head { color: var(--hm-rose-deep, #9a1020); }
 
 .hm-checklist {
   display: grid; gap: 6px;


### PR DESCRIPTION
## What changed & why
Second polish pass — the three drawer bugs surfaced by the board review (the two drawer screenshots), all approved for this run.

**#2 — Operator-review PRs mislabeled as "Automation in flight."** `drawerVariant()` keyed only on `card.isAction`, which the server doesn't set for operator-review PRs — so a PR awaiting your risk decision rendered with the sage "Automation in flight" header and only "Open on github". Now any card in an **operator-decision lane** (`operator-review` / `needs-attention`) gets the **"action" risk-decision** variant (Approve & merge / Send back).

**#1 — Failed/no-PR task led with a dead "Approve & merge."** A failed `task` in the action variant showed "Approve & merge" as its primary — disabled (nothing to merge) and semantically wrong, leaving the card with *no working action*. The action footer is now adaptive:
- **PR present** → "Approve & merge" (opens the GitHub merge UI; the board never merges) + "Send back to Codex".
- **No PR** → no dead Approve & merge; lead with **"Dismiss"** — the honest "triage it off the board" primary, wired to the existing server-persisted dismiss (and it closes the drawer). "Send back" stays a disabled ghost with "No linked PR" (there's no real re-dispatch without a PR — not fabricating one).

`DrawerActionHandlers` gains `onDismiss`; `BoardView` wires it to the existing `onDismissCard`.

**#3 — Failed status rendered in the green "ok" box.** `VerdictBlock` gains a `tone`; `PrBody` tints the Status block **warn** for a failed task/mission, so "Task failed in the runner." no longer reads as a positive sage box.

## Affected surfaces
- [x] Monitor board / slack-operator (frontend `@avg/monitor-ui` only)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (`@avg/monitor-ui` **538 passed**; new drawerVariant + warn-tone + adaptive-footer tests; updated the no-PR action-card footer test)
- [ ] docker compose config (no ops change)

## Durable invariants (AGENTS.md)
- [x] **No auto-merge / auto-deploy** — Approve & merge still only opens GitHub + records approval; the board never merges
- [x] **No new ungated authority** — Dismiss reuses the existing server-persisted dismiss; no new endpoint. No real re-dispatch is invented for no-PR cards (send-back stays honestly disabled)
- [x] No secrets/config changes
- [x] Truth-boundary: a failed card now reads as a failure (warn tone), every action card has a *working* primary, and impossible actions are disabled with a reason rather than shown live

## Follow-ups (later runs)
The remaining audit items are smaller polish (top-strip KPI chips are display-only by design; co-pilot suggestion chips wired). Happy to keep going per your steer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)