### PR TITLE
fix(runner): mark no-PR / empty-clone / agent-abort runs as failed, not completed

### DIFF
--- a/services/slack-operator/src/branch-worker-outcome.ts
+++ b/services/slack-operator/src/branch-worker-outcome.ts
@@ -1,0 +1,57 @@
+export type BranchWorkerOutcome =
+  | {
+      opened: true;
+      pullRequestUrl?: string;
+      pullRequestNumber?: number;
+      summary?: string;
+    }
+  | {
+      opened: false;
+      reason: string;
+      summary?: string;
+    };
+
+export const BRANCH_WORKER_OUTCOME_PREFIX = "AVERRAY_BRANCH_WORKER_OUTCOME ";
+
+export function formatBranchWorkerOutcome(outcome: BranchWorkerOutcome): string {
+  return `${BRANCH_WORKER_OUTCOME_PREFIX}${JSON.stringify(outcome)}`;
+}
+
+export function parseBranchWorkerOutcome(value: string): BranchWorkerOutcome | undefined {
+  const line = value
+    .split(/\r?\n/)
+    .reverse()
+    .find((candidate) => candidate.startsWith(BRANCH_WORKER_OUTCOME_PREFIX));
+  if (!line) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line.slice(BRANCH_WORKER_OUTCOME_PREFIX.length));
+  } catch {
+    return undefined;
+  }
+  return isBranchWorkerOutcome(parsed) ? parsed : undefined;
+}
+
+function isBranchWorkerOutcome(value: unknown): value is BranchWorkerOutcome {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  if (record.opened === true) {
+    return optionalString(record.pullRequestUrl)
+      && optionalNumber(record.pullRequestNumber)
+      && optionalString(record.summary);
+  }
+  if (record.opened === false) {
+    return typeof record.reason === "string"
+      && record.reason.trim().length > 0
+      && optionalString(record.summary);
+  }
+  return false;
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function optionalNumber(value: unknown): boolean {
+  return value === undefined || typeof value === "number";
+}

--- a/services/slack-operator/src/claude-branch-worker.ts
+++ b/services/slack-operator/src/claude-branch-worker.ts
@@ -28,7 +28,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { assertNoForbiddenFiles, redact } from "./codex-branch-worker.js";
+import {
+  assertNoForbiddenFiles,
+  gitCheckoutFailureReason,
+  redact,
+} from "./codex-branch-worker.js";
+import {
+  formatBranchWorkerOutcome,
+  type BranchWorkerOutcome,
+} from "./branch-worker-outcome.js";
 import {
   specialistAgentDefinition,
   taskAgentBranchPrefix,
@@ -218,7 +226,7 @@ export async function runClaudeBranchWorker(
   task: ClaudeWorkerTask = parseClaudeWorkerTask(),
   config: ClaudeWorkerConfig = parseClaudeWorkerConfig(),
   deps: ClaudeBranchWorkerDeps = {}
-): Promise<void> {
+): Promise<BranchWorkerOutcome> {
   const exec = deps.exec ?? defaultExec;
   const openPullRequest = deps.openPullRequest ?? openPullRequestViaApi;
   const branch = claudeBranchName(task);
@@ -228,7 +236,9 @@ export async function runClaudeBranchWorker(
   await mkdir(config.workRoot, { recursive: true });
   const workdir = await mkdtemp(join(config.workRoot, `${slug(task.id)}-`));
   try {
-    await exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    const cloneResult = await exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    const checkoutFailure = await gitCheckoutFailureReason(exec, workdir, cloneResult, taskAgentLabel(task.agent ?? "claude"));
+    if (checkoutFailure) return { opened: false, reason: checkoutFailure, summary: checkoutFailure };
     await exec("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
     await exec("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
     await exec("git", ["fetch", "origin", config.baseBranch], { cwd: workdir, token: config.githubToken });
@@ -248,7 +258,11 @@ export async function runClaudeBranchWorker(
     assertNoForbiddenFiles(changedFiles, taskAgentLabel(task.agent ?? "claude"));
     if (changedFiles.length === 0) {
       console.log(`${taskAgentLabel(task.agent ?? "claude")} produced no changes for ${task.repo}; not opening a PR.`);
-      return;
+      return {
+        opened: false,
+        reason: `no_changes: ${taskAgentLabel(task.agent ?? "claude")} produced no changes for ${task.repo}; not opening a PR.`,
+        summary: `${taskAgentLabel(task.agent ?? "claude")} produced no changes for ${task.repo}; not opening a PR.`,
+      };
     }
 
     await exec("git", ["add", "-A"], { cwd: workdir });
@@ -262,6 +276,12 @@ export async function runClaudeBranchWorker(
       body: buildPullRequestBody(task),
     });
     console.log(`${taskAgentLabel(task.agent ?? "claude")} opened PR #${pr.number} on ${task.repo} (${branch})${pr.html_url ? ` — ${pr.html_url}` : ""}.`);
+    return {
+      opened: true,
+      pullRequestNumber: pr.number,
+      ...(pr.html_url ? { pullRequestUrl: pr.html_url } : {}),
+      summary: `${taskAgentLabel(task.agent ?? "claude")} opened PR #${pr.number} on ${task.repo}.`,
+    };
   } finally {
     if (!config.keepWorktree) await rm(workdir, { recursive: true, force: true });
   }
@@ -428,6 +448,10 @@ function lastNonEmptyLine(value: string): string {
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
   runClaudeBranchWorker()
+    .then((outcome) => {
+      console.log(formatBranchWorkerOutcome(outcome));
+      if (!outcome.opened) process.exitCode = 2;
+    })
     .catch((error) => {
       console.error(redact(error instanceof Error ? error.message : String(error)));
       process.exitCode = 1;

--- a/services/slack-operator/src/claude-task-runner.ts
+++ b/services/slack-operator/src/claude-task-runner.ts
@@ -25,6 +25,7 @@ import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
 import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
+import { parseBranchWorkerOutcome, type BranchWorkerOutcome } from "./branch-worker-outcome.js";
 import {
   budgetGate,
   buildClaudeInvocationEnv,
@@ -69,6 +70,7 @@ export interface ClaudeTaskRunResult {
   stdout: string;
   stderr: string;
   summary?: string;
+  outcome?: BranchWorkerOutcome;
   usage?: unknown;
   model?: string;
   costUsd?: number;
@@ -203,8 +205,9 @@ export async function runClaudeTaskRunnerOnce(
       ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
       result,
     }).catch(() => undefined);
-    if (result.exitCode === 0) {
-      const summary = sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout));
+    const outcome = result.outcome ?? parseBranchWorkerOutcome(result.stdout);
+    if (result.exitCode === 0 && outcome?.opened) {
+      const summary = openedPullRequestSummary(result, outcome, `${taskAgentLabel(config.agent)} runner opened a pull request.`);
       const task = await completeCodexTask(claimed.id, {
         path: config.path,
         completionSummary: summary,
@@ -215,7 +218,11 @@ export async function runClaudeTaskRunnerOnce(
       await heartbeat(config, "completed", summary || `${taskAgentLabel(config.agent)} runner completed ${taskLabel(claimed)}.`, undefined, claimed.id);
       return { status: "completed", task: task ?? claimed };
     }
-    const reason = summarizeFailure(result);
+    const reason = outcome && !outcome.opened
+      ? noPullRequestFailureReason(outcome)
+      : result.exitCode === 0
+        ? `${taskAgentLabel(config.agent)} task command exited successfully but did not report an opened pull request.`
+        : summarizeFailure(result);
     const task = await failCodexTask(claimed.id, {
       path: config.path,
       failureReason: reason,
@@ -315,11 +322,13 @@ export async function executeClaudeTaskCommand(
       finished = true;
       clearTimeout(timeout);
       progressWrites.finally(() => {
+        const outcome = parseBranchWorkerOutcome(stdout);
         resolve({
           exitCode: code ?? 1,
           stdout,
           stderr,
-          summary: summarizeCommandResult(stdout) || summarizeCommandResult(stderr),
+          summary: (outcome?.summary ?? summarizeCommandResult(stdout)) || summarizeCommandResult(stderr),
+          outcome,
         });
       });
     });
@@ -366,6 +375,17 @@ function summarizeFailure(result: ClaudeTaskRunResult): string {
   const stderr = sanitizeOutput(summarizeCommandResult(result.stderr));
   const stdout = sanitizeOutput(summarizeCommandResult(result.stdout));
   return stderr || stdout || `Claude task command exited with ${result.exitCode}.`;
+}
+
+function openedPullRequestSummary(result: ClaudeTaskRunResult, outcome: Extract<BranchWorkerOutcome, { opened: true }>, fallback: string): string {
+  const summary = sanitizeOutput((result.summary ?? outcome.summary ?? summarizeCommandResult(result.stdout)) || fallback);
+  const url = outcome.pullRequestUrl ? sanitizeOutput(outcome.pullRequestUrl) : "";
+  if (!url || summary.includes(url)) return summary;
+  return `${summary}\n${url}`.trim();
+}
+
+function noPullRequestFailureReason(outcome: Extract<BranchWorkerOutcome, { opened: false }>): string {
+  return sanitizeOutput(outcome.reason || outcome.summary || "Worker finished without opening a pull request.");
 }
 
 function summarizeCommandResult(value: string): string {

--- a/services/slack-operator/src/codex-branch-worker.ts
+++ b/services/slack-operator/src/codex-branch-worker.ts
@@ -3,6 +3,10 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  formatBranchWorkerOutcome,
+  type BranchWorkerOutcome,
+} from "./branch-worker-outcome.js";
 import { taskAgentBranchPrefix, taskAgentCommitPrefix, taskAgentPrBodyLabel } from "./specialist-agents.js";
 
 export interface CodexWorkerTask {
@@ -52,7 +56,7 @@ export interface GithubPullRequestForWorker {
   };
 }
 
-interface CommandResult {
+export interface CommandResult {
   exitCode: number;
   stdout: string;
   stderr: string;
@@ -62,6 +66,12 @@ export type ExecFn = (
   command: string,
   args: string[],
   options?: { cwd?: string; timeoutMs?: number; token?: string }
+) => Promise<CommandResult>;
+
+type CheckoutExecFn = (
+  command: string,
+  args: string[],
+  options: { cwd?: string; timeoutMs?: number; token?: string }
 ) => Promise<CommandResult>;
 
 export interface OpenedPullRequest {
@@ -252,7 +262,7 @@ export async function runCodexBranchWorker(
   task: CodexWorkerTask = parseCodexWorkerTask(),
   config: CodexWorkerConfig = parseCodexWorkerConfig(),
   deps: CodexBranchWorkerDeps = {}
-): Promise<void> {
+): Promise<BranchWorkerOutcome> {
   const exec = deps.exec ?? run;
   const openPullRequest = deps.openPullRequest ?? openPullRequestViaApi;
   if (task.pullRequestNumber === undefined) {
@@ -266,7 +276,9 @@ export async function runCodexBranchWorker(
   const workdir = await mkdtemp(join(config.workRoot, `${task.id}-`));
   let cleanup = !config.keepWorktree;
   try {
-    await exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    const cloneResult = await exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    const checkoutFailure = await gitCheckoutFailureReason(exec, workdir, cloneResult, "Codex");
+    if (checkoutFailure) return { opened: false, reason: checkoutFailure, summary: checkoutFailure };
     await exec("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
     await exec("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
     await exec("git", ["fetch", "origin", `${pr.head.ref}:${pr.head.ref}`], { cwd: workdir, token: config.githubToken });
@@ -292,10 +304,20 @@ export async function runCodexBranchWorker(
     if (afterSha !== beforeSha) {
       await exec("git", ["push", "origin", `HEAD:${pr.head.ref}`], { cwd: workdir, token: config.githubToken });
       console.log(`Codex pushed ${afterSha.slice(0, 12)} to ${headRepo}:${pr.head.ref}.`);
+      return {
+        opened: true,
+        pullRequestNumber: task.pullRequestNumber,
+        ...(pr.html_url ? { pullRequestUrl: pr.html_url } : {}),
+        summary: `Codex pushed changes to ${task.repo}#${task.pullRequestNumber}.`,
+      };
     } else {
       console.log("Codex completed without producing a new commit.");
+      return {
+        opened: false,
+        reason: "no_changes: Codex completed without producing a new commit.",
+        summary: "Codex completed without producing a new commit.",
+      };
     }
-    console.log(`Hermes should re-check ${task.repo}#${task.pullRequestNumber} after CI settles.`);
   } finally {
     if (cleanup) {
       await rm(workdir, { recursive: true, force: true });
@@ -310,7 +332,7 @@ async function runGreenfieldCodexBranchWorker(
     exec: ExecFn;
     openPullRequest: NonNullable<CodexBranchWorkerDeps["openPullRequest"]>;
   }
-): Promise<void> {
+): Promise<BranchWorkerOutcome> {
   const branch = codexBranchName(task);
   validateGreenfieldCodexWorkerTask(task, branch, config);
 
@@ -318,7 +340,9 @@ async function runGreenfieldCodexBranchWorker(
   await mkdir(config.workRoot, { recursive: true });
   const workdir = await mkdtemp(join(config.workRoot, `${slug(task.id)}-`));
   try {
-    await deps.exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    const cloneResult = await deps.exec("git", ["clone", "--no-tags", "--depth=50", cloneUrl, workdir], { token: config.githubToken });
+    const checkoutFailure = await gitCheckoutFailureReason(deps.exec, workdir, cloneResult, "Codex");
+    if (checkoutFailure) return { opened: false, reason: checkoutFailure, summary: checkoutFailure };
     await deps.exec("git", ["config", "user.name", config.gitUserName], { cwd: workdir });
     await deps.exec("git", ["config", "user.email", config.gitUserEmail], { cwd: workdir });
     await deps.exec("git", ["fetch", "origin", config.baseBranch], { cwd: workdir, token: config.githubToken });
@@ -338,7 +362,11 @@ async function runGreenfieldCodexBranchWorker(
     assertNoForbiddenFiles(changedFiles);
     if (changedFiles.length === 0) {
       console.log(`Codex produced no changes for ${task.repo}; not opening a PR.`);
-      return;
+      return {
+        opened: false,
+        reason: `no_changes: Codex produced no changes for ${task.repo}; not opening a PR.`,
+        summary: `Codex produced no changes for ${task.repo}; not opening a PR.`,
+      };
     }
 
     await deps.exec("git", ["add", "-A"], { cwd: workdir });
@@ -352,6 +380,12 @@ async function runGreenfieldCodexBranchWorker(
       body: buildPullRequestBody(task),
     });
     console.log(`Codex opened PR #${pr.number} on ${task.repo} (${branch})${pr.html_url ? ` - ${pr.html_url}` : ""}.`);
+    return {
+      opened: true,
+      pullRequestNumber: pr.number,
+      ...(pr.html_url ? { pullRequestUrl: pr.html_url } : {}),
+      summary: `Codex opened PR #${pr.number} on ${task.repo}.`,
+    };
   } finally {
     if (!config.keepWorktree) await rm(workdir, { recursive: true, force: true });
   }
@@ -404,6 +438,54 @@ async function gitChangedFiles(cwd: string, exec: ExecFn = run): Promise<string[
     .filter(Boolean)
     .map((line) => line.slice(3).trim())
     .filter(Boolean);
+}
+
+export async function gitCheckoutFailureReason(
+  exec: CheckoutExecFn,
+  cwd: string,
+  cloneResult: CommandResult,
+  who = "worker",
+): Promise<string | undefined> {
+  if (cloneResult.exitCode !== 0) {
+    return `${who} clone failed before the agent ran: ${commandOutputSummary(cloneResult) || "git clone exited non-zero"}`;
+  }
+  const inside = await commandResultOrFailure(exec, "git", ["rev-parse", "--is-inside-work-tree"], { cwd });
+  if (!inside.ok || inside.result.exitCode !== 0 || inside.result.stdout.trim() !== "true") {
+    return checkoutFailureMessage(who, "git rev-parse did not find a worktree", cloneResult, inside.ok ? inside.result : undefined, inside.ok ? undefined : inside.reason);
+  }
+  const tracked = await commandResultOrFailure(exec, "git", ["ls-files"], { cwd });
+  if (!tracked.ok || tracked.result.exitCode !== 0 || tracked.result.stdout.trim().length === 0) {
+    return checkoutFailureMessage(who, "git ls-files found no tracked files", cloneResult, tracked.ok ? tracked.result : undefined, tracked.ok ? undefined : tracked.reason);
+  }
+  return undefined;
+}
+
+async function commandResultOrFailure(
+  exec: CheckoutExecFn,
+  command: string,
+  args: string[],
+  options: { cwd?: string; timeoutMs?: number; token?: string },
+): Promise<{ ok: true; result: CommandResult } | { ok: false; reason: string }> {
+  try {
+    return { ok: true, result: await exec(command, args, options) };
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function checkoutFailureMessage(
+  who: string,
+  check: string,
+  cloneResult: CommandResult,
+  checkResult?: CommandResult,
+  checkError?: string,
+): string {
+  const details = [
+    checkError ? `check error: ${checkError}` : "",
+    checkResult ? `check output: ${commandOutputSummary(checkResult) || "empty"}` : "",
+    `clone output: ${commandOutputSummary(cloneResult) || "empty"}`,
+  ].filter(Boolean).join("; ");
+  return `${who} clone produced an unusable checkout (${check}); ${details}`;
 }
 
 // Exported so the Claude branch worker reuses the exact same secret-file
@@ -566,6 +648,16 @@ function lastNonEmptyLine(value: string): string {
   return value.trim().split(/\r?\n/).filter(Boolean).slice(-1)[0]?.trim() ?? "";
 }
 
+function commandOutputSummary(result: CommandResult): string {
+  return redact([result.stderr, result.stdout].join("\n"))
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .slice(-4)
+    .join("\n")
+    .trim();
+}
+
 export function redact(value: string): string {
   return value
     .replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[redacted private key]")
@@ -576,6 +668,10 @@ export function redact(value: string): string {
 
 if (fileURLToPath(import.meta.url) === process.argv[1]) {
   runCodexBranchWorker()
+    .then((outcome) => {
+      console.log(formatBranchWorkerOutcome(outcome));
+      if (!outcome.opened) process.exitCode = 2;
+    })
     .catch((error) => {
       console.error(error instanceof Error ? error.message : String(error));
       process.exitCode = 1;

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -404,6 +404,7 @@ export async function failCodexTask(
   id: string,
   deps: CodexTaskQueueDeps & {
     failureReason?: string;
+    completionSummary?: string;
     exitCode?: number;
     stdoutTail?: string;
     stderrTail?: string;
@@ -415,21 +416,23 @@ export async function failCodexTask(
   if (!existing) return undefined;
   if (TERMINAL_STATUSES.has(existing.status)) return existing;
   const now = (deps.now ?? new Date()).toISOString();
+  const failureReason = deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`;
   const task: CodexTask = {
     ...existing,
     status: "failed",
     failedAt: now,
     workingNow: undefined,
-    failureReason: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
+    failureReason,
+    completionSummary: deps.completionSummary ?? failureReason,
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
     ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
-    progressMessage: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
+    progressMessage: failureReason,
     progressAt: now,
     events: appendTaskEvent(existing, {
       at: now,
       status: "failed",
-      message: deps.failureReason ?? `${taskAgentEventLabel(taskAgent(existing))} task runner failed.`,
+      message: failureReason,
     }),
     updatedAt: now,
   };

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -3,6 +3,7 @@ import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
 import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
 
+import { parseBranchWorkerOutcome, type BranchWorkerOutcome } from "./branch-worker-outcome.js";
 import type { CodexTask } from "./codex-task-queue.js";
 import {
   claimNextApprovedCodexTask,
@@ -30,6 +31,7 @@ export interface CodexTaskRunResult {
   stdout: string;
   stderr: string;
   summary?: string;
+  outcome?: BranchWorkerOutcome;
   usage?: unknown;
   model?: string;
   costUsd?: number;
@@ -120,8 +122,9 @@ export async function runCodexTaskRunnerOnce(
       ...(claimed.correlationId ? { runId: claimed.correlationId } : {}),
       result,
     }).catch(() => undefined);
-    if (result.exitCode === 0) {
-      const summary = sanitizeOutput(result.summary ?? summarizeCommandResult(result.stdout));
+    const outcome = result.outcome ?? parseBranchWorkerOutcome(result.stdout);
+    if (result.exitCode === 0 && outcome?.opened) {
+      const summary = openedPullRequestSummary(result, outcome, "Codex runner opened a pull request.");
       const task = await completeCodexTask(claimed.id, {
         path: config.path,
         completionSummary: summary,
@@ -138,7 +141,11 @@ export async function runCodexTaskRunnerOnce(
       );
       return { status: "completed", task: task ?? claimed };
     }
-    const reason = summarizeFailure(result);
+    const reason = outcome && !outcome.opened
+      ? noPullRequestFailureReason(outcome)
+      : result.exitCode === 0
+        ? "Codex task command exited successfully but did not report an opened pull request."
+        : summarizeFailure(result);
     const task = await failCodexTask(claimed.id, {
       path: config.path,
       failureReason: reason,
@@ -237,11 +244,13 @@ export async function executeCodexTaskCommand(
       finished = true;
       clearTimeout(timeout);
       progressWrites.finally(() => {
+        const outcome = parseBranchWorkerOutcome(stdout);
         resolve({
           exitCode: code ?? 1,
           stdout,
           stderr,
-          summary: summarizeCommandResult(stdout) || summarizeCommandResult(stderr),
+          summary: (outcome?.summary ?? summarizeCommandResult(stdout)) || summarizeCommandResult(stderr),
+          outcome,
         });
       });
     });
@@ -283,6 +292,17 @@ function summarizeFailure(result: CodexTaskRunResult): string {
   const stderr = sanitizeOutput(summarizeCommandResult(result.stderr));
   const stdout = sanitizeOutput(summarizeCommandResult(result.stdout));
   return stderr || stdout || `Codex task command exited with ${result.exitCode}.`;
+}
+
+function openedPullRequestSummary(result: CodexTaskRunResult, outcome: Extract<BranchWorkerOutcome, { opened: true }>, fallback: string): string {
+  const summary = sanitizeOutput((result.summary ?? outcome.summary ?? summarizeCommandResult(result.stdout)) || fallback);
+  const url = outcome.pullRequestUrl ? sanitizeOutput(outcome.pullRequestUrl) : "";
+  if (!url || summary.includes(url)) return summary;
+  return `${summary}\n${url}`.trim();
+}
+
+function noPullRequestFailureReason(outcome: Extract<BranchWorkerOutcome, { opened: false }>): string {
+  return sanitizeOutput(outcome.reason || outcome.summary || "Worker finished without opening a pull request.");
 }
 
 function summarizeCommandResult(value: string): string {

--- a/test/unit/claude-branch-worker.test.ts
+++ b/test/unit/claude-branch-worker.test.ts
@@ -133,10 +133,19 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
     };
   }
 
-  function fakeExec(opts: { claudeExit?: number; changed?: string[]; claudeStderr?: string } = {}) {
+  function fakeExec(opts: { claudeExit?: number; changed?: string[]; claudeStderr?: string; emptyCheckout?: boolean; cloneStderr?: string } = {}) {
     const calls: { command: string; args: string[] }[] = [];
     const exec: ExecFn = async (command, args) => {
       calls.push({ command, args });
+      if (command === "git" && args[0] === "clone") {
+        return { exitCode: 0, stdout: "", stderr: opts.cloneStderr ?? "" } satisfies CommandResult;
+      }
+      if (command === "git" && args[0] === "rev-parse" && args.includes("--is-inside-work-tree")) {
+        return { exitCode: 0, stdout: opts.emptyCheckout ? "false\n" : "true\n", stderr: "" } satisfies CommandResult;
+      }
+      if (command === "git" && args[0] === "ls-files") {
+        return { exitCode: 0, stdout: opts.emptyCheckout ? "" : "package.json\n", stderr: "" } satisfies CommandResult;
+      }
       if (command === "git" && args[0] === "status") {
         const lines = (opts.changed ?? ["src/healthz.ts"]).map((f) => ` M ${f}`).join("\n");
         return { exitCode: 0, stdout: lines, stderr: "" } satisfies CommandResult;
@@ -152,7 +161,7 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
   it("happy path: creates the branch, runs Claude, commits, pushes, and OPENS a PR", async () => {
     const { exec, calls } = fakeExec();
     const prInputs: unknown[] = [];
-    await runClaudeBranchWorker(task, await config(), {
+    const outcome = await runClaudeBranchWorker(task, await config(), {
       exec,
       openPullRequest: async (_t, _c, input) => {
         prInputs.push(input);
@@ -168,12 +177,16 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
     expect(prInputs).toHaveLength(1);
     expect(prInputs[0]).toMatchObject({ base: "main" });
     expect((prInputs[0] as { head: string }).head).toMatch(/^claude\//);
+    expect(outcome).toMatchObject({
+      opened: true,
+      pullRequestUrl: "https://github.com/averray-agent/agent/pull/777",
+    });
   });
 
   it("test-writer specialist opens a normal PR through the same harness", async () => {
     const { exec, calls } = fakeExec();
     const prInputs: unknown[] = [];
-    await runClaudeBranchWorker({ ...task, agent: "test-writer", title: "Add parser tests" }, await config(), {
+    const outcome = await runClaudeBranchWorker({ ...task, agent: "test-writer", title: "Add parser tests" }, await config(), {
       exec,
       openPullRequest: async (_t, _c, input) => {
         prInputs.push(input);
@@ -186,17 +199,34 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
     expect((prInputs[0] as { head: string }).head).toMatch(/^test-writer\//);
     expect((prInputs[0] as { body: string }).body).toContain("test-writer specialist");
     expect((prInputs[0] as { body: string }).body).toContain("human-gated");
+    expect(outcome).toMatchObject({ opened: true, pullRequestNumber: 778 });
   });
 
   it("no changes → does NOT commit, push, or open a PR", async () => {
     const { exec, calls } = fakeExec({ changed: [] });
     let opened = 0;
-    await runClaudeBranchWorker(task, await config(), {
+    const outcome = await runClaudeBranchWorker(task, await config(), {
       exec,
       openPullRequest: async () => { opened += 1; return { number: 1 }; },
     });
     expect(opened).toBe(0);
     expect(calls.some((c) => c.command === "git" && c.args[0] === "commit")).toBe(false);
+    expect(calls.some((c) => c.command === "git" && c.args[0] === "push")).toBe(false);
+    expect(outcome).toMatchObject({ opened: false, reason: expect.stringContaining("no_changes") });
+  });
+
+  it("empty checkout after clone → returns no-PR failure and preserves git stderr", async () => {
+    const { exec, calls } = fakeExec({ emptyCheckout: true, cloneStderr: "remote: Repository not found." });
+    const outcome = await runClaudeBranchWorker(task, await config(), {
+      exec,
+      openPullRequest: async () => ({ number: 1 }),
+    });
+
+    expect(outcome).toMatchObject({
+      opened: false,
+      reason: expect.stringContaining("remote: Repository not found."),
+    });
+    expect(calls.some((c) => c.command === "claude")).toBe(false);
     expect(calls.some((c) => c.command === "git" && c.args[0] === "push")).toBe(false);
   });
 

--- a/test/unit/claude-task-runner.test.ts
+++ b/test/unit/claude-task-runner.test.ts
@@ -93,7 +93,13 @@ describe("claude task runner", () => {
     const result = await runClaudeTaskRunnerOnce(config(path), {
       executor: async (task) => {
         seen.push(task.id);
-        return { exitCode: 0, stdout: "opened PR", stderr: "", summary: "opened PR" };
+        return {
+          exitCode: 0,
+          stdout: "opened PR",
+          stderr: "",
+          summary: "opened PR",
+          outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/777" },
+        };
       },
       log: () => {},
     });
@@ -117,7 +123,13 @@ describe("claude task runner", () => {
     }), {
       executor: async (task) => {
         seen.push({ id: task.id, agent: task.agent });
-        return { exitCode: 0, stdout: "opened PR", stderr: "", summary: "opened PR" };
+        return {
+          exitCode: 0,
+          stdout: "opened PR",
+          stderr: "",
+          summary: "opened PR",
+          outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/778" },
+        };
       },
       log: () => {},
     });
@@ -134,13 +146,19 @@ describe("claude task runner", () => {
     const id = await approvedClaudeTask(path);
 
     const result = await runClaudeTaskRunnerOnce(config(path), {
-      executor: async () => ({ exitCode: 0, stdout: "branch pushed\nPR opened\n", stderr: "", summary: "PR opened" }),
+      executor: async () => ({
+        exitCode: 0,
+        stdout: "branch pushed\nPR opened\n",
+        stderr: "",
+        summary: "PR opened",
+        outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/779" },
+      }),
       log: () => {},
     });
 
     expect(result.status).toBe("completed");
     const [task] = await listCodexTasks({ path });
-    expect(task).toMatchObject({ id, status: "completed", completionSummary: "PR opened" });
+    expect(task).toMatchObject({ id, status: "completed", completionSummary: "PR opened\nhttps://github.com/averray-agent/agent/pull/779" });
     await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
       runnerId: "test-claude-runner",
       status: "completed",
@@ -160,6 +178,7 @@ describe("claude task runner", () => {
         stdout: "opened PR",
         stderr: "",
         summary: "opened PR",
+        outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/780" },
         usage: {
           input_tokens: 120,
           output_tokens: 30,
@@ -179,6 +198,48 @@ describe("claude task runner", () => {
       inputTokens: 120,
       outputTokens: 30,
       cacheTokens: 15,
+    });
+  });
+
+  it("zero-exit no-PR outcome → failCodexTask + failed heartbeat", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+
+    const result = await runClaudeTaskRunnerOnce(config(path), {
+      executor: async () => ({
+        exitCode: 0,
+        stdout: "Claude produced no changes; not opening a PR.\n",
+        stderr: "",
+        summary: "Claude produced no changes; not opening a PR.",
+        outcome: { opened: false, reason: "no_changes" },
+      }),
+      log: () => {},
+    });
+
+    expect(result).toMatchObject({ status: "failed", reason: "no_changes" });
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({ id, status: "failed", failureReason: "no_changes", completionSummary: "no_changes" });
+    await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({ status: "failed", message: "no_changes" });
+  });
+
+  it("timeout errors remain failed", async () => {
+    const path = await tempQueuePath();
+    const id = await approvedClaudeTask(path);
+
+    const result = await runClaudeTaskRunnerOnce(config(path), {
+      executor: async () => {
+        throw new Error("Claude task command timed out after 1000ms.");
+      },
+      log: () => {},
+    });
+
+    expect(result).toMatchObject({ status: "failed", reason: "Claude task command timed out after 1000ms." });
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      id,
+      status: "failed",
+      failureReason: "Claude task command timed out after 1000ms.",
+      completionSummary: "Claude task command timed out after 1000ms.",
     });
   });
 

--- a/test/unit/codex-branch-worker.test.ts
+++ b/test/unit/codex-branch-worker.test.ts
@@ -170,6 +170,12 @@ describe("codex branch worker", () => {
     const commands: Array<{ command: string; args: string[]; cwd?: string }> = [];
     const exec: ExecFn = async (command, args, options) => {
       commands.push({ command, args, ...(options?.cwd ? { cwd: options.cwd } : {}) });
+      if (command === "git" && args[0] === "rev-parse" && args.includes("--is-inside-work-tree")) {
+        return { exitCode: 0, stdout: "true\n", stderr: "" };
+      }
+      if (command === "git" && args[0] === "ls-files") {
+        return { exitCode: 0, stdout: "package.json\n", stderr: "" };
+      }
       if (command === "git" && args[0] === "status") {
         return { exitCode: 0, stdout: " M services/slack-operator/src/codex-branch-worker.ts\n", stderr: "" };
       }
@@ -177,7 +183,7 @@ describe("codex branch worker", () => {
     };
     const opened: Array<{ head: string; base: string; title: string; body: string }> = [];
 
-    await runCodexBranchWorker(greenfield, config, {
+    const outcome = await runCodexBranchWorker(greenfield, config, {
       exec,
       openPullRequest: async (_task, _config, input) => {
         opened.push(input);
@@ -199,5 +205,84 @@ describe("codex branch worker", () => {
       title: "codex: Add runner guard",
       body: expect.stringContaining("Review + merge are human-gated"),
     })]);
+    expect(outcome).toMatchObject({
+      opened: true,
+      pullRequestUrl: "https://github.com/averray-agent/agent/pull/606",
+    });
+  });
+
+  it("returns a no-PR outcome when greenfield Codex produces no changes", async () => {
+    const greenfield: CodexWorkerTask = {
+      id: "codex-task-greenfield-nochange",
+      repo: "averray-agent/agent",
+      title: "No changes",
+      prompt: "Try the change.",
+    };
+    const config = parseCodexWorkerConfig({
+      CODEX_TASK_REPO: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_CODEX_COMMAND: "codex",
+      CODEX_BRANCH_WORKER_CODEX_ARGS: "[\"exec\",\"{prompt}\"]",
+    });
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const exec: ExecFn = async (command, args) => {
+      commands.push({ command, args });
+      if (command === "git" && args[0] === "rev-parse" && args.includes("--is-inside-work-tree")) {
+        return { exitCode: 0, stdout: "true\n", stderr: "" };
+      }
+      if (command === "git" && args[0] === "ls-files") {
+        return { exitCode: 0, stdout: "package.json\n", stderr: "" };
+      }
+      if (command === "git" && args[0] === "status") {
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+
+    const outcome = await runCodexBranchWorker(greenfield, config, {
+      exec,
+      openPullRequest: async () => ({ number: 1 }),
+    });
+
+    expect(outcome).toMatchObject({ opened: false, reason: expect.stringContaining("no_changes") });
+    expect(commands.some((c) => c.command === "git" && c.args[0] === "push")).toBe(false);
+  });
+
+  it("returns a no-PR outcome when clone leaves an empty checkout", async () => {
+    const greenfield: CodexWorkerTask = {
+      id: "codex-task-greenfield-empty",
+      repo: "averray-agent/agent",
+      title: "Empty clone",
+      prompt: "Try the change.",
+    };
+    const config = parseCodexWorkerConfig({
+      CODEX_TASK_REPO: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_ALLOWED_REPOS: "averray-agent/agent",
+      CODEX_BRANCH_WORKER_CODEX_COMMAND: "codex",
+      CODEX_BRANCH_WORKER_CODEX_ARGS: "[\"exec\",\"{prompt}\"]",
+    });
+    const commands: Array<{ command: string; args: string[] }> = [];
+    const exec: ExecFn = async (command, args) => {
+      commands.push({ command, args });
+      if (command === "git" && args[0] === "clone") {
+        return { exitCode: 0, stdout: "", stderr: "fatal: could not read Username for https://github.com" };
+      }
+      if (command === "git" && args[0] === "rev-parse" && args.includes("--is-inside-work-tree")) {
+        return { exitCode: 0, stdout: "false\n", stderr: "" };
+      }
+      return { exitCode: 0, stdout: "", stderr: "" };
+    };
+
+    const outcome = await runCodexBranchWorker(greenfield, config, {
+      exec,
+      openPullRequest: async () => ({ number: 1 }),
+    });
+
+    expect(outcome).toMatchObject({
+      opened: false,
+      reason: expect.stringContaining("fatal: could not read Username"),
+    });
+    expect(commands.some((c) => c.command === "codex")).toBe(false);
+    expect(commands.some((c) => c.command === "git" && c.args[0] === "push")).toBe(false);
   });
 });

--- a/test/unit/codex-task-runner.test.ts
+++ b/test/unit/codex-task-runner.test.ts
@@ -67,6 +67,7 @@ describe("codex task runner", () => {
           stdout: "branch pushed\nready for Hermes\n",
           stderr: "",
           summary: "ready for Hermes",
+          outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/390" },
           usage: {
             model: "gpt-5-codex",
             inputTokens: 20,
@@ -93,14 +94,14 @@ describe("codex task runner", () => {
       status: "completed",
       runnerId: "test-runner",
       attemptCount: 1,
-      completionSummary: "ready for Hermes",
+      completionSummary: "ready for Hermes\nhttps://github.com/averray-agent/agent/pull/390",
       stdoutTail: "branch pushed\nready for Hermes\n",
     });
     await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
       runnerId: "test-runner",
       status: "completed",
       activeTaskId: proposed.task.id,
-      message: "ready for Hermes",
+      message: "ready for Hermes\nhttps://github.com/averray-agent/agent/pull/390",
     });
   });
 
@@ -125,7 +126,13 @@ describe("codex task runner", () => {
     const result = await runCodexTaskRunnerOnce(config(path), {
       executor: async (task) => {
         seen.push(task.id);
-        return { exitCode: 0, stdout: "done\n", stderr: "", summary: "done" };
+        return {
+          exitCode: 0,
+          stdout: "done\n",
+          stderr: "",
+          summary: "done",
+          outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/606" },
+        };
       },
       now: new Date("2026-06-01T10:04:00.000Z"),
     });
@@ -152,7 +159,13 @@ describe("codex task runner", () => {
       executor: async (task) => {
         expect(task.pullRequestNumber).toBeUndefined();
         expect(renderCodexTaskRunnerArgs(["--pr={pr}", "{CODEX_TASK_PR}"], task)).toEqual(["--pr=", ""]);
-        return { exitCode: 0, stdout: "opened pr\n", stderr: "", summary: "opened pr" };
+        return {
+          exitCode: 0,
+          stdout: "opened pr\n",
+          stderr: "",
+          summary: "opened pr",
+          outcome: { opened: true, pullRequestUrl: "https://github.com/averray-agent/agent/pull/607" },
+        };
       },
     });
 
@@ -164,6 +177,61 @@ describe("codex task runner", () => {
       agent: "codex",
     });
     expect(task.pullRequestNumber).toBeUndefined();
+  });
+
+  it("marks a zero-exit no-PR outcome failed instead of completed", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      agent: "codex",
+      title: "No diff",
+      prompt: "Try the change.",
+    }, { path });
+    await approveCodexTask(proposed.task.id, { path });
+
+    const result = await runCodexTaskRunnerOnce(config(path), {
+      executor: async () => ({
+        exitCode: 0,
+        stdout: "Codex produced no changes; not opening a PR.\n",
+        stderr: "",
+        summary: "Codex produced no changes; not opening a PR.",
+        outcome: { opened: false, reason: "no_changes" },
+      }),
+    });
+
+    expect(result).toMatchObject({ status: "failed", reason: "no_changes" });
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      id: proposed.task.id,
+      status: "failed",
+      failureReason: "no_changes",
+      completionSummary: "no_changes",
+      progressMessage: "no_changes",
+    });
+  });
+
+  it("marks an executor timeout error failed", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      pullRequestNumber: 394,
+      prompt: "Finish PR #394.",
+    }, { path });
+    await approveCodexTask(proposed.task.id, { path });
+
+    const result = await runCodexTaskRunnerOnce(config(path), {
+      executor: async () => {
+        throw new Error("Codex task command timed out after 1000ms.");
+      },
+    });
+
+    expect(result).toMatchObject({ status: "failed", reason: "Codex task command timed out after 1000ms." });
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      status: "failed",
+      failureReason: "Codex task command timed out after 1000ms.",
+      completionSummary: "Codex task command timed out after 1000ms.",
+    });
   });
 
   it("marks an approved task failed when the executor exits nonzero", async () => {


### PR DESCRIPTION
## What changed & why

- Added a structured branch-worker outcome sentinel so runners no longer infer success from exit code or human log text.
- Updated Codex and Claude-family task runners so `completed` requires an explicit PR outcome. Zero-exit no-PR outcomes now become `failed`, with the reason stored on `failureReason`, `completionSummary`, progress, and the heartbeat.
- Hardened both branch workers immediately after `git clone`: they verify the checkout is a Git worktree with tracked files before launching Codex/Claude. Empty/unusable checkouts return a no-PR failure outcome that preserves the git stderr/stdout tail.
- Kept timeout/non-zero/exception paths failed, and kept PR URLs carried in completion summaries for completed outcomes.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [x] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm test -- test/unit/codex-task-runner.test.ts test/unit/claude-task-runner.test.ts test/unit/codex-branch-worker.test.ts test/unit/claude-branch-worker.test.ts`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)

## Rollout / rollback

No ops, env, secret, compose, or image changes. Rollback is reverting this PR; the old behavior would again treat zero-exit no-PR worker returns as completed.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; `HALT_FILE` honored; no new **ungated** agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated `AGENTS.md` / affected docs **if this changes how agents work**

## Known limits / follow-ups

- Failed tasks now also carry `completionSummary` equal to the failure reason so the board/list views have a concise terminal summary without marking the task completed.
