### PR TITLE
fix(ops): give testbed-mission-runner the policy store + workflow env

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -299,6 +299,13 @@ services:
       # settlement stays operator-gated in the hermes container. Testnet only.
       AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
       WALLET_NETWORK: testnet
+      # Citation-repair workflow preflight also reads the shared policy store
+      # (DATABASE_URL — mutation-policy checks prior claim/submit attempts;
+      # missing it surfaces as policy_store_unavailable) and records handoff
+      # events + reads the policy config. Read-only on dry-run; same shared DB.
+      DATABASE_URL: ${DATABASE_URL}
+      AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
+      POLICY_CONFIG_PATH: /config/policy.yaml
       # T4 live gold-path driver. Default is off so CI/test deploys keep the
       # deterministic fake path; when enabled the runner invokes Claude with
       # Playwright-MCP/browser tooling and writes a structured report.


### PR DESCRIPTION
## Symptom
After #425 cleared the wallet preflight, the board **Citation Repair** dry-run hit the *next* gate: `CONCLUSION: FAIL — policy_store_unavailable` (verdict FAILED, "agent stopped before any mutation").

## Root cause
`policy_store_unavailable` is thrown in `mutation-policy.ts:121/191` when the policy **store query (the DB)** is unreachable. The `testbed-mission-runner` has no `DATABASE_URL`, so the mutation-policy readiness check can't read prior claim/submit attempts. Diffing the testbed runner's env against the `hermes` container (which runs this workflow fine) showed it's missing `DATABASE_URL`, `AVERRAY_HANDOFF_EVENTS_PATH`, and `POLICY_CONFIG_PATH` (it already has the wallet vars from #425 + `AVERRAY_API_BASE_URL`).

## Fix
Add those three to the `testbed-mission-runner` env. This completes the workflow env the runner needs — same set the `hermes` container has.

## Safety
- **Read-only on dry-run** — the policy store is *read* for the readiness check; board `citation_repair` runs never claim/submit. Real settlement (`dryRun:false`) stays operator-gated in the `hermes` container (#415 runbook). Same shared `avg-postgres` DB; testnet.
- No code changes; one service's env block.

## After merge
`git pull && docker compose -p avg … up -d --force-recreate testbed-mission-runner`, then re-run the Citation Repair dry-run — it should clear the policy preflight and finally exercise the #418 adapter (expect ≥3 Charts dead-links + disposition PASS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)