### PR TITLE
fix(monitor): treat "does not expose … yet" as awaiting, not a degradation

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-model.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-model.test.ts
@@ -43,6 +43,14 @@ describe("awaiting vs degraded tone", () => {
     expect(probeOpsTone(p)).toBe("awaiting");
   });
 
+  test("catches the live product's forward-compat wordings, not just 'awaiting'", () => {
+    // Live money_path phrases it "does not expose … yet"; treasury "not exposed
+    // by /health yet" — both must read as awaiting (grey), never amber degraded.
+    expect(isAwaitingProbe(probe("money_path", "degraded", "product /health does not expose settlement counts yet"))).toBe(true);
+    expect(isAwaitingProbe(probe("treasury_liquidity", "degraded", "treasury addresses not exposed by /health yet"))).toBe(true);
+    expect(isAwaitingProbe(probe("x", "degraded", "not wired yet"))).toBe(true);
+  });
+
   test("a genuine degradation stays degraded", () => {
     const p = probe("chain_height", "degraded", "chain not advancing — last block 3d 20h old");
     expect(isAwaitingProbe(p)).toBe(false);

--- a/packages/monitor-ui/src/lib/monitor/ops-model.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-model.ts
@@ -23,7 +23,10 @@ import { OPS_PILLARS, OPS_PILLAR_LABELS, probePillar } from "./product-health.js
  */
 export type OpsTone = "ok" | "degraded" | "red" | "awaiting";
 
-const AWAITING_RE = /awaiting|not exposed|not configured|unconfigured|no data/i;
+// Catches the product's forward-compat phrasings: "awaiting …", "not exposed
+// [by /health] yet", "does not expose … yet", "not wired yet", etc. `not expose`
+// (no trailing d) matches both "not exposed" and "does not expose".
+const AWAITING_RE = /awaiting|not expose|not wired|not configured|unconfigured|no data/i;
 
 /** A probe whose degraded status is really "upstream data not wired yet". */
 export function isAwaitingProbe(probe: { status: ProbeStatus; detail: string }): boolean {


### PR DESCRIPTION
## Live bug spotted on monitor.averray.com

The Ops-awareness features all deployed and work — but the co-pilot **Ops suggestions** box showed a false positive:

> ● Money path — product /health does not expose settlement counts yet  `[ Propose task ]`

That's an **awaiting-data** state (the product `/health` doesn't expose settlement counts yet, #128), not an incident — so proposing an "investigate stuck settlements" task is wrong. Meanwhile *Treasury* (*"not exposed by /health yet"*) correctly greyed out.

**Cause:** `AWAITING_RE` matched `not exposed` (past tense, Treasury's wording) but not the money_path wording `does not expose`.

**Fix:** broaden to `not expose` (matches both "not exposed" and "does not expose") + `not wired`. One line; flows through everywhere `isAwaitingProbe` is used — `ProbeGrid`, `opsDigestSummary`, `opsSuggestions`, `pillarStatuses`, `opsBannerData` — so money_path now reads grey (awaiting) with no suggestion, and the Flow pillar chip greys out too.

## Verification
- new `ops-model` test asserts the live money_path + treasury + "not wired" wordings all read as awaiting
- **775 tests** · `tsc` clean · `vite build` green