### PR TITLE
fix(worker): drop unsupported claude max-turns flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,11 +160,11 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   protected/base branches**), rejects secret-like files before committing,
   redacts command output, and **opens a PR but never merges**. The Claude
   worker is greenfield (creates the branch + opens the PR); by default it runs
-  Claude Code headless with `stream-json`, `--verbose`, bounded
-  `--max-turns`, and `--permission-mode acceptEdits`, emits live progress/usage
-  for the monitor drawer, and falls back to bare text `-p` only when the
-  installed CLI does not support those flags. The Codex worker iterates an
-  existing PR.
+  Claude Code headless with `stream-json`, `--verbose`, and
+  `--permission-mode acceptEdits`, emits live progress/usage for the monitor
+  drawer, and falls back to bare text `-p` only when the installed CLI does not
+  support those flags. The outer task-runner timeout is the execution bound. The
+  Codex worker iterates an existing PR.
 - **Cross-agent review requests and C2 reviewer panels are advisory records.**
   Hermes, the operator, Codex, or Claude may request a second-agent review on a
   card. High-risk work uses a panel of independent Hermes/Codex/Claude verdicts;

--- a/services/slack-operator/src/claude-branch-worker.ts
+++ b/services/slack-operator/src/claude-branch-worker.ts
@@ -678,8 +678,6 @@ function defaultClaudeArgs(env: NodeJS.ProcessEnv): string[] {
     "--output-format",
     outputFormat,
     ...verbose,
-    "--max-turns",
-    "{maxTurns}",
     "--permission-mode",
     permissionMode,
   ];

--- a/test/unit/claude-branch-worker.test.ts
+++ b/test/unit/claude-branch-worker.test.ts
@@ -50,15 +50,13 @@ describe("claude branch worker — pure functions", () => {
       "--output-format",
       "stream-json",
       "--verbose",
-      "--max-turns",
-      "{maxTurns}",
       "--permission-mode",
       "acceptEdits",
     ]);
     expect(c.allowedRepos).toEqual(["a/b", "c/d"]);
   });
 
-  it("lets operators override max turns and headless Claude flags", () => {
+  it("lets operators override headless Claude flags without adding a max-turns default", () => {
     const c = parseClaudeWorkerConfig({
       CLAUDE_BRANCH_WORKER_ALLOWED_REPOS: "a/b",
       CLAUDE_BRANCH_WORKER_MAX_TURNS: "12",
@@ -73,8 +71,6 @@ describe("claude branch worker — pure functions", () => {
       "{prompt}",
       "--output-format",
       "text",
-      "--max-turns",
-      "{maxTurns}",
       "--permission-mode",
       "bypassPermissions",
     ]);
@@ -134,9 +130,9 @@ describe("claude branch worker — pure functions", () => {
     });
   });
 
-  it("renders {prompt} into the claude args", () => {
-    expect(renderClaudeWorkerArgs(["-p", "{prompt}", "--max-turns", "{maxTurns}"], "hello", task, { maxTurns: 7 }))
-      .toEqual(["-p", "hello", "--max-turns", "7"]);
+  it("renders placeholders into operator-supplied claude args", () => {
+    expect(renderClaudeWorkerArgs(["-p", "{prompt}", "--task-id", "{taskId}"], "hello", task, { maxTurns: 7 }))
+      .toEqual(["-p", "hello", "--task-id", task.id]);
   });
 
   it("parses stream-json progress, final result text, and usage", () => {
@@ -296,8 +292,6 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
           "--output-format",
           "stream-json",
           "--verbose",
-          "--max-turns",
-          "{maxTurns}",
           "--permission-mode",
           "acceptEdits",
         ],
@@ -341,8 +335,6 @@ describe("claude branch worker — orchestration (injected exec + PR open)", () 
         "{prompt}",
         "--output-format",
         "stream-json",
-        "--max-turns",
-        "{maxTurns}",
         "--permission-mode",
         "acceptEdits",
       ],


### PR DESCRIPTION
## What changed
- Keep the Claude branch worker on the stream-json live-progress path that main already had, but remove the unsupported `--max-turns` flag from the default Claude Code invocation.
- Preserve env/operator override support through `CLAUDE_BRANCH_WORKER_CLAUDE_ARGS`; custom args still flow through `renderClaudeWorkerArgs`.
- Update worker tests so defaults are `-p {prompt} --output-format stream-json --verbose --permission-mode acceptEdits`, with no default max-turns flag.
- Update `AGENTS.md` so the working agreement states the outer task-runner timeout is the execution bound.

## Flag verification
- Required container check attempted first:
  `docker exec avg-claude-task-runner-1 claude --help`
- Local result: blocked because Docker/Colima is not running on this machine:
  `failed to connect to the docker API ... /Users/pascalkuriger/.colima/default/docker.sock: no such file or directory`
- No local `claude` binary is installed here either (`command not found`).
- This PR therefore removes the known-unsupported default flag and keeps the existing text fallback path for CLI flag mismatches.

## Checks
- `npm test -- test/unit/claude-branch-worker.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`

## Surface
- Claude-family branch worker defaults/tests.
- `AGENTS.md` working agreement update.
- No queue, runner claiming, monitor UI, ops, secrets, merge, or deploy changes.
