### PR TITLE
fix(monitor): warm the gray utilities/agent-room/composer surfaces

### DIFF
--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -400,7 +400,7 @@ body { margin: 0; }
   font-size: 11px;
   line-height: 1.2;
   color: var(--hm-ink);
-  background: rgba(255,255,255,0.72);
+  background: var(--hm-paper-3);
 }
 .hm-now-reason--risk {
   color: var(--hm-amber-deep);
@@ -516,7 +516,7 @@ body { margin: 0; }
   margin: 0 22px 10px;
   border: 1px solid var(--hm-line);
   border-radius: var(--hm-radius);
-  background: rgba(255,253,247,0.72);
+  background: var(--hm-paper-3);
   overflow: hidden;
 }
 .hm-utility-bar--attention {
@@ -1009,7 +1009,7 @@ body { margin: 0; }
   margin: 12px 16px 0;
   padding: 0;
   overflow: hidden;
-  background: rgba(255,253,247,0.56);
+  background: var(--hm-paper-3);
 }
 .hm-backlog-suggestions-head,
 .hm-backlog-suggestion-row {
@@ -2088,7 +2088,7 @@ body { margin: 0; }
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   border-bottom: 1px solid var(--hm-line-soft);
-  background: rgba(255, 253, 247, 0.82);
+  background: var(--hm-paper-3);
 }
 .hm-rail-tab {
   min-width: 0;
@@ -2143,7 +2143,7 @@ body { margin: 0; }
   overflow-y: auto;
   padding: 14px 16px 16px;
   scrollbar-width: thin;
-  background: linear-gradient(180deg, rgba(250, 248, 241, 0.96), var(--hm-paper-2));
+  background: var(--hm-paper);
 }
 .hm-rail-panel--digest::-webkit-scrollbar { width: 6px; }
 .hm-rail-panel--digest::-webkit-scrollbar-thumb { background: var(--hm-line); border-radius: 999px; }
@@ -2287,7 +2287,7 @@ body { margin: 0; }
   border: 1px dashed var(--hm-line);
   border-radius: var(--hm-radius-sm);
   color: var(--hm-muted);
-  background: rgba(255, 253, 247, 0.56);
+  background: var(--hm-paper-3);
 }
 .hm-rail-waiting-empty strong {
   color: var(--hm-sage-deep);
@@ -2413,7 +2413,7 @@ body { margin: 0; }
   display: flex;
   flex-direction: column;
   border-bottom: 1px solid var(--hm-line-soft);
-  background: linear-gradient(180deg, rgba(250, 248, 241, 0.96), var(--hm-paper-2));
+  background: var(--hm-paper);
   overflow: hidden;
 }
 .hm-activity-head {
@@ -2423,7 +2423,7 @@ body { margin: 0; }
   justify-content: space-between;
   gap: 10px;
   border-bottom: 1px solid var(--hm-line-soft);
-  background: rgba(255, 253, 247, 0.82);
+  background: var(--hm-paper-3);
 }
 .hm-activity-head strong {
   font-family: var(--font-display);
@@ -2514,7 +2514,7 @@ button.hm-activity-row:hover {
   padding: var(--hm-space-3);
   border: 1px solid var(--hm-line);
   border-radius: 8px;
-  background: rgba(255, 253, 247, 0.7);
+  background: var(--hm-paper);
 }
 .hm-room-thread-head {
   display: flex;
@@ -2608,7 +2608,7 @@ button.hm-activity-row:hover {
 }
 .hm-turn--rank-muted {
   opacity: 0.72;
-  background: rgba(255, 253, 247, 0.58);
+  background: var(--hm-paper-3);
 }
 .hm-turn-time {
   grid-column: 2;
@@ -2658,7 +2658,7 @@ button.hm-activity-row:hover {
   gap: 3px 9px;
   padding: 8px 10px;
   border-radius: var(--hm-radius-sm);
-  background: rgba(245, 241, 231, 0.68);
+  background: var(--hm-paper-3);
   border: 1px solid rgba(47, 43, 37, 0.09);
   font-family: var(--font-body);
   font-size: 12px;
@@ -2747,7 +2747,7 @@ button.hm-turn-pin {
   border: 1px solid rgba(47, 43, 37, 0.14);
   border-radius: 12px;
   padding: 11px 12px;
-  background: rgba(250, 248, 241, 0.86);
+  background: var(--hm-paper-3);
   font-family: var(--font-body);
   font-size: 13px;
   color: var(--hm-ink);


### PR DESCRIPTION
Kills the light-gray patches in the **Utilities bar**, the **Agent room**, and the box **above the composer** — exactly the surfaces flagged on the live board.

## Cause
PR-D4 (#438) migrated cards/lanes onto the warm-dark `--h4` profile, but ~a dozen secondary surfaces **hardcoded** light cream backgrounds (`rgba(255,253,247,…)`, `rgba(250,248,241,…)`) instead of using the `--hm-*` tokens — so the `--hm-*`→`--h4` remap couldn't reach them, and they rendered light-gray on the dark board.

## Fix (CSS-only, 12 surfaces)
Re-point them at the warm paper stack (`--hm-paper` / `--hm-paper-3` → `#241F1B` / `#201C18`):
- **Utilities:** `.hm-utility-bar`
- **Agent room:** `.hm-rail-tabs`, `.hm-rail-panel--digest`, `.hm-rail-waiting-empty`, `.hm-activity`, `.hm-activity-head`, `.hm-room-thread`, `.hm-turn--rank-muted`, `.hm-turn-pin` (the "Referenced card")
- **Above chat:** `.hm-backlog-suggestions--rail`, `.hm-compose-input`, `.hm-now-reason`

Borders/text already use remapped `--hm-line`/`--hm-muted` (light on dark), so contrast holds.

## Scope / truth-boundary
Visual-only, no behaviour/DOM change. **Semantic-tinted** surfaces (`--err`, `--running`, `--cta`, `--risk`, draft pill) are intentionally preserved — they carry meaning. A few same-pattern *neutral* surfaces outside these regions (mission-fact chips, kbd highlights) were left out of scope; flag if you want them swept too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)