### PR TITLE
fix(monitor): stop doubling the routing rationale in routed-task text

### DIFF
--- a/services/slack-operator/src/hermes-router-routine.ts
+++ b/services/slack-operator/src/hermes-router-routine.ts
@@ -149,7 +149,11 @@ export async function runHermesRouterOnce(config: HermesRouterConfig, deps: Herm
       routingReason: proposal.whyAgent,
       prompt: proposal.taskPrompt,
       title: `Hermes routed work: ${proposal.surface}`,
-      reason: `${proposal.why} ${proposal.whyAgent}`,
+      // reason = the gap rationale ONLY. `whyAgent` (the agent-choice rationale)
+      // already rides on `routingReason`; appending it here too doubled it in
+      // every surface that renders routingReason + reason together (task summary,
+      // drawer "PROPOSED CODEX TASK", co-pilot digest rec).
+      reason: proposal.why,
       requester: HERMES_ROUTER_REQUESTER,
       correlationId: routerCorrelationId(proposal),
     });

--- a/test/unit/hermes-router-routine.test.ts
+++ b/test/unit/hermes-router-routine.test.ts
@@ -77,7 +77,7 @@ function deps(overrides: Partial<HermesRouterDeps> = {}): HermesRouterDeps {
         riskTier: PROPOSAL.riskTier,
         routingReason: PROPOSAL.whyAgent,
         title: `Hermes routed work: ${PROPOSAL.surface}`,
-        reason: `${PROPOSAL.why} ${PROPOSAL.whyAgent}`,
+        reason: PROPOSAL.why,
         requester: "hermes-router",
         correlationId: routerCorrelationId(PROPOSAL),
       }),
@@ -151,7 +151,13 @@ describe("Hermes router routine", () => {
       prompt: PROPOSAL.taskPrompt,
       requester: "hermes-router",
       correlationId: routerCorrelationId(PROPOSAL),
+      // dedup: whyAgent rides on routingReason only; reason is the gap why alone,
+      // so surfaces that render routingReason + reason don't double whyAgent.
+      routingReason: PROPOSAL.whyAgent,
+      reason: PROPOSAL.why,
     }));
+    const proposeArg = vi.mocked(d.propose).mock.calls[0]?.[0] as { reason: string };
+    expect(proposeArg.reason).not.toContain(PROPOSAL.whyAgent);
     expect((vi.mocked(d.propose).mock.calls[0]?.[0] as Record<string, unknown>).status).toBeUndefined();
     expect(d.narrate).toHaveBeenCalledWith(PROPOSAL, expect.objectContaining({
       id: "task-router-1",


### PR DESCRIPTION
## What I saw (driving the live board)

Routed-task cards printed the **agent-choice rationale twice** — in the co-pilot **digest** `rec` line *and* in the card **drawer**'s "PROPOSED CODEX TASK" block:

> security review → … Hermes suggested codex for this soft surface. **Fills uncovered backlog gap: Pre-check evidence for PR #714…** security review → … Hermes suggested codex for this soft surface.

## Root cause

The Hermes router passed `whyAgent` in **two** fields of the propose input:
```
routingReason: proposal.whyAgent,
reason: `${proposal.why} ${proposal.whyAgent}`,   // ← whyAgent again
```
`monitor-v2.ts` builds the task summary as `[health.summary, routingReason, reason].join(" · ")`, so anything rendering that (summary, drawer, digest rec) showed `whyAgent` twice.

## Fix

`reason` is the **gap rationale only** (`proposal.why`); `whyAgent` lives on `routingReason` alone — one source of truth per field. No renderer changed; the doubling disappears everywhere downstream because the data no longer carries the duplicate.

## Verify

Router-routine test now asserts the propose input has `routingReason: whyAgent` + `reason: why`, with an explicit `reason` never-contains-`whyAgent` guard. **8 tests green**, averray-mcp + slack-operator `tsc` clean.

Backend-only; renders clean on the next `--build slack-operator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)