### PR TITLE
feat(monitor): inbox-first layout cutover — hero Decision Inbox + read-only tier columns (PR-E1)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -111,7 +111,8 @@ describe("MonitorPage — container", () => {
 
     // Chrome is present even with no board data — no blank screen, no throw.
     await waitFor(() => expect(within(container).getByRole("banner")).toBeTruthy());
-    expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+    // PR-E1: the inbox-first board still renders its hero Decision Inbox column.
+    expect(within(container).getByRole("region", { name: "Your decisions lane" })).toBeTruthy();
     expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
   });
 

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -21,34 +21,38 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(view.getByText(/your review decision/)).toBeTruthy();
     expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
     expect(view.getByRole("region", { name: "Kanban lane grid" })).toBeTruthy();
-    expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+    // PR-E1: inbox-first columns replace the flat 8 lanes — a hero Decision
+    // Inbox + read-only tier columns (empty non-gate lanes hide; the
+    // operator-review gate stays a reachable rail).
+    expect(container.querySelectorAll("section.hm-col").length).toBe(7);
     expect(view.getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();
     // PR-D1: fixed-shell footer (END OF BOARD) with real counts.
     const footer = container.querySelector(".h4-board-footer");
     expect(footer).toBeTruthy();
     expect(footer?.textContent).toMatch(/End of board/i);
     expect(footer?.textContent).toMatch(/\d+ cards? · \d+ waiting on you · \d+ running/);
-    // PR-D1: DECIDE tier is reserved for the Decision Inbox (needs-attention) only.
-    const decideLanes = container.querySelectorAll('section.hm-lane[data-h4-tier="decide"]');
-    expect(decideLanes.length).toBe(1);
-    expect(decideLanes[0]?.getAttribute("aria-label")).toBe("Needs attention lane");
+    // PR-E1: DECIDE tier is reserved for the hero Decision Inbox only.
+    const decideCols = container.querySelectorAll('section.hm-col[data-h4-tier="decide"]');
+    expect(decideCols.length).toBe(1);
+    expect(decideCols[0]?.getAttribute("aria-label")).toBe("Your decisions lane");
   });
 
-  test("every lane with cards stays expanded in one Kanban row; empty lanes stay reachable mini-rails", () => {
+  test("renders inbox-first columns: hero Decision Inbox + read-only tier columns; the empty gate lane is a reachable rail", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
     const view = within(container);
-    expect(view.getByRole("region", { name: "Needs attention lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Your decisions lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Builder tasks lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Drafts lane" })).toBeTruthy();
-    expect(view.getByRole("region", { name: "Codex needed lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Hermes checking lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Release queue lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Deploying lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Done lane" })).toBeTruthy();
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(7);
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(1);
+    expect(container.querySelectorAll("section.hm-col").length).toBe(7);
+    expect(container.querySelectorAll(".hm-col-rail").length).toBe(1);
 
     expect(view.getByText(/governance dispute UI/)).toBeTruthy();
-    expect(view.getByRole("button", { name: /Operator review \(0 cards\)/ })).toBeTruthy();
+    // operator-review is empty + a gate → it stays as a reachable rail.
+    expect(view.getByRole("button", { name: /Runs needing review \(0 cards\)/ })).toBeTruthy();
   });
 
   test("renders the action card with one primary and Hermes verdict", () => {
@@ -236,9 +240,10 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelector(".hm-now--calm")).toBeTruthy();
     // The deploying lane (in-flight automation) is expanded and shows its body…
     expect(within(container).getByText(/Post-merge verify/)).toBeTruthy();
-    expect(container.querySelectorAll("section.hm-lane").length).toBe(2); // deploying + done
-    // …and empty lanes are mini-rails, so the full Kanban remains visible.
-    expect(container.querySelectorAll(".hm-lane--collapsed").length).toBe(6);
+    // …columns: the always-present Decision Inbox (empty) + deploying + done.
+    expect(container.querySelectorAll("section.hm-col").length).toBe(3);
+    // PR-E1: empty non-gate lanes hide; the operator-review gate stays a rail.
+    expect(container.querySelectorAll(".hm-col-rail").length).toBe(1);
   });
 
   test("groups near-identical deploy verification cards without hiding attention cards", () => {
@@ -260,15 +265,16 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(queryAllByRole("article").length).toBe(3);
   });
 
-  test("an attention lane stays visible even after a collapse attempt", () => {
+  test("the Decision Inbox is the one actionable surface and never collapses", () => {
     const board: MonitorBoard = {
       at: "2026-06-02T08:00:00Z",
       cards: [reviewCard({ id: "agent #901", title: "Review the settlement risk" })],
     };
-    const { getByRole, getByText } = render(<BoardView board={board} status="open" keyboard={false} />);
+    const { getByRole, getByText, queryByRole } = render(<BoardView board={board} status="open" keyboard={false} />);
 
-    fireEvent.click(getByRole("button", { name: "Collapse Needs attention lane" }));
-    expect(getByRole("region", { name: "Needs attention lane" })).toBeTruthy();
+    // The inbox hero has no collapse chevron — attention can never be hidden.
+    expect(queryByRole("button", { name: /Collapse Your decisions/ })).toBeNull();
+    expect(getByRole("region", { name: "Your decisions lane" })).toBeTruthy();
     expect(getByText("Review the settlement risk")).toBeTruthy();
   });
 
@@ -357,7 +363,8 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getByText("Self-heal 2 open · dispatch 4/5")).toBeTruthy();
     expect(getByLabelText("Automation health: Self-heal 2 open · dispatch 4/5")).toBeTruthy();
     expect(queryByRole("article")).toBeNull();
-    expect(container.querySelector(".hm-lane--needs-attention .hm-card")).toBeNull();
+    // …and never as a card in the Decision Inbox.
+    expect(container.querySelector(".hm-col--inbox .hm-card")).toBeNull();
   });
 
   test("renders LLM usage when the monitor snapshot reports counters", () => {
@@ -582,8 +589,10 @@ describe("BoardView — degraded + transient states", () => {
     const { container, getByText } = render(<BoardView board={undefined} status="connecting" />);
     expect(container.querySelector(".hm-now--degraded")).toBeNull();
     expect(getByText(/Nothing needs you right now/)).toBeTruthy();
-    // Still eight lanes, all empty.
-    expect(container.querySelectorAll(".hm-lane").length).toBe(8);
+    // PR-E1: just the Decision Inbox (empty success state) + the operator-review
+    // gate rail; empty non-gate lanes hide (design: no junk-drawer rails).
+    expect(container.querySelectorAll("section.hm-col").length).toBe(1);
+    expect(container.querySelector('section.hm-col[data-h4-tier="decide"]')).toBeTruthy();
   });
 
   test("zero-decision board renders a deliberate success empty state", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -34,7 +34,7 @@ import { TopStrip } from "./TopStrip.js";
 import { TopStripDegraded } from "./TopStripDegraded.js";
 import { BoardNowBanner } from "./BoardNowBanner.js";
 import { LanesBar } from "./LanesBar.js";
-import { Board } from "./Board.js";
+import { KanbanBoard } from "./KanbanBoard.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
 import { HermesCheckingBody } from "./HermesCheckingBody.js";
@@ -542,15 +542,14 @@ export function BoardView({
             onDismissSuite={onDismissSuite}
             onSpawnMission={onSpawnMission}
           />
-          <Board
+          <KanbanBoard
             grouped={displayGrouped}
             ariaLabel="Kanban lane grid"
-            className="hm-lanes--kanban"
             expanded={surfacedExpanded}
             onToggleLane={onToggleLane}
             renderLaneHeader={
               onCreateTask
-                ? (id) => (id === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
+                ? (lane) => (lane === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
                 : undefined
             }
             renderCard={renderCard}

--- a/packages/monitor-ui/src/components/KanbanBoard.test.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { KanbanBoard } from "./KanbanBoard.js";
+import type { BoardCard, Lane } from "../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+function card(lane: Lane, id = lane): BoardCard {
+  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor: "agent", tone: "neutral" } } as unknown as BoardCard;
+}
+function grouped(partial: Partial<Record<Lane, BoardCard[]>>): Record<Lane, BoardCard[]> {
+  return {
+    "needs-attention": [], drafts: [], "codex-needed": [], "hermes-checking": [],
+    "operator-review": [], "release-queue": [], deploying: [], done: [],
+    ...partial,
+  };
+}
+const renderCard = (c: BoardCard) => <div className="hm-card" key={c.id}>{c.id}</div>;
+// Mirror BoardView's seeding: a pipeline lane is "expanded" when it has cards.
+const expandedFor = (...lanes: Lane[]) => new Set<Lane>(lanes);
+
+describe("KanbanBoard", () => {
+  test("renders a hero Decision Inbox holding the DECIDE-tier cards", () => {
+    const g = grouped({ "needs-attention": [card("needs-attention", "act-1")], "codex-needed": [card("codex-needed", "t-1")] });
+    const { container } = render(
+      <KanbanBoard grouped={g} expanded={expandedFor("codex-needed")} onToggleLane={() => {}} renderCard={renderCard} />,
+    );
+    const inbox = container.querySelector('section.hm-col--inbox[data-h4-tier="decide"]') as HTMLElement;
+    expect(inbox).toBeTruthy();
+    expect(inbox.getAttribute("aria-label")).toBe("Your decisions lane");
+    expect(within(inbox).getByText("act-1")).toBeTruthy();
+    expect(within(inbox).getByText("Everything waiting on you")).toBeTruthy();
+    // exactly one DECIDE column (the inbox is the only actionable surface)
+    expect(container.querySelectorAll('section.hm-col[data-h4-tier="decide"]').length).toBe(1);
+  });
+
+  test("shows an honest success empty-state when nothing waits on you", () => {
+    const { getByText } = render(
+      <KanbanBoard grouped={grouped({ "codex-needed": [card("codex-needed")] })} expanded={expandedFor("codex-needed")} onToggleLane={() => {}} renderCard={renderCard} />,
+    );
+    expect(getByText("Nothing waiting on you")).toBeTruthy();
+  });
+
+  test("renders read-only WATCH/HIDE tier columns with design eyebrows", () => {
+    const g = grouped({ "codex-needed": [card("codex-needed")], done: [card("done")] });
+    const { getByRole } = render(
+      <KanbanBoard grouped={g} expanded={expandedFor("codex-needed", "done")} onToggleLane={() => {}} renderCard={renderCard} />,
+    );
+    expect(getByRole("region", { name: "Builder tasks lane" })).toBeTruthy();
+    expect(getByRole("region", { name: "Done lane" })).toBeTruthy();
+  });
+
+  test("hides empty non-gate lanes but keeps the operator-review gate as a reachable rail", () => {
+    const { container, getByRole, queryByRole } = render(
+      <KanbanBoard grouped={grouped({ "codex-needed": [card("codex-needed")] })} expanded={expandedFor("codex-needed")} onToggleLane={() => {}} renderCard={renderCard} />,
+    );
+    // empty non-gate (drafts, deploying, …) hide entirely
+    expect(queryByRole("region", { name: "Drafts lane" })).toBeNull();
+    // empty gate (operator-review) survives as a rail
+    expect(getByRole("button", { name: /Runs needing review \(0 cards\)/ })).toBeTruthy();
+    expect(container.querySelectorAll(".hm-col-rail").length).toBe(1);
+  });
+
+  test("a collapsed (not-expanded) non-empty lane renders as a rail that expands on click", () => {
+    const onToggleLane = vi.fn();
+    const g = grouped({ done: [card("done", "d1")] });
+    const { getByRole } = render(
+      <KanbanBoard grouped={g} expanded={expandedFor()} onToggleLane={onToggleLane} renderCard={renderCard} />,
+    );
+    fireEvent.click(getByRole("button", { name: /Expand Done \(1 cards\)/ }));
+    expect(onToggleLane).toHaveBeenCalledWith("done");
+  });
+
+  test("the header collapse chevron toggles a pipeline lane (but the inbox has none)", () => {
+    const onToggleLane = vi.fn();
+    const g = grouped({ "needs-attention": [card("needs-attention")], "codex-needed": [card("codex-needed")] });
+    const { getByRole, queryByRole } = render(
+      <KanbanBoard grouped={g} expanded={expandedFor("codex-needed")} onToggleLane={onToggleLane} renderCard={renderCard} />,
+    );
+    expect(queryByRole("button", { name: /Collapse Your decisions lane/ })).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Collapse Builder tasks lane" }));
+    expect(onToggleLane).toHaveBeenCalledWith("codex-needed");
+  });
+
+  test("uses renderLaneHeader and renderLaneBody overrides for pipeline lanes", () => {
+    const g = grouped({ "codex-needed": [card("codex-needed", "real")] });
+    const { getByText, queryByText } = render(
+      <KanbanBoard
+        grouped={g}
+        expanded={expandedFor("codex-needed")}
+        onToggleLane={() => {}}
+        renderCard={renderCard}
+        renderLaneHeader={(lane) => (lane === "codex-needed" ? <div>＋ Propose task</div> : null)}
+        renderLaneBody={(lane) => (lane === "codex-needed" ? <div>grouped body</div> : undefined)}
+      />,
+    );
+    expect(getByText("＋ Propose task")).toBeTruthy();
+    expect(getByText("grouped body")).toBeTruthy();
+    // the body override replaces the default card render
+    expect(queryByText("real")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/KanbanBoard.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.tsx
@@ -1,0 +1,232 @@
+// Hermes Handoff Monitor — inbox-first Kanban (PR-E1).
+//
+// The Hermes-4 "decision cockpit" layout (docs/design/hermes-4/project/
+// board.jsx + kanban.jsx): a hero DECISION INBOX column ("Your decisions" —
+// the union of every DECIDE-tier card, the single actionable surface), then
+// read-only WATCH / HIDE tier columns in pipeline position. Empty non-gate
+// pipeline lanes hide; gate / collapsed lanes show as reachable vertical rails.
+//
+// This component owns only the column STRUCTURE + chrome (tier eyebrows, count
+// pills, collapse chevrons, rails). Card internals come from the caller's
+// `renderCard` (the existing CardRouter) — richer inbox cards land in later
+// E-PRs. Card membership + visibility live in board-columns.ts (pure, tested).
+
+import type { ReactNode } from "react";
+import type { BoardCard, Lane } from "../lib/monitor/card-types.js";
+import {
+  BOARD_COLUMNS,
+  columnTier,
+  columnVisibility,
+  inboxCards,
+  tierLabel,
+  type BoardColumnDef,
+} from "../lib/monitor/board-columns.js";
+
+export interface KanbanBoardProps {
+  /** Lane → card[] grouping from `groupByLane(cards)` (already search/filter-narrowed). */
+  grouped: Record<Lane, BoardCard[]>;
+  /** Pipeline lanes currently expanded (controlled). A lane not in the set collapses to a rail. */
+  expanded: ReadonlySet<Lane>;
+  /** Toggle a pipeline lane's expand/collapse (the rail + the header chevron). */
+  onToggleLane: (lane: Lane) => void;
+  /** Render a single card (the shared CardRouter renderer). */
+  renderCard: (card: BoardCard) => ReactNode;
+  /** Optional per-lane header content (e.g. the codex-needed create form). */
+  renderLaneHeader?: (lane: Lane) => ReactNode;
+  /** Optional whole-body renderer for a pipeline lane (grouping). Return undefined for the default. */
+  renderLaneBody?: (lane: Lane, cards: BoardCard[]) => ReactNode | undefined;
+  /** Accessible label for the column row region. */
+  ariaLabel?: string;
+}
+
+export function KanbanBoard({
+  grouped,
+  expanded,
+  onToggleLane,
+  renderCard,
+  renderLaneHeader,
+  renderLaneBody,
+  ariaLabel = "Kanban lane grid",
+}: KanbanBoardProps) {
+  const inbox = inboxCards(grouped);
+
+  return (
+    <div className="hm-kanban scroll-x" role="region" aria-label={ariaLabel}>
+      {BOARD_COLUMNS.map((col) => {
+        if (col.inbox) {
+          return <InboxColumn key={col.id} col={col} cards={inbox} renderCard={renderCard} />;
+        }
+        const lane = col.lane!;
+        const cards = grouped[lane] ?? [];
+        const visibility = columnVisibility(col, cards.length, expanded);
+        if (visibility === "hidden") return null;
+        if (visibility === "rail") {
+          return (
+            <ColumnRail key={col.id} col={col} count={cards.length} onExpand={() => onToggleLane(lane)} />
+          );
+        }
+        return (
+          <PipelineColumn
+            key={col.id}
+            col={col}
+            cards={cards}
+            onCollapse={() => onToggleLane(lane)}
+            renderCard={renderCard}
+            laneHeader={renderLaneHeader?.(lane)}
+            laneBody={renderLaneBody?.(lane, cards)}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+/** Shared tier-eyebrow + name + count-pill + subtitle header. */
+function ColumnHead({
+  col,
+  count,
+  eyebrow,
+  onCollapse,
+}: {
+  col: BoardColumnDef;
+  count: number;
+  eyebrow: string;
+  onCollapse?: () => void;
+}) {
+  const tier = columnTier(col);
+  return (
+    <div className="hm-col-head" data-h4-tier={tier}>
+      <div className="hm-col-head-top">
+        <span className="hm-col-eyebrow">{eyebrow}</span>
+        {onCollapse ? (
+          <button
+            type="button"
+            className="hm-col-collapse"
+            onClick={onCollapse}
+            aria-label={`Collapse ${col.name} lane`}
+            title="Collapse"
+          >
+            ‹
+          </button>
+        ) : null}
+      </div>
+      <div className="hm-col-title-row">
+        <span className="hm-col-title">{col.name}</span>
+        <span className={`hm-col-count${count ? "" : " is-empty"}`}>{count}</span>
+        {col.gate ? <span className="hm-col-gate" title="Operator gate">gate</span> : null}
+      </div>
+      <div className="hm-col-sub">{col.sub}</div>
+    </div>
+  );
+}
+
+/** The hero Decision Inbox — the one actionable column. Always full-width, never collapses. */
+function InboxColumn({
+  col,
+  cards,
+  renderCard,
+}: {
+  col: BoardColumnDef;
+  cards: readonly BoardCard[];
+  renderCard: (card: BoardCard) => ReactNode;
+}) {
+  return (
+    <section
+      className="hm-col hm-col--inbox"
+      data-h4-tier="decide"
+      role="region"
+      aria-label={`${col.name} lane`}
+    >
+      <ColumnHead col={col} count={cards.length} eyebrow="Decision inbox" />
+      <div className="hm-col-body scroll-y">
+        {cards.length === 0 ? (
+          <EmptyColumn inbox />
+        ) : (
+          cards.map((card) => renderCard(card))
+        )}
+      </div>
+    </section>
+  );
+}
+
+/** A read-only WATCH / HIDE pipeline column. */
+function PipelineColumn({
+  col,
+  cards,
+  onCollapse,
+  renderCard,
+  laneHeader,
+  laneBody,
+}: {
+  col: BoardColumnDef;
+  cards: BoardCard[];
+  onCollapse: () => void;
+  renderCard: (card: BoardCard) => ReactNode;
+  laneHeader?: ReactNode;
+  laneBody?: ReactNode;
+}) {
+  const tier = columnTier(col);
+  return (
+    <section
+      className={`hm-col hm-col--${tier}`}
+      data-h4-tier={tier}
+      role="region"
+      aria-label={`${col.name} lane`}
+    >
+      <ColumnHead col={col} count={cards.length} eyebrow={tierLabel(tier)} onCollapse={onCollapse} />
+      <div className="hm-col-body scroll-y">
+        {laneHeader}
+        {cards.length === 0 ? (
+          <EmptyColumn />
+        ) : laneBody !== undefined ? (
+          laneBody
+        ) : (
+          cards.map((card) => renderCard(card))
+        )}
+      </div>
+    </section>
+  );
+}
+
+/** A collapsed pipeline lane — a reachable vertical rail (gate lanes keep one even at zero). */
+function ColumnRail({
+  col,
+  count,
+  onExpand,
+}: {
+  col: BoardColumnDef;
+  count: number;
+  onExpand: () => void;
+}) {
+  const tier = columnTier(col);
+  return (
+    <button
+      type="button"
+      className={`hm-col-rail hm-lane--collapsed${count ? "" : " is-empty"}`}
+      data-h4-tier={tier}
+      onClick={onExpand}
+      aria-label={`Expand ${col.name} (${count} cards)`}
+      title={`${col.name} — ${count} cards`}
+    >
+      <span className={`hm-col-rail-count${count ? "" : " is-empty"}`}>{count}</span>
+      <span className="hm-col-rail-name">{col.name}</span>
+      {col.gate ? <span className="hm-col-rail-gate">gate</span> : null}
+    </button>
+  );
+}
+
+function EmptyColumn({ inbox }: { inbox?: boolean }) {
+  return (
+    <div className={`hm-col-empty${inbox ? " hm-col-empty--inbox" : ""}`}>
+      <span className="hm-col-empty-glyph" aria-hidden>
+        {inbox ? "✓" : "·"}
+      </span>
+      <div>
+        <div className="hm-col-empty-title">{inbox ? "Nothing waiting on you" : "No cards"}</div>
+        <div className="hm-col-empty-sub">
+          {inbox ? "agents are working — watch the lanes" : "nothing in this stage"}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import {
+  BOARD_COLUMNS,
+  columnTier,
+  columnVisibility,
+  inboxCards,
+  tierLabel,
+  type BoardColumnDef,
+} from "./board-columns.js";
+import type { BoardCard, Lane } from "./card-types.js";
+
+function card(lane: Lane, id = lane): BoardCard {
+  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor: "agent", tone: "neutral" } } as unknown as BoardCard;
+}
+
+function grouped(partial: Partial<Record<Lane, BoardCard[]>>): Record<Lane, BoardCard[]> {
+  return {
+    "needs-attention": [], drafts: [], "codex-needed": [], "hermes-checking": [],
+    "operator-review": [], "release-queue": [], deploying: [], done: [],
+    ...partial,
+  };
+}
+
+const col = (id: string): BoardColumnDef => BOARD_COLUMNS.find((c) => c.id === id)!;
+
+describe("BOARD_COLUMNS", () => {
+  it("leads with the inbox hero and maps the remaining seven lanes (no needs-attention pipeline column)", () => {
+    expect(BOARD_COLUMNS[0]?.inbox).toBe(true);
+    expect(BOARD_COLUMNS[0]?.name).toBe("Your decisions");
+    expect(BOARD_COLUMNS.length).toBe(8);
+    const pipelineLanes = BOARD_COLUMNS.filter((c) => !c.inbox).map((c) => c.lane);
+    expect(pipelineLanes).not.toContain("needs-attention"); // folded into the inbox
+    expect(pipelineLanes).toContain("operator-review");
+    expect(pipelineLanes).toContain("done");
+  });
+
+  it("carries the design eyebrows for the named columns", () => {
+    expect(col("codex-needed").name).toBe("Builder tasks");
+    expect(col("operator-review").name).toBe("Runs needing review");
+    expect(col("deploying").name).toBe("Deploying");
+    expect(col("done").name).toBe("Done");
+    expect(col("inbox").sub).toBe("Everything waiting on you");
+  });
+
+  it("marks the inbox and operator-review as gate lanes", () => {
+    expect(col("inbox").gate).toBe(true);
+    expect(col("operator-review").gate).toBe(true);
+    expect(col("done").gate).toBeUndefined();
+  });
+});
+
+describe("columnTier / tierLabel", () => {
+  it("puts the inbox in DECIDE and pipeline columns on tierFor", () => {
+    expect(columnTier(col("inbox"))).toBe("decide");
+    expect(columnTier(col("codex-needed"))).toBe("watch");
+    expect(columnTier(col("done"))).toBe("hide");
+  });
+
+  it("labels tiers for the column eyebrow", () => {
+    expect(tierLabel("decide")).toBe("Decide");
+    expect(tierLabel("watch")).toBe("Watch");
+    expect(tierLabel("hide")).toBe("Hide");
+  });
+});
+
+describe("inboxCards", () => {
+  it("unions every DECIDE-tier lane's cards (currently needs-attention)", () => {
+    const g = grouped({
+      "needs-attention": [card("needs-attention", "a1"), card("needs-attention", "a2")],
+      "operator-review": [card("operator-review", "o1")],
+    });
+    const ids = inboxCards(g).map((c) => c.id);
+    expect(ids).toEqual(["a1", "a2"]);
+    // operator-review is WATCH-tier → not folded into the inbox.
+    expect(ids).not.toContain("o1");
+  });
+
+  it("is empty when no decide-tier card exists", () => {
+    expect(inboxCards(grouped({ done: [card("done")] }))).toEqual([]);
+  });
+});
+
+describe("columnVisibility", () => {
+  const expanded = new Set<Lane>(["codex-needed"]);
+
+  it("always shows the inbox as a full column", () => {
+    expect(columnVisibility(col("inbox"), 0, new Set())).toBe("column");
+  });
+
+  it("hides an empty non-gate pipeline lane", () => {
+    expect(columnVisibility(col("drafts"), 0, expanded)).toBe("hidden");
+  });
+
+  it("keeps an empty GATE lane as a reachable rail", () => {
+    expect(columnVisibility(col("operator-review"), 0, expanded)).toBe("rail");
+  });
+
+  it("shows an expanded lane as a column and a collapsed one as a rail", () => {
+    expect(columnVisibility(col("codex-needed"), 3, expanded)).toBe("column");
+    expect(columnVisibility(col("deploying"), 3, expanded)).toBe("rail");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/board-columns.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.ts
@@ -1,0 +1,90 @@
+// Hermes Handoff Monitor — inbox-first column model (PR-E1).
+//
+// The Hermes-4 "decision cockpit" replaces the flat 8-lane render with an
+// inbox-first column layout (docs/design/hermes-4/project/board.jsx +
+// kanban.jsx): a hero DECISION INBOX column holding the union of every card
+// in a DECIDE-tier lane (the one actionable surface), then read-only WATCH /
+// HIDE tier columns in pipeline position.
+//
+// This module is the pure mapping layer — the lane→column metadata (design
+// eyebrows + subtitles), the inbox card union, and the per-column
+// hidden/rail/column visibility rule. It reuses `tierFor` so the tier system
+// stays single-sourced (lane-rules.ts), and is unit-tested in
+// board-columns.test.ts so the structure is litigated here, not in the view.
+
+import type { BoardCard, Lane } from "./card-types.js";
+import { LANES } from "./card-types.js";
+import { tierFor, type KanbanTier } from "./lane-rules.js";
+
+export interface BoardColumnDef {
+  /** Stable column key (the lane id for pipeline columns; "inbox" for the hero). */
+  id: string;
+  /** The existing lane this column mirrors. Omitted for the inbox hero (it's a union). */
+  lane?: Lane;
+  /** The hero Decision Inbox — the single actionable surface. */
+  inbox?: boolean;
+  /** A gate lane stays reachable (as a rail) even when empty — never hidden. */
+  gate?: boolean;
+  /** Design column name (board.jsx / kanban.jsx LANES). */
+  name: string;
+  /** Design eyebrow subtitle under the column name. */
+  sub: string;
+}
+
+/**
+ * The design's lane→column mapping (data.jsx LANES), mapped onto the existing
+ * eight lanes. `needs-attention` (the only DECIDE-tier lane) is folded into the
+ * inbox hero and so has no pipeline column of its own; the remaining seven
+ * lanes become read-only pipeline columns in this order.
+ */
+export const BOARD_COLUMNS: readonly BoardColumnDef[] = [
+  { id: "inbox", inbox: true, gate: true, name: "Your decisions", sub: "Everything waiting on you" },
+  { id: "codex-needed", lane: "codex-needed", name: "Builder tasks", sub: "Proposed by Claude / Codex" },
+  { id: "drafts", lane: "drafts", name: "Drafts", sub: "Author finishes" },
+  { id: "hermes-checking", lane: "hermes-checking", name: "Hermes checking", sub: "Verifying" },
+  { id: "operator-review", lane: "operator-review", gate: true, name: "Runs needing review", sub: "Failed / finished runs" },
+  { id: "release-queue", lane: "release-queue", name: "Release queue", sub: "Staged for release" },
+  { id: "deploying", lane: "deploying", name: "Deploying", sub: "Verifying post-merge" },
+  { id: "done", lane: "done", name: "Done", sub: "Release history" },
+] as const;
+
+/** The tier a column belongs to. The inbox is always DECIDE; pipeline columns defer to `tierFor`. */
+export function columnTier(col: BoardColumnDef): KanbanTier {
+  if (col.inbox) return "decide";
+  return col.lane ? tierFor(col.lane) : "watch";
+}
+
+/** Human tier label shown as the column eyebrow (the inbox gets its own copy). */
+export function tierLabel(tier: KanbanTier): string {
+  return tier === "decide" ? "Decide" : tier === "watch" ? "Watch" : "Hide";
+}
+
+/**
+ * The Decision Inbox holds the union of every card in a DECIDE-tier lane — the
+ * single place to act. With the current tier map that's `needs-attention`, but
+ * deriving it from `tierFor` keeps it correct if the tier of a lane changes.
+ */
+export function inboxCards(grouped: Partial<Record<Lane, BoardCard[]>>): BoardCard[] {
+  return LANES.filter((lane) => tierFor(lane) === "decide").flatMap((lane) => grouped[lane] ?? []);
+}
+
+export type ColumnVisibility = "hidden" | "rail" | "column";
+
+/**
+ * Per-column visibility, matching the design (kanban.jsx KanbanRow):
+ *   - the inbox is always a full column;
+ *   - an empty NON-gate pipeline lane hides entirely (no junk-drawer rails);
+ *   - an expanded pipeline lane is a full column;
+ *   - otherwise it collapses to a reachable vertical rail (gate lanes included,
+ *     so a gate never disappears even at zero cards).
+ */
+export function columnVisibility(
+  col: BoardColumnDef,
+  cardCount: number,
+  expanded: ReadonlySet<Lane>,
+): ColumnVisibility {
+  if (col.inbox) return "column";
+  if (cardCount === 0 && !col.gate) return "hidden";
+  if (col.lane && expanded.has(col.lane)) return "column";
+  return "rail";
+}

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -28,6 +28,8 @@ import "./styles/hermes4-rail.css";
 // PR-D4: full board card/lane migration — aliases the legacy --hm-* tokens onto
 // the --h4 profile system so the whole board tracks the active profile.
 import "./styles/hermes4-board.css";
+// PR-E1: inbox-first Kanban — hero Decision Inbox + read-only tier columns.
+import "./styles/hermes4-kanban.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/styles/hermes4-kanban.css
+++ b/packages/monitor-ui/src/styles/hermes4-kanban.css
@@ -1,0 +1,165 @@
+/* =========================================================
+   Hermes-4 inbox-first Kanban (PR-E1).
+
+   The "decision cockpit" column layout (docs/design/hermes-4/
+   project/kanban.jsx): a hero DECISION INBOX column + read-only
+   WATCH / HIDE tier columns + collapsed vertical rails. Consumes
+   the --h4 token system (profile-tracking); additive, namespaced
+   .hm-col* / .hm-kanban so it never clobbers the legacy lanes.
+   ========================================================= */
+
+.hm-kanban {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+  padding: 2px 4px 14px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+/* ---- column shell ---- */
+.hm-col {
+  flex: 1 1 0;
+  min-width: min(266px, 78vw);
+  max-width: 420px;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--h4-surface);
+  border: 1px solid var(--h4-line);
+  border-radius: var(--h4-r-lane);
+  overflow: hidden;
+}
+.hm-col--inbox {
+  flex: 1.25 1 0;
+  min-width: min(320px, 82vw);
+  max-width: 470px;
+  box-shadow: var(--h4-sh-sm);
+  border-color: var(--h4-act-line);
+}
+
+/* ---- header (tier eyebrow + name + count + sub) ---- */
+.hm-col-head {
+  flex: none;
+  padding: 12px 14px 11px;
+  background: var(--h4-paper-sunken);
+  border-bottom: 1px solid var(--h4-line);
+}
+.hm-col-head[data-h4-tier="decide"] {
+  background: var(--h4-tier-decide-bg);
+  border-bottom-color: var(--h4-tier-decide-line);
+}
+.hm-col-head[data-h4-tier="hide"] { background: var(--h4-surface); border-bottom-color: var(--h4-line-2); }
+
+.hm-col-head-top { display: flex; align-items: center; justify-content: space-between; min-height: 16px; }
+.hm-col-eyebrow {
+  font-family: var(--h4-font-display);
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0;
+  color: var(--h4-muted);
+}
+.hm-col-head[data-h4-tier="decide"] .hm-col-eyebrow { color: var(--h4-tier-decide-text); }
+.hm-col-head[data-h4-tier="hide"] .hm-col-eyebrow { color: var(--h4-faint); }
+
+.hm-col-collapse {
+  width: 22px; height: 22px; flex: none;
+  border-radius: 6px;
+  border: 1px solid var(--h4-line);
+  background: var(--h4-paper);
+  color: var(--h4-muted);
+  cursor: pointer;
+  font-size: 12px; line-height: 1;
+}
+.hm-col-collapse:hover { color: var(--h4-ink); }
+
+.hm-col-title-row { display: flex; align-items: center; gap: 8px; margin-top: 6px; }
+.hm-col-title { font-family: var(--h4-font-display); font-weight: 700; font-size: 15px; white-space: nowrap; color: var(--h4-ink); }
+.hm-col-count {
+  min-width: 20px; height: 20px; padding: 0 6px;
+  display: grid; place-items: center;
+  border-radius: var(--h4-r-pill);
+  font-family: var(--h4-font-display); font-size: 11px; font-weight: 700;
+  background: var(--h4-ink); color: var(--h4-paper);
+}
+.hm-col-count.is-empty { background: var(--h4-paper-sunken); color: var(--h4-faint); }
+[data-h4-tier="decide"] .hm-col-count:not(.is-empty) { background: var(--h4-act); color: var(--h4-act-ink); }
+[data-h4-tier="hide"] .hm-col-count:not(.is-empty) { background: var(--h4-faint); color: var(--h4-paper); }
+
+.hm-col-gate {
+  font-family: var(--h4-font-display); font-size: 8.5px; font-weight: 700; text-transform: uppercase;
+  color: var(--h4-act-text);
+}
+.hm-col-sub {
+  margin-top: 4px;
+  font-family: var(--h4-font-display); font-size: 9.5px; font-weight: 700; text-transform: uppercase;
+  color: var(--h4-faint);
+}
+
+/* ---- body ---- */
+.hm-col-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: var(--h4-pad-lane);
+  display: flex;
+  flex-direction: column;
+  gap: var(--h4-gap-cards);
+  overflow-y: auto;
+}
+
+/* ---- empty state ---- */
+.hm-col-empty {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px;
+  border-radius: var(--h4-r-sm);
+  border: 1px dashed var(--h4-line);
+  background: var(--h4-paper-sunken);
+}
+.hm-col-empty-glyph {
+  width: 24px; height: 24px; flex: none;
+  display: grid; place-items: center;
+  border-radius: 7px;
+  background: var(--h4-paper); color: var(--h4-faint); font-size: 13px;
+}
+.hm-col-empty--inbox .hm-col-empty-glyph { background: var(--h4-ok-soft); color: var(--h4-ok-text); }
+.hm-col-empty-title { font-family: var(--h4-font-display); font-size: 12.5px; font-weight: 600; color: var(--h4-muted); }
+.hm-col-empty--inbox .hm-col-empty-title { color: var(--h4-ok-text); }
+.hm-col-empty-sub { font-size: 11px; color: var(--h4-faint); margin-top: 1px; }
+
+/* ---- collapsed rail ---- */
+.hm-col-rail {
+  flex: none;
+  width: 50px;
+  align-self: stretch;
+  display: flex; flex-direction: column; align-items: center; gap: 14px;
+  padding: 14px 6px;
+  background: var(--h4-surface);
+  border: 1px solid var(--h4-line);
+  border-radius: var(--h4-r-lane);
+  cursor: pointer;
+}
+.hm-col-rail.is-empty { border-style: dashed; }
+.hm-col-rail-count {
+  min-width: 22px; height: 22px; padding: 0 5px;
+  display: grid; place-items: center;
+  border-radius: var(--h4-r-pill);
+  font-family: var(--h4-font-display); font-size: 11px; font-weight: 700;
+  background: var(--h4-ink); color: var(--h4-paper);
+}
+.hm-col-rail-count.is-empty { background: transparent; color: var(--h4-faint); border: 1px solid var(--h4-line); }
+[data-h4-tier="hide"] .hm-col-rail-count:not(.is-empty) { background: var(--h4-faint); color: var(--h4-paper); }
+.hm-col-rail-name {
+  writing-mode: vertical-rl; transform: rotate(180deg);
+  font-family: var(--h4-font-display); font-size: 11.5px; font-weight: 700; text-transform: uppercase;
+  white-space: nowrap; color: var(--h4-muted);
+}
+.hm-col-rail-gate {
+  writing-mode: vertical-rl; transform: rotate(180deg);
+  margin-top: auto;
+  font-family: var(--h4-font-display); font-size: 8px; font-weight: 700; text-transform: uppercase;
+  color: var(--h4-act-text);
+}


### PR DESCRIPTION
## What

**PR-E1 — the keystone of the Hermes-4 "decision cockpit."** Replaces BoardView's flat 8-lane render with the design's **inbox-first columns** (`docs/design/hermes-4/project/board.jsx` + `kanban.jsx`): a hero **DECISION INBOX** column — "Your decisions" + count + "EVERYTHING WAITING ON YOU", holding the union of every DECIDE-tier card (the one actionable surface) — then read-only **WATCH** / **HIDE** tier columns in pipeline position.

## How
- **`lib/monitor/board-columns.ts`** (pure, tested) — the lane→column mapping (design eyebrows + subtitles), the inbox card union, and the per-column hidden/rail/column visibility rule. **Reuses `tierFor`** so the tier system stays single-sourced in `lane-rules.ts`.
  - `inboxCards()` = the union of every DECIDE-tier lane's cards. `needs-attention` folds into the hero, so it has no pipeline column of its own.
  - `columnVisibility()` — inbox is always a full column; an empty **non-gate** pipeline lane hides (no junk-drawer rails); an expanded lane is a column; otherwise a reachable vertical **rail** (gate lanes kept even at zero).
- **`components/KanbanBoard.tsx`** — the column structure: hero "Your decisions" inbox, then WATCH ("Builder tasks", "Hermes checking", "Runs needing review", "Deploying", …) + HIDE ("Done") columns with tier eyebrows, count pills, collapse chevrons, and collapsed rails. Reuses the caller's `renderCard` / `renderLaneHeader` (codex create form) / `renderLaneBody` (grouping). **Card internals unchanged** — richer inbox cards land in later E-PRs.
- **`styles/hermes4-kanban.css`** — the `--h4`-token column/rail/head layer (rounded lanes, warm-dark tier surfaces, inbox 1.25-flex / coral edge). Additive + namespaced (`.hm-col*`) so it never clobbers the legacy lanes.
- **`BoardView.tsx`** — swap `<Board>` → `<KanbanBoard>` for the lane grid. `Board` / `Lane` / `MiniRail` are **retained** (still unit-tested) but no longer used by the app — a later E-PR can retire them.

## Truth-boundary (hard)
Real cards only. Honest success empty-state ("Nothing waiting on you") and "No cards"; degraded/empty render the inbox + gate rail, never fabricated lanes. The operator-review **gate** stays reachable instead of vanishing.

## Visual verification (tests are structure-blind)
Rendered the real `BoardView` with `FIXTURE_CARDS` via a throwaway harness and confirmed it renders as `Hermes.html`: the coral-edged **DECISION INBOX** hero ("Your decisions · 2 · GATE") holding the decision cards, the **WATCH** "Builder tasks" column with the Propose-task composer, horizontal tier columns, the empty operator-review **gate rail**, CoPilotRail preserved, footer intact. Harness removed before commit.

## Tests
New `board-columns.test.ts` + `KanbanBoard.test.tsx`. The **layout-structural** BoardView / MonitorPage assertions that asserted flat lanes are updated to the inbox-first structure (the cutover is the point); behavioral assertions (card text, CTAs, drawer, keyboard, filters) untouched. **Full suite (1645)** + typecheck + `@avg/monitor-ui` vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)