### PR TITLE
Add agent-authored suite proposals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,11 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   sidecar provides sessions, `HALT_FILE` is absent, and D3 is not suspended.
   External-agent requested tester runs (T6, carrying `requesterAgent`) still land
   `requested` and require operator approval before any runner can claim them.
+- **Saved tester suite proposals are operator-gated.** Test-writer specialists
+  and product/platform agents may propose reusable saved suites through the
+  monitor suite request surface. These proposals land `requested`; approval only
+  saves the suite, and never starts a run. Running a saved suite remains a
+  separate operator/internal action bounded by the tester safety rules.
 - **Humans own approval.** A PASS verdict is a release *signal*, not a merge order.
   Merge and deploy are human-gated. No auto-merge.
 - **Per-agent task runners** (`codex-task-runner`, `claude-task-runner`) claim

--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -285,6 +285,56 @@ describe("MonitorPage — container", () => {
     }
   });
 
+  test("requested suite approval and dismiss POST to the suite endpoints", async () => {
+    const fetcher = vi.fn(async (): Promise<MonitorBoard> => ({
+      cards: [],
+      at: "2026-05-28T10:30:00Z",
+      testbedSuites: [{
+        schemaVersion: 1,
+        kind: "testbed_suite",
+        id: "testbed-suite-settings-coverage-1",
+        status: "requested",
+        name: "Settings coverage gap",
+        target: "https://app.averray.com/settings",
+        mode: "surface_sweep",
+        author: "test-writer",
+        requesterAgent: "test-writer",
+        requestReason: "Changed surface has no saved regression suite.",
+        requestedAt: "2026-05-28T10:00:00.000Z",
+        createdAt: "2026-05-28T10:00:00.000Z",
+        updatedAt: "2026-05-28T10:00:00.000Z",
+        history: [],
+      }],
+    }));
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 200 }));
+    try {
+      const { getByRole } = render(
+        <MonitorPage
+          options={{ fetcher, EventSourceCtor: ES, storage: memStorage() }}
+          backlogSuggestions={{ enabled: false }}
+          collaboration={{ enabled: false }}
+          alerts={{ enabled: false }}
+          autonomy={{ fetchMode: async () => null }}
+        />,
+        { wrapper },
+      );
+      await waitFor(() => expect(getByRole("button", { name: "Approve" })).toBeTruthy());
+
+      fireEvent.click(getByRole("button", { name: "Approve" }));
+      fireEvent.click(getByRole("button", { name: "Dismiss" }));
+
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      const [approveUrl, approveInit] = fetchSpy.mock.calls[0] as [string, RequestInit];
+      const [dismissUrl, dismissInit] = fetchSpy.mock.calls[1] as [string, RequestInit];
+      expect(approveUrl).toBe("/monitor/testbed-suites/testbed-suite-settings-coverage-1/approve");
+      expect(approveInit.method).toBe("POST");
+      expect(dismissUrl).toBe("/monitor/testbed-suites/testbed-suite-settings-coverage-1/dismiss");
+      expect(dismissInit.method).toBe("POST");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   test("the default mission approval POSTs to /monitor/testbed-missions/:id/approve", async () => {
     const requestedMission = {
       id: "testbed-mission-requested-1",

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -52,6 +52,10 @@ export interface MonitorPageProps {
   onSaveSuite?: (input: SaveTestSuiteInput) => void;
   /** Override running a named suite (defaults to POST /monitor/testbed-suites/:id/run). */
   onRunSuite?: (id: string) => void;
+  /** Override approving a requested suite (defaults to POST /monitor/testbed-suites/:id/approve). */
+  onApproveSuite?: (id: string) => void;
+  /** Override dismissing a requested suite (defaults to POST /monitor/testbed-suites/:id/dismiss). */
+  onDismissSuite?: (id: string) => void;
   /** Override the /claude propose (defaults to POST /monitor/codex-tasks). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Override the create-task dispatch (defaults to POST /monitor/codex-tasks propose). */
@@ -88,6 +92,8 @@ export function MonitorPage({
   onSpawnMission = defaultSpawnMission,
   onSaveSuite = defaultSaveSuite,
   onRunSuite = defaultRunSuite,
+  onApproveSuite = defaultApproveSuite,
+  onDismissSuite = defaultDismissSuite,
   onSpawnClaudeTask = defaultSpawnClaudeTask,
   onCreateTask = defaultCreateTask,
   onApproveTask = defaultApproveTask,
@@ -140,6 +146,8 @@ export function MonitorPage({
         onSpawnMission={onSpawnMission}
         onSaveSuite={onSaveSuite}
         onRunSuite={onRunSuite}
+        onApproveSuite={onApproveSuite}
+        onDismissSuite={onDismissSuite}
         onSpawnClaudeTask={onSpawnClaudeTask}
         onCreateTask={onCreateTask}
         onApproveTask={onApproveTask}
@@ -174,6 +182,24 @@ function defaultSaveSuite(input: SaveTestSuiteInput): void {
 
 function defaultRunSuite(id: string): void {
   void fetch(`${SUITES_URL}/${encodeURIComponent(id)}/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+function defaultApproveSuite(id: string): void {
+  void fetch(`${SUITES_URL}/${encodeURIComponent(id)}/approve`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+  }).catch(() => {
+    /* surfaced via the board feed / degraded state, not thrown here */
+  });
+}
+
+function defaultDismissSuite(id: string): void {
+  void fetch(`${SUITES_URL}/${encodeURIComponent(id)}/dismiss`, {
     method: "POST",
     headers: { "content-type": "application/json" },
   }).catch(() => {

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -164,6 +164,51 @@ describe("BoardView — rich-mix board (open stream)", () => {
     });
   });
 
+  test("renders requested agent-authored suites with operator approval actions", () => {
+    const onApproveSuite = vi.fn();
+    const onDismissSuite = vi.fn();
+    const board: MonitorBoard = {
+      at: "2026-06-02T08:00:00Z",
+      cards: [],
+      testbedSuites: [{
+        schemaVersion: 1,
+        kind: "testbed_suite",
+        id: "testbed-suite-settings-coverage-1",
+        status: "requested",
+        name: "Settings coverage gap",
+        target: "https://app.averray.com/settings",
+        mode: "surface_sweep",
+        goal: "Check settings affordances.",
+        author: "test-writer",
+        requesterAgent: "test-writer",
+        requestReason: "Changed surface has no saved regression suite.",
+        requestedAt: "2026-06-02T07:30:00.000Z",
+        createdAt: "2026-06-02T07:30:00.000Z",
+        updatedAt: "2026-06-02T07:30:00.000Z",
+        history: [],
+      }],
+    };
+    const { getByRole, getByText, queryByRole } = render(
+      <BoardView
+        board={board}
+        status="open"
+        onApproveSuite={onApproveSuite}
+        onDismissSuite={onDismissSuite}
+        keyboard={false}
+      />,
+    );
+
+    expect(getByText("Settings coverage gap")).toBeTruthy();
+    expect(getByText(/test-writer requested/)).toBeTruthy();
+    expect(getByText("requested")).toBeTruthy();
+    expect(queryByRole("button", { name: "Run" })).toBeNull();
+
+    fireEvent.click(getByRole("button", { name: "Approve" }));
+    fireEvent.click(getByRole("button", { name: "Dismiss" }));
+    expect(onApproveSuite).toHaveBeenCalledWith("testbed-suite-settings-coverage-1");
+    expect(onDismissSuite).toHaveBeenCalledWith("testbed-suite-settings-coverage-1");
+  });
+
   test("a calm board still expands lanes holding in-flight cards (regression: action==0 used to hide all but Done)", () => {
     const calm: MonitorBoard = {
       at: "2026-05-28T10:30:00Z",

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -101,6 +101,8 @@ export interface BoardViewProps {
   onSpawnMission?: (input: MissionSpawnInput) => void;
   onSaveSuite?: (input: SaveTestSuiteInput) => void;
   onRunSuite?: (id: string) => void;
+  onApproveSuite?: (id: string) => void;
+  onDismissSuite?: (id: string) => void;
   /** Propose a greenfield Claude task (/claude <repo> <task>). */
   onSpawnClaudeTask?: (repo: string, prompt: string) => void;
   /** Propose a task — /task verb + the codex-needed create form (O3). */
@@ -147,6 +149,8 @@ export function BoardView({
   onSpawnMission,
   onSaveSuite,
   onRunSuite,
+  onApproveSuite,
+  onDismissSuite,
   onSpawnClaudeTask,
   onCreateTask,
   onApproveTask,
@@ -505,7 +509,13 @@ export function BoardView({
             onFilterChange={setFilter}
           />
           <LlmUsagePanel usage={board?.llmUsage} />
-          <TestSuitesPanel suites={board?.testbedSuites} onRunSuite={onRunSuite} onSaveSuite={onSaveSuite} />
+          <TestSuitesPanel
+            suites={board?.testbedSuites}
+            onRunSuite={onRunSuite}
+            onSaveSuite={onSaveSuite}
+            onApproveSuite={onApproveSuite}
+            onDismissSuite={onDismissSuite}
+          />
           {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} onSaveSuite={onSaveSuite} /> : null}
           <Board
             grouped={displayGrouped}

--- a/packages/monitor-ui/src/components/TestSuitesPanel.tsx
+++ b/packages/monitor-ui/src/components/TestSuitesPanel.tsx
@@ -7,9 +7,11 @@ export interface TestSuitesPanelProps {
   suites?: SavedTestSuite[];
   onRunSuite?: (id: string) => void;
   onSaveSuite?: (input: SaveTestSuiteInput) => void;
+  onApproveSuite?: (id: string) => void;
+  onDismissSuite?: (id: string) => void;
 }
 
-export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite }: TestSuitesPanelProps) {
+export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite, onApproveSuite, onDismissSuite }: TestSuitesPanelProps) {
   const nameId = useId();
   const targetId = useId();
   const goalId = useId();
@@ -75,14 +77,30 @@ export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite }: TestSu
               <div>
                 <strong>{suite.name}</strong>
                 <span>{modeLabel(suite.mode)} · {targetLabel(suite.target)}</span>
+                {suite.status === "requested" ? (
+                  <small>{suite.requesterAgent ?? suite.author} requested · {suite.requestReason ?? "waiting for operator approval"}</small>
+                ) : null}
               </div>
               <div className="hm-test-suite-meta">
                 <span className={`hm-test-suite-verdict hm-test-suite-verdict--${verdictTone(suite.lastRun?.verdict)}`}>
-                  {suite.lastRun ? suite.lastRun.verdict : "never run"}
+                  {suite.status === "requested" ? "requested" : suite.lastRun ? suite.lastRun.verdict : "never run"}
                 </span>
                 <small>{suite.history.length} runs</small>
               </div>
-              {onRunSuite ? (
+              {suite.status === "requested" ? (
+                <div className="hm-test-suite-actions">
+                  {onApproveSuite ? (
+                    <button type="button" className="hm-btn hm-btn--action hm-btn--sm" onClick={() => onApproveSuite(suite.id)}>
+                      Approve
+                    </button>
+                  ) : null}
+                  {onDismissSuite ? (
+                    <button type="button" className="hm-btn hm-btn--sm" onClick={() => onDismissSuite(suite.id)}>
+                      Dismiss
+                    </button>
+                  ) : null}
+                </div>
+              ) : onRunSuite ? (
                 <button type="button" className="hm-btn hm-btn--action hm-btn--sm" onClick={() => onRunSuite(suite.id)}>
                   Run
                 </button>

--- a/packages/monitor-ui/src/lib/monitor/mission-launch.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-launch.ts
@@ -2,6 +2,7 @@ export type MissionLaunchMode = "surface_sweep" | "gold_path" | "siwe_auth";
 export type MissionInitialStatus = "ready" | "requested";
 export type SavedTestSuiteAuthor = "predefined" | "operator" | "test-writer" | "platform";
 export type SavedTestSuiteVerdict = "pass" | "partial" | "fail" | "requested" | "ready" | "running" | "failed" | "unknown";
+export type SavedTestSuiteStatus = "requested" | "saved";
 
 export interface MissionLaunchInput {
   targetUrl: string;
@@ -23,11 +24,17 @@ export interface SavedTestSuite {
   schemaVersion: 1;
   kind: "testbed_suite";
   id: string;
+  status?: SavedTestSuiteStatus;
   name: string;
   target: string;
   mode: MissionLaunchMode;
   goal?: string;
   author: SavedTestSuiteAuthor;
+  requesterAgent?: string;
+  requestReason?: string;
+  requestedAt?: string;
+  approvedAt?: string;
+  approvedBy?: string;
   createdAt: string;
   updatedAt: string;
   history: SavedTestSuiteHistoryEntry[];

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -523,6 +523,11 @@ body { margin: 0; }
   align-items: center;
   gap: 7px;
 }
+.hm-test-suite-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
 .hm-test-suite-verdict {
   font-family: var(--font-mono);
   text-transform: uppercase;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -167,9 +167,12 @@ import {
 } from "./monitor-testbed-missions.js";
 import {
   appendTestbedSuiteRun,
+  approveRequestedTestbedSuite,
   createTestbedSuite,
+  dismissRequestedTestbedSuite,
   getTestbedSuite,
   listTestbedSuites,
+  requestTestbedSuite,
   type TestbedSuite,
 } from "./monitor-testbed-suites.js";
 import {
@@ -783,6 +786,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     await handleMonitorTestbedMissionRequestProposal(request, response);
     return;
   }
+  if (request.method === "POST" && url.pathname === "/monitor/testbed-suites/request") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    await handleMonitorTestbedSuiteRequestProposal(request, response);
+    return;
+  }
   const testbedSuiteRunId = monitorTestbedSuiteRunId(url.pathname);
   if (request.method === "POST" && testbedSuiteRunId) {
     if (!monitorConfig.enabled) {
@@ -801,7 +816,8 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     await handleMonitorTestbedSuiteRunRequest(testbedSuiteRunId, response);
     return;
   }
-  if (url.pathname === "/monitor/testbed-suites" && (request.method === "GET" || request.method === "POST")) {
+  const testbedSuiteApproveId = monitorTestbedSuiteActionId(url.pathname, "approve");
+  if (request.method === "POST" && testbedSuiteApproveId) {
     if (!monitorConfig.enabled) {
       writeJson(response, 404, { error: "monitor_disabled" });
       return;
@@ -812,11 +828,58 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
     }
     const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
     if (!missionVerdict.allowed) {
-      writeJson(response, 403, { error: "testbed_suite_forbidden", reason: missionVerdict.reason });
+      writeJson(response, 403, { error: "testbed_suite_approve_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedSuiteApproveRequest(testbedSuiteApproveId, response);
+    return;
+  }
+  const testbedSuiteDismissId = monitorTestbedSuiteActionId(url.pathname, "dismiss");
+  if (request.method === "POST" && testbedSuiteDismissId) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "testbed_suite_dismiss_forbidden", reason: missionVerdict.reason });
+      return;
+    }
+    await handleMonitorTestbedSuiteDismissRequest(testbedSuiteDismissId, response);
+    return;
+  }
+  const testbedSuiteId = monitorTestbedSuiteId(url.pathname);
+  const handlesTestbedSuiteRead = request.method === "GET" && (url.pathname === "/monitor/testbed-suites" || Boolean(testbedSuiteId));
+  const handlesTestbedSuiteCreate = request.method === "POST" && url.pathname === "/monitor/testbed-suites";
+  if (handlesTestbedSuiteRead || handlesTestbedSuiteCreate) {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
       return;
     }
     if (request.method === "GET") {
+      if (testbedSuiteId) {
+        const suite = getTestbedSuite(testbedSuiteId);
+        if (!suite) {
+          writeJson(response, 404, { error: "testbed_suite_not_found", id: testbedSuiteId });
+          return;
+        }
+        writeJson(response, 200, { schemaVersion: 1, kind: "testbed_suite_detail", suite });
+        return;
+      }
       writeJson(response, 200, listTestbedSuites({ missionRuns: listTestbedMissionRuns({ limit: 50 }) }));
+      return;
+    }
+    const missionVerdict = authorizeMissionSpawn(missionSpawnRoles, request.headers);
+    if (!missionVerdict.allowed) {
+      writeJson(response, 403, { error: "testbed_suite_forbidden", reason: missionVerdict.reason });
       return;
     }
     await handleMonitorTestbedSuiteCreateRequest(request, response);
@@ -1671,11 +1734,79 @@ async function handleMonitorTestbedSuiteCreateRequest(request: http.IncomingMess
   }
 }
 
+async function handleMonitorTestbedSuiteRequestProposal(request: http.IncomingMessage, response: http.ServerResponse) {
+  try {
+    const rawBody = await readBody(request);
+    const payload = rawBody ? JSON.parse(rawBody) as unknown : {};
+    if (!isRecord(payload)) {
+      writeJson(response, 400, { error: "invalid_payload" });
+      return;
+    }
+    const suite = requestTestbedSuite(platformSuiteRequestPayload(payload));
+    writeJson(response, 200, {
+      ok: true,
+      suite,
+      nextStep: "Suite proposal is requested and operator-gated; it is not runnable until approved.",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.startsWith("suite_") || message.startsWith("invalid_suite_")) {
+      writeJson(response, 400, { error: message });
+      return;
+    }
+    logger.error({ err: error }, "monitor_testbed_suite_request_failed");
+    writeJson(response, 500, {
+      error: "monitor_testbed_suite_request_failed",
+      message,
+    });
+  }
+}
+
+async function handleMonitorTestbedSuiteApproveRequest(id: string, response: http.ServerResponse) {
+  const result = approveRequestedTestbedSuite(id, { approvedBy: "operator" });
+  if (!result.ok) {
+    writeJson(response, result.error === "not_found" ? 404 : 409, {
+      error: `testbed_suite_${result.error}`,
+      ...(result.suite ? { suite: result.suite } : {}),
+    });
+    return;
+  }
+  writeJson(response, 200, {
+    ok: true,
+    suite: result.suite,
+    nextStep: "Suite approved and saved. It is runnable from the Suites panel; approval did not start a run.",
+  });
+}
+
+async function handleMonitorTestbedSuiteDismissRequest(id: string, response: http.ServerResponse) {
+  const result = dismissRequestedTestbedSuite(id);
+  if (!result.ok) {
+    writeJson(response, result.error === "not_found" ? 404 : 409, {
+      error: `testbed_suite_${result.error}`,
+      ...(result.suite ? { suite: result.suite } : {}),
+    });
+    return;
+  }
+  writeJson(response, 200, {
+    ok: true,
+    suite: result.suite,
+    nextStep: "Requested suite dismissed; it was not saved and no run was started.",
+  });
+}
+
 async function handleMonitorTestbedSuiteRunRequest(id: string, response: http.ServerResponse) {
   try {
     const suite = getTestbedSuite(id);
     if (!suite) {
       writeJson(response, 404, { error: "testbed_suite_not_found", id });
+      return;
+    }
+    if (suite.status === "requested") {
+      writeJson(response, 409, {
+        error: "testbed_suite_not_approved",
+        suite,
+        message: "Requested suites must be approved by the operator before they can run.",
+      });
       return;
     }
     const created = createMonitorTestbedMissionFromPayload({
@@ -1715,6 +1846,22 @@ async function handleMonitorTestbedSuiteRunRequest(id: string, response: http.Se
       message: error instanceof Error ? error.message : String(error),
     });
   }
+}
+
+function platformSuiteRequestPayload(payload: Record<string, unknown>) {
+  const author = typeof payload.author === "string" ? payload.author.trim() : undefined;
+  const requesterAgent = typeof payload.requesterAgent === "string" ? payload.requesterAgent.trim() : undefined;
+  const requestAuthor = author === "test-writer" ? "test-writer" : "platform";
+  return {
+    ...payload,
+    author: requestAuthor,
+    requesterAgent: requesterAgent ?? requestAuthor,
+    reason: typeof payload.reason === "string" && payload.reason.trim()
+      ? payload.reason
+      : requestAuthor === "test-writer"
+        ? "Test-writer specialist proposed a suite for a coverage gap."
+        : "Platform agent requested a saved suite.",
+  };
 }
 
 async function handleMonitorTestbedMissionRequestProposal(request: http.IncomingMessage, response: http.ServerResponse) {
@@ -3640,21 +3787,39 @@ function monitorTestbedSuiteRunId(pathname: string): string | undefined {
   return id.length > 0 && !id.includes("/") ? id : undefined;
 }
 
+function monitorTestbedSuiteId(pathname: string): string | undefined {
+  const prefix = "/monitor/testbed-suites/";
+  if (!pathname.startsWith(prefix)) return undefined;
+  const id = decodeURIComponent(pathname.slice(prefix.length)).trim();
+  return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
+function monitorTestbedSuiteActionId(pathname: string, action: "approve" | "dismiss"): string | undefined {
+  const prefix = "/monitor/testbed-suites/";
+  const suffix = `/${action}`;
+  if (!pathname.startsWith(prefix) || !pathname.endsWith(suffix)) return undefined;
+  const raw = pathname.slice(prefix.length, -suffix.length);
+  const id = decodeURIComponent(raw).trim();
+  return id.length > 0 && !id.includes("/") ? id : undefined;
+}
+
 function testerSavedSuitesForManifest() {
   const missionRuns = listTestbedMissionRuns({ limit: 50 });
-  return listTestbedSuites({ missionRuns }).suites.map((suite) => ({
-    id: suite.id,
-    name: suite.name,
-    flow: testerSuiteFlowId(suite.mode),
-    target: suite.target,
-    ...(suite.lastRun ? {
-      lastRun: {
-        missionId: suite.lastRun.runId,
-        verdict: suite.lastRun.verdict,
-        at: suite.lastRun.ts,
-      },
-    } : {}),
-  }));
+  return listTestbedSuites({ missionRuns }).suites
+    .filter((suite) => suite.status !== "requested")
+    .map((suite) => ({
+      id: suite.id,
+      name: suite.name,
+      flow: testerSuiteFlowId(suite.mode),
+      target: suite.target,
+      ...(suite.lastRun ? {
+        lastRun: {
+          missionId: suite.lastRun.runId,
+          verdict: suite.lastRun.verdict,
+          at: suite.lastRun.ts,
+        },
+      } : {}),
+    }));
 }
 
 function testerSuiteFlowId(mode: TestbedSuite["mode"]): string {

--- a/services/slack-operator/src/monitor-testbed-suites.ts
+++ b/services/slack-operator/src/monitor-testbed-suites.ts
@@ -13,6 +13,7 @@ const MAX_TESTBED_SUITE_HISTORY = 50;
 export type TestbedSuiteAuthor = "predefined" | "operator" | "test-writer" | "platform";
 export type TestbedSuiteMode = Extract<TestbedMissionMode, "surface_sweep" | "siwe_auth" | "gold_path">;
 export type TestbedSuiteRunVerdict = TestbedMissionVerdict | "requested" | "ready" | "running" | "failed" | "unknown";
+export type TestbedSuiteStatus = "requested" | "saved";
 
 export interface TestbedSuiteHistoryEntry {
   runId: string;
@@ -24,11 +25,17 @@ export interface TestbedSuite {
   schemaVersion: 1;
   kind: "testbed_suite";
   id: string;
+  status: TestbedSuiteStatus;
   name: string;
   target: string;
   mode: TestbedSuiteMode;
   goal?: string;
   author: TestbedSuiteAuthor;
+  requesterAgent?: string;
+  requestReason?: string;
+  requestedAt?: string;
+  approvedAt?: string;
+  approvedBy?: string;
   createdAt: string;
   updatedAt: string;
   history: TestbedSuiteHistoryEntry[];
@@ -46,6 +53,9 @@ export interface CreateTestbedSuiteInput {
   mode?: unknown;
   goal?: unknown;
   author?: unknown;
+  requesterAgent?: unknown;
+  reason?: unknown;
+  requestReason?: unknown;
 }
 
 export interface ListTestbedSuitesOptions {
@@ -83,17 +93,72 @@ export function createTestbedSuite(
   input: CreateTestbedSuiteInput,
   deps: TestbedSuiteStoreDeps = {}
 ): TestbedSuite {
+  return createSuiteRecord(input, "saved", deps);
+}
+
+export function requestTestbedSuite(
+  input: CreateTestbedSuiteInput,
+  deps: TestbedSuiteStoreDeps = {}
+): TestbedSuite {
+  const author = parseSuiteAuthor(input.author);
+  if (author !== "test-writer" && author !== "platform") {
+    throw new Error("invalid_suite_request_author");
+  }
+  return createSuiteRecord(input, "requested", deps);
+}
+
+export function approveRequestedTestbedSuite(
+  id: string,
+  deps: TestbedSuiteStoreDeps & { approvedBy?: string } = {}
+): { ok: true; suite: TestbedSuite } | { ok: false; error: "not_found" | "not_requested"; suite?: TestbedSuite } {
+  ensureSuiteStoreLoaded(deps.path, { force: true });
+  const suite = suites.find((candidate) => candidate.id === id);
+  if (!suite) return { ok: false, error: "not_found" };
+  if (suite.status !== "requested") return { ok: false, error: "not_requested", suite: cloneSuite(suite) };
+  const now = (deps.now ?? new Date()).toISOString();
+  suite.status = "saved";
+  suite.approvedAt = now;
+  suite.approvedBy = deps.approvedBy ?? "operator";
+  suite.updatedAt = now;
+  persistSuiteStore(deps.path);
+  return { ok: true, suite: cloneSuite(suite) };
+}
+
+export function dismissRequestedTestbedSuite(
+  id: string,
+  deps: TestbedSuiteStoreDeps = {}
+): { ok: true; suite: TestbedSuite } | { ok: false; error: "not_found" | "not_requested"; suite?: TestbedSuite } {
+  ensureSuiteStoreLoaded(deps.path, { force: true });
+  const index = suites.findIndex((candidate) => candidate.id === id);
+  if (index < 0) return { ok: false, error: "not_found" };
+  const suite = suites[index];
+  if (suite.status !== "requested") return { ok: false, error: "not_requested", suite: cloneSuite(suite) };
+  const dismissed = cloneSuite({ ...suite, updatedAt: (deps.now ?? new Date()).toISOString() });
+  suites.splice(index, 1);
+  persistSuiteStore(deps.path);
+  return { ok: true, suite: dismissed };
+}
+
+function createSuiteRecord(
+  input: CreateTestbedSuiteInput,
+  status: TestbedSuiteStatus,
+  deps: TestbedSuiteStoreDeps = {}
+): TestbedSuite {
   ensureSuiteStoreLoaded(deps.path, { force: true });
   const now = (deps.now ?? new Date()).toISOString();
   const suite: TestbedSuite = {
     schemaVersion: 1,
     kind: "testbed_suite",
     id: nextSuiteId(input.name),
+    status,
     name: parseSuiteName(input.name),
     target: parseHttpTarget(input.target),
     mode: parseSuiteMode(input.mode),
     ...(parseOptionalString(input.goal) ? { goal: parseOptionalString(input.goal) } : {}),
     author: parseSuiteAuthor(input.author),
+    ...(parseOptionalString(input.requesterAgent) ? { requesterAgent: parseOptionalString(input.requesterAgent) } : {}),
+    ...(parseOptionalString(input.reason) || parseOptionalString(input.requestReason) ? { requestReason: parseOptionalString(input.reason) ?? parseOptionalString(input.requestReason) } : {}),
+    ...(status === "requested" ? { requestedAt: now } : {}),
     createdAt: now,
     updatedAt: now,
     history: [],
@@ -191,7 +256,7 @@ function suiteStoreSuites(value: unknown): TestbedSuite[] {
     : isRecord(value) && Array.isArray(value.suites)
       ? value.suites
       : [];
-  return rawSuites.filter(isTestbedSuite).slice(-MAX_TESTBED_SUITES);
+  return rawSuites.filter(isTestbedSuite).map(normalizeSuite).slice(-MAX_TESTBED_SUITES);
 }
 
 function suiteStoreSeq(value: unknown, loadedSuites: TestbedSuite[]): number {
@@ -257,6 +322,7 @@ function isTestbedSuite(value: unknown): value is TestbedSuite {
   if (!isRecord(value)) return false;
   if (value.schemaVersion !== 1 || value.kind !== "testbed_suite") return false;
   if (typeof value.id !== "string" || typeof value.name !== "string" || typeof value.target !== "string") return false;
+  if (value.status !== undefined && value.status !== "requested" && value.status !== "saved") return false;
   if (value.mode !== "surface_sweep" && value.mode !== "siwe_auth" && value.mode !== "gold_path") return false;
   if (value.author !== "predefined" && value.author !== "operator" && value.author !== "test-writer" && value.author !== "platform") return false;
   if (typeof value.createdAt !== "string" || typeof value.updatedAt !== "string") return false;
@@ -266,9 +332,16 @@ function isTestbedSuite(value: unknown): value is TestbedSuite {
 
 function cloneSuite(suite: TestbedSuite): TestbedSuite {
   return {
-    ...suite,
+    ...normalizeSuite(suite),
     history: suite.history.map((entry) => ({ ...entry })),
     ...(suite.lastRun ? { lastRun: { ...suite.lastRun } } : {}),
+  };
+}
+
+function normalizeSuite(suite: TestbedSuite): TestbedSuite {
+  return {
+    ...suite,
+    status: suite.status ?? "saved",
   };
 }
 

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -2039,6 +2039,7 @@ function testbedSuitesFromSnapshot(rawSnapshot: unknown): TestbedSuite[] {
         && typeof suite.id === "string"
         && typeof suite.name === "string"
         && typeof suite.target === "string"
+        && (suite.status === undefined || suite.status === "requested" || suite.status === "saved")
         && (suite.mode === "surface_sweep" || suite.mode === "siwe_auth" || suite.mode === "gold_path")
         && Array.isArray(suite.history)
       ) {

--- a/services/slack-operator/src/specialist-agents.ts
+++ b/services/slack-operator/src/specialist-agents.ts
@@ -22,6 +22,7 @@ export const TEST_WRITER_ROLE_PROMPT = [
   "- Prefer adding or tightening tests, fixtures, and small test harness helpers.",
   "- Do not broaden production behavior unless a compile failure or test seam requires the smallest supporting change.",
   "- Keep edits scoped to the requested test-writing task and explain any non-test edit in the PR body.",
+  "- When a changed surface or coverage gap should become a reusable browser suite, propose it through POST /monitor/testbed-suites/request with author \"test-writer\"; this is operator-gated and must not auto-run.",
   "- Run the smallest relevant checks and leave merge/deploy decisions to the human gate.",
 ].join("\n");
 

--- a/services/slack-operator/src/tester-capabilities.ts
+++ b/services/slack-operator/src/tester-capabilities.ts
@@ -187,6 +187,19 @@ export function buildTesterCapabilitiesManifest(deps: TesterCapabilitiesDeps = {
         auth: "same monitor auth as /monitor",
         contentType: "application/json",
       },
+      requestSuite: {
+        method: "POST",
+        path: "/monitor/testbed-suites/request",
+        auth: "same monitor auth as /monitor",
+        contentType: "application/json",
+        note: "agent-authored suite proposals land requested; operators approve before they become runnable saved suites",
+      },
+      approveRequestedSuite: {
+        method: "POST",
+        path: "/monitor/testbed-suites/{id}/approve",
+        auth: "monitor auth plus the mission-spawn role gate when configured",
+        note: "approval saves the suite but does not run it",
+      },
       approveRequestedMission: {
         method: "POST",
         path: "/monitor/testbed-missions/{id}/approve",

--- a/test/unit/monitor-testbed-suites.test.ts
+++ b/test/unit/monitor-testbed-suites.test.ts
@@ -6,8 +6,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   __resetTestbedSuitesForTests,
   appendTestbedSuiteRun,
+  approveRequestedTestbedSuite,
   createTestbedSuite,
+  dismissRequestedTestbedSuite,
   listTestbedSuites,
+  requestTestbedSuite,
 } from "../../services/slack-operator/src/monitor-testbed-suites.js";
 import { createMonitorTestbedMissionFromPayload } from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
 
@@ -74,5 +77,80 @@ describe("monitor testbed suites", () => {
       verdict: "ready",
       ts: "2026-06-02T08:05:00.000Z",
     });
+  });
+
+  it("parks test-writer suite proposals as requested until the operator approves", () => {
+    const path = join(dir, "suites.json");
+    const requested = requestTestbedSuite(
+      {
+        name: "Settings coverage gap",
+        target: "https://app.averray.com/settings",
+        mode: "surface_sweep",
+        goal: "Check settings affordances after the profile PR.",
+        author: "test-writer",
+        requesterAgent: "test-writer",
+        reason: "Changed surface has no saved regression suite.",
+      },
+      { path, now: new Date("2026-06-02T09:00:00.000Z") },
+    );
+
+    expect(requested).toMatchObject({
+      status: "requested",
+      author: "test-writer",
+      requesterAgent: "test-writer",
+      requestReason: "Changed surface has no saved regression suite.",
+      requestedAt: "2026-06-02T09:00:00.000Z",
+      history: [],
+    });
+
+    const approved = approveRequestedTestbedSuite(requested.id, {
+      path,
+      approvedBy: "operator",
+      now: new Date("2026-06-02T09:05:00.000Z"),
+    });
+
+    expect(approved).toMatchObject({
+      ok: true,
+      suite: {
+        id: requested.id,
+        status: "saved",
+        approvedAt: "2026-06-02T09:05:00.000Z",
+        approvedBy: "operator",
+        history: [],
+      },
+    });
+    expect(listTestbedSuites({ path }).suites[0]).toMatchObject({ id: requested.id, status: "saved" });
+  });
+
+  it("parks platform-agent suite requests and lets the operator dismiss them without saving", () => {
+    const path = join(dir, "suites.json");
+    const requested = requestTestbedSuite(
+      {
+        name: "Feature smoke",
+        target: "https://app.averray.com/new-feature",
+        mode: "siwe_auth",
+        goal: "Verify role-gated feature entry.",
+        author: "platform",
+        requesterAgent: "codex",
+        reason: "Product repo agent requested reusable coverage.",
+      },
+      { path, now: new Date("2026-06-02T09:00:00.000Z") },
+    );
+
+    const dismissed = dismissRequestedTestbedSuite(requested.id, {
+      path,
+      now: new Date("2026-06-02T09:03:00.000Z"),
+    });
+
+    expect(dismissed).toMatchObject({
+      ok: true,
+      suite: {
+        id: requested.id,
+        status: "requested",
+        author: "platform",
+        requesterAgent: "codex",
+      },
+    });
+    expect(listTestbedSuites({ path }).suites).toEqual([]);
   });
 });

--- a/test/unit/specialist-agents.test.ts
+++ b/test/unit/specialist-agents.test.ts
@@ -6,6 +6,7 @@ import {
   INTERNAL_SPECIALIST_AGENTS,
   SECURITY_AGENT_ID,
   SECURITY_ROLE_PROMPT,
+  TEST_WRITER_ROLE_PROMPT,
   taskAgentDefinition,
   specialistAgentDefinition,
 } from "../../services/slack-operator/src/specialist-agents.js";
@@ -75,5 +76,11 @@ describe("C3 specialist agent templates", () => {
 
   it("keeps the roster modular", () => {
     expect(INTERNAL_SPECIALIST_AGENTS.map((agent) => agent.id)).toEqual(["test-writer", "security", "docs"]);
+  });
+
+  it("tells the test-writer to propose saved suites without auto-running them", () => {
+    expect(TEST_WRITER_ROLE_PROMPT).toContain("/monitor/testbed-suites/request");
+    expect(TEST_WRITER_ROLE_PROMPT).toContain('author "test-writer"');
+    expect(TEST_WRITER_ROLE_PROMPT).toContain("must not auto-run");
   });
 });

--- a/test/unit/tester-capabilities.test.ts
+++ b/test/unit/tester-capabilities.test.ts
@@ -30,6 +30,8 @@ describe("tester capabilities manifest", () => {
         requestMission: { method: "POST", path: "/monitor/testbed-missions" },
         requestBoardGatedMission: { method: "POST", path: "/monitor/testbed-missions/request" },
         approveRequestedMission: { method: "POST", path: "/monitor/testbed-missions/{id}/approve" },
+        requestSuite: { method: "POST", path: "/monitor/testbed-suites/request" },
+        approveRequestedSuite: { method: "POST", path: "/monitor/testbed-suites/{id}/approve" },
       },
       runtime: {
         runnerEnabled: true,


### PR DESCRIPTION
## What changed
- Added requested/saved status for testbed suites, with agent-authored proposals parked as requested until operator approval.
- Added monitor endpoints for suite request, approval, dismissal, detail reads, and blocked unapproved suites from running.
- Wired requested suites into the board UI with Approve/Dismiss actions, updated tester capabilities, and taught the test-writer specialist to propose suites through the gated endpoint.

## Safety / authority
- Planner/proposer only: test-writer and platform agents can request suites, but cannot save or run them automatically.
- Approval saves a suite only; it does not start a mission.
- Requested suites are excluded from the runnable tester manifest until approved.

## Checks
- npm run typecheck
- npm test

## Surfaces
- Backend monitor API/store
- Monitor UI suite panel
- Tester capabilities manifest
- Specialist prompt / AGENTS invariant