### PR TITLE
Mission drawer: surface scope/goal + agent narrative + all detail

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -277,6 +277,60 @@ describe("DetailDrawer — variants", () => {
     // no invented attempt count / score row
     expect(queryByText(/run #/)).toBeNull();
     expect(queryByText(/out of 10/)).toBeNull();
+    // a thin report without goal/narrative shows NEITHER section (no padding)
+    expect(queryByText("Scope")).toBeNull();
+    expect(queryByText("What the agent did")).toBeNull();
+  });
+
+  test("mission drawer surfaces scope (goal) + the agent narrative + scored per-step detail", () => {
+    const card = {
+      id: "mission gold-path-12",
+      lane: "hermes-checking",
+      type: "mission",
+      agentType: "hermes",
+      title: "Gold path on app.averray.com",
+      summary: "agent report posted",
+      repo: "depre-dev/site",
+      freshness: 4,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+      mission: {
+        verdict: "OK",
+        verdictTone: "ok",
+        confidence: 0.9,
+        target: "https://app.averray.com/overview",
+        goal: "Complete the claim → submit → verify gold path as a fresh agent.",
+        narrative: "Opened a clean browser context.\nSigned in through the local signer sidecar.\nClaimed task and submitted the receipt.",
+        seed: "fresh · no memory",
+        path: [
+          { n: 1, status: "ok", desc: "Loaded overview", lat: "1.2s" },
+          { n: 2, status: "ok", desc: "Claimed task" },
+        ],
+        blockers: [],
+        evidence: [],
+        mutationBoundary: "Read-only mission — the agent stopped before any mutation.",
+        recommendations: ["Add a confirmation toast after submit"],
+        successScore: 9,
+        clarityScore: 8,
+        latencyScore: 7,
+      },
+    } as unknown as BoardCard;
+    const { getByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    // Scope (goal) leads.
+    expect(getByText("Scope")).toBeTruthy();
+    expect(getByText(/Complete the claim → submit → verify/)).toBeTruthy();
+    // The agent narrative renders as its own readable section, one line per step.
+    expect(getByText("What the agent did")).toBeTruthy();
+    expect(getByText("Signed in through the local signer sidecar.")).toBeTruthy();
+    // Scores render for a scored run.
+    expect(getByText(/out of 10/)).toBeTruthy();
+    // Per-step detail + latency, not just "PASS".
+    expect(getByText("Loaded overview")).toBeTruthy();
+    expect(getByText("1.2s")).toBeTruthy();
+    expect(getByText("Add a confirmation toast after submit")).toBeTruthy();
   });
 
   // Regression: live cards cross an HTTP/JSON boundary and don't always carry

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -522,6 +522,9 @@ function MissionBody({ card }: { card: MissionCard }) {
 
   return (
     <>
+      {m.goal ? (
+        <VerdictBlock head="Scope" accent="var(--hm-hermes-deep)">{m.goal}</VerdictBlock>
+      ) : null}
       <section>
         <div className="hm-section-h">{verdictHead}</div>
         <div className="hm-mission-confidence">
@@ -555,6 +558,21 @@ function MissionBody({ card }: { card: MissionCard }) {
           ) : null}
         </div>
       </section>
+
+      {m.narrative ? (
+        <section>
+          <div className="hm-section-h">What the agent did</div>
+          <div className="hm-mission-narrative">
+            {m.narrative
+              .split("\n")
+              .map((line) => line.trim())
+              .filter(Boolean)
+              .map((line, i) => (
+                <p key={i}>{line}</p>
+              ))}
+          </div>
+        </section>
+      ) : null}
 
       {m.path.length > 0 ? (
         <section>

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -238,6 +238,10 @@ export interface MissionReport {
   latency?: string;
   /** URL under test */
   target: string;
+  /** What the mission was asked to test — surfaced as "Scope" at the top. */
+  goal?: string;
+  /** The agent's "what I tried" trace, newline-separated, as readable text. */
+  narrative?: string;
   /** e.g. "fresh · no memory" */
   seed: string;
   /** Attempt count. Optional — not carried by a live agent report. */

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2372,6 +2372,22 @@ button.hm-turn-pin {
 }
 
 /* Mission path (numbered steps with status) */
+/* "What the agent did" — the agent narrative, one line per step. */
+.hm-mission-narrative {
+  display: grid;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+}
+.hm-mission-narrative p {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--hm-ink-soft);
+}
 .hm-mpath {
   display: grid; gap: 4px;
   border: 1px solid var(--hm-line);

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -208,6 +208,11 @@ export interface CardMissionReport {
   /** 0..1 */
   confidence: number;
   target: string;
+  /** What the mission was asked to test (run.goal) — the operator's "Scope". */
+  goal?: string;
+  /** The agent's "what I tried" trace (newline-separated), pulled out of the
+   *  evidence list so it reads as a narrative rather than a buried trace row. */
+  narrative?: string;
   seed: string;
   path: CardMissionStep[];
   blockers: CardMissionBlocker[];
@@ -1222,6 +1227,9 @@ function isReviewPanelReviewer(value: CardReviewRequest["reviewer"]): value is R
 
 const EVIDENCE_KINDS = new Set(["screenshot", "trace", "console", "video"]);
 
+/** Matches the agent-narrative evidence entry ("what_i_tried: …" / "what i tried: …"). */
+const MISSION_NARRATIVE_RE = /^what[_ ]i[_ ]tried\s*:\s*/i;
+
 /** Parse one structured-report evidence string ("type: detail") into the UI shape. */
 function mapMissionEvidence(raw: string): CardMissionEvidence {
   const match = /^(\w+):\s*(.+)$/.exec(raw.trim());
@@ -1379,15 +1387,27 @@ export function mapMissionReport(run: Record<string, unknown>): CardMissionRepor
   const runs = missionRuns(source);
   const latency = missionLatency(source);
 
+  // The agent's "what I tried" trace is serialized into evidence as a
+  // `what_i_tried: <lines>` entry. Lift it out so it renders as a readable
+  // narrative instead of a buried trace row, and drop it from the evidence list.
+  const narrativeEntry = report.evidence.find((e) => MISSION_NARRATIVE_RE.test(e.trim()));
+  const narrative = narrativeEntry
+    ? narrativeEntry.trim().replace(MISSION_NARRATIVE_RE, "").trim()
+    : undefined;
+  const evidenceForUi = report.evidence.filter((e) => !MISSION_NARRATIVE_RE.test(e.trim()));
+  const goal = asString(run.goal);
+
   return {
     verdict,
     verdictTone,
     confidence: report.confidence,
     target: asString(run.targetUrl) ?? "",
+    ...(goal ? { goal } : {}),
+    ...(narrative ? { narrative } : {}),
     seed: run.freshMemory === false ? "warm memory" : "fresh · no memory",
     path,
     blockers,
-    evidence: report.evidence.map(mapMissionEvidence),
+    evidence: evidenceForUi.map(mapMissionEvidence),
     mutationBoundary: notes ? `${boundaryBase} ${notes}` : boundaryBase,
     recommendations: report.recommendations,
     ...(runs !== undefined ? { runs } : {}),

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1256,6 +1256,32 @@ describe("mapMissionReport", () => {
     expect(m.recommendations).toEqual(["Add a spinner to the Sign-message modal"]);
   });
 
+  it("surfaces the goal as scope and lifts the what_i_tried trace into a narrative", () => {
+    const m = mapMissionReport({
+      ...run,
+      goal: "Test onboarding like a fresh outside agent.",
+      result: {
+        ...run.result,
+        evidence: [
+          "screenshot: https://x.test/step3.png",
+          "what_i_tried: Opened a clean Chromium context.\nClicked Connect wallet.\nStopped before signing.",
+        ],
+      },
+    })!;
+    expect(m.goal).toBe("Test onboarding like a fresh outside agent.");
+    expect(m.narrative).toBe("Opened a clean Chromium context.\nClicked Connect wallet.\nStopped before signing.");
+    // The narrative is lifted OUT of evidence — not double-shown as a trace row.
+    expect(m.evidence).toHaveLength(1);
+    expect(m.evidence.some((e) => /Opened a clean Chromium/.test(e.label))).toBe(false);
+  });
+
+  it("omits goal/narrative when the report doesn't carry them (truth-boundary — no padding)", () => {
+    const m = mapMissionReport(run)!;
+    expect(m.goal).toBeUndefined();
+    expect(m.narrative).toBeUndefined();
+    expect(m.evidence).toHaveLength(2);
+  });
+
   it("maps 0–5 scores to 0–10 by key, omitting unknown ones", () => {
     const m = mapMissionReport(run)!;
     expect(m.successScore).toBe(8); // 4 × 2


### PR DESCRIPTION
## What changed & why
The mission drawer (`MissionBody`) showed verdict/confidence/path/evidence, but the operator couldn't see **what** the mission tested or **why** the verdict landed — the goal was absent and the agent's account ("what I tried") was buried as a generic evidence trace row. The structured report already carries both.

**Server (`monitor-v2.ts` `mapMissionReport`):**
- Populate **`goal`** from `run.goal`.
- Lift the **agent narrative** out of evidence: the runner serializes its `whatITried` trace as a `what_i_tried: <lines>` evidence entry — we extract it into `report.narrative` and **drop it from the evidence list** so it's no longer a buried "trace" row. `CardMissionReport` (and the UI `MissionReport` type) gain `goal` / `narrative`.

**Drawer (`DrawerBody.tsx` `MissionBody`):**
- **"Scope"** block at the **top**, showing the goal.
- **"What the agent did"** section rendering the narrative, one readable line per step.
- scores / blockers / recommendations / mutation-boundary already render whenever present; per-step rows already show desc + status (+ latency) — verified, not "just PASS".

## Truth-boundary
`goal` and `narrative` render **only when the report carries them**. A thin exploration shows its real thin narrative and **no padded sections** — the existing partial-report test now also asserts neither "Scope" nor "What the agent did" appears when absent.

**Accept:** the drawer shows scope/goal + the agent's narrative + every populated section; a scored gold-path run shows scores + per-step detail. ✅

## Affected surfaces
- [x] Monitor board / slack-operator (UI mission drawer + the server mission-report mapper)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (full **1425 passed**; new mapper tests for goal/narrative extraction + evidence removal, new drawer render tests, thin-report negative case)
- [ ] docker compose config (no ops change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — read-only presentation of report data
- [x] No secrets/authority changes
- [x] Truth-boundary upheld: only report-present fields render; the narrative is the agent's real trace, surfaced (not fabricated), and removed from evidence so it isn't double-shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)