### PR TITLE
fix(monitor): Ops as a split within a persistent board frame (rail, hero banner, KPIs, toolbar)

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -607,27 +607,15 @@ export function BoardView({
         {announcement}
       </div>
 
-      {/* Board-level Delivery ⇆ Ops switch — swaps the WHOLE board, above the
-          lanes (not a per-lane toggle). Always present, including when the
-          delivery SSE is degraded, since Ops reads product health from its own
-          poll rather than the board stream. */}
+      {/* Board-level Delivery ⇆ Ops switch — swaps the CENTER (lanes) region,
+          NOT the whole board: the top strip, co-pilot rail, and footer stay in
+          both views so Hermes keeps board + ops awareness and can narrate ops in
+          chat. Always present, including when the delivery SSE is degraded, since
+          Ops reads product health from its own poll rather than the board stream. */}
       <div className="ops-switch-bar">
         <BoardSurfaceSwitch surface={boardSurface} onChange={setBoardSurface} health={productHealth} />
       </div>
 
-      {boardSurface === "ops" ? (
-        productHealth ? (
-          <OpsBoard health={productHealth} />
-        ) : (
-          <div className="ops-board ops-board--empty" data-testid="ops-board-loading">
-            <div className="ops-empty">
-              <span className="ops-empty-title">Loading health…</span>
-              <span className="ops-empty-detail">Polling the live product heartbeat.</span>
-            </div>
-          </div>
-        )
-      ) : (
-        <>
       {degraded ? (
         <TopStripDegraded
           lastKnownAt={liveLabel || undefined}
@@ -647,37 +635,56 @@ export function BoardView({
         />
       )}
 
-      <BoardNowBanner banner={state.banner} cta={bannerCta} />
+      {/* Delivery-only hero sentence (it's about the card decisions). In Ops the
+          <OpsBoard> carries its own status sub-header + soft incident banner. */}
+      {boardSurface === "delivery" ? <BoardNowBanner banner={state.banner} cta={bannerCta} /> : null}
 
       <div className="hm-main">
+        {/* The lanes column swaps Delivery ⇆ Ops; the co-pilot rail is a sibling
+            that stays mounted in BOTH views. */}
         <div className="hm-lanes-wrap">
-          <LanesBar
-            counts={state.counts}
-            mode={state.mode}
-            searchValue={query}
-            onSearchChange={setQuery}
-            searchInputRef={searchInputRef}
-            activeFilter={filter}
-            onFilterChange={setFilter}
-          />
-          <UtilitiesPanel
-            usage={board?.llmUsage}
-            suites={board?.testbedSuites}
-            onRunSuite={onRunSuite}
-            onSaveSuite={onSaveSuite}
-            onApproveSuite={onApproveSuite}
-            onDismissSuite={onDismissSuite}
-            onSpawnMission={onSpawnMission}
-          />
-          <KanbanBoard
-            grouped={displayGrouped}
-            ariaLabel="Kanban lane grid"
-            expanded={surfacedExpanded}
-            onToggleLane={onToggleLane}
-            renderCard={renderCard}
-            renderPipelineCard={renderPipelineCard}
-            renderLaneBody={renderLaneBody}
-          />
+          {boardSurface === "ops" ? (
+            productHealth ? (
+              <OpsBoard health={productHealth} />
+            ) : (
+              <div className="ops-board ops-board--empty" data-testid="ops-board-loading">
+                <div className="ops-empty">
+                  <span className="ops-empty-title">Loading health…</span>
+                  <span className="ops-empty-detail">Polling the live product heartbeat.</span>
+                </div>
+              </div>
+            )
+          ) : (
+            <>
+              <LanesBar
+                counts={state.counts}
+                mode={state.mode}
+                searchValue={query}
+                onSearchChange={setQuery}
+                searchInputRef={searchInputRef}
+                activeFilter={filter}
+                onFilterChange={setFilter}
+              />
+              <UtilitiesPanel
+                usage={board?.llmUsage}
+                suites={board?.testbedSuites}
+                onRunSuite={onRunSuite}
+                onSaveSuite={onSaveSuite}
+                onApproveSuite={onApproveSuite}
+                onDismissSuite={onDismissSuite}
+                onSpawnMission={onSpawnMission}
+              />
+              <KanbanBoard
+                grouped={displayGrouped}
+                ariaLabel="Kanban lane grid"
+                expanded={surfacedExpanded}
+                onToggleLane={onToggleLane}
+                renderCard={renderCard}
+                renderPipelineCard={renderPipelineCard}
+                renderLaneBody={renderLaneBody}
+              />
+            </>
+          )}
         </div>
 
         <CoPilotRail
@@ -705,8 +712,6 @@ export function BoardView({
           Real counts only (total cards, how many wait on the operator, how
           many are running). New --h4 surface. */}
       <BoardFooter cards={cards} />
-        </>
-      )}
 
       {/* P0-4: transient confirmation that an Ask-Hermes action was received.
           aria-live so it's announced; visually a small floating toast. It

--- a/packages/monitor-ui/src/ops-preview.tsx
+++ b/packages/monitor-ui/src/ops-preview.tsx
@@ -1,7 +1,9 @@
-// Dev-only preview harness for the Ops surface. Renders OpsBoard against the ops
-// fixtures with a fixture picker + the board-level surface switch, so the look
-// can be iterated in the browser without the live backend. NOT a Vite build
-// input (ops-preview.html is dev-served only), so this never ships to prod.
+// Dev-only preview harness for the Ops surface. Mirrors the REAL board frame
+// (`.hm-board` grid → top strip · banner · `.hm-main` [lanes | rail] · footer)
+// with real classNames so the actual layout CSS applies, then swaps only the
+// `.hm-lanes-wrap` content between a delivery placeholder and <OpsBoard> — the
+// co-pilot rail stays mounted in both views (that's the whole point of the
+// split). NOT a Vite build input (ops-preview.html is dev-served only).
 
 import { StrictMode, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -34,12 +36,75 @@ const FIXTURES = {
 } as const;
 type FixtureKey = keyof typeof FIXTURES;
 
+// Lightweight stand-ins for the real frame pieces (top strip, rail, footer) so
+// the grid rows/columns resolve exactly like production without pulling the live
+// board data those components need.
+function MockTopStrip() {
+  return (
+    <div className="hm-top" role="banner">
+      <div className="hm-brand">
+        <div className="hm-brand-mark" aria-hidden>A</div>
+        <div>
+          <div className="hm-brand-name">Hermes</div>
+          <div className="hm-brand-sub">Handoff monitor · Averray</div>
+        </div>
+      </div>
+      <div className="hm-kpis">
+        <span className="hm-kpi"><span className="n">37</span> Action needed</span>
+        <span className="hm-kpi hm-kpi--zero"><span className="n">0</span> Operator review</span>
+        <span className="hm-kpi hm-kpi--ok"><span className="dot" aria-hidden /> Deploy OK</span>
+      </div>
+      <div className="hm-top-right">
+        <span className="hm-deploy-pill"><span className="ledge" aria-hidden /> Live · 10:42:47</span>
+      </div>
+    </div>
+  );
+}
+
+function MockRail() {
+  return (
+    <aside
+      aria-label="Hermes co-pilot (mock)"
+      style={{
+        background: "var(--h4-surface)",
+        borderLeft: "1px solid var(--h4-line)",
+        padding: "14px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 10,
+        minHeight: 0,
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ color: "var(--h4-ink)", fontWeight: 500, fontSize: 13 }}>Hermes co-pilot</div>
+      <p style={{ color: "var(--h4-muted)", fontSize: 12, margin: 0, lineHeight: 1.5 }}>
+        Stays mounted in both views. In Ops, Hermes narrates product-health deltas here — the next
+        chunk feeds ops signals into the digest + chat.
+      </p>
+      <div
+        style={{
+          marginTop: "auto",
+          border: "1px solid var(--h4-line)",
+          borderRadius: "var(--h4-r-btn)",
+          padding: "9px 12px",
+          color: "var(--h4-faint)",
+          fontSize: 12,
+        }}
+      >
+        Ask Hermes…
+      </div>
+    </aside>
+  );
+}
+
 function Harness() {
   const [key, setKey] = useState<FixtureKey>("live");
   const [surface, setSurface] = useState<BoardSurface>("ops");
   const health = FIXTURES[key].health;
   return (
     <div className="hm-board">
+      <div className="hm-sr-only" role="status" aria-live="assertive" />
+
       <div className="ops-switch-bar">
         <BoardSurfaceSwitch surface={surface} onChange={setSurface} health={health} />
         <div className="ops-switch" style={{ marginLeft: "auto" }} role="group" aria-label="Preview fixture">
@@ -55,13 +120,33 @@ function Harness() {
           ))}
         </div>
       </div>
-      {surface === "ops" ? (
-        <OpsBoard health={health} nowMs={FIXTURE_NOW} />
-      ) : (
-        <div className="ops-board">
-          <p className="ops-await">Delivery kanban renders here (unchanged in Ops work).</p>
+
+      <MockTopStrip />
+
+      {surface === "delivery" ? (
+        <div className="hm-now" style={{ padding: "10px 18px", color: "var(--h4-muted)" }}>
+          37 decisions waiting on you — delivery banner (hidden in Ops)
         </div>
-      )}
+      ) : null}
+
+      <div className="hm-main">
+        <div className="hm-lanes-wrap">
+          {surface === "ops" ? (
+            <OpsBoard health={health} nowMs={FIXTURE_NOW} />
+          ) : (
+            <div className="ops-board">
+              <p className="ops-await">Delivery kanban renders here (unchanged in Ops work).</p>
+            </div>
+          )}
+        </div>
+        <MockRail />
+      </div>
+
+      <footer className="h4-board-footer" aria-label="Board footer">
+        <span className="h4-board-footer-end"><span className="dot" aria-hidden /> End of board</span>
+        <span className="h4-board-footer-stat">40 cards · 37 waiting on you · 0 running</span>
+        <span className="h4-board-footer-meta">Hermes · Averray</span>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## What & why

Refines the Ops surface (#505) from a **full-canvas takeover** into a **split within a persistent board frame**, based on live review. The whole frame stays mounted in both Delivery and Ops — **top strip, hero banner, search/filter toolbar, Utilities strip, Hermes co-pilot rail, footer** — and **only the lane columns swap** (kanban ⇄ ops zones). Delivery-specific *content* adapts to Ops.

```
 ┌ Delivery | Ops ─────────────────────────────────────────┐  board-level switch
 ┌ Hermes · [Availability|Chain|Solvency|Flow chips] · LIVE ┐  top strip (KPIs → pillars)
 ┌ OPS NOW · chain · testnet — "Chain height degraded …"    ┐  hero banner (ops importance)
 ┌ ⌕ search · sorted by urgency · ALL BLOCKED REVIEW …      ┐  toolbar (stays)
 ┌ ▸ Utilities · LLM usage · suites · tester launcher       ┐  utilities (stays)
 ┌──────────────────────────────┬──────────────────────────┐
 │  kanban  ⇆  OPS ZONES        │  Hermes co-pilot (chat)  │  only this swaps; rail stays
 └──────────────────────────────┴──────────────────────────┘
 └ End of board · N cards ──────────────────────────────────┘  footer (stays)
```

Keeping the rail mounted is the seam for what's next: **Hermes narrating product-health deltas into the digest + chat**.

## Frame elements that adapt to Ops

- **Hero banner** — reuses `<BoardNowBanner>` driven by an ops payload (`opsBannerData`): calm ✓ nominal / amber ! a real degradation / rose ‼ a page-worthy red. Network-aware sub (testnet *"not paging"* vs mainnet *"on-call is paged"*) + "most urgent because" reason chips. Awaiting-data probes never raise the banner (telemetry, not an incident).
- **Top-strip KPIs** — pillar-status chips (Availability / Chain / Solvency / Flow, each toned by its worst probe) replace the delivery lane counts in Ops.
- **Search/filter toolbar + Utilities** — stay mounted in both surfaces.

## Structure

- `TopStrip` gains optional `opsPillars`; renders pillar chips instead of lane counts when present.
- `BoardView`: `TopStrip` + hero banner + toolbar + Utilities + rail + footer are always mounted; only `KanbanBoard` ⇄ `OpsBoard` swaps inside `.hm-lanes-wrap`.
- Retired the now-redundant in-board `OpsSoftBanner` + `OpsBoard` sub-header (the hero banner + top-strip chips carry that context).
- New `ops-frame.ts` (`opsBannerData` + `pillarStatuses`), pure + unit-tested.
- `ops-preview` harness mirrors the full real frame (top strip · hero · toolbar · utilities · main[lanes|rail] · footer) across the three fixture states.

## Verification

- `tsc -b` clean
- **762 tests** (new `ops-frame` suite; delivery-mode BoardView + TopStrip tests unaffected)
- `vite build` green
- Verified all three fixture states + both surfaces in the preview: the frame persists; Delivery is unchanged; Ops shows pillar chips + an ops hero + the ops zones with the rail beside them.

## Deploy (after merge)

Frontend-only rebuild:
`cd /srv/averray-reference-agent && git pull && docker compose --env-file .env.prod -f ops/compose.yml -f ops/compose.prod.yml -p avg up -d --build slack-operator`