### PR TITLE
feat(testbed): add citation_repair as a board mission mode

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -13,6 +13,10 @@
       "types": "./dist/default-workflow-runtime.d.ts",
       "import": "./dist/default-workflow-runtime.js"
     },
+    "./job-workflows": {
+      "types": "./dist/job-workflows.d.ts",
+      "import": "./dist/job-workflows.js"
+    },
     "./operator-handler": {
       "types": "./dist/operator-handler.d.ts",
       "import": "./dist/operator-handler.js"

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -13,7 +13,7 @@ const MAX_MISSION_RUNS = 50;
 
 export type TestbedMissionStatus = "requested" | "ready" | "running" | "completed" | "failed";
 export type TestbedMissionVerdict = "pass" | "partial" | "fail";
-export type TestbedMissionMode = "explore" | "surface_sweep" | "siwe_auth" | "gold_path";
+export type TestbedMissionMode = "explore" | "surface_sweep" | "siwe_auth" | "gold_path" | "citation_repair";
 export type TestbedMissionRequesterAgent = "codex" | "claude" | "test-writer" | "security" | "docs" | "hermes" | "operator";
 export type TestbedMissionRunnerHeartbeatStatus =
   | "idle"
@@ -56,6 +56,9 @@ export interface TestbedMissionRun {
   /** Routes for a surface_sweep (relative to the app base URL, or absolute).
    *  Empty/absent ⇒ the default public surface list. */
   routes?: string[];
+  /** citation_repair: the Wikipedia job to repair. Absent ⇒ the workflow
+   *  auto-selects a claimable citation-repair job. */
+  jobId?: string;
   mission: Record<string, unknown>;
   result?: Record<string, unknown>;
   history: TestbedMissionHistoryEntry[];
@@ -276,6 +279,7 @@ export function recordTestbedMissionRunFromOperatorResult(
   const safety = isRecord(rawMission.safety) ? rawMission.safety : {};
   const createdAt = new Date(nowMs).toISOString();
   const mode = parseTestbedMissionMode(stringField(target, "mode"));
+  const jobId = stringField(target, "jobId");
   const binding = resolveTestbedMutationBinding({
     targetUrl: stringField(target, "url"),
     mode,
@@ -311,6 +315,7 @@ export function recordTestbedMissionRunFromOperatorResult(
     mutationBindingReason: binding.reason,
     ...(mode ? { mode } : {}),
     ...(routes.length > 0 ? { routes } : {}),
+    ...(jobId ? { jobId } : {}),
     mission,
     history: [
       {
@@ -1240,7 +1245,7 @@ function missionFailedMs(run: TestbedMissionRun): number {
 }
 
 function parseTestbedMissionMode(value: string | undefined): TestbedMissionMode | undefined {
-  if (value === "surface_sweep" || value === "siwe_auth" || value === "gold_path") return value;
+  if (value === "surface_sweep" || value === "siwe_auth" || value === "gold_path" || value === "citation_repair") return value;
   return undefined;
 }
 
@@ -1370,6 +1375,8 @@ function testbedMissionTitle(mode: TestbedMissionMode | undefined): string {
       return "SIWE auth role-gating mission";
     case "gold_path":
       return "Autonomous gold-path mission";
+    case "citation_repair":
+      return "Wikipedia citation-repair (dry run)";
     default:
       return "Fresh-agent browser mission";
   }

--- a/services/slack-operator/src/testbed-agent-entrypoint.ts
+++ b/services/slack-operator/src/testbed-agent-entrypoint.ts
@@ -34,6 +34,8 @@ export interface AgentTestbedMissionInput {
   mode?: TestbedMissionMode;
   /** T1: routes for a surface sweep (relative to the app base URL, or absolute). */
   routes?: string[];
+  /** citation_repair: the Wikipedia job to repair; absent ⇒ workflow auto-selects. */
+  jobId?: string;
   /** When true, create the mission as `requested` (operator must approve before a
    *  runner can claim it) rather than auto-`ready`. Used for external agent
    *  requests; operator-scheduled gold-path runs rely on the spend/safety budget
@@ -54,6 +56,7 @@ export interface MonitorTestbedMissionPostInput {
   mode?: unknown;
   initialStatus?: unknown;
   routes?: unknown;
+  jobId?: unknown;
   path?: string;
 }
 
@@ -114,11 +117,17 @@ export function createMonitorTestbedMissionFromPayload(
   input: MonitorTestbedMissionPostInput,
   nowMs: number = Date.now()
 ): AgentTestbedMissionResult {
-  const targetUrl = parseHttpUrl(input.targetUrl);
   const mode = parseMonitorMissionMode(input.mode);
+  const jobId = cleanString(input.jobId);
+  // citation_repair selects a Wikipedia job (by jobId or auto), so it has no
+  // page URL to test up front; default to the Wikipedia base when none is given.
+  const targetUrl = mode === "citation_repair" && !cleanString(input.targetUrl)
+    ? "https://en.wikipedia.org/"
+    : parseHttpUrl(input.targetUrl);
   const initialStatus = cleanString(input.initialStatus);
   const missionInput: AgentTestbedMissionInput = {
     targetUrl,
+    ...(jobId ? { jobId } : {}),
     ...(cleanString(input.goal) ? { goal: cleanString(input.goal) } : {}),
     ...(cleanString(input.agentName) ? { agentName: cleanString(input.agentName) } : {}),
     ...(cleanString(input.requester) ? { requester: cleanString(input.requester) } : {}),
@@ -191,13 +200,14 @@ function createTestbedMissionRecord(
   // Carry executor selection onto the mission packet's target so the recorded
   // run picks up `mode` / `routes` (the averray-mcp packet generator is
   // deliberately agnostic to monitor-local executors).
-  if (input.mode || (input.routes && input.routes.length > 0)) {
+  if (input.mode || (input.routes && input.routes.length > 0) || input.jobId) {
     const target =
       mission.target && typeof mission.target === "object" && !Array.isArray(mission.target)
         ? (mission.target as Record<string, unknown>)
         : {};
     if (input.mode) target.mode = input.mode;
     if (input.routes && input.routes.length > 0) target.routes = input.routes;
+    if (input.jobId) target.jobId = input.jobId;
     mission.target = target;
   }
   const run = recordTestbedMissionRunFromOperatorResult(
@@ -342,7 +352,7 @@ function parseStringArray(value: unknown): string[] {
 
 function parseMonitorMissionMode(value: unknown): TestbedMissionMode | undefined {
   const mode = cleanString(value);
-  if (mode === "surface_sweep" || mode === "siwe_auth" || mode === "gold_path") return mode;
+  if (mode === "surface_sweep" || mode === "siwe_auth" || mode === "gold_path" || mode === "citation_repair") return mode;
   return undefined;
 }
 

--- a/services/slack-operator/src/testbed-citation-mission.ts
+++ b/services/slack-operator/src/testbed-citation-mission.ts
@@ -1,0 +1,191 @@
+// Citation-repair board mission (PR-1).
+//
+// A board-launched citation_repair mission reuses the existing
+// request → approve → runner → report → card pipeline, but instead of driving
+// a browser it runs the Wikipedia citation-repair WORKFLOW in dry-run and maps
+// its result into the standard TestbedMissionStructuredReport so the board
+// renders it as a mission card.
+//
+// Hard rule: dryRun is FORCED true here — a board citation-repair mission only
+// ANALYZES (no claim, no submit). Settlement stays operator-gated elsewhere.
+// The client/mission can never flip this to a mutation.
+
+import {
+  runWikipediaCitationRepairWorkflow,
+  type WorkflowDeps,
+} from "@avg/averray-mcp/job-workflows";
+import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
+import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
+import type { TestbedMissionRunResult, TestbedMissionRunnerConfig } from "./testbed-mission-runner.js";
+
+export interface CitationRepairMissionDeps {
+  /** Injected for tests; defaults to the real workflow. */
+  runWorkflow?: typeof runWikipediaCitationRepairWorkflow;
+  /** Injected for tests; defaults to the process-wide workflow deps. */
+  workflowDeps?: WorkflowDeps;
+}
+
+/** The standard structured-report shape the mission pipeline ingests. */
+interface CitationRepairMissionReport {
+  verdict: "pass" | "fail";
+  confidence: number;
+  stoppedBeforeMutation: true;
+  mutationMode: "read_only";
+  mutationsAttempted: string[];
+  mutationBoundaryNotes: string[];
+  scores: Record<string, number>;
+  completedPath: string[];
+  blockers: string[];
+  confusingMoments: string[];
+  recommendations: string[];
+  evidence: string[];
+  summary: string;
+}
+
+export async function executeCitationRepairMission(
+  mission: TestbedMissionRun,
+  _config: TestbedMissionRunnerConfig,
+  deps: CitationRepairMissionDeps = {},
+): Promise<TestbedMissionRunResult> {
+  const runWorkflow = deps.runWorkflow ?? runWikipediaCitationRepairWorkflow;
+  const workflowDeps = deps.workflowDeps ?? createDefaultWorkflowDeps();
+  const jobId = typeof mission.jobId === "string" && mission.jobId.trim() ? mission.jobId.trim() : undefined;
+
+  let report: CitationRepairMissionReport;
+  try {
+    // dryRun is FORCED — never read from the mission/client.
+    const result = await runWorkflow({ ...(jobId ? { jobId } : {}), dryRun: true }, workflowDeps);
+    report = citationRepairResultToReport(result as Record<string, unknown>);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    report = citationRepairResultToReport({ status: "failed", reason, reviewNotes: [reason] });
+  }
+
+  return {
+    exitCode: 0,
+    stdout: report.summary,
+    stderr: "",
+    reportText: JSON.stringify({ kind: "testbed_mission_report", report }),
+    summary: report.summary,
+  };
+}
+
+/**
+ * Map a Wikipedia citation-repair workflow result → the standard mission report.
+ * Pure + defensive (the workflow returns a union of object shapes).
+ *
+ * verdict: blocked/failed → "fail"; needs_review/submitted (a clean dry-run
+ * that produced a reviewable proposal) → "pass" (the MISSION ran successfully;
+ * the proposal still needs operator review — surfaced in summary/recommendations,
+ * and quality-judged downstream). dryRun is analysis-only, so it never claims a
+ * "verified" outcome on its own.
+ */
+export function citationRepairResultToReport(result: Record<string, unknown>): CitationRepairMissionReport {
+  const status = str(result.status) ?? "unknown";
+  const failed = status === "blocked" || status === "failed";
+  const confidence = clamp01(num(result.confidence));
+  const reviewNotes = strArray(result.reviewNotes);
+  const reason = str(result.reason);
+
+  const summaryRec = rec(result.evidenceSummary);
+  const totalCitations = num(summaryRec?.totalCitations);
+  const flaggedCitations = num(summaryRec?.flaggedCitations);
+  const deadLinkCitations = num(summaryRec?.deadLinkCitations);
+
+  const readiness = rec(result.readiness);
+  const validatedBeforeClaim = readiness?.validatedBeforeClaim === true;
+  const wrapperProbe = rec(rec(readiness?.invalidWrappedOutput)?.probeResult);
+  const wrapperRejected = wrapperProbe ? wrapperProbe.valid !== true : undefined;
+
+  const evidence: string[] = [`status: ${status}`];
+  if (status !== "unknown") evidence.push(`verdict: ${failed ? "fail" : "pass (dry-run; needs operator review)"}`);
+  if (deadLinkCitations !== undefined) evidence.push(`dead-link citations: ${deadLinkCitations}`);
+  if (totalCitations !== undefined) evidence.push(`total citations: ${totalCitations}`);
+  if (flaggedCitations !== undefined) evidence.push(`flagged citations: ${flaggedCitations}`);
+  if (readiness) evidence.push(`validated before claim: ${validatedBeforeClaim ? "yes" : "no"}`);
+  if (wrapperRejected !== undefined) evidence.push(`invalid-wrapper probe: ${wrapperRejected ? "rejected (good)" : "accepted (unsafe)"}`);
+  if (reason) evidence.push(`reason: ${reason}`);
+  evidence.push(...renderProposalPreview(rec(result.proposalPreview)));
+  if (evidence.length === 0) evidence.push("Citation-repair workflow returned no detail.");
+
+  const deadLinkLabel = deadLinkCitations !== undefined ? `${deadLinkCitations} dead-link citation(s)` : "no dead-link count";
+  const summary = failed
+    ? `Citation-repair dry run blocked (${status})${reason ? `: ${reason}` : ""}.`
+    : `Citation-repair dry run — needs operator review before claim/submit · ${deadLinkLabel} · confidence ${Math.round(confidence * 100)}%.`;
+
+  return {
+    verdict: failed ? "fail" : "pass",
+    confidence,
+    stoppedBeforeMutation: true,
+    mutationMode: "read_only",
+    mutationsAttempted: [],
+    mutationBoundaryNotes: [
+      "Dry run — no Averray claim or submit was attempted. Board citation-repair runs are analysis-only; settlement stays operator-gated.",
+    ],
+    scores: {},
+    completedPath: failed
+      ? []
+      : [
+        "Selected a claimable Wikipedia citation-repair job",
+        "Fetched the article's citations and evidence",
+        "Built the citation-repair proposal",
+        "Validated the submission against the platform schema before any claim (no mutation)",
+      ],
+    blockers: failed
+      ? [reason ?? `Citation-repair workflow ended with status "${status}".`, ...reviewNotes]
+      : [],
+    confusingMoments: [],
+    recommendations: reviewNotes,
+    evidence,
+    summary,
+  };
+}
+
+function renderProposalPreview(preview: Record<string, unknown> | undefined): string[] {
+  if (!preview) return [];
+  const lines: string[] = [];
+  const findings = arr(preview.citation_findings);
+  for (const f of findings.slice(0, 8)) {
+    const r = rec(f);
+    if (!r) continue;
+    const problem = str(r.problem) ?? "finding";
+    const claim = str(r.current_claim) ?? str(r.target_text) ?? "";
+    lines.push(`finding · ${problem}: ${truncate(claim, 160)}`);
+  }
+  const changes = arr(preview.proposed_changes);
+  for (const c of changes.slice(0, 8)) {
+    const r = rec(c);
+    if (!r) continue;
+    const from = truncate(str(r.target_text) ?? "", 80);
+    const to = truncate(str(r.replacement_text) ?? "", 80);
+    lines.push(`change · ${from} → ${to}`);
+  }
+  const notes = str(preview.review_notes);
+  if (notes) lines.push(`proposal notes: ${truncate(notes, 200)}`);
+  return lines;
+}
+
+// ── defensive readers ───────────────────────────────────────────────
+function rec(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+function arr(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+function strArray(value: unknown): string[] {
+  return arr(value).map((v) => (typeof v === "string" ? v.trim() : "")).filter(Boolean);
+}
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function clamp01(value: number | undefined): number {
+  if (value === undefined) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+function truncate(text: string, max: number): string {
+  const t = text.trim();
+  return t.length <= max ? t : `${t.slice(0, max - 1)}…`;
+}

--- a/services/slack-operator/src/testbed-mission-runner.ts
+++ b/services/slack-operator/src/testbed-mission-runner.ts
@@ -26,6 +26,7 @@ import {
   type GoldPathAutonomyDeps,
 } from "./gold-path-autonomy.js";
 import { executeSiweAuthMission, type SiweAuthMissionDeps } from "./testbed-auth-mission.js";
+import { executeCitationRepairMission } from "./testbed-citation-mission.js";
 import { executeSurfaceSweep, type SurfaceSweepDeps } from "./testbed-surface-sweep.js";
 import {
   parseTestbedLiveScreencastConfig,
@@ -449,6 +450,11 @@ export async function executeBrowserTestbedMission(
   }
   if (mission.mode === "gold_path") {
     return executeGoldPathTestbedMission(mission, config);
+  }
+  if (mission.mode === "citation_repair") {
+    // Not a browser mission: run the Wikipedia citation-repair workflow
+    // (dryRun forced server-side — a board mission never claims/submits).
+    return executeCitationRepairMission(mission, config);
   }
   return executePlaywrightTestbedMission(mission, config);
 }

--- a/test/unit/testbed-citation-mission.test.ts
+++ b/test/unit/testbed-citation-mission.test.ts
@@ -1,0 +1,216 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  citationRepairResultToReport,
+  executeCitationRepairMission,
+} from "../../services/slack-operator/src/testbed-citation-mission.js";
+import type { TestbedMissionRun } from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import type { TestbedMissionRunnerConfig } from "../../services/slack-operator/src/testbed-mission-runner.js";
+import {
+  __resetTestbedMissionRunsForTests,
+  recordTestbedMissionReportFromMessage,
+} from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import {
+  createMonitorTestbedMissionFromPayload,
+  approveRequestedTestbedMission,
+  getTestbedMissionForAgent,
+} from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
+
+// A representative dry-run workflow result (needs_review: a proposal was built).
+const NEEDS_REVIEW_RESULT = {
+  status: "needs_review",
+  dryRun: true,
+  runId: "run-1",
+  jobId: "job-42",
+  confidence: 0.82,
+  evidenceSummary: { totalCitations: 12, flaggedCitations: 3, deadLinkCitations: 2 },
+  readiness: {
+    validatedBeforeClaim: true,
+    invalidWrappedOutput: { probeResult: { valid: false, reason: "wrapper rejected" } },
+  },
+  proposalPreview: {
+    citation_findings: [
+      { problem: "dead link", current_claim: "Founded in 1999 [1]" },
+    ],
+    proposed_changes: [
+      { target_text: "[1] http://dead.example", replacement_text: "[1] https://archive.example/1999" },
+    ],
+    review_notes: "One dead link replaced with an archived copy.",
+  },
+  reviewNotes: ["Verify the archived copy matches the original source."],
+};
+
+const BLOCKED_RESULT = {
+  status: "blocked",
+  dryRun: true,
+  reason: "pre-claim validation failed: schema mismatch",
+  confidence: 0.4,
+  reviewNotes: ["Fix the proposal shape before retrying."],
+};
+
+const config = {} as TestbedMissionRunnerConfig;
+
+describe("citationRepairResultToReport", () => {
+  it("maps needs_review → pass and preserves counts, readiness, and the proposal preview", () => {
+    const report = citationRepairResultToReport(NEEDS_REVIEW_RESULT);
+
+    expect(report.verdict).toBe("pass");
+    expect(report.confidence).toBe(0.82);
+    expect(report.stoppedBeforeMutation).toBe(true);
+    expect(report.mutationMode).toBe("read_only");
+    expect(report.completedPath.length).toBeGreaterThan(0);
+    expect(report.blockers).toEqual([]);
+    expect(report.recommendations).toContain("Verify the archived copy matches the original source.");
+
+    const evidence = report.evidence.join("\n");
+    expect(evidence).toContain("dead-link citations: 2");
+    expect(evidence).toContain("total citations: 12");
+    expect(evidence).toContain("flagged citations: 3");
+    expect(evidence).toContain("validated before claim: yes");
+    expect(evidence).toContain("invalid-wrapper probe: rejected (good)");
+    // The proposal preview is the review surface — it must survive the mapping.
+    expect(evidence).toContain("Founded in 1999 [1]");
+    expect(evidence).toContain("https://archive.example/1999");
+  });
+
+  it("maps blocked → fail with a non-empty blocker reason", () => {
+    const report = citationRepairResultToReport(BLOCKED_RESULT);
+
+    expect(report.verdict).toBe("fail");
+    expect(report.completedPath).toEqual([]);
+    expect(report.blockers[0]).toContain("schema mismatch");
+    expect(report.stoppedBeforeMutation).toBe(true);
+  });
+
+  it("clamps an out-of-range confidence into 0..1", () => {
+    expect(citationRepairResultToReport({ status: "needs_review", confidence: 9 }).confidence).toBe(1);
+    expect(citationRepairResultToReport({ status: "needs_review", confidence: -3 }).confidence).toBe(0);
+    expect(citationRepairResultToReport({ status: "needs_review" }).confidence).toBe(0);
+  });
+});
+
+describe("executeCitationRepairMission", () => {
+  function mission(over: Partial<TestbedMissionRun> = {}): TestbedMissionRun {
+    return { id: "m1", mode: "citation_repair", jobId: "job-42", ...over } as TestbedMissionRun;
+  }
+
+  it("forces dryRun:true and passes the mission jobId to the workflow", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const runWorkflow = (async (input: Record<string, unknown>) => {
+      calls.push(input);
+      return NEEDS_REVIEW_RESULT;
+    }) as never;
+
+    const result = await executeCitationRepairMission(mission(), config, {
+      runWorkflow,
+      workflowDeps: {} as never,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].dryRun).toBe(true);
+    expect(calls[0].jobId).toBe("job-42");
+    expect(result.exitCode).toBe(0);
+
+    const payload = JSON.parse(result.reportText ?? "{}");
+    expect(payload.kind).toBe("testbed_mission_report");
+    expect(payload.report.verdict).toBe("pass");
+  });
+
+  it("still forces dryRun:true even when the mission carries no jobId", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const runWorkflow = (async (input: Record<string, unknown>) => {
+      calls.push(input);
+      return NEEDS_REVIEW_RESULT;
+    }) as never;
+
+    await executeCitationRepairMission(mission({ jobId: undefined }), config, {
+      runWorkflow,
+      workflowDeps: {} as never,
+    });
+
+    expect(calls[0].dryRun).toBe(true);
+    expect(calls[0]).not.toHaveProperty("jobId");
+  });
+
+  it("turns a workflow throw into a fail report rather than crashing the runner", async () => {
+    const runWorkflow = (async () => {
+      throw new Error("workflow exploded");
+    }) as never;
+
+    const result = await executeCitationRepairMission(mission(), config, {
+      runWorkflow,
+      workflowDeps: {} as never,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.reportText ?? "{}");
+    expect(payload.report.verdict).toBe("fail");
+    expect(payload.report.blockers.join(" ")).toContain("workflow exploded");
+  });
+});
+
+describe("citation_repair board round-trip (request → approve → report)", () => {
+  let dir = "";
+  let path = "";
+
+  beforeEach(() => {
+    __resetTestbedMissionRunsForTests();
+    dir = mkdtempSync(join(tmpdir(), "averray-citation-mission-"));
+    path = join(dir, "missions.json");
+  });
+
+  afterEach(() => {
+    __resetTestbedMissionRunsForTests();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("carries mode + jobId through request/approve and ingests the dry-run report as a card", async () => {
+    const created = createMonitorTestbedMissionFromPayload(
+      {
+        path,
+        mode: "citation_repair",
+        jobId: "job-42",
+        initialStatus: "requested",
+      },
+      Date.parse("2026-05-25T10:01:00.000Z")
+    );
+
+    expect(created.run).toMatchObject({
+      mode: "citation_repair",
+      jobId: "job-42",
+      status: "requested",
+    });
+
+    const approved = approveRequestedTestbedMission(created.run.id, {
+      path,
+      approvedBy: "operator",
+      now: new Date("2026-05-25T10:03:00.000Z"),
+    });
+    expect(approved.ok).toBe(true);
+    expect(approved.run).toMatchObject({ status: "ready", mode: "citation_repair", jobId: "job-42" });
+
+    // Runner branch: run the workflow (faked) and produce the report text.
+    const runResult = await executeCitationRepairMission(
+      approved.run as unknown as TestbedMissionRun,
+      config,
+      {
+        runWorkflow: (async () => NEEDS_REVIEW_RESULT) as never,
+        workflowDeps: {} as never,
+      }
+    );
+
+    recordTestbedMissionReportFromMessage(
+      { path, relatedCorrelationId: created.run.id, text: runResult.reportText ?? "" },
+      Date.parse("2026-05-25T10:07:00.000Z")
+    );
+
+    const detail = getTestbedMissionForAgent(created.run.id, { path });
+    expect(detail).toMatchObject({
+      status: "completed",
+      report: { verdict: "OK" },
+    });
+  });
+});


### PR DESCRIPTION
## What

Makes Wikipedia **citation-repair** a first-class testbed mission **mode** so it reuses the existing `request → approve → claim → runner → report → card` pipeline rather than a parallel run type. Board-launched citation-repair runs are **`dryRun: true` only** (analysis, no claim/submit) — settlement stays operator-gated elsewhere.

## Changes

- **Mode**: `TestbedMissionMode` gains `"citation_repair"`. The request/approve/claim flow accepts it unchanged and carries an optional `jobId` (absent ⇒ the workflow auto-selects a claimable citation-repair job). Threaded through `parseMonitorMissionMode` / `parseTestbedMissionMode`, `MonitorTestbedMissionPostInput`, `AgentTestbedMissionInput`, `createTestbedMissionRecord` (target carry), and `recordTestbedMissionRunFromOperatorResult` (run carry). citation_repair has no page URL up front, so `targetUrl` defaults to `https://en.wikipedia.org/` when none is given.
- **Runner branch** (`executeBrowserTestbedMission`): citation_repair dispatches to the new `executeCitationRepairMission`, which calls `runWikipediaCitationRepairWorkflow({ jobId, dryRun: true })`. **`dryRun: true` is forced server-side** — hardcoded in the call, never read from the mission/client. A board citation-repair run only *analyzes*; it never claims or submits.
- **Report mapping** (`citationRepairResultToReport`, pure): workflow result → standard `TestbedMissionStructuredReport`.
  - verdict: `needs_review`/`submitted` → **pass** (a clean dry-run that produced a reviewable proposal); `blocked`/`failed` → **fail**.
  - evidence carries: status, dead-link / total / flagged citation counts, schema readiness (`validatedBeforeClaim` + invalid-wrapper probe), and the **proposal preview** (`citation_findings` + `proposed_changes`) — the review surface is preserved, not dropped.
  - The "needs review" nuance lives in `summary`/`recommendations`; quality-judging it is a later step (PR-2).
  - A workflow throw becomes a fail report rather than crashing the runner.
- **Board card**: no `monitor-v2.ts` / `DrawerBody` changes needed — the report uses standard fields (`verdict`, `confidence`, `evidence[]`, `recommendations`, `summary`, `completedPath`), so the existing mission card + `MissionBody` render it. Browser-mission rendering is untouched.
- **Package export**: expose `@avg/averray-mcp/job-workflows` as a compiled `./dist` subpath export so slack-operator can import the workflow entrypoint + its types.

## On the verdict mapping

`recordTestbedMissionReportFromMessage` only maps `verdict === "pass"` → completed and `partial`/`fail` → failed; there is no `needs_review` verdict. A clean dry-run that built a reviewable proposal is mapped to **pass** (the *mission* ran successfully) with the "needs operator review before claim/submit" caveat surfaced in `summary`/`recommendations`. dryRun is analysis-only, so it never claims a "verified" outcome on its own.

## Acceptance

- ✅ A citation_repair mission can be requested + approved on the board (round-trip test).
- ✅ Runner runs the workflow with `dryRun: true` (asserted forced, with and without a `jobId`).
- ✅ Card shows verdict + confidence + dead-link count + a readable proposal preview.
- ✅ `dryRun: true` is enforced server-side, never just defaulted.

## Tests

- mode round-trips request → approve → report (mode + `jobId` carried; ingested as a completed card)
- workflow-result → report mapping unit (status → verdict; counts / readiness / proposal preview preserved; confidence clamped to 0..1; passes the ingest validator)
- `dryRun: true` forced (injected fake workflow asserts `input.dryRun === true` and the `jobId` is passed; throw → fail report)

## Verification

- `tsc -b packages/* services/*` — clean
- `vitest run` citation-mission + entrypoint + runner + monitor-testbed-missions + auth + gold-path + operator suites — 88 passing
- `@avg/monitor-ui` vite build — clean

## Constraints honored

Reuses the mission model (no parallel run type); touches only the testbed layer + the runner + the package export; no chain/settlement code; does not regress browser missions.

Unblocks **PR-2** (the Hermes analysis brain — `citationRepairDisposition`), which depends on this report shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)