### PR TITLE
feat(monitor): hybrid product-health — /health chain + direct-RPC balances

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -157,11 +157,12 @@ import { narrateRouterProposal } from "./monitor-router-narration.js";
 import { runFailureAnalysisOnce } from "./failure-analysis-routine.js";
 import {
   appendHistory,
-  buildProductHealthProbes,
+  collectProductHealthProbes,
   initialProductHealthAlertState,
   loadProductHealthConfig,
   probeSparkline,
   runProductHealthOnce,
+  type ChainAdvance,
   type ProductHealthSnapshot,
 } from "./product-health.js";
 import {
@@ -255,6 +256,8 @@ const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedCha
 // Resets on restart; a monitoring sparkline doesn't need durability.
 const PRODUCT_HEALTH_HISTORY_MAX = 60;
 let productHealthHistory: ProductHealthSnapshot[] = [];
+// Block-advance tracker so a frozen chain (static height) isn't read as green.
+let productHealthChainAdvance: ChainAdvance | undefined;
 
 /** The settlement signer's address, derived from the key the monitor already holds
  *  (AGENT_WALLET_PRIVATE_KEY) so signer_liquidity needs no duplicated config. A
@@ -3404,12 +3407,18 @@ function startOperatorRoutines() {
     productHealthRunning = true;
     try {
       const phConfig = loadProductHealthConfig();
-      // Derive the settlement signer from AGENT_WALLET_PRIVATE_KEY (already held) so
-      // signer_liquidity watches the real wallet with zero duplicated config.
+      // Signer address for the balance probe: PRODUCT_HEALTH_SIGNER_ADDRESS or derived
+      // from AGENT_WALLET_PRIVATE_KEY (already held). Chain height reads /health.
       const signerAddress = phConfig.signerAddress ?? deriveProductHealthSigner();
-      const probeFns = buildProductHealthProbes({ ...phConfig, signerAddress });
+      // One /health fetch feeds product_api + chain_height; the block-advance tracker
+      // persists across ticks to catch a frozen chain. Balances come from direct RPC.
+      const collection = await collectProductHealthProbes({ ...phConfig, signerAddress }, fetch, {
+        advance: productHealthChainAdvance,
+        nowMs: Date.now(),
+      });
+      productHealthChainAdvance = collection.chainAdvance;
       const result = await runProductHealthOnce({
-        runProbes: () => Promise.all(probeFns.map((p) => p())),
+        runProbes: async () => collection.probes,
         alert: (payload) => alertChannel.dispatch(payload),
         boardUrl:
           optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ??

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -6,13 +6,23 @@
 // reuses the D3/D4 plane: pure `evaluateProductHealth` + effect-injected
 // `runProductHealthOnce`, so detection + alerting unit-test with no fs/network.
 //
-// Chain/signer reads are raw JSON-RPC over an injected `fetch` (no viem dep in
-// slack-operator; mockable in tests).
+// Two data sources, deliberately:
+//  • API + chain height come from the product's OWN `GET /health` payload — the
+//    product self-reports block height + blockchain capability + signer status
+//    there, so the monitor always watches the EXACT chain the product runs on
+//    (it reads `auth.chainId`), with no separate endpoint that can drift to the
+//    wrong network. A frozen chain still reports its last block, so a block-advance
+//    tracker turns a static height into a halt signal.
+//  • Signer BALANCES come from a direct eth-RPC (eth_getBalance + erc20 balanceOf)
+//    — `/health` does not expose balances, so this is the only source of real
+//    solvency monitoring. Raw JSON-RPC over the injected `fetch` (no viem dep).
 //
-// TRUTH-BOUNDARY (the whole point): an UNCONFIGURED probe reports `degraded`,
-// never a fake green; a CONFIGURED probe that trips its threshold reports `red`.
-// Only `red` fires an alert. A probe that can't reach its dependency reports
-// `degraded` (our own RPC/network hiccup must not page as a product outage).
+// TRUTH-BOUNDARY (the whole point): an UNCONFIGURED or unreadable probe reports
+// `degraded`, never a fake green; a probe the product self-reports as failing (or a
+// balance below its floor) reports `red`. Only `red` fires an alert. A dependency
+// hiccup (our RPC, the /health fetch) → `degraded`, never a product-down page. A
+// chain HALT is network-conditional: a testnet freeze is `degraded` (no page — a
+// known reset happens), a mainnet halt is `red` (settlement down = page).
 
 import type { AlertPayload } from "./alert-bridge.js";
 
@@ -82,19 +92,20 @@ export function probeSparkline(
   return bins > 0 && series.length > bins ? series.slice(series.length - bins) : series;
 }
 
-// ── Config (env-driven; chain/liquidity stay degraded until their keys are set) ──
+// ── Config (env-driven; balances stay degraded until their RPC/USDC keys are set) ──
 
 export interface ProductHealthConfig {
   apiBaseUrl?: string;
   apiHealthPath: string;
+  /** Direct eth-RPC for the signer-balance probe (PRODUCT_HEALTH_RPC_URL, else the
+   *  per-network default). Chain HEIGHT no longer needs it — that reads /health. */
   rpcUrl?: string;
-  /**
-   * chain_height goes RED if the latest block is older than this many seconds —
-   * a chain halt (blocks frozen) is a real settlement-down condition, not an RPC
-   * hiccup. 0 disables the freshness check (height-only, the pre-halt-detect
-   * behaviour). Env: PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS (default 600).
-   */
+  /** chain_height freshness window (seconds): block height static for longer than
+   *  this ⇒ "not advancing". 0 disables. Env: PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS. */
   chainMaxStaleSeconds: number;
+  /** Halt severity: "auto" (mainnet chainId → red, testnet → degraded) | "red" |
+   *  "degraded". Env: PRODUCT_HEALTH_HALT_SEVERITY. */
+  haltSeverity: string;
   signerAddress?: string;
   usdcAddress?: string;
   usdcDecimals: number;
@@ -113,14 +124,12 @@ function trimTrailingSlash(s: string): string {
   return s.replace(/\/+$/, "");
 }
 
-// Public Hub eth-rpc per network — so the monitor watches the SAME chain the
-// product settles on, with zero duplicated config. `WALLET_NETWORK` (the signal
-// the chain services already use) selects it; PRODUCT_HEALTH_RPC_URL overrides.
-// Mainnet is intentionally absent until Codex confirms its endpoint — set
-// PRODUCT_HEALTH_RPC_URL there. Testnet uses the SAME canonical Hub eth-rpc the
-// product settles on (deployments/testnet.json, all three backend RPC vars, and
-// the indexer), verified live (chainId 420420417, USDC precompile answering).
-// The old `testnet-passet-hub-eth-rpc.polkadot.io` host no longer resolves.
+// Direct eth-rpc per network for the signer-BALANCE probe (chain height reads
+// /health instead). `WALLET_NETWORK` selects it; PRODUCT_HEALTH_RPC_URL overrides.
+// Testnet uses the SAME canonical Hub eth-rpc the product settles on
+// (deployments/testnet.json, all three backend RPC vars, and the indexer),
+// verified live (chainId 420420417, USDC precompile answering). The old
+// `testnet-passet-hub-eth-rpc.polkadot.io` host no longer resolves.
 const NETWORK_ETH_RPC: Record<string, string> = {
   testnet: "https://eth-rpc-testnet.polkadot.io/",
 };
@@ -130,6 +139,16 @@ export function networkEthRpc(walletNetwork: string | undefined): string | undef
   return NETWORK_ETH_RPC[(walletNetwork || "testnet").toLowerCase()];
 }
 
+// A chain HALT pages on mainnet (settlement down) but not on a testnet (resets
+// happen). `auth.chainId` from /health selects; PRODUCT_HEALTH_HALT_SEVERITY overrides.
+const MAINNET_CHAIN_IDS = new Set<number>([420420419]); // Polkadot Hub mainnet (DOT). Testnet 420420417 → degraded.
+
+/** Resolve halt severity: explicit override, else auto by chainId (mainnet → red). */
+export function chainHaltStatus(chainId: number | undefined, override: string | undefined): ProbeStatus {
+  if (override === "red" || override === "degraded") return override;
+  return chainId !== undefined && MAINNET_CHAIN_IDS.has(chainId) ? "red" : "degraded";
+}
+
 export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): ProductHealthConfig {
   const base = env.AVERRAY_API_BASE_URL;
   return {
@@ -137,6 +156,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     apiHealthPath: env.PRODUCT_HEALTH_API_PATH || "/health",
     rpcUrl: env.PRODUCT_HEALTH_RPC_URL || networkEthRpc(env.WALLET_NETWORK),
     chainMaxStaleSeconds: num(env.PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS, 600),
+    haltSeverity: env.PRODUCT_HEALTH_HALT_SEVERITY || "auto",
     signerAddress: env.PRODUCT_HEALTH_SIGNER_ADDRESS || undefined,
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
@@ -145,7 +165,41 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
   };
 }
 
-// ── Probes (each degraded-safe; fetch injected for testability) ──────
+// ── Product /health payload (the product self-reports chain + signer state) ──
+
+/** The slice of the Averray API `/health` payload the monitor reads. All optional
+ *  — the product may omit fields, and every derivation degrades safely if so. */
+export interface ProductHealthPayload {
+  status?: string;
+  auth?: { chainId?: number };
+  serviceHealth?: { ok?: boolean };
+  capabilityHealth?: Record<string, string>;
+  warnings?: Array<{ code?: string; severity?: string; message?: string }>;
+  components?: {
+    blockchain?: {
+      ok?: boolean;
+      enabled?: boolean;
+      blockNumber?: number;
+      signerConfigured?: boolean;
+      arbitratorSignerConfigured?: boolean;
+    };
+  };
+}
+
+export interface ProductHealthFetch {
+  /** AVERRAY_API_BASE_URL was set. */
+  configured: boolean;
+  /** The GET completed (any status). */
+  reachable: boolean;
+  /** Response was 2xx. */
+  httpOk: boolean;
+  status: number;
+  url: string;
+  body?: ProductHealthPayload;
+  error?: string;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
 
 function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -155,25 +209,113 @@ function joinUrl(base: string, path: string): string {
   return `${trimTrailingSlash(base)}/${path.replace(/^\/+/, "")}`;
 }
 
-/** Is the Averray product API answering? REAL as soon as AVERRAY_API_BASE_URL is set. */
-export async function probeProductApi(input: {
+/** Coerce a number|numeric-string to a finite number, else undefined. */
+function pickNum(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function formatInt(n: number): string {
+  return n.toLocaleString("en-US");
+}
+
+function formatDuration(ms: number): string {
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return h < 24 ? `${h}h ${m % 60}m` : `${Math.floor(h / 24)}d ${h % 24}h`;
+}
+
+// ── Chain-advance tracker (a frozen chain still reports its last block) ──
+
+/** Tracks when the chain's block height last advanced, so a frozen chain can be
+ *  told apart from a live one. Pure state transition; the caller persists it. */
+export interface ChainAdvance {
+  lastBlock: number;
+  lastAdvanceAtMs: number;
+}
+
+export function trackChainAdvance(
+  prev: ChainAdvance | undefined,
+  block: number | undefined,
+  nowMs: number,
+): ChainAdvance {
+  if (block === undefined) return prev ?? { lastBlock: -1, lastAdvanceAtMs: nowMs };
+  if (!prev || block > prev.lastBlock) return { lastBlock: block, lastAdvanceAtMs: nowMs };
+  return prev; // block <= lastBlock: no advance — keep the old timestamp so staleness accrues.
+}
+
+// ── /health-derived probes (product_api + chain_height) ─────────────
+
+/** Fetch the product's `/health` once; product_api + chain_height derive from it. */
+export async function fetchProductHealth(input: {
   baseUrl?: string;
   healthPath: string;
   fetchImpl: typeof fetch;
-}): Promise<ProbeResult> {
+}): Promise<ProductHealthFetch> {
   if (!input.baseUrl) {
-    return { name: "product_api", status: "degraded", detail: "AVERRAY_API_BASE_URL not configured" };
+    return { configured: false, reachable: false, httpOk: false, status: 0, url: "" };
   }
   const url = joinUrl(input.baseUrl, input.healthPath);
   try {
     const res = await input.fetchImpl(url, { method: "GET", redirect: "follow" });
-    return res.ok
-      ? { name: "product_api", status: "ok", detail: `${url} → ${res.status}` }
-      : { name: "product_api", status: "red", detail: `${url} → HTTP ${res.status}` };
+    let body: ProductHealthPayload | undefined;
+    try {
+      body = (await res.json()) as ProductHealthPayload;
+    } catch {
+      body = undefined;
+    }
+    return { configured: true, reachable: true, httpOk: res.ok, status: res.status, url, body };
   } catch (err) {
-    return { name: "product_api", status: "red", detail: `${url} unreachable: ${errMsg(err)}` };
+    return { configured: true, reachable: false, httpOk: false, status: 0, url, error: errMsg(err) };
   }
 }
+
+/** Is the Averray product API answering? REAL as soon as AVERRAY_API_BASE_URL is set. */
+export function deriveProductApiProbe(h: ProductHealthFetch): ProbeResult {
+  const name = "product_api";
+  if (!h.configured) return { name, status: "degraded", detail: "AVERRAY_API_BASE_URL not configured" };
+  if (!h.reachable) return { name, status: "red", detail: `${h.url} unreachable: ${h.error ?? "fetch failed"}` };
+  if (!h.httpOk) return { name, status: "red", detail: `${h.url} → HTTP ${h.status}` };
+  if (h.body?.serviceHealth?.ok === false) return { name, status: "red", detail: `${h.url} → service reports unhealthy` };
+  const chainId = h.body?.auth?.chainId;
+  return { name, status: "ok", detail: `${h.url} → ${h.status}${chainId ? ` · chain ${chainId}` : ""}` };
+}
+
+/** Chain reachable + producing blocks, per the product's own /health. Unreadable
+ *  /health → degraded (product_api carries the red; never double-page). A frozen
+ *  height (static past the window) → `haltStatus` (red on mainnet, degraded on a
+ *  testnet freeze), never a green on a stopped chain. */
+export function deriveChainProbe(
+  h: ProductHealthFetch,
+  staleness?: { staticForMs: number; stalenessMs: number; haltStatus: ProbeStatus },
+): ProbeResult {
+  const name = "chain_height";
+  if (!h.configured || !h.reachable || !h.httpOk) {
+    return { name, status: "degraded", detail: "chain status unavailable (product /health not readable)" };
+  }
+  const bc = h.body?.components?.blockchain;
+  if (!bc) return { name, status: "degraded", detail: "product /health did not report a blockchain component" };
+  const chainId = h.body?.auth?.chainId;
+  const tag = chainId ? ` · chain ${chainId}` : "";
+  if (bc.ok === false) return { name, status: "red", detail: `product reports its blockchain component unhealthy${tag}` };
+  const block = pickNum(bc.blockNumber);
+  if (block === undefined) return { name, status: "degraded", detail: `blockchain healthy but no block height reported${tag}` };
+  if (block <= 0) return { name, status: "red", detail: `chain reports block ${block}${tag}` };
+  if (staleness && staleness.stalenessMs > 0 && staleness.staticForMs >= staleness.stalenessMs) {
+    return {
+      name,
+      status: staleness.haltStatus,
+      detail: `chain not advancing — block #${formatInt(block)} static for ${formatDuration(staleness.staticForMs)}${tag}`,
+    };
+  }
+  return { name, status: "ok", detail: `block #${formatInt(block)}${tag}` };
+}
+
+// ── Direct eth-RPC signer-balance probe (the only source of real balances) ──
 
 /** Minimal eth JSON-RPC call; returns the raw `result` (may be a string or object). */
 async function ethRpcRaw(
@@ -204,52 +346,6 @@ async function ethRpc(
   const result = await ethRpcRaw(rpcUrl, method, params, fetchImpl);
   if (typeof result !== "string") throw new Error(`${method}: expected a string result`);
   return result;
-}
-
-/**
- * Chain reachable + producing FRESH blocks. Reads the latest block for both its
- * height and its timestamp: a halted chain (frozen block) still answers RPC, so a
- * height-only check stays green straight through a settlement-stopping halt. If the
- * latest block is older than `maxStaleSeconds`, that's RED (real product-down).
- * An RPC hiccup → degraded (not a product-down page).
- */
-export async function probeChainHeight(input: {
-  rpcUrl?: string;
-  maxStaleSeconds?: number;
-  fetchImpl: typeof fetch;
-  now?: () => number;
-}): Promise<ProbeResult> {
-  if (!input.rpcUrl) {
-    return { name: "chain_height", status: "degraded", detail: "PRODUCT_HEALTH_RPC_URL not configured" };
-  }
-  try {
-    const block = (await ethRpcRaw(input.rpcUrl, "eth_getBlockByNumber", ["latest", false], input.fetchImpl)) as
-      | { number?: string; timestamp?: string }
-      | null;
-    if (!block || typeof block.number !== "string") {
-      return { name: "chain_height", status: "degraded", detail: "chain returned no latest block" };
-    }
-    const height = BigInt(block.number);
-    if (height <= 0n) {
-      return { name: "chain_height", status: "red", detail: "chain reports block 0" };
-    }
-    const maxStale = input.maxStaleSeconds ?? 0;
-    if (maxStale > 0 && typeof block.timestamp === "string") {
-      const nowSec = Math.floor((input.now?.() ?? Date.now()) / 1000);
-      const ageSec = nowSec - Number(BigInt(block.timestamp));
-      if (ageSec > maxStale) {
-        return {
-          name: "chain_height",
-          status: "red",
-          detail: `chain stalled: block #${height.toString()} last advanced ${Math.floor(ageSec / 60)}m ago (> ${Math.floor(maxStale / 60)}m)`,
-        };
-      }
-      return { name: "chain_height", status: "ok", detail: `block #${height.toString()} (${Math.max(0, ageSec)}s ago)` };
-    }
-    return { name: "chain_height", status: "ok", detail: `block #${height.toString()}` };
-  } catch (err) {
-    return { name: "chain_height", status: "degraded", detail: `RPC unreachable: ${errMsg(err)}` };
-  }
 }
 
 // erc20 balanceOf(address) selector.
@@ -313,25 +409,45 @@ export async function probeSignerLiquidity(input: {
   }
 }
 
-/** Build the real probe set from config, all sharing one injected fetch. */
-export function buildProductHealthProbes(
+// ── Collector: one /health fetch (api + chain) + the direct-RPC balance probe ──
+
+export interface ProductHealthCollection {
+  probes: ProbeResult[];
+  /** Updated block-advance tracker — the caller persists it across ticks. */
+  chainAdvance: ChainAdvance;
+}
+
+export async function collectProductHealthProbes(
   config: ProductHealthConfig,
   fetchImpl: typeof fetch = fetch,
-): Array<() => Promise<ProbeResult>> {
-  return [
-    () => probeProductApi({ baseUrl: config.apiBaseUrl, healthPath: config.apiHealthPath, fetchImpl }),
-    () => probeChainHeight({ rpcUrl: config.rpcUrl, maxStaleSeconds: config.chainMaxStaleSeconds, fetchImpl }),
-    () =>
-      probeSignerLiquidity({
-        rpcUrl: config.rpcUrl,
-        signerAddress: config.signerAddress,
-        usdcAddress: config.usdcAddress,
-        usdcDecimals: config.usdcDecimals,
-        minGasNative: config.minGasNative,
-        minUsdc: config.minUsdc,
-        fetchImpl,
-      }),
-  ];
+  chainCtx: { advance?: ChainAdvance; nowMs: number } = { nowMs: 0 },
+): Promise<ProductHealthCollection> {
+  const h = await fetchProductHealth({
+    baseUrl: config.apiBaseUrl,
+    healthPath: config.apiHealthPath,
+    fetchImpl,
+  });
+  const chainId = h.body?.auth?.chainId;
+  const block = pickNum(h.body?.components?.blockchain?.blockNumber);
+  const chainAdvance = trackChainAdvance(chainCtx.advance, block, chainCtx.nowMs);
+  const staleness = {
+    staticForMs: chainCtx.nowMs - chainAdvance.lastAdvanceAtMs,
+    stalenessMs: config.chainMaxStaleSeconds * 1000,
+    haltStatus: chainHaltStatus(chainId, config.haltSeverity),
+  };
+  const signer = await probeSignerLiquidity({
+    rpcUrl: config.rpcUrl,
+    signerAddress: config.signerAddress,
+    usdcAddress: config.usdcAddress,
+    usdcDecimals: config.usdcDecimals,
+    minGasNative: config.minGasNative,
+    minUsdc: config.minUsdc,
+    fetchImpl,
+  });
+  return {
+    probes: [deriveProductApiProbe(h), deriveChainProbe(h, staleness), signer],
+    chainAdvance,
+  };
 }
 
 // ── Alert rendering (reuses the D4 AlertPayload) ────────────────────

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -3,9 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   evaluateProductHealth,
   redProbeKey,
-  probeProductApi,
-  probeChainHeight,
+  fetchProductHealth,
+  deriveProductApiProbe,
+  deriveChainProbe,
+  trackChainAdvance,
+  chainHaltStatus,
   probeSignerLiquidity,
+  collectProductHealthProbes,
   decideProductHealthAlert,
   runProductHealthOnce,
   initialProductHealthAlertState,
@@ -14,6 +18,9 @@ import {
   appendHistory,
   probeSparkline,
   type ProbeResult,
+  type ProductHealthConfig,
+  type ProductHealthFetch,
+  type ProductHealthPayload,
   type ProductHealthAlertState,
   type ProductHealthDeps,
   type ProductHealthSnapshot,
@@ -21,33 +28,7 @@ import {
 } from "../../services/slack-operator/src/product-health.js";
 import type { AlertPayload } from "../../services/slack-operator/src/alert-bridge.js";
 
-// ── mock fetch (typed so the "Typecheck and test" job stays green) ──
-
-interface MockResponse {
-  ok?: boolean;
-  status?: number;
-  result?: string;
-  error?: string;
-}
-type FetchHandler = (url: string, init: RequestInit) => MockResponse;
-
-function mockFetch(handler: FetchHandler): typeof fetch {
-  return (async (url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
-    const r = handler(String(url), init ?? {});
-    const status = r.status ?? 200;
-    return {
-      ok: r.ok ?? (status >= 200 && status < 300),
-      status,
-      json: async () => (r.error ? { error: { message: r.error } } : { result: r.result }),
-    } as unknown as Response;
-  }) as unknown as typeof fetch;
-}
-
-function throwingFetch(): typeof fetch {
-  return (async () => {
-    throw new Error("network down");
-  }) as unknown as typeof fetch;
-}
+// ── mocks (typed so the "Typecheck and test" job stays green) ──
 
 function rpcMethod(init: RequestInit): string {
   try {
@@ -57,7 +38,77 @@ function rpcMethod(init: RequestInit): string {
   }
 }
 
+/** GET /health returns `healthBody`; eth-RPC POSTs return the gas/usdc hex. */
+function combinedFetch(cfg: {
+  healthBody?: unknown;
+  healthStatus?: number;
+  gasHex?: string;
+  usdcHex?: string;
+}): typeof fetch {
+  return (async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const method = init?.method ?? "GET";
+    if (method === "GET") {
+      const status = cfg.healthStatus ?? 200;
+      return { ok: status >= 200 && status < 300, status, json: async () => cfg.healthBody ?? {} } as unknown as Response;
+    }
+    const result = rpcMethod(init ?? {}) === "eth_getBalance" ? cfg.gasHex : cfg.usdcHex;
+    return { ok: true, status: 200, json: async () => ({ result }) } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+/** Signer-balance mock: eth_getBalance → gasHex, else usdcHex. */
+function balances(gasHex: string, usdcHex: string): typeof fetch {
+  return (async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> =>
+    ({ ok: true, status: 200, json: async () => ({ result: rpcMethod(init ?? {}) === "eth_getBalance" ? gasHex : usdcHex }) }) as unknown as Response) as unknown as typeof fetch;
+}
+
+function healthFetch(status: number, body: unknown): typeof fetch {
+  return (async () => ({ ok: status >= 200 && status < 300, status, json: async () => body }) as unknown as Response) as unknown as typeof fetch;
+}
+
+function throwingFetch(): typeof fetch {
+  return (async () => {
+    throw new Error("network down");
+  }) as unknown as typeof fetch;
+}
+
 const probe = (name: string, status: ProbeResult["status"], detail = ""): ProbeResult => ({ name, status, detail });
+
+// A realistic slice of the live Averray /health payload (testnet chainId 420420417).
+const HEALTHY_BODY: ProductHealthPayload = {
+  status: "ok",
+  auth: { chainId: 420420417 },
+  serviceHealth: { ok: true },
+  components: {
+    blockchain: { ok: true, enabled: true, blockNumber: 10612201, signerConfigured: true },
+  },
+};
+
+const fetched = (body: ProductHealthPayload, over: Partial<ProductHealthFetch> = {}): ProductHealthFetch => ({
+  configured: true,
+  reachable: true,
+  httpOk: true,
+  status: 200,
+  url: "https://api.x/health",
+  body,
+  ...over,
+});
+
+const TESTNET_RPC = "https://eth-rpc-testnet.polkadot.io/";
+
+const cfg = (over: Partial<ProductHealthConfig> = {}): ProductHealthConfig => ({
+  apiBaseUrl: "https://api.x",
+  apiHealthPath: "/health",
+  rpcUrl: "http://rpc",
+  chainMaxStaleSeconds: 600,
+  haltSeverity: "auto",
+  signerAddress: "0xabc",
+  usdcAddress: "0xusdc",
+  usdcDecimals: 6,
+  minGasNative: 0,
+  minUsdc: 0,
+  ...over,
+});
 
 describe("evaluateProductHealth", () => {
   it("overall status is the worst probe (red > degraded > ok)", () => {
@@ -81,90 +132,124 @@ describe("redProbeKey", () => {
   });
 });
 
-describe("probeProductApi", () => {
-  it("degraded (never fake green) when the base url is unconfigured", async () => {
-    const r = await probeProductApi({ baseUrl: undefined, healthPath: "/health", fetchImpl: mockFetch(() => ({ status: 200 })) });
-    expect(r.status).toBe("degraded");
+describe("fetchProductHealth", () => {
+  it("configured:false when the base url is unset (never a fake reachable)", async () => {
+    const h = await fetchProductHealth({ baseUrl: undefined, healthPath: "/health", fetchImpl: healthFetch(200, HEALTHY_BODY) });
+    expect(h.configured).toBe(false);
+    expect(h.reachable).toBe(false);
   });
 
-  it("ok on a 2xx", async () => {
-    const r = await probeProductApi({ baseUrl: "https://api.x", healthPath: "/health", fetchImpl: mockFetch(() => ({ status: 200 })) });
-    expect(r.status).toBe("ok");
+  it("parses the JSON body on a 2xx", async () => {
+    const h = await fetchProductHealth({ baseUrl: "https://api.x", healthPath: "/health", fetchImpl: healthFetch(200, HEALTHY_BODY) });
+    expect(h).toMatchObject({ configured: true, reachable: true, httpOk: true, status: 200 });
+    expect(h.body?.components?.blockchain?.blockNumber).toBe(10612201);
   });
 
-  it("red on a non-2xx", async () => {
-    const r = await probeProductApi({ baseUrl: "https://api.x", healthPath: "/health", fetchImpl: mockFetch(() => ({ status: 503 })) });
-    expect(r.status).toBe("red");
+  it("reachable but not httpOk on a non-2xx", async () => {
+    const h = await fetchProductHealth({ baseUrl: "https://api.x", healthPath: "/health", fetchImpl: healthFetch(503, {}) });
+    expect(h).toMatchObject({ reachable: true, httpOk: false, status: 503 });
   });
 
-  it("red when the endpoint is unreachable", async () => {
-    const r = await probeProductApi({ baseUrl: "https://api.x", healthPath: "/health", fetchImpl: throwingFetch() });
-    expect(r.status).toBe("red");
-  });
-});
-
-describe("probeChainHeight", () => {
-  it("degraded when the RPC url is unconfigured", async () => {
-    const r = await probeChainHeight({ rpcUrl: undefined, fetchImpl: mockFetch(() => ({ result: "0x1" })) });
-    expect(r.status).toBe("degraded");
-  });
-
-  it("ok when the chain reports a positive height (height-only, no freshness threshold)", async () => {
-    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: { number: "0x2a" } })) });
-    expect(r.status).toBe("ok");
-    expect(r.detail).toContain("42");
-  });
-
-  it("red when the chain reports block 0", async () => {
-    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: { number: "0x0" } })) });
-    expect(r.status).toBe("red");
-  });
-
-  it("degraded (not a page) on an RPC hiccup — our dependency, not a product outage", async () => {
-    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ error: "upstream busy" })) });
-    expect(r.status).toBe("degraded");
-  });
-
-  // Halt detection — the whole point: a frozen chain still answers RPC.
-  const NOW_MS = 1_783_000_000_000; // fixed clock; NOW_MS/1000 = 1_783_000_000 s
-  const at = (secAgo: number) => "0x" + BigInt(Math.floor(NOW_MS / 1000) - secAgo).toString(16);
-
-  it("red when the latest block is stale beyond the freshness threshold (chain halted)", async () => {
-    const r = await probeChainHeight({
-      rpcUrl: "http://rpc",
-      maxStaleSeconds: 600,
-      now: () => NOW_MS,
-      fetchImpl: mockFetch(() => ({ result: { number: "0x2a", timestamp: at(3600) } })), // 60m old
-    });
-    expect(r.status).toBe("red");
-    expect(r.detail).toContain("stalled");
-    expect(r.detail).toContain("42");
-  });
-
-  it("ok when the latest block is fresh (advancing) under the threshold", async () => {
-    const r = await probeChainHeight({
-      rpcUrl: "http://rpc",
-      maxStaleSeconds: 600,
-      now: () => NOW_MS,
-      fetchImpl: mockFetch(() => ({ result: { number: "0x2a", timestamp: at(12) } })), // 12s old
-    });
-    expect(r.status).toBe("ok");
-    expect(r.detail).toContain("42");
-  });
-
-  it("degraded when the chain returns a block with no number", async () => {
-    const r = await probeChainHeight({ rpcUrl: "http://rpc", fetchImpl: mockFetch(() => ({ result: { hash: "0xabc" } })) });
-    expect(r.status).toBe("degraded");
-    expect(r.detail).toContain("no latest block");
+  it("not reachable (with the error) when the request throws", async () => {
+    const h = await fetchProductHealth({ baseUrl: "https://api.x", healthPath: "/health", fetchImpl: throwingFetch() });
+    expect(h.reachable).toBe(false);
+    expect(h.error).toContain("network down");
   });
 });
 
-describe("probeSignerLiquidity", () => {
+describe("deriveProductApiProbe", () => {
+  it("degraded (never fake green) when unconfigured", () => {
+    expect(deriveProductApiProbe({ configured: false, reachable: false, httpOk: false, status: 0, url: "" }).status).toBe("degraded");
+  });
+
+  it("red when unreachable", () => {
+    const r = deriveProductApiProbe({ configured: true, reachable: false, httpOk: false, status: 0, url: "https://api.x/health", error: "ENOTFOUND" });
+    expect(r.status).toBe("red");
+  });
+
+  it("red on a non-2xx and on a self-reported unhealthy service", () => {
+    expect(deriveProductApiProbe(fetched(HEALTHY_BODY, { httpOk: false, status: 503 })).status).toBe("red");
+    expect(deriveProductApiProbe(fetched({ ...HEALTHY_BODY, serviceHealth: { ok: false } })).status).toBe("red");
+  });
+
+  it("ok on a healthy payload, surfacing the chain id it's watching", () => {
+    const r = deriveProductApiProbe(fetched(HEALTHY_BODY));
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("420420417");
+  });
+});
+
+describe("deriveChainProbe (/health-derived)", () => {
+  it("degraded (not a page) when /health is unreadable — product_api carries the red", () => {
+    expect(deriveChainProbe({ configured: true, reachable: false, httpOk: false, status: 0, url: "u" }).status).toBe("degraded");
+  });
+
+  it("degraded when the payload has no blockchain component", () => {
+    expect(deriveChainProbe(fetched({ status: "ok" })).status).toBe("degraded");
+  });
+
+  it("ok with the reported block height and chain id", () => {
+    const r = deriveChainProbe(fetched(HEALTHY_BODY));
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("10,612,201");
+    expect(r.detail).toContain("420420417");
+  });
+
+  it("red when the product reports its blockchain component unhealthy", () => {
+    expect(deriveChainProbe(fetched({ ...HEALTHY_BODY, components: { blockchain: { ok: false, blockNumber: 10 } } })).status).toBe("red");
+  });
+
+  it("red when the chain reports block 0", () => {
+    expect(deriveChainProbe(fetched({ ...HEALTHY_BODY, components: { blockchain: { ok: true, blockNumber: 0 } } })).status).toBe("red");
+  });
+
+  it("halt severity is caller-supplied: degraded on a testnet freeze, red on a mainnet halt", () => {
+    const stale = (haltStatus: "red" | "degraded") => deriveChainProbe(fetched(HEALTHY_BODY), { staticForMs: 900_000, stalenessMs: 600_000, haltStatus });
+    expect(stale("degraded").status).toBe("degraded");
+    expect(stale("degraded").detail).toContain("not advancing");
+    expect(stale("red").status).toBe("red");
+  });
+
+  it("ok when the block is fresh (static, but within the window)", () => {
+    expect(deriveChainProbe(fetched(HEALTHY_BODY), { staticForMs: 30_000, stalenessMs: 600_000, haltStatus: "red" }).status).toBe("ok");
+  });
+});
+
+describe("trackChainAdvance", () => {
+  it("starts the clock at the first observation", () => {
+    expect(trackChainAdvance(undefined, 100, 5000)).toEqual({ lastBlock: 100, lastAdvanceAtMs: 5000 });
+  });
+
+  it("resets the clock when the block advances", () => {
+    expect(trackChainAdvance({ lastBlock: 100, lastAdvanceAtMs: 5000 }, 101, 9000)).toEqual({ lastBlock: 101, lastAdvanceAtMs: 9000 });
+  });
+
+  it("keeps the old advance time when the block is static (so staleness accrues)", () => {
+    expect(trackChainAdvance({ lastBlock: 100, lastAdvanceAtMs: 5000 }, 100, 9000)).toEqual({ lastBlock: 100, lastAdvanceAtMs: 5000 });
+  });
+
+  it("holds the previous tracker when the block is missing", () => {
+    expect(trackChainAdvance({ lastBlock: 100, lastAdvanceAtMs: 5000 }, undefined, 9000)).toEqual({ lastBlock: 100, lastAdvanceAtMs: 5000 });
+  });
+});
+
+describe("chainHaltStatus", () => {
+  it("auto: mainnet chainId pages (red), testnet freezes (degraded)", () => {
+    expect(chainHaltStatus(420420419, "auto")).toBe("red"); // Polkadot Hub mainnet
+    expect(chainHaltStatus(420420417, "auto")).toBe("degraded"); // testnet
+    expect(chainHaltStatus(undefined, "auto")).toBe("degraded");
+  });
+
+  it("explicit override wins over the auto chainId rule", () => {
+    expect(chainHaltStatus(420420417, "red")).toBe("red");
+    expect(chainHaltStatus(420420419, "degraded")).toBe("degraded");
+  });
+});
+
+describe("probeSignerLiquidity (direct RPC)", () => {
   const floors = { usdcDecimals: 6, minGasNative: 0.1, minUsdc: 5 };
   // 1 ETH = 1e18 wei = 0xDE0B6B3A7640000 ; 0.01 ETH = 1e16 = 0x2386F26FC10000
   // 10 USDC = 10_000_000 = 0x989680 ; 1 USDC = 1_000_000 = 0xF4240
-  const balances = (gasHex: string, usdcHex: string): typeof fetch =>
-    mockFetch((_url, init) => ({ result: rpcMethod(init) === "eth_getBalance" ? gasHex : usdcHex }));
 
   it("degraded when RPC / signer address are unconfigured", async () => {
     const r = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: undefined, usdcAddress: undefined, ...floors, fetchImpl: balances("0x0", "0x0") });
@@ -195,6 +280,44 @@ describe("probeSignerLiquidity", () => {
   });
 });
 
+describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", () => {
+  it("healthy: api ok (/health), chain ok (/health), signer ok (direct RPC)", async () => {
+    const { probes } = await collectProductHealthProbes(cfg(), combinedFetch({ healthBody: HEALTHY_BODY, gasHex: "0xDE0B6B3A7640000", usdcHex: "0x989680" }), { nowMs: 1000 });
+    expect(probes.map((p) => p.name)).toEqual(["product_api", "chain_height", "signer_liquidity"]);
+    expect(probes.map((p) => p.status)).toEqual(["ok", "ok", "ok"]);
+    expect(probes[2]?.detail).toContain("USDC 10.00");
+  });
+
+  it("all degraded when nothing is configured (never fake green)", async () => {
+    const { probes } = await collectProductHealthProbes(cfg({ apiBaseUrl: undefined, rpcUrl: undefined }), combinedFetch({ healthBody: HEALTHY_BODY }), { nowMs: 1000 });
+    expect(probes.map((p) => p.status)).toEqual(["degraded", "degraded", "degraded"]);
+  });
+
+  it("a frozen testnet chain → chain_height degraded (no page)", async () => {
+    const { probes } = await collectProductHealthProbes(cfg(), combinedFetch({ healthBody: HEALTHY_BODY, gasHex: "0x1", usdcHex: "0x1" }), {
+      advance: { lastBlock: 10612201, lastAdvanceAtMs: 0 },
+      nowMs: 700_000,
+    });
+    const chain = probes.find((p) => p.name === "chain_height");
+    expect(chain?.status).toBe("degraded");
+    expect(chain?.detail).toContain("not advancing");
+  });
+
+  it("a frozen MAINNET chain → chain_height red (pages: settlement down)", async () => {
+    const mainnet: ProductHealthPayload = { ...HEALTHY_BODY, auth: { chainId: 420420419 } };
+    const { probes } = await collectProductHealthProbes(cfg(), combinedFetch({ healthBody: mainnet, gasHex: "0x1", usdcHex: "0x1" }), {
+      advance: { lastBlock: 10612201, lastAdvanceAtMs: 0 },
+      nowMs: 700_000,
+    });
+    expect(probes.find((p) => p.name === "chain_height")?.status).toBe("red");
+  });
+
+  it("returns an updated chain-advance tracker for the caller to persist", async () => {
+    const { chainAdvance } = await collectProductHealthProbes(cfg(), combinedFetch({ healthBody: HEALTHY_BODY, gasHex: "0x1", usdcHex: "0x1" }), { advance: undefined, nowMs: 1000 });
+    expect(chainAdvance).toEqual({ lastBlock: 10612201, lastAdvanceAtMs: 1000 });
+  });
+});
+
 describe("decideProductHealthAlert (de-dup)", () => {
   const red = evaluateProductHealth([probe("product_api", "red", "down")]);
   const healthy = evaluateProductHealth([probe("product_api", "ok")]);
@@ -216,7 +339,7 @@ describe("decideProductHealthAlert (de-dup)", () => {
   });
 
   it("alerts immediately when the red set changes", () => {
-    const red2 = evaluateProductHealth([probe("signer_liquidity", "red", "low")]);
+    const red2 = evaluateProductHealth([probe("chain_height", "red", "halt")]);
     const state: ProductHealthAlertState = { lastRedKey: "product_api", lastAlertAtMs: 1000 };
     expect(decideProductHealthAlert({ evaluation: red2, state, nowMs: 2000, cooldownMs: 60_000 }).alert).toBe(true);
   });
@@ -257,11 +380,10 @@ describe("runProductHealthOnce", () => {
     const r = await runProductHealthOnce(h.deps);
     expect(r.status).toBe("healthy");
     expect(r.alerted).toBe(false);
-    expect(h.alerts).toHaveLength(0);
   });
 
-  it("does not alert when only degraded (unconfigured probes)", async () => {
-    const h = harness([probe("chain_height", "degraded", "not configured")]);
+  it("does not alert when only degraded (a testnet freeze)", async () => {
+    const h = harness([probe("chain_height", "degraded", "not advancing")]);
     const r = await runProductHealthOnce(h.deps);
     expect(r.status).toBe("degraded");
     expect(r.alerted).toBe(false);
@@ -276,47 +398,42 @@ describe("runProductHealthOnce", () => {
   });
 });
 
-const TESTNET_RPC = "https://eth-rpc-testnet.polkadot.io/";
-
 describe("loadProductHealthConfig", () => {
-  it("defaults the RPC to the network endpoint (Option B); signer/USDC resolve elsewhere", () => {
+  it("defaults: /health path, testnet RPC, 600s freshness, auto halt severity", () => {
     const c = loadProductHealthConfig({});
     expect(c.apiBaseUrl).toBeUndefined();
-    expect(c.rpcUrl).toBe(TESTNET_RPC); // WALLET_NETWORK absent → testnet
-    expect(c.signerAddress).toBeUndefined(); // derived in the wiring from AGENT_WALLET_PRIVATE_KEY, not here
-    expect(c.usdcAddress).toBeUndefined();
     expect(c.apiHealthPath).toBe("/health");
+    expect(c.rpcUrl).toBe(TESTNET_RPC); // WALLET_NETWORK absent → testnet
+    expect(c.chainMaxStaleSeconds).toBe(600);
+    expect(c.haltSeverity).toBe("auto");
     expect(c.usdcDecimals).toBe(6);
     expect(c.minGasNative).toBe(0);
     expect(c.minUsdc).toBe(0);
   });
 
-  it("selects the RPC by WALLET_NETWORK, leaving mainnet unset until confirmed", () => {
-    expect(loadProductHealthConfig({ WALLET_NETWORK: "testnet" }).rpcUrl).toBe(TESTNET_RPC);
-    expect(loadProductHealthConfig({ WALLET_NETWORK: "mainnet" }).rpcUrl).toBeUndefined();
-  });
-
-  it("reads env overrides; an explicit RPC wins over the network map", () => {
+  it("reads env overrides", () => {
     const c = loadProductHealthConfig({
       AVERRAY_API_BASE_URL: "https://api.x/",
       PRODUCT_HEALTH_RPC_URL: "http://rpc",
+      PRODUCT_HEALTH_USDC_ADDRESS: "0xusdc",
       PRODUCT_HEALTH_MIN_USDC: "5",
-      PRODUCT_HEALTH_MIN_GAS_NATIVE: "0.1",
+      PRODUCT_HEALTH_HALT_SEVERITY: "red",
+      PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS: "120",
     });
     expect(c.apiBaseUrl).toBe("https://api.x");
     expect(c.rpcUrl).toBe("http://rpc");
+    expect(c.usdcAddress).toBe("0xusdc");
     expect(c.minUsdc).toBe(5);
-    expect(c.minGasNative).toBe(0.1);
+    expect(c.haltSeverity).toBe("red");
+    expect(c.chainMaxStaleSeconds).toBe(120);
   });
 });
 
 describe("networkEthRpc", () => {
-  it("resolves testnet (default + case-insensitive), leaves mainnet/unknown unset", () => {
+  it("resolves testnet to the live host (default + case-insensitive), leaves mainnet unset", () => {
     expect(networkEthRpc(undefined)).toBe(TESTNET_RPC);
-    expect(networkEthRpc("testnet")).toBe(TESTNET_RPC);
     expect(networkEthRpc("TestNet")).toBe(TESTNET_RPC);
     expect(networkEthRpc("mainnet")).toBeUndefined();
-    expect(networkEthRpc("weird")).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## What

Hybrid product-health monitoring, building on #497 (halt detection) + #498 (live eth-rpc default). Two data sources, each where it's authoritative:

- **`product_api` + `chain_height`** read the product's own `/health` payload (`components.blockchain.{ok,blockNumber}` + `auth.chainId`).
- **`signer_liquidity`** keeps the direct eth-RPC balance probe (`eth_getBalance` + erc20 `balanceOf`) — `/health` exposes no balances, so this is the only source of real solvency monitoring.

Probe names + the `/monitor/product-health` shape are unchanged → **frontend untouched**.

## Why hybrid (not one source)

| | Real signer balances | Frozen-chain safe | Drift-proof chain |
|---|---|---|---|
| `/health` only | ❌ (no balances exposed) | ✅ | ✅ |
| direct-RPC only (#497/#498) | ✅ | ✅ | ❌ (endpoint drifts on retarget) |
| **this PR** | ✅ | ✅ | ✅ |

`chain_height` reads `/health` so it always watches the **exact chain the product runs on** (`auth.chainId`) — no separate endpoint that silently drifts to the wrong network when the product retargets (e.g. Paseo → Westend). Balances still need a direct eth-RPC (`/health` doesn't expose them), so that probe stays direct, degrading safely if its endpoint drifts.

## Chain-halt severity is network-conditional

A frozen chain (block height static past `PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS`, default 600s) is:
- **degraded** on a testnet (a reset happens — no page),
- **red** on mainnet (settlement down = page).

`auth.chainId` selects (mainnet `420420419` → red); `PRODUCT_HEALTH_HALT_SEVERITY` (`auto`|`red`|`degraded`) overrides. **Right now Paseo is frozen at block 10612201** (Q3 reset), so `chain_height` honestly degrades without paging; a mainnet halt would page.

## Config

- `PRODUCT_HEALTH_RPC_URL` — direct eth-RPC for the balance probe (default: the live `eth-rpc-testnet.polkadot.io` from #498).
- `PRODUCT_HEALTH_USDC_ADDRESS` — the product's USDC (`0x00…01200000`, verified on-chain).
- `PRODUCT_HEALTH_SIGNER_ADDRESS` — or derived from `AGENT_WALLET_PRIVATE_KEY`.
- `PRODUCT_HEALTH_MIN_GAS_NATIVE` / `PRODUCT_HEALTH_MIN_USDC` — floors that turn low balances red.
- **NEW** `PRODUCT_HEALTH_HALT_SEVERITY` — `auto` (default) | `red` | `degraded`.

## Verify

- `51/51` product-health unit tests pass.
- `product-health.ts` + `auth.ts` typecheck clean. (The one extra `tsc` error — `index.ts:6` `addressFromPrivateKey` — is the node_modules-symlink-to-other-branch artifact; the line is byte-identical to main, whose CI is green. CI builds fresh and is authoritative.)

## After merge

Redeploy `slack-operator`. On the VPS set the balance-probe USDC (per the parallel investigation): `PRODUCT_HEALTH_USDC_ADDRESS=0x0000053900000000000000000000000001200000` (the RPC already defaults to the live host). Then: `product_api` **green**, `chain_height` **degraded** — *"chain not advancing"* (Paseo frozen, the truth), `signer_liquidity` shows **real gas + USDC balances**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
