### PR TITLE
chore(ops): retire Hermes dashboard for v0.18 (serve/loopback) + pin aux model

### DIFF
--- a/docs/VPS_SMOKE.md
+++ b/docs/VPS_SMOKE.md
@@ -427,17 +427,14 @@ curl -sS http://127.0.0.1:8790/health
 
 ## Dashboard Access
 
-Hermes dashboard is not exposed publicly. Docker binds it to
-`127.0.0.1:9119` on the VPS, so open the SSH tunnel from your laptop, not from
-inside the VPS shell. The Hermes dashboard command uses `--insecure` because
-Hermes requires it for the container-internal `0.0.0.0` bind; Docker still
-limits host access to VPS loopback.
+The Hermes-native browser dashboard is retired. Hermes v0.18 made
+`dashboard --insecure` a no-op — a non-loopback dashboard bind now refuses to
+start without an auth provider — so the `hermes` service runs `serve` (the
+headless gateway backend) bound to container-loopback only, not exposed.
 
-SSH tunnel:
-
-```bash
-ssh -L 9119:localhost:9119 ubuntu@YOUR_VPS
-```
+Operate the control plane via the slack-operator SPA behind Cloudflare Access
+(`https://monitor.averray.com/monitor/`), not the Hermes UI. The interactive
+brain (Session API) is `hermes-gateway` on `127.0.0.1:8642`.
 
 Then open:
 

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -6,6 +6,14 @@ model:
   api_key_env: OLLAMA_API_KEY
   default: glm-5.2:cloud
 
+# Pin v0.18's post-turn background-review fork to our own provider. Left unset
+# it defaults to "auto" and falls through the auxiliary chain to OpenRouter →
+# Nous Portal (no credit) → repeated credit-error log spam. Same model as above.
+auxiliary:
+  background_review:
+    provider: ollama-cloud
+    model: glm-5.2:cloud
+
 mcp_servers:
   averray:
     command: /app/scripts/run-mcp-server.sh

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -804,11 +804,16 @@ services:
       - ../hermes/profiles:/opt/data/browser-profiles
       - avg-hermes-skills:/opt/data/skills
     networks: [avg-internal]
-    ports:
-      - "127.0.0.1:9119:9119"
-    # Hermes requires --insecure for non-loopback container binds. The Docker
-    # port mapping above keeps this reachable only from VPS localhost.
-    command: ["dashboard", "--host", "0.0.0.0", "--port", "9119", "--insecure"]
+    # Headless backend only — the Hermes-native browser dashboard is retired.
+    # v0.18 made `dashboard --insecure` a no-op: a non-loopback dashboard/serve
+    # bind now refuses to start without an auth provider (that was the v0.17→
+    # v0.18 dashboard crash-loop). `dashboard` and `serve` boot the same
+    # start_server backend; the auth gate only engages on a NON-loopback bind.
+    # We operate via the slack-operator SPA behind Cloudflare Access, not the
+    # Hermes UI, so run `serve` (headless gateway backend) on container-loopback
+    # — crash-free, not exposed (no host port-map). The shared /opt/data backend
+    # keeps running exactly as the dashboard's backend did.
+    command: ["serve", "--host", "127.0.0.1", "--port", "9119"]
 
 volumes:
   avg-postgres:


### PR DESCRIPTION
## What

Ops prep for a **clean v0.17 → v0.18 re-bump**. The earlier direct bump hit breaking changes and was rolled back to v0.17 (prod is healthy). A source dig against the v0.18 tag re-characterized all three symptoms:

| Symptom | Verdict | This PR |
|---|---|---|
| Session-API **401** on `POST /api/sessions` | **Not a code change** — auth path is byte-identical v0.17↔v0.18 for our key (config resolution → `self._api_key` → `_check_auth`). The 401 was a recreate artifact. | none — the clean boot re-tests it |
| **Dashboard crash-loop** | **Real.** v0.18 made `dashboard --insecure` a no-op; a non-loopback dashboard/`serve` bind refuses to start without an auth provider. | ✅ fixed |
| **Aux-model credit spam** | **Real, cosmetic.** v0.18's post-turn background-review fork falls through to OpenRouter→Nous (no credit). | ✅ fixed |

## Changes

- **`ops/compose.yml`** — `hermes` service: `dashboard --host 0.0.0.0 … --insecure` → **`serve --host 127.0.0.1 --port 9119`**, and drop the now-unreachable `127.0.0.1:9119:9119` host port-map. `dashboard` and `serve` boot the **same** `start_server` backend and the v0.18 auth gate only engages on a **non-loopback** bind, so loopback is crash-free. We operate the control plane via the slack-operator SPA behind Cloudflare Access, not the Hermes-native UI. The shared `/opt/data` backend keeps running as before.
- **`hermes/config/hermes.yaml`** — add `auxiliary.background_review: { provider: ollama-cloud, model: glm-5.2:cloud }` to keep the review fork on our provider (no OpenRouter/Nous fall-through).
- **`docs/VPS_SMOKE.md`** — the "Dashboard Access" section (SSH-tunnel to :9119) is now stale; replace with the retired-dashboard + SPA reality.

## Why `serve`/loopback and not remove the service

Conservative + reversible: `serve` keeps the `hermes` container's `/opt/data` agent backend running exactly as the dashboard's backend did — I can't confirm from compose alone whether it does autonomous work `hermes-gateway` doesn't. If it proves fully redundant with `hermes-gateway`, a follow-up removes the service outright. (`hermes-workspace`, the optional command-center overlay, points at `hermes:9119`; its dashboard proxy no longer resolves — expected, since we're retiring the dashboard.)

## Testing

- YAML validated (`ops/compose.yml`, `hermes/config/hermes.yaml` both parse; `hermes.command` = `["serve","--host","127.0.0.1","--port","9119"]`, `ports` = none).
- **Not yet run against a live v0.18 gateway** (no spare box). The reasoning is source-grounded (dashboard.py: `serve`/`dashboard` share `start_server`; dashboard_register.py: the gate only engages on a non-loopback bind), but the re-bump itself — with rollback ready — is the real test.

## Scope

**Prep only — no deploy.** Operator gates the re-bump. Prod stays on v0.17 until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
