### PR TITLE
feat(monitor): rail "Hermes digest" header — real counts, honest awaiting-data deltas (PR-D3d)

### DIFF
--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import type { ReactNode } from "react";
+import { cleanup, render, within } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import { CoPilotRail } from "./CoPilotRail.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
+}
+
+function card(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "c", type: "pr", lane: "hermes-checking", agentType: "claude", title: "t", summary: "",
+    repo: "r", freshness: 1, state: "fresh", risk: [], waitingOn: { actor: "agent", tone: "neutral" }, ...over,
+  } as unknown as BoardCard;
+}
+
+describe("PR-D3d — rail Hermes digest", () => {
+  test("shows real needs-you / running counts and an honest awaiting-data since-marker", () => {
+    const cards = [
+      card({ waitingOn: { actor: "operator", tone: "warn" } }),
+      card({ isAction: true }),
+      card({ state: "running" }),
+    ];
+    const { container } = render(<CoPilotRail boardCards={cards} collaboration={{ enabled: false }} />, { wrapper });
+    const digest = container.querySelector(".hm-rail-digest") as HTMLElement;
+    expect(digest).toBeTruthy();
+    const view = within(digest);
+    // needs-you = 2 (operator + isAction), running = 1
+    expect(view.getByText("needs you").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("2");
+    expect(view.getByText("running now").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("1");
+    // No fabricated session deltas — the since-marker is honest awaiting-data.
+    expect(view.getByText(/since last look · awaiting data/i)).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -17,6 +17,7 @@ import {
 } from "../../lib/monitor/collaboration.js";
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { derivePresence, activeCount, type PresencePeer } from "../../lib/monitor/presence.js";
+import { railDigestCounts } from "../../lib/monitor/rail-digest.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
 import { HermesTurn } from "./HermesTurn.js";
@@ -132,6 +133,8 @@ export function CoPilotRail({
           </div>
         </div>
       </div>
+
+      <RailDigest cards={boardCards ?? []} />
 
       <BacklogSuggestionsRailBlock
         response={backlogSuggestions}
@@ -255,6 +258,44 @@ function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCa
     if (card) return card.id;
   }
   return undefined;
+}
+
+/**
+ * PR-D3d — the "Hermes digest" at the top of the rail. Leads with the figures
+ * we can compute from REAL board cards (needs-you, running). The
+ * since-you-last-looked marker + session deltas need a backend session signal
+ * we don't have, so they read as honest awaiting-data — never a fabricated
+ * count.
+ */
+function RailDigest({ cards }: { cards: readonly BoardCard[] }) {
+  const { needsYou, running } = railDigestCounts(cards);
+  return (
+    <section className="hm-rail-digest" aria-label="Hermes digest">
+      <div className="hm-rail-digest-head">
+        <span className="hm-kicker">Digest</span>
+        <strong>Hermes digest</strong>
+        <span
+          className="hm-rail-digest-since"
+          title="The since-you-last-looked marker needs a real session backend — not wired yet."
+        >
+          since last look · awaiting data
+        </span>
+      </div>
+      <div className="hm-rail-digest-stats">
+        <DigestStat label="needs you" value={needsYou} tone="act" />
+        <DigestStat label="running now" value={running} tone="ok" />
+      </div>
+    </section>
+  );
+}
+
+function DigestStat({ label, value, tone }: { label: string; value: number; tone: "act" | "ok" }) {
+  return (
+    <div className="hm-rail-digest-stat">
+      <span className="hm-rail-digest-value" data-tone={tone}>{value}</span>
+      <span className="hm-rail-digest-label">{label}</span>
+    </div>
+  );
 }
 
 /**

--- a/packages/monitor-ui/src/lib/monitor/rail-digest.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/rail-digest.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { railDigestCounts } from "./rail-digest.js";
+import type { BoardCard } from "./card-types.js";
+
+function c(over: Record<string, unknown>): BoardCard {
+  return { id: "c", type: "pr", state: "fresh", waitingOn: { actor: "agent", tone: "neutral" }, ...over } as unknown as BoardCard;
+}
+
+describe("railDigestCounts", () => {
+  it("counts needs-you from operator-waiting / action cards", () => {
+    const counts = railDigestCounts([
+      c({ waitingOn: { actor: "operator", tone: "warn" } }),
+      c({ isAction: true }),
+      c({ waitingOn: { actor: "CI", tone: "info" } }),
+    ]);
+    expect(counts.needsYou).toBe(2);
+  });
+
+  it("counts running from state, mission status, or workingNow", () => {
+    const counts = railDigestCounts([
+      c({ state: "running" }),
+      c({ type: "mission", missionStatus: "running" }),
+      c({ workingNow: { agent: "codex", label: "fixing", source: "runner" } }),
+      c({ state: "fresh" }),
+    ]);
+    expect(counts.running).toBe(3);
+  });
+
+  it("is all-zero for an empty board", () => {
+    expect(railDigestCounts([])).toEqual({ needsYou: 0, running: 0 });
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/rail-digest.ts
+++ b/packages/monitor-ui/src/lib/monitor/rail-digest.ts
@@ -1,0 +1,34 @@
+// Hermes-4 rail digest (PR-D3d).
+//
+// The "Hermes digest" at the top of the rail — a glanceable summary of board
+// state. Only the figures we can compute from REAL board cards are emitted as
+// numbers; session-relative deltas (since-you-last-looked, prod changes) need a
+// backend session signal we don't have, so they're surfaced as honest
+// awaiting-data, never a fabricated count. Pure + deterministic.
+
+import type { BoardCard } from "./card-types.js";
+import { isWaitingOnOperator } from "./lane-rules.js";
+
+export interface RailDigestCounts {
+  /** Cards awaiting the operator's decision (the DECIDE inbox). */
+  needsYou: number;
+  /** Cards with real in-flight work right now. */
+  running: number;
+}
+
+function isRunning(card: BoardCard): boolean {
+  if (card.state === "running") return true;
+  const missionStatus = (card as { missionStatus?: string }).missionStatus;
+  if (missionStatus === "running") return true;
+  return Boolean(card.workingNow);
+}
+
+export function railDigestCounts(cards: readonly BoardCard[]): RailDigestCounts {
+  let needsYou = 0;
+  let running = 0;
+  for (const card of cards) {
+    if (isWaitingOnOperator(card)) needsYou += 1;
+    if (isRunning(card)) running += 1;
+  }
+  return { needsYou, running };
+}

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -193,3 +193,35 @@
   text-transform: uppercase;
   color: var(--h4-ok-text);
 }
+
+/* ---- D3d: rail "Hermes digest" header ---- */
+.hm-rail-digest {
+  border: 1px solid var(--h4-line-2);
+  border-radius: var(--h4-r-card);
+  background: var(--h4-paper-sunken);
+  padding: 12px 14px;
+}
+.hm-rail-digest-head { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.hm-rail-digest-head strong { font-family: var(--h4-font-display); font-size: 14px; color: var(--h4-ink); }
+.hm-rail-digest-since { margin-left: auto; font-family: var(--h4-font-mono); font-size: 10.5px; color: var(--h4-faint); }
+.hm-rail-digest-stats { display: flex; gap: 10px; margin-top: 11px; }
+.hm-rail-digest-stat {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: var(--h4-r-sm);
+  background: var(--h4-paper);
+  border: 1px solid var(--h4-line-2);
+}
+.hm-rail-digest-value { font-family: var(--h4-font-display); font-size: 22px; font-weight: 700; line-height: 1; }
+.hm-rail-digest-value[data-tone="act"] { color: var(--h4-act-text); }
+.hm-rail-digest-value[data-tone="ok"] { color: var(--h4-ok-text); }
+.hm-rail-digest-label {
+  font-family: var(--h4-font-display);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}


### PR DESCRIPTION
## What

**PR-D3d** — the **"Hermes digest"** at the top of the rail (design `rail.jsx`), on the merged `--h4` system. Additive + real-data + honest.

- **`lib/monitor/rail-digest.ts`** — pure `railDigestCounts(cards)` → `{ needsYou, running }` from real board cards (`needsYou` = `isWaitingOnOperator`; `running` = state / mission status / `workingNow`).
- **`CoPilotRail`** — a `RailDigest` block at the top of the rail: **"needs you"** (act) and **"running now"** (ok) stat tiles. The since-you-last-looked marker + session deltas (advanced, prod changes) need a backend session signal we don't have, so they read as honest **"awaiting data"** — never a fabricated count.
- `--h4`-styled (`.hm-rail-digest`) in `styles/hermes4-cards.css`.

## Truth-boundary
Only figures computable from real cards are shown as numbers; session-relative deltas are honest awaiting-data, not invented. `prefers-reduced-motion` inherited.

## Tests
`railDigestCounts` (needs-you from operator/action, running from state/mission/workingNow, empty board) + the digest render (real counts + honest awaiting-data since-marker). **Full suite (1627)** + typecheck + `@avg/monitor-ui` vite build green.

## Note
Was briefly bundled on the D3c branch; #435 (presence) merged mid-flight, so this rebased onto main as its own clean single-commit PR. With #435 + this, the rail now leads with a digest + presence — and the Hermes-4 redesign is feature-complete (only cosmetic `--h4` reskin of already-functional surfaces remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)