### PR TITLE
feat(monitor): show Codex usage as run counts (the monitor's own Codex runs)

### DIFF
--- a/packages/averray-mcp/src/llm-usage.test.ts
+++ b/packages/averray-mcp/src/llm-usage.test.ts
@@ -92,6 +92,9 @@ describe("aggregateLlmUsage — billing block (multi-provider)", () => {
     // Ollama is dedicated to this app; Codex is a shared ChatGPT plan.
     expect(ollama.dedicated).toBe(true);
     expect(codex.dedicated).toBe(false);
+    // Both measured in tokens here (codexA carries token counters).
+    expect(ollama.unit).toBe("tokens");
+    expect(codex.unit).toBe("tokens");
 
     expect(b.metered.monthCostUsd).toBe(0.16);
     // Total = Ollama (dedicated $20) + Claude metered $0.16 — NOT Codex's shared $100.
@@ -127,6 +130,29 @@ describe("aggregateLlmUsage — billing block (multi-provider)", () => {
     // Total is metered-only and flagged incomplete (an active plan has no price).
     expect(b.monthlyTotalUsd).toBe(0.16);
     expect(b.monthlyTotalComplete).toBe(false);
+  });
+
+  it("shows Codex RUNS as the burn proxy when it reports no tokens (usage, not cost)", () => {
+    // 1h + 3h ago (both in the 5h window); 3d ago (in week/month, not session).
+    const runs = ["2026-07-07T11:00:00.000Z", "2026-07-07T09:00:00.000Z", "2026-07-04T00:00:00.000Z"];
+    const b = aggregateLlmUsage([ollamaA, metered], {
+      now: NOW,
+      subscriptions: [OLLAMA_PRO, CODEX_PRO5X],
+      subscriptionRuns: { codex: runs }, // Codex emits no token events
+    }).billing;
+
+    const codex = b.subscriptions.find((s) => s.provider === "codex")!;
+    expect(codex.active).toBe(true);
+    expect(codex.unit).toBe("runs");
+    expect(codex.windows!.session5h.calls).toBe(2); // the two runs inside 5h
+    expect(codex.windows!.session5h.tokens).toBe(0); // never a fabricated token count
+    expect(codex.windows!.week7d.calls).toBe(3);
+    expect(codex.windows!.month.calls).toBe(3);
+    expect(codex.note).toMatch(/runs/i);
+
+    // Runs are USAGE, not cost — Codex stays shared and out of the total.
+    expect(codex.dedicated).toBe(false);
+    expect(b.monthlyTotalUsd).toBe(20.16);
   });
 
   it("keeps a dedicated flat cost with no clock; a shared plan alone yields no app total", () => {

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -106,6 +106,13 @@ export interface SubscriptionBilling {
    * summed into the app total, which would overstate what the app costs.
    */
   dedicated: boolean;
+  /**
+   * What the burn windows measure. "tokens" when the provider emits token
+   * counters (Ollama); "runs" when it doesn't but the monitor still knows how
+   * many times it invoked it (Codex — the CLI reports no tokens, so we count the
+   * Codex task runs this app dispatched, `LlmUsageWindow.calls`, as the proxy).
+   */
+  unit: "tokens" | "runs";
   models: string[];
   windows: {
     session5h: LlmUsageWindow;
@@ -192,6 +199,10 @@ export interface LlmUsageAggregateOptions {
   /** Flat-rate subscription plans (Ollama, Codex) for the billing block — caller
    *  resolves them from env via resolveSubscriptionPlans. Omitted → none. */
   subscriptions?: readonly SubscriptionPlanConfig[];
+  /** Run timestamps (ISO) per subscription provider that reports RUNS not tokens.
+   *  Codex's CLI emits no token counters, but the monitor knows every Codex task
+   *  it dispatched — pass those `startedAt`s so the burn windows show run counts. */
+  subscriptionRuns?: Partial<Record<"ollama" | "codex", readonly string[]>>;
 }
 
 export interface LlmUsageActiveCallInput {
@@ -233,7 +244,11 @@ const CODEX_BURN_NOTE =
   + "The token/call counts here are a burn proxy.";
 const CODEX_NO_USAGE_NOTE =
   "Codex draws from your ChatGPT plan (rolling ~5-hour window). The Codex CLI isn't emitting token "
-  + "counters, so there's no burn proxy yet — the flat plan price is your spend.";
+  + "counters, and this monitor hasn't dispatched any Codex runs yet — so there's no usage to show.";
+const CODEX_RUNS_NOTE =
+  "Codex task runs this monitor dispatched — the Codex CLI reports no tokens, so this counts runs "
+  + "(each ≈ one coding session against your shared ChatGPT plan), not tokens. Use it to gauge how much "
+  + "of Codex is driven from here.";
 
 const activeCalls = new Map<string, LlmUsageActiveCall>();
 let nextActiveCallId = 0;
@@ -442,7 +457,7 @@ export function aggregateLlmUsage(
   const total = totalsFor(events);
   const sourceStatus = sourceStatuses(events, options);
   const recent = buildRecent(events, options.now, options.recentWindowMinutes ?? 60);
-  const billing = buildBilling(events, options.now, options.subscriptions);
+  const billing = buildBilling(events, options.now, options.subscriptions, options.subscriptionRuns);
   const status = events.length > 0 ? "recorded" : "not_recorded";
   return {
     status,
@@ -472,6 +487,7 @@ function buildBilling(
   events: readonly LlmUsageEvent[],
   now: Date | undefined,
   plans: readonly SubscriptionPlanConfig[] | undefined,
+  runs: Partial<Record<"ollama" | "codex", readonly string[]>> | undefined,
 ): LlmUsageBilling {
   const anchor = now && Number.isFinite(now.getTime()) ? now : undefined;
   const endMs = anchor ? anchor.getTime() : undefined;
@@ -492,18 +508,31 @@ function buildBilling(
   }
 
   // One entry per provider that's either configured (has a flat cost to show) or
-  // active (has usage). Providers that are neither are omitted — no clutter.
+  // active (has usage). Usage is token counters when the provider emits them
+  // (Ollama), else the run timestamps the monitor dispatched (Codex). Providers
+  // that are neither configured nor active are omitted — no clutter.
   const subscriptions: SubscriptionBilling[] = [];
   for (const plan of plans ?? []) {
     const provEvents = events.filter((event) => subscriptionProviderOf(event.agent, event.model) === plan.provider);
-    const active = provEvents.length > 0;
+    const provRuns = runs?.[plan.provider] ?? [];
+    const hasTokens = provEvents.length > 0;
+    const hasRuns = provRuns.length > 0;
+    const active = hasTokens || hasRuns;
     if (!plan.configured && !active) continue;
-    const windows = endMs !== undefined && monthStartMs !== undefined && active
-      ? {
-          session5h: usageWindowFor(provEvents, endMs - SESSION_WINDOW_MS, endMs, "5h session"),
-          week7d: usageWindowFor(provEvents, endMs - WEEK_WINDOW_MS, endMs, "7d week"),
-          month: usageWindowFor(provEvents, monthStartMs, endMs, "this month"),
-        }
+    const unit: "tokens" | "runs" = hasTokens ? "tokens" : "runs";
+    const windowsReady = endMs !== undefined && monthStartMs !== undefined && active;
+    const windows = windowsReady
+      ? hasTokens
+        ? {
+            session5h: usageWindowFor(provEvents, endMs! - SESSION_WINDOW_MS, endMs!, "5h session"),
+            week7d: usageWindowFor(provEvents, endMs! - WEEK_WINDOW_MS, endMs!, "7d week"),
+            month: usageWindowFor(provEvents, monthStartMs!, endMs!, "this month"),
+          }
+        : {
+            session5h: usageRunWindow(provRuns, endMs! - SESSION_WINDOW_MS, endMs!, "5h session"),
+            week7d: usageRunWindow(provRuns, endMs! - WEEK_WINDOW_MS, endMs!, "7d week"),
+            month: usageRunWindow(provRuns, monthStartMs!, endMs!, "this month"),
+          }
       : null;
     subscriptions.push({
       provider: plan.provider,
@@ -514,9 +543,10 @@ function buildBilling(
       configured: plan.configured,
       active,
       dedicated: plan.dedicated,
+      unit,
       models: uniqueStrings(provEvents.map((event) => event.model)),
       windows,
-      note: subscriptionNote(plan.provider, active),
+      note: subscriptionNote(plan.provider, active, unit),
     });
   }
 
@@ -544,9 +574,12 @@ function buildBilling(
   };
 }
 
-/** Per-provider honest note: Ollama meters GPU-time; Codex may not report usage. */
-function subscriptionNote(provider: "ollama" | "codex", active: boolean): string {
-  if (provider === "codex") return active ? CODEX_BURN_NOTE : CODEX_NO_USAGE_NOTE;
+/** Per-provider honest note, aware of whether we're showing tokens or run counts. */
+function subscriptionNote(provider: "ollama" | "codex", active: boolean, unit: "tokens" | "runs"): string {
+  if (provider === "codex") {
+    if (!active) return CODEX_NO_USAGE_NOTE;
+    return unit === "runs" ? CODEX_RUNS_NOTE : CODEX_BURN_NOTE;
+  }
   return OLLAMA_BURN_NOTE;
 }
 
@@ -570,6 +603,26 @@ function usageWindowFor(
     calls += 1;
   }
   return { label, tokens, calls, inputTokens, outputTokens, since: new Date(startMs).toISOString() };
+}
+
+/**
+ * Count of runs whose timestamp falls in [startMs, endMs] — the burn proxy for a
+ * provider that reports no tokens (Codex). The count lands in `calls`; token
+ * fields stay 0 so the UI shows "N runs", never a fabricated token figure.
+ */
+function usageRunWindow(
+  runTimestamps: readonly string[],
+  startMs: number,
+  endMs: number,
+  label: string,
+): LlmUsageWindow {
+  let calls = 0;
+  for (const ts of runTimestamps) {
+    const t = Date.parse(ts);
+    if (!Number.isFinite(t) || t < startMs || t > endMs) continue;
+    calls += 1;
+  }
+  return { label, tokens: 0, calls, inputTokens: 0, outputTokens: 0, since: new Date(startMs).toISOString() };
 }
 
 /** UTC start-of-month for the anchor — the metered billing cycle boundary. */
@@ -650,9 +703,9 @@ export function aggregateLlmUsageForAgent(
     }],
     activeCalls: aggregate.activeCalls.filter((call) => call.agent === agent),
     recent: null,
-    // Per-agent sub-view: no clock/plan is threaded here, so windows stay null
+    // Per-agent sub-view: no clock/plan/runs threaded here, so windows stay null
     // and the subscription cost is "not configured" (honest, never fabricated).
-    billing: buildBilling(events, undefined, undefined),
+    billing: buildBilling(events, undefined, undefined, undefined),
   };
 }
 

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -158,6 +158,7 @@ const ollamaSub: SubscriptionBilling = {
   configured: true,
   active: true,
   dedicated: true, // Hermes/Ollama is used only inside the monitor
+  unit: "tokens",
   models: ["glm-5.2:cloud", "deepseek-v4-pro:cloud"],
   windows: {
     session5h: { label: "5h session", tokens: 1_200_000, calls: 40, inputTokens: 1_000_000, outputTokens: 200_000, since: "2026-07-07T07:00:00.000Z" },
@@ -176,6 +177,7 @@ const codexSub: SubscriptionBilling = {
   configured: true,
   active: false,
   dedicated: false, // Codex draws from your shared ChatGPT plan
+  unit: "runs", // Codex reports no tokens — usage proxy is run counts
   models: [],
   windows: null,
   note: "Codex draws from your ChatGPT plan. The Codex CLI isn't emitting token counters, so there's no burn proxy yet.",
@@ -234,23 +236,26 @@ describe("UsagePanel — cost & subscription burn", () => {
     expect(queryByText(hasText("Codex burn"))).toBeNull();
   });
 
-  test("renders a SECOND burn block for Codex once it reports usage", () => {
-    const codexActive: SubscriptionBilling = {
+  test("shows Codex RUNS as a second burn block — the monitor's own Codex usage (not tokens)", () => {
+    // Codex reports no tokens, so its windows count runs the monitor dispatched.
+    const codexRuns: SubscriptionBilling = {
       ...codexSub,
       active: true,
+      unit: "runs",
       models: ["gpt-5.5-codex"],
       windows: {
-        session5h: { label: "5h session", tokens: 500_000, calls: 12, inputTokens: 400_000, outputTokens: 100_000, since: "2026-07-07T07:00:00.000Z" },
-        week7d: { label: "7d week", tokens: 900_000, calls: 30, inputTokens: 700_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
-        month: { label: "this month", tokens: 900_000, calls: 30, inputTokens: 700_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
+        session5h: { label: "5h session", tokens: 0, calls: 3, inputTokens: 0, outputTokens: 0, since: "2026-07-07T07:00:00.000Z" },
+        week7d: { label: "7d week", tokens: 0, calls: 18, inputTokens: 0, outputTokens: 0, since: "2026-06-30T12:00:00.000Z" },
+        month: { label: "this month", tokens: 0, calls: 40, inputTokens: 0, outputTokens: 0, since: "2026-07-01T00:00:00.000Z" },
       },
-      note: "Codex draws from your ChatGPT plan, metered against a rolling ~5-hour window.",
+      note: "Codex task runs this monitor dispatched — the Codex CLI reports no tokens, so this counts runs.",
     };
-    const usage: LlmUsageAggregate = { ...withBilling, billing: { ...proBilling, subscriptions: [ollamaSub, codexActive] } };
+    const usage: LlmUsageAggregate = { ...withBilling, billing: { ...proBilling, subscriptions: [ollamaSub, codexRuns] } };
     const { getByText, getAllByText } = render(<UsagePanel usage={usage} />);
     expect(getByText("Ollama burn · Pro plan")).toBeTruthy();
-    expect(getByText(hasText("Codex burn"))).toBeTruthy(); // "Codex burn · Pro 5× plan"
-    expect(getByText("12 calls")).toBeTruthy(); // codex 5h session
+    expect(getByText(hasText("Codex runs"))).toBeTruthy(); // title "Codex runs · Pro 5× plan"
+    expect(getByText(hasText("3 runs"))).toBeTruthy(); // 5h session run count
+    expect(getByText(hasText("40 runs"))).toBeTruthy(); // this month
     expect(getAllByText("5h session").length).toBe(2); // one window row per block
   });
 

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -374,27 +374,40 @@ function RowCost({ entry }: { entry: LlmUsageModelRollup }) {
 
 /**
  * Subscription burn — how much of a plan's allocation you've used in its real
- * reset windows (5h session · 7d week · this month). Tokens/calls are a proxy
- * for the plan's real metered unit (GPU-time / rolling-window usage), flagged as
- * such — never dressed up as dollars. Rendered once per active subscription.
+ * reset windows (5h session · 7d week · this month). For a token-reporting plan
+ * (Ollama) each cell shows tokens + calls; for a runs-only plan (Codex, whose
+ * CLI reports no tokens) each cell shows the count of Codex task runs this
+ * monitor dispatched — a truthful usage proxy, never fabricated tokens.
  */
 function SubscriptionBurn({ subscription }: { subscription: SubscriptionBilling }) {
   const windows = subscription.windows;
   if (!windows) return null;
+  const isRuns = subscription.unit === "runs";
   const planName = subscription.planLabel ? `${subscription.planLabel} plan` : subscription.label;
+  const title = `${subscription.label} ${isRuns ? "runs" : "burn"} · ${planName}`;
+  const chip = isRuns ? "runs" : "proxy";
+  const chipTitle = isRuns
+    ? "The Codex CLI reports no tokens, so this counts Codex task runs this monitor dispatched."
+    : "Tokens/calls are a proxy for the plan's real metered unit — not dollars.";
   const cells: LlmUsageWindow[] = [windows.session5h, windows.week7d, windows.month];
   return (
-    <div className="hm-usage-burn" role="group" aria-label={`${subscription.label} subscription burn`}>
+    <div className="hm-usage-burn" role="group" aria-label={`${subscription.label} subscription ${isRuns ? "runs" : "burn"}`}>
       <div className="hm-usage-burn-head">
-        <span className="hm-usage-burn-title">{subscription.label} burn · {planName}</span>
-        <span className="hm-usage-burn-chip" title="Tokens/calls are a proxy for the plan's real metered unit — not dollars.">proxy</span>
+        <span className="hm-usage-burn-title">{title}</span>
+        <span className="hm-usage-burn-chip" title={chipTitle}>{chip}</span>
       </div>
       <div className="hm-usage-burn-windows">
         {cells.map((win) => (
           <div className="hm-usage-burn-win" key={win.label}>
             <span className="hm-usage-burn-win-label">{win.label}</span>
-            <strong className="hm-usage-burn-win-tok">{formatCompactNumber(win.tokens)}</strong>
-            <small className="hm-usage-burn-win-calls">{formatNumber(win.calls)} calls</small>
+            {isRuns ? (
+              <strong className="hm-usage-burn-win-tok">{formatNumber(win.calls)} runs</strong>
+            ) : (
+              <>
+                <strong className="hm-usage-burn-win-tok">{formatCompactNumber(win.tokens)}</strong>
+                <small className="hm-usage-burn-win-calls">{formatNumber(win.calls)} calls</small>
+              </>
+            )}
           </div>
         ))}
       </div>

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -139,6 +139,8 @@ export interface SubscriptionBilling {
   active: boolean;
   /** Dedicated to this app (counts in the total) vs shared (context only). */
   dedicated: boolean;
+  /** Burn windows measure "tokens" (Ollama) or "runs" (Codex — no token counters). */
+  unit: "tokens" | "runs";
   models: string[];
   windows: {
     session5h: LlmUsageWindow;

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -1001,6 +1001,20 @@ function usageEvents(value: unknown): LlmUsageEvent[] {
 }
 
 /**
+ * Timestamps of Codex task runs this monitor dispatched — every codex-agent task
+ * that reached "running" (has `startedAt`). Claude-run tasks (agent === "claude")
+ * are excluded so the Codex burn proxy counts only genuine Codex invocations.
+ */
+function codexRunTimestamps(rawSnapshot: unknown): string[] {
+  return asArray(asRecord(rawSnapshot)?.codexTasks)
+    .map((entry) => asRecord(entry))
+    .filter((task): task is Record<string, unknown> => Boolean(task))
+    .filter((task) => (asString(task.agent) ?? "codex") === "codex")
+    .map((task) => asString(task.startedAt))
+    .filter((ts): ts is string => Boolean(ts));
+}
+
+/**
  * High-risk file predicate. Mirrors the "high" branch of
  * github-pr-state.ts `highRiskForFile` (which is module-private), so the
  * `critical` flag on a card file matches the review-gating logic.
@@ -2425,6 +2439,9 @@ export function buildV2BoardSnapshot(
       // Flat-plan cost + burn windows per subscription provider
       // (env: OLLAMA_PLAN, CODEX_PLAN).
       subscriptions: resolveSubscriptionPlans(process.env),
+      // Codex reports no tokens, so its burn proxy is the count of Codex task
+      // runs this monitor dispatched (each `startedAt` = one run).
+      subscriptionRuns: { codex: codexRunTimestamps(rawSnapshot) },
     }),
     testbedSuites: testbedSuitesFromSnapshot(rawSnapshot),
     automationHealth: automationHealthForBoard(rawSnapshot, snapshotAt, process.env, {


### PR DESCRIPTION
Follows #523/#524/#525. You noted the panel showed Codex *cost* but no *usage* — so you couldn't gauge how much of your ChatGPT plan the monitor actually drives.

The Codex CLI reports **no token counts**, but the monitor **does** know every Codex task it dispatched. So the Codex burn proxy is now **run counts** — a truthful signal, never fabricated tokens.

## What
- **`llm-usage.ts`**: `SubscriptionBilling` gains `unit: "tokens" | "runs"`. A new `subscriptionRuns` option feeds run timestamps; `buildBilling` builds **run windows** (5h/7d/month counts, `tokens` stays 0) when a provider emits no token events. `usageRunWindow` + a runs-specific honest note.
- **`monitor-v2.ts`**: `codexRunTimestamps(rawSnapshot)` — every **codex-agent** task with a `startedAt` (Claude-run tasks excluded, since the queue is shared), passed as `subscriptionRuns.codex`.
- **`UsagePanel.tsx`**: `SubscriptionBurn` renders **"N runs"** per window (chip `runs`) for a runs-unit provider; `"X tokens · Y calls"` for tokens.

## Result
Codex now shows **both**:
- **Cost** — shared `$100/mo`, still under "used beyond this monitor · not in the total" (unchanged from #525).
- **Usage** — a **"Codex runs · Pro 5×"** block: `5h: 3 runs · 7d: 18 · month: 40` (illustrative) = the monitor's own Codex usage → gauge your ChatGPT-plan burn.

Each run ≈ one coding session against your shared plan. It's usage, not cost, so it doesn't touch the total.

## Truth boundary
Runs are real (the monitor dispatched them); no token count is ever invented for Codex. If the Codex CLI ever *does* report tokens, the same block auto-switches to token windows.

## Tests
- `averray-mcp` billing: **10/10** (+ Codex run-window test: 5h/7d/month counts, tokens stay 0, stays shared/out-of-total).
- `monitor-ui`: **808/808** (+ Codex runs block renders "3 runs"/"40 runs", second burn block).
- `averray-mcp` build ✓ · `monitor-ui` typecheck 0 · SPA build ✓ · slack-operator local tsc = known stale-`@avg` baseline.

## Deploy
No new env — same `OLLAMA_PLAN=pro` + `CODEX_PLAN=pro5x`, `--build` redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)