### PR TITLE
Organize monitor board by operator focus

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -178,6 +178,8 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
+      await waitFor(() => expect(getByRole("button", { name: /Utilities/ })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: /Utilities/ }));
       await waitFor(() => expect(getByRole("button", { name: "Start a mission" })).toBeTruthy());
 
       fireEvent.click(getByRole("button", { name: "Start a mission" }));
@@ -219,6 +221,8 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
+      await waitFor(() => expect(getByRole("button", { name: /Utilities/ })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: /Utilities/ }));
       await waitFor(() => expect(getByRole("button", { name: "Start a mission" })).toBeTruthy());
 
       fireEvent.click(getByRole("button", { name: "Start a mission" }));
@@ -272,6 +276,8 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
+      await waitFor(() => expect(getByRole("button", { name: /Utilities/ })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: /Utilities/ }));
       await waitFor(() => expect(getByRole("button", { name: "Run" })).toBeTruthy());
 
       fireEvent.click(getByRole("button", { name: "Run" }));

--- a/packages/monitor-ui/src/components/Board.tsx
+++ b/packages/monitor-ui/src/components/Board.tsx
@@ -52,6 +52,12 @@ export const ACTION_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
 export type BoardProps = {
   /** Lane → card[] grouping from `groupByLane(cards)`. */
   grouped: Record<LaneKey, BoardCard[]>;
+  /** Optional lane subset, preserving canonical descriptor order. */
+  lanes?: readonly LaneId[];
+  /** Accessible label for this lane group. */
+  ariaLabel?: string;
+  /** Optional class hook for tier-specific layout. */
+  className?: string;
   /** Initial expansion when Board is uncontrolled. */
   initialExpanded?: ReadonlySet<LaneId>;
   /** Controlled expansion. When provided, Board defers to the parent
@@ -71,6 +77,9 @@ export type BoardProps = {
 
 export function Board({
   grouped,
+  lanes,
+  ariaLabel = "Lane grid",
+  className,
   initialExpanded = DEFAULT_EXPANDED,
   expanded: controlledExpanded,
   onToggleLane,
@@ -98,9 +107,13 @@ export function Board({
     [isControlled, onToggleLane],
   );
 
+  const laneSet = lanes ? new Set<LaneId>(lanes) : null;
+  const descriptors = laneSet ? LANE_DESCRIPTORS.filter((lane) => laneSet.has(lane.id)) : LANE_DESCRIPTORS;
+  const classes = ["hm-lanes", className].filter(Boolean).join(" ");
+
   return (
-    <div className="hm-lanes" role="region" aria-label="Lane grid">
-      {LANE_DESCRIPTORS.map((lane) => {
+    <div className={classes} role="region" aria-label={ariaLabel}>
+      {descriptors.map((lane) => {
         const cards = grouped[lane.id] ?? [];
         const isExpanded = expanded.has(lane.id);
         const customBody = renderLaneBody?.(lane.id, cards);

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -20,20 +20,26 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelector(".hm-now--action")).toBeTruthy();
     expect(view.getByText(/your review decision/)).toBeTruthy();
     expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
-    expect(view.getByRole("region", { name: "Lane grid" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "DECIDE" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "WATCH" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "HIDE" })).toBeTruthy();
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
     expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
 
-  test("every lane that holds cards is expanded; only empty lanes stay mini-rails", () => {
+  test("DECIDE/WATCH stay expanded while HIDE lanes collapse to reachable mini-rails", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
-    // 7 of 8 lanes hold cards after grouping (the lone operator-review PR is an
-    // action card, promoted to needs-attention) → 7 expanded, 1 empty rail.
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(7);
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(1);
-    // drafts/codex-needed hold cards but aren't in the action preset — pre-fix
-    // they were hidden behind rails; now their card bodies render.
-    expect(within(container).getByText(/governance dispute UI/)).toBeTruthy();
+    const view = within(container);
+    expect(view.getByRole("region", { name: "Needs attention lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Codex needed lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Hermes checking lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Deploying lane" })).toBeTruthy();
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(4);
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(4);
+
+    expect(view.queryByText(/governance dispute UI/)).toBeNull();
+    fireEvent.click(view.getByRole("button", { name: /Drafts \(1 card\)/ }));
+    expect(view.getByText(/governance dispute UI/)).toBeTruthy();
   });
 
   test("renders the action card with one primary and Hermes verdict", () => {
@@ -94,6 +100,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const view = within(container);
     expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
     expect(view.getByText(/Post-merge verify/)).toBeTruthy();
+    fireEvent.click(view.getByRole("button", { name: /Done \(11 cards\)/ }));
     expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
   });
 
@@ -118,6 +125,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     };
     const { getByText, getByRole } = render(<BoardView board={board} status="open" onRunSuite={onRunSuite} keyboard={false} />);
 
+    fireEvent.click(getByRole("button", { name: /Utilities/ }));
     expect(getByText("Daily app sweep")).toBeTruthy();
     expect(getByText("pass")).toBeTruthy();
     expect(getByText("1 runs")).toBeTruthy();
@@ -140,6 +148,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
       />,
     );
 
+    fireEvent.click(getByRole("button", { name: /Utilities/ }));
     fireEvent.click(getByRole("button", { name: "Start a mission" }));
     fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/agents" } });
     fireEvent.click(getByLabelText(/Role Gating/));
@@ -219,9 +228,40 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelector(".hm-now--calm")).toBeTruthy();
     // The deploying lane (in-flight automation) is expanded and shows its body…
     expect(within(container).getByText(/Post-merge verify/)).toBeTruthy();
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(2); // deploying + done
-    // …and the six empty lanes are mini-rails — not everything-but-Done collapsed.
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(6);
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(1); // deploying
+    // …and empty/quiet lanes (including Done history) are mini-rails.
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(7);
+  });
+
+  test("groups near-identical deploy verification cards without hiding attention cards", () => {
+    const board: MonitorBoard = {
+      at: "2026-06-02T08:00:00Z",
+      cards: [
+        deployCard({ id: "deploy-1", deployId: "#1", title: "post-production-deploy verification after workflow run #1" }),
+        deployCard({ id: "deploy-2", deployId: "#2", title: "post-production-deploy verification after workflow run #2" }),
+        deployCard({ id: "deploy-3", deployId: "#3", title: "post-production-deploy verification after workflow run #3" }),
+      ],
+    };
+    const { getByRole, getByText, queryAllByRole } = render(<BoardView board={board} status="open" keyboard={false} />);
+
+    expect(getByRole("group", { name: /post-production-deploy verification after workflow run #1 group/i })).toBeTruthy();
+    expect(getByText("3 similar")).toBeTruthy();
+    expect(queryAllByRole("article").length).toBe(0);
+
+    fireEvent.click(getByRole("button", { name: "Expand" }));
+    expect(queryAllByRole("article").length).toBe(3);
+  });
+
+  test("an attention lane stays visible even after a collapse attempt", () => {
+    const board: MonitorBoard = {
+      at: "2026-06-02T08:00:00Z",
+      cards: [reviewCard({ id: "agent #901", title: "Review the settlement risk" })],
+    };
+    const { getByRole, getByText } = render(<BoardView board={board} status="open" keyboard={false} />);
+
+    fireEvent.click(getByRole("button", { name: "Collapse Needs attention lane" }));
+    expect(getByRole("region", { name: "Needs attention lane" })).toBeTruthy();
+    expect(getByText("Review the settlement risk")).toBeTruthy();
   });
 
   test("calm banner CTA filters to today's done cards and mutes alerts for one hour", () => {
@@ -370,6 +410,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
       },
     };
     const { getAllByText, getByRole, getByText, queryByText, queryAllByText } = render(<BoardView board={board} status="open" />);
+    fireEvent.click(getByRole("button", { name: /Utilities/ }));
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
     // Collapsed by default: leads with the headline (total tokens + call count)…
     expect(getByText("59K tokens · 12 calls")).toBeTruthy();
@@ -410,6 +451,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     };
 
     const { getByRole, getByText, queryByText } = render(<BoardView board={board} status="open" />);
+    fireEvent.click(getByRole("button", { name: /Utilities/ }));
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
     // The one-line summary states "usage not reported" honestly without expanding.
     expect(getByText("usage not reported")).toBeTruthy();
@@ -611,6 +653,25 @@ function doneCard(overrides: Partial<BoardCard> = {}): BoardCard {
     waitingOn: { actor: "CI", tone: "neutral" },
     closedAt: "2026-06-01T08:00:00.000Z",
     mergeStatus: "MERGED",
+    ...overrides,
+  } as BoardCard;
+}
+
+function deployCard(overrides: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "deploy-1",
+    lane: "deploying",
+    type: "deploy",
+    agentType: "ext",
+    title: "post-production-deploy verification after workflow run",
+    summary: "Verification is running.",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 1,
+    state: "fresh",
+    risk: ["workflow"],
+    waitingOn: { actor: "relay", tone: "info" },
+    deployId: "#1",
+    verification: { current: 1, total: 3, label: "post-deploy smoke" },
     ...overrides,
   } as BoardCard;
 }

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -12,18 +12,19 @@
 //     <div.hm-main>              grid: lanes-wrap | hermes rail (420px)
 //       <div.hm-lanes-wrap>
 //         <LanesBar />           search + filter chips + urgency label
-//         <Board renderCard />   the eight lanes, cards via <CardRouter>
+//         <UtilityBar />         collapsed tester / suites / LLM usage
+//         <BoardTier />          DECIDE / WATCH / HIDE lane groups
 //       <CoPilotRail />          live narration + Ask-Hermes
 //   <DetailDrawer />             when ?card= resolves
 //   <KeyboardOverlay />          when ? is pressed
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { deriveBoardState, matchesBoardFilter, type BoardMode, type BoardFilter } from "../lib/monitor/board-state.js";
 import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
-import type { MissionSpawnInput, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+import type { MissionSpawnInput, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
 import { CreateTaskForm } from "./CreateTaskForm.js";
 import { StartMissionLauncher } from "./StartMissionLauncher.js";
 import { TestSuitesPanel } from "./TestSuitesPanel.js";
@@ -33,7 +34,7 @@ import { TopStrip } from "./TopStrip.js";
 import { TopStripDegraded } from "./TopStripDegraded.js";
 import { BoardNowBanner } from "./BoardNowBanner.js";
 import { LanesBar } from "./LanesBar.js";
-import { Board, CALM_EXPANDED, DEFAULT_EXPANDED } from "./Board.js";
+import { Board } from "./Board.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
 import { HermesCheckingBody } from "./HermesCheckingBody.js";
@@ -43,42 +44,56 @@ import { CoPilotRail } from "./hermes/CoPilotRail.js";
 import { KeyboardOverlay } from "./shortcuts/KeyboardOverlay.js";
 import type { UseCollaborationOptions } from "../hooks/useCollaboration.js";
 import { useBoardKeyboard } from "../hooks/useBoardKeyboard.js";
+import { Badge, Button } from "./ui.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
 // action preset expands that lane (not operator-review) to keep the
 // action treatment — verdict + CTA — on screen.
-const ACTION_EXPANDED: ReadonlySet<LaneId> = new Set<LaneId>([
-  "needs-attention",
-  "hermes-checking",
-  "release-queue",
-  "deploying",
-  "done",
-]);
 const OPERATOR_CARD_SNOOZE_MS = 30 * 60_000;
 
-function expandedForMode(mode: BoardMode): ReadonlySet<LaneId> {
-  if (mode === "calm") return CALM_EXPANDED;
-  if (mode === "degraded") return DEFAULT_EXPANDED;
-  return ACTION_EXPANDED;
-}
-
 const ALL_LANES = LANES as readonly LaneId[];
+const DECIDE_LANES = ["needs-attention", "operator-review"] as const satisfies readonly LaneId[];
+const WATCH_LANES = ["codex-needed", "hermes-checking", "deploying"] as const satisfies readonly LaneId[];
+const HIDE_LANES = ["drafts", "release-queue", "done"] as const satisfies readonly LaneId[];
 
 /** Lanes that currently hold at least one card. */
 function lanesWithCards(grouped: Partial<Record<LaneId, BoardCard[]>>): LaneId[] {
   return ALL_LANES.filter((lane) => (grouped[lane]?.length ?? 0) > 0);
 }
 
-// A lane with cards is always shown — only empty lanes collapse to rails. The
-// mode preset just decides which EMPTY lanes stay open (e.g. Done as release
-// history). This is why a calm board with automation in flight still shows
-// those lanes' cards instead of hiding everything but Done.
+function hasCards(grouped: Partial<Record<LaneId, BoardCard[]>>, lane: LaneId): boolean {
+  return (grouped[lane]?.length ?? 0) > 0;
+}
+
+function mustSurfaceCard(card: BoardCard): boolean {
+  const lane = laneFor(card);
+  return (
+    lane === "needs-attention" ||
+    lane === "operator-review" ||
+    card.isAction === true ||
+    card.state === "failed-fetch" ||
+    card.state === "source-offline"
+  );
+}
+
+function mustSurfaceLanes(grouped: Partial<Record<LaneId, BoardCard[]>>): LaneId[] {
+  return ALL_LANES.filter((lane) => (grouped[lane] ?? []).some(mustSurfaceCard));
+}
+
+// Operator-focus defaults: DECIDE + WATCH lanes with cards are open; quiet
+// history/author lanes stay reachable as rails unless a degraded/action card
+// forces them open. Filters still reveal matching lanes below.
 function expandedForBoard(
-  mode: BoardMode,
+  _mode: BoardMode,
   grouped: Partial<Record<LaneId, BoardCard[]>>,
   alwaysOpen: readonly LaneId[] = [],
 ): Set<LaneId> {
-  return new Set<LaneId>([...expandedForMode(mode), ...lanesWithCards(grouped), ...alwaysOpen]);
+  return new Set<LaneId>([
+    ...DECIDE_LANES.filter((lane) => hasCards(grouped, lane)),
+    ...WATCH_LANES.filter((lane) => hasCards(grouped, lane)),
+    ...mustSurfaceLanes(grouped),
+    ...alwaysOpen,
+  ]);
 }
 
 function matchesQuery(card: BoardCard, q: string): boolean {
@@ -294,6 +309,9 @@ export function BoardView({
     if (filter === "all") return expanded;
     return new Set(LANES.filter((lane) => (displayGrouped[lane]?.length ?? 0) > 0));
   }, [filter, expanded, displayGrouped]);
+  const surfacedExpanded = useMemo<ReadonlySet<LaneId>>(() => (
+    new Set<LaneId>([...effectiveExpanded, ...mustSurfaceLanes(displayGrouped), ...alwaysOpen])
+  ), [alwaysOpen, displayGrouped, effectiveExpanded]);
 
   const orderedCards = useMemo<BoardCard[]>(
     () => LANES.flatMap((lane) => displayGrouped[lane] ?? []),
@@ -321,6 +339,15 @@ export function BoardView({
       onKeepWatching={(c) => onKeepWatchingCard(c.id)}
     />
   );
+  const renderLaneBody = (id: LaneId, laneCards: BoardCard[]) => {
+    const groupedItems = groupLaneCards(id, laneCards);
+    const hasGroupedCards = groupedItems.some((item) => item.kind === "group");
+    if (id === "hermes-checking" && !hasGroupedCards) {
+      return <HermesCheckingBody cards={laneCards} renderCard={renderCard} />;
+    }
+    if (!hasGroupedCards) return undefined;
+    return <GroupedLaneBody items={groupedItems} renderCard={renderCard} />;
+  };
 
   const drawerCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
   const boardFocusedCard = boardFocusId ? orderedCards.find((c) => c.id === boardFocusId) : undefined;
@@ -508,31 +535,73 @@ export function BoardView({
             activeFilter={filter}
             onFilterChange={setFilter}
           />
-          <LlmUsagePanel usage={board?.llmUsage} />
-          <TestSuitesPanel
+          <UtilityBar
+            usage={board?.llmUsage}
             suites={board?.testbedSuites}
             onRunSuite={onRunSuite}
             onSaveSuite={onSaveSuite}
             onApproveSuite={onApproveSuite}
             onDismissSuite={onDismissSuite}
+            onSpawnMission={onSpawnMission}
           />
-          {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} onSaveSuite={onSaveSuite} /> : null}
-          <Board
-            grouped={displayGrouped}
-            expanded={effectiveExpanded}
-            onToggleLane={onToggleLane}
-            renderLaneHeader={
-              onCreateTask
-                ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
-                : undefined
-            }
-            renderCard={renderCard}
-            renderLaneBody={(id, laneCards) =>
-              id === "hermes-checking"
-                ? <HermesCheckingBody cards={laneCards} renderCard={renderCard} />
-                : undefined
-            }
-          />
+          <div className="hm-operator-board" aria-label="Operator workflow board">
+            <BoardTier
+              id="decide"
+              title="DECIDE"
+              description="What needs the operator."
+              count={tierCount(displayGrouped, DECIDE_LANES)}
+            >
+              <Board
+                grouped={displayGrouped}
+                lanes={DECIDE_LANES}
+                ariaLabel="DECIDE lane group"
+                className="hm-lanes--decide"
+                expanded={surfacedExpanded}
+                onToggleLane={onToggleLane}
+                renderCard={renderCard}
+                renderLaneBody={renderLaneBody}
+              />
+            </BoardTier>
+            <BoardTier
+              id="watch"
+              title="WATCH"
+              description="Agents and release automation still moving."
+              count={tierCount(displayGrouped, WATCH_LANES)}
+            >
+              <Board
+                grouped={displayGrouped}
+                lanes={WATCH_LANES}
+                ariaLabel="WATCH lane group"
+                className="hm-lanes--watch"
+                expanded={surfacedExpanded}
+                onToggleLane={onToggleLane}
+                renderLaneHeader={
+                  onCreateTask
+                    ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
+                    : undefined
+                }
+                renderCard={renderCard}
+                renderLaneBody={renderLaneBody}
+              />
+            </BoardTier>
+            <BoardTier
+              id="hide"
+              title="HIDE"
+              description="Quiet author work, branch protection, and release history."
+              count={tierCount(displayGrouped, HIDE_LANES)}
+            >
+              <Board
+                grouped={displayGrouped}
+                lanes={HIDE_LANES}
+                ariaLabel="HIDE lane group"
+                className="hm-lanes--hide"
+                expanded={surfacedExpanded}
+                onToggleLane={onToggleLane}
+                renderCard={renderCard}
+                renderLaneBody={renderLaneBody}
+              />
+            </BoardTier>
+          </div>
         </div>
 
         <CoPilotRail
@@ -591,6 +660,214 @@ export function BoardView({
       ) : null}
 
       {overlayOpen ? <KeyboardOverlay onClose={() => setOverlayOpen(false)} /> : null}
+    </div>
+  );
+}
+
+function tierCount(grouped: Partial<Record<LaneId, BoardCard[]>>, lanes: readonly LaneId[]): number {
+  return lanes.reduce((sum, lane) => sum + (grouped[lane]?.length ?? 0), 0);
+}
+
+function BoardTier({
+  id,
+  title,
+  description,
+  count,
+  children,
+}: {
+  id: "decide" | "watch" | "hide";
+  title: string;
+  description: string;
+  count: number;
+  children: ReactNode;
+}) {
+  return (
+    <section className={`hm-board-tier hm-board-tier--${id}`} aria-label={title}>
+      <div className="hm-board-tier-head">
+        <div>
+          <span className="hm-board-tier-kicker">{title}</span>
+          <strong>{description}</strong>
+        </div>
+        <Badge variant={count > 0 ? (id === "decide" ? "pending" : "neutral") : "ghost"}>
+          {count} {count === 1 ? "card" : "cards"}
+        </Badge>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function UtilityBar({
+  usage,
+  suites = [],
+  onRunSuite,
+  onSaveSuite,
+  onApproveSuite,
+  onDismissSuite,
+  onSpawnMission,
+}: {
+  usage?: LlmUsageAggregate;
+  suites?: SavedTestSuite[];
+  onRunSuite?: (id: string) => void;
+  onSaveSuite?: (input: SaveTestSuiteInput) => void;
+  onApproveSuite?: (id: string) => void;
+  onDismissSuite?: (id: string) => void;
+  onSpawnMission?: BoardViewProps["onSpawnMission"];
+}) {
+  const requestedSuites = suites.filter((suite) => suite.status === "requested").length;
+  const shouldOpen = requestedSuites > 0;
+  const [open, setOpen] = useState(shouldOpen);
+  useEffect(() => {
+    if (shouldOpen) setOpen(true);
+  }, [shouldOpen]);
+
+  const usageLabel = usage?.status === "recorded"
+    ? `${formatCompactNumber(usage.totalTokens)} tokens`
+    : "usage quiet";
+  const suitesLabel = suites.length > 0
+    ? `${suites.length} suite${suites.length === 1 ? "" : "s"}`
+    : "no suites";
+  const launcherLabel = onSpawnMission ? "tester ready" : "tester off";
+
+  return (
+    <section className={`hm-utility-bar${requestedSuites > 0 ? " hm-utility-bar--attention" : ""}`} aria-label="Board utilities">
+      <button
+        type="button"
+        className="hm-utility-bar-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span aria-hidden>{open ? "▾" : "▸"}</span>
+        <span className="hm-kicker">Utilities</span>
+        <strong>LLM usage · suites · tester launcher</strong>
+        <span className="hm-utility-bar-summary">
+          {usageLabel} · {suitesLabel} · {launcherLabel}
+        </span>
+        {requestedSuites > 0 ? <Badge variant="pending">{requestedSuites} requested</Badge> : null}
+      </button>
+      {open ? (
+        <div className="hm-utility-bar-body">
+          <LlmUsagePanel usage={usage} />
+          <TestSuitesPanel
+            suites={suites}
+            onRunSuite={onRunSuite}
+            onSaveSuite={onSaveSuite}
+            onApproveSuite={onApproveSuite}
+            onDismissSuite={onDismissSuite}
+          />
+          {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} onSaveSuite={onSaveSuite} /> : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+type GroupedLaneItem =
+  | { kind: "card"; card: BoardCard }
+  | { kind: "group"; id: string; title: string; cards: BoardCard[] };
+
+function groupLaneCards(lane: LaneId, cards: BoardCard[]): GroupedLaneItem[] {
+  const buckets = new Map<string, BoardCard[]>();
+  const orderedKeys: string[] = [];
+  for (const card of cards) {
+    const key = groupKeyForCard(lane, card);
+    if (!key) continue;
+    if (!buckets.has(key)) orderedKeys.push(key);
+    buckets.set(key, [...(buckets.get(key) ?? []), card]);
+  }
+
+  const used = new Set<string>();
+  const groups = new Map<string, GroupedLaneItem>();
+  for (const key of orderedKeys) {
+    const bucket = buckets.get(key) ?? [];
+    if (bucket.length < 2) continue;
+    for (const card of bucket) used.add(card.id);
+    groups.set(key, {
+      kind: "group",
+      id: key,
+      title: bucket[0]?.title ?? "Similar cards",
+      cards: bucket,
+    });
+  }
+
+  const out: GroupedLaneItem[] = [];
+  const emittedGroups = new Set<string>();
+  for (const card of cards) {
+    if (!used.has(card.id)) {
+      out.push({ kind: "card", card });
+      continue;
+    }
+    const key = groupKeyForCard(lane, card);
+    if (key && !emittedGroups.has(key)) {
+      const group = groups.get(key);
+      if (group) out.push(group);
+      emittedGroups.add(key);
+    }
+  }
+  return out;
+}
+
+function groupKeyForCard(lane: LaneId, card: BoardCard): string | null {
+  if (mustSurfaceCard(card)) return null;
+  if (card.type !== "deploy") return null;
+  const normalized = card.title
+    .toLowerCase()
+    .replace(/#[0-9]+/g, "#")
+    .replace(/[a-f0-9]{6,}/g, "<hash>")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!/post[-\s](merge|production|deploy)|deploy verification|post-production-deploy/.test(normalized)) return null;
+  return `${lane}:${card.type}:${normalized}`;
+}
+
+function GroupedLaneBody({
+  items,
+  renderCard,
+}: {
+  items: GroupedLaneItem[];
+  renderCard: (card: BoardCard) => ReactNode;
+}) {
+  return (
+    <>
+      {items.map((item) => (
+        item.kind === "group"
+          ? <GroupedCard key={item.id} group={item} renderCard={renderCard} />
+          : renderCard(item.card)
+      ))}
+    </>
+  );
+}
+
+function GroupedCard({
+  group,
+  renderCard,
+}: {
+  group: Extract<GroupedLaneItem, { kind: "group" }>;
+  renderCard: (card: BoardCard) => ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="hm-card hm-card-group" role="group" aria-label={`${group.title} group`}>
+      <div className="hm-card-group-head">
+        <div>
+          <Badge variant="neutral">{group.cards.length} similar</Badge>
+          <strong>{group.title}</strong>
+          <span>{group.cards.length} near-identical verification cards grouped. Expand to inspect each one.</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+        >
+          {expanded ? "Collapse" : "Expand"}
+        </Button>
+      </div>
+      {expanded ? (
+        <div className="hm-card-group-list">
+          {group.cards.map((card) => renderCard(card))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -467,6 +467,153 @@ body { margin: 0; }
   color: var(--hm-muted);
   letter-spacing: 0 !important;
 }
+
+.hm-utility-bar {
+  margin: 0 22px 10px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: rgba(255,253,247,0.72);
+  overflow: hidden;
+}
+.hm-utility-bar--attention {
+  border-color: var(--hm-amber-ring);
+  background:
+    linear-gradient(180deg, rgba(250, 236, 214, 0.36), rgba(255,253,247,0.72)),
+    var(--hm-paper);
+}
+.hm-utility-bar-toggle {
+  width: 100%;
+  min-height: 42px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px;
+  cursor: pointer;
+  text-align: left;
+}
+.hm-utility-bar-toggle strong {
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--hm-ink);
+}
+.hm-utility-bar-summary {
+  margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--hm-muted);
+}
+.hm-utility-bar-body {
+  display: grid;
+  gap: 10px;
+  padding: 0 10px 10px;
+}
+.hm-utility-bar-body .hm-llm-usage,
+.hm-utility-bar-body .hm-test-suites,
+.hm-utility-bar-body .hm-mission-launcher {
+  margin: 0;
+}
+
+.hm-operator-board {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0 22px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.hm-board-tier {
+  display: grid;
+  gap: 8px;
+}
+.hm-board-tier-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 2px;
+}
+.hm-board-tier-head > div {
+  display: grid;
+  gap: 2px;
+}
+.hm-board-tier-kicker {
+  font-family: var(--font-display);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.12em !important;
+  color: var(--hm-sage-deep);
+}
+.hm-board-tier-head strong {
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--hm-ink);
+}
+.hm-board-tier--decide .hm-board-tier-kicker {
+  color: var(--hm-amber-deep);
+}
+.hm-operator-board .hm-lanes {
+  padding: 0;
+  flex: none;
+  min-height: 94px;
+  overflow-x: auto;
+}
+.hm-operator-board .hm-lanes--decide {
+  min-height: 260px;
+}
+.hm-operator-board .hm-lanes--watch {
+  min-height: 230px;
+}
+.hm-operator-board .hm-lanes--hide {
+  min-height: 74px;
+}
+.hm-board-tier--hide .hm-lane--expanded {
+  max-height: 220px;
+}
+.hm-board-tier--watch .hm-lane--expanded {
+  min-width: 260px;
+}
+.hm-card-group {
+  padding: 10px;
+  background:
+    linear-gradient(180deg, rgba(248,250,247,0.92), rgba(255,253,247,0.98)),
+    var(--hm-paper);
+}
+.hm-card-group-head {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hm-card-group-head > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+.hm-card-group-head strong {
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--hm-ink);
+}
+.hm-card-group-head span:not(.hm-badge):not(.dot) {
+  color: var(--hm-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+.hm-card-group-list {
+  display: grid;
+  gap: 9px;
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--hm-line-soft);
+}
 .hm-llm-usage {
   margin: 0 22px 10px;
   padding: 10px 12px;


### PR DESCRIPTION
## What changed
- Split the monitor board into DECIDE, WATCH, and HIDE tiers so operator decisions lead the page and machine/history lanes collapse into reachable rails.
- Folded LLM usage, saved suites, and tester launcher into one collapsible utility bar.
- Added grouping for near-identical deploy verification cards with count + expand, while excluding action/degraded/operator-attention cards from grouping or collapse.
- Extended board tests for tiering, empty-lane reachability, grouping expand, utility collapse, and attention-card visibility.

## Why
The board had too many equal-weight lanes and repeated utility strips. This keeps every lane reachable while making the operator decision path the first thing on screen.

## Checks
- npm run typecheck
- npm test
- npm --workspace @avg/monitor-ui run build

## Surface impact
- Frontend/monitor UI only.
- No backend, contracts, indexer, Caddy, public site, environment, or VPS secret changes.

## Notes
Truth-boundary behavior is preserved: degraded/source-offline/action cards are forced visible and are never grouped into quiet cards.