### PR TITLE
fix(monitor): improve action lane and Hermes rail readability

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -31,6 +31,17 @@ describe("Card — type coverage", () => {
     expect(view.queryByText("Send back to Codex")).toBeNull();
   });
 
+  test("cards classified into needs-attention get the action treatment even if isAction is missing", () => {
+    const card = {
+      ...fixture("agent #547"),
+      lane: "needs-attention",
+      isAction: false,
+      waitingOn: { actor: "operator", tone: "warn" },
+    } as BoardCard;
+    const { container } = render(<Card card={card} />);
+    expect(container.querySelector(".hm-card--action")).toBeTruthy();
+  });
+
   test("mission card renders its summary and checks bar", () => {
     const { container } = render(<Card card={fixture("mission browser-onboard-04")} />);
     const view = within(container);

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -109,7 +109,7 @@ export function Card({
   onOpenMissionIssue,
   onKeepWatching,
 }: CardProps) {
-  const isAction = Boolean(card.isAction);
+  const isAction = laneFor(card) === "needs-attention";
   const isStale = card.state === "stale";
   const isClosed = card.type === "done";
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -137,7 +137,9 @@ describe("CoPilotRail", () => {
       />,
       { wrapper },
     );
-    expect(getByText(/Proposed Codex work for Repair failed mission/)).toBeTruthy();
+    const activityText = getByText(/Proposed Codex work for Repair failed mission/);
+    expect(activityText).toBeTruthy();
+    expect(activityText.closest(".hm-turn-body")).toBeTruthy();
     expect(getAllByText(/narration/).length).toBeGreaterThan(0);
     fireEvent.click(getByRole("button", { name: "Open referenced card task-activity-1" }));
     expect(onCardClick).toHaveBeenCalledWith("task-activity-1");

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -328,12 +328,12 @@ body { margin: 0; }
    ============================================================ */
 .hm-main {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 440px;
+  grid-template-columns: minmax(0, 1fr) clamp(440px, 24vw, 560px);
   min-height: 0;
   overflow: hidden;
 }
 .hm-main--hermes-wide {
-  grid-template-columns: 1fr 540px;
+  grid-template-columns: minmax(0, 1fr) clamp(520px, 30vw, 640px);
 }
 
 /* ============================================================
@@ -988,8 +988,11 @@ body { margin: 0; }
 .hm-lane--focus { flex: 4 1 0; min-width: 520px; background: var(--hm-paper); }
 .hm-lane--action { border-color: var(--hm-amber-ring); }
 .hm-lane--action.hm-lane--expanded {
-  flex: 1.45 0 410px;
-  min-width: 390px;
+  flex: 1.36 0 420px;
+  min-width: 410px;
+  background:
+    linear-gradient(180deg, rgba(250, 236, 214, 0.58) 0, rgba(255, 253, 247, 0.92) 168px),
+    var(--hm-paper);
 }
 .hm-lane--action::before {
   content: ""; position: absolute; inset: 0 0 auto 0; height: 3px;
@@ -1112,6 +1115,10 @@ body { margin: 0; }
   scrollbar-width: thin;
   scrollbar-color: var(--hm-line) transparent;
 }
+.hm-lane--action .hm-lane-body {
+  padding: 12px;
+  gap: 10px;
+}
 .hm-lane-body::-webkit-scrollbar { width: 6px; }
 .hm-lane-body::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
 
@@ -1165,22 +1172,21 @@ body { margin: 0; }
 
 /* Action-needed card */
 .hm-card--action {
-  background: var(--hm-amber-wash);
+  background:
+    linear-gradient(90deg, rgba(250, 236, 214, 0.92) 0, rgba(255, 253, 247, 0.96) 54px),
+    var(--hm-paper);
   border-color: var(--hm-amber-ring);
-  box-shadow: var(--hm-shadow-action);
-  animation: hm-action-breathe 3.4s ease-in-out infinite;
-}
-@keyframes hm-action-breathe {
-  0%, 100% { box-shadow: 0 0 0 1px var(--hm-amber-ring), 0 12px 28px rgba(167,97,34,0.16); }
-  50%      { box-shadow: 0 0 0 1px var(--hm-amber-ring), 0 16px 38px rgba(167,97,34,0.26); }
+  box-shadow: 0 1px 0 rgba(167,97,34,0.08), 0 8px 22px rgba(167,97,34,0.08);
 }
 .hm-card--action::before {
   content: "";
   position: absolute;
-  left: 0; top: 12px; bottom: 12px;
-  width: 3px;
-  border-radius: 0 3px 3px 0;
+  left: 0; top: 0; bottom: 0;
+  width: 4px;
   background: var(--hm-amber);
+}
+.hm-card--action:hover {
+  box-shadow: 0 1px 0 rgba(167,97,34,0.10), 0 12px 26px rgba(167,97,34,0.12);
 }
 
 /* Card pieces */
@@ -1795,7 +1801,7 @@ body { margin: 0; }
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid var(--hm-line-soft);
-  background: linear-gradient(180deg, rgba(250, 248, 241, 0.92), var(--hm-paper));
+  background: linear-gradient(180deg, rgba(250, 248, 241, 0.96), var(--hm-paper-2));
   overflow: hidden;
 }
 .hm-activity-head {
@@ -1815,7 +1821,8 @@ body { margin: 0; }
 .hm-activity-stream {
   flex: 1;
   min-height: 0;
-  padding-top: 12px;
+  padding: 12px 14px 14px;
+  gap: 12px;
 }
 .hm-activity-row {
   width: 100%;
@@ -1878,17 +1885,24 @@ button.hm-activity-row:hover {
 /* Hermes turn (card-stream) */
 .hm-turn {
   display: grid;
-  gap: 9px;
-  padding: 11px 12px;
+  gap: 8px;
+  padding: 12px 14px;
   border-radius: var(--hm-radius);
   background: var(--hm-paper);
   border: 1px solid rgba(47, 43, 37, 0.11);
-  box-shadow: 0 8px 22px rgba(47, 43, 37, 0.045);
-  font-size: 12.5px;
+  box-shadow: 0 6px 18px rgba(47, 43, 37, 0.035);
+  font-size: 13px;
   line-height: 1.55;
   min-width: 0;
   overflow: hidden;
 }
+.hm-activity-stream .hm-turn {
+  border-left: 4px solid var(--hm-line-strong);
+}
+.hm-activity-stream .hm-turn--activity-info { border-left-color: var(--hm-hermes); }
+.hm-activity-stream .hm-turn--activity-action { border-left-color: var(--hm-amber); }
+.hm-activity-stream .hm-turn--activity-success { border-left-color: var(--hm-sage); }
+.hm-activity-stream .hm-turn--activity-warning { border-left-color: var(--hm-clay); }
 .hm-turn-head {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -1949,7 +1963,9 @@ button.hm-activity-row:hover {
 }
 
 .hm-turn-body {
-  color: var(--hm-ink-soft);
+  color: var(--hm-ink);
+  font-size: 13px;
+  line-height: 1.5;
   min-width: 0;
   overflow-wrap: anywhere;
   word-break: break-word;


### PR DESCRIPTION
## What changed
- Make card action styling follow the canonical lane classification via `laneFor(card) === "needs-attention"`, so cards promoted into Needs attention do not render with stale/non-action treatment.
- Calm and widen the Needs attention visual treatment: lighter action cards, persistent amber left rail, and a little more lane spacing.
- Improve Hermes co-pilot/activity readability by widening the right rail at large viewports and increasing activity card/body contrast and spacing.
- Add regression coverage for lane-classified action styling and activity text rendering.

## Checks
- `npm run typecheck`
- `npm --workspace @avg/monitor-ui run build`
- `npm --workspace @avg/monitor-ui test`
- `npm test`
- Local browser smoke against `http://127.0.0.1:5173/`

## Surface
- Monitor UI only.
- No backend, runner, ops, secrets, or deployment config changes.
