### PR TITLE
polish(monitor): fix composer bleed-through + unreadable active scope chip

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -369,16 +369,19 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(onMute.mock.calls[0]?.[0]).toBeGreaterThan(Date.now() + 59 * 60_000);
   });
 
-  test("Ask Hermes float gives immediate feedback and focuses the composer (collaboration on)", () => {
+  test("the `a` Ask-Hermes shortcut gives immediate feedback and focuses the composer (collaboration on)", () => {
+    // The floating "Ask Hermes" pill was removed as a redundant duplicate of the
+    // rail composer (it bled out from under it). `a` — focus a card, then Ask
+    // about it — is the real remaining trigger for the same triggerAsk path.
     const { getByRole, getByText } = render(
       <BoardView
         board={richBoard}
         status="open"
-        keyboard={false}
         collaboration={{ fetcher: async () => [], poster: async () => {}, refreshIntervalMs: 0 }}
       />,
     );
-    fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
+    fireEvent.keyDown(document.body, { key: "j" }); // focus the first card
+    fireEvent.keyDown(document.body, { key: "a" }); // Ask Hermes about it
     // P0-4: the action is visibly acknowledged (transient status line)…
     expect(getByText(/Asking Hermes/)).toBeTruthy();
     // …and the (enabled) composer takes focus.
@@ -390,11 +393,9 @@ describe("BoardView — rich-mix board (open stream)", () => {
     // input must stay usable for commands while the free-form Ask path is
     // honestly unavailable.
     const onMute = vi.fn();
-    const { getByRole, getByText, container } = render(
+    const { getByRole, container } = render(
       <BoardView board={richBoard} status="open" keyboard={false} onMute={onMute} />,
     );
-    fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
-    expect(getByText(/Ask Hermes unavailable/)).toBeTruthy();
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     expect(input.disabled).toBe(false);
     // A free-form question reports unavailable instead of silently dropping…
@@ -409,8 +410,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
 
   test("Ask Hermes composer is fully disabled when it is Ask-only and collaboration is off", () => {
     // No command handlers wired → Ask-only → the input is honestly disabled.
-    const { getByRole, container } = render(<BoardView board={richBoard} status="open" keyboard={false} />);
-    fireEvent.click(getByRole("button", { name: "Ask Hermes" }));
+    const { container } = render(<BoardView board={richBoard} status="open" keyboard={false} />);
     const input = container.querySelector(".hm-compose-input") as HTMLTextAreaElement;
     expect(input.disabled).toBe(true);
     expect(input.getAttribute("aria-label")).toMatch(/Ask Hermes unavailable/);

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -667,21 +667,13 @@ export function BoardView({
         />
       ) : null}
 
-      {!drawerCard ? (
-        <button
-          type="button"
-          className="hm-ask-float"
-          onClick={() => {
-            const nextFocusId = boardFocusId ?? state.banner.primaryActionId ?? state.mostUrgent?.id ?? orderedCards[0]?.id ?? null;
-            const card = nextFocusId ? orderedCards.find((c) => c.id === nextFocusId) : undefined;
-            triggerAsk(nextFocusId, card?.title ?? card?.id);
-          }}
-          aria-label="Ask Hermes"
-        >
-          <span className="mark" aria-hidden>H</span>
-          Ask Hermes <span className="hm-kbd">A</span>
-        </button>
-      ) : null}
+      {/* The old `.hm-ask-float` FAB was a fallback "Ask Hermes" button for a
+          layout with no co-pilot column. This board ALWAYS renders <CoPilotRail>
+          (above) with its own always-on Ask-Hermes composer in the same
+          bottom-right corner, so the FAB was permanently redundant — and its
+          coral pill bled out from under the composer. Removed. The `a` shortcut
+          still scopes + focuses the rail composer (useBoardKeyboard → onAsk →
+          triggerAsk), and the drawer's "Ask Hermes" action does the same. */}
 
       {overlayOpen ? <KeyboardOverlay onClose={() => setOverlayOpen(false)} /> : null}
     </div>

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.test.tsx
@@ -95,7 +95,10 @@ describe("CoPilotRail", () => {
       <CoPilotRail focusedCard={card548} collaboration={{ fetcher: async () => [], refreshIntervalMs: 0 }} />,
       { wrapper },
     );
-    expect(getByText("scope · agent #548")).toBeTruthy();
+    // #481 switched the composer scope chip to shortId (`agent #548` → `#548`)
+    // and updated AskHermesComposer.test.tsx, but missed this sibling that renders
+    // the same composer — leaving it red on main. Match the shipped behaviour.
+    expect(getByText("scope · #548")).toBeTruthy();
   });
 
   test("asking a question scoped to the focused card posts relatedPr and renders the reply", async () => {

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -2824,7 +2824,10 @@ button.hm-turn-pin {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.hm-compose-chip.is-on { background: var(--hm-ink); color: #fffdf7; border-color: var(--hm-ink); }
+/* --hm-ink remaps to a LIGHT cream in this dark theme, so the active chip has a
+   light background — its text must be DARK (var(--hm-paper)), not white, or it's
+   invisible (white-on-cream). */
+.hm-compose-chip.is-on { background: var(--hm-ink); color: var(--hm-paper); border-color: var(--hm-ink); }
 
 /* ============================================================
    DETAIL DRAWER (over board)
@@ -3114,38 +3117,11 @@ button.hm-turn-pin {
   display: inline-flex; gap: 3px;
 }
 
-/* Persistent Ask Hermes floating composer (for board with no Hermes column) */
-.hm-ask-float {
-  position: absolute;
-  right: 22px; bottom: 22px;
-  display: flex; align-items: center; gap: 10px;
-  padding: 10px 14px 10px 12px;
-  border-radius: 999px;
-  /* dark-mode: --hm-ink remaps to a LIGHT ink (#EDE6DD), which turned this
-     floating pill into a cream patch with near-invisible text bleeding up at
-     the board's bottom-right. It's the "Ask Hermes" CTA, so use the on-theme
-     coral action colour (--h4-act) with white text. */
-  background: var(--h4-act);
-  color: #fffdf7;
-  box-shadow: var(--hm-shadow-pop);
-  cursor: pointer;
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 12.5px;
-  border: 0;
-}
-.hm-ask-float .mark {
-  width: 22px; height: 22px;
-  border-radius: 6px;
-  background: var(--hm-sage);
-  color: #fffdf7;
-  display: grid; place-items: center;
-  font-size: 11px; font-weight: 800;
-}
-.hm-ask-float .hm-kbd {
-  background: rgba(255,253,247,0.18);
-  color: #fffdf7;
-}
+/* The `.hm-ask-float` FAB was removed: the co-pilot rail is always present
+   with its own Ask-Hermes composer in this same bottom-right corner, so the
+   floating pill was redundant and bled out from under the composer. The `a`
+   shortcut and the drawer's "Ask Hermes" action drive the rail composer
+   directly. See BoardView.tsx for the note. */
 
 /* ============================================================
    TIMELINE STRIP (deploy timeline / activity)
@@ -3933,7 +3909,7 @@ button.hm-turn-pin {
 .hm-ask-status {
   position: absolute;
   right: 22px;
-  bottom: 72px; /* sits just above the .hm-ask-float pill */
+  bottom: 22px; /* bottom-right corner (the old .hm-ask-float pill is gone) */
   pointer-events: none;
   z-index: 20;
 }


### PR DESCRIPTION
Two operator-reported composer issues from the live board (screenshots): something bled out from under the composer at the bottom-right, and an active chip was white-on-cream (unreadable).

## Bleed-through — removed the redundant floating "Ask Hermes" pill
`.hm-ask-float` was a fallback FAB "for a board with no Hermes column." But this board **always** renders `<CoPilotRail>` (with its own always-on Ask-Hermes composer) in the *same* bottom-right corner — the sole media query (`max-width:1100px`) never hides the rail — so the pill was permanently redundant and physically collided with the composer, poking its coral edge out from underneath.

Removed the render + its dead CSS. **No capability lost:** the `a` shortcut (`useBoardKeyboard → onAsk → triggerAsk`) and the drawer's "Ask Hermes" action still scope + focus the rail composer via the identical `triggerAsk` path. The P0-4 immediate-feedback toast now sits in the corner the pill vacated.

## Contrast — active scope chip was invisible
`.hm-compose-chip.is-on` set `color: #fffdf7` (white) on `background: var(--hm-ink)`, which remaps to a **light cream** in this dark theme → white-on-cream. Text is now `var(--hm-paper)` (dark), readable on the light chip.

## Tests
- Retargeted the three FAB-driven `BoardView` tests to the `a` shortcut / direct composer state. The behaviours they covered (immediate feedback, honest-unavailable, disabled-when-ask-only) are unchanged — just no longer routed through the removed button.
- Also repairs a **pre-existing red test on `main`**: #481 switched the composer scope chip to `shortId` (`agent #548` → `#548`) and updated `AskHermesComposer.test.tsx`, but missed `CoPilotRail.test.tsx`, which renders the same composer. Confirmed failing in isolation on the base commit; not introduced here.

## Verification
- `monitor-ui`: **713 tests pass** (70 files)
- `npm run typecheck` (tsc -b) clean
- `npm run build` (vite) clean — 122 modules

Frontend-only; ships in the `slack-operator` image on the next `--build`. **Please review + merge — not auto-merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)