### PR TITLE
feat(monitor): add saved testbed suites

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -205,6 +205,86 @@ describe("MonitorPage — container", () => {
     }
   });
 
+  test("the board launcher can save the launched config as a suite", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({ cards: [], at: "2026-05-28T10:30:00Z" }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
+    try {
+      const { getByRole, getByLabelText } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Start a mission" })).toBeTruthy());
+
+      fireEvent.click(getByRole("button", { name: "Start a mission" }));
+      fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/overview" } });
+      fireEvent.click(getByLabelText(/Save this config as a suite/));
+      fireEvent.change(getByLabelText("Suite name"), { target: { value: "Daily app sweep" } });
+      fireEvent.click(getByRole("button", { name: "Launch mission" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const [missionUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const [suiteUrl, suiteInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+      expect(missionUrl).toBe("/monitor/testbed-missions");
+      expect(suiteUrl).toBe("/monitor/testbed-suites");
+      expect(JSON.parse(String(suiteInit.body))).toEqual({
+        name: "Daily app sweep",
+        target: "https://app.averray.com/overview",
+        mode: "surface_sweep",
+        author: "operator",
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("the saved suite Run button POSTs to /monitor/testbed-suites/:id/run", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [],
+      at: "2026-05-28T10:30:00Z",
+      testbedSuites: [{
+        schemaVersion: 1,
+        kind: "testbed_suite",
+        id: "testbed-suite-daily-app-sweep-1",
+        name: "Daily app sweep",
+        target: "https://app.averray.com",
+        mode: "surface_sweep",
+        author: "operator",
+        createdAt: "2026-05-28T10:00:00.000Z",
+        updatedAt: "2026-05-28T10:00:00.000Z",
+        history: [],
+      }],
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 202 }));
+    try {
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Run" })).toBeTruthy());
+
+      fireEvent.click(getByRole("button", { name: "Run" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      expect(calledUrl).toBe("/monitor/testbed-suites/testbed-suite-daily-app-sweep-1/run");
+      expect(init.method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   test("the default mission approval POSTs to /monitor/testbed-missions/:id/approve", async () => {
     const requestedMission = {
       id: "testbed-mission-requested-1",

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -29,11 +29,12 @@ import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionA
 import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonomyMode.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import type { BoardCard, CreateTaskInput } from "./lib/monitor/card-types.js";
-import type { MissionSpawnInput } from "./lib/monitor/mission-launch.js";
+import type { MissionSpawnInput, SaveTestSuiteInput } from "./lib/monitor/mission-launch.js";
 import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
 const MISSIONS_URL = "/monitor/testbed-missions";
+const SUITES_URL = "/monitor/testbed-suites";
 const CODEX_TASKS_URL = "/monitor/codex-tasks";
 const SELF_HEALING_PROPOSALS_URL = "/monitor/self-healing-proposals";
 const ALERT_MUTE_URL = "/monitor/alert-mute";
@@ -47,6 +48,10 @@ export interface MonitorPageProps {
   backlogSuggestions?: UseBacklogSuggestionsOptions;
   /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
   onSpawnMission?: (input: MissionSpawnInput) => void;
+  /** Override saving a named suite (defaults to POST /monitor/testbed-suites). */
+  onSaveSuite?: (input: SaveTestSuiteInput) => void;
+  /** Override running a named suite (defaults to POST /monitor/testbed-suites/:id/run). */
+  onRunSuite?: (id: string) => void;
   /** Override the /claude propose (defaults to POST /monitor/codex-tasks). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Override the create-task dispatch (defaults to POST /monitor/codex-tasks propose). */
@@ -81,6 +86,8 @@ export function MonitorPage({
   options,
   backlogSuggestions,
   onSpawnMission = defaultSpawnMission,
+  onSaveSuite = defaultSaveSuite,
+  onRunSuite = defaultRunSuite,
   onSpawnClaudeTask = defaultSpawnClaudeTask,
   onCreateTask = defaultCreateTask,
   onApproveTask = defaultApproveTask,
@@ -131,6 +138,8 @@ export function MonitorPage({
         onCardClose={clearCard}
         onCardNavigate={setCard}
         onSpawnMission={onSpawnMission}
+        onSaveSuite={onSaveSuite}
+        onRunSuite={onRunSuite}
         onSpawnClaudeTask={onSpawnClaudeTask}
         onCreateTask={onCreateTask}
         onApproveTask={onApproveTask}
@@ -151,6 +160,25 @@ export function MonitorPage({
       />
     </ErrorBoundary>
   );
+}
+
+function defaultSaveSuite(input: SaveTestSuiteInput): void {
+  void fetch(SUITES_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+function defaultRunSuite(id: string): void {
+  void fetch(`${SUITES_URL}/${encodeURIComponent(id)}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
 }
 
 /**

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -97,6 +97,73 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
   });
 
+  test("renders saved suites with run history and dispatches re-runs", () => {
+    const onRunSuite = vi.fn();
+    const board: MonitorBoard = {
+      at: "2026-06-02T08:00:00Z",
+      cards: [],
+      testbedSuites: [{
+        schemaVersion: 1,
+        kind: "testbed_suite",
+        id: "testbed-suite-daily-sweep-1",
+        name: "Daily app sweep",
+        target: "https://app.averray.com/overview",
+        mode: "surface_sweep",
+        author: "operator",
+        createdAt: "2026-06-02T07:00:00.000Z",
+        updatedAt: "2026-06-02T07:30:00.000Z",
+        history: [{ runId: "testbed-mission-1", verdict: "pass", ts: "2026-06-02T07:30:00.000Z" }],
+        lastRun: { runId: "testbed-mission-1", verdict: "pass", ts: "2026-06-02T07:30:00.000Z" },
+      }],
+    };
+    const { getByText, getByRole } = render(<BoardView board={board} status="open" onRunSuite={onRunSuite} keyboard={false} />);
+
+    expect(getByText("Daily app sweep")).toBeTruthy();
+    expect(getByText("pass")).toBeTruthy();
+    expect(getByText("1 runs")).toBeTruthy();
+
+    fireEvent.click(getByRole("button", { name: "Run" }));
+    expect(onRunSuite).toHaveBeenCalledWith("testbed-suite-daily-sweep-1");
+  });
+
+  test("promotes a launcher config into a named saved suite", () => {
+    const onSpawnMission = vi.fn();
+    const onSaveSuite = vi.fn();
+    const board: MonitorBoard = { at: "2026-06-02T08:00:00Z", cards: [] };
+    const { getByRole, getByLabelText } = render(
+      <BoardView
+        board={board}
+        status="open"
+        onSpawnMission={onSpawnMission}
+        onSaveSuite={onSaveSuite}
+        keyboard={false}
+      />,
+    );
+
+    fireEvent.click(getByRole("button", { name: "Start a mission" }));
+    fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/agents" } });
+    fireEvent.click(getByLabelText(/Role Gating/));
+    fireEvent.change(getByLabelText("Goal"), { target: { value: "verify role gates" } });
+    fireEvent.click(getByLabelText(/Save this config as a suite/));
+    fireEvent.change(getByLabelText("Suite name"), { target: { value: "Role gate sweep" } });
+    fireEvent.click(getByRole("button", { name: "Launch mission" }));
+
+    expect(onSpawnMission).toHaveBeenCalledWith({
+      targetUrl: "https://app.averray.com/agents",
+      mode: "siwe_auth",
+      freshMemory: true,
+      initialStatus: "ready",
+      goal: "verify role gates",
+    });
+    expect(onSaveSuite).toHaveBeenCalledWith({
+      name: "Role gate sweep",
+      target: "https://app.averray.com/agents",
+      mode: "siwe_auth",
+      author: "operator",
+      goal: "verify role gates",
+    });
+  });
+
   test("a calm board still expands lanes holding in-flight cards (regression: action==0 used to hide all but Done)", () => {
     const calm: MonitorBoard = {
       at: "2026-05-28T10:30:00Z",

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -23,9 +23,10 @@ import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache
 import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
-import type { MissionSpawnInput } from "../lib/monitor/mission-launch.js";
+import type { MissionSpawnInput, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
 import { CreateTaskForm } from "./CreateTaskForm.js";
 import { StartMissionLauncher } from "./StartMissionLauncher.js";
+import { TestSuitesPanel } from "./TestSuitesPanel.js";
 import { laneFor } from "../lib/monitor/lane-rules.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
@@ -98,6 +99,8 @@ export interface BoardViewProps {
   onCardClose?: () => void;
   onCardNavigate?: (id: string) => void;
   onSpawnMission?: (input: MissionSpawnInput) => void;
+  onSaveSuite?: (input: SaveTestSuiteInput) => void;
+  onRunSuite?: (id: string) => void;
   /** Propose a greenfield Claude task (/claude <repo> <task>). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Propose a task — /task verb + the codex-needed create form (O3). */
@@ -142,6 +145,8 @@ export function BoardView({
   onCardClose,
   onCardNavigate,
   onSpawnMission,
+  onSaveSuite,
+  onRunSuite,
   onSpawnClaudeTask,
   onCreateTask,
   onApproveTask,
@@ -500,7 +505,8 @@ export function BoardView({
             onFilterChange={setFilter}
           />
           <LlmUsagePanel usage={board?.llmUsage} />
-          {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} /> : null}
+          <TestSuitesPanel suites={board?.testbedSuites} onRunSuite={onRunSuite} onSaveSuite={onSaveSuite} />
+          {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} onSaveSuite={onSaveSuite} /> : null}
           <Board
             grouped={displayGrouped}
             expanded={effectiveExpanded}

--- a/packages/monitor-ui/src/components/StartMissionLauncher.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.tsx
@@ -1,20 +1,24 @@
 import { useId, useState, type FormEvent } from "react";
-import type { MissionLaunchInput, MissionLaunchMode } from "../lib/monitor/mission-launch.js";
+import type { MissionLaunchInput, MissionLaunchMode, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
 
 const DEFAULT_TARGET = "https://app.averray.com";
 
 export interface StartMissionLauncherProps {
   onSpawnMission?: (input: MissionLaunchInput) => void;
+  onSaveSuite?: (input: SaveTestSuiteInput) => void;
 }
 
-export function StartMissionLauncher({ onSpawnMission }: StartMissionLauncherProps) {
+export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissionLauncherProps) {
   const targetId = useId();
   const goalId = useId();
+  const suiteNameId = useId();
   const [open, setOpen] = useState(false);
   const [targetUrl, setTargetUrl] = useState(DEFAULT_TARGET);
   const [mode, setMode] = useState<MissionLaunchMode>("surface_sweep");
   const [freshMemory, setFreshMemory] = useState(true);
   const [requestApproval, setRequestApproval] = useState(false);
+  const [saveSuite, setSaveSuite] = useState(false);
+  const [suiteName, setSuiteName] = useState("");
   const [goal, setGoal] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -23,6 +27,10 @@ export function StartMissionLauncher({ onSpawnMission }: StartMissionLauncherPro
     const target = targetUrl.trim();
     if (!isHttpUrl(target)) {
       setError("Use an http:// or https:// target.");
+      return;
+    }
+    if (saveSuite && !suiteName.trim()) {
+      setError("Name the suite before saving it.");
       return;
     }
     setError(null);
@@ -34,6 +42,15 @@ export function StartMissionLauncher({ onSpawnMission }: StartMissionLauncherPro
       initialStatus: requestApproval ? "requested" : "ready",
       ...(trimmedGoal ? { goal: trimmedGoal } : {}),
     });
+    if (saveSuite) {
+      onSaveSuite?.({
+        name: suiteName.trim(),
+        target,
+        mode,
+        author: "operator",
+        ...(trimmedGoal ? { goal: trimmedGoal } : {}),
+      });
+    }
     setOpen(false);
   };
 
@@ -86,6 +103,16 @@ export function StartMissionLauncher({ onSpawnMission }: StartMissionLauncherPro
               <span>Gold Path</span>
               <small>testnet</small>
             </label>
+            <label>
+              <input
+                type="radio"
+                name="mission-flow"
+                checked={mode === "siwe_auth"}
+                onChange={() => setMode("siwe_auth")}
+              />
+              <span>Role Gating</span>
+              <small>read-only</small>
+            </label>
           </fieldset>
 
           <fieldset className="hm-choice-group hm-choice-group--compact">
@@ -129,6 +156,30 @@ export function StartMissionLauncher({ onSpawnMission }: StartMissionLauncherPro
             />
             <span>Request approval before the runner claims it</span>
           </label>
+
+          {onSaveSuite ? (
+            <>
+              <label className="hm-checkbox-row">
+                <input
+                  type="checkbox"
+                  checked={saveSuite}
+                  onChange={(event) => setSaveSuite(event.target.checked)}
+                />
+                <span>Save this config as a suite</span>
+              </label>
+              {saveSuite ? (
+                <label className="hm-field" htmlFor={suiteNameId}>
+                  <span>Suite name</span>
+                  <input
+                    id={suiteNameId}
+                    value={suiteName}
+                    onChange={(event) => setSuiteName(event.target.value)}
+                    placeholder="Daily app sweep"
+                  />
+                </label>
+              ) : null}
+            </>
+          ) : null}
 
           {error ? <div className="hm-form-error" role="alert">{error}</div> : null}
 

--- a/packages/monitor-ui/src/components/TestSuitesPanel.tsx
+++ b/packages/monitor-ui/src/components/TestSuitesPanel.tsx
@@ -1,0 +1,191 @@
+import { useId, useMemo, useState, type FormEvent } from "react";
+import type { MissionLaunchMode, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+
+const DEFAULT_TARGET = "https://app.averray.com";
+
+export interface TestSuitesPanelProps {
+  suites?: SavedTestSuite[];
+  onRunSuite?: (id: string) => void;
+  onSaveSuite?: (input: SaveTestSuiteInput) => void;
+}
+
+export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite }: TestSuitesPanelProps) {
+  const nameId = useId();
+  const targetId = useId();
+  const goalId = useId();
+  const [open, setOpen] = useState(false);
+  const [authoringPath, setAuthoringPath] = useState<"predefined" | "operator">("predefined");
+  const [name, setName] = useState("");
+  const [target, setTarget] = useState(DEFAULT_TARGET);
+  const [mode, setMode] = useState<MissionLaunchMode>("surface_sweep");
+  const [goal, setGoal] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const sortedSuites = useMemo(
+    () => suites.slice().sort((a, b) => (b.lastRun?.ts ?? b.updatedAt).localeCompare(a.lastRun?.ts ?? a.updatedAt)),
+    [suites],
+  );
+
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedTarget = target.trim();
+    const trimmedName = name.trim();
+    const trimmedGoal = goal.trim();
+    if (!trimmedName) {
+      setError("Name the suite before saving it.");
+      return;
+    }
+    if (!isHttpUrl(trimmedTarget)) {
+      setError("Use an http:// or https:// target.");
+      return;
+    }
+    if (authoringPath === "operator" && !trimmedGoal) {
+      setError("Operator-NL suites need a goal.");
+      return;
+    }
+    setError(null);
+    onSaveSuite?.({
+      name: trimmedName,
+      target: trimmedTarget,
+      mode: authoringPath === "operator" ? "surface_sweep" : mode,
+      author: authoringPath,
+      ...(trimmedGoal ? { goal: trimmedGoal } : {}),
+    });
+    setOpen(false);
+  };
+
+  return (
+    <section className="hm-test-suites" aria-label="Saved test suites">
+      <div className="hm-mission-launcher-head">
+        <div>
+          <span className="hm-mission-launcher-kicker">Suites</span>
+          <strong>Saved suite library</strong>
+          <span>{suites.length > 0 ? `${suites.length} named suites` : "No saved suites yet"}</span>
+        </div>
+        {onSaveSuite ? (
+          <button type="button" className="hm-btn hm-btn--sm" onClick={() => setOpen((value) => !value)}>
+            {open ? "Close" : "+ New suite"}
+          </button>
+        ) : null}
+      </div>
+
+      {sortedSuites.length > 0 ? (
+        <div className="hm-test-suite-list">
+          {sortedSuites.map((suite) => (
+            <div className="hm-test-suite-row" key={suite.id}>
+              <div>
+                <strong>{suite.name}</strong>
+                <span>{modeLabel(suite.mode)} · {targetLabel(suite.target)}</span>
+              </div>
+              <div className="hm-test-suite-meta">
+                <span className={`hm-test-suite-verdict hm-test-suite-verdict--${verdictTone(suite.lastRun?.verdict)}`}>
+                  {suite.lastRun ? suite.lastRun.verdict : "never run"}
+                </span>
+                <small>{suite.history.length} runs</small>
+              </div>
+              {onRunSuite ? (
+                <button type="button" className="hm-btn hm-btn--action hm-btn--sm" onClick={() => onRunSuite(suite.id)}>
+                  Run
+                </button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="hm-test-suite-empty">Save a launcher config or create a named suite for repeat testbed runs.</p>
+      )}
+
+      {open ? (
+        <form className="hm-mission-launcher-form hm-test-suite-form" onSubmit={submit}>
+          <fieldset className="hm-choice-group">
+            <legend>Authoring</legend>
+            <label>
+              <input
+                type="radio"
+                name="suite-authoring"
+                checked={authoringPath === "predefined"}
+                onChange={() => setAuthoringPath("predefined")}
+              />
+              <span>Predefined</span>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="suite-authoring"
+                checked={authoringPath === "operator"}
+                onChange={() => setAuthoringPath("operator")}
+              />
+              <span>Operator-NL</span>
+            </label>
+          </fieldset>
+          <label className="hm-field" htmlFor={nameId}>
+            <span>Name</span>
+            <input id={nameId} value={name} onChange={(event) => setName(event.target.value)} placeholder="Daily surface sweep" />
+          </label>
+          <label className="hm-field" htmlFor={targetId}>
+            <span>Target</span>
+            <input id={targetId} type="url" value={target} onChange={(event) => setTarget(event.target.value)} placeholder={DEFAULT_TARGET} />
+          </label>
+          {authoringPath === "predefined" ? (
+            <fieldset className="hm-choice-group hm-choice-group--suite-flow">
+              <legend>Flow</legend>
+              <label>
+                <input type="radio" name="suite-flow" checked={mode === "surface_sweep"} onChange={() => setMode("surface_sweep")} />
+                <span>Surface Sweep</span>
+              </label>
+              <label>
+                <input type="radio" name="suite-flow" checked={mode === "gold_path"} onChange={() => setMode("gold_path")} />
+                <span>Gold Path</span>
+              </label>
+              <label>
+                <input type="radio" name="suite-flow" checked={mode === "siwe_auth"} onChange={() => setMode("siwe_auth")} />
+                <span>Role Gating</span>
+              </label>
+            </fieldset>
+          ) : null}
+          <label className="hm-field hm-field--wide" htmlFor={goalId}>
+            <span>Goal</span>
+            <textarea id={goalId} value={goal} onChange={(event) => setGoal(event.target.value)} rows={2} placeholder="What should the tester prove?" />
+          </label>
+          {error ? <div className="hm-form-error" role="alert">{error}</div> : null}
+          <div className="hm-mission-launcher-actions">
+            <button type="submit" className="hm-btn hm-btn--action">
+              Save suite
+            </button>
+            <span>Saved suites still use server-side mutation safety when run.</span>
+          </div>
+        </form>
+      ) : null}
+    </section>
+  );
+}
+
+function modeLabel(mode: MissionLaunchMode): string {
+  if (mode === "gold_path") return "Gold Path";
+  if (mode === "siwe_auth") return "Role Gating";
+  return "Surface Sweep";
+}
+
+function targetLabel(value: string): string {
+  try {
+    const parsed = new URL(value);
+    return parsed.host;
+  } catch {
+    return value;
+  }
+}
+
+function verdictTone(verdict: string | undefined): string {
+  if (verdict === "pass" || verdict === "completed") return "pass";
+  if (verdict === "fail" || verdict === "failed") return "fail";
+  if (verdict === "partial" || verdict === "running" || verdict === "requested" || verdict === "ready") return "partial";
+  return "unknown";
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -7,12 +7,14 @@
 
 import type { BoardCard, Lane } from "./card-types.js";
 import type { CalmBoardMetrics } from "./board-state.js";
+import type { SavedTestSuite } from "./mission-launch.js";
 
 export interface MonitorBoard {
   cards: BoardCard[];
   /** ISO timestamp from the server */
   at: string;
   llmUsage?: LlmUsageAggregate;
+  testbedSuites?: SavedTestSuite[];
   /** Optional board-summary metrics; omitted means the UI must not fabricate them. */
   calmMetrics?: CalmBoardMetrics;
   /** Quiet automation-capacity gauge. Omitted means the UI must omit it. */
@@ -105,10 +107,12 @@ export function applyEventToBoard(
         ? event.automationHealth
         : undefined;
       const llmUsage = isLlmUsageAggregate(event.llmUsage) ? event.llmUsage : undefined;
+      const testbedSuites = Array.isArray(event.testbedSuites) ? (event.testbedSuites as SavedTestSuite[]) : undefined;
       return {
         cards,
         at,
         ...(llmUsage ? { llmUsage } : {}),
+        ...(testbedSuites ? { testbedSuites } : {}),
         ...(calmMetrics ? { calmMetrics } : {}),
         ...(automationHealth ? { automationHealth } : {}),
       };

--- a/packages/monitor-ui/src/lib/monitor/mission-launch.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-launch.ts
@@ -1,5 +1,7 @@
-export type MissionLaunchMode = "surface_sweep" | "gold_path";
+export type MissionLaunchMode = "surface_sweep" | "gold_path" | "siwe_auth";
 export type MissionInitialStatus = "ready" | "requested";
+export type SavedTestSuiteAuthor = "predefined" | "operator" | "test-writer" | "platform";
+export type SavedTestSuiteVerdict = "pass" | "partial" | "fail" | "requested" | "ready" | "running" | "failed" | "unknown";
 
 export interface MissionLaunchInput {
   targetUrl: string;
@@ -10,3 +12,32 @@ export interface MissionLaunchInput {
 }
 
 export type MissionSpawnInput = string | MissionLaunchInput;
+
+export interface SavedTestSuiteHistoryEntry {
+  runId: string;
+  verdict: SavedTestSuiteVerdict;
+  ts: string;
+}
+
+export interface SavedTestSuite {
+  schemaVersion: 1;
+  kind: "testbed_suite";
+  id: string;
+  name: string;
+  target: string;
+  mode: MissionLaunchMode;
+  goal?: string;
+  author: SavedTestSuiteAuthor;
+  createdAt: string;
+  updatedAt: string;
+  history: SavedTestSuiteHistoryEntry[];
+  lastRun?: SavedTestSuiteHistoryEntry;
+}
+
+export interface SaveTestSuiteInput {
+  name: string;
+  target: string;
+  mode: MissionLaunchMode;
+  goal?: string;
+  author: SavedTestSuiteAuthor;
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -399,6 +399,15 @@ body { margin: 0; }
   border: 1px solid var(--hm-line);
   border-radius: var(--hm-radius);
 }
+.hm-test-suites {
+  margin: 0 22px 10px;
+  padding: 10px 12px;
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  display: grid;
+  gap: 10px;
+}
 .hm-mission-launcher-head {
   display: flex;
   align-items: center;
@@ -476,6 +485,55 @@ body { margin: 0; }
   margin: 0;
   padding: 0;
   border: 0;
+}
+.hm-choice-group--suite-flow {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.hm-test-suite-list {
+  display: grid;
+  gap: 6px;
+}
+.hm-test-suite-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid var(--hm-line);
+  border-radius: 8px;
+  background: var(--hm-rail);
+}
+.hm-test-suite-row > div:first-child {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.hm-test-suite-row strong {
+  font-family: var(--font-display);
+  font-size: 13px;
+}
+.hm-test-suite-row span,
+.hm-test-suite-row small,
+.hm-test-suite-empty {
+  color: var(--hm-muted);
+  font-size: 12px;
+}
+.hm-test-suite-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.hm-test-suite-verdict {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+}
+.hm-test-suite-verdict--pass { color: var(--hm-sage-deep); }
+.hm-test-suite-verdict--partial { color: var(--hm-amber-deep); }
+.hm-test-suite-verdict--fail { color: var(--hm-rose); }
+.hm-test-suite-verdict--unknown { color: var(--hm-muted); }
+.hm-test-suite-form {
+  border-top: 1px solid var(--hm-line);
+  padding-top: 10px;
 }
 .hm-choice-group label,
 .hm-checkbox-row {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -166,6 +166,13 @@ import {
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
 import {
+  appendTestbedSuiteRun,
+  createTestbedSuite,
+  getTestbedSuite,
+  listTestbedSuites,
+  type TestbedSuite,
+} from "./monitor-testbed-suites.js";
+import {
   approveRequestedTestbedMission,
   createMonitorTestbedMissionFromPayload,
   getTestbedMissionForAgent,
@@ -721,6 +728,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     writeJson(response, 200, buildTesterCapabilitiesManifest({
       runner: readTestbedMissionRunnerHeartbeat() ?? null,
       missionRuns: listTestbedMissionRuns({ limit: 50 }),
+      savedSuites: testerSavedSuitesForManifest(),
     }));
     return;
   }
@@ -773,6 +781,45 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorTestbedMissionRequestProposal(request, response);
+    return;
+  }
+  const testbedSuiteRunId = monitorTestbedSuiteRunId(url.pathname);
+  if (request.method === "POST" && testbedSuiteRunId) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "testbed_suite_run_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedSuiteRunRequest(testbedSuiteRunId, response);
+    return;
+  }
+  if (url.pathname === "/monitor/testbed-suites" && (request.method === "GET" || request.method === "POST")) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "testbed_suite_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    if (request.method === "GET") {
+      writeJson(response, 200, listTestbedSuites({ missionRuns: listTestbedMissionRuns({ limit: 50 }) }));
+      return;
+    }
+    await handleMonitorTestbedSuiteCreateRequest(request, response);
     return;
   }
   const testbedMissionApprovalId = monitorTestbedMissionApproveId(url.pathname);
@@ -1595,6 +1642,76 @@ async function handleMonitorTestbedMissionRequest(request: http.IncomingMessage,
     logger.error({ err: error }, "monitor_testbed_mission_create_failed");
     writeJson(response, 500, {
       error: "monitor_testbed_mission_create_failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function handleMonitorTestbedSuiteCreateRequest(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const suite = createTestbedSuite(payload);
+    writeJson(response, 200, { ok: true, suite });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("suite_") || message.startsWith("invalid_suite_")) {
+      writeJson(response, 400, { error: message });
+      return;
+    }
+    logger.error({ err: error }, "monitor_testbed_suite_create_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_suite_create_failed",
+      message,
+    });
+  }
+}
+
+async function handleMonitorTestbedSuiteRunRequest(id: string, response: http.ServerResponse) {
+  try {
+    const suite = getTestbedSuite(id);
+    if (!suite) {
+      writeJson(response, 404, { error: "testbed_suite_not_found", id });
+      return;
+    }
+    const created = createMonitorTestbedMissionFromPayload({
+      targetUrl: suite.target,
+      mode: suite.mode,
+      freshMemory: true,
+      initialStatus: "ready",
+      requester: "operator",
+      ...(suite.goal ? { goal: suite.goal } : {}),
+    });
+    recordTestbedMissionCollaboration(created.run);
+    const updatedSuite = appendTestbedSuiteRun(suite.id, created.run);
+    logger.info(
+      {
+        suiteId: suite.id,
+        missionId: created.run.id,
+        targetUrl: created.run.targetUrl,
+      },
+      "monitor_testbed_suite_run_created"
+    );
+    writeJson(response, 200, {
+      ok: true,
+      suite: updatedSuite ?? suite,
+      ...created,
+    });
+  } catch (error) {
+    if (error instanceof TestbedMissionRequestValidationError) {
+      writeJson(response, 400, {
+        error: error.code,
+        message: error.message,
+      });
+      return;
+    }
+    logger.error({ err: error }, "monitor_testbed_suite_run_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_suite_run_failed",
       message: error instanceof Error ? error.message : String(error),
     });
   }
@@ -3158,6 +3275,7 @@ async function loadMonitorSnapshot(
     ...enriched,
     codexTasks,
     testbedMissions: listTestbedMissionRuns({ limit: 20 }),
+    testbedSuites: listTestbedSuites({ missionRuns: listTestbedMissionRuns({ limit: 50 }) }).suites,
     testbedMissionRunner: summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat()),
     llmUsageEvents,
     collaborationMessages: listCollaborationMessages({ limit: 200 }),
@@ -3511,6 +3629,37 @@ function monitorTestbedMissionActionId(pathname: string, action: "accept-failure
   const raw = pathname.slice(prefix.length, -suffix.length);
   const id = decodeURIComponent(raw).trim();
   return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+function monitorTestbedSuiteRunId(pathname: string): string | undefined {
+  const prefix = "/monitor/testbed-suites/";
+  const suffix = "/run";
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return undefined;
+  const raw = pathname.slice(prefix.length, -suffix.length);
+  const id = decodeURIComponent(raw).trim();
+  return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+function testerSavedSuitesForManifest() {
+  const missionRuns = listTestbedMissionRuns({ limit: 50 });
+  return listTestbedSuites({ missionRuns }).suites.map((suite) => ({
+    id: suite.id,
+    name: suite.name,
+    flow: testerSuiteFlowId(suite.mode),
+    target: suite.target,
+    ...(suite.lastRun ? {
+      lastRun: {
+        missionId: suite.lastRun.runId,
+        verdict: suite.lastRun.verdict,
+        at: suite.lastRun.ts,
+      },
+    } : {}),
+  }));
+}
+
+function testerSuiteFlowId(mode: TestbedSuite["mode"]): string {
+  if (mode === "siwe_auth") return "siwe_auth_role_gating";
+  return mode;
 }
 
 async function createGithubIssueForMission(

--- a/services/slack-operator/src/monitor-testbed-suites.ts
+++ b/services/slack-operator/src/monitor-testbed-suites.ts
@@ -1,0 +1,277 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import type {
+  TestbedMissionMode,
+  TestbedMissionRun,
+  TestbedMissionVerdict,
+} from "./monitor-testbed-missions.js";
+
+const MAX_TESTBED_SUITES = 100;
+const MAX_TESTBED_SUITE_HISTORY = 50;
+
+export type TestbedSuiteAuthor = "predefined" | "operator" | "test-writer" | "platform";
+export type TestbedSuiteMode = Extract<TestbedMissionMode, "surface_sweep" | "siwe_auth" | "gold_path">;
+export type TestbedSuiteRunVerdict = TestbedMissionVerdict | "requested" | "ready" | "running" | "failed" | "unknown";
+
+export interface TestbedSuiteHistoryEntry {
+  runId: string;
+  verdict: TestbedSuiteRunVerdict;
+  ts: string;
+}
+
+export interface TestbedSuite {
+  schemaVersion: 1;
+  kind: "testbed_suite";
+  id: string;
+  name: string;
+  target: string;
+  mode: TestbedSuiteMode;
+  goal?: string;
+  author: TestbedSuiteAuthor;
+  createdAt: string;
+  updatedAt: string;
+  history: TestbedSuiteHistoryEntry[];
+  lastRun?: TestbedSuiteHistoryEntry;
+}
+
+export interface TestbedSuiteStoreDeps {
+  path?: string;
+  now?: Date;
+}
+
+export interface CreateTestbedSuiteInput {
+  name?: unknown;
+  target?: unknown;
+  mode?: unknown;
+  goal?: unknown;
+  author?: unknown;
+}
+
+export interface ListTestbedSuitesOptions {
+  path?: string;
+  missionRuns?: TestbedMissionRun[];
+}
+
+let suites: TestbedSuite[] = [];
+let suiteSeq = 0;
+let loadedSuiteStorePath: string | undefined;
+
+export function __resetTestbedSuitesForTests(): void {
+  suites = [];
+  suiteSeq = 0;
+  loadedSuiteStorePath = undefined;
+}
+
+export function listTestbedSuites(options: ListTestbedSuitesOptions = {}) {
+  ensureSuiteStoreLoaded(options.path, { force: true });
+  const missionRuns = options.missionRuns ?? [];
+  return {
+    schemaVersion: 1,
+    kind: "testbed_suite_list",
+    suites: suites.map((suite) => enrichSuite(cloneSuite(suite), missionRuns)),
+  };
+}
+
+export function getTestbedSuite(id: string, deps: TestbedSuiteStoreDeps = {}): TestbedSuite | undefined {
+  ensureSuiteStoreLoaded(deps.path, { force: true });
+  const suite = suites.find((candidate) => candidate.id === id);
+  return suite ? cloneSuite(suite) : undefined;
+}
+
+export function createTestbedSuite(
+  input: CreateTestbedSuiteInput,
+  deps: TestbedSuiteStoreDeps = {}
+): TestbedSuite {
+  ensureSuiteStoreLoaded(deps.path, { force: true });
+  const now = (deps.now ?? new Date()).toISOString();
+  const suite: TestbedSuite = {
+    schemaVersion: 1,
+    kind: "testbed_suite",
+    id: nextSuiteId(input.name),
+    name: parseSuiteName(input.name),
+    target: parseHttpTarget(input.target),
+    mode: parseSuiteMode(input.mode),
+    ...(parseOptionalString(input.goal) ? { goal: parseOptionalString(input.goal) } : {}),
+    author: parseSuiteAuthor(input.author),
+    createdAt: now,
+    updatedAt: now,
+    history: [],
+  };
+  suites.push(suite);
+  while (suites.length > MAX_TESTBED_SUITES) suites.shift();
+  persistSuiteStore(deps.path);
+  return cloneSuite(suite);
+}
+
+export function appendTestbedSuiteRun(
+  suiteId: string,
+  run: TestbedMissionRun,
+  deps: TestbedSuiteStoreDeps = {}
+): TestbedSuite | undefined {
+  ensureSuiteStoreLoaded(deps.path, { force: true });
+  const suite = suites.find((candidate) => candidate.id === suiteId);
+  if (!suite) return undefined;
+  const entry: TestbedSuiteHistoryEntry = {
+    runId: run.id,
+    verdict: missionRunVerdict(run),
+    ts: run.completedAt ?? run.failedAt ?? run.updatedAt,
+  };
+  suite.history = [
+    ...suite.history.filter((candidate) => candidate.runId !== run.id),
+    entry,
+  ].slice(-MAX_TESTBED_SUITE_HISTORY);
+  suite.updatedAt = (deps.now ?? new Date()).toISOString();
+  suite.lastRun = entry;
+  persistSuiteStore(deps.path);
+  return cloneSuite(suite);
+}
+
+function enrichSuite(suite: TestbedSuite, missionRuns: TestbedMissionRun[]): TestbedSuite {
+  if (suite.history.length === 0) return suite;
+  const runsById = new Map(missionRuns.map((run) => [run.id, run]));
+  const history = suite.history.map((entry) => {
+    const run = runsById.get(entry.runId);
+    return run
+      ? { runId: run.id, verdict: missionRunVerdict(run), ts: run.completedAt ?? run.failedAt ?? run.updatedAt }
+      : entry;
+  });
+  return {
+    ...suite,
+    history,
+    lastRun: history[history.length - 1],
+  };
+}
+
+function missionRunVerdict(run: TestbedMissionRun): TestbedSuiteRunVerdict {
+  const result = isRecord(run.result) ? run.result : {};
+  const nested = isRecord(result.structuredReport) ? result.structuredReport : {};
+  const verdict = typeof nested.verdict === "string" ? nested.verdict : typeof result.verdict === "string" ? result.verdict : undefined;
+  if (verdict === "pass" || verdict === "partial" || verdict === "fail") return verdict;
+  if (run.status === "completed") return "pass";
+  if (run.status === "requested" || run.status === "ready" || run.status === "running" || run.status === "failed") return run.status;
+  return "unknown";
+}
+
+function ensureSuiteStoreLoaded(path?: string, options: { force?: boolean } = {}): void {
+  const targetPath = suiteStorePath(path);
+  if (!targetPath || (!options.force && loadedSuiteStorePath === targetPath)) return;
+  try {
+    const value: unknown = JSON.parse(readFileSync(targetPath, "utf8"));
+    const loaded = suiteStoreSuites(value);
+    suites = loaded;
+    suiteSeq = suiteStoreSeq(value, loaded);
+    loadedSuiteStorePath = targetPath;
+  } catch (error) {
+    const code = isRecord(error) ? error.code : undefined;
+    if (code !== "ENOENT") throw error;
+    suites = [];
+    suiteSeq = 0;
+    loadedSuiteStorePath = targetPath;
+  }
+}
+
+function persistSuiteStore(path?: string): void {
+  const targetPath = suiteStorePath(path);
+  if (!targetPath) return;
+  const store = {
+    schemaVersion: 1,
+    kind: "testbed_suite_store",
+    suiteSeq,
+    suites: suites.slice(-MAX_TESTBED_SUITES),
+  };
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, `${JSON.stringify(store, null, 2)}\n`);
+  loadedSuiteStorePath = targetPath;
+}
+
+function suiteStoreSuites(value: unknown): TestbedSuite[] {
+  const rawSuites = Array.isArray(value)
+    ? value
+    : isRecord(value) && Array.isArray(value.suites)
+      ? value.suites
+      : [];
+  return rawSuites.filter(isTestbedSuite).slice(-MAX_TESTBED_SUITES);
+}
+
+function suiteStoreSeq(value: unknown, loadedSuites: TestbedSuite[]): number {
+  if (isRecord(value) && typeof value.suiteSeq === "number" && Number.isFinite(value.suiteSeq)) {
+    return Math.max(0, Math.floor(value.suiteSeq));
+  }
+  return loadedSuites.reduce((max, suite) => {
+    const match = suite.id.match(/-(\d+)$/);
+    const parsed = match ? Number(match[1]) : 0;
+    return Number.isFinite(parsed) ? Math.max(max, parsed) : max;
+  }, 0);
+}
+
+function nextSuiteId(name: unknown): string {
+  suiteSeq += 1;
+  const slug = parseOptionalString(name)
+    ?.toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40) || "suite";
+  return `testbed-suite-${slug}-${suiteSeq}`;
+}
+
+function parseSuiteName(value: unknown): string {
+  const text = parseOptionalString(value);
+  if (!text) throw new Error("suite_name_required");
+  return text.slice(0, 120);
+}
+
+function parseHttpTarget(value: unknown): string {
+  const text = parseOptionalString(value);
+  if (!text) throw new Error("suite_target_required");
+  try {
+    const parsed = new URL(text);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") throw new Error("invalid_suite_target");
+    return parsed.toString();
+  } catch {
+    throw new Error("invalid_suite_target");
+  }
+}
+
+function parseSuiteMode(value: unknown): TestbedSuiteMode {
+  const text = parseOptionalString(value);
+  if (text === "surface_sweep" || text === "siwe_auth" || text === "gold_path") return text;
+  throw new Error("invalid_suite_mode");
+}
+
+function parseSuiteAuthor(value: unknown): TestbedSuiteAuthor {
+  const text = parseOptionalString(value);
+  if (text === "predefined" || text === "operator" || text === "test-writer" || text === "platform") return text;
+  return "operator";
+}
+
+function parseOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function suiteStorePath(path?: string): string | undefined {
+  return path ?? process.env.AVERRAY_TESTBED_SUITES_PATH;
+}
+
+function isTestbedSuite(value: unknown): value is TestbedSuite {
+  if (!isRecord(value)) return false;
+  if (value.schemaVersion !== 1 || value.kind !== "testbed_suite") return false;
+  if (typeof value.id !== "string" || typeof value.name !== "string" || typeof value.target !== "string") return false;
+  if (value.mode !== "surface_sweep" && value.mode !== "siwe_auth" && value.mode !== "gold_path") return false;
+  if (value.author !== "predefined" && value.author !== "operator" && value.author !== "test-writer" && value.author !== "platform") return false;
+  if (typeof value.createdAt !== "string" || typeof value.updatedAt !== "string") return false;
+  if (!Array.isArray(value.history)) return false;
+  return true;
+}
+
+function cloneSuite(suite: TestbedSuite): TestbedSuite {
+  return {
+    ...suite,
+    history: suite.history.map((entry) => ({ ...entry })),
+    ...(suite.lastRun ? { lastRun: { ...suite.lastRun } } : {}),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -28,6 +28,7 @@ import {
   type LlmUsageAggregate,
   type LlmUsageEvent,
 } from "@avg/averray-mcp/llm-usage";
+import type { TestbedSuite } from "./monitor-testbed-suites.js";
 import type {
   HermesBoardCardSnapshot,
   HermesBoardSnapshot,
@@ -315,6 +316,7 @@ export interface BoardSnapshotV2 {
   at: string;
   repo: string;
   llmUsage: LlmUsageAggregate;
+  testbedSuites: TestbedSuite[];
   automationHealth?: AutomationHealth;
 }
 
@@ -1976,11 +1978,33 @@ export function buildV2BoardSnapshot(
     llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents), {
       activeCalls: listActiveLlmUsageCalls(),
     }),
+    testbedSuites: testbedSuitesFromSnapshot(rawSnapshot),
     automationHealth: automationHealthForBoard(rawSnapshot, snapshotAt, process.env, {
       selfHealingCapacitySignals: quietSelfHealingCapacitySignals,
       taskHealthCapacitySignals: quietTaskHealthCapacitySignals,
     }),
   };
+}
+
+function testbedSuitesFromSnapshot(rawSnapshot: unknown): TestbedSuite[] {
+  const root = asRecord(rawSnapshot);
+  return asArray(root?.testbedSuites)
+    .flatMap((entry) => {
+      const suite = asRecord(entry);
+      if (
+        suite
+        && suite.schemaVersion === 1
+        && suite.kind === "testbed_suite"
+        && typeof suite.id === "string"
+        && typeof suite.name === "string"
+        && typeof suite.target === "string"
+        && (suite.mode === "surface_sweep" || suite.mode === "siwe_auth" || suite.mode === "gold_path")
+        && Array.isArray(suite.history)
+      ) {
+        return [suite as unknown as TestbedSuite];
+      }
+      return [];
+    });
 }
 
 /**

--- a/test/unit/monitor-testbed-suites.test.ts
+++ b/test/unit/monitor-testbed-suites.test.ts
@@ -1,0 +1,78 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  __resetTestbedSuitesForTests,
+  appendTestbedSuiteRun,
+  createTestbedSuite,
+  listTestbedSuites,
+} from "../../services/slack-operator/src/monitor-testbed-suites.js";
+import { createMonitorTestbedMissionFromPayload } from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "averray-testbed-suites-"));
+  __resetTestbedSuitesForTests();
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  __resetTestbedSuitesForTests();
+});
+
+describe("monitor testbed suites", () => {
+  it("persists named suites and reloads them from the durable store", () => {
+    const path = join(dir, "suites.json");
+    const suite = createTestbedSuite(
+      {
+        name: "Daily surface sweep",
+        target: "https://app.averray.com",
+        mode: "surface_sweep",
+        author: "operator",
+      },
+      { path, now: new Date("2026-06-02T08:00:00.000Z") },
+    );
+
+    __resetTestbedSuitesForTests();
+
+    expect(listTestbedSuites({ path }).suites).toEqual([suite]);
+  });
+
+  it("appends each run to suite history with the mission verdict", () => {
+    const path = join(dir, "suites.json");
+    const suite = createTestbedSuite(
+      {
+        name: "Gold-path smoke",
+        target: "https://app.testnet.averray.com",
+        mode: "gold_path",
+        goal: "Prove the testnet worker loop.",
+        author: "predefined",
+      },
+      { path, now: new Date("2026-06-02T08:00:00.000Z") },
+    );
+    const { run } = createMonitorTestbedMissionFromPayload({
+      targetUrl: suite.target,
+      mode: suite.mode,
+      goal: suite.goal,
+    }, Date.parse("2026-06-02T08:05:00.000Z"));
+
+    const updated = appendTestbedSuiteRun(suite.id, run, {
+      path,
+      now: new Date("2026-06-02T08:06:00.000Z"),
+    });
+
+    expect(updated?.history).toEqual([{
+      runId: run.id,
+      verdict: "ready",
+      ts: "2026-06-02T08:05:00.000Z",
+    }]);
+    expect(listTestbedSuites({ path }).suites[0]?.lastRun).toEqual({
+      runId: run.id,
+      verdict: "ready",
+      ts: "2026-06-02T08:05:00.000Z",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a durable testbed suite store with named saved suites and per-suite run history
- expose monitor endpoints to list/create suites and re-run a suite through the existing mission creation path
- add a Suites panel plus launcher promotion so operators can save configs and re-run named suites

## Safety / authority
- saved suite runs reuse /monitor/testbed-missions creation, so mutation safety is still derived server-side from mode, target, and environment
- no auto-run, no auto-approval, no authority change; human merge/deploy gate unchanged

## Checks
- npm run typecheck
- npm test

## Surface impact
- backend: monitor API + suite store
- frontend: monitor board suites panel + launcher promotion
- no contracts, no chain, no secrets, no production env changes required unless operators want AVERRAY_TESTBED_SUITES_PATH set for durable suite storage