### PR TITLE
feat(testbed): analyze citation-repair runs (Hermes verdict + fix-spec; FAIL → signal)

### DIFF
--- a/services/slack-operator/src/citation-repair-disposition.ts
+++ b/services/slack-operator/src/citation-repair-disposition.ts
@@ -1,0 +1,631 @@
+// L2-PR2 — the Hermes analysis brain for citation-repair missions.
+//
+// Browser missions get testbedMissionSelfHealingDisposition(); citation-repair
+// runs get THIS. It is quality-aware: a run can pass the permissive platform
+// benchmark and still be a FAIL — it missed the dead links it was hired to fix,
+// sliced garbled mid-<ref> claims, flagged live sources as "weak", or proposed
+// prose that no editor can apply. That judgement is the "analyzed by Hermes"
+// step.
+//
+// Two layers:
+//   Layer A — a CHEAP, DETERMINISTIC quality gate (no LLM) over the real #407
+//             report fields. It alone decides PASS / NEEDS_REVIEW / FAIL.
+//   Layer B — Hermes's own LLM (reused monitor-hermes-voice transport) writes
+//             the operator-facing verdict prose. It may NOT overturn a
+//             deterministic PASS into a fabricated FAIL.
+//
+// TRUTH-BOUNDARY (critical): an honest empty proposal (citation_findings: [])
+// with a justified review note — genuinely no dead links — is a PASS. We never
+// manufacture a defect to create work.
+//
+// On FAIL the disposition emits exactly one FailureSignal { source:
+// "citation_repair", … }. It does NOT dispatch — L2-PR3 wires the signal into
+// self-healing. This module only defines + emits the signal.
+
+import type { FailureSignal } from "./self-healing.js";
+
+/** Confidence below this floor is at least a needs_review. */
+export const CITATION_REPAIR_CONFIDENCE_FLOOR = 0.7;
+
+/** The citation-repair adapter files a fix would target. */
+export const CITATION_REPAIR_ADAPTER_AREA = "citation-repair-adapter";
+const ADAPTER_FILES = "packages/averray-mcp/src/wiki-evidence.ts (citation/<ref> extraction) and packages/averray-mcp/src/job-workflows.ts (buildWikipediaCitationRepairProposal)";
+
+export type CitationRepairVerdict = "pass" | "needs_review" | "fail";
+
+export type CitationRepairFailReason =
+  | "missed_dead_links"
+  | "garbled_extraction"
+  | "live_source_noise"
+  | "non_applyable_fix"
+  | "workflow_blocked";
+
+export type CitationRepairReason = CitationRepairFailReason | "low_confidence" | "unanalyzable" | "clean";
+
+export interface CitationRepairFinding {
+  section?: string;
+  problem?: string;
+  current_claim?: string;
+  evidence_url?: string;
+}
+
+export interface CitationRepairChange {
+  change_type?: string;
+  target_text?: string;
+  replacement_text?: string;
+  source_url?: string;
+}
+
+/** The structured citation-repair signal the gate reads — derived from the
+ *  #407 dry-run workflow result (evidenceSummary + proposalPreview + readiness). */
+export interface CitationRepairAnalysis {
+  status: string;
+  confidence: number;
+  reason?: string;
+  totalCitations?: number;
+  flaggedCitations?: number;
+  deadLinkCitations?: number;
+  findings: CitationRepairFinding[];
+  changes: CitationRepairChange[];
+  reviewNotes: string[];
+  /** proposalPreview.review_notes — the proposal's own justification. */
+  reviewNotesText?: string;
+  validatedBeforeClaim?: boolean;
+  jobId?: string;
+  runId?: string;
+  pageTitle?: string;
+  revisionId?: string;
+}
+
+/** What the gate knows about the job it was hired for. */
+export interface CitationRepairJobDefinition {
+  taskType?: string;
+  categories?: string[];
+  jobId?: string;
+  pageTitle?: string;
+}
+
+export interface CitationRepairQualityResult {
+  verdict: CitationRepairVerdict;
+  /** FAIL reasons (empty unless verdict === "fail"). */
+  reasons: CitationRepairFailReason[];
+  /** Human-readable, per-reason explanations for the operator. */
+  notes: string[];
+  honestEmpty: boolean;
+  lowConfidence: boolean;
+}
+
+export interface CitationRepairDisposition {
+  verdict: CitationRepairVerdict;
+  /** A citation FAIL points at a concrete code target, so it IS auto-fixable. */
+  autoFixable: boolean;
+  reason: CitationRepairReason;
+  fixPrompt?: string;
+  /** Operator-facing verdict prose posted to the card. */
+  verdictText: string;
+  /** Exactly one FailureSignal on FAIL; empty otherwise. */
+  signals: FailureSignal[];
+  /** True when Layer B (the LLM) authored the verdict prose. */
+  layerBUsed: boolean;
+}
+
+/** A Hermes-attributed card comment (structurally compatible with
+ *  recordCollaborationMessage's input). */
+export interface CitationRepairCardComment {
+  author: "hermes";
+  kind: "status" | "proposal";
+  addressedTo: "operator" | "everyone";
+  relatedCorrelationId: string;
+  text: string;
+  hermesMode: "live" | "templated";
+}
+
+export interface CitationRepairDispositionDeps {
+  /** Layer B: author the verdict prose. Injected so tests need no network. */
+  llm?: (prompt: { system: string; user: string }) => Promise<string | null>;
+  /** Post the Hermes-attributed verdict to the mission card. */
+  postComment?: (comment: CitationRepairCardComment) => void;
+  /** Repo a fix would target (so L2-PR3 can route the signal). */
+  repo?: string;
+  /** Board URL for the evidence deep-link. */
+  boardUrl?: string;
+}
+
+// ── extraction ──────────────────────────────────────────────────────
+
+/**
+ * Map a raw #407 dry-run workflow result (or an already-structured analysis)
+ * into a CitationRepairAnalysis. Pure + defensive — the workflow returns a
+ * union of shapes and older runs may carry only a subset.
+ */
+export function toCitationRepairAnalysis(raw: unknown): CitationRepairAnalysis {
+  const r = isRec(raw) ? raw : {};
+  // Already a structured analysis (carries findings/changes) → normalize in place.
+  if (Array.isArray(r.findings) || Array.isArray(r.changes)) {
+    return normalizeAnalysis(r);
+  }
+  const summary = isRec(r.evidenceSummary) ? r.evidenceSummary : {};
+  const preview = isRec(r.proposalPreview) ? r.proposalPreview : {};
+  const readiness = isRec(r.readiness) ? r.readiness : {};
+  return normalizeAnalysis({
+    status: r.status,
+    confidence: r.confidence,
+    reason: r.reason,
+    totalCitations: summary.totalCitations,
+    flaggedCitations: summary.flaggedCitations,
+    deadLinkCitations: summary.deadLinkCitations,
+    findings: preview.citation_findings,
+    changes: preview.proposed_changes,
+    reviewNotes: r.reviewNotes,
+    reviewNotesText: preview.review_notes,
+    validatedBeforeClaim: readiness.validatedBeforeClaim,
+    jobId: r.jobId,
+    runId: r.runId,
+    pageTitle: preview.page_title ?? summary.pageTitle,
+    revisionId: preview.revision_id ?? summary.revisionId,
+  });
+}
+
+/** Read the structured citation analysis off a recorded mission run.
+ *  PR #407 attaches `run.result.citationRepair`; we also fall back to raw
+ *  result fields. Returns undefined when there is nothing to analyze. */
+export function citationRepairAnalysisFromRun(run: unknown): CitationRepairAnalysis | undefined {
+  const r = isRec(run) ? run : {};
+  const result = isRec(r.result) ? r.result : undefined;
+  if (!result) return undefined;
+  const block = isRec(result.citationRepair) ? result.citationRepair : undefined;
+  const source = block
+    ?? (isRec(result.proposalPreview) || isRec(result.evidenceSummary) || str(result.status) ? result : undefined);
+  if (!source) return undefined;
+  const analysis = toCitationRepairAnalysis(source);
+  return {
+    ...analysis,
+    jobId: analysis.jobId ?? str(r.jobId),
+    runId: analysis.runId ?? str(r.id),
+    pageTitle: analysis.pageTitle ?? str(r.targetUrl),
+  };
+}
+
+function normalizeAnalysis(r: Record<string, unknown>): CitationRepairAnalysis {
+  return {
+    status: (str(r.status) ?? "unknown").toLowerCase(),
+    confidence: clamp01(num(r.confidence) ?? 0),
+    ...(str(r.reason) ? { reason: str(r.reason) } : {}),
+    ...(num(r.totalCitations) !== undefined ? { totalCitations: num(r.totalCitations) } : {}),
+    ...(num(r.flaggedCitations) !== undefined ? { flaggedCitations: num(r.flaggedCitations) } : {}),
+    ...(num(r.deadLinkCitations) !== undefined ? { deadLinkCitations: num(r.deadLinkCitations) } : {}),
+    findings: arr(r.findings).map(toFinding).filter((f): f is CitationRepairFinding => f !== undefined),
+    changes: arr(r.changes).map(toChange).filter((c): c is CitationRepairChange => c !== undefined),
+    reviewNotes: strArr(r.reviewNotes),
+    ...(str(r.reviewNotesText) ? { reviewNotesText: str(r.reviewNotesText) } : {}),
+    ...(typeof r.validatedBeforeClaim === "boolean" ? { validatedBeforeClaim: r.validatedBeforeClaim } : {}),
+    ...(str(r.jobId) ? { jobId: str(r.jobId) } : {}),
+    ...(str(r.runId) ? { runId: str(r.runId) } : {}),
+    ...(str(r.pageTitle) ? { pageTitle: str(r.pageTitle) } : {}),
+    ...(str(r.revisionId) ? { revisionId: str(r.revisionId) } : {}),
+  };
+}
+
+function toFinding(value: unknown): CitationRepairFinding | undefined {
+  const r = isRec(value) ? value : undefined;
+  if (!r) return undefined;
+  return {
+    ...(str(r.section) ? { section: str(r.section) } : {}),
+    ...(str(r.problem) ? { problem: str(r.problem) } : {}),
+    ...(str(r.current_claim) ? { current_claim: str(r.current_claim) } : {}),
+    ...(str(r.evidence_url) ? { evidence_url: str(r.evidence_url) } : {}),
+  };
+}
+
+function toChange(value: unknown): CitationRepairChange | undefined {
+  const r = isRec(value) ? value : undefined;
+  if (!r) return undefined;
+  return {
+    ...(str(r.change_type) ? { change_type: str(r.change_type) } : {}),
+    ...(str(r.target_text) ? { target_text: str(r.target_text) } : {}),
+    ...(str(r.replacement_text) ? { replacement_text: str(r.replacement_text) } : {}),
+    ...(str(r.source_url) ? { source_url: str(r.source_url) } : {}),
+  };
+}
+
+// ── Layer A — deterministic quality gate ────────────────────────────
+
+/**
+ * Decide PASS / NEEDS_REVIEW / FAIL from the structured analysis alone. Pure,
+ * no LLM. This is the ONLY authority on the verdict; Layer B writes prose.
+ */
+export function citationRepairQualityGate(
+  analysis: CitationRepairAnalysis,
+  definition?: CitationRepairJobDefinition
+): CitationRepairQualityResult {
+  const status = analysis.status;
+  const lowConfidence = analysis.confidence < CITATION_REPAIR_CONFIDENCE_FLOOR;
+
+  // The workflow itself blocked/failed — a fail, but not a quality defect.
+  if (status === "blocked" || status === "failed") {
+    return {
+      verdict: "fail",
+      reasons: ["workflow_blocked"],
+      notes: [analysis.reason ? `Workflow ${status}: ${analysis.reason}` : `Workflow ${status} before producing a reviewable proposal.`],
+      honestEmpty: false,
+      lowConfidence,
+    };
+  }
+
+  const { findings, changes } = analysis;
+  const hasJustification =
+    Boolean(analysis.reviewNotesText && analysis.reviewNotesText.trim().length > 0) ||
+    analysis.reviewNotes.some((n) => n.trim().length > 0);
+  const honestEmpty = findings.length === 0 && changes.length === 0 && hasJustification;
+  const isDeadLinkJob = jobImpliesDeadLinkRepair(definition);
+
+  // TRUTH-BOUNDARY: an honest empty proposal with a justified note is a PASS.
+  // Never manufacture a defect. (Still subject to the confidence floor.)
+  if (honestEmpty) {
+    return {
+      verdict: lowConfidence ? "needs_review" : "pass",
+      reasons: [],
+      notes: lowConfidence
+        ? [`No repair proposed (justified), but confidence ${pct(analysis.confidence)} is below the ${pct(CITATION_REPAIR_CONFIDENCE_FLOOR)} floor — operator review.`]
+        : ["No dead links found and the empty result is justified — nothing to repair."],
+      honestEmpty: true,
+      lowConfidence,
+    };
+  }
+
+  const reasons: CitationRepairFailReason[] = [];
+  const notes: string[] = [];
+
+  // 1) Missed dead links: hired for dead-link repair, produced work, yet reports
+  //    zero dead-link citations — it missed the links it was hired to fix.
+  if (isDeadLinkJob && analysis.deadLinkCitations === 0) {
+    reasons.push("missed_dead_links");
+    notes.push("Dead-link repair job, but the proposal reports 0 dead-link citations while still producing findings/changes — it missed the dead links it was hired to fix.");
+  }
+
+  // 2) Garbled extraction: a claim/target is a raw mid-string slice —
+  //    unbalanced <ref>/template/brackets, or broken leading markup.
+  const garbled = [
+    ...findings.map((f) => f.current_claim),
+    ...changes.map((c) => c.target_text),
+  ].filter(isNonEmpty).filter(looksGarbled);
+  if (garbled.length > 0) {
+    reasons.push("garbled_extraction");
+    notes.push(`Extraction is garbled (unbalanced <ref>/template/brackets or broken markup): "${truncate(garbled[0]!, 120)}".`);
+  }
+
+  // 3) Live-source noise: the adapter assigns problem="weak_source" ONLY to
+  //    citations with no dead-link marker (i.e. LIVE). So a weak_source finding
+  //    on a dead-link job == flagging a live source as weak (and any change that
+  //    replaces it with an archive is archiving a live source) — noise.
+  const weakSourceFindings = findings.filter((f) => /weak[_\s-]?source/i.test(f.problem ?? ""));
+  if (isDeadLinkJob && weakSourceFindings.length > 0) {
+    reasons.push("live_source_noise");
+    const archiving = changes.some((c) => /replace/i.test(c.change_type ?? "") && isArchiveUrl(c.replacement_text) );
+    notes.push(
+      archiving
+        ? `Flags ${weakSourceFindings.length} live source(s) as weak_source and proposes replacing a live source with an archive of itself — scope-creep noise, not dead-link repair.`
+        : `Flags ${weakSourceFindings.length} live source(s) as weak_source instead of repairing dead links — false-positive noise.`
+    );
+  }
+
+  // 4) Non-applyable fix: a replacement that is prose ("Use archived source …
+  //    after editor review.") rather than applyable wikitext (<ref>…</ref> /
+  //    {{cite …}} / [http…]).
+  const nonApplyable = changes.filter(
+    (c) => /replace/i.test(c.change_type ?? "") && isNonEmpty(c.replacement_text) && isProseNotWikitext(c.replacement_text!)
+  );
+  if (nonApplyable.length > 0) {
+    reasons.push("non_applyable_fix");
+    notes.push(`replacement_text is prose, not applyable wikitext: "${truncate(nonApplyable[0]!.replacement_text!, 120)}".`);
+  }
+
+  if (reasons.length > 0) {
+    return { verdict: "fail", reasons, notes, honestEmpty: false, lowConfidence };
+  }
+  if (lowConfidence) {
+    return {
+      verdict: "needs_review",
+      reasons: [],
+      notes: [`Proposal looks clean, but confidence ${pct(analysis.confidence)} is below the ${pct(CITATION_REPAIR_CONFIDENCE_FLOOR)} floor — operator review.`],
+      honestEmpty: false,
+      lowConfidence: true,
+    };
+  }
+  return { verdict: "pass", reasons: [], notes: ["Proposal repairs dead links with applyable, coherent citations."], honestEmpty: false, lowConfidence: false };
+}
+
+function jobImpliesDeadLinkRepair(definition?: CitationRepairJobDefinition): boolean {
+  if (!definition) return true; // a citation_repair mission is, by mode, dead-link repair
+  if (definition.taskType && definition.taskType.toLowerCase() === "citation_repair") return true;
+  if ((definition.categories ?? []).some((c) => /dead[\s_-]?(external\s+)?link/i.test(c))) return true;
+  // No explicit signal either way — treat a citation-repair disposition as a
+  // dead-link job (the mode that routed here implies it).
+  return definition.taskType === undefined && (definition.categories ?? []).length === 0;
+}
+
+/** Structural-only garbled detector. Deliberately avoids "starts lowercase"
+ *  heuristics — context slices legitimately start mid-sentence, and flagging
+ *  those would manufacture defects. We only trip on unbalanced wiki delimiters
+ *  or broken leading markup, which are unambiguous. */
+export function looksGarbled(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  const openRefs = (t.match(/<ref\b/gi) ?? []).length;
+  const closeRefs = (t.match(/<\/ref\s*>/gi) ?? []).length + (t.match(/\/\s*>/g) ?? []).length;
+  if (openRefs > closeRefs) return true; // dangling <ref … >
+  if (count(t, "{{") !== count(t, "}}")) return true; // unbalanced template
+  if (count(t, "[") !== count(t, "]")) return true; // unbalanced brackets
+  if (/^(?:\}\}|\]|\||\/?>|<\/)/.test(t)) return true; // broken leading markup
+  return false;
+}
+
+/** Replacement text with no wiki markup that reads like an editor instruction
+ *  — i.e. not applyable as-is. */
+export function isProseNotWikitext(text: string): boolean {
+  const t = text.trim();
+  if (!t) return false;
+  const hasWikiMarkup = /<ref\b|<\/ref>|\{\{|\[https?:\/\/|\|\s*(url|title|website|publisher)\s*=/i.test(t);
+  if (hasWikiMarkup) return false;
+  return /\b(use|editor|review|verify|should|replace|consider|recommend|please)\b/i.test(t) || /[.!?]$/.test(t);
+}
+
+function isArchiveUrl(text?: string): boolean {
+  return Boolean(text && /web\.archive\.org\/|archive\.org\/web\//i.test(text));
+}
+
+// ── fix-spec + verdict prose ────────────────────────────────────────
+
+/**
+ * Deterministic, build-handoff fix-spec (root cause → required behavior →
+ * acceptance → tests), ALWAYS file-scoped to the adapter. Guarantees a
+ * non-empty fixPrompt for the signal regardless of the LLM.
+ */
+export function buildCitationRepairFixSpec(
+  gate: CitationRepairQualityResult,
+  analysis: CitationRepairAnalysis,
+  definition?: CitationRepairJobDefinition
+): string {
+  const page = analysis.pageTitle ?? definition?.pageTitle ?? analysis.jobId ?? "the article";
+  const rootCauses: string[] = [];
+  const required: string[] = [];
+  const acceptance: string[] = [];
+  const tests: string[] = [];
+
+  for (const reason of gate.reasons) {
+    switch (reason) {
+      case "missed_dead_links":
+        rootCauses.push("wiki-evidence.ts dead-link detection misses the article's actually-dead citations (deadLinkMarkers under-populated), so the proposal reports 0 dead links.");
+        required.push("Extend deadLinkMarkers detection in wiki-evidence.ts (url-status=dead/unfit/usurped, {{dead link}}, dead-url=yes, 404/'not found' context) and have buildWikipediaCitationRepairProposal prioritize dead-link citations.");
+        acceptance.push("A revision with known dead links yields deadLinkCitations > 0 and dead_link findings for each.");
+        tests.push("wiki-evidence unit: a fixture revision with a {{dead link}} / url-status=dead citation populates deadLinkMarkers.");
+        break;
+      case "garbled_extraction":
+        rootCauses.push("wiki-evidence.ts context extraction slices mid-<ref> / mid-template, producing current_claim/target_text that are raw mid-string fragments with unbalanced markup.");
+        required.push("Extract claim text on <ref>…</ref> (and template) BOUNDARIES only in wiki-evidence.ts — never a raw character-window slice. Balance <ref>/{{}}/[] before emitting.");
+        acceptance.push("Every current_claim / target_text has balanced <ref>/template/bracket delimiters and starts at a token boundary.");
+        tests.push("wiki-evidence unit: extraction of a citation inside a sentence returns a balanced, boundary-aligned claim.");
+        break;
+      case "live_source_noise":
+        rootCauses.push("job-workflows.ts buildWikipediaCitationRepairProposal flags every non-dead citation as problem=weak_source, so live (HTTP 200) sources get flagged/'archived' as noise on a dead-link job.");
+        required.push("Gate weak_source on actual source liveness in job-workflows.ts — do not flag a live source as weak, and do not replace a live source with an archive of itself. Scope the proposal to dead-link citations.");
+        acceptance.push("A live (200) source produces no weak_source finding and no archive-of-itself change.");
+        tests.push("job-workflows unit: an evidence bundle of all-live sources yields zero weak_source findings.");
+        break;
+      case "non_applyable_fix":
+        rootCauses.push("job-workflows.ts emits prose replacement_text ('Use archived source … after editor review.') instead of applyable wikitext.");
+        required.push("Emit applyable wikitext in replacement_text (a complete <ref>…</ref> / {{cite web …}}) in job-workflows.ts, or mark the change as flag_for_editor_review rather than a replace_citation.");
+        acceptance.push("Every replace_citation replacement_text is valid, applyable wikitext (contains <ref>/{{cite}}).");
+        tests.push("job-workflows unit: a replace_citation change's replacement_text parses as a citation template, not a sentence.");
+        break;
+      case "workflow_blocked":
+        rootCauses.push(`the citation-repair workflow ended ${analysis.status}${analysis.reason ? ` (${analysis.reason})` : ""} before producing a reviewable proposal.`);
+        required.push("Diagnose why the dry-run workflow blocked/failed (evidence fetch, schema validation, or policy) in job-workflows.ts and surface a recoverable path.");
+        acceptance.push("The same job runs to a needs_review dry-run proposal.");
+        tests.push("job-workflows unit: the blocking condition is handled or reported with a clear reason.");
+        break;
+    }
+  }
+
+  return [
+    `Fix the Averray citation-repair adapter for job ${analysis.jobId ?? "(unknown)"} (${page}).`,
+    `Files: ${ADAPTER_FILES}.`,
+    "",
+    "Root cause:",
+    ...rootCauses.map((r) => `- ${r}`),
+    "",
+    "Required behavior:",
+    ...required.map((r) => `- ${r}`),
+    "",
+    "Acceptance:",
+    ...acceptance.map((a) => `- ${a}`),
+    "",
+    "Tests:",
+    ...tests.map((t) => `- ${t}`),
+    "",
+    "Keep the change narrow and the proposal Averray-attributed (read-only; no Wikipedia edit). Do not weaken the dry-run/no-claim boundary.",
+  ].join("\n");
+}
+
+const HERMES_CITATION_PERSONA =
+  "You are Hermes, the analysis brain for an autonomous agent platform. You judge whether a Wikipedia citation-repair proposal is genuinely good — not whether it passed a permissive benchmark. Be concise, concrete, and honest: if the deterministic gate found no defect, do not invent one. Write for an operator.";
+
+export function buildHermesVerdictPrompt(
+  gate: CitationRepairQualityResult,
+  analysis: CitationRepairAnalysis,
+  definition?: CitationRepairJobDefinition
+): { system: string; user: string } {
+  const lines = [
+    `Job: ${definition?.taskType ?? "citation_repair"} on ${analysis.pageTitle ?? definition?.pageTitle ?? analysis.jobId ?? "an article"}.`,
+    `Deterministic gate verdict: ${gate.verdict.toUpperCase()}${gate.reasons.length ? ` (${gate.reasons.join(", ")})` : ""}.`,
+    `Counts: total=${analysis.totalCitations ?? "?"}, flagged=${analysis.flaggedCitations ?? "?"}, dead-link=${analysis.deadLinkCitations ?? "?"}. Confidence: ${pct(analysis.confidence)}.`,
+    "",
+    "Gate findings:",
+    ...gate.notes.map((n) => `- ${n}`),
+    "",
+    "Proposal preview:",
+    ...analysis.findings.slice(0, 5).map((f) => `- finding [${f.problem ?? "?"}]: ${truncate(f.current_claim ?? "", 140)}`),
+    ...analysis.changes.slice(0, 5).map((c) => `- change [${c.change_type ?? "?"}]: ${truncate(c.target_text ?? "", 70)} → ${truncate(c.replacement_text ?? "", 90)}`),
+    analysis.reviewNotesText ? `\nProposal review_notes: ${truncate(analysis.reviewNotesText, 200)}` : "",
+    "",
+    `Write ONE short paragraph: state the verdict (${gate.verdict}) and name the concrete defect(s) an operator must see. Do NOT change the verdict. Do not restate the fix-spec; just the verdict + defect.`,
+  ];
+  return { system: HERMES_CITATION_PERSONA, user: lines.filter((l) => l !== undefined).join("\n") };
+}
+
+export function buildDeterministicVerdictText(
+  verdict: CitationRepairVerdict,
+  gate: CitationRepairQualityResult,
+  analysis: CitationRepairAnalysis
+): string {
+  const head =
+    verdict === "pass"
+      ? "PASS — the citation-repair proposal looks good."
+      : verdict === "needs_review"
+        ? "NEEDS REVIEW — the citation-repair proposal needs an operator look."
+        : `FAIL — the citation-repair proposal is not good enough (${gate.reasons.join(", ")}).`;
+  const deadLink = analysis.deadLinkCitations !== undefined ? ` ${analysis.deadLinkCitations} dead-link citation(s),` : "";
+  const meta = `Analyzed ${analysis.totalCitations ?? "?"} citation(s);${deadLink} confidence ${pct(analysis.confidence)}.`;
+  return [head, meta, ...gate.notes].join(" ");
+}
+
+// ── signal ──────────────────────────────────────────────────────────
+
+export function buildCitationRepairFailureSignal(input: {
+  run: { id?: string; jobId?: string; targetUrl?: string };
+  analysis: CitationRepairAnalysis;
+  gate: CitationRepairQualityResult;
+  fixPrompt: string;
+  repo?: string;
+  boardUrl?: string;
+}): FailureSignal {
+  const { run, analysis, gate, fixPrompt, repo, boardUrl } = input;
+  const jobId = analysis.jobId ?? str(run.jobId);
+  const runId = analysis.runId ?? str(run.id);
+  const page = analysis.pageTitle ?? str(run.targetUrl) ?? jobId ?? runId ?? "unknown";
+  return {
+    surface: `citation-repair:${jobId ?? runId ?? "unknown"}`,
+    source: "citation_repair",
+    summary: `Citation-repair proposal for ${page} failed Hermes's quality gate: ${gate.reasons.join(", ")}.`,
+    area: CITATION_REPAIR_ADAPTER_AREA,
+    // A citation FAIL has a concrete code target (the adapter), so it is
+    // auto-fixable — unlike a browser-mission product blocker.
+    autoFixable: true,
+    fixPrompt,
+    ...(repo ? { repo } : {}),
+    ...(jobId ? { jobId } : {}),
+    ...(runId ? { runId } : {}),
+    ...(boardUrl && runId ? { evidence: `${boardUrl}?mission=${encodeURIComponent(runId)}` } : runId ? { evidence: runId } : {}),
+  };
+}
+
+// ── orchestrator ────────────────────────────────────────────────────
+
+/**
+ * The full citation-repair disposition: Layer A decides the verdict, Layer B
+ * (LLM, FAIL/needs_review only) writes the operator prose, the verdict is
+ * posted to the card, and exactly one FailureSignal is emitted on FAIL. Layer B
+ * can never overturn a deterministic PASS.
+ */
+export async function citationRepairDisposition(
+  run: { id?: string; jobId?: string; targetUrl?: string; result?: unknown },
+  definition?: CitationRepairJobDefinition,
+  deps: CitationRepairDispositionDeps = {}
+): Promise<CitationRepairDisposition> {
+  const runId = str(run.id) ?? "unknown";
+  const analysis = citationRepairAnalysisFromRun(run);
+
+  // Nothing structured to analyze → needs_review, never a fabricated FAIL.
+  if (!analysis) {
+    const verdictText =
+      "I could not analyze this citation-repair run — no structured proposal was attached to the report. Operator review before any follow-up.";
+    deps.postComment?.({ author: "hermes", kind: "status", addressedTo: "operator", relatedCorrelationId: runId, text: verdictText, hermesMode: "templated" });
+    return { verdict: "needs_review", autoFixable: false, reason: "unanalyzable", verdictText, signals: [], layerBUsed: false };
+  }
+
+  const gate = citationRepairQualityGate(analysis, definition);
+  let layerBUsed = false;
+  let verdictText: string;
+  let fixPrompt: string | undefined;
+
+  if (gate.verdict === "pass") {
+    verdictText = buildDeterministicVerdictText("pass", gate, analysis);
+  } else {
+    // Layer B is invoked ONLY for fail/needs_review. The deterministic,
+    // file-scoped fix-spec is the signal payload (always non-empty).
+    fixPrompt = buildCitationRepairFixSpec(gate, analysis, definition);
+    let prose: string | null = null;
+    if (deps.llm) {
+      try {
+        prose = await deps.llm(buildHermesVerdictPrompt(gate, analysis, definition));
+      } catch {
+        prose = null;
+      }
+    }
+    layerBUsed = Boolean(prose && prose.trim().length > 0);
+    // Layer B writes prose; it MUST NOT overturn Layer A's verdict.
+    const proseText = layerBUsed ? prose!.trim() : buildDeterministicVerdictText(gate.verdict, gate, analysis);
+    verdictText = `${proseText}\n\nProposed fix-spec (Codex):\n${fixPrompt}`;
+  }
+
+  deps.postComment?.({
+    author: "hermes",
+    kind: gate.verdict === "fail" ? "proposal" : "status",
+    addressedTo: "operator",
+    relatedCorrelationId: runId,
+    text: verdictText,
+    hermesMode: layerBUsed ? "live" : "templated",
+  });
+
+  const signals =
+    gate.verdict === "fail"
+      ? [buildCitationRepairFailureSignal({ run, analysis, gate, fixPrompt: fixPrompt!, ...(deps.repo ? { repo: deps.repo } : {}), ...(deps.boardUrl ? { boardUrl: deps.boardUrl } : {}) })]
+      : [];
+
+  const reason: CitationRepairReason =
+    gate.verdict === "fail" ? gate.reasons[0]! : gate.verdict === "needs_review" ? "low_confidence" : "clean";
+
+  return {
+    verdict: gate.verdict,
+    autoFixable: gate.verdict === "fail",
+    reason,
+    ...(fixPrompt ? { fixPrompt } : {}),
+    verdictText,
+    signals,
+    layerBUsed,
+  };
+}
+
+// ── defensive readers ───────────────────────────────────────────────
+
+function isRec(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+function arr(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+function isNonEmpty(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+function strArr(value: unknown): string[] {
+  return arr(value).map((v) => (typeof v === "string" ? v.trim() : "")).filter((v) => v.length > 0);
+}
+function num(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+function truncate(text: string, max: number): string {
+  const t = text.trim();
+  return t.length <= max ? t : `${t.slice(0, max - 1)}…`;
+}
+function pct(value: number): string {
+  return `${Math.round(value * 100)}%`;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -130,6 +130,7 @@ import {
   applyHermesMemoryInfluence,
   generateHermesBoardNarration,
   generateHermesReply,
+  requestHermesCompletion,
 } from "./monitor-hermes-voice.js";
 import {
   approveCodexTask,
@@ -163,6 +164,8 @@ import {
   testbedMissionReportValidationCoaching,
   testbedMissionResultCoaching,
   testbedMissionSelfHealingDisposition,
+  citationRepairDisposition,
+  type CitationRepairJobDefinition,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
 import {
@@ -1571,7 +1574,62 @@ function recordTestbedMissionReportValidationCollaboration(
   }
 }
 
+// L2-PR2 — a citation-repair mission is not a browser/product run; route it to
+// Hermes's quality-aware disposition (Layer A gate + Layer B verdict prose),
+// which posts the verdict to the card and emits a FailureSignal on FAIL. We do
+// NOT dispatch here — L2-PR3 wires the signal into self-healing. Fire-and-forget
+// so report ingestion never blocks on the LLM.
+function surfaceCitationRepairDisposition(run: TestbedMissionRun): void {
+  const apiKey = optionalEnv("OLLAMA_API_KEY");
+  const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
+  const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";
+  const fixRepo = optionalEnv("B2_SELF_HEALING_REPO") || optionalEnv("GITHUB_DEFAULT_REPO");
+  const definition: CitationRepairJobDefinition = {
+    taskType: "citation_repair",
+    ...(run.jobId ? { jobId: run.jobId } : {}),
+    ...(run.targetUrl ? { pageTitle: run.targetUrl } : {}),
+  };
+  const llm = apiKey
+    ? (prompt: { system: string; user: string }) =>
+      requestHermesCompletion(
+        { messages: [{ role: "system", content: prompt.system }, { role: "user", content: prompt.user }], maxTokens: 600, temperature: 0.4 },
+        { apiKey, baseUrl, model, runId: run.id, taskId: run.id }
+      )
+    : undefined;
+  void citationRepairDisposition(run, definition, {
+    ...(llm ? { llm } : {}),
+    ...(fixRepo ? { repo: fixRepo } : {}),
+    postComment: (comment) => {
+      recordCollaborationMessage({
+        author: comment.author,
+        kind: comment.kind,
+        addressedTo: comment.addressedTo,
+        relatedCorrelationId: comment.relatedCorrelationId,
+        text: comment.text,
+        hermesMode: comment.hermesMode,
+      });
+    },
+  })
+    .then((disposition) => {
+      recordHermesMemoryNote({ text: `Citation-repair ${run.id}: ${disposition.verdict} (${disposition.reason}).`, relatedCorrelationId: run.id });
+      // Emit-only: the signal is available for L2-PR3 to collect; we log it here
+      // for visibility but never dispatch a fix from this PR.
+      for (const signal of disposition.signals) {
+        logger.info({ missionId: run.id, jobId: signal.jobId, area: signal.area, reasons: disposition.reason }, "citation_repair_failure_signal_emitted");
+      }
+    })
+    .catch((error) => {
+      logger.warn({ err: error, missionId: run.id }, "citation_repair_disposition_failed");
+    });
+}
+
 function recordTestbedMissionReportCollaboration(run: TestbedMissionRun): void {
+  // Citation-repair runs are analyzed by Hermes's quality gate, not the
+  // browser-mission product coaching below.
+  if (run.mode === "citation_repair") {
+    surfaceCitationRepairDisposition(run);
+    return;
+  }
   try {
     const verdict = typeof run.result?.verdict === "string" ? run.result.verdict : run.status;
     recordHermesMemoryNote({

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -168,8 +168,30 @@ export interface HermesOwnerAsk {
 
 let llmUsageDebugLogged = false;
 
-export async function generateHermesReply(
-  context: HermesReplyContext,
+/** One chat turn fed to the model. */
+export interface HermesCompletionMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+/** Knobs for a single completion (the answer-shaping params that vary per call). */
+export interface HermesCompletionRequest {
+  messages: HermesCompletionMessage[];
+  maxTokens?: number;
+  temperature?: number;
+}
+
+/**
+ * The single Hermes LLM transport: POST to the OpenAI-compatible
+ * `/chat/completions`, log usage, and extract the reply text (incl. the
+ * DeepSeek `reasoning` fallback via extractReplyText). Returns the raw reply
+ * text or null on any failure (no key, non-200, timeout, empty). This is the
+ * ONE place that talks to the model — generateHermesReply / board narration
+ * and the citation-repair verdict all funnel through it, so there is never a
+ * second LLM client. Callers apply their own post-processing on the text.
+ */
+export async function requestHermesCompletion(
+  request: HermesCompletionRequest,
   options: GenerateHermesReplyOptions
 ): Promise<string | null> {
   if (!options.apiKey) return null;
@@ -181,13 +203,10 @@ export async function generateHermesReply(
 
   const body = {
     model,
-    messages: [
-      { role: "system", content: HERMES_PERSONA },
-      { role: "user", content: buildUserPrompt(context) },
-    ],
+    messages: request.messages,
     stream: false,
-    max_tokens: 220,
-    temperature: 0.7,
+    max_tokens: request.maxTokens ?? 220,
+    temperature: request.temperature ?? 0.7,
     // Keep the token budget on the answer, not chain-of-thought (ollama.com/v1).
     reasoning_effort: options.reasoningEffort ?? "low",
   };
@@ -220,8 +239,7 @@ export async function generateHermesReply(
       ...(options.taskId ? { taskId: options.taskId } : {}),
       result: json,
     }, options);
-    const text = extractReplyText(json);
-    return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
+    return extractReplyText(json);
   } catch {
     return null;
   } finally {
@@ -230,66 +248,40 @@ export async function generateHermesReply(
   }
 }
 
+export async function generateHermesReply(
+  context: HermesReplyContext,
+  options: GenerateHermesReplyOptions
+): Promise<string | null> {
+  const text = await requestHermesCompletion(
+    {
+      messages: [
+        { role: "system", content: HERMES_PERSONA },
+        { role: "user", content: buildUserPrompt(context) },
+      ],
+      maxTokens: 220,
+      temperature: 0.7,
+    },
+    options
+  );
+  return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
+}
+
 export async function generateHermesBoardNarration(
   context: HermesBoardNarrationContext,
   options: GenerateHermesReplyOptions
 ): Promise<string | null> {
-  if (!options.apiKey) return null;
-  const baseUrl = options.baseUrl.replace(/\/+$/, "");
-  const url = `${baseUrl}/chat/completions`;
-  const model = options.model ?? "deepseek-v4-pro:cloud";
-  const timeoutMs = options.timeoutMs ?? 6_000;
-  const fetchImpl = options.fetchFn ?? fetch;
-
-  const body = {
-    model,
-    messages: [
-      { role: "system", content: HERMES_PERSONA },
-      { role: "user", content: buildBoardNarrationPrompt(context) },
-    ],
-    stream: false,
-    max_tokens: 180,
-    temperature: 0.65,
-    // Keep the token budget on the answer, not chain-of-thought (ollama.com/v1).
-    reasoning_effort: options.reasoningEffort ?? "low",
-  };
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const endLlmUsageCall = beginLlmUsageCall({
-    agent: "hermes",
-    model,
-    ...(options.runId ? { runId: options.runId } : {}),
-    ...(options.taskId ? { taskId: options.taskId } : {}),
-  });
-  try {
-    const response = await fetchImpl(url, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${options.apiKey}`,
-      },
-      body: JSON.stringify(body),
-      signal: controller.signal,
-    });
-    if (!response.ok) return null;
-    const json = await response.json().catch(() => null) as unknown;
-    maybeLogHermesUsageShape(json);
-    await recordHermesLlmUsage({
-      agent: "hermes",
-      model,
-      ...(options.runId ? { runId: options.runId } : {}),
-      ...(options.taskId ? { taskId: options.taskId } : {}),
-      result: json,
-    }, options);
-    const text = extractReplyText(json);
-    return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-    endLlmUsageCall();
-  }
+  const text = await requestHermesCompletion(
+    {
+      messages: [
+        { role: "system", content: HERMES_PERSONA },
+        { role: "user", content: buildBoardNarrationPrompt(context) },
+      ],
+      maxTokens: 180,
+      temperature: 0.65,
+    },
+    options
+  );
+  return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
 }
 
 export function buildUserPrompt(context: HermesReplyContext): string {

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -9,6 +9,25 @@ import {
   type TestbedMissionMutationMode,
 } from "./testbed-mutation-binding.js";
 
+// L2-PR2 — the quality-aware disposition for citation-repair missions (the
+// citation analogue of testbedMissionSelfHealingDisposition below). It lives in
+// its own module (heavy + LLM-touching); re-exported here so this file stays
+// the single entry point for mission dispositions.
+export {
+  citationRepairDisposition,
+  citationRepairQualityGate,
+  citationRepairAnalysisFromRun,
+  toCitationRepairAnalysis,
+  buildCitationRepairFailureSignal,
+  type CitationRepairDisposition,
+  type CitationRepairDispositionDeps,
+  type CitationRepairAnalysis,
+  type CitationRepairJobDefinition,
+  type CitationRepairQualityResult,
+  type CitationRepairVerdict,
+  type CitationRepairFailReason,
+} from "./citation-repair-disposition.js";
+
 const MAX_MISSION_RUNS = 50;
 
 export type TestbedMissionStatus = "requested" | "ready" | "running" | "completed" | "failed";

--- a/services/slack-operator/src/self-healing.ts
+++ b/services/slack-operator/src/self-healing.ts
@@ -26,7 +26,16 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 
 export type HealingRiskTier = "high" | "low";
-export type HealingSource = "testbed_mission" | "post_deploy_verification" | "ci_main" | "ops_health";
+export type HealingSource =
+  | "testbed_mission"
+  | "post_deploy_verification"
+  | "ci_main"
+  | "ops_health"
+  // L2: a Hermes-analyzed citation-repair mission whose proposal failed the
+  // deterministic quality gate (missed dead links, garbled extraction, live-
+  // source noise, non-applyable fix). Unlike a browser mission, this points at
+  // a concrete code target (the citation-repair adapter), so it is auto-fixable.
+  | "citation_repair";
 
 export interface FailureSignal {
   /** Stable per-surface key for dedup + cooldown, e.g. "testbed:sweep-7". */
@@ -48,6 +57,10 @@ export interface FailureSignal {
   nonAutoFixableReason?: string;
   /** Source-specific prompt with enough context for a code agent to act. */
   fixPrompt?: string;
+  /** citation_repair: the Wikipedia job whose repair failed the quality gate. */
+  jobId?: string;
+  /** citation_repair: the analysis run id (for evidence/audit). */
+  runId?: string;
 }
 
 export interface HealingClassification {
@@ -207,6 +220,7 @@ function humanSource(source: HealingSource): string {
     case "post_deploy_verification": return "post-deploy verification";
     case "ci_main": return "CI on main";
     case "ops_health": return "ops-health check";
+    case "citation_repair": return "citation-repair mission";
   }
 }
 

--- a/services/slack-operator/src/testbed-citation-mission.ts
+++ b/services/slack-operator/src/testbed-citation-mission.ts
@@ -17,6 +17,7 @@ import {
 import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
 import type { TestbedMissionRun } from "./monitor-testbed-missions.js";
 import type { TestbedMissionRunResult, TestbedMissionRunnerConfig } from "./testbed-mission-runner.js";
+import { toCitationRepairAnalysis, type CitationRepairAnalysis } from "./citation-repair-disposition.js";
 
 export interface CitationRepairMissionDeps {
   /** Injected for tests; defaults to the real workflow. */
@@ -40,6 +41,11 @@ interface CitationRepairMissionReport {
   recommendations: string[];
   evidence: string[];
   summary: string;
+  /** L2: the structured citation-repair signal, preserved so Hermes's
+   *  disposition (citationRepairDisposition) can read the REAL fields
+   *  (counts, findings, changes) instead of re-parsing the evidence strings.
+   *  Survives ingestion into run.result via the report spread. */
+  citationRepair?: CitationRepairAnalysis;
 }
 
 export async function executeCitationRepairMission(
@@ -138,6 +144,8 @@ export function citationRepairResultToReport(result: Record<string, unknown>): C
     recommendations: reviewNotes,
     evidence,
     summary,
+    // Preserve the structured signal for Hermes's downstream quality gate.
+    citationRepair: toCitationRepairAnalysis(result),
   };
 }
 

--- a/test/unit/citation-repair-disposition.test.ts
+++ b/test/unit/citation-repair-disposition.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  citationRepairQualityGate,
+  citationRepairDisposition,
+  toCitationRepairAnalysis,
+  type CitationRepairAnalysis,
+  type CitationRepairCardComment,
+  type CitationRepairJobDefinition,
+} from "../../services/slack-operator/src/citation-repair-disposition.js";
+
+const CITATION_JOB: CitationRepairJobDefinition = {
+  taskType: "citation_repair",
+  categories: ["dead external links"],
+  jobId: "wiki-en-62871101",
+};
+
+// A clean baseline structured analysis; override per case to isolate one defect.
+function analysis(over: Partial<CitationRepairAnalysis> = {}): CitationRepairAnalysis {
+  return {
+    status: "needs_review",
+    confidence: 0.72,
+    totalCitations: 9,
+    flaggedCitations: 4,
+    deadLinkCitations: 2,
+    findings: [{ problem: "dead_link", current_claim: "The tower opened in 1889." }],
+    changes: [{ change_type: "replace_citation", target_text: "The tower opened in 1889.", replacement_text: "<ref>{{cite web|url=https://x|title=y}}</ref>" }],
+    reviewNotes: ["note"],
+    reviewNotesText: "Repaired the dead link with an archived copy.",
+    jobId: "wiki-en-62871101",
+    runId: "run-1",
+    pageTitle: "Eiffel Tower",
+    ...over,
+  };
+}
+
+// ── Layer A — deterministic quality gate, one FAIL reason at a time ──
+
+describe("citationRepairQualityGate — FAIL reasons", () => {
+  it("FAILs missed_dead_links: dead-link job, work produced, but 0 dead-link citations", () => {
+    const g = citationRepairQualityGate(
+      analysis({
+        deadLinkCitations: 0,
+        findings: [{ problem: "dead_link", current_claim: "The tower opened in 1889." }],
+        changes: [{ change_type: "flag_for_editor_review", target_text: "The tower opened in 1889.", replacement_text: "<ref>{{cite web|url=https://x|title=y}}</ref>" }],
+      }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("fail");
+    expect(g.reasons).toContain("missed_dead_links");
+    expect(g.reasons).not.toContain("live_source_noise");
+    expect(g.reasons).not.toContain("garbled_extraction");
+  });
+
+  it("FAILs garbled_extraction: a claim with a dangling <ref> (unbalanced markup)", () => {
+    const g = citationRepairQualityGate(
+      analysis({
+        findings: [{ problem: "dead_link", current_claim: "opened in 1889 <ref name=foo" }],
+        changes: [{ change_type: "flag_for_editor_review", target_text: "opened", replacement_text: "<ref>{{cite}}</ref>" }],
+      }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("fail");
+    expect(g.reasons).toContain("garbled_extraction");
+    expect(g.reasons).not.toContain("missed_dead_links"); // deadLinkCitations is 2
+  });
+
+  it("FAILs live_source_noise: flags a live source as weak_source on a dead-link job", () => {
+    const g = citationRepairQualityGate(
+      analysis({
+        findings: [{ problem: "weak_source", current_claim: "The company is reputable." }],
+        changes: [{ change_type: "flag_for_editor_review", target_text: "The company is reputable.", replacement_text: "<ref>{{cite web|url=https://x|title=y}}</ref>" }],
+      }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("fail");
+    expect(g.reasons).toContain("live_source_noise");
+    expect(g.reasons).not.toContain("non_applyable_fix");
+  });
+
+  it("FAILs non_applyable_fix: a replace_citation whose replacement is prose, not wikitext", () => {
+    const g = citationRepairQualityGate(
+      analysis({
+        findings: [{ problem: "dead_link", current_claim: "The bridge was built in 1930." }],
+        changes: [{ change_type: "replace_citation", target_text: "The bridge was built in 1930.", replacement_text: "Editor should verify and replace this citation with a reliable source." }],
+      }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("fail");
+    expect(g.reasons).toContain("non_applyable_fix");
+  });
+
+  it("FAILs workflow_blocked when the dry-run never produced a proposal", () => {
+    const g = citationRepairQualityGate(
+      analysis({ status: "blocked", reason: "pre-claim validation failed", findings: [], changes: [] }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("fail");
+    expect(g.reasons).toEqual(["workflow_blocked"]);
+  });
+});
+
+describe("citationRepairQualityGate — PASS / NEEDS_REVIEW", () => {
+  it("TRUTH-BOUNDARY: an honest empty proposal with a justified note is a PASS (no manufactured defect)", () => {
+    const g = citationRepairQualityGate(
+      analysis({
+        deadLinkCitations: 0,
+        flaggedCitations: 0,
+        findings: [],
+        changes: [],
+        reviewNotesText: "Checked all citations; every external link resolves (HTTP 200) with no dead-link markers. No repair needed.",
+        reviewNotes: ["No dead links found; all sources live."],
+        confidence: 0.8,
+      }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("pass");
+    expect(g.reasons).toEqual([]);
+    expect(g.honestEmpty).toBe(true);
+  });
+
+  it("a clean repair (dead links fixed, applyable wikitext) at healthy confidence is a PASS", () => {
+    const g = citationRepairQualityGate(analysis(), CITATION_JOB);
+    expect(g.verdict).toBe("pass");
+    expect(g.reasons).toEqual([]);
+  });
+
+  it("a clean proposal below the confidence floor is NEEDS_REVIEW, not FAIL", () => {
+    const g = citationRepairQualityGate(analysis({ confidence: 0.5 }), CITATION_JOB);
+    expect(g.verdict).toBe("needs_review");
+    expect(g.reasons).toEqual([]);
+    expect(g.lowConfidence).toBe(true);
+  });
+
+  it("an honest-empty but low-confidence run is NEEDS_REVIEW", () => {
+    const g = citationRepairQualityGate(
+      analysis({ findings: [], changes: [], deadLinkCitations: 0, confidence: 0.4, reviewNotesText: "No dead links found." }),
+      CITATION_JOB
+    );
+    expect(g.verdict).toBe("needs_review");
+    expect(g.honestEmpty).toBe(true);
+  });
+});
+
+// ── The known-defective fixture (acceptance #1) ─────────────────────
+
+// wiki-en-62871101-citation-repair-hash-r3 — a raw #407 dry-run result that
+// missed the dead links, sliced a garbled mid-<ref> claim, flagged a live
+// source as weak, and proposed prose no editor can apply.
+const DEFECTIVE_RAW = {
+  status: "needs_review",
+  dryRun: true,
+  runId: "wiki-en-62871101-citation-repair-hash-r3",
+  jobId: "wiki-en-62871101",
+  confidence: 0.62,
+  evidenceSummary: { pageTitle: "Acme Corporation", revisionId: "62871101", totalCitations: 9, flaggedCitations: 4, deadLinkCitations: 0 },
+  proposalPreview: {
+    page_title: "Acme Corporation",
+    revision_id: "62871101",
+    citation_findings: [
+      { section: "References", problem: "weak_source", current_claim: "ounded in 1999 by a group of engineers <ref name=acme", evidence_url: "https://example.com/live-source" },
+    ],
+    proposed_changes: [
+      { change_type: "replace_citation", target_text: "ounded in 1999", replacement_text: "Use archived source https://web.archive.org/web/2020/https://example.com/live-source after editor review.", source_url: "https://web.archive.org/web/2020/https://example.com/live-source" },
+    ],
+    review_notes: "Averray-attributed proposal only.",
+  },
+  readiness: { validatedBeforeClaim: true },
+  reviewNotes: ["Editor should verify the archived copy."],
+};
+
+function defectiveRun() {
+  return {
+    id: "wiki-en-62871101-citation-repair-hash-r3",
+    jobId: "wiki-en-62871101",
+    targetUrl: "https://en.wikipedia.org/wiki/Acme_Corporation",
+    result: DEFECTIVE_RAW,
+  };
+}
+
+describe("citationRepairDisposition — defective fixture", () => {
+  it("FAILs with missed_dead_links + garbled_extraction + live_source_noise", () => {
+    const g = citationRepairQualityGate(toCitationRepairAnalysis(DEFECTIVE_RAW), CITATION_JOB);
+    expect(g.verdict).toBe("fail");
+    expect(g.reasons).toContain("missed_dead_links");
+    expect(g.reasons).toContain("garbled_extraction");
+    expect(g.reasons).toContain("live_source_noise");
+  });
+
+  it("posts a Hermes verdict whose fix-spec points at wiki-evidence.ts + job-workflows.ts", async () => {
+    const posted: CitationRepairCardComment[] = [];
+    const disposition = await citationRepairDisposition(defectiveRun(), CITATION_JOB, {
+      llm: async () => "FAIL — the proposal missed the dead links, sliced a garbled claim, and flagged a live source.",
+      postComment: (c) => posted.push(c),
+      repo: "depre-dev/averray-reference-agent",
+    });
+
+    expect(disposition.verdict).toBe("fail");
+    expect(disposition.layerBUsed).toBe(true);
+    expect(posted).toHaveLength(1);
+    const text = posted[0]!.text;
+    expect(posted[0]!.author).toBe("hermes");
+    expect(posted[0]!.hermesMode).toBe("live");
+    expect(text).toContain("wiki-evidence.ts");
+    expect(text).toContain("job-workflows.ts");
+  });
+
+  it("emits exactly one FailureSignal with the citation_repair shape and a non-empty fixPrompt", async () => {
+    const disposition = await citationRepairDisposition(defectiveRun(), CITATION_JOB, {
+      llm: async () => "FAIL.",
+      repo: "depre-dev/averray-reference-agent",
+      boardUrl: "https://board.example",
+    });
+    expect(disposition.signals).toHaveLength(1);
+    const signal = disposition.signals[0]!;
+    expect(signal.source).toBe("citation_repair");
+    expect(signal.area).toBe("citation-repair-adapter");
+    expect(signal.jobId).toBe("wiki-en-62871101");
+    expect(signal.runId).toBe("wiki-en-62871101-citation-repair-hash-r3");
+    expect(signal.autoFixable).toBe(true);
+    expect(signal.repo).toBe("depre-dev/averray-reference-agent");
+    expect(signal.fixPrompt && signal.fixPrompt.length).toBeGreaterThan(0);
+    expect(signal.fixPrompt).toContain("wiki-evidence.ts");
+    expect(signal.fixPrompt).toContain("job-workflows.ts");
+  });
+});
+
+// ── Layer B can't overturn a deterministic PASS ─────────────────────
+
+const HONEST_EMPTY_RAW = {
+  status: "needs_review",
+  dryRun: true,
+  runId: "wiki-en-clean-r1",
+  jobId: "wiki-en-clean",
+  confidence: 0.8,
+  evidenceSummary: { pageTitle: "Clean Page", revisionId: "1", totalCitations: 5, flaggedCitations: 0, deadLinkCitations: 0 },
+  proposalPreview: {
+    page_title: "Clean Page",
+    revision_id: "1",
+    citation_findings: [],
+    proposed_changes: [],
+    review_notes: "Checked all 5 citations; every external link resolves (HTTP 200) with no dead-link markers. No repair needed.",
+  },
+  readiness: { validatedBeforeClaim: true },
+  reviewNotes: ["No dead links found; all sources live."],
+};
+
+describe("Layer B may not flip a PASS to FAIL", () => {
+  it("an honest empty PASS stays PASS even when the LLM screams FAIL — and emits no signal", async () => {
+    const posted: CitationRepairCardComment[] = [];
+    let llmCalled = false;
+    const disposition = await citationRepairDisposition(
+      { id: "wiki-en-clean-r1", jobId: "wiki-en-clean", result: HONEST_EMPTY_RAW },
+      CITATION_JOB,
+      {
+        llm: async () => {
+          llmCalled = true;
+          return "THIS RUN IS A CATASTROPHIC FAILURE. Mark it FAIL and open a fix.";
+        },
+        postComment: (c) => posted.push(c),
+        repo: "depre-dev/averray-reference-agent",
+      }
+    );
+
+    expect(disposition.verdict).toBe("pass");
+    expect(disposition.signals).toEqual([]);
+    expect(disposition.autoFixable).toBe(false);
+    // Layer B isn't even consulted on a PASS, so it cannot manufacture a defect.
+    expect(llmCalled).toBe(false);
+    expect(posted).toHaveLength(1);
+    expect(posted[0]!.hermesMode).toBe("templated");
+    expect(posted[0]!.text.startsWith("PASS")).toBe(true);
+  });
+});
+
+describe("citationRepairDisposition — unanalyzable run", () => {
+  it("returns needs_review (never a fabricated FAIL) when no structured proposal is attached", async () => {
+    const posted: CitationRepairCardComment[] = [];
+    const disposition = await citationRepairDisposition(
+      { id: "run-x", jobId: "job-x", result: {} },
+      CITATION_JOB,
+      { postComment: (c) => posted.push(c) }
+    );
+    expect(disposition.verdict).toBe("needs_review");
+    expect(disposition.reason).toBe("unanalyzable");
+    expect(disposition.signals).toEqual([]);
+    expect(posted).toHaveLength(1);
+  });
+});
+
+// ── structured block survives a PR-1 report round-trip ──────────────
+
+describe("toCitationRepairAnalysis", () => {
+  it("extracts counts, findings, and changes from a raw dry-run result", () => {
+    const a = toCitationRepairAnalysis(DEFECTIVE_RAW);
+    expect(a.deadLinkCitations).toBe(0);
+    expect(a.totalCitations).toBe(9);
+    expect(a.findings).toHaveLength(1);
+    expect(a.findings[0]!.problem).toBe("weak_source");
+    expect(a.changes[0]!.change_type).toBe("replace_citation");
+    expect(a.jobId).toBe("wiki-en-62871101");
+    expect(a.runId).toBe("wiki-en-62871101-citation-repair-hash-r3");
+  });
+
+  it("is idempotent on an already-structured analysis (the run.result.citationRepair block)", () => {
+    const once = toCitationRepairAnalysis(DEFECTIVE_RAW);
+    const twice = toCitationRepairAnalysis(once);
+    expect(twice.deadLinkCitations).toBe(0);
+    expect(twice.findings).toHaveLength(1);
+    expect(twice.changes[0]!.replacement_text).toContain("archived source");
+  });
+});


### PR DESCRIPTION
## What

**L2-PR2** — the citation-repair analogue of `testbedMissionSelfHealingDisposition`. Browser missions get an auto-disposition; citation-repair runs (added in #407) didn't — an operator had to eyeball the proposal. This adds the quality-aware **"analyzed by Hermes"** brain. A run can pass the permissive platform benchmark and still be a **FAIL** because it missed the real dead links, sliced a garbled mid-`<ref>` claim, flagged a live source as weak, or proposed prose no editor can apply.

## Two layers (new module `citation-repair-disposition.ts`)

**Layer A — `citationRepairQualityGate(analysis, definition)`** — cheap, deterministic, no LLM, over the *real* #407 fields. It alone decides PASS / NEEDS_REVIEW / FAIL:
- `missed_dead_links` — dead-link job, work produced, but `deadLinkCitations === 0` (missed what it was hired to fix).
- `garbled_extraction` — a `current_claim`/`target_text` with unbalanced `<ref>`/template/brackets or broken leading markup. **Structural only** — I deliberately avoid a "starts lowercase" heuristic, since the adapter's `current_claim` is a mid-sentence context slice and flagging those would manufacture defects.
- `live_source_noise` — the adapter assigns `problem: "weak_source"` *only* to citations with no dead-link marker (i.e. live), so a `weak_source` finding on a dead-link job **is** flagging a live source as weak.
- `non_applyable_fix` — a `replace_citation` whose `replacement_text` is prose ("Use archived source … after editor review."), not applyable wikitext.
- `workflow_blocked`; and `confidence < 0.7` → at least `needs_review`.

> **TRUTH-BOUNDARY (critical):** an honest empty proposal (`citation_findings: []`) with a justified `review_notes` is a **PASS**. We never manufacture a defect to create work. (Verified by test.)

**Layer B — Hermes's own LLM** (reused `monitor-hermes-voice` transport) authors the operator-facing verdict prose, invoked **only** for fail/needs_review. It **cannot overturn a deterministic PASS** — on a PASS it isn't even consulted. The deterministic, build-handoff **fix-spec** (root cause → required behavior → acceptance → tests) is always file-scoped to `packages/averray-mcp/src/wiki-evidence.ts` (`<ref>`/citation extraction) + `job-workflows.ts` (`buildWikipediaCitationRepairProposal`), so the signal's `fixPrompt` is always non-empty and points at the adapter.

## Other changes

- **`self-healing.ts`** — extend `FailureSignal` with `source: "citation_repair"` + optional `jobId`/`runId`: the exact shape **L2-PR3** will consume. On FAIL the disposition emits **exactly one** `FailureSignal` (`autoFixable: true` — a concrete code target, unlike a browser-mission product blocker). **This PR does NOT dispatch.**
- **`monitor-hermes-voice.ts`** — extract `requestHermesCompletion`, the single LLM transport (POST + usage logging + `extractReplyText`, incl. the DeepSeek `reasoning` fallback). `generateHermesReply` / board narration now funnel through it → **no second LLM client**. No behavior change (all 41 existing voice tests pass).
- **`testbed-citation-mission.ts`** (#407) — attach a structured `citationRepair` block to the emitted report so the raw fields (counts, findings, changes) survive into `run.result` for the gate to read. Additive; the flattened evidence strings are unchanged.
- **`monitor-testbed-missions.ts`** — re-export the disposition + analysis accessor (single entry point for mission dispositions).
- **`index.ts`** — on citation_repair report ingestion, route to `surfaceCitationRepairDisposition`: runs the disposition with the real OLLAMA-bound LLM, posts the Hermes-attributed verdict to the card, and **logs (does not dispatch)** the signal. Browser-mission coaching untouched.

## Acceptance

- ✅ The known-defective `wiki-en-62871101-citation-repair-hash-r3` output → **FAIL** with `missed_dead_links` + `garbled_extraction` + `live_source_noise`, a Hermes-authored verdict on the card, and a fix-spec pointing at `wiki-evidence.ts` + `job-workflows.ts`.
- ✅ A synthetic honest `citation_findings: []` run → **PASS**, no signal.
- ✅ A FAIL emits **exactly one** `FailureSignal` with a non-empty `fixPrompt`.
- ✅ Layer B can't flip a PASS to FAIL (asserted; LLM not consulted on PASS).

## Tests (no network — LLM injected)

Layer-A gate per FAIL reason; honest-empty PASS; clean PASS; low-confidence → needs_review; the defective fixture end-to-end (verdict + card post + signal shape); Layer-B-can't-overturn-PASS; unanalyzable run → needs_review/no signal; `toCitationRepairAnalysis` extraction + idempotency.

## Verification

- `tsc -b packages/* services/*` — clean
- `vitest run` — **1503 passing** (incl. self-healing 40, monitor-testbed-missions 20, monitor-hermes-voice 41 — no regression to browser-mission disposition)
- `@avg/monitor-ui` vite build — clean

## Note on file scope

The spec named `monitor-testbed-missions.ts (+ a small analysis module)`, but its other requirements forced minimal, additive touches to four more files, each justified: `self-healing.ts` (define the signal shape against the *real* `FailureSignal`, not a fork), `monitor-hermes-voice.ts` (reuse the LLM path with no second client), `testbed-citation-mission.ts` (preserve the structured fields the gate reads), and `index.ts` (post the verdict to the card). No chain/settlement code; no dispatch (L2-PR3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)