### PR TITLE
feat(monitor): wire real LLM cost + daily chart + show every agent

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -507,12 +507,12 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getAllByText("?").length).toBeGreaterThan(0);
     // The in-flight line names the live call.
     expect(getByText("claude · claude-sonnet-4-5")).toBeTruthy();
-    // Idle sources show as ONE muted line in place; the honest reason is one
-    // click away (truth-boundary preserved), and there is no flat "not reported" row.
-    expect(getByText(/1 source idle: codex/)).toBeTruthy();
-    expect(queryAllByText("not reported").length).toBe(0);
-    fireEvent.click(getByText(/1 source idle: codex/));
+    // Every expected agent is accounted for: idle ones are listed explicitly
+    // (not collapsed) with their honest reason; no flat "not reported" row.
+    expect(getByText("Idle agents · 1")).toBeTruthy();
+    // codex (idle) is named explicitly with its honest reason (unique to the usage card).
     expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
+    expect(queryAllByText("not reported").length).toBe(0);
   });
 
   test("renders a plain-language usage explanation when no source emits counters", () => {

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -29,6 +29,15 @@ const recorded: LlmUsageAggregate = {
     },
   ],
   byDay: [],
+  // The full expected roster: hermes active, the rest idle.
+  sourceStatus: [
+    { agent: "hermes", status: "recorded" },
+    { agent: "claude", status: "not_reported", reason: "Claude Agent SDK usage counters have not arrived yet." },
+    { agent: "test-writer", status: "not_reported", reason: "Test-writer SDK usage counters have not arrived yet." },
+    { agent: "security", status: "not_reported", reason: "Security specialist SDK usage counters have not arrived yet." },
+    { agent: "docs", status: "not_reported", reason: "Docs specialist SDK usage counters have not arrived yet." },
+    { agent: "codex", status: "not_reported", reason: "Codex CLI does not report usage." },
+  ],
 };
 
 describe("UsagePanel", () => {
@@ -41,11 +50,55 @@ describe("UsagePanel", () => {
     expect(getAllByText("?").length).toBeGreaterThan(0); // latency has no source
   });
 
-  test("shows an honest awaiting-data chart slot — never a synthetic series", () => {
+  test("shows EVERY expected agent — idle ones listed explicitly with reasons, never collapsed", () => {
+    const { getByText } = render(<UsagePanel usage={recorded} />);
+    expect(getByText("Idle agents · 5")).toBeTruthy();
+    // The agents that had no usage are still named (the operator's ask), with reasons.
+    for (const agent of ["claude", "test-writer", "security", "docs", "codex"]) {
+      expect(getByText(agent)).toBeTruthy();
+    }
+    expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
+  });
+
+  test("renders a real Cost column only when costStatus is recorded", () => {
+    const withCost: LlmUsageAggregate = {
+      ...recorded,
+      costUsd: 0.42,
+      costStatus: "recorded",
+      byModel: [{ ...recorded.byModel[0]!, costUsd: 0.42, costStatus: "recorded" }],
+    };
+    const { getByText, getAllByText } = render(<UsagePanel usage={withCost} />);
+    expect(getByText("Cost")).toBeTruthy();
+    expect(getAllByText("$0.42").length).toBeGreaterThan(0); // total + model row
+  });
+
+  test("omits the Cost column entirely when no source reports cost (no column of '?')", () => {
+    const { queryByText } = render(<UsagePanel usage={recorded} />);
+    expect(queryByText("Cost")).toBeNull();
+  });
+
+  test("renders a REAL daily-tokens chart from byDay (≥2 days), not the awaiting frame", () => {
+    const withDays: LlmUsageAggregate = {
+      ...recorded,
+      byDay: [
+        { day: "2026-06-07", inputTokens: 4_000, outputTokens: 1_000, totalTokens: 5_000, costUsd: null, costStatus: "not_recorded", runs: 3, byModel: [] },
+        { day: "2026-06-08", inputTokens: 6_000, outputTokens: 2_000, totalTokens: 8_000, costUsd: null, costStatus: "not_recorded", runs: 4, byModel: [] },
+        { day: "2026-06-09", inputTokens: 3_000, outputTokens: 1_000, totalTokens: 4_000, costUsd: null, costStatus: "not_recorded", runs: 2, byModel: [] },
+      ],
+    };
+    const { getByText, queryByText } = render(<UsagePanel usage={withDays} />);
+    expect(getByText("Daily tokens · last 3 days")).toBeTruthy();
+    expect(getByText("daily")).toBeTruthy();
+    expect(getByText(/17K tokens over 3 days/)).toBeTruthy();
+    // The "awaiting per-minute" frame is replaced by the real chart.
+    expect(queryByText("not wired")).toBeNull();
+  });
+
+  test("falls back to an honest awaiting-data frame when there's no daily series", () => {
     const { getByText, getByLabelText } = render(<UsagePanel usage={recorded} />);
-    expect(getByLabelText("Recent per-model usage — awaiting data stream")).toBeTruthy();
+    expect(getByLabelText("Usage over time — awaiting per-minute stream")).toBeTruthy();
     expect(getByText("not wired")).toBeTruthy();
-    expect(getByText("awaiting per-model usage stream")).toBeTruthy();
+    expect(getByText("awaiting per-minute usage stream")).toBeTruthy();
   });
 
   test("renders the honest empty state when nothing is recorded", () => {

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -1,47 +1,54 @@
-import { useState } from "react";
 import type { LlmUsageAggregate } from "../lib/monitor/board-cache.js";
 import { formatCompactNumber, formatNumber, formatRelativeTime } from "../lib/monitor/format.js";
 import { UtilCard } from "./UtilCard.js";
 
 /**
- * LLM usage card — the redesigned, design-faithful surface for the Utilities
- * panel. Binds ONLY to real LlmUsageAggregate: per-(agent, model) rows, an
- * "All models" total, the in-flight line, and idle sources with their honest
- * reasons one click away. Truth-boundary:
+ * LLM usage card — the design-faithful surface for the Utilities panel. Binds
+ * ONLY to real LlmUsageAggregate: per-(agent, model) rows, an "All models"
+ * total, the in-flight line, EVERY expected agent (active or idle — none
+ * hidden), real cost when recorded, and a real daily-tokens chart. Truth-boundary:
  *   - Latency renders "?" — LlmUsageModelRollup has no latency field.
- *   - Cost is never shown while costStatus is "not_recorded".
- *   - The recent-usage chart is an explicit awaiting-data frame, never the
- *     design's synthetic "demo shape" series (no real per-minute stream exists).
- *   - When nothing is recorded, the honest message replaces the table — no
- *     zero-filled fake rows.
+ *   - Cost shows only when costStatus is "recorded" (never fabricated); the Cost
+ *     column appears only when at least one source reports it.
+ *   - The time chart is REAL daily byDay tokens when ≥2 days exist; otherwise an
+ *     honest "awaiting per-minute stream" frame (that source isn't wired yet).
+ *   - When nothing is recorded, the honest message replaces the table.
  */
 export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
-  const [showIdle, setShowIdle] = useState(false);
   const recorded = usage?.status === "recorded";
   const latestDay = usage?.byDay?.[0];
   // Every (agent, model) that actually reported counters.
   const models = usage?.byModel?.length ? usage.byModel : latestDay?.byModel ?? [];
-  // Idle sources collapse into ONE line; their honest reasons stay reachable.
+  // Every expected agent that has NOT reported — shown explicitly, never collapsed,
+  // so the full agent roster (claude · test-writer · security · docs · codex · hermes)
+  // is always accounted for.
   const idleSources = (usage?.sourceStatus ?? []).filter((entry) => entry.status === "not_reported");
   const activeCalls = usage?.activeCalls ?? [];
   const emptyMessage = usage?.message
     ?? "No LLM usage counters have been recorded yet. Sources stay not reported until a real provider or runner emits whitelisted counters.";
   const hasTable = recorded && models.length > 0;
+  // Cost column only when a real cost was recorded somewhere (never a column of "?").
+  const showCost = !!usage && (usage.costStatus === "recorded" || models.some((m) => m.costStatus === "recorded"));
+  // Real daily-tokens series (oldest→newest, last 14 days) — a chart, not a guess.
+  const chartDays = (usage?.byDay ?? []).slice().sort((a, b) => a.day.localeCompare(b.day)).slice(-14);
+  const hasChart = recorded && chartDays.length >= 2;
 
   return (
-    <UtilCard title="LLM usage" hint="per model · last 60 min" fill ariaLabel="LLM usage">
+    <UtilCard title="LLM usage" hint="per model · all agents" fill ariaLabel="LLM usage">
       {hasTable ? (
-        <div className="hm-usage-table">
+        <div className={`hm-usage-table${showCost ? " hm-usage-table--cost" : ""}`}>
           <div className="hm-usage-row hm-usage-row--head">
             <span className="hm-usage-c-model">Model</span>
             <span className="hm-usage-c-num">Tokens</span>
             <span className="hm-usage-c-num">Calls</span>
+            {showCost ? <span className="hm-usage-c-num">Cost</span> : null}
             <span className="hm-usage-c-num">Latency</span>
           </div>
           <div className="hm-usage-row hm-usage-row--total">
             <span className="hm-usage-c-model">All models</span>
             <span className="hm-usage-c-num">{formatCompactNumber(usage!.totalTokens)}</span>
             <span className="hm-usage-c-num">{formatNumber(usage!.runs)}</span>
+            {showCost ? <span className="hm-usage-c-num">{formatCost(usage!.costUsd, usage!.costStatus)}</span> : null}
             <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
           </div>
           {models.map((entry) => (
@@ -53,6 +60,11 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
               </span>
               <span className="hm-usage-c-num">{formatCompactNumber(entry.totalTokens)}</span>
               <span className="hm-usage-c-num">{formatNumber(entry.runs)}</span>
+              {showCost ? (
+                <span className={`hm-usage-c-num${entry.costStatus === "recorded" ? "" : " hm-usage-c-na"}`} title={entry.costStatus === "recorded" ? undefined : "cost not reported"}>
+                  {formatCost(entry.costUsd, entry.costStatus)}
+                </span>
+              ) : null}
               <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
             </div>
           ))}
@@ -99,38 +111,31 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
         </strong>
       </div>
 
-      {/* Idle sources — one muted line; honest reasons one click away. */}
+      {/* Idle agents — the rest of the roster, shown explicitly (not collapsed),
+          each with its honest reason. So every agent is accounted for. */}
       {idleSources.length > 0 ? (
         <div className="hm-usage-idle">
-          <button
-            type="button"
-            className="hm-usage-idle-toggle"
-            aria-expanded={showIdle}
-            onClick={() => setShowIdle((value) => !value)}
-          >
-            <span aria-hidden>{showIdle ? "▾" : "▸"}</span>
-            {idleSources.length} source{idleSources.length === 1 ? "" : "s"} idle: {idleSources.map((entry) => entry.agent).join(" · ")}
-          </button>
-          {showIdle ? (
-            <ul className="hm-usage-idle-list">
-              {idleSources.map((entry) => (
-                <li key={entry.agent}>
-                  <strong>{entry.agent}</strong>
-                  <span>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</span>
-                </li>
-              ))}
-            </ul>
-          ) : null}
+          <span className="hm-usage-idle-head">Idle agents · {idleSources.length}</span>
+          <ul className="hm-usage-idle-list">
+            {idleSources.map((entry) => (
+              <li key={entry.agent}>
+                <span className="hm-usage-jewel hm-usage-jewel--idle" style={{ background: agentJewel(entry.agent) }} aria-hidden />
+                <strong>{entry.agent}</strong>
+                <span>{entry.reason ?? `${entry.agent} usage counters have not arrived.`}</span>
+              </li>
+            ))}
+          </ul>
         </div>
       ) : null}
 
-      {/* Recent-usage chart slot — honest awaiting-data frame, never synthetic
-          data. Keeps the design's visual slot; a real per-minute stream renders
-          here when it lands. */}
-      {hasTable ? (
-        <div className="hm-usage-chart" role="img" aria-label="Recent per-model usage — awaiting data stream">
+      {/* Time chart — REAL daily byDay tokens when we have ≥2 days; otherwise an
+          honest awaiting frame (the per-minute stream isn't wired). */}
+      {hasChart ? (
+        <DailyTokensChart days={chartDays} />
+      ) : hasTable ? (
+        <div className="hm-usage-chart" role="img" aria-label="Usage over time — awaiting per-minute stream">
           <div className="hm-usage-chart-head">
-            <span className="hm-usage-chart-label">Recent usage · tokens/min · per model</span>
+            <span className="hm-usage-chart-label">Usage over time · per minute</span>
             <span className="hm-usage-chart-chip">not wired</span>
           </div>
           <svg className="hm-usage-chart-frame" viewBox="0 0 300 120" preserveAspectRatio="none" aria-hidden>
@@ -151,11 +156,64 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
               </text>
             ))}
           </svg>
-          <span className="hm-usage-chart-note">awaiting per-model usage stream</span>
+          <span className="hm-usage-chart-note">awaiting per-minute usage stream</span>
         </div>
       ) : null}
     </UtilCard>
   );
+}
+
+/** Real daily-tokens bars from byDay (totalTokens per day). */
+function DailyTokensChart({ days }: { days: { day: string; totalTokens: number }[] }) {
+  const padL = 4, padR = 4, padT = 8, padB = 18;
+  const w = 300, h = 120;
+  const plotW = w - padL - padR;
+  const plotH = h - padT - padB;
+  const max = Math.max(1, ...days.map((d) => d.totalTokens));
+  const slot = plotW / days.length;
+  const barW = Math.min(28, slot * 0.62);
+  const tickIdx = days.length <= 4
+    ? days.map((_, i) => i)
+    : [0, Math.round((days.length - 1) / 2), days.length - 1];
+  return (
+    <div className="hm-usage-chart" role="img" aria-label={`Daily tokens, last ${days.length} days`}>
+      <div className="hm-usage-chart-head">
+        <span className="hm-usage-chart-label">Daily tokens · last {days.length} days</span>
+        <span className="hm-usage-chart-chip hm-usage-chart-chip--live">daily</span>
+      </div>
+      <svg className="hm-usage-chart-frame" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-hidden>
+        {[0.5].map((g) => (
+          <line key={g} x1={padL} x2={w - padR} y1={padT + g * plotH} y2={padT + g * plotH} stroke="var(--h4-line-2)" strokeWidth="1" />
+        ))}
+        {days.map((d, i) => {
+          const bh = (d.totalTokens / max) * plotH;
+          const x = padL + i * slot + (slot - barW) / 2;
+          const y = padT + (plotH - bh);
+          return <rect key={d.day} x={x} y={y} width={barW} height={Math.max(0, bh)} rx="1.5" fill="var(--h4-tel)" opacity="0.72" />;
+        })}
+        {tickIdx.map((i) => (
+          <text
+            key={days[i]!.day}
+            x={padL + i * slot + slot / 2}
+            y={h - 5}
+            fill="var(--h4-faint)"
+            fontSize="8"
+            fontFamily="var(--font-mono)"
+            textAnchor={i === 0 ? "start" : i === days.length - 1 ? "end" : "middle"}
+          >
+            {days[i]!.day.slice(5)}
+          </text>
+        ))}
+      </svg>
+      <span className="hm-usage-chart-note hm-usage-chart-note--live">{formatCompactNumber(days.reduce((s, d) => s + d.totalTokens, 0))} tokens over {days.length} days</span>
+    </div>
+  );
+}
+
+function formatCost(usd: number | null | undefined, status: string): string {
+  if (status !== "recorded" || usd == null) return "?";
+  if (usd === 0) return "$0";
+  return usd < 0.01 ? "<$0.01" : `$${usd.toFixed(2)}`;
 }
 
 /**

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -91,6 +91,11 @@
   padding: 8px 2px;
   border-top: 1px solid var(--h4-line-2);
 }
+/* with a real cost column the table is 5 across */
+.hm-usage-table--cost .hm-usage-row {
+  grid-template-columns: 1fr 52px 40px 58px 50px;
+  gap: 8px;
+}
 .hm-usage-row--head {
   border-top: 0;
   padding-bottom: 7px;
@@ -217,35 +222,44 @@
 .hm-usage-idle {
   margin-top: 9px;
 }
-.hm-usage-idle-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  border: 0;
-  background: transparent;
-  cursor: pointer;
-  padding: 2px 0;
-  font-family: var(--font-mono);
-  font-size: 11px;
+.hm-usage-idle-head {
+  display: block;
+  margin-bottom: 6px;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--h4-faint);
 }
 .hm-usage-idle-list {
   list-style: none;
-  margin: 6px 0 0;
+  margin: 0;
   padding: 0;
   display: grid;
-  gap: 6px;
+  gap: 5px;
 }
 .hm-usage-idle-list li {
-  display: grid;
-  gap: 2px;
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  min-width: 0;
+}
+.hm-usage-jewel--idle {
+  align-self: center;
+  opacity: 0.5;
 }
 .hm-usage-idle-list strong {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 11.5px;
   color: var(--h4-ink-2);
+  flex: none;
 }
-.hm-usage-idle-list span {
+/* the reason is the span AFTER the name — scoped so it doesn't also match the
+   jewel span (which must stay 6px, not grow). */
+.hm-usage-idle-list strong + span {
+  flex: 1;
+  min-width: 0;
   font-size: 11px;
   color: var(--h4-faint);
   line-height: 1.4;
@@ -295,6 +309,17 @@
   font-size: 10px;
   color: var(--h4-faint);
   pointer-events: none;
+}
+/* the daily chart carries real data — its chip + caption read as "live", and the
+   caption sits below the bars (static) rather than overlaying an empty frame. */
+.hm-usage-chart-chip--live {
+  color: var(--h4-tel);
+  border-color: var(--h4-tel);
+}
+.hm-usage-chart-note--live {
+  position: static;
+  text-align: left;
+  margin-top: 4px;
 }
 
 /* ── SuitePanel: honest-empty + rows inside the card ─────────────────────── */


### PR DESCRIPTION
## Why
Follow-up to #458. You asked to *"take care of the wiring, but all — not just codex, hermes and claude have to be there too."* This replaces the deferred **"not wired"** usage placeholders with **real** `LlmUsageAggregate` data — frontend-only, no backend changes.

## What changed (all real data)
- **Every agent is present.** The usage card now accounts for the full expected roster (`claude · test-writer · security · docs · codex · hermes`): active agents as model rows, and the idle ones named **explicitly** with their honest reason — instead of collapsing them behind a single "N idle" line. So security/docs/test-writer are no longer hidden.
- **Real cost.** A **Cost** column appears when any source reports `costStatus: "recorded"` — shows `$` per model + the total, and `?` for sources that genuinely don't report (e.g. Codex). The column is omitted entirely when nothing reports cost, so it's never a column of `?`.
- **Real daily chart.** When `byDay` has ≥2 days, the chart slot renders a real **daily-tokens** bar strip with a total caption ("68K tokens over 5 days"), replacing the awaiting frame. The honest **"awaiting per-minute usage stream"** frame stays the fallback when there's no series.

## Truth-boundary
Cost and the daily chart are drawn **only** from real recorded data. Latency still renders `?` (no source exists). The per-minute stream stays an explicit awaiting frame. Nothing fabricated.

## Verification
- ✅ `tsc -b` clean · **691/691 vitest** (4 new: all-agents, cost-present, cost-absent, daily-chart) · `vite build` clean
- ✅ Visually verified in a throwaway harness (deleted): 3 active agents + 3 idle named with reasons, `$0.42`/`$0.18`/`$0.24`/`?` cost cells, a 5-bar daily chart. Caught + fixed a flexbox bug where the idle-row jewel grew to fill the row (DOM-inspected: jewel back to 6px).

## Blast radius
`packages/monitor-ui` only — `UsagePanel.tsx` + its tests + `BoardView.test.tsx` + `hermes4-utilities.css`.

## Still backend-only (out of scope, needs a feed)
Per-minute usage stream, per-model latency, deploy-step telemetry — these have no frontend-reachable source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)