### PR TITLE
feat(monitor): ops auto-remediation Phase 1 — RPC failover (opt-in, gated)

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -174,6 +174,12 @@ import {
   type ProductHealthSnapshotBlocks,
 } from "./product-health.js";
 import {
+  loadRemediationConfig,
+  decideRpcRemediation,
+  initialRpcRemediationState,
+  buildRemediationAlert,
+} from "./ops-remediation.js";
+import {
   readFreshCardFailureAnalysis,
   writeCardFailureAnalysis,
 } from "./operator-card-failure-analysis.js";
@@ -3180,6 +3186,7 @@ function startOperatorRoutines() {
   let productHealthRunning = false;
   let productHealthAlertState = initialProductHealthAlertState();
   let runwayAlertState = initialRunwayAlertState();
+  let rpcRemediationState = initialRpcRemediationState();
   // Slice 3: previous overall product-health status, so the co-pilot narrates
   // only on an edge across the red boundary (entered-red / recovered).
   let prevProductHealthStatus: OpsStatus = "unknown";
@@ -3449,14 +3456,35 @@ function startOperatorRoutines() {
       // Signer address for the balance probe: PRODUCT_HEALTH_SIGNER_ADDRESS or derived
       // from AGENT_WALLET_PRIVATE_KEY (already held). Chain height reads /health.
       const signerAddress = phConfig.signerAddress ?? deriveProductHealthSigner();
+      // Auto-remediation: the direct-RPC read uses the currently-active endpoint
+      // (primary, or a backup we failed over to), never necessarily the configured
+      // primary. Off unless OPS_AUTOREMEDIATE_ENABLED + PRODUCT_HEALTH_RPC_BACKUPS.
+      const remediationConfig = loadRemediationConfig(process.env, phConfig.rpcUrl);
+      const activeRpc = remediationConfig.endpoints[rpcRemediationState.activeIndex] ?? phConfig.rpcUrl;
       // One /health fetch feeds product_api + chain_height; the block-advance tracker
       // persists across ticks to catch a frozen chain. Balances come from direct RPC.
-      const collection = await collectProductHealthProbes({ ...phConfig, signerAddress }, fetch, {
+      const collection = await collectProductHealthProbes({ ...phConfig, signerAddress, rpcUrl: activeRpc }, fetch, {
         advance: productHealthChainAdvance,
         nowMs: Date.now(),
       });
       productHealthChainAdvance = collection.chainAdvance;
       productHealthSnapshotBlocks = collection.snapshot;
+      // Decide + apply RPC auto-remediation from this cycle's read health. Pure
+      // decision; the only effect is rotating which endpoint we read next tick
+      // (state.activeIndex) + dispatching an audit (failover) or page (escalate).
+      const remediation = decideRpcRemediation({
+        rpcHealthy: collection.rpcOk,
+        state: rpcRemediationState,
+        config: remediationConfig,
+        nowMs: Date.now(),
+      });
+      rpcRemediationState = remediation.state;
+      const remediationAlert = buildRemediationAlert(
+        remediation.outcome,
+        optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ??
+          "https://monitor.averray.com/monitor",
+      );
+      if (remediationAlert) await alertChannel.dispatch(remediationAlert);
       const result = await runProductHealthOnce({
         runProbes: async () => collection.probes,
         alert: (payload) => alertChannel.dispatch(payload),

--- a/services/slack-operator/src/ops-remediation.ts
+++ b/services/slack-operator/src/ops-remediation.ts
@@ -1,0 +1,179 @@
+// Ops auto-remediation — the safe, opt-in, allowlisted harness.
+//
+// See docs/OPS_AUTO_REMEDIATION.md. This is the ONE ops capability that acts
+// rather than just suggests, so it is deliberately narrow:
+//   • OFF by default (a dedicated OPS_AUTOREMEDIATE_ENABLED switch).
+//   • ONE allowlisted action in v1 — rpc_failover: rotate the monitor's OWN read
+//     RPC off a flaky/1006 endpoint to a configured backup. Never touches funds,
+//     never touches the product; fully reversible (rotate on).
+//   • Edge-triggered + a circuit-breaker: once every endpoint has been tried and
+//     none work, or the rate cap trips, it STOPS and escalates to a human.
+//   • A verify-loop: the next cycle's RPC health decides resolve vs. escalate.
+//
+// The decision is PURE (decideRpcRemediation) so the whole state machine —
+// gate, flap-guard, failover, breaker, rate-cap, resolve — is deterministic and
+// unit-tested; index.ts owns the effect (rotate the active URL, dispatch alerts).
+
+import type { AlertPayload } from "./alert-bridge.js";
+
+export interface RemediationConfig {
+  /** Master switch. OFF by default — nothing executes unless this is true. */
+  enabled: boolean;
+  /** [primary, ...backups]; failover cycles through these. */
+  endpoints: string[];
+  /** Consecutive unhealthy cycles on the active endpoint before we fail over
+   *  (a flap guard — one hiccup never triggers an action). */
+  failThreshold: number;
+  /** Failovers since the last healthy cycle before the breaker trips + escalates. */
+  maxAttempts: number;
+  /** Max failovers within `windowMs` before the breaker trips (rate cap). */
+  maxPerWindow: number;
+  windowMs: number;
+}
+
+function numEnv(raw: string | undefined, fallback: number): number {
+  const n = Number((raw ?? "").trim());
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/** Build the remediation config from env. `primaryRpc` is the monitor's configured
+ *  read RPC; backups come from PRODUCT_HEALTH_RPC_BACKUPS (csv). */
+export function loadRemediationConfig(
+  env: Record<string, string | undefined>,
+  primaryRpc: string | undefined,
+): RemediationConfig {
+  const backups = (env.PRODUCT_HEALTH_RPC_BACKUPS ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const endpoints = [primaryRpc, ...backups].filter((x): x is string => !!x);
+  return {
+    enabled: (env.OPS_AUTOREMEDIATE_ENABLED ?? "").trim().toLowerCase() === "true",
+    endpoints,
+    failThreshold: numEnv(env.OPS_AUTOREMEDIATE_FAIL_THRESHOLD, 2),
+    maxAttempts: numEnv(env.OPS_AUTOREMEDIATE_MAX_ATTEMPTS, 3),
+    maxPerWindow: numEnv(env.OPS_AUTOREMEDIATE_MAX_PER_WINDOW, 5),
+    windowMs: numEnv(env.OPS_AUTOREMEDIATE_WINDOW_MS, 3_600_000),
+  };
+}
+
+export interface RpcRemediationState {
+  /** Index into config.endpoints we are currently reading from. */
+  activeIndex: number;
+  /** Consecutive unhealthy cycles on the active endpoint. */
+  failStreak: number;
+  /** Failovers performed since the last healthy cycle (breaker budget). */
+  failoversSinceHealthy: number;
+  /** True once the breaker has tripped — we stop acting until health returns. */
+  breakerTripped: boolean;
+  /** Epoch-ms of recent failovers, for the rate cap. */
+  windowActions: number[];
+}
+
+export function initialRpcRemediationState(): RpcRemediationState {
+  return { activeIndex: 0, failStreak: 0, failoversSinceHealthy: 0, breakerTripped: false, windowActions: [] };
+}
+
+export type RpcRemediationOutcome =
+  | { kind: "none" }
+  | { kind: "failover"; from: string; to: string; reason: string }
+  | { kind: "escalate"; reason: string }
+  | { kind: "resolved"; endpoint: string };
+
+/**
+ * Decide the next auto-remediation step from the current RPC health. Pure.
+ *
+ * `rpcHealthy`: true = the active endpoint answered this cycle; false = it failed;
+ * undefined = not judgeable (RPC/​signer not configured) → always `none`.
+ *
+ * Invariants: never acts while disabled; tolerates `failThreshold-1` hiccups;
+ * fails over only to a configured backup; trips the breaker (→ escalate, then goes
+ * quiet) on rate-cap, on exhausting the endpoints, or when there is no backup; and
+ * a healthy cycle after any trouble resolves it (state reset, stays on the endpoint
+ * that is currently working).
+ */
+export function decideRpcRemediation(input: {
+  rpcHealthy: boolean | undefined;
+  state: RpcRemediationState;
+  config: RemediationConfig;
+  nowMs: number;
+}): { outcome: RpcRemediationOutcome; state: RpcRemediationState } {
+  const { state, config, nowMs } = input;
+  if (!config.enabled || input.rpcHealthy === undefined) {
+    return { outcome: { kind: "none" }, state };
+  }
+
+  if (input.rpcHealthy) {
+    if (state.failStreak > 0 || state.failoversSinceHealthy > 0 || state.breakerTripped) {
+      // Reset the per-episode counters + breaker, but KEEP windowActions so the
+      // rate cap still catches an endpoint that flaps (fail over → recover →
+      // fail over …) many times within the window.
+      return {
+        outcome: { kind: "resolved", endpoint: config.endpoints[state.activeIndex] ?? "" },
+        state: { ...state, failStreak: 0, failoversSinceHealthy: 0, breakerTripped: false },
+      };
+    }
+    return { outcome: { kind: "none" }, state };
+  }
+
+  // Unhealthy. Once the breaker is tripped we stay quiet until health returns.
+  if (state.breakerTripped) {
+    return { outcome: { kind: "none" }, state };
+  }
+
+  const failStreak = state.failStreak + 1;
+  if (failStreak < config.failThreshold) {
+    return { outcome: { kind: "none" }, state: { ...state, failStreak } };
+  }
+
+  const trip = (reason: string): { outcome: RpcRemediationOutcome; state: RpcRemediationState } => ({
+    outcome: { kind: "escalate", reason },
+    state: { ...state, failStreak, breakerTripped: true },
+  });
+
+  const window = state.windowActions.filter((t) => nowMs - t < config.windowMs);
+  if (config.endpoints.length <= 1) return trip("no backup RPC endpoint configured");
+  if (window.length >= config.maxPerWindow) return trip(`rate cap — ${window.length} failovers within the window`);
+  if (state.failoversSinceHealthy >= config.maxAttempts) {
+    return trip(`tried ${state.failoversSinceHealthy} endpoints, still failing`);
+  }
+
+  const nextIndex = (state.activeIndex + 1) % config.endpoints.length;
+  return {
+    outcome: {
+      kind: "failover",
+      from: config.endpoints[state.activeIndex],
+      to: config.endpoints[nextIndex],
+      reason: `primary RPC unhealthy ${failStreak} cycles`,
+    },
+    state: {
+      ...state,
+      activeIndex: nextIndex,
+      failStreak: 0,
+      failoversSinceHealthy: state.failoversSinceHealthy + 1,
+      windowActions: [...window, nowMs],
+    },
+  };
+}
+
+/** An alert for a remediation outcome — audit-level for a failover, page-level for
+ *  an escalation. `null` for none/resolved (resolved is narrated, not paged). Pure. */
+export function buildRemediationAlert(outcome: RpcRemediationOutcome, boardUrl: string): AlertPayload | null {
+  if (outcome.kind === "failover") {
+    return {
+      count: 1,
+      items: [{ id: "rpc-failover", title: `RPC failover → ${outcome.to}` }],
+      boardUrl,
+      text: `Auto-remediation: RPC failover — ${outcome.from} unhealthy (${outcome.reason}), rotated to ${outcome.to}. Reversible; monitor read-path only.`,
+    };
+  }
+  if (outcome.kind === "escalate") {
+    return {
+      count: 1,
+      items: [{ id: "rpc-escalate", title: "RPC auto-remediation halted" }],
+      boardUrl,
+      text: `Auto-remediation HALTED — ${outcome.reason}. The read RPC is still unhealthy and needs an operator.`,
+    };
+  }
+  return null;
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -883,7 +883,7 @@ export async function probeSignerLiquidity(input: {
   minGasNative: number;
   minUsdc: number;
   fetchImpl: typeof fetch;
-}): Promise<ProbeResult & { pools?: SolvencyPoolData[] }> {
+}): Promise<ProbeResult & { pools?: SolvencyPoolData[]; rpcOk?: boolean }> {
   if (!input.rpcUrl || !input.signerAddress) {
     return {
       name: "signer_liquidity",
@@ -944,9 +944,11 @@ export async function probeSignerLiquidity(input: {
       });
     }
 
-    return { name: "signer_liquidity", status: red ? "red" : "ok", detail: parts.join(", "), pools };
+    return { name: "signer_liquidity", status: red ? "red" : "ok", detail: parts.join(", "), pools, rpcOk: true };
   } catch (err) {
-    return { name: "signer_liquidity", status: "degraded", detail: `balance read failed: ${errMsg(err)}` };
+    // The direct RPC read itself failed (timeout / 1006 / bad endpoint) — distinct
+    // from a low balance. rpcOk:false is the auto-remediation failover signal.
+    return { name: "signer_liquidity", status: "degraded", detail: `balance read failed: ${errMsg(err)}`, rpcOk: false };
   }
 }
 
@@ -1068,6 +1070,9 @@ export interface ProductHealthCollection {
   snapshot: ProductHealthSnapshotBlocks;
   /** GET /health round-trip latency (ms) — the caller records it on the history entry. */
   latencyMs?: number;
+  /** Did the direct read RPC respond this cycle? true/false/undefined(=can't judge).
+   *  The auto-remediation failover signal. */
+  rpcOk?: boolean;
 }
 
 /** Absolute age (seconds) of the chain's latest block via the direct RPC — but
@@ -1178,6 +1183,7 @@ export async function collectProductHealthProbes(
     chainAdvance,
     snapshot,
     latencyMs: h.latencyMs,
+    rpcOk: signer.rpcOk,
   };
 }
 

--- a/test/unit/ops-remediation.test.ts
+++ b/test/unit/ops-remediation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  decideRpcRemediation,
+  initialRpcRemediationState,
+  buildRemediationAlert,
+  loadRemediationConfig,
+  type RemediationConfig,
+} from "../../services/slack-operator/src/ops-remediation.js";
+
+const cfg = (over: Partial<RemediationConfig> = {}): RemediationConfig => ({
+  enabled: true,
+  endpoints: ["rpc-a", "rpc-b", "rpc-c"],
+  failThreshold: 2,
+  maxAttempts: 3,
+  maxPerWindow: 5,
+  windowMs: 3_600_000,
+  ...over,
+});
+
+describe("decideRpcRemediation", () => {
+  it("never acts while disabled, even when unhealthy", () => {
+    const r = decideRpcRemediation({ rpcHealthy: false, state: initialRpcRemediationState(), config: cfg({ enabled: false }), nowMs: 0 });
+    expect(r.outcome.kind).toBe("none");
+  });
+
+  it("does nothing when health is unjudgeable (RPC not configured)", () => {
+    const r = decideRpcRemediation({ rpcHealthy: undefined, state: initialRpcRemediationState(), config: cfg(), nowMs: 0 });
+    expect(r.outcome.kind).toBe("none");
+  });
+
+  it("tolerates a single hiccup below the flap threshold", () => {
+    const r = decideRpcRemediation({ rpcHealthy: false, state: initialRpcRemediationState(), config: cfg(), nowMs: 0 });
+    expect(r.outcome.kind).toBe("none");
+    expect(r.state.failStreak).toBe(1);
+  });
+
+  it("fails over to the next endpoint once the flap threshold is met", () => {
+    const s = decideRpcRemediation({ rpcHealthy: false, state: initialRpcRemediationState(), config: cfg(), nowMs: 0 }).state;
+    const r = decideRpcRemediation({ rpcHealthy: false, state: s, config: cfg(), nowMs: 1000 });
+    expect(r.outcome).toMatchObject({ kind: "failover", from: "rpc-a", to: "rpc-b" });
+    expect(r.state.activeIndex).toBe(1);
+    expect(r.state.failoversSinceHealthy).toBe(1);
+    expect(r.state.failStreak).toBe(0);
+    expect(r.state.windowActions).toHaveLength(1);
+  });
+
+  it("resolves + resets on a healthy cycle, staying on the endpoint that works", () => {
+    const troubled = { ...initialRpcRemediationState(), activeIndex: 1, failoversSinceHealthy: 1, failStreak: 1, windowActions: [500] };
+    const r = decideRpcRemediation({ rpcHealthy: true, state: troubled, config: cfg(), nowMs: 1000 });
+    expect(r.outcome).toEqual({ kind: "resolved", endpoint: "rpc-b" });
+    expect(r.state.activeIndex).toBe(1);
+    expect(r.state.failoversSinceHealthy).toBe(0);
+    expect(r.state.breakerTripped).toBe(false);
+    expect(r.state.windowActions).toEqual([500]); // kept — the rate cap must still see past flaps
+  });
+
+  it("escalates at the threshold when there is no backup endpoint", () => {
+    const c = cfg({ endpoints: ["rpc-a"] });
+    const s = decideRpcRemediation({ rpcHealthy: false, state: initialRpcRemediationState(), config: c, nowMs: 0 }).state;
+    const r = decideRpcRemediation({ rpcHealthy: false, state: s, config: c, nowMs: 1 });
+    expect(r.outcome).toMatchObject({ kind: "escalate" });
+    expect(r.state.breakerTripped).toBe(true);
+  });
+
+  it("trips the breaker once the failover budget is exhausted", () => {
+    const s = { ...initialRpcRemediationState(), failoversSinceHealthy: 3, failStreak: 1 };
+    const r = decideRpcRemediation({ rpcHealthy: false, state: s, config: cfg(), nowMs: 0 });
+    expect(r.outcome).toMatchObject({ kind: "escalate", reason: expect.stringContaining("still failing") });
+    expect(r.state.breakerTripped).toBe(true);
+  });
+
+  it("trips the breaker on the rate cap (flapping across recover cycles)", () => {
+    const s = { ...initialRpcRemediationState(), failStreak: 1, windowActions: [1, 2, 3, 4, 5] };
+    const r = decideRpcRemediation({ rpcHealthy: false, state: s, config: cfg(), nowMs: 10 });
+    expect(r.outcome).toMatchObject({ kind: "escalate", reason: expect.stringContaining("rate cap") });
+  });
+
+  it("stays quiet once the breaker is tripped, until health returns", () => {
+    const tripped = { ...initialRpcRemediationState(), breakerTripped: true, failStreak: 5 };
+    expect(decideRpcRemediation({ rpcHealthy: false, state: tripped, config: cfg(), nowMs: 0 }).outcome.kind).toBe("none");
+    const recovered = decideRpcRemediation({ rpcHealthy: true, state: tripped, config: cfg(), nowMs: 0 });
+    expect(recovered.outcome.kind).toBe("resolved");
+    expect(recovered.state.breakerTripped).toBe(false);
+  });
+});
+
+describe("buildRemediationAlert", () => {
+  it("audits a failover, pages an escalation, and is silent for none/resolved", () => {
+    expect(buildRemediationAlert({ kind: "failover", from: "a", to: "b", reason: "x" }, "url")?.text).toContain("failover");
+    expect(buildRemediationAlert({ kind: "escalate", reason: "no backup" }, "url")?.text).toContain("HALTED");
+    expect(buildRemediationAlert({ kind: "none" }, "url")).toBeNull();
+    expect(buildRemediationAlert({ kind: "resolved", endpoint: "b" }, "url")).toBeNull();
+  });
+});
+
+describe("loadRemediationConfig", () => {
+  it("is off by default; endpoints = primary + csv backups", () => {
+    const c = loadRemediationConfig({ PRODUCT_HEALTH_RPC_BACKUPS: "rpc-b, rpc-c" }, "rpc-a");
+    expect(c.enabled).toBe(false);
+    expect(c.endpoints).toEqual(["rpc-a", "rpc-b", "rpc-c"]);
+  });
+
+  it("enables only on an explicit 'true'", () => {
+    expect(loadRemediationConfig({ OPS_AUTOREMEDIATE_ENABLED: "true" }, "rpc-a").enabled).toBe(true);
+    expect(loadRemediationConfig({ OPS_AUTOREMEDIATE_ENABLED: "1" }, "rpc-a").enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Auto-remediation Phase 1 — RPC failover

The first instance of the safe auto-remediation harness from [`docs/OPS_AUTO_REMEDIATION.md`](docs/OPS_AUTO_REMEDIATION.md) (#517). It proves the *whole* harness on the lowest-risk action, exactly as scoped.

**What it does:** when the monitor's own direct-RPC read fails (timeout / `1006`), rotate to a configured backup endpoint. Pure monitor read-path — **never touches funds or the product**, fully reversible.

### Approved scope (from the spec sign-off)
- **`rpc_failover` only** (the v1 allowlist).
- **Separate `OPS_AUTOREMEDIATE_ENABLED` switch**, **off by default** — independent of board autopilot.
- Escalation = **page** (this PR) + board card (*Phase 1.1 follow-on*).
- **`maxAttempts` 3**, **`maxPerWindow` 5/h**, flap-guard `failThreshold` 2.

### The harness
- **`decideRpcRemediation`** (pure): gate → flap-guard → failover (cycles `endpoints`) → **circuit-breaker** (escalate + go quiet on budget-exhausted / rate-cap / no-backup) → **verify-loop** (a healthy cycle resolves + resets, staying on the endpoint that works). Deterministic, fully unit-tested; `index.ts` owns the only effect.
- **Signal:** `probeSignerLiquidity` reports `rpcOk` (did the direct read succeed?) — surfaced on the collection.
- **Effect:** the monitor reads `endpoints[activeIndex]` each tick; a failover advances the index (audit alert), an escalation pages.

### Safety invariants (all enforced + tested)
Off by default · only the allowlisted action · **never funds** · every action alerted (audit / page) · breaker **escalates to a human, never loops** · an unconfigured/unreadable signal (`rpcOk` undefined) **never acts** · fully reversible.

## Verification
- **114 backend tests** (12 new: gate-off, hiccup-tolerance, failover, resolve-on-recovery, no-backup→escalate, budget→breaker, rate-cap→breaker, breaker-holds-until-healthy + the alert builder + config parsing).
- slack-operator `tsc` unchanged at the `@avg` baseline.

## To enable (operator)
Set `OPS_AUTOREMEDIATE_ENABLED=true` + `PRODUCT_HEALTH_RPC_BACKUPS=<csv of backup RPCs>`. Inert (no-op) without both — safe to merge dormant.

## Not live-verifiable
Fires only on a real RPC failure with a backup configured — covered by unit tests until then.