### PR TITLE
feat(monitor): add tester mission launcher

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -164,6 +164,47 @@ describe("MonitorPage — container", () => {
     }
   });
 
+  test("the board launcher POSTs an explicit mission request without mutation flags", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: [], at: "2026-05-28T10:30:00Z" }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
+    try {
+      const { getByRole, getByLabelText } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Start a mission" })).toBeTruthy());
+
+      fireEvent.click(getByRole("button", { name: "Start a mission" }));
+      fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/agent" } });
+      fireEvent.click(getByLabelText(/Gold Path/));
+      fireEvent.click(getByLabelText("Memory"));
+      fireEvent.change(getByLabelText("Goal"), { target: { value: "prove the signed-in receipt loop" } });
+      fireEvent.click(getByLabelText(/Request approval/));
+      fireEvent.click(getByRole("button", { name: "Launch mission" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/testbed-missions");
+      expect(init.method).toBe("POST");
+      expect(JSON.parse(String(init.body))).toEqual({
+        targetUrl: "https://app.averray.com/agent",
+        mode: "gold_path",
+        freshMemory: false,
+        initialStatus: "requested",
+        goal: "prove the signed-in receipt loop",
+      });
+      expect(JSON.parse(String(init.body))).not.toHaveProperty("allowTestMutations");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   test("the default mission approval POSTs to /monitor/testbed-missions/:id/approve", async () => {
     const requestedMission = {
       id: "testbed-mission-requested-1",
@@ -202,6 +243,51 @@ describe("MonitorPage — container", () => {
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
       expect(calledUrl).toBe("/monitor/testbed-missions/testbed-mission-requested-1/approve");
+      expect(init.method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("requested mission dismiss POSTs to /monitor/testbed-missions/:id/dismiss", async () => {
+    const requestedMission = {
+      id: "testbed-mission-requested-1",
+      lane: "operator-review",
+      type: "mission",
+      agentType: "hermes",
+      title: "Tester run requested",
+      summary: "Tester run requested by codex; it has not started and remains board-gated until the operator approves it.",
+      repo: "testbed/mission",
+      freshness: 1,
+      state: "fresh",
+      risk: ["testbed"],
+      waitingOn: { actor: "operator", tone: "neutral" },
+      missionStatus: "requested",
+    } as unknown as MonitorBoard["cards"][number];
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [requestedMission],
+      at: "2026-05-28T10:30:00Z",
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole, getByText } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Dismiss" })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+      expect(getByText(/Dismiss this requested tester mission/)).toBeTruthy();
+      fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/testbed-missions/testbed-mission-requested-1/dismiss");
       expect(init.method).toBe("POST");
     } finally {
       fetchSpy.mockRestore();

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -29,6 +29,7 @@ import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionA
 import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonomyMode.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import type { BoardCard, CreateTaskInput } from "./lib/monitor/card-types.js";
+import type { MissionSpawnInput } from "./lib/monitor/mission-launch.js";
 import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
@@ -45,7 +46,7 @@ export interface MonitorPageProps {
   /** Override the read-only backlog-suggestions endpoint wiring for tests. */
   backlogSuggestions?: UseBacklogSuggestionsOptions;
   /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
-  onSpawnMission?: (url: string) => void;
+  onSpawnMission?: (input: MissionSpawnInput) => void;
   /** Override the /claude propose (defaults to POST /monitor/codex-tasks). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Override the create-task dispatch (defaults to POST /monitor/codex-tasks propose). */
@@ -58,6 +59,8 @@ export interface MonitorPageProps {
   onSnoozeCard?: (card: BoardCard, untilMs: number) => void;
   /** Override the tester mission approval (defaults to POST /monitor/testbed-missions/:id/approve). */
   onApproveMission?: (id: string) => void;
+  /** Override requested-mission dismiss (defaults to POST /monitor/testbed-missions/:id/dismiss). */
+  onDismissMission?: (id: string) => void;
   /** Override the drawer mission re-run (defaults to POST /monitor/testbed-missions). */
   onRerunMission?: (targetUrl: string, freshness: "fresh" | "memory") => void;
   /** Override failed-mission acknowledgement (defaults to POST /monitor/testbed-missions/:id/accept-failure). */
@@ -84,6 +87,7 @@ export function MonitorPage({
   onDismissCard = defaultDismissCard,
   onSnoozeCard = defaultSnoozeCard,
   onApproveMission = defaultApproveMission,
+  onDismissMission = defaultDismissMission,
   onRerunMission = defaultRerunMission,
   onAcceptMissionFailure = defaultAcceptMissionFailure,
   onOpenMissionIssue = defaultOpenMissionIssue,
@@ -133,6 +137,7 @@ export function MonitorPage({
         onDismissCard={onDismissCard}
         onSnoozeCard={onSnoozeCard}
         onApproveMission={onApproveMission}
+        onDismissMission={onDismissMission}
         onRerunMission={onRerunMission}
         onAcceptMissionFailure={onAcceptMissionFailure}
         onOpenMissionIssue={onOpenMissionIssue}
@@ -155,14 +160,26 @@ export function MonitorPage({
  * board — so the spawned card appears and updates through the live feed.
  * Fire-and-forget: the board feed, not this call, drives the UI.
  */
-function defaultSpawnMission(url: string): void {
+function defaultSpawnMission(input: MissionSpawnInput): void {
   void fetch(MISSIONS_URL, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ targetUrl: url }),
+    body: JSON.stringify(missionSpawnBody(input)),
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
   });
+}
+
+function missionSpawnBody(input: MissionSpawnInput): Record<string, unknown> {
+  if (typeof input === "string") return { targetUrl: input };
+  const body: Record<string, unknown> = {
+    targetUrl: input.targetUrl,
+    mode: input.mode,
+    freshMemory: input.freshMemory,
+    initialStatus: input.initialStatus,
+  };
+  if (input.goal) body.goal = input.goal;
+  return body;
 }
 
 /**
@@ -271,6 +288,15 @@ function defaultApproveMission(id: string): void {
     headers: { "content-type": "application/json" },
   }).catch(() => {
     /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+function defaultDismissMission(id: string): void {
+  void fetch(`${MISSIONS_URL}/${encodeURIComponent(id)}/dismiss`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* optimistic local hide already applied; next poll is the source of truth */
   });
 }
 

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -23,7 +23,9 @@ import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache
 import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
+import type { MissionSpawnInput } from "../lib/monitor/mission-launch.js";
 import { CreateTaskForm } from "./CreateTaskForm.js";
+import { StartMissionLauncher } from "./StartMissionLauncher.js";
 import { laneFor } from "../lib/monitor/lane-rules.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
@@ -95,7 +97,7 @@ export interface BoardViewProps {
   onCardClick?: (id: string) => void;
   onCardClose?: () => void;
   onCardNavigate?: (id: string) => void;
-  onSpawnMission?: (url: string) => void;
+  onSpawnMission?: (input: MissionSpawnInput) => void;
   /** Propose a greenfield Claude task (/claude <repo> <task>). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Propose a task — /task verb + the codex-needed create form (O3). */
@@ -104,6 +106,8 @@ export interface BoardViewProps {
   onApproveTask?: (id: string) => void;
   /** Approve a requested tester mission — the operator human gate (T6). */
   onApproveMission?: (id: string) => void;
+  /** Dismiss a requested tester mission before the runner can claim it. */
+  onDismissMission?: (id: string) => void;
   /** Persist operator dismissal for cards backed by server-side state. */
   onDismissCard?: (card: BoardCard) => void;
   /** Persist operator snooze for cards backed by server-side state. */
@@ -142,6 +146,7 @@ export function BoardView({
   onCreateTask,
   onApproveTask,
   onApproveMission,
+  onDismissMission,
   onDismissCard: persistDismissCard,
   onSnoozeCard: persistSnoozeCard,
   onRerunMission,
@@ -296,6 +301,7 @@ export function BoardView({
       onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
       onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
       onApproveMission={onApproveMission ? (c) => onApproveMission(c.id) : undefined}
+      onDismissMission={onDismissMission ? (c) => onDismissMission(c.correlationId ?? c.id) : undefined}
       onApproveMerge={onApproveMergeCard}
       onRerunMission={onRerunMission ? (c, freshness) => {
         const target = c.type === "mission" ? c.mission?.target : undefined;
@@ -494,6 +500,7 @@ export function BoardView({
             onFilterChange={setFilter}
           />
           <LlmUsagePanel usage={board?.llmUsage} />
+          {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} /> : null}
           <Board
             grouped={displayGrouped}
             expanded={effectiveExpanded}

--- a/packages/monitor-ui/src/components/StartMissionLauncher.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.tsx
@@ -1,0 +1,154 @@
+import { useId, useState, type FormEvent } from "react";
+import type { MissionLaunchInput, MissionLaunchMode } from "../lib/monitor/mission-launch.js";
+
+const DEFAULT_TARGET = "https://app.averray.com";
+
+export interface StartMissionLauncherProps {
+  onSpawnMission?: (input: MissionLaunchInput) => void;
+}
+
+export function StartMissionLauncher({ onSpawnMission }: StartMissionLauncherProps) {
+  const targetId = useId();
+  const goalId = useId();
+  const [open, setOpen] = useState(false);
+  const [targetUrl, setTargetUrl] = useState(DEFAULT_TARGET);
+  const [mode, setMode] = useState<MissionLaunchMode>("surface_sweep");
+  const [freshMemory, setFreshMemory] = useState(true);
+  const [requestApproval, setRequestApproval] = useState(false);
+  const [goal, setGoal] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const target = targetUrl.trim();
+    if (!isHttpUrl(target)) {
+      setError("Use an http:// or https:// target.");
+      return;
+    }
+    setError(null);
+    const trimmedGoal = goal.trim();
+    onSpawnMission?.({
+      targetUrl: target,
+      mode,
+      freshMemory,
+      initialStatus: requestApproval ? "requested" : "ready",
+      ...(trimmedGoal ? { goal: trimmedGoal } : {}),
+    });
+    setOpen(false);
+  };
+
+  return (
+    <section className="hm-mission-launcher" aria-label="Start a mission">
+      <div className="hm-mission-launcher-head">
+        <div>
+          <span className="hm-mission-launcher-kicker">Tester</span>
+          <strong>Start a mission</strong>
+          <span>Launch a real browser run from the board.</span>
+        </div>
+        <button type="button" className="hm-btn hm-btn--primary hm-btn--sm" onClick={() => setOpen((value) => !value)}>
+          {open ? "Close" : "Start a mission"}
+        </button>
+      </div>
+
+      {open ? (
+        <form className="hm-mission-launcher-form" onSubmit={submit}>
+          <label className="hm-field hm-field--wide" htmlFor={targetId}>
+            <span>Target</span>
+            <input
+              id={targetId}
+              type="url"
+              required
+              value={targetUrl}
+              onChange={(event) => setTargetUrl(event.target.value)}
+              placeholder={DEFAULT_TARGET}
+            />
+          </label>
+
+          <fieldset className="hm-choice-group">
+            <legend>Flow</legend>
+            <label>
+              <input
+                type="radio"
+                name="mission-flow"
+                checked={mode === "surface_sweep"}
+                onChange={() => setMode("surface_sweep")}
+              />
+              <span>Surface Sweep</span>
+              <small>read-only</small>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="mission-flow"
+                checked={mode === "gold_path"}
+                onChange={() => setMode("gold_path")}
+              />
+              <span>Gold Path</span>
+              <small>testnet</small>
+            </label>
+          </fieldset>
+
+          <fieldset className="hm-choice-group hm-choice-group--compact">
+            <legend>Memory</legend>
+            <label>
+              <input
+                type="radio"
+                name="mission-memory"
+                checked={freshMemory}
+                onChange={() => setFreshMemory(true)}
+              />
+              <span>Fresh</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="mission-memory"
+                checked={!freshMemory}
+                onChange={() => setFreshMemory(false)}
+              />
+              <span>Memory</span>
+            </label>
+          </fieldset>
+
+          <label className="hm-field hm-field--wide" htmlFor={goalId}>
+            <span>Goal</span>
+            <textarea
+              id={goalId}
+              value={goal}
+              onChange={(event) => setGoal(event.target.value)}
+              placeholder="Optional scope or question for the browser agent"
+              rows={2}
+            />
+          </label>
+
+          <label className="hm-checkbox-row">
+            <input
+              type="checkbox"
+              checked={requestApproval}
+              onChange={(event) => setRequestApproval(event.target.checked)}
+            />
+            <span>Request approval before the runner claims it</span>
+          </label>
+
+          {error ? <div className="hm-form-error" role="alert">{error}</div> : null}
+
+          <div className="hm-mission-launcher-actions">
+            <button type="submit" className="hm-btn hm-btn--action">
+              Launch mission
+            </button>
+            <span>Server derives mutation safety from target, flow, and environment.</span>
+          </div>
+        </form>
+      ) : null}
+    </section>
+  );
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -404,10 +404,13 @@ describe("Card — requested tester mission approve (T6)", () => {
   } as unknown as BoardCard;
 
   test("shows that the mission has not started and requires approval", () => {
-    const { getByRole, getByText } = render(<Card card={requestedMission} onApproveMission={vi.fn()} />);
+    const { getByRole, getByText } = render(
+      <Card card={requestedMission} onApproveMission={vi.fn()} onDismissMission={vi.fn()} />,
+    );
     expect(getByText("Tester run requested")).toBeTruthy();
     expect(getByText("not started")).toBeTruthy();
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
+    expect(getByRole("button", { name: "Dismiss" })).toBeTruthy();
   });
 
   test("approving a tester mission requires confirm before dispatching to the runner queue", () => {
@@ -419,6 +422,17 @@ describe("Card — requested tester mission approve (T6)", () => {
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onApproveMission).toHaveBeenCalledTimes(1);
     expect(onApproveMission.mock.calls[0]?.[0]?.id).toBe("testbed-mission-requested-1");
+  });
+
+  test("dismissing a tester mission requires confirm before clearing the request", () => {
+    const onDismissMission = vi.fn();
+    const { getByRole, getByText } = render(<Card card={requestedMission} onDismissMission={onDismissMission} />);
+    fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    expect(onDismissMission).not.toHaveBeenCalled();
+    expect(getByText(/Dismiss this requested tester mission\?/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
+    expect(onDismissMission).toHaveBeenCalledTimes(1);
+    expect(onDismissMission.mock.calls[0]?.[0]?.id).toBe("testbed-mission-requested-1");
   });
 
   test("failed mission triage exposes operator Re-run, Accept failure, and Open issue actions", () => {

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -46,6 +46,8 @@ export type CardProps = {
   onApprove?: (card: BoardCard) => void;
   /** Approve a requested tester mission (T6). Operator-only; runs through a confirm. */
   onApproveMission?: (card: BoardCard) => void;
+  /** Dismiss a requested tester mission before the runner can claim it. */
+  onDismissMission?: (card: BoardCard) => void;
   /** Approve a PR for merge review. Opens/records only; humans still merge. */
   onApproveMerge?: (card: BoardCard) => void;
   /** Re-run a failed tester mission. */
@@ -100,6 +102,7 @@ export function Card({
   onClick,
   onApprove,
   onApproveMission,
+  onDismissMission,
   onApproveMerge,
   onRerunMission,
   onAcceptMissionFailure,
@@ -225,6 +228,7 @@ export function Card({
           card={card}
           onApprove={onApprove}
           onApproveMission={onApproveMission}
+          onDismissMission={onDismissMission}
           onApproveMerge={onApproveMerge}
           onRerunMission={onRerunMission}
           onAcceptMissionFailure={onAcceptMissionFailure}
@@ -542,6 +546,7 @@ function OperatorActions({
   card,
   onApprove,
   onApproveMission,
+  onDismissMission,
   onApproveMerge,
   onRerunMission,
   onAcceptMissionFailure,
@@ -550,6 +555,7 @@ function OperatorActions({
   card: BoardCard;
   onApprove?: (card: BoardCard) => void;
   onApproveMission?: (card: BoardCard) => void;
+  onDismissMission?: (card: BoardCard) => void;
   onApproveMerge?: (card: BoardCard) => void;
   onRerunMission?: (card: BoardCard, freshness: "fresh" | "memory") => void;
   onAcceptMissionFailure?: (card: BoardCard) => void;
@@ -571,14 +577,33 @@ function OperatorActions({
           run: () => onApprove(card),
           kind: "action" as const,
         }]
-      : card.type === "mission" && missionStatus === "requested" && onApproveMission
-        ? [{
-            key: "approve-mission",
-            label: "Approve & dispatch",
-            confirm: "Dispatch tester runner?",
-            run: () => onApproveMission(card),
-            kind: "action" as const,
-          }]
+      : card.type === "mission" && missionStatus === "requested"
+        ? [
+            onApproveMission
+              ? {
+                  key: "approve-mission",
+                  label: "Approve & dispatch",
+                  confirm: "Dispatch tester runner?",
+                  run: () => onApproveMission(card),
+                  kind: "action" as const,
+                }
+              : undefined,
+            onDismissMission
+              ? {
+                  key: "dismiss-mission",
+                  label: "Dismiss",
+                  confirm: "Dismiss this requested tester mission?",
+                  run: () => onDismissMission(card),
+                  kind: "ghost" as const,
+                }
+              : undefined,
+          ].filter((action): action is {
+            key: string;
+            label: string;
+            confirm: string;
+            run: () => void;
+            kind: "action" | "ghost";
+          } => Boolean(action))
         : card.type === "mission" && missionStatus === "failed"
           ? [
               missionTarget && onRerunMission

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -21,6 +21,8 @@ export type CardRouterProps = {
   onApprove?: (card: BoardCard) => void;
   /** Approve a board-gated requested tester mission (T6). */
   onApproveMission?: (card: BoardCard) => void;
+  /** Dismiss a requested tester mission before a runner can claim it. */
+  onDismissMission?: (card: BoardCard) => void;
   /** Approve a PR for merge review. Opens/records only; humans still merge. */
   onApproveMerge?: (card: BoardCard) => void;
   /** Re-run a failed tester mission. */
@@ -40,6 +42,7 @@ export function CardRouter({
   onDegradedAction,
   onApprove,
   onApproveMission,
+  onDismissMission,
   onApproveMerge,
   onRerunMission,
   onAcceptMissionFailure,
@@ -69,6 +72,7 @@ export function CardRouter({
       onClick={onClick}
       onApprove={onApprove}
       onApproveMission={onApproveMission}
+      onDismissMission={onDismissMission}
       onApproveMerge={onApproveMerge}
       onRerunMission={onRerunMission}
       onAcceptMissionFailure={onAcceptMissionFailure}

--- a/packages/monitor-ui/src/lib/monitor/index.ts
+++ b/packages/monitor-ui/src/lib/monitor/index.ts
@@ -15,6 +15,7 @@ export * from "./drawer-routing.js";
 export * from "./snapshot-store.js";
 export * from "./live-stream.js";
 export * from "./hermes-commands.js";
+export * from "./mission-launch.js";
 export * from "./collaboration.js";
 export * from "./notifications.js";
 export * from "./alert-audio.js";

--- a/packages/monitor-ui/src/lib/monitor/mission-launch.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-launch.ts
@@ -1,0 +1,12 @@
+export type MissionLaunchMode = "surface_sweep" | "gold_path";
+export type MissionInitialStatus = "ready" | "requested";
+
+export interface MissionLaunchInput {
+  targetUrl: string;
+  mode: MissionLaunchMode;
+  freshMemory: boolean;
+  initialStatus: MissionInitialStatus;
+  goal?: string;
+}
+
+export type MissionSpawnInput = string | MissionLaunchInput;

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -391,6 +391,141 @@ body { margin: 0; }
   display: grid;
   gap: 9px;
 }
+
+.hm-mission-launcher {
+  margin: 0 22px 10px;
+  padding: 10px 12px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+}
+.hm-mission-launcher-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+.hm-mission-launcher-head > div {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  min-width: 0;
+}
+.hm-mission-launcher-kicker {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage-deep);
+}
+.hm-mission-launcher-head strong {
+  font-family: var(--font-display);
+  font-size: 14px;
+}
+.hm-mission-launcher-head span:last-child {
+  color: var(--hm-ink-soft);
+  font-size: 12px;
+}
+.hm-mission-launcher-form {
+  display: grid;
+  grid-template-columns: minmax(280px, 1.2fr) minmax(190px, 0.75fr) minmax(150px, 0.55fr);
+  gap: 10px;
+  align-items: end;
+  margin-top: 12px;
+}
+.hm-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+.hm-field span,
+.hm-choice-group legend {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.11em !important;
+  text-transform: uppercase;
+  color: var(--hm-sage-deep);
+}
+.hm-field input,
+.hm-field textarea {
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid var(--hm-line);
+  border-radius: 8px;
+  background: var(--hm-paper);
+  color: var(--hm-ink);
+  font: 12px var(--font-body);
+  padding: 8px 10px;
+  outline: none;
+}
+.hm-field textarea {
+  resize: vertical;
+}
+.hm-field input:focus,
+.hm-field textarea:focus {
+  border-color: var(--hm-sage);
+  box-shadow: 0 0 0 3px rgba(15, 118, 110, 0.10);
+}
+.hm-choice-group {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+.hm-choice-group label,
+.hm-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 7px 9px;
+  border: 1px solid var(--hm-line);
+  border-radius: 8px;
+  background: var(--hm-rail);
+  font-size: 12px;
+  color: var(--hm-ink);
+}
+.hm-choice-group input,
+.hm-checkbox-row input {
+  accent-color: var(--hm-sage);
+}
+.hm-choice-group small {
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.hm-checkbox-row {
+  align-self: end;
+  grid-column: span 1;
+}
+.hm-mission-launcher-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  grid-column: span 2;
+}
+.hm-mission-launcher-actions span,
+.hm-form-error {
+  color: var(--hm-muted);
+  font-size: 12px;
+}
+.hm-form-error {
+  color: var(--hm-rose);
+}
+@media (max-width: 1100px) {
+  .hm-mission-launcher-form {
+    grid-template-columns: 1fr;
+  }
+  .hm-mission-launcher-actions,
+  .hm-checkbox-row {
+    grid-column: span 1;
+  }
+}
 .hm-llm-usage-head,
 .hm-llm-usage-row {
   display: flex;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -151,6 +151,7 @@ import { parseProposeTaskPayload } from "./codex-task-request.js";
 import {
   acceptTestbedMissionFailure,
   diagnoseTestbedMissionReportFromMessage,
+  dismissRequestedTestbedMissionRun,
   failedTestbedMissionsForSelfHealing,
   listTestbedMissionRuns,
   readTestbedMissionRunnerHeartbeat,
@@ -166,7 +167,7 @@ import {
 } from "./monitor-testbed-missions.js";
 import {
   approveRequestedTestbedMission,
-  createTestbedMissionFromAgent,
+  createMonitorTestbedMissionFromPayload,
   getTestbedMissionForAgent,
   listTestbedMissionsForAgent,
   requestTestbedMissionFromAgent,
@@ -789,6 +790,24 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorTestbedMissionApprovalRequest(testbedMissionApprovalId, response);
+    return;
+  }
+  const testbedMissionDismissId = monitorTestbedMissionActionId(url.pathname, "dismiss");
+  if (request.method === "POST" && testbedMissionDismissId) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "mission_dismiss_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedMissionDismissRequest(testbedMissionDismissId, response);
     return;
   }
   const testbedMissionAcceptFailureId = monitorTestbedMissionActionId(url.pathname, "accept-failure");
@@ -1550,31 +1569,7 @@ async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage,
       return;
     }
 
-    const targetUrl = stringField(payload, "targetUrl");
-    if (!targetUrl) {
-      writeJson(response, 400, {
-        error: "missing_target_url",
-        message: "targetUrl is required so Hermes knows which page to test.",
-      });
-      return;
-    }
-
-    const mode = stringField(payload, "mode");
-    const created = createTestbedMissionFromAgent({
-      targetUrl,
-      ...(stringField(payload, "goal") ? { goal: stringField(payload, "goal") } : {}),
-      ...(stringField(payload, "agentName") ? { agentName: stringField(payload, "agentName") } : {}),
-      ...(stringField(payload, "requester") ? { requester: stringField(payload, "requester") } : {}),
-      ...(stringField(payload, "environment") ? { environment: stringField(payload, "environment") } : {}),
-      ...(booleanField(payload, "freshMemory") !== undefined ? { freshMemory: booleanField(payload, "freshMemory") } : {}),
-      ...(booleanField(payload, "allowTestMutations") !== undefined ? { allowTestMutations: booleanField(payload, "allowTestMutations") } : {}),
-      ...(numberField(payload, "maxBrowserSteps") !== undefined ? { maxBrowserSteps: numberField(payload, "maxBrowserSteps") } : {}),
-      ...(numberField(payload, "maxMinutes") !== undefined ? { maxMinutes: numberField(payload, "maxMinutes") } : {}),
-      ...(mode === "surface_sweep" || mode === "siwe_auth" || mode === "gold_path" ? { mode } : {}),
-      ...(Array.isArray(payload.routes)
-        ? { routes: payload.routes.filter((r): r is string => typeof r === "string" && r.length > 0) }
-        : {}),
-    });
+    const created = createMonitorTestbedMissionFromPayload(payload);
     recordTestbedMissionCollaboration(created.run);
     logger.info(
       {
@@ -1589,6 +1584,13 @@ async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage,
       ...created,
     });
   } catch (error) {
+    if (error instanceof TestbedMissionRequestValidationError) {
+      writeJson(response, 400, {
+        error: error.code,
+        message: error.message,
+      });
+      return;
+    }
     logger.error({ err: error }, "monitor_testbed_mission_create_failed");
     writeJson(response, 500, {
       error: "monitor_testbed_mission_create_failed",
@@ -1668,6 +1670,36 @@ async function handleMonitorTestbedMissionApprovalRequest(id: string, response: 
     logger.error({ err: error, missionId: id }, "monitor_testbed_mission_approval_failed");
     writeJson(response, 500, {
       error: "monitor_testbed_mission_approval_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorTestbedMissionDismissRequest(id: string, response: http.ServerResponse) {
+  try {
+    const result = dismissRequestedTestbedMissionRun(id, { dismissedBy: "operator" });
+    if (!result.ok) {
+      if (result.error === "not_found") {
+        writeJson(response, 404, { error: "testbed_mission_not_found", id });
+        return;
+      }
+      writeJson(response, 409, {
+        error: "testbed_mission_not_requested",
+        id,
+        status: result.run?.status,
+      });
+      return;
+    }
+    recordTestbedMissionDismissedCollaboration(result.run);
+    logger.info({ missionId: id }, "monitor_testbed_mission_dismissed");
+    writeJson(response, 200, {
+      ok: true,
+      run: result.run,
+    });
+  } catch (error) {
+    logger.error({ err: error, missionId: id }, "monitor_testbed_mission_dismiss_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_mission_dismiss_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }
@@ -1827,6 +1859,23 @@ function recordTestbedMissionApprovalCollaboration(run: TestbedMissionRun): void
     });
   } catch (error) {
     logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_approval_collaboration_failed");
+  }
+}
+
+function recordTestbedMissionDismissedCollaboration(run: TestbedMissionRun): void {
+  try {
+    recordCollaborationMessage({
+      author: "hermes",
+      kind: "status",
+      addressedTo: "operator",
+      relatedCorrelationId: run.id,
+      text: [
+        `Operator dismissed requested tester run ${run.id}.`,
+        "The runner never claimed it; no browser mission was started.",
+      ].join(" "),
+    });
+  } catch (error) {
+    logger.warn({ err: error, missionId: run.id }, "monitor_testbed_mission_dismiss_collaboration_failed");
   }
 }
 
@@ -3405,14 +3454,6 @@ function numberField(value: unknown, key: string): number | undefined {
   return undefined;
 }
 
-function booleanField(value: unknown, key: string): boolean | undefined {
-  if (!isRecord(value)) return undefined;
-  const field = value[key];
-  if (typeof field === "boolean") return field;
-  if (typeof field === "string") return parseOptionalBoolean(field);
-  return undefined;
-}
-
 function formatUtcTime(time: { hour: number; minute: number }): string {
   return `${String(time.hour).padStart(2, "0")}:${String(time.minute).padStart(2, "0")}`;
 }
@@ -3462,7 +3503,7 @@ function monitorTestbedMissionApproveId(pathname: string): string | undefined {
   return id.length > 0 && !id.includes("/") ? id : undefined;
 }
 
-function monitorTestbedMissionActionId(pathname: string, action: "accept-failure" | "open-issue"): string | undefined {
+function monitorTestbedMissionActionId(pathname: string, action: "accept-failure" | "dismiss" | "open-issue"): string | undefined {
   const prefix = "/monitor/testbed-missions/";
   const suffix = `/${action}`;
   if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return undefined;

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -190,6 +190,10 @@ export type ApproveTestbedMissionRunResult =
   | { ok: true; run: TestbedMissionRun }
   | { ok: false; error: "not_found" | "not_requested"; run?: TestbedMissionRun };
 
+export type DismissTestbedMissionRunResult =
+  | { ok: true; run: TestbedMissionRun }
+  | { ok: false; error: "not_found" | "not_requested"; run?: TestbedMissionRun };
+
 export type TestbedMissionFailureTriageResult =
   | { ok: true; run: TestbedMissionRun }
   | { ok: false; error: "not_found" | "not_failed"; run?: TestbedMissionRun };
@@ -346,6 +350,33 @@ export function approveTestbedMissionRun(
   trimMissionHistory(existing);
   persistMissionStore(deps.path);
   return { ok: true, run: cloneRun(existing) };
+}
+
+export function dismissRequestedTestbedMissionRun(
+  id: string,
+  deps: TestbedMissionStoreDeps & { dismissedBy?: string } = {}
+): DismissTestbedMissionRunResult {
+  ensureMissionStoreLoaded(deps.path, { force: true });
+  const index = missionRuns.findIndex((run) => run.id === id);
+  if (index < 0) return { ok: false, error: "not_found" };
+  const existing = missionRuns[index];
+  if (existing.status !== "requested") {
+    return { ok: false, error: "not_requested", run: cloneRun(existing) };
+  }
+  const now = (deps.now ?? new Date()).toISOString();
+  existing.updatedAt = now;
+  existing.statusReason = `Operator dismissed the requested tester run before the runner claimed it.`;
+  existing.history.push({
+    at: now,
+    status: "requested",
+    event: "mission_dismissed",
+    message: `${existing.statusReason} Dismissed by ${deps.dismissedBy ?? "operator"}.`,
+  });
+  trimMissionHistory(existing);
+  const dismissed = cloneRun(existing);
+  missionRuns.splice(index, 1);
+  persistMissionStore(deps.path);
+  return { ok: true, run: dismissed };
 }
 
 export function acceptTestbedMissionFailure(

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -40,6 +40,22 @@ export interface AgentTestbedMissionInput {
   requireApproval?: boolean;
 }
 
+export interface MonitorTestbedMissionPostInput {
+  targetUrl?: unknown;
+  goal?: unknown;
+  agentName?: unknown;
+  requester?: unknown;
+  environment?: unknown;
+  freshMemory?: unknown;
+  allowTestMutations?: unknown;
+  maxBrowserSteps?: unknown;
+  maxMinutes?: unknown;
+  mode?: unknown;
+  initialStatus?: unknown;
+  routes?: unknown;
+  path?: string;
+}
+
 export type AgentRequestedTestbedMissionMode = "fresh" | "memory";
 
 export interface AgentRequestedTestbedMissionInput {
@@ -91,6 +107,34 @@ export function createTestbedMissionFromAgent(
   // guarded by their own budget/preflight rules.
   const initialStatus = input.requireApproval ? "requested" : "ready";
   return createTestbedMissionRecord(input, nowMs, { initialStatus });
+}
+
+export function createMonitorTestbedMissionFromPayload(
+  input: MonitorTestbedMissionPostInput,
+  nowMs: number = Date.now()
+): AgentTestbedMissionResult {
+  const targetUrl = parseHttpUrl(input.targetUrl);
+  const mode = parseMonitorMissionMode(input.mode);
+  const initialStatus = cleanString(input.initialStatus);
+  const missionInput: AgentTestbedMissionInput = {
+    targetUrl,
+    ...(cleanString(input.goal) ? { goal: cleanString(input.goal) } : {}),
+    ...(cleanString(input.agentName) ? { agentName: cleanString(input.agentName) } : {}),
+    ...(cleanString(input.requester) ? { requester: cleanString(input.requester) } : {}),
+    ...(cleanString(input.environment) ? { environment: cleanString(input.environment) } : {}),
+    ...(parseOptionalBoolean(input.freshMemory) !== undefined ? { freshMemory: parseOptionalBoolean(input.freshMemory) } : {}),
+    ...(parseOptionalNumber(input.maxBrowserSteps) !== undefined ? { maxBrowserSteps: parseOptionalNumber(input.maxBrowserSteps) } : {}),
+    ...(parseOptionalNumber(input.maxMinutes) !== undefined ? { maxMinutes: parseOptionalNumber(input.maxMinutes) } : {}),
+    ...(mode ? { mode } : {}),
+    ...(parseStringArray(input.routes).length > 0 ? { routes: parseStringArray(input.routes) } : {}),
+    ...(initialStatus === "requested" ? { requireApproval: true } : {}),
+    ...(input.path ? { path: input.path } : {}),
+    allowTestMutations: mode === "gold_path",
+  };
+  // Deliberately ignore input.allowTestMutations. The monitor board launcher
+  // never sends it; if a client forges it, mutation posture is still derived
+  // server-side from the target, mode, and configured environment.
+  return createTestbedMissionFromAgent(missionInput, nowMs);
 }
 
 export function requestTestbedMissionFromAgent(
@@ -247,6 +291,31 @@ function nextStepForRun(
 
 function cleanString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function parseOptionalNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return value;
+}
+
+function parseStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function parseMonitorMissionMode(value: unknown): TestbedMissionMode | undefined {
+  const mode = cleanString(value);
+  if (mode === "surface_sweep" || mode === "siwe_auth" || mode === "gold_path") return mode;
+  return undefined;
 }
 
 function parseAgentRequestedTestbedMission(input: AgentRequestedTestbedMissionInput): {

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -4,6 +4,7 @@ import {
   __resetTestbedMissionRunsForTests,
   acceptTestbedMissionFailure,
   diagnoseTestbedMissionReportFromMessage,
+  dismissRequestedTestbedMissionRun,
   failedTestbedMissionsForSelfHealing,
   failTestbedMissionRun,
   listTestbedMissionRuns,
@@ -156,6 +157,44 @@ describe("monitor testbed mission runs", () => {
         missionEnvironment: "mainnet",
       },
     });
+  });
+
+  it("dismisses only requested mission runs before a runner can claim them", () => {
+    const requested = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/requested" }),
+      Date.parse("2026-05-22T10:00:00.000Z"),
+      undefined,
+      { initialStatus: "requested" },
+    )!;
+    const ready = recordTestbedMissionRunFromOperatorResult(
+      missionResult({ targetUrl: "https://testbed.example/ready" }),
+      Date.parse("2026-05-22T10:01:00.000Z"),
+    )!;
+
+    const dismissed = dismissRequestedTestbedMissionRun(requested.id, {
+      now: new Date("2026-05-22T10:02:00.000Z"),
+      dismissedBy: "operator",
+    });
+    const rejected = dismissRequestedTestbedMissionRun(ready.id);
+
+    expect(dismissed).toMatchObject({
+      ok: true,
+      run: {
+        id: requested.id,
+        status: "requested",
+        statusReason: "Operator dismissed the requested tester run before the runner claimed it.",
+        history: [
+          { event: "mission_requested" },
+          { event: "mission_dismissed", at: "2026-05-22T10:02:00.000Z" },
+        ],
+      },
+    });
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: "not_requested",
+      run: { id: ready.id, status: "ready" },
+    });
+    expect(listTestbedMissionRuns({ limit: 10 }).map((run) => run.id)).toEqual([ready.id]);
   });
 
   it("turns active mission runs into mission-native board items", () => {

--- a/test/unit/testbed-agent-entrypoint.test.ts
+++ b/test/unit/testbed-agent-entrypoint.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
 import {
   createTestbedMissionFromAgent,
+  createMonitorTestbedMissionFromPayload,
   getTestbedMissionForAgent,
   listTestbedMissionsForAgent,
   requestTestbedMissionFromAgent,
@@ -207,6 +208,54 @@ describe("testbed agent entrypoint", () => {
       mutationMode: "read_only",
     });
     expect(String(result.mission.missionPrompt)).toContain("Mutation profile override: mainnet / read_only");
+  });
+
+  it("ignores client mutation flags on monitor mission posts", () => {
+    const result = createMonitorTestbedMissionFromPayload(
+      {
+        path,
+        targetUrl: "https://app.averray.com",
+        mode: "surface_sweep",
+        initialStatus: "ready",
+        freshMemory: true,
+        allowTestMutations: true,
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    expect(result.run).toMatchObject({
+      targetUrl: "https://app.averray.com/",
+      mode: "surface_sweep",
+      status: "ready",
+      requestedAllowTestMutations: false,
+      allowTestMutations: false,
+      environment: "mainnet",
+      mutationMode: "read_only",
+      mutationBindingReason: "surface_sweep missions are read-only by contract.",
+    });
+  });
+
+  it("derives testnet gold-path mutation posture from mode and target, not a client flag", () => {
+    const result = createMonitorTestbedMissionFromPayload(
+      {
+        path,
+        targetUrl: "https://testnet.averray.example/gold-path",
+        mode: "gold_path",
+        initialStatus: "ready",
+        freshMemory: true,
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    expect(result.run).toMatchObject({
+      targetUrl: "https://testnet.averray.example/gold-path",
+      mode: "gold_path",
+      status: "ready",
+      requestedAllowTestMutations: true,
+      allowTestMutations: true,
+      environment: "testnet",
+      mutationMode: "testbed_mutation_allowed",
+    });
   });
 
   it("allows explicit testnet mutation binding for test-mode missions", () => {


### PR DESCRIPTION
What changed
- Added a compact board-level Start a mission launcher for URL, Surface Sweep vs Gold Path, Fresh vs Memory, optional goal, and requested-vs-ready status.
- Preserved /mission <url> while widening the default mission POST body through a whitelist-only request shape.
- Wired requested mission Dismiss as a real backend action; Approve/Dismiss now both operate on requested tester cards.
- Moved monitor mission POST parsing into a shared helper that ignores forged client allowTestMutations flags while deriving Gold Path mutation posture server-side from mode and target environment.

Checks run
- npm run typecheck
- npm test
- npm --workspace @avg/monitor-ui run build
- Browser smoke check on http://127.0.0.1:5174/ verified the launcher opens and renders target/flow/memory/goal/approval controls.

Surfaces affected
- Frontend: monitor-ui board controls and card actions.
- Backend: slack-operator monitor testbed mission create/dismiss endpoints and mission store.
- No contracts, deploy config, Caddy, or secrets changed.

Authority and safety
- No auto-run or merge/deploy authority changes.
- Launcher never sends raw allowTestMutations.
- Requested missions remain operator-gated until approved; dismiss only clears not-yet-claimed requested runs.
- Human merge/deploy gate unchanged.