### PR TITLE
feat: publish tester ready inventory

### DIFF
--- a/docs/HERMES_TESTER_UX.md
+++ b/docs/HERMES_TESTER_UX.md
@@ -115,7 +115,7 @@ How a product-repo (external) agent discovers what the tester can do, sees what'
    - `surface_sweep` · read_only · `available`
    - `authed_surface_sweep` · read_only · `available` | `ready_needs_session` (tells the agent if the T2 session is wired)
    - `siwe_auth` · read_only
-   - `gold_path` · testbed_mutation_only · `available_live_driver` | `available_fake_default` (tells the agent if the real driver is on)
+   - `gold_path` · testbed_mutation_only · `available_live_driver` | `ready_needs_live_driver` (tells the agent if the real driver is on)
    The `status` field is the truth-boundary — it never advertises a capability that isn't actually runnable.
 2. **REQUEST** — POST a mission with `initialStatus: "requested"` + `requesterAgent` + `requestReason` → it parks as a `requested` card. **External agents REQUEST, they cannot RUN** — the security boundary.
 3. **APPROVE** — the requested card appears on the board; the operator approves (`/approve`) or dismisses. The human decides whether to spend the run. (A future trust policy could auto-approve low-risk read-only requests.)

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -719,6 +719,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     }
     writeJson(response, 200, buildTesterCapabilitiesManifest({
       runner: readTestbedMissionRunnerHeartbeat() ?? null,
+      missionRuns: listTestbedMissionRuns({ limit: 50 }),
     }));
     return;
   }

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -1,10 +1,33 @@
-import type { TestbedMissionRunnerHeartbeat } from "./monitor-testbed-missions.js";
+import type {
+  TestbedMissionMode,
+  TestbedMissionRun,
+  TestbedMissionRunnerHeartbeat,
+  TestbedMissionVerdict,
+} from "./monitor-testbed-missions.js";
+import { resolveTestbedMutationBinding, type TestbedMissionEnvironment, type TestbedMissionMutationMode } from "./testbed-mutation-binding.js";
 import { isSweepSessionConfigured, parseSweepSessionConfig } from "./testbed-session.js";
 
 export interface TesterCapabilitiesDeps {
   now?: Date;
   env?: Record<string, string | undefined>;
   runner?: TestbedMissionRunnerHeartbeat | null;
+  missionRuns?: TestbedMissionRun[];
+  savedSuites?: TesterSavedSuite[];
+}
+
+export interface TesterSavedSuite {
+  id?: string;
+  name: string;
+  flow: string;
+  target: string;
+  status?: "available" | "unavailable";
+  lastRun?: TesterInventoryLastRun;
+}
+
+export interface TesterInventoryLastRun {
+  missionId?: string;
+  verdict: TestbedMissionVerdict | "requested" | "ready" | "running" | "failed" | "unknown";
+  at: string;
 }
 
 export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {}) {
@@ -12,7 +35,9 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
   const now = deps.now ?? new Date();
   const runnerEnabled = truthy(env.TESTBED_MISSION_RUNNER_ENABLED);
   const signerEnabled = truthy(env.TEST_WALLET_SIGNER_ENABLED);
-  const runnerExecutor = env.TESTBED_MISSION_RUNNER_EXECUTOR || "playwright";
+  const runnerExecutor = runnerExecutorMode(env);
+  const runnerConfigured = runnerExecutor === "command" ? Boolean(env.TESTBED_MISSION_RUNNER_COMMAND?.trim()) : true;
+  const runnerReady = runnerEnabled && runnerConfigured;
   const goldPathLive = truthy(env.TESTBED_GOLDPATH_LIVE);
   const goldPathAutonomy = truthy(env.TESTBED_GOLDPATH_AUTONOMY_ENABLED);
   const missionEnvironment = env.TESTBED_MISSION_ENVIRONMENT || env.AVERRAY_TESTBED_ENVIRONMENT || "inferred_from_target_url";
@@ -20,6 +45,123 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
   // sweep is genuinely available once a session SOURCE is configured (the
   // signer sidecar URL, or a manual storageState path / token).
   const sessionConfigured = isSweepSessionConfigured(parseSweepSessionConfig(env as NodeJS.ProcessEnv));
+  const goldPathSessionConfigured = sessionConfigured || Boolean(env.TEST_WALLET_SIGNER_BASE_URL?.trim());
+  const runnerUnavailableStatus = !runnerEnabled ? "unavailable_runner_disabled" : "unavailable_runner_misconfigured";
+  const basicFlowStatus = runnerReady ? "available" : runnerUnavailableStatus;
+  const authedSweepStatus = !runnerReady
+    ? runnerUnavailableStatus
+    : sessionConfigured
+      ? "available"
+      : "ready_needs_session";
+  const siweStatus = !runnerReady
+    ? runnerUnavailableStatus
+    : signerEnabled
+      ? "available"
+      : "planned";
+  const goldPathStatus = !runnerReady
+    ? runnerUnavailableStatus
+    : !goldPathLive
+      ? "ready_needs_live_driver"
+      : goldPathSessionConfigured
+        ? "available_live_driver"
+        : "ready_needs_session";
+  const missionRuns = deps.missionRuns ?? [];
+  const missionTypes = [
+    {
+      id: "surface_sweep",
+      status: basicFlowStatus,
+      tier: 1,
+      scope: "read_only",
+      mutation: "never",
+      supportedEnvs: ["local", "preview", "testnet", "mainnet-read-only"],
+      request: {
+        body: {
+          mode: "surface_sweep",
+          targetUrl: "https://app-or-site.example",
+          routes: ["/", "/jobs", "/agents"],
+          requester: "agent-name",
+        },
+      },
+      evidence: ["http status", "screenshots", "trace", "video", "visible text", "console errors", "network failures", "artifact manifest"],
+      result: "structured mission report with verdict, scores, blockers, findings, and evidence links",
+    },
+    {
+      id: "targeted_read_only",
+      status: basicFlowStatus,
+      tier: 1,
+      scope: "read_only",
+      mutation: "stop_before_mutation",
+      supportedEnvs: ["local", "preview", "testnet", "mainnet-read-only"],
+      request: {
+        body: {
+          targetUrl: "https://app-or-site.example/path",
+          goal: "Inspect the changed route like a new outside agent; stop before mutation.",
+          allowTestMutations: false,
+          requester: "agent-name",
+        },
+      },
+      evidence: ["http status", "screenshots", "trace", "video", "visible text", "console errors", "network failures", "artifact manifest", "baseline comparison when available"],
+      result: "structured mission report with verdict, blockers, confusing moments, mutation boundary notes, and evidence links",
+    },
+    {
+      id: "authed_surface_sweep",
+      status: authedSweepStatus,
+      tier: 1,
+      scope: "read_only",
+      mutation: "never",
+      supportedEnvs: ["testnet", "mainnet-read-only"],
+      request: {
+        body: {
+          mode: "surface_sweep",
+          targetUrl: "https://app.example",
+          requester: "agent-name",
+        },
+      },
+      note: sessionConfigured
+        ? "Runner session injection (T2) is wired and a session source is configured: the sweep covers the authed operator pages (overview/runs/sessions/receipts/treasury/disputes/policies/agents/audit-log/capabilities) and applies the boundary-honesty check there. Read-only."
+        : "Runner session injection (T2) is wired; set a session source on the runner (TESTBED_SESSION_SIGNER_URL via the T3 sidecar, or a manual TESTBED_SESSION_STORAGE_STATE_PATH/TOKEN). Until then the sweep runs public-only.",
+    },
+    {
+      id: "siwe_auth_role_gating",
+      status: siweStatus,
+      tier: 1,
+      scope: "read_only",
+      mutation: "never",
+      supportedEnvs: ["testnet"],
+      dependsOn: ["T3 signer sidecar"],
+      request: {
+        body: {
+          mode: "siwe_auth",
+          targetUrl: env.AVERRAY_API_BASE_URL || "https://api.testnet.example",
+          goal: "Verify SIWE sessions for agent/admin/verifier and prove wrong-role requests are rejected.",
+          requester: "agent-name",
+        },
+      },
+      evidence: ["JWT role claims by role", "agent -> admin 403 missing_role", "agent -> verifier 403", "no token -> wallet_sign_in"],
+      result: "structured mission report with per-check findings and no token/key material",
+    },
+    {
+      id: "gold_path",
+      status: goldPathStatus,
+      tier: 2,
+      scope: "testbed_mutation_only",
+      mutation: "testnet-only, never mainnet (T5 env->mutation binding; mainnet is structurally read-only)",
+      supportedEnvs: ["local", "testnet", "staging"],
+      dependsOn: ["T3 signer sidecar", "T5 env-to-mutation binding"],
+      request: {
+        body: {
+          mode: "gold_path",
+          targetUrl: "https://app.testnet.example",
+          goal: "Attempt the agent gold path (onboard -> claim -> submit -> verify -> payout/SBT -> receipt) and judge honestly.",
+          allowTestMutations: true,
+          requester: "agent-name",
+        },
+      },
+      note: goldPathLive
+        ? `T4: the live Claude + Playwright-MCP gold-path driver is enabled. Operator-scheduled/per-deploy gold-path runs ${goldPathAutonomy ? "auto-run within TESTBED_GOLDPATH_* spend/safety caps" : "need TESTBED_GOLDPATH_AUTONOMY_ENABLED=1 plus budget caps before mutating"}; external agent requests still use the T6 request->approve gate. It uses the T3 signer sidecar for sessions and obeys T5 mutation binding (mainnet read-only).`
+        : "T4: the live Claude + Playwright-MCP driver is wired but disabled by default. Until TESTBED_GOLDPATH_LIVE=1, the runner emits an honest \"not executed\" report rather than a fake pass.",
+    },
+  ];
 
   return {
     schemaVersion: 1,
@@ -62,6 +204,7 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
     runtime: {
       runnerEnabled,
       runnerExecutor,
+      runnerConfigured,
       missionEnvironment,
       evidenceCapture: {
         trace: env.TESTBED_MISSION_CAPTURE_TRACE === "0" || env.TESTBED_MISSION_CAPTURE_TRACE === "false" ? "disabled" : "enabled",
@@ -81,102 +224,14 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
       haltFile: "all runners remain subject to HALT_FILE",
       privateContextRule: "browser missions must use page-visible evidence, not private repo or monitor internals",
     },
-    missionTypes: [
-      {
-        id: "surface_sweep",
-        status: "available",
-        tier: 1,
-        scope: "read_only",
-        mutation: "never",
-        supportedEnvs: ["local", "preview", "testnet", "mainnet-read-only"],
-        request: {
-          body: {
-            mode: "surface_sweep",
-            targetUrl: "https://app-or-site.example",
-            routes: ["/", "/jobs", "/agents"],
-            requester: "agent-name",
-          },
-        },
-        evidence: ["http status", "screenshots", "trace", "video", "visible text", "console errors", "network failures", "artifact manifest"],
-        result: "structured mission report with verdict, scores, blockers, findings, and evidence links",
-      },
-      {
-        id: "targeted_read_only",
-        status: "available",
-        tier: 1,
-        scope: "read_only",
-        mutation: "stop_before_mutation",
-        supportedEnvs: ["local", "preview", "testnet", "mainnet-read-only"],
-        request: {
-          body: {
-            targetUrl: "https://app-or-site.example/path",
-            goal: "Inspect the changed route like a new outside agent; stop before mutation.",
-            allowTestMutations: false,
-            requester: "agent-name",
-          },
-        },
-        evidence: ["http status", "screenshots", "trace", "video", "visible text", "console errors", "network failures", "artifact manifest", "baseline comparison when available"],
-        result: "structured mission report with verdict, blockers, confusing moments, mutation boundary notes, and evidence links",
-      },
-      {
-        id: "authed_surface_sweep",
-        status: sessionConfigured ? "available" : "ready_needs_session",
-        tier: 1,
-        scope: "read_only",
-        mutation: "never",
-        supportedEnvs: ["testnet", "mainnet-read-only"],
-        request: {
-          body: {
-            mode: "surface_sweep",
-            targetUrl: "https://app.example",
-            requester: "agent-name",
-          },
-        },
-        note: sessionConfigured
-          ? "Runner session injection (T2) is wired and a session source is configured: the sweep covers the authed operator pages (overview/runs/sessions/receipts/treasury/disputes/policies/agents/audit-log/capabilities) and applies the boundary-honesty check there. Read-only."
-          : "Runner session injection (T2) is wired; set a session source on the runner (TESTBED_SESSION_SIGNER_URL via the T3 sidecar, or a manual TESTBED_SESSION_STORAGE_STATE_PATH/TOKEN). Until then the sweep runs public-only.",
-      },
-      {
-        id: "siwe_auth_role_gating",
-        status: signerEnabled ? "available" : "planned",
-        tier: 1,
-        scope: "read_only",
-        mutation: "never",
-        supportedEnvs: ["testnet"],
-        dependsOn: ["T3 signer sidecar"],
-        request: {
-          body: {
-            mode: "siwe_auth",
-            targetUrl: env.AVERRAY_API_BASE_URL || "https://api.testnet.example",
-            goal: "Verify SIWE sessions for agent/admin/verifier and prove wrong-role requests are rejected.",
-            requester: "agent-name",
-          },
-        },
-        evidence: ["JWT role claims by role", "agent -> admin 403 missing_role", "agent -> verifier 403", "no token -> wallet_sign_in"],
-        result: "structured mission report with per-check findings and no token/key material",
-      },
-      {
-        id: "gold_path",
-        status: goldPathLive ? "available_live_driver" : "available_fake_default",
-        tier: 2,
-        scope: "testbed_mutation_only",
-        mutation: "testnet-only, never mainnet (T5 env→mutation binding; mainnet is structurally read-only)",
-        supportedEnvs: ["local", "testnet", "staging"],
-        dependsOn: ["T3 signer sidecar", "T5 env-to-mutation binding"],
-        request: {
-          body: {
-            mode: "gold_path",
-            targetUrl: "https://app.testnet.example",
-            goal: "Attempt the agent gold path (onboard → claim → submit → verify → payout/SBT → receipt) and judge honestly.",
-            allowTestMutations: true,
-            requester: "agent-name",
-          },
-        },
-        note: goldPathLive
-          ? `T4: the live Claude + Playwright-MCP gold-path driver is enabled. Operator-scheduled/per-deploy gold-path runs ${goldPathAutonomy ? "auto-run within TESTBED_GOLDPATH_* spend/safety caps" : "need TESTBED_GOLDPATH_AUTONOMY_ENABLED=1 plus budget caps before mutating"}; external agent requests still use the T6 request→approve gate. It uses the T3 signer sidecar for sessions and obeys T5 mutation binding (mainnet read-only).`
-          : "T4: the live Claude + Playwright-MCP driver is wired but disabled by default. Until TESTBED_GOLDPATH_LIVE=1, the runner emits an honest \"not executed\" report rather than a fake pass.",
-      },
-    ],
+    missionTypes,
+    inventory: buildReadyToTestInventory({
+      env,
+      missionRuns,
+      missionTypes,
+      savedSuites: deps.savedSuites ?? [],
+      runnerReady,
+    }),
     approvalGate: {
       agentRequestedRuns: "external-agent requests use /monitor/testbed-missions/request and land as requested; runners ignore them until operator approval",
       currentEnforcement: "POST /monitor/testbed-missions still creates ready operator missions; POST /monitor/testbed-missions/{id}/approve is the T6 requested -> ready gate",
@@ -202,4 +257,189 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
 
 function truthy(value: string | undefined): boolean {
   return value === "1" || value === "true";
+}
+
+function runnerExecutorMode(env: Record<string, string | undefined>): "playwright" | "command" {
+  const normalized = env.TESTBED_MISSION_RUNNER_EXECUTOR?.trim().toLowerCase();
+  if (normalized === "command" || normalized === "external") return "command";
+  if (normalized === "playwright" || normalized === "browser" || normalized === "real-browser") return "playwright";
+  return env.TESTBED_MISSION_RUNNER_COMMAND?.trim() ? "command" : "playwright";
+}
+
+function buildReadyToTestInventory(input: {
+  env: Record<string, string | undefined>;
+  missionRuns: TestbedMissionRun[];
+  missionTypes: Array<{ id: string; status: string; scope: string; mutation: string }>;
+  savedSuites: TesterSavedSuite[];
+  runnerReady: boolean;
+}) {
+  const missionTypesById = new Map(input.missionTypes.map((flow) => [flow.id, flow]));
+  const recentRuns = input.missionRuns
+    .slice()
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .slice(0, 20)
+    .map((run) => ({
+      id: run.id,
+      name: run.title,
+      flow: missionFlowId(run),
+      target: run.targetUrl,
+      status: run.status,
+      environment: run.environment,
+      mutationMode: run.mutationMode,
+      lastRun: lastRunFromMission(run),
+    }));
+
+  return {
+    status: input.runnerReady ? "ready" : "not_ready",
+    savedSuitesAvailable: input.savedSuites.length > 0,
+    savedSuitesStore: input.savedSuites.length > 0 ? "provided" : "not_wired",
+    savedSuites: input.savedSuites.map((suite) => {
+      const flow = missionTypesById.get(suite.flow);
+      const lastRun = suite.lastRun ?? lastRunForSuite(suite, input.missionRuns);
+      return {
+        ...suite,
+        status: suite.status ?? (flow?.status === "available" || flow?.status === "available_live_driver" ? "available" : "unavailable"),
+        flowStatus: flow?.status ?? "unknown_flow",
+        ...(lastRun ? { lastRun } : {}),
+      };
+    }),
+    recentRuns,
+    targets: buildTargetInventory(input.env, input.missionRuns),
+  };
+}
+
+function buildTargetInventory(env: Record<string, string | undefined>, missionRuns: TestbedMissionRun[]) {
+  const targets = new Map<string, {
+    id: string;
+    label: string;
+    url: string;
+    source: string;
+    environment: TestbedMissionEnvironment;
+    reachability: Record<string, unknown>;
+    mutationProfile: {
+      mode: TestbedMissionMutationMode;
+      allowTestMutations: boolean;
+      scope: string;
+      reason: string;
+    };
+  }>();
+
+  const add = (input: { id: string; label: string; url?: string; source: string; mode?: TestbedMissionMode; requestMutation?: boolean }) => {
+    if (!input.url) return;
+    const binding = resolveTestbedMutationBinding({
+      targetUrl: input.url,
+      mode: input.mode,
+      requestedAllowTestMutations: input.requestMutation === true,
+      configuredEnvironment: env.TESTBED_MISSION_ENVIRONMENT || env.AVERRAY_TESTBED_ENVIRONMENT,
+    });
+    targets.set(input.id, {
+      id: input.id,
+      label: input.label,
+      url: input.url,
+      source: input.source,
+      environment: binding.environment,
+      reachability: reachabilityForTarget(input.url, missionRuns),
+      mutationProfile: {
+        mode: binding.mutationMode,
+        allowTestMutations: binding.allowTestMutations,
+        scope: binding.mutationScope,
+        reason: binding.reason,
+      },
+    });
+  };
+
+  add({
+    id: "public_surface",
+    label: "Public surface",
+    url: env.TESTBED_SURFACE_SWEEP_BASE_URL || env.AVERRAY_PUBLIC_BASE_URL || "https://averray.com",
+    source: env.TESTBED_SURFACE_SWEEP_BASE_URL || env.AVERRAY_PUBLIC_BASE_URL ? "env" : "default",
+    mode: "surface_sweep",
+  });
+  add({
+    id: "operator_app",
+    label: "Operator app",
+    url: env.AVERRAY_APP_BASE_URL,
+    source: "env",
+  });
+  add({
+    id: "platform_api",
+    label: "Platform API",
+    url: env.AVERRAY_API_BASE_URL,
+    source: "env",
+    mode: "siwe_auth",
+  });
+
+  for (const run of missionRuns) {
+    const id = `recent:${stableTargetId(run.targetUrl)}`;
+    if (targets.has(id)) continue;
+    add({
+      id,
+      label: "Recent mission target",
+      url: run.targetUrl,
+      source: "mission_history",
+      mode: run.mode,
+      requestMutation: run.requestedAllowTestMutations === true,
+    });
+  }
+
+  return Array.from(targets.values());
+}
+
+function reachabilityForTarget(targetUrl: string, missionRuns: TestbedMissionRun[]): Record<string, unknown> {
+  const latest = missionRuns
+    .filter((run) => run.targetUrl === targetUrl)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+  if (!latest) {
+    return {
+      status: "not_checked_by_manifest",
+      note: "This GET does not probe targets; reachability is reported only from previous mission evidence.",
+    };
+  }
+  return {
+    status: latest.status === "completed" ? "reachable_last_run_passed" : latest.status === "failed" ? "last_run_failed" : "last_run_incomplete",
+    missionId: latest.id,
+    checkedAt: latest.completedAt ?? latest.failedAt ?? latest.updatedAt,
+    verdict: lastRunFromMission(latest).verdict,
+  };
+}
+
+function missionFlowId(run: TestbedMissionRun): string {
+  if (run.mode === "gold_path") return "gold_path";
+  if (run.mode === "siwe_auth") return "siwe_auth_role_gating";
+  if (run.mode === "surface_sweep") return "surface_sweep";
+  return "targeted_read_only";
+}
+
+function lastRunForSuite(suite: TesterSavedSuite, runs: TestbedMissionRun[]): TesterInventoryLastRun | undefined {
+  const run = runs
+    .filter((candidate) => candidate.targetUrl === suite.target && missionFlowId(candidate) === suite.flow)
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+  return run ? lastRunFromMission(run) : undefined;
+}
+
+function lastRunFromMission(run: TestbedMissionRun): TesterInventoryLastRun {
+  return {
+    missionId: run.id,
+    verdict: missionVerdict(run),
+    at: run.completedAt ?? run.failedAt ?? run.updatedAt,
+  };
+}
+
+function missionVerdict(run: TestbedMissionRun): TesterInventoryLastRun["verdict"] {
+  const structured = run.result && typeof run.result === "object" && !Array.isArray(run.result)
+    ? run.result as Record<string, unknown>
+    : {};
+  const nested = structured.structuredReport && typeof structured.structuredReport === "object" && !Array.isArray(structured.structuredReport)
+    ? structured.structuredReport as Record<string, unknown>
+    : {};
+  const verdict = typeof nested.verdict === "string" ? nested.verdict : typeof structured.verdict === "string" ? structured.verdict : undefined;
+  if (verdict === "pass" || verdict === "partial" || verdict === "fail") return verdict;
+  if (run.status === "completed") return "pass";
+  if (run.status === "failed") return "failed";
+  if (run.status === "requested" || run.status === "ready" || run.status === "running") return run.status;
+  return "unknown";
+}
+
+function stableTargetId(targetUrl: string): string {
+  return targetUrl.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 60) || "target";
 }

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import type { TestbedMissionRun } from "../../services/slack-operator/src/monitor-testbed-missions.js";
 import { buildTesterCapabilitiesManifest } from "../../services/slack-operator/src/tester-capabilities.js";
 
 describe("tester capabilities manifest", () => {
@@ -51,7 +52,7 @@ describe("tester capabilities manifest", () => {
     });
     const goldPath = manifest.missionTypes.find((mission) => mission.id === "gold_path");
     expect(goldPath).toMatchObject({
-      status: "available_fake_default",
+      status: "ready_needs_live_driver",
       scope: "testbed_mutation_only",
     });
     const siweAuth = manifest.missionTypes.find((mission) => mission.id === "siwe_auth_role_gating");
@@ -68,17 +69,25 @@ describe("tester capabilities manifest", () => {
   });
 
   it("authed sweep is ready-but-needs-session until a session SOURCE is configured (T2)", () => {
-    // No runner session source → ready_needs_session, even with the sidecar up.
-    const noSource = buildTesterCapabilitiesManifest({ env: { TEST_WALLET_SIGNER_ENABLED: "1" } });
+    // No runner session source -> ready_needs_session, even with the sidecar up.
+    const noSource = buildTesterCapabilitiesManifest({
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TEST_WALLET_SIGNER_ENABLED: "1",
+      },
+    });
     expect(noSource.runtime.signerSidecarEnabled).toBe(true);
     expect(noSource.runtime.authedSessionConfigured).toBe(false);
     expect(noSource.missionTypes.find((m) => m.id === "authed_surface_sweep")).toMatchObject({
       status: "ready_needs_session",
     });
 
-    // Sidecar URL on the runner → available, sourced from the sidecar.
+    // Sidecar URL on the runner -> available, sourced from the sidecar.
     const viaSidecar = buildTesterCapabilitiesManifest({
-      env: { TESTBED_SESSION_SIGNER_URL: "http://test-wallet-signer:8791" },
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TESTBED_SESSION_SIGNER_URL: "http://test-wallet-signer:8791",
+      },
     });
     expect(viaSidecar.runtime.authedSessionConfigured).toBe(true);
     expect(viaSidecar.runtime.authedSessionSource).toBe("test-wallet-signer sidecar");
@@ -86,9 +95,12 @@ describe("tester capabilities manifest", () => {
       status: "available",
     });
 
-    // Manual storageState path → available, sourced manually (decoupled landing).
+    // Manual storageState path -> available, sourced manually (decoupled landing).
     const viaManual = buildTesterCapabilitiesManifest({
-      env: { TESTBED_SESSION_STORAGE_STATE_PATH: "/data/agent-storage-state.json" },
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TESTBED_SESSION_STORAGE_STATE_PATH: "/data/agent-storage-state.json",
+      },
     });
     expect(viaManual.runtime.authedSessionConfigured).toBe(true);
     expect(viaManual.runtime.authedSessionSource).toBe("manual storageState/token");
@@ -96,4 +108,165 @@ describe("tester capabilities manifest", () => {
       status: "available",
     });
   });
+
+  it("does not advertise runnable flows when the runner or required driver/session is not wired", () => {
+    const disabled = buildTesterCapabilitiesManifest({
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "0",
+        TEST_WALLET_SIGNER_ENABLED: "1",
+        TESTBED_SESSION_SIGNER_URL: "http://test-wallet-signer:8791",
+        TESTBED_GOLDPATH_LIVE: "1",
+      },
+    });
+    expect(disabled.inventory.status).toBe("not_ready");
+    expect(disabled.missionTypes.find((m) => m.id === "surface_sweep")).toMatchObject({
+      status: "unavailable_runner_disabled",
+    });
+    expect(disabled.missionTypes.find((m) => m.id === "gold_path")).toMatchObject({
+      status: "unavailable_runner_disabled",
+    });
+
+    const commandMissing = buildTesterCapabilitiesManifest({
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TESTBED_MISSION_RUNNER_EXECUTOR: "command",
+      },
+    });
+    expect(commandMissing.runtime.runnerConfigured).toBe(false);
+    expect(commandMissing.missionTypes.find((m) => m.id === "targeted_read_only")).toMatchObject({
+      status: "unavailable_runner_misconfigured",
+    });
+
+    const liveNoSession = buildTesterCapabilitiesManifest({
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TESTBED_GOLDPATH_LIVE: "1",
+      },
+    });
+    expect(liveNoSession.missionTypes.find((m) => m.id === "gold_path")).toMatchObject({
+      status: "ready_needs_session",
+    });
+  });
+
+  it("publishes ready-to-test inventory from saved suites, targets, and recent mission evidence", () => {
+    const run = missionRun({
+      id: "mission-1",
+      title: "Gold path smoke",
+      mode: "gold_path",
+      targetUrl: "https://app.testnet.example/gold",
+      status: "completed",
+      allowTestMutations: true,
+      requestedAllowTestMutations: true,
+      updatedAt: "2026-06-01T11:58:00.000Z",
+      completedAt: "2026-06-01T11:58:00.000Z",
+      result: { structuredReport: { verdict: "pass" } },
+    });
+    const failedRun = missionRun({
+      id: "mission-2",
+      title: "Settings inspection",
+      targetUrl: "https://preview.example/settings",
+      status: "failed",
+      updatedAt: "2026-06-01T11:59:00.000Z",
+      failedAt: "2026-06-01T11:59:00.000Z",
+      result: { verdict: "fail" },
+    });
+
+    const manifest = buildTesterCapabilitiesManifest({
+      now: new Date("2026-06-01T12:00:00.000Z"),
+      env: {
+        TESTBED_MISSION_RUNNER_ENABLED: "1",
+        TESTBED_GOLDPATH_LIVE: "1",
+        TESTBED_SESSION_SIGNER_URL: "http://test-wallet-signer:8791",
+        TESTBED_SURFACE_SWEEP_BASE_URL: "https://averray.com",
+        AVERRAY_APP_BASE_URL: "https://app.testnet.example",
+        AVERRAY_API_BASE_URL: "https://api.testnet.example",
+        AVERRAY_TESTBED_ENVIRONMENT: "testnet",
+      },
+      missionRuns: [run, failedRun],
+      savedSuites: [
+        {
+          id: "suite-gold",
+          name: "Gold path smoke",
+          flow: "gold_path",
+          target: "https://app.testnet.example/gold",
+        },
+      ],
+    });
+
+    expect(manifest.inventory).toMatchObject({
+      status: "ready",
+      savedSuitesAvailable: true,
+      savedSuitesStore: "provided",
+    });
+    expect(manifest.inventory.savedSuites[0]).toMatchObject({
+      id: "suite-gold",
+      name: "Gold path smoke",
+      flow: "gold_path",
+      target: "https://app.testnet.example/gold",
+      status: "available",
+      flowStatus: "available_live_driver",
+      lastRun: {
+        missionId: "mission-1",
+        verdict: "pass",
+        at: "2026-06-01T11:58:00.000Z",
+      },
+    });
+    expect(manifest.inventory.recentRuns.map((entry) => entry.id)).toEqual(["mission-2", "mission-1"]);
+    expect(manifest.inventory.recentRuns[0]).toMatchObject({
+      flow: "targeted_read_only",
+      target: "https://preview.example/settings",
+      lastRun: { verdict: "fail" },
+    });
+    expect(manifest.inventory.targets).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: "public_surface",
+        url: "https://averray.com",
+        reachability: expect.objectContaining({ status: "not_checked_by_manifest" }),
+        mutationProfile: expect.objectContaining({ mode: "read_only", allowTestMutations: false }),
+      }),
+      expect.objectContaining({
+        id: "operator_app",
+        url: "https://app.testnet.example",
+        environment: "testnet",
+      }),
+      expect.objectContaining({
+        id: "recent:https-app-testnet-example-gold",
+        reachability: expect.objectContaining({
+          status: "reachable_last_run_passed",
+          missionId: "mission-1",
+          verdict: "pass",
+        }),
+        mutationProfile: expect.objectContaining({
+          mode: "testbed_mutation_allowed",
+          allowTestMutations: true,
+        }),
+      }),
+    ]));
+  });
 });
+
+function missionRun(overrides: Partial<TestbedMissionRun>): TestbedMissionRun {
+  const now = "2026-06-01T12:00:00.000Z";
+  return {
+    schemaVersion: 1,
+    kind: "testbed_mission_run",
+    id: "mission",
+    status: "ready",
+    title: "Mission",
+    targetUrl: "https://example.test",
+    goal: "Inspect the target.",
+    agentName: "Hermes",
+    freshMemory: true,
+    allowTestMutations: false,
+    requestedAllowTestMutations: false,
+    mutationMode: "read_only",
+    mutationScope: "none; stop at mutation boundary",
+    mutationBindingReason: "mission did not request testbed mutations.",
+    mission: {},
+    history: [],
+    createdAt: now,
+    updatedAt: now,
+    statusReason: "ready",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## What changed & why

Extends `GET /monitor/tester/capabilities` from a static flow-type manifest into a ready-to-test inventory manifest for P6.

- Adds live inventory fields for saved suites when supplied, recent mission runs, and available targets.
- Reports target reachability only from prior mission evidence; the manifest does not probe targets or invent readiness.
- Adds mutation profiles per target through the existing env-to-mutation binding.
- Gates flow statuses on runner readiness, command-runner configuration, session wiring, signer availability, and live gold-path driver state.
- Renames the disabled gold-path state from `available_fake_default` to `ready_needs_live_driver` so it is not advertised as runnable.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No ops, compose, migrations, Hermes pin, or secret/config changes. Rollback is reverting this PR; the endpoint will return the previous static capability shape.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

Saved suite persistence is not wired yet, so the manifest reports `savedSuitesStore: "not_wired"` and an empty suite list unless a caller supplies saved suites. That is intentional truth-boundary behavior for this P6 slice.