### PR TITLE
feat(monitor): record agentic session-turn usage on the usage panel

### DIFF
--- a/services/slack-operator/src/hermes-session-client.ts
+++ b/services/slack-operator/src/hermes-session-client.ts
@@ -42,6 +42,11 @@ export interface HermesSessionConfig {
 export interface HermesSessionTurn {
   sessionId: string;
   text: string;
+  /** Raw `usage` block from the turn response ({input_tokens, output_tokens, …}).
+   *  Passed to the monitor's usage recorder so agentic replies show on the panel. */
+  usage?: Record<string, unknown> | null;
+  /** Model the gateway ran the turn on, when the response reports it. */
+  model?: string | null;
 }
 
 const DEFAULT_TIMEOUT_MS = 45_000;
@@ -90,7 +95,12 @@ export async function runHermesSessionTurn(
   const json = await postJson(cfg, `/api/sessions/${encodeURIComponent(sessionId)}/chat`, { input });
   const text = extractTurnText(json);
   if (!text) return null;
-  return { sessionId: extractTurnSessionId(json) ?? sessionId, text };
+  return {
+    sessionId: extractTurnSessionId(json) ?? sessionId,
+    text,
+    usage: extractTurnUsage(json),
+    model: extractTurnModel(json),
+  };
 }
 
 /**
@@ -170,6 +180,18 @@ function extractTurnSessionId(json: unknown): string | null {
   const root = asRecord(json);
   if (!root) return null;
   return asId(root.session_id) ?? asId(root.sessionId) ?? extractSessionId(json);
+}
+
+/** The raw `usage` object off a turn response, or null when absent. */
+export function extractTurnUsage(json: unknown): Record<string, unknown> | null {
+  return asRecord(asRecord(json)?.usage) ?? null;
+}
+
+/** The model the turn ran on, when the response reports it. */
+export function extractTurnModel(json: unknown): string | null {
+  const root = asRecord(json);
+  if (!root) return null;
+  return asId(root.model) ?? asId(asRecord(root.message)?.model) ?? asId(asRecord(root.usage)?.model);
 }
 
 function asRecord(v: unknown): Record<string, unknown> | undefined {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -1447,7 +1447,7 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       // sessionConfig is set (flag-gated); otherwise this is a no-op.
       if (sessionConfig) {
         try {
-          const turn = await generateHermesReplyViaSession(replyContext, sessionConfig, hermesCopilotSessionId);
+          const turn = await generateHermesReplyViaSession(replyContext, sessionConfig, hermesCopilotSessionId, { model });
           if (turn) {
             hermesCopilotSessionId = turn.sessionId;
             llmText = turn.text;

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -327,9 +327,35 @@ export function resolveHermesSessionConfig(
 export async function generateHermesReplyViaSession(
   context: HermesReplyContext,
   config: HermesSessionConfig,
-  sessionId?: string
+  sessionId?: string,
+  usageOptions?: { model?: string; usageLogPath?: string }
 ): Promise<HermesSessionTurn | null> {
-  return chatWithHermesSession(config, buildUserPrompt(context), sessionId);
+  // Mark the call live (the co-pilot "thinking" indicator) for the turn's
+  // duration — an agent turn is much slower than the Ollama completion.
+  const endLlmUsageCall = beginLlmUsageCall({
+    agent: "hermes",
+    ...(usageOptions?.model ? { model: usageOptions.model } : {}),
+  });
+  try {
+    const turn = await chatWithHermesSession(config, buildUserPrompt(context), sessionId);
+    // Record the agentic turn's token usage so the monitor's usage panel counts
+    // it. The Ollama transport records via requestHermesCompletion; without this
+    // the panel would under-report Hermes once session replies flow.
+    if (turn?.usage) {
+      const model = turn.model ?? usageOptions?.model;
+      await recordLlmUsageFromResult(
+        {
+          agent: "hermes",
+          ...(model ? { model } : {}),
+          result: { usage: turn.usage, ...(turn.model ? { model: turn.model } : {}) },
+        },
+        { path: usageOptions?.usageLogPath ?? llmUsageLogPath() }
+      ).catch((error) => logger.warn({ err: error }, "monitor_session_usage_record_failed"));
+    }
+    return turn;
+  } finally {
+    endLlmUsageCall();
+  }
 }
 
 export function buildUserPrompt(context: HermesReplyContext): string {

--- a/test/unit/hermes-session-client.test.ts
+++ b/test/unit/hermes-session-client.test.ts
@@ -86,7 +86,7 @@ describe("runHermesSessionTurn", () => {
       jsonResponse({ session_id: "s1", message: { role: "assistant", content: " hello " }, usage: {} }),
     ]);
     const turn = await runHermesSessionTurn(cfg(fetchFn), "s1", "hi");
-    expect(turn).toEqual({ sessionId: "s1", text: "hello" });
+    expect(turn).toMatchObject({ sessionId: "s1", text: "hello" });
     expect(calls[0]!.url).toBe("http://gw:8642/api/sessions/s1/chat");
     expect(calls[0]!.body).toEqual({ input: "hi" });
   });
@@ -120,7 +120,7 @@ describe("chatWithHermesSession", () => {
       jsonResponse({ message: { content: "reply" } }),
     ]);
     const turn = await chatWithHermesSession(cfg(fetchFn), "hi");
-    expect(turn).toEqual({ sessionId: "s2", text: "reply" });
+    expect(turn).toMatchObject({ sessionId: "s2", text: "reply" });
     expect(calls.map((c) => c.url)).toEqual([
       "http://gw:8642/api/sessions",
       "http://gw:8642/api/sessions/s2/chat",
@@ -130,7 +130,7 @@ describe("chatWithHermesSession", () => {
   it("reuses a supplied session id with a single turn call", async () => {
     const { fetchFn, calls } = mockFetch([jsonResponse({ session_id: "s1", message: { content: "ok" } })]);
     const turn = await chatWithHermesSession(cfg(fetchFn), "hi", "s1");
-    expect(turn).toEqual({ sessionId: "s1", text: "ok" });
+    expect(turn).toMatchObject({ sessionId: "s1", text: "ok" });
     expect(calls).toHaveLength(1);
     expect(calls[0]!.url).toBe("http://gw:8642/api/sessions/s1/chat");
   });
@@ -142,7 +142,7 @@ describe("chatWithHermesSession", () => {
       jsonResponse({ message: { content: "healed" } }), // retry turn
     ]);
     const turn = await chatWithHermesSession(cfg(fetchFn), "hi", "stale");
-    expect(turn).toEqual({ sessionId: "s3", text: "healed" });
+    expect(turn).toMatchObject({ sessionId: "s3", text: "healed" });
     expect(calls).toHaveLength(3);
   });
 

--- a/test/unit/hermes-session-usage.test.ts
+++ b/test/unit/hermes-session-usage.test.ts
@@ -1,0 +1,96 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  extractTurnModel,
+  extractTurnUsage,
+  runHermesSessionTurn,
+  type HermesSessionConfig,
+} from "../../services/slack-operator/src/hermes-session-client.js";
+import {
+  generateHermesReplyViaSession,
+  type HermesReplyContext,
+} from "../../services/slack-operator/src/monitor-hermes-voice.js";
+
+const CHAT_RESPONSE = {
+  object: "hermes.session.chat.completion",
+  session_id: "s1",
+  message: { role: "assistant", content: "Two cards await your review." },
+  usage: { input_tokens: 21675, output_tokens: 388, total_tokens: 22063 },
+};
+
+function fetchReturning(body: unknown): typeof fetch {
+  return (async () => ({ ok: true, status: 200, json: async () => body })) as unknown as typeof fetch;
+}
+
+describe("session usage extraction", () => {
+  it("extractTurnUsage returns the raw usage block, else null", () => {
+    expect(extractTurnUsage(CHAT_RESPONSE)).toEqual({ input_tokens: 21675, output_tokens: 388, total_tokens: 22063 });
+    expect(extractTurnUsage({ message: { content: "x" } })).toBeNull();
+    expect(extractTurnUsage(null)).toBeNull();
+  });
+
+  it("extractTurnModel reads model where reported, else null", () => {
+    expect(extractTurnModel({ model: "deepseek" })).toBe("deepseek");
+    expect(extractTurnModel({ usage: { model: "glm-5.2" } })).toBe("glm-5.2");
+    expect(extractTurnModel(CHAT_RESPONSE)).toBeNull();
+  });
+
+  it("runHermesSessionTurn carries usage alongside the reply text", async () => {
+    const cfg: HermesSessionConfig = { baseUrl: "http://gw", apiToken: "t", fetchFn: fetchReturning(CHAT_RESPONSE) };
+    const turn = await runHermesSessionTurn(cfg, "s1", "hi");
+    expect(turn?.text).toContain("cards");
+    expect(turn?.usage).toEqual({ input_tokens: 21675, output_tokens: 388, total_tokens: 22063 });
+  });
+});
+
+describe("generateHermesReplyViaSession records the agentic turn's usage", () => {
+  let dir = "";
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes an LlmUsageEvent with the turn's tokens to the usage log", async () => {
+    dir = mkdtempSync(join(tmpdir(), "hermes-usage-"));
+    const path = join(dir, "usage.jsonl");
+    const context: HermesReplyContext = {
+      operatorMessage: { text: "status?", addressedTo: "hermes", kind: "chat" },
+      recentMessages: [],
+    };
+    const cfg: HermesSessionConfig = { baseUrl: "http://gw", apiToken: "t", fetchFn: fetchReturning(CHAT_RESPONSE) };
+
+    const turn = await generateHermesReplyViaSession(context, cfg, "s1", {
+      model: "deepseek-v4-pro:cloud",
+      usageLogPath: path,
+    });
+    expect(turn?.text).toBeTruthy();
+
+    const lines = readFileSync(path, "utf8").trim().split("\n").filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const event = JSON.parse(lines[0]!);
+    expect(event.agent).toBe("hermes");
+    expect(event.model).toBe("deepseek-v4-pro:cloud");
+    expect(event.inputTokens).toBe(21675);
+    expect(event.outputTokens).toBe(388);
+  });
+
+  it("does not throw and records nothing when the gateway fails", async () => {
+    dir = mkdtempSync(join(tmpdir(), "hermes-usage-"));
+    const path = join(dir, "usage.jsonl");
+    const context: HermesReplyContext = {
+      operatorMessage: { text: "status?", addressedTo: "hermes", kind: "chat" },
+      recentMessages: [],
+    };
+    const cfg: HermesSessionConfig = {
+      baseUrl: "http://gw",
+      apiToken: "t",
+      fetchFn: (async () => ({ ok: false, status: 502, json: async () => ({}) })) as unknown as typeof fetch,
+    };
+    const turn = await generateHermesReplyViaSession(context, cfg, "s1", { model: "m", usageLogPath: path });
+    expect(turn).toBeNull();
+    expect(() => readFileSync(path, "utf8")).toThrow(); // no file written
+  });
+});


### PR DESCRIPTION
## Why

The follow-up promised when we flipped the co-pilot onto the agentic Session API. The #466 transport returned the reply text but **not** the turn's token usage — so once agentic replies flow, the monitor's usage panel would **under-report Hermes** (the Ollama transport records via `requestHermesCompletion`; the session path didn't). A live turn is ~21K input tokens, so that gap is material.

## What

- **`hermes-session-client.ts`** — `HermesSessionTurn` now carries the turn's raw **`usage`** (`{input_tokens, output_tokens, …}`) + **`model`**; added `extractTurnUsage` / `extractTurnModel`.
- **`monitor-hermes-voice.ts`** — `generateHermesReplyViaSession` marks the call live (`beginLlmUsageCall`, for the "thinking" indicator) and **records the turn's usage** via `recordLlmUsageFromResult`, so agentic replies land on the panel like every other agent. Degraded-safe (records nothing on failure).
- **`index.ts`** — passes the model label through so the recorded event is attributed.

The session `/chat` response's `usage` block flows straight into the existing `recordLlmUsageFromResult` (which already reads `input_tokens`/`output_tokens`), so the panel's token counts, per-model rollups, and live per-minute series all pick it up.

## Tests

`tsc -b services/slack-operator` clean; **28 session tests green** — new: usage/model extraction + a **record-to-disk integration test** (a turn writes an `LlmUsageEvent` with the right tokens to a temp usage log; a failed gateway writes nothing). The #466 turn-shape assertions were relaxed to `toMatchObject` for the two new fields.

## Deploy

Ships with the node image (already rebuilt for #467). Once `HERMES_SESSION_API_ENABLED=1` is on, Hermes's agentic replies show truthfully on the usage panel — closing the gap flagged when we enabled it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)