### PR TITLE
polish(monitor): shared shortId in the co-pilot digest rail (3rd renderer)

### DIFF
--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -56,6 +56,22 @@ describe("CoPilotRail", () => {
     expect(container.querySelector(".hm-turn-time")).toBeTruthy();
   });
 
+  test("digest waiting card collapses a long routed-task id to a short handle", () => {
+    const card = {
+      id: "codex-task-averray-agent-agent-new-20260701T191453225Z-ivp2v0",
+      lane: "codex-needed", type: "task", taskStatus: "proposed", agentType: "codex",
+      title: "Hermes routed work: PR security review", summary: "", repo: "averray-agent/agent",
+      freshness: 4, state: "fresh", risk: [], waitingOn: { actor: "operator", tone: "warn" }, files: [],
+    } as unknown as BoardCard;
+    const { container } = render(
+      <CoPilotRail boardCards={[card]} collaboration={{ fetcher: vi.fn(async () => []), refreshIntervalMs: 0 }} />,
+      { wrapper },
+    );
+    const waiting = container.querySelector(".hm-rail-waiting-card");
+    expect(waiting?.textContent).toContain("task ivp2v0"); // shared shortId — same as the cards
+    expect(waiting?.textContent).not.toContain("codex-task-averray"); // raw id no longer printed
+  });
+
   test("shows one template-mode banner and labels offline Hermes replies", async () => {
     const fetcher = vi.fn(async () => [
       msg("1", "hermes", "Template answer from the board.", { hermesMode: "templated" }),

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -19,6 +19,7 @@ import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useC
 import { derivePresence, activeCount, type PresencePeer } from "../../lib/monitor/presence.js";
 import { railDigestCounts } from "../../lib/monitor/rail-digest.js";
 import { isDecision } from "../../lib/monitor/lane-rules.js";
+import { shortId } from "../../lib/monitor/card-id.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
 import { HermesTurn } from "./HermesTurn.js";
@@ -440,7 +441,7 @@ function DigestWaitingCard({
       <span className="hm-rail-waiting-dot" aria-hidden />
       <span className="hm-rail-waiting-main">
         <strong>{card.title}</strong>
-        <small>{card.agentType} · {card.id}</small>
+        <small>{card.agentType} · {shortId(card.id)}</small>
         {rec ? <span className="hm-rail-waiting-rec"><b>rec ·</b> {rec}</span> : null}
         <span className="hm-rail-waiting-chips">
           <Badge variant={risk.tone}>{risk.label}</Badge>


### PR DESCRIPTION
## What & why

Third catch in the same family, spotted on the **live board** after #476/#478 deployed. The co-pilot **digest rail** ("waiting on you" list) still printed the raw machine task id:

`codex · codex-task-averray-agent-agent-new-20260701T191453225Z-ivp2v0`

`<Card>` (#476) and `<PipelineMirrorCard>` (#478) were fixed; `DigestWaitingCard` was the one renderer still bypassing the shared helper.

## Fix

The visible id in `DigestWaitingCard` now uses the shared `shortId` → `codex · task ivp2v0`. The `onClick` navigation target and the `aria-label` keep the full `card.id` (navigation + precise a11y identity — deliberately not shortened).

## Verify

- New `CoPilotRail` render test: the digest waiting card shows `task ivp2v0`, not the raw id.
- **18 rail + card-id tests green**, monitor-ui `tsc` clean.

Frontend-only; renders on the next `--build slack-operator`.

### Separately found (not in this PR)
The digest **`rec:` line duplicates the routing rationale** for routed tasks (e.g. *"security review → … this soft surface."* printed twice). Traced to the **backend** router rationale assembly (`hermes-router-routine.ts` — `why`/`whyAgent` doubling downstream into the card summary). That's a backend content fix, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)