### PR TITLE
feat(self-healing): route citation-repair FAILs to a proposed fix task + re-run to close

### DIFF
--- a/packages/averray-mcp/src/dispatch-routing.ts
+++ b/packages/averray-mcp/src/dispatch-routing.ts
@@ -64,6 +64,28 @@ const CLAUDE_SURFACES: SurfaceGroup[] = [
   { surface: "MCP tooling", keywords: ["mcp tool", "tool ergonomics", "tool schema"] },
 ];
 
+// Averray adapter logic (L2: the Wikipedia citation-repair adapter). Codex owns
+// correctness-sensitive adapter code, but it is REVERSIBLE app logic in this
+// repo — low risk. Keeping it low-risk is deliberate: a high-risk classification
+// escalates-only and never reaches the operator's approve button, but a
+// self-healing citation fix is meant to be PROPOSED for approval. Checked before
+// the high-risk surfaces so an incidental word in the fix-spec (e.g. "policy")
+// can't bump a citation-adapter task to high-risk.
+const ADAPTER_SURFACES: SurfaceGroup[] = [
+  {
+    surface: "citation-repair adapter",
+    keywords: [
+      "citation-repair-adapter",
+      "citation repair adapter",
+      "wiki-evidence.ts",
+      "job-workflows.ts",
+      "citation extractor",
+      "citation findings",
+      "buildwikipediacitationrepairproposal",
+    ],
+  },
+];
+
 const SPECIALIST_SURFACES: SurfaceGroup[] = [
   { surface: "tests", keywords: ["test", "tests", "spec", "vitest", "coverage", "test-writing", "playwright"] },
 ];
@@ -110,6 +132,18 @@ export function classifyTask(input: RoutingInput): RoutingDecision {
       agent: "security",
       riskTier: "high",
       reason: `${securitySurface} → security specialist, high-risk/operator-reviewed`,
+    };
+  }
+
+  // Reversible adapter logic → codex, low-risk (so it can be proposed, not just
+  // escalated). Checked before high-risk so the fix-spec's incidental keywords
+  // don't misroute a citation-adapter task.
+  const adapterSurface = firstSurface(haystack, ADAPTER_SURFACES);
+  if (adapterSurface) {
+    return {
+      agent: "codex",
+      riskTier: "low",
+      reason: `${adapterSurface} → codex, low-risk (reversible adapter logic)`,
     };
   }
 

--- a/services/slack-operator/src/citation-repair-disposition.ts
+++ b/services/slack-operator/src/citation-repair-disposition.ts
@@ -596,6 +596,114 @@ export async function citationRepairDisposition(
   };
 }
 
+// ── L2-PR3 — self-healing bridge (sync, no LLM) ─────────────────────
+
+export interface CitationRepairSignalOptions {
+  /** Repo a fix would target — required for the signal to be routable. */
+  repo?: string;
+  /** Board URL for the evidence deep-link. */
+  boardUrl?: string;
+  /** Override the derived job definition (taskType/categories). */
+  definition?: CitationRepairJobDefinition;
+}
+
+/**
+ * Synchronously derive the FailureSignal for a FAILED citation-repair run — the
+ * shape the B2 self-healing scan feeds to runSelfHealingOnce. Returns undefined
+ * unless Layer A's verdict is FAIL (a PASS / needs_review / unanalyzable run
+ * never dispatches). No LLM: the verdict prose was already posted at ingestion
+ * (L2-PR2); here we only need the deterministic, file-scoped fix-spec as the
+ * task prompt.
+ */
+export function citationRepairSignalFromRun(
+  run: { id?: string; jobId?: string; targetUrl?: string; result?: unknown },
+  options: CitationRepairSignalOptions = {}
+): FailureSignal | undefined {
+  const analysis = citationRepairAnalysisFromRun(run);
+  if (!analysis) return undefined;
+  const jobId = analysis.jobId ?? str(run.jobId);
+  const pageTitle = analysis.pageTitle ?? str(run.targetUrl);
+  const definition: CitationRepairJobDefinition =
+    options.definition ?? {
+      taskType: "citation_repair",
+      ...(jobId ? { jobId } : {}),
+      ...(pageTitle ? { pageTitle } : {}),
+    };
+  const gate = citationRepairQualityGate(analysis, definition);
+  if (gate.verdict !== "fail") return undefined;
+  const fixPrompt = buildCitationRepairFixSpec(gate, analysis, definition);
+  return buildCitationRepairFailureSignal({
+    run,
+    analysis,
+    gate,
+    fixPrompt,
+    ...(options.repo ? { repo: options.repo } : {}),
+    ...(options.boardUrl ? { boardUrl: options.boardUrl } : {}),
+  });
+}
+
+/** correlationId stamped on a citation self-heal task:
+ *  `self-heal:${source}:${surface}` = `self-heal:citation_repair:citation-repair:<jobId>`. */
+export const CITATION_REPAIR_SELF_HEAL_CORRELATION_PREFIX = "self-heal:citation_repair:";
+
+/** Recover the originating jobId from a citation self-heal task's correlationId. */
+export function citationRepairJobIdFromCorrelation(correlationId?: string): string | undefined {
+  if (!correlationId || !correlationId.startsWith(CITATION_REPAIR_SELF_HEAL_CORRELATION_PREFIX)) return undefined;
+  const marker = "citation-repair:";
+  const idx = correlationId.lastIndexOf(marker);
+  if (idx < 0) return undefined;
+  const jobId = correlationId.slice(idx + marker.length).trim();
+  return jobId.length > 0 ? jobId : undefined;
+}
+
+export interface CitationRepairRerunTask {
+  id: string;
+  status: string;
+  correlationId?: string;
+  completedAt?: string;
+}
+export interface CitationRepairRerunRun {
+  jobId?: string;
+  mode?: string;
+  createdAt?: string;
+}
+export interface CitationRepairRerunDecision {
+  jobId: string;
+  taskId: string;
+}
+
+/**
+ * Close-the-loop: decide which citation-repair jobs to RE-RUN. For each
+ * COMPLETED citation self-heal task, re-run its job (so the card re-runs and
+ * flips to PASS if the adapter fix worked) — UNLESS a citation_repair mission
+ * for that job was already created at/after the task completed (idempotent: the
+ * re-run we just spawned blocks the next tick). Keyed by jobId. Honors the B2
+ * relief valve: returns nothing when self-healing is disabled.
+ */
+export function decideCitationRepairReruns(input: {
+  tasks: ReadonlyArray<CitationRepairRerunTask>;
+  runs: ReadonlyArray<CitationRepairRerunRun>;
+  enabled?: boolean;
+}): CitationRepairRerunDecision[] {
+  if (input.enabled === false) return [];
+  const decisions: CitationRepairRerunDecision[] = [];
+  const seen = new Set<string>();
+  for (const task of input.tasks) {
+    if (task.status !== "completed" || !task.completedAt) continue;
+    const jobId = citationRepairJobIdFromCorrelation(task.correlationId);
+    if (!jobId || seen.has(jobId)) continue;
+    const completedMs = Date.parse(task.completedAt);
+    if (!Number.isFinite(completedMs)) continue;
+    const alreadyReran = input.runs.some(
+      (r) => r.mode === "citation_repair" && r.jobId === jobId && Boolean(r.createdAt) && Date.parse(r.createdAt!) >= completedMs
+    );
+    if (alreadyReran) continue;
+    seen.add(jobId);
+    decisions.push({ jobId, taskId: task.id });
+  }
+  return decisions;
+}
+
 // ── defensive readers ───────────────────────────────────────────────
 
 function isRec(value: unknown): value is Record<string, unknown> {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -154,6 +154,7 @@ import {
   diagnoseTestbedMissionReportFromMessage,
   dismissRequestedTestbedMissionRun,
   failedTestbedMissionsForSelfHealing,
+  failedCitationRepairRunsForSelfHealing,
   listTestbedMissionRuns,
   readTestbedMissionRunnerHeartbeat,
   recordTestbedMissionIssueOpened,
@@ -165,6 +166,8 @@ import {
   testbedMissionResultCoaching,
   testbedMissionSelfHealingDisposition,
   citationRepairDisposition,
+  citationRepairSignalFromRun,
+  decideCitationRepairReruns,
   type CitationRepairJobDefinition,
   type TestbedMissionRun,
 } from "./monitor-testbed-missions.js";
@@ -2634,6 +2637,26 @@ async function collectSelfHealingSignals(boardUrl: string): Promise<FailureSigna
   }
 
   try {
+    // L2-PR3 — citation-repair FAILs flow through the SAME self-healing stream.
+    // The Layer-A gate is deterministic (no LLM here); the verdict prose was
+    // already posted at ingestion (L2-PR2). A FAIL carries the file-scoped
+    // fix-spec as the task prompt and routes (area "citation-repair-adapter") to
+    // Codex at low risk, so runSelfHealingOnce PROPOSES an operator-gated task.
+    const citationRuns = failedCitationRepairRunsForSelfHealing(listTestbedMissionRuns({ limit: 25 }), {
+      maxAgeHours: routineConfig.selfHealing.testbedFailureMaxAgeHours,
+    });
+    for (const run of citationRuns) {
+      const signal = citationRepairSignalFromRun(run, {
+        ...(fixRepo ? { repo: fixRepo } : {}),
+        boardUrl,
+      });
+      if (signal) signals.push(signal);
+    }
+  } catch (error) {
+    logger.warn({ err: error }, "b2_collect_citation_signals_failed");
+  }
+
+  try {
     const monitor = await getHandoffMonitor({ limit: 50, activeWindowMinutes: 24 * 60 });
     for (const c of monitor.recent ?? []) {
       const failed = c.status === "failed" || c.status === "blocked";
@@ -2656,6 +2679,30 @@ async function collectSelfHealingSignals(boardUrl: string): Promise<FailureSigna
   }
 
   return signals;
+}
+
+// L2-PR3 — close the loop. When a citation self-healing fix task COMPLETES,
+// re-run the citation_repair mission for that job (read-only dry-run analysis)
+// so the card re-runs and, if the adapter fix worked, flips to PASS and closes.
+// Keyed by jobId; idempotent (the re-run we spawn blocks the next tick). Honors
+// the relief valve via the `enabled` gate. Poll-based — the next B2 tick after
+// completion triggers it; the runners (claude/codex) only call completeCodexTask.
+async function reconcileCitationRepairReruns(): Promise<void> {
+  try {
+    const tasks = await listCodexTasks();
+    const runs = listTestbedMissionRuns({ limit: 50 });
+    const decisions = decideCitationRepairReruns({
+      tasks,
+      runs,
+      enabled: routineConfig.selfHealing.enabled,
+    });
+    for (const decision of decisions) {
+      createMonitorTestbedMissionFromPayload({ mode: "citation_repair", jobId: decision.jobId, initialStatus: "ready" });
+      logger.info({ jobId: decision.jobId, taskId: decision.taskId }, "citation_repair_rerun_after_fix");
+    }
+  } catch (error) {
+    logger.warn({ err: error }, "citation_repair_rerun_reconcile_failed");
+  }
 }
 
 // O4-PR3b — run a freshly-proposed task through the autopilot gate. Returns the
@@ -3328,6 +3375,8 @@ function startOperatorRoutines() {
       if (acted.length > 0) {
         logger.info({ handled: acted }, "b2_self_healing_acted");
       }
+      // Close the loop: re-run citation_repair missions whose fix task completed.
+      await reconcileCitationRepairReruns();
     } catch (error) {
       logger.error({ err: error }, "b2_self_healing_failed");
     } finally {

--- a/services/slack-operator/src/monitor-testbed-missions.ts
+++ b/services/slack-operator/src/monitor-testbed-missions.ts
@@ -19,6 +19,10 @@ export {
   citationRepairAnalysisFromRun,
   toCitationRepairAnalysis,
   buildCitationRepairFailureSignal,
+  // L2-PR3 — self-healing bridge (sync signal + close-the-loop re-run).
+  citationRepairSignalFromRun,
+  citationRepairJobIdFromCorrelation,
+  decideCitationRepairReruns,
   type CitationRepairDisposition,
   type CitationRepairDispositionDeps,
   type CitationRepairAnalysis,
@@ -26,6 +30,7 @@ export {
   type CitationRepairQualityResult,
   type CitationRepairVerdict,
   type CitationRepairFailReason,
+  type CitationRepairRerunDecision,
 } from "./citation-repair-disposition.js";
 
 const MAX_MISSION_RUNS = 50;
@@ -389,6 +394,41 @@ export function failedTestbedMissionsForSelfHealing(
   }
 
   return Array.from(latestBySurface.values())
+    .filter((run) => run.status === "failed")
+    .filter((run) => {
+      const failedMs = missionFailedMs(run);
+      return Number.isFinite(failedMs) && nowMs - failedMs <= maxAgeMs;
+    })
+    .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+    .map((run) => cloneRun(run));
+}
+
+/**
+ * L2-PR3 — the citation-repair analogue of failedTestbedMissionsForSelfHealing.
+ * Collect the latest FAILED citation-repair run PER JOB (deduped on jobId, not
+ * the per-run id, so re-runs of the same job collapse to one self-healing
+ * surface instead of swarming the queue), within the freshness window. The
+ * caller converts each into a FailureSignal (citationRepairSignalFromRun).
+ */
+export function failedCitationRepairRunsForSelfHealing(
+  runs: readonly TestbedMissionRun[],
+  options: SelfHealingTestbedMissionFilterOptions = {},
+): TestbedMissionRun[] {
+  const nowMs = (options.now ?? new Date()).getTime();
+  const maxAgeHours = Math.max(1, options.maxAgeHours ?? 72);
+  const maxAgeMs = maxAgeHours * 60 * 60 * 1000;
+  const latestByJob = new Map<string, TestbedMissionRun>();
+
+  for (const run of runs) {
+    if (run.mode !== "citation_repair") continue;
+    const key = run.jobId ?? run.id;
+    const current = latestByJob.get(key);
+    if (!current || missionUpdatedMs(run) > missionUpdatedMs(current)) {
+      latestByJob.set(key, run);
+    }
+  }
+
+  return Array.from(latestByJob.values())
     .filter((run) => run.status === "failed")
     .filter((run) => {
       const failedMs = missionFailedMs(run);

--- a/test/unit/citation-repair-self-healing.test.ts
+++ b/test/unit/citation-repair-self-healing.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyTask } from "../../packages/averray-mcp/src/dispatch-routing.js";
+import {
+  runSelfHealingOnce,
+  selfHealingTargetSignature,
+  type FailureSignal,
+  type SelfHealingDeps,
+} from "../../services/slack-operator/src/self-healing.js";
+import {
+  citationRepairSignalFromRun,
+  citationRepairJobIdFromCorrelation,
+  decideCitationRepairReruns,
+  failedCitationRepairRunsForSelfHealing,
+} from "../../services/slack-operator/src/monitor-testbed-missions.js";
+
+// A raw #410 dry-run result that FAILs the gate (0 dead links + weak_source +
+// garbled <ref> + prose replacement). Attached as run.result the way PR #407 does.
+const DEFECTIVE_RAW = {
+  status: "needs_review",
+  runId: "wiki-en-62871101-citation-repair-hash-r3",
+  jobId: "wiki-en-62871101",
+  confidence: 0.62,
+  evidenceSummary: { pageTitle: "Acme Corporation", totalCitations: 9, flaggedCitations: 4, deadLinkCitations: 0 },
+  proposalPreview: {
+    page_title: "Acme Corporation",
+    citation_findings: [{ problem: "weak_source", current_claim: "ounded in 1999 <ref name=acme", evidence_url: "https://example.com/live" }],
+    proposed_changes: [{ change_type: "replace_citation", target_text: "ounded in 1999", replacement_text: "Use archived source after editor review.", source_url: "https://example.com/live" }],
+    review_notes: "Averray-attributed proposal only.",
+  },
+  reviewNotes: ["Editor should verify."],
+};
+
+function citationRun(over: Record<string, unknown> = {}) {
+  return {
+    id: "run-cr-1",
+    jobId: "wiki-en-62871101",
+    mode: "citation_repair",
+    status: "failed",
+    targetUrl: "https://en.wikipedia.org/wiki/Acme_Corporation",
+    createdAt: "2026-06-01T10:00:00.000Z",
+    updatedAt: "2026-06-01T10:05:00.000Z",
+    failedAt: "2026-06-01T10:05:00.000Z",
+    history: [],
+    mission: {},
+    result: DEFECTIVE_RAW,
+    ...over,
+  } as never;
+}
+
+const REPO = "depre-dev/averray-reference-agent";
+
+// ── routing ─────────────────────────────────────────────────────────
+
+describe("classifyTask — citation-repair adapter routing", () => {
+  it("routes area=citation-repair-adapter → codex, low risk (proposable, not escalate-only)", () => {
+    const r = classifyTask({ repo: REPO, area: "citation-repair-adapter", prompt: "Fix the adapter in wiki-evidence.ts and job-workflows.ts." });
+    expect(r.agent).toBe("codex");
+    expect(r.riskTier).toBe("low");
+  });
+
+  it("an incidental high-risk word in the fix-spec does NOT bump a citation task to high-risk", () => {
+    // "policy" is a treasury/policy high-risk keyword; the adapter surface wins
+    // because it's checked first, so the task stays proposable (low risk).
+    const r = classifyTask({ repo: REPO, area: "citation-repair-adapter", prompt: "Diagnose the schema validation or policy path in job-workflows.ts." });
+    expect(r.agent).toBe("codex");
+    expect(r.riskTier).toBe("low");
+  });
+
+  it("does not regress: a genuine settlement task is still high-risk codex", () => {
+    const r = classifyTask({ repo: REPO, prompt: "Fix the on-chain settlement escrow payout." });
+    expect(r.riskTier).toBe("high");
+    expect(r.agent).toBe("codex");
+  });
+});
+
+// ── collectors ──────────────────────────────────────────────────────
+
+describe("failedCitationRepairRunsForSelfHealing", () => {
+  it("returns only the latest FAILED citation-repair run per jobId; ignores non-citation + non-failed", () => {
+    const runs = [
+      citationRun({ id: "old", updatedAt: "2026-06-01T09:00:00.000Z", failedAt: "2026-06-01T09:00:00.000Z" }),
+      citationRun({ id: "new", updatedAt: "2026-06-01T10:05:00.000Z" }),
+      citationRun({ id: "other-job", jobId: "wiki-en-99", updatedAt: "2026-06-01T10:01:00.000Z", failedAt: "2026-06-01T10:01:00.000Z" }),
+      citationRun({ id: "completed", jobId: "wiki-en-ok", status: "completed", failedAt: undefined }),
+      { id: "browser", mode: "surface_sweep", status: "failed", targetUrl: "https://app", updatedAt: "2026-06-01T10:02:00.000Z", failedAt: "2026-06-01T10:02:00.000Z" } as never,
+    ];
+    const out = failedCitationRepairRunsForSelfHealing(runs, { now: new Date("2026-06-01T11:00:00.000Z") });
+    const ids = out.map((r) => r.id).sort();
+    expect(ids).toEqual(["new", "other-job"]); // deduped to latest per job, citation+failed only
+  });
+});
+
+describe("citationRepairSignalFromRun", () => {
+  it("builds a routable citation_repair FailureSignal for a FAILED run", () => {
+    const signal = citationRepairSignalFromRun(citationRun(), { repo: REPO, boardUrl: "https://board.example" });
+    expect(signal).toBeDefined();
+    expect(signal!.source).toBe("citation_repair");
+    expect(signal!.area).toBe("citation-repair-adapter");
+    expect(signal!.autoFixable).toBe(true);
+    expect(signal!.repo).toBe(REPO);
+    expect(signal!.jobId).toBe("wiki-en-62871101");
+    expect(signal!.fixPrompt).toContain("wiki-evidence.ts");
+    expect(signal!.fixPrompt).toContain("job-workflows.ts");
+  });
+
+  it("returns undefined for a run that is not a FAIL (no dispatch from a clean run)", () => {
+    const cleanRaw = {
+      status: "needs_review",
+      jobId: "wiki-en-clean",
+      confidence: 0.8,
+      evidenceSummary: { totalCitations: 5, flaggedCitations: 0, deadLinkCitations: 0 },
+      proposalPreview: { citation_findings: [], proposed_changes: [], review_notes: "All 5 links resolve (200). No repair needed." },
+      reviewNotes: ["No dead links found."],
+    };
+    expect(citationRepairSignalFromRun(citationRun({ jobId: "wiki-en-clean", result: cleanRaw }), { repo: REPO })).toBeUndefined();
+  });
+});
+
+// ── signal → proposed task (operator-gated, no auto-execute) ─────────
+
+interface Captured {
+  agent: string;
+  riskTier: string;
+  prompt: string;
+  targetSignature: string;
+  correlationId: string;
+}
+
+function healDeps(signals: FailureSignal[], over: Partial<SelfHealingDeps> = {}): { deps: SelfHealingDeps; proposed: Captured[]; alerts: number } {
+  const proposed: Captured[] = [];
+  const state = { alerts: 0 };
+  const deps: SelfHealingDeps = {
+    getSignals: () => signals,
+    isSuspended: () => false,
+    isHalt: () => false,
+    classify: (s) =>
+      classifyTask({ ...(s.repo ? { repo: s.repo } : {}), prompt: s.summary, ...(s.area ? { area: s.area } : {}) }),
+    hasOpenFixTask: () => false,
+    proposalsToday: () => 0,
+    maxProposalsPerDay: 10,
+    openFixCount: () => 0,
+    maxOpenFixTasks: 3,
+    maxProposalsPerTick: 10,
+    inCooldown: () => false,
+    markHandled: () => {},
+    propose: async ({ signal, targetSignature, agent, riskTier, prompt }) => {
+      proposed.push({ agent, riskTier, prompt, targetSignature, correlationId: `self-heal:${targetSignature}` });
+      return { taskId: `task-${targetSignature}` };
+    },
+    alert: async () => {
+      state.alerts += 1;
+      return true;
+    },
+    audit: async () => {},
+    boardUrl: "https://board.example",
+    now: () => new Date("2026-06-01T11:00:00.000Z"),
+    ...over,
+  };
+  return { deps, proposed, get alerts() { return state.alerts; } };
+}
+
+describe("citation FAIL → self-healing dispatch", () => {
+  it("proposes ONE operator-gated Codex task whose prompt is the fix-spec — no auto-execute", async () => {
+    const signal = citationRepairSignalFromRun(citationRun(), { repo: REPO })!;
+    const h = healDeps([signal]);
+    const result = await runSelfHealingOnce(h.deps);
+
+    expect(h.proposed).toHaveLength(1);
+    expect(h.proposed[0]!.agent).toBe("codex");
+    expect(h.proposed[0]!.riskTier).toBe("low");
+    expect(h.proposed[0]!.prompt).toContain("wiki-evidence.ts");
+    expect(h.proposed[0]!.prompt).toContain("job-workflows.ts");
+    // The only action is "propose" — runSelfHealingOnce never approves or executes.
+    expect(result.handled[0]).toMatchObject({ action: "propose" });
+    expect(h.alerts).toBe(0);
+    // correlationId encodes the jobId so the loop can re-run the right mission.
+    expect(h.proposed[0]!.correlationId).toBe("self-heal:citation_repair:citation-repair:wiki-en-62871101");
+    expect(selfHealingTargetSignature(signal)).toBe("citation_repair:citation-repair:wiki-en-62871101");
+  });
+
+  it("relief valve: while autopilot is suspended, a citation FAIL escalates — it does NOT dispatch", async () => {
+    const signal = citationRepairSignalFromRun(citationRun(), { repo: REPO })!;
+    const h = healDeps([signal], { isSuspended: () => true });
+    const result = await runSelfHealingOnce(h.deps);
+    expect(h.proposed).toHaveLength(0);
+    expect(result.handled[0]).toMatchObject({ action: "escalate" });
+  });
+});
+
+// ── close the loop (re-run keyed by jobId) ──────────────────────────
+
+describe("citationRepairJobIdFromCorrelation", () => {
+  it("recovers the jobId from a citation self-heal correlationId", () => {
+    expect(citationRepairJobIdFromCorrelation("self-heal:citation_repair:citation-repair:wiki-en-62871101")).toBe("wiki-en-62871101");
+  });
+  it("returns undefined for a non-citation correlationId", () => {
+    expect(citationRepairJobIdFromCorrelation("self-heal:testbed_mission:testbed:app/x")).toBeUndefined();
+    expect(citationRepairJobIdFromCorrelation(undefined)).toBeUndefined();
+  });
+});
+
+describe("decideCitationRepairReruns", () => {
+  const completedTask = {
+    id: "task-1",
+    status: "completed",
+    correlationId: "self-heal:citation_repair:citation-repair:wiki-en-62871101",
+    completedAt: "2026-06-02T12:00:00.000Z",
+  };
+
+  it("re-runs the citation_repair mission for the jobId when the fix task completes", () => {
+    const out = decideCitationRepairReruns({ tasks: [completedTask], runs: [], enabled: true });
+    expect(out).toEqual([{ jobId: "wiki-en-62871101", taskId: "task-1" }]);
+  });
+
+  it("is idempotent: a re-run mission created after completion suppresses further re-runs", () => {
+    const out = decideCitationRepairReruns({
+      tasks: [completedTask],
+      runs: [{ jobId: "wiki-en-62871101", mode: "citation_repair", createdAt: "2026-06-02T12:00:30.000Z" }],
+      enabled: true,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("ignores non-completed tasks and non-citation correlationIds", () => {
+    const out = decideCitationRepairReruns({
+      tasks: [
+        { ...completedTask, status: "running" },
+        { id: "t2", status: "completed", correlationId: "self-heal:testbed_mission:testbed:x", completedAt: "2026-06-02T12:00:00.000Z" },
+      ],
+      runs: [],
+      enabled: true,
+    });
+    expect(out).toEqual([]);
+  });
+
+  it("relief valve: returns nothing when self-healing is disabled", () => {
+    expect(decideCitationRepairReruns({ tasks: [completedTask], runs: [], enabled: false })).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

**L2-PR3** — wire L2-PR2's (#410) `citation_repair` `FailureSignal` into the **existing** self-healing dispatch stream so a failed citation-repair card produces an **operator-gated** Codex fix task, and re-runs to close once the fix lands. The fix is a normal code PR in this repo (`wiki-evidence.ts` / `job-workflows.ts`), so it reuses the same machine as browser missions — no new task protocol.

`failedTestbedMissionsForSelfHealing → collectSelfHealingSignals → runSelfHealingOnce → proposeCodexTask`, gated by `classifyTask` + `evaluateDispatchPolicy` (unchanged).

## Changes

- **`monitor-testbed-missions.ts`** — `failedCitationRepairRunsForSelfHealing()` mirrors the browser collector: latest FAILED citation-repair run **per jobId** (dedup on jobId, not the per-run id, so re-runs don't swarm the queue), within the freshness window.
- **`citation-repair-disposition.ts`** — `citationRepairSignalFromRun()` synchronously (no LLM — the verdict prose was posted at ingestion in #410) derives the `FailureSignal` for a FAILED run, carrying the Layer-B **file-scoped fix-spec** as the task prompt and `area: "citation-repair-adapter"`. Returns `undefined` for PASS / needs_review / unanalyzable (a clean run never dispatches). Plus `citationRepairJobIdFromCorrelation` + `decideCitationRepairReruns` (pure, enabled-gated) for the close-the-loop.
- **`dispatch-routing.ts`** — a `citation-repair adapter` surface group (`citation-repair-adapter`, `wiki-evidence.ts`, `job-workflows.ts`, "citation extractor", …) → **codex, LOW risk**. Checked **before** the high-risk surfaces so an incidental fix-spec word (e.g. "policy") can't bump it to high-risk; low risk is deliberate so the fix is **proposed** (high-risk escalates-only and never reaches the operator's approve button). Security still wins first; `evaluateDispatchPolicy` untouched.
- **`index.ts`** — gather citation signals in `collectSelfHealingSignals` alongside testbed/deploy signals (same enabled-gated, cooldown/dedup/budget-guarded routine). **Operator-gated** — `runSelfHealingOnce` PROPOSES; nothing auto-approves or auto-executes during burn-in.
- **Close the loop** — `reconcileCitationRepairReruns()` (called in the B2 tick, after the enabled gate) re-runs the `citation_repair` mission for a job whose fix task **completed** — keyed by jobId parsed from the task `correlationId` (`self-heal:citation_repair:citation-repair:<jobId>`), idempotent (a re-run created at/after completion blocks the next tick). The re-run is a read-only dry-run analysis (`initialStatus: "ready"`), so the card re-runs and flips to PASS if the adapter fix worked.

## Acceptance

- ✅ A FAILED citation-repair card → a **proposed** Codex task whose prompt is #410's fix-spec, awaiting operator approval (not auto-run; `action: "propose"`, no execute hook).
- ✅ Subject to the existing dispatch budget / allowlist / cooldown / open-fix guardrails (reused `runSelfHealingOnce`).
- ✅ On task completion, the `citation_repair` mission for that jobId re-runs automatically (next B2 tick) and the card reflects the new verdict.
- ✅ With `B2_SELF_HEALING_ENABLED=0`, no citation-repair dispatch occurs (collect + reconcile sit behind the same gate; `decideCitationRepairReruns({enabled:false})` → `[]`).

## Tests (no fs/network)

Routing (area→codex/low; incidental high-risk word doesn't bump it; settlement still high-risk); `failedCitationRepairRunsForSelfHealing` dedup/filter; signal builder (FAIL→routable signal, clean→undefined); signal → **one** proposed Codex task with prompt = fix-spec, `action: "propose"` (no auto-execute), correlationId encodes the jobId; relief valve (suspended → escalate, not dispatch); close-the-loop re-run keyed by jobId + idempotent + disabled-flag suppression; jobId correlation parsing.

## Verification

- `tsc -b packages/* services/*` — clean
- `vitest run` — **1517 passing** (self-healing 40 + new citation self-healing 14; no regression to browser-mission self-healing — same code path, additive)
- `@avg/monitor-ui` vite build — clean

## Constraints honored

Reuses `self-healing.ts` / `dispatch-routing.ts` / `dispatch-policy.ts` / `codex-task-queue.ts` (no parallel dispatch path); operator-gated (proposes, never auto-executes); no chain/settlement; browser-mission self-healing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)