### PR TITLE
feat(orch): agentic board-grounded backlog for the Hermes router (P4c, PR 1/2)

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -256,6 +256,14 @@ services:
       HERMES_API_URL: ${HERMES_API_URL:-}
       HERMES_API_TOKEN: ${HERMES_API_TOKEN:-}
       HERMES_SESSION_TIMEOUT_MS: ${HERMES_SESSION_TIMEOUT_MS:-}
+      # ORCH-P4c — agentic router backlog. When ON (needs the gateway session AND
+      # a non-empty dispatch.allowed_repos), Hermes reasons over the live board to
+      # propose board-grounded work gaps, augmenting the deterministic roadmap
+      # backlog. Everything still flows through the hard taxonomy + dispatch-policy
+      # + operator gate. OFF by default; falls back to the roadmap backlog on any
+      # failure. One session turn per router tick.
+      HERMES_ROUTER_AGENTIC_BACKLOG: ${HERMES_ROUTER_AGENTIC_BACKLOG:-0}
+      HERMES_ROUTER_AGENTIC_MAX_ITEMS: ${HERMES_ROUTER_AGENTIC_MAX_ITEMS:-3}
       LLM_USAGE_LOG_PATH: ${LLM_USAGE_LOG_PATH:-/data/llm-usage.jsonl}
       HERMES_MONITOR_MEMORY_PATH: ${HERMES_MONITOR_MEMORY_PATH:-/data/hermes-monitor-memory.json}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}

--- a/services/slack-operator/src/agentic-backlog.ts
+++ b/services/slack-operator/src/agentic-backlog.ts
@@ -1,0 +1,209 @@
+/**
+ * ORCH-P4c — agentic backlog source for the Hermes router.
+ *
+ * The router's deterministic backlog (roadmap plan) is the predictable FLOOR.
+ * This adds a board-grounded layer: Hermes (glm-5.2, over the gateway session
+ * with its MCP tools + memory) reasons about the LIVE board and proposes genuine
+ * work gaps. Those items are AUGMENTED onto the roadmap floor and flow through
+ * the UNCHANGED router path — hard taxonomy (`assertTaxonomy`) + dispatch-policy
+ * allowlist/budget + operator approval. Hermes gains NO new authority: it only
+ * answers "what's worth proposing," grounded in board evidence it must cite.
+ *
+ * Every guardrail is preserved because this only changes the *backlog source*:
+ *   • proposes-only (the router still writes `proposed`, never approves)
+ *   • hard routing taxonomy still deterministically assigns/validates the agent
+ *   • dispatch-policy allowlist + per-day/per-repo budgets still gate
+ *   • operator approval still required; autonomy-mode + anomaly-pause still apply
+ *
+ * DEGRADED-SAFE: any failure (gateway down, non-JSON, no items) returns [] so the
+ * caller falls back to the deterministic backlog. Every item is validated
+ * (allowlisted repo + a cited board signal) or dropped — a hallucinated item with
+ * no board signal never becomes a proposal.
+ */
+
+import type { RoutedWorkAgent, WorkRouterBacklogItem } from "@avg/averray-mcp/work-router";
+import { chatWithHermesSession, type HermesSessionConfig } from "./hermes-session-client.js";
+import type { HermesBoardSnapshot } from "./monitor-hermes-voice.js";
+
+export interface AgenticBacklogConfig {
+  session: HermesSessionConfig;
+  /** dispatch.allowed_repos — Hermes may only propose for these (pre-filtered). */
+  allowedRepos: readonly string[];
+  /** Hard cap on items accepted from one router tick. */
+  maxItems: number;
+}
+
+export interface AgenticBacklogInFlight {
+  repo: string;
+  status: string;
+  title?: string;
+  surface?: string;
+}
+
+export interface AgenticBacklogContext {
+  board: HermesBoardSnapshot;
+  /** Current queue tasks — so Hermes doesn't re-propose in-flight work. */
+  inFlight: readonly AgenticBacklogInFlight[];
+  /** Operator preferences / prior room decisions (guidance, not proof). */
+  memoryNotes: readonly string[];
+}
+
+export interface AgenticBacklogDeps {
+  /** Injection point so tests never hit the gateway. */
+  chat?: typeof chatWithHermesSession;
+}
+
+/**
+ * A router backlog item + the agent Hermes *suggested*. The suggestion is parsed
+ * and carried now; PR #2 makes the work-router honor it on soft surfaces (the
+ * hard taxonomy always overrides). Until then it's inert metadata.
+ */
+export type AgenticBacklogItem = WorkRouterBacklogItem & { suggestedAgent?: RoutedWorkAgent };
+
+/** Ask Hermes for board-grounded work gaps; validate + normalize to backlog items. */
+export async function collectAgenticBacklog(
+  config: AgenticBacklogConfig,
+  context: AgenticBacklogContext,
+  deps: AgenticBacklogDeps = {}
+): Promise<AgenticBacklogItem[]> {
+  if (config.allowedRepos.length === 0 || config.maxItems <= 0) return [];
+  const chat = deps.chat ?? chatWithHermesSession;
+
+  let turnText: string | null = null;
+  try {
+    const turn = await chat(config.session, buildAgenticBacklogPrompt(config, context));
+    turnText = turn?.text ?? null;
+  } catch {
+    return [];
+  }
+  if (!turnText) return [];
+
+  const allowed = new Set(config.allowedRepos.map((repo) => repo.trim().toLowerCase()));
+  const items: AgenticBacklogItem[] = [];
+  const seen = new Set<string>();
+  for (const raw of parseWorkItems(turnText)) {
+    if (items.length >= config.maxItems) break;
+    const item = normalizeItem(raw, allowed);
+    if (!item) continue;
+    const key = `${item.repo}::${item.surface ?? ""}`.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    items.push(item);
+  }
+  return items;
+}
+
+// --- prompt -----------------------------------------------------------------
+
+export function buildAgenticBacklogPrompt(config: AgenticBacklogConfig, context: AgenticBacklogContext): string {
+  const lines: string[] = [];
+  lines.push("You are Hermes, the board orchestrator. Find GENUINE work gaps on the live board that should become tasks.");
+  lines.push("");
+  lines.push("Live board (highest-priority evidence — every item you propose MUST cite a signal from here):");
+  lines.push(formatBoardForPrompt(context.board));
+  lines.push("");
+  if (context.inFlight.length > 0) {
+    lines.push("Already in flight (do NOT re-propose these):");
+    for (const task of context.inFlight.slice(0, 20)) {
+      lines.push(`- [${task.status}] ${task.repo}: ${truncate(task.surface || task.title || "task", 100)}`);
+    }
+    lines.push("");
+  }
+  if (context.memoryNotes.length > 0) {
+    lines.push("Operator memory (preferences / prior decisions — guidance, not proof):");
+    for (const note of context.memoryNotes.slice(0, 8)) lines.push(`- ${truncate(note, 200)}`);
+    lines.push("");
+  }
+  lines.push(`You may ONLY propose work for these repos: ${config.allowedRepos.join(", ")}.`);
+  lines.push("");
+  lines.push("Rules:");
+  lines.push("- Propose only REAL gaps grounded in the board (a failed check needing a fix, a stuck draft, missing coverage, a follow-up a card asks for). Do NOT invent work.");
+  lines.push("- Skip anything already in flight above. Skip merge/deploy — those stay with the human.");
+  lines.push(`- At most ${config.maxItems} items, highest-leverage first. Fewer is fine. If nothing is genuinely needed, return [].`);
+  lines.push("- suggestedAgent: 'codex' for chain/settlement/contracts/secrets/DB-migrations/deploy/ops; 'claude' for UI/frontend/monitor/docs/tests/non-financial. (The system enforces the dangerous ones regardless.)");
+  lines.push("");
+  lines.push("Return ONLY a JSON array, no prose, each item exactly:");
+  lines.push('[{"repo":"owner/name","surface":"short area label","title":"short title","prompt":"concrete task instruction for the worker agent","why":"why this is needed","boardSignal":"the exact board card/lane/failure this addresses","suggestedAgent":"codex|claude"}]');
+  return lines.join("\n");
+}
+
+function formatBoardForPrompt(board: HermesBoardSnapshot): string {
+  const out: string[] = [];
+  if (board.headline) out.push(`headline: ${truncate(board.headline, 300)}`);
+  if (board.counts) {
+    const counts = Object.entries(board.counts)
+      .filter(([, v]) => v !== undefined && v !== "" && v !== false)
+      .map(([k, v]) => `${k}=${String(v)}`)
+      .join(", ");
+    if (counts) out.push(`lanes: ${counts}`);
+  }
+  const items = board.items ?? [];
+  if (items.length === 0) return `${out.join("\n")}\ncards: none`;
+  out.push("cards:");
+  for (const card of items.slice(0, 14)) {
+    const id = card.repo && card.number ? `${card.repo}#${card.number}` : card.repo || "card";
+    const parts = [
+      `${card.lane} / owner ${card.owner}`,
+      id,
+      card.verdict ? `verdict ${card.verdict}` : "",
+      card.ageLabel ? `age ${card.ageLabel}` : "",
+      `title ${truncate(card.title, 120)}`,
+      card.why ? `why ${truncate(card.why, 160)}` : "",
+      card.next ? `next ${truncate(card.next, 160)}` : "",
+    ].filter(Boolean);
+    out.push(`  - ${parts.join(" | ")}`);
+  }
+  return out.join("\n");
+}
+
+// --- parse + validate -------------------------------------------------------
+
+/** Extract the first JSON array from a model reply, tolerant of surrounding prose. */
+export function parseWorkItems(text: string): unknown[] {
+  const start = text.indexOf("[");
+  const end = text.lastIndexOf("]");
+  if (start < 0 || end <= start) return [];
+  try {
+    const parsed = JSON.parse(text.slice(start, end + 1)) as unknown;
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Validate one raw item → AgenticBacklogItem, or null to drop it. */
+export function normalizeItem(raw: unknown, allowedRepos: ReadonlySet<string>): AgenticBacklogItem | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  const repo = str(r.repo);
+  const surface = str(r.surface);
+  const prompt = str(r.prompt);
+  const boardSignal = str(r.boardSignal);
+  // Hard requirements: an allowlisted repo, a task surface + prompt, and — the
+  // hallucination guard — a cited board signal. Missing any → drop the item.
+  if (!repo || !allowedRepos.has(repo.toLowerCase())) return null;
+  if (!surface || !prompt || !boardSignal) return null;
+
+  const title = str(r.title) || surface;
+  const why = str(r.why);
+  const suggestedAgent = r.suggestedAgent === "codex" || r.suggestedAgent === "claude" ? r.suggestedAgent : undefined;
+
+  return {
+    repo,
+    surface,
+    title,
+    prompt,
+    area: surface,
+    description: [why, `board: ${boardSignal}`].filter(Boolean).join(" — "),
+    shortDescription: why || title,
+    ...(suggestedAgent ? { suggestedAgent } : {}),
+  };
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -142,6 +142,8 @@ import {
   runHermesRouterOnce,
   type HermesRouterAuditRecord,
 } from "./hermes-router-routine.js";
+import { collectAgenticBacklog } from "./agentic-backlog.js";
+import type { WorkRouterBacklogItem } from "@avg/averray-mcp/work-router";
 import {
   approveCodexTask,
   annotateCodexTaskDecisionRecord,
@@ -3441,7 +3443,7 @@ function startOperatorRoutines() {
         maxProposalsPerTick: routineConfig.hermesRouter.maxProposalsPerTick,
         lookbackMs: routineConfig.hermesRouter.lookbackHours * 60 * 60_000,
       }, {
-        getBacklog: () => collectHermesRouterBacklog(),
+        getBacklog: () => collectHermesRouterBacklogAugmented(),
         listTasks: () => listCodexTasks(),
         policy: () => loadDispatchPolicyConfig(),
         classify: (input) => classifyTaskForWorkRouter(input),
@@ -3887,6 +3889,71 @@ function collectHermesRouterBacklog() {
       description: item.closeCriteria.join("; "),
       shortDescription: item.scoreSignals[0] ?? item.title,
     }));
+}
+
+// ORCH-P4c — augment the deterministic roadmap backlog with a board-grounded
+// agentic layer when HERMES_ROUTER_AGENTIC_BACKLOG=1 and the gateway session is
+// configured. Degraded-safe: any failure falls back to the roadmap floor. The
+// items still flow through the UNCHANGED router (hard taxonomy + dispatch-policy
+// + operator gate), so Hermes gains no new authority — only a smarter backlog.
+async function collectHermesRouterBacklogAugmented(): Promise<WorkRouterBacklogItem[]> {
+  const roadmap: WorkRouterBacklogItem[] = collectHermesRouterBacklog();
+  const sessionConfig = resolveHermesSessionConfig();
+  const enabled = /^(1|true|yes|on)$/i.test((optionalEnv("HERMES_ROUTER_AGENTIC_BACKLOG") ?? "").trim());
+  if (!enabled || !sessionConfig) return roadmap;
+  try {
+    const board = await loadHermesRouterBoardSnapshot();
+    if (!board) return roadmap;
+    const policy = loadDispatchPolicyConfig();
+    if (policy.allowedRepos.length === 0) return roadmap; // fail-closed: nothing to propose
+    const maxItems = Math.max(1, Number.parseInt(optionalEnv("HERMES_ROUTER_AGENTIC_MAX_ITEMS", "3") ?? "3", 10) || 3);
+    const inFlight = (await listCodexTasks())
+      .filter((task) => task.status === "proposed" || task.status === "approved" || task.status === "running")
+      .map((task) => ({
+        repo: task.repo,
+        status: task.status,
+        ...(task.title ? { title: task.title } : {}),
+        ...(task.surface ? { surface: task.surface } : {}),
+      }));
+    const memoryNotes = listHermesMemoryNotes({ limit: 8 }).map((note) => note.text);
+    const agentic = await collectAgenticBacklog(
+      { session: sessionConfig, allowedRepos: policy.allowedRepos, maxItems },
+      { board, inFlight, memoryNotes },
+    );
+    if (agentic.length > 0) logger.info({ count: agentic.length }, "hermes_router_agentic_backlog_added");
+    return mergeRouterBacklog(roadmap, agentic);
+  } catch (error) {
+    logger.warn({ err: error }, "hermes_router_agentic_backlog_failed");
+    return roadmap;
+  }
+}
+
+async function loadHermesRouterBoardSnapshot() {
+  try {
+    const url = new URL("http://localhost/monitor/events?limit=40&activeWindowMinutes=240");
+    const snapshot = await withTimeout(
+      loadMonitorSnapshot(url, { suppressNarration: true }),
+      4_000,
+      "hermes_router_board_snapshot_timeout",
+    );
+    return buildHermesBoardSnapshotFromMonitor(snapshot);
+  } catch (error) {
+    logger.warn({ err: error }, "hermes_router_board_snapshot_unavailable");
+    return undefined;
+  }
+}
+
+function mergeRouterBacklog(roadmap: WorkRouterBacklogItem[], agentic: WorkRouterBacklogItem[]): WorkRouterBacklogItem[] {
+  const keyOf = (item: WorkRouterBacklogItem) => `${item.repo}::${item.surface ?? item.area ?? ""}`.toLowerCase();
+  const seen = new Set(roadmap.map(keyOf));
+  const merged: WorkRouterBacklogItem[] = [...roadmap];
+  for (const item of agentic) {
+    const k = keyOf(item);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    merged.push(item);
+  }
+  return merged;
 }
 
 function classifyTaskForWorkRouter(input: Parameters<typeof classifyTask>[0]) {

--- a/test/unit/agentic-backlog.test.ts
+++ b/test/unit/agentic-backlog.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  buildAgenticBacklogPrompt,
+  collectAgenticBacklog,
+  normalizeItem,
+  parseWorkItems,
+  type AgenticBacklogConfig,
+  type AgenticBacklogContext,
+} from "../../services/slack-operator/src/agentic-backlog.js";
+
+const CFG = (over: Partial<AgenticBacklogConfig> = {}): AgenticBacklogConfig => ({
+  session: { baseUrl: "http://gw:8642", apiToken: "t" },
+  allowedRepos: ["averray-agent/agent"],
+  maxItems: 3,
+  ...over,
+});
+
+const CTX: AgenticBacklogContext = {
+  board: { headline: "1 failure", counts: { needsAttention: 1 }, items: [] },
+  inFlight: [],
+  memoryNotes: [],
+};
+
+function chatReturning(text: string) {
+  return vi.fn(async () => ({ sessionId: "s1", text }));
+}
+
+const VALID_ITEM = {
+  repo: "averray-agent/agent",
+  surface: "settlement waiver",
+  title: "fix waiver selectors",
+  prompt: "Update the EscrowCore waiver selector to tolerate the pinned contract.",
+  why: "CI failing on the deploy verification",
+  boardSignal: "needs-attention: post-production-deploy verification failed",
+  suggestedAgent: "codex",
+};
+
+describe("collectAgenticBacklog", () => {
+  it("returns validated, mapped items from Hermes's JSON reply", async () => {
+    const chat = chatReturning(JSON.stringify([VALID_ITEM]));
+    const items = await collectAgenticBacklog(CFG(), CTX, { chat });
+    expect(chat).toHaveBeenCalledOnce();
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      repo: "averray-agent/agent",
+      surface: "settlement waiver",
+      prompt: VALID_ITEM.prompt,
+      suggestedAgent: "codex",
+    });
+    expect(items[0]!.description).toContain("board:");
+  });
+
+  it("drops items for non-allowlisted repos", async () => {
+    const chat = chatReturning(JSON.stringify([{ ...VALID_ITEM, repo: "someone/else" }]));
+    expect(await collectAgenticBacklog(CFG(), CTX, { chat })).toHaveLength(0);
+  });
+
+  it("drops items with no cited board signal (hallucination guard)", async () => {
+    const chat = chatReturning(JSON.stringify([{ ...VALID_ITEM, boardSignal: "" }]));
+    expect(await collectAgenticBacklog(CFG(), CTX, { chat })).toHaveLength(0);
+  });
+
+  it("never calls the gateway when the allowlist is empty (fail-closed)", async () => {
+    const chat = chatReturning(JSON.stringify([VALID_ITEM]));
+    expect(await collectAgenticBacklog(CFG({ allowedRepos: [] }), CTX, { chat })).toHaveLength(0);
+    expect(chat).not.toHaveBeenCalled();
+  });
+
+  it("returns [] on a gateway error or non-JSON reply", async () => {
+    const throwing = vi.fn(async () => { throw new Error("gw down"); });
+    expect(await collectAgenticBacklog(CFG(), CTX, { chat: throwing as never })).toHaveLength(0);
+    const prose = chatReturning("Sorry, I couldn't parse the board.");
+    expect(await collectAgenticBacklog(CFG(), CTX, { chat: prose })).toHaveLength(0);
+  });
+
+  it("caps at maxItems and dedupes repo::surface", async () => {
+    const many = [VALID_ITEM, { ...VALID_ITEM, surface: "a" }, { ...VALID_ITEM, surface: "b" }, { ...VALID_ITEM, surface: "c" }];
+    const chat = chatReturning(JSON.stringify(many));
+    expect(await collectAgenticBacklog(CFG({ maxItems: 2 }), CTX, { chat })).toHaveLength(2);
+    const dupes = [VALID_ITEM, { ...VALID_ITEM }];
+    expect(await collectAgenticBacklog(CFG(), CTX, { chat: chatReturning(JSON.stringify(dupes)) })).toHaveLength(1);
+  });
+});
+
+describe("parseWorkItems", () => {
+  it("extracts a JSON array even with surrounding prose", () => {
+    expect(parseWorkItems('here you go: [{"repo":"a"}] done')).toEqual([{ repo: "a" }]);
+    expect(parseWorkItems("no json here")).toEqual([]);
+    expect(parseWorkItems("[not valid json")).toEqual([]);
+  });
+});
+
+describe("normalizeItem", () => {
+  const allowed = new Set(["averray-agent/agent"]);
+  it("keeps a valid item and parses suggestedAgent", () => {
+    const item = normalizeItem(VALID_ITEM, allowed);
+    expect(item?.repo).toBe("averray-agent/agent");
+    expect(item?.suggestedAgent).toBe("codex");
+  });
+  it("rejects missing repo/surface/prompt/boardSignal, and bad suggestedAgent → undefined", () => {
+    expect(normalizeItem({ ...VALID_ITEM, prompt: "" }, allowed)).toBeNull();
+    expect(normalizeItem({ ...VALID_ITEM, repo: "x/y" }, allowed)).toBeNull();
+    expect(normalizeItem({ ...VALID_ITEM, suggestedAgent: "gpt" }, allowed)?.suggestedAgent).toBeUndefined();
+    expect(normalizeItem(null, allowed)).toBeNull();
+  });
+});
+
+describe("buildAgenticBacklogPrompt", () => {
+  it("names the allowed repos and demands a board signal + JSON-only output", () => {
+    const prompt = buildAgenticBacklogPrompt(CFG(), CTX);
+    expect(prompt).toContain("averray-agent/agent");
+    expect(prompt).toContain("boardSignal");
+    expect(prompt).toMatch(/JSON array/i);
+  });
+});


### PR DESCRIPTION
## What — Tier-1 #2, part 1 of 2

Lights up the dormant **codex-needed** lane. Your O4/O5 dispatch stack (router, hard taxonomy, `dispatch-policy`, `enqueue_agent_task`, autopilot, anomaly-pause) was already complete and safe — the only non-agentic piece was that the router decides *what work is needed* from a deterministic roadmap backlog. This makes **that decision** agentic: Hermes (glm-5.2, over the gateway session with its MCP tools + memory) reasons over the **live board** and proposes board-grounded work gaps, **augmenting** the roadmap floor.

## Safety — this only changes the *backlog source*

Every guardrail between "proposed" and "executed" is **untouched**:
- **Proposes-only** — the router still writes `proposed`; never approves/dispatches/merges/deploys.
- **Hard routing taxonomy** still deterministically assigns + `assertTaxonomy`-validates the agent (chain/settlement/secrets/migrations/deploy → Codex, or it throws).
- **dispatch-policy** allowlist + per-day/per-repo budgets still gate.
- **Operator approval** still required; autonomy-mode + anomaly-pause still apply.
- **Hallucination guard** — every item must cite a board signal; items without one are dropped. Non-allowlisted repos dropped. Low `maxItems`.

Hermes gains **zero** new authority — it only answers "what's worth proposing," grounded in evidence it must cite.

## How

- **`agentic-backlog.ts`** (new) — `collectAgenticBacklog`: prompt Hermes with the live board + in-flight tasks + memory + the allowlist → parse strict JSON → validate each item (allowlisted repo + surface + prompt + **cited boardSignal**) → map to `WorkRouterBacklogItem`. Also parses `suggestedAgent` (inert now; **PR 2/2** makes `work-router` honor it on *soft* surfaces, hard taxonomy still overriding). **Degraded-safe**: any failure → `[]`.
- **`index.ts`** — `collectHermesRouterBacklogAugmented` wraps the router's `getBacklog`: **flag-gated** (`HERMES_ROUTER_AGENTIC_BACKLOG=0`), **fail-closed** (empty `dispatch.allowed_repos` → roadmap only), degraded-safe fallback, merge/dedupe onto the roadmap floor.
- **`ops/compose.yml`** — `HERMES_ROUTER_AGENTIC_BACKLOG` / `_MAX_ITEMS` passthrough, **off by default**.

## Tests

`tsc -b services/slack-operator` clean; **10 unit tests** (mapping, non-allowlisted-repo drop, hallucination-guard drop, fail-closed no-call, gateway-error/non-JSON → `[]`, maxItems cap, dedupe, prompt shape) + compose-env green.

## Activation (deliberate, operator-gated)
Enable the router **and** `HERMES_ROUTER_AGENTIC_BACKLOG=1` **and** opt repos into `dispatch.allowed_repos` (still fail-closed). Then Hermes proposes → they land `proposed` in codex-needed → you approve.

**PR 2/2** (next): soft-surface agent suggestion — Hermes's `suggestedAgent` honored on UI/docs/tests, hard taxonomy overriding everything dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)