### PR TITLE
feat: add testbed live screencast foundation

### DIFF
--- a/docs/HERMES_TESTER_UX.md
+++ b/docs/HERMES_TESTER_UX.md
@@ -98,6 +98,8 @@ On completion the drawer must read like a verdict you can act on: the **scope/go
 ### 4c. True 1:1 live *(optional upgrade — P3b)*
 The 2s poll panel gets you "watch the steps + latest screenshot advance." A literal frame-by-frame **live screencast of the browser** is a separate, bigger build (a video / CDP screencast stream) — offered as **P3b**, not pretended into the poll panel.
 
+Implementation note: the monitor can expose a bounded, monitor-authenticated `liveScreencast` stream for Playwright-owned testnet missions. The current gold-path live driver shells out to the Claude browser runtime and does not itself hold a Playwright `BrowserContext`; until that external driver publishes frames or exposes its context, gold-path missions must report `liveScreencast.status="unavailable"` and fall back to the P3 stage/output view instead of pretending to stream.
+
 ---
 
 ## 5. Gold-path flagship — the SIWE session *(prerequisite for the real flagship scope)*

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -279,6 +279,15 @@ export interface MissionProgress {
   at?: string;
   /** Latest screenshot URL — present only when a servable URL exists. */
   screenshot?: string;
+  /** Optional P3b stream metadata. Missing means fall back to the P3 step-view. */
+  liveScreencast?: {
+    status: "running" | "ended" | "unavailable";
+    streamUrl?: string;
+    latestFrameUrl?: string;
+    frameCount?: number;
+    updatedAt?: string;
+    reason?: string;
+  };
 }
 
 /** Browser mission card (testbed). */

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -182,6 +182,10 @@ import {
 } from "./testbed-agent-entrypoint.js";
 import { buildTesterCapabilitiesManifest } from "./tester-capabilities.js";
 import {
+  readTestbedScreencastManifest,
+  screencastLatestFramePath,
+} from "./testbed-live-screencast.js";
+import {
   formatStalePrAlertForSlack,
   shouldPostStalePrAlert,
   stalePrAlertItems,
@@ -892,6 +896,19 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     await handleMonitorTestbedMissionOpenIssueRequest(testbedMissionOpenIssueId, request, response);
+    return;
+  }
+  const testbedMissionScreencastRoute = monitorTestbedMissionScreencastRoute(url.pathname);
+  if (request.method === "GET" && testbedMissionScreencastRoute) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorTestbedMissionScreencastRequest(testbedMissionScreencastRoute, request, response, url);
     return;
   }
   const testbedMissionId = monitorTestbedMissionId(url.pathname);
@@ -1921,6 +1938,103 @@ async function handleMonitorTestbedMissionOpenIssueRequest(
       message: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+async function handleMonitorTestbedMissionScreencastRequest(
+  route: { id: string; kind: "stream" | "latest" },
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  url: URL
+): Promise<void> {
+  const run = listTestbedMissionRuns({ limit: 50 }).find((candidate) => candidate.id === route.id);
+  if (!run) {
+    writeJson(response, 404, { error: "testbed_mission_not_found", id: route.id });
+    return;
+  }
+  if (route.kind === "latest") {
+    const framePath = screencastLatestFramePath(testbedMissionArtifactsRoot(), route.id);
+    const body = await readFile(framePath).catch(() => undefined);
+    if (!body) {
+      writeJson(response, 404, { error: "testbed_screencast_frame_not_found", id: route.id });
+      return;
+    }
+    response.writeHead(200, {
+      "content-type": "image/jpeg",
+      "cache-control": "no-store",
+    });
+    response.end(body);
+    return;
+  }
+  await writeTestbedMissionScreencastStream(request, response, url, route.id);
+}
+
+async function writeTestbedMissionScreencastStream(
+  request: http.IncomingMessage,
+  response: http.ServerResponse,
+  url: URL,
+  missionId: string,
+): Promise<void> {
+  const intervalMs = Math.max(250, parseOptionalInteger(url.searchParams.get("intervalMs")) ?? 500);
+  let closed = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let lastFrameCount = -1;
+
+  response.writeHead(200, {
+    "content-type": "text/event-stream; charset=utf-8",
+    "cache-control": "no-cache, no-transform",
+    connection: "keep-alive",
+    "x-accel-buffering": "no",
+  });
+  response.write(`retry: ${intervalMs}\n\n`);
+
+  const send = async () => {
+    const run = listTestbedMissionRuns({ limit: 50 }).find((candidate) => candidate.id === missionId);
+    const manifest = await readTestbedScreencastManifest(testbedMissionArtifactsRoot(), missionId);
+    if (!run) {
+      writeSseEvent(response, "screencast.error", { error: "testbed_mission_not_found", missionId });
+      return;
+    }
+    if (!manifest) {
+      writeSseEvent(response, "screencast.status", {
+        missionId,
+        status: run.liveScreencast?.status ?? "unavailable",
+        reason: run.liveScreencast?.reason ?? "no_screencast_frame_yet",
+        updatedAt: run.liveScreencast?.updatedAt ?? run.progressAt ?? run.updatedAt,
+      });
+      return;
+    }
+    if (manifest.frameCount === lastFrameCount && manifest.status === "running") return;
+    lastFrameCount = manifest.frameCount;
+    const latest = await readFile(screencastLatestFramePath(testbedMissionArtifactsRoot(), missionId)).catch(() => undefined);
+    if (!latest) {
+      writeSseEvent(response, "screencast.status", {
+        missionId,
+        status: manifest.status,
+        frameCount: manifest.frameCount,
+        reason: "latest_frame_missing",
+        updatedAt: manifest.updatedAt,
+      });
+      return;
+    }
+    writeSseEvent(response, "screencast.frame", {
+      missionId,
+      status: manifest.status,
+      contentType: manifest.contentType,
+      frameCount: manifest.frameCount,
+      updatedAt: manifest.updatedAt,
+      ...(manifest.endedAt ? { endedAt: manifest.endedAt } : {}),
+      ...(manifest.reason ? { reason: manifest.reason } : {}),
+      dataUrl: `data:${manifest.contentType};base64,${latest.toString("base64")}`,
+    });
+  };
+
+  request.on("close", () => {
+    closed = true;
+    if (timer) clearInterval(timer);
+  });
+
+  await send();
+  if (!closed) timer = setInterval(() => void send(), intervalMs);
 }
 
 function recordTestbedMissionCollaboration(run: TestbedMissionRun): void {
@@ -3602,6 +3716,27 @@ function monitorTestbedMissionId(pathname: string): string | undefined {
   if (!pathname.startsWith(prefix)) return undefined;
   const id = decodeURIComponent(pathname.slice(prefix.length)).trim();
   return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+function monitorTestbedMissionScreencastRoute(pathname: string): { id: string; kind: "stream" | "latest" } | undefined {
+  const prefix = "/monitor/testbed-missions/";
+  if (!pathname.startsWith(prefix)) return undefined;
+  const rest = pathname.slice(prefix.length);
+  const streamSuffix = "/screencast";
+  const latestSuffix = "/screencast/latest.jpg";
+  if (rest.endsWith(latestSuffix)) {
+    const id = decodeURIComponent(rest.slice(0, -latestSuffix.length)).trim();
+    return id && !id.includes("/") ? { id, kind: "latest" } : undefined;
+  }
+  if (rest.endsWith(streamSuffix)) {
+    const id = decodeURIComponent(rest.slice(0, -streamSuffix.length)).trim();
+    return id && !id.includes("/") ? { id, kind: "stream" } : undefined;
+  }
+  return undefined;
+}
+
+function testbedMissionArtifactsRoot(): string {
+  return optionalEnv("TESTBED_MISSION_ARTIFACTS_DIR") ?? "/data/testbed-mission-artifacts";
 }
 
 /** Parse the card id from /monitor/cards/:id/operator-notes. */

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -80,6 +80,17 @@ export interface TestbedMissionRun {
   stderrTail?: string;
   progressMessage?: string;
   progressAt?: string;
+  progressScreenshotUrl?: string;
+  liveScreencast?: {
+    status: "running" | "ended" | "unavailable";
+    streamUrl?: string;
+    latestFrameUrl?: string;
+    frameCount?: number;
+    startedAt?: string;
+    updatedAt?: string;
+    endedAt?: string;
+    reason?: string;
+  };
   goldPathAutonomy?: {
     budget?: {
       reservedAt: string;
@@ -602,6 +613,8 @@ export function updateTestbedMissionProgress(
     progressMessage?: string;
     stdoutTail?: string;
     stderrTail?: string;
+    progressScreenshotUrl?: string;
+    liveScreencast?: TestbedMissionRun["liveScreencast"];
   } = {}
 ): TestbedMissionRun | undefined {
   ensureMissionStoreLoaded(deps.path, { force: true });
@@ -615,6 +628,8 @@ export function updateTestbedMissionProgress(
   existing.updatedAt = now;
   if (deps.stdoutTail) existing.stdoutTail = deps.stdoutTail;
   if (deps.stderrTail) existing.stderrTail = deps.stderrTail;
+  if (deps.progressScreenshotUrl) existing.progressScreenshotUrl = deps.progressScreenshotUrl;
+  if (deps.liveScreencast) existing.liveScreencast = deps.liveScreencast;
   existing.history.push({
     at: now,
     status: "running",

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -216,9 +216,19 @@ export interface CardMissionProgress {
   /** When the latest progress was recorded (ISO). */
   at?: string;
   /** Latest screenshot URL — present only when an absolute, servable URL exists.
-   *  The runner does not publish one live today (no artifact endpoint), so this
-   *  is usually absent; the UI shows stage + output without faking an image. */
+   *  P3b screencast frames use relative monitor-authenticated URLs instead and
+   *  are exposed through `liveScreencast`. */
   screenshot?: string;
+  /** Optional P3b stream metadata. Present only when the runner published a
+   *  real bounded screencast stream or an honest unavailable reason. */
+  liveScreencast?: {
+    status: "running" | "ended" | "unavailable";
+    streamUrl?: string;
+    latestFrameUrl?: string;
+    frameCount?: number;
+    updatedAt?: string;
+    reason?: string;
+  };
 }
 export interface CardMissionReport {
   verdict: "OK" | "PARTIAL" | "FAILED";
@@ -678,12 +688,31 @@ function missionRunProgress(run: Record<string, unknown> | undefined): CardMissi
   // A servable absolute screenshot URL only — never a local artifact path.
   const screenshotRaw = asString(run.progressScreenshotUrl) ?? asString(run.liveScreenshotUrl);
   const screenshot = screenshotRaw && /^https?:\/\//i.test(screenshotRaw) ? screenshotRaw : undefined;
-  if (!message && !output && !screenshot) return undefined;
+  const liveScreencast = missionLiveScreencast(run);
+  if (!message && !output && !screenshot && !liveScreencast) return undefined;
   return {
     ...(message ? { message } : {}),
     ...(output ? { output } : {}),
     ...(at ? { at } : {}),
     ...(screenshot ? { screenshot } : {}),
+    ...(liveScreencast ? { liveScreencast } : {}),
+  };
+}
+
+function missionLiveScreencast(run: Record<string, unknown>): CardMissionProgress["liveScreencast"] | undefined {
+  const source = asRecord(run.liveScreencast);
+  if (!source) return undefined;
+  const status = asString(source.status);
+  if (status !== "running" && status !== "ended" && status !== "unavailable") return undefined;
+  const streamUrl = asString(source.streamUrl);
+  const latestFrameUrl = asString(source.latestFrameUrl);
+  return {
+    status,
+    ...(streamUrl && streamUrl.startsWith("/monitor/testbed-missions/") ? { streamUrl } : {}),
+    ...(latestFrameUrl && latestFrameUrl.startsWith("/monitor/testbed-missions/") ? { latestFrameUrl } : {}),
+    ...(typeof source.frameCount === "number" ? { frameCount: source.frameCount } : {}),
+    ...(asString(source.updatedAt) ? { updatedAt: asString(source.updatedAt) } : {}),
+    ...(asString(source.reason) ? { reason: asString(source.reason) } : {}),
   };
 }
 

--- a/services/slack-operator/src/testbed-live-screencast.ts
+++ b/services/slack-operator/src/testbed-live-screencast.ts
@@ -1,0 +1,262 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { Page } from "playwright-core";
+
+import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
+
+export interface TestbedLiveScreencastConfig {
+  enabled: boolean;
+  intervalMs: number;
+  maxFrames: number;
+  jpegQuality: number;
+}
+
+export interface TestbedLiveScreencastState {
+  status: "running" | "ended" | "unavailable";
+  streamUrl?: string;
+  latestFrameUrl?: string;
+  frameCount?: number;
+  startedAt?: string;
+  updatedAt?: string;
+  endedAt?: string;
+  reason?: string;
+}
+
+export interface TestbedScreencastManifest {
+  schemaVersion: 1;
+  kind: "testbed_live_screencast";
+  missionId: string;
+  status: "running" | "ended";
+  contentType: "image/jpeg";
+  frameCount: number;
+  latestFrame: string;
+  updatedAt: string;
+  endedAt?: string;
+  reason?: string;
+}
+
+export interface TestbedLiveScreencastController {
+  stop: (reason?: string) => Promise<void>;
+}
+
+const DEFAULT_INTERVAL_MS = 500;
+const DEFAULT_MAX_FRAMES = 240;
+const DEFAULT_JPEG_QUALITY = 45;
+
+export function parseTestbedLiveScreencastConfig(
+  env: NodeJS.ProcessEnv = process.env
+): TestbedLiveScreencastConfig {
+  return {
+    enabled: env.TESTBED_MISSION_LIVE_SCREENCAST_ENABLED === "1" || env.TESTBED_MISSION_LIVE_SCREENCAST_ENABLED === "true",
+    intervalMs: boundedInt(env.TESTBED_MISSION_LIVE_SCREENCAST_INTERVAL_MS, DEFAULT_INTERVAL_MS, 250, 5_000),
+    maxFrames: boundedInt(env.TESTBED_MISSION_LIVE_SCREENCAST_MAX_FRAMES, DEFAULT_MAX_FRAMES, 1, 1_000),
+    jpegQuality: boundedInt(env.TESTBED_MISSION_LIVE_SCREENCAST_JPEG_QUALITY, DEFAULT_JPEG_QUALITY, 20, 80),
+  };
+}
+
+export function liveScreencastAllowedForMission(
+  mission: Pick<TestbedMissionRun, "environment" | "targetUrl">,
+  config: TestbedLiveScreencastConfig,
+): { ok: true } | { ok: false; reason: string } {
+  if (!config.enabled) return { ok: false, reason: "live_screencast_disabled" };
+  if (mission.environment !== "testnet") return { ok: false, reason: "live_screencast_testnet_only" };
+  if (urlContainsCredential(mission.targetUrl)) return { ok: false, reason: "live_screencast_target_url_contains_credentials" };
+  return { ok: true };
+}
+
+export function screencastArtifactsDir(artifactsRoot: string, missionId: string): string {
+  return join(artifactsRoot, missionId, "live-screencast");
+}
+
+export function screencastManifestPath(artifactsRoot: string, missionId: string): string {
+  return join(screencastArtifactsDir(artifactsRoot, missionId), "manifest.json");
+}
+
+export function screencastLatestFramePath(artifactsRoot: string, missionId: string): string {
+  return join(screencastArtifactsDir(artifactsRoot, missionId), "latest.jpg");
+}
+
+export async function readTestbedScreencastManifest(
+  artifactsRoot: string,
+  missionId: string,
+): Promise<TestbedScreencastManifest | undefined> {
+  const text = await readFile(screencastManifestPath(artifactsRoot, missionId), "utf8").catch(() => undefined);
+  if (!text) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+  return isTestbedScreencastManifest(parsed) ? parsed : undefined;
+}
+
+export async function startPlaywrightLiveScreencast(input: {
+  mission: TestbedMissionRun;
+  page: Page;
+  artifactsRoot: string;
+  config: TestbedLiveScreencastConfig;
+  update: (state: TestbedLiveScreencastState) => void;
+  now?: () => Date;
+}): Promise<TestbedLiveScreencastController | undefined> {
+  const allowed = liveScreencastAllowedForMission(input.mission, input.config);
+  if (!allowed.ok) {
+    input.update({
+      status: "unavailable",
+      reason: allowed.reason,
+      updatedAt: (input.now?.() ?? new Date()).toISOString(),
+    });
+    return undefined;
+  }
+
+  const dir = screencastArtifactsDir(input.artifactsRoot, input.mission.id);
+  await mkdir(dir, { recursive: true });
+  const latestFramePath = screencastLatestFramePath(input.artifactsRoot, input.mission.id);
+  const startedAt = (input.now?.() ?? new Date()).toISOString();
+  const streamUrl = `/monitor/testbed-missions/${encodeURIComponent(input.mission.id)}/screencast`;
+  const latestFrameUrl = `${streamUrl}/latest.jpg`;
+  let stopped = false;
+  let frameCount = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const publishState = (state: Omit<TestbedLiveScreencastState, "streamUrl" | "latestFrameUrl">) => {
+    input.update({
+      ...state,
+      streamUrl,
+      latestFrameUrl,
+    });
+  };
+
+  const capture = async () => {
+    if (stopped) return;
+    const now = (input.now?.() ?? new Date()).toISOString();
+    if (frameCount >= input.config.maxFrames) {
+      stopped = true;
+      await writeManifest({
+        missionId: input.mission.id,
+        status: "ended",
+        frameCount,
+        updatedAt: now,
+        endedAt: now,
+        reason: "max_frames_reached",
+        artifactsRoot: input.artifactsRoot,
+      });
+      publishState({ status: "ended", frameCount, updatedAt: now, endedAt: now, reason: "max_frames_reached" });
+      return;
+    }
+    const url = input.page.url();
+    if (urlContainsCredential(url) || !isCaptureablePageUrl(url)) {
+      publishState({ status: "running", frameCount, startedAt, updatedAt: now, reason: "redacted_non_page_frame" });
+      schedule();
+      return;
+    }
+    try {
+      await input.page.screenshot({
+        path: latestFramePath,
+        type: "jpeg",
+        quality: input.config.jpegQuality,
+        fullPage: false,
+        animations: "disabled",
+      });
+      frameCount += 1;
+      await writeManifest({
+        missionId: input.mission.id,
+        status: "running",
+        frameCount,
+        updatedAt: now,
+        artifactsRoot: input.artifactsRoot,
+      });
+      publishState({ status: "running", frameCount, startedAt, updatedAt: now });
+    } catch {
+      publishState({ status: "running", frameCount, startedAt, updatedAt: now, reason: "frame_capture_failed" });
+    }
+    schedule();
+  };
+
+  const schedule = () => {
+    if (stopped) return;
+    timer = setTimeout(() => void capture(), input.config.intervalMs);
+    timer.unref?.();
+  };
+
+  publishState({ status: "running", frameCount: 0, startedAt, updatedAt: startedAt });
+  schedule();
+
+  return {
+    async stop(reason = "mission_finished") {
+      if (stopped) return;
+      stopped = true;
+      if (timer) clearTimeout(timer);
+      const now = (input.now?.() ?? new Date()).toISOString();
+      await writeManifest({
+        missionId: input.mission.id,
+        status: "ended",
+        frameCount,
+        updatedAt: now,
+        endedAt: now,
+        reason,
+        artifactsRoot: input.artifactsRoot,
+      }).catch(() => undefined);
+      publishState({ status: "ended", frameCount, startedAt, updatedAt: now, endedAt: now, reason });
+    },
+  };
+}
+
+async function writeManifest(input: {
+  missionId: string;
+  status: "running" | "ended";
+  frameCount: number;
+  updatedAt: string;
+  endedAt?: string;
+  reason?: string;
+  artifactsRoot: string;
+}): Promise<void> {
+  const manifest: TestbedScreencastManifest = {
+    schemaVersion: 1,
+    kind: "testbed_live_screencast",
+    missionId: input.missionId,
+    status: input.status,
+    contentType: "image/jpeg",
+    frameCount: input.frameCount,
+    latestFrame: "latest.jpg",
+    updatedAt: input.updatedAt,
+    ...(input.endedAt ? { endedAt: input.endedAt } : {}),
+    ...(input.reason ? { reason: input.reason } : {}),
+  };
+  await writeFile(screencastManifestPath(input.artifactsRoot, input.missionId), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
+function isCaptureablePageUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function urlContainsCredential(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return Boolean(url.username || url.password);
+  } catch {
+    return false;
+  }
+}
+
+function boundedInt(value: string | undefined, fallback: number, min: number, max: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+function isTestbedScreencastManifest(value: unknown): value is TestbedScreencastManifest {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as TestbedScreencastManifest).schemaVersion === 1 &&
+    (value as TestbedScreencastManifest).kind === "testbed_live_screencast" &&
+    typeof (value as TestbedScreencastManifest).missionId === "string" &&
+    ((value as TestbedScreencastManifest).status === "running" || (value as TestbedScreencastManifest).status === "ended") &&
+    typeof (value as TestbedScreencastManifest).frameCount === "number" &&
+    typeof (value as TestbedScreencastManifest).latestFrame === "string" &&
+    typeof (value as TestbedScreencastManifest).updatedAt === "string"
+  );
+}

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -28,6 +28,12 @@ import {
 import { executeSiweAuthMission, type SiweAuthMissionDeps } from "./testbed-auth-mission.js";
 import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
 import {
+  parseTestbedLiveScreencastConfig,
+  startPlaywrightLiveScreencast,
+  type TestbedLiveScreencastConfig,
+  type TestbedLiveScreencastController,
+} from "./testbed-live-screencast.js";
+import {
   basicAuthHeadersForUrl,
   basicAuthHttpCredentialsForUrl,
   cloudflareAccessHeaders,
@@ -73,6 +79,8 @@ export interface TestbedMissionRunnerConfig {
   /** T5 evidence capture toggles. Defaults on for the Playwright executor. */
   captureTrace?: boolean;
   captureVideo?: boolean;
+  /** Optional P3b live screencast. Testnet-only, bounded, and monitor-authenticated. */
+  liveScreencast?: TestbedLiveScreencastConfig;
   /** T2 pre-seeded session source (sidecar URL and/or manual storageState path/token). */
   session?: SweepSessionConfig;
   /** Cloudflare Access service-token headers for gated hosted app routes. */
@@ -147,6 +155,7 @@ export function parseTestbedMissionRunnerConfig(
       : {}),
     captureTrace: env.TESTBED_MISSION_CAPTURE_TRACE !== "0" && env.TESTBED_MISSION_CAPTURE_TRACE !== "false",
     captureVideo: env.TESTBED_MISSION_CAPTURE_VIDEO !== "0" && env.TESTBED_MISSION_CAPTURE_VIDEO !== "false",
+    liveScreencast: parseTestbedLiveScreencastConfig(env),
     session: parseSweepSessionConfig(env),
     ...(cloudflareAccess ? { cloudflareAccess } : {}),
     ...(basicAuth ? { basicAuth } : {}),
@@ -448,6 +457,17 @@ export async function executeGoldPathTestbedMission(
   mission: TestbedMissionRun,
   config: TestbedMissionRunnerConfig
 ): Promise<TestbedMissionRunResult> {
+  if (config.liveScreencast?.enabled) {
+    updateTestbedMissionProgress(mission.id, {
+      path: config.path,
+      progressMessage: "Gold-path live driver is running out-of-process; true browser screencast is unavailable for this driver boundary.",
+      liveScreencast: {
+        status: "unavailable",
+        reason: "gold_path_driver_out_of_process",
+        updatedAt: new Date().toISOString(),
+      },
+    });
+  }
   const result = await runGoldPathMissionEntry({
     ...process.env,
     TESTBED_MISSION_ID: mission.id,
@@ -571,6 +591,7 @@ export async function executePlaywrightTestbedMission(
   let page: Page | undefined;
   let tracePath: string | undefined;
   let traceRunning = false;
+  let liveScreencast: TestbedLiveScreencastController | undefined;
   try {
     browser = await chromium.launch({
       headless: true,
@@ -593,6 +614,25 @@ export async function executePlaywrightTestbedMission(
     });
     context = contextAndPage.context;
     page = contextAndPage.page;
+    if (config.liveScreencast?.enabled) {
+      liveScreencast = await startPlaywrightLiveScreencast({
+        mission,
+        page,
+        artifactsRoot: config.artifactsDir || "/tmp/averray-testbed-mission-artifacts",
+        config: config.liveScreencast,
+        update: (state) => {
+          updateTestbedMissionProgress(mission.id, {
+            path: config.path,
+            progressMessage:
+              state.status === "unavailable"
+                ? `Live browser screencast unavailable: ${state.reason ?? "not available"}.`
+                : undefined,
+            liveScreencast: state,
+            ...(state.latestFrameUrl ? { progressScreenshotUrl: state.latestFrameUrl } : {}),
+          });
+        },
+      });
+    }
     if (config.basicAuth) {
       await page.route("**/*", (route) => {
         const headers = basicAuthHeadersForUrl(route.request().url(), config.basicAuth, route.request().headers());
@@ -686,6 +726,8 @@ export async function executePlaywrightTestbedMission(
         ? "No real mutation boundary was crossed; only visibly safe testbed actions were allowed."
         : "No real mutation boundary was crossed; the run stayed browser-visible and read-only.");
     }
+    await liveScreencast?.stop("mission_finished");
+    liveScreencast = undefined;
     ({ traceRunning } = await finalizePlaywrightArtifacts({
       context,
       page,
@@ -787,6 +829,8 @@ export async function executePlaywrightTestbedMission(
       const failureText = await visiblePageText(page).catch(() => "");
       if (failureText) evidence.push({ type: "visible_text_failure", value: clip(failureText, 900) });
     }
+    await liveScreencast?.stop("mission_failed");
+    liveScreencast = undefined;
     ({ traceRunning } = await finalizePlaywrightArtifacts({
       context,
       page,
@@ -875,6 +919,7 @@ export async function executePlaywrightTestbedMission(
       summary: detail,
     };
   } finally {
+    await liveScreencast?.stop("mission_finished").catch(() => undefined);
     if (traceRunning && context && tracePath) await context.tracing.stop({ path: tracePath }).catch(() => undefined);
     await context?.close().catch(() => undefined);
     await browser?.close().catch(() => undefined);

--- a/test/unit/monitor-testbed-missions.test.ts
+++ b/test/unit/monitor-testbed-missions.test.ts
@@ -21,6 +21,7 @@ import {
   testbedMissionRunToMonitorItem,
   testbedMissionSelfHealingDisposition,
   testbedMissionStructuredReport,
+  updateTestbedMissionProgress,
 } from "../../services/slack-operator/src/monitor-testbed-missions.js";
 
 describe("monitor testbed mission runs", () => {
@@ -49,6 +50,31 @@ describe("monitor testbed mission runs", () => {
     });
     expect(run?.id).toMatch(/^testbed-mission-/);
     expect(listTestbedMissionRuns()).toHaveLength(1);
+  });
+
+  it("persists live screencast progress metadata while a mission is running", () => {
+    const run = recordTestbedMissionRunFromOperatorResult(missionResult(), Date.parse("2026-05-22T10:00:00.000Z"));
+    const updated = updateTestbedMissionProgress(run!.id, {
+      progressMessage: "Capturing live browser frame.",
+      progressScreenshotUrl: "/monitor/testbed-missions/testbed-mission-1/screencast/latest.jpg",
+      liveScreencast: {
+        status: "running",
+        streamUrl: "/monitor/testbed-missions/testbed-mission-1/screencast",
+        latestFrameUrl: "/monitor/testbed-missions/testbed-mission-1/screencast/latest.jpg",
+        frameCount: 2,
+        updatedAt: "2026-05-22T10:00:02.000Z",
+      },
+    });
+
+    expect(updated).toMatchObject({
+      status: "running",
+      progressMessage: "Capturing live browser frame.",
+      progressScreenshotUrl: "/monitor/testbed-missions/testbed-mission-1/screencast/latest.jpg",
+      liveScreencast: {
+        status: "running",
+        frameCount: 2,
+      },
+    });
   });
 
   it("records a SIWE auth mission as a mission-native run", () => {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -580,7 +580,14 @@ describe("enrichBoardCard", () => {
           status: "running",
           progressMessage: "Clicking safe visible control: Connect wallet",
           stdoutTail: "opened https://staging.averray.com\nclicked Connect wallet\n",
-          progressAt: "2026-06-02T10:00:00.000Z"
+          progressAt: "2026-06-02T10:00:00.000Z",
+          liveScreencast: {
+            status: "running",
+            streamUrl: "/monitor/testbed-missions/mission%20run-1/screencast",
+            latestFrameUrl: "/monitor/testbed-missions/mission%20run-1/screencast/latest.jpg",
+            frameCount: 3,
+            updatedAt: "2026-06-02T10:00:00.000Z"
+          }
         }
       }
     );
@@ -588,7 +595,14 @@ describe("enrichBoardCard", () => {
     expect(card.missionProgress).toEqual({
       message: "Clicking safe visible control: Connect wallet",
       output: "opened https://staging.averray.com\nclicked Connect wallet\n",
-      at: "2026-06-02T10:00:00.000Z"
+      at: "2026-06-02T10:00:00.000Z",
+      liveScreencast: {
+        status: "running",
+        streamUrl: "/monitor/testbed-missions/mission%20run-1/screencast",
+        latestFrameUrl: "/monitor/testbed-missions/mission%20run-1/screencast/latest.jpg",
+        frameCount: 3,
+        updatedAt: "2026-06-02T10:00:00.000Z"
+      }
     });
     // No verdict/report while running — the agent posts that only at the end.
     expect(card.mission).toBeUndefined();

--- a/test/unit/testbed-live-screencast.test.ts
+++ b/test/unit/testbed-live-screencast.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Page } from "playwright-core";
+
+import type { TestbedMissionRun } from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import {
+  liveScreencastAllowedForMission,
+  parseTestbedLiveScreencastConfig,
+  readTestbedScreencastManifest,
+  screencastLatestFramePath,
+  startPlaywrightLiveScreencast,
+} from "../../services/slack-operator/src/testbed-live-screencast.js";
+
+describe("testbed live screencast", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("parses a bounded opt-in config", () => {
+    expect(parseTestbedLiveScreencastConfig({
+      TESTBED_MISSION_LIVE_SCREENCAST_ENABLED: "1",
+      TESTBED_MISSION_LIVE_SCREENCAST_INTERVAL_MS: "10",
+      TESTBED_MISSION_LIVE_SCREENCAST_MAX_FRAMES: "2000",
+      TESTBED_MISSION_LIVE_SCREENCAST_JPEG_QUALITY: "99",
+    } as NodeJS.ProcessEnv)).toEqual({
+      enabled: true,
+      intervalMs: 250,
+      maxFrames: 1000,
+      jpegQuality: 80,
+    });
+  });
+
+  it("is testnet-only and rejects credential-bearing target URLs", () => {
+    const enabled = { enabled: true, intervalMs: 500, maxFrames: 10, jpegQuality: 45 };
+    expect(liveScreencastAllowedForMission(
+      { environment: "mainnet", targetUrl: "https://app.averray.com" },
+      enabled,
+    )).toEqual({ ok: false, reason: "live_screencast_testnet_only" });
+    expect(liveScreencastAllowedForMission(
+      { environment: "testnet", targetUrl: "https://user:pass@app.testnet.example" },
+      enabled,
+    )).toEqual({ ok: false, reason: "live_screencast_target_url_contains_credentials" });
+  });
+
+  it("captures bounded latest-frame evidence and publishes monitor stream metadata", async () => {
+    vi.useFakeTimers();
+    const root = mkdtempSync(join(tmpdir(), "averray-screencast-test-"));
+    const mission = missionRun({
+      id: "mission-live-1",
+      targetUrl: "https://app.testnet.example/gold",
+      environment: "testnet",
+    });
+    const page = {
+      url: () => "https://app.testnet.example/gold",
+      screenshot: vi.fn(async ({ path }: { path: string }) => {
+        writeFileSync(path, Buffer.from("jpeg-frame"));
+      }),
+    } as unknown as Page;
+    const updates: unknown[] = [];
+
+    const controller = await startPlaywrightLiveScreencast({
+      mission,
+      page,
+      artifactsRoot: root,
+      config: { enabled: true, intervalMs: 5, maxFrames: 2, jpegQuality: 40 },
+      update: (state) => updates.push(state),
+    });
+
+    expect(controller).toBeDefined();
+    await vi.advanceTimersByTimeAsync(5);
+    expect(page.screenshot).toHaveBeenCalledOnce();
+    expect(readFileSync(screencastLatestFramePath(root, mission.id), "utf8")).toBe("jpeg-frame");
+    await vi.waitFor(() => {
+      expect(updates).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          status: "running",
+          streamUrl: `/monitor/testbed-missions/${mission.id}/screencast`,
+          latestFrameUrl: `/monitor/testbed-missions/${mission.id}/screencast/latest.jpg`,
+          frameCount: 1,
+        }),
+      ]));
+    });
+
+    await controller?.stop("test_finished");
+    const manifest = await readTestbedScreencastManifest(root, mission.id);
+    expect(manifest).toMatchObject({
+      status: "ended",
+      reason: "test_finished",
+    });
+    expect(manifest?.frameCount).toBeGreaterThanOrEqual(1);
+  });
+});
+
+function missionRun(overrides: Partial<TestbedMissionRun>): TestbedMissionRun {
+  const now = "2026-06-02T10:00:00.000Z";
+  return {
+    schemaVersion: 1,
+    kind: "testbed_mission_run",
+    id: "mission",
+    status: "running",
+    title: "Mission",
+    targetUrl: "https://example.test",
+    goal: "Inspect the target.",
+    agentName: "Hermes",
+    freshMemory: true,
+    allowTestMutations: false,
+    requestedAllowTestMutations: false,
+    mutationMode: "read_only",
+    mutationScope: "none; stop at mutation boundary",
+    mutationBindingReason: "mission did not request testbed mutations.",
+    mission: {},
+    history: [],
+    createdAt: now,
+    updatedAt: now,
+    statusReason: "running",
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## What changed & why

- Added an opt-in P3b live screencast foundation for Playwright-owned testnet missions, with bounded frame capture, monitor-authenticated stream URLs, latest-frame artifacts, and defensive redaction for credential-bearing URLs or non-page frames.
- Added monitor endpoints for /monitor/testbed-missions/:id/screencast and /monitor/testbed-missions/:id/screencast/latest.jpg, plus board payload metadata so the drawer can add a Live view toggle and fall back cleanly to the P3 step view.
- Kept the gold-path driver truth-boundary honest: it runs out-of-process today, so when screencast is enabled it reports unavailable instead of pretending to have a Playwright BrowserContext stream.
- Documented the current P3b implementation boundary in docs/HERMES_TESTER_UX.md and added regression coverage for config bounds, testnet-only guards, persisted progress metadata, and board projection.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] npm run typecheck
- [x] npm test
- [ ] docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config (only if ops/Docker/compose touched)

## Rollout / rollback

No deploy template or secret changes. The screencast path is disabled by default and only activates when TESTBED_MISSION_LIVE_SCREENCAST_ENABLED is true. Rollback is reverting this PR or leaving the flag unset.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated AGENTS.md / affected docs if this changes how agents work

## Known limits / follow-ups

- Gold-path missions currently surface liveScreencast.status=unavailable when the feature is enabled because gold-path shells out to the Claude browser runtime. A true gold-path stream needs that external driver to publish frames or expose its Playwright context.
- Claude still owns the drawer Live view toggle. This PR supplies the backend stream and typed monitor payload, with fallback metadata for the existing P3 step view.
