### PR TITLE
P3: run lifecycle — live-follow panel for a running mission

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -379,6 +379,84 @@ describe("DetailDrawer — variants", () => {
     expect(queryByText(/success · clarity · latency/i)).toBeNull();
   });
 
+  function runningMission(progress?: Record<string, unknown>) {
+    return {
+      id: "mission run-9",
+      lane: "hermes-checking",
+      type: "mission",
+      agentType: "hermes",
+      title: "Verify checkout on staging",
+      summary: "running",
+      repo: "depre-dev/site",
+      freshness: 1,
+      state: "running",
+      risk: [],
+      waitingOn: { actor: "agent", tone: "info" },
+      missionStatus: "running",
+      ...(progress ? { missionProgress: progress } : {})
+    } as unknown as BoardCard;
+  }
+
+  test("a RUNNING mission shows live stage + recent output with honest copy, no verdict", () => {
+    const card = runningMission({
+      message: "Clicking safe visible control: Connect wallet",
+      output: "opened https://staging.averray.com/checkout\nclicked Connect wallet\n"
+    });
+    const { getByText, queryByText } = render(
+      <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />
+    );
+    expect(getByText("Mission · running")).toBeTruthy();
+    expect(getByText("Clicking safe visible control: Connect wallet")).toBeTruthy();
+    expect(getByText("Recent runner output")).toBeTruthy();
+    expect(getByText(/clicked Connect wallet/)).toBeTruthy();
+    // Honest copy: rolling tail + ~2s refresh + no verdict promise.
+    expect(getByText(/Rolling ~12KB tail/)).toBeTruthy();
+    expect(getByText(/Refreshes ~every 2s/)).toBeTruthy();
+    // No verdict / scores while running.
+    expect(queryByText("PARTIAL")).toBeNull();
+    expect(queryByText(/out of 10/)).toBeNull();
+  });
+
+  test("a running mission with no output yet stays honest (no fabricated steps)", () => {
+    const { getByText } = render(
+      <DetailDrawer card={runningMission({ message: "Runner claimed the mission." })} cards={[]} onClose={noop} onNavigate={noop} />
+    );
+    expect(getByText(/No output yet/)).toBeTruthy();
+  });
+
+  test("the SAME drawer auto-swaps from the live view to the full report on completion", () => {
+    const running = runningMission({ message: "step 1", output: "line\n" });
+    const { getByText, queryByText, rerender } = render(
+      <DetailDrawer card={running} cards={[{ id: running.id }]} onClose={noop} onNavigate={noop} />
+    );
+    expect(getByText("Mission · running")).toBeTruthy();
+
+    // The board.card.updated SSE replaces the card with the completed report.
+    const done = {
+      ...running,
+      state: "fresh",
+      missionStatus: "completed",
+      missionProgress: undefined,
+      mission: {
+        verdict: "OK",
+        verdictTone: "ok",
+        confidence: 0.9,
+        target: "https://staging.averray.com/checkout",
+        seed: "fresh · no memory",
+        path: [{ n: 1, status: "ok", desc: "Loaded checkout" }],
+        blockers: [],
+        evidence: [],
+        mutationBoundary: "Read-only mission — the agent stopped before any mutation.",
+        recommendations: []
+      }
+    } as unknown as BoardCard;
+    rerender(<DetailDrawer card={done} cards={[{ id: done.id }]} onClose={noop} onNavigate={noop} />);
+
+    expect(queryByText("Mission · running")).toBeNull();
+    expect(getByText("OK")).toBeTruthy();
+    expect(getByText("Loaded checkout")).toBeTruthy();
+  });
+
   // Regression: live cards cross an HTTP/JSON boundary and don't always carry
   // the type-required nested objects (the backend doesn't populate deploy
   // `verification` or a mission `mission` report yet). The drawer must render,

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -482,7 +482,72 @@ function MissionBlockerBlock({ blocker }: { blocker: MissionBlocker }) {
   );
 }
 
+/**
+ * Live-follow view for a RUNNING mission. Shows only real progress — the stage
+ * line + recent runner output (a rolling tail) — and a screenshot only when a
+ * servable URL exists. No verdict and no per-step ledger: the agent posts the
+ * verdict only in the terminal report, at which point MissionBody re-renders
+ * into the full report (the `board.card.updated` SSE refreshes this ~every 2s).
+ */
+function MissionRunInProgress({ card }: { card: MissionCard }) {
+  const progress = card.missionProgress;
+  const stage = progress?.message?.trim();
+  const output = progress?.output?.trim();
+  const screenshot = progress?.screenshot;
+  return (
+    <>
+      <section>
+        <div className="hm-section-h">Mission · running</div>
+        <div
+          className="hm-verdict-block"
+          style={{ background: "var(--hm-hermes-soft)", borderColor: "rgba(15,107,90,0.18)" }}
+        >
+          <div className="head" style={{ color: "var(--hm-hermes-deep)", display: "flex", alignItems: "center", gap: 8 }}>
+            <span className="fresh-dot" style={{ background: "var(--hm-hermes)" }} aria-hidden />
+            {stage || "Runner claimed the mission — starting…"}
+          </div>
+          <div className="body" style={{ color: "var(--hm-muted)" }}>{card.title}</div>
+        </div>
+      </section>
+
+      {screenshot ? (
+        <section>
+          <div className="hm-section-h">Latest screenshot</div>
+          <img
+            src={screenshot}
+            alt="Latest mission screenshot"
+            style={{ width: "100%", borderRadius: "var(--hm-radius)", border: "1px solid var(--hm-line)", display: "block" }}
+          />
+        </section>
+      ) : null}
+
+      <section>
+        <div className="hm-section-h">Recent runner output</div>
+        {output ? (
+          <pre className="hm-mission-run-output">{output}</pre>
+        ) : (
+          <div className="hm-verdict-block">
+            <div className="body" style={{ color: "var(--hm-muted)" }}>
+              No output yet — waiting for the runner's first lines.
+            </div>
+          </div>
+        )}
+        <div className="hm-mission-run-note">
+          Rolling ~12KB tail — older steps scroll off. Refreshes ~every 2s while the run is live.
+          No verdict until the agent posts its report.
+        </div>
+      </section>
+    </>
+  );
+}
+
 function MissionBody({ card }: { card: MissionCard }) {
+  // RUNNING → follow the run live (stage + recent output). The SAME body
+  // auto-swaps to the end report once the agent posts one: the
+  // `board.card.updated` SSE refreshes this card every ~2s and re-renders.
+  if (card.missionStatus === "running") {
+    return <MissionRunInProgress card={card} />;
+  }
   // `mission` is required on the type, but a live mission card has no
   // structured report until the browser agent posts one. Read defensively.
   const m = (card as { mission?: MissionCard["mission"] }).mission;

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -269,12 +269,26 @@ export interface MissionReport {
   recommendations: string[];
 }
 
+/** Live snapshot of a RUNNING mission (the rolling ~2s poll) — not a report. */
+export interface MissionProgress {
+  /** Latest stage line. */
+  message?: string;
+  /** Sanitized recent runner output — a rolling tail (older lines scroll off). */
+  output?: string;
+  /** When the latest progress was recorded (ISO). */
+  at?: string;
+  /** Latest screenshot URL — present only when a servable URL exists. */
+  screenshot?: string;
+}
+
 /** Browser mission card (testbed). */
 export interface MissionCard extends CardBase {
   type: "mission";
   mission?: MissionReport;
   /** requested missions are board-gated and cannot be claimed until approved. */
   missionStatus?: "requested" | "ready" | "running" | "completed" | "failed";
+  /** Live progress while running; absent once the terminal report lands. */
+  missionProgress?: MissionProgress;
 }
 
 /** Task lifecycle status (mirrors the serializer's TaskStatus). */

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2527,6 +2527,28 @@ button.hm-turn-pin {
 }
 
 /* Mission path (numbered steps with status) */
+/* Live-follow (running mission): scrollable recent runner output + honest note. */
+.hm-mission-run-output {
+  margin: 0;
+  max-height: 240px;
+  overflow: auto;
+  padding: 10px 12px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper-3, var(--hm-paper));
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--hm-ink-soft);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.hm-mission-run-note {
+  margin-top: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
 /* "What the agent did" — the agent narrative, one line per step. */
 .hm-mission-narrative {
   display: grid;

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -206,6 +206,19 @@ export interface CardMissionEvidence {
   label: string;
   href: string;
 }
+/** Live snapshot of a RUNNING mission (rolling ~2s poll), not a final report. */
+export interface CardMissionProgress {
+  /** Latest stage line (`progressMessage`). */
+  message?: string;
+  /** Sanitized recent runner output — a rolling tail (older lines scroll off). */
+  output?: string;
+  /** When the latest progress was recorded (ISO). */
+  at?: string;
+  /** Latest screenshot URL — present only when an absolute, servable URL exists.
+   *  The runner does not publish one live today (no artifact endpoint), so this
+   *  is usually absent; the UI shows stage + output without faking an image. */
+  screenshot?: string;
+}
 export interface CardMissionReport {
   verdict: "OK" | "PARTIAL" | "FAILED";
   verdictTone: "ok" | "warn" | "fail";
@@ -302,6 +315,10 @@ export interface BoardCard {
   mission?: CardMissionReport;
   /** Mission lifecycle status; requested missions are board-gated and not runner-claimable. */
   missionStatus?: MissionStatus;
+  /** Live progress while a mission is RUNNING (the rolling ~2s poll snapshot):
+   *  stage message + a sanitized recent-output tail. No verdict — the agent
+   *  posts that only in the terminal report. */
+  missionProgress?: CardMissionProgress;
   /** D2: latest durable explanation associated with this card. */
   decisionRecord?: HermesDecisionRecord;
   /** C1: active cross-agent review requests scoped to this card. */
@@ -647,6 +664,24 @@ function workingNowFromRunningTask(
     taskId,
     ...(runnerId ? { runnerId } : {}),
     ...(since ? { since } : {}),
+  };
+}
+
+/** Project a running mission's live poll snapshot (stage + recent output). */
+function missionRunProgress(run: Record<string, unknown> | undefined): CardMissionProgress | undefined {
+  if (!run) return undefined;
+  const message = asString(run.progressMessage);
+  const output = asString(run.stdoutTail);
+  const at = asString(run.progressAt) ?? asString(run.updatedAt);
+  // A servable absolute screenshot URL only — never a local artifact path.
+  const screenshotRaw = asString(run.progressScreenshotUrl) ?? asString(run.liveScreenshotUrl);
+  const screenshot = screenshotRaw && /^https?:\/\//i.test(screenshotRaw) ? screenshotRaw : undefined;
+  if (!message && !output && !screenshot) return undefined;
+  return {
+    ...(message ? { message } : {}),
+    ...(output ? { output } : {}),
+    ...(at ? { at } : {}),
+    ...(screenshot ? { screenshot } : {}),
   };
 }
 
@@ -1565,6 +1600,12 @@ export function enrichBoardCard(
       card.mission = mission;
       const oneLine = missionReportOneLine(ctx.missionRun);
       if (oneLine) card.summary = oneLine;
+    }
+    // While running, surface the live poll snapshot (stage + recent output) so
+    // the drawer can follow the run. Real progress only — no verdict here.
+    if (status === "running") {
+      const progress = missionRunProgress(ctx.missionRun);
+      if (progress) card.missionProgress = progress;
     }
     const workingNow = workingNowFromMissionRun(ctx.missionRun);
     if (workingNow) card.workingNow = workingNow;

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -570,6 +570,65 @@ describe("enrichBoardCard", () => {
     ]);
   });
 
+  it("projects live progress (stage + recent output) for a RUNNING mission, with no verdict", () => {
+    const card = enrichBoardCard(
+      base({ id: "mission run-1", type: "mission", lane: "hermes-checking", title: "Verify checkout" }),
+      slim({ lane: "Hermes Checking" }),
+      {
+        missionRun: {
+          id: "mission run-1",
+          status: "running",
+          progressMessage: "Clicking safe visible control: Connect wallet",
+          stdoutTail: "opened https://staging.averray.com\nclicked Connect wallet\n",
+          progressAt: "2026-06-02T10:00:00.000Z"
+        }
+      }
+    );
+    expect(card.missionStatus).toBe("running");
+    expect(card.missionProgress).toEqual({
+      message: "Clicking safe visible control: Connect wallet",
+      output: "opened https://staging.averray.com\nclicked Connect wallet\n",
+      at: "2026-06-02T10:00:00.000Z"
+    });
+    // No verdict/report while running — the agent posts that only at the end.
+    expect(card.mission).toBeUndefined();
+  });
+
+  it("drops live progress once the mission has a terminal report (the swap to the end report)", () => {
+    const card = enrichBoardCard(
+      base({ id: "mission done-1", type: "mission", lane: "hermes-checking" }),
+      slim({ lane: "Hermes Checking" }),
+      {
+        missionRun: {
+          id: "mission done-1",
+          status: "completed",
+          progressMessage: "almost done",
+          stdoutTail: "x",
+          result: { verdict: "pass", confidence: 0.9, completedPath: ["Loaded checkout"] }
+        }
+      }
+    );
+    expect(card.missionStatus).toBe("completed");
+    expect(card.missionProgress).toBeUndefined();
+    expect(card.mission?.verdict).toBe("OK");
+  });
+
+  it("ignores a non-servable (local path) progress screenshot — never fakes an image", () => {
+    const card = enrichBoardCard(
+      base({ id: "mission run-2", type: "mission", lane: "hermes-checking" }),
+      slim({ lane: "Hermes Checking" }),
+      {
+        missionRun: {
+          id: "mission run-2",
+          status: "running",
+          progressMessage: "step",
+          progressScreenshotUrl: "/data/testbed-mission-artifacts/run-2/after.png"
+        }
+      }
+    );
+    expect(card.missionProgress?.screenshot).toBeUndefined();
+  });
+
   it("marks a card failed-fetch when the GitHub source read reported a real error", () => {
     const card = enrichBoardCard(base(), slim(), {
       summary: {


### PR DESCRIPTION
## What changed & why
Implements **P3** (HERMES_TESTER_UX.md §4/§4a). The mission drawer now follows a run through **requested/dispatched → running (live) → done**, in the *same* `MissionBody` — no reload, no separate component.

- **`monitor-v2.ts`** — project a RUNNING mission's live poll snapshot onto the card as `missionProgress { message, output, at, screenshot? }`, read from the run record's `progressMessage` + `stdoutTail` + `progressAt` that the runner writes ~every 2s (`testbed-mission-runner` `publishProgress`).
- **`DrawerBody` `MissionBody`** — when `missionStatus === "running"`, render **`MissionRunInProgress`**: a **stage badge** (from `progressMessage`), a **screenshot** slot, and scrollable **recent runner output** (the rolling tail). On completion the same body **auto-swaps to the full scored report** (P0b) — no new poll loop: the existing **`board.card.updated` SSE** refreshes the card and React re-renders.
- Honest copy: *"Rolling ~12KB tail — older steps scroll off"*, *"Refreshes ~every 2s"*, *"No verdict until the agent posts its report"*.

## Truth-boundary (the explicit ask: real progress only)
- **No new endpoint** (per the task) and **no fabricated screenshot.** The runner does not publish a live screenshot, and serving artifacts would need a new endpoint — so the screenshot slot renders **only** when an absolute servable URL is present (none today). The view shows the real live data (stage + output) without faking an image; a test asserts a local artifact path is ignored.
- **No per-step ledger, no verdict before the agent posts one.** The running view shows the rolling output tail and the latest stage line — nothing implying a structured ledger.

> Note: the live **screenshot** is wired end-to-end but stays empty until the runner publishes a servable URL (the optional `STAGE:`/screenshot extraction is a separate Codex follow-up, and serving artifacts is out of scope here because the task forbids a new endpoint). Stage + recent output advancing ~2s is fully delivered.

## Affected surfaces
- [x] Monitor board / slack-operator (mission drawer + the running-mission card projection)
- [x] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test` (full **1449 passed**; new enrichBoardCard projection tests + drawer live-view/ swap tests)
- [ ] docker compose config (no ops change)

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — read-only live presentation
- [x] No new endpoint; uses the existing `board.card.updated` SSE
- [x] No secrets/authority changes
- [x] Truth-boundary upheld: real progress only — no fabricated steps, screenshot, or verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)