### PR TITLE
style(monitor): reskin the co-pilot rail to the --h4 profile system (PR-D3e)

### DIFF
--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -22,6 +22,9 @@ import "./styles/hermes4-tokens.css";
 import "./styles/hermes4-shell.css";
 // PR-D2: card badge families + active/mirror treatment (--h4).
 import "./styles/hermes4-cards.css";
+// PR-D3e: rail reskin — re-points the co-pilot rail's --hm-* surfaces to --h4-*
+// so the column tracks the active color profile. Cosmetic, additive, rail-only.
+import "./styles/hermes4-rail.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/styles/hermes4-rail.css
+++ b/packages/monitor-ui/src/styles/hermes4-rail.css
@@ -1,0 +1,73 @@
+/* =========================================================
+   Hermes-4 rail reskin (PR-D3e) — cosmetic only.
+
+   Re-points the co-pilot RAIL's existing .hm-* surfaces to the
+   --h4-* token system so the whole rail column tracks the active
+   color profile (Midnight by default), matching the --h4 digest,
+   presence, and composer-preview surfaces already living inside
+   it. Loaded LAST, so these win over monitor.css.
+
+   Strictly additive + appearance-only: no DOM, no class, no text
+   changes — every selector here already exists and is unchanged
+   structurally, so the className/text/role-based tests are
+   untouched. Scoped to the rail; the board lanes/cards keep their
+   shipped --hm-* warmth until a later, deliberate full migration.
+
+   Honest note: the warm baked rgba() surface values in monitor.css
+   (paper gradients, input fills) are replaced with profile tokens
+   here precisely so a dark profile doesn't show light artifacts.
+   ========================================================= */
+
+/* ---- rail container + header ---- */
+.hm-hermes {
+  background: var(--h4-paper);
+  border-left-color: var(--h4-line);
+}
+.hm-hermes-head {
+  background: var(--h4-paper);
+  border-bottom-color: var(--h4-line-2);
+}
+.hm-hermes-title { color: var(--h4-ink); }
+.hm-hermes-sub { color: var(--h4-muted); }
+.hm-hermes-mode-banner {
+  border-color: var(--h4-line-2);
+  background: var(--h4-paper-sunken);
+  color: var(--h4-ink-2);
+}
+.hm-hermes-tool {
+  border-color: var(--h4-line);
+  color: var(--h4-muted);
+}
+.hm-hermes-tool:hover {
+  color: var(--h4-ink);
+  background: var(--h4-paper-sunken);
+}
+.hm-hermes-stream::-webkit-scrollbar-thumb { background: var(--h4-line); }
+
+/* ---- activity / room ---- */
+.hm-activity {
+  background: var(--h4-paper-sunken);
+  border-bottom-color: var(--h4-line-2);
+}
+.hm-activity-head {
+  background: var(--h4-paper);
+  border-bottom-color: var(--h4-line-2);
+}
+.hm-activity-head strong { color: var(--h4-ink); }
+
+/* ---- composer ---- */
+.hm-compose {
+  background: var(--h4-paper);
+  border-top-color: var(--h4-line-2);
+}
+.hm-compose-input {
+  border-color: var(--h4-line);
+  background: var(--h4-paper-sunken);
+  color: var(--h4-ink);
+}
+.hm-compose-input:focus {
+  border-color: var(--h4-tel);
+  background: var(--h4-paper);
+}
+.hm-compose-input::placeholder { color: var(--h4-faint); }
+.hm-compose-toolbar { color: var(--h4-muted); }


### PR DESCRIPTION
## What

**PR-D3e** — cosmetic reskin of the co-pilot **rail** to the `--h4` profile system. Appearance-only.

Re-points the rail column's existing `.hm-*` surfaces (container, header, mode banner, tools, activity/room, composer) to the `--h4-*` tokens so the whole rail tracks the active color profile (Midnight default) — matching the `--h4` digest, presence, and command-preview surfaces already living inside it.

- **`styles/hermes4-rail.css`** — a new additive override layer, imported **last** in `main.tsx`. Replaces monitor.css's baked **warm `rgba()` surface values** (paper gradients, input fills) with profile tokens, so a dark profile shows no light artifacts.

## Why a CSS-only override (not editing the components)
The rail's structure is heavily tested by className/text/role. An additive override touches **no DOM, no class, no text** — every selector already exists, structurally unchanged — so all existing tests stay green. Scoped to the rail; board lanes/cards keep their shipped `--hm-*` warmth until a later, deliberate full migration.

## Truth-boundary
No data or behavior change — purely how the rail is painted. `prefers-reduced-motion` inherited.

## Tests
**Full suite (1623)** + typecheck + `@avg/monitor-ui` vite build all green. CSS cascade isn't assertable in jsdom, so this is verified via build + token-reference review rather than a unit test (called out honestly rather than adding a brittle pseudo-test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)