### PR TITLE
feat(monitor): liquidity runway + pre-floor alert

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -48,4 +48,65 @@ describe("opsSuggestions", () => {
     };
     expect(opsSuggestions(health).find((s) => s.id === "chain-frozen")).toBeUndefined();
   });
+
+  test("runway projection → proactive pre-floor suggestion carrying a PREPARE task", () => {
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "degraded",
+      checks: 10,
+      probes: [{ name: "signer_liquidity", status: "ok", detail: "gas 4999.99, USDC 3.00", sparkline: [] }],
+      solvency: {
+        pools: [],
+        runway: [
+          { key: "signer_gas", label: "signer gas", unit: "PAS", current: 4999, floor: 1, burnPerHour: null, hoursToFloor: null, estimable: true, status: "ok" },
+          { key: "signer_usdc", label: "signer USDC", unit: "USDC", current: 3, floor: 1, burnPerHour: 0.4, hoursToFloor: 5, estimable: true, status: "red" },
+        ],
+      },
+    };
+    const byId = Object.fromEntries(opsSuggestions(health).map((s) => [s.id, s]));
+    expect(byId["signer-runway"]).toBeTruthy();
+    expect(byId["signer-runway"].tone).toBe("act"); // red projection
+    expect(byId["signer-runway"].text).toContain("signer USDC ~5h to floor");
+    expect(byId["signer-runway"].task?.prompt).toContain("PREPARE ONLY");
+    expect(byId["signer-runway"].task?.prompt).toContain("do NOT move funds");
+    expect(byId["signer-runway"].task?.repo).toContain("averray-reference-agent");
+    expect(byId["signer-floor"]).toBeUndefined(); // signer probe is healthy → no at-floor item
+  });
+
+  test("runway at floor (0h) does not double up — signer-floor owns the at-floor case", () => {
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "red",
+      checks: 10,
+      probes: [{ name: "signer_liquidity", status: "red", detail: "USDC 1.00 below floor 1.00", sparkline: [] }],
+      solvency: {
+        pools: [],
+        runway: [
+          { key: "signer_usdc", label: "signer USDC", unit: "USDC", current: 1, floor: 1, burnPerHour: 0.4, hoursToFloor: 0, estimable: true, status: "red" },
+        ],
+      },
+    };
+    const byId = Object.fromEntries(opsSuggestions(health).map((s) => [s.id, s]));
+    expect(byId["signer-floor"]).toBeTruthy(); // probe below floor
+    expect(byId["signer-runway"]).toBeUndefined(); // hoursToFloor 0 excluded from the proactive one
+  });
+
+  test("stable / awaiting runway → no proactive suggestion", () => {
+    const health: ProductHealth = {
+      enabled: true,
+      at: 1,
+      status: "healthy",
+      checks: 10,
+      probes: [{ name: "signer_liquidity", status: "ok", detail: "USDC 3.00", sparkline: [] }],
+      solvency: {
+        pools: [],
+        runway: [
+          { key: "signer_usdc", label: "signer USDC", unit: "USDC", current: 3, floor: 1, burnPerHour: 0, hoursToFloor: null, estimable: true, status: "ok" },
+        ],
+      },
+    };
+    expect(opsSuggestions(health).find((s) => s.id === "signer-runway")).toBeUndefined();
+  });
 });

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -29,6 +29,13 @@ export interface OpsSuggestion {
 // re-route to the product on the approval gate.
 const OPS_INVESTIGATE_REPO = "depre-dev/averray-reference-agent";
 
+/** Compact runway ETA for the suggestion text: "~6h", "~2d". */
+function runwayEta(hoursToFloor: number): string {
+  if (hoursToFloor <= 0) return "at floor";
+  if (hoursToFloor < 48) return `~${Math.round(hoursToFloor)}h`;
+  return `~${Math.round(hoursToFloor / 24)}d`;
+}
+
 export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion[] {
   if (!health || !health.enabled || health.checks === 0) return [];
   const byName = new Map(health.probes.map((probe) => [probe.name, probe] as const));
@@ -40,6 +47,30 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
       id: "signer-floor",
       tone: signer.status === "red" ? "act" : "warn",
       text: "Signer USDC below floor — top up before the next payout.",
+    });
+  }
+
+  // Proactive pre-floor warning from the runway projection — fires BEFORE the
+  // balance hits the floor (the signer-floor branch above owns the at-floor case,
+  // so we require hoursToFloor > 0). Topping up is operator-only, so the task
+  // PREPARES the fix (compute the amount + draft the steps); it never moves funds.
+  const runwayDanger = (health.solvency?.runway ?? [])
+    .filter((p) => (p.status === "red" || p.status === "degraded") && (p.hoursToFloor ?? 0) > 0)
+    .sort((a, b) => (a.hoursToFloor ?? 0) - (b.hoursToFloor ?? 0));
+  const nearest = runwayDanger[0];
+  if (nearest && nearest.hoursToFloor != null) {
+    const eta = runwayEta(nearest.hoursToFloor);
+    const burn =
+      nearest.burnPerHour != null ? ` (burning ~${nearest.burnPerHour.toFixed(2)} ${nearest.unit}/h)` : "";
+    out.push({
+      id: "signer-runway",
+      tone: nearest.status === "red" ? "act" : "warn",
+      text: `${nearest.label} ${eta} to floor — top up before settlement halts.`,
+      task: {
+        agent: "claude",
+        repo: OPS_INVESTIGATE_REPO,
+        prompt: `Prepare a signer top-up — do NOT move funds, PREPARE ONLY. ${nearest.label} is projected to reach its ${nearest.floor} ${nearest.unit} floor in ${eta} (current ${nearest.current} ${nearest.unit}${burn}). Compute how much ${nearest.unit} to add to reach a safe buffer (target ≈ 5× the floor) and draft the exact top-up steps/command for the operator to review and execute.`,
+      },
     });
   }
 

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -38,6 +38,23 @@ export interface SolvencySnapshot {
   pools: SolvencyPool[];
   /** Honest runway note, e.g. "≈ 6 payouts to floor" or "pending settlement data". */
   runwayNote?: string | null;
+  /** Per-pool time-to-floor projection — drives the pre-floor ops suggestion. */
+  runway?: RunwayPool[];
+}
+
+/** A floored pool's projected liquidity runway (mirrors the backend). */
+export interface RunwayPool {
+  key: string;
+  label: string;
+  unit: string;
+  current: number;
+  floor: number;
+  /** Depletion rate in units/hour; null = flat / refilling / not estimable. */
+  burnPerHour: number | null;
+  /** Hours until the balance hits the floor; null = stable/awaiting; 0 = at floor. */
+  hoursToFloor: number | null;
+  estimable: boolean;
+  status: ProbeStatus;
 }
 
 /** Money-path funnel counts. Any `null` → that step awaits data. */

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -160,6 +160,7 @@ import { runFailureAnalysisOnce } from "./failure-analysis-routine.js";
 import {
   appendHistory,
   collectProductHealthProbes,
+  deriveLiquidityRunway,
   deriveProductHealthHistory,
   initialProductHealthAlertState,
   loadProductHealthConfig,
@@ -3465,10 +3466,12 @@ function startOperatorRoutines() {
         },
         cooldownMs: routineConfig.productHealth.cooldownMs,
       });
-      // Enrich each entry with the samples the Trends zone graphs: the /health
-      // round-trip latency and the signer USDC balance (from the solvency block).
-      const signerUsdcSample =
-        collection.snapshot.solvency?.pools.find((p) => p.key === "signer_usdc")?.amount ?? null;
+      // Enrich each entry with the samples the Trends zone graphs + the runway
+      // projection reads: the /health round-trip latency and the signer USDC / gas
+      // balances (from the solvency block).
+      const signerPools = collection.snapshot.solvency?.pools ?? [];
+      const signerUsdcSample = signerPools.find((p) => p.key === "signer_usdc")?.amount ?? null;
+      const signerGasSample = signerPools.find((p) => p.key === "signer_gas")?.amount ?? null;
       productHealthHistory = appendHistory(
         productHealthHistory,
         {
@@ -3477,9 +3480,22 @@ function startOperatorRoutines() {
           probes: result.evaluation.probes,
           latencyMs: collection.latencyMs ?? null,
           signerUsdc: signerUsdcSample,
+          signerGas: signerGasSample,
         },
         PRODUCT_HEALTH_HISTORY_MAX,
       );
+      // Liquidity runway: project time-to-floor from the balance series (incl. the
+      // sample just appended) and write the honest note into the solvency block —
+      // "signer USDC ≈ 6h to floor" / "stable" / awaiting. Suggest-only: the board
+      // tells the operator when to top up; it never moves funds.
+      if (productHealthSnapshotBlocks?.solvency) {
+        const runway = deriveLiquidityRunway(
+          productHealthHistory,
+          productHealthSnapshotBlocks.solvency.pools,
+          Date.now(),
+        );
+        productHealthSnapshotBlocks.solvency.runwayNote = runway.note;
+      }
       // Slice 3: proactive ops narration — Hermes posts a co-pilot turn on a
       // fresh red / recovery edge (self-deduped by the transition; muted = quiet,
       // the Digest still shows state). Network tunes the wording.

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -159,10 +159,13 @@ import { narrateRouterProposal } from "./monitor-router-narration.js";
 import { runFailureAnalysisOnce } from "./failure-analysis-routine.js";
 import {
   appendHistory,
+  buildRunwayAlertPayload,
   collectProductHealthProbes,
+  decideRunwayAlert,
   deriveLiquidityRunway,
   deriveProductHealthHistory,
   initialProductHealthAlertState,
+  initialRunwayAlertState,
   loadProductHealthConfig,
   probeSparkline,
   runProductHealthOnce,
@@ -3176,6 +3179,7 @@ function startOperatorRoutines() {
   let anomalyPauseRunning = false;
   let productHealthRunning = false;
   let productHealthAlertState = initialProductHealthAlertState();
+  let runwayAlertState = initialRunwayAlertState();
   // Slice 3: previous overall product-health status, so the co-pilot narrates
   // only on an edge across the red boundary (entered-red / recovered).
   let prevProductHealthStatus: OpsStatus = "unknown";
@@ -3495,6 +3499,27 @@ function startOperatorRoutines() {
           Date.now(),
         );
         productHealthSnapshotBlocks.solvency.runwayNote = runway.note;
+        productHealthSnapshotBlocks.solvency.runway = runway.pools;
+        // Pre-floor alert: page the moment a pool's PROJECTED runway crosses into
+        // the danger band — before the balance actually hits the floor. Edge-
+        // triggered + cooldown-deduped so it warns once per crossing, not every
+        // poll. The operator tops up (funds are theirs); the board just warns.
+        const runwayDecision = decideRunwayAlert({
+          runway,
+          state: runwayAlertState,
+          nowMs: Date.now(),
+          cooldownMs: routineConfig.productHealth.cooldownMs,
+        });
+        runwayAlertState = runwayDecision.state;
+        if (runwayDecision.alert) {
+          await alertChannel.dispatch(
+            buildRunwayAlertPayload(
+              runway,
+              optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ??
+                "https://monitor.averray.com/monitor",
+            ),
+          );
+        }
       }
       // Slice 3: proactive ops narration — Hermes posts a co-pilot turn on a
       // fresh red / recovery edge (self-deduped by the transition; muted = quiet,

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -363,6 +363,71 @@ function summariseRunway(pools: ReadonlyArray<LiquidityRunwayPool>): string | nu
   return pools.some((p) => p.estimable) ? "stable — no depletion trend" : null;
 }
 
+// ── Pre-floor runway alert (edge-triggered; mirrors decideProductHealthAlert) ──
+
+export interface RunwayAlertState {
+  /** The danger-set key at the previous alert ("" when last clear). */
+  lastDangerKey: string;
+  lastAlertAtMs: number;
+}
+
+export function initialRunwayAlertState(): RunwayAlertState {
+  return { lastDangerKey: "", lastAlertAtMs: 0 };
+}
+
+/** The danger set: floored pools projected into the warn/page band, keyed by
+ *  pool:status so a worsening (degraded→red) counts as a new edge. Empty = safe. */
+function runwayDangerKey(runway: LiquidityRunway): string {
+  return runway.pools
+    .filter((p) => p.status === "red" || p.status === "degraded")
+    .map((p) => `${p.key}:${p.status}`)
+    .sort()
+    .join(",");
+}
+
+/**
+ * Fire a pre-floor alert on the rising edge into the danger band (or a worsening
+ * within it), then re-fire only after the cooldown while it persists — so the
+ * operator hears about a projected floor BEFORE it halts settlement, without a
+ * page every poll. Clears (no alert) once every pool is out of the band.
+ */
+export function decideRunwayAlert(input: {
+  runway: LiquidityRunway;
+  state: RunwayAlertState;
+  nowMs: number;
+  cooldownMs: number;
+}): { alert: boolean; state: RunwayAlertState } {
+  const key = runwayDangerKey(input.runway);
+  if (key === "") {
+    return { alert: false, state: { lastDangerKey: "", lastAlertAtMs: input.state.lastAlertAtMs } };
+  }
+  const changed = key !== input.state.lastDangerKey;
+  const cooldownElapsed =
+    input.cooldownMs > 0 && input.nowMs - input.state.lastAlertAtMs >= input.cooldownMs;
+  if (changed || cooldownElapsed) {
+    return { alert: true, state: { lastDangerKey: key, lastAlertAtMs: input.nowMs } };
+  }
+  return { alert: false, state: { ...input.state, lastDangerKey: key } };
+}
+
+/** Build the D4 alert payload for the pools in the danger band (nearest-first). */
+export function buildRunwayAlertPayload(runway: LiquidityRunway, boardUrl: string): AlertPayload {
+  const danger = runway.pools
+    .filter((p) => p.status === "red" || p.status === "degraded")
+    .sort((a, b) => (a.hoursToFloor ?? 0) - (b.hoursToFloor ?? 0));
+  const items = danger.map((p) => ({
+    id: `runway-${p.key}`,
+    title: `${p.label} — ${formatRunwayHours(p.hoursToFloor ?? 0)}`,
+  }));
+  const lead = danger.length ? `${danger[0].label} ${formatRunwayHours(danger[0].hoursToFloor ?? 0)}` : "";
+  return {
+    count: danger.length,
+    items,
+    boardUrl,
+    text: `Liquidity runway — ${lead}. Top up before settlement halts (operator action).`,
+  };
+}
+
 // ── Config (env-driven; balances stay degraded until their RPC/USDC keys are set) ──
 
 export interface ProductHealthConfig {
@@ -968,6 +1033,8 @@ export interface SolvencyPoolData {
 export interface SolvencySnapshotData {
   pools: SolvencyPoolData[];
   runwayNote?: string | null;
+  /** Per-pool time-to-floor projection — drives the pre-floor ops suggestion. */
+  runway?: LiquidityRunwayPool[];
 }
 export interface MoneyPathData {
   settled24h?: number | null;

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -68,8 +68,10 @@ export interface ProductHealthSnapshot {
   probes: ProbeResult[];
   /** GET /health round-trip latency (ms) for this check — Trends latency series. */
   latencyMs?: number | null;
-  /** Signer USDC balance at this check — Trends balance series. */
+  /** Signer USDC balance at this check — Trends balance series + USDC runway. */
   signerUsdc?: number | null;
+  /** Signer native-gas balance at this check — gas runway (matters on mainnet). */
+  signerGas?: number | null;
 }
 
 /** Append a snapshot to a bounded rolling history (oldest→newest). Pure. */
@@ -202,6 +204,163 @@ function deriveIncidents(history: ReadonlyArray<ProductHealthSnapshot>): Product
     }
   }
   return incidents.sort((a, b) => b.startedAt - a.startedAt).slice(0, 12);
+}
+
+// ── Liquidity runway (projects time-to-floor from the balance series) ──
+
+/** Per-pool balance accessor into a history entry — only the live signer pools
+ *  carry a stored series; treasury pools are forward-compat (no series yet). */
+const RUNWAY_SERIES: Record<string, (s: ProductHealthSnapshot) => number | null | undefined> = {
+  signer_gas: (s) => s.signerGas,
+  signer_usdc: (s) => s.signerUsdc,
+};
+
+export interface LiquidityRunwayPool {
+  key: string;
+  label: string;
+  unit: string;
+  current: number;
+  floor: number;
+  /** Depletion rate in units/hour; null = flat, refilling, or not estimable. */
+  burnPerHour: number | null;
+  /** Projected hours until the balance hits the floor; null = stable / refilling
+   *  / awaiting samples; 0 = already at or below the floor. */
+  hoursToFloor: number | null;
+  /** Did we have enough data to project? false = awaiting samples (not "stable"). */
+  estimable: boolean;
+  status: ProbeStatus;
+}
+
+export interface LiquidityRunway {
+  pools: LiquidityRunwayPool[];
+  /** Honest one-line summary of the nearest pool — feeds SolvencySnapshot.runwayNote. */
+  note: string | null;
+}
+
+export interface LiquidityRunwayOptions {
+  /** Trailing window the burn rate is fit over (default 6h). */
+  windowMs?: number;
+  /** Minimum non-null samples needed to project (default 3). */
+  minSamples?: number;
+  /** Minimum elapsed span across those samples (default 15m) — rejects a burst. */
+  minSpanMs?: number;
+  /** A projection beyond this is treated as "stable" — rejects noise (default 240h). */
+  stableCapHours?: number;
+  /** hoursToFloor ≤ this ⇒ degraded (default 24h). */
+  warnHours?: number;
+  /** hoursToFloor ≤ this ⇒ red (default 6h). */
+  redHours?: number;
+}
+
+/** Least-squares slope of value-vs-time (units per ms); null if undetermined. */
+function seriesSlopePerMs(samples: ReadonlyArray<{ t: number; v: number }>): number | null {
+  const n = samples.length;
+  if (n < 2) return null;
+  let sumT = 0;
+  let sumV = 0;
+  for (const s of samples) {
+    sumT += s.t;
+    sumV += s.v;
+  }
+  const meanT = sumT / n;
+  const meanV = sumV / n;
+  let num = 0;
+  let den = 0;
+  for (const s of samples) {
+    const dt = s.t - meanT;
+    num += dt * (s.v - meanV);
+    den += dt * dt;
+  }
+  return den === 0 ? null : num / den;
+}
+
+function formatRunwayHours(hours: number): string {
+  if (hours <= 0) return "at floor";
+  if (hours < 1) return `~${Math.max(1, Math.round(hours * 60))}m to floor`;
+  if (hours < 48) return `~${Math.round(hours)}h to floor`;
+  return `~${Math.round(hours / 24)}d to floor`;
+}
+
+/**
+ * Project liquidity runway for each floored signer pool from its balance series.
+ * Pure — the caller passes `nowMs`. Honest by construction: too few samples / too
+ * short a span read as "awaiting"; a flat or refilling trend, or a projection past
+ * `stableCapHours`, reads as "stable" — never a fabricated countdown off sensor
+ * noise. Only floored, live signer pools (with a stored series) get a runway;
+ * informational + forward-compat treasury pools are skipped.
+ */
+export function deriveLiquidityRunway(
+  history: ReadonlyArray<ProductHealthSnapshot>,
+  pools: ReadonlyArray<SolvencyPoolData>,
+  nowMs: number,
+  opts: LiquidityRunwayOptions = {},
+): LiquidityRunway {
+  const windowMs = opts.windowMs ?? 6 * 60 * 60 * 1000;
+  const minSamples = opts.minSamples ?? 3;
+  const minSpanMs = opts.minSpanMs ?? 15 * 60 * 1000;
+  const stableCapHours = opts.stableCapHours ?? 240;
+  const warnHours = opts.warnHours ?? 24;
+  const redHours = opts.redHours ?? 6;
+  const windowStart = nowMs - windowMs;
+
+  const out: LiquidityRunwayPool[] = [];
+  for (const pool of pools) {
+    const accessor = RUNWAY_SERIES[pool.key];
+    if (!accessor || pool.informational || pool.amount == null || pool.floor == null || pool.floor <= 0) {
+      continue;
+    }
+    const current = pool.amount;
+    const floor = pool.floor;
+    const mk = (
+      extra: Pick<LiquidityRunwayPool, "burnPerHour" | "hoursToFloor" | "estimable" | "status">,
+    ): LiquidityRunwayPool => ({ key: pool.key, label: pool.label, unit: pool.unit, current, floor, ...extra });
+
+    // Already at/below floor — the balance probe owns the red; runway is 0.
+    if (current <= floor) {
+      out.push(mk({ burnPerHour: null, hoursToFloor: 0, estimable: true, status: "red" }));
+      continue;
+    }
+    const samples: { t: number; v: number }[] = [];
+    for (const snap of history) {
+      if (snap.at < windowStart) continue;
+      const v = accessor(snap);
+      if (typeof v === "number" && Number.isFinite(v)) samples.push({ t: snap.at, v });
+    }
+    const spanMs = samples.length ? samples[samples.length - 1].t - samples[0].t : 0;
+    if (samples.length < minSamples || spanMs < minSpanMs) {
+      out.push(mk({ burnPerHour: null, hoursToFloor: null, estimable: false, status: "ok" }));
+      continue;
+    }
+    const slope = seriesSlopePerMs(samples);
+    const burnPerHour = slope == null ? null : -slope * 3_600_000; // +ve = depleting
+    if (burnPerHour == null || burnPerHour <= 0) {
+      out.push(mk({ burnPerHour, hoursToFloor: null, estimable: true, status: "ok" })); // stable / refilling
+      continue;
+    }
+    const hoursToFloor = (current - floor) / burnPerHour;
+    if (hoursToFloor > stableCapHours) {
+      out.push(mk({ burnPerHour, hoursToFloor: null, estimable: true, status: "ok" })); // effectively stable
+      continue;
+    }
+    const status: ProbeStatus = hoursToFloor <= redHours ? "red" : hoursToFloor <= warnHours ? "degraded" : "ok";
+    out.push(mk({ burnPerHour, hoursToFloor, estimable: true, status }));
+  }
+
+  return { pools: out, note: summariseRunway(out) };
+}
+
+/** The honest one-liner: the nearest depleting pool, else stable, else awaiting. */
+function summariseRunway(pools: ReadonlyArray<LiquidityRunwayPool>): string | null {
+  const trending = pools
+    .filter((p) => p.hoursToFloor != null)
+    .sort((a, b) => (a.hoursToFloor as number) - (b.hoursToFloor as number));
+  if (trending.length) {
+    const p = trending[0];
+    return `${p.label} ${formatRunwayHours(p.hoursToFloor as number)}`;
+  }
+  // Enough data but no downward trend → a real, honest "stable". No estimable
+  // pool at all → null (awaiting) so the board shows its awaiting-data line.
+  return pools.some((p) => p.estimable) ? "stable — no depletion trend" : null;
 }
 
 // ── Config (env-driven; balances stay degraded until their RPC/USDC keys are set) ──

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -23,7 +23,9 @@ import {
   appendHistory,
   probeSparkline,
   deriveProductHealthHistory,
+  deriveLiquidityRunway,
   type ProbeResult,
+  type SolvencyPoolData,
   type ProductHealthConfig,
   type ProductHealthFetch,
   type ProductHealthPayload,
@@ -875,5 +877,97 @@ describe("deriveProductHealthHistory", () => {
     expect(b.balanceSeries).toEqual([]);
     expect(b.uptimePct24h).toBeNull();
     expect(b.incidents).toEqual([]);
+  });
+});
+
+describe("deriveLiquidityRunway", () => {
+  const HOUR = 3_600_000;
+  const bal = (at: number, usdc: number | null, gas: number | null = null): ProductHealthSnapshot => ({
+    at,
+    status: "healthy",
+    probes: [],
+    signerUsdc: usdc,
+    signerGas: gas,
+  });
+  const usdcPool = (amount: number | null, floor: number | null = 1): SolvencyPoolData => ({
+    key: "signer_usdc",
+    label: "signer USDC",
+    amount,
+    unit: "USDC",
+    floor,
+    status: "ok",
+  });
+
+  it("projects a countdown from a steady drain (degraded band)", () => {
+    const now = 6 * HOUR;
+    // 19 → 13 over 6h = 1 USDC/h; floor 1 ⇒ (13-1)/1 = 12h ⇒ degraded
+    const history = Array.from({ length: 7 }, (_, i) => bal(i * HOUR, 19 - i));
+    const r = deriveLiquidityRunway(history, [usdcPool(13)], now);
+    expect(r.pools).toHaveLength(1);
+    expect(r.pools[0].burnPerHour).toBeCloseTo(1, 6);
+    expect(r.pools[0].hoursToFloor).toBeCloseTo(12, 6);
+    expect(r.pools[0].status).toBe("degraded");
+    expect(r.note).toBe("signer USDC ~12h to floor");
+  });
+
+  it("pages (red) when the floor is < 6h out", () => {
+    const now = 6 * HOUR;
+    // 13 → 5 over 4h = 2/h; current 5, floor 1 ⇒ (5-1)/2 = 2h ⇒ red
+    const history = [bal(2 * HOUR, 13), bal(3 * HOUR, 11), bal(4 * HOUR, 9), bal(5 * HOUR, 7), bal(6 * HOUR, 5)];
+    const r = deriveLiquidityRunway(history, [usdcPool(5)], now);
+    expect(r.pools[0].hoursToFloor).toBeCloseTo(2, 6);
+    expect(r.pools[0].status).toBe("red");
+    expect(r.note).toBe("signer USDC ~2h to floor");
+  });
+
+  it("reads stable — not a fake countdown — when the balance is flat", () => {
+    const now = 6 * HOUR;
+    const history = Array.from({ length: 7 }, (_, i) => bal(i * HOUR, 5));
+    const r = deriveLiquidityRunway(history, [usdcPool(5)], now);
+    expect(r.pools[0].hoursToFloor).toBeNull();
+    expect(r.pools[0].estimable).toBe(true);
+    expect(r.pools[0].status).toBe("ok");
+    expect(r.note).toBe("stable — no depletion trend");
+  });
+
+  it("reads stable when the balance is refilling (rising)", () => {
+    const now = 6 * HOUR;
+    const history = Array.from({ length: 7 }, (_, i) => bal(i * HOUR, 3 + i));
+    const r = deriveLiquidityRunway(history, [usdcPool(9)], now);
+    expect(r.pools[0].hoursToFloor).toBeNull();
+    expect(r.pools[0].burnPerHour ?? 0).toBeLessThanOrEqual(0);
+    expect(r.note).toBe("stable — no depletion trend");
+  });
+
+  it("awaits samples (not stable) when there is too little data", () => {
+    const now = 6 * HOUR;
+    const history = [bal(5 * HOUR, 8), bal(6 * HOUR, 7)]; // 2 samples < min 3
+    const r = deriveLiquidityRunway(history, [usdcPool(7)], now);
+    expect(r.pools[0].estimable).toBe(false);
+    expect(r.pools[0].hoursToFloor).toBeNull();
+    expect(r.note).toBeNull(); // no estimable pool ⇒ frontend shows awaiting-data
+  });
+
+  it("reports 0h at/below the floor regardless of trend", () => {
+    const now = 6 * HOUR;
+    const history = Array.from({ length: 7 }, (_, i) => bal(i * HOUR, 1));
+    const r = deriveLiquidityRunway(history, [usdcPool(1, 1)], now); // current == floor
+    expect(r.pools[0].hoursToFloor).toBe(0);
+    expect(r.pools[0].status).toBe("red");
+    expect(r.note).toBe("signer USDC at floor");
+  });
+
+  it("skips informational + series-less pools; the nearest depleting pool wins the note", () => {
+    const now = 6 * HOUR;
+    const history = Array.from({ length: 7 }, (_, i) => bal(i * HOUR, 19 - i, 5000)); // gas flat 5000
+    const pools: SolvencyPoolData[] = [
+      { key: "signer_gas", label: "signer gas", amount: 5000, unit: "PAS", floor: 1, status: "ok" }, // stable, kept
+      usdcPool(13), // draining ⇒ 12h
+      { key: "reward_bank", label: "Reward bank", amount: 100, unit: "USDC", floor: 25, status: "ok" }, // no series ⇒ skip
+      { key: "escrow", label: "Escrow", amount: 96, unit: "USDC", status: "ok", informational: true }, // informational ⇒ skip
+    ];
+    const r = deriveLiquidityRunway(history, pools, now);
+    expect(r.pools.map((p) => p.key)).toEqual(["signer_gas", "signer_usdc"]);
+    expect(r.note).toBe("signer USDC ~12h to floor"); // gas is stable ⇒ usdc is the nearest
   });
 });

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -24,8 +24,13 @@ import {
   probeSparkline,
   deriveProductHealthHistory,
   deriveLiquidityRunway,
+  decideRunwayAlert,
+  buildRunwayAlertPayload,
+  initialRunwayAlertState,
   type ProbeResult,
   type SolvencyPoolData,
+  type LiquidityRunway,
+  type LiquidityRunwayPool,
   type ProductHealthConfig,
   type ProductHealthFetch,
   type ProductHealthPayload,
@@ -969,5 +974,84 @@ describe("deriveLiquidityRunway", () => {
     const r = deriveLiquidityRunway(history, pools, now);
     expect(r.pools.map((p) => p.key)).toEqual(["signer_gas", "signer_usdc"]);
     expect(r.note).toBe("signer USDC ~12h to floor"); // gas is stable ⇒ usdc is the nearest
+  });
+});
+
+describe("decideRunwayAlert", () => {
+  const HOUR = 3_600_000;
+  const pool = (key: string, status: ProbeResult["status"], hours: number | null = 5): LiquidityRunwayPool => ({
+    key,
+    label: key,
+    unit: "USDC",
+    current: 3,
+    floor: 1,
+    burnPerHour: 0.4,
+    hoursToFloor: hours,
+    estimable: true,
+    status,
+  });
+  const rw = (...pools: LiquidityRunwayPool[]): LiquidityRunway => ({ pools, note: null });
+
+  it("fires on the rising edge into the danger band, then stays quiet within cooldown", () => {
+    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: initialRunwayAlertState(), nowMs: 1000, cooldownMs: HOUR });
+    expect(first.alert).toBe(true);
+    const again = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: first.state, nowMs: 1000 + 5 * 60_000, cooldownMs: HOUR });
+    expect(again.alert).toBe(false);
+  });
+
+  it("re-fires when the danger worsens (degraded → red) even within cooldown", () => {
+    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const worse = decideRunwayAlert({ runway: rw(pool("signer_usdc", "red", 2)), state: first.state, nowMs: 60_000, cooldownMs: HOUR });
+    expect(worse.alert).toBe(true);
+  });
+
+  it("re-fires after the cooldown while the danger persists", () => {
+    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const later = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: first.state, nowMs: HOUR + 1, cooldownMs: HOUR });
+    expect(later.alert).toBe(true);
+  });
+
+  it("clears (no alert, key reset) once every pool is out of the band", () => {
+    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "red", 2)), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const safe = decideRunwayAlert({ runway: rw(pool("signer_usdc", "ok", null)), state: first.state, nowMs: 60_000, cooldownMs: HOUR });
+    expect(safe.alert).toBe(false);
+    expect(safe.state.lastDangerKey).toBe("");
+  });
+
+  it("stays quiet when nothing is in the danger band", () => {
+    const d = decideRunwayAlert({ runway: rw(pool("signer_usdc", "ok", null), pool("signer_gas", "ok", null)), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    expect(d.alert).toBe(false);
+  });
+});
+
+describe("buildRunwayAlertPayload", () => {
+  const pool = (key: string, status: ProbeResult["status"], hours: number): LiquidityRunwayPool => ({
+    key,
+    label: key === "signer_usdc" ? "signer USDC" : "signer gas",
+    unit: "USDC",
+    current: 3,
+    floor: 1,
+    burnPerHour: 0.4,
+    hoursToFloor: hours,
+    estimable: true,
+    status,
+  });
+
+  it("summarises the danger pools nearest-first with a board link", () => {
+    const runway: LiquidityRunway = { pools: [pool("signer_gas", "degraded", 20), pool("signer_usdc", "red", 3)], note: null };
+    const p = buildRunwayAlertPayload(runway, "https://board");
+    expect(p.count).toBe(2);
+    expect(p.items[0].id).toBe("runway-signer_usdc"); // nearest first
+    expect(p.items[0].title).toContain("~3h to floor");
+    expect(p.boardUrl).toBe("https://board");
+    expect(p.text).toContain("signer USDC ~3h to floor");
+    expect(p.text).toContain("operator action");
+  });
+
+  it("excludes stable pools from the payload", () => {
+    const runway: LiquidityRunway = { pools: [{ ...pool("signer_usdc", "ok", 0), hoursToFloor: null }, pool("signer_gas", "degraded", 10)], note: null };
+    const p = buildRunwayAlertPayload(runway, "https://board");
+    expect(p.count).toBe(1);
+    expect(p.items[0].id).toBe("runway-signer_gas");
   });
 });


### PR DESCRIPTION
## Liquidity runway + pre-floor alert

The everyday fire-drill risk: **signer USDC is at 2.00 against a 1.00 floor, not mintable, no faucet.** If it hits the floor, settlement halts — and today you'd only find out *after*. This projects the runway from the balance series and pages you *before* the floor — all suggest-only (topping up is operator-only; the board never moves funds).

### Slice 1 — runway projection + board note
- Each history entry also records `signerGas` (USDC was already stored).
- **`deriveLiquidityRunway(history, pools, nowMs)`** (pure): least-squares burn rate → hours-to-floor per floored signer pool. Honest by construction — `< 3` samples / `< 15min` span ⇒ **awaiting**; flat / refilling / `> 240h` ⇒ **stable** (never a fake countdown); at/below floor ⇒ **0h**; bands **≤ 6h red · ≤ 24h degraded**.
- Fills `solvency.runwayNote` — *"signer USDC ~6h to floor"* / *"stable — no depletion trend"* / awaiting. The Solvency zone already renders it → **zero frontend change** for the note.

### Slice 2 — the proactive alert + prepare-task
- **`decideRunwayAlert`** — edge-triggered (mirrors `decideProductHealthAlert`): fires on the crossing into the band, re-fires on a worsening (degraded→red) or after cooldown while it persists, clears when safe. One page per crossing, not per poll. Dispatched via the existing D4/Slack channel.
- Emits the structured **`solvency.runway`** (per-pool time-to-floor); the frontend `opsSuggestions` turns it into a proactive **"signer USDC ~6h to floor — top up before settlement halts"** item (pre-floor only — `hoursToFloor > 0`; the at-floor `signer-floor` item is unchanged, no double-up).
- The suggestion carries a **PREPARE task**: a worker computes how much to add to a safe buffer and drafts the exact steps/command for you to review and execute. **"do NOT move funds — PREPARE ONLY"** is in the prompt — Hermes does the homework, never the transfer.

## Safety / truth boundary
Suggest-only throughout: the board tells you *when* and *how much*, and can *prepare* the fix; **it never funds**. A projection off a noisy, deploy-resetting, slow-moving series degrades to awaiting/stable rather than a jumpy number.

## Verification
- **102 backend** product-health tests (14 runway/alert: derivation bands + edge/cooldown/clear + payload) and **778 frontend** tests (incl. 3 new suggestion tests).
- Backend `tsc` unchanged at the `@avg` baseline (25 → 25); frontend `tsc` clean.

## After merge
Redeploy `slack-operator`: the runway note shows on the Solvency zone now; the pre-floor alert + prepare-task suggestion fire the moment signer runway crosses < 24h. (The alert path isn't live-verifiable on the board until a real crossing — testnet USDC is stable — so it's covered by unit tests.)