### PR TITLE
feat(monitor): ops remediation suggestions — Hermes proposes, you approve

### DIFF
--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import type { ReactNode } from "react";
-import { cleanup, render, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
 import { SWRConfig } from "swr";
 import { CoPilotRail } from "./CoPilotRail.js";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
-import { OPS_FIXTURE_LIVE } from "../../lib/monitor/ops-fixtures.js";
+import { OPS_FIXTURE_LIVE, OPS_FIXTURE_RED } from "../../lib/monitor/ops-fixtures.js";
 
 afterEach(cleanup);
 
@@ -55,5 +55,20 @@ describe("PR-D3d — rail Hermes digest", () => {
   test("no ops line when product health is absent (rail stays delivery-only)", () => {
     const { container } = render(<CoPilotRail boardCards={[]} collaboration={{ enabled: false }} />, { wrapper });
     expect(container.querySelector(".hm-rail-ops")).toBeNull();
+  });
+
+  test("ops suggestions box: informational rows + a human-gated Propose task button", () => {
+    const onCreateTask = vi.fn();
+    const { container } = render(
+      <CoPilotRail boardCards={[]} collaboration={{ enabled: false }} productHealth={OPS_FIXTURE_RED} onCreateTask={onCreateTask} />,
+      { wrapper },
+    );
+    const box = container.querySelector(".hm-rail-ops-sugg") as HTMLElement;
+    expect(box).toBeTruthy();
+    expect(box.textContent).toContain("Signer USDC below floor");
+    const propose = within(box).getByText("Propose task");
+    fireEvent.click(propose);
+    expect(onCreateTask).toHaveBeenCalledTimes(1);
+    expect(onCreateTask.mock.calls[0][0].repo).toContain("averray-reference-agent");
   });
 });

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.tsx
@@ -20,6 +20,7 @@ import { derivePresence, activeCount, type PresencePeer } from "../../lib/monito
 import { railDigestCounts } from "../../lib/monitor/rail-digest.js";
 import { isDecision } from "../../lib/monitor/lane-rules.js";
 import { opsDigestSummary } from "../../lib/monitor/ops-digest.js";
+import { opsSuggestions } from "../../lib/monitor/ops-suggestions.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { shortId } from "../../lib/monitor/card-id.js";
 import { AgentTag, Badge, Button, EmptyState, StatusPill, type AgentTagAgent, type StateVariant } from "../ui.js";
@@ -179,6 +180,7 @@ export function CoPilotRail({
             <RailDigest
               cards={boardCards ?? []}
               health={productHealth}
+              onCreateTask={onCreateTask}
               onCardClick={onCardClick}
               onGoRoom={() => setRailTab("room")}
               onOpenRoster={() => setRosterOpen(true)}
@@ -348,12 +350,14 @@ function cardIdForMessage(message: CollaborationMessage, cards: readonly BoardCa
 function RailDigest({
   cards,
   health,
+  onCreateTask,
   onCardClick,
   onGoRoom,
   onOpenRoster,
 }: {
   cards: readonly BoardCard[];
   health?: ProductHealth;
+  onCreateTask?: (input: CreateTaskInput) => void;
   onCardClick?: (id: string) => void;
   onGoRoom: () => void;
   onOpenRoster: () => void;
@@ -375,6 +379,7 @@ function RailDigest({
         </span>
       </div>
       {health ? <RailOpsRow health={health} /> : null}
+      {health ? <RailOpsSuggestions health={health} onCreateTask={onCreateTask} /> : null}
       <div className="hm-rail-digest-stats">
         <DigestStat label="NEEDS YOU" value={needsYou} tone="act" />
         <DigestStat label="RUNNING NOW" value={running} tone="ok" />
@@ -421,6 +426,44 @@ function RailOpsRow({ health }: { health: ProductHealth }) {
       <span className="hm-rail-ops-dot" aria-hidden />
       <span className="hm-rail-ops-label">Ops · {label}</span>
       {detail ? <span className="hm-rail-ops-detail">{detail}</span> : null}
+    </div>
+  );
+}
+
+/**
+ * The Digest's "Ops suggestions" box — remediation Hermes SUGGESTS from the live
+ * probes. Informational rows (e.g. top up the signer — funds are operator-only)
+ * carry no action; actionable rows carry a human-gated "Propose task" button
+ * that proposes the task the operator approves. Hidden when there's nothing to
+ * suggest.
+ */
+function RailOpsSuggestions({
+  health,
+  onCreateTask,
+}: {
+  health: ProductHealth;
+  onCreateTask?: (input: CreateTaskInput) => void;
+}) {
+  const suggestions = opsSuggestions(health);
+  if (suggestions.length === 0) return null;
+  return (
+    <div className="hm-rail-ops-sugg" aria-label="Ops suggestions">
+      <div className="hm-rail-ops-sugg-head">
+        <span className="hm-kicker">Ops suggestions</span>
+      </div>
+      {suggestions.map((suggestion) => (
+        <div key={suggestion.id} className={`hm-rail-ops-sugg-row hm-rail-ops-sugg-row--${suggestion.tone}`}>
+          <span className="hm-rail-ops-dot" aria-hidden />
+          <span className="hm-rail-ops-sugg-text">{suggestion.text}</span>
+          {suggestion.task && onCreateTask ? (
+            <Button variant="secondary" size="sm" onClick={() => suggestion.task && onCreateTask(suggestion.task)}>
+              Propose task
+            </Button>
+          ) : (
+            <span className="hm-rail-ops-sugg-tag">info</span>
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import type { ProductHealth } from "./product-health.js";
+import { opsSuggestions } from "./ops-suggestions.js";
+import { OPS_FIXTURE_LIVE, OPS_FIXTURE_RED } from "./ops-fixtures.js";
+
+describe("opsSuggestions", () => {
+  test("red board → signer-below-floor (informational) + money-path (proposed task)", () => {
+    const byId = Object.fromEntries(opsSuggestions(OPS_FIXTURE_RED).map((s) => [s.id, s]));
+    expect(byId["signer-floor"]).toBeTruthy();
+    expect(byId["signer-floor"].task).toBeUndefined(); // funds = operator-only, never a task
+    expect(byId["money-stuck"]).toBeTruthy();
+    expect(byId["money-stuck"].tone).toBe("act");
+    expect(byId["money-stuck"].task?.prompt).toContain("money path");
+    expect(byId["money-stuck"].task?.repo).toContain("averray-reference-agent");
+  });
+
+  test("live board → chain-frozen (informational); awaiting probes produce nothing", () => {
+    const suggestions = opsSuggestions(OPS_FIXTURE_LIVE);
+    const ids = suggestions.map((s) => s.id);
+    expect(ids).toContain("chain-frozen");
+    expect(ids).not.toContain("money-stuck"); // money_path is awaiting-data → skipped
+    expect(ids).not.toContain("signer-floor"); // signer healthy in the live fixture
+    expect(suggestions.find((s) => s.id === "chain-frozen")?.task).toBeUndefined();
+  });
+
+  test("healthy / off / empty → no suggestions", () => {
+    expect(
+      opsSuggestions({
+        enabled: true,
+        at: 1,
+        status: "healthy",
+        checks: 5,
+        probes: [{ name: "product_api", status: "ok", detail: "200", sparkline: [] }],
+      }),
+    ).toEqual([]);
+    expect(opsSuggestions({ enabled: false, at: null, status: "unknown", checks: 0, probes: [] })).toEqual([]);
+    expect(opsSuggestions(undefined)).toEqual([]);
+  });
+
+  test("mainnet degraded chain does not get the testnet 'wait it out' suggestion", () => {
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "degraded",
+      checks: 5,
+      network: "mainnet",
+      probes: [{ name: "chain_height", status: "degraded", detail: "not advancing", sparkline: [] }],
+    };
+    expect(opsSuggestions(health).find((s) => s.id === "chain-frozen")).toBeUndefined();
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -1,0 +1,79 @@
+// Ops remediation suggestions — pure derivation from product health for the
+// co-pilot's "Ops suggestions" box.
+//
+// Hermes SUGGESTS, never executes. Two kinds:
+//   - informational (no task): anything the operator must do themselves —
+//     especially anything touching funds (topping up the signer is operator-only).
+//   - actionable (carries a `task`): a human-gated proposed task the operator
+//     approves; a worker then runs it. Hermes never runs it himself.
+//
+// Derived from the probe status + detail (which already carry the human-readable
+// specifics), so it works today without the structured solvency/flow blocks.
+// Awaiting-data probes never produce a suggestion (telemetry, not an incident).
+
+import type { ProductHealth } from "./product-health.js";
+import type { CreateTaskInput } from "./card-types.js";
+import { isAwaitingProbe } from "./ops-model.js";
+
+export type OpsSuggestionTone = "warn" | "act" | "tel";
+
+export interface OpsSuggestion {
+  id: string;
+  tone: OpsSuggestionTone;
+  text: string;
+  /** Present → render a human-gated "Propose task" button that proposes this. */
+  task?: CreateTaskInput;
+}
+
+// Ops investigations start in the monitor/reference-agent repo; the operator can
+// re-route to the product on the approval gate.
+const OPS_INVESTIGATE_REPO = "depre-dev/averray-reference-agent";
+
+export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion[] {
+  if (!health || !health.enabled || health.checks === 0) return [];
+  const byName = new Map(health.probes.map((probe) => [probe.name, probe] as const));
+  const out: OpsSuggestion[] = [];
+
+  const signer = byName.get("signer_liquidity");
+  if (signer && !isAwaitingProbe(signer) && (signer.status === "red" || /below floor/i.test(signer.detail))) {
+    out.push({
+      id: "signer-floor",
+      tone: signer.status === "red" ? "act" : "warn",
+      text: "Signer USDC below floor — top up before the next payout.",
+    });
+  }
+
+  const money = byName.get("money_path");
+  if (money && !isAwaitingProbe(money) && (money.status === "red" || money.status === "degraded")) {
+    out.push({
+      id: "money-stuck",
+      tone: money.status === "red" ? "act" : "warn",
+      text: `Money path — ${money.detail}`,
+      task: {
+        agent: "claude",
+        repo: OPS_INVESTIGATE_REPO,
+        prompt: `Investigate the live product money path. Health probe: ${money.detail}. Trace the stuck/failed settlements and propose a fix.`,
+      },
+    });
+  }
+
+  const chain = byName.get("chain_height");
+  if (chain && !isAwaitingProbe(chain) && chain.status === "degraded" && health.network !== "mainnet") {
+    out.push({
+      id: "chain-frozen",
+      tone: "tel",
+      text: "Chain not advancing — testnet reset, wait it out.",
+    });
+  }
+
+  const caps = byName.get("capabilities");
+  if (caps && !isAwaitingProbe(caps) && caps.status === "degraded") {
+    out.push({
+      id: "capabilities",
+      tone: "warn",
+      text: `Capabilities — ${caps.detail}. Check config.`,
+    });
+  }
+
+  return out;
+}

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -459,3 +459,36 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ---- co-pilot Digest "Ops suggestions" box (Hermes suggests; you approve) ---- */
+.hm-rail-ops-sugg {
+  margin: 9px 0 2px;
+  background: var(--h4-paper);
+  border: 1px solid var(--h4-act-line);
+  border-radius: var(--h4-r-card);
+  padding: 9px 11px;
+}
+.hm-rail-ops-sugg-head { margin-bottom: 7px; }
+.hm-rail-ops-sugg-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 6px 0;
+  border-top: 1px solid var(--h4-line-2);
+  --tone: var(--h4-tel);
+}
+.hm-rail-ops-sugg-row:first-of-type { border-top: 0; }
+.hm-rail-ops-sugg-row--warn { --tone: var(--h4-warn); }
+.hm-rail-ops-sugg-row--act { --tone: var(--h4-act); }
+.hm-rail-ops-sugg-row--tel { --tone: var(--h4-tel); }
+.hm-rail-ops-sugg-row .hm-rail-ops-dot { background: var(--tone); }
+.hm-rail-ops-sugg-text { flex: 1; font-size: 12px; color: var(--h4-ink-2); line-height: 1.35; min-width: 0; }
+.hm-rail-ops-sugg-tag {
+  font-size: 10.5px;
+  color: var(--h4-muted);
+  background: var(--h4-paper-sunken);
+  border: 1px solid var(--h4-line);
+  border-radius: var(--h4-r-pill);
+  padding: 2px 8px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Slice 4 of Hermes ops-awareness (final)

An **"Ops suggestions" box** in the co-pilot Digest — right under the ops line — surfaces remediation Hermes derives from the live probes. This is Option A from the approved mockup.

**The boundary you set: Hermes suggests, never executes.**
- **Informational** rows (no button) — anything the operator must do, especially funds: *"Signer USDC below floor → top up before the next payout"*, *"chain not advancing → testnet reset, wait it out"*.
- **Actionable** rows — a human-gated **`Propose task`** button that proposes the remediation task (`onCreateTask` → the operator approves → a worker runs it). Hermes never runs it himself, and there's no new authority.

## Behavior
- **Derived from probe status + detail** (`opsSuggestions()`) — works today without the structured solvency/flow blocks (#128); the probe `detail` already carries the specifics.
- **Awaiting-data probes never suggest** (telemetry, not an incident).
- **Hidden entirely** when there's nothing to suggest (a healthy board shows no box).
- Rendered in `RailDigest` alongside the Slice 1 ops line + reuses the existing backlog-suggestion visual pattern.

## Verification
- `tsc` clean · **774 tests** (opsSuggestions rules — signer-floor is informational/no-task, money-path carries a proposed task, awaiting/healthy/off produce nothing, mainnet skips the testnet "wait" note; plus the CoPilotRail test that the `Propose task` button calls `onCreateTask`) · `vite build` green.

## The Hermes ops-awareness arc (all four slices)
1. Digest ops line · 2. ops-aware answers (#508, merged) · 3. proactive narration (#509) · **4. remediation suggestions (this).**