### PR TITLE
feat(monitor): Hermes-4 drawer forensics — mission expected-vs-observed, live frame, task convert-to-bug (PR-D2b)

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DrawerBody.forensics.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.forensics.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DrawerBody } from "./DrawerBody.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+const base = {
+  lane: "hermes-checking",
+  agentType: "hermes",
+  repo: "averray-reference-agent",
+  freshness: 1,
+  risk: [],
+  waitingOn: { actor: "agent", tone: "neutral" },
+};
+
+function missionCard(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "m1",
+    type: "mission",
+    title: "Citation repair dry run",
+    summary: "",
+    state: "fresh",
+    ...base,
+    ...over,
+  } as unknown as BoardCard;
+}
+
+const report = (over: Record<string, unknown> = {}) => ({
+  verdict: "OK",
+  verdictTone: "ok",
+  confidence: 0.82,
+  target: "en.wikipedia.org",
+  seed: "fresh · no memory",
+  goal: "repair dead links",
+  conclusion: "",
+  narrative: "",
+  path: [],
+  blockers: [],
+  evidence: [],
+  scores: [],
+  recommendations: [],
+  mutationBoundary: "Dry run — no claim or submit attempted.",
+  ...over,
+});
+
+describe("PR-D2b — Mission forensics (expected vs observed)", () => {
+  test("renders the eo table + env/identity badges from real fields", () => {
+    const { container } = render(<DrawerBody card={missionCard({ missionStatus: "completed", mission: report() })} variant="mission" />);
+    const eo = container.querySelector(".h4-eo");
+    expect(eo).toBeTruthy();
+    expect(eo?.textContent).toMatch(/Confidence/);
+    expect(eo?.textContent).toMatch(/met/); // 0.82 ≥ 70% → criterion met
+    expect(eo?.textContent).toMatch(/Mutation boundary/);
+    expect(eo?.textContent).toMatch(/enforced/);
+    const env = container.querySelector(".h4-env");
+    expect(env?.textContent).toMatch(/agent · hermes/);
+    expect(env?.textContent).toMatch(/en\.wikipedia\.org/);
+  });
+
+  test("a failed mission gets an honest awaiting-data failure-frame slot", () => {
+    const { container } = render(
+      <DrawerBody card={missionCard({ missionStatus: "failed", mission: report({ verdict: "FAILED", verdictTone: "fail", confidence: 0.4 }) })} variant="mission" />
+    );
+    const awaiting = container.querySelector(".h4-awaiting");
+    expect(awaiting?.textContent).toMatch(/Failure frame/);
+    expect(awaiting?.textContent).toMatch(/awaiting data/i);
+    // criterion below the bar
+    expect(container.querySelector(".h4-eo")?.textContent).toMatch(/below/);
+  });
+});
+
+describe("PR-D2b — live-follow frame", () => {
+  test("a running mission with no streamed screenshot shows an honest 'Latest frame' awaiting-data slot", () => {
+    const { container } = render(<DrawerBody card={missionCard({ missionStatus: "running", missionProgress: { message: "step 1" } })} variant="mission" />);
+    const awaiting = container.querySelector(".h4-awaiting");
+    expect(awaiting?.textContent).toMatch(/Latest frame/);
+    expect(awaiting?.textContent).toMatch(/awaiting data/i);
+  });
+
+  test("a running mission with a real screenshot shows it (no awaiting slot)", () => {
+    const { container } = render(
+      <DrawerBody card={missionCard({ missionStatus: "running", missionProgress: { message: "step 2", screenshot: "https://x.test/s.png" } })} variant="mission" />
+    );
+    expect(container.querySelector("img[alt='Latest mission screenshot']")).toBeTruthy();
+    expect(container.querySelector(".h4-awaiting")).toBeNull();
+  });
+});
+
+describe("PR-D2b — Task convert-to-bug preview", () => {
+  function taskCard(over: Record<string, unknown>): BoardCard {
+    return { id: "t1", type: "task", title: "Fix the adapter", summary: "", state: "fresh", prompt: "do the thing", ...base, ...over } as unknown as BoardCard;
+  }
+  test("drafts a bug from the task's real risk area + failure reason", () => {
+    const { container } = render(
+      <DrawerBody card={taskCard({ risk: ["workflow"], failureReason: "runner exited non-zero" })} variant="task" />
+    );
+    const bug = container.querySelector(".h4-bug");
+    expect(bug).toBeTruthy();
+    expect(bug?.textContent).toMatch(/workflow/);
+    expect(bug?.textContent).toMatch(/runner exited non-zero/);
+  });
+  test("degrades to an honest awaiting-data slot with no area or failure", () => {
+    const { container } = render(<DrawerBody card={taskCard({ risk: [] })} variant="task" />);
+    expect(container.querySelector(".h4-bug")).toBeNull();
+    expect(container.querySelector(".h4-awaiting")?.textContent).toMatch(/Bug preview/);
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -325,12 +325,51 @@ function DraftBody({ card }: { card: BoardCard }) {
   );
 }
 
+/**
+ * PR-D2b — "if converted to a bug" preview for a Codex task. Drafts what a bug
+ * report would carry, entirely from the task's REAL fields (title / repo / risk
+ * area / first prompt line / failure reason). Honest awaiting-data when a field
+ * is missing; the whole section degrades to an awaiting-data slot when there's
+ * not enough task context.
+ */
+function TaskBugPreview({ card, failureReason }: { card: BoardCard; prompt?: string; failureReason?: string }) {
+  // Fields that aren't already shown verbatim elsewhere in the task drawer
+  // (title → header, prompt → its own section). The bug a Codex task would
+  // become carries its risk area + any failure reason; both are real.
+  const rows: Array<[string, string | undefined]> = [
+    ["area", card.risk?.[0]],
+    ["failure", failureReason],
+  ];
+  const known = rows.filter(([, v]) => typeof v === "string" && v.trim().length > 0);
+  return (
+    <section>
+      <div className="hm-section-h">If converted to a bug</div>
+      {known.length > 0 ? (
+        <div className="h4-bug">
+          {rows.map(([k, v]) => (
+            <div className="h4-bug-row" key={k}>
+              <span className="h4-bug-k">{k}</span>
+              <span className={"h4-bug-v" + (v && v.trim() ? "" : " is-empty")}>
+                {v && v.trim() ? v : "awaiting data"}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <AwaitingData label="Bug preview" note="not enough task context to draft a bug yet" />
+      )}
+    </section>
+  );
+}
+
 function TaskBody({ card }: { card: BoardCard }) {
   const prompt = "prompt" in card ? card.prompt : undefined;
   const heartbeat = "runnerHeartbeat" in card ? card.runnerHeartbeat : undefined;
+  const failureReason = "failureReason" in card ? (card as { failureReason?: string }).failureReason : undefined;
   return (
     <>
       <VerdictBlock head="Proposed Codex task">{card.summary || "Awaiting operator approval to dispatch."}</VerdictBlock>
+      <TaskBugPreview card={card} prompt={prompt} failureReason={failureReason} />
       {prompt ? (
         <section>
           <div className="hm-section-h">Task prompt</div>
@@ -544,16 +583,21 @@ function MissionRunInProgress({ card }: { card: MissionCard }) {
         </div>
       </section>
 
-      {screenshot ? (
-        <section>
-          <div className="hm-section-h">Latest screenshot</div>
+      {/* PR-D2b — live-follow frame from the #413 worker stream. Show the real
+          screenshot if the stream has pushed one; otherwise an honest
+          awaiting-data slot — never a fabricated frame. */}
+      <section>
+        <div className="hm-section-h">Latest frame</div>
+        {screenshot ? (
           <img
             src={screenshot}
             alt="Latest mission screenshot"
             style={{ width: "100%", borderRadius: "var(--hm-radius)", border: "1px solid var(--hm-line)", display: "block" }}
           />
-        </section>
-      ) : null}
+        ) : (
+          <AwaitingData label="Latest frame" note="the runner has not streamed a screenshot yet" />
+        )}
+      </section>
 
       <section>
         <div className="hm-section-h">Recent runner output</div>
@@ -572,6 +616,53 @@ function MissionRunInProgress({ card }: { card: MissionCard }) {
         </div>
       </section>
     </>
+  );
+}
+
+/**
+ * PR-D2b — Mission forensics: a compact "expected vs observed" reconciliation
+ * derived HONESTLY from the real report fields (the success criterion vs the
+ * observed value — never invented pairs), plus env/identity badges (--h4 agent
+ * jewel) and, on a failure, an honest awaiting-data failure-frame slot (no
+ * screenshot/frame stream is wired into the terminal report yet).
+ */
+function MissionForensics({ card, m }: { card: MissionCard; m: NonNullable<MissionCard["mission"]> }) {
+  // Honest derivations — the success criterion vs the observed value. (The bare
+  // verdict already has its own section, so it's not repeated here.)
+  const rows: Array<{ field: string; expected: string; observed: string; ok: boolean }> = [
+    // Observed = whether the success CRITERION held (the raw confidence % has
+    // its own section, so the table reports met/below — not the number again).
+    { field: "Confidence", expected: "≥ 70%", observed: m.confidence >= 0.7 ? "met" : "below", ok: m.confidence >= 0.7 },
+    { field: "Mutation boundary", expected: "stopped before mutation", observed: m.mutationBoundary ? "enforced" : "—", ok: Boolean(m.mutationBoundary) },
+  ];
+  return (
+    <section>
+      <div className="hm-section-h">Forensics · expected vs observed</div>
+      <div className="h4-eo" role="table" aria-label="Expected vs observed">
+        <div className="h4-eo-row h4-eo-head" role="row">
+          <span role="columnheader">field</span>
+          <span role="columnheader">expected</span>
+          <span role="columnheader">observed</span>
+          <span role="columnheader" aria-label="match" />
+        </div>
+        {rows.map((r) => (
+          <div className={"h4-eo-row" + (r.ok ? "" : " is-off")} role="row" key={r.field}>
+            <span role="cell">{r.field}</span>
+            <span className="mono" role="cell">{r.expected}</span>
+            <span className="mono" role="cell">{r.observed}</span>
+            <span role="cell" aria-hidden>{r.ok ? "✓" : "✕"}</span>
+          </div>
+        ))}
+      </div>
+      <div className="h4-env">
+        <span className="h4-badge h4-badge--state h4-tone--tel">agent · {card.agentType}</span>
+        {m.seed ? <span className="h4-badge h4-badge--state h4-tone--tel">{m.seed}</span> : null}
+        {m.target ? <span className="h4-badge h4-badge--state h4-tone--tel">{m.target}</span> : null}
+      </div>
+      {m.verdictTone === "fail" ? (
+        <AwaitingData label="Failure frame" note="no screenshot was captured at the failing step" />
+      ) : null}
+    </section>
   );
 }
 
@@ -688,6 +779,8 @@ function MissionBody({ card }: { card: MissionCard }) {
           </div>
         </section>
       ) : null}
+
+      <MissionForensics card={card} m={m} />
 
       {m.narrative ? (
         <section>

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -88,3 +88,42 @@
   border-color: var(--h4-ok);
 }
 .h4-stepper-label { font-size: 12px; color: var(--h4-muted); }
+
+/* ---- mission forensics: expected vs observed ---- */
+.h4-eo { border: 1px solid var(--h4-line-2); border-radius: var(--h4-r-sm); overflow: hidden; }
+.h4-eo-row {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr 1fr auto;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--h4-ink-2);
+  border-top: 1px solid var(--h4-line-2);
+}
+.h4-eo-row:first-child { border-top: 0; }
+.h4-eo-head {
+  font-family: var(--h4-font-display);
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+  background: var(--h4-paper-sunken);
+}
+.h4-eo-row.is-off { color: var(--h4-warn-text); }
+.h4-eo-row .mono { color: inherit; }
+
+.h4-env { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 10px; }
+
+/* ---- task: if-converted-to-a-bug preview ---- */
+.h4-bug { border: 1px solid var(--h4-line-2); border-radius: var(--h4-r-sm); overflow: hidden; }
+.h4-bug-row {
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  gap: 10px;
+  padding: 7px 12px;
+  font-size: 12px;
+  border-top: 1px solid var(--h4-line-2);
+}
+.h4-bug-row:first-child { border-top: 0; }
+.h4-bug-k { font-family: var(--h4-font-display); text-transform: uppercase; font-size: 10px; color: var(--h4-faint); align-self: center; }
+.h4-bug-v { color: var(--h4-ink-2); word-break: break-word; }
+.h4-bug-v.is-empty { color: var(--h4-faint); font-family: var(--h4-font-mono); }


### PR DESCRIPTION
## What

**PR-D2b** — the deeper **per-category drawer forensics**, on the `AwaitingData`/`--h4` foundation from **PR-D2 (#431, merged)**. Additive: new drawer sections, no existing section removed; every `DrawerBody`/`DetailDrawer` test contract preserved.

## Mission drawer
- **`MissionForensics`** — an **expected-vs-observed** reconciliation derived **honestly** from the real report fields (the success criterion vs the observed outcome, never invented pairs): *Confidence* met/below the 70% bar, *Mutation boundary* enforced. The bare verdict/confidence keep their own sections, so the table reports **criteria, not the raw numbers again**.
- **env/identity badges** (`--h4` agent jewel: `agent · <type>` + seed + target).
- On a failure, an honest **awaiting-data Failure-frame** slot — no screenshot is wired into the terminal report, so we say so rather than fake one.
- **Live-follow** (`MissionRunInProgress`): the **"Latest frame"** shows the real screenshot when the **#413** worker stream has pushed one, else an honest `awaiting first frame` slot — never a fabricated frame.

## Task drawer
- **`TaskBugPreview`** — *"if converted to a bug"*, drafted only from the task's **real** fields (risk area + failure reason; title/prompt already shown elsewhere aren't restated). Degrades to an awaiting-data slot when there isn't enough context.

All `--h4` styling in `styles/hermes4-cards.css`. `prefers-reduced-motion` inherited.

## Truth-boundary
Every new slot is a real derivation or an honest `awaiting data` placeholder — no fabricated frames, numbers, or bug fields.

## Tests
`MissionForensics` (eo table met/below + env badges + failure-frame awaiting-data); live-frame (real screenshot vs awaiting-data); `TaskBugPreview` (real area/failure vs awaiting-data). **Full suite (1606)** + typecheck + vite build green; the locked `Card`/`DetailDrawer`/`DrawerBody.variant` suites still pass (two mission/task assertions de-conflicted by reporting criteria, not duplicated numbers/text).

## Where this leaves D2
With #431 + this, D2 covers: badge families, active/mirror, awaiting-data pattern, deploy checkpoint stepper, **mission expected-vs-observed + live-frame + failure-frame, task convert-to-bug**. The remaining design depth is the **compact Decision-Inbox card** treatment (a card-side change in the DECIDE lane) — a small follow-up, or fold into D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)