### PR TITLE
fix(skills-observer): run as skills-volume owner (UID 10000) + retry on access errors

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -107,6 +107,12 @@ services:
       dockerfile: ops/Dockerfile.node
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
+    # Hermes owns the skills volume as UID 10000 and continuously re-secures it to
+    # mode 0700 (owner-only) as it writes, so no chmod / hermes-permissions pass keeps
+    # it readable by the image's default appuser (10001) -- every inotify watch then
+    # fails EACCES and this service crash-loops. Read as that same owner UID. The
+    # mount below stays read-only; the observer only ever reads.
+    user: "10000:10000"
     depends_on:
       hermes-permissions:
         condition: service_completed_successfully

--- a/services/skills-observer/src/index.ts
+++ b/services/skills-observer/src/index.ts
@@ -2,31 +2,65 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import chokidar from "chokidar";
 import { logger, optionalEnv, query, sha256Text } from "@avg/mcp-common";
+import { describeWatchError } from "./watch-error.js";
 
 const skillsDir = optionalEnv("HERMES_SKILLS_DIR", "/opt/data/skills");
 const slackWebhookUrl = optionalEnv("SLACK_WEBHOOK_URL");
+const watchRetryMs = Number(optionalEnv("SKILLS_OBSERVER_WATCH_RETRY_MS", "30000"));
 
 logger.info({ skillsDir }, "skills_observer_starting");
 
-// chokidar v4 removed glob support: a "**/*.md" pattern is treated as a literal
-// (nonexistent) path, so the watcher established no persistent handle and the
-// process exited immediately -> restart loop. Watch the skills dir and filter to
-// .md via `ignored` (stats is undefined on the directory-scan pass, so folders
-// pass through and recursion still works). cwd keeps emitted paths relative, so
-// ingest's path.join(skillsDir, relativePath) is unchanged.
-const watcher = chokidar.watch(".", {
-  cwd: skillsDir,
-  ignoreInitial: false,
-  ignored: (testPath, stats) => Boolean(stats?.isFile()) && !testPath.endsWith(".md"),
-  awaitWriteFinish: {
-    stabilityThreshold: 500,
-    pollInterval: 100
-  }
-});
+let retryTimer: NodeJS.Timeout | undefined;
 
-watcher.on("add", ingest);
-watcher.on("change", ingest);
-watcher.on("error", (error) => logger.error({ err: error }, "skills_observer_error"));
+function scheduleRetry(): void {
+  // A pending timer keeps the event loop alive, so an unwatchable skills dir
+  // degrades to periodic retries instead of the process exiting and Docker
+  // restart-looping. It also self-heals once the directory becomes readable.
+  if (retryTimer) return;
+  retryTimer = setTimeout(() => {
+    retryTimer = undefined;
+    logger.info({ skillsDir }, "skills_observer_watch_retry");
+    startWatcher();
+  }, watchRetryMs);
+}
+
+function startWatcher(): void {
+  // chokidar v4 removed glob support: a "**/*.md" pattern is treated as a literal
+  // (nonexistent) path, so the watcher established no persistent handle and the
+  // process exited immediately -> restart loop. Watch the skills dir and filter to
+  // .md via `ignored` (stats is undefined on the directory-scan pass, so folders
+  // pass through and recursion still works). cwd keeps emitted paths relative, so
+  // ingest's path.join(skillsDir, relativePath) is unchanged.
+  const watcher = chokidar.watch(".", {
+    cwd: skillsDir,
+    ignoreInitial: false,
+    ignored: (testPath, stats) => Boolean(stats?.isFile()) && !testPath.endsWith(".md"),
+    awaitWriteFinish: {
+      stabilityThreshold: 500,
+      pollInterval: 100
+    }
+  });
+
+  watcher.on("add", ingest);
+  watcher.on("change", ingest);
+  watcher.on("error", (error) => {
+    const disposition = describeWatchError(error);
+    if (!disposition.retryable) {
+      logger.error({ err: error }, disposition.logKey);
+      return;
+    }
+    // Access errors (unreadable or absent skills volume) are operational, not
+    // fatal: tear the watcher down, surface the one-line fix, and retry.
+    logger.error(
+      { err: error, skillsDir, retryMs: watchRetryMs },
+      `${disposition.logKey}: ${disposition.remediation}`
+    );
+    void watcher.close().catch(() => undefined);
+    scheduleRetry();
+  });
+}
+
+startWatcher();
 
 async function ingest(relativePath: string) {
   const filePath = path.join(skillsDir, relativePath);

--- a/services/skills-observer/src/watch-error.ts
+++ b/services/skills-observer/src/watch-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Classify a chokidar/fs watch error so the observer can react without
+ * crash-looping. Access-class errors (the skills volume not readable by this
+ * container's user, or not present yet) are operational: log a clear remediation
+ * and retry rather than let the process exit. Anything else is a genuine fault.
+ */
+export interface WatchErrorDisposition {
+  /** True when the watcher should be torn down and re-established after a delay. */
+  retryable: boolean;
+  /** Structured log key. */
+  logKey: string;
+  /** Operator-facing remediation, present only for retryable access errors. */
+  remediation?: string;
+}
+
+const RETRYABLE_CODES = new Set(["EACCES", "EPERM", "ENOENT"]);
+
+export function describeWatchError(error: unknown): WatchErrorDisposition {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code: unknown }).code)
+      : undefined;
+
+  if (code && RETRYABLE_CODES.has(code)) {
+    return {
+      retryable: true,
+      logKey: "skills_observer_watch_unavailable",
+      remediation:
+        `cannot watch the skills directory (${code}). The skills volume must be readable by ` +
+        `this container's user; Hermes owns it as UID 10000 and secures it to mode 0700, so run ` +
+        `skills-observer as user "10000:10000". Will retry.`
+    };
+  }
+
+  return { retryable: false, logKey: "skills_observer_error" };
+}

--- a/test/unit/skills-observer-watch-error.test.ts
+++ b/test/unit/skills-observer-watch-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { describeWatchError } from "../../services/skills-observer/src/watch-error.js";
+
+describe("describeWatchError", () => {
+  it("marks EACCES as retryable with a UID-10000 remediation hint", () => {
+    const disposition = describeWatchError(Object.assign(new Error("denied"), { code: "EACCES" }));
+    expect(disposition.retryable).toBe(true);
+    expect(disposition.logKey).toBe("skills_observer_watch_unavailable");
+    expect(disposition.remediation).toMatch(/10000/);
+    expect(disposition.remediation).toMatch(/EACCES/);
+  });
+
+  it("marks EPERM and ENOENT as retryable too", () => {
+    expect(describeWatchError(Object.assign(new Error(), { code: "EPERM" })).retryable).toBe(true);
+    expect(describeWatchError(Object.assign(new Error(), { code: "ENOENT" })).retryable).toBe(true);
+  });
+
+  it("marks an unknown error code as non-retryable with the generic log key", () => {
+    const disposition = describeWatchError(Object.assign(new Error("boom"), { code: "EMFILE" }));
+    expect(disposition.retryable).toBe(false);
+    expect(disposition.logKey).toBe("skills_observer_error");
+    expect(disposition.remediation).toBeUndefined();
+  });
+
+  it("handles a plain Error and non-error values without throwing", () => {
+    expect(describeWatchError(new Error("boom")).retryable).toBe(false);
+    expect(describeWatchError(undefined).retryable).toBe(false);
+    expect(describeWatchError("nope").retryable).toBe(false);
+    expect(describeWatchError(null).retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

On the live VPS, `avg-skills-observer-1` was in a permanent restart storm (exit 0 → Docker restart, ~every 60s), spamming:

```
EACCES: permission denied, watch '/hermes-skills'
```

The chokidar-v4 glob fix (#463) was correct and is working — it just **unmasked a pre-existing permission problem** that the old "watch a nonexistent glob path" bug had been hiding.

## Root cause (diagnosed live)

The shared `avg-hermes-skills` volume is owned by **UID 10000** (Hermes) at mode **`0700`**, and Hermes **continuously re-secures it** to `0700` as its curator writes. The observer runs as the image's default `appuser` (**UID 10001**), so:

- `hermes-permissions`' `chmod -R 0777` and any manual `chmod` **never hold** — Hermes chmods it right back (confirmed live: a `755` I set reverted to `700` within minutes).
- `usePolling` wouldn't help either — at `0700` owned by 10000, even a *read* by UID 10001 is denied.

Verified the fix live by running the real image as UID 10000: the watch established with **no EACCES** (it then only hit `ECONNREFUSED` on Postgres because the throwaway container had no DB — i.e. the watcher had already fired an ingest, proving it works).

## Fix

- **`ops/compose.yml`** — run `skills-observer` as `user: "10000:10000"`, the volume owner (owner has `rwx` even at `0700`). Mounts stay **read-only**; the observer only ever reads. Immune to Hermes re-securing perms.
- **`services/skills-observer/src/index.ts`** — on `EACCES`/`EPERM`/`ENOENT`, log a one-line remediation and **retry the watch with backoff** (a pending timer keeps the event loop alive) instead of exiting into a restart storm. Self-heals once the directory is readable. Retry cadence via `SKILLS_OBSERVER_WATCH_RETRY_MS` (default 30s).
- **`services/skills-observer/src/watch-error.ts`** — small pure `describeWatchError` helper (classify retryable access errors vs genuine faults), unit-tested.

## Testing

- `npx tsc -b services/skills-observer` — clean.
- `npx vitest run test/unit/skills-observer-watch-error.test.ts` — 4/4 pass.
- `compose.yml` parses; `skills-observer.user = 10000:10000`, mounts still `:ro`.

## Deploy

After merge, redeploy (rebuild or pull) and recreate the service:

```sh
docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg up -d --force-recreate skills-observer
docker ps --format '{{.Names}}\t{{.Status}}' | grep skills-observer   # → Up, no Restarting
```

> Note: this is the skills-notify side service only — **no mission-path impact**. Also spotted in passing: an orphan `ops_avg-hermes-skills` volume (from a `docker compose` run made outside `-p avg`) that nothing mounts — safe to `docker volume rm` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)