### PR TITLE
feat(monitor): honest LLM cost split + Ollama subscription-burn windows

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -252,6 +252,9 @@ services:
       GITHUB_HELPER_LIMIT: ${GITHUB_HELPER_LIMIT:-5}
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-https://ollama.com/v1}
+      # Ollama Cloud subscription tier (free|pro|max) — sets the flat monthly cost
+      # the LLM-usage panel shows as real recurring spend. Unset → "plan not set".
+      OLLAMA_PLAN: ${OLLAMA_PLAN:-}
       HERMES_MONITOR_REPLY_MODEL: ${HERMES_MONITOR_REPLY_MODEL:-glm-5.2:cloud}
       # Preferred co-pilot transport: the real agentic Hermes via the gateway
       # Session API (MCP tools + skills + memory), instead of the stateless Ollama

--- a/packages/averray-mcp/src/llm-usage.test.ts
+++ b/packages/averray-mcp/src/llm-usage.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  aggregateLlmUsage,
+  llmBillingClass,
+  resolveOllamaPlan,
+  type LlmUsageEvent,
+} from "./llm-usage.js";
+
+function evt(over: Partial<LlmUsageEvent> & Pick<LlmUsageEvent, "agent" | "model" | "ts">): LlmUsageEvent {
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    ...over,
+  };
+}
+
+describe("resolveOllamaPlan", () => {
+  it("maps free/pro/max to their flat monthly price (case-insensitive)", () => {
+    expect(resolveOllamaPlan({ OLLAMA_PLAN: "pro" } as NodeJS.ProcessEnv)).toEqual({
+      plan: "pro",
+      monthlyUsd: 20,
+      configured: true,
+    });
+    expect(resolveOllamaPlan({ OLLAMA_PLAN: "MAX" } as NodeJS.ProcessEnv)).toEqual({
+      plan: "max",
+      monthlyUsd: 100,
+      configured: true,
+    });
+    expect(resolveOllamaPlan({ OLLAMA_PLAN: "free" } as NodeJS.ProcessEnv)).toEqual({
+      plan: "free",
+      monthlyUsd: 0,
+      configured: true,
+    });
+  });
+
+  it("treats unset / unknown plans as not configured (never invents a cost)", () => {
+    expect(resolveOllamaPlan({} as NodeJS.ProcessEnv)).toEqual({ plan: "none", monthlyUsd: null, configured: false });
+    expect(resolveOllamaPlan({ OLLAMA_PLAN: "enterprise" } as NodeJS.ProcessEnv)).toEqual({
+      plan: "none",
+      monthlyUsd: null,
+      configured: false,
+    });
+  });
+});
+
+describe("llmBillingClass", () => {
+  it("classes Ollama Cloud (:cloud / ollama / hermes) as subscription", () => {
+    expect(llmBillingClass("hermes", "glm-5.2:cloud")).toBe("subscription");
+    expect(llmBillingClass("hermes", "deepseek-v4-pro:cloud")).toBe("subscription");
+    expect(llmBillingClass("worker", "some-ollama-model")).toBe("subscription");
+    expect(llmBillingClass("hermes", "not_recorded")).toBe("subscription");
+  });
+
+  it("classes the Claude SDK agents as metered, everything else unknown", () => {
+    expect(llmBillingClass("claude", "not_recorded")).toBe("metered");
+    expect(llmBillingClass("test-writer", "claude-opus-4")).toBe("metered");
+    expect(llmBillingClass("security", "claude-sonnet")).toBe("metered");
+    expect(llmBillingClass("codex", "gpt-x")).toBe("unknown");
+  });
+});
+
+describe("aggregateLlmUsage — billing block", () => {
+  const NOW = new Date("2026-07-07T12:00:00.000Z");
+  // Ollama (subscription) events at varying ages.
+  const subA = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-07-07T11:00:00.000Z", inputTokens: 100, outputTokens: 50, cacheTokens: 1000 }); // 1h ago → 1150 tok
+  const subB = evt({ agent: "hermes", model: "deepseek-v4-pro:cloud", ts: "2026-07-07T09:00:00.000Z", inputTokens: 8, outputTokens: 2700 }); // 3h ago → 2708 tok
+  const subC = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-07-07T05:00:00.000Z", inputTokens: 10, outputTokens: 20, cacheTokens: 100 }); // 7h ago → 130 tok, outside 5h
+  const subOld = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-06-15T00:00:00.000Z", inputTokens: 5, outputTokens: 5 }); // last month
+  // Claude (metered) event with a recorded cost, this month.
+  const metered = evt({ agent: "claude", model: "not_recorded", ts: "2026-07-06T00:00:00.000Z", inputTokens: 8, outputTokens: 2700, cacheTokens: 160000, costUsd: 0.16 });
+
+  it("splits subscription windows and metered $, and totals them honestly for a configured plan", () => {
+    const agg = aggregateLlmUsage([subA, subB, subC, subOld, metered], {
+      now: NOW,
+      subscription: { plan: "pro", monthlyUsd: 20, configured: true },
+    });
+    const b = agg.billing;
+
+    // Subscription side — flat Ollama Pro, active, correct windows (tokens = in+out+cache).
+    expect(b.subscription.provider).toBe("ollama");
+    expect(b.subscription.plan).toBe("pro");
+    expect(b.subscription.monthlyUsd).toBe(20);
+    expect(b.subscription.configured).toBe(true);
+    expect(b.subscription.active).toBe(true);
+    expect(b.subscription.models).toContain("glm-5.2:cloud");
+
+    const w = b.subscription.windows!;
+    // 5h session excludes subC (7h old) and subOld.
+    expect(w.session5h.calls).toBe(2);
+    expect(w.session5h.tokens).toBe(1150 + 2708);
+    // 7d week + this month include subA/B/C but not last-month subOld.
+    expect(w.week7d.calls).toBe(3);
+    expect(w.week7d.tokens).toBe(1150 + 2708 + 130);
+    expect(w.month.calls).toBe(3);
+    expect(w.month.tokens).toBe(1150 + 2708 + 130);
+
+    // Metered side — real recorded $ this month.
+    expect(b.metered.monthCostUsd).toBe(0.16);
+    expect(b.metered.costStatus).toBe("recorded");
+
+    // Honest month total = flat plan + metered $, and it's complete.
+    expect(b.monthlyTotalUsd).toBe(20.16);
+    expect(b.monthlyTotalComplete).toBe(true);
+    expect(b.note).toMatch(/GPU-time/i);
+  });
+
+  it("never invents a subscription cost when the plan is unset — total is metered-only + flagged incomplete", () => {
+    const agg = aggregateLlmUsage([subA, metered], { now: NOW }); // no subscription option
+    const b = agg.billing;
+    expect(b.subscription.configured).toBe(false);
+    expect(b.subscription.monthlyUsd).toBeNull();
+    expect(b.subscription.plan).toBe("none");
+    // Total excludes the (unknown) Ollama cost, so it's incomplete.
+    expect(b.monthlyTotalUsd).toBe(0.16);
+    expect(b.monthlyTotalComplete).toBe(false);
+  });
+
+  it("leaves windows null when there is no clock to anchor them", () => {
+    const agg = aggregateLlmUsage([subA], { subscription: { plan: "pro", monthlyUsd: 20, configured: true } });
+    expect(agg.billing.subscription.windows).toBeNull();
+    // A configured flat plan still surfaces its price even without a clock.
+    expect(agg.billing.monthlyTotalUsd).toBe(20);
+    expect(agg.billing.monthlyTotalComplete).toBe(true);
+  });
+});

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -70,6 +70,59 @@ export interface LlmUsageRecent {
   series: LlmUsageRecentSeries[];
 }
 
+/** A bounded usage window — real tokens/calls between `since` and the anchor.
+ *  For subscription providers this is the honest "burn" proxy (GPU-time isn't
+ *  exposed to us, so tokens/calls stand in), never a fabricated dollar figure. */
+export interface LlmUsageWindow {
+  label: string;
+  tokens: number;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  since: string;
+}
+
+/**
+ * How usage maps to money, split by the two billing models actually in play:
+ *   - metered   → per-token providers that report a real dollar cost (Claude SDK).
+ *   - subscription → flat-rate providers (Ollama Cloud) billed by GPU-time, NOT
+ *     per token. There is no truthful per-call $, so we surface the flat plan
+ *     price plus a token/call burn proxy against Ollama's real reset windows.
+ * `monthlyTotalUsd` is the honest month-to-date picture (flat plan + metered $);
+ * `monthlyTotalComplete` is false when the Ollama plan isn't configured, so the
+ * UI can say the total excludes the (unknown) subscription cost.
+ */
+export interface LlmUsageBilling {
+  metered: {
+    models: string[];
+    monthCostUsd: number | null;
+    costStatus: "recorded" | "not_recorded";
+  };
+  subscription: {
+    provider: "ollama";
+    plan: "free" | "pro" | "max" | "none";
+    monthlyUsd: number | null;
+    configured: boolean;
+    active: boolean;
+    models: string[];
+    windows: {
+      session5h: LlmUsageWindow;
+      week7d: LlmUsageWindow;
+      month: LlmUsageWindow;
+    } | null;
+  };
+  monthlyTotalUsd: number | null;
+  monthlyTotalComplete: boolean;
+  note: string;
+}
+
+/** Resolved Ollama Cloud subscription plan (caller reads it from env). */
+export interface OllamaPlanConfig {
+  plan: "free" | "pro" | "max" | "none";
+  monthlyUsd: number | null;
+  configured: boolean;
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
   message: string;
@@ -87,6 +140,8 @@ export interface LlmUsageAggregate {
   activeCalls: LlmUsageActiveCall[];
   /** Live per-minute per-model series for the recent window (null when idle). */
   recent: LlmUsageRecent | null;
+  /** Cost split by billing model + Ollama subscription-burn windows. */
+  billing: LlmUsageBilling;
 }
 
 export interface LlmUsageCaptureInput {
@@ -107,6 +162,9 @@ export interface LlmUsageAggregateOptions {
   now?: Date;
   /** Recent-window length in minutes (default 60). */
   recentWindowMinutes?: number;
+  /** Ollama Cloud subscription plan for the billing block (caller resolves it
+   *  from env via resolveOllamaPlan). Omitted → treated as not configured. */
+  subscription?: OllamaPlanConfig;
 }
 
 export interface LlmUsageActiveCallInput {
@@ -128,8 +186,48 @@ const DEFAULT_SOURCE_REASONS: Readonly<Record<string, string>> = {
   hermes: "Hermes monitor replies may be templated when OLLAMA_API_KEY is unset; live Hermes agent usage is recorded from post_llm_call traces when provider counters are present.",
 };
 
+/** Ollama Cloud flat monthly plan prices (USD). Free/Pro/Max — no per-token bill. */
+const OLLAMA_PLAN_MONTHLY_USD: Readonly<Record<string, number>> = { free: 0, pro: 20, max: 100 };
+/** Ollama's real usage reset windows: a 5-hour session window and a 7-day week. */
+const SESSION_WINDOW_MS = 5 * 60 * 60 * 1000;
+const WEEK_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+/** Agents whose usage is metered per token (Claude Agent SDK reports real cost). */
+const METERED_AGENTS: ReadonlySet<string> = new Set(["claude", "test-writer", "security", "docs"]);
+const OLLAMA_BURN_NOTE =
+  "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars. "
+  + "The token/call counts here are a burn proxy; Ollama emails you near 90% of your allocation "
+  + "(session resets ~5h, weekly resets ~7d).";
+
 const activeCalls = new Map<string, LlmUsageActiveCall>();
 let nextActiveCallId = 0;
+
+/**
+ * Resolve the Ollama Cloud subscription plan from env (OLLAMA_PLAN=free|pro|max).
+ * Unknown/unset → not configured, so the UI shows an honest "plan not set" state
+ * instead of inventing a subscription cost.
+ */
+export function resolveOllamaPlan(env: NodeJS.ProcessEnv = process.env): OllamaPlanConfig {
+  const raw = env.OLLAMA_PLAN?.trim().toLowerCase();
+  if (raw && raw in OLLAMA_PLAN_MONTHLY_USD) {
+    return { plan: raw as "free" | "pro" | "max", monthlyUsd: OLLAMA_PLAN_MONTHLY_USD[raw]!, configured: true };
+  }
+  return { plan: "none", monthlyUsd: null, configured: false };
+}
+
+/**
+ * Classify an (agent, model) into its billing model:
+ *   - subscription → Ollama Cloud (`:cloud` model suffix, an ollama-tagged model,
+ *     or the hermes agent, which runs on Ollama). Flat-rate, no per-token $.
+ *   - metered → Claude Agent SDK agents (claude + specialists) that report cost.
+ *   - unknown → anything else (counted for tokens, never assigned a cost).
+ */
+export function llmBillingClass(agent: string, model: string): "subscription" | "metered" | "unknown" {
+  const a = agent.trim().toLowerCase();
+  const m = model.trim().toLowerCase();
+  if (m.endsWith(":cloud") || m.includes("ollama") || a === "hermes") return "subscription";
+  if (METERED_AGENTS.has(a)) return "metered";
+  return "unknown";
+}
 
 export function llmUsageLogPath(env: NodeJS.ProcessEnv = process.env): string {
   return env.LLM_USAGE_LOG_PATH?.trim() || env.AVERRAY_LLM_USAGE_LOG_PATH?.trim() || DEFAULT_USAGE_LOG_PATH;
@@ -267,6 +365,7 @@ export function aggregateLlmUsage(
   const total = totalsFor(events);
   const sourceStatus = sourceStatuses(events, options);
   const recent = buildRecent(events, options.now, options.recentWindowMinutes ?? 60);
+  const billing = buildBilling(events, options.now, options.subscription);
   const status = events.length > 0 ? "recorded" : "not_recorded";
   return {
     status,
@@ -280,7 +379,103 @@ export function aggregateLlmUsage(
     sourceStatus,
     activeCalls: [...(options.activeCalls ?? [])],
     recent,
+    billing,
   };
+}
+
+/**
+ * Build the billing block: split usage into metered (real recorded $) and
+ * subscription (Ollama flat plan + token/call burn windows), plus an honest
+ * month-to-date total. No per-token dollar figure is ever invented for the
+ * subscription side — Ollama meters GPU-time, which we don't have, so tokens
+ * and calls stand in as the burn proxy.
+ */
+function buildBilling(
+  events: readonly LlmUsageEvent[],
+  now: Date | undefined,
+  plan: OllamaPlanConfig | undefined,
+): LlmUsageBilling {
+  const resolved: OllamaPlanConfig = plan ?? { plan: "none", monthlyUsd: null, configured: false };
+  const anchor = now && Number.isFinite(now.getTime()) ? now : undefined;
+  const endMs = anchor ? anchor.getTime() : undefined;
+  const monthStartMs = anchor ? startOfUtcMonthMs(anchor) : undefined;
+
+  const subscriptionEvents = events.filter((event) => llmBillingClass(event.agent, event.model) === "subscription");
+  const meteredEvents = events.filter((event) => llmBillingClass(event.agent, event.model) === "metered");
+
+  // Metered $ this month — recorded costs only (never fabricated).
+  let monthCostUsd: number | null = null;
+  if (endMs !== undefined && monthStartMs !== undefined) {
+    const recorded = meteredEvents.filter((event) => {
+      const t = Date.parse(event.ts);
+      return typeof event.costUsd === "number" && Number.isFinite(t) && t >= monthStartMs && t <= endMs;
+    });
+    if (recorded.length > 0) {
+      monthCostUsd = round(recorded.reduce((sum, event) => sum + (event.costUsd ?? 0), 0), 6);
+    }
+  }
+
+  const windows = endMs !== undefined && monthStartMs !== undefined
+    ? {
+        session5h: usageWindowFor(subscriptionEvents, endMs - SESSION_WINDOW_MS, endMs, "5h session"),
+        week7d: usageWindowFor(subscriptionEvents, endMs - WEEK_WINDOW_MS, endMs, "7d week"),
+        month: usageWindowFor(subscriptionEvents, monthStartMs, endMs, "this month"),
+      }
+    : null;
+
+  const flatUsd = resolved.configured ? (resolved.monthlyUsd ?? 0) : null;
+  const monthlyTotalUsd = flatUsd !== null || monthCostUsd !== null
+    ? round((flatUsd ?? 0) + (monthCostUsd ?? 0), 6)
+    : null;
+
+  return {
+    metered: {
+      models: uniqueStrings(meteredEvents.map((event) => event.model)),
+      monthCostUsd,
+      costStatus: meteredEvents.some((event) => typeof event.costUsd === "number") ? "recorded" : "not_recorded",
+    },
+    subscription: {
+      provider: "ollama",
+      plan: resolved.plan,
+      monthlyUsd: resolved.monthlyUsd,
+      configured: resolved.configured,
+      active: subscriptionEvents.length > 0,
+      models: uniqueStrings(subscriptionEvents.map((event) => event.model)),
+      windows,
+    },
+    monthlyTotalUsd,
+    // Complete only when the flat subscription cost is known; otherwise the
+    // total is metered-only and the UI flags the Ollama gap.
+    monthlyTotalComplete: flatUsd !== null,
+    note: OLLAMA_BURN_NOTE,
+  };
+}
+
+/** Tokens/calls for subscription events inside [startMs, endMs] — the burn proxy. */
+function usageWindowFor(
+  events: readonly LlmUsageEvent[],
+  startMs: number,
+  endMs: number,
+  label: string,
+): LlmUsageWindow {
+  let tokens = 0;
+  let calls = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  for (const event of events) {
+    const t = Date.parse(event.ts);
+    if (!Number.isFinite(t) || t < startMs || t > endMs) continue;
+    inputTokens += event.inputTokens;
+    outputTokens += event.outputTokens;
+    tokens += event.inputTokens + event.outputTokens + (event.cacheTokens ?? 0);
+    calls += 1;
+  }
+  return { label, tokens, calls, inputTokens, outputTokens, since: new Date(startMs).toISOString() };
+}
+
+/** UTC start-of-month for the anchor — the metered billing cycle boundary. */
+function startOfUtcMonthMs(now: Date): number {
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1);
 }
 
 /**
@@ -356,6 +551,9 @@ export function aggregateLlmUsageForAgent(
     }],
     activeCalls: aggregate.activeCalls.filter((call) => call.agent === agent),
     recent: null,
+    // Per-agent sub-view: no clock/plan is threaded here, so windows stay null
+    // and the subscription cost is "not configured" (honest, never fabricated).
+    billing: buildBilling(events, undefined, undefined),
   };
 }
 

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 import { UsagePanel } from "./UsagePanel.js";
-import type { LlmUsageAggregate } from "../lib/monitor/board-cache.js";
+import type { LlmUsageAggregate, LlmUsageBilling } from "../lib/monitor/board-cache.js";
 
 afterEach(cleanup);
 
@@ -145,5 +145,93 @@ describe("UsagePanel", () => {
     expect(getByText(/No LLM usage counters have been recorded yet/)).toBeTruthy();
     // No awaiting-data chart and no fabricated rows when there's nothing real.
     expect(queryByText("not wired")).toBeNull();
+  });
+});
+
+// ── Cost & subscription burn (Ollama flat plan + metered Claude $) ──────────
+const proBilling: LlmUsageBilling = {
+  metered: { models: ["not_recorded"], monthCostUsd: 0.16, costStatus: "recorded" },
+  subscription: {
+    provider: "ollama",
+    plan: "pro",
+    monthlyUsd: 20,
+    configured: true,
+    active: true,
+    models: ["glm-5.2:cloud", "deepseek-v4-pro:cloud"],
+    windows: {
+      session5h: { label: "5h session", tokens: 1_200_000, calls: 40, inputTokens: 1_000_000, outputTokens: 200_000, since: "2026-07-07T07:00:00.000Z" },
+      week7d: { label: "7d week", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
+      month: { label: "this month", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
+    },
+  },
+  monthlyTotalUsd: 20.16,
+  monthlyTotalComplete: true,
+  note: "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars.",
+};
+
+const withBilling: LlmUsageAggregate = {
+  ...recorded,
+  costUsd: 0.16,
+  costStatus: "recorded",
+  byModel: [
+    { agent: "hermes", model: "glm-5.2:cloud", inputTokens: 2_000_000, outputTokens: 16_300, totalTokens: 2_000_000, costUsd: null, costStatus: "not_recorded", runs: 92, lastActiveAt: "2026-07-07T11:59:00.000Z" },
+    { agent: "claude", model: "not_recorded", inputTokens: 8, outputTokens: 2_700, totalTokens: 161_600, costUsd: 0.16, costStatus: "recorded", runs: 1, lastActiveAt: "2026-07-07T11:00:00.000Z" },
+  ],
+  billing: proBilling,
+};
+
+describe("UsagePanel — cost & subscription burn", () => {
+  test("headlines an honest 'cost this month' = flat Ollama plan + metered Claude $", () => {
+    const { getByText } = render(<UsagePanel usage={withBilling} />);
+    expect(getByText("Cost this month")).toBeTruthy();
+    expect(getByText(/≈\s*\$20\.16/)).toBeTruthy(); // flat $20 + metered $0.16
+    expect(getByText("Ollama Pro · flat")).toBeTruthy();
+    expect(getByText("$20/mo")).toBeTruthy();
+    expect(getByText("Metered · Claude API")).toBeTruthy();
+  });
+
+  test("a subscription (:cloud) row shows a muted 'flat' tag, not a misleading '?'", () => {
+    const { getByText } = render(<UsagePanel usage={withBilling} />);
+    expect(getByText("flat")).toBeTruthy(); // the glm-5.2:cloud row
+    // The metered Claude row still shows its real recorded dollars.
+    const dollars = getByText("Cost this month").ownerDocument.body.textContent ?? "";
+    expect(dollars).toContain("$0.16");
+  });
+
+  test("renders the Ollama burn block against its real reset windows (tokens/calls as a proxy)", () => {
+    const { getByText, getAllByText } = render(<UsagePanel usage={withBilling} />);
+    expect(getByText("Ollama burn · Pro plan")).toBeTruthy();
+    expect(getByText("proxy")).toBeTruthy();
+    expect(getByText("5h session")).toBeTruthy();
+    expect(getByText("7d week")).toBeTruthy();
+    expect(getByText("this month")).toBeTruthy();
+    expect(getByText("40 calls")).toBeTruthy(); // 5h session
+    expect(getAllByText("92 calls").length).toBe(2); // week + month
+    expect(getByText(/GPU-time/)).toBeTruthy(); // the honest note
+  });
+
+  test("when the plan is unset, shows 'plan not set' and flags the total incomplete — never invents a subscription $", () => {
+    const unset: LlmUsageAggregate = {
+      ...withBilling,
+      billing: {
+        ...proBilling,
+        subscription: { ...proBilling.subscription, plan: "none", monthlyUsd: null, configured: false },
+        monthlyTotalUsd: 0.16,
+        monthlyTotalComplete: false,
+      },
+    };
+    const { getByText } = render(<UsagePanel usage={unset} />);
+    expect(getByText("Ollama Cloud · flat")).toBeTruthy();
+    expect(getByText("plan not set")).toBeTruthy();
+    expect(getByText(/\$0\.16 \+/)).toBeTruthy(); // metered-only total, "+" signals the missing sub cost
+  });
+
+  test("omits the burn block when there's no subscription activity or no window clock", () => {
+    const idleSub: LlmUsageAggregate = {
+      ...withBilling,
+      billing: { ...proBilling, subscription: { ...proBilling.subscription, active: false } },
+    };
+    const { queryByText } = render(<UsagePanel usage={idleSub} />);
+    expect(queryByText(/Ollama burn/)).toBeNull();
   });
 });

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -1,4 +1,10 @@
-import type { LlmUsageAggregate, LlmUsageRecent } from "../lib/monitor/board-cache.js";
+import type {
+  LlmUsageAggregate,
+  LlmUsageBilling,
+  LlmUsageModelRollup,
+  LlmUsageRecent,
+  LlmUsageWindow,
+} from "../lib/monitor/board-cache.js";
 import { formatCompactNumber, formatNumber, formatRelativeTime } from "../lib/monitor/format.js";
 import { UtilCard } from "./UtilCard.js";
 
@@ -27,8 +33,14 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
   const emptyMessage = usage?.message
     ?? "No LLM usage counters have been recorded yet. Sources stay not reported until a real provider or runner emits whitelisted counters.";
   const hasTable = recorded && models.length > 0;
-  // Cost column only when a real cost was recorded somewhere (never a column of "?").
-  const showCost = !!usage && (usage.costStatus === "recorded" || models.some((m) => m.costStatus === "recorded"));
+  // Cost split by billing model (metered $ vs flat Ollama subscription + burn windows).
+  const billing = usage?.billing;
+  // Cost column: when billing is present every row has a meaningful cell (metered $,
+  // "flat" for subscription, or "?"), so show it. Otherwise fall back to the old
+  // "only when something recorded" rule so we never paint a bare column of "?".
+  const showCost = !!usage && (
+    !!billing || usage.costStatus === "recorded" || models.some((m) => m.costStatus === "recorded")
+  );
   // Real daily-tokens series (oldest→newest, last 14 days) — a chart, not a guess.
   const chartDays = (usage?.byDay ?? []).slice().sort((a, b) => a.day.localeCompare(b.day)).slice(-14);
   const hasChart = recorded && chartDays.length >= 2;
@@ -38,6 +50,7 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
 
   return (
     <UtilCard title="LLM usage" hint="per model · all agents" fill ariaLabel="LLM usage">
+      {hasTable && billing ? <CostSummary billing={billing} /> : null}
       {hasTable ? (
         <div className={`hm-usage-table${showCost ? " hm-usage-table--cost" : ""}`}>
           <div className="hm-usage-row hm-usage-row--head">
@@ -51,7 +64,11 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
             <span className="hm-usage-c-model">All models</span>
             <span className="hm-usage-c-num">{formatCompactNumber(usage!.totalTokens)}</span>
             <span className="hm-usage-c-num">{formatNumber(usage!.runs)}</span>
-            {showCost ? <span className="hm-usage-c-num">{formatCost(usage!.costUsd, usage!.costStatus)}</span> : null}
+            {showCost ? (
+              <span className="hm-usage-c-num" title="Recorded metered cost (Claude API, all time). Ollama runs on a flat subscription — see Cost this month above.">
+                {formatCost(usage!.costUsd, usage!.costStatus)}
+              </span>
+            ) : null}
             <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
           </div>
           {models.map((entry) => (
@@ -63,11 +80,7 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
               </span>
               <span className="hm-usage-c-num">{formatCompactNumber(entry.totalTokens)}</span>
               <span className="hm-usage-c-num">{formatNumber(entry.runs)}</span>
-              {showCost ? (
-                <span className={`hm-usage-c-num${entry.costStatus === "recorded" ? "" : " hm-usage-c-na"}`} title={entry.costStatus === "recorded" ? undefined : "cost not reported"}>
-                  {formatCost(entry.costUsd, entry.costStatus)}
-                </span>
-              ) : null}
+              {showCost ? <RowCost entry={entry} /> : null}
               <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
             </div>
           ))}
@@ -103,6 +116,13 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
           <span>{emptyMessage}</span>
         </p>
       )}
+
+      {/* Ollama subscription burn — flat-plan usage against its real reset windows.
+          Tokens/calls stand in for GPU-time (which Ollama doesn't expose); never a
+          fabricated per-token dollar figure. */}
+      {billing && billing.subscription.active && billing.subscription.windows ? (
+        <OllamaBurn billing={billing} />
+      ) : null}
 
       {/* What's running now (in-flight) — always glanceable. */}
       <div className="hm-usage-active">
@@ -274,6 +294,130 @@ function DailyTokensChart({ days }: { days: { day: string; totalTokens: number }
       <span className="hm-usage-chart-note hm-usage-chart-note--live">{formatCompactNumber(days.reduce((s, d) => s + d.totalTokens, 0))} tokens over {days.length} days</span>
     </div>
   );
+}
+
+/**
+ * Cost-this-month headline — the honest picture the old single "$0.16" total
+ * couldn't give: the flat Ollama subscription (already paid, doesn't grow per
+ * call) plus the genuinely-metered Claude API dollars, and their month total.
+ */
+function CostSummary({ billing }: { billing: LlmUsageBilling }) {
+  const { subscription, metered } = billing;
+  const planName = subscription.configured
+    ? `Ollama ${capitalize(subscription.plan)}`
+    : "Ollama Cloud";
+  const subAmount = subscription.configured
+    ? `${formatPlanUsd(subscription.monthlyUsd ?? 0)}/mo`
+    : "plan not set";
+  const meteredAmount = metered.monthCostUsd != null ? formatUsd(metered.monthCostUsd) : "$0";
+  const totalText = billing.monthlyTotalUsd != null
+    ? `${subscription.configured ? "≈ " : ""}${formatUsd(billing.monthlyTotalUsd)}${billing.monthlyTotalComplete ? "" : " +"}`
+    : "—";
+  return (
+    <div className="hm-usage-cost" role="group" aria-label="Cost this month">
+      <div className="hm-usage-cost-head">
+        <span className="hm-usage-cost-label">Cost this month</span>
+        <span className="hm-usage-cost-total" title={billing.monthlyTotalComplete ? undefined : "Excludes the Ollama subscription — set OLLAMA_PLAN to include it."}>{totalText}</span>
+      </div>
+      <div className="hm-usage-cost-rows">
+        <div className="hm-usage-cost-row">
+          <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-hermes)" }} aria-hidden />
+          <span className="hm-usage-cost-name">{planName} · flat</span>
+          <span className={`hm-usage-cost-amt${subscription.configured ? "" : " hm-usage-c-na"}`}>{subAmount}</span>
+        </div>
+        <div className="hm-usage-cost-row">
+          <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-claude)" }} aria-hidden />
+          <span className="hm-usage-cost-name">Metered · Claude API</span>
+          <span className="hm-usage-cost-amt">{meteredAmount}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Per-row cost cell, billing-aware. Subscription (Ollama) rows show a muted
+ * "flat" tag instead of a misleading "?" — their cost lives in the flat plan,
+ * not per call. Metered rows show the real recorded dollars (or "?" if a
+ * metered provider didn't emit cost). Unknown rows stay "?".
+ */
+function RowCost({ entry }: { entry: LlmUsageModelRollup }) {
+  if (billingClassOf(entry.agent, entry.model) === "subscription") {
+    return (
+      <span
+        className="hm-usage-c-num hm-usage-c-flat"
+        title="Included in your flat Ollama subscription — billed by GPU-time, not per call."
+      >
+        flat
+      </span>
+    );
+  }
+  if (entry.costStatus === "recorded") {
+    return <span className="hm-usage-c-num">{formatCost(entry.costUsd, entry.costStatus)}</span>;
+  }
+  return <span className="hm-usage-c-num hm-usage-c-na" title="cost not reported">?</span>;
+}
+
+/**
+ * Ollama subscription burn — how much of the plan's allocation you've used in
+ * Ollama's real reset windows (5h session · 7d week · this month). Tokens/calls
+ * are a proxy for GPU-time (the real metered unit, which Ollama doesn't expose),
+ * flagged as such — never dressed up as dollars.
+ */
+function OllamaBurn({ billing }: { billing: LlmUsageBilling }) {
+  const { subscription } = billing;
+  const windows = subscription.windows;
+  if (!windows) return null;
+  const planName = subscription.configured ? `${capitalize(subscription.plan)} plan` : "Cloud";
+  const cells: LlmUsageWindow[] = [windows.session5h, windows.week7d, windows.month];
+  return (
+    <div className="hm-usage-burn" role="group" aria-label="Ollama subscription burn">
+      <div className="hm-usage-burn-head">
+        <span className="hm-usage-burn-title">Ollama burn · {planName}</span>
+        <span className="hm-usage-burn-chip" title="Tokens/calls are a proxy for GPU-time — Ollama's real metered unit — not dollars.">proxy</span>
+      </div>
+      <div className="hm-usage-burn-windows">
+        {cells.map((win) => (
+          <div className="hm-usage-burn-win" key={win.label}>
+            <span className="hm-usage-burn-win-label">{win.label}</span>
+            <strong className="hm-usage-burn-win-tok">{formatCompactNumber(win.tokens)}</strong>
+            <small className="hm-usage-burn-win-calls">{formatNumber(win.calls)} calls</small>
+          </div>
+        ))}
+      </div>
+      <small className="hm-usage-burn-note">{billing.note}</small>
+    </div>
+  );
+}
+
+/**
+ * Billing model for an (agent, model) — mirrors the backend llmBillingClass so
+ * a row's cost cell matches how the aggregate classed it. Ollama Cloud (`:cloud`
+ * suffix / ollama-tagged / the hermes agent) is flat-rate subscription; the
+ * Claude SDK agents are metered; everything else is unknown.
+ */
+function billingClassOf(agent: string, model: string): "subscription" | "metered" | "unknown" {
+  const a = agent.trim().toLowerCase();
+  const m = model.trim().toLowerCase();
+  if (m.endsWith(":cloud") || m.includes("ollama") || a === "hermes") return "subscription";
+  if (a === "claude" || a === "test-writer" || a === "security" || a === "docs") return "metered";
+  return "unknown";
+}
+
+function capitalize(value: string): string {
+  return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
+}
+
+/** Format a known dollar amount (assumes a real number, unlike formatCost). */
+function formatUsd(usd: number): string {
+  if (usd === 0) return "$0";
+  return usd < 0.01 ? "<$0.01" : `$${usd.toFixed(2)}`;
+}
+
+/** Plan price — drops the ".00" on whole-dollar tiers so "$20/mo" reads clean. */
+function formatPlanUsd(usd: number): string {
+  if (usd === 0) return "$0";
+  return Number.isInteger(usd) ? `$${usd}` : `$${usd.toFixed(2)}`;
 }
 
 function formatCost(usd: number | null | undefined, status: string): string {

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -118,6 +118,41 @@ export interface LlmUsageRecent {
   series: LlmUsageRecentSeries[];
 }
 
+/** A bounded usage window — tokens/calls between `since` and the snapshot anchor. */
+export interface LlmUsageWindow {
+  label: string;
+  tokens: number;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  since: string;
+}
+
+/** Cost split by billing model + Ollama subscription-burn windows. */
+export interface LlmUsageBilling {
+  metered: {
+    models: string[];
+    monthCostUsd: number | null;
+    costStatus: "recorded" | "not_recorded";
+  };
+  subscription: {
+    provider: "ollama";
+    plan: "free" | "pro" | "max" | "none";
+    monthlyUsd: number | null;
+    configured: boolean;
+    active: boolean;
+    models: string[];
+    windows: {
+      session5h: LlmUsageWindow;
+      week7d: LlmUsageWindow;
+      month: LlmUsageWindow;
+    } | null;
+  };
+  monthlyTotalUsd: number | null;
+  monthlyTotalComplete: boolean;
+  note: string;
+}
+
 export interface LlmUsageAggregate {
   status: "recorded" | "not_recorded";
   message?: string;
@@ -134,6 +169,9 @@ export interface LlmUsageAggregate {
   sourceStatus?: LlmUsageSourceStatus[];
   activeCalls?: LlmUsageActiveCall[];
   recent?: LlmUsageRecent | null;
+  /** Cost split by billing model + Ollama subscription-burn windows (optional:
+   *  absent on older cached payloads, so the UI must degrade gracefully). */
+  billing?: LlmUsageBilling;
 }
 
 export interface MonitorEvent {

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -178,6 +178,142 @@
 .hm-usage-bar-in { background: var(--h4-tel); opacity: 0.8; }
 .hm-usage-bar-out { background: var(--h4-tel); opacity: 0.32; }
 
+/* ── Cost this month — flat subscription vs metered $, an honest headline ──── */
+.hm-usage-cost {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 11px;
+  padding: 10px 11px;
+  border: 1px solid var(--h4-line-2);
+  border-radius: 9px;
+  background: var(--h4-paper-sunken);
+}
+.hm-usage-cost-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+.hm-usage-cost-label {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-usage-cost-total {
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--h4-ink);
+  letter-spacing: -0.01em;
+}
+.hm-usage-cost-rows {
+  display: grid;
+  gap: 5px;
+}
+.hm-usage-cost-row {
+  display: grid;
+  grid-template-columns: 6px 1fr auto;
+  align-items: center;
+  gap: 8px;
+}
+.hm-usage-cost-name {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--h4-ink-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-usage-cost-amt {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--h4-muted);
+  text-align: right;
+}
+.hm-usage-cost-amt.hm-usage-c-na {
+  color: var(--h4-faint);
+}
+
+/* the "flat" tag on a subscription row — muted telemetry, not a dead "?" */
+.hm-usage-c-flat {
+  color: var(--h4-tel);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+
+/* ── Ollama subscription burn — usage against its real 5h/7d/month windows ── */
+.hm-usage-burn {
+  display: grid;
+  gap: 8px;
+  margin-top: 11px;
+  padding-top: 10px;
+  border-top: 1px solid var(--h4-line-2);
+}
+.hm-usage-burn-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.hm-usage-burn-title {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-usage-burn-chip {
+  font-family: var(--font-display);
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--h4-tel);
+  border: 1px solid var(--h4-line-2);
+  border-radius: 5px;
+  padding: 1px 5px;
+}
+.hm-usage-burn-windows {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.hm-usage-burn-win {
+  display: grid;
+  gap: 2px;
+  padding: 7px 8px;
+  border: 1px solid var(--h4-line-2);
+  border-radius: 7px;
+  background: var(--h4-paper-sunken);
+}
+.hm-usage-burn-win-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+}
+.hm-usage-burn-win-tok {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--h4-ink);
+}
+.hm-usage-burn-win-calls {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+}
+.hm-usage-burn-note {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.45;
+  color: var(--h4-faint);
+  text-wrap: pretty;
+}
+
 .hm-usage-empty {
   display: grid;
   gap: 5px;

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -25,6 +25,7 @@ import {
 import {
   aggregateLlmUsage,
   listActiveLlmUsageCalls,
+  resolveOllamaPlan,
   type LlmUsageAggregate,
   type LlmUsageEvent,
 } from "@avg/averray-mcp/llm-usage";
@@ -2421,6 +2422,8 @@ export function buildV2BoardSnapshot(
       activeCalls: listActiveLlmUsageCalls(),
       // Anchor the live "tokens/min" window to the snapshot time.
       now: snapshotAt,
+      // Ollama Cloud flat-plan cost + subscription-burn windows (env: OLLAMA_PLAN).
+      subscription: resolveOllamaPlan(process.env),
     }),
     testbedSuites: testbedSuitesFromSnapshot(rawSnapshot),
     automationHealth: automationHealthForBoard(rawSnapshot, snapshotAt, process.env, {


### PR DESCRIPTION
## Why
The LLM-usage panel couldn't answer two operator questions: *how high are the costs?* and *how much of my Ollama sub have I burnt?* It showed `?` for every Ollama `:cloud` model's cost and a single **$0.16** "All models" total — which is really just the one metered Claude call, not total spend.

The root cause is a genuine billing difference, confirmed against Ollama's 2026 pricing: **Ollama Cloud is a flat monthly plan metered by GPU-time — not tokens or per-call dollars.** So there is *no truthful per-token $* to show for the `:cloud` models. Claude is the opposite — its SDK reports a real `total_cost_usd` (the `$0.16`).

## What
Splits usage by billing model and never fabricates a subscription dollar figure.

**Backend (`averray-mcp/llm-usage.ts`)** — a `billing` block on the aggregate:
- `metered` — recorded Claude $ (month-to-date).
- `subscription` — flat Ollama plan ($20 Pro) + **burn windows** against Ollama's real resets: **5h session · 7d week · month**. Tokens/calls stand in for GPU-time (the real metered unit we don't have), flagged as a proxy.
- `monthlyTotalUsd` — honest month total (flat plan + metered $); `monthlyTotalComplete` is false when the plan is unset so the UI can flag the gap.
- `resolveOllamaPlan(env)` reads `OLLAMA_PLAN=free|pro|max` (unset → "plan not set", never invented).

**Frontend (`UsagePanel.tsx`)**:
- A **Cost this month** headline: `Ollama Pro (flat) $20/mo` + `Metered (Claude) $0.16` = `≈ $20.16`.
- Subscription rows show a muted **flat** tag instead of a misleading `?`.
- An **Ollama burn · Pro plan** block with the three windows + the honest GPU-time note.

**compose** — `OLLAMA_PLAN` passthrough (dormant until set on the VPS).

## Truth boundary
No per-token dollar is ever invented for Ollama. The flat plan price is labelled *flat*; window counts are labelled a *proxy*; an unset plan shows *plan not set* and marks the total incomplete. Only Claude's SDK-recorded $ appears as real spend.

## Deploy
Requires `OLLAMA_PLAN=pro` in `.env.prod` + a `--build` redeploy (frontend + backend both changed).

## Tests
- `averray-mcp` billing: **7/7** (plan resolve, billing-class, windows, honest totals, unset-plan, no-clock).
- `monitor-ui`: **807/807** (incl. 13 `UsagePanel` — cost headline, flat tag, burn windows, unset-plan).
- `averray-mcp` build ✓ · `monitor-ui` typecheck 0 · SPA build ✓. (slack-operator's local tsc shows the known stale-`@avg`-subpath baseline; CI fresh-build resolves it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)