### PR TITLE
feat(monitor): agent-room presence tiles + rail Hermes digest, real signals only (PR-D3c/d)

### DIFF
--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.presence.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.presence.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import type { ReactNode } from "react";
+import { cleanup, render, within } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { CoPilotRail } from "./CoPilotRail.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
+
+function workingCard(): BoardCard {
+  return {
+    id: "agent #561",
+    type: "pr",
+    lane: "hermes-checking",
+    agentType: "claude",
+    title: "in flight",
+    summary: "",
+    repo: "averray-agent/agent",
+    freshness: 1,
+    state: "running",
+    risk: [],
+    waitingOn: { actor: "CI", tone: "info" },
+    workingNow: { agent: "codex", label: "Codex fixing", source: "runner" },
+  } as unknown as BoardCard;
+}
+
+describe("PR-D3c — room presence strip", () => {
+  test("renders an active peer (from workingNow) with the active dot + count", () => {
+    const { container } = render(
+      <CoPilotRail boardCards={[workingCard()]} collaboration={{ enabled: false }} />,
+      { wrapper },
+    );
+    const presence = container.querySelector(".hm-room-presence");
+    expect(presence).toBeTruthy();
+    expect(within(presence as HTMLElement).getByText("codex")).toBeTruthy();
+    expect(container.querySelector(".hm-room-peer-dot.is-active")).toBeTruthy();
+    expect(presence?.textContent).toMatch(/1 active/);
+  });
+
+  test("reads honestly as 'quiet' when no agent has a live signal", () => {
+    const { container } = render(<CoPilotRail boardCards={[]} collaboration={{ enabled: false }} />, { wrapper });
+    const presence = container.querySelector(".hm-room-presence--quiet");
+    expect(presence?.textContent).toMatch(/quiet/i);
+    expect(container.querySelector(".hm-room-peer")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -16,6 +16,7 @@ import {
   type CollaborationMessage,
 } from "../../lib/monitor/collaboration.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
+import { derivePresence, activeCount, type PresencePeer } from "../../lib/monitor/presence.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
 import { HermesTurn } from "./HermesTurn.js";
@@ -91,6 +92,12 @@ export function CoPilotRail({
     () => buildRoomThreads(messages, boardCards ?? []),
     [boardCards, messages],
   );
+  // PR-D3c: who's in the room, from real signals only (workingNow → active,
+  // recent collaboration authors → online). Recomputes as messages/cards move.
+  const peers = useMemo(
+    () => derivePresence({ messages, cards: boardCards ?? [], nowMs: Date.now() }),
+    [boardCards, messages],
+  );
 
   const scopedConversationActive = useMemo(
     () => hasScopedConversation(messages, focusedCard),
@@ -143,6 +150,7 @@ export function CoPilotRail({
         <div className="hm-activity-head">
           <span className="hm-kicker">Room</span>
           <strong>Agent collaboration</strong>
+          <RoomPresence peers={peers} />
         </div>
         <div className="hm-hermes-stream hm-activity-stream" ref={streamRef} aria-live="polite">
           {roomThreads.length > 0 ? (
@@ -247,6 +255,34 @@ function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCa
     if (card) return card.id;
   }
   return undefined;
+}
+
+/**
+ * PR-D3c — multi-agent presence tiles for the room header. Renders only agents
+ * with a real live signal (active in-flight work, or a recent message); an
+ * empty room reads honestly as "quiet", never a fabricated always-on roster.
+ */
+function RoomPresence({ peers }: { peers: readonly PresencePeer[] }) {
+  if (peers.length === 0) {
+    return <span className="hm-room-presence hm-room-presence--quiet">quiet · no agents active</span>;
+  }
+  const active = activeCount(peers);
+  return (
+    <div className="hm-room-presence" role="list" aria-label="Agents present">
+      {peers.map((peer) => (
+        <span
+          className="hm-room-peer"
+          role="listitem"
+          key={peer.agent}
+          title={peer.detail ? `${peer.agent} · ${peer.detail}` : `${peer.agent} · ${peer.presence}`}
+        >
+          <span className={`hm-room-peer-dot is-${peer.presence}`} aria-hidden />
+          <span className="hm-room-peer-name">{peer.agent}</span>
+        </span>
+      ))}
+      {active > 0 ? <span className="hm-room-presence-count">{active} active</span> : null}
+    </div>
+  );
 }
 
 function RoomThreadBlock({

--- a/packages/monitor-ui/src/lib/monitor/presence.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/presence.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { derivePresence, activeCount } from "./presence.js";
+import type { BoardCard } from "./card-types.js";
+
+const NOW = Date.parse("2026-06-06T12:00:00Z");
+
+function card(workingNow?: { agent: string; label?: string }): BoardCard {
+  return { id: "c", type: "pr", ...(workingNow ? { workingNow: { ...workingNow, source: "runner" } } : {}) } as unknown as BoardCard;
+}
+function msg(author: string, agoMs: number) {
+  return { author, ts: NOW - agoMs };
+}
+
+describe("derivePresence", () => {
+  it("marks an agent with real in-flight work (workingNow) as active", () => {
+    const peers = derivePresence({ messages: [], cards: [card({ agent: "codex", label: "Codex fixing" })], nowMs: NOW });
+    expect(peers).toHaveLength(1);
+    expect(peers[0]).toMatchObject({ agent: "codex", presence: "active", detail: "Codex fixing" });
+  });
+
+  it("marks a recent collaboration author as online", () => {
+    const peers = derivePresence({ messages: [msg("claude", 2 * 60_000)], cards: [], nowMs: NOW });
+    expect(peers).toEqual([{ agent: "claude", presence: "online" }]);
+  });
+
+  it("active wins over online for the same agent", () => {
+    const peers = derivePresence({
+      messages: [msg("codex", 1_000)],
+      cards: [card({ agent: "codex", label: "working" })],
+      nowMs: NOW,
+    });
+    expect(peers).toHaveLength(1);
+    expect(peers[0]!.presence).toBe("active");
+  });
+
+  it("excludes authors older than the online window, and 'everyone'", () => {
+    const peers = derivePresence({
+      messages: [msg("claude", 30 * 60_000), msg("everyone", 1_000)],
+      cards: [],
+      nowMs: NOW,
+    });
+    expect(peers).toEqual([]);
+  });
+
+  it("orders active before online, then by name; activeCount counts the active tier", () => {
+    const peers = derivePresence({
+      messages: [msg("docs", 1_000), msg("claude", 1_000)],
+      cards: [card({ agent: "codex" }), card({ agent: "hermes" })],
+      nowMs: NOW,
+    });
+    expect(peers.map((p) => `${p.agent}:${p.presence}`)).toEqual([
+      "codex:active",
+      "hermes:active",
+      "claude:online",
+      "docs:online",
+    ]);
+    expect(activeCount(peers)).toBe(2);
+  });
+
+  it("is honestly empty when there is no live signal", () => {
+    expect(derivePresence({ messages: [], cards: [card()], nowMs: NOW })).toEqual([]);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/presence.ts
+++ b/packages/monitor-ui/src/lib/monitor/presence.ts
@@ -1,0 +1,66 @@
+// Hermes-4 agent-room presence (PR-D3c).
+//
+// Derives who's "in the room" from REAL signals the board already carries —
+// never a fabricated roster:
+//   - active  ← a card's `workingNow` (an agent with real in-flight work)
+//   - online  ← authored a collaboration message within the recency window
+// An agent with no live signal simply isn't shown (honest empty over an
+// always-on roster). Pure + deterministic so it unit-tests with no clock.
+
+import type { BoardCard } from "./card-types.js";
+
+export type PresenceState = "active" | "online";
+
+export interface PresencePeer {
+  agent: string;
+  presence: PresenceState;
+  /** Optional one-liner (e.g. the workingNow label) for the tile's title. */
+  detail?: string;
+}
+
+export interface PresenceInput {
+  messages: ReadonlyArray<{ author?: string; ts?: number }>;
+  cards: readonly BoardCard[];
+  nowMs: number;
+  /** How recently an author must have posted to count as "online". Default 10m. */
+  onlineWindowMs?: number;
+}
+
+const DEFAULT_ONLINE_WINDOW_MS = 10 * 60_000;
+
+export function derivePresence(input: PresenceInput): PresencePeer[] {
+  const window = input.onlineWindowMs ?? DEFAULT_ONLINE_WINDOW_MS;
+  const peers = new Map<string, PresencePeer>();
+
+  // Active: an agent with real in-flight work on a card (workingNow).
+  for (const card of input.cards) {
+    const wn = card.workingNow;
+    const agent = wn?.agent;
+    if (typeof agent === "string" && agent.length > 0) {
+      peers.set(agent, { agent, presence: "active", ...(wn?.label ? { detail: wn.label } : {}) });
+    }
+  }
+
+  // Online: authored a collaboration message within the window — unless they're
+  // already shown as active (active is the stronger signal).
+  for (const message of input.messages) {
+    const author = message.author;
+    if (typeof author !== "string" || author.length === 0 || author === "everyone") continue;
+    const existing = peers.get(author);
+    if (existing?.presence === "active") continue;
+    if (typeof message.ts === "number" && input.nowMs - message.ts <= window && input.nowMs - message.ts >= 0) {
+      if (!peers.has(author)) peers.set(author, { agent: author, presence: "online" });
+    }
+  }
+
+  // Active first, then online; stable by agent name within a tier.
+  return [...peers.values()].sort((a, b) => {
+    if (a.presence !== b.presence) return a.presence === "active" ? -1 : 1;
+    return a.agent.localeCompare(b.agent);
+  });
+}
+
+/** Count of agents actively working — the glanceable "N active" figure. */
+export function activeCount(peers: readonly PresencePeer[]): number {
+  return peers.filter((peer) => peer.presence === "active").length;
+}

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -158,3 +158,38 @@
 }
 .hm-decision-next { font-size: 11.5px; color: var(--h4-muted); }
 .hm-decision-next .lbl { font-weight: 600; color: var(--h4-ink-2); }
+
+/* ---- D3c: agent-room presence tiles ---- */
+.hm-room-presence {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-left: auto;
+}
+.hm-room-presence--quiet {
+  font-family: var(--h4-font-mono);
+  font-size: 10.5px;
+  color: var(--h4-faint);
+}
+.hm-room-peer {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px 1px 5px;
+  border-radius: var(--h4-r-pill);
+  background: var(--h4-tel-chip);
+  font-size: 10.5px;
+  color: var(--h4-tel);
+}
+.hm-room-peer-dot { width: 6px; height: 6px; border-radius: 50%; flex: none; background: var(--h4-faint); }
+.hm-room-peer-dot.is-online { background: var(--h4-tel); }
+.hm-room-peer-dot.is-active { background: var(--h4-ok); box-shadow: 0 0 6px var(--h4-ok); }
+.hm-room-peer-name { font-family: var(--h4-font-display); font-weight: 600; }
+.hm-room-presence-count {
+  font-family: var(--h4-font-display);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--h4-ok-text);
+}


### PR DESCRIPTION
## What

**PR-D3c** — the multi-agent **presence tiles** from the Hermes-4 agent-room design, on the merged `--h4` system. A presence strip in the collaboration-room header, derived **only** from signals the rail already carries — never a fabricated always-on roster.

> Scope note: D3's other "rail/utilities" pieces are **already functional** on `main` — the LLM-usage panel renders per-(agent,model) tokens with in/out bars and **shows no `$`** (already truth-boundary-correct), and the room turn-stream exists. The genuine gap was **presence**, so that's what this PR adds. The rest is pure `--h4` visual reskin of already-working surfaces.

## Changes
- **`lib/monitor/presence.ts`** — pure `derivePresence({ messages, cards, nowMs })` → peers:
  - **active** = an agent with real in-flight work (a card's `workingNow`)
  - **online** = authored a collaboration message within the recency window (10m), unless already active (active wins)
  - ordered active-first then by name; **honestly empty** when no agent has a live signal. Plus `activeCount()`.
- **`CoPilotRail`** — a `RoomPresence` strip in the room header: per-agent dot (active = sage glow, online = telemetry) + name + a glanceable **"N active"** count. An empty room reads **"quiet · no agents active"**, never invented presence. **No new wiring** — uses the rail's existing `messages` + `boardCards`.
- `--h4`-styled (`.hm-room-presence` / `.hm-room-peer`) in `styles/hermes4-cards.css`.

## Truth-boundary
Presence reflects real `workingNow`/collaboration signals only; an agent with no signal isn't shown. `prefers-reduced-motion` inherited.

## Tests
`derivePresence` (active from workingNow, online from recent author, active>online precedence, stale/`everyone` excluded, ordering, honest empty) + the strip render (active dot + count; quiet fallback). **Full suite (1620)** + typecheck + `@avg/monitor-ui` vite build green (run twice — stable; existing CoPilotRail suite unchanged).

## Where D3 / the redesign stands
With #434 (Decision-Inbox) + this, **D3 is substantively complete** — the only remaining design work is pure `--h4` visual reskin of the existing (already-functional) rail/utilities surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)