### PR TITLE
feat(monitor): redesign Hermes rail as collaboration room

### DIFF
--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -81,7 +81,7 @@ describe("AskHermesComposer", () => {
     type(input, "what's blocking #548?");
     fireEvent.click(getByRole("button", { name: /Send/ }));
     // No focused card → the question is board-scoped.
-    expect(onAsk).toHaveBeenCalledWith("what's blocking #548?", { scope: "board" });
+    expect(onAsk).toHaveBeenCalledWith("what's blocking #548?", { scope: "board", target: "everyone" });
     expect(input.value).toBe("");
   });
 
@@ -169,18 +169,23 @@ describe("AskHermesComposer — G3 compose chips + prefill", () => {
     // Default: scoped to the focused card.
     type(input, "why did this fail?");
     fireEvent.click(getByRole("button", { name: /Send/ }));
-    expect(onAsk).toHaveBeenLastCalledWith("why did this fail?", { scope: "card" });
+    expect(onAsk).toHaveBeenLastCalledWith("why did this fail?", { scope: "card", target: "everyone" });
     // Toggle the scope chip → whole board.
     fireEvent.click(getByText(/^scope ·/).closest("button") as HTMLElement);
     type(input, "board status?");
     fireEvent.click(getByRole("button", { name: /Send/ }));
-    expect(onAsk).toHaveBeenLastCalledWith("board status?", { scope: "board" });
+    expect(onAsk).toHaveBeenLastCalledWith("board status?", { scope: "board", target: "everyone" });
   });
 
-  test("the 'to' chip is an honest recipient label, not a fake toggle", () => {
-    const { getByText } = render(<AskHermesComposer onAsk={vi.fn()} />);
-    const to = getByText("to · Hermes");
-    expect(to.tagName).toBe("SPAN"); // informational, not a button
+  test("the target selector sends a question to a chosen agent", () => {
+    const onAsk = vi.fn();
+    const { container, getByLabelText, getByRole } = render(<AskHermesComposer onAsk={onAsk} />);
+    const target = getByLabelText("Message target") as HTMLSelectElement;
+    fireEvent.change(target, { target: { value: "codex" } });
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "can you inspect the failing card?");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onAsk).toHaveBeenCalledWith("can you inspect the failing card?", { scope: "board", target: "codex" });
   });
 
   test("prefill drops suggestion text into the composer when the token bumps", () => {

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -8,9 +8,10 @@
 // Enter sends, Shift+Enter inserts a newline. Parsing lives in the pure
 // hermes-commands helper; this component owns only input + dispatch.
 
-import { useEffect, useRef, useState, type KeyboardEvent } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type KeyboardEvent } from "react";
 import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
 import type { CreateTaskInput } from "../../lib/monitor/card-types.js";
+import type { CollaborationTarget } from "../../lib/monitor/collaboration.js";
 
 export interface AskHermesComposerProps {
   /** Spawn a browser mission against a URL (/mission <url>). */
@@ -20,7 +21,7 @@ export interface AskHermesComposerProps {
   /** Propose a task (/task <agent> [<repo>#<pr>] <prompt>). */
   onCreateTask?: (input: CreateTaskInput) => void;
   /** Ask Hermes a free-form question, scoped to the focused card or the whole board. */
-  onAsk?: (text: string, opts?: { scope: "card" | "board" }) => void;
+  onAsk?: (text: string, opts?: { scope: "card" | "board"; target: CollaborationTarget }) => void;
   /** Prefill the composer with this text (e.g. a suggestion chip). */
   prefill?: string;
   /** Bump to (re)apply `prefill` into the input + focus it. */
@@ -49,6 +50,23 @@ export interface AskHermesComposerProps {
   /** Inline error when the POST itself failed (question didn't send). */
   sendError?: string | null;
 }
+
+const TARGET_OPTIONS: Array<{ value: CollaborationTarget; label: string }> = [
+  { value: "everyone", label: "@everyone" },
+  { value: "codex", label: "@codex" },
+  { value: "claude", label: "@claude" },
+  { value: "hermes", label: "@hermes" },
+];
+
+const TARGET_SELECT_STYLE: CSSProperties = {
+  border: 0,
+  background: "transparent",
+  color: "inherit",
+  font: "inherit",
+  fontWeight: 700,
+  textTransform: "none",
+  outline: "none",
+};
 
 export function AskHermesComposer({
   onSpawnMission,
@@ -84,6 +102,7 @@ export function AskHermesComposer({
   // focused there's nothing to scope to, so it's board-only.
   const [scopeToCard, setScopeToCard] = useState(true);
   const effectiveScope: "card" | "board" = focusedCardId && scopeToCard ? "card" : "board";
+  const [target, setTarget] = useState<CollaborationTarget>("everyone");
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // The board's `a` shortcut bumps focusToken to bring focus here.
@@ -173,7 +192,7 @@ export function AskHermesComposer({
         if (!collaborationEnabled) {
           setError("Ask Hermes unavailable — the collaboration channel is offline.");
         } else if (onAsk) {
-          onAsk(command.text, { scope: effectiveScope });
+          onAsk(command.text, { scope: effectiveScope, target });
           setValue("");
           setError(null);
         } else {
@@ -193,10 +212,19 @@ export function AskHermesComposer({
   return (
     <div className="hm-compose">
       <div className="hm-compose-toolbar">
-        {/* Honest recipient label: a question posts to the Hermes collaboration
-            channel as the operator. Targeting other agents isn't a wired action,
-            so this is informational, not a fake toggle. */}
-        <span className="hm-compose-chip is-on">to · Hermes</span>
+        <label className="hm-compose-chip is-on" title="Choose who the room message addresses">
+          to ·{" "}
+          <select
+            aria-label="Message target"
+            value={target}
+            onChange={(event) => setTarget(event.target.value as CollaborationTarget)}
+            style={TARGET_SELECT_STYLE}
+          >
+            {TARGET_OPTIONS.map((option) => (
+              <option value={option.value} key={option.value}>{option.label}</option>
+            ))}
+          </select>
+        </label>
         {/* Scope toggle: actually controls whether a question is scoped to the
             focused card or the whole board on send. Board-only with no card. */}
         {focusedCardId ? (

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -46,8 +46,8 @@ describe("CoPilotRail", () => {
     const fetcher = vi.fn(async () => [msg("1", "hermes", "Pre-check passed on #548.")]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
     await waitFor(() => expect(within(container).getByText(/Pre-check passed on #548/)).toBeTruthy());
-    expect(within(container).getAllByText("Hermes").length).toBeGreaterThan(0);
-    expect(within(container).getAllByText(/reply/).length).toBeGreaterThan(0);
+    expect(within(container).getByText("Hermes → everyone")).toBeTruthy();
+    expect(within(container).getAllByText(/chat/).length).toBeGreaterThan(0);
     expect(container.querySelector(".hm-turn-time")).toBeTruthy();
   });
 
@@ -58,13 +58,13 @@ describe("CoPilotRail", () => {
     ]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
     await waitFor(() => expect(within(container).getByText(/Template answer from the board/)).toBeTruthy());
-    expect(within(container).getAllByText("Hermes (offline — templated)").length).toBeGreaterThan(0);
+    expect(within(container).getAllByText("Hermes (offline — templated) → everyone").length).toBeGreaterThan(0);
     expect(within(container).getAllByText(/replies are templated/)).toHaveLength(1);
   });
 
   test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
     const { getByText } = render(<CoPilotRail />, { wrapper });
-    expect(getByText(/No real Hermes activity has been logged yet/)).toBeTruthy();
+    expect(getByText("No agent chatter yet.")).toBeTruthy();
   });
 
   test("the scope chip reflects the focused card", async () => {
@@ -86,7 +86,7 @@ describe("CoPilotRail", () => {
       <CoPilotRail focusedCard={card548} collaboration={{ fetcher, poster, refreshIntervalMs: 0 }} />,
       { wrapper },
     );
-    await waitFor(() => expect(within(container).getByText(/No real Hermes activity has been logged yet/)).toBeTruthy());
+    await waitFor(() => expect(within(container).getByText("No agent chatter yet.")).toBeTruthy());
 
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     fireEvent.change(input, { target: { value: "what's blocking?" } });
@@ -94,6 +94,7 @@ describe("CoPilotRail", () => {
 
     expect(poster).toHaveBeenCalledWith({
       text: "what's blocking?",
+      addressedTo: "everyone",
       relatedPr: { repo: "depre-dev/agent", number: 548 },
     });
     // Hermes's reply lands on the revalidate triggered by ask().
@@ -114,38 +115,21 @@ describe("CoPilotRail", () => {
     expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/x");
   });
 
-  test("shows proactive board activity and links it back to a card", () => {
+  test("shows the current board summary and links it back to a card", () => {
     const onCardClick = vi.fn();
-    const taskCard: BoardCard = {
-      ...card548,
-      id: "task-activity-1",
-      type: "task",
-      agentType: "codex",
-      title: "Repair failed mission",
-      summary: "Hermes self-healing proposal for a failed testbed mission.",
-      lane: "codex-needed",
-      prompt: "Repair the failed mission.",
-      taskStatus: "proposed",
-      riskTier: "low",
-    };
-    const { container, getAllByText, getByText, getByRole } = render(
+    const { getByText, getByRole } = render(
       <CoPilotRail
-        boardCards={[taskCard]}
+        boardCards={[card548]}
         boardBanner={banner}
         onCardClick={onCardClick}
         collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }}
       />,
       { wrapper },
     );
-    const activityText = getByText(/Proposed Codex work for Repair failed mission/);
-    expect(activityText).toBeTruthy();
-    expect(activityText.closest(".hm-turn-body")).toBeTruthy();
-    expect(getAllByText(/narration/).length).toBeGreaterThan(0);
-    fireEvent.click(getByRole("button", { name: "Open referenced card task-activity-1" }));
-    expect(onCardClick).toHaveBeenCalledWith("task-activity-1");
-    fireEvent.click(getByRole("button", { name: "Why this route?" }));
-    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
-    expect(input.value).toBe("Why this route?");
+    expect(getByText(/Needs you:/)).toBeTruthy();
+    expect(getByText(/Operator review is waiting on agent #548/)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Open referenced card agent #548" }));
+    expect(onCardClick).toHaveBeenCalledWith("agent #548");
   });
 
   test("card-scoped collaboration messages render with a real card pin", async () => {
@@ -164,10 +148,81 @@ describe("CoPilotRail", () => {
       { wrapper },
     );
     await waitFor(() => expect(within(container).getByText(/What is still blocking this/)).toBeTruthy());
-    expect(within(container).getByText("Pascal")).toBeTruthy();
-    expect(within(container).getByText(/question/)).toBeTruthy();
+    expect(within(container).getByText("You → everyone")).toBeTruthy();
+    expect(within(container).getAllByText(/chat/).length).toBeGreaterThan(0);
     fireEvent.click(getByRole("button", { name: "Open referenced card agent #548" }));
     expect(onCardClick).toHaveBeenCalledWith("agent #548");
+  });
+
+  test("renders a multi-agent room with directed turns and kind ranking", async () => {
+    const fetcher = vi.fn(async () => [
+      msg("codex-help", "codex", "Need a second read on the deploy edge.", {
+        kind: "request_help",
+        addressedTo: "claude",
+      }),
+      msg("claude-status", "claude", "I am reading the trace.", {
+        kind: "status",
+        addressedTo: "hermes",
+      }),
+      msg("tester-proposal", "test-writer", "Add a browser auth regression.", {
+        kind: "proposal",
+        addressedTo: "everyone",
+      }),
+      msg("security-chat", "security", "Secrets stay isolated.", { addressedTo: "docs" }),
+      msg("docs-chat", "docs", "Runbook note is ready.", { addressedTo: "operator" }),
+      msg("system-chat", "system", "Board snapshot refreshed.", { addressedTo: "everyone" }),
+    ]);
+    const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
+    await waitFor(() => expect(within(container).getByText("Codex → Claude")).toBeTruthy());
+    expect(within(container).getByText("Claude → Hermes")).toBeTruthy();
+    expect(within(container).getByText("Test-writer → everyone")).toBeTruthy();
+    expect(within(container).getByText("Security → Docs")).toBeTruthy();
+    expect(within(container).getByText("Docs → You")).toBeTruthy();
+    expect(within(container).getByText("System → everyone")).toBeTruthy();
+    expect(container.querySelector(".hm-turn--kind-request_help")?.className).toContain("hm-turn--rank-prominent");
+    expect(container.querySelector(".hm-turn--kind-status")?.className).toContain("hm-turn--rank-muted");
+  });
+
+  test("threads collaboration turns by their related card/task reference", async () => {
+    const onCardClick = vi.fn();
+    const fetcher = vi.fn(async () => [
+      msg("operator-question", "operator", "Can this move?", {
+        relatedPr: { repo: "depre-dev/agent", number: 548 },
+      }),
+      msg("hermes-reply", "hermes", "It needs one more review.", {
+        addressedTo: "operator",
+        relatedPr: { repo: "depre-dev/agent", number: 548 },
+      }),
+    ]);
+    const { container, getByRole } = render(
+      <CoPilotRail
+        boardCards={[card548]}
+        onCardClick={onCardClick}
+        collaboration={{ fetcher, refreshIntervalMs: 0 }}
+      />,
+      { wrapper },
+    );
+    await waitFor(() => expect(within(container).getByText("Thread · depre-dev/agent #548")).toBeTruthy());
+    expect(within(container).getByText("2 turns")).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Open referenced card agent #548" }));
+    expect(onCardClick).toHaveBeenCalledWith("agent #548");
+  });
+
+  test("the composer can address a specific agent through the collaboration target field", async () => {
+    const poster = vi.fn(async () => undefined);
+    const { container, getByLabelText } = render(
+      <CoPilotRail collaboration={{ fetcher: async () => [], poster, refreshIntervalMs: 0 }} />,
+      { wrapper },
+    );
+    const target = getByLabelText("Message target") as HTMLSelectElement;
+    fireEvent.change(target, { target: { value: "codex" } });
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: "please inspect this" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(poster).toHaveBeenCalledWith({
+      text: "please inspect this",
+      addressedTo: "codex",
+    });
   });
 });
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -7,21 +7,18 @@
 // mission (M7').
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { CSSProperties } from "react";
 import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../../lib/monitor/backlog-suggestions.js";
 import type { BoardNowBanner as BoardNowBannerData } from "../../lib/monitor/board-state.js";
 import {
-  actorLabel,
   formatTurnTime,
   relatedPrForCard,
   type CollaborationMessage,
 } from "../../lib/monitor/collaboration.js";
-import {
-  buildHermesActivityFeed,
-  type HermesActivityEntry,
-} from "../../lib/monitor/activity-feed.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
+import { HermesTurn } from "./HermesTurn.js";
 
 export interface CoPilotRailProps {
   onSpawnMission?: (url: string) => void;
@@ -90,19 +87,9 @@ export function CoPilotRail({
     setPrefill(text);
     setPrefillToken((t) => t + 1);
   };
-  const activity = useMemo(
-    () => buildHermesActivityFeed({
-      cards: boardCards ?? [],
-      messages,
-      banner: boardBanner ?? {
-        tone: "calm",
-        eyebrow: "Board now",
-        headline: "Nothing waits on you. Hermes will narrate real board events when they arrive.",
-        sub: "No current board summary was provided to the rail.",
-        primaryActionId: undefined,
-      },
-    }),
-    [boardBanner, boardCards, messages],
+  const roomThreads = useMemo(
+    () => buildRoomThreads(messages, boardCards ?? []),
+    [boardCards, messages],
   );
 
   const scopedConversationActive = useMemo(
@@ -121,7 +108,7 @@ export function CoPilotRail({
   useEffect(() => {
     const el = streamRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [activity.length]);
+  }, [messages.length, roomThreads.length]);
 
   return (
     <aside className="hm-hermes" role="complementary" aria-label="Hermes co-pilot">
@@ -152,20 +139,27 @@ export function CoPilotRail({
         </div>
       ) : null}
 
-      <section className="hm-activity" aria-label="Hermes activity">
+      <section className="hm-activity" aria-label="Multi-agent collaboration room">
         <div className="hm-activity-head">
-          <span className="hm-kicker">Activity</span>
-          <strong>What Hermes sees</strong>
+          <span className="hm-kicker">Room</span>
+          <strong>Agent collaboration</strong>
         </div>
         <div className="hm-hermes-stream hm-activity-stream" ref={streamRef} aria-live="polite">
-          {activity.map((entry) => (
-            <ActivityEntryRow
-              entry={entry}
-              onCardClick={onCardClick}
-              onUseInComposer={fillComposer}
-              key={entry.id}
-            />
-          ))}
+          {roomThreads.length > 0 ? (
+            roomThreads.map((thread) => (
+              <RoomThreadBlock
+                thread={thread}
+                onCardClick={onCardClick}
+                key={thread.key}
+              />
+            ))
+          ) : (
+            <RoomEmptyState />
+          )}
+          <BoardSummaryRow
+            banner={boardBanner}
+            onCardClick={onCardClick}
+          />
         </div>
       </section>
 
@@ -173,7 +167,7 @@ export function CoPilotRail({
         onSpawnMission={onSpawnMission}
         onSpawnClaudeTask={onSpawnClaudeTask}
         onCreateTask={onCreateTask}
-        onAsk={(text, opts) => ask(text, opts?.scope === "board" ? undefined : relatedPr)}
+        onAsk={(text, opts) => ask(text, opts?.scope === "board" ? undefined : relatedPr, opts?.target ?? "everyone")}
         onMute={onMute}
         onUnmute={onUnmute}
         muted={muted}
@@ -190,6 +184,216 @@ export function CoPilotRail({
       />
     </aside>
   );
+}
+
+interface RoomThread {
+  key: string;
+  label: string;
+  cardId?: string;
+  latestTs: number;
+  turns: CollaborationMessage[];
+}
+
+const ROOM_THREAD_STYLE: CSSProperties = {
+  display: "grid",
+  gap: 8,
+  padding: 8,
+  border: "1px solid var(--hm-line)",
+  borderRadius: 8,
+  background: "rgba(255, 253, 247, 0.7)",
+};
+
+const ROOM_THREAD_HEAD_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  minWidth: 0,
+  color: "var(--hm-muted)",
+  fontSize: 11,
+  textTransform: "uppercase",
+  letterSpacing: ".08em",
+};
+
+const ROOM_THREAD_LABEL_STYLE: CSSProperties = {
+  flex: "1 1 auto",
+  minWidth: 0,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const ROOM_EMPTY_STYLE: CSSProperties = { opacity: 0.78 };
+const BOARD_SUMMARY_STYLE: CSSProperties = { opacity: 0.86 };
+
+function buildRoomThreads(messages: readonly CollaborationMessage[], cards: readonly BoardCard[]): RoomThread[] {
+  const threads = new Map<string, RoomThread>();
+  const sorted = [...messages].sort((a, b) => a.ts - b.ts);
+  for (const message of sorted) {
+    const key = threadKeyForMessage(message);
+    const existing = threads.get(key);
+    const label = threadLabelForMessage(message);
+    const cardId = cardIdForMessage(message, cards);
+    if (existing) {
+      existing.turns.push(message);
+      existing.latestTs = Math.max(existing.latestTs, message.ts);
+      if (!existing.cardId && cardId) existing.cardId = cardId;
+    } else {
+      threads.set(key, {
+        key,
+        label,
+        ...(cardId ? { cardId } : {}),
+        latestTs: message.ts,
+        turns: [message],
+      });
+    }
+  }
+  return [...threads.values()].sort((a, b) => a.latestTs - b.latestTs);
+}
+
+function threadKeyForMessage(message: CollaborationMessage): string {
+  if (message.relatedPr) return `pr:${message.relatedPr.repo}#${message.relatedPr.number}`;
+  if (message.relatedCorrelationId) return `correlation:${message.relatedCorrelationId}`;
+  return "room:whole-board";
+}
+
+function threadLabelForMessage(message: CollaborationMessage): string {
+  if (message.relatedPr) return `${message.relatedPr.repo} #${message.relatedPr.number}`;
+  if (message.relatedCorrelationId) return message.relatedCorrelationId;
+  return "Whole board";
+}
+
+function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCard[]): string | undefined {
+  if (message.relatedPr) {
+    const messagePr = message.relatedPr;
+    const card = cards.find((candidate) => {
+      const cardPr = relatedPrForCard(candidate);
+      return cardPr?.repo === messagePr.repo && cardPr.number === messagePr.number;
+    });
+    if (card) return card.id;
+  }
+  if (message.relatedCorrelationId) {
+    const card = cards.find((candidate) => (
+      candidate.id === message.relatedCorrelationId || candidate.correlationId === message.relatedCorrelationId
+    ));
+    if (card) return card.id;
+  }
+  return undefined;
+}
+
+function RoomThreadBlock({
+  thread,
+  onCardClick,
+}: {
+  thread: RoomThread;
+  onCardClick?: (id: string) => void;
+}) {
+  return (
+    <div
+      className="hm-room-thread"
+      style={ROOM_THREAD_STYLE}
+    >
+      <div
+        className="hm-room-thread-head"
+        style={ROOM_THREAD_HEAD_STYLE}
+      >
+        <span style={ROOM_THREAD_LABEL_STYLE}>
+          Thread · {thread.label}
+        </span>
+        <span>{thread.turns.length} turn{thread.turns.length === 1 ? "" : "s"}</span>
+      </div>
+      {thread.cardId ? (
+        <ActivityPin cardId={thread.cardId} onCardClick={onCardClick} />
+      ) : null}
+      {thread.turns.map((turn) => (
+        <HermesTurn
+          turn={turn}
+          onCardClick={onCardClick}
+          key={turn.id}
+        />
+      ))}
+    </div>
+  );
+}
+
+function RoomEmptyState() {
+  return (
+    <div
+      className="hm-turn hm-turn--system hm-turn--kind-status"
+      style={ROOM_EMPTY_STYLE}
+    >
+      <div className="hm-turn-head">
+        <span className="hm-turn-actor">
+          <span className="actor-dot" aria-hidden />
+          Room
+        </span>
+        <span className="hm-turn-kind">· empty</span>
+      </div>
+      <div className="hm-turn-body">
+        No agent chatter yet.
+        <small>Real Hermes, Codex, Claude, and specialist turns will appear here when recorded.</small>
+      </div>
+    </div>
+  );
+}
+
+function BoardSummaryRow({
+  banner,
+  onCardClick,
+}: {
+  banner?: BoardNowBannerData;
+  onCardClick?: (id: string) => void;
+}) {
+  const summary = boardSummaryCopy(banner);
+  return (
+    <div className="hm-turn hm-turn--system hm-turn--kind-status" style={BOARD_SUMMARY_STYLE}>
+      <div className="hm-turn-head">
+        <span className="hm-turn-actor">
+          <span className="actor-dot" aria-hidden />
+          Board
+        </span>
+        <span className="hm-turn-kind">· current summary</span>
+        <span className="hm-turn-time">{formatTurnTime(Date.now())}</span>
+      </div>
+      <div className="hm-turn-body">
+        <b>{summary.headline}:</b> {summary.text}
+        {banner?.sub ? <small>{banner.sub}</small> : null}
+      </div>
+      {banner?.primaryActionId ? (
+        <ActivityPin cardId={banner.primaryActionId} onCardClick={onCardClick} />
+      ) : null}
+    </div>
+  );
+}
+
+function boardSummaryCopy(banner: BoardNowBannerData | undefined): { headline: string; text: string } {
+  if (!banner) {
+    return {
+      headline: "Board summary",
+      text: "No current board summary was provided to the rail.",
+    };
+  }
+  if (banner.tone === "action") {
+    return {
+      headline: "Needs you",
+      text: `Operator review is waiting${banner.primaryActionId ? ` on ${banner.primaryActionId}` : " in the action lane"}.`,
+    };
+  }
+  if (banner.tone === "degraded") {
+    return {
+      headline: "Freshness warning",
+      text: "Reconnect or verify freshness before approving board state.",
+    };
+  }
+  if (banner.tone === "hermes-focus") {
+    return {
+      headline: "Active review thread",
+      text: `A scoped review conversation is active${banner.primaryActionId ? ` on ${banner.primaryActionId}` : ""}.`,
+    };
+  }
+  return {
+    headline: "Nothing urgent",
+    text: "No operator decision is waiting in the room right now.",
+  };
 }
 
 function hasScopedConversation(messages: readonly CollaborationMessage[], card: BoardCard | undefined): boolean {
@@ -213,53 +417,6 @@ function messageMatchesCard(message: CollaborationMessage, card: BoardCard): boo
   }
   const correlation = card.correlationId ?? card.id;
   return Boolean(message.relatedCorrelationId && message.relatedCorrelationId === correlation);
-}
-
-function ActivityEntryRow({
-  entry,
-  onCardClick,
-  onUseInComposer,
-}: {
-  entry: HermesActivityEntry;
-  onCardClick?: (id: string) => void;
-  onUseInComposer?: (text: string) => void;
-}) {
-  return (
-    <div className={`hm-turn hm-turn--${entry.actor} hm-turn--activity-${entry.tone}`}>
-      <div className="hm-turn-head">
-        <span className="hm-turn-actor">
-          <span className="actor-dot" aria-hidden />
-          {entry.actorDisplay ?? actorLabel(entry.actor)}
-        </span>
-        <span className="hm-turn-kind">· {entry.kindLabel}</span>
-        <span className="hm-turn-time">{formatTurnTime(entry.atMs)}</span>
-      </div>
-      <div className="hm-turn-body">
-        {entry.text}
-        {entry.meta ? <small>{entry.meta}</small> : null}
-      </div>
-      {entry.cardId ? (
-        <ActivityPin
-          cardId={entry.cardId}
-          onCardClick={onCardClick}
-        />
-      ) : null}
-      {onUseInComposer && entry.suggestions?.length ? (
-        <div className="hm-turn-actions" aria-label="Suggested prompts">
-          {entry.suggestions.map((suggestion) => (
-            <button
-              type="button"
-              className="hm-turn-suggest"
-              onClick={() => onUseInComposer(suggestion)}
-              key={suggestion}
-            >
-              {suggestion}
-            </button>
-          ))}
-        </div>
-      ) : null}
-    </div>
-  );
 }
 
 function ActivityPin({

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
@@ -18,7 +18,7 @@ const base: CollaborationMessage = {
 describe("HermesTurn", () => {
   test("renders actor label, kind, and body", () => {
     const { container, getByText } = render(<HermesTurn turn={base} />);
-    expect(getByText("Hermes")).toBeTruthy();
+    expect(getByText("Hermes → You")).toBeTruthy();
     expect(getByText(/status/)).toBeTruthy();
     expect(getByText("Pre-check passed on #548.")).toBeTruthy();
     expect((container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--hermes");
@@ -26,24 +26,33 @@ describe("HermesTurn", () => {
 
   test("labels live and templated Hermes turns honestly", () => {
     const live = render(<HermesTurn turn={{ ...base, id: "live", hermesMode: "live" }} />);
-    expect(live.getByText("Hermes (live)")).toBeTruthy();
+    expect(live.getByText("Hermes (live) → You")).toBeTruthy();
     live.unmount();
 
     const templated = render(<HermesTurn turn={{ ...base, id: "templated", hermesMode: "templated" }} />);
-    expect(templated.getByText("Hermes (offline — templated)")).toBeTruthy();
+    expect(templated.getByText("Hermes (offline — templated) → You")).toBeTruthy();
   });
 
-  test("operator turns are labelled Pascal", () => {
+  test("operator turns are labelled as You", () => {
     const { getByText } = render(<HermesTurn turn={{ ...base, id: "2", author: "operator" }} />);
-    expect(getByText("Pascal")).toBeTruthy();
+    expect(getByText("You → You")).toBeTruthy();
   });
 
   test("Claude turns are attributed as agent messages", () => {
     const { container, getByText } = render(
       <HermesTurn turn={{ ...base, id: "claude-1", author: "claude", addressedTo: "codex" }} />,
     );
-    expect(getByText("Claude")).toBeTruthy();
+    expect(getByText("Claude → Codex")).toBeTruthy();
     expect((container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--claude");
+  });
+
+  test("ranks request-help turns as prominent and status turns as muted", () => {
+    const help = render(<HermesTurn turn={{ ...base, id: "help", kind: "request_help" }} />);
+    expect((help.container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--rank-prominent");
+    help.unmount();
+
+    const status = render(<HermesTurn turn={{ ...base, id: "status", kind: "status" }} />);
+    expect((status.container.querySelector(".hm-turn") as HTMLElement).className).toContain("hm-turn--rank-muted");
   });
 
   test("a relatedPr renders a real GitHub PR link", () => {

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
@@ -1,25 +1,56 @@
 // Hermes Handoff Monitor — a single collaboration turn (M8').
 
-import type { CollaborationMessage } from "../../lib/monitor/collaboration.js";
-import { actorLabelForMessage, formatTurnTime } from "../../lib/monitor/collaboration.js";
+import type { CollaborationAuthor, CollaborationMessage, CollaborationTarget } from "../../lib/monitor/collaboration.js";
+import { actorLabel, actorLabelForMessage, formatTurnTime } from "../../lib/monitor/collaboration.js";
+import type { CSSProperties } from "react";
 
-export function HermesTurn({ turn }: { turn: CollaborationMessage }) {
+const PROMINENT_TURN_STYLE: CSSProperties = {
+  borderLeftColor: "var(--hm-amber)",
+  background: "var(--hm-amber-soft, #fff3df)",
+};
+
+const MUTED_TURN_STYLE: CSSProperties = {
+  opacity: 0.72,
+  background: "rgba(255, 253, 247, 0.58)",
+};
+
+const DEFAULT_TURN_STYLE: CSSProperties = {};
+
+export function HermesTurn({
+  turn,
+  cardId,
+  onCardClick,
+}: {
+  turn: CollaborationMessage;
+  cardId?: string;
+  onCardClick?: (id: string) => void;
+}) {
   const prHref = turn.relatedPr
     ? `https://github.com/${turn.relatedPr.repo}/pull/${turn.relatedPr.number}`
     : undefined;
+  const pending = turn.id.startsWith("optimistic-");
+  const rank = rankForKind(turn.kind);
 
   return (
-    <div className={"hm-turn hm-turn--" + turn.author}>
+    <div
+      className={`hm-turn hm-turn--${turn.author} hm-turn--kind-${turn.kind} hm-turn--rank-${rank}`}
+      style={turnStyleForKind(turn.kind)}
+    >
       <div className="hm-turn-head">
         <span className="hm-turn-actor">
           <span className="actor-dot" aria-hidden />
-          {actorLabelForMessage(turn)}
+          {roomActorLabel(turn)}
         </span>
-        <span style={{ marginLeft: 4, opacity: 0.7, fontWeight: 500, letterSpacing: 0 }}>· {turn.kind}</span>
+        <span className="hm-turn-kind">
+          · {kindLabel(turn.kind)}
+          {pending ? " · pending" : ""}
+        </span>
         <span className="hm-turn-time">{formatTurnTime(turn.ts)}</span>
       </div>
       <div className="hm-turn-body">{turn.text}</div>
-      {turn.relatedPr ? (
+      {cardId ? (
+        <CardPin cardId={cardId} onCardClick={onCardClick} />
+      ) : turn.relatedPr ? (
         <a className="hm-turn-pin" href={prHref} target="_blank" rel="noreferrer">
           <span className="pin-id">#{turn.relatedPr.number}</span>
           <span className="pin-title">{turn.relatedPr.repo}</span>
@@ -27,4 +58,67 @@ export function HermesTurn({ turn }: { turn: CollaborationMessage }) {
       ) : null}
     </div>
   );
+}
+
+function CardPin({
+  cardId,
+  onCardClick,
+}: {
+  cardId: string;
+  onCardClick?: (id: string) => void;
+}) {
+  const content = (
+    <>
+      <span className="pin-id">{cardId}</span>
+      <span className="pin-title">Referenced card</span>
+      <span className="pin-arrow">{onCardClick ? "open ›" : "referenced"}</span>
+    </>
+  );
+  if (!onCardClick) return <div className="hm-turn-pin">{content}</div>;
+  return (
+    <button
+      type="button"
+      className="hm-turn-pin"
+      onClick={() => onCardClick(cardId)}
+      aria-label={`Open referenced card ${cardId}`}
+    >
+      {content}
+    </button>
+  );
+}
+
+function roomActorLabel(turn: CollaborationMessage): string {
+  return `${authorLabel(turn.author, turn)} → ${targetLabel(turn.addressedTo)}`;
+}
+
+function authorLabel(author: CollaborationAuthor, turn: CollaborationMessage): string {
+  if (author === "operator") return "You";
+  return actorLabelForMessage(turn);
+}
+
+function targetLabel(target: CollaborationTarget): string {
+  if (target === "everyone") return "everyone";
+  if (target === "operator") return "You";
+  return actorLabel(target);
+}
+
+function kindLabel(kind: CollaborationMessage["kind"]): string {
+  if (kind === "request_help") return "request help";
+  return kind;
+}
+
+function rankForKind(kind: CollaborationMessage["kind"]): "prominent" | "normal" | "muted" {
+  if (kind === "request_help" || kind === "proposal") return "prominent";
+  if (kind === "status") return "muted";
+  return "normal";
+}
+
+function turnStyleForKind(kind: CollaborationMessage["kind"]): CSSProperties {
+  if (kind === "request_help" || kind === "proposal") {
+    return PROMINENT_TURN_STYLE;
+  }
+  if (kind === "status") {
+    return MUTED_TURN_STYLE;
+  }
+  return DEFAULT_TURN_STYLE;
 }

--- a/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
+++ b/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
@@ -37,8 +37,30 @@ describe("useCollaboration", () => {
       result.current.ask("what's blocking?", { repo: "depre-dev/agent", number: 548 });
     });
 
-    expect(poster).toHaveBeenCalledWith({ text: "what's blocking?", relatedPr: { repo: "depre-dev/agent", number: 548 } });
+    expect(poster).toHaveBeenCalledWith({
+      text: "what's blocking?",
+      addressedTo: "hermes",
+      relatedPr: { repo: "depre-dev/agent", number: 548 },
+    });
     await waitFor(() => expect(result.current.messages.map((m) => m.id)).toEqual(["q", "a"]));
+  });
+
+  test("ask can address a non-Hermes collaboration target", async () => {
+    const poster = vi.fn(async () => {});
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [], poster, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => result.current.ask("please inspect this", undefined, "codex"));
+
+    expect(poster).toHaveBeenCalledWith({ text: "please inspect this", addressedTo: "codex" });
+    expect(result.current.messages.at(-1)).toMatchObject({
+      author: "operator",
+      addressedTo: "codex",
+      text: "please inspect this",
+    });
   });
 
   test("a blank question does not post", async () => {

--- a/packages/monitor-ui/src/hooks/useCollaboration.ts
+++ b/packages/monitor-ui/src/hooks/useCollaboration.ts
@@ -8,7 +8,7 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
-import type { CollaborationMessage, CollaborationRelatedPr } from "../lib/monitor/collaboration.js";
+import type { CollaborationMessage, CollaborationRelatedPr, CollaborationTarget } from "../lib/monitor/collaboration.js";
 
 const DEFAULT_URL = "/monitor/collaboration";
 const DEFAULT_REFRESH_MS = 4000;
@@ -16,6 +16,7 @@ const DEFAULT_REFRESH_MS = 4000;
 export interface AskInput {
   text: string;
   relatedPr?: CollaborationRelatedPr;
+  addressedTo?: CollaborationTarget;
 }
 
 export interface UseCollaborationOptions {
@@ -31,7 +32,7 @@ export interface UseCollaborationOptions {
 export interface CollaborationState {
   messages: CollaborationMessage[];
   /** Ask Hermes; optionally scoped to a PR. Records + triggers a revalidate. */
-  ask: (text: string, relatedPr?: CollaborationRelatedPr) => void;
+  ask: (text: string, relatedPr?: CollaborationRelatedPr, addressedTo?: CollaborationTarget) => void;
   isLoading: boolean;
   error: unknown;
   /** Whether the rail is wired to a live collaboration channel at all. */
@@ -61,7 +62,7 @@ function makeDefaultPoster(url: string): (input: AskInput) => Promise<void> {
       body: JSON.stringify({
         author: "operator",
         kind: "chat",
-        addressedTo: "hermes",
+        addressedTo: input.addressedTo ?? "hermes",
         text: input.text,
         ...(input.relatedPr ? { relatedPr: input.relatedPr } : {}),
       }),
@@ -108,7 +109,7 @@ export function useCollaboration(opts: UseCollaborationOptions = {}): Collaborat
   const clearSendError = useCallback(() => setSendError(null), []);
 
   const ask = useCallback(
-    (text: string, relatedPr?: CollaborationRelatedPr) => {
+    (text: string, relatedPr?: CollaborationRelatedPr, addressedTo: CollaborationTarget = "hermes") => {
       const trimmed = text.trim();
       if (!trimmed || !enabled) return;
       seq.current += 1;
@@ -119,13 +120,13 @@ export function useCollaboration(opts: UseCollaborationOptions = {}): Collaborat
         author: "operator",
         kind: "chat",
         text: trimmed,
-        addressedTo: "hermes",
+        addressedTo,
         ...(relatedPr ? { relatedPr } : {}),
       };
       setOptimistic((prev) => [...prev, optimisticMessage]);
       setSendError(null);
       setPending(true);
-      void poster({ text: trimmed, ...(relatedPr ? { relatedPr } : {}) })
+      void poster({ text: trimmed, addressedTo, ...(relatedPr ? { relatedPr } : {}) })
         .then(() => mutate())
         .catch(() => {
           // Do NOT swallow: roll back the optimistic message and surface


### PR DESCRIPTION
## Summary
- Redesigns the Hermes co-pilot rail as a multi-agent collaboration room instead of a Hermes-only narration feed.
- Groups real collaboration turns by PR/correlation thread and renders author -> target labels for Hermes, Codex, Claude, specialists, system, and the operator.
- Adds an @target selector to the composer and plumbs the selected `addressedTo` value through the existing collaboration UI hook.
- Keeps empty/degraded states honest: no generated agent chatter, only real recorded turns plus a factual board summary.

## Safety / authority
- UI-only collaboration-room presentation.
- No backend API changes.
- No auto-run, auto-approve, merge, deploy, or authority changes.
- The only non-`components/hermes` change is frontend hook payload plumbing so the selected target reaches the existing endpoint.

## Checks
- `npm --workspace @avg/monitor-ui test`
- `npm --workspace @avg/monitor-ui run typecheck`
- `npm --workspace @avg/monitor-ui run build`
- Browser visual gut-check against `http://127.0.0.1:5178/`

## Notes
- Full monitor-ui suite passed: 566 tests.
- The Vite dev server was only used locally for visual verification and was stopped before commit.
