### PR TITLE
fix(monitor): stop the Utilities panel clipping to a header strip

### DIFF
--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -517,7 +517,15 @@ body { margin: 0; }
   border: 1px solid var(--hm-line);
   border-radius: var(--hm-radius);
   background: var(--hm-paper-3);
-  overflow: hidden;
+  overflow-x: hidden;
+  /* The utility bar is a flex child of the fixed-height board column. Without
+     this, a full board's lanes shrink it (flex-shrink defaults to 1) and the
+     `overflow:hidden` clipped its expanded LLM-usage / tester content down to a
+     ~120px header strip. Keep its content height, but cap it so it can never
+     dominate the board — scroll past the cap instead of clipping. */
+  flex-shrink: 0;
+  max-height: 60vh;
+  overflow-y: auto;
 }
 .hm-utility-bar--attention {
   border-color: var(--hm-amber-ring);


### PR DESCRIPTION
Spotted while looking at the live board: opening **Utilities** showed only a header strip — the LLM-usage table, the per-minute tokens chart, the tester launcher, and the saved-suites list were all cut off.

## Root cause
`.hm-utility-bar` is a flex child of the fixed-height board column. With `flex-shrink` defaulting to **1** and `overflow: hidden`, a full board's lanes squeezed it down to **~120px** and clipped its **676px** of content, with no scroll. It only reproduces under height pressure — a board with many cards — which is why it surfaced now (15 proposals open), not in the calm-board tests.

```
.hm-utility-bar  →  clientH 120px · scrollH 676px · overflow hidden · flex 0 1 auto
```

## Fix (CSS only, `monitor.css`)
- `flex-shrink: 0` — the lanes can't squeeze it below its content.
- `max-height: 60vh` — an expanded panel can't dominate the board.
- `overflow-y: auto` — scroll past the cap instead of clipping (`overflow-x` stays hidden for the rounded corners).

## Verified
Injected the exact rule into the **live deployed board**: the bar went **121px → 678px**, rendering the full LLM-usage table (806.2K tokens, Hermes active), the tokens/min chart, the tester launcher, and "no saved suites" — with the lanes correctly pushed below. `vite build` clean. Pre-existing bug (not from #484–487; those didn't touch the utility bar).

Not auto-merged — your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)