### PR TITLE
fix(product-health): detect a chain halt (chain_height freshness)

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -88,6 +88,13 @@ export interface ProductHealthConfig {
   apiBaseUrl?: string;
   apiHealthPath: string;
   rpcUrl?: string;
+  /**
+   * chain_height goes RED if the latest block is older than this many seconds —
+   * a chain halt (blocks frozen) is a real settlement-down condition, not an RPC
+   * hiccup. 0 disables the freshness check (height-only, the pre-halt-detect
+   * behaviour). Env: PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS (default 600).
+   */
+  chainMaxStaleSeconds: number;
   signerAddress?: string;
   usdcAddress?: string;
   usdcDecimals: number;
@@ -126,6 +133,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     apiBaseUrl: base ? trimTrailingSlash(base) : undefined,
     apiHealthPath: env.PRODUCT_HEALTH_API_PATH || "/health",
     rpcUrl: env.PRODUCT_HEALTH_RPC_URL || networkEthRpc(env.WALLET_NETWORK),
+    chainMaxStaleSeconds: num(env.PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS, 600),
     signerAddress: env.PRODUCT_HEALTH_SIGNER_ADDRESS || undefined,
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
@@ -164,13 +172,13 @@ export async function probeProductApi(input: {
   }
 }
 
-/** Minimal eth JSON-RPC call over the injected fetch. Throws on transport/RPC error. */
-async function ethRpc(
+/** Minimal eth JSON-RPC call; returns the raw `result` (may be a string or object). */
+async function ethRpcRaw(
   rpcUrl: string,
   method: string,
   params: unknown[],
   fetchImpl: typeof fetch,
-): Promise<string> {
+): Promise<unknown> {
   const res = await fetchImpl(rpcUrl, {
     method: "POST",
     headers: { "content-type": "application/json" },
@@ -179,20 +187,63 @@ async function ethRpc(
   if (!res.ok) throw new Error(`${method} → HTTP ${res.status}`);
   const json = (await res.json()) as { result?: unknown; error?: { message?: string } };
   if (json.error) throw new Error(`${method}: ${json.error.message ?? "rpc error"}`);
-  if (typeof json.result !== "string") throw new Error(`${method}: missing result`);
+  if (json.result === undefined || json.result === null) throw new Error(`${method}: missing result`);
   return json.result;
 }
 
-/** Chain reachable + producing blocks. RPC hiccup → degraded (not a product-down page). */
-export async function probeChainHeight(input: { rpcUrl?: string; fetchImpl: typeof fetch }): Promise<ProbeResult> {
+/** eth JSON-RPC call whose result is a hex string (eth_call, eth_getBalance, …). */
+async function ethRpc(
+  rpcUrl: string,
+  method: string,
+  params: unknown[],
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const result = await ethRpcRaw(rpcUrl, method, params, fetchImpl);
+  if (typeof result !== "string") throw new Error(`${method}: expected a string result`);
+  return result;
+}
+
+/**
+ * Chain reachable + producing FRESH blocks. Reads the latest block for both its
+ * height and its timestamp: a halted chain (frozen block) still answers RPC, so a
+ * height-only check stays green straight through a settlement-stopping halt. If the
+ * latest block is older than `maxStaleSeconds`, that's RED (real product-down).
+ * An RPC hiccup → degraded (not a product-down page).
+ */
+export async function probeChainHeight(input: {
+  rpcUrl?: string;
+  maxStaleSeconds?: number;
+  fetchImpl: typeof fetch;
+  now?: () => number;
+}): Promise<ProbeResult> {
   if (!input.rpcUrl) {
     return { name: "chain_height", status: "degraded", detail: "PRODUCT_HEALTH_RPC_URL not configured" };
   }
   try {
-    const height = BigInt(await ethRpc(input.rpcUrl, "eth_blockNumber", [], input.fetchImpl));
-    return height > 0n
-      ? { name: "chain_height", status: "ok", detail: `block #${height.toString()}` }
-      : { name: "chain_height", status: "red", detail: "chain reports block 0" };
+    const block = (await ethRpcRaw(input.rpcUrl, "eth_getBlockByNumber", ["latest", false], input.fetchImpl)) as
+      | { number?: string; timestamp?: string }
+      | null;
+    if (!block || typeof block.number !== "string") {
+      return { name: "chain_height", status: "degraded", detail: "chain returned no latest block" };
+    }
+    const height = BigInt(block.number);
+    if (height <= 0n) {
+      return { name: "chain_height", status: "red", detail: "chain reports block 0" };
+    }
+    const maxStale = input.maxStaleSeconds ?? 0;
+    if (maxStale > 0 && typeof block.timestamp === "string") {
+      const nowSec = Math.floor((input.now?.() ?? Date.now()) / 1000);
+      const ageSec = nowSec - Number(BigInt(block.timestamp));
+      if (ageSec > maxStale) {
+        return {
+          name: "chain_height",
+          status: "red",
+          detail: `chain stalled: block #${height.toString()} last advanced ${Math.floor(ageSec / 60)}m ago (> ${Math.floor(maxStale / 60)}m)`,
+        };
+      }
+      return { name: "chain_height", status: "ok", detail: `block #${height.toString()} (${Math.max(0, ageSec)}s ago)` };
+    }
+    return { name: "chain_height", status: "ok", detail: `block #${height.toString()}` };
   } catch (err) {
     return { name: "chain_height", status: "degraded", detail: `RPC unreachable: ${errMsg(err)}` };
   }
@@ -266,7 +317,7 @@ export function buildProductHealthProbes(
 ): Array<() => Promise<ProbeResult>> {
   return [
     () => probeProductApi({ baseUrl: config.apiBaseUrl, healthPath: config.apiHealthPath, fetchImpl }),
-    () => probeChainHeight({ rpcUrl: config.rpcUrl, fetchImpl }),
+    () => probeChainHeight({ rpcUrl: config.rpcUrl, maxStaleSeconds: config.chainMaxStaleSeconds, fetchImpl }),
     () =>
       probeSignerLiquidity({
         rpcUrl: config.rpcUrl,

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -109,20 +109,53 @@ describe("probeChainHeight", () => {
     expect(r.status).toBe("degraded");
   });
 
-  it("ok when the chain reports a positive height", async () => {
-    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: "0x2a" })) });
+  it("ok when the chain reports a positive height (height-only, no freshness threshold)", async () => {
+    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: { number: "0x2a" } })) });
     expect(r.status).toBe("ok");
     expect(r.detail).toContain("42");
   });
 
   it("red when the chain reports block 0", async () => {
-    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: "0x0" })) });
+    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: { number: "0x0" } })) });
     expect(r.status).toBe("red");
   });
 
   it("degraded (not a page) on an RPC hiccup — our dependency, not a product outage", async () => {
     const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ error: "upstream busy" })) });
     expect(r.status).toBe("degraded");
+  });
+
+  // Halt detection — the whole point: a frozen chain still answers RPC.
+  const NOW_MS = 1_783_000_000_000; // fixed clock; NOW_MS/1000 = 1_783_000_000 s
+  const at = (secAgo: number) => "0x" + BigInt(Math.floor(NOW_MS / 1000) - secAgo).toString(16);
+
+  it("red when the latest block is stale beyond the freshness threshold (chain halted)", async () => {
+    const r = await probeChainHeight({
+      rpcUrl: "http://rpc",
+      maxStaleSeconds: 600,
+      now: () => NOW_MS,
+      fetchImpl: mockFetch(() => ({ result: { number: "0x2a", timestamp: at(3600) } })), // 60m old
+    });
+    expect(r.status).toBe("red");
+    expect(r.detail).toContain("stalled");
+    expect(r.detail).toContain("42");
+  });
+
+  it("ok when the latest block is fresh (advancing) under the threshold", async () => {
+    const r = await probeChainHeight({
+      rpcUrl: "http://rpc",
+      maxStaleSeconds: 600,
+      now: () => NOW_MS,
+      fetchImpl: mockFetch(() => ({ result: { number: "0x2a", timestamp: at(12) } })), // 12s old
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("42");
+  });
+
+  it("degraded when the chain returns a block with no number", async () => {
+    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: { hash: "0xabc" } })) });
+    expect(r.status).toBe("degraded");
+    expect(r.detail).toContain("no latest block");
   });
 });
 


### PR DESCRIPTION
## The blind spot
`probeChainHeight` read `eth_blockNumber` and returned **ok** whenever `height > 0`. A halted chain still answers RPC with its last (frozen) block — so the monitor stays **green straight through a settlement-stopping chain halt**.

This isn't hypothetical: **Paseo Asset Hub has been frozen at block 10612201 for ~44h** as I write this (verified live), and the current probe would report `chain_height: ok` the entire time.

## The fix
`probeChainHeight` now reads the **latest block for both its number and its timestamp** (one `eth_getBlockByNumber` call) and goes **RED** if the block is older than `chainMaxStaleSeconds` — a stalled chain is real product-down, not an RPC hiccup.

- **env** `PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS` (default **600**; `0` = old height-only behaviour). Hub blocks are ~6–12s, so 600s is well clear of normal cadence and well under a halt.
- `height == 0` → red (unchanged); RPC error → **degraded** (our dependency, not a product page — unchanged philosophy).
- Refactored the JSON-RPC helper into `ethRpcRaw` (raw result, object or string) + `ethRpc` (string wrapper) so the block object reads cleanly without loosening the string-typed callers (`eth_call` / `eth_getBalance`).

## Tests
Existing `probeChainHeight` cases updated to block objects; new cases for **stale → red**, **fresh → ok**, and **numberless block → degraded** (fetch + clock injected for determinism). `npm run typecheck` + `npm test` cover it in CI.

> Scoped to *only* the halt-detection fix. The separate dead-default-RPC-host fix (`testnet-passet-hub-eth-rpc.polkadot.io` → `eth-rpc-testnet.polkadot.io`) is a follow-up PR, kept separate on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)