### PR TITLE
Restore monitor board Kanban layout

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -20,26 +20,26 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelector(".hm-now--action")).toBeTruthy();
     expect(view.getByText(/your review decision/)).toBeTruthy();
     expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
-    expect(view.getByRole("region", { name: "DECIDE" })).toBeTruthy();
-    expect(view.getByRole("region", { name: "WATCH" })).toBeTruthy();
-    expect(view.getByRole("region", { name: "HIDE" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Kanban lane grid" })).toBeTruthy();
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
     expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
 
-  test("DECIDE/WATCH stay expanded while HIDE lanes collapse to reachable mini-rails", () => {
+  test("every lane with cards stays expanded in one Kanban row; empty lanes stay reachable mini-rails", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
     const view = within(container);
     expect(view.getByRole("region", { name: "Needs attention lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Drafts lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Codex needed lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Hermes checking lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Release queue lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Deploying lane" })).toBeTruthy();
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(4);
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(4);
+    expect(view.getByRole("region", { name: "Done lane" })).toBeTruthy();
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(7);
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(1);
 
-    expect(view.queryByText(/governance dispute UI/)).toBeNull();
-    fireEvent.click(view.getByRole("button", { name: /Drafts \(1 card\)/ }));
     expect(view.getByText(/governance dispute UI/)).toBeTruthy();
+    expect(view.getByRole("button", { name: /Operator review \(0 cards\)/ })).toBeTruthy();
   });
 
   test("renders the action card with one primary and Hermes verdict", () => {
@@ -100,7 +100,6 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const view = within(container);
     expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
     expect(view.getByText(/Post-merge verify/)).toBeTruthy();
-    fireEvent.click(view.getByRole("button", { name: /Done \(11 cards\)/ }));
     expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
   });
 
@@ -228,9 +227,9 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelector(".hm-now--calm")).toBeTruthy();
     // The deploying lane (in-flight automation) is expanded and shows its body…
     expect(within(container).getByText(/Post-merge verify/)).toBeTruthy();
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(1); // deploying
-    // …and empty/quiet lanes (including Done history) are mini-rails.
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(7);
+    expect(container.querySelectorAll("section.hm-lane").length).toBe(2); // deploying + done
+    // …and empty lanes are mini-rails, so the full Kanban remains visible.
+    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(6);
   });
 
   test("groups near-identical deploy verification cards without hiding attention cards", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -13,7 +13,7 @@
 //       <div.hm-lanes-wrap>
 //         <LanesBar />           search + filter chips + urgency label
 //         <UtilityBar />         collapsed tester / suites / LLM usage
-//         <BoardTier />          DECIDE / WATCH / HIDE lane groups
+//         <Board />              kanban lanes, cards via <CardRouter>
 //       <CoPilotRail />          live narration + Ask-Hermes
 //   <DetailDrawer />             when ?card= resolves
 //   <KeyboardOverlay />          when ? is pressed
@@ -52,17 +52,10 @@ import { Badge, Button } from "./ui.js";
 const OPERATOR_CARD_SNOOZE_MS = 30 * 60_000;
 
 const ALL_LANES = LANES as readonly LaneId[];
-const DECIDE_LANES = ["needs-attention", "operator-review"] as const satisfies readonly LaneId[];
-const WATCH_LANES = ["codex-needed", "hermes-checking", "deploying"] as const satisfies readonly LaneId[];
-const HIDE_LANES = ["drafts", "release-queue", "done"] as const satisfies readonly LaneId[];
 
 /** Lanes that currently hold at least one card. */
 function lanesWithCards(grouped: Partial<Record<LaneId, BoardCard[]>>): LaneId[] {
   return ALL_LANES.filter((lane) => (grouped[lane]?.length ?? 0) > 0);
-}
-
-function hasCards(grouped: Partial<Record<LaneId, BoardCard[]>>, lane: LaneId): boolean {
-  return (grouped[lane]?.length ?? 0) > 0;
 }
 
 function mustSurfaceCard(card: BoardCard): boolean {
@@ -80,17 +73,16 @@ function mustSurfaceLanes(grouped: Partial<Record<LaneId, BoardCard[]>>): LaneId
   return ALL_LANES.filter((lane) => (grouped[lane] ?? []).some(mustSurfaceCard));
 }
 
-// Operator-focus defaults: DECIDE + WATCH lanes with cards are open; quiet
-// history/author lanes stay reachable as rails unless a degraded/action card
-// forces them open. Filters still reveal matching lanes below.
+// Kanban defaults: every lane with cards opens in the single horizontal board;
+// empty lanes stay reachable as mini-rails. Degraded/action cards force their
+// lane open even after a manual collapse attempt.
 function expandedForBoard(
   _mode: BoardMode,
   grouped: Partial<Record<LaneId, BoardCard[]>>,
   alwaysOpen: readonly LaneId[] = [],
 ): Set<LaneId> {
   return new Set<LaneId>([
-    ...DECIDE_LANES.filter((lane) => hasCards(grouped, lane)),
-    ...WATCH_LANES.filter((lane) => hasCards(grouped, lane)),
+    ...lanesWithCards(grouped),
     ...mustSurfaceLanes(grouped),
     ...alwaysOpen,
   ]);
@@ -544,64 +536,20 @@ export function BoardView({
             onDismissSuite={onDismissSuite}
             onSpawnMission={onSpawnMission}
           />
-          <div className="hm-operator-board" aria-label="Operator workflow board">
-            <BoardTier
-              id="decide"
-              title="DECIDE"
-              description="What needs the operator."
-              count={tierCount(displayGrouped, DECIDE_LANES)}
-            >
-              <Board
-                grouped={displayGrouped}
-                lanes={DECIDE_LANES}
-                ariaLabel="DECIDE lane group"
-                className="hm-lanes--decide"
-                expanded={surfacedExpanded}
-                onToggleLane={onToggleLane}
-                renderCard={renderCard}
-                renderLaneBody={renderLaneBody}
-              />
-            </BoardTier>
-            <BoardTier
-              id="watch"
-              title="WATCH"
-              description="Agents and release automation still moving."
-              count={tierCount(displayGrouped, WATCH_LANES)}
-            >
-              <Board
-                grouped={displayGrouped}
-                lanes={WATCH_LANES}
-                ariaLabel="WATCH lane group"
-                className="hm-lanes--watch"
-                expanded={surfacedExpanded}
-                onToggleLane={onToggleLane}
-                renderLaneHeader={
-                  onCreateTask
-                    ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
-                    : undefined
-                }
-                renderCard={renderCard}
-                renderLaneBody={renderLaneBody}
-              />
-            </BoardTier>
-            <BoardTier
-              id="hide"
-              title="HIDE"
-              description="Quiet author work, branch protection, and release history."
-              count={tierCount(displayGrouped, HIDE_LANES)}
-            >
-              <Board
-                grouped={displayGrouped}
-                lanes={HIDE_LANES}
-                ariaLabel="HIDE lane group"
-                className="hm-lanes--hide"
-                expanded={surfacedExpanded}
-                onToggleLane={onToggleLane}
-                renderCard={renderCard}
-                renderLaneBody={renderLaneBody}
-              />
-            </BoardTier>
-          </div>
+          <Board
+            grouped={displayGrouped}
+            ariaLabel="Kanban lane grid"
+            className="hm-lanes--kanban"
+            expanded={surfacedExpanded}
+            onToggleLane={onToggleLane}
+            renderLaneHeader={
+              onCreateTask
+                ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
+                : undefined
+            }
+            renderCard={renderCard}
+            renderLaneBody={renderLaneBody}
+          />
         </div>
 
         <CoPilotRail
@@ -661,39 +609,6 @@ export function BoardView({
 
       {overlayOpen ? <KeyboardOverlay onClose={() => setOverlayOpen(false)} /> : null}
     </div>
-  );
-}
-
-function tierCount(grouped: Partial<Record<LaneId, BoardCard[]>>, lanes: readonly LaneId[]): number {
-  return lanes.reduce((sum, lane) => sum + (grouped[lane]?.length ?? 0), 0);
-}
-
-function BoardTier({
-  id,
-  title,
-  description,
-  count,
-  children,
-}: {
-  id: "decide" | "watch" | "hide";
-  title: string;
-  description: string;
-  count: number;
-  children: ReactNode;
-}) {
-  return (
-    <section className={`hm-board-tier hm-board-tier--${id}`} aria-label={title}>
-      <div className="hm-board-tier-head">
-        <div>
-          <span className="hm-board-tier-kicker">{title}</span>
-          <strong>{description}</strong>
-        </div>
-        <Badge variant={count > 0 ? (id === "decide" ? "pending" : "neutral") : "ghost"}>
-          {count} {count === 1 ? "card" : "cards"}
-        </Badge>
-      </div>
-      {children}
-    </section>
   );
 }
 

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -520,66 +520,6 @@ body { margin: 0; }
   margin: 0;
 }
 
-.hm-operator-board {
-  flex: 1;
-  min-height: 0;
-  overflow-y: auto;
-  padding: 0 22px 22px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.hm-board-tier {
-  display: grid;
-  gap: 8px;
-}
-.hm-board-tier-head {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 0 2px;
-}
-.hm-board-tier-head > div {
-  display: grid;
-  gap: 2px;
-}
-.hm-board-tier-kicker {
-  font-family: var(--font-display);
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0.12em !important;
-  color: var(--hm-sage-deep);
-}
-.hm-board-tier-head strong {
-  font-family: var(--font-display);
-  font-size: 14px;
-  color: var(--hm-ink);
-}
-.hm-board-tier--decide .hm-board-tier-kicker {
-  color: var(--hm-amber-deep);
-}
-.hm-operator-board .hm-lanes {
-  padding: 0;
-  flex: none;
-  min-height: 94px;
-  overflow-x: auto;
-}
-.hm-operator-board .hm-lanes--decide {
-  min-height: 260px;
-}
-.hm-operator-board .hm-lanes--watch {
-  min-height: 230px;
-}
-.hm-operator-board .hm-lanes--hide {
-  min-height: 74px;
-}
-.hm-board-tier--hide .hm-lane--expanded {
-  max-height: 220px;
-}
-.hm-board-tier--watch .hm-lane--expanded {
-  min-width: 260px;
-}
 .hm-card-group {
   padding: 10px;
   background:
@@ -1200,6 +1140,25 @@ body { margin: 0; }
   scrollbar-width: none;
 }
 .hm-lanes::-webkit-scrollbar { display: none; }
+.hm-lanes--kanban {
+  padding-top: 2px;
+  scroll-snap-type: x proximity;
+}
+.hm-lanes--kanban .hm-lane,
+.hm-lanes--kanban .hm-lane-rail {
+  scroll-snap-align: start;
+}
+.hm-lanes--kanban .hm-lane--expanded {
+  flex: 1 0 304px;
+  min-width: 304px;
+}
+.hm-lanes--kanban .hm-lane--action.hm-lane--expanded {
+  flex-basis: 392px;
+  min-width: 380px;
+}
+.hm-lanes--kanban .hm-lane--collapsed {
+  width: 60px;
+}
 
 /* Lane states: collapsed (empty/quiet) vs expanded */
 .hm-lane {


### PR DESCRIPTION
## What changed
- Restores the monitor board to one horizontal Kanban lane grid instead of DECIDE/WATCH/HIDE vertical tiers.
- Keeps the collapsed utility bar and deploy-card grouping from the prior PR.
- Opens every lane that has cards; only empty lanes collapse to reachable mini-rails.
- Adds Kanban-specific lane width rules so active lanes have usable card space while the board remains horizontally navigable.
- Updates tests to assert the one-row Kanban structure, lane reachability, grouping, and attention-card visibility.

## Why
PR #424 shipped the utility/grouping ideas but the tiered layout made the board stop feeling like a Kanban and hid the full room overview. This follow-up restores the all-lanes-at-once structure the operator needs.

## Checks
- npm run typecheck
- npm test
- npm --workspace @avg/monitor-ui run build

## Surface impact
- Frontend/monitor UI only.
- No backend, contracts, indexer, Caddy, public site, environment, or VPS secret changes.

## Notes
Truth-boundary behavior is preserved: action/degraded/source-offline cards still force their lanes open and are not grouped away.