### PR TITLE
fix(monitor): make pipeline cards read-only mirrors

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -119,7 +119,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const view = within(container);
     expect(view.getByText("Verify onboarding flow on staging.averray.com")).toBeTruthy();
     expect(view.getByText(/Post-merge verify/)).toBeTruthy();
-    expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
+    expect(view.getAllByText("VERIFIED").length).toBeGreaterThan(0);
   });
 
   test("renders saved suites with run history and dispatches re-runs", () => {
@@ -283,6 +283,57 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const inbox = getByRole("region", { name: "Your decisions lane" });
     expect(inbox).toBeTruthy();
     expect(within(inbox).getByText("Review the settlement risk")).toBeTruthy();
+  });
+
+  test("pipeline cards are read-only mirrors that jump to the matching inbox decision", async () => {
+    const onApproveTask = vi.fn();
+    const board: MonitorBoard = {
+      at: "2026-06-02T08:00:00Z",
+      cards: [{
+        id: "task-action-1",
+        lane: "codex-needed",
+        type: "task",
+        agentType: "codex",
+        title: "Fix the failed mission",
+        summary: "Self-healing proposal awaiting a human dispatch call.",
+        repo: "depre-dev/averray-reference-agent",
+        freshness: 1,
+        state: "fresh",
+        risk: [],
+        waitingOn: { actor: "operator", tone: "warn" },
+        taskStatus: "proposed",
+        prompt: "Fix the failed mission.",
+      }],
+    };
+    const { container, getByRole } = render(
+      <BoardView board={board} status="open" onApproveTask={onApproveTask} keyboard={false} />,
+    );
+
+    const inbox = getByRole("region", { name: "Your decisions lane" });
+    const pipeline = getByRole("region", { name: "Builder tasks lane" });
+    expect(within(inbox).getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
+    expect(within(pipeline).queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
+    expect(within(pipeline).getByText("Fix the failed mission")).toBeTruthy();
+
+    fireEvent.click(within(pipeline).getByRole("button", { name: /Awaiting your decision in inbox.*jump/i }));
+
+    await waitFor(() => {
+      const focused = container.querySelector('[data-inbox-card-id="task-action-1"] .hm-card.is-focused');
+      expect(focused).toBeTruthy();
+      expect(document.activeElement).toBe(focused);
+    });
+  });
+
+  test("HIDE-tier done cards render as VERIFIED read-only mirrors", () => {
+    const board: MonitorBoard = {
+      at: "2026-06-02T08:00:00Z",
+      cards: [doneCard({ id: "done-verified", title: "Merged release checklist" })],
+    };
+    const { getByRole } = render(<BoardView board={board} status="open" keyboard={false} />);
+    const done = getByRole("region", { name: "Done lane" });
+    expect(within(done).getByText("VERIFIED")).toBeTruthy();
+    expect(within(done).queryByText("CLOSED")).toBeNull();
+    expect(within(done).queryByRole("button", { name: /Approve|Re-run|Open issue|Accept failure/ })).toBeNull();
   });
 
   test("calm banner CTA filters to today's done cards and mutes alerts for one hour", () => {
@@ -514,7 +565,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     fireEvent.click(getByRole("button", { name: /^Confirm$/ }));
     expect(onApproveTask).toHaveBeenCalledWith("task-action-1");
 
-    expect(boardLanes(container).getByText("Fix the failed mission")).toBeTruthy();
+    expect(boardLanes(container).getAllByText("Fix the failed mission").length).toBeGreaterThan(0);
   });
 
   test("renders backlog suggestions as a collapsed planner-only rail block", () => {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -25,10 +25,10 @@ import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggesti
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
 import type { MissionSpawnInput, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
-import { CreateTaskForm } from "./CreateTaskForm.js";
 import { StartMissionLauncher } from "./StartMissionLauncher.js";
 import { TestSuitesPanel } from "./TestSuitesPanel.js";
-import { laneFor, isWaitingOnOperator } from "../lib/monitor/lane-rules.js";
+import { laneFor, isWaitingOnOperator, tierFor, type KanbanTier } from "../lib/monitor/lane-rules.js";
+import { inboxCards } from "../lib/monitor/board-columns.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
 import { TopStripDegraded } from "./TopStripDegraded.js";
@@ -37,6 +37,7 @@ import { LanesBar } from "./LanesBar.js";
 import { KanbanBoard } from "./KanbanBoard.js";
 import type { LaneId } from "./Lane.js";
 import { CardRouter } from "./cards/CardRouter.js";
+import { PipelineMirrorCard } from "./PipelineMirrorCard.js";
 import { HermesCheckingBody } from "./HermesCheckingBody.js";
 import { DetailDrawer } from "./drawer/DetailDrawer.js";
 import { missionReportText, type DrawerActionHandlers } from "../lib/monitor/drawer-footer.js";
@@ -92,6 +93,23 @@ function matchesQuery(card: BoardCard, q: string): boolean {
   if (!q) return true;
   const hay = `${card.id} ${card.title} ${card.repo} ${card.branch ?? ""} ${card.summary ?? ""}`.toLowerCase();
   return hay.includes(q);
+}
+
+function scheduleInboxFocus(cardId: string) {
+  if (typeof document === "undefined") return;
+  const focus = () => {
+    const anchors = Array.from(document.querySelectorAll<HTMLElement>("[data-inbox-card-id]"));
+    const anchor = anchors.find((node) => node.dataset.inboxCardId === cardId);
+    if (!anchor) return;
+    anchor.scrollIntoView?.({ block: "nearest", inline: "nearest", behavior: "smooth" });
+    const target = anchor.querySelector<HTMLElement>(".hm-card") ?? anchor;
+    target.focus?.({ preventScroll: true });
+  };
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(() => window.requestAnimationFrame(focus));
+    return;
+  }
+  setTimeout(focus, 0);
 }
 
 export interface BoardViewProps {
@@ -309,9 +327,19 @@ export function BoardView({
     () => LANES.flatMap((lane) => displayGrouped[lane] ?? []),
     [displayGrouped],
   );
+  const inboxIds = useMemo(
+    () => new Set(inboxCards(displayGrouped).map((card) => card.id)),
+    [displayGrouped],
+  );
 
-  // Shared per-card renderer — used directly by most lanes and re-used by the
-  // hermes-checking lane body (P1-1) so unrouted cards still render the same way.
+  const jumpToInbox = useCallback((card: BoardCard) => {
+    setFilter("all");
+    setBoardFocusId(card.id);
+    scheduleInboxFocus(card.id);
+  }, []);
+
+  // Decision Inbox renderer — full CardRouter with action handlers. Pipeline
+  // lanes use read-only mirrors below, so actionable buttons live only here.
   const renderCard = (card: BoardCard) => (
     <CardRouter
       key={card.id}
@@ -331,14 +359,37 @@ export function BoardView({
       onKeepWatching={(c) => onKeepWatchingCard(c.id)}
     />
   );
+  const renderPipelineMirror = useCallback((
+    card: BoardCard,
+    tier: KanbanTier,
+    inboxAvailable: boolean,
+  ) => (
+    <PipelineMirrorCard
+      key={card.id}
+      card={card}
+      tier={tier}
+      focused={card.id === boardFocusId}
+      inboxAvailable={inboxAvailable}
+      onJumpToInbox={jumpToInbox}
+    />
+  ), [boardFocusId, jumpToInbox]);
+  const renderPipelineCard = useCallback((
+    card: BoardCard,
+    context: { tier: KanbanTier; inboxAvailable: boolean },
+  ) => renderPipelineMirror(card, context.tier, context.inboxAvailable), [renderPipelineMirror]);
+  const renderPipelineCardForLane = useCallback((
+    lane: LaneId,
+    card: BoardCard,
+  ) => renderPipelineMirror(card, tierFor(lane), inboxIds.has(card.id)), [inboxIds, renderPipelineMirror]);
   const renderLaneBody = (id: LaneId, laneCards: BoardCard[]) => {
     const groupedItems = groupLaneCards(id, laneCards);
     const hasGroupedCards = groupedItems.some((item) => item.kind === "group");
+    const renderMirror = (card: BoardCard) => renderPipelineCardForLane(id, card);
     if (id === "hermes-checking" && !hasGroupedCards) {
-      return <HermesCheckingBody cards={laneCards} renderCard={renderCard} />;
+      return <HermesCheckingBody cards={laneCards} renderCard={renderMirror} />;
     }
     if (!hasGroupedCards) return undefined;
-    return <GroupedLaneBody items={groupedItems} renderCard={renderCard} />;
+    return <GroupedLaneBody items={groupedItems} renderCard={renderMirror} />;
   };
 
   const drawerCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
@@ -547,12 +598,8 @@ export function BoardView({
             ariaLabel="Kanban lane grid"
             expanded={surfacedExpanded}
             onToggleLane={onToggleLane}
-            renderLaneHeader={
-              onCreateTask
-                ? (lane) => (lane === "codex-needed" ? <CreateTaskForm onCreate={onCreateTask} /> : null)
-                : undefined
-            }
             renderCard={renderCard}
+            renderPipelineCard={renderPipelineCard}
             renderLaneBody={renderLaneBody}
           />
         </div>

--- a/packages/monitor-ui/src/components/HermesCheckingBody.tsx
+++ b/packages/monitor-ui/src/components/HermesCheckingBody.tsx
@@ -20,7 +20,7 @@ import { isUnroutedCard, inflightStatus } from "../lib/monitor/lane-rules.js";
 
 export type HermesCheckingBodyProps = {
   cards: BoardCard[];
-  /** The shared per-card renderer (CardRouter) supplied by BoardView. */
+  /** The per-card renderer supplied by BoardView (pipeline mirror or full card, depending on caller). */
   renderCard: (card: BoardCard) => ReactNode;
 };
 

--- a/packages/monitor-ui/src/components/KanbanBoard.test.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.test.tsx
@@ -6,8 +6,8 @@ import type { BoardCard, Lane } from "../lib/monitor/card-types.js";
 
 afterEach(cleanup);
 
-function card(lane: Lane, id = lane): BoardCard {
-  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor: "agent", tone: "neutral" } } as unknown as BoardCard;
+function card(lane: Lane, id = lane, actor: "operator" | "agent" = "agent"): BoardCard {
+  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor, tone: actor === "operator" ? "warn" : "neutral" } } as unknown as BoardCard;
 }
 function grouped(partial: Partial<Record<Lane, BoardCard[]>>): Record<Lane, BoardCard[]> {
   return {
@@ -21,8 +21,8 @@ const renderCard = (c: BoardCard) => <div className="hm-card" key={c.id}>{c.id}<
 const expandedFor = (...lanes: Lane[]) => new Set<Lane>(lanes);
 
 describe("KanbanBoard", () => {
-  test("renders a hero Decision Inbox holding the DECIDE-tier cards", () => {
-    const g = grouped({ "needs-attention": [card("needs-attention", "act-1")], "codex-needed": [card("codex-needed", "t-1")] });
+  test("renders a hero Decision Inbox holding operator-waiting cards", () => {
+    const g = grouped({ "needs-attention": [card("needs-attention", "act-1", "operator")], "codex-needed": [card("codex-needed", "t-1")] });
     const { container } = render(
       <KanbanBoard grouped={g} expanded={expandedFor("codex-needed")} onToggleLane={() => {}} renderCard={renderCard} />,
     );
@@ -74,7 +74,7 @@ describe("KanbanBoard", () => {
 
   test("the header collapse chevron toggles a pipeline lane (but the inbox has none)", () => {
     const onToggleLane = vi.fn();
-    const g = grouped({ "needs-attention": [card("needs-attention")], "codex-needed": [card("codex-needed")] });
+    const g = grouped({ "needs-attention": [card("needs-attention", "needs-attention", "operator")], "codex-needed": [card("codex-needed")] });
     const { getByRole, queryByRole } = render(
       <KanbanBoard grouped={g} expanded={expandedFor("codex-needed")} onToggleLane={onToggleLane} renderCard={renderCard} />,
     );

--- a/packages/monitor-ui/src/components/KanbanBoard.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.tsx
@@ -2,14 +2,15 @@
 //
 // The Hermes-4 "decision cockpit" layout (docs/design/hermes-4/project/
 // board.jsx + kanban.jsx): a hero DECISION INBOX column ("Your decisions" —
-// the union of every DECIDE-tier card, the single actionable surface), then
+// the union of every operator-waiting card, the single actionable surface), then
 // read-only WATCH / HIDE tier columns in pipeline position. Empty non-gate
 // pipeline lanes hide; gate / collapsed lanes show as reachable vertical rails.
 //
 // This component owns only the column STRUCTURE + chrome (tier eyebrows, count
-// pills, collapse chevrons, rails). Card internals come from the caller's
-// `renderCard` (the existing CardRouter) — richer inbox cards land in later
-// E-PRs. Card membership + visibility live in board-columns.ts (pure, tested).
+// pills, collapse chevrons, rails). Inbox card internals come from the caller's
+// `renderCard` (the existing CardRouter); pipeline lanes may use a separate
+// read-only mirror renderer. Card membership + visibility live in
+// board-columns.ts (pure, tested).
 
 import type { ReactNode } from "react";
 import type { BoardCard, Lane } from "../lib/monitor/card-types.js";
@@ -21,6 +22,7 @@ import {
   tierLabel,
   type BoardColumnDef,
 } from "../lib/monitor/board-columns.js";
+import type { KanbanTier } from "../lib/monitor/lane-rules.js";
 
 export interface KanbanBoardProps {
   /** Lane → card[] grouping from `groupByLane(cards)` (already search/filter-narrowed). */
@@ -31,6 +33,8 @@ export interface KanbanBoardProps {
   onToggleLane: (lane: Lane) => void;
   /** Render a single card (the shared CardRouter renderer). */
   renderCard: (card: BoardCard) => ReactNode;
+  /** Render a read-only pipeline mirror card. Defaults to renderCard for low-level tests. */
+  renderPipelineCard?: (card: BoardCard, context: { tier: KanbanTier; inboxAvailable: boolean }) => ReactNode;
   /** Optional per-lane header content (e.g. the codex-needed create form). */
   renderLaneHeader?: (lane: Lane) => ReactNode;
   /** Optional whole-body renderer for a pipeline lane (grouping). Return undefined for the default. */
@@ -44,11 +48,13 @@ export function KanbanBoard({
   expanded,
   onToggleLane,
   renderCard,
+  renderPipelineCard,
   renderLaneHeader,
   renderLaneBody,
   ariaLabel = "Kanban lane grid",
 }: KanbanBoardProps) {
   const inbox = inboxCards(grouped);
+  const inboxIds = new Set(inbox.map((card) => card.id));
 
   return (
     <div className="hm-kanban scroll-x" role="region" aria-label={ariaLabel}>
@@ -72,6 +78,8 @@ export function KanbanBoard({
             cards={cards}
             onCollapse={() => onToggleLane(lane)}
             renderCard={renderCard}
+            renderPipelineCard={renderPipelineCard}
+            inboxIds={inboxIds}
             laneHeader={renderLaneHeader?.(lane)}
             laneBody={renderLaneBody?.(lane, cards)}
           />
@@ -142,7 +150,11 @@ function InboxColumn({
         {cards.length === 0 ? (
           <EmptyColumn inbox />
         ) : (
-          cards.map((card) => renderCard(card))
+          cards.map((card) => (
+            <div className="hm-inbox-card-anchor" data-inbox-card-id={card.id} key={card.id}>
+              {renderCard(card)}
+            </div>
+          ))
         )}
       </div>
     </section>
@@ -155,6 +167,8 @@ function PipelineColumn({
   cards,
   onCollapse,
   renderCard,
+  renderPipelineCard,
+  inboxIds,
   laneHeader,
   laneBody,
 }: {
@@ -162,10 +176,15 @@ function PipelineColumn({
   cards: BoardCard[];
   onCollapse: () => void;
   renderCard: (card: BoardCard) => ReactNode;
+  renderPipelineCard?: (card: BoardCard, context: { tier: KanbanTier; inboxAvailable: boolean }) => ReactNode;
+  inboxIds: ReadonlySet<string>;
   laneHeader?: ReactNode;
   laneBody?: ReactNode;
 }) {
   const tier = columnTier(col);
+  const renderPipeline = renderPipelineCard
+    ? (card: BoardCard) => renderPipelineCard(card, { tier, inboxAvailable: inboxIds.has(card.id) })
+    : renderCard;
   return (
     <section
       className={`hm-col hm-col--${tier}`}
@@ -181,7 +200,7 @@ function PipelineColumn({
         ) : laneBody !== undefined ? (
           laneBody
         ) : (
-          cards.map((card) => renderCard(card))
+          cards.map((card) => renderPipeline(card))
         )}
       </div>
     </section>

--- a/packages/monitor-ui/src/components/PipelineMirrorCard.tsx
+++ b/packages/monitor-ui/src/components/PipelineMirrorCard.tsx
@@ -1,0 +1,99 @@
+import type { BoardCard } from "../lib/monitor/card-types.js";
+import { isWaitingOnOperator, type KanbanTier } from "../lib/monitor/lane-rules.js";
+import { AgentTag, StatusPill, type StateVariant } from "./ui.js";
+
+export type PipelineMirrorCardProps = {
+  card: BoardCard;
+  tier: KanbanTier;
+  focused?: boolean;
+  inboxAvailable?: boolean;
+  onJumpToInbox?: (card: BoardCard) => void;
+};
+
+function shortId(id: string): string {
+  return id.replace(/^[a-z-]+ /, "");
+}
+
+function statusFor(card: BoardCard, tier: KanbanTier): { label: string; variant: StateVariant } {
+  if (tier === "hide" || card.type === "done") return { label: "VERIFIED", variant: "pass" };
+  if (card.state === "failed-fetch" || card.state === "source-offline") return { label: "SOURCE ISSUE", variant: "degraded" };
+  if (card.state === "stale") return { label: "STALE", variant: "age" };
+  if (card.state === "running") return { label: "RUNNING", variant: "running" };
+  if (card.type === "task" && card.taskStatus) return { label: card.taskStatus.toUpperCase(), variant: taskVariant(card.taskStatus) };
+  if (card.type === "mission" && card.missionStatus) return { label: card.missionStatus.toUpperCase(), variant: missionVariant(card.missionStatus) };
+  if (card.type === "deploy") return { label: deployStatusLabel(card), variant: "running" };
+  if (card.waitingOn?.actor) return { label: `WAITING ON ${card.waitingOn.actor.toUpperCase()}`, variant: "neutral" };
+  return { label: "WATCHING", variant: "neutral" };
+}
+
+function deployStatusLabel(card: Extract<BoardCard, { type: "deploy" }>): string {
+  const current = card.deploySteps?.find((step) => (
+    step.state === "in-progress" || step.state === "current" || step.state === "running"
+  ));
+  return current?.label ?? card.verification?.label ?? "DEPLOYING";
+}
+
+function taskVariant(status: NonNullable<Extract<BoardCard, { type: "task" }>["taskStatus"]>): StateVariant {
+  if (status === "failed" || status === "cancelled") return "fail";
+  if (status === "completed") return "pass";
+  if (status === "running") return "running";
+  return "pending";
+}
+
+function missionVariant(status: NonNullable<Extract<BoardCard, { type: "mission" }>["missionStatus"]>): StateVariant {
+  if (status === "failed") return "fail";
+  if (status === "completed") return "pass";
+  if (status === "running") return "running";
+  if (status === "requested") return "pending";
+  return "neutral";
+}
+
+export function PipelineMirrorCard({
+  card,
+  tier,
+  focused = false,
+  inboxAvailable = false,
+  onJumpToInbox,
+}: PipelineMirrorCardProps) {
+  const status = statusFor(card, tier);
+  const canJump = inboxAvailable && isWaitingOnOperator(card) && onJumpToInbox;
+  const classes = [
+    "hm-pipeline-card",
+    tier === "hide" ? "hm-pipeline-card--verified" : "",
+    isWaitingOnOperator(card) ? "is-awaiting-inbox" : "",
+    focused ? "is-focused" : "",
+  ].filter(Boolean).join(" ");
+
+  return (
+    <article
+      className={classes}
+      data-pipeline-card-id={card.id}
+      data-h4-tier={tier}
+      aria-label={`${card.agentType} ${shortId(card.id)} — ${card.title}`}
+    >
+      <div className="hm-pipeline-card-head">
+        <AgentTag agent={card.agentType} identifier={shortId(card.id)} className="hm-pipeline-card-id hm-mono" />
+        <StatusPill variant={status.variant} dot className="hm-pipeline-card-status">
+          {status.label}
+        </StatusPill>
+      </div>
+      <div className="hm-pipeline-card-title">{card.title}</div>
+      <div className="hm-pipeline-card-meta">
+        <span className="hm-pipeline-card-repo">{card.repo}</span>
+      </div>
+      {canJump ? (
+        <button
+          type="button"
+          className="hm-pipeline-card-jump"
+          onClick={(event) => {
+            event.stopPropagation();
+            onJumpToInbox(card);
+          }}
+        >
+          <span>Awaiting your decision in inbox</span>
+          <strong>jump ›</strong>
+        </button>
+      ) : null}
+    </article>
+  );
+}

--- a/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./board-columns.js";
 import type { BoardCard, Lane } from "./card-types.js";
 
-function card(lane: Lane, id = lane): BoardCard {
-  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor: "agent", tone: "neutral" } } as unknown as BoardCard;
+function card(lane: Lane, id = lane, actor: "operator" | "agent" = "agent"): BoardCard {
+  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor, tone: actor === "operator" ? "warn" : "neutral" } } as unknown as BoardCard;
 }
 
 function grouped(partial: Partial<Record<Lane, BoardCard[]>>): Record<Lane, BoardCard[]> {
@@ -64,19 +64,19 @@ describe("columnTier / tierLabel", () => {
 });
 
 describe("inboxCards", () => {
-  it("unions every DECIDE-tier lane's cards (currently needs-attention)", () => {
+  it("unions every operator-waiting card exactly once, including pipeline mirrors", () => {
     const g = grouped({
-      "needs-attention": [card("needs-attention", "a1"), card("needs-attention", "a2")],
-      "operator-review": [card("operator-review", "o1")],
+      "needs-attention": [card("needs-attention", "a1", "operator"), card("needs-attention", "a2", "operator")],
+      "operator-review": [card("operator-review", "o1", "operator")],
+      "codex-needed": [card("codex-needed", "t1", "agent")],
     });
     const ids = inboxCards(g).map((c) => c.id);
-    expect(ids).toEqual(["a1", "a2"]);
-    // operator-review is WATCH-tier → not folded into the inbox.
-    expect(ids).not.toContain("o1");
+    expect(ids).toEqual(["a1", "a2", "o1"]);
+    expect(ids).not.toContain("t1");
   });
 
-  it("is empty when no decide-tier card exists", () => {
-    expect(inboxCards(grouped({ done: [card("done")] }))).toEqual([]);
+  it("is empty when no card waits on the operator", () => {
+    expect(inboxCards(grouped({ done: [card("done", "done", "agent")] }))).toEqual([]);
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/board-columns.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.ts
@@ -3,7 +3,7 @@
 // The Hermes-4 "decision cockpit" replaces the flat 8-lane render with an
 // inbox-first column layout (docs/design/hermes-4/project/board.jsx +
 // kanban.jsx): a hero DECISION INBOX column holding the union of every card
-// in a DECIDE-tier lane (the one actionable surface), then read-only WATCH /
+// waiting on the operator (the one actionable surface), then read-only WATCH /
 // HIDE tier columns in pipeline position.
 //
 // This module is the pure mapping layer — the lane→column metadata (design
@@ -14,7 +14,7 @@
 
 import type { BoardCard, Lane } from "./card-types.js";
 import { LANES } from "./card-types.js";
-import { tierFor, type KanbanTier } from "./lane-rules.js";
+import { isWaitingOnOperator, tierFor, type KanbanTier } from "./lane-rules.js";
 
 export interface BoardColumnDef {
   /** Stable column key (the lane id for pipeline columns; "inbox" for the hero). */
@@ -60,12 +60,24 @@ export function tierLabel(tier: KanbanTier): string {
 }
 
 /**
- * The Decision Inbox holds the union of every card in a DECIDE-tier lane — the
- * single place to act. With the current tier map that's `needs-attention`, but
- * deriving it from `tierFor` keeps it correct if the tier of a lane changes.
+ * The Decision Inbox holds every card genuinely waiting on the human operator
+ * — the single place to act. Most operator-waiting cards are promoted into
+ * `needs-attention` by laneFor(), but cards can still mirror in pipeline lanes
+ * (operator-review / codex-needed) while they await a decision; include them
+ * here exactly once so pipeline "jump to inbox" links always target a real
+ * actionable card.
  */
 export function inboxCards(grouped: Partial<Record<Lane, BoardCard[]>>): BoardCard[] {
-  return LANES.filter((lane) => tierFor(lane) === "decide").flatMap((lane) => grouped[lane] ?? []);
+  const seen = new Set<string>();
+  const out: BoardCard[] = [];
+  for (const lane of LANES) {
+    for (const card of grouped[lane] ?? []) {
+      if (!isWaitingOnOperator(card) || seen.has(card.id)) continue;
+      seen.add(card.id);
+      out.push(card);
+    }
+  }
+  return out;
 }
 
 export type ColumnVisibility = "hidden" | "rail" | "column";

--- a/packages/monitor-ui/src/styles/hermes4-kanban.css
+++ b/packages/monitor-ui/src/styles/hermes4-kanban.css
@@ -110,6 +110,114 @@
   gap: var(--h4-gap-cards);
   overflow-y: auto;
 }
+.hm-inbox-card-anchor {
+  display: contents;
+}
+
+/* ---- read-only pipeline mirrors (PR-E3) ---- */
+.hm-pipeline-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border-radius: var(--h4-r-sm);
+  border: 1px solid var(--h4-line);
+  background: var(--h4-paper);
+  box-shadow: 0 1px 0 rgba(19, 24, 21, 0.04);
+}
+.hm-pipeline-card.is-focused {
+  outline: 2px solid var(--h4-act-line);
+  outline-offset: 2px;
+}
+.hm-pipeline-card.is-awaiting-inbox {
+  border-color: var(--h4-act-line);
+  background: var(--h4-tier-decide-bg);
+}
+.hm-pipeline-card--verified {
+  border-color: var(--h4-line-2);
+  background: var(--h4-surface);
+}
+.hm-pipeline-card-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.hm-pipeline-card-id,
+.hm-pipeline-card-status {
+  min-width: 0;
+}
+.hm-pipeline-card-id .hm-agent-tag-id,
+.hm-pipeline-card-id .hm-agent-tag-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-pipeline-card-status {
+  max-width: 132px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--h4-font-display);
+  font-size: 9.5px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+.hm-pipeline-card-title {
+  color: var(--h4-ink);
+  font-family: var(--h4-font-body);
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.hm-pipeline-card-meta {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  color: var(--h4-muted);
+  font-family: var(--h4-font-display);
+  font-size: 10.5px;
+  font-weight: 650;
+}
+.hm-pipeline-card-repo {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-pipeline-card-jump {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 30px;
+  padding: 7px 9px;
+  border-radius: 7px;
+  border: 1px solid var(--h4-act-line);
+  background: var(--h4-act);
+  color: var(--h4-act-ink);
+  cursor: pointer;
+  font-family: var(--h4-font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+}
+.hm-pipeline-card-jump span,
+.hm-pipeline-card-jump strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-pipeline-card-jump strong {
+  flex: none;
+  text-transform: uppercase;
+}
+.hm-pipeline-card-jump:hover {
+  filter: brightness(0.96);
+}
 
 /* ---- empty state ---- */
 .hm-col-empty {


### PR DESCRIPTION
## What changed & why

- Added compact read-only pipeline mirror cards for WATCH/HIDE lanes: identity, title, repo, and honest status only.
- Kept full actionable CardRouter cards in the Decision Inbox, with pipeline mirrors showing only "Awaiting your decision in inbox · jump ›" when an inbox twin exists.
- Updated the inbox union to include every operator-waiting card exactly once, so jump-to-inbox has a truthful target.
- HIDE/Done cards now render as VERIFIED mirrors in the pipeline.

## Affected surfaces
- [ ] MCP servers (averray / wallet / receipt / trace / policy)
- [x] Monitor board / slack-operator
- [ ] Worker runners / task queue
- [ ] ops / compose / Dockerfile / Hermes image pin
- [ ] Database migrations
- [ ] Secrets / config / env
- [ ] Docs / tests only

## Checks run
- [x] `npm run typecheck`
- [x] `npm test`
- [ ] `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` (only if ops/Docker/compose touched)
- [x] `npm run build --workspace @avg/monitor-ui`
- [x] Local browser smoke: Vite app loaded at http://127.0.0.1:5174 with no console errors; no live monitor backend was available locally, so card-rich E3 behavior is covered by fixture DOM tests.

## Rollout / rollback

Frontend-only monitor UI change. Rollback by reverting this PR; no env, secrets, DB, Docker, or ops changes.

## Durable invariants (AGENTS.md)
- [x] No auto-merge / auto-deploy — a human still owns the gate
- [x] Wallet remains testnet-only; HALT_FILE honored; no new ungated agent power
- [x] No secrets committed/printed/logged
- [x] Updated AGENTS.md / affected docs if this changes how agents work

## Known limits / follow-ups

- This PR intentionally does not redesign lane grouping or the deploy stepper. It only makes lane cards read-only mirrors and moves decisions to the inbox.