### PR TITLE
Expose requester-safe testbed mission reports

### DIFF
--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -144,6 +144,45 @@ export interface TestbedMissionStructuredReport {
   summary: string;
 }
 
+export interface TestbedMissionRequesterScore {
+  label: string;
+  value: number;
+}
+
+export interface TestbedMissionRequesterPathStep {
+  n: number;
+  status: "ok" | "warn" | "fail";
+  desc: string;
+}
+
+export interface TestbedMissionRequesterBlocker {
+  head: string;
+  body?: string;
+}
+
+export interface TestbedMissionRequesterEvidence {
+  kind: "screenshot" | "trace" | "console" | "video";
+  label: string;
+  href: string;
+}
+
+export interface TestbedMissionRequesterMissionBody {
+  verdict: "OK" | "PARTIAL" | "FAILED";
+  verdictTone: "ok" | "warn" | "fail";
+  confidence: number;
+  target: string;
+  goal?: string;
+  narrative?: string;
+  conclusion?: string;
+  scores?: TestbedMissionRequesterScore[];
+  seed: string;
+  path: TestbedMissionRequesterPathStep[];
+  blockers: TestbedMissionRequesterBlocker[];
+  evidence: TestbedMissionRequesterEvidence[];
+  mutationBoundary: string;
+  recommendations: string[];
+}
+
 export interface TestbedMissionBaselineComparison {
   baselineRunId: string;
   baselineCompletedAt?: string;
@@ -778,6 +817,55 @@ export function testbedMissionStructuredReport(run: TestbedMissionRun): TestbedM
   return normalizeTestbedMissionStructuredReport(result, run);
 }
 
+export function testbedMissionRequesterMissionBody(run: TestbedMissionRun): TestbedMissionRequesterMissionBody | undefined {
+  const report = testbedMissionStructuredReport(run);
+  if (!report) return undefined;
+  const source = reportSource(run);
+  const [verdict, verdictTone]: [TestbedMissionRequesterMissionBody["verdict"], TestbedMissionRequesterMissionBody["verdictTone"]] =
+    report.verdict === "pass"
+      ? ["OK", "ok"]
+      : report.verdict === "partial"
+        ? ["PARTIAL", "warn"]
+        : ["FAILED", "fail"];
+  const narrativeEntry = report.evidence.find((entry) => MISSION_NARRATIVE_RE.test(entry.trim()));
+  const narrative = narrativeEntry
+    ? narrativeEntry.trim().replace(MISSION_NARRATIVE_RE, "").trim()
+    : undefined;
+  const evidence = report.evidence
+    .filter((entry) => !MISSION_NARRATIVE_RE.test(entry.trim()))
+    .map(testbedMissionRequesterEvidence);
+  const notes = report.mutationBoundaryNotes.join(" ").trim();
+  const boundaryBase = report.stoppedBeforeMutation
+    ? "Read-only mission — the agent stopped before any mutation."
+    : "The agent crossed or attempted a mutation boundary.";
+  const conclusion = missionRequesterConclusion(report, source);
+  const scores = missionRequesterScoreList(report.scores);
+
+  return {
+    verdict,
+    verdictTone,
+    confidence: report.confidence,
+    target: run.targetUrl,
+    ...(run.goal ? { goal: run.goal } : {}),
+    ...(narrative ? { narrative } : {}),
+    ...(conclusion ? { conclusion } : {}),
+    ...(scores.length > 0 ? { scores } : {}),
+    seed: run.freshMemory === false ? "warm memory" : "fresh · no memory",
+    path: report.completedPath.map((desc, index) => ({
+      n: index + 1,
+      status: missionRequesterStepStatus(source, index),
+      desc: missionRequesterStepDesc(source, index, desc),
+    })),
+    blockers: [
+      ...report.blockers.map((head, index) => missionRequesterBlocker(source, "blockers", index, head)),
+      ...report.confusingMoments.map((head, index) => missionRequesterBlocker(source, "confusingMoments", index, head)),
+    ],
+    evidence,
+    mutationBoundary: notes ? `${boundaryBase} ${notes}` : boundaryBase,
+    recommendations: report.recommendations,
+  };
+}
+
 export function testbedMissionResultCoaching(run: TestbedMissionRun): string {
   const result = run.result ?? {};
   const verdict = typeof result.verdict === "string" ? result.verdict : run.status;
@@ -1108,6 +1196,124 @@ function missionFailedMs(run: TestbedMissionRun): number {
 function parseTestbedMissionMode(value: string | undefined): TestbedMissionMode | undefined {
   if (value === "surface_sweep" || value === "siwe_auth" || value === "gold_path") return value;
   return undefined;
+}
+
+const EVIDENCE_KINDS = new Set(["screenshot", "trace", "console", "video"]);
+const MISSION_NARRATIVE_RE = /^what[_ ]i[_ ]tried\s*:\s*/i;
+
+function testbedMissionRequesterEvidence(raw: string): TestbedMissionRequesterEvidence {
+  const match = /^(\w+):\s*(.+)$/.exec(raw.trim());
+  const kindRaw = match ? match[1]!.toLowerCase() : "";
+  const kind = (EVIDENCE_KINDS.has(kindRaw) ? kindRaw : "trace") as TestbedMissionRequesterEvidence["kind"];
+  const label = (match ? match[2]! : raw).trim();
+  const href = /^https?:\/\//i.test(label) ? label : "#";
+  return { kind, label, href };
+}
+
+function missionRequesterScoreList(scores: Record<string, number>): TestbedMissionRequesterScore[] {
+  return Object.entries(scores)
+    .filter(([, value]) => Number.isFinite(value))
+    .map(([key, value]) => ({ label: missionRequesterScoreLabel(key), value: Math.round(value * 2) }));
+}
+
+function missionRequesterScoreLabel(key: string): string {
+  return key
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .trim()
+    .replace(/\b\w/g, (ch) => ch.toUpperCase());
+}
+
+function reportSource(run: TestbedMissionRun): Record<string, unknown> {
+  const result = isRecord(run.result) ? run.result : {};
+  return result;
+}
+
+function missionRequesterArrayEntry(
+  source: Record<string, unknown>,
+  key: string,
+  index: number
+): Record<string, unknown> | undefined {
+  const value = source[key];
+  if (!Array.isArray(value)) return undefined;
+  const entry = value[index];
+  return isRecord(entry) ? entry : undefined;
+}
+
+function missionRequesterStepRecord(source: Record<string, unknown>, index: number): Record<string, unknown> | undefined {
+  return missionRequesterArrayEntry(source, "completedPath", index)
+    ?? missionRequesterArrayEntry(source, "path", index)
+    ?? missionRequesterArrayEntry(source, "steps", index)
+    ?? missionRequesterArrayEntry(source, "completedSteps", index);
+}
+
+function missionRequesterStepStatus(source: Record<string, unknown>, index: number): TestbedMissionRequesterPathStep["status"] {
+  const step = missionRequesterStepRecord(source, index);
+  const raw = firstString(step?.status, step?.verdict, step?.outcome, step?.state)?.toLowerCase();
+  if (!raw) return "ok";
+  if (/\b(fail|failed|error|blocked|blocker)\b/.test(raw)) return "fail";
+  if (/\b(warn|partial|slow|skip|skipped|pending)\b/.test(raw)) return "warn";
+  return "ok";
+}
+
+function missionRequesterStepDesc(source: Record<string, unknown>, index: number, fallback: string): string {
+  const step = missionRequesterStepRecord(source, index);
+  return firstString(step?.desc, step?.description, step?.action, step?.name, step?.value)
+    ?? (fallback === "[object Object]" ? "Step recorded by browser agent" : fallback);
+}
+
+function missionRequesterBlocker(
+  source: Record<string, unknown>,
+  key: "blockers" | "confusingMoments",
+  index: number,
+  fallback: string
+): TestbedMissionRequesterBlocker {
+  const entry = missionRequesterArrayEntry(source, key, index);
+  const evidence = Array.isArray(entry?.evidence)
+    ? entry.evidence.map((value) => asNonEmptyString(value)).filter((value): value is string => Boolean(value))
+    : [];
+  const head = firstString(entry?.head, entry?.title, entry?.summary, entry?.label, entry?.message)
+    ?? (fallback === "[object Object]" ? "Browser-agent finding" : fallback);
+  const body = firstString(
+    entry?.body,
+    entry?.detail,
+    entry?.details,
+    entry?.description,
+    entry?.message,
+    evidence.length ? evidence.join(" ") : undefined,
+  );
+  return { head, ...(body ? { body } : {}) };
+}
+
+function missionRequesterConclusion(
+  report: TestbedMissionStructuredReport,
+  source: Record<string, unknown>
+): string | undefined {
+  const verdict = report.verdict === "pass" ? "OK" : report.verdict === "partial" ? "PARTIAL" : "FAIL";
+  const detail = report.verdict === "pass"
+    ? firstString(source.conclusion, source.summary, report.summary, report.recommendations[0])
+    : firstString(
+      report.blockers[0],
+      report.confusingMoments[0],
+      report.recommendations[0],
+      source.conclusion,
+      source.summary,
+      report.summary,
+    );
+  const cleaned = detail ? detail.replace(/^(pass|partial|fail|failed|ok)\s*:\s*/i, "").trim() : "";
+  return cleaned ? `${verdict} — ${cleaned}` : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const text = asNonEmptyString(value);
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
 }
 
 function testbedMissionTitle(mode: TestbedMissionMode | undefined): string {

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -6,6 +6,7 @@ import {
   readTestbedMissionRunnerHeartbeat,
   recordTestbedMissionRunFromOperatorResult,
   summarizeTestbedMissionRunnerHeartbeat,
+  testbedMissionRequesterMissionBody,
   type TestbedMissionMode,
   type TestbedMissionRequesterAgent,
   type TestbedMissionRun,
@@ -202,12 +203,39 @@ export function getTestbedMissionForAgent(id: string, input: AgentTestbedMission
   const run = listTestbedMissionRuns({ limit: 50, path: input.path })
     .find((candidate) => candidate.id === id);
   if (!run) return undefined;
+  const report = run.status === "completed" || run.status === "failed"
+    ? testbedMissionRequesterMissionBody(run)
+    : undefined;
+  if (!report) {
+    return {
+      schemaVersion: 1,
+      kind: "hermes_testbed_agent_mission_report",
+      id: run.id,
+      status: run.status,
+      updatedAt: run.updatedAt,
+      runner,
+      nextStep: nextStepForRun(run, runner),
+    };
+  }
   return {
     schemaVersion: 1,
-    kind: "hermes_testbed_agent_mission",
+    kind: "hermes_testbed_agent_mission_report",
+    id: run.id,
+    status: run.status,
+    title: run.title,
+    targetUrl: run.targetUrl,
+    goal: run.goal,
+    ...(run.requesterAgent ? { requesterAgent: run.requesterAgent } : {}),
+    ...(run.requestReason ? { requestReason: run.requestReason } : {}),
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    ...(run.requestedAt ? { requestedAt: run.requestedAt } : {}),
+    ...(run.approvedAt ? { approvedAt: run.approvedAt } : {}),
+    ...(run.claimedAt ? { claimedAt: run.claimedAt } : {}),
+    ...(run.completedAt ? { completedAt: run.completedAt } : {}),
+    ...(run.failedAt ? { failedAt: run.failedAt } : {}),
     runner,
-    run,
-    mission: run.mission,
+    report,
     nextStep: nextStepForRun(run, runner),
   };
 }

--- a/test/unit/testbed-agent-entrypoint.test.ts
+++ b/test/unit/testbed-agent-entrypoint.test.ts
@@ -5,6 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   __resetTestbedMissionRunsForTests,
+  acceptTestbedMissionFailure,
+  recordTestbedMissionReportFromMessage,
+  recordTestbedMissionIssueOpened,
   updateTestbedMissionRunnerHeartbeat,
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
 import {
@@ -306,7 +309,7 @@ describe("testbed agent entrypoint", () => {
     });
   });
 
-  it("returns one mission with the next useful agent action", () => {
+  it("returns a requester-safe status envelope before mission completion", () => {
     const created = createTestbedMissionFromAgent(
       {
         path,
@@ -319,17 +322,151 @@ describe("testbed agent entrypoint", () => {
     const detail = getTestbedMissionForAgent(created.run.id, { path });
 
     expect(detail).toMatchObject({
-      kind: "hermes_testbed_agent_mission",
-      run: {
-        id: created.run.id,
-        status: "ready",
-        targetUrl: "https://testbed.example/app",
-      },
-      mission: {
-        kind: "testbed_agent_browser_mission",
-      },
+      kind: "hermes_testbed_agent_mission_report",
+      id: created.run.id,
+      status: "ready",
     });
+    expect(detail).not.toHaveProperty("report");
+    expect(detail).not.toHaveProperty("run");
+    expect(detail).not.toHaveProperty("mission");
+    expect(detail).not.toHaveProperty("result");
+    expect(detail).not.toHaveProperty("targetUrl");
+    expect(detail).not.toHaveProperty("goal");
     expect(detail?.nextStep).toContain("Mission is ready");
     expect(getTestbedMissionForAgent("missing", { path })).toBeUndefined();
+  });
+
+  it("returns the requester MissionBody report after completion", () => {
+    const created = createTestbedMissionFromAgent(
+      {
+        path,
+        requester: "codex",
+        targetUrl: "https://testbed.example/app",
+        goal: "verify the app is understandable to a fresh tester",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    recordTestbedMissionReportFromMessage(
+      {
+        path,
+        relatedCorrelationId: created.run.id,
+        text: JSON.stringify({
+          verdict: "pass",
+          confidence: 0.91,
+          stoppedBeforeMutation: true,
+          summary: "pass: the fresh tester completed the happy path",
+          completedPath: [
+            { desc: "Opened the app shell", status: "ok" },
+            { desc: "Followed the primary CTA", status: "ok" },
+          ],
+          blockers: [],
+          confusingMoments: [],
+          evidence: [
+            "what_i_tried: opened the page and followed the primary path",
+            "screenshot: https://example.test/screen.png",
+            "console: no errors",
+          ],
+          mutationBoundaryNotes: ["No mutation was attempted."],
+          recommendations: ["Keep the sandbox label visible."],
+          scores: { orientation: 5, trustBoundary: 4 },
+        }),
+      },
+      Date.parse("2026-05-25T10:07:00.000Z")
+    );
+
+    const detail = getTestbedMissionForAgent(created.run.id, { path });
+
+    expect(detail).toMatchObject({
+      kind: "hermes_testbed_agent_mission_report",
+      id: created.run.id,
+      status: "completed",
+      completedAt: "2026-05-25T10:07:00.000Z",
+      report: {
+        verdict: "OK",
+        verdictTone: "ok",
+        confidence: 0.91,
+        target: "https://testbed.example/app",
+        goal: "verify the app is understandable to a fresh tester",
+        narrative: "opened the page and followed the primary path",
+        conclusion: "OK — the fresh tester completed the happy path",
+        seed: "fresh · no memory",
+        path: [
+          { n: 1, status: "ok", desc: "Opened the app shell" },
+          { n: 2, status: "ok", desc: "Followed the primary CTA" },
+        ],
+        blockers: [],
+        evidence: [
+          { kind: "screenshot", label: "https://example.test/screen.png", href: "https://example.test/screen.png" },
+          { kind: "console", label: "no errors", href: "#" },
+        ],
+        mutationBoundary: "Read-only mission — the agent stopped before any mutation. No mutation was attempted.",
+        recommendations: ["Keep the sandbox label visible."],
+      },
+    });
+    expect(detail?.report?.scores).toEqual([
+      { label: "Orientation", value: 10 },
+      { label: "Trust Boundary", value: 8 },
+    ]);
+  });
+
+  it("does not leak operator-private mission fields to requesters", () => {
+    const created = createTestbedMissionFromAgent(
+      {
+        path,
+        requester: "claude",
+        targetUrl: "https://testbed.example/app",
+        goal: "find the confusing part of the app",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    recordTestbedMissionReportFromMessage(
+      {
+        path,
+        relatedCorrelationId: created.run.id,
+        text: JSON.stringify({
+          verdict: "fail",
+          confidence: 0.8,
+          stoppedBeforeMutation: true,
+          completedPath: ["Opened the app"],
+          blockers: ["The tester could not find the next action."],
+          evidence: ["trace: https://example.test/trace.zip"],
+          mutationBoundaryNotes: ["No mutation was attempted."],
+          recommendations: ["Clarify the primary next action."],
+          scores: { completion: 1 },
+        }),
+      },
+      Date.parse("2026-05-25T10:07:00.000Z")
+    );
+    acceptTestbedMissionFailure(created.run.id, {
+      path,
+      acceptedBy: "operator",
+      now: new Date("2026-05-25T10:08:00.000Z"),
+    });
+    recordTestbedMissionIssueOpened(created.run.id, {
+      path,
+      issueUrl: "https://github.com/depre-dev/averray-reference-agent/issues/999",
+      issueNumber: 999,
+      openedBy: "operator",
+    });
+
+    const detail = getTestbedMissionForAgent(created.run.id, { path });
+    const serialized = JSON.stringify(detail);
+
+    expect(detail).not.toHaveProperty("run");
+    expect(detail).not.toHaveProperty("mission");
+    expect(detail).not.toHaveProperty("result");
+    expect(serialized).not.toContain("operatorAccepted");
+    expect(serialized).not.toContain("operatorIssue");
+    expect(serialized).not.toContain("missionPrompt");
+    expect(serialized).not.toContain("issues/999");
+    expect(detail).toMatchObject({
+      status: "failed",
+      report: {
+        verdict: "FAILED",
+        blockers: [{ head: "The tester could not find the next action." }],
+      },
+    });
   });
 });


### PR DESCRIPTION
## What changed
- Changes the existing `GET /monitor/testbed-missions/:id` agent-facing detail path to return a requester-safe `hermes_testbed_agent_mission_report` envelope instead of raw run/mission internals.
- Before completion, the response is status-only: id, status, updatedAt, runner state, and nextStep.
- After completion/failure, the response includes a public MissionBody-style report with verdict, path, blockers, evidence, mutation boundary, recommendations, and scores.
- Keeps operator-private/raw fields out of requester payloads, including raw mission packets, results, operator triage fields, and operator issue links.

## Safety / authority
- Read-only endpoint behavior only.
- No operator authority change.
- No task creation, approval, GitHub, Slack, or queue mutation.

## Checks run
- `npm run typecheck`
- `npm test -- test/unit/testbed-agent-entrypoint.test.ts`
- `npm test` (117 files / 1435 tests)

## Affected surface
- Backend monitor/testbed mission API and unit tests only.