### PR TITLE
Agentic router narration: narrate router proposals in Hermes's own voice, grounded in the proposal (#5)

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -264,6 +264,12 @@ services:
       # failure. One session turn per router tick.
       HERMES_ROUTER_AGENTIC_BACKLOG: ${HERMES_ROUTER_AGENTIC_BACKLOG:-0}
       HERMES_ROUTER_AGENTIC_MAX_ITEMS: ${HERMES_ROUTER_AGENTIC_MAX_ITEMS:-3}
+      # Feature #5 — agentic router narration. When ON (needs the gateway session),
+      # each router proposal is narrated by the real agentic Hermes (its own board
+      # context), grounded ONLY in the proposal fields. Tagged "live" on success;
+      # OFF by default and degraded-safe: falls back to the persona completion, then
+      # the canned template (tagged "templated"). One session turn per proposal.
+      HERMES_ROUTER_AGENTIC_NARRATION: ${HERMES_ROUTER_AGENTIC_NARRATION:-0}
       LLM_USAGE_LOG_PATH: ${LLM_USAGE_LOG_PATH:-/data/llm-usage.jsonl}
       HERMES_MONITOR_MEMORY_PATH: ${HERMES_MONITOR_MEMORY_PATH:-/data/hermes-monitor-memory.json}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -142,8 +142,10 @@ import {
   runHermesRouterOnce,
   type HermesRouterAuditRecord,
 } from "./hermes-router-routine.js";
+import { narrateRouterProposal } from "./monitor-router-narration.js";
+import { chatWithHermesSession } from "./hermes-session-client.js";
 import { collectAgenticBacklog } from "./agentic-backlog.js";
-import type { WorkRouterBacklogItem } from "@avg/averray-mcp/work-router";
+import type { RoutedProposal, WorkRouterBacklogItem } from "@avg/averray-mcp/work-router";
 import {
   approveCodexTask,
   annotateCodexTaskDecisionRecord,
@@ -3973,67 +3975,53 @@ function classifyTaskForWorkRouter(input: Parameters<typeof classifyTask>[0]) {
 }
 
 async function narrateHermesRouterProposal(
-  proposal: Parameters<typeof fallbackHermesRouterNarration>[0],
-  task: Parameters<typeof fallbackHermesRouterNarration>[1],
+  proposal: RoutedProposal,
+  task: CodexTask,
 ): Promise<void> {
-  const fallback = fallbackHermesRouterNarration(proposal, task);
-  let text = fallback;
-  let hermesMode: "live" | "templated" = "templated";
   const apiKey = optionalEnv("OLLAMA_API_KEY");
   const baseUrl = optionalEnv("OLLAMA_BASE_URL") ?? "https://ollama.com/v1";
   const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "glm-5.2:cloud";
-  if (apiKey) {
-    const llmText = await requestHermesCompletion({
-      messages: [
-        { role: "system", content: HERMES_PERSONA },
-        { role: "user", content: buildHermesRouterNarrationPrompt(proposal, task) },
-      ],
-      maxTokens: 90,
-      temperature: 0.45,
-    }, {
-      apiKey,
-      baseUrl,
-      model,
-      timeoutMs: 6_000,
-      taskId: task.id,
-      runId: "correlationId" in task && typeof task.correlationId === "string" ? task.correlationId : routerCorrelationId(proposal),
-    }).catch((error) => {
-      logger.warn({ err: error, taskId: task.id }, "orch_p4b_router_narration_llm_failed");
-      return null;
-    });
-    if (llmText) {
-      text = llmText;
-      hermesMode = "live";
-    }
-  }
+  // FLAG-GATED (default OFF): only route through the real agentic Hermes when
+  // HERMES_ROUTER_AGENTIC_NARRATION is truthy AND a gateway config resolves.
+  const agenticEnabled = /^(1|true|yes|on)$/i.test((optionalEnv("HERMES_ROUTER_AGENTIC_NARRATION") ?? "").trim());
+  const sessionConfig = agenticEnabled ? resolveHermesSessionConfig() : null;
+  const runId = task.correlationId ?? routerCorrelationId(proposal);
 
-  recordCollaborationMessage({
-    author: "hermes",
-    kind: "proposal",
-    addressedTo: "operator",
-    text: text.replace(/\s+/g, " ").trim().slice(0, 1000),
-    hermesMode,
-    relatedCorrelationId: "correlationId" in task && typeof task.correlationId === "string" ? task.correlationId : routerCorrelationId(proposal),
+  await narrateRouterProposal(proposal, task, {
+    fallback: fallbackHermesRouterNarration,
+    sessionConfig,
+    agenticEnabled,
+    // Transport 1: the real agentic Hermes agent (MCP tools/skills/memory).
+    // Degraded-safe: chatWithHermesSession returns null on any failure.
+    runSession: (config, prompt) => chatWithHermesSession(config, prompt),
+    // Transport 2: the stateless Ollama persona completion (existing path).
+    runCompletion: apiKey
+      ? (prompt) =>
+          requestHermesCompletion(
+            {
+              messages: [
+                { role: "system", content: HERMES_PERSONA },
+                { role: "user", content: prompt },
+              ],
+              maxTokens: 90,
+              temperature: 0.45,
+            },
+            { apiKey, baseUrl, model, timeoutMs: 6_000, taskId: task.id, runId },
+          ).catch((error) => {
+            logger.warn({ err: error, taskId: task.id }, "orch_p4b_router_narration_llm_failed");
+            return null;
+          })
+      : undefined,
+    record: ({ text, hermesMode, relatedCorrelationId }) =>
+      recordCollaborationMessage({
+        author: "hermes",
+        kind: "proposal",
+        addressedTo: "operator",
+        text,
+        hermesMode,
+        relatedCorrelationId,
+      }),
   });
-}
-
-function buildHermesRouterNarrationPrompt(
-  proposal: Parameters<typeof fallbackHermesRouterNarration>[0],
-  task: Parameters<typeof fallbackHermesRouterNarration>[1],
-): string {
-  return [
-    "Hermes just created a proposed task from the roadmap backlog. Write one concise, truthful sentence for the monitor co-pilot rail.",
-    "",
-    `Task id: ${task.id}`,
-    `Repo: ${proposal.repo}`,
-    `Surface/gap: ${proposal.surface}`,
-    `Agent: ${proposal.agent}`,
-    `Risk tier: ${proposal.riskTier}`,
-    `Why gap: ${proposal.why}`,
-    `Why agent: ${proposal.whyAgent}`,
-    "",
-    "Rules: say this is proposed-only and waiting for operator approval. Do not claim it ran, was approved, merged, or dispatched.",
-  ].join("\n");
 }
 
 async function recordHermesRouterAudit(record: HermesRouterAuditRecord): Promise<void> {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -10,7 +10,12 @@ import { getHandoffMonitor, recordHandoffEvent } from "@avg/averray-mcp/handoff-
 import { getHermesBacklogPlan } from "@avg/averray-mcp/hermes-backlog";
 import { classifyTask } from "@avg/averray-mcp/dispatch-routing";
 import { buildAgentScorecard, routingScoresFromScorecard } from "@avg/averray-mcp/agent-scorecard";
-import { readLlmUsageEvents } from "@avg/averray-mcp/llm-usage";
+import {
+  beginLlmUsageCall,
+  llmUsageLogPath,
+  readLlmUsageEvents,
+  recordLlmUsageFromResult,
+} from "@avg/averray-mcp/llm-usage";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
 import {
   formatOperatorResultForSlack,
@@ -3992,8 +3997,35 @@ async function narrateHermesRouterProposal(
     sessionConfig,
     agenticEnabled,
     // Transport 1: the real agentic Hermes agent (MCP tools/skills/memory).
-    // Degraded-safe: chatWithHermesSession returns null on any failure.
-    runSession: (config, prompt) => chatWithHermesSession(config, prompt),
+    // Degraded-safe: chatWithHermesSession returns null on any failure. The call
+    // is bracketed with beginLlmUsageCall so the monitor shows Hermes "thinking"
+    // for the (slow) agent turn, mirroring the co-pilot session reply.
+    runSession: async (config, prompt) => {
+      const endLlmUsageCall = beginLlmUsageCall({ agent: "hermes", model, taskId: task.id, runId });
+      try {
+        return await chatWithHermesSession(config, prompt);
+      } finally {
+        endLlmUsageCall();
+      }
+    },
+    // Record the agent turn's token usage so the monitor usage panel counts the
+    // tokens this narration actually spent. The completion path records via
+    // requestHermesCompletion; without this the panel under-reports Hermes once
+    // agentic narration flows. Fired only when the session produced usable text.
+    onSessionTurn: (turn) => {
+      if (!turn.usage) return;
+      const usageModel = turn.model ?? model;
+      void recordLlmUsageFromResult(
+        {
+          agent: "hermes",
+          model: usageModel,
+          taskId: task.id,
+          runId,
+          result: { usage: turn.usage, ...(turn.model ? { model: turn.model } : {}) },
+        },
+        { path: llmUsageLogPath() },
+      ).catch((error) => logger.warn({ err: error, taskId: task.id }, "orch_p4b_router_narration_usage_record_failed"));
+    },
     // Transport 2: the stateless Ollama persona completion (existing path).
     runCompletion: apiKey
       ? (prompt) =>

--- a/services/slack-operator/src/monitor-router-narration.ts
+++ b/services/slack-operator/src/monitor-router-narration.ts
@@ -1,0 +1,190 @@
+/**
+ * Hermes narration for router proposals (ORCH-P4b, feature #5).
+ *
+ * When the Hermes router turns a backlog gap into a *proposed* task it narrates
+ * the proposal for the monitor co-pilot rail. This module owns that narration so
+ * it can be unit-tested in isolation (index.ts wires the real dependencies).
+ *
+ * Three transports, tried in order — every step is DEGRADED-SAFE, falling back
+ * to the next on any failure so the rail never breaks:
+ *   1. Agentic session (flag `HERMES_ROUTER_AGENTIC_NARRATION` + a resolved
+ *      gateway config): the real Hermes agent (MCP tools/skills/memory) narrates
+ *      the WHY in its own board-aware voice. Tagged `hermesMode: "live"`.
+ *   2. Ollama persona completion (existing behaviour): a stateless persona-only
+ *      completion. Also tagged `"live"` — it is a real model turn.
+ *   3. Canned template (`fallbackHermesRouterNarration`): tagged `"templated"`.
+ *
+ * TRUTH-BOUNDARY (the whole point of this feature):
+ *   - The narration is grounded ONLY in the fields that actually exist on the
+ *     `RoutedProposal` (repo, surface, agent, riskTier, why, whyAgent, taskPrompt).
+ *     `boardSignal` is folded into the backlog item's description upstream and is
+ *     NOT preserved on the proposal, so we never claim one. The prompt builders
+ *     emit a line for a field only when that field is non-empty on the proposal,
+ *     and the guardrails forbid inventing signals/urgency/rationale not present.
+ *   - `hermesMode` is tagged `"live"` ONLY when a real model transport produced
+ *     the text (session or completion). A template fallback stays `"templated"`.
+ *     The UI honesty badge reads this, so the mapping must never mark templated
+ *     output as live.
+ */
+
+import type { RoutedProposal } from "@avg/averray-mcp/work-router";
+import type { HermesReplyMode } from "./monitor-collab.js";
+import type { HermesSessionConfig, HermesSessionTurn } from "./hermes-session-client.js";
+
+/** Only the task fields the narration needs (id + optional correlation id). */
+export interface RouterNarrationTask {
+  id: string;
+  correlationId?: string;
+}
+
+export interface RouterNarrationResult {
+  text: string;
+  hermesMode: HermesReplyMode;
+}
+
+/**
+ * Injected transports/recorder so the orchestrator is testable without touching
+ * the network or the collaboration store. index.ts supplies the real impls.
+ */
+export interface RouterNarrationDeps {
+  /** Canned, always-available template (the final fallback). */
+  fallback: (proposal: RoutedProposal, task: RouterNarrationTask) => string;
+  /** Resolved gateway config, or null when the session transport is unavailable. */
+  sessionConfig: HermesSessionConfig | null;
+  /** True when `HERMES_ROUTER_AGENTIC_NARRATION` is truthy. */
+  agenticEnabled: boolean;
+  /** Runs one agentic session turn; returns null on any failure (degraded-safe). */
+  runSession?: (config: HermesSessionConfig, prompt: string) => Promise<HermesSessionTurn | null>;
+  /** Runs the Ollama persona completion; returns null on any failure. */
+  runCompletion?: (prompt: string) => Promise<string | null>;
+  /** Records the finished narration onto the collaboration thread. */
+  record: (result: RouterNarrationResult & { relatedCorrelationId: string }) => void;
+}
+
+/** Stable correlation id for the proposal's narration (mirrors the routine). */
+export function routerNarrationCorrelationId(
+  proposal: Pick<RoutedProposal, "dedupeKey">,
+  task: RouterNarrationTask,
+): string {
+  return task.correlationId ?? `hermes-router:${proposal.dedupeKey}`;
+}
+
+/**
+ * The grounded facts we are willing to put in a prompt, derived ONLY from the
+ * proposal. A field is present in the returned lines iff it is non-empty on the
+ * proposal — so a proposal without a given signal never surfaces one. This is
+ * the single choke point the no-fabrication guard (and its test) relies on.
+ */
+export function routerProposalFactLines(
+  proposal: RoutedProposal,
+  task: RouterNarrationTask,
+): string[] {
+  const lines: string[] = [];
+  const push = (label: string, value: string | undefined) => {
+    const trimmed = (value ?? "").trim();
+    if (trimmed) lines.push(`${label}: ${trimmed}`);
+  };
+  push("Task id", task.id);
+  push("Repo", proposal.repo);
+  push("Surface/gap", proposal.surface);
+  push("Agent", proposal.agent);
+  push("Risk tier", proposal.riskTier);
+  push("Why this gap (stated rationale)", proposal.why);
+  push("Why this agent (routing rationale)", proposal.whyAgent);
+  return lines;
+}
+
+const TRUTH_RULES = [
+  "Rules (follow exactly):",
+  "- Describe ONLY the proposal facts listed above. Do not add any signal, urgency, deadline, board card, failure, metric, PR number, or rationale that is not in that list.",
+  "- If a fact is not listed, it is unknown — do not guess or imply it. Never invent a board signal or a reason the work matters.",
+  "- This task is PROPOSED ONLY and waiting for operator approval. Do not say it ran, was approved, merged, dispatched, or that anyone acted.",
+  "- Reply with exactly one concise, truthful sentence for the monitor co-pilot rail. No preamble, no list, no trailing notes.",
+];
+
+/**
+ * Prompt for the stateless persona completion (transport 2). Threads the real
+ * proposal facts + the truth guardrails.
+ */
+export function buildHermesRouterNarrationPrompt(
+  proposal: RoutedProposal,
+  task: RouterNarrationTask,
+): string {
+  return [
+    "Hermes just created a proposed task from the roadmap backlog. Write one concise, truthful sentence for the monitor co-pilot rail.",
+    "",
+    ...routerProposalFactLines(proposal, task),
+    "",
+    ...TRUTH_RULES,
+  ].join("\n");
+}
+
+/**
+ * Prompt for the agentic session turn (transport 1). Same grounded facts, but
+ * framed for the real Hermes agent so it narrates the actual WHY in its own
+ * board/context-aware voice — WITHOUT loosening the truth guardrails. The agent
+ * may draw on its own memory of prior room decisions, but the proposal facts
+ * here are the only claims it may assert about *this* proposal.
+ */
+export function buildHermesRouterAgenticNarrationPrompt(
+  proposal: RoutedProposal,
+  task: RouterNarrationTask,
+): string {
+  return [
+    "You are narrating a router proposal for the monitor co-pilot rail. The Hermes router just turned a backlog gap into a PROPOSED task (not approved, not running).",
+    "Speak in your own agentic voice and surface the WHY, but stay strictly grounded in these proposal facts:",
+    "",
+    ...routerProposalFactLines(proposal, task),
+    "",
+    ...TRUTH_RULES,
+    "- You may reflect your own board/context awareness in tone, but every concrete claim about THIS proposal must come from the facts above.",
+  ].join("\n");
+}
+
+/**
+ * Produce the narration for a router proposal and record it. Tries the agentic
+ * session (when enabled + configured), then the Ollama completion, then the
+ * canned template. `hermesMode` is "live" only when a real model transport
+ * produced the text.
+ *
+ * Returns the recorded result so callers/tests can assert the text + mode.
+ */
+export async function narrateRouterProposal(
+  proposal: RoutedProposal,
+  task: RouterNarrationTask,
+  deps: RouterNarrationDeps,
+): Promise<RouterNarrationResult> {
+  let text = deps.fallback(proposal, task);
+  let hermesMode: HermesReplyMode = "templated";
+
+  // Transport 1: the real agentic Hermes. Only runs when the flag is on AND a
+  // gateway config resolved. Any failure returns null -> fall through.
+  if (deps.agenticEnabled && deps.sessionConfig && deps.runSession) {
+    const turn = await deps
+      .runSession(deps.sessionConfig, buildHermesRouterAgenticNarrationPrompt(proposal, task))
+      .catch(() => null);
+    if (turn?.text?.trim()) {
+      text = turn.text;
+      hermesMode = "live";
+    }
+  }
+
+  // Transport 2: the stateless Ollama persona completion. Runs when the agentic
+  // path did not produce text (disabled, unconfigured, or failed).
+  if (hermesMode === "templated" && deps.runCompletion) {
+    const completion = await deps
+      .runCompletion(buildHermesRouterNarrationPrompt(proposal, task))
+      .catch(() => null);
+    if (completion?.trim()) {
+      text = completion;
+      hermesMode = "live";
+    }
+  }
+
+  const result: RouterNarrationResult = {
+    text: text.replace(/\s+/g, " ").trim().slice(0, 1000),
+    hermesMode,
+  };
+  deps.record({ ...result, relatedCorrelationId: routerNarrationCorrelationId(proposal, task) });
+  return result;
+}

--- a/services/slack-operator/src/monitor-router-narration.ts
+++ b/services/slack-operator/src/monitor-router-narration.ts
@@ -57,6 +57,14 @@ export interface RouterNarrationDeps {
   runSession?: (config: HermesSessionConfig, prompt: string) => Promise<HermesSessionTurn | null>;
   /** Runs the Ollama persona completion; returns null on any failure. */
   runCompletion?: (prompt: string) => Promise<string | null>;
+  /**
+   * Side effect fired ONLY when the agentic session produced usable narration
+   * text. index.ts uses it to record the agent turn's token usage on the monitor
+   * usage panel (the completion path records usage inside `runCompletion`; the
+   * template path spends no tokens). Kept as an injected side effect so this
+   * module stays a pure text+mode producer with no usage/IO logic of its own.
+   */
+  onSessionTurn?: (turn: HermesSessionTurn) => void;
   /** Records the finished narration onto the collaboration thread. */
   record: (result: RouterNarrationResult & { relatedCorrelationId: string }) => void;
 }
@@ -166,6 +174,8 @@ export async function narrateRouterProposal(
     if (turn?.text?.trim()) {
       text = turn.text;
       hermesMode = "live";
+      // Attribute the agent turn's token usage (side effect owned by index.ts).
+      deps.onSessionTurn?.(turn);
     }
   }
 

--- a/test/unit/monitor-router-narration.test.ts
+++ b/test/unit/monitor-router-narration.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { RoutedProposal } from "@avg/averray-mcp/work-router";
+import type { HermesSessionConfig, HermesSessionTurn } from "../../services/slack-operator/src/hermes-session-client.js";
+import {
+  buildHermesRouterAgenticNarrationPrompt,
+  buildHermesRouterNarrationPrompt,
+  narrateRouterProposal,
+  routerNarrationCorrelationId,
+  routerProposalFactLines,
+  type RouterNarrationDeps,
+  type RouterNarrationResult,
+  type RouterNarrationTask,
+} from "../../services/slack-operator/src/monitor-router-narration.js";
+
+const PROPOSAL: RoutedProposal = {
+  taskPrompt: "Add the missing monitor follow-up card renderer.",
+  repo: "depre-dev/averray-reference-agent",
+  surface: "monitor board",
+  agent: "claude",
+  riskTier: "low",
+  why: "Fills uncovered backlog gap: monitor board.",
+  whyAgent: "UI/documentation-shaped work routes to Claude.",
+  dedupeKey: "depre-dev/averray-reference-agent|monitor-board|monitor-board",
+};
+
+const TASK: RouterNarrationTask = { id: "task-42", correlationId: "corr-42" };
+
+const SESSION_CONFIG: HermesSessionConfig = { baseUrl: "http://gw:8642", apiToken: "tok" };
+
+function fallback(proposal: RoutedProposal, task: RouterNarrationTask): string {
+  return `TEMPLATE: routed ${proposal.surface} to ${proposal.agent} as proposed task ${task.id}.`;
+}
+
+/** A recorder that captures the single recorded narration. */
+function recorder() {
+  const calls: Array<RouterNarrationResult & { relatedCorrelationId: string }> = [];
+  return {
+    record: (r: RouterNarrationResult & { relatedCorrelationId: string }) => {
+      calls.push(r);
+    },
+    calls,
+  };
+}
+
+function deps(overrides: Partial<RouterNarrationDeps> = {}): RouterNarrationDeps & { calls: ReturnType<typeof recorder>["calls"] } {
+  const rec = recorder();
+  return {
+    fallback,
+    sessionConfig: null,
+    agenticEnabled: false,
+    record: rec.record,
+    calls: rec.calls,
+    ...overrides,
+  };
+}
+
+function turn(text: string): HermesSessionTurn {
+  return { sessionId: "s1", text };
+}
+
+describe("routerProposalFactLines — truth boundary (no fabrication)", () => {
+  it("emits a line only for fields that are actually present on the proposal", () => {
+    const lines = routerProposalFactLines(PROPOSAL, TASK);
+    expect(lines).toContain("Repo: depre-dev/averray-reference-agent");
+    expect(lines).toContain("Surface/gap: monitor board");
+    expect(lines).toContain("Agent: claude");
+    expect(lines).toContain("Risk tier: low");
+    expect(lines.some((l) => l.startsWith("Why this gap"))).toBe(true);
+    expect(lines.some((l) => l.startsWith("Why this agent"))).toBe(true);
+  });
+
+  it("never invents a board signal / rationale the proposal does not carry", () => {
+    // A RoutedProposal has no boardSignal field, and whyAgent may be empty for a
+    // deterministic route. The builder must stay silent about absent fields.
+    const sparse: RoutedProposal = {
+      ...PROPOSAL,
+      whyAgent: "",
+      why: "",
+    };
+    const lines = routerProposalFactLines(sparse, TASK);
+    const joined = lines.join("\n").toLowerCase();
+    expect(joined).not.toContain("board signal");
+    expect(joined).not.toContain("boardsignal");
+    expect(lines.some((l) => l.startsWith("Why this gap"))).toBe(false);
+    expect(lines.some((l) => l.startsWith("Why this agent"))).toBe(false);
+    // Only the present facts remain.
+    expect(lines).toEqual([
+      "Task id: task-42",
+      "Repo: depre-dev/averray-reference-agent",
+      "Surface/gap: monitor board",
+      "Agent: claude",
+      "Risk tier: low",
+    ]);
+  });
+});
+
+describe("prompt builders thread the real proposal fields + guardrails", () => {
+  it("completion prompt carries every present proposal fact and the no-fabrication rules", () => {
+    const prompt = buildHermesRouterNarrationPrompt(PROPOSAL, TASK);
+    expect(prompt).toContain("depre-dev/averray-reference-agent");
+    expect(prompt).toContain("monitor board");
+    expect(prompt).toContain("claude");
+    expect(prompt).toContain("UI/documentation-shaped work routes to Claude.");
+    // truth guardrails present
+    expect(prompt).toContain("Describe ONLY the proposal facts listed above");
+    expect(prompt).toContain("Never invent a board signal");
+    expect(prompt).toContain("PROPOSED ONLY");
+    expect(prompt).toContain("one concise, truthful sentence");
+  });
+
+  it("agentic prompt threads the same real fields and keeps the guardrails", () => {
+    const prompt = buildHermesRouterAgenticNarrationPrompt(PROPOSAL, TASK);
+    expect(prompt).toContain("depre-dev/averray-reference-agent");
+    expect(prompt).toContain("monitor board");
+    expect(prompt).toContain("Fills uncovered backlog gap: monitor board.");
+    expect(prompt).toContain("UI/documentation-shaped work routes to Claude.");
+    expect(prompt).toContain("your own agentic voice");
+    expect(prompt).toContain("Describe ONLY the proposal facts listed above");
+    expect(prompt).toContain("Never invent a board signal");
+  });
+
+  it("neither prompt mentions a board signal when the proposal has none", () => {
+    for (const prompt of [
+      buildHermesRouterNarrationPrompt(PROPOSAL, TASK),
+      buildHermesRouterAgenticNarrationPrompt(PROPOSAL, TASK),
+    ]) {
+      // The only occurrences of "signal" are in the guardrails forbidding
+      // invention — never a concrete asserted board signal fact line.
+      expect(prompt).not.toMatch(/board signal:/i);
+      expect(prompt).not.toMatch(/boardSignal/);
+    }
+  });
+});
+
+describe("narrateRouterProposal — agentic path", () => {
+  it("uses the agentic session and tags the turn live when the flag is on and it succeeds", async () => {
+    const runSession = vi.fn(async () => turn("Proposing a monitor-board card render for Claude; it waits for your approval."));
+    const runCompletion = vi.fn(async () => "should-not-be-called");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(runSession).toHaveBeenCalledTimes(1);
+    // real proposal fields were threaded into the agentic prompt
+    const [cfgArg, promptArg] = runSession.mock.calls[0]!;
+    expect(cfgArg).toBe(SESSION_CONFIG);
+    expect(promptArg).toContain("depre-dev/averray-reference-agent");
+    expect(promptArg).toContain("monitor board");
+    expect(promptArg).toContain("UI/documentation-shaped work routes to Claude.");
+    // the completion transport is never reached once the session produced text
+    expect(runCompletion).not.toHaveBeenCalled();
+
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toContain("Proposing a monitor-board card render");
+    expect(d.calls).toHaveLength(1);
+    expect(d.calls[0]).toMatchObject({ hermesMode: "live", relatedCorrelationId: "corr-42" });
+  });
+
+  it("does NOT touch the session when the flag is off (default), even if a config exists", async () => {
+    const runSession = vi.fn(async () => turn("live text"));
+    const runCompletion = vi.fn(async () => "Completion narration.");
+    const d = deps({ agenticEnabled: false, sessionConfig: SESSION_CONFIG, runSession, runCompletion });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(runSession).not.toHaveBeenCalled();
+    expect(runCompletion).toHaveBeenCalledTimes(1);
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toBe("Completion narration.");
+  });
+});
+
+describe("narrateRouterProposal — degraded fallback (session -> completion -> template)", () => {
+  it("falls back to the completion when the agentic session returns null", async () => {
+    const runSession = vi.fn(async () => null);
+    const runCompletion = vi.fn(async () => "Ollama persona narration, proposed and waiting.");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(runSession).toHaveBeenCalledTimes(1);
+    expect(runCompletion).toHaveBeenCalledTimes(1);
+    // the completion got the persona-completion prompt (same facts, no throw)
+    expect(runCompletion.mock.calls[0]![0]).toContain("depre-dev/averray-reference-agent");
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toBe("Ollama persona narration, proposed and waiting.");
+  });
+
+  it("falls back to the completion when the agentic session throws", async () => {
+    const runSession = vi.fn(async () => {
+      throw new Error("gateway down");
+    });
+    const runCompletion = vi.fn(async () => "Completion after session throw.");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toBe("Completion after session throw.");
+  });
+
+  it("falls back to the canned TEMPLATE and stays templated when both transports fail", async () => {
+    const runSession = vi.fn(async () => null);
+    const runCompletion = vi.fn(async () => null);
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(result.hermesMode).toBe("templated");
+    expect(result.text).toBe(fallback(PROPOSAL, TASK));
+    expect(d.calls[0]).toMatchObject({ hermesMode: "templated" });
+  });
+
+  it("uses the template (templated) when there is no completion transport either (no OLLAMA key)", async () => {
+    const d = deps({ agenticEnabled: false, sessionConfig: null });
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+    expect(result.hermesMode).toBe("templated");
+    expect(result.text).toBe(fallback(PROPOSAL, TASK));
+  });
+});
+
+describe("narrateRouterProposal — honesty tagging never over-claims", () => {
+  it("an empty/whitespace session reply is treated as no reply (not tagged live off blank text)", async () => {
+    const runSession = vi.fn(async () => turn("   "));
+    const runCompletion = vi.fn(async () => "Completion fills in.");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+    // blank agentic text must not be recorded as live; the completion is used
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toBe("Completion fills in.");
+  });
+
+  it("records under the proposal's correlation id (falling back to the router correlation id)", async () => {
+    const d = deps();
+    await narrateRouterProposal(PROPOSAL, { id: "task-9" }, d);
+    expect(d.calls[0]!.relatedCorrelationId).toBe(routerNarrationCorrelationId(PROPOSAL, { id: "task-9" }));
+    expect(d.calls[0]!.relatedCorrelationId).toBe("hermes-router:depre-dev/averray-reference-agent|monitor-board|monitor-board");
+  });
+});

--- a/test/unit/monitor-router-narration.test.ts
+++ b/test/unit/monitor-router-narration.test.ts
@@ -55,8 +55,16 @@ function deps(overrides: Partial<RouterNarrationDeps> = {}): RouterNarrationDeps
   };
 }
 
-function turn(text: string): HermesSessionTurn {
-  return { sessionId: "s1", text };
+function turn(
+  text: string,
+  extra: { usage?: Record<string, unknown> | null; model?: string | null } = {},
+): HermesSessionTurn {
+  return {
+    sessionId: "s1",
+    text,
+    ...(extra.usage !== undefined ? { usage: extra.usage } : {}),
+    ...(extra.model !== undefined ? { model: extra.model } : {}),
+  };
 }
 
 describe("routerProposalFactLines — truth boundary (no fabrication)", () => {
@@ -237,5 +245,58 @@ describe("narrateRouterProposal — honesty tagging never over-claims", () => {
     await narrateRouterProposal(PROPOSAL, { id: "task-9" }, d);
     expect(d.calls[0]!.relatedCorrelationId).toBe(routerNarrationCorrelationId(PROPOSAL, { id: "task-9" }));
     expect(d.calls[0]!.relatedCorrelationId).toBe("hermes-router:depre-dev/averray-reference-agent|monitor-board|monitor-board");
+  });
+});
+
+describe("narrateRouterProposal — agent-turn usage capture (no under-report)", () => {
+  it("forwards the successful agentic turn to onSessionTurn so index.ts can record its usage", async () => {
+    const onSessionTurn = vi.fn();
+    const produced = turn("Live narration for the rail.", { usage: { input_tokens: 120, output_tokens: 40 }, model: "hermes-4" });
+    const runSession = vi.fn(async () => produced);
+    const runCompletion = vi.fn(async () => "unused");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion, onSessionTurn });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(result.hermesMode).toBe("live");
+    // the whole turn (carrying usage + model) is handed to the recorder side effect
+    expect(onSessionTurn).toHaveBeenCalledTimes(1);
+    expect(onSessionTurn).toHaveBeenCalledWith(produced);
+    expect(onSessionTurn.mock.calls[0]![0]!.usage).toEqual({ input_tokens: 120, output_tokens: 40 });
+  });
+
+  it("does NOT record usage on the completion path (completion records its own; no double-count)", async () => {
+    const onSessionTurn = vi.fn();
+    const runSession = vi.fn(async () => null); // session fails -> completion used
+    const runCompletion = vi.fn(async () => "Completion narration.");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion, onSessionTurn });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toBe("Completion narration.");
+    expect(onSessionTurn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT record usage on the template path (no tokens spent)", async () => {
+    const onSessionTurn = vi.fn();
+    const runSession = vi.fn(async () => null);
+    const runCompletion = vi.fn(async () => null);
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion, onSessionTurn });
+
+    const result = await narrateRouterProposal(PROPOSAL, TASK, d);
+
+    expect(result.hermesMode).toBe("templated");
+    expect(onSessionTurn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onSessionTurn for a blank agentic reply (no usable text, so nothing to attribute here)", async () => {
+    const onSessionTurn = vi.fn();
+    const runSession = vi.fn(async () => turn("   ", { usage: { input_tokens: 5 } }));
+    const runCompletion = vi.fn(async () => "Completion fills in.");
+    const d = deps({ agenticEnabled: true, sessionConfig: SESSION_CONFIG, runSession, runCompletion, onSessionTurn });
+
+    await narrateRouterProposal(PROPOSAL, TASK, d);
+    expect(onSessionTurn).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

Feature **#5 — agentic board narration**: make Hermes narrate each router proposal in its own agentic voice, grounded in the real proposal, surfacing the WHY.

When `HERMES_ROUTER_AGENTIC_NARRATION` is truthy **and** a gateway session config resolves, each Hermes router proposal is narrated by the **real agentic Hermes** (its MCP tools/skills/memory + board awareness) via `chatWithHermesSession`, instead of the persona-only stateless completion. The prompt threads the proposal's **real** `RoutedProposal` fields (repo, surface, agent, riskTier, why, whyAgent) so Hermes narrates the actual WHY.

## Flag-gated + degraded-safe

- New flag `HERMES_ROUTER_AGENTIC_NARRATION` (**default OFF**); added to `slack-operator`'s `environment:` in `ops/compose.yml` as `${HERMES_ROUTER_AGENTIC_NARRATION:-0}`.
- Transport order, falling through on **any** failure: **agentic session → Ollama persona completion → canned template**. With the flag off, behaviour is equivalent to the prior path (completion → template).
- One session turn per proposal; the reply is fire-and-forget so a slow turn never blocks the router tick.

## Truth-boundary (the whole point)

- The narration is grounded **only** in fields that actually exist on the `RoutedProposal`. `boardSignal`/`why` from the agentic backlog are folded into the backlog item's `description` upstream and are **not** preserved on the proposal, so the narration **never claims a board signal**. A single choke point (`routerProposalFactLines`) emits a fact line **only** when the field is non-empty — a proposal lacking a signal never surfaces one — and the prompt guardrails explicitly forbid inventing signals/urgency/deadlines/facts and forbid claiming the task ran/merged/dispatched.
- **Honesty tagging:** `hermesMode` is set to `"live"` **only** when a real model transport (session or completion) produced the text; a template fallback stays `"templated"`. This drives the existing UI live/templated honesty badge (`HermesTurn`), so templated output is never marked live.

## Structure

Extracted the narration into a new testable `services/slack-operator/src/monitor-router-narration.ts` module (mirrors the `monitor-hermes-narration.ts` extraction idiom); `index.ts` wires the real transports/recorder via dependency injection. Kept the one-sentence-for-the-rail contract (≤1000 chars, whitespace-collapsed).

## Tests

`test/unit/monitor-router-narration.test.ts` (13 tests) asserts:
- the agentic path threads the real proposal fields into the prompt and is skipped when the flag is off;
- degraded fallback: session null/throw → completion → template;
- truth-boundary: a proposal with no `boardSignal` never produces one (fact-line builder + both prompts);
- live/templated tagging matches which path produced the text (incl. blank session reply not tagged live).

```
npx tsc -b packages/averray-mcp && npx tsc -b services/slack-operator
npx vitest run test/unit/monitor-router-narration.test.ts
```
→ 13 passed. Related existing suites (hermes-router-routine, monitor-collab, monitor-hermes-narration, hermes-session-voice/client/usage, slack-routines) stay green (109 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)