### PR TITLE
feat(monitor): add truthful deploy stepper

### DIFF
--- a/packages/monitor-ui/src/components/DeployStepper.tsx
+++ b/packages/monitor-ui/src/components/DeployStepper.tsx
@@ -1,0 +1,39 @@
+import type { DeployStepView } from "../lib/monitor/deploy-stepper.js";
+
+const STATE_LABEL: Record<DeployStepView["state"], string> = {
+  done: "done",
+  "in-progress": "in progress",
+  pending: "pending",
+};
+
+const STATE_GLYPH: Record<DeployStepView["state"], string> = {
+  done: "✓",
+  "in-progress": "⟳",
+  pending: "",
+};
+
+export function DeployStepper({
+  steps,
+  compact = false,
+}: {
+  steps: readonly DeployStepView[];
+  compact?: boolean;
+}) {
+  return (
+    <div
+      className={"h4-stepper h4-deploy-stepper" + (compact ? " h4-deploy-stepper--compact" : "")}
+      aria-label="Deploy verification steps"
+    >
+      {steps.map((step) => (
+        <div key={step.id} className={`h4-stepper-row is-${step.state}`}>
+          <span className="h4-stepper-dot" aria-hidden>
+            {STATE_GLYPH[step.state]}
+          </span>
+          <span className="h4-stepper-label">{step.label}</span>
+          <span className="h4-stepper-state">{STATE_LABEL[step.state]}</span>
+          <span className="h4-stepper-source">{step.detail}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -64,6 +64,10 @@ describe("Card — type coverage", () => {
     const view = within(container);
     expect(view.getByText(/Post-merge verify/)).toBeTruthy();
     expect(view.getByText("xcm")).toBeTruthy();
+    expect(view.getByText("Current deploy: verifying")).toBeTruthy();
+    expect(view.getByText("CI queued")).toBeTruthy();
+    expect(view.getByText("browser replay")).toBeTruthy();
+    expect(container.querySelectorAll(".h4-stepper-row.is-done").length).toBe(1);
   });
 
   test("codex task card renders without checks (no CI yet)", () => {

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -26,9 +26,11 @@ import type {
   AgentType,
   HermesDecisionRecord,
   CardWorkingNow,
+  DeployCard,
   MissionCard,
   MissionReport,
 } from "../../lib/monitor/card-types.js";
+import { deployStepsForCard } from "../../lib/monitor/deploy-stepper.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor, isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
@@ -38,6 +40,7 @@ import { AgentTag, Badge, Button, CardHeader, StatusPill, type StateVariant } fr
 import { ChecksBar } from "./ChecksBar.js";
 import { CardBadges } from "./CardBadges.js";
 import { AgentDiscussion } from "./AgentDiscussion.js";
+import { DeployStepper } from "../DeployStepper.js";
 
 export type CardProps = {
   card: BoardCard;
@@ -168,6 +171,8 @@ export function Card({
       ) : null}
 
       {!isClosed && card.type === "mission" ? <MissionRunSummary card={card} /> : null}
+
+      {!isClosed && card.type === "deploy" ? <DeployCardStepper card={card} /> : null}
 
       {/* P1-2: hoist the decision onto operator-facing cards. On the two
           lanes where the operator decides (needs-attention, codex-needed),
@@ -393,6 +398,18 @@ function MissionRunSummary({ card }: { card: MissionCard }) {
       )}
 
       {boundary ? <div className="hm-mission-run-boundary">{boundary}</div> : null}
+    </div>
+  );
+}
+
+function DeployCardStepper({ card }: { card: DeployCard }) {
+  const steps = deployStepsForCard(card);
+  return (
+    <div className="hm-deploy-stepper-card" aria-label="Current deploy verification">
+      <div className="hm-deploy-stepper-head">
+        <span>Current deploy: verifying</span>
+      </div>
+      <DeployStepper steps={steps} compact />
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx
@@ -194,7 +194,9 @@ describe("DetailDrawer — variants", () => {
       <DetailDrawer card={card} cards={[{ id: card.id }]} onClose={noop} onNavigate={noop} />,
     );
     expect(getByText("Deploying · post-merge verification")).toBeTruthy();
-    expect(getByText(/3\/5 · indexer settle/)).toBeTruthy();
+    expect(getByText("Current deploy: verifying")).toBeTruthy();
+    expect(getByText("CI queued")).toBeTruthy();
+    expect(getByText("browser replay")).toBeTruthy();
   });
 
   test("codex task card shows its prompt", () => {
@@ -458,9 +460,8 @@ describe("DetailDrawer — variants", () => {
   });
 
   // Regression: live cards cross an HTTP/JSON boundary and don't always carry
-  // the type-required nested objects (the backend doesn't populate deploy
-  // `verification` or a mission `mission` report yet). The drawer must render,
-  // not crash — this is the bug that took the live board down on card click.
+  // deploy `verification` or a mission `mission` report. The drawer must
+  // render, not crash, and deploy steps must stay honest pending data.
   test("deploy card with NO verification (live shape) renders without crashing", () => {
     const card = {
       id: "post-production-deploy-verification-afte-3e4a",
@@ -480,6 +481,7 @@ describe("DetailDrawer — variants", () => {
     );
     expect(getByText("Deploying · post-merge verification")).toBeTruthy();
     expect(getByText("post_deploy_healthy")).toBeTruthy();
+    expect(getByText("Current deploy: verifying")).toBeTruthy();
     expect(queryByText("Verification progress")).toBeNull(); // omitted, not crashed
   });
 

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.deploy.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.deploy.test.tsx
@@ -24,24 +24,40 @@ function deployCard(over: Record<string, unknown>): BoardCard {
   } as unknown as BoardCard;
 }
 
-describe("DeployBody — PR-D2 checkpoint stepper + honest awaiting-data", () => {
-  test("renders a checkpoint stepper from real verification counters", () => {
-    const card = deployCard({ verification: { current: 2, total: 5, label: "smoke tests" } });
+describe("DeployBody — E5 named deploy stepper + honest awaiting-data", () => {
+  test("renders named deploy steps from real check-run sources", () => {
+    const card = deployCard({
+      checks: { pass: 2, running: 1, fail: 0, pending: 3, total: 6 },
+      checkRuns: [
+        { name: "CI queued", status: "pass" },
+        { name: "install dependencies", status: "pass" },
+        { name: "unit tests", status: "running" },
+      ],
+    });
     const { container } = render(<DrawerBody card={card} variant="deploy" />);
     const stepper = container.querySelector(".h4-stepper");
     expect(stepper).toBeTruthy();
-    expect(container.querySelectorAll(".h4-stepper-dot").length).toBe(5);
-    expect(container.querySelectorAll(".h4-stepper-dot.is-done").length).toBe(2);
-    expect(stepper?.textContent).toMatch(/2\/5 · smoke tests/);
-    expect(container.querySelector(".h4-awaiting")).toBeNull();
+    expect(container.querySelectorAll(".h4-stepper-row").length).toBe(6);
+    expect(container.querySelectorAll(".h4-stepper-row.is-done").length).toBe(2);
+    expect(container.querySelectorAll(".h4-stepper-row.is-in-progress").length).toBe(1);
+    expect(stepper?.textContent).toMatch(/CI queued/);
+    expect(stepper?.textContent).toMatch(/browser replaypendingawaiting data/);
   });
 
-  test("shows an honest 'awaiting data' slot when verification isn't wired", () => {
+  test("shows honest pending awaiting-data steps when verification isn't wired", () => {
     const card = deployCard({ verification: undefined });
     const { container } = render(<DrawerBody card={card} variant="deploy" />);
-    const awaiting = container.querySelector(".h4-awaiting");
-    expect(awaiting).toBeTruthy();
-    expect(awaiting?.textContent).toMatch(/awaiting data/i);
-    expect(container.querySelector(".h4-stepper")).toBeNull();
+    expect(container.querySelector(".h4-stepper")).toBeTruthy();
+    expect(container.querySelectorAll(".h4-stepper-row").length).toBe(6);
+    expect(container.querySelectorAll(".h4-stepper-row.is-done").length).toBe(0);
+    expect(container.textContent?.match(/awaiting data/g)?.length).toBe(6);
+  });
+
+  test("legacy verification label marks only the active stage, not fake completed steps", () => {
+    const card = deployCard({ verification: { current: 4, total: 6, label: "browser replay" } });
+    const { container } = render(<DrawerBody card={card} variant="deploy" />);
+    expect(container.querySelectorAll(".h4-stepper-row.is-done").length).toBe(0);
+    expect(container.querySelectorAll(".h4-stepper-row.is-in-progress").length).toBe(1);
+    expect(container.textContent).toMatch(/browser replayin progress/);
   });
 });

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -20,6 +20,8 @@ import type {
 import { humanizeSignalText } from "../../lib/monitor/signal-labels.js";
 import { cleanFailureText } from "../../lib/monitor/mission-failure.js";
 import { laneFor } from "../../lib/monitor/lane-rules.js";
+import { deployStepsForCard } from "../../lib/monitor/deploy-stepper.js";
+import { DeployStepper } from "../DeployStepper.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
 import { OperatorNotes } from "./OperatorNotes.js";
 
@@ -408,45 +410,24 @@ function AwaitingData({ label, note }: { label: string; note?: string }) {
   );
 }
 
-/**
- * PR-D2 — deploy checkpoint stepper, from the REAL `verification` counters
- * (current/total/label). Steps up to `current` are done; the rest pending. No
- * fabricated step names — just the verified count.
- */
-function CheckpointStepper({ current, total, label }: { current: number; total: number; label: string }) {
-  const steps = Math.max(0, Math.min(40, total));
-  return (
-    <div className="h4-stepper" aria-label={`${current} of ${total} checkpoints · ${label}`}>
-      <div className="h4-stepper-track">
-        {Array.from({ length: steps }).map((_, i) => (
-          <span key={i} className={"h4-stepper-dot" + (i < current ? " is-done" : "")} aria-hidden />
-        ))}
-      </div>
-      <div className="h4-stepper-label mono">{current}/{total} · {label}</div>
-    </div>
-  );
-}
-
 function DeployBody({ card }: { card: DeployCard }) {
-  // `verification`/`deployId` are required on the UI type, but the live
-  // backend doesn't always populate them (deploy verification is not wired
-  // yet). They cross an HTTP/JSON boundary, so read defensively — a
-  // verification-less deploy card must render, not crash the drawer.
+  // These fields cross an HTTP/JSON boundary and the live backend does not
+  // always populate them. A verification-less deploy card must render honest
+  // pending steps, not crash or invent completed checkpoints.
   const verification = (card as { verification?: DeployCard["verification"] }).verification;
   const deployId = (card as { deployId?: string }).deployId;
+  const steps = deployStepsForCard(card);
   return (
     <>
       <VerdictBlock head="Post-merge verification">{card.summary || "Verifying the deploy."}</VerdictBlock>
       <section>
         <div className="hm-section-h">Checkpoints</div>
-        {verification ? (
-          <>
-            <CheckpointStepper current={verification.current} total={verification.total} label={verification.label} />
-            {deployId ? <div className="hm-card-meta">Deploy {deployId}.</div> : null}
-          </>
-        ) : (
-          <AwaitingData label="Post-merge verification" note="the deploy runner has not reported checkpoints yet" />
-        )}
+        <div className="hm-deploy-stepper-head">
+          <span>Current deploy: verifying</span>
+          {verification?.label ? <span className="hm-deploy-stepper-source">source: {verification.label}</span> : null}
+        </div>
+        <DeployStepper steps={steps} />
+        {deployId ? <div className="hm-card-meta">Deploy {deployId}.</div> : null}
       </section>
       <ChecksSection checks={card.checks} checkRuns={card.checkRuns} />
     </>

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -342,8 +342,21 @@ export interface CreateTaskInput {
 /** Deploy verification card. */
 export interface DeployCard extends CardBase {
   type: "deploy";
-  deployId: string;
-  verification: { current: number; total: number; label: string };
+  deployId?: string;
+  /**
+   * Legacy deploy progress. The live backend may omit it, and the numeric
+   * current/total values are not step-specific enough to prove completed named
+   * stages. The UI may use the label as a current-stage hint only.
+   */
+  verification?: { current: number; total: number; label: string };
+  /** Future exact deploy-step source. Omitted until the backend wires it. */
+  deploySteps?: {
+    id?: string;
+    label: string;
+    state: "done" | "in-progress" | "pending" | "current" | "running" | "pass" | "success";
+    detail?: string;
+    source?: string;
+  }[];
 }
 
 /** Draft card — author hasn't marked ready yet. */

--- a/packages/monitor-ui/src/lib/monitor/deploy-stepper.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/deploy-stepper.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest";
+import { deployStepsForCard } from "./deploy-stepper.js";
+
+describe("deployStepsForCard", () => {
+  test("maps only real named check-run sources to deploy steps", () => {
+    const steps = deployStepsForCard({
+      checkRuns: [
+        { name: "CI queued", status: "pass" },
+        { name: "install dependencies", status: "pass" },
+        { name: "unit tests", status: "running" },
+      ],
+    });
+
+    expect(steps.map((step) => [step.label, step.state])).toEqual([
+      ["CI queued", "done"],
+      ["install", "done"],
+      ["unit tests", "in-progress"],
+      ["browser replay", "pending"],
+      ["Hermes review", "pending"],
+      ["ready", "pending"],
+    ]);
+    expect(steps.find((step) => step.id === "browser-replay")?.detail).toBe("awaiting data");
+  });
+
+  test("legacy verification label can mark the current stage but not completed prior stages", () => {
+    const steps = deployStepsForCard({
+      verification: { current: 3, total: 5, label: "browser replay" },
+    });
+
+    expect(steps.find((step) => step.id === "browser-replay")?.state).toBe("in-progress");
+    expect(steps.filter((step) => step.state === "done")).toHaveLength(0);
+    expect(steps.find((step) => step.id === "ci-queued")?.detail).toBe("awaiting data");
+  });
+
+  test("explicit deploySteps source wins when the backend wires exact step data", () => {
+    const steps = deployStepsForCard({
+      deploySteps: [
+        { label: "CI queued", state: "done", detail: "workflow 123" },
+        { label: "Hermes review", state: "current", detail: "reviewing evidence" },
+      ],
+      checkRuns: [
+        { name: "Hermes review", status: "pass" },
+      ],
+    });
+
+    expect(steps.find((step) => step.id === "ci-queued")).toMatchObject({
+      state: "done",
+      detail: "workflow 123",
+    });
+    expect(steps.find((step) => step.id === "hermes-review")).toMatchObject({
+      state: "in-progress",
+      detail: "reviewing evidence",
+    });
+  });
+
+  test("with no deploy source, every step stays pending and awaiting data", () => {
+    const steps = deployStepsForCard({});
+
+    expect(steps).toHaveLength(6);
+    expect(steps.every((step) => step.state === "pending")).toBe(true);
+    expect(steps.every((step) => step.detail === "awaiting data")).toBe(true);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/deploy-stepper.ts
+++ b/packages/monitor-ui/src/lib/monitor/deploy-stepper.ts
@@ -1,0 +1,214 @@
+import type { CardCheckRun, CardChecks, DeployCard } from "./card-types.js";
+
+export type DeployStepId =
+  | "ci-queued"
+  | "install"
+  | "unit-tests"
+  | "browser-replay"
+  | "hermes-review"
+  | "ready";
+
+export type DeployStepState = "done" | "in-progress" | "pending";
+
+export interface DeployStepView {
+  id: DeployStepId;
+  label: string;
+  state: DeployStepState;
+  detail: string;
+}
+
+export const DEPLOY_STEPS: readonly { id: DeployStepId; label: string }[] = [
+  { id: "ci-queued", label: "CI queued" },
+  { id: "install", label: "install" },
+  { id: "unit-tests", label: "unit tests" },
+  { id: "browser-replay", label: "browser replay" },
+  { id: "hermes-review", label: "Hermes review" },
+  { id: "ready", label: "ready" },
+];
+
+type DeployStepperSource = Pick<DeployCard, "checkRuns" | "checks" | "verification" | "deploySteps">;
+
+const AWAITING_DATA = "awaiting data";
+
+const STEP_MATCHERS: Record<DeployStepId, RegExp[]> = {
+  "ci-queued": [
+    /\bci\b.*\bqueue[du]?\b/i,
+    /\bqueue[du]?\b.*\bci\b/i,
+    /\bgithub actions?\b/i,
+    /\bworkflow\b/i,
+    /\bdeploy production\b/i,
+  ],
+  install: [
+    /\binstall\b/i,
+    /\bnpm ci\b/i,
+    /\bsetup node\b/i,
+    /\bdependencies\b/i,
+  ],
+  "unit-tests": [
+    /\bunit\b/i,
+    /\bunit tests?\b/i,
+    /\bnpm test\b/i,
+    /\bvitest\b/i,
+  ],
+  "browser-replay": [
+    /\bbrowser replay\b/i,
+    /\bbrowser\b/i,
+    /\bplaywright\b/i,
+    /\btestbed\b/i,
+    /\bsmoke\b/i,
+  ],
+  "hermes-review": [
+    /\bhermes\b.*\breview\b/i,
+    /\breview\b.*\bhermes\b/i,
+    /\bhermes checking\b/i,
+    /\bpost[-_\s]?deploy verification\b/i,
+  ],
+  ready: [
+    /\bready\b/i,
+    /\bdeploy ok\b/i,
+    /\bpost[_-\s]?deploy[_-\s]?healthy\b/i,
+  ],
+};
+
+const STATUS_WEIGHT: Record<DeployStepState, number> = {
+  pending: 0,
+  "in-progress": 1,
+  done: 2,
+};
+
+export function deployStepsForCard(card: DeployStepperSource): DeployStepView[] {
+  const steps = new Map<DeployStepId, DeployStepView>(
+    DEPLOY_STEPS.map((step) => [
+      step.id,
+      {
+        ...step,
+        state: "pending",
+        detail: AWAITING_DATA,
+      },
+    ]),
+  );
+
+  const explicitStepIds = applyExplicitDeploySteps(steps, card.deploySteps);
+  applyCheckRuns(steps, card.checkRuns, explicitStepIds);
+  applyAggregateChecks(steps, card.checks, card.checkRuns, explicitStepIds);
+  applyLegacyVerificationLabel(steps, card.verification, explicitStepIds);
+
+  return DEPLOY_STEPS.map((step) => steps.get(step.id)!);
+}
+
+function applyExplicitDeploySteps(steps: Map<DeployStepId, DeployStepView>, rawSteps: unknown): Set<DeployStepId> {
+  const explicitStepIds = new Set<DeployStepId>();
+  if (!Array.isArray(rawSteps)) return explicitStepIds;
+  for (const raw of rawSteps) {
+    if (!raw || typeof raw !== "object") continue;
+    const record = raw as Record<string, unknown>;
+    const id = stepIdFromString(stringField(record.id) ?? stringField(record.label) ?? stringField(record.name));
+    if (!id) continue;
+    const state = normalizeExplicitState(stringField(record.state) ?? stringField(record.status));
+    const detail = stringField(record.detail) ?? stringField(record.source) ?? "deploy step";
+    mergeStep(steps, id, { state, detail });
+    explicitStepIds.add(id);
+  }
+  return explicitStepIds;
+}
+
+function applyCheckRuns(
+  steps: Map<DeployStepId, DeployStepView>,
+  checkRuns: CardCheckRun[] | undefined,
+  explicitStepIds: Set<DeployStepId>,
+): void {
+  if (!checkRuns || checkRuns.length === 0) return;
+  if (!explicitStepIds.has("ci-queued")) {
+    mergeStep(steps, "ci-queued", {
+      state: "done",
+      detail: `${checkRuns.length} check run${checkRuns.length === 1 ? "" : "s"} reported`,
+    });
+  }
+
+  for (const step of DEPLOY_STEPS) {
+    if (explicitStepIds.has(step.id)) continue;
+    const matching = checkRuns.filter((run) => stepMatchesName(step.id, run.name));
+    if (matching.length === 0) continue;
+    mergeStep(steps, step.id, stateFromCheckRuns(matching));
+  }
+}
+
+function applyAggregateChecks(
+  steps: Map<DeployStepId, DeployStepView>,
+  checks: CardChecks | undefined,
+  checkRuns: CardCheckRun[] | undefined,
+  explicitStepIds: Set<DeployStepId>,
+): void {
+  if (!checks || checks.total <= 0 || (checkRuns && checkRuns.length > 0) || explicitStepIds.has("ci-queued")) return;
+  mergeStep(steps, "ci-queued", {
+    state: "done",
+    detail: `${checks.total} aggregate check${checks.total === 1 ? "" : "s"} reported`,
+  });
+}
+
+function applyLegacyVerificationLabel(
+  steps: Map<DeployStepId, DeployStepView>,
+  verification: DeployCard["verification"] | undefined,
+  explicitStepIds: Set<DeployStepId>,
+): void {
+  const label = verification?.label?.trim();
+  if (!label) return;
+  const id = stepIdFromString(label);
+  if (!id) return;
+  if (explicitStepIds.has(id)) return;
+  mergeStep(steps, id, {
+    state: "in-progress",
+    detail: `legacy verification label: ${label}`,
+  });
+}
+
+function stateFromCheckRuns(checkRuns: CardCheckRun[]): { state: DeployStepState; detail: string } {
+  const names = checkRuns.map((run) => run.name).join(", ");
+  if (checkRuns.some((run) => run.status === "running")) {
+    return { state: "in-progress", detail: names };
+  }
+  if (checkRuns.some((run) => run.status === "fail")) {
+    return { state: "pending", detail: `failed: ${names}` };
+  }
+  if (checkRuns.some((run) => run.status === "pass")) {
+    return { state: "done", detail: names };
+  }
+  return { state: "pending", detail: names };
+}
+
+function normalizeExplicitState(value: string | undefined): DeployStepState {
+  const normalized = value?.toLowerCase().trim();
+  if (normalized === "done" || normalized === "pass" || normalized === "passed" || normalized === "success") return "done";
+  if (normalized === "current" || normalized === "running" || normalized === "in_progress" || normalized === "in-progress") return "in-progress";
+  return "pending";
+}
+
+function mergeStep(
+  steps: Map<DeployStepId, DeployStepView>,
+  id: DeployStepId,
+  update: { state: DeployStepState; detail: string },
+): void {
+  const current = steps.get(id);
+  if (!current) return;
+  if (STATUS_WEIGHT[update.state] < STATUS_WEIGHT[current.state]) return;
+  steps.set(id, {
+    ...current,
+    state: update.state,
+    detail: update.detail || current.detail,
+  });
+}
+
+function stepMatchesName(id: DeployStepId, name: string): boolean {
+  return STEP_MATCHERS[id].some((matcher) => matcher.test(name));
+}
+
+function stepIdFromString(value: string | undefined): DeployStepId | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim();
+  return DEPLOY_STEPS.find((step) => normalized.toLowerCase() === step.label.toLowerCase())?.id
+    ?? DEPLOY_STEPS.find((step) => stepMatchesName(step.id, normalized))?.id;
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -73,21 +73,91 @@
 }
 .h4-awaiting-note { font-size: 11.5px; color: var(--h4-faint); }
 
-/* ---- drawer: deploy checkpoint stepper ---- */
-.h4-stepper { display: flex; flex-direction: column; gap: 8px; }
-.h4-stepper-track { display: flex; gap: 5px; flex-wrap: wrap; }
+/* ---- deploy checkpoint stepper ---- */
+.hm-deploy-stepper-card {
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+}
+.hm-deploy-stepper-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-family: var(--h4-font-display);
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--h4-ink-2);
+}
+.hm-deploy-stepper-source {
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--h4-faint);
+}
+.h4-stepper {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.h4-deploy-stepper--compact { gap: 6px; }
+.h4-stepper-row {
+  display: grid;
+  grid-template-columns: 16px minmax(88px, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  color: var(--h4-muted);
+}
 .h4-stepper-dot {
-  width: 10px;
-  height: 10px;
+  width: 15px;
+  height: 15px;
   border-radius: 50%;
   border: 1.5px solid var(--h4-line-strong);
   background: transparent;
+  color: var(--h4-act-ink);
+  display: grid;
+  place-items: center;
+  font-size: 9px;
+  line-height: 1;
 }
-.h4-stepper-dot.is-done {
+.h4-stepper-row.is-done .h4-stepper-dot {
   background: var(--h4-ok);
   border-color: var(--h4-ok);
 }
-.h4-stepper-label { font-size: 12px; color: var(--h4-muted); }
+.h4-stepper-row.is-in-progress .h4-stepper-dot {
+  background: var(--h4-ok-soft);
+  border-color: var(--h4-ok);
+  color: var(--h4-ok-text);
+}
+.h4-stepper-label {
+  font-family: var(--h4-font-display);
+  font-size: 12px;
+  font-weight: 650;
+  color: var(--h4-muted);
+}
+.h4-stepper-row.is-done .h4-stepper-label { color: var(--h4-ink-2); }
+.h4-stepper-row.is-in-progress .h4-stepper-label {
+  color: var(--h4-ok-text);
+  font-weight: 800;
+}
+.h4-stepper-state {
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+  white-space: nowrap;
+}
+.h4-stepper-row.is-done .h4-stepper-state { color: var(--h4-ok-text); }
+.h4-stepper-row.is-in-progress .h4-stepper-state { color: var(--h4-ok-text); }
+.h4-stepper-source {
+  grid-column: 2 / -1;
+  margin-top: -4px;
+  font-size: 10.5px;
+  color: var(--h4-faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.h4-deploy-stepper--compact .h4-stepper-source { display: none; }
 
 /* ---- mission forensics: expected vs observed ---- */
 .h4-eo { border: 1px solid var(--h4-line-2); border-radius: var(--h4-r-sm); overflow: hidden; }


### PR DESCRIPTION
## What changed

- Adds a shared DeployStepper component for the Deploying lane card and deploy drawer.
- Replaces the old numeric verification-dot drawer with six named stages from the E1 design:
  - CI queued
  - install
  - unit tests
  - browser replay
  - Hermes review
  - ready
- Adds a pure deploy-stepper mapper that only marks steps done/in-progress from real sources:
  - exact future `deploySteps`
  - named `checkRuns`
  - aggregate `checks` only for the CI queued source
  - legacy `verification.label` only as a current-stage hint
- Missing/unmapped stages render as `pending` with `awaiting data`; legacy `verification.current/total` no longer fabricates green completed stages.

## Checks run

- `npm test -- packages/monitor-ui/src/lib/monitor/deploy-stepper.test.ts packages/monitor-ui/src/components/drawer/DrawerBody.deploy.test.tsx packages/monitor-ui/src/components/cards/Card.test.tsx packages/monitor-ui/src/components/drawer/DetailDrawer.test.tsx`
- `npm run typecheck`
- `npm test`
- `npm --workspace @avg/monitor-ui run build`

Notes:
- One full-suite run briefly failed `test/unit/testbed-live-screencast.test.ts`; rerunning that file passed, and a subsequent full `npm test` passed 141 files / 1650 tests.
- Local browser smoke reached the monitor app, but without the slack-operator API it correctly rendered degraded/offline mode, so no live deploy card was available in the isolated worktree.

## Affected surfaces

- Monitor UI only: cards, drawer, deploy-stepper helper, monitor CSS, tests.
- No backend, ops, secrets/config, runners, contracts, or deploy behavior changed.

## Rollout / rollback

- Normal frontend build/deploy.
- Rollback is reverting this PR.
