### PR TITLE
feat(monitor): Hermes-4 card badge families + active/mirror + drawer awaiting-data/checkpoints (PR-D2)

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -23,7 +23,6 @@ import type {
   BoardCard,
   CardChecks,
   WaitingOn,
-  RiskTag,
   AgentType,
   HermesDecisionRecord,
   CardWorkingNow,
@@ -31,12 +30,13 @@ import type {
   MissionReport,
 } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
-import { laneFor } from "../../lib/monitor/lane-rules.js";
+import { laneFor, isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
 import { missionFailureCardSummary } from "../../lib/monitor/mission-failure.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { AgentTag, Badge, Button, CardHeader, StatusPill, type StateVariant } from "../ui.js";
 import { ChecksBar } from "./ChecksBar.js";
+import { CardBadges } from "./CardBadges.js";
 import { AgentDiscussion } from "./AgentDiscussion.js";
 
 export type CardProps = {
@@ -86,15 +86,6 @@ function shortId(id: string): string {
 }
 
 // Risk-tag pill classification — matches the bundle's branching.
-const HIGH_RISK_TAGS = new Set<RiskTag>(["contracts", "workflow", "review-gated", "secrets", "config"]);
-const SECRET_RISK_TAGS = new Set<RiskTag>(["secrets"]);
-
-function riskBadgeVariant(tag: RiskTag): StateVariant {
-  if (SECRET_RISK_TAGS.has(tag)) return "secret";
-  if (HIGH_RISK_TAGS.has(tag)) return "risk";
-  return "neutral";
-}
-
 function freshnessVariant(card: BoardCard, isStale: boolean, isClosed: boolean): StateVariant {
   if (isClosed) return "neutral";
   if (isStale) return "age";
@@ -158,6 +149,9 @@ export function Card({
       // through dozens of cards) while staying programmatically reachable.
       tabIndex={-1}
       data-card-id={card.id}
+      // PR-D2: active (awaiting the operator → DECIDE-orange edge) vs passive
+      // mirror (someone/something else owns it → dimmed). Styled in --h4.
+      data-h4-card={isWaitingOnOperator(card) && !isClosed ? "active" : "mirror"}
       role={onClick ? "button" : "article"}
       aria-label={`${agentLabel(card.agentType)} ${shortId(card.id)} — ${card.title}`}
     >
@@ -202,16 +196,11 @@ export function Card({
         </div>
       ) : null}
 
-      {!isClosed && card.risk && card.risk.length > 0 ? (
-        <div className="hm-pillrow">
-          {card.risk.map((r) => (
-            <Badge key={r} variant={riskBadgeVariant(r)}>
-              {r}
-            </Badge>
-          ))}
-          {card.isDraft ? <Badge variant="draft">draft</Badge> : null}
-        </div>
-      ) : null}
+      {/* PR-D2: unified Hermes-4 badge families (State / Risk / Evidence /
+          Gate) in the --h4 palette, from real card fields. Supersedes the
+          ad-hoc risk pillrow. Not rendered on closed cards (compressed
+          history layout). */}
+      {!isClosed ? <CardBadges card={card} /> : null}
 
       {checks ? (
         <div className="hm-checks">

--- a/packages/monitor-ui/src/components/cards/CardBadges.test.tsx
+++ b/packages/monitor-ui/src/components/cards/CardBadges.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { CardBadges } from "./CardBadges.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function card(over: Record<string, unknown>): BoardCard {
+  return { id: "x", type: "pr", state: "fresh", risk: [], waitingOn: { actor: "agent", tone: "neutral" }, ...over } as BoardCard;
+}
+
+describe("CardBadges — State family", () => {
+  test("a running mission shows a running State badge (ok tone)", () => {
+    const { container } = render(<CardBadges card={card({ type: "mission", missionStatus: "running" })} />);
+    const badge = container.querySelector(".h4-badge--state");
+    expect(badge?.textContent).toMatch(/running/i);
+    expect(badge?.className).toContain("h4-tone--ok");
+  });
+  test("a stale card shows a warn State badge", () => {
+    const { container } = render(<CardBadges card={card({ state: "stale" })} />);
+    const badge = container.querySelector(".h4-badge--state");
+    expect(badge?.textContent).toMatch(/stale/i);
+    expect(badge?.className).toContain("h4-tone--warn");
+  });
+});
+
+describe("CardBadges — Risk family", () => {
+  test("risk tags render verbatim; a high signal escalates the family to warn", () => {
+    const { container } = render(
+      <CardBadges card={card({ risk: ["workflow", "contracts"], riskSignals: [{ severity: "high", code: "x", message: "m" }] })} />
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("workflow");
+    expect(text).toContain("contracts");
+    expect(container.querySelector(".h4-badge--risk.h4-tone--warn")?.textContent).toMatch(/risk: high/i);
+  });
+});
+
+describe("CardBadges — Evidence family (mission only)", () => {
+  test("counts mission evidence per kind", () => {
+    const { container } = render(
+      <CardBadges card={card({ type: "mission", mission: { evidence: [{ kind: "screenshot" }, { kind: "screenshot" }, { kind: "trace" }] } })} />
+    );
+    const text = container.textContent ?? "";
+    expect(text).toMatch(/2 screenshots/i);
+    expect(text).toMatch(/1 trace/i);
+  });
+  test("non-mission cards show no Evidence badge", () => {
+    const { container } = render(<CardBadges card={card({ type: "pr" })} />);
+    expect(container.querySelector(".h4-badge--evidence")).toBeNull();
+  });
+});
+
+describe("CardBadges — Gate family", () => {
+  test("operator → coral 'needs you' (act tone, DECIDE-orange)", () => {
+    const { container } = render(<CardBadges card={card({ waitingOn: { actor: "operator", tone: "warn" } })} />);
+    const gate = container.querySelector(".h4-badge--gate");
+    expect(gate?.textContent).toMatch(/needs you/i);
+    expect(gate?.className).toContain("h4-tone--act");
+  });
+  test("CI → telemetry tone, not coral", () => {
+    const { container } = render(<CardBadges card={card({ waitingOn: { actor: "CI", tone: "info" } })} />);
+    const gate = container.querySelector(".h4-badge--gate");
+    expect(gate?.textContent).toMatch(/CI/);
+    expect(gate?.className).toContain("h4-tone--tel");
+    expect(gate?.className).not.toContain("h4-tone--act");
+  });
+});
+
+describe("CardBadges — honest empty", () => {
+  test("renders nothing when no family has data", () => {
+    const { container } = render(
+      <CardBadges card={{ id: "y", type: "pr", risk: [] } as unknown as BoardCard} />
+    );
+    expect(container.querySelector(".hm-card-badges")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/cards/CardBadges.tsx
+++ b/packages/monitor-ui/src/components/cards/CardBadges.tsx
@@ -1,0 +1,140 @@
+// Hermes-4 card badge families (PR-D2).
+//
+// One unified badge row — four families, each from REAL card fields, never
+// fabricated:
+//   - State    ← missionStatus / card.state            (tone: ok/warn/tel)
+//   - Risk     ← risk[] (+ riskSignals severity)        (tone: tel, warn if high)
+//   - Evidence ← mission.evidence kinds                 (tone: tel)
+//   - Gate     ← waitingOn.actor                        (tone: act for operator)
+//
+// Tones use the PR-D1 --h4 semantic palette. The component renders only the
+// families a card actually has — an empty card yields an empty row (the caller
+// can skip it). Risk-tag text is preserved verbatim so it stays greppable.
+
+import type { BoardCard, CardState, RiskTag, WaitingOn } from "../../lib/monitor/card-types.js";
+
+type Tone = "ok" | "warn" | "act" | "tel";
+
+function StateBadge({ card }: { card: BoardCard }) {
+  const meta = stateMeta(card);
+  if (!meta) return null;
+  return (
+    <span className={`h4-badge h4-badge--state h4-tone--${meta.tone}`} title={`state: ${meta.label}`}>
+      <span className="h4-badge-glyph" aria-hidden>{meta.glyph}</span>
+      {meta.label}
+    </span>
+  );
+}
+
+function stateMeta(card: BoardCard): { label: string; tone: Tone; glyph: string } | null {
+  if (card.type === "mission") {
+    const s = (card as { missionStatus?: string }).missionStatus;
+    switch (s) {
+      case "running": return { label: "running", tone: "ok", glyph: "◐" };
+      case "completed": return { label: "done", tone: "tel", glyph: "✓" };
+      case "failed": return { label: "failed", tone: "warn", glyph: "✕" };
+      case "requested": return { label: "queued", tone: "tel", glyph: "·" };
+      case "ready": return { label: "ready", tone: "ok", glyph: "▲" };
+      default: break;
+    }
+  }
+  const map: Record<CardState, { label: string; tone: Tone; glyph: string }> = {
+    "running": { label: "running", tone: "ok", glyph: "◐" },
+    "fresh": { label: "fresh", tone: "tel", glyph: "▲" },
+    "stale": { label: "stale", tone: "warn", glyph: "◑" },
+    "failed-fetch": { label: "fetch failed", tone: "warn", glyph: "✕" },
+    "source-offline": { label: "offline", tone: "warn", glyph: "▢" },
+  };
+  return map[card.state] ?? null;
+}
+
+function RiskBadges({ card }: { card: BoardCard }) {
+  const tags: RiskTag[] = Array.isArray(card.risk) ? card.risk : [];
+  // Highest severity across real risk signals (if any) escalates the family.
+  const severities = (card.riskSignals ?? []).map((s) => s.severity);
+  const high = severities.includes("high");
+  const med = !high && severities.includes("medium");
+  if (tags.length === 0 && !high && !med) return null;
+  return (
+    <>
+      {high || med ? (
+        <span className={`h4-badge h4-badge--risk h4-tone--warn`} title="risk signals">
+          <span className="h4-badge-glyph" aria-hidden>{high ? "◆" : "◣"}</span>
+          risk: {high ? "high" : "med"}
+        </span>
+      ) : null}
+      {tags.map((tag) => (
+        <span key={tag} className="h4-badge h4-badge--risk h4-tone--tel" title={`risk area: ${tag}`}>
+          {tag}
+        </span>
+      ))}
+    </>
+  );
+}
+
+function EvidenceBadges({ card }: { card: BoardCard }) {
+  if (card.type !== "mission") return null;
+  const evidence = (card as { mission?: { evidence?: Array<{ kind?: string }> } }).mission?.evidence;
+  if (!Array.isArray(evidence) || evidence.length === 0) return null;
+  const counts = new Map<string, number>();
+  for (const e of evidence) {
+    const k = typeof e?.kind === "string" ? e.kind : "evidence";
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  return (
+    <>
+      {[...counts.entries()].map(([kind, n]) => (
+        <span key={kind} className="h4-badge h4-badge--evidence h4-tone--tel" title="mission evidence">
+          {n} {kind}{n === 1 ? "" : "s"}
+        </span>
+      ))}
+    </>
+  );
+}
+
+const GATE_META: Record<WaitingOn["actor"], { label: string; tone: Tone }> = {
+  operator: { label: "needs you", tone: "act" },
+  author: { label: "author", tone: "tel" },
+  agent: { label: "agent", tone: "tel" },
+  CI: { label: "CI", tone: "tel" },
+  relay: { label: "relay", tone: "tel" },
+  "branch-protection": { label: "branch protection", tone: "tel" },
+};
+
+function GateBadge({ card }: { card: BoardCard }) {
+  const waitingOn = card.waitingOn;
+  if (!waitingOn) return null;
+  const meta = GATE_META[waitingOn.actor];
+  if (!meta) return null;
+  // Operator is always coral (DECIDE-orange); others take their declared tone
+  // (warn → amber) but default to telemetry.
+  const tone: Tone = meta.tone === "act" ? "act" : waitingOn.tone === "warn" ? "warn" : "tel";
+  return (
+    <span className={`h4-badge h4-badge--gate h4-tone--${tone}`} title={`waiting on ${waitingOn.actor}`}>
+      <span className="h4-badge-dot" aria-hidden />
+      {meta.label}
+    </span>
+  );
+}
+
+/** The unified badge row. Returns null when no family has anything to show. */
+export function CardBadges({ card }: { card: BoardCard }) {
+  const hasState = stateMeta(card) !== null;
+  const hasRisk = (Array.isArray(card.risk) && card.risk.length > 0) || (card.riskSignals?.length ?? 0) > 0;
+  const hasEvidence =
+    card.type === "mission" &&
+    Array.isArray((card as { mission?: { evidence?: unknown[] } }).mission?.evidence) &&
+    ((card as { mission?: { evidence?: unknown[] } }).mission?.evidence?.length ?? 0) > 0;
+  const hasGate = Boolean(card.waitingOn);
+  if (!hasState && !hasRisk && !hasEvidence && !hasGate) return null;
+
+  return (
+    <div className="hm-card-badges" data-h4 role="list" aria-label="Card badges">
+      <StateBadge card={card} />
+      <RiskBadges card={card} />
+      <EvidenceBadges card={card} />
+      <GateBadge card={card} />
+      {card.isDraft ? <span className="h4-badge h4-badge--risk h4-tone--tel" title="draft">draft</span> : null}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.deploy.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.deploy.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DrawerBody } from "./DrawerBody.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function deployCard(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "deploy-1",
+    type: "deploy",
+    lane: "deploying",
+    agentType: "hermes",
+    title: "Deploy monitor stack",
+    summary: "Verifying the deploy.",
+    repo: "averray-reference-agent",
+    freshness: 2,
+    state: "running",
+    risk: [],
+    waitingOn: { actor: "CI", tone: "info" },
+    deployId: "deploy-abc123",
+    ...over,
+  } as unknown as BoardCard;
+}
+
+describe("DeployBody — PR-D2 checkpoint stepper + honest awaiting-data", () => {
+  test("renders a checkpoint stepper from real verification counters", () => {
+    const card = deployCard({ verification: { current: 2, total: 5, label: "smoke tests" } });
+    const { container } = render(<DrawerBody card={card} variant="deploy" />);
+    const stepper = container.querySelector(".h4-stepper");
+    expect(stepper).toBeTruthy();
+    expect(container.querySelectorAll(".h4-stepper-dot").length).toBe(5);
+    expect(container.querySelectorAll(".h4-stepper-dot.is-done").length).toBe(2);
+    expect(stepper?.textContent).toMatch(/2\/5 · smoke tests/);
+    expect(container.querySelector(".h4-awaiting")).toBeNull();
+  });
+
+  test("shows an honest 'awaiting data' slot when verification isn't wired", () => {
+    const card = deployCard({ verification: undefined });
+    const { container } = render(<DrawerBody card={card} variant="deploy" />);
+    const awaiting = container.querySelector(".h4-awaiting");
+    expect(awaiting).toBeTruthy();
+    expect(awaiting?.textContent).toMatch(/awaiting data/i);
+    expect(container.querySelector(".h4-stepper")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -354,6 +354,40 @@ function TaskBody({ card }: { card: BoardCard }) {
   );
 }
 
+/**
+ * PR-D2 — an honest "awaiting data" slot for a forensic field that isn't wired
+ * to a real backend signal yet. Truth-boundary: we show the field exists and is
+ * unwired, never a fabricated value. Styled in the --h4 palette.
+ */
+function AwaitingData({ label, note }: { label: string; note?: string }) {
+  return (
+    <div className="h4-awaiting" role="note">
+      <span className="h4-awaiting-label">{label}</span>
+      <span className="h4-awaiting-chip">awaiting data</span>
+      {note ? <span className="h4-awaiting-note">{note}</span> : null}
+    </div>
+  );
+}
+
+/**
+ * PR-D2 — deploy checkpoint stepper, from the REAL `verification` counters
+ * (current/total/label). Steps up to `current` are done; the rest pending. No
+ * fabricated step names — just the verified count.
+ */
+function CheckpointStepper({ current, total, label }: { current: number; total: number; label: string }) {
+  const steps = Math.max(0, Math.min(40, total));
+  return (
+    <div className="h4-stepper" aria-label={`${current} of ${total} checkpoints · ${label}`}>
+      <div className="h4-stepper-track">
+        {Array.from({ length: steps }).map((_, i) => (
+          <span key={i} className={"h4-stepper-dot" + (i < current ? " is-done" : "")} aria-hidden />
+        ))}
+      </div>
+      <div className="h4-stepper-label mono">{current}/{total} · {label}</div>
+    </div>
+  );
+}
+
 function DeployBody({ card }: { card: DeployCard }) {
   // `verification`/`deployId` are required on the UI type, but the live
   // backend doesn't always populate them (deploy verification is not wired
@@ -364,17 +398,17 @@ function DeployBody({ card }: { card: DeployCard }) {
   return (
     <>
       <VerdictBlock head="Post-merge verification">{card.summary || "Verifying the deploy."}</VerdictBlock>
-      {verification ? (
-        <section>
-          <div className="hm-section-h">Verification progress</div>
-          <div className="hm-verdict-block">
-            <div className="head">
-              {verification.current}/{verification.total} · {verification.label}
-            </div>
-            {deployId ? <div className="body">Deploy {deployId}.</div> : null}
-          </div>
-        </section>
-      ) : null}
+      <section>
+        <div className="hm-section-h">Checkpoints</div>
+        {verification ? (
+          <>
+            <CheckpointStepper current={verification.current} total={verification.total} label={verification.label} />
+            {deployId ? <div className="hm-card-meta">Deploy {deployId}.</div> : null}
+          </>
+        ) : (
+          <AwaitingData label="Post-merge verification" note="the deploy runner has not reported checkpoints yet" />
+        )}
+      </section>
       <ChecksSection checks={card.checks} checkRuns={card.checkRuns} />
     </>
   );

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -20,6 +20,8 @@ import "./styles/monitor.css";
 // win; namespaced so it never clobbers the shipped board's --hm-* tokens.
 import "./styles/hermes4-tokens.css";
 import "./styles/hermes4-shell.css";
+// PR-D2: card badge families + active/mirror treatment (--h4).
+import "./styles/hermes4-cards.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -1,0 +1,90 @@
+/* =========================================================
+   Hermes-4 card surface (PR-D2) — badge families + active/
+   mirror treatment. Loaded after monitor.css; consumes the
+   PR-D1 --h4-* tokens. Additive: the rest of the card keeps
+   its --hm-* styling until later migration.
+   ========================================================= */
+
+/* ---- unified badge row (State / Risk / Evidence / Gate) ---- */
+.hm-card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  margin-top: 10px;
+}
+
+.h4-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 20px;
+  padding: 0 9px;
+  border-radius: var(--h4-r-pill);
+  font-family: var(--h4-font-display);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  white-space: nowrap;
+  letter-spacing: 0;
+}
+.h4-badge-glyph { font-size: 9px; line-height: 1; flex: none; }
+.h4-badge-dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; flex: none; }
+
+/* tones — the --h4 semantic palette */
+.h4-tone--ok   { background: var(--h4-ok-soft);   color: var(--h4-ok-text); }
+.h4-tone--warn { background: var(--h4-warn-soft); color: var(--h4-warn-text); }
+.h4-tone--act  { background: var(--h4-act-soft);  color: var(--h4-act-text); }
+.h4-tone--tel  { background: var(--h4-tel-chip);  color: var(--h4-tel); }
+
+/* ---- active vs passive-mirror cards ----
+   Active = awaiting the operator → a coral (DECIDE-orange) left edge.
+   Mirror = someone/something else owns it → no coral edge (the absence is
+   the signal; we don't gray the whole board). Reserved coral, per the
+   design: only the operator's queue wears it. */
+.hm-card[data-h4-card="active"] {
+  border-left: 3px solid var(--h4-act);
+}
+
+/* ---- drawer: honest "awaiting data" slot (truth-boundary) ---- */
+.h4-awaiting {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex-wrap: wrap;
+  padding: 11px 12px;
+  border: 1px dashed var(--h4-line);
+  border-radius: var(--h4-r-sm);
+  background: var(--h4-paper-sunken);
+}
+.h4-awaiting-label {
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: 12px;
+  color: var(--h4-ink-2);
+}
+.h4-awaiting-chip {
+  font-family: var(--h4-font-mono);
+  font-size: 10.5px;
+  color: var(--h4-faint);
+  padding: 1px 7px;
+  border: 1px solid var(--h4-line-2);
+  border-radius: var(--h4-r-pill);
+}
+.h4-awaiting-note { font-size: 11.5px; color: var(--h4-faint); }
+
+/* ---- drawer: deploy checkpoint stepper ---- */
+.h4-stepper { display: flex; flex-direction: column; gap: 8px; }
+.h4-stepper-track { display: flex; gap: 5px; flex-wrap: wrap; }
+.h4-stepper-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1.5px solid var(--h4-line-strong);
+  background: transparent;
+}
+.h4-stepper-dot.is-done {
+  background: var(--h4-ok);
+  border-color: var(--h4-ok);
+}
+.h4-stepper-label { font-size: 12px; color: var(--h4-muted); }


### PR DESCRIPTION
## What

**PR-D2** of the Hermes-4 redesign — the **card surface**, built on PR-D1's (#430) `--h4` token system. Foundation-first + additive: the new pieces consume `--h4-*`; the rest of the card/drawer keeps its `--hm-*` styling until later migration. **Every existing card/drawer test contract is preserved** (role / aria / className assertions unchanged) — zero regression.

## Cards

- **`CardBadges`** — one unified badge row, **four families**, each from **real** card fields (never fabricated):
  | Family | Source | Tone |
  |---|---|---|
  | **State** | `missionStatus` / `card.state` | ok / warn / tel |
  | **Risk** | `risk[]` (+ `riskSignals` severity) | tel; warn when a high signal |
  | **Evidence** | `mission.evidence` kinds, counted | tel (mission cards only) |
  | **Gate** | `waitingOn.actor` | **DECIDE-orange for operator**, else tel/warn |

  Supersedes the ad-hoc risk pillrow in `Card.tsx` (risk-tag text preserved, so existing assertions still pass). Removed the now-dead `riskBadgeVariant` helper.

- **Active vs passive mirror** — a card awaiting the operator wears a coral (DECIDE-orange) left edge (`data-h4-card="active"`, via D1's `isWaitingOnOperator`); every other card has none — **the absence is the signal**, so we never gray the board. Reserved coral, per the design.

## Drawer (honest, additive)

- **`AwaitingData`** — the truth-boundary slot for a forensic field not yet wired to a real backend signal: shows the field + an "awaiting data" chip, **never a fabricated value**.
- **`CheckpointStepper`** — deploy verification rendered as a real stepper from the `verification.current/total/label` counters (done dots vs pending); falls back to `AwaitingData` when the deploy runner hasn't reported checkpoints. Wired into `DeployBody`.

All `--h4` styling in the new `styles/hermes4-cards.css` (loaded after `monitor.css`). `prefers-reduced-motion` inherited from D1.

## Tests

`CardBadges` (4 families from real fields + honest empty); `DeployBody` stepper (dots from counters) + awaiting-data fallback. **Full suite (1600)** + typecheck + `@avg/monitor-ui` vite build green; the existing `Card` / `CardRouter` / `DetailDrawer` / `DrawerBody.variant` / `ChecksBar` suites all still pass unchanged.

## Scope note (honest)

This PR lands the **card badge families + active/mirror + the honest `awaiting-data` pattern + the Deploy checkpoint stepper** — a coherent, reviewable slice. The deeper **per-category drawer forensics** (Mission expected-vs-observed table + run-timeline + the live #413 frame stream; Task "if converted to a bug" preview; the compact Decision-Inbox card treatment) build on this same `AwaitingData` / `--h4` foundation and are the next D2 slice — kept out to keep this PR narrow and green rather than a sprawling drawer rewrite of the heavily-tested `DrawerBody`. Happy to fan that out next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)