### PR TITLE
feat(monitor): resolve product-health chain config from the network (Option B)

### DIFF
--- a/packages/mcp-common/src/auth.ts
+++ b/packages/mcp-common/src/auth.ts
@@ -1,6 +1,16 @@
 import { privateKeyToAccount } from "viem/accounts";
 import { optionalEnv, requiredEnv } from "./config.js";
 
+/**
+ * Derive the H160 address for a private key. Read-only — the key never leaves
+ * memory. Lets the product-health monitor watch the agent signer's balance
+ * without maintaining a duplicate address in config.
+ */
+export function addressFromPrivateKey(privateKey: string): string {
+  const pk = (privateKey.startsWith("0x") ? privateKey : `0x${privateKey}`) as `0x${string}`;
+  return privateKeyToAccount(pk).address;
+}
+
 export interface AuthSession {
   wallet: string;
   token: string;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3,7 +3,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFile } from "node:fs/promises";
-import { logger, optionalEnv, query } from "@avg/mcp-common";
+import { addressFromPrivateKey, logger, optionalEnv, query } from "@avg/mcp-common";
 import { createDefaultWorkflowDeps } from "@avg/averray-mcp/default-workflow-runtime";
 import { invokeAgentTask } from "@avg/averray-mcp/agent-invocation";
 import { getHandoffMonitor, recordHandoffEvent } from "@avg/averray-mcp/handoff-events";
@@ -255,6 +255,19 @@ const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedCha
 // Resets on restart; a monitoring sparkline doesn't need durability.
 const PRODUCT_HEALTH_HISTORY_MAX = 60;
 let productHealthHistory: ProductHealthSnapshot[] = [];
+
+/** The settlement signer's address, derived from the key the monitor already holds
+ *  (AGENT_WALLET_PRIVATE_KEY) so signer_liquidity needs no duplicated config. A
+ *  missing / all-zero placeholder key → undefined (the probe stays degraded). */
+function deriveProductHealthSigner(): string | undefined {
+  const pk = process.env.AGENT_WALLET_PRIVATE_KEY?.trim();
+  if (!pk || /^0x0+$/i.test(pk)) return undefined;
+  try {
+    return addressFromPrivateKey(pk);
+  } catch {
+    return undefined;
+  }
+}
 const monitorConfig = parseMonitorConfig(process.env);
 const missionSpawnRoles = parseMissionSpawnRoles(process.env);
 // The Vite-built redesigned monitor SPA, served as the default board at
@@ -3390,7 +3403,11 @@ function startOperatorRoutines() {
     if (productHealthRunning || !routineConfig.productHealth.enabled) return;
     productHealthRunning = true;
     try {
-      const probeFns = buildProductHealthProbes(loadProductHealthConfig());
+      const phConfig = loadProductHealthConfig();
+      // Derive the settlement signer from AGENT_WALLET_PRIVATE_KEY (already held) so
+      // signer_liquidity watches the real wallet with zero duplicated config.
+      const signerAddress = phConfig.signerAddress ?? deriveProductHealthSigner();
+      const probeFns = buildProductHealthProbes({ ...phConfig, signerAddress });
       const result = await runProductHealthOnce({
         runProbes: () => Promise.all(probeFns.map((p) => p())),
         alert: (payload) => alertChannel.dispatch(payload),

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -106,12 +106,26 @@ function trimTrailingSlash(s: string): string {
   return s.replace(/\/+$/, "");
 }
 
+// Public Hub eth-rpc per network — so the monitor watches the SAME chain the
+// product settles on, with zero duplicated config. `WALLET_NETWORK` (the signal
+// the chain services already use) selects it; PRODUCT_HEALTH_RPC_URL overrides.
+// Mainnet is intentionally absent until Codex confirms its endpoint — set
+// PRODUCT_HEALTH_RPC_URL there. Testnet URL verified via docs.polkadot.com.
+const NETWORK_ETH_RPC: Record<string, string> = {
+  testnet: "https://testnet-passet-hub-eth-rpc.polkadot.io/",
+};
+
+/** Resolve the eth-rpc for the product's network (WALLET_NETWORK); testnet default. */
+export function networkEthRpc(walletNetwork: string | undefined): string | undefined {
+  return NETWORK_ETH_RPC[(walletNetwork || "testnet").toLowerCase()];
+}
+
 export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): ProductHealthConfig {
   const base = env.AVERRAY_API_BASE_URL;
   return {
     apiBaseUrl: base ? trimTrailingSlash(base) : undefined,
     apiHealthPath: env.PRODUCT_HEALTH_API_PATH || "/health",
-    rpcUrl: env.PRODUCT_HEALTH_RPC_URL || undefined,
+    rpcUrl: env.PRODUCT_HEALTH_RPC_URL || networkEthRpc(env.WALLET_NETWORK),
     signerAddress: env.PRODUCT_HEALTH_SIGNER_ADDRESS || undefined,
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -10,6 +10,7 @@ import {
   runProductHealthOnce,
   initialProductHealthAlertState,
   loadProductHealthConfig,
+  networkEthRpc,
   appendHistory,
   probeSparkline,
   type ProbeResult,
@@ -242,19 +243,27 @@ describe("runProductHealthOnce", () => {
   });
 });
 
+const TESTNET_RPC = "https://testnet-passet-hub-eth-rpc.polkadot.io/";
+
 describe("loadProductHealthConfig", () => {
-  it("is degraded-safe by default: API base optional, chain/liquidity unset", () => {
+  it("defaults the RPC to the network endpoint (Option B); signer/USDC resolve elsewhere", () => {
     const c = loadProductHealthConfig({});
     expect(c.apiBaseUrl).toBeUndefined();
-    expect(c.rpcUrl).toBeUndefined();
-    expect(c.signerAddress).toBeUndefined();
+    expect(c.rpcUrl).toBe(TESTNET_RPC); // WALLET_NETWORK absent → testnet
+    expect(c.signerAddress).toBeUndefined(); // derived in the wiring from AGENT_WALLET_PRIVATE_KEY, not here
+    expect(c.usdcAddress).toBeUndefined();
     expect(c.apiHealthPath).toBe("/health");
     expect(c.usdcDecimals).toBe(6);
     expect(c.minGasNative).toBe(0);
     expect(c.minUsdc).toBe(0);
   });
 
-  it("reads env overrides and trims the API base", () => {
+  it("selects the RPC by WALLET_NETWORK, leaving mainnet unset until confirmed", () => {
+    expect(loadProductHealthConfig({ WALLET_NETWORK: "testnet" }).rpcUrl).toBe(TESTNET_RPC);
+    expect(loadProductHealthConfig({ WALLET_NETWORK: "mainnet" }).rpcUrl).toBeUndefined();
+  });
+
+  it("reads env overrides; an explicit RPC wins over the network map", () => {
     const c = loadProductHealthConfig({
       AVERRAY_API_BASE_URL: "https://api.x/",
       PRODUCT_HEALTH_RPC_URL: "http://rpc",
@@ -265,6 +274,16 @@ describe("loadProductHealthConfig", () => {
     expect(c.rpcUrl).toBe("http://rpc");
     expect(c.minUsdc).toBe(5);
     expect(c.minGasNative).toBe(0.1);
+  });
+});
+
+describe("networkEthRpc", () => {
+  it("resolves testnet (default + case-insensitive), leaves mainnet/unknown unset", () => {
+    expect(networkEthRpc(undefined)).toBe(TESTNET_RPC);
+    expect(networkEthRpc("testnet")).toBe(TESTNET_RPC);
+    expect(networkEthRpc("TestNet")).toBe(TESTNET_RPC);
+    expect(networkEthRpc("mainnet")).toBeUndefined();
+    expect(networkEthRpc("weird")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What
The chain probes stop needing hand-maintained `PRODUCT_HEALTH_*` config — they derive it from what the product **already** uses:
- **RPC** from `WALLET_NETWORK` via a network map (testnet = the public Passet Hub eth-rpc, verified via docs.polkadot.com). `PRODUCT_HEALTH_RPC_URL` still overrides; mainnet is intentionally unset until Codex confirms its endpoint.
- **Signer address** derived from `AGENT_WALLET_PRIVATE_KEY` (already in the monitor's env) via a new read-only `mcp-common` `addressFromPrivateKey` helper.

So on the next deploy, **`chain_height` and the gas half of `signer_liquidity` go green with zero new config.**

## The one remaining value
`signer_liquidity`'s **USDC** half stays grey until `PRODUCT_HEALTH_USDC_ADDRESS` is set — that's the product's canonical USDC on Passet Hub, which is **Codex-owned chain config**. Flagged for Codex to hand over; I didn't guess it (a monitor watching the wrong token would quietly lie).

## Verified
- 34 product-health tests green, incl. network-map resolution (testnet default, mainnet unset, explicit override wins).
- Address derivation checked against the `key=1` viem vector (`0x7E5F…Bdf`).
- CI does the authoritative full build (the new `@avg/mcp-common` helper resolves on a fresh build; my local symlink pins the stale one).

## Truth-boundary
Deriving from `WALLET_NETWORK` means the monitor watches the **same chain the product settles on**, and mainnet fails safe to degraded rather than silently hitting the testnet RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)