### PR TITLE
monitor(router): thread the PR's real diff areas into the router snapshot (Stage 3)

### DIFF
--- a/services/slack-operator/src/agentic-backlog.ts
+++ b/services/slack-operator/src/agentic-backlog.ts
@@ -149,6 +149,10 @@ function formatBoardForPrompt(board: HermesBoardSnapshot): string {
       card.ageLabel ? `age ${card.ageLabel}` : "",
       `title ${truncate(card.title, 120)}`,
       card.why ? `why ${truncate(card.why, 160)}` : "",
+      // The REAL diff areas (Stage 3). This is the definitive list of what the
+      // PR touches — grounds the model so it can't invent a category (secrets/
+      // migrations) the diff doesn't contain.
+      card.touchedAreas && card.touchedAreas.length > 0 ? `diff-areas ${card.touchedAreas.join(", ")}` : "",
       card.next ? `next ${truncate(card.next, 160)}` : "",
     ].filter(Boolean);
     out.push(`  - ${parts.join(" | ")}`);

--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -98,6 +98,7 @@ function boardCardFromItem(
   const why = reasonForItem(item, summary, prState, codexTaskStatus);
   const correlationId = textProp(item, "correlationId");
   const headBranch = headBranchForPr(prState, summary, item);
+  const realAreas = touchedAreasForItem(summary);
   return {
     ...identity,
     title: title || "Untitled handoff",
@@ -108,6 +109,7 @@ function boardCardFromItem(
     ...(why ? { why } : {}),
     next: classification.next,
     tags: tagsForItem(item, summary),
+    ...(realAreas.length > 0 ? { touchedAreas: realAreas.slice(0, 8) } : {}),
     ...(correlationId ? { correlationId } : {}),
     ...(headBranch ? { headBranch } : {}),
   };
@@ -357,11 +359,21 @@ function titleForItem(
   return "";
 }
 
-function tagsForItem(item: Record<string, unknown>, summary: Record<string, unknown>): string[] {
+/**
+ * The PR's real diff areas from the enriched github-live review signals — the
+ * categories the diff ACTUALLY touches (secrets/contracts/settlement/tests/…),
+ * NOT mixed with test-case ids like `tags`. Threaded onto the card so the
+ * agentic router sees the real areas and can't invent a category the PR doesn't
+ * touch. Empty when there is no review signal.
+ */
+function touchedAreasForItem(summary: Record<string, unknown>): string[] {
   const reviewSignals = recordProp(summary, "reviewSignals");
-  const touchedAreas = reviewSignals ? arrayStrings(reviewSignals.touchedAreas) : [];
+  return reviewSignals ? unique(arrayStrings(reviewSignals.touchedAreas)) : [];
+}
+
+function tagsForItem(item: Record<string, unknown>, summary: Record<string, unknown>): string[] {
   const testCaseIds = arrayStrings(item.testCaseIds);
-  return unique([...touchedAreas, ...testCaseIds]).slice(0, 6);
+  return unique([...touchedAreasForItem(summary), ...testCaseIds]).slice(0, 6);
 }
 
 function boardCounts(

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -78,6 +78,14 @@ export interface HermesBoardCardSnapshot {
   next?: string;
   tags?: ReadonlyArray<string>;
   /**
+   * The PR's REAL diff areas from the enriched github-live review signals
+   * (secrets / contracts / settlement / indexer / tests / docs / …). Distinct
+   * from `tags` (which mixes in test-case ids). Threaded so the agentic router
+   * sees what the PR ACTUALLY touches and can't invent a category the diff
+   * doesn't contain. Absent for non-PR cards or when there's no review signal.
+   */
+  touchedAreas?: ReadonlyArray<string>;
+  /**
    * Stable correlation id for items without PR identity (deploy
    * verifications, missions, tasks). The classifier already keys these
    * by correlationId; forwarding it lets the v2 mapper build a unique

--- a/test/unit/agentic-backlog.test.ts
+++ b/test/unit/agentic-backlog.test.ts
@@ -114,3 +114,28 @@ describe("buildAgenticBacklogPrompt", () => {
     expect(prompt).toMatch(/JSON array/i);
   });
 });
+
+describe("buildAgenticBacklogPrompt — Stage 3 diff areas", () => {
+  it("surfaces a card's REAL diff-areas so the model can't invent categories the PR doesn't touch", () => {
+    const ctx: AgenticBacklogContext = {
+      ...CTX,
+      board: {
+        headline: "1 review",
+        items: [
+          {
+            repo: "averray-agent/agent",
+            number: 717,
+            title: "rewire outflow breaker",
+            lane: "Operator Review",
+            owner: "Operator",
+            verdict: "needs review",
+            why: "critical files gate",
+            touchedAreas: ["contracts", "tests"],
+          },
+        ],
+      },
+    };
+    const prompt = buildAgenticBacklogPrompt(CFG(), ctx);
+    expect(prompt).toContain("diff-areas contracts, tests");
+  });
+});

--- a/test/unit/monitor-hermes-board.test.ts
+++ b/test/unit/monitor-hermes-board.test.ts
@@ -3,6 +3,61 @@ import { describe, expect, it } from "vitest";
 import { buildHermesBoardSnapshotFromMonitor } from "../../services/slack-operator/src/monitor-hermes-board.js";
 
 describe("buildHermesBoardSnapshotFromMonitor", () => {
+  it("threads the PR's REAL diff areas onto the card — not the generic critical-files menu (Stage 3)", () => {
+    const board = buildHermesBoardSnapshotFromMonitor({
+      generatedAt: "2026-07-02T08:54:42.000Z",
+      status: "attention",
+      counts: { active: 0, running: 0, recent: 1 },
+      recent: [
+        {
+          correlationId: "github-live-pr-averray-agent-agent-717",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 717,
+          status: "completed",
+          reason: "pr_critical_files",
+          updatedAt: "2026-07-02T08:49:42.000Z",
+          summary: {
+            finalVerdict: "needs_review",
+            // The generic critical-files MENU — the phrasing the #717 near-miss fabricated from.
+            reviewReasons: [
+              { code: "pr_critical_files", message: "3 changed file(s) touch secrets, contracts, or database migrations." },
+            ],
+            currentPullRequest: { repo: "averray-agent/agent", number: 717, draft: false, state: "open", title: "rewire outflow breaker" },
+            // The REAL diff areas: only contracts + tests.
+            reviewSignals: { touchedAreas: ["contracts", "tests"] },
+          },
+        },
+      ],
+    });
+    const card = board?.items?.[0];
+    expect(card?.touchedAreas).toEqual(["contracts", "tests"]);
+    expect(card?.touchedAreas).not.toContain("secrets");
+    expect(card?.touchedAreas).not.toContain("migrations");
+  });
+
+  it("omits touchedAreas when the item carries no review signal (honest absence)", () => {
+    const board = buildHermesBoardSnapshotFromMonitor({
+      generatedAt: "2026-07-02T08:54:42.000Z",
+      status: "attention",
+      counts: { active: 0, running: 0, recent: 1 },
+      recent: [
+        {
+          correlationId: "github-live-pr-averray-agent-agent-720",
+          repo: "averray-agent/agent",
+          pullRequestNumber: 720,
+          status: "completed",
+          reason: "pr_is_draft",
+          updatedAt: "2026-07-02T08:49:42.000Z",
+          summary: {
+            finalVerdict: "needs_review",
+            currentPullRequest: { repo: "averray-agent/agent", number: 720, draft: true, state: "open", title: "wip" },
+          },
+        },
+      ],
+    });
+    expect(board?.items?.[0]?.touchedAreas).toBeUndefined();
+  });
+
   it("turns live monitor data into lane/owner context for Hermes", () => {
     const board = buildHermesBoardSnapshotFromMonitor({
       generatedAt: "2026-05-20T08:54:42.000Z",


### PR DESCRIPTION
**Stage 3 of "solved in the board"** — the *structural* complement to #486. Where #486 tells the router *not* to fabricate, this makes fabrication hard by **showing it the real diff**.

## The gap
The router's agentic backlog reasoned about board cards whose only file-category signal was the generic critical-files `why` — *"N files touch secrets, contracts, **or** database migrations"* (a **menu** of what the gate checks). The model could upgrade that menu into a specific *"#717 touches secrets + migrations"* claim. It never had the PR's **real** diff areas at that layer.

## The fix
- **`HermesBoardCardSnapshot.touchedAreas`** now carries the enriched github-live review signals — the same `reviewSignals.touchedAreas` #484 uses — **pure** (not mixed with test-case ids like `tags`).
- **`formatBoardForPrompt`** surfaces them per card as `diff-areas contracts, tests` — the definitive list of what the PR touches.
- Combined with **#486's TRUTH_RULES** ("state only what the card's own fields say"), the router is now *shown the truth* AND *told to use it*. The #717 shape can no longer be produced: the model sees `diff-areas contracts, tests`, not a secrets/migrations menu.

## Scope / safety
- 5 files, +107/−3. `monitor-hermes-voice.ts` (type), `monitor-hermes-board.ts` (`touchedAreasForItem` helper — DRYs `tagsForItem`; honest absence when no signal), `agentic-backlog.ts` (`formatBoardForPrompt` only).
- **No agentic-backlog rule/guard change** — that's #486; this only feeds better data. The `formatBoardForPrompt` change is a *different function* than #486 touched, so **no source conflict**.
- tsc clean · board-builder **6/6** (incl. the #717 fixture: card carries `["contracts","tests"]`, not the menu) · agentic-backlog **11/11** · hermes voice/narration **51/51** (tags behavior preserved).

## Merge note
Independent of #486 and correct on its own. The *only* overlap is a trivial append in `test/unit/agentic-backlog.test.ts` (both add a `describe` block at the end) — merge #486 first, or keep both blocks at merge. Source files don't conflict.

Not auto-merged — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)