### PR TITLE
feat(monitor): add Citation Repair flow to the board mission launcher

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -29,7 +29,7 @@ import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionA
 import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonomyMode.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import type { BoardCard, CreateTaskInput } from "./lib/monitor/card-types.js";
-import type { MissionSpawnInput, SaveTestSuiteInput } from "./lib/monitor/mission-launch.js";
+import { missionLaunchBody, type MissionSpawnInput, type SaveTestSuiteInput } from "./lib/monitor/mission-launch.js";
 import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
@@ -225,15 +225,7 @@ function defaultSpawnMission(input: MissionSpawnInput): void {
 }
 
 function missionSpawnBody(input: MissionSpawnInput): Record<string, unknown> {
-  if (typeof input === "string") return { targetUrl: input };
-  const body: Record<string, unknown> = {
-    targetUrl: input.targetUrl,
-    mode: input.mode,
-    freshMemory: input.freshMemory,
-    initialStatus: input.initialStatus,
-  };
-  if (input.goal) body.goal = input.goal;
-  return body;
+  return missionLaunchBody(input);
 }
 
 /**

--- a/packages/monitor-ui/src/components/StartMissionLauncher.test.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, type RenderResult } from "@testing-library/react";
+import { StartMissionLauncher } from "./StartMissionLauncher.js";
+
+afterEach(cleanup);
+
+function openLauncher(r: RenderResult) {
+  fireEvent.click(r.getByRole("button", { name: "Start a mission" }));
+}
+
+function selectFlow(r: RenderResult, label: string) {
+  const radio = r.getByText(label).closest("label")?.querySelector("input");
+  fireEvent.click(radio as HTMLInputElement);
+}
+
+function launch(r: RenderResult) {
+  fireEvent.click(r.getByRole("button", { name: "Launch mission" }));
+}
+
+describe("StartMissionLauncher — Citation Repair flow", () => {
+  test("selecting Citation Repair swaps Target URL for a read-only Job ID field", () => {
+    const r = render(<StartMissionLauncher onSpawnMission={() => {}} />);
+    openLauncher(r);
+    selectFlow(r, "Citation Repair");
+
+    expect(r.getByLabelText(/Job ID/)).toBeTruthy();
+    expect(r.queryByText("Target")).toBeNull(); // URL field is swapped out
+    expect(r.getByText(/read-only analysis/i)).toBeTruthy();
+  });
+
+  test("launching Citation Repair with a Job ID spawns { mode: citation_repair, jobId } and no target", () => {
+    const onSpawnMission = vi.fn();
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    selectFlow(r, "Citation Repair");
+    fireEvent.change(r.getByLabelText(/Job ID/), { target: { value: "wiki-en-62871101" } });
+    launch(r);
+
+    expect(onSpawnMission).toHaveBeenCalledTimes(1);
+    expect(onSpawnMission).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "citation_repair", jobId: "wiki-en-62871101", targetUrl: "", initialStatus: "ready" })
+    );
+  });
+
+  test("Citation Repair with an empty Job ID still launches (workflow auto-selects)", () => {
+    const onSpawnMission = vi.fn();
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    selectFlow(r, "Citation Repair");
+    launch(r);
+
+    expect(onSpawnMission).toHaveBeenCalledTimes(1);
+    const arg = onSpawnMission.mock.calls[0]![0];
+    expect(arg.mode).toBe("citation_repair");
+    expect(arg).not.toHaveProperty("jobId");
+  });
+
+  test("does not regress: Surface Sweep still launches with a targetUrl and no jobId", () => {
+    const onSpawnMission = vi.fn();
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    launch(r); // surface_sweep is the default flow
+
+    expect(onSpawnMission).toHaveBeenCalledTimes(1);
+    const arg = onSpawnMission.mock.calls[0]![0];
+    expect(arg.mode).toBe("surface_sweep");
+    expect(arg.targetUrl).toMatch(/^https?:\/\//);
+    expect(arg).not.toHaveProperty("jobId");
+  });
+});

--- a/packages/monitor-ui/src/components/StartMissionLauncher.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.tsx
@@ -10,10 +10,12 @@ export interface StartMissionLauncherProps {
 
 export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissionLauncherProps) {
   const targetId = useId();
+  const jobIdId = useId();
   const goalId = useId();
   const suiteNameId = useId();
   const [open, setOpen] = useState(false);
   const [targetUrl, setTargetUrl] = useState(DEFAULT_TARGET);
+  const [jobId, setJobId] = useState("");
   const [mode, setMode] = useState<MissionLaunchMode>("surface_sweep");
   const [freshMemory, setFreshMemory] = useState(true);
   const [requestApproval, setRequestApproval] = useState(false);
@@ -22,10 +24,15 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
   const [goal, setGoal] = useState("");
   const [error, setError] = useState<string | null>(null);
 
+  const isCitation = mode === "citation_repair";
+
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const target = targetUrl.trim();
-    if (!isHttpUrl(target)) {
+    const trimmedJobId = jobId.trim();
+    // citation_repair keys off a Job ID (or auto-selects), not a URL — so it
+    // skips the http(s) target check.
+    if (!isCitation && !isHttpUrl(target)) {
       setError("Use an http:// or https:// target.");
       return;
     }
@@ -36,16 +43,18 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
     setError(null);
     const trimmedGoal = goal.trim();
     onSpawnMission?.({
-      targetUrl: target,
+      // citation_repair omits the target server-side; the launch body drops it.
+      targetUrl: isCitation ? "" : target,
       mode,
       freshMemory,
       initialStatus: requestApproval ? "requested" : "ready",
+      ...(isCitation && trimmedJobId ? { jobId: trimmedJobId } : {}),
       ...(trimmedGoal ? { goal: trimmedGoal } : {}),
     });
     if (saveSuite) {
       onSaveSuite?.({
         name: suiteName.trim(),
-        target,
+        target: isCitation ? (trimmedJobId || "auto-select") : target,
         mode,
         author: "operator",
         ...(trimmedGoal ? { goal: trimmedGoal } : {}),
@@ -69,17 +78,31 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
 
       {open ? (
         <form className="hm-mission-launcher-form" onSubmit={submit}>
-          <label className="hm-field hm-field--wide" htmlFor={targetId}>
-            <span>Target</span>
-            <input
-              id={targetId}
-              type="url"
-              required
-              value={targetUrl}
-              onChange={(event) => setTargetUrl(event.target.value)}
-              placeholder={DEFAULT_TARGET}
-            />
-          </label>
+          {isCitation ? (
+            <label className="hm-field hm-field--wide" htmlFor={jobIdId}>
+              <span>Job ID</span>
+              <input
+                id={jobIdId}
+                type="text"
+                value={jobId}
+                onChange={(event) => setJobId(event.target.value)}
+                placeholder="Leave empty to auto-select a claimable job"
+              />
+              <small>read-only analysis — no claim or edit (dry run)</small>
+            </label>
+          ) : (
+            <label className="hm-field hm-field--wide" htmlFor={targetId}>
+              <span>Target</span>
+              <input
+                id={targetId}
+                type="url"
+                required
+                value={targetUrl}
+                onChange={(event) => setTargetUrl(event.target.value)}
+                placeholder={DEFAULT_TARGET}
+              />
+            </label>
+          )}
 
           <fieldset className="hm-choice-group">
             <legend>Flow</legend>
@@ -111,6 +134,16 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
                 onChange={() => setMode("siwe_auth")}
               />
               <span>Role Gating</span>
+              <small>read-only</small>
+            </label>
+            <label>
+              <input
+                type="radio"
+                name="mission-flow"
+                checked={mode === "citation_repair"}
+                onChange={() => setMode("citation_repair")}
+              />
+              <span>Citation Repair</span>
               <small>read-only</small>
             </label>
           </fieldset>

--- a/packages/monitor-ui/src/lib/monitor/mission-launch.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-launch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { missionLaunchBody, type MissionLaunchInput } from "./mission-launch.js";
+
+const base: Omit<MissionLaunchInput, "mode"> = {
+  targetUrl: "https://app.averray.com",
+  freshMemory: true,
+  initialStatus: "ready",
+};
+
+describe("missionLaunchBody — mode → POST body", () => {
+  test("citation_repair carries jobId and OMITS targetUrl", () => {
+    const body = missionLaunchBody({ ...base, mode: "citation_repair", jobId: "wiki-en-62871101" });
+    expect(body).toEqual({
+      mode: "citation_repair",
+      jobId: "wiki-en-62871101",
+      freshMemory: true,
+      initialStatus: "ready",
+    });
+    expect(body).not.toHaveProperty("targetUrl");
+  });
+
+  test("citation_repair with no jobId omits jobId (server auto-selects) and targetUrl", () => {
+    const body = missionLaunchBody({ ...base, targetUrl: "", mode: "citation_repair" });
+    expect(body).toEqual({ mode: "citation_repair", freshMemory: true, initialStatus: "ready" });
+    expect(body).not.toHaveProperty("jobId");
+    expect(body).not.toHaveProperty("targetUrl");
+  });
+
+  test("existing flows are unchanged: surface_sweep keeps targetUrl, no jobId", () => {
+    const body = missionLaunchBody({ ...base, mode: "surface_sweep" });
+    expect(body).toEqual({
+      targetUrl: "https://app.averray.com",
+      mode: "surface_sweep",
+      freshMemory: true,
+      initialStatus: "ready",
+    });
+    expect(body).not.toHaveProperty("jobId");
+  });
+
+  test("a bare string spawn stays a plain targetUrl body", () => {
+    expect(missionLaunchBody("https://example.test")).toEqual({ targetUrl: "https://example.test" });
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/mission-launch.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-launch.ts
@@ -1,4 +1,4 @@
-export type MissionLaunchMode = "surface_sweep" | "gold_path" | "siwe_auth";
+export type MissionLaunchMode = "surface_sweep" | "gold_path" | "siwe_auth" | "citation_repair";
 export type MissionInitialStatus = "ready" | "requested";
 export type SavedTestSuiteAuthor = "predefined" | "operator" | "test-writer" | "platform";
 export type SavedTestSuiteVerdict = "pass" | "partial" | "fail" | "requested" | "ready" | "running" | "failed" | "unknown";
@@ -10,9 +10,41 @@ export interface MissionLaunchInput {
   freshMemory: boolean;
   initialStatus: MissionInitialStatus;
   goal?: string;
+  /** citation_repair only: the Wikipedia job to repair. Empty ⇒ the workflow
+   *  auto-selects a claimable job. (Other modes key off targetUrl.) */
+  jobId?: string;
 }
 
 export type MissionSpawnInput = string | MissionLaunchInput;
+
+/**
+ * Build the POST body for /monitor/testbed-missions from a launch input. Pure
+ * so the mode→body mapping is unit-tested. citation_repair keys off jobId, not
+ * a URL — it omits targetUrl and carries jobId (empty jobId ⇒ the server-side
+ * workflow auto-selects a claimable job). The runner forces dryRun for
+ * citation_repair, so the board run is read-only analysis.
+ */
+export function missionLaunchBody(input: MissionSpawnInput): Record<string, unknown> {
+  if (typeof input === "string") return { targetUrl: input };
+  if (input.mode === "citation_repair") {
+    const body: Record<string, unknown> = {
+      mode: input.mode,
+      freshMemory: input.freshMemory,
+      initialStatus: input.initialStatus,
+    };
+    if (input.jobId) body.jobId = input.jobId;
+    if (input.goal) body.goal = input.goal;
+    return body;
+  }
+  const body: Record<string, unknown> = {
+    targetUrl: input.targetUrl,
+    mode: input.mode,
+    freshMemory: input.freshMemory,
+    initialStatus: input.initialStatus,
+  };
+  if (input.goal) body.goal = input.goal;
+  return body;
+}
 
 export interface SavedTestSuiteHistoryEntry {
   runId: string;


### PR DESCRIPTION
## What

#407 wired `citation_repair` end-to-end **except** the launcher radio, so the loop couldn't be started from the board UI. This adds the one-click board action.

## Changes

- **`StartMissionLauncher.tsx`** — a 4th flow radio **"Citation Repair"** → `mode: "citation_repair"`. When selected, the **Target URL** field is swapped for a **"Job ID"** input (citation_repair keys off `jobId`, not a URL — empty ⇒ the workflow auto-selects a claimable job), labeled **"read-only analysis — no claim or edit (dry run)"** (the runner forces `dryRun` server-side). The `http(s)` target check is skipped for this mode. The 3 existing flows are untouched.
- **`mission-launch.ts`** — `MissionLaunchMode` gains `"citation_repair"`; `MissionLaunchInput` gains optional `jobId`. New pure **`missionLaunchBody()`** builds the POST body: citation_repair carries `jobId` (when set) and **omits `targetUrl`**; other modes are byte-for-byte unchanged. `MonitorPage.missionSpawnBody` now delegates to it, so the mode→body mapping lives (and is tested) in one place.

**No backend change** — `monitor-testbed-missions` already accepts `mode: "citation_repair"` + `jobId` (#407).

## Acceptance

- ✅ Selecting "Citation Repair" + a Job ID and clicking Launch POSTs `{ mode: "citation_repair", jobId }` (no `targetUrl`); the existing pipeline surfaces a citation_repair card that runs dry-run.
- ✅ Read-only labeling on the flow + the Job ID field.
- ✅ The 3 existing flows don't regress.

## Tests

- `missionLaunchBody` mode→body mapping: citation_repair → `jobId` sent, **no `targetUrl`**; empty jobId omitted (server auto-selects); surface_sweep unchanged; bare-string spawn unchanged.
- `StartMissionLauncher`: Citation Repair swaps to a read-only Job ID field (Target gone, "read-only analysis" shown); Launch spawns `{ mode: citation_repair, jobId, targetUrl: "" }`; empty Job ID still launches; Surface Sweep still launches with a `targetUrl` and no `jobId`.

## Verification

- `tsc -b` clean · `vitest run` **1525 passing** (+8) · `@avg/monitor-ui` vite build clean

## Constraints honored

Touches `StartMissionLauncher.tsx` + `mission-launch.ts` (+ a one-line delegation in `MonitorPage.tsx` so the body builder is shared/tested) + tests; honest read-only labeling; no backend change; 3 existing flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)