### PR TITLE
fix(ops): wire AGENT_WALLET_PRIVATE_KEY into testbed-mission-runner

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -293,6 +293,12 @@ services:
       TESTBED_BASIC_AUTH_USER: ${TESTBED_BASIC_AUTH_USER:-}
       TESTBED_BASIC_AUTH_PASS: ${TESTBED_BASIC_AUTH_PASS:-}
       TESTBED_BASIC_AUTH_HOSTS: ${TESTBED_BASIC_AUTH_HOSTS:-app.averray.com}
+      # Worker wallet — citation_repair / gold-path dry-run preflight calls
+      # wallet_status (reads AGENT_WALLET_PRIVATE_KEY) to derive the address.
+      # Board citation_repair runs are read-only/dry-run; real claim/submit
+      # settlement stays operator-gated in the hermes container. Testnet only.
+      AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
+      WALLET_NETWORK: testnet
       # T4 live gold-path driver. Default is off so CI/test deploys keep the
       # deterministic fake path; when enabled the runner invokes Claude with
       # Playwright-MCP/browser tooling and writes a structured report.


### PR DESCRIPTION
## Symptom
Board **Citation Repair** dry-run failed at the wallet preflight: `CONCLUSION: FAIL — wallet_not_configured` (verdict FAILED, 0% confidence, "agent stopped before any mutation"). The adapter fix (#418) was never reached — the workflow checks the wallet *before* it analyzes anything.

## Root cause
Board `citation_repair` missions run in the **`testbed-mission-runner`** container, whose `environment:` block (`ops/compose.yml:269`) did **not** list `AGENT_WALLET_PRIVATE_KEY`. The key is in `.env.prod` and injected into the `hermes` container (`:680`), but **Compose only passes a var to a service that lists it** — so `wallet_status` in the testbed runner read nothing → `wallet_not_configured`. (Earlier manual dry-runs worked because they ran in the `hermes` container.)

## Fix
Add `AGENT_WALLET_PRIVATE_KEY` + `WALLET_NETWORK` to the `testbed-mission-runner` env, mirroring the `hermes` service.

## Safety
- Board `citation_repair` runs are **read-only / dry-run** — the preflight only uses the key to **derive the wallet address**; the runner never claims or submits.
- Real settlement (`dryRun:false`) stays **operator-gated** via the manual MCP call in the **`hermes`** container (#415 runbook) — unchanged by this PR.
- Testnet only. No code changes; one service's env block.

## After merge
`git pull && docker compose -p avg … up -d --build testbed-mission-runner`, then re-run the Citation Repair dry-run — it should clear the wallet preflight and finally exercise the #418 adapter fix (expect ≥3 Charts dead-links + disposition PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)