### PR TITLE
feat(monitor): structured product-health blocks — chainId/network/solvency/flow (#128 Slice A)

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -166,6 +166,7 @@ import {
   runProductHealthOnce,
   type ChainAdvance,
   type ProductHealthSnapshot,
+  type ProductHealthSnapshotBlocks,
 } from "./product-health.js";
 import {
   readFreshCardFailureAnalysis,
@@ -260,6 +261,8 @@ const PRODUCT_HEALTH_HISTORY_MAX = 60;
 let productHealthHistory: ProductHealthSnapshot[] = [];
 // Block-advance tracker so a frozen chain (static height) isn't read as green.
 let productHealthChainAdvance: ChainAdvance | undefined;
+// Structured snapshot blocks (chain id / network / solvency / flow) for the Ops board.
+let productHealthSnapshotBlocks: ProductHealthSnapshotBlocks | undefined;
 
 /** The settlement signer's address, derived from the key the monitor already holds
  *  (AGENT_WALLET_PRIVATE_KEY) so signer_liquidity needs no duplicated config. A
@@ -712,6 +715,10 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         detail: p.detail,
         sparkline: probeSparkline(productHealthHistory, p.name, 30),
       })),
+      // Structured Ops-board blocks (chain id / network / solvency / flow),
+      // emitted only when their data is actually available — else absent (the
+      // frontend renders honest awaiting-data).
+      ...(productHealthSnapshotBlocks ?? {}),
     });
     return;
   }
@@ -3439,6 +3446,7 @@ function startOperatorRoutines() {
         nowMs: Date.now(),
       });
       productHealthChainAdvance = collection.chainAdvance;
+      productHealthSnapshotBlocks = collection.snapshot;
       const result = await runProductHealthOnce({
         runProbes: async () => collection.probes,
         alert: (payload) => alertChannel.dispatch(payload),

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -547,7 +547,7 @@ export async function probeSignerLiquidity(input: {
   minGasNative: number;
   minUsdc: number;
   fetchImpl: typeof fetch;
-}): Promise<ProbeResult> {
+}): Promise<ProbeResult & { pools?: SolvencyPoolData[] }> {
   if (!input.rpcUrl || !input.signerAddress) {
     return {
       name: "signer_liquidity",
@@ -569,6 +569,7 @@ export async function probeSignerLiquidity(input: {
       parts.push(gasPart);
     }
 
+    let usdc: number | undefined;
     if (input.usdcAddress) {
       const usdcRaw = await ethRpc(
         input.rpcUrl,
@@ -576,7 +577,7 @@ export async function probeSignerLiquidity(input: {
         [{ to: input.usdcAddress, data: encodeBalanceOf(input.signerAddress) }, "latest"],
         input.fetchImpl,
       );
-      const usdc = Number(BigInt(usdcRaw || "0x0")) / 10 ** input.usdcDecimals;
+      usdc = Number(BigInt(usdcRaw || "0x0")) / 10 ** input.usdcDecimals;
       const usdcPart = `USDC ${usdc.toFixed(2)}`;
       if (input.minUsdc > 0 && usdc < input.minUsdc) {
         red = true;
@@ -586,7 +587,28 @@ export async function probeSignerLiquidity(input: {
       }
     }
 
-    return { name: "signer_liquidity", status: red ? "red" : "ok", detail: parts.join(", ") };
+    const pools: SolvencyPoolData[] = [
+      {
+        key: "signer_gas",
+        label: "Signer gas",
+        amount: gasNative,
+        unit: "PAS",
+        floor: input.minGasNative > 0 ? input.minGasNative : null,
+        status: input.minGasNative > 0 && gasNative < input.minGasNative ? "red" : "ok",
+      },
+    ];
+    if (usdc !== undefined) {
+      pools.push({
+        key: "signer_usdc",
+        label: "Signer USDC",
+        amount: usdc,
+        unit: "USDC",
+        floor: input.minUsdc > 0 ? input.minUsdc : null,
+        status: input.minUsdc > 0 && usdc < input.minUsdc ? "red" : "ok",
+      });
+    }
+
+    return { name: "signer_liquidity", status: red ? "red" : "ok", detail: parts.join(", "), pools };
   } catch (err) {
     return { name: "signer_liquidity", status: "degraded", detail: `balance read failed: ${errMsg(err)}` };
   }
@@ -605,7 +627,7 @@ export async function probeTreasuryLiquidity(input: {
   minAac: number;
   rpcUrl?: string;
   fetchImpl: typeof fetch;
-}): Promise<ProbeResult> {
+}): Promise<ProbeResult & { pools?: SolvencyPoolData[] }> {
   const name = "treasury_liquidity";
   const a = input.addresses;
   if (!a || !a.token) return { name, status: "degraded", detail: "treasury addresses not exposed by /health yet" };
@@ -637,8 +659,19 @@ export async function probeTreasuryLiquidity(input: {
     withFloor("reserve", reserve, input.minTreasuryReserve);
     withFloor("AAC", aac, input.minAac);
     if (escrow !== undefined) parts.push(`escrow ${escrow.toFixed(2)}`); // in-flight — informational, no floor
+
+    const pools: SolvencyPoolData[] = [];
+    const pool = (key: string, label: string, val: number | undefined, floor: number): void => {
+      if (val === undefined) return;
+      pools.push({ key, label, amount: val, unit: "USDC", floor: floor > 0 ? floor : null, status: floor > 0 && val < floor ? "red" : "ok" });
+    };
+    pool("reward_bank", "Reward bank", input.rewardBankLiquid, input.minRewardBank);
+    pool("reserve", "Treasury reserve", reserve, input.minTreasuryReserve);
+    pool("aac", "Agent core", aac, input.minAac);
+    if (escrow !== undefined) pools.push({ key: "escrow", label: "Escrow (in-flight)", amount: escrow, unit: "USDC", status: "ok", informational: true });
+
     if (parts.length === 0) return { name, status: "degraded", detail: "no treasury balances readable" };
-    return { name, status: red ? "red" : "ok", detail: parts.join(", ") };
+    return { name, status: red ? "red" : "ok", detail: parts.join(", "), pools };
   } catch (err) {
     return { name, status: "degraded", detail: `treasury read failed: ${errMsg(err)}` };
   }
@@ -646,10 +679,55 @@ export async function probeTreasuryLiquidity(input: {
 
 // ── Collector: one /health fetch (api + chain) + the direct-RPC balance probe ──
 
+// ── Structured "snapshot" blocks the Ops board consumes forward-compat ──
+// Each is emitted only when its data is actually available: signer solvency is
+// always readable via direct RPC; treasury pools + settlement flow arrive when
+// the product /health exposes addresses + settlement (until then the frontend
+// shows honest awaiting-data, never a fabricated zero).
+
+export interface SolvencyPoolData {
+  key: string;
+  label: string;
+  amount: number | null;
+  unit: string;
+  floor?: number | null;
+  status: ProbeStatus;
+  informational?: boolean;
+}
+export interface SolvencySnapshotData {
+  pools: SolvencyPoolData[];
+  runwayNote?: string | null;
+}
+export interface MoneyPathData {
+  settled24h?: number | null;
+  stuck?: number | null;
+  failed24h?: number | null;
+  asOf?: number | null;
+}
+export interface ProductHealthSnapshotBlocks {
+  chainId?: number | null;
+  network?: "testnet" | "mainnet" | "unknown";
+  solvency?: SolvencySnapshotData;
+  flow?: MoneyPathData;
+}
+
+function resolveProductHealthNetwork(chainId: number | undefined): "testnet" | "mainnet" | "unknown" {
+  if (chainId === undefined) return "unknown";
+  return MAINNET_CHAIN_IDS.has(chainId) ? "mainnet" : "testnet";
+}
+
+function parseHealthAsOf(asOf: string | undefined): number | null {
+  if (!asOf) return null;
+  const t = Date.parse(asOf);
+  return Number.isNaN(t) ? null : t;
+}
+
 export interface ProductHealthCollection {
   probes: ProbeResult[];
   /** Updated block-advance tracker — the caller persists it across ticks. */
   chainAdvance: ChainAdvance;
+  /** Structured blocks for the Ops board (chain id / network / solvency / flow). */
+  snapshot: ProductHealthSnapshotBlocks;
 }
 
 /** Absolute age (seconds) of the chain's latest block via the direct RPC — but
@@ -722,6 +800,23 @@ export async function collectProductHealthProbes(
     rpcUrl: config.rpcUrl,
     fetchImpl,
   });
+  const solvencyPools = [...(signer.pools ?? []), ...(treasury.pools ?? [])];
+  const settlement = h.body?.settlement;
+  const snapshot: ProductHealthSnapshotBlocks = {
+    chainId: chainId ?? null,
+    network: resolveProductHealthNetwork(chainId),
+    ...(solvencyPools.length ? { solvency: { pools: solvencyPools } } : {}),
+    ...(settlement
+      ? {
+          flow: {
+            settled24h: settlement.settled24h ?? null,
+            stuck: settlement.stuck ?? null,
+            failed24h: settlement.failed24h ?? null,
+            asOf: parseHealthAsOf(settlement.asOf),
+          },
+        }
+      : {}),
+  };
   return {
     probes: [
       deriveProductApiProbe(h),
@@ -741,6 +836,7 @@ export async function collectProductHealthProbes(
       treasury,
     ],
     chainAdvance,
+    snapshot,
   };
 }
 

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -400,6 +400,15 @@ describe("probeSignerLiquidity (direct RPC)", () => {
     expect(r.detail).toContain("USDC 10.00");
   });
 
+  it("exposes structured signer pools (gas + USDC) for the Ops board", async () => {
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0x989680") });
+    expect(r.pools?.map((p) => p.key)).toEqual(["signer_gas", "signer_usdc"]);
+    const usdc = r.pools?.find((p) => p.key === "signer_usdc");
+    expect(usdc?.amount).toBe(10);
+    expect(usdc?.unit).toBe("USDC");
+    expect(usdc?.floor).toBe(5);
+  });
+
   it("red when native gas is below the floor", async () => {
     const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: balances("0x2386F26FC10000", "0x989680") });
     expect(r.status).toBe("red");
@@ -436,6 +445,15 @@ describe("probeTreasuryLiquidity (direct RPC + /health rewardBank)", () => {
     expect(r.status).toBe("ok");
     expect(r.detail).toContain("reward 100.00");
     expect(r.detail).toContain("escrow 10.00");
+  });
+
+  it("exposes structured treasury pools (reward / reserve / aac / escrow-informational)", async () => {
+    const r = await probeTreasuryLiquidity({ ...base, rewardBankLiquid: 100, fetchImpl: balances("0x0", "0x989680") });
+    const byKey = Object.fromEntries((r.pools ?? []).map((p) => [p.key, p]));
+    expect(byKey.reward_bank.amount).toBe(100);
+    expect(byKey.reserve.amount).toBe(10);
+    expect(byKey.escrow.informational).toBe(true);
+    expect(byKey.escrow.floor).toBeUndefined();
   });
 
   it("red when the treasury reserve is below its floor", async () => {
@@ -507,6 +525,35 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
   it("returns an updated chain-advance tracker for the caller to persist", async () => {
     const { chainAdvance } = await collectProductHealthProbes(cfg(), combinedFetch({ healthBody: HEALTHY_BODY, gasHex: "0x1", usdcHex: "0x1" }), { advance: undefined, nowMs: 1000 });
     expect(chainAdvance).toEqual({ lastBlock: 10612201, lastAdvanceAtMs: 1000 });
+  });
+
+  it("assembles the structured snapshot: chainId / network / solvency, and flow when settlement is present", async () => {
+    const { snapshot } = await collectProductHealthProbes(
+      cfg(),
+      combinedFetch({
+        healthBody: { ...HEALTHY_BODY, settlement: { settled24h: 37, stuck: 1, failed24h: 0, asOf: "2026-07-05T00:00:00.000Z" } },
+        chainIdHex: CHAIN_ID_HEX,
+        blockTimestampHex: tsHex(10_000_000, 12),
+        gasHex: "0xDE0B6B3A7640000",
+        usdcHex: "0x989680",
+      }),
+      { nowMs: 10_000_000 },
+    );
+    expect(snapshot.chainId).toBe(420420417);
+    expect(snapshot.network).toBe("testnet");
+    expect(snapshot.solvency?.pools.some((p) => p.key === "signer_usdc" && p.amount === 10)).toBe(true);
+    expect(snapshot.flow?.settled24h).toBe(37);
+    expect(snapshot.flow?.stuck).toBe(1);
+  });
+
+  it("omits the flow block when the product /health exposes no settlement (honest awaiting)", async () => {
+    const { snapshot } = await collectProductHealthProbes(
+      cfg(),
+      combinedFetch({ healthBody: { ...HEALTHY_BODY, settlement: undefined }, gasHex: "0x1", usdcHex: "0x1" }),
+      { nowMs: 1000 },
+    );
+    expect(snapshot.flow).toBeUndefined();
+    expect(snapshot.network).toBe("testnet");
   });
 });
 


### PR DESCRIPTION
## #128 Slice A — structured snapshot blocks

Turns the Ops board's grey zones real by surfacing data the collector **already computes** but only stringified. The frontend already consumes these blocks forward-compat (optional `chainId`/`network`/`solvency`/`flow` on `ProductHealth`), so this is purely backend.

- `probeSignerLiquidity` / `probeTreasuryLiquidity` now also return `pools` — gas / USDC / reward / reserve / AAC / escrow, each with amount, floor, and per-pool status.
- `collectProductHealthProbes` assembles a `snapshot` `{ chainId, network, solvency, flow }`. **Each block is emitted only when its data is actually available** — signer solvency is always readable via direct RPC; treasury pools + `flow` arrive when the product `/health` exposes `addresses` + `settlement`, else **absent** so the frontend renders honest awaiting-data (never a fabricated zero).
- `index.ts` stores the snapshot and spreads it into `GET /monitor/product-health`.

### What lights up on deploy
- **Now:** the Ops board chain badge (`chain 420420417`), the network-aware hero banner, and the **signer** rows in Solvency & runway (real, direct-RPC).
- **When Codex's `/health` catches up** (currently *"addresses not exposed"* / *"does not expose settlement counts"*): the treasury-pool rows + the settlement funnel — no further monitor change.

## Verification
- **81 product-health tests** (new: structured signer pools, treasury pools + informational escrow, collector snapshot chainId/network/solvency, `flow` present-when-settlement + omitted-when-absent).
- slack-operator `tsc` adds **zero errors** over the pre-existing `@avg` subpath baseline (25 → 25); CI fresh-build authoritative.

## Next
**Slice B** — the history ring buffer (uptime% / latency / balance series + incident episodes) → lights up **Trends** and **Incidents**.