### PR TITLE
feat(hermes): learn routing from agent outcomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,12 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   proposed Codex/Claude tasks and narrate why in the monitor co-pilot rail. It
   reuses the dispatch allowlist/caps, same-tick and queue dedupe, cooldown,
   HALT, and D3 suspension gates; it **never** approves, dispatches, merges, or
-  deploys. No backlog gap means no proposal and no chatter.
+  deploys. No backlog gap means no proposal and no chatter. ORCH-P4c adds
+  learned routing memory from real runner outcomes (`opened_pr`, `no_pr`,
+  `failed`) per agent × surface. That memory may break ties on soft/ambiguous
+  surfaces only; hard taxonomy still binds chain/settlement/treasury to Codex
+  and UI/docs/monitor to Claude, and the dispatch policy always remains the final
+  gate.
 - **Gold-path tester autonomy is budgeted, testnet-only.** Internal/operator
   scheduled gold-path missions may auto-post a sponsored starter job and run the
   claim→submit→verify→settle loop only when `TESTBED_GOLDPATH_AUTONOMY_ENABLED`

--- a/packages/averray-mcp/src/agent-scorecard.ts
+++ b/packages/averray-mcp/src/agent-scorecard.ts
@@ -10,6 +10,34 @@ import {
 
 export type ScorecardAgent = "codex" | "claude" | "test-writer" | "security" | "docs" | "hermes" | "browser" | "unknown";
 export type ScorecardConfidence = "none" | "low" | "medium" | "high";
+export type AgentRoutingOutcomeKind = "opened_pr" | "no_pr" | "failed";
+export type AgentRoutingScoreStatus = "baseline_available" | "insufficient_data";
+
+export interface AgentRoutingSurfaceScore {
+  agent: ScorecardAgent;
+  surface: string;
+  status: AgentRoutingScoreStatus;
+  score: number | null;
+  samples: number;
+  openedPr: number;
+  noPr: number;
+  failed: number;
+  avgDurationMinutes: number | null;
+  tokenUsage: {
+    status: "recorded" | "not_recorded";
+    totalTokens: number | null;
+    costUsd: number | null;
+  };
+  lastOutcomeAt: string | null;
+  note: string;
+}
+
+export type WorkRouterScoreMap = Record<string, Partial<Record<"codex" | "claude", {
+  status: AgentRoutingScoreStatus;
+  score: number | null;
+  samples: number;
+  reason: string;
+}>>>;
 
 export interface AgentScorecardOptions {
   now?: Date;
@@ -50,8 +78,30 @@ interface MutableAgentStats {
   checkNeutral: number;
   verdicts: Record<string, number>;
   surfaces: Map<string, { count: number; ready: number; blocked: number }>;
+  routingOutcomes: AgentRoutingOutcome[];
   seenPrKeys: Set<string>;
 }
+
+interface AgentRoutingOutcome {
+  agent: ScorecardAgent;
+  surface: string;
+  outcome: AgentRoutingOutcomeKind;
+  ciPassed?: boolean;
+  merged?: boolean;
+  reverted?: boolean;
+  durationMs?: number;
+  tokenUsage?: {
+    model?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheTokens?: number;
+    totalTokens?: number;
+    costUsd?: number;
+  };
+  recordedAt: string;
+}
+
+const ROUTING_SCORE_MIN_SAMPLES = 2;
 
 export async function getAgentScorecard(options: AgentScorecardOptions = {}) {
   const now = options.now ?? new Date();
@@ -102,6 +152,7 @@ export function buildAgentScorecard(snapshot: unknown, options: { now?: Date } =
   const items = Array.from(agents.values())
     .map((agent) => finalizeAgent(agent, llmUsage))
     .sort((a, b) => agentSortKey(a.agent) - agentSortKey(b.agent) || b.sampleCount - a.sampleCount);
+  const routingMemory = buildRoutingMemory(Array.from(agents.values()));
 
   const totals = items.reduce(
     (acc, item) => {
@@ -119,24 +170,50 @@ export function buildAgentScorecard(snapshot: unknown, options: { now?: Date } =
     schemaVersion: 1,
     kind: "averray_agent_scorecard",
     generatedAt: now.toISOString(),
-    truthBoundary: "Read-only A1 scorecard from monitor events, task queue state, browser mission reports, and whitelisted LLM usage counters. Missing cost/token/autopilot-rework signals are marked as not_recorded, not inferred.",
+    truthBoundary: "Read-only scorecard from monitor events, task queue state, browser mission reports, runner completion outcomes, and whitelisted LLM usage counters. Missing cost/token/autopilot-rework/merge-webhook signals are marked as not_recorded, not inferred.",
     totals,
     llmUsage,
+    routingMemory,
     agents: items,
     gaps: [
       llmUsage.status === "recorded"
         ? "LLM usage only includes providers/runs that report whitelisted counters; missing providers stay not_recorded."
         : "Cost and token totals are not present in the current runner events.",
       "Autopilot auto-approval rework is not yet emitted as a durable signal.",
+      "PR merge/revert status is not pushed by a webhook yet; routing memory records it only when a task record already contains that evidence.",
       "Time-to-PR and time-to-merge need GitHub timeline evidence before they become routing inputs.",
     ],
     safety: {
       readOnly: true,
       mutatesGithub: false,
       mutatesRunnerQueue: false,
-      routingInfluence: "A1 only observes. A2 may use these baselines later with high-risk surfaces still rule-bound.",
+      routingInfluence: "ORCH-P4c may use routingMemory only on soft surfaces. Hard taxonomy and dispatch policy remain authoritative.",
     },
   };
+}
+
+export function routingScoresFromScorecard(scorecard: unknown): WorkRouterScoreMap {
+  const routingMemory = recordField(scorecard, "routingMemory");
+  const scores: WorkRouterScoreMap = {};
+  for (const entry of records(routingMemory?.scores)) {
+    const agent = scorecardAgent(stringField(entry, "agent") ?? "");
+    if (agent !== "codex" && agent !== "claude") continue;
+    const surface = normalizeSurface(stringField(entry, "surface"));
+    if (!surface) continue;
+    const status = stringField(entry, "status") === "baseline_available" ? "baseline_available" : "insufficient_data";
+    const score = numberField(entry, "score");
+    const samples = Math.max(0, numberField(entry, "samples") ?? 0);
+    scores[surface] = {
+      ...(scores[surface] ?? {}),
+      [agent]: {
+        status,
+        score: status === "baseline_available" && score !== undefined ? score : null,
+        samples,
+        reason: stringField(entry, "note") ?? `${agent} has ${samples} ${surface} routing sample(s).`,
+      },
+    };
+  }
+  return scores;
 }
 
 function recordHandoffItem(agents: Map<ScorecardAgent, MutableAgentStats>, item: Record<string, unknown>): void {
@@ -212,6 +289,16 @@ function recordTask(agents: Map<ScorecardAgent, MutableAgentStats>, task: Record
   if (durationMs !== undefined) {
     stats.taskDurationMsTotal += durationMs;
     stats.taskDurationCount += 1;
+  }
+
+  const routingOutcome = routingOutcomeForTask(task);
+  if (routingOutcome) {
+    stats.routingOutcomes.push(routingOutcome);
+    const surfaceStats = stats.surfaces.get(routingOutcome.surface) ?? { count: 0, ready: 0, blocked: 0 };
+    surfaceStats.count += 1;
+    if (routingOutcome.outcome === "opened_pr") surfaceStats.ready += 1;
+    if (routingOutcome.outcome === "failed") surfaceStats.blocked += 1;
+    stats.surfaces.set(routingOutcome.surface, surfaceStats);
   }
 }
 
@@ -337,7 +424,84 @@ function finalizeAgent(stats: MutableAgentStats, llmUsage: ReturnType<typeof agg
       .map(([surface, value]) => ({ surface, ...value }))
       .sort((a, b) => b.count - a.count || a.surface.localeCompare(b.surface))
       .slice(0, 8),
+    routingSurfaces: routingScoresForAgent(stats).slice(0, 8),
   };
+}
+
+function buildRoutingMemory(stats: MutableAgentStats[]) {
+  const scores = stats
+    .flatMap((agent) => routingScoresForAgent(agent))
+    .sort((a, b) => a.surface.localeCompare(b.surface) || agentSortKey(a.agent) - agentSortKey(b.agent));
+  const ready = scores.filter((score) => score.status === "baseline_available").length;
+  return {
+    status: ready > 0 ? "recorded" : "insufficient_data",
+    minSamples: ROUTING_SCORE_MIN_SAMPLES,
+    truthBoundary: "Only task records with explicit runner completion routing outcomes feed learned routing. Sparse surfaces stay insufficient_data; merge/revert is not inferred without a real upstream signal.",
+    scores,
+  };
+}
+
+function routingScoresForAgent(stats: MutableAgentStats): AgentRoutingSurfaceScore[] {
+  const bySurface = new Map<string, AgentRoutingOutcome[]>();
+  for (const outcome of stats.routingOutcomes) {
+    bySurface.set(outcome.surface, [...(bySurface.get(outcome.surface) ?? []), outcome]);
+  }
+  return Array.from(bySurface.entries())
+    .map(([surface, outcomes]) => routingSurfaceScore(stats.agent, surface, outcomes))
+    .sort((a, b) => (b.samples - a.samples) || a.surface.localeCompare(b.surface));
+}
+
+function routingSurfaceScore(agent: ScorecardAgent, surface: string, outcomes: AgentRoutingOutcome[]): AgentRoutingSurfaceScore {
+  const sorted = outcomes.slice().sort((a, b) => b.recordedAt.localeCompare(a.recordedAt));
+  const samples = sorted.length;
+  const openedPr = sorted.filter((outcome) => outcome.outcome === "opened_pr").length;
+  const noPr = sorted.filter((outcome) => outcome.outcome === "no_pr").length;
+  const failed = sorted.filter((outcome) => outcome.outcome === "failed").length;
+  const durations = sorted.map((outcome) => outcome.durationMs).filter((value): value is number => typeof value === "number");
+  const tokenTotals = sorted.map((outcome) => outcome.tokenUsage?.totalTokens).filter((value): value is number => typeof value === "number");
+  const costs = sorted.map((outcome) => outcome.tokenUsage?.costUsd).filter((value): value is number => typeof value === "number");
+  const status: AgentRoutingScoreStatus = samples >= ROUTING_SCORE_MIN_SAMPLES ? "baseline_available" : "insufficient_data";
+  const score = status === "baseline_available" ? weightedRoutingScore(sorted) : null;
+  return {
+    agent,
+    surface,
+    status,
+    score,
+    samples,
+    openedPr,
+    noPr,
+    failed,
+    avgDurationMinutes: durations.length > 0 ? round((durations.reduce((sum, value) => sum + value, 0) / durations.length) / 60_000, 2) : null,
+    tokenUsage: {
+      status: tokenTotals.length > 0 ? "recorded" : "not_recorded",
+      totalTokens: tokenTotals.length > 0 ? tokenTotals.reduce((sum, value) => sum + value, 0) : null,
+      costUsd: costs.length > 0 ? round(costs.reduce((sum, value) => sum + value, 0), 6) : null,
+    },
+    lastOutcomeAt: sorted[0]?.recordedAt ?? null,
+    note: status === "baseline_available"
+      ? `${agent} has ${samples} real ${surface} outcome(s); recent runs are weighted more heavily.`
+      : `${agent} has only ${samples} real ${surface} outcome(s); learned routing must fall back to static routing.`,
+  };
+}
+
+function weightedRoutingScore(outcomes: AgentRoutingOutcome[]): number {
+  let weighted = 0;
+  let totalWeight = 0;
+  outcomes.forEach((outcome, index) => {
+    const weight = Math.pow(0.72, index);
+    weighted += routingOutcomeValue(outcome) * weight;
+    totalWeight += weight;
+  });
+  return totalWeight > 0 ? clamp(Math.round((weighted / totalWeight) * 100), 0, 100) : 0;
+}
+
+function routingOutcomeValue(outcome: AgentRoutingOutcome): number {
+  if (outcome.reverted) return 0;
+  let value = outcome.outcome === "opened_pr" ? 1 : outcome.outcome === "no_pr" ? 0.35 : 0;
+  if (outcome.ciPassed === true) value += 0.05;
+  if (outcome.ciPassed === false) value -= 0.15;
+  if (outcome.merged === true) value += 0.05;
+  return clamp(value, 0, 1);
 }
 
 function ensureAgent(agents: Map<ScorecardAgent, MutableAgentStats>, agent: ScorecardAgent): MutableAgentStats {
@@ -371,6 +535,7 @@ function ensureAgent(agents: Map<ScorecardAgent, MutableAgentStats>, agent: Scor
     checkNeutral: 0,
     verdicts: {},
     surfaces: new Map(),
+    routingOutcomes: [],
     seenPrKeys: new Set(),
   };
   agents.set(agent, next);
@@ -431,6 +596,53 @@ function taskAgent(task: Record<string, unknown>): ScorecardAgent {
   const scorecard = scorecardAgent(agent);
   if (scorecard !== "unknown") return scorecard;
   return "codex";
+}
+
+function routingOutcomeForTask(task: Record<string, unknown>): AgentRoutingOutcome | undefined {
+  const explicit = recordField(task, "routingOutcome");
+  if (!explicit) return undefined;
+  const agent = scorecardAgent(stringField(explicit, "agent") ?? stringField(task, "agent") ?? "");
+  if (agent === "unknown") return undefined;
+  const surface = normalizeSurface(stringField(explicit, "surface") ?? stringField(task, "surface"));
+  if (!surface) return undefined;
+  const outcome = routingOutcomeKind(stringField(explicit, "outcome"));
+  if (!outcome) return undefined;
+  const recordedAt = stringField(explicit, "recordedAt") ?? stringField(task, "completedAt") ?? stringField(task, "failedAt");
+  if (!recordedAt) return undefined;
+  const tokenUsage = recordField(explicit, "tokenUsage");
+  return {
+    agent,
+    surface,
+    outcome,
+    ...(typeof booleanField(explicit, "ciPassed") === "boolean" ? { ciPassed: booleanField(explicit, "ciPassed") } : {}),
+    ...(typeof booleanField(explicit, "merged") === "boolean" ? { merged: booleanField(explicit, "merged") } : {}),
+    ...(typeof booleanField(explicit, "reverted") === "boolean" ? { reverted: booleanField(explicit, "reverted") } : {}),
+    ...(numberField(explicit, "durationMs") !== undefined ? { durationMs: numberField(explicit, "durationMs") } : {}),
+    ...(tokenUsage ? { tokenUsage: routingTokenUsage(tokenUsage) } : {}),
+    recordedAt,
+  };
+}
+
+function routingOutcomeKind(value: string | undefined): AgentRoutingOutcomeKind | undefined {
+  if (value === "opened_pr" || value === "no_pr" || value === "failed") return value;
+  return undefined;
+}
+
+function routingTokenUsage(value: Record<string, unknown>): AgentRoutingOutcome["tokenUsage"] | undefined {
+  const inputTokens = numberField(value, "inputTokens");
+  const outputTokens = numberField(value, "outputTokens");
+  const cacheTokens = numberField(value, "cacheTokens");
+  const totalTokens = numberField(value, "totalTokens");
+  const costUsd = numberField(value, "costUsd");
+  const usage = {
+    ...(stringField(value, "model") ? { model: stringField(value, "model") } : {}),
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(cacheTokens !== undefined ? { cacheTokens } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
+  return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
 function agentForMission(mission: Record<string, unknown>): ScorecardAgent {
@@ -575,6 +787,14 @@ function records(value: unknown): Record<string, unknown>[] {
 
 function arrayStrings(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0) : [];
+}
+
+function normalizeSurface(value: string | undefined): string {
+  return (value ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9/._ -]+/g, " ")
+    .trim()
+    .replace(/\s+/g, " ");
 }
 
 function round(value: number, digits: number): number {

--- a/packages/averray-mcp/src/work-router.ts
+++ b/packages/averray-mcp/src/work-router.ts
@@ -4,6 +4,16 @@ import type { HermesBacklogItem } from "./hermes-backlog.js";
 
 export type RoutedWorkAgent = "codex" | "claude";
 export type RoutedWorkStatus = "proposed" | "approved" | "running" | "completed" | "failed" | "cancelled" | string;
+export type WorkRouterRoutingScoreStatus = "baseline_available" | "insufficient_data";
+
+export interface WorkRouterRoutingScore {
+  status: WorkRouterRoutingScoreStatus;
+  score: number | null;
+  samples: number;
+  reason?: string;
+}
+
+export type WorkRouterRoutingScores = Record<string, Partial<Record<RoutedWorkAgent, WorkRouterRoutingScore>>>;
 
 export interface WorkRouterBacklogItem extends Partial<Pick<HermesBacklogItem, "id" | "title" | "prompt" | "stream">> {
   repo: string;
@@ -38,6 +48,8 @@ export interface PlanAndRouteWorkInput {
   recentlyDone: WorkRouterTaskSnapshot[];
   policy: WorkRouterPolicySnapshot;
   classify: WorkRouterClassifier;
+  /** ORCH-P4c: learned scorecard memory. Used only on soft surfaces. */
+  routingScores?: WorkRouterRoutingScores;
   maxProposals?: number;
 }
 
@@ -83,7 +95,12 @@ export function planAndRouteWork(input: PlanAndRouteWorkInput): RoutedProposal[]
       prompt: [title, description].filter(Boolean).join(": "),
       tags: item.stream ? [item.stream] : undefined,
     });
-    const agent = routedAgent(routing.agent);
+    const classifiedAgent = routedAgent(routing.agent);
+    const hardAgent = hardTaxonomyAgent(surface, title);
+    const learned = hardAgent
+      ? { agent: hardAgent, note: hardAgent === classifiedAgent ? undefined : `Hard taxonomy kept ${surface} with ${hardAgent}; learned routing and classifier output cannot override it.` }
+      : learnedRoutingChoice(surface, classifiedAgent, input.routingScores);
+    const agent = learned.agent;
     assertTaxonomy(surface, title, agent);
     if (!policyAllows(input.policy, { repo, agent, accepted: proposals.length, acceptedRepoCounts })) continue;
 
@@ -94,7 +111,7 @@ export function planAndRouteWork(input: PlanAndRouteWorkInput): RoutedProposal[]
       agent,
       riskTier: routing.riskTier,
       why: `Fills uncovered backlog gap: ${title}.`,
-      whyAgent: routing.reason,
+      whyAgent: [routing.reason, learned.note].filter(Boolean).join(" "),
       dedupeKey: proposalDedupeKey,
     };
     proposals.push(proposal);
@@ -133,13 +150,54 @@ function routedAgent(agent: string): RoutedWorkAgent {
 }
 
 function assertTaxonomy(surface: string, title: string, agent: RoutedWorkAgent): void {
+  const hardAgent = hardTaxonomyAgent(surface, title);
+  if (hardAgent && agent !== hardAgent) {
+    throw new Error(`routing_taxonomy_violation: ${surface} must route to ${hardAgent}`);
+  }
+}
+
+function hardTaxonomyAgent(surface: string, title: string): RoutedWorkAgent | undefined {
   const haystack = normalizeText(`${surface} ${title}`);
   if (matchesAny(haystack, ["chain", "settlement", "escrow", "contract", "contracts", "xcm", "polkadot", "substrate", "treasury"])) {
-    if (agent !== "codex") throw new Error(`routing_taxonomy_violation: ${surface} must route to codex`);
+    return "codex";
   }
   if (matchesAny(haystack, ["ui", "frontend", "front end", "docs", "documentation", "readme", "copy", "monitor", "drawer", "board"])) {
-    if (agent !== "claude") throw new Error(`routing_taxonomy_violation: ${surface} must route to claude`);
+    return "claude";
   }
+  return undefined;
+}
+
+function learnedRoutingChoice(
+  surface: string,
+  staticAgent: RoutedWorkAgent,
+  routingScores: WorkRouterRoutingScores | undefined,
+): { agent: RoutedWorkAgent; note?: string } {
+  const normalizedSurface = normalizeText(surface);
+  const surfaceScores = routingScores?.[normalizedSurface];
+  if (!surfaceScores) return { agent: staticAgent };
+  const otherAgent: RoutedWorkAgent = staticAgent === "codex" ? "claude" : "codex";
+  const staticScore = surfaceScores[staticAgent];
+  const otherScore = surfaceScores[otherAgent];
+  if (!isUsableRoutingScore(staticScore) || !isUsableRoutingScore(otherScore)) {
+    return {
+      agent: staticAgent,
+      note: `Learned routing has insufficient ${normalizedSurface || "general"} data; static fallback kept ${staticAgent}.`,
+    };
+  }
+  if ((otherScore.score ?? 0) > (staticScore.score ?? 0)) {
+    return {
+      agent: otherAgent,
+      note: `Learned routing preferred ${otherAgent} for ${normalizedSurface || "general"} (${otherAgent} ${otherScore.score} from ${otherScore.samples} sample(s), ${staticAgent} ${staticScore.score} from ${staticScore.samples}).`,
+    };
+  }
+  return {
+    agent: staticAgent,
+    note: `Learned routing kept ${staticAgent} for ${normalizedSurface || "general"} (${staticAgent} ${staticScore.score} from ${staticScore.samples} sample(s), ${otherAgent} ${otherScore.score} from ${otherScore.samples}).`,
+  };
+}
+
+function isUsableRoutingScore(score: WorkRouterRoutingScore | undefined): score is WorkRouterRoutingScore & { score: number } {
+  return score?.status === "baseline_available" && typeof score.score === "number" && Number.isFinite(score.score);
 }
 
 function matchesAny(haystack: string, needles: string[]): boolean {

--- a/services/slack-operator/src/claude-task-runner.ts
+++ b/services/slack-operator/src/claude-task-runner.ts
@@ -23,7 +23,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
-import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
+import { beginLlmUsageCall, recordLlmUsageFromResult, type LlmUsageEvent } from "@avg/averray-mcp/llm-usage";
 
 import { parseBranchWorkerOutcome, type BranchWorkerOutcome } from "./branch-worker-outcome.js";
 import {
@@ -34,7 +34,7 @@ import {
   type ClaudeWorkerAuthEnv,
   type ClaudeWorkerAuthMode,
 } from "./claude-worker-auth.js";
-import type { CodexTask, TaskAgent } from "./codex-task-queue.js";
+import type { CodexTask, CodexTaskRoutingTokenUsage, TaskAgent } from "./codex-task-queue.js";
 import {
   claimNextApprovedCodexTask,
   completeCodexTask,
@@ -198,7 +198,7 @@ export async function runClaudeTaskRunnerOnce(
   });
   try {
     const result = await executor(claimed, config, { mode });
-    await recordLlmUsageFromResult({
+    const usageEvent = await recordLlmUsageFromResult({
       agent: config.agent,
       ...(config.model ? { model: config.model } : {}),
       taskId: claimed.id,
@@ -206,6 +206,7 @@ export async function runClaudeTaskRunnerOnce(
       result,
     }).catch(() => undefined);
     const outcome = result.outcome ?? parseBranchWorkerOutcome(result.stdout);
+    const tokenUsage = routingTokenUsage(usageEvent);
     if (result.exitCode === 0 && outcome?.opened) {
       const summary = openedPullRequestSummary(result, outcome, `${taskAgentLabel(config.agent)} runner opened a pull request.`);
       const task = await completeCodexTask(claimed.id, {
@@ -214,6 +215,10 @@ export async function runClaudeTaskRunnerOnce(
         exitCode: result.exitCode,
         stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
         stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+        routingOutcome: {
+          outcome: "opened_pr",
+          ...(tokenUsage ? { tokenUsage } : {}),
+        },
       });
       await heartbeat(config, "completed", summary || `${taskAgentLabel(config.agent)} runner completed ${taskLabel(claimed)}.`, undefined, claimed.id);
       return { status: "completed", task: task ?? claimed };
@@ -229,12 +234,20 @@ export async function runClaudeTaskRunnerOnce(
       exitCode: result.exitCode,
       stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
       stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+      routingOutcome: {
+        outcome: outcome && !outcome.opened ? "no_pr" : "failed",
+        ...(tokenUsage ? { tokenUsage } : {}),
+      },
     });
     await heartbeat(config, "failed", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
   } catch (error) {
     const reason = sanitizeOutput(error instanceof Error ? error.message : String(error));
-    const task = await failCodexTask(claimed.id, { path: config.path, failureReason: reason });
+    const task = await failCodexTask(claimed.id, {
+      path: config.path,
+      failureReason: reason,
+      routingOutcome: { outcome: "failed" },
+    });
     await heartbeat(config, "error", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
   } finally {
@@ -386,6 +399,18 @@ function openedPullRequestSummary(result: ClaudeTaskRunResult, outcome: Extract<
 
 function noPullRequestFailureReason(outcome: Extract<BranchWorkerOutcome, { opened: false }>): string {
   return sanitizeOutput(outcome.reason || outcome.summary || "Worker finished without opening a pull request.");
+}
+
+function routingTokenUsage(event: LlmUsageEvent | undefined): CodexTaskRoutingTokenUsage | undefined {
+  if (!event) return undefined;
+  return {
+    model: event.model,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    ...(event.cacheTokens !== undefined ? { cacheTokens: event.cacheTokens } : {}),
+    totalTokens: event.inputTokens + event.outputTokens + (event.cacheTokens ?? 0),
+    ...(event.costUsd !== undefined ? { costUsd: event.costUsd } : {}),
+  };
 }
 
 function summarizeCommandResult(value: string): string {

--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -28,6 +28,31 @@ export type CodexRunnerHeartbeatStatus =
  */
 export type TaskAgent = "codex" | "claude" | "test-writer" | "security" | "docs" | (string & {});
 
+export type CodexTaskRoutingOutcomeKind = "opened_pr" | "no_pr" | "failed";
+
+export interface CodexTaskRoutingTokenUsage {
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheTokens?: number;
+  totalTokens?: number;
+  costUsd?: number;
+}
+
+export interface CodexTaskRoutingOutcome {
+  agent: TaskAgent;
+  surface: string;
+  outcome: CodexTaskRoutingOutcomeKind;
+  ciPassed?: boolean;
+  merged?: boolean;
+  reverted?: boolean;
+  durationMs?: number;
+  tokenUsage?: CodexTaskRoutingTokenUsage;
+  recordedAt: string;
+  evidence: "runner_completion";
+  truthBoundary: string;
+}
+
 /** Resolve a task's agent, defaulting legacy/undefined tasks to "codex". */
 export function taskAgent(task: { agent?: TaskAgent | string }): TaskAgent {
   const agent = typeof task.agent === "string" ? task.agent.trim() : "";
@@ -36,6 +61,8 @@ export function taskAgent(task: { agent?: TaskAgent | string }): TaskAgent {
 
 export interface CodexTaskInput {
   repo: string;
+  /** ORCH-P4c: normalized work surface for learned routing memory. */
+  surface?: string;
   /**
    * The PR this task acts on. Optional: greenfield tasks (Claude opens
    * its own PR) have no PR number yet. When present, propose dedupes on
@@ -102,6 +129,7 @@ export interface CodexTask extends CodexTaskInput {
   operatorDismissedBy?: string;
   operatorSnoozedUntil?: string;
   operatorSnoozedBy?: string;
+  routingOutcome?: CodexTaskRoutingOutcome;
   events?: CodexTaskEvent[];
 }
 
@@ -148,6 +176,7 @@ export async function proposeCodexTask(
       ...existing,
       correlationId: input.correlationId ?? existing.correlationId,
       title: input.title ?? existing.title,
+      surface: input.surface ?? existing.surface,
       prompt: input.prompt || existing.prompt,
       reason: input.reason ?? existing.reason,
       requester: input.requester ?? existing.requester,
@@ -164,6 +193,7 @@ export async function proposeCodexTask(
     id: makeCodexTaskId(input.repo, input.pullRequestNumber, now),
     status: "proposed",
     repo: input.repo,
+    ...(input.surface ? { surface: input.surface } : {}),
     agent: input.agent ?? "codex",
     ...(input.pullRequestNumber !== undefined ? { pullRequestNumber: input.pullRequestNumber } : {}),
     ...(input.correlationId ? { correlationId: input.correlationId } : {}),
@@ -370,6 +400,7 @@ export async function completeCodexTask(
     exitCode?: number;
     stdoutTail?: string;
     stderrTail?: string;
+    routingOutcome?: Partial<CodexTaskRoutingOutcome>;
   } = {}
 ): Promise<CodexTask | undefined> {
   const path = queuePath(deps.path);
@@ -387,6 +418,7 @@ export async function completeCodexTask(
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
     ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
+    routingOutcome: buildTaskRoutingOutcome(existing, now, deps.routingOutcome?.outcome ?? "opened_pr", deps.routingOutcome),
     progressMessage: deps.completionSummary ?? `${taskAgentEventLabel(taskAgent(existing))} runner completed the task.`,
     progressAt: now,
     events: appendTaskEvent(existing, {
@@ -408,6 +440,7 @@ export async function failCodexTask(
     exitCode?: number;
     stdoutTail?: string;
     stderrTail?: string;
+    routingOutcome?: Partial<CodexTaskRoutingOutcome>;
   } = {}
 ): Promise<CodexTask | undefined> {
   const path = queuePath(deps.path);
@@ -427,6 +460,7 @@ export async function failCodexTask(
     ...(typeof deps.exitCode === "number" ? { exitCode: deps.exitCode } : {}),
     ...(deps.stdoutTail ? { stdoutTail: deps.stdoutTail } : {}),
     ...(deps.stderrTail ? { stderrTail: deps.stderrTail } : {}),
+    routingOutcome: buildTaskRoutingOutcome(existing, now, deps.routingOutcome?.outcome ?? "failed", deps.routingOutcome),
     progressMessage: failureReason,
     progressAt: now,
     events: appendTaskEvent(existing, {
@@ -684,6 +718,72 @@ function appendTaskEvent(task: CodexTask, event: CodexTaskEvent): CodexTaskEvent
   return [...(task.events ?? []), event]
     .filter((entry) => entry.at && entry.status && entry.message)
     .slice(-25);
+}
+
+function buildTaskRoutingOutcome(
+  task: CodexTask,
+  recordedAt: string,
+  outcome: CodexTaskRoutingOutcomeKind,
+  overrides: Partial<CodexTaskRoutingOutcome> | undefined,
+): CodexTaskRoutingOutcome {
+  const tokenUsage = cleanRoutingTokenUsage(overrides?.tokenUsage);
+  const durationMs = cleanNonNegativeNumber(overrides?.durationMs)
+    ?? durationBetween(task.startedAt, recordedAt);
+  return {
+    agent: taskAgent({ agent: overrides?.agent ?? task.agent }),
+    surface: normalizeRoutingSurface(overrides?.surface ?? task.surface ?? inferredTaskSurface(task)),
+    outcome,
+    ...(typeof overrides?.ciPassed === "boolean" ? { ciPassed: overrides.ciPassed } : {}),
+    ...(typeof overrides?.merged === "boolean" ? { merged: overrides.merged } : {}),
+    ...(typeof overrides?.reverted === "boolean" ? { reverted: overrides.reverted } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(tokenUsage ? { tokenUsage } : {}),
+    recordedAt,
+    evidence: "runner_completion",
+    truthBoundary: "Recorded from the runner completion path. PR merge/revert and CI results are present only when an upstream caller supplied that evidence.",
+  };
+}
+
+function inferredTaskSurface(task: Pick<CodexTask, "title" | "routingReason" | "prompt">): string {
+  const titleSurface = task.title?.match(/^Hermes routed work:\s*(.+)$/i)?.[1]?.trim();
+  if (titleSurface) return titleSurface;
+  return "general";
+}
+
+function normalizeRoutingSurface(value: string | undefined): string {
+  const normalized = value?.trim().toLowerCase().replace(/[^a-z0-9/._ -]+/g, " ").replace(/\s+/g, " ").trim();
+  return normalized || "general";
+}
+
+function cleanRoutingTokenUsage(value: CodexTaskRoutingTokenUsage | undefined): CodexTaskRoutingTokenUsage | undefined {
+  if (!value) return undefined;
+  const inputTokens = cleanNonNegativeNumber(value.inputTokens);
+  const outputTokens = cleanNonNegativeNumber(value.outputTokens);
+  const cacheTokens = cleanNonNegativeNumber(value.cacheTokens);
+  const totalTokens = cleanNonNegativeNumber(value.totalTokens)
+    ?? [inputTokens, outputTokens, cacheTokens].reduce<number>((sum, item) => sum + (item ?? 0), 0);
+  const costUsd = cleanNonNegativeNumber(value.costUsd);
+  const tokenUsage: CodexTaskRoutingTokenUsage = {
+    ...(value.model ? { model: value.model } : {}),
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(cacheTokens !== undefined ? { cacheTokens } : {}),
+    ...(totalTokens > 0 ? { totalTokens } : {}),
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
+  return Object.keys(tokenUsage).length > 0 ? tokenUsage : undefined;
+}
+
+function cleanNonNegativeNumber(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function durationBetween(start: string | undefined, end: string | undefined): number | undefined {
+  if (!start || !end) return undefined;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) return undefined;
+  return endMs - startMs;
 }
 
 function isCodexTask(value: unknown): value is CodexTask {

--- a/services/slack-operator/src/codex-task-runner.ts
+++ b/services/slack-operator/src/codex-task-runner.ts
@@ -1,10 +1,10 @@
 import { spawn } from "node:child_process";
 import { hostname } from "node:os";
 import { fileURLToPath } from "node:url";
-import { beginLlmUsageCall, recordLlmUsageFromResult } from "@avg/averray-mcp/llm-usage";
+import { beginLlmUsageCall, recordLlmUsageFromResult, type LlmUsageEvent } from "@avg/averray-mcp/llm-usage";
 
 import { parseBranchWorkerOutcome, type BranchWorkerOutcome } from "./branch-worker-outcome.js";
-import type { CodexTask } from "./codex-task-queue.js";
+import type { CodexTask, CodexTaskRoutingTokenUsage } from "./codex-task-queue.js";
 import {
   claimNextApprovedCodexTask,
   completeCodexTask,
@@ -115,7 +115,7 @@ export async function runCodexTaskRunnerOnce(
   });
   try {
     const result = await executor(claimed, config);
-    await recordLlmUsageFromResult({
+    const usageEvent = await recordLlmUsageFromResult({
       agent: "codex",
       ...(config.model ? { model: config.model } : {}),
       taskId: claimed.id,
@@ -123,6 +123,7 @@ export async function runCodexTaskRunnerOnce(
       result,
     }).catch(() => undefined);
     const outcome = result.outcome ?? parseBranchWorkerOutcome(result.stdout);
+    const tokenUsage = routingTokenUsage(usageEvent);
     if (result.exitCode === 0 && outcome?.opened) {
       const summary = openedPullRequestSummary(result, outcome, "Codex runner opened a pull request.");
       const task = await completeCodexTask(claimed.id, {
@@ -131,6 +132,10 @@ export async function runCodexTaskRunnerOnce(
         exitCode: result.exitCode,
         stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
         stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+        routingOutcome: {
+          outcome: "opened_pr",
+          ...(tokenUsage ? { tokenUsage } : {}),
+        },
       });
       await updateRunnerHeartbeat(
         config,
@@ -152,6 +157,10 @@ export async function runCodexTaskRunnerOnce(
       exitCode: result.exitCode,
       stdoutTail: sanitizeTail(result.stdout, config.outputTailBytes),
       stderrTail: sanitizeTail(result.stderr, config.outputTailBytes),
+      routingOutcome: {
+        outcome: outcome && !outcome.opened ? "no_pr" : "failed",
+        ...(tokenUsage ? { tokenUsage } : {}),
+      },
     });
     await updateRunnerHeartbeat(config, "failed", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
@@ -160,6 +169,7 @@ export async function runCodexTaskRunnerOnce(
     const task = await failCodexTask(claimed.id, {
       path: config.path,
       failureReason: reason,
+      routingOutcome: { outcome: "failed" },
     });
     await updateRunnerHeartbeat(config, "error", reason, undefined, claimed.id);
     return { status: "failed", task: task ?? claimed, reason };
@@ -303,6 +313,18 @@ function openedPullRequestSummary(result: CodexTaskRunResult, outcome: Extract<B
 
 function noPullRequestFailureReason(outcome: Extract<BranchWorkerOutcome, { opened: false }>): string {
   return sanitizeOutput(outcome.reason || outcome.summary || "Worker finished without opening a pull request.");
+}
+
+function routingTokenUsage(event: LlmUsageEvent | undefined): CodexTaskRoutingTokenUsage | undefined {
+  if (!event) return undefined;
+  return {
+    model: event.model,
+    inputTokens: event.inputTokens,
+    outputTokens: event.outputTokens,
+    ...(event.cacheTokens !== undefined ? { cacheTokens: event.cacheTokens } : {}),
+    totalTokens: event.inputTokens + event.outputTokens + (event.cacheTokens ?? 0),
+    ...(event.costUsd !== undefined ? { costUsd: event.costUsd } : {}),
+  };
 }
 
 function summarizeCommandResult(value: string): string {

--- a/services/slack-operator/src/hermes-router-routine.ts
+++ b/services/slack-operator/src/hermes-router-routine.ts
@@ -12,6 +12,7 @@ import {
   type PlanAndRouteWorkInput,
   type RoutedProposal,
   type WorkRouterBacklogItem,
+  type WorkRouterRoutingScores,
 } from "@avg/averray-mcp/work-router";
 import type { CodexTask, CodexTaskInput } from "./codex-task-queue.js";
 
@@ -41,6 +42,7 @@ export interface HermesRouterDeps {
   listTasks: () => Promise<CodexTask[]> | CodexTask[];
   policy: () => DispatchPolicyConfig;
   classify: (input: RoutingInput) => Pick<RoutingDecision, "agent" | "riskTier" | "reason">;
+  routingScores?: () => Promise<WorkRouterRoutingScores> | WorkRouterRoutingScores;
   plan?: (input: PlanAndRouteWorkInput) => RoutedProposal[];
   evaluatePolicy?: (config: DispatchPolicyConfig, input: Parameters<typeof evaluateDispatchPolicy>[1]) => DispatchPolicyDecision;
   propose: (input: CodexTaskInput) => Promise<{ task: CodexTask; created: boolean }> | { task: CodexTask; created: boolean };
@@ -75,12 +77,14 @@ export async function runHermesRouterOnce(config: HermesRouterConfig, deps: Herm
   const policy = deps.policy();
   const planner = deps.plan ?? planAndRouteWork;
   const evaluate = deps.evaluatePolicy ?? evaluateDispatchPolicy;
+  const routingScores = deps.routingScores ? await deps.routingScores() : undefined;
   const routed = planner({
     backlog,
     inFlight: tasks.filter((task) => ACTIVE_STATUSES.has(task.status)).map(taskSnapshot),
     recentlyDone: tasks.filter((task) => isRecentlyDone(task, nowMs, config.lookbackMs)).map(taskSnapshot),
     policy: buildPolicySnapshot(policy, tasks, now),
     classify: deps.classify,
+    ...(routingScores ? { routingScores } : {}),
     maxProposals: config.maxProposalsPerTick,
   });
 
@@ -132,6 +136,7 @@ export async function runHermesRouterOnce(config: HermesRouterConfig, deps: Herm
 
     const { task } = await deps.propose({
       repo: proposal.repo,
+      surface: proposal.surface,
       agent: proposal.agent,
       riskTier: proposal.riskTier,
       routingReason: proposal.whyAgent,
@@ -179,6 +184,7 @@ function taskSnapshot(task: CodexTask): PlanAndRouteWorkInput["inFlight"][number
     repo: task.repo,
     status: task.status,
     ...(task.title ? { title: task.title } : {}),
+    ...(task.surface ? { surface: task.surface } : {}),
     ...(task.prompt ? { prompt: task.prompt } : {}),
     ...(task.routingReason ? { area: task.routingReason } : {}),
   };

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -9,7 +9,7 @@ import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
 import { getHandoffMonitor, recordHandoffEvent } from "@avg/averray-mcp/handoff-events";
 import { getHermesBacklogPlan } from "@avg/averray-mcp/hermes-backlog";
 import { classifyTask } from "@avg/averray-mcp/dispatch-routing";
-import { buildAgentScorecard } from "@avg/averray-mcp/agent-scorecard";
+import { buildAgentScorecard, routingScoresFromScorecard } from "@avg/averray-mcp/agent-scorecard";
 import { readLlmUsageEvents } from "@avg/averray-mcp/llm-usage";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
 import {
@@ -3418,6 +3418,7 @@ function startOperatorRoutines() {
         listTasks: () => listCodexTasks(),
         policy: () => loadDispatchPolicyConfig(),
         classify: (input) => classifyTaskForWorkRouter(input),
+        routingScores: () => loadHermesRouterRoutingScores(),
         propose: async (input) => {
           const result = await proposeCodexTask(input);
           if (result.created && result.task.status === "proposed") {
@@ -3825,6 +3826,17 @@ function hermesMemoryNotesForBoard(board: ReturnType<typeof buildHermesBoardSnap
     addNotes(listHermesMemoryNotes({ limit }).map((note) => note.text));
   }
   return notes;
+}
+
+async function loadHermesRouterRoutingScores() {
+  const tasks = await listCodexTasks().catch(() => []);
+  return routingScoresFromScorecard(buildAgentScorecard({
+    codexTasks: {
+      schemaVersion: 1,
+      kind: "codex_task_queue",
+      items: tasks,
+    },
+  }));
 }
 
 function collectHermesRouterBacklog() {

--- a/test/unit/agent-scorecard.test.ts
+++ b/test/unit/agent-scorecard.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { buildAgentScorecard, getAgentScorecard } from "../../packages/averray-mcp/src/agent-scorecard.js";
+import {
+  buildAgentScorecard,
+  getAgentScorecard,
+  routingScoresFromScorecard,
+} from "../../packages/averray-mcp/src/agent-scorecard.js";
 
 describe("A1 agent scorecard", () => {
   it("aggregates PR, task, check, surface, and mission signals per agent", () => {
@@ -269,7 +273,66 @@ describe("A1 agent scorecard", () => {
     });
     expect(scorecard.agents).toEqual([]);
     expect(scorecard.gaps).toContain("Cost and token totals are not present in the current runner events.");
-    expect(scorecard.safety.routingInfluence).toContain("A1 only observes");
+    expect(scorecard.safety.routingInfluence).toContain("Hard taxonomy and dispatch policy remain authoritative");
+  });
+
+  it("computes per-agent surface routing memory from real runner outcomes", () => {
+    const scorecard = buildAgentScorecard({
+      codexTasks: {
+        items: [
+          routingTask("codex-old-win", "codex", "ops hygiene", "opened_pr", "2026-05-31T09:00:00.000Z", 100),
+          routingTask("codex-recent-fail", "codex", "ops hygiene", "failed", "2026-05-31T11:00:00.000Z", 80),
+          routingTask("claude-old-fail", "claude", "ops hygiene", "failed", "2026-05-31T09:05:00.000Z", 40),
+          routingTask("claude-recent-win", "claude", "ops hygiene", "opened_pr", "2026-05-31T11:05:00.000Z", 60),
+        ],
+      },
+    }, { now: new Date("2026-05-31T12:00:00.000Z") });
+
+    expect(scorecard.routingMemory).toMatchObject({
+      status: "recorded",
+      minSamples: 2,
+    });
+    const scores = routingScoresFromScorecard(scorecard);
+    expect(scores["ops hygiene"]?.codex).toMatchObject({
+      status: "baseline_available",
+      samples: 2,
+    });
+    expect(scores["ops hygiene"]?.claude).toMatchObject({
+      status: "baseline_available",
+      samples: 2,
+    });
+    expect(scores["ops hygiene"]?.claude?.score ?? 0).toBeGreaterThan(scores["ops hygiene"]?.codex?.score ?? 0);
+
+    const claude = scorecard.agents.find((agent) => agent.agent === "claude");
+    expect(claude?.routingSurfaces?.[0]).toMatchObject({
+      surface: "ops hygiene",
+      samples: 2,
+      openedPr: 1,
+      failed: 1,
+      tokenUsage: {
+        status: "recorded",
+        totalTokens: 100,
+      },
+    });
+  });
+
+  it("marks sparse routing memory insufficient instead of fabricating confidence", () => {
+    const scorecard = buildAgentScorecard({
+      codexTasks: {
+        items: [
+          routingTask("codex-one", "codex", "ops hygiene", "opened_pr", "2026-05-31T09:00:00.000Z", 20),
+        ],
+      },
+    }, { now: new Date("2026-05-31T12:00:00.000Z") });
+
+    expect(scorecard.routingMemory).toMatchObject({
+      status: "insufficient_data",
+    });
+    expect(routingScoresFromScorecard(scorecard)["ops hygiene"]?.codex).toMatchObject({
+      status: "insufficient_data",
+      score: null,
+      samples: 1,
+    });
   });
 
   it("reads task and browser mission stores without needing monitor internals", async () => {
@@ -332,3 +395,36 @@ describe("A1 agent scorecard", () => {
     }
   });
 });
+
+function routingTask(
+  id: string,
+  agent: "codex" | "claude",
+  surface: string,
+  outcome: "opened_pr" | "no_pr" | "failed",
+  recordedAt: string,
+  totalTokens: number,
+) {
+  return {
+    id,
+    agent,
+    surface,
+    status: outcome === "failed" ? "failed" : "completed",
+    startedAt: "2026-05-31T08:55:00.000Z",
+    completedAt: outcome === "failed" ? undefined : recordedAt,
+    failedAt: outcome === "failed" ? recordedAt : undefined,
+    routingOutcome: {
+      agent,
+      surface,
+      outcome,
+      durationMs: 10 * 60_000,
+      tokenUsage: {
+        model: `${agent}-model`,
+        inputTokens: totalTokens,
+        outputTokens: 0,
+        totalTokens,
+      },
+      recordedAt,
+      evidence: "runner_completion",
+    },
+  };
+}

--- a/test/unit/claude-task-runner.test.ts
+++ b/test/unit/claude-task-runner.test.ts
@@ -48,7 +48,7 @@ describe("claude task runner", () => {
   }
 
   async function approvedClaudeTask(path: string, prompt = "Build the thing"): Promise<string> {
-    const { task } = await proposeCodexTask({ repo: "averray-agent/agent", agent: "claude", prompt }, { path });
+    const { task } = await proposeCodexTask({ repo: "averray-agent/agent", agent: "claude", surface: "ops hygiene", prompt }, { path });
     await approveCodexTask(task.id, { path, approvedBy: "operator" });
     return task.id;
   }
@@ -205,6 +205,23 @@ describe("claude task runner", () => {
       outputTokens: 30,
       cacheTokens: 15,
       costUsd: 0.42,
+    });
+    const [task] = await listCodexTasks({ path });
+    expect(task).toMatchObject({
+      id,
+      routingOutcome: {
+        agent: "claude",
+        surface: "ops hygiene",
+        outcome: "opened_pr",
+        tokenUsage: {
+          model: "claude-sonnet-4-5",
+          inputTokens: 120,
+          outputTokens: 30,
+          cacheTokens: 15,
+          totalTokens: 165,
+          costUsd: 0.42,
+        },
+      },
     });
   });
 

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -254,6 +254,53 @@ describe("codex task queue", () => {
     expect(await claimNextApprovedCodexTask({ path })).toBeUndefined();
   });
 
+  it("stamps routing outcomes from runner completion without inventing CI or merge state", async () => {
+    const path = await tempQueuePath();
+    const proposed = await proposeCodexTask({
+      repo: "averray-agent/agent",
+      agent: "claude",
+      surface: "ops hygiene",
+      prompt: "Fix the routine wrapper.",
+    }, { path, now: new Date("2026-05-17T13:10:00.000Z") });
+    await approveCodexTask(proposed.task.id, { path, now: new Date("2026-05-17T13:11:00.000Z") });
+    await claimNextApprovedCodexTask({
+      path,
+      agent: "claude",
+      runnerId: "claude-runner",
+      now: new Date("2026-05-17T13:12:00.000Z"),
+    });
+
+    const completed = await completeCodexTask(proposed.task.id, {
+      path,
+      completionSummary: "Opened PR.",
+      routingOutcome: {
+        tokenUsage: {
+          model: "claude-sonnet-4-5",
+          inputTokens: 120,
+          outputTokens: 30,
+        },
+      },
+      now: new Date("2026-05-17T13:14:00.000Z"),
+    });
+
+    expect(completed?.routingOutcome).toMatchObject({
+      agent: "claude",
+      surface: "ops hygiene",
+      outcome: "opened_pr",
+      durationMs: 120_000,
+      tokenUsage: {
+        model: "claude-sonnet-4-5",
+        inputTokens: 120,
+        outputTokens: 30,
+        totalTokens: 150,
+      },
+      recordedAt: "2026-05-17T13:14:00.000Z",
+      evidence: "runner_completion",
+    });
+    expect(completed?.routingOutcome?.ciPassed).toBeUndefined();
+    expect(completed?.routingOutcome?.merged).toBeUndefined();
+  });
+
   it("rehydrates and requeues one orphaned running task after runner restart", async () => {
     const path = await tempQueuePath();
     const proposed = await proposeCodexTask({

--- a/test/unit/codex-task-runner.test.ts
+++ b/test/unit/codex-task-runner.test.ts
@@ -53,6 +53,7 @@ describe("codex task runner", () => {
       repo: "averray-agent/agent",
       pullRequestNumber: 390,
       title: "Finish draft",
+      surface: "ops hygiene",
       prompt: "Finish PR #390.",
       correlationId: "github-pr-390",
       requester: "monitor",
@@ -96,6 +97,17 @@ describe("codex task runner", () => {
       attemptCount: 1,
       completionSummary: "ready for Hermes\nhttps://github.com/averray-agent/agent/pull/390",
       stdoutTail: "branch pushed\nready for Hermes\n",
+      routingOutcome: {
+        agent: "codex",
+        surface: "ops hygiene",
+        outcome: "opened_pr",
+        tokenUsage: {
+          model: "gpt-5-codex",
+          inputTokens: 20,
+          outputTokens: 8,
+          totalTokens: 28,
+        },
+      },
     });
     await expect(readCodexRunnerHeartbeat({ path })).resolves.toMatchObject({
       runnerId: "test-runner",
@@ -184,6 +196,7 @@ describe("codex task runner", () => {
     const proposed = await proposeCodexTask({
       repo: "averray-agent/agent",
       agent: "codex",
+      surface: "ops hygiene",
       title: "No diff",
       prompt: "Try the change.",
     }, { path });
@@ -207,6 +220,11 @@ describe("codex task runner", () => {
       failureReason: "no_changes",
       completionSummary: "no_changes",
       progressMessage: "no_changes",
+      routingOutcome: {
+        agent: "codex",
+        surface: "ops hygiene",
+        outcome: "no_pr",
+      },
     });
   });
 

--- a/test/unit/hermes-router-routine.test.ts
+++ b/test/unit/hermes-router-routine.test.ts
@@ -146,6 +146,7 @@ describe("Hermes router routine", () => {
     }]);
     expect(d.propose).toHaveBeenCalledWith(expect.objectContaining({
       repo: PROPOSAL.repo,
+      surface: PROPOSAL.surface,
       agent: "claude",
       prompt: PROPOSAL.taskPrompt,
       requester: "hermes-router",
@@ -161,6 +162,27 @@ describe("Hermes router routine", () => {
       reason: "routed_proposal",
       taskId: "task-router-1",
       surface: PROPOSAL.surface,
+    }));
+  });
+
+  it("passes learned routing scores into the planner", async () => {
+    const routingScores = {
+      "ops hygiene": {
+        codex: { status: "baseline_available" as const, score: 90, samples: 3 },
+        claude: { status: "baseline_available" as const, score: 40, samples: 3 },
+      },
+    };
+    const plan = vi.fn(() => []);
+    const d = deps({
+      routingScores: vi.fn(() => routingScores),
+      plan,
+    });
+
+    await runHermesRouterOnce(config(), d);
+
+    expect(d.routingScores).toHaveBeenCalled();
+    expect(plan).toHaveBeenCalledWith(expect.objectContaining({
+      routingScores,
     }));
   });
 

--- a/test/unit/work-router.test.ts
+++ b/test/unit/work-router.test.ts
@@ -53,11 +53,24 @@ describe("planAndRouteWork", () => {
     expect(proposals.every((proposal) => proposal.dedupeKey.length > 0 && proposal.taskPrompt.length > 0)).toBe(true);
   });
 
-  it("asserts when the injected classifier violates the routing taxonomy", () => {
-    expect(() => planAndRouteWork(input({
+  it("keeps hard taxonomy authoritative when the classifier or learned memory disagrees", () => {
+    const proposals = planAndRouteWork(input({
       backlog: [item("Escrow settlement proof", "chain/settlement", "Verify invariants")],
       classify: () => ({ agent: "claude", riskTier: "low", reason: "wrong agent" }),
-    }))).toThrow(/routing_taxonomy_violation/);
+      routingScores: {
+        "chain/settlement": {
+          claude: { status: "baseline_available", score: 99, samples: 4 },
+          codex: { status: "baseline_available", score: 10, samples: 4 },
+        },
+      },
+    }));
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      surface: "chain/settlement",
+      agent: "codex",
+    });
+    expect(proposals[0]?.whyAgent).toContain("Hard taxonomy kept chain/settlement with codex");
   });
 
   it("does not re-propose gaps covered by in-flight or recently-done tasks", () => {
@@ -105,6 +118,59 @@ describe("planAndRouteWork", () => {
       backlog: [item("Monitor drawer polish", "ui", "Tighten drawer")],
       policy: { ...POLICY, allowedAgents: ["codex"] },
     }))).toEqual([]);
+  });
+
+  it("prefers the higher learned score on soft surfaces only", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: {
+        "ops hygiene": {
+          codex: { status: "baseline_available", score: 88, samples: 3 },
+          claude: { status: "baseline_available", score: 42, samples: 3 },
+        },
+      },
+    }));
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      surface: "ops hygiene",
+      agent: "codex",
+    });
+    expect(proposals[0]?.whyAgent).toContain("Learned routing preferred codex");
+  });
+
+  it("falls back to static routing when learned surface data is sparse", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: {
+        "ops hygiene": {
+          codex: { status: "baseline_available", score: 88, samples: 3 },
+          claude: { status: "insufficient_data", score: null, samples: 1 },
+        },
+      },
+    }));
+
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]).toMatchObject({
+      surface: "ops hygiene",
+      agent: "claude",
+    });
+    expect(proposals[0]?.whyAgent).toContain("insufficient ops hygiene data");
+  });
+
+  it("does not route around dispatch policy when learned memory picks a blocked agent", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      policy: { ...POLICY, allowedAgents: ["claude"] },
+      routingScores: {
+        "ops hygiene": {
+          codex: { status: "baseline_available", score: 88, samples: 3 },
+          claude: { status: "baseline_available", score: 42, samples: 3 },
+        },
+      },
+    }));
+
+    expect(proposals).toEqual([]);
   });
 
   it("returns an empty array when there are no real gaps", () => {


### PR DESCRIPTION
## What changed

- Added ORCH-P4c learned routing memory to `agent-scorecard`: per-agent x surface runner outcomes (`opened_pr`, `no_pr`, `failed`) with recent-run weighting, sparse `insufficient_data`, token usage when the runner emitted whitelisted counters, and an explicit merge/revert truth-boundary gap.
- Stamped routing outcomes from the Codex and Claude-family runner completion paths onto the existing task queue records; no parallel store.
- Injected scorecard-derived routing scores into `planAndRouteWork` via the Hermes router routine.
- Kept hard taxonomy authoritative: chain/settlement/treasury stays Codex; UI/docs/monitor stays Claude. Learned scores affect only soft/ambiguous surfaces, and dispatch policy still runs after the selected agent.
- Surfaced the routing memory through `/monitor/agents` via the existing scorecard response and updated `AGENTS.md` with the new operating rule.

## Checks

- `npm run typecheck`
- `npm test`

## Affected surfaces

- MCP package: `agent-scorecard`, `work-router`
- Slack operator: task queue, Codex/Claude runners, Hermes router routine
- Tests
- Docs/working agreement: `AGENTS.md`

## Rollout / rollback

- No env, secrets, migrations, compose, deploy, or authority changes.
- Rollback is reverting this PR; existing static routing still works when `routingScores` is absent or sparse.

## Guardrails

- Learned routing never overrides hard taxonomy or dispatch policy.
- Sparse data is labeled `insufficient_data`; no fabricated routing confidence.
- Merge/revert and CI fields are recorded only when real upstream evidence supplies them.
