### PR TITLE
feat(monitor): add decision card grammar

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -421,7 +421,9 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
-      await waitFor(() => expect(getByRole("button", { name: "Dismiss" })).toBeTruthy());
+      await waitFor(() => expect(getByRole("button", { name: "Choices ↓" })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: "Choices ↓" }));
+      expect(getByRole("button", { name: "Dismiss" })).toBeTruthy();
       fireEvent.click(getByRole("button", { name: "Dismiss" }));
       expect(getByText(/Dismiss this requested tester mission/)).toBeTruthy();
       fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
@@ -480,7 +482,9 @@ describe("MonitorPage — container", () => {
         />,
         { wrapper },
       );
-      await waitFor(() => expect(getByRole("button", { name: "Accept failure" })).toBeTruthy());
+      await waitFor(() => expect(getByRole("button", { name: "Choices ↓" })).toBeTruthy());
+      fireEvent.click(getByRole("button", { name: "Choices ↓" }));
+      expect(getByRole("button", { name: "Accept failure" })).toBeTruthy();
 
       fireEvent.click(getByRole("button", { name: "Accept failure" }));
       expect(getByText(/Accept this failed mission/)).toBeTruthy();

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { cleanup, fireEvent, render, within } from "@testing-library/react";
-import { Card } from "./Card.js";
+import { Card, deriveDecisionCardReason } from "./Card.js";
 import { FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
-import type { BoardCard, PRCard } from "../../lib/monitor/card-types.js";
+import type { BoardCard, MissionCard, PRCard } from "../../lib/monitor/card-types.js";
 
 afterEach(cleanup);
 
@@ -27,7 +27,7 @@ describe("Card — type coverage", () => {
     expect(container.querySelector(".hm-checks-bar")).toBeTruthy();
     // Hermes verdict + CTA
     expect(view.getByText("Hermes verdict")).toBeTruthy();
-    expect(view.getByRole("button", { name: "Approve merge" })).toBeTruthy();
+    expect(view.getByRole("button", { name: "Approve & merge" })).toBeTruthy();
     expect(view.queryByText("Send back to Codex")).toBeNull();
   });
 
@@ -277,7 +277,7 @@ describe("Card — interactivity", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
 
     // Clicking the primary CTA must not also trigger the card's onClick.
-    fireEvent.click(within(container).getByText("Approve merge"));
+    fireEvent.click(within(container).getByText("Approve & merge"));
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onApproveMerge).not.toHaveBeenCalled(); // first click only arms confirm
   });
@@ -336,6 +336,7 @@ describe("Card — task approve (O3 dispatch)", () => {
     const card = {
       ...proposed,
       summary: "dispatch_budget_exhausted then duplicate_signal",
+      waitingOn: { actor: "agent", tone: "info" },
     } as unknown as BoardCard;
     const { getByText, getByTitle, queryByText } = render(<Card card={card} onApprove={vi.fn()} />);
     expect(getByText("Dispatch budget used up — paused until reset")).toBeTruthy();
@@ -421,8 +422,10 @@ describe("Card — requested tester mission approve (T6)", () => {
     );
     expect(getByText("Tester run requested")).toBeTruthy();
     expect(getByText("not started")).toBeTruthy();
+    expect(getByText("Why you're seeing this")).toBeTruthy();
+    expect(getByText("What happens next")).toBeTruthy();
     expect(getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
-    expect(getByRole("button", { name: "Dismiss" })).toBeTruthy();
+    expect(getByRole("button", { name: "Choices ↓" })).toBeTruthy();
   });
 
   test("approving a tester mission requires confirm before dispatching to the runner queue", () => {
@@ -439,6 +442,7 @@ describe("Card — requested tester mission approve (T6)", () => {
   test("dismissing a tester mission requires confirm before clearing the request", () => {
     const onDismissMission = vi.fn();
     const { getByRole, getByText } = render(<Card card={requestedMission} onDismissMission={onDismissMission} />);
+    fireEvent.click(getByRole("button", { name: "Choices ↓" }));
     fireEvent.click(getByRole("button", { name: "Dismiss" }));
     expect(onDismissMission).not.toHaveBeenCalled();
     expect(getByText(/Dismiss this requested tester mission\?/)).toBeTruthy();
@@ -479,15 +483,87 @@ describe("Card — requested tester mission approve (T6)", () => {
       />,
     );
     expect(getByRole("button", { name: "Re-run" })).toBeTruthy();
+    expect(getByRole("button", { name: "Choices ↓" })).toBeTruthy();
+    expect(queryByRole("button", { name: "Accept failure" })).toBeNull();
+    expect(queryByRole("button", { name: "Open issue" })).toBeNull();
+    expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
+    fireEvent.click(getByRole("button", { name: "Choices ↓" }));
     expect(getByRole("button", { name: "Accept failure" })).toBeTruthy();
     expect(getByRole("button", { name: "Open issue" })).toBeTruthy();
-    expect(queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
     fireEvent.click(getByRole("button", { name: "Re-run" }));
     expect(getByText(/Re-run as a fresh mission\?/)).toBeTruthy();
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onRerunMission).toHaveBeenCalledWith(failedMission, "fresh");
     expect(onAcceptMissionFailure).not.toHaveBeenCalled();
     expect(onOpenMissionIssue).not.toHaveBeenCalled();
+  });
+});
+
+describe("Card — decision-card reason derivation (E2)", () => {
+  test("derives policy-store 503 from source failure fields", () => {
+    const card = {
+      ...fixture("agent #548"),
+      sourceFailure: { source: "runner", code: "503", message: "policy-store returned 503 Service Unavailable" },
+    } as BoardCard;
+    expect(deriveDecisionCardReason(card)).toEqual({
+      text: "policy store unavailable (503)",
+      source: "sourceFailure",
+      derived: true,
+    });
+  });
+
+  test("derives timed-out from a structured mission failure", () => {
+    const base = fixture("mission browser-checkout-12") as MissionCard;
+    const card = {
+      ...base,
+      mission: {
+        ...base.mission,
+        blockers: [{ head: "Timeout 30000ms exceeded waiting for navigation" }],
+      },
+    } as BoardCard;
+    expect(deriveDecisionCardReason(card)).toMatchObject({
+      text: "timed out",
+      source: "mission",
+      derived: true,
+    });
+  });
+
+  test("derives blocked age from waiting/freshness when no richer reason exists", () => {
+    const card = {
+      ...fixture("agent #548"),
+      sourceFailure: undefined,
+      decisionRecord: undefined,
+      riskSignals: undefined,
+      verdict: undefined,
+      freshness: 185,
+    } as BoardCard;
+    expect(deriveDecisionCardReason(card)).toEqual({
+      text: "blocked 3h waiting on operator",
+      source: "blockedAge",
+      derived: true,
+    });
+  });
+
+  test("falls back honestly when no reason field exists", () => {
+    const card = {
+      id: "x",
+      lane: "needs-attention",
+      type: "pr",
+      agentType: "codex",
+      title: "No reason",
+      summary: "",
+      repo: "depre-dev/example",
+      freshness: 0,
+      state: "fresh",
+      risk: [],
+      waitingOn: { actor: "operator", tone: "warn" },
+      files: [],
+    } as BoardCard;
+    expect(deriveDecisionCardReason(card)).toEqual({
+      text: "Reason not recorded; open the drawer before acting.",
+      source: "fallback",
+      derived: false,
+    });
   });
 });
 
@@ -506,25 +582,25 @@ describe("Card — archive hint 'Keep watching' (G4)", () => {
 });
 
 describe("Card — decision hoist (P1-2)", () => {
-  test("needs-attention card surfaces the decision summary + top reason in the body", () => {
+  test("needs-attention card surfaces the E2 reason grammar", () => {
     const card = fixture("agent #542"); // needs-attention, has a decisionRecord
     const { container } = render(<Card card={card} />);
-    const block = container.querySelector(".hm-card-decision");
+    const block = container.querySelector(".hm-decision-grammar");
     expect(block).toBeTruthy();
     const view = within(block as HTMLElement);
-    expect(view.getByText("Hermes decided")).toBeTruthy();
-    expect(view.getByText(/Escalated for triage/)).toBeTruthy();
-    // Top reason only — the full reason list stays in the drawer.
+    expect(view.getByText("Why you're seeing this")).toBeTruthy();
     expect(view.getByText(/no reviewer assigned/)).toBeTruthy();
+    // Top reason only — the full reason list stays in the drawer.
     expect(view.queryByText(/no activity for 48h/)).toBeNull();
+    expect(view.getByText("What happens next")).toBeTruthy();
   });
 
-  test("codex-needed card surfaces the decision in the body", () => {
+  test("codex-needed card surfaces the E2 reason grammar", () => {
     const card = fixture("task starter-coding-014"); // codex-needed, has a decisionRecord
     const { container } = render(<Card card={card} />);
-    const block = container.querySelector(".hm-card-decision");
+    const block = container.querySelector(".hm-decision-grammar");
     expect(block).toBeTruthy();
-    expect(within(block as HTMLElement).getByText(/Proposed a bounded Codex task/)).toBeTruthy();
+    expect(within(block as HTMLElement).getByText(/14 near-identical policy-attach entries/)).toBeTruthy();
   });
 
   test("a card without a decision record shows no hoist (no fabricated rationale)", () => {
@@ -557,12 +633,12 @@ describe("Card — decision hoist (P1-2)", () => {
 });
 
 describe("Card — failed mission readable summary", () => {
-  test("renders a clean one-liner, never raw stderr / box-drawing / pipes", () => {
+  test("renders a clean inbox reason, never raw stderr / box-drawing / pipes", () => {
     const card = fixture("mission browser-checkout-12"); // failed mission, raw dump in summary + blocker
     const { container } = render(<Card card={card} />);
-    const meta = container.querySelector(".hm-card-meta");
-    expect(meta).toBeTruthy();
-    const text = meta?.textContent ?? "";
+    const context = container.querySelector(".hm-decision-grammar");
+    expect(context).toBeTruthy();
+    const text = context?.textContent ?? "";
     // Clean, mapped one-liner.
     expect(text).toContain("Mission failed — browser binary not installed");
     // Zero raw noise on the card.
@@ -572,18 +648,16 @@ describe("Card — failed mission readable summary", () => {
     expect(text).not.toContain("ms-playwright");
   });
 
-  test("renders failed tester runs as a compact report, without raw runner output", () => {
+  test("renders failed tester runs as the decision grammar, without raw runner output", () => {
     const card = fixture("mission browser-checkout-12");
     const { container } = render(<Card card={card} />);
-    const run = container.querySelector(".hm-mission-run");
-    expect(run).toBeTruthy();
-    const text = run?.textContent ?? "";
-    expect(within(run as HTMLElement).getByText("Tester run")).toBeTruthy();
-    expect(within(run as HTMLElement).getByText("FAILED 0%")).toBeTruthy();
-    expect(within(run as HTMLElement).getByText("staging.averray.com/checkout")).toBeTruthy();
+    const context = container.querySelector(".hm-decision-grammar");
+    expect(context).toBeTruthy();
+    const text = context?.textContent ?? "";
+    expect(within(context as HTMLElement).getByText("Why you're seeing this")).toBeTruthy();
+    expect(within(context as HTMLElement).getByText("What happens next")).toBeTruthy();
     expect(text).toContain("browser binary not installed");
-    expect(text).toContain("no artifacts captured");
-    expect(text).toContain("No mutation");
+    expect(text).toContain("Re-run starts a fresh mission");
     expect(text).not.toContain("ms-playwright");
     expect(text).not.toContain("npx playwright install");
     expect(text).not.toContain("|");

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -31,7 +31,7 @@ import type {
 } from "../../lib/monitor/card-types.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor, isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
-import { humanizedSignalParts } from "../../lib/monitor/signal-labels.js";
+import { humanizedSignalParts, humanizeSignalText } from "../../lib/monitor/signal-labels.js";
 import { missionFailureCardSummary } from "../../lib/monitor/mission-failure.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
 import { AgentTag, Badge, Button, CardHeader, StatusPill, type StateVariant } from "../ui.js";
@@ -95,6 +95,92 @@ function freshnessVariant(card: BoardCard, isStale: boolean, isClosed: boolean):
   return "neutral";
 }
 
+export interface DecisionCardReason {
+  text: string;
+  source: "sourceFailure" | "mission" | "taskFailure" | "riskSignal" | "decisionRecord" | "verdict" | "blockedAge" | "fallback";
+  derived: boolean;
+}
+
+/** Derive the operator-facing reason from fields the card actually carries.
+ *  No matching source means an explicit unknown, not guessed copy. */
+export function deriveDecisionCardReason(card: BoardCard): DecisionCardReason {
+  if (card.sourceFailure) {
+    return {
+      text: reasonFromText(card.sourceFailure.message, `${card.sourceFailure.source} source failed: ${card.sourceFailure.message}`),
+      source: "sourceFailure",
+      derived: true,
+    };
+  }
+
+  const missionLine = missionFailureCardSummary(card);
+  if (missionLine) {
+    return { text: reasonFromText(missionLine, missionLine), source: "mission", derived: true };
+  }
+
+  const failureReason = "failureReason" in card ? (card as { failureReason?: string }).failureReason : undefined;
+  if (failureReason?.trim()) {
+    return { text: reasonFromText(failureReason, humanizeSignalText(compactSentence(failureReason, 140))), source: "taskFailure", derived: true };
+  }
+
+  const riskSignal = card.riskSignals?.find((signal) => signal.message.trim().length > 0);
+  if (riskSignal) {
+    return { text: humanizeSignalText(compactSentence(riskSignal.message, 150)), source: "riskSignal", derived: true };
+  }
+
+  const decisionReason = card.decisionRecord?.reasons.find((reason) => reason.trim().length > 0);
+  if (decisionReason) {
+    return { text: humanizeSignalText(compactSentence(decisionReason, 150)), source: "decisionRecord", derived: true };
+  }
+
+  const verdict = "verdict" in card ? (card as { verdict?: string }).verdict : undefined;
+  if (verdict?.trim()) {
+    return { text: humanizeSignalText(compactSentence(verdict, 150)), source: "verdict", derived: true };
+  }
+
+  if (card.waitingOn?.actor) {
+    const age = blockedAge(card.freshness);
+    if (age) {
+      return {
+        text: `blocked ${age} waiting on ${card.waitingOn.actor}`,
+        source: "blockedAge",
+        derived: true,
+      };
+    }
+  }
+
+  return {
+    text: "Reason not recorded; open the drawer before acting.",
+    source: "fallback",
+    derived: false,
+  };
+}
+
+function reasonFromText(raw: string, fallback: string): string {
+  if (/policy[-\s]?store|policy store/i.test(raw) && /\b(?:503|service unavailable|unavailable)\b/i.test(raw)) {
+    return /\b503\b/.test(raw) ? "policy store unavailable (503)" : "policy store unavailable";
+  }
+  if (/timed?\s*out|timeout (?:of )?\d|exceeded.*timeout|navigation timeout/i.test(raw)) {
+    return "timed out";
+  }
+  if (/\b(?:blocked|blocker)\b/i.test(raw)) {
+    return humanizeSignalText(compactSentence(raw, 140));
+  }
+  return humanizeSignalText(compactSentence(fallback, 140));
+}
+
+function blockedAge(freshnessMinutes: number): string | undefined {
+  if (!Number.isFinite(freshnessMinutes) || freshnessMinutes <= 0) return undefined;
+  const minutes = Math.max(1, Math.round(freshnessMinutes));
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder >= 15 ? `${hours}h ${remainder}m` : `${hours}h`;
+}
+
+function isInboxDecisionCard(card: BoardCard, isClosed: boolean): boolean {
+  return !isClosed && isWaitingOnOperator(card);
+}
+
 // ── Card ───────────────────────────────────────────────────────────
 
 export function Card({
@@ -113,6 +199,7 @@ export function Card({
   const isAction = laneFor(card) === "needs-attention";
   const isStale = card.state === "stale";
   const isClosed = card.type === "done";
+  const isInboxCard = isInboxDecisionCard(card, isClosed);
 
   const classes = [
     "hm-card",
@@ -159,7 +246,13 @@ export function Card({
 
       <div className="hm-card-title">{card.title}</div>
 
-      {cardSummary && !isClosed ? (
+      {card.repo && !isClosed && isInboxCard ? (
+        <div className="hm-decision-repo hm-mono" title={card.repo}>
+          {card.repo}
+        </div>
+      ) : null}
+
+      {cardSummary && !isClosed && !isInboxCard ? (
         <div className="hm-card-meta" style={{ lineHeight: 1.5 }}>
           <span style={{ color: "var(--hm-ink-soft)", fontFamily: "var(--font-body)", fontSize: 12 }}>
             <HumanizedText text={cardSummary} />
@@ -167,7 +260,7 @@ export function Card({
         </div>
       ) : null}
 
-      {!isClosed && card.type === "mission" ? <MissionRunSummary card={card} /> : null}
+      {!isClosed && card.type === "mission" && !isInboxCard ? <MissionRunSummary card={card} /> : null}
 
       {/* P1-2: hoist the decision onto operator-facing cards. On the two
           lanes where the operator decides (needs-attention, codex-needed),
@@ -176,7 +269,7 @@ export function Card({
           record (all reasons, safety, changed) still lives in the drawer's
           "Why Hermes did this". Renders nothing when there's no decision
           record — never a fabricated rationale. */}
-      {!isClosed && card.decisionRecord && isDecisionLane(card) ? (
+      {!isClosed && card.decisionRecord && isDecisionLane(card) && !isInboxCard ? (
         <>
           <CardDecisionLine record={card.decisionRecord} />
           {/* PR-D3b: the compact Decision-Inbox context — a 1-line grants chip
@@ -190,9 +283,9 @@ export function Card({
         <ReviewRequestedLine card={card} />
       ) : null}
 
-      {!isClosed ? <AgentDiscussion messages={card.discussion} compact /> : null}
+      {!isClosed && !isInboxCard ? <AgentDiscussion messages={card.discussion} compact /> : null}
 
-      {!isClosed && card.workingNow ? <WorkingNowLine workingNow={card.workingNow} /> : null}
+      {!isClosed && card.workingNow && !isInboxCard ? <WorkingNowLine workingNow={card.workingNow} /> : null}
 
       {isClosed && verdictText ? (
         <div className="hm-card-meta">
@@ -208,6 +301,8 @@ export function Card({
           history layout). */}
       {!isClosed ? <CardBadges card={card} /> : null}
 
+      {isInboxCard ? <DecisionCardExplanation card={card} /> : null}
+
       {checks ? (
         <div className="hm-checks">
           <ChecksBar checks={checks} />
@@ -219,7 +314,7 @@ export function Card({
           close-time + verdict only) — they never show a waiting-on line,
           matching the design. Live data still carries a waitingOn on done
           cards, so gate it here rather than relying on the source. */}
-      {!isClosed && card.waitingOn ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
+      {!isClosed && card.waitingOn && !isInboxCard ? <WaitingOnLine waitingOn={card.waitingOn} /> : null}
 
       {card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "requested" ? (
         <div className="hm-waiting hm-waiting--neutral">
@@ -231,6 +326,7 @@ export function Card({
       {!isClosed && card.waitingOn?.actor === "operator" ? (
         <OperatorActions
           card={card}
+          collapsedChoices={isInboxCard}
           onApprove={onApprove}
           onApproveMission={onApproveMission}
           onDismissMission={onDismissMission}
@@ -240,6 +336,8 @@ export function Card({
           onOpenMissionIssue={onOpenMissionIssue}
         />
       ) : null}
+
+      {!isClosed && isInboxCard ? <AgentDiscussion messages={card.discussion} compact /> : null}
 
       {isAction && verdict ? (
         <div className="hm-verdict">
@@ -569,6 +667,46 @@ function DecisionInboxContext({ record }: { record: HermesDecisionRecord }) {
   );
 }
 
+function DecisionCardExplanation({ card }: { card: BoardCard }) {
+  const reason = deriveDecisionCardReason(card);
+  const whatNext = deriveWhatHappensNext(card);
+  return (
+    <div className="hm-decision-grammar" aria-label="Decision context">
+      <div className="hm-decision-grammar-row">
+        <span className="hm-decision-grammar-label">Why you're seeing this</span>
+        <span className={reason.derived ? undefined : "hm-decision-grammar-fallback"}>
+          <HumanizedText text={reason.text} />
+        </span>
+      </div>
+      <div className="hm-decision-grammar-row">
+        <span className="hm-decision-grammar-label">What happens next</span>
+        <span>
+          <HumanizedText text={whatNext} />
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function deriveWhatHappensNext(card: BoardCard): string {
+  const waitingNext = card.decisionRecord?.outcome.waitingNext?.trim();
+  if (waitingNext) return waitingNext;
+  if (card.next?.trim()) return card.next.trim();
+  if (card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "failed") {
+    return "Re-run starts a fresh mission; Accept failure clears this triage card; Open issue files the blocker.";
+  }
+  if (card.type === "mission" && (card as { missionStatus?: string }).missionStatus === "requested") {
+    return "Approval lets the tester runner claim the mission; dismissing leaves it unstarted.";
+  }
+  if (card.type === "task" && (card as { taskStatus?: string }).taskStatus === "proposed") {
+    return "Confirming dispatch queues the task for the selected agent; nothing runs until the confirmation.";
+  }
+  if (card.type === "pr" && (card as { action?: { primary?: string } }).action?.primary) {
+    return "Use the recommended action only after the risk and intent are clear; merge remains human-gated.";
+  }
+  return "Open the drawer for the full state before acting.";
+}
+
 // ── Waiting-on line ────────────────────────────────────────────────
 
 function WaitingOnLine({ waitingOn }: { waitingOn: WaitingOn }) {
@@ -593,6 +731,7 @@ function waitingToneVariant(tone: WaitingOn["tone"]): StateVariant {
 
 function OperatorActions({
   card,
+  collapsedChoices = false,
   onApprove,
   onApproveMission,
   onDismissMission,
@@ -602,6 +741,7 @@ function OperatorActions({
   onOpenMissionIssue,
 }: {
   card: BoardCard;
+  collapsedChoices?: boolean;
   onApprove?: (card: BoardCard) => void;
   onApproveMission?: (card: BoardCard) => void;
   onDismissMission?: (card: BoardCard) => void;
@@ -611,6 +751,7 @@ function OperatorActions({
   onOpenMissionIssue?: (card: BoardCard) => void;
 }) {
   const [confirmingKey, setConfirmingKey] = useState<string | null>(null);
+  const [choicesOpen, setChoicesOpen] = useState(false);
   const agent = agentLabel(card.agentType);
   const stop = (e: { stopPropagation: () => void }) => e.stopPropagation();
   const taskStatus = (card as { taskStatus?: string }).taskStatus;
@@ -700,9 +841,65 @@ function OperatorActions({
             : [];
 
   if (actions.length === 0) return null;
+  const recommendedPrimary = (card as { action?: { primary?: string } }).action?.primary;
+  const recommendedLabel = typeof recommendedPrimary === "string" && recommendedPrimary.trim()
+    ? recommendedPrimary.trim()
+    : undefined;
+  const [primaryAction, ...secondaryActions] = actions;
   const confirming = confirmingKey ? actions.find((action) => action.key === confirmingKey) : undefined;
 
   if (!confirming) {
+    if (collapsedChoices && primaryAction) {
+      return (
+        <div className="hm-card-cta hm-card-cta--operator hm-card-cta--decision" role="group" aria-label="Operator actions">
+          <Button
+            variant={primaryAction.kind === "action" ? "action" : "ghost"}
+            size="sm"
+            title={`${recommendedLabel ?? primaryAction.label} opens a confirmation before running.`}
+            onClick={(e) => {
+              stop(e);
+              setConfirmingKey(primaryAction.key);
+            }}
+          >
+            {recommendedLabel ?? primaryAction.label}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="hm-decision-choices-toggle"
+            aria-expanded={choicesOpen}
+            onClick={(e) => {
+              stop(e);
+              setChoicesOpen((open) => !open);
+            }}
+          >
+            Choices {choicesOpen ? "↑" : "↓"}
+          </Button>
+          {choicesOpen ? (
+            <div className="hm-decision-choices" role="group" aria-label="Alternative choices">
+              {secondaryActions.length > 0 ? (
+                secondaryActions.map((action) => (
+                  <Button
+                    variant={action.kind === "action" ? "action" : "ghost"}
+                    size="sm"
+                    key={action.key}
+                    title={`${action.label} opens a confirmation before running.`}
+                    onClick={(e) => {
+                      stop(e);
+                      setConfirmingKey(action.key);
+                    }}
+                  >
+                    {action.label}
+                  </Button>
+                ))
+              ) : (
+                <span className="hm-decision-choices-empty">No alternate action is wired for this card.</span>
+              )}
+            </div>
+          ) : null}
+        </div>
+      );
+    }
     return (
       <div className="hm-card-cta hm-card-cta--operator hm-card-cta--actions" role="group" aria-label="Operator actions">
         {actions.map((action) => (

--- a/packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
+++ b/packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
@@ -41,32 +41,39 @@ function decisionCard(decisionRecord: HermesDecisionRecord): BoardCard {
   } as unknown as BoardCard;
 }
 
-describe("PR-D3b — compact Decision-Inbox context", () => {
-  test("a read-only decision shows an ok grants chip + 'what happens next'", () => {
+describe("PR-E2 — Decision-Inbox card grammar", () => {
+  test("a decision card shows reason + what-happens-next from the decision record", () => {
     const { container, getByText } = render(<Card card={decisionCard(record())} />);
-    const inbox = container.querySelector(".hm-decision-inbox");
-    expect(inbox).toBeTruthy();
-    const chip = inbox?.querySelector(".h4-badge--gate");
-    expect(chip?.textContent).toMatch(/read-only/);
-    expect(chip?.className).toContain("h4-tone--ok");
+    const context = container.querySelector(".hm-decision-grammar");
+    expect(context).toBeTruthy();
+    expect(getByText(/Why you're seeing this/)).toBeTruthy();
+    expect(getByText(/review-gated surface/)).toBeTruthy();
     expect(getByText(/What happens next/)).toBeTruthy();
     expect(getByText(/Hermes merges and verifies the deploy/)).toBeTruthy();
+    expect(container.querySelector(".hm-decision-inbox")).toBeNull();
   });
 
-  test("a mutating decision names the surfaces it touches with a warn chip", () => {
-    const { container } = render(
+  test("reason copy remains traceable on mutating decisions", () => {
+    const { getByText } = render(
       <Card card={decisionCard(record({ safety: { readOnly: false, mutates: true, mutatesGithub: true, mutatesAverray: true } }))} />
     );
-    const chip = container.querySelector(".hm-decision-inbox .h4-badge--gate");
-    expect(chip?.textContent).toMatch(/mutates GitHub · Averray/);
-    expect(chip?.className).toContain("h4-tone--warn");
+    expect(getByText(/review-gated surface/)).toBeTruthy();
+  });
+
+  test("uses an honest fallback when no reason was recorded", () => {
+    const noReason = record({ reasons: [] });
+    const card = decisionCard(noReason);
+    card.freshness = 0;
+    const { getByText } = render(<Card card={card} />);
+    expect(getByText(/Reason not recorded; open the drawer before acting/)).toBeTruthy();
   });
 
   test("renders no inbox context on a non-decision lane card", () => {
     const card = decisionCard(record());
     (card as { isAction?: boolean }).isAction = false;
     (card as { lane?: string }).lane = "hermes-checking";
+    card.waitingOn = { actor: "CI", tone: "info" };
     const { container } = render(<Card card={card} />);
-    expect(container.querySelector(".hm-decision-inbox")).toBeNull();
+    expect(container.querySelector(".hm-decision-grammar")).toBeNull();
   });
 });

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -159,6 +159,65 @@
 .hm-decision-next { font-size: 11.5px; color: var(--h4-muted); }
 .hm-decision-next .lbl { font-weight: 600; color: var(--h4-ink-2); }
 
+/* ---- E2: Decision-card body grammar ---- */
+.hm-decision-repo {
+  margin-top: 5px;
+  font-size: 11px;
+  color: var(--h4-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-decision-grammar {
+  display: grid;
+  gap: 7px;
+  margin-top: 10px;
+  padding-top: 9px;
+  border-top: 1px solid var(--h4-line-2);
+}
+.hm-decision-grammar-row {
+  display: grid;
+  gap: 3px;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--h4-ink-2);
+}
+.hm-decision-grammar-label {
+  font-family: var(--h4-font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-decision-grammar-fallback {
+  color: var(--h4-muted);
+}
+.hm-card-cta--decision {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+  margin-top: 11px;
+}
+.hm-card-cta--decision .hm-decision-choices {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
+  gap: 6px;
+}
+.hm-decision-choices-toggle {
+  min-width: 86px;
+}
+.hm-decision-choices-empty {
+  grid-column: 1 / -1;
+  padding: 7px 8px;
+  border-radius: var(--h4-r-sm);
+  background: var(--h4-paper-sunken);
+  border: 1px solid var(--h4-line-2);
+  font-size: 11px;
+  color: var(--h4-muted);
+}
+
 /* ---- D3c: agent-room presence tiles ---- */
 .hm-room-presence {
   display: inline-flex;


### PR DESCRIPTION
## What changed
- Reworked operator-waiting inbox cards to follow the E2 grammar: identity/title/repo, existing badges, honest "Why you're seeing this", "What happens next", recommended primary action, and collapsed Choices disclosure.
- Added deriveDecisionCardReason so visible reasons trace to real card fields: source failures, mission failure summaries, task failure reasons, risk signals, decision records, verdicts, or blocked age; otherwise it renders an explicit unknown fallback.
- Updated card/MonitorPage tests for the new Choices disclosure and added reason-derivation coverage for policy-store 503, timeout, blocked age, and fallback cases.

## Checks run
- npm run typecheck
- npm test -- packages/monitor-ui/src/MonitorPage.test.tsx packages/monitor-ui/src/components/cards/Card.test.tsx packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
- npm test

## Surface
- Frontend / monitor UI only.
- No backend, contracts, indexer, Caddy, public site, or env changes.
