### PR TITLE
fix(adapter): detect template dead-links, emit coherent/applyable citation repairs, stop flagging live sources

### DIFF
--- a/packages/averray-mcp/src/job-workflows.ts
+++ b/packages/averray-mcp/src/job-workflows.ts
@@ -506,65 +506,139 @@ export function buildWikipediaCitationRepairProposal(
   definition: unknown,
   evidence: WikipediaEvidenceBundle
 ): { output: Record<string, unknown>; confidence: number } {
-  const findings = evidence.citations
-    .filter((citation) => citation.urls.length > 0 || citation.deadLinkMarkers.length > 0)
-    .slice(0, 5)
-    .map((citation) => {
-      const evidenceUrl = citation.archiveUrls[0] ?? citation.urls[0] ?? evidence.revisionUrl ?? "";
-      return {
-        section: "References",
-        problem: citation.deadLinkMarkers.length > 0 ? "dead_link" : "weak_source",
-        current_claim: citation.context || citation.title || `Reference ${citation.index}`,
-        evidence_url: evidenceUrl,
-      };
-    });
-  const proposedChanges = evidence.citations
-    .filter((citation) => citation.urls.length > 0 || citation.archiveUrls.length > 0)
-    .slice(0, 5)
-    .map((citation) => {
-      const sourceUrl = citation.archiveUrls[0] ?? citation.urls[0] ?? evidence.revisionUrl ?? "";
-      return {
-        change_type: citation.archiveUrls.length > 0 ? "replace_citation" : "flag_for_editor_review",
-        target_text: citation.context || citation.title || `Reference ${citation.index}`,
-        replacement_text:
-          citation.archiveUrls.length > 0
-            ? `Use archived source ${citation.archiveUrls[0]} after editor review.`
-            : "Editor should verify and replace this citation with a live reliable source or archive.",
-        source_url: sourceUrl,
-      };
-    });
+  const sourceByUrl = new Map<string, WikipediaEvidenceBundle["sourceChecks"][number]>();
+  for (const check of evidence.sourceChecks) sourceByUrl.set(check.url, check);
 
-  if (findings.length === 0 && evidence.citations[0]) {
-    const citation = evidence.citations[0];
-    findings.push({
-      section: "References",
-      problem: "weak_source",
-      current_claim: citation.context || citation.title || `Reference ${citation.index}`,
-      evidence_url: citation.urls[0] ?? evidence.revisionUrl ?? "",
-    });
-    proposedChanges.push({
-      change_type: "flag_for_editor_review",
-      target_text: citation.context || citation.title || `Reference ${citation.index}`,
-      replacement_text: "Editor should review this citation before publishing any change.",
-      source_url: citation.urls[0] ?? evidence.revisionUrl ?? "",
-    });
-  }
+  const fallbackEvidenceUrl = firstNonEmpty(evidence.revisionUrl, "https://en.wikipedia.org/");
+  const anchorUrl = (citation: WikipediaCitation): string =>
+    firstNonEmpty(citation.urls[0], citation.archiveUrls[0], fallbackEvidenceUrl);
 
-  const hasDeadMarker = evidence.citations.some((citation) => citation.deadLinkMarkers.length > 0);
-  const hasSource = evidence.citations.some((citation) => citation.urls.length > 0 || citation.archiveUrls.length > 0);
-  const confidence = hasDeadMarker && hasSource ? 0.72 : hasSource ? 0.62 : 0.4;
+  // ONLY genuinely dead links are defects. A live `<ref>` (url-status=live / 200)
+  // is NOT a weak_source — flagging one and "replacing" it with an archive of
+  // itself is noise, so we never emit weak_source findings. Prefer fewer real
+  // findings (or an honest empty proposal) over manufactured work.
+  const deadCitations = evidence.citations
+    .filter((citation) => citation.deadLinkMarkers.length > 0)
+    .slice(0, 10);
+
+  const findings = deadCitations.map((citation) => ({
+    section: firstNonEmpty(citation.section, "References"),
+    problem: "dead_link" as const,
+    current_claim: coherentCitationText(citation),
+    evidence_url: anchorUrl(citation),
+  }));
+
+  const proposedChanges = deadCitations.map((citation) => {
+    const target = coherentCitationText(citation);
+    const primaryUrl = citation.urls[0];
+    const sourceCheck = primaryUrl ? sourceByUrl.get(primaryUrl) : undefined;
+    const archiveUrl = firstNonEmpty(citation.archiveUrls[0], sourceCheck?.archiveUrl ?? undefined) || undefined;
+    const archiveDate = archiveUrl ? archiveDateFromWaybackUrl(archiveUrl) : undefined;
+
+    // Applyable, HONEST fix: only when a real cite template carries the url AND a
+    // Wayback snapshot whose date plausibly supports the cited content exists.
+    if (archiveUrl && archiveDate && isCiteTemplate(target) && plausibleArchive(archiveDate, citation.accessDates)) {
+      const replacement = addArchiveParamsToCitation(target, archiveUrl, archiveDate);
+      if (replacement && replacement !== target) {
+        return {
+          change_type: "replace_citation" as const,
+          target_text: target,
+          replacement_text: replacement,
+          source_url: archiveUrl,
+        };
+      }
+    }
+
+    // Otherwise flag for an editor — never assert an unverified / wrong-date
+    // snapshot. (The output schema has no "verify_archive" change_type, so the
+    // schema-valid way to say "verify before applying" is flag_for_editor_review.)
+    const note = archiveUrl
+      ? `Dead link. A Wayback snapshot exists (${archiveUrl}${archiveDate ? `, dated ${archiveDate}` : ""}) but it was not verified to support the cited content; an editor should confirm it covers the claim before adding |archive-url= |archive-date= |url-status=dead.`
+      : "Dead link with no automatically reliable archive. An editor should find a live replacement source, or a verified Wayback snapshot that supports the cited content, before changing the citation.";
+    return {
+      change_type: "flag_for_editor_review" as const,
+      target_text: target,
+      replacement_text: note,
+      source_url: anchorUrl(citation),
+    };
+  });
+
+  const replaceCount = proposedChanges.filter((change) => change.change_type === "replace_citation").length;
 
   return {
     output: {
-      page_title: evidence.pageTitle || readPageTitle(definition) || "Unknown page",
-      revision_id: evidence.revisionId || readRevisionId(definition) || "unknown",
+      page_title: firstNonEmpty(evidence.pageTitle, readPageTitle(definition), "Unknown page"),
+      revision_id: firstNonEmpty(evidence.revisionId, readRevisionId(definition), "unknown"),
       citation_findings: findings,
       proposed_changes: proposedChanges,
-      review_notes:
-        "Averray-attributed proposal only. No Wikipedia edit was made. Human editor should verify the source/archive before publishing.",
+      review_notes: citationRepairReviewNotes(deadCitations.length, replaceCount),
     },
-    confidence,
+    confidence: citationRepairConfidence(deadCitations.length, replaceCount),
   };
+}
+
+/** The full citation wikitext (coherent), never an arbitrary slice. */
+function coherentCitationText(citation: WikipediaCitation): string {
+  return firstNonEmpty(citation.raw, citation.context, citation.title, `Reference ${citation.index}`);
+}
+
+function isCiteTemplate(raw: string | undefined): boolean {
+  return typeof raw === "string" && /\{\{\s*cite\b/i.test(raw);
+}
+
+/** Parse the snapshot date out of a Wayback URL (`/web/YYYYMMDD…/`). */
+function archiveDateFromWaybackUrl(url: string): string | undefined {
+  const match = url.match(/\/web\/(\d{4})(\d{2})(\d{2})/);
+  if (!match) return undefined;
+  return `${match[1]}-${match[2]}-${match[3]}`;
+}
+
+/** A snapshot "plausibly supports the cited date" only when there is a cited
+ *  access-date to compare AND the snapshot lands in a sane window around it
+ *  (≈ up to a year before, a few years after). With no cited date we cannot
+ *  verify support, so we decline (→ flag for editor) rather than assert. */
+function plausibleArchive(archiveDate: string, accessDates: string[]): boolean {
+  const archiveMs = Date.parse(archiveDate);
+  if (Number.isNaN(archiveMs)) return false;
+  for (const accessDate of accessDates) {
+    const accessMs = Date.parse(accessDate);
+    if (Number.isNaN(accessMs)) continue;
+    const days = (archiveMs - accessMs) / 86_400_000;
+    if (days >= -366 && days <= 366 * 5) return true;
+  }
+  return false;
+}
+
+/** Insert `|archive-url= |archive-date= |url-status=dead` into the citation's
+ *  cite template — applyable wikitext. Returns undefined if it already has an
+ *  archive or has no cite template to augment. */
+function addArchiveParamsToCitation(raw: string, archiveUrl: string, archiveDate: string): string | undefined {
+  if (/\|\s*archive-?url\s*=/i.test(raw)) return undefined;
+  const template = raw.match(/\{\{\s*cite\b[\s\S]*?\}\}/i)?.[0];
+  if (!template) return undefined;
+  const inner = template.replace(/\}\}\s*$/, "").trimEnd();
+  const augmented = `${inner} |archive-url=${archiveUrl} |archive-date=${archiveDate} |url-status=dead}}`;
+  return raw.replace(template, augmented);
+}
+
+function citationRepairConfidence(deadCount: number, replaceCount: number): number {
+  if (deadCount === 0) return 0.6; // honest "nothing to repair"
+  if (replaceCount > 0) return 0.78; // at least one applyable archive fix
+  return 0.55; // dead links found, but only editor flags → needs review
+}
+
+function citationRepairReviewNotes(deadCount: number, replaceCount: number): string {
+  if (deadCount === 0) {
+    return "Averray-attributed analysis only. After checking both <ref> and template-embedded citations, no dead-link markers were found in this revision, so no repair is proposed. No Wikipedia edit was made.";
+  }
+  return `Averray-attributed proposal only. Found ${deadCount} dead-link citation(s); ${replaceCount} have an applyable archived-source fix, the rest are flagged for an editor to verify. No Wikipedia edit was made — an editor must confirm each archive supports the cited content before publishing.`;
+}
+
+function firstNonEmpty(...values: Array<string | undefined>): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return "";
 }
 
 export function fixSchemaOnlyWikipediaProposal(output: Record<string, unknown>): Record<string, unknown> {

--- a/packages/averray-mcp/src/wiki-evidence.ts
+++ b/packages/averray-mcp/src/wiki-evidence.ts
@@ -44,6 +44,13 @@ export interface WikipediaCitation {
   accessDates: string[];
   title?: string;
   context: string;
+  /** The full, faithful citation wikitext — the entire `<ref>…</ref>` or the
+   *  template/table-row that carries the citation. Unlike `context` (an
+   *  arbitrary character window), this is coherent and editor-applyable, so it
+   *  is what a proposal uses for `current_claim` / `target_text`. */
+  raw?: string;
+  /** Nearest preceding section heading (e.g. "Charts"), when detectable. */
+  section?: string;
 }
 
 const WIKIPEDIA_API = "https://en.wikipedia.org/w/api.php";
@@ -134,12 +141,14 @@ export function extractWikipediaCitationsFromWikitext(
   options: { maxCitations: number; maxContextChars: number }
 ): WikipediaCitation[] {
   const citations: WikipediaCitation[] = [];
+  const refSpans: Array<[number, number]> = [];
   const refPattern = /<ref\b([^>/]*?)(?:\/>|>([\s\S]*?)<\/ref>)/gi;
   let match: RegExpExecArray | null;
   while ((match = refPattern.exec(wikitext)) && citations.length < options.maxCitations) {
     const attrs = match[1] ?? "";
     const body = match[2] ?? "";
     const raw = match[0];
+    refSpans.push([match.index, match.index + raw.length]);
     const context = contextAround(wikitext, match.index, raw.length, options.maxContextChars);
     const templateNames = extractTemplateNames(body);
     const bareUrls = extractBareUrls(body);
@@ -159,8 +168,51 @@ export function extractWikipediaCitationsFromWikitext(
       accessDates: extractTemplateParamValues(body, ["access-date", "accessdate"]),
       ...optionalString("title", firstTemplateParamValue(body, ["title"])),
       context,
+      raw,
+      ...optionalString("section", sectionAt(wikitext, match.index)),
     });
   }
+
+  // Template-embedded dead links — `{{dead link}}` / `{{link rot}}` markers that
+  // annotate a citation OUTSIDE a `<ref>` (e.g. `{{album chart|…}}{{dead link}}`
+  // rows in a Charts table). The `<ref>`-only pass above is blind to these, so
+  // a page whose dead links live on chart/cite templates reports 0 dead links.
+  // We attribute each marker to the table-row / line it sits on (coherent
+  // wikitext), skipping any marker already inside a counted `<ref>`.
+  const insideRef = (at: number) => refSpans.some(([start, end]) => at >= start && at < end);
+  const deadMarkerPattern = /\{\{\s*(?:dead link|dead-link|link rot|bare url inline)\b[^{}]*\}\}/gi;
+  const seenLineStarts = new Set<number>();
+  let marker: RegExpExecArray | null;
+  while ((marker = deadMarkerPattern.exec(wikitext)) && citations.length < options.maxCitations) {
+    const at = marker.index;
+    if (insideRef(at)) continue;
+    const lineStart = wikitext.lastIndexOf("\n", at) + 1;
+    if (seenLineStarts.has(lineStart)) continue;
+    seenLineStarts.add(lineStart);
+    const lineEndRaw = wikitext.indexOf("\n", at);
+    const lineEnd = lineEndRaw < 0 ? wikitext.length : lineEndRaw;
+    // Faithful row wikitext (template syntax preserved), trimmed of table markup.
+    const raw = wikitext.slice(lineStart, lineEnd).replace(/^[|*#:;!\s]+/, "").trim() || marker[0];
+    const bareUrls = extractBareUrls(raw);
+    const urls = unique([...extractTemplateParamValues(raw, ["url"]), ...bareUrls]).filter((url) => !isArchiveUrl(url));
+    const archiveUrls = unique([
+      ...extractTemplateParamValues(raw, ["archive-url", "archiveurl"]),
+      ...bareUrls.filter((url) => isArchiveUrl(url)),
+    ]);
+    citations.push({
+      index: citations.length + 1,
+      templateNames: extractTemplateNames(raw),
+      urls,
+      archiveUrls,
+      deadLinkMarkers: ["maintenance_template"],
+      accessDates: extractTemplateParamValues(raw, ["access-date", "accessdate"]),
+      ...optionalString("title", firstTemplateParamValue(raw, ["title"])),
+      context: cleanWikiValue(raw).slice(0, options.maxContextChars),
+      raw,
+      ...optionalString("section", sectionAt(wikitext, at)),
+    });
+  }
+
   return citations;
 }
 
@@ -339,6 +391,20 @@ function extractRefName(attrs: string): string | undefined {
   const quoted = attrs.match(/\bname\s*=\s*["']([^"']+)["']/i)?.[1];
   if (quoted) return cleanWikiValue(quoted);
   return attrs.match(/\bname\s*=\s*([^\s/>]+)/i)?.[1];
+}
+
+/** The nearest section heading (`== Heading ==`) at or before `index`, cleaned
+ *  of `=` markers. Lets a finding say where it lives (e.g. "Charts"). */
+function sectionAt(text: string, index: number): string | undefined {
+  const before = text.slice(0, index);
+  const headingPattern = /^[ \t]*(={2,6})[ \t]*(.+?)[ \t]*\1[ \t]*$/gm;
+  let last: string | undefined;
+  let m: RegExpExecArray | null;
+  while ((m = headingPattern.exec(before))) {
+    const title = cleanWikiValue(m[2]);
+    if (title) last = title;
+  }
+  return last;
 }
 
 function contextAround(text: string, index: number, length: number, maxChars: number): string {

--- a/test/unit/citation-repair-adapter.test.ts
+++ b/test/unit/citation-repair-adapter.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import { extractWikipediaCitationsFromWikitext } from "../../packages/averray-mcp/src/wiki-evidence.js";
+import { buildWikipediaCitationRepairProposal } from "../../packages/averray-mcp/src/job-workflows.js";
+import { wikipediaCitationRepairOutputSchema } from "../../packages/schemas/src/wikipedia.js";
+
+const EXTRACT_OPTS = { maxCitations: 80, maxContextChars: 240 };
+const REVISION_URL = "https://en.wikipedia.org/w/index.php?title=(Hash)&oldid=1351905908";
+
+// A Charts table whose Billboard rows carry {{dead link}} on {{album chart}}
+// templates — the exact shape the <ref>-only extractor was blind to.
+const CHARTS_WIKITEXT = `== Charts ==
+{| class="wikitable"
+|-
+! Chart (2024) !! Peak
+|-
+| {{album chart|Billboard|artist=Foo|album=Bar|type=Heatseekers}}{{dead link|date=April 2024|bot=InternetArchiveBot}}
+| 19
+|-
+| {{album chart|Billboard|artist=Foo|album=Bar|type=Independent}}{{dead link|date=April 2024|bot=InternetArchiveBot}}
+| 44
+|-
+| {{album chart|Billboard|artist=Foo|album=Bar|type=World}}{{dead link|date=April 2024|bot=InternetArchiveBot}}
+| 4
+|}
+
+== References ==
+{{reflist}}`;
+
+function chartsEvidence() {
+  return {
+    pageTitle: "(Hash)",
+    revisionId: "1351905908",
+    revisionUrl: REVISION_URL,
+    citations: extractWikipediaCitationsFromWikitext(CHARTS_WIKITEXT, EXTRACT_OPTS),
+    sourceChecks: [],
+  };
+}
+
+describe("extractWikipediaCitationsFromWikitext — template-embedded dead links", () => {
+  it("detects {{dead link}} on {{album chart}} rows outside <ref>, with section + coherent raw", () => {
+    const citations = extractWikipediaCitationsFromWikitext(CHARTS_WIKITEXT, EXTRACT_OPTS);
+    const dead = citations.filter((c) => c.deadLinkMarkers.length > 0);
+    expect(dead.length).toBeGreaterThanOrEqual(3);
+    for (const c of dead) {
+      expect(c.section).toBe("Charts");
+      expect(c.deadLinkMarkers).toContain("maintenance_template");
+      expect(c.raw).toContain("album chart"); // coherent full row, not a slice
+      expect(c.raw).toContain("dead link");
+    }
+  });
+
+  it("does not double-count a {{dead link}} that sits inside a <ref>", () => {
+    const citations = extractWikipediaCitationsFromWikitext(
+      `Body.<ref>{{dead link|date=May 2026}}{{cite news |url=https://example.com/story}}</ref>`,
+      EXTRACT_OPTS
+    );
+    expect(citations).toHaveLength(1); // the <ref> pass owns it; the template pass skips it
+    expect(citations[0]!.deadLinkMarkers).toContain("maintenance_template");
+  });
+});
+
+describe("buildWikipediaCitationRepairProposal — Charts dead links", () => {
+  it("reports >=3 dead_link findings in Charts with coherent target_text and no live-source noise", () => {
+    const { output, confidence } = buildWikipediaCitationRepairProposal({}, chartsEvidence());
+    const findings = output.citation_findings as Array<Record<string, unknown>>;
+    const changes = output.proposed_changes as Array<Record<string, unknown>>;
+
+    expect(findings.length).toBeGreaterThanOrEqual(3);
+    expect(findings.every((f) => f.problem === "dead_link")).toBe(true);
+    expect(findings.every((f) => f.section === "Charts")).toBe(true);
+    expect(findings.every((f) => String(f.current_claim).includes("album chart"))).toBe(true);
+    // No weak_source noise on a dead-link job.
+    expect(findings.some((f) => f.problem === "weak_source")).toBe(false);
+    // No archivable URL here → honest editor flags, never an asserted archive.
+    expect(changes.every((c) => c.change_type === "flag_for_editor_review")).toBe(true);
+    expect(confidence).toBeLessThan(0.7); // dead links found but only editor flags → needs review
+    expect(wikipediaCitationRepairOutputSchema.safeParse(output).success).toBe(true);
+  });
+});
+
+describe("buildWikipediaCitationRepairProposal — live sources are never flagged", () => {
+  it("a live <ref> (200 / url-status=live) produces an honest empty proposal, not weak_source", () => {
+    const citations = extractWikipediaCitationsFromWikitext(
+      `Claim.<ref name="live">{{cite web |title=Live |url=https://live.example/x |access-date=2023-01-01}}</ref>`,
+      EXTRACT_OPTS
+    );
+    const { output, confidence } = buildWikipediaCitationRepairProposal(
+      {},
+      {
+        pageTitle: "Live Page",
+        revisionId: "1",
+        revisionUrl: REVISION_URL,
+        citations,
+        sourceChecks: [{ url: "https://live.example/x", status: 200, ok: true, finalUrl: "https://live.example/x", archiveUrl: null }],
+      }
+    );
+    expect(output.citation_findings).toEqual([]);
+    expect(output.proposed_changes).toEqual([]);
+    expect(confidence).toBe(0.6);
+    expect(String(output.review_notes)).toMatch(/no dead-link/i);
+    // Top-level shape stays exactly the 5 allowed keys (no stray fields). The
+    // full schema requires .min(1) on both arrays — i.e. you cannot SUBMIT a
+    // no-op repair — so an honest empty proposal is intentionally not a valid
+    // submission: the workflow declines to claim/submit it rather than
+    // manufacturing a defect to satisfy the schema.
+    expect(Object.keys(output).sort()).toEqual([
+      "citation_findings",
+      "page_title",
+      "proposed_changes",
+      "review_notes",
+      "revision_id",
+    ]);
+    expect(wikipediaCitationRepairOutputSchema.safeParse(output).success).toBe(false);
+  });
+});
+
+describe("buildWikipediaCitationRepairProposal — applyable, honest archive fixes", () => {
+  const deadCiteCitation = (over: Record<string, unknown> = {}) => ({
+    index: 1,
+    referenceId: "r",
+    templateNames: ["cite web"],
+    urls: ["https://dead.example/a"],
+    archiveUrls: ["https://web.archive.org/web/20230115000000/https://dead.example/a"],
+    deadLinkMarkers: ["url_status_dead"],
+    accessDates: ["2023-01-10"],
+    title: "A",
+    context: "context",
+    raw: '<ref name="r">{{cite web |title=A |url=https://dead.example/a |access-date=2023-01-10}}</ref>',
+    section: "Reception",
+    ...over,
+  });
+
+  function proposalFor(citation: Record<string, unknown>) {
+    return buildWikipediaCitationRepairProposal(
+      {},
+      {
+        pageTitle: "Album",
+        revisionId: "1",
+        revisionUrl: REVISION_URL,
+        citations: [citation as never],
+        sourceChecks: [{ url: "https://dead.example/a", status: 404, ok: false, finalUrl: "https://dead.example/a", archiveUrl: "https://web.archive.org/web/20230115000000/https://dead.example/a" }],
+      }
+    );
+  }
+
+  it("emits applyable wikitext (archive-url/date/url-status=dead) when a plausible snapshot supports the cited date", () => {
+    const { output, confidence } = proposalFor(deadCiteCitation());
+    const change = (output.proposed_changes as Array<Record<string, unknown>>)[0]!;
+    expect(change.change_type).toBe("replace_citation");
+    expect(String(change.replacement_text)).toContain("{{cite web");
+    expect(String(change.replacement_text)).toContain("|archive-url=https://web.archive.org/web/20230115000000/https://dead.example/a");
+    expect(String(change.replacement_text)).toContain("|archive-date=2023-01-15");
+    expect(String(change.replacement_text)).toContain("|url-status=dead");
+    expect(confidence).toBeGreaterThanOrEqual(0.7);
+    expect(wikipediaCitationRepairOutputSchema.safeParse(output).success).toBe(true);
+  });
+
+  it("flags instead of asserting when there is no cited date to verify the snapshot against", () => {
+    // No access-date → we cannot verify the snapshot supports the claim → flag.
+    const { output } = proposalFor(deadCiteCitation({ accessDates: [], raw: '<ref name="r">{{cite web |title=A |url=https://dead.example/a}}</ref>' }));
+    const change = (output.proposed_changes as Array<Record<string, unknown>>)[0]!;
+    expect(change.change_type).toBe("flag_for_editor_review");
+    expect(String(change.replacement_text)).toMatch(/not verified|confirm/i);
+    expect(wikipediaCitationRepairOutputSchema.safeParse(output).success).toBe(true);
+  });
+});

--- a/test/unit/job-workflows.test.ts
+++ b/test/unit/job-workflows.test.ts
@@ -36,6 +36,8 @@ const evidence = {
       accessDates: ["2020-01-02"],
       title: "Review",
       context: "A review citation with a dead source.",
+      raw: '<ref name="review">{{cite web |title=Review |url=https://dead.example/review |access-date=2020-01-02}}</ref>',
+      section: "Reception",
     },
   ],
   sourceChecks: [
@@ -98,7 +100,7 @@ describe("runWikipediaCitationRepairWorkflow", () => {
       jobId,
       sessionId,
       draftId: "draft-1",
-      confidence: 0.72,
+      confidence: 0.78,
       proposalSummary: {
         citationFindings: 1,
         proposedChanges: 1,


### PR DESCRIPTION
## What

**AQ** — the actual fix the whole citation-repair loop (#407 / #410 / #411 / #414 / #415) was built around. `averray_run_wikipedia_citation_repair` produced benchmark-passing but low-quality output on the live job `wiki-en-62871101-citation-repair-hash-r3` (page "(Hash)", rev `1351905908`): a dry run found **0 dead links** while the Charts section has real `{{dead link}}` tags on `{{album chart}}` Billboard rows, then flagged **5 live `<ref>` sources** as `weak_source` and "replaced" them with archives of themselves, with garbled claims and prose `replacement_text`.

Touches **only `wiki-evidence.ts` + `job-workflows.ts`** (+ tests) — zero collision with the 5 loop PRs. Proposal-only: no Wikipedia edits, no chain/settlement, no generated frontend.

## Root cause → fix

1. **Template dead links were invisible** — `extractWikipediaCitationsFromWikitext` walked `<ref>…</ref>` only, so `{{album chart}}{{dead link}}` rows (no `<ref>`) were never seen. → Added a second pass that detects `{{dead link}}` / `{{link rot}}` markers annotating a citation **outside** a `<ref>`, attributed to the table-row/line they sit on, **skipping markers already inside a counted `<ref>`** (no double-count).
2. **Garbled claims** — `current_claim`/`target_text` was `citation.context` (an arbitrary `slice()`). → Added `raw` (the full, faithful `<ref>…</ref>` or row wikitext) + `section` (nearest heading, e.g. "Charts") to `WikipediaCitation`; proposals now use `raw` — coherent and editor-applyable.
3. **Live sources flagged as weak_source** — `problem` defaulted to `weak_source` for any URL and `replace_citation` fired whenever any archive existed. → Findings are now **only genuinely dead links**; a live `<ref>` (200 / `url-status=live`) is never `weak_source` and is never "replaced with its own archive". The invented `weak_source` fallback is removed. Prefer fewer real findings (or honest empty) over noise.
4. **Non-applyable / dishonest fixes** — `replacement_text` was hardcoded prose. → When a dead **cite template** has a Wayback snapshot whose date **plausibly supports the cited access-date**, `replacement_text` is valid wikitext adding `|archive-url= |archive-date= |url-status=dead` (`replace_citation`). Otherwise `flag_for_editor_review` with an editor note — **never assert an unverified / wrong-date snapshot**.
5. **Confidence reflects reality** — applyable archive fix `0.78`; dead links found but only editor flags `0.55`; no dead links `0.6`.

## On `verify_archive` and honest-empty (truth boundary)

- The output schema enumerates `change_type` to `replace_citation | add_citation | flag_for_editor_review` — there is **no `verify_archive`**. Emitting it would fail submit, so "verify before applying" is expressed as the schema-valid `flag_for_editor_review` (with the note in `replacement_text`).
- The schema also requires **`.min(1)`** on `citation_findings` and `proposed_changes` — **you cannot submit a no-op repair**. So an honest empty proposal keeps the correct top-level shape but is intentionally *not* a valid submission; the workflow declines to claim/submit rather than fabricate a defect to satisfy the schema.

## Acceptance / verify

The live dry run is the operator's pre-settlement gate (needs the running MCP + wallet, so it's not runnable in CI):
```
averray_run_wikipedia_citation_repair(jobId="wiki-en-62871101-citation-repair-hash-r3", dryRun=true)
→ deadLinkCitations ≥ 3, Charts-section findings, coherent target_text, no live-source noise
```
A deterministic fixture test mirrors that exact page shape (`{{album chart}}{{dead link}}` rows in a Charts table) and asserts the same properties, so the behavior is locked without the network.

## Tests

- `{{album chart}}{{dead link}}` Charts fixture → **≥3 `dead_link` findings in "Charts"** with coherent `target_text`, **no live-source noise**, full-schema-validates.
- an in-`<ref>` `{{dead link}}` is **not double-counted**.
- a live `<ref>` → **honest empty proposal** (no `weak_source`), top-level shape intact, full schema correctly rejects min(1).
- an **applyable** archive fix → valid wikitext (`|archive-url=|archive-date=|url-status=dead`), full-schema-validates.
- **no cited date** to verify the snapshot → `flag_for_editor_review`, not an asserted replace.
- Updated the job-workflows happy-path fixture to carry a real cite template (its dead link now yields an applyable `replace_citation` at confidence `0.78`).

## Verification

- `tsc -b` clean · `vitest run` **1537 passing** · `@avg/monitor-ui` vite build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)