### PR TITLE
fix(runner): clone with Basic auth (x-access-token), not Bearer — unblocks autonomous dispatch

### DIFF
--- a/services/slack-operator/src/claude-branch-worker.ts
+++ b/services/slack-operator/src/claude-branch-worker.ts
@@ -350,7 +350,10 @@ const defaultExec: ExecFn = (command, args, options) =>
 
 function gitArgsWithAuth(command: string, args: string[], token?: string): string[] {
   if (command !== "git" || !token) return args;
-  return ["-c", `http.https://github.com/.extraheader=AUTHORIZATION: Bearer ${token}`, ...args];
+  // GitHub's git smart-HTTP endpoint rejects `Authorization: Bearer <PAT>`; it
+  // requires Basic auth with the token as the password (x-access-token user).
+  const basic = Buffer.from(`x-access-token:${token}`).toString("base64");
+  return ["-c", `http.https://github.com/.extraheader=AUTHORIZATION: Basic ${basic}`, ...args];
 }
 
 function resolveGithubTokenForRepo(repo: string, env: NodeJS.ProcessEnv): string | undefined {

--- a/services/slack-operator/src/codex-branch-worker.ts
+++ b/services/slack-operator/src/codex-branch-worker.ts
@@ -495,9 +495,12 @@ async function run(
 
 function gitArgsWithAuth(command: string, args: string[], token?: string): string[] {
   if (command !== "git" || !token) return args;
+  // GitHub's git smart-HTTP endpoint rejects `Authorization: Bearer <PAT>`; it
+  // requires Basic auth with the token as the password (x-access-token user).
+  const basic = Buffer.from(`x-access-token:${token}`).toString("base64");
   return [
     "-c",
-    `http.https://github.com/.extraheader=AUTHORIZATION: Bearer ${token}`,
+    `http.https://github.com/.extraheader=AUTHORIZATION: Basic ${basic}`,
     ...args,
   ];
 }


### PR DESCRIPTION
## The bug (bootstrap blocker for the whole autonomous loop)

Both branch workers authenticate git with `Authorization: Bearer <token>`:

```
http.https://github.com/.extraheader=AUTHORIZATION: Bearer ${token}
```

GitHub's **git smart-HTTP endpoint rejects `Bearer <PAT>`** (it's fine for the REST API, not for git). git falls through to an interactive username prompt and dies:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

…leaving the worktree empty. The Claude/Codex agent then runs on an empty checkout, produces no changes, and the no-op is recorded as **`completed`** — which is exactly why autonomous dispatches have *never opened a PR* (the failure was silently masked as success).

## The fix

GitHub's git endpoint requires **Basic auth with the token as the password** under the `x-access-token` user — the same scheme `actions/checkout` uses. Switch the extraheader in both `claude-branch-worker.ts` and `codex-branch-worker.ts`:

```
const basic = Buffer.from(`x-access-token:${token}`).toString("base64");
http.https://github.com/.extraheader=AUTHORIZATION: Basic ${basic}
```

(The `Bearer` usages in `codex-branch-worker.ts:368/388` are **REST API** calls and are left unchanged — Bearer is correct there.)

## Verification (on the live runner)

- `Bearer` extraheader clone of the private repo → `fatal: could not read Username` ❌
- `Basic base64("x-access-token:"+token)` extraheader clone → succeeds, repo checked out ✅

After merge + redeploy of the runners, approved tasks will actually clone, make changes, and open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)