### PR TITLE
docs(hermes): v0.18 upgrade plan (we're live on v0.17) + staging runbook

### DIFF
--- a/docs/HERMES_UPGRADE_v018.md
+++ b/docs/HERMES_UPGRADE_v018.md
@@ -1,0 +1,132 @@
+# Hermes v0.17 → v0.18 — Upgrade Plan + Staging-Smoke Runbook
+
+- **Status:** Plan + runbook. No brain-feature implementation here (needs the image running). Refreshes the target from the **already-completed** v0.17 upgrade to v0.18.
+- **Date:** 2026-07-02
+- **Prod is on v0.17.** `nousresearch/hermes-agent:v2026.6.19` on both `hermes` and `hermes-gateway` (confirmed via `docker inspect avg-hermes-1 avg-hermes-gateway-1`, 2026-07-02). The full v0.14→v0.17 bump **and** the agentic arc (PRs #465–475) are **live in prod**: Session API, agentic backlog, router narration, SSE streaming, learned routing, model = `glm-5.2:cloud`.
+- **⚠ Stale template:** `ops/.env.example:11` still shows the **v0.14** digest. It does not reflect the live pin and misled this plan's first draft — **update it to `v2026.6.19`** (§ Cleanup).
+- **Upstream now:** **v0.18.0 / v2026.7.1** ("The Judgment Release", 2026-07-01).
+- **Builds on:** [`HERMES_UPGRADE_v017.md`](./HERMES_UPGRADE_v017.md) — the v0.17 eval, now **executed and deployed**.
+
+---
+
+## 0. Bottom line
+
+We already did the hard part. **v0.17 is live** and the whole "control plane on a smarter brain" arc runs in prod. The v0.17→v0.18 bump is a **single-major, ~2-week jump**, and the heavy v0.15–0.17 changes (s6 supervision, UID-remap/boot-chown) are **already crossed and verified** (#464 skills-volume owner + #467 trace EADDRINUSE). So this bump is **low-risk relative to the last one.**
+
+The "remaining new features" are exactly two buckets:
+
+1. **The two v0.17 items we deliberately deferred** — background subagents (#1) and MCP elicitation (#4) — each blocked on a specific gateway limitation, *not* forgotten.
+2. **What v0.18 adds** — and the single highest-value question is whether **v0.18's matured background subagents unblock #1.**
+
+---
+
+## 1. Remaining from v0.17 (deferred, with their exact blockers)
+
+### 1.1 Background subagents (#1) — **DEFERRED**
+v0.17's `delegate_task` posts completion to the gateway's **process watcher, not the REST `/api/sessions` history**, so a background result can't round-trip through our stateless co-pilot / router loop. Groundwork exists; the loop was left one-shot.
+- **Unblock condition:** the delegation result must land somewhere our loop can read — the REST session history, or a pollable/streamable run endpoint. **← v0.18 is the candidate (see §2.1).**
+
+### 1.2 MCP elicitation (#4) — **DORMANT**
+The v0.17 gateway Session API is create/chat/fork only — **no tool-confirmation event, no answer endpoint**. We shipped fail-closed groundwork (`packages/averray-mcp/src/copilot-elicitation.ts`, `GATEWAY_ELICITATION_SUPPORTED=false`, flag `HERMES_COPILOT_ELICITATION` OFF) + `docs/HERMES_COPILOT_ELICITATION.md`.
+- **Unblock condition:** the gateway lands an elicitation event + an answer endpoint. **Check in the v0.18 smoke (§3).**
+
+---
+
+## 2. What v0.18 adds
+
+### 2.1 Matured background subagents — **ADOPT + the key unblock question**
+*"parallel subagents run in the background, one consolidated return when all finish"* ([#49734](https://github.com/NousResearch/hermes-agent/pull/49734)); a "will resume" affordance; CLI/TUI status-bar tracking.
+- The "**consolidated return into the conversation**" framing *suggests* the result now re-enters the session — exactly the round-trip **#1** needs. **This is NOT confirmed from the release notes** (concurrency/depth/timeout **and** the delivery channel are undocumented).
+- **→ The #1 smoke question (highest value):** does a background `delegate_task` result appear in the REST `/api/sessions/{id}` history (or a readable run endpoint)? If yes, #1 unblocks and becomes the top post-bump build.
+
+### 2.2 Completion contracts for `/goal` (`pre_verify`) — **ADOPT (truth-boundary synergy)**
+Evidence-based done-ness: *"the standing-goal loop judges against evidence, not the model's say-so"* ([#50501](https://github.com/NousResearch/hermes-agent/pull/50501)) via a **`pre_verify` hook** + a profile-scoped checks ledger; migration `v32` defaults **verify-on-stop OFF**.
+- Same principle as our card-side ground-truth panel (#484) and router grounding (#486/#487). **`pre_verify` is a seam to make our verification Hermes's own done-check** — e.g. "PR checks green + no `reconcileTaskClaim` mismatch." Medium effort, post-bump.
+
+### 2.3 Gateway scale-to-zero + drain — **ADOPT (ops, config)**
+Dormant-when-idle + wake-without-dropping-in-flight; external drain coordination; **`restart_drain_timeout`** (default **0** to avoid systemd crash loops); self-heal for stranded gateways. Our gateway runs supervised at `:8642` — set `restart_drain_timeout` deliberately (verify it doesn't clip in-flight co-pilot sessions).
+
+### 2.4 MoA / `/learn` / `/journey` — **BORROW / nice-to-have**
+`moa` provider + `/moa` (strong ensemble for hard routing calls); `/learn` auto-distills skills (feeds our `skills-observer`); `/journey` memory/skill timeline. Low urgency. **Vertex AI — SKIP** unless we want Gemini.
+
+---
+
+## 3. Staging smoke (v0.17 → v0.18 — lighter than the last bump)
+
+The s6 / UID-remap heavy lifting is already done and verified, so this smoke focuses on **(a) the two unblock questions** and **(b) v0.18's breaking-change surface**. Isolated throwaway profile; touches no prod containers/volumes. ~20 min.
+
+### 3.0 Resolve the real digest (never `:latest`/`:main`)
+```bash
+docker buildx imagetools inspect nousresearch/hermes-agent:v2026.7.1 | grep -i digest | head -1
+# record the sha256 → that's the new pin. Do NOT invent one.
+```
+
+### 3.1 Isolated bring-up
+```bash
+cd /srv/averray-reference-agent
+docker pull nousresearch/hermes-agent:v2026.7.1
+HERMES_IMAGE=nousresearch/hermes-agent:v2026.7.1 \
+  docker compose --env-file .env.prod \
+  -f ops/compose.yml -f ops/compose.prod.yml -f ops/compose.command-center.yml \
+  -p avg-v018smoke up -d hermes hermes-gateway
+docker compose -p avg-v018smoke logs --tail=60 hermes hermes-gateway   # boots clean under s6?
+```
+
+### 3.2 ⚠ #1 UNBLOCK TEST (the highest-value check)
+From a gateway session, issue a **background** `delegate_task` and then read the session:
+```bash
+# after the subagent finishes ("will resume"), does its result land in REST history?
+curl -s -H "Authorization: Bearer $HERMES_API_TOKEN" \
+  http://localhost:<smoke-gw-port>/api/sessions/<id> | jq '.messages[-3:]'
+```
+✅ **Result appears in `/api/sessions/{id}` history** → #1 unblocks; make it the top post-bump build.
+❌ Still watcher-only → #1 stays deferred; note the exact delivery channel v0.18 uses.
+
+### 3.3 #4 elicitation check
+- Does the v0.18 gateway emit a **tool-confirmation / elicitation** stream event and expose an **answer endpoint**? (Inspect `/api/sessions` SSE + the OpenAPI/`api_server` surface.) ✅ → activate the shipped #4 groundwork post-bump. ❌ → stays dormant.
+
+### 3.4 Regression + breaking-change surface (v0.18-specific)
+- **Skills-volume owner unchanged** (v0.18 has no new Docker changes, but confirm): `docker run --rm -v avg_avg-hermes-skills:/s alpine stat -c '%u:%g %a' /s` → still `10000:10000 0700`, so #464's `user: "10000:10000"` holds.
+- **MCP tools** (`averray`,`wallet`,`receipt`,`trace`,`policy`) all connect — esp. **`trace`** (the #467 EADDRINUSE fix must survive v0.18's s6 double-spawn).
+- **Models resolve:** `glm-5.2:cloud` (our default) **and** `deepseek-v4-pro:cloud`.
+- **verify-on-stop now OFF** (migration v32) — confirm nothing we rely on assumed it ON.
+- **Per-profile cron** (reverted from centralized) — our daily operator-report cron still registers.
+- **auth.json cloning disabled** — our gateway OAuth/token path doesn't depend on it.
+- **`prompt_caching.enabled` backed out** — confirm not set in our config.
+
+### 3.5 Go / no-go + teardown
+```bash
+docker compose -p avg-v018smoke down     # tears down ONLY the smoke project
+```
+GO if 3.1/3.4 pass → bump the pin (record the digest, the #1/#4 answers, the model + ownership results). NO-GO on any ❌ → capture + hold/fix.
+
+---
+
+## 4. Post-bump integration backlog (prioritized by the smoke's answers)
+
+Narrow PRs, each behind the existing guardrails (dispatch allowlist, budgets, 4h cap, HALT tiering, human merge/deploy gate):
+
+1. **IF §3.2 confirms round-trip → wire background subagents (#1)** into the co-pilot/router planner — the deferred highest-leverage item finally lands. Decide the budget-accounting question first (does Hermes's own fan-out count against the dispatch budget?).
+2. **`pre_verify` completion contract (§2.2)** — wire one real Averray check (PR checks green + no `reconcileTaskClaim` mismatch, reusing #484) into Hermes's `/goal` verification. Highest synergy with #484–488.
+3. **IF §3.3 confirms elicitation → activate #4** — the fail-closed groundwork already exists; just flip on the gateway path.
+4. **Gateway scale-to-zero + `restart_drain_timeout`** tuning in compose.
+5. **MoA preset for high-risk routing** (optional).
+
+---
+
+## 5. Open decisions for the operator
+
+1. **Bump v0.18?** Low-risk single-major jump (§3). The longer we hold, the wider the v0.19 gap.
+2. **Background subagents:** if v0.18 unblocks them, do we want Hermes fanning out its own parallel work — and does that spend count against the dispatch budget?
+3. **Completion contracts:** adopt `pre_verify` as the seam that makes our verification Hermes's own done-check? (Recommended — same truth-boundary principle we just shipped.)
+4. **Elicitation:** activate #4 if v0.18 exposes it, or keep lane-park.
+
+---
+
+## Cleanup
+
+`ops/.env.example` pins the **v0.14** digest while prod runs **v0.17** (`v2026.6.19`) — this stale template misled the first draft of this plan. **Update `.env.example`'s `HERMES_IMAGE` (and its comment) to the live `v2026.6.19` digest** so the template matches reality. Small, worth doing with the next ops PR.
+
+---
+
+*Refreshed 2026-07-02 after confirming the live pin is v0.17. Recommendation + runbook — the bump itself is operator-run on the box.*

--- a/docs/HERMES_UPGRADE_v018.md
+++ b/docs/HERMES_UPGRADE_v018.md
@@ -55,6 +55,8 @@ Dormant-when-idle + wake-without-dropping-in-flight; external drain coordination
 
 The s6 / UID-remap heavy lifting is already done and verified, so this smoke focuses on **(a) the two unblock questions** and **(b) v0.18's breaking-change surface**. Isolated throwaway profile; touches no prod containers/volumes. ~20 min.
 
+> **Turnkey:** [`ops/smoke-hermes-v018.sh`](../ops/smoke-hermes-v018.sh) runs the bring-up + the two unblock tests (#1 delegate round-trip, #4 elicitation) automatically on a **throwaway box** (`OLLAMA_API_KEY=… ./ops/smoke-hermes-v018.sh`; isolated project + gateway on `:8643`; self-tearing-down). It reuses this repo's own compose so the config + model are exactly like prod. **Run it on a spare box/VM/local Docker — NOT the prod VPS** (it stands up a parallel ~6-container stack). The annotated steps below are the manual version + the extra breaking-change checks (§3.4) the script leaves to you.
+
 ### 3.0 Resolve the real digest (never `:latest`/`:main`)
 ```bash
 docker buildx imagetools inspect nousresearch/hermes-agent:v2026.7.1 | grep -i digest | head -1

--- a/ops/smoke-hermes-v018.sh
+++ b/ops/smoke-hermes-v018.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Turnkey v0.18 staging smoke — RUN ON A THROWAWAY BOX, NEVER PROD.
+#
+# Stands up an ISOLATED Hermes v0.18 gateway from this repo's own compose (so
+# the config + model are exactly like prod, no guessing) and answers the two
+# questions that gate the remaining upgrade work (see docs/HERMES_UPGRADE_v018.md):
+#
+#   TEST #1  Do BACKGROUND delegate_task results round-trip into the REST
+#            session history (GET /api/sessions/{id})? If yes, the deferred
+#            "background subagents" item (the highest-leverage one) unblocks.
+#   CHECK #4 Does the gateway expose MCP elicitation (a tool-confirmation event
+#            + an answer endpoint)? If yes, the dormant inline-approval item
+#            (#4) unblocks.
+#
+# plus a model-resolution + boot sanity check. Cleans itself up on exit.
+#
+# Prereqs on the throwaway box: docker, docker compose, jq, curl, a checkout of
+# THIS repo, and a real OLLAMA_API_KEY (ollama-cloud — glm-5.2:cloud runs there).
+# Registry + ollama.com network access. It binds only 127.0.0.1:${SMOKE_GW_PORT}.
+#
+# Usage (from the repo root):
+#   OLLAMA_API_KEY=sk-... ./ops/smoke-hermes-v018.sh
+#
+# NOTE (honest): this is a smoke, so first run may need a nudge — LLMs don't
+# always call a tool on command (the #1 prompt may need retrying / hardening),
+# and the exact session-history JSON shape + the elicitation endpoint names are
+# not documented for v0.18, so the script dumps raw output alongside each verdict
+# for you to eyeball. Adjust the greps to what you see.
+set -euo pipefail
+
+IMAGE="nousresearch/hermes-agent:v2026.7.1"           # v0.18.0
+PROJECT="hermesv018smoke"
+PORT="${SMOKE_GW_PORT:-8643}"                          # NOT 8642 — never clash with a live gateway
+GW="http://127.0.0.1:${PORT}"
+: "${OLLAMA_API_KEY:?Set OLLAMA_API_KEY (ollama-cloud) so glm-5.2:cloud can run}"
+command -v jq   >/dev/null || { echo "need jq";   exit 1; }
+command -v curl >/dev/null || { echo "need curl"; exit 1; }
+[ -f ops/compose.yml ] || { echo "run from the repo root (ops/compose.yml not found)"; exit 1; }
+
+ENVF="$(mktemp)"
+TOK="smoke-$(head -c 8 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+cat > "$ENVF" <<EOF
+HERMES_GATEWAY_API_KEY=${TOK}
+OLLAMA_API_KEY=${OLLAMA_API_KEY}
+HERMES_GATEWAY_PORT=${PORT}
+EOF
+
+COMPOSE=(docker compose --env-file "$ENVF" -f ops/compose.yml -f ops/compose.command-center.yml -p "$PROJECT")
+cleanup(){ echo "── teardown (removes the smoke project + its volumes) ──"; "${COMPOSE[@]}" down -v >/dev/null 2>&1 || true; rm -f "$ENVF"; }
+trap cleanup EXIT
+auth=(-H "Authorization: Bearer ${TOK}" -H "Content-Type: application/json")
+
+echo "── pull + isolated bring-up (project=$PROJECT, gateway 127.0.0.1:$PORT) ──"
+docker pull "$IMAGE"
+HERMES_IMAGE="$IMAGE" "${COMPOSE[@]}" up -d hermes-gateway
+
+echo "── wait for /health (up to 2 min; boot pulls its own postgres + mcp-bundle) ──"
+for i in $(seq 1 40); do
+  curl -fsS "$GW/health" >/dev/null 2>&1 && { echo "✅ gateway healthy"; break; }
+  sleep 3
+  if [ "$i" = 40 ]; then echo "❌ gateway never healthy — logs:"; "${COMPOSE[@]}" logs --tail=80 hermes-gateway; exit 1; fi
+done
+
+echo "── model sanity: one plain turn ──"
+SID=$(curl -s "${auth[@]}" -X POST "$GW/api/sessions" -d '{}' | jq -r '.session.id')
+echo "session=$SID"
+reply=$(curl -s "${auth[@]}" -X POST "$GW/api/sessions/$SID/chat" -d '{"input":"Reply with exactly one word: READY"}' | jq -r '.message.content // .message // empty')
+echo "model reply: ${reply:0:120}"
+[ -n "$reply" ] && echo "✅ glm-5.2:cloud resolves + answers" || echo "⚠ empty reply — check OLLAMA_API_KEY / model catalog on v0.18"
+
+echo
+echo "════════ TEST #1 — background delegate_task round-trip ════════"
+curl -s "${auth[@]}" -X POST "$GW/api/sessions/$SID/chat" \
+  -d '{"input":"Use the delegate_task tool with background=true to spawn ONE subagent whose entire job is to compute 21+21 and reply with only the number 42. Return to me immediately with the background handle — do NOT wait for the subagent."}' \
+  | jq -r '.message.content // empty' | sed 's/^/  spawn turn: /' | head -6
+echo "  …waiting 60s for the background subagent to finish + (maybe) re-enter the session…"
+sleep 60
+echo "  REST session history now:"
+hist=$(curl -s "${auth[@]}" "$GW/api/sessions/$SID")
+echo "$hist" | jq '{turns:((.messages // .session.messages // []) | length), last3:((.messages // .session.messages // [])[-3:] | map({role, content:(.content|tostring|.[0:200])}))}' 2>/dev/null || { echo "  (unexpected shape — raw:)"; echo "$hist" | head -c 500; }
+echo
+if echo "$hist" | grep -q '42'; then
+  echo "✅ #1 PASS — the subagent's result (42) IS in the REST session history →"
+  echo "   background subagents ROUND-TRIP → wire them into the planner (top post-bump build)."
+else
+  echo "❌ #1 FAIL/UNCLEAR — '42' not found in REST history. Either it round-trips"
+  echo "   under a different JSON shape (eyeball the dump above) or it's still"
+  echo "   watcher-only → #1 stays deferred. Record the exact delivery shape."
+fi
+
+echo
+echo "════════ CHECK #4 — does the gateway expose MCP elicitation? ════════"
+oapi=$(curl -s "${auth[@]}" "$GW/openapi.json" 2>/dev/null || true)
+if [ -n "$oapi" ] && echo "$oapi" | jq -e . >/dev/null 2>&1; then
+  hits=$(echo "$oapi" | jq -r '.paths | keys[]' 2>/dev/null | grep -iE 'elicit|confirm|answer|approve' || true)
+  if [ -n "$hits" ]; then echo "✅ candidate elicitation endpoints:"; echo "$hits" | sed 's/^/   /';
+  else echo "❌ no elicit/confirm/answer paths in the OpenAPI → #4 stays dormant on v0.18."; fi
+else
+  echo "⚠ no parseable /openapi.json at $GW — inspect the gateway API surface manually"
+  echo "  (look for a tool-confirmation SSE event + an answer endpoint)."
+fi
+
+echo
+echo "════════ smoke complete — teardown runs automatically on exit ════════"


### PR DESCRIPTION
**Correction to the premise:** prod is **on v0.17** (`v2026.6.19`, confirmed via `docker inspect`) — the v0.14→v0.17 bump + the whole agentic arc (PRs #465–475) is **already live**: Session API, agentic backlog (what generates the board's routed proposals), narration, streaming, learned routing, model `glm-5.2:cloud`. (`ops/.env.example` still shows a stale **v0.14** digest — flagged for cleanup; it's what misled the first draft.)

## So what actually remains
**v0.18 ("Judgment Release", 2026-07-01)** is the next bump — a **low-risk single-major jump** (the heavy s6/UID changes are already crossed + verified via #464/#467). The remaining features are two buckets:

**The two v0.17 items we deferred (real blockers, not forgotten):**
- **Background subagents (#1)** — v0.17's `delegate_task` posts completion to the gateway *watcher*, not the REST session, so it can't round-trip our stateless loop.
- **MCP elicitation (#4)** — v0.17 gateway is create/chat/fork only; shipped as fail-closed groundwork.

**v0.18's adds — and the headline question:**
- **Matured background subagents** ("one consolidated return when all finish") *may unblock #1* if the result now round-trips the REST session — **the top staging-smoke test.**
- **Completion contracts (`pre_verify`)** — evidence-based `/goal` done-ness; a clean seam to make our verification (#484's `reconcileTaskClaim`) Hermes's own done-check.
- Gateway scale-to-zero + drain, MoA, `/learn`, `/journey`.

## In the doc
- v0.17-remaining + v0.18-delta with fit verdicts.
- A **v0.17→v0.18 staging-smoke runbook** centered on the two unblock tests (does a background `delegate_task` land in `/api/sessions/{id}`? does the gateway emit elicitation?) + the v0.18 breaking-change surface (verify-on-stop OFF/v32, per-profile cron, auth.json cloning, model resolution, the #467 trace check).
- A prioritized **post-bump backlog** (all behind existing guardrails).
- A cleanup note to fix the stale `.env.example` pin.

Docs-only; no code, no image change. The bump is operator-run. Not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)