### PR TITLE
review-followup: honest framing for the ground-truth verification panel

### DIFF
--- a/packages/monitor-ui/src/components/drawer/DrawerBody.groundTruth.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.groundTruth.test.tsx
@@ -49,21 +49,21 @@ describe("DrawerBody — proposed-task ground-truth verification panel", () => {
       },
       claimFlags: [
         { kind: "claimed_blocked_but_mergeable", detail: "Task says PR #717 is blocked, but it is clean with 0 failed checks." },
-        { kind: "claimed_category_absent", detail: "Task claims 'secrets' + 'migrations', but PR #717's real diff touches: contracts, tests." },
+        { kind: "claimed_category_absent", detail: "Task text mentions 'secrets' + 'migrations', but PR #717's real diff doesn't touch that — real areas: contracts, tests." },
       ],
     });
     const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
     const text = container.textContent ?? "";
     // The warn header + both flag details are surfaced.
-    expect(text).toMatch(/claim doesn't match the PR/i);
+    expect(text).toMatch(/doesn.t match PR #717.s real signals/i);
     expect(text).toMatch(/is blocked, but it is clean with 0 failed checks/);
-    expect(text).toMatch(/real diff touches: contracts, tests/);
+    expect(text).toMatch(/real areas: contracts, tests/);
     // The real ground-truth signals are shown as fact.
     expect(text).toMatch(/717 · ground truth|717 ground truth/);
     expect(text).toMatch(/5\/5 passed/);
     // The warn tint is applied (not the calm/green "consistent" line).
     expect(container.querySelector(".hm-verdict-block--warn")).toBeTruthy();
-    expect(text).not.toMatch(/consistent with the PR's real signals/);
+    expect(text).not.toMatch(/No mismatch detected/i);
   });
 
   test("verified card WITH NO flags renders the calm 'consistent' line, not a warning", () => {
@@ -81,7 +81,7 @@ describe("DrawerBody — proposed-task ground-truth verification panel", () => {
     });
     const { container } = render(<DrawerBody card={card} variant={drawerVariant(card)} />);
     const text = container.textContent ?? "";
-    expect(text).toMatch(/consistent with the PR's real signals/);
+    expect(text).toMatch(/No mismatch detected/i);
     expect(container.querySelector(".hm-verdict-block--warn")).toBeNull();
   });
 
@@ -99,7 +99,7 @@ describe("DrawerBody — proposed-task ground-truth verification panel", () => {
     expect(text).toMatch(/Couldn't verify PR #717/);
     expect(text).toMatch(/Judge Hermes's claim yourself/);
     // Truth boundary: no agreement, no warn, no ground-truth grid.
-    expect(text).not.toMatch(/consistent with the PR's real signals/);
+    expect(text).not.toMatch(/No mismatch detected/i);
     expect(container.querySelector(".hm-verdict-block--warn")).toBeNull();
     expect(container.querySelector(".h4-eo")).toBeNull();
   });

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -147,7 +147,7 @@ function GroundTruthSection({ card }: { card: BoardCard }) {
 
       {flags.length > 0 ? (
         <div className="hm-verdict-block hm-verdict-block--warn" style={{ marginBottom: 10 }}>
-          <div className="head">⚠ Hermes's claim doesn't match the PR</div>
+          <div className="head">⚠ Task text doesn't match PR #{gt.pr}'s real signals — check before approving</div>
           <div className="body">
             <ul style={{ margin: "6px 0 0", paddingLeft: 18 }}>
               {flags.map((f) => (
@@ -159,7 +159,7 @@ function GroundTruthSection({ card }: { card: BoardCard }) {
       ) : (
         <div className="hm-verdict-block" style={{ marginBottom: 10 }}>
           <div className="body" style={{ color: "var(--hm-sage-deep)" }}>
-            Hermes's claim is consistent with the PR's real signals.
+            No mismatch detected between the task text and the PR's real signals below.
           </div>
         </div>
       )}

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -1903,7 +1903,7 @@ export function reconcileTaskClaim(
     if (missing.length > 0) {
       flags.push({
         kind: "claimed_category_absent",
-        detail: `Task claims ${missing.map((m) => `'${m}'`).join(" + ")}, but PR #${prNumber}'s real diff touches: ${touchedAreas.join(", ")}.`,
+        detail: `Task text mentions ${missing.map((m) => `'${m}'`).join(" + ")}, but PR #${prNumber}'s real diff doesn't touch that — real areas: ${touchedAreas.join(", ")}.`,
       });
     }
   }


### PR DESCRIPTION
Small self-review follow-up to #484 (which merged before my review completed). **Wording only — detection logic unchanged.** #484's core is sound (honest "couldn't verify" path, conservative flags that treat an unreadable mergeable-state as *not* green, ground-truth never fabricated, no-PR→no-panel). Review caught two framing nits that undercut a feature whose whole job is honesty:

- **Category flag polarity.** It said the task *"claims"* a risk word and matched that word regardless of assertion polarity — a prompt like *"ensure no secrets leak"* could read as *"claims secrets."* Reframed to **"Task text mentions X, but the real diff doesn't touch that"** — accurate as a text↔diff discrepancy and non-accusatory if a rare negated mention trips it. Warn header likewise → **"Task text doesn't match PR #N's real signals — check before approving."**
- **"Consistent" overstated.** The no-flags line asserted *"Hermes's claim is consistent with the PR's real signals,"* but the checks are deliberately conservative (2 mismatch types) — that implies more verification than performed. Now **"No mismatch detected between the task text and the PR's real signals below."**

## Verify
- 3 files, +9/−9 (2 UI strings, 1 backend flag detail, test assertions).
- `tsc -b` (3 packages) clean · backend reconcile **139/139** · ground-truth render **4/4** · (verified full monitor-ui **721/721** + vite build on the sibling branch before the merge race).

Not auto-merged — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)