### PR TITLE
fix(skills-observer): chokidar v4 dropped globs — watch dir + filter .md

### DIFF
--- a/services/skills-observer/src/index.ts
+++ b/services/skills-observer/src/index.ts
@@ -8,9 +8,16 @@ const slackWebhookUrl = optionalEnv("SLACK_WEBHOOK_URL");
 
 logger.info({ skillsDir }, "skills_observer_starting");
 
-const watcher = chokidar.watch("**/*.md", {
+// chokidar v4 removed glob support: a "**/*.md" pattern is treated as a literal
+// (nonexistent) path, so the watcher established no persistent handle and the
+// process exited immediately -> restart loop. Watch the skills dir and filter to
+// .md via `ignored` (stats is undefined on the directory-scan pass, so folders
+// pass through and recursion still works). cwd keeps emitted paths relative, so
+// ingest's path.join(skillsDir, relativePath) is unchanged.
+const watcher = chokidar.watch(".", {
   cwd: skillsDir,
   ignoreInitial: false,
+  ignored: (testPath, stats) => Boolean(stats?.isFile()) && !testPath.endsWith(".md"),
   awaitWriteFinish: {
     stabilityThreshold: 500,
     pollInterval: 100


### PR DESCRIPTION
## Why
On the VPS, `avg-skills-observer-1` is crash-looping — `Restarting (0)` every ~minute (exits cleanly, then `restart: unless-stopped` relaunches it).

Root cause: the service depends on `chokidar ^4.0.3`, and **chokidar v4 removed glob support**. So `chokidar.watch("**/*.md", { cwd: skillsDir })` is treated as a **literal path** `**/*.md` (which doesn't exist) → no files matched → no persistent watcher handle → the Node process has nothing keeping the event loop alive → it **exits immediately** → restart loop.

## Fix
Watch the skills directory itself and filter to `.md` via chokidar v4's `ignored` predicate:
```ts
chokidar.watch(".", {
  cwd: skillsDir,
  ignoreInitial: false,
  ignored: (testPath, stats) => Boolean(stats?.isFile()) && !testPath.endsWith(".md"),
  awaitWriteFinish: { ... },
});
```
Directories pass through (chokidar calls `ignored` once without `stats` during the scan, so folders aren't excluded → recursion still works), and `.md` files are watched. `cwd` keeps emitted paths relative, so `ingest()`'s `path.join(skillsDir, relativePath)` is unchanged — no other edits needed.

## Verification
- `tsc -b` clean (the `ignored` signature matches chokidar v4 types).
- Behavior can only be fully confirmed on deploy (it needs the mounted `/hermes-skills` dir), but the watcher now establishes a persistent handle, so the process stays up instead of exiting.

## Blast radius
`services/skills-observer/src/index.ts` only — one `watch(...)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)