### PR TITLE
polish(monitor): share shortId so mirror-lane cards collapse long task-ids (follow-up #476)

### DIFF
--- a/packages/monitor-ui/src/components/PipelineMirrorCard.test.tsx
+++ b/packages/monitor-ui/src/components/PipelineMirrorCard.test.tsx
@@ -34,6 +34,18 @@ describe("PipelineMirrorCard — PR-F2 done passive state", () => {
     expect(container.querySelector(".is-awaiting-inbox")).toBeNull();
   });
 
+  test("collapses a long routed-task id to a short handle in the mirror header", () => {
+    const card = mk({
+      id: "codex-task-averray-agent-agent-new-20260701T142620409Z-vfs58z",
+      type: "task", taskStatus: "proposed", agentType: "codex",
+      title: "Hermes routed work: deploy verification failure",
+    });
+    const { container } = render(<PipelineMirrorCard card={card} tier="watch" />);
+    const head = container.querySelector(".hm-pipeline-card-head");
+    expect(head?.textContent).toContain("task vfs58z"); // shared shortId — same as the full Card
+    expect(head?.textContent).not.toContain("codex-task-averray"); // raw machine id no longer crowds the header
+  });
+
   test("a card with a live operator decision keeps the jump-to-inbox affordance", () => {
     const onJumpToInbox = vi.fn();
     const live = mk({ lane: "operator-review", waitingOn: { actor: "operator", tone: "warn" } });

--- a/packages/monitor-ui/src/components/PipelineMirrorCard.tsx
+++ b/packages/monitor-ui/src/components/PipelineMirrorCard.tsx
@@ -1,6 +1,7 @@
 import type { BoardCard } from "../lib/monitor/card-types.js";
 import { isDecision, type KanbanTier } from "../lib/monitor/lane-rules.js";
 import { deployStepsForCard } from "../lib/monitor/deploy-stepper.js";
+import { shortId } from "../lib/monitor/card-id.js";
 import { AgentTag, StatusPill, type StateVariant } from "./ui.js";
 import { DeployStepper } from "./DeployStepper.js";
 
@@ -13,10 +14,6 @@ export type PipelineMirrorCardProps = {
   /** PR-F3: render the deploy checkpoint stepper inline (the active deploy). */
   showStepper?: boolean;
 };
-
-function shortId(id: string): string {
-  return id.replace(/^[a-z-]+ /, "");
-}
 
 function statusFor(card: BoardCard, tier: KanbanTier): { label: string; variant: StateVariant } {
   if (tier === "hide" || card.type === "done") return { label: "VERIFIED", variant: "pass" };

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -31,6 +31,7 @@ import type {
   MissionReport,
 } from "../../lib/monitor/card-types.js";
 import { deployStepsForCard } from "../../lib/monitor/deploy-stepper.js";
+import { shortId } from "../../lib/monitor/card-id.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor, isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
 import { humanizedSignalParts, humanizeSignalText } from "../../lib/monitor/signal-labels.js";
@@ -80,23 +81,8 @@ function freshClass(card: BoardCard): string {
   return "";
 }
 
-/**
- * Turn a card ID into the compact monospace badge the header shows next to the
- * agent name. First strips the leading agent-type prefix (`agent #548` → `#548`,
- * `mission browser-X` → `browser-X`). Then, for routed codex/claude task ids —
- * long machine handles like `codex-task-averray-agent-agent-new-…Z-vfs58z` that
- * carry no operator meaning and crush the agent label to a `c…` stub — collapse
- * to a short stable handle (`task vfs58z`). PR refs (`#711`) and short slugs
- * (`browser-onboard-04`, `starter-coding-014`) are left untouched.
- */
-function shortId(id: string): string {
-  const withoutAgent = id.replace(/^[a-z-]+ /, "");
-  if (/(?:^|-)task-/.test(withoutAgent) && !withoutAgent.includes("#")) {
-    const tail = withoutAgent.match(/[a-z0-9]{4,12}$/i)?.[0];
-    if (tail) return `task ${tail}`;
-  }
-  return withoutAgent;
-}
+// `shortId` — the compact header id badge — is shared via
+// ../../lib/monitor/card-id.js so <Card> and <PipelineMirrorCard> can't drift.
 
 // Risk-tag pill classification — matches the bundle's branching.
 function freshnessVariant(card: BoardCard, isStale: boolean, isClosed: boolean): StateVariant {

--- a/packages/monitor-ui/src/lib/monitor/card-id.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-id.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { shortId } from "./card-id.js";
+
+describe("shortId", () => {
+  it("strips the leading agent-type prefix", () => {
+    expect(shortId("agent #548")).toBe("#548");
+    expect(shortId("mission browser-onboard-04")).toBe("browser-onboard-04");
+  });
+
+  it("collapses long codex/claude machine task ids to a short handle", () => {
+    expect(shortId("codex-task-averray-agent-agent-new-20260701T142620409Z-vfs58z")).toBe("task vfs58z");
+    // tolerates a leading "task " type prefix too
+    expect(shortId("task codex-task-averray-agent-agent-new-20260701T142620409Z-vfs58z")).toBe("task vfs58z");
+  });
+
+  it("leaves PR refs and short slugs untouched", () => {
+    expect(shortId("#711")).toBe("#711");
+    expect(shortId("starter-coding-014")).toBe("starter-coding-014");
+    expect(shortId("browser-onboard-04")).toBe("browser-onboard-04");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/card-id.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-id.ts
@@ -1,0 +1,25 @@
+// Shared card-id → header-badge formatting.
+//
+// Both the full <Card> (decision inbox / lanes) and the read-only
+// <PipelineMirrorCard> (WATCH/HIDE mirror lanes) render the same monospace id
+// badge next to the agent name, so the formatting MUST live in one place — a
+// duplicated copy already drifted once (the mirror lane kept showing the raw
+// machine task id after the Card copy was shortened).
+
+/**
+ * Turn a card ID into the compact monospace badge shown next to the agent name.
+ * First strips the leading agent-type prefix (`agent #548` → `#548`,
+ * `mission browser-X` → `browser-X`). Then, for routed codex/claude task ids —
+ * long machine handles like `codex-task-averray-agent-agent-new-…Z-vfs58z` that
+ * carry no operator meaning and crush the agent label to a `c…` stub — collapse
+ * to a short stable handle (`task vfs58z`). PR refs (`#711`) and short slugs
+ * (`browser-onboard-04`, `starter-coding-014`) are left untouched.
+ */
+export function shortId(id: string): string {
+  const withoutAgent = id.replace(/^[a-z-]+ /, "");
+  if (/(?:^|-)task-/.test(withoutAgent) && !withoutAgent.includes("#")) {
+    const tail = withoutAgent.match(/[a-z0-9]{4,12}$/i)?.[0];
+    if (tail) return `task ${tail}`;
+  }
+  return withoutAgent;
+}


### PR DESCRIPTION
## What & why

Follow-up to #476, **caught by checking the live board after deploy.** #476 fixed the routed-task header truncation in the full `<Card>` (decision inbox) — it read `codex · task vfs58z`. But the *same* task in the **Builder-tasks / WATCH lane** still showed the raw `c… codex-task-averray-agent-…` stub.

**Root cause:** `<PipelineMirrorCard>` (the read-only mirror-lane renderer) had its **own duplicate `shortId`** with the pre-#476 logic. #476 only updated the copy in `Card.tsx`, so the two drifted.

## Fix

Extract `shortId` into one shared `lib/monitor/card-id.ts`; both `<Card>` and `<PipelineMirrorCard>` import it. **Single source of truth — the renderers can't drift again** (which is precisely how this bug arose). Zero behavior change to `<Card>`; the mirror card now collapses long machine task ids to the same short handle.

## Verify

- `card-id.test.ts` — prefix strip / long-task-id collapse / PR-refs + short slugs untouched.
- `PipelineMirrorCard.test.tsx` — render assertion that the mirror header shows `task vfs58z`, not the raw id.
- **50 tests green** (card-id + Card + PipelineMirrorCard); monitor-ui `tsc` clean; grep confirms no remaining duplicate of the logic.

Frontend-only; lands with the next `--build slack-operator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)