### PR TITLE
feat(copilot): live-token streaming for "Ask Hermes" replies (flag-gated, #3)

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -256,6 +256,13 @@ services:
       HERMES_API_URL: ${HERMES_API_URL:-}
       HERMES_API_TOKEN: ${HERMES_API_TOKEN:-}
       HERMES_SESSION_TIMEOUT_MS: ${HERMES_SESSION_TIMEOUT_MS:-}
+      # Feature #3 — live-token streaming for the co-pilot's "Ask Hermes" replies.
+      # When ON (and the gateway session transport above resolves), the co-pilot
+      # streams Hermes's reply token-by-token over the board SSE instead of
+      # landing it whole on the next poll. OFF by default; degraded-safe — any
+      # streaming failure falls back to the sync session turn, so the co-pilot
+      # reply is never muted or faked.
+      HERMES_COPILOT_STREAMING: ${HERMES_COPILOT_STREAMING:-0}
       # ORCH-P4c — agentic router backlog. When ON (needs the gateway session AND
       # a non-empty dispatch.allowed_repos), Hermes reasons over the live board to
       # propose board-grounded work gaps, augmenting the deterministic roadmap

--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -113,6 +113,15 @@ export function MonitorPage({
   autonomy,
 }: MonitorPageProps = {}) {
   const { board, status, refresh } = useMonitorBoard(options);
+  // Feature #3 — let the co-pilot rail consume live Hermes tokens off the board
+  // SSE by default (opt-in to the EventSource delta source). DEGRADED-SAFE: the
+  // delta events only exist when the backend HERMES_COPILOT_STREAMING flag is
+  // on; with it off no events arrive and the rail renders off the poll exactly
+  // as before. Callers/tests can still fully override the wiring.
+  const collaborationWithStreaming = useMemo<UseCollaborationOptions>(
+    () => ({ live: true, ...collaboration }),
+    [collaboration],
+  );
   // PR-D1: apply the Hermes-4 color profile (default Midnight) + motion/density
   // to <html> as --h4-* tokens. Foundation-first — drives the new shell/footer/
   // kanban-tier surfaces; the existing board keeps its --hm-* styling until
@@ -166,7 +175,7 @@ export function MonitorPage({
         onRerunMission={onRerunMission}
         onAcceptMissionFailure={onAcceptMissionFailure}
         onOpenMissionIssue={onOpenMissionIssue}
-        collaboration={collaboration}
+        collaboration={collaborationWithStreaming}
         onMute={muteEverywhere}
         onUnmute={unmuteEverywhere}
         muted={muted}

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
@@ -68,4 +68,23 @@ describe("HermesTurn", () => {
     const { queryByRole } = render(<HermesTurn turn={base} />);
     expect(queryByRole("link")).toBeNull();
   });
+
+  test("shows a live streaming affordance only while streaming (feature #3)", () => {
+    const streaming = render(
+      <HermesTurn turn={{ ...base, id: "s", kind: "chat", hermesMode: "live", streaming: true }} />,
+    );
+    const el = streaming.container.querySelector(".hm-turn") as HTMLElement;
+    expect(el.className).toContain("hm-turn--streaming");
+    expect(el.getAttribute("aria-busy")).toBe("true");
+    expect(streaming.getByText(/streaming/)).toBeTruthy();
+    expect(streaming.container.querySelector(".hm-turn-caret")).toBeTruthy();
+    streaming.unmount();
+
+    // A finalized (non-streaming) turn shows no caret and is not aria-busy.
+    const done = render(<HermesTurn turn={{ ...base, id: "d", kind: "chat", hermesMode: "live" }} />);
+    const doneEl = done.container.querySelector(".hm-turn") as HTMLElement;
+    expect(doneEl.className).not.toContain("hm-turn--streaming");
+    expect(doneEl.getAttribute("aria-busy")).toBeNull();
+    expect(done.container.querySelector(".hm-turn-caret")).toBeNull();
+  });
 });

--- a/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
+++ b/packages/monitor-ui/src/components/hermes/HermesTurn.tsx
@@ -17,21 +17,30 @@ export function HermesTurn({
     ? `https://github.com/${turn.relatedPr.repo}/pull/${turn.relatedPr.number}`
     : undefined;
   const pending = turn.id.startsWith("optimistic-");
+  // Feature #3 — a genuinely live-streaming Hermes turn (tokens still arriving).
+  const streaming = turn.streaming === true;
   const rank = rankForKind(turn.kind);
 
   return (
     <div
-      className={`hm-turn hm-turn--${turn.author} hm-turn--kind-${turn.kind} hm-turn--rank-${rank}`}
+      className={`hm-turn hm-turn--${turn.author} hm-turn--kind-${turn.kind} hm-turn--rank-${rank}${
+        streaming ? " hm-turn--streaming" : ""
+      }`}
+      {...(streaming ? { "aria-busy": true } : {})}
     >
       <div className="hm-turn-head">
         <AgentTag agent={turn.author} label={roomActorLabel(turn)} className="hm-turn-actor" />
         <span className="hm-turn-kind">
           · {kindLabel(turn.kind)}
           {pending ? " · pending" : ""}
+          {streaming ? " · streaming…" : ""}
         </span>
         <span className="hm-turn-time">{formatTurnTime(turn.ts)}</span>
       </div>
-      <div className="hm-turn-body">{turn.text}</div>
+      <div className="hm-turn-body">
+        {turn.text}
+        {streaming ? <span className="hm-turn-caret" aria-hidden>▍</span> : null}
+      </div>
       {cardId ? (
         <CardPin cardId={cardId} onCardClick={onCardClick} />
       ) : turn.relatedPr ? (

--- a/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
+++ b/packages/monitor-ui/src/hooks/useCollaboration.test.tsx
@@ -3,8 +3,12 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import type { ReactNode } from "react";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { SWRConfig } from "swr";
-import { useCollaboration } from "./useCollaboration.js";
-import type { CollaborationMessage } from "../lib/monitor/collaboration.js";
+import { reduceStreamingTurn, useCollaboration } from "./useCollaboration.js";
+import type {
+  CollaborationMessage,
+  CopilotStreamEvent,
+  CopilotStreamSource,
+} from "../lib/monitor/collaboration.js";
 
 afterEach(cleanup);
 
@@ -158,5 +162,161 @@ describe("useCollaboration", () => {
     // copy (server's), not the optimistic duplicate.
     await waitFor(() => expect(result.current.messages.map((m) => m.id)).toEqual(["q", "a"]));
     expect(result.current.messages.filter((m) => m.text === "status?")).toHaveLength(1);
+  });
+});
+
+// Feature #3 — live-token streaming. A synchronous delta source lets the test
+// push SSE events; the hook accumulates them into an in-progress Hermes turn.
+describe("useCollaboration — live-token streaming (feature #3)", () => {
+  /** A DI delta source that captures the handler so the test can drive events. */
+  function controllableSource(): { source: CopilotStreamSource; emit: (e: CopilotStreamEvent) => void; unsubscribed: () => boolean } {
+    let handler: ((e: CopilotStreamEvent) => void) | undefined;
+    let off = false;
+    return {
+      source: (onEvent) => {
+        handler = onEvent;
+        return () => {
+          off = true;
+        };
+      },
+      emit: (e) => handler?.(e),
+      unsubscribed: () => off,
+    };
+  }
+
+  test("accumulates hermes.delta into a live streaming turn, then finalizes on completion", async () => {
+    const { source, emit } = controllableSource();
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [], deltaSource: source, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => emit({ type: "hermes.delta", payload: { turnId: "t1", delta: "Operator ", addressedTo: "everyone" } }));
+    act(() => emit({ type: "hermes.delta", payload: { turnId: "t1", delta: "review is waiting." } }));
+
+    // Mid-stream: one Hermes turn, text accumulated, flagged streaming + live.
+    const streaming = result.current.messages.find((m) => m.id === "t1");
+    expect(streaming?.text).toBe("Operator review is waiting.");
+    expect(streaming?.author).toBe("hermes");
+    expect(streaming?.streaming).toBe(true);
+    expect(streaming?.hermesMode).toBe("live");
+
+    act(() =>
+      emit({ type: "hermes.turn.completed", payload: { turnId: "t1", text: "Operator review is waiting. Why: board.", hermesMode: "live" } }),
+    );
+
+    // Finalized: authoritative text, streaming flag cleared.
+    const done = result.current.messages.find((m) => m.id === "t1");
+    expect(done?.text).toBe("Operator review is waiting. Why: board.");
+    expect(done?.streaming).toBeUndefined();
+  });
+
+  test("reconciles the streamed turn away once the polled feed echoes the finalized text", async () => {
+    const { source, emit } = controllableSource();
+    // The feed starts empty, then (after the turn completes) the poll begins
+    // returning the same Hermes reply as a real server message.
+    let turns: CollaborationMessage[] = [];
+    const fetcher = vi.fn(async () => turns);
+    // A small refresh interval lets SWR re-poll so the echo lands on its own.
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher, deltaSource: source, refreshIntervalMs: 20 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(fetcher).toHaveBeenCalled());
+
+    act(() => emit({ type: "hermes.turn.completed", payload: { turnId: "t1", text: "all green", hermesMode: "live" } }));
+    // Before the echo: the streamed turn is the only copy of the reply.
+    expect(result.current.messages.filter((m) => m.text === "all green")).toHaveLength(1);
+    expect(result.current.messages.find((m) => m.text === "all green")?.id).toBe("t1");
+
+    // The server feed now carries the same Hermes reply under its own id.
+    turns = [{ id: "srv-a", ts: Date.now(), author: "hermes", kind: "chat", text: "all green", addressedTo: "everyone" }];
+
+    // Once the poll echoes it, the streamed turn drops — exactly one copy, the
+    // server's — so the reply never renders twice.
+    await waitFor(() => {
+      const green = result.current.messages.filter((m) => m.text === "all green");
+      expect(green).toHaveLength(1);
+      expect(green[0]?.id).toBe("srv-a");
+    });
+  });
+
+  test("finalizes an interrupted stream honestly as templated (no stuck live bubble)", async () => {
+    const { source, emit } = controllableSource();
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [], deltaSource: source, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Partial live tokens streamed…
+    act(() => emit({ type: "hermes.delta", payload: { turnId: "t1", delta: "half a th" } }));
+    expect(result.current.messages.find((m) => m.id === "t1")?.streaming).toBe(true);
+    expect(result.current.messages.find((m) => m.id === "t1")?.hermesMode).toBe("live");
+
+    // …then the gateway failed mid-stream and the co-pilot fell back to a
+    // templated reply. The terminal event carries the real text + mode.
+    act(() =>
+      emit({
+        type: "hermes.turn.completed",
+        payload: { turnId: "t1", text: "Operator review has 2 cards waiting.", hermesMode: "templated" },
+      }),
+    );
+    const done = result.current.messages.find((m) => m.id === "t1");
+    expect(done?.text).toBe("Operator review has 2 cards waiting."); // partial replaced
+    expect(done?.streaming).toBeUndefined(); // not stuck
+    expect(done?.hermesMode).toBe("templated"); // honest badge, not a live lie
+  });
+
+  test("renders exactly as before when no delta events ever arrive (degraded-safe)", async () => {
+    const { source } = controllableSource(); // never emits
+    const { result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [{ id: "1", ts: 1, author: "hermes", kind: "chat", text: "hi", addressedTo: "everyone" }], deltaSource: source, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.messages).toHaveLength(1));
+    expect(result.current.messages[0]?.text).toBe("hi");
+    expect(result.current.messages[0]?.streaming).toBeUndefined();
+  });
+
+  test("unsubscribes from the delta source on unmount", async () => {
+    const { source, unsubscribed } = controllableSource();
+    const { unmount, result } = renderHook(
+      () => useCollaboration({ fetcher: async () => [], deltaSource: source, refreshIntervalMs: 0 }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    unmount();
+    expect(unsubscribed()).toBe(true);
+  });
+});
+
+describe("reduceStreamingTurn (pure)", () => {
+  const empty = () => new Map();
+
+  test("delta creates then appends to a turn, marking it streaming", () => {
+    let m = reduceStreamingTurn(empty(), { type: "hermes.delta", payload: { turnId: "t", delta: "ab" } });
+    m = reduceStreamingTurn(m, { type: "hermes.delta", payload: { turnId: "t", delta: "cd" } });
+    expect(m.get("t")).toMatchObject({ text: "abcd", streaming: true });
+  });
+
+  test("completion replaces text with the authoritative final and clears streaming", () => {
+    let m = reduceStreamingTurn(empty(), { type: "hermes.delta", payload: { turnId: "t", delta: "partial" } });
+    m = reduceStreamingTurn(m, { type: "hermes.turn.completed", payload: { turnId: "t", text: "final full text" } });
+    expect(m.get("t")).toMatchObject({ text: "final full text", streaming: false });
+  });
+
+  test("ignores malformed events (no turnId, non-string/empty delta, empty completed text)", () => {
+    const base = empty();
+    // @ts-expect-error — exercising a malformed payload at the boundary
+    expect(reduceStreamingTurn(base, { type: "hermes.delta", payload: {} })).toBe(base);
+    expect(reduceStreamingTurn(base, { type: "hermes.delta", payload: { turnId: "t", delta: "" } })).toBe(base);
+    expect(reduceStreamingTurn(base, { type: "hermes.turn.completed", payload: { turnId: "t", text: "" } })).toBe(base);
+  });
+
+  test("a completion for an unseen turn still renders (terminal text is authoritative)", () => {
+    const m = reduceStreamingTurn(empty(), { type: "hermes.turn.completed", payload: { turnId: "t", text: "solo" } });
+    expect(m.get("t")).toMatchObject({ text: "solo", streaming: false });
   });
 });

--- a/packages/monitor-ui/src/hooks/useCollaboration.ts
+++ b/packages/monitor-ui/src/hooks/useCollaboration.ts
@@ -3,15 +3,31 @@
 // Polls slack-operator's /monitor/collaboration for the operator ↔ Hermes
 // ↔ Codex turn stream, and posts operator questions back. Posting a
 // question records it and schedules an async Hermes reply server-side; the
-// reply shows up on the next poll, so the rail "answers" without any
-// bespoke streaming. Dependency-injected (fetcher, poster) for tests.
+// reply shows up on the next poll, so the rail "answers" even without
+// streaming. Dependency-injected (fetcher, poster) for tests.
+//
+// Feature #3 — live-token streaming (FLAG-GATED backend, default off): when a
+// `deltaSource` is wired, the hook also subscribes to co-pilot SSE events
+// (`hermes.delta` / `hermes.turn.completed`) and renders the in-progress Hermes
+// reply token-by-token ahead of the next poll. DEGRADED-SAFE: if no delta
+// events ever arrive (flag off, or the stream fails), the rail renders exactly
+// as before off the poll. Streaming turns are reconciled away once the polled
+// feed echoes the finalized reply — never a duplicate.
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import useSWR from "swr";
-import type { CollaborationMessage, CollaborationRelatedPr, CollaborationTarget } from "../lib/monitor/collaboration.js";
+import type {
+  CollaborationMessage,
+  CollaborationRelatedPr,
+  CollaborationTarget,
+  CopilotStreamEvent,
+  CopilotStreamSource,
+  HermesReplyMode,
+} from "../lib/monitor/collaboration.js";
 
 const DEFAULT_URL = "/monitor/collaboration";
 const DEFAULT_REFRESH_MS = 4000;
+const DEFAULT_STREAM_URL = "/monitor/v2/stream";
 
 export interface AskInput {
   text: string;
@@ -27,6 +43,44 @@ export interface UseCollaborationOptions {
   poster?: (input: AskInput) => Promise<void>;
   refreshIntervalMs?: number;
   limit?: number;
+  /**
+   * Live-token stream subscription (feature #3). When provided, the hook
+   * renders streamed Hermes deltas ahead of the poll. Omit to keep the rail on
+   * the poll path (default). Tests inject a synchronous stub; production wires
+   * the EventSource-backed default via `streamUrl` + `streamToken`.
+   */
+  deltaSource?: CopilotStreamSource;
+  /** SSE URL for the default EventSource delta source. Default "/monitor/v2/stream". */
+  streamUrl?: string;
+  /** Auth token appended to the default delta-source SSE URL (EventSource can't send headers). */
+  streamToken?: string;
+  /**
+   * When true, open the default EventSource delta source against `streamUrl`.
+   * Off by default so nothing touches the network unless the app opts in
+   * (mirrors the backend flag being off by default). Ignored when an explicit
+   * `deltaSource` is provided.
+   */
+  live?: boolean;
+  /** Injected EventSource constructor (tests / non-browser). */
+  EventSourceCtor?: typeof EventSource;
+}
+
+/** An in-progress or just-finalized streamed Hermes turn, keyed by turnId. */
+interface StreamingTurn {
+  turnId: string;
+  text: string;
+  addressedTo: CollaborationTarget;
+  ts: number;
+  /** True while deltas are still arriving; false once `hermes.turn.completed` lands. */
+  streaming: boolean;
+  /**
+   * Provenance badge. Deltas are always "live" (genuinely streamed tokens); the
+   * terminal event carries the authoritative mode, so a mid-stream failure that
+   * fell back to a templated reply finalizes honestly as "templated".
+   */
+  hermesMode: HermesReplyMode;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
 }
 
 export interface CollaborationState {
@@ -70,6 +124,56 @@ function makeDefaultPoster(url: string): (input: AskInput) => Promise<void> {
   };
 }
 
+/**
+ * EventSource-backed default delta source: opens the board SSE and forwards the
+ * named co-pilot events. Degraded-safe — if EventSource is unavailable (SSR /
+ * tests without a DOM) it's a no-op that never calls the handler, so the rail
+ * stays on the poll path. Only opened when the app sets `live: true`.
+ */
+function makeEventSourceDeltaSource(
+  streamUrl: string,
+  streamToken: string | undefined,
+  EventSourceCtor: typeof EventSource | undefined,
+): CopilotStreamSource {
+  return (onEvent) => {
+    const Ctor =
+      EventSourceCtor ??
+      (typeof globalThis !== "undefined"
+        ? (globalThis as { EventSource?: typeof EventSource }).EventSource
+        : undefined);
+    if (!Ctor) return () => {};
+    const url = streamToken ? `${streamUrl}?token=${encodeURIComponent(streamToken)}` : streamUrl;
+    let source: EventSource | undefined;
+    try {
+      source = new Ctor(url);
+    } catch {
+      return () => {};
+    }
+    const handle = (type: CopilotStreamEvent["type"]) => (e: MessageEvent) => {
+      if (!e || typeof e.data !== "string") return;
+      try {
+        const payload = JSON.parse(e.data);
+        onEvent({ type, payload } as CopilotStreamEvent);
+      } catch {
+        /* ignore malformed frame — a bad event never breaks the rail */
+      }
+    };
+    const onDelta = handle("hermes.delta");
+    const onCompleted = handle("hermes.turn.completed");
+    source.addEventListener("hermes.delta", onDelta as EventListener);
+    source.addEventListener("hermes.turn.completed", onCompleted as EventListener);
+    return () => {
+      source?.removeEventListener("hermes.delta", onDelta as EventListener);
+      source?.removeEventListener("hermes.turn.completed", onCompleted as EventListener);
+      try {
+        source?.close();
+      } catch {
+        /* already closed */
+      }
+    };
+  };
+}
+
 export function useCollaboration(opts: UseCollaborationOptions = {}): CollaborationState {
   const enabled = opts.enabled ?? true;
   const url = opts.url ?? DEFAULT_URL;
@@ -94,16 +198,59 @@ export function useCollaboration(opts: UseCollaborationOptions = {}): Collaborat
   const [sendError, setSendError] = useState<string | null>(null);
   const seq = useRef(0);
 
+  // Feature #3 — in-progress streamed Hermes turns keyed by turnId. Deltas
+  // append to a turn's text; the terminal event finalizes it (streaming:false).
+  // A finalized turn stays until the polled feed echoes the same text, then it's
+  // reconciled away so the reply never renders twice.
+  const [streamingTurns, setStreamingTurns] = useState<Map<string, StreamingTurn>>(() => new Map());
+
   const serverMessages = data ?? [];
+
+  // Resolve the delta source once: an explicit injected source wins; otherwise
+  // build the EventSource-backed default only when the app opts in via `live`.
+  // No source ⇒ the subscription effect is a no-op and the rail stays on polls.
+  const deltaSource = useMemo<CopilotStreamSource | undefined>(() => {
+    if (opts.deltaSource) return opts.deltaSource;
+    if (!enabled || !opts.live) return undefined;
+    return makeEventSourceDeltaSource(
+      opts.streamUrl ?? DEFAULT_STREAM_URL,
+      opts.streamToken,
+      opts.EventSourceCtor,
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [opts.deltaSource, enabled, opts.live, opts.streamUrl, opts.streamToken, opts.EventSourceCtor]);
+
+  useEffect(() => {
+    if (!deltaSource) return undefined;
+    const unsubscribe = deltaSource((event) => {
+      setStreamingTurns((prev) => reduceStreamingTurn(prev, event));
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [deltaSource]);
 
   // Drop any optimistic message the server feed has now echoed back, so we
   // don't render the operator's question twice.
   const pendingOptimistic = optimistic.filter(
     (o) => !serverMessages.some((m) => m.author === "operator" && m.text === o.text),
   );
+  // Render streamed Hermes turns until the server feed echoes the finalized
+  // text (same reconcile-on-echo discipline as optimistic operator messages).
+  const liveStreamingTurns = useMemo(
+    () =>
+      [...streamingTurns.values()].filter(
+        (t) => t.streaming || !serverMessages.some((m) => m.author === "hermes" && m.text === t.text),
+      ),
+    [streamingTurns, serverMessages],
+  );
+  const streamingMessages = useMemo(
+    () => liveStreamingTurns.map(streamingTurnToMessage),
+    [liveStreamingTurns],
+  );
   const messages = useMemo(
-    () => [...serverMessages, ...pendingOptimistic],
-    [serverMessages, pendingOptimistic],
+    () => [...serverMessages, ...pendingOptimistic, ...streamingMessages],
+    [serverMessages, pendingOptimistic, streamingMessages],
   );
 
   const clearSendError = useCallback(() => setSendError(null), []);
@@ -148,5 +295,86 @@ export function useCollaboration(opts: UseCollaborationOptions = {}): Collaborat
     pending,
     sendError,
     clearSendError,
+  };
+}
+
+/**
+ * Fold one co-pilot SSE event into the streaming-turns map (pure; exported for
+ * unit tests). `hermes.delta` appends the token to its turn (creating it
+ * mid-flight, `streaming:true`); `hermes.turn.completed` replaces the text with
+ * the authoritative final text and clears `streaming`. Malformed events (no
+ * turnId, non-string delta/text) are ignored so a bad frame never corrupts the
+ * feed. A completed event for an unseen turn still renders (the terminal text is
+ * authoritative even if deltas were dropped). Always returns a NEW map on change
+ * so React re-renders.
+ */
+export function reduceStreamingTurn(
+  prev: Map<string, StreamingTurn>,
+  event: CopilotStreamEvent,
+): Map<string, StreamingTurn> {
+  const turnId = event.payload?.turnId;
+  if (typeof turnId !== "string" || !turnId) return prev;
+
+  if (event.type === "hermes.delta") {
+    const delta = event.payload.delta;
+    if (typeof delta !== "string" || delta.length === 0) return prev;
+    const next = new Map(prev);
+    const existing = next.get(turnId);
+    next.set(turnId, {
+      turnId,
+      text: (existing?.text ?? "") + delta,
+      addressedTo: (event.payload.addressedTo ?? existing?.addressedTo ?? "everyone") as CollaborationTarget,
+      ts: existing?.ts ?? Date.now(),
+      streaming: true,
+      hermesMode: "live", // a streamed token is always genuinely live
+      ...(event.payload.relatedPr ?? existing?.relatedPr
+        ? { relatedPr: event.payload.relatedPr ?? existing?.relatedPr }
+        : {}),
+      ...(event.payload.relatedCorrelationId ?? existing?.relatedCorrelationId
+        ? { relatedCorrelationId: event.payload.relatedCorrelationId ?? existing?.relatedCorrelationId }
+        : {}),
+    });
+    return next;
+  }
+
+  // hermes.turn.completed — finalize with the authoritative full text + mode.
+  const text = event.payload.text;
+  if (typeof text !== "string" || !text) return prev;
+  const next = new Map(prev);
+  const existing = next.get(turnId);
+  next.set(turnId, {
+    turnId,
+    text,
+    addressedTo: (event.payload.addressedTo ?? existing?.addressedTo ?? "everyone") as CollaborationTarget,
+    ts: existing?.ts ?? Date.now(),
+    streaming: false,
+    // Honor the authoritative mode: a mid-stream failure that fell back to a
+    // templated reply finalizes as "templated", not a stuck live badge.
+    hermesMode: event.payload.hermesMode ?? existing?.hermesMode ?? "live",
+    ...(event.payload.relatedPr ?? existing?.relatedPr
+      ? { relatedPr: event.payload.relatedPr ?? existing?.relatedPr }
+      : {}),
+    ...(event.payload.relatedCorrelationId ?? existing?.relatedCorrelationId
+      ? { relatedCorrelationId: event.payload.relatedCorrelationId ?? existing?.relatedCorrelationId }
+      : {}),
+  });
+  return next;
+}
+
+/** Project a streaming turn into a renderable Hermes CollaborationMessage. */
+function streamingTurnToMessage(turn: StreamingTurn): CollaborationMessage {
+  return {
+    id: turn.turnId,
+    ts: turn.ts,
+    author: "hermes",
+    kind: "chat",
+    text: turn.text,
+    addressedTo: turn.addressedTo,
+    // Carry the turn's authoritative provenance badge. While streaming this is
+    // "live" (genuine tokens); a fallback finalizes it to its real mode.
+    hermesMode: turn.hermesMode,
+    ...(turn.streaming ? { streaming: true } : {}),
+    ...(turn.relatedPr ? { relatedPr: turn.relatedPr } : {}),
+    ...(turn.relatedCorrelationId ? { relatedCorrelationId: turn.relatedCorrelationId } : {}),
   };
 }

--- a/packages/monitor-ui/src/lib/monitor/collaboration.ts
+++ b/packages/monitor-ui/src/lib/monitor/collaboration.ts
@@ -31,7 +31,53 @@ export interface CollaborationMessage {
   hermesMode?: HermesReplyMode;
   relatedPr?: CollaborationRelatedPr;
   relatedCorrelationId?: string;
+  /**
+   * True while this Hermes turn is still receiving live tokens over the
+   * co-pilot SSE (feature #3). Set only on the in-progress streaming turn so the
+   * UI can show a "streaming…" affordance; cleared when the terminal
+   * `hermes.turn.completed` finalizes the text. Absent for polled/templated
+   * turns, which render exactly as before.
+   */
+  streaming?: boolean;
 }
+
+// --- co-pilot live-token stream (feature #3) --------------------------------
+// The frontend's copy of the SSE event contract broadcast by slack-operator's
+// board stream while a co-pilot Hermes reply streams. Independent of the
+// backend declaration by design (they cross an HTTP/SSE boundary).
+
+/** Incremental token for an in-progress co-pilot Hermes turn (`hermes.delta`). */
+export interface CopilotDeltaEvent {
+  turnId: string;
+  delta: string;
+  addressedTo?: CollaborationTarget;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+/** Terminal event for a co-pilot Hermes turn (`hermes.turn.completed`). */
+export interface CopilotTurnCompletedEvent {
+  turnId: string;
+  text: string;
+  hermesMode?: HermesReplyMode;
+  addressedTo?: CollaborationTarget;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+export type CopilotStreamEvent =
+  | { type: "hermes.delta"; payload: CopilotDeltaEvent }
+  | { type: "hermes.turn.completed"; payload: CopilotTurnCompletedEvent };
+
+/**
+ * Subscribe to co-pilot live-token events. Returns an unsubscribe fn. The
+ * default implementation (in the hook) is EventSource-backed against the board
+ * SSE; tests inject a synchronous stub. A no-op source (returns a no-op
+ * unsubscribe and never calls the handler) keeps the rail on the poll path.
+ */
+export type CopilotStreamSource = (
+  onEvent: (event: CopilotStreamEvent) => void,
+) => () => void;
 
 export interface ReviewRequest {
   id: string;

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2652,6 +2652,26 @@ button.hm-activity-row:hover {
   color: var(--hm-ink);
 }
 
+/* Feature #3 — live-token streaming affordance. Shown only while a Hermes turn
+ * is genuinely receiving tokens over the co-pilot SSE; the blinking caret is
+ * removed the moment the turn finalizes, so it never implies fake typing. */
+.hm-turn-caret {
+  display: inline-block;
+  margin-left: 1px;
+  color: var(--hm-accent, currentColor);
+  animation: hm-caret-blink 1s steps(2, start) infinite;
+}
+.hm-turn--streaming .hm-turn-kind {
+  color: var(--hm-accent, var(--hm-muted));
+}
+@keyframes hm-caret-blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .hm-turn-caret { animation: none; }
+}
+
 /* Pinned context card inside a Hermes turn */
 .hm-turn-pin {
   display: grid;

--- a/services/slack-operator/src/hermes-session-client.ts
+++ b/services/slack-operator/src/hermes-session-client.ts
@@ -19,9 +19,13 @@
  * transport and then the canned template — the co-pilot never breaks.
  *
  * Live SSE streaming (`POST /api/sessions/{id}/chat/stream`; events
- * `assistant.delta {message_id, delta}` … `run.completed {session_id, messages,
- * usage}`) is a documented follow-up for live-token display. This client uses
- * the synchronous turn, which is simpler and carries the full agentic result.
+ * `assistant.delta {message_id, delta}` … terminal `run.completed {session_id,
+ * messages, usage}`) is implemented by `streamHermesSessionTurn` /
+ * `chatWithHermesSessionStream` for live-token display in the co-pilot. It is
+ * FLAG-GATED at the caller and DEGRADED-SAFE by the same contract as the sync
+ * path: any failure (no token, non-2xx, timeout, parse error, no terminal
+ * event) returns null so the caller falls back to the synchronous turn — the
+ * co-pilot never breaks. The synchronous turn remains the default transport.
  */
 
 export interface HermesSessionConfig {
@@ -74,6 +78,197 @@ async function postJson(cfg: HermesSessionConfig, path: string, body: unknown): 
   } finally {
     clearTimeout(timer);
   }
+}
+
+/**
+ * POST to a streaming endpoint and return the raw response body as a byte
+ * stream, or null on any failure (no token, missing url, non-2xx, no body,
+ * thrown/aborted). Mirrors `postJson`'s degraded-safe contract but hands back
+ * the SSE stream instead of a parsed JSON body. The caller owns reading +
+ * timing out the stream; `abortSignal` lets it cancel the in-flight request.
+ */
+async function postStream(
+  cfg: HermesSessionConfig,
+  path: string,
+  body: unknown,
+  abortSignal: AbortSignal
+): Promise<ReadableStream<Uint8Array> | null> {
+  if (!cfg.apiToken || !cfg.baseUrl) return null;
+  const url = `${cfg.baseUrl.replace(/\/+$/, "")}${path}`;
+  const fetchImpl = cfg.fetchFn ?? fetch;
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "text/event-stream",
+        authorization: `Bearer ${cfg.apiToken}`,
+      },
+      body: JSON.stringify(body ?? {}),
+      signal: abortSignal,
+    });
+    if (!response.ok || !response.body) return null;
+    return response.body as ReadableStream<Uint8Array>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Split a raw SSE text buffer into complete frames on blank lines, returning
+ * the parsed frames and the trailing partial buffer (a frame that hasn't been
+ * terminated by a blank line yet). Each frame is decoded into its `event` name
+ * and concatenated `data` payload per the SSE grammar (multiple `data:` lines
+ * join with "\n"; lines starting with ":" are comments/keepalives and ignored).
+ * Exported for unit tests.
+ */
+export function parseSseFrames(buffer: string): { frames: SseFrame[]; rest: string } {
+  // Normalize CRLF so the blank-line split is uniform, then peel complete
+  // frames (terminated by a blank line) off the front, leaving any partial.
+  const normalized = buffer.replace(/\r\n/g, "\n");
+  const frames: SseFrame[] = [];
+  let rest = normalized;
+  let sep = rest.indexOf("\n\n");
+  while (sep >= 0) {
+    const raw = rest.slice(0, sep);
+    rest = rest.slice(sep + 2);
+    const frame = parseSseFrame(raw);
+    if (frame) frames.push(frame);
+    sep = rest.indexOf("\n\n");
+  }
+  return { frames, rest };
+}
+
+export interface SseFrame {
+  event: string;
+  data: string;
+}
+
+function parseSseFrame(raw: string): SseFrame | null {
+  let event = "message";
+  const dataLines: string[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line || line.startsWith(":")) continue; // blank or comment/keepalive
+    if (line.startsWith("event:")) {
+      event = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      // The SSE grammar strips exactly one leading space after the colon.
+      dataLines.push(line.slice("data:".length).replace(/^ /, ""));
+    }
+  }
+  if (dataLines.length === 0) return null;
+  return { event, data: dataLines.join("\n") };
+}
+
+/**
+ * Run one agent turn in an existing session over the SSE streaming endpoint.
+ * Calls `onDelta(deltaText)` for each `assistant.delta` frame as tokens arrive,
+ * accumulates the full text, and resolves the final `HermesSessionTurn` (full
+ * text + usage + model via the existing extractors) when the terminal
+ * `run.completed` frame lands. Returns null on ANY failure — no token, non-2xx,
+ * timeout, malformed frame, a stream that ends without `run.completed`, or a
+ * completed turn that yields no text — so the caller falls back to the sync
+ * turn. `onDelta` is best-effort: a throwing callback never breaks the turn.
+ */
+export async function streamHermesSessionTurn(
+  cfg: HermesSessionConfig,
+  sessionId: string,
+  input: string,
+  onDelta: (deltaText: string) => void
+): Promise<HermesSessionTurn | null> {
+  if (!sessionId || !input.trim()) return null;
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  try {
+    const stream = await postStream(
+      cfg,
+      `/api/sessions/${encodeURIComponent(sessionId)}/chat/stream`,
+      { input },
+      controller.signal
+    );
+    if (!stream) return null;
+
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let accumulated = "";
+    let completion: unknown = null;
+
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const { frames, rest } = parseSseFrames(buffer);
+        buffer = rest;
+        for (const frame of frames) {
+          if (frame.event === "assistant.delta") {
+            const delta = extractDeltaText(frame.data);
+            if (delta) {
+              accumulated += delta;
+              emitDelta(onDelta, delta);
+            }
+          } else if (frame.event === "run.completed") {
+            completion = safeParseJson(frame.data);
+          }
+        }
+        if (completion) break; // terminal frame seen — stop reading
+      }
+    } finally {
+      // Best-effort: release the reader / cancel the underlying stream.
+      try {
+        await reader.cancel();
+      } catch {
+        /* stream already closed */
+      }
+    }
+
+    if (!completion) return null; // stream ended without a terminal frame
+
+    // Prefer the authoritative full text from run.completed; fall back to the
+    // deltas we accumulated if the terminal frame carries no message body.
+    const finalText = extractTurnText(completion) ?? (accumulated.trim() || null);
+    if (!finalText) return null;
+    return {
+      sessionId: extractTurnSessionId(completion) ?? sessionId,
+      text: finalText,
+      usage: extractTurnUsage(completion),
+      model: extractTurnModel(completion),
+    };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Streaming sibling of `chatWithHermesSession`: create a session if one isn't
+ * supplied, and if a supplied session id has gone stale (the streamed turn
+ * fails) create a fresh session and retry once. NOTE on deltas across a retry:
+ * a stale first attempt usually emits nothing (it fails before any token) and
+ * the retry then streams cleanly; but a first attempt that emitted partial
+ * tokens before failing will fall through to the retry, so callers that render
+ * deltas must treat the terminal turn's full text as authoritative and reset
+ * their buffer to it. Returns the (possibly new) session id + reply, or null on
+ * failure.
+ */
+export async function chatWithHermesSessionStream(
+  cfg: HermesSessionConfig,
+  input: string,
+  onDelta: (deltaText: string) => void,
+  existingSessionId?: string
+): Promise<HermesSessionTurn | null> {
+  if (!input.trim()) return null;
+  if (existingSessionId) {
+    const turn = await streamHermesSessionTurn(cfg, existingSessionId, input, onDelta);
+    if (turn) return turn;
+    // fall through: stale/invalid session id -> recreate once
+  }
+  const fresh = await createHermesSession(cfg);
+  if (!fresh) return null;
+  return streamHermesSessionTurn(cfg, fresh, input, onDelta);
 }
 
 /** Create an empty Hermes session; returns its id or null on failure. */
@@ -192,6 +387,43 @@ export function extractTurnModel(json: unknown): string | null {
   const root = asRecord(json);
   if (!root) return null;
   return asId(root.model) ?? asId(asRecord(root.message)?.model) ?? asId(asRecord(root.usage)?.model);
+}
+
+/**
+ * Pull the incremental text out of an `assistant.delta` frame's data. The
+ * gateway sends `{message_id, delta}` where `delta` is the token text; we also
+ * tolerate a bare string payload or a `{delta: {content}}` / `{text}` shape so a
+ * minor wire drift degrades to "" (no delta) rather than throwing.
+ */
+function extractDeltaText(data: string): string {
+  const json = safeParseJson(data);
+  if (typeof json === "string") return json;
+  const root = asRecord(json);
+  if (!root) return "";
+  if (typeof root.delta === "string") return root.delta;
+  const nested = asRecord(root.delta);
+  const fromNested = asText(nested?.content) ?? asText(nested?.text);
+  if (fromNested) return fromNested;
+  return asText(root.text) ?? asText(root.content) ?? "";
+}
+
+/** Invoke the delta callback without letting a throwing subscriber break the turn. */
+function emitDelta(onDelta: (deltaText: string) => void, delta: string): void {
+  try {
+    onDelta(delta);
+  } catch {
+    /* subscriber threw — never break the stream over a bad callback */
+  }
+}
+
+function safeParseJson(data: string): unknown {
+  const trimmed = data.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
 }
 
 function asRecord(v: unknown): Record<string, unknown> | undefined {

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -133,9 +133,15 @@ import {
   generateHermesBoardNarration,
   generateHermesReply,
   generateHermesReplyViaSession,
+  generateHermesReplyViaSessionStream,
   requestHermesCompletion,
   resolveHermesSessionConfig,
 } from "./monitor-hermes-voice.js";
+import {
+  emitCopilotStreamEvent,
+  onCopilotStreamEvent,
+  type CopilotStreamEvent,
+} from "./monitor-copilot-stream.js";
 import {
   fallbackHermesRouterNarration,
   routerCorrelationId,
@@ -1413,6 +1419,10 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
   // Null unless HERMES_SESSION_API_ENABLED + URL + token are all set, so the
   // default transport stays the Ollama completion below.
   const sessionConfig = resolveHermesSessionConfig();
+  // Live-token streaming for the co-pilot's Hermes reply. FLAG-GATED (default
+  // off) and only meaningful when a gateway session config resolves. When off,
+  // the reply falls through to the sync session turn exactly as before.
+  const streamingEnabled = /^(1|true|yes|on)$/i.test((optionalEnv("HERMES_COPILOT_STREAMING") ?? "").trim());
 
   const timer = setTimeout(async () => {
     let text = draft.text;
@@ -1438,6 +1448,12 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       ...(board ? { board } : {}),
     };
     const memoryRequest = classifyHermesMemoryRequest(operatorMessage);
+    // Stable id correlating this turn's deltas + terminal event on the SSE, and
+    // whether we broadcast at least one live token. Declared at the callback
+    // scope so the terminal-event emit below (outside the transport branch) can
+    // finalize the frontend's in-progress bubble even on a mid-stream fallback.
+    const turnId = `hermes-turn-${operatorMessage.id}`;
+    let sawStreamDelta = false;
     if (draft.force) {
       text = draft.text;
     } else if (memoryRequest !== "none") {
@@ -1449,7 +1465,28 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
       // sessionConfig is set (flag-gated); otherwise this is a no-op.
       if (sessionConfig) {
         try {
-          const turn = await generateHermesReplyViaSession(replyContext, sessionConfig, hermesCopilotSessionId, { model });
+          const streamMeta = {
+            addressedTo: draft.addressedTo,
+            ...(draft.relatedPr ? { relatedPr: draft.relatedPr } : {}),
+            ...(draft.relatedCorrelationId ? { relatedCorrelationId: draft.relatedCorrelationId } : {}),
+          };
+          // When streaming is on, forward each token to open board SSE
+          // connections as `hermes.delta`. TRUTH-BOUNDARY: deltas are broadcast
+          // only as they genuinely arrive from the gateway. On any streaming
+          // failure the streaming variant returns null and we fall back to the
+          // sync turn below with no partial/fake tokens surfaced as final.
+          const turn = streamingEnabled
+            ? await generateHermesReplyViaSessionStream(
+                replyContext,
+                sessionConfig,
+                (delta) => {
+                  sawStreamDelta = true;
+                  emitCopilotStreamEvent({ type: "hermes.delta", payload: { turnId, delta, ...streamMeta } });
+                },
+                hermesCopilotSessionId,
+                { model }
+              )
+            : await generateHermesReplyViaSession(replyContext, sessionConfig, hermesCopilotSessionId, { model });
           if (turn) {
             hermesCopilotSessionId = turn.sessionId;
             llmText = turn.text;
@@ -1483,6 +1520,29 @@ function scheduleHermesAutoReply(operatorMessage: Awaited<ReturnType<typeof reco
     }
     if (memoryRequest !== "forget_pr") {
       text = appendHermesWhyTrace(applyHermesMemoryInfluence(text, replyContext), replyContext);
+    }
+    // Terminal live-token event. Fires when streaming was on AND either (a) the
+    // reply came back genuinely live, or (b) we already broadcast partial tokens
+    // for this turn (so the frontend's in-progress bubble MUST be finalized/
+    // cleared rather than left stuck). Carries the AUTHORITATIVE final text +
+    // the REAL hermesMode so the frontend renders exactly the reply the next
+    // collaboration poll will echo — a mid-stream failure that fell back to a
+    // templated reply resolves honestly (real text, "templated" badge), never a
+    // frozen live bubble. When streaming was on but the gateway never streamed a
+    // token (pure fallback), no delta and no live turn ⇒ no terminal event, so a
+    // templated reply is never dressed up as streamed (truth-boundary).
+    if (streamingEnabled && (hermesMode === "live" || sawStreamDelta)) {
+      emitCopilotStreamEvent({
+        type: "hermes.turn.completed",
+        payload: {
+          turnId,
+          text,
+          hermesMode,
+          addressedTo: draft.addressedTo,
+          ...(draft.relatedPr ? { relatedPr: draft.relatedPr } : {}),
+          ...(draft.relatedCorrelationId ? { relatedCorrelationId: draft.relatedCorrelationId } : {}),
+        },
+      });
     }
     try {
       recordCollaborationMessage({
@@ -4196,10 +4256,20 @@ async function writeMonitorV2Stream(
     writeSseEvent(response, "board.card.added", { card, at: new Date().toISOString() });
   });
 
+  // Forward co-pilot live-token events (hermes.delta / hermes.turn.completed) to
+  // this SSE connection. Only emitted when HERMES_COPILOT_STREAMING is on and a
+  // reply genuinely streams from the gateway; otherwise this is a no-op and the
+  // co-pilot reply lands on the next collaboration poll exactly as today.
+  const offCopilot = onCopilotStreamEvent((event: CopilotStreamEvent) => {
+    if (closed) return;
+    writeSseEvent(response, event.type, event.payload);
+  });
+
   request.on("close", () => {
     closed = true;
     if (timer) clearInterval(timer);
     offSpawn();
+    offCopilot();
   });
 
   await send();

--- a/services/slack-operator/src/monitor-copilot-stream.ts
+++ b/services/slack-operator/src/monitor-copilot-stream.ts
@@ -1,0 +1,75 @@
+// Hermes Handoff Monitor — co-pilot live-token event bus (feature #3).
+//
+// A tiny in-process pub/sub that carries the co-pilot's live Hermes reply
+// tokens from the reply handler to every open board SSE connection, mirroring
+// the `onDebugCardSpawned` idiom in monitor-v2-debug.ts. The reply handler
+// emits `hermes.delta` per streamed token and a terminal `hermes.turn.completed`
+// when the turn resolves; `writeMonitorV2Stream` subscribes and forwards each
+// event to the browser via the existing SSE writer.
+//
+// FLAG-GATED + DEGRADED-SAFE: the handler only emits when
+// `HERMES_COPILOT_STREAMING` is truthy AND a gateway session config resolves.
+// When streaming is off, or the stream fails, nothing is emitted here and the
+// co-pilot behaves exactly as today (a single templated/sync reply lands on the
+// next collaboration poll). No fake tokens are ever synthesized.
+
+import type { CollaborationRelatedPr } from "./monitor-collab.js";
+
+/** An incremental token for an in-progress co-pilot Hermes turn. */
+export interface CopilotDeltaEvent {
+  /** Stable id correlating every delta + the terminal event for one turn. */
+  turnId: string;
+  /** The token text to append to the in-progress turn. */
+  delta: string;
+  addressedTo: string;
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+/** The terminal event for a co-pilot Hermes turn: the authoritative full text. */
+export interface CopilotTurnCompletedEvent {
+  turnId: string;
+  /** Full reply text (post-processed), authoritative over the accumulated deltas. */
+  text: string;
+  addressedTo: string;
+  /**
+   * The turn's authoritative provenance. Usually "live" (the streamed reply
+   * completed), but "templated" when the gateway failed mid-stream and the
+   * co-pilot fell back to a canned reply — the frontend then finalizes the
+   * in-progress bubble honestly instead of leaving a stuck live badge.
+   */
+  hermesMode: "live" | "templated";
+  relatedPr?: CollaborationRelatedPr;
+  relatedCorrelationId?: string;
+}
+
+export type CopilotStreamEvent =
+  | { type: "hermes.delta"; payload: CopilotDeltaEvent }
+  | { type: "hermes.turn.completed"; payload: CopilotTurnCompletedEvent };
+
+const subscribers = new Set<(event: CopilotStreamEvent) => void>();
+
+/** Subscribe an SSE connection to co-pilot stream events. Returns an unsubscribe fn. */
+export function onCopilotStreamEvent(fn: (event: CopilotStreamEvent) => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+/** Broadcast one co-pilot stream event to every open SSE connection (best-effort). */
+export function emitCopilotStreamEvent(event: CopilotStreamEvent): void {
+  for (const fn of subscribers) {
+    try {
+      fn(event);
+    } catch {
+      // A throwing subscriber (e.g. a dead SSE socket) must never break the
+      // reply handler or the other subscribers.
+    }
+  }
+}
+
+/** Test/introspection helper: number of currently subscribed SSE connections. */
+export function copilotStreamSubscriberCount(): number {
+  return subscribers.size;
+}

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -31,6 +31,7 @@ import {
 import { logger } from "@avg/mcp-common";
 import {
   chatWithHermesSession,
+  chatWithHermesSessionStream,
   type HermesSessionConfig,
   type HermesSessionTurn,
 } from "./hermes-session-client.js";
@@ -338,24 +339,66 @@ export async function generateHermesReplyViaSession(
   });
   try {
     const turn = await chatWithHermesSession(config, buildUserPrompt(context), sessionId);
-    // Record the agentic turn's token usage so the monitor's usage panel counts
-    // it. The Ollama transport records via requestHermesCompletion; without this
-    // the panel would under-report Hermes once session replies flow.
-    if (turn?.usage) {
-      const model = turn.model ?? usageOptions?.model;
-      await recordLlmUsageFromResult(
-        {
-          agent: "hermes",
-          ...(model ? { model } : {}),
-          result: { usage: turn.usage, ...(turn.model ? { model: turn.model } : {}) },
-        },
-        { path: usageOptions?.usageLogPath ?? llmUsageLogPath() }
-      ).catch((error) => logger.warn({ err: error }, "monitor_session_usage_record_failed"));
-    }
+    await recordHermesSessionTurnUsage(turn, usageOptions);
     return turn;
   } finally {
     endLlmUsageCall();
   }
+}
+
+/**
+ * Live-token variant of `generateHermesReplyViaSession`: streams the agentic
+ * turn over the gateway SSE endpoint, forwarding each token to `onDelta` as it
+ * arrives, and records the turn's usage identically to the sync path. Returns
+ * null on ANY failure so the caller falls back to the synchronous session turn
+ * (and then the Ollama completion, and then the template) — the co-pilot never
+ * breaks. FLAG-GATED at the caller; this function itself has no flag.
+ *
+ * TRUTH-BOUNDARY: deltas are forwarded ONLY as they genuinely stream from the
+ * gateway; if the stream fails before completing, this returns null WITHOUT a
+ * final turn, so the caller renders the eventual sync reply with no fake typing.
+ */
+export async function generateHermesReplyViaSessionStream(
+  context: HermesReplyContext,
+  config: HermesSessionConfig,
+  onDelta: (deltaText: string) => void,
+  sessionId?: string,
+  usageOptions?: { model?: string; usageLogPath?: string }
+): Promise<HermesSessionTurn | null> {
+  const endLlmUsageCall = beginLlmUsageCall({
+    agent: "hermes",
+    ...(usageOptions?.model ? { model: usageOptions.model } : {}),
+  });
+  try {
+    const turn = await chatWithHermesSessionStream(config, buildUserPrompt(context), onDelta, sessionId);
+    await recordHermesSessionTurnUsage(turn, usageOptions);
+    return turn;
+  } finally {
+    endLlmUsageCall();
+  }
+}
+
+/**
+ * Record an agentic turn's token usage so the monitor's usage panel counts it.
+ * The Ollama transport records via requestHermesCompletion; without this the
+ * panel would under-report Hermes once session replies flow. Shared by the sync
+ * and streaming session variants so both count identically. No-op when the turn
+ * is null or carries no usage.
+ */
+async function recordHermesSessionTurnUsage(
+  turn: HermesSessionTurn | null,
+  usageOptions?: { model?: string; usageLogPath?: string }
+): Promise<void> {
+  if (!turn?.usage) return;
+  const model = turn.model ?? usageOptions?.model;
+  await recordLlmUsageFromResult(
+    {
+      agent: "hermes",
+      ...(model ? { model } : {}),
+      result: { usage: turn.usage, ...(turn.model ? { model: turn.model } : {}) },
+    },
+    { path: usageOptions?.usageLogPath ?? llmUsageLogPath() }
+  ).catch((error) => logger.warn({ err: error }, "monitor_session_usage_record_failed"));
 }
 
 export function buildUserPrompt(context: HermesReplyContext): string {

--- a/test/unit/hermes-session-client.test.ts
+++ b/test/unit/hermes-session-client.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   chatWithHermesSession,
+  chatWithHermesSessionStream,
   createHermesSession,
   extractSessionId,
   extractTurnText,
   forkHermesSession,
+  parseSseFrames,
   runHermesSessionTurn,
+  streamHermesSessionTurn,
   type HermesSessionConfig,
 } from "../../services/slack-operator/src/hermes-session-client.js";
 
@@ -186,5 +189,186 @@ describe("extractors tolerate shape drift", () => {
     expect(extractTurnText({ messages: [{ role: "assistant", content: "last" }] })).toBe("last");
     expect(extractTurnText({ message: { content: "   " } })).toBeNull();
     expect(extractTurnText({})).toBeNull();
+  });
+});
+
+// --- SSE streaming -----------------------------------------------------------
+
+/** Encode named SSE frames into a wire string (the shape the gateway sends). */
+function sseFrame(event: string, data: unknown): string {
+  const payload = typeof data === "string" ? data : JSON.stringify(data);
+  return `event: ${event}\ndata: ${payload}\n\n`;
+}
+
+/**
+ * Build a mock streaming Response whose `body` is a ReadableStream that yields
+ * `chunks` as UTF-8 bytes (each chunk may hold zero, one, or several — even
+ * partial — SSE frames, so the reader's buffering is exercised).
+ */
+function streamResponse(chunks: string[], init?: { ok?: boolean; status?: number; noBody?: boolean }): Response {
+  const encoder = new TextEncoder();
+  const body = init?.noBody
+    ? null
+    : new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+          controller.close();
+        },
+      });
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    body,
+  } as unknown as Response;
+}
+
+describe("parseSseFrames", () => {
+  it("splits complete frames on blank lines and returns the trailing partial", () => {
+    const { frames, rest } = parseSseFrames(
+      "event: assistant.delta\ndata: {\"delta\":\"a\"}\n\nevent: assistant.delta\ndata: {\"delta\":\"b\"}\n\nevent: run.compl",
+    );
+    expect(frames).toEqual([
+      { event: "assistant.delta", data: '{"delta":"a"}' },
+      { event: "assistant.delta", data: '{"delta":"b"}' },
+    ]);
+    expect(rest).toBe("event: run.compl");
+  });
+
+  it("joins multi-line data, ignores comments/keepalives, and normalizes CRLF", () => {
+    const { frames } = parseSseFrames("event: x\r\ndata: line1\r\ndata: line2\r\n\r\n");
+    expect(frames).toEqual([{ event: "x", data: "line1\nline2" }]);
+    // A comment-only frame (":" line) carries no data and is dropped.
+    expect(parseSseFrames(": keepalive\n\n").frames).toEqual([]);
+  });
+});
+
+describe("streamHermesSessionTurn", () => {
+  it("calls onDelta per assistant.delta and returns the final turn from run.completed", async () => {
+    const { fetchFn, calls } = mockFetch([
+      streamResponse([
+        sseFrame("assistant.delta", { message_id: "m1", delta: "Hello" }),
+        sseFrame("assistant.delta", { message_id: "m1", delta: ", world" }),
+        sseFrame("run.completed", {
+          session_id: "s1",
+          message: { role: "assistant", content: "Hello, world" },
+          usage: { input_tokens: 3, output_tokens: 5 },
+          model: "glm-5.2:cloud",
+        }),
+      ]),
+    ]);
+    const deltas: string[] = [];
+    const turn = await streamHermesSessionTurn(cfg(fetchFn), "s1", "hi", (d) => deltas.push(d));
+
+    expect(deltas).toEqual(["Hello", ", world"]);
+    expect(turn).toMatchObject({
+      sessionId: "s1",
+      text: "Hello, world",
+      usage: { input_tokens: 3, output_tokens: 5 },
+      model: "glm-5.2:cloud",
+    });
+    // Posts to the streaming endpoint with bearer auth + { input }.
+    expect(calls[0]!.url).toBe("http://gw:8642/api/sessions/s1/chat/stream");
+    expect(calls[0]!.method).toBe("POST");
+    expect(calls[0]!.body).toEqual({ input: "hi" });
+    expect(calls[0]!.auth).toBe("Bearer tok");
+  });
+
+  it("reassembles frames split across chunk boundaries", async () => {
+    const full =
+      sseFrame("assistant.delta", { delta: "abc" }) +
+      sseFrame("run.completed", { session_id: "s1", message: { content: "abc" } });
+    // Slice the wire mid-frame so the reader must buffer across chunks.
+    const cut = 12;
+    const { fetchFn } = mockFetch([streamResponse([full.slice(0, cut), full.slice(cut)])]);
+    const deltas: string[] = [];
+    const turn = await streamHermesSessionTurn(cfg(fetchFn), "s1", "hi", (d) => deltas.push(d));
+    expect(deltas).toEqual(["abc"]);
+    expect(turn?.text).toBe("abc");
+  });
+
+  it("falls back to accumulated deltas when run.completed carries no message body", async () => {
+    const { fetchFn } = mockFetch([
+      streamResponse([
+        sseFrame("assistant.delta", { delta: "par" }),
+        sseFrame("assistant.delta", { delta: "tial" }),
+        sseFrame("run.completed", { session_id: "s1", usage: {} }),
+      ]),
+    ]);
+    const turn = await streamHermesSessionTurn(cfg(fetchFn), "s1", "hi", () => {});
+    expect(turn?.text).toBe("partial");
+  });
+
+  it("returns null when the stream ends without a run.completed frame", async () => {
+    const { fetchFn } = mockFetch([
+      streamResponse([sseFrame("assistant.delta", { delta: "x" })]),
+    ]);
+    const deltas: string[] = [];
+    const turn = await streamHermesSessionTurn(cfg(fetchFn), "s1", "hi", (d) => deltas.push(d));
+    expect(deltas).toEqual(["x"]); // deltas still fired
+    expect(turn).toBeNull(); // but no authoritative turn → caller falls back
+  });
+
+  it("returns null on a non-2xx response, a missing body, no token, and empty input", async () => {
+    const nonOk = mockFetch([streamResponse([], { ok: false, status: 500 })]);
+    expect(await streamHermesSessionTurn(cfg(nonOk.fetchFn), "s1", "hi", () => {})).toBeNull();
+
+    const noBody = mockFetch([streamResponse([], { noBody: true })]);
+    expect(await streamHermesSessionTurn(cfg(noBody.fetchFn), "s1", "hi", () => {})).toBeNull();
+
+    const noToken = mockFetch([streamResponse([sseFrame("run.completed", { message: { content: "x" } })])]);
+    expect(
+      await streamHermesSessionTurn({ baseUrl: "http://gw:8642", apiToken: "", fetchFn: noToken.fetchFn }, "s1", "hi", () => {}),
+    ).toBeNull();
+    expect(noToken.calls).toHaveLength(0);
+
+    const emptyInput = mockFetch([streamResponse([sseFrame("run.completed", { message: { content: "x" } })])]);
+    expect(await streamHermesSessionTurn(cfg(emptyInput.fetchFn), "s1", "   ", () => {})).toBeNull();
+    expect(emptyInput.calls).toHaveLength(0);
+  });
+
+  it("tolerates a malformed delta frame (ignores it) and a throwing onDelta", async () => {
+    const { fetchFn } = mockFetch([
+      streamResponse([
+        "event: assistant.delta\ndata: {not json\n\n", // malformed → no delta
+        sseFrame("assistant.delta", { delta: "ok" }),
+        sseFrame("run.completed", { message: { content: "ok" } }),
+      ]),
+    ]);
+    // A callback that throws must never break the turn.
+    const turn = await streamHermesSessionTurn(cfg(fetchFn), "s1", "hi", () => {
+      throw new Error("subscriber blew up");
+    });
+    expect(turn?.text).toBe("ok");
+  });
+
+  it("returns null when fetch itself throws", async () => {
+    const { fetchFn } = mockFetch([new Error("ECONNRESET")]);
+    expect(await streamHermesSessionTurn(cfg(fetchFn), "s1", "hi", () => {})).toBeNull();
+  });
+});
+
+describe("chatWithHermesSessionStream", () => {
+  it("creates a session then streams the turn when no id is supplied", async () => {
+    const { fetchFn, calls } = mockFetch([
+      jsonResponse({ session: { id: "s2" } }),
+      streamResponse([sseFrame("run.completed", { session_id: "s2", message: { content: "reply" } })]),
+    ]);
+    const turn = await chatWithHermesSessionStream(cfg(fetchFn), "hi", () => {});
+    expect(turn).toMatchObject({ sessionId: "s2", text: "reply" });
+    expect(calls.map((c) => c.url)).toEqual([
+      "http://gw:8642/api/sessions",
+      "http://gw:8642/api/sessions/s2/chat/stream",
+    ]);
+  });
+
+  it("recreates the session once when the supplied id is stale, then retries the stream", async () => {
+    const { fetchFn, calls } = mockFetch([
+      streamResponse([], { ok: false, status: 404 }), // stale id stream fails
+      jsonResponse({ session: { id: "s3" } }), // recreate
+      streamResponse([sseFrame("run.completed", { session_id: "s3", message: { content: "healed" } })]),
+    ]);
+    const turn = await chatWithHermesSessionStream(cfg(fetchFn), "hi", () => {}, "stale");
+    expect(turn).toMatchObject({ sessionId: "s3", text: "healed" });
+    expect(calls).toHaveLength(3);
   });
 });

--- a/test/unit/hermes-session-voice.test.ts
+++ b/test/unit/hermes-session-voice.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import {
   generateHermesReplyViaSession,
+  generateHermesReplyViaSessionStream,
   resolveHermesSessionConfig,
   type HermesReplyContext,
 } from "../../services/slack-operator/src/monitor-hermes-voice.js";
@@ -67,5 +71,81 @@ describe("generateHermesReplyViaSession", () => {
   it("returns null when the gateway is unreachable (caller falls back to Ollama)", async () => {
     const cfg = { baseUrl: "http://gw:8642", apiToken: "tok", fetchFn: fetchReturning({}, false) };
     expect(await generateHermesReplyViaSession(context, cfg)).toBeNull();
+  });
+});
+
+describe("generateHermesReplyViaSessionStream", () => {
+  const context: HermesReplyContext = {
+    operatorMessage: { text: "what's the state of the board?", addressedTo: "hermes", kind: "chat" },
+    recentMessages: [],
+  };
+
+  function sseFrame(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+  function streamBody(chunks: string[]): ReadableStream<Uint8Array> {
+    const encoder = new TextEncoder();
+    return new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const c of chunks) controller.enqueue(encoder.encode(c));
+        controller.close();
+      },
+    });
+  }
+  /** Sequenced mock: JSON for /api/sessions, an SSE body for /chat/stream. */
+  function sequencedFetch(streamChunks: string[]): typeof fetch {
+    let i = 0;
+    return (async (url: unknown) => {
+      i += 1;
+      if (String(url).endsWith("/chat/stream")) {
+        return { ok: true, status: 200, body: streamBody(streamChunks) } as unknown as Response;
+      }
+      return { ok: true, status: 200, json: async () => ({ session: { id: "s9" } }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("streams deltas to onDelta and returns the finalized turn (usage recorded like sync)", async () => {
+    const cfg = {
+      baseUrl: "http://gw:8642",
+      apiToken: "tok",
+      fetchFn: sequencedFetch([
+        sseFrame("assistant.delta", { delta: "Operator review " }),
+        sseFrame("assistant.delta", { delta: "has 2 cards." }),
+        sseFrame("run.completed", {
+          session_id: "s9",
+          message: { content: "Operator review has 2 cards." },
+          usage: { input_tokens: 10, output_tokens: 6 },
+        }),
+      ]),
+    };
+    const deltas: string[] = [];
+    // Point usage recording at a temp JSONL so the shared recorder writes there
+    // instead of the container's /data path (keeps test output clean + proves
+    // the streaming path records usage exactly like the sync path).
+    const usageLogPath = join(tmpdir(), `hermes-stream-usage-${Date.now()}.jsonl`);
+    const turn = await generateHermesReplyViaSessionStream(context, cfg, (d) => deltas.push(d), undefined, {
+      usageLogPath,
+    });
+    expect(deltas).toEqual(["Operator review ", "has 2 cards."]);
+    expect(turn?.sessionId).toBe("s9");
+    expect(turn?.text).toBe("Operator review has 2 cards.");
+    // Usage was recorded (a non-empty JSONL line with the token counts).
+    const recorded = readFileSync(usageLogPath, "utf8").trim();
+    expect(recorded).toContain("output");
+    rmSync(usageLogPath, { force: true });
+  });
+
+  it("returns null on a streaming failure so the caller falls back to the sync path", async () => {
+    // Gateway reachable for session creation, but the stream 500s → null.
+    const failingStream = (async (url: unknown) => {
+      if (String(url).endsWith("/chat/stream")) {
+        return { ok: false, status: 500, body: null } as unknown as Response;
+      }
+      return { ok: true, status: 200, json: async () => ({ session: { id: "s9" } }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+    const cfg = { baseUrl: "http://gw:8642", apiToken: "tok", fetchFn: failingStream };
+    const deltas: string[] = [];
+    expect(await generateHermesReplyViaSessionStream(context, cfg, (d) => deltas.push(d))).toBeNull();
+    expect(deltas).toEqual([]); // no tokens surfaced on failure
   });
 });

--- a/test/unit/monitor-copilot-stream.test.ts
+++ b/test/unit/monitor-copilot-stream.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  copilotStreamSubscriberCount,
+  emitCopilotStreamEvent,
+  onCopilotStreamEvent,
+  type CopilotStreamEvent,
+} from "../../services/slack-operator/src/monitor-copilot-stream.js";
+
+describe("monitor-copilot-stream event bus", () => {
+  it("broadcasts events to every subscriber and unsubscribes cleanly", () => {
+    const a: CopilotStreamEvent[] = [];
+    const b: CopilotStreamEvent[] = [];
+    const offA = onCopilotStreamEvent((e) => a.push(e));
+    const offB = onCopilotStreamEvent((e) => b.push(e));
+    expect(copilotStreamSubscriberCount()).toBe(2);
+
+    const delta: CopilotStreamEvent = {
+      type: "hermes.delta",
+      payload: { turnId: "t1", delta: "hi", addressedTo: "everyone" },
+    };
+    emitCopilotStreamEvent(delta);
+    expect(a).toEqual([delta]);
+    expect(b).toEqual([delta]);
+
+    offA();
+    expect(copilotStreamSubscriberCount()).toBe(1);
+    const completed: CopilotStreamEvent = {
+      type: "hermes.turn.completed",
+      payload: { turnId: "t1", text: "hi there", hermesMode: "live", addressedTo: "everyone" },
+    };
+    emitCopilotStreamEvent(completed);
+    expect(a).toEqual([delta]); // unsubscribed → no further events
+    expect(b).toEqual([delta, completed]);
+
+    offB();
+    expect(copilotStreamSubscriberCount()).toBe(0);
+  });
+
+  it("a throwing subscriber never breaks the broadcast to the others", () => {
+    const received: CopilotStreamEvent[] = [];
+    const offBad = onCopilotStreamEvent(() => {
+      throw new Error("dead socket");
+    });
+    const offGood = onCopilotStreamEvent((e) => received.push(e));
+
+    const event: CopilotStreamEvent = { type: "hermes.delta", payload: { turnId: "t", delta: "x", addressedTo: "everyone" } };
+    expect(() => emitCopilotStreamEvent(event)).not.toThrow();
+    expect(received).toEqual([event]);
+
+    offBad();
+    offGood();
+  });
+
+  it("emitting with no subscribers is a no-op", () => {
+    expect(copilotStreamSubscriberCount()).toBe(0);
+    expect(() =>
+      emitCopilotStreamEvent({ type: "hermes.delta", payload: { turnId: "t", delta: "x", addressedTo: "everyone" } }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What shipped

Live token streaming for the monitor co-pilot's **"Ask Hermes"** replies, over the Hermes gateway Session API's SSE endpoint (`POST /api/sessions/{id}/chat/stream`). When enabled, Hermes's reply renders token-by-token in the co-pilot rail instead of landing whole on the next poll.

- **FLAG-GATED, default OFF** — `HERMES_COPILOT_STREAMING` (truthy: `1|true|yes|on`). Only meaningful when the gateway session transport (`HERMES_SESSION_API_ENABLED` + URL + token) already resolves.
- **DEGRADED-SAFE** — flag off, or ANY streaming failure (no token, non-2xx, timeout, parse error, no terminal frame) returns null and the co-pilot falls back to the exact path it uses today: sync session turn → Ollama completion → canned template. The sync path is byte-for-byte unchanged.
- **TRUTH-BOUNDARY** — the "streaming…" caret shows **only** while genuine tokens arrive from the gateway; it is never a fake typing animation for templated replies. A stream that fails mid-flight finalizes the bubble honestly with its **real** `hermesMode` badge (`live` vs `templated`) — no stuck "streaming…" state, no live badge on a canned reply.

## How it works

**Backend transport**
- `hermes-session-client.ts`: `streamHermesSessionTurn` + `chatWithHermesSessionStream` (SSE POST sibling of `postJson`; `parseSseFrames` splits frames on blank lines; `onDelta` per `assistant.delta`; final `HermesSessionTurn` from `run.completed` via the existing extractors; null on any failure; create-if-needed + stale-session retry-once).
- `monitor-hermes-voice.ts`: `generateHermesReplyViaSessionStream` mirrors the sync variant, records usage identically (shared `recordHermesSessionTurnUsage`), returns null to let the caller fall back. Sync `generateHermesReplyViaSession` unchanged.
- `index.ts`: the co-pilot handler uses the streaming variant when the flag is on **and** a session config resolves, emitting `hermes.delta` / `hermes.turn.completed` (stable `turnId`) on a new in-process bus (`monitor-copilot-stream.ts`); `writeMonitorV2Stream` forwards them to open board SSE connections — mirrors the existing `onDebugCardSpawned` idiom.

**Frontend (minimal, honest)**
- `useCollaboration` consumes the two events via a dependency-injected delta source (EventSource-backed default, opt-in via `live`; `MonitorPage` enables it by default). Deltas accumulate into an in-progress Hermes turn; the terminal event finalizes it; it's reconciled away once the poll echoes the finalized reply (same discipline as optimistic operator messages) — never rendered twice.
- `HermesTurn` shows a subtle blinking caret + "streaming…" only while streaming, `aria-busy` while live, and preserves the existing live/templated honesty badge. Reduced-motion respected.

## Tests (all green)

```
npx tsc -b packages/averray-mcp services/slack-operator packages/monitor-ui   # clean
npx vitest run \
  test/unit/hermes-session-client.test.ts \
  test/unit/hermes-session-voice.test.ts \
  test/unit/monitor-copilot-stream.test.ts \
  packages/monitor-ui/src/hooks/useCollaboration.test.tsx \
  packages/monitor-ui/src/components/hermes/HermesTurn.test.tsx
# 5 files, 65 tests passed
```

Also verified no regressions: full `monitor-ui` suite **702 passed (69 files)**; backend hermes/collab suites (incl. pre-existing sync usage + voice) **85 passed**; Vite production bundle builds clean.

Coverage added: SSE frame parser; streaming client (onDelta calls, final text/usage/model, frames split across chunk boundaries, fallback-to-accumulated-deltas, null on malformed/non-2xx/no-body/no-token/empty-input/no-terminal/thrown-fetch, stale-session retry); voice streaming fallback + usage recording; the delta-event bus (broadcast/unsubscribe/throwing-subscriber); the hook's delta accumulation → finalize → reconcile-on-echo → honest-templated-fallback → degraded-safe-no-events → unmount; the streaming affordance render.

## Config

`ops/compose.yml` slack-operator: `HERMES_COPILOT_STREAMING: ${HERMES_COPILOT_STREAMING:-0}`.

## Scope / truth-boundary decisions

- **Delivery channel**: the co-pilot rail is poll-based (`useCollaboration`), decoupled from the board V2 SSE. Rather than build a bespoke transport, deltas ride the **existing** board SSE (`/monitor/v2/stream`) via a small in-process bus — the narrowest path that reaches the browser and matches the `onDebugCardSpawned` pattern.
- **Second EventSource**: the frontend delta source opens its own lightweight EventSource on the same stream URL (mirrors the board stream's default no-token posture). Threading the board hook's `LiveStream` through `MonitorPage → BoardView → CoPilotRail` would have bloated the PR; a second SSE connection is cheap and fully DI/degraded-safe. Noted here as the one deferred-polish option if connection-count ever matters.
- **Mid-stream fallback**: emits a terminal event whenever tokens were broadcast (even on fallback) so the in-progress bubble is finalized with the authoritative text + real mode — chosen over leaving a truthful-but-stuck "streaming…" bubble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)