### PR TITLE
fix(monitor): make "Create product fix" produce a buildable task (real repo + honest label)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -467,9 +467,15 @@ export function BoardView({
     if (onCreateTask) {
       a.onCreateProductFix = (card) => {
         const report = missionReportText(card);
+        // Testbed mission cards carry the synthetic repo "testbed/mission",
+        // which is not a real GitHub repo and can't be cloned — the runner
+        // rejects it, so the proposed task is un-buildable. A tester finding's
+        // fix lives in the reference-agent (the adapter/workflow code), so
+        // route the product-fix task there instead of the mission's repo.
+        const repo = card.repo === "testbed/mission" ? "depre-dev/averray-reference-agent" : card.repo;
         onCreateTask({
           agent: "claude", // greenfield product fix — the worker opens its own PR
-          repo: card.repo,
+          repo,
           prompt: `Product fix proposed from a failed testbed mission.\n\n${card.title}\n\n${report ?? card.summary}`,
         });
       };

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
@@ -113,7 +113,7 @@ export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}):
     });
     buttons.push({
       key: "create-product-fix",
-      label: "Create product fix → Codex",
+      label: "Create product fix → Claude",
       kind: "action",
       ...(h.onCreateProductFix
         ? { run: () => h.onCreateProductFix!(card) }


### PR DESCRIPTION
## Bug
Clicking **"Create product fix → Codex"** on a mission card did nothing useful — it created proposed tasks against `repo: "testbed/mission"` (the card's synthetic repo), which the runner can't clone and isn't in any allow-list. They piled up un-buildable in `codex-needed`. The label also said "→ Codex" while the handler dispatches `agent: "claude"` (and the Codex runner has no `codex login` creds right now).

## Fix
- **Real repo:** `BoardView.tsx` `onCreateProductFix` now routes a testbed-mission product fix to `depre-dev/averray-reference-agent` (where the adapter/workflow code lives); non-mission cards keep `card.repo`.
- **Honest label:** `drawer-footer.ts` `"Create product fix → Codex"` → `"→ Claude"` to match the actual agent.

## Notes
- Separate follow-up worth doing: disable the action on a **PASS** mission (no defect to fix) and carry the disposition's fix-spec as the prompt. Kept out of this minimal fix.
- Clean up: the existing `codex-task-testbed-mission-new-*` proposed tasks are un-buildable — dismiss them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)