### PR TITLE
Monitor UI: unify design-system primitives

### DIFF
--- a/packages/monitor-ui/src/components/Lane.tsx
+++ b/packages/monitor-ui/src/components/Lane.tsx
@@ -12,6 +12,7 @@
 
 import type { ReactNode } from "react";
 import { MiniRail, type LaneDescriptor, type LaneId } from "./MiniRail.js";
+import { Button, EmptyState, LaneHeader } from "./ui.js";
 
 export type { LaneDescriptor, LaneId };
 
@@ -64,27 +65,26 @@ export function Lane({ lane, expanded, count, children, headerAccessory, onToggl
 
   return (
     <section className={classes} aria-label={`${lane.name} lane`}>
-      <div className="hm-lane-head">
-        <div className="hm-lane-head-row">
-          <span className="hm-lane-title">{lane.name}</span>
-          <span className="hm-lane-count">{count}</span>
-          {onToggle ? (
-            <button
-              type="button"
-              className="hm-lane-collapse"
-              onClick={() => onToggle(lane.id)}
-              aria-label={`Collapse ${lane.name} lane`}
-            >
-              collapse ‹
-            </button>
-          ) : null}
-        </div>
-        {lane.action ? <div className="hm-lane-action">{lane.action}</div> : null}
-      </div>
+      <LaneHeader
+        title={lane.name}
+        count={count}
+        action={lane.action ? <span>{lane.action}</span> : undefined}
+        collapse={onToggle ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="hm-lane-collapse"
+            onClick={() => onToggle(lane.id)}
+            aria-label={`Collapse ${lane.name} lane`}
+          >
+            collapse ‹
+          </Button>
+        ) : undefined}
+      />
       <div className="hm-lane-body">
         {headerAccessory}
         {count === 0 ? (
-          <div className="hm-lane-empty">{laneEmptyMessage(lane)}</div>
+          <EmptyState className="hm-lane-empty">{laneEmptyMessage(lane)}</EmptyState>
         ) : (
           children
         )}

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -35,6 +35,7 @@ import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
 import { missionFailureCardSummary } from "../../lib/monitor/mission-failure.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
+import { AgentTag, Badge, Button, CardHeader, StatusPill, type StateVariant } from "../ui.js";
 import { ChecksBar } from "./ChecksBar.js";
 import { AgentDiscussion } from "./AgentDiscussion.js";
 
@@ -88,10 +89,19 @@ function shortId(id: string): string {
 const HIGH_RISK_TAGS = new Set<RiskTag>(["contracts", "workflow", "review-gated", "secrets", "config"]);
 const SECRET_RISK_TAGS = new Set<RiskTag>(["secrets"]);
 
-function riskPillClass(tag: RiskTag): string {
-  if (SECRET_RISK_TAGS.has(tag)) return "hm-pill hm-pill--secret";
-  if (HIGH_RISK_TAGS.has(tag)) return "hm-pill hm-pill--risk";
-  return "hm-pill hm-pill--neutral";
+function riskBadgeVariant(tag: RiskTag): StateVariant {
+  if (SECRET_RISK_TAGS.has(tag)) return "secret";
+  if (HIGH_RISK_TAGS.has(tag)) return "risk";
+  return "neutral";
+}
+
+function freshnessVariant(card: BoardCard, isStale: boolean, isClosed: boolean): StateVariant {
+  if (isClosed) return "neutral";
+  if (isStale) return "age";
+  const tier = freshnessTier(card.freshness);
+  if (tier === "fresh") return "fresh";
+  if (tier === "warm") return "pending";
+  return "neutral";
 }
 
 // ── Card ───────────────────────────────────────────────────────────
@@ -195,11 +205,11 @@ export function Card({
       {!isClosed && card.risk && card.risk.length > 0 ? (
         <div className="hm-pillrow">
           {card.risk.map((r) => (
-            <span key={r} className={riskPillClass(r)}>
+            <Badge key={r} variant={riskBadgeVariant(r)}>
               {r}
-            </span>
+            </Badge>
           ))}
-          {card.isDraft ? <span className="hm-pill hm-pill--draft">draft</span> : null}
+          {card.isDraft ? <Badge variant="draft">draft</Badge> : null}
         </div>
       ) : null}
 
@@ -256,25 +266,17 @@ export function Card({
           >
             Hermes: archive in 4h?{" "}
             {onKeepWatching ? (
-              <button
-                type="button"
+              <Button
+                variant="ghost"
+                size="xs"
                 className="hm-keep-watching"
-                style={{
-                  color: "var(--hm-sage-deep)",
-                  cursor: "pointer",
-                  borderBottom: "1px dotted",
-                  background: "none",
-                  border: 0,
-                  padding: 0,
-                  font: "inherit",
-                }}
                 onClick={(e) => {
                   e.stopPropagation();
                   onKeepWatching(card);
                 }}
               >
                 Keep watching
-              </button>
+              </Button>
             ) : (
               // No handler wired ⇒ honest disabled label, not a fake link.
               <span style={{ color: "var(--hm-muted)" }} aria-disabled="true">
@@ -295,17 +297,13 @@ function CardHead({ card, isStale, isClosed }: { card: BoardCard; isStale: boole
   const freshnessLabel = isClosed ? "CLOSED" : isStale ? `STALE ${formatted ?? ""}` : `FRESH ${formatted ?? ""}`;
 
   return (
-    <div className="hm-card-head">
-      <span className="hm-card-id">
-        <span className={`agent-dot agent-dot--${card.agentType ?? "ext"}`} aria-hidden />
-        <span className="hm-mono">{agentLabel(card.agentType)}</span>
-        <strong className="hm-mono">{shortId(card.id)}</strong>
-      </span>
-      <span className={"hm-card-fresh " + freshClass(card)}>
-        <span className="fresh-dot" aria-hidden />
-        {freshnessLabel}
-      </span>
-    </div>
+    <CardHeader
+      agent={card.agentType}
+      id={shortId(card.id)}
+      status={freshnessLabel}
+      statusVariant={freshnessVariant(card, isStale, isClosed)}
+      statusClassName={freshClass(card)}
+    />
   );
 }
 
@@ -319,11 +317,10 @@ function ReviewRequestedLine({ card }: { card: BoardCard }) {
     ? active.map((request) => actorDisplayName(request.reviewer)).join(", ")
     : actorDisplayName(first.reviewer);
   return (
-    <div className="hm-review-request" aria-label={`${label} from ${reviewers}`}>
-      <span className="hm-review-request-dot" aria-hidden />
+    <Badge variant="info" dot className="hm-review-request" aria-label={`${label} from ${reviewers}`}>
       <span>{label}</span>
       <strong>{reviewers}</strong>
-    </div>
+    </Badge>
   );
 }
 
@@ -347,8 +344,7 @@ function WorkingNowLine({ workingNow }: { workingNow: CardWorkingNow }) {
 
   return (
     <div className="hm-working-now" aria-label={`Working now: ${workingNow.label}`} title={details || undefined}>
-      <span className={`agent-dot agent-dot--${workingNow.agent}`} aria-hidden />
-      working now
+      <AgentTag agent={workingNow.agent} label="working now" />
       <span className="target">{workingNow.label}</span>
     </div>
   );
@@ -367,7 +363,12 @@ function MissionRunSummary({ card }: { card: MissionCard }) {
     <div className={`hm-mission-run hm-mission-run--${tone}`} aria-label={`Tester run ${status}`}>
       <div className="hm-mission-run-top">
         <span className="hm-mission-run-kicker">Tester run</span>
-        <span className={`hm-mission-run-verdict hm-mission-run-verdict--${tone}`}>{status}</span>
+        <StatusPill
+          variant={missionToneVariant(tone)}
+          className={`hm-mission-run-verdict hm-mission-run-verdict--${tone}`}
+        >
+          {status}
+        </StatusPill>
         {target ? <span className="hm-mission-run-target">{target}</span> : null}
       </div>
 
@@ -418,6 +419,13 @@ function missionRunTone(card: MissionCard, mission: MissionReport | undefined): 
   if (card.missionStatus === "failed") return "fail";
   if (card.missionStatus === "completed") return "ok";
   if (card.missionStatus === "running") return "warn";
+  return "neutral";
+}
+
+function missionToneVariant(tone: "ok" | "warn" | "fail" | "neutral"): StateVariant {
+  if (tone === "ok") return "pass";
+  if (tone === "warn") return "pending";
+  if (tone === "fail") return "fail";
   return "neutral";
 }
 
@@ -533,9 +541,16 @@ function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
   return (
     <div className={`hm-waiting hm-waiting--${waitingOn.tone}`}>
       waiting on
-      <span className="target">→ {waitingOn.actor}</span>
+      <StatusPill variant={waitingToneVariant(waitingOn.tone)} className="target">
+        → {waitingOn.actor}
+      </StatusPill>
     </div>
   );
+}
+
+function waitingToneVariant(tone: WaitingOn["tone"]): StateVariant {
+  if (tone === "info") return "info";
+  return "pending";
 }
 
 // ── Operator actions ────────────────────────────────────────────────
@@ -657,9 +672,9 @@ function OperatorActions({
     return (
       <div className="hm-card-cta hm-card-cta--operator hm-card-cta--actions" role="group" aria-label="Operator actions">
         {actions.map((action) => (
-          <button
-            type="button"
-            className={`hm-btn ${action.kind === "action" ? "hm-btn--action" : "hm-btn--ghost"} hm-btn--sm`}
+          <Button
+            variant={action.kind === "action" ? "action" : "ghost"}
+            size="sm"
             key={action.key}
             title={`${action.label} opens a confirmation before running.`}
             onClick={(e) => {
@@ -668,7 +683,7 @@ function OperatorActions({
             }}
           >
             {action.label}
-          </button>
+          </Button>
         ))}
       </div>
     );
@@ -680,9 +695,9 @@ function OperatorActions({
         {confirming.confirm}
         <small>First click only arms this action. Confirm to send it to the live queue.</small>
       </span>
-      <button
-        type="button"
-        className="hm-btn hm-btn--action hm-btn--sm"
+      <Button
+        variant="action"
+        size="sm"
         onClick={(e) => {
           stop(e);
           setConfirmingKey(null);
@@ -690,17 +705,17 @@ function OperatorActions({
         }}
       >
         Confirm
-      </button>
-      <button
-        type="button"
-        className="hm-btn hm-btn--ghost hm-btn--sm"
+      </Button>
+      <Button
+        variant="ghost"
+        size="sm"
         onClick={(e) => {
           stop(e);
           setConfirmingKey(null);
         }}
       >
         Cancel
-      </button>
+      </Button>
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/cards/DegradedCard.tsx
+++ b/packages/monitor-ui/src/components/cards/DegradedCard.tsx
@@ -17,6 +17,7 @@
 
 import type { ReactNode } from "react";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
+import { Badge, Button, CardHeader, type StateVariant } from "../ui.js";
 
 export type DegradedCardKind = "failed-fetch" | "source-offline";
 
@@ -48,20 +49,12 @@ export function DegradedCard({ card, body, pills, action, onAction, onClick }: D
       role={onClick ? "button" : "article"}
       aria-label={`${card.id} — ${isErr ? "error" : "offline"}: ${card.title}`}
     >
-      <div className="hm-card-head">
-        <span className="hm-card-id">
-          <span className="agent-dot agent-dot--ext" aria-hidden />
-          <strong className="hm-mono">{card.id}</strong>
-        </span>
-        <span className="hm-card-fresh">
-          <span
-            className="fresh-dot"
-            style={{ background: isErr ? "var(--hm-rose)" : "var(--hm-offline)" }}
-            aria-hidden
-          />
-          {isErr ? "ERROR" : "OFFLINE"}
-        </span>
-      </div>
+      <CardHeader
+        agent="ext"
+        id={card.id}
+        status={isErr ? "ERROR" : "OFFLINE"}
+        statusVariant={isErr ? "fail" : "degraded"}
+      />
 
       <div className="hm-card-title" style={{ color: isErr ? "var(--hm-rose)" : "var(--hm-muted)" }}>
         {body}
@@ -69,16 +62,16 @@ export function DegradedCard({ card, body, pills, action, onAction, onClick }: D
 
       <div className="hm-pillrow">
         {pills.map(([cls, label]) => (
-          <span key={label} className={"hm-pill " + cls}>
+          <Badge key={label} variant={pillVariantFromClass(cls)} className={cls}>
             {label}
-          </span>
+          </Badge>
         ))}
       </div>
 
       <div className="hm-card-cta">
-        <button
-          type="button"
-          className="hm-btn hm-btn--ghost hm-btn--sm"
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={(e) => {
             e.stopPropagation();
             onAction?.();
@@ -86,8 +79,17 @@ export function DegradedCard({ card, body, pills, action, onAction, onClick }: D
           disabled={!onAction}
         >
           {action}
-        </button>
+        </Button>
       </div>
     </div>
   );
+}
+
+function pillVariantFromClass(cls: string): StateVariant {
+  if (cls.includes("--err")) return "fail";
+  if (cls.includes("--offline")) return "degraded";
+  if (cls.includes("--running")) return "pending";
+  if (cls.includes("--ok")) return "pass";
+  if (cls.includes("--info")) return "info";
+  return "neutral";
 }

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState, type CSSProperties, type KeyboardEvent } f
 import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
 import type { CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { CollaborationTarget } from "../../lib/monitor/collaboration.js";
+import { Button } from "../ui.js";
 
 export interface AskHermesComposerProps {
   /** Spawn a browser mission against a URL (/mission <url>). */
@@ -283,15 +284,15 @@ export function AskHermesComposer({
           }}
           onKeyDown={onKeyDown}
         />
-        <button
-          type="button"
+        <Button
+          variant="primary"
           className="hm-compose-send"
           onClick={send}
           disabled={inputDisabled}
           title={inputDisabled ? "Ask Hermes unavailable" : undefined}
         >
           Send <span className="hm-kbd">⏎</span>
-        </button>
+        </Button>
       </div>
       {!collaborationEnabled ? (
         <div className="hm-compose-note" role="note" style={{ color: "var(--hm-muted)", fontSize: 12, marginTop: 6 }}>

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -7,7 +7,6 @@
 // mission (M7').
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import type { CSSProperties } from "react";
 import type { BoardCard, CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { BacklogSuggestion, BacklogSuggestionsResponse } from "../../lib/monitor/backlog-suggestions.js";
 import type { BoardNowBanner as BoardNowBannerData } from "../../lib/monitor/board-state.js";
@@ -17,6 +16,7 @@ import {
   type CollaborationMessage,
 } from "../../lib/monitor/collaboration.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
+import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
 import { HermesTurn } from "./HermesTurn.js";
 
@@ -194,37 +194,6 @@ interface RoomThread {
   turns: CollaborationMessage[];
 }
 
-const ROOM_THREAD_STYLE: CSSProperties = {
-  display: "grid",
-  gap: 8,
-  padding: 8,
-  border: "1px solid var(--hm-line)",
-  borderRadius: 8,
-  background: "rgba(255, 253, 247, 0.7)",
-};
-
-const ROOM_THREAD_HEAD_STYLE: CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  gap: 8,
-  minWidth: 0,
-  color: "var(--hm-muted)",
-  fontSize: 11,
-  textTransform: "uppercase",
-  letterSpacing: ".08em",
-};
-
-const ROOM_THREAD_LABEL_STYLE: CSSProperties = {
-  flex: "1 1 auto",
-  minWidth: 0,
-  overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap",
-};
-
-const ROOM_EMPTY_STYLE: CSSProperties = { opacity: 0.78 };
-const BOARD_SUMMARY_STYLE: CSSProperties = { opacity: 0.86 };
-
 function buildRoomThreads(messages: readonly CollaborationMessage[], cards: readonly BoardCard[]): RoomThread[] {
   const threads = new Map<string, RoomThread>();
   const sorted = [...messages].sort((a, b) => a.ts - b.ts);
@@ -288,18 +257,14 @@ function RoomThreadBlock({
   onCardClick?: (id: string) => void;
 }) {
   return (
-    <div
-      className="hm-room-thread"
-      style={ROOM_THREAD_STYLE}
-    >
-      <div
-        className="hm-room-thread-head"
-        style={ROOM_THREAD_HEAD_STYLE}
-      >
-        <span style={ROOM_THREAD_LABEL_STYLE}>
+    <div className="hm-room-thread">
+      <div className="hm-room-thread-head">
+        <span className="hm-room-thread-label">
           Thread · {thread.label}
         </span>
-        <span>{thread.turns.length} turn{thread.turns.length === 1 ? "" : "s"}</span>
+        <StatusPill variant="neutral" className="hm-room-thread-count">
+          {thread.turns.length} turn{thread.turns.length === 1 ? "" : "s"}
+        </StatusPill>
       </div>
       {thread.cardId ? (
         <ActivityPin cardId={thread.cardId} onCardClick={onCardClick} />
@@ -317,22 +282,16 @@ function RoomThreadBlock({
 
 function RoomEmptyState() {
   return (
-    <div
-      className="hm-turn hm-turn--system hm-turn--kind-status"
-      style={ROOM_EMPTY_STYLE}
-    >
+    <EmptyState className="hm-turn hm-turn--system hm-turn--kind-status hm-room-empty">
       <div className="hm-turn-head">
-        <span className="hm-turn-actor">
-          <span className="actor-dot" aria-hidden />
-          Room
-        </span>
+        <AgentTag agent="room" label="Room" className="hm-turn-actor" />
         <span className="hm-turn-kind">· empty</span>
       </div>
       <div className="hm-turn-body">
         No agent chatter yet.
         <small>Real Hermes, Codex, Claude, and specialist turns will appear here when recorded.</small>
       </div>
-    </div>
+    </EmptyState>
   );
 }
 
@@ -345,12 +304,9 @@ function BoardSummaryRow({
 }) {
   const summary = boardSummaryCopy(banner);
   return (
-    <div className="hm-turn hm-turn--system hm-turn--kind-status" style={BOARD_SUMMARY_STYLE}>
+    <div className="hm-turn hm-turn--system hm-turn--kind-status hm-board-summary-row">
       <div className="hm-turn-head">
-        <span className="hm-turn-actor">
-          <span className="actor-dot" aria-hidden />
-          Board
-        </span>
+        <AgentTag agent="board" label="Board" className="hm-turn-actor" />
         <span className="hm-turn-kind">· current summary</span>
         <span className="hm-turn-time">{formatTurnTime(Date.now())}</span>
       </div>
@@ -523,36 +479,51 @@ function BacklogSuggestionRow({
         <small>{suggestion.reason}</small>
       </span>
       <span className="hm-backlog-suggestion-meta">
-        {suggestion.suggestedOwner} · {suggestion.riskTier} · {Math.round(suggestion.confidence * 100)}%
+        <AgentTag agent={suggestionOwnerAgent(suggestion.suggestedOwner)} label={suggestion.suggestedOwner} />
+        <Badge variant={suggestion.riskTier === "high" ? "risk" : "neutral"}>{suggestion.riskTier}</Badge>
+        <Badge variant={confidenceVariant(suggestion.confidence)}>{Math.round(suggestion.confidence * 100)}%</Badge>
       </span>
       {relatedCard ? (
         onCardClick ? (
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="xs"
             className="hm-backlog-link"
             onClick={() => onCardClick(relatedCard.id)}
             aria-label={`Open related card ${relatedCard.id}`}
           >
             Open card
-          </button>
+          </Button>
         ) : (
           <span className="hm-backlog-link">linked card</span>
         )
       ) : null}
       {suggestion.suggestedPrompt && onUseInComposer ? (
-        <button
-          type="button"
+        <Button
+          variant="secondary"
+          size="xs"
           className="hm-backlog-use"
           onClick={() => onUseInComposer(suggestion.suggestedPrompt!)}
         >
           Use in composer
-        </button>
+        </Button>
       ) : null}
       {suggestion.suggestedPrompt ? (
-        <button type="button" className="hm-backlog-copy" onClick={copyPrompt}>
+        <Button variant="ghost" size="xs" className="hm-backlog-copy" onClick={copyPrompt}>
           Copy prompt
-        </button>
+        </Button>
       ) : null}
     </div>
   );
+}
+
+function suggestionOwnerAgent(owner: BacklogSuggestion["suggestedOwner"]): AgentTagAgent {
+  if (owner === "codex" || owner === "claude" || owner === "operator" || owner === "hermes") return owner;
+  return "system";
+}
+
+function confidenceVariant(confidence: number): StateVariant {
+  if (confidence >= 0.8) return "pass";
+  if (confidence >= 0.5) return "pending";
+  return "degraded";
 }

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
@@ -2,19 +2,7 @@
 
 import type { CollaborationAuthor, CollaborationMessage, CollaborationTarget } from "../../lib/monitor/collaboration.js";
 import { actorLabel, actorLabelForMessage, formatTurnTime } from "../../lib/monitor/collaboration.js";
-import type { CSSProperties } from "react";
-
-const PROMINENT_TURN_STYLE: CSSProperties = {
-  borderLeftColor: "var(--hm-amber)",
-  background: "var(--hm-amber-soft, #fff3df)",
-};
-
-const MUTED_TURN_STYLE: CSSProperties = {
-  opacity: 0.72,
-  background: "rgba(255, 253, 247, 0.58)",
-};
-
-const DEFAULT_TURN_STYLE: CSSProperties = {};
+import { AgentTag } from "../ui.js";
 
 export function HermesTurn({
   turn,
@@ -34,13 +22,9 @@ export function HermesTurn({
   return (
     <div
       className={`hm-turn hm-turn--${turn.author} hm-turn--kind-${turn.kind} hm-turn--rank-${rank}`}
-      style={turnStyleForKind(turn.kind)}
     >
       <div className="hm-turn-head">
-        <span className="hm-turn-actor">
-          <span className="actor-dot" aria-hidden />
-          {roomActorLabel(turn)}
-        </span>
+        <AgentTag agent={turn.author} label={roomActorLabel(turn)} className="hm-turn-actor" />
         <span className="hm-turn-kind">
           · {kindLabel(turn.kind)}
           {pending ? " · pending" : ""}
@@ -111,14 +95,4 @@ function rankForKind(kind: CollaborationMessage["kind"]): "prominent" | "normal"
   if (kind === "request_help" || kind === "proposal") return "prominent";
   if (kind === "status") return "muted";
   return "normal";
-}
-
-function turnStyleForKind(kind: CollaborationMessage["kind"]): CSSProperties {
-  if (kind === "request_help" || kind === "proposal") {
-    return PROMINENT_TURN_STYLE;
-  }
-  if (kind === "status") {
-    return MUTED_TURN_STYLE;
-  }
-  return DEFAULT_TURN_STYLE;
 }

--- a/packages/monitor-ui/src/components/ui.test.tsx
+++ b/packages/monitor-ui/src/components/ui.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { AgentTag, Badge, Button, CardHeader, EmptyState, LaneHeader, StatusPill } from "./ui.js";
+
+afterEach(cleanup);
+
+describe("monitor design primitives", () => {
+  test("Badge and StatusPill apply state variants from one vocabulary", () => {
+    const { container, getByText } = render(
+      <>
+        <Badge variant="fail" dot>failed</Badge>
+        <StatusPill variant="degraded" dot>?</StatusPill>
+      </>,
+    );
+    expect(getByText("failed").className).toContain("hm-pill--fail");
+    expect(getByText("?").className).toContain("hm-status-pill--degraded");
+    expect(container.querySelectorAll(".dot, .status-dot")).toHaveLength(2);
+  });
+
+  test("Button variants keep native button semantics", () => {
+    const { getByRole } = render(<Button variant="action">Re-run</Button>);
+    const button = getByRole("button", { name: "Re-run" });
+    expect(button.className).toContain("hm-btn--action");
+    expect(button.getAttribute("type")).toBe("button");
+  });
+
+  test("AgentTag renders the shared agent dot grammar", () => {
+    const { container, getByText } = render(<AgentTag agent="claude" identifier="#123" />);
+    expect(container.querySelector(".agent-dot--claude")).toBeTruthy();
+    expect(getByText("claude")).toBeTruthy();
+    expect(getByText("#123")).toBeTruthy();
+  });
+
+  test("CardHeader and LaneHeader expose the unified board grammar", () => {
+    const { container, getByText } = render(
+      <>
+        <CardHeader agent="codex" id="#9" status="FRESH 2m" statusVariant="fresh" />
+        <LaneHeader title="PRE-CHECK IN FLIGHT" count={1} action="Risk decision" />
+      </>,
+    );
+    expect(container.querySelector(".hm-card-head .hm-agent-tag")).toBeTruthy();
+    expect(container.querySelector(".hm-lane-head .hm-lane-count")).toBeTruthy();
+    expect(getByText("PRE-CHECK IN FLIGHT")).toBeTruthy();
+  });
+
+  test("EmptyState is a reusable quiet state, not a card", () => {
+    const { container, getByText } = render(<EmptyState>Nothing needs you right now.</EmptyState>);
+    expect(container.querySelector(".hm-empty-state")).toBeTruthy();
+    expect(getByText("Nothing needs you right now.")).toBeTruthy();
+    expect(container.querySelector(".hm-card")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/ui.tsx
+++ b/packages/monitor-ui/src/components/ui.tsx
@@ -1,0 +1,198 @@
+import type { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from "react";
+import type { AgentType } from "../lib/monitor/card-types.js";
+
+export type StateVariant =
+  | "fail"
+  | "pass"
+  | "pending"
+  | "degraded"
+  | "fresh"
+  | "age"
+  | "neutral"
+  | "risk"
+  | "secret"
+  | "info"
+  | "draft"
+  | "ghost"
+  | "running"
+  | "hermes";
+
+export type ButtonVariant = "primary" | "secondary" | "ghost" | "action";
+export type ButtonSize = "xs" | "sm" | "md";
+export type AgentTagAgent = AgentType | "operator" | "system" | "room" | "board";
+
+function joinClasses(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+export function variantClass(prefix: string, variant: StateVariant): string {
+  return `${prefix}--${variant}`;
+}
+
+export function agentClass(agent: AgentTagAgent | undefined): string {
+  return `agent-dot--${agent ?? "ext"}`;
+}
+
+export function agentDisplayName(agent: AgentTagAgent | undefined): string {
+  if (agent === "operator") return "operator";
+  if (agent === "test-writer") return "test-writer";
+  if (agent === "security") return "security";
+  if (agent === "docs") return "docs";
+  if (agent === "hermes") return "hermes";
+  if (agent === "codex") return "codex";
+  if (agent === "claude") return "claude";
+  if (agent === "room") return "room";
+  if (agent === "board") return "board";
+  if (agent === "system") return "system";
+  return "ext";
+}
+
+export function Badge({
+  variant = "neutral",
+  dot = false,
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  variant?: StateVariant;
+  dot?: boolean;
+}) {
+  return (
+    <span className={joinClasses("hm-badge", "hm-pill", variantClass("hm-badge", variant), variantClass("hm-pill", variant), className)} {...props}>
+      {dot ? <span className="dot" aria-hidden /> : null}
+      {children}
+    </span>
+  );
+}
+
+export function StatusPill({
+  variant = "neutral",
+  dot = false,
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  variant?: StateVariant;
+  dot?: boolean;
+}) {
+  return (
+    <span className={joinClasses("hm-status-pill", variantClass("hm-status-pill", variant), className)} {...props}>
+      {dot ? <span className="status-dot" aria-hidden /> : null}
+      {children}
+    </span>
+  );
+}
+
+export function Button({
+  variant = "secondary",
+  size = "md",
+  className,
+  children,
+  type = "button",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}) {
+  return (
+    <button
+      type={type}
+      className={joinClasses(
+        "hm-btn",
+        `hm-btn--${variant}`,
+        size !== "md" ? `hm-btn--${size}` : undefined,
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function AgentTag({
+  agent,
+  identifier,
+  label,
+  className,
+  children,
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  agent?: AgentTagAgent;
+  identifier?: ReactNode;
+  label?: ReactNode;
+}) {
+  const display = label ?? agentDisplayName(agent);
+  return (
+    <span className={joinClasses("hm-agent-tag", className)} {...props}>
+      <span className={joinClasses("agent-dot", agentClass(agent))} aria-hidden />
+      <span className="hm-agent-tag-label">{display}</span>
+      {identifier ? <strong className="hm-agent-tag-id">{identifier}</strong> : null}
+      {children}
+    </span>
+  );
+}
+
+export function CardHeader({
+  agent,
+  id,
+  status,
+  statusVariant,
+  statusClassName,
+}: {
+  agent?: AgentTagAgent;
+  id: ReactNode;
+  status: ReactNode;
+  statusVariant: StateVariant;
+  statusClassName?: string;
+}) {
+  return (
+    <div className="hm-card-head">
+      <AgentTag agent={agent} identifier={id} className="hm-card-id hm-mono" />
+      <StatusPill
+        variant={statusVariant}
+        dot
+        className={joinClasses("hm-card-fresh", statusClassName)}
+      >
+        {status}
+      </StatusPill>
+    </div>
+  );
+}
+
+export function LaneHeader({
+  title,
+  count,
+  action,
+  collapse,
+}: {
+  title: string;
+  count: number;
+  action?: ReactNode;
+  collapse?: ReactNode;
+}) {
+  return (
+    <div className="hm-lane-head">
+      <div className="hm-lane-head-row">
+        <span className="hm-lane-title">{title}</span>
+        <StatusPill variant={count > 0 ? "pending" : "neutral"} className="hm-lane-count">
+          {count}
+        </StatusPill>
+        {collapse}
+      </div>
+      {action ? <div className="hm-lane-action">{action}</div> : null}
+    </div>
+  );
+}
+
+export function EmptyState({
+  children,
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={joinClasses("hm-empty-state", className)} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -54,6 +54,28 @@
   --hm-stale:       #a59f8e;
   --hm-fresh:       #1e6642;
 
+  --hm-state-fail:          var(--hm-rose);
+  --hm-state-fail-bg:       var(--hm-rose-soft);
+  --hm-state-pass:          var(--hm-sage-deep);
+  --hm-state-pass-bg:       var(--hm-sage-soft);
+  --hm-state-pending:       var(--hm-amber-deep);
+  --hm-state-pending-bg:    var(--hm-amber-soft);
+  --hm-state-degraded:      var(--hm-offline);
+  --hm-state-degraded-bg:   var(--hm-offline-soft);
+  --hm-state-fresh:         var(--hm-sage);
+  --hm-state-fresh-bg:      var(--hm-sage-soft);
+  --hm-state-age:           var(--hm-stale);
+  --hm-state-age-bg:        var(--hm-rail);
+  --hm-state-neutral:       var(--hm-muted);
+  --hm-state-neutral-bg:    var(--hm-rail);
+
+  --hm-space-1: 4px;
+  --hm-space-2: 6px;
+  --hm-space-3: 8px;
+  --hm-space-4: 10px;
+  --hm-space-5: 12px;
+  --hm-space-6: 16px;
+
   --hm-shadow-card: 0 1px 0 rgba(17,19,21,0.04), 0 8px 24px rgba(34,43,36,0.06);
   --hm-shadow-pop:  0 24px 60px rgba(34,43,36,0.16), 0 0 0 1px rgba(17,19,21,0.06);
   --hm-shadow-action: 0 0 0 1px var(--hm-amber-ring), 0 12px 28px rgba(167,97,34,0.18), 0 1px 0 rgba(167,97,34,0.10);
@@ -873,8 +895,15 @@ body { margin: 0; }
   white-space: nowrap;
 }
 .hm-backlog-suggestion-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   white-space: nowrap;
   justify-self: end;
+}
+.hm-backlog-suggestion-meta .hm-agent-tag {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
 }
 .hm-backlog-copy,
 .hm-backlog-link,
@@ -920,6 +949,11 @@ body { margin: 0; }
 .hm-backlog-link:hover {
   border-color: var(--hm-cyan-ring);
   color: var(--hm-ink);
+}
+
+.hm-empty-state {
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
 }
 .hm-filter-chip {
   display: inline-flex; align-items: center; gap: 6px;
@@ -1207,7 +1241,9 @@ body { margin: 0; }
   width: 100%;
   overflow: hidden;
 }
-.hm-card-id .agent-dot {
+.agent-dot {
+  display: inline-block;
+  flex: 0 0 auto;
   width: 6px; height: 6px; border-radius: 999px;
 }
 .agent-dot--codex  { background: #6b8a4e; }
@@ -1215,8 +1251,26 @@ body { margin: 0; }
 .agent-dot--test-writer { background: #2f7fb8; }
 .agent-dot--security { background: #a3414f; }
 .agent-dot--docs { background: #6b5b9a; }
-.agent-dot--hermes { background: var(--hm-sage); }
+.agent-dot--hermes { background: var(--hm-hermes); }
+.agent-dot--operator { background: var(--hm-ink); }
+.agent-dot--system { background: var(--hm-muted-soft); }
+.agent-dot--room { background: var(--hm-hermes); }
+.agent-dot--board { background: var(--hm-muted); }
 .agent-dot--ext    { background: var(--hm-muted); }
+.hm-agent-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  max-width: 100%;
+}
+.hm-agent-tag-label,
+.hm-agent-tag-id {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .hm-card-id strong {
   font-weight: 600;
   color: var(--hm-ink);
@@ -1242,12 +1296,23 @@ body { margin: 0; }
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.hm-card-fresh .fresh-dot {
+.hm-card-fresh .fresh-dot,
+.hm-card-fresh .status-dot {
   width: 6px; height: 6px; border-radius: 999px; background: var(--hm-fresh);
+  flex: 0 0 auto;
 }
-.hm-card-fresh.is-stale .fresh-dot   { background: var(--hm-stale); }
-.hm-card-fresh.is-fresh .fresh-dot   { background: var(--hm-sage); box-shadow: 0 0 0 3px rgba(30,102,66,0.16); }
-.hm-card-fresh.is-warm .fresh-dot    { background: var(--hm-amber); }
+.hm-card-fresh.is-stale .fresh-dot,
+.hm-card-fresh.is-stale .status-dot { background: var(--hm-state-age); }
+.hm-card-fresh.is-fresh .fresh-dot,
+.hm-card-fresh.is-fresh .status-dot { background: var(--hm-state-fresh); box-shadow: 0 0 0 3px rgba(30,102,66,0.16); }
+.hm-card-fresh.is-warm .fresh-dot,
+.hm-card-fresh.is-warm .status-dot { background: var(--hm-amber); }
+.hm-status-pill--fail .status-dot { background: var(--hm-state-fail); }
+.hm-status-pill--pass .status-dot { background: var(--hm-sage); }
+.hm-status-pill--pending .status-dot { background: var(--hm-amber); }
+.hm-status-pill--degraded .status-dot { background: var(--hm-state-degraded); }
+.hm-status-pill--age .status-dot { background: var(--hm-state-age); }
+.hm-status-pill--neutral .status-dot { background: var(--hm-state-neutral); }
 
 .hm-card-title {
   font-family: var(--font-body);
@@ -1534,6 +1599,13 @@ body { margin: 0; }
 }
 
 .hm-pillrow { display: flex; flex-wrap: wrap; gap: 5px; }
+.hm-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 100%;
+  min-width: 0;
+}
 .hm-pill {
   display: inline-flex; align-items: center; gap: 5px;
   max-width: 100%;
@@ -1558,6 +1630,13 @@ body { margin: 0; }
 .hm-pill--neutral{ background: var(--hm-rail); color: var(--hm-muted); }
 .hm-pill--draft  { background: #ece8db; color: #756d58; border: 1px dashed rgba(0,0,0,0.06); }
 .hm-pill--ghost  { background: transparent; color: var(--hm-muted-soft); border: 1px solid var(--hm-line); }
+.hm-pill--fail   { background: var(--hm-state-fail-bg); color: var(--hm-state-fail); }
+.hm-pill--pass   { background: var(--hm-state-pass-bg); color: var(--hm-state-pass); }
+.hm-pill--pending{ background: var(--hm-state-pending-bg); color: var(--hm-state-pending); }
+.hm-pill--degraded { background: var(--hm-state-degraded-bg); color: var(--hm-state-degraded); border: 1px dashed rgba(0,0,0,0.18); }
+.hm-pill--fresh  { background: var(--hm-state-fresh-bg); color: var(--hm-state-pass); }
+.hm-pill--age    { background: var(--hm-state-age-bg); color: var(--hm-state-age); }
+.hm-pill--running { background: var(--hm-state-pending-bg); color: var(--hm-state-pending); }
 
 .hm-pill .dot { width: 5px; height: 5px; border-radius: 999px; background: currentColor; }
 
@@ -1668,6 +1747,12 @@ body { margin: 0; }
   color: #fffdf7;
 }
 .hm-btn--primary:hover { background: var(--hm-sage-deep); }
+.hm-btn--secondary {
+  background: var(--hm-paper);
+  border-color: var(--hm-line);
+  color: var(--hm-ink);
+}
+.hm-btn--secondary:hover { background: var(--hm-paper-2); border-color: var(--hm-line-strong); }
 .hm-btn--action {
   background: var(--hm-amber);
   color: #fffdf7;
@@ -1681,6 +1766,28 @@ body { margin: 0; }
 .hm-btn--ghost:hover { background: var(--hm-paper); }
 .hm-btn--xs { height: 26px; padding: 0 10px; font-size: 10.5px; }
 .hm-btn--sm { height: 28px; padding: 0 11px; font-size: 11px; }
+.hm-btn:disabled,
+.hm-btn[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+.hm-btn.hm-keep-watching {
+  height: auto;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px dotted currentColor;
+  border-radius: 0;
+  color: var(--hm-sage-deep);
+  background: transparent;
+  font: inherit;
+  letter-spacing: inherit !important;
+  text-transform: none;
+}
+.hm-btn.hm-keep-watching:hover {
+  background: transparent;
+  transform: none;
+}
 
 .hm-kbd {
   display: inline-grid; place-items: center;
@@ -1896,6 +2003,44 @@ button.hm-activity-row:hover {
   min-width: 0;
   overflow: hidden;
 }
+.hm-room-thread {
+  display: grid;
+  gap: var(--hm-space-3);
+  padding: var(--hm-space-3);
+  border: 1px solid var(--hm-line);
+  border-radius: 8px;
+  background: rgba(255, 253, 247, 0.7);
+}
+.hm-room-thread-head {
+  display: flex;
+  align-items: center;
+  gap: var(--hm-space-3);
+  min-width: 0;
+  color: var(--hm-muted);
+  font-family: var(--font-display);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em !important;
+}
+.hm-room-thread-label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-room-thread-count {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--hm-muted);
+}
+.hm-room-empty {
+  opacity: 0.78;
+}
+.hm-board-summary-row {
+  opacity: 0.86;
+}
 .hm-activity-stream .hm-turn {
   border-left: 4px solid var(--hm-line-strong);
 }
@@ -1942,7 +2087,8 @@ button.hm-activity-row:hover {
   white-space: nowrap;
   margin-top: -4px;
 }
-.hm-turn-actor .actor-dot { width: 7px; height: 7px; border-radius: 999px; }
+.hm-turn-actor .actor-dot,
+.hm-turn-actor .agent-dot { width: 7px; height: 7px; border-radius: 999px; }
 .hm-turn--hermes  .actor-dot { background: var(--hm-hermes); }
 .hm-turn--operator .actor-dot { background: var(--hm-ink); }
 .hm-turn--codex   .actor-dot { background: #6b8a4e; }
@@ -1951,6 +2097,14 @@ button.hm-activity-row:hover {
 .hm-turn--security .actor-dot { background: #a3414f; }
 .hm-turn--docs .actor-dot { background: #6b5b9a; }
 .hm-turn--system  .actor-dot { background: var(--hm-muted-soft); }
+.hm-turn--rank-prominent {
+  border-left-color: var(--hm-amber);
+  background: var(--hm-amber-soft, #fff3df);
+}
+.hm-turn--rank-muted {
+  opacity: 0.72;
+  background: rgba(255, 253, 247, 0.58);
+}
 .hm-turn-time {
   grid-column: 2;
   grid-row: 1;


### PR DESCRIPTION
## What changed & why

- Added shared monitor UI primitives for Badge, StatusPill, Button, AgentTag, CardHeader, LaneHeader, and EmptyState.
- Moved board cards, degraded cards, lane headers/empty states, and the Hermes room rail onto the shared primitives.
- Added state tokens for fail/pass/pending/degraded/fresh/age/neutral while preserving degraded/offline honesty.
- Added primitive unit coverage, including degraded ? rendering.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] npm run typecheck
- [x] npm test
- [ ] docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config (only if ops/Docker/compose touched)

## Rollout / rollback

Frontend-only monitor UI refactor. Roll back by reverting this PR; no env, ops, DB, or runtime authority changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power (new capability -> new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated AGENTS.md / affected docs if this changes how agents work

## Known limits / follow-ups

- This is a mechanical design-system pass only; no data/behavior changes.
- Existing drawer/detail inline styles remain outside this PR scope.