### PR TITLE
fix(monitor): don't count the shared Codex plan in the app's cost total

### DIFF
--- a/packages/averray-mcp/src/llm-usage.test.ts
+++ b/packages/averray-mcp/src/llm-usage.test.ts
@@ -15,10 +15,11 @@ function evt(over: Partial<LlmUsageEvent> & Pick<LlmUsageEvent, "agent" | "model
   return { inputTokens: 0, outputTokens: 0, ...over };
 }
 
-const OLLAMA_PRO: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "pro", planLabel: "Pro", monthlyUsd: 20, configured: true };
-const CODEX_PRO5X: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "pro5x", planLabel: "Pro 5×", monthlyUsd: 100, configured: true };
-const OLLAMA_UNSET: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "none", planLabel: "", monthlyUsd: null, configured: false };
-const CODEX_UNSET: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "none", planLabel: "", monthlyUsd: null, configured: false };
+// Ollama is dedicated (monitor-only); Codex is shared (used beyond this app).
+const OLLAMA_PRO: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "pro", planLabel: "Pro", monthlyUsd: 20, configured: true, dedicated: true };
+const CODEX_PRO5X: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "pro5x", planLabel: "Pro 5×", monthlyUsd: 100, configured: true, dedicated: false };
+const OLLAMA_UNSET: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "none", planLabel: "", monthlyUsd: null, configured: false, dedicated: true };
+const CODEX_UNSET: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "none", planLabel: "", monthlyUsd: null, configured: false, dedicated: false };
 
 describe("resolveOllamaPlan / resolveCodexPlan / resolveSubscriptionPlans", () => {
   it("maps each provider's plan to its flat monthly price (case-insensitive, dash/underscore tolerant)", () => {
@@ -88,8 +89,13 @@ describe("aggregateLlmUsage — billing block (multi-provider)", () => {
     expect(codex.windows!.session5h.calls).toBe(1);
     expect(codex.note).toMatch(/ChatGPT/i);
 
+    // Ollama is dedicated to this app; Codex is a shared ChatGPT plan.
+    expect(ollama.dedicated).toBe(true);
+    expect(codex.dedicated).toBe(false);
+
     expect(b.metered.monthCostUsd).toBe(0.16);
-    expect(b.monthlyTotalUsd).toBe(120.16); // 20 + 100 + 0.16
+    // Total = Ollama (dedicated $20) + Claude metered $0.16 — NOT Codex's shared $100.
+    expect(b.monthlyTotalUsd).toBe(20.16);
     expect(b.monthlyTotalComplete).toBe(true);
   });
 
@@ -102,9 +108,10 @@ describe("aggregateLlmUsage — billing block (multi-provider)", () => {
     const codex = b.subscriptions.find((s) => s.provider === "codex")!;
     expect(codex.active).toBe(false);
     expect(codex.windows).toBeNull();
-    expect(codex.monthlyUsd).toBe(100); // flat cost still counted
+    expect(codex.monthlyUsd).toBe(100); // flat cost shown as context
     expect(codex.note).toMatch(/isn't emitting|no burn proxy/i);
-    expect(b.monthlyTotalUsd).toBe(120.16);
+    // Codex (shared) stays out of the total whether or not it reports usage.
+    expect(b.monthlyTotalUsd).toBe(20.16);
     expect(b.monthlyTotalComplete).toBe(true);
   });
 
@@ -122,11 +129,17 @@ describe("aggregateLlmUsage — billing block (multi-provider)", () => {
     expect(b.monthlyTotalComplete).toBe(false);
   });
 
-  it("keeps a configured flat cost even with no clock to anchor windows", () => {
-    const b = aggregateLlmUsage([codexA], { subscriptions: [CODEX_PRO5X] }).billing;
-    const codex = b.subscriptions.find((s) => s.provider === "codex")!;
-    expect(codex.windows).toBeNull();
-    expect(b.monthlyTotalUsd).toBe(100);
-    expect(b.monthlyTotalComplete).toBe(true);
+  it("keeps a dedicated flat cost with no clock; a shared plan alone yields no app total", () => {
+    const dedicated = aggregateLlmUsage([ollamaA], { subscriptions: [OLLAMA_PRO] }).billing;
+    expect(dedicated.subscriptions[0]!.windows).toBeNull();
+    expect(dedicated.monthlyTotalUsd).toBe(20);
+    expect(dedicated.monthlyTotalComplete).toBe(true);
+
+    // Codex alone is shared → its $100 is context, so there's nothing to total.
+    const sharedOnly = aggregateLlmUsage([codexA], { subscriptions: [CODEX_PRO5X] }).billing;
+    expect(sharedOnly.subscriptions[0]!.provider).toBe("codex");
+    expect(sharedOnly.subscriptions[0]!.monthlyUsd).toBe(100);
+    expect(sharedOnly.monthlyTotalUsd).toBeNull();
+    expect(sharedOnly.monthlyTotalComplete).toBe(true); // no dedicated plan to be missing
   });
 });

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -98,6 +98,14 @@ export interface SubscriptionBilling {
   monthlyUsd: number | null;
   configured: boolean;
   active: boolean;
+  /**
+   * True when this plan is dedicated to this app (Hermes/Ollama is only used
+   * inside the monitor), so its flat cost belongs in "cost this month". False
+   * when it's a shared plan used beyond this app (Codex draws from your ChatGPT
+   * plan, which you also use elsewhere) — its cost is shown as context but NOT
+   * summed into the app total, which would overstate what the app costs.
+   */
+  dedicated: boolean;
   models: string[];
   windows: {
     session5h: LlmUsageWindow;
@@ -113,9 +121,11 @@ export interface SubscriptionBilling {
  *   - subscriptions → flat-rate providers (Ollama, Codex/ChatGPT) billed by a
  *     fixed monthly plan, NOT per token. Each surfaces its flat price plus a burn
  *     proxy against its reset windows (when it reports usage).
- * `monthlyTotalUsd` is the honest month-to-date picture (every configured flat
- * plan + metered $); `monthlyTotalComplete` is false when a shown subscription's
- * plan isn't configured, so the UI can flag that the total is missing a cost.
+ * `monthlyTotalUsd` is the honest month-to-date picture — every DEDICATED flat
+ * plan (used only inside this app) + metered $. Shared plans (Codex, used beyond
+ * this app) are listed as context but NOT summed, so the total never overstates
+ * what the app costs. `monthlyTotalComplete` is false when a dedicated plan isn't
+ * configured, so the UI can flag that the total is missing a cost.
  */
 export interface LlmUsageBilling {
   metered: {
@@ -136,6 +146,8 @@ export interface SubscriptionPlanConfig {
   planLabel: string;
   monthlyUsd: number | null;
   configured: boolean;
+  /** See SubscriptionBilling.dedicated — dedicated plans count in the app total. */
+  dedicated: boolean;
 }
 
 export interface LlmUsageAggregate {
@@ -232,7 +244,9 @@ let nextActiveCallId = 0;
  * instead of inventing a subscription cost.
  */
 export function resolveOllamaPlan(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig {
-  return resolvePlan("ollama", "Ollama", env.OLLAMA_PLAN, OLLAMA_PLAN_MONTHLY_USD, OLLAMA_PLAN_LABELS);
+  // Dedicated: Hermes/Ollama is only used inside the monitor, so its flat cost
+  // is genuinely this app's spend and counts in the "cost this month" total.
+  return resolvePlan("ollama", "Ollama", true, env.OLLAMA_PLAN, OLLAMA_PLAN_MONTHLY_USD, OLLAMA_PLAN_LABELS);
 }
 
 /**
@@ -241,7 +255,9 @@ export function resolveOllamaPlan(env: NodeJS.ProcessEnv = process.env): Subscri
  * Unknown/unset → not configured.
  */
 export function resolveCodexPlan(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig {
-  return resolvePlan("codex", "Codex", env.CODEX_PLAN, CODEX_PLAN_MONTHLY_USD, CODEX_PLAN_LABELS);
+  // Shared: Codex draws from your ChatGPT plan, which you also use beyond this
+  // app — so its flat cost is shown as context but NOT summed into the app total.
+  return resolvePlan("codex", "Codex", false, env.CODEX_PLAN, CODEX_PLAN_MONTHLY_USD, CODEX_PLAN_LABELS);
 }
 
 /** Both known subscription providers, resolved from env — for aggregateLlmUsage. */
@@ -252,15 +268,16 @@ export function resolveSubscriptionPlans(env: NodeJS.ProcessEnv = process.env): 
 function resolvePlan(
   provider: "ollama" | "codex",
   label: string,
+  dedicated: boolean,
   raw: string | undefined,
   prices: Readonly<Record<string, number>>,
   labels: Readonly<Record<string, string>>,
 ): SubscriptionPlanConfig {
   const key = raw?.trim().toLowerCase().replace(/[-_\s]/g, "");
   if (key && key in prices) {
-    return { provider, label, plan: key, planLabel: labels[key] ?? key, monthlyUsd: prices[key]!, configured: true };
+    return { provider, label, dedicated, plan: key, planLabel: labels[key] ?? key, monthlyUsd: prices[key]!, configured: true };
   }
-  return { provider, label, plan: "none", planLabel: "", monthlyUsd: null, configured: false };
+  return { provider, label, dedicated, plan: "none", planLabel: "", monthlyUsd: null, configured: false };
 }
 
 /**
@@ -496,16 +513,19 @@ function buildBilling(
       monthlyUsd: plan.monthlyUsd,
       configured: plan.configured,
       active,
+      dedicated: plan.dedicated,
       models: uniqueStrings(provEvents.map((event) => event.model)),
       windows,
       note: subscriptionNote(plan.provider, active),
     });
   }
 
-  const flatSum = subscriptions
-    .filter((sub) => sub.configured)
-    .reduce((sum, sub) => sum + (sub.monthlyUsd ?? 0), 0);
-  const anyFlat = subscriptions.some((sub) => sub.configured);
+  // Only DEDICATED flat plans (used solely inside this app) count toward the
+  // month total — a shared plan (Codex/ChatGPT, used elsewhere too) is shown as
+  // context but summing it would overstate what this app actually costs.
+  const dedicatedFlat = subscriptions.filter((sub) => sub.dedicated && sub.configured);
+  const flatSum = dedicatedFlat.reduce((sum, sub) => sum + (sub.monthlyUsd ?? 0), 0);
+  const anyFlat = dedicatedFlat.length > 0;
   const monthlyTotalUsd = anyFlat || monthCostUsd !== null
     ? round((anyFlat ? flatSum : 0) + (monthCostUsd ?? 0), 6)
     : null;
@@ -518,9 +538,9 @@ function buildBilling(
     },
     subscriptions,
     monthlyTotalUsd,
-    // Complete only when every shown subscription's flat cost is known; an
-    // active-but-unconfigured provider makes the total incomplete (flagged in UI).
-    monthlyTotalComplete: subscriptions.every((sub) => sub.configured),
+    // Complete only when every DEDICATED subscription's flat cost is known; a
+    // shared plan (excluded from the total) never gates completeness.
+    monthlyTotalComplete: subscriptions.filter((sub) => sub.dedicated).every((sub) => sub.configured),
   };
 }
 

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -157,6 +157,7 @@ const ollamaSub: SubscriptionBilling = {
   monthlyUsd: 20,
   configured: true,
   active: true,
+  dedicated: true, // Hermes/Ollama is used only inside the monitor
   models: ["glm-5.2:cloud", "deepseek-v4-pro:cloud"],
   windows: {
     session5h: { label: "5h session", tokens: 1_200_000, calls: 40, inputTokens: 1_000_000, outputTokens: 200_000, since: "2026-07-07T07:00:00.000Z" },
@@ -174,6 +175,7 @@ const codexSub: SubscriptionBilling = {
   monthlyUsd: 100,
   configured: true,
   active: false,
+  dedicated: false, // Codex draws from your shared ChatGPT plan
   models: [],
   windows: null,
   note: "Codex draws from your ChatGPT plan. The Codex CLI isn't emitting token counters, so there's no burn proxy yet.",
@@ -181,7 +183,7 @@ const codexSub: SubscriptionBilling = {
 const proBilling: LlmUsageBilling = {
   metered: { models: ["not_recorded"], monthCostUsd: 0.16, costStatus: "recorded" },
   subscriptions: [ollamaSub, codexSub],
-  monthlyTotalUsd: 120.16,
+  monthlyTotalUsd: 20.16, // dedicated Ollama $20 + Claude $0.16 (Codex shared, excluded)
   monthlyTotalComplete: true,
 };
 
@@ -200,15 +202,18 @@ const withBilling: LlmUsageAggregate = {
 const hasText = (needle: string) => (content: string) => content.includes(needle);
 
 describe("UsagePanel — cost & subscription burn", () => {
-  test("headlines an honest 'cost this month' = each flat plan (Ollama + Codex) + metered Claude $", () => {
+  test("totals only DEDICATED spend (Ollama + Claude); shows shared Codex separately, not summed", () => {
     const { getByText } = render(<UsagePanel usage={withBilling} />);
     expect(getByText("Cost this month")).toBeTruthy();
-    expect(getByText(/≈\s*\$120\.16/)).toBeTruthy(); // $20 + $100 + $0.16
+    // Total is the app's real cost: Ollama $20 + Claude $0.16 — NOT the shared Codex $100.
+    expect(getByText(/≈\s*\$20\.16/)).toBeTruthy();
     expect(getByText("Ollama Pro · flat")).toBeTruthy();
     expect(getByText("$20/mo")).toBeTruthy();
+    expect(getByText("Metered · Claude API")).toBeTruthy();
+    // Codex is still visible, but under a "shared" heading and excluded from the total.
+    expect(getByText(hasText("used beyond this monitor"))).toBeTruthy();
     expect(getByText(hasText("Codex Pro"))).toBeTruthy(); // "Codex Pro 5× · flat"
     expect(getByText("$100/mo")).toBeTruthy();
-    expect(getByText("Metered · Claude API")).toBeTruthy();
   });
 
   test("a subscription (:cloud) row shows a muted 'flat' tag, not a misleading '?'", () => {

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -298,38 +298,53 @@ function DailyTokensChart({ days }: { days: { day: string; totalTokens: number }
 }
 
 /**
- * Cost-this-month headline — the honest picture the old single "$0.16" total
- * couldn't give: each flat subscription (Ollama, Codex — already paid, doesn't
- * grow per call) plus the genuinely-metered Claude API dollars, and the total.
+ * Cost-this-month headline. The total counts only what this app actually spends:
+ * dedicated flat plans (Ollama, used only inside the monitor) + metered Claude $.
+ * Shared plans (Codex draws from your ChatGPT plan, used beyond this app too) are
+ * listed separately as context and NOT summed — folding a shared subscription
+ * into the total would overstate what the app costs.
  */
 function CostSummary({ billing }: { billing: LlmUsageBilling }) {
-  const anyConfigured = billing.subscriptions.some((sub) => sub.configured);
+  const dedicated = billing.subscriptions.filter((sub) => sub.dedicated);
+  const shared = billing.subscriptions.filter((sub) => !sub.dedicated);
+  const anyDedicatedCost = dedicated.some((sub) => sub.configured) || billing.metered.monthCostUsd != null;
   const meteredAmount = billing.metered.monthCostUsd != null ? formatUsd(billing.metered.monthCostUsd) : "$0";
   const totalText = billing.monthlyTotalUsd != null
-    ? `${anyConfigured ? "≈ " : ""}${formatUsd(billing.monthlyTotalUsd)}${billing.monthlyTotalComplete ? "" : " +"}`
+    ? `${anyDedicatedCost ? "≈ " : ""}${formatUsd(billing.monthlyTotalUsd)}${billing.monthlyTotalComplete ? "" : " +"}`
     : "—";
   return (
     <div className="hm-usage-cost" role="group" aria-label="Cost this month">
       <div className="hm-usage-cost-head">
         <span className="hm-usage-cost-label">Cost this month</span>
-        <span className="hm-usage-cost-total" title={billing.monthlyTotalComplete ? undefined : "Excludes a subscription with no plan set — set OLLAMA_PLAN / CODEX_PLAN to include it."}>{totalText}</span>
+        <span className="hm-usage-cost-total" title={billing.monthlyTotalComplete ? undefined : "A dedicated plan has no price set — set OLLAMA_PLAN. Shared plans are intentionally excluded."}>{totalText}</span>
       </div>
       <div className="hm-usage-cost-rows">
-        {billing.subscriptions.map((sub) => (
-          <div className="hm-usage-cost-row" key={sub.provider}>
-            <span className="hm-usage-jewel" style={{ background: providerJewel(sub.provider) }} aria-hidden />
-            <span className="hm-usage-cost-name">{planLine(sub)} · flat</span>
-            <span className={`hm-usage-cost-amt${sub.configured ? "" : " hm-usage-c-na"}`}>
-              {sub.configured ? `${formatPlanUsd(sub.monthlyUsd ?? 0)}/mo` : "plan not set"}
-            </span>
-          </div>
-        ))}
+        {dedicated.map((sub) => <CostRow key={sub.provider} sub={sub} />)}
         <div className="hm-usage-cost-row">
           <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-claude)" }} aria-hidden />
           <span className="hm-usage-cost-name">Metered · Claude API</span>
           <span className="hm-usage-cost-amt">{meteredAmount}</span>
         </div>
       </div>
+      {shared.length > 0 ? (
+        <div className="hm-usage-cost-shared">
+          <span className="hm-usage-cost-shared-head">Shared · used beyond this monitor · not in the total</span>
+          {shared.map((sub) => <CostRow key={sub.provider} sub={sub} />)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** One subscription row in the cost summary — jewel, plan line, flat price. */
+function CostRow({ sub }: { sub: SubscriptionBilling }) {
+  return (
+    <div className="hm-usage-cost-row">
+      <span className="hm-usage-jewel" style={{ background: providerJewel(sub.provider) }} aria-hidden />
+      <span className="hm-usage-cost-name">{planLine(sub)} · flat</span>
+      <span className={`hm-usage-cost-amt${sub.configured ? "" : " hm-usage-c-na"}`}>
+        {sub.configured ? `${formatPlanUsd(sub.monthlyUsd ?? 0)}/mo` : "plan not set"}
+      </span>
     </div>
   );
 }

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -137,6 +137,8 @@ export interface SubscriptionBilling {
   monthlyUsd: number | null;
   configured: boolean;
   active: boolean;
+  /** Dedicated to this app (counts in the total) vs shared (context only). */
+  dedicated: boolean;
   models: string[];
   windows: {
     session5h: LlmUsageWindow;

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -236,6 +236,26 @@
 .hm-usage-cost-amt.hm-usage-c-na {
   color: var(--h4-faint);
 }
+/* shared subscriptions — shown as context, kept visually apart from the counted
+   rows so a shared plan (Codex) never reads as part of the app's total */
+.hm-usage-cost-shared {
+  display: grid;
+  gap: 5px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--h4-line-2);
+}
+.hm-usage-cost-shared-head {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+}
+.hm-usage-cost-shared .hm-usage-cost-amt {
+  color: var(--h4-faint);
+}
 
 /* the "flat" tag on a subscription row — muted telemetry, not a dead "?" */
 .hm-usage-c-flat {


### PR DESCRIPTION
You caught a real truth-boundary miss in #524: it folded Codex's full **$100/mo ChatGPT plan** into "cost this month," but **Codex is a *shared* subscription — you use it beyond this monitor** — whereas **Hermes/Ollama runs *only* inside the monitor.** Summing a shared plan overstates what the app actually costs.

## Fix — dedicated vs shared
Each subscription now carries a `dedicated` flag:
- **Ollama → dedicated** (monitor-only) → its flat $20 counts in the total.
- **Codex → shared** (drives your other work too) → shown as context, **never summed**.

**Backend (`averray-mcp/llm-usage.ts`)**:
- `SubscriptionBilling` / `SubscriptionPlanConfig` gain `dedicated`; `resolveOllamaPlan` sets it true, `resolveCodexPlan` false.
- `monthlyTotalUsd` = **dedicated** flat plans + metered $ only; `monthlyTotalComplete` gates on dedicated plans (a shared plan never makes the total "incomplete").

**Frontend (`UsagePanel.tsx`)**:
- The **Cost this month** total counts Ollama + Claude → **≈ $20.16**.
- Codex moves below a dashed divider: **"Shared · used beyond this monitor · not in the total"** — still visible with its `$100/mo`, but plainly outside the app total.

## Why this is the honest line
The monitor can't claim a shared flat plan as its own spend — its marginal Codex cost is already covered by a plan you'd pay for anyway. Metered Claude $ and the dedicated Ollama plan *are* the app's real spend; Codex is context. (Codex's burn windows, if its CLI ever reports, still show — that's genuinely the monitor's own usage.)

## Tests
- `averray-mcp` billing: **9/9** — dedicated-only total ($20.16 not $120.16), a shared-plan-alone yields a `null` app total, dedicated flag per provider.
- `monitor-ui`: **808/808** — shared section renders, total excludes Codex, `dedicated` on every fixture.
- `averray-mcp` build ✓ · `monitor-ui` typecheck 0 · SPA build ✓ · slack-operator local tsc = known stale-`@avg` baseline (no new errors).

## Deploy
No new env — same `OLLAMA_PLAN=pro` + `CODEX_PLAN=pro5x`, `--build` redeploy. Stacks on #523/#524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)