### PR TITLE
feat(monitor): Ask-Hermes command-preview → Confirm/Edit/Cancel before any mutating command (PR-D3a)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -127,6 +127,8 @@ describe("MonitorPage — container", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     fireEvent.change(input, { target: { value: "/mission https://staging.averray.com/onboarding" } });
     fireEvent.keyDown(input, { key: "Enter" });
+    // PR-D3: a mutating command stages a Confirm gate before it fires.
+    fireEvent.click(within(container).getByRole("button", { name: "Confirm" }));
     expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/onboarding");
   });
 
@@ -153,6 +155,8 @@ describe("MonitorPage — container", () => {
       const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
       fireEvent.change(input, { target: { value: "/mission https://x.test/y" } });
       fireEvent.keyDown(input, { key: "Enter" });
+      // PR-D3: confirm the staged mutating command before it POSTs.
+      fireEvent.click(within(container).getByRole("button", { name: "Confirm" }));
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -16,13 +16,15 @@ describe("AskHermesComposer", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     type(input, "/mission https://staging.averray.com/onboarding");
     fireEvent.click(getByRole("button", { name: /Send/ }));
+    // PR-D3: a mutating command stages a Confirm gate before it fires.
+    fireEvent.click(getByRole("button", { name: "Confirm" }));
     expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/onboarding");
     expect(input.value).toBe("");
   });
 
   test("Enter sends; Shift+Enter does not", () => {
     const onSpawnMission = vi.fn();
-    const { container } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
 
     type(input, "/mission https://x.test/a");
@@ -30,6 +32,8 @@ describe("AskHermesComposer", () => {
     expect(onSpawnMission).not.toHaveBeenCalled();
 
     fireEvent.keyDown(input, { key: "Enter" });
+    // Enter stages the command; the operator confirms it before it fires.
+    fireEvent.click(getByRole("button", { name: "Confirm" }));
     expect(onSpawnMission).toHaveBeenCalledWith("https://x.test/a");
   });
 
@@ -51,6 +55,7 @@ describe("AskHermesComposer", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     type(input, "/claude averray-agent/agent Add a HEALTHCHECK.md");
     fireEvent.click(getByRole("button", { name: /Send/ }));
+    fireEvent.click(getByRole("button", { name: "Confirm" }));
     expect(onSpawnClaudeTask).toHaveBeenCalledWith("averray-agent/agent", "Add a HEALTHCHECK.md");
     expect(input.value).toBe("");
   });
@@ -126,6 +131,7 @@ describe("AskHermesComposer", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     type(input, "/task claude averray-agent/agent Add a HEALTHCHECK.md");
     fireEvent.click(getByRole("button", { name: /Send/ }));
+    fireEvent.click(getByRole("button", { name: "Confirm" }));
     expect(onCreateTask).toHaveBeenCalledWith({
       agent: "claude",
       repo: "averray-agent/agent",
@@ -140,6 +146,7 @@ describe("AskHermesComposer", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     type(input, "/task codex averray-agent/agent#42 tighten it");
     fireEvent.click(getByRole("button", { name: /Send/ }));
+    fireEvent.click(getByRole("button", { name: "Confirm" }));
     expect(onCreateTask).toHaveBeenCalledWith({
       agent: "codex",
       repo: "averray-agent/agent",
@@ -156,6 +163,79 @@ describe("AskHermesComposer", () => {
     fireEvent.click(getByRole("button", { name: /Send/ }));
     expect(onCreateTask).not.toHaveBeenCalled();
     expect(within(container).getByRole("alert").textContent).toMatch(/not a valid agent/i);
+  });
+});
+
+describe("AskHermesComposer — PR-D3 command-preview gate", () => {
+  test("a mutating command stages a Confirm gate and does not fire on Send", () => {
+    const onSpawnMission = vi.fn();
+    const { container, getByRole, getByText } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/mission https://x.test/a");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    // staged, not fired
+    expect(onSpawnMission).not.toHaveBeenCalled();
+    expect(container.querySelector(".hm-compose-preview")).toBeTruthy();
+    expect(getByText("Spawn browser mission")).toBeTruthy();
+    expect(container.querySelector(".hm-compose-preview-detail")?.textContent).toMatch(/x\.test\/a/);
+  });
+
+  test("Cancel aborts the staged command and clears the input — nothing fires", () => {
+    const onSpawnMission = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/mission https://x.test/a");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    fireEvent.click(getByRole("button", { name: "Cancel" }));
+    expect(onSpawnMission).not.toHaveBeenCalled();
+    expect(container.querySelector(".hm-compose-preview")).toBeNull();
+    expect(input.value).toBe("");
+  });
+
+  test("Edit dismisses the gate but keeps the typed command for fixing", () => {
+    const onSpawnMission = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={onSpawnMission} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/mission https://x.test/a");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    fireEvent.click(getByRole("button", { name: "Edit" }));
+    expect(onSpawnMission).not.toHaveBeenCalled();
+    expect(container.querySelector(".hm-compose-preview")).toBeNull();
+    expect(input.value).toBe("/mission https://x.test/a");
+  });
+
+  test("autopilot is treated as mutating — it stages a confirm gate", () => {
+    const onSetAutopilot = vi.fn();
+    const onSetSupervised = vi.fn();
+    const { container, getByRole, getByText } = render(
+      <AskHermesComposer onSetAutopilot={onSetAutopilot} onSetSupervised={onSetSupervised} />
+    );
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/autopilot");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(onSetAutopilot).not.toHaveBeenCalled();
+    expect(getByText("Engage autopilot")).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Confirm" }));
+    expect(onSetAutopilot).toHaveBeenCalledTimes(1);
+  });
+
+  test("benign commands (a question) never stage a gate — they fire directly", () => {
+    const onAsk = vi.fn();
+    const { container, getByRole } = render(<AskHermesComposer onAsk={onAsk} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "what is blocking the release?");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(container.querySelector(".hm-compose-preview")).toBeNull();
+    expect(onAsk).toHaveBeenCalledTimes(1);
+  });
+
+  test("an unwired mutating command shows its honest hint, not a gate", () => {
+    const { container, getByRole } = render(<AskHermesComposer onSpawnMission={vi.fn()} />);
+    const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
+    type(input, "/claude averray-agent/agent do x");
+    fireEvent.click(getByRole("button", { name: /Send/ }));
+    expect(container.querySelector(".hm-compose-preview")).toBeNull();
+    expect(within(container).getByRole("alert").textContent).toMatch(/isn't wired here/);
   });
 });
 

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -69,6 +69,39 @@ const TARGET_SELECT_STYLE: CSSProperties = {
   outline: "none",
 };
 
+type HermesCommand = ReturnType<typeof parseHermesInput>;
+interface CommandPreview {
+  title: string;
+  detail: string;
+}
+
+/**
+ * PR-D3 — a command-preview for a MUTATING Ask-Hermes command (one that fires a
+ * real server action). Returns the human "this is what will happen" summary the
+ * Confirm/Edit/Cancel gate shows; null for benign commands (a question, mute,
+ * revert-to-supervised) which never need a confirm step.
+ */
+function mutatingPreview(command: HermesCommand): CommandPreview | null {
+  switch (command.kind) {
+    case "mission":
+      return { title: "Spawn browser mission", detail: `→ ${command.url}` };
+    case "claude":
+      return { title: "Propose Claude task", detail: `${command.repo} · ${command.prompt}` };
+    case "task":
+      return {
+        title: "Propose task",
+        detail: `@${command.agent} ${command.repo}${command.pullRequestNumber !== undefined ? `#${command.pullRequestNumber}` : ""} · ${command.prompt}`,
+      };
+    case "autopilot":
+      return {
+        title: "Engage autopilot",
+        detail: "Hermes may auto-approve non-high-risk actions for ~4h. Settlement & high-risk stay operator-gated.",
+      };
+    default:
+      return null;
+  }
+}
+
 export function AskHermesComposer({
   onSpawnMission,
   onSpawnClaudeTask,
@@ -104,6 +137,8 @@ export function AskHermesComposer({
   const [scopeToCard, setScopeToCard] = useState(true);
   const effectiveScope: "card" | "board" = focusedCardId && scopeToCard ? "card" : "board";
   const [target, setTarget] = useState<CollaborationTarget>("everyone");
+  // PR-D3: a pending mutating command awaiting Confirm/Edit/Cancel.
+  const [preview, setPreview] = useState<{ command: HermesCommand; view: CommandPreview } | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   // The board's `a` shortcut bumps focusToken to bring focus here.
@@ -122,8 +157,7 @@ export function AskHermesComposer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefillToken]);
 
-  const send = () => {
-    const command = parseHermesInput(value);
+  const dispatch = (command: HermesCommand) => {
     switch (command.kind) {
       case "empty":
         return;
@@ -201,6 +235,49 @@ export function AskHermesComposer({
         }
         return;
     }
+  };
+
+  // Is the handler for this mutating command actually wired? (We only gate a
+  // command that will really fire — an unwired one falls through to its honest
+  // "isn't wired here" hint, unchanged.)
+  const handlerWired = (command: HermesCommand): boolean =>
+    (command.kind === "mission" && Boolean(onSpawnMission)) ||
+    (command.kind === "claude" && Boolean(onSpawnClaudeTask)) ||
+    (command.kind === "task" && Boolean(onCreateTask)) ||
+    (command.kind === "autopilot" && Boolean(onSetAutopilot));
+
+  const send = () => {
+    const command = parseHermesInput(value);
+    if (command.kind === "empty") return;
+    if (command.kind === "error") {
+      setError(command.message);
+      return;
+    }
+    // PR-D3: a mutating command never fires straight from Enter — it stages a
+    // Confirm/Edit/Cancel preview first. Benign commands (ask, mute, supervised)
+    // and unwired ones dispatch directly.
+    const view = mutatingPreview(command);
+    if (view && handlerWired(command)) {
+      setPreview({ command, view });
+      setError(null);
+      return;
+    }
+    dispatch(command);
+  };
+
+  const confirmPreview = () => {
+    if (!preview) return;
+    const command = preview.command;
+    setPreview(null);
+    dispatch(command);
+  };
+  const editPreview = () => {
+    setPreview(null);
+    inputRef.current?.focus();
+  };
+  const cancelPreview = () => {
+    setPreview(null);
+    setValue("");
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -294,6 +371,25 @@ export function AskHermesComposer({
           Send <span className="hm-kbd">⏎</span>
         </Button>
       </div>
+      {/* PR-D3: command-preview gate — a mutating command stages here for an
+          explicit Confirm before it fires. Truth-boundary: nothing mutating
+          runs from a single keystroke. */}
+      {preview ? (
+        <div className="hm-compose-preview" role="group" aria-label="Confirm command">
+          <div className="hm-compose-preview-head">
+            <span className="eyebrow">Confirm command</span>
+            <strong>{preview.view.title}</strong>
+          </div>
+          <div className="hm-compose-preview-detail mono">{preview.view.detail}</div>
+          <div className="hm-compose-preview-actions">
+            <Button variant="primary" className="hm-compose-confirm" onClick={confirmPreview}>
+              Confirm
+            </Button>
+            <Button variant="ghost" onClick={editPreview}>Edit</Button>
+            <Button variant="ghost" onClick={cancelPreview}>Cancel</Button>
+          </div>
+        </div>
+      ) : null}
       {!collaborationEnabled ? (
         <div className="hm-compose-note" role="note" style={{ color: "var(--hm-muted)", fontSize: 12, marginTop: 6 }}>
           Ask Hermes unavailable — the collaboration channel is offline.{!askOnly ? " Commands like /mission and /mute still work." : ""}

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -112,6 +112,8 @@ describe("CoPilotRail", () => {
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     fireEvent.change(input, { target: { value: "/mission https://staging.averray.com/x" } });
     fireEvent.keyDown(input, { key: "Enter" });
+    // PR-D3: the mutating /mission stages a Confirm gate before it fires.
+    fireEvent.click(within(container).getByRole("button", { name: "Confirm" }));
     expect(onSpawnMission).toHaveBeenCalledWith("https://staging.averray.com/x");
   });
 

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -127,3 +127,23 @@
 .h4-bug-k { font-family: var(--h4-font-display); text-transform: uppercase; font-size: 10px; color: var(--h4-faint); align-self: center; }
 .h4-bug-v { color: var(--h4-ink-2); word-break: break-word; }
 .h4-bug-v.is-empty { color: var(--h4-faint); font-family: var(--h4-font-mono); }
+
+/* ---- D3: Ask-Hermes command-preview confirm gate ---- */
+.hm-compose-preview {
+  margin-top: 8px;
+  padding: 11px 12px;
+  border: 1px solid var(--h4-act-line);
+  border-radius: var(--h4-r-sm);
+  background: var(--h4-act-soft);
+}
+.hm-compose-preview-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.hm-compose-preview-head .eyebrow {
+  font-family: var(--h4-font-display);
+  font-weight: 700;
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--h4-act-text);
+}
+.hm-compose-preview-head strong { font-family: var(--h4-font-display); font-size: 13.5px; color: var(--h4-ink); }
+.hm-compose-preview-detail { margin-top: 6px; font-size: 12px; color: var(--h4-ink-2); word-break: break-word; }
+.hm-compose-preview-actions { display: flex; gap: 8px; margin-top: 10px; }


### PR DESCRIPTION
## What

**PR-D3a** — the operator-safety piece of the Hermes-4 composer redesign, on the merged D1/D2 `--h4` system. A mutating Ask-Hermes command **no longer fires from a single Enter** — it stages a **Confirm / Edit / Cancel** preview first.

## AskHermesComposer
- **`mutatingPreview()`** classifies the command. **Mutating** = `/mission`, `/claude`, `/task`, `/autopilot` (each fires a real server action). **Benign** = a question, `/mute`, `/unmute`, `/supervised` — those still dispatch directly.
- On send, a mutating command **with a wired handler** stages a preview panel (title + the exact "this is what will happen" detail) instead of firing:
  - **Confirm** runs it · **Edit** dismisses the gate and keeps the typed text for fixing · **Cancel** aborts and clears.
- **Truth-boundary**: nothing mutating runs from one keystroke, and **`/autopilot`** (which grants auto-approval authority) is gated too.
- **Unchanged paths**: a malformed command still shows its parse error, an unwired one its honest "isn't wired here" hint — no preview. The `send`→`dispatch` refactor preserves every existing dispatch case.
- `--h4`-styled preview panel (act-tint) in `styles/hermes4-cards.css`.

## Tests
The gate: mutating stages → Confirm fires / Cancel aborts+clears / Edit keeps text; `/autopilot` gated; benign fires directly; unwired shows the hint, not a gate. The existing mission/claude/task happy-path composer + MonitorPage + CoPilotRail tests were updated **deliberately** to click Confirm after Send — the handlers still fire, just after the gate.

**Full suite (1612)** + typecheck + `@avg/monitor-ui` vite build green.

## Scope (honest)
This lands the **command-preview safety gate** — the highest-value, most truth-boundary-aligned piece of D3. The rest of D3 (digest-first rail + agent-room reskin, per-model utilities chart, the compact Decision-Inbox card) builds on the same `--h4` layer and is the next slice (D3b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)