### PR TITLE
monitor: 'what you can do' on decision cards + short scope chip

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -701,7 +701,7 @@ function DecisionCardExplanation({ card }: { card: BoardCard }) {
   );
 }
 
-function deriveWhatHappensNext(card: BoardCard): string {
+export function deriveWhatHappensNext(card: BoardCard): string {
   const waitingNext = card.decisionRecord?.outcome.waitingNext?.trim();
   if (waitingNext) return waitingNext;
   if (card.next?.trim()) return card.next.trim();

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -23,6 +23,7 @@ import { laneFor } from "../../lib/monitor/lane-rules.js";
 import { deployStepsForCard } from "../../lib/monitor/deploy-stepper.js";
 import { DeployStepper } from "../DeployStepper.js";
 import { ChecksBar } from "../cards/ChecksBar.js";
+import { deriveDecisionCardReason, deriveWhatHappensNext } from "../cards/Card.js";
 import { OperatorNotes } from "./OperatorNotes.js";
 
 export type DrawerVariant = "mission" | "action" | "done" | "draft" | "task" | "deploy" | "pr";
@@ -87,9 +88,57 @@ export function DrawerBody({ card, variant }: { card: BoardCard; variant: Drawer
   return (
     <>
       {body}
+      <DecisionContextSection card={card} />
       <DecisionRecordSection record={card.decisionRecord} />
       <OperatorNotes cardId={card.id} />
     </>
+  );
+}
+
+/**
+ * "Why this needs you · what you can do" — the operator-facing situation + next
+ * move, shown on every card awaiting a decision. This is what was missing: a
+ * card whose verdict is just "deploy failed" would otherwise show a bare box and
+ * no path forward. Reuses the card's OWN honest derivations (deriveDecisionCardReason
+ * / deriveWhatHappensNext) — grounded in real fields, never fabricated. When the
+ * data is genuinely thin it says so and points at "Ask Hermes" rather than
+ * inventing a reason.
+ */
+function DecisionContextSection({ card }: { card: BoardCard }) {
+  const lane = laneFor(card);
+  const isDecisionCard = card.isAction || lane === "operator-review" || lane === "needs-attention";
+  if (!isDecisionCard || card.type === "done") return null;
+
+  const rawNext = deriveWhatHappensNext(card);
+  // deriveWhatHappensNext's no-data tail literally says "open the drawer" — nonsense here.
+  const next = rawNext === "Open the drawer for the full state before acting." ? undefined : rawNext;
+  // The drawer already explains the WHY (the verdict block, risk signals, decision
+  // record). What's missing on a bare card is the NEXT MOVE + a path to a deeper
+  // read — so that's all we add, no duplicating the reason.
+  const reason = deriveDecisionCardReason(card);
+  const hasWhy =
+    reason.derived
+    || (card.riskSignals?.length ?? 0) > 0
+    || Boolean(card.decisionRecord)
+    || Boolean((card as { verdict?: string }).verdict?.trim());
+
+  // If the drawer already shows a why and there's no next move to add, don't add an empty box.
+  if (!next && hasWhy) return null;
+
+  return (
+    <section>
+      <div className="hm-section-h">What you can do</div>
+      <div className="hm-verdict-block">
+        <div className="body">
+          {next ? <p style={{ margin: 0 }}>{humanizeSignalText(next)}</p> : null}
+          {!hasWhy ? (
+            <p style={{ margin: next ? "8px 0 0" : 0, color: "var(--hm-muted)", fontSize: 12 }}>
+              Hermes hasn't recorded a reason yet — use <b>Ask Hermes</b> below for an analysis and a suggested fix or rollback.
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx
@@ -47,6 +47,32 @@ describe("drawerVariant — operator-decision lanes get the risk-decision treatm
   });
 });
 
+describe("DrawerBody — 'What you can do' guidance on decision cards", () => {
+  test("surfaces the next move for a bare-verdict decision card (the deploy-failed case)", () => {
+    const c = card({
+      type: "deploy", lane: "operator-review", isAction: true,
+      verdict: "deploy failed",
+      next: "prepare a fix or rollback plan, then let deployment verification run again",
+    });
+    const { container } = render(<DrawerBody card={c} variant="action" />);
+    expect(container.textContent).toContain("What you can do");
+    expect(container.textContent).toContain("prepare a fix or rollback plan");
+  });
+
+  test("points at Ask Hermes when no reason is recorded anywhere", () => {
+    // no verdict / risk signals / record, and no waiting-on actor → nothing to derive a why from
+    const c = card({ type: "deploy", lane: "operator-review", isAction: true, waitingOn: undefined });
+    const { container } = render(<DrawerBody card={c} variant="action" />);
+    expect(container.textContent).toContain("Ask Hermes");
+  });
+
+  test("stays out of the way when the drawer already explains why and there's no next move", () => {
+    const c = card({ type: "pr", lane: "operator-review", isAction: true, verdict: "needs review" });
+    const { container } = render(<DrawerBody card={c} variant="action" />);
+    expect(container.textContent).not.toContain("What you can do");
+  });
+});
+
 describe("DrawerBody — a failed status doesn't render as the green 'ok' box (tone)", () => {
   test("a failed task's Status block carries the warn modifier", () => {
     const failed = card({ type: "task", taskStatus: "failed", lane: "needs-attention", summary: "Task failed in the runner." });

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.test.tsx
@@ -98,9 +98,9 @@ describe("AskHermesComposer", () => {
     expect(within(container).getByRole("alert").textContent).toMatch(/isn't wired here/);
   });
 
-  test("the scope chip reflects the focused card", () => {
+  test("the scope chip reflects the focused card (short handle, not the raw id)", () => {
     const { getByText } = render(<AskHermesComposer focusedCardId="agent #548" />);
-    expect(getByText("scope · agent #548")).toBeTruthy();
+    expect(getByText("scope · #548")).toBeTruthy();
   });
 
   test("/mute and /unmute dispatch to their handlers", () => {

--- a/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
+++ b/packages/monitor-ui/src/components/hermes/AskHermesComposer.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useRef, useState, type CSSProperties, type KeyboardEvent } from "react";
 import { parseHermesInput } from "../../lib/monitor/hermes-commands.js";
+import { shortId } from "../../lib/monitor/card-id.js";
 import type { CreateTaskInput } from "../../lib/monitor/card-types.js";
 import type { CollaborationTarget } from "../../lib/monitor/collaboration.js";
 import { Button } from "../ui.js";
@@ -313,7 +314,7 @@ export function AskHermesComposer({
             title={scopeToCard ? "Scoped to this card — click for the whole board" : "Whole board — click to scope to this card"}
             onClick={() => setScopeToCard((s) => !s)}
           >
-            scope · {scopeToCard ? focusedCardId : "board"}
+            scope · {scopeToCard ? shortId(focusedCardId) : "board"}
           </button>
         ) : (
           <span className="hm-compose-chip">scope · board</span>


### PR DESCRIPTION
Two operator-reported issues from driving the live board.

## 1) Decision cards were a dead end (the important one)

A card whose Hermes verdict is just **"deploy failed"** opened a drawer showing the bare verdict over a big empty box — **no *why*, no *what to do next*, no analysis.** You couldn't actually decide from it, and it's across many cards. Meanwhile the card *in the lane* already derives a "what happens next" from real fields — the drawer just never reused it.

**Fix:** a **"What you can do"** section on every operator-decision drawer, surfacing the next move via the card's own honest derivation (`deriveWhatHappensNext`, now exported + shared). When nothing is recorded anywhere, it says so and points at **Ask Hermes** for an analysis — rather than fabricating a reason. It deliberately does **not** repeat the *why* (the verdict block / risk signals / decision record already show that), so rich cards don't double up.

So the deploy card now reads: `deploy failed` → **What you can do · prepare a fix or rollback plan, then let deployment verification run again**.

## 2) The scope chip leaked the raw id

The composer scope chip printed `scope · CODEX-TASK-…-IVP2VO` (the whole bar). That was the **4th and last** place the long task id leaked — now on the shared `shortId` (`scope · task ivp2vo`). Card, mirror, digest, and scope chip are all one helper now.

## Verify
+3 drawer tests (next-move surfaced; Ask-Hermes pointer when reason-less; no empty box when the why is already shown and there's no next); composer scope-chip test updated. **118 tests green, tsc clean.**

Frontend-only; renders on the next `--build slack-operator`.

### Still open from the same feedback (not in this PR)
- The **element bleeding under the composer** (z-index on `.hm-compose`).
- **Contrast** on the light chips / dim placeholders.
I have both located; happy to do them next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)