### PR TITLE
Let Hermes suggest the agent on soft surfaces; keep the dangerous wall (Full-B)

### DIFF
--- a/packages/averray-mcp/src/work-router.ts
+++ b/packages/averray-mcp/src/work-router.ts
@@ -21,6 +21,12 @@ export interface WorkRouterBacklogItem extends Partial<Pick<HermesBacklogItem, "
   area?: string;
   description?: string;
   shortDescription?: string;
+  /**
+   * Agent Hermes suggested (agentic backlog). Honored ONLY on soft surfaces; the
+   * hard taxonomy always overrides on dangerous surfaces. Absent for
+   * deterministic/roadmap items (which route via the classifier + learned routing).
+   */
+  suggestedAgent?: RoutedWorkAgent;
 }
 
 export interface WorkRouterTaskSnapshot {
@@ -97,10 +103,29 @@ export function planAndRouteWork(input: PlanAndRouteWorkInput): RoutedProposal[]
     });
     const classifiedAgent = routedAgent(routing.agent);
     const hardAgent = hardTaxonomyAgent(surface, title);
-    const learned = hardAgent
-      ? { agent: hardAgent, note: hardAgent === classifiedAgent ? undefined : `Hard taxonomy kept ${surface} with ${hardAgent}; learned routing and classifier output cannot override it.` }
-      : learnedRoutingChoice(surface, classifiedAgent, input.routingScores);
-    const agent = learned.agent;
+    const suggested = item.suggestedAgent === "codex" || item.suggestedAgent === "claude" ? item.suggestedAgent : undefined;
+    let choice: { agent: RoutedWorkAgent; note?: string };
+    if (hardAgent) {
+      // Dangerous surface: the hard taxonomy is the wall. Nothing — not the
+      // classifier, not learned routing, not Hermes's suggestion — overrides it.
+      choice = {
+        agent: hardAgent,
+        note: hardAgent === classifiedAgent
+          ? undefined
+          : `Hard taxonomy kept ${surface} with ${hardAgent}; classifier, learned routing, and Hermes's suggestion cannot override it.`,
+      };
+    } else if (suggested) {
+      // Soft surface only: honor Hermes's suggested agent, above the classifier
+      // and learned routing. assertTaxonomy below is still the final guard.
+      const learnedAgent = learnedRoutingChoice(surface, classifiedAgent, input.routingScores).agent;
+      choice = {
+        agent: suggested,
+        note: `Hermes suggested ${suggested} for this soft surface.${learnedAgent !== suggested ? ` (classifier/learned leaned ${learnedAgent})` : ""}`,
+      };
+    } else {
+      choice = learnedRoutingChoice(surface, classifiedAgent, input.routingScores);
+    }
+    const agent = choice.agent;
     assertTaxonomy(surface, title, agent);
     if (!policyAllows(input.policy, { repo, agent, accepted: proposals.length, acceptedRepoCounts })) continue;
 
@@ -111,7 +136,7 @@ export function planAndRouteWork(input: PlanAndRouteWorkInput): RoutedProposal[]
       agent,
       riskTier: routing.riskTier,
       why: `Fills uncovered backlog gap: ${title}.`,
-      whyAgent: [routing.reason, learned.note].filter(Boolean).join(" "),
+      whyAgent: [routing.reason, choice.note].filter(Boolean).join(" "),
       dedupeKey: proposalDedupeKey,
     };
     proposals.push(proposal);
@@ -156,13 +181,23 @@ function assertTaxonomy(surface: string, title: string, agent: RoutedWorkAgent):
   }
 }
 
+// The hard-taxonomy WALL — the ONLY surfaces force-routed to an agent and
+// validated by assertTaxonomy (which throws on any violation). These are the
+// dangerous, correctness-critical, hard-to-reverse surfaces that must always be
+// Codex; nothing (classifier, learned routing, or Hermes's suggestion) overrides
+// them. Everything else (UI/docs/tests/residual) defaults to Claude via the
+// classifier but is Hermes-overridable on soft surfaces (agent suggestion).
+//
+// secrets/migrations/deploy are walled explicitly: they were only classifier-
+// defaulted to Codex, and once soft surfaces became Hermes-overridable they'd
+// otherwise be re-routable off Codex, which must never happen.
 function hardTaxonomyAgent(surface: string, title: string): RoutedWorkAgent | undefined {
   const haystack = normalizeText(`${surface} ${title}`);
-  if (matchesAny(haystack, ["chain", "settlement", "escrow", "contract", "contracts", "xcm", "polkadot", "substrate", "treasury"])) {
+  if (matchesAny(haystack, [
+    "chain", "settlement", "escrow", "contract", "contracts", "xcm", "polkadot", "substrate", "treasury",
+    "secret", "secrets", "credential", "credentials", "migration", "migrations", "deploy", "deployment",
+  ])) {
     return "codex";
-  }
-  if (matchesAny(haystack, ["ui", "frontend", "front end", "docs", "documentation", "readme", "copy", "monitor", "drawer", "board"])) {
-    return "claude";
   }
   return undefined;
 }

--- a/test/unit/work-router.test.ts
+++ b/test/unit/work-router.test.ts
@@ -220,6 +220,55 @@ describe("planAndRouteWork", () => {
   });
 });
 
+describe("planAndRouteWork — Hermes soft-surface agent suggestion (B)", () => {
+  // "Soft" = surfaces the hard taxonomy pins to NEITHER agent (not chain/settlement/etc.
+  // → codex, not ui/docs/monitor/board → claude). Hermes may pick the agent only there.
+  it("honors Hermes's suggested agent on a residual soft surface, above classifier/learned routing", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [{ ...item("Add retry-path coverage", "test-coverage", "Cover the EACCES retry"), suggestedAgent: "codex" }],
+    }));
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.agent).toBe("codex"); // classifier defaulted claude; Hermes's suggestion wins on the soft surface
+    expect(proposals[0]!.whyAgent).toContain("Hermes suggested codex");
+    expect(proposals[0]!.whyAgent).toContain("leaned claude"); // transparency: notes the divergence
+  });
+
+  it("lets the hard taxonomy override Hermes's suggestion on a dangerous surface", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [{ ...item("Escrow settlement proof", "chain/settlement", "Verify invariants"), suggestedAgent: "claude" }],
+    }));
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.agent).toBe("codex"); // hard taxonomy forces codex despite the claude suggestion
+    expect(proposals[0]!.whyAgent).not.toContain("Hermes suggested"); // suggestion ignored on the hard surface
+  });
+
+  it("now lets Hermes override the agent on ui/docs (a soft default, no longer a hard pin)", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [{ ...item("Restructure the drawer internals", "ui", "Refactor drawer internals"), suggestedAgent: "codex" }],
+    }));
+    expect(proposals[0]!.agent).toBe("codex"); // ui defaults to claude but Hermes's suggestion wins
+    expect(proposals[0]!.whyAgent).toContain("Hermes suggested codex");
+  });
+
+  it("keeps dangerous surfaces (deploy/secrets/migrations) walled to Codex despite a claude suggestion", () => {
+    for (const surface of ["deploy verification", "secret rotation", "db migration"]) {
+      const proposals = planAndRouteWork(input({
+        backlog: [{ ...item(`Handle ${surface}`, surface, "do it"), suggestedAgent: "claude" }],
+      }));
+      expect(proposals[0]!.agent).toBe("codex");
+      expect(proposals[0]!.whyAgent).not.toContain("Hermes suggested");
+    }
+  });
+
+  it("falls back to classifier/learned routing when no agent is suggested (soft surface)", () => {
+    const proposals = planAndRouteWork(input({
+      backlog: [item("Add retry-path coverage", "test-coverage", "Cover the EACCES retry")],
+    }));
+    expect(proposals[0]!.agent).toBe("claude");
+    expect(proposals[0]!.whyAgent).not.toContain("Hermes suggested");
+  });
+});
+
 function input(overrides: Partial<PlanAndRouteWorkInput> = {}): PlanAndRouteWorkInput {
   return {
     backlog: [],


### PR DESCRIPTION
## What & why

PR **2 of 2** of Tier-1 #2 (active agentic dispatch), the routing-core half. This is the concrete realization of the plan's **Rung-C planner**: Hermes doesn't just surface *what* to work on, it can now suggest *which agent* handles it — but only where that's safe.

The operator asked for "more freedom" for Hermes (**Full-B**): soften the UI/docs `claude` pin to an overridable default so Hermes can route UI/docs/tests to **either** agent, while the Codex/dangerous pin stays a **hard wall**.

The producer that actually emits `suggestedAgent` (`collectAgenticBacklog`) lands in the sibling PR (#470). This PR is the deterministic router change that **honors** the suggestion, so all guardrails live in reviewable core routing code — not in an LLM prompt.

## Changes to `planAndRouteWork`

- **New optional `WorkRouterBacklogItem.suggestedAgent`.** Honored above the classifier and learned routing **only on soft surfaces**. `whyAgent` records that Hermes suggested it and notes any divergence from what the classifier/learned routing leaned (transparency — no truth-boundary inflation).
- **`hardTaxonomyAgent` no longer pins ui/docs/monitor/board to Claude.** Those become soft defaults (Claude via the classifier) that Hermes may override to either agent.
- **The Codex wall is unchanged in force and EXPANDED in scope:** `secret(s)`, `credential(s)`, `migration(s)`, `deploy(ment)` join `chain/settlement/escrow/contract(s)/xcm/polkadot/substrate/treasury`. These were previously only classifier-*defaulted* to Codex; once soft surfaces became overridable they had to be walled **explicitly** so Hermes can never route them off Codex.

## Safety wall — untouched

- `assertTaxonomy` still **THROWS** `routing_taxonomy_violation` if anything routes a walled surface off Codex. It runs after the routing decision, so the suggestion path cannot bypass it.
- Dispatch policy (allowlist + budget, **fail-closed**) unchanged.
- Hermes **proposes**; it does not dispatch. The operator approves every task. No auto-merge, no auto-deploy.

## Tests

5 new cases in `test/unit/work-router.test.ts`:
1. honors a suggestion on a residual soft surface, above classifier/learned (with divergence note),
2. **ui/docs now overridable** (Hermes → codex is honored),
3. **dangerous deploy/secrets/migrations stay walled** to Codex despite a contrary `claude` suggestion,
4. hard chain surface overrides the suggestion,
5. no-suggestion fallback to classifier/learned.

`npx tsc -b packages/averray-mcp` clean; **15 work-router + 8 router-routine tests green**.

## Not in scope / follow-ups

- Producer wiring (`collectAgenticBacklog` emitting `suggestedAgent`) → PR #470.
- Operator, to activate after both merge + deploy: enable the router + `HERMES_ROUTER_AGENTIC_BACKLOG=1` + opt repos into `dispatch.allowed_repos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)