### PR TITLE
feat(monitor): add Codex (ChatGPT) as a second flat-rate subscription

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -255,6 +255,9 @@ services:
       # Ollama Cloud subscription tier (free|pro|max) — sets the flat monthly cost
       # the LLM-usage panel shows as real recurring spend. Unset → "plan not set".
       OLLAMA_PLAN: ${OLLAMA_PLAN:-}
+      # Codex/ChatGPT subscription tier (free|go|plus|pro5x|pro) — flat monthly cost
+      # for the codex agent in the same panel. Unset → "plan not set".
+      CODEX_PLAN: ${CODEX_PLAN:-}
       HERMES_MONITOR_REPLY_MODEL: ${HERMES_MONITOR_REPLY_MODEL:-glm-5.2:cloud}
       # Preferred co-pilot transport: the real agentic Hermes via the gateway
       # Session API (MCP tools + skills + memory), instead of the stateless Ollama

--- a/packages/averray-mcp/src/llm-usage.test.ts
+++ b/packages/averray-mcp/src/llm-usage.test.ts
@@ -3,124 +3,130 @@ import { describe, expect, it } from "vitest";
 import {
   aggregateLlmUsage,
   llmBillingClass,
+  resolveCodexPlan,
   resolveOllamaPlan,
+  resolveSubscriptionPlans,
+  subscriptionProviderOf,
   type LlmUsageEvent,
+  type SubscriptionPlanConfig,
 } from "./llm-usage.js";
 
 function evt(over: Partial<LlmUsageEvent> & Pick<LlmUsageEvent, "agent" | "model" | "ts">): LlmUsageEvent {
-  return {
-    inputTokens: 0,
-    outputTokens: 0,
-    ...over,
-  };
+  return { inputTokens: 0, outputTokens: 0, ...over };
 }
 
-describe("resolveOllamaPlan", () => {
-  it("maps free/pro/max to their flat monthly price (case-insensitive)", () => {
-    expect(resolveOllamaPlan({ OLLAMA_PLAN: "pro" } as NodeJS.ProcessEnv)).toEqual({
-      plan: "pro",
-      monthlyUsd: 20,
-      configured: true,
-    });
-    expect(resolveOllamaPlan({ OLLAMA_PLAN: "MAX" } as NodeJS.ProcessEnv)).toEqual({
-      plan: "max",
-      monthlyUsd: 100,
-      configured: true,
-    });
-    expect(resolveOllamaPlan({ OLLAMA_PLAN: "free" } as NodeJS.ProcessEnv)).toEqual({
-      plan: "free",
-      monthlyUsd: 0,
-      configured: true,
-    });
+const OLLAMA_PRO: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "pro", planLabel: "Pro", monthlyUsd: 20, configured: true };
+const CODEX_PRO5X: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "pro5x", planLabel: "Pro 5×", monthlyUsd: 100, configured: true };
+const OLLAMA_UNSET: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "none", planLabel: "", monthlyUsd: null, configured: false };
+const CODEX_UNSET: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "none", planLabel: "", monthlyUsd: null, configured: false };
+
+describe("resolveOllamaPlan / resolveCodexPlan / resolveSubscriptionPlans", () => {
+  it("maps each provider's plan to its flat monthly price (case-insensitive, dash/underscore tolerant)", () => {
+    expect(resolveOllamaPlan({ OLLAMA_PLAN: "pro" } as NodeJS.ProcessEnv)).toEqual(OLLAMA_PRO);
+    expect(resolveOllamaPlan({ OLLAMA_PLAN: "MAX" } as NodeJS.ProcessEnv)).toMatchObject({ plan: "max", monthlyUsd: 100, configured: true });
+    expect(resolveCodexPlan({ CODEX_PLAN: "pro5x" } as NodeJS.ProcessEnv)).toEqual(CODEX_PRO5X);
+    expect(resolveCodexPlan({ CODEX_PLAN: "pro-5x" } as NodeJS.ProcessEnv)).toEqual(CODEX_PRO5X); // normalised
+    expect(resolveCodexPlan({ CODEX_PLAN: "plus" } as NodeJS.ProcessEnv)).toMatchObject({ plan: "plus", monthlyUsd: 20, planLabel: "Plus" });
   });
 
   it("treats unset / unknown plans as not configured (never invents a cost)", () => {
-    expect(resolveOllamaPlan({} as NodeJS.ProcessEnv)).toEqual({ plan: "none", monthlyUsd: null, configured: false });
-    expect(resolveOllamaPlan({ OLLAMA_PLAN: "enterprise" } as NodeJS.ProcessEnv)).toEqual({
-      plan: "none",
-      monthlyUsd: null,
-      configured: false,
-    });
+    expect(resolveOllamaPlan({} as NodeJS.ProcessEnv)).toEqual(OLLAMA_UNSET);
+    expect(resolveCodexPlan({ CODEX_PLAN: "enterprise" } as NodeJS.ProcessEnv)).toEqual(CODEX_UNSET);
+  });
+
+  it("resolveSubscriptionPlans returns both providers from env", () => {
+    const plans = resolveSubscriptionPlans({ OLLAMA_PLAN: "pro", CODEX_PLAN: "pro5x" } as NodeJS.ProcessEnv);
+    expect(plans.map((p) => p.provider)).toEqual(["ollama", "codex"]);
+    expect(plans).toEqual([OLLAMA_PRO, CODEX_PRO5X]);
   });
 });
 
-describe("llmBillingClass", () => {
-  it("classes Ollama Cloud (:cloud / ollama / hermes) as subscription", () => {
-    expect(llmBillingClass("hermes", "glm-5.2:cloud")).toBe("subscription");
-    expect(llmBillingClass("hermes", "deepseek-v4-pro:cloud")).toBe("subscription");
-    expect(llmBillingClass("worker", "some-ollama-model")).toBe("subscription");
-    expect(llmBillingClass("hermes", "not_recorded")).toBe("subscription");
+describe("subscriptionProviderOf / llmBillingClass", () => {
+  it("attributes events to their subscription provider", () => {
+    expect(subscriptionProviderOf("hermes", "glm-5.2:cloud")).toBe("ollama");
+    expect(subscriptionProviderOf("worker", "some-ollama-model")).toBe("ollama");
+    expect(subscriptionProviderOf("codex", "gpt-5.5-codex")).toBe("codex");
+    expect(subscriptionProviderOf("claude", "claude-opus")).toBeNull();
   });
 
-  it("classes the Claude SDK agents as metered, everything else unknown", () => {
+  it("classes both Ollama and Codex as subscription, Claude agents as metered, else unknown", () => {
+    expect(llmBillingClass("hermes", "glm-5.2:cloud")).toBe("subscription");
+    expect(llmBillingClass("codex", "gpt-5.5-codex")).toBe("subscription");
     expect(llmBillingClass("claude", "not_recorded")).toBe("metered");
     expect(llmBillingClass("test-writer", "claude-opus-4")).toBe("metered");
-    expect(llmBillingClass("security", "claude-sonnet")).toBe("metered");
-    expect(llmBillingClass("codex", "gpt-x")).toBe("unknown");
+    expect(llmBillingClass("someone-else", "mystery")).toBe("unknown");
   });
 });
 
-describe("aggregateLlmUsage — billing block", () => {
+describe("aggregateLlmUsage — billing block (multi-provider)", () => {
   const NOW = new Date("2026-07-07T12:00:00.000Z");
-  // Ollama (subscription) events at varying ages.
-  const subA = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-07-07T11:00:00.000Z", inputTokens: 100, outputTokens: 50, cacheTokens: 1000 }); // 1h ago → 1150 tok
-  const subB = evt({ agent: "hermes", model: "deepseek-v4-pro:cloud", ts: "2026-07-07T09:00:00.000Z", inputTokens: 8, outputTokens: 2700 }); // 3h ago → 2708 tok
-  const subC = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-07-07T05:00:00.000Z", inputTokens: 10, outputTokens: 20, cacheTokens: 100 }); // 7h ago → 130 tok, outside 5h
-  const subOld = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-06-15T00:00:00.000Z", inputTokens: 5, outputTokens: 5 }); // last month
-  // Claude (metered) event with a recorded cost, this month.
+  const ollamaA = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-07-07T11:00:00.000Z", inputTokens: 100, outputTokens: 50, cacheTokens: 1000 }); // 1h → 1150
+  const ollamaB = evt({ agent: "hermes", model: "deepseek-v4-pro:cloud", ts: "2026-07-07T09:00:00.000Z", inputTokens: 8, outputTokens: 2700 }); // 3h → 2708
+  const codexA = evt({ agent: "codex", model: "gpt-5.5-codex", ts: "2026-07-07T11:30:00.000Z", inputTokens: 1000, outputTokens: 500 }); // 30m → 1500
   const metered = evt({ agent: "claude", model: "not_recorded", ts: "2026-07-06T00:00:00.000Z", inputTokens: 8, outputTokens: 2700, cacheTokens: 160000, costUsd: 0.16 });
 
-  it("splits subscription windows and metered $, and totals them honestly for a configured plan", () => {
-    const agg = aggregateLlmUsage([subA, subB, subC, subOld, metered], {
+  it("builds one entry per configured/active provider and totals every flat plan + metered $", () => {
+    const b = aggregateLlmUsage([ollamaA, ollamaB, codexA, metered], {
       now: NOW,
-      subscription: { plan: "pro", monthlyUsd: 20, configured: true },
-    });
-    const b = agg.billing;
+      subscriptions: [OLLAMA_PRO, CODEX_PRO5X],
+    }).billing;
 
-    // Subscription side — flat Ollama Pro, active, correct windows (tokens = in+out+cache).
-    expect(b.subscription.provider).toBe("ollama");
-    expect(b.subscription.plan).toBe("pro");
-    expect(b.subscription.monthlyUsd).toBe(20);
-    expect(b.subscription.configured).toBe(true);
-    expect(b.subscription.active).toBe(true);
-    expect(b.subscription.models).toContain("glm-5.2:cloud");
+    expect(b.subscriptions.map((s) => s.provider)).toEqual(["ollama", "codex"]);
 
-    const w = b.subscription.windows!;
-    // 5h session excludes subC (7h old) and subOld.
-    expect(w.session5h.calls).toBe(2);
-    expect(w.session5h.tokens).toBe(1150 + 2708);
-    // 7d week + this month include subA/B/C but not last-month subOld.
-    expect(w.week7d.calls).toBe(3);
-    expect(w.week7d.tokens).toBe(1150 + 2708 + 130);
-    expect(w.month.calls).toBe(3);
-    expect(w.month.tokens).toBe(1150 + 2708 + 130);
+    const ollama = b.subscriptions.find((s) => s.provider === "ollama")!;
+    expect(ollama.monthlyUsd).toBe(20);
+    expect(ollama.active).toBe(true);
+    expect(ollama.windows!.session5h.tokens).toBe(1150 + 2708);
+    expect(ollama.windows!.session5h.calls).toBe(2);
+    expect(ollama.note).toMatch(/GPU-time/i);
 
-    // Metered side — real recorded $ this month.
+    const codex = b.subscriptions.find((s) => s.provider === "codex")!;
+    expect(codex.monthlyUsd).toBe(100);
+    expect(codex.planLabel).toBe("Pro 5×");
+    expect(codex.active).toBe(true);
+    expect(codex.windows!.session5h.tokens).toBe(1500);
+    expect(codex.windows!.session5h.calls).toBe(1);
+    expect(codex.note).toMatch(/ChatGPT/i);
+
     expect(b.metered.monthCostUsd).toBe(0.16);
-    expect(b.metered.costStatus).toBe("recorded");
-
-    // Honest month total = flat plan + metered $, and it's complete.
-    expect(b.monthlyTotalUsd).toBe(20.16);
+    expect(b.monthlyTotalUsd).toBe(120.16); // 20 + 100 + 0.16
     expect(b.monthlyTotalComplete).toBe(true);
-    expect(b.note).toMatch(/GPU-time/i);
   });
 
-  it("never invents a subscription cost when the plan is unset — total is metered-only + flagged incomplete", () => {
-    const agg = aggregateLlmUsage([subA, metered], { now: NOW }); // no subscription option
-    const b = agg.billing;
-    expect(b.subscription.configured).toBe(false);
-    expect(b.subscription.monthlyUsd).toBeNull();
-    expect(b.subscription.plan).toBe("none");
-    // Total excludes the (unknown) Ollama cost, so it's incomplete.
+  it("shows a configured provider that reports NO usage as flat-cost-only (no windows, honest note)", () => {
+    const b = aggregateLlmUsage([ollamaA, metered], {
+      now: NOW,
+      subscriptions: [OLLAMA_PRO, CODEX_PRO5X], // Codex configured but no codex events
+    }).billing;
+
+    const codex = b.subscriptions.find((s) => s.provider === "codex")!;
+    expect(codex.active).toBe(false);
+    expect(codex.windows).toBeNull();
+    expect(codex.monthlyUsd).toBe(100); // flat cost still counted
+    expect(codex.note).toMatch(/isn't emitting|no burn proxy/i);
+    expect(b.monthlyTotalUsd).toBe(120.16);
+    expect(b.monthlyTotalComplete).toBe(true);
+  });
+
+  it("omits a provider that is neither configured nor active, and flags an unconfigured-but-active one", () => {
+    const b = aggregateLlmUsage([ollamaA, metered], {
+      now: NOW,
+      subscriptions: [OLLAMA_UNSET, CODEX_UNSET], // neither configured
+    }).billing;
+    // Ollama has usage → shown (active, unconfigured); Codex has neither → omitted.
+    expect(b.subscriptions.map((s) => s.provider)).toEqual(["ollama"]);
+    expect(b.subscriptions[0]!.configured).toBe(false);
+    expect(b.subscriptions[0]!.active).toBe(true);
+    // Total is metered-only and flagged incomplete (an active plan has no price).
     expect(b.monthlyTotalUsd).toBe(0.16);
     expect(b.monthlyTotalComplete).toBe(false);
   });
 
-  it("leaves windows null when there is no clock to anchor them", () => {
-    const agg = aggregateLlmUsage([subA], { subscription: { plan: "pro", monthlyUsd: 20, configured: true } });
-    expect(agg.billing.subscription.windows).toBeNull();
-    // A configured flat plan still surfaces its price even without a clock.
-    expect(agg.billing.monthlyTotalUsd).toBe(20);
-    expect(agg.billing.monthlyTotalComplete).toBe(true);
+  it("keeps a configured flat cost even with no clock to anchor windows", () => {
+    const b = aggregateLlmUsage([codexA], { subscriptions: [CODEX_PRO5X] }).billing;
+    const codex = b.subscriptions.find((s) => s.provider === "codex")!;
+    expect(codex.windows).toBeNull();
+    expect(b.monthlyTotalUsd).toBe(100);
+    expect(b.monthlyTotalComplete).toBe(true);
   });
 });

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -83,14 +83,39 @@ export interface LlmUsageWindow {
 }
 
 /**
+ * One flat-rate subscription provider (Ollama Cloud, Codex/ChatGPT). Billed by a
+ * fixed monthly plan — GPU-time / rolling-window usage, NOT per token — so there
+ * is no truthful per-call $. We surface the flat plan price plus a token/call
+ * burn proxy against the provider's real reset windows, but only when the
+ * provider actually reports usage (`active`); Codex's CLI may not, in which case
+ * `windows` is null and the flat cost stands alone.
+ */
+export interface SubscriptionBilling {
+  provider: "ollama" | "codex";
+  label: string;
+  plan: string;
+  planLabel: string;
+  monthlyUsd: number | null;
+  configured: boolean;
+  active: boolean;
+  models: string[];
+  windows: {
+    session5h: LlmUsageWindow;
+    week7d: LlmUsageWindow;
+    month: LlmUsageWindow;
+  } | null;
+  note: string;
+}
+
+/**
  * How usage maps to money, split by the two billing models actually in play:
  *   - metered   → per-token providers that report a real dollar cost (Claude SDK).
- *   - subscription → flat-rate providers (Ollama Cloud) billed by GPU-time, NOT
- *     per token. There is no truthful per-call $, so we surface the flat plan
- *     price plus a token/call burn proxy against Ollama's real reset windows.
- * `monthlyTotalUsd` is the honest month-to-date picture (flat plan + metered $);
- * `monthlyTotalComplete` is false when the Ollama plan isn't configured, so the
- * UI can say the total excludes the (unknown) subscription cost.
+ *   - subscriptions → flat-rate providers (Ollama, Codex/ChatGPT) billed by a
+ *     fixed monthly plan, NOT per token. Each surfaces its flat price plus a burn
+ *     proxy against its reset windows (when it reports usage).
+ * `monthlyTotalUsd` is the honest month-to-date picture (every configured flat
+ * plan + metered $); `monthlyTotalComplete` is false when a shown subscription's
+ * plan isn't configured, so the UI can flag that the total is missing a cost.
  */
 export interface LlmUsageBilling {
   metered: {
@@ -98,27 +123,17 @@ export interface LlmUsageBilling {
     monthCostUsd: number | null;
     costStatus: "recorded" | "not_recorded";
   };
-  subscription: {
-    provider: "ollama";
-    plan: "free" | "pro" | "max" | "none";
-    monthlyUsd: number | null;
-    configured: boolean;
-    active: boolean;
-    models: string[];
-    windows: {
-      session5h: LlmUsageWindow;
-      week7d: LlmUsageWindow;
-      month: LlmUsageWindow;
-    } | null;
-  };
+  subscriptions: SubscriptionBilling[];
   monthlyTotalUsd: number | null;
   monthlyTotalComplete: boolean;
-  note: string;
 }
 
-/** Resolved Ollama Cloud subscription plan (caller reads it from env). */
-export interface OllamaPlanConfig {
-  plan: "free" | "pro" | "max" | "none";
+/** Resolved flat-rate subscription plan for one provider (caller reads env). */
+export interface SubscriptionPlanConfig {
+  provider: "ollama" | "codex";
+  label: string;
+  plan: string;
+  planLabel: string;
   monthlyUsd: number | null;
   configured: boolean;
 }
@@ -162,9 +177,9 @@ export interface LlmUsageAggregateOptions {
   now?: Date;
   /** Recent-window length in minutes (default 60). */
   recentWindowMinutes?: number;
-  /** Ollama Cloud subscription plan for the billing block (caller resolves it
-   *  from env via resolveOllamaPlan). Omitted → treated as not configured. */
-  subscription?: OllamaPlanConfig;
+  /** Flat-rate subscription plans (Ollama, Codex) for the billing block — caller
+   *  resolves them from env via resolveSubscriptionPlans. Omitted → none. */
+  subscriptions?: readonly SubscriptionPlanConfig[];
 }
 
 export interface LlmUsageActiveCallInput {
@@ -186,9 +201,13 @@ const DEFAULT_SOURCE_REASONS: Readonly<Record<string, string>> = {
   hermes: "Hermes monitor replies may be templated when OLLAMA_API_KEY is unset; live Hermes agent usage is recorded from post_llm_call traces when provider counters are present.",
 };
 
-/** Ollama Cloud flat monthly plan prices (USD). Free/Pro/Max — no per-token bill. */
+/** Flat monthly plan prices (USD) per provider — no per-token bill for these. */
 const OLLAMA_PLAN_MONTHLY_USD: Readonly<Record<string, number>> = { free: 0, pro: 20, max: 100 };
-/** Ollama's real usage reset windows: a 5-hour session window and a 7-day week. */
+const OLLAMA_PLAN_LABELS: Readonly<Record<string, string>> = { free: "Free", pro: "Pro", max: "Max" };
+// Codex draws from the ChatGPT plan: Free/Go/Plus, Pro 5× ($100, Apr 2026), Pro ($200).
+const CODEX_PLAN_MONTHLY_USD: Readonly<Record<string, number>> = { free: 0, go: 8, plus: 20, pro5x: 100, pro: 200 };
+const CODEX_PLAN_LABELS: Readonly<Record<string, string>> = { free: "Free", go: "Go", plus: "Plus", pro5x: "Pro 5×", pro: "Pro" };
+/** Real usage reset windows shared by these subscriptions: 5-hour session, 7-day week. */
 const SESSION_WINDOW_MS = 5 * 60 * 60 * 1000;
 const WEEK_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 /** Agents whose usage is metered per token (Claude Agent SDK reports real cost). */
@@ -197,6 +216,12 @@ const OLLAMA_BURN_NOTE =
   "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars. "
   + "The token/call counts here are a burn proxy; Ollama emails you near 90% of your allocation "
   + "(session resets ~5h, weekly resets ~7d).";
+const CODEX_BURN_NOTE =
+  "Codex draws from your ChatGPT plan, metered against a rolling ~5-hour window — not per-call dollars. "
+  + "The token/call counts here are a burn proxy.";
+const CODEX_NO_USAGE_NOTE =
+  "Codex draws from your ChatGPT plan (rolling ~5-hour window). The Codex CLI isn't emitting token "
+  + "counters, so there's no burn proxy yet — the flat plan price is your spend.";
 
 const activeCalls = new Map<string, LlmUsageActiveCall>();
 let nextActiveCallId = 0;
@@ -206,26 +231,61 @@ let nextActiveCallId = 0;
  * Unknown/unset → not configured, so the UI shows an honest "plan not set" state
  * instead of inventing a subscription cost.
  */
-export function resolveOllamaPlan(env: NodeJS.ProcessEnv = process.env): OllamaPlanConfig {
-  const raw = env.OLLAMA_PLAN?.trim().toLowerCase();
-  if (raw && raw in OLLAMA_PLAN_MONTHLY_USD) {
-    return { plan: raw as "free" | "pro" | "max", monthlyUsd: OLLAMA_PLAN_MONTHLY_USD[raw]!, configured: true };
+export function resolveOllamaPlan(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig {
+  return resolvePlan("ollama", "Ollama", env.OLLAMA_PLAN, OLLAMA_PLAN_MONTHLY_USD, OLLAMA_PLAN_LABELS);
+}
+
+/**
+ * Resolve the Codex (ChatGPT) subscription plan from env
+ * (CODEX_PLAN=free|go|plus|pro5x|pro; "pro-5x"/"pro_5x" normalise to pro5x).
+ * Unknown/unset → not configured.
+ */
+export function resolveCodexPlan(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig {
+  return resolvePlan("codex", "Codex", env.CODEX_PLAN, CODEX_PLAN_MONTHLY_USD, CODEX_PLAN_LABELS);
+}
+
+/** Both known subscription providers, resolved from env — for aggregateLlmUsage. */
+export function resolveSubscriptionPlans(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig[] {
+  return [resolveOllamaPlan(env), resolveCodexPlan(env)];
+}
+
+function resolvePlan(
+  provider: "ollama" | "codex",
+  label: string,
+  raw: string | undefined,
+  prices: Readonly<Record<string, number>>,
+  labels: Readonly<Record<string, string>>,
+): SubscriptionPlanConfig {
+  const key = raw?.trim().toLowerCase().replace(/[-_\s]/g, "");
+  if (key && key in prices) {
+    return { provider, label, plan: key, planLabel: labels[key] ?? key, monthlyUsd: prices[key]!, configured: true };
   }
-  return { plan: "none", monthlyUsd: null, configured: false };
+  return { provider, label, plan: "none", planLabel: "", monthlyUsd: null, configured: false };
+}
+
+/**
+ * The flat-rate subscription provider for an (agent, model), or null when it
+ * isn't a subscription:
+ *   - ollama → the hermes agent, a `:cloud` model suffix, or an ollama-tagged model.
+ *   - codex  → the codex agent.
+ */
+export function subscriptionProviderOf(agent: string, model: string): "ollama" | "codex" | null {
+  const a = agent.trim().toLowerCase();
+  const m = model.trim().toLowerCase();
+  if (a === "codex") return "codex";
+  if (a === "hermes" || m.endsWith(":cloud") || m.includes("ollama")) return "ollama";
+  return null;
 }
 
 /**
  * Classify an (agent, model) into its billing model:
- *   - subscription → Ollama Cloud (`:cloud` model suffix, an ollama-tagged model,
- *     or the hermes agent, which runs on Ollama). Flat-rate, no per-token $.
+ *   - subscription → a flat-rate provider (Ollama or Codex). No per-token $.
  *   - metered → Claude Agent SDK agents (claude + specialists) that report cost.
  *   - unknown → anything else (counted for tokens, never assigned a cost).
  */
 export function llmBillingClass(agent: string, model: string): "subscription" | "metered" | "unknown" {
-  const a = agent.trim().toLowerCase();
-  const m = model.trim().toLowerCase();
-  if (m.endsWith(":cloud") || m.includes("ollama") || a === "hermes") return "subscription";
-  if (METERED_AGENTS.has(a)) return "metered";
+  if (subscriptionProviderOf(agent, model)) return "subscription";
+  if (METERED_AGENTS.has(agent.trim().toLowerCase())) return "metered";
   return "unknown";
 }
 
@@ -365,7 +425,7 @@ export function aggregateLlmUsage(
   const total = totalsFor(events);
   const sourceStatus = sourceStatuses(events, options);
   const recent = buildRecent(events, options.now, options.recentWindowMinutes ?? 60);
-  const billing = buildBilling(events, options.now, options.subscription);
+  const billing = buildBilling(events, options.now, options.subscriptions);
   const status = events.length > 0 ? "recorded" : "not_recorded";
   return {
     status,
@@ -384,23 +444,22 @@ export function aggregateLlmUsage(
 }
 
 /**
- * Build the billing block: split usage into metered (real recorded $) and
- * subscription (Ollama flat plan + token/call burn windows), plus an honest
- * month-to-date total. No per-token dollar figure is ever invented for the
- * subscription side — Ollama meters GPU-time, which we don't have, so tokens
- * and calls stand in as the burn proxy.
+ * Build the billing block: split usage into metered (real recorded $) and one
+ * entry per flat-rate subscription provider (Ollama, Codex), each with its flat
+ * plan price and a token/call burn proxy against its reset windows — plus an
+ * honest month-to-date total. No per-token dollar figure is ever invented for a
+ * subscription; when a provider reports no usage (e.g. the Codex CLI), its
+ * windows are null and the flat price stands alone.
  */
 function buildBilling(
   events: readonly LlmUsageEvent[],
   now: Date | undefined,
-  plan: OllamaPlanConfig | undefined,
+  plans: readonly SubscriptionPlanConfig[] | undefined,
 ): LlmUsageBilling {
-  const resolved: OllamaPlanConfig = plan ?? { plan: "none", monthlyUsd: null, configured: false };
   const anchor = now && Number.isFinite(now.getTime()) ? now : undefined;
   const endMs = anchor ? anchor.getTime() : undefined;
   const monthStartMs = anchor ? startOfUtcMonthMs(anchor) : undefined;
 
-  const subscriptionEvents = events.filter((event) => llmBillingClass(event.agent, event.model) === "subscription");
   const meteredEvents = events.filter((event) => llmBillingClass(event.agent, event.model) === "metered");
 
   // Metered $ this month — recorded costs only (never fabricated).
@@ -415,17 +474,40 @@ function buildBilling(
     }
   }
 
-  const windows = endMs !== undefined && monthStartMs !== undefined
-    ? {
-        session5h: usageWindowFor(subscriptionEvents, endMs - SESSION_WINDOW_MS, endMs, "5h session"),
-        week7d: usageWindowFor(subscriptionEvents, endMs - WEEK_WINDOW_MS, endMs, "7d week"),
-        month: usageWindowFor(subscriptionEvents, monthStartMs, endMs, "this month"),
-      }
-    : null;
+  // One entry per provider that's either configured (has a flat cost to show) or
+  // active (has usage). Providers that are neither are omitted — no clutter.
+  const subscriptions: SubscriptionBilling[] = [];
+  for (const plan of plans ?? []) {
+    const provEvents = events.filter((event) => subscriptionProviderOf(event.agent, event.model) === plan.provider);
+    const active = provEvents.length > 0;
+    if (!plan.configured && !active) continue;
+    const windows = endMs !== undefined && monthStartMs !== undefined && active
+      ? {
+          session5h: usageWindowFor(provEvents, endMs - SESSION_WINDOW_MS, endMs, "5h session"),
+          week7d: usageWindowFor(provEvents, endMs - WEEK_WINDOW_MS, endMs, "7d week"),
+          month: usageWindowFor(provEvents, monthStartMs, endMs, "this month"),
+        }
+      : null;
+    subscriptions.push({
+      provider: plan.provider,
+      label: plan.label,
+      plan: plan.plan,
+      planLabel: plan.planLabel,
+      monthlyUsd: plan.monthlyUsd,
+      configured: plan.configured,
+      active,
+      models: uniqueStrings(provEvents.map((event) => event.model)),
+      windows,
+      note: subscriptionNote(plan.provider, active),
+    });
+  }
 
-  const flatUsd = resolved.configured ? (resolved.monthlyUsd ?? 0) : null;
-  const monthlyTotalUsd = flatUsd !== null || monthCostUsd !== null
-    ? round((flatUsd ?? 0) + (monthCostUsd ?? 0), 6)
+  const flatSum = subscriptions
+    .filter((sub) => sub.configured)
+    .reduce((sum, sub) => sum + (sub.monthlyUsd ?? 0), 0);
+  const anyFlat = subscriptions.some((sub) => sub.configured);
+  const monthlyTotalUsd = anyFlat || monthCostUsd !== null
+    ? round((anyFlat ? flatSum : 0) + (monthCostUsd ?? 0), 6)
     : null;
 
   return {
@@ -434,21 +516,18 @@ function buildBilling(
       monthCostUsd,
       costStatus: meteredEvents.some((event) => typeof event.costUsd === "number") ? "recorded" : "not_recorded",
     },
-    subscription: {
-      provider: "ollama",
-      plan: resolved.plan,
-      monthlyUsd: resolved.monthlyUsd,
-      configured: resolved.configured,
-      active: subscriptionEvents.length > 0,
-      models: uniqueStrings(subscriptionEvents.map((event) => event.model)),
-      windows,
-    },
+    subscriptions,
     monthlyTotalUsd,
-    // Complete only when the flat subscription cost is known; otherwise the
-    // total is metered-only and the UI flags the Ollama gap.
-    monthlyTotalComplete: flatUsd !== null,
-    note: OLLAMA_BURN_NOTE,
+    // Complete only when every shown subscription's flat cost is known; an
+    // active-but-unconfigured provider makes the total incomplete (flagged in UI).
+    monthlyTotalComplete: subscriptions.every((sub) => sub.configured),
   };
+}
+
+/** Per-provider honest note: Ollama meters GPU-time; Codex may not report usage. */
+function subscriptionNote(provider: "ollama" | "codex", active: boolean): string {
+  if (provider === "codex") return active ? CODEX_BURN_NOTE : CODEX_NO_USAGE_NOTE;
+  return OLLAMA_BURN_NOTE;
 }
 
 /** Tokens/calls for subscription events inside [startMs, endMs] — the burn proxy. */

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, test } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 import { UsagePanel } from "./UsagePanel.js";
-import type { LlmUsageAggregate, LlmUsageBilling } from "../lib/monitor/board-cache.js";
+import type { LlmUsageAggregate, LlmUsageBilling, SubscriptionBilling } from "../lib/monitor/board-cache.js";
 
 afterEach(cleanup);
 
@@ -148,25 +148,41 @@ describe("UsagePanel", () => {
   });
 });
 
-// ── Cost & subscription burn (Ollama flat plan + metered Claude $) ──────────
+// ── Cost & subscription burn (Ollama + Codex flat plans + metered Claude $) ──
+const ollamaSub: SubscriptionBilling = {
+  provider: "ollama",
+  label: "Ollama",
+  plan: "pro",
+  planLabel: "Pro",
+  monthlyUsd: 20,
+  configured: true,
+  active: true,
+  models: ["glm-5.2:cloud", "deepseek-v4-pro:cloud"],
+  windows: {
+    session5h: { label: "5h session", tokens: 1_200_000, calls: 40, inputTokens: 1_000_000, outputTokens: 200_000, since: "2026-07-07T07:00:00.000Z" },
+    week7d: { label: "7d week", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
+    month: { label: "this month", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
+  },
+  note: "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars.",
+};
+// Codex configured (Pro 5× $100) but its CLI isn't reporting usage → flat cost only.
+const codexSub: SubscriptionBilling = {
+  provider: "codex",
+  label: "Codex",
+  plan: "pro5x",
+  planLabel: "Pro 5×",
+  monthlyUsd: 100,
+  configured: true,
+  active: false,
+  models: [],
+  windows: null,
+  note: "Codex draws from your ChatGPT plan. The Codex CLI isn't emitting token counters, so there's no burn proxy yet.",
+};
 const proBilling: LlmUsageBilling = {
   metered: { models: ["not_recorded"], monthCostUsd: 0.16, costStatus: "recorded" },
-  subscription: {
-    provider: "ollama",
-    plan: "pro",
-    monthlyUsd: 20,
-    configured: true,
-    active: true,
-    models: ["glm-5.2:cloud", "deepseek-v4-pro:cloud"],
-    windows: {
-      session5h: { label: "5h session", tokens: 1_200_000, calls: 40, inputTokens: 1_000_000, outputTokens: 200_000, since: "2026-07-07T07:00:00.000Z" },
-      week7d: { label: "7d week", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
-      month: { label: "this month", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
-    },
-  },
-  monthlyTotalUsd: 20.16,
+  subscriptions: [ollamaSub, codexSub],
+  monthlyTotalUsd: 120.16,
   monthlyTotalComplete: true,
-  note: "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars.",
 };
 
 const withBilling: LlmUsageAggregate = {
@@ -180,58 +196,81 @@ const withBilling: LlmUsageAggregate = {
   billing: proBilling,
 };
 
+// text matcher tolerant of the "×" glyph in "Pro 5×"
+const hasText = (needle: string) => (content: string) => content.includes(needle);
+
 describe("UsagePanel — cost & subscription burn", () => {
-  test("headlines an honest 'cost this month' = flat Ollama plan + metered Claude $", () => {
+  test("headlines an honest 'cost this month' = each flat plan (Ollama + Codex) + metered Claude $", () => {
     const { getByText } = render(<UsagePanel usage={withBilling} />);
     expect(getByText("Cost this month")).toBeTruthy();
-    expect(getByText(/≈\s*\$20\.16/)).toBeTruthy(); // flat $20 + metered $0.16
+    expect(getByText(/≈\s*\$120\.16/)).toBeTruthy(); // $20 + $100 + $0.16
     expect(getByText("Ollama Pro · flat")).toBeTruthy();
     expect(getByText("$20/mo")).toBeTruthy();
+    expect(getByText(hasText("Codex Pro"))).toBeTruthy(); // "Codex Pro 5× · flat"
+    expect(getByText("$100/mo")).toBeTruthy();
     expect(getByText("Metered · Claude API")).toBeTruthy();
   });
 
   test("a subscription (:cloud) row shows a muted 'flat' tag, not a misleading '?'", () => {
     const { getByText } = render(<UsagePanel usage={withBilling} />);
     expect(getByText("flat")).toBeTruthy(); // the glm-5.2:cloud row
-    // The metered Claude row still shows its real recorded dollars.
     const dollars = getByText("Cost this month").ownerDocument.body.textContent ?? "";
     expect(dollars).toContain("$0.16");
   });
 
-  test("renders the Ollama burn block against its real reset windows (tokens/calls as a proxy)", () => {
-    const { getByText, getAllByText } = render(<UsagePanel usage={withBilling} />);
+  test("renders the Ollama burn block; a configured-but-idle Codex shows cost only (no burn block)", () => {
+    const { getByText, getAllByText, queryByText } = render(<UsagePanel usage={withBilling} />);
     expect(getByText("Ollama burn · Pro plan")).toBeTruthy();
-    expect(getByText("proxy")).toBeTruthy();
     expect(getByText("5h session")).toBeTruthy();
-    expect(getByText("7d week")).toBeTruthy();
-    expect(getByText("this month")).toBeTruthy();
-    expect(getByText("40 calls")).toBeTruthy(); // 5h session
-    expect(getAllByText("92 calls").length).toBe(2); // week + month
-    expect(getByText(/GPU-time/)).toBeTruthy(); // the honest note
+    expect(getByText("40 calls")).toBeTruthy();
+    expect(getAllByText("92 calls").length).toBe(2);
+    expect(getByText(/GPU-time/)).toBeTruthy();
+    // Codex reports no usage → its cost shows in the strip but no burn windows.
+    expect(queryByText(hasText("Codex burn"))).toBeNull();
   });
 
-  test("when the plan is unset, shows 'plan not set' and flags the total incomplete — never invents a subscription $", () => {
+  test("renders a SECOND burn block for Codex once it reports usage", () => {
+    const codexActive: SubscriptionBilling = {
+      ...codexSub,
+      active: true,
+      models: ["gpt-5.5-codex"],
+      windows: {
+        session5h: { label: "5h session", tokens: 500_000, calls: 12, inputTokens: 400_000, outputTokens: 100_000, since: "2026-07-07T07:00:00.000Z" },
+        week7d: { label: "7d week", tokens: 900_000, calls: 30, inputTokens: 700_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
+        month: { label: "this month", tokens: 900_000, calls: 30, inputTokens: 700_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
+      },
+      note: "Codex draws from your ChatGPT plan, metered against a rolling ~5-hour window.",
+    };
+    const usage: LlmUsageAggregate = { ...withBilling, billing: { ...proBilling, subscriptions: [ollamaSub, codexActive] } };
+    const { getByText, getAllByText } = render(<UsagePanel usage={usage} />);
+    expect(getByText("Ollama burn · Pro plan")).toBeTruthy();
+    expect(getByText(hasText("Codex burn"))).toBeTruthy(); // "Codex burn · Pro 5× plan"
+    expect(getByText("12 calls")).toBeTruthy(); // codex 5h session
+    expect(getAllByText("5h session").length).toBe(2); // one window row per block
+  });
+
+  test("when a plan is unset, shows 'plan not set' and flags the total incomplete — never invents a subscription $", () => {
     const unset: LlmUsageAggregate = {
       ...withBilling,
       billing: {
-        ...proBilling,
-        subscription: { ...proBilling.subscription, plan: "none", monthlyUsd: null, configured: false },
+        metered: proBilling.metered,
+        subscriptions: [{ ...ollamaSub, plan: "none", planLabel: "", monthlyUsd: null, configured: false }],
         monthlyTotalUsd: 0.16,
         monthlyTotalComplete: false,
       },
     };
     const { getByText } = render(<UsagePanel usage={unset} />);
-    expect(getByText("Ollama Cloud · flat")).toBeTruthy();
+    expect(getByText("Ollama · flat")).toBeTruthy();
     expect(getByText("plan not set")).toBeTruthy();
     expect(getByText(/\$0\.16 \+/)).toBeTruthy(); // metered-only total, "+" signals the missing sub cost
   });
 
-  test("omits the burn block when there's no subscription activity or no window clock", () => {
-    const idleSub: LlmUsageAggregate = {
+  test("omits every burn block when no subscription is active", () => {
+    const idle: LlmUsageAggregate = {
       ...withBilling,
-      billing: { ...proBilling, subscription: { ...proBilling.subscription, active: false } },
+      billing: { ...proBilling, subscriptions: [{ ...ollamaSub, active: false }, codexSub] },
     };
-    const { queryByText } = render(<UsagePanel usage={idleSub} />);
-    expect(queryByText(/Ollama burn/)).toBeNull();
+    const { queryByText } = render(<UsagePanel usage={idle} />);
+    expect(queryByText(hasText("burn"))).toBeNull();
   });
 });

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -4,6 +4,7 @@ import type {
   LlmUsageModelRollup,
   LlmUsageRecent,
   LlmUsageWindow,
+  SubscriptionBilling,
 } from "../lib/monitor/board-cache.js";
 import { formatCompactNumber, formatNumber, formatRelativeTime } from "../lib/monitor/format.js";
 import { UtilCard } from "./UtilCard.js";
@@ -117,12 +118,12 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
         </p>
       )}
 
-      {/* Ollama subscription burn — flat-plan usage against its real reset windows.
-          Tokens/calls stand in for GPU-time (which Ollama doesn't expose); never a
-          fabricated per-token dollar figure. */}
-      {billing && billing.subscription.active && billing.subscription.windows ? (
-        <OllamaBurn billing={billing} />
-      ) : null}
+      {/* Subscription burn — one block per active flat-plan provider (Ollama,
+          Codex), usage against its real reset windows. Tokens/calls stand in for
+          the plan's metered unit; never a fabricated per-token dollar figure. */}
+      {billing?.subscriptions
+        .filter((sub) => sub.active && sub.windows)
+        .map((sub) => <SubscriptionBurn key={sub.provider} subscription={sub} />)}
 
       {/* What's running now (in-flight) — always glanceable. */}
       <div className="hm-usage-active">
@@ -298,33 +299,31 @@ function DailyTokensChart({ days }: { days: { day: string; totalTokens: number }
 
 /**
  * Cost-this-month headline — the honest picture the old single "$0.16" total
- * couldn't give: the flat Ollama subscription (already paid, doesn't grow per
- * call) plus the genuinely-metered Claude API dollars, and their month total.
+ * couldn't give: each flat subscription (Ollama, Codex — already paid, doesn't
+ * grow per call) plus the genuinely-metered Claude API dollars, and the total.
  */
 function CostSummary({ billing }: { billing: LlmUsageBilling }) {
-  const { subscription, metered } = billing;
-  const planName = subscription.configured
-    ? `Ollama ${capitalize(subscription.plan)}`
-    : "Ollama Cloud";
-  const subAmount = subscription.configured
-    ? `${formatPlanUsd(subscription.monthlyUsd ?? 0)}/mo`
-    : "plan not set";
-  const meteredAmount = metered.monthCostUsd != null ? formatUsd(metered.monthCostUsd) : "$0";
+  const anyConfigured = billing.subscriptions.some((sub) => sub.configured);
+  const meteredAmount = billing.metered.monthCostUsd != null ? formatUsd(billing.metered.monthCostUsd) : "$0";
   const totalText = billing.monthlyTotalUsd != null
-    ? `${subscription.configured ? "≈ " : ""}${formatUsd(billing.monthlyTotalUsd)}${billing.monthlyTotalComplete ? "" : " +"}`
+    ? `${anyConfigured ? "≈ " : ""}${formatUsd(billing.monthlyTotalUsd)}${billing.monthlyTotalComplete ? "" : " +"}`
     : "—";
   return (
     <div className="hm-usage-cost" role="group" aria-label="Cost this month">
       <div className="hm-usage-cost-head">
         <span className="hm-usage-cost-label">Cost this month</span>
-        <span className="hm-usage-cost-total" title={billing.monthlyTotalComplete ? undefined : "Excludes the Ollama subscription — set OLLAMA_PLAN to include it."}>{totalText}</span>
+        <span className="hm-usage-cost-total" title={billing.monthlyTotalComplete ? undefined : "Excludes a subscription with no plan set — set OLLAMA_PLAN / CODEX_PLAN to include it."}>{totalText}</span>
       </div>
       <div className="hm-usage-cost-rows">
-        <div className="hm-usage-cost-row">
-          <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-hermes)" }} aria-hidden />
-          <span className="hm-usage-cost-name">{planName} · flat</span>
-          <span className={`hm-usage-cost-amt${subscription.configured ? "" : " hm-usage-c-na"}`}>{subAmount}</span>
-        </div>
+        {billing.subscriptions.map((sub) => (
+          <div className="hm-usage-cost-row" key={sub.provider}>
+            <span className="hm-usage-jewel" style={{ background: providerJewel(sub.provider) }} aria-hidden />
+            <span className="hm-usage-cost-name">{planLine(sub)} · flat</span>
+            <span className={`hm-usage-cost-amt${sub.configured ? "" : " hm-usage-c-na"}`}>
+              {sub.configured ? `${formatPlanUsd(sub.monthlyUsd ?? 0)}/mo` : "plan not set"}
+            </span>
+          </div>
+        ))}
         <div className="hm-usage-cost-row">
           <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-claude)" }} aria-hidden />
           <span className="hm-usage-cost-name">Metered · Claude API</span>
@@ -336,9 +335,9 @@ function CostSummary({ billing }: { billing: LlmUsageBilling }) {
 }
 
 /**
- * Per-row cost cell, billing-aware. Subscription (Ollama) rows show a muted
- * "flat" tag instead of a misleading "?" — their cost lives in the flat plan,
- * not per call. Metered rows show the real recorded dollars (or "?" if a
+ * Per-row cost cell, billing-aware. Subscription (Ollama, Codex) rows show a
+ * muted "flat" tag instead of a misleading "?" — their cost lives in the flat
+ * plan, not per call. Metered rows show the real recorded dollars (or "?" if a
  * metered provider didn't emit cost). Unknown rows stay "?".
  */
 function RowCost({ entry }: { entry: LlmUsageModelRollup }) {
@@ -346,7 +345,7 @@ function RowCost({ entry }: { entry: LlmUsageModelRollup }) {
     return (
       <span
         className="hm-usage-c-num hm-usage-c-flat"
-        title="Included in your flat Ollama subscription — billed by GPU-time, not per call."
+        title="Included in a flat subscription plan — billed by the plan, not per call."
       >
         flat
       </span>
@@ -359,22 +358,21 @@ function RowCost({ entry }: { entry: LlmUsageModelRollup }) {
 }
 
 /**
- * Ollama subscription burn — how much of the plan's allocation you've used in
- * Ollama's real reset windows (5h session · 7d week · this month). Tokens/calls
- * are a proxy for GPU-time (the real metered unit, which Ollama doesn't expose),
- * flagged as such — never dressed up as dollars.
+ * Subscription burn — how much of a plan's allocation you've used in its real
+ * reset windows (5h session · 7d week · this month). Tokens/calls are a proxy
+ * for the plan's real metered unit (GPU-time / rolling-window usage), flagged as
+ * such — never dressed up as dollars. Rendered once per active subscription.
  */
-function OllamaBurn({ billing }: { billing: LlmUsageBilling }) {
-  const { subscription } = billing;
+function SubscriptionBurn({ subscription }: { subscription: SubscriptionBilling }) {
   const windows = subscription.windows;
   if (!windows) return null;
-  const planName = subscription.configured ? `${capitalize(subscription.plan)} plan` : "Cloud";
+  const planName = subscription.planLabel ? `${subscription.planLabel} plan` : subscription.label;
   const cells: LlmUsageWindow[] = [windows.session5h, windows.week7d, windows.month];
   return (
-    <div className="hm-usage-burn" role="group" aria-label="Ollama subscription burn">
+    <div className="hm-usage-burn" role="group" aria-label={`${subscription.label} subscription burn`}>
       <div className="hm-usage-burn-head">
-        <span className="hm-usage-burn-title">Ollama burn · {planName}</span>
-        <span className="hm-usage-burn-chip" title="Tokens/calls are a proxy for GPU-time — Ollama's real metered unit — not dollars.">proxy</span>
+        <span className="hm-usage-burn-title">{subscription.label} burn · {planName}</span>
+        <span className="hm-usage-burn-chip" title="Tokens/calls are a proxy for the plan's real metered unit — not dollars.">proxy</span>
       </div>
       <div className="hm-usage-burn-windows">
         {cells.map((win) => (
@@ -385,27 +383,33 @@ function OllamaBurn({ billing }: { billing: LlmUsageBilling }) {
           </div>
         ))}
       </div>
-      <small className="hm-usage-burn-note">{billing.note}</small>
+      <small className="hm-usage-burn-note">{subscription.note}</small>
     </div>
   );
 }
 
+/** "Ollama Pro", "Codex Pro 5×", or just the label when the plan isn't set. */
+function planLine(sub: SubscriptionBilling): string {
+  return sub.planLabel ? `${sub.label} ${sub.planLabel}` : sub.label;
+}
+
+/** Provider jewel — Ollama rides the hermes token, Codex its own. */
+function providerJewel(provider: "ollama" | "codex"): string {
+  return provider === "codex" ? "var(--h4-ag-codex)" : "var(--h4-ag-hermes)";
+}
+
 /**
- * Billing model for an (agent, model) — mirrors the backend llmBillingClass so
- * a row's cost cell matches how the aggregate classed it. Ollama Cloud (`:cloud`
- * suffix / ollama-tagged / the hermes agent) is flat-rate subscription; the
- * Claude SDK agents are metered; everything else is unknown.
+ * Billing model for an (agent, model) — mirrors the backend llmBillingClass so a
+ * row's cost cell matches how the aggregate classed it. Flat-rate subscriptions
+ * (the codex agent, or Ollama via the hermes agent / `:cloud` / ollama-tagged
+ * models) show "flat"; the Claude SDK agents are metered; else unknown.
  */
 function billingClassOf(agent: string, model: string): "subscription" | "metered" | "unknown" {
   const a = agent.trim().toLowerCase();
   const m = model.trim().toLowerCase();
-  if (m.endsWith(":cloud") || m.includes("ollama") || a === "hermes") return "subscription";
+  if (a === "codex" || a === "hermes" || m.endsWith(":cloud") || m.includes("ollama")) return "subscription";
   if (a === "claude" || a === "test-writer" || a === "security" || a === "docs") return "metered";
   return "unknown";
-}
-
-function capitalize(value: string): string {
-  return value ? value.charAt(0).toUpperCase() + value.slice(1) : value;
 }
 
 /** Format a known dollar amount (assumes a real number, unlike formatCost). */

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -128,29 +128,34 @@ export interface LlmUsageWindow {
   since: string;
 }
 
-/** Cost split by billing model + Ollama subscription-burn windows. */
+/** One flat-rate subscription provider (Ollama, Codex/ChatGPT) + its burn windows. */
+export interface SubscriptionBilling {
+  provider: "ollama" | "codex";
+  label: string;
+  plan: string;
+  planLabel: string;
+  monthlyUsd: number | null;
+  configured: boolean;
+  active: boolean;
+  models: string[];
+  windows: {
+    session5h: LlmUsageWindow;
+    week7d: LlmUsageWindow;
+    month: LlmUsageWindow;
+  } | null;
+  note: string;
+}
+
+/** Cost split by billing model + per-subscription burn windows. */
 export interface LlmUsageBilling {
   metered: {
     models: string[];
     monthCostUsd: number | null;
     costStatus: "recorded" | "not_recorded";
   };
-  subscription: {
-    provider: "ollama";
-    plan: "free" | "pro" | "max" | "none";
-    monthlyUsd: number | null;
-    configured: boolean;
-    active: boolean;
-    models: string[];
-    windows: {
-      session5h: LlmUsageWindow;
-      week7d: LlmUsageWindow;
-      month: LlmUsageWindow;
-    } | null;
-  };
+  subscriptions: SubscriptionBilling[];
   monthlyTotalUsd: number | null;
   monthlyTotalComplete: boolean;
-  note: string;
 }
 
 export interface LlmUsageAggregate {

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -25,7 +25,7 @@ import {
 import {
   aggregateLlmUsage,
   listActiveLlmUsageCalls,
-  resolveOllamaPlan,
+  resolveSubscriptionPlans,
   type LlmUsageAggregate,
   type LlmUsageEvent,
 } from "@avg/averray-mcp/llm-usage";
@@ -2422,8 +2422,9 @@ export function buildV2BoardSnapshot(
       activeCalls: listActiveLlmUsageCalls(),
       // Anchor the live "tokens/min" window to the snapshot time.
       now: snapshotAt,
-      // Ollama Cloud flat-plan cost + subscription-burn windows (env: OLLAMA_PLAN).
-      subscription: resolveOllamaPlan(process.env),
+      // Flat-plan cost + burn windows per subscription provider
+      // (env: OLLAMA_PLAN, CODEX_PLAN).
+      subscriptions: resolveSubscriptionPlans(process.env),
     }),
     testbedSuites: testbedSuitesFromSnapshot(rawSnapshot),
     automationHealth: automationHealthForBoard(rawSnapshot, snapshotAt, process.env, {


### PR DESCRIPTION
Follows #523. You asked to give Codex the same treatment as Ollama — it's on a ChatGPT subscription too.

## Why it works the same
Codex draws from a flat **ChatGPT plan** on a **rolling ~5-hour window** (per OpenAI's docs) — structurally identical to Ollama Cloud. And the runner already tries to record Codex usage (`recordLlmUsageFromResult({ agent: "codex", … })`); the CLI just isn't emitting parseable token counters yet, so Codex sits idle with the "does not report usage" line.

So:
- **Now:** Codex's flat plan cost (Pro 5× = $100/mo) joins the **Cost this month** total.
- **Automatically later:** if Codex ever emits counters, a second burn block (5h/7d/month) lights up exactly like Ollama's — no further work.

## What
Generalises the billing block from one subscription to a list.

**Backend (`averray-mcp/llm-usage.ts`)**:
- `LlmUsageBilling.subscription` → `subscriptions: SubscriptionBilling[]` (one per provider).
- `subscriptionProviderOf(agent, model)` attributes events: `hermes`/`:cloud`/ollama-tagged → ollama, `codex` → codex.
- `resolveCodexPlan(CODEX_PLAN=free|go|plus|pro5x|pro)` (dash/underscore tolerant) + `resolveSubscriptionPlans()`.
- `monthlyTotalUsd` sums **every configured** flat plan + metered $; `monthlyTotalComplete` false if any shown plan is unset.
- Honest per-provider note — Codex says *"the CLI isn't emitting token counters, so there's no burn proxy yet"* when idle.

**Frontend (`UsagePanel.tsx`)**:
- Cost-this-month strip iterates `subscriptions` → **Ollama Pro $20 + Codex Pro 5× $100 + Metered $0.16 = ≈ $120.16**.
- Burn block generalised to one per **active** subscription (idle Codex → cost row only, no empty windows).
- The `codex` agent's model rows show the muted **flat** tag.

**compose** — `CODEX_PLAN` passthrough (dormant until set).

## Truth boundary
Unchanged. No per-token $ is invented for any subscription. A provider with usage but no plan shows *plan not set* and marks the total incomplete; a configured provider with no usage shows its flat cost and an honest "no burn proxy yet" note — never fake windows.

## Deploy
`CODEX_PLAN=pro5x` (alongside `OLLAMA_PLAN=pro`) in `.env.prod` + `--build` redeploy.

## Tests
- `averray-mcp` billing: **9/9** (multi-provider windows, per-provider notes, idle-provider cost-only, unconfigured-active, no-clock).
- `monitor-ui`: **808/808** (incl. 14 `UsagePanel` — Codex cost row, total ≈ $120.16, second burn block on Codex activity, idle-Codex cost-only).
- `averray-mcp` build ✓ · `monitor-ui` typecheck 0 · SPA build ✓ · slack-operator local tsc = known stale-`@avg` baseline (CI resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)