### PR TITLE
fix(ops): testbed runner deploy — tester-env passthrough + zombie reaping (init)

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -246,6 +246,24 @@ services:
       AVERRAY_CODEX_TASKS_PATH: ${AVERRAY_CODEX_TASKS_PATH:-/data/codex-tasks.json}
       AVERRAY_TESTBED_MISSIONS_PATH: ${AVERRAY_TESTBED_MISSIONS_PATH:-/data/testbed-missions.json}
       TESTBED_MISSION_ENVIRONMENT: ${TESTBED_MISSION_ENVIRONMENT:-}
+      # Tester-capability awareness for the monitor/API: it builds the
+      # /monitor/tester/capabilities manifest and gates mission dispatch on these.
+      # They MUST mirror the testbed-mission-runner service so one .env drives both;
+      # without them the monitor hardwired runnerEnabled:false (and reported the
+      # signer/session/gold-path as unavailable) even when the runner was online.
+      TESTBED_MISSION_RUNNER_ENABLED: ${TESTBED_MISSION_RUNNER_ENABLED:-0}
+      TESTBED_MISSION_RUNNER_EXECUTOR: ${TESTBED_MISSION_RUNNER_EXECUTOR:-playwright}
+      TESTBED_MISSION_RUNNER_COMMAND: ${TESTBED_MISSION_RUNNER_COMMAND:-}
+      TEST_WALLET_SIGNER_ENABLED: ${TEST_WALLET_SIGNER_ENABLED:-0}
+      TEST_WALLET_SIGNER_BASE_URL: ${TEST_WALLET_SIGNER_BASE_URL:-http://test-wallet-signer:8791}
+      TESTBED_SESSION_SIGNER_URL: ${TESTBED_SESSION_SIGNER_URL:-}
+      TESTBED_SESSION_ROLE: ${TESTBED_SESSION_ROLE:-agent}
+      TESTBED_SESSION_TYPE: ${TESTBED_SESSION_TYPE:-browser}
+      TESTBED_SESSION_STORAGE_STATE_PATH: ${TESTBED_SESSION_STORAGE_STATE_PATH:-}
+      TESTBED_SESSION_TOKEN: ${TESTBED_SESSION_TOKEN:-}
+      TESTBED_GOLDPATH_LIVE: ${TESTBED_GOLDPATH_LIVE:-0}
+      TESTBED_GOLDPATH_AUTONOMY_ENABLED: ${TESTBED_GOLDPATH_AUTONOMY_ENABLED:-0}
+      AVERRAY_TESTBED_ENVIRONMENT: ${AVERRAY_TESTBED_ENVIRONMENT:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-data:/data

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -272,6 +272,7 @@ services:
       - "127.0.0.1:${SLACK_OPERATOR_HTTP_PORT:-8790}:${SLACK_OPERATOR_HTTP_PORT:-8790}"
 
   testbed-mission-runner:
+    init: true
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
@@ -411,6 +412,7 @@ services:
       - "127.0.0.1:${TEST_WALLET_SIGNER_PORT:-8791}:${TEST_WALLET_SIGNER_PORT:-8791}"
 
   codex-task-runner:
+    init: true
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
@@ -458,6 +460,7 @@ services:
   # lands, and provisions the auth secrets in .env.prod. For SUB billing,
   # leave ANTHROPIC_API_KEY UNSET (an empty value is treated as absent).
   claude-task-runner:
+    init: true
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
@@ -524,6 +527,7 @@ services:
   # the claude-runner's flag). The worker still refuses every task until
   # CLAUDE_BRANCH_WORKER_ALLOWED_REPOS is populated.
   test-writer-task-runner:
+    init: true
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
@@ -585,6 +589,7 @@ services:
   # SECURITY_TASK_RUNNER_ENABLED=1 are both set. High-risk findings remain
   # proposes-only/escalate in the role prompt; merge/deploy are human-gated.
   security-task-runner:
+    init: true
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
@@ -637,6 +642,7 @@ services:
   # C3 docs specialist runner — same off-by-default Claude-family runner
   # pattern, pinned to agent=="docs" and isolated by the per-agent claim filter.
   docs-task-runner:
+    init: true
     build:
       context: ..
       dockerfile: ops/Dockerfile.node


### PR DESCRIPTION
Two `ops/compose.yml` fixes for the testbed-runner stack, found while diagnosing "I ran a mission but nothing came back" + a VPS health check.

## 1. Tester-capability env never reached the monitor (the "runnerEnabled:false" bug)
The `slack-operator` (monitor/API) service builds `GET /monitor/tester/capabilities` and gates mission dispatch on `TESTBED_MISSION_RUNNER_ENABLED` + the session/signer/gold-path vars — but compose set those **only on `testbed-mission-runner`**, never on `slack-operator`. So the monitor read them as `undefined` and **hardwired `runnerEnabled: false`** even with the runner online and `.env` set (confirmed live: manifest showed a fresh runner heartbeat *and* `runnerEnabled:false` + all mission types `unavailable_runner_disabled`). Dispatched missions parked in READY, unclaimed.

→ Mirror the tester-capability env onto `slack-operator` with the same `${VAR:-default}` as the runner, so one `.env` drives both. Additive + non-breaking.

## 2. Runner zombies (40 on the VPS)
All 40 zombies were parented to the `testbed-mission-runner` node process. It runs as **PID 1 in its container with no init/reaper**, so Playwright chromium helper processes that exit and reparent to node were never reaped (`browser.close()` already runs in a `finally`, so it's the reparented-helper case, not a close leak).

→ Add `init: true` to `testbed-mission-runner` and the task runners (codex/claude/test-writer/security/docs) — Docker runs tini as PID 1, which reaps reparented children. Zero functional risk; existing zombies clear on next deploy/restart.

## Operator runbook (after merge + redeploy)
1. `.env`: `TESTBED_MISSION_RUNNER_ENABLED=1` (+ `testbed-runner` profile) → `/monitor/tester/capabilities` flips to `runnerReady: true`, missions get claimed.
2. For authed targets (e.g. `api.averray.com`, strict SIWE): bring up `test-wallet-signer` (`TEST_WALLET_SIGNER_ENABLED=1`) + `TESTBED_SESSION_SIGNER_URL=http://test-wallet-signer:8791`.
3. Gold-path mutations: testnet/staging URL + `TESTBED_GOLDPATH_LIVE=1` (mainnet stays read-only).

## Verification
YAML validated; env keys sit in the `slack-operator` env block, and `init: true` is a service-level key on each of the 6 child-spawning services. Compose-only; the capability manifest already reads these vars (`tester-capabilities.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)