### PR TITLE
feat(monitor): Hermes-4 tokens + theme engine + fixed shell footer + DECIDE/WATCH/HIDE tiers (PR-D1)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -27,6 +27,7 @@ import { useCardParam } from "./hooks/useCardParam.js";
 import type { UseCollaborationOptions } from "./hooks/useCollaboration.js";
 import { useActionAlerts, type UseActionAlertsOptions } from "./hooks/useActionAlerts.js";
 import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonomyMode.js";
+import { useColorProfile } from "./hooks/useColorProfile.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import type { BoardCard, CreateTaskInput } from "./lib/monitor/card-types.js";
 import { missionLaunchBody, type MissionSpawnInput, type SaveTestSuiteInput } from "./lib/monitor/mission-launch.js";
@@ -110,6 +111,11 @@ export function MonitorPage({
   autonomy,
 }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
+  // PR-D1: apply the Hermes-4 color profile (default Midnight) + motion/density
+  // to <html> as --h4-* tokens. Foundation-first — drives the new shell/footer/
+  // kanban-tier surfaces; the existing board keeps its --hm-* styling until
+  // later D-PRs migrate it.
+  useColorProfile();
   const { data: backlogSuggestionsData } = useBacklogSuggestions(backlogSuggestions);
   const { cardId, setCard, clearCard } = useCardParam();
   const { mode: autonomyMode, setAutopilot, setSupervised } = useAutonomyMode(autonomy);

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -23,6 +23,15 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(view.getByRole("region", { name: "Kanban lane grid" })).toBeTruthy();
     expect(container.querySelectorAll(".hm-lane").length).toBe(8);
     expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
+    // PR-D1: fixed-shell footer (END OF BOARD) with real counts.
+    const footer = container.querySelector(".h4-board-footer");
+    expect(footer).toBeTruthy();
+    expect(footer?.textContent).toMatch(/End of board/i);
+    expect(footer?.textContent).toMatch(/\d+ cards? · \d+ waiting on you · \d+ running/);
+    // PR-D1: DECIDE tier is reserved for the Decision Inbox (needs-attention) only.
+    const decideLanes = container.querySelectorAll('section.hm-lane[data-h4-tier="decide"]');
+    expect(decideLanes.length).toBe(1);
+    expect(decideLanes[0]?.getAttribute("aria-label")).toBe("Needs attention lane");
   });
 
   test("every lane with cards stays expanded in one Kanban row; empty lanes stay reachable mini-rails", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -28,7 +28,7 @@ import type { MissionSpawnInput, SavedTestSuite, SaveTestSuiteInput } from "../l
 import { CreateTaskForm } from "./CreateTaskForm.js";
 import { StartMissionLauncher } from "./StartMissionLauncher.js";
 import { TestSuitesPanel } from "./TestSuitesPanel.js";
-import { laneFor } from "../lib/monitor/lane-rules.js";
+import { laneFor, isWaitingOnOperator } from "../lib/monitor/lane-rules.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
 import { TopStripDegraded } from "./TopStripDegraded.js";
@@ -579,6 +579,11 @@ export function BoardView({
         />
       </div>
 
+      {/* PR-D1: fixed shell footer — the bottom edge of the no-scroll board.
+          Real counts only (total cards, how many wait on the operator, how
+          many are running). New --h4 surface. */}
+      <BoardFooter cards={cards} />
+
       {/* P0-4: transient confirmation that an Ask-Hermes action was received.
           aria-live so it's announced; visually a small floating toast. It
           self-clears after a few seconds (the composer carries the durable
@@ -615,6 +620,30 @@ export function BoardView({
 
       {overlayOpen ? <KeyboardOverlay onClose={() => setOverlayOpen(false)} /> : null}
     </div>
+  );
+}
+
+/**
+ * PR-D1 — the fixed shell's bottom edge. Honest, real-data counts only:
+ * total cards, how many wait on the operator (the DECIDE workload), and how
+ * many are running. No fabricated "last sync" clock (we have no real board-sync
+ * signal to show). Styled with the --h4 token system.
+ */
+function BoardFooter({ cards }: { cards: readonly BoardCard[] }) {
+  const total = cards.length;
+  const waiting = cards.filter((c) => isWaitingOnOperator(c)).length;
+  const running = cards.filter((c) => c.state === "running").length;
+  return (
+    <footer className="h4-board-footer" aria-label="Board footer">
+      <span className="h4-board-footer-end">
+        <span className="dot" aria-hidden />
+        End of board
+      </span>
+      <span className="h4-board-footer-stat">
+        {total} {total === 1 ? "card" : "cards"} · {waiting} waiting on you · {running} running
+      </span>
+      <span className="h4-board-footer-meta">Hermes · Averray</span>
+    </footer>
   );
 }
 

--- a/packages/monitor-ui/src/components/Lane.tsx
+++ b/packages/monitor-ui/src/components/Lane.tsx
@@ -12,6 +12,7 @@
 
 import type { ReactNode } from "react";
 import { MiniRail, type LaneDescriptor, type LaneId } from "./MiniRail.js";
+import { tierFor } from "../lib/monitor/lane-rules.js";
 import { Button, EmptyState, LaneHeader } from "./ui.js";
 
 export type { LaneDescriptor, LaneId };
@@ -64,7 +65,7 @@ export function Lane({ lane, expanded, count, children, headerAccessory, onToggl
     .join(" ");
 
   return (
-    <section className={classes} aria-label={`${lane.name} lane`}>
+    <section className={classes} aria-label={`${lane.name} lane`} data-h4-tier={tierFor(lane.id)}>
       <LaneHeader
         title={lane.name}
         count={count}

--- a/packages/monitor-ui/src/components/MiniRail.tsx
+++ b/packages/monitor-ui/src/components/MiniRail.tsx
@@ -10,6 +10,7 @@
 // block in styles/monitor.css.
 
 import type { Lane } from "../lib/monitor/card-types.js";
+import { tierFor } from "../lib/monitor/lane-rules.js";
 
 /** Canonical lane id — re-exported so <Lane>/<Board> share one source. */
 export type LaneId = Lane;
@@ -44,7 +45,7 @@ export function MiniRail({ lane, count, onToggle }: MiniRailProps) {
       aria-label={`${lane.name} (${count} ${count === 1 ? "card" : "cards"}) — click to expand`}
       title={`${lane.name} (${count})`}
     >
-      <div className="hm-lane-rail">
+      <div className="hm-lane-rail" data-h4-tier={tierFor(lane.id)}>
         <span className={"ct " + (count > 0 ? "ct--has" : "ct--zero")}>{count}</span>
         <span className="lbl">{lane.name}</span>
         <span className="icn" aria-hidden>

--- a/packages/monitor-ui/src/hooks/useColorProfile.ts
+++ b/packages/monitor-ui/src/hooks/useColorProfile.ts
@@ -1,0 +1,71 @@
+// Hermes-4 theme hook (PR-D1).
+//
+// Applies the active color profile + motion intensity + density to <html> as
+// `--h4-*` custom properties and `data-h4-*` attributes. Mounts the D1 default
+// (Midnight) and re-applies motion when the prefers-reduced-motion preference
+// changes. A profile switcher UI (the tweaks panel) lands in a later D-PR; this
+// hook already exposes the setters it will drive.
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  applyColorProfile,
+  applyDensity,
+  applyMotion,
+  DEFAULT_DENSITY,
+  DEFAULT_MOTION,
+  DEFAULT_PROFILE,
+  type ColorProfileId,
+  type Density,
+} from "../lib/monitor/color-profile.js";
+
+export interface UseColorProfileOptions {
+  profile?: ColorProfileId;
+  motion?: number;
+  density?: Density;
+}
+
+export interface ColorProfileControls {
+  profile: ColorProfileId;
+  setProfile: (profile: ColorProfileId) => void;
+  motion: number;
+  setMotion: (motion: number) => void;
+  density: Density;
+  setDensity: (density: Density) => void;
+}
+
+export function useColorProfile(opts: UseColorProfileOptions = {}): ColorProfileControls {
+  const [profile, setProfile] = useState<ColorProfileId>(opts.profile ?? DEFAULT_PROFILE);
+  const [motion, setMotion] = useState<number>(opts.motion ?? DEFAULT_MOTION);
+  const [density, setDensity] = useState<Density>(opts.density ?? DEFAULT_DENSITY);
+
+  useEffect(() => {
+    applyColorProfile(profile);
+  }, [profile]);
+
+  useEffect(() => {
+    applyMotion(motion);
+  }, [motion]);
+
+  useEffect(() => {
+    applyDensity(density);
+  }, [density]);
+
+  // Honor prefers-reduced-motion changes after mount (applyMotion forces the
+  // bucket to "off" when reduced).
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = () => applyMotion(motion);
+    mq.addEventListener?.("change", onChange);
+    return () => mq.removeEventListener?.("change", onChange);
+  }, [motion]);
+
+  return {
+    profile,
+    setProfile: useCallback((p: ColorProfileId) => setProfile(p), []),
+    motion,
+    setMotion: useCallback((m: number) => setMotion(m), []),
+    density,
+    setDensity: useCallback((d: Density) => setDensity(d), []),
+  };
+}

--- a/packages/monitor-ui/src/lib/monitor/color-profile.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/color-profile.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  PROFILES,
+  PROFILE_OPTIONS,
+  DEFAULT_PROFILE,
+  buildTheme,
+  mix,
+  darken,
+  lighten,
+  rgba,
+  inkOn,
+  motionBucket,
+  applyColorProfile,
+  applyMotion,
+  applyDensity,
+} from "./color-profile.js";
+
+afterEach(() => {
+  const root = document.documentElement;
+  for (const attr of ["data-h4-profile", "data-h4-dark", "data-h4-glow", "data-h4-motion", "data-h4-density"]) {
+    root.removeAttribute(attr);
+  }
+  root.removeAttribute("style");
+});
+
+describe("color math (verbatim port)", () => {
+  test("mix / lighten / darken / rgba / inkOn", () => {
+    expect(mix("#000000", "#ffffff", 0.5)).toBe("#808080");
+    expect(lighten("#000000", 1)).toBe("#ffffff");
+    expect(darken("#ffffff", 1)).toBe("#000000");
+    expect(rgba("#E8865E", 0.18)).toBe("rgba(232,134,94,0.18)");
+    expect(inkOn("#ffffff")).toBe("#14110c"); // light bg → dark ink
+    expect(inkOn("#1A1714")).toBe("#ffffff"); // dark bg → light ink
+  });
+});
+
+describe("profiles", () => {
+  test("ships all 6 profiles; default is Midnight", () => {
+    expect(Object.keys(PROFILES).sort()).toEqual(["averray", "claude", "editorial", "midnight", "midpolka", "slate"]);
+    expect(PROFILE_OPTIONS).toHaveLength(6);
+    expect(DEFAULT_PROFILE).toBe("midnight");
+    expect(PROFILES.midnight.dark).toBe(true);
+    expect(PROFILES.claude.dark).toBe(false);
+  });
+
+  test("buildTheme emits a full --h4-* token set keyed off the profile", () => {
+    const theme = buildTheme(PROFILES.midnight);
+    expect(theme["--h4-canvas"]).toBe("#1A1714");
+    expect(theme["--h4-paper"]).toBe("#241F1B");
+    expect(theme["--h4-ink"]).toBe("#EDE6DD");
+    expect(theme["--h4-act"]).toBe("#E8865E");
+    // accent ink is computed from luminance: the coral sits below the 0.42
+    // threshold, so inkOn picks white.
+    expect(theme["--h4-act-ink"]).toBe("#ffffff");
+    expect(theme["--h4-ok"]).toBe("#7FB089");
+    expect(theme["--h4-warn"]).toBe("#E0A050");
+    expect(theme["--h4-tier-decide-bg"]).toMatch(/^rgba\(/);
+    // every key is namespaced --h4-* (no clobber of --hm-*/--avy-*).
+    expect(Object.keys(theme).every((k) => k.startsWith("--h4-"))).toBe(true);
+  });
+
+  test("Averray profile honors its explicit accentFill / accentInk overrides", () => {
+    const theme = buildTheme(PROFILES.averray);
+    expect(theme["--h4-act"]).toBe("#E6007A");
+    expect(theme["--h4-act-deep"]).toBe("#D6006E");
+    expect(theme["--h4-act-ink"]).toBe("#ffffff");
+  });
+});
+
+describe("motion buckets", () => {
+  test("slider value → bucket", () => {
+    expect(motionBucket(0)).toBe("off");
+    expect(motionBucket(20)).toBe("low");
+    expect(motionBucket(60)).toBe("med");
+    expect(motionBucket(90)).toBe("high");
+  });
+});
+
+describe("apply* write to <html>", () => {
+  test("applyColorProfile sets --h4-* props + data-h4-profile/dark/glow", () => {
+    const root = document.documentElement;
+    const id = applyColorProfile("midpolka", root);
+    expect(id).toBe("midpolka");
+    expect(root.getAttribute("data-h4-profile")).toBe("midpolka");
+    expect(root.getAttribute("data-h4-dark")).toBe("1");
+    expect(root.getAttribute("data-h4-glow")).toBe("1");
+    expect(root.style.getPropertyValue("--h4-act")).toBe("#FF2D92");
+    // it never writes a shipped-board token.
+    expect(root.style.getPropertyValue("--hm-paper")).toBe("");
+    expect(root.style.getPropertyValue("--avy-ink")).toBe("");
+  });
+
+  test("an unknown profile falls back to the default", () => {
+    const id = applyColorProfile("nope" as never, document.documentElement);
+    expect(id).toBe(DEFAULT_PROFILE);
+  });
+
+  test("applyMotion sets --h4-mi + data-h4-motion; applyDensity sets data-h4-density", () => {
+    const root = document.documentElement;
+    applyMotion(60, root);
+    expect(root.getAttribute("data-h4-motion")).toBe("med");
+    expect(root.style.getPropertyValue("--h4-mi")).toBe("0.6");
+    applyDensity("compact", root);
+    expect(root.getAttribute("data-h4-density")).toBe("compact");
+    applyDensity("bogus" as never, root);
+    expect(root.getAttribute("data-h4-density")).toBe("regular");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/color-profile.ts
+++ b/packages/monitor-ui/src/lib/monitor/color-profile.ts
@@ -1,0 +1,193 @@
+// Hermes-4 design system — color profiles + theme engine (PR-D1).
+//
+// Ports docs/design/hermes-4/project/app.jsx's profile/buildTheme layer into
+// the monitor. FOUNDATION-FIRST + no-fork: every custom property this engine
+// writes is namespaced `--h4-*`, so it NEVER clobbers the shipped board's
+// existing `--hm-*` / `--avy-*` tokens. The new D1 shell / footer / kanban-tier
+// layer consumes `--h4-*`; the rest of the board keeps its current styling
+// until later D-PRs migrate it onto this system.
+//
+// Color math is a verbatim port of the reference so the 6 profiles render
+// identically.
+
+export type ColorProfileId = "claude" | "midnight" | "slate" | "editorial" | "averray" | "midpolka";
+export type MotionBucket = "off" | "low" | "med" | "high";
+export type Density = "compact" | "regular" | "comfy";
+
+export interface ColorProfile {
+  label: string;
+  dark: boolean;
+  glow?: boolean;
+  base: string;
+  surface: string;
+  ink: string;
+  muted: string;
+  accent: string;
+  healthy: string;
+  degraded: string;
+  accentFill?: string;
+  accentInk?: string;
+}
+
+/** The 6 profiles, verbatim from the design reference. */
+export const PROFILES: Record<ColorProfileId, ColorProfile> = {
+  claude: { label: "Claude Warm", dark: false, base: "#FAF7F2", surface: "#FFFDFA", ink: "#2A2622", muted: "#A89B8C", accent: "#D97757", healthy: "#6B8F71", degraded: "#C8843C" },
+  midnight: { label: "Midnight", dark: true, glow: false, base: "#1A1714", surface: "#241F1B", ink: "#EDE6DD", muted: "#6B635A", accent: "#E8865E", healthy: "#7FB089", degraded: "#E0A050" },
+  slate: { label: "Slate Console", dark: false, base: "#F4F5F7", surface: "#FFFFFF", ink: "#1F2430", muted: "#8A93A3", accent: "#5B6CFF", healthy: "#3FA66A", degraded: "#D9911F" },
+  editorial: { label: "Editorial", dark: false, base: "#FBFAF7", surface: "#FFFFFF", ink: "#17120E", muted: "#9C948A", accent: "#B23A28", healthy: "#2F7D52", degraded: "#B5791E" },
+  averray: { label: "Averray (Polkadot)", dark: false, base: "#F6F5F8", surface: "#FFFFFF", ink: "#1B1722", muted: "#8C8A99", accent: "#E6007A", healthy: "#0FA67E", degraded: "#E0A030", accentFill: "#D6006E", accentInk: "#ffffff" },
+  midpolka: { label: "Midnight × Polkadot", dark: true, glow: true, base: "#14111C", surface: "#201B2E", ink: "#ECE8F2", muted: "#6B6580", accent: "#FF2D92", healthy: "#2DD4BF", degraded: "#F0B44C", accentInk: "#14111C" },
+};
+
+/** D1 default — Midnight (operator's pick). All 6 ship + are switchable. */
+export const DEFAULT_PROFILE: ColorProfileId = "midnight";
+export const DEFAULT_MOTION = 60;
+export const DEFAULT_DENSITY: Density = "regular";
+
+export const PROFILE_OPTIONS: ReadonlyArray<{ value: ColorProfileId; label: string }> = (
+  Object.entries(PROFILES) as Array<[ColorProfileId, ColorProfile]>
+).map(([value, p]) => ({ value, label: p.label }));
+
+// ── color math (verbatim port) ──────────────────────────────────────
+function hx(h: string): { r: number; g: number; b: number } {
+  let s = h.replace("#", "");
+  if (s.length === 3) s = s.split("").map((c) => c + c).join("");
+  return { r: parseInt(s.slice(0, 2), 16), g: parseInt(s.slice(2, 4), 16), b: parseInt(s.slice(4, 6), 16) };
+}
+function toHex({ r, g, b }: { r: number; g: number; b: number }): string {
+  const t = (n: number) => Math.max(0, Math.min(255, Math.round(n))).toString(16).padStart(2, "0");
+  return `#${t(r)}${t(g)}${t(b)}`;
+}
+export function mix(a: string, b: string, t: number): string {
+  const A = hx(a), B = hx(b);
+  return toHex({ r: A.r + (B.r - A.r) * t, g: A.g + (B.g - A.g) * t, b: A.b + (B.b - A.b) * t });
+}
+export function rgba(h: string, a: number): string {
+  const { r, g, b } = hx(h);
+  return `rgba(${r},${g},${b},${a})`;
+}
+export function lighten(h: string, t: number): string {
+  return mix(h, "#ffffff", t);
+}
+export function darken(h: string, t: number): string {
+  return mix(h, "#000000", t);
+}
+function lum(h: string): number {
+  const { r, g, b } = hx(h);
+  const f = (c: number) => {
+    const x = c / 255;
+    return x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+export function inkOn(bg: string): string {
+  return lum(bg) > 0.42 ? "#14110c" : "#ffffff";
+}
+
+/** Slider value (0..100) → motion bucket. */
+export function motionBucket(v: number): MotionBucket {
+  return v <= 0 ? "off" : v <= 33 ? "low" : v <= 66 ? "med" : "high";
+}
+
+/**
+ * Build the profile-dependent custom properties, keyed `--h4-*`. The constant
+ * tokens (agent jewel, radii, fonts) live in hermes4-tokens.css and are not
+ * re-themed. Mirrors the reference buildTheme exactly.
+ */
+export function buildTheme(p: ColorProfile): Record<string, string> {
+  const dark = !!p.dark, glow = !!p.glow;
+  const { base, surface: surf, ink, muted, accent, healthy: ok, degraded: warn } = p;
+  const accFill = p.accentFill || (dark ? accent : darken(accent, 0.08));
+  const accInk = p.accentInk || inkOn(accFill);
+  return {
+    "--h4-canvas": base,
+    "--h4-surface": mix(base, surf, 0.5),
+    "--h4-paper": surf,
+    "--h4-paper-sunken": mix(surf, base, 0.4),
+    "--h4-paper-veil": rgba(surf, 0.72),
+    "--h4-ink": ink,
+    "--h4-ink-2": dark ? mix(ink, muted, 0.16) : mix(ink, muted, 0.3),
+    "--h4-muted": dark ? lighten(muted, 0.22) : muted,
+    "--h4-faint": dark ? lighten(mix(muted, base, 0.28), 0.08) : mix(muted, base, 0.45),
+    "--h4-line": rgba(ink, dark ? 0.14 : 0.12),
+    "--h4-line-2": rgba(ink, dark ? 0.08 : 0.06),
+    "--h4-line-strong": rgba(ink, dark ? 0.22 : 0.16),
+    "--h4-act": accent,
+    "--h4-act-deep": accFill,
+    "--h4-act-ink": accInk,
+    "--h4-act-text": dark ? lighten(accent, 0.1) : darken(accent, 0.12),
+    "--h4-act-soft": rgba(accent, dark ? 0.18 : 0.12),
+    "--h4-act-soft-2": rgba(accent, dark ? 0.3 : 0.2),
+    "--h4-act-line": rgba(accent, dark ? 0.5 : 0.34),
+    // DECIDE tier tint — desaturated toward neutral so it never blurs with the true coral CTA.
+    "--h4-tier-decide-bg": rgba(mix(accent, base, dark ? 0.55 : 0.45), dark ? 0.16 : 0.34),
+    "--h4-tier-decide-line": rgba(mix(accent, base, dark ? 0.4 : 0.32), dark ? 0.34 : 0.3),
+    "--h4-tier-decide-text": dark ? lighten(mix(accent, muted, 0.34), 0.06) : darken(mix(accent, muted, 0.3), 0.04),
+    "--h4-ok": ok,
+    "--h4-ok-text": dark ? lighten(ok, 0.12) : darken(ok, 0.1),
+    "--h4-ok-soft": rgba(ok, dark ? 0.2 : 0.16),
+    "--h4-ok-line": rgba(ok, dark ? 0.42 : 0.24),
+    "--h4-warn": warn,
+    "--h4-warn-text": dark ? lighten(warn, 0.1) : darken(warn, 0.14),
+    "--h4-warn-soft": rgba(warn, dark ? 0.2 : 0.16),
+    "--h4-warn-line": rgba(warn, dark ? 0.42 : 0.28),
+    "--h4-tel": dark ? lighten(muted, 0.18) : darken(muted, 0.04),
+    "--h4-tel-soft": rgba(muted, dark ? 0.18 : 0.5),
+    "--h4-tel-chip": dark ? mix(surf, muted, 0.2) : mix(base, muted, 0.16),
+    "--h4-glow-1": rgba(accent, dark ? (glow ? 0.14 : 0.1) : 0.05),
+    "--h4-glow-2": rgba(ok, dark ? 0.07 : 0.04),
+    "--h4-act-glow": dark ? `0 0 ${glow ? 20 : 14}px ${rgba(accent, glow ? 0.6 : 0.45)}` : "none",
+    "--h4-sh-sm": dark ? "0 1px 0 rgba(255,255,255,0.04) inset, 0 2px 8px rgba(0,0,0,0.40)" : "0 1px 2px rgba(40,33,18,0.05), 0 2px 6px rgba(40,33,18,0.04)",
+    "--h4-sh": dark ? "inset 0 1px 0 rgba(255,255,255,0.05), 0 10px 30px rgba(0,0,0,0.45)" : "0 2px 6px rgba(40,33,18,0.05), 0 14px 34px rgba(40,33,18,0.07)",
+    "--h4-sh-lift": dark ? "inset 0 1px 0 rgba(255,255,255,0.06), 0 16px 44px rgba(0,0,0,0.55)" : "0 8px 18px rgba(40,33,18,0.09), 0 26px 56px rgba(40,33,18,0.12)",
+    "--h4-sh-coral": dark ? `0 6px 22px ${rgba(accent, glow ? 0.55 : 0.4)}, 0 0 ${glow ? 22 : 14}px ${rgba(accent, glow ? 0.5 : 0.32)}` : `0 8px 24px ${rgba(accent, 0.24)}`,
+    "--h4-sh-inset": dark ? "inset 0 1px 0 rgba(255,255,255,0.10)" : "inset 0 1px 0 rgba(255,255,255,0.6)",
+  };
+}
+
+function resolveProfile(id: ColorProfileId): ColorProfile {
+  return PROFILES[id] ?? PROFILES[DEFAULT_PROFILE];
+}
+
+/**
+ * Apply a color profile to a root element (default <html>): writes the
+ * `--h4-*` custom properties and sets the `data-h4-profile/dark/glow`
+ * attributes the scoped CSS keys on. Returns the resolved id.
+ */
+export function applyColorProfile(id: ColorProfileId, root: HTMLElement = document.documentElement): ColorProfileId {
+  const resolvedId = PROFILES[id] ? id : DEFAULT_PROFILE;
+  const p = resolveProfile(resolvedId);
+  const vars = buildTheme(p);
+  for (const key in vars) root.style.setProperty(key, vars[key]!);
+  root.setAttribute("data-h4-profile", resolvedId);
+  root.setAttribute("data-h4-dark", p.dark ? "1" : "0");
+  root.setAttribute("data-h4-glow", p.glow ? "1" : "0");
+  return resolvedId;
+}
+
+/** True when the environment asks for reduced motion. */
+export function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    : false;
+}
+
+/**
+ * Apply motion intensity: writes `--h4-mi` (0..1) and `data-h4-motion` bucket.
+ * prefers-reduced-motion forces the bucket to "off" so JS-gated motion stops
+ * too (the CSS @media already disables animations).
+ */
+export function applyMotion(intensity: number, root: HTMLElement = document.documentElement): MotionBucket {
+  const clamped = Math.max(0, Math.min(100, intensity));
+  const bucket = prefersReducedMotion() ? "off" : motionBucket(clamped);
+  root.style.setProperty("--h4-mi", String(Math.max(clamped / 100, 0)));
+  root.setAttribute("data-h4-motion", bucket);
+  return bucket;
+}
+
+/** Apply density bucket: sets `data-h4-density` (the CSS scopes spacing on it). */
+export function applyDensity(density: Density, root: HTMLElement = document.documentElement): Density {
+  const value: Density = density === "compact" || density === "comfy" ? density : "regular";
+  root.setAttribute("data-h4-density", value);
+  return value;
+}

--- a/packages/monitor-ui/src/lib/monitor/lane-rules.ts
+++ b/packages/monitor-ui/src/lib/monitor/lane-rules.ts
@@ -45,6 +45,31 @@ export function isUnroutedCard(card: BoardCard | undefined | null): boolean {
   return !card.lane;
 }
 
+/**
+ * PR-D1 — DECIDE / WATCH / HIDE kanban tiers. Each of the 8 lanes belongs to
+ * one tier (a coloring/grouping layer over the existing flat lanes, not a
+ * re-routing of cards):
+ *   - DECIDE: the Decision Inbox — `needs-attention`, the single lane that
+ *     unions everything waiting on the operator (laneFor promotes isAction /
+ *     operator-waiting cards here). DECIDE-orange (--h4-act) is reserved for
+ *     this tier only.
+ *   - WATCH:  in-flight pipeline lanes (drafts → deploying).
+ *   - HIDE:   `done` (release history), de-emphasized.
+ */
+export type KanbanTier = "decide" | "watch" | "hide";
+
+export function tierFor(lane: Lane): KanbanTier {
+  if (lane === "needs-attention") return "decide";
+  if (lane === "done") return "hide";
+  return "watch";
+}
+
+/** Cards genuinely waiting on the human operator — the DECIDE workload. */
+export function isWaitingOnOperator(card: BoardCard | undefined | null): boolean {
+  if (!card) return false;
+  return card.isAction === true || card.waitingOn?.actor === "operator";
+}
+
 export type InflightStatus = "Pre-check" | "CI watching" | "Mission running";
 
 /**

--- a/packages/monitor-ui/src/lib/monitor/lane-tiers.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/lane-tiers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { tierFor, isWaitingOnOperator } from "./lane-rules.js";
+import { LANES, type BoardCard } from "./card-types.js";
+
+describe("tierFor — DECIDE / WATCH / HIDE kanban tiers", () => {
+  test("needs-attention is the only DECIDE lane (Decision Inbox)", () => {
+    expect(tierFor("needs-attention")).toBe("decide");
+    const decide = LANES.filter((l) => tierFor(l) === "decide");
+    expect(decide).toEqual(["needs-attention"]);
+  });
+
+  test("done is HIDE", () => {
+    expect(tierFor("done")).toBe("hide");
+  });
+
+  test("every other lane is WATCH", () => {
+    for (const lane of LANES) {
+      if (lane === "needs-attention" || lane === "done") continue;
+      expect(tierFor(lane)).toBe("watch");
+    }
+  });
+
+  test("every lane maps to exactly one tier", () => {
+    for (const lane of LANES) {
+      expect(["decide", "watch", "hide"]).toContain(tierFor(lane));
+    }
+  });
+});
+
+describe("isWaitingOnOperator", () => {
+  const card = (over: Partial<BoardCard>) => over as BoardCard;
+
+  test("true for an action card", () => {
+    expect(isWaitingOnOperator(card({ isAction: true }))).toBe(true);
+  });
+
+  test("true when waitingOn.actor is the operator", () => {
+    expect(isWaitingOnOperator(card({ waitingOn: { actor: "operator", tone: "warn" } }))).toBe(true);
+  });
+
+  test("false for a card waiting on CI / an agent", () => {
+    expect(isWaitingOnOperator(card({ waitingOn: { actor: "CI", tone: "info" } }))).toBe(false);
+    expect(isWaitingOnOperator(card({ waitingOn: { actor: "agent", tone: "neutral" } }))).toBe(false);
+  });
+
+  test("false for null / undefined", () => {
+    expect(isWaitingOnOperator(undefined)).toBe(false);
+    expect(isWaitingOnOperator(null)).toBe(false);
+  });
+});

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -15,6 +15,11 @@ import { MonitorPage } from "./MonitorPage.js";
 // alone left the board on fallback fonts.
 import "./styles/averray-tokens.css";
 import "./styles/monitor.css";
+// Hermes-4 design layer (PR-D1): the --h4-* token system + theme engine and
+// the new shell/footer/kanban-tier styles. Loaded LAST so its additive rules
+// win; namespaced so it never clobbers the shipped board's --hm-* tokens.
+import "./styles/hermes4-tokens.css";
+import "./styles/hermes4-shell.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/styles/hermes4-shell.css
+++ b/packages/monitor-ui/src/styles/hermes4-shell.css
@@ -1,0 +1,89 @@
+/* =========================================================
+   Hermes-4 shell + kanban tier layer (PR-D1).
+   Loaded AFTER monitor.css so these additive rules win.
+   FOUNDATION-FIRST: only the NEW surfaces (the END OF BOARD
+   footer + the kanban tier accents + flex-fill) consume the
+   --h4-* tokens. The existing board chrome keeps its --hm-*
+   styling until later D-PRs migrate it.
+   ========================================================= */
+
+/* ---- fixed app shell: header → banner → utilities → board → footer ----
+   The board root is already 100vh / overflow:hidden with no page scroll
+   (monitor.css .hm-board). Add a trailing auto row for the footer so the
+   board region (1fr) keeps its internal column scroll and the footer pins
+   to the bottom. */
+.hm-board {
+  grid-template-rows: auto auto 1fr auto;
+}
+
+/* ---- "END OF BOARD" footer — a new --h4 surface ---- */
+.h4-board-footer {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  padding: 10px 22px;
+  border-top: 1px solid var(--h4-line);
+  background: var(--h4-paper-veil);
+  color: var(--h4-muted);
+  font-family: var(--h4-font-body);
+}
+.h4-board-footer-end {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.h4-board-footer-end .dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--h4-line-strong);
+}
+.h4-board-footer-stat {
+  font-family: var(--h4-font-mono);
+  font-size: 11.5px;
+  color: var(--h4-muted);
+}
+.h4-board-footer-meta {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--h4-faint);
+}
+
+/* ---- DECIDE / WATCH / HIDE kanban: columns flex-fill the width ----
+   The lanes already live in a horizontal flex row (.hm-lanes); make the
+   expanded columns share the width evenly, with the Decision Inbox a touch
+   wider. Empty non-gate lanes still collapse to mini-rails (monitor.css). */
+.hm-lanes--kanban .hm-lane--expanded {
+  flex: 1 1 0;
+  min-width: 288px;
+}
+.hm-lanes--kanban .hm-lane--action.hm-lane--expanded {
+  flex: 1.25 1 0;
+  min-width: 340px;
+}
+
+/* DECIDE-orange (--h4-act) is RESERVED for the Decision Inbox (the one lane
+   that holds what needs the operator). A restrained left accent bar + header
+   tint — never a heavy wash that would blur with a true coral CTA. No other
+   tier gets coral. */
+.hm-lane--expanded[data-h4-tier="decide"] {
+  box-shadow: inset 3px 0 0 0 var(--h4-act);
+}
+.hm-lane--expanded[data-h4-tier="decide"] .hm-lane-head {
+  background: var(--h4-tier-decide-bg);
+}
+.hm-lane-rail[data-h4-tier="decide"] {
+  box-shadow: inset 3px 0 0 0 var(--h4-act-line);
+}
+
+/* WATCH / HIDE tiers stay neutral — telemetry-gray, never coral. */
+.hm-lane--expanded[data-h4-tier="hide"] {
+  opacity: 0.94;
+}

--- a/packages/monitor-ui/src/styles/hermes4-tokens.css
+++ b/packages/monitor-ui/src/styles/hermes4-tokens.css
@@ -1,0 +1,140 @@
+/* =========================================================
+   Hermes-4 design tokens (PR-D1) — EXTENDS averray-tokens.css.
+   FOUNDATION-FIRST + no-fork: every token here is namespaced
+   `--h4-*`, so it never clobbers the shipped board's `--hm-*`
+   / `--avy-*`. The new D1 shell / footer / kanban-tier layer
+   consumes these; the existing board is migrated onto them in
+   later D-PRs.
+
+   :root defaults below = the Midnight profile (D1 default), so
+   first paint matches before color-profile.ts runs; the engine
+   then rewrites the profile-dependent --h4-* at runtime and can
+   switch between all 6 profiles.
+
+     coral = act (needs you)   sage/green = healthy
+     amber = degraded          warm-gray  = telemetry
+   Agent identity uses a cool jewel palette kept deliberately
+   distinct from the warm status set (never status).
+   ========================================================= */
+
+:root {
+  /* ---- profile-dependent (Midnight defaults; runtime-overridden) ---- */
+  --h4-canvas:       #1A1714;
+  --h4-surface:      #1F1B18;
+  --h4-paper:        #241F1B;
+  --h4-paper-sunken: #201C18;
+  --h4-paper-veil:   rgba(36,31,27,0.72);
+
+  --h4-ink:    #EDE6DD;
+  --h4-ink-2:  #D8D1C8;
+  --h4-muted:  #8C857E;
+  --h4-faint:  #625C55;
+  --h4-line:        rgba(237,230,221,0.14);
+  --h4-line-2:      rgba(237,230,221,0.08);
+  --h4-line-strong: rgba(237,230,221,0.22);
+
+  --h4-act:        #E8865E;
+  --h4-act-deep:   #E8865E;
+  --h4-act-ink:    #ffffff;
+  --h4-act-text:   #EA926E;
+  --h4-act-soft:   rgba(232,134,94,0.18);
+  --h4-act-soft-2: rgba(232,134,94,0.30);
+  --h4-act-line:   rgba(232,134,94,0.50);
+
+  --h4-tier-decide-bg:   rgba(119,73,53,0.16);
+  --h4-tier-decide-line: rgba(150,90,64,0.34);
+  --h4-tier-decide-text: #C18267;
+
+  --h4-ok:      #7FB089;
+  --h4-ok-text: #8EB997;
+  --h4-ok-soft: rgba(127,176,137,0.20);
+  --h4-ok-line: rgba(127,176,137,0.42);
+
+  --h4-warn:      #E0A050;
+  --h4-warn-text: #E3AA62;
+  --h4-warn-soft: rgba(224,160,80,0.20);
+  --h4-warn-line: rgba(224,160,80,0.42);
+
+  --h4-tel:      #867F78;
+  --h4-tel-soft: rgba(107,99,90,0.18);
+  --h4-tel-chip: #322D28;
+
+  --h4-glow-1: rgba(232,134,94,0.10);
+  --h4-glow-2: rgba(127,176,137,0.07);
+  --h4-act-glow: none;
+
+  --h4-sh-sm:   0 1px 0 rgba(255,255,255,0.04) inset, 0 2px 8px rgba(0,0,0,0.40);
+  --h4-sh:      inset 0 1px 0 rgba(255,255,255,0.05), 0 10px 30px rgba(0,0,0,0.45);
+  --h4-sh-lift: inset 0 1px 0 rgba(255,255,255,0.06), 0 16px 44px rgba(0,0,0,0.55);
+  --h4-sh-coral: 0 6px 22px rgba(232,134,94,0.40), 0 0 14px rgba(232,134,94,0.32);
+  --h4-sh-inset: inset 0 1px 0 rgba(255,255,255,0.10);
+
+  /* ---- constants (not re-themed across profiles) ---- */
+
+  /* agent identity — cool jewel palette, kept distinct from status */
+  --h4-ag-hermes: #4b56c4;
+  --h4-ag-claude: #7048b6;
+  --h4-ag-codex:  #2f8f83;
+  --h4-ag-test:   #5d6b7d;
+  --h4-ag-op:     #2a2723;
+  --h4-ag-system: #8a8275;
+
+  /* type — reuse the #422 families (don't fork) */
+  --h4-font-display: var(--font-display);
+  --h4-font-body:    var(--font-body);
+  --h4-font-mono:    var(--font-mono);
+
+  /* radii — warm, rounded */
+  --h4-r-sm:   8px;
+  --h4-r-chip: 9px;
+  --h4-r-btn:  11px;
+  --h4-r-card: 15px;
+  --h4-r-lane: 19px;
+  --h4-r-pill: 999px;
+
+  /* motion intensity (0..1, runtime-driven by color-profile.ts) */
+  --h4-mi: 0.6;
+  --h4-ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+  --h4-ease-spring: cubic-bezier(0.34, 1.62, 0.4, 1);
+  --h4-dur-fast: 150ms;
+  --h4-dur: 200ms;
+
+  /* density-scoped spacing (data-h4-density on <html>) */
+  --h4-pad-card: 18px;
+  --h4-pad-lane: 16px;
+  --h4-gap-cards: 14px;
+  --h4-gap-tier: 22px;
+  --h4-gap-room: 12px;
+}
+
+:root[data-h4-density="compact"] {
+  --h4-pad-card: 13px; --h4-pad-lane: 12px; --h4-gap-cards: 10px; --h4-gap-tier: 16px; --h4-gap-room: 9px;
+}
+:root[data-h4-density="comfy"] {
+  --h4-pad-card: 22px; --h4-pad-lane: 20px; --h4-gap-cards: 18px; --h4-gap-tier: 30px; --h4-gap-room: 16px;
+}
+
+/* ---- motion atoms (namespaced; gated on data-h4-motion + reduced-motion) ---- */
+@keyframes h4-slide-in {
+  from { opacity: 0; transform: translateY(12px) scale(0.985); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes h4-live {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.45; transform: scale(0.82); }
+}
+
+.h4-advance { animation: h4-slide-in 320ms var(--h4-ease-spring) both; }
+.h4-live-dot { animation: h4-live calc(2.4s / max(var(--h4-mi), 0.4)) ease-in-out infinite; }
+:root[data-h4-dark="1"] .h4-live-dot { box-shadow: 0 0 9px currentColor; }
+:root[data-h4-glow="1"] .h4-live-dot { box-shadow: 0 0 13px currentColor; }
+
+/* off: kill all h4 motion; low: keep slide-ins, drop the live pulse */
+:root[data-h4-motion="off"] .h4-advance,
+:root[data-h4-motion="off"] .h4-live-dot { animation: none !important; }
+:root[data-h4-motion="low"] .h4-live-dot { animation: none; }
+
+/* reduced-motion always wins, regardless of bucket */
+@media (prefers-reduced-motion: reduce) {
+  .h4-advance, .h4-live-dot { animation: none !important; }
+}


### PR DESCRIPTION
## What

**PR-D1** of the Hermes-4 redesign (design reference `docs/design/hermes-4/project/*`, merged in #429). Ports the token layer + theme engine, the fixed app-shell footer, and the DECIDE/WATCH/HIDE kanban tier layer.

**Foundation-first + no-fork** (per your steer): the entire new design system is namespaced **`--h4-*`** so it *never* clobbers the shipped board's `--hm-*` or #422's `--avy-*` tokens. The new shell-footer + kanban-tier surfaces consume `--h4-*`; the existing board keeps its current styling until **D2/D3** migrate it incrementally. Zero-regression at every step.

## Tokens — `styles/hermes4-tokens.css` (extends `averray-tokens.css`)
- Semantic palette: `--h4-act` coral / `--h4-ok` sage / `--h4-warn` amber / `--h4-tel` telemetry.
- **Agent-identity jewel** `--h4-ag-*` — kept deliberately distinct from status (never reads as status).
- Type reuses #422's `--font-*` (Space Grotesk / Manrope / JetBrains) — no fork; radii `--h4-r-*`; elevation `--h4-sh-*`; `--h4-mi` motion; `data-h4-density` spacing; `data-h4-motion` buckets + `prefers-reduced-motion`.
- `:root` defaults = the Midnight profile, so first paint matches before JS runs.

## Theme engine — `lib/monitor/color-profile.ts` + `hooks/useColorProfile.ts`
- **All 6 color profiles** (claude / midnight / slate / editorial / averray / midpolka), a verbatim port of the reference color math (`mix`/`darken`/`lighten`/`rgba`/`inkOn`) + `buildTheme`, keyed `--h4-*`. `applyColorProfile`/`applyMotion`/`applyDensity` write the custom props + `data-h4-profile/dark/glow/motion/density` on `<html>`.
- `useColorProfile` applies the **D1 default = Midnight** (your pick; all 6 switchable) on mount and honors `prefers-reduced-motion`. Wired in `MonitorPage`. (A profile-switcher UI is a later D-PR — the hook already exposes the setters.)

## Shell — fixed `100vh` / `overflow:hidden` / internal column scroll
The board is already a fixed grid with no page scroll (`monitor.css`); D1 adds the trailing **"END OF BOARD"** footer row with **honest real-data counts only** — `N cards · M waiting on you · K running`. No fabricated "last sync" clock (we have no real board-sync signal to show).

## Kanban DECIDE / WATCH / HIDE — `tierFor()` + `isWaitingOnOperator()`
A tier layer over the existing 8 lanes (not a re-route): `needs-attention` = **DECIDE** (the Decision Inbox), `done` = **HIDE**, the rest = **WATCH**. Lanes/rails carry `data-h4-tier`; expanded columns flex-fill the width; **DECIDE-orange (`--h4-act`) is reserved for the Decision Inbox only** (a restrained left accent + header tint, never a heavy wash). Empty non-gate lanes still collapse to mini-rails. Card-advance entrance uses the `.h4-advance` spring, reduced-motion gated.

Wired to **real board state** (`laneFor` + `waitingOn.actor === "operator"`). Truth-boundary preserved.

## No regression
The `8-lane` / `"Kanban lane grid"` region / per-lane aria-labels / mini-rail DOM contracts are **unchanged**, so every existing board test still passes.

## Tests
`color-profile` (math; all 6 profiles; `buildTheme` `--h4-*` shape; Midnight `act-ink` via `inkOn`; `apply*` write `--h4-*` + data attrs and **never touch `--hm-*`/`--avy-*`**); `lane-tiers` (`tierFor` mapping + `isWaitingOnOperator`); `BoardView` footer counts + the single DECIDE lane = needs-attention.

## Verification
`tsc -b` clean · `vitest run` **1590 passing** · `@avg/monitor-ui` vite build clean.

## Scope note
A faithful read of "DECIDE/WATCH/HIDE kanban" maps the existing 8 lanes into 3 tiers (the board was already a horizontal kanban with empty→rail collapse), so this is a tier/tint/flex layer rather than a destructive board rewrite — keeping D1 narrow and the tested contracts intact. The richer card/drawer/rail work is D2/D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)