### PR TITLE
Mission report: derived conclusion + labeled scores + real per-step status

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -333,6 +333,52 @@ describe("DetailDrawer — variants", () => {
     expect(getByText("Add a confirmation toast after submit")).toBeTruthy();
   });
 
+  test("mission drawer shows the derived conclusion + a labeled score list (suppressing the legacy 3-col)", () => {
+    const card = {
+      id: "mission scored-22",
+      lane: "hermes-checking",
+      type: "mission",
+      agentType: "hermes",
+      title: "Onboarding sweep",
+      summary: "agent report posted",
+      repo: "depre-dev/site",
+      freshness: 5,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+      mission: {
+        verdict: "PARTIAL",
+        verdictTone: "warn",
+        confidence: 0.8,
+        target: "https://staging.averray.com/onboarding",
+        conclusion: "PARTIAL — Sign-message modal latency slowed the claim path.",
+        seed: "fresh · no memory",
+        path: [{ n: 1, status: "ok", desc: "Loaded onboarding" }],
+        blockers: [],
+        evidence: [],
+        mutationBoundary: "Read-only mission — the agent stopped before any mutation.",
+        recommendations: [],
+        scores: [
+          { label: "Success", value: 8 },
+          { label: "Clarity", value: 6 },
+        ],
+        // legacy fixed scores also present — must NOT render once the list is shown
+        successScore: 8,
+        clarityScore: 6,
+      },
+    } as unknown as BoardCard;
+    const { getByText, queryByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
+    );
+    expect(getByText("Conclusion")).toBeTruthy();
+    expect(getByText("PARTIAL — Sign-message modal latency slowed the claim path.")).toBeTruthy();
+    // Labeled score list renders…
+    expect(getByText("Success")).toBeTruthy();
+    expect(getByText("8/10")).toBeTruthy();
+    // …and the fixed "success · clarity · latency" column is suppressed (no double-show).
+    expect(queryByText(/success · clarity · latency/i)).toBeNull();
+  });
+
   // Regression: live cards cross an HTTP/JSON boundary and don't always carry
   // the type-required nested objects (the backend doesn't populate deploy
   // `verification` or a mission `mission` report yet). The drawer must render,

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -516,14 +516,28 @@ function MissionBody({ card }: { card: MissionCard }) {
     "Verdict" +
     (m.runs !== undefined ? ` · run #${m.runs}` : "") +
     (m.latency ? ` · ${m.latency}` : "");
+  // When the report carries a full labeled score list, show that (in its own
+  // section) and drop the fixed success/clarity/latency column to avoid showing
+  // the same numbers twice.
+  const hasGenericScores = (m.scores?.length ?? 0) > 0;
   const hasScores =
-    m.successScore !== undefined || m.clarityScore !== undefined || m.latencyScore !== undefined;
+    !hasGenericScores &&
+    (m.successScore !== undefined || m.clarityScore !== undefined || m.latencyScore !== undefined);
   const fmtScore = (n: number | undefined) => (n === undefined ? "—" : String(n));
 
   return (
     <>
       {m.goal ? (
         <VerdictBlock head="Scope" accent="var(--hm-hermes-deep)">{m.goal}</VerdictBlock>
+      ) : null}
+      {m.conclusion ? (
+        <VerdictBlock
+          head="Conclusion"
+          accent={verdictColor}
+          tone={m.verdictTone === "fail" ? "fail" : m.verdictTone === "warn" ? "warn" : undefined}
+        >
+          {m.conclusion}
+        </VerdictBlock>
       ) : null}
       <section>
         <div className="hm-section-h">{verdictHead}</div>
@@ -558,6 +572,23 @@ function MissionBody({ card }: { card: MissionCard }) {
           ) : null}
         </div>
       </section>
+
+      {hasGenericScores ? (
+        <section>
+          <div className="hm-section-h">Scores · out of 10</div>
+          <div className="hm-checklist">
+            {m.scores!.map((score) => (
+              <div className="row" key={score.label}>
+                <span className="box" style={{ borderColor: "var(--hm-hermes)", color: "transparent" }}>
+                  ✓
+                </span>
+                <span>{score.label}</span>
+                <span className="hint">{score.value}/10</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {m.narrative ? (
         <section>

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -229,6 +229,12 @@ export interface MissionEvidence {
   href: string;
 }
 
+/** One labeled 0..10 score from the structured report (beyond the fixed three). */
+export interface MissionScore {
+  label: string;
+  value: number;
+}
+
 export interface MissionReport {
   verdict: "OK" | "PARTIAL" | "FAILED";
   verdictTone: "ok" | "warn" | "fail";
@@ -242,6 +248,10 @@ export interface MissionReport {
   goal?: string;
   /** The agent's "what I tried" trace, newline-separated, as readable text. */
   narrative?: string;
+  /** One-line "VERDICT — why" conclusion derived from the report. */
+  conclusion?: string;
+  /** All labeled scores the report carried (0..10), beyond the fixed three. */
+  scores?: MissionScore[];
   /** e.g. "fresh · no memory" */
   seed: string;
   /** Attempt count. Optional — not carried by a live agent report. */

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -197,6 +197,10 @@ export interface CardMissionBlocker {
   head: string;
   body?: string;
 }
+export interface CardMissionScore {
+  label: string;
+  value: number;
+}
 export interface CardMissionEvidence {
   kind: "screenshot" | "trace" | "console" | "video";
   label: string;
@@ -213,6 +217,10 @@ export interface CardMissionReport {
   /** The agent's "what I tried" trace (newline-separated), pulled out of the
    *  evidence list so it reads as a narrative rather than a buried trace row. */
   narrative?: string;
+  /** One-line "VERDICT — why" conclusion derived from the report. */
+  conclusion?: string;
+  /** All labeled scores the report carried (0..10), beyond the fixed three. */
+  scores?: CardMissionScore[];
   seed: string;
   path: CardMissionStep[];
   blockers: CardMissionBlocker[];
@@ -1306,6 +1314,57 @@ function missionStepDesc(source: Record<string, unknown>, index: number, fallbac
     ?? (fallback === "[object Object]" ? "Step recorded by browser agent" : fallback);
 }
 
+/** Real per-step status when the report carries one; defaults to "ok" (a
+ *  completed step) rather than inventing a pass/fail the data doesn't have. */
+function missionStepStatus(source: Record<string, unknown>, index: number): CardMissionStep["status"] {
+  const step = reportArrayEntry(source, "completedPath", index)
+    ?? reportArrayEntry(source, "path", index)
+    ?? reportArrayEntry(source, "steps", index)
+    ?? reportArrayEntry(source, "completedSteps", index);
+  const raw = firstString(step?.status, step?.verdict, step?.outcome, step?.state)?.toLowerCase();
+  if (!raw) return "ok";
+  if (/\b(fail|failed|error|blocked|blocker)\b/.test(raw)) return "fail";
+  if (/\b(warn|partial|slow|skip|skipped|pending)\b/.test(raw)) return "warn";
+  return "ok";
+}
+
+/** Humanize a score key ("success_rate" → "Success Rate"). */
+function missionScoreLabel(key: string): string {
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .trim()
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+/** Every labeled score the report carried, mapped 0..5 → 0..10. */
+function missionScoreList(scores: Record<string, number>): CardMissionScore[] {
+  return Object.entries(scores)
+    .filter(([, value]) => Number.isFinite(value))
+    .map(([key, value]) => ({ label: missionScoreLabel(key), value: Math.round(value * 2) }));
+}
+
+/** A one-line "VERDICT — why" conclusion derived from the report's own fields. */
+function missionConclusion(
+  report: ReturnType<typeof testbedMissionStructuredReport>,
+  source: Record<string, unknown>,
+): string | undefined {
+  if (!report) return undefined;
+  const verdict = report.verdict === "pass" ? "OK" : report.verdict === "partial" ? "PARTIAL" : "FAIL";
+  const detail = report.verdict === "pass"
+    ? firstString(source.conclusion, source.summary, report.summary, report.recommendations[0])
+    : firstString(
+      report.blockers[0],
+      report.confusingMoments[0],
+      report.recommendations[0],
+      source.conclusion,
+      source.summary,
+      report.summary,
+    );
+  const cleaned = detail ? detail.replace(/^(pass|partial|fail|failed|ok)\s*:\s*/i, "").trim() : "";
+  return cleaned ? `${verdict} — ${cleaned}` : undefined;
+}
+
 function missionBlockerHead(source: Record<string, unknown>, key: "blockers" | "confusingMoments", index: number, fallback: string): string {
   const entry = reportArrayEntry(source, key, index);
   return firstString(entry?.head, entry?.title, entry?.summary, entry?.label, entry?.message)
@@ -1361,7 +1420,7 @@ export function mapMissionReport(run: Record<string, unknown>): CardMissionRepor
     const lat = missionStepLatency(source, i);
     return {
       n: i + 1,
-      status: "ok" as const,
+      status: missionStepStatus(source, i),
       desc: missionStepDesc(source, i, desc),
       ...(lat ? { lat } : {}),
     };
@@ -1396,6 +1455,8 @@ export function mapMissionReport(run: Record<string, unknown>): CardMissionRepor
     : undefined;
   const evidenceForUi = report.evidence.filter((e) => !MISSION_NARRATIVE_RE.test(e.trim()));
   const goal = asString(run.goal);
+  const conclusion = missionConclusion(report, source);
+  const scores = missionScoreList(report.scores);
 
   return {
     verdict,
@@ -1404,6 +1465,8 @@ export function mapMissionReport(run: Record<string, unknown>): CardMissionRepor
     target: asString(run.targetUrl) ?? "",
     ...(goal ? { goal } : {}),
     ...(narrative ? { narrative } : {}),
+    ...(conclusion ? { conclusion } : {}),
+    ...(scores.length > 0 ? { scores } : {}),
     seed: run.freshMemory === false ? "warm memory" : "fresh · no memory",
     path,
     blockers,

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -1282,6 +1282,33 @@ describe("mapMissionReport", () => {
     expect(m.evidence).toHaveLength(2);
   });
 
+  it("derives a one-line conclusion and a labeled score list, and reads real per-step status", () => {
+    const m = mapMissionReport({
+      ...run,
+      result: { ...run.result, steps: [{ status: "ok" }, { status: "fail" }] },
+    })!;
+    // "VERDICT — why" from the verdict + the top blocker.
+    expect(m.conclusion).toBe("PARTIAL — Sign-message modal latency");
+    // Every reported score, humanized + mapped 0..5 → 0..10.
+    expect(m.scores).toEqual([
+      { label: "Success", value: 8 },
+      { label: "Clarity", value: 6 },
+      { label: "Latency", value: 10 },
+    ]);
+    // Real per-step status, not a hardcoded "ok".
+    expect(m.path.map((s) => s.status)).toEqual(["ok", "fail"]);
+  });
+
+  it("omits the labeled score list when the report carries no scores (no padding)", () => {
+    const m = mapMissionReport({
+      id: "m2",
+      targetUrl: "https://x.test",
+      result: { verdict: "pass", confidence: 0.9, completedPath: ["Loaded"] },
+    })!;
+    expect(m.scores).toBeUndefined();
+    expect(m.path[0]!.status).toBe("ok"); // completed step, no invented fail
+  });
+
   it("maps 0–5 scores to 0–10 by key, omitting unknown ones", () => {
     const m = mapMissionReport(run)!;
     expect(m.successScore).toBe(8); // 4 × 2


### PR DESCRIPTION
## What changed & why
**Salvages the genuinely-additive pieces from the parallel #389** (`codex/p0b-mission-report-detail`) on top of the already-merged #388 — without re-introducing the goal/narrative/Scope work #388 shipped. (#389 is being closed as superseded; it duplicated most of #388 plus these three extras.)

- **`conclusion`** — a one-line **"VERDICT — why"** derived from the report's own verdict + top blocker / recommendation / summary (`missionConclusion`). Renders as a tone-matched **"Conclusion"** block under Scope.
- **`scores`** — **every labeled score** the report carried (mapped 0..5 → 0..10), not just the fixed success/clarity/latency. Renders as a **"Scores · out of 10"** section; the legacy 3-score column is suppressed when the list is present (no double-show).
- **real per-step status** — `missionStepStatus` reads each step's actual `status`/`verdict`/`outcome` (fail/warn/ok) instead of the hardcoded `"ok"`. This closes the **per-step follow-up I flagged on #388**. Defaults to `"ok"` (a completed step) when the report carries no status, so nothing is invented.

## Truth-boundary
- `conclusion` is **derived from real report fields**, never fabricated.
- `scores` render **only when reported** (omitted otherwise — no padding).
- per-step status **never invents a fail** — absent status → "ok" (the step completed).

## Provenance
This reconciles a duplicate-work collision: Codex (#389, P0b) and I (#388, the CLAUDE mission-report task) implemented the same feature in parallel; #388 merged first. Per the operator's call, #389 is closed as superseded and its unique delta lands here as a clean Claude PR on top of main.

## Affected surfaces
- [x] Monitor board / slack-operator (mission-report mapper + drawer)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (full **1428 passed**; new mapper tests for conclusion/scores/per-step status, new drawer test for the Conclusion block + labeled scores + legacy-column suppression)
- [ ] docker compose config (no ops change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — read-only presentation of report data
- [x] No secrets/authority changes
- [x] Truth-boundary upheld (derived-not-faked conclusion; scores only when present; no invented step failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)