### PR TITLE
fix(monitor): approve a proposed task from the drawer / Ops surface

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -741,7 +741,9 @@ export function BoardView({
         {askStatus ? <span className="hm-ask-status-toast">{askStatus}</span> : null}
       </div>
 
-      {drawerCard && boardSurface === "delivery" ? (
+      {/* The drawer renders on BOTH surfaces — a proposed task opened from the
+          Ops co-pilot digest must be approvable in place, not only from Delivery. */}
+      {drawerCard ? (
         <DetailDrawer
           card={drawerCard}
           cards={orderedCards}

--- a/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
+++ b/packages/monitor-ui/src/components/drawer/DetailDrawer.tsx
@@ -54,7 +54,7 @@ function githubUrlForCard(card: BoardCard): string | undefined {
 function footerHint(key: string): "A" | "B" | undefined {
   // The action variant's primary is "approve-merge" (PR present) or "dismiss"
   // (no PR) — they're mutually exclusive, so both take the "A" badge.
-  if (key === "approve-merge" || key === "dismiss") return "A";
+  if (key === "approve-merge" || key === "dismiss" || key === "approve-dispatch") return "A";
   if (key === "send-back-codex") return "B";
   return undefined;
 }

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
@@ -159,14 +159,41 @@ describe("buildDrawerFooter — done + generic variants", () => {
     expect(openUrl).toHaveBeenCalledWith("https://github.com/averray-agent/agent/pull/12");
   });
 
-  it("no-PR task card → Open on github is DISABLED, never the repo-root fallback (P0-3)", () => {
-    // A proposed task has a repo but no resolved PR yet. The old code fell back
-    // to githubUrlForCard()'s repo root; now it must be disabled with a reason.
-    const taskNoPr = card({ type: "task", id: "claude-task-x1", taskStatus: "proposed" });
+  it("non-proposed no-PR task → Open on github is DISABLED, never the repo-root fallback (P0-3)", () => {
+    // A task with a repo but no resolved PR must NOT fall back to the repo root.
+    // (A *proposed* task gets the dedicated approve footer instead — tested below.)
+    const taskNoPr = card({ type: "task", id: "claude-task-x1", lane: "hermes-checking" });
     const f = buildDrawerFooter(taskNoPr, {});
     const open = find(f, "open-github");
     expect(open.run).toBeUndefined();
     expect(open.disabledReason).toBe("No PR yet — opens once the task proposes a change.");
+  });
+});
+
+describe("buildDrawerFooter — proposed task (approve gate, reachable from Ops)", () => {
+  const proposed = card({ type: "task", id: "codex-task-x-new-1", taskStatus: "proposed", lane: "codex-needed" });
+
+  it("leads with Approve & dispatch wired to onApproveAndMerge; no PR merge/open actions", () => {
+    const onApproveAndMerge = vi.fn();
+    const f = buildDrawerFooter(proposed, { handlers: { onApproveAndMerge, onDismiss: vi.fn(), onAskHermes: vi.fn() } });
+    expect(f.map((b) => b.key)).toEqual(["approve-dispatch", "dismiss-task", "ask-hermes"]);
+    expect(f.find((b) => b.key === "approve-merge")).toBeUndefined();
+    expect(f.find((b) => b.key === "open-github")).toBeUndefined();
+    const approve = find(f, "approve-dispatch");
+    expect(approve.label).toBe("Approve & dispatch");
+    approve.run!();
+    expect(onApproveAndMerge).toHaveBeenCalledWith(proposed);
+  });
+
+  it("disables Approve with a reason when no handler is wired (no silent no-op)", () => {
+    const approve = find(buildDrawerFooter(proposed, {}), "approve-dispatch");
+    expect(approve.run).toBeUndefined();
+    expect(approve.disabledReason).toMatch(/Approving/);
+  });
+
+  it("a non-proposed task does NOT get the approve-dispatch gate", () => {
+    const running = card({ type: "task", id: "codex-task-x-running-1", taskStatus: "running" });
+    expect(buildDrawerFooter(running, {}).find((b) => b.key === "approve-dispatch")).toBeUndefined();
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
@@ -87,6 +87,38 @@ export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}):
   const url = githubUrlForCard(card);
   const buttons: FooterButton[] = [];
 
+  // A PROPOSED task hasn't dispatched yet — there is no PR to merge, so the
+  // resolving action is to APPROVE + DISPATCH it to the runner (the O3 operator
+  // gate). This makes the gate reachable from the drawer on ANY surface, incl.
+  // Ops, where the lane cards that normally carry Approve are hidden.
+  // onApproveAndMerge is wired to the task-approve dispatch in BoardView.
+  const taskStatus = (card as { taskStatus?: string }).taskStatus;
+  if (card.type === "task" && taskStatus === "proposed") {
+    buttons.push({
+      key: "approve-dispatch",
+      label: "Approve & dispatch",
+      kind: "action",
+      ...(h.onApproveAndMerge
+        ? { run: () => h.onApproveAndMerge!(card) }
+        : { disabledReason: "Approving a task isn't available here." }),
+    });
+    buttons.push({
+      key: "dismiss-task",
+      label: "Dismiss",
+      kind: "ghost",
+      ...(h.onDismiss
+        ? { run: () => h.onDismiss!(card) }
+        : { disabledReason: "Dismissing isn't available here." }),
+    });
+    buttons.push({
+      key: "ask-hermes",
+      label: "Ask Hermes",
+      kind: "ghost",
+      ...(h.onAskHermes ? { run: () => h.onAskHermes!(card) } : { disabledReason: "Ask Hermes isn't available here." }),
+    });
+    return buttons;
+  }
+
   if (variant === "mission") {
     buttons.push({
       key: "fresh-run",


### PR DESCRIPTION
## The "no progress" bug

A Hermes ops-suggestion **"Propose task"** lands a codex-task as `proposed`, waiting on the operator — correct, supervised behavior. But the **Approve** gate lived only on the delivery-lane card, and from the **Ops surface** it was unreachable:
1. The Ops board **replaces the delivery lanes**, hiding the cards that carry Approve.
2. The detail drawer was gated to `boardSurface === "delivery"`, so opening a proposed task from the Ops co-pilot digest set `?card=` but **rendered nothing**.

Result: the task opened but dead-ended — while the runner (`vps-claude-task-runner`) sat **idle**, literally reporting *"no approved claude task is waiting"* (56 tasks stuck at `proposed`).

## Fix (frontend only)
- **`BoardView`**: render `<DetailDrawer>` on **both** surfaces — `drawerCard`/`drawerActions` are already computed regardless of surface.
- **`drawer-footer`**: a `proposed` task now leads with **"Approve & dispatch"** (wired to the existing `onApproveTask` dispatch via `onApproveAndMerge`) + Dismiss + Ask Hermes — instead of the PR-oriented footer (there's no PR to merge yet, so no dead `approve-merge`/`open-github`).

Backend approve (`approveCodexTask`) + `onApproveTask` were already wired end-to-end; this just makes the gate reachable from where you propose.

## Verification
- **802 frontend tests** (new proposed-task footer coverage: approve-dispatch wiring + run, no PR actions, disabled-without-handler, non-proposed excluded; updated the P0-3 no-repo-root test to a non-proposed task).
- Frontend `tsc` clean.

## After deploy
Opening a proposed task from the Ops co-pilot opens the drawer with **Approve & dispatch** → click it → the idle runner claims it → progress. (Backlog cleanup + the root-cause 500s are separate follow-ups.)