### PR TITLE
polish(monitor): short handle for long task-ids in card headers

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -77,6 +77,22 @@ describe("Card — type coverage", () => {
     expect(container.querySelector(".hm-checks-bar")).toBeNull();
   });
 
+  test("a routed task's long machine id collapses to a short handle in the header", () => {
+    const card = {
+      ...fixture("task starter-coding-014"),
+      id: "codex-task-averray-agent-agent-new-20260701T142620409Z-vfs58z",
+    } as BoardCard;
+    const { container } = render(<Card card={card} />);
+    const head = container.querySelector(".hm-card-head");
+    expect(head?.textContent).toContain("task vfs58z"); // short, operator-scannable handle
+    expect(head?.textContent).not.toContain("codex-task-averray"); // raw id no longer crowds the header
+  });
+
+  test("a short task slug is left as-is in the header", () => {
+    const { container } = render(<Card card={fixture("task starter-coding-014")} />);
+    expect(container.querySelector(".hm-card-head")?.textContent).toContain("starter-coding-014");
+  });
+
   test("card shows a small cross-agent review request indicator", () => {
     const card: BoardCard = {
       ...fixture("agent #547"),

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -81,11 +81,21 @@ function freshClass(card: BoardCard): string {
 }
 
 /**
- * Strip the leading agent-type prefix from a card ID for the monospace
- * badge. `agent #548` → `#548`, `mission browser-X` → `browser-X`.
+ * Turn a card ID into the compact monospace badge the header shows next to the
+ * agent name. First strips the leading agent-type prefix (`agent #548` → `#548`,
+ * `mission browser-X` → `browser-X`). Then, for routed codex/claude task ids —
+ * long machine handles like `codex-task-averray-agent-agent-new-…Z-vfs58z` that
+ * carry no operator meaning and crush the agent label to a `c…` stub — collapse
+ * to a short stable handle (`task vfs58z`). PR refs (`#711`) and short slugs
+ * (`browser-onboard-04`, `starter-coding-014`) are left untouched.
  */
 function shortId(id: string): string {
-  return id.replace(/^[a-z-]+ /, "");
+  const withoutAgent = id.replace(/^[a-z-]+ /, "");
+  if (/(?:^|-)task-/.test(withoutAgent) && !withoutAgent.includes("#")) {
+    const tail = withoutAgent.match(/[a-z0-9]{4,12}$/i)?.[0];
+    if (tail) return `task ${tail}`;
+  }
+  return withoutAgent;
 }
 
 // Risk-tag pill classification — matches the bundle's branching.


### PR DESCRIPTION
## What I saw (live board check)

While verifying the Tier 1–3 deliveries on the live monitor, the routed/proposed task cards render their raw queue id in the header — e.g. `codex-task-averray-agent-agent-new-20260701T142620409Z-vfs58z`. It's meaningless to the operator and long enough to **crush the agent label to a `c…` stub**, where PR cards read cleanly as `codex #711`:

`● c…  codex-task-averray-agent-age…   PROPOSED`

## Fix

`shortId()` now collapses codex/claude task ids to a short, stable handle (the trailing token) so the header reads:

`● codex · task vfs58z   PROPOSED`

- Guarded on the `-task-` segment + absence of `#`, so **only** the long machine handles are touched. PR refs (`#711`) and short slugs (`browser-onboard-04`, `starter-coding-014`) are left exactly as-is.
- The full id still lives in the drawer — nothing is hidden, just the header handle is made scannable.

## Verify

Component render test (jsdom renders the real `Card`): a long task id shows `task vfs58z` and no longer contains the raw `codex-task-averray…`; a short slug is unchanged. **43 Card tests green; monitor-ui `tsc` clean.**

(The live board will show it after this merges + a `--build` deploy — the fix isn't in the shipped image yet. Fixtures use short ids, so a dev-server preview wouldn't exercise the long-id path; the render test is the precise check.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)