### PR TITLE
chore(ops): update stale .env.example Hermes pin (v0.14 → v0.17)

### DIFF
--- a/ops/.env.example
+++ b/ops/.env.example
@@ -6,9 +6,11 @@
 # docs/DEPLOY.md.
 # AVERRAY_IMAGE=
 
-# Pinned Hermes Agent v0.14.0 / v2026.5.16 multi-arch image digest.
-# Refresh intentionally after testing a new Hermes release.
-HERMES_IMAGE=nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33
+# Pinned Hermes Agent v0.17.0 / v2026.6.19 — matches the live prod pin in .env.prod.
+# Refresh intentionally after testing a new Hermes release — staged smoke first
+# (see docs/HERMES_UPGRADE_v018.md). For stricter pinning, resolve the tag to a
+# digest: `docker buildx imagetools inspect nousresearch/hermes-agent:v2026.6.19`.
+HERMES_IMAGE=nousresearch/hermes-agent:v2026.6.19
 
 POSTGRES_USER=avg_agent
 POSTGRES_PASSWORD=change-me


### PR DESCRIPTION
The `ops/.env.example` template still pinned **v0.14.0 / v2026.5.16** while prod has run **v0.17.0 / v2026.6.19** since 2026-07-01. The stale template is what misled the first draft of the v0.18 upgrade plan into thinking we were four majors behind.

Fix: match the live prod pin (`.env.prod` = `nousresearch/hermes-agent:v2026.6.19`), refresh the comment, and point the "refresh intentionally" note at the staged smoke in `docs/HERMES_UPGRADE_v018.md`. Config template only — no runtime or image change.

Not auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)