### PR TITLE
fix(monitor): surface mission-launch result — no more silent "nothing happens"

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -30,7 +30,7 @@ import { useAutonomyMode, type UseAutonomyModeOptions } from "./hooks/useAutonom
 import { useColorProfile } from "./hooks/useColorProfile.js";
 import { kpiCounts } from "./lib/monitor/board-state.js";
 import type { BoardCard, CreateTaskInput } from "./lib/monitor/card-types.js";
-import { missionLaunchBody, type MissionSpawnInput, type SaveTestSuiteInput } from "./lib/monitor/mission-launch.js";
+import { missionLaunchBody, type MissionSpawnInput, type MissionLaunchOutcome, type MissionLaunchResult, type SaveTestSuiteInput } from "./lib/monitor/mission-launch.js";
 import { BoardView } from "./components/BoardView.js";
 import { ErrorBoundary } from "./components/ErrorBoundary.js";
 
@@ -47,8 +47,10 @@ export interface MonitorPageProps {
   options?: UseMonitorBoardOptions;
   /** Override the read-only backlog-suggestions endpoint wiring for tests. */
   backlogSuggestions?: UseBacklogSuggestionsOptions;
-  /** Override the /mission spawn (defaults to POST /monitor/testbed-missions). */
-  onSpawnMission?: (input: MissionSpawnInput) => void;
+  /** Override the /mission spawn (defaults to POST /monitor/testbed-missions).
+   *  May report a {@link MissionLaunchResult} so the launcher can confirm the
+   *  spawn instead of failing silently. */
+  onSpawnMission?: (input: MissionSpawnInput) => MissionLaunchOutcome;
   /** Override saving a named suite (defaults to POST /monitor/suites). */
   onSaveSuite?: (input: SaveTestSuiteInput) => void;
   /** Override running a named suite (defaults to POST /monitor/suites/:id/run). */
@@ -220,14 +222,22 @@ function defaultDismissSuite(id: string): void {
  * board — so the spawned card appears and updates through the live feed.
  * Fire-and-forget: the board feed, not this call, drives the UI.
  */
-function defaultSpawnMission(input: MissionSpawnInput): void {
-  void fetch(MISSIONS_URL, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(missionSpawnBody(input)),
-  }).catch(() => {
-    /* surfaced via the board feed / degraded state, not thrown here */
-  });
+async function defaultSpawnMission(input: MissionSpawnInput): Promise<MissionLaunchResult> {
+  // Reports the POST result so the launcher can confirm "requested ✓" or show
+  // "launch failed — <status>" instead of swallowing the outcome. We check
+  // response.ok explicitly (a 4xx/5xx does NOT reject fetch), and never throw —
+  // a network failure resolves to { ok: false } so callers that ignore the
+  // result (the /mission command path) can't trip an unhandled rejection.
+  try {
+    const res = await fetch(MISSIONS_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(missionSpawnBody(input)),
+    });
+    return { ok: res.ok, status: res.status };
+  } catch {
+    return { ok: false, error: "network" };
+  }
 }
 
 function missionSpawnBody(input: MissionSpawnInput): Record<string, unknown> {

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -24,7 +24,7 @@ import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache
 import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
-import type { MissionSpawnInput, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+import type { MissionSpawnInput, MissionLaunchOutcome, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
 import { StartMissionLauncher } from "./StartMissionLauncher.js";
 import { TestSuitesPanel } from "./TestSuitesPanel.js";
 import { laneFor, isDecision, tierFor, type KanbanTier } from "../lib/monitor/lane-rules.js";
@@ -124,7 +124,7 @@ export interface BoardViewProps {
   onCardClick?: (id: string) => void;
   onCardClose?: () => void;
   onCardNavigate?: (id: string) => void;
-  onSpawnMission?: (input: MissionSpawnInput) => void;
+  onSpawnMission?: (input: MissionSpawnInput) => MissionLaunchOutcome;
   onSaveSuite?: (input: SaveTestSuiteInput) => void;
   onRunSuite?: (id: string) => void;
   onApproveSuite?: (id: string) => void;

--- a/packages/monitor-ui/src/components/StartMissionLauncher.test.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.test.tsx
@@ -69,3 +69,46 @@ describe("StartMissionLauncher — Citation Repair flow", () => {
     expect(arg).not.toHaveProperty("jobId");
   });
 });
+
+describe("StartMissionLauncher — launch feedback (no more silent close)", () => {
+  test("a reported success shows 'Mission requested ✓' and keeps the panel open", async () => {
+    const onSpawnMission = vi.fn(async () => ({ ok: true, status: 200 }));
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    launch(r);
+
+    expect(await r.findByText(/Mission requested ✓/)).toBeTruthy();
+    // The panel stays open (the silent close was the "nothing happens" report).
+    expect(r.getByText("Target")).toBeTruthy();
+  });
+
+  test("a non-2xx POST shows an explicit failure instead of failing silently", async () => {
+    const onSpawnMission = vi.fn(async () => ({ ok: false, status: 500 }));
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    launch(r);
+
+    const alert = await r.findByRole("alert");
+    expect(alert.textContent).toMatch(/Launch failed — HTTP 500/);
+    expect(r.getByText("Target")).toBeTruthy(); // still open so the operator can retry
+  });
+
+  test("a network failure ({ ok:false, error }) reads as a failure, not success", async () => {
+    const onSpawnMission = vi.fn(async () => ({ ok: false, error: "network" }));
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    launch(r);
+
+    const alert = await r.findByRole("alert");
+    expect(alert.textContent).toMatch(/Launch failed — network/);
+  });
+
+  test("a fire-and-forget handler (returns void) still confirms best-effort", () => {
+    const onSpawnMission = vi.fn(() => {});
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    openLauncher(r);
+    launch(r);
+
+    expect(r.getByText(/Mission requested ✓/)).toBeTruthy(); // synchronous, no await
+  });
+});

--- a/packages/monitor-ui/src/components/StartMissionLauncher.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.tsx
@@ -1,12 +1,20 @@
 import { useId, useState, type FormEvent } from "react";
-import type { MissionLaunchInput, MissionLaunchMode, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+import type {
+  MissionLaunchInput,
+  MissionLaunchMode,
+  MissionLaunchOutcome,
+  MissionLaunchResult,
+  SaveTestSuiteInput,
+} from "../lib/monitor/mission-launch.js";
 
 const DEFAULT_TARGET = "https://app.averray.com";
 
 export interface StartMissionLauncherProps {
-  onSpawnMission?: (input: MissionLaunchInput) => void;
+  onSpawnMission?: (input: MissionLaunchInput) => MissionLaunchOutcome;
   onSaveSuite?: (input: SaveTestSuiteInput) => void;
 }
+
+type LaunchFeedback = { ok: boolean; detail: string };
 
 export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissionLauncherProps) {
   const targetId = useId();
@@ -23,8 +31,28 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
   const [suiteName, setSuiteName] = useState("");
   const [goal, setGoal] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const [feedback, setFeedback] = useState<LaunchFeedback | null>(null);
 
   const isCitation = mode === "citation_repair";
+
+  // Turn the spawn outcome into honest feedback. `undefined` means the handler
+  // is fire-and-forget (the /mission command path or a test mock) — best-effort
+  // "requested". A reported { ok:false } becomes an explicit failure line.
+  const applyOutcome = (outcome: MissionLaunchResult | void) => {
+    setPending(false);
+    if (outcome && outcome.ok === false) {
+      const why = outcome.status ? `HTTP ${outcome.status}` : (outcome.error ?? "request failed");
+      setFeedback({ ok: false, detail: why });
+      return;
+    }
+    setFeedback({
+      ok: true,
+      detail: requestApproval
+        ? "queued — approve it in the Decision Inbox"
+        : "it’ll appear in the Hermes-checking lane",
+    });
+  };
 
   const submit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -41,8 +69,12 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
       return;
     }
     setError(null);
+    setFeedback(null);
     const trimmedGoal = goal.trim();
-    onSpawnMission?.({
+    // Spawn first (so the mission POST precedes the suite POST), then the
+    // optional suite save — both fired synchronously before we await the
+    // outcome, so a fire-and-forget handler stays fully synchronous.
+    const outcome = onSpawnMission?.({
       // citation_repair omits the target server-side; the launch body drops it.
       targetUrl: isCitation ? "" : target,
       mode,
@@ -60,7 +92,20 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
         ...(trimmedGoal ? { goal: trimmedGoal } : {}),
       });
     }
-    setOpen(false);
+    // A thenable result → await it for the real POST status; a sync/void handler
+    // resolves immediately. The panel stays open so the feedback is visible
+    // (the silent close was the "nothing happens" report).
+    if (outcome && typeof (outcome as { then?: unknown }).then === "function") {
+      setPending(true);
+      Promise.resolve(outcome as Promise<MissionLaunchResult | void>)
+        .then(applyOutcome)
+        .catch(() => {
+          setPending(false);
+          setFeedback({ ok: false, detail: "request failed" });
+        });
+    } else {
+      applyOutcome(outcome as MissionLaunchResult | void);
+    }
   };
 
   return (
@@ -215,10 +260,19 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
           ) : null}
 
           {error ? <div className="hm-form-error" role="alert">{error}</div> : null}
+          {feedback ? (
+            feedback.ok ? (
+              <div className="hm-form-ok" role="status">Mission requested ✓ — {feedback.detail}.</div>
+            ) : (
+              <div className="hm-form-error" role="alert">
+                Launch failed — {feedback.detail}. The board can’t confirm it; check the tester runner.
+              </div>
+            )
+          ) : null}
 
           <div className="hm-mission-launcher-actions">
-            <button type="submit" className="hm-btn hm-btn--action">
-              Launch mission
+            <button type="submit" className="hm-btn hm-btn--action" disabled={pending}>
+              {pending ? "Launching…" : "Launch mission"}
             </button>
             <span>Server derives mutation safety from target, flow, and environment.</span>
           </div>

--- a/packages/monitor-ui/src/lib/monitor/mission-launch.ts
+++ b/packages/monitor-ui/src/lib/monitor/mission-launch.ts
@@ -18,6 +18,25 @@ export interface MissionLaunchInput {
 export type MissionSpawnInput = string | MissionLaunchInput;
 
 /**
+ * The result of a spawn POST, so the launcher can give the operator honest
+ * feedback instead of failing silently (PR — launch feedback). `ok` mirrors the
+ * HTTP response.ok; `status` is the code; `error` is set for a network failure.
+ */
+export interface MissionLaunchResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+/**
+ * A spawn handler may be fire-and-forget (returns void — e.g. the /mission
+ * command path or a test mock) OR report the POST result so the UI can confirm
+ * it. Returning the result is what lets the launcher show "requested ✓" vs
+ * "launch failed" rather than silently closing.
+ */
+export type MissionLaunchOutcome = void | Promise<MissionLaunchResult | void>;
+
+/**
  * Build the POST body for /monitor/testbed-missions from a launch input. Pure
  * so the mode→body mapping is unit-tested. citation_repair keys off jobId, not
  * a URL — it omits targetUrl and carries jobId (empty jobId ⇒ the server-side

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -796,6 +796,11 @@ body { margin: 0; }
 .hm-form-error {
   color: var(--hm-rose);
 }
+.hm-form-ok {
+  color: var(--hm-sage-deep);
+  font-size: 12px;
+  font-weight: 600;
+}
 @media (max-width: 1100px) {
   .hm-mission-launcher-form {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## What

Diagnosed **live** on `monitor.averray.com`: clicking **Launch mission** fires `POST /monitor/testbed-missions` which returns **200**, but the launcher just **closes silently** — no confirmation, no error, no visible result. Cause: the spawn was fire-and-forget — `defaultSpawnMission` did `void fetch(...).catch(()=>{})`, never checked `response.ok`, and the launcher called `onSpawnMission?.()` then `setOpen(false)`. A 200, a 4xx/5xx, and a network failure all looked identical: *"nothing happens."*

This makes the launch **honest about its result**.

- **`lib/monitor/mission-launch.ts`** — new `MissionLaunchResult { ok, status?, error? }` + `MissionLaunchOutcome` (`void | Promise<MissionLaunchResult | void>`). A handler may stay fire-and-forget **or** report the POST result.
- **`MonitorPage` `defaultSpawnMission`** — now async; checks `response.ok` explicitly (a 4xx/5xx does **not** reject `fetch`), returns `{ ok, status }`, and **never throws** (network failure → `{ ok:false }`, so the `/mission` command path can't trip an unhandled rejection). The `onSpawnMission` type is widened along the launcher chain (MonitorPage → BoardView → StartMissionLauncher); the composer `(url)=>void` paths are unaffected.
- **`StartMissionLauncher`** — awaits the outcome and **surfaces it**: *"Mission requested ✓ — it'll appear in the Hermes-checking lane"* (or *"queued — approve it in the Decision Inbox"*), or an explicit *"Launch failed — HTTP `<status>`"* / network error. The panel **stays open** so the feedback is visible (the silent close was the report); the button shows *"Launching…"* + disables in flight. A `void` handler still confirms best-effort, synchronously. Spawn POST precedes the suite POST (order preserved).
- **`.hm-form-ok`** style (sage) alongside `.hm-form-error`.

## Truth-boundary
This surfaces the **real** result — it never claims success on a non-2xx. It makes the **frontend** honest. The separate backend bug we found live — a `200` that produces **no visible mission** (tester-runner provisioning / SSE not emitting the card) — is slack-operator/ops's lane and **out of scope** here; this fix makes that failure *visible* instead of silent.

## Tests
`StartMissionLauncher` gains feedback coverage: reported success → "✓" + panel stays open; non-2xx → explicit failure (still open to retry); network failure → failure; `void` handler → best-effort. Existing launcher + MonitorPage suite-save tests stay green (sync path + POST order preserved). **Full monitor-ui suite (679)** + typecheck + vite build green.

> Verified the *diagnosis* live (POST 200, silent close); the *fix* is verified by unit tests (exact rendered feedback asserted) since it isn't deployed yet. Happy to confirm in-browser once it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)