### PR TITLE
feat(monitor): compact Decision-Inbox card context — grants + what-happens-next (PR-D3b)

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -177,7 +177,13 @@ export function Card({
           "Why Hermes did this". Renders nothing when there's no decision
           record — never a fabricated rationale. */}
       {!isClosed && card.decisionRecord && isDecisionLane(card) ? (
-        <CardDecisionLine record={card.decisionRecord} />
+        <>
+          <CardDecisionLine record={card.decisionRecord} />
+          {/* PR-D3b: the compact Decision-Inbox context — a 1-line grants chip
+              + "what happens next", from the real decision record. The full
+              bundle/forensics stay in the drawer. */}
+          <DecisionInboxContext record={card.decisionRecord} />
+        </>
       ) : null}
 
       {!isClosed && card.reviewRequests?.some((request) => request.status === "requested") ? (
@@ -518,6 +524,45 @@ function CardDecisionLine({ record }: { record: HermesDecisionRecord }) {
         <span className="hm-card-decision-reason">
           <span className="hm-card-decision-reason-dot" aria-hidden />
           <HumanizedText text={topReason} />
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** A 1-line summary of what Hermes's decision is GRANTED to do, from the real
+ *  safety block. Read-only is the calm/ok case; anything that mutates names the
+ *  surface(s) it touches — never inflated. */
+function decisionGrants(safety: HermesDecisionRecord["safety"]): { text: string; mutating: boolean } {
+  if (safety.readOnly && !safety.mutates) return { text: "read-only", mutating: false };
+  const surfaces: string[] = [];
+  if (safety.mutatesGithub) surfaces.push("GitHub");
+  if (safety.mutatesAverray) surfaces.push("Averray");
+  if (safety.editsWikipedia) surfaces.push("Wikipedia");
+  if (surfaces.length > 0) return { text: `mutates ${surfaces.join(" · ")}`, mutating: true };
+  return safety.mutates ? { text: "mutates", mutating: true } : { text: "read-only", mutating: false };
+}
+
+/**
+ * PR-D3b — the compact Decision-Inbox context shown on DECIDE-lane cards: a
+ * grants chip (what the decision is allowed to do) + "what happens next" (from
+ * outcome.waitingNext). Both come straight from the real decision record — no
+ * fabricated authority or next-step. Renders nothing when neither is present.
+ */
+function DecisionInboxContext({ record }: { record: HermesDecisionRecord }) {
+  const whatNext = record.outcome.waitingNext?.trim();
+  const grants = decisionGrants(record.safety);
+  return (
+    <div className="hm-decision-inbox" data-h4>
+      <span
+        className={"h4-badge h4-badge--gate " + (grants.mutating ? "h4-tone--warn" : "h4-tone--ok")}
+        title="what this decision is granted to do"
+      >
+        {grants.text}
+      </span>
+      {whatNext ? (
+        <span className="hm-decision-next">
+          <span className="lbl">What happens next ·</span> <HumanizedText text={whatNext} />
         </span>
       ) : null}
     </div>

--- a/packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
+++ b/packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { Card } from "./Card.js";
+import type { BoardCard, HermesDecisionRecord } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function record(over: Partial<HermesDecisionRecord> = {}): HermesDecisionRecord {
+  return {
+    schemaVersion: 1,
+    recordType: "hermes_decision_record",
+    id: "dr-1",
+    kind: "routing",
+    subject: { kind: "pr", id: "agent #547" } as never,
+    decision: "route to operator",
+    reasons: ["review-gated surface"],
+    inputs: {},
+    outcome: { summary: "Routed to you for a risk decision", waitingNext: "On approval, Hermes merges and verifies the deploy." },
+    safety: { readOnly: true, mutates: false },
+    generatedAt: "2026-06-06T09:00:00Z",
+    ...over,
+  };
+}
+
+function decisionCard(decisionRecord: HermesDecisionRecord): BoardCard {
+  return {
+    id: "agent #547",
+    type: "pr",
+    lane: "needs-attention",
+    agentType: "claude",
+    title: "Allow operator override of agent claim-stake floor",
+    summary: "",
+    repo: "averray-agent/agent",
+    freshness: 1,
+    state: "fresh",
+    risk: ["review-gated"],
+    waitingOn: { actor: "operator", tone: "warn" },
+    isAction: true,
+    decisionRecord,
+  } as unknown as BoardCard;
+}
+
+describe("PR-D3b — compact Decision-Inbox context", () => {
+  test("a read-only decision shows an ok grants chip + 'what happens next'", () => {
+    const { container, getByText } = render(<Card card={decisionCard(record())} />);
+    const inbox = container.querySelector(".hm-decision-inbox");
+    expect(inbox).toBeTruthy();
+    const chip = inbox?.querySelector(".h4-badge--gate");
+    expect(chip?.textContent).toMatch(/read-only/);
+    expect(chip?.className).toContain("h4-tone--ok");
+    expect(getByText(/What happens next/)).toBeTruthy();
+    expect(getByText(/Hermes merges and verifies the deploy/)).toBeTruthy();
+  });
+
+  test("a mutating decision names the surfaces it touches with a warn chip", () => {
+    const { container } = render(
+      <Card card={decisionCard(record({ safety: { readOnly: false, mutates: true, mutatesGithub: true, mutatesAverray: true } }))} />
+    );
+    const chip = container.querySelector(".hm-decision-inbox .h4-badge--gate");
+    expect(chip?.textContent).toMatch(/mutates GitHub · Averray/);
+    expect(chip?.className).toContain("h4-tone--warn");
+  });
+
+  test("renders no inbox context on a non-decision lane card", () => {
+    const card = decisionCard(record());
+    (card as { isAction?: boolean }).isAction = false;
+    (card as { lane?: string }).lane = "hermes-checking";
+    const { container } = render(<Card card={card} />);
+    expect(container.querySelector(".hm-decision-inbox")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -147,3 +147,14 @@
 .hm-compose-preview-head strong { font-family: var(--h4-font-display); font-size: 13.5px; color: var(--h4-ink); }
 .hm-compose-preview-detail { margin-top: 6px; font-size: 12px; color: var(--h4-ink-2); word-break: break-word; }
 .hm-compose-preview-actions { display: flex; gap: 8px; margin-top: 10px; }
+
+/* ---- D3b: compact Decision-Inbox context (DECIDE-lane cards) ---- */
+.hm-decision-inbox {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 9px;
+}
+.hm-decision-next { font-size: 11.5px; color: var(--h4-muted); }
+.hm-decision-next .lbl { font-weight: 600; color: var(--h4-ink-2); }


### PR DESCRIPTION
## What

**PR-D3b** — the compact **Decision-Inbox card** treatment deferred from D2 and folded into D3, on the merged D1/D2/D3a `--h4` system. Additive + real-data: DECIDE-lane cards (`needs-attention`) now carry a compact decision context built **entirely from the real `HermesDecisionRecord`** — never a fabricated grant or next step.

## Card.tsx
- **`DecisionInboxContext`** (rendered alongside the existing `CardDecisionLine` on decision-lane cards with a `decisionRecord`):
  - a **1-line grants chip** from `record.safety` — `read-only` (ok tone) or the named surfaces it mutates (`mutates GitHub · Averray`, warn tone). Never inflated.
  - **"What happens next"** from `record.outcome.waitingNext`, when present.
- `decisionGrants()` summarizes the safety block honestly (read-only vs the exact mutated surfaces). The full bundle/forensics stay in the drawer.
- Renders nothing when there's no `waitingNext`/grants context, and never on a non-decision lane.
- `--h4`-styled (`.hm-decision-inbox` + the existing `h4-badge` gate chip).

## Truth-boundary
The grants chip reflects exactly what `safety` declares; "what happens next" is the real `waitingNext` or absent. No invented authority or next-step.

## Tests
read-only → ok grants chip + what-happens-next; mutating → warn chip naming the surfaces; no context on a non-decision lane. **Full suite (1615)** + typecheck + `@avg/monitor-ui` vite build green; the existing `Card` suite is unchanged (additive, distinct text).

## Where D3 stands
This closes the **compact Decision-Inbox** piece (D2's deferral). Remaining D3 surfaces — **digest-first rail + agent-room `--h4` reskin** and the **per-model utilities usage chart** — are the next slice on the same foundation (D3c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)