### PR TITLE
feat(monitor): add most-urgent decisions banner

### DIFF
--- a/packages/monitor-ui/src/components/BoardNowBanner.test.tsx
+++ b/packages/monitor-ui/src/components/BoardNowBanner.test.tsx
@@ -65,4 +65,28 @@ describe("BoardNowBanner", () => {
     const noCta = render(<BoardNowBanner banner={banner("calm")} />);
     expect(noCta.container.querySelector(".hm-now-cta")).toBeNull();
   });
+
+  test("renders most-urgent reason chips only when the selector provides real reasons", () => {
+    const withReasons = render(
+      <BoardNowBanner
+        banner={{
+          ...banner("action"),
+          mostUrgentReasons: [
+            { label: "blocked 2h", tone: "warn", title: "Lane age" },
+            { label: "high risk", tone: "risk" },
+            { label: "safe: read-only", tone: "safe" },
+          ],
+        }}
+      />,
+    );
+    expect(withReasons.getByLabelText("Most urgent because")).toBeTruthy();
+    expect(withReasons.getByText("blocked 2h")).toBeTruthy();
+    expect(withReasons.getByText("high risk")).toBeTruthy();
+    expect(withReasons.getByText("safe: read-only")).toBeTruthy();
+    expect(withReasons.container.querySelector(".hm-now-reason--safe")).toBeTruthy();
+    withReasons.unmount();
+
+    const withoutReasons = render(<BoardNowBanner banner={banner("action")} />);
+    expect(withoutReasons.queryByLabelText("Most urgent because")).toBeNull();
+  });
 });

--- a/packages/monitor-ui/src/components/BoardNowBanner.tsx
+++ b/packages/monitor-ui/src/components/BoardNowBanner.tsx
@@ -18,6 +18,11 @@ export type BannerData = {
   headline: string;
   sub: string;
   primaryActionId: string | undefined;
+  mostUrgentReasons?: Array<{
+    label: string;
+    tone: "neutral" | "risk" | "safe" | "warn";
+    title?: string;
+  }>;
 };
 
 export type BoardNowBannerProps = {
@@ -34,6 +39,7 @@ const GLYPHS: Record<BannerData["tone"], string> = {
 };
 
 export function BoardNowBanner({ banner, cta }: BoardNowBannerProps) {
+  const reasons = banner.mostUrgentReasons ?? [];
   const toneClass =
     banner.tone === "action"
       ? "hm-now hm-now--action"
@@ -55,6 +61,20 @@ export function BoardNowBanner({ banner, cta }: BoardNowBannerProps) {
         </div>
         <h1 className="hm-now-head">{banner.headline}</h1>
         <p className="hm-now-sub">{banner.sub}</p>
+        {reasons.length > 0 ? (
+          <div className="hm-now-reasons" aria-label="Most urgent because">
+            <span className="hm-now-reasons-label">Most urgent because</span>
+            {reasons.map((reason) => (
+              <span
+                key={`${reason.tone}:${reason.label}`}
+                className={`hm-now-reason hm-now-reason--${reason.tone}`}
+                title={reason.title}
+              >
+                {reason.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
       </div>
       {cta ? <div className="hm-now-cta">{cta}</div> : null}
     </div>

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -18,7 +18,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(container.querySelector(".hm-brand-name")?.textContent).toBe("Hermes");
     // action tone — the fixtures include action cards
     expect(container.querySelector(".hm-now--action")).toBeTruthy();
-    expect(view.getByText(/your review decision/)).toBeTruthy();
+    expect(view.getByText(/decisions waiting on you/)).toBeTruthy();
     expect(view.getByText("sorted by next-action urgency")).toBeTruthy();
     expect(view.getByRole("region", { name: "Kanban lane grid" })).toBeTruthy();
     // PR-E1: inbox-first columns replace the flat 8 lanes — a hero Decision
@@ -72,7 +72,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     };
     const { getByRole } = render(<BoardView board={board} status="open" onCardClick={onCardClick} keyboard={false} />);
 
-    fireEvent.click(getByRole("button", { name: /Jump to agent #548/ }));
+    fireEvent.click(getByRole("button", { name: /Review most urgent/ }));
     expect(onCardClick).toHaveBeenCalledWith("agent #548");
 
     fireEvent.click(getByRole("button", { name: "Open review checklist" }));

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -868,7 +868,7 @@ function renderBannerCta({
     <>
       <div className="button-row">
         <button type="button" className="hm-btn hm-btn--action" onClick={openCard}>
-          Jump to {card.id} <span className="hm-kbd">↵</span>
+          Review most urgent <span className="hm-kbd">↵</span>
         </button>
         <button type="button" className="hm-btn hm-btn--ghost" onClick={openCard}>
           Open review checklist

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -164,14 +164,41 @@ test("boardMode: streamOnline=true is a no-op (calm/action driven by cards)", ()
 
 test("boardNowBanner: action mode produces an action-toned banner with the most urgent card cited", () => {
   const cards = [
-    card({ id: "act-1", isAction: true, title: "Approve the thing" }),
+    card({
+      id: "act-1",
+      isAction: true,
+      title: "Approve the thing",
+      risk: ["secrets"],
+      action: { kind: "operator-review", primary: "Approve merge" },
+      decisionRecord: {
+        schemaVersion: 1,
+        recordType: "hermes_decision_record",
+        id: "dr-act-1",
+        kind: "auto_approval",
+        subject: { type: "pr", id: "act-1" },
+        decision: "escalated",
+        reasons: ["Secret-touching change requires operator review"],
+        inputs: {},
+        outcome: { summary: "Waiting on operator" },
+        safety: { readOnly: true, mutates: false },
+        generatedAt: "2026-06-07T10:00:00.000Z",
+      },
+    }),
   ];
   const banner = boardNowBanner(cards, { nowLabel: "14:32:08 utc" });
   assert.equal(banner.tone, "action");
   assert.match(banner.eyebrow, /1 action needed/);
-  assert.match(banner.headline, /1 card needs your review decision/);
-  assert.match(banner.sub, /Approve the thing/);
+  assert.equal(banner.headline, "1 decision waiting on you");
+  assert.equal(banner.sub, "Most urgent: Approve the thing — suggests Approve merge.");
   assert.equal(banner.primaryActionId, "act-1");
+  assert.deepEqual(
+    banner.mostUrgentReasons?.map((reason) => ({ label: reason.label, tone: reason.tone })),
+    [
+      { label: "blocked 5m", tone: "neutral" },
+      { label: "risk: secrets", tone: "risk" },
+      { label: "safe: read-only", tone: "safe" },
+    ],
+  );
 });
 
 test("boardNowBanner: multiple action cards pluralize correctly", () => {
@@ -181,7 +208,25 @@ test("boardNowBanner: multiple action cards pluralize correctly", () => {
   ];
   const banner = boardNowBanner(cards);
   assert.match(banner.eyebrow, /2 action needed/);
-  assert.match(banner.headline, /2 cards need your review decision/);
+  assert.equal(banner.headline, "2 decisions waiting on you");
+});
+
+test("boardNowBanner: action banner traces to existing most-urgent selection", () => {
+  const cards = [
+    card({ id: "later", isAction: true, title: "Later decision", freshness: 30 }),
+    card({ id: "urgent", isAction: true, title: "Urgent decision", freshness: 1, action: { kind: "operator-review", primary: "Review now" } }),
+  ];
+  const banner = boardNowBanner(cards);
+  assert.equal(mostUrgentCard(cards)?.id, "urgent");
+  assert.equal(banner.primaryActionId, "urgent");
+  assert.equal(banner.sub, "Most urgent: Urgent decision — suggests Review now.");
+});
+
+test("boardNowBanner: most-urgent reasons stay empty when the card has no real signals", () => {
+  const banner = boardNowBanner([
+    card({ id: "thin", isAction: true, title: "Thin card", freshness: undefined, risk: [] }),
+  ]);
+  assert.deepEqual(banner.mostUrgentReasons, []);
 });
 
 test("boardNowBanner: Hermes focus mode uses the scoped review card", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -8,7 +8,7 @@
 
 import type { BoardCard, Lane } from "./card-types.js";
 import { groupByLane, laneCounts, laneFor } from "./lane-rules.js";
-import { sortByUrgency } from "./urgency.js";
+import { formatFreshness, sortByUrgency } from "./urgency.js";
 
 /** The state a LanesBar filter chip narrows the board to. */
 export type BoardFilter = "all" | "blocked" | "review" | "ready" | "running" | "done" | "today-done";
@@ -57,6 +57,12 @@ export interface KPICounts {
 
 export type BoardMode = "calm" | "action" | "hermes-focus" | "degraded";
 
+export interface MostUrgentReasonChip {
+  label: string;
+  tone: "neutral" | "risk" | "safe" | "warn";
+  title?: string;
+}
+
 export interface CalmBoardMetrics {
   avgTimeToDecision?: string;
   disputes?: number;
@@ -72,6 +78,7 @@ export interface BoardNowBanner {
   headline: string;
   sub: string;
   primaryActionId: string | undefined;
+  mostUrgentReasons?: MostUrgentReasonChip[];
 }
 
 export interface DeriveBoardOpts {
@@ -168,16 +175,18 @@ export function boardNowBanner(cards: BoardCard[], opts: DeriveBoardOpts = {}): 
     const actionCount = counts.action;
     const headline =
       actionCount === 1
-        ? `1 card needs your review decision; automation has gone as far as it safely can.`
-        : `${actionCount} cards need your review decision; automation has gone as far as it safely can.`;
+        ? "1 decision waiting on you"
+        : `${actionCount} decisions waiting on you`;
+    const suggestedAction = urgent ? suggestedActionFor(urgent) : undefined;
     return {
       tone: "action",
       eyebrow: now ? `Board now · ${now} · ${actionCount} action needed` : `Board now · ${actionCount} action needed`,
       headline,
       sub: urgent
-        ? `Most urgent: ${urgent.title}. Approve only if the risk and intent are clear.`
-        : `Approve only if the risk and intent are clear.`,
+        ? `Most urgent: ${urgent.title} — suggests ${suggestedAction}.`
+        : `Review the decision inbox before approving anything.`,
       primaryActionId: urgent?.id,
+      mostUrgentReasons: urgent ? mostUrgentReasonsFor(urgent) : undefined,
     };
   }
 
@@ -244,6 +253,77 @@ function pendingReviewCount(cards: BoardCard[]): number {
 
 function isPendingReviewCard(card: BoardCard): boolean {
   return card.waitingOn?.actor === "operator" && (card.lane === "operator-review" || card.isAction === true);
+}
+
+function suggestedActionFor(card: BoardCard): string {
+  if (card.type === "pr" && card.action?.primary) return card.action.primary;
+  if (card.type === "task") {
+    if (card.action?.primary) return card.action.primary;
+    if (card.taskStatus === "proposed") return "approve dispatch";
+    if (card.taskStatus === "failed") return "review failure";
+  }
+  if (card.type === "mission") {
+    if (card.missionStatus === "requested") return "approve mission";
+    if (card.missionStatus === "failed") return "review failure";
+    if (card.mission?.recommendations?.[0]) return "review suggested fix";
+  }
+  if (card.type === "deploy") return "review deployment";
+  if (card.next) return normalizeSuggestedAction(card.next);
+  if (card.decisionRecord?.outcome?.waitingNext) return normalizeSuggestedAction(card.decisionRecord.outcome.waitingNext);
+  return "review decision";
+}
+
+function normalizeSuggestedAction(value: string): string {
+  const trimmed = value.trim().replace(/\s+/g, " ");
+  if (!trimmed) return "review decision";
+  return trimmed.length > 72 ? `${trimmed.slice(0, 69).trim()}...` : trimmed;
+}
+
+function mostUrgentReasonsFor(card: BoardCard): MostUrgentReasonChip[] {
+  const chips: MostUrgentReasonChip[] = [];
+  const age = formatFreshness(card.freshness);
+  if (age) {
+    chips.push({
+      label: `blocked ${age.toLowerCase()}`,
+      tone: card.freshness >= 240 ? "warn" : "neutral",
+      title: "Minutes since this card entered its current lane.",
+    });
+  }
+
+  const risk = riskReasonFor(card);
+  if (risk) chips.push(risk);
+
+  const safety = safetyReasonFor(card);
+  if (safety) chips.push(safety);
+
+  return chips.slice(0, 4);
+}
+
+function riskReasonFor(card: BoardCard): MostUrgentReasonChip | undefined {
+  if (card.type === "task" && card.riskTier) {
+    return { label: `${card.riskTier} risk`, tone: card.riskTier === "high" ? "risk" : "neutral" };
+  }
+  const signal = card.riskSignals?.find((entry) => entry.severity === "high")
+    ?? card.riskSignals?.find((entry) => entry.severity === "medium")
+    ?? card.riskSignals?.[0];
+  if (signal) {
+    return {
+      label: `${signal.severity} risk`,
+      tone: signal.severity === "high" ? "risk" : "warn",
+      title: signal.message,
+    };
+  }
+  const [firstRisk] = card.risk ?? [];
+  if (!firstRisk) return undefined;
+  return { label: `risk: ${firstRisk.replace(/-/g, " ")}`, tone: "risk" };
+}
+
+function safetyReasonFor(card: BoardCard): MostUrgentReasonChip | undefined {
+  const safety = card.decisionRecord?.safety;
+  if (!safety) return undefined;
+  if (safety.readOnly && !safety.mutates) return { label: "safe: read-only", tone: "safe" };
+  if (safety.mutates) return { label: "mutates", tone: "warn" };
+  return undefined;
 }
 
 function doneClosedAt(card: BoardCard): string | undefined {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -374,6 +374,50 @@ body { margin: 0; }
 }
 .hm-now-sub strong { color: var(--hm-ink); font-weight: 600; }
 
+.hm-now-reasons {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 10px;
+}
+.hm-now-reasons-label {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 800;
+  letter-spacing: 0.16em !important;
+  text-transform: uppercase;
+  color: var(--hm-muted);
+}
+.hm-now-reason {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border-radius: 999px;
+  border: 1px solid var(--hm-line);
+  padding: 3px 9px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--hm-ink);
+  background: rgba(255,255,255,0.72);
+}
+.hm-now-reason--risk {
+  color: var(--hm-amber-deep);
+  border-color: var(--hm-amber-ring);
+  background: rgba(247, 210, 155, 0.34);
+}
+.hm-now-reason--warn {
+  color: var(--hm-amber-deep);
+  border-color: rgba(161, 93, 38, 0.24);
+  background: rgba(237, 174, 117, 0.2);
+}
+.hm-now-reason--safe {
+  color: var(--hm-sage-deep);
+  border-color: rgba(30,102,66,0.18);
+  background: var(--hm-sage-wash);
+}
+
 .hm-now-cta {
   display: inline-flex; flex-direction: column; align-items: flex-end; gap: 8px;
 }


### PR DESCRIPTION
## Summary
- update the action BoardNow banner to say N decisions waiting on you and cite the most-urgent card with its suggested action
- add real-backed most-urgent-because chips for lane age, risk, and D2 safety signals, omitting the row when those signals are absent
- rename the primary banner CTA to Review most urgent while keeping it wired to the existing most-urgent card selection

## Checks
- npm test -- packages/monitor-ui/src/lib/monitor/board-state.test.ts packages/monitor-ui/src/components/BoardNowBanner.test.tsx packages/monitor-ui/src/components/BoardView.test.tsx
- npm run typecheck
- npm test

## Impact
- Frontend monitor UI only
- No backend, secrets, deploy, or authority changes