### PR TITLE
style(monitor): tighten board overflow and rail controls

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -655,12 +655,13 @@ function OperatorActions({
 
   if (!confirming) {
     return (
-      <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Operator actions">
+      <div className="hm-card-cta hm-card-cta--operator hm-card-cta--actions" role="group" aria-label="Operator actions">
         {actions.map((action) => (
           <button
             type="button"
             className={`hm-btn ${action.kind === "action" ? "hm-btn--action" : "hm-btn--ghost"} hm-btn--sm`}
             key={action.key}
+            title={`${action.label} opens a confirmation before running.`}
             onClick={(e) => {
               stop(e);
               setConfirmingKey(action.key);
@@ -674,9 +675,10 @@ function OperatorActions({
   }
 
   return (
-    <div className="hm-card-cta hm-card-cta--operator" role="group" aria-label="Confirm operator action">
-      <span style={{ fontSize: 12, color: "var(--hm-ink-soft)", marginRight: "auto" }}>
+    <div className="hm-card-cta hm-card-cta--operator hm-card-cta--confirm" role="group" aria-label="Confirm operator action">
+      <span className="hm-card-confirm-copy">
         {confirming.confirm}
+        <small>Nothing runs until you confirm.</small>
       </span>
       <button
         type="button"

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -848,7 +848,7 @@ body { margin: 0; }
 }
 .hm-backlog-suggestions--rail .hm-backlog-suggestion-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
   gap: 7px;
 }
@@ -869,9 +869,14 @@ body { margin: 0; }
 }
 .hm-backlog-suggestion-meta {
   white-space: nowrap;
+  justify-self: end;
 }
 .hm-backlog-copy,
-.hm-backlog-link {
+.hm-backlog-link,
+.hm-backlog-use {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: 0 0 auto;
   border: 1px solid var(--hm-line);
   border-radius: 7px;
@@ -883,6 +888,16 @@ body { margin: 0; }
   padding: 6px 8px;
   cursor: pointer;
 }
+.hm-backlog-use {
+  background: var(--hm-sage-wash);
+  color: var(--hm-sage-deep);
+}
+.hm-backlog-suggestions--rail .hm-backlog-link,
+.hm-backlog-suggestions--rail .hm-backlog-use,
+.hm-backlog-suggestions--rail .hm-backlog-copy {
+  min-width: 0;
+  justify-content: center;
+}
 .hm-backlog-link {
   background: var(--hm-rail);
   color: var(--hm-muted);
@@ -893,7 +908,8 @@ body { margin: 0; }
   align-items: center;
   cursor: default;
 }
-.hm-backlog-copy:hover {
+.hm-backlog-copy:hover,
+.hm-backlog-use:hover {
   border-color: var(--hm-sage);
 }
 .hm-backlog-link:hover {
@@ -960,12 +976,16 @@ body { margin: 0; }
   cursor: pointer;
 }
 .hm-lane--expanded {
-  flex: 1 1 0;
-  min-width: 280px;
+  flex: 1 1 300px;
+  min-width: 300px;
 }
 .hm-lane--xl { flex: 2 1 0; }
 .hm-lane--focus { flex: 4 1 0; min-width: 520px; background: var(--hm-paper); }
 .hm-lane--action { border-color: var(--hm-amber-ring); }
+.hm-lane--action.hm-lane--expanded {
+  flex: 1.3 0 350px;
+  min-width: 350px;
+}
 .hm-lane--action::before {
   content: ""; position: absolute; inset: 0 0 auto 0; height: 3px;
   background: linear-gradient(90deg, var(--hm-amber) 0%, var(--hm-amber-soft) 100%);
@@ -1114,8 +1134,11 @@ body { margin: 0; }
   gap: 7px;
   cursor: pointer;
   position: relative;
+  min-width: 0;
+  overflow: hidden;
   transition: border-color 160ms, box-shadow 160ms, transform 160ms;
 }
+.hm-card > * { min-width: 0; }
 .hm-card:hover {
   border-color: var(--hm-line-strong);
   box-shadow: var(--hm-shadow-card);
@@ -1158,6 +1181,7 @@ body { margin: 0; }
 /* Card pieces */
 .hm-card-head {
   display: flex; align-items: flex-start; gap: 8px;
+  min-width: 0;
 }
 .hm-card-id {
   font-family: var(--font-mono);
@@ -1233,6 +1257,11 @@ body { margin: 0; }
 }
 .hm-card-meta .sep { color: var(--hm-muted-soft); }
 .hm-card-meta .repo { color: var(--hm-ink-soft); }
+.hm-card-meta > span {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
 
 .hm-review-request {
   display: inline-flex;
@@ -1371,12 +1400,14 @@ body { margin: 0; }
   gap: 6px;
   padding: 8px 0 2px;
   border-top: 1px solid var(--hm-line-soft);
+  min-width: 0;
 }
 .hm-mission-run-top {
   display: flex;
   align-items: center;
   gap: 6px;
   min-width: 0;
+  flex-wrap: wrap;
 }
 .hm-mission-run-kicker {
   flex: 0 0 auto;
@@ -1426,8 +1457,8 @@ body { margin: 0; }
 }
 .hm-mission-run-blocker {
   display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 6px;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 2px;
   align-items: baseline;
   min-width: 0;
   font-size: 11.5px;
@@ -1445,6 +1476,7 @@ body { margin: 0; }
   min-width: 0;
   font-weight: 700;
   color: var(--hm-ink);
+  overflow-wrap: anywhere;
 }
 .hm-mission-run-facts {
   display: flex;
@@ -1468,6 +1500,11 @@ body { margin: 0; }
   font-family: var(--font-body);
   font-size: 11px;
   line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
 }
 .hm-mission-run--fail .hm-mission-run-boundary {
   color: var(--hm-muted);
@@ -1476,6 +1513,7 @@ body { margin: 0; }
 .hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }
 .hm-pill {
   display: inline-flex; align-items: center; gap: 5px;
+  max-width: 100%;
   height: 20px;
   padding: 0 8px;
   border-radius: 999px;
@@ -1487,6 +1525,8 @@ body { margin: 0; }
   background: var(--hm-rail);
   color: var(--hm-muted);
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .hm-pill--risk   { background: var(--hm-amber-soft); color: var(--hm-amber-deep); }
 .hm-pill--secret { background: var(--hm-rose-soft); color: var(--hm-rose); }
@@ -1577,6 +1617,8 @@ body { margin: 0; }
    ============================================================ */
 .hm-btn {
   display: inline-flex; align-items: center; gap: 8px;
+  justify-content: center;
+  min-width: 0;
   height: 32px;
   padding: 0 14px;
   border-radius: 8px;
@@ -1634,6 +1676,7 @@ body { margin: 0; }
   display: flex;
   flex-direction: column;
   min-height: 0;
+  min-width: 0;
   background: var(--hm-paper-2);
   border-left: 1px solid var(--hm-line);
   overflow: hidden;
@@ -1643,6 +1686,10 @@ body { margin: 0; }
   padding: 14px 18px 12px;
   border-bottom: 1px solid var(--hm-line-soft);
   background: var(--hm-paper);
+  min-width: 0;
+}
+.hm-hermes-head > div:last-child {
+  min-width: 0;
 }
 .hm-hermes-mark {
   width: 28px; height: 28px;
@@ -1668,6 +1715,10 @@ body { margin: 0; }
   color: var(--hm-muted);
   letter-spacing: 0 !important;
   margin-top: 1px;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .hm-hermes-sub .pulse {
   display: inline-block;
@@ -1810,6 +1861,8 @@ button.hm-activity-row:hover {
   border: 1px solid var(--hm-line);
   font-size: 12.5px;
   line-height: 1.55;
+  min-width: 0;
+  overflow: hidden;
 }
 .hm-turn-head {
   display: flex; align-items: center; gap: 8px;
@@ -1819,16 +1872,23 @@ button.hm-activity-row:hover {
   letter-spacing: 0.1em !important;
   text-transform: uppercase;
   color: var(--hm-muted);
+  min-width: 0;
+  flex-wrap: wrap;
 }
 .hm-turn-actor {
   display: inline-flex; align-items: center; gap: 5px;
   color: var(--hm-ink);
+  min-width: 0;
+  max-width: 100%;
 }
 .hm-turn-kind {
   margin-left: 4px;
   opacity: 0.7;
   font-weight: 500;
   letter-spacing: 0 !important;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .hm-turn-actor .actor-dot { width: 7px; height: 7px; border-radius: 999px; }
 .hm-turn--hermes  .actor-dot { background: var(--hm-hermes); }
@@ -1848,7 +1908,11 @@ button.hm-activity-row:hover {
   color: var(--hm-muted-soft);
 }
 
-.hm-turn-body { color: var(--hm-ink-soft); }
+.hm-turn-body {
+  color: var(--hm-ink-soft);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
 .hm-turn-body b { color: var(--hm-ink); font-weight: 600; }
 .hm-turn-body small {
   display: block;
@@ -1870,10 +1934,12 @@ button.hm-activity-row:hover {
 /* Pinned context card inside a Hermes turn */
 .hm-turn-pin {
   display: grid;
-  /* id (flex + truncates) · title · arrow — the long id must not widen the rail. */
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-areas:
+    "id arrow"
+    "title title";
   align-items: center;
-  gap: 9px;
+  gap: 3px 9px;
   padding: 8px 10px;
   border-radius: var(--hm-radius-sm);
   background: var(--hm-paper-3);
@@ -1884,12 +1950,14 @@ button.hm-activity-row:hover {
   text-decoration: none;
   width: 100%;
   text-align: left;
+  min-width: 0;
 }
 button.hm-turn-pin {
   cursor: pointer;
 }
 .hm-turn-pin:hover { border-color: var(--hm-line-strong); }
 .hm-turn-pin .pin-id {
+  grid-area: id;
   font-family: var(--font-mono);
   font-size: 10.5px;
   color: var(--hm-muted);
@@ -1899,22 +1967,29 @@ button.hm-turn-pin {
   white-space: nowrap;
 }
 .hm-turn-pin .pin-title {
+  grid-area: title;
   font-weight: 600;
-  color: var(--hm-ink);
-  font-size: 12px;
+  color: var(--hm-muted);
+  font-size: 11px;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 .hm-turn-pin .pin-arrow {
+  grid-area: arrow;
   color: var(--hm-muted-soft);
   font-family: var(--font-mono);
   font-size: 12px;
+  white-space: nowrap;
 }
 
 .hm-turn-actions {
   display: flex; gap: 6px;
+  flex-wrap: wrap;
 }
 .hm-turn-suggest {
   display: inline-flex; align-items: center; gap: 6px;
+  justify-content: center;
+  flex: 1 1 132px;
+  min-width: 0;
   padding: 5px 9px;
   border-radius: 999px;
   background: var(--hm-sage-wash);
@@ -1926,6 +2001,9 @@ button.hm-turn-pin {
   cursor: pointer;
   border: 1px solid rgba(30,102,66,0.14);
   font: inherit;
+  line-height: 1.25;
+  text-align: center;
+  overflow-wrap: anywhere;
 }
 .hm-turn-suggest:hover { background: var(--hm-sage-soft); }
 
@@ -1942,7 +2020,7 @@ button.hm-turn-pin {
 }
 .hm-compose-row {
   display: grid;
-  grid-template-columns: 1fr auto;
+  grid-template-columns: minmax(0, 1fr) 66px;
   gap: 8px;
   align-items: end;
 }
@@ -1955,6 +2033,7 @@ button.hm-turn-pin {
   font-size: 13px;
   color: var(--hm-ink);
   min-height: 56px;
+  min-width: 0;
   resize: none;
   outline: none;
   line-height: 1.45;
@@ -1970,6 +2049,7 @@ button.hm-turn-pin {
 .hm-compose-send {
   display: inline-flex; align-items: center; gap: 8px;
   padding: 0 14px;
+  justify-content: center;
   height: 56px;
   border-radius: 10px;
   background: var(--hm-sage);
@@ -1979,6 +2059,7 @@ button.hm-turn-pin {
   font-size: 12px;
   font-weight: 700;
   cursor: pointer;
+  min-width: 0;
 }
 .hm-compose-send:hover { background: var(--hm-sage-deep); }
 .hm-compose-chip {
@@ -2193,7 +2274,49 @@ button.hm-turn-pin {
 .hm-card-cta {
   display: flex; gap: 6px; margin-top: 2px;
 }
-.hm-card-cta--operator { flex-wrap: wrap; }
+.hm-card-cta--operator {
+  flex-wrap: wrap;
+  min-width: 0;
+}
+.hm-card-cta--actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(88px, 1fr));
+  align-items: stretch;
+}
+.hm-card-cta--operator .hm-btn {
+  width: 100%;
+  min-height: 28px;
+  height: auto;
+  padding: 6px 9px;
+  line-height: 1.12;
+  white-space: normal;
+  text-align: center;
+}
+.hm-card-cta--confirm {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+  padding: 8px;
+  border-radius: var(--hm-radius-sm);
+  border: 1px solid var(--hm-amber-ring);
+  background: rgba(255, 253, 247, 0.72);
+}
+.hm-card-confirm-copy {
+  grid-column: 1 / -1;
+  display: grid;
+  gap: 2px;
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+.hm-card-confirm-copy small {
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+}
 .hm-signal-code {
   text-decoration: underline dotted rgba(40,60,80,0.45);
   text-underline-offset: 2px;


### PR DESCRIPTION
## Summary
- widen action lanes and harden card internals so long mission text, URLs, branch ids, and pills do not leak out of their cards
- make operator action confirmation states explicit: first click opens a clear confirm panel, and the copy says nothing runs until confirm
- polish the Hermes co-pilot rail: safer wrapping for long messages, two-line referenced-card pins, styled follow-up controls, wrapped suggestion chips, and tighter composer sizing

## Scope
Frontend polish only. No authority changes, no new actions, no backend behavior changes, no auto-merge/deploy behavior.

## Checks
- `npm test -- packages/monitor-ui/src/components/cards/Card.test.tsx packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx`
- `npm run typecheck`
- `npm test`
- `npm --workspace packages/monitor-ui run build`

## Verification notes
I started the local Vite server successfully and confirmed it served the monitor UI on `127.0.0.1:5175`. A headless screenshot pass could not complete in this sandbox because the Playwright browser binary was not installed, and launching system Chrome from the REPL aborted under sandbox permissions. The source-level overflow protections and production build are covered by the checks above.

## Affected surfaces
- Monitor UI only: `packages/monitor-ui/src/components/cards/Card.tsx`, `packages/monitor-ui/src/styles/monitor.css`
- No ops, secrets, runners, MCP, migrations, or compose changes
