### PR TITLE
feat(monitor): RPC failover board card (auto-remediation Phase 1.1)

### DIFF
--- a/packages/monitor-ui/src/components/ops/DepsDeployZone.test.tsx
+++ b/packages/monitor-ui/src/components/ops/DepsDeployZone.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { DepsDeployZone } from "./DepsDeployZone.js";
+import type { ProductHealth, RemediationStatus } from "../../lib/monitor/product-health.js";
+
+afterEach(cleanup);
+
+const health = (remediation?: RemediationStatus): ProductHealth => ({
+  enabled: true,
+  at: 1,
+  status: "healthy",
+  checks: 5,
+  probes: [{ name: "product_api", status: "ok", detail: "200", sparkline: [] }],
+  remediation,
+});
+
+const rem = (state: RemediationStatus["state"], detail: string, onBackup = false): RemediationStatus => ({
+  state,
+  enabled: state !== "off",
+  activeEndpoint: "https://eth-rpc-testnet.polkadot.io/",
+  onBackup,
+  detail,
+});
+
+describe("DepsDeployZone — RPC failover row", () => {
+  test("no row when remediation is absent or off", () => {
+    expect(render(<DepsDeployZone health={health()} />).queryByTestId("ops-remediation")).toBeNull();
+    cleanup();
+    expect(
+      render(<DepsDeployZone health={health(rem("off", "auto-remediation off"))} />).queryByTestId("ops-remediation"),
+    ).toBeNull();
+  });
+
+  test("armed → calm sage row", () => {
+    const row = render(<DepsDeployZone health={health(rem("armed", "armed · primary eth-rpc-testnet.polkadot.io"))} />).getByTestId("ops-remediation");
+    expect(row.className).toContain("ops-deploy-row--ok");
+    expect(row.textContent).toContain("armed");
+  });
+
+  test("failover → amber row", () => {
+    const row = render(<DepsDeployZone health={health(rem("failover", "reading backup services.polkadothub-rpc.com", true))} />).getByTestId("ops-remediation");
+    expect(row.className).toContain("ops-deploy-row--degraded");
+    expect(row.textContent).toContain("reading backup");
+  });
+
+  test("halted → coral row", () => {
+    const row = render(<DepsDeployZone health={health(rem("halted", "halted — RPC unhealthy, needs an operator"))} />).getByTestId("ops-remediation");
+    expect(row.className).toContain("ops-deploy-row--red");
+    expect(row.textContent).toContain("halted");
+  });
+});

--- a/packages/monitor-ui/src/components/ops/DepsDeployZone.tsx
+++ b/packages/monitor-ui/src/components/ops/DepsDeployZone.tsx
@@ -49,7 +49,22 @@ export function DepsDeployZone({ health }: DepsDeployZoneProps) {
             {structuredLive ? "structured blocks live" : "awaiting structured blocks"}
           </span>
         </div>
+        {health.remediation && health.remediation.state !== "off" && (
+          <div
+            className={`ops-deploy-row ops-deploy-row--${remediationTone(health.remediation.state)}`}
+            data-testid="ops-remediation"
+          >
+            <span className="ops-dot" aria-hidden />
+            <span className="ops-deploy-name">RPC failover</span>
+            <span className="ops-deploy-val">{health.remediation.detail}</span>
+          </div>
+        )}
       </div>
     </OpsZone>
   );
+}
+
+/** armed → sage · failover → amber · halted → coral (the row only renders when enabled). */
+function remediationTone(state: "armed" | "failover" | "halted" | "off"): string {
+  return state === "halted" ? "red" : state === "failover" ? "degraded" : "ok";
 }

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -112,6 +112,18 @@ export interface ProductHealth {
   solvency?: SolvencySnapshot;
   flow?: MoneyPathSnapshot;
   history?: HealthHistory;
+  remediation?: RemediationStatus;
+}
+
+/** RPC auto-remediation status — drives the Ops "RPC failover" row. */
+export interface RemediationStatus {
+  /** off = disabled · armed = on primary, healthy · failover = reading a backup ·
+   *  halted = breaker tripped, needs an operator. */
+  state: "off" | "armed" | "failover" | "halted";
+  enabled: boolean;
+  activeEndpoint: string | null;
+  onBackup: boolean;
+  detail: string;
 }
 
 const PROBE_LABELS: Record<string, string> = {

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -442,6 +442,8 @@
 .ops-deploy-row { display: flex; align-items: center; gap: 9px; font-size: 12px; --tone: var(--h4-ok); }
 .ops-deploy-row--ok { --tone: var(--h4-ok); }
 .ops-deploy-row--awaiting { --tone: var(--h4-tel); }
+.ops-deploy-row--degraded { --tone: var(--h4-warn); }
+.ops-deploy-row--red { --tone: var(--h4-act); }
 .ops-deploy-row .ops-dot { background: var(--tone); }
 .ops-deploy-name { color: var(--h4-ink); min-width: 118px; }
 .ops-deploy-val { color: var(--h4-muted); }

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -178,6 +178,8 @@ import {
   decideRpcRemediation,
   initialRpcRemediationState,
   buildRemediationAlert,
+  describeRemediationStatus,
+  type RemediationStatus,
 } from "./ops-remediation.js";
 import {
   readFreshCardFailureAnalysis,
@@ -274,6 +276,7 @@ let productHealthHistory: ProductHealthSnapshot[] = [];
 let productHealthChainAdvance: ChainAdvance | undefined;
 // Structured snapshot blocks (chain id / network / solvency / flow) for the Ops board.
 let productHealthSnapshotBlocks: ProductHealthSnapshotBlocks | undefined;
+let productHealthRemediation: RemediationStatus | undefined;
 
 /** The settlement signer's address, derived from the key the monitor already holds
  *  (AGENT_WALLET_PRIVATE_KEY) so signer_liquidity needs no duplicated config. A
@@ -734,6 +737,9 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       // incident episodes) from the rolling buffer. Always present — the series
       // are honestly short and uptimePct24h is null until a check lands in-window.
       history: deriveProductHealthHistory(productHealthHistory, Date.now()),
+      // RPC auto-remediation status for the Ops "RPC failover" row (undefined =
+      // omitted by JSON when the routine hasn't run a cycle yet).
+      remediation: productHealthRemediation,
     });
     return;
   }
@@ -3187,6 +3193,7 @@ function startOperatorRoutines() {
   let productHealthAlertState = initialProductHealthAlertState();
   let runwayAlertState = initialRunwayAlertState();
   let rpcRemediationState = initialRpcRemediationState();
+  let lastRemediationReason: string | undefined;
   // Slice 3: previous overall product-health status, so the co-pilot narrates
   // only on an edge across the red boundary (entered-red / recovered).
   let prevProductHealthStatus: OpsStatus = "unknown";
@@ -3485,6 +3492,17 @@ function startOperatorRoutines() {
           "https://monitor.averray.com/monitor",
       );
       if (remediationAlert) await alertChannel.dispatch(remediationAlert);
+      if (remediation.outcome.kind === "failover" || remediation.outcome.kind === "escalate") {
+        lastRemediationReason = remediation.outcome.reason;
+      } else if (remediation.outcome.kind === "resolved") {
+        lastRemediationReason = undefined;
+      }
+      // Board status for the Ops "RPC failover" row (armed / failover / halted / off).
+      productHealthRemediation = describeRemediationStatus({
+        config: remediationConfig,
+        state: rpcRemediationState,
+        lastReason: lastRemediationReason,
+      });
       const result = await runProductHealthOnce({
         runProbes: async () => collection.probes,
         alert: (payload) => alertChannel.dispatch(payload),

--- a/services/slack-operator/src/ops-remediation.ts
+++ b/services/slack-operator/src/ops-remediation.ts
@@ -177,3 +177,52 @@ export function buildRemediationAlert(outcome: RpcRemediationOutcome, boardUrl: 
   }
   return null;
 }
+
+/** Board-facing snapshot of the remediation state, for the Ops "RPC failover" row. */
+export interface RemediationStatus {
+  /** off = disabled · armed = on primary, healthy · failover = reading a backup ·
+   *  halted = breaker tripped, needs an operator. */
+  state: "off" | "armed" | "failover" | "halted";
+  enabled: boolean;
+  /** The RPC endpoint currently in use. */
+  activeEndpoint: string | null;
+  onBackup: boolean;
+  /** One-line board detail. */
+  detail: string;
+}
+
+function hostOf(url: string | null): string {
+  if (!url) return "—";
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
+/** Derive the board status from the live config + state. Pure. `lastReason` is the
+ *  most recent failover/escalate reason (index.ts threads it) for the halted line. */
+export function describeRemediationStatus(input: {
+  config: RemediationConfig;
+  state: RpcRemediationState;
+  lastReason?: string;
+}): RemediationStatus {
+  const active = input.config.endpoints[input.state.activeIndex] ?? input.config.endpoints[0] ?? null;
+  const onBackup = input.state.activeIndex > 0;
+  if (!input.config.enabled) {
+    return { state: "off", enabled: false, activeEndpoint: active, onBackup, detail: "auto-remediation off" };
+  }
+  if (input.state.breakerTripped) {
+    return {
+      state: "halted",
+      enabled: true,
+      activeEndpoint: active,
+      onBackup,
+      detail: input.lastReason ? `halted — ${input.lastReason}` : "halted — RPC unhealthy, needs an operator",
+    };
+  }
+  if (onBackup) {
+    return { state: "failover", enabled: true, activeEndpoint: active, onBackup, detail: `reading backup ${hostOf(active)}` };
+  }
+  return { state: "armed", enabled: true, activeEndpoint: active, onBackup, detail: `armed · primary ${hostOf(active)}` };
+}

--- a/test/unit/ops-remediation.test.ts
+++ b/test/unit/ops-remediation.test.ts
@@ -4,6 +4,7 @@ import {
   initialRpcRemediationState,
   buildRemediationAlert,
   loadRemediationConfig,
+  describeRemediationStatus,
   type RemediationConfig,
 } from "../../services/slack-operator/src/ops-remediation.js";
 
@@ -103,5 +104,37 @@ describe("loadRemediationConfig", () => {
   it("enables only on an explicit 'true'", () => {
     expect(loadRemediationConfig({ OPS_AUTOREMEDIATE_ENABLED: "true" }, "rpc-a").enabled).toBe(true);
     expect(loadRemediationConfig({ OPS_AUTOREMEDIATE_ENABLED: "1" }, "rpc-a").enabled).toBe(false);
+  });
+});
+
+describe("describeRemediationStatus", () => {
+  it("off when disabled", () => {
+    const s = describeRemediationStatus({ config: cfg({ enabled: false }), state: initialRpcRemediationState() });
+    expect(s.state).toBe("off");
+    expect(s.enabled).toBe(false);
+  });
+
+  it("armed on the primary when enabled + healthy", () => {
+    const s = describeRemediationStatus({ config: cfg(), state: initialRpcRemediationState() });
+    expect(s.state).toBe("armed");
+    expect(s.activeEndpoint).toBe("rpc-a");
+    expect(s.onBackup).toBe(false);
+  });
+
+  it("failover when reading a backup", () => {
+    const s = describeRemediationStatus({ config: cfg(), state: { ...initialRpcRemediationState(), activeIndex: 1 } });
+    expect(s.state).toBe("failover");
+    expect(s.onBackup).toBe(true);
+    expect(s.activeEndpoint).toBe("rpc-b");
+  });
+
+  it("halted with the reason when the breaker tripped", () => {
+    const s = describeRemediationStatus({
+      config: cfg(),
+      state: { ...initialRpcRemediationState(), breakerTripped: true },
+      lastReason: "no backup RPC endpoint configured",
+    });
+    expect(s.state).toBe("halted");
+    expect(s.detail).toContain("no backup");
   });
 });


### PR DESCRIPTION
## Auto-remediation Phase 1.1 — the board card

Surfaces the #518 RPC-failover state **on** the Ops board, so a failover or escalation is visible where you're looking — not only as a page.

The backend already ran the decide loop each cycle; this emits a status block and the **Dependencies & deploy** zone renders an **"RPC failover"** row:

| State | Tone | Meaning |
|---|---|---|
| **armed** | sage | enabled, on the primary, healthy |
| **failover** | amber | reading a backup after a rotation |
| **halted** | coral | breaker tripped — needs an operator |
| **off** | — | disabled → **no row** (honest, no clutter) |

- **`describeRemediationStatus(config, state, lastReason)`** (pure) — derives the board state from the live config + state machine.
- `index.ts` threads the last failover/escalate reason, builds the status each cycle, and emits `remediation` from `GET /monitor/product-health` (`undefined` until the routine ticks → omitted by JSON).
- Frontend: `ProductHealth.remediation` (`RemediationStatus`); `DepsDeployZone` renders the toned row + two new `ops-deploy-row` tones (`--degraded` / `--red`).

The escalation still **pages** (that's #518) — this is the complementary on-board view.

## Verification
- **799 frontend tests** (4 new: off→no-row, armed/failover/halted tones) + **16 backend** remediation tests (4 new: off / armed / failover / halted-with-reason).
- Both typechecks clean; backend `tsc` unchanged at the `@avg` baseline.

## Live behavior
While the primary RPC is healthy it shows a calm **"RPC failover · armed · primary eth-rpc-testnet.polkadot.io"** row once enabled; it flips amber on a real rotation and coral if the breaker trips. (Off until `OPS_AUTOREMEDIATE_ENABLED=true`, per #519.)