### PR TITLE
Anti-entrenchment exploration for learned routing (flag-gated, Tier-3 #6)

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -230,6 +230,13 @@ services:
       HERMES_ROUTER_COOLDOWN_MINUTES: ${HERMES_ROUTER_COOLDOWN_MINUTES:-30}
       HERMES_ROUTER_MAX_PROPOSALS_PER_TICK: ${HERMES_ROUTER_MAX_PROPOSALS_PER_TICK:-1}
       HERMES_ROUTER_RECENTLY_DONE_LOOKBACK_HOURS: ${HERMES_ROUTER_RECENTLY_DONE_LOOKBACK_HOURS:-72}
+      # ORCH-P4c anti-entrenchment (learned routing). When ON, learned routing
+      # occasionally routes a soft surface to an under-sampled *allowed* agent so
+      # it can build a baseline the classifier's default would otherwise starve —
+      # deterministic, bounded, soft-surfaces-only, always explained on the card.
+      # OFF by default; the hard Codex wall + dispatch policy are never affected,
+      # and every explored task is still operator-approved before it runs.
+      HERMES_ROUTER_ANTI_ENTRENCHMENT: ${HERMES_ROUTER_ANTI_ENTRENCHMENT:-0}
       HERMES_ROUTER_BACKLOG_LIMIT: ${HERMES_ROUTER_BACKLOG_LIMIT:-12}
       HERMES_ROUTER_DEFAULT_REPO: ${HERMES_ROUTER_DEFAULT_REPO:-}
       SLACK_OPERATOR_MONITOR_ENABLED: ${SLACK_OPERATOR_MONITOR_ENABLED:-0}

--- a/packages/averray-mcp/src/work-router.ts
+++ b/packages/averray-mcp/src/work-router.ts
@@ -56,6 +56,14 @@ export interface PlanAndRouteWorkInput {
   classify: WorkRouterClassifier;
   /** ORCH-P4c: learned scorecard memory. Used only on soft surfaces. */
   routingScores?: WorkRouterRoutingScores;
+  /**
+   * ORCH-P4c anti-entrenchment (flag-gated, default off). When true, learned
+   * routing occasionally routes a soft surface to an under-explored *allowed*
+   * agent so it can build a baseline the classifier's default would otherwise
+   * starve. Off ⇒ learned routing is pure exploitation (today's behavior). The
+   * hard taxonomy wall is never affected either way.
+   */
+  explore?: boolean;
   maxProposals?: number;
 }
 
@@ -123,7 +131,10 @@ export function planAndRouteWork(input: PlanAndRouteWorkInput): RoutedProposal[]
         note: `Hermes suggested ${suggested} for this soft surface.${learnedAgent !== suggested ? ` (classifier/learned leaned ${learnedAgent})` : ""}`,
       };
     } else {
-      choice = learnedRoutingChoice(surface, classifiedAgent, input.routingScores);
+      choice = learnedRoutingChoice(surface, classifiedAgent, input.routingScores, {
+        explore: input.explore,
+        allowedAgents: input.policy.allowedAgents,
+      });
     }
     const agent = choice.agent;
     assertTaxonomy(surface, title, agent);
@@ -206,6 +217,7 @@ function learnedRoutingChoice(
   surface: string,
   staticAgent: RoutedWorkAgent,
   routingScores: WorkRouterRoutingScores | undefined,
+  opts: { explore?: boolean; allowedAgents?: readonly string[] } = {},
 ): { agent: RoutedWorkAgent; note?: string } {
   const normalizedSurface = normalizeText(surface);
   const surfaceScores = routingScores?.[normalizedSurface];
@@ -213,6 +225,29 @@ function learnedRoutingChoice(
   const otherAgent: RoutedWorkAgent = staticAgent === "codex" ? "claude" : "codex";
   const staticScore = surfaceScores[staticAgent];
   const otherScore = surfaceScores[otherAgent];
+
+  // ORCH-P4c anti-entrenchment (flag-gated via opts.explore; deterministic).
+  // The exploitation rules below only fire when BOTH agents have a baseline, so
+  // an agent the classifier never routes to can never earn samples — leaving
+  // learned routing permanently locked on the classifier's default. When the
+  // static agent is established but the OTHER agent is under-explored, route ONE
+  // exploratory task to it so it can build a baseline. Bounded: once it reaches
+  // the sample floor it becomes baseline_available and normal exploitation
+  // resumes (at most ~EXPLORATION_MIN_SAMPLES explorations per surface/agent).
+  // Soft surfaces only (this fn is never reached on the hard wall); never routes
+  // to a dispatch-policy-blocked agent; always explained in the note.
+  if (
+    opts.explore &&
+    agentAllowed(otherAgent, opts.allowedAgents) &&
+    isEstablishedRoutingScore(staticScore) &&
+    isUnderExploredRoutingScore(otherScore)
+  ) {
+    return {
+      agent: otherAgent,
+      note: `Anti-entrenchment: routing explored ${otherAgent} for ${normalizedSurface || "general"} to build a baseline (${otherAgent} has ${routingScoreSamples(otherScore)} sample(s) vs ${staticAgent}'s ${staticScore.samples}); learned routing needs data on both agents before it can compare them.`,
+    };
+  }
+
   if (!isUsableRoutingScore(staticScore) || !isUsableRoutingScore(otherScore)) {
     return {
       agent: staticAgent,
@@ -233,6 +268,30 @@ function learnedRoutingChoice(
 
 function isUsableRoutingScore(score: WorkRouterRoutingScore | undefined): score is WorkRouterRoutingScore & { score: number } {
   return score?.status === "baseline_available" && typeof score.score === "number" && Number.isFinite(score.score);
+}
+
+/** Sample floor for a usable baseline; mirrors the scorecard's ROUTING_SCORE_MIN_SAMPLES. */
+const EXPLORATION_MIN_SAMPLES = 2;
+
+/** Established = a usable baseline built from at least the sample floor. */
+function isEstablishedRoutingScore(
+  score: WorkRouterRoutingScore | undefined,
+): score is WorkRouterRoutingScore & { score: number } {
+  return isUsableRoutingScore(score) && score.samples >= EXPLORATION_MIN_SAMPLES;
+}
+
+/** Under-explored = absent, or fewer real samples than the floor (nothing to compare). */
+function isUnderExploredRoutingScore(score: WorkRouterRoutingScore | undefined): boolean {
+  return !score || score.samples < EXPLORATION_MIN_SAMPLES;
+}
+
+function routingScoreSamples(score: WorkRouterRoutingScore | undefined): number {
+  return score?.samples ?? 0;
+}
+
+/** A soft-surface exploration must never route to a dispatch-policy-blocked agent. */
+function agentAllowed(agent: RoutedWorkAgent, allowedAgents: readonly string[] | undefined): boolean {
+  return !allowedAgents || allowedAgents.includes(agent);
 }
 
 function matchesAny(haystack: string, needles: string[]): boolean {

--- a/services/slack-operator/src/hermes-router-routine.ts
+++ b/services/slack-operator/src/hermes-router-routine.ts
@@ -22,6 +22,12 @@ export interface HermesRouterConfig {
   cooldownMs: number;
   maxProposalsPerTick: number;
   lookbackMs: number;
+  /**
+   * ORCH-P4c anti-entrenchment (flag-gated, default off). Passed to
+   * planAndRouteWork so learned routing can explore under-sampled agents on soft
+   * surfaces. The hard taxonomy wall + dispatch policy are unaffected.
+   */
+  explore?: boolean;
 }
 
 export interface HermesRouterAuditRecord {
@@ -85,6 +91,7 @@ export async function runHermesRouterOnce(config: HermesRouterConfig, deps: Herm
     policy: buildPolicySnapshot(policy, tasks, now),
     classify: deps.classify,
     ...(routingScores ? { routingScores } : {}),
+    ...(config.explore ? { explore: true } : {}),
     maxProposals: config.maxProposalsPerTick,
   });
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3509,6 +3509,7 @@ function startOperatorRoutines() {
         cooldownMs: routineConfig.hermesRouter.cooldownMs,
         maxProposalsPerTick: routineConfig.hermesRouter.maxProposalsPerTick,
         lookbackMs: routineConfig.hermesRouter.lookbackHours * 60 * 60_000,
+        explore: routineConfig.hermesRouter.explore,
       }, {
         getBacklog: () => collectHermesRouterBacklogAugmented(),
         listTasks: () => listCodexTasks(),

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -65,6 +65,7 @@ export interface SlackRoutineConfig {
     cooldownMs: number;
     maxProposalsPerTick: number;
     lookbackHours: number;
+    explore: boolean;
   };
 }
 
@@ -144,6 +145,8 @@ export function parseSlackRoutineConfig(
       cooldownMs: Math.max(60_000, (positiveNumber(env.HERMES_ROUTER_COOLDOWN_MINUTES) || 30) * 60_000),
       maxProposalsPerTick: Math.max(1, positiveNumber(env.HERMES_ROUTER_MAX_PROPOSALS_PER_TICK) || 1),
       lookbackHours: Math.max(1, positiveNumber(env.HERMES_ROUTER_RECENTLY_DONE_LOOKBACK_HOURS) || 72),
+      // ORCH-P4c anti-entrenchment: learned routing explores under-sampled agents on soft surfaces.
+      explore: env.HERMES_ROUTER_ANTI_ENTRENCHMENT === "1",
     },
   };
 }

--- a/test/unit/work-router.test.ts
+++ b/test/unit/work-router.test.ts
@@ -269,6 +269,99 @@ describe("planAndRouteWork — Hermes soft-surface agent suggestion (B)", () => 
   });
 });
 
+describe("planAndRouteWork — learned-routing anti-entrenchment exploration (ORCH-P4c)", () => {
+  // The classifier defaults "ops hygiene" (a soft surface) to claude, so
+  // staticAgent = claude and the under-dog is codex. Exploration should give the
+  // under-sampled codex a chance to build a baseline — but only when opted in.
+  const undersampledCodex = {
+    "ops hygiene": {
+      claude: { status: "baseline_available" as const, score: 70, samples: 4 },
+      codex: { status: "insufficient_data" as const, score: null, samples: 1 },
+    },
+  };
+
+  it("explores the under-sampled agent on a soft surface so it can build a baseline", () => {
+    const proposals = planAndRouteWork(input({
+      explore: true,
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: undersampledCodex,
+    }));
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.agent).toBe("codex"); // classifier leaned claude; exploration routes the under-sampled codex
+    expect(proposals[0]!.whyAgent).toContain("Anti-entrenchment");
+    expect(proposals[0]!.whyAgent).toContain("explored codex");
+  });
+
+  it("does not explore when the flag is off — learned routing stays pure exploitation", () => {
+    const proposals = planAndRouteWork(input({
+      // explore omitted → default off
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: undersampledCodex,
+    }));
+    expect(proposals[0]!.agent).toBe("claude"); // insufficient-data fallback keeps the classifier's pick
+    expect(proposals[0]!.whyAgent).not.toContain("Anti-entrenchment");
+    expect(proposals[0]!.whyAgent).toContain("insufficient ops hygiene data");
+  });
+
+  it("stops exploring once the under-dog has a baseline (exploitation resumes)", () => {
+    const proposals = planAndRouteWork(input({
+      explore: true,
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: {
+        "ops hygiene": {
+          claude: { status: "baseline_available", score: 42, samples: 3 },
+          codex: { status: "baseline_available", score: 88, samples: 2 },
+        },
+      },
+    }));
+    expect(proposals[0]!.agent).toBe("codex"); // both established → compare scores, not explore
+    expect(proposals[0]!.whyAgent).toContain("Learned routing preferred codex");
+    expect(proposals[0]!.whyAgent).not.toContain("Anti-entrenchment");
+  });
+
+  it("never explores to a dispatch-policy-blocked agent", () => {
+    const proposals = planAndRouteWork(input({
+      explore: true,
+      policy: { ...POLICY, allowedAgents: ["claude"] },
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: undersampledCodex,
+    }));
+    expect(proposals).toHaveLength(1);
+    expect(proposals[0]!.agent).toBe("claude"); // codex is blocked → no exploration to it
+    expect(proposals[0]!.whyAgent).not.toContain("Anti-entrenchment");
+  });
+
+  it("does not explore during cold-start when neither agent is established", () => {
+    const proposals = planAndRouteWork(input({
+      explore: true,
+      backlog: [item("Ops hygiene", "ops hygiene", "Tighten the routine guard")],
+      routingScores: {
+        "ops hygiene": {
+          claude: { status: "insufficient_data", score: null, samples: 1 },
+          codex: { status: "insufficient_data", score: null, samples: 0 },
+        },
+      },
+    }));
+    expect(proposals[0]!.agent).toBe("claude"); // classifier default until data builds
+    expect(proposals[0]!.whyAgent).not.toContain("Anti-entrenchment");
+  });
+
+  it("never explores off the hard taxonomy wall, even with exploration on", () => {
+    const proposals = planAndRouteWork(input({
+      explore: true,
+      backlog: [item("Escrow settlement proof", "chain/settlement", "Verify invariants")],
+      routingScores: {
+        "chain settlement": {
+          codex: { status: "baseline_available", score: 90, samples: 4 },
+          claude: { status: "insufficient_data", score: null, samples: 0 },
+        },
+      },
+    }));
+    expect(proposals[0]!.agent).toBe("codex"); // hard wall forces codex; exploration never runs here
+    expect(proposals[0]!.whyAgent).not.toContain("Anti-entrenchment");
+  });
+});
+
 function input(overrides: Partial<PlanAndRouteWorkInput> = {}): PlanAndRouteWorkInput {
   return {
     backlog: [],


### PR DESCRIPTION
## What & why

Tier-3 **#6 — learned routing**, the last rung. Investigating revealed learned routing already exists (the A2 work): real outcomes → scorecard → per-surface/agent scores → `learnedRoutingChoice`, with **decay** (`0.72^index` recency weighting), **cold-start** (≥2 samples or classifier fallback), and **always-explain** already shipped. The one missing A2 safeguard was **anti-entrenchment** — so that's #6.

**The gap:** `learnedRoutingChoice` only compared two agents that *both* had a baseline and picked the strictly-higher score. An agent the classifier never routes to on a surface could never earn samples → stayed `insufficient_data` → learned routing could never compare them → **permanent lock-in to the classifier's default.** An agent that started behind never got a chance to prove itself.

## The fix — deterministic, bounded exploration (flag `HERMES_ROUTER_ANTI_ENTRENCHMENT`, default OFF)

When the static agent is *established* on a **soft** surface but the *other allowed* agent is *under-explored* (below the baseline sample floor), route **one** exploratory task to it so it can build a baseline. Once it reaches the floor it's `baseline_available` and normal exploitation resumes — bounded to ~2 explorations per surface/agent, rate-limited by one-proposal-per-surface-per-tick + the 5-min cadence.

## Safety — this is the highest-risk dispatch surface, kept deterministic (not agentic)

- **Deterministic** — no RNG; a pure function of the scorecard samples (the router's purity test still passes).
- **Soft surfaces only** — `learnedRoutingChoice` is never reached on the hard wall; `assertTaxonomy` still **throws** on any off-Codex routing of a walled surface (chain/settlement/secrets/migrations/deploy/…).
- **Never routes to a dispatch-policy-blocked agent** (`agentAllowed` guard).
- **Always-explained** — the card's `whyAgent` states it was an anti-entrenchment exploration and why (no truth-boundary inflation).
- **Operator-gated** — every explored task is still approved before it runs; exploration only shapes a *proposal*, never an autonomous dispatch.
- **OFF by default** — when off, learned routing is byte-for-byte today's behavior.

## Wiring

`explore?` on `PlanAndRouteWorkInput` → `HermesRouterConfig` → routine config (`HERMES_ROUTER_ANTI_ENTRENCHMENT`) → `ops/compose.yml` passthrough. The note-only `learnedRoutingChoice` call (Hermes-suggestion branch) stays pure-exploitation.

## Tests

+6 in `work-router.test.ts`: explores the under-sampled agent; **no-op when the flag is off**; stops once the under-dog is established; **never explores to a blocked agent**; no exploration during cold-start; **never explores off the hard wall**. `tsc -b` clean; **21 work-router + 8 router-routine + 11 slack-routines green.**

## Activation (after merge + deploy)

Flip `HERMES_ROUTER_ANTI_ENTRENCHMENT=1` + `--force-recreate slack-operator`. Only meaningful once the router (`HERMES_ROUTER_ENABLED=1`) has surfaces with a real sample imbalance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)