### PR TITLE
fix(monitor): dedupe greenfield task proposals — a product flap can't flood the board

### DIFF
--- a/services/slack-operator/src/codex-task-queue.ts
+++ b/services/slack-operator/src/codex-task-queue.ts
@@ -155,6 +155,13 @@ export async function listCodexTasks(deps: CodexTaskQueueDeps = {}): Promise<Cod
   return tasks.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
 }
 
+/** Collapse whitespace for greenfield dedupe — two prompts identical modulo
+ *  spacing target the same work, so re-proposing one while it's still open
+ *  updates it in place instead of piling on a duplicate. */
+function normalizeTaskPrompt(prompt: string): string {
+  return prompt.trim().replace(/\s+/g, " ");
+}
+
 export async function proposeCodexTask(
   input: CodexTaskInput,
   deps: CodexTaskQueueDeps = {}
@@ -162,15 +169,19 @@ export async function proposeCodexTask(
   const path = queuePath(deps.path);
   const tasks = await readCodexTasks(path);
   const now = (deps.now ?? new Date()).toISOString();
-  // Dedupe only when the task targets a specific PR. Greenfield tasks
-  // (no PR yet) are each distinct, so they always create a new entry.
-  const existing = input.pullRequestNumber === undefined
-    ? undefined
-    : tasks.find((task) =>
-        !TERMINAL_STATUSES.has(task.status)
-        && task.repo === input.repo
-        && task.pullRequestNumber === input.pullRequestNumber
-      );
+  // Dedupe a NON-terminal task so a flapping product can't flood the board with
+  // identical proposals: on repo + PR when a PR is targeted; on repo + normalized
+  // prompt for GREENFIELD tasks (no PR). Previously greenfield tasks were always
+  // distinct, so an intermittent /health 500 spawned dozens of the same
+  // "investigate" task. An open (proposed / approved / running) match is updated
+  // in place (bumps updatedAt) rather than duplicated.
+  const normalizedPrompt = normalizeTaskPrompt(input.prompt);
+  const existing = tasks.find((task) => {
+    if (TERMINAL_STATUSES.has(task.status) || task.repo !== input.repo) return false;
+    return input.pullRequestNumber !== undefined
+      ? task.pullRequestNumber === input.pullRequestNumber
+      : task.pullRequestNumber === undefined && normalizeTaskPrompt(task.prompt) === normalizedPrompt;
+  });
   if (existing) {
     const updated: CodexTask = {
       ...existing,

--- a/test/unit/codex-task-queue.test.ts
+++ b/test/unit/codex-task-queue.test.ts
@@ -85,6 +85,38 @@ describe("codex task queue", () => {
     });
   });
 
+  it("dedupes greenfield (no-PR) tasks on repo + normalized prompt — a flap can't flood the board", async () => {
+    const path = await tempQueuePath();
+    const first = await proposeCodexTask(
+      { repo: "depre-dev/averray-reference-agent", prompt: "Investigate the /health 500.", requester: "hermes" },
+      { path, now: new Date("2026-07-07T07:41:00.000Z") },
+    );
+    expect(first.created).toBe(true);
+
+    // Same repo + same prompt (modulo whitespace) while the first is still open → deduped.
+    const dup = await proposeCodexTask(
+      { repo: "depre-dev/averray-reference-agent", prompt: "  Investigate the   /health 500.  ", requester: "hermes" },
+      { path, now: new Date("2026-07-07T07:41:30.000Z") },
+    );
+    expect(dup.created).toBe(false);
+    expect(dup.task.id).toBe(first.task.id);
+    expect(dup.task.updatedAt).toBe("2026-07-07T07:41:30.000Z");
+
+    // A different prompt → a distinct task; a different repo (same prompt) → distinct (per-repo).
+    const otherPrompt = await proposeCodexTask(
+      { repo: "depre-dev/averray-reference-agent", prompt: "Investigate the money path.", requester: "hermes" },
+      { path, now: new Date("2026-07-07T07:42:00.000Z") },
+    );
+    expect(otherPrompt.created).toBe(true);
+    const otherRepo = await proposeCodexTask(
+      { repo: "averray-agent/agent", prompt: "Investigate the /health 500.", requester: "hermes" },
+      { path, now: new Date("2026-07-07T07:42:30.000Z") },
+    );
+    expect(otherRepo.created).toBe(true);
+
+    expect(await listCodexTasks({ path })).toHaveLength(3); // deduped first + other-prompt + other-repo
+  });
+
   it("records explicit operator delegation in the initial task event", async () => {
     const path = await tempQueuePath();
     const result = await proposeCodexTask({


### PR DESCRIPTION
## Why the board flooded with 56 identical tasks

`proposeCodexTask` already deduped tasks that target a **PR** (repo + PR number). But ops-suggestion tasks are **greenfield** (no PR — they're "investigate" tasks), and the code explicitly made those *"each distinct, always a new entry."* So when `api.averray.com/health` flapped **500** during the testnet chain stall, the same *"investigate the 500"* proposal was created dozens of times — **56 stacked up** in one incident.

## Fix
A greenfield task now dedupes on **repo + normalized prompt**: if an open (`proposed`/`approved`/`running`) task with the same repo and same prompt (modulo whitespace) already exists, it's **updated in place** (bumps `updatedAt`) rather than duplicated.

- PR-targeted dedup: unchanged.
- A **terminal** task (completed/failed/cancelled) never blocks a fresh proposal — a genuinely new incident still proposes.
- Per-repo — the same prompt against a different repo is distinct.

## Verification
- **17 codex-task-queue tests** (new: identical greenfield prompt deduped + `updatedAt` bumped, different prompt distinct, different repo distinct).
- slack-operator `tsc` unchanged at the `@avg` baseline.

## Note
This is the monitor-side belt-and-suspenders. The root-cause 500s (product `/health` throwing instead of degrading during a chain stall) are being handed to Codex separately.