### PR TITLE
feat(router): add pure work routing decision core

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -49,6 +49,10 @@
       "types": "./dist/dispatch-routing.d.ts",
       "import": "./dist/dispatch-routing.js"
     },
+    "./work-router": {
+      "types": "./dist/work-router.d.ts",
+      "import": "./dist/work-router.js"
+    },
     "./decision-records": {
       "types": "./dist/decision-records.d.ts",
       "import": "./dist/decision-records.js"

--- a/packages/averray-mcp/src/work-router.ts
+++ b/packages/averray-mcp/src/work-router.ts
@@ -1,0 +1,191 @@
+import type { DispatchPolicyConfig } from "./dispatch-policy.js";
+import type { RoutingDecision, RoutingInput, RiskTier } from "./dispatch-routing.js";
+import type { HermesBacklogItem } from "./hermes-backlog.js";
+
+export type RoutedWorkAgent = "codex" | "claude";
+export type RoutedWorkStatus = "proposed" | "approved" | "running" | "completed" | "failed" | "cancelled" | string;
+
+export interface WorkRouterBacklogItem extends Partial<Pick<HermesBacklogItem, "id" | "title" | "prompt" | "stream">> {
+  repo: string;
+  surface?: string;
+  area?: string;
+  description?: string;
+  shortDescription?: string;
+}
+
+export interface WorkRouterTaskSnapshot {
+  repo: string;
+  status?: RoutedWorkStatus;
+  surface?: string;
+  area?: string;
+  title?: string;
+  prompt?: string;
+}
+
+export interface WorkRouterPolicySnapshot extends Pick<
+  DispatchPolicyConfig,
+  "allowedRepos" | "allowedAgents" | "perDayMax" | "perRepoPerDayMax"
+> {
+  todayCount: number;
+  todayRepoCounts?: Record<string, number>;
+}
+
+export type WorkRouterClassifier = (input: RoutingInput) => Pick<RoutingDecision, "agent" | "riskTier" | "reason">;
+
+export interface PlanAndRouteWorkInput {
+  backlog: WorkRouterBacklogItem[];
+  inFlight: WorkRouterTaskSnapshot[];
+  recentlyDone: WorkRouterTaskSnapshot[];
+  policy: WorkRouterPolicySnapshot;
+  classify: WorkRouterClassifier;
+  maxProposals?: number;
+}
+
+export interface RoutedProposal {
+  taskPrompt: string;
+  repo: string;
+  surface: string;
+  agent: RoutedWorkAgent;
+  riskTier: RiskTier;
+  why: string;
+  whyAgent: string;
+  dedupeKey: string;
+}
+
+const DEFAULT_MAX_PROPOSALS = 3;
+const ACTIVE_STATUSES = new Set(["proposed", "approved", "running"]);
+
+export function planAndRouteWork(input: PlanAndRouteWorkInput): RoutedProposal[] {
+  const maxProposals = boundedMax(input.maxProposals ?? DEFAULT_MAX_PROPOSALS);
+  if (maxProposals <= 0) return [];
+
+  const covered = new Set<string>();
+  for (const task of input.inFlight) {
+    if (!task.status || ACTIVE_STATUSES.has(task.status)) covered.add(dedupeKeyForTask(task));
+  }
+  for (const task of input.recentlyDone) covered.add(dedupeKeyForTask(task));
+
+  const proposals: RoutedProposal[] = [];
+  const acceptedRepoCounts = new Map<string, number>();
+  for (const item of input.backlog) {
+    if (proposals.length >= maxProposals) break;
+    const repo = normalizeRepo(item.repo);
+    if (!repo) continue;
+    const surface = itemSurface(item);
+    const title = itemTitle(item);
+    const proposalDedupeKey = dedupeKey(repo, surface, title);
+    if (covered.has(proposalDedupeKey)) continue;
+
+    const description = itemDescription(item);
+    const routing = input.classify({
+      repo,
+      area: surface,
+      prompt: [title, description].filter(Boolean).join(": "),
+      tags: item.stream ? [item.stream] : undefined,
+    });
+    const agent = routedAgent(routing.agent);
+    assertTaxonomy(surface, title, agent);
+    if (!policyAllows(input.policy, { repo, agent, accepted: proposals.length, acceptedRepoCounts })) continue;
+
+    const proposal: RoutedProposal = {
+      taskPrompt: item.prompt?.trim() || defaultPrompt(title, description, surface),
+      repo,
+      surface,
+      agent,
+      riskTier: routing.riskTier,
+      why: `Fills uncovered backlog gap: ${title}.`,
+      whyAgent: routing.reason,
+      dedupeKey: proposalDedupeKey,
+    };
+    proposals.push(proposal);
+    acceptedRepoCounts.set(repo, (acceptedRepoCounts.get(repo) ?? 0) + 1);
+    covered.add(proposalDedupeKey);
+  }
+
+  return proposals;
+}
+
+function policyAllows(
+  policy: WorkRouterPolicySnapshot,
+  input: {
+    repo: string;
+    agent: RoutedWorkAgent;
+    accepted: number;
+    acceptedRepoCounts: Map<string, number>;
+  },
+): boolean {
+  if (!Array.isArray(policy.allowedRepos) || policy.allowedRepos.length === 0) return false;
+  if (!policy.allowedRepos.includes(input.repo)) return false;
+  if (!Array.isArray(policy.allowedAgents) || !policy.allowedAgents.includes(input.agent)) return false;
+  if (input.accepted + policy.todayCount >= policy.perDayMax) return false;
+
+  if (policy.perRepoPerDayMax > 0) {
+    const current = policy.todayRepoCounts?.[input.repo] ?? 0;
+    const acceptedForRepo = input.acceptedRepoCounts.get(input.repo) ?? 0;
+    if (current + acceptedForRepo >= policy.perRepoPerDayMax) return false;
+  }
+  return true;
+}
+
+function routedAgent(agent: string): RoutedWorkAgent {
+  if (agent === "codex" || agent === "claude") return agent;
+  throw new Error(`routing_taxonomy_violation: unsupported routed agent ${agent}`);
+}
+
+function assertTaxonomy(surface: string, title: string, agent: RoutedWorkAgent): void {
+  const haystack = normalizeText(`${surface} ${title}`);
+  if (matchesAny(haystack, ["chain", "settlement", "escrow", "contract", "contracts", "xcm", "polkadot", "substrate", "treasury"])) {
+    if (agent !== "codex") throw new Error(`routing_taxonomy_violation: ${surface} must route to codex`);
+  }
+  if (matchesAny(haystack, ["ui", "frontend", "front end", "docs", "documentation", "readme", "copy", "monitor", "drawer", "board"])) {
+    if (agent !== "claude") throw new Error(`routing_taxonomy_violation: ${surface} must route to claude`);
+  }
+}
+
+function matchesAny(haystack: string, needles: string[]): boolean {
+  return needles.some((needle) => haystack.includes(needle));
+}
+
+function dedupeKeyForTask(task: WorkRouterTaskSnapshot): string {
+  return dedupeKey(normalizeRepo(task.repo), task.surface ?? task.area ?? "", task.title ?? task.prompt ?? "");
+}
+
+function dedupeKey(repo: string, surface: string, title: string): string {
+  const normalizedSurface = normalizeText(surface);
+  const normalizedTitle = normalizeText(title);
+  return [repo, normalizedSurface || normalizedTitle, normalizedTitle].filter(Boolean).join("|");
+}
+
+function itemSurface(item: WorkRouterBacklogItem): string {
+  return (item.surface ?? item.area ?? item.stream ?? "general").trim() || "general";
+}
+
+function itemTitle(item: WorkRouterBacklogItem): string {
+  return (item.title ?? item.id ?? item.description ?? item.shortDescription ?? "Untitled backlog item").trim();
+}
+
+function itemDescription(item: WorkRouterBacklogItem): string {
+  return (item.shortDescription ?? item.description ?? item.prompt ?? item.title ?? "").trim();
+}
+
+function defaultPrompt(title: string, description: string, surface: string): string {
+  const suffix = description && description !== title ? ` ${description}` : "";
+  return `Build ${title} for ${surface}.${suffix}`.trim();
+}
+
+function normalizeRepo(value: string | undefined): string {
+  return (value ?? "").trim();
+}
+
+function normalizeText(value: string | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+function boundedMax(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_MAX_PROPOSALS;
+  return Math.max(0, Math.floor(value));
+}

--- a/test/unit/work-router.test.ts
+++ b/test/unit/work-router.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RoutingInput } from "../../packages/averray-mcp/src/dispatch-routing.js";
+import {
+  planAndRouteWork,
+  type PlanAndRouteWorkInput,
+  type WorkRouterBacklogItem,
+  type WorkRouterClassifier,
+  type WorkRouterPolicySnapshot,
+} from "../../packages/averray-mcp/src/work-router.js";
+
+const POLICY: WorkRouterPolicySnapshot = {
+  allowedRepos: ["depre-dev/averray-reference-agent"],
+  allowedAgents: ["codex", "claude"],
+  perDayMax: 10,
+  perRepoPerDayMax: 5,
+  todayCount: 0,
+  todayRepoCounts: {},
+};
+
+const classify: WorkRouterClassifier = (input: RoutingInput) => {
+  const haystack = [input.area, input.prompt, input.repo, ...(input.tags ?? [])].filter(Boolean).join(" ").toLowerCase();
+  if (/chain|settlement|escrow|contract|polkadot/.test(haystack)) {
+    return { agent: "codex", riskTier: "high", reason: "chain/settlement taxonomy -> codex" };
+  }
+  return { agent: "claude", riskTier: "low", reason: "UI/docs taxonomy -> claude" };
+};
+
+describe("planAndRouteWork", () => {
+  it("routes chain/settlement gaps to Codex and UI gaps to Claude with rationales", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [
+        item("Escrow settlement proof", "chain/settlement", "Verify escrow settlement invariants"),
+        item("Monitor drawer polish", "ui", "Tighten the running mission drawer"),
+      ],
+    }));
+
+    expect(proposals).toHaveLength(2);
+    expect(proposals[0]).toMatchObject({
+      repo: "depre-dev/averray-reference-agent",
+      surface: "chain/settlement",
+      agent: "codex",
+      riskTier: "high",
+      why: "Fills uncovered backlog gap: Escrow settlement proof.",
+      whyAgent: "chain/settlement taxonomy -> codex",
+    });
+    expect(proposals[1]).toMatchObject({
+      surface: "ui",
+      agent: "claude",
+      riskTier: "low",
+      whyAgent: "UI/docs taxonomy -> claude",
+    });
+    expect(proposals.every((proposal) => proposal.dedupeKey.length > 0 && proposal.taskPrompt.length > 0)).toBe(true);
+  });
+
+  it("asserts when the injected classifier violates the routing taxonomy", () => {
+    expect(() => planAndRouteWork(input({
+      backlog: [item("Escrow settlement proof", "chain/settlement", "Verify invariants")],
+      classify: () => ({ agent: "claude", riskTier: "low", reason: "wrong agent" }),
+    }))).toThrow(/routing_taxonomy_violation/);
+  });
+
+  it("does not re-propose gaps covered by in-flight or recently-done tasks", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [
+        item("Monitor drawer polish", "ui", "Tighten the running mission drawer"),
+        item("Docs quickstart copy", "docs", "Improve quickstart wording"),
+        item("Escrow settlement proof", "chain/settlement", "Verify escrow settlement invariants"),
+      ],
+      inFlight: [{
+        repo: "depre-dev/averray-reference-agent",
+        status: "running",
+        surface: "ui",
+        title: "Monitor drawer polish",
+      }],
+      recentlyDone: [{
+        repo: "depre-dev/averray-reference-agent",
+        status: "completed",
+        surface: "docs",
+        title: "Docs quickstart copy",
+      }],
+    }));
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({ surface: "chain/settlement", agent: "codex" });
+  });
+
+  it("drops proposals beyond global budget, per-repo cap, and allowlists", () => {
+    expect(planAndRouteWork(input({
+      backlog: [item("Monitor drawer polish", "ui", "Tighten drawer")],
+      policy: { ...POLICY, perDayMax: 1, todayCount: 1 },
+    }))).toEqual([]);
+
+    expect(planAndRouteWork(input({
+      backlog: [item("Monitor drawer polish", "ui", "Tighten drawer")],
+      policy: { ...POLICY, perRepoPerDayMax: 1, todayRepoCounts: { "depre-dev/averray-reference-agent": 1 } },
+    }))).toEqual([]);
+
+    expect(planAndRouteWork(input({
+      backlog: [item("Monitor drawer polish", "ui", "Tighten drawer")],
+      policy: { ...POLICY, allowedRepos: ["other/repo"] },
+    }))).toEqual([]);
+
+    expect(planAndRouteWork(input({
+      backlog: [item("Monitor drawer polish", "ui", "Tighten drawer")],
+      policy: { ...POLICY, allowedAgents: ["codex"] },
+    }))).toEqual([]);
+  });
+
+  it("returns an empty array when there are no real gaps", () => {
+    const backlog = [item("Monitor drawer polish", "ui", "Tighten the running mission drawer")];
+    const proposals = planAndRouteWork(input({
+      backlog,
+      inFlight: [{
+        repo: "depre-dev/averray-reference-agent",
+        status: "approved",
+        surface: "ui",
+        title: "Monitor drawer polish",
+      }],
+    }));
+
+    expect(proposals).toEqual([]);
+  });
+
+  it("caps proposals to maxProposals deterministically", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [
+        item("Monitor drawer polish", "ui", "Tighten drawer"),
+        item("Docs quickstart copy", "docs", "Improve wording"),
+        item("Board filter labels", "ui", "Clarify filters"),
+      ],
+      maxProposals: 2,
+    }));
+
+    expect(proposals.map((proposal) => proposal.surface)).toEqual(["ui", "docs"]);
+    expect(proposals).toHaveLength(2);
+  });
+
+  it("is pure for the same injected inputs", () => {
+    const classifier = vi.fn(classify);
+    const routeInput = input({
+      backlog: [
+        item("Monitor drawer polish", "ui", "Tighten drawer"),
+        item("Escrow settlement proof", "chain/settlement", "Verify invariants"),
+      ],
+      classify: classifier,
+    });
+
+    const first = planAndRouteWork(routeInput);
+    const second = planAndRouteWork(routeInput);
+
+    expect(second).toEqual(first);
+    expect(classifier).toHaveBeenCalledTimes(4);
+  });
+});
+
+function input(overrides: Partial<PlanAndRouteWorkInput> = {}): PlanAndRouteWorkInput {
+  return {
+    backlog: [],
+    inFlight: [],
+    recentlyDone: [],
+    policy: POLICY,
+    classify,
+    ...overrides,
+  };
+}
+
+function item(title: string, surface: string, description: string): WorkRouterBacklogItem {
+  return {
+    repo: "depre-dev/averray-reference-agent",
+    title,
+    surface,
+    shortDescription: description,
+    prompt: `Build ${title}: ${description}`,
+  };
+}


### PR DESCRIPTION
## What changed

- Added `@avg/averray-mcp/work-router` with a pure `planAndRouteWork(input)` decision core for P4a.
- The router computes uncovered backlog gaps, dedupes against proposed/approved/running and recently terminal work, injects classification, asserts Codex/Claude taxonomy, and applies the injected dispatch policy caps before returning proposals only.
- Added unit coverage for taxonomy routing, taxonomy violation assertions, in-flight/recent dedupe, policy allowlist/budget drops, empty-gap behavior, max proposal caps, and deterministic/pure output.

## Scope / authority

- Proposals only. No routine wiring, queue mutation, dispatch, narration, env, or runner changes.
- No secrets and no production deploy changes.
- P4b can wire this behind a default-off flag later.

## Affected surfaces

- MCP package source/tests only: `packages/averray-mcp` plus unit tests.
- No backend runtime, frontend, contracts, Caddy, or public site changes.

## Checks run

- `npm test -- test/unit/work-router.test.ts` — passed, 7 tests.
- `npm run typecheck` — passed.
- `npm run build` — passed.
- `npm test -- --no-file-parallelism --maxWorkers=1` — passed, 121 files / 1487 tests.

Note: the default parallel `npm test` currently reproduces an unrelated `test/unit/testbed-live-screencast.test.ts` manifest flake in the full suite; that same test passes in isolation and the serial full-suite run passes. This PR does not touch the screencast path.