### PR TITLE
fix(trace-mcp): survive EADDRINUSE on the ingest port (v0.17 double-spawn)

### DIFF
--- a/packages/trace-mcp/src/index.ts
+++ b/packages/trace-mcp/src/index.ts
@@ -3,6 +3,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { jsonContent, logger, optionalEnv, query, runStdioServer } from "@avg/mcp-common";
 import { recordHermesLlmUsageFromTraceEvent } from "./hermes-llm-usage.js";
+import { classifyIngestBindError } from "./ingest-errors.js";
 
 const server = new McpServer({
   name: "trace-mcp",
@@ -56,7 +57,7 @@ await runStdioServer(server);
 
 function startHttpIngest() {
   const port = Number(optionalEnv("TRACE_HTTP_PORT", "8789"));
-  http
+  const ingestServer = http
     .createServer(async (req, res) => {
       if (req.method !== "POST" || req.url !== "/hermes-event") {
         res.writeHead(404).end();
@@ -90,6 +91,19 @@ function startHttpIngest() {
       }
     })
     .listen(port, "0.0.0.0", () => logger.info({ port }, "trace_http_ingest_listening"));
+
+  // A stdio MCP server must never die because this auxiliary ingest port is
+  // taken. Under Hermes v0.17 the s6 supervisor spawns the MCP set for more than
+  // one service (main-hermes gateway + dashboard), so a second trace-mcp instance
+  // hits EADDRINUSE here; without this handler the unhandled 'error' event crashes
+  // the process and Hermes reports the MCP as "Connection closed". Degrade to
+  // stdio-only — whichever instance won the port handles HTTP ingest, and the
+  // stdio tools still work in every instance.
+  ingestServer.on("error", (error: NodeJS.ErrnoException) => {
+    const { retryable, logKey } = classifyIngestBindError(error);
+    if (retryable) logger.warn({ port }, logKey);
+    else logger.error({ err: error, port }, logKey);
+  });
 }
 
 async function ensureRun(hermesRunId: string | undefined, task: string): Promise<string> {

--- a/packages/trace-mcp/src/ingest-errors.ts
+++ b/packages/trace-mcp/src/ingest-errors.ts
@@ -1,0 +1,27 @@
+/**
+ * Classify an http.Server `error` from the trace HTTP-ingest listener.
+ *
+ * `EADDRINUSE` is expected and benign: trace-mcp also runs as a stdio MCP
+ * server, and under Hermes v0.17 the s6 supervisor spawns the MCP set for more
+ * than one service (the `main-hermes` gateway AND the `dashboard`), so a second
+ * trace-mcp instance can't bind the shared ingest port. That must degrade to
+ * stdio-only — an unhandled `error` event would otherwise crash the process,
+ * and Hermes then reports the whole MCP server as "Connection closed" (which is
+ * exactly what happened on the first v0.17 boot). Any other bind error is a
+ * genuine fault worth surfacing at error level.
+ */
+export interface IngestBindErrorDisposition {
+  /** True for the benign shared-port case — warn and keep serving stdio. */
+  retryable: boolean;
+  /** Structured log key. */
+  logKey: string;
+}
+
+export function classifyIngestBindError(
+  error: (Error & { code?: string }) | undefined
+): IngestBindErrorDisposition {
+  if (error?.code === "EADDRINUSE") {
+    return { retryable: true, logKey: "trace_http_ingest_port_unavailable_stdio_only" };
+  }
+  return { retryable: false, logKey: "trace_http_ingest_error" };
+}

--- a/test/unit/trace-ingest-errors.test.ts
+++ b/test/unit/trace-ingest-errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyIngestBindError } from "../../packages/trace-mcp/src/ingest-errors.js";
+
+describe("classifyIngestBindError", () => {
+  it("treats EADDRINUSE as benign — warn and keep serving stdio", () => {
+    const disposition = classifyIngestBindError(Object.assign(new Error("address in use"), { code: "EADDRINUSE" }));
+    expect(disposition.retryable).toBe(true);
+    expect(disposition.logKey).toBe("trace_http_ingest_port_unavailable_stdio_only");
+  });
+
+  it("treats other bind errors as genuine faults with the generic key", () => {
+    const denied = classifyIngestBindError(Object.assign(new Error("denied"), { code: "EACCES" }));
+    expect(denied.retryable).toBe(false);
+    expect(denied.logKey).toBe("trace_http_ingest_error");
+  });
+
+  it("handles a codeless error and undefined without throwing", () => {
+    expect(classifyIngestBindError(new Error("boom")).retryable).toBe(false);
+    expect(classifyIngestBindError(undefined).retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
## What the v0.17 staging smoke found

On the first live boot of `nousresearch/hermes-agent:v2026.6.19`, 4 of 5 MCP servers connected — only **`trace`** failed: `Failed to connect to MCP server 'trace' … Connection closed`.

**Root cause (ours, not v0.17's):** `trace-mcp` is the only MCP server that binds a fixed HTTP port — `TRACE_HTTP_PORT` default **8789** — *in addition to* its stdio server. v0.17's s6 supervisor runs **two** Hermes services in one container (`main-hermes` gateway **+** `dashboard`), and each spawns the full MCP set from `hermes.yaml`. So `trace-mcp` is launched twice, the second `.listen(8789)` hits **`EADDRINUSE`**, and with no `'error'` handler that unhandled event **crashes the process** → the stdio transport dies → Hermes reports "Connection closed". On v0.14 only the dashboard ran, so it was spawned once and never collided.

The other four MCP servers are pure stdio (no port bind), which is exactly why they were unaffected.

## Fix

Attach an `'error'` handler to the ingest server. On `EADDRINUSE`, **warn and keep serving stdio** — whichever instance won the port handles HTTP ingest, and the stdio tools (which use the DB) work in every instance. Any other bind error logs at error level. `classifyIngestBindError` is a pure, unit-tested helper (mirrors the `describeWatchError` pattern from #464).

A stdio MCP server should never die because an auxiliary HTTP port is busy — so this is correct independent of the exact spawn mechanism.

## Tests

`npx tsc -b packages/trace-mcp` clean; **3 unit tests** green (EADDRINUSE → benign/warn; other codes → fault; codeless/undefined tolerated).

## Deploy

Ships via the normal `avg-node-runtime` rebuild (`mcp-bundle` repopulates `avg-app` → the hermes container reads the new `trace-mcp` dist). After deploy on the v0.17 pin, `trace` should connect and the "Connection closed" warning disappears — the live confirmation of the diagnosis.

> Context: this is the one defect the v0.17 staging smoke surfaced. Everything else (s6 boot, `command: dashboard` routing, the #464 UID-10000 coupling, averray/wallet/receipt/policy MCP, dashboard, skills) came back clean — v0.17 is otherwise a drop-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)