### PR TITLE
feat(monitor): redesign Utilities panel + mission launcher for intuitiveness

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.test.tsx
+++ b/packages/monitor-ui/src/MonitorPage.test.tsx
@@ -191,15 +191,15 @@ describe("MonitorPage — container", () => {
       );
       await waitFor(() => expect(getByRole("button", { name: /Utilities/ })).toBeTruthy());
       fireEvent.click(getByRole("button", { name: /Utilities/ }));
-      await waitFor(() => expect(getByRole("button", { name: "Start a mission" })).toBeTruthy());
+      // The launcher is always-expanded inside the Utilities panel now.
+      await waitFor(() => expect(getByLabelText("Target")).toBeTruthy());
 
-      fireEvent.click(getByRole("button", { name: "Start a mission" }));
       fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/agent" } });
       fireEvent.click(getByLabelText(/Gold Path/));
       fireEvent.click(getByLabelText("Memory"));
       fireEvent.change(getByLabelText("Goal"), { target: { value: "prove the signed-in receipt loop" } });
-      fireEvent.click(getByLabelText(/Request approval/));
-      fireEvent.click(getByRole("button", { name: "Launch mission" }));
+      // Approval is on by default (propose) → the CTA reads "Propose mission".
+      fireEvent.click(getByRole("button", { name: "Propose mission" }));
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const [calledUrl, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
@@ -234,13 +234,12 @@ describe("MonitorPage — container", () => {
       );
       await waitFor(() => expect(getByRole("button", { name: /Utilities/ })).toBeTruthy());
       fireEvent.click(getByRole("button", { name: /Utilities/ }));
-      await waitFor(() => expect(getByRole("button", { name: "Start a mission" })).toBeTruthy());
+      await waitFor(() => expect(getByLabelText("Target")).toBeTruthy());
 
-      fireEvent.click(getByRole("button", { name: "Start a mission" }));
       fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/overview" } });
       fireEvent.click(getByLabelText(/Save this config as a suite/));
       fireEvent.change(getByLabelText("Suite name"), { target: { value: "Daily app sweep" } });
-      fireEvent.click(getByRole("button", { name: "Launch mission" }));
+      fireEvent.click(getByRole("button", { name: "Propose mission" }));
 
       expect(fetchSpy).toHaveBeenCalledTimes(2);
       const [missionUrl] = fetchSpy.mock.calls[0] as [string, RequestInit];

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -167,12 +167,14 @@ describe("BoardView — rich-mix board (open stream)", () => {
     );
 
     fireEvent.click(getByRole("button", { name: /Utilities/ }));
-    fireEvent.click(getByRole("button", { name: "Start a mission" }));
+    // The launcher is always-expanded inside the Utilities panel now.
     fireEvent.change(getByLabelText("Target"), { target: { value: "https://app.averray.com/agents" } });
     fireEvent.click(getByLabelText(/Role Gating/));
     fireEvent.change(getByLabelText("Goal"), { target: { value: "verify role gates" } });
     fireEvent.click(getByLabelText(/Save this config as a suite/));
     fireEvent.change(getByLabelText("Suite name"), { target: { value: "Role gate sweep" } });
+    // Turn approval off → auto-dispatch (initialStatus "ready"); CTA reads "Launch mission".
+    fireEvent.click(getByLabelText(/Request approval/));
     fireEvent.click(getByRole("button", { name: "Launch mission" }));
 
     expect(onSpawnMission).toHaveBeenCalledWith({
@@ -493,25 +495,22 @@ describe("BoardView — rich-mix board (open stream)", () => {
         ],
       },
     };
-    const { getAllByText, getByRole, getByText, queryByText, queryAllByText } = render(<BoardView board={board} status="open" />);
+    const { getAllByText, getByRole, getByText, queryAllByText } = render(<BoardView board={board} status="open" />);
     fireEvent.click(getByRole("button", { name: /Utilities/ }));
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
-    // Collapsed by default: leads with the headline (total tokens + call count)…
-    expect(getByText("59K tokens · 12 calls")).toBeTruthy();
-    // …and the detail (per-source rows, idle line) is hidden until expanded.
-    expect(queryByText("48K in · 9K out")).toBeNull();
-    expect(queryByText(/source idle/)).toBeNull();
-    // Expand the panel to reveal the active source detail + collapsed idle line.
-    fireEvent.click(getByText("59K tokens · 12 calls"));
-    expect(getAllByText("claude · claude-sonnet-4-5").length).toBeGreaterThan(0);
-    expect(getByText("59K tokens")).toBeTruthy();
-    expect(getByText("48K in · 9K out")).toBeTruthy();
-    // Idle sources collapse into ONE muted line; the reason is hidden until expand.
+    // The card shows a real per-model table: an "All models" total + the row.
+    expect(getByText("All models")).toBeTruthy();
+    expect(getAllByText("59K").length).toBeGreaterThan(0); // total + the single model
+    expect(getByText("claude-sonnet-4-5")).toBeTruthy();
+    expect(getByText(/48K in · 9K out/)).toBeTruthy();
+    // Latency has no real source → an explicit "?" (never fabricated).
+    expect(getAllByText("?").length).toBeGreaterThan(0);
+    // The in-flight line names the live call.
+    expect(getByText("claude · claude-sonnet-4-5")).toBeTruthy();
+    // Idle sources show as ONE muted line in place; the honest reason is one
+    // click away (truth-boundary preserved), and there is no flat "not reported" row.
     expect(getByText(/1 source idle: codex/)).toBeTruthy();
-    expect(queryByText("Codex CLI does not report usage.")).toBeNull();
-    // No flat per-source "not reported" row.
     expect(queryAllByText("not reported").length).toBe(0);
-    // Expanding the idle line reveals the honest reason (truth-boundary preserved).
     fireEvent.click(getByText(/1 source idle: codex/));
     expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
   });
@@ -537,10 +536,8 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const { getByRole, getByText, queryByText } = render(<BoardView board={board} status="open" />);
     fireEvent.click(getByRole("button", { name: /Utilities/ }));
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
-    // The one-line summary states "usage not reported" honestly without expanding.
+    // Honest empty state, shown in place — no fabricated zero-filled rows.
     expect(getByText("usage not reported")).toBeTruthy();
-    // The full plain-language explanation is reachable on expand (truth-boundary).
-    fireEvent.click(getByText("usage not reported"));
     expect(getByText(/No LLM usage counters have been recorded yet/)).toBeTruthy();
     expect(queryByText("not_recorded")).toBeNull();
   });

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -12,7 +12,7 @@
 //     <div.hm-main>              grid: lanes-wrap | hermes rail (420px)
 //       <div.hm-lanes-wrap>
 //         <LanesBar />           search + filter chips + urgency label
-//         <UtilityBar />         collapsed tester / suites / LLM usage
+//         <UtilitiesPanel />     collapsed strip ⇄ 2-col: usage | launcher+suites
 //         <Board />              kanban lanes, cards via <CardRouter>
 //       <CoPilotRail />          live narration + Ask-Hermes
 //   <DetailDrawer />             when ?card= resolves
@@ -20,13 +20,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { deriveBoardState, matchesBoardFilter, type BoardMode, type BoardFilter } from "../lib/monitor/board-state.js";
-import type { LlmUsageAggregate, MonitorBoard } from "../lib/monitor/board-cache.js";
+import type { MonitorBoard } from "../lib/monitor/board-cache.js";
 import type { BacklogSuggestionsResponse } from "../lib/monitor/backlog-suggestions.js";
 import type { StreamStatus } from "../lib/monitor/live-stream.js";
 import { LANES, type BoardCard, type CreateTaskInput } from "../lib/monitor/card-types.js";
-import type { MissionSpawnInput, MissionLaunchOutcome, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
-import { StartMissionLauncher } from "./StartMissionLauncher.js";
-import { TestSuitesPanel } from "./TestSuitesPanel.js";
+import type { MissionSpawnInput, MissionLaunchOutcome, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+import { UtilitiesPanel } from "./UtilitiesPanel.js";
 import { laneFor, isDecision, tierFor, type KanbanTier } from "../lib/monitor/lane-rules.js";
 import { deployStepsForCard } from "../lib/monitor/deploy-stepper.js";
 import { inboxCards } from "../lib/monitor/board-columns.js";
@@ -604,7 +603,7 @@ export function BoardView({
             activeFilter={filter}
             onFilterChange={setFilter}
           />
-          <UtilityBar
+          <UtilitiesPanel
             usage={board?.llmUsage}
             suites={board?.testbedSuites}
             onRunSuite={onRunSuite}
@@ -712,71 +711,6 @@ function BoardFooter({ cards }: { cards: readonly BoardCard[] }) {
       </span>
       <span className="h4-board-footer-meta">Hermes · Averray</span>
     </footer>
-  );
-}
-
-function UtilityBar({
-  usage,
-  suites = [],
-  onRunSuite,
-  onSaveSuite,
-  onApproveSuite,
-  onDismissSuite,
-  onSpawnMission,
-}: {
-  usage?: LlmUsageAggregate;
-  suites?: SavedTestSuite[];
-  onRunSuite?: (id: string) => void;
-  onSaveSuite?: (input: SaveTestSuiteInput) => void;
-  onApproveSuite?: (id: string) => void;
-  onDismissSuite?: (id: string) => void;
-  onSpawnMission?: BoardViewProps["onSpawnMission"];
-}) {
-  const requestedSuites = suites.filter((suite) => suite.status === "requested").length;
-  const shouldOpen = requestedSuites > 0;
-  const [open, setOpen] = useState(shouldOpen);
-  useEffect(() => {
-    if (shouldOpen) setOpen(true);
-  }, [shouldOpen]);
-
-  const usageLabel = usage?.status === "recorded"
-    ? `${formatCompactNumber(usage.totalTokens)} tokens`
-    : "usage quiet";
-  const suitesLabel = suites.length > 0
-    ? `${suites.length} suite${suites.length === 1 ? "" : "s"}`
-    : "no suites";
-  const launcherLabel = onSpawnMission ? "tester ready" : "tester off";
-
-  return (
-    <section className={`hm-utility-bar${requestedSuites > 0 ? " hm-utility-bar--attention" : ""}`} aria-label="Board utilities">
-      <button
-        type="button"
-        className="hm-utility-bar-toggle"
-        aria-expanded={open}
-        onClick={() => setOpen((value) => !value)}
-      >
-        <span aria-hidden>{open ? "▾" : "▸"}</span>
-        <span className="hm-kicker">Utilities</span>
-        <strong>LLM usage · suites · tester launcher</strong>
-        <span className="hm-utility-bar-summary">
-          {usageLabel} · {suitesLabel} · {launcherLabel}
-        </span>
-        {requestedSuites > 0 ? <Badge variant="pending">{requestedSuites} requested</Badge> : null}
-      </button>
-      {open ? (
-        <div className="hm-utility-bar-body">
-          <LlmUsagePanel usage={usage} />
-          <TestSuitesPanel
-            suites={suites}
-            onRunSuite={onRunSuite}
-            onSaveSuite={onSaveSuite}
-            onApproveSuite={onApproveSuite}
-            onDismissSuite={onDismissSuite}
-          />
-          {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} onSaveSuite={onSaveSuite} /> : null}
-        </div>
-      ) : null}
-    </section>
   );
 }
 
@@ -967,142 +901,4 @@ function formatClock(iso: string | undefined): string {
   if (Number.isNaN(d.getTime())) return "";
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())}`;
-}
-
-function LlmUsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
-  // Collapsed to a single line by default — the panel used to eat a full band
-  // of vertical space across the board. The headline (total · calls · live)
-  // stays glanceable; per-source detail + idle reasons are one click away.
-  const [expanded, setExpanded] = useState(false);
-  const [showIdle, setShowIdle] = useState(false);
-  const recorded = usage?.status === "recorded";
-  const latestDay = usage?.byDay?.[0];
-  // Active sources get the space — every (agent, model) that actually reported.
-  const models = usage?.byModel?.length ? usage.byModel : latestDay?.byModel ?? [];
-  // Idle sources collapse into ONE line; their honest reasons stay reachable on expand.
-  const idleSources = (usage?.sourceStatus ?? []).filter((entry) => entry.status === "not_reported");
-  const activeCalls = usage?.activeCalls ?? [];
-  const emptyMessage = usage?.message
-    ?? "No LLM usage counters have been recorded yet. Sources stay not reported until a real provider or runner emits whitelisted counters.";
-  const headline = recorded
-    ? `${formatCompactNumber(usage!.totalTokens)} tokens · ${formatNumber(usage!.runs)} calls`
-    : "usage not reported";
-  const lastLabel = recorded && usage!.lastActiveAt ? `last ${formatRelativeTime(usage!.lastActiveAt)}` : "";
-  // Keep the live signal glanceable without expanding.
-  const flightLabel = activeCalls.length > 0 ? `${activeCalls.length} in flight` : "idle";
-
-  return (
-    <section className="hm-llm-usage" aria-label="LLM usage">
-      {/* One-line summary — leads with the total; the rest is behind the toggle. */}
-      <button
-        type="button"
-        className="hm-llm-usage-summary"
-        aria-expanded={expanded}
-        onClick={() => setExpanded((value) => !value)}
-      >
-        <span aria-hidden>{expanded ? "▾" : "▸"}</span>
-        <span className="hm-kicker">LLM usage</span>
-        <strong className="hm-llm-usage-headline">{headline}</strong>
-        <span className="hm-llm-usage-summary-meta">
-          {[flightLabel, lastLabel].filter(Boolean).join(" · ")}
-        </span>
-      </button>
-
-      {expanded ? (
-      <div className="hm-llm-usage-detail">
-      {/* What's running now (in-flight). */}
-      <div className="hm-llm-usage-active">
-        <span>What's running now</span>
-        {activeCalls.length > 0 ? (
-          <strong>{activeCalls.map((call) => `${call.agent} · ${call.model}`).join(" · ")}</strong>
-        ) : (
-          <strong>No in-flight LLM calls</strong>
-        )}
-      </div>
-
-      {/* Active sources — prominent: per-(agent, model) tokens + in/out bar. */}
-      {recorded && models.length > 0 ? (
-        <div className="hm-llm-usage-sources">
-          {models.map((entry) => {
-            const split = Math.max(1, entry.inputTokens + entry.outputTokens);
-            const inPct = Math.round((entry.inputTokens / split) * 100);
-            return (
-              <div className="hm-llm-usage-source" key={`${entry.agent}:${entry.model}`}>
-                <div className="hm-llm-usage-source-head">
-                  <strong>{entry.agent} · {entry.model}</strong>
-                  <span>{formatCompactNumber(entry.totalTokens)} tokens</span>
-                </div>
-                <div
-                  className="hm-llm-usage-bar"
-                  role="img"
-                  aria-label={`${formatCompactNumber(entry.inputTokens)} in, ${formatCompactNumber(entry.outputTokens)} out`}
-                >
-                  <span className="hm-llm-usage-bar-in" style={{ width: `${inPct}%` }} />
-                  <span className="hm-llm-usage-bar-out" style={{ width: `${100 - inPct}%` }} />
-                </div>
-                <div className="hm-llm-usage-source-foot">
-                  <small>{formatCompactNumber(entry.inputTokens)} in · {formatCompactNumber(entry.outputTokens)} out</small>
-                  <small>{formatNumber(entry.runs)} calls · last {formatRelativeTime(entry.lastActiveAt)}</small>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
-
-      {/* Idle sources — one muted, expandable line; reasons honest but quiet. */}
-      {idleSources.length > 0 ? (
-        <div className="hm-llm-usage-idle">
-          <button
-            type="button"
-            className="hm-llm-usage-idle-toggle"
-            aria-expanded={showIdle}
-            onClick={() => setShowIdle((value) => !value)}
-          >
-            <span aria-hidden>{showIdle ? "▾" : "▸"}</span>
-            {idleSources.length} source{idleSources.length === 1 ? "" : "s"} idle: {idleSources.map((entry) => entry.agent).join(" · ")}
-          </button>
-          {showIdle ? (
-            <ul className="hm-llm-usage-idle-list">
-              {idleSources.map((entry) => (
-                <li key={entry.agent}>
-                  <strong>{entry.agent}</strong>
-                  <span>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</span>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-      ) : null}
-
-      {/* Truth-boundary explanation when nothing reported and no idle list to carry it. */}
-      {!recorded && models.length === 0 ? (
-        <div className="hm-llm-usage-empty">{emptyMessage}</div>
-      ) : null}
-      </div>
-      ) : null}
-    </section>
-  );
-}
-
-function formatNumber(value: number): string {
-  return new Intl.NumberFormat("en-US").format(value);
-}
-
-function formatCompactNumber(value: number): string {
-  return new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 }).format(value);
-}
-
-function formatRelativeTime(iso: string | null | undefined): string {
-  if (!iso) return "last active unknown";
-  const time = Date.parse(iso);
-  if (!Number.isFinite(time)) return "last active unknown";
-  const seconds = Math.max(0, Math.round((Date.now() - time) / 1000));
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
 }

--- a/packages/monitor-ui/src/components/StartMissionLauncher.test.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.test.tsx
@@ -5,23 +5,26 @@ import { StartMissionLauncher } from "./StartMissionLauncher.js";
 
 afterEach(cleanup);
 
-function openLauncher(r: RenderResult) {
-  fireEvent.click(r.getByRole("button", { name: "Start a mission" }));
-}
-
+// The launcher is always-expanded now (no "Start a mission" toggle): the form
+// is present the moment it renders.
 function selectFlow(r: RenderResult, label: string) {
   const radio = r.getByText(label).closest("label")?.querySelector("input");
   fireEvent.click(radio as HTMLInputElement);
 }
 
-function launch(r: RenderResult) {
-  fireEvent.click(r.getByRole("button", { name: "Launch mission" }));
+// The submit button's label states the consequence — "Propose mission" (the
+// safe default) or "Launch mission" (when approval is turned off).
+function submit(r: RenderResult) {
+  fireEvent.click(r.getByRole("button", { name: /Propose mission|Launch mission/ }));
+}
+
+function toggleApproval(r: RenderResult) {
+  fireEvent.click(r.getByLabelText(/Request approval/));
 }
 
 describe("StartMissionLauncher — Citation Repair flow", () => {
   test("selecting Citation Repair swaps Target URL for a read-only Job ID field", () => {
     const r = render(<StartMissionLauncher onSpawnMission={() => {}} />);
-    openLauncher(r);
     selectFlow(r, "Citation Repair");
 
     expect(r.getByLabelText(/Job ID/)).toBeTruthy();
@@ -29,26 +32,25 @@ describe("StartMissionLauncher — Citation Repair flow", () => {
     expect(r.getByText(/read-only analysis/i)).toBeTruthy();
   });
 
-  test("launching Citation Repair with a Job ID spawns { mode: citation_repair, jobId } and no target", () => {
+  test("proposing Citation Repair with a Job ID spawns { mode: citation_repair, jobId } and no target", () => {
     const onSpawnMission = vi.fn();
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
     selectFlow(r, "Citation Repair");
     fireEvent.change(r.getByLabelText(/Job ID/), { target: { value: "wiki-en-62871101" } });
-    launch(r);
+    submit(r);
 
     expect(onSpawnMission).toHaveBeenCalledTimes(1);
+    // Propose-by-default → initialStatus "requested".
     expect(onSpawnMission).toHaveBeenCalledWith(
-      expect.objectContaining({ mode: "citation_repair", jobId: "wiki-en-62871101", targetUrl: "", initialStatus: "ready" })
+      expect.objectContaining({ mode: "citation_repair", jobId: "wiki-en-62871101", targetUrl: "", initialStatus: "requested" })
     );
   });
 
   test("Citation Repair with an empty Job ID still launches (workflow auto-selects)", () => {
     const onSpawnMission = vi.fn();
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
     selectFlow(r, "Citation Repair");
-    launch(r);
+    submit(r);
 
     expect(onSpawnMission).toHaveBeenCalledTimes(1);
     const arg = onSpawnMission.mock.calls[0]![0];
@@ -59,14 +61,44 @@ describe("StartMissionLauncher — Citation Repair flow", () => {
   test("does not regress: Surface Sweep still launches with a targetUrl and no jobId", () => {
     const onSpawnMission = vi.fn();
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
-    launch(r); // surface_sweep is the default flow
+    submit(r); // surface_sweep is the default flow
 
     expect(onSpawnMission).toHaveBeenCalledTimes(1);
     const arg = onSpawnMission.mock.calls[0]![0];
     expect(arg.mode).toBe("surface_sweep");
     expect(arg.targetUrl).toMatch(/^https?:\/\//);
+    expect(arg.initialStatus).toBe("requested"); // propose by default
     expect(arg).not.toHaveProperty("jobId");
+  });
+});
+
+describe("StartMissionLauncher — intuitive flow picker + consequence CTA", () => {
+  test("shows a plain-language description for the selected flow", () => {
+    const r = render(<StartMissionLauncher onSpawnMission={() => {}} />);
+    // Default flow's description is visible up front.
+    expect(r.getByText(/Read-only crawl/)).toBeTruthy();
+    selectFlow(r, "Gold Path");
+    expect(r.getByText(/end-to-end/)).toBeTruthy();
+    selectFlow(r, "Role Gating");
+    expect(r.getByText(/access controls/)).toBeTruthy();
+  });
+
+  test("CTA states the consequence: Propose by default, Launch when approval is off", () => {
+    const onSpawnMission = vi.fn();
+    const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
+    // Default: propose (safe — goes to Your decisions).
+    expect(r.getByRole("button", { name: "Propose mission" })).toBeTruthy();
+    expect(r.getByText(/lands in Your decisions/)).toBeTruthy();
+
+    // Turn approval off → auto-dispatch.
+    toggleApproval(r);
+    expect(r.getByRole("button", { name: "Launch mission" })).toBeTruthy();
+    expect(r.getByText(/Auto-dispatch/)).toBeTruthy();
+
+    submit(r);
+    expect(onSpawnMission).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: "surface_sweep", initialStatus: "ready" })
+    );
   });
 });
 
@@ -74,19 +106,17 @@ describe("StartMissionLauncher — launch feedback (no more silent close)", () =
   test("a reported success shows 'Mission requested ✓' and keeps the panel open", async () => {
     const onSpawnMission = vi.fn(async () => ({ ok: true, status: 200 }));
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
-    launch(r);
+    submit(r);
 
     expect(await r.findByText(/Mission requested ✓/)).toBeTruthy();
-    // The panel stays open (the silent close was the "nothing happens" report).
+    // The panel stays put (the silent close was the "nothing happens" report).
     expect(r.getByText("Target")).toBeTruthy();
   });
 
   test("a non-2xx POST shows an explicit failure instead of failing silently", async () => {
     const onSpawnMission = vi.fn(async () => ({ ok: false, status: 500 }));
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
-    launch(r);
+    submit(r);
 
     const alert = await r.findByRole("alert");
     expect(alert.textContent).toMatch(/Launch failed — HTTP 500/);
@@ -96,8 +126,7 @@ describe("StartMissionLauncher — launch feedback (no more silent close)", () =
   test("a network failure ({ ok:false, error }) reads as a failure, not success", async () => {
     const onSpawnMission = vi.fn(async () => ({ ok: false, error: "network" }));
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
-    launch(r);
+    submit(r);
 
     const alert = await r.findByRole("alert");
     expect(alert.textContent).toMatch(/Launch failed — network/);
@@ -106,8 +135,7 @@ describe("StartMissionLauncher — launch feedback (no more silent close)", () =
   test("a fire-and-forget handler (returns void) still confirms best-effort", () => {
     const onSpawnMission = vi.fn(() => {});
     const r = render(<StartMissionLauncher onSpawnMission={onSpawnMission} />);
-    openLauncher(r);
-    launch(r);
+    submit(r);
 
     expect(r.getByText(/Mission requested ✓/)).toBeTruthy(); // synchronous, no await
   });

--- a/packages/monitor-ui/src/components/StartMissionLauncher.tsx
+++ b/packages/monitor-ui/src/components/StartMissionLauncher.tsx
@@ -6,8 +6,22 @@ import type {
   MissionLaunchResult,
   SaveTestSuiteInput,
 } from "../lib/monitor/mission-launch.js";
+import { UtilCard } from "./UtilCard.js";
 
 const DEFAULT_TARGET = "https://app.averray.com";
+
+/**
+ * The mission flows, with a plain-language line each (the operator's #1 pain was
+ * bare radios with no hint what "Role Gating" or "Citation Repair" does). The
+ * tag mirrors the server's mutation posture; the description is the honest
+ * one-liner shown under the picker for the selected flow.
+ */
+const FLOWS: { mode: MissionLaunchMode; name: string; tag: string; desc: string }[] = [
+  { mode: "surface_sweep", name: "Surface Sweep", tag: "read-only", desc: "Read-only crawl — visits and observes, never mutates." },
+  { mode: "gold_path", name: "Gold Path", tag: "testnet", desc: "Runs a critical journey end-to-end on testnet — pass / fail." },
+  { mode: "siwe_auth", name: "Role Gating", tag: "read-only", desc: "Checks access controls hold for each role — read-only." },
+  { mode: "citation_repair", name: "Citation Repair", tag: "read-only", desc: "Read-only domain repair against a Job ID — dry run, no claim or edit." },
+];
 
 export interface StartMissionLauncherProps {
   onSpawnMission?: (input: MissionLaunchInput) => MissionLaunchOutcome;
@@ -21,12 +35,14 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
   const jobIdId = useId();
   const goalId = useId();
   const suiteNameId = useId();
-  const [open, setOpen] = useState(false);
+  const flowDescId = useId();
   const [targetUrl, setTargetUrl] = useState(DEFAULT_TARGET);
   const [jobId, setJobId] = useState("");
   const [mode, setMode] = useState<MissionLaunchMode>("surface_sweep");
   const [freshMemory, setFreshMemory] = useState(true);
-  const [requestApproval, setRequestApproval] = useState(false);
+  // Propose-by-default: the first click PROPOSES the mission for review rather
+  // than auto-dispatching it (no accidental runs). Turn it off for auto-dispatch.
+  const [requestApproval, setRequestApproval] = useState(true);
   const [saveSuite, setSaveSuite] = useState(false);
   const [suiteName, setSuiteName] = useState("");
   const [goal, setGoal] = useState("");
@@ -35,6 +51,7 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
   const [feedback, setFeedback] = useState<LaunchFeedback | null>(null);
 
   const isCitation = mode === "citation_repair";
+  const activeFlow = FLOWS.find((flow) => flow.mode === mode)!;
 
   // Turn the spawn outcome into honest feedback. `undefined` means the handler
   // is fire-and-forget (the /mission command path or a test mock) — best-effort
@@ -109,176 +126,164 @@ export function StartMissionLauncher({ onSpawnMission, onSaveSuite }: StartMissi
   };
 
   return (
-    <section className="hm-mission-launcher" aria-label="Start a mission">
-      <div className="hm-mission-launcher-head">
-        <div>
-          <span className="hm-mission-launcher-kicker">Tester</span>
-          <strong>Start a mission</strong>
-          <span>Launch a real browser run from the board.</span>
-        </div>
-        <button type="button" className="hm-btn hm-btn--primary hm-btn--sm" onClick={() => setOpen((value) => !value)}>
-          {open ? "Close" : "Start a mission"}
-        </button>
-      </div>
-
-      {open ? (
-        <form className="hm-mission-launcher-form" onSubmit={submit}>
-          {isCitation ? (
-            <label className="hm-field hm-field--wide" htmlFor={jobIdId}>
-              <span>Job ID</span>
-              <input
-                id={jobIdId}
-                type="text"
-                value={jobId}
-                onChange={(event) => setJobId(event.target.value)}
-                placeholder="Leave empty to auto-select a claimable job"
-              />
-              <small>read-only analysis — no claim or edit (dry run)</small>
-            </label>
-          ) : (
-            <label className="hm-field hm-field--wide" htmlFor={targetId}>
-              <span>Target</span>
-              <input
-                id={targetId}
-                type="url"
-                required
-                value={targetUrl}
-                onChange={(event) => setTargetUrl(event.target.value)}
-                placeholder={DEFAULT_TARGET}
-              />
-            </label>
-          )}
-
-          <fieldset className="hm-choice-group">
-            <legend>Flow</legend>
-            <label>
-              <input
-                type="radio"
-                name="mission-flow"
-                checked={mode === "surface_sweep"}
-                onChange={() => setMode("surface_sweep")}
-              />
-              <span>Surface Sweep</span>
-              <small>read-only</small>
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="mission-flow"
-                checked={mode === "gold_path"}
-                onChange={() => setMode("gold_path")}
-              />
-              <span>Gold Path</span>
-              <small>testnet</small>
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="mission-flow"
-                checked={mode === "siwe_auth"}
-                onChange={() => setMode("siwe_auth")}
-              />
-              <span>Role Gating</span>
-              <small>read-only</small>
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="mission-flow"
-                checked={mode === "citation_repair"}
-                onChange={() => setMode("citation_repair")}
-              />
-              <span>Citation Repair</span>
-              <small>read-only</small>
-            </label>
-          </fieldset>
-
-          <fieldset className="hm-choice-group hm-choice-group--compact">
-            <legend>Memory</legend>
-            <label>
-              <input
-                type="radio"
-                name="mission-memory"
-                checked={freshMemory}
-                onChange={() => setFreshMemory(true)}
-              />
-              <span>Fresh</span>
-            </label>
-            <label>
-              <input
-                type="radio"
-                name="mission-memory"
-                checked={!freshMemory}
-                onChange={() => setFreshMemory(false)}
-              />
-              <span>Memory</span>
-            </label>
-          </fieldset>
-
-          <label className="hm-field hm-field--wide" htmlFor={goalId}>
-            <span>Goal</span>
-            <textarea
-              id={goalId}
-              value={goal}
-              onChange={(event) => setGoal(event.target.value)}
-              placeholder="Optional scope or question for the browser agent"
-              rows={2}
-            />
-          </label>
-
-          <label className="hm-checkbox-row">
-            <input
-              type="checkbox"
-              checked={requestApproval}
-              onChange={(event) => setRequestApproval(event.target.checked)}
-            />
-            <span>Request approval before the runner claims it</span>
-          </label>
-
-          {onSaveSuite ? (
-            <>
-              <label className="hm-checkbox-row">
-                <input
-                  type="checkbox"
-                  checked={saveSuite}
-                  onChange={(event) => setSaveSuite(event.target.checked)}
-                />
-                <span>Save this config as a suite</span>
-              </label>
-              {saveSuite ? (
-                <label className="hm-field" htmlFor={suiteNameId}>
-                  <span>Suite name</span>
+    <UtilCard title="Start a mission" hint="tester launcher" ariaLabel="Start a mission">
+      <form className="hm-mission-launcher-form" onSubmit={submit}>
+        {/* Flow as labelled cards + one honest description for the active flow. */}
+        <div className="hm-flow-field">
+          <span className="hm-field-eyebrow">Flow</span>
+          <div className="hm-flow-grid" role="radiogroup" aria-label="Flow">
+            {FLOWS.map((flow) => {
+              const on = mode === flow.mode;
+              return (
+                <label key={flow.mode} className={`hm-flow-card${on ? " hm-flow-card--on" : ""}`}>
                   <input
-                    id={suiteNameId}
-                    value={suiteName}
-                    onChange={(event) => setSuiteName(event.target.value)}
-                    placeholder="Daily app sweep"
+                    type="radio"
+                    name="mission-flow"
+                    className="hm-visually-hidden"
+                    checked={on}
+                    onChange={() => setMode(flow.mode)}
+                    aria-describedby={flowDescId}
                   />
+                  <span className="hm-flow-dot" aria-hidden />
+                  <span className="hm-flow-name">{flow.name}</span>
+                  {flow.tag ? <span className="hm-flow-tag">{flow.tag}</span> : null}
                 </label>
-              ) : null}
-            </>
-          ) : null}
-
-          {error ? <div className="hm-form-error" role="alert">{error}</div> : null}
-          {feedback ? (
-            feedback.ok ? (
-              <div className="hm-form-ok" role="status">Mission requested ✓ — {feedback.detail}.</div>
-            ) : (
-              <div className="hm-form-error" role="alert">
-                Launch failed — {feedback.detail}. The board can’t confirm it; check the tester runner.
-              </div>
-            )
-          ) : null}
-
-          <div className="hm-mission-launcher-actions">
-            <button type="submit" className="hm-btn hm-btn--action" disabled={pending}>
-              {pending ? "Launching…" : "Launch mission"}
-            </button>
-            <span>Server derives mutation safety from target, flow, and environment.</span>
+              );
+            })}
           </div>
-        </form>
-      ) : null}
-    </section>
+          <p className="hm-flow-desc" id={flowDescId}>{activeFlow.desc}</p>
+        </div>
+
+        {/* target / job-id swap — citation_repair keys off a Job ID. */}
+        {isCitation ? (
+          <label className="hm-field hm-field--wide" htmlFor={jobIdId}>
+            <span>Job ID</span>
+            <input
+              id={jobIdId}
+              type="text"
+              value={jobId}
+              onChange={(event) => setJobId(event.target.value)}
+              placeholder="Leave empty to auto-select a claimable job"
+            />
+            <small>read-only analysis — no claim or edit (dry run)</small>
+          </label>
+        ) : (
+          <label className="hm-field hm-field--wide" htmlFor={targetId}>
+            <span>Target</span>
+            <input
+              id={targetId}
+              type="url"
+              required
+              value={targetUrl}
+              onChange={(event) => setTargetUrl(event.target.value)}
+              placeholder={DEFAULT_TARGET}
+            />
+          </label>
+        )}
+
+        <fieldset className="hm-choice-group">
+          <legend>Memory</legend>
+          <label>
+            <input
+              type="radio"
+              name="mission-memory"
+              checked={freshMemory}
+              onChange={() => setFreshMemory(true)}
+            />
+            <span>Fresh</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="mission-memory"
+              checked={!freshMemory}
+              onChange={() => setFreshMemory(false)}
+            />
+            <span>Memory</span>
+          </label>
+        </fieldset>
+
+        <label className="hm-field hm-field--wide" htmlFor={goalId}>
+          <span>Goal</span>
+          <textarea
+            id={goalId}
+            value={goal}
+            onChange={(event) => setGoal(event.target.value)}
+            placeholder="Optional scope or question for the browser agent"
+            rows={2}
+          />
+        </label>
+
+        <div className="hm-toggle-row">
+          <ToggleChip checked={requestApproval} onChange={setRequestApproval}>
+            Request approval
+          </ToggleChip>
+          {onSaveSuite ? (
+            <ToggleChip checked={saveSuite} onChange={setSaveSuite}>
+              Save this config as a suite
+            </ToggleChip>
+          ) : null}
+        </div>
+
+        {saveSuite && onSaveSuite ? (
+          <label className="hm-field" htmlFor={suiteNameId}>
+            <span>Suite name</span>
+            <input
+              id={suiteNameId}
+              value={suiteName}
+              onChange={(event) => setSuiteName(event.target.value)}
+              placeholder="Daily app sweep"
+            />
+          </label>
+        ) : null}
+
+        {error ? <div className="hm-form-error" role="alert">{error}</div> : null}
+        {feedback ? (
+          feedback.ok ? (
+            <div className="hm-form-ok" role="status">Mission requested ✓ — {feedback.detail}.</div>
+          ) : (
+            <div className="hm-form-error" role="alert">
+              Launch failed — {feedback.detail}. The board can’t confirm it; check the tester runner.
+            </div>
+          )
+        ) : null}
+
+        <div className="hm-launcher-actions">
+          <button type="submit" className="hm-btn hm-btn--launch" disabled={pending}>
+            {pending ? "Launching…" : requestApproval ? "Propose mission" : "Launch mission"}
+          </button>
+          <p className="hm-launch-explainer">
+            {requestApproval
+              ? "Hermes reviews before any runner claims it — lands in Your decisions."
+              : "Auto-dispatch — runs immediately, without a review gate."}
+          </p>
+        </div>
+      </form>
+    </UtilCard>
+  );
+}
+
+/** A pill toggle that keeps a real, label-associated checkbox for a11y + tests. */
+function ToggleChip({
+  checked,
+  onChange,
+  children,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  children: string;
+}) {
+  return (
+    <label className={`hm-toggle-chip${checked ? " hm-toggle-chip--on" : ""}`}>
+      <input
+        type="checkbox"
+        className="hm-visually-hidden"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+      />
+      <span className="hm-toggle-dot" aria-hidden />
+      <span>{children}</span>
+    </label>
   );
 }
 

--- a/packages/monitor-ui/src/components/TestSuitesPanel.tsx
+++ b/packages/monitor-ui/src/components/TestSuitesPanel.tsx
@@ -1,5 +1,6 @@
 import { useId, useMemo, useState, type FormEvent } from "react";
 import type { MissionLaunchMode, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+import { UtilCard } from "./UtilCard.js";
 
 const DEFAULT_TARGET = "https://app.averray.com";
 
@@ -55,21 +56,19 @@ export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite, onApprov
     setOpen(false);
   };
 
-  return (
-    <section className="hm-test-suites" aria-label="Saved test suites">
-      <div className="hm-mission-launcher-head">
-        <div>
-          <span className="hm-mission-launcher-kicker">Suites</span>
-          <strong>Saved suite library</strong>
-          <span>{suites.length > 0 ? `${suites.length} named suites` : "No saved suites yet"}</span>
-        </div>
-        {onSaveSuite ? (
-          <button type="button" className="hm-btn hm-btn--sm" onClick={() => setOpen((value) => !value)}>
-            {open ? "Close" : "+ New suite"}
-          </button>
-        ) : null}
-      </div>
+  const newSuiteButton = onSaveSuite ? (
+    <button type="button" className="hm-btn hm-btn--sm hm-btn--dashed" onClick={() => setOpen((value) => !value)}>
+      {open ? "Close" : "+ New suite"}
+    </button>
+  ) : undefined;
 
+  return (
+    <UtilCard
+      title="Saved suites"
+      hint={suites.length > 0 ? `${suites.length} saved` : "library"}
+      action={newSuiteButton}
+      ariaLabel="Saved test suites"
+    >
       {sortedSuites.length > 0 ? (
         <div className="hm-test-suite-list">
           {sortedSuites.map((suite) => (
@@ -109,7 +108,13 @@ export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite, onApprov
           ))}
         </div>
       ) : (
-        <p className="hm-test-suite-empty">Save a launcher config or create a named suite for repeat testbed runs.</p>
+        <div className="hm-suite-empty">
+          <span className="hm-suite-empty-icon" aria-hidden>·</span>
+          <div>
+            <strong>No saved suites yet</strong>
+            <span>Save a launcher config or create a named suite for repeat testbed runs.</span>
+          </div>
+        </div>
       )}
 
       {open ? (
@@ -173,7 +178,7 @@ export function TestSuitesPanel({ suites = [], onRunSuite, onSaveSuite, onApprov
           </div>
         </form>
       ) : null}
-    </section>
+    </UtilCard>
   );
 }
 

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { UsagePanel } from "./UsagePanel.js";
+import type { LlmUsageAggregate } from "../lib/monitor/board-cache.js";
+
+afterEach(cleanup);
+
+const recorded: LlmUsageAggregate = {
+  status: "recorded",
+  inputTokens: 8_000,
+  outputTokens: 2_000,
+  totalTokens: 10_000,
+  costUsd: null,
+  costStatus: "not_recorded",
+  runs: 5,
+  lastActiveAt: "2026-06-09T10:00:00.000Z",
+  byModel: [
+    {
+      agent: "hermes",
+      model: "deepseek-v4-pro",
+      inputTokens: 8_000,
+      outputTokens: 2_000,
+      totalTokens: 10_000,
+      costUsd: null,
+      costStatus: "not_recorded",
+      runs: 5,
+      lastActiveAt: "2026-06-09T10:00:00.000Z",
+    },
+  ],
+  byDay: [],
+};
+
+describe("UsagePanel", () => {
+  test("renders the real per-model table with a '?' latency (never fabricated)", () => {
+    const { getByText, getAllByText, getByRole } = render(<UsagePanel usage={recorded} />);
+    expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
+    expect(getByText("All models")).toBeTruthy();
+    expect(getByText("deepseek-v4-pro")).toBeTruthy();
+    expect(getAllByText("10K").length).toBeGreaterThan(0); // total + model row, compact
+    expect(getAllByText("?").length).toBeGreaterThan(0); // latency has no source
+  });
+
+  test("shows an honest awaiting-data chart slot — never a synthetic series", () => {
+    const { getByText, getByLabelText } = render(<UsagePanel usage={recorded} />);
+    expect(getByLabelText("Recent per-model usage — awaiting data stream")).toBeTruthy();
+    expect(getByText("not wired")).toBeTruthy();
+    expect(getByText("awaiting per-model usage stream")).toBeTruthy();
+  });
+
+  test("renders the honest empty state when nothing is recorded", () => {
+    const empty: LlmUsageAggregate = {
+      status: "not_recorded",
+      message: "No LLM usage counters have been recorded yet.",
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+      costUsd: null,
+      costStatus: "not_recorded",
+      runs: 0,
+      byModel: [],
+      byDay: [],
+    };
+    const { getByText, queryByText } = render(<UsagePanel usage={empty} />);
+    expect(getByText("usage not reported")).toBeTruthy();
+    expect(getByText(/No LLM usage counters have been recorded yet/)).toBeTruthy();
+    // No awaiting-data chart and no fabricated rows when there's nothing real.
+    expect(queryByText("not wired")).toBeNull();
+  });
+});

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react";
+import type { LlmUsageAggregate } from "../lib/monitor/board-cache.js";
+import { formatCompactNumber, formatNumber, formatRelativeTime } from "../lib/monitor/format.js";
+import { UtilCard } from "./UtilCard.js";
+
+/**
+ * LLM usage card — the redesigned, design-faithful surface for the Utilities
+ * panel. Binds ONLY to real LlmUsageAggregate: per-(agent, model) rows, an
+ * "All models" total, the in-flight line, and idle sources with their honest
+ * reasons one click away. Truth-boundary:
+ *   - Latency renders "?" — LlmUsageModelRollup has no latency field.
+ *   - Cost is never shown while costStatus is "not_recorded".
+ *   - The recent-usage chart is an explicit awaiting-data frame, never the
+ *     design's synthetic "demo shape" series (no real per-minute stream exists).
+ *   - When nothing is recorded, the honest message replaces the table — no
+ *     zero-filled fake rows.
+ */
+export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
+  const [showIdle, setShowIdle] = useState(false);
+  const recorded = usage?.status === "recorded";
+  const latestDay = usage?.byDay?.[0];
+  // Every (agent, model) that actually reported counters.
+  const models = usage?.byModel?.length ? usage.byModel : latestDay?.byModel ?? [];
+  // Idle sources collapse into ONE line; their honest reasons stay reachable.
+  const idleSources = (usage?.sourceStatus ?? []).filter((entry) => entry.status === "not_reported");
+  const activeCalls = usage?.activeCalls ?? [];
+  const emptyMessage = usage?.message
+    ?? "No LLM usage counters have been recorded yet. Sources stay not reported until a real provider or runner emits whitelisted counters.";
+  const hasTable = recorded && models.length > 0;
+
+  return (
+    <UtilCard title="LLM usage" hint="per model · last 60 min" fill ariaLabel="LLM usage">
+      {hasTable ? (
+        <div className="hm-usage-table">
+          <div className="hm-usage-row hm-usage-row--head">
+            <span className="hm-usage-c-model">Model</span>
+            <span className="hm-usage-c-num">Tokens</span>
+            <span className="hm-usage-c-num">Calls</span>
+            <span className="hm-usage-c-num">Latency</span>
+          </div>
+          <div className="hm-usage-row hm-usage-row--total">
+            <span className="hm-usage-c-model">All models</span>
+            <span className="hm-usage-c-num">{formatCompactNumber(usage!.totalTokens)}</span>
+            <span className="hm-usage-c-num">{formatNumber(usage!.runs)}</span>
+            <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
+          </div>
+          {models.map((entry) => (
+            <div className="hm-usage-row" key={`${entry.agent}:${entry.model}`}>
+              <span className="hm-usage-c-model">
+                <span className="hm-usage-jewel" style={{ background: agentJewel(entry.agent) }} aria-hidden />
+                <span className="hm-usage-model">{entry.model}</span>
+                <span className="hm-usage-owner">{entry.agent}</span>
+              </span>
+              <span className="hm-usage-c-num">{formatCompactNumber(entry.totalTokens)}</span>
+              <span className="hm-usage-c-num">{formatNumber(entry.runs)}</span>
+              <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
+            </div>
+          ))}
+          {/* in/out split + last-active live below the table, per active source */}
+          <div className="hm-usage-splits">
+            {models.map((entry) => {
+              // Only draw the split bar when there's a real in+out denominator —
+              // a cache-only row (totalTokens from cacheTokens, in+out === 0)
+              // would otherwise paint a fabricated 100% bar.
+              const flow = entry.inputTokens + entry.outputTokens;
+              const inPct = flow > 0 ? Math.round((entry.inputTokens / flow) * 100) : 0;
+              return (
+                <div className="hm-usage-split" key={`${entry.agent}:${entry.model}:split`}>
+                  {flow > 0 ? (
+                    <div
+                      className="hm-usage-bar"
+                      role="img"
+                      aria-label={`${formatCompactNumber(entry.inputTokens)} in, ${formatCompactNumber(entry.outputTokens)} out`}
+                    >
+                      <span className="hm-usage-bar-in" style={{ width: `${inPct}%` }} />
+                      <span className="hm-usage-bar-out" style={{ width: `${100 - inPct}%` }} />
+                    </div>
+                  ) : null}
+                  <small>{formatCompactNumber(entry.inputTokens)} in · {formatCompactNumber(entry.outputTokens)} out · last {formatRelativeTime(entry.lastActiveAt)}</small>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ) : (
+        <p className="hm-usage-empty">
+          <strong>usage not reported</strong>
+          <span>{emptyMessage}</span>
+        </p>
+      )}
+
+      {/* What's running now (in-flight) — always glanceable. */}
+      <div className="hm-usage-active">
+        <span>What's running now</span>
+        <strong>
+          {activeCalls.length > 0
+            ? activeCalls.map((call) => `${call.agent} · ${call.model}`).join(" · ")
+            : "No in-flight LLM calls"}
+        </strong>
+      </div>
+
+      {/* Idle sources — one muted line; honest reasons one click away. */}
+      {idleSources.length > 0 ? (
+        <div className="hm-usage-idle">
+          <button
+            type="button"
+            className="hm-usage-idle-toggle"
+            aria-expanded={showIdle}
+            onClick={() => setShowIdle((value) => !value)}
+          >
+            <span aria-hidden>{showIdle ? "▾" : "▸"}</span>
+            {idleSources.length} source{idleSources.length === 1 ? "" : "s"} idle: {idleSources.map((entry) => entry.agent).join(" · ")}
+          </button>
+          {showIdle ? (
+            <ul className="hm-usage-idle-list">
+              {idleSources.map((entry) => (
+                <li key={entry.agent}>
+                  <strong>{entry.agent}</strong>
+                  <span>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+
+      {/* Recent-usage chart slot — honest awaiting-data frame, never synthetic
+          data. Keeps the design's visual slot; a real per-minute stream renders
+          here when it lands. */}
+      {hasTable ? (
+        <div className="hm-usage-chart" role="img" aria-label="Recent per-model usage — awaiting data stream">
+          <div className="hm-usage-chart-head">
+            <span className="hm-usage-chart-label">Recent usage · tokens/min · per model</span>
+            <span className="hm-usage-chart-chip">not wired</span>
+          </div>
+          <svg className="hm-usage-chart-frame" viewBox="0 0 300 120" preserveAspectRatio="none" aria-hidden>
+            {[0.25, 0.5, 0.75].map((g) => (
+              <line key={g} x1="4" x2="296" y1={8 + g * 94} y2={8 + g * 94} stroke="var(--h4-line-2)" strokeWidth="1" />
+            ))}
+            {["-60m", "-45m", "-30m", "-15m", "now"].map((t, i) => (
+              <text
+                key={t}
+                x={4 + (i / 4) * 292}
+                y="116"
+                fill="var(--h4-faint)"
+                fontSize="8"
+                fontFamily="var(--font-mono)"
+                textAnchor={i === 0 ? "start" : i === 4 ? "end" : "middle"}
+              >
+                {t}
+              </text>
+            ))}
+          </svg>
+          <span className="hm-usage-chart-note">awaiting per-model usage stream</span>
+        </div>
+      ) : null}
+    </UtilCard>
+  );
+}
+
+/**
+ * Map an agent to its --h4 jewel token. Unknown agents fall back to the system
+ * jewel — never a fabricated identity or hardcoded hex.
+ */
+function agentJewel(agent: string): string {
+  const a = agent.toLowerCase();
+  if (a.includes("hermes")) return "var(--h4-ag-hermes)";
+  if (a.includes("codex")) return "var(--h4-ag-codex)";
+  if (a.includes("test")) return "var(--h4-ag-test)";
+  if (a.includes("claude")) return "var(--h4-ag-claude)";
+  if (a.includes("operator") || a === "op") return "var(--h4-ag-op)";
+  return "var(--h4-ag-system)";
+}

--- a/packages/monitor-ui/src/components/UtilCard.test.tsx
+++ b/packages/monitor-ui/src/components/UtilCard.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { UtilCard } from "./UtilCard.js";
+
+afterEach(cleanup);
+
+describe("UtilCard", () => {
+  test("exposes the title as the section's accessible region name", () => {
+    const { getByRole } = render(
+      <UtilCard title="LLM usage">
+        <p>body</p>
+      </UtilCard>,
+    );
+    expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
+  });
+
+  test("renders the hint and action slot in the header", () => {
+    const { getByText } = render(
+      <UtilCard title="Saved suites" hint="library" action={<button type="button">+ New suite</button>}>
+        <p>body</p>
+      </UtilCard>,
+    );
+    expect(getByText("library")).toBeTruthy();
+    expect(getByText("+ New suite")).toBeTruthy();
+  });
+
+  test("ariaLabel overrides the title for the region name", () => {
+    const { getByRole } = render(
+      <UtilCard title="Start a mission" ariaLabel="Mission launcher">
+        <p>body</p>
+      </UtilCard>,
+    );
+    expect(getByRole("region", { name: "Mission launcher" })).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/UtilCard.tsx
+++ b/packages/monitor-ui/src/components/UtilCard.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+export interface UtilCardProps {
+  /** Card title (display font). Doubles as the section's accessible name. */
+  title: string;
+  /** Faint eyebrow hint to the right of the title (e.g. "per model · last 60 min"). */
+  hint?: string;
+  /** Optional right-aligned action slot (e.g. a "+ New suite" button). */
+  action?: ReactNode;
+  /** Stretch to fill the grid cell height (the usage card on the left). */
+  fill?: boolean;
+  /** Override the accessible region name when it should differ from the title. */
+  ariaLabel?: string;
+  children?: ReactNode;
+}
+
+/**
+ * Shared, calm card chrome for the Utilities panel (usage · suites · launcher).
+ * One header treatment so the three surfaces read as siblings; secondary to the
+ * board (dim paper, hairline border). All color comes from the --h4-* profile
+ * tokens so it tracks the active theme.
+ */
+export function UtilCard({ title, hint, action, fill, ariaLabel, children }: UtilCardProps) {
+  return (
+    <section className={`hm-util-card${fill ? " hm-util-card--fill" : ""}`} aria-label={ariaLabel ?? title}>
+      <div className="hm-util-card-head">
+        <span className="hm-util-card-title">{title}</span>
+        {hint ? <span className="hm-util-card-hint">{hint}</span> : null}
+        {action ? <span className="hm-util-card-action">{action}</span> : null}
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/packages/monitor-ui/src/components/UtilitiesPanel.tsx
+++ b/packages/monitor-ui/src/components/UtilitiesPanel.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import type { LlmUsageAggregate } from "../lib/monitor/board-cache.js";
+import type { MissionLaunchOutcome, MissionSpawnInput, SavedTestSuite, SaveTestSuiteInput } from "../lib/monitor/mission-launch.js";
+import { formatCompactNumber } from "../lib/monitor/format.js";
+import { UsagePanel } from "./UsagePanel.js";
+import { TestSuitesPanel } from "./TestSuitesPanel.js";
+import { StartMissionLauncher } from "./StartMissionLauncher.js";
+import { Badge } from "./ui.js";
+
+export interface UtilitiesPanelProps {
+  usage?: LlmUsageAggregate;
+  suites?: SavedTestSuite[];
+  onRunSuite?: (id: string) => void;
+  onSaveSuite?: (input: SaveTestSuiteInput) => void;
+  onApproveSuite?: (id: string) => void;
+  onDismissSuite?: (id: string) => void;
+  onSpawnMission?: (input: MissionSpawnInput) => MissionLaunchOutcome;
+}
+
+/**
+ * The supporting Utilities row: a collapsed strip that expands into a calm,
+ * two-column card surface — real LLM usage on the left, the mission launcher
+ * over the saved-suite library on the right. Secondary to the board; the only
+ * coral is the selected mission flow. Auto-opens when a suite is awaiting the
+ * operator (a requested agent-authored suite).
+ */
+export function UtilitiesPanel({
+  usage,
+  suites = [],
+  onRunSuite,
+  onSaveSuite,
+  onApproveSuite,
+  onDismissSuite,
+  onSpawnMission,
+}: UtilitiesPanelProps) {
+  const requestedSuites = suites.filter((suite) => suite.status === "requested").length;
+  const shouldOpen = requestedSuites > 0;
+  const [open, setOpen] = useState(shouldOpen);
+  useEffect(() => {
+    if (shouldOpen) setOpen(true);
+  }, [shouldOpen]);
+
+  const usageLabel = usage?.status === "recorded"
+    ? `${formatCompactNumber(usage.totalTokens)} tokens`
+    : "usage quiet";
+  const suitesLabel = suites.length > 0
+    ? `${suites.length} suite${suites.length === 1 ? "" : "s"}`
+    : "no suites";
+  const launcherLabel = onSpawnMission ? "tester ready" : "tester off";
+
+  return (
+    <section className={`hm-utility-bar${requestedSuites > 0 ? " hm-utility-bar--attention" : ""}`} aria-label="Board utilities">
+      <button
+        type="button"
+        className="hm-utility-bar-toggle"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span aria-hidden>{open ? "▾" : "▸"}</span>
+        <span className="hm-kicker">Utilities</span>
+        <strong>LLM usage · suites · tester launcher</strong>
+        <span className="hm-utility-bar-summary">
+          {open ? "collapse" : `${usageLabel} · ${suitesLabel} · ${launcherLabel}`}
+        </span>
+        {requestedSuites > 0 ? <Badge variant="pending">{requestedSuites} requested</Badge> : null}
+      </button>
+      {open ? (
+        <div className="hm-utility-bar-body">
+          <UsagePanel usage={usage} />
+          <div className="hm-util-right">
+            {onSpawnMission ? <StartMissionLauncher onSpawnMission={onSpawnMission} onSaveSuite={onSaveSuite} /> : null}
+            <TestSuitesPanel
+              suites={suites}
+              onRunSuite={onRunSuite}
+              onSaveSuite={onSaveSuite}
+              onApproveSuite={onApproveSuite}
+              onDismissSuite={onDismissSuite}
+            />
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/monitor-ui/src/lib/monitor/format.ts
+++ b/packages/monitor-ui/src/lib/monitor/format.ts
@@ -1,0 +1,25 @@
+// Shared number/time formatters for the monitor surfaces. Extracted verbatim
+// from BoardView so the Utilities panel (UtilitiesPanel, UsagePanel) and the
+// board can share one honest implementation instead of duplicating it.
+
+export function formatNumber(value: number): string {
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+export function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 1 }).format(value);
+}
+
+export function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return "last active unknown";
+  const time = Date.parse(iso);
+  if (!Number.isFinite(time)) return "last active unknown";
+  const seconds = Math.max(0, Math.round((Date.now() - time) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -30,6 +30,9 @@ import "./styles/hermes4-rail.css";
 import "./styles/hermes4-board.css";
 // PR-E1: inbox-first Kanban — hero Decision Inbox + read-only tier columns.
 import "./styles/hermes4-kanban.css";
+// Utilities redesign: calm two-column card panel (LLM usage · suites · launcher)
+// + the redesigned mission-starter. Loaded last so its additive rules win.
+import "./styles/hermes4-utilities.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -1,0 +1,537 @@
+/* Hermes-4 — Utilities panel redesign (LLM usage · suites · tester launcher).
+ *
+ * A calm, dim, two-column card surface that is secondary to the board. Coral
+ * (--h4-act*) appears exactly once: on the selected mission flow. Loaded last
+ * (after hermes4-board.css) so these additive rules win; every color comes from
+ * the active --h4-* profile so the panel tracks the theme. Markup that still
+ * lives in monitor.css (the suite authoring form, choice groups) is untouched.
+ */
+
+/* ── shared card chrome (UtilCard) ───────────────────────────────────────── */
+.hm-util-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 14px 15px;
+  background: var(--h4-paper);
+  border: 1px solid var(--h4-line-2);
+  border-radius: var(--h4-r-card);
+}
+.hm-util-card--fill {
+  height: 100%;
+}
+.hm-util-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.hm-util-card-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 13.5px;
+  color: var(--h4-ink-2);
+  white-space: nowrap;
+  flex: none;
+}
+.hm-util-card-hint {
+  font-family: var(--font-display);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+  flex: none;
+}
+.hm-util-card-action {
+  margin-left: auto;
+}
+
+/* ── the expanded panel grid: usage | (launcher over suites) ─────────────── */
+.hm-utility-bar-body {
+  /* override monitor.css's single-column stack */
+  grid-template-columns: 1fr 1fr;
+  align-items: stretch;
+  gap: 12px;
+  padding: 2px 14px 14px;
+}
+.hm-util-right {
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: 12px;
+  min-width: 0;
+}
+/* the cards no longer carry their own band margins inside the grid */
+.hm-utility-bar-body .hm-llm-usage,
+.hm-utility-bar-body .hm-test-suites,
+.hm-utility-bar-body .hm-mission-launcher {
+  margin: 0;
+}
+/* Collapse on the PANEL's own width — it lives in the narrower lanes column
+   beside the co-pilot rail, not the full viewport, so a container query
+   measures the right axis (a viewport media query collapses too late). */
+.hm-utility-bar {
+  container-type: inline-size;
+}
+@container (max-width: 640px) {
+  .hm-utility-bar-body {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── UsagePanel: per-model table (real data) ─────────────────────────────── */
+.hm-usage-table {
+  display: flex;
+  flex-direction: column;
+}
+.hm-usage-row {
+  display: grid;
+  grid-template-columns: 1fr 56px 46px 62px;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 2px;
+  border-top: 1px solid var(--h4-line-2);
+}
+.hm-usage-row--head {
+  border-top: 0;
+  padding-bottom: 7px;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-usage-row--total {
+  border-top: 1px solid var(--h4-line-2);
+  border-bottom: 1px solid var(--h4-line-2);
+}
+.hm-usage-row--total .hm-usage-c-model,
+.hm-usage-row--total .hm-usage-c-num {
+  font-family: var(--font-display);
+  font-weight: 700;
+  color: var(--h4-ink);
+}
+.hm-usage-c-model {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+}
+.hm-usage-c-num {
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--h4-muted);
+}
+.hm-usage-c-na {
+  color: var(--h4-faint);
+}
+.hm-usage-jewel {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+}
+.hm-usage-model {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--h4-ink-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-usage-owner {
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  color: var(--h4-faint);
+  flex: none;
+}
+.hm-usage-splits {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 9px;
+}
+.hm-usage-split {
+  display: grid;
+  gap: 3px;
+}
+.hm-usage-split small {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+}
+.hm-usage-bar {
+  display: flex;
+  height: 5px;
+  border-radius: 3px;
+  overflow: hidden;
+  background: var(--h4-paper-sunken);
+}
+/* in/out split uses the telemetry token (two opacities) — never --h4-act,
+   which is reserved for the one selected flow card. */
+.hm-usage-bar-in { background: var(--h4-tel); opacity: 0.8; }
+.hm-usage-bar-out { background: var(--h4-tel); opacity: 0.32; }
+
+.hm-usage-empty {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding: 4px 2px;
+}
+.hm-usage-empty strong {
+  font-family: var(--font-display);
+  font-size: 13px;
+  color: var(--h4-muted);
+}
+.hm-usage-empty span {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--h4-faint);
+  text-wrap: pretty;
+}
+
+.hm-usage-active {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--h4-line-2);
+  flex-wrap: wrap;
+}
+.hm-usage-active > span {
+  font-family: var(--font-display);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+  flex: none;
+}
+.hm-usage-active > strong {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--h4-ink-2);
+}
+
+.hm-usage-idle {
+  margin-top: 9px;
+}
+.hm-usage-idle-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 2px 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--h4-faint);
+}
+.hm-usage-idle-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+.hm-usage-idle-list li {
+  display: grid;
+  gap: 2px;
+}
+.hm-usage-idle-list strong {
+  font-family: var(--font-display);
+  font-size: 11.5px;
+  color: var(--h4-ink-2);
+}
+.hm-usage-idle-list span {
+  font-size: 11px;
+  color: var(--h4-faint);
+  line-height: 1.4;
+}
+
+/* recent-usage chart — honest awaiting-data frame (no synthetic series) */
+.hm-usage-chart {
+  margin-top: auto;
+  padding-top: 12px;
+  position: relative;
+}
+.hm-usage-chart-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.hm-usage-chart-label {
+  font-family: var(--font-display);
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-usage-chart-chip {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  padding: 1px 7px;
+  border-radius: var(--h4-r-pill);
+  border: 1px solid var(--h4-line-2);
+  color: var(--h4-faint);
+}
+.hm-usage-chart-frame {
+  display: block;
+  width: 100%;
+  height: 90px;
+  overflow: visible;
+}
+.hm-usage-chart-note {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 34px;
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+  pointer-events: none;
+}
+
+/* ── SuitePanel: honest-empty + rows inside the card ─────────────────────── */
+.hm-suite-empty {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 2px;
+}
+.hm-suite-empty-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  background: var(--h4-paper-sunken);
+  border: 1px solid var(--h4-line-2);
+  color: var(--h4-faint);
+  font-size: 16px;
+}
+.hm-suite-empty > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+.hm-suite-empty strong {
+  font-family: var(--font-display);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--h4-muted);
+}
+.hm-suite-empty span {
+  font-size: 12px;
+  color: var(--h4-faint);
+  line-height: 1.4;
+  text-wrap: pretty;
+}
+.hm-btn.hm-btn--dashed {
+  border-style: dashed;
+}
+/* suite rows read as calmer chips inside the card */
+.hm-util-card .hm-test-suite-list {
+  gap: 8px;
+}
+.hm-util-card .hm-test-suite-row {
+  border: 1px solid var(--h4-line-2);
+  border-radius: var(--h4-r-sm);
+  background: var(--h4-paper-sunken);
+}
+/* suite name truncates rather than overflowing the now half-width card. */
+.hm-util-card .hm-test-suite-row > div:first-child strong {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── LauncherPanel: flow cards + toggle pills + ink CTA ──────────────────── */
+/* The launcher now lives in a half-width card, not the full-width bar — so the
+   old 3-column form grid (≥640px min) overflows. Stack it vertically. */
+.hm-util-card .hm-mission-launcher-form {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 11px;
+  margin-top: 0;
+}
+.hm-util-card .hm-mission-launcher-form > * {
+  min-width: 0;
+  width: 100%;
+}
+/* In-card field labels read as calm faint eyebrows (matching the Flow eyebrow
+   + the design) — not the board's green sage labels that .hm-field spans and
+   .hm-choice-group legends inherit from monitor.css. */
+.hm-util-card .hm-field > span,
+.hm-util-card .hm-choice-group legend {
+  color: var(--h4-faint);
+  letter-spacing: 0.04em !important;
+}
+.hm-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+.hm-field-eyebrow {
+  display: block;
+  margin-bottom: 6px;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-flow-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+.hm-flow-card {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 34px;
+  padding: 0 10px;
+  border-radius: var(--h4-r-sm);
+  border: 1px solid var(--h4-line);
+  background: var(--h4-paper-sunken);
+  cursor: pointer;
+  transition: border-color var(--h4-dur) var(--h4-ease), background var(--h4-dur) var(--h4-ease);
+}
+.hm-flow-card:focus-within {
+  outline: 2px solid var(--h4-act);
+  outline-offset: 1px;
+}
+.hm-flow-card--on {
+  /* the single coral accent in the whole utilities area */
+  border-color: var(--h4-act-line);
+  background: var(--h4-act-soft);
+}
+.hm-flow-dot {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  border: 1.5px solid var(--h4-line-strong);
+  flex: none;
+  display: grid;
+  place-items: center;
+}
+.hm-flow-card--on .hm-flow-dot {
+  border-color: var(--h4-act);
+}
+.hm-flow-card--on .hm-flow-dot::after {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--h4-act);
+}
+.hm-flow-name {
+  font-family: var(--font-display);
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--h4-ink-2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.hm-flow-card--on .hm-flow-name {
+  color: var(--h4-act-text);
+}
+.hm-flow-tag {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--h4-faint);
+  flex: none;
+}
+/* on the selected (coral-soft) card, lift the safety tag so read-only/testnet
+   clears contrast against the warm fill. */
+.hm-flow-card--on .hm-flow-tag {
+  color: var(--h4-act-text);
+}
+.hm-flow-desc {
+  margin: 7px 0 0;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--h4-muted);
+}
+
+.hm-toggle-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.hm-toggle-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 28px;
+  padding: 0 11px;
+  border-radius: var(--h4-r-pill);
+  border: 1px solid var(--h4-line-2);
+  cursor: pointer;
+  font-size: 11.5px;
+  color: var(--h4-faint);
+}
+.hm-toggle-chip:focus-within {
+  outline: 2px solid var(--h4-act);
+  outline-offset: 1px;
+}
+.hm-toggle-chip--on {
+  color: var(--h4-ok-text);
+  border-color: var(--h4-ok-line);
+  background: var(--h4-ok-soft);
+}
+.hm-toggle-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  flex: none;
+}
+.hm-toggle-chip--on .hm-toggle-dot {
+  background: currentColor;
+}
+
+.hm-launcher-actions {
+  display: grid;
+  gap: 6px;
+}
+.hm-btn.hm-btn--launch {
+  /* demoted to ink — never coral — so it never out-shouts the inbox Decide CTA */
+  width: 100%;
+  background: var(--h4-ink);
+  color: var(--h4-paper);
+  border: 1px solid transparent;
+}
+.hm-btn.hm-btn--launch:hover:not(:disabled) {
+  background: var(--h4-ink-2);
+}
+.hm-btn.hm-btn--launch:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.hm-launch-explainer {
+  margin: 0;
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--h4-faint);
+  text-wrap: pretty;
+}


### PR DESCRIPTION
## Why
The operator flagged the **Utilities** row and the **Start a mission** launcher as *"not very intuitive."* This rebuilds both toward the hermes-4 design, with the launcher's intuitiveness as the priority.

## What changed
**Launcher (the main pain):**
- Flows are now **labelled cards** with a plain-language line each — *"Surface Sweep · read-only — visits and observes, never mutates."* No more bare radios with no hint what *Role Gating* / *Citation Repair* do.
- The CTA states its **consequence**: **"Propose mission"** (→ lands in *Your decisions*, the safe default) vs **"Launch mission"** (auto-dispatch), with a one-line explainer.
- **Always-expanded** in the panel (drops the nested *"Start a mission"* toggle); checkboxes → toggle pills.
- The #456 launch feedback (*"Mission requested ✓"* / *"Launch failed"* / *"Launching…"*) is preserved **verbatim**.

**LLM usage:**
- Real per-model table (agent jewels, tokens/calls) bound to `LlmUsageAggregate` **only**. **Latency renders `?`** (no source exists), cost is never fabricated, the empty state is honest, and the recent-usage chart is an explicit **"not wired · awaiting per-model usage stream"** frame — no synthetic series.

**Structure / discipline:**
- New `UtilCard` / `UsagePanel` / `UtilitiesPanel` + shared `format.ts`; `TestSuitesPanel` gets the card chrome (run/approve/dismiss + requested-suite auto-open intact). Inline `UtilityBar` + `LlmUsagePanel` removed from `BoardView` (−214 lines there).
- Additive styling in `hermes4-utilities.css` on `--h4-*` tokens; **coral reserved for the one selected flow card** (the launch CTA is ink); in-card labels are faint eyebrows; 2-col collapses via a panel-relative **container query**.
- a11y: flow radios are a named `radiogroup` with per-flow `aria-describedby`.

## Operator-approved behavior changes
Propose-by-default · always-expanded · coral-on-selected-flow (ink CTA) · awaiting-data chart. Tests updated to match (no assertions weakened).

## Verification
- ✅ `tsc -b` clean · **687/687 vitest** · `vite build` clean
- ✅ Visually verified in a throwaway harness (deleted): 2-col layout, coral-once confirmed via computed styles (`.hm-flow-card--on` = `--h4-act-soft`; CTA = `--h4-ink`; in/out bars = `--h4-tel`), uniform faint labels
- ✅ Adversarial review pass (truth-boundary / regression / a11y / design) — all 9 findings fixed before this PR

## Blast radius
`packages/monitor-ui` only. No backend changes. The `--hm-*`/`--h4-*` token systems are extended, not forked.

## Follow-up (deferred, per operator: "ship redesign as-is, wire next")
- **Frontend, real data:** a "daily tokens" chart from `byDay`, and a cost column when `costStatus === "recorded"`.
- **Needs backend feeds:** per-minute usage stream, per-model latency, deploy-step telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)