### PR TITLE
Polish: stop long ids/text leaking out of cards and the rail

### DIFF
--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -966,7 +966,10 @@ body { margin: 0; }
   font-size: 11px;
   color: var(--hm-muted);
   display: inline-flex; align-items: center; gap: 5px;
-  flex-shrink: 0;
+  /* Long correlation ids must truncate, not spill past the card edge. */
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
 }
 .hm-card-id .agent-dot {
   width: 6px; height: 6px; border-radius: 999px;
@@ -982,6 +985,13 @@ body { margin: 0; }
   font-weight: 600;
   color: var(--hm-ink);
   letter-spacing: 0 !important;
+  /* The id is the long part — it shrinks and ellipsizes; the dot + agent
+   *  label stay intact. */
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hm-card-fresh {
@@ -1006,6 +1016,8 @@ body { margin: 0; }
   line-height: 1.4;
   color: var(--hm-ink);
   text-wrap: pretty;
+  /* Break long unbreakable tokens (urls, ids, branches) instead of leaking. */
+  overflow-wrap: anywhere;
 }
 .hm-card--action .hm-card-title {
   font-weight: 700;
@@ -1017,6 +1029,9 @@ body { margin: 0; }
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--hm-muted);
+  /* Long repo/branch/url tokens break to the next line, never past the edge. */
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 .hm-card-meta .sep { color: var(--hm-muted-soft); }
 .hm-card-meta .repo { color: var(--hm-ink-soft); }
@@ -1657,7 +1672,8 @@ button.hm-activity-row:hover {
 /* Pinned context card inside a Hermes turn */
 .hm-turn-pin {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  /* id (flex + truncates) · title · arrow — the long id must not widen the rail. */
+  grid-template-columns: minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 9px;
   padding: 8px 10px;
@@ -1679,6 +1695,10 @@ button.hm-turn-pin {
   font-family: var(--font-mono);
   font-size: 10.5px;
   color: var(--hm-muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .hm-turn-pin .pin-title {
   font-weight: 600;


### PR DESCRIPTION
## What changed & why
Long unbreakable strings (correlation ids, repos, branches, urls) were spilling **past their panel edges** — visible on the board as card ids like `codex-task-testbed-mission-new-…-2oexod` running off the card, and the co-pilot rail pin widening past the rail. The containers couldn't shrink or truncate.

- **Card header id** (`.hm-card-id`) — was `flex-shrink: 0`, so the full id ran past the card edge. Now the id span shrinks (`min-width: 0`) and the id `<strong>` **ellipsizes**; the agent dot + label stay intact. *(Also fixes `DegradedCard`, which shares the class.)*
- **Co-pilot rail pin** (`.hm-turn-pin`) — the id sat in an `auto` grid track that widened the whole rail. Now it's a `minmax(0, 1fr)` track and `.pin-id` ellipsizes, so the pin stays inside the rail.
- **Defensive wrapping** — `.hm-card-title` and `.hm-card-meta` get `overflow-wrap: anywhere`, so a raw URL / long branch wraps **inside** the card instead of leaking.

**CSS-only** — no markup or logic change.

## Affected surfaces
- [x] Monitor board / slack-operator (frontend `@avg/monitor-ui` styles only)

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (`@avg/monitor-ui` **540 passed** — unchanged; CSS-only)
- [x] `@avg/monitor-ui` vite build clean
- [ ] docker compose config (no ops change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — pure styling
- [x] No secrets/authority/data changes
- [x] Truth-boundary unaffected — text is clipped/wrapped, never hidden in a way that changes meaning (ids ellipsize with the full value still in the DOM/title)

## Notes / follow-ups
Focused on the two confirmed leaks from the screenshot (card id, rail pin) plus defensive title/meta wrapping. If more leaks show up (e.g. the tester-run/agent-discussion blocks in Done cards, or the "Jump to <id>" banner button on a narrow viewport), send a screenshot and I'll guard those too — they're the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)