### PR TITLE
monitor: Hermes auto-produces a grounded failure analysis for decision cards

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -293,6 +293,18 @@ services:
       # OFF by default and degraded-safe: falls back to the persona completion, then
       # the canned template (tagged "templated"). One session turn per proposal.
       HERMES_ROUTER_AGENTIC_NARRATION: ${HERMES_ROUTER_AGENTIC_NARRATION:-0}
+      # Hermes failure analysis — when ON (needs the gateway session), a scheduled
+      # routine asks the real agentic Hermes for ONE grounded paragraph on WHY a
+      # failed operator-decision card likely failed + a fix/rollback next step
+      # (or an explicit "cause unclear" when signals are thin), cached per card and
+      # rendered as "Hermes's read" in the drawer. Grounded ONLY in the card's real
+      # failure fields — no fabricated cause, no template fallback. OFF by default
+      # and degraded-safe: with the gateway down it writes nothing and the drawer
+      # keeps its "Ask Hermes" pointer. Reads cards only; never mutates anything.
+      HERMES_FAILURE_ANALYSIS: ${HERMES_FAILURE_ANALYSIS:-0}
+      HERMES_FAILURE_ANALYSIS_INTERVAL_MINUTES: ${HERMES_FAILURE_ANALYSIS_INTERVAL_MINUTES:-5}
+      HERMES_FAILURE_ANALYSIS_MAX_PER_TICK: ${HERMES_FAILURE_ANALYSIS_MAX_PER_TICK:-3}
+      AVERRAY_CARD_FAILURE_ANALYSIS_PATH: ${AVERRAY_CARD_FAILURE_ANALYSIS_PATH:-/data/card-failure-analysis.json}
       LLM_USAGE_LOG_PATH: ${LLM_USAGE_LOG_PATH:-/data/llm-usage.jsonl}
       HERMES_MONITOR_MEMORY_PATH: ${HERMES_MONITOR_MEMORY_PATH:-/data/hermes-monitor-memory.json}
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.hermesAnalysis.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.hermesAnalysis.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DrawerBody } from "./DrawerBody.js";
+import { drawerVariant } from "./DrawerBody.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+/**
+ * A failed operator-decision card (needs-attention) with NO recorded reason, so
+ * the "What you can do" section shows its existing "Ask Hermes" pointer when no
+ * analysis is present — the exact bare-card state this feature augments.
+ */
+function failedCard(over: Record<string, unknown>): BoardCard {
+  return {
+    id: "deploy-1",
+    type: "deploy",
+    lane: "needs-attention",
+    agentType: "hermes",
+    title: "Deploy monitor stack",
+    summary: "Deploy failed.",
+    repo: "averray-reference-agent",
+    freshness: 3,
+    state: "failed-fetch",
+    risk: [],
+    isAction: true,
+    waitingOn: { actor: "operator", tone: "warn" },
+    ...over,
+  } as unknown as BoardCard;
+}
+
+describe("DrawerBody — Hermes's read (agentic failure analysis)", () => {
+  test("renders the analysis, tagged as an agentic analysis, when card.hermesAnalysis is present", () => {
+    const card = failedCard({
+      hermesAnalysis: {
+        text: "Both unit tests and browser replay failed on this deploy, so verification never went green; roll back to the last passing build and re-run before promoting.",
+        model: "hermes-4",
+        at: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    const text = container.textContent ?? "";
+    expect(text).toMatch(/Hermes's read/);
+    // clearly tagged as an agentic analysis (honesty label)
+    expect(text).toMatch(/agentic analysis/);
+    // the grounded analysis text is surfaced verbatim
+    expect(text).toMatch(/roll back to the last passing build/);
+    // and it is framed as a read, not a verified root cause
+    expect(text).toMatch(/not a verified root cause/i);
+  });
+
+  test("surfaces the 'cause unclear' analysis verbatim (truth boundary — never a fabricated cause)", () => {
+    const card = failedCard({
+      hermesAnalysis: {
+        text: "Cause unclear from the available signals. Open the failed check output before deciding whether to fix or roll back.",
+        at: "2026-07-01T00:00:00.000Z",
+      },
+    });
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    expect(container.textContent).toMatch(/Cause unclear from the available signals\./);
+  });
+
+  // A bare decision card with no recorded why anywhere → the existing drawer
+  // shows its "Ask Hermes" pointer (see DrawerBody.variant.test.tsx). We reuse
+  // that exact shape to prove HermesReadSection neither renders nor disturbs it.
+  function barePointerCard(over: Record<string, unknown>): BoardCard {
+    return {
+      id: "bare-1",
+      type: "deploy",
+      lane: "operator-review",
+      agentType: "hermes",
+      title: "Deploy monitor stack",
+      summary: "summary",
+      repo: "averray-reference-agent",
+      freshness: 5,
+      state: "fresh",
+      risk: [],
+      isAction: true,
+      waitingOn: undefined,
+      ...over,
+    } as unknown as BoardCard;
+  }
+
+  test("when NO analysis is present, renders no 'Hermes's read' and keeps the existing 'Ask Hermes' pointer", () => {
+    const card = barePointerCard({}); // no hermesAnalysis, no recorded why
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    const text = container.textContent ?? "";
+    // No agentic-read section at all — byte-for-byte the existing bare-card drawer.
+    expect(text).not.toMatch(/Hermes's read/);
+    expect(text).not.toMatch(/agentic analysis/);
+    // The existing "Ask Hermes" pointer in "What you can do" is preserved.
+    expect(text).toMatch(/Ask Hermes/);
+  });
+
+  test("an empty analysis text renders nothing (never an empty agentic box) and keeps the pointer", () => {
+    const card = barePointerCard({ hermesAnalysis: { text: "   ", at: "2026-07-01T00:00:00.000Z" } });
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    expect(container.textContent).not.toMatch(/Hermes's read/);
+    // still shows the pointer since there's no recorded why
+    expect(container.textContent).toMatch(/Ask Hermes/);
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -88,10 +88,49 @@ export function DrawerBody({ card, variant }: { card: BoardCard; variant: Drawer
   return (
     <>
       {body}
+      <HermesReadSection card={card} />
       <DecisionContextSection card={card} />
       <DecisionRecordSection record={card.decisionRecord} />
       <OperatorNotes cardId={card.id} />
     </>
+  );
+}
+
+/**
+ * "Hermes's read" — the agentic failure analysis for a failed decision card:
+ * Hermes's grounded guess at WHY it failed + a recommended fix/rollback next
+ * step. Shown ONLY when the (flag-gated) failure-analysis routine produced one
+ * for this card's current failure (card.hermesAnalysis present). When absent,
+ * this renders nothing and the "What you can do" section keeps its existing "Ask
+ * Hermes" pointer — the drawer is byte-for-byte today's behavior.
+ *
+ * TRUTH-BOUNDARY: this is clearly labeled as Hermes's AGENTIC READ (not a
+ * verified fact) so the operator never mistakes a grounded guess for proof. The
+ * analysis text itself is grounded server-side ONLY in the card's real failure
+ * fields, and says "cause unclear from the available signals" when the data is
+ * thin — this section just surfaces that honest read verbatim.
+ */
+function HermesReadSection({ card }: { card: BoardCard }) {
+  const analysis = (card as { hermesAnalysis?: { text: string; model?: string; at: string } }).hermesAnalysis;
+  const text = analysis?.text?.trim();
+  if (!text) return null;
+  return (
+    <section>
+      <div className="hm-section-h" style={{ color: "var(--hm-hermes-deep)" }}>
+        Hermes's read
+        <span className="hm-pill hm-pill--hermes" style={{ marginLeft: 8 }}>
+          agentic analysis
+        </span>
+      </div>
+      <div className="hm-verdict-block" style={{ background: "var(--hm-hermes-soft)", borderColor: "rgba(15,107,90,0.18)" }}>
+        <div className="body">
+          <p style={{ margin: 0 }}>{text}</p>
+          <p style={{ margin: "8px 0 0", color: "var(--hm-muted)", fontSize: 12 }}>
+            Hermes's grounded read of the failure signals on this card — not a verified root cause. Confirm before acting.
+          </p>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -95,7 +95,10 @@ describe("CoPilotRail", () => {
       <CoPilotRail focusedCard={card548} collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }} />,
       { wrapper },
     );
-    expect(getByText("scope · agent #548")).toBeTruthy();
+    // #481 switched the composer scope chip to shortId (`agent #548` → `#548`)
+    // and updated AskHermesComposer.test.tsx, but missed this sibling that renders
+    // the same composer — leaving it red on main. Match the shipped behaviour.
+    expect(getByText("scope · #548")).toBeTruthy();
   });
 
   test("asking a question scoped to the focused card posts relatedPr and renders the reply", async () => {

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -200,6 +200,14 @@ export interface CardBase {
   sourceFailure?: CardSourceFailure;
   /** Agent currently working this in-flight card, backed by live runner/classifier state. */
   workingNow?: CardWorkingNow;
+  /**
+   * Hermes's grounded, agentic read of WHY a failed decision card likely failed
+   * plus a recommended next step. Present only on failure cards when the
+   * (flag-gated) failure-analysis routine produced one and it is still fresh for
+   * the card's current failure. Absent otherwise — the drawer then keeps its
+   * existing "Ask Hermes" pointer. Tagged as an agentic analysis in the UI.
+   */
+  hermesAnalysis?: { text: string; model?: string; at: string };
 }
 
 /** PR card — file changes, Hermes verdict, operator-review action. */

--- a/services/slack-operator/src/failure-analysis-routine.ts
+++ b/services/slack-operator/src/failure-analysis-routine.ts
@@ -1,0 +1,105 @@
+// Hermes failure-analysis routine (feature: grounded failure analysis for
+// operator decision cards).
+//
+// The effectful, flag-gated companion to the pure analyzeCardFailure(...). On a
+// scheduled tick it walks the current board, picks the operator-decision cards
+// that represent a FAILURE, and — for each one lacking a FRESH cached analysis —
+// asks the real agentic Hermes for one grounded paragraph (why it likely failed
+// + a fix/rollback next step, or an explicit "cause unclear"). The paragraph is
+// cached keyed by card id + a hash of the failure context, so it re-runs only
+// when the failure changes. It NEVER approves, dispatches, merges, deploys, or
+// mutates the card — it only attaches Hermes's read.
+//
+// Modeled on hermes-router-routine.ts (runHermesRouterOnce): pure orchestration
+// over injected deps, degraded-safe, and a no-op when the flag is off.
+
+import {
+  analyzeCardFailure,
+  hashFailureContext,
+  hasDiagnosableFailureDetail,
+  type FailureAnalysisCard,
+  type FailureAnalysisDeps,
+} from "./monitor-failure-analysis.js";
+
+export interface FailureAnalysisRoutineConfig {
+  enabled: boolean;
+  intervalMs: number;
+  /** Max analyses produced per tick — caps token spend when many cards fail at once. */
+  maxPerTick: number;
+}
+
+export interface FailureAnalysisRoutineDeps {
+  /** The failure cards to consider, already projected to the grounded fields. */
+  listFailureCards: () => Promise<FailureAnalysisCard[]> | FailureAnalysisCard[];
+  /** Fresh cached analysis for this card + failure hash, or undefined. */
+  readFresh: (cardId: string, failureHash: string) => { text: string } | undefined;
+  /** Persist a produced analysis for a card. */
+  write: (cardId: string, value: { text: string; model?: string; failureHash: string }) => void;
+  /** The agentic transport + flag + usage side effect passed to analyzeCardFailure. */
+  analysisDeps: FailureAnalysisDeps;
+  /** Guardrails — mirror the router routine so autopilot halt/suspend also parks this. */
+  isSuspended: () => boolean;
+  isHalt: () => boolean;
+}
+
+export interface FailureAnalysisRoutineResult {
+  status: "disabled" | "paused" | "idle" | "analyzed";
+  reason?:
+    | "halt_present"
+    | "autopilot_suspended"
+    | "no_failure_cards"
+    | "all_fresh"
+    /** Failure cards needed analysis but every turn came back degraded (gateway down / empty). */
+    | "degraded";
+  analyzed: Array<{ cardId: string }>;
+}
+
+/**
+ * One pass of the failure-analysis routine. Degraded-safe throughout: a
+ * transport that returns nothing simply produces no analysis for that card (the
+ * drawer keeps its "Ask Hermes" pointer). No-op when the flag is off.
+ */
+export async function runFailureAnalysisOnce(
+  config: FailureAnalysisRoutineConfig,
+  deps: FailureAnalysisRoutineDeps,
+): Promise<FailureAnalysisRoutineResult> {
+  if (!config.enabled) return { status: "disabled", analyzed: [] };
+  if (deps.isHalt()) return { status: "paused", reason: "halt_present", analyzed: [] };
+  if (deps.isSuspended()) return { status: "paused", reason: "autopilot_suspended", analyzed: [] };
+
+  const cards = await deps.listFailureCards();
+  if (cards.length === 0) return { status: "idle", reason: "no_failure_cards", analyzed: [] };
+
+  const analyzed: Array<{ cardId: string }> = [];
+  let sawStale = false;
+  for (const card of cards) {
+    if (analyzed.length >= config.maxPerTick) break;
+    // Skip a card with no concrete, diagnosable failure detail — explaining a
+    // bare "failed" with nothing to reason about would only invite a guess.
+    if (!hasDiagnosableFailureDetail(card)) continue;
+
+    const failureHash = hashFailureContext(card);
+    if (deps.readFresh(card.id, failureHash)) continue; // already fresh
+    sawStale = true;
+
+    const result = await analyzeCardFailure(card, deps.analysisDeps);
+    if (result.hermesMode !== "live" || !result.text) continue; // degraded — write nothing
+
+    deps.write(card.id, {
+      text: result.text,
+      failureHash,
+      ...(result.model ? { model: result.model } : {}),
+    });
+    analyzed.push({ cardId: card.id });
+  }
+
+  if (analyzed.length > 0) return { status: "analyzed", analyzed };
+  // sawStale means there WERE failure cards needing analysis but every turn came
+  // back degraded (gateway down / empty) — report "degraded", not "all_fresh"
+  // (the board is NOT clean) and not "no_failure_cards" (there were some).
+  return {
+    status: "idle",
+    reason: sawStale ? "degraded" : "all_fresh",
+    analyzed: [],
+  };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -56,7 +56,7 @@ import {
   type ReviewRequestStatus,
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
-import { buildV2BoardSnapshot, diffBoardSnapshots, type BoardSnapshotV2 } from "./monitor-v2.js";
+import { buildV2BoardSnapshot, diffBoardSnapshots, failureAnalysisCardFor, type BoardSnapshotV2 } from "./monitor-v2.js";
 import { buildBacklogSuggestionsResponse } from "./backlog-suggestions.js";
 import { listDecisionRecordsForMonitor } from "./decision-record-store.js";
 import {
@@ -154,6 +154,11 @@ import {
   type HermesRouterAuditRecord,
 } from "./hermes-router-routine.js";
 import { narrateRouterProposal } from "./monitor-router-narration.js";
+import { runFailureAnalysisOnce } from "./failure-analysis-routine.js";
+import {
+  readFreshCardFailureAnalysis,
+  writeCardFailureAnalysis,
+} from "./operator-card-failure-analysis.js";
 import { chatWithHermesSession } from "./hermes-session-client.js";
 import { collectAgenticBacklog } from "./agentic-backlog.js";
 import type { RoutedProposal, WorkRouterBacklogItem } from "@avg/averray-mcp/work-router";
@@ -365,7 +370,7 @@ async function emitAutopilotAwayDigest(session: EndedAutopilotAwaySession) {
     loadAuditEvents: loadAutopilotAwayAuditEvents,
     loadBoardCards: async () => {
       const raw = await loadMonitorSnapshot(new URL("http://localhost/monitor/events?limit=50&activeWindowMinutes=240"), { suppressNarration: true });
-      return buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }).cards;
+      return buildV2BoardSnapshot(raw, monitorV2BoardOptions()).cards;
     },
     recordBoardDigest: async (_digest, text) => {
       recordCollaborationMessage({
@@ -547,7 +552,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
-    writeJson(response, 200, mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() })));
+    writeJson(response, 200, mergeDebugCards(buildV2BoardSnapshot(raw, monitorV2BoardOptions())));
     return;
   }
   // Dev-only acceptance vehicle: inject a synthetic card so the
@@ -682,7 +687,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
-    const board = mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }));
+    const board = mergeDebugCards(buildV2BoardSnapshot(raw, monitorV2BoardOptions()));
     writeJson(response, 200, buildBacklogSuggestionsResponse(board.cards));
     return;
   }
@@ -3225,7 +3230,7 @@ function startOperatorRoutines() {
         new URL("http://localhost/monitor/events?limit=100&activeWindowMinutes=1440"),
         { suppressNarration: true },
       );
-      const board = buildV2BoardSnapshot(raw, { repo: monitorV2Repo() });
+      const board = buildV2BoardSnapshot(raw, monitorV2BoardOptions());
       const items: AlertItem[] = board.cards
         .filter((c) => c.lane === "needs-attention")
         .map((c) => ({ id: c.id, title: c.title }));
@@ -3541,6 +3546,93 @@ function startOperatorRoutines() {
     }
   };
 
+  // Hermes failure analysis. On a scheduled tick it reads the current board,
+  // picks the failed operator-decision cards lacking a FRESH cached analysis,
+  // and asks the real agentic Hermes for one grounded paragraph (why it likely
+  // failed + a fix/rollback next step, or an explicit "cause unclear"). It
+  // caches that per card and NEVER approves, dispatches, merges, or mutates a
+  // card. Degraded-safe: with the gateway session down it writes nothing and the
+  // drawer keeps its "Ask Hermes" pointer.
+  let failureAnalysisRunning = false;
+  const checkFailureAnalysis = async () => {
+    if (failureAnalysisRunning || !routineConfig.failureAnalysis.enabled) return;
+    failureAnalysisRunning = true;
+    try {
+      const model = optionalEnv("HERMES_MONITOR_REPLY_MODEL") ?? "glm-5.2:cloud";
+      // Only route through the real agentic Hermes; a canned "why it failed"
+      // would be a fabricated cause. So the transport is the gateway session
+      // ONLY — null (unconfigured / down) means no analysis this tick.
+      const sessionConfig = resolveHermesSessionConfig();
+      const result = await runFailureAnalysisOnce(
+        {
+          enabled: routineConfig.failureAnalysis.enabled,
+          intervalMs: routineConfig.failureAnalysis.intervalMs,
+          maxPerTick: routineConfig.failureAnalysis.maxPerTick,
+        },
+        {
+          listFailureCards: async () => {
+            const raw = await loadMonitorSnapshot(
+              new URL("http://localhost/monitor/events?limit=50&activeWindowMinutes=240"),
+              { suppressNarration: true },
+            );
+            // Build WITHOUT getAnalysis — the routine only needs each card's
+            // failure projection, not the threaded analyses (that would re-read
+            // the cache for nothing). Reuse the SAME projection the board
+            // threading uses, so "which cards get an analysis" is defined once.
+            return buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }).cards
+              .map((card) => failureAnalysisCardFor(card))
+              .filter((c): c is NonNullable<typeof c> => Boolean(c));
+          },
+          readFresh: (cardId, failureHash) => readFreshCardFailureAnalysis(cardId, failureHash),
+          write: (cardId, value) => {
+            writeCardFailureAnalysis(cardId, value);
+            logger.info({ cardId }, "hermes_failure_analysis_written");
+          },
+          analysisDeps: {
+            enabled: routineConfig.failureAnalysis.enabled,
+            sessionConfig,
+            // Degraded-safe: chatWithHermesSession returns null on any failure.
+            // Bracketed with beginLlmUsageCall so the monitor shows Hermes
+            // "thinking" for the (slow) agent turn, mirroring the co-pilot /
+            // router-narration paths.
+            runSession: async (config, prompt) => {
+              const endLlmUsageCall = beginLlmUsageCall({ agent: "hermes", model });
+              try {
+                return await chatWithHermesSession(config, prompt);
+              } finally {
+                endLlmUsageCall();
+              }
+            },
+            // Record the agent turn's token usage so the monitor usage panel
+            // counts what this analysis actually spent. Fired only when the
+            // session produced usable text (mirrors router narration onSessionTurn).
+            onSessionTurn: (turn) => {
+              if (!turn.usage) return;
+              const usageModel = turn.model ?? model;
+              void recordLlmUsageFromResult(
+                {
+                  agent: "hermes",
+                  model: usageModel,
+                  result: { usage: turn.usage, ...(turn.model ? { model: turn.model } : {}) },
+                },
+                { path: llmUsageLogPath() },
+              ).catch((error) => logger.warn({ err: error }, "hermes_failure_analysis_usage_record_failed"));
+            },
+          },
+          isSuspended: () => isAutopilotSuspended(),
+          isHalt: () => isHaltFilePresent(),
+        },
+      );
+      if (result.analyzed.length > 0) {
+        logger.info({ analyzed: result.analyzed }, "hermes_failure_analysis_done");
+      }
+    } catch (error) {
+      logger.error({ err: error }, "hermes_failure_analysis_failed");
+    } finally {
+      failureAnalysisRunning = false;
+    }
+  };
+
   if (routineConfig.channelId && routineConfig.dailyBrief.enabled) {
     setTimeout(() => void checkDailyBrief(), 5_000);
     setInterval(() => void checkDailyBrief(), 60_000);
@@ -3580,6 +3672,10 @@ function startOperatorRoutines() {
   if (routineConfig.hermesRouter.enabled) {
     setTimeout(() => void checkHermesRouter(), 15_000);
     setInterval(() => void checkHermesRouter(), routineConfig.hermesRouter.intervalMs);
+  }
+  if (routineConfig.failureAnalysis.enabled) {
+    setTimeout(() => void checkFailureAnalysis(), 17_000);
+    setInterval(() => void checkFailureAnalysis(), routineConfig.failureAnalysis.intervalMs);
   }
 }
 
@@ -4224,6 +4320,31 @@ function monitorV2Repo(): string {
 }
 
 /**
+ * True when the Hermes failure-analysis feature is enabled (flag, default off).
+ * Uses the SAME predicate as parseSlackRoutineConfig (`=== "1"`) so the board
+ * threading and the routine/scheduler can never disagree about the flag.
+ */
+function isFailureAnalysisEnabled(): boolean {
+  return optionalEnv("HERMES_FAILURE_ANALYSIS") === "1";
+}
+
+/**
+ * Board-build options for every buildV2BoardSnapshot call. When the failure-
+ * analysis flag is ON, surfaces the FRESH cached Hermes analysis onto failure
+ * cards (keyed by card id + failure hash). When OFF (default), getAnalysis is
+ * omitted, so the board is byte-for-byte today's behavior — no analysis field,
+ * drawer keeps its "Ask Hermes" pointer.
+ */
+function monitorV2BoardOptions(): { repo: string; getAnalysis?: (cardId: string, failureHash: string) => { text: string; model?: string; at: string } | undefined } {
+  const repo = monitorV2Repo();
+  if (!isFailureAnalysisEnabled()) return { repo };
+  return {
+    repo,
+    getAnalysis: (cardId, failureHash) => readFreshCardFailureAnalysis(cardId, failureHash),
+  };
+}
+
+/**
  * v2 SSE stream — emits typed card-level events derived from consecutive
  * real BoardSnapshotV2 reads, followed by a reconciliation snapshot. Lane
  * movement is never simulated: a `board.card.moved` means the card's real
@@ -4253,7 +4374,7 @@ async function writeMonitorV2Stream(
     inFlight = true;
     try {
       const raw = await loadMonitorSnapshot(url, { suppressNarration: true });
-      const snapshot = mergeDebugCards(buildV2BoardSnapshot(raw, { repo: monitorV2Repo() }));
+      const snapshot = mergeDebugCards(buildV2BoardSnapshot(raw, monitorV2BoardOptions()));
       for (const event of diffBoardSnapshots(lastSnapshot, snapshot)) {
         writeSseEvent(response, event.type, event);
       }

--- a/services/slack-operator/src/monitor-failure-analysis.ts
+++ b/services/slack-operator/src/monitor-failure-analysis.ts
@@ -1,0 +1,213 @@
+/**
+ * Hermes failure analysis for operator decision cards (feature: grounded failure
+ * analysis).
+ *
+ * A card whose verdict is just "deploy failed" (or a failed task / degraded
+ * fetch) shows a bare box and no path forward. When this feature is on, the real
+ * agentic Hermes produces ONE short paragraph: the likely WHY it failed + a
+ * recommended next step (fix vs rollback) — or an explicit "cause unclear from
+ * the available signals" when the data is thin. This module owns producing that
+ * paragraph so it can be unit-tested in isolation (index.ts wires the real deps).
+ *
+ * Modeled on monitor-router-narration.ts (#472): a flag-gated agentic call, a
+ * prompt grounded ONLY in real card fields, usage recorded via an injected side
+ * effect, and a degraded fallback. Two differences from the router narration:
+ *   - There is NO template/Ollama fallback. This analysis is an agentic read of
+ *     a failure; if the real agent can't run (flag off, gateway down, empty
+ *     reply) we produce NOTHING — the drawer keeps its existing "Ask Hermes"
+ *     pointer. A canned "why it failed" would be a fabricated root cause, which
+ *     the truth-boundary forbids. So the only "live" transport is the session.
+ *   - `hermesMode` is "live" ONLY when the real session produced the text; there
+ *     is no "templated" analysis to mis-tag.
+ *
+ * TRUTH-BOUNDARY (the whole point):
+ *   - The prompt is grounded ONLY in the failure fields that actually exist on
+ *     the card (title, repo, verdict, failureReason, sourceFailure, failed check
+ *     names, degraded state, risk signals). `failureContextFactLines` emits a
+ *     line for a field only when it is non-empty — the single choke point the
+ *     no-fabrication guard relies on.
+ *   - The guardrails forbid inventing a root cause the data doesn't support and
+ *     REQUIRE an explicit "cause unclear from the available signals" when the
+ *     signals don't determine the cause. Hermes must never guess.
+ *   - The result is tagged as Hermes's agentic read so the UI honesty
+ *     badge/label is accurate. Usage is recorded, mirroring the co-pilot /
+ *     router-narration path.
+ */
+
+import type { HermesReplyMode } from "./monitor-collab.js";
+import type { HermesSessionConfig, HermesSessionTurn } from "./hermes-session-client.js";
+
+/**
+ * The ONLY card fields the failure analysis is allowed to read. A deliberately
+ * narrow projection (not the full BoardCard) so the module stays pure and the
+ * grounded-fact surface is auditable. index.ts / monitor-v2 build this from a
+ * real card; a field is present here iff it is real on the card.
+ */
+export interface FailureAnalysisCard {
+  id: string;
+  title: string;
+  repo?: string;
+  /** Hermes verdict / reasoning carried from the classifier, when present. */
+  verdict?: string;
+  /** Codex/Claude task failure reason, when the task failed. */
+  failureReason?: string;
+  /** Degraded source read / heartbeat failure message, when present. */
+  sourceFailure?: { source: string; code?: string; message: string };
+  /** Names of CI checks that failed (from the per-check breakdown). */
+  failedCheckNames?: string[];
+  /** Card state, e.g. "failed-fetch" for a degraded card. */
+  state?: string;
+  /** Hermes review findings — the "why review" detail, when present. */
+  riskSignals?: string[];
+  /** A short label for the kind of failure, e.g. "deploy verification". */
+  failureKind?: string;
+}
+
+export interface FailureAnalysisResult {
+  text: string;
+  /** "live" only when the real agentic session produced the text; else "none". */
+  hermesMode: HermesReplyMode | "none";
+  /** Model the gateway ran the turn on, when reported — surfaced on the card. */
+  model?: string;
+}
+
+export interface FailureAnalysisDeps {
+  /** Resolved gateway config, or null when the session transport is unavailable. */
+  sessionConfig: HermesSessionConfig | null;
+  /** True when HERMES_FAILURE_ANALYSIS is truthy. */
+  enabled: boolean;
+  /** Runs one agentic session turn; returns null on any failure (degraded-safe). */
+  runSession?: (config: HermesSessionConfig, prompt: string) => Promise<HermesSessionTurn | null>;
+  /**
+   * Side effect fired ONLY when the session produced a usable analysis. index.ts
+   * uses it to record the agent turn's token usage on the monitor usage panel
+   * (mirrors the router-narration onSessionTurn). Kept injected so this module
+   * stays a pure text+mode producer with no usage/IO of its own.
+   */
+  onSessionTurn?: (turn: HermesSessionTurn) => void;
+}
+
+/** Cap so a runaway agent reply can't bloat the card payload. */
+const MAX_ANALYSIS_CHARS = 900;
+
+/**
+ * The grounded failure facts we are willing to put in a prompt, derived ONLY
+ * from the card. A field is present in the returned lines iff it is non-empty on
+ * the card — so a card without a given failure signal never surfaces one. This
+ * is the single choke point the no-fabrication guard (and its test) relies on.
+ */
+export function failureContextFactLines(card: FailureAnalysisCard): string[] {
+  const lines: string[] = [];
+  const push = (label: string, value: string | undefined) => {
+    const trimmed = (value ?? "").trim();
+    if (trimmed) lines.push(`${label}: ${trimmed}`);
+  };
+  push("Card", card.title);
+  push("Repo", card.repo);
+  push("Failure kind", card.failureKind);
+  push("Verdict", card.verdict);
+  push("Failure reason", card.failureReason);
+  if (card.sourceFailure && card.sourceFailure.message.trim()) {
+    const sf = card.sourceFailure;
+    const code = sf.code ? ` [${sf.code}]` : "";
+    push("Source failure", `${sf.source}${code}: ${sf.message}`);
+  }
+  const failedChecks = (card.failedCheckNames ?? []).map((n) => n.trim()).filter(Boolean);
+  if (failedChecks.length > 0) push("Failed checks", failedChecks.join(", "));
+  if (card.state && card.state.trim()) push("Card state", card.state);
+  const signals = (card.riskSignals ?? []).map((s) => s.trim()).filter(Boolean);
+  if (signals.length > 0) push("Risk signals", signals.slice(0, 5).join("; "));
+  return lines;
+}
+
+/**
+ * True when the card carries at least one CONCRETE failure detail Hermes can
+ * reason about beyond the bare verdict/title/state. Used by the routine to skip
+ * cards whose only signal is "failed" with no diagnosable context — asking the
+ * agent to explain a failure with no detail would only invite a guess.
+ */
+export function hasDiagnosableFailureDetail(card: FailureAnalysisCard): boolean {
+  if ((card.failureReason ?? "").trim()) return true;
+  if (card.sourceFailure && card.sourceFailure.message.trim()) return true;
+  if ((card.failedCheckNames ?? []).some((n) => n.trim())) return true;
+  if ((card.riskSignals ?? []).some((s) => s.trim())) return true;
+  return false;
+}
+
+const TRUTH_RULES = [
+  "Rules (follow exactly):",
+  "- Ground EVERY claim in the failure facts listed above. Do not invent a root cause, error, log line, metric, PR number, or step that is not in that list.",
+  "- If the listed signals do not actually determine why it failed, say exactly: \"Cause unclear from the available signals.\" Then, still grounded only in what is listed, suggest the safest next step. Never guess a cause to fill the gap.",
+  "- Recommend ONE concrete next step and say whether it leans toward a fix or a rollback, based only on the listed signals. If the signals don't favor either, say so.",
+  "- Do not claim you inspected logs, ran commands, merged, deployed, approved, rolled back, or took any action. You are reading the card, not acting.",
+  "- Reply with ONE short paragraph (2-4 sentences) for the operator's decision drawer. No preamble, no heading, no list, no trailing notes.",
+];
+
+/**
+ * Prompt for the agentic failure analysis. Threads the real failure facts + the
+ * truth guardrails (grounded-only, explicit "cause unclear" path). Framed for
+ * the real Hermes agent so it reads the failure in its own board-aware voice —
+ * WITHOUT loosening the guardrails: the facts here are the only claims it may
+ * assert about THIS failure.
+ */
+export function buildFailureAnalysisPrompt(card: FailureAnalysisCard): string {
+  return [
+    "An operator is looking at a decision card on the monitor board that represents a FAILURE. Read why it likely failed and recommend the next move, for the operator's decision drawer.",
+    "Stay strictly grounded in these failure facts from the card:",
+    "",
+    ...failureContextFactLines(card),
+    "",
+    ...TRUTH_RULES,
+    "- You may reflect your own board/context awareness in tone, but every concrete claim about THIS failure must come from the facts above.",
+  ].join("\n");
+}
+
+/**
+ * A stable hash of the failure context, so the cache re-runs ONLY when the
+ * failure actually changes (not on every unrelated board refresh). Derived from
+ * the same grounded fact lines the prompt uses, so any change to a real failure
+ * field invalidates the cache. Small, dependency-free FNV-1a over the joined
+ * lines — collisions are astronomically unlikely for this short, low-cardinality
+ * input, and a collision would at worst reuse a still-relevant analysis.
+ */
+export function hashFailureContext(card: FailureAnalysisCard): string {
+  const basis = failureContextFactLines(card).join("\n");
+  let h = 0x811c9dc5;
+  // Iterate Unicode CODE POINTS (not UTF-16 units) so astral chars don't split
+  // into surrogate halves — keeps distinct failure texts distinct.
+  for (const ch of basis) {
+    h ^= ch.codePointAt(0)!;
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Produce the grounded failure analysis for a card via the real agentic Hermes.
+ * Runs the session ONLY when the flag is on AND a gateway config resolved AND a
+ * session runner is provided; any failure (disabled, unconfigured, thrown, empty
+ * reply) returns `{ text: "", hermesMode: "none" }` so the caller writes nothing
+ * and the drawer keeps its existing "Ask Hermes" pointer. There is deliberately
+ * no template fallback — a canned cause would be fabrication.
+ */
+export async function analyzeCardFailure(
+  card: FailureAnalysisCard,
+  deps: FailureAnalysisDeps,
+): Promise<FailureAnalysisResult> {
+  if (!deps.enabled || !deps.sessionConfig || !deps.runSession) {
+    return { text: "", hermesMode: "none" };
+  }
+  const turn = await deps
+    .runSession(deps.sessionConfig, buildFailureAnalysisPrompt(card))
+    .catch(() => null);
+  const text = turn?.text?.trim();
+  if (!turn || !text) return { text: "", hermesMode: "none" };
+
+  // Only now (real text produced) attribute the agent turn's token usage.
+  deps.onSessionTurn?.(turn);
+  return {
+    text: text.replace(/\s+/g, " ").trim().slice(0, MAX_ANALYSIS_CHARS),
+    hermesMode: "live",
+    ...(turn.model ? { model: turn.model } : {}),
+  };
+}

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -51,6 +51,7 @@ import {
   type ReviewPanelResponse,
   type ReviewPanelReviewer,
 } from "./reviewer-panel.js";
+import { hashFailureContext, type FailureAnalysisCard } from "./monitor-failure-analysis.js";
 
 // ── v2 typed model ──────────────────────────────────────────────────
 
@@ -339,6 +340,13 @@ export interface BoardCard {
   reviewRequests?: CardReviewRequest[];
   /** C4: real Hermes/agent discussion scoped to this card. */
   discussion?: CardDiscussionMessage[];
+  /**
+   * Hermes's grounded, agentic read of WHY this failed decision card likely
+   * failed + a recommended next step. Threaded on from the failure-analysis
+   * cache ONLY for failure cards, and ONLY when the cached analysis is still
+   * fresh for the card's current failure context. Absent otherwise.
+   */
+  hermesAnalysis?: { text: string; model?: string; at: string };
 }
 
 export interface BoardSnapshotV2 {
@@ -2004,9 +2012,121 @@ function minutesSince(value: string | undefined, now: Date): number {
   return Math.max(0, Math.floor((now.getTime() - ms) / 60_000));
 }
 
+// ── Failure-analysis card selection + projection ─────────────────────
+// The SINGLE definition of "which cards get a Hermes failure analysis": an
+// operator-decision card (isAction, or in an operator-review / needs-attention
+// lane) that represents a FAILURE. Reused by the board threading here and by the
+// failure-analysis routine, so the two never diverge.
+
+// A failure keyword in the verdict, but ONLY when it is NOT negated. The
+// negation guard is load-bearing for the truth-boundary: a passing verdict like
+// "Hermes pre-check passed, no errors" or "previously failing, now green" must
+// NOT be read as a failure (which would invite a fabricated "why it failed").
+// The structured signals below (state/taskStatus/checkRuns/...) are the primary,
+// reliable failure evidence; the verdict keyword is a last-resort fallback.
+const FAILURE_VERDICT = /\b(fail(?:ed|ing|ure)?|blocked|errored|broke|broken|regress(?:ed|ion)?)\b/i;
+// A recovery / negation cue anywhere in the verdict (either order) flips a
+// failure keyword to non-failure: "no errors", "error resolved", "previously
+// failing, now green", "all checks passed". The list is intentionally broad —
+// a false negative (skip a real failure) just leaves the drawer as today, while
+// a false positive would fabricate a "why it failed" on a passing card.
+const RECOVERY_CUE = /\b(no|not|zero|without|resolved|fixed|cleared|passed|passing|green|recovered|now|healthy|succeeded|success)\b/i;
+
+function verdictSignalsFailure(verdict: string): boolean {
+  const trimmed = verdict.trim();
+  if (!trimmed) return false;
+  if (!FAILURE_VERDICT.test(trimmed)) return false;
+  if (RECOVERY_CUE.test(trimmed)) return false; // negated / recovered — not a live failure
+  return true;
+}
+
+/** True when the card is an operator-decision card sitting in a decision lane. */
+function isDecisionCard(card: BoardCard): boolean {
+  return Boolean(card.isAction) || card.lane === "operator-review" || card.lane === "needs-attention";
+}
+
+/**
+ * True when the card carries a real failure signal (never a guess). Prefers the
+ * structured signals (degraded fetch, failed task/mission, failed checks); the
+ * free-text verdict is only a negation-guarded fallback.
+ */
+function hasFailureSignal(card: BoardCard): boolean {
+  if (card.state === "failed-fetch") return true;
+  if (card.taskStatus === "failed") return true;
+  if (card.missionStatus === "failed") return true;
+  if ((card.failureReason ?? "").trim()) return true;
+  if (card.sourceFailure && card.sourceFailure.message.trim()) return true;
+  if ((card.checkRuns ?? []).some((run) => run.status === "fail")) return true;
+  if ((card.checks?.fail ?? 0) > 0) return true;
+  if (verdictSignalsFailure(card.verdict ?? "")) return true;
+  return false;
+}
+
+/**
+ * Project a board card to the grounded failure fields the analysis may read, or
+ * undefined when the card is NOT a failure decision card (so it is skipped).
+ * Done / history cards are always skipped. Every field is copied straight from
+ * the real card — no derivation, no fabrication.
+ */
+export function failureAnalysisCardFor(card: BoardCard): FailureAnalysisCard | undefined {
+  if (card.type === "done") return undefined;
+  if (!isDecisionCard(card) || !hasFailureSignal(card)) return undefined;
+  const failedCheckNames = (card.checkRuns ?? [])
+    .filter((run) => run.status === "fail")
+    .map((run) => run.name);
+  const riskSignals = (card.riskSignals ?? []).map((s) => s.message);
+  return {
+    id: card.id,
+    title: card.title,
+    ...(card.repo ? { repo: card.repo } : {}),
+    ...(card.verdict ? { verdict: card.verdict } : {}),
+    ...(card.failureReason ? { failureReason: card.failureReason } : {}),
+    ...(card.sourceFailure
+      ? {
+          sourceFailure: {
+            source: card.sourceFailure.source,
+            ...(card.sourceFailure.code ? { code: card.sourceFailure.code } : {}),
+            message: card.sourceFailure.message,
+          },
+        }
+      : {}),
+    ...(failedCheckNames.length > 0 ? { failedCheckNames } : {}),
+    ...(card.state ? { state: card.state } : {}),
+    ...(riskSignals.length > 0 ? { riskSignals } : {}),
+    failureKind: failureKindFor(card),
+  };
+}
+
+/** A short, honest label for the kind of failure (derived from the card type). */
+function failureKindFor(card: BoardCard): string {
+  switch (card.type) {
+    case "deploy":
+      return "deploy verification";
+    case "mission":
+      return "browser mission";
+    case "task":
+      return "codex task";
+    case "pr":
+      return "pull request";
+    default:
+      return "board card";
+  }
+}
+
 export function buildV2BoardSnapshot(
   rawSnapshot: unknown,
-  opts: { repo?: string; now?: () => Date } = {}
+  opts: {
+    repo?: string;
+    now?: () => Date;
+    /**
+     * Optional reader for a FRESH cached Hermes failure analysis, keyed by card
+     * id + a failure-context hash. Threaded onto failure decision cards only.
+     * When omitted (the default), or when it returns undefined, cards carry no
+     * analysis and the drawer keeps its existing "Ask Hermes" pointer — so the
+     * feature is byte-for-byte a no-op unless the caller opts in.
+     */
+    getAnalysis?: (cardId: string, failureHash: string) => { text: string; model?: string; at: string } | undefined;
+  } = {}
 ): BoardSnapshotV2 {
   const now = opts.now ?? (() => new Date());
   const snapshotAt = now();
@@ -2068,8 +2188,22 @@ export function buildV2BoardSnapshot(
     return !correlationIds.some((id) => actionableTaskCorrelationIds.has(id));
   });
 
+  // Thread a FRESH cached Hermes failure analysis onto each failure decision
+  // card. No-op unless the caller supplied getAnalysis AND the cache is fresh for
+  // the card's CURRENT failure context (hash match) — a stale analysis for a
+  // changed failure is never surfaced.
+  const allCards = [...cards, ...taskCards];
+  if (opts.getAnalysis) {
+    for (const card of allCards) {
+      const projected = failureAnalysisCardFor(card);
+      if (!projected) continue;
+      const analysis = opts.getAnalysis(card.id, hashFailureContext(projected));
+      if (analysis && analysis.text.trim()) card.hermesAnalysis = analysis;
+    }
+  }
+
   return {
-    cards: [...cards, ...taskCards],
+    cards: allCards,
     at: snapshotAt.toISOString(),
     repo: opts.repo ?? "",
     llmUsage: aggregateLlmUsage(usageEvents(asRecord(rawSnapshot)?.llmUsageEvents), {

--- a/services/slack-operator/src/operator-card-failure-analysis.ts
+++ b/services/slack-operator/src/operator-card-failure-analysis.ts
@@ -1,0 +1,118 @@
+// Per-card Hermes failure analysis cache (feature: grounded failure analysis
+// for operator decision cards).
+//
+// When HERMES_FAILURE_ANALYSIS is on and the gateway session is available, the
+// failure-analysis routine asks the real agentic Hermes for ONE short grounded
+// paragraph explaining why a failed operator-decision card likely failed and a
+// recommended next step (fix vs rollback). That paragraph is cached HERE, keyed
+// by card id, together with a hash of the failure context it was grounded in.
+// The board threads a cached entry back onto the card ONLY when the stored hash
+// still matches the card's current failure context, so a stale analysis for a
+// changed failure is never shown — the routine re-runs when the failure moves.
+//
+// This mirrors operator-card-notes.ts (the per-card JSON store pattern) and is
+// file-backed on /data so it survives a restart. Unlike operator notes this
+// store IS board-facing (it is threaded onto the card the operator reads), but
+// it carries ONLY Hermes's own grounded read of the card's real failure fields
+// — no operator-private text ever flows through it.
+
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { dirname } from "node:path";
+import { optionalEnv } from "@avg/mcp-common";
+
+/** One cached Hermes failure analysis for a card. */
+export interface CardFailureAnalysis {
+  /** The grounded analysis paragraph (Hermes's agentic read). */
+  text: string;
+  /** Model the gateway ran the turn on, when reported. */
+  model?: string;
+  /** When the analysis was produced (ISO). */
+  at: string;
+  /**
+   * Hash of the failure context the analysis was grounded in. The board only
+   * surfaces the analysis while this still matches the card's current failure —
+   * so a changed failure invalidates the cache and the routine re-runs.
+   */
+  failureHash: string;
+}
+
+function analysisPath(path?: string): string {
+  return (
+    path ??
+    optionalEnv("AVERRAY_CARD_FAILURE_ANALYSIS_PATH", "/data/card-failure-analysis.json") ??
+    "/data/card-failure-analysis.json"
+  );
+}
+
+type AnalysisFile = Record<string, CardFailureAnalysis>;
+
+function readFile(path?: string): AnalysisFile {
+  const p = analysisPath(path);
+  try {
+    if (!existsSync(p)) return {};
+    const raw = JSON.parse(readFileSync(p, "utf8")) as unknown;
+    return raw && typeof raw === "object" && !Array.isArray(raw) ? (raw as AnalysisFile) : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Read a card's cached failure analysis, or undefined when none is stored. */
+export function readCardFailureAnalysis(cardId: string, path?: string): CardFailureAnalysis | undefined {
+  const stored = readFile(path)[cardId];
+  return normalizeAnalysis(stored);
+}
+
+/**
+ * Read a card's cached failure analysis ONLY when it is fresh for the given
+ * failure hash. Returns undefined when nothing is stored, or when the stored
+ * analysis was grounded in a different (now-stale) failure context. This is the
+ * single freshness gate the board threading + routine share.
+ */
+export function readFreshCardFailureAnalysis(
+  cardId: string,
+  failureHash: string,
+  path?: string,
+): CardFailureAnalysis | undefined {
+  const stored = readCardFailureAnalysis(cardId, path);
+  if (!stored) return undefined;
+  return stored.failureHash === failureHash ? stored : undefined;
+}
+
+/** Persist a card's failure analysis. Returns the stored value. */
+export function writeCardFailureAnalysis(
+  cardId: string,
+  value: { text: string; model?: string; failureHash: string },
+  now: () => Date = () => new Date(),
+  path?: string,
+): CardFailureAnalysis {
+  const file = readFile(path);
+  const next: CardFailureAnalysis = {
+    text: value.text,
+    ...(value.model ? { model: value.model } : {}),
+    failureHash: value.failureHash,
+    at: now().toISOString(),
+  };
+  file[cardId] = next;
+  const p = analysisPath(path);
+  mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, `${JSON.stringify(file, null, 2)}\n`);
+  return next;
+}
+
+function normalizeAnalysis(value: unknown): CardFailureAnalysis | undefined {
+  const record = (value && typeof value === "object" && !Array.isArray(value) ? value : undefined) as
+    | Partial<CardFailureAnalysis>
+    | undefined;
+  if (!record) return undefined;
+  const text = typeof record.text === "string" ? record.text.trim() : "";
+  const failureHash = typeof record.failureHash === "string" ? record.failureHash : "";
+  const at = typeof record.at === "string" ? record.at : "";
+  if (!text || !failureHash) return undefined;
+  return {
+    text,
+    ...(typeof record.model === "string" && record.model ? { model: record.model } : {}),
+    failureHash,
+    at,
+  };
+}

--- a/services/slack-operator/src/routines.ts
+++ b/services/slack-operator/src/routines.ts
@@ -67,6 +67,16 @@ export interface SlackRoutineConfig {
     lookbackHours: number;
     explore: boolean;
   };
+  /**
+   * Hermes failure analysis: produces a grounded "why it failed + next step" read
+   * for failed operator-decision cards. Off by default; needs the gateway session
+   * to actually run (degraded-safe otherwise). Never mutates a card or the queue.
+   */
+  failureAnalysis: {
+    enabled: boolean;
+    intervalMs: number;
+    maxPerTick: number;
+  };
 }
 
 export function parseSlackRoutineConfig(
@@ -147,6 +157,12 @@ export function parseSlackRoutineConfig(
       lookbackHours: Math.max(1, positiveNumber(env.HERMES_ROUTER_RECENTLY_DONE_LOOKBACK_HOURS) || 72),
       // ORCH-P4c anti-entrenchment: learned routing explores under-sampled agents on soft surfaces.
       explore: env.HERMES_ROUTER_ANTI_ENTRENCHMENT === "1",
+    },
+    failureAnalysis: {
+      // Off by default — reads failed cards only, never mutates anything.
+      enabled: env.HERMES_FAILURE_ANALYSIS === "1",
+      intervalMs: Math.max(60_000, (positiveNumber(env.HERMES_FAILURE_ANALYSIS_INTERVAL_MINUTES) || 5) * 60_000),
+      maxPerTick: Math.max(1, positiveNumber(env.HERMES_FAILURE_ANALYSIS_MAX_PER_TICK) || 3),
     },
   };
 }

--- a/test/unit/failure-analysis-routine.test.ts
+++ b/test/unit/failure-analysis-routine.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HermesSessionConfig, HermesSessionTurn } from "../../services/slack-operator/src/hermes-session-client.js";
+import type { FailureAnalysisCard } from "../../services/slack-operator/src/monitor-failure-analysis.js";
+import { hashFailureContext } from "../../services/slack-operator/src/monitor-failure-analysis.js";
+import {
+  runFailureAnalysisOnce,
+  type FailureAnalysisRoutineConfig,
+  type FailureAnalysisRoutineDeps,
+} from "../../services/slack-operator/src/failure-analysis-routine.js";
+
+const SESSION_CONFIG: HermesSessionConfig = { baseUrl: "http://gw:8642", apiToken: "tok" };
+
+const CARD: FailureAnalysisCard = {
+  id: "deploy-abc",
+  title: "Deploy monitor stack",
+  repo: "depre-dev/averray-reference-agent",
+  verdict: "deploy failed",
+  failedCheckNames: ["unit tests"],
+  failureKind: "deploy verification",
+};
+
+function turn(text: string, model?: string): HermesSessionTurn {
+  return { sessionId: "s1", text, ...(model ? { model } : {}) };
+}
+
+const CONFIG: FailureAnalysisRoutineConfig = { enabled: true, intervalMs: 300_000, maxPerTick: 3 };
+
+/** A store double that records writes and can seed a fresh entry. */
+function store(seed: Record<string, { text: string; failureHash: string }> = {}) {
+  const written: Array<{ cardId: string; value: { text: string; model?: string; failureHash: string } }> = [];
+  const state = new Map(Object.entries(seed));
+  return {
+    written,
+    readFresh: (cardId: string, failureHash: string) => {
+      const hit = state.get(cardId);
+      return hit && hit.failureHash === failureHash ? { text: hit.text } : undefined;
+    },
+    write: (cardId: string, value: { text: string; model?: string; failureHash: string }) => {
+      written.push({ cardId, value });
+      state.set(cardId, { text: value.text, failureHash: value.failureHash });
+    },
+  };
+}
+
+function deps(overrides: Partial<FailureAnalysisRoutineDeps> = {}): FailureAnalysisRoutineDeps {
+  const s = store();
+  return {
+    listFailureCards: () => [CARD],
+    readFresh: s.readFresh,
+    write: s.write,
+    analysisDeps: {
+      enabled: true,
+      sessionConfig: SESSION_CONFIG,
+      runSession: vi.fn(async () => turn("Grounded read: unit tests failed; roll back and re-run.")),
+    },
+    isSuspended: () => false,
+    isHalt: () => false,
+    ...overrides,
+  };
+}
+
+describe("runFailureAnalysisOnce — flag + guardrails", () => {
+  it("is a no-op when the flag is off (byte-for-byte today: no session, no write)", async () => {
+    const runSession = vi.fn(async () => turn("x"));
+    const write = vi.fn();
+    const result = await runFailureAnalysisOnce(
+      { ...CONFIG, enabled: false },
+      deps({ write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(result.status).toBe("disabled");
+    expect(runSession).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("parks under a HALT (never analyzes while halted)", async () => {
+    const runSession = vi.fn(async () => turn("x"));
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ isHalt: () => true, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(result.status).toBe("paused");
+    expect(result.reason).toBe("halt_present");
+    expect(runSession).not.toHaveBeenCalled();
+  });
+
+  it("parks when autopilot is suspended", async () => {
+    const result = await runFailureAnalysisOnce(CONFIG, deps({ isSuspended: () => true }));
+    expect(result.status).toBe("paused");
+    expect(result.reason).toBe("autopilot_suspended");
+  });
+});
+
+describe("runFailureAnalysisOnce — analyze + cache by hash", () => {
+  it("analyzes a failed card and caches it keyed by card id + failure hash", async () => {
+    const s = store();
+    const runSession = vi.fn(async () => turn("unit tests failed; roll back and re-run.", "hermes-4"));
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+
+    expect(result.status).toBe("analyzed");
+    expect(result.analyzed).toEqual([{ cardId: "deploy-abc" }]);
+    expect(s.written).toHaveLength(1);
+    expect(s.written[0]!.cardId).toBe("deploy-abc");
+    expect(s.written[0]!.value.failureHash).toBe(hashFailureContext(CARD));
+    expect(s.written[0]!.value.model).toBe("hermes-4");
+    // the grounded prompt was threaded with the card's real failure fields
+    expect((runSession.mock.calls[0]![1] as string)).toContain("unit tests");
+  });
+
+  it("skips a card that already has a FRESH cached analysis (re-runs only when the failure changes)", async () => {
+    const runSession = vi.fn(async () => turn("new analysis"));
+    const s = store({ "deploy-abc": { text: "cached", failureHash: hashFailureContext(CARD) } });
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(runSession).not.toHaveBeenCalled();
+    expect(s.written).toHaveLength(0);
+    expect(result.status).toBe("idle");
+    expect(result.reason).toBe("all_fresh");
+  });
+
+  it("re-runs when the cached analysis is STALE for the current failure (hash changed)", async () => {
+    const runSession = vi.fn(async () => turn("fresh analysis for the changed failure"));
+    // seeded under a DIFFERENT hash -> stale
+    const s = store({ "deploy-abc": { text: "old", failureHash: "deadbeef" } });
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(runSession).toHaveBeenCalledTimes(1);
+    expect(s.written).toHaveLength(1);
+    expect(result.status).toBe("analyzed");
+  });
+
+  it("skips a card with no diagnosable detail (won't ask Hermes to guess a bare 'failed')", async () => {
+    const runSession = vi.fn(async () => turn("x"));
+    const bare: FailureAnalysisCard = { id: "bare", title: "Failed", verdict: "failed", state: "failed-fetch" };
+    const s = store();
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ listFailureCards: () => [bare], readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(runSession).not.toHaveBeenCalled();
+    expect(s.written).toHaveLength(0);
+    expect(result.status).toBe("idle");
+  });
+
+  it("caps analyses per tick at maxPerTick", async () => {
+    const cards: FailureAnalysisCard[] = [
+      { ...CARD, id: "c1" },
+      { ...CARD, id: "c2" },
+      { ...CARD, id: "c3" },
+    ];
+    const runSession = vi.fn(async () => turn("grounded read"));
+    const s = store();
+    const result = await runFailureAnalysisOnce(
+      { ...CONFIG, maxPerTick: 2 },
+      deps({ listFailureCards: () => cards, readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(runSession).toHaveBeenCalledTimes(2);
+    expect(s.written).toHaveLength(2);
+    expect(result.analyzed).toHaveLength(2);
+  });
+});
+
+describe("runFailureAnalysisOnce — degraded-safe (no fabricated cache)", () => {
+  it("writes NOTHING when the session is unavailable (gateway down) — drawer keeps its pointer", async () => {
+    const s = store();
+    // sessionConfig null -> analyzeCardFailure returns { hermesMode: "none" }
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: null, runSession: vi.fn() } }),
+    );
+    expect(s.written).toHaveLength(0);
+    expect(result.status).toBe("idle");
+    // there WAS a failure card needing analysis, but the gateway was down —
+    // report "degraded", never "all_fresh" / "no_failure_cards".
+    expect(result.reason).toBe("degraded");
+  });
+
+  it("writes NOTHING when the session returns null (never caches a fabricated cause)", async () => {
+    const s = store();
+    const runSession = vi.fn(async () => null);
+    const result = await runFailureAnalysisOnce(
+      CONFIG,
+      deps({ readFresh: s.readFresh, write: s.write, analysisDeps: { enabled: true, sessionConfig: SESSION_CONFIG, runSession } }),
+    );
+    expect(runSession).toHaveBeenCalledTimes(1);
+    expect(s.written).toHaveLength(0);
+    expect(result.status).toBe("idle");
+    expect(result.reason).toBe("degraded");
+  });
+
+  it("returns idle with no failure cards on the board", async () => {
+    const result = await runFailureAnalysisOnce(CONFIG, deps({ listFailureCards: () => [] }));
+    expect(result.status).toBe("idle");
+    expect(result.reason).toBe("no_failure_cards");
+  });
+});

--- a/test/unit/monitor-failure-analysis.test.ts
+++ b/test/unit/monitor-failure-analysis.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HermesSessionConfig, HermesSessionTurn } from "../../services/slack-operator/src/hermes-session-client.js";
+import {
+  analyzeCardFailure,
+  buildFailureAnalysisPrompt,
+  failureContextFactLines,
+  hasDiagnosableFailureDetail,
+  hashFailureContext,
+  type FailureAnalysisCard,
+  type FailureAnalysisDeps,
+} from "../../services/slack-operator/src/monitor-failure-analysis.js";
+
+const FAILED_DEPLOY: FailureAnalysisCard = {
+  id: "deploy-abc",
+  title: "Deploy monitor stack",
+  repo: "depre-dev/averray-reference-agent",
+  verdict: "deploy failed",
+  failureKind: "deploy verification",
+  failedCheckNames: ["unit tests", "browser replay"],
+  state: "failed-fetch",
+};
+
+const SESSION_CONFIG: HermesSessionConfig = { baseUrl: "http://gw:8642", apiToken: "tok" };
+
+function turn(
+  text: string,
+  extra: { usage?: Record<string, unknown> | null; model?: string | null } = {},
+): HermesSessionTurn {
+  return {
+    sessionId: "s1",
+    text,
+    ...(extra.usage !== undefined ? { usage: extra.usage } : {}),
+    ...(extra.model !== undefined ? { model: extra.model } : {}),
+  };
+}
+
+function deps(overrides: Partial<FailureAnalysisDeps> = {}): FailureAnalysisDeps {
+  return {
+    enabled: true,
+    sessionConfig: SESSION_CONFIG,
+    ...overrides,
+  };
+}
+
+describe("failureContextFactLines — truth boundary (no fabrication)", () => {
+  it("emits a line only for failure fields actually present on the card", () => {
+    const lines = failureContextFactLines(FAILED_DEPLOY);
+    expect(lines).toContain("Card: Deploy monitor stack");
+    expect(lines).toContain("Repo: depre-dev/averray-reference-agent");
+    expect(lines).toContain("Verdict: deploy failed");
+    expect(lines).toContain("Failed checks: unit tests, browser replay");
+    expect(lines).toContain("Card state: failed-fetch");
+    expect(lines).toContain("Failure kind: deploy verification");
+  });
+
+  it("stays silent about absent fields — never invents a failure reason or source failure", () => {
+    const sparse: FailureAnalysisCard = { id: "c1", title: "A bare failed card", failureKind: "codex task" };
+    const lines = failureContextFactLines(sparse);
+    const joined = lines.join("\n").toLowerCase();
+    expect(joined).not.toContain("failure reason");
+    expect(joined).not.toContain("source failure");
+    expect(joined).not.toContain("failed checks");
+    expect(joined).not.toContain("risk signals");
+    // Only the present facts remain.
+    expect(lines).toEqual(["Card: A bare failed card", "Failure kind: codex task"]);
+  });
+
+  it("threads a source failure only when it carries a real message", () => {
+    const withSource: FailureAnalysisCard = {
+      id: "c2",
+      title: "Runner offline",
+      sourceFailure: { source: "runner", code: "HEARTBEAT_LOST", message: "no heartbeat for 12m" },
+    };
+    expect(failureContextFactLines(withSource)).toContain("Source failure: runner [HEARTBEAT_LOST]: no heartbeat for 12m");
+    const emptyMsg: FailureAnalysisCard = { id: "c3", title: "x", sourceFailure: { source: "runner", message: "  " } };
+    expect(failureContextFactLines(emptyMsg).some((l) => l.startsWith("Source failure"))).toBe(false);
+  });
+});
+
+describe("hasDiagnosableFailureDetail — skip the undiagnosable", () => {
+  it("is true when the card carries a concrete failure detail", () => {
+    expect(hasDiagnosableFailureDetail(FAILED_DEPLOY)).toBe(true);
+    expect(hasDiagnosableFailureDetail({ id: "x", title: "t", failureReason: "OOM killed" })).toBe(true);
+    expect(hasDiagnosableFailureDetail({ id: "x", title: "t", riskSignals: ["contract touched"] })).toBe(true);
+  });
+
+  it("is false for a bare 'failed' with no diagnosable context (would only invite a guess)", () => {
+    expect(hasDiagnosableFailureDetail({ id: "x", title: "Failed", verdict: "failed", state: "failed-fetch" })).toBe(false);
+  });
+});
+
+describe("buildFailureAnalysisPrompt — grounded prompt + guardrails", () => {
+  it("threads every present failure fact and the no-fabrication + cause-unclear rules", () => {
+    const prompt = buildFailureAnalysisPrompt(FAILED_DEPLOY);
+    expect(prompt).toContain("depre-dev/averray-reference-agent");
+    expect(prompt).toContain("deploy failed");
+    expect(prompt).toContain("unit tests, browser replay");
+    // truth guardrails present
+    expect(prompt).toContain("Ground EVERY claim in the failure facts listed above");
+    expect(prompt).toContain("Do not invent a root cause");
+    expect(prompt).toContain('Cause unclear from the available signals.');
+    expect(prompt).toContain("Never guess a cause to fill the gap");
+    expect(prompt).toContain("fix or a rollback");
+    expect(prompt).toContain("Do not claim you inspected logs");
+  });
+
+  it("does not name a failure signal the card lacks", () => {
+    const prompt = buildFailureAnalysisPrompt({ id: "c", title: "Bare card", failureKind: "pull request" });
+    expect(prompt).not.toMatch(/failure reason:/i);
+    expect(prompt).not.toMatch(/failed checks:/i);
+    expect(prompt).not.toMatch(/source failure:/i);
+  });
+});
+
+describe("hashFailureContext — cache key changes iff the failure changes", () => {
+  it("is stable for the same failure context", () => {
+    expect(hashFailureContext(FAILED_DEPLOY)).toBe(hashFailureContext({ ...FAILED_DEPLOY }));
+  });
+
+  it("changes when a real failure field changes", () => {
+    const before = hashFailureContext(FAILED_DEPLOY);
+    expect(hashFailureContext({ ...FAILED_DEPLOY, failedCheckNames: ["unit tests"] })).not.toBe(before);
+    expect(hashFailureContext({ ...FAILED_DEPLOY, verdict: "deploy failed (retry 2)" })).not.toBe(before);
+  });
+});
+
+describe("analyzeCardFailure — agentic-only, degraded-safe", () => {
+  it("runs the session, tags live, and threads the real failure facts into the prompt", async () => {
+    const runSession = vi.fn(async () =>
+      turn("Both unit tests and browser replay failed on this deploy, so the verification never went green; roll back to the last passing build and re-run before promoting."),
+    );
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ runSession }));
+
+    expect(runSession).toHaveBeenCalledTimes(1);
+    const [cfgArg, promptArg] = runSession.mock.calls[0]!;
+    expect(cfgArg).toBe(SESSION_CONFIG);
+    expect(promptArg).toContain("unit tests, browser replay");
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toContain("roll back");
+  });
+
+  it("is a no-op when the flag is off (default behavior) — no session, no text", async () => {
+    const runSession = vi.fn(async () => turn("should not run"));
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ enabled: false, runSession }));
+    expect(runSession).not.toHaveBeenCalled();
+    expect(result).toEqual({ text: "", hermesMode: "none" });
+  });
+
+  it("is a no-op when no gateway session config resolved (degraded)", async () => {
+    const runSession = vi.fn(async () => turn("should not run"));
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ sessionConfig: null, runSession }));
+    expect(runSession).not.toHaveBeenCalled();
+    expect(result.hermesMode).toBe("none");
+  });
+
+  it("produces NOTHING (never a fabricated cause) when the session returns null", async () => {
+    const runSession = vi.fn(async () => null);
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ runSession }));
+    expect(result).toEqual({ text: "", hermesMode: "none" });
+  });
+
+  it("produces NOTHING when the session throws (never guesses on a gateway error)", async () => {
+    const runSession = vi.fn(async () => {
+      throw new Error("gateway down");
+    });
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ runSession }));
+    expect(result.hermesMode).toBe("none");
+    expect(result.text).toBe("");
+  });
+
+  it("treats a blank agentic reply as no analysis (never tags live off empty text)", async () => {
+    const onSessionTurn = vi.fn();
+    const runSession = vi.fn(async () => turn("   ", { usage: { input_tokens: 5 } }));
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ runSession, onSessionTurn }));
+    expect(result.hermesMode).toBe("none");
+    // no usable text -> nothing to attribute here
+    expect(onSessionTurn).not.toHaveBeenCalled();
+  });
+
+  it("honors the 'cause unclear' path verbatim when the model can't determine the cause", async () => {
+    // The prompt REQUIRES this phrasing when signals are thin; the module surfaces
+    // it verbatim rather than dropping or embellishing it.
+    const runSession = vi.fn(async () =>
+      turn("Cause unclear from the available signals. The safest next step is to open the failed check output before deciding to fix or roll back."),
+    );
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ runSession }));
+    expect(result.hermesMode).toBe("live");
+    expect(result.text).toContain("Cause unclear from the available signals.");
+  });
+
+  it("forwards the successful turn to onSessionTurn (usage) with its model captured", async () => {
+    const onSessionTurn = vi.fn();
+    const produced = turn("Grounded read of the failure.", { usage: { input_tokens: 120, output_tokens: 44 }, model: "hermes-4" });
+    const runSession = vi.fn(async () => produced);
+    const result = await analyzeCardFailure(FAILED_DEPLOY, deps({ runSession, onSessionTurn }));
+
+    expect(result.hermesMode).toBe("live");
+    expect(result.model).toBe("hermes-4");
+    expect(onSessionTurn).toHaveBeenCalledTimes(1);
+    expect(onSessionTurn).toHaveBeenCalledWith(produced);
+  });
+});

--- a/test/unit/monitor-v2-failure-analysis.test.ts
+++ b/test/unit/monitor-v2-failure-analysis.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildV2BoardSnapshot,
+  failureAnalysisCardFor,
+  type BoardCard,
+} from "../../services/slack-operator/src/monitor-v2.js";
+import { hashFailureContext } from "../../services/slack-operator/src/monitor-failure-analysis.js";
+
+function card(over: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "c1",
+    lane: "needs-attention",
+    type: "deploy",
+    agentType: "hermes",
+    title: "Deploy monitor stack",
+    summary: "Deploy failed.",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 3,
+    state: "failed-fetch",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "warn" },
+    isAction: true,
+    ...over,
+  } as BoardCard;
+}
+
+describe("failureAnalysisCardFor — which cards get an analysis (single source of truth)", () => {
+  it("projects a failed operator-decision card to its grounded failure fields", () => {
+    const projected = failureAnalysisCardFor(
+      card({
+        verdict: "deploy failed",
+        checkRuns: [
+          { name: "unit tests", status: "fail" },
+          { name: "lint", status: "pass" },
+          { name: "browser replay", status: "fail" },
+        ],
+        riskSignals: [{ severity: "high", code: "contract_touch", message: "touches escrow contract" }],
+      }),
+    );
+    expect(projected).toBeTruthy();
+    expect(projected!.id).toBe("c1");
+    expect(projected!.repo).toBe("depre-dev/averray-reference-agent");
+    expect(projected!.verdict).toBe("deploy failed");
+    // only the FAILED check names are carried
+    expect(projected!.failedCheckNames).toEqual(["unit tests", "browser replay"]);
+    expect(projected!.riskSignals).toEqual(["touches escrow contract"]);
+    expect(projected!.failureKind).toBe("deploy verification");
+  });
+
+  it("skips a NON-failure decision card (operator-review with a passing pre-check)", () => {
+    const ok = card({
+      type: "pr",
+      lane: "operator-review",
+      isAction: false,
+      state: "fresh",
+      verdict: "Hermes pre-check passed",
+    });
+    expect(failureAnalysisCardFor(ok)).toBeUndefined();
+  });
+
+  it("does NOT treat a NEGATED failure keyword in the verdict as a failure (truth boundary)", () => {
+    // These verdicts contain 'error'/'fail' but are passing — a fabricated
+    // "why it failed" here would violate the truth boundary.
+    for (const verdict of [
+      "Hermes pre-check passed, no errors",
+      "previously failing, now green",
+      "all checks passed; error resolved",
+      "no failures found",
+    ]) {
+      const passing = card({ type: "pr", lane: "operator-review", isAction: false, state: "fresh", verdict });
+      expect(failureAnalysisCardFor(passing)).toBeUndefined();
+    }
+  });
+
+  it("DOES treat an un-negated failure verdict as a failure", () => {
+    const failed = card({ type: "pr", lane: "operator-review", isAction: false, state: "fresh", verdict: "deploy failed at verification" });
+    expect(failureAnalysisCardFor(failed)).toBeTruthy();
+  });
+
+  it("skips a non-decision card even when it has a failure signal (not awaiting the operator)", () => {
+    const checking = card({ lane: "hermes-checking", isAction: false, verdict: "deploy failed" });
+    expect(failureAnalysisCardFor(checking)).toBeUndefined();
+  });
+
+  it("skips done / history cards", () => {
+    const done = card({ type: "done", lane: "done", isAction: false, verdict: "failed" });
+    expect(failureAnalysisCardFor(done)).toBeUndefined();
+  });
+
+  it("recognizes a failed task card via taskStatus + failureReason", () => {
+    const task = card({
+      type: "task",
+      taskStatus: "failed",
+      failureReason: "runner exited non-zero: npm ci failed",
+      state: "fresh",
+    });
+    const projected = failureAnalysisCardFor(task);
+    expect(projected).toBeTruthy();
+    expect(projected!.failureReason).toBe("runner exited non-zero: npm ci failed");
+    expect(projected!.failureKind).toBe("codex task");
+  });
+});
+
+describe("buildV2BoardSnapshot — threads a FRESH analysis onto failure cards only", () => {
+  // A raw snapshot that classifies into an operator-review DECISION card carrying
+  // a real GitHub source-read failure (→ failed-fetch + sourceFailure), so
+  // failureAnalysisCardFor selects it.
+  const raw = {
+    active: [
+      {
+        title: "Deploy monitor stack",
+        status: "needs_review",
+        intent: "operator_review",
+        summary: {
+          pullRequest: { repo: "depre-dev/agent", number: 601, state: "open" },
+          finalVerdict: "operator_review",
+          githubLive: {
+            fetchError: { code: "500", message: "GitHub returned 500 reading /pulls/601", lastGoodAt: "2026-06-30T12:00:00Z" },
+          },
+        },
+        ageLabel: "5m",
+      },
+    ],
+    recent: [],
+  };
+
+  it("attaches the cached analysis when its hash matches the card's current failure", () => {
+    // First build with no reader to learn the real card + its failure hash.
+    const probe = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    const failureCard = probe.cards.find((c) => failureAnalysisCardFor(c));
+    expect(failureCard).toBeTruthy();
+    const projected = failureAnalysisCardFor(failureCard!)!;
+    const hash = hashFailureContext(projected);
+
+    const analysis = { text: "GitHub read failed (500); this is an upstream/source outage, not a code regression — retry the fetch, don't roll back the deploy.", at: "2026-06-30T13:00:00Z" };
+    const built = buildV2BoardSnapshot(raw, {
+      repo: "depre-dev/agent",
+      getAnalysis: (cardId, failureHash) =>
+        cardId === failureCard!.id && failureHash === hash ? analysis : undefined,
+    });
+    const withAnalysis = built.cards.find((c) => c.id === failureCard!.id);
+    expect(withAnalysis?.hermesAnalysis).toEqual(analysis);
+  });
+
+  it("does NOT attach a stale analysis (reader returns undefined for a non-matching hash)", () => {
+    const built = buildV2BoardSnapshot(raw, {
+      repo: "depre-dev/agent",
+      // reader that never matches (simulates a stale cache for a changed failure)
+      getAnalysis: () => undefined,
+    });
+    expect(built.cards.every((c) => c.hermesAnalysis === undefined)).toBe(true);
+  });
+
+  it("is byte-for-byte today's behavior when no reader is supplied (no analysis field anywhere)", () => {
+    const built = buildV2BoardSnapshot(raw, { repo: "depre-dev/agent" });
+    expect(built.cards.every((c) => c.hermesAnalysis === undefined)).toBe(true);
+    expect(JSON.stringify(built)).not.toContain("hermesAnalysis");
+  });
+});

--- a/test/unit/operator-card-failure-analysis.test.ts
+++ b/test/unit/operator-card-failure-analysis.test.ts
@@ -1,0 +1,66 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readCardFailureAnalysis,
+  readFreshCardFailureAnalysis,
+  writeCardFailureAnalysis,
+} from "../../services/slack-operator/src/operator-card-failure-analysis.js";
+
+describe("operator-card-failure-analysis — per-card cache keyed by failure hash", () => {
+  let dir: string;
+  let path: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "averray-failure-analysis-"));
+    path = join(dir, "card-failure-analysis.json");
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns undefined when nothing is stored", () => {
+    expect(readCardFailureAnalysis("deploy-abc", path)).toBeUndefined();
+    expect(readFreshCardFailureAnalysis("deploy-abc", "hash1", path)).toBeUndefined();
+  });
+
+  it("round-trips a stored analysis with its model + failure hash + timestamp", () => {
+    writeCardFailureAnalysis(
+      "deploy-abc",
+      { text: "unit tests failed; roll back and re-run.", model: "hermes-4", failureHash: "hash1" },
+      () => new Date("2026-07-01T00:00:00Z"),
+      path,
+    );
+    const read = readCardFailureAnalysis("deploy-abc", path);
+    expect(read).toEqual({
+      text: "unit tests failed; roll back and re-run.",
+      model: "hermes-4",
+      failureHash: "hash1",
+      at: "2026-07-01T00:00:00.000Z",
+    });
+  });
+
+  it("readFresh returns the entry only when the failure hash still matches", () => {
+    writeCardFailureAnalysis("deploy-abc", { text: "grounded", failureHash: "hash1" }, () => new Date(), path);
+    // Fresh for the same failure...
+    expect(readFreshCardFailureAnalysis("deploy-abc", "hash1", path)?.text).toBe("grounded");
+    // ...stale once the failure context (hash) changed.
+    expect(readFreshCardFailureAnalysis("deploy-abc", "hash2", path)).toBeUndefined();
+  });
+
+  it("is scoped per card — a different card is unaffected", () => {
+    writeCardFailureAnalysis("card-1", { text: "a", failureHash: "h" }, () => new Date(), path);
+    expect(readCardFailureAnalysis("card-2", path)).toBeUndefined();
+  });
+
+  it("ignores a malformed entry (missing text or hash)", () => {
+    // A well-formed write, then confirm normalization drops junk shapes by
+    // writing a second card and reading the first back cleanly.
+    writeCardFailureAnalysis("ok", { text: "fine", failureHash: "h" }, () => new Date(), path);
+    expect(readCardFailureAnalysis("ok", path)?.text).toBe("fine");
+    // An empty-text write yields no usable entry on read-back.
+    writeCardFailureAnalysis("blank", { text: "   ", failureHash: "h" }, () => new Date(), path);
+    expect(readCardFailureAnalysis("blank", path)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

A failed operator-decision card (deploy failed / failed task / degraded fetch) showed a bare verdict and no path forward. This adds a **flag-gated** feature (`HERMES_FAILURE_ANALYSIS`, default **off**) where the real agentic Hermes produces **one grounded paragraph** for such a card — likely *why* it failed + a recommended next step (**fix vs rollback**), or an explicit *"cause unclear from the available signals"* when the data is thin. It renders in the drawer as **"Hermes's read"**, tagged as an agentic analysis.

## How

- **Pure producer** `monitor-failure-analysis.ts` — grounded fact extraction (one line per real failure field, only when non-empty), truth-guarded prompt (forbids inventing a cause; requires the "cause unclear" phrasing), a failure-context hash, and `analyzeCardFailure` (session-only, degraded-safe). Modeled on `monitor-router-narration.ts` (#472).
- **Routine** `failure-analysis-routine.ts` (`runFailureAnalysisOnce`, modeled on `runHermesRouterOnce`) — walks the board, picks failed decision cards lacking a **fresh** cached analysis, produces + caches it. Never approves/dispatches/merges/mutates.
- **Per-card store** `operator-card-failure-analysis.ts` — JSON cache keyed by card id + a hash of the failure context (re-runs only when the failure changes). Mirrors `operator-card-notes.ts`.
- **Card threading** — `buildV2BoardSnapshot` gains an optional `getAnalysis` reader (flag-gated in `index.ts`); `failureAnalysisCardFor` is the single definition of *which* cards get analyzed, reused by the board and the routine so they never diverge.
- **Drawer** — new "Hermes's read" section in `DrawerBody.tsx` when `card.hermesAnalysis` is present; absent → the existing "Ask Hermes" pointer is untouched.
- **Flag + wiring** — `routines.ts` parse, `index.ts` scheduler + session transport with usage recording (mirrors the router-narration `onSessionTurn`), `ops/compose.yml` passthrough.

## Truth-boundary

- Grounded **only** in real failure fields; **no template fallback** (a canned cause would be fabrication — the only transport is the real session).
- Explicit **"cause unclear"** path when signals are thin; verdict-keyword selection is **negation-guarded** so "no errors" / "now green" is never read as a failure.
- Tagged **"agentic analysis" / "not a verified root cause"** in the UI; **LLM usage recorded**.
- **Flag OFF = byte-for-byte today's behavior** (no reader, no analysis field, drawer unchanged).

## Tests

47 new tests across the pure module, routine, store, board threading, and drawer — grounded-only prompt, cache-by-hash + freshness, degraded-safe, flag-off no-op, the "cause unclear" path, the negation guard, and the honesty tagging. No regressions in the touched suites (`monitor-v2`, drawer, routines).

```
npx tsc -b packages/averray-mcp packages/monitor-ui services/slack-operator
npx vitest run test/unit/monitor-failure-analysis.test.ts test/unit/failure-analysis-routine.test.ts test/unit/operator-card-failure-analysis.test.ts test/unit/monitor-v2-failure-analysis.test.ts packages/monitor-ui/src/components/drawer/DrawerBody.hermesAnalysis.test.tsx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)