### PR TITLE
fix(product-health): point the testnet eth-rpc default at the live host

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -110,9 +110,12 @@ function trimTrailingSlash(s: string): string {
 // product settles on, with zero duplicated config. `WALLET_NETWORK` (the signal
 // the chain services already use) selects it; PRODUCT_HEALTH_RPC_URL overrides.
 // Mainnet is intentionally absent until Codex confirms its endpoint — set
-// PRODUCT_HEALTH_RPC_URL there. Testnet URL verified via docs.polkadot.com.
+// PRODUCT_HEALTH_RPC_URL there. Testnet uses the SAME canonical Hub eth-rpc the
+// product settles on (deployments/testnet.json, all three backend RPC vars, and
+// the indexer), verified live (chainId 420420417, USDC precompile answering).
+// The old `testnet-passet-hub-eth-rpc.polkadot.io` host no longer resolves.
 const NETWORK_ETH_RPC: Record<string, string> = {
-  testnet: "https://testnet-passet-hub-eth-rpc.polkadot.io/",
+  testnet: "https://eth-rpc-testnet.polkadot.io/",
 };
 
 /** Resolve the eth-rpc for the product's network (WALLET_NETWORK); testnet default. */

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -243,7 +243,7 @@ describe("runProductHealthOnce", () => {
   });
 });
 
-const TESTNET_RPC = "https://testnet-passet-hub-eth-rpc.polkadot.io/";
+const TESTNET_RPC = "https://eth-rpc-testnet.polkadot.io/";
 
 describe("loadProductHealthConfig", () => {
   it("defaults the RPC to the network endpoint (Option B); signer/USDC resolve elsewhere", () => {


### PR DESCRIPTION
## The problem
`NETWORK_ETH_RPC.testnet` defaulted to `https://testnet-passet-hub-eth-rpc.polkadot.io/` — **a host that no longer resolves** (`nslookup`: no answer; `curl`: could not resolve host, while `eth-rpc-testnet.polkadot.io` resolves fine from the same box, so it's not a general DNS issue). A monitor deploy **without** a `PRODUCT_HEALTH_RPC_URL` override silently rides a dead endpoint and every chain probe degrades.

## The fix
Point the testnet default at `https://eth-rpc-testnet.polkadot.io/` — the **same canonical Hub eth-rpc the product settles on**: `deployments/testnet.json`, all three backend RPC vars (`deploy/backend.env.template`), and the indexer (`ponder.config.ts`). Verified live: **chainId `0x190f1b41` = 420420417**, USDC precompile answering. Also corrects the stale `verified via docs.polkadot.com` comment (that host is gone).

One-line default + the test's `TESTNET_RPC` constant + a comment. Kept separate from the chain-halt-detection fix (that's its own PR) as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)