### PR TITLE
feat(monitor): wire the live per-minute usage stream (tokens/min · per model)

### DIFF
--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -54,6 +54,22 @@ export interface LlmUsageActiveCall {
   taskId?: string;
 }
 
+/** One per-model line in the recent (live) usage window. `points` are per-minute
+ *  total-token sums, oldest→newest, length === windowMinutes. */
+export interface LlmUsageRecentSeries {
+  agent: string;
+  model: string;
+  points: number[];
+}
+
+/** A real, live "tokens/min · per model" window built from event timestamps.
+ *  null when there is no clock to anchor the window or no events fell in it. */
+export interface LlmUsageRecent {
+  windowMinutes: number;
+  endsAt: string;
+  series: LlmUsageRecentSeries[];
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
   message: string;
@@ -69,6 +85,8 @@ export interface LlmUsageAggregate {
   byDay: LlmUsageDayRollup[];
   sourceStatus: LlmUsageSourceStatus[];
   activeCalls: LlmUsageActiveCall[];
+  /** Live per-minute per-model series for the recent window (null when idle). */
+  recent: LlmUsageRecent | null;
 }
 
 export interface LlmUsageCaptureInput {
@@ -84,6 +102,11 @@ export interface LlmUsageAggregateOptions {
   expectedAgents?: readonly string[];
   sourceReasons?: Readonly<Record<string, string>>;
   activeCalls?: readonly LlmUsageActiveCall[];
+  /** Anchor for the live "recent" window (server passes new Date()); when
+   *  omitted, `recent` is null (no clock to build a last-N-minutes window). */
+  now?: Date;
+  /** Recent-window length in minutes (default 60). */
+  recentWindowMinutes?: number;
 }
 
 export interface LlmUsageActiveCallInput {
@@ -243,6 +266,7 @@ export function aggregateLlmUsage(
   const byDay = rollupByDay(events);
   const total = totalsFor(events);
   const sourceStatus = sourceStatuses(events, options);
+  const recent = buildRecent(events, options.now, options.recentWindowMinutes ?? 60);
   const status = events.length > 0 ? "recorded" : "not_recorded";
   return {
     status,
@@ -255,7 +279,50 @@ export function aggregateLlmUsage(
     byDay,
     sourceStatus,
     activeCalls: [...(options.activeCalls ?? [])],
+    recent,
   };
+}
+
+/**
+ * Build the live "tokens/min · per model" window from real event timestamps.
+ * Returns null when there's no clock to anchor the window or no event fell in
+ * it — so the UI honestly falls back to the daily view instead of a flat fake.
+ */
+function buildRecent(
+  events: readonly LlmUsageEvent[],
+  now: Date | undefined,
+  windowMinutes: number,
+): LlmUsageRecent | null {
+  if (!now || !Number.isFinite(now.getTime()) || windowMinutes <= 0) return null;
+  const end = now.getTime();
+  const start = end - windowMinutes * 60_000;
+  const byKey = new Map<string, number[]>();
+  for (const event of events) {
+    const t = Date.parse(event.ts);
+    if (!Number.isFinite(t) || t < start || t > end) continue;
+    let idx = Math.floor((t - start) / 60_000);
+    if (idx < 0) idx = 0;
+    if (idx >= windowMinutes) idx = windowMinutes - 1;
+    const key = `${event.agent} ${event.model}`;
+    let points = byKey.get(key);
+    if (!points) {
+      points = new Array<number>(windowMinutes).fill(0);
+      byKey.set(key, points);
+    }
+    points[idx] += event.inputTokens + event.outputTokens + (event.cacheTokens ?? 0);
+  }
+  if (byKey.size === 0) return null;
+  const series = Array.from(byKey.entries())
+    .map(([key, points]) => {
+      const [agent = "unknown", model = "not_recorded"] = key.split(" ");
+      return { agent, model, points };
+    })
+    .sort((a, b) => sumPoints(b.points) - sumPoints(a.points) || a.agent.localeCompare(b.agent) || a.model.localeCompare(b.model));
+  return { windowMinutes, endsAt: new Date(end).toISOString(), series };
+}
+
+function sumPoints(points: readonly number[]): number {
+  return points.reduce((sum, value) => sum + value, 0);
 }
 
 export function aggregateLlmUsageForAgent(
@@ -288,6 +355,7 @@ export function aggregateLlmUsageForAgent(
       ...(byModel.length > 0 ? {} : { reason: sourceReason(agent, undefined) }),
     }],
     activeCalls: aggregate.activeCalls.filter((call) => call.agent === agent),
+    recent: null,
   };
 }
 

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -94,11 +94,37 @@ describe("UsagePanel", () => {
     expect(queryByText("not wired")).toBeNull();
   });
 
-  test("falls back to an honest awaiting-data frame when there's no daily series", () => {
+  test("renders the live per-minute per-model lines when there's recent activity", () => {
+    const points = new Array<number>(60).fill(0);
+    points[58] = 40;
+    points[59] = 120;
+    const claudePoints = new Array<number>(60).fill(0);
+    claudePoints[59] = 35;
+    const withRecent: LlmUsageAggregate = {
+      ...recorded,
+      recent: {
+        windowMinutes: 60,
+        endsAt: "2026-06-09T12:30:00.000Z",
+        series: [
+          { agent: "hermes", model: "deepseek-v4-pro", points },
+          { agent: "claude", model: "claude-sonnet-4-6", points: claudePoints },
+        ],
+      },
+    };
+    const { getByText, getByLabelText, queryByText } = render(<UsagePanel usage={withRecent} />);
+    expect(getByLabelText(/Live tokens per minute/)).toBeTruthy();
+    expect(getByText("Recent usage · tokens/min · per model")).toBeTruthy();
+    expect(getByText("live · 60m")).toBeTruthy();
+    // Per-model legend names both active models; no "idle"/"not wired" frame.
+    expect(queryByText("idle")).toBeNull();
+    expect(queryByText("not wired")).toBeNull();
+  });
+
+  test("falls back to an honest idle frame when there's no recent activity and no daily series", () => {
     const { getByText, getByLabelText } = render(<UsagePanel usage={recorded} />);
-    expect(getByLabelText("Usage over time — awaiting per-minute stream")).toBeTruthy();
-    expect(getByText("not wired")).toBeTruthy();
-    expect(getByText("awaiting per-minute usage stream")).toBeTruthy();
+    expect(getByLabelText("Usage over time — no recent activity")).toBeTruthy();
+    expect(getByText("idle")).toBeTruthy();
+    expect(getByText("no token usage in the last hour")).toBeTruthy();
   });
 
   test("renders the honest empty state when nothing is recorded", () => {

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -1,4 +1,4 @@
-import type { LlmUsageAggregate } from "../lib/monitor/board-cache.js";
+import type { LlmUsageAggregate, LlmUsageRecent } from "../lib/monitor/board-cache.js";
 import { formatCompactNumber, formatNumber, formatRelativeTime } from "../lib/monitor/format.js";
 import { UtilCard } from "./UtilCard.js";
 
@@ -32,6 +32,9 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
   // Real daily-tokens series (oldest→newest, last 14 days) — a chart, not a guess.
   const chartDays = (usage?.byDay ?? []).slice().sort((a, b) => a.day.localeCompare(b.day)).slice(-14);
   const hasChart = recorded && chartDays.length >= 2;
+  // Live per-minute per-model series — shown only when there's real recent activity.
+  const recent = usage?.recent ?? null;
+  const hasRecent = !!recent && recent.series.some((s) => s.points.some((p) => p > 0));
 
   return (
     <UtilCard title="LLM usage" hint="per model · all agents" fill ariaLabel="LLM usage">
@@ -128,15 +131,17 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
         </div>
       ) : null}
 
-      {/* Time chart — REAL daily byDay tokens when we have ≥2 days; otherwise an
-          honest awaiting frame (the per-minute stream isn't wired). */}
-      {hasChart ? (
+      {/* Time chart — live per-minute per-model lines when there's recent activity,
+          else the real daily byDay bars, else an honest idle frame. */}
+      {hasRecent && recent ? (
+        <RecentLinesChart recent={recent} jewel={agentJewel} />
+      ) : hasChart ? (
         <DailyTokensChart days={chartDays} />
       ) : hasTable ? (
-        <div className="hm-usage-chart" role="img" aria-label="Usage over time — awaiting per-minute stream">
+        <div className="hm-usage-chart" role="img" aria-label="Usage over time — no recent activity">
           <div className="hm-usage-chart-head">
             <span className="hm-usage-chart-label">Usage over time · per minute</span>
-            <span className="hm-usage-chart-chip">not wired</span>
+            <span className="hm-usage-chart-chip">idle</span>
           </div>
           <svg className="hm-usage-chart-frame" viewBox="0 0 300 120" preserveAspectRatio="none" aria-hidden>
             {[0.25, 0.5, 0.75].map((g) => (
@@ -156,10 +161,71 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
               </text>
             ))}
           </svg>
-          <span className="hm-usage-chart-note">awaiting per-minute usage stream</span>
+          <span className="hm-usage-chart-note">no token usage in the last hour</span>
         </div>
       ) : null}
     </UtilCard>
+  );
+}
+
+/** Live per-model lines — real per-minute token sums over the recent window. */
+function RecentLinesChart({ recent, jewel }: { recent: LlmUsageRecent; jewel: (agent: string) => string }) {
+  const padL = 4, padR = 4, padT = 8, padB = 18;
+  const w = 300, h = 120;
+  const plotW = w - padL - padR;
+  const plotH = h - padT - padB;
+  const n = Math.max(1, recent.windowMinutes);
+  const max = Math.max(1, ...recent.series.flatMap((s) => s.points));
+  const xAt = (i: number) => padL + (n <= 1 ? plotW : (i / (n - 1)) * plotW);
+  const yAt = (v: number) => padT + (1 - v / max) * plotH;
+  const linePath = (points: number[]) => points.map((v, i) => `${i ? "L" : "M"}${xAt(i).toFixed(1)} ${yAt(v).toFixed(1)}`).join(" ");
+  const ticks = [`-${n}m`, `-${Math.round(n * 0.75)}m`, `-${Math.round(n / 2)}m`, `-${Math.round(n / 4)}m`, "now"];
+  return (
+    <div className="hm-usage-chart" role="img" aria-label={`Live tokens per minute, last ${n} minutes, per model`}>
+      <div className="hm-usage-chart-head">
+        <span className="hm-usage-chart-label">Recent usage · tokens/min · per model</span>
+        <span className="hm-usage-chart-chip hm-usage-chart-chip--live">live · {n}m</span>
+      </div>
+      <svg className="hm-usage-chart-frame" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-hidden>
+        {[0.25, 0.5, 0.75].map((g) => (
+          <line key={g} x1={padL} x2={w - padR} y1={padT + g * plotH} y2={padT + g * plotH} stroke="var(--h4-line-2)" strokeWidth="1" />
+        ))}
+        {recent.series.map((s) => (
+          <path
+            key={`${s.agent}:${s.model}`}
+            d={linePath(s.points)}
+            fill="none"
+            stroke={jewel(s.agent)}
+            strokeWidth="1.6"
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            opacity="0.75"
+            vectorEffect="non-scaling-stroke"
+          />
+        ))}
+        {ticks.map((t, i) => (
+          <text
+            key={t}
+            x={padL + (i / 4) * plotW}
+            y={h - 5}
+            fill="var(--h4-faint)"
+            fontSize="8"
+            fontFamily="var(--font-mono)"
+            textAnchor={i === 0 ? "start" : i === 4 ? "end" : "middle"}
+          >
+            {t}
+          </text>
+        ))}
+      </svg>
+      <div className="hm-usage-chart-legend">
+        {recent.series.map((s) => (
+          <span className="hm-usage-legend-item" key={`${s.agent}:${s.model}`}>
+            <span className="hm-usage-jewel" style={{ background: jewel(s.agent) }} aria-hidden />
+            <span>{s.model}</span>
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -104,6 +104,20 @@ export interface LlmUsageActiveCall {
   taskId?: string;
 }
 
+/** One per-model line in the live usage window; points are per-minute token sums. */
+export interface LlmUsageRecentSeries {
+  agent: string;
+  model: string;
+  points: number[];
+}
+
+/** Real "tokens/min · per model" window (null when there's no recent activity). */
+export interface LlmUsageRecent {
+  windowMinutes: number;
+  endsAt: string;
+  series: LlmUsageRecentSeries[];
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
   message?: string;
@@ -119,6 +133,7 @@ export interface LlmUsageAggregate {
   byDay: LlmUsageDayRollup[];
   sourceStatus?: LlmUsageSourceStatus[];
   activeCalls?: LlmUsageActiveCall[];
+  recent?: LlmUsageRecent | null;
 }
 
 export interface MonitorEvent {

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -321,6 +321,27 @@
   text-align: left;
   margin-top: 4px;
 }
+/* per-model legend under the live tokens/min lines */
+.hm-usage-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+}
+.hm-usage-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.hm-usage-legend-item > span:last-child {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--h4-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
 /* ── SuitePanel: honest-empty + rows inside the card ─────────────────────── */
 .hm-suite-empty {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -2074,6 +2074,8 @@ export function buildV2BoardSnapshot(
     repo: opts.repo ?? "",
     llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents), {
       activeCalls: listActiveLlmUsageCalls(),
+      // Anchor the live "tokens/min" window to the snapshot time.
+      now: snapshotAt,
     }),
     testbedSuites: testbedSuitesFromSnapshot(rawSnapshot),
     automationHealth: automationHealthForBoard(rawSnapshot, snapshotAt, process.env, {

--- a/test/unit/llm-usage.test.ts
+++ b/test/unit/llm-usage.test.ts
@@ -328,4 +328,41 @@ describe("LLM usage tracker", () => {
     expect(serialized).not.toContain("sk-should-never-appear");
     expect(serialized).not.toContain("also-nope");
   });
+
+  it("builds a real per-minute, per-model recent window from event timestamps", () => {
+    const now = new Date("2026-06-09T12:30:00.000Z"); // window start = 11:30:00
+    const aggregate = aggregateLlmUsage(
+      [
+        { agent: "hermes", model: "deepseek-v4-pro", inputTokens: 50, outputTokens: 10, ts: "2026-06-09T11:30:30.000Z" }, // idx 0 → 60
+        { agent: "hermes", model: "deepseek-v4-pro", inputTokens: 100, outputTokens: 20, ts: "2026-06-09T12:29:30.000Z" }, // idx 59 → 120
+        { agent: "claude", model: "claude-sonnet-4-6", inputTokens: 30, outputTokens: 5, ts: "2026-06-09T12:29:45.000Z" }, // idx 59 → 35
+      ],
+      { now, recentWindowMinutes: 60 },
+    );
+    expect(aggregate.recent).not.toBeNull();
+    expect(aggregate.recent!.windowMinutes).toBe(60);
+    expect(aggregate.recent!.endsAt).toBe("2026-06-09T12:30:00.000Z");
+    const hermes = aggregate.recent!.series.find((s) => s.agent === "hermes");
+    expect(hermes!.points).toHaveLength(60);
+    expect(hermes!.points[0]).toBe(60);
+    expect(hermes!.points[59]).toBe(120);
+    const claude = aggregate.recent!.series.find((s) => s.agent === "claude");
+    expect(claude!.points[59]).toBe(35);
+  });
+
+  it("returns recent: null without a clock to anchor the window", () => {
+    const aggregate = aggregateLlmUsage([
+      { agent: "hermes", model: "x", inputTokens: 1, outputTokens: 1, ts: "2026-06-09T12:00:00.000Z" },
+    ]);
+    expect(aggregate.recent).toBeNull();
+  });
+
+  it("returns recent: null when no events fall inside the window", () => {
+    const now = new Date("2026-06-09T12:30:00.000Z");
+    const aggregate = aggregateLlmUsage(
+      [{ agent: "hermes", model: "x", inputTokens: 1, outputTokens: 1, ts: "2026-06-01T00:00:00.000Z" }],
+      { now },
+    );
+    expect(aggregate.recent).toBeNull();
+  });
 });


### PR DESCRIPTION
## Why
Follow-up to #459 (now merged) — the last frontend-reachable usage feed. Replaces the *"awaiting per-minute stream"* placeholder with a **real live chart** built from event timestamps.

## What changed (all real data)
- **`averray-mcp/llm-usage`** — `aggregateLlmUsage` now emits a `recent` window: per-(agent, model) **per-minute token sums** over the last N minutes (default 60), anchored to `options.now`. Returns `null` when there's no clock or no events in the window — so the UI honestly falls back to the daily chart, never a flat fake.
- **`slack-operator/monitor-v2`** — passes `now: snapshotAt` so the window tracks the snapshot time.
- **`monitor-ui/UsagePanel`** — renders live **per-model lines** (colored by agent jewel + a per-model legend) when there's recent activity; else the real **daily `byDay` bars** (#459); else an honest **"no token usage in the last hour"** idle frame.

## Truth-boundary
Every point is a real summed token count from a real event `ts` — no synthetic series. **Latency stays `?`** and **deploy stays GitHub check-run-fed** — those have no additional honest source, so they're left as honest states (not faked).

## Verification
- ✅ `tsc -b` clean across **averray-mcp + monitor-ui + slack-operator**
- ✅ **13** llm-usage tests (3 new: real per-minute bucketing · null without a clock · null when no events in window) · **692** monitor-ui tests (1 new: live lines render) · `vite build` clean
- ✅ Visually verified in a throwaway harness (deleted): three per-model lines over −60m→now, "live · 60m" chip, per-model legend — alongside the cost column + all-agents roster.

## Blast radius
`averray-mcp` (additive `recent` field) + one line in `monitor-v2` + `monitor-ui` render/types. Additive + non-breaking (the field is optional; absence → daily/idle fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)