### PR TITLE
feat(hermes): surface self-management diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,13 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   (high-risk surface, any rollback, or while D3-suspended / HALT is set; rollback
   is always operator-confirmed). Deduped + cooldown'd; depends on D3 as the loop
   fail-safe. Same invariant #6 guardrail — it only proposes.
+- **Self-management health (ORCH-P5).** Task-health may requeue failed/stale
+  tasks only within its configured retry cap and only through the same dispatch
+  policy, D3, and `HALT_FILE` gates; when the cap is spent, a runner heartbeat is
+  missing/stale, or a task target is not code-fixable, it escalates to
+  needs-attention instead of looping. The monitor's automation diagnostics are
+  read-only: they expose real retry/stuck/routing/budget state, mark unavailable
+  sources as unknown (`?`), and do not approve, merge, deploy, or create work.
 - **Hermes router (ORCH-P4b, off by default).** When
   `HERMES_ROUTER_ENABLED=1`, Hermes may turn the roadmap-backed backlog plan into
   proposed Codex/Claude tasks and narrate why in the monitor co-pilot rail. It

--- a/packages/monitor-ui/src/components/TopStrip.test.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.test.tsx
@@ -120,4 +120,88 @@ describe("TopStrip", () => {
     expect(getByText("Self-heal 2 open · dispatch 4/5 · quiet 1")).toBeTruthy();
     expect(getByLabelText("Automation health: Self-heal 2 open · dispatch 4/5 · quiet 1")).toBeTruthy();
   });
+
+  test("automation gauge opens a real self-management diagnostics panel", () => {
+    const { getByLabelText, getByText } = render(
+      <TopStrip
+        counts={calmCounts}
+        automationHealth={{
+          sourceStatus: "ok",
+          selfHealingOpen: 1,
+          dispatchUsedToday: 3,
+          dispatchPerDayCap: 10,
+          quietSignalCount: 0,
+          taskHealth: {
+            status: "stuck",
+            runningTasks: 2,
+            stuckTasks: 1,
+            retryWaitingTasks: 1,
+            escalatedTasks: 1,
+            runner: {
+              status: "stale",
+              reason: "runner_heartbeat_stale",
+              activeTaskId: "task-1",
+              ageMs: 120_000,
+            },
+          },
+          routing: {
+            status: "baseline_available",
+            decisionsToday: 2,
+            surfaces: 1,
+            baselineSurfaces: 1,
+            insufficientSurfaces: 0,
+            top: {
+              surface: "ops hygiene",
+              agent: "codex",
+              score: 78,
+              samples: 3,
+            },
+          },
+        }}
+      />,
+    );
+
+    fireEvent.click(getByLabelText("Automation health: Self-heal 1 open · dispatch 3/10 · stuck 1"));
+    expect(getByText("Task health")).toBeTruthy();
+    expect(getByText("stuck · 2 running · 1 stuck · 1 retry waiting · 1 escalated")).toBeTruthy();
+    expect(getByText("Routing memory")).toBeTruthy();
+    expect(getByText(/baseline available · 1 baseline · 0 sparse · 2 decisions today/)).toBeTruthy();
+    expect(getByText(/Retries stay bounded and respect dispatch policy/)).toBeTruthy();
+  });
+
+  test("automation gauge shows unknowns when task-queue counts are degraded", () => {
+    const { getByLabelText, getByText } = render(
+      <TopStrip
+        counts={calmCounts}
+        automationHealth={{
+          sourceStatus: "degraded",
+          selfHealingOpen: null,
+          dispatchUsedToday: null,
+          dispatchPerDayCap: 10,
+          quietSignalCount: null,
+          taskHealth: {
+            status: "unknown",
+            runningTasks: 0,
+            stuckTasks: 0,
+            retryWaitingTasks: 0,
+            escalatedTasks: 0,
+            runner: { status: "unknown", reason: "task_queue_unavailable" },
+          },
+          routing: {
+            status: "unknown",
+            decisionsToday: null,
+            surfaces: null,
+            baselineSurfaces: null,
+            insufficientSurfaces: null,
+          },
+        }}
+      />,
+    );
+
+    expect(getByText("Self-heal ? open · dispatch ?/10 · quiet ? · source ?")).toBeTruthy();
+    fireEvent.click(getByLabelText("Automation health: Self-heal ? open · dispatch ?/10 · quiet ? · source ?"));
+    expect(getByText("Task health")).toBeTruthy();
+    expect(getByText("unknown · task_queue_unavailable")).toBeTruthy();
+    expect(getByText("Dispatch ? of 10")).toBeTruthy();
+  });
 });

--- a/packages/monitor-ui/src/components/TopStrip.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.tsx
@@ -72,18 +72,84 @@ export function TopStrip({ counts, liveAt, deployHealth = "OK", automationHealth
 }
 
 function AutomationHealthPill({ health }: { health: AutomationHealth }) {
-  const quietSignals = Math.max(0, Math.floor(health.quietSignalCount ?? 0));
+  const quietSignals = health.quietSignalCount === null ? null : Math.max(0, Math.floor(health.quietSignalCount ?? 0));
+  const taskHealth = health.taskHealth;
+  const sourceDegraded = health.sourceStatus === "degraded";
   const text = [
-    `Self-heal ${health.selfHealingOpen} open`,
-    `dispatch ${health.dispatchUsedToday}/${health.dispatchPerDayCap}`,
-    quietSignals > 0 ? `quiet ${quietSignals}` : "",
+    `Self-heal ${countLabel(health.selfHealingOpen)} open`,
+    `dispatch ${countLabel(health.dispatchUsedToday)}/${health.dispatchPerDayCap}`,
+    taskHealth?.stuckTasks ? `stuck ${taskHealth.stuckTasks}` : "",
+    quietSignals === null ? "quiet ?" : quietSignals > 0 ? `quiet ${quietSignals}` : "",
+    sourceDegraded ? "source ?" : "",
   ].filter(Boolean).join(" · ");
   return (
-    <span className="hm-kpi hm-kpi--automation" aria-label={`Automation health: ${text}`}>
-      <span className="dot" aria-hidden />
-      {text}
-    </span>
+    <details className="hm-automation-health">
+      <summary className="hm-kpi hm-kpi--automation hm-automation-summary" aria-label={`Automation health: ${text}`}>
+        <span className="dot" aria-hidden />
+        {text}
+      </summary>
+      <div className="hm-automation-panel" role="group" aria-label="Automation diagnostics">
+        <div className="hm-automation-row">
+          <span>Task health</span>
+          <strong>{taskHealthLine(taskHealth)}</strong>
+        </div>
+        <div className="hm-automation-row">
+          <span>Runner</span>
+          <strong>{runnerLine(taskHealth)}</strong>
+        </div>
+        <div className="hm-automation-row">
+          <span>Routing memory</span>
+          <strong>{routingLine(health.routing)}</strong>
+        </div>
+        <div className="hm-automation-row">
+          <span>Budget</span>
+          <strong>Dispatch {countLabel(health.dispatchUsedToday)} of {health.dispatchPerDayCap}</strong>
+        </div>
+        <div className="hm-automation-note">
+          Retries stay bounded and respect dispatch policy, HALT, anomaly pause, and the human merge gate.
+        </div>
+      </div>
+    </details>
   );
+}
+
+function countLabel(value: number | null | undefined): string {
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : "?";
+}
+
+function taskHealthLine(health: AutomationHealth["taskHealth"]): string {
+  if (!health || health.status === "unknown") return "unknown";
+  const parts = [
+    `${health.runningTasks} running`,
+    `${health.stuckTasks} stuck`,
+    `${health.retryWaitingTasks} retry waiting`,
+    `${health.escalatedTasks} escalated`,
+  ];
+  return `${statusLabel(health.status)} · ${parts.join(" · ")}`;
+}
+
+function runnerLine(health: AutomationHealth["taskHealth"]): string {
+  const runner = health?.runner;
+  if (!runner) return "unknown";
+  const age = typeof runner.ageMs === "number" ? ` · ${Math.round(runner.ageMs / 1000)}s ago` : "";
+  return `${statusLabel(runner.status)} · ${runner.reason}${age}`;
+}
+
+function routingLine(routing: AutomationHealth["routing"]): string {
+  if (!routing || routing.status === "unknown") return "unknown";
+  const top = routing.top
+    ? ` · top ${routing.top.agent} on ${routing.top.surface} (${routing.top.score}, ${routing.top.samples} samples)`
+    : "";
+  return [
+    statusLabel(routing.status),
+    `${countLabel(routing.baselineSurfaces)} baseline`,
+    `${countLabel(routing.insufficientSurfaces)} sparse`,
+    `${countLabel(routing.decisionsToday)} decisions today`,
+  ].join(" · ") + top;
+}
+
+function statusLabel(status: string): string {
+  return status.replace(/_/g, " ");
 }
 
 function Kpi({

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -22,12 +22,45 @@ export interface MonitorBoard {
 }
 
 export interface AutomationHealth {
-  selfHealingOpen: number;
-  dispatchUsedToday: number;
+  sourceStatus?: "ok" | "degraded";
+  selfHealingOpen: number | null;
+  dispatchUsedToday: number | null;
   dispatchPerDayCap: number;
-  quietSignalCount?: number;
-  selfHealingCapacitySignals?: number;
-  taskHealthCapacitySignals?: number;
+  quietSignalCount?: number | null;
+  selfHealingCapacitySignals?: number | null;
+  taskHealthCapacitySignals?: number | null;
+  taskHealth?: {
+    status: "ok" | "stuck" | "degraded" | "unknown";
+    runningTasks: number;
+    stuckTasks: number;
+    retryWaitingTasks: number;
+    escalatedTasks: number;
+    runner: {
+      status: "online" | "missing" | "stale" | "unavailable" | "unknown";
+      reason: string;
+      activeTaskId?: string;
+      ageMs?: number;
+    };
+  };
+  routing?: {
+    status: "baseline_available" | "insufficient_data" | "unknown";
+    decisionsToday: number | null;
+    surfaces: number | null;
+    baselineSurfaces: number | null;
+    insufficientSurfaces: number | null;
+    top?: {
+      surface: string;
+      agent: string;
+      score: number;
+      samples: number;
+    };
+  };
+  guardrails?: {
+    dispatchPolicy: "enforced";
+    haltInterlock: "enforced";
+    anomalyPause: "enforced";
+    authority: "human_merge_gate";
+  };
 }
 
 export interface LlmUsageModelRollup {
@@ -177,8 +210,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isAutomationHealth(value: unknown): value is AutomationHealth {
   if (!isRecord(value)) return false;
-  return Number.isFinite(value.selfHealingOpen)
-    && Number.isFinite(value.dispatchUsedToday)
+  const selfHealingKnown = value.selfHealingOpen === null || Number.isFinite(value.selfHealingOpen);
+  const dispatchKnown = value.dispatchUsedToday === null || Number.isFinite(value.dispatchUsedToday);
+  return selfHealingKnown
+    && dispatchKnown
     && Number.isFinite(value.dispatchPerDayCap);
 }
 

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -175,6 +175,64 @@ body { margin: 0; }
   text-transform: none;
   letter-spacing: 0.02em !important;
 }
+.hm-automation-health {
+  position: relative;
+  display: inline-flex;
+}
+.hm-automation-summary {
+  list-style: none;
+  cursor: pointer;
+}
+.hm-automation-summary::-webkit-details-marker { display: none; }
+.hm-automation-health[open] .hm-automation-summary {
+  background: var(--hm-paper);
+  border-color: var(--hm-line-strong);
+  color: var(--hm-ink);
+}
+.hm-automation-panel {
+  position: absolute;
+  z-index: 25;
+  top: calc(100% + 8px);
+  right: 0;
+  width: min(420px, 88vw);
+  padding: 12px;
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+  border: 1px solid var(--hm-line);
+  box-shadow: var(--hm-shadow-pop);
+  color: var(--hm-ink);
+  text-align: left;
+}
+.hm-automation-row {
+  display: grid;
+  grid-template-columns: 112px 1fr;
+  gap: 12px;
+  align-items: start;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--hm-line-soft);
+}
+.hm-automation-row span {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.1em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-automation-row strong {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-weight: 650;
+  line-height: 1.45;
+  color: var(--hm-ink);
+  overflow-wrap: anywhere;
+}
+.hm-automation-note {
+  padding-top: 9px;
+  font-size: 12px;
+  color: var(--hm-muted);
+}
 .hm-kpi--zero     { opacity: 0.55; }
 .hm-kpi .dot { width: 6px; height: 6px; border-radius: 999px; background: currentColor; opacity: 0.7; }
 

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -28,11 +28,14 @@ import {
   type LlmUsageAggregate,
   type LlmUsageEvent,
 } from "@avg/averray-mcp/llm-usage";
+import { buildAgentScorecard } from "@avg/averray-mcp/agent-scorecard";
 import type { TestbedSuite } from "./monitor-testbed-suites.js";
 import type {
   HermesBoardCardSnapshot,
   HermesBoardSnapshot,
 } from "./monitor-hermes-voice.js";
+import type { CodexRunnerHeartbeat, CodexTask } from "./codex-task-queue.js";
+import { summarizeTaskHealth, type TaskHealthDiagnostics } from "./task-health.js";
 import {
   testbedMissionStructuredReport,
   type TestbedMissionRun,
@@ -354,16 +357,40 @@ export type BoardCardStreamEvent =
   | { type: "board.card.archived"; id: string; fromLane?: Lane; at: string };
 
 export interface AutomationHealth {
+  /** Whether task-queue backed automation counts are known for this snapshot. */
+  sourceStatus: "ok" | "degraded";
   /** Non-terminal self-healing fix proposals currently open. */
-  selfHealingOpen: number;
+  selfHealingOpen: number | null;
   /** Hermes/system-managed task proposals created today. */
-  dispatchUsedToday: number;
+  dispatchUsedToday: number | null;
   /** Same cap used by the dispatch/self-healing backstops. */
   dispatchPerDayCap: number;
   /** Slack-only capacity/escalation signals kept off the decision lanes. */
-  quietSignalCount: number;
-  selfHealingCapacitySignals: number;
-  taskHealthCapacitySignals: number;
+  quietSignalCount: number | null;
+  selfHealingCapacitySignals: number | null;
+  taskHealthCapacitySignals: number | null;
+  /** O5 read-only task health summary: stuck means runner evidence says the task is not actually progressing. */
+  taskHealth: TaskHealthDiagnostics;
+  /** ORCH-P4c routing memory summary for auditability; hard taxonomy/policy still win. */
+  routing: {
+    status: "baseline_available" | "insufficient_data" | "unknown";
+    decisionsToday: number | null;
+    surfaces: number | null;
+    baselineSurfaces: number | null;
+    insufficientSurfaces: number | null;
+    top?: {
+      surface: string;
+      agent: string;
+      score: number;
+      samples: number;
+    };
+  };
+  guardrails: {
+    dispatchPolicy: "enforced";
+    haltInterlock: "enforced";
+    anomalyPause: "enforced";
+    authority: "human_merge_gate";
+  };
 }
 
 // ── Lane normalization ──────────────────────────────────────────────
@@ -2156,31 +2183,124 @@ interface AutomationCapacitySignalCounts {
 export function automationHealthForBoard(
   rawSnapshot: unknown,
   now: Date = new Date(),
-  env: { HERMES_DISPATCH_PER_DAY_MAX?: string | undefined } = process.env,
+  env: {
+    HERMES_DISPATCH_PER_DAY_MAX?: string | undefined;
+    O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES?: string | undefined;
+  } = process.env,
   capacitySignals: AutomationCapacitySignalCounts = {},
 ): AutomationHealth {
   const selfHealingCapacitySignals = Math.max(0, Math.floor(capacitySignals.selfHealingCapacitySignals ?? 0));
   const taskHealthCapacitySignals = Math.max(0, Math.floor(capacitySignals.taskHealthCapacitySignals ?? 0));
   const quietSignalCount = selfHealingCapacitySignals + taskHealthCapacitySignals;
-  const tasks = asArray(asRecord(asRecord(rawSnapshot)?.codexTasks)?.items)
+  const root = asRecord(rawSnapshot);
+  const codexTasks = asRecord(root?.codexTasks);
+  const sourceAvailable = Array.isArray(codexTasks?.items);
+  const tasks = asArray(codexTasks?.items)
     .map(asRecord)
     .filter((task): task is Record<string, unknown> => Boolean(task));
   const today = now.toISOString().slice(0, 10);
-  const selfHealingOpen = tasks.filter((task) =>
+  const selfHealingOpen = sourceAvailable ? tasks.filter((task) =>
     asString(task.requester) === "hermes-self-healing"
     && !AUTOMATION_TERMINAL_TASK_STATUSES.has(asString(task.status) ?? "")
-  ).length;
-  const dispatchUsedToday = tasks.filter((task) =>
+  ).length : null;
+  const dispatchUsedToday = sourceAvailable ? tasks.filter((task) =>
     isAutomationDispatchTask(task)
     && asString(task.createdAt)?.slice(0, 10) === today
-  ).length;
+  ).length : null;
   return {
+    sourceStatus: sourceAvailable ? "ok" : "degraded",
     selfHealingOpen,
     dispatchUsedToday,
     dispatchPerDayCap: dispatchPerDayCap(env),
     quietSignalCount,
     selfHealingCapacitySignals,
     taskHealthCapacitySignals,
+    taskHealth: summarizeTaskHealth(tasks as unknown as CodexTask[], {
+      config: { restartRecoveryMs: taskHealthRestartRecoveryMs(env) },
+      now,
+      runner: sourceAvailable ? runnerFromSummary(codexTasks?.runner) : undefined,
+      sourceAvailable,
+    }),
+    routing: routingDiagnosticsForBoard(tasks, rawSnapshot, now, sourceAvailable),
+    guardrails: {
+      dispatchPolicy: "enforced",
+      haltInterlock: "enforced",
+      anomalyPause: "enforced",
+      authority: "human_merge_gate",
+    },
+  };
+}
+
+function runnerFromSummary(value: unknown): CodexRunnerHeartbeat | undefined {
+  const runner = asRecord(value);
+  if (!runner) return undefined;
+  const runnerId = asString(runner.runnerId);
+  const status = asString(runner.status);
+  const message = asString(runner.message);
+  const updatedAt = asString(runner.updatedAt);
+  if (!runnerId || !status || !message || !updatedAt) return undefined;
+  return {
+    schemaVersion: 1,
+    kind: "codex_runner_heartbeat",
+    runnerId,
+    status: status as CodexRunnerHeartbeat["status"],
+    message,
+    updatedAt,
+    ...(asString(runner.activeTaskId) ? { activeTaskId: asString(runner.activeTaskId) } : {}),
+  };
+}
+
+function taskHealthRestartRecoveryMs(env: { O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES?: string | undefined }): number {
+  const parsed = Number.parseInt(env.O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES ?? "", 10);
+  const minutes = Number.isFinite(parsed) && parsed > 0 ? parsed : 10;
+  return Math.max(60_000, minutes * 60_000);
+}
+
+function routingDiagnosticsForBoard(
+  tasks: Record<string, unknown>[],
+  rawSnapshot: unknown,
+  now: Date,
+  sourceAvailable: boolean,
+): AutomationHealth["routing"] {
+  if (!sourceAvailable) {
+    return {
+      status: "unknown",
+      decisionsToday: null,
+      surfaces: null,
+      baselineSurfaces: null,
+      insufficientSurfaces: null,
+    };
+  }
+  const today = now.toISOString().slice(0, 10);
+  const decisionsToday = tasks.filter((task) =>
+    isAutomationDispatchTask(task)
+    && asString(task.createdAt)?.slice(0, 10) === today
+    && Boolean(asString(task.routingReason) || asRecord(task.decisionRecord))
+  ).length;
+  const scorecard = buildAgentScorecard(rawSnapshot, { now });
+  const routingMemory = asRecord(scorecard.routingMemory);
+  const scores = asArray(routingMemory?.scores)
+    .map(asRecord)
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry));
+  const baselineScores = scores.filter((score) => asString(score.status) === "baseline_available");
+  const insufficientScores = scores.filter((score) => asString(score.status) === "insufficient_data");
+  const surfaceCount = new Set(scores.map((score) => asString(score.surface)).filter(Boolean)).size;
+  const top = baselineScores
+    .map((score) => ({
+      surface: asString(score.surface) ?? "unknown",
+      agent: asString(score.agent) ?? "unknown",
+      score: asFiniteNumber(score.score) ?? 0,
+      samples: asFiniteNumber(score.samples) ?? 0,
+    }))
+    .filter((score) => Number.isFinite(score.score) && score.score > 0)
+    .sort((a, b) => b.score - a.score || b.samples - a.samples)[0];
+  return {
+    status: baselineScores.length > 0 ? "baseline_available" : "insufficient_data",
+    decisionsToday,
+    surfaces: surfaceCount,
+    baselineSurfaces: baselineScores.length,
+    insufficientSurfaces: insufficientScores.length,
+    ...(top ? { top } : {}),
   };
 }
 

--- a/services/slack-operator/src/task-health.ts
+++ b/services/slack-operator/src/task-health.ts
@@ -36,6 +36,26 @@ export interface TaskHealthResult {
   actions: TaskHealthAction[];
 }
 
+export type TaskHealthDiagnosticStatus =
+  | "ok"
+  | "stuck"
+  | "degraded"
+  | "unknown";
+
+export interface TaskHealthDiagnostics {
+  status: TaskHealthDiagnosticStatus;
+  runningTasks: number;
+  stuckTasks: number;
+  retryWaitingTasks: number;
+  escalatedTasks: number;
+  runner: {
+    status: "online" | "missing" | "stale" | "unavailable" | "unknown";
+    reason: string;
+    activeTaskId?: string;
+    ageMs?: number;
+  };
+}
+
 const TERMINAL_NO_ACTION = new Set(["completed", "cancelled"]);
 
 export async function runTaskHealthOnce(
@@ -72,6 +92,65 @@ export async function runTaskHealthOnce(
   }
 
   return { actions };
+}
+
+export function summarizeTaskHealth(
+  tasks: CodexTask[],
+  ctx: {
+    config: Pick<TaskHealthConfig, "restartRecoveryMs">;
+    now: Date;
+    runner?: CodexRunnerHeartbeat;
+    sourceAvailable?: boolean;
+  },
+): TaskHealthDiagnostics {
+  if (ctx.sourceAvailable === false) {
+    return {
+      status: "unknown",
+      runningTasks: 0,
+      stuckTasks: 0,
+      retryWaitingTasks: 0,
+      escalatedTasks: 0,
+      runner: { status: "unknown", reason: "task_queue_unavailable" },
+    };
+  }
+
+  let runningTasks = 0;
+  let stuckTasks = 0;
+  let retryWaitingTasks = 0;
+  let escalatedTasks = 0;
+
+  for (const task of tasks) {
+    if (task.selfManagementEscalatedAt) escalatedTasks += 1;
+    if (task.status === "failed") {
+      const retryAfter = parseDate(task.retryAfter);
+      if (retryAfter && retryAfter.getTime() > ctx.now.getTime()) retryWaitingTasks += 1;
+    }
+    if (task.status !== "running") continue;
+    runningTasks += 1;
+    const staleAgeMs = ageMs(task.progressAt ?? task.startedAt ?? task.updatedAt, ctx.now);
+    const runner = runnerStateForTask(task, ctx.runner, ctx.now);
+    if (runner.unavailable && staleAgeMs >= ctx.config.restartRecoveryMs) {
+      stuckTasks += 1;
+    }
+  }
+
+  const runner = runnerSummary(ctx.runner, ctx.now);
+  const status: TaskHealthDiagnosticStatus = stuckTasks > 0
+    ? "stuck"
+    : runner.status === "missing" && runningTasks > 0
+      ? "degraded"
+      : runner.status === "stale" || runner.status === "unavailable"
+        ? "degraded"
+        : "ok";
+
+  return {
+    status,
+    runningTasks,
+    stuckTasks,
+    retryWaitingTasks,
+    escalatedTasks,
+    runner,
+  };
 }
 
 export async function decideTaskHealthAction(
@@ -162,13 +241,54 @@ function runnerStateForTask(
   task: CodexTask,
   runner: CodexRunnerHeartbeat | undefined,
   now: Date,
-): { unavailable: boolean; activeTaskMismatch: boolean } {
-  if (!runner) return { unavailable: true, activeTaskMismatch: false };
+): { unavailable: boolean; activeTaskMismatch: boolean; reason: string } {
+  if (!runner) return { unavailable: true, activeTaskMismatch: false, reason: "runner_missing" };
   const heartbeatAgeMs = ageMs(runner.updatedAt, now);
   const stale = heartbeatAgeMs > 90_000;
   const unavailable = stale || runner.status === "disabled" || runner.status === "misconfigured" || runner.status === "error" || runner.status === "failed";
   const activeTaskMismatch = Boolean(runner.activeTaskId && runner.activeTaskId !== task.id);
-  return { unavailable: unavailable || activeTaskMismatch, activeTaskMismatch };
+  return {
+    unavailable: unavailable || activeTaskMismatch,
+    activeTaskMismatch,
+    reason: activeTaskMismatch
+      ? "active_task_mismatch"
+      : stale
+        ? "runner_heartbeat_stale"
+        : unavailable
+          ? `runner_${runner.status}`
+          : "runner_available",
+  };
+}
+
+function runnerSummary(
+  runner: CodexRunnerHeartbeat | undefined,
+  now: Date,
+): TaskHealthDiagnostics["runner"] {
+  if (!runner) return { status: "missing", reason: "no_runner_heartbeat" };
+  const runnerAgeMs = ageMs(runner.updatedAt, now);
+  const stale = runnerAgeMs > 90_000;
+  if (stale) {
+    return {
+      status: "stale",
+      reason: "runner_heartbeat_stale",
+      activeTaskId: runner.activeTaskId,
+      ageMs: runnerAgeMs,
+    };
+  }
+  if (runner.status === "disabled" || runner.status === "misconfigured" || runner.status === "error" || runner.status === "failed") {
+    return {
+      status: "unavailable",
+      reason: `runner_${runner.status}`,
+      activeTaskId: runner.activeTaskId,
+      ageMs: runnerAgeMs,
+    };
+  }
+  return {
+    status: "online",
+    reason: `runner_${runner.status}`,
+    activeTaskId: runner.activeTaskId,
+    ageMs: runnerAgeMs,
+  };
 }
 
 function ageMs(value: string | undefined, now: Date): number {

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -46,6 +46,45 @@ function slim(overrides: Partial<HermesBoardCardSnapshot> = {}): HermesBoardCard
   };
 }
 
+function routingTask(
+  id: string,
+  agent: "codex" | "claude",
+  surface: string,
+  outcome: "opened_pr" | "no_pr" | "failed",
+  recordedAt: string,
+  totalTokens: number,
+) {
+  return {
+    id,
+    schemaVersion: 1,
+    kind: "codex_task",
+    repo: "depre-dev/averray-reference-agent",
+    prompt: "route this work",
+    createdAt: recordedAt,
+    updatedAt: recordedAt,
+    agent,
+    surface,
+    status: outcome === "failed" ? "failed" : "completed",
+    startedAt: "2026-06-01T07:55:00.000Z",
+    completedAt: outcome === "failed" ? undefined : recordedAt,
+    failedAt: outcome === "failed" ? recordedAt : undefined,
+    routingOutcome: {
+      agent,
+      surface,
+      outcome,
+      durationMs: 10 * 60_000,
+      tokenUsage: {
+        model: `${agent}-model`,
+        inputTokens: totalTokens,
+        outputTokens: 0,
+        totalTokens,
+      },
+      recordedAt,
+      evidence: "runner_completion",
+    },
+  };
+}
+
 describe("normalizeLane", () => {
   it("maps every classifier label to the kebab-case enum", () => {
     expect(normalizeLane("Needs Attention")).toBe("needs-attention");
@@ -1835,13 +1874,106 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
 
     expect(automationHealthForBoard(raw, new Date("2026-06-01T12:00:00.000Z"), {
       HERMES_DISPATCH_PER_DAY_MAX: "5",
-    })).toEqual({
+    })).toMatchObject({
+      sourceStatus: "ok",
       selfHealingOpen: 1,
       dispatchUsedToday: 4,
       dispatchPerDayCap: 5,
       quietSignalCount: 0,
       selfHealingCapacitySignals: 0,
       taskHealthCapacitySignals: 0,
+      taskHealth: {
+        status: "ok",
+        runningTasks: 0,
+        stuckTasks: 0,
+      },
+      routing: {
+        status: "insufficient_data",
+        decisionsToday: 0,
+      },
+      guardrails: {
+        dispatchPolicy: "enforced",
+        haltInterlock: "enforced",
+        anomalyPause: "enforced",
+        authority: "human_merge_gate",
+      },
+    });
+  });
+
+  it("automation health exposes stuck runner-silent work and routing scorecard memory", () => {
+    const raw = {
+      codexTasks: {
+        runner: {
+          schemaVersion: 1,
+          kind: "codex_runner_heartbeat",
+          runnerId: "claude-runner",
+          status: "running",
+          message: "Runner is alive but on a different task.",
+          updatedAt: "2026-06-01T11:59:40.000Z",
+          activeTaskId: "other-task",
+        },
+        items: [
+          {
+            id: "running-stuck",
+            schemaVersion: 1,
+            kind: "codex_task",
+            status: "running",
+            repo: "depre-dev/averray-reference-agent",
+            agent: "claude",
+            prompt: "fix stale work",
+            createdAt: "2026-06-01T09:00:00.000Z",
+            startedAt: "2026-06-01T11:40:00.000Z",
+            progressAt: "2026-06-01T11:40:00.000Z",
+            updatedAt: "2026-06-01T11:40:00.000Z",
+          },
+          routingTask("codex-win-a", "codex", "ops hygiene", "opened_pr", "2026-06-01T08:00:00.000Z", 20),
+          routingTask("codex-win-b", "codex", "ops hygiene", "opened_pr", "2026-06-01T09:00:00.000Z", 22),
+        ],
+      },
+    };
+
+    expect(automationHealthForBoard(raw, new Date("2026-06-01T12:00:00.000Z"), {
+      HERMES_DISPATCH_PER_DAY_MAX: "5",
+      O5_TASK_HEALTH_RESTART_RECOVERY_MINUTES: "10",
+    })).toMatchObject({
+      sourceStatus: "ok",
+      taskHealth: {
+        status: "stuck",
+        runningTasks: 1,
+        stuckTasks: 1,
+        runner: {
+          status: "online",
+          activeTaskId: "other-task",
+        },
+      },
+      routing: {
+        status: "baseline_available",
+        decisionsToday: 0,
+        baselineSurfaces: 1,
+        top: {
+          agent: "codex",
+          surface: "ops hygiene",
+          samples: 2,
+        },
+      },
+    });
+  });
+
+  it("automation health uses unknown counts when the task queue source is unavailable", () => {
+    expect(automationHealthForBoard({ active: [], recent: [] }, new Date("2026-06-01T12:00:00.000Z")))
+      .toMatchObject({
+        sourceStatus: "degraded",
+        selfHealingOpen: null,
+        dispatchUsedToday: null,
+        quietSignalCount: 0,
+        taskHealth: {
+          status: "unknown",
+          runner: { status: "unknown" },
+        },
+        routing: {
+          status: "unknown",
+          decisionsToday: null,
+        },
     });
   });
 

--- a/test/unit/task-health.test.ts
+++ b/test/unit/task-health.test.ts
@@ -4,6 +4,7 @@ import type { CodexTask } from "../../services/slack-operator/src/codex-task-que
 import {
   decideTaskHealthAction,
   runTaskHealthOnce,
+  summarizeTaskHealth,
   type TaskHealthConfig,
 } from "../../services/slack-operator/src/task-health.js";
 
@@ -258,6 +259,57 @@ describe("task health self-management", () => {
     expect(result).toMatchObject({
       action: "escalate",
       reason: "autopilot_suspended",
+    });
+  });
+
+  it("summarizes claimed-but-silent work as stuck, distinct from genuinely running", () => {
+    const now = new Date("2026-06-01T10:00:00.000Z");
+    const summary = summarizeTaskHealth([
+      task({
+        id: "running-stuck",
+        status: "running",
+        startedAt: "2026-06-01T09:40:00.000Z",
+        progressAt: "2026-06-01T09:40:00.000Z",
+        updatedAt: "2026-06-01T09:40:00.000Z",
+      }),
+      task({
+        id: "running-fresh",
+        status: "running",
+        startedAt: "2026-06-01T09:59:00.000Z",
+        progressAt: "2026-06-01T09:59:00.000Z",
+        updatedAt: "2026-06-01T09:59:00.000Z",
+      }),
+    ], {
+      config,
+      now,
+      sourceAvailable: true,
+    });
+
+    expect(summary).toMatchObject({
+      status: "stuck",
+      runningTasks: 2,
+      stuckTasks: 1,
+      runner: {
+        status: "missing",
+        reason: "no_runner_heartbeat",
+      },
+    });
+  });
+
+  it("marks task health unknown instead of zero when the queue source is unavailable", () => {
+    const summary = summarizeTaskHealth([], {
+      config,
+      now: new Date("2026-06-01T10:00:00.000Z"),
+      sourceAvailable: false,
+    });
+
+    expect(summary).toEqual({
+      status: "unknown",
+      runningTasks: 0,
+      stuckTasks: 0,
+      retryWaitingTasks: 0,
+      escalatedTasks: 0,
+      runner: { status: "unknown", reason: "task_queue_unavailable" },
     });
   });
 });


### PR DESCRIPTION
## Summary
- add read-only task-health diagnostics for running, stuck, retry-waiting, and escalated work
- extend the monitor automation-health snapshot with task-health, routing-memory, budget, guardrail, and degraded-source state
- make the header automation gauge expandable so operators can inspect self-management diagnostics without adding a decision-lane card
- document ORCH-P5 self-management rules in AGENTS.md

## Authority / safety
- no authority change: no auto-merge, no auto-deploy, no new task creation path
- retries remain bounded and continue to respect dispatch policy, D3 anomaly pause, and HALT_FILE
- degraded task-queue data renders as unknown, not zero

## Checks
- npm run typecheck
- npm test
- npm test -- test/unit/task-health.test.ts test/unit/monitor-v2.test.ts packages/monitor-ui/src/components/TopStrip.test.tsx

## Affected surfaces
- slack-operator monitor snapshot and task-health diagnostics
- monitor UI top-strip automation health disclosure
- tests and AGENTS.md