### PR TITLE
docs(design): add Hermes-4 redesign reference (Claude Design handoff)

### DIFF
--- a/docs/design/hermes-4/README.md
+++ b/docs/design/hermes-4/README.md
@@ -1,0 +1,22 @@
+# CODING AGENTS: READ THIS FIRST
+
+This is a **handoff bundle** from Claude Design (claude.ai/design).
+
+A user mocked up designs in HTML/CSS/JS using an AI design tool, then exported this bundle so a coding agent can implement the designs for real.
+
+## What you should do — IMPORTANT
+
+**Read `hermes-4/project/Hermes.html` in full.** The user had this file open when they triggered the handoff, so it's almost certainly the primary design they want built. Read it top to bottom — don't skim. Then **follow its imports**: open every file it pulls in (shared components, CSS, scripts) so you understand how the pieces fit together before you start implementing.
+
+**If anything is ambiguous, ask the user to confirm before you start implementing.** It's much cheaper to clarify scope up front than to build the wrong thing.
+
+## About the design files
+
+The design medium is **HTML/CSS/JS** — these are prototypes, not production code. Your job is to **recreate them pixel-perfectly** in whatever technology makes sense for the target codebase (React, Vue, native, whatever fits). Match the visual output; don't copy the prototype's internal structure unless it happens to fit.
+
+**Don't render these files in a browser or take screenshots unless the user asks you to.** Everything you need — dimensions, colors, layout rules — is spelled out in the source. Read the HTML and CSS directly; a screenshot won't tell you anything they don't.
+
+## Bundle contents
+
+- `hermes-4/README.md` — this file
+- `hermes-4/project/` — the `Hermes 4` project files (HTML prototypes, assets, components)

--- a/docs/design/hermes-4/project/Hermes - Token Spec.html
+++ b/docs/design/hermes-4/project/Hermes - Token Spec.html
@@ -1,0 +1,258 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hermes — Token Spec</title>
+<link rel="stylesheet" href="hermes.css">
+<style>
+  body { overflow:auto; }
+  .doc { max-width:1040px; margin:0 auto; padding:48px 32px 120px; }
+  .h-eyebrow { font-family:var(--font-display); font-size:11px; font-weight:700; text-transform:uppercase; color:var(--act-text); letter-spacing:0; }
+  .h-title { font-family:var(--font-display); font-weight:700; font-size:40px; line-height:1.04; margin:8px 0 10px; }
+  .h-lede { font-size:16px; color:var(--hm-muted); max-width:64ch; line-height:1.6; }
+  .sec { margin-top:48px; }
+  .sec > h2 { font-family:var(--font-display); font-weight:700; font-size:13px; text-transform:uppercase; color:var(--hm-muted); margin:0 0 16px; padding-bottom:8px; border-bottom:1px solid var(--hm-line); }
+  .grid { display:grid; gap:14px; }
+  .c2 { grid-template-columns:repeat(2,1fr); }
+  .c3 { grid-template-columns:repeat(3,1fr); }
+  .c4 { grid-template-columns:repeat(4,1fr); }
+  .card2 { background:var(--hm-paper); border:1px solid var(--hm-line); border-radius:var(--r-card); padding:16px; box-shadow:var(--sh-sm); }
+  .sw { height:64px; border-radius:var(--r-sm); border:1px solid var(--hm-line); margin-bottom:10px; }
+  .name { font-family:var(--font-display); font-weight:600; font-size:13px; }
+  .mono2 { font-family:var(--font-mono); font-size:12px; color:var(--hm-muted); }
+  .role { font-size:12px; color:var(--hm-muted); margin-top:3px; }
+  table { width:100%; border-collapse:collapse; font-size:13px; }
+  th { text-align:left; font-family:var(--font-display); font-size:10.5px; font-weight:700; text-transform:uppercase; color:var(--hm-muted); padding:8px 12px; border-bottom:1px solid var(--hm-line); }
+  td { padding:10px 12px; border-bottom:1px solid var(--hm-line-2); vertical-align:top; }
+  td.k { font-family:var(--font-mono); font-size:12px; color:var(--act-text); white-space:nowrap; }
+  td.v { font-family:var(--font-mono); font-size:12px; color:var(--hm-ink); }
+  td.d { color:var(--hm-muted); }
+  .specimen { font-family:var(--font-display); font-weight:700; line-height:1.05; color:var(--hm-ink); }
+  .pillrow { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+  .note { font-size:13px; color:var(--hm-muted); line-height:1.65; background:var(--hm-paper-sunken); border:1px solid var(--hm-line-2); border-left:3px solid var(--act); border-radius:var(--r-sm); padding:14px 16px; }
+  code { font-family:var(--font-mono); font-size:0.9em; }
+</style>
+</head>
+<body>
+<main class="doc">
+  <div class="h-eyebrow">Hermes · handoff monitor</div>
+  <h1 class="h-title">Token spec</h1>
+  <p class="h-lede">Everything an engineer needs to port the redesigned board + collaboration room into <code>monitor-ui</code>. Warm-ivory base; color is meaning; coral is reserved for the one action that needs the operator. All values are CSS custom properties — drop them into <code>:root</code>.</p>
+
+  <!-- color -->
+  <section class="sec">
+    <h2>Semantic color — color is meaning</h2>
+    <div class="grid c4">
+      <div class="card2"><div class="sw" style="background:var(--act)"></div><div class="name">Act / coral</div><div class="mono2">#D97757</div><div class="role">The action that needs you. Reserved.</div></div>
+      <div class="card2"><div class="sw" style="background:var(--ok)"></div><div class="name">Healthy / sage</div><div class="mono2">#1e6642</div><div class="role">Pass, deploy ok, online.</div></div>
+      <div class="card2"><div class="sw" style="background:var(--warn)"></div><div class="name">Degraded / amber</div><div class="mono2">#a76122</div><div class="role">Failed, blocked, timed out.</div></div>
+      <div class="card2"><div class="sw" style="background:var(--tel)"></div><div class="name">Telemetry / warm-gray</div><div class="mono2">#7c7464</div><div class="role">Quiet status, counts at 0.</div></div>
+    </div>
+    <div class="grid c4" style="margin-top:14px">
+      <div class="card2"><div class="sw" style="background:var(--hm-canvas)"></div><div class="name">Canvas</div><div class="mono2">#e9e4d9</div></div>
+      <div class="card2"><div class="sw" style="background:var(--hm-surface)"></div><div class="name">Surface (tier)</div><div class="mono2">#f1ede4</div></div>
+      <div class="card2"><div class="sw" style="background:var(--hm-paper)"></div><div class="name">Paper (card)</div><div class="mono2">#fffdf8</div></div>
+      <div class="card2"><div class="sw" style="background:var(--hm-paper-sunken)"></div><div class="name">Sunken (inset)</div><div class="mono2">#f6f3ea</div></div>
+    </div>
+    <table style="margin-top:18px">
+      <thead><tr><th>Token</th><th>Value</th><th>Use</th></tr></thead>
+      <tbody>
+        <tr><td class="k">--act / --act-deep</td><td class="v">#D97757 / #C15F3C</td><td class="d">Primary action fill + hover. Muted-terracotta alt: #B5651D.</td></tr>
+        <tr><td class="k">--act-soft / --act-line</td><td class="v">rgba(217,119,87,.12) / .34</td><td class="d">Coral wash + hairline (needs-you banner, prominent turns).</td></tr>
+        <tr><td class="k">--ok-soft / --warn-soft</td><td class="v">#d9ebdf / #f4e3cf</td><td class="d">Pill + chip washes (never translucent).</td></tr>
+        <tr><td class="k">--hm-ink / --hm-muted / --hm-faint</td><td class="v">#1b1a16 / #6b6557 / #948d7c</td><td class="d">Text primary / secondary / tertiary.</td></tr>
+        <tr><td class="k">--hm-line</td><td class="v">rgba(38,32,18,.10)</td><td class="d">Hairline borders everywhere.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- card grammar -->
+  <section class="sec">
+    <h2>Card grammar — one shape, five zones</h2>
+    <p class="h-lede" style="font-size:14px; margin-bottom:16px">Every kanban card (mission · task · deploy · done) uses the same five zones so the eye learns one pattern. More than this belongs in the drawer. Show only real fields — unknown is honest (<code>PR: —</code>, <code>?</code>), never fabricated.</p>
+    <div class="grid c2">
+      <div class="card2" style="padding:0; overflow:hidden">
+        <div style="padding:16px; border-bottom:1px solid var(--hm-line-2)">
+          <div style="display:flex; align-items:center; gap:6; font-size:12px"><span style="width:7px;height:7px;border-radius:50%;background:var(--ag-claude)"></span><span class="name" style="color:var(--ag-claude)">Claude</span><span style="color:var(--hm-faint)">·</span><span class="mono2">codex-task</span><span style="margin-left:auto" class="mono2">FRESH 5.2H</span></div>
+          <div class="font-display" style="font-weight:700; font-size:15.5px; margin-top:10px">Fix /auth/verify KMS-JWT auth</div>
+          <div class="mono2" style="margin-top:6px">depre-dev/averray-reference-agent</div>
+          <div style="font-size:12.5px; color:var(--hm-ink-2); margin-top:2px">proposed · waiting for your approval</div>
+          <div class="pillrow" style="margin-top:10px"><span class="pill pill--act" style="height:19px;font-size:9.5px"><span class="dot"></span>proposed</span><span class="pill pill--warn" style="height:19px;font-size:9.5px">risk: med</span><span class="pill pill--tel" style="height:19px;font-size:9.5px">no PR yet</span></div>
+          <div style="margin-top:12px"><span class="btn btn--act btn--sm" style="width:100%">Approve &amp; dispatch</span></div>
+        </div>
+      </div>
+      <div class="card2">
+        <table>
+          <tbody>
+            <tr><td class="k">1 · meta</td><td class="d">agent dot + name · type · age (<code>FRESH 5.2H</code>)</td></tr>
+            <tr><td class="k">2 · title</td><td class="d">the real human title — never "claude task"</td></tr>
+            <tr><td class="k">3 · context</td><td class="d">repo · current state / next step</td></tr>
+            <tr><td class="k">4 · signals</td><td class="d">≤3 chips: state/verdict · risk tier · PR# or "no PR yet" · CI · key metrics</td></tr>
+            <tr><td class="k">5 · action</td><td class="d">single next action (Approve &amp; dispatch / Decide → / Review →)</td></tr>
+          </tbody>
+        </table>
+        <div class="note" style="margin-top:14px; font-size:12.5px">Running cards swap the context zone for a <strong>checkpoint stepper</strong> (CI queued → install → unit tests → browser replay → Hermes review → ready) — concrete steps, not a fake %. Done cards dim + desaturate and carry only a verdict pill.</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- decision-safety layer -->
+  <section class="sec">
+    <h2>Decision-safety layer</h2>
+    <p class="h-lede" style="font-size:14px; margin-bottom:16px">North star: <em>show exactly where the operator’s judgment changes the outcome — not everything the agents are doing.</em> The <strong>Decision Inbox</strong> ("Your decisions") is the single union of every card where <code>waitingOn === 'operator'</code>, pulled from all lanes — the ONE place to act. The same cards still appear in their pipeline lane, but <strong>read-only</strong> (a "→ In your decisions" pointer, never a CTA). Coral is reserved for the single most-urgent recommended action; everything else is ink/neutral.</p>
+    <div class="grid c2">
+      <div class="card2">
+        <div class="name" style="margin-bottom:10px">Four badge families (G) — one shape each</div>
+        <table><tbody>
+          <tr><td class="k">State</td><td class="d">failed · blocked · running · ready · done</td></tr>
+          <tr><td class="k">Risk</td><td class="d">low · med · high, typed: code / deploy / data / money</td></tr>
+          <tr><td class="k">Evidence</td><td class="d">traces · shots · video · PR · tests · CI</td></tr>
+          <tr><td class="k">Gate</td><td class="d">needs-you (act dot) · agent · system</td></tr>
+        </tbody></table>
+        <div class="name" style="margin:14px 0 8px">Failure class (D)</div>
+        <div class="pillrow">
+          <span class="chip" style="font-size:10px">Product</span><span class="chip" style="font-size:10px">Test</span><span class="chip" style="font-size:10px">Infra</span><span class="chip" style="font-size:10px">Agent</span><span class="chip" style="font-size:10px">Policy</span><span class="chip" style="font-size:10px">Unknown</span>
+        </div>
+      </div>
+      <div class="card2">
+        <div class="name" style="margin-bottom:10px">Decision bundle (B) — every inbox card answers</div>
+        <table><tbody>
+          <tr><td class="k">Recommended</td><td class="d">Hermes’s call — the primary (coral if most-urgent)</td></tr>
+          <tr><td class="k">Why now</td><td class="d">one sentence</td></tr>
+          <tr><td class="k">Risk</td><td class="d">typed + level</td></tr>
+          <tr><td class="k">Grants / does not</td><td class="d">exact scope + what it does NOT allow</td></tr>
+          <tr><td class="k">Blast radius</td><td class="d">repo · branch · env · area · users</td></tr>
+          <tr><td class="k">Rollback</td><td class="d">what happens if wrong</td></tr>
+          <tr><td class="k">Choices</td><td class="d">Approve · Reject · Rerun · Convert · Ask Hermes · Replay · Dismiss</td></tr>
+        </tbody></table>
+        <div class="note" style="margin-top:12px; font-size:12px">Plus <strong>“Why you’re seeing this”</strong> (C) on every inbox card and <strong>“Unblock”</strong> on every blocked one. Command-box preview (F) shows scope · mutation · budget · timeout · gates before any mutating command runs — budget is a run/step cap, never a fabricated $.</div>
+      </div>
+    </div>
+    <div class="note" style="margin-top:14px"><strong>Drawer lifecycle — requested → running (LIVE) → done, in place.</strong> Opening a running mission shows the <strong>live-follow</strong> view: a stage badge (current checkpoint, “no verdict yet”), the latest streamed frame (or an honest <code>awaiting first frame</code> placeholder before any frame arrives), a <strong>rolling output tail labeled “recent output (rolling tail) · ~2s”</strong>, and the lit checkpoint stepper. On completion the <em>same drawer</em> auto-swaps to the end-report (verdict, outcome, evidence, traces, discussion, the 3 actions) — no reload. The stream is clearly marked <span style="color:var(--ag-claude)">demo</span>; a real worker streams stage/output/frames and a verdict is never shown before the run posts one.</div>
+    <div class="note" style="margin-top:14px"><strong>Decision clarity layer.</strong> The Decision Inbox (“Your decisions”) holds the only human actions; pipeline mirror cards are passive — a quiet <em>“Awaiting your decision · in inbox”</em> label that jumps, never a CTA. Lanes read plainly: <em>Builder tasks</em> (agent shown as Claude / Codex), <em>Runs needing review</em>. Every inbox card carries a <strong>what-happens-next</strong> line; failed cards carry a <strong>failure class</strong>; missions carry <strong>env/identity badges</strong> (environment · identity · data-mode · browser · viewport) and a <strong>run contract</strong> (target/flow/mode/success/stop/budget/artifacts). The drawer orders evidence forensically — <em>verdict → Expected vs Observed → run timeline → failure frame → replay → diagnostics → raw</em> — and a <strong>convert-to-bug preview</strong> shows the exact card it would create. States carry a shape glyph as well as color (✕ failed · ▢ blocked · ◐ running · ▲ ready · ✓ done); every control has a visible focus ring. Global controls (<em>Mode: supervised</em>, <em>Pause agents</em>), the digest’s “since you last looked”, dedupe, heartbeat, real checkpoints and forensic data are <strong>design-only slots</strong> marked <code>preview</code> / <code>awaiting data</code> — never fabricated.</div>
+  </section>
+
+  <!-- color profiles -->
+  <section class="sec">
+    <h2>Color profiles — full themes (default: Midnight)</h2>
+    <p class="h-lede" style="font-size:14px; margin-bottom:16px">Six switchable profiles. Each defines base · surface · ink · the single act-accent · healthy · degraded · muted. <strong>Color = meaning and the accent stays single-purpose in every profile.</strong> All derived tokens (softs, lines, text variants, shadows, glow) are computed from these anchors — light profiles darken accent for on-surface text; dark profiles lighten it and add a reserved glow to act + live/active states only. Switching cross-fades surfaces (~0.5s).</p>
+    <div class="grid c3">
+      <div class="card2"><div style="display:flex; gap:0; height:48px; border-radius:8px; overflow:hidden; border:1px solid var(--hm-line); margin-bottom:10px"><i style="flex:2; background:#FAF7F2"></i><i style="flex:2; background:#FFFDFA"></i><i style="flex:1.4; background:#D97757"></i><i style="flex:1; background:#6B8F71"></i><i style="flex:1; background:#C8843C"></i></div><div class="name">Claude Warm</div><div class="mono2">act #D97757 · ok #6B8F71 · deg #C8843C</div></div>
+      <div class="card2"><div style="display:flex; gap:0; height:48px; border-radius:8px; overflow:hidden; border:1px solid var(--hm-line); margin-bottom:10px"><i style="flex:2; background:#1A1714"></i><i style="flex:2; background:#241F1B"></i><i style="flex:1.4; background:#E8865E"></i><i style="flex:1; background:#7FB089"></i><i style="flex:1; background:#E0A050"></i></div><div class="name">Midnight <span style="color:var(--act-text); font-size:10px">· default · warm dark</span></div><div class="mono2">act #E8865E · ok #7FB089 · deg #E0A050</div></div>
+      <div class="card2"><div style="display:flex; gap:0; height:48px; border-radius:8px; overflow:hidden; border:1px solid var(--hm-line); margin-bottom:10px"><i style="flex:2; background:#F4F5F7"></i><i style="flex:2; background:#FFFFFF"></i><i style="flex:1.4; background:#5B6CFF"></i><i style="flex:1; background:#3FA66A"></i><i style="flex:1; background:#D9911F"></i></div><div class="name">Slate Console <span style="color:var(--hm-faint); font-size:10px">· cool</span></div><div class="mono2">act #5B6CFF · ok #3FA66A · deg #D9911F</div></div>
+      <div class="card2"><div style="display:flex; gap:0; height:48px; border-radius:8px; overflow:hidden; border:1px solid var(--hm-line); margin-bottom:10px"><i style="flex:2; background:#FBFAF7"></i><i style="flex:2; background:#FFFFFF"></i><i style="flex:1.4; background:#B23A28"></i><i style="flex:1; background:#2F7D52"></i><i style="flex:1; background:#B5791E"></i></div><div class="name">Editorial <span style="color:var(--hm-faint); font-size:10px">· hi-contrast</span></div><div class="mono2">act #B23A28 · ok #2F7D52 · deg #B5791E</div></div>
+      <div class="card2"><div style="display:flex; gap:0; height:48px; border-radius:8px; overflow:hidden; border:1px solid var(--hm-line); margin-bottom:10px"><i style="flex:2; background:#F6F5F8"></i><i style="flex:2; background:#FFFFFF"></i><i style="flex:1.4; background:#E6007A"></i><i style="flex:1; background:#0FA67E"></i><i style="flex:1; background:#E0A030"></i></div><div class="name">Averray (Polkadot)</div><div class="mono2">act #E6007A → CTA #D6006E · ok #0FA67E</div></div>
+      <div class="card2"><div style="display:flex; gap:0; height:48px; border-radius:8px; overflow:hidden; border:1px solid var(--hm-line); margin-bottom:10px"><i style="flex:2; background:#14111C"></i><i style="flex:2; background:#201B2E"></i><i style="flex:1.4; background:#FF2D92"></i><i style="flex:1; background:#2DD4BF"></i><i style="flex:1; background:#F0B44C"></i></div><div class="name">Midnight × Polkadot <span style="color:var(--hm-faint); font-size:10px">· glow</span></div><div class="mono2">act #FF2D92 (ink on fill) · ok #2DD4BF</div></div>
+    </div>
+    <div class="note" style="margin-top:16px"><strong>Contrast guards baked in.</strong> Averray CTA fill drops to <code>#D6006E</code> so white labels stay ≥AA on the magenta; Midnight × Polkadot uses near-black ink (<code>#14111C</code>) on its luminous magenta fill. Degraded never collapses into healthy or empty — the <code>?</code> degraded state keeps its own amber/gold across all six. Dark profiles add a reserved bloom (<code>--act-glow</code>, <code>--sh-coral</code>) to the act-accent + LIVE/active dots only; everything else stays calm and dim.</div>
+  </section>
+
+  <!-- agent identity -->
+  <section class="sec">
+    <h2>Agent identity — cool jewel set, kept distinct from status</h2>
+    <p class="h-lede" style="font-size:14px; margin-bottom:16px">Identity colors live only in avatar tiles + the author's name. They are deliberately cooler than the warm status palette so identity never reads as a status signal.</p>
+    <div class="grid c4">
+      <div class="card2"><div class="sw" style="background:var(--ag-hermes); display:grid; place-items:center; color:#fff; font-family:var(--font-display); font-weight:700; font-size:24px">H</div><div class="name">Hermes</div><div class="mono2">#4b56c4</div><div class="role">orchestrator</div></div>
+      <div class="card2"><div class="sw" style="background:var(--ag-claude); display:grid; place-items:center; color:#fff; font-family:var(--font-display); font-weight:700; font-size:24px">C</div><div class="name">Claude</div><div class="mono2">#7048b6</div><div class="role">worker</div></div>
+      <div class="card2"><div class="sw" style="background:var(--ag-codex); display:grid; place-items:center; color:#fff; font-family:var(--font-display); font-weight:700; font-size:24px">X</div><div class="name">Codex</div><div class="mono2">#2f8f83</div><div class="role">worker</div></div>
+      <div class="card2"><div class="sw" style="background:var(--ag-test); display:grid; place-items:center; color:#fff; font-family:var(--font-display); font-weight:700; font-size:24px">T</div><div class="name">Test-writer</div><div class="mono2">#5d6b7d</div><div class="role">tester</div></div>
+    </div>
+    <div class="grid c2" style="margin-top:14px">
+      <div class="card2"><div class="sw" style="background:var(--ag-op); display:grid; place-items:center; color:#fff; font-family:var(--font-display); font-weight:700; font-size:20px">●</div><div class="name">Operator (You)</div><div class="mono2">#2a2723</div><div class="role">graphite — the participant</div></div>
+      <div class="card2"><div class="sw" style="background:var(--ag-system); display:grid; place-items:center; color:#fff; font-family:var(--font-display); font-weight:700; font-size:20px">S</div><div class="name">System</div><div class="mono2">#8a8275</div><div class="role">release automation</div></div>
+    </div>
+  </section>
+
+  <!-- type -->
+  <section class="sec">
+    <h2>Type scale</h2>
+    <div class="card2">
+      <div class="specimen" style="font-size:40px">Space Grotesk — display</div>
+      <div style="font-family:var(--font-body); font-size:16px; color:var(--hm-ink); margin-top:14px; line-height:1.6">Manrope — body. Calm, evidence-led, infrastructure-grade. Default 15px / 1.55.</div>
+      <div class="mono" style="font-size:14px; color:var(--hm-ink-2); margin-top:12px">JetBrains Mono — ids, traces, wallet, timestamps</div>
+    </div>
+    <table style="margin-top:16px">
+      <thead><tr><th>Role</th><th>Size</th><th>Token / notes</th></tr></thead>
+      <tbody>
+        <tr><td>Banner headline</td><td class="v">27px / 700</td><td class="d">Friendly display, line-height 1.14.</td></tr>
+        <tr><td>Card title</td><td class="v">19px / 700</td><td class="d">DECIDE card titles.</td></tr>
+        <tr><td>Lane title</td><td class="v">15px / 700</td><td class="d">—</td></tr>
+        <tr><td>Body</td><td class="v">13.5–15px / 400</td><td class="d">Turn text, descriptions.</td></tr>
+        <tr><td>Eyebrow</td><td class="v">11px / 700</td><td class="d">Uppercase, <code>letter-spacing:0</code> (global kill).</td></tr>
+        <tr><td>Mono meta</td><td class="v">11–12.5px</td><td class="d">Ids, times, traces.</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <!-- radii + shadow + pills -->
+  <section class="sec">
+    <h2>Radii · elevation · pills</h2>
+    <div class="grid c2">
+      <div class="card2">
+        <table>
+          <tbody>
+            <tr><td class="k">--r-sm</td><td class="v">8px</td><td class="d">inner elements</td></tr>
+            <tr><td class="k">--r-chip</td><td class="v">9px</td><td class="d">meta chips</td></tr>
+            <tr><td class="k">--r-btn</td><td class="v">11px</td><td class="d">buttons, inputs</td></tr>
+            <tr><td class="k">--r-card</td><td class="v">15px</td><td class="d">cards</td></tr>
+            <tr><td class="k">--r-lane</td><td class="v">19px</td><td class="d">tier lanes</td></tr>
+            <tr><td class="k">--r-pill</td><td class="v">999px</td><td class="d">status pills</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="card2">
+        <table>
+          <tbody>
+            <tr><td class="k">--sh-sm</td><td class="d">resting cards</td></tr>
+            <tr><td class="k">--sh</td><td class="d">panels</td></tr>
+            <tr><td class="k">--sh-lift</td><td class="d">hover / drawer</td></tr>
+            <tr><td class="k">--sh-coral</td><td class="d">primary action glow</td></tr>
+          </tbody>
+        </table>
+        <div class="pillrow" style="margin-top:14px">
+          <span class="pill pill--act"><span class="dot"></span>→ Operator</span>
+          <span class="pill pill--ok"><span class="dot"></span>Deploy ok</span>
+          <span class="pill pill--warn"><span class="dot"></span>Failed 0%</span>
+          <span class="pill pill--tel">quiet 27</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- motion -->
+  <section class="sec">
+    <h2>Motion timings</h2>
+    <table>
+      <thead><tr><th>Token / anim</th><th>Value</th><th>Where</th></tr></thead>
+      <tbody>
+        <tr><td class="k">--ease</td><td class="v">cubic-bezier(.2,.7,.2,1)</td><td class="d">all transitions</td></tr>
+        <tr><td class="k">--dur-fast / --dur</td><td class="v">150ms / 200ms</td><td class="d">hover, press, color</td></tr>
+        <tr><td class="k">hm-slide-in</td><td class="v">320ms ease-out</td><td class="d">new turns + cards enter</td></tr>
+        <tr><td class="k">hm-breathe</td><td class="v">~4s loop (÷ intensity)</td><td class="d">needs-you banner + urgent card</td></tr>
+        <tr><td class="k">lane-spring (FLIP)</td><td class="v">500–780ms · cubic-bezier(.34,1.62,.4,1)</td><td class="d">card crossing columns on advance — overshoot spring + lift + scale(1.06). Runs at full regardless of the global intensity (it's a one-shot, not decorative), skipped only at motion 0 / reduced-motion.</td></tr>
+        <tr><td class="k">hm-live</td><td class="v">~2.4s loop</td><td class="d">LIVE clock + presence dots</td></tr>
+        <tr><td class="k">hm-shimmer</td><td class="v">~2.6s loop</td><td class="d">running / deploying items (high intensity only)</td></tr>
+        <tr><td class="k">hm-pop</td><td class="v">420ms</td><td class="d">counts on change</td></tr>
+      </tbody>
+    </table>
+    <div class="note" style="margin-top:16px"><strong>Intensity + reduced-motion.</strong>A single <code>--mi</code> (0–1) and <code>data-motion="off|low|med|high"</code> on <code>&lt;html&gt;</code> gate the decorative layers: <em>low</em> keeps only slide-ins + the live pulse, <em>med</em> (default, 60%) adds breathing + count pops, <em>high</em> turns on shimmer. <code>@media (prefers-reduced-motion: reduce)</code> hard-disables every animation regardless — fully supported.</div>
+  </section>
+
+  <!-- data model -->
+  <section class="sec">
+    <h2>Room data model — ports 1:1</h2>
+    <pre class="code-block" style="border-radius:var(--r-card)">Turn = {
+  author:  'hermes' | 'claude' | 'codex' | 'test-writer' | 'operator' | 'system',
+  target?: same set | 'everyone',          // directed message → arrow in UI
+  kind:    'chat' | 'proposal' | 'request_help' | 'status' | 'review',
+  time, text, pending?, demo?
+}
+// Threads group turns by the card/task they're about (thread.cardRef → opens drawer).
+// Ranking by kind: request_help / proposal / review = prominent (coral / sage, left border);
+//                  chat = normal;  status = dimmed muted telemetry.</pre>
+    <div class="note" style="margin-top:16px; border-left-color:var(--ag-claude)"><strong>Honesty contract — ship this, not the scaffold.</strong>The default room renders <em>only real turns</em>. The <code>demoTimeline</code> (synthetic <code>request_help</code> / <code>proposal</code> / typing) exists solely so this prototype's motion can be judged — every entry is <code>demo:true</code> and <strong>must be stripped from the production port</strong>. Truth-boundary holds: degraded shows <code>?</code> not <code>0</code>, empty is honestly empty ("no agent chatter yet"; "no saved suites yet"), a down telemetry source reads <code>?</code> + "source unavailable" (see Utilities → LLM usage) rather than a fabricated count, and nothing about agent-to-agent dialogue is fabricated at runtime.</div>
+  </section>
+</main>
+</body>
+</html>

--- a/docs/design/hermes-4/project/Hermes.html
+++ b/docs/design/hermes-4/project/Hermes.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Hermes — Handoff Monitor</title>
+<link rel="stylesheet" href="hermes.css">
+<template id="__bundler_thumbnail">
+  <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <rect width="100" height="100" rx="20" fill="#e9e4d9"/>
+    <rect x="22" y="24" width="34" height="34" rx="9" fill="#1b1a16"/>
+    <text x="39" y="48" font-family="Space Grotesk, sans-serif" font-size="22" font-weight="700" fill="#fffdf8" text-anchor="middle">H</text>
+    <circle cx="70" cy="32" r="6" fill="#D97757"/>
+    <rect x="22" y="66" width="56" height="8" rx="4" fill="#D97757" opacity="0.85"/>
+    <rect x="22" y="80" width="40" height="6" rx="3" fill="#1e6642" opacity="0.6"/>
+  </svg>
+</template>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="root"></div>
+<script type="text/babel" src="tweaks-panel.jsx"></script>
+<script type="text/babel" src="parts.jsx"></script>
+<script type="text/babel" src="data.jsx"></script>
+<script type="text/babel" src="board.jsx"></script>
+<script type="text/babel" src="utilities.jsx"></script>
+<script type="text/babel" src="kanban.jsx"></script>
+<script type="text/babel" src="room.jsx"></script>
+<script type="text/babel" src="rail.jsx"></script>
+<script type="text/babel" src="drawer.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/docs/design/hermes-4/project/app.jsx
+++ b/docs/design/hermes-4/project/app.jsx
@@ -1,0 +1,368 @@
+/* Hermes — app shell: color profiles, motion/tweaks, kanban + room composition */
+const { CARDS, THREADS, DEMO_TIMELINE, AGENTS: AGA, CLOCK_START } = window.HERMES_DATA;
+const { TopBar, NeedsYouBanner, Toolbar, ControlsSheet } = window.Board;
+const { UtilitiesPanel } = window.Utilities;
+const { KanbanRow, SEED_CHECKPOINTS } = window.Kanban;
+const { RightRail } = window.Rail;
+const { CardDrawer } = window.Drawer;
+
+/* ───────── color math ───────── */
+const _hx = (h) => { h = h.replace('#',''); if (h.length===3) h = h.split('').map(c=>c+c).join(''); return { r:parseInt(h.slice(0,2),16), g:parseInt(h.slice(2,4),16), b:parseInt(h.slice(4,6),16) }; };
+const _hex = ({r,g,b}) => { const t=n=>Math.max(0,Math.min(255,Math.round(n))).toString(16).padStart(2,'0'); return '#'+t(r)+t(g)+t(b); };
+const mix = (a,b,t) => { const A=_hx(a), B=_hx(b); return _hex({ r:A.r+(B.r-A.r)*t, g:A.g+(B.g-A.g)*t, b:A.b+(B.b-A.b)*t }); };
+const rgba = (h,a) => { const {r,g,b}=_hx(h); return `rgba(${r},${g},${b},${a})`; };
+const lighten = (h,t) => mix(h,'#ffffff',t);
+const darken  = (h,t) => mix(h,'#000000',t);
+const _lum = (h) => { const {r,g,b}=_hx(h); const f=c=>{c/=255;return c<=0.03928?c/12.92:Math.pow((c+0.055)/1.055,2.4);}; return 0.2126*f(r)+0.7152*f(g)+0.0722*f(b); };
+const inkOn = (bg) => _lum(bg) > 0.42 ? '#14110c' : '#ffffff';
+
+/* ───────── profiles ───────── */
+const PROFILES = {
+  claude:    { label:'Claude Warm',       dark:false, base:'#FAF7F2', surface:'#FFFDFA', ink:'#2A2622', muted:'#A89B8C', accent:'#D97757', healthy:'#6B8F71', degraded:'#C8843C' },
+  midnight:  { label:'Midnight',          dark:true,  glow:false, base:'#1A1714', surface:'#241F1B', ink:'#EDE6DD', muted:'#6B635A', accent:'#E8865E', healthy:'#7FB089', degraded:'#E0A050' },
+  slate:     { label:'Slate Console',     dark:false, base:'#F4F5F7', surface:'#FFFFFF', ink:'#1F2430', muted:'#8A93A3', accent:'#5B6CFF', healthy:'#3FA66A', degraded:'#D9911F' },
+  editorial: { label:'Editorial',         dark:false, base:'#FBFAF7', surface:'#FFFFFF', ink:'#17120E', muted:'#9C948A', accent:'#B23A28', healthy:'#2F7D52', degraded:'#B5791E' },
+  averray:   { label:'Averray (Polkadot)',dark:false, base:'#F6F5F8', surface:'#FFFFFF', ink:'#1B1722', muted:'#8C8A99', accent:'#E6007A', healthy:'#0FA67E', degraded:'#E0A030', accentFill:'#D6006E', accentInk:'#ffffff' },
+  midpolka:  { label:'Midnight × Polkadot',dark:true, glow:true, base:'#14111C', surface:'#201B2E', ink:'#ECE8F2', muted:'#6B6580', accent:'#FF2D92', healthy:'#2DD4BF', degraded:'#F0B44C', accentInk:'#14111C' },
+};
+const PROFILE_OPTS = Object.entries(PROFILES).map(([value,p]) => ({ value, label:p.label }));
+
+function buildTheme(p) {
+  const dark = !!p.dark, glow = !!p.glow;
+  const { base, surface:surf, ink, muted, accent, healthy:ok, degraded:warn } = p;
+  const accFill = p.accentFill || (dark ? accent : darken(accent,0.08));
+  const accInk  = p.accentInk  || inkOn(accFill);
+  return {
+    '--hm-canvas':base, '--hm-surface':mix(base,surf,0.5), '--hm-paper':surf,
+    '--hm-paper-sunken':mix(surf,base,0.4), '--hm-paper-veil':rgba(surf,0.72),
+    '--hm-ink':ink, '--hm-ink-2': dark ? mix(ink,muted,0.16) : mix(ink,muted,0.30),
+    '--hm-muted': dark ? lighten(muted,0.22) : muted,
+    '--hm-faint': dark ? lighten(mix(muted,base,0.28),0.08) : mix(muted,base,0.45),
+    '--hm-line':rgba(ink,dark?0.14:0.12), '--hm-line-2':rgba(ink,dark?0.08:0.06), '--hm-line-strong':rgba(ink,dark?0.22:0.16),
+    '--act':accent, '--act-deep':accFill, '--act-ink':accInk,
+    '--act-text':dark?lighten(accent,0.10):darken(accent,0.12),
+    '--act-soft':rgba(accent,dark?0.18:0.12), '--act-soft-2':rgba(accent,dark?0.30:0.20), '--act-line':rgba(accent,dark?0.5:0.34),
+    /* DECIDE tier tint — desaturated toward neutral so it never blurs with the true-coral CTA (#4) */
+    '--tier-decide-bg':   rgba(mix(accent, base, dark?0.55:0.45), dark?0.16:0.34),
+    '--tier-decide-line': rgba(mix(accent, base, dark?0.40:0.32), dark?0.34:0.30),
+    '--tier-decide-text': dark ? lighten(mix(accent,muted,0.34),0.06) : darken(mix(accent,muted,0.30),0.04),
+    '--ok':ok, '--ok-text':dark?lighten(ok,0.12):darken(ok,0.10), '--ok-soft':rgba(ok,dark?0.20:0.16), '--ok-line':rgba(ok,dark?0.42:0.24),
+    '--warn':warn, '--warn-text':dark?lighten(warn,0.10):darken(warn,0.14), '--warn-soft':rgba(warn,dark?0.20:0.16), '--warn-line':rgba(warn,dark?0.42:0.28),
+    '--tel':dark?lighten(muted,0.18):darken(muted,0.04), '--tel-soft':rgba(muted,dark?0.18:0.5), '--tel-chip':dark?mix(surf,muted,0.20):mix(base,muted,0.16),
+    '--glow-1':rgba(accent, dark?(glow?0.14:0.10):0.05), '--glow-2':rgba(ok, dark?0.07:0.04),
+    '--act-glow': dark ? `0 0 ${glow?20:14}px ${rgba(accent,glow?0.6:0.45)}` : 'none',
+    '--sh-sm':  dark ? '0 1px 0 rgba(255,255,255,0.04) inset, 0 2px 8px rgba(0,0,0,0.40)' : '0 1px 2px rgba(40,33,18,0.05), 0 2px 6px rgba(40,33,18,0.04)',
+    '--sh':     dark ? 'inset 0 1px 0 rgba(255,255,255,0.05), 0 10px 30px rgba(0,0,0,0.45)' : '0 2px 6px rgba(40,33,18,0.05), 0 14px 34px rgba(40,33,18,0.07)',
+    '--sh-lift':dark ? 'inset 0 1px 0 rgba(255,255,255,0.06), 0 16px 44px rgba(0,0,0,0.55)' : '0 8px 18px rgba(40,33,18,0.09), 0 26px 56px rgba(40,33,18,0.12)',
+    '--sh-coral':dark ? `0 6px 22px ${rgba(accent,glow?0.55:0.40)}, 0 0 ${glow?22:14}px ${rgba(accent,glow?0.50:0.32)}` : `0 8px 24px ${rgba(accent,0.24)}`,
+    '--sh-inset':dark ? 'inset 0 1px 0 rgba(255,255,255,0.10)' : 'inset 0 1px 0 rgba(255,255,255,0.6)',
+  };
+}
+
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "profile": "midnight",
+  "motion": 60,
+  "density": "regular",
+  "avatar": "tile",
+  "utilities": "collapsed",
+  "demo": false
+}/*EDITMODE-END*/;
+
+const bucket = (v) => v<=0 ? 'off' : v<=33 ? 'low' : v<=66 ? 'med' : 'high';
+
+/* board footer — gives the page a clear bottom edge so it visibly ends */
+function BoardFooter({ cards, clock }) {
+  const total = cards.length;
+  const waiting = cards.filter(c => c.waitingOn === 'operator').length;
+  const running = cards.filter(c => c.state && c.state.kind === 'running').length;
+  return (
+    <footer style={{ flex:'none', display:'flex', alignItems:'center', gap:14, flexWrap:'wrap',
+      padding:'12px 22px', borderTop:'1px solid var(--hm-line)', background:'var(--hm-paper-veil)' }}>
+      <span style={{ display:'inline-flex', alignItems:'center', gap:8 }}>
+        <span style={{ width:5, height:5, borderRadius:'50%', background:'var(--hm-line-strong)' }} />
+        <span className="eyebrow" style={{ fontSize:9.5, color:'var(--hm-faint)' }}>End of board</span>
+      </span>
+      <span className="mono" style={{ fontSize:11.5, color:'var(--hm-muted)' }}>
+        {total} cards · {waiting} waiting on you · {running} running
+      </span>
+      <span style={{ marginLeft:'auto', display:'inline-flex', alignItems:'center', gap:8 }}>
+        <span className="mono" style={{ fontSize:11, color:'var(--hm-faint)' }} title="Last board sync — needs a real backend signal">last sync · {clock}</span>
+        <span style={{ fontSize:11, color:'var(--hm-faint)' }}>Hermes · Averray</span>
+      </span>
+    </footer>
+  );
+}
+
+/* synthetic runner stream (demo — the real worker streams these) */
+const STREAM_LINES = [
+  'runner: claimed testbed slot · fresh agent, no memory',
+  'browser: launching chromium (headless, read-only)',
+  'nav: GET https://en.wikipedia.org/ · budget 45s',
+  'nav: first paint at 1.8s',
+  'dom: settled · 0 console errors',
+  'replay: step 1/4 — open article',
+  'frame: captured screenshot',
+  'replay: step 2/4 — locate citation block',
+  'replay: step 3/4 — verify reference target',
+  'frame: captured screenshot',
+  'replay: step 4/4 — assert no mutation crossed',
+  'hermes: collecting 8 traces',
+  'hermes: scoring run against policy',
+  'hermes: verdict posted',
+];
+
+/* complete a live mission into its end-report (in place — same card, kind flips) */
+function completeMission(c, output, frames) {
+  const steps = (c.checkpoints || []).map(s => ({ ...s, state:'done' }));
+  return {
+    ...c,
+    checkpoints: steps,
+    live: null,
+    completed: true,
+    stage: 'opreview',
+    waitingOn: 'operator',
+    state: { label:'Passed', kind:'ready' },
+    gate: 'operator',
+    failureClass: null,
+    verdict: 'mission passed · 45s budget held',
+    evidence: [ {k:'traces', n:8}, {k:'shots', n:2}, {k:'video'}, {k:'replay'} ],
+    whySeeing: 'The re-run finished and Hermes posted a passing verdict — accept to close, or re-run / convert.',
+    unblock: null,
+    body: 'Read-only mission completed. The fresh agent reached the citation block, verified the reference target, and crossed no mutation boundary.',
+    decision: {
+      recommended: 'Accept & close',
+      why: 'Run passed within the 45s budget with no boundary crossed; nothing to merge or deploy.',
+      grants: 'closes this card · records the passing run',
+      denies: 'no merge · no deploy · no spend · no prod data',
+      blast: { repo:'en.wikipedia.org (target)', branch:'—', env:'testbed', area:'browser-runner', users:'none' },
+      rollback: 'Re-open from Done if the verdict is later disputed.',
+      choices: ['Accept & close','Re-run','Convert to bug','Ask Hermes','Open replay','Dismiss'],
+    },
+  };
+}
+
+function HermesApp() {
+  const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+  const clock = useClock(CLOCK_START);
+  const wide = useWide(860);
+  const [filter, setFilter] = React.useState('all');
+  const [openId, setOpenId] = React.useState(null);
+
+  const [presence, setPresence] = React.useState({});
+  const [typingMap, setTypingMap] = React.useState({});
+  const [extras, setExtras] = React.useState([]);
+  const [freshSet, setFreshSet] = React.useState(() => new Set());
+  const [to, setTo] = React.useState('@everyone');
+  const [draft, setDraft] = React.useState('');
+  const [sending, setSending] = React.useState(false);
+  const boardRef = React.useRef(null);
+  const firstTheme = React.useRef(true);
+  const [utilOpen, setUtilOpen] = React.useState(t.utilities === 'expanded');
+  React.useEffect(() => { setUtilOpen(t.utilities === 'expanded'); }, [t.utilities]);
+
+  /* ---- A: unified card store + decision actions ---- */
+  const [cards, setCards] = React.useState(() => CARDS.map(c => ({ ...c })));
+  const [arrivedId, setArrivedId] = React.useState(null);
+  const [advanced, setAdvanced] = React.useState(0);
+  const [railTab, setRailTab] = React.useState('digest');
+  const [controlsOpen, setControlsOpen] = React.useState(false);
+
+  const decide = (cardId, action) => {
+    const a = (action || '').toLowerCase();
+    let patch = null, stageChanged = false, startLive = false;
+    if (/approve|dispatch/.test(a))      { patch = { stage:'checking', state:{ label:'Running', kind:'running' }, waitingOn:null, checkpoints:SEED_CHECKPOINTS(), gate:'agent', urgent:false, live:{ output:[], frames:0, startedAt:Date.now() }, completed:false }; stageChanged = true; startLive = true; }
+    else if (/rerun/.test(a))            { patch = { stage:'checking', state:{ label:'Running', kind:'running' }, waitingOn:null, checkpoints:SEED_CHECKPOINTS(), gate:'agent', urgent:false, live:{ output:[], frames:0, startedAt:Date.now() }, completed:false, failureClass:null }; stageChanged = true; startLive = true; }
+    else if (/reject|dismiss/.test(a))   { patch = { stage:'done', state:{ label:'Rejected', kind:'done' }, waitingOn:null, gate:'system', verdict:'rejected', urgent:false, live:null }; stageChanged = true; }
+    else if (/convert/.test(a))          { patch = { stage:'done', state:{ label:'Converted', kind:'done' }, waitingOn:null, gate:'system', verdict:'converted to bug', urgent:false, live:null }; stageChanged = true; }
+    else if (/hold/.test(a))             { patch = { waitingOn:null, state:{ label:'Held', kind:'blocked' }, gate:'agent', urgent:false }; }
+    else if (/accept/.test(a))           { patch = { stage:'done', state:{ label:'Accepted', kind:'done' }, waitingOn:null, gate:'system', verdict:'accepted · passed', urgent:false, live:null, completed:false }; stageChanged = true; }
+    else if (/edit/.test(a))             { return openCard(cardId); }
+    else return;
+    setCards(prev => {
+      const next = prev.map(c => c.id === cardId ? { ...c, ...patch } : c);
+      // promote a new most-urgent among remaining decisions
+      const stillUrgent = next.some(c => c.waitingOn === 'operator' && c.urgent);
+      if (!stillUrgent) { const firstWaiting = next.find(c => c.waitingOn === 'operator'); if (firstWaiting) firstWaiting.urgent = true; }
+      return next;
+    });
+    if (stageChanged) { setArrivedId(cardId); setAdvanced(n => n + 1); setTimeout(() => setArrivedId(a2 => a2 === cardId ? null : a2), 1500); }
+    // open the live-follow drawer so the operator can watch it run
+    if (startLive) setTimeout(() => setOpenId(cardId), 360);
+  };
+
+  const askHermes = (cardId) => { setRailTab('room'); };
+
+  /* ---- live-follow stream driver (clearly-marked demo; real worker streams stage/output/frames) ---- */
+  React.useEffect(() => {
+    const iv = setInterval(() => {
+      setCards(prev => {
+        let changed = false;
+        const next = prev.map(c => {
+          if (c.stage !== 'checking' || !c.live) return c;
+          changed = true;
+          const steps = c.checkpoints || [];
+          const curIdx = steps.findIndex(s => s.state === 'current');
+          const replayIdx = steps.findIndex(s => /replay/.test(s.label));
+          const line = STREAM_LINES[Math.min(c.live.output.length, STREAM_LINES.length - 1)];
+          const output = [...c.live.output, line].slice(-60);
+          // frames begin once the run reaches browser replay
+          const frames = (curIdx >= replayIdx && replayIdx >= 0) ? c.live.frames + 1 : c.live.frames;
+          // advance one checkpoint per tick
+          if (curIdx >= 0 && curIdx < steps.length - 1) {
+            const checkpoints = steps.map((s,i) => i <= curIdx ? { ...s, state:'done' } : (i === curIdx+1 ? { ...s, state:'current' } : s));
+            return { ...c, checkpoints, live:{ ...c.live, output, frames } };
+          }
+          // last checkpoint reached → complete into the end-report (in place)
+          return completeMission(c, output, frames);
+        });
+        return changed ? next : prev;
+      });
+    }, 2000);
+    return () => clearInterval(iv);
+  }, []);
+
+  /* ---- color profile ---- */
+  React.useLayoutEffect(() => {
+    const root = document.documentElement;
+    const p = PROFILES[t.profile] || PROFILES.claude;
+    if (!firstTheme.current) { root.classList.add('theming'); setTimeout(()=>root.classList.remove('theming'), 540); }
+    firstTheme.current = false;
+    const vars = buildTheme(p);
+    for (const k in vars) root.style.setProperty(k, vars[k]);
+    root.setAttribute('data-dark', p.dark ? '1' : '0');
+    root.setAttribute('data-glow', p.glow ? '1' : '0');
+  }, [t.profile]);
+
+  React.useEffect(() => {
+    document.documentElement.setAttribute('data-motion', bucket(t.motion));
+    document.documentElement.style.setProperty('--mi', String(Math.max(t.motion/100, 0)));
+  }, [t.motion]);
+  React.useEffect(() => { document.documentElement.setAttribute('data-density', t.density); }, [t.density]);
+
+  const markFresh = (id) => {
+    setFreshSet(s => new Set(s).add(id));
+    setTimeout(() => setFreshSet(s => { const n = new Set(s); n.delete(id); return n; }), 1300);
+  };
+
+  /* ---- demo timeline ---- */
+  React.useEffect(() => {
+    if (!t.demo) { setExtras(e => e.filter(x => !x.turn.demo)); setPresence({}); setTypingMap({}); return; }
+    const timers = [];
+    DEMO_TIMELINE.forEach(ev => {
+      timers.push(setTimeout(() => {
+        if (ev.type === 'presence') setPresence(p => ({ ...p, [ev.agent]: ev.presence }));
+        else if (ev.type === 'typing') setTypingMap(m => ({ ...m, [ev.threadId]: ev.agent }));
+        else if (ev.type === 'turn') {
+          setTypingMap(m => { const n = { ...m }; delete n[ev.threadId]; return n; });
+          setExtras(e => [...e, { threadId: ev.threadId, turn: ev.turn }]);
+          markFresh(ev.turn.text);
+        }
+      }, ev.at));
+    });
+    timers.push(setTimeout(() => setTypingMap({}), DEMO_TIMELINE[DEMO_TIMELINE.length-1].at + 400));
+    return () => timers.forEach(clearTimeout);
+  }, [t.demo]);
+
+  /* ---- composer optimistic send ---- */
+  const onSend = () => {
+    const text = draft.trim(); if (!text) return;
+    const tgt = to.replace('@','');
+    const opId = 'op-' + Date.now();
+    setExtras(e => [...e, { threadId:'direct', turn:{ id:opId, author:'operator', target:tgt, kind:'chat', time:clock.slice(0,5), text, pending:true } }]);
+    markFresh(text);
+    setDraft(''); setSending(true);
+    setPresence(p => ({ ...p, hermes:'active' }));
+    setTimeout(() => setExtras(e => e.map(x => x.turn.id===opId ? { ...x, turn:{ ...x.turn, pending:false } } : x)), 480);
+    setTimeout(() => setTypingMap(m => ({ ...m, direct:'hermes' })), 620);
+    setTimeout(() => {
+      setTypingMap(m => { const n = { ...m }; delete n.direct; return n; });
+      const reply = ackFor(text, tgt);
+      setExtras(e => [...e, { threadId:'direct', turn:{ id:'hm-'+Date.now(), author:'hermes', target:'operator', kind:'chat', time:clock.slice(0,5), text:reply, preview:true } }]);
+      markFresh(reply);
+      setSending(false);
+    }, 2000);
+  };
+
+  const threads = React.useMemo(() => {
+    const merged = THREADS.map(th => ({ ...th, turns:[...th.turns, ...extras.filter(e=>e.threadId===th.id).map(e=>e.turn)] }));
+    const direct = extras.filter(e=>e.threadId==='direct').map(e=>e.turn);
+    if (direct.length) merged.push({ id:'direct', label:'you ↔ hermes', cardRef:null, turns:direct });
+    return merged;
+  }, [extras]);
+
+  const openCard = (id) => setOpenId(id);
+  const jump = () => {
+    const urgent = cards.find(c => c.waitingOn === 'operator' && c.urgent) || cards.find(c => c.waitingOn === 'operator');
+    if (urgent) openCard(urgent.id);
+  };
+
+  const header = (
+    <div style={{ padding:'18px 22px 12px', display:'flex', flexDirection:'column', gap:14, flex:'none' }}>
+      <NeedsYouBanner clock={clock} onJump={jump} wide={wide} cards={cards} />
+      <Toolbar active={filter} onFilter={setFilter} />
+      <UtilitiesPanel open={utilOpen} onToggle={()=>setUtilOpen(o=>!o)} />
+    </div>
+  );
+
+  const roomProps = { threads, presence, typingMap, onOpenCard:openCard, demoActive:t.demo,
+    composer:{ to, setTo, draft, setDraft, onSend, sending, freshSet } };
+
+  return (
+    <AvatarStyleContext.Provider value={t.avatar}>
+    <div style={{ height:'100%', display:'flex', flexDirection:'column' }}>
+      <TopBar clock={clock} cards={cards} onToggleControls={()=>setControlsOpen(o=>!o)} />
+      <ControlsSheet open={controlsOpen} onClose={()=>setControlsOpen(false)} />
+      <div id="mainscroll" style={{ flex:1, minHeight:0, display: wide?'grid':'block',
+        gridTemplateColumns: wide ? 'minmax(0,1fr) clamp(360px, 30vw, 460px)' : undefined,
+        gridTemplateRows: wide ? 'minmax(0, 1fr)' : undefined,
+        overflowY: wide ? 'hidden' : 'auto' }} className={wide?'':'scroll-y'}>
+        <div ref={boardRef} id="boardscroll" style={{ minWidth:0, minHeight:0, height: wide?'100%':'auto',
+          display:'flex', flexDirection:'column', overflow: wide?'hidden':'visible' }}>
+          {header}
+          <div style={{ position:'relative', flex: wide?1:'none', minHeight:0, height: wide?'auto':'62vh' }}>
+            <KanbanRow cards={cards} decide={decide} arrivedId={arrivedId}
+              onOpenCard={openCard} onOpenReplay={openCard} onAskHermes={askHermes} />
+            {/* subtle bottom boundary so the board region visibly ends */}
+            <div aria-hidden="true" style={{ position:'absolute', left:0, right:0, bottom:0, height:22, pointerEvents:'none',
+              background:'linear-gradient(to top, var(--hm-canvas), transparent)' }} />
+          </div>
+          <BoardFooter cards={cards} clock={clock} />
+        </div>
+        <div style={{ height: wide?'100%':'82vh', minHeight: wide?0:560, overflow:'hidden', borderTop: wide?'none':'1px solid var(--hm-line)' }}>
+          <RightRail tab={railTab} setTab={setRailTab} cards={cards} advanced={advanced}
+            onOpenCard={openCard} roomProps={roomProps} />
+        </div>
+      </div>
+
+      <CardDrawer card={openId ? cards.find(c => c.id === openId) || null : null} onClose={()=>setOpenId(null)} decide={decide} onAskHermes={askHermes} />
+
+      <TweaksPanel title="Tweaks">
+        <TweakSection label="Theme" />
+        <TweakSelect label="Color profile" value={t.profile} options={PROFILE_OPTS} onChange={v=>setTweak('profile', v)} />
+        <TweakSection label="Feel" />
+        <TweakSlider label="Motion" value={t.motion} min={0} max={100} step={10} unit="%" onChange={v=>setTweak('motion', v)} />
+        <TweakSection label="Layout" />
+        <TweakRadio label="Density" value={t.density} options={['compact','regular','comfy']} onChange={v=>setTweak('density', v)} />
+        <TweakRadio label="Agent avatars" value={t.avatar} options={[{value:'tile',label:'Tiles'},{value:'dot',label:'Dots'}]} onChange={v=>setTweak('avatar', v)} />
+        <TweakRadio label="Utilities row" value={t.utilities} options={[{value:'collapsed',label:'Collapsed'},{value:'expanded',label:'Expanded'}]} onChange={v=>setTweak('utilities', v)} />
+        <TweakSection label="Room" />
+        <TweakToggle label="Demo timeline (synthetic)" value={t.demo} onChange={v=>setTweak('demo', v)} />
+        <div style={{ fontSize:10.5, color:'rgba(41,38,27,.5)', lineHeight:1.5, marginTop:-2 }}>
+          Injects synthetic request_help / proposal / typing so you can judge the motion. Stripped in production — only real turns animate.
+        </div>
+      </TweaksPanel>
+    </div>
+    </AvatarStyleContext.Provider>
+  );
+}
+
+function ackFor(text, tgt) {
+  const s = text.toLowerCase();
+  if (s.startsWith('/mission')) return 'Heard. In production I\u2019d queue that mission and post a status turn here when the runner reports back. Design preview — nothing dispatched.';
+  if (s.startsWith('/task')) return 'Heard. I\u2019d propose that task for your approval before any runner claims it. Design preview — no task created.';
+  if (s.startsWith('/mute')) return 'Muting telemetry for 1h. Design preview — board state unchanged.';
+  const tt = tgt==='everyone' ? 'the room' : tgt;
+  return `Routing to ${tt}. In production I\u2019d relay this and surface their reply as a new turn. Design preview — no message sent.`;
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<HermesApp />);

--- a/docs/design/hermes-4/project/board.jsx
+++ b/docs/design/hermes-4/project/board.jsx
@@ -1,0 +1,384 @@
+/* Hermes — board (left column): top bar, banner, toolbar, DECIDE / WATCH / HIDE */
+const { AGENTS } = window.HERMES_DATA;
+
+/* tiny author line: presence dot (agent color) + name + mono id */
+function AuthorLine({ authorId, mono, freshness }) {
+  const a = AGENTS[authorId] || AGENTS.system;
+  return (
+    <div style={{ display:'flex', alignItems:'center', gap:8, minWidth:0 }}>
+      <PresenceDot presence={a.presence} color={a.color} size={8} ring={false} />
+      <span className="font-display" style={{ fontWeight:600, fontSize:12.5, color:a.color }}>{a.name}</span>
+      {mono && <span className="mono" style={{ fontSize:12, color:'var(--hm-muted)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{mono}</span>}
+      {freshness && (
+        <span style={{ marginLeft:'auto', display:'inline-flex', alignItems:'center', gap:6, flex:'none' }}>
+          <span style={{ width:6, height:6, borderRadius:'50%', background:'var(--ok)' }} />
+          <span className="font-display" style={{ fontSize:11, fontWeight:600, textTransform:'uppercase', color:'var(--hm-faint)' }}>{freshness}</span>
+        </span>
+      )}
+    </div>
+  );
+}
+
+/* ───────────────── top bar ───────────────── */
+function TopBar({ clock, cards, controls, onToggleControls }) {
+  const { SELF_HEAL, CONTROLS } = window.HERMES_DATA;
+  controls = controls || CONTROLS;
+  cards = cards || window.HERMES_DATA.CARDS;
+  const decisions = cards.filter(c => c.waitingOn === 'operator').length;
+  const running = cards.filter(c => c.state && c.state.kind === 'running').length;
+  const done = cards.filter(c => c.stage === 'done').length;
+  const chips = [
+    { id:'dec',  label:'Decisions', count:decisions, primary:true },
+    { id:'run',  label:'Running',   count:running },
+    { id:'done', label:'Done',      count:done },
+  ];
+  return (
+    <header style={{ display:'flex', alignItems:'center', gap:16, padding:'12px 20px', background:'var(--hm-paper-veil)',
+      borderBottom:'1px solid var(--hm-line)', backdropFilter:'blur(12px)', flex:'none', zIndex:30 }}>
+      <div style={{ display:'flex', alignItems:'center', gap:12, flex:'none' }}>
+        <BrandMark size={40} label="A" />
+        <div>
+          <div className="font-display" style={{ fontWeight:700, fontSize:19, lineHeight:1 }}>Hermes</div>
+          <div className="eyebrow" style={{ fontSize:10, marginTop:3 }}>Handoff monitor · Averray</div>
+        </div>
+      </div>
+
+      <div className="scroll-y" style={{ display:'flex', alignItems:'center', gap:8, overflowX:'auto', overflowY:'hidden', flex:1, padding:'2px 0' }}>
+        {chips.map(c => <StatusChip key={c.id} c={c} />)}
+        <span className="pill pill--ok" style={{ flex:'none', height:30 }} title="Overall production health"><span className="dot" />Prod healthy</span>
+        <span className="chip" style={{ flex:'none', height:30, borderRadius:'var(--r-pill)' }}>{SELF_HEAL}</span>
+        <span className="chip" style={{ flex:'none', height:30, borderRadius:'var(--r-pill)' }} title="Heartbeat needs a real backend signal — not fabricated">heartbeat —</span>
+      </div>
+
+      <div style={{ display:'flex', alignItems:'center', gap:8, flex:'none' }}>
+        {/* global controls — design-only, not yet wired (preview) */}
+        <button onClick={onToggleControls} className="chip click" title="Operating mode and grants — preview, not wired"
+          style={{ height:34, gap:7, paddingRight:9 }}>
+          <span style={{ width:7, height:7, borderRadius:'50%', background:'var(--ok)', flex:'none' }} />
+          <span className="font-display" style={{ fontWeight:600, fontSize:12, color:'var(--hm-ink-2)' }}>Mode: {controls.mode}</span>
+          <span style={{ fontSize:9, padding:'1px 5px', borderRadius:4, background:'var(--hm-paper-sunken)', color:'var(--hm-faint)', textTransform:'uppercase', fontWeight:700, letterSpacing:'0' }}>preview</span>
+        </button>
+        <button className="btn btn--ghost btn--sm" title="Pause all agents — preview, not wired"
+          style={{ height:34 }} aria-label="Pause agents (preview, not wired)">
+          <span aria-hidden="true" style={{ display:'inline-flex', gap:2.5, marginRight:5 }}>
+            <span style={{ width:3, height:11, background:'var(--hm-muted)', borderRadius:1 }} />
+            <span style={{ width:3, height:11, background:'var(--hm-muted)', borderRadius:1 }} />
+          </span>
+          Pause agents
+        </button>
+        <span className="pill pill--ok" style={{ height:34, fontFamily:'var(--font-mono)', fontWeight:600, fontSize:12 }}>
+          <span className="dot live-dot" />LIVE · {clock}
+        </span>
+        <button className="btn btn--ghost btn--sm" style={{ height:34 }} aria-label="Refresh board">⟳ Refresh</button>
+      </div>
+    </header>
+  );
+}
+
+/* global controls popover (design-only — honest/inert) */
+function ControlsSheet({ open, onClose }) {
+  const { CONTROLS, ROLES } = window.HERMES_DATA;
+  if (!open) return null;
+  return (
+    <>
+      <div onClick={onClose} style={{ position:'fixed', inset:0, zIndex:64 }} />
+      <div className="anim-rise" style={{ position:'fixed', top:60, right:18, width:'min(360px,92vw)', zIndex:65,
+        background:'var(--hm-paper)', border:'1px solid var(--hm-line)', borderRadius:'var(--r-card)', boxShadow:'var(--sh-lift)', padding:'16px 17px' }}>
+        <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:4 }}>
+          <span className="font-display" style={{ fontWeight:700, fontSize:15 }}>Operating mode</span>
+          <span style={{ fontSize:9, padding:'2px 7px', borderRadius:5, background:'var(--hm-paper-sunken)', color:'var(--hm-faint)', textTransform:'uppercase', fontWeight:700 }}>preview · not wired</span>
+        </div>
+        <p style={{ margin:'0 0 12px', fontSize:12.5, color:'var(--hm-muted)', lineHeight:1.5 }}>
+          Supervised — agents propose, you approve every mutation, merge and deploy.
+        </p>
+        <div style={{ display:'grid', gap:7 }}>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)' }}>This mode grants agents</div>
+          {['observe','propose tasks','open PRs','run CI'].map(g => (
+            <div key={g} style={{ display:'flex', alignItems:'center', gap:8, fontSize:12.5, color:'var(--hm-ink-2)' }}>
+              <span style={{ color:'var(--ok-text)', flex:'none' }}>✓</span>{g}
+            </div>
+          ))}
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginTop:6 }}>It restricts</div>
+          {['merge','deploy','spend','touch prod data'].map(g => (
+            <div key={g} style={{ display:'flex', alignItems:'center', gap:8, fontSize:12.5, color:'var(--hm-faint)' }}>
+              <span style={{ flex:'none' }}>✕</span><span style={{ textDecoration:'line-through' }}>{g}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop:13, paddingTop:12, borderTop:'1px solid var(--hm-line-2)', fontSize:11, color:'var(--hm-faint)', lineHeight:1.5 }}>
+          Switching modes and pausing agents need the real control backend — inert in this prototype.
+        </div>
+      </div>
+    </>
+  );
+}
+function StatusChip({ c }) {
+  const primary = c.primary && c.count > 0;
+  return (
+    <span className="font-display" style={{
+      flex:'none', display:'inline-flex', alignItems:'center', gap:8, height:30, padding:'0 12px',
+      borderRadius:'var(--r-pill)', fontSize:11.5, fontWeight:700, textTransform:'uppercase',
+      border:`1px solid ${primary ? 'var(--hm-line-strong)' : 'var(--hm-line)'}`,
+      background: c.count>0 ? 'var(--hm-paper)' : 'transparent',
+      color: c.count>0 ? 'var(--hm-ink-2)' : 'var(--hm-faint)' }}>
+      {primary && <span style={{ width:6, height:6, borderRadius:'50%', background:'var(--act)', flex:'none' }} />}
+      <span style={{ fontFamily:'var(--font-mono)', fontWeight:600, color: c.count>0?'var(--hm-ink)':'var(--hm-faint)' }}>{c.count}</span>
+      {c.label}
+    </span>
+  );
+}
+
+/* ───────────────── needs-you banner — compact status bar with a primary action ───────────────── */
+function NeedsYouBanner({ clock, onJump, wide, cards }) {
+  cards = cards || window.HERMES_DATA.CARDS;
+  const decisions = cards.filter(c => c.waitingOn === 'operator');
+  const n = decisions.length;
+  const urgent = decisions.find(c => c.urgent) || decisions[0];
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  /* calm state (0 decisions) — single line */
+  if (n === 0) {
+    return (
+      <div style={{ display:'flex', alignItems:'center', gap:12, padding:'10px 16px',
+        borderRadius:'var(--r-btn)', background:'var(--hm-paper)', border:'1px solid var(--ok-line)' }}>
+        <span style={{ flex:'none', width:24, height:24, borderRadius:7, background:'var(--ok-soft)', display:'grid', placeItems:'center', color:'var(--ok-text)', fontSize:13 }}>✓</span>
+        <span className="font-display" style={{ fontWeight:700, fontSize:14, color:'var(--ok-text)', flex:'none' }}>Nothing needs you</span>
+        <span style={{ fontSize:13, color:'var(--hm-muted)' }}>Prod healthy · agents working — watch the lanes below.</span>
+        <span className="mono" style={{ marginLeft:'auto', fontSize:11.5, color:'var(--hm-faint)', flex:'none' }}>{clock}</span>
+      </div>
+    );
+  }
+
+  /* collapsed by operator — single coral line */
+  if (collapsed) {
+    return (
+      <button onClick={()=>setCollapsed(false)} style={{ width:'100%', textAlign:'left', display:'flex', alignItems:'center', gap:11,
+        padding:'9px 14px', borderRadius:'var(--r-btn)', cursor:'pointer',
+        background:'linear-gradient(120deg, var(--act-soft), transparent 70%, var(--hm-paper))', border:'1px solid var(--act-line)' }}>
+        <span className="dot live-dot" style={{ width:7, height:7, borderRadius:'50%', background:'var(--act)', flex:'none' }} />
+        <span className="font-display" style={{ fontWeight:700, fontSize:13.5, color:'var(--act-text)', flex:'none' }}>{n} waiting on you</span>
+        <span style={{ fontSize:12.5, color:'var(--hm-muted)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+          most urgent: {urgent.title}
+        </span>
+        <span className="font-display" style={{ marginLeft:'auto', fontSize:11.5, fontWeight:600, color:'var(--hm-faint)', flex:'none' }}>expand ▾</span>
+      </button>
+    );
+  }
+
+  /* default — dense status bar: badge · one-line summary · chips · inline CTA */
+  return (
+    <div className="breathe" style={{ position:'relative', overflow:'hidden',
+      padding:'15px 17px 14px 19px', borderRadius:'var(--r-card)',
+      background:'linear-gradient(120deg, var(--act-soft), transparent 64%, var(--hm-paper))', border:'1px solid var(--act-line)' }}>
+      <span style={{ position:'absolute', left:0, top:0, bottom:0, width:4, background:'var(--act)' }} />
+
+      {/* row 1: badge + headline/context + inline CTA */}
+      <div style={{ display:'flex', alignItems:'center', gap:14 }}>
+        <div style={{ position:'relative', flex:'none', width:44, height:44, borderRadius:12, background:'var(--act-soft-2)',
+          display:'grid', placeItems:'center', color:'var(--act-text)', fontFamily:'var(--font-display)', fontWeight:700, fontSize:21, boxShadow:'var(--act-glow)' }}>
+          {n}
+          <span className="breathe-ring" style={{ position:'absolute', inset:0, borderRadius:12, boxShadow:'0 0 0 2.5px var(--act)' }} />
+        </div>
+
+        <div style={{ flex:1, minWidth:0 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:3, minWidth:0 }}>
+            <span className="dot live-dot" style={{ width:6, height:6, borderRadius:'50%', background:'var(--act)', flex:'none' }} />
+            <h1 className="font-display" style={{ margin:0, fontWeight:700, fontSize:18, lineHeight:1.1, color:'var(--hm-ink)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap', minWidth:0 }}>{n} decisions waiting on you</h1>
+          </div>
+          <div style={{ fontSize:12.5, color:'var(--hm-muted)', minWidth:0, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>
+            Most urgent: <strong style={{ color:'var(--hm-ink-2)', fontWeight:600 }}>{urgent.title}</strong>
+            {urgent.decision && <> — suggests <span style={{ color:'var(--act-text)', fontWeight:600 }}>{urgent.decision.recommended}</span></>}
+          </div>
+        </div>
+
+        <div style={{ display:'flex', alignItems:'center', gap:7, flex:'none' }}>
+          <button className="btn btn--act btn--sm" onClick={onJump} style={{ whiteSpace:'nowrap' }}>Review most urgent ↵</button>
+          <button onClick={()=>setCollapsed(true)} title="Collapse" aria-label="Collapse status bar"
+            style={{ width:28, height:28, borderRadius:7, border:'1px solid var(--act-line)', background:'transparent', color:'var(--act-text)', cursor:'pointer', fontSize:12, lineHeight:1, flex:'none' }}>▴</button>
+        </div>
+      </div>
+
+      {/* row 2: most-urgent-because chips */}
+      {urgent.reasonChips && (
+        <div style={{ display:'flex', alignItems:'center', gap:7, marginTop:12, paddingLeft:58, flexWrap:'wrap' }}>
+          <span className="eyebrow" style={{ fontSize:8.5, color:'var(--hm-faint)', flex:'none' }}>most urgent because</span>
+          {urgent.reasonChips.map((r,i) => (
+            <span key={i} className="chip" style={{ padding:'2px 9px', fontSize:11, color:'var(--hm-ink-2)', flex:'none' }}>{r}</span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ───────────────── toolbar ───────────────── */
+function Toolbar({ active, onFilter }) {
+  const { FILTERS } = window.HERMES_DATA;
+  return (
+    <div style={{ display:'flex', alignItems:'center', gap:14, flexWrap:'wrap' }}>
+      <div style={{ position:'relative', flex:'none', width:280 }}>
+        <input placeholder="Search PR, repo, correlation" className="mono" style={{ width:'100%', height:38, padding:'0 36px 0 14px',
+          borderRadius:'var(--r-btn)', border:'1px solid var(--hm-line)', background:'var(--hm-paper)', fontSize:12.5, color:'var(--hm-ink)', outline:'none' }} />
+        <span className="chip" style={{ position:'absolute', right:7, top:7, padding:'2px 7px' }}>/</span>
+      </div>
+      <span style={{ fontSize:12.5, color:'var(--hm-muted)' }}>focus on the lane that needs you</span>
+      <div style={{ marginLeft:'auto', display:'flex', alignItems:'center', gap:10 }}>
+        <span style={{ fontSize:12, color:'var(--hm-faint)' }}>sorted by next-action urgency</span>
+        <div style={{ display:'flex', gap:6 }}>
+          {FILTERS.map(f => (
+            <button key={f.id} onClick={() => onFilter(f.id)} className="font-display" style={{
+              display:'inline-flex', alignItems:'center', gap:7, height:30, padding:'0 12px', borderRadius:'var(--r-pill)',
+              cursor:'pointer', fontSize:12, fontWeight:600,
+              border:`1px solid ${active===f.id ? 'transparent':'var(--hm-line)'}`,
+              background: active===f.id ? 'var(--hm-ink)' : 'var(--hm-paper)',
+              color: active===f.id ? 'var(--hm-paper)' : (f.count>0?'var(--hm-ink-2)':'var(--hm-faint)') }}>
+              {f.label}<span className="mono" style={{ fontSize:11, opacity:0.8 }}>{f.count}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UtilitiesRow() {
+  return (
+    <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:12,
+      padding:'10px 16px', borderRadius:'var(--r-btn)', background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:10 }}>
+        <span style={{ color:'var(--hm-faint)' }}>▸</span>
+        <span className="font-display" style={{ fontWeight:600, fontSize:13 }}>Utilities</span>
+        <span style={{ fontSize:13, color:'var(--hm-muted)' }}>LLM usage · suites · tester launcher</span>
+      </div>
+      <span className="mono" style={{ fontSize:12, color:'var(--hm-faint)' }}>17K tokens · no suites · tester ready</span>
+    </div>
+  );
+}
+
+/* ───────────────── tier heading ───────────────── */
+function TierHead({ eyebrow, title, count, act, dim }) {
+  return (
+    <div style={{ display:'flex', alignItems:'flex-end', justifyContent:'space-between', gap:12, marginBottom:12, opacity: dim?0.72:1 }}>
+      <div>
+        {eyebrow && <Lab act={act} style={{ display:'block', marginBottom:4 }}>{eyebrow}</Lab>}
+        <div className="font-display" style={{ fontWeight:700, fontSize:dim?15:17, color:dim?'var(--hm-muted)':'var(--hm-ink)' }}>{title}</div>
+      </div>
+      {count!=null && <span className="eyebrow" style={{ flex:'none' }}><CountTween value={count} /> cards</span>}
+    </div>
+  );
+}
+
+/* ───────────────── DECIDE ───────────────── */
+function DecideTier({ onOpenCard, expandedId, setExpandedId }) {
+  const { DECIDE } = window.HERMES_DATA;
+  return (
+    <section data-screen-label="DECIDE">
+      <TierHead eyebrow={DECIDE.eyebrow} title={DECIDE.title} count={DECIDE.cards.length} act />
+      <div style={{ background:'linear-gradient(180deg, rgba(217,119,87,0.05), transparent 40%)',
+        border:'1px solid var(--act-line)', borderRadius:'var(--r-lane)', padding:'var(--pad-lane)' }}>
+        <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:12 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:10 }}>
+            <span className="font-display" style={{ fontWeight:700, fontSize:15, whiteSpace:'nowrap' }}>{DECIDE.lane.name}</span>
+            <Pill tone="act" style={{ minHeight:20, height:20, fontSize:10 }}>{DECIDE.cards.length}</Pill>
+          </div>
+          <Lab act>{DECIDE.lane.sub}</Lab>
+        </div>
+        <div style={{ display:'grid', gap:'var(--gap-cards)' }}>
+          {DECIDE.cards.map(card => (
+            <DecideCard key={card.id} card={card}
+              expanded={expandedId===card.id}
+              onToggle={() => setExpandedId(expandedId===card.id ? null : card.id)}
+              onOpen={() => onOpenCard(card.id)} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function DecideCard({ card, expanded, onToggle, onOpen }) {
+  return (
+    <article id={card.id} className={cx('anim-slide hover-lift', card.urgent && expanded && 'breathe')} style={{
+      background:'var(--hm-paper)', borderRadius:'var(--r-card)', border:'1px solid var(--hm-line)',
+      borderLeft:`3px solid ${expanded ? 'var(--act)' : 'var(--hm-line)'}`, boxShadow:'var(--sh-sm)', overflow:'hidden' }}>
+      <div className="click" onClick={onToggle} style={{ padding:'var(--pad-card)' }}>
+        <AuthorLine authorId={card.author} mono={card.id} freshness={card.freshness} />
+        <h3 className="font-display" style={{ margin:'12px 0 6px', fontSize:19, fontWeight:700 }}>{card.title}</h3>
+        <div style={{ fontSize:14, color:'var(--warn-text)', fontWeight:500 }}>{card.status}</div>
+
+        <div style={{ display:'flex', alignItems:'center', gap:10, marginTop:14, flexWrap:'wrap' }}>
+          <Lab>Tester run</Lab>
+          <Pill tone="warn" dot>{card.tester.verdict} {card.tester.pct}</Pill>
+          <span className="mono" style={{ fontSize:12, color:'var(--hm-muted)' }}>{card.tester.target}</span>
+        </div>
+
+        <div style={{ marginTop:12 }}>
+          <Lab style={{ display:'block', marginBottom:5 }}>{card.blocker.label}</Lab>
+          <div style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'7px 12px', borderRadius:'var(--r-sm)',
+            background:'var(--warn-soft)', border:'1px solid var(--warn-line)' }}>
+            <span style={{ width:7, height:7, borderRadius:'50%', background:'var(--warn)' }} />
+            <span className="font-display" style={{ fontSize:12.5, fontWeight:600, textTransform:'uppercase', color:'var(--warn-text)', whiteSpace:'nowrap' }}>{card.blocker.value}</span>
+          </div>
+        </div>
+
+        <div style={{ display:'flex', gap:7, marginTop:12, flexWrap:'wrap' }}>
+          {card.chips.map((c,i) => <span key={i} className="chip">{c}</span>)}
+        </div>
+        <p style={{ margin:'12px 0 0', fontSize:13.5, color:'var(--hm-muted)', display:'-webkit-box', WebkitLineClamp:expanded?99:2, WebkitBoxOrient:'vertical', overflow:'hidden' }}>{card.body}</p>
+      </div>
+
+      {expanded && (
+        <div className="anim-rise" style={{ padding:'0 var(--pad-card) var(--pad-card)' }}>
+          {/* agent discussion */}
+          <div style={{ background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', padding:'12px 14px', marginBottom:14 }}>
+            <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:10 }}>
+              <PresenceDot presence="active" color={AGENTS.hermes.color} size={8} />
+              <Lab>Agent discussion</Lab>
+            </div>
+            <div style={{ display:'flex', gap:10 }}>
+              <AgentAvatar agent={AGENTS[card.discussion.author]} size={26} />
+              <div style={{ minWidth:0 }}>
+                <div style={{ display:'flex', alignItems:'center', gap:8 }}>
+                  <span className="font-display" style={{ fontWeight:600, fontSize:13, color:AGENTS[card.discussion.author].color }}>{AGENTS[card.discussion.author].name}</span>
+                  <span className="mono" style={{ fontSize:11, color:'var(--hm-faint)' }}>{card.discussion.time}</span>
+                </div>
+                <p style={{ margin:'4px 0 0', fontSize:13.5, color:'var(--hm-ink-2)', lineHeight:1.6 }}>{card.discussion.text}</p>
+                <span className="chip" style={{ marginTop:9 }}>testbed</span>
+              </div>
+            </div>
+          </div>
+
+          <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:12 }}>
+            <Lab>Waiting on</Lab>
+            <Pill tone="act" dot style={{ minHeight:22 }}>→ Operator</Pill>
+          </div>
+
+          <div className="focus-row" style={{ display:'grid', gridTemplateColumns:'1.2fr 1fr 1fr', gap:9, marginBottom:12 }}>
+            {card.actions.map(a => (
+              <button key={a.id} className={cx('btn', a.kind==='act'?'btn--act':'btn--ghost')}>{a.label}</button>
+            ))}
+          </div>
+
+          <div style={{ display:'flex', alignItems:'center', gap:10, padding:'10px 14px', borderRadius:'var(--r-sm)',
+            background:'var(--ok-soft)', border:'1px solid var(--ok-line)' }}>
+            <Lab style={{ color:'var(--ok-text)' }}>Hermes verdict</Lab>
+            <span style={{ fontSize:13.5, color:'var(--ok-text)', fontWeight:500 }}>{card.verdict}</span>
+            <button className="btn btn--sm" onClick={(e)=>{e.stopPropagation();onOpen();}} style={{ marginLeft:'auto', background:'transparent', color:'var(--ok-text)', border:'1px solid var(--ok-line)' }}>Open card ↗</button>
+          </div>
+        </div>
+      )}
+
+      {!expanded && (
+        <div className="click" onClick={onToggle} style={{ display:'flex', alignItems:'center', justifyContent:'space-between',
+          padding:'10px var(--pad-card)', borderTop:'1px solid var(--hm-line-2)', background:'var(--hm-paper-sunken)' }}>
+          <span style={{ display:'flex', alignItems:'center', gap:8 }}>
+            <Lab>Waiting on</Lab><Pill tone="act" style={{ minHeight:20, height:20, fontSize:10 }}>→ Operator</Pill>
+          </span>
+          <span className="font-display" style={{ fontSize:12.5, fontWeight:600, color:'var(--act-text)' }}>Expand to decide ↓</span>
+        </div>
+      )}
+    </article>
+  );
+}
+
+window.Board = { TopBar, ControlsSheet, NeedsYouBanner, Toolbar, TierHead, DecideTier, AuthorLine };

--- a/docs/design/hermes-4/project/data.jsx
+++ b/docs/design/hermes-4/project/data.jsx
@@ -1,0 +1,333 @@
+/* Hermes seed data — exported to window.HERMES_DATA
+   ─────────────────────────────────────────────────────────────
+   HONESTY CONTRACT (port note for engineers):
+   • Cards/threads below are the REAL board snapshot.
+   • Fields that need a real backend the prototype lacks — heartbeat,
+     real cost, confirmed dedupe, live "since you last looked" deltas —
+     are NOT fabricated. They carry honest placeholders (—, ?, "awaiting
+     data") and are tagged `needsData:true` where relevant.
+   • `DEMO_TIMELINE` is a SYNTHETIC design-eval scaffold (Demo toggle only,
+     every entry demo:true) and MUST be stripped from the production port.
+   • Data model is 1:1 with monitor-ui.
+*/
+
+const AGENTS = {
+  hermes:   { id:'hermes',      name:'Hermes',      mark:'H', color:'var(--ag-hermes)', role:'orchestrator', presence:'active' },
+  claude:   { id:'claude',      name:'Claude',      mark:'C', color:'var(--ag-claude)', role:'worker',       presence:'online' },
+  codex:    { id:'codex',       name:'Codex',       mark:'X', color:'var(--ag-codex)',  role:'worker',       presence:'online' },
+  test:     { id:'test-writer', name:'Test-writer', mark:'T', color:'var(--ag-test)',   role:'tester',       presence:'idle' },
+  operator: { id:'operator',    name:'You',         mark:'●', color:'var(--ag-op)',     role:'operator',     presence:'online' },
+  system:   { id:'system',      name:'System',      mark:'S', color:'var(--ag-system)', role:'system',       presence:'online' },
+};
+
+/* ── cast roster (I) — per-role capabilities. observe / mutate / approve ── */
+const ROLES = [
+  { id:'hermes', name:'Hermes', title:'Orchestrator', blurb:'Reviews output and routes work. Proposes and gates — never merges or deploys on its own.',
+    can:['observe','approve','route'], cannot:['mutate code','merge','deploy'], active:true },
+  { id:'claude', name:'Claude', title:'Builder', blurb:'Worker agent. Writes and changes code, opens PRs. Cannot merge or deploy.',
+    can:['observe','mutate code','open PR'], cannot:['merge','deploy','approve'], active:true },
+  { id:'codex', name:'Codex', title:'Builder', blurb:'Worker agent. Writes and changes code, opens PRs. Cannot merge or deploy.',
+    can:['observe','mutate code','open PR'], cannot:['merge','deploy','approve'], active:true },
+  { id:'test', name:'Test-writer', title:'QA', blurb:'Writes tests and replays captured traces. Observes only — never touches product code.',
+    can:['observe','write tests','replay'], cannot:['mutate product code','merge','approve'], active:true },
+  { id:'security', name:'Security', title:'Specialist', blurb:'Review-only security specialist. Not engaged on the current board.',
+    can:['observe','approve'], cannot:['mutate code','deploy'], active:false },
+  { id:'docs', name:'Docs', title:'Specialist', blurb:'Documentation specialist. Not engaged on the current board.',
+    can:['observe','write docs'], cannot:['mutate code','merge','deploy'], active:false },
+  { id:'operator', name:'You', title:'Operator', blurb:'The human. The only actor that can approve mutations, merges and deploys.',
+    can:['observe','approve','merge','deploy','reject'], cannot:[], active:true },
+];
+
+/* ── top status rail ── */
+const SELF_HEAL = 'Self-heal 1 open · dispatch 0/10 · quiet 27';
+/* heartbeat needs a real backend signal — honest placeholder, never faked */
+const HEARTBEAT = { value:null, label:'awaiting data', needsData:true };
+/* "since you last looked" needs a real session backend — this marker is design-only */
+const LAST_LOOKED = { time:'13:18', needsData:true };
+/* global controls (design-only, not yet wired) */
+const CONTROLS = { mode:'supervised', paused:false, preview:true };
+
+const FILTERS = [
+  { id:'all', label:'All', count:9 },
+  { id:'blocked', label:'Blocked', count:2 },
+  { id:'review', label:'Decisions', count:6 },
+  { id:'running', label:'Running', count:2 },
+  { id:'done', label:'Done', count:4 },
+];
+
+/* =========================================================
+   UNIFIED CARD STORE (single source of truth)
+   stage ∈ codex | checking | opreview | queue | deploying | done
+   waitingOn:'operator' → appears in the Decision Inbox (actionable)
+   Badge families (G): state · risk · evidence · gate
+   ========================================================= */
+const MISSION_BODY = 'Read-only mission — the agent stopped before any mutation.';
+
+const CARDS = [
+  /* ---- failed browser mission — most-urgent decision ---- */
+  {
+    id:'fresh-agent-browser-mission--mpz9rsmn-1c', threadId:'mpz9rsmn-1c',
+    stage:'opreview', waitingOn:'operator', urgent:true,
+    author:'hermes', type:'browser mission', title:'Fresh-agent browser mission', repo:'en.wikipedia.org',
+    state:{ label:'Failed', kind:'failed' },
+    risk:{ level:'low', type:'test' },
+    failureClass:'Infra',
+    evidence:[ {k:'traces', n:8}, {k:'shots', n:2}, {k:'video'}, {k:'replay'} ],
+    gate:'operator',
+    whySeeing:'Automation stopped: a fresh-agent run timed out and needs your call before any retry.',
+    reasonChips:['blocked 4h','blocks 2 tasks','low risk','safe rerun'],
+    unblock:null,
+    env:{ environment:'testbed', identity:'fresh agent · no memory', dataMode:'read-only', browser:'chromium 124', viewport:'1280×800' },
+    contract:{ target:'https://en.wikipedia.org/', flow:'Surface Sweep (read-only)', mode:'read-only · no mutation', success:'reaches citation block, no boundary crossed', stop:'45s nav budget or any mutation attempt', budget:'≤ 1 run · 45s', artifacts:'traces · screenshots · video · replay' },
+    forensic:{
+      expectedObserved:[
+        { field:'first paint', expected:'< 5s', observed:'timed out at 30s', ok:false },
+        { field:'mutation boundary', expected:'none crossed', observed:'none crossed', ok:true },
+        { field:'console errors', expected:'0', observed:'awaiting data', needsData:true },
+      ],
+      timeline:[
+        { t:'+0.0s', e:'runner claimed testbed slot' },
+        { t:'+0.4s', e:'chromium launched (headless)' },
+        { t:'+0.6s', e:'GET en.wikipedia.org · budget 45s' },
+        { t:'+30.0s', e:'nav budget exceeded — no first paint' },
+        { t:'+30.1s', e:'runner aborted · 8 traces captured' },
+      ],
+      failureFrame:'last frame before abort',
+    },
+    body: MISSION_BODY + ' Runner failed before crossing any boundary.',
+    whatNext:'Approving dispatches a fresh read-only re-run; you’ll watch it live and decide again on the result.',
+    convertPreview:{ creates:'Bug in depre-dev/agent', title:'Fresh-agent mission times out before first paint', labels:['infra','testbed'], assignee:'unassigned', needsData:true },
+    decision:{
+      recommended:'Rerun once with 45s nav budget',
+      why:'Timed out before first paint; a cold fresh-agent run needs more nav headroom.',
+      grants:'browser test only · read-only · 45s timeout · no code changes',
+      denies:'no merge · no deploy · no spend · no prod data',
+      blast:{ repo:'en.wikipedia.org (target)', branch:'—', env:'testbed', area:'browser-runner', users:'none' },
+      rollback:'Nothing to roll back — read-only test. On failure it returns here to your inbox.',
+      choices:['Rerun once with 45s nav budget','Reject','Convert to bug','Ask Hermes','Open replay','Dismiss'],
+    },
+    discussion:{ author:'hermes', time:'11:04',
+      text:'I created a fresh-agent browser mission for https://en.wikipedia.org/. The mission is now on the board as testbed-mission-mpz9rsmn-1c. I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed.' },
+  },
+  /* ---- failed dry run — policy store down ---- */
+  {
+    id:'wikipedia-citation-repair-dry-run--mpz9gi3i-1b', threadId:'mpz9gi3i-1b',
+    stage:'opreview', waitingOn:'operator',
+    author:'hermes', type:'citation-repair · dry run', title:'Wikipedia citation-repair (dry run)', repo:'en.wikipedia.org',
+    state:{ label:'Blocked', kind:'blocked' },
+    risk:{ level:'low', type:'test' },
+    failureClass:'Infra',
+    evidence:[ {k:'traces', n:3} ],
+    gate:'operator',
+    whySeeing:'Automation stopped: the policy store returned 503, so the run could not start.',
+    unblock:'Policy store reachable again (503 clears), then re-run.',
+    env:{ environment:'testbed', identity:'fresh agent · no memory', dataMode:'read-only · dry run', browser:'chromium 124', viewport:'1280×800' },
+    contract:{ target:'https://en.wikipedia.org/', flow:'Citation Repair (dry run)', mode:'read-only · no claim, no submission', success:'policy loads, repair plan drafted', stop:'policy-store error or mutation attempt', budget:'≤ 1 run', artifacts:'traces' },
+    body: MISSION_BODY + ' Dry run — no Averray claim or submission attempted.',
+    whatNext:'Holding keeps it out of your inbox until the policy store recovers; nothing runs meanwhile.',
+    decision:{
+      recommended:'Hold for policy-store recovery',
+      why:'Blocked by a policy-store 503, not by the mission itself — retrying now will just fail again.',
+      grants:'browser test only · read-only · no code changes',
+      denies:'no merge · no deploy · no spend · no prod data',
+      blast:{ repo:'en.wikipedia.org (target)', branch:'—', env:'testbed', area:'browser-runner', users:'none' },
+      rollback:'Nothing to roll back — dry run, no claim or submission.',
+      choices:['Hold for policy-store recovery','Rerun','Convert to bug','Ask Hermes','Open replay','Dismiss'],
+    },
+    discussion:{ author:'hermes', time:'10:56',
+      text:'I created a fresh-agent browser mission for https://en.wikipedia.org/. The mission is now on the board as testbed-mission-mpz9gi3i-1b. I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed.' },
+  },
+  {
+    id:'wikipedia-citation-repair-dry-run--mpz9uldc-1d', threadId:'mpz9uldc-1d',
+    stage:'opreview', waitingOn:'operator',
+    author:'hermes', type:'citation-repair · dry run', title:'Wikipedia citation-repair (dry run)', repo:'en.wikipedia.org',
+    state:{ label:'Blocked', kind:'blocked' },
+    risk:{ level:'low', type:'test' },
+    failureClass:'Infra',
+    evidence:[ {k:'traces', n:3} ],
+    gate:'operator',
+    whySeeing:'Automation stopped: the policy store returned 503, so the run could not start.',
+    unblock:'Policy store reachable again (503 clears), then re-run.',
+    dedupe:{ label:'possible duplicate of mpz9gi3i-1b', needsData:true },
+    env:{ environment:'testbed', identity:'fresh agent · no memory', dataMode:'read-only · dry run', browser:'chromium 124', viewport:'1280×800' },
+    contract:{ target:'https://en.wikipedia.org/', flow:'Citation Repair (dry run)', mode:'read-only · no claim, no submission', success:'policy loads, repair plan drafted', stop:'policy-store error or mutation attempt', budget:'≤ 1 run', artifacts:'traces' },
+    body: MISSION_BODY + ' Dry run — no Averray claim or submission attempted.',
+    whatNext:'Rejecting closes this card as a duplicate; reopen from Done if it proves separate.',
+    convertPreview:{ creates:'Bug in depre-dev/agent', title:'Policy store 503 blocks citation-repair dry runs', labels:['infra','policy-store'], assignee:'unassigned', needsData:true },
+    decision:{
+      recommended:'Reject as duplicate',
+      why:'Looks like the same policy-store outage as mpz9gi3i-1b — but dedupe is unconfirmed (awaiting data).',
+      grants:'closes this card only · no code changes',
+      denies:'no merge · no deploy · no spend · no prod data',
+      blast:{ repo:'en.wikipedia.org (target)', branch:'—', env:'testbed', area:'browser-runner', users:'none' },
+      rollback:'Reopen from Done if it turns out to be a separate failure.',
+      choices:['Reject as duplicate','Rerun','Hold','Ask Hermes','Open replay','Dismiss'],
+    },
+    discussion:{ author:'hermes', time:'11:10',
+      text:'I created a fresh-agent browser mission for https://en.wikipedia.org/. The mission is now on the board as testbed-mission-mpz9uldc-1d. I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed.' },
+  },
+
+  /* ---- proposed codex tasks (stage codex) — waiting on operator ---- */
+  {
+    id:'codex-task-testbed-mission-new-20260604T115119265Z-fk01m9',
+    stage:'codex', waitingOn:'operator',
+    author:'claude', type:'task', title:'Add citation_repair mission mode', repo:'depre-dev/averray-reference-agent',
+    state:{ label:'Proposed', kind:'ready' },
+    risk:{ level:'low', type:'code' },
+    evidence:[ {k:'pr', n:null} ],
+    gate:'operator',
+    freshness:'Fresh 1.7h',
+    whySeeing:'Policy requires approval because dispatching creates a branch and opens a PR.',
+    unblock:null,
+    whatNext:'Approving dispatches the task to a builder; it opens a PR and runs CI — no merge without your second approval.',
+    convertPreview:{ creates:'Bug in depre-dev/averray-reference-agent', title:'citation_repair mission mode missing', labels:['feature'], assignee:'unassigned', needsData:true },
+    decision:{
+      recommended:'Approve & dispatch',
+      why:'Read-only feature addition; no auth or prod surface touched.',
+      grants:'create branch · open PR · run CI · no merge, no deploy',
+      denies:'no merge · no deploy · no prod data · no spend',
+      blast:{ repo:'depre-dev/averray-reference-agent', branch:'feat/citation-mode', env:'CI only', area:'missions', users:'none' },
+      rollback:'Close the PR — nothing merges without a second approval.',
+      choices:['Approve & dispatch','Reject','Edit task','Ask Hermes','Dismiss'],
+    },
+  },
+  {
+    id:'codex-task-testbed-mission-new-20260604T082128545Z-96otu1',
+    stage:'codex', waitingOn:'operator',
+    author:'claude', type:'task', title:'Fix /auth/verify KMS-JWT auth', repo:'depre-dev/averray-reference-agent',
+    state:{ label:'Proposed', kind:'ready' },
+    risk:{ level:'med', type:'code' },
+    evidence:[ {k:'pr', n:null} ],
+    gate:'operator',
+    freshness:'Fresh 5.2h',
+    whySeeing:'Policy requires approval because this modifies the auth path.',
+    unblock:null,
+    whatNext:'Approving opens a PR and runs CI; the auth change still needs your explicit merge before it reaches prod.',
+    convertPreview:{ creates:'Bug in depre-dev/averray-reference-agent', title:'/auth/verify rejects valid KMS-JWT', labels:['bug','auth'], assignee:'unassigned', needsData:true },
+    decision:{
+      recommended:'Approve & dispatch with extra review',
+      why:'Touches the auth path — medium risk; CI plus your review gate the merge.',
+      grants:'create branch · open PR · run CI · no merge',
+      denies:'no merge · no deploy · no prod data · no spend',
+      blast:{ repo:'depre-dev/averray-reference-agent', branch:'fix/kms-jwt-verify', env:'CI only', area:'auth', users:'none until merged' },
+      rollback:'Close the PR — auth changes never reach prod without your merge.',
+      choices:['Approve & dispatch','Reject','Edit task','Ask Hermes','Dismiss'],
+    },
+  },
+  {
+    id:'codex-task-testbed-mission-new-20260604T082127110Z-wt0crk',
+    stage:'codex', waitingOn:'operator',
+    author:'claude', type:'task', title:'Harden testbed runner nav budget', repo:'depre-dev/averray-reference-agent',
+    state:{ label:'Proposed', kind:'ready' },
+    risk:{ level:'low', type:'code' },
+    evidence:[ {k:'pr', n:null} ],
+    gate:'operator',
+    freshness:'Fresh 5.2h',
+    whySeeing:'Policy requires approval because dispatching creates a branch and opens a PR.',
+    unblock:null,
+    whatNext:'Approving dispatches the task to a builder; it opens a PR and runs CI — no merge without your second approval.',
+    convertPreview:{ creates:'Bug in depre-dev/averray-reference-agent', title:'Testbed runner nav budget too tight for cold starts', labels:['infra'], assignee:'unassigned', needsData:true },
+    decision:{
+      recommended:'Approve & dispatch',
+      why:'Config-only change to the testbed runner; low blast radius.',
+      grants:'create branch · open PR · run CI · no merge, no deploy',
+      denies:'no merge · no deploy · no prod data · no spend',
+      blast:{ repo:'depre-dev/averray-reference-agent', branch:'chore/nav-budget', env:'CI only', area:'testbed-runner', users:'none' },
+      rollback:'Close the PR — nothing merges without a second approval.',
+      choices:['Approve & dispatch','Reject','Edit task','Ask Hermes','Dismiss'],
+    },
+  },
+
+  /* ---- running: post-merge deploy verification (stage deploying) ---- */
+  {
+    id:'post-production-deploy-verification', stage:'deploying', waitingOn:null,
+    author:'system', type:'deploy-verify', title:'Current deploy: verifying', repo:'depre-dev/agent',
+    grouped:3,
+    state:{ label:'Verifying', kind:'running' },
+    risk:{ level:'low', type:'deploy' },
+    evidence:[ {k:'tests'}, {k:'ci'} ],
+    gate:'system',
+    whySeeing:null,
+    checkpoints:[
+      { label:'CI queued', state:'done' },
+      { label:'install', state:'done' },
+      { label:'unit tests', state:'done' },
+      { label:'browser replay', state:'current' },
+      { label:'Hermes review', state:'todo' },
+      { label:'ready', state:'todo' },
+    ],
+    body:'3 near-identical verification cards grouped. Expand to inspect each one.',
+  },
+
+  /* ---- done (release history) ---- */
+  { id:'post-production-deploy-verification--3f2a', stage:'done', waitingOn:null, author:'system', type:'deploy-verify', title:'post-production-deploy verification', repo:'depre-dev/agent', state:{ label:'Verified', kind:'done' }, gate:'system', verdict:'deploy ok' },
+  { id:'post-production-deploy-verification--9b71', stage:'done', waitingOn:null, author:'system', type:'deploy-verify', title:'post-production-deploy verification', repo:'depre-dev/agent', state:{ label:'Verified', kind:'done' }, gate:'system', verdict:'deploy ok' },
+  { id:'post-production-deploy-verification--c08d', stage:'done', waitingOn:null, author:'system', type:'deploy-verify', title:'post-production-deploy verification', repo:'depre-dev/agent', state:{ label:'Verified', kind:'done' }, gate:'system', verdict:'deploy ok' },
+  { id:'branch-protection-sync--a14e', stage:'done', waitingOn:null, author:'system', type:'branch-sync', title:'branch-protection sync', repo:'depre-dev/agent', state:{ label:'Verified', kind:'done' }, gate:'system', verdict:'verified' },
+];
+
+/* pipeline lane definitions (left→right). gate:true lanes stay visible even empty (K). */
+const LANES = [
+  { id:'inbox',     name:'Your decisions',     sub:'Everything waiting on you',  tier:'decide', inbox:true, gate:true },
+  { id:'codex',     name:'Builder tasks',      sub:'Proposed by Claude / Codex', tier:'watch' },
+  { id:'checking',  name:'Hermes checking',    sub:'Verifying',                  tier:'watch' },
+  { id:'opreview',  name:'Runs needing review',sub:'Failed / finished runs',     tier:'decide', gate:true },
+  { id:'queue',     name:'Release queue',      sub:'Staged for release',         tier:'hide' },
+  { id:'deploying', name:'Deploying',          sub:'Verifying post-merge',       tier:'watch' },
+  { id:'done',      name:'Done',               sub:'Release history',            tier:'hide' },
+];
+
+/* ── ROOM: real threads (kind:status, hermes → you) ── */
+const THREADS = [
+  { id:'mpz9gi3i-1b', cardRef:'wikipedia-citation-repair-dry-run--mpz9gi3i-1b',
+    turns:[ { id:'t1', author:'hermes', target:'operator', kind:'status', time:'10:56',
+      text:'I created a fresh-agent browser mission for https://en.wikipedia.org/. The mission is now on the board as testbed-mission-mpz9gi3i-1b. I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed.' } ] },
+  { id:'mpz9rsmn-1c', cardRef:'fresh-agent-browser-mission--mpz9rsmn-1c',
+    turns:[ { id:'t2', author:'hermes', target:'operator', kind:'status', time:'11:04',
+      text:'I created a fresh-agent browser mission for https://en.wikipedia.org/. The mission is now on the board as testbed-mission-mpz9rsmn-1c. I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed.' } ] },
+  { id:'mpz9uldc-1d', cardRef:'wikipedia-citation-repair-dry-run--mpz9uldc-1d',
+    turns:[ { id:'t3', author:'hermes', target:'operator', kind:'status', time:'11:10',
+      text:'I created a fresh-agent browser mission for https://en.wikipedia.org/. The mission is now on the board as testbed-mission-mpz9uldc-1d. I will hand it to the Hermes testbed runner; when the runner returns a structured report, I will attach it here and explain what changed.' } ] },
+];
+
+/* ── SYNTHETIC demo timeline (Demo toggle only — stripped in prod) ── */
+const DEMO_TIMELINE = [
+  { at:600,  type:'presence', agent:'codex', presence:'active' },
+  { at:700,  type:'typing',   threadId:'mpz9rsmn-1c', agent:'codex' },
+  { at:2100, type:'turn', threadId:'mpz9rsmn-1c', turn:{
+      author:'codex', target:'hermes', kind:'request_help', time:'now', demo:true,
+      text:'Re-run keeps timing out before first paint. Is the nav budget the limit, or is the read-only boundary stopping the page from settling? I can\u2019t tell from the 8 traces.' } },
+  { at:2600, type:'typing', threadId:'mpz9rsmn-1c', agent:'hermes' },
+  { at:4200, type:'turn', threadId:'mpz9rsmn-1c', turn:{
+      author:'hermes', target:'codex', kind:'proposal', time:'now', demo:true,
+      text:'Proposal: raise the nav budget to 45s for this fresh-agent class and keep the read-only boundary. That covers a cold first paint without weakening the mutation guard. Needs operator ok before re-run.' } },
+  { at:4600, type:'presence', agent:'codex', presence:'online' },
+  { at:5400, type:'turn', threadId:'mpz9gi3i-1b', turn:{
+      author:'claude', target:'everyone', kind:'chat', time:'now', demo:true,
+      text:'Seeing the same policy-store 503 on the dry-run side (mpz9gi3i-1b). Likely one outage, not two missions. Holding my re-run until it clears.' } },
+  { at:6000, type:'presence', agent:'test', presence:'active' },
+  { at:6200, type:'turn', threadId:'mpz9rsmn-1c', turn:{
+      author:'test', target:'hermes', kind:'status', time:'now', demo:true,
+      text:'Replaying the 8 captured traces for mpz9rsmn-1c so the re-run starts from a known state.' } },
+  { at:7400, type:'presence', agent:'test', presence:'idle' },
+];
+
+const KIND_META = {
+  request_help: { label:'Needs help', tone:'act',  rank:3 },
+  proposal:     { label:'Proposal',   tone:'ok',   rank:2 },
+  review:       { label:'Review',     tone:'act',  rank:2 },
+  chat:         { label:'Chat',       tone:'ink',  rank:1 },
+  status:       { label:'Status',     tone:'tel',  rank:0 },
+};
+
+/* evidence label map (G — Evidence family) */
+const EVIDENCE_LABEL = {
+  traces:(n)=>`${n} traces`, shots:(n)=>`${n} shots`, video:()=>'video', replay:()=>'replay',
+  pr:(n)=>n?`PR #${n}`:'no PR yet', tests:()=>'tests', ci:()=>'CI', diff:()=>'diff', files:(n)=>`${n} files`,
+};
+
+window.HERMES_DATA = {
+  AGENTS, ROLES, SELF_HEAL, HEARTBEAT, LAST_LOOKED, CONTROLS, FILTERS,
+  CARDS, LANES, THREADS, DEMO_TIMELINE, KIND_META, EVIDENCE_LABEL,
+  CLOCK_START:'13:33:20',
+};

--- a/docs/design/hermes-4/project/drawer.jsx
+++ b/docs/design/hermes-4/project/drawer.jsx
@@ -1,0 +1,390 @@
+/* Hermes — card drawer (lifecycle: running live-follow → end-report, in place) */
+const { AGENTS: AGD, CARDS: CARDS_D, THREADS: THR_D } = window.HERMES_DATA;
+const K = window.Kanban;
+
+function cardKind(card) {
+  if (!card) return null;
+  if (card.stage === 'checking' && card.live) return 'live';
+  if (card.decision && card.waitingOn === 'operator') return 'decision';
+  if (card.state && card.state.kind === 'running') return 'running';
+  return 'info';
+}
+
+function Sec({ label, children, right }) {
+  return (
+    <div style={{ marginBottom:20 }}>
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:10 }}>
+        <Lab>{label}</Lab>{right}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ShotSlot({ label }) {
+  return (
+    <div style={{ position:'relative', aspectRatio:'16/10', borderRadius:'var(--r-sm)', overflow:'hidden',
+      background:'repeating-linear-gradient(135deg, var(--hm-paper-sunken), var(--hm-paper-sunken) 10px, var(--hm-surface) 10px, var(--hm-surface) 20px)',
+      border:'1px solid var(--hm-line)', display:'grid', placeItems:'center' }}>
+      <span className="chip" style={{ background:'var(--hm-paper)' }}>{label}</span>
+    </div>
+  );
+}
+
+function EvidenceSection({ card }) {
+  const traces = (card.evidence||[]).find(e=>e.k==='traces');
+  const hasVideo = (card.evidence||[]).some(e=>e.k==='video'||e.k==='replay');
+  const shots = (card.evidence||[]).find(e=>e.k==='shots');
+  return (
+    <Sec label="Evidence">
+      <div style={{ marginBottom:12 }}><K.EvidenceChips evidence={card.evidence||[]} /></div>
+      {shots && <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:10, marginBottom:10 }}><ShotSlot label="screenshot 1" /><ShotSlot label="screenshot 2" /></div>}
+      {hasVideo && (
+        <div style={{ position:'relative', aspectRatio:'16/8', borderRadius:'var(--r-sm)', background:'var(--hm-ink)', display:'grid', placeItems:'center', marginBottom: traces?12:0 }}>
+          <span style={{ width:44, height:44, borderRadius:'50%', background:'rgba(255,255,255,0.14)', display:'grid', placeItems:'center', color:'#fff', fontSize:15, paddingLeft:4 }}>▶</span>
+          <span className="chip" style={{ position:'absolute', left:10, bottom:10, background:'rgba(0,0,0,0.4)', color:'#fff', borderColor:'transparent' }}>session replay</span>
+        </div>
+      )}
+      {traces && (
+        <div style={{ border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', overflow:'hidden' }}>
+          {Array.from({length: traces.n||3}).map((_,i)=>(
+            <div key={i} style={{ display:'flex', alignItems:'center', gap:10, padding:'9px 12px', borderTop: i?'1px solid var(--hm-line-2)':'none', background: i%2?'var(--hm-paper-sunken)':'var(--hm-paper)' }}>
+              <span className="mono" style={{ fontSize:11.5, color:'var(--hm-faint)' }}>{String(i+1).padStart(2,'0')}</span>
+              <span className="mono" style={{ fontSize:12, color:'var(--hm-ink-2)' }}>trace-{card.threadId||card.id.slice(-6)}-{String(i+1).padStart(2,'0')}</span>
+              <span className="chip" style={{ marginLeft:'auto', padding:'1px 7px', fontSize:10.5 }}>captured</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </Sec>
+  );
+}
+
+/* ── live-follow view (requested → running) — refreshes from streamed card.live ── */
+function LiveFrame({ frames, target }) {
+  if (!frames || frames < 1) {
+    return (
+      <div style={{ position:'relative', aspectRatio:'16/9', borderRadius:'var(--r-sm)', border:'1px dashed var(--hm-line-strong)',
+        background:'var(--hm-paper-sunken)', display:'grid', placeItems:'center', color:'var(--hm-faint)' }}>
+        <div style={{ textAlign:'center' }}>
+          <div className="spin" style={{ width:18, height:18, margin:'0 auto 8px', borderRadius:'50%', border:'2px solid var(--hm-line-strong)', borderTopColor:'var(--hm-muted)' }} />
+          <div className="font-display" style={{ fontSize:12, fontWeight:600 }}>awaiting first frame</div>
+          <div className="mono" style={{ fontSize:10.5, marginTop:3 }}>runner has not streamed a screenshot yet</div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={{ position:'relative', aspectRatio:'16/9', borderRadius:'var(--r-sm)', overflow:'hidden', border:'1px solid var(--hm-line)',
+      background:'repeating-linear-gradient(135deg, var(--hm-paper-sunken), var(--hm-paper-sunken) 11px, var(--hm-surface) 11px, var(--hm-surface) 22px)' }}>
+      {/* faux browser chrome — clearly a demo slot, not a fabricated screenshot */}
+      <div style={{ position:'absolute', top:0, left:0, right:0, height:24, background:'var(--hm-paper)', borderBottom:'1px solid var(--hm-line-2)', display:'flex', alignItems:'center', gap:5, padding:'0 9px' }}>
+        <span style={{ width:7, height:7, borderRadius:'50%', background:'var(--warn)' }} />
+        <span style={{ width:7, height:7, borderRadius:'50%', background:'var(--hm-line-strong)' }} />
+        <span style={{ width:7, height:7, borderRadius:'50%', background:'var(--hm-line-strong)' }} />
+        <span className="mono" style={{ fontSize:9, color:'var(--hm-faint)', marginLeft:6, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{target}</span>
+      </div>
+      <div style={{ position:'absolute', inset:'24px 0 0', display:'grid', placeItems:'center' }}>
+        <span className="chip" style={{ background:'var(--hm-paper)', color:'var(--ag-claude)', borderColor:'rgba(112,72,182,0.3)' }}>live frame {frames} · demo stream</span>
+      </div>
+      <span style={{ position:'absolute', right:8, bottom:8, display:'inline-flex', alignItems:'center', gap:5, padding:'2px 8px', borderRadius:'var(--r-pill)', background:'rgba(0,0,0,0.42)', color:'#fff' }}>
+        <span className="live-dot" style={{ width:6, height:6, borderRadius:'50%', background:'#ff5a4d' }} />
+        <span className="mono" style={{ fontSize:9.5 }}>LIVE</span>
+      </span>
+    </div>
+  );
+}
+
+function LiveFollow({ card }) {
+  const live = card.live || { output:[], frames:0 };
+  const steps = card.checkpoints || [];
+  const cur = steps.find(s => s.state === 'current');
+  const tailRef = React.useRef(null);
+  React.useEffect(() => { const el = tailRef.current; if (el) el.scrollTop = el.scrollHeight; }, [live.output.length]);
+  return (
+    <>
+      {/* stage badge */}
+      <div style={{ display:'flex', alignItems:'center', gap:10, padding:'11px 13px', borderRadius:'var(--r-sm)',
+        background:'var(--ok-soft)', border:'1px solid var(--ok-line)', marginBottom:16 }}>
+        <span className="spin" style={{ width:14, height:14, borderRadius:'50%', border:'2px solid var(--ok-line)', borderTopColor:'var(--ok)', flex:'none' }} />
+        <div style={{ minWidth:0 }}>
+          <div className="eyebrow" style={{ fontSize:8.5, color:'var(--ok-text)' }}>Live · following</div>
+          <div className="font-display" style={{ fontSize:14, fontWeight:700, color:'var(--ok-text)' }}>running {cur ? cur.label : '…'}</div>
+        </div>
+        <span className="mono" style={{ marginLeft:'auto', fontSize:10.5, color:'var(--ok-text)', flex:'none' }}>no verdict yet</span>
+      </div>
+
+      <Sec label="Latest frame">
+        <LiveFrame frames={live.frames} target={card.repo} />
+      </Sec>
+
+      <Sec label="Recent output (rolling tail) · ~2s" right={<span className="chip" style={{ padding:'1px 7px', fontSize:9, color:'var(--ag-claude)', borderColor:'rgba(112,72,182,0.3)' }}>demo stream</span>}>
+        <div ref={tailRef} className="scroll-y" style={{ maxHeight:148, borderRadius:'var(--r-sm)', background:'var(--hm-ink)',
+          border:'1px solid var(--hm-line)', padding:'9px 11px', display:'flex', flexDirection:'column', gap:3 }}>
+          {live.output.length === 0
+            ? <span className="mono" style={{ fontSize:11, color:'rgba(255,255,255,0.4)' }}>awaiting runner output…</span>
+            : live.output.map((line, i) => (
+                <div key={i} className="mono" style={{ fontSize:11, color: i===live.output.length-1 ? 'rgba(255,255,255,0.92)' : 'rgba(255,255,255,0.55)', lineHeight:1.5, display:'flex', gap:8 }}>
+                  <span style={{ color:'rgba(255,255,255,0.3)', flex:'none' }}>{String(i+1).padStart(2,'0')}</span>
+                  <span style={{ minWidth:0, wordBreak:'break-word' }}>{line}</span>
+                </div>
+              ))}
+        </div>
+      </Sec>
+
+      <Sec label="Checkpoints"><K.CheckpointStepper steps={steps} /></Sec>
+    </>
+  );
+}
+
+/* ── #11 env / identity badges on missions ── */
+function EnvBadges({ env }) {
+  if (!env) return null;
+  const rows = [
+    ['environment', env.environment], ['identity', env.identity], ['data-mode', env.dataMode],
+    ['browser', env.browser], ['viewport', env.viewport],
+  ].filter(r => r[1]);
+  return (
+    <div style={{ display:'flex', gap:6, flexWrap:'wrap', marginBottom:18 }}>
+      {rows.map(([k,v]) => (
+        <span key={k} className="chip" style={{ padding:'3px 9px', fontSize:10.5, gap:6 }}>
+          <span className="eyebrow" style={{ fontSize:8, color:'var(--hm-faint)' }}>{k}</span>
+          <span style={{ color:'var(--hm-ink-2)' }}>{v}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/* ── #12 contract preview (target/flow/mode/success/stop/budget/artifacts) ── */
+function ContractPreview({ contract }) {
+  if (!contract) return null;
+  const rows = [
+    ['target', contract.target], ['flow', contract.flow], ['mode', contract.mode],
+    ['success', contract.success], ['stop', contract.stop], ['budget', contract.budget], ['artifacts', contract.artifacts],
+  ];
+  return (
+    <Sec label="Run contract" right={<span className="chip" style={{ padding:'1px 7px', fontSize:9, color:'var(--hm-faint)' }}>before run</span>}>
+      <div style={{ border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', overflow:'hidden' }}>
+        {rows.map(([k,v],i) => (
+          <div key={k} style={{ display:'grid', gridTemplateColumns:'78px 1fr', gap:10, padding:'8px 12px', borderTop:i?'1px solid var(--hm-line-2)':'none', background: i%2?'var(--hm-paper-sunken)':'var(--hm-paper)' }}>
+            <span className="eyebrow" style={{ fontSize:8.5, color:'var(--hm-faint)', paddingTop:1 }}>{k}</span>
+            <span style={{ fontSize:12.5, color: v?'var(--hm-ink-2)':'var(--hm-faint)', lineHeight:1.45 }}>{v || 'awaiting data'}</span>
+          </div>
+        ))}
+      </div>
+    </Sec>
+  );
+}
+
+/* ── #12 forensic evidence order: verdict → timeline → failure frame → replay → diagnostics → raw ── */
+function ExpectedObserved({ rows }) {
+  return (
+    <div style={{ border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', overflow:'hidden', marginBottom:14 }}>
+      <div style={{ display:'grid', gridTemplateColumns:'1.1fr 1fr 1fr auto', gap:8, padding:'7px 12px', background:'var(--hm-paper-sunken)', borderBottom:'1px solid var(--hm-line-2)' }}>
+        {['field','expected','observed',''].map((h,i)=><span key={i} className="eyebrow" style={{ fontSize:8, color:'var(--hm-faint)' }}>{h}</span>)}
+      </div>
+      {rows.map((r,i)=>(
+        <div key={i} style={{ display:'grid', gridTemplateColumns:'1.1fr 1fr 1fr auto', gap:8, padding:'8px 12px', borderTop:i?'1px solid var(--hm-line-2)':'none', alignItems:'center' }}>
+          <span style={{ fontSize:12, color:'var(--hm-ink-2)' }}>{r.field}</span>
+          <span className="mono" style={{ fontSize:11, color:'var(--hm-muted)' }}>{r.expected}</span>
+          <span className="mono" style={{ fontSize:11, color: r.needsData?'var(--hm-faint)':(r.ok?'var(--ok-text)':'var(--warn-text)') }}>{r.observed}</span>
+          <span aria-hidden="true" style={{ fontSize:11, color: r.needsData?'var(--hm-faint)':(r.ok?'var(--ok-text)':'var(--warn-text)') }}>{r.needsData?'—':(r.ok?'✓':'✕')}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+function RunTimeline({ events }) {
+  return (
+    <div style={{ position:'relative', paddingLeft:4 }}>
+      {events.map((e,i)=>(
+        <div key={i} style={{ display:'flex', gap:11, paddingBottom: i<events.length-1?12:0, position:'relative' }}>
+          <div style={{ display:'flex', flexDirection:'column', alignItems:'center', flex:'none' }}>
+            <span style={{ width:9, height:9, borderRadius:'50%', background: i===events.length-1?'var(--warn)':'var(--hm-line-strong)', flex:'none', marginTop:3 }} />
+            {i<events.length-1 && <span style={{ width:1.5, flex:1, background:'var(--hm-line-2)', marginTop:2 }} />}
+          </div>
+          <div style={{ minWidth:0, paddingBottom:2 }}>
+            <span className="mono" style={{ fontSize:10.5, color:'var(--hm-faint)' }}>{e.t}</span>
+            <div style={{ fontSize:12.5, color:'var(--hm-ink-2)', lineHeight:1.4 }}>{e.e}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+function ForensicSection({ card }) {
+  const f = card.forensic; if (!f) return null;
+  return (
+    <Sec label="Forensics" right={<span className="chip" style={{ padding:'1px 7px', fontSize:9, color:'var(--hm-faint)' }}>verdict → timeline → frame → replay → raw</span>}>
+      {f.expectedObserved && (
+        <>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginBottom:7 }}>Expected vs observed</div>
+          <ExpectedObserved rows={f.expectedObserved} />
+        </>
+      )}
+      {f.timeline && (
+        <>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginBottom:9 }}>Run timeline</div>
+          <RunTimeline events={f.timeline} />
+        </>
+      )}
+      {f.failureFrame && (
+        <div style={{ marginTop:14 }}>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginBottom:7 }}>Failure frame</div>
+          <div style={{ position:'relative', aspectRatio:'16/9', borderRadius:'var(--r-sm)', border:'1px solid var(--warn-line)',
+            background:'repeating-linear-gradient(135deg, var(--hm-paper-sunken), var(--hm-paper-sunken) 11px, var(--hm-surface) 11px, var(--hm-surface) 22px)', display:'grid', placeItems:'center' }}>
+            <span className="chip" style={{ background:'var(--hm-paper)', color:'var(--warn-text)', borderColor:'var(--warn-line)' }}>{f.failureFrame} · awaiting data</span>
+          </div>
+        </div>
+      )}
+      <div style={{ display:'flex', gap:7, marginTop:14, flexWrap:'wrap' }}>
+        <button className="btn btn--soft btn--sm">Open replay</button>
+        <button className="btn btn--soft btn--sm">Diagnostics</button>
+        <button className="btn btn--soft btn--sm">Raw trace ↗</button>
+      </div>
+    </Sec>
+  );
+}
+
+/* ── #12 convert-to-bug preview (what bug card it creates) ── */
+function ConvertPreview({ preview }) {
+  if (!preview) return null;
+  return (
+    <Sec label="If converted to a bug" right={<span className="chip" style={{ padding:'1px 7px', fontSize:9, color:'var(--hm-faint)' }}>preview · awaiting data</span>}>
+      <div style={{ border:'1px dashed var(--hm-line-strong)', borderRadius:'var(--r-sm)', padding:'12px 13px', background:'var(--hm-paper-sunken)' }}>
+        <div className="eyebrow" style={{ fontSize:8.5, color:'var(--hm-faint)' }}>{preview.creates}</div>
+        <div className="font-display" style={{ fontSize:13.5, fontWeight:700, color:'var(--hm-ink)', margin:'4px 0 8px', textWrap:'pretty' }}>{preview.title}</div>
+        <div style={{ display:'flex', gap:6, flexWrap:'wrap', alignItems:'center' }}>
+          {(preview.labels||[]).map(l => <span key={l} className="chip" style={{ padding:'2px 8px', fontSize:10 }}>{l}</span>)}
+          <span className="mono" style={{ fontSize:10.5, color:'var(--hm-faint)', marginLeft:'auto' }}>assignee · {preview.assignee || 'unassigned'}</span>
+        </div>
+      </div>
+    </Sec>
+  );
+}
+
+function DrawerInner({ card, onClose, decide, onAskHermes }) {
+  const kind = cardKind(card);
+  const author = AGD[card.author] || AGD.system;
+  const thread = THR_D.find(t => t.cardRef === card.id);
+  return (
+    <>
+      <div style={{ flex:'none', padding:'16px 18px', borderBottom:'1px solid var(--hm-line)', display:'flex', gap:12, alignItems:'flex-start' }}>
+        <AgentAvatar agent={author} size={34} />
+        <div style={{ flex:1, minWidth:0 }}>
+          <div className="mono" style={{ fontSize:11.5, color:'var(--hm-muted)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{card.id}</div>
+          <h2 className="font-display" style={{ margin:'4px 0 0', fontSize:20, fontWeight:700 }}>{card.title}</h2>
+        </div>
+        <button onClick={onClose} className="btn btn--ghost btn--sm" style={{ width:32, padding:0, flex:'none' }}>✕</button>
+      </div>
+
+      <div className="scroll-y" style={{ flex:1, padding:'18px', minHeight:0 }}>
+        <div style={{ display:'flex', gap:5, flexWrap:'wrap', marginBottom:14, alignItems:'center' }}>
+          {card.state && <K.StatePill s={card.state} />}
+          {card.risk && <K.RiskPill risk={card.risk} />}
+          <K.FailureClass card={card} />
+          {card.gate && <K.GatePill gate={card.gate} />}
+        </div>
+
+        {kind === 'live' ? (
+          <LiveFollow card={card} />
+        ) : (
+          <>
+            <EnvBadges env={card.env} />
+            <K.WhySeeing card={card} />
+            {card.verdict && card.completed && (
+              <div style={{ display:'flex', alignItems:'center', gap:10, padding:'12px 14px', borderRadius:'var(--r-sm)',
+                background: card.state && card.state.kind==='ready' ? 'var(--ok-soft)' : 'var(--hm-paper-sunken)',
+                border:`1px solid ${card.state && card.state.kind==='ready' ? 'var(--ok-line)' : 'var(--hm-line-2)'}`, margin:'14px 0 0' }}>
+                <span style={{ width:9, height:9, borderRadius:'50%', flex:'none', background: card.state && card.state.kind==='ready' ? 'var(--ok)' : 'var(--hm-muted)' }} />
+                <div style={{ minWidth:0, flex:1 }}>
+                  <Lab style={{ display:'block', color: card.state && card.state.kind==='ready' ? 'var(--ok-text)' : 'var(--hm-muted)' }}>Hermes verdict</Lab>
+                  <span style={{ fontSize:14, fontWeight:600, color: card.state && card.state.kind==='ready' ? 'var(--ok-text)' : 'var(--hm-ink-2)', textWrap:'pretty' }}>{card.verdict}</span>
+                </div>
+                <span className="mono" style={{ fontSize:10.5, color:'var(--hm-faint)', flex:'none' }}>just posted</span>
+              </div>
+            )}
+            {card.body && <p style={{ margin:'14px 0 18px', fontSize:14, color:'var(--hm-ink-2)', lineHeight:1.65 }}>{card.body}</p>}
+
+            {kind === 'decision' && (
+              <Sec label="Decision">
+                <K.DecisionBundle card={card} urgent={card.urgent}
+                  onAction={(c)=>{ decide(card.id, c); onClose(); }}
+                  onOpenReplay={()=>{}} onAskHermes={()=>{ onAskHermes(card.id); onClose(); }} />
+              </Sec>
+            )}
+
+            {/* #12 forensic order: verdict (above) → timeline/frame → replay/raw */}
+            <ForensicSection card={card} />
+
+            {/* #12 run contract — what this run will / won't do */}
+            <ContractPreview contract={card.contract} />
+
+            {kind === 'running' && card.checkpoints && (
+              <Sec label="Checkpoints"><K.CheckpointStepper steps={card.checkpoints} /></Sec>
+            )}
+
+            {card.grouped && (
+              <Sec label={`${card.grouped} grouped runs`}>
+                <div style={{ border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', overflow:'hidden' }}>
+                  {Array.from({length:card.grouped}).map((_,i)=>(
+                    <div key={i} style={{ display:'flex', alignItems:'center', gap:10, padding:'11px 12px', borderTop:i?'1px solid var(--hm-line-2)':'none' }}>
+                      <span className="spin" style={{ width:11, height:11, borderRadius:'50%', border:'2px solid var(--ok-line)', borderTopColor:'var(--ok)' }} />
+                      <span className="mono" style={{ fontSize:12, color:'var(--hm-ink-2)' }}>verification-run-{String(i+1).padStart(2,'0')}</span>
+                      <Pill tone="ok" style={{ marginLeft:'auto', minHeight:20, height:20, fontSize:10 }}>verifying</Pill>
+                    </div>
+                  ))}
+                </div>
+              </Sec>
+            )}
+
+            {(card.evidence && card.evidence.length>0) && <EvidenceSection card={card} />}
+
+            {/* #12 convert-to-bug preview */}
+            {kind === 'decision' && <ConvertPreview preview={card.convertPreview} />}
+
+            {thread && (
+              <Sec label="Agent discussion" right={<span className="mono" style={{ fontSize:11, color:'var(--hm-faint)' }}>{thread.turns.length} turn{thread.turns.length>1?'s':''}</span>}>
+                <div style={{ display:'grid', gap:4, border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', padding:'6px 6px' }}>
+                  {thread.turns.map(t => <window.Room.Turn key={t.id} turn={t} fresh={false} />)}
+                </div>
+                <button onClick={()=>{ onAskHermes(card.id); }} className="btn btn--soft btn--sm" style={{ marginTop:10 }}>Show in room →</button>
+              </Sec>
+            )}
+
+            {kind === 'info' && card.verdict && !card.completed && (
+              <div style={{ display:'flex', alignItems:'center', gap:10, padding:'12px 14px', borderRadius:'var(--r-sm)', background:'var(--ok-soft)', border:'1px solid var(--ok-line)' }}>
+                <span style={{ width:9, height:9, borderRadius:'50%', background:'var(--ok)' }} />
+                <Lab style={{ color:'var(--ok-text)' }}>Outcome</Lab>
+                <span style={{ fontSize:14, fontWeight:600, color:'var(--ok-text)' }}>{card.verdict}</span>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+function CardDrawer({ card, onClose, decide, onAskHermes }) {
+  React.useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+  const open = !!card;
+  return (
+    <>
+      <div onClick={onClose} style={{ position:'fixed', inset:0, background:'rgba(10,8,14,0.46)', backdropFilter:'blur(2px)', zIndex:60,
+        opacity: open?1:0, pointerEvents: open?'auto':'none', transition:'opacity var(--dur) var(--ease)' }} />
+      <div style={{ position:'fixed', top:0, right:0, bottom:0, width:'min(560px, 92vw)', zIndex:61, background:'var(--hm-paper)',
+        borderLeft:'1px solid var(--hm-line)', boxShadow:'var(--sh-lift)', display:'flex', flexDirection:'column',
+        transform: open?'translateX(0)':'translateX(102%)', transition:'transform 320ms var(--ease-out)' }}>
+        {card && <DrawerInner card={card} onClose={onClose} decide={decide} onAskHermes={onAskHermes} />}
+      </div>
+    </>
+  );
+}
+
+window.Drawer = { CardDrawer };

--- a/docs/design/hermes-4/project/hermes.css
+++ b/docs/design/hermes-4/project/hermes.css
@@ -1,0 +1,374 @@
+@import url("https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap");
+
+/* =========================================================
+   Hermes — Handoff Monitor (Averray surface)
+   Warm ivory control room. Color = meaning:
+     coral  = act (needs you)      sage  = healthy
+     amber  = degraded             warm-gray = telemetry
+   Agent identity uses a cool jewel palette kept deliberately
+   distinct from the warm status set, so identity never reads
+   as status.
+   ========================================================= */
+
+:root {
+  color-scheme: light;
+
+  /* ---- layered warm surfaces (depth) ---- */
+  --hm-canvas:        #e9e4d9;   /* deepest — behind everything */
+  --hm-surface:       #f1ede4;   /* tier background */
+  --hm-paper:         #fffdf8;   /* cards */
+  --hm-paper-sunken:  #f6f3ea;   /* nested / inset */
+  --hm-paper-veil:    rgba(255,253,248,0.72);
+
+  --hm-ink:    #1b1a16;
+  --hm-ink-2:  #3a372f;
+  --hm-muted:  #6b6557;
+  --hm-faint:  #948d7c;
+  --hm-line:   rgba(38,32,18,0.10);
+  --hm-line-2: rgba(38,32,18,0.06);
+  --hm-line-strong: rgba(38,32,18,0.16);
+
+  /* ---- ACT: coral (reserved for the action that needs you) ---- */
+  --act:        #D97757;
+  --act-deep:   #C15F3C;   /* hover / pressed */
+  --act-ink:    #fffdf8;   /* text on coral */
+  --act-text:   #b0532f;   /* coral text on light */
+  --act-soft:   rgba(217,119,87,0.12);
+  --act-soft-2: rgba(217,119,87,0.20);
+  --act-line:   rgba(217,119,87,0.34);
+
+  /* ---- HEALTHY: sage ---- */
+  --ok:       #1e6642;
+  --ok-text:  #1c5c3c;
+  --ok-soft:  #d9ebdf;
+  --ok-line:  rgba(30,102,66,0.24);
+
+  /* ---- DEGRADED: amber ---- */
+  --warn:      #a76122;
+  --warn-text: #8a4f1c;
+  --warn-soft: #f4e3cf;
+  --warn-line: rgba(167,97,34,0.28);
+
+  /* ---- TELEMETRY: warm-gray ---- */
+  --tel:      #7c7464;
+  --tel-soft: #ebe6d9;
+  --tel-chip: #efebe0;
+
+  /* ---- agent identity (cool jewel — never status) ---- */
+  --ag-hermes: #4b56c4;
+  --ag-claude: #7048b6;
+  --ag-codex:  #2f8f83;
+  --ag-test:   #5d6b7d;
+  --ag-op:     #2a2723;
+  --ag-system: #8a8275;
+
+  /* ---- type ---- */
+  --font-display: "Space Grotesk", "Manrope", ui-sans-serif, system-ui, sans-serif;
+  --font-body:    "Manrope", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono:    "JetBrains Mono", "SFMono-Regular", "Menlo", ui-monospace, monospace;
+
+  /* ---- radii (warm, rounded) ---- */
+  --r-sm:   8px;
+  --r-chip: 9px;
+  --r-btn:  11px;
+  --r-card: 15px;
+  --r-lane: 19px;
+  --r-pill: 999px;
+
+  /* ---- elevation ---- */
+  --sh-sm:   0 1px 2px rgba(40,33,18,0.05), 0 2px 6px rgba(40,33,18,0.04);
+  --sh:      0 2px 6px rgba(40,33,18,0.05), 0 14px 34px rgba(40,33,18,0.07);
+  --sh-lift: 0 8px 18px rgba(40,33,18,0.09), 0 26px 56px rgba(40,33,18,0.12);
+  --sh-coral:0 8px 24px rgba(217,119,87,0.24);
+  --sh-inset:inset 0 1px 0 rgba(255,255,255,0.6);
+
+  /* ---- motion ---- */
+  --ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --ease-out: cubic-bezier(0.16, 0.84, 0.3, 1);
+  --dur-fast: 150ms;
+  --dur: 200ms;
+  --mi: 0.6;            /* 0..1 motion intensity (JS-driven) */
+
+  /* themeable atmosphere (overridden per color profile) */
+  --glow-1: rgba(217,119,87,0.05);
+  --glow-2: rgba(30,102,66,0.04);
+  --act-glow: none;
+
+  /* ---- density-scoped spacing (data-density on <html>) ---- */
+  --pad-card: 18px;
+  --pad-lane: 16px;
+  --gap-cards: 14px;
+  --gap-tier: 22px;
+  --gap-room: 12px;
+}
+:root[data-density="compact"] {
+  --pad-card: 13px; --pad-lane: 12px; --gap-cards: 10px; --gap-tier: 16px; --gap-room: 9px;
+}
+:root[data-density="comfy"] {
+  --pad-card: 22px; --pad-lane: 20px; --gap-cards: 18px; --gap-tier: 30px; --gap-room: 16px;
+}
+
+* { letter-spacing: 0 !important; box-sizing: border-box; }
+
+html, body { height: 100%; }
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--hm-ink);
+  background:
+    radial-gradient(1200px 700px at 12% -8%, var(--glow-1), transparent 60%),
+    radial-gradient(1000px 600px at 100% 0%, var(--glow-2), transparent 55%),
+    var(--hm-canvas);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow: hidden;
+}
+
+/* smooth cross-fade when switching color profile */
+.theming, .theming * {
+  transition: background-color 0.5s var(--ease), color 0.5s var(--ease),
+    border-color 0.5s var(--ease), box-shadow 0.5s var(--ease), fill 0.5s var(--ease) !important;
+}
+:root[data-dark="1"] .live-dot { box-shadow: 0 0 9px currentColor; }
+:root[data-glow="1"] .live-dot { box-shadow: 0 0 13px currentColor; }
+
+#root { height: 100%; }
+
+::selection { background: var(--act-soft-2); }
+
+/* thin warm scrollbars */
+.scroll-y { overflow-y: auto; overflow-x: hidden; scrollbar-width: thin; scrollbar-color: rgba(38,32,18,0.18) transparent; }
+.scroll-y::-webkit-scrollbar { width: 9px; }
+.scroll-y::-webkit-scrollbar-thumb { background: rgba(38,32,18,0.16); border-radius: 6px; border: 2px solid transparent; background-clip: content-box; }
+.scroll-y::-webkit-scrollbar-thumb:hover { background: rgba(38,32,18,0.28); background-clip: content-box; }
+.scroll-y::-webkit-scrollbar-track { background: transparent; }
+
+/* horizontal scroll (kanban row) */
+.scroll-x { overflow-x: auto; overflow-y: hidden; scrollbar-width: thin; scrollbar-color: rgba(38,32,18,0.18) transparent; }
+.scroll-x::-webkit-scrollbar { height: 10px; }
+.scroll-x::-webkit-scrollbar-thumb { background: rgba(38,32,18,0.16); border-radius: 6px; border: 2px solid transparent; background-clip: content-box; }
+.scroll-x::-webkit-scrollbar-thumb:hover { background: rgba(38,32,18,0.28); background-clip: content-box; }
+.scroll-x::-webkit-scrollbar-track { background: transparent; }
+
+/* kanban card + advance affordance */
+.kcard { transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease), border-color var(--dur) var(--ease); }
+.kcard:hover { box-shadow: var(--sh-lift); border-color: var(--act-line); }
+.kcard:hover .advance { opacity: 1; transform: translateX(0); }
+.advance { opacity: 0; transform: translateX(-3px); transition: opacity var(--dur-fast) var(--ease), transform var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease); }
+.advance:hover { background: var(--act-soft) !important; color: var(--act-text) !important; }
+.krail { transition: background var(--dur) var(--ease), border-color var(--dur) var(--ease); }
+.krail:hover { border-color: var(--hm-line-strong); background: var(--hm-paper-sunken); }
+
+/* utilities expanded grid → stack on narrow */
+@media (max-width: 820px) {
+  .util-grid { grid-template-columns: 1fr !important; }
+}
+
+/* ---------------- typographic atoms ---------------- */
+.font-display { font-family: var(--font-display); }
+.mono { font-family: var(--font-mono); }
+.eyebrow {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+  white-space: nowrap;
+}
+.eyebrow--act { color: var(--act-text); }
+
+/* ---------------- pills ---------------- */
+.pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  min-height: 22px; padding: 0 10px;
+  border-radius: var(--r-pill);
+  font-family: var(--font-display);
+  font-size: 10.5px; font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.pill .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.pill--ok      { background: var(--ok-soft);  color: var(--ok-text); }
+.pill--warn    { background: var(--warn-soft); color: var(--warn-text); }
+.pill--act     { background: var(--act-soft);  color: var(--act-text); }
+.pill--tel     { background: var(--tel-chip);  color: var(--tel); }
+.pill--ink     { background: var(--hm-ink);    color: var(--hm-paper); }
+
+/* meta chip (traces / screenshots / video etc) */
+.chip {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 9px; border-radius: var(--r-chip);
+  background: var(--hm-paper-sunken);
+  border: 1px solid var(--hm-line-2);
+  font-size: 11.5px; color: var(--hm-muted);
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+/* ---------------- buttons ---------------- */
+.btn {
+  display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  height: 38px; padding: 0 16px;
+  border-radius: var(--r-btn);
+  font-family: var(--font-display);
+  font-size: 13px; font-weight: 600;
+  border: 1px solid transparent;
+  cursor: pointer; user-select: none;
+  white-space: nowrap;
+  transition: transform var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease),
+              border-color var(--dur-fast) var(--ease), box-shadow var(--dur-fast) var(--ease), color var(--dur-fast) var(--ease);
+}
+.btn:active { transform: translateY(0.5px); }
+.btn--act {
+  background: var(--act); color: var(--act-ink);
+  box-shadow: var(--sh-coral), var(--sh-inset);
+}
+.btn--act:hover { background: var(--act-deep); transform: translateY(-1px); }
+.btn--ghost {
+  background: var(--hm-paper); color: var(--hm-ink);
+  border-color: var(--hm-line);
+}
+.btn--ghost:hover { border-color: var(--hm-line-strong); background: #fff; transform: translateY(-1px); }
+.btn--soft {
+  background: var(--hm-paper-sunken); color: var(--hm-ink-2);
+  border-color: var(--hm-line-2);
+}
+.btn--soft:hover { background: #fff; border-color: var(--hm-line); }
+.btn--sm { height: 30px; padding: 0 12px; font-size: 12px; border-radius: var(--r-sm); }
+
+/* ---------------- generic card / lane ---------------- */
+.surface { background: var(--hm-paper); border: 1px solid var(--hm-line); border-radius: var(--r-card); box-shadow: var(--sh-sm); }
+
+/* ============================================================
+   MOTION — gated on intensity bucket + prefers-reduced-motion
+   ============================================================ */
+@keyframes hm-rise {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes hm-slide-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.985); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes hm-breathe {
+  0%, 100% { box-shadow: 0 2px 6px rgba(40,33,18,0.05), 0 16px 36px rgba(217,119,87,0.10); }
+  50%      { box-shadow: 0 4px 12px rgba(40,33,18,0.07), 0 22px 50px rgba(217,119,87,0.20); }
+}
+@keyframes hm-breathe-ring {
+  0%, 100% { transform: scale(1);   opacity: 0.55; }
+  50%      { transform: scale(1.35); opacity: 0; }
+}
+@keyframes hm-live {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.45; transform: scale(0.82); }
+}
+@keyframes hm-shimmer {
+  from { background-position: -160% 0; }
+  to   { background-position: 260% 0; }
+}
+@keyframes hm-typing {
+  0%, 60%, 100% { transform: translateY(0); opacity: 0.45; }
+  30% { transform: translateY(-3px); opacity: 1; }
+}
+@keyframes hm-pop {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.28); }
+  100% { transform: scale(1); }
+}
+@keyframes hm-spin { to { transform: rotate(360deg); } }
+@keyframes hm-flash {
+  0% { background: var(--act-soft-2); box-shadow: 0 0 0 2px var(--act-line), var(--sh-lift); }
+  100% { background: transparent; box-shadow: var(--sh-sm); }
+}
+@keyframes hm-prog {
+  0%   { left: -42%; }
+  100% { left: 100%; }
+}
+
+/* default (med / intensity ~0.6) — essentials + breathe + count */
+.anim-rise   { animation: hm-rise 360ms var(--ease-out) both; }
+.anim-slide  { animation: hm-slide-in 320ms var(--ease-out) both; }
+.live-dot    { animation: hm-live calc(2.4s / max(var(--mi),0.4)) ease-in-out infinite; }
+.breathe     { animation: hm-breathe calc(4s / max(var(--mi),0.4)) ease-in-out infinite; }
+.breathe-ring{ animation: hm-breathe-ring calc(2.6s / max(var(--mi),0.4)) ease-out infinite; }
+.pop         { animation: hm-pop 420ms var(--ease-out); }
+.flash-in    { animation: hm-flash 1.5s var(--ease) both; }
+.spin        { animation: hm-spin 0.9s linear infinite; }
+.prog-indef  { animation: hm-prog calc(1.6s / max(var(--mi),0.5)) var(--ease) infinite; }
+
+/* shimmer is decorative — only at higher intensity */
+.shimmer { position: relative; overflow: hidden; }
+.shimmer::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: linear-gradient(100deg, transparent 30%, rgba(255,255,255,0.55) 50%, transparent 70%);
+  background-size: 200% 100%;
+  animation: hm-shimmer calc(2.6s / max(var(--mi),0.5)) linear infinite;
+  opacity: 0;
+}
+
+/* typing dots */
+.typing { display: inline-flex; gap: 4px; align-items: center; }
+.typing i { width: 5px; height: 5px; border-radius: 50%; background: currentColor; display: block; animation: hm-typing 1.1s ease-in-out infinite; }
+.typing i:nth-child(2) { animation-delay: 0.16s; }
+.typing i:nth-child(3) { animation-delay: 0.32s; }
+
+/* ---- intensity buckets (data-motion on <html>) ---- */
+:root[data-motion="off"] *,
+:root[data-motion="off"] *::after {
+  animation: none !important;
+  transition: none !important;
+}
+:root[data-motion="off"] .breathe-ring { display: none; }
+
+/* low: keep slide-ins + live pulse, drop breathe & shimmer */
+:root[data-motion="low"] .breathe { animation: none; }
+:root[data-motion="low"] .shimmer::after { display: none; }
+
+/* med (default): breathe on, shimmer off */
+:root[data-motion="med"] .shimmer::after { opacity: 0; }
+
+/* high: shimmer visible, everything alive */
+:root[data-motion="high"] .shimmer::after { opacity: 1; }
+:root[data-motion="high"] .breathe { animation-duration: calc(3s / max(var(--mi),0.6)); }
+
+/* hover lift for cards */
+.hover-lift { transition: transform var(--dur) var(--ease), box-shadow var(--dur) var(--ease), border-color var(--dur) var(--ease); }
+.hover-lift:hover { transform: translateY(-2px); box-shadow: var(--sh-lift); border-color: var(--act-line); }
+
+/* focus-dim: hovering the primary action recedes its siblings */
+.focus-row { transition: none; }
+.focus-row .btn { transition: opacity var(--dur) var(--ease), transform var(--dur-fast) var(--ease), background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease); }
+.focus-row:has(.btn--act:hover) .btn:not(:hover) { opacity: 0.4; }
+
+.click { cursor: pointer; }
+
+/* ── accessibility (a11y #8) ── */
+/* visible keyboard focus ring on every interactive element */
+a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible,
+textarea:focus-visible, [tabindex]:focus-visible, .click:focus-visible, .cardref:focus-visible, .chip.click:focus-visible {
+  outline: 2px solid var(--act);
+  outline-offset: 2px;
+  border-radius: var(--r-sm);
+}
+:root[data-dark="1"] a:focus-visible, :root[data-dark="1"] button:focus-visible,
+:root[data-dark="1"] input:focus-visible, :root[data-dark="1"] select:focus-visible,
+:root[data-dark="1"] textarea:focus-visible, :root[data-dark="1"] [tabindex]:focus-visible,
+:root[data-dark="1"] .click:focus-visible, :root[data-dark="1"] .cardref:focus-visible {
+  outline-color: var(--act);
+  box-shadow: 0 0 0 4px var(--act-soft);
+}
+/* comfortable minimum hit area on small buttons */
+.btn--sm { min-height: 30px; }
+/* chips never drop below a legible floor */
+.chip { font-size: max(10px, 1em); }
+
+/* link-y card ref */
+.cardref { transition: background var(--dur-fast) var(--ease), border-color var(--dur-fast) var(--ease); }
+.cardref:hover { background: var(--hm-paper); border-color: var(--act-line); }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::after { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
+  .breathe-ring, .shimmer::after, .typing i { display: none !important; }
+}

--- a/docs/design/hermes-4/project/kanban.jsx
+++ b/docs/design/hermes-4/project/kanban.jsx
@@ -1,0 +1,457 @@
+/* Hermes — pipeline kanban + Decision Inbox
+   DECIDE inbox = union of all waitingOn==='operator' cards (the ONE place to act).
+   WATCH/HIDE lanes show the same cards in pipeline position, READ-ONLY.
+   Badge families (G): state · risk · evidence · gate. Coral only on the single
+   most-urgent recommended action (K). */
+const { AGENTS: AGK, LANES, EVIDENCE_LABEL } = window.HERMES_DATA;
+
+const TIER_META = {
+  decide: { label:'Decide', text:'var(--tier-decide-text)', headBg:'var(--tier-decide-bg)', line:'var(--tier-decide-line)', countBg:'var(--act)', countFg:'var(--act-ink)' },
+  watch:  { label:'Watch',  text:'var(--hm-muted)', headBg:'var(--hm-paper-sunken)', line:'var(--hm-line)', countBg:'var(--hm-ink)', countFg:'var(--hm-paper)' },
+  hide:   { label:'Hide',   text:'var(--hm-faint)', headBg:'var(--hm-surface)', line:'var(--hm-line-2)', countBg:'var(--hm-faint)', countFg:'var(--hm-paper)' },
+};
+const STATE_TONE = { failed:'warn', blocked:'warn', running:'ok', ready:'ok', done:'tel' };
+const RISK_TONE  = { low:'tel', med:'warn', high:'warn' };
+const CLASS_COLOR = { Product:'var(--ag-claude)', Test:'var(--ag-test)', Infra:'var(--warn)', Agent:'var(--ag-codex)', Policy:'var(--ag-hermes)', Unknown:'var(--hm-faint)' };
+const STAGE_ORDER = ['codex','checking','opreview','queue','deploying','done'];
+const SEED_CHECKPOINTS = () => ([
+  { label:'CI queued', state:'current' }, { label:'install', state:'todo' }, { label:'unit tests', state:'todo' },
+  { label:'browser replay', state:'todo' }, { label:'Hermes review', state:'todo' }, { label:'ready', state:'todo' },
+]);
+
+const motionOn = () =>
+  document.documentElement.getAttribute('data-motion') !== 'off' &&
+  !(window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+
+/* ───────── G: 4 badge families ───────── */
+/* per-state glyph so state is distinguishable WITHOUT color (a11y #8) */
+const STATE_GLYPH = { failed:'✕', blocked:'▢', running:'◐', ready:'▲', done:'✓' };
+function StatePill({ s }) {
+  const tone = STATE_TONE[s.kind] || 'tel';
+  const glyph = STATE_GLYPH[s.kind] || '·';
+  return (
+    <Pill tone={tone} style={{ minHeight:20, height:20, fontSize:10, gap:5 }}>
+      <span aria-hidden="true" style={{ fontSize:9, lineHeight:1, flex:'none' }}>{glyph}</span>{s.label}
+    </Pill>
+  );
+}
+function RiskPill({ risk }) {
+  // shape encodes level without relying on color (a11y #8)
+  const mark = risk.level==='high' ? '◆' : risk.level==='med' ? '◣' : '○';
+  return (
+    <Pill tone={RISK_TONE[risk.level]||'tel'} style={{ minHeight:20, height:20, fontSize:10, gap:5 }}>
+      <span aria-hidden="true" style={{ fontSize:8.5, lineHeight:1, flex:'none' }}>{mark}</span>
+      Risk: {risk.level}{risk.type?` · ${risk.type}`:''}
+    </Pill>
+  );
+}
+function EvidenceChips({ evidence }) {
+  return <>{evidence.map((e,i) => {
+    const fn = EVIDENCE_LABEL[e.k]; const label = fn ? fn(e.n) : e.k;
+    return <span key={i} className="chip" style={{ padding:'2px 7px', fontSize:10, gap:4 }}>{label}</span>;
+  })}</>;
+}
+function GatePill({ gate }) {
+  const map = { operator:{ c:'var(--act)', t:'needs you' }, agent:{ c:'var(--ag-claude)', t:'agent' }, system:{ c:'var(--hm-faint)', t:'system' } };
+  const g = map[gate] || map.system;
+  return (
+    <span className="chip" style={{ padding:'2px 8px', fontSize:9.5, gap:5, textTransform:'uppercase', fontFamily:'var(--font-display)', fontWeight:700, color:'var(--hm-muted)' }}>
+      <span style={{ width:6, height:6, borderRadius:'50%', background:g.c, flex:'none' }} />{g.t}
+    </span>
+  );
+}
+function Badges({ card, show }) {
+  show = show || ['state','risk','evidence','gate'];
+  return (
+    <div style={{ display:'flex', gap:5, flexWrap:'wrap', marginTop:10, alignItems:'center' }}>
+      {show.includes('state') && card.state && <StatePill s={card.state} />}
+      {show.includes('risk') && card.risk && <RiskPill risk={card.risk} />}
+      {show.includes('evidence') && card.evidence && <EvidenceChips evidence={card.evidence} />}
+      {show.includes('gate') && card.gate && <GatePill gate={card.gate} />}
+    </div>
+  );
+}
+
+/* ───────── D: failure class chip ───────── */
+function FailureClass({ card }) {
+  if (!card.failureClass) return null;
+  return (
+    <span className="chip" style={{ padding:'2px 8px', fontSize:9.5, gap:5, textTransform:'uppercase', fontFamily:'var(--font-display)', fontWeight:700, color:'var(--hm-ink-2)' }}>
+      <span style={{ width:6, height:6, borderRadius:'50%', background:CLASS_COLOR[card.failureClass]||'var(--hm-faint)', flex:'none' }} />
+      {card.failureClass}
+    </span>
+  );
+}
+
+/* ───────── C: why am I seeing this / unblock ───────── */
+function WhySeeing({ card }) {
+  if (!card.whySeeing && !card.unblock) return null;
+  return (
+    <div style={{ marginTop:10, display:'grid', gap:6 }}>
+      {card.whySeeing && (
+        <div style={{ display:'flex', gap:7, fontSize:12, color:'var(--hm-muted)', lineHeight:1.5 }}>
+          <span style={{ flex:'none', color:'var(--hm-faint)' }}>?</span>
+          <span><span style={{ fontWeight:600, color:'var(--hm-ink-2)' }}>Why you’re seeing this · </span>{card.whySeeing}</span>
+        </div>
+      )}
+      {card.unblock && (
+        <div style={{ display:'flex', gap:7, fontSize:12, color:'var(--hm-muted)', lineHeight:1.5 }}>
+          <span style={{ flex:'none', color:'var(--ok-text)' }}>→</span>
+          <span><span style={{ fontWeight:600, color:'var(--ok-text)' }}>Unblock · </span>{card.unblock}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ───────── E: checkpoint stepper (replaces progress bar) ───────── */
+function CheckpointStepper({ steps }) {
+  return (
+    <div style={{ marginTop:12, display:'flex', flexDirection:'column', gap:7 }}>
+      {steps.map((s,i) => {
+        const done = s.state==='done', cur = s.state==='current';
+        return (
+          <div key={i} style={{ display:'flex', alignItems:'center', gap:9, opacity: s.state==='todo'?0.5:1 }}>
+            <span style={{ width:15, height:15, borderRadius:'50%', flex:'none', display:'grid', placeItems:'center',
+              background: done?'var(--ok)':(cur?'var(--ok-soft)':'transparent'),
+              border: done?'none':`1.5px solid ${cur?'var(--ok)':'var(--hm-line-strong)'}`,
+              color:'var(--act-ink)', fontSize:9 }}>
+              {done ? '✓' : (cur ? <span className="live-dot" style={{ width:6, height:6, borderRadius:'50%', background:'var(--ok)' }} /> : '')}
+            </span>
+            <span className="font-display" style={{ fontSize:12, fontWeight: cur?700:500,
+              color: cur?'var(--ok-text)':(done?'var(--hm-ink-2)':'var(--hm-muted)') }}>{s.label}</span>
+            {cur && <span className="mono" style={{ marginLeft:'auto', fontSize:9.5, color:'var(--hm-faint)' }}>in progress</span>}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/* ───────── meta + title (shared) ───────── */
+function CardMeta({ card }) {
+  const a = AGK[card.author] || AGK.system;
+  return (
+    <div style={{ display:'flex', alignItems:'center', gap:6, minWidth:0 }}>
+      <PresenceDot presence={a.presence} color={a.color} size={7} ring={false} />
+      <span className="font-display" style={{ fontWeight:600, fontSize:12, color:a.color, whiteSpace:'nowrap', flex:'none' }}>{a.name}</span>
+      {card.type && <>
+        <span style={{ color:'var(--hm-faint)', flex:'none' }}>·</span>
+        <span className="mono" style={{ fontSize:10.5, color:'var(--hm-muted)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{card.type}</span>
+      </>}
+      {card.freshness && <span className="font-display" style={{ marginLeft:'auto', flex:'none', fontSize:10, fontWeight:700, textTransform:'uppercase', color:'var(--hm-faint)' }}>{card.freshness}</span>}
+    </div>
+  );
+}
+
+/* ───────── B: decision bundle ───────── */
+function BundleRow({ label, children, danger }) {
+  return (
+    <div style={{ display:'grid', gridTemplateColumns:'92px 1fr', gap:10, padding:'7px 0', borderTop:'1px solid var(--hm-line-2)' }}>
+      <span className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', paddingTop:1 }}>{label}</span>
+      <div style={{ fontSize:12.5, color: danger?'var(--warn-text)':'var(--hm-ink-2)', lineHeight:1.5 }}>{children}</div>
+    </div>
+  );
+}
+function DecisionBundle({ card, urgent, onAction, onOpenReplay, onAskHermes }) {
+  const d = card.decision; if (!d) return null;
+  const choiceKind = (c) => {
+    const a = c.toLowerCase();
+    if (/approve|dispatch|rerun/.test(a)) return 'act';
+    if (/reject|dismiss|hold/.test(a)) return 'ghost';
+    return 'soft';
+  };
+  return (
+    <div className="anim-rise" style={{ marginTop:12, borderRadius:'var(--r-sm)', background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', padding:'12px 14px' }}>
+      {/* recommended */}
+      <div style={{ display:'flex', alignItems:'flex-start', gap:9 }}>
+        <span style={{ flex:'none', marginTop:1, width:18, height:18, borderRadius:'50%', display:'grid', placeItems:'center',
+          background: urgent?'var(--act-soft-2)':'var(--ok-soft)', color: urgent?'var(--act-text)':'var(--ok-text)', fontSize:11 }}>★</span>
+        <div style={{ minWidth:0 }}>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)' }}>Hermes recommends</div>
+          <div className="font-display" style={{ fontSize:14, fontWeight:700, color:'var(--hm-ink)', marginTop:2 }}>{d.recommended}</div>
+          <div style={{ fontSize:12, color:'var(--hm-muted)', marginTop:3, lineHeight:1.5 }}>{d.why}</div>
+        </div>
+      </div>
+
+      <div style={{ marginTop:10 }}>
+        <BundleRow label="Risk">
+          <span style={{ fontWeight:600, color: card.risk && card.risk.level!=='low' ? 'var(--warn-text)' : 'var(--hm-ink-2)' }}>
+            {card.risk ? `${card.risk.type} · ${card.risk.level}` : '—'}
+          </span>
+        </BundleRow>
+        <BundleRow label="Grants">{d.grants}</BundleRow>
+        <BundleRow label="Does not" danger>{d.denies}</BundleRow>
+        <BundleRow label="Blast radius">
+          <span className="mono" style={{ fontSize:11.5 }}>
+            {d.blast.repo} · {d.blast.branch} · {d.blast.env} · {d.blast.area} · users: {d.blast.users}
+          </span>
+        </BundleRow>
+        <BundleRow label="Rollback">{d.rollback}</BundleRow>
+        <BundleRow label="Evidence">
+          <div style={{ display:'flex', gap:6, flexWrap:'wrap' }}>
+            {(card.evidence||[]).map((e,i)=>{ const fn=EVIDENCE_LABEL[e.k]; return (
+              <button key={i} onClick={(ev)=>{ev.stopPropagation(); onOpenReplay&&onOpenReplay();}} className="chip click" style={{ padding:'2px 8px', fontSize:10.5, color:'var(--hm-ink-2)' }}>{fn?fn(e.n):e.k} ↗</button>
+            );})}
+            {(!card.evidence||!card.evidence.length) && <span style={{ fontSize:11.5, color:'var(--hm-faint)' }}>none yet</span>}
+          </div>
+        </BundleRow>
+      </div>
+
+      {/* choices — recommended is primary (coral only when urgent, K); rest are alternatives */}
+      <div style={{ display:'flex', gap:7, flexWrap:'wrap', marginTop:12, alignItems:'center' }}>
+        <button onClick={(e)=>{ e.stopPropagation(); onAction && onAction(d.recommended); }}
+          className={cx('btn btn--sm', urgent ? 'btn--act' : '')}
+          style={ urgent ? undefined : { background:'var(--hm-ink)', color:'var(--hm-paper)', border:'1px solid transparent' } }>
+          {d.recommended}
+        </button>
+        {d.choices.filter(c => c.toLowerCase().split(' ')[0] !== d.recommended.toLowerCase().split(' ')[0]).map((c,i) => {
+          const a = c.toLowerCase();
+          const kind = /reject|dismiss|hold/.test(a) ? 'ghost' : 'soft';
+          const onClick = (ev) => {
+            ev.stopPropagation();
+            if (/ask hermes/.test(a)) return onAskHermes && onAskHermes();
+            if (/replay/.test(a)) return onOpenReplay && onOpenReplay();
+            onAction && onAction(c);
+          };
+          return <button key={i} onClick={onClick} className={cx('btn btn--sm', kind==='ghost'?'btn--ghost':'btn--soft')}>{c}</button>;
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* ───────── Inbox card (actionable) ───────── */
+function InboxCard({ card, urgent, expanded, onToggle, onAction, onOpen, onOpenReplay, onAskHermes, justArrived }) {
+  return (
+    <article data-flip-id={card.id} className={cx('kcard', justArrived && 'flash-in', urgent && expanded && 'breathe')}
+      style={{ position:'relative', background:'var(--hm-paper)', borderRadius:'var(--r-card)', border:'1px solid var(--hm-line)',
+        borderLeft:`3px solid ${urgent?'var(--act)':'var(--hm-line-strong)'}`, boxShadow:'var(--sh-sm)', padding:'var(--pad-card)' }}>
+      <div className="click" onClick={onToggle}>
+        <CardMeta card={card} />
+        <h4 className="font-display" style={{ margin:'10px 0 0', fontSize:15.5, fontWeight:700, lineHeight:1.25, color:'var(--hm-ink)', textWrap:'pretty' }}>{card.title}</h4>
+        {card.repo && <div className="mono" style={{ fontSize:11.5, color:'var(--hm-muted)', marginTop:5, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{card.repo}</div>}
+        <div style={{ display:'flex', gap:5, flexWrap:'wrap', marginTop:10, alignItems:'center' }}>
+          {card.state && <StatePill s={card.state} />}
+          {card.risk && <RiskPill risk={card.risk} />}
+          <FailureClass card={card} />
+          {card.dedupe && <span className="chip" style={{ padding:'2px 8px', fontSize:9.5, color:'var(--hm-faint)' }} title="dedupe needs real data — unconfirmed">⊘ {card.dedupe.label}</span>}
+        </div>
+        <WhySeeing card={card} />
+      </div>
+
+      {expanded
+        ? <DecisionBundle card={card} urgent={urgent} onAction={(c)=>onAction(card.id,c)} onOpenReplay={()=>onOpenReplay(card.id)} onAskHermes={()=>onAskHermes(card.id)} />
+        : (
+          <>
+            {card.whatNext && (
+              <div style={{ display:'flex', gap:7, marginTop:11, fontSize:11.5, color:'var(--hm-muted)', lineHeight:1.5 }}>
+                <span aria-hidden="true" style={{ flex:'none', color:'var(--hm-faint)' }}>↳</span>
+                <span><span style={{ fontWeight:600, color:'var(--hm-ink-2)' }}>What happens next · </span>{card.whatNext}</span>
+              </div>
+            )}
+            <div style={{ display:'flex', alignItems:'center', gap:9, marginTop:12 }}>
+              <button onClick={(e)=>{e.stopPropagation(); onAction(card.id, card.decision.recommended);}}
+                className={cx('btn btn--sm', urgent?'btn--act':'')}
+                style={ urgent ? { flex:1 } : { flex:1, background:'var(--hm-ink)', color:'var(--hm-paper)', border:'1px solid transparent' } }>
+                {card.decision.recommended}
+              </button>
+              <button onClick={(e)=>{e.stopPropagation(); onToggle();}} className="btn btn--ghost btn--sm">Choices ↓</button>
+            </div>
+          </>
+        )}
+    </article>
+  );
+}
+
+/* ───────── read-only pipeline card (WATCH / HIDE) ───────── */
+function PipelineCard({ card, onOpen, onGoInbox, justArrived }) {
+  const running = card.state && card.state.kind === 'running';
+  const dim = card.stage === 'done';
+  return (
+    <article data-flip-id={card.id} onClick={onOpen}
+      className={cx('kcard', running && 'shimmer', justArrived && 'flash-in', 'click')}
+      style={{ position:'relative', background:'var(--hm-paper)', borderRadius:'var(--r-card)', border:'1px solid var(--hm-line)',
+        boxShadow:'var(--sh-sm)', padding:'var(--pad-card)', opacity: dim?0.74:1, filter: dim?'saturate(0.8)':'none' }}>
+      <CardMeta card={card} />
+      <h4 className="font-display" style={{ margin:'10px 0 0', fontSize:15, fontWeight:700, lineHeight:1.25, color:'var(--hm-ink)', textWrap:'pretty' }}>{card.title}</h4>
+      {card.repo && <div className="mono" style={{ fontSize:11.5, color:'var(--hm-muted)', marginTop:5, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{card.repo}</div>}
+      {running && card.checkpoints
+        ? <CheckpointStepper steps={card.checkpoints} />
+        : <Badges card={card} show={dim?['state']:['state','risk','gate']} />}
+      {/* read-only mirror: NOT a place to act — a quiet label pointing to the inbox (#1) */}
+      {card.waitingOn === 'operator' && (
+        <button onClick={(e)=>{e.stopPropagation(); onGoInbox();}}
+          aria-label="This item awaits your decision in the Decision Inbox — jump to it"
+          style={{ width:'100%', marginTop:12, display:'flex', alignItems:'center', gap:7, padding:'7px 10px',
+            borderRadius:'var(--r-sm)', background:'transparent', border:'1px dashed var(--hm-line)', cursor:'pointer', textAlign:'left' }}>
+          <span aria-hidden="true" style={{ width:6, height:6, borderRadius:'50%', background:'var(--act)', flex:'none' }} />
+          <span style={{ fontSize:11.5, color:'var(--hm-muted)' }}>Awaiting your decision · in inbox</span>
+          <span className="font-display" style={{ marginLeft:'auto', fontSize:11, fontWeight:600, color:'var(--hm-faint)', flex:'none' }}>jump ›</span>
+        </button>
+      )}
+    </article>
+  );
+}
+
+/* ───────── codex composer ───────── */
+function ColComposer({ onAskHermes }) {
+  const [open, setOpen] = React.useState(false);
+  if (!open) return <button onClick={()=>setOpen(true)} className="btn btn--soft btn--sm" style={{ width:'100%', marginBottom:'var(--gap-cards)', borderStyle:'dashed' }}>+ Propose task</button>;
+  return (
+    <div style={{ background:'var(--hm-paper)', border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-card)', padding:12, marginBottom:'var(--gap-cards)' }}>
+      <div style={{ display:'flex', gap:6, marginBottom:8 }}>
+        <select className="font-display" style={{ height:32, padding:'0 8px', borderRadius:'var(--r-sm)', border:'1px solid var(--hm-line)', background:'var(--hm-paper-sunken)', fontSize:12, fontWeight:600, color:'var(--hm-ink)' }}>
+          <option>claude</option><option>codex</option>
+        </select>
+        <input placeholder="owner/repo" className="mono" style={{ flex:1, minWidth:0, height:32, padding:'0 10px', borderRadius:'var(--r-sm)', border:'1px solid var(--hm-line)', background:'var(--hm-paper-sunken)', fontSize:12, color:'var(--hm-ink)', outline:'none' }} />
+      </div>
+      <textarea placeholder="Describe the task…" rows={2} style={{ width:'100%', padding:'8px 10px', borderRadius:'var(--r-sm)', border:'1px solid var(--hm-line)', background:'var(--hm-paper-sunken)', fontSize:12.5, fontFamily:'var(--font-body)', color:'var(--hm-ink)', resize:'none', outline:'none' }} />
+      <div style={{ display:'flex', gap:8, marginTop:9 }}>
+        <button className="btn btn--soft btn--sm" style={{ flex:1, background:'var(--hm-ink)', color:'var(--hm-paper)', border:'1px solid transparent' }}>Propose</button>
+        <button onClick={()=>setOpen(false)} className="btn btn--soft btn--sm">Cancel</button>
+      </div>
+      <p style={{ margin:'8px 0 0', fontSize:11, color:'var(--hm-faint)' }}>Lands proposed — it appears in Your decisions before any runner claims it.</p>
+    </div>
+  );
+}
+
+/* ───────── column ───────── */
+function Column({ lane, cards, isInbox, onAction, onOpen, onOpenReplay, onAskHermes, onCollapse, onGoInbox, arrivedId, expandedId, setExpandedId }) {
+  const tm = TIER_META[lane.tier];
+  const urgentId = isInbox ? (cards.find(c=>c.urgent) ? cards.find(c=>c.urgent).id : (cards[0]&&cards[0].id)) : null;
+  return (
+    <section data-screen-label={lane.name} style={{
+      flex: isInbox ? '1.25 1 0' : '1 1 0',
+      minWidth: isInbox ? 'min(320px, 82vw)' : 'min(266px, 78vw)',
+      maxWidth: isInbox ? 470 : 420,
+      alignSelf:'stretch',
+      height:'100%',
+      display:'flex', flexDirection:'column', minHeight:0,
+      background:'var(--hm-surface)', border:`1px solid ${tm.line}`, borderRadius:'var(--r-lane)', overflow:'hidden',
+      boxShadow: isInbox?'var(--sh-sm)':'none' }}>
+      <header style={{ flex:'none', padding:'12px 14px 11px', background: tm.headBg, borderBottom:`1px solid ${tm.line}` }}>
+        <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+          <span className="eyebrow" style={{ color: tm.text, fontSize:9.5 }}>{isInbox?'Decision inbox':tm.label}</span>
+          {!isInbox && <button onClick={onCollapse} title="Collapse" style={{ width:22, height:22, borderRadius:6, border:'1px solid var(--hm-line)', background:'var(--hm-paper)', color:'var(--hm-muted)', cursor:'pointer', fontSize:12, lineHeight:1, flex:'none' }}>‹</button>}
+        </div>
+        <div style={{ display:'flex', alignItems:'center', gap:8, marginTop:6 }}>
+          <span className="font-display" style={{ fontWeight:700, fontSize:15, whiteSpace:'nowrap' }}>{lane.name}</span>
+          <span className="font-display" style={{ minWidth:20, height:20, padding:'0 6px', borderRadius:'var(--r-pill)',
+            background: cards.length? tm.countBg : 'var(--hm-paper-sunken)', color: cards.length? tm.countFg : 'var(--hm-faint)',
+            display:'grid', placeItems:'center', fontSize:11, fontWeight:700 }}>
+            <CountTween value={cards.length} />
+          </span>
+        </div>
+        <div className="eyebrow" style={{ marginTop:4, color:'var(--hm-faint)', fontSize:9.5 }}>{lane.sub}</div>
+      </header>
+      <div className="scroll-y" style={{ flex:'1 1 auto', minHeight:0, padding:'var(--pad-lane)', display:'flex', flexDirection:'column', gap:'var(--gap-cards)' }}>
+        {lane.id==='codex' && <ColComposer onAskHermes={onAskHermes} />}
+        {cards.length === 0 && (
+          <div style={{ display:'flex', alignItems:'center', gap:10, padding:'12px 12px', borderRadius:'var(--r-sm)',
+            border:'1px dashed var(--hm-line)', background:'var(--hm-paper-sunken)' }}>
+            <span aria-hidden="true" style={{ width:24, height:24, borderRadius:7, flex:'none', display:'grid', placeItems:'center',
+              background: isInbox?'var(--ok-soft)':'var(--hm-paper)', color: isInbox?'var(--ok-text)':'var(--hm-faint)', fontSize:13 }}>{isInbox?'✓':'·'}</span>
+            <div style={{ minWidth:0 }}>
+              <div className="font-display" style={{ fontSize:12.5, fontWeight:600, color: isInbox?'var(--ok-text)':'var(--hm-muted)' }}>{isInbox?'Nothing waiting on you':'No cards'}</div>
+              <div style={{ fontSize:11, color:'var(--hm-faint)', marginTop:1 }}>{isInbox?'agents are working — watch the lanes':'nothing in this stage'}</div>
+            </div>
+          </div>
+        )}
+        {cards.map(card => isInbox
+          ? <InboxCard key={card.id} card={card} urgent={card.id===urgentId}
+              expanded={expandedId===card.id} onToggle={()=>setExpandedId(expandedId===card.id?null:card.id)}
+              onAction={onAction} onOpen={()=>onOpen(card.id)} onOpenReplay={onOpenReplay} onAskHermes={onAskHermes}
+              justArrived={arrivedId===card.id} />
+          : <PipelineCard key={card.id} card={card} onOpen={()=>onOpen(card.id)} onGoInbox={onGoInbox} justArrived={arrivedId===card.id} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+/* ───────── collapsed rail (gate lanes only; empty non-gate hides fully — K) ───────── */
+function Rail({ lane, count, onExpand }) {
+  const tm = TIER_META[lane.tier];
+  return (
+    <button onClick={onExpand} className="krail" style={{ flex:'none', width:50, alignSelf:'stretch',
+      background:'var(--hm-surface)', border:`1px ${count?'solid':'dashed'} ${tm.line}`, borderRadius:'var(--r-lane)',
+      display:'flex', flexDirection:'column', alignItems:'center', gap:14, padding:'14px 6px', cursor:'pointer' }}>
+      <span className="font-display" style={{ minWidth:22, height:22, padding:'0 5px', borderRadius:'var(--r-pill)',
+        background: count? tm.countBg : 'transparent', color: count? tm.countFg : 'var(--hm-faint)',
+        border: count? 'none':`1px solid ${tm.line}`, display:'grid', placeItems:'center', fontSize:11, fontWeight:700 }}>{count}</span>
+      <span className="font-display" style={{ writingMode:'vertical-rl', transform:'rotate(180deg)', fontSize:11.5, fontWeight:700, textTransform:'uppercase', color: tm.text, whiteSpace:'nowrap' }}>{lane.name}</span>
+      {lane.gate && <span className="eyebrow" style={{ writingMode:'vertical-rl', transform:'rotate(180deg)', fontSize:8, color:'var(--act-text)', marginTop:'auto' }}>gate</span>}
+    </button>
+  );
+}
+
+/* ───────── the row ───────── */
+function KanbanRow({ cards, decide, arrivedId, onOpenCard, onOpenReplay, onAskHermes }) {
+  const [collapsed, setCollapsed] = React.useState(() => new Set(['queue']));
+  const [expandedId, setExpandedId] = React.useState(null);
+  const positions = React.useRef(new Map());
+  const goInbox = () => setExpandedId(null);
+
+  // first-mount: auto-expand the most-urgent inbox card
+  React.useEffect(() => {
+    const inbox = cards.filter(c=>c.waitingOn==='operator');
+    const urgent = inbox.find(c=>c.urgent) || inbox[0];
+    if (urgent) setExpandedId(urgent.id);
+  }, []);
+
+  // generic FLIP — animate any card whose position changed between commits
+  React.useLayoutEffect(() => {
+    const seen = new Set();
+    document.querySelectorAll('[data-flip-id]').forEach(el => {
+      const id = el.getAttribute('data-flip-id'); seen.add(id);
+      const r = el.getBoundingClientRect();
+      const prev = positions.current.get(id);
+      positions.current.set(id, r);
+      if (!prev || !motionOn()) return;
+      const dx = prev.left - r.left, dy = prev.top - r.top;
+      if (Math.abs(dx) < 1 && Math.abs(dy) < 1) return;
+      const arriving = id === arrivedId;
+      const travelled = Math.hypot(dx, dy);
+      el.style.transition = 'none';
+      el.style.transform = arriving ? `translate(${dx}px,${dy}px) scale(1.06)` : `translate(${dx}px,${dy}px)`;
+      if (arriving) { el.style.zIndex='8'; el.style.boxShadow='var(--sh-lift)'; } else el.style.zIndex='5';
+      requestAnimationFrame(() => {
+        const dur = arriving ? Math.min(780, 500 + travelled*0.55) : 420;
+        const spring = arriving ? 'cubic-bezier(.34,1.62,.4,1)' : 'cubic-bezier(.2,.7,.2,1)';
+        el.style.transition = `transform ${dur}ms ${spring}, box-shadow ${dur}ms ease`;
+        el.style.transform = '';
+        if (arriving) el.style.boxShadow='';
+        setTimeout(()=>{ el.style.zIndex=''; el.style.transition=''; el.style.boxShadow=''; }, dur+40);
+      });
+    });
+    for (const id of [...positions.current.keys()]) if (!seen.has(id)) positions.current.delete(id);
+  });
+
+  const expand = (id) => setCollapsed(prev => { const n=new Set(prev); n.delete(id); return n; });
+  const collapse = (id) => setCollapsed(prev => new Set(prev).add(id));
+
+  const cardsFor = (lane) => lane.inbox
+    ? cards.filter(c => c.waitingOn === 'operator')
+    : cards.filter(c => c.stage === lane.id);
+
+  return (
+    <div className="scroll-x" style={{ height:'100%', display:'flex', gap:12, padding:'2px 22px 16px', alignItems:'flex-start' }}>
+      {LANES.map(lane => {
+        const laneCards = cardsFor(lane);
+        // K: empty non-gate lane hides fully; gate lane stays (as rail if collapsed)
+        if (!lane.inbox && laneCards.length === 0 && !lane.gate) return null;
+        const isCollapsed = !lane.inbox && collapsed.has(lane.id);
+        if (isCollapsed) return <Rail key={lane.id} lane={lane} count={laneCards.length} onExpand={()=>expand(lane.id)} />;
+        return (
+          <Column key={lane.id} lane={lane} cards={laneCards} isInbox={!!lane.inbox}
+            onAction={decide} onOpen={onOpenCard} onOpenReplay={onOpenCard} onAskHermes={onAskHermes}
+            onCollapse={()=>collapse(lane.id)} onGoInbox={goInbox} arrivedId={arrivedId}
+            expandedId={expandedId} setExpandedId={setExpandedId} />
+        );
+      })}
+    </div>
+  );
+}
+
+window.Kanban = { KanbanRow, Badges, DecisionBundle, CheckpointStepper, CardMeta, StatePill, RiskPill, EvidenceChips, GatePill, FailureClass, WhySeeing, STAGE_ORDER, SEED_CHECKPOINTS };

--- a/docs/design/hermes-4/project/parts.jsx
+++ b/docs/design/hermes-4/project/parts.jsx
@@ -1,0 +1,120 @@
+/* Hermes — shared atoms + hooks (exported to window) */
+
+const cx = (...a) => a.filter(Boolean).join(' ');
+
+/* viewport width >= threshold (side-by-side vs stacked) */
+function useWide(threshold = 1180) {
+  const get = () => (typeof window !== 'undefined' ? window.innerWidth >= threshold : true);
+  const [wide, setWide] = React.useState(get);
+  React.useEffect(() => {
+    const on = () => setWide(get());
+    window.addEventListener('resize', on);
+    return () => window.removeEventListener('resize', on);
+  }, []);
+  return wide;
+}
+
+/* live clock that ticks from a HH:MM:SS start */function useClock(start) {
+  const toSec = (s) => { const [h,m,sec]=s.split(':').map(Number); return h*3600+m*60+sec; };
+  const [t, setT] = React.useState(toSec(start));
+  React.useEffect(() => {
+    const id = setInterval(() => setT(x => x + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  const h = Math.floor(t/3600)%24, m = Math.floor(t/60)%60, s = t%60;
+  const p = (n) => String(n).padStart(2,'0');
+  return `${p(h)}:${p(m)}:${p(s)}`;
+}
+
+/* number that pops when it changes */
+function CountTween({ value, className }) {
+  const [disp, setDisp] = React.useState(value);
+  const [pop, setPop] = React.useState(false);
+  const ref = React.useRef(value);
+  React.useEffect(() => {
+    if (ref.current === value) return;
+    ref.current = value;
+    setDisp(value); setPop(true);
+    const id = setTimeout(() => setPop(false), 440);
+    return () => clearTimeout(id);
+  }, [value]);
+  return <span className={cx(className, pop && 'pop')} style={{ display:'inline-block' }}>{disp}</span>;
+}
+
+/* presence dot — online | active | idle */
+function PresenceDot({ presence, color = 'var(--ok)', size = 9, ring = true }) {
+  const base = { width:size, height:size, borderRadius:'50%', position:'relative', flex:'none' };
+  if (presence === 'idle') {
+    return <span style={{ ...base, border:`1.5px solid ${color}`, opacity:0.5, background:'transparent' }} />;
+  }
+  return (
+    <span style={{ ...base, background: color, boxShadow: presence==='active' ? `0 0 0 0 ${color}` : 'none' }}>
+      {presence === 'active' && ring && (
+        <span className="breathe-ring" style={{ position:'absolute', inset:-1, borderRadius:'50%', boxShadow:`0 0 0 3px ${color}` }} />
+      )}
+    </span>
+  );
+}
+
+/* agent identity — monogram tile (default) or dot, + presence */
+const AvatarStyleContext = React.createContext('tile');
+function AgentAvatar({ agent, size = 30, style, presence, showPresence = true }) {
+  const ctxStyle = React.useContext(AvatarStyleContext);
+  style = style || ctxStyle;
+  const a = agent;
+  const pres = presence || a.presence;
+  if (style === 'dot') {
+    return (
+      <span style={{ display:'inline-flex', alignItems:'center', gap:7 }}>
+        <PresenceDot presence={pres} color={a.color} size={Math.round(size*0.34)} />
+        <span className="font-display" style={{ fontWeight:600, color:a.color, fontSize:size*0.46 }}>{a.name}</span>
+      </span>
+    );
+  }
+  const r = Math.max(8, size*0.32);
+  return (
+    <span style={{ position:'relative', flex:'none', width:size, height:size }}>
+      <span className="font-display" style={{
+        width:size, height:size, borderRadius:r, background:a.color, color:'#fff',
+        display:'grid', placeItems:'center', fontWeight:700, fontSize:size*0.46,
+        boxShadow:'inset 0 1px 0 rgba(255,255,255,0.25), 0 1px 3px rgba(40,33,18,0.18)',
+        letterSpacing:'0',
+      }}>{a.mark}</span>
+      {showPresence && (
+        <span style={{ position:'absolute', right:-2, bottom:-2, padding:2, background:'var(--hm-paper)', borderRadius:'50%', display:'grid', placeItems:'center' }}>
+          <PresenceDot presence={pres} color={pres==='idle' ? 'var(--hm-faint)' : 'var(--ok)'} size={8} />
+        </span>
+      )}
+    </span>
+  );
+}
+
+/* brand mark tile */
+function BrandMark({ size = 38, label = 'A' }) {
+  return (
+    <span className="font-display" style={{
+      width:size, height:size, borderRadius:11, background:'var(--hm-ink)', color:'var(--hm-paper)',
+      display:'grid', placeItems:'center', fontWeight:700, fontSize:size*0.5,
+      boxShadow:'inset 0 1px 0 rgba(255,255,255,0.18), var(--sh-sm)', flex:'none',
+    }}>{label}</span>
+  );
+}
+
+const TONE_BG = { act:'var(--act-soft)', ok:'var(--ok-soft)', warn:'var(--warn-soft)', tel:'var(--tel-chip)', ink:'var(--hm-paper-sunken)' };
+const TONE_FG = { act:'var(--act-text)', ok:'var(--ok-text)', warn:'var(--warn-text)', tel:'var(--tel)', ink:'var(--hm-ink-2)' };
+
+function Pill({ tone='tel', dot=false, children, className, style }) {
+  return (
+    <span className={cx('pill', className)} style={{ background:TONE_BG[tone], color:TONE_FG[tone], ...style }}>
+      {dot && <span className="dot" />}
+      {children}
+    </span>
+  );
+}
+
+/* small label eyebrow */
+function Lab({ children, act, style }) {
+  return <span className={cx('eyebrow', act && 'eyebrow--act')} style={style}>{children}</span>;
+}
+
+Object.assign(window, { cx, useWide, useClock, CountTween, PresenceDot, AgentAvatar, BrandMark, Pill, Lab, TONE_BG, TONE_FG, AvatarStyleContext });

--- a/docs/design/hermes-4/project/rail.jsx
+++ b/docs/design/hermes-4/project/rail.jsx
@@ -1,0 +1,170 @@
+/* Hermes — right rail: Digest (default) + Agent Room tabs, and the cast roster.
+   The room explains the board; it isn't the board. */
+const { ROLES, AGENTS: AGRail } = window.HERMES_DATA;
+
+/* ── cast roster (I) — modal overlay listing per-role capabilities ── */
+function Roster({ open, onClose }) {
+  React.useEffect(() => {
+    const onKey = e => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey); return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+  const capColor = (c) => /mutate|merge|deploy/.test(c) ? 'var(--warn-text)' : (c==='approve'?'var(--act-text)':'var(--ok-text)');
+  return (
+    <>
+      <div onClick={onClose} style={{ position:'fixed', inset:0, background:'rgba(10,8,14,0.46)', backdropFilter:'blur(2px)', zIndex:70,
+        opacity:open?1:0, pointerEvents:open?'auto':'none', transition:'opacity var(--dur) var(--ease)' }} />
+      <div style={{ position:'fixed', top:'50%', left:'50%', width:'min(560px,92vw)', maxHeight:'84vh', zIndex:71,
+        transform:`translate(-50%,-50%) scale(${open?1:0.97})`, opacity:open?1:0, pointerEvents:open?'auto':'none',
+        transition:'opacity var(--dur) var(--ease), transform var(--dur) var(--ease)',
+        background:'var(--hm-paper)', border:'1px solid var(--hm-line)', borderRadius:'var(--r-card)', boxShadow:'var(--sh-lift)', display:'flex', flexDirection:'column', overflow:'hidden' }}>
+        <div style={{ flex:'none', padding:'16px 18px', borderBottom:'1px solid var(--hm-line)', display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+          <div>
+            <div className="font-display" style={{ fontWeight:700, fontSize:17 }}>The cast</div>
+            <div className="eyebrow" style={{ marginTop:3, color:'var(--hm-faint)' }}>who can observe · mutate · approve</div>
+          </div>
+          <button onClick={onClose} className="btn btn--ghost btn--sm" style={{ width:32, padding:0 }}>✕</button>
+        </div>
+        <div className="scroll-y" style={{ padding:'12px 16px 16px', display:'grid', gap:10 }}>
+          {ROLES.map(r => {
+            const ag = AGRail[r.id] || { color:'var(--hm-faint)', mark:r.name[0], presence:'idle' };
+            return (
+              <div key={r.id} style={{ display:'flex', gap:12, padding:'12px 13px', borderRadius:'var(--r-sm)',
+                background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', opacity: r.active?1:0.6 }}>
+                <AgentAvatar agent={ag} size={32} presence={r.active?ag.presence:'idle'} />
+                <div style={{ minWidth:0, flex:1 }}>
+                  <div style={{ display:'flex', alignItems:'center', gap:8, flexWrap:'wrap' }}>
+                    <span className="font-display" style={{ fontWeight:700, fontSize:14, color:ag.color }}>{r.name}</span>
+                    <span className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)' }}>{r.title}</span>
+                    {!r.active && <span className="chip" style={{ padding:'1px 7px', fontSize:9 }}>not engaged</span>}
+                  </div>
+                  <p style={{ margin:'5px 0 8px', fontSize:12.5, color:'var(--hm-muted)', lineHeight:1.5 }}>{r.blurb}</p>
+                  <div style={{ display:'flex', gap:5, flexWrap:'wrap' }}>
+                    {r.can.map(c => <span key={c} className="chip" style={{ padding:'2px 8px', fontSize:10, color:capColor(c) }}>✓ {c}</span>)}
+                    {r.cannot.map(c => <span key={c} className="chip" style={{ padding:'2px 8px', fontSize:10, color:'var(--hm-faint)', textDecoration:'line-through' }}>{c}</span>)}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+}
+
+/* ── digest (H) — what changed + what needs me ── */
+function DigestStat({ label, value, tone, needsData }) {
+  return (
+    <div style={{ flex:1, minWidth:0, background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-sm)', padding:'10px 12px' }}>
+      <div className="font-display" style={{ fontSize:22, fontWeight:700, color: needsData?'var(--hm-faint)':(tone||'var(--hm-ink)') }}>{needsData?'—':value}</div>
+      <div className="eyebrow" style={{ fontSize:8.5, color:'var(--hm-faint)', marginTop:2 }}>{label}</div>
+    </div>
+  );
+}
+
+function DigestView({ cards, advanced, onOpenCard, onOpenRoster, onGoRoom }) {
+  const { LAST_LOOKED } = window.HERMES_DATA;
+  const inbox = cards.filter(c => c.waitingOn === 'operator');
+  const running = cards.filter(c => c.state && c.state.kind === 'running');
+  const riskTone = (lvl) => lvl==='high'||lvl==='med' ? 'var(--warn-text)' : 'var(--hm-muted)';
+  return (
+    <div className="scroll-y" style={{ flex:1, minHeight:0, padding:'16px 16px 20px' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:10, marginBottom:6 }}>
+        <BrandMark size={30} label="H" />
+        <div>
+          <div className="font-display" style={{ fontWeight:700, fontSize:15 }}>Hermes digest</div>
+          <div className="mono" style={{ fontSize:11, color:'var(--hm-faint)' }} title="The last-look marker needs a real session backend — timestamp shown, deltas awaiting data">since you last looked · {LAST_LOOKED ? LAST_LOOKED.time : '—'}</div>
+        </div>
+      </div>
+
+      <div style={{ display:'flex', gap:8, margin:'12px 0 6px' }}>
+        <DigestStat label="needs you" value={inbox.length} tone="var(--act-text)" />
+        <DigestStat label="running now" value={running.length} tone="var(--ok-text)" />
+        <DigestStat label="advanced (session)" value={advanced} />
+        <DigestStat label="prod changes" value={0} />
+      </div>
+      <p style={{ fontSize:11.5, color:'var(--hm-faint)', margin:'4px 2px 16px', lineHeight:1.5 }}>
+        Since 13:18: “advanced” counts moves you made this session; per-event deltas need a real session backend — honest until wired.
+      </p>
+
+      <div className="eyebrow" style={{ marginBottom:9 }}>{inbox.length} waiting on you</div>
+      {inbox.length === 0 ? (
+        <div style={{ textAlign:'center', padding:'28px 10px', color:'var(--hm-faint)' }}>
+          <div style={{ fontSize:24, color:'var(--ok-text)' }}>✓</div>
+          <div className="font-display" style={{ fontSize:13, fontWeight:600, color:'var(--ok-text)', marginTop:6 }}>Inbox clear</div>
+          <div style={{ fontSize:12, marginTop:3 }}>Nothing needs your judgment right now.</div>
+        </div>
+      ) : (
+        <div style={{ display:'grid', gap:8 }}>
+          {inbox.map(c => {
+            const ag = AGRail[c.author] || AGRail.system;
+            const d = c.decision;
+            return (
+              <button key={c.id} onClick={()=>onOpenCard(c.id)} className="cardref click" style={{ textAlign:'left',
+                display:'block', padding:'10px 12px', borderRadius:'var(--r-sm)', width:'100%',
+                background:'var(--hm-paper-sunken)', border:`1px solid ${c.urgent?'var(--act-line)':'var(--hm-line-2)'}`, cursor:'pointer' }}>
+                <div style={{ display:'flex', gap:10, alignItems:'flex-start' }}>
+                  <span style={{ width:7, height:7, borderRadius:'50%', marginTop:5, flex:'none', background: c.urgent?'var(--act)':'var(--hm-line-strong)' }} />
+                  <span style={{ minWidth:0, flex:1 }}>
+                    <span className="font-display" style={{ display:'block', fontSize:13, fontWeight:600, color:'var(--hm-ink)', textWrap:'pretty' }}>{c.title}</span>
+                    <span style={{ fontSize:11, color:'var(--hm-faint)' }}>{ag.name}</span>
+                  </span>
+                  <span className="font-display" style={{ fontSize:11.5, fontWeight:600, color:'var(--act-text)', flex:'none' }}>Open ›</span>
+                </div>
+                {/* enriched: recommended · risk · grants (#6) */}
+                <div style={{ margin:'7px 0 0 17px', display:'grid', gap:3 }}>
+                  {d && <div style={{ fontSize:11.5, color:'var(--hm-ink-2)' }}><span style={{ color:'var(--hm-faint)' }}>rec ·</span> {d.recommended}</div>}
+                  <div style={{ display:'flex', gap:10, flexWrap:'wrap', fontSize:11 }}>
+                    {c.risk && <span style={{ color:riskTone(c.risk.level) }}>risk · {c.risk.level} · {c.risk.type}</span>}
+                    {d && d.grants && <span className="mono" style={{ color:'var(--hm-faint)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap', maxWidth:'22ch' }} title={d.grants}>grants · {d.grants}</span>}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      <div style={{ display:'flex', gap:8, marginTop:18 }}>
+        <button onClick={onGoRoom} className="btn btn--soft btn--sm" style={{ flex:1 }}>Open agent room →</button>
+        <button onClick={onOpenRoster} className="btn btn--soft btn--sm">Who’s who</button>
+      </div>
+    </div>
+  );
+}
+
+/* ── right rail shell: tabs + persistent composer ── */
+function RightRail({ tab, setTab, cards, advanced, onOpenCard, roomProps }) {
+  const [roster, setRoster] = React.useState(false);
+  const inbox = cards.filter(c => c.waitingOn === 'operator').length;
+  const Tab = ({ id, label, badge }) => (
+    <button onClick={()=>setTab(id)} className="font-display" style={{ flex:1, height:38, border:0, cursor:'pointer', position:'relative',
+      background: tab===id?'var(--hm-paper)':'transparent', color: tab===id?'var(--hm-ink)':'var(--hm-muted)',
+      fontSize:13, fontWeight:tab===id?700:600, display:'inline-flex', alignItems:'center', justifyContent:'center', gap:7,
+      borderBottom:`2px solid ${tab===id?'var(--act)':'transparent'}` }}>
+      {label}
+      {badge>0 && <span className="mono" style={{ fontSize:10, minWidth:16, height:16, padding:'0 4px', borderRadius:8, display:'grid', placeItems:'center',
+        background: tab===id?'var(--act-soft)':'var(--hm-paper-sunken)', color: tab===id?'var(--act-text)':'var(--hm-faint)' }}>{badge}</span>}
+    </button>
+  );
+  const Composer = window.Room.Composer;
+  return (
+    <aside style={{ display:'flex', flexDirection:'column', height:'100%', background:'var(--hm-paper)', borderLeft:'1px solid var(--hm-line)', minWidth:0 }}>
+      <div style={{ flex:'none', display:'flex', borderBottom:'1px solid var(--hm-line)', background:'var(--hm-paper-veil)', backdropFilter:'blur(8px)' }}>
+        <Tab id="digest" label="Digest" badge={inbox} />
+        <Tab id="room" label="Agent room" badge={0} />
+      </div>
+      {/* tab content fills the middle; composer is always pinned below */}
+      <div style={{ flex:1, minHeight:0, display:'flex', flexDirection:'column' }}>
+        {tab === 'digest'
+          ? <DigestView cards={cards} advanced={advanced} onOpenCard={onOpenCard} onOpenRoster={()=>setRoster(true)} onGoRoom={()=>setTab('room')} />
+          : <RoomColumn {...roomProps} onOpenRoster={()=>setRoster(true)} hideHeader noComposer />}
+      </div>
+      {/* persistent Ask-Hermes composer — present in BOTH modes (acting/asking always available) */}
+      <Composer {...roomProps.composer} onOpenCard={onOpenCard} />
+      <Roster open={roster} onClose={()=>setRoster(false)} />
+    </aside>
+  );
+}
+
+window.Rail = { RightRail, Roster };

--- a/docs/design/hermes-4/project/room.jsx
+++ b/docs/design/hermes-4/project/room.jsx
@@ -1,0 +1,260 @@
+/* Hermes — collaboration room (right column) */
+const { AGENTS: AGR, KIND_META } = window.HERMES_DATA;
+
+const targetLabel = (t) => t==='operator' ? 'you' : t==='everyone' ? 'everyone' : (AGR[t]?.name || t);
+
+/* ───────── co-pilot header ───────── */
+function CoPilotHeader() {
+  return (
+    <div style={{ padding:'16px 18px 12px', borderBottom:'1px solid var(--hm-line)', flex:'none' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:11 }}>
+        <BrandMark size={34} label="H" />
+        <div style={{ minWidth:0 }}>
+          <div className="font-display" style={{ fontWeight:700, fontSize:16 }}>Hermes co-pilot</div>
+          <div style={{ display:'flex', alignItems:'center', gap:7, marginTop:2 }}>
+            <span className="dot live-dot" style={{ width:6, height:6, borderRadius:'50%', background:'var(--ok)' }} />
+            <span style={{ fontSize:12, color:'var(--hm-muted)' }}>Live activity · context: whole board</span>
+          </div>
+        </div>
+      </div>
+      <div className="cardref click" style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:10, marginTop:12,
+        padding:'9px 12px', borderRadius:'var(--r-sm)', background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)' }}>
+        <div style={{ minWidth:0 }}>
+          <div style={{ display:'flex', alignItems:'center', gap:7 }}>
+            <span style={{ color:'var(--hm-faint)' }}>▸</span>
+            <span className="font-display" style={{ fontWeight:600, fontSize:12.5 }}>Suggested follow-ups (3)</span>
+          </div>
+          <div className="eyebrow" style={{ marginTop:3, color:'var(--hm-faint)' }}>planner-only · read-only</div>
+        </div>
+        <span className="mono" style={{ fontSize:11.5, color:'var(--hm-faint)', flex:'none' }}>no tasks created</span>
+      </div>
+    </div>
+  );
+}
+
+/* ───────── presence bar ───────── */
+function PresenceBar({ presence, onOpenRoster }) {
+  const order = ['hermes','claude','codex','test'];
+  const active = order.filter(id => (presence[id]||AGR[id].presence)==='active').length;
+  return (
+    <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', gap:10, padding:'12px 18px',
+      borderBottom:'1px solid var(--hm-line)', flex:'none', background:'var(--hm-paper-veil)' }}>
+      <div>
+        <span className="font-display" style={{ fontWeight:700, fontSize:14 }}>Room</span>
+        <button onClick={onOpenRoster} className="click" style={{ marginLeft:8, fontSize:12, color:'var(--hm-muted)', background:'none', border:0, cursor:'pointer', textDecoration:'underline', textDecorationColor:'var(--hm-line-strong)', textUnderlineOffset:2 }}>who’s who ↗</button>
+      </div>
+      <button onClick={onOpenRoster} className="click" title="Open the cast roster" style={{ display:'flex', alignItems:'center', gap:6, background:'none', border:0, cursor:'pointer' }}>
+        {order.map(id => {
+          const pres = presence[id] || AGR[id].presence;
+          return <span key={id} title={`${AGR[id].name} · ${pres}`} style={{ position:'relative' }}><AgentAvatar agent={AGR[id]} size={24} presence={pres} /></span>;
+        })}
+        <span className="mono" style={{ fontSize:11, color: active? 'var(--ok-text)':'var(--hm-faint)', marginLeft:4 }}>{active} active</span>
+      </button>
+    </div>
+  );
+}
+
+/* ───────── a single turn ───────── */
+function Turn({ turn, fresh }) {
+  const a = AGR[turn.author] || AGR.system;
+  const meta = KIND_META[turn.kind] || KIND_META.status;
+  const muted = turn.kind === 'status';
+  const prominent = meta.rank >= 2;
+  return (
+    <div className={cx(fresh && 'anim-slide')} style={{
+      display:'flex', gap:11, padding:'11px 12px', borderRadius:'var(--r-sm)',
+      background: prominent ? (meta.tone==='act'?'var(--act-soft)':'var(--ok-soft)') : 'transparent',
+      borderLeft: prominent ? `3px solid ${meta.tone==='act'?'var(--act)':'var(--ok)'}` : '3px solid transparent',
+      opacity: muted ? 0.82 : 1 }}>
+      <AgentAvatar agent={a} size={muted?22:28} presence={turn.author==='operator'?'online':a.presence} />
+      <div style={{ minWidth:0, flex:1 }}>
+        <div style={{ display:'flex', alignItems:'center', gap:7, flexWrap:'wrap' }}>
+          <span style={{ display:'inline-flex', alignItems:'center', gap:6, whiteSpace:'nowrap' }}>
+            <span className="font-display" style={{ fontWeight:600, fontSize:13, color:a.color }}>{a.name}</span>
+            {turn.target && <span style={{ color:'var(--hm-faint)', fontSize:12 }}>→ {targetLabel(turn.target)}</span>}
+          </span>
+          <span className={cx('pill', `pill--${meta.tone}`)} style={{ minHeight:18, height:18, fontSize:9.5, padding:'0 8px' }}>{meta.label}</span>
+          {turn.demo && <span className="chip" style={{ padding:'1px 6px', fontSize:9.5, color:'var(--ag-claude)', borderColor:'rgba(112,72,182,0.3)' }}>demo</span>}
+          {turn.preview && <span className="chip" style={{ padding:'1px 6px', fontSize:9.5, color:'var(--act-text)', borderColor:'var(--act-line)' }}>preview</span>}
+          <span className="mono" style={{ marginLeft:'auto', fontSize:11, color:'var(--hm-faint)' }}>{turn.time}</span>
+        </div>
+        <p style={{ margin:'5px 0 0', fontSize: muted?13:13.5, color:'var(--hm-ink-2)', lineHeight:1.62 }}>
+          {turn.pending && <span className="spin" style={{ display:'inline-block', width:9, height:9, marginRight:6, borderRadius:'50%', border:'2px solid var(--hm-line)', borderTopColor:'var(--hm-muted)', verticalAlign:'middle' }} />}
+          {turn.text}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function TypingBubble({ agentId }) {
+  const a = AGR[agentId]; if (!a) return null;
+  return (
+    <div className="anim-rise" style={{ display:'flex', gap:11, padding:'8px 12px', alignItems:'center' }}>
+      <AgentAvatar agent={a} size={24} presence="active" />
+      <span style={{ display:'inline-flex', alignItems:'center', gap:8, padding:'7px 12px', borderRadius:'var(--r-pill)',
+        background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', color:a.color }}>
+        <span className="typing"><i/><i/><i/></span>
+        <span style={{ fontSize:12, color:'var(--hm-muted)' }}>{a.name} is {a.role==='tester'?'replaying':'working'}…</span>
+      </span>
+    </div>
+  );
+}
+
+/* ───────── a thread (card-grouped) ───────── */
+function Thread({ thread, freshSet, typingAgent, onOpenCard }) {
+  const turns = thread.turns;
+  return (
+    <div style={{ borderTop:'1px solid var(--hm-line-2)', padding:'14px 14px 6px' }}>
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:10 }}>
+        <span className="font-display" style={{ fontSize:10.5, fontWeight:700, textTransform:'uppercase', color:'var(--hm-faint)' }}>
+          Thread · {thread.label || ('testbed-mission-'+thread.id)}
+        </span>
+        <span className="mono" style={{ fontSize:10.5, color:'var(--hm-faint)' }}>{turns.length} {turns.length===1?'turn':'turns'}</span>
+      </div>
+      {thread.cardRef && (
+        <div className="cardref click" onClick={()=>onOpenCard(thread.cardRef)} style={{ display:'flex', alignItems:'center', justifyContent:'space-between',
+          gap:8, padding:'9px 11px', borderRadius:'var(--r-sm)', background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', marginBottom:8 }}>
+          <div style={{ minWidth:0 }}>
+            <div className="mono" style={{ fontSize:11.5, color:'var(--hm-ink-2)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{thread.cardRef}</div>
+            <div className="eyebrow" style={{ marginTop:2, color:'var(--hm-faint)' }}>referenced card</div>
+          </div>
+          <span className="font-display" style={{ fontSize:11.5, fontWeight:600, color:'var(--act-text)', flex:'none' }}>open ›</span>
+        </div>
+      )}
+      <div style={{ display:'grid', gap:4 }}>
+        {turns.map(t => <Turn key={t.id} turn={t} fresh={freshSet.has(t.id)} />)}
+        {typingAgent && <TypingBubble agentId={typingAgent} />}
+      </div>
+    </div>
+  );
+}
+
+function EmptyRoom() {
+  return (
+    <div style={{ flex:1, display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:10, padding:30, textAlign:'center' }}>
+      <div style={{ width:46, height:46, borderRadius:14, background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line)',
+        display:'grid', placeItems:'center', color:'var(--hm-faint)', fontSize:20 }}>···</div>
+      <div className="font-display" style={{ fontWeight:600, fontSize:14, color:'var(--hm-muted)' }}>No agent chatter yet</div>
+      <div style={{ fontSize:12.5, color:'var(--hm-faint)', maxWidth:'26ch' }}>Turns appear here as agents coordinate. Nothing is fabricated — empty is honestly empty.</div>
+    </div>
+  );
+}
+
+/* command interpretation (F) — never mutates without this preview */
+function interpret(text) {
+  const s = text.trim();
+  if (s.startsWith('/mission')) return { action:'Create a fresh-agent browser mission', scope:'browser runner only', mutation:'none (read-only)', budget:'≤ 1 run', timeout:'90s', gates:'merge / deploy gates unchanged' };
+  if (s.startsWith('/task')) return { action:'Propose a task for an agent', scope:'open a PR on CI', mutation:'branch + PR · no merge', budget:'≤ 1 task', timeout:'—', gates:'merge / deploy gates unchanged' };
+  if (s.startsWith('/mute')) return { action:'Mute telemetry', scope:'board notifications', mutation:'none', budget:'—', timeout:'1h', gates:'board state unchanged' };
+  return { action:'Send a message to the room', scope:'chat only', mutation:'none', budget:'—', timeout:'—', gates:'no board changes' };
+}
+const isCommand = (text) => text.trim().startsWith('/');
+
+function CommandPreview({ text, onConfirm, onEdit, onCancel }) {
+  const p = interpret(text);
+  const rows = [['scope',p.scope],['mutation',p.mutation],['budget',p.budget],['timeout',p.timeout],['gates',p.gates]];
+  return (
+    <div className="anim-rise" style={{ marginBottom:10, borderRadius:'var(--r-sm)', background:'var(--hm-paper)', border:'1px solid var(--act-line)', padding:'11px 13px' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:8 }}>
+        <span className="dot live-dot" style={{ width:6, height:6, borderRadius:'50%', background:'var(--act)' }} />
+        <span className="eyebrow" style={{ color:'var(--act-text)' }}>Confirm before it runs</span>
+      </div>
+      <div className="font-display" style={{ fontSize:13.5, fontWeight:700, color:'var(--hm-ink)' }}>I will: {p.action}</div>
+      <div style={{ display:'grid', gridTemplateColumns:'auto 1fr', gap:'3px 10px', margin:'8px 0 0' }}>
+        {rows.filter(r=>r[1] && r[1]!=='—').map(([k,v]) => (
+          <React.Fragment key={k}>
+            <span className="eyebrow" style={{ fontSize:8.5, color:'var(--hm-faint)', paddingTop:2 }}>{k}</span>
+            <span className="mono" style={{ fontSize:11.5, color:'var(--hm-ink-2)' }}>{v}</span>
+          </React.Fragment>
+        ))}
+      </div>
+      <div style={{ display:'flex', gap:7, marginTop:11 }}>
+        <button onClick={onConfirm} className="btn btn--act btn--sm" style={{ flex:1 }}>Confirm</button>
+        <button onClick={onEdit} className="btn btn--ghost btn--sm">Edit</button>
+        <button onClick={onCancel} className="btn btn--soft btn--sm">Cancel</button>
+      </div>
+    </div>
+  );
+}
+
+/* ───────── composer ───────── */
+const TO_OPTS = ['@everyone','@hermes','@claude','@codex','@test-writer'];
+function Composer({ to, setTo, draft, setDraft, onSend, sending }) {
+  const [scope, setScope] = React.useState('board');
+  const [supervised, setSupervised] = React.useState(true);
+  const [pending, setPending] = React.useState(null); // text awaiting confirm (F)
+  const taRef = React.useRef(null);
+  const submit = () => {
+    if (!draft.trim() || sending) return;
+    if (isCommand(draft)) { setPending(draft); return; } // mutating command → preview first
+    onSend();
+  };
+  const confirm = () => { setPending(null); onSend(); };
+  return (
+    <div style={{ flex:'none', borderTop:'1px solid var(--hm-line)', padding:'12px 14px 14px', background:'var(--hm-paper-veil)', backdropFilter:'blur(8px)' }}>
+      {pending && <CommandPreview text={pending} onConfirm={confirm} onEdit={()=>{ setPending(null); taRef.current&&taRef.current.focus(); }} onCancel={()=>setPending(null)} />}
+      <div style={{ display:'flex', alignItems:'center', gap:7, marginBottom:9, flexWrap:'wrap' }}>
+        <div style={{ display:'inline-flex', alignItems:'center', gap:6, height:28, padding:'0 4px 0 10px', borderRadius:'var(--r-pill)',
+          background:'var(--hm-ink)', color:'var(--hm-paper)' }}>
+          <span className="eyebrow" style={{ color:'rgba(255,255,255,0.6)', fontSize:9.5 }}>To</span>
+          <select value={to} onChange={e=>setTo(e.target.value)} className="font-display" style={{ height:24, border:0, background:'transparent',
+            color:'#fff', fontSize:12, fontWeight:600, outline:'none', cursor:'pointer' }}>
+            {TO_OPTS.map(o => <option key={o} value={o} style={{ color:'#000' }}>{o}</option>)}
+          </select>
+        </div>
+        <button onClick={()=>setScope(s=>s==='board'?'card':'board')} className="chip click" style={{ height:28 }}>
+          <span className="eyebrow" style={{ fontSize:9.5 }}>Scope</span> {scope}
+        </button>
+        <button onClick={()=>setSupervised(s=>!s)} className="chip click" style={{ height:28, color: supervised?'var(--ok-text)':'var(--hm-faint)', borderColor: supervised?'var(--ok-line)':'var(--hm-line-2)' }}>
+          <span style={{ width:7, height:7, borderRadius:'50%', border:`1.5px solid currentColor`, background: supervised?'currentColor':'transparent' }} />
+          {supervised?'supervised':'auto'}
+        </button>
+        <span className="mono" style={{ marginLeft:'auto', fontSize:10.5, color:'var(--hm-faint)' }}>↵ send · ⇧↵ newline</span>
+      </div>
+      <div style={{ display:'flex', gap:9, alignItems:'flex-end' }}>
+        <textarea ref={taRef} value={draft} onChange={e=>setDraft(e.target.value)} rows={2}
+          onKeyDown={e=>{ if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); submit(); } }}
+          placeholder="Ask Hermes · /task <agent> <repo> <prompt> · /mission <url> · /mute 1h"
+          style={{ flex:1, padding:'10px 12px', borderRadius:'var(--r-btn)', border:'1px solid var(--hm-line)', background:'var(--hm-paper)',
+            fontSize:13, fontFamily:'var(--font-body)', color:'var(--hm-ink)', resize:'none', outline:'none', minHeight:46 }} />
+        <button className={cx('btn', isCommand(draft)?'btn--soft':'btn--act')} onClick={submit} disabled={sending}
+          style={ isCommand(draft) ? { height:46, background:'var(--hm-ink)', color:'var(--hm-paper)', border:'1px solid transparent', opacity:sending?0.7:1 } : { height:46, opacity: sending?0.7:1 } }>
+          {sending ? <span className="typing" style={{ color:'#fff' }}><i/><i/><i/></span> : (isCommand(draft) ? 'Preview ↵' : <>Send ↵</>)}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/* ───────── room column ───────── */
+function RoomColumn({ threads, presence, typingMap, onOpenCard, onOpenRoster, demoActive, composer, hideHeader, noComposer }) {
+  const scrollRef = React.useRef(null);
+  const hasTurns = threads.some(t => t.turns.length);
+  React.useEffect(() => {
+    const el = scrollRef.current; if (el) el.scrollTop = el.scrollHeight;
+  }, [threads, typingMap, composer && composer.sending]);
+  return (
+    <aside style={{ display:'flex', flexDirection:'column', height:'100%', background:'var(--hm-paper)', minWidth:0 }}>
+      {!hideHeader && <CoPilotHeader />}
+      <PresenceBar presence={presence} onOpenRoster={onOpenRoster} />
+      <div ref={scrollRef} className="scroll-y" style={{ flex:1, minHeight:0 }}>
+        {demoActive && (
+          <div style={{ display:'flex', alignItems:'center', gap:8, padding:'8px 14px', background:'rgba(112,72,182,0.06)',
+            borderBottom:'1px solid var(--hm-line-2)' }}>
+            <span style={{ width:6, height:6, borderRadius:'50%', background:'var(--ag-claude)' }} className="live-dot" />
+            <span style={{ fontSize:11.5, color:'var(--ag-claude)' }}>Demo timeline playing — synthetic turns, stripped in production.</span>
+          </div>
+        )}
+        {hasTurns
+          ? threads.filter(t=>t.turns.length || typingMap[t.id]).map(t => (
+              <Thread key={t.id} thread={t} freshSet={composer.freshSet} typingAgent={typingMap[t.id]} onOpenCard={onOpenCard} />
+            ))
+          : <EmptyRoom />}
+      </div>
+      {!noComposer && <Composer {...composer} onOpenCard={onOpenCard} />}
+    </aside>
+  );
+}
+
+window.Room = { RoomColumn, Composer, PresenceBar, Turn, targetLabel };

--- a/docs/design/hermes-4/project/tweaks-panel.jsx
+++ b/docs/design/hermes-4/project/tweaks-panel.jsx
@@ -1,0 +1,541 @@
+// @ds-adherence-ignore -- omelette starter scaffold (raw elements/hex/px by design)
+
+/* BEGIN USAGE */
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+// Exports (to window): useTweaks, TweaksPanel, TweakSection, TweakRow, TweakSlider,
+//   TweakToggle, TweakRadio, TweakSelect, TweakText, TweakNumber, TweakColor, TweakButton.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "palette": ["#D97757", "#29261b", "#f6f4ef"],
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        options={['#D97757', '#2A6FDB', '#1F8A5B', '#7A5AE0']}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakColor  label="Palette" value={t.palette}
+//                        options={[['#D97757', '#29261b', '#f6f4ef'],
+//                                  ['#475569', '#0f172a', '#f1f5f9']]}
+//                        onChange={(v) => setTweak('palette', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// TweakRadio is the segmented control for 2–3 short options (auto-falls-back to
+// TweakSelect past ~16/~10 chars per label); reach for TweakSelect directly when
+// options are many or long. For color tweaks always curate 3-4 options rather than
+// a free picker; an option can also be a whole 2–5 color palette (the stored value
+// is the array). The Tweak* controls are a floor, not a ceiling — build custom
+// controls inside the panel if a tweak calls for UI they don't cover.
+/* END USAGE */
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    transform:scale(var(--dc-inv-zoom,1));transform-origin:bottom right;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;box-sizing:border-box;width:100%;min-width:0;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;box-sizing:border-box;min-width:0;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+
+  .twk-chips{display:flex;gap:6px}
+  .twk-chip{position:relative;appearance:none;flex:1;min-width:0;height:46px;
+    padding:0;border:0;border-radius:6px;overflow:hidden;cursor:default;
+    box-shadow:0 0 0 .5px rgba(0,0,0,.12),0 1px 2px rgba(0,0,0,.06);
+    transition:transform .12s cubic-bezier(.3,.7,.4,1),box-shadow .12s}
+  .twk-chip:hover{transform:translateY(-1px);
+    box-shadow:0 0 0 .5px rgba(0,0,0,.18),0 4px 10px rgba(0,0,0,.12)}
+  .twk-chip[data-on="1"]{box-shadow:0 0 0 1.5px rgba(0,0,0,.85),
+    0 2px 6px rgba(0,0,0,.15)}
+  .twk-chip>span{position:absolute;top:0;bottom:0;right:0;width:34%;
+    display:flex;flex-direction:column;box-shadow:-1px 0 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i{flex:1;box-shadow:0 -1px 0 rgba(0,0,0,.1)}
+  .twk-chip>span>i:first-child{box-shadow:none}
+  .twk-chip svg{position:absolute;top:6px;left:6px;width:13px;height:13px;
+    filter:drop-shadow(0 1px 1px rgba(0,0,0,.3))}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+    // Same-window signal so in-page listeners (deck-stage rail thumbnails)
+    // can react — the parent message only reaches the host, not peers.
+    window.dispatchEvent(new CustomEvent('tweakchange', { detail: edits }));
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel" data-omelette-chrome=""
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">
+          {children}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  // Segments wrap mid-word once per-segment width runs out. The track is
+  // ~248px (280 panel − 28 body pad − 4 seg pad), each button loses 12px
+  // to its own padding, and 11.5px system-ui averages ~6.3px/char — so 2
+  // options fit ~16 chars each, 3 fit ~10. Past that (or >3 options), fall
+  // back to a dropdown rather than wrap.
+  const labelLen = (o) => String(typeof o === 'object' ? o.label : o).length;
+  const maxLen = options.reduce((m, o) => Math.max(m, labelLen(o)), 0);
+  const fitsAsSegments = maxLen <= ({ 2: 16, 3: 10 }[options.length] ?? 0);
+  if (!fitsAsSegments) {
+    // <select> emits strings — map back to the original option value so the
+    // fallback stays type-preserving (numbers, booleans) like the segment path.
+    const resolve = (s) => {
+      const m = options.find((o) => String(typeof o === 'object' ? o.value : o) === s);
+      return m === undefined ? s : typeof m === 'object' ? m.value : m;
+    };
+    return <TweakSelect label={label} value={value} options={options}
+                        onChange={(s) => onChange(resolve(s))} />;
+  }
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+// Relative-luminance contrast pick — checkmarks drawn over a swatch need to
+// read on both #111 and #fafafa without per-option configuration. Hex input
+// only (#rgb / #rrggbb); named or rgb()/hsl() colors fall through to "light".
+function __twkIsLight(hex) {
+  const h = String(hex).replace('#', '');
+  const x = h.length === 3 ? h.replace(/./g, (c) => c + c) : h.padEnd(6, '0');
+  const n = parseInt(x.slice(0, 6), 16);
+  if (Number.isNaN(n)) return true;
+  const r = (n >> 16) & 255, g = (n >> 8) & 255, b = n & 255;
+  return r * 299 + g * 587 + b * 114 > 148000;
+}
+
+const __TwkCheck = ({ light }) => (
+  <svg viewBox="0 0 14 14" aria-hidden="true">
+    <path d="M3 7.2 5.8 10 11 4.2" fill="none" strokeWidth="2.2"
+          strokeLinecap="round" strokeLinejoin="round"
+          stroke={light ? 'rgba(0,0,0,.78)' : '#fff'} />
+  </svg>
+);
+
+// TweakColor — curated color/palette picker. Each option is either a single
+// hex string or an array of 1-5 hex strings; the card adapts — a lone color
+// renders solid, a palette renders colors[0] as the hero (left ~2/3) with the
+// rest stacked in a sharp column on the right. onChange emits the
+// option in the shape it was passed (string stays string, array stays array).
+// Without options it falls back to the native color input for back-compat.
+function TweakColor({ label, value, options, onChange }) {
+  if (!options || !options.length) {
+    return (
+      <div className="twk-row twk-row-h">
+        <div className="twk-lbl"><span>{label}</span></div>
+        <input type="color" className="twk-swatch" value={value}
+               onChange={(e) => onChange(e.target.value)} />
+      </div>
+    );
+  }
+  // Native <input type=color> emits lowercase hex per the HTML spec, so
+  // compare case-insensitively. String() guards JSON.stringify(undefined),
+  // which returns the primitive undefined (no .toLowerCase).
+  const key = (o) => String(JSON.stringify(o)).toLowerCase();
+  const cur = key(value);
+  return (
+    <TweakRow label={label}>
+      <div className="twk-chips" role="radiogroup">
+        {options.map((o, i) => {
+          const colors = Array.isArray(o) ? o : [o];
+          const [hero, ...rest] = colors;
+          const sup = rest.slice(0, 4);
+          const on = key(o) === cur;
+          return (
+            <button key={i} type="button" className="twk-chip" role="radio"
+                    aria-checked={on} data-on={on ? '1' : '0'}
+                    aria-label={colors.join(', ')} title={colors.join(' · ')}
+                    style={{ background: hero }}
+                    onClick={() => onChange(o)}>
+              {sup.length > 0 && (
+                <span>
+                  {sup.map((c, j) => <i key={j} style={{ background: c }} />)}
+                </span>
+              )}
+              {on && <__TwkCheck light={__twkIsLight(hero)} />}
+            </button>
+          );
+        })}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/docs/design/hermes-4/project/utilities.jsx
+++ b/docs/design/hermes-4/project/utilities.jsx
@@ -1,0 +1,299 @@
+/* Hermes — Utilities panel (supporting row: LLM usage · suites · tester launcher)
+   Calm, dim, secondary to the board. Coral appears once — Launch mission. */
+const { AGENTS: AGU } = window.HERMES_DATA;
+
+/* tiny telemetry sparkline (data viz, not decoration) */
+function Sparkline({ data, color='var(--tel)', w=92, h=26 }) {
+  const max = Math.max(...data, 1), min = Math.min(...data, 0);
+  const span = (max - min) || 1;
+  const pts = data.map((v,i) => [ (i/(data.length-1))*w, h - 3 - ((v-min)/span)*(h-6) ]);
+  const d = pts.map((p,i)=> (i?'L':'M')+p[0].toFixed(1)+' '+p[1].toFixed(1)).join(' ');
+  const area = d + ` L ${w} ${h} L 0 ${h} Z`;
+  return (
+    <svg width={w} height={h} style={{ display:'block', overflow:'visible' }}>
+      <path d={area} fill={color} opacity="0.12" />
+      <path d={d} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" opacity="0.7" />
+      <circle cx={pts[pts.length-1][0]} cy={pts[pts.length-1][1]} r="2.2" fill={color} />
+    </svg>
+  );
+}
+
+function Vital({ label, value, sub, q }) {
+  return (
+    <div style={{ minWidth:0 }}>
+      <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)' }}>{label}</div>
+      <div className="font-display" style={{ fontSize:19, fontWeight:700, marginTop:3, color: q?'var(--hm-faint)':'var(--hm-ink)' }}>
+        {q ? '?' : value}
+      </div>
+      <div className="mono" style={{ fontSize:10, color:'var(--hm-faint)', marginTop:1 }}>{q ? 'source unavailable' : sub}</div>
+    </div>
+  );
+}
+
+/* ── surface 1: LLM usage — per-model breakdown ──
+   Real per-model rows; an unavailable metric shows ? (never fabricated). */
+const USAGE_MODELS = [
+  { model:'deepseek-v4-pro', owner:'Hermes',      ownerColor:'var(--ag-hermes)', tokens:'9.2K', calls:38, lat:'1.9s' },
+  { model:'claude-sonnet-4.6', owner:'workers',   ownerColor:'var(--ag-claude)', tokens:'5.1K', calls:52, lat:'2.4s' },
+  { model:'codex-large',     owner:'Codex',       ownerColor:'var(--ag-codex)',  tokens:'2.1K', calls:26, lat:null }, // latency source down → ?
+  { model:'claude-haiku-4',  owner:'test-writer', ownerColor:'var(--ag-test)',   tokens:'0.6K', calls:8,  lat:'3.1s' },
+];
+const USAGE_TOTAL = { tokens:'17.0K', calls:124, lat:null }; // aggregate avg-latency unavailable while a source is down
+
+function UCol({ children, w, right, head }) {
+  return <div style={{ width:w, flex: w?'none':1, minWidth:0, textAlign: right?'right':'left',
+    fontFamily: head?'var(--font-display)':'inherit', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{children}</div>;
+}
+
+/* per-model multi-line chart — one faint line per model over last 60 min.
+   Demo series (clearly synthetic shape); real backend streams per-model tokens/min. */
+function UsageChart({ series, height=150 }) {
+  const w = 300, h = height, padL = 4, padR = 4, padT = 8, padB = 18;
+  const n = series[0].data.length;
+  const allMax = Math.max(...series.flatMap(s => s.data), 1);
+  const x = (i) => padL + (i/(n-1))*(w-padL-padR);
+  const y = (v) => padT + (1 - v/allMax)*(h-padT-padB);
+  const line = (data) => data.map((v,i)=>(i?'L':'M')+x(i).toFixed(1)+' '+y(v).toFixed(1)).join(' ');
+  const ticks = ['-60m','-45m','-30m','-15m','now'];
+  return (
+    <div style={{ marginTop:'auto', paddingTop:12 }}>
+      <div style={{ display:'flex', alignItems:'center', justifyContent:'space-between', marginBottom:8 }}>
+        <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)' }}>Recent usage · tokens/min · per model</div>
+        <span className="chip" style={{ padding:'1px 7px', fontSize:9, color:'var(--ag-claude)', borderColor:'rgba(112,72,182,0.3)' }}>demo shape</span>
+      </div>
+      <svg viewBox={`0 0 ${w} ${h}`} width="100%" height={h} preserveAspectRatio="none" style={{ display:'block', overflow:'visible' }}>
+        {/* gridlines */}
+        {[0.25,0.5,0.75].map(g => <line key={g} x1={padL} x2={w-padR} y1={padT+g*(h-padT-padB)} y2={padT+g*(h-padT-padB)} stroke="var(--hm-line-2)" strokeWidth="1" />)}
+        {/* per-model lines */}
+        {series.map(s => (
+          <g key={s.model}>
+            <path d={line(s.data)} fill="none" stroke={s.color} strokeWidth="1.6" strokeLinejoin="round" strokeLinecap="round" opacity="0.62" vectorEffect="non-scaling-stroke" />
+            <circle cx={x(n-1)} cy={y(s.data[n-1])} r="2.4" fill={s.color} />
+          </g>
+        ))}
+        {/* x ticks */}
+        {ticks.map((t,i) => <text key={t} x={padL + (i/(ticks.length-1))*(w-padL-padR)} y={h-5} fill="var(--hm-faint)" fontSize="8" fontFamily="var(--font-mono)" textAnchor={i===0?'start':(i===ticks.length-1?'end':'middle')}>{t}</text>)}
+      </svg>
+      {/* legend */}
+      <div style={{ display:'flex', gap:12, flexWrap:'wrap', marginTop:8 }}>
+        {series.map(s => (
+          <span key={s.model} style={{ display:'inline-flex', alignItems:'center', gap:6, minWidth:0 }}>
+            <span style={{ width:10, height:2.5, borderRadius:2, background:s.color, flex:'none' }} />
+            <span className="mono" style={{ fontSize:10, color:'var(--hm-muted)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{s.model}</span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* synthetic per-model usage series (demo shape — real backend streams this) */
+const USAGE_SERIES = [
+  { model:'deepseek-v4-pro', color:'var(--ag-hermes)', data:[4,6,5,8,7,11,9,14,12,16,13,15,17] },
+  { model:'claude-sonnet-4.6', color:'var(--ag-claude)', data:[7,9,8,6,10,9,12,8,11,10,13,11,9] },
+  { model:'codex-large', color:'var(--ag-codex)', data:[2,3,2,4,3,5,4,3,6,4,5,3,4] },
+  { model:'claude-haiku-4', color:'var(--ag-test)', data:[1,0,1,2,1,1,0,2,1,1,2,1,1] },
+];
+
+function UsagePanel() {
+  const colHead = { fontSize:9, fontWeight:700, textTransform:'uppercase', color:'var(--hm-faint)', letterSpacing:'0' };
+  return (
+    <UtilCard title="LLM usage" hint="per model · last 60 min" fill>
+      {/* column header */}
+      <div className="font-display" style={{ display:'flex', alignItems:'center', gap:10, padding:'0 2px 7px' }}>
+        <UCol head><span style={colHead}>Model</span></UCol>
+        <UCol w={56} right head><span style={colHead}>Tokens</span></UCol>
+        <UCol w={46} right head><span style={colHead}>Calls</span></UCol>
+        <UCol w={62} right head><span style={colHead}>Latency</span></UCol>
+      </div>
+      {/* total row */}
+      <div style={{ display:'flex', alignItems:'center', gap:10, padding:'9px 2px', borderTop:'1px solid var(--hm-line-2)', borderBottom:'1px solid var(--hm-line-2)' }}>
+        <UCol><span className="font-display" style={{ fontSize:12.5, fontWeight:700, color:'var(--hm-ink)' }}>All models</span></UCol>
+        <UCol w={56} right><span className="mono" style={{ fontSize:13, fontWeight:600, color:'var(--hm-ink)' }}>{USAGE_TOTAL.tokens}</span></UCol>
+        <UCol w={46} right><span className="mono" style={{ fontSize:13, fontWeight:600, color:'var(--hm-ink)' }}>{USAGE_TOTAL.calls}</span></UCol>
+        <UCol w={62} right><span className="mono" style={{ fontSize:13, fontWeight:600, color: USAGE_TOTAL.lat?'var(--hm-ink)':'var(--hm-faint)' }}>{USAGE_TOTAL.lat||'?'}</span></UCol>
+      </div>
+      {/* per-model rows */}
+      <div style={{ display:'flex', flexDirection:'column' }}>
+        {USAGE_MODELS.map((m,i) => (
+          <div key={m.model} style={{ display:'flex', alignItems:'center', gap:10, padding:'8px 2px', borderTop: i?'1px solid var(--hm-line-2)':'none' }}>
+            <UCol>
+              <div style={{ display:'flex', alignItems:'center', gap:7, minWidth:0 }}>
+                <span style={{ width:6, height:6, borderRadius:'50%', background:m.ownerColor, flex:'none' }} />
+                <span className="mono" style={{ fontSize:12, color:'var(--hm-ink-2)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{m.model}</span>
+                <span className="font-display" style={{ fontSize:10.5, color:'var(--hm-faint)', flex:'none' }}>{m.owner}</span>
+              </div>
+            </UCol>
+            <UCol w={56} right><span className="mono" style={{ fontSize:12, color:'var(--hm-muted)' }}>{m.tokens}</span></UCol>
+            <UCol w={46} right><span className="mono" style={{ fontSize:12, color:'var(--hm-muted)' }}>{m.calls}</span></UCol>
+            <UCol w={62} right><span className="mono" style={{ fontSize:12, color: m.lat?'var(--hm-muted)':'var(--hm-faint)' }}>{m.lat||'?'}</span></UCol>
+          </div>
+        ))}
+      </div>
+      {/* recent usage chart fills the remaining height */}
+      <UsageChart series={USAGE_SERIES} />
+    </UtilCard>
+  );
+}
+
+/* ── surface 2: saved suite library (honestly empty) ── */
+function SuitePanel() {
+  const suites = []; // current reality: none saved
+  return (
+    <UtilCard title="Saved suites" hint={suites.length ? `${suites.length} saved` : 'library'}
+      action={<button className="btn btn--soft btn--sm" style={{ borderStyle:'dashed' }}>+ New suite</button>}>
+      {suites.length === 0 ? (
+        <div style={{ display:'flex', alignItems:'center', gap:12, padding:'4px 2px' }}>
+          <div style={{ width:34, height:34, borderRadius:10, flex:'none', background:'var(--hm-paper-sunken)',
+            border:'1px solid var(--hm-line-2)', display:'grid', placeItems:'center', color:'var(--hm-faint)', fontSize:16 }}>·</div>
+          <div style={{ minWidth:0 }}>
+            <div className="font-display" style={{ fontSize:13, fontWeight:600, color:'var(--hm-muted)' }}>No saved suites yet</div>
+            <div style={{ fontSize:12, color:'var(--hm-faint)', marginTop:2, textWrap:'pretty' }}>Save a launcher config or create a named suite for repeat runs.</div>
+          </div>
+        </div>
+      ) : (
+        <div style={{ display:'flex', gap:8, flexWrap:'wrap' }}>
+          {suites.map(s => (
+            <div key={s.name} className="chip" style={{ padding:'6px 10px', gap:8 }}>
+              <span className="font-display" style={{ fontWeight:600, color:'var(--hm-ink-2)' }}>{s.name}</span>
+              <Pill tone={s.tone} style={{ minHeight:17, height:17, fontSize:9 }}>{s.verdict}</Pill>
+              <button className="btn btn--sm" style={{ height:22, padding:'0 8px', background:'transparent', border:'1px solid var(--hm-line)', color:'var(--hm-muted)' }}>Run</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </UtilCard>
+  );
+}
+
+/* ── surface 3: tester launcher ── */
+const FLOWS = [
+  { id:'sweep',    name:'Surface Sweep',   tag:'read-only', desc:'Read-only crawl — visits and observes, never mutates.' },
+  { id:'gold',     name:'Gold Path',       tag:'testnet',   desc:'Runs a critical journey end-to-end — pass / fail.' },
+  { id:'role',     name:'Role Gating',     tag:'',          desc:'Checks access controls hold for each role.' },
+  { id:'citation', name:'Citation Repair', tag:'',          desc:'Domain repair against a Job ID — dry-run first.' },
+];
+function LauncherPanel() {
+  const [flow, setFlow] = React.useState('sweep');
+  const [target, setTarget] = React.useState('en.wikipedia.org');
+  const [jobId, setJobId] = React.useState('');
+  const [goal, setGoal] = React.useState('');
+  const [approval, setApproval] = React.useState(true);
+  const [saveSuite, setSaveSuite] = React.useState(false);
+  const isCitation = flow === 'citation';
+  const activeFlow = FLOWS.find(f => f.id === flow);
+  return (
+    <UtilCard title="Start a mission" hint="tester launcher">
+      <div style={{ display:'grid', gap:11 }}>
+        {/* flow picker */}
+        <div>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginBottom:6 }}>Flow</div>
+          <div style={{ display:'grid', gridTemplateColumns:'1fr 1fr', gap:6 }}>
+            {FLOWS.map(f => {
+              const on = flow===f.id;
+              return (
+                <button key={f.id} onClick={()=>setFlow(f.id)} className="font-display" style={{ display:'flex', alignItems:'center', gap:8,
+                  textAlign:'left', height:34, padding:'0 10px', borderRadius:'var(--r-sm)', cursor:'pointer',
+                  border:`1px solid ${on?'var(--act-line)':'var(--hm-line)'}`, background: on?'var(--act-soft)':'var(--hm-paper-sunken)' }}>
+                  <span style={{ width:13, height:13, borderRadius:'50%', flex:'none', border:`1.5px solid ${on?'var(--act)':'var(--hm-line-strong)'}`,
+                    display:'grid', placeItems:'center' }}>
+                    {on && <span style={{ width:6, height:6, borderRadius:'50%', background:'var(--act)' }} />}
+                  </span>
+                  <span style={{ fontSize:12.5, fontWeight:600, color: on?'var(--act-text)':'var(--hm-ink-2)', whiteSpace:'nowrap', overflow:'hidden', textOverflow:'ellipsis' }}>{f.name}</span>
+                  {f.tag && <span className="mono" style={{ marginLeft:'auto', fontSize:9.5, color:'var(--hm-faint)', flex:'none' }}>{f.tag}</span>}
+                </button>
+              );
+            })}
+          </div>
+          {/* one honest line per flow (#10) */}
+          {activeFlow && <div style={{ marginTop:7, fontSize:11.5, color:'var(--hm-muted)', lineHeight:1.45 }}>{activeFlow.desc}</div>}
+        </div>
+        {/* target / job id swap */}
+        <div>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginBottom:5 }}>{isCitation ? 'Job ID' : 'Target URL'}</div>
+          {isCitation
+            ? <input value={jobId} onChange={e=>setJobId(e.target.value)} placeholder="citation-job-…" className="mono"
+                style={{ width:'100%', height:34, padding:'0 11px', borderRadius:'var(--r-sm)', border:'1px solid var(--hm-line)', background:'var(--hm-paper-sunken)', fontSize:12.5, color:'var(--hm-ink)', outline:'none' }} />
+            : <input value={target} onChange={e=>setTarget(e.target.value)} placeholder="https://…" className="mono"
+                style={{ width:'100%', height:34, padding:'0 11px', borderRadius:'var(--r-sm)', border:'1px solid var(--hm-line)', background:'var(--hm-paper-sunken)', fontSize:12.5, color:'var(--hm-ink)', outline:'none' }} />}
+        </div>
+        {/* goal */}
+        <div>
+          <div className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', marginBottom:5 }}>Goal <span style={{ textTransform:'none', fontWeight:500 }}>· optional</span></div>
+          <textarea value={goal} onChange={e=>setGoal(e.target.value)} rows={2} placeholder="What should the fresh agent attempt?"
+            style={{ width:'100%', padding:'8px 11px', borderRadius:'var(--r-sm)', border:'1px solid var(--hm-line)', background:'var(--hm-paper-sunken)', fontSize:12.5, fontFamily:'var(--font-body)', color:'var(--hm-ink)', resize:'none', outline:'none' }} />
+        </div>
+        {/* toggles */}
+        <div style={{ display:'flex', alignItems:'center', gap:8, flexWrap:'wrap' }}>
+          <ToggleChip on={approval} set={setApproval}>request approval</ToggleChip>
+          <ToggleChip on={saveSuite} set={setSaveSuite}>save as suite</ToggleChip>
+        </div>
+        {/* CTA — conditional + visually demoted so it never out-shouts the decision CTA (#9) */}
+        <button className="btn btn--sm" style={{ width:'100%', background:'var(--hm-ink)', color:'var(--hm-paper)', border:'1px solid transparent' }}>
+          {approval ? 'Propose mission' : 'Launch mission'}
+        </button>
+        <p style={{ margin:0, fontSize:10.5, color:'var(--hm-faint)', textWrap:'pretty' }}>
+          {approval ? 'Hermes reviews before any runner claims it — lands in Your decisions.' : 'Auto-dispatch — runs immediately, without a review gate.'}
+        </p>
+      </div>
+    </UtilCard>
+  );
+}
+
+function ToggleChip({ on, set, children }) {
+  return (
+    <button onClick={()=>set(v=>!v)} className="chip click" style={{ height:28, gap:7,
+      color: on?'var(--ok-text)':'var(--hm-faint)', borderColor: on?'var(--ok-line)':'var(--hm-line-2)' }}>
+      <span style={{ width:8, height:8, borderRadius:'50%', border:'1.5px solid currentColor', background: on?'currentColor':'transparent', flex:'none' }} />
+      {children}
+    </button>
+  );
+}
+
+/* shared card chrome (calm, dim, secondary) */
+function UtilCard({ title, hint, action, children, fill }) {
+  return (
+    <div style={{ background:'var(--hm-paper)', border:'1px solid var(--hm-line-2)', borderRadius:'var(--r-card)', padding:'14px 15px',
+      display:'flex', flexDirection:'column', minWidth:0, height: fill?'100%':'auto' }}>
+      <div style={{ display:'flex', alignItems:'center', gap:8, marginBottom:12 }}>
+        <span className="font-display" style={{ fontWeight:700, fontSize:13.5, color:'var(--hm-ink-2)', whiteSpace:'nowrap', flex:'none' }}>{title}</span>
+        {hint && <span className="eyebrow" style={{ fontSize:9, color:'var(--hm-faint)', flex:'none' }}>{hint}</span>}
+        {action && <span style={{ marginLeft:'auto' }}>{action}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+/* ── the row: collapsed strip ⇄ expanded panel ── */
+function UtilitiesPanel({ open, onToggle }) {
+  return (
+    <div style={{ borderRadius:'var(--r-card)', background:'var(--hm-paper-sunken)', border:'1px solid var(--hm-line-2)', overflow:'hidden' }}>
+      <button onClick={onToggle} style={{ width:'100%', display:'flex', alignItems:'center', justifyContent:'space-between', gap:12,
+        padding:'11px 16px', background:'transparent', border:0, cursor:'pointer', textAlign:'left' }}>
+        <div style={{ display:'flex', alignItems:'center', gap:10, minWidth:0 }}>
+          <span style={{ color:'var(--hm-faint)', flex:'none', display:'inline-block', transition:'transform var(--dur) var(--ease)',
+            transform: open?'rotate(90deg)':'none' }}>▸</span>
+          <span className="font-display" style={{ fontWeight:600, fontSize:13, color:'var(--hm-ink-2)', flex:'none' }}>Utilities</span>
+          <span style={{ fontSize:13, color:'var(--hm-muted)', overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>LLM usage · suites · tester launcher</span>
+        </div>
+        <span className="mono" style={{ fontSize:12, color:'var(--hm-faint)', flex:'none' }}>{open ? 'collapse' : '17K tokens · no suites · tester ready'}</span>
+      </button>
+      {open && (
+        <div style={{ padding:'2px 14px 14px', borderTop:'1px solid var(--hm-line-2)' }}>
+          <div className="util-grid" style={{ display:'grid', gap:12, gridTemplateColumns:'1fr 1fr', alignItems:'stretch', marginTop:12 }}>
+            {/* left: full-height per-model usage */}
+            <UsagePanel />
+            {/* right: launcher on top, compact saved-suites below */}
+            <div style={{ display:'grid', gap:12, gridTemplateRows:'auto auto', minWidth:0 }}>
+              <LauncherPanel />
+              <SuitePanel />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+window.Utilities = { UtilitiesPanel };


### PR DESCRIPTION
The finished decision-cockpit redesign, exported from claude.ai/design, as the in-repo spec for **Frontend PR-D**.

**Contents** (`docs/design/hermes-4/`): componentized JSX prototypes (`board/kanban/parts/drawer/rail/room/utilities/app/data`), the **`hermes.css` token layer** (warm-ivory base · `--act` coral / `--ok` sage / `--warn` amber / `--tel` telemetry semantic colors · agent-identity jewel palette kept distinct from status · Space Grotesk/Manrope/JetBrains type · radii/elevation incl. `--sh-coral` · `--mi` motion intensity · density scoping · 6 color profiles · fixed `overflow:hidden` shell), plus `Hermes.html` and the Token Spec.

**Reference only** — not wired in. It's the pixel-perfect target for PR-D, which ports it into `packages/monitor-ui` reusing the #422 design-system. PNGs omitted (spec lives in the HTML/CSS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)