### PR TITLE
feat(monitor): co-pilot on the Hermes gateway Session API (spike)

### DIFF
--- a/docs/HERMES_SESSION_API_SPIKE.md
+++ b/docs/HERMES_SESSION_API_SPIKE.md
@@ -1,0 +1,77 @@
+# Spike — co-pilot on the Hermes gateway Session API
+
+- **Status:** Spike. Built + unit-tested; **flag-gated OFF**; **not yet verified against a live gateway** (see the checklist). No behavior change until enabled.
+- **Date:** 2026-07-01
+- **Companion:** [`HERMES_UPGRADE_v017.md`](./HERMES_UPGRADE_v017.md) §2.2 (this is that item, spiked).
+- **Why:** make Hermes a more *agentic* right-hand. Today the co-pilot's "Ask Hermes" is a **stateless** OpenAI-compat call straight to Ollama (`requestHermesCompletion`) carrying only the *persona* — no MCP tools, no skills, no memory, no continuity. This spike lets the co-pilot talk to the **real Hermes agent** over the gateway Session API, so replies can actually use board tools, remember prior turns, and act like the orchestrator brain rather than a persona-prompted completion.
+
+---
+
+## What shipped (dormant)
+
+| File | Change |
+|---|---|
+| `services/slack-operator/src/hermes-session-client.ts` | **New.** Degraded-safe client for `/api/sessions/*` — create / turn / chat (create-if-needed + self-heal) / fork, tolerant extractors, injectable fetch. Zero external imports → fully isolated tests. |
+| `services/slack-operator/src/monitor-hermes-voice.ts` | `resolveHermesSessionConfig(env)` (fail-closed env gate) + `generateHermesReplyViaSession(context, cfg, sessionId?)` (sends `buildUserPrompt` as the turn input; **no persona injected** — the session *is* Hermes). |
+| `services/slack-operator/src/index.ts` | In `scheduleHermesAutoReply`: **session transport preferred when configured, else the existing Ollama path, else the canned template.** One module-level session id keeps the co-pilot thread continuous. |
+| `ops/compose.yml` | `HERMES_SESSION_API_ENABLED` / `HERMES_API_URL` / `HERMES_API_TOKEN` / `HERMES_SESSION_TIMEOUT_MS` passthrough to `slack-operator`, **default off**. |
+| `test/unit/hermes-session-{client,voice}.test.ts` | 23 tests: wire shapes, auth header, degraded paths, self-heal-on-stale-id, env gating, extractor drift tolerance. |
+
+**Default behavior is byte-identical:** `resolveHermesSessionConfig` returns `null` unless the flag + URL + token are all set, so the new branch never runs until you opt in.
+
+---
+
+## Wire format (confirmed from `gateway/platforms/api_server.py` @ v0.17)
+
+Auth: `Authorization: Bearer {API_SERVER_KEY}` on every call.
+
+| Method | Path | Body | Response (fields we read) |
+|---|---|---|---|
+| POST | `/api/sessions` | `{}` | `{ session: { id } }` |
+| POST | `/api/sessions/{id}/chat` | `{ "input": "…" }` | `{ session_id, message: { role, content }, usage }` — reply at **`message.content`** |
+| POST | `/api/sessions/{id}/chat/stream` | `{ "input": "…" }` | SSE: `assistant.delta {message_id, delta}` … `run.completed {session_id, messages, usage}` |
+| POST | `/api/sessions/{id}/fork` | `{ "title"? }` | `{ session: { id } }` |
+| GET | `/api/sessions/{id}/messages` | — | message history |
+
+The client uses the **synchronous `/chat`** turn: simplest, robust, and it carries the full agentic result. Extractors tolerate minor field drift (fall back to `content` / last assistant message) so a rename degrades to `null` (→ Ollama fallback) instead of throwing.
+
+---
+
+## How to enable (only with the command-center gateway up)
+
+The gateway already exists in `ops/compose.command-center.yml` (`hermes-gateway`, `API_SERVER_ENABLED=true`, `API_SERVER_KEY=${HERMES_GATEWAY_API_KEY}`, `:8642`). In `.env.prod`:
+
+```
+HERMES_SESSION_API_ENABLED=1
+HERMES_API_URL=http://hermes-gateway:8642
+HERMES_API_TOKEN=${HERMES_GATEWAY_API_KEY}
+# HERMES_SESSION_TIMEOUT_MS=45000   # agent turns are slower than a bare completion
+```
+
+Bring up slack-operator **and** the command-center profile together. Flip it off by unsetting the flag — the co-pilot reverts to the Ollama transport with zero risk.
+
+---
+
+## ⚠ Verify against a running gateway BEFORE trusting it
+
+This spike is unit-tested against the **documented** shapes, but the pinned image is **v0.14** and the Session API is **v0.15+**. Do **not** enable in prod until, on a **v0.17** gateway:
+
+1. **Create + turn round-trips.** From inside the network:
+   ```sh
+   ID=$(curl -s -XPOST http://hermes-gateway:8642/api/sessions -H "Authorization: Bearer $KEY" -d '{}' | jq -r .session.id)
+   curl -s -XPOST http://hermes-gateway:8642/api/sessions/$ID/chat -H "Authorization: Bearer $KEY" -d '{"input":"what changed on the board?"}' | jq .message.content
+   ```
+   Confirm the reply text really lands at **`message.content`** (adjust the extractor if not).
+2. **Agentic, not just a completion.** Ask something only the real agent can answer (needs an `averray_*` MCP tool or memory). Confirm it uses tools — otherwise the gateway session isn't wired to your MCP servers / profile.
+3. **Continuity.** Two turns on the same id; confirm turn 2 remembers turn 1 (then we can stop resending the thread — see follow-ups).
+4. **Latency + timeout.** Time a real turn; set `HERMES_SESSION_TIMEOUT_MS` above p95. The co-pilot reply is fire-and-forget, so a slow turn only delays Hermes's message.
+5. **Fallback intact.** Point the URL at a dead port; confirm the co-pilot still replies (Ollama → canned) and `hermesMode` stays honest.
+
+---
+
+## Follow-ups (not in this spike)
+
+- **Live SSE streaming** (`/chat/stream`) for token-by-token co-pilot replies — event shapes captured above; drop-in once the sync path is proven.
+- **Stop resending the thread.** Once continuity (step 3) is confirmed, send only the new operator message per turn and let session memory carry context (cheaper, more natural).
+- **Fork** for "explore this alternative" branches from the rail.
+- **Reuse the session transport for the orchestration routines** (PR handoff / operator report) currently shelled over SSH `hermes chat -q` — the higher-value half of the "SSH → Session API" move.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -240,6 +240,16 @@ services:
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-https://ollama.com/v1}
       HERMES_MONITOR_REPLY_MODEL: ${HERMES_MONITOR_REPLY_MODEL:-deepseek-v4-pro:cloud}
+      # Preferred co-pilot transport: the real agentic Hermes via the gateway
+      # Session API (MCP tools + skills + memory), instead of the stateless Ollama
+      # completion above. OFF by default (fail-closed). Enable only with the
+      # command-center gateway up: set ENABLED=1, point URL at hermes-gateway:8642,
+      # reuse HERMES_GATEWAY_API_KEY as the token. Falls back to Ollama on any
+      # gateway failure, so flipping this on can never mute the co-pilot.
+      HERMES_SESSION_API_ENABLED: ${HERMES_SESSION_API_ENABLED:-0}
+      HERMES_API_URL: ${HERMES_API_URL:-}
+      HERMES_API_TOKEN: ${HERMES_API_TOKEN:-}
+      HERMES_SESSION_TIMEOUT_MS: ${HERMES_SESSION_TIMEOUT_MS:-}
       LLM_USAGE_LOG_PATH: ${LLM_USAGE_LOG_PATH:-/data/llm-usage.jsonl}
       HERMES_MONITOR_MEMORY_PATH: ${HERMES_MONITOR_MEMORY_PATH:-/data/hermes-monitor-memory.json}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}

--- a/services/slack-operator/src/hermes-session-client.ts
+++ b/services/slack-operator/src/hermes-session-client.ts
@@ -1,0 +1,185 @@
+/**
+ * Client for the Hermes gateway Session API (`API_SERVER_ENABLED`, gated by
+ * `API_SERVER_KEY`, served on :8642 by the command-center `hermes-gateway`).
+ *
+ * Unlike `requestHermesCompletion` — a stateless OpenAI-compat call straight to
+ * Ollama that only carries Hermes's *persona* — a session turn runs the real
+ * Hermes *agent*: its MCP tools, skills, and memory, with context preserved
+ * across turns. This is the transport that lets the co-pilot talk to the
+ * agentic Hermes rather than a persona-prompted completion.
+ *
+ * Wire format (confirmed from gateway/platforms/api_server.py @ v0.17):
+ *   POST /api/sessions            {}          -> { session: { id, ... } }
+ *   POST /api/sessions/{id}/chat  { input }   -> { session_id, message: { role, content }, usage }
+ *   POST /api/sessions/{id}/fork  { title? }  -> { session: { id, ... } }
+ *   Auth: `Authorization: Bearer {API_SERVER_KEY}`
+ *
+ * Every call is DEGRADED-SAFE: it returns null on any failure (no token,
+ * non-2xx, timeout, malformed body) so the caller can fall back to the Ollama
+ * transport and then the canned template — the co-pilot never breaks.
+ *
+ * Live SSE streaming (`POST /api/sessions/{id}/chat/stream`; events
+ * `assistant.delta {message_id, delta}` … `run.completed {session_id, messages,
+ * usage}`) is a documented follow-up for live-token display. This client uses
+ * the synchronous turn, which is simpler and carries the full agentic result.
+ */
+
+export interface HermesSessionConfig {
+  /** Gateway base, e.g. `http://hermes-gateway:8642` (from `HERMES_API_URL`). */
+  baseUrl: string;
+  /** Bearer token = `API_SERVER_KEY` / `HERMES_API_TOKEN`. */
+  apiToken: string;
+  /**
+   * Per-call hard timeout. An agent turn (MCP tools + skills) is far slower than
+   * a bare completion, so this defaults high (45s). The co-pilot reply is
+   * fire-and-forget, so a slow turn only delays Hermes's message, never blocks.
+   */
+  timeoutMs?: number;
+  /** Injection point so tests don't hit the network. */
+  fetchFn?: typeof fetch;
+}
+
+export interface HermesSessionTurn {
+  sessionId: string;
+  text: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 45_000;
+
+async function postJson(cfg: HermesSessionConfig, path: string, body: unknown): Promise<unknown | null> {
+  if (!cfg.apiToken || !cfg.baseUrl) return null;
+  const url = `${cfg.baseUrl.replace(/\/+$/, "")}${path}`;
+  const fetchImpl = cfg.fetchFn ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${cfg.apiToken}`,
+      },
+      body: JSON.stringify(body ?? {}),
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    return (await response.json().catch(() => null)) as unknown;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Create an empty Hermes session; returns its id or null on failure. */
+export async function createHermesSession(
+  cfg: HermesSessionConfig,
+  init?: { title?: string }
+): Promise<string | null> {
+  const json = await postJson(cfg, "/api/sessions", init?.title ? { title: init.title } : {});
+  return extractSessionId(json);
+}
+
+/** Run one synchronous agent turn in an existing session. */
+export async function runHermesSessionTurn(
+  cfg: HermesSessionConfig,
+  sessionId: string,
+  input: string
+): Promise<HermesSessionTurn | null> {
+  if (!sessionId || !input.trim()) return null;
+  const json = await postJson(cfg, `/api/sessions/${encodeURIComponent(sessionId)}/chat`, { input });
+  const text = extractTurnText(json);
+  if (!text) return null;
+  return { sessionId: extractTurnSessionId(json) ?? sessionId, text };
+}
+
+/**
+ * Send a message to Hermes, creating a session if one isn't supplied. If a
+ * supplied session id has gone stale (the turn fails), transparently create a
+ * fresh session and retry once, so the co-pilot self-heals across gateway
+ * restarts. Returns the (possibly new) session id + reply, or null on failure.
+ */
+export async function chatWithHermesSession(
+  cfg: HermesSessionConfig,
+  input: string,
+  existingSessionId?: string
+): Promise<HermesSessionTurn | null> {
+  if (!input.trim()) return null;
+  if (existingSessionId) {
+    const turn = await runHermesSessionTurn(cfg, existingSessionId, input);
+    if (turn) return turn;
+    // fall through: stale/invalid session id -> recreate once
+  }
+  const fresh = await createHermesSession(cfg);
+  if (!fresh) return null;
+  return runHermesSessionTurn(cfg, fresh, input);
+}
+
+/** Branch a session (CLI `/branch` semantics); returns the new session id. */
+export async function forkHermesSession(
+  cfg: HermesSessionConfig,
+  sessionId: string,
+  title?: string
+): Promise<string | null> {
+  if (!sessionId) return null;
+  const json = await postJson(
+    cfg,
+    `/api/sessions/${encodeURIComponent(sessionId)}/fork`,
+    title ? { title } : {}
+  );
+  return extractSessionId(json);
+}
+
+// --- tolerant extractors -----------------------------------------------------
+// Response shapes are confirmed from api_server.py; the fallbacks tolerate minor
+// shape drift across Hermes versions so a field rename degrades to null (caller
+// falls back) rather than throwing.
+
+/** `{ session: { id } }`, with fallbacks to `{ id }` / `{ session_id }`. */
+export function extractSessionId(json: unknown): string | null {
+  const root = asRecord(json);
+  if (!root) return null;
+  const session = asRecord(root.session);
+  return asId(session?.id) ?? asId(root.id) ?? asId(root.session_id) ?? asId(root.sessionId);
+}
+
+/** `{ message: { content } }`, with fallbacks incl. the last assistant message. */
+export function extractTurnText(json: unknown): string | null {
+  const root = asRecord(json);
+  if (!root) return null;
+  const message = asRecord(root.message);
+  const direct =
+    asText(message?.content) ??
+    asText(root.content) ??
+    asText(root.output) ??
+    asText(root.text) ??
+    asText(root.reply);
+  if (direct) return direct;
+  const messages = Array.isArray(root.messages) ? root.messages : [];
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = asRecord(messages[i]);
+    if (m && (m.role === undefined || m.role === "assistant")) {
+      const t = asText(m.content);
+      if (t) return t;
+    }
+  }
+  return null;
+}
+
+function extractTurnSessionId(json: unknown): string | null {
+  const root = asRecord(json);
+  if (!root) return null;
+  return asId(root.session_id) ?? asId(root.sessionId) ?? extractSessionId(json);
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+function asId(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+function asText(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -132,7 +132,9 @@ import {
   applyHermesMemoryInfluence,
   generateHermesBoardNarration,
   generateHermesReply,
+  generateHermesReplyViaSession,
   requestHermesCompletion,
+  resolveHermesSessionConfig,
 } from "./monitor-hermes-voice.js";
 import {
   fallbackHermesRouterNarration,
@@ -1394,6 +1396,11 @@ async function handleCommand(envelope: SlackCommandEnvelope) {
 // own bubble paints first, then Hermes's reply lands 2-5s later.
 // timer.unref() so a slow LLM call can't keep the process alive on
 // shutdown.
+// Persists across operator posts so the gateway Session-API transport (when
+// enabled) keeps one continuous Hermes thread rather than a fresh session per
+// reply. Best-effort in-memory; recreated automatically if the id goes stale.
+let hermesCopilotSessionId: string | undefined;
+
 function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof recordCollaborationMessage>>) {
   const draft = synthesizeHermesReplyFor(operatorMessage);
   if (!draft) return;
@@ -1401,6 +1408,9 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
   const apiKey = optionalEnv("OLLAMA_API_KEY");
   const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
   const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "deepseek-v4-pro:cloud";
+  // Null unless HERMES_SESSION_API_ENABLED + URL + token are all set, so the
+  // default transport stays the Ollama completion below.
+  const sessionConfig = resolveHermesSessionConfig();
 
   const timer = setTimeout(async () => {
     let text = draft.text;
@@ -1418,7 +1428,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
         kind: operatorMessage.kind,
         ...(operatorMessage.relatedPr ? { relatedPr: operatorMessage.relatedPr } : {}),
       },
-      recentMessages: apiKey
+      recentMessages: (apiKey || sessionConfig)
         ? listCollaborationMessages({ limit: 10 }).map((m) => ({ author: m.author, text: m.text, ts: m.ts }))
         : [],
       memoryNotes,
@@ -1430,26 +1440,43 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       text = draft.text;
     } else if (memoryRequest !== "none") {
       text = hermesMemoryGovernanceReply(operatorMessage, memoryRequest, memoryNotes);
-    } else if (apiKey) {
-      try {
-        // replyContext carries the recent thread oldest-first so the
-        // model sees the conversation in natural order rather than reversed.
-        const llmText = await generateHermesReply(replyContext, {
-          apiKey,
-          baseUrl,
-          model,
-          taskId: operatorMessage.id,
-          runId: operatorMessage.relatedCorrelationId
-            ?? (operatorMessage.relatedPr ? `${operatorMessage.relatedPr.repo}#${operatorMessage.relatedPr.number}` : operatorMessage.id),
-        });
-        if (llmText) {
-          text = llmText;
-          hermesMode = "live";
-        } else {
-          logger.info({ id: operatorMessage.id }, "monitor_collaboration_llm_reply_unavailable_fell_back");
+    } else {
+      let llmText: string | null = null;
+      // Preferred transport: the real agentic Hermes via the gateway Session
+      // API — MCP tools + skills + memory, one persistent thread. Only runs when
+      // sessionConfig is set (flag-gated); otherwise this is a no-op.
+      if (sessionConfig) {
+        try {
+          const turn = await generateHermesReplyViaSession(replyContext, sessionConfig, hermesCopilotSessionId);
+          if (turn) {
+            hermesCopilotSessionId = turn.sessionId;
+            llmText = turn.text;
+          }
+        } catch (error) {
+          logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_session_reply_threw");
         }
-      } catch (error) {
-        logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_llm_reply_threw");
+      }
+      // Fallback transport: the stateless Ollama persona completion. replyContext
+      // carries the recent thread oldest-first so the model sees natural order.
+      if (!llmText && apiKey) {
+        try {
+          llmText = await generateHermesReply(replyContext, {
+            apiKey,
+            baseUrl,
+            model,
+            taskId: operatorMessage.id,
+            runId: operatorMessage.relatedCorrelationId
+              ?? (operatorMessage.relatedPr ? `${operatorMessage.relatedPr.repo}#${operatorMessage.relatedPr.number}` : operatorMessage.id),
+          });
+        } catch (error) {
+          logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_llm_reply_threw");
+        }
+      }
+      if (llmText) {
+        text = llmText;
+        hermesMode = "live";
+      } else if (sessionConfig || apiKey) {
+        logger.info({ id: operatorMessage.id }, "monitor_collaboration_llm_reply_unavailable_fell_back");
       }
     }
     if (memoryRequest !== "forget_pr") {

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -29,6 +29,11 @@ import {
   type LlmUsageEvent,
 } from "@avg/averray-mcp/llm-usage";
 import { logger } from "@avg/mcp-common";
+import {
+  chatWithHermesSession,
+  type HermesSessionConfig,
+  type HermesSessionTurn,
+} from "./hermes-session-client.js";
 
 export const HERMES_PERSONA = `You are Hermes, the board orchestrator for the Averray platform.
 
@@ -282,6 +287,49 @@ export async function generateHermesBoardNarration(
     options
   );
   return text ? appendHermesWhyTrace(applyHermesMemoryInfluence(text, context), context) : null;
+}
+
+/**
+ * Resolve the Hermes gateway Session-API transport from env. Returns null (=>
+ * caller uses the Ollama transport) unless the flag is on AND both the URL and
+ * token are set. Fail-closed: a half-configured gateway never activates.
+ *
+ * Env (set in .env.prod when the command-center gateway is up):
+ *   HERMES_SESSION_API_ENABLED=1
+ *   HERMES_API_URL=http://hermes-gateway:8642
+ *   HERMES_API_TOKEN=<API_SERVER_KEY>            (= HERMES_GATEWAY_API_KEY)
+ *   HERMES_SESSION_TIMEOUT_MS=45000              (optional)
+ */
+export function resolveHermesSessionConfig(
+  env: NodeJS.ProcessEnv = process.env
+): HermesSessionConfig | null {
+  if (!/^(1|true|yes|on)$/i.test((env.HERMES_SESSION_API_ENABLED ?? "").trim())) return null;
+  const baseUrl = (env.HERMES_API_URL ?? "").trim();
+  const apiToken = (env.HERMES_API_TOKEN ?? "").trim();
+  if (!baseUrl || !apiToken) return null;
+  const timeoutMs = Number(env.HERMES_SESSION_TIMEOUT_MS);
+  return {
+    baseUrl,
+    apiToken,
+    ...(Number.isFinite(timeoutMs) && timeoutMs > 0 ? { timeoutMs } : {}),
+  };
+}
+
+/**
+ * Co-pilot reply via the real agentic Hermes: send the operator's turn (with
+ * compact board context, via the shared buildUserPrompt) to a persistent
+ * gateway session and return its reply + the session id so the caller can keep
+ * the thread going. No persona is injected here — the session *is* Hermes, with
+ * its own system prompt, MCP tools, skills, and memory. Returns null on any
+ * failure so the caller falls back to the Ollama transport. Memory-influence +
+ * `Why:` post-processing is left to the caller for parity with that path.
+ */
+export async function generateHermesReplyViaSession(
+  context: HermesReplyContext,
+  config: HermesSessionConfig,
+  sessionId?: string
+): Promise<HermesSessionTurn | null> {
+  return chatWithHermesSession(config, buildUserPrompt(context), sessionId);
 }
 
 export function buildUserPrompt(context: HermesReplyContext): string {

--- a/test/unit/hermes-session-client.test.ts
+++ b/test/unit/hermes-session-client.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chatWithHermesSession,
+  createHermesSession,
+  extractSessionId,
+  extractTurnText,
+  forkHermesSession,
+  runHermesSessionTurn,
+  type HermesSessionConfig,
+} from "../../services/slack-operator/src/hermes-session-client.js";
+
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number; throwJson?: boolean }): Response {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    json: async () => {
+      if (init?.throwJson) throw new Error("bad json");
+      return body;
+    },
+  } as unknown as Response;
+}
+
+interface MockCall {
+  url: string;
+  method?: string;
+  body?: unknown;
+  auth?: unknown;
+}
+
+function mockFetch(responses: Array<Response | Error>): { fetchFn: typeof fetch; calls: MockCall[] } {
+  const calls: MockCall[] = [];
+  let i = 0;
+  const fetchFn = (async (url: unknown, init: RequestInit | undefined) => {
+    calls.push({
+      url: String(url),
+      method: init?.method,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      auth: (init?.headers as Record<string, string> | undefined)?.authorization,
+    });
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    if (r instanceof Error) throw r;
+    return r as Response;
+  }) as unknown as typeof fetch;
+  return { fetchFn, calls };
+}
+
+const cfg = (fetchFn: typeof fetch): HermesSessionConfig => ({
+  baseUrl: "http://gw:8642/", // trailing slash exercises the strip
+  apiToken: "tok",
+  fetchFn,
+});
+
+describe("createHermesSession", () => {
+  it("posts {} to /api/sessions with bearer auth and returns session.id", async () => {
+    const { fetchFn, calls } = mockFetch([jsonResponse({ object: "hermes.session", session: { id: "s1" } })]);
+    const id = await createHermesSession(cfg(fetchFn));
+    expect(id).toBe("s1");
+    expect(calls[0]!.url).toBe("http://gw:8642/api/sessions");
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.body).toEqual({});
+    expect(calls[0]!.auth).toBe("Bearer tok");
+  });
+
+  it("returns null on a non-2xx response", async () => {
+    const { fetchFn } = mockFetch([jsonResponse({}, { ok: false, status: 500 })]);
+    expect(await createHermesSession(cfg(fetchFn))).toBeNull();
+  });
+
+  it("returns null when the body is not valid JSON", async () => {
+    const { fetchFn } = mockFetch([jsonResponse(null, { throwJson: true })]);
+    expect(await createHermesSession(cfg(fetchFn))).toBeNull();
+  });
+
+  it("returns null and never calls fetch without a token", async () => {
+    const { fetchFn, calls } = mockFetch([jsonResponse({ session: { id: "s1" } })]);
+    expect(await createHermesSession({ baseUrl: "http://gw:8642", apiToken: "", fetchFn })).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("runHermesSessionTurn", () => {
+  it("posts { input } to /api/sessions/{id}/chat and returns message.content", async () => {
+    const { fetchFn, calls } = mockFetch([
+      jsonResponse({ session_id: "s1", message: { role: "assistant", content: " hello " }, usage: {} }),
+    ]);
+    const turn = await runHermesSessionTurn(cfg(fetchFn), "s1", "hi");
+    expect(turn).toEqual({ sessionId: "s1", text: "hello" });
+    expect(calls[0]!.url).toBe("http://gw:8642/api/sessions/s1/chat");
+    expect(calls[0]!.body).toEqual({ input: "hi" });
+  });
+
+  it("returns null on empty input without calling fetch", async () => {
+    const { fetchFn, calls } = mockFetch([jsonResponse({ message: { content: "x" } })]);
+    expect(await runHermesSessionTurn(cfg(fetchFn), "s1", "   ")).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns null on a non-2xx turn", async () => {
+    const { fetchFn } = mockFetch([jsonResponse({}, { ok: false, status: 404 })]);
+    expect(await runHermesSessionTurn(cfg(fetchFn), "s1", "hi")).toBeNull();
+  });
+
+  it("falls back to root.content, then to the last assistant message", async () => {
+    const c1 = mockFetch([jsonResponse({ content: "root-level" })]);
+    expect((await runHermesSessionTurn(cfg(c1.fetchFn), "s", "q"))?.text).toBe("root-level");
+
+    const c2 = mockFetch([
+      jsonResponse({ messages: [{ role: "user", content: "q" }, { role: "assistant", content: "final" }] }),
+    ]);
+    expect((await runHermesSessionTurn(cfg(c2.fetchFn), "s", "q"))?.text).toBe("final");
+  });
+});
+
+describe("chatWithHermesSession", () => {
+  it("creates a session then runs the turn when no id is supplied", async () => {
+    const { fetchFn, calls } = mockFetch([
+      jsonResponse({ session: { id: "s2" } }),
+      jsonResponse({ message: { content: "reply" } }),
+    ]);
+    const turn = await chatWithHermesSession(cfg(fetchFn), "hi");
+    expect(turn).toEqual({ sessionId: "s2", text: "reply" });
+    expect(calls.map((c) => c.url)).toEqual([
+      "http://gw:8642/api/sessions",
+      "http://gw:8642/api/sessions/s2/chat",
+    ]);
+  });
+
+  it("reuses a supplied session id with a single turn call", async () => {
+    const { fetchFn, calls } = mockFetch([jsonResponse({ session_id: "s1", message: { content: "ok" } })]);
+    const turn = await chatWithHermesSession(cfg(fetchFn), "hi", "s1");
+    expect(turn).toEqual({ sessionId: "s1", text: "ok" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("http://gw:8642/api/sessions/s1/chat");
+  });
+
+  it("recreates the session once when the supplied id is stale, then retries", async () => {
+    const { fetchFn, calls } = mockFetch([
+      jsonResponse({}, { ok: false, status: 404 }), // stale id turn fails
+      jsonResponse({ session: { id: "s3" } }), // recreate
+      jsonResponse({ message: { content: "healed" } }), // retry turn
+    ]);
+    const turn = await chatWithHermesSession(cfg(fetchFn), "hi", "stale");
+    expect(turn).toEqual({ sessionId: "s3", text: "healed" });
+    expect(calls).toHaveLength(3);
+  });
+
+  it("returns null when creation fails after a stale id", async () => {
+    const { fetchFn } = mockFetch([
+      jsonResponse({}, { ok: false, status: 404 }),
+      jsonResponse({}, { ok: false, status: 500 }),
+    ]);
+    expect(await chatWithHermesSession(cfg(fetchFn), "hi", "stale")).toBeNull();
+  });
+
+  it("returns null when a network error is thrown", async () => {
+    const { fetchFn } = mockFetch([new Error("ECONNREFUSED")]);
+    expect(await chatWithHermesSession(cfg(fetchFn), "hi")).toBeNull();
+  });
+});
+
+describe("forkHermesSession", () => {
+  it("posts { title } to /api/sessions/{id}/fork and returns the new id", async () => {
+    const { fetchFn, calls } = mockFetch([jsonResponse({ session: { id: "f1" } })]);
+    const id = await forkHermesSession(cfg(fetchFn), "s1", "alt path");
+    expect(id).toBe("f1");
+    expect(calls[0]!.url).toBe("http://gw:8642/api/sessions/s1/fork");
+    expect(calls[0]!.body).toEqual({ title: "alt path" });
+  });
+});
+
+describe("extractors tolerate shape drift", () => {
+  it("extractSessionId reads session.id / id / session_id and null otherwise", () => {
+    expect(extractSessionId({ session: { id: "a" } })).toBe("a");
+    expect(extractSessionId({ id: "b" })).toBe("b");
+    expect(extractSessionId({ session_id: "c" })).toBe("c");
+    expect(extractSessionId({ nope: 1 })).toBeNull();
+    expect(extractSessionId(null)).toBeNull();
+    expect(extractSessionId("x")).toBeNull();
+  });
+
+  it("extractTurnText prefers message.content, then falls back, else null", () => {
+    expect(extractTurnText({ message: { content: "primary" } })).toBe("primary");
+    expect(extractTurnText({ output: "out" })).toBe("out");
+    expect(extractTurnText({ messages: [{ role: "assistant", content: "last" }] })).toBe("last");
+    expect(extractTurnText({ message: { content: "   " } })).toBeNull();
+    expect(extractTurnText({})).toBeNull();
+  });
+});

--- a/test/unit/hermes-session-voice.test.ts
+++ b/test/unit/hermes-session-voice.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  generateHermesReplyViaSession,
+  resolveHermesSessionConfig,
+  type HermesReplyContext,
+} from "../../services/slack-operator/src/monitor-hermes-voice.js";
+
+describe("resolveHermesSessionConfig", () => {
+  const base = {
+    HERMES_API_URL: "http://hermes-gateway:8642",
+    HERMES_API_TOKEN: "gwkey",
+  } as NodeJS.ProcessEnv;
+
+  it("returns null when the flag is unset (default = Ollama transport)", () => {
+    expect(resolveHermesSessionConfig({ ...base })).toBeNull();
+  });
+
+  it("returns null when enabled but URL or token is missing (fail-closed)", () => {
+    expect(resolveHermesSessionConfig({ HERMES_SESSION_API_ENABLED: "1", HERMES_API_TOKEN: "gwkey" })).toBeNull();
+    expect(resolveHermesSessionConfig({ HERMES_SESSION_API_ENABLED: "1", HERMES_API_URL: "http://gw" })).toBeNull();
+  });
+
+  it("resolves a config when enabled with URL + token", () => {
+    const cfg = resolveHermesSessionConfig({ ...base, HERMES_SESSION_API_ENABLED: "1" });
+    expect(cfg).toEqual({ baseUrl: "http://hermes-gateway:8642", apiToken: "gwkey" });
+  });
+
+  it("accepts truthy flag spellings and rejects falsey ones", () => {
+    for (const on of ["1", "true", "YES", "On"]) {
+      expect(resolveHermesSessionConfig({ ...base, HERMES_SESSION_API_ENABLED: on })).not.toBeNull();
+    }
+    for (const off of ["0", "false", "", "no"]) {
+      expect(resolveHermesSessionConfig({ ...base, HERMES_SESSION_API_ENABLED: off })).toBeNull();
+    }
+  });
+
+  it("carries a positive numeric timeout override", () => {
+    const cfg = resolveHermesSessionConfig({ ...base, HERMES_SESSION_API_ENABLED: "1", HERMES_SESSION_TIMEOUT_MS: "30000" });
+    expect(cfg?.timeoutMs).toBe(30000);
+    const noTimeout = resolveHermesSessionConfig({ ...base, HERMES_SESSION_API_ENABLED: "1", HERMES_SESSION_TIMEOUT_MS: "oops" });
+    expect(noTimeout && "timeoutMs" in noTimeout).toBe(false);
+  });
+});
+
+describe("generateHermesReplyViaSession", () => {
+  const context: HermesReplyContext = {
+    operatorMessage: { text: "what's the state of the board?", addressedTo: "hermes", kind: "chat" },
+    recentMessages: [],
+  };
+
+  function fetchReturning(body: unknown, ok = true): typeof fetch {
+    return (async () => ({ ok, status: ok ? 200 : 500, json: async () => body })) as unknown as typeof fetch;
+  }
+
+  it("returns the session reply + id via the real-agent transport", async () => {
+    const cfg = {
+      baseUrl: "http://gw:8642",
+      apiToken: "tok",
+      fetchFn: fetchReturning({ session: { id: "s9" }, message: { content: "Operator review has 2 cards waiting on you." } }),
+    };
+    const turn = await generateHermesReplyViaSession(context, cfg);
+    expect(turn?.sessionId).toBe("s9");
+    expect(turn?.text).toContain("Operator review");
+  });
+
+  it("returns null when the gateway is unreachable (caller falls back to Ollama)", async () => {
+    const cfg = { baseUrl: "http://gw:8642", apiToken: "tok", fetchFn: fetchReturning({}, false) };
+    expect(await generateHermesReplyViaSession(context, cfg)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Spikes the highest-leverage item from the v0.17 eval ([#465](https://github.com/depre-dev/averray-reference-agent/pull/465) §2.2): let the co-pilot talk to the **real agentic Hermes** via the gateway **Session API** instead of a stateless Ollama completion.

Today "Ask Hermes" calls `requestHermesCompletion` → Ollama Cloud directly, carrying only Hermes's *persona* — **no MCP tools, skills, memory, or continuity**. This adds a degraded-safe client for `/api/sessions/*` so the co-pilot can route through the actual Hermes agent as a persistent thread.

## Design

- **`hermes-session-client.ts`** (new) — create / turn / `chat` (create-if-needed + **self-heal** on a stale id) / fork. Wire shapes confirmed from `gateway/platforms/api_server.py` @ v0.17 (`POST /api/sessions` → `{session:{id}}`; `POST /api/sessions/{id}/chat {input}` → `{message:{content}}`; bearer `API_SERVER_KEY`). Tolerant extractors, injectable fetch, **returns null on any failure**.
- **`monitor-hermes-voice.ts`** — `resolveHermesSessionConfig` (fail-closed env gate) + `generateHermesReplyViaSession` (the session **is** Hermes — no persona injected).
- **`index.ts`** — in `scheduleHermesAutoReply`: **session preferred when configured → Ollama fallback → canned template**; one persistent co-pilot session id.
- **`ops/compose.yml`** — `HERMES_SESSION_*` passthrough, **default OFF**.

## Safety / truth-boundary

- **Flag-gated OFF** → `resolveHermesSessionConfig` returns null unless `HERMES_SESSION_API_ENABLED` + URL + token are all set, so **default behavior is byte-identical**.
- Any gateway failure falls back to Ollama then the canned reply — enabling this **can never mute the co-pilot**; `hermesMode` stays honest (`live` only on real success).
- **⚠ Not yet verified against a live gateway** — the pinned image is v0.14; the Session API is v0.15+. `docs/HERMES_SESSION_API_SPIKE.md` has the **verify-on-v0.17 checklist** (create+turn round-trip, confirm reply lands at `message.content`, confirm it actually uses MCP tools, continuity, latency/timeout, fallback) to run **before** enabling — which depends on the [#465](https://github.com/depre-dev/averray-reference-agent/pull/465) v0.17 bump.

## Tests

`npx tsc -b services/slack-operator` clean; **23 unit tests** (`hermes-session-client`, `hermes-session-voice`) green — wire shapes, auth header, degraded paths, self-heal-on-stale-id, env gating, extractor drift tolerance.

## Follow-ups (documented, not in this PR)

Live SSE streaming (`/chat/stream`; event shapes captured), stop resending the thread once continuity is confirmed, fork-for-branches, and reusing the session transport for the SSH-shelled orchestration routines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)