### PR TITLE
monitor: verify proposed-task PR claims against real ground-truth

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DrawerBody.groundTruth.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.groundTruth.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DrawerBody, drawerVariant } from "./DrawerBody.js";
+import type { BoardCard, CardGroundTruth, CardClaimFlag } from "../../lib/monitor/card-types.js";
+
+afterEach(cleanup);
+
+/**
+ * A proposed Codex task card that cites a PR. The ground-truth panel lives in
+ * the SHARED DrawerBody wrapper, so it renders regardless of which body variant
+ * the card routes to (an actionable task routes to the "action"/PrBody variant,
+ * not TaskBody — this proves the wrapper avoids that trap).
+ */
+function taskCard(over: {
+  groundTruth?: CardGroundTruth;
+  claimFlags?: CardClaimFlag[];
+  isAction?: boolean;
+}): BoardCard {
+  return {
+    id: "codex-task-depre-dev-agent-new-1-aa",
+    type: "task",
+    lane: "codex-needed",
+    agentType: "codex",
+    title: "Decompose blocked PR #717",
+    summary: "Awaiting operator approval to dispatch.",
+    repo: "depre-dev/agent",
+    freshness: 2,
+    state: "fresh",
+    risk: [],
+    taskStatus: "proposed",
+    prompt: "decompose blocked PR #717 — it blocks the merge and touches secrets + migrations.",
+    waitingOn: { actor: "operator", tone: "warn" },
+    ...over,
+  } as unknown as BoardCard;
+}
+
+describe("DrawerBody — proposed-task ground-truth verification panel", () => {
+  test("mismatch card renders the ⚠ warn block with each flag's detail", () => {
+    const card = taskCard({
+      groundTruth: {
+        pr: 717,
+        repo: "depre-dev/agent",
+        verified: true,
+        mergeableState: "clean",
+        checks: { passed: 5, failed: 0, total: 5 },
+        touchedAreas: ["contracts", "tests"],
+        verdict: "ok_to_merge",
+      },
+      claimFlags: [
+        { kind: "claimed_blocked_but_mergeable", detail: "Task says PR #717 is blocked, but it is clean with 0 failed checks." },
+        { kind: "claimed_category_absent", detail: "Task claims 'secrets' + 'migrations', but PR #717's real diff touches: contracts, tests." },
+      ],
+    });
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    const text = container.textContent ?? "";
+    // The warn header + both flag details are surfaced.
+    expect(text).toMatch(/claim doesn't match the PR/i);
+    expect(text).toMatch(/is blocked, but it is clean with 0 failed checks/);
+    expect(text).toMatch(/real diff touches: contracts, tests/);
+    // The real ground-truth signals are shown as fact.
+    expect(text).toMatch(/717 · ground truth|717 ground truth/);
+    expect(text).toMatch(/5\/5 passed/);
+    // The warn tint is applied (not the calm/green "consistent" line).
+    expect(container.querySelector(".hm-verdict-block--warn")).toBeTruthy();
+    expect(text).not.toMatch(/consistent with the PR's real signals/);
+  });
+
+  test("verified card WITH NO flags renders the calm 'consistent' line, not a warning", () => {
+    const card = taskCard({
+      isAction: false,
+      groundTruth: {
+        pr: 717,
+        repo: "depre-dev/agent",
+        verified: true,
+        mergeableState: "clean",
+        checks: { passed: 5, failed: 0, total: 5 },
+        touchedAreas: ["contracts"],
+        verdict: "ok_to_merge",
+      },
+    });
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    const text = container.textContent ?? "";
+    expect(text).toMatch(/consistent with the PR's real signals/);
+    expect(container.querySelector(".hm-verdict-block--warn")).toBeNull();
+  });
+
+  test("verified:false card renders an honest 'couldn't verify' note — NEVER a green/consistent state", () => {
+    const card = taskCard({
+      groundTruth: {
+        pr: 717,
+        repo: "depre-dev/agent",
+        verified: false,
+        reason: "PR state unavailable — not among the fetched open PRs, rate-limited, or already closed.",
+      },
+    });
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    const text = container.textContent ?? "";
+    expect(text).toMatch(/Couldn't verify PR #717/);
+    expect(text).toMatch(/Judge Hermes's claim yourself/);
+    // Truth boundary: no agreement, no warn, no ground-truth grid.
+    expect(text).not.toMatch(/consistent with the PR's real signals/);
+    expect(container.querySelector(".hm-verdict-block--warn")).toBeNull();
+    expect(container.querySelector(".h4-eo")).toBeNull();
+  });
+
+  test("no groundTruth ⇒ the section is absent entirely (honest absence, no PR cited)", () => {
+    const card = taskCard({});
+    const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
+    const text = container.textContent ?? "";
+    expect(text).not.toMatch(/Verify the claim/);
+    expect(text).not.toMatch(/ground truth/i);
+    expect(text).not.toMatch(/Couldn't verify/);
+  });
+});

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -8,7 +8,9 @@ import type {
   BoardCard,
   CardCheckRun,
   CardChecks,
+  CardClaimFlag,
   CardFile,
+  CardGroundTruth,
   CardReviewRequest,
   CardRiskSignal,
   DeployCard,
@@ -88,12 +90,126 @@ export function DrawerBody({ card, variant }: { card: BoardCard; variant: Drawer
   return (
     <>
       {body}
+      <GroundTruthSection card={card} />
       <HermesReadSection card={card} />
       <DecisionContextSection card={card} />
       <DecisionRecordSection record={card.decisionRecord} />
       <OperatorNotes cardId={card.id} />
     </>
   );
+}
+
+/**
+ * "Verify the claim" — for a proposed task whose free-text prompt cites a PR,
+ * show that PR's REAL signals (joined server-side, zero client fetch) next to
+ * Hermes's claim so a fabricated premise is caught at the decision point. This
+ * lives in the shared DrawerBody wrapper (not TaskBody) because an actionable
+ * task routes to the "action" variant → PrBody, not TaskBody; the wrapper shows
+ * it regardless of variant.
+ *
+ * TRUTH BOUNDARY:
+ *  - No cited PR ⇒ card.groundTruth is absent ⇒ this renders nothing (honest
+ *    absence — we never invent a PR to check).
+ *  - groundTruth.verified === false ⇒ a MUTED "couldn't verify" note carrying
+ *    only the honest reason. Never a green check, never read as agreement.
+ *  - verified ⇒ the PR's actual mergeable state / checks / touched areas /
+ *    verdict as plain fact. A prominent ⚠ warn block ONLY when the server
+ *    attached conservative claimFlags; otherwise a calm "consistent" line, which
+ *    is honest precisely because we DID verify against the real PR.
+ * Every value comes from the real joined summary — nothing here is fabricated.
+ */
+function GroundTruthSection({ card }: { card: BoardCard }) {
+  const gt = (card as { groundTruth?: CardGroundTruth }).groundTruth;
+  if (!gt) return null;
+
+  // Couldn't verify — muted, visually distinct from a verified/agreement state.
+  if (!gt.verified) {
+    return (
+      <section>
+        <div className="hm-section-h" style={{ color: "var(--hm-muted)" }}>
+          Verify the claim · PR #{gt.pr}
+        </div>
+        <div className="hm-verdict-block">
+          <div className="body" style={{ color: "var(--hm-muted)" }}>
+            Couldn't verify PR #{gt.pr}
+            {gt.repo ? <> in <b>{gt.repo}</b></> : null} — {gt.reason ?? "PR state unavailable."} Judge Hermes's claim yourself.
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const flags = (card as { claimFlags?: CardClaimFlag[] }).claimFlags ?? [];
+  const rows = groundTruthRows(gt);
+  return (
+    <section>
+      <div className="hm-section-h">Verify the claim · PR #{gt.pr} ground truth</div>
+
+      {flags.length > 0 ? (
+        <div className="hm-verdict-block hm-verdict-block--warn" style={{ marginBottom: 10 }}>
+          <div className="head">⚠ Hermes's claim doesn't match the PR</div>
+          <div className="body">
+            <ul style={{ margin: "6px 0 0", paddingLeft: 18 }}>
+              {flags.map((f) => (
+                <li key={f.kind}>{f.detail}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : (
+        <div className="hm-verdict-block" style={{ marginBottom: 10 }}>
+          <div className="body" style={{ color: "var(--hm-sage-deep)" }}>
+            Hermes's claim is consistent with the PR's real signals.
+          </div>
+        </div>
+      )}
+
+      <div className="h4-eo" role="table" aria-label="PR ground truth">
+        <div className="h4-eo-row h4-eo-head" role="row">
+          <span role="columnheader">signal</span>
+          <span role="columnheader" style={{ gridColumn: "span 3" }}>
+            real PR state
+          </span>
+        </div>
+        {rows.map((r) => (
+          <div className="h4-eo-row" role="row" key={r.label} style={{ gridTemplateColumns: "1.1fr 3fr" }}>
+            <span role="cell">{r.label}</span>
+            <span className="mono" role="cell" style={{ gridColumn: "span 3" }}>
+              {r.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      <div className="hm-card-meta" style={{ marginTop: 8 }}>
+        Real signals from PR #{gt.pr}
+        {gt.repo ? <> in {gt.repo}</> : null} — joined from the fetched PR state, not from the task text.
+      </div>
+    </section>
+  );
+}
+
+/** Turn the verified ground-truth into plain label/value rows (only the fields
+ *  the join actually carried — never a fabricated placeholder). */
+function groundTruthRows(gt: CardGroundTruth): Array<{ label: string; value: string }> {
+  const rows: Array<{ label: string; value: string }> = [];
+  const mergeBits = [
+    gt.merged ? "merged" : undefined,
+    gt.draft ? "draft" : undefined,
+    gt.mergeableState,
+    gt.state && gt.state !== "open" ? gt.state : undefined,
+  ].filter(Boolean);
+  if (mergeBits.length > 0) rows.push({ label: "mergeable", value: mergeBits.join(" · ") });
+  if (gt.checks) {
+    rows.push({
+      label: "checks",
+      value: `${gt.checks.passed}/${gt.checks.total} passed${gt.checks.failed > 0 ? ` · ${gt.checks.failed} failed` : ""}`,
+    });
+  }
+  if (gt.touchedAreas && gt.touchedAreas.length > 0) {
+    rows.push({ label: "touched areas", value: gt.touchedAreas.join(", ") });
+  }
+  if (gt.verdict) rows.push({ label: "verdict", value: gt.verdict });
+  return rows;
 }
 
 /**

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -77,6 +77,33 @@ export interface CardRiskSignal {
   message: string;
 }
 
+/**
+ * Mirrors the backend CardGroundTruth (monitor-v2.ts). The REAL signals of the
+ * PR a proposed task's prompt cites, joined server-side from the already-fetched
+ * PR summary. `verified:false` carries ONLY the honest "couldn't verify" reason
+ * — the drawer must render that as a muted note, never a green/consistent state.
+ */
+export interface CardGroundTruth {
+  pr: number;
+  repo: string;
+  verified: boolean;
+  reason?: string;
+  mergeableState?: string;
+  state?: string;
+  draft?: boolean;
+  merged?: boolean;
+  checks?: { passed: number; failed: number; total: number };
+  touchedAreas?: string[];
+  verdict?: string;
+}
+
+/** Mirrors the backend CardClaimFlag — a conservative, high-confidence mismatch
+ *  between a task's claim and the PR's real signals. */
+export interface CardClaimFlag {
+  kind: "claimed_blocked_but_mergeable" | "claimed_category_absent";
+  detail: string;
+}
+
 export interface CardReviewRequest {
   id: string;
   requestedBy: "hermes" | "operator" | "codex" | "claude" | "test-writer" | "security" | "docs";
@@ -337,6 +364,11 @@ export interface CodexTaskCard extends CardBase {
   taskEvents?: TaskTimelineEvent[];
   output?: string;
   failureReason?: string;
+  /** Ground-truth of the PR this task's prompt cites (when it cites one). Drives
+   *  the drawer's "verify the claim against the real PR" panel. */
+  groundTruth?: CardGroundTruth;
+  /** Conservative, high-confidence claim-vs-reality mismatches for that PR. */
+  claimFlags?: CardClaimFlag[];
 }
 
 /** Payload for proposing a task from the board (O3 dispatch). */

--- a/services/slack-operator/src/github-pr-state.ts
+++ b/services/slack-operator/src/github-pr-state.ts
@@ -983,7 +983,13 @@ function numberField(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
-function inferTouchedArea(path: string): string {
+/**
+ * Classify a changed file into a coarse risk area. Shared vocabulary: the
+ * board's proposed-task ground-truth check (monitor-v2) reconciles a task's
+ * free-text claim against the PR's REAL touched areas using the exact same
+ * classifier the live PR review does, so the two never disagree on wording.
+ */
+export function inferTouchedArea(path: string): string {
   const p = path.toLowerCase();
   if (p.includes("secret") || p.endsWith(".env") || p.includes(".env.")) return "secrets";
   if (p.startsWith("contracts/") || p.endsWith(".sol")) return "contracts";
@@ -998,7 +1004,7 @@ function inferTouchedArea(path: string): string {
   return "other";
 }
 
-function highRiskForFile(path: string): "high" | "medium" | "low" {
+export function highRiskForFile(path: string): "high" | "medium" | "low" {
   const p = path.toLowerCase();
   if (p.includes("secret") || p.endsWith(".env") || p.includes(".env.") || p.includes("migration") || p.startsWith("contracts/") || p.endsWith(".sol")) return "high";
   const area = inferTouchedArea(path);

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -188,6 +188,41 @@ export interface CardSourceFailure {
   lastGoodAt?: string;
 }
 
+/**
+ * The REAL signals of the PR a proposed task's prompt cites, joined from the
+ * already-fetched PR summary (zero new network calls). Lets the operator judge
+ * a task's free-text premise against the PR's actual state at the decision
+ * point. `verified:false` carries ONLY the honest "couldn't verify" reason —
+ * never a partial/fabricated signal set (see reconcileTaskClaim).
+ */
+export interface CardGroundTruth {
+  /** The PR number cited in the task prompt/reason (or task.pullRequestNumber). */
+  pr: number;
+  repo: string;
+  /** true ⇒ the PR was found among the fetched open PRs and its signals are real. */
+  verified: boolean;
+  /** Only when verified:false — why the PR state couldn't be confirmed. */
+  reason?: string;
+  mergeableState?: string;
+  state?: string;
+  draft?: boolean;
+  merged?: boolean;
+  checks?: { passed: number; failed: number; total: number };
+  touchedAreas?: string[];
+  verdict?: string;
+}
+
+/**
+ * A CONSERVATIVE, high-confidence mismatch between the task's free-text claim
+ * and the PR's real signals. Emitted only when unambiguous — a false "no
+ * mismatch" is fine (the operator still sees the real ground truth), a false
+ * "MISMATCH!" cries wolf, so when unsure we emit nothing.
+ */
+export interface CardClaimFlag {
+  kind: "claimed_blocked_but_mergeable" | "claimed_category_absent";
+  detail: string;
+}
+
 // ── Mission report (testbed browser missions) ───────────────────────
 // Mirrors the UI MissionReport. The optional numeric fields (runs,
 // latency, per-step latency, and the 0–10 scores) are populated only
@@ -320,6 +355,20 @@ export interface BoardCard {
   runnerHeartbeat?: CardRunnerHeartbeat;
   /** Real task lifecycle events recorded by the queue, used for Hermes timeline narration. */
   taskEvents?: TaskTimelineEvent[];
+  /**
+   * Proposed-task cards: the REAL signals of the PR the task's prompt cites,
+   * joined from the already-fetched PR summary (no new fetch). Present only when
+   * the task prose (or pullRequestNumber) references a PR. Lets the operator
+   * catch a fabricated premise at the decision point. Absent ⇒ no PR cited.
+   */
+  groundTruth?: CardGroundTruth;
+  /**
+   * Proposed-task cards: conservative, high-confidence mismatches between the
+   * task's claim and the PR's real signals. Only ever set alongside a
+   * `verified:true` groundTruth; empty/absent when the claim is consistent or
+   * the PR couldn't be verified.
+   */
+  claimFlags?: CardClaimFlag[];
   /** Agent currently working this in-flight card, backed by live runner/classifier state. */
   workingNow?: CardWorkingNow;
   /** Per-check CI breakdown (non-done cards) — the list under the bar. */
@@ -1742,6 +1791,158 @@ const REPEATED_FAILURE_ATTEMPTS = 2;
 const AUTOMATION_TERMINAL_TASK_STATUSES = new Set(["completed", "failed", "cancelled"]);
 const CARD_DISCUSSION_LIMIT = 4;
 
+/** Pull the first PR number a task's prose (or explicit field) cites. Honors
+ *  `#123` and `PR 123` / `PR#123` forms; prompt is checked before reason. */
+export function citedPrNumber(task: Record<string, unknown>): number | undefined {
+  const explicit = asFiniteNumber(task.pullRequestNumber);
+  if (explicit !== undefined) return explicit;
+  for (const field of [asString(task.prompt), asString(task.reason)]) {
+    if (!field) continue;
+    const match = field.match(/(?:PR\s*#?|#)(\d{1,7})\b/i);
+    if (match) {
+      const n = Number.parseInt(match[1]!, 10);
+      if (Number.isFinite(n) && n > 0) return n;
+    }
+  }
+  return undefined;
+}
+
+// A task asserts the PR is BLOCKED/gated. Kept deliberately tight — generic
+// mentions of "gate" in unrelated prose shouldn't trip it, but the phrasings
+// Hermes's router actually uses ("blocked PR", "blocks the merge", "cannot
+// merge", "merge-blocking", "gating") do.
+const CLAIMS_BLOCKED = /\b(blocked|block(?:s|ing)?\s+the\s+merge|blocks?\s+merge|cannot\s+merge|can't\s+merge|un-?mergeable|not\s+mergeable|merge[-\s]?block\w*|gat(?:e|es|ing|ed))\b/i;
+// Real PR states that mean "nothing is blocking the merge".
+const MERGEABLE_STATES = new Set(["mergeable", "clean", "has_hooks", "unstable"]);
+
+/**
+ * Reconcile a proposed task's free-text claim against the REAL PR summary it
+ * cites. Pure + side-effect-free so it unit-tests without the whole board.
+ *
+ * TRUTH BOUNDARY:
+ *  - No summary, or a fail-stale summary (githubLive.fetchError) ⇒
+ *    `groundTruth.verified:false` carrying ONLY the honest reason, and NEVER a
+ *    claimFlag (we can't contradict a claim we couldn't verify).
+ *  - Otherwise `groundTruth.verified:true` carries the PR's actual signals, and
+ *    claimFlags are computed CONSERVATIVELY (high-risk, unambiguous only).
+ *  - The caller passes `undefined` when the task cites no PR, in which case this
+ *    isn't called at all and the card carries no panel.
+ */
+export function reconcileTaskClaim(
+  task: Record<string, unknown>,
+  summary: Record<string, unknown> | undefined,
+  prNumber: number,
+): { groundTruth: CardGroundTruth; claimFlags?: CardClaimFlag[] } {
+  const repo = asString(task.repo) ?? "";
+  const githubLive = asRecord(summary?.githubLive);
+  // Missing from the fetched set, or a rate-limited sub-fetch ⇒ unverifiable.
+  if (!summary || githubLive?.fetchError) {
+    return {
+      groundTruth: {
+        pr: prNumber,
+        repo,
+        verified: false,
+        reason: "PR state unavailable — not among the fetched open PRs, rate-limited, or already closed. Judge Hermes's claim yourself.",
+      },
+    };
+  }
+
+  const pr = asRecord(summary.currentPullRequest) ?? asRecord(summary.pullRequest);
+  const totals = asRecord(githubLive?.checkTotals);
+  const checks = totals
+    ? {
+        passed: numberFieldV2(totals.passed),
+        failed: numberFieldV2(totals.failed),
+        total: numberFieldV2(totals.total),
+      }
+    : undefined;
+  const reviewSignals = asRecord(summary.reviewSignals);
+  const touchedAreas = asArray(reviewSignals?.touchedAreas)
+    .map((value) => asString(value))
+    .filter((value): value is string => Boolean(value));
+  const mergeableState = asString(pr?.mergeableState);
+  const verdict = asString(summary.finalVerdict);
+
+  const groundTruth: CardGroundTruth = {
+    pr: prNumber,
+    repo,
+    verified: true,
+    ...(mergeableState ? { mergeableState } : {}),
+    ...(asString(pr?.state) ? { state: asString(pr?.state) } : {}),
+    ...(typeof pr?.draft === "boolean" ? { draft: pr.draft } : {}),
+    ...(typeof pr?.merged === "boolean" ? { merged: pr.merged } : {}),
+    ...(checks ? { checks } : {}),
+    ...(touchedAreas.length > 0 ? { touchedAreas } : {}),
+    ...(verdict ? { verdict } : {}),
+  };
+
+  const claimText = [asString(task.prompt), asString(task.reason)].filter(Boolean).join(" ");
+  const flags: CardClaimFlag[] = [];
+
+  // (1) Claimed blocked, but the PR is actually mergeable with no failing checks
+  // and not held. Every clause must agree before we contradict the operator's
+  // task — a mergeable state we can't read (undefined) is NOT treated as green.
+  const noFailedChecks = !checks || checks.failed === 0;
+  const stateIsMergeable = mergeableState ? MERGEABLE_STATES.has(mergeableState.toLowerCase()) : false;
+  const notHeld = verdict !== "hold";
+  const notDraft = pr?.draft !== true;
+  const notMerged = pr?.merged !== true;
+  if (CLAIMS_BLOCKED.test(claimText) && stateIsMergeable && noFailedChecks && notHeld && notDraft && notMerged) {
+    const failedNote = checks ? `${checks.failed} failed checks` : "no failing checks";
+    flags.push({
+      kind: "claimed_blocked_but_mergeable",
+      detail: `Task says PR #${prNumber} is blocked, but it is ${mergeableState} with ${failedNote}.`,
+    });
+  }
+
+  // (2) Claimed a HIGH-RISK category (secrets / migrations / .env) that the real
+  // diff does not touch. Only these high-signal absentees are flagged — generic
+  // words like "backend" or "docs" are far too noisy to contradict on.
+  if (touchedAreas.length > 0) {
+    const missing = claimedHighRiskCategoriesAbsent(claimText, touchedAreas);
+    if (missing.length > 0) {
+      flags.push({
+        kind: "claimed_category_absent",
+        detail: `Task claims ${missing.map((m) => `'${m}'`).join(" + ")}, but PR #${prNumber}'s real diff touches: ${touchedAreas.join(", ")}.`,
+      });
+    }
+  }
+
+  return { groundTruth, ...(flags.length > 0 ? { claimFlags: flags } : {}) };
+}
+
+/** Coerce a summary numeric field, defaulting missing/non-finite to 0. */
+function numberFieldV2(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Which HIGH-RISK categories a task's prose asserts that the PR's real
+ * `touchedAreas` do NOT contain. Deliberately narrow: only `secrets`,
+ * `migration(s)`, and `.env` — the categories whose false presence would most
+ * mislead a risk decision. A claim of `secrets` is satisfied by a real
+ * `secrets` area; a claim of `migration` maps to the `settlement`/`backend`
+ * areas the classifier uses, so we only assert absence when NO plausible area
+ * is present.
+ */
+function claimedHighRiskCategoriesAbsent(claimText: string, touchedAreas: string[]): string[] {
+  const text = claimText.toLowerCase();
+  const areas = new Set(touchedAreas.map((a) => a.toLowerCase()));
+  const missing: string[] = [];
+  // "secrets" / ".env": the classifier bucket is literally `secrets`.
+  if (/\bsecrets?\b/.test(text) && !areas.has("secrets")) missing.push("secrets");
+  if (/(?:^|[^.\w])\.env\b/.test(text) && !areas.has("secrets")) missing.push(".env");
+  // "migration(s)": the classifier folds DB migrations into the touched-area
+  // vocab as high-risk but has no dedicated `migration` bucket, so treat it as
+  // absent only when NONE of the areas a migration could live in are present.
+  if (/\bmigrations?\b/.test(text) && !MIGRATION_HOST_AREAS.some((a) => areas.has(a))) missing.push("migrations");
+  return missing;
+}
+
+// Areas a real DB migration would surface under (there's no dedicated bucket).
+// If none are present, a "migrations" claim is unsupported by the real diff.
+const MIGRATION_HOST_AREAS = ["backend", "indexer", "settlement", "ops"];
+
 /**
  * Synthesize `codex-needed` cards for queued tasks the classifier won't
  * surface on its own. Greenfield tasks (no PR yet) emit no monitor/handoff
@@ -1755,7 +1956,7 @@ const CARD_DISCUSSION_LIMIT = 4;
 export function synthesizeTaskCards(
   rawSnapshot: unknown,
   runner: Record<string, unknown> | undefined,
-  opts: { now?: Date } = {},
+  opts: { now?: Date; summaryIndex?: Map<string, Record<string, unknown>> } = {},
 ): BoardCard[] {
   const root = asRecord(rawSnapshot);
   const codexTasks = asRecord(root?.codexTasks);
@@ -1792,6 +1993,14 @@ export function synthesizeTaskCards(
         ? [{ severity: riskTier === "high" ? "high" as const : "low" as const, code: "routing", message: routingReason }]
         : []),
     ];
+    // Ground-truth check: if this greenfield task's prose cites a PR, join the
+    // PR's REAL signals from the already-fetched summary index so the operator
+    // can catch a fabricated premise. No PR cited ⇒ no panel (honest absence).
+    const citedPr = opts.summaryIndex ? citedPrNumber(task) : undefined;
+    const reconciled =
+      citedPr !== undefined
+        ? reconcileTaskClaim(task, opts.summaryIndex!.get(prKey(asString(task.repo), citedPr) ?? ""), citedPr)
+        : undefined;
     const card: BoardCard = {
       id,
       lane: health.lane,
@@ -1812,6 +2021,8 @@ export function synthesizeTaskCards(
       ...(health.sourceFailure ? { sourceFailure: health.sourceFailure } : {}),
       ...(prompt ? { prompt } : {}),
       ...(taskEvents.length > 0 ? { taskEvents } : {}),
+      ...(reconciled ? { groundTruth: reconciled.groundTruth } : {}),
+      ...(reconciled?.claimFlags ? { claimFlags: reconciled.claimFlags } : {}),
       ...(asString(task.correlationId) ? { correlationId: asString(task.correlationId) } : {}),
       ...(decisionRecord ? { decisionRecord } : {}),
     };
@@ -2168,7 +2379,7 @@ export function buildV2BoardSnapshot(
   // self-healing event also produced a task, keep the task card because it
   // owns the real approve/dispatch control; the handoff event is context.
   const existingIds = new Set(sourceCards.map((c) => c.id));
-  const taskCards = synthesizeTaskCards(rawSnapshot, runner, { now: snapshotAt })
+  const taskCards = synthesizeTaskCards(rawSnapshot, runner, { now: snapshotAt, summaryIndex })
     .filter((c) => !existingIds.has(c.id))
     .map((card) => {
       const scope = { correlationId: card.correlationId ?? card.id };

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -22,6 +22,8 @@ import {
   enrichBoardCard,
   mapMissionReport,
   synthesizeTaskCards,
+  reconcileTaskClaim,
+  citedPrNumber,
   taskHealthForBoard,
   automationHealthForBoard,
   diffBoardSnapshots,
@@ -2212,6 +2214,152 @@ describe("synthesizeTaskCards (O3 — surface queued tasks)", () => {
       isAction: true,
     });
     expect(snap.cards.some((card) => card.type === "task")).toBe(false);
+  });
+});
+
+describe("citedPrNumber (extract the PR a task's prose references)", () => {
+  it("prefers an explicit pullRequestNumber", () => {
+    expect(citedPrNumber({ pullRequestNumber: 717, prompt: "decompose PR #900" })).toBe(717);
+  });
+  it("parses '#N' and 'PR N' / 'PR#N' from prompt, then reason", () => {
+    expect(citedPrNumber({ prompt: "decompose blocked PR #717 — 3 files" })).toBe(717);
+    expect(citedPrNumber({ prompt: "look at PR 512 please" })).toBe(512);
+    expect(citedPrNumber({ prompt: "no ref here", reason: "relates to #48" })).toBe(48);
+  });
+  it("returns undefined when no PR is cited", () => {
+    expect(citedPrNumber({ prompt: "add a HEALTHCHECK.md", reason: "operator delegated" })).toBeUndefined();
+  });
+});
+
+describe("reconcileTaskClaim (ground-truth a proposed task's claim vs the real PR)", () => {
+  // The real #717 case: a task claims a merge-blocking premise, but the PR is
+  // green + mergeable and touches only contracts + a doc + a test.
+  const greenSummary717 = {
+    finalVerdict: "ok_to_merge",
+    currentPullRequest: { repo: "depre-dev/agent", number: 717, state: "open", draft: false, merged: false, mergeableState: "clean" },
+    githubLive: { checkTotals: { total: 5, passed: 5, failed: 0, active: 0, neutral: 0 } },
+    reviewSignals: { touchedAreas: ["contracts", "docs", "tests"] },
+  };
+
+  it("(a) flags claimed_blocked_but_mergeable when the task says blocked but the PR is mergeable + all-green (the #717 case)", () => {
+    const task = {
+      repo: "depre-dev/agent",
+      prompt: "decompose blocked PR #717 — 3 files touch secrets, contracts, AND database migrations, triggering pr_critical_files; it blocks the merge.",
+    };
+    const { groundTruth, claimFlags } = reconcileTaskClaim(task, greenSummary717, 717);
+    expect(groundTruth.verified).toBe(true);
+    expect(groundTruth.mergeableState).toBe("clean");
+    expect(groundTruth.checks).toEqual({ passed: 5, failed: 0, total: 5 });
+    expect(groundTruth.touchedAreas).toEqual(["contracts", "docs", "tests"]);
+    const kinds = (claimFlags ?? []).map((f) => f.kind);
+    expect(kinds).toContain("claimed_blocked_but_mergeable");
+  });
+
+  it("(b) flags claimed_category_absent when the task claims secrets+migrations but the real diff touches only contracts+tests", () => {
+    const task = {
+      repo: "depre-dev/agent",
+      prompt: "decompose PR #717 — it touches secrets and database migrations and needs splitting.",
+    };
+    // A neutral (non-blocked-claiming) prompt so only the category flag fires.
+    const summary = {
+      finalVerdict: "operator_review",
+      currentPullRequest: { repo: "depre-dev/agent", number: 717, state: "open", mergeableState: "unstable" },
+      githubLive: { checkTotals: { total: 4, passed: 3, failed: 1, active: 0, neutral: 0 } },
+      reviewSignals: { touchedAreas: ["contracts", "tests"] },
+    };
+    const { claimFlags } = reconcileTaskClaim(task, summary, 717);
+    const absent = (claimFlags ?? []).find((f) => f.kind === "claimed_category_absent");
+    expect(absent).toBeTruthy();
+    expect(absent?.detail).toMatch(/secrets/);
+    expect(absent?.detail).toMatch(/migrations/);
+    // it does NOT false-positive the blocked flag (checks show 1 failed).
+    expect((claimFlags ?? []).some((f) => f.kind === "claimed_blocked_but_mergeable")).toBe(false);
+  });
+
+  it("(c) emits NO flags when the claim is consistent with the real signals", () => {
+    const task = {
+      repo: "depre-dev/agent",
+      // Claims contracts (present) and does not assert a false block.
+      prompt: "PR #717 changes contracts — split the Solidity refactor into two commits.",
+    };
+    const { groundTruth, claimFlags } = reconcileTaskClaim(task, greenSummary717, 717);
+    expect(groundTruth.verified).toBe(true);
+    expect(claimFlags).toBeUndefined();
+  });
+
+  it("(c2) a 'blocked' claim does NOT flag when the PR genuinely has failing checks", () => {
+    const task = { repo: "depre-dev/agent", prompt: "PR #717 is blocked — CI is red." };
+    const redSummary = {
+      finalVerdict: "hold",
+      currentPullRequest: { repo: "depre-dev/agent", number: 717, state: "open", mergeableState: "clean" },
+      githubLive: { checkTotals: { total: 5, passed: 3, failed: 2, active: 0, neutral: 0 } },
+      reviewSignals: { touchedAreas: ["contracts"] },
+    };
+    const { claimFlags } = reconcileTaskClaim(task, redSummary, 717);
+    expect(claimFlags).toBeUndefined();
+  });
+
+  it("(d) verified:false with NO flags when the summary is missing", () => {
+    const task = { repo: "depre-dev/agent", prompt: "PR #717 is blocked and touches secrets." };
+    const { groundTruth, claimFlags } = reconcileTaskClaim(task, undefined, 717);
+    expect(groundTruth.verified).toBe(false);
+    expect(groundTruth.reason).toBeTruthy();
+    expect(claimFlags).toBeUndefined();
+  });
+
+  it("(d2) verified:false with NO flags when the summary is fail-stale (githubLive.fetchError)", () => {
+    const task = { repo: "depre-dev/agent", prompt: "PR #717 is blocked and touches migrations." };
+    const staleSummary = {
+      ...greenSummary717,
+      githubLive: { ...greenSummary717.githubLive, fetchError: { code: "rate_limited", message: "429" } },
+    };
+    const { groundTruth, claimFlags } = reconcileTaskClaim(task, staleSummary, 717);
+    expect(groundTruth.verified).toBe(false);
+    expect(claimFlags).toBeUndefined();
+  });
+
+  it("(e) synthesizeTaskCards attaches groundTruth only when a PR is cited AND the index is threaded", () => {
+    const rawSnapshot = {
+      codexTasks: {
+        items: [
+          {
+            id: "codex-task-depre-dev-agent-new-1-aa",
+            status: "proposed",
+            agent: "codex",
+            repo: "depre-dev/agent",
+            prompt: "decompose blocked PR #717 — it blocks the merge and touches secrets + migrations.",
+          },
+          {
+            id: "codex-task-depre-dev-agent-new-2-bb",
+            status: "proposed",
+            agent: "codex",
+            repo: "depre-dev/agent",
+            prompt: "add a HEALTHCHECK.md — no PR involved",
+          },
+        ],
+      },
+    };
+    const summaryIndex = new Map<string, Record<string, unknown>>([
+      ["depre-dev/agent#717", greenSummary717],
+    ]);
+    const cards = synthesizeTaskCards(rawSnapshot, undefined, { summaryIndex });
+    const cited = cards.find((c) => c.id.endsWith("-aa"));
+    const noRef = cards.find((c) => c.id.endsWith("-bb"));
+    expect(cited?.groundTruth?.verified).toBe(true);
+    expect((cited?.claimFlags ?? []).some((f) => f.kind === "claimed_blocked_but_mergeable")).toBe(true);
+    // No PR cited ⇒ no panel at all (honest absence).
+    expect(noRef?.groundTruth).toBeUndefined();
+    expect(noRef?.claimFlags).toBeUndefined();
+  });
+
+  it("(e2) attaches nothing when summaryIndex is not threaded (byte-for-byte prior behavior)", () => {
+    const rawSnapshot = {
+      codexTasks: {
+        items: [{ id: "t1", status: "proposed", agent: "codex", repo: "depre-dev/agent", prompt: "blocked PR #717" }],
+      },
+    };
+    const [card] = synthesizeTaskCards(rawSnapshot, undefined);
+    expect(card?.groundTruth).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Why
Hermes's router auto-proposes Codex/Claude tasks that land on the monitor board awaiting operator approval. The task **prompt is free LLM text and can fabricate a premise**. Real example: a task claimed *"decompose blocked PR #717 — 3 files touch secrets, contracts, AND database migrations, triggering pr_critical_files"* — but PR #717 actually touched only 2 contract files + a doc + a test, was mergeable, all checks green. The operator only caught it by manually checking GitHub.

This makes the board show the cited PR's **real signals next to Hermes's claim**, at the decision point, so a fabrication is caught before approval.

## What
**Backend** (`services/slack-operator/src/monitor-v2.ts`, `github-pr-state.ts`)
- Export `inferTouchedArea` + `highRiskForFile` — the same classifier vocab the live PR review uses, so the reconcile never disagrees on area wording.
- `reconcileTaskClaim(task, summary, prNumber)` — a **pure, unit-testable** helper reading only the already-fetched PR summary (**zero new network calls**): `currentPullRequest.mergeableState/state/draft/merged`, `githubLive.checkTotals`, `reviewSignals.touchedAreas`, `finalVerdict`.
  - No summary or a **fail-stale** summary (`githubLive.fetchError`) ⇒ `groundTruth.verified:false` carrying **only** the honest reason, never a `claimFlag`.
  - Otherwise `verified:true` + **conservative** flags: `claimed_blocked_but_mergeable` (every clause must agree — mergeable state, 0 failed checks, not held/draft/merged) and `claimed_category_absent` (only the high-risk absentees `secrets`/`migrations`/`.env`; generic words are too noisy to contradict).
- `citedPrNumber()` parses the first `#N` / `PR N` / `PR#N` from prompt then reason (honors an explicit `pullRequestNumber`). **No PR cited ⇒ no panel.**
- Thread the existing `summaryIndex` into `synthesizeTaskCards` (via `opts`) and attach `groundTruth?`/`claimFlags?` to greenfield task cards. **Non-breaking**: when the index isn't threaded, cards are byte-for-byte as before.

**Frontend** (`packages/monitor-ui/src/components/drawer/DrawerBody.tsx`, `card-types.ts`)
- `GroundTruthSection` in the **shared DrawerBody wrapper** (an actionable task routes to `PrBody`, not `TaskBody` — the wrapper shows it either way).
  - `verified:false` ⇒ a **muted** "Couldn't verify PR #N … judge Hermes's claim yourself" note (never a green check).
  - `verified` ⇒ the PR's real mergeable state / checks / touched areas / verdict as fact; a prominent ⚠ warn block **only** when `claimFlags` are present, else a calm "consistent" line (honest precisely because we *did* verify).
  - Reuses existing classes only (`hm-verdict-block[--warn]`, `h4-eo` grid) — **no new CSS**.

## Truth boundary
- Always surfaces the real, unambiguous ground-truth when verified — that alone lets the operator judge.
- Mismatch flags are conservative + high-confidence; when in doubt, **no flag** (a false "no mismatch" is fine, a false "MISMATCH!" is not).
- "Couldn't verify" is visually distinct and never reads as agreement.
- No PR cited ⇒ the panel doesn't render at all (honest absence).
- Every value comes from the real joined summary — nothing is fabricated.

## Tests
- **Backend** (`test/unit/monitor-v2.test.ts`): the #717 blocked-but-mergeable case, category-absent, consistent→no-flags, failing-checks→no-false-block, no-summary/`fetchError`→`verified:false`, no-PR→no-panel, index-not-threaded no-op; plus `citedPrNumber` parsing.
- **Frontend** (`DrawerBody.groundTruth.test.tsx`, jsdom): mismatch ⚠ + details, verified-consistent line, couldn't-verify muted (no green/grid), absent section.

## Verify
- `tsc -b packages/averray-mcp packages/monitor-ui services/slack-operator` → exit 0
- `vitest run test/unit/monitor-v2.test.ts` → 139/139
- full `packages/monitor-ui` `vitest run` → 721/721 (72 files)
- `npm run build` (vite) → exit 0

## Out of scope
- PR-bound tasks (those with `pullRequestNumber` set) still surface via their PR card — unchanged.
- No new GitHub fetching; the check reads the summaries already on the snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)