### PR TITLE
Co-pilot MCP elicitation groundwork (flag off, fail-closed) — #4

### DIFF
--- a/docs/HERMES_COPILOT_ELICITATION.md
+++ b/docs/HERMES_COPILOT_ELICITATION.md
@@ -1,0 +1,185 @@
+# Co-pilot MCP Elicitation — Inline Tool-Call Approvals (feature #4)
+
+- **Status:** **GROUNDWORK / DESIGN.** Not a live approval gate. No tool call is
+  gated by this today. Ships behind `HERMES_COPILOT_ELICITATION` (default OFF),
+  fail-closed, degraded-safe.
+- **Date:** 2026-07-01
+- **Depends on:** #3 (streaming co-pilot session, branch
+  `claude/copilot-sse-streaming`) for the live stream this would read from, and
+  on **new Hermes gateway support that does not exist yet** (see §3).
+
+> ## Repo orientation
+> This doc lives in the implementation repo (`depre-dev/averray-reference-agent`).
+> Every `path:line` citation is local to this repo unless prefixed `[gateway]`,
+> which marks the external `nousresearch/hermes-agent` image (`gateway run`,
+> `api_server.py`) — code we do **not** own and can only reach over HTTP.
+
+---
+
+## 1. Goal
+
+When the agentic Hermes co-pilot — reached over the gateway **Session API**
+(`services/slack-operator/src/hermes-session-client.ts`) — hits a tool call that
+needs human confirmation, surface an **inline approve/deny** in the co-pilot
+rail (`packages/monitor-ui/src/components/hermes/CoPilotRail.tsx`) instead of
+failing the turn or silently proceeding. This is a **security-sensitive approval
+surface**: it decides whether a tool the agent proposes actually runs.
+
+---
+
+## 2. Why this is groundwork, not a live feature (truth boundary)
+
+**The Hermes gateway does not expose MCP elicitation.** Confirmed from the
+Session API client, which is the only programmatic channel we have to the agent:
+
+- The Session API surface is **create / chat / fork** only —
+  `hermes-session-client.ts:11-15`:
+  - `POST /api/sessions` → `{ session: { id } }`
+  - `POST /api/sessions/{id}/chat` `{ input }` → `{ message: { content }, usage }`
+  - `POST /api/sessions/{id}/fork` → `{ session: { id } }`
+- The **only** documented stream events are `assistant.delta` and
+  `run.completed` — `hermes-session-client.ts:21-23`. **Neither is a
+  tool-confirmation / elicitation request.**
+- There is **no endpoint to answer a pending tool call** — nothing like
+  `POST /api/sessions/{id}/elicitations/{eid}`.
+- The gateway image today (`ops/compose.command-center.yml`, `${HERMES_IMAGE}`)
+  is documented as **unverified for the Session API at all** — the pinned image
+  is v0.14 and the Session API is v0.15+ (`docs/HERMES_SESSION_API_SPIKE.md`,
+  "Verify against a running gateway BEFORE trusting it").
+
+The current co-pilot is also **synchronous poll-based chat** with no tool
+channel: `useCollaboration` polls `/monitor/collaboration`
+(`packages/monitor-ui/src/hooks/useCollaboration.ts:1-7`) and messages are only
+`chat | proposal | request_help | status`
+(`services/slack-operator/src/monitor-collab.ts:40`).
+
+**Consequence.** A UI that showed an "approve/deny this tool call" affordance
+today would be **theater** — it could not receive a real elicitation request and
+could not deliver a real answer to the agent. Per the truth-boundary rule, we do
+**not** ship that. Instead we ship the types, the fail-closed gate, and a
+dormant no-op handler, and we document the exact gateway support required so the
+real slice is a small, well-scoped follow-up.
+
+---
+
+## 3. Exact gateway support required (does not exist yet)
+
+The real feature becomes buildable when the gateway provides **both**:
+
+1. **An elicitation request in the session stream.** On the SSE stream
+   (`POST /api/sessions/{id}/chat/stream`), a new event emitted when the agent
+   blocks on a tool that needs confirmation, e.g.:
+
+   ```json
+   { "type": "tool.confirmation",
+     "id": "elc_abc",
+     "session_id": "sess_1",
+     "tool_name": "averray_submit",
+     "summary": "Submit the proposal to the marketplace",
+     "arguments": { "jobId": "j1" },
+     "expires_at_ms": 1751500000000 }
+   ```
+
+   (Our parser already accepts this shape and an `elicitation.request` alias —
+   `packages/averray-mcp/src/copilot-elicitation.ts`, `parseElicitationRequest`.)
+
+2. **An answer endpoint** to resolve that request, e.g.:
+
+   ```
+   POST /api/sessions/{id}/elicitations/{elicitationId}
+   { "decision": "approve" | "deny", "reason"?: "…" }
+   ```
+
+   returning a confirmation the agent received the answer. Approve **must**
+   require a delivered, acknowledged response — the client treats an
+   unacknowledged delivery as failure and denies (see §4).
+
+Until **both** exist, `GATEWAY_ELICITATION_SUPPORTED` stays `false`
+(`copilot-elicitation.ts`) and the handler falls closed.
+
+---
+
+## 4. Fail-closed semantics (the security contract)
+
+A proposed tool call is allowed to proceed (**approve**) **only** when **all** of:
+
+1. `HERMES_COPILOT_ELICITATION` is explicitly on (`1`/`true`), **and**
+2. the gateway actually supports elicitation (§3), **and**
+3. an operator **explicitly** clicked approve in the rail, **and**
+4. that approval was **delivered and acknowledged** by the gateway.
+
+**Every other path denies.** Encoded as a pure truth table in
+`resolveElicitationOutcome` (`copilot-elicitation.ts`) and exhaustively tested
+(`test/unit/copilot-elicitation.test.ts`):
+
+| Condition | Outcome | `reason` |
+| --- | --- | --- |
+| Flag off (default) | **DENY** (ungated) | `feature-disabled` |
+| Flag on, gateway unsupported (today) | **DENY** (ungated) | `no-gateway-support` |
+| No/malformed elicitation frame | **DENY** (ungated) | `no-request` |
+| Operator silent / window elapsed | **DENY** (ungated) | `no-operator-response` / `timeout` |
+| Approve but undeliverable to gateway | **DENY** (ungated) | `delivery-unreachable` |
+| Operator denies | **DENY** (gated) | `operator-denied` |
+| Enabled + supported + approve + delivered | **APPROVE** (gated) | `operator-approved` |
+
+Key invariants (asserted in tests):
+
+- **Silence is DENY.** If the operator does not respond, or the rail/gateway is
+  unreachable, the tool call is denied — never auto-approved.
+- **No auto-approve path.** There is no input combination lacking an *explicit*
+  operator approve that yields approve. A dedicated test sweeps the
+  decision-less / deny / undelivered space and asserts every result is DENY.
+- **Off ⇒ inert.** With the flag off the handler engages neither the operator
+  nor the gateway (proven by call-count assertions).
+
+---
+
+## 5. Intended flow (once §3 lands)
+
+```
+Hermes agent (gateway session)
+   │  emits tool.confirmation on the SSE stream
+   ▼
+slack-operator stream reader  ──parseElicitationRequest()──▶ ElicitationRequest
+   │  records a co-pilot turn of a new kind ("elicitation")
+   ▼
+CoPilotRail  ──▶ renders an inline Approve / Deny affordance (scoped, expiring)
+   │  operator clicks
+   ▼
+slack-operator route (POST answer)  ──deliverDecision()──▶ gateway answer endpoint
+   │  gateway acknowledges
+   ▼
+resolveElicitationOutcome()  ──▶ approve (only here) or fail-closed deny
+```
+
+Concretely, the follow-up PR (blocked on §3 + a real gateway) adds:
+
+1. **Stream reader**: in the streaming session client (#3), detect
+   `tool.confirmation` frames via `parseElicitationRequest`.
+2. **A new collaboration kind** `"elicitation"` in
+   `services/slack-operator/src/monitor-collab.ts` so the pending request renders
+   as a turn without pretending to be ordinary chat.
+3. **An answer route** in `services/slack-operator/src/index.ts` (e.g.
+   `POST /monitor/elicitations/:id`) that calls `deliverDecision` →
+   the gateway answer endpoint, with the operator as `decidedBy` for audit.
+4. **Rail affordance**: an approve/deny control in `CoPilotRail.tsx` /
+   `HermesTurn.tsx`, wired through `handleElicitationRequest`'s `collectDecision`
+   hook, with a visible expiry and a "denies on timeout" note.
+5. **Gate the tool call** on `isToolCallApproved(outcome)`.
+
+None of steps 1–5 ship in this PR.
+
+---
+
+## 6. What ships in this PR (groundwork)
+
+| File | Change |
+| --- | --- |
+| `packages/averray-mcp/src/copilot-elicitation.ts` | **New.** Types (`ElicitationRequest` / `ElicitationDecision` / `ElicitationOutcome`), fail-closed env gate (`resolveCopilotElicitationConfig`), strict frame parser (`parseElicitationRequest`), the pure fail-closed truth table (`resolveElicitationOutcome`), and a degraded-safe no-op handler (`handleElicitationRequest`) that gates nothing and can never auto-approve. No `@avg/*` imports → isolated tests. |
+| `test/unit/copilot-elicitation.test.ts` | **New.** 29 tests: default-OFF, the full fail-closed table, the never-auto-approve sweep, off ⇒ hooks-never-called, the future wired path staying fail-closed, and parser rejection of `assistant.delta` / `run.completed` / malformed frames. |
+| `ops/compose.yml` | `HERMES_COPILOT_ELICITATION` (+ `_TIMEOUT_MS`) passthrough to `slack-operator`, default `0`. |
+| `docs/HERMES_COPILOT_ELICITATION.md` | This doc. |
+
+**Default behavior is byte-identical.** The module is not yet imported by any
+runtime path; it is dormant until the gateway support above lands and the
+follow-up wires it in. No UI claims to gate a tool call it cannot gate.

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -256,6 +256,15 @@ services:
       HERMES_API_URL: ${HERMES_API_URL:-}
       HERMES_API_TOKEN: ${HERMES_API_TOKEN:-}
       HERMES_SESSION_TIMEOUT_MS: ${HERMES_SESSION_TIMEOUT_MS:-}
+      # #4 — co-pilot MCP elicitation (inline tool-call approvals in the rail).
+      # GROUNDWORK ONLY, OFF by default (fail-closed). The Hermes gateway does
+      # not expose MCP elicitation yet (Session API = create/chat/fork; stream =
+      # assistant.delta/run.completed only — no tool-confirmation event, no answer
+      # endpoint), so this gates NOTHING today: with the flag on it still falls
+      # closed to DENY. It is a dormant scaffold until the gateway support in
+      # docs/HERMES_COPILOT_ELICITATION.md lands. NEVER auto-approves a tool call.
+      HERMES_COPILOT_ELICITATION: ${HERMES_COPILOT_ELICITATION:-0}
+      HERMES_COPILOT_ELICITATION_TIMEOUT_MS: ${HERMES_COPILOT_ELICITATION_TIMEOUT_MS:-}
       # ORCH-P4c — agentic router backlog. When ON (needs the gateway session AND
       # a non-empty dispatch.allowed_repos), Hermes reasons over the live board to
       # propose board-grounded work gaps, augmenting the deterministic roadmap

--- a/packages/averray-mcp/src/copilot-elicitation.ts
+++ b/packages/averray-mcp/src/copilot-elicitation.ts
@@ -1,0 +1,334 @@
+/**
+ * Co-pilot MCP elicitation — GROUNDWORK (feature #4), NOT a live approval gate.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * TRUTH BOUNDARY — READ THIS FIRST
+ * ────────────────────────────────────────────────────────────────────────────
+ * The intended feature is: when the agentic Hermes co-pilot (reached over the
+ * gateway Session API — see `services/slack-operator/src/hermes-session-client.ts`)
+ * hits a tool call that needs human confirmation, surface an inline approve/deny
+ * in the co-pilot rail instead of failing or silently proceeding.
+ *
+ * That feature is NOT possible yet, because the Hermes gateway does not expose
+ * MCP elicitation. The confirmed Session API surface is create / chat / fork
+ * (`hermes-session-client.ts:11-15`), and the only documented stream events are
+ * `assistant.delta` and `run.completed` (`hermes-session-client.ts:21-23`).
+ * There is:
+ *   - NO stream event that says "the agent is waiting for you to approve a tool
+ *     call" (an elicitation / tool-confirmation request), and
+ *   - NO endpoint to send an approve/deny answer back to a pending tool call.
+ * See `docs/HERMES_COPILOT_ELICITATION.md` for the exact gateway support required.
+ *
+ * So this module ships as GROUNDWORK behind an OFF-by-default flag:
+ *   - the request/decision TYPES the real feature will use,
+ *   - a FAIL-CLOSED env gate, and
+ *   - a DEGRADED-SAFE, NO-OP handler that gates nothing today and — crucially —
+ *     can NEVER autonomously approve a tool call.
+ *
+ * It does NOT fake a gate. With the flag off (default) it does nothing. Even
+ * with the flag on, because there is no gateway answer channel and no live
+ * elicitation stream, every path resolves to DENY. A tool call is only ever
+ * "approved" when a real operator explicitly approves AND a real answer channel
+ * confirms the answer was delivered to the gateway — a path that does not exist
+ * until the gateway support in the design doc lands. Until then this stays a
+ * dormant scaffold: no UI claims to gate what it cannot gate.
+ *
+ * This is deliberately a self-contained pure module (no `@avg/*` imports, env
+ * passed in) so its safety properties are exhaustively unit-testable in
+ * isolation — mirroring `hermes-session-client.ts`.
+ */
+
+/** Env flag name. Default OFF. */
+export const COPILOT_ELICITATION_FLAG = "HERMES_COPILOT_ELICITATION";
+
+/**
+ * How an operator (or the absence of one) resolved a pending tool-confirmation.
+ * There is no "auto" / "default-approve" — the only ways a call proceeds are an
+ * explicit operator approval that we could actually deliver.
+ */
+export type ElicitationDecisionKind = "approve" | "deny";
+
+/**
+ * A pending tool-confirmation the agent is (hypothetically) blocked on. Field
+ * names mirror the shape the gateway WOULD have to emit; see the design doc.
+ * Everything the UI needs to render an honest approve/deny prompt.
+ */
+export interface ElicitationRequest {
+  /** Stable id used to correlate the operator's answer back to this request. */
+  id: string;
+  /** The session this elicitation belongs to (Session API session id). */
+  sessionId: string;
+  /** MCP tool the agent wants to call, e.g. `averray_submit`. */
+  toolName: string;
+  /** Human-readable summary of what the tool would do (for the rail prompt). */
+  summary: string;
+  /** Raw proposed arguments, shown to the operator. Never trusted blindly. */
+  arguments?: Record<string, unknown>;
+  /**
+   * Server-side deadline (epoch ms) after which the gateway itself abandons the
+   * call. Advisory: we ALSO fail closed locally on our own timeout regardless.
+   */
+  expiresAtMs?: number;
+}
+
+/** An operator's explicit answer to a specific `ElicitationRequest`. */
+export interface ElicitationDecision {
+  /** Must match `ElicitationRequest.id`. */
+  requestId: string;
+  decision: ElicitationDecisionKind;
+  /** Who answered (audit); operator identity, not the agent. */
+  decidedBy: string;
+  /** Optional operator note recorded with the decision. */
+  reason?: string;
+}
+
+/**
+ * The resolved outcome for a pending tool call. `gated` is whether THIS surface
+ * actually took responsibility for the decision. When `gated` is false, this
+ * module did NOT gate the call — it fell closed to a DENY recommendation and the
+ * caller must treat the tool call as denied/aborted (never "proceed anyway").
+ */
+export interface ElicitationOutcome {
+  /**
+   * True only when this surface actively delivered an operator decision to the
+   * gateway. False for every fail-closed / disabled / no-support path. It is
+   * NEVER true today, because no delivery channel exists.
+   */
+  gated: boolean;
+  /** The effective decision. Fail-closed paths always yield "deny". */
+  decision: ElicitationDecisionKind;
+  /** Machine-readable reason, for logs + the honesty banner in the rail. */
+  reason: ElicitationOutcomeReason;
+}
+
+export type ElicitationOutcomeReason =
+  /** Flag off (default): the surface is dormant. */
+  | "feature-disabled"
+  /** Flag on, but the gateway exposes no elicitation channel yet (today). */
+  | "no-gateway-support"
+  /** The request frame was absent or malformed — nothing to gate. */
+  | "no-request"
+  /** No operator answered within the window → fail closed. */
+  | "no-operator-response"
+  /** We had an operator answer but could not deliver it to the gateway. */
+  | "delivery-unreachable"
+  /** Local hard timeout elapsed → fail closed. */
+  | "timeout"
+  /** Operator explicitly denied. */
+  | "operator-denied"
+  /** Operator explicitly approved AND delivery to the gateway was confirmed. */
+  | "operator-approved";
+
+/** Resolved config for the elicitation surface. */
+export interface CopilotElicitationConfig {
+  /** Master switch. False ⇒ the whole surface is a no-op. */
+  enabled: boolean;
+  /**
+   * Whether the gateway actually exposes an elicitation channel we can answer.
+   * Hardcoded FALSE today: no such stream event or answer endpoint exists. When
+   * the gateway support in the design doc lands, this becomes a real probe.
+   */
+  gatewaySupported: boolean;
+  /** Local fail-closed timeout for an operator answer (ms). */
+  timeoutMs: number;
+}
+
+/**
+ * There is no gateway elicitation support today. This is a single, honest
+ * source of truth the handler and tests key off, rather than sprinkling `false`
+ * around. Flipping this to true is meaningless until the answer endpoint + the
+ * stream event exist AND `deliverDecision` is implemented against them.
+ */
+export const GATEWAY_ELICITATION_SUPPORTED = false;
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+/**
+ * FAIL-CLOSED env gate. Returns `enabled: false` unless the flag is explicitly
+ * "1" / "true". Any other value (unset, "0", "", "off", garbage) ⇒ disabled.
+ * Never throws.
+ */
+export function resolveCopilotElicitationConfig(
+  env: Record<string, string | undefined> = process.env
+): CopilotElicitationConfig {
+  const raw = (env[COPILOT_ELICITATION_FLAG] ?? "").trim().toLowerCase();
+  const enabled = raw === "1" || raw === "true";
+  const timeoutMs = parsePositiveInt(env.HERMES_COPILOT_ELICITATION_TIMEOUT_MS) ?? DEFAULT_TIMEOUT_MS;
+  return {
+    enabled,
+    // Even when the operator opts in, we tell the truth about the gateway.
+    gatewaySupported: GATEWAY_ELICITATION_SUPPORTED,
+    timeoutMs,
+  };
+}
+
+/**
+ * Tolerant parser for an elicitation request frame off the session stream.
+ *
+ * The gateway emits no such frame today, so in practice this returns null for
+ * everything real. It exists so that (a) the type contract is exercised by
+ * tests, and (b) when the gateway support lands, the stream reader has a single,
+ * strict entry point that rejects anything not shaped like a real elicitation
+ * request (fail closed: a malformed frame is NOT a gate-able request).
+ */
+export function parseElicitationRequest(frame: unknown): ElicitationRequest | null {
+  const root = asRecord(frame);
+  if (!root) return null;
+  // Require an explicit elicitation discriminator so we never mistake an
+  // ordinary `assistant.delta` / `run.completed` event for a tool prompt.
+  const type = asText(root.type) ?? asText(root.event);
+  if (type !== "tool.confirmation" && type !== "elicitation.request") return null;
+  const id = asText(root.id) ?? asText(root.request_id) ?? asText(root.requestId);
+  const sessionId = asText(root.session_id) ?? asText(root.sessionId);
+  const toolName = asText(root.tool) ?? asText(root.tool_name) ?? asText(root.toolName);
+  if (!id || !sessionId || !toolName) return null;
+  const summary =
+    asText(root.summary) ?? asText(root.description) ?? `Approve tool call: ${toolName}`;
+  return {
+    id,
+    sessionId,
+    toolName,
+    summary,
+    arguments: asRecord(root.arguments) ?? asRecord(root.args) ?? undefined,
+    expiresAtMs: asPositiveNumber(root.expires_at_ms) ?? asPositiveNumber(root.expiresAtMs),
+  };
+}
+
+/**
+ * The fail-closed decision truth table, as a pure function so every branch is
+ * unit-testable. A tool call proceeds ("approve") ONLY when:
+ *   - the feature is enabled, AND
+ *   - the gateway actually supports elicitation, AND
+ *   - an operator explicitly approved, AND
+ *   - that approval was actually delivered to the gateway (`deliveredOk`).
+ * EVERY other combination — disabled, unsupported, no request, no operator
+ * answer, undelivered, explicit deny — yields "deny". There is deliberately no
+ * code path where the absence of an operator decision yields "approve".
+ */
+export function resolveElicitationOutcome(input: {
+  config: CopilotElicitationConfig;
+  request: ElicitationRequest | null;
+  /** The operator's explicit answer, if one was collected in time. */
+  decision: ElicitationDecision | null;
+  /** Whether an approve answer was confirmed delivered to the gateway. */
+  deliveredOk: boolean;
+  /** True if the local/gateway timeout elapsed before an answer. */
+  timedOut?: boolean;
+}): ElicitationOutcome {
+  const { config, request, decision, deliveredOk, timedOut } = input;
+
+  // 1. Dormant by default.
+  if (!config.enabled) return deny("feature-disabled");
+
+  // 2. Honest about the gateway: with no elicitation channel we cannot gate.
+  //    Fail closed to DENY — we never let the call proceed ungated.
+  if (!config.gatewaySupported) return deny("no-gateway-support");
+
+  // 3. Nothing to gate.
+  if (!request) return deny("no-request");
+
+  // 4. Hard timeout beats any stale answer.
+  if (timedOut) return deny("timeout");
+
+  // 5. No operator answered → fail closed. NEVER auto-approve on silence.
+  if (!decision || decision.requestId !== request.id) return deny("no-operator-response");
+
+  // 6. Explicit deny.
+  if (decision.decision === "deny") {
+    return { gated: true, decision: "deny", reason: "operator-denied" };
+  }
+
+  // 7. Explicit approve, but we must have actually delivered it.
+  if (!deliveredOk) return deny("delivery-unreachable");
+
+  // 8. The only proceed path: enabled + supported + explicit approve + delivered.
+  return { gated: true, decision: "approve", reason: "operator-approved" };
+}
+
+/**
+ * DEGRADED-SAFE no-op handler — the wired entry point behind the OFF flag.
+ *
+ * Today this ALWAYS resolves to a fail-closed DENY (never gates, never
+ * approves): with the flag off it short-circuits on "feature-disabled", and
+ * even when enabled it short-circuits on "no-gateway-support" because
+ * `GATEWAY_ELICITATION_SUPPORTED` is false. The `collectDecision` /
+ * `deliverDecision` seams are where the real implementation will plug in once
+ * the gateway exposes the elicitation stream + answer endpoint (see the design
+ * doc). They are intentionally NOT called while unsupported, so there is no way
+ * for this to accidentally proceed.
+ */
+export async function handleElicitationRequest(
+  request: ElicitationRequest | null,
+  config: CopilotElicitationConfig,
+  hooks?: {
+    /** Collect the operator's explicit answer (rail approve/deny). */
+    collectDecision?: (req: ElicitationRequest, timeoutMs: number) => Promise<ElicitationDecision | null>;
+    /** Deliver an approve answer to the gateway; resolves true iff confirmed. */
+    deliverDecision?: (decision: ElicitationDecision) => Promise<boolean>;
+  }
+): Promise<ElicitationOutcome> {
+  // Short-circuit while dormant or unsupported — do NOT engage the operator or
+  // the gateway. resolveElicitationOutcome returns DENY for both.
+  if (!config.enabled || !config.gatewaySupported || !request) {
+    return resolveElicitationOutcome({
+      config,
+      request,
+      decision: null,
+      deliveredOk: false,
+    });
+  }
+
+  // --- Unreachable today (gatewaySupported is false) ------------------------
+  // This is the shape the real path takes once support lands. Kept minimal and
+  // still fail-closed: any thrown/absent step degrades to DENY.
+  let decision: ElicitationDecision | null = null;
+  let timedOut = false;
+  try {
+    decision = hooks?.collectDecision
+      ? await hooks.collectDecision(request, config.timeoutMs)
+      : null;
+  } catch {
+    decision = null; // fail closed
+  }
+  if (!decision) timedOut = true;
+
+  let deliveredOk = false;
+  if (decision?.decision === "approve") {
+    try {
+      deliveredOk = hooks?.deliverDecision ? await hooks.deliverDecision(decision) : false;
+    } catch {
+      deliveredOk = false; // fail closed
+    }
+  }
+
+  return resolveElicitationOutcome({ config, request, decision, deliveredOk, timedOut });
+}
+
+/** Convenience: is a tool call allowed to proceed given an outcome? */
+export function isToolCallApproved(outcome: ElicitationOutcome): boolean {
+  return outcome.gated && outcome.decision === "approve";
+}
+
+// --- helpers -----------------------------------------------------------------
+
+function deny(reason: ElicitationOutcomeReason): ElicitationOutcome {
+  return { gated: false, decision: "deny", reason };
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+function asText(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+function asPositiveNumber(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : undefined;
+}
+
+function parsePositiveInt(v: string | undefined): number | null {
+  if (!v) return null;
+  const n = Number.parseInt(v, 10);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}

--- a/test/unit/copilot-elicitation.test.ts
+++ b/test/unit/copilot-elicitation.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COPILOT_ELICITATION_FLAG,
+  GATEWAY_ELICITATION_SUPPORTED,
+  handleElicitationRequest,
+  isToolCallApproved,
+  parseElicitationRequest,
+  resolveCopilotElicitationConfig,
+  resolveElicitationOutcome,
+  type CopilotElicitationConfig,
+  type ElicitationDecision,
+  type ElicitationRequest,
+} from "../../packages/averray-mcp/src/copilot-elicitation.js";
+
+const REQUEST: ElicitationRequest = {
+  id: "elc_1",
+  sessionId: "sess_1",
+  toolName: "averray_submit",
+  summary: "Submit the proposal to the marketplace",
+};
+
+const APPROVE: ElicitationDecision = {
+  requestId: "elc_1",
+  decision: "approve",
+  decidedBy: "operator",
+};
+
+const DENY: ElicitationDecision = {
+  requestId: "elc_1",
+  decision: "deny",
+  decidedBy: "operator",
+};
+
+/** A config with the gateway pretended-supported, to exercise the FUTURE path. */
+function supportedConfig(over: Partial<CopilotElicitationConfig> = {}): CopilotElicitationConfig {
+  return { enabled: true, gatewaySupported: true, timeoutMs: 1000, ...over };
+}
+
+describe("resolveCopilotElicitationConfig — fail-closed env gate", () => {
+  it("is OFF by default (unset flag)", () => {
+    const cfg = resolveCopilotElicitationConfig({});
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("stays OFF for 0 / empty / off / garbage", () => {
+    for (const raw of ["0", "", " ", "off", "no", "false-ish", "2", "yes"]) {
+      expect(resolveCopilotElicitationConfig({ [COPILOT_ELICITATION_FLAG]: raw }).enabled).toBe(false);
+    }
+  });
+
+  it("turns ON only for explicit 1 / true (case/space tolerant)", () => {
+    for (const raw of ["1", "true", "TRUE", " True "]) {
+      expect(resolveCopilotElicitationConfig({ [COPILOT_ELICITATION_FLAG]: raw }).enabled).toBe(true);
+    }
+  });
+
+  it("always reports the gateway as unsupported today, even when enabled", () => {
+    const cfg = resolveCopilotElicitationConfig({ [COPILOT_ELICITATION_FLAG]: "1" });
+    expect(cfg.gatewaySupported).toBe(false);
+    expect(GATEWAY_ELICITATION_SUPPORTED).toBe(false);
+  });
+
+  it("reads a positive timeout override, else defaults", () => {
+    expect(
+      resolveCopilotElicitationConfig({
+        [COPILOT_ELICITATION_FLAG]: "1",
+        HERMES_COPILOT_ELICITATION_TIMEOUT_MS: "5000",
+      }).timeoutMs
+    ).toBe(5000);
+    // bad values fall back to the default (non-zero)
+    expect(
+      resolveCopilotElicitationConfig({ HERMES_COPILOT_ELICITATION_TIMEOUT_MS: "-1" }).timeoutMs
+    ).toBeGreaterThan(0);
+    expect(
+      resolveCopilotElicitationConfig({ HERMES_COPILOT_ELICITATION_TIMEOUT_MS: "abc" }).timeoutMs
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveElicitationOutcome — the fail-closed truth table", () => {
+  it("DENY (feature-disabled) when the flag is off — even with an explicit approve", () => {
+    const out = resolveElicitationOutcome({
+      config: { enabled: false, gatewaySupported: false, timeoutMs: 1000 },
+      request: REQUEST,
+      decision: APPROVE,
+      deliveredOk: true,
+    });
+    expect(out).toEqual({ gated: false, decision: "deny", reason: "feature-disabled" });
+  });
+
+  it("DENY (no-gateway-support) when enabled but the gateway can't be answered — even with a delivered approve", () => {
+    const out = resolveElicitationOutcome({
+      config: { enabled: true, gatewaySupported: false, timeoutMs: 1000 },
+      request: REQUEST,
+      decision: APPROVE,
+      deliveredOk: true,
+    });
+    expect(out).toEqual({ gated: false, decision: "deny", reason: "no-gateway-support" });
+  });
+
+  it("DENY (no-request) when there is nothing to gate", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: null,
+      decision: APPROVE,
+      deliveredOk: true,
+    });
+    expect(out.decision).toBe("deny");
+    expect(out.reason).toBe("no-request");
+  });
+
+  it("DENY (no-operator-response) on operator silence — the core never-auto-approve guarantee", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: REQUEST,
+      decision: null,
+      deliveredOk: false,
+    });
+    expect(out).toEqual({ gated: false, decision: "deny", reason: "no-operator-response" });
+  });
+
+  it("DENY (timeout) when the window elapsed, regardless of a late answer", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: REQUEST,
+      decision: APPROVE,
+      deliveredOk: true,
+      timedOut: true,
+    });
+    expect(out.decision).toBe("deny");
+    expect(out.reason).toBe("timeout");
+  });
+
+  it("DENY (no-operator-response) when the answer is for a different request id", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: REQUEST,
+      decision: { ...APPROVE, requestId: "some-other-id" },
+      deliveredOk: true,
+    });
+    expect(out.decision).toBe("deny");
+    expect(out.reason).toBe("no-operator-response");
+  });
+
+  it("DENY (operator-denied) on an explicit deny — and it IS gated", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: REQUEST,
+      decision: DENY,
+      deliveredOk: false,
+    });
+    expect(out).toEqual({ gated: true, decision: "deny", reason: "operator-denied" });
+  });
+
+  it("DENY (delivery-unreachable) when an approve could not be delivered to the gateway", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: REQUEST,
+      decision: APPROVE,
+      deliveredOk: false,
+    });
+    expect(out.decision).toBe("deny");
+    expect(out.reason).toBe("delivery-unreachable");
+  });
+
+  it("APPROVE only on enabled + supported + explicit approve + delivered", () => {
+    const out = resolveElicitationOutcome({
+      config: supportedConfig(),
+      request: REQUEST,
+      decision: APPROVE,
+      deliveredOk: true,
+    });
+    expect(out).toEqual({ gated: true, decision: "approve", reason: "operator-approved" });
+    expect(isToolCallApproved(out)).toBe(true);
+  });
+
+  it("there is NO input combination without an explicit approve that yields approve", () => {
+    // Exhaustively sweep the decision-less / deny / undelivered space and assert
+    // none of it ever produces an approval.
+    const configs: CopilotElicitationConfig[] = [
+      { enabled: false, gatewaySupported: false, timeoutMs: 1000 },
+      { enabled: true, gatewaySupported: false, timeoutMs: 1000 },
+      supportedConfig(),
+    ];
+    const decisions: (ElicitationDecision | null)[] = [null, DENY];
+    for (const config of configs) {
+      for (const decision of decisions) {
+        for (const deliveredOk of [false, true]) {
+          for (const timedOut of [false, true]) {
+            const out = resolveElicitationOutcome({
+              config,
+              request: REQUEST,
+              decision,
+              deliveredOk,
+              timedOut,
+            });
+            expect(out.decision).toBe("deny");
+            expect(isToolCallApproved(out)).toBe(false);
+          }
+        }
+      }
+    }
+  });
+});
+
+describe("handleElicitationRequest — degraded-safe no-op handler (today)", () => {
+  it("never engages the operator or the gateway while the flag is OFF", async () => {
+    let collectCalls = 0;
+    let deliverCalls = 0;
+    const out = await handleElicitationRequest(REQUEST, resolveCopilotElicitationConfig({}), {
+      collectDecision: async () => {
+        collectCalls++;
+        return APPROVE;
+      },
+      deliverDecision: async () => {
+        deliverCalls++;
+        return true;
+      },
+    });
+    expect(out).toEqual({ gated: false, decision: "deny", reason: "feature-disabled" });
+    expect(collectCalls).toBe(0);
+    expect(deliverCalls).toBe(0);
+  });
+
+  it("even when ENABLED, does not engage hooks and falls closed (no gateway support today)", async () => {
+    let collectCalls = 0;
+    let deliverCalls = 0;
+    const out = await handleElicitationRequest(
+      REQUEST,
+      resolveCopilotElicitationConfig({ [COPILOT_ELICITATION_FLAG]: "1" }),
+      {
+        collectDecision: async () => {
+          collectCalls++;
+          return APPROVE;
+        },
+        deliverDecision: async () => {
+          deliverCalls++;
+          return true;
+        },
+      }
+    );
+    // Real product config can never reach an approval today.
+    expect(out).toEqual({ gated: false, decision: "deny", reason: "no-gateway-support" });
+    expect(isToolCallApproved(out)).toBe(false);
+    expect(collectCalls).toBe(0);
+    expect(deliverCalls).toBe(0);
+  });
+
+  it("with a null request, returns a fail-closed DENY", async () => {
+    const out = await handleElicitationRequest(
+      null,
+      resolveCopilotElicitationConfig({ [COPILOT_ELICITATION_FLAG]: "1" })
+    );
+    expect(out.decision).toBe("deny");
+    expect(out.gated).toBe(false);
+  });
+
+  // The following exercise the FUTURE wired path (gateway pretended-supported)
+  // to prove the handler itself stays fail-closed once support lands.
+  it("[future path] fails closed to DENY when the operator does not answer", async () => {
+    const out = await handleElicitationRequest(REQUEST, supportedConfig(), {
+      collectDecision: async () => null, // operator silent / timeout
+    });
+    expect(out.decision).toBe("deny");
+    expect(out.reason).toBe("timeout");
+  });
+
+  it("[future path] fails closed to DENY when collecting the decision throws", async () => {
+    const out = await handleElicitationRequest(REQUEST, supportedConfig(), {
+      collectDecision: async () => {
+        throw new Error("rail unreachable");
+      },
+    });
+    expect(out.decision).toBe("deny");
+    expect(isToolCallApproved(out)).toBe(false);
+  });
+
+  it("[future path] fails closed to DENY when an approve cannot be delivered", async () => {
+    const out = await handleElicitationRequest(REQUEST, supportedConfig(), {
+      collectDecision: async () => APPROVE,
+      deliverDecision: async () => false, // gateway unreachable
+    });
+    expect(out.decision).toBe("deny");
+    expect(out.reason).toBe("delivery-unreachable");
+  });
+
+  it("[future path] fails closed to DENY when delivery throws", async () => {
+    const out = await handleElicitationRequest(REQUEST, supportedConfig(), {
+      collectDecision: async () => APPROVE,
+      deliverDecision: async () => {
+        throw new Error("boom");
+      },
+    });
+    expect(out.decision).toBe("deny");
+  });
+
+  it("[future path] honours an explicit operator DENY (gated)", async () => {
+    const out = await handleElicitationRequest(REQUEST, supportedConfig(), {
+      collectDecision: async () => DENY,
+    });
+    expect(out).toEqual({ gated: true, decision: "deny", reason: "operator-denied" });
+  });
+
+  it("[future path] approves ONLY on explicit approve + confirmed delivery", async () => {
+    const out = await handleElicitationRequest(REQUEST, supportedConfig(), {
+      collectDecision: async () => APPROVE,
+      deliverDecision: async () => true,
+    });
+    expect(out).toEqual({ gated: true, decision: "approve", reason: "operator-approved" });
+    expect(isToolCallApproved(out)).toBe(true);
+  });
+});
+
+describe("parseElicitationRequest — strict, fail-closed parser", () => {
+  it("returns null for non-objects and empties", () => {
+    for (const bad of [null, undefined, 42, "x", [], true]) {
+      expect(parseElicitationRequest(bad)).toBeNull();
+    }
+  });
+
+  it("returns null for ordinary stream events (assistant.delta / run.completed)", () => {
+    expect(parseElicitationRequest({ type: "assistant.delta", message_id: "m1", delta: "hi" })).toBeNull();
+    expect(parseElicitationRequest({ type: "run.completed", session_id: "s1" })).toBeNull();
+  });
+
+  it("returns null when the discriminator is right but required fields are missing", () => {
+    expect(parseElicitationRequest({ type: "tool.confirmation" })).toBeNull();
+    expect(parseElicitationRequest({ type: "tool.confirmation", id: "e1" })).toBeNull();
+    expect(parseElicitationRequest({ type: "tool.confirmation", id: "e1", session_id: "s1" })).toBeNull();
+  });
+
+  it("parses a well-formed tool.confirmation frame", () => {
+    const req = parseElicitationRequest({
+      type: "tool.confirmation",
+      id: "e1",
+      session_id: "s1",
+      tool_name: "averray_submit",
+      summary: "Submit proposal",
+      arguments: { jobId: "j1" },
+      expires_at_ms: 123,
+    });
+    expect(req).toEqual({
+      id: "e1",
+      sessionId: "s1",
+      toolName: "averray_submit",
+      summary: "Submit proposal",
+      arguments: { jobId: "j1" },
+      expiresAtMs: 123,
+    });
+  });
+
+  it("accepts the elicitation.request alias and synthesizes a summary when absent", () => {
+    const req = parseElicitationRequest({
+      event: "elicitation.request",
+      request_id: "e2",
+      sessionId: "s2",
+      toolName: "averray_claim",
+    });
+    expect(req?.toolName).toBe("averray_claim");
+    expect(req?.summary).toContain("averray_claim");
+  });
+});


### PR DESCRIPTION
## What this is

**Groundwork for feature #4** (inline approve/deny in the Hermes co-pilot rail when a tool call needs confirmation) — **NOT a live approval gate.** No tool call is gated by this PR. It ships behind `HERMES_COPILOT_ELICITATION` (**default OFF**), degraded-safe, fail-closed.

## Why groundwork and not the real feature (truth boundary)

I researched whether the Hermes gateway Session API actually exposes MCP elicitation. **It does not.** Evidence, cited from this repo:

- The Session API surface is **create / chat / fork** only — `services/slack-operator/src/hermes-session-client.ts:11-15`.
- The only documented stream events are **`assistant.delta`** and **`run.completed`** — `hermes-session-client.ts:21-23`. Neither is a tool-confirmation / elicitation request.
- There is **no endpoint to answer a pending tool call** (nothing like `POST /api/sessions/{id}/elicitations/{eid}`).
- The gateway image is documented as **unverified even for the Session API** (pinned v0.14; Session API is v0.15+) — `docs/HERMES_SESSION_API_SPIKE.md`.
- The current co-pilot is synchronous poll-based chat with **no tool channel**: `useCollaboration` polls `/monitor/collaboration` (`packages/monitor-ui/src/hooks/useCollaboration.ts:1-7`); message kinds are only `chat | proposal | request_help | status` (`services/slack-operator/src/monitor-collab.ts:40`).
- A repo-wide grep for `elicit` / tool-confirmation / tool-approval / human-in-the-loop-tool-call returns **zero** hits in code.

Per the truth-boundary rule, I did **not** build a UI that pretends to gate tool calls it cannot gate. Instead this PR ships the types, a fail-closed gate, and a dormant no-op handler, plus a design doc stating the exact gateway support required so the real slice is a small, well-scoped follow-up.

## What's in this PR

| File | Change |
| --- | --- |
| `packages/averray-mcp/src/copilot-elicitation.ts` | **New.** Types (`ElicitationRequest` / `ElicitationDecision` / `ElicitationOutcome`), fail-closed env gate (`resolveCopilotElicitationConfig`), strict frame parser (`parseElicitationRequest`), the pure fail-closed truth table (`resolveElicitationOutcome`), and a degraded-safe **no-op handler** (`handleElicitationRequest`) that gates nothing and can **never auto-approve**. No `@avg/*` imports → isolated tests. |
| `test/unit/copilot-elicitation.test.ts` | **New. 29 tests** — default-OFF, the full fail-closed table, a **never-auto-approve exhaustive sweep**, off ⇒ hooks-never-called, the future wired path staying fail-closed, and parser rejection of `assistant.delta` / `run.completed` / malformed frames. |
| `ops/compose.yml` | `HERMES_COPILOT_ELICITATION` (+ `_TIMEOUT_MS`) passthrough to `slack-operator`, default `0`. |
| `docs/HERMES_COPILOT_ELICITATION.md` | Design doc: intended flow, the **exact gateway support required** (a `tool.confirmation` stream event + an answer endpoint — neither exists), fail-closed semantics, truth boundary. |

**Default behavior is byte-identical.** The module is not yet imported by any runtime path; it is dormant until the gateway support lands and a follow-up wires it in.

## Fail-closed / security contract

A tool call is allowed to proceed (**approve**) **only** when all of: flag on **and** gateway actually supports elicitation **and** an operator **explicitly** approved **and** that approval was **delivered + acknowledged** by the gateway. **Every other path denies** — including flag-off, no gateway support (i.e. today), operator silence, timeout, and unreachable gateway/rail. A dedicated test sweeps the decision-less / deny / undelivered space and asserts every result is DENY. **Silence is never auto-approve.**

## Tests

```
npx tsc -b packages/averray-mcp        # build first (nodenext)
npx vitest run test/unit/copilot-elicitation.test.ts
# → Test Files 1 passed (1) · Tests 29 passed (29)
```

(The full suite has known pre-existing failures unrelated to this change; only the new test file was run.)

## Dependency / overlap note

This conceptually depends on **#3** (streaming co-pilot session, branch `claude/copilot-sse-streaming`) for the live stream the real feature would read `tool.confirmation` frames from. Built independently in a separate worktree; the design doc's §5 lists the follow-up wiring (a `"elicitation"` collaboration kind, an answer route, and a rail affordance) that lands **only after** #3 and real gateway support exist. No overlap with #3's files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)