### PR TITLE
feat(monitor): proactive ops narration — Hermes posts on a fresh red / recovery

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -143,6 +143,7 @@ import {
   resolveHermesSessionConfig,
   type HermesProductHealthSnapshot,
 } from "./monitor-hermes-voice.js";
+import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
 import {
   emitCopilotStreamEvent,
   onCopilotStreamEvent,
@@ -3162,6 +3163,9 @@ function startOperatorRoutines() {
   let anomalyPauseRunning = false;
   let productHealthRunning = false;
   let productHealthAlertState = initialProductHealthAlertState();
+  // Slice 3: previous overall product-health status, so the co-pilot narrates
+  // only on an edge across the red boundary (entered-red / recovered).
+  let prevProductHealthStatus: OpsStatus = "unknown";
   let taskHealthRunning = false;
   const anomalyConfig = loadAnomalyConfig();
   const dispatchPerDayCap = Number(process.env.HERMES_DISPATCH_PER_DAY_MAX) || 10;
@@ -3453,6 +3457,28 @@ function startOperatorRoutines() {
         { at: Date.now(), status: result.status, probes: result.evaluation.probes },
         PRODUCT_HEALTH_HISTORY_MAX,
       );
+      // Slice 3: proactive ops narration — Hermes posts a co-pilot turn on a
+      // fresh red / recovery edge (self-deduped by the transition; muted = quiet,
+      // the Digest still shows state). Network tunes the wording.
+      const opsNarration = decideOpsNarration({
+        prev: prevProductHealthStatus,
+        curr: result.status as OpsStatus,
+        probes: result.evaluation.probes,
+        network:
+          (process.env.WALLET_NETWORK ?? "").trim().toLowerCase() === "mainnet" ? "mainnet" : "testnet",
+        muted: getServerAlertMuteUntilMs() > Date.now(),
+      });
+      prevProductHealthStatus = result.status as OpsStatus;
+      if (opsNarration.post && opsNarration.text) {
+        try {
+          recordCollaborationMessage({ author: "hermes", text: opsNarration.text, kind: "chat" });
+          logger.info({ edge: opsNarration.edge }, "ops_narration_posted");
+        } catch (err) {
+          logger.warn({ err }, "ops_narration_post_failed");
+        }
+      } else if (opsNarration.suppressed) {
+        logger.info({ edge: opsNarration.edge, suppressed: opsNarration.suppressed }, "ops_narration_suppressed");
+      }
       if (result.status !== "healthy") {
         logger.warn(
           { status: result.status, alerted: result.alerted, probes: result.evaluation.probes },

--- a/services/slack-operator/src/ops-narration.ts
+++ b/services/slack-operator/src/ops-narration.ts
@@ -1,0 +1,94 @@
+// Proactive ops narration — the pure decision for whether Hermes should post a
+// co-pilot turn about a product-health change, and what to say.
+//
+// Fires ONLY on an overall-status edge across the red boundary (entered-red /
+// recovered). This is self-deduping (transitions only), so a probe staying red
+// never re-posts. It stays silent on the boot transition (prev "unknown", so a
+// restart doesn't spam), on routine degraded↔healthy moves (those live in the
+// Digest ops line), and while the operator is muted. Network tunes the wording:
+// a mainnet red pages on-call; a testnet red is informational.
+//
+// Kept pure (no I/O, no @avg deps) so it runs in the local unit suite; the
+// caller (index.ts checkProductHealth) supplies prev/curr, the probes, the
+// resolved network, and the current mute state.
+
+export type OpsStatus = "healthy" | "degraded" | "red" | "unknown";
+export type OpsNetwork = "testnet" | "mainnet" | "unknown";
+
+export interface OpsNarrationProbe {
+  name: string;
+  status: string;
+  detail: string;
+}
+
+export interface DecideOpsNarrationInput {
+  prev: OpsStatus;
+  curr: OpsStatus;
+  probes: readonly OpsNarrationProbe[];
+  network: OpsNetwork;
+  muted: boolean;
+}
+
+export interface OpsNarrationDecision {
+  post: boolean;
+  /** The edge that was detected (present even when suppressed, for logging). */
+  edge?: "red" | "recovered";
+  /** The Hermes turn text — present only when `post` is true. */
+  text?: string;
+  /** Why a real edge did not post (for observability). */
+  suppressed?: "muted";
+}
+
+const PROBE_LABELS: Record<string, string> = {
+  product_api: "Product API",
+  api_latency: "API latency",
+  chain_height: "Chain height",
+  capabilities: "Capabilities",
+  signer_liquidity: "Signer liquidity",
+  treasury_liquidity: "Treasury",
+  money_path: "Money path",
+};
+
+function label(name: string): string {
+  return PROBE_LABELS[name] ?? name.replace(/_/g, " ");
+}
+
+function trim(detail: string, max = 160): string {
+  const d = detail.trim();
+  return d.length > max ? `${d.slice(0, max - 1)}…` : d;
+}
+
+export function decideOpsNarration(input: DecideOpsNarrationInput): OpsNarrationDecision {
+  const { prev, curr, probes, network, muted } = input;
+
+  // Never narrate the boot transition — a restart shouldn't spam the thread.
+  if (prev === "unknown") return { post: false };
+
+  const enteredRed = prev !== "red" && curr === "red";
+  const recovered = prev === "red" && curr !== "red";
+  if (!enteredRed && !recovered) return { post: false };
+
+  const edge: "red" | "recovered" = enteredRed ? "red" : "recovered";
+
+  // Mute = quiet everywhere; the state still shows passively in the Digest ops line.
+  if (muted) return { post: false, edge, suppressed: "muted" };
+
+  if (edge === "red") {
+    const reds = probes.filter((p) => p.status === "red");
+    const lead = reds[0];
+    const extra = reds.length > 1 ? ` (+${reds.length - 1} more)` : "";
+    const tone = network === "mainnet" ? "On-call is paged." : "Testnet — informational.";
+    const detail = lead?.detail ? `: ${trim(lead.detail)}` : "";
+    return {
+      post: true,
+      edge,
+      text: `⚠ Ops — ${lead ? label(lead.name) : "a probe"} red${detail}${extra}. ${tone}`,
+    };
+  }
+
+  return {
+    post: true,
+    edge,
+    text: `✓ Ops recovered — product health back to ${curr}.`,
+  };
+}

--- a/test/unit/ops-narration.test.ts
+++ b/test/unit/ops-narration.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { decideOpsNarration, type OpsNarrationProbe } from "../../services/slack-operator/src/ops-narration.js";
+
+const probes = (over: Partial<Record<string, string>> = {}): OpsNarrationProbe[] => [
+  { name: "product_api", status: "ok", detail: "200" },
+  { name: "chain_height", status: over.chain_height ?? "ok", detail: "block #9,481,204 · 3s old" },
+  { name: "money_path", status: over.money_path ?? "ok", detail: "6 stuck ≥ threshold — settlements not landing" },
+];
+
+describe("decideOpsNarration", () => {
+  it("does not narrate the boot transition (prev unknown)", () => {
+    expect(decideOpsNarration({ prev: "unknown", curr: "red", probes: probes({ money_path: "red" }), network: "mainnet", muted: false }).post).toBe(false);
+  });
+
+  it("does not narrate a routine degraded↔healthy move", () => {
+    expect(decideOpsNarration({ prev: "healthy", curr: "degraded", probes: probes(), network: "testnet", muted: false }).post).toBe(false);
+    expect(decideOpsNarration({ prev: "degraded", curr: "healthy", probes: probes(), network: "testnet", muted: false }).post).toBe(false);
+  });
+
+  it("narrates entering red and names the lead red probe", () => {
+    const d = decideOpsNarration({ prev: "degraded", curr: "red", probes: probes({ money_path: "red" }), network: "mainnet", muted: false });
+    expect(d.post).toBe(true);
+    expect(d.edge).toBe("red");
+    expect(d.text).toContain("Money path red");
+    expect(d.text).toContain("settlements not landing");
+    expect(d.text).toContain("On-call is paged.");
+  });
+
+  it("tones a testnet red as informational, not paging", () => {
+    const d = decideOpsNarration({ prev: "healthy", curr: "red", probes: probes({ money_path: "red" }), network: "testnet", muted: false });
+    expect(d.text).toContain("Testnet — informational.");
+    expect(d.text).not.toContain("paged");
+  });
+
+  it("appends +N when several probes are red", () => {
+    const d = decideOpsNarration({ prev: "healthy", curr: "red", probes: probes({ chain_height: "red", money_path: "red" }), network: "mainnet", muted: false });
+    expect(d.text).toContain("(+1 more)");
+  });
+
+  it("narrates recovery from red", () => {
+    const d = decideOpsNarration({ prev: "red", curr: "degraded", probes: probes(), network: "testnet", muted: false });
+    expect(d.post).toBe(true);
+    expect(d.edge).toBe("recovered");
+    expect(d.text).toContain("Ops recovered");
+    expect(d.text).toContain("degraded");
+  });
+
+  it("stays quiet while red persists (no edge)", () => {
+    expect(decideOpsNarration({ prev: "red", curr: "red", probes: probes({ money_path: "red" }), network: "mainnet", muted: false }).post).toBe(false);
+  });
+
+  it("mute suppresses the post but reports the edge", () => {
+    const d = decideOpsNarration({ prev: "healthy", curr: "red", probes: probes({ money_path: "red" }), network: "mainnet", muted: true });
+    expect(d.post).toBe(false);
+    expect(d.edge).toBe("red");
+    expect(d.suppressed).toBe("muted");
+  });
+});


### PR DESCRIPTION
## Slice 3 of Hermes ops-awareness

Hermes now **comes to you** when ops changes, instead of you watching. The product-health heartbeat posts a co-pilot turn on an overall-status **edge across the red boundary**:

> ⚠ **Ops** — Money path red: 6 stuck, settlements not landing. On-call is paged.
> ✓ **Ops recovered** — product health back to healthy.

## Locked behavior

- **Fires only on an edge** — entered-red (`healthy|degraded → red`) or recovered (`red → healthy|degraded`). Transition-based, so it's **self-deduping** (no repeat while red persists).
- **Silent on** — the boot transition (`unknown → …`, so a restart doesn't spam) and routine `degraded ↔ healthy` moves (those live in the Digest ops line from Slice 1).
- **Mute = quiet everywhere** — respects the operator's server-side mute (`getServerAlertMuteUntilMs`); the state still shows passively in the Digest.
- **Network tunes the wording** — mainnet reds say *"on-call is paged"*, testnet reds are *"informational"*. So it's useful on testnet now, appropriately loud on mainnet.
- **Rides the existing infra** — piggybacks on the 2-min heartbeat + the collaboration thread (`recordCollaborationMessage({author:"hermes"})`). No new timer, no new channel, and no auto-reply loop (auto-reply only fires on *operator* messages).

## Structure

- New pure **`ops-narration.ts` → `decideOpsNarration(prev, curr, probes, network, muted)`** — no I/O, no `@avg` deps, so it runs in the local unit suite.
- Wired into `checkProductHealth` (index.ts): tracks `prevProductHealthStatus`, posts on an edge.

## Out of scope (later)
Per-probe escalation (1 red → 2 red while already red), narrating degradations, LLM-enriched phrasing.

## Verification
- **8 decision tests green** (boot skip, degraded-skip, entered-red naming + `+N`, testnet-informational, recovery, red-persists silence, mute-suppress-but-report-edge).
- slack-operator `tsc` adds **zero errors** over the pre-existing `@avg` subpath baseline (25 → 25); CI fresh-build authoritative.