### PR TITLE
fix(monitor): stop inbox decision cards clipping Approve & dispatch

### DIFF
--- a/packages/monitor-ui/src/styles/hermes4-kanban.css
+++ b/packages/monitor-ui/src/styles/hermes4-kanban.css
@@ -114,6 +114,17 @@
   display: contents;
 }
 
+/* Inbox decision cards must keep their natural height so the column SCROLLS
+   (.hm-col-body is overflow-y:auto) rather than flex-shrinking the cards. The
+   anchor is display:contents, so each .hm-card is a direct flex child of the
+   column; .hm-card has overflow:hidden, so without flex-shrink:0 three tall
+   decision cards squish to fit and CLIP the "What happens next" body + the
+   Approve & dispatch / Choices actions. */
+.hm-col--inbox .hm-card,
+.hm-col-body > .hm-pipeline-card {
+  flex-shrink: 0;
+}
+
 /* ---- read-only pipeline mirrors (PR-E3) ---- */
 .hm-pipeline-card {
   display: flex;


### PR DESCRIPTION
**Functional blocker found on the live board** (`monitor.averray.com`): the DECISION INBOX cards clip their lower half — the **"What happens next"** body and the **Approve & dispatch / Choices** actions are cut off. With 3+ decisions the operator literally can't approve from the inbox.

## Cause
Each `.hm-card` is a direct flex child of `.hm-col-body` (the `.hm-inbox-card-anchor` is `display:contents`) with default `flex-shrink:1`, and `.hm-card` has `overflow:hidden`. When the inbox's total card height exceeds the column, the cards **shrink to fit and clip** instead of the column scrolling.

## Fix
Give inbox cards (and pipeline mirrors) `flex-shrink:0` so they keep their natural height and `.hm-col-body`'s existing `overflow-y:auto` scrolls the column instead. One CSS rule, no behaviour/DOM change.

Found by visually walking the deployed board per `docs/COCKPIT_VERIFICATION_CHECKLIST.md` (item A6/A7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)