### PR TITLE
style(monitor): accent discipline + consistent inbox primaries + honest stepper note (PR-G)

### DIFF
--- a/packages/monitor-ui/src/components/DeployStepper.test.tsx
+++ b/packages/monitor-ui/src/components/DeployStepper.test.tsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DeployStepper } from "./DeployStepper.js";
+import { DEPLOY_STEPS, type DeployStepView } from "../lib/monitor/deploy-stepper.js";
+
+afterEach(cleanup);
+
+const allPending: DeployStepView[] = DEPLOY_STEPS.map((s) => ({ ...s, state: "pending", detail: "awaiting data" }));
+
+describe("DeployStepper — PR-G honest all-pending note", () => {
+  test("an all-pending stepper carries an explicit 'awaiting deploy telemetry' note (no fabricated ✓)", () => {
+    const { getByText, container } = render(<DeployStepper steps={allPending} />);
+    expect(getByText("awaiting deploy telemetry")).toBeTruthy();
+    // truth-boundary: no step is marked done.
+    expect(container.querySelectorAll(".h4-stepper-row.is-done").length).toBe(0);
+    expect(container.querySelectorAll(".h4-stepper-row").length).toBe(DEPLOY_STEPS.length);
+  });
+
+  test("the note disappears once any step has real telemetry", () => {
+    const partlyWired = allPending.map((s, i) => (i === 0 ? { ...s, state: "in-progress" as const, detail: "CI running" } : s));
+    const { queryByText } = render(<DeployStepper steps={partlyWired} />);
+    expect(queryByText("awaiting deploy telemetry")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/DeployStepper.tsx
+++ b/packages/monitor-ui/src/components/DeployStepper.tsx
@@ -19,6 +19,11 @@ export function DeployStepper({
   steps: readonly DeployStepView[];
   compact?: boolean;
 }) {
+  // PR-G: when no step has any real telemetry yet, every step is "pending".
+  // That's honest (we never fabricate a ✓), but an all-pending column can read
+  // as broken — so add an explicit note that the data, not the deploy, is what's
+  // missing. Per-step wiring is a separate future data task.
+  const allPending = steps.length > 0 && steps.every((step) => step.state === "pending");
   return (
     <div
       className={"h4-stepper h4-deploy-stepper" + (compact ? " h4-deploy-stepper--compact" : "")}
@@ -34,6 +39,12 @@ export function DeployStepper({
           <span className="h4-stepper-source">{step.detail}</span>
         </div>
       ))}
+      {allPending ? (
+        <div className="h4-stepper-awaiting" role="note">
+          <span className="h4-stepper-awaiting-dot" aria-hidden />
+          awaiting deploy telemetry
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -159,6 +159,26 @@
 }
 .h4-deploy-stepper--compact .h4-stepper-source { display: none; }
 
+/* PR-G: honest all-pending note — the stepper has no per-step telemetry wired
+   yet, so it reads as intentional ("awaiting"), not broken. Quiet/faint, never
+   an action tone, and never a fabricated ✓. */
+.h4-stepper-awaiting {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 4px;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+}
+.h4-stepper-awaiting-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  border: 1px dashed var(--h4-line-strong);
+  flex: none;
+}
+
 /* ---- mission forensics: expected vs observed ---- */
 .h4-eo { border: 1px solid var(--h4-line-2); border-radius: var(--h4-r-sm); overflow: hidden; }
 .h4-eo-row {
@@ -268,6 +288,20 @@
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 7px;
   margin-top: 11px;
+}
+/* PR-G: the inbox recommended action is THE genuine primary — it wears --act
+   coral consistently on EVERY decision card (one coherent primary style), so no
+   inbox primary ever looks muted and the most-urgent is never the weakest. This
+   is the positive half of accent discipline: coral marks real primary actions
+   (here), and is removed from read-only affordances (the mirror jump). Scoped to
+   the inbox decision CTA so it does not recolour other action buttons. */
+.hm-card-cta--decision .hm-btn--action {
+  background: var(--h4-act);
+  border-color: var(--h4-act-line);
+  color: var(--h4-act-ink);
+}
+.hm-card-cta--decision .hm-btn--action:hover {
+  background: var(--h4-act-deep);
 }
 .hm-card-cta--decision .hm-decision-choices {
   grid-column: 1 / -1;

--- a/packages/monitor-ui/src/styles/hermes4-kanban.css
+++ b/packages/monitor-ui/src/styles/hermes4-kanban.css
@@ -188,6 +188,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* PR-G: read-only navigation affordance — quiet, NOT --act coral. Coral is
+   reserved for genuine primary actions; a mirror's "jump to inbox" only
+   navigates, so it reads as a calm telemetry-toned link, never an action. */
 .hm-pipeline-card-jump {
   display: flex;
   align-items: center;
@@ -196,13 +199,13 @@
   min-height: 30px;
   padding: 7px 9px;
   border-radius: 7px;
-  border: 1px solid var(--h4-act-line);
-  background: var(--h4-act);
-  color: var(--h4-act-ink);
+  border: 1px dashed var(--h4-line);
+  background: transparent;
+  color: var(--h4-tel);
   cursor: pointer;
   font-family: var(--h4-font-display);
   font-size: 10.5px;
-  font-weight: 800;
+  font-weight: 600;
 }
 .hm-pipeline-card-jump span,
 .hm-pipeline-card-jump strong {
@@ -214,9 +217,12 @@
 .hm-pipeline-card-jump strong {
   flex: none;
   text-transform: uppercase;
+  color: var(--h4-muted);
 }
 .hm-pipeline-card-jump:hover {
-  filter: brightness(0.96);
+  border-color: var(--h4-line-strong);
+  background: var(--h4-paper-sunken);
+  color: var(--h4-ink-2);
 }
 
 /* ---- empty state ---- */


### PR DESCRIPTION
## What

**PR-G — cockpit polish, visual-only (no behaviour change).** `--act` coral is the single *"needs-you / act"* signal and should mark **only** genuine primary actions.

### 1. Quiet the read-only JUMP affordance
The *"Awaiting your decision in inbox · JUMP ›"* control on read-only WATCH mirror cards was painted in `--act` coral, so it shouted like an action. Restyled as a **quiet ghost / `--tel`** navigation link (transparent, dashed hairline, telemetry-toned). Read-only must not look actionable. *(hermes4-kanban.css)*

### 2. Consistent inbox primary buttons
The inbox recommended action is **THE** genuine primary, so it now wears `--act` coral **consistently on every decision card** (scoped to `.hm-card-cta--decision` so it doesn't recolour drawer/banner action buttons). One coherent primary style — no inbox primary looks muted, and the most-urgent is never the weakest. This is the *positive* half of accent discipline: coral moves **onto** the real primary and **off** the read-only jump. *(hermes4-cards.css)*

### 3. Honest deploy-stepper label
When no per-step deploy/CI telemetry is wired, every step is "pending" — honest, kept — but an all-pending column can read as broken. `DeployStepper` now renders an explicit **"awaiting deploy telemetry"** note **when (and only when) every step is pending**. **No fabricated ✓**; real per-step wiring is a separate future data task. *(DeployStepper.tsx + hermes4-cards.css)*

> The `.hm-col-gate` "Operator gate" badge is intentional and **untouched**.

## Acceptance / truth-boundary
`--act` coral now appears only on real primary actions; the read-only JUMP is a quiet affordance; inbox primaries are one coherent coral style (most-urgent never weakest); the all-pending stepper carries an honest "awaiting telemetry" note with **zero fabricated ✓**.

## Verification
Harness (computed styles): JUMP → transparent / dashed / `--tel`; inbox primary → `--h4-act` coral; all-pending stepper → the note + 0 done rows. CSS cascade isn't assertable in jsdom, so the two CSS-only fixes are verified visually + the stepper note logic is unit-tested. New `DeployStepper.test.tsx` (all-pending → note + zero done; partly-wired → no note). **Full monitor-ui suite (675)** + typecheck + vite build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)