### PR TITLE
feat(monitor): Hermes ops-awareness — Digest ops line + ops-aware Ask-Hermes answers

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -694,6 +694,7 @@ export function BoardView({
           backlogSuggestions={backlogSuggestions}
           boardCards={cards}
           boardBanner={state.banner}
+          productHealth={productHealth}
           focusedCard={scopeCard}
           onCardClick={onCardClick}
           collaboration={collaboration}

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, within } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { CoPilotRail } from "./CoPilotRail.js";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
+import { OPS_FIXTURE_LIVE } from "../../lib/monitor/ops-fixtures.js";
 
 afterEach(cleanup);
 
@@ -37,5 +38,22 @@ describe("PR-D3d — rail Hermes digest", () => {
     expect(view.getByText(/session deltas · honest until wired/i)).toBeTruthy();
     expect(view.getByText("ADVANCED (SESSION)").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("—");
     expect(view.getByText("PROD CHANGES").parentElement?.querySelector(".hm-rail-digest-value")?.textContent).toBe("—");
+  });
+
+  test("surfaces a compact ops line when product health is provided", () => {
+    const { container } = render(
+      <CoPilotRail boardCards={[]} collaboration={{ enabled: false }} productHealth={OPS_FIXTURE_LIVE} />,
+      { wrapper },
+    );
+    const ops = container.querySelector(".hm-rail-ops") as HTMLElement;
+    expect(ops).toBeTruthy();
+    expect(ops.className).toContain("hm-rail-ops--degraded");
+    expect(ops.textContent).toContain("Ops · degraded · safe");
+    expect(ops.textContent).toContain("chain not advancing");
+  });
+
+  test("no ops line when product health is absent (rail stays delivery-only)", () => {
+    const { container } = render(<CoPilotRail boardCards={[]} collaboration={{ enabled: false }} />, { wrapper });
+    expect(container.querySelector(".hm-rail-ops")).toBeNull();
   });
 });

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -19,6 +19,8 @@ import { useCollaboration, type UseCollaborationOptions } from "../../hooks/useC
 import { derivePresence, activeCount, type PresencePeer } from "../../lib/monitor/presence.js";
 import { railDigestCounts } from "../../lib/monitor/rail-digest.js";
 import { isDecision } from "../../lib/monitor/lane-rules.js";
+import { opsDigestSummary } from "../../lib/monitor/ops-digest.js";
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { shortId } from "../../lib/monitor/card-id.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
 import { AskHermesComposer } from "./AskHermesComposer.js";
@@ -36,6 +38,9 @@ export interface CoPilotRailProps {
   boardCards?: readonly BoardCard[];
   /** Current board "what needs you" summary. Appended to the activity feed. */
   boardBanner?: BoardNowBannerData;
+  /** Live product-health snapshot — drives the Digest ops line so ops status is
+      glanceable from the Delivery view too. Omit to hide the ops line. */
+  productHealth?: ProductHealth;
   /** Focused card — scopes Ask-Hermes questions + the scope chip. */
   focusedCard?: BoardCard;
   /** Open a related card from a linked follow-up suggestion. */
@@ -67,6 +72,7 @@ export function CoPilotRail({
   backlogSuggestions,
   boardCards,
   boardBanner,
+  productHealth,
   focusedCard,
   onCardClick,
   collaboration,
@@ -172,6 +178,7 @@ export function CoPilotRail({
           >
             <RailDigest
               cards={boardCards ?? []}
+              health={productHealth}
               onCardClick={onCardClick}
               onGoRoom={() => setRailTab("room")}
               onOpenRoster={() => setRosterOpen(true)}
@@ -340,11 +347,13 @@ function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCa
  */
 function RailDigest({
   cards,
+  health,
   onCardClick,
   onGoRoom,
   onOpenRoster,
 }: {
   cards: readonly BoardCard[];
+  health?: ProductHealth;
   onCardClick?: (id: string) => void;
   onGoRoom: () => void;
   onOpenRoster: () => void;
@@ -365,6 +374,7 @@ function RailDigest({
           session deltas · honest until wired
         </span>
       </div>
+      {health ? <RailOpsRow health={health} /> : null}
       <div className="hm-rail-digest-stats">
         <DigestStat label="NEEDS YOU" value={needsYou} tone="act" />
         <DigestStat label="RUNNING NOW" value={running} tone="ok" />
@@ -396,6 +406,22 @@ function RailDigest({
         <Button variant="ghost" size="sm" onClick={onOpenRoster}>Who&apos;s who</Button>
       </div>
     </section>
+  );
+}
+
+/**
+ * The Digest's ops line — a compact product-health summary so ops status is
+ * visible from the Delivery view (the rail is mounted in both surfaces). Honest
+ * off/awaiting tones; a detail line appears only for a real incident.
+ */
+function RailOpsRow({ health }: { health: ProductHealth }) {
+  const { toneClass, label, detail } = opsDigestSummary(health);
+  return (
+    <div className={`hm-rail-ops hm-rail-ops--${toneClass}`} aria-label="Product ops status">
+      <span className="hm-rail-ops-dot" aria-hidden />
+      <span className="hm-rail-ops-label">Ops · {label}</span>
+      {detail ? <span className="hm-rail-ops-detail">{detail}</span> : null}
+    </div>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/ops-digest.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-digest.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import type { ProductHealth } from "./product-health.js";
+import { opsDigestSummary } from "./ops-digest.js";
+import { OPS_FIXTURE_LIVE, OPS_FIXTURE_RED } from "./ops-fixtures.js";
+
+describe("opsDigestSummary", () => {
+  test("degraded board → degraded tone + the lead real-degraded probe detail", () => {
+    const s = opsDigestSummary(OPS_FIXTURE_LIVE);
+    expect(s.toneClass).toBe("degraded");
+    expect(s.label).toBe("degraded · safe");
+    expect(s.detail).toContain("chain not advancing");
+  });
+
+  test("red board → fail tone + the red probe detail, not an awaiting probe", () => {
+    const s = opsDigestSummary(OPS_FIXTURE_RED);
+    expect(s.toneClass).toBe("fail");
+    expect(s.label).toContain("red");
+    expect(s.detail).toContain("settlements not landing");
+  });
+
+  test("healthy board → pass tone, no detail line", () => {
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "healthy",
+      checks: 5,
+      probes: [{ name: "product_api", status: "ok", detail: "200", sparkline: [] }],
+    };
+    const s = opsDigestSummary(health);
+    expect(s.toneClass).toBe("pass");
+    expect(s.label).toBe("all healthy");
+    expect(s.detail).toBe("");
+  });
+
+  test("an awaiting-only degradation does not surface an incident detail", () => {
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "degraded",
+      checks: 5,
+      probes: [
+        { name: "product_api", status: "ok", detail: "200", sparkline: [] },
+        { name: "money_path", status: "degraded", detail: "awaiting /health settlement counts", sparkline: [] },
+      ],
+    };
+    const s = opsDigestSummary(health);
+    expect(s.toneClass).toBe("degraded");
+    expect(s.detail).toBe(""); // the only degraded probe is awaiting → not an incident
+  });
+
+  test("monitoring off + undefined are honest", () => {
+    expect(opsDigestSummary({ enabled: false, at: null, status: "unknown", checks: 0, probes: [] }).label).toBe(
+      "monitoring off",
+    );
+    expect(opsDigestSummary(undefined)).toEqual({ toneClass: "muted", label: "awaiting", detail: "" });
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-digest.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-digest.ts
@@ -1,0 +1,42 @@
+// Ops digest summary — a compact one-line view of product health for the
+// co-pilot rail's Digest, so ops status is glanceable from the Delivery view
+// (the rail is mounted in both surfaces). Pure: health snapshot → {tone, label,
+// detail}. Truth-boundary preserved: off / awaiting states are honest, and an
+// awaiting-data probe is never surfaced as the "lead incident" (it's telemetry,
+// not a degradation).
+
+import type { ProductHealth, ProductHealthProbe } from "./product-health.js";
+import { overallSummary, overallToneClass } from "./product-health.js";
+import { isAwaitingProbe } from "./ops-model.js";
+
+export interface OpsDigestSummary {
+  /** Maps to the board's --hm-state-* family: pass / degraded / fail / muted. */
+  toneClass: "pass" | "degraded" | "fail" | "muted";
+  /** Short headline, e.g. "degraded · safe", "all healthy", "2 probes red". */
+  label: string;
+  /** The lead incident probe's compact detail, or "" when nominal/off. */
+  detail: string;
+}
+
+/** The worst REAL probe (red beats a genuine degradation; awaiting is skipped). */
+function leadIncidentProbe(probes: readonly ProductHealthProbe[]): ProductHealthProbe | undefined {
+  return (
+    probes.find((p) => p.status === "red") ??
+    probes.find((p) => p.status === "degraded" && !isAwaitingProbe(p))
+  );
+}
+
+function compact(detail: string): string {
+  const trimmed = detail.trim();
+  return trimmed.length > 64 ? `${trimmed.slice(0, 61)}…` : trimmed;
+}
+
+export function opsDigestSummary(health: ProductHealth | undefined): OpsDigestSummary {
+  if (!health) return { toneClass: "muted", label: "awaiting", detail: "" };
+  const overall = overallSummary(health);
+  const toneClass = overallToneClass(overall.tone);
+  // Only show a detail line when there's a real incident to point at — a healthy
+  // or off board keeps the line clean.
+  const lead = overall.tone === "red" || overall.tone === "degraded" ? leadIncidentProbe(health.probes) : undefined;
+  return { toneClass, label: overall.label, detail: lead ? compact(lead.detail) : "" };
+}

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -423,3 +423,31 @@
 
 /* ---- footer ---- */
 .ops-foot { margin: 14px 0 0; text-align: center; font-size: 11px; color: var(--h4-faint); }
+
+/* ---- co-pilot Digest ops line (rail is mounted in both surfaces) ---- */
+.hm-rail-ops {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  margin: 9px 0 2px;
+  border-radius: var(--h4-r-btn);
+  background: var(--h4-paper-sunken);
+  border: 1px solid var(--h4-line);
+  border-left: 3px solid var(--tone, var(--h4-tel));
+  font-size: 12px;
+  min-width: 0;
+}
+.hm-rail-ops--pass { --tone: var(--h4-ok); }
+.hm-rail-ops--degraded { --tone: var(--h4-warn); }
+.hm-rail-ops--fail { --tone: var(--h4-act); }
+.hm-rail-ops--muted { --tone: var(--h4-tel); }
+.hm-rail-ops-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--tone); flex: none; }
+.hm-rail-ops-label { color: var(--h4-ink); font-weight: 500; white-space: nowrap; }
+.hm-rail-ops-detail {
+  color: var(--h4-muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -141,6 +141,7 @@ import {
   generateHermesReplyViaSessionStream,
   requestHermesCompletion,
   resolveHermesSessionConfig,
+  type HermesProductHealthSnapshot,
 } from "./monitor-hermes-voice.js";
 import {
   emitCopilotStreamEvent,
@@ -1663,6 +1664,21 @@ function shortMemoryNote(note: string): string {
   return compact.length > 180 ? `${compact.slice(0, 179)}…` : compact;
 }
 
+/**
+ * The current live product-health snapshot, compacted for Hermes's reply context
+ * so ops questions get answered from real probes (not guesses). undefined when
+ * the heartbeat is off or has no checks yet — Hermes then simply has no ops data.
+ */
+function currentProductHealthForHermes(): HermesProductHealthSnapshot | undefined {
+  if (!routineConfig.productHealth.enabled) return undefined;
+  const last = productHealthHistory[productHealthHistory.length - 1];
+  if (!last) return undefined;
+  return {
+    status: last.status ?? "unknown",
+    probes: (last.probes ?? []).map((p) => ({ name: p.name, status: p.status, detail: p.detail })),
+  };
+}
+
 async function loadHermesBoardSnapshotForReply(
   operatorMessage: Awaited<ReturnType<typeof recordCollaborationMessage>>
 ) {
@@ -1673,7 +1689,9 @@ async function loadHermesBoardSnapshotForReply(
       4_000,
       "monitor_reply_board_snapshot_timeout"
     );
-    return buildHermesBoardSnapshotFromMonitor(snapshot);
+    const board = buildHermesBoardSnapshotFromMonitor(snapshot);
+    const productHealth = currentProductHealthForHermes();
+    return productHealth ? { ...board, productHealth } : board;
   } catch (error) {
     logger.warn({ err: error, id: operatorMessage.id }, "monitor_collaboration_board_snapshot_unavailable");
     return undefined;

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -100,6 +100,17 @@ export interface HermesBoardCardSnapshot {
   headBranch?: string;
 }
 
+/**
+ * Compact live product-health for Hermes — the running product's probes so the
+ * co-pilot can answer ops / uptime / chain / solvency / settlement questions.
+ * `detail` carries the human-readable specifics ("chain not advancing — last
+ * block 3d 22h old", "gas 4999.99 PAS · USDC 2.00", etc.).
+ */
+export interface HermesProductHealthSnapshot {
+  status: string;
+  probes: ReadonlyArray<{ name: string; status: string; detail: string }>;
+}
+
 export interface HermesBoardSnapshot {
   generatedAt?: string;
   status?: string;
@@ -107,6 +118,8 @@ export interface HermesBoardSnapshot {
   counts?: Readonly<Record<string, number | string | boolean>>;
   runner?: string;
   items?: ReadonlyArray<HermesBoardCardSnapshot>;
+  /** Live product-health probes — lets Hermes answer ops questions with real state. */
+  productHealth?: HermesProductHealthSnapshot;
 }
 
 export interface HermesReplyContext {
@@ -414,6 +427,11 @@ export function buildUserPrompt(context: HermesReplyContext): string {
 
   if (context.board) {
     appendBoardSnapshotLines(lines, context.board);
+    lines.push("");
+  }
+
+  if (context.board?.productHealth) {
+    appendProductHealthLines(lines, context.board.productHealth);
     lines.push("");
   }
 
@@ -909,6 +927,16 @@ function selectedBoardItem(context: HermesWhyTraceContext): HermesBoardCardSnaps
 function tracePrLabel(item: HermesBoardCardSnapshot): string {
   if (item.repo && item.number) return `${item.repo}#${item.number}`;
   return item.repo || item.title || "card";
+}
+
+function appendProductHealthLines(lines: string[], health: HermesProductHealthSnapshot): void {
+  lines.push(
+    "Live product health (probes of the RUNNING Averray product — use these to answer ops / uptime / chain / signer-solvency / settlement questions; say \"not wired yet\" for anything not listed):",
+  );
+  lines.push(`- overall: ${health.status}`);
+  for (const probe of health.probes) {
+    lines.push(`  - ${probe.name}: ${probe.status}${probe.detail ? ` — ${truncate(probe.detail, 200)}` : ""}`);
+  }
 }
 
 function appendBoardSnapshotLines(lines: string[], board: HermesBoardSnapshot): void {

--- a/test/unit/monitor-hermes-voice.test.ts
+++ b/test/unit/monitor-hermes-voice.test.ts
@@ -139,6 +139,31 @@ describe("buildUserPrompt", () => {
     expect(prompt).toContain("trust the board");
   });
 
+  it("threads live product-health probes into the prompt so ops questions are answerable", () => {
+    const prompt = buildUserPrompt(baseContext({
+      board: {
+        status: "attention",
+        productHealth: {
+          status: "degraded",
+          probes: [
+            { name: "product_api", status: "ok", detail: "200 · chain 420420417" },
+            { name: "chain_height", status: "degraded", detail: "chain not advancing — last block 3d 22h old" },
+            { name: "signer_liquidity", status: "ok", detail: "gas 4999.99 PAS · USDC 2.00" },
+          ],
+        },
+      },
+    }));
+    expect(prompt).toContain("Live product health");
+    expect(prompt).toContain("overall: degraded");
+    expect(prompt).toContain("chain_height: degraded — chain not advancing");
+    expect(prompt).toContain("signer_liquidity: ok — gas 4999.99 PAS · USDC 2.00");
+  });
+
+  it("omits the product-health block when the snapshot carries none", () => {
+    const prompt = buildUserPrompt(baseContext({ board: { status: "calm" } }));
+    expect(prompt).not.toContain("Live product health");
+  });
+
   it("tells the model to reply as Hermes in 1-4 sentences", () => {
     const prompt = buildUserPrompt(baseContext());
     expect(prompt).toMatch(/1-4 conversational sentences/);


### PR DESCRIPTION
Makes the Hermes co-pilot aware of the live product ("Ops"). Two slices, both shipping in the same `slack-operator` image (they deploy together).

## Slice 1 — Ops line in the Digest (frontend)
The co-pilot rail is mounted in **both** surfaces. Its Digest now shows a compact product-health line, so ops status is glanceable from the Delivery view too:

> ● **Ops · degraded · safe** · chain not advancing — last block 3d 22h old

- `CoPilotRail` gains an optional `productHealth` prop; `BoardView` passes the snapshot it already fetches.
- New pure **`opsDigestSummary()`** — truth-boundary preserved: off/awaiting are honest; an **awaiting-data probe is never surfaced as the lead incident**.

## Slice 2 — Ops-aware Ask-Hermes answers (backend)
When the operator asks Hermes, the reply context now includes the live probes, so *"why is the chain degraded?"* / *"is the signer solvent?"* get answered from **real probes** — across all LLM tiers (agentic gateway / Ollama / template).

- `HermesBoardSnapshot` gains an optional `productHealth`; `buildUserPrompt` renders a "Live product health" section after the board snapshot.
- `currentProductHealthForHermes()` reads the heartbeat's current snapshot; `loadHermesBoardSnapshotForReply` attaches it. `undefined` when the heartbeat is off — Hermes simply has no ops data (honest, never fabricated).
- Solvency/flow blocks aren't backend-emitted yet (#128), so Hermes gets the 7 probes — whose `detail` carries the specifics he needs.

## Verification
- monitor-ui: `tsc` clean · **766 tests** (new `ops-digest` + CoPilotRail Digest cases) · `vite build` green.
- slack-operator: `buildUserPrompt` tests green (+2 for the product-health section). Local `tsc` shows only the pre-existing `@avg/*` subpath noise; **CI (fresh build) is authoritative**.

## Next on the plan
Slice 3 — proactive ops narration (Hermes posts on a fresh red / recovery). Slice 4 — ops remediation suggestions.

Independent of #507 (frame work); both lightly touch `BoardView`/`hermes4-ops.css` additively.