### PR TITLE
feat(monitor): switchable Delivery ⇆ Monitoring lane + product-health backend (PR2)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -45,6 +45,10 @@ import { CoPilotRail } from "./hermes/CoPilotRail.js";
 import { KeyboardOverlay } from "./shortcuts/KeyboardOverlay.js";
 import type { UseCollaborationOptions } from "../hooks/useCollaboration.js";
 import { useBoardKeyboard } from "../hooks/useBoardKeyboard.js";
+import { useProductHealth } from "../hooks/useProductHealth.js";
+import { hasFreshRed, type ProductHealth } from "../lib/monitor/product-health.js";
+import { MonitoringLaneToggle, type LaneMode } from "./monitoring/MonitoringLaneToggle.js";
+import { MonitoringSurface } from "./monitoring/MonitoringSurface.js";
 import { Badge, Button } from "./ui.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
@@ -225,6 +229,32 @@ export function BoardView({
   const [overlayOpen, setOverlayOpen] = useState(false);
   const [askToken, setAskToken] = useState(0);
   const [hermesFocusConversationActive, setHermesFocusConversationActive] = useState(false);
+
+  // ── PR2: the right lane switches Delivery ⇆ Monitoring ──────────────
+  const { health: productHealth } = useProductHealth();
+  const [deliveryMode, setDeliveryMode] = useState<LaneMode>(() => {
+    try {
+      return localStorage.getItem("hm-lane-mode") === "monitoring" ? "monitoring" : "delivery";
+    } catch {
+      return "delivery";
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem("hm-lane-mode", deliveryMode);
+    } catch {
+      /* ignore storage errors (private mode) */
+    }
+  }, [deliveryMode]);
+  // Auto-flip to Monitoring on a FRESH red (once per incident): a probe that was
+  // already red doesn't re-trigger, so a manual switch back to Delivery sticks.
+  const prevHealthRef = useRef<ProductHealth | undefined>(undefined);
+  useEffect(() => {
+    if (productHealth && hasFreshRed(prevHealthRef.current, productHealth)) {
+      setDeliveryMode("monitoring");
+    }
+    prevHealthRef.current = productHealth;
+  }, [productHealth]);
   const searchInputRef = useRef<HTMLInputElement>(null);
   // P0-4: every Ask-Hermes trigger must produce immediate visible feedback.
   // We bump askToken (focuses the composer, which scrolls it into view),
@@ -385,6 +415,17 @@ export function BoardView({
   ) => renderPipelineMirror(card, tierFor(lane), inboxIds.has(card.id)), [inboxIds, renderPipelineMirror]);
   const renderLaneBody = (id: LaneId, laneCards: BoardCard[]) => {
     const renderMirror = (card: BoardCard) => renderPipelineCardForLane(id, card);
+    // PR2: the Done lane doubles as the Monitoring lane. In monitoring mode its
+    // body IS the monitoring surface; in delivery mode the release history renders.
+    if (id === "done" && deliveryMode === "monitoring") {
+      return productHealth ? (
+        <MonitoringSurface health={productHealth} />
+      ) : (
+        <div className="hm-mon-empty">
+          <span className="hm-mon-empty-title">Loading health…</span>
+        </div>
+      );
+    }
     // PR-F3: the Deploying lane surfaces the active/current deploy ungrouped, with
     // its verification stepper visible; older near-identical verifications still
     // group behind "N similar" so the dedupe no longer shadows the live deploy.
@@ -410,6 +451,10 @@ export function BoardView({
     if (!hasGroupedCards) return undefined;
     return <GroupedLaneBody items={groupedItems} renderCard={renderMirror} />;
   };
+  const renderLaneHeader = (lane: LaneId): ReactNode =>
+    lane === "done" ? (
+      <MonitoringLaneToggle mode={deliveryMode} onChange={setDeliveryMode} health={productHealth} />
+    ) : null;
 
   const drawerCard = focusedCardId ? orderedCards.find((c) => c.id === focusedCardId) : undefined;
   const boardFocusedCard = boardFocusId ? orderedCards.find((c) => c.id === boardFocusId) : undefined;
@@ -620,6 +665,7 @@ export function BoardView({
             renderCard={renderCard}
             renderPipelineCard={renderPipelineCard}
             renderLaneBody={renderLaneBody}
+            renderLaneHeader={renderLaneHeader}
           />
         </div>
 

--- a/packages/monitor-ui/src/components/monitoring/MonitoringLaneToggle.tsx
+++ b/packages/monitor-ui/src/components/monitoring/MonitoringLaneToggle.tsx
@@ -1,0 +1,41 @@
+// The Delivery ⇆ Monitoring segmented toggle for the right lane head. Carries a
+// health dot on the Monitoring tab so a red probe is visible from the Delivery
+// view (the lane also auto-flips to Monitoring on a fresh red — see BoardView).
+
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import { overallSummary, overallToneClass } from "../../lib/monitor/product-health.js";
+
+export type LaneMode = "delivery" | "monitoring";
+
+export interface MonitoringLaneToggleProps {
+  mode: LaneMode;
+  onChange: (mode: LaneMode) => void;
+  health: ProductHealth | undefined;
+}
+
+export function MonitoringLaneToggle({ mode, onChange, health }: MonitoringLaneToggleProps) {
+  const tone = health ? overallToneClass(overallSummary(health).tone) : "muted";
+  return (
+    <div className="hm-lane-switch" role="tablist" aria-label="Right lane view">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "delivery"}
+        className={`hm-lane-switch-opt${mode === "delivery" ? " is-on" : ""}`}
+        onClick={() => onChange("delivery")}
+      >
+        Delivery
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "monitoring"}
+        className={`hm-lane-switch-opt${mode === "monitoring" ? " is-on" : ""}`}
+        onClick={() => onChange("monitoring")}
+      >
+        <span className={`hm-dot hm-dot--${tone}`} aria-hidden="true" />
+        Monitoring
+      </button>
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/monitoring/MonitoringSurface.test.tsx
+++ b/packages/monitor-ui/src/components/monitoring/MonitoringSurface.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+
+import { MonitoringSurface } from "./MonitoringSurface.js";
+import { MonitoringLaneToggle } from "./MonitoringLaneToggle.js";
+import { ProbeSparkline } from "./ProbeSparkline.js";
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+
+afterEach(cleanup);
+
+const health = (over: Partial<ProductHealth> = {}): ProductHealth => ({
+  enabled: true,
+  at: 1,
+  status: "red",
+  checks: 30,
+  probes: [
+    { name: "product_api", status: "ok", detail: "api → 200", sparkline: ["ok", "ok"] },
+    { name: "chain_height", status: "degraded", detail: "RPC not set", sparkline: ["degraded"] },
+    { name: "signer_liquidity", status: "red", detail: "gas 0.04 < 0.1", sparkline: ["ok", "red"] },
+  ],
+  ...over,
+});
+
+describe("MonitoringSurface", () => {
+  it("renders a card per probe, the detail, and the overall headline", () => {
+    render(<MonitoringSurface health={health()} />);
+    expect(screen.getByText("Product API")).toBeTruthy();
+    expect(screen.getByText("gas 0.04 < 0.1")).toBeTruthy();
+    expect(screen.getByText("1 probe red")).toBeTruthy();
+    expect(screen.getByTestId("probe-signer_liquidity").className).toContain("hm-probe--fail");
+  });
+
+  it("shows the honest 'monitoring off' state, not a green", () => {
+    render(<MonitoringSurface health={health({ enabled: false })} />);
+    expect(screen.getByTestId("product-health-off")).toBeTruthy();
+    expect(screen.queryByTestId("probe-product_api")).toBeNull();
+  });
+
+  it("shows 'awaiting first check' when enabled but no data yet", () => {
+    render(<MonitoringSurface health={health({ enabled: true, checks: 0 })} />);
+    expect(screen.getByTestId("product-health-idle")).toBeTruthy();
+  });
+});
+
+describe("MonitoringLaneToggle", () => {
+  it("fires onChange when a tab is clicked", () => {
+    const onChange = vi.fn();
+    render(<MonitoringLaneToggle mode="delivery" onChange={onChange} health={health()} />);
+    fireEvent.click(screen.getByText("Monitoring"));
+    expect(onChange).toHaveBeenCalledWith("monitoring");
+  });
+});
+
+describe("ProbeSparkline", () => {
+  it("pads to a fixed cell count and colours each cell by status", () => {
+    const { container } = render(<ProbeSparkline series={["ok", "red"]} bins={5} />);
+    expect(container.querySelectorAll(".hm-spark-cell").length).toBe(5);
+    expect(container.querySelectorAll(".hm-spark-cell--empty").length).toBe(3);
+    expect(container.querySelectorAll(".hm-spark-cell--fail").length).toBe(1);
+    expect(container.querySelectorAll(".hm-spark-cell--pass").length).toBe(1);
+  });
+});

--- a/packages/monitor-ui/src/components/monitoring/MonitoringSurface.tsx
+++ b/packages/monitor-ui/src/components/monitoring/MonitoringSurface.tsx
@@ -1,0 +1,28 @@
+// The Monitoring view that fills the switched right lane. A stack of monitoring
+// sections — product-health is the first. Future sections (uptime %, liquidity
+// trend, money-path KPIs, incident log) drop in as their own components below;
+// this surface just composes them, so growing the monitoring story is additive.
+
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import { overallSummary, overallToneClass } from "../../lib/monitor/product-health.js";
+import { ProductHealthSection } from "./ProductHealthSection.js";
+
+export interface MonitoringSurfaceProps {
+  health: ProductHealth;
+}
+
+export function MonitoringSurface({ health }: MonitoringSurfaceProps) {
+  const overall = overallSummary(health);
+  return (
+    <div className="hm-mon-surface" data-testid="monitoring-surface">
+      <section className="hm-mon-section">
+        <header className="hm-mon-section-head">
+          <span className="hm-mon-section-title">Product health</span>
+          <span className={`hm-pill hm-pill--${overallToneClass(overall.tone)}`}>{overall.label}</span>
+        </header>
+        <ProductHealthSection health={health} />
+      </section>
+      <p className="hm-mon-headroom">More monitoring lands here — uptime, liquidity trend, incidents.</p>
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/monitoring/ProbeSparkline.tsx
+++ b/packages/monitor-ui/src/components/monitoring/ProbeSparkline.tsx
@@ -1,0 +1,27 @@
+// A compact uptime strip — one cell per check, coloured by status (green ok /
+// grey degraded / coral red). The series right-aligns into a fixed cell count so
+// every probe's strip lines up.
+
+import type { ProbeStatus } from "../../lib/monitor/product-health.js";
+import { probeTone } from "../../lib/monitor/product-health.js";
+
+export interface ProbeSparklineProps {
+  series: ProbeStatus[];
+  /** Fixed cell count; older checks pad the left with empty cells. */
+  bins?: number;
+}
+
+export function ProbeSparkline({ series, bins = 24 }: ProbeSparklineProps) {
+  const cells = series.slice(Math.max(0, series.length - bins));
+  const pad = Math.max(0, bins - cells.length);
+  return (
+    <div className="hm-spark" role="img" aria-label={`uptime over the last ${cells.length} checks`}>
+      {Array.from({ length: pad }).map((_, i) => (
+        <span key={`pad-${i}`} className="hm-spark-cell hm-spark-cell--empty" />
+      ))}
+      {cells.map((status, i) => (
+        <span key={i} className={`hm-spark-cell hm-spark-cell--${probeTone(status)}`} />
+      ))}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/components/monitoring/ProductHealthSection.tsx
+++ b/packages/monitor-ui/src/components/monitoring/ProductHealthSection.tsx
@@ -1,0 +1,53 @@
+// The product-health monitoring section — one card per probe (status pill +
+// uptime sparkline + live detail). Truth-boundary: honest empty states for
+// "monitoring off" and "no checks yet"; a degraded (unconfigured / unreachable)
+// probe reads grey, never a fake green.
+
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import { probeLabel, probeTone } from "../../lib/monitor/product-health.js";
+import { ProbeSparkline } from "./ProbeSparkline.js";
+
+export interface ProductHealthSectionProps {
+  health: ProductHealth;
+}
+
+const PILL_TEXT: Record<string, string> = { ok: "ok", degraded: "degraded", red: "red" };
+
+export function ProductHealthSection({ health }: ProductHealthSectionProps) {
+  if (!health.enabled) {
+    return (
+      <div className="hm-mon-empty" data-testid="product-health-off">
+        <span className="hm-mon-empty-title">Monitoring is off</span>
+        <span className="hm-mon-empty-detail">Set PRODUCT_HEALTH_ENABLED to start probing the live product.</span>
+      </div>
+    );
+  }
+  if (health.checks === 0) {
+    return (
+      <div className="hm-mon-empty" data-testid="product-health-idle">
+        <span className="hm-mon-empty-title">Awaiting first check</span>
+        <span className="hm-mon-empty-detail">The heartbeat runs every couple of minutes.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="hm-mon-probes">
+      {health.probes.map((probe) => {
+        const tone = probeTone(probe.status);
+        return (
+          <div key={probe.name} className={`hm-probe hm-probe--${tone}`} data-testid={`probe-${probe.name}`}>
+            <div className="hm-probe-head">
+              <span className="hm-probe-name">
+                <span className={`hm-dot hm-dot--${tone}`} aria-hidden="true" />
+                {probeLabel(probe.name)}
+              </span>
+              <span className={`hm-pill hm-pill--${tone}`}>{PILL_TEXT[probe.status]}</span>
+            </div>
+            <ProbeSparkline series={probe.sparkline} />
+            <div className="hm-probe-detail">{probe.detail}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/monitor-ui/src/hooks/useProductHealth.ts
+++ b/packages/monitor-ui/src/hooks/useProductHealth.ts
@@ -1,0 +1,65 @@
+// useProductHealth — polls GET /monitor/product-health (the live-product probes)
+// for the Monitoring lane. Degraded-safe: a failed fetch leaves the last good
+// snapshot + surfaces the error; it never throws into render.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ProductHealth } from "../lib/monitor/product-health.js";
+
+const DEFAULT_URL = "/monitor/product-health";
+const DEFAULT_INTERVAL_MS = 20_000;
+
+export interface UseProductHealthOptions {
+  url?: string;
+  intervalMs?: number;
+  /** Injected fetcher (tests / non-browser). Defaults to fetch + JSON. */
+  fetcher?: (url: string) => Promise<ProductHealth>;
+  /** When false, the poll is not started (default true). */
+  live?: boolean;
+}
+
+export interface ProductHealthState {
+  health: ProductHealth | undefined;
+  error: unknown;
+  isLoading: boolean;
+  refresh: () => void;
+}
+
+async function defaultFetcher(url: string): Promise<ProductHealth> {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`product-health fetch failed: ${res.status}`);
+  return (await res.json()) as ProductHealth;
+}
+
+export function useProductHealth(options: UseProductHealthOptions = {}): ProductHealthState {
+  const { url = DEFAULT_URL, intervalMs = DEFAULT_INTERVAL_MS, fetcher = defaultFetcher, live = true } = options;
+  const [health, setHealth] = useState<ProductHealth | undefined>(undefined);
+  const [error, setError] = useState<unknown>(undefined);
+  const [isLoading, setIsLoading] = useState(true);
+  const mounted = useRef(true);
+
+  const load = useCallback(async () => {
+    try {
+      const next = await fetcher(url);
+      if (!mounted.current) return;
+      setHealth(next);
+      setError(undefined);
+    } catch (err) {
+      if (mounted.current) setError(err);
+    } finally {
+      if (mounted.current) setIsLoading(false);
+    }
+  }, [fetcher, url]);
+
+  useEffect(() => {
+    mounted.current = true;
+    void load();
+    if (!live) return () => void (mounted.current = false);
+    const timer = setInterval(() => void load(), intervalMs);
+    return () => {
+      mounted.current = false;
+      clearInterval(timer);
+    };
+  }, [load, live, intervalMs]);
+
+  return { health, error, isLoading, refresh: () => void load() };
+}

--- a/packages/monitor-ui/src/lib/monitor/product-health.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  probeLabel,
+  probeTone,
+  hasFreshRed,
+  overallSummary,
+  overallToneClass,
+  type ProductHealth,
+} from "./product-health.js";
+
+const mk = (over: Partial<ProductHealth> = {}): ProductHealth => ({
+  enabled: true,
+  at: 1,
+  status: "healthy",
+  checks: 5,
+  probes: [],
+  ...over,
+});
+
+const red = (names: string[]): ProductHealth =>
+  mk({ status: "red", probes: names.map((n) => ({ name: n, status: "red" as const, detail: "", sparkline: [] })) });
+
+describe("probeLabel", () => {
+  it("maps known probes and humanizes the rest", () => {
+    expect(probeLabel("product_api")).toBe("Product API");
+    expect(probeLabel("signer_liquidity")).toBe("Signer liquidity");
+    expect(probeLabel("weird_thing")).toBe("Weird thing");
+  });
+});
+
+describe("probeTone", () => {
+  it("maps a probe status onto the --hm-state family", () => {
+    expect(probeTone("ok")).toBe("pass");
+    expect(probeTone("degraded")).toBe("degraded");
+    expect(probeTone("red")).toBe("fail");
+  });
+});
+
+describe("hasFreshRed (drives the auto-flip)", () => {
+  it("is false when next isn't red", () => {
+    expect(hasFreshRed(undefined, mk())).toBe(false);
+    expect(hasFreshRed(red(["a"]), mk({ status: "degraded" }))).toBe(false);
+  });
+  it("is true on a first-seen red", () => {
+    expect(hasFreshRed(undefined, red(["a"]))).toBe(true);
+  });
+  it("is false when the same probe was already red last poll (once per incident)", () => {
+    expect(hasFreshRed(red(["a"]), red(["a"]))).toBe(false);
+  });
+  it("is true when a NEW probe crosses into red", () => {
+    expect(hasFreshRed(red(["a"]), red(["a", "b"]))).toBe(true);
+  });
+});
+
+describe("overallSummary (truth-boundary honest)", () => {
+  it("distinguishes off / awaiting / degraded / healthy / red", () => {
+    expect(overallSummary(mk({ enabled: false })).tone).toBe("off");
+    expect(overallSummary(mk({ checks: 0 })).tone).toBe("idle");
+    expect(overallSummary(mk({ status: "degraded" })).label).toBe("degraded · safe");
+    expect(overallSummary(mk({ status: "healthy" })).label).toBe("all healthy");
+    const r = overallSummary(red(["x"]));
+    expect(r.tone).toBe("red");
+    expect(r.label).toBe("1 probe red");
+    expect(overallSummary(red(["x", "y"])).label).toBe("2 probes red");
+  });
+});
+
+describe("overallToneClass", () => {
+  it("maps tones onto --hm-state families (muted for off/idle)", () => {
+    expect(overallToneClass("healthy")).toBe("pass");
+    expect(overallToneClass("red")).toBe("fail");
+    expect(overallToneClass("degraded")).toBe("degraded");
+    expect(overallToneClass("off")).toBe("muted");
+    expect(overallToneClass("idle")).toBe("muted");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -1,0 +1,72 @@
+// Product-health — the monitor board's view of the LIVE product (not the dev
+// board). Mirrors the slack-operator GET /monitor/product-health shape. Pure
+// types + helpers only; the hook (useProductHealth) and components consume these.
+
+export type ProbeStatus = "ok" | "degraded" | "red";
+export type ProductHealthStatus = "healthy" | "degraded" | "red" | "unknown";
+
+export interface ProductHealthProbe {
+  name: string;
+  status: ProbeStatus;
+  detail: string;
+  /** Per-check statuses, oldest → newest (feeds the sparkline). */
+  sparkline: ProbeStatus[];
+}
+
+export interface ProductHealth {
+  /** false = the heartbeat routine is off (honest "monitoring off", not a green). */
+  enabled: boolean;
+  /** Epoch ms of the last check, or null if none yet. */
+  at: number | null;
+  status: ProductHealthStatus;
+  checks: number;
+  probes: ProductHealthProbe[];
+}
+
+const PROBE_LABELS: Record<string, string> = {
+  product_api: "Product API",
+  chain_height: "Chain height",
+  signer_liquidity: "Signer liquidity",
+};
+
+export function probeLabel(name: string): string {
+  return PROBE_LABELS[name] ?? name.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+}
+
+/** Map a probe status onto the board's --hm-state-* token family. */
+export function probeTone(status: ProbeStatus): "pass" | "degraded" | "fail" {
+  return status === "ok" ? "pass" : status === "red" ? "fail" : "degraded";
+}
+
+/**
+ * A NEWLY-red probe versus the previous poll — drives the lane auto-flip so a
+ * fresh incident surfaces itself. Pure: a probe already red last time doesn't
+ * re-trigger; only a probe that just crossed into red does.
+ */
+export function hasFreshRed(prev: ProductHealth | undefined, next: ProductHealth): boolean {
+  if (next.status !== "red") return false;
+  const prevRed = new Set((prev?.probes ?? []).filter((p) => p.status === "red").map((p) => p.name));
+  return next.probes.some((p) => p.status === "red" && !prevRed.has(p.name));
+}
+
+export type OverallTone = "healthy" | "degraded" | "red" | "off" | "idle";
+
+/** The Monitoring lane's headline. Truth-boundary aware: off vs no-data-yet vs real state. */
+export function overallSummary(h: ProductHealth): { label: string; tone: OverallTone } {
+  if (!h.enabled) return { label: "monitoring off", tone: "off" };
+  if (h.checks === 0) return { label: "awaiting first check", tone: "idle" };
+  if (h.status === "red") {
+    const n = h.probes.filter((p) => p.status === "red").length;
+    return { label: `${n} probe${n === 1 ? "" : "s"} red`, tone: "red" };
+  }
+  if (h.status === "degraded") return { label: "degraded · safe", tone: "degraded" };
+  return { label: "all healthy", tone: "healthy" };
+}
+
+/** Overall tone → the --hm-state-* family (pass/degraded/fail) or a muted neutral. */
+export function overallToneClass(tone: OverallTone): "pass" | "degraded" | "fail" | "muted" {
+  if (tone === "healthy") return "pass";
+  if (tone === "red") return "fail";
+  if (tone === "degraded") return "degraded";
+  return "muted";
+}

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -3938,3 +3938,93 @@ button.hm-turn-pin {
   align-items: center;
   gap: 6px;
 }
+
+/* ── Product-health Monitoring lane (PR2) ─────────────────────────── */
+
+/* Delivery ⇆ Monitoring toggle in the Done lane head */
+.hm-lane-switch {
+  display: inline-flex;
+  gap: 2px;
+  padding: 2px;
+  background: var(--hm-paper-3);
+  border: 1px solid var(--hm-line);
+  border-radius: 999px;
+}
+.hm-lane-switch-opt {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font: inherit;
+  font-size: 11px;
+  color: var(--hm-muted);
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  padding: 4px 11px;
+  cursor: pointer;
+}
+.hm-lane-switch-opt:hover { color: var(--hm-ink); }
+.hm-lane-switch-opt.is-on { color: var(--hm-paper); background: var(--hm-ink); }
+
+/* Status dot + pill (shared) */
+.hm-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; }
+.hm-dot--pass { background: var(--hm-state-pass); }
+.hm-dot--degraded { background: var(--hm-state-degraded); }
+.hm-dot--fail { background: var(--hm-state-fail); }
+.hm-dot--muted { background: var(--hm-muted-soft); }
+.hm-pill { font-size: 10.5px; font-weight: 500; padding: 2px 8px; border-radius: 999px; white-space: nowrap; }
+.hm-pill--pass { background: var(--hm-state-pass-bg); color: var(--hm-state-pass); }
+.hm-pill--degraded { background: var(--hm-state-degraded-bg); color: var(--hm-state-degraded); }
+.hm-pill--fail { background: var(--hm-state-fail-bg); color: var(--hm-state-fail); }
+.hm-pill--muted { background: var(--hm-paper-3); color: var(--hm-muted); }
+
+/* Monitoring surface — extensible section stack that fills the switched lane */
+.hm-mon-surface { display: flex; flex-direction: column; gap: 12px; }
+.hm-mon-section { display: flex; flex-direction: column; gap: 9px; }
+.hm-mon-section-head { display: flex; align-items: center; justify-content: space-between; }
+.hm-mon-section-title { font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--hm-muted-soft); }
+.hm-mon-probes { display: flex; flex-direction: column; gap: 9px; }
+
+/* One probe card */
+.hm-probe { background: var(--hm-paper-2); border: 1px solid var(--hm-line); border-radius: 11px; padding: 11px 12px; }
+.hm-probe--fail { border-color: var(--hm-state-fail); background: var(--hm-state-fail-bg); }
+.hm-probe-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.hm-probe-name { display: inline-flex; align-items: center; gap: 8px; font-size: 13.5px; color: var(--hm-ink-soft); }
+.hm-probe--fail .hm-probe-name { color: var(--hm-ink); font-weight: 500; }
+.hm-probe-detail {
+  font-size: 11.5px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--hm-muted);
+  margin-top: 7px;
+  overflow-wrap: anywhere;
+}
+.hm-probe--fail .hm-probe-detail { color: var(--hm-state-fail); }
+
+/* Uptime sparkline */
+.hm-spark { display: flex; gap: 2px; align-items: flex-end; }
+.hm-spark-cell { flex: 1 1 0; min-width: 3px; height: 16px; border-radius: 1.5px; opacity: 0.9; }
+.hm-spark-cell--pass { background: var(--hm-state-pass); }
+.hm-spark-cell--degraded { background: var(--hm-state-degraded); }
+.hm-spark-cell--fail { background: var(--hm-state-fail); }
+.hm-spark-cell--empty { background: var(--hm-line); opacity: 0.5; }
+
+/* Empty / off states + honest headroom */
+.hm-mon-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 12px;
+  text-align: center;
+  border: 1px dashed var(--hm-line);
+  border-radius: 11px;
+}
+.hm-mon-empty-title { font-size: 13px; color: var(--hm-ink-soft); }
+.hm-mon-empty-detail { font-size: 11.5px; color: var(--hm-muted); }
+.hm-mon-headroom {
+  font-size: 11px;
+  color: var(--hm-muted-soft);
+  text-align: center;
+  padding: 10px 8px;
+  border-top: 1px solid var(--hm-line);
+  margin: 0;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -156,10 +156,13 @@ import {
 import { narrateRouterProposal } from "./monitor-router-narration.js";
 import { runFailureAnalysisOnce } from "./failure-analysis-routine.js";
 import {
+  appendHistory,
   buildProductHealthProbes,
   initialProductHealthAlertState,
   loadProductHealthConfig,
+  probeSparkline,
   runProductHealthOnce,
+  type ProductHealthSnapshot,
 } from "./product-health.js";
 import {
   readFreshCardFailureAnalysis,
@@ -248,6 +251,10 @@ const authConfig = {
   allowedUserIds: parseCsvSet(optionalEnv("SLACK_ALLOWED_USER_IDS")),
 };
 const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedChannelIds);
+// Product-health heartbeat — in-memory rolling history (feeds /monitor/product-health).
+// Resets on restart; a monitoring sparkline doesn't need durability.
+const PRODUCT_HEALTH_HISTORY_MAX = 60;
+let productHealthHistory: ProductHealthSnapshot[] = [];
 const monitorConfig = parseMonitorConfig(process.env);
 const missionSpawnRoles = parseMissionSpawnRoles(process.env);
 // The Vite-built redesigned monitor SPA, served as the default board at
@@ -661,6 +668,33 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       return;
     }
     writeJson(response, 200, await loadCodexTaskQueueSummary());
+    return;
+  }
+  if (request.method === "GET" && url.pathname === "/monitor/product-health") {
+    if (!monitorConfig.enabled) {
+      writeJson(response, 404, { error: "monitor_disabled" });
+      return;
+    }
+    if (!isMonitorAuthorized(monitorConfig, request.headers, url)) {
+      writeJson(response, 401, { error: "monitor_unauthorized" });
+      return;
+    }
+    const last = productHealthHistory[productHealthHistory.length - 1];
+    writeJson(response, 200, {
+      // `enabled:false` is the honest "monitoring is off" signal — distinct from
+      // "enabled but no checks yet" (checks:0). The UI must not imply health data
+      // exists when the routine isn't running.
+      enabled: routineConfig.productHealth.enabled,
+      at: last?.at ?? null,
+      status: last?.status ?? "unknown",
+      checks: productHealthHistory.length,
+      probes: (last?.probes ?? []).map((p) => ({
+        name: p.name,
+        status: p.status,
+        detail: p.detail,
+        sparkline: probeSparkline(productHealthHistory, p.name, 30),
+      })),
+    });
     return;
   }
   if (request.method === "GET" && url.pathname === "/monitor/decision-records") {
@@ -3370,6 +3404,11 @@ function startOperatorRoutines() {
         },
         cooldownMs: routineConfig.productHealth.cooldownMs,
       });
+      productHealthHistory = appendHistory(
+        productHealthHistory,
+        { at: Date.now(), status: result.status, probes: result.evaluation.probes },
+        PRODUCT_HEALTH_HISTORY_MAX,
+      );
       if (result.status !== "healthy") {
         logger.warn(
           { status: result.status, alerted: result.alerted, probes: result.evaluation.probes },

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -49,6 +49,39 @@ export function redProbeKey(evaluation: ProductHealthEvaluation): string {
   return evaluation.redProbes.map((p) => p.name).sort().join(",");
 }
 
+// ── Rolling history (feeds the board's per-probe uptime sparkline) ──
+
+export interface ProductHealthSnapshot {
+  /** Epoch ms of the check. */
+  at: number;
+  status: ProductHealthStatus;
+  probes: ProbeResult[];
+}
+
+/** Append a snapshot to a bounded rolling history (oldest→newest). Pure. */
+export function appendHistory(
+  history: ReadonlyArray<ProductHealthSnapshot>,
+  snapshot: ProductHealthSnapshot,
+  maxLen: number,
+): ProductHealthSnapshot[] {
+  const next = [...history, snapshot];
+  return maxLen > 0 && next.length > maxLen ? next.slice(next.length - maxLen) : next;
+}
+
+/** The last `bins` statuses for one probe (oldest→newest), for a sparkline. Pure. */
+export function probeSparkline(
+  history: ReadonlyArray<ProductHealthSnapshot>,
+  probeName: string,
+  bins: number,
+): ProbeStatus[] {
+  const series: ProbeStatus[] = [];
+  for (const snap of history) {
+    const hit = snap.probes.find((p) => p.name === probeName);
+    if (hit) series.push(hit.status);
+  }
+  return bins > 0 && series.length > bins ? series.slice(series.length - bins) : series;
+}
+
 // ── Config (env-driven; chain/liquidity stay degraded until their keys are set) ──
 
 export interface ProductHealthConfig {

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -10,9 +10,13 @@ import {
   runProductHealthOnce,
   initialProductHealthAlertState,
   loadProductHealthConfig,
+  appendHistory,
+  probeSparkline,
   type ProbeResult,
   type ProductHealthAlertState,
   type ProductHealthDeps,
+  type ProductHealthSnapshot,
+  type ProductHealthStatus,
 } from "../../services/slack-operator/src/product-health.js";
 import type { AlertPayload } from "../../services/slack-operator/src/alert-bridge.js";
 
@@ -261,5 +265,50 @@ describe("loadProductHealthConfig", () => {
     expect(c.rpcUrl).toBe("http://rpc");
     expect(c.minUsdc).toBe(5);
     expect(c.minGasNative).toBe(0.1);
+  });
+});
+
+describe("appendHistory", () => {
+  const snap = (at: number, status: ProductHealthStatus): ProductHealthSnapshot => ({
+    at,
+    status,
+    probes: [probe("product_api", status === "healthy" ? "ok" : status === "red" ? "red" : "degraded")],
+  });
+
+  it("appends newest-last", () => {
+    const h = appendHistory([snap(1, "healthy")], snap(2, "red"), 10);
+    expect(h.map((s) => s.at)).toEqual([1, 2]);
+  });
+
+  it("bounds to maxLen, dropping the oldest", () => {
+    let h: ProductHealthSnapshot[] = [];
+    for (let i = 1; i <= 5; i++) h = appendHistory(h, snap(i, "healthy"), 3);
+    expect(h.map((s) => s.at)).toEqual([3, 4, 5]);
+  });
+
+  it("maxLen <= 0 keeps everything (unbounded)", () => {
+    expect(appendHistory([snap(1, "healthy")], snap(2, "healthy"), 0)).toHaveLength(2);
+  });
+});
+
+describe("probeSparkline", () => {
+  const history: ProductHealthSnapshot[] = [
+    { at: 1, status: "healthy", probes: [probe("api", "ok")] },
+    { at: 2, status: "red", probes: [probe("api", "red")] },
+    { at: 3, status: "degraded", probes: [probe("api", "degraded")] },
+  ];
+
+  it("returns the last N statuses, oldest to newest", () => {
+    expect(probeSparkline(history, "api", 10)).toEqual(["ok", "red", "degraded"]);
+    expect(probeSparkline(history, "api", 2)).toEqual(["red", "degraded"]);
+  });
+
+  it("skips checks where the probe is absent", () => {
+    const h: ProductHealthSnapshot[] = [...history, { at: 4, status: "healthy", probes: [probe("other", "ok")] }];
+    expect(probeSparkline(h, "api", 10)).toEqual(["ok", "red", "degraded"]);
+  });
+
+  it("returns empty for an unknown probe", () => {
+    expect(probeSparkline(history, "nope", 10)).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Stacked on #493. The right board lane (delivery / release history) becomes **completely switchable** — `Delivery ⇆ Monitoring` — giving live-product monitoring a **full column** instead of a cramped widget, and architected so future monitoring sections stack in.

## The lane

- **Toggle** at the lane head (`Delivery ⇆ Monitoring`), persisted.
- **Monitoring** = one card per product-health probe: status pill + a **24-check uptime sparkline** (green ok / grey degraded / coral red) + the live detail, an overall headline, and honest **headroom** for future sections.
- **Health dot** on the Monitoring toggle so a red probe shows from the Delivery view, and the lane **auto-flips to Monitoring on a fresh red** (once per incident) — a real problem surfaces itself.

## Truth-boundary, carried into the UI

- unconfigured / unreachable probe → grey `degraded` (the board's own "offline / no urgency" colour), **never a fake green**
- `monitoring off` and `awaiting first check` are distinct honest empty states — the lane never implies health data that isn't there.

## Architecture (built for what's next)

- `useProductHealth` polls `/monitor/product-health`, degraded-safe (a failed fetch keeps the last snapshot).
- `MonitoringSurface` **composes sections** — product-health is the first; uptime %, liquidity trend, money-path KPIs, an incident log drop in as their own components below with no rework.
- Wired through `Board`'s existing `renderLaneHeader` / `renderLaneBody` slots — **no kanban surgery**. Styled entirely on the board's `--hm-state-*` tokens, so it **theme-adapts** (dark today).

## Backend (this branch, earlier commit)

Rolling history + per-probe sparkline + `GET /monitor/product-health` — `{ enabled, at, status, checks, probes:[{name,status,detail,sparkline}] }`.

## Verified

- **44/44** monitor-ui tests (13 new: lib helpers incl. the auto-flip `hasFreshRed`, the surface / toggle / sparkline components) — and the **31 BoardView tests still pass** (regression-clean).
- `tsc` **0 errors** across monitor-ui; backend 32 tests, no new type errors. CI does the authoritative Docker/SPA build.
- Design approved via two mockups (light base + the dark switchable lane).

## Scope

Product monitoring is opt-in (`PRODUCT_HEALTH_ENABLED`); the lane shows honest empty states until it's on. No deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
