### PR TITLE
fix(monitor): single source of truth for "operator decision" — isDecision (PR-F1)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -681,9 +681,11 @@ describe("BoardView — filter chips (G1)", () => {
     expect(doneChip.tagName).toBe("BUTTON");
     fireEvent.click(doneChip);
 
-    // The live action card is filtered out; done-lane (CLOSED) cards remain.
+    // The live action card is filtered out; done-lane cards remain as passive
+    // VERIFIED mirrors (PR-F1: finished cards no longer leak into the inbox as
+    // "CLOSED" decisions — they show only in the read-only Done column).
     expect(view.queryByText("Allow operator override of agent claim-stake floor")).toBeNull();
-    expect(view.getAllByText("CLOSED").length).toBeGreaterThan(0);
+    expect(view.getAllByText("VERIFIED").length).toBeGreaterThan(0);
     expect(doneChip.getAttribute("aria-pressed")).toBe("true");
 
     // Clicking "All" restores the full board.

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -27,7 +27,7 @@ import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card
 import type { MissionSpawnInput, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
 import { StartMissionLauncher } from "./StartMissionLauncher.js";
 import { TestSuitesPanel } from "./TestSuitesPanel.js";
-import { laneFor, isWaitingOnOperator, tierFor, type KanbanTier } from "../lib/monitor/lane-rules.js";
+import { laneFor, isDecision, tierFor, type KanbanTier } from "../lib/monitor/lane-rules.js";
 import { inboxCards } from "../lib/monitor/board-columns.js";
 import { relatedPrForCard } from "../lib/monitor/collaboration.js";
 import { TopStrip } from "./TopStrip.js";
@@ -677,7 +677,9 @@ export function BoardView({
  */
 function BoardFooter({ cards }: { cards: readonly BoardCard[] }) {
   const total = cards.length;
-  const waiting = cards.filter((c) => isWaitingOnOperator(c)).length;
+  // PR-F1: the footer "waiting on you" uses the shared isDecision predicate so
+  // it agrees with the inbox, rail count, and banner (no release-history leak).
+  const waiting = cards.filter((c) => isDecision(c)).length;
   const running = cards.filter((c) => c.state === "running").length;
   return (
     <footer className="h4-board-footer" aria-label="Board footer">

--- a/packages/monitor-ui/src/components/KanbanBoard.test.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.test.tsx
@@ -7,7 +7,9 @@ import type { BoardCard, Lane } from "../lib/monitor/card-types.js";
 afterEach(cleanup);
 
 function card(lane: Lane, id = lane, actor: "operator" | "agent" = "agent"): BoardCard {
-  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor, tone: actor === "operator" ? "warn" : "neutral" } } as unknown as BoardCard;
+  // A needs-attention card is isAction (laneFor promotes it there) — that's what
+  // makes it a real operator decision under the canonical isDecision predicate.
+  return { id, lane, type: "pr", state: "fresh", isAction: lane === "needs-attention", waitingOn: { actor, tone: actor === "operator" ? "warn" : "neutral" } } as unknown as BoardCard;
 }
 function grouped(partial: Partial<Record<Lane, BoardCard[]>>): Record<Lane, BoardCard[]> {
   return {

--- a/packages/monitor-ui/src/components/PipelineMirrorCard.tsx
+++ b/packages/monitor-ui/src/components/PipelineMirrorCard.tsx
@@ -1,5 +1,5 @@
 import type { BoardCard } from "../lib/monitor/card-types.js";
-import { isWaitingOnOperator, type KanbanTier } from "../lib/monitor/lane-rules.js";
+import { isDecision, type KanbanTier } from "../lib/monitor/lane-rules.js";
 import { AgentTag, StatusPill, type StateVariant } from "./ui.js";
 
 export type PipelineMirrorCardProps = {
@@ -56,11 +56,15 @@ export function PipelineMirrorCard({
   onJumpToInbox,
 }: PipelineMirrorCardProps) {
   const status = statusFor(card, tier);
-  const canJump = inboxAvailable && isWaitingOnOperator(card) && onJumpToInbox;
+  // PR-F1: the "jump to inbox" affordance + "awaiting" treatment use the shared
+  // isDecision predicate, so a mirror only points to the inbox when the card is
+  // genuinely there. Finished release-history cards (no live decision) stay
+  // passive — no broken jump to a card the inbox no longer holds.
+  const canJump = inboxAvailable && isDecision(card) && onJumpToInbox;
   const classes = [
     "hm-pipeline-card",
     tier === "hide" ? "hm-pipeline-card--verified" : "",
-    isWaitingOnOperator(card) ? "is-awaiting-inbox" : "",
+    isDecision(card) ? "is-awaiting-inbox" : "",
     focused ? "is-focused" : "",
   ].filter(Boolean).join(" ");
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
@@ -22,8 +22,8 @@ function card(over: Record<string, unknown>): BoardCard {
 describe("PR-D3d — rail Hermes digest", () => {
   test("shows real needs-you / running counts and an honest awaiting-data since-marker", () => {
     const cards = [
-      card({ id: "operator-waiting", waitingOn: { actor: "operator", tone: "warn" } }),
-      card({ id: "action-card", isAction: true }),
+      card({ id: "operator-waiting", lane: "operator-review", waitingOn: { actor: "operator", tone: "warn" } }),
+      card({ id: "action-card", isAction: true, waitingOn: { actor: "operator", tone: "warn" } }),
       card({ id: "running-card", state: "running" }),
     ];
     const { container } = render(<CoPilotRail boardCards={cards} collaboration={{ enabled: false }} />, { wrapper });

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -18,7 +18,7 @@ import {
 import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useCollaboration.js";
 import { derivePresence, activeCount, type PresencePeer } from "../../lib/monitor/presence.js";
 import { railDigestCounts } from "../../lib/monitor/rail-digest.js";
-import { isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
+import { isDecision } from "../../lib/monitor/lane-rules.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
 import { HermesTurn } from "./HermesTurn.js";
@@ -349,7 +349,9 @@ function RailDigest({
   onOpenRoster: () => void;
 }) {
   const { needsYou, running } = railDigestCounts(cards);
-  const waiting = cards.filter(isWaitingOnOperator);
+  // PR-F1: the rail "WAITING ON YOU" list shares the isDecision predicate with
+  // the count (railDigestCounts) and the inbox — no release-history leak.
+  const waiting = cards.filter(isDecision);
   return (
     <section className="hm-rail-digest" aria-label="Hermes digest">
       <div className="hm-rail-digest-head">

--- a/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
@@ -10,7 +10,13 @@ import {
 import type { BoardCard, Lane } from "./card-types.js";
 
 function card(lane: Lane, id = lane, actor: "operator" | "agent" = "agent"): BoardCard {
-  return { id, lane, type: "pr", state: "fresh", waitingOn: { actor, tone: actor === "operator" ? "warn" : "neutral" } } as unknown as BoardCard;
+  // A needs-attention card is isAction (laneFor promotes it there) — that's what
+  // makes it a real operator decision under the canonical isDecision predicate.
+  return {
+    id, lane, type: "pr", state: "fresh",
+    isAction: lane === "needs-attention",
+    waitingOn: { actor, tone: actor === "operator" ? "warn" : "neutral" },
+  } as unknown as BoardCard;
 }
 
 function grouped(partial: Partial<Record<Lane, BoardCard[]>>): Record<Lane, BoardCard[]> {
@@ -73,6 +79,22 @@ describe("inboxCards", () => {
     const ids = inboxCards(g).map((c) => c.id);
     expect(ids).toEqual(["a1", "a2", "o1"]);
     expect(ids).not.toContain("t1");
+  });
+
+  it("excludes done / verified / closed release-history cards (PR-F1 truth-boundary)", () => {
+    // A finished codex card that still carries an operator/isAction flag must
+    // never appear in the inbox — it's release history, not a live decision.
+    const finished = {
+      id: "rel-1", lane: "needs-attention", type: "done", state: "fresh",
+      isAction: true, closedAt: "5/27/2026", mergeStatus: "MERGED",
+      waitingOn: { actor: "operator", tone: "warn" },
+    } as unknown as BoardCard;
+    const g = grouped({
+      "needs-attention": [card("needs-attention", "live-1", "operator"), finished],
+    });
+    const ids = inboxCards(g).map((c) => c.id);
+    expect(ids).toEqual(["live-1"]);
+    expect(ids).not.toContain("rel-1");
   });
 
   it("is empty when no card waits on the operator", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-columns.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.ts
@@ -14,7 +14,7 @@
 
 import type { BoardCard, Lane } from "./card-types.js";
 import { LANES } from "./card-types.js";
-import { isWaitingOnOperator, tierFor, type KanbanTier } from "./lane-rules.js";
+import { isDecision, tierFor, type KanbanTier } from "./lane-rules.js";
 
 export interface BoardColumnDef {
   /** Stable column key (the lane id for pipeline columns; "inbox" for the hero). */
@@ -60,19 +60,20 @@ export function tierLabel(tier: KanbanTier): string {
 }
 
 /**
- * The Decision Inbox holds every card genuinely waiting on the human operator
- * — the single place to act. Most operator-waiting cards are promoted into
+ * The Decision Inbox holds every card that's a real operator decision
+ * (`isDecision`, PR-F1) — the single place to act. Most are promoted into
  * `needs-attention` by laneFor(), but cards can still mirror in pipeline lanes
  * (operator-review / codex-needed) while they await a decision; include them
  * here exactly once so pipeline "jump to inbox" links always target a real
- * actionable card.
+ * actionable card. `isDecision` excludes done / verified / closed release
+ * history, so the hero never inflates with finished work.
  */
 export function inboxCards(grouped: Partial<Record<Lane, BoardCard[]>>): BoardCard[] {
   const seen = new Set<string>();
   const out: BoardCard[] = [];
   for (const lane of LANES) {
     for (const card of grouped[lane] ?? []) {
-      if (!isWaitingOnOperator(card) || seen.has(card.id)) continue;
+      if (!isDecision(card) || seen.has(card.id)) continue;
       seen.add(card.id);
       out.push(card);
     }

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -7,7 +7,7 @@
 // Per §5/§16 of docs/HERMES_MONITOR_REDESIGN_SPEC.md.
 
 import type { BoardCard, Lane } from "./card-types.js";
-import { groupByLane, laneCounts, laneFor } from "./lane-rules.js";
+import { groupByLane, laneCounts, laneFor, isDecision } from "./lane-rules.js";
 import { formatFreshness, sortByUrgency } from "./urgency.js";
 
 /** The state a LanesBar filter chip narrows the board to. */
@@ -112,7 +112,11 @@ export function kpiCounts(cards: BoardCard[]): KPICounts {
     counts["release-queue"] +
     counts["deploying"];
   return {
-    action: counts["needs-attention"],
+    // PR-F1: the action count is the real operator-decision count (isDecision),
+    // NOT the needs-attention lane size — so done/verified release-history cards
+    // that linger in the lane never inflate it. Drives the banner, board mode,
+    // and the TopStrip "action needed" pill, which now agree with the inbox/rail.
+    action: Array.isArray(cards) ? cards.filter(isDecision).length : 0,
     codex: counts["codex-needed"],
     review: counts["operator-review"],
     checking: counts["hermes-checking"],
@@ -142,7 +146,7 @@ export function boardMode(cards: BoardCard[], opts: DeriveBoardOpts = {}): Board
   if (!Array.isArray(cards) || cards.length === 0) return "calm";
   const counts = kpiCounts(cards);
   if (counts.blocked > 0) return "degraded";
-  if (opts.hermesFocusCardId && cards.some((card) => card.id === opts.hermesFocusCardId && isPendingReviewCard(card))) {
+  if (opts.hermesFocusCardId && cards.some((card) => card.id === opts.hermesFocusCardId && isDecision(card))) {
     return "hermes-focus";
   }
   if (counts.action > 0) return "action";
@@ -248,11 +252,10 @@ function calmSub(counts: KPICounts, metrics?: CalmBoardMetrics): string {
 }
 
 function pendingReviewCount(cards: BoardCard[]): number {
-  return cards.filter(isPendingReviewCard).length || 1;
-}
-
-function isPendingReviewCard(card: BoardCard): boolean {
-  return card.waitingOn?.actor === "operator" && (card.lane === "operator-review" || card.isAction === true);
+  // PR-F1: the shared isDecision predicate is the single source of truth (it
+  // also excludes done/verified/closed). The `|| 1` floor only applies in the
+  // hermes-focus prose, where a card is by definition under review.
+  return cards.filter(isDecision).length || 1;
 }
 
 function suggestedActionFor(card: BoardCard): string {

--- a/packages/monitor-ui/src/lib/monitor/lane-rules.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/lane-rules.test.ts
@@ -3,7 +3,7 @@
 
 import { test, assert } from "vitest";
 
-import { laneFor, groupByLane, laneCounts, isUnroutedCard, inflightStatus } from "./lane-rules.js";
+import { laneFor, groupByLane, laneCounts, isUnroutedCard, inflightStatus, isDecision, isFinishedCard } from "./lane-rules.js";
 import { LANES } from "./card-types.js";
 
 // ── Test fixtures ───────────────────────────────────────────────────
@@ -298,4 +298,33 @@ test("laneCounts: mixed input returns correct per-lane totals", () => {
   assert.equal(result["hermes-checking"], 0);
   assert.equal(result["release-queue"], 0);
   assert.equal(result["deploying"], 0);
+});
+
+// ── PR-F1: isFinishedCard + isDecision (single source of truth) ──────
+
+test("isFinishedCard: done / closed / merged release history", () => {
+  assert.equal(isFinishedCard(prCard({ type: "done" })), true);
+  assert.equal(isFinishedCard(prCard({ closedAt: "5/27/2026" })), true);
+  assert.equal(isFinishedCard(prCard({ mergeStatus: "MERGED" })), true);
+  assert.equal(isFinishedCard(prCard({ mergeStatus: "CLOSED" })), true);
+  assert.equal(isFinishedCard(prCard()), false);
+  assert.equal(isFinishedCard(null), false);
+});
+
+test("isDecision: a real operator decision (operator-review PR or isAction)", () => {
+  assert.equal(isDecision(prCard({ lane: "operator-review", waitingOn: { actor: "operator" } })), true);
+  assert.equal(isDecision(prCard({ lane: "needs-attention", isAction: true, waitingOn: { actor: "operator" } })), true);
+  // operator-owned proposed task in codex-needed (isAction:false) is still a decision
+  assert.equal(isDecision(prCard({ type: "task", lane: "codex-needed", waitingOn: { actor: "operator" } })), true);
+});
+
+test("isDecision: not waiting on the operator → not a decision", () => {
+  assert.equal(isDecision(prCard({ lane: "hermes-checking", isAction: false, waitingOn: { actor: "CI" } })), false);
+  assert.equal(isDecision(null), false);
+});
+
+test("isDecision: finished release history is never a decision, even with a stale operator/isAction flag", () => {
+  // The "keep as release history; no board action needed" leak (truth-boundary).
+  assert.equal(isDecision(prCard({ type: "done", isAction: true, waitingOn: { actor: "operator" }, closedAt: "5/27/2026", mergeStatus: "MERGED" })), false);
+  assert.equal(isDecision(prCard({ mergeStatus: "MERGED", waitingOn: { actor: "operator" } })), false);
 });

--- a/packages/monitor-ui/src/lib/monitor/lane-rules.ts
+++ b/packages/monitor-ui/src/lib/monitor/lane-rules.ts
@@ -70,6 +70,44 @@ export function isWaitingOnOperator(card: BoardCard | undefined | null): boolean
   return card.isAction === true || card.waitingOn?.actor === "operator";
 }
 
+/**
+ * A finished card — done / verified / closed release history. These are never
+ * operator decisions even when they still carry an `isAction` / operator-waiting
+ * flag left over from their active life (the "keep as release history; no board
+ * action needed" codex cards), so the decision predicate excludes them.
+ */
+export function isFinishedCard(card: BoardCard | undefined | null): boolean {
+  if (!card) return false;
+  if (card.type === "done") return true;
+  const c = card as { closedAt?: string | null; mergeStatus?: string | null };
+  return c.closedAt != null || c.mergeStatus != null;
+}
+
+/**
+ * PR-F1 — THE single definition of "a card waiting on an operator decision":
+ * the one actionable surface. Every decision surface (the Decision Inbox
+ * membership, the rail "WAITING ON YOU" list + count, the banner / KPI action
+ * count, the footer "waiting on you", the pipeline "jump to inbox" mirror) must
+ * use this predicate so they can never disagree again.
+ *
+ * "Waiting on the operator" = isAction (a needs-attention promotion) OR an
+ * explicit operator owner — this matches the design's inbox filter
+ * (`waitingOn === 'operator'`) and the cards that are genuinely actionable from
+ * the inbox today (operator-review PRs, operator-owned proposed tasks/missions
+ * awaiting dispatch). The narrower `(operator-review || isAction)` form in
+ * board-state was the banner's *pending-review* notion and would wrongly drop
+ * operator-owned proposed tasks, so it is NOT the decision predicate.
+ *
+ * The truth-boundary fix is the exclusion: a finished done/verified/closed card
+ * is never a decision even when it still carries a stale operator/isAction flag
+ * (the "keep as release history; no board action needed" leak).
+ */
+export function isDecision(card: BoardCard | undefined | null): boolean {
+  if (!card) return false;
+  if (isFinishedCard(card)) return false;
+  return isWaitingOnOperator(card);
+}
+
 export type InflightStatus = "Pre-check" | "CI watching" | "Mission running";
 
 /**

--- a/packages/monitor-ui/src/lib/monitor/rail-digest.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/rail-digest.test.ts
@@ -7,13 +7,22 @@ function c(over: Record<string, unknown>): BoardCard {
 }
 
 describe("railDigestCounts", () => {
-  it("counts needs-you from operator-waiting / action cards", () => {
+  it("counts needs-you from real operator decisions only (PR-F1 isDecision)", () => {
     const counts = railDigestCounts([
-      c({ waitingOn: { actor: "operator", tone: "warn" } }),
-      c({ isAction: true }),
-      c({ waitingOn: { actor: "CI", tone: "info" } }),
+      c({ lane: "operator-review", waitingOn: { actor: "operator", tone: "warn" } }), // decision
+      c({ isAction: true, waitingOn: { actor: "operator", tone: "warn" } }),          // decision
+      c({ waitingOn: { actor: "CI", tone: "info" } }),                                 // not a decision
     ]);
     expect(counts.needsYou).toBe(2);
+  });
+
+  it("excludes done / verified / closed release history from the count (truth-boundary)", () => {
+    const counts = railDigestCounts([
+      c({ isAction: true, waitingOn: { actor: "operator", tone: "warn" } }),
+      // finished release-history card that still carries the operator flag
+      c({ type: "done", isAction: true, closedAt: "5/27/2026", mergeStatus: "MERGED", waitingOn: { actor: "operator", tone: "warn" } }),
+    ]);
+    expect(counts.needsYou).toBe(1);
   });
 
   it("counts running from state, mission status, or workingNow", () => {

--- a/packages/monitor-ui/src/lib/monitor/rail-digest.ts
+++ b/packages/monitor-ui/src/lib/monitor/rail-digest.ts
@@ -7,7 +7,7 @@
 // awaiting-data, never a fabricated count. Pure + deterministic.
 
 import type { BoardCard } from "./card-types.js";
-import { isWaitingOnOperator } from "./lane-rules.js";
+import { isDecision } from "./lane-rules.js";
 
 export interface RailDigestCounts {
   /** Cards awaiting the operator's decision (the DECIDE inbox). */
@@ -27,7 +27,7 @@ export function railDigestCounts(cards: readonly BoardCard[]): RailDigestCounts 
   let needsYou = 0;
   let running = 0;
   for (const card of cards) {
-    if (isWaitingOnOperator(card)) needsYou += 1;
+    if (isDecision(card)) needsYou += 1;
     if (isRunning(card)) running += 1;
   }
   return { needsYou, running };


### PR DESCRIPTION
## What

**PR-F1 — the keystone of the cockpit-correctness wave.** Today the inbox, the rail "WAITING ON YOU" count/list, the banner, the footer, and the TopStrip each compute "an operator decision" differently, so the board shows **~9 "waiting on you" when only ~3 are real** — done/verified codex release-history ("keep as release history; no board action needed") leaks into the count. A truth-boundary violation and the opposite of "one place to act."

Fix: **one predicate, used everywhere.**

## How
- **`lib/monitor/lane-rules.ts`** — new `isFinishedCard` (done / closed / merged release history) + **`isDecision`** = waiting-on-operator **AND not finished**.
  - "Waiting on operator" = `isAction || waitingOn.actor === "operator"` — matching the design's literal inbox filter (`waitingOn === 'operator'`) and the cards genuinely actionable from the inbox today: operator-review PRs **and operator-owned proposed tasks/missions awaiting dispatch**.
  - ⚠️ **Deliberate divergence from the spec's quoted predicate:** the narrower `waitingOn operator && (operator-review || isAction)` form in `board-state.ts:255` was the banner's *pending-review* notion. In real data `isAction ⟺ lane:needs-attention` (server invariant), so that form would **drop operator-owned proposed tasks in `codex-needed`** — a regression the existing "task card exposes one dispatch primary" test catches. The actual bug is the missing **finished-card exclusion**, which `isDecision` adds.
- **All consumers now call `isDecision`:** inbox membership (`board-columns.inboxCards`), rail count + "WAITING ON YOU" list (`rail-digest` + `CoPilotRail`), `kpiCounts.action` (→ banner headline, board mode, TopStrip pill) + `pendingReviewCount` (the redundant local `isPendingReviewCard` is removed), `BoardFooter`, and the `PipelineMirrorCard` "jump to inbox" affordance (so a mirror only links to the inbox when the card is actually there — the *VERIFIED done-mirror styling* remains F2's slice).

## Truth-boundary / acceptance
Every surface now shows the **same** operator-decision count and **zero release-history** in the inbox. Verified in a fixture harness with a synthetic release-history leak: inbox, rail "NEEDS YOU", banner, footer, and TopStrip **all agree (4 = 4 = 4 = 4 = 4)** and the leak is excluded; a realistic done-lane leak (stale `waitingOn:operator`) is excluded from the count yet still renders as a passive **VERIFIED** mirror in the Done column (no card vanishes).

## Tests
New `isDecision` / `isFinishedCard` unit tests (incl. the finished-exclusion); each consumer's test gains a done/verified exclusion case; fixtures that modelled "action cards" without an operator owner are made realistic. **Full suite (1668)** + typecheck + `@avg/monitor-ui` vite build green.

## For F2/F3 (rebase on this)
`isDecision` is the shared predicate to build on. F2's banner cutover can read the F1 `counts.action`; F2's done-mirror styling can assume the jump affordance already gates on `isDecision`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)