### PR TITLE
feat(monitor): leading-indicator anomaly flags on the Trends metrics

### DIFF
--- a/packages/monitor-ui/src/components/ops/TrendsZone.test.tsx
+++ b/packages/monitor-ui/src/components/ops/TrendsZone.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { TrendsZone } from "./TrendsZone.js";
+import type { HealthHistory } from "../../lib/monitor/product-health.js";
+
+afterEach(cleanup);
+
+const base = (over: Partial<HealthHistory>): HealthHistory => ({
+  uptimePct24h: 100,
+  uptimeSeries: ["ok", "ok", "ok"],
+  latencySeriesMs: [75, 75, 75],
+  balanceSeries: [10, 10, 10],
+  incidents: [],
+  ...over,
+});
+
+describe("TrendsZone anomaly flags", () => {
+  test("renders a leading-indicator flag when latency spikes off its baseline", () => {
+    const history = base({ latencySeriesMs: [...Array(10).fill(75), 320] });
+    const { getByTestId } = render(<TrendsZone history={history} />);
+    const chip = getByTestId("ops-anomaly-latency");
+    expect(chip.textContent).toMatch(/▲ \d+% vs baseline/);
+    expect(chip.className).toContain("ops-anomaly--warn");
+  });
+
+  test("no flag on a steady series", () => {
+    const history = base({ latencySeriesMs: [75, 76, 75, 74, 75, 76, 75, 74, 75, 76] });
+    const { queryByTestId } = render(<TrendsZone history={history} />);
+    expect(queryByTestId("ops-anomaly-latency")).toBeNull();
+    expect(queryByTestId("ops-anomaly-balance")).toBeNull();
+  });
+
+  test("still renders the awaiting state (no crash) when there's no history", () => {
+    const { getByTestId } = render(<TrendsZone history={undefined} />);
+    expect(getByTestId("ops-trends-awaiting")).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/ops/TrendsZone.tsx
+++ b/packages/monitor-ui/src/components/ops/TrendsZone.tsx
@@ -2,8 +2,14 @@
 // (SVG line), and signer USDC balance (SVG line). All fed by the server-side
 // history store; until that store has data the zone shows an honest accruing
 // state rather than a flat fake line.
+//
+// Each metric also carries a leading-indicator anomaly flag: when the latest
+// sample deviates from the metric's OWN recent baseline (latency spiking, balance
+// draining) beyond a robust threshold, a chip annotates that trend — a heads-up
+// before a fixed floor would trip.
 
 import type { HealthHistory } from "../../lib/monitor/product-health.js";
+import { detectAnomalies, anomalyPhrase, type MetricAnomaly } from "../../lib/monitor/ops-anomaly.js";
 import { OpsZone } from "./OpsZone.js";
 import { OpsSpark, LineSpark } from "./OpsSparks.js";
 
@@ -15,11 +21,26 @@ function hasSeries(values: (number | null)[] | undefined): boolean {
   return Array.isArray(values) && values.filter((v) => typeof v === "number").length >= 2;
 }
 
+function AnomalyChip({ a }: { a: MetricAnomaly | undefined }) {
+  if (!a) return null;
+  return (
+    <span
+      className={`ops-anomaly ops-anomaly--${a.severity}`}
+      data-testid={`ops-anomaly-${a.metric}`}
+      title={`${a.label}: ${a.current} vs ~${a.baseline} baseline · robust z ${a.z}`}
+    >
+      {anomalyPhrase(a)}
+    </span>
+  );
+}
+
 export function TrendsZone({ history }: TrendsZoneProps) {
   const uptime = history?.uptimeSeries ?? [];
   const latency = history?.latencySeriesMs;
   const balance = history?.balanceSeries;
   const anyData = uptime.length > 0 || hasSeries(latency) || hasSeries(balance);
+  const anomalies = detectAnomalies(history);
+  const anomalyOf = (metric: MetricAnomaly["metric"]) => anomalies.find((a) => a.metric === metric);
 
   return (
     <OpsZone className="z-trends" icon="chart" title="Trends" testId="ops-zone-trends">
@@ -48,6 +69,7 @@ export function TrendsZone({ history }: TrendsZoneProps) {
               <span>API latency</span>
               <span className="ops-trend-val">{lastNum(latency)}</span>
             </div>
+            <AnomalyChip a={anomalyOf("latency")} />
             {hasSeries(latency) ? (
               <LineSpark values={latency!} tone="tel" ariaLabel="API latency trend" />
             ) : (
@@ -60,6 +82,7 @@ export function TrendsZone({ history }: TrendsZoneProps) {
               <span>Signer USDC</span>
               <span className="ops-trend-val">{lastNum(balance, "")}</span>
             </div>
+            <AnomalyChip a={anomalyOf("balance")} />
             {hasSeries(balance) ? (
               <LineSpark values={balance!} tone="ok" ariaLabel="Signer USDC balance trend" />
             ) : (

--- a/packages/monitor-ui/src/lib/monitor/ops-anomaly.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-anomaly.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+import { detectAnomalies, anomalyPhrase } from "./ops-anomaly.js";
+import type { HealthHistory } from "./product-health.js";
+
+const hist = (latency?: (number | null)[], balance?: (number | null)[]): HealthHistory => ({
+  latencySeriesMs: latency,
+  balanceSeries: balance,
+});
+
+describe("detectAnomalies", () => {
+  test("flags a latency spike against its own baseline (up, warn)", () => {
+    const a = detectAnomalies(hist([...Array(10).fill(75), 300])).find((x) => x.metric === "latency");
+    expect(a).toBeTruthy();
+    expect(a!.direction).toBe("up");
+    expect(a!.severity).toBe("warn");
+    expect(a!.baseline).toBe(75);
+    expect(a!.current).toBe(300);
+    expect(a!.deviationPct).toBeGreaterThan(200);
+  });
+
+  test("does not flag ordinary latency jitter", () => {
+    expect(detectAnomalies(hist([74, 75, 76, 75, 74, 76, 75, 74, 76, 78]))).toEqual([]);
+  });
+
+  test("flags a signer-balance drain (down)", () => {
+    const a = detectAnomalies(hist(undefined, [...Array(10).fill(10), 6])).find((x) => x.metric === "balance");
+    expect(a).toBeTruthy();
+    expect(a!.direction).toBe("down");
+    expect(a!.deviationPct).toBeLessThan(0);
+  });
+
+  test("ignores the good direction — a latency drop or a balance refill never flags", () => {
+    expect(detectAnomalies(hist([...Array(10).fill(200), 40]))).toEqual([]); // latency improved
+    expect(detectAnomalies(hist(undefined, [...Array(10).fill(5), 12]))).toEqual([]); // balance refilled
+  });
+
+  test("insufficient samples → no flag (never fabricates a signal)", () => {
+    expect(detectAnomalies(hist([75, 400]))).toEqual([]); // 2 samples < min 8
+    expect(detectAnomalies(undefined)).toEqual([]);
+  });
+
+  test("a real but sub-threshold deviation is held back by the min-% bar", () => {
+    // flat baseline 100, current 120 → z ≈ 4 (≥ infoZ) but only 20% (< 25%) → no flag
+    expect(detectAnomalies(hist([...Array(9).fill(100), 120]))).toEqual([]);
+  });
+
+  test("severity: moderate → info, extreme → warn", () => {
+    expect(detectAnomalies(hist([...Array(9).fill(100), 128]))[0].severity).toBe("info"); // ~28%
+    expect(detectAnomalies(hist([...Array(9).fill(100), 300]))[0].severity).toBe("warn"); // 200%
+  });
+
+  test("anomalyPhrase renders a compact arrow + %", () => {
+    const a = detectAnomalies(hist([...Array(10).fill(75), 300]))[0];
+    expect(anomalyPhrase(a)).toMatch(/^▲ \d+% vs baseline$/);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-anomaly.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-anomaly.ts
@@ -1,0 +1,127 @@
+// Leading-indicator anomaly detection — baseline-relative flags over the Trends
+// series. Instead of a fixed floor, each metric is judged against its OWN recent
+// baseline: median + MAD → a robust z-score, so a spike (latency) or a drain
+// (balance) shows up BEFORE it trips a fixed threshold.
+//
+// Honest by construction: too few samples reads as no-signal (never a flag); a
+// flat baseline gets a min-spread floor so ordinary jitter doesn't flag; a
+// deviation only counts in the metric's BAD direction (latency up / balance
+// down); and it must clear both a robust-z and a minimum-% bar. Pure — no time,
+// no DOM — over the history series the payload already carries.
+
+import type { HealthHistory } from "./product-health.js";
+
+export type AnomalyMetric = "latency" | "balance";
+export type AnomalySeverity = "info" | "warn";
+
+export interface MetricAnomaly {
+  metric: AnomalyMetric;
+  label: string;
+  /** "up" = the metric rose, "down" = it fell. Only the metric's bad direction flags. */
+  direction: "up" | "down";
+  current: number;
+  /** Baseline center (median of the prior samples). */
+  baseline: number;
+  /** Signed % deviation of current vs baseline. */
+  deviationPct: number;
+  /** Robust (MAD-based) z-score. */
+  z: number;
+  severity: AnomalySeverity;
+}
+
+export interface AnomalyConfig {
+  /** Total clean samples needed (incl. the current one) before we judge. */
+  minSamples: number;
+  /** Spread floor as a fraction of |median| — tames a flat baseline. */
+  minRelSpread: number;
+  /** |z| ≥ this ⇒ flag (info). */
+  infoZ: number;
+  /** |z| ≥ this ⇒ warn. */
+  warnZ: number;
+  /** |deviation%| must ALSO clear this — no trivial flags. */
+  minPct: number;
+}
+
+const DEFAULTS: AnomalyConfig = { minSamples: 8, minRelSpread: 0.05, infoZ: 3.5, warnZ: 6, minPct: 25 };
+
+function median(xs: number[]): number {
+  if (xs.length === 0) return 0;
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+interface Analysis {
+  current: number;
+  baseline: number;
+  deviationPct: number;
+  z: number;
+  severity: AnomalySeverity;
+}
+
+function analyze(
+  raw: ReadonlyArray<number | null> | undefined,
+  badDir: "up" | "down",
+  cfg: AnomalyConfig,
+): Analysis | null {
+  const clean = (raw ?? []).filter((v): v is number => typeof v === "number" && Number.isFinite(v));
+  if (clean.length < cfg.minSamples) return null; // insufficient → no signal (never a flag)
+  const current = clean[clean.length - 1];
+  const baseline = clean.slice(0, clean.length - 1);
+  const med = median(baseline);
+  const mad = median(baseline.map((v) => Math.abs(v - med)));
+  // 1.4826·MAD ≈ σ for normal data; the relative floor stops a flat baseline from
+  // turning millisecond jitter into an infinite z.
+  const spread = Math.max(1.4826 * mad, cfg.minRelSpread * Math.abs(med), 1e-9);
+  const z = (current - med) / spread;
+  const badward = badDir === "up" ? z > 0 : z < 0;
+  if (!badward) return null;
+  const deviationPct = med !== 0 ? ((current - med) / Math.abs(med)) * 100 : 0;
+  if (Math.abs(z) < cfg.infoZ || Math.abs(deviationPct) < cfg.minPct) return null;
+  return { current, baseline: med, deviationPct, z, severity: Math.abs(z) >= cfg.warnZ ? "warn" : "info" };
+}
+
+const round = (n: number, d = 1): number => Math.round(n * 10 ** d) / 10 ** d;
+
+/** Baseline-relative anomaly flags for the Trends metrics. Pure. */
+export function detectAnomalies(history: HealthHistory | undefined, config?: Partial<AnomalyConfig>): MetricAnomaly[] {
+  if (!history) return [];
+  const cfg = { ...DEFAULTS, ...config };
+  const out: MetricAnomaly[] = [];
+
+  const lat = analyze(history.latencySeriesMs, "up", cfg);
+  if (lat) {
+    out.push({
+      metric: "latency",
+      label: "API latency",
+      direction: "up",
+      current: round(lat.current),
+      baseline: round(lat.baseline),
+      deviationPct: round(lat.deviationPct),
+      z: round(lat.z, 2),
+      severity: lat.severity,
+    });
+  }
+
+  const bal = analyze(history.balanceSeries, "down", cfg);
+  if (bal) {
+    out.push({
+      metric: "balance",
+      label: "Signer USDC",
+      direction: "down",
+      current: round(bal.current, 2),
+      baseline: round(bal.baseline, 2),
+      deviationPct: round(bal.deviationPct),
+      z: round(bal.z, 2),
+      severity: bal.severity,
+    });
+  }
+
+  return out;
+}
+
+/** Compact chip phrase for the Trends flag: "▲ 353% vs baseline" / "▼ 30% vs baseline". */
+export function anomalyPhrase(a: MetricAnomaly): string {
+  const arrow = a.direction === "up" ? "▲" : "▼";
+  return `${arrow} ${Math.abs(Math.round(a.deviationPct))}% vs baseline`;
+}

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -370,6 +370,23 @@
   margin-bottom: 4px;
 }
 .ops-trend-val { color: var(--h4-ink); font-variant-numeric: tabular-nums; }
+
+/* Leading-indicator anomaly flag — a chip above the affected trend line. */
+.ops-anomaly {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 4px;
+  margin: 0 0 4px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  border: 1px solid color-mix(in srgb, currentColor 30%, transparent);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+.ops-anomaly--warn { color: var(--h4-warn); }
+.ops-anomaly--info { color: var(--h4-tel); }
 .ops-trend .ops-spark { display: flex; height: 15px; margin-left: 0; }
 .ops-trend .ops-spark-cell { height: 13px; }
 


### PR DESCRIPTION
## Leading-indicator anomaly flags

Turns the Trends series from fixed-threshold displays into **leading indicators**: each metric is judged against its **own recent baseline**, so a latency spike or a signer-balance drain flags **before** it would trip a fixed floor. **Purely frontend** — the series are already in the payload's `history` block.

### The detector — `detectAnomalies(history)` (pure)
Robust, baseline-relative:
- **median + MAD → a robust z-score** (outlier-resistant, unlike mean/σ).
- Flags **only in the metric's bad direction**: latency **up**, balance **down** (a latency drop or a balance refill never flags).
- Fires when **|z| ≥ 3.5 *and* deviation ≥ 25%** — both bars, so nothing trivial slips through.
- **Honest by construction:** `< 8` samples → no-signal (never a flag); a **flat baseline** gets a min-spread floor (5% of the median) so millisecond jitter doesn't flag; `info` vs `warn` by z magnitude.

### The flag
`TrendsZone` renders a chip above the affected line — **"▲ 353% vs baseline"** (warn = amber, info = telemetry-gray), with `current / baseline / robust-z` in the tooltip.

### Scope
Frontend-only, no backend, **no new alert** — a leading flag is a heads-up on the board, not a page (the #514 runway alert already owns the page-worthy liquidity case). Extensible: latency + signer balance today; more metrics (settlement rate, once Codex exposes it) drop in as one more `analyze()` call.

## Verification
- **789 frontend tests** (11 new: spike / drain / jitter-holds / wrong-direction / insufficient-samples / min-% guard / info-vs-warn severity + the Trends chip render).
- Frontend `tsc` clean.

## Live visibility
Only shows when a metric is actually anomalous — testnet latency is steady ~75 ms, so it won't render on the board today; covered by unit tests until a real spike/drain occurs.