### PR TITLE
feat(monitor): model Claude as a shared subscription (not metered)

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -258,6 +258,10 @@ services:
       # Codex/ChatGPT subscription tier (free|go|plus|pro5x|pro) — flat monthly cost
       # for the codex agent in the same panel. Unset → "plan not set".
       CODEX_PLAN: ${CODEX_PLAN:-}
+      # Claude subscription tier (pro|max5x|max20x) — flat monthly cost for the
+      # Claude runner (sub mode; usage is plan-covered). Shown as shared context,
+      # NOT summed into the total. Unset → "plan not set".
+      CLAUDE_PLAN: ${CLAUDE_PLAN:-}
       HERMES_MONITOR_REPLY_MODEL: ${HERMES_MONITOR_REPLY_MODEL:-glm-5.2:cloud}
       # Preferred co-pilot transport: the real agentic Hermes via the gateway
       # Session API (MCP tools + skills + memory), instead of the stateless Ollama

--- a/packages/averray-mcp/src/llm-usage.test.ts
+++ b/packages/averray-mcp/src/llm-usage.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   aggregateLlmUsage,
   llmBillingClass,
+  resolveClaudePlan,
   resolveCodexPlan,
   resolveOllamaPlan,
   resolveSubscriptionPlans,
@@ -15,144 +16,127 @@ function evt(over: Partial<LlmUsageEvent> & Pick<LlmUsageEvent, "agent" | "model
   return { inputTokens: 0, outputTokens: 0, ...over };
 }
 
-// Ollama is dedicated (monitor-only); Codex is shared (used beyond this app).
+// Ollama is dedicated (monitor-only); Codex + Claude are shared (used beyond this app).
 const OLLAMA_PRO: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "pro", planLabel: "Pro", monthlyUsd: 20, configured: true, dedicated: true };
 const CODEX_PRO5X: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "pro5x", planLabel: "Pro 5×", monthlyUsd: 100, configured: true, dedicated: false };
+const CLAUDE_MAX5X: SubscriptionPlanConfig = { provider: "claude", label: "Claude", plan: "max5x", planLabel: "Max 5×", monthlyUsd: 100, configured: true, dedicated: false };
 const OLLAMA_UNSET: SubscriptionPlanConfig = { provider: "ollama", label: "Ollama", plan: "none", planLabel: "", monthlyUsd: null, configured: false, dedicated: true };
 const CODEX_UNSET: SubscriptionPlanConfig = { provider: "codex", label: "Codex", plan: "none", planLabel: "", monthlyUsd: null, configured: false, dedicated: false };
 
-describe("resolveOllamaPlan / resolveCodexPlan / resolveSubscriptionPlans", () => {
+describe("resolve*Plan / resolveSubscriptionPlans", () => {
   it("maps each provider's plan to its flat monthly price (case-insensitive, dash/underscore tolerant)", () => {
     expect(resolveOllamaPlan({ OLLAMA_PLAN: "pro" } as NodeJS.ProcessEnv)).toEqual(OLLAMA_PRO);
-    expect(resolveOllamaPlan({ OLLAMA_PLAN: "MAX" } as NodeJS.ProcessEnv)).toMatchObject({ plan: "max", monthlyUsd: 100, configured: true });
-    expect(resolveCodexPlan({ CODEX_PLAN: "pro5x" } as NodeJS.ProcessEnv)).toEqual(CODEX_PRO5X);
     expect(resolveCodexPlan({ CODEX_PLAN: "pro-5x" } as NodeJS.ProcessEnv)).toEqual(CODEX_PRO5X); // normalised
-    expect(resolveCodexPlan({ CODEX_PLAN: "plus" } as NodeJS.ProcessEnv)).toMatchObject({ plan: "plus", monthlyUsd: 20, planLabel: "Plus" });
+    expect(resolveClaudePlan({ CLAUDE_PLAN: "max5x" } as NodeJS.ProcessEnv)).toEqual(CLAUDE_MAX5X);
+    expect(resolveClaudePlan({ CLAUDE_PLAN: "MAX20X" } as NodeJS.ProcessEnv)).toMatchObject({ plan: "max20x", monthlyUsd: 200, planLabel: "Max 20×" });
   });
 
   it("treats unset / unknown plans as not configured (never invents a cost)", () => {
     expect(resolveOllamaPlan({} as NodeJS.ProcessEnv)).toEqual(OLLAMA_UNSET);
-    expect(resolveCodexPlan({ CODEX_PLAN: "enterprise" } as NodeJS.ProcessEnv)).toEqual(CODEX_UNSET);
+    expect(resolveClaudePlan({ CLAUDE_PLAN: "enterprise" } as NodeJS.ProcessEnv)).toMatchObject({ plan: "none", configured: false });
   });
 
-  it("resolveSubscriptionPlans returns both providers from env", () => {
-    const plans = resolveSubscriptionPlans({ OLLAMA_PLAN: "pro", CODEX_PLAN: "pro5x" } as NodeJS.ProcessEnv);
-    expect(plans.map((p) => p.provider)).toEqual(["ollama", "codex"]);
-    expect(plans).toEqual([OLLAMA_PRO, CODEX_PRO5X]);
+  it("resolveSubscriptionPlans returns all three providers from env", () => {
+    const plans = resolveSubscriptionPlans({ OLLAMA_PLAN: "pro", CODEX_PLAN: "pro5x", CLAUDE_PLAN: "max5x" } as NodeJS.ProcessEnv);
+    expect(plans.map((p) => p.provider)).toEqual(["ollama", "codex", "claude"]);
+    expect(plans).toEqual([OLLAMA_PRO, CODEX_PRO5X, CLAUDE_MAX5X]);
   });
 });
 
 describe("subscriptionProviderOf / llmBillingClass", () => {
-  it("attributes events to their subscription provider", () => {
+  it("attributes events to their subscription provider (Claude included)", () => {
     expect(subscriptionProviderOf("hermes", "glm-5.2:cloud")).toBe("ollama");
-    expect(subscriptionProviderOf("worker", "some-ollama-model")).toBe("ollama");
     expect(subscriptionProviderOf("codex", "gpt-5.5-codex")).toBe("codex");
-    expect(subscriptionProviderOf("claude", "claude-opus")).toBeNull();
+    expect(subscriptionProviderOf("claude", "claude-opus")).toBe("claude");
+    expect(subscriptionProviderOf("test-writer", "claude-sonnet")).toBe("claude"); // a Claude specialist
+    expect(subscriptionProviderOf("nobody", "mystery")).toBeNull();
   });
 
-  it("classes both Ollama and Codex as subscription, Claude agents as metered, else unknown", () => {
+  it("classes Ollama, Codex, and Claude as subscription (Claude runs on a plan); else unknown", () => {
     expect(llmBillingClass("hermes", "glm-5.2:cloud")).toBe("subscription");
     expect(llmBillingClass("codex", "gpt-5.5-codex")).toBe("subscription");
-    expect(llmBillingClass("claude", "not_recorded")).toBe("metered");
-    expect(llmBillingClass("test-writer", "claude-opus-4")).toBe("metered");
+    expect(llmBillingClass("claude", "not_recorded")).toBe("subscription"); // was metered — now plan-covered
+    expect(llmBillingClass("security", "claude-opus-4")).toBe("subscription");
     expect(llmBillingClass("someone-else", "mystery")).toBe("unknown");
   });
 });
 
-describe("aggregateLlmUsage — billing block (multi-provider)", () => {
+describe("aggregateLlmUsage — billing block (Ollama + Codex + Claude)", () => {
   const NOW = new Date("2026-07-07T12:00:00.000Z");
   const ollamaA = evt({ agent: "hermes", model: "glm-5.2:cloud", ts: "2026-07-07T11:00:00.000Z", inputTokens: 100, outputTokens: 50, cacheTokens: 1000 }); // 1h → 1150
-  const ollamaB = evt({ agent: "hermes", model: "deepseek-v4-pro:cloud", ts: "2026-07-07T09:00:00.000Z", inputTokens: 8, outputTokens: 2700 }); // 3h → 2708
   const codexA = evt({ agent: "codex", model: "gpt-5.5-codex", ts: "2026-07-07T11:30:00.000Z", inputTokens: 1000, outputTokens: 500 }); // 30m → 1500
-  const metered = evt({ agent: "claude", model: "not_recorded", ts: "2026-07-06T00:00:00.000Z", inputTokens: 8, outputTokens: 2700, cacheTokens: 160000, costUsd: 0.16 });
+  // Claude reports tokens AND a per-call cost, but the flat plan covers it.
+  const claudeA = evt({ agent: "claude", model: "claude-opus", ts: "2026-07-07T11:00:00.000Z", inputTokens: 100, outputTokens: 200, cacheTokens: 5000, costUsd: 0.16 }); // 1h → 5300 tok
 
-  it("builds one entry per configured/active provider and totals every flat plan + metered $", () => {
-    const b = aggregateLlmUsage([ollamaA, ollamaB, codexA, metered], {
+  it("makes Claude a SHARED subscription with token burn + a would-be $ context, never in the total", () => {
+    const b = aggregateLlmUsage([ollamaA, codexA, claudeA], {
       now: NOW,
-      subscriptions: [OLLAMA_PRO, CODEX_PRO5X],
+      subscriptions: [OLLAMA_PRO, CODEX_PRO5X, CLAUDE_MAX5X],
     }).billing;
 
-    expect(b.subscriptions.map((s) => s.provider)).toEqual(["ollama", "codex"]);
+    expect(b.subscriptions.map((s) => s.provider)).toEqual(["ollama", "codex", "claude"]);
 
-    const ollama = b.subscriptions.find((s) => s.provider === "ollama")!;
-    expect(ollama.monthlyUsd).toBe(20);
-    expect(ollama.active).toBe(true);
-    expect(ollama.windows!.session5h.tokens).toBe(1150 + 2708);
-    expect(ollama.windows!.session5h.calls).toBe(2);
-    expect(ollama.note).toMatch(/GPU-time/i);
+    const claude = b.subscriptions.find((s) => s.provider === "claude")!;
+    expect(claude.dedicated).toBe(false); // used interactively elsewhere too
+    expect(claude.unit).toBe("tokens"); // Claude reports tokens (unlike Codex)
+    expect(claude.active).toBe(true);
+    expect(claude.monthlyUsd).toBe(100);
+    expect(claude.planLabel).toBe("Max 5×");
+    expect(claude.windows!.session5h.tokens).toBe(5300);
+    expect(claude.windows!.session5h.calls).toBe(1);
+    // The $0.16 is a would-be API cost the plan covers — context, not spend.
+    expect(claude.apiEquivalentUsd).toBe(0.16);
+    expect(claude.note).toMatch(/plan|not billed per token/i);
 
-    const codex = b.subscriptions.find((s) => s.provider === "codex")!;
-    expect(codex.monthlyUsd).toBe(100);
-    expect(codex.planLabel).toBe("Pro 5×");
-    expect(codex.active).toBe(true);
-    expect(codex.windows!.session5h.tokens).toBe(1500);
-    expect(codex.windows!.session5h.calls).toBe(1);
-    expect(codex.note).toMatch(/ChatGPT/i);
-
-    // Ollama is dedicated to this app; Codex is a shared ChatGPT plan.
-    expect(ollama.dedicated).toBe(true);
-    expect(codex.dedicated).toBe(false);
-    // Both measured in tokens here (codexA carries token counters).
-    expect(ollama.unit).toBe("tokens");
-    expect(codex.unit).toBe("tokens");
-
-    expect(b.metered.monthCostUsd).toBe(0.16);
-    // Total = Ollama (dedicated $20) + Claude metered $0.16 — NOT Codex's shared $100.
-    expect(b.monthlyTotalUsd).toBe(20.16);
+    // Nothing is metered now (Claude moved to subscription).
+    expect(b.metered.monthCostUsd).toBeNull();
+    // Total is the app's dedicated spend only: Ollama $20 — NOT Codex or Claude ($100 each).
+    expect(b.monthlyTotalUsd).toBe(20);
     expect(b.monthlyTotalComplete).toBe(true);
   });
 
-  it("shows a configured provider that reports NO usage as flat-cost-only (no windows, honest note)", () => {
-    const b = aggregateLlmUsage([ollamaA, metered], {
+  it("keeps a configured provider with no usage as flat-cost-only (Codex idle)", () => {
+    const b = aggregateLlmUsage([ollamaA, claudeA], {
       now: NOW,
-      subscriptions: [OLLAMA_PRO, CODEX_PRO5X], // Codex configured but no codex events
+      subscriptions: [OLLAMA_PRO, CODEX_PRO5X, CLAUDE_MAX5X], // Codex configured but no codex events
     }).billing;
-
     const codex = b.subscriptions.find((s) => s.provider === "codex")!;
     expect(codex.active).toBe(false);
     expect(codex.windows).toBeNull();
-    expect(codex.monthlyUsd).toBe(100); // flat cost shown as context
-    expect(codex.note).toMatch(/isn't emitting|no burn proxy/i);
-    // Codex (shared) stays out of the total whether or not it reports usage.
-    expect(b.monthlyTotalUsd).toBe(20.16);
+    expect(codex.monthlyUsd).toBe(100);
+    // Ollama dedicated $20 is the whole total; Codex + Claude are shared context.
+    expect(b.monthlyTotalUsd).toBe(20);
     expect(b.monthlyTotalComplete).toBe(true);
   });
 
-  it("omits a provider that is neither configured nor active, and flags an unconfigured-but-active one", () => {
-    const b = aggregateLlmUsage([ollamaA, metered], {
+  it("omits a provider that is neither configured nor active; flags an unconfigured-but-active dedicated plan", () => {
+    const b = aggregateLlmUsage([ollamaA], {
       now: NOW,
       subscriptions: [OLLAMA_UNSET, CODEX_UNSET], // neither configured
     }).billing;
-    // Ollama has usage → shown (active, unconfigured); Codex has neither → omitted.
-    expect(b.subscriptions.map((s) => s.provider)).toEqual(["ollama"]);
+    expect(b.subscriptions.map((s) => s.provider)).toEqual(["ollama"]); // codex omitted
     expect(b.subscriptions[0]!.configured).toBe(false);
     expect(b.subscriptions[0]!.active).toBe(true);
-    // Total is metered-only and flagged incomplete (an active plan has no price).
-    expect(b.monthlyTotalUsd).toBe(0.16);
+    // A dedicated plan with usage but no price → total unknown + incomplete.
+    expect(b.monthlyTotalUsd).toBeNull();
     expect(b.monthlyTotalComplete).toBe(false);
   });
 
   it("shows Codex RUNS as the burn proxy when it reports no tokens (usage, not cost)", () => {
-    // 1h + 3h ago (both in the 5h window); 3d ago (in week/month, not session).
-    const runs = ["2026-07-07T11:00:00.000Z", "2026-07-07T09:00:00.000Z", "2026-07-04T00:00:00.000Z"];
-    const b = aggregateLlmUsage([ollamaA, metered], {
+    const runs = ["2026-07-07T11:00:00.000Z", "2026-07-07T09:00:00.000Z", "2026-07-04T00:00:00.000Z"]; // 1h,3h in 5h; 3d in week/month
+    const b = aggregateLlmUsage([ollamaA], {
       now: NOW,
       subscriptions: [OLLAMA_PRO, CODEX_PRO5X],
-      subscriptionRuns: { codex: runs }, // Codex emits no token events
+      subscriptionRuns: { codex: runs },
     }).billing;
-
     const codex = b.subscriptions.find((s) => s.provider === "codex")!;
     expect(codex.active).toBe(true);
     expect(codex.unit).toBe("runs");
-    expect(codex.windows!.session5h.calls).toBe(2); // the two runs inside 5h
+    expect(codex.windows!.session5h.calls).toBe(2);
     expect(codex.windows!.session5h.tokens).toBe(0); // never a fabricated token count
-    expect(codex.windows!.week7d.calls).toBe(3);
     expect(codex.windows!.month.calls).toBe(3);
-    expect(codex.note).toMatch(/runs/i);
-
-    // Runs are USAGE, not cost — Codex stays shared and out of the total.
     expect(codex.dedicated).toBe(false);
-    expect(b.monthlyTotalUsd).toBe(20.16);
+    expect(b.monthlyTotalUsd).toBe(20); // Ollama only
   });
 
   it("keeps a dedicated flat cost with no clock; a shared plan alone yields no app total", () => {
@@ -161,9 +145,9 @@ describe("aggregateLlmUsage — billing block (multi-provider)", () => {
     expect(dedicated.monthlyTotalUsd).toBe(20);
     expect(dedicated.monthlyTotalComplete).toBe(true);
 
-    // Codex alone is shared → its $100 is context, so there's nothing to total.
-    const sharedOnly = aggregateLlmUsage([codexA], { subscriptions: [CODEX_PRO5X] }).billing;
-    expect(sharedOnly.subscriptions[0]!.provider).toBe("codex");
+    // Claude alone is shared → its $100 is context, so there's nothing to total.
+    const sharedOnly = aggregateLlmUsage([claudeA], { subscriptions: [CLAUDE_MAX5X] }).billing;
+    expect(sharedOnly.subscriptions[0]!.provider).toBe("claude");
     expect(sharedOnly.subscriptions[0]!.monthlyUsd).toBe(100);
     expect(sharedOnly.monthlyTotalUsd).toBeNull();
     expect(sharedOnly.monthlyTotalComplete).toBe(true); // no dedicated plan to be missing

--- a/packages/averray-mcp/src/llm-usage.ts
+++ b/packages/averray-mcp/src/llm-usage.ts
@@ -82,16 +82,19 @@ export interface LlmUsageWindow {
   since: string;
 }
 
+/** Flat-rate subscription providers whose usage isn't billed per token. */
+export type SubscriptionProvider = "ollama" | "codex" | "claude";
+
 /**
- * One flat-rate subscription provider (Ollama Cloud, Codex/ChatGPT). Billed by a
- * fixed monthly plan — GPU-time / rolling-window usage, NOT per token — so there
- * is no truthful per-call $. We surface the flat plan price plus a token/call
- * burn proxy against the provider's real reset windows, but only when the
- * provider actually reports usage (`active`); Codex's CLI may not, in which case
- * `windows` is null and the flat cost stands alone.
+ * One flat-rate subscription provider (Ollama Cloud, Codex/ChatGPT, Claude
+ * Pro/Max). Billed by a fixed monthly plan — usage draws from the plan's limits,
+ * NOT per token — so there is no truthful per-call $. We surface the flat plan
+ * price plus a token/run burn proxy against the provider's real reset windows,
+ * but only when the provider actually reports usage (`active`); Codex's CLI may
+ * not, in which case `windows` is null and the flat cost stands alone.
  */
 export interface SubscriptionBilling {
-  provider: "ollama" | "codex";
+  provider: SubscriptionProvider;
   label: string;
   plan: string;
   planLabel: string;
@@ -119,6 +122,14 @@ export interface SubscriptionBilling {
     week7d: LlmUsageWindow;
     month: LlmUsageWindow;
   } | null;
+  /**
+   * For a subscription whose usage IS covered by the flat plan but whose runner
+   * still reports a per-call dollar figure (Claude's SDK `total_cost_usd`): the
+   * month-to-date sum of those figures — i.e. what this usage WOULD cost at API
+   * rates. Shown as context ("≈ covered by your plan"), never summed into the
+   * total. null when the provider reports no cost (Ollama, Codex).
+   */
+  apiEquivalentUsd: number | null;
   note: string;
 }
 
@@ -147,7 +158,7 @@ export interface LlmUsageBilling {
 
 /** Resolved flat-rate subscription plan for one provider (caller reads env). */
 export interface SubscriptionPlanConfig {
-  provider: "ollama" | "codex";
+  provider: SubscriptionProvider;
   label: string;
   plan: string;
   planLabel: string;
@@ -202,7 +213,7 @@ export interface LlmUsageAggregateOptions {
   /** Run timestamps (ISO) per subscription provider that reports RUNS not tokens.
    *  Codex's CLI emits no token counters, but the monitor knows every Codex task
    *  it dispatched — pass those `startedAt`s so the burn windows show run counts. */
-  subscriptionRuns?: Partial<Record<"ollama" | "codex", readonly string[]>>;
+  subscriptionRuns?: Partial<Record<SubscriptionProvider, readonly string[]>>;
 }
 
 export interface LlmUsageActiveCallInput {
@@ -230,11 +241,22 @@ const OLLAMA_PLAN_LABELS: Readonly<Record<string, string>> = { free: "Free", pro
 // Codex draws from the ChatGPT plan: Free/Go/Plus, Pro 5× ($100, Apr 2026), Pro ($200).
 const CODEX_PLAN_MONTHLY_USD: Readonly<Record<string, number>> = { free: 0, go: 8, plus: 20, pro5x: 100, pro: 200 };
 const CODEX_PLAN_LABELS: Readonly<Record<string, string>> = { free: "Free", go: "Go", plus: "Plus", pro5x: "Pro 5×", pro: "Pro" };
+// Claude Code draws from the Claude plan: Pro ($20), Max 5× ($100), Max 20× ($200).
+const CLAUDE_PLAN_MONTHLY_USD: Readonly<Record<string, number>> = { pro: 20, max5x: 100, max20x: 200 };
+const CLAUDE_PLAN_LABELS: Readonly<Record<string, string>> = { pro: "Pro", max5x: "Max 5×", max20x: "Max 20×" };
 /** Real usage reset windows shared by these subscriptions: 5-hour session, 7-day week. */
 const SESSION_WINDOW_MS = 5 * 60 * 60 * 1000;
 const WEEK_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
-/** Agents whose usage is metered per token (Claude Agent SDK reports real cost). */
-const METERED_AGENTS: ReadonlySet<string> = new Set(["claude", "test-writer", "security", "docs"]);
+/**
+ * Agents metered per token (charged real $ per call). Empty today: the Claude
+ * runner authenticates by SUBSCRIPTION (sub mode), and after Anthropic PAUSED
+ * the June-15-2026 Agent-SDK-credit change, that usage is included in the flat
+ * Claude plan — so Claude is a subscription provider (see subscriptionProviderOf),
+ * not metered. Kept as a seam for a genuine API-key deployment.
+ */
+const METERED_AGENTS: ReadonlySet<string> = new Set<string>();
+/** Claude Agent SDK agents — all run on the Claude plan (claude + specialists). */
+const CLAUDE_AGENTS: ReadonlySet<string> = new Set(["claude", "test-writer", "security", "docs"]);
 const OLLAMA_BURN_NOTE =
   "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars. "
   + "The token/call counts here are a burn proxy; Ollama emails you near 90% of your allocation "
@@ -249,6 +271,12 @@ const CODEX_RUNS_NOTE =
   "Codex task runs this monitor dispatched — the Codex CLI reports no tokens, so this counts runs "
   + "(each ≈ one coding session against your shared ChatGPT plan), not tokens. Use it to gauge how much "
   + "of Codex is driven from here.";
+const CLAUDE_BURN_NOTE =
+  "Claude Code draws from your Claude plan's shared 5h/weekly limits — included, not billed per token "
+  + "(Anthropic paused the June-15-2026 Agent-SDK-credit change). The $ figure is what this usage WOULD "
+  + "cost at API rates; your plan covers it, so it's not in the total.";
+const CLAUDE_NO_USAGE_NOTE =
+  "Claude Code draws from your Claude plan's shared 5h/weekly limits. No Claude usage recorded yet.";
 
 const activeCalls = new Map<string, LlmUsageActiveCall>();
 let nextActiveCallId = 0;
@@ -275,13 +303,22 @@ export function resolveCodexPlan(env: NodeJS.ProcessEnv = process.env): Subscrip
   return resolvePlan("codex", "Codex", false, env.CODEX_PLAN, CODEX_PLAN_MONTHLY_USD, CODEX_PLAN_LABELS);
 }
 
-/** Both known subscription providers, resolved from env — for aggregateLlmUsage. */
+/**
+ * Resolve the Claude (Anthropic) subscription plan from env
+ * (CLAUDE_PLAN=pro|max5x|max20x). Shared: Claude Code draws from your Claude plan,
+ * which you also use interactively elsewhere — flat cost is context, not summed.
+ */
+export function resolveClaudePlan(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig {
+  return resolvePlan("claude", "Claude", false, env.CLAUDE_PLAN, CLAUDE_PLAN_MONTHLY_USD, CLAUDE_PLAN_LABELS);
+}
+
+/** Every known subscription provider, resolved from env — for aggregateLlmUsage. */
 export function resolveSubscriptionPlans(env: NodeJS.ProcessEnv = process.env): SubscriptionPlanConfig[] {
-  return [resolveOllamaPlan(env), resolveCodexPlan(env)];
+  return [resolveOllamaPlan(env), resolveCodexPlan(env), resolveClaudePlan(env)];
 }
 
 function resolvePlan(
-  provider: "ollama" | "codex",
+  provider: SubscriptionProvider,
   label: string,
   dedicated: boolean,
   raw: string | undefined,
@@ -300,19 +337,22 @@ function resolvePlan(
  * isn't a subscription:
  *   - ollama → the hermes agent, a `:cloud` model suffix, or an ollama-tagged model.
  *   - codex  → the codex agent.
+ *   - claude → the Claude Agent SDK agents (claude + specialists), which run on
+ *     the Claude plan (sub mode; usage is plan-covered while the credit is paused).
  */
-export function subscriptionProviderOf(agent: string, model: string): "ollama" | "codex" | null {
+export function subscriptionProviderOf(agent: string, model: string): SubscriptionProvider | null {
   const a = agent.trim().toLowerCase();
   const m = model.trim().toLowerCase();
   if (a === "codex") return "codex";
+  if (CLAUDE_AGENTS.has(a)) return "claude";
   if (a === "hermes" || m.endsWith(":cloud") || m.includes("ollama")) return "ollama";
   return null;
 }
 
 /**
  * Classify an (agent, model) into its billing model:
- *   - subscription → a flat-rate provider (Ollama or Codex). No per-token $.
- *   - metered → Claude Agent SDK agents (claude + specialists) that report cost.
+ *   - subscription → a flat-rate provider (Ollama, Codex, or Claude). No per-token $.
+ *   - metered → genuine per-token API usage (none today — see METERED_AGENTS).
  *   - unknown → anything else (counted for tokens, never assigned a cost).
  */
 export function llmBillingClass(agent: string, model: string): "subscription" | "metered" | "unknown" {
@@ -487,7 +527,7 @@ function buildBilling(
   events: readonly LlmUsageEvent[],
   now: Date | undefined,
   plans: readonly SubscriptionPlanConfig[] | undefined,
-  runs: Partial<Record<"ollama" | "codex", readonly string[]>> | undefined,
+  runs: Partial<Record<SubscriptionProvider, readonly string[]>> | undefined,
 ): LlmUsageBilling {
   const anchor = now && Number.isFinite(now.getTime()) ? now : undefined;
   const endMs = anchor ? anchor.getTime() : undefined;
@@ -520,6 +560,19 @@ function buildBilling(
     const active = hasTokens || hasRuns;
     if (!plan.configured && !active) continue;
     const unit: "tokens" | "runs" = hasTokens ? "tokens" : "runs";
+    // What this plan-covered usage WOULD cost at API rates this month (Claude's
+    // SDK reports total_cost_usd even though the flat plan covers it). Context
+    // only — never summed into the total. null when the provider reports no cost.
+    let apiEquivalentUsd: number | null = null;
+    if (endMs !== undefined && monthStartMs !== undefined) {
+      const priced = provEvents.filter((event) => {
+        const t = Date.parse(event.ts);
+        return typeof event.costUsd === "number" && Number.isFinite(t) && t >= monthStartMs && t <= endMs;
+      });
+      if (priced.length > 0) {
+        apiEquivalentUsd = round(priced.reduce((sum, event) => sum + (event.costUsd ?? 0), 0), 6);
+      }
+    }
     const windowsReady = endMs !== undefined && monthStartMs !== undefined && active;
     const windows = windowsReady
       ? hasTokens
@@ -546,6 +599,7 @@ function buildBilling(
       unit,
       models: uniqueStrings(provEvents.map((event) => event.model)),
       windows,
+      apiEquivalentUsd,
       note: subscriptionNote(plan.provider, active, unit),
     });
   }
@@ -575,11 +629,12 @@ function buildBilling(
 }
 
 /** Per-provider honest note, aware of whether we're showing tokens or run counts. */
-function subscriptionNote(provider: "ollama" | "codex", active: boolean, unit: "tokens" | "runs"): string {
+function subscriptionNote(provider: SubscriptionProvider, active: boolean, unit: "tokens" | "runs"): string {
   if (provider === "codex") {
     if (!active) return CODEX_NO_USAGE_NOTE;
     return unit === "runs" ? CODEX_RUNS_NOTE : CODEX_BURN_NOTE;
   }
+  if (provider === "claude") return active ? CLAUDE_BURN_NOTE : CLAUDE_NO_USAGE_NOTE;
   return OLLAMA_BURN_NOTE;
 }
 

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -148,7 +148,7 @@ describe("UsagePanel", () => {
   });
 });
 
-// ── Cost & subscription burn (Ollama + Codex flat plans + metered Claude $) ──
+// ── Cost & subscription burn (Ollama + Codex + Claude flat plans) ───────────
 const ollamaSub: SubscriptionBilling = {
   provider: "ollama",
   label: "Ollama",
@@ -165,6 +165,7 @@ const ollamaSub: SubscriptionBilling = {
     week7d: { label: "7d week", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
     month: { label: "this month", tokens: 2_000_000, calls: 92, inputTokens: 1_800_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
   },
+  apiEquivalentUsd: null,
   note: "Ollama Cloud bills a flat monthly plan metered by GPU-time — not tokens or per-call dollars.",
 };
 // Codex configured (Pro 5× $100) but its CLI isn't reporting usage → flat cost only.
@@ -180,12 +181,34 @@ const codexSub: SubscriptionBilling = {
   unit: "runs", // Codex reports no tokens — usage proxy is run counts
   models: [],
   windows: null,
+  apiEquivalentUsd: null,
   note: "Codex draws from your ChatGPT plan. The Codex CLI isn't emitting token counters, so there's no burn proxy yet.",
 };
+// Claude: shared Max 5× plan, usage plan-covered (paused credit change) but token
+// counts ARE reported — token burn windows + a would-be API-cost of $0.16.
+const claudeSub: SubscriptionBilling = {
+  provider: "claude",
+  label: "Claude",
+  plan: "max5x",
+  planLabel: "Max 5×",
+  monthlyUsd: 100,
+  configured: true,
+  active: true,
+  dedicated: false, // you use Claude interactively elsewhere too
+  unit: "tokens",
+  models: ["not_recorded"],
+  windows: {
+    session5h: { label: "5h session", tokens: 800_000, calls: 30, inputTokens: 700_000, outputTokens: 100_000, since: "2026-07-07T07:00:00.000Z" },
+    week7d: { label: "7d week", tokens: 1_500_000, calls: 70, inputTokens: 1_300_000, outputTokens: 200_000, since: "2026-06-30T12:00:00.000Z" },
+    month: { label: "this month", tokens: 1_500_000, calls: 70, inputTokens: 1_300_000, outputTokens: 200_000, since: "2026-07-01T00:00:00.000Z" },
+  },
+  apiEquivalentUsd: 0.16,
+  note: "Claude Code draws from your Claude plan's shared 5h/weekly limits — included, not billed per token.",
+};
 const proBilling: LlmUsageBilling = {
-  metered: { models: ["not_recorded"], monthCostUsd: 0.16, costStatus: "recorded" },
-  subscriptions: [ollamaSub, codexSub],
-  monthlyTotalUsd: 20.16, // dedicated Ollama $20 + Claude $0.16 (Codex shared, excluded)
+  metered: { models: [], monthCostUsd: null, costStatus: "not_recorded" }, // nothing metered — Claude is a subscription now
+  subscriptions: [ollamaSub, codexSub, claudeSub],
+  monthlyTotalUsd: 20, // dedicated Ollama $20 only (Codex + Claude shared, excluded; Claude's $0.16 is plan-covered)
   monthlyTotalComplete: true,
 };
 
@@ -200,40 +223,46 @@ const withBilling: LlmUsageAggregate = {
   billing: proBilling,
 };
 
-// text matcher tolerant of the "×" glyph in "Pro 5×"
+// text matcher tolerant of the "×" glyph in plan labels
 const hasText = (needle: string) => (content: string) => content.includes(needle);
 
 describe("UsagePanel — cost & subscription burn", () => {
-  test("totals only DEDICATED spend (Ollama + Claude); shows shared Codex separately, not summed", () => {
-    const { getByText } = render(<UsagePanel usage={withBilling} />);
+  test("totals only DEDICATED spend (Ollama); Codex + Claude are shared context, not summed", () => {
+    const { getByText, getAllByText, queryByText } = render(<UsagePanel usage={withBilling} />);
     expect(getByText("Cost this month")).toBeTruthy();
-    // Total is the app's real cost: Ollama $20 + Claude $0.16 — NOT the shared Codex $100.
-    expect(getByText(/≈\s*\$20\.16/)).toBeTruthy();
+    // Total is the app's real dedicated cost: Ollama $20 — NOT Codex or Claude ($100 each, shared).
+    expect(getByText(/≈\s*\$20\.00/)).toBeTruthy();
     expect(getByText("Ollama Pro · flat")).toBeTruthy();
     expect(getByText("$20/mo")).toBeTruthy();
-    expect(getByText("Metered · Claude API")).toBeTruthy();
-    // Codex is still visible, but under a "shared" heading and excluded from the total.
+    // Claude is no longer a metered line — its usage is plan-covered.
+    expect(queryByText(hasText("Metered"))).toBeNull();
+    // Codex + Claude under the "shared" heading, each $100/mo, excluded from the total.
     expect(getByText(hasText("used beyond this monitor"))).toBeTruthy();
     expect(getByText(hasText("Codex Pro"))).toBeTruthy(); // "Codex Pro 5× · flat"
-    expect(getByText("$100/mo")).toBeTruthy();
+    expect(getByText(hasText("Claude Max"))).toBeTruthy(); // "Claude Max 5× · flat"
+    expect(getAllByText("$100/mo").length).toBe(2); // Codex + Claude
   });
 
-  test("a subscription (:cloud) row shows a muted 'flat' tag, not a misleading '?'", () => {
-    const { getByText } = render(<UsagePanel usage={withBilling} />);
-    expect(getByText("flat")).toBeTruthy(); // the glm-5.2:cloud row
-    const dollars = getByText("Cost this month").ownerDocument.body.textContent ?? "";
-    expect(dollars).toContain("$0.16");
+  test("subscription rows (Ollama + Claude) show a muted 'flat' tag, not a misleading '?'", () => {
+    const { getAllByText, getByText } = render(<UsagePanel usage={withBilling} />);
+    expect(getAllByText("flat").length).toBeGreaterThanOrEqual(2); // glm + claude model rows
+    // The would-be $0.16 surfaces as Claude context, not as a metered charge.
+    const body = getByText("Cost this month").ownerDocument.body.textContent ?? "";
+    expect(body).toContain("$0.16");
   });
 
-  test("renders the Ollama burn block; a configured-but-idle Codex shows cost only (no burn block)", () => {
+  test("renders token burn blocks for Ollama and Claude; idle Codex shows no burn block", () => {
     const { getByText, getAllByText, queryByText } = render(<UsagePanel usage={withBilling} />);
     expect(getByText("Ollama burn · Pro plan")).toBeTruthy();
-    expect(getByText("5h session")).toBeTruthy();
-    expect(getByText("40 calls")).toBeTruthy();
-    expect(getAllByText("92 calls").length).toBe(2);
-    expect(getByText(/GPU-time/)).toBeTruthy();
-    // Codex reports no usage → its cost shows in the strip but no burn windows.
+    expect(getByText(hasText("Claude burn"))).toBeTruthy(); // "Claude burn · Max 5× plan"
+    expect(getAllByText("5h session").length).toBe(2); // Ollama + Claude token blocks
+    expect(getByText("40 calls")).toBeTruthy(); // Ollama 5h
+    // Claude's would-be API cost is shown as context, never in the total.
+    expect(getByText(hasText("$0.16 at API rates"))).toBeTruthy();
+    expect(getByText(hasText("covered by your plan"))).toBeTruthy();
+    // Codex reports no usage → no burn block for it.
     expect(queryByText(hasText("Codex burn"))).toBeNull();
+    expect(queryByText(hasText("Codex runs"))).toBeNull();
   });
 
   test("shows Codex RUNS as a second burn block — the monitor's own Codex usage (not tokens)", () => {

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -5,6 +5,7 @@ import type {
   LlmUsageRecent,
   LlmUsageWindow,
   SubscriptionBilling,
+  SubscriptionProvider,
 } from "../lib/monitor/board-cache.js";
 import { formatCompactNumber, formatNumber, formatRelativeTime } from "../lib/monitor/format.js";
 import { UtilCard } from "./UtilCard.js";
@@ -308,7 +309,6 @@ function CostSummary({ billing }: { billing: LlmUsageBilling }) {
   const dedicated = billing.subscriptions.filter((sub) => sub.dedicated);
   const shared = billing.subscriptions.filter((sub) => !sub.dedicated);
   const anyDedicatedCost = dedicated.some((sub) => sub.configured) || billing.metered.monthCostUsd != null;
-  const meteredAmount = billing.metered.monthCostUsd != null ? formatUsd(billing.metered.monthCostUsd) : "$0";
   const totalText = billing.monthlyTotalUsd != null
     ? `${anyDedicatedCost ? "≈ " : ""}${formatUsd(billing.monthlyTotalUsd)}${billing.monthlyTotalComplete ? "" : " +"}`
     : "—";
@@ -320,11 +320,15 @@ function CostSummary({ billing }: { billing: LlmUsageBilling }) {
       </div>
       <div className="hm-usage-cost-rows">
         {dedicated.map((sub) => <CostRow key={sub.provider} sub={sub} />)}
-        <div className="hm-usage-cost-row">
-          <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-claude)" }} aria-hidden />
-          <span className="hm-usage-cost-name">Metered · Claude API</span>
-          <span className="hm-usage-cost-amt">{meteredAmount}</span>
-        </div>
+        {/* Metered row only when there's genuine per-token API spend. Today there
+            is none — Claude runs on a subscription (plan-covered) — so it hides. */}
+        {billing.metered.monthCostUsd != null ? (
+          <div className="hm-usage-cost-row">
+            <span className="hm-usage-jewel" style={{ background: "var(--h4-ag-system)" }} aria-hidden />
+            <span className="hm-usage-cost-name">Metered · API</span>
+            <span className="hm-usage-cost-amt">{formatUsd(billing.metered.monthCostUsd)}</span>
+          </div>
+        ) : null}
       </div>
       {shared.length > 0 ? (
         <div className="hm-usage-cost-shared">
@@ -411,6 +415,11 @@ function SubscriptionBurn({ subscription }: { subscription: SubscriptionBilling 
           </div>
         ))}
       </div>
+      {subscription.apiEquivalentUsd != null ? (
+        <div className="hm-usage-burn-apieq" title="What this month's usage would cost at API rates — your plan covers it, so it isn't in the total.">
+          ≈ {formatUsd(subscription.apiEquivalentUsd)} at API rates <span>· covered by your plan</span>
+        </div>
+      ) : null}
       <small className="hm-usage-burn-note">{subscription.note}</small>
     </div>
   );
@@ -421,22 +430,25 @@ function planLine(sub: SubscriptionBilling): string {
   return sub.planLabel ? `${sub.label} ${sub.planLabel}` : sub.label;
 }
 
-/** Provider jewel — Ollama rides the hermes token, Codex its own. */
-function providerJewel(provider: "ollama" | "codex"): string {
-  return provider === "codex" ? "var(--h4-ag-codex)" : "var(--h4-ag-hermes)";
+/** Provider jewel — Ollama rides the hermes token, Codex + Claude their own. */
+function providerJewel(provider: SubscriptionProvider): string {
+  if (provider === "codex") return "var(--h4-ag-codex)";
+  if (provider === "claude") return "var(--h4-ag-claude)";
+  return "var(--h4-ag-hermes)";
 }
 
 /**
  * Billing model for an (agent, model) — mirrors the backend llmBillingClass so a
  * row's cost cell matches how the aggregate classed it. Flat-rate subscriptions
- * (the codex agent, or Ollama via the hermes agent / `:cloud` / ollama-tagged
- * models) show "flat"; the Claude SDK agents are metered; else unknown.
+ * (codex, the Claude SDK agents, or Ollama via hermes / `:cloud` / ollama-tagged
+ * models) show "flat" — Claude included, since it runs on a plan (see
+ * subscriptionProviderOf). Everything else is unknown.
  */
 function billingClassOf(agent: string, model: string): "subscription" | "metered" | "unknown" {
   const a = agent.trim().toLowerCase();
   const m = model.trim().toLowerCase();
   if (a === "codex" || a === "hermes" || m.endsWith(":cloud") || m.includes("ollama")) return "subscription";
-  if (a === "claude" || a === "test-writer" || a === "security" || a === "docs") return "metered";
+  if (a === "claude" || a === "test-writer" || a === "security" || a === "docs") return "subscription";
   return "unknown";
 }
 

--- a/packages/monitor-ui/src/lib/monitor/board-cache.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-cache.ts
@@ -128,9 +128,12 @@ export interface LlmUsageWindow {
   since: string;
 }
 
-/** One flat-rate subscription provider (Ollama, Codex/ChatGPT) + its burn windows. */
+/** Flat-rate subscription providers whose usage isn't billed per token. */
+export type SubscriptionProvider = "ollama" | "codex" | "claude";
+
+/** One flat-rate subscription provider (Ollama, Codex, Claude) + its burn windows. */
 export interface SubscriptionBilling {
-  provider: "ollama" | "codex";
+  provider: SubscriptionProvider;
   label: string;
   plan: string;
   planLabel: string;
@@ -139,7 +142,7 @@ export interface SubscriptionBilling {
   active: boolean;
   /** Dedicated to this app (counts in the total) vs shared (context only). */
   dedicated: boolean;
-  /** Burn windows measure "tokens" (Ollama) or "runs" (Codex — no token counters). */
+  /** Burn windows measure "tokens" (Ollama, Claude) or "runs" (Codex — no token counters). */
   unit: "tokens" | "runs";
   models: string[];
   windows: {
@@ -147,6 +150,9 @@ export interface SubscriptionBilling {
     week7d: LlmUsageWindow;
     month: LlmUsageWindow;
   } | null;
+  /** Month-to-date would-be API cost for a plan-covered provider (Claude's
+   *  total_cost_usd); shown as "≈ covered by your plan", never in the total. */
+  apiEquivalentUsd: number | null;
   note: string;
 }
 

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -326,6 +326,14 @@
   font-size: 10px;
   color: var(--h4-faint);
 }
+.hm-usage-burn-apieq {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--h4-muted);
+}
+.hm-usage-burn-apieq span {
+  color: var(--h4-faint);
+}
 .hm-usage-burn-note {
   font-family: var(--font-mono);
   font-size: 10px;


### PR DESCRIPTION
You asked me to check what Anthropic changed for Claude. The short version, straight from [Anthropic's own doc](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan): they **announced** a June-15-2026 split (autonomous Agent-SDK usage → a separate metered credit) and then **paused it on June 16**:

> "We're pausing the changes to Claude Agent SDK usage described below. For now, nothing has changed: Claude Agent SDK, `claude -p`, and third-party app usage still draw from your subscription's usage limits."

So autonomous Claude usage is **still included in the flat Claude plan** — not metered per token. Our runner authenticates by **subscription** (`claude-worker-auth` `sub` mode; it refuses an API key). That means the old **"Metered · Claude API · $0.16"** line overstated real spend — the plan already covers it (the same overstatement we just fixed for Codex).

## What
Claude becomes a **third subscription provider** — modelled like Codex, but with real token usage (Claude reports tokens; Codex doesn't).

**Backend (`averray-mcp/llm-usage.ts`)**:
- `SubscriptionProvider` += `"claude"`; the Claude SDK agents (claude + specialists) now class as **subscription**, `dedicated: false` (shared — you use Claude interactively elsewhere).
- `METERED_AGENTS` is now empty — nothing is metered today (kept as a seam for a genuine API-key deployment).
- `SubscriptionBilling.apiEquivalentUsd`: the month-to-date **would-be** API cost (Claude's `total_cost_usd`) — context only, **never summed**.
- `resolveClaudePlan(CLAUDE_PLAN=pro|max5x|max20x)`; wired into `resolveSubscriptionPlans`.

**Frontend (`UsagePanel.tsx`)**:
- Claude appears under **"shared · used beyond this monitor · not in the total"** ($100/mo Max 5×).
- A **Claude burn** block with real **token windows** (5h/7d/month).
- A muted **"≈ $0.16 at API rates · covered by your plan"** line — the would-be cost, honestly reframed.
- The metered cost row is now conditional and hides (nothing metered). The total drops to the one dedicated plan: **Ollama $20**.

## Truth boundary
No invented $. The `$0.16` moves out of the total (it's plan-covered, not spend) and is shown as *would-be* API cost. Claude's flat plan is shared context, not summed. If Anthropic ever un-pauses the credit, Claude flips back to genuinely metered — revisit then.

## Tests
- `averray-mcp` billing: **10/10** — Claude shared + token windows + `apiEquivalentUsd`, out of the total; nothing metered; total = Ollama $20.
- `monitor-ui`: **808/808**.
- `averray-mcp` build ✓ · `monitor-ui` typecheck 0 · SPA build ✓ · slack-operator local tsc = known stale-`@avg` baseline.

## Deploy
Add `CLAUDE_PLAN=max5x` (alongside `OLLAMA_PLAN=pro` + `CODEX_PLAN=pro5x`) in `.env.prod`, `--build` redeploy. Stacks on #523–#526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)