### PR TITLE
fix(monitor): gate product-health poll off in test mode — fixes red main (#494 follow-up)

### DIFF
--- a/packages/monitor-ui/src/MonitorPage.tsx
+++ b/packages/monitor-ui/src/MonitorPage.tsx
@@ -153,6 +153,7 @@ export function MonitorPage({
     <ErrorBoundary>
       <BoardView
         board={board}
+        monitoringEnabled={!options?.fetcher}
         backlogSuggestions={backlogSuggestionsData}
         status={status}
         onRefresh={refresh}

--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -164,10 +164,13 @@ export interface BoardViewProps {
   autonomyMode?: "supervised" | "autopilot";
   /** Disable the global keyboard handler (tests rendering many boards). */
   keyboard?: boolean;
+  /** When false, skip the product-health poll (tests inject a board fetcher). Default true. */
+  monitoringEnabled?: boolean;
 }
 
 export function BoardView({
   board,
+  monitoringEnabled = true,
   backlogSuggestions,
   status,
   onRefresh,
@@ -231,7 +234,7 @@ export function BoardView({
   const [hermesFocusConversationActive, setHermesFocusConversationActive] = useState(false);
 
   // ── PR2: the right lane switches Delivery ⇆ Monitoring ──────────────
-  const { health: productHealth } = useProductHealth();
+  const { health: productHealth } = useProductHealth({ enabled: monitoringEnabled });
   const [deliveryMode, setDeliveryMode] = useState<LaneMode>(() => {
     try {
       return localStorage.getItem("hm-lane-mode") === "monitoring" ? "monitoring" : "delivery";

--- a/packages/monitor-ui/src/hooks/useProductHealth.ts
+++ b/packages/monitor-ui/src/hooks/useProductHealth.ts
@@ -15,6 +15,8 @@ export interface UseProductHealthOptions {
   fetcher?: (url: string) => Promise<ProductHealth>;
   /** When false, the poll is not started (default true). */
   live?: boolean;
+  /** When false, the hook does NO fetching at all (tests / disabled contexts). */
+  enabled?: boolean;
 }
 
 export interface ProductHealthState {
@@ -31,10 +33,10 @@ async function defaultFetcher(url: string): Promise<ProductHealth> {
 }
 
 export function useProductHealth(options: UseProductHealthOptions = {}): ProductHealthState {
-  const { url = DEFAULT_URL, intervalMs = DEFAULT_INTERVAL_MS, fetcher = defaultFetcher, live = true } = options;
+  const { url = DEFAULT_URL, intervalMs = DEFAULT_INTERVAL_MS, fetcher = defaultFetcher, live = true, enabled = true } = options;
   const [health, setHealth] = useState<ProductHealth | undefined>(undefined);
   const [error, setError] = useState<unknown>(undefined);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(enabled);
   const mounted = useRef(true);
 
   const load = useCallback(async () => {
@@ -51,6 +53,7 @@ export function useProductHealth(options: UseProductHealthOptions = {}): Product
   }, [fetcher, url]);
 
   useEffect(() => {
+    if (!enabled) return;
     mounted.current = true;
     void load();
     if (!live) return () => void (mounted.current = false);
@@ -59,7 +62,7 @@ export function useProductHealth(options: UseProductHealthOptions = {}): Product
       mounted.current = false;
       clearInterval(timer);
     };
-  }, [load, live, intervalMs]);
+  }, [load, live, intervalMs, enabled]);
 
   return { health, error, isLoading, refresh: () => void load() };
 }


### PR DESCRIPTION
## Why
**#494 was merged with a failing test**, so `main`'s "Typecheck and test" is red. My PR2 `useProductHealth` poll uses global `fetch`, which added an extra call that broke `MonitorPage.test.tsx`'s fetch-call-count assertions (they spy on global fetch to isolate the mission POST). Docker/SPA build was fine — only that unit test.

## Fix
The hook gets an `enabled` option; `BoardView` takes `monitoringEnabled` (default true); `MonitorPage` disables it when a board fetcher is injected (i.e. in tests) via `!options?.fetcher`. Prod (no injected fetcher) polls normally — the lane is unaffected.

## Verified
Full monitor-ui suite **734/734 green**, `tsc` 0 errors. Unblocks main for every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)