### PR TITLE
fix(monitor): keep launched testbed missions visible on a busy board

### DIFF
--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -14,6 +14,9 @@ interface BoardClassification {
 }
 
 const TERMINAL_CODEX_STATUSES = new Set(["completed", "cancelled", "failed", "terminal"]);
+// Density cap on the noisy PR/handoff cards. Active testbed missions are pinned
+// on top of this so a just-launched mission is never capped off a busy board.
+const MAX_BOARD_CARDS = 10;
 const QUIET_AUTOMATION_REASONS = [
   "dispatch_budget_exhausted",
   "open_fix_cap_reached",
@@ -33,10 +36,24 @@ export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBo
   const allRawItems = [...arrayRecords(snapshot.active), ...arrayRecords(snapshot.recent), ...missionItems];
   const quietSelfHealingCapacitySignals = allRawItems.filter(isQuietSelfHealingCapacityEvent).length;
   const rawItems = dedupeItems(allRawItems.filter((item) => !isQuietSelfHealingCapacityEvent(item)));
-  const cards = rawItems
-    .map((item) => boardCardFromItem(item, snapshot, activeTasks))
-    .filter((item): item is HermesBoardCardSnapshot => Boolean(item))
-    .slice(0, 10);
+  const classified = rawItems
+    .map((item) => ({ item, card: boardCardFromItem(item, snapshot, activeTasks) }))
+    .filter((entry): entry is { item: Record<string, unknown>; card: HermesBoardCardSnapshot } =>
+      Boolean(entry.card));
+  // A just-launched testbed mission is "active" (ready/running). It must stay
+  // visible in its lane even when the board is already busy: without this, an
+  // active mission appended after a full slate of PR/handoff cards is dropped by
+  // the board cap, so a successful (HTTP 200) launch surfaces no card at all.
+  // Pin active missions; everything else (PRs, recent handoffs, completed/failed
+  // missions) shares the MAX_BOARD_CARDS cap.
+  const pinnedMissionCards = classified
+    .filter((entry) => isActiveMissionItem(entry.item))
+    .map((entry) => entry.card);
+  const cappedCards = classified
+    .filter((entry) => !isActiveMissionItem(entry.item))
+    .map((entry) => entry.card)
+    .slice(0, MAX_BOARD_CARDS);
+  const cards = [...pinnedMissionCards, ...cappedCards];
 
   const counts = boardCounts(cards, snapshot, { quietSelfHealingCapacitySignals });
   const runner = runnerSummary(snapshot);
@@ -490,6 +507,17 @@ function reviewReasons(summary: Record<string, unknown>): string[] {
 
 function isRunningItem(item: Record<string, unknown>, status: string): boolean {
   return status === "running" || booleanProp(item, "active") || normalize(textProp(item, "activeState")) === "running";
+}
+
+/**
+ * An in-flight testbed mission (requested / ready / running) — the kind of card
+ * a successful launch produces and the operator is waiting to see. `intent` is
+ * set only by testbedMissionRunToMonitorItem; `active` is true while the run is
+ * awaiting approval or executing and false once it completes or fails. Pinned
+ * past the board cap so a launched mission stays visible even on a busy board.
+ */
+function isActiveMissionItem(item: Record<string, unknown>): boolean {
+  return normalize(textProp(item, "intent")) === "testbed_agent_mission" && booleanProp(item, "active");
 }
 
 function isDonePrState(prState: Record<string, unknown> | undefined): boolean {

--- a/test/unit/monitor-mission-board.test.ts
+++ b/test/unit/monitor-mission-board.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  __resetTestbedMissionRunsForTests,
+  listTestbedMissionRuns,
+} from "../../services/slack-operator/src/monitor-testbed-missions.js";
+import { createMonitorTestbedMissionFromPayload } from "../../services/slack-operator/src/testbed-agent-entrypoint.js";
+import { buildV2BoardSnapshot, diffBoardSnapshots } from "../../services/slack-operator/src/monitor-v2.js";
+
+// Mirror testbed-agent-entrypoint.test.ts: the averray-mcp packet generator is
+// stubbed to a minimal browser-mission packet so the store records a run.
+vi.mock("@avg/averray-mcp/operator-testbed", () => ({
+  getTestbedAgentMission: (input: Record<string, unknown> = {}) => ({
+    schemaVersion: 1,
+    kind: "testbed_agent_browser_mission",
+    target: {
+      url: input.targetUrl ?? "[TESTBED_URL]",
+      goal: input.goal ?? "test the page",
+      agentName: input.agentName ?? "Hermes",
+      freshMemory: input.freshMemory !== false,
+      maxBrowserSteps: input.maxBrowserSteps ?? 80,
+      maxMinutes: input.maxMinutes ?? 20,
+    },
+    missionPrompt: `Goal: ${input.goal ?? "test the page"}`,
+    safety: {
+      browserMissionShouldMutate: input.allowTestMutations === true,
+    },
+  }),
+}));
+
+// Regression coverage for the backend defect where a successful (HTTP 200)
+// testbed-mission launch produced no visible card on the v2 board: a created
+// mission must (a) appear in the /monitor/v2/board snapshot, and (b) generate a
+// board.card.added stream event the first time it shows up.
+describe("testbed mission → v2 board", () => {
+  let dir = "";
+  let path = "";
+
+  beforeEach(() => {
+    __resetTestbedMissionRunsForTests();
+    dir = mkdtempSync(join(tmpdir(), "averray-mission-board-"));
+    path = join(dir, "missions.json");
+  });
+
+  afterEach(() => {
+    __resetTestbedMissionRunsForTests();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function boardRaw() {
+    return { active: [], recent: [], testbedMissions: listTestbedMissionRuns({ limit: 20, path }) };
+  }
+
+  it("surfaces a launched surface_sweep mission as a hermes-checking mission card", () => {
+    const created = createMonitorTestbedMissionFromPayload({
+      targetUrl: "https://app.averray.com",
+      mode: "surface_sweep",
+      freshMemory: "true",
+      path,
+    });
+
+    const snap = buildV2BoardSnapshot(boardRaw(), { repo: "depre-dev/agent" });
+    const missionCard = snap.cards.find((card) => card.type === "mission");
+
+    expect(missionCard, "a mission card should appear on the v2 board snapshot").toBeDefined();
+    expect(missionCard?.lane).toBe("hermes-checking");
+    expect(missionCard?.agentType).toBe("hermes");
+    // The card must correspond to the run we actually created (no faked card):
+    // it carries the run's real title, not a synthetic placeholder.
+    expect(missionCard?.title).toBe(created.run.title);
+  });
+
+  it("keeps the mission visible even when the board is busy with ≥10 PR cards", () => {
+    // monitor.averray.com is a live, busy board: many active PR/handoff items
+    // are in flight. The classifier caps the board, so a mission appended after
+    // a full slate of PR cards must not be the one that falls off.
+    const active = Array.from({ length: 12 }, (_unused, i) => ({
+      title: `Active PR ${i}`,
+      status: "running",
+      intent: "pr_review",
+      active: true,
+      summary: { pullRequest: { repo: "depre-dev/agent", number: 600 + i, state: "open" } },
+      ageLabel: "3m",
+    }));
+
+    const created = createMonitorTestbedMissionFromPayload({
+      targetUrl: "https://app.averray.com",
+      mode: "surface_sweep",
+      path,
+    });
+
+    const raw = { active, recent: [], testbedMissions: listTestbedMissionRuns({ limit: 20, path }) };
+    const snap = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const missionCard = snap.cards.find((card) => card.type === "mission");
+
+    expect(missionCard, "the mission must survive the board cap on a busy board").toBeDefined();
+    expect(missionCard?.lane).toBe("hermes-checking");
+    expect(missionCard?.title).toBe(created.run.title);
+  });
+
+  it("emits board.card.added the first time the mission appears in the stream diff", () => {
+    const empty = buildV2BoardSnapshot(
+      { active: [], recent: [], testbedMissions: [] },
+      { repo: "depre-dev/agent" },
+    );
+
+    createMonitorTestbedMissionFromPayload({
+      targetUrl: "https://app.averray.com",
+      mode: "surface_sweep",
+      path,
+    });
+
+    const next = buildV2BoardSnapshot(boardRaw(), { repo: "depre-dev/agent" });
+    const events = diffBoardSnapshots(empty, next);
+    const added = events.find(
+      (event) => event.type === "board.card.added" && event.card.type === "mission",
+    );
+
+    expect(added, "the new mission should produce a board.card.added stream event").toBeDefined();
+  });
+});


### PR DESCRIPTION
## Problem

A successful (**HTTP 200**) testbed-mission launch produced **no visible card** on the Hermes v2 board. Reproduced on monitor.averray.com: *Utilities → Start a mission → Surface Sweep* returns 200, but no card appears in any lane and **HERMES CHECKING stays 0** — the operator's "Launch mission → nothing happens".

## Root cause

The mission *is* created, persisted, and classified correctly into the `hermes-checking` lane — it just gets dropped before render. In `buildHermesBoardSnapshotFromMonitor` (`monitor-hermes-board.ts`), mission items are appended **last** and the board is then capped:

```ts
const allRawItems = [...active, ...recent, ...missionItems]; // missions last
const cards = rawItems.map(...).filter(Boolean).slice(0, 10); // cap drops the tail
```

On a **busy** board (monitor.averray.com has ≥10 active PR/handoff items) the just-launched mission is the tail item and is sliced off. On a quiet/dev board it surfaces fine — which is why this didn't reproduce locally.

## Fix

Pin **active** (`requested` / `ready` / `running`) testbed missions on top of the cap so a launched mission always stays visible in its lane. Completed/failed (historical) missions still share the `MAX_BOARD_CARDS` cap like any other recent item.

Once the card is back in the snapshot, the v2 stream's existing `diffBoardSnapshots` already emits a `board.card.added` event for it — no separate broadcast hook needed.

Truth-boundary preserved: only missions that genuinely exist in the store are surfaced (no faked cards); a mission with no report yet shows its honest "ready / awaiting" state.

## Tests

New `test/unit/monitor-mission-board.test.ts`:
- a launched `surface_sweep` mission surfaces as a `hermes-checking` mission card via the board snapshot;
- the snapshot diff emits `board.card.added` the first time the mission appears;
- **the mission survives a busy (≥10 PR-card) board** — the regression guard for this bug.

Full suite green: **1002 tests / 77 files**, plus `tsc -b services/slack-operator` clean. No card-count assumptions downstream were affected.

## Scope notes

- Frontend launcher honesty (PR #456) is already merged; not touched here.
- Runner provisioning (Playwright in prod) is a separate concern — the card now shows an honest pending state regardless of runner health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)