### PR TITLE
[codex] Add Digest and Agent room tabs to Hermes rail

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -43,6 +43,12 @@ function wrapper({ children }: { children: ReactNode }) {
   return <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>{children}</SWRConfig>;
 }
 
+function boardLanes(container: HTMLElement) {
+  const lanes = container.querySelector(".hm-lanes-wrap");
+  expect(lanes).toBeTruthy();
+  return within(lanes as HTMLElement);
+}
+
 function taskCard(overrides: Partial<BoardCard> = {}): BoardCard {
   return {
     id: "codex-task-1",
@@ -75,7 +81,7 @@ describe("MonitorPage — container", () => {
 
     // Once the fetch resolves, the rich-mix board renders.
     await waitFor(() =>
-      expect(within(container).getByText("Allow operator override of agent claim-stake floor")).toBeTruthy(),
+      expect(boardLanes(container).getByText("Allow operator override of agent claim-stake floor")).toBeTruthy(),
     );
     expect(within(container).getByRole("banner")).toBeTruthy();
     expect(within(container).getByRole("complementary", { name: "Hermes co-pilot" })).toBeTruthy();

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -10,6 +10,12 @@ afterEach(cleanup);
 
 const richBoard: MonitorBoard = { cards: FIXTURE_CARDS, at: "2026-05-28T10:30:00Z" };
 
+function boardLanes(container: HTMLElement) {
+  const lanes = container.querySelector(".hm-lanes-wrap");
+  expect(lanes).toBeTruthy();
+  return within(lanes as HTMLElement);
+}
+
 describe("BoardView — rich-mix board (open stream)", () => {
   test("renders the full board chrome end-to-end", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
@@ -57,7 +63,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
 
   test("renders the action card with one primary and Hermes verdict", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
-    const view = within(container);
+    const view = boardLanes(container);
     expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
     expect(view.getAllByRole("button", { name: "Approve merge" }).length).toBeGreaterThan(0);
     expect(view.queryByText("Send back to Codex")).toBeNull();
@@ -270,12 +276,13 @@ describe("BoardView — rich-mix board (open stream)", () => {
       at: "2026-06-02T08:00:00Z",
       cards: [reviewCard({ id: "agent #901", title: "Review the settlement risk" })],
     };
-    const { getByRole, getByText, queryByRole } = render(<BoardView board={board} status="open" keyboard={false} />);
+    const { getByRole, queryByRole } = render(<BoardView board={board} status="open" keyboard={false} />);
 
     // The inbox hero has no collapse chevron — attention can never be hidden.
     expect(queryByRole("button", { name: /Collapse Your decisions/ })).toBeNull();
-    expect(getByRole("region", { name: "Your decisions lane" })).toBeTruthy();
-    expect(getByText("Review the settlement risk")).toBeTruthy();
+    const inbox = getByRole("region", { name: "Your decisions lane" });
+    expect(inbox).toBeTruthy();
+    expect(within(inbox).getByText("Review the settlement risk")).toBeTruthy();
   });
 
   test("calm banner CTA filters to today's done cards and mutes alerts for one hour", () => {
@@ -496,7 +503,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
         prompt: "Fix the failed mission.",
       }],
     };
-    const { getByRole, getByText, queryByText } = render(
+    const { container, getByRole, queryByText } = render(
       <BoardView board={board} status="open" onApproveTask={onApproveTask} keyboard={false} />,
     );
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
@@ -507,7 +514,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onApproveTask).toHaveBeenCalledWith("task-action-1");
 
-    expect(getByText("Fix the failed mission")).toBeTruthy();
+    expect(boardLanes(container).getByText("Fix the failed mission")).toBeTruthy();
   });
 
   test("renders backlog suggestions as a collapsed planner-only rail block", () => {
@@ -613,7 +620,7 @@ describe("BoardView — degraded + transient states", () => {
 describe("BoardView — filter chips (G1)", () => {
   test("clicking a filter chip narrows the visible board to that state", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
-    const view = within(container);
+    const view = boardLanes(container);
     // Baseline: the action card is visible.
     expect(view.getByText("Allow operator override of agent claim-stake floor")).toBeTruthy();
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
@@ -22,18 +22,20 @@ function card(over: Record<string, unknown>): BoardCard {
 describe("PR-D3d — rail Hermes digest", () => {
   test("shows real needs-you / running counts and an honest awaiting-data since-marker", () => {
     const cards = [
-      card({ waitingOn: { actor: "operator", tone: "warn" } }),
-      card({ isAction: true }),
-      card({ state: "running" }),
+      card({ id: "operator-waiting", waitingOn: { actor: "operator", tone: "warn" } }),
+      card({ id: "action-card", isAction: true }),
+      card({ id: "running-card", state: "running" }),
     ];
     const { container } = render(<CoPilotRail boardCards={cards} collaboration={{ enabled: false }} />, { wrapper });
     const digest = container.querySelector(".hm-rail-digest") as HTMLElement;
     expect(digest).toBeTruthy();
     const view = within(digest);
     // needs-you = 2 (operator + isAction), running = 1
-    expect(view.getByText("needs you").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("2");
-    expect(view.getByText("running now").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("1");
+    expect(view.getByText("NEEDS YOU").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("2");
+    expect(view.getByText("RUNNING NOW").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("1");
     // No fabricated session deltas — the since-marker is honest awaiting-data.
-    expect(view.getByText(/since last look · awaiting data/i)).toBeTruthy();
+    expect(view.getByText(/session deltas · honest until wired/i)).toBeTruthy();
+    expect(view.getByText("ADVANCED (SESSION)").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("—");
+    expect(view.getByText("PROD CHANGES").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("—");
   });
 });

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.presence.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.presence.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test } from "vitest";
 import type { ReactNode } from "react";
-import { cleanup, render, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { CoPilotRail } from "./CoPilotRail.js";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
@@ -29,12 +29,17 @@ function workingCard(): BoardCard {
   } as unknown as BoardCard;
 }
 
+function openAgentRoom(container: HTMLElement) {
+  fireEvent.click(within(container).getByRole("tab", { name: /Agent room/ }));
+}
+
 describe("PR-D3c — room presence strip", () => {
   test("renders an active peer (from workingNow) with the active dot + count", () => {
     const { container } = render(
       <CoPilotRail boardCards={[workingCard()]} collaboration={{ enabled: false }} />,
       { wrapper },
     );
+    openAgentRoom(container);
     const presence = container.querySelector(".hm-room-presence");
     expect(presence).toBeTruthy();
     expect(within(presence as HTMLElement).getByText("codex")).toBeTruthy();
@@ -44,6 +49,7 @@ describe("PR-D3c — room presence strip", () => {
 
   test("reads honestly as 'quiet' when no agent has a live signal", () => {
     const { container } = render(<CoPilotRail boardCards={[]} collaboration={{ enabled: false }} />, { wrapper });
+    openAgentRoom(container);
     const presence = container.querySelector(".hm-room-presence--quiet");
     expect(presence?.textContent).toMatch(/quiet/i);
     expect(container.querySelector(".hm-room-peer")).toBeNull();

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -41,10 +41,15 @@ const banner: BoardNowBanner = {
   primaryActionId: "agent #548",
 };
 
+function openAgentRoom(container: HTMLElement) {
+  fireEvent.click(within(container).getByRole("tab", { name: /Agent room/ }));
+}
+
 describe("CoPilotRail", () => {
   test("renders the collaboration feed as turns", async () => {
     const fetcher = vi.fn(async () => [msg("1", "hermes", "Pre-check passed on #548.")]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
+    openAgentRoom(container);
     await waitFor(() => expect(within(container).getByText(/Pre-check passed on #548/)).toBeTruthy());
     expect(within(container).getByText("Hermes → everyone")).toBeTruthy();
     expect(within(container).getAllByText(/chat/).length).toBeGreaterThan(0);
@@ -57,14 +62,16 @@ describe("CoPilotRail", () => {
       msg("2", "hermes", "Another template answer.", { hermesMode: "templated" }),
     ]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
+    openAgentRoom(container);
     await waitFor(() => expect(within(container).getByText(/Template answer from the board/)).toBeTruthy());
     expect(within(container).getAllByText("Hermes (offline — templated) → everyone").length).toBeGreaterThan(0);
     expect(within(container).getAllByText(/replies are templated/)).toHaveLength(1);
   });
 
   test("is inert (no fetch, empty-state copy) when collaboration is omitted", () => {
-    const { getByText } = render(<CoPilotRail />, { wrapper });
-    expect(getByText("No agent chatter yet.")).toBeTruthy();
+    const { container } = render(<CoPilotRail />, { wrapper });
+    openAgentRoom(container);
+    expect(within(container).getByText("No agent chatter yet.")).toBeTruthy();
   });
 
   test("the scope chip reflects the focused card", async () => {
@@ -86,6 +93,7 @@ describe("CoPilotRail", () => {
       <CoPilotRail focusedCard={card548} collaboration={{ fetcher, poster, refreshIntervalMs: 0 }} />,
       { wrapper },
     );
+    openAgentRoom(container);
     await waitFor(() => expect(within(container).getByText("No agent chatter yet.")).toBeTruthy());
 
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
@@ -119,7 +127,7 @@ describe("CoPilotRail", () => {
 
   test("shows the current board summary and links it back to a card", () => {
     const onCardClick = vi.fn();
-    const { getByText, getByRole } = render(
+    const { container, getByText, getByRole } = render(
       <CoPilotRail
         boardCards={[card548]}
         boardBanner={banner}
@@ -128,6 +136,7 @@ describe("CoPilotRail", () => {
       />,
       { wrapper },
     );
+    openAgentRoom(container);
     expect(getByText(/Needs you:/)).toBeTruthy();
     expect(getByText(/Operator review is waiting on agent #548/)).toBeTruthy();
     fireEvent.click(getByRole("button", { name: "Open referenced card agent #548" }));
@@ -149,6 +158,7 @@ describe("CoPilotRail", () => {
       />,
       { wrapper },
     );
+    openAgentRoom(container);
     await waitFor(() => expect(within(container).getByText(/What is still blocking this/)).toBeTruthy());
     expect(within(container).getByText("You → everyone")).toBeTruthy();
     expect(within(container).getAllByText(/chat/).length).toBeGreaterThan(0);
@@ -175,6 +185,7 @@ describe("CoPilotRail", () => {
       msg("system-chat", "system", "Board snapshot refreshed.", { addressedTo: "everyone" }),
     ]);
     const { container } = render(<CoPilotRail collaboration={{ fetcher, refreshIntervalMs: 0 }} />, { wrapper });
+    openAgentRoom(container);
     await waitFor(() => expect(within(container).getByText("Codex → Claude")).toBeTruthy());
     expect(within(container).getByText("Claude → Hermes")).toBeTruthy();
     expect(within(container).getByText("Test-writer → everyone")).toBeTruthy();
@@ -204,6 +215,7 @@ describe("CoPilotRail", () => {
       />,
       { wrapper },
     );
+    openAgentRoom(container);
     await waitFor(() => expect(within(container).getByText("Thread · depre-dev/agent #548")).toBeTruthy());
     expect(within(container).getByText("2 turns")).toBeTruthy();
     fireEvent.click(getByRole("button", { name: "Open referenced card agent #548" }));
@@ -225,6 +237,48 @@ describe("CoPilotRail", () => {
       text: "please inspect this",
       addressedTo: "codex",
     });
+  });
+
+  test("defaults to the digest tab and opens the agent room from the digest action", () => {
+    const { container, getByRole } = render(<CoPilotRail boardCards={[card548]} collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }} />, { wrapper });
+    expect(getByRole("tab", { name: /Digest/ }).getAttribute("aria-selected")).toBe("true");
+    expect(within(container).getByText(/session deltas · honest until wired/i)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: "Open agent room →" }));
+    expect(getByRole("tab", { name: /Agent room/ }).getAttribute("aria-selected")).toBe("true");
+    expect(within(container).getByText("No agent chatter yet.")).toBeTruthy();
+  });
+
+  test("digest lists cards waiting on the operator with recommendation, risk, grants, and Open", () => {
+    const onCardClick = vi.fn();
+    const waitingCard = {
+      ...card548,
+      decisionRecord: {
+        schemaVersion: 1,
+        recordType: "hermes_decision_record",
+        id: "decision-1",
+        kind: "escalation",
+        subject: { type: "card", id: card548.id },
+        decision: "approve if rollout scope is acceptable",
+        reasons: [],
+        inputs: {},
+        outcome: { summary: "operator decision needed" },
+        safety: { readOnly: false, mutates: true },
+        generatedAt: "2026-06-07T08:00:00Z",
+      },
+      risk: ["secrets" as const],
+      waitingOn: { actor: "operator" as const, tone: "warn" as const },
+    };
+    const { getByText, getByRole } = render(
+      <CoPilotRail boardCards={[waitingCard]} onCardClick={onCardClick} collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }} />,
+      { wrapper },
+    );
+    expect(getByText("1 waiting on you")).toBeTruthy();
+    expect(getByText(/rec ·/i)).toBeTruthy();
+    expect(getByText("approve if rollout scope is acceptable")).toBeTruthy();
+    expect(getByText(/risk · secrets/i)).toBeTruthy();
+    expect(getByText(/grants · gated mutation/i)).toBeTruthy();
+    fireEvent.click(getByRole("button", { name: `Open ${card548.id}` }));
+    expect(onCardClick).toHaveBeenCalledWith(card548.id);
   });
 });
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -18,6 +18,7 @@ import {
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { derivePresence, activeCount, type PresencePeer } from "../../lib/monitor/presence.js";
 import { railDigestCounts } from "../../lib/monitor/rail-digest.js";
+import { isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
 import { HermesTurn } from "./HermesTurn.js";
@@ -82,6 +83,10 @@ export function CoPilotRail({
   );
   const relatedPr = relatedPrForCard(focusedCard);
   const streamRef = useRef<HTMLDivElement>(null);
+  const digestPanelId = useId();
+  const roomPanelId = useId();
+  const [railTab, setRailTab] = useState<"digest" | "room">("digest");
+  const [rosterOpen, setRosterOpen] = useState(false);
   // Suggestion chips fill the composer: hold the text + a bump token.
   const [prefill, setPrefill] = useState("");
   const [prefillToken, setPrefillToken] = useState(0);
@@ -134,45 +139,81 @@ export function CoPilotRail({
         </div>
       </div>
 
-      <RailDigest cards={boardCards ?? []} />
-
-      <BacklogSuggestionsRailBlock
-        response={backlogSuggestions}
-        boardCards={boardCards ?? []}
-        onCardClick={onCardClick}
-        onUseInComposer={fillComposer}
-      />
-
       {templateModeObserved ? (
         <div className="hm-hermes-mode-banner" role="status">
           Hermes is offline — replies are templated until the live model key is configured.
         </div>
       ) : null}
 
-      <section className="hm-activity" aria-label="Multi-agent collaboration room">
-        <div className="hm-activity-head">
-          <span className="hm-kicker">Room</span>
-          <strong>Agent collaboration</strong>
-          <RoomPresence peers={peers} />
-        </div>
-        <div className="hm-hermes-stream hm-activity-stream" ref={streamRef} aria-live="polite">
-          {roomThreads.length > 0 ? (
-            roomThreads.map((thread) => (
-              <RoomThreadBlock
-                thread={thread}
+      <div className="hm-rail-tabs" role="tablist" aria-label="Hermes rail views">
+        <RailTab
+          active={railTab === "digest"}
+          badge={railDigestCounts(boardCards ?? []).needsYou}
+          controls={digestPanelId}
+          label="Digest"
+          onClick={() => setRailTab("digest")}
+        />
+        <RailTab
+          active={railTab === "room"}
+          controls={roomPanelId}
+          label="Agent room"
+          onClick={() => setRailTab("room")}
+        />
+      </div>
+
+      <div className="hm-rail-tabpanels">
+        {railTab === "digest" ? (
+          <section
+            className="hm-rail-panel hm-rail-panel--digest"
+            id={digestPanelId}
+            role="tabpanel"
+            aria-label="Hermes digest"
+          >
+            <RailDigest
+              cards={boardCards ?? []}
+              onCardClick={onCardClick}
+              onGoRoom={() => setRailTab("room")}
+              onOpenRoster={() => setRosterOpen(true)}
+            />
+            <BacklogSuggestionsRailBlock
+              response={backlogSuggestions}
+              boardCards={boardCards ?? []}
+              onCardClick={onCardClick}
+              onUseInComposer={fillComposer}
+            />
+          </section>
+        ) : (
+          <section
+            className="hm-activity hm-rail-panel hm-rail-panel--room"
+            id={roomPanelId}
+            role="tabpanel"
+            aria-label="Multi-agent collaboration room"
+          >
+            <div className="hm-activity-head">
+              <span className="hm-kicker">Room</span>
+              <strong>Agent collaboration</strong>
+              <RoomPresence peers={peers} />
+            </div>
+            <div className="hm-hermes-stream hm-activity-stream" ref={streamRef} aria-live="polite">
+              {roomThreads.length > 0 ? (
+                roomThreads.map((thread) => (
+                  <RoomThreadBlock
+                    thread={thread}
+                    onCardClick={onCardClick}
+                    key={thread.key}
+                  />
+                ))
+              ) : (
+                <RoomEmptyState />
+              )}
+              <BoardSummaryRow
+                banner={boardBanner}
                 onCardClick={onCardClick}
-                key={thread.key}
               />
-            ))
-          ) : (
-            <RoomEmptyState />
-          )}
-          <BoardSummaryRow
-            banner={boardBanner}
-            onCardClick={onCardClick}
-          />
-        </div>
-      </section>
+            </div>
+          </section>
+        )}
+      </div>
 
       <AskHermesComposer
         onSpawnMission={onSpawnMission}
@@ -193,7 +234,36 @@ export function CoPilotRail({
         pending={pending}
         sendError={sendError}
       />
+      <RailRoster open={rosterOpen} onClose={() => setRosterOpen(false)} />
     </aside>
+  );
+}
+
+function RailTab({
+  active,
+  badge,
+  controls,
+  label,
+  onClick,
+}: {
+  active: boolean;
+  badge?: number;
+  controls: string;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`hm-rail-tab${active ? " is-active" : ""}`}
+      role="tab"
+      aria-selected={active}
+      aria-controls={controls}
+      onClick={onClick}
+    >
+      <span>{label}</span>
+      {badge && badge > 0 ? <span className="hm-rail-tab-badge">{badge}</span> : null}
+    </button>
   );
 }
 
@@ -267,8 +337,19 @@ function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCa
  * we don't have, so they read as honest awaiting-data — never a fabricated
  * count.
  */
-function RailDigest({ cards }: { cards: readonly BoardCard[] }) {
+function RailDigest({
+  cards,
+  onCardClick,
+  onGoRoom,
+  onOpenRoster,
+}: {
+  cards: readonly BoardCard[];
+  onCardClick?: (id: string) => void;
+  onGoRoom: () => void;
+  onOpenRoster: () => void;
+}) {
   const { needsYou, running } = railDigestCounts(cards);
+  const waiting = cards.filter(isWaitingOnOperator);
   return (
     <section className="hm-rail-digest" aria-label="Hermes digest">
       <div className="hm-rail-digest-head">
@@ -278,22 +359,191 @@ function RailDigest({ cards }: { cards: readonly BoardCard[] }) {
           className="hm-rail-digest-since"
           title="The since-you-last-looked marker needs a real session backend — not wired yet."
         >
-          since last look · awaiting data
+          session deltas · honest until wired
         </span>
       </div>
       <div className="hm-rail-digest-stats">
-        <DigestStat label="needs you" value={needsYou} tone="act" />
-        <DigestStat label="running now" value={running} tone="ok" />
+        <DigestStat label="NEEDS YOU" value={needsYou} tone="act" />
+        <DigestStat label="RUNNING NOW" value={running} tone="ok" />
+        <DigestStat label="ADVANCED (SESSION)" needsData />
+        <DigestStat label="PROD CHANGES" needsData />
+      </div>
+      <p className="hm-rail-digest-note">
+        Advanced and production-change deltas need a real session marker; they stay blank until that source is wired.
+      </p>
+      <div className="hm-rail-waiting-head">{needsYou} waiting on you</div>
+      {waiting.length > 0 ? (
+        <div className="hm-rail-waiting-list">
+          {waiting.slice(0, 5).map((card) => (
+            <DigestWaitingCard
+              card={card}
+              onCardClick={onCardClick}
+              key={card.id}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="hm-rail-waiting-empty">
+          <strong>Inbox clear</strong>
+          <span>Nothing needs your judgment right now.</span>
+        </div>
+      )}
+      <div className="hm-rail-digest-actions">
+        <Button variant="secondary" size="sm" onClick={onGoRoom}>Open agent room →</Button>
+        <Button variant="ghost" size="sm" onClick={onOpenRoster}>Who&apos;s who</Button>
       </div>
     </section>
   );
 }
 
-function DigestStat({ label, value, tone }: { label: string; value: number; tone: "act" | "ok" }) {
+function DigestStat({
+  label,
+  value,
+  tone,
+  needsData,
+}: {
+  label: string;
+  value?: number;
+  tone?: "act" | "ok";
+  needsData?: boolean;
+}) {
   return (
     <div className="hm-rail-digest-stat">
-      <span className="hm-rail-digest-value" data-tone={tone}>{value}</span>
+      <span className="hm-rail-digest-value" data-tone={tone ?? "neutral"} data-needs-data={needsData ? "true" : undefined}>
+        {needsData ? "—" : value}
+      </span>
       <span className="hm-rail-digest-label">{label}</span>
+    </div>
+  );
+}
+
+function DigestWaitingCard({
+  card,
+  onCardClick,
+}: {
+  card: BoardCard;
+  onCardClick?: (id: string) => void;
+}) {
+  const rec = recommendationForCard(card);
+  const risk = riskLabelForCard(card);
+  const grants = grantsLabelForCard(card);
+  return (
+    <button
+      type="button"
+      className="hm-rail-waiting-card"
+      onClick={() => onCardClick?.(card.id)}
+      disabled={!onCardClick}
+      aria-label={`Open ${card.id}`}
+    >
+      <span className="hm-rail-waiting-dot" aria-hidden />
+      <span className="hm-rail-waiting-main">
+        <strong>{card.title}</strong>
+        <small>{card.agentType} · {card.id}</small>
+        {rec ? <span className="hm-rail-waiting-rec"><b>rec ·</b> {rec}</span> : null}
+        <span className="hm-rail-waiting-chips">
+          <Badge variant={risk.tone}>{risk.label}</Badge>
+          <Badge variant={grants.tone}>{grants.label}</Badge>
+        </span>
+      </span>
+      <span className="hm-rail-waiting-open">Open ›</span>
+    </button>
+  );
+}
+
+function recommendationForCard(card: BoardCard): string | undefined {
+  if (card.decisionRecord?.decision) return card.decisionRecord.decision;
+  if ("action" in card && card.action?.primary) return card.action.primary;
+  return card.next ?? card.summary;
+}
+
+function riskLabelForCard(card: BoardCard): { label: string; tone: StateVariant } {
+  if ("riskTier" in card && card.riskTier) {
+    return { label: `risk · ${card.riskTier}`, tone: card.riskTier === "high" ? "risk" : "neutral" };
+  }
+  if (card.risk.length > 0) {
+    const high = card.risk.some((tag) => tag === "contracts" || tag === "secrets" || tag === "xcm" || tag === "indexer");
+    return { label: `risk · ${card.risk.slice(0, 2).join(", ")}`, tone: high ? "risk" : "pending" };
+  }
+  return { label: "risk · not recorded", tone: "neutral" };
+}
+
+function grantsLabelForCard(card: BoardCard): { label: string; tone: StateVariant } {
+  const safety = card.decisionRecord?.safety;
+  if (!safety) return { label: "grants · not recorded", tone: "neutral" };
+  if (!safety.mutates) return { label: "grants · read-only", tone: "pass" };
+  return { label: "grants · gated mutation", tone: "pending" };
+}
+
+function RailRoster({ open, onClose }: { open: boolean; onClose: () => void }) {
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, open]);
+
+  if (!open) return null;
+
+  const roles = [
+    {
+      agent: "hermes" as const,
+      title: "Orchestrator",
+      body: "Reads the board, narrates handoffs, reviews evidence, and routes the next safe step.",
+      can: ["observe", "recommend", "route"],
+      cannot: ["merge", "deploy"],
+    },
+    {
+      agent: "codex" as const,
+      title: "Builder",
+      body: "Implements code fixes and opens PRs when a task is approved.",
+      can: ["branch", "test", "PR"],
+      cannot: ["merge"],
+    },
+    {
+      agent: "claude" as const,
+      title: "Builder / reviewer",
+      body: "Handles UI, docs, review, and collaboration turns when assigned.",
+      can: ["branch", "review", "PR"],
+      cannot: ["deploy"],
+    },
+    {
+      agent: "operator" as const,
+      title: "Final authority",
+      body: "Owns risky decisions, approvals, merge/deploy gates, and production judgment.",
+      can: ["approve", "merge", "deploy"],
+      cannot: ["be bypassed"],
+    },
+  ];
+
+  return (
+    <div className="hm-roster-layer" role="presentation">
+      <button type="button" className="hm-roster-scrim" aria-label="Close who's who" onClick={onClose} />
+      <section className="hm-roster-dialog" role="dialog" aria-modal="true" aria-label="Who's who">
+        <div className="hm-roster-head">
+          <div>
+            <strong>Who&apos;s who</strong>
+            <span>observe · mutate · approve</span>
+          </div>
+          <Button variant="ghost" size="sm" onClick={onClose}>Close</Button>
+        </div>
+        <div className="hm-roster-list">
+          {roles.map((role) => (
+            <div className="hm-roster-row" key={role.agent}>
+              <AgentTag agent={role.agent} label={role.agent === "operator" ? "You" : role.agent} />
+              <div>
+                <strong>{role.title}</strong>
+                <p>{role.body}</p>
+                <span>
+                  {role.can.map((capability) => <Badge variant="pass" key={capability}>✓ {capability}</Badge>)}
+                  {role.cannot.map((capability) => <Badge variant="neutral" key={capability}>not {capability}</Badge>)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/packages/monitor-ui/src/styles/hermes4-rail.css
+++ b/packages/monitor-ui/src/styles/hermes4-rail.css
@@ -43,6 +43,68 @@
   background: var(--h4-paper-sunken);
 }
 .hm-hermes-stream::-webkit-scrollbar-thumb { background: var(--h4-line); }
+.hm-rail-tabs {
+  background: var(--h4-paper-veil);
+  border-bottom-color: var(--h4-line-2);
+}
+.hm-rail-tab { color: var(--h4-muted); }
+.hm-rail-tab:hover {
+  color: var(--h4-ink);
+  background: var(--h4-paper-sunken);
+}
+.hm-rail-tab.is-active {
+  color: var(--h4-ink);
+  background: var(--h4-paper);
+  border-bottom-color: var(--h4-act);
+}
+.hm-rail-tab-badge {
+  background: var(--h4-act-soft);
+  color: var(--h4-act-text);
+}
+.hm-rail-panel--digest {
+  background: var(--h4-paper-sunken);
+}
+.hm-rail-panel--digest::-webkit-scrollbar-thumb { background: var(--h4-line); }
+.hm-rail-digest-head strong,
+.hm-rail-waiting-main strong,
+.hm-roster-head strong,
+.hm-roster-row strong { color: var(--h4-ink); }
+.hm-rail-digest-since,
+.hm-rail-digest-note,
+.hm-rail-waiting-head,
+.hm-rail-waiting-main small,
+.hm-rail-waiting-rec,
+.hm-roster-head span,
+.hm-roster-row p { color: var(--h4-muted); }
+.hm-rail-digest-stat,
+.hm-rail-waiting-card,
+.hm-roster-dialog {
+  border-color: var(--h4-line);
+  background: var(--h4-paper);
+}
+.hm-rail-digest-value { color: var(--h4-ink); }
+.hm-rail-digest-value[data-tone="act"],
+.hm-rail-waiting-open { color: var(--h4-act-text); }
+.hm-rail-digest-value[data-tone="ok"],
+.hm-rail-waiting-empty strong { color: var(--h4-ok-text); }
+.hm-rail-digest-value[data-needs-data="true"],
+.hm-rail-digest-label,
+.hm-rail-waiting-rec b { color: var(--h4-faint); }
+.hm-rail-waiting-card:hover {
+  border-color: var(--h4-act);
+  background: var(--h4-paper-sunken);
+}
+.hm-rail-waiting-dot { background: var(--h4-act); }
+.hm-rail-waiting-empty {
+  border-color: var(--h4-line-2);
+  background: var(--h4-paper);
+  color: var(--h4-muted);
+}
+.hm-roster-head { border-bottom-color: var(--h4-line-2); }
+.hm-roster-row {
+  border-color: var(--h4-line);
+  background: var(--h4-paper-sunken);
+}
 
 /* ---- activity / room ---- */
 .hm-activity {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2039,6 +2039,303 @@ body { margin: 0; }
   font-size: 10.5px;
   line-height: 1.45;
 }
+.hm-rail-tabs {
+  flex: 0 0 auto;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  border-bottom: 1px solid var(--hm-line-soft);
+  background: rgba(255, 253, 247, 0.82);
+}
+.hm-rail-tab {
+  min-width: 0;
+  height: 38px;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: var(--hm-muted);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 12.5px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  cursor: pointer;
+}
+.hm-rail-tab:hover {
+  color: var(--hm-ink);
+  background: var(--hm-rail);
+}
+.hm-rail-tab.is-active {
+  color: var(--hm-ink);
+  background: var(--hm-paper);
+  border-bottom-color: var(--hm-amber);
+}
+.hm-rail-tab-badge {
+  min-width: 17px;
+  height: 17px;
+  padding: 0 5px;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  background: var(--hm-amber-soft);
+  color: var(--hm-amber-deep);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1;
+}
+.hm-rail-tabpanels {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.hm-rail-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.hm-rail-panel--digest {
+  overflow-y: auto;
+  padding: 14px 16px 16px;
+  scrollbar-width: thin;
+  background: linear-gradient(180deg, rgba(250, 248, 241, 0.96), var(--hm-paper-2));
+}
+.hm-rail-panel--digest::-webkit-scrollbar { width: 6px; }
+.hm-rail-panel--digest::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
+.hm-rail-digest {
+  display: grid;
+  gap: 12px;
+}
+.hm-rail-digest-head {
+  display: grid;
+  gap: 2px;
+}
+.hm-rail-digest-head strong {
+  font-family: var(--font-display);
+  font-size: 14px;
+  color: var(--hm-ink);
+}
+.hm-rail-digest-since,
+.hm-rail-digest-note {
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+.hm-rail-digest-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+.hm-rail-digest-stat {
+  min-width: 0;
+  padding: 10px 11px;
+  border-radius: var(--hm-radius-sm);
+  border: 1px solid var(--hm-line);
+  background: var(--hm-paper);
+  display: grid;
+  gap: 2px;
+}
+.hm-rail-digest-value {
+  font-family: var(--font-display);
+  font-size: 22px;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--hm-ink);
+}
+.hm-rail-digest-value[data-tone="act"] { color: var(--hm-amber-deep); }
+.hm-rail-digest-value[data-tone="ok"] { color: var(--hm-sage-deep); }
+.hm-rail-digest-value[data-needs-data="true"] { color: var(--hm-muted-soft); }
+.hm-rail-digest-label {
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.hm-rail-waiting-head {
+  margin-top: 2px;
+  color: var(--hm-muted);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em !important;
+}
+.hm-rail-waiting-list {
+  display: grid;
+  gap: 8px;
+}
+.hm-rail-waiting-card {
+  width: 100%;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: start;
+  padding: 10px 11px;
+  border-radius: var(--hm-radius-sm);
+  border: 1px solid var(--hm-line);
+  background: var(--hm-paper);
+  color: var(--hm-ink);
+  text-align: left;
+  cursor: pointer;
+}
+.hm-rail-waiting-card:hover {
+  border-color: var(--hm-amber);
+  background: var(--hm-paper-3);
+}
+.hm-rail-waiting-card:disabled {
+  cursor: default;
+}
+.hm-rail-waiting-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  margin-top: 5px;
+  background: var(--hm-amber);
+}
+.hm-rail-waiting-main {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+.hm-rail-waiting-main strong {
+  min-width: 0;
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 13px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+.hm-rail-waiting-main small,
+.hm-rail-waiting-rec {
+  min-width: 0;
+  color: var(--hm-muted);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.hm-rail-waiting-rec b {
+  color: var(--hm-muted-soft);
+  font-weight: 700;
+}
+.hm-rail-waiting-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+.hm-rail-waiting-open {
+  color: var(--hm-amber-deep);
+  font-family: var(--font-display);
+  font-size: 11.5px;
+  font-weight: 800;
+  white-space: nowrap;
+  padding-top: 1px;
+}
+.hm-rail-waiting-empty {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 4px;
+  padding: 22px 12px;
+  border: 1px dashed var(--hm-line);
+  border-radius: var(--hm-radius-sm);
+  color: var(--hm-muted);
+  background: rgba(255, 253, 247, 0.56);
+}
+.hm-rail-waiting-empty strong {
+  color: var(--hm-sage-deep);
+  font-family: var(--font-display);
+  font-size: 13px;
+}
+.hm-rail-digest-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+.hm-roster-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+}
+.hm-roster-scrim {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: rgba(15, 18, 20, 0.48);
+  backdrop-filter: blur(2px);
+  cursor: pointer;
+}
+.hm-roster-dialog {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: min(560px, calc(100vw - 28px));
+  max-height: min(720px, calc(100vh - 36px));
+  transform: translate(-50%, -50%);
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius);
+  background: var(--hm-paper);
+  box-shadow: 0 24px 80px rgba(15, 18, 20, 0.32);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.hm-roster-head {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--hm-line-soft);
+}
+.hm-roster-head strong {
+  display: block;
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 16px;
+}
+.hm-roster-head span {
+  display: block;
+  margin-top: 2px;
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.hm-roster-list {
+  overflow-y: auto;
+  display: grid;
+  gap: 9px;
+  padding: 12px 14px 14px;
+}
+.hm-roster-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  padding: 11px 12px;
+  border: 1px solid var(--hm-line);
+  border-radius: var(--hm-radius-sm);
+  background: var(--hm-paper-2);
+}
+.hm-roster-row strong {
+  color: var(--hm-ink);
+  font-family: var(--font-display);
+  font-size: 13px;
+}
+.hm-roster-row p {
+  margin: 4px 0 8px;
+  color: var(--hm-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+.hm-roster-row span:last-child {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
 .hm-hermes-tools {
   margin-left: auto;
   display: flex; gap: 6px;


### PR DESCRIPTION
## What changed & why

- Tabs the Hermes co-pilot rail into Digest and Agent room views, matching the E6 rail direction.
- Adds Digest stat tiles for NEEDS YOU, RUNNING NOW, ADVANCED (SESSION), and PROD CHANGES.
- Keeps unbacked session/product deltas honest with blank values and an explicit honest-until-wired note.
- Adds the waiting-on-you list with per-card recommendation, risk chip, grants chip, and Open action.
- Moves the existing collaboration room behind the Agent room tab while keeping the Ask Hermes composer pinned.
- Adds a Who is who roster for Hermes, Codex, Claude, and Operator responsibilities.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] npm run typecheck
- [x] npm test
- [ ] docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config (only if ops/Docker/compose touched)

## Rollout / rollback

Frontend monitor UI only. No ops, env, secret, migration, or Hermes image changes. Rollback by reverting this PR.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power (new capability ⇒ new allowlist + budget + human approval)
- [x] No secrets committed/printed/logged
- [x] Updated AGENTS.md / affected docs if this changes how agents work

## Known limits / follow-ups

ADVANCED (SESSION) and PROD CHANGES are intentionally blank until a real session delta source is wired. The UI says this directly rather than inventing counts.