### PR TITLE
feat(monitor): product-health history block — Trends + Incidents (#128 Slice B)

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -160,6 +160,7 @@ import { runFailureAnalysisOnce } from "./failure-analysis-routine.js";
 import {
   appendHistory,
   collectProductHealthProbes,
+  deriveProductHealthHistory,
   initialProductHealthAlertState,
   loadProductHealthConfig,
   probeSparkline,
@@ -719,6 +720,10 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       // emitted only when their data is actually available — else absent (the
       // frontend renders honest awaiting-data).
       ...(productHealthSnapshotBlocks ?? {}),
+      // History-derived Trends + Incidents (uptime% / latency / balance series +
+      // incident episodes) from the rolling buffer. Always present — the series
+      // are honestly short and uptimePct24h is null until a check lands in-window.
+      history: deriveProductHealthHistory(productHealthHistory, Date.now()),
     });
     return;
   }
@@ -3460,9 +3465,19 @@ function startOperatorRoutines() {
         },
         cooldownMs: routineConfig.productHealth.cooldownMs,
       });
+      // Enrich each entry with the samples the Trends zone graphs: the /health
+      // round-trip latency and the signer USDC balance (from the solvency block).
+      const signerUsdcSample =
+        collection.snapshot.solvency?.pools.find((p) => p.key === "signer_usdc")?.amount ?? null;
       productHealthHistory = appendHistory(
         productHealthHistory,
-        { at: Date.now(), status: result.status, probes: result.evaluation.probes },
+        {
+          at: Date.now(),
+          status: result.status,
+          probes: result.evaluation.probes,
+          latencyMs: collection.latencyMs ?? null,
+          signerUsdc: signerUsdcSample,
+        },
         PRODUCT_HEALTH_HISTORY_MAX,
       );
       // Slice 3: proactive ops narration — Hermes posts a co-pilot turn on a

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -66,6 +66,10 @@ export interface ProductHealthSnapshot {
   at: number;
   status: ProductHealthStatus;
   probes: ProbeResult[];
+  /** GET /health round-trip latency (ms) for this check — Trends latency series. */
+  latencyMs?: number | null;
+  /** Signer USDC balance at this check — Trends balance series. */
+  signerUsdc?: number | null;
 }
 
 /** Append a snapshot to a bounded rolling history (oldest→newest). Pure. */
@@ -90,6 +94,114 @@ export function probeSparkline(
     if (hit) series.push(hit.status);
   }
   return bins > 0 && series.length > bins ? series.slice(series.length - bins) : series;
+}
+
+// ── History-derived Ops blocks (Trends + Incidents) ──
+
+/** Mirrors the frontend's awaiting regex (ops-model `AWAITING_RE`): a degraded
+ *  probe whose detail is really "upstream data not wired yet". Excluded from
+ *  incidents so a forward-compat gap never masquerades as a live degradation. */
+const AWAITING_DETAIL_RE = /awaiting|not expose|not wired|not configured|unconfigured|no data/i;
+
+function isAwaitingDetail(status: ProbeStatus, detail: string): boolean {
+  return status !== "red" && AWAITING_DETAIL_RE.test(detail);
+}
+
+export interface ProductHealthIncident {
+  id: string;
+  probe: string;
+  severity: "degraded" | "red";
+  /** Epoch ms of the first check in the run. */
+  startedAt: number;
+  /** Epoch ms of recovery; null → still ongoing. */
+  endedAt?: number | null;
+  /** The probe's detail at the tail of the run — the incident description. */
+  note?: string;
+}
+
+export interface ProductHealthHistoryBlock {
+  /** Share of trailing-24h checks that were NOT red, 0..100; null under-window. */
+  uptimePct24h: number | null;
+  /** Per-check overall tone (oldest→newest), bounded to `maxSeries`. */
+  uptimeSeries: ProbeStatus[];
+  latencySeriesMs: (number | null)[];
+  balanceSeries: (number | null)[];
+  incidents: ProductHealthIncident[];
+}
+
+/** Overall check status → probe tone for the uptime sparkline. */
+function overallTone(status: ProductHealthStatus): ProbeStatus {
+  return status === "healthy" ? "ok" : status;
+}
+
+/**
+ * Derive the Ops Trends + Incidents block from the rolling history. Pure — the
+ * caller passes `nowMs`. The series are newest-anchored to `maxSeries` bins; the
+ * uptime% is over the trailing `uptimeWindowMs` and counts "not red" as up (a
+ * degraded product still serves; only red is a page-worthy outage).
+ */
+export function deriveProductHealthHistory(
+  history: ReadonlyArray<ProductHealthSnapshot>,
+  nowMs: number,
+  opts: { maxSeries?: number; uptimeWindowMs?: number } = {},
+): ProductHealthHistoryBlock {
+  const maxSeries = opts.maxSeries ?? 48;
+  const uptimeWindowMs = opts.uptimeWindowMs ?? 24 * 60 * 60 * 1000;
+  const series =
+    maxSeries > 0 && history.length > maxSeries ? history.slice(history.length - maxSeries) : history;
+
+  const windowStart = nowMs - uptimeWindowMs;
+  const inWindow = history.filter((s) => s.at >= windowStart);
+  const uptimePct24h =
+    inWindow.length > 0
+      ? Math.round((inWindow.filter((s) => s.status !== "red").length / inWindow.length) * 1000) / 10
+      : null;
+
+  return {
+    uptimePct24h,
+    uptimeSeries: series.map((s) => overallTone(s.status)),
+    latencySeriesMs: series.map((s) => s.latencyMs ?? null),
+    balanceSeries: series.map((s) => s.signerUsdc ?? null),
+    incidents: deriveIncidents(history),
+  };
+}
+
+/** Contiguous degraded/red runs per probe → incident episodes (newest-first,
+ *  capped). Awaiting-data degradations are excluded — a forward-compat gap is
+ *  not an incident. An unrecovered run stays open (`endedAt: null`). */
+function deriveIncidents(history: ReadonlyArray<ProductHealthSnapshot>): ProductHealthIncident[] {
+  const names: string[] = [];
+  for (const snap of history) {
+    for (const p of snap.probes) if (!names.includes(p.name)) names.push(p.name);
+  }
+  const incidents: ProductHealthIncident[] = [];
+  for (const name of names) {
+    let startedAt: number | null = null;
+    let severity: "degraded" | "red" = "degraded";
+    let note = "";
+    for (const snap of history) {
+      const probe = snap.probes.find((p) => p.name === name);
+      const bad =
+        !!probe &&
+        (probe.status === "red" ||
+          (probe.status === "degraded" && !isAwaitingDetail(probe.status, probe.detail)));
+      if (bad) {
+        if (startedAt === null) {
+          startedAt = snap.at;
+          severity = "degraded";
+        }
+        if (probe!.status === "red") severity = "red";
+        note = probe!.detail;
+      } else if (startedAt !== null) {
+        incidents.push({ id: `${name}-${startedAt}`, probe: name, severity, startedAt, endedAt: snap.at, note });
+        startedAt = null;
+      }
+    }
+    if (startedAt !== null) {
+      incidents.push({ id: `${name}-${startedAt}`, probe: name, severity, startedAt, endedAt: null, note });
+    }
+  }
+  return incidents.sort((a, b) => b.startedAt - a.startedAt).slice(0, 12);
 }
 
 // ── Config (env-driven; balances stay degraded until their RPC/USDC keys are set) ──
@@ -728,6 +840,8 @@ export interface ProductHealthCollection {
   chainAdvance: ChainAdvance;
   /** Structured blocks for the Ops board (chain id / network / solvency / flow). */
   snapshot: ProductHealthSnapshotBlocks;
+  /** GET /health round-trip latency (ms) — the caller records it on the history entry. */
+  latencyMs?: number;
 }
 
 /** Absolute age (seconds) of the chain's latest block via the direct RPC — but
@@ -837,6 +951,7 @@ export async function collectProductHealthProbes(
     ],
     chainAdvance,
     snapshot,
+    latencyMs: h.latencyMs,
   };
 }
 

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -22,6 +22,7 @@ import {
   networkEthRpc,
   appendHistory,
   probeSparkline,
+  deriveProductHealthHistory,
   type ProbeResult,
   type ProductHealthConfig,
   type ProductHealthFetch,
@@ -760,5 +761,119 @@ describe("probeSparkline", () => {
 
   it("returns empty for an unknown probe", () => {
     expect(probeSparkline(history, "nope", 10)).toEqual([]);
+  });
+});
+
+describe("deriveProductHealthHistory", () => {
+  const HOUR = 3_600_000;
+  const snap = (
+    at: number,
+    status: ProductHealthStatus,
+    opts: { probes?: ProbeResult[]; latencyMs?: number | null; signerUsdc?: number | null } = {},
+  ): ProductHealthSnapshot => ({
+    at,
+    status,
+    probes: opts.probes ?? [probe("product_api", status === "healthy" ? "ok" : status)],
+    latencyMs: opts.latencyMs,
+    signerUsdc: opts.signerUsdc,
+  });
+
+  it("builds the uptime / latency / balance series oldest→newest", () => {
+    const now = 100 * HOUR;
+    const history = [
+      snap(now - 2 * HOUR, "healthy", { latencyMs: 120, signerUsdc: 10 }),
+      snap(now - 1 * HOUR, "degraded", { latencyMs: 240, signerUsdc: 8 }),
+      snap(now, "red", { latencyMs: null, signerUsdc: null }),
+    ];
+    const b = deriveProductHealthHistory(history, now);
+    expect(b.uptimeSeries).toEqual(["ok", "degraded", "red"]);
+    expect(b.latencySeriesMs).toEqual([120, 240, null]);
+    expect(b.balanceSeries).toEqual([10, 8, null]);
+  });
+
+  it("uptimePct24h counts non-red checks; null when nothing is in-window", () => {
+    const now = 100 * HOUR;
+    // 4 checks in the last 24h: 3 non-red (healthy/degraded/healthy), 1 red → 75.0
+    const history = [
+      snap(now - 3 * HOUR, "healthy"),
+      snap(now - 2 * HOUR, "degraded"),
+      snap(now - 1 * HOUR, "red"),
+      snap(now, "healthy"),
+    ];
+    expect(deriveProductHealthHistory(history, now).uptimePct24h).toBe(75);
+    // a check older than the 24h window doesn't count → null
+    const stale = [snap(now - 30 * HOUR, "healthy")];
+    expect(deriveProductHealthHistory(stale, now).uptimePct24h).toBeNull();
+  });
+
+  it("bounds the series to maxSeries (newest-anchored); uptime% still spans the window", () => {
+    const now = 100 * HOUR;
+    const history = Array.from({ length: 60 }, (_, i) =>
+      snap(now - (60 - i) * 60_000, "healthy", { latencyMs: i }),
+    );
+    const b = deriveProductHealthHistory(history, now, { maxSeries: 10 });
+    expect(b.uptimeSeries).toHaveLength(10);
+    expect(b.latencySeriesMs).toEqual(Array.from({ length: 10 }, (_, i) => 50 + i));
+    expect(b.uptimePct24h).toBe(100); // all 60 in-window, none red
+  });
+
+  it("derives an incident episode — red severity wins, unrecovered stays open", () => {
+    const now = 100 * HOUR;
+    const history = [
+      snap(now - 4 * HOUR, "healthy", { probes: [probe("chain_height", "ok")] }),
+      snap(now - 3 * HOUR, "degraded", { probes: [probe("chain_height", "degraded", "chain not advancing")] }),
+      snap(now - 2 * HOUR, "red", { probes: [probe("chain_height", "red", "chain halted")] }),
+      snap(now - 1 * HOUR, "red", { probes: [probe("chain_height", "red", "chain halted")] }),
+    ];
+    const inc = deriveProductHealthHistory(history, now).incidents;
+    expect(inc).toHaveLength(1);
+    expect(inc[0]).toMatchObject({
+      probe: "chain_height",
+      severity: "red",
+      startedAt: now - 3 * HOUR,
+      endedAt: null,
+      note: "chain halted",
+    });
+  });
+
+  it("closes an incident on recovery and excludes awaiting-data degradations", () => {
+    const now = 100 * HOUR;
+    const history = [
+      // a real degradation that recovers
+      snap(now - 4 * HOUR, "degraded", { probes: [probe("api_latency", "degraded", "slow: 900ms")] }),
+      snap(now - 3 * HOUR, "healthy", { probes: [probe("api_latency", "ok")] }),
+      // an awaiting-data "degraded" (forward-compat gap) must NOT become an incident
+      snap(now - 2 * HOUR, "degraded", { probes: [probe("money_path", "degraded", "does not expose settlement counts yet")] }),
+      snap(now - 1 * HOUR, "degraded", { probes: [probe("money_path", "degraded", "does not expose settlement counts yet")] }),
+    ];
+    const inc = deriveProductHealthHistory(history, now).incidents;
+    expect(inc).toHaveLength(1);
+    expect(inc[0]).toMatchObject({
+      probe: "api_latency",
+      severity: "degraded",
+      startedAt: now - 4 * HOUR,
+      endedAt: now - 3 * HOUR,
+    });
+  });
+
+  it("sorts multiple incidents newest-first", () => {
+    const now = 100 * HOUR;
+    const history = [
+      snap(now - 5 * HOUR, "red", { probes: [probe("product_api", "red", "503")] }),
+      snap(now - 4 * HOUR, "healthy", { probes: [probe("product_api", "ok")] }),
+      snap(now - 2 * HOUR, "degraded", { probes: [probe("chain_height", "degraded", "chain not advancing")] }),
+      snap(now - 1 * HOUR, "degraded", { probes: [probe("chain_height", "degraded", "chain not advancing")] }),
+    ];
+    const inc = deriveProductHealthHistory(history, now).incidents;
+    expect(inc.map((i) => i.probe)).toEqual(["chain_height", "product_api"]);
+  });
+
+  it("no history → empty series, null uptime, no incidents", () => {
+    const b = deriveProductHealthHistory([], 100 * HOUR);
+    expect(b.uptimeSeries).toEqual([]);
+    expect(b.latencySeriesMs).toEqual([]);
+    expect(b.balanceSeries).toEqual([]);
+    expect(b.uptimePct24h).toBeNull();
+    expect(b.incidents).toEqual([]);
   });
 });


### PR DESCRIPTION
## #128 Slice B — history ring buffer → Trends + Incidents

Completes #128. Turns the Ops board's grey **Trends** and **Incidents** zones real by *deriving* over the samples the heartbeat already polls — no new data source. Stacks on #512 (Slice A), already in `main`.

- Each history entry now records the `/health` round-trip **latencyMs** and the **signer USDC** balance (lifted from Slice A's solvency block) alongside `status` + `probes`.
- **`deriveProductHealthHistory(history, nowMs)`** (pure) emits `{ uptimePct24h, uptimeSeries, latencySeriesMs, balanceSeries, incidents }`:
  - **uptime%** over the trailing 24h counts *"not red"* as up — a degraded product still serves; only red is a page-worthy outage — and is `null` until a check lands in-window.
  - series are newest-anchored to `maxSeries` bins, oldest→newest.
  - **incidents** = contiguous degraded/red runs per probe → `{ severity (red wins), startedAt, endedAt|null=ongoing, note }`. **Awaiting-data degradations are excluded** (same regex as the frontend `ops-model`) so a forward-compat gap never masquerades as a live incident.
- `index.ts` records the two new samples on each append and emits `history` from `GET /monitor/product-health` — **always present** (series honestly short, uptime `null` under-window; the frontend renders awaiting-data gracefully).

### Wiring is end-to-end
The frontend `ProductHealth` already carries `history?: HealthHistory` forward-compat, and `useProductHealth`'s fetcher returns the raw payload straight through → **Trends + Incidents light up on deploy with zero frontend change.**

## Verification
- **88 product-health tests** (7 new: series build, uptime% window + null, `maxSeries` bound, incident severity/ongoing, recovery-close + awaiting-exclusion, newest-first sort, empty history).
- slack-operator `tsc` unchanged at the pre-existing `@avg` subpath baseline (25 → 25); CI fresh-build authoritative.

## After merge
Redeploy `slack-operator`, then the Ops board's **Trends** (uptime% + latency/balance sparklines) and **Incidents** (episode list with durations) go live — plus Slice A's chain badge + signer Solvency. #128 done.