### PR TITLE
fix(monitor): warm-dark fix for floating Ask-Hermes pill (cream bleed)

### DIFF
--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -3096,7 +3096,11 @@ button.hm-turn-pin {
   display: flex; align-items: center; gap: 10px;
   padding: 10px 14px 10px 12px;
   border-radius: 999px;
-  background: var(--hm-ink);
+  /* dark-mode: --hm-ink remaps to a LIGHT ink (#EDE6DD), which turned this
+     floating pill into a cream patch with near-invisible text bleeding up at
+     the board's bottom-right. It's the "Ask Hermes" CTA, so use the on-theme
+     coral action colour (--h4-act) with white text. */
+  background: var(--h4-act);
   color: #fffdf7;
   box-shadow: var(--hm-shadow-pop);
   cursor: pointer;


### PR DESCRIPTION
**Reported on the live board:** a light/orange patch bleeding up at the board's bottom-right corner.

## Cause
The floating "Ask Hermes" pill (`.hm-ask-float`) sets `background: var(--hm-ink)`. In light mode that's near-black (a dark pill). But the warm-dark remap flips `--hm-ink → #EDE6DD` (light cream) — so the pill became a **cream patch with near-invisible white text**, peeking up at the bottom-right. Same token-inversion class as the #452 gray sweep, which didn't cover this element.

## Fix
It's the "Ask Hermes" CTA → paint it the on-theme coral action colour (`--h4-act`) with white text. One line, visual-only, no behaviour change.

Found by driving the live board through the verification checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)