### PR TITLE
fix(ci): sync bootstrap-wallet.sh Hermes pin with .env.example (#490 follow-up)

### DIFF
--- a/scripts/bootstrap-wallet.sh
+++ b/scripts/bootstrap-wallet.sh
@@ -20,7 +20,7 @@ const agentAccount = privateKeyToAccount(agentPrivateKey);
 const adminAccount = privateKeyToAccount(adminPrivateKey);
 const verifierAccount = privateKeyToAccount(verifierPrivateKey);
 
-console.log(`HERMES_IMAGE=nousresearch/hermes-agent@sha256:b6e41c155d6bfce5ad83c5d0fec670086db8a43250e4511c9474134be5482d33`);
+console.log(`HERMES_IMAGE=nousresearch/hermes-agent:v2026.6.19`);
 console.log(`POSTGRES_USER=avg_agent`);
 console.log(`POSTGRES_PASSWORD=${randomUUID().replaceAll("-", "")}`);
 console.log(`POSTGRES_DB=avg_agent`);


### PR DESCRIPTION
## What
`main` CI has been red since **#490** (c56266c, merged 19:27 today). #490 bumped `ops/.env.example` `HERMES_IMAGE` to the `:v2026.6.19` tag but left `scripts/bootstrap-wallet.sh` emitting the old `@sha256:b6e41c…` digest. The `compose-env.test.ts` guard cross-checks that the bootstrap generator emits the **same** pin as `.env.example`, so it fails on every push.

## Fix
One line — `scripts/bootstrap-wallet.sh` now emits `HERMES_IMAGE=nousresearch/hermes-agent:v2026.6.19` (matches `.env.example`).

## Verified
All four assertions in the failing test now hold (checked against file contents): bootstrap `HERMES_IMAGE` == the `.env.example` pin; bootstrap + `.env.example` both carry `HERMES_MONITOR_REPLY_MODEL=glm-5.2:cloud`; `.env.example` carries `LLM_USAGE_LOG_PATH=…`.

**Unblocks CI for every open PR** (main was red for all of them), including #491.

🤖 Generated with [Claude Code](https://claude.com/claude-code)