### PR TITLE
fix(monitor): drop the empty Latency column + honest would-be table total

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -503,8 +503,8 @@ describe("BoardView — rich-mix board (open stream)", () => {
     expect(getAllByText("59K").length).toBeGreaterThan(0); // total + the single model
     expect(getByText("claude-sonnet-4-5")).toBeTruthy();
     expect(getByText(/48K in · 9K out/)).toBeTruthy();
-    // Latency has no real source → an explicit "?" (never fabricated).
-    expect(getAllByText("?").length).toBeGreaterThan(0);
+    // The latency column (no data source) is gone — no fabricated "?" placeholder.
+    expect(queryAllByText("Latency").length).toBe(0);
     // The in-flight line names the live call.
     expect(getByText("claude · claude-sonnet-4-5")).toBeTruthy();
     // Every expected agent is accounted for: idle ones are listed explicitly

--- a/packages/monitor-ui/src/components/UsagePanel.test.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.test.tsx
@@ -41,13 +41,15 @@ const recorded: LlmUsageAggregate = {
 };
 
 describe("UsagePanel", () => {
-  test("renders the real per-model table with a '?' latency (never fabricated)", () => {
-    const { getByText, getAllByText, getByRole } = render(<UsagePanel usage={recorded} />);
+  test("renders the real per-model table (tokens + calls); no latency column of '?'", () => {
+    const { getByText, getAllByText, getByRole, queryByText } = render(<UsagePanel usage={recorded} />);
     expect(getByRole("region", { name: "LLM usage" })).toBeTruthy();
     expect(getByText("All models")).toBeTruthy();
     expect(getByText("deepseek-v4-pro")).toBeTruthy();
     expect(getAllByText("10K").length).toBeGreaterThan(0); // total + model row, compact
-    expect(getAllByText("?").length).toBeGreaterThan(0); // latency has no source
+    // The latency column (all "?", no data source) is gone — not a placeholder.
+    expect(queryByText("Latency")).toBeNull();
+    expect(queryByText("?")).toBeNull();
   });
 
   test("shows EVERY expected agent — idle ones listed explicitly with reasons, never collapsed", () => {
@@ -60,16 +62,18 @@ describe("UsagePanel", () => {
     expect(getByText("Codex CLI does not report usage.")).toBeTruthy();
   });
 
-  test("renders a real Cost column only when costStatus is recorded", () => {
+  test("real per-row $ for a genuinely-metered row; the table total is a would-be ≈", () => {
     const withCost: LlmUsageAggregate = {
       ...recorded,
       costUsd: 0.42,
       costStatus: "recorded",
-      byModel: [{ ...recorded.byModel[0]!, costUsd: 0.42, costStatus: "recorded" }],
+      // agent "mystery" → unknown billing class → a real per-token $ shows on the row.
+      byModel: [{ ...recorded.byModel[0]!, agent: "mystery", costUsd: 0.42, costStatus: "recorded" }],
     };
-    const { getByText, getAllByText } = render(<UsagePanel usage={withCost} />);
+    const { getByText } = render(<UsagePanel usage={withCost} />);
     expect(getByText("Cost")).toBeTruthy();
-    expect(getAllByText("$0.42").length).toBeGreaterThan(0); // total + model row
+    expect(getByText("$0.42")).toBeTruthy(); // the metered row
+    expect(getByText("≈ $0.42")).toBeTruthy(); // the would-be table total
   });
 
   test("omits the Cost column entirely when no source reports cost (no column of '?')", () => {

--- a/packages/monitor-ui/src/components/UsagePanel.tsx
+++ b/packages/monitor-ui/src/components/UsagePanel.tsx
@@ -15,9 +15,10 @@ import { UtilCard } from "./UtilCard.js";
  * ONLY to real LlmUsageAggregate: per-(agent, model) rows, an "All models"
  * total, the in-flight line, EVERY expected agent (active or idle — none
  * hidden), real cost when recorded, and a real daily-tokens chart. Truth-boundary:
- *   - Latency renders "?" — LlmUsageModelRollup has no latency field.
- *   - Cost shows only when costStatus is "recorded" (never fabricated); the Cost
- *     column appears only when at least one source reports it.
+ *   - No latency column — the usage events carry no per-call duration, so rather
+ *     than a column of "?" there's no column (add it back if runners emit latency).
+ *   - The table-total Cost is the would-be API cost (subscriptions cover it);
+ *     per-row cost is "flat" for a subscription, real $ only when truly metered.
  *   - The time chart is REAL daily byDay tokens when ≥2 days exist; otherwise an
  *     honest "awaiting per-minute stream" frame (that source isn't wired yet).
  *   - When nothing is recorded, the honest message replaces the table.
@@ -37,9 +38,9 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
   const hasTable = recorded && models.length > 0;
   // Cost split by billing model (metered $ vs flat Ollama subscription + burn windows).
   const billing = usage?.billing;
-  // Cost column: when billing is present every row has a meaningful cell (metered $,
-  // "flat" for subscription, or "?"), so show it. Otherwise fall back to the old
-  // "only when something recorded" rule so we never paint a bare column of "?".
+  // Cost column: when billing is present every row has a meaningful cell ("flat"
+  // for a subscription, real $ if metered), so show it. Otherwise fall back to the
+  // old "only when something recorded" rule so we never paint a bare column of "?".
   const showCost = !!usage && (
     !!billing || usage.costStatus === "recorded" || models.some((m) => m.costStatus === "recorded")
   );
@@ -60,18 +61,16 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
             <span className="hm-usage-c-num">Tokens</span>
             <span className="hm-usage-c-num">Calls</span>
             {showCost ? <span className="hm-usage-c-num">Cost</span> : null}
-            <span className="hm-usage-c-num">Latency</span>
           </div>
           <div className="hm-usage-row hm-usage-row--total">
             <span className="hm-usage-c-model">All models</span>
             <span className="hm-usage-c-num">{formatCompactNumber(usage!.totalTokens)}</span>
             <span className="hm-usage-c-num">{formatNumber(usage!.runs)}</span>
             {showCost ? (
-              <span className="hm-usage-c-num" title="Recorded metered cost (Claude API, all time). Ollama runs on a flat subscription — see Cost this month above.">
-                {formatCost(usage!.costUsd, usage!.costStatus)}
+              <span className="hm-usage-c-num" title="Would-be cost at API rates from providers that report it (e.g. Claude's total_cost_usd). Your subscriptions cover it — it's NOT in the 'cost this month' total above.">
+                {formatWouldBeCost(usage!.costUsd, usage!.costStatus)}
               </span>
             ) : null}
-            <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
           </div>
           {models.map((entry) => (
             <div className="hm-usage-row" key={`${entry.agent}:${entry.model}`}>
@@ -83,7 +82,6 @@ export function UsagePanel({ usage }: { usage?: LlmUsageAggregate }) {
               <span className="hm-usage-c-num">{formatCompactNumber(entry.totalTokens)}</span>
               <span className="hm-usage-c-num">{formatNumber(entry.runs)}</span>
               {showCost ? <RowCost entry={entry} /> : null}
-              <span className="hm-usage-c-num hm-usage-c-na" title="latency not reported">?</span>
             </div>
           ))}
           {/* in/out split + last-active live below the table, per active source */}
@@ -468,6 +466,17 @@ function formatCost(usd: number | null | undefined, status: string): string {
   if (status !== "recorded" || usd == null) return "?";
   if (usd === 0) return "$0";
   return usd < 0.01 ? "<$0.01" : `$${usd.toFixed(2)}`;
+}
+
+/**
+ * Table-total cost = the would-be API cost from providers that report it (Claude's
+ * total_cost_usd); the subscriptions cover it, so it's never real spend. Prefixed
+ * "≈" to signal that, em-dash when nothing reports a cost.
+ */
+function formatWouldBeCost(usd: number | null | undefined, status: string): string {
+  if (status !== "recorded" || usd == null) return "—";
+  if (usd === 0) return "$0";
+  return usd < 0.01 ? "≈ <$0.01" : `≈ $${usd.toFixed(2)}`;
 }
 
 /**

--- a/packages/monitor-ui/src/styles/hermes4-utilities.css
+++ b/packages/monitor-ui/src/styles/hermes4-utilities.css
@@ -85,15 +85,15 @@
 }
 .hm-usage-row {
   display: grid;
-  grid-template-columns: 1fr 56px 46px 62px;
+  grid-template-columns: 1fr 64px 52px;
   align-items: center;
   gap: 10px;
   padding: 8px 2px;
   border-top: 1px solid var(--h4-line-2);
 }
-/* with a real cost column the table is 5 across */
+/* with a cost column the table is 4 across */
 .hm-usage-table--cost .hm-usage-row {
-  grid-template-columns: 1fr 52px 40px 58px 50px;
+  grid-template-columns: 1fr 60px 46px 64px;
   gap: 8px;
 }
 .hm-usage-row--head {


### PR DESCRIPTION
Two tidies I spotted while verifying the live LLM-usage panel.

## Latency column → removed
The usage events carry **no per-call duration** (`LlmUsageModelRollup` has no latency field), so the Latency column was a full column of `?` for zero signal. Rather than a placeholder, it's gone — with all subscription rows already reading **flat**, the table now has no `?` at all. (If the runners ever emit real per-call latency, we add it back with actual numbers.)

## Stale "metered · Claude API" cost total → fixed
Now that everything is a subscription, the table-total Cost cell used to show the raw recorded `$0.38` with a stale *"metered · Claude API"* tooltip — confusing next to a column of "flat". It now reads **`≈ $0.38`** (the would-be API cost, e.g. Claude's `total_cost_usd`) with an honest tooltip: *the subscriptions cover it, so it's not real spend and not in the "cost this month" total above.* Per-row cost stays **flat** for subscriptions, real `$` only when genuinely metered.

## Tests
- `monitor-ui` **808/808** (updated the two tests that asserted the old latency `?`; added a real-per-row-`$` + would-be-`≈`-total case).
- typecheck 0 · SPA build ✓.

Frontend-only. Stacks on #523–#527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)