### PR TITLE
monitor(router): ground the agentic backlog so it can't fabricate risk

### DIFF
--- a/services/slack-operator/src/agentic-backlog.ts
+++ b/services/slack-operator/src/agentic-backlog.ts
@@ -79,12 +79,19 @@ export async function collectAgenticBacklog(
   if (!turnText) return [];
 
   const allowed = new Set(config.allowedRepos.map((repo) => repo.trim().toLowerCase()));
+  const boardText = boardGroundingText(context.board);
   const items: AgenticBacklogItem[] = [];
   const seen = new Set<string>();
   for (const raw of parseWorkItems(turnText)) {
     if (items.length >= config.maxItems) break;
     const item = normalizeItem(raw, allowed);
     if (!item) continue;
+    // Truth-boundary guard: a proposal that asserts a HIGH-RISK file category
+    // (secrets/.env/migrations) the board evidence never mentions is an
+    // ungrounded claim — drop it rather than surface a fabricated risk to the
+    // operator. The generic-menu → specific-claim case (the #717 near-miss) is
+    // addressed by the prompt's grounding rules + the card-side ground-truth panel.
+    if (ungroundedHighRiskClaim(item, boardText)) continue;
     const key = `${item.repo}::${item.surface ?? ""}`.toLowerCase();
     if (seen.has(key)) continue;
     seen.add(key);
@@ -118,6 +125,9 @@ export function buildAgenticBacklogPrompt(config: AgenticBacklogConfig, context:
   lines.push("");
   lines.push("Rules:");
   lines.push("- Propose only REAL gaps grounded in the board (a failed check needing a fix, a stuck draft, missing coverage, a follow-up a card asks for). Do NOT invent work.");
+  lines.push("- GROUND every factual claim in a specific card above — state only what that card's own fields (title/why/verdict/next) actually say about THAT card.");
+  lines.push("- A card's \"why\" may list risk categories as possibilities (a review-gate that checks for secrets, contracts, OR migrations is a MENU of what it looks for — NOT proof the PR touches them). Never restate such a menu as a definite claim: do not say a PR \"touches secrets/migrations/contracts\" or is \"blocked/gated\" unless the cited card states that specifically for that PR.");
+  lines.push("- Never invent PR numbers, file names, diff contents, error text, checks, or metrics that are not in the cited card. If you cannot ground a task's rationale in a specific card above, do not propose it.");
   lines.push("- Skip anything already in flight above. Skip merge/deploy — those stay with the human.");
   lines.push(`- At most ${config.maxItems} items, highest-leverage first. Fewer is fine. If nothing is genuinely needed, return [].`);
   lines.push("- suggestedAgent: 'codex' for chain/settlement/contracts/secrets/DB-migrations/deploy/ops; 'claude' for UI/frontend/monitor/docs/tests/non-financial. (The system enforces the dangerous ones regardless.)");
@@ -198,6 +208,41 @@ export function normalizeItem(raw: unknown, allowedRepos: ReadonlySet<string>): 
     shortDescription: why || title,
     ...(suggestedAgent ? { suggestedAgent } : {}),
   };
+}
+
+// --- grounding guard --------------------------------------------------------
+
+// High-risk file categories whose *false* assertion would most mislead a risk /
+// routing decision — the ones the #717 near-miss fabricated. Kept deliberately
+// tiny (secrets/.env and DB migrations). A proposal that asserts one of these
+// but the board evidence never mentions it is dropped as ungrounded.
+const HIGH_RISK_CLAIM_TOKENS: ReadonlyArray<{ label: string; pattern: RegExp }> = [
+  { label: "secrets", pattern: /\bsecrets?\b|(?:^|[^.\w])\.env\b/i },
+  { label: "migrations", pattern: /\bmigrations?\b/i },
+];
+
+/**
+ * The high-risk category an item's text asserts that the board evidence the
+ * model was shown NEVER mentions — or null when every asserted category is
+ * grounded in the board. Mirrors the existing "must cite a real board signal"
+ * guard: an ungrounded high-risk claim is a fabrication, so the caller drops it.
+ */
+export function ungroundedHighRiskClaim(item: AgenticBacklogItem, boardText: string): string | null {
+  const claim = `${item.prompt} ${item.title} ${item.description ?? ""}`;
+  for (const { label, pattern } of HIGH_RISK_CLAIM_TOKENS) {
+    if (pattern.test(claim) && !pattern.test(boardText)) return label;
+  }
+  return null;
+}
+
+/** The board evidence the model is shown, flattened to one lowercase corpus so a
+ *  proposal's high-risk claims can be checked for grounding against it. */
+export function boardGroundingText(board: HermesBoardSnapshot): string {
+  const parts: string[] = [board.headline ?? ""];
+  for (const card of board.items ?? []) {
+    parts.push(card.title ?? "", card.why ?? "", card.verdict ?? "", card.next ?? "", card.lane ?? "");
+  }
+  return parts.join(" \n ").toLowerCase();
 }
 
 function str(v: unknown): string {

--- a/test/unit/agentic-backlog.test.ts
+++ b/test/unit/agentic-backlog.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  boardGroundingText,
   buildAgenticBacklogPrompt,
   collectAgenticBacklog,
   normalizeItem,
   parseWorkItems,
+  ungroundedHighRiskClaim,
   type AgenticBacklogConfig,
   type AgenticBacklogContext,
+  type AgenticBacklogItem,
 } from "../../services/slack-operator/src/agentic-backlog.js";
 
 const CFG = (over: Partial<AgenticBacklogConfig> = {}): AgenticBacklogConfig => ({
@@ -81,6 +84,19 @@ describe("collectAgenticBacklog", () => {
     const dupes = [VALID_ITEM, { ...VALID_ITEM }];
     expect(await collectAgenticBacklog(CFG(), CTX, { chat: chatReturning(JSON.stringify(dupes)) })).toHaveLength(1);
   });
+
+  it("drops an item asserting a high-risk category the board never mentions (source grounding guard)", async () => {
+    // The #717 shape: a fabricated "touches secrets + migrations" claim against a
+    // board (default CTX) whose evidence mentions neither.
+    const fabricated = { ...VALID_ITEM, surface: "contracts audit", prompt: "Decompose PR #717 — 3 files touch secrets, contracts, AND database migrations." };
+    expect(await collectAgenticBacklog(CFG(), CTX, { chat: chatReturning(JSON.stringify([fabricated])) })).toHaveLength(0);
+  });
+
+  it("keeps a high-risk item when the board evidence actually mentions it", async () => {
+    const grounded = { ...VALID_ITEM, surface: "secrets rotation", prompt: "Rotate the committed secrets flagged by the scan." };
+    const ctx: AgenticBacklogContext = { ...CTX, board: { ...CTX.board, headline: "secrets scan flagged a committed .env" } };
+    expect(await collectAgenticBacklog(CFG(), ctx, { chat: chatReturning(JSON.stringify([grounded])) })).toHaveLength(1);
+  });
 });
 
 describe("parseWorkItems", () => {
@@ -112,5 +128,53 @@ describe("buildAgenticBacklogPrompt", () => {
     expect(prompt).toContain("averray-agent/agent");
     expect(prompt).toContain("boardSignal");
     expect(prompt).toMatch(/JSON array/i);
+  });
+
+  it("includes the truth-boundary grounding rules (no menu→claim, no invented specifics)", () => {
+    const prompt = buildAgenticBacklogPrompt(CFG(), CTX);
+    expect(prompt).toMatch(/GROUND every factual claim/);
+    expect(prompt).toMatch(/MENU of what it looks for/);
+    expect(prompt).toMatch(/Never invent PR numbers/);
+  });
+});
+
+describe("ungroundedHighRiskClaim (source truth-boundary guard)", () => {
+  const allowed = new Set(["averray-agent/agent"]);
+  const item = (over: Partial<AgenticBacklogItem>): AgenticBacklogItem => ({
+    ...(normalizeItem(VALID_ITEM, allowed) as AgenticBacklogItem),
+    ...over,
+  });
+
+  it("flags a high-risk category the board never mentions (the #717 fabrication)", () => {
+    const claim = item({ prompt: "Decompose the PR — it touches secrets and database migrations." });
+    expect(ungroundedHighRiskClaim(claim, "deploy verification failed on paseo")).toBe("secrets");
+  });
+
+  it("passes a high-risk claim that IS grounded in the board evidence", () => {
+    const claim = item({ prompt: "Rotate the leaked secrets in the deploy pipeline." });
+    expect(ungroundedHighRiskClaim(claim, "needs-attention: secrets scan flagged a committed .env")).toBeNull();
+  });
+
+  it("ignores items that assert no high-risk category (contracts are NOT in the guard)", () => {
+    const claim = item({ prompt: "Fix the flaky monitor test and the contract selector.", title: "flaky test", description: "" });
+    expect(ungroundedHighRiskClaim(claim, "anything")).toBeNull();
+  });
+
+  it("flags an ungrounded migrations claim too", () => {
+    const claim = item({ prompt: "Write the DB migration for the new column.", title: "migration", description: "" });
+    expect(ungroundedHighRiskClaim(claim, "board with no db work")).toBe("migrations");
+  });
+});
+
+describe("boardGroundingText", () => {
+  it("flattens headline + card fields into one lowercase corpus", () => {
+    const text = boardGroundingText({
+      headline: "One SECRETS scan failed",
+      items: [{ title: "Rotate key", lane: "needs-attention", owner: "codex", why: "committed .env", next: "rotate then redeploy" }],
+    });
+    expect(text).toContain("secrets");
+    expect(text).toContain(".env");
+    expect(text).toContain("rotate then redeploy");
+    expect(text).toBe(text.toLowerCase());
   });
 });


### PR DESCRIPTION
**Stage 2 of "solved in the board"** — the source-side complement to #484's card-side ground-truth panel.

## The gap
The Hermes router's agentic backlog wrote each proposed task's `prompt` as **free LLM text with no grounding check** (`agentic-backlog.ts` → `item.prompt = str(r.prompt)` → straight to the operator's board). That's the source of the #717 near-miss: a proposed task claimed *"decompose blocked PR #717 — 3 files touch secrets, contracts, AND database migrations"* when #717 touched 2 contract files, was mergeable, all checks green. The model took a board card's generic critical-files *menu* ("touches secrets, contracts, **or** migrations") and restated it as a definite claim about the specific PR.

## Two source-side guards (agentic path only — deterministic roadmap floor untouched)
1. **TRUTH_RULES in the generator prompt** — ground every claim in a specific cited card; a card's `why` category list is a MENU of what a gate checks, **not** proof the PR touches them (never restate it as definite); never invent PR numbers, file names, diff contents, or checks.
2. **Deterministic drop guard** (`ungroundedHighRiskClaim`) — an item asserting a high-risk category (**secrets / .env / migrations**) the board evidence *never mentions* is dropped as ungrounded, mirroring the existing "must cite a real board signal" guard. **Contracts are deliberately NOT guarded** — commonly + legitimately touched, and #717's contracts claim was actually *true*; it's the secrets/migrations fabrication that misleads a risk decision.

## Defense in depth (honest scope)
This **reduces** source fabrication; **#484's ground-truth panel stays the authoritative operator-facing catch.** The exact #717 menu→claim case needs the real diff, which the router layer doesn't have — so the prompt rules discourage it and the card panel catches it if it slips through. **Known limitation:** a legit high-risk proposal worded differently from its card (`credentials` vs `secrets`) may be dropped — a missed *extra* proposal, never a wrong one; the roadmap floor still covers planned work.

## Verify
- 2 files, +109/−0 (additive). `agentic-backlog.ts` + its test.
- `tsc -b` clean · **agentic-backlog 18/18** (8 new: guard drops the #717 shape, passes grounded, ignores contracts/no-risk, flags migrations, corpus extraction) · router/work-router siblings **47/47**.
- No guardrail weakened: proposes-only, hard `assertTaxonomy`, dispatch allowlist/budget, operator approval all unchanged.

Not auto-merged — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)