### PR TITLE
feat(harness): add INT-0 charter and integration contracts

### DIFF
--- a/docs/HARNESS_INT0_HANDBACK.md
+++ b/docs/HARNESS_INT0_HANDBACK.md
@@ -1,0 +1,134 @@
+# INT-0 handback — charter and versioned contracts
+
+**Status:** implementation complete; pending review
+
+**Branch:** `codex/harness-integration-plan`
+
+**Baseline:** `5869af7bf2fc7e6168fbe070744f7d37fdf8c52a` (`origin/main`)
+
+**Runtime authority change:** none
+
+## Built
+
+- Added the reviewed Harness integration charter at `docs/HARNESS_INTEGRATION_PLAN.md`.
+- Added strict, versioned Zod contracts in `@avg/schemas`:
+  - `AgentTask` V1;
+  - `AgentRunProjection` V1;
+  - `VerifiedHandoff` V1;
+  - `HermesDecisionRecord` V2;
+  - the current `HermesDecisionRecord` V1 reader;
+  - the current legacy `codex_task` V1 reader.
+- Added shared actor, artifact, capability, acceptance, model, mutation, pull-request, hash,
+  timestamp, and exact Harness run-state primitives.
+- Added deterministic canonical serialization and SHA-256 hashing through Web Crypto.
+- Bound approval hashes to the immutable task content, including policy version/hash, while
+  excluding lifecycle bookkeeping and post-approval bindings.
+- Added pure cross-contract checks that:
+  - require run identity and policy to match the approved task;
+  - prove effective capabilities, network allowlists, and budgets do not exceed task authority;
+  - require a verified handoff to match the approved task hash, TaskIntent, run manifest, verifier
+    plan, verification decision, and all stable IDs.
+- Kept child delegation disabled in V1: `delegable=false`, `maxChildren=0`, and
+  `maxConcurrentChildren=0`.
+- Added conservative read-only compatibility views. Historical `codex_task` records remain
+  explicitly non-dispatchable because they lack TaskIntent, immutable acceptance, typed grants,
+  budget, deadline, and policy hash.
+- Added six cross-language JSON fixtures and 18 focused invariant tests.
+
+## Safety pins
+
+1. Unknown contract versions and undeclared fields fail closed for all new contracts.
+2. Artifact refs and their declared hashes must agree.
+3. An approved task requires an exact task hash, decision actor, decision timestamp, and approved
+   timestamp.
+4. Harness and verifier identities cannot request or approve an AgentTask.
+5. Operator approvals can be decided only by an operator. Policy approvals can be decided only by
+   policy or an operator.
+6. Material edits change the approval hash and invalidate the approval match.
+7. Legacy records are read but never rewritten or promoted into dispatchable `AgentTask` records.
+8. Failed or quarantined run projections require structured failure details.
+9. Non-healthy run sources require an explicit reason.
+10. PR-open eligibility requires completed output, independent accepted verification, and every
+    recorded check passing.
+
+No board, queue, runner, policy, dispatcher, Harness CLI, GitHub write, Averray mutation, wallet,
+settlement, deployment, or production configuration path changed. `AGENTS.md` remains accurate
+because no role or operational behavior changed.
+
+## Files
+
+- `docs/HARNESS_INTEGRATION_PLAN.md`
+- `docs/HARNESS_INT0_HANDBACK.md`
+- `packages/schemas/src/agent-integration-common.ts`
+- `packages/schemas/src/agent-contract-hash.ts`
+- `packages/schemas/src/agent-task.ts`
+- `packages/schemas/src/agent-run-projection.ts`
+- `packages/schemas/src/verified-handoff.ts`
+- `packages/schemas/src/hermes-decision-record.ts`
+- `packages/schemas/src/legacy-agent-task.ts`
+- `packages/schemas/src/index.ts`
+- `test/fixtures/agent-integration/*.json`
+- `test/unit/agent-integration-contracts.test.ts`
+
+## Verification
+
+```text
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npx vitest run test/unit/agent-integration-contracts.test.ts
+Test Files  1 passed (1)
+Tests       18 passed (18)
+
+$ npm test
+Test Files  176 passed (176)
+Tests       2172 passed (2172)
+```
+
+One intermediate full-suite run observed the existing
+`testbed-live-screencast.test.ts` timing test fail to find its manifest. The isolated test then
+passed 3/3, and the final uninterrupted full suite passed 2,172/2,172. INT-0 does not touch that
+test or its runtime path.
+
+`npm install` changed no dependency manifest or lockfile. It reported the lockfile's existing audit
+inventory; INT-0 adds no dependency.
+
+## Affected surfaces
+
+- Shared schema package: yes
+- Documentation: yes
+- Tests/fixtures: yes
+- MCP runtime: no
+- Monitor/board: no
+- Slack operator: no
+- Agent queue/runners: no
+- Ops/compose/environment/secrets: no
+- Averray platform: no
+- Generic Agent Harness: no
+
+## Rollback
+
+Remove the new schema modules, fixtures, tests, handback, and their exports from
+`packages/schemas/src/index.ts`. No stored data, migration, runtime flag, or external system needs
+rollback.
+
+## Decisions and rationale
+
+1. **Legacy tasks remain non-dispatchable.** Inventing acceptance, grants, budgets, or policy hashes
+   would manufacture authority.
+2. **Approval hashes cover policy identity.** Reusing approval after a policy or material task
+   change is unsafe.
+3. **Lifecycle fields are excluded from the approval payload.** Status and timestamps can advance
+   without changing what was authorized.
+4. **Canonical hashing uses the Web Crypto API.** It works in Node 22 and browser consumers without
+   importing Node-only crypto into the shared schema entrypoint.
+5. **Authority attenuation is a cross-contract assertion.** A run can be structurally valid while
+   still being invalid for a particular task; both checks are required.
+6. **V1 disables children.** Child execution can be introduced only through a later version and
+   explicit guardrail review.
+
+## Open questions
+
+No open question blocks review of INT-0. INT-1 still needs the generic read-interface version and
+two immutable pilot run IDs selected before its read-only projection proof.

--- a/docs/HARNESS_INTEGRATION_PLAN.md
+++ b/docs/HARNESS_INTEGRATION_PLAN.md
@@ -1,0 +1,1100 @@
+# Agent Harness integration plan
+
+**Status:** implementation-ready architecture and packet plan
+
+**Planning baseline:** 2026-07-23
+
+**Owning repository:** `averray-reference-agent`
+
+**Scope:** Hermes Ops Board integration with the generic Agent Harness and the Averray control plane
+
+**Non-goal:** this document does not authorize dispatch, production mutation, settlement, deployment, or changes to the generic Harness kernel
+
+> **Hermes coordinates. Harness executes. Verification gates. The operator releases.**
+
+## 1. Executive decision
+
+The system will keep one Hermes Ops Board and one conversational operations lead. Hermes decides
+what work should be proposed and when it should be considered. A dedicated dispatcher translates
+an approved, immutable `AgentTask` into the generic Harness `TaskIntent`. The Harness owns durable
+technical execution. An independent verifier determines whether the output satisfies the approved
+acceptance criteria. The operator retains release authority.
+
+The integration is an adapter around the generic Harness, not a fork of it:
+
+- Averray-, Hermes-, repository-, board-, and agent-specific policy stays outside the Harness
+  kernel.
+- The kernel remains domain-agnostic and continues to reject product, company, and agent names in
+  its hygiene gate.
+- Hermes remains the only conversational voice in the Ops Board. The Harness emits structured
+  state, events, artifacts, and verification evidence; it does not narrate to the operator.
+- Existing direct Codex and Claude runners remain a bounded, observable fallback during migration.
+  The target executor is the Harness; model, provider, effort, and promoted-skill versions become
+  run metadata rather than board lanes or sources of authority.
+- The internal lane identifier remains `codex-needed` for compatibility. Its visible title becomes
+  **WORK QUEUE** everywhere.
+
+The rollout starts with versioned contracts and read-only projection. No dispatch is enabled until
+the PKT-033 implementation is landed on Harness `origin/main`, the generic Harness gates are clean,
+and an operator explicitly enables the supervised dispatcher.
+
+## 2. Evidence baseline and current state
+
+This plan is based on the fetched `origin/main` of all three repositories, not on stale local
+branches or generated output.
+
+| Repository | Inspected upstream head | Evidence relevant to this plan |
+|---|---|---|
+| `averray-reference-agent` | `5869af7bf2fc…` — `fix(product-health): quiet unchanged red alerts (#530)` | Hermes O0–O5, A1–A4, D1–D4, initial B/C slices, direct task queues/runners, approval policy, anomaly pause, independent review, and the current Ops Board are already implemented. |
+| generic `agent-harness` | `8c0b86fd3c0…` — PKT-033 specification merge | Phases 0–5 and PKT-029–032 machinery are on main. PKT-033 is a specification only on main. The implementation and clean-gate handback exist on `origin/codex/pkt-033-real-corpus-detection` at `749e8ce…`, but are not landed. |
+| Averray platform (`Polkadot`) | `38bcf834…` — worker money-rail handoff | `worker/` already maps an Averray bounty job into a Harness `TaskIntent`, executes the Harness as a black box in a deny-all-network sandbox, and assembles evidence. Claim, PR-open, submission, verification, and settlement remain platform control-plane seams. |
+
+Primary evidence anchors:
+
+- Hermes: `docs/HERMES_MULTI_AGENT_ORCHESTRATION_PLAN.md`,
+  `docs/HERMES_ORCHESTRATION_DESIGN.md`, `docs/HERMES_INTEGRATION_MAP.md`,
+  `docs/HERMES_ROADMAP.md`, `services/slack-operator/src/codex-task-queue.ts`,
+  `services/slack-operator/src/monitor-v2.ts`, and the board/narration/UI types and components.
+- Harness: `docs/ARCHITECTURE.md`, `docs/PHASE-6-EXIT.md`,
+  `docs/packets/PKT-032-HANDBACK.md`, `docs/packets/PKT-033-real-corpus-detection.md`,
+  `src/agent_runtime/contracts/task.py`, and `src/agent_runtime/contracts/run.py`.
+- Averray: `docs/packets/PKT-AVGW-001-HANDBACK.md`, `worker/README.md`,
+  `worker/HANDOFF.md`, `worker/src/job-adapter.js`, `worker/src/harness-driver.js`, and
+  `worker/src/submission.js`.
+
+### 2.1 Hermes capabilities to preserve, not rebuild
+
+The current roadmap and source establish the following baseline:
+
+The existing eight-lane pipeline remains:
+`needs-attention → drafts → codex-needed → hermes-checking → operator-review → release-queue →
+deploying → done`. This plan changes neither that persisted ordering nor those identifiers.
+
+| Existing stream | Shipped capability | Integration consequence |
+|---|---|---|
+| O0 | Source map and integration discovery | INT-0 narrows and versions the cross-system boundary; it does not repeat discovery. |
+| O1 | Agent attribution on the board | INT-1 extends attribution with structured Harness run projection. |
+| O2 | Claude worker | Claude and Codex runners remain transitional fallbacks. |
+| O3 | Board dispatch | INT-2 reuses the existing proposal and operator decision experience. |
+| O4 | Enqueue guardrail and autonomy | INT-2 extends the fail-closed policy; it does not create a second autonomy system. |
+| O5 | Liveness, retry, and restart hardening | INT-4 adds Harness/DBOS-specific drills and reconciliation. |
+| A1–A4 | Scorecards, measured routing, cost, and model/effort metadata | INT-6 consumes measured evidence; it never lets a model author policy. |
+| D1–D4 | Digests, decision records, anomaly pause, and alert bridge | INT-0 versions the record, INT-4 adds Harness signals, and INT-5 extends the same away mode. |
+| B1–B2 | Default-off autonomous proposals and self-healing proposals | Harness work begins as proposal-only and inherits the same safety posture. |
+| C1–C3 | Cross-agent review, reviewer panel, and specialists | INT-3 binds independent verification to the existing review/release flow. |
+
+The current queue is named `CodexTask`/`codex_task`, but already accepts several agents and powers
+both direct runners. The current lifecycle is `proposed → approved → running →
+completed|failed|cancelled`, with one runner heartbeat projection. It is useful migration
+infrastructure, but it is not a sufficient cross-system contract: it lacks a stable work item ID,
+immutable TaskIntent binding, medium risk, typed capabilities, durable Harness run identity, and a
+verified handoff.
+
+### 2.2 Generic Harness capabilities and limits
+
+The Harness already supplies the execution primitives this integration should consume:
+
+- versioned `TaskIntent` (`harness/v1alpha1`);
+- immutable `RunManifest` with task/policy/verifier hashes, grants, risk, budgets, model bindings,
+  prompt versions, promoted-skill versions, and retention;
+- durable DBOS workflow identity and ledger state;
+- a fixed 19-event vocabulary with `run_id`, `attempt`, `correlation_id`, actor, payload/ref, and
+  payload hash;
+- content-addressed artifacts;
+- independent verification and acceptance records;
+- fail-closed capabilities, deny-by-default egress, approval/suspend/cancel/quarantine states;
+- replay-safe execution and offline learning with human-gated promotion/deprecation.
+
+The generic CLI can inspect a known run (`status`, `events`, `deliverables`, approvals, artifacts),
+but it does not currently expose a global run-list API. That is not a blocker:
+
+- INT-1 registers a small set of known pilot run bindings for read-only projection.
+- INT-2 persists the `workItemId ↔ harnessRunId` binding as part of dispatch, so later discovery
+  does not require scanning internal DBOS tables.
+- The board adapter must not query private DBOS tables or infer state from process liveness.
+
+Phase-6 deterministic machinery is complete, but the upstream exit record still states that
+empirical real-model closure is pending. Phase 7 is an architectural direction in the Harness,
+not an implementation packet. Therefore this plan does not claim either phase complete.
+
+### 2.3 Existing Averray worker seam
+
+The platform `worker/` is an Averray demand-side profile and adapter. It must not be copied into the
+reference agent or generalized into the kernel. It already proves several correct boundaries:
+
+- an Averray job is translated into a generic `TaskIntent`;
+- the Harness is invoked as a black box;
+- the sandbox can run with network disabled;
+- an unverified run cannot be presented as verified;
+- the work engine does not receive settlement authority;
+- claim, authenticated PR open, submission, verification, and settlement remain downstream
+  platform operations.
+
+The Hermes dispatcher is a separate operations integration seam. It may submit approved technical
+work to the same generic Harness, but Averray economic jobs continue to use the platform worker and
+control plane. Both paths correlate through stable IDs; neither path absorbs the other's authority.
+
+## 3. Target organization and hard boundaries
+
+```mermaid
+flowchart LR
+  operator["Operator<br/>approve · release · high-risk decisions"]
+  hermes["Hermes<br/>triage · propose · coordinate · explain"]
+  policy["Versioned policy<br/>risk · grants · budgets · allowlists"]
+  dispatcher["Dedicated dispatcher<br/>validate · bind · submit · reconcile"]
+  harness["Generic Agent Harness<br/>durable execution ledger / DBOS"]
+  verifier["Independent verifier<br/>acceptance decision"]
+  github["GitHub / CI<br/>PR · checks · release truth"]
+  averray["Averray control plane<br/>auth · claims · sessions · settlement · audit"]
+  board["One Ops Board<br/>read model only"]
+
+  hermes -->|"proposes AgentTask"| policy
+  operator -->|"approval where required"| policy
+  policy -->|"approved immutable task hash"| dispatcher
+  dispatcher -->|"maps to TaskIntent"| harness
+  harness -->|"artifacts + structured events"| verifier
+  verifier -->|"VerifiedHandoff"| github
+  operator -->|"merge / deploy release"| github
+  averray <-->|"job/session IDs and economic operations"| dispatcher
+  hermes --> board
+  dispatcher --> board
+  harness --> board
+  verifier --> board
+  github --> board
+  averray --> board
+```
+
+### 3.1 Role definitions
+
+- **Operator:** the accountable release owner and approval authority for high-risk or irreversible
+  actions. Humans merge, deploy, grant new authority, promote/deprecate learned skills, and
+  authorize settlement policy.
+- **Hermes:** the operations lead. Hermes observes, triages, proposes, sequences, explains, and
+  records decisions. Hermes decides what and when within versioned policy; it does not choose
+  unrestricted implementation commands.
+- **Dispatcher:** a narrow non-conversational control component. It validates the exact approved
+  task and policy hashes, maps to `TaskIntent`, submits once, records the run binding, reconciles
+  events, and refuses authority expansion.
+- **Harness:** the technical executor. It decides how to perform the bounded task through its
+  strategy, tools, models, and approved promoted skills. It owns durable execution truth.
+- **Verifier:** an execution-independent judge that evaluates the immutable approved acceptance
+  criteria and produces a signed/hashed acceptance decision and evidence references.
+- **Averray control plane:** owner of identities, authorization, claims, sessions, economic job
+  state, submission eligibility, settlement, and the economic audit trail.
+- **GitHub/CI:** owner of repository mutation truth after a branch or PR exists, including commits,
+  checks, reviews, merge, release, and deploy status.
+- **Ops Board:** a correlated projection of the above systems. It can initiate an operator command
+  through an authoritative API; it never becomes the execution or economic ledger.
+
+For an Averray-backed job, control-plane authorization is mandatory and authoritative; a local
+dispatch policy can only narrow it. For a repository-only Hermes task with no Averray job, the
+authority source is the operator-approved, versioned dispatch policy. Neither Hermes nor the
+Harness can mint either form of permission.
+
+### 3.2 RACI and authority matrix
+
+`A` = accountable/authoritative, `R` = performs, `C` = consulted/input, `I` = informed/projected,
+`—` = no authority.
+
+| Action | Operator | Hermes | Dispatcher | Harness | Verifier | Averray control plane | GitHub/CI |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Observe and triage | A | R | I | I | I | I | I |
+| Propose technical work | A | R | C | — | C | C | C |
+| Classify risk under versioned rules | A | R | R | — | C | C | — |
+| Approve low-risk auto-eligible dispatch | A via policy | R under policy | R/enforce | — | — | — | — |
+| Approve medium-risk dispatch | A | R/propose | R/enforce | — | C | C | — |
+| Approve high-risk or irreversible work | A/R | C | R/enforce | — | C | C | — |
+| Compile and bind `TaskIntent` | I | C | A/R | C/schema | C | C | — |
+| Execute bounded technical work | I | I | C/control | A/R | I | — | — |
+| Change run grants/budget/deadline | A | C/propose | R/enforce | — | C | C | — |
+| Judge acceptance | I | I | C | — | A/R | I | C/evidence |
+| Open an ordinary PR | A via policy | C | R where delegated | — | C/gate | C when economic | A/state |
+| Merge or release | A/R | C | — | — | C | C | A/state |
+| Deploy production | A/R | C | — | — | C | C | A/state |
+| Claim/submit/settle an Averray job | A via policy | C | C/request only | — | C | A/R | C |
+| Promote/deprecate a Harness skill | A/R | C | — | — | C | — | C |
+| Propose a Phase-7 Harness change | A | C | — | R/produce evidence only | R/independent evidence | — | C |
+| Merge a Phase-7 Harness change | A/R | C | — | — | C | — | A/state |
+
+### 3.3 Explicitly forbidden authority
+
+The Harness and its models must never receive:
+
+- wallets, private keys, seed phrases, JWT signing keys, settlement credentials, or economic
+  signing authority;
+- production secrets or unrestricted production access;
+- claim, submission, or settlement authority;
+- policy-authoring or policy-approval authority;
+- unrestricted deployment capability;
+- the ability to impersonate a human approval;
+- final review, merge, or release authority;
+- authority to broaden their own grants, budget, deadline, network access, allowed paths, or child
+  delegation;
+- authority to promote, activate beyond approved grants, silently restore, or merge their own
+  learned skill changes.
+
+Verifier and executor identities must be distinct for the same run. A direct runner cannot approve
+its own proposal, and a Harness execution result cannot mark itself verified.
+
+No single agent may request, execute, finally approve, and financially settle the same action.
+Every protected action records one requester, one executor, one independent verifier where
+technical work is involved, and one authority owner. The operator owns the global HALT; Hermes may
+trigger an anomaly pause only under versioned policy; the dispatcher enforces both; the Harness
+may only suspend/cancel within the resulting bounded control instruction.
+
+## 4. Sources of truth and reconciliation
+
+| Fact | Authoritative source | Board behavior |
+|---|---|---|
+| Proposed work and its current approval | Versioned `AgentTask` store plus append-only approval records | Project exact version/hash and actor; never infer approval from lane placement. |
+| Risk, grants, allowlists, budgets, and autonomy | Versioned policy artifact and operator approval log | Show policy version/hash and the effective decision. |
+| TaskIntent submitted to the Harness | Content-addressed TaskIntent artifact plus dispatch binding | Show ref/hash; no editable prompt after approval. |
+| Run state, attempts, events, and terminal outcome | Harness ledger/DBOS | Project state with source timestamps and stale/degraded markers. |
+| Run artifacts and verification evidence | Harness artifact store and verifier record | Link immutable refs/hashes; never copy mutable summaries as proof. |
+| Averray identity, claim, session, submission, verification, and settlement | Averray control plane | Show economic state and IDs; never derive it from a PR or Harness completion. |
+| Branch, commit, PR, checks, review, merge, release, and deploy | GitHub/CI/release system | Existing GitHub projection remains authoritative. |
+| Board lane, title, “working now,” and digest | Ops Board read model | Explicitly non-authoritative, reproducible from the sources above. |
+| Model/provider/effort and active skill versions | Immutable Harness `RunManifest`/events | Display as metadata and evidence, not executor ownership or policy. |
+
+Every source adapter returns `observedAt`, source `updatedAt`, and
+`healthy|stale|degraded|unavailable`. An unavailable source produces an honest degraded card. It
+must not preserve a green state indefinitely or synthesize completion.
+
+### 4.1 Stable identities
+
+The following identifiers are carried unchanged wherever applicable:
+
+- `correlationId`: one end-to-end trace across proposal, decision, dispatch, run, verification,
+  PR, and economic operations;
+- `workItemId`: stable Hermes work identity across task versions and projection type changes;
+- `harnessRunId`: immutable Harness run/workflow identity;
+- `averrayJobId` and `averraySessionId`: present only when the work is an Averray economic job;
+- GitHub `{repository, pullRequestNumber}` and immutable head SHA when a PR exists;
+- `taskVersion`, `taskHash`, `taskIntentRef`, `taskIntentHash`, `policyVersion`,
+  `policyHash`, `runManifestRef`, and `runManifestHash`.
+
+Idempotency keys are scoped to the action, for example
+`dispatch:{workItemId}:{taskVersion}:{taskHash}` and
+`handoff:{harnessRunId}:{verificationDecisionHash}`. Retries return the existing binding/result;
+they do not create a second run or PR.
+
+## 5. Versioned integration contracts
+
+Contracts live in `@avg/schemas`, use strict validation, preserve unknown-version refusal, and are
+serialized canonically before hashing. JSON examples below are illustrative; the implementation
+packet must publish Zod schemas, inferred TypeScript types, fixtures, and compatibility tests.
+
+Shared integration primitives are also versioned and strict:
+
+```ts
+type Sha256 = `sha256:${string}`;
+type IsoDateTime = string; // Zod datetime with offset
+
+type ActorRef = {
+  type: "operator" | "hermes" | "policy" | "dispatcher" |
+    "harness" | "verifier" | "averray" | "github";
+  id: string;
+};
+
+type ArtifactRef = {
+  uri: string;
+  sha256: Sha256;
+  mediaType?: string;
+  sizeBytes?: number;
+};
+
+type CapabilityGrant = {
+  capabilityId: string;
+  resource: string;
+  constraints: Record<string, string | number | boolean | string[]>;
+  expiresAt?: IsoDateTime;
+};
+
+type AcceptanceCriterion =
+  | { id: string; type: "command"; command: string; workingDirectory?: string; required: boolean }
+  | { id: string; type: "search"; include: string[]; pattern: string;
+      expectedMatches: number; required: boolean }
+  | { id: string; type: "baseline_comparison"; rule: "no_new_failures";
+      baselineCommand?: string; required: boolean }
+  | { id: string; type: "rubric"; rubric: string; threshold: number;
+      judgedDeliverables: string[]; borderlineMargin: number; required: boolean };
+
+type ModelBindingMetadata = {
+  role: string;
+  adapter: string;
+  provider: string;
+  modelRef: string;
+  profileHash: string;
+  judgeIndependence?: string;
+};
+
+type MutationRef = {
+  system: "agent-task" | "agent-harness" | "github" | "averray" | "policy";
+  action: string;
+  target: string;
+  idempotencyKey?: string;
+  resultRef?: ArtifactRef;
+};
+
+type HarnessRunState =
+  | "accepted" | "contract_compiled" | "environment_preparing" | "environment_ready"
+  | "strategy_selected" | "executing" | "verifying" | "repairing" | "replanning"
+  | "approval_required" | "suspended" | "finalizing" | "completed" | "partial"
+  | "failed" | "cancel_requested" | "compensating" | "cancelled" | "quarantined"
+  | "learning_queued" | "learning_processed";
+```
+
+IDs are non-empty, bounded strings in their owning namespace. USD authorization uses integer
+microdollars; the schema must not use binary floating point for authorization. Artifact hashes are
+mandatory for evidence and approval bindings. Free-form `constraints` are display/audit data only;
+the dispatcher maps only policy-recognized capability schemas and refuses unknown keys.
+
+### 5.1 `AgentTask` v1
+
+`AgentTask` is the immutable-after-approval coordination contract. It is not a shell prompt and not
+an authorization by itself.
+
+```ts
+type AgentTaskV1 = {
+  schemaVersion: 1;
+  kind: "agent_task";
+  workItemId: string;
+  taskVersion: number;
+  correlationId: string;
+  taskKind: string;
+  lifecycle: "proposed" | "approved" | "dispatching" | "running" |
+    "verifying" | "handoff_ready" | "blocked" | "failed" | "cancelled";
+  proposal: {
+    title: string;
+    objective: string;
+    whyNow: string;
+    requestedBy: ActorRef;
+    createdAt: string;
+    sourceRefs: ArtifactRef[];
+  };
+  repository: {
+    provider: "github";
+    nameWithOwner: string;
+    baseRevision: string;
+    allowedPaths: string[];
+    forbiddenPaths: string[];
+  };
+  intent: {
+    apiVersion: "harness/v1alpha1";
+    profile: string;
+    templateRef: ArtifactRef;
+    templateHash: string;
+  };
+  acceptance: {
+    criteria: AcceptanceCriterion[];
+    verifierPlanRef: ArtifactRef;
+    verifierPlanHash: string;
+  };
+  risk: {
+    tier: "low" | "medium" | "high";
+    reasons: string[];
+    irreversible: boolean;
+  };
+  requestedAuthority: {
+    grants: CapabilityGrant[];
+    network: "deny" | { allowlist: string[] };
+    maxChildren: number;
+    maxConcurrentChildren: number;
+    delegable: false;
+  };
+  budget: {
+    elapsedSeconds: number;
+    modelTokens: number;
+    toolCalls: number;
+    estimatedUsdMicros: number | null;
+  };
+  deadline: string;
+  executor:
+    | { kind: "harness"; selectionReason: string }
+    | { kind: "direct";
+        directAgent: "codex" | "claude" | "test-writer" | "security" | "docs";
+        selectionReason: string };
+  approval: {
+    required: "policy" | "operator";
+    status: "pending" | "approved" | "denied" | "expired";
+    actor?: ActorRef;
+    decidedAt?: string;
+    policyVersion: string;
+    policyHash: string;
+    approvedTaskHash?: string;
+  };
+  timestamps: {
+    proposedAt: string;
+    approvedAt?: string;
+    dispatchClaimedAt?: string;
+    runBoundAt?: string;
+    terminalAt?: string;
+    updatedAt: string;
+  };
+  bindings?: {
+    harnessRunId?: string;
+    runManifestRef?: ArtifactRef;
+    runManifestHash?: string;
+    averrayJobId?: string;
+    averraySessionId?: string;
+    pullRequest?: { repository: string; number: number; headSha: string };
+  };
+};
+```
+
+Invariants:
+
+- `workItemId` is stable and `taskVersion` increases for material changes.
+- Objective, repository scope, TaskIntent template, acceptance, risk, requested authority, budget,
+  deadline, executor kind, and policy hash are immutable after approval.
+- Any material edit invalidates approval and creates a new version; the old version remains
+  auditable.
+- Approved effective grants are equal to or narrower than requested grants.
+- `delegable` is always `false` in the initial integration.
+- `executor.kind="direct"` is a compatibility mode, not the target design.
+- A Harness binding is written once. A second, conflicting `harnessRunId` is a quarantine event.
+
+### 5.2 `AgentRunProjection` v1
+
+`AgentRunProjection` is a read-only, lossy board projection. It can never be used to resume,
+approve, cancel, release, or settle a run without an authoritative command path.
+
+```ts
+type AgentRunProjectionV1 = {
+  schemaVersion: 1;
+  kind: "agent_run_projection";
+  workItemId: string;
+  correlationId: string;
+  harnessRunId: string;
+  taskVersion: number;
+  source: {
+    system: "agent-harness";
+    health: "healthy" | "stale" | "degraded" | "unavailable";
+    observedAt: string;
+    sourceUpdatedAt?: string;
+    reason?: string;
+  };
+  heartbeat: {
+    status: "active" | "stale" | "terminal" | "unknown";
+    lastEventAt?: string;
+    ageSeconds?: number;
+  };
+  run: {
+    state: HarnessRunState;
+    attempt: number;
+    terminal: boolean;
+    outcome?: "completed" | "partial" | "failed" | "cancelled";
+    reason?: string;
+    lastEventAt?: string;
+  };
+  manifest: {
+    ref?: ArtifactRef;
+    hash: string;
+    profile: string;
+    riskClass: string;
+    effectiveCapabilities: string[];
+    network: "deny" | { allowlist: string[] };
+    policyHash: string;
+    verifierHash: string;
+    modelBindings: ModelBindingMetadata[];
+    skillVersions: string[];
+  };
+  progress: {
+    phase: string;
+    summary: string;
+    completedUnits?: number;
+    totalUnits?: number;
+    blocker?: string;
+  };
+  budget: {
+    elapsedSecondsUsed?: number;
+    modelTokensUsed?: number;
+    toolCallsUsed?: number;
+    estimatedUsdMicrosUsed?: number;
+    exhausted: boolean;
+  };
+  artifacts: ArtifactRef[];
+  verification?: {
+    status: "pending" | "passed" | "failed" | "inconclusive";
+    decisionRef?: ArtifactRef;
+    decisionHash?: string;
+  };
+  bindings?: AgentTaskV1["bindings"];
+};
+```
+
+The summary is deterministic structured rendering from Harness state/events. It is not free-form
+model narration. Raw prompts, secrets, credentials, unredacted logs, and model chain-of-thought
+must never enter the projection.
+
+### 5.3 `VerifiedHandoff` v1
+
+`VerifiedHandoff` is the only Harness-to-review handoff eligible to advance toward PR/release.
+
+```ts
+type VerifiedHandoffV1 = {
+  schemaVersion: 1;
+  kind: "verified_handoff";
+  workItemId: string;
+  correlationId: string;
+  harnessRunId: string;
+  taskVersion: number;
+  taskHash: string;
+  taskIntentRef: ArtifactRef;
+  taskIntentHash: string;
+  runManifestRef: ArtifactRef;
+  runManifestHash: string;
+  outcome: "completed" | "partial" | "failed";
+  deliverables: {
+    patchRef?: ArtifactRef;
+    commitSha?: string;
+    summaryRef: ArtifactRef;
+    structuredSubmissionRef: ArtifactRef;
+    artifacts: ArtifactRef[];
+  };
+  checks: Array<{
+    name: string;
+    commandHash?: string;
+    status: "passed" | "failed" | "skipped";
+    evidenceRef: ArtifactRef;
+  }>;
+  verification: {
+    verified: boolean;
+    decision: "accept" | "reject" | "inconclusive";
+    verifier: ActorRef;
+    planHash: string;
+    decisionRef: ArtifactRef;
+    decisionHash: string;
+    evidenceRefs: ArtifactRef[];
+    verifiedAt: string;
+  };
+  openQuestions: string[];
+  eligibleForPrOpen: boolean;
+  pullRequest?: { repository: string; number: number; headSha: string };
+  generatedAt: string;
+};
+```
+
+`eligibleForPrOpen` can be true only when outcome is `completed`, verification is `accept`, every
+required check passed, refs/hashes match the approved task and run manifest, and policy permits the
+PR-open action. A handoff never grants merge or deployment authority.
+
+### 5.4 `HermesDecisionRecord` v2
+
+The current v1 decision record remains readable. V2 adds explicit fields required for an
+explainable cross-system decision instead of hiding them in generic input/outcome maps.
+
+```ts
+type HermesDecisionRecordV2 = {
+  schemaVersion: 2;
+  kind: "hermes_decision";
+  decisionId: string;
+  correlationId: string;
+  workItemId?: string;
+  decisionType:
+    | "task_proposal"
+    | "risk_classification"
+    | "executor_selection"
+    | "dispatch_approval"
+    | "dispatch_refusal"
+    | "anomaly_pause"
+    | "handoff"
+    | "escalation"
+    | "away_digest";
+  proposal: {
+    what: string;
+    why: string[];
+    whyNow?: string;
+    evidenceRefs: ArtifactRef[];
+  };
+  inputs: Array<{
+    name: string;
+    ref?: ArtifactRef;
+    hash?: string;
+    observedAt?: string;
+  }>;
+  routing?: {
+    executor: "harness" | "direct";
+    modelProvider?: string;
+    modelRef?: string;
+    reason: string;
+    scorecardRef?: ArtifactRef;
+  };
+  risk: {
+    tier: "low" | "medium" | "high";
+    reasons: string[];
+    irreversible: boolean;
+  };
+  approval: {
+    required: "policy" | "operator";
+    decision: "pending" | "approved" | "denied" | "expired" | "not_applicable";
+    actor?: ActorRef;
+    policyVersion: string;
+    policyHash: string;
+    decidedAt?: string;
+  };
+  effects: {
+    mutates: boolean;
+    mutations: MutationRef[];
+    authorityChanged: boolean;
+    budgetChanged: boolean;
+  };
+  next: {
+    action: string;
+    owner: "operator" | "hermes" | "dispatcher" | "harness" | "verifier" | "averray";
+    dueAt?: string;
+    blockedBy?: string[];
+  };
+  generatedAt: string;
+};
+```
+
+Compatibility rules:
+
+- V1 records are decoded by a V1 schema and mapped to an in-memory compatibility view.
+- Existing V1 files are not rewritten.
+- New Harness-related decisions are written only as V2 after INT-0.
+- Unknown versions fail visibly and are projected as a source/contract error.
+
+## 6. One-board lifecycle
+
+The board keeps one correlated work item. It must not show separate task, run, and PR cards for the
+same `workItemId`; the projection enriches or changes the card presentation as authoritative
+bindings appear.
+
+| Authoritative state | Board presentation | Operator action |
+|---|---|---|
+| `AgentTask.proposed` | `codex-needed` / **WORK QUEUE**, proposal and risk visible | Approve, edit as a new version, or deny |
+| Approved, no run binding | **WORK QUEUE**, “dispatch pending” | Wait or cancel through authoritative task API |
+| Dispatcher validation refused | Needs attention, exact policy/hash refusal | Revise as a new task version or cancel |
+| Harness `accepted|compiled|environment_ready|strategy_selected|executing|repairing|replanning` | **WORK QUEUE**, live structured progress and last-event time | Observe; cancel only through control API |
+| Harness `approval_required|suspended` | Needs attention/decision inbox | Required actor approves or denies through control API |
+| Harness `verifying|finalizing` | Verification/checking presentation | Observe verifier evidence |
+| Harness `partial|failed|cancelled|quarantined` or verification reject | Needs attention, failure and retry eligibility | Review; retry creates a new attempt/run under policy |
+| Verified handoff, no PR yet | **WORK QUEUE**, “verified handoff ready” | Open PR if policy/operator permits |
+| PR open | Existing GitHub/CI lanes, same `workItemId` | Review checks and evidence |
+| CI/review failed | Existing needs-attention lane | Fix via a new bounded task/attempt |
+| CI green, release pending | Existing operator-review/release presentation | Human merge/release |
+| Merged/deployed | Done/recently shipped | Observe; reconcile economic state separately |
+
+An Averray job may be technically complete while economic submission or settlement is pending.
+The card must show both axes rather than collapse them into a single “done” boolean:
+
+- `technicalState`: Harness/verifier/GitHub;
+- `economicState`: Averray control plane;
+- `releaseState`: operator/GitHub/deploy system.
+
+### 6.1 Board naming and agent presentation
+
+- Preserve internal lane ID `codex-needed` in routes, filters, snapshots, saved layout, API shapes,
+  and migration tests.
+- Change every visible lane/KPI title to **WORK QUEUE** (sentence case is acceptable only where the
+  UI style transforms labels).
+- Add `harness` as an execution source/agent tag, not as a new lane.
+- Display provider/model/effort beneath a Harness run as metadata.
+- Keep Hermes as the sole natural-language voice. Harness progress uses fixed labels such as
+  “executing · attempt 2 · last event 28s ago,” not an invented agent chat message.
+
+## 7. Dedicated dispatch path
+
+The dispatcher accepts typed IDs and artifacts, never an unrestricted shell string:
+
+1. Hermes creates an `AgentTask` proposal and a V2 decision record explaining what, why, why now,
+   risk, requested authority, budget, executor, and next owner.
+2. Contract validation canonicalizes and hashes the task.
+3. Versioned risk, allowlist, budget, concurrency, repository, path, network, autonomy, and HALT
+   checks run fail-closed.
+4. The required approval actor approves that exact task version and hash.
+5. The dispatcher atomically claims the task using the dispatch idempotency key.
+6. It maps the approved fields into a generic `TaskIntent` and proves the mapped authority is a
+   subset of the approved authority.
+7. It persists the content-addressed TaskIntent ref/hash and submits it through the generic
+   Harness control interface.
+8. It records the returned `harnessRunId` and manifest binding exactly once using an outbox.
+9. The Harness performs durable execution. Structured events and artifacts are projected
+   read-only to the board.
+10. An independent verifier evaluates the original acceptance plan and creates a
+    `VerifiedHandoff`.
+11. A policy-gated PR opener or the operator creates the PR using the verified handoff. The
+    executor cannot open an unverified PR or merge it.
+12. GitHub/CI, the operator, and—when applicable—the Averray control plane continue their
+    authoritative review, release, submission, and settlement flows.
+
+Any hash mismatch, unknown contract version, policy version change after approval, expanded grant,
+expired deadline, exhausted budget, stale approval, duplicate conflicting binding, unavailable
+authoritative source, or global HALT causes refusal or suspension. None is converted into a
+best-effort prompt.
+
+## 8. Risk and autonomy policy
+
+Risk is three-tiered in the integration contract even though the legacy queue currently exposes
+only high/low.
+
+| Tier | Examples | Initial dispatch rule | PR/release rule |
+|---|---|---|---|
+| Low | Documentation, tests, static analysis, non-sensitive internal tooling, small isolated UI work, narrow deterministic source edits, and strictly verified dependency maintenance with no lifecycle scripts or security/infra/auth/economic change; deny-all network and reversible branch-only output | Supervised in INT-2; eligible for policy approval only after burn-in in INT-5 | Verified PR may be opened under policy; human still merges/releases |
+| Medium | Backend behavior, API/schema changes, CI workflows, larger dependency/config updates, data-processing logic, bounded network allowlists, and material cost | Explicit operator approval; max concurrency 1; tighter budget and deadline | Operator PR-open/review; human merge/release |
+| High | Contracts/chain behavior, wallets/signing/settlement/claims, authentication/authorization, secrets, database migrations, production infrastructure, deployment systems, policy/permission changes, Harness self-evolution, or any irreversible action | Never auto-dispatch; many categories are categorically forbidden to Harness, otherwise require explicit operator plan and separate capabilities | Human-only review, merge, deployment, and economic authorization |
+
+Initial invariants:
+
+- `HARNESS_DISPATCH_ENABLED=false` until INT-2 acceptance.
+- Global and repository HALT override all autonomy and retry paths.
+- Harness concurrency is one; child delegation is disabled.
+- Network is deny by default. An allowlist is explicit, task-scoped, expiring, and approved.
+- Budgets apply before submission and during execution. Exhaustion suspends/fails closed.
+- Retry never expands scope, grants, budget, deadline, or risk tier. Material changes require a new
+  task version and approval.
+- Away mode does not broaden authority. It may only exercise actions already allowed by the active
+  policy version.
+- Learned routing and model scores can recommend within the allowlist; hard policy, risk, budget,
+  approval, and HALT rules always win.
+
+### 8.1 Autonomy levels
+
+| Level | Meaning | Allowed behavior |
+|---|---|---|
+| A0 — observe | INT-1 default | Read and project known Harness runs; no mutation. |
+| A1 — supervised | INT-2 through burn-in | Hermes proposes; an operator approves every dispatch; dispatcher executes the exact approved task. |
+| A2 — policy-bounded away | INT-5 only | Hermes may approve and dispatch explicitly allowlisted low-risk work inside start/expiry, task, concurrency, token, and spend limits. |
+| A3 — measured routing | INT-6 only | Routing may change inside A2 authority from versioned measured evidence; no new action or grant becomes autonomous. |
+
+There is no unrestricted autonomy level. Medium/high risk, new authority, skill
+promotion/deprecation, merge, deployment, economic settlement, and Harness self-evolution always
+retain their explicit human or control-plane gates.
+
+## 9. Migration and compatibility
+
+The migration is additive and reversible:
+
+1. Add the four versioned contracts and compatibility decoders.
+2. Add read-only Harness projection behind `HARNESS_PROJECTION_ENABLED=false`.
+3. Rename only visible `codex-needed` copy to **WORK QUEUE**; keep identifiers and API paths stable.
+4. Project two manually created real Harness pilot runs—one successful, one failed—through known
+   bindings. Do not add dispatch.
+5. Add the supervised dispatcher as an alternate executor behind a separate flag. Keep direct
+   runners enabled as fallback.
+6. For newly approved eligible work, select `executor.kind="harness"`; retain
+   `executor.kind="direct"` for explicit fallback and unsupported profiles.
+7. Migrate queue storage through dual-read/single-write:
+   - read legacy `codex_task` V1 and map it to the compatibility view;
+   - write new proposals as `agent_task` V1 after INT-2;
+   - do not rewrite historical records;
+   - preserve current `POST /monitor/codex-tasks` as a compatibility route until clients move to
+     an `agent-tasks` endpoint;
+   - preserve existing dedupe behavior for legacy items, but use `workItemId` plus task hash for
+     new idempotency.
+8. Remove direct runners only after the burn-in criteria below are met and a separate removal
+   packet is approved.
+
+Fallback is a deliberate executor selection with a V2 decision record. The dispatcher must not
+silently fall back after a Harness failure because that could run the same task twice.
+
+### 9.1 Burn-in exit before direct-runner retirement
+
+- at least 20 eligible low-risk Harness work items across at least three task families;
+- at least 14 consecutive days without an uncontained authority or duplicate-dispatch incident;
+- 100% correlation from task through run and handoff, and through PR when present;
+- zero unverified PR openings;
+- successful completion of all INT-4 failure drills;
+- measured completion, verification, cost, and latency no worse than the approved thresholds;
+- explicit operator decision to retire each fallback independently.
+
+## 10. Integration packets
+
+Each packet is a narrow PR with its own handback, clean diff, smallest relevant tests, source
+impact statement, rollback, and any environment changes. INT packet numbers are local to this
+integration and do not redefine Hermes O/A/B/C/D/T streams or Harness Phase numbers.
+
+### INT-0 — charter and versioned contracts
+
+**Goal:** land this charter and the four strict schemas without runtime behavior.
+
+**Deliverables:**
+
+- `AgentTask` V1, `AgentRunProjection` V1, `VerifiedHandoff` V1, and
+  `HermesDecisionRecord` V2 in `@avg/schemas`;
+- canonical serialization/hashing helpers and fixtures;
+- V1 decision-record and legacy `codex_task` compatibility readers;
+- source-of-truth, identity, RACI, and risk invariants pinned in tests/docs;
+- no new dispatch route and no policy allowlist expansion.
+
+**Gate:** schema tests prove round trip, unknown-version refusal, approval invalidation on material
+change, grant attenuation, verified-handoff eligibility, and V1 read compatibility. Every
+protected action has an unambiguous requester, executor, verifier, and authority owner; no role can
+both execute and finally approve the same work.
+
+### INT-1 — read-only Harness projection
+
+**Goal:** display real successful and failed Harness runs in the existing board without enabling
+task submission or any Harness mutation.
+
+**Deliverables:**
+
+- a narrow read port that permits only known-run `status`, `events`, and `deliverables` reads;
+- an allowlisted pilot binding registry containing no secrets;
+- pure mapping into `AgentRunProjection`;
+- honest source health, staleness, terminal failure, verification, artifacts, and correlation;
+- one correlated card per work item;
+- visible **WORK QUEUE** title while preserving `codex-needed`;
+- Harness tag and structured progress, with Hermes still the only conversational voice.
+
+**Feature flag:** `HARNESS_PROJECTION_ENABLED=false` by default. The flag controls only reads and
+rendering. No `HARNESS_DISPATCH_ENABLED` code path exists in this packet.
+
+**Acceptance proof:**
+
+- one real successful and one real failed Harness run are projected by immutable run ID, with a
+  quarantined-state fixture in the mapper tests;
+- killing or denying the read source changes the card to stale/degraded, never healthy;
+- no test or source in the packet calls `run submit`, `approve`, `deny`, `cancel`, `release`, skill
+  mutation, wallet, GitHub write, or Averray mutation commands;
+- the same run event sequence always yields the same projection;
+- unknown state/version fails visibly;
+- legacy task/PR cards and saved lane identifiers remain compatible.
+
+**Exact proposed files:**
+
+| File | Change |
+|---|---|
+| `services/slack-operator/src/harness-run-registry.ts` | New strict loader for allowlisted pilot `{workItemId, correlationId, harnessRunId}` bindings and staleness settings. |
+| `services/slack-operator/src/harness-read-port.ts` | New interface plus safe read-only CLI adapter; fixed argv, timeout, output limits, redaction, and no shell interpolation. |
+| `services/slack-operator/src/harness-run-projection.ts` | New pure state/event/manifest-to-`AgentRunProjection` mapper and source-health calculation. |
+| `services/slack-operator/src/monitor-v2.ts` | Merge correlated Harness projections into the existing board snapshot without duplicate cards. |
+| `services/slack-operator/src/monitor-hermes-board.ts` | Add structured execution facts to the slim board input. |
+| `services/slack-operator/src/monitor-hermes-narration.ts` | Replace Codex-owned lane language with work-queue language and fixed Harness progress phrasing. |
+| `services/slack-operator/src/monitor-hermes-voice.ts` | Carry the bounded projection fields while preserving one Hermes voice. |
+| `services/slack-operator/src/index.ts` | Load the read-only source behind the projection flag and pass results into board construction. |
+| `packages/monitor-ui/src/lib/monitor/card-types.ts` | Add `harness` agent/source and the V1 projection fields to the UI boundary. |
+| `packages/monitor-ui/src/lib/monitor/board-columns.ts` | Change visible title/subtitle to **WORK QUEUE**; preserve ID. |
+| `packages/monitor-ui/src/components/Board.tsx` | Change the legacy visible lane label only. |
+| `packages/monitor-ui/src/components/TopStrip.tsx` | Change visible KPI label only. |
+| `packages/monitor-ui/src/components/ui.tsx` | Add a Harness tag tone/label. |
+| `packages/monitor-ui/src/components/cards/Card.tsx` | Render structured run state, attempt, source age, and verification badge. |
+| `packages/monitor-ui/src/components/drawer/DrawerBody.tsx` | Render manifest/grants/model/skill/artifact/failure details without raw secret-bearing logs. |
+| `packages/monitor-ui/src/components/hermes/CoPilotRail.tsx` | Replace visible Codex queue copy where it describes the shared lane; no create/dispatch changes. |
+| `packages/monitor-ui/src/styles/monitor.css` | Add only the presentation styles required for the new metadata/health states. |
+| `test/unit/harness-run-registry.test.ts` | Binding validation, duplicates, unknown version, and no-secret fixtures. |
+| `test/unit/harness-read-port.test.ts` | Fixed read-only argv, timeout/output/redaction, malformed output, and forbidden-command pins. |
+| `test/unit/harness-run-projection.test.ts` | State mapping, correlation, determinism, staleness, failed/quarantined runs, and unknown-state refusal. |
+| `test/unit/monitor-v2.test.ts` | Correlated merge/no-duplicate and source-failure coverage. |
+| `test/unit/monitor-hermes-board.test.ts` | Slim board projection coverage. |
+| `test/unit/monitor-hermes-narration.test.ts` | One-voice and work-queue copy coverage. |
+| `packages/monitor-ui/src/lib/monitor/board-columns.test.ts` | Visible-title/internal-ID compatibility pin. |
+| `packages/monitor-ui/src/components/Board.test.tsx` | Legacy board title compatibility. |
+| `packages/monitor-ui/src/components/TopStrip.test.tsx` | KPI copy coverage. |
+| `packages/monitor-ui/src/components/cards/Card.test.tsx` | Successful, running, stale, failed, and verified rendering. |
+| `packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx` | Harness detail and redaction coverage. |
+
+If INT-0 lands separately, INT-1 imports `AgentRunProjection` from `@avg/schemas`. It must not
+create a second UI-only authoritative schema; current duplicated monitor/UI types should be
+adapted at the HTTP boundary and retired in a later cleanup packet.
+
+### INT-2 — supervised dispatch
+
+**Goal:** submit approved low/medium-risk tasks through a dedicated dispatcher with concurrency
+one.
+
+**Dependencies:**
+
+- PKT-033 implementation and handback merged to Harness `origin/main`;
+- clean offline and PostgreSQL Harness gates from the landed commit;
+- pinned compatible Harness contract/CLI version;
+- INT-0/INT-1 accepted, including outage behavior;
+- operator-approved policy version, repositories, profiles, capabilities, budgets, and pilot
+  users;
+- global HALT and rollback tested.
+
+**Deliverables:** dispatch claim/idempotency, approved-task-to-TaskIntent mapping, attenuation
+proof, outbox-backed run binding, supervised operator decision, cancellation/timeout control,
+direct-runner explicit fallback, and audit records. Start with low-risk tasks; medium risk requires
+an operator approval. High risk remains forbidden or human-only.
+
+**Gate:** concurrent/replayed dispatch creates exactly one Harness run; approval/hash/policy/grant
+mismatches refuse; HALT wins; no wallet/settlement/deploy/GitHub-merge capability is present.
+Several representative low-risk tasks complete through the supervised path; failed verification
+produces no submission; restart and duplicate delivery remain idempotent.
+
+### INT-3 — verified PR handoff
+
+**Goal:** connect the independent Harness verifier to the existing C1/C2 review and GitHub/CI flow.
+
+**Deliverables:** verified-handoff store/validation, PR-open eligibility check, evidence links,
+head-SHA binding, existing reviewer-panel integration, and reconciliation after GitHub changes.
+
+**Gate:** false/inconclusive/mismatched/stale verification cannot open a PR; a valid handoff can
+open at most one PR; executor cannot review, merge, or deploy; human release remains explicit.
+
+### INT-4 — hardening and failure drills
+
+**Goal:** extend O5 and D3/D4 to the Harness/DBOS boundary.
+
+**Deliverables:** source-age alerts, reconciliation worker, poison-event quarantine, orphan
+detectors, duplicate-binding detector, durable leases, bounded retry eligibility, queue
+backpressure, an external watchdog, alerts that do not depend on Hermes availability, operator
+runbook, dashboards, and all drills in section 11.
+
+**Gate:** every drill has deterministic detection, containment, recovery, audit evidence, and an
+owner; no recovery silently expands authority or duplicates execution.
+
+### INT-5 — away mode after burn-in
+
+**Goal:** allow the existing away mode to approve only proven low-risk Harness tasks.
+
+**Dependencies:** INT-4 accepted, minimum burn-in evidence achieved, operator-approved policy
+version, and alert bridge verified.
+
+**Deliverables:** explicit start and expiry, low-risk repo/task-family allowlists, maximum
+spend/tokens/tasks/concurrency, concurrency one initially, per-repo/daily budgets, quiet-hour rules,
+immediate anomaly pause, high-risk escalation, one-command HALT, verified-result-only draft PR
+creation, bounded idempotent retries, and away digest. Medium/high risk and policy changes remain
+operator-only.
+
+**Gate:** policy-denied, stale, anomalous, or budget-exhausted tasks remain proposed; returning
+operator receives a complete decision/run/handoff digest. Across 10–20 or more representative
+supervised tasks there are zero unauthorized actions, zero duplicate submissions, every high-risk
+task is escalated, and all recovery drills are green.
+
+### INT-6 — measured routing
+
+**Goal:** use A1–A3 evidence to choose eligible profile, model/provider/effort, and direct fallback
+within hard policy.
+
+**Deliverables:** scorecard inputs, cost/latency/success/safety thresholds, shadow recommendation,
+bounded rollout, conservative defaults for unknown task families, and decision-record
+explanations. The executor is still the Harness; model and provider are run metadata.
+
+**Gate:** a recommendation cannot bypass risk, grants, approval, HALT, budget, verifier
+independence, or an operator override. Shadow results must show an approved improvement before
+activation.
+
+### INT-7 — Phase-7 evolution
+
+**Goal:** allow evidence-backed `harness_evolution` cards to propose improvements to the generic
+Harness only after the Harness publishes detailed Phase-7 packets.
+
+**Required proposal contents:** failure evidence, causal mechanism, affected profiles, eval suite,
+baseline/experiment, one changed variable, cost/latency/safety results, rollout, rollback, and
+human reviewers.
+
+**Gate:** no self-modifying runtime path, no self-merge, no hygiene exception, no product-specific
+kernel code, no permission expansion, and explicit operator approval. A plan paragraph in the
+architecture is not a sufficient packet.
+
+## 11. Failure drills
+
+INT-4 must run these against disposable or isolated environments and record detection time,
+containment, recovery, data reconciliation, and authority checks.
+
+| Drill | Injected failure | Required outcome |
+|---|---|---|
+| Dispatcher crash before submit | Claim persisted, no Harness call | Lease expires/reconciles; retry submits once using same idempotency key. |
+| Dispatcher crash after submit before binding write | Harness has run, task appears dispatching | Reconcile by correlation/idempotency; bind existing run, never submit a second. |
+| Duplicate webhook/event | Same event delivered repeatedly/out of order | Projection is idempotent and monotonic by event identity/attempt; no duplicate card/action. |
+| Harness/DBOS unavailable | Status reads and controls fail | Card becomes degraded/stale; dispatch pauses; existing green state is not extended. |
+| Harness worker killed mid-run | Worker stops after a durable step | DBOS state remains recoverable; external watchdog alerts; restart resumes/reconciles without a duplicate protected effect. |
+| Board unavailable | UI/read model down | Harness execution continues durably; recovery replays projections without control mutations. |
+| Policy changes after approval | Active policy hash differs | Pre-submit refusal; already-running manifest remains immutable and is flagged for operator review. |
+| Approval/task hash mismatch | Edited task reuses old approval | Refuse and require a new task version/approval. |
+| Capability expansion | Mapper or skill requests more authority | Fail closed before execution; immutable refusal evidence. |
+| Budget/deadline exhaustion | Run exceeds approved boundary | Harness suspends/fails according to policy; no automatic budget/deadline increase. |
+| Global HALT during run | Operator sets HALT | New dispatch stops; in-scope runs receive bounded cancel/suspend; audit records result. |
+| Verifier outage | Execution completes, judge unavailable | Technical output remains unverified; no PR-open eligibility. |
+| Verification timeout | Verifier exceeds the approved deadline | Handoff remains ineligible, timeout is visible, and bounded retry/escalation follows policy. |
+| Verifier rejects output | Completed run fails acceptance | Needs attention; executor cannot override or relabel acceptance. |
+| Malicious/oversized event | Secret-like or huge payload | Adapter redacts/truncates/quarantines; board remains available and source shows degraded. |
+| Conflicting run binding | Same task version points at two run IDs | Quarantine work item, stop downstream actions, require operator reconciliation. |
+| PR head changes after handoff | PR SHA differs from verified SHA | Verification becomes stale; block release until re-verification. |
+| PR API failure | Verified handoff cannot open or read a PR | Retain the handoff and idempotency key, show the outage, and retry without opening duplicate PRs. |
+| Averray control-plane outage | Economic state unavailable | Keep technical state but show economic state unknown; do not claim, submit, or settle. |
+| Settlement replay | Same eligible handoff submitted twice | Averray idempotency returns existing result; no duplicate economic mutation. |
+| Direct fallback after Harness failure | Operator selects fallback | Require explicit new decision/idempotency scope; prove the old run is terminal/cancelled first. |
+| Hermes unavailable | Conversational coordinator stops | Dispatcher admits no unapproved work, external alerts remain active, durable runs follow policy, and the board exposes coordinator unavailability. |
+
+## 12. Observability and audit requirements
+
+Minimum structured dimensions:
+
+- all stable IDs from section 4.1;
+- task, TaskIntent, manifest, policy, verifier plan, and decision hashes;
+- task risk, effective capabilities, network mode, budget remaining, and deadline;
+- dispatch decision/refusal reason and idempotency result;
+- Harness state, attempt, last event time, source age, outcome, model/provider/effort, and skill
+  versions;
+- verification status and evidence refs;
+- PR number/head SHA/check/review/release state;
+- Averray job/session/submission/settlement IDs and states, with no credentials;
+- actor type and identity for every approval or mutation;
+- redaction/truncation/quarantine counters;
+- projection lag and reconciliation lag.
+
+Logs and board payloads must not contain TaskIntent secrets, environment values, private prompts,
+raw credentials, wallet material, or chain-of-thought. Artifact access follows the owning system's
+authorization and retention policy.
+
+## 13. Decisions and rationale
+
+1. **One board, one voice.** Multiple executor lanes or model personas would make implementation
+   choices appear to be operational authorities. Structured projection keeps Hermes accountable
+   for coordination while preserving execution evidence.
+2. **Keep `codex-needed`, rename its presentation.** The ID is embedded in routing, snapshots,
+   filters, tests, and saved state. A visible rename achieves the operating model without a risky
+   storage/API migration.
+3. **Use a dedicated dispatcher.** Replaying an unrestricted shell prompt cannot prove approval,
+   idempotency, attenuation, or the exact submitted artifact. Typed mapping can.
+4. **Treat the board as a projection.** Execution, economic, and repository systems already have
+   stronger ledgers. Duplicating authority in a UI creates split-brain failure modes.
+5. **Bind approval to content hashes.** Approval of an editable prompt is ambiguous. Exact hashes
+   make material change, replay, and audit behavior deterministic.
+6. **Model three risk tiers.** Medium-risk work needs more nuance than the legacy high/low flag
+   while preserving a clear hard boundary for high/irreversible work.
+7. **Keep direct runners during burn-in.** They are proven operational paths and provide rollback.
+   Silent fallback is forbidden because it can duplicate work.
+8. **Use known run bindings for INT-1.** The current generic CLI inspects a run by ID but has no
+   list API. Pilot bindings prove projection without DBOS table coupling or kernel changes; INT-2
+   creates future bindings durably.
+9. **Do not merge the platform worker with Hermes.** It is an Averray job adapter with an explicit
+   money-rail seam. Reusing its black-box principles is correct; moving economic authority into
+   Hermes or Harness is not.
+10. **Gate INT-2 on landed PKT-033.** A remote implementation branch with a clean-gate handback is
+    useful reported evidence but not an upstream dependency. `origin/main` and clean gates from
+    the landed commit are the integration pin.
+11. **Separate deterministic machinery from empirical claims.** Harness Phase-6 tooling is
+    implemented, but the checked upstream exit record still marks the real-model ceremony pending.
+12. **Wait for detailed Phase-7 packets.** Architecture direction alone is insufficient authority
+    for self-evolution. Every change remains an ordinary reviewed PR with human merge.
+
+## 14. Open questions
+
+No open question blocks INT-0 or the read-only INT-1 packet. The following must be resolved and
+recorded before the named later gate:
+
+1. **INT-2:** Which Harness CLI/API release and exact JSON projection schema will be pinned after
+   PKT-033 lands? Prefer a published generic interface; do not couple to private DBOS tables.
+2. **INT-2:** Which repositories, task profiles, capabilities, path scopes, time/token/tool/USD
+   budgets, and operator identities form the first supervised allowlist?
+3. **INT-2:** Should the initial dispatcher run inside `slack-operator` or as a separate service
+   process sharing only the AgentTask store? Recommendation: separate process for failure and
+   credential isolation, while keeping the contract/board adapters shared.
+4. **INT-3:** Which service owns authenticated PR opening for non-economic Hermes tasks?
+   Recommendation: a narrow GitHub write service after verified handoff, not the Harness.
+5. **INT-3:** What verifier identity/provider separation is sufficient when executor and judge may
+   use the same model vendor? At minimum use distinct invocation, context, credentials, and
+   immutable verifier-plan hash; prefer a different model/provider for medium risk.
+6. **INT-4:** What source-age and reconciliation-lag thresholds match production SLOs?
+7. **INT-5:** What numeric burn-in thresholds supplement the minimums in section 9.1, and who can
+   pause/re-enable away-mode Harness dispatch?
+8. **INT-6:** Which scorecard window and minimum sample size are required before routing moves
+   beyond shadow mode?
+9. **INT-7:** What Phase-7 packet series will the generic Harness publish, and how will its
+   empirical Phase-6 ceremony be independently reviewed?
+
+## 15. First implementation handoff
+
+The next authorized implementation should be **INT-0 only**. It should add schemas, fixtures, and
+compatibility tests without changing the board, queue, runners, dispatcher, policies, or
+production environment. After INT-0 review, INT-1 should be a separate read-only PR using the
+exact file surface and acceptance proof in section 10.
+
+Do not combine INT-0 and INT-1 with PKT-033, platform worker changes, supervised dispatch,
+VerifiedHandoff-to-PR writes, away mode, learned routing, or Phase-7 work.

--- a/packages/schemas/src/agent-contract-hash.ts
+++ b/packages/schemas/src/agent-contract-hash.ts
@@ -1,0 +1,96 @@
+import { agentTaskV1Schema, type AgentTaskV1 } from "./agent-task.js";
+
+export type CanonicalContractValue =
+  | null
+  | boolean
+  | number
+  | string
+  | CanonicalContractValue[]
+  | { [key: string]: CanonicalContractValue };
+
+export function canonicalContractJson(value: unknown): string {
+  return JSON.stringify(toCanonicalValue(value, new Set<object>()));
+}
+
+export async function hashCanonicalContract(value: unknown): Promise<`sha256:${string}`> {
+  const serialized = canonicalContractJson(value);
+  const bytes = new TextEncoder().encode(serialized);
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
+  const hex = Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `sha256:${hex}`;
+}
+
+export function agentTaskApprovalPayload(taskInput: AgentTaskV1): CanonicalContractValue {
+  const task = agentTaskV1Schema.parse(taskInput);
+  return toCanonicalValue({
+    schemaVersion: task.schemaVersion,
+    kind: task.kind,
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    correlationId: task.correlationId,
+    taskKind: task.taskKind,
+    proposal: task.proposal,
+    repository: task.repository,
+    intent: task.intent,
+    acceptance: task.acceptance,
+    risk: task.risk,
+    requestedAuthority: task.requestedAuthority,
+    budget: task.budget,
+    deadline: task.deadline,
+    executor: task.executor,
+    policyVersion: task.approval.policyVersion,
+    policyHash: task.approval.policyHash,
+  }, new Set<object>());
+}
+
+export async function hashAgentTaskApprovalPayload(
+  task: AgentTaskV1,
+): Promise<`sha256:${string}`> {
+  return hashCanonicalContract(agentTaskApprovalPayload(task));
+}
+
+export async function agentTaskApprovalHashMatches(task: AgentTaskV1): Promise<boolean> {
+  if (task.approval.status !== "approved" || !task.approval.approvedTaskHash) return false;
+  return task.approval.approvedTaskHash === await hashAgentTaskApprovalPayload(task);
+}
+
+function toCanonicalValue(value: unknown, seen: Set<object>): CanonicalContractValue {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new TypeError("canonical contracts reject non-finite numbers");
+    return value;
+  }
+  if (Array.isArray(value)) {
+    if (seen.has(value)) throw new TypeError("canonical contracts reject cyclic values");
+    seen.add(value);
+    const result = value.map((item) => toCanonicalValue(item, seen));
+    seen.delete(value);
+    return result;
+  }
+  if (typeof value === "object") {
+    if (seen.has(value)) throw new TypeError("canonical contracts reject cyclic values");
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("canonical contracts accept only plain objects");
+    }
+    seen.add(value);
+    const record = value as Record<string, unknown>;
+    const result: Record<string, CanonicalContractValue> = {};
+    for (const key of Object.keys(record).sort(compareCodeUnits)) {
+      const field = record[key];
+      if (field === undefined) {
+        throw new TypeError(`canonical contracts reject undefined field: ${key}`);
+      }
+      result[key] = toCanonicalValue(field, seen);
+    }
+    seen.delete(value);
+    return result;
+  }
+  throw new TypeError(`canonical contracts reject ${typeof value} values`);
+}
+
+function compareCodeUnits(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/packages/schemas/src/agent-integration-common.ts
+++ b/packages/schemas/src/agent-integration-common.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+
+export const integrationIdSchema = z.string().trim().min(1).max(240);
+export const integrationTextSchema = z.string().trim().min(1).max(8_000);
+export const integrationTimestampSchema = z.string().datetime({ offset: true });
+export const sha256Schema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+export const nonNegativeSafeIntegerSchema = z.number().int().nonnegative().safe();
+export const positiveSafeIntegerSchema = z.number().int().positive().safe();
+
+export const actorRefSchema = z.object({
+  type: z.enum([
+    "operator",
+    "hermes",
+    "policy",
+    "dispatcher",
+    "harness",
+    "verifier",
+    "averray",
+    "github",
+  ]),
+  id: integrationIdSchema,
+}).strict();
+
+export const artifactRefSchema = z.object({
+  uri: z.string().trim().min(1).max(2_048),
+  sha256: sha256Schema,
+  mediaType: z.string().trim().min(1).max(240).optional(),
+  sizeBytes: nonNegativeSafeIntegerSchema.optional(),
+}).strict();
+
+const capabilityConstraintValueSchema = z.union([
+  z.string().max(2_000),
+  z.number().finite(),
+  z.boolean(),
+  z.array(z.string().max(2_000)).max(200),
+]);
+
+export const capabilityGrantSchema = z.object({
+  capabilityId: integrationIdSchema,
+  resource: integrationTextSchema,
+  constraints: z.record(capabilityConstraintValueSchema),
+  expiresAt: integrationTimestampSchema.optional(),
+}).strict();
+
+const commandAcceptanceCriterionSchema = z.object({
+  id: integrationIdSchema,
+  type: z.literal("command"),
+  command: integrationTextSchema,
+  workingDirectory: z.string().trim().min(1).max(2_048).optional(),
+  required: z.boolean(),
+}).strict();
+
+const searchAcceptanceCriterionSchema = z.object({
+  id: integrationIdSchema,
+  type: z.literal("search"),
+  include: uniqueNonEmptyStrings(200),
+  pattern: integrationTextSchema,
+  expectedMatches: nonNegativeSafeIntegerSchema,
+  required: z.boolean(),
+}).strict();
+
+const baselineComparisonAcceptanceCriterionSchema = z.object({
+  id: integrationIdSchema,
+  type: z.literal("baseline_comparison"),
+  rule: z.literal("no_new_failures"),
+  baselineCommand: integrationTextSchema.optional(),
+  required: z.boolean(),
+}).strict();
+
+const rubricAcceptanceCriterionSchema = z.object({
+  id: integrationIdSchema,
+  type: z.literal("rubric"),
+  rubric: integrationTextSchema,
+  threshold: z.number().min(0).max(1),
+  judgedDeliverables: uniqueNonEmptyStrings(200),
+  borderlineMargin: z.number().min(0).max(1),
+  required: z.boolean(),
+}).strict();
+
+export const acceptanceCriterionSchema = z.discriminatedUnion("type", [
+  commandAcceptanceCriterionSchema,
+  searchAcceptanceCriterionSchema,
+  baselineComparisonAcceptanceCriterionSchema,
+  rubricAcceptanceCriterionSchema,
+]);
+
+export const modelBindingMetadataSchema = z.object({
+  role: integrationIdSchema,
+  adapter: integrationIdSchema,
+  provider: integrationIdSchema,
+  modelRef: integrationTextSchema,
+  profileHash: sha256Schema,
+  judgeIndependence: integrationTextSchema.optional(),
+}).strict();
+
+export const mutationRefSchema = z.object({
+  system: z.enum(["agent-task", "agent-harness", "github", "averray", "policy"]),
+  action: integrationIdSchema,
+  target: integrationTextSchema,
+  idempotencyKey: integrationTextSchema.optional(),
+  resultRef: artifactRefSchema.optional(),
+}).strict();
+
+export const harnessRunStateSchema = z.enum([
+  "accepted",
+  "contract_compiled",
+  "environment_preparing",
+  "environment_ready",
+  "strategy_selected",
+  "executing",
+  "verifying",
+  "repairing",
+  "replanning",
+  "approval_required",
+  "suspended",
+  "finalizing",
+  "completed",
+  "partial",
+  "failed",
+  "cancel_requested",
+  "compensating",
+  "cancelled",
+  "quarantined",
+  "learning_queued",
+  "learning_processed",
+]);
+
+export const githubPullRequestRefSchema = z.object({
+  repository: integrationTextSchema,
+  number: positiveSafeIntegerSchema,
+  headSha: z.string().regex(/^[a-f0-9]{40}$/),
+}).strict();
+
+export function uniqueNonEmptyStrings(maxItems: number, minItems = 0) {
+  return z.array(integrationTextSchema)
+    .min(minItems)
+    .max(maxItems)
+    .refine((values) => new Set(values).size === values.length, "values must be unique");
+}
+
+export type ActorRef = z.infer<typeof actorRefSchema>;
+export type ArtifactRef = z.infer<typeof artifactRefSchema>;
+export type CapabilityGrant = z.infer<typeof capabilityGrantSchema>;
+export type AcceptanceCriterion = z.infer<typeof acceptanceCriterionSchema>;
+export type ModelBindingMetadata = z.infer<typeof modelBindingMetadataSchema>;
+export type MutationRef = z.infer<typeof mutationRefSchema>;
+export type HarnessRunState = z.infer<typeof harnessRunStateSchema>;
+export type GithubPullRequestRef = z.infer<typeof githubPullRequestRefSchema>;

--- a/packages/schemas/src/agent-run-projection.ts
+++ b/packages/schemas/src/agent-run-projection.ts
@@ -1,0 +1,246 @@
+import { z } from "zod";
+
+import {
+  artifactRefSchema,
+  harnessRunStateSchema,
+  integrationIdSchema,
+  integrationTextSchema,
+  integrationTimestampSchema,
+  modelBindingMetadataSchema,
+  nonNegativeSafeIntegerSchema,
+  sha256Schema,
+  uniqueNonEmptyStrings,
+} from "./agent-integration-common.js";
+import {
+  agentTaskBindingsSchema,
+  agentTaskNetworkPolicySchema,
+  agentTaskV1Schema,
+  type AgentTaskV1,
+} from "./agent-task.js";
+
+const terminalOutcomeSchema = z.enum(["completed", "partial", "failed", "cancelled"]);
+
+export const agentRunProjectionV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("agent_run_projection"),
+  workItemId: integrationIdSchema,
+  correlationId: integrationIdSchema,
+  harnessRunId: integrationIdSchema,
+  taskVersion: z.number().int().positive().safe(),
+  source: z.object({
+    system: z.literal("agent-harness"),
+    health: z.enum(["healthy", "stale", "degraded", "unavailable"]),
+    observedAt: integrationTimestampSchema,
+    sourceUpdatedAt: integrationTimestampSchema.optional(),
+    reason: integrationTextSchema.optional(),
+  }).strict(),
+  heartbeat: z.object({
+    status: z.enum(["active", "stale", "terminal", "unknown"]),
+    lastEventAt: integrationTimestampSchema.optional(),
+    ageSeconds: nonNegativeSafeIntegerSchema.optional(),
+  }).strict(),
+  run: z.object({
+    state: harnessRunStateSchema,
+    attempt: nonNegativeSafeIntegerSchema,
+    terminal: z.boolean(),
+    outcome: terminalOutcomeSchema.optional(),
+    reason: integrationTextSchema.optional(),
+    lastEventAt: integrationTimestampSchema.optional(),
+  }).strict(),
+  manifest: z.object({
+    ref: artifactRefSchema.optional(),
+    hash: sha256Schema,
+    profile: integrationIdSchema,
+    riskClass: z.enum(["low", "standard", "elevated"]),
+    effectiveCapabilities: uniqueNonEmptyStrings(200),
+    network: agentTaskNetworkPolicySchema,
+    policyHash: sha256Schema,
+    verifierHash: sha256Schema,
+    modelBindings: z.array(modelBindingMetadataSchema).max(100),
+    skillVersions: uniqueNonEmptyStrings(200),
+  }).strict(),
+  progress: z.object({
+    phase: integrationIdSchema,
+    summary: integrationTextSchema,
+    completedUnits: nonNegativeSafeIntegerSchema.optional(),
+    totalUnits: nonNegativeSafeIntegerSchema.optional(),
+    blocker: integrationTextSchema.optional(),
+  }).strict(),
+  budget: z.object({
+    elapsedSecondsUsed: nonNegativeSafeIntegerSchema.optional(),
+    elapsedSecondsLimit: nonNegativeSafeIntegerSchema.optional(),
+    modelTokensUsed: nonNegativeSafeIntegerSchema.optional(),
+    modelTokensLimit: nonNegativeSafeIntegerSchema.optional(),
+    toolCallsUsed: nonNegativeSafeIntegerSchema.optional(),
+    toolCallsLimit: nonNegativeSafeIntegerSchema.optional(),
+    estimatedUsdMicrosUsed: nonNegativeSafeIntegerSchema.optional(),
+    estimatedUsdMicrosLimit: nonNegativeSafeIntegerSchema.nullable().optional(),
+    exhausted: z.boolean(),
+  }).strict(),
+  artifacts: z.array(artifactRefSchema).max(1_000),
+  verification: z.object({
+    status: z.enum(["pending", "passed", "failed", "inconclusive"]),
+    decisionRef: artifactRefSchema.optional(),
+    decisionHash: sha256Schema.optional(),
+  }).strict().superRefine((verification, context) => {
+    const refPresent = verification.decisionRef !== undefined;
+    const hashPresent = verification.decisionHash !== undefined;
+    if (refPresent !== hashPresent) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "decisionRef and decisionHash must be present together",
+        path: ["decisionRef"],
+      });
+    }
+    if (verification.decisionRef && verification.decisionHash
+        && verification.decisionRef.sha256 !== verification.decisionHash) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "verification decision ref hash must match decisionHash",
+        path: ["decisionHash"],
+      });
+    }
+  }).optional(),
+  failure: z.object({
+    code: integrationIdSchema,
+    message: integrationTextSchema,
+    retryable: z.boolean(),
+  }).strict().optional(),
+  bindings: agentTaskBindingsSchema.optional(),
+}).strict().superRefine((projection, context) => {
+  if (projection.source.health !== "healthy" && !projection.source.reason) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "non-healthy sources require an explicit reason",
+      path: ["source", "reason"],
+    });
+  }
+  if (projection.manifest.ref && projection.manifest.ref.sha256 !== projection.manifest.hash) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "manifest ref hash must match manifest hash",
+      path: ["manifest", "hash"],
+    });
+  }
+  if (projection.run.terminal !== (projection.run.outcome !== undefined)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "terminal and outcome must be present together",
+      path: ["run", "outcome"],
+    });
+  }
+  if (projection.heartbeat.status === "terminal" && !projection.run.terminal) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "terminal heartbeat requires a terminal run",
+      path: ["heartbeat", "status"],
+    });
+  }
+  if (projection.progress.completedUnits !== undefined
+      && projection.progress.totalUnits !== undefined
+      && projection.progress.completedUnits > projection.progress.totalUnits) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "completedUnits cannot exceed totalUnits",
+      path: ["progress", "completedUnits"],
+    });
+  }
+  if (projection.bindings?.harnessRunId
+      && projection.bindings.harnessRunId !== projection.harnessRunId) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "binding harnessRunId must match projection harnessRunId",
+      path: ["bindings", "harnessRunId"],
+    });
+  }
+  if ((projection.run.state === "failed" || projection.run.state === "quarantined")
+      && !projection.failure) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${projection.run.state} runs require structured failure details`,
+      path: ["failure"],
+    });
+  }
+});
+
+export type AgentRunProjectionV1 = z.infer<typeof agentRunProjectionV1Schema>;
+
+export function assertAgentRunProjectionWithinTask(
+  taskInput: AgentTaskV1,
+  projectionInput: AgentRunProjectionV1,
+): void {
+  const task = agentTaskForAuthority(taskInput);
+  const projection = agentRunProjectionV1Schema.parse(projectionInput);
+  if (projection.workItemId !== task.workItemId
+      || projection.correlationId !== task.correlationId
+      || projection.taskVersion !== task.taskVersion) {
+    throw new Error("run projection identity does not match approved task");
+  }
+  if (projection.manifest.policyHash !== task.approval.policyHash) {
+    throw new Error("run projection policy hash does not match approved task");
+  }
+  if (task.bindings?.harnessRunId && projection.harnessRunId !== task.bindings.harnessRunId) {
+    throw new Error("run projection Harness run id does not match approved task binding");
+  }
+  if (task.bindings?.runManifestHash
+      && projection.manifest.hash !== task.bindings.runManifestHash) {
+    throw new Error("run projection manifest hash does not match approved task binding");
+  }
+
+  const approvedCapabilities = new Set(
+    task.requestedAuthority.grants.map((grant) => grant.capabilityId),
+  );
+  const expandedCapability = projection.manifest.effectiveCapabilities
+    .find((capability) => !approvedCapabilities.has(capability));
+  if (expandedCapability) {
+    throw new Error(`run projection expands capability: ${expandedCapability}`);
+  }
+  assertNetworkAttenuated(task.requestedAuthority.network, projection.manifest.network);
+  assertBudgetWithinTask(task, projection);
+}
+
+function agentTaskForAuthority(task: AgentTaskV1): AgentTaskV1 {
+  const parsed = agentTaskV1Schema.parse(task);
+  if (parsed.approval.status !== "approved") {
+    throw new Error("run projection requires an approved task");
+  }
+  return parsed;
+}
+
+function assertNetworkAttenuated(
+  approved: AgentTaskV1["requestedAuthority"]["network"],
+  effective: AgentRunProjectionV1["manifest"]["network"],
+): void {
+  if (approved === "deny") {
+    if (effective !== "deny") throw new Error("run projection expands denied network access");
+    return;
+  }
+  if (effective === "deny") return;
+  const approvedDestinations = new Set(approved.allowlist);
+  const expandedDestination = effective.allowlist
+    .find((destination) => !approvedDestinations.has(destination));
+  if (expandedDestination) {
+    throw new Error(`run projection expands network destination: ${expandedDestination}`);
+  }
+}
+
+function assertBudgetWithinTask(
+  task: AgentTaskV1,
+  projection: AgentRunProjectionV1,
+): void {
+  const limits: Array<[number | null | undefined, number | null]> = [
+    [projection.budget.elapsedSecondsLimit, task.budget.elapsedSeconds],
+    [projection.budget.modelTokensLimit, task.budget.modelTokens],
+    [projection.budget.toolCallsLimit, task.budget.toolCalls],
+    [projection.budget.estimatedUsdMicrosLimit, task.budget.estimatedUsdMicros],
+  ];
+  for (const [effective, approved] of limits) {
+    if (effective === undefined) continue;
+    if (approved === null && effective !== null) {
+      throw new Error("run projection adds a monetary budget where none was approved");
+    }
+    if (effective !== null && approved !== null && effective > approved) {
+      throw new Error("run projection budget exceeds approved task budget");
+    }
+  }
+}

--- a/packages/schemas/src/agent-task.ts
+++ b/packages/schemas/src/agent-task.ts
@@ -1,0 +1,289 @@
+import { z } from "zod";
+
+import {
+  acceptanceCriterionSchema,
+  actorRefSchema,
+  artifactRefSchema,
+  capabilityGrantSchema,
+  githubPullRequestRefSchema,
+  integrationIdSchema,
+  integrationTextSchema,
+  integrationTimestampSchema,
+  nonNegativeSafeIntegerSchema,
+  positiveSafeIntegerSchema,
+  sha256Schema,
+  uniqueNonEmptyStrings,
+} from "./agent-integration-common.js";
+
+export const agentTaskLifecycleSchema = z.enum([
+  "proposed",
+  "approved",
+  "dispatching",
+  "running",
+  "verifying",
+  "handoff_ready",
+  "blocked",
+  "failed",
+  "cancelled",
+]);
+
+export const agentTaskRiskTierSchema = z.enum(["low", "medium", "high"]);
+
+export const agentTaskNetworkPolicySchema = z.union([
+  z.literal("deny"),
+  z.object({
+    allowlist: uniqueNonEmptyStrings(200, 1),
+  }).strict(),
+]);
+
+export const agentTaskExecutorSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("harness"),
+    selectionReason: integrationTextSchema,
+  }).strict(),
+  z.object({
+    kind: z.literal("direct"),
+    directAgent: z.enum(["codex", "claude", "test-writer", "security", "docs"]),
+    selectionReason: integrationTextSchema,
+  }).strict(),
+]);
+
+export const agentTaskBindingsSchema = z.object({
+  harnessRunId: integrationIdSchema.optional(),
+  runManifestRef: artifactRefSchema.optional(),
+  runManifestHash: sha256Schema.optional(),
+  averrayJobId: integrationIdSchema.optional(),
+  averraySessionId: integrationIdSchema.optional(),
+  pullRequest: githubPullRequestRefSchema.optional(),
+}).strict().superRefine((bindings, context) => {
+  const refPresent = bindings.runManifestRef !== undefined;
+  const hashPresent = bindings.runManifestHash !== undefined;
+  if (refPresent !== hashPresent) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "runManifestRef and runManifestHash must be present together",
+      path: ["runManifestRef"],
+    });
+  }
+  if (bindings.runManifestRef && bindings.runManifestHash
+      && bindings.runManifestRef.sha256 !== bindings.runManifestHash) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "run manifest ref hash must match runManifestHash",
+      path: ["runManifestHash"],
+    });
+  }
+});
+
+const agentTaskApprovalSchema = z.object({
+  required: z.enum(["policy", "operator"]),
+  status: z.enum(["pending", "approved", "denied", "expired"]),
+  actor: actorRefSchema.optional(),
+  decidedAt: integrationTimestampSchema.optional(),
+  policyVersion: integrationIdSchema,
+  policyHash: sha256Schema,
+  approvedTaskHash: sha256Schema.optional(),
+}).strict().superRefine((approval, context) => {
+  const decided = approval.status === "approved"
+    || approval.status === "denied"
+    || approval.status === "expired";
+  if (decided && (!approval.actor || !approval.decidedAt)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "a decided approval requires actor and decidedAt",
+      path: ["actor"],
+    });
+  }
+  if (approval.actor) {
+    const actorAllowed = approval.required === "operator"
+      ? approval.actor.type === "operator"
+      : approval.actor.type === "policy" || approval.actor.type === "operator";
+    if (!actorAllowed) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${approval.required} approval cannot be decided by ${approval.actor.type}`,
+        path: ["actor", "type"],
+      });
+    }
+  }
+  if (approval.status === "approved") {
+    if (approval.approvedTaskHash === undefined) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "approvedTaskHash is required for an approved task",
+        path: ["approvedTaskHash"],
+      });
+    }
+  } else if (approval.approvedTaskHash !== undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "approvedTaskHash is allowed only when status is approved",
+      path: ["approvedTaskHash"],
+    });
+  }
+});
+
+export const agentTaskV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("agent_task"),
+  workItemId: integrationIdSchema,
+  taskVersion: positiveSafeIntegerSchema,
+  correlationId: integrationIdSchema,
+  taskKind: integrationIdSchema,
+  lifecycle: agentTaskLifecycleSchema,
+  proposal: z.object({
+    title: integrationTextSchema,
+    objective: integrationTextSchema,
+    whyNow: integrationTextSchema,
+    requestedBy: actorRefSchema,
+    createdAt: integrationTimestampSchema,
+    sourceRefs: z.array(artifactRefSchema).max(200),
+  }).strict(),
+  repository: z.object({
+    provider: z.literal("github"),
+    nameWithOwner: z.string().regex(/^[^/\s]+\/[^/\s]+$/).max(240),
+    baseRevision: integrationIdSchema,
+    allowedPaths: uniqueNonEmptyStrings(500),
+    forbiddenPaths: uniqueNonEmptyStrings(500),
+  }).strict(),
+  intent: z.object({
+    apiVersion: z.literal("harness/v1alpha1"),
+    profile: integrationIdSchema,
+    templateRef: artifactRefSchema,
+    templateHash: sha256Schema,
+  }).strict(),
+  acceptance: z.object({
+    criteria: z.array(acceptanceCriterionSchema).min(1).max(200),
+    verifierPlanRef: artifactRefSchema,
+    verifierPlanHash: sha256Schema,
+  }).strict(),
+  risk: z.object({
+    tier: agentTaskRiskTierSchema,
+    reasons: z.array(integrationTextSchema).min(1).max(50),
+    irreversible: z.boolean(),
+  }).strict(),
+  requestedAuthority: z.object({
+    grants: z.array(capabilityGrantSchema).max(200),
+    network: agentTaskNetworkPolicySchema,
+    maxChildren: nonNegativeSafeIntegerSchema,
+    maxConcurrentChildren: nonNegativeSafeIntegerSchema,
+    delegable: z.literal(false),
+  }).strict(),
+  budget: z.object({
+    elapsedSeconds: positiveSafeIntegerSchema,
+    modelTokens: positiveSafeIntegerSchema,
+    toolCalls: positiveSafeIntegerSchema,
+    estimatedUsdMicros: nonNegativeSafeIntegerSchema.nullable(),
+  }).strict(),
+  deadline: integrationTimestampSchema,
+  executor: agentTaskExecutorSchema,
+  approval: agentTaskApprovalSchema,
+  timestamps: z.object({
+    proposedAt: integrationTimestampSchema,
+    approvedAt: integrationTimestampSchema.optional(),
+    dispatchClaimedAt: integrationTimestampSchema.optional(),
+    runBoundAt: integrationTimestampSchema.optional(),
+    terminalAt: integrationTimestampSchema.optional(),
+    updatedAt: integrationTimestampSchema,
+  }).strict(),
+  bindings: agentTaskBindingsSchema.optional(),
+}).strict().superRefine((task, context) => {
+  if (task.intent.templateRef.sha256 !== task.intent.templateHash) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "TaskIntent ref hash must match templateHash",
+      path: ["intent", "templateHash"],
+    });
+  }
+  if (task.acceptance.verifierPlanRef.sha256 !== task.acceptance.verifierPlanHash) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "verifier plan ref hash must match verifierPlanHash",
+      path: ["acceptance", "verifierPlanHash"],
+    });
+  }
+  const allowedPaths = new Set(task.repository.allowedPaths);
+  const overlap = task.repository.forbiddenPaths.find((path) => allowedPaths.has(path));
+  if (overlap) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `path cannot be both allowed and forbidden: ${overlap}`,
+      path: ["repository", "forbiddenPaths"],
+    });
+  }
+  const criterionIds = task.acceptance.criteria.map((criterion) => criterion.id);
+  if (new Set(criterionIds).size !== criterionIds.length) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "acceptance criterion ids must be unique",
+      path: ["acceptance", "criteria"],
+    });
+  }
+  const grantIds = task.requestedAuthority.grants.map((grant) => grant.capabilityId);
+  if (new Set(grantIds).size !== grantIds.length) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "capability grant ids must be unique",
+      path: ["requestedAuthority", "grants"],
+    });
+  }
+  if (!["operator", "hermes", "averray"].includes(task.proposal.requestedBy.type)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${task.proposal.requestedBy.type} cannot request an AgentTask`,
+      path: ["proposal", "requestedBy", "type"],
+    });
+  }
+  if (task.requestedAuthority.maxConcurrentChildren > task.requestedAuthority.maxChildren) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "maxConcurrentChildren cannot exceed maxChildren",
+      path: ["requestedAuthority", "maxConcurrentChildren"],
+    });
+  }
+  if (task.requestedAuthority.maxChildren !== 0
+      || task.requestedAuthority.maxConcurrentChildren !== 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "AgentTask V1 disables child delegation and requires zero child budgets",
+      path: ["requestedAuthority", "maxChildren"],
+    });
+  }
+  const approvalRequired = task.lifecycle !== "proposed" && task.lifecycle !== "cancelled";
+  if (approvalRequired && task.approval.status !== "approved") {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${task.lifecycle} tasks require approved status`,
+      path: ["approval", "status"],
+    });
+  }
+  if (task.approval.status === "approved" && task.timestamps.approvedAt === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "approvedAt is required for an approved task",
+      path: ["timestamps", "approvedAt"],
+    });
+  }
+  if (Date.parse(task.deadline) <= Date.parse(task.timestamps.proposedAt)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "deadline must be after proposedAt",
+      path: ["deadline"],
+    });
+  }
+  if (task.lifecycle === "running" && !task.bindings?.harnessRunId
+      && task.executor.kind === "harness") {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "a running Harness task requires a harnessRunId binding",
+      path: ["bindings", "harnessRunId"],
+    });
+  }
+});
+
+export type AgentTaskLifecycle = z.infer<typeof agentTaskLifecycleSchema>;
+export type AgentTaskRiskTier = z.infer<typeof agentTaskRiskTierSchema>;
+export type AgentTaskNetworkPolicy = z.infer<typeof agentTaskNetworkPolicySchema>;
+export type AgentTaskExecutor = z.infer<typeof agentTaskExecutorSchema>;
+export type AgentTaskBindings = z.infer<typeof agentTaskBindingsSchema>;
+export type AgentTaskV1 = z.infer<typeof agentTaskV1Schema>;

--- a/packages/schemas/src/hermes-decision-record.ts
+++ b/packages/schemas/src/hermes-decision-record.ts
@@ -1,0 +1,225 @@
+import { z } from "zod";
+
+import {
+  actorRefSchema,
+  artifactRefSchema,
+  integrationIdSchema,
+  integrationTextSchema,
+  integrationTimestampSchema,
+  mutationRefSchema,
+  sha256Schema,
+} from "./agent-integration-common.js";
+import { agentTaskRiskTierSchema } from "./agent-task.js";
+
+export const hermesDecisionRecordV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  recordType: z.literal("hermes_decision_record"),
+  id: integrationIdSchema,
+  kind: z.enum(["routing", "auto_approval", "escalation", "anomaly_pause", "away_digest"]),
+  subject: z.object({
+    type: z.enum(["task", "card", "repo", "pr", "mission", "digest", "autopilot_session"]),
+    id: integrationIdSchema,
+    repo: integrationTextSchema.optional(),
+    pullRequestNumber: z.number().int().positive().safe().optional(),
+  }).strict(),
+  decision: integrationTextSchema,
+  reasons: z.array(integrationTextSchema).min(1).max(50),
+  inputs: z.record(z.unknown()),
+  outcome: z.object({
+    summary: integrationTextSchema,
+    waitingNext: integrationTextSchema.optional(),
+    changed: z.array(integrationTextSchema).max(200).optional(),
+  }).strict(),
+  safety: z.object({
+    readOnly: z.boolean(),
+    mutates: z.boolean(),
+    mutatesGithub: z.boolean().optional(),
+    mutatesAverray: z.boolean().optional(),
+    editsWikipedia: z.boolean().optional(),
+  }).strict(),
+  generatedAt: integrationTimestampSchema,
+}).strict();
+
+export const hermesDecisionTypeV2Schema = z.enum([
+  "task_proposal",
+  "risk_classification",
+  "executor_selection",
+  "dispatch_approval",
+  "dispatch_refusal",
+  "anomaly_pause",
+  "handoff",
+  "escalation",
+  "away_digest",
+]);
+
+export const hermesDecisionRecordV2Schema = z.object({
+  schemaVersion: z.literal(2),
+  kind: z.literal("hermes_decision"),
+  decisionId: integrationIdSchema,
+  correlationId: integrationIdSchema,
+  workItemId: integrationIdSchema.optional(),
+  decisionType: hermesDecisionTypeV2Schema,
+  proposal: z.object({
+    what: integrationTextSchema,
+    why: z.array(integrationTextSchema).min(1).max(50),
+    whyNow: integrationTextSchema.optional(),
+    evidenceRefs: z.array(artifactRefSchema).max(500),
+  }).strict(),
+  inputs: z.array(z.object({
+    name: integrationIdSchema,
+    ref: artifactRefSchema.optional(),
+    hash: sha256Schema.optional(),
+    observedAt: integrationTimestampSchema.optional(),
+  }).strict().superRefine((input, context) => {
+    if (input.ref && input.hash && input.ref.sha256 !== input.hash) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "input ref hash must match declared hash",
+        path: ["hash"],
+      });
+    }
+  })).max(500),
+  routing: z.discriminatedUnion("executor", [
+    z.object({
+      executor: z.literal("harness"),
+      modelProvider: integrationIdSchema.optional(),
+      modelRef: integrationTextSchema.optional(),
+      reason: integrationTextSchema,
+      scorecardRef: artifactRefSchema.optional(),
+    }).strict(),
+    z.object({
+      executor: z.literal("direct"),
+      directAgent: z.enum(["codex", "claude", "test-writer", "security", "docs"]),
+      modelProvider: integrationIdSchema.optional(),
+      modelRef: integrationTextSchema.optional(),
+      reason: integrationTextSchema,
+      scorecardRef: artifactRefSchema.optional(),
+    }).strict(),
+  ]).optional(),
+  risk: z.object({
+    tier: agentTaskRiskTierSchema,
+    reasons: z.array(integrationTextSchema).min(1).max(50),
+    irreversible: z.boolean(),
+  }).strict(),
+  approval: z.object({
+    required: z.enum(["policy", "operator"]),
+    decision: z.enum(["pending", "approved", "denied", "expired", "not_applicable"]),
+    actor: actorRefSchema.optional(),
+    policyVersion: integrationIdSchema,
+    policyHash: sha256Schema,
+    decidedAt: integrationTimestampSchema.optional(),
+  }).strict().superRefine((approval, context) => {
+    const decided = approval.decision === "approved"
+      || approval.decision === "denied"
+      || approval.decision === "expired";
+    if (decided && (!approval.actor || !approval.decidedAt)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "decided approval requires actor and decidedAt",
+        path: ["actor"],
+      });
+    }
+    if (approval.actor) {
+      const actorAllowed = approval.required === "operator"
+        ? approval.actor.type === "operator"
+        : approval.actor.type === "policy" || approval.actor.type === "operator";
+      if (!actorAllowed) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${approval.required} approval cannot be decided by ${approval.actor.type}`,
+          path: ["actor", "type"],
+        });
+      }
+    }
+  }),
+  effects: z.object({
+    mutates: z.boolean(),
+    mutations: z.array(mutationRefSchema).max(500),
+    authorityChanged: z.boolean(),
+    budgetChanged: z.boolean(),
+  }).strict(),
+  next: z.object({
+    action: integrationTextSchema,
+    owner: z.enum(["operator", "hermes", "dispatcher", "harness", "verifier", "averray"]),
+    dueAt: integrationTimestampSchema.optional(),
+    blockedBy: z.array(integrationTextSchema).max(200).optional(),
+  }).strict(),
+  generatedAt: integrationTimestampSchema,
+}).strict().superRefine((record, context) => {
+  if (!record.effects.mutates
+      && (record.effects.mutations.length > 0
+        || record.effects.authorityChanged
+        || record.effects.budgetChanged)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "non-mutating decisions cannot declare mutations or authority/budget changes",
+      path: ["effects", "mutates"],
+    });
+  }
+  if (record.effects.mutates && record.effects.mutations.length === 0) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "mutating decisions must identify at least one mutation",
+      path: ["effects", "mutations"],
+    });
+  }
+});
+
+export const hermesDecisionRecordSchema = z.union([
+  hermesDecisionRecordV1Schema,
+  hermesDecisionRecordV2Schema,
+]);
+
+export interface HermesDecisionCompatibilityView {
+  sourceVersion: 1 | 2;
+  decisionId: string;
+  decisionType: string;
+  correlationId?: string;
+  workItemId?: string;
+  why: string[];
+  approvalDecision: string;
+  mutates: boolean;
+  nextAction?: string;
+  generatedAt: string;
+  legacy: boolean;
+}
+
+export function parseHermesDecisionRecord(value: unknown): HermesDecisionRecord {
+  return hermesDecisionRecordSchema.parse(value);
+}
+
+export function toHermesDecisionCompatibilityView(
+  input: unknown,
+): HermesDecisionCompatibilityView {
+  const record = parseHermesDecisionRecord(input);
+  if (record.schemaVersion === 1) {
+    return {
+      sourceVersion: 1,
+      decisionId: record.id,
+      decisionType: record.kind,
+      why: record.reasons,
+      approvalDecision: record.decision,
+      mutates: record.safety.mutates,
+      ...(record.outcome.waitingNext ? { nextAction: record.outcome.waitingNext } : {}),
+      generatedAt: record.generatedAt,
+      legacy: true,
+    };
+  }
+  return {
+    sourceVersion: 2,
+    decisionId: record.decisionId,
+    decisionType: record.decisionType,
+    correlationId: record.correlationId,
+    ...(record.workItemId ? { workItemId: record.workItemId } : {}),
+    why: record.proposal.why,
+    approvalDecision: record.approval.decision,
+    mutates: record.effects.mutates,
+    nextAction: record.next.action,
+    generatedAt: record.generatedAt,
+    legacy: false,
+  };
+}
+
+export type HermesDecisionRecordV1 = z.infer<typeof hermesDecisionRecordV1Schema>;
+export type HermesDecisionRecordV2 = z.infer<typeof hermesDecisionRecordV2Schema>;
+export type HermesDecisionRecord = z.infer<typeof hermesDecisionRecordSchema>;

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,2 +1,8 @@
+export * from "./agent-contract-hash.js";
+export * from "./agent-integration-common.js";
+export * from "./agent-run-projection.js";
+export * from "./agent-task.js";
+export * from "./hermes-decision-record.js";
+export * from "./legacy-agent-task.js";
+export * from "./verified-handoff.js";
 export * from "./wikipedia.js";
-

--- a/packages/schemas/src/legacy-agent-task.ts
+++ b/packages/schemas/src/legacy-agent-task.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+import {
+  integrationIdSchema,
+  integrationTextSchema,
+  integrationTimestampSchema,
+} from "./agent-integration-common.js";
+import { hermesDecisionRecordV1Schema } from "./hermes-decision-record.js";
+
+export const legacyCodexTaskV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("codex_task"),
+  id: integrationIdSchema,
+  repo: integrationTextSchema,
+  pullRequestNumber: z.number().int().positive().safe().optional(),
+  agent: integrationIdSchema.optional(),
+  correlationId: integrationIdSchema.optional(),
+  title: integrationTextSchema.optional(),
+  prompt: integrationTextSchema,
+  reason: integrationTextSchema.optional(),
+  requester: integrationIdSchema.optional(),
+  riskTier: z.enum(["high", "low"]).optional(),
+  routingReason: integrationTextSchema.optional(),
+  status: z.enum(["proposed", "approved", "running", "completed", "failed", "cancelled"]),
+  createdAt: integrationTimestampSchema,
+  updatedAt: integrationTimestampSchema,
+  approvedAt: integrationTimestampSchema.optional(),
+  startedAt: integrationTimestampSchema.optional(),
+  completedAt: integrationTimestampSchema.optional(),
+  failedAt: integrationTimestampSchema.optional(),
+  cancelledAt: integrationTimestampSchema.optional(),
+  decisionRecord: hermesDecisionRecordV1Schema.optional(),
+}).passthrough();
+
+export interface LegacyAgentTaskCompatibilityView {
+  sourceVersion: 1;
+  sourceKind: "codex_task";
+  workItemId: string;
+  correlationId?: string;
+  repository: string;
+  pullRequestNumber?: number;
+  objective: string;
+  requestedBy?: string;
+  executor: {
+    kind: "direct";
+    directAgent: string;
+  };
+  legacyRiskTier: "low" | "high" | "unknown";
+  lifecycle: "proposed" | "approved" | "running" | "completed" | "failed" | "cancelled";
+  createdAt: string;
+  updatedAt: string;
+  nonDispatchable: true;
+  missingRequiredAgentTaskFields: Array<
+    | "taskVersion"
+    | "taskKind"
+    | "taskIntentRef"
+    | "immutableAcceptance"
+    | "typedGrants"
+    | "budget"
+    | "deadline"
+    | "approvalPolicyHash"
+  >;
+}
+
+export function parseLegacyCodexTask(value: unknown): LegacyCodexTaskV1 {
+  return legacyCodexTaskV1Schema.parse(value);
+}
+
+export function toLegacyAgentTaskCompatibilityView(
+  input: unknown,
+): LegacyAgentTaskCompatibilityView {
+  const task = parseLegacyCodexTask(input);
+  return {
+    sourceVersion: 1,
+    sourceKind: "codex_task",
+    workItemId: task.id,
+    ...(task.correlationId ? { correlationId: task.correlationId } : {}),
+    repository: task.repo,
+    ...(task.pullRequestNumber ? { pullRequestNumber: task.pullRequestNumber } : {}),
+    objective: task.prompt,
+    ...(task.requester ? { requestedBy: task.requester } : {}),
+    executor: {
+      kind: "direct",
+      directAgent: task.agent ?? "codex",
+    },
+    legacyRiskTier: task.riskTier ?? "unknown",
+    lifecycle: task.status,
+    createdAt: task.createdAt,
+    updatedAt: task.updatedAt,
+    nonDispatchable: true,
+    missingRequiredAgentTaskFields: [
+      "taskVersion",
+      "taskKind",
+      "taskIntentRef",
+      "immutableAcceptance",
+      "typedGrants",
+      "budget",
+      "deadline",
+      "approvalPolicyHash",
+    ],
+  };
+}
+
+export type LegacyCodexTaskV1 = z.infer<typeof legacyCodexTaskV1Schema>;

--- a/packages/schemas/src/verified-handoff.ts
+++ b/packages/schemas/src/verified-handoff.ts
@@ -1,0 +1,176 @@
+import { z } from "zod";
+
+import {
+  actorRefSchema,
+  artifactRefSchema,
+  githubPullRequestRefSchema,
+  integrationIdSchema,
+  integrationTextSchema,
+  integrationTimestampSchema,
+  sha256Schema,
+} from "./agent-integration-common.js";
+import {
+  agentRunProjectionV1Schema,
+  assertAgentRunProjectionWithinTask,
+  type AgentRunProjectionV1,
+} from "./agent-run-projection.js";
+import { agentTaskApprovalHashMatches } from "./agent-contract-hash.js";
+import { agentTaskV1Schema, type AgentTaskV1 } from "./agent-task.js";
+
+export const verifiedHandoffV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("verified_handoff"),
+  workItemId: integrationIdSchema,
+  correlationId: integrationIdSchema,
+  harnessRunId: integrationIdSchema,
+  taskVersion: z.number().int().positive().safe(),
+  taskHash: sha256Schema,
+  taskIntentRef: artifactRefSchema,
+  taskIntentHash: sha256Schema,
+  runManifestRef: artifactRefSchema,
+  runManifestHash: sha256Schema,
+  outcome: z.enum(["completed", "partial", "failed"]),
+  deliverables: z.object({
+    patchRef: artifactRefSchema.optional(),
+    commitSha: z.string().regex(/^[a-f0-9]{40}$/).optional(),
+    summaryRef: artifactRefSchema,
+    structuredSubmissionRef: artifactRefSchema,
+    artifacts: z.array(artifactRefSchema).max(1_000),
+  }).strict(),
+  checks: z.array(z.object({
+    name: integrationTextSchema,
+    commandHash: sha256Schema.optional(),
+    status: z.enum(["passed", "failed", "skipped"]),
+    evidenceRef: artifactRefSchema,
+  }).strict()).min(1).max(500),
+  verification: z.object({
+    verified: z.boolean(),
+    decision: z.enum(["accept", "reject", "inconclusive"]),
+    verifier: actorRefSchema,
+    planHash: sha256Schema,
+    decisionRef: artifactRefSchema,
+    decisionHash: sha256Schema,
+    evidenceRefs: z.array(artifactRefSchema).min(1).max(1_000),
+    verifiedAt: integrationTimestampSchema,
+  }).strict(),
+  openQuestions: z.array(z.string().trim().min(1).max(8_000)).max(200),
+  eligibleForPrOpen: z.boolean(),
+  pullRequest: githubPullRequestRefSchema.optional(),
+  generatedAt: integrationTimestampSchema,
+}).strict().superRefine((handoff, context) => {
+  const hashBindings: Array<{
+    ref: { sha256: string };
+    hash: string;
+    path: Array<string | number>;
+    label: string;
+  }> = [
+    {
+      ref: handoff.taskIntentRef,
+      hash: handoff.taskIntentHash,
+      path: ["taskIntentHash"],
+      label: "TaskIntent",
+    },
+    {
+      ref: handoff.runManifestRef,
+      hash: handoff.runManifestHash,
+      path: ["runManifestHash"],
+      label: "run manifest",
+    },
+    {
+      ref: handoff.verification.decisionRef,
+      hash: handoff.verification.decisionHash,
+      path: ["verification", "decisionHash"],
+      label: "verification decision",
+    },
+  ];
+  for (const binding of hashBindings) {
+    if (binding.ref.sha256 !== binding.hash) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${binding.label} ref hash must match its declared hash`,
+        path: binding.path,
+      });
+    }
+  }
+  if (handoff.verification.verifier.type !== "verifier") {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "verification actor must have verifier type",
+      path: ["verification", "verifier", "type"],
+    });
+  }
+  if (handoff.verification.verified !== (handoff.verification.decision === "accept")) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "verified must be true exactly when the verifier decision is accept",
+      path: ["verification", "verified"],
+    });
+  }
+  if (handoff.eligibleForPrOpen) {
+    if (handoff.outcome !== "completed") {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "PR-open eligibility requires completed outcome",
+        path: ["eligibleForPrOpen"],
+      });
+    }
+    if (!handoff.verification.verified) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "PR-open eligibility requires verified acceptance",
+        path: ["eligibleForPrOpen"],
+      });
+    }
+    if (handoff.checks.some((check) => check.status !== "passed")) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "PR-open eligibility requires every recorded check to pass",
+        path: ["checks"],
+      });
+    }
+  }
+});
+
+export type VerifiedHandoffV1 = z.infer<typeof verifiedHandoffV1Schema>;
+
+export async function assertVerifiedHandoffMatchesTaskAndRun(
+  taskInput: AgentTaskV1,
+  projectionInput: AgentRunProjectionV1,
+  handoffInput: VerifiedHandoffV1,
+): Promise<void> {
+  const task = agentTaskV1Schema.parse(taskInput);
+  const projection = agentRunProjectionV1Schema.parse(projectionInput);
+  const handoff = verifiedHandoffV1Schema.parse(handoffInput);
+
+  assertAgentRunProjectionWithinTask(task, projection);
+  if (!await agentTaskApprovalHashMatches(task)) {
+    throw new Error("verified handoff requires an exact approved task hash");
+  }
+  if (handoff.workItemId !== task.workItemId
+      || handoff.correlationId !== task.correlationId
+      || handoff.taskVersion !== task.taskVersion
+      || handoff.harnessRunId !== projection.harnessRunId) {
+    throw new Error("verified handoff identity does not match task and run");
+  }
+  if (handoff.taskHash !== task.approval.approvedTaskHash) {
+    throw new Error("verified handoff task hash does not match approved task");
+  }
+  if (handoff.taskIntentHash !== task.intent.templateHash) {
+    throw new Error("verified handoff TaskIntent hash does not match approved task");
+  }
+  if (handoff.runManifestHash !== projection.manifest.hash) {
+    throw new Error("verified handoff manifest hash does not match run projection");
+  }
+  if (handoff.verification.planHash !== task.acceptance.verifierPlanHash) {
+    throw new Error("verified handoff verifier plan does not match approved task");
+  }
+  if (projection.verification?.decisionHash
+      && handoff.verification.decisionHash !== projection.verification.decisionHash) {
+    throw new Error("verified handoff decision does not match run projection");
+  }
+  if (handoff.eligibleForPrOpen) {
+    if (projection.run.outcome !== "completed" || projection.verification?.status !== "passed") {
+      throw new Error("PR-open handoff requires a completed run and passed verification projection");
+    }
+  }
+}

--- a/test/fixtures/agent-integration/agent-run-projection-v1.json
+++ b/test/fixtures/agent-integration/agent-run-projection-v1.json
@@ -1,0 +1,70 @@
+{
+  "schemaVersion": 1,
+  "kind": "agent_run_projection",
+  "workItemId": "work-001",
+  "correlationId": "correlation-001",
+  "harnessRunId": "run-001",
+  "taskVersion": 1,
+  "source": {
+    "system": "agent-harness",
+    "health": "healthy",
+    "observedAt": "2026-07-23T12:10:30.000Z",
+    "sourceUpdatedAt": "2026-07-23T12:10:25.000Z"
+  },
+  "heartbeat": {
+    "status": "active",
+    "lastEventAt": "2026-07-23T12:10:25.000Z",
+    "ageSeconds": 5
+  },
+  "run": {
+    "state": "executing",
+    "attempt": 1,
+    "terminal": false,
+    "lastEventAt": "2026-07-23T12:10:25.000Z"
+  },
+  "manifest": {
+    "hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "profile": "coding-change",
+    "riskClass": "low",
+    "effectiveCapabilities": [
+      "fs.write_file"
+    ],
+    "network": "deny",
+    "policyHash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+    "verifierHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "modelBindings": [
+      {
+        "role": "executor",
+        "adapter": "openai-compatible",
+        "provider": "example-provider",
+        "modelRef": "example-model",
+        "profileHash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+      }
+    ],
+    "skillVersions": []
+  },
+  "progress": {
+    "phase": "executing",
+    "summary": "Executing the bounded task.",
+    "completedUnits": 1,
+    "totalUnits": 3
+  },
+  "budget": {
+    "elapsedSecondsUsed": 300,
+    "elapsedSecondsLimit": 1800,
+    "modelTokensUsed": 12000,
+    "modelTokensLimit": 50000,
+    "toolCallsUsed": 20,
+    "toolCallsLimit": 100,
+    "estimatedUsdMicrosUsed": 1200000,
+    "estimatedUsdMicrosLimit": 5000000,
+    "exhausted": false
+  },
+  "artifacts": [],
+  "verification": {
+    "status": "pending"
+  },
+  "bindings": {
+    "harnessRunId": "run-001"
+  }
+}

--- a/test/fixtures/agent-integration/agent-task-v1.json
+++ b/test/fixtures/agent-integration/agent-task-v1.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "kind": "agent_task",
+  "workItemId": "work-001",
+  "taskVersion": 1,
+  "correlationId": "correlation-001",
+  "taskKind": "coding-change",
+  "lifecycle": "proposed",
+  "proposal": {
+    "title": "Add a bounded schema test",
+    "objective": "Add one focused schema test without changing runtime behavior.",
+    "whyNow": "The contract boundary needs deterministic acceptance evidence.",
+    "requestedBy": {
+      "type": "hermes",
+      "id": "hermes-ops"
+    },
+    "createdAt": "2026-07-23T12:00:00.000Z",
+    "sourceRefs": []
+  },
+  "repository": {
+    "provider": "github",
+    "nameWithOwner": "owner/repo",
+    "baseRevision": "5869af7bf2fc7e6168fbe070744f7d37fdf8c52a",
+    "allowedPaths": [
+      "packages/schemas",
+      "test/unit"
+    ],
+    "forbiddenPaths": [
+      "ops",
+      "contracts"
+    ]
+  },
+  "intent": {
+    "apiVersion": "harness/v1alpha1",
+    "profile": "coding-change",
+    "templateRef": {
+      "uri": "artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "mediaType": "application/yaml"
+    },
+    "templateHash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "acceptance": {
+    "criteria": [
+      {
+        "id": "schemas-typecheck",
+        "type": "command",
+        "command": "npm --workspace @avg/schemas run typecheck",
+        "required": true
+      }
+    ],
+    "verifierPlanRef": {
+      "uri": "artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "sha256": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "mediaType": "application/json"
+    },
+    "verifierPlanHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  "risk": {
+    "tier": "low",
+    "reasons": [
+      "Schema and test files only."
+    ],
+    "irreversible": false
+  },
+  "requestedAuthority": {
+    "grants": [
+      {
+        "capabilityId": "fs.write_file",
+        "resource": "owner/repo",
+        "constraints": {
+          "allowedPaths": [
+            "packages/schemas",
+            "test/unit"
+          ]
+        },
+        "expiresAt": "2026-07-23T14:00:00.000Z"
+      }
+    ],
+    "network": "deny",
+    "maxChildren": 0,
+    "maxConcurrentChildren": 0,
+    "delegable": false
+  },
+  "budget": {
+    "elapsedSeconds": 1800,
+    "modelTokens": 50000,
+    "toolCalls": 100,
+    "estimatedUsdMicros": 5000000
+  },
+  "deadline": "2026-07-23T14:00:00.000Z",
+  "executor": {
+    "kind": "harness",
+    "selectionReason": "The bounded coding-change profile is supported."
+  },
+  "approval": {
+    "required": "operator",
+    "status": "pending",
+    "policyVersion": "dispatch-policy-v1",
+    "policyHash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "timestamps": {
+    "proposedAt": "2026-07-23T12:00:00.000Z",
+    "updatedAt": "2026-07-23T12:00:00.000Z"
+  }
+}

--- a/test/fixtures/agent-integration/hermes-decision-v2.json
+++ b/test/fixtures/agent-integration/hermes-decision-v2.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": 2,
+  "kind": "hermes_decision",
+  "decisionId": "decision-001",
+  "correlationId": "correlation-001",
+  "workItemId": "work-001",
+  "decisionType": "task_proposal",
+  "proposal": {
+    "what": "Propose one bounded schema test.",
+    "why": [
+      "The contract boundary needs executable evidence."
+    ],
+    "whyNow": "The charter is ready for contract implementation.",
+    "evidenceRefs": []
+  },
+  "inputs": [
+    {
+      "name": "task-intent-template",
+      "ref": {
+        "uri": "artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "observedAt": "2026-07-23T12:00:00.000Z"
+    }
+  ],
+  "routing": {
+    "executor": "harness",
+    "reason": "The bounded coding-change profile is supported."
+  },
+  "risk": {
+    "tier": "low",
+    "reasons": [
+      "Schema and test files only."
+    ],
+    "irreversible": false
+  },
+  "approval": {
+    "required": "operator",
+    "decision": "pending",
+    "policyVersion": "dispatch-policy-v1",
+    "policyHash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  "effects": {
+    "mutates": false,
+    "mutations": [],
+    "authorityChanged": false,
+    "budgetChanged": false
+  },
+  "next": {
+    "action": "Wait for the operator to approve or deny the exact task hash.",
+    "owner": "operator"
+  },
+  "generatedAt": "2026-07-23T12:00:01.000Z"
+}

--- a/test/fixtures/agent-integration/legacy-codex-task-v1.json
+++ b/test/fixtures/agent-integration/legacy-codex-task-v1.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "kind": "codex_task",
+  "id": "codex-task-owner-repo-new-legacy",
+  "repo": "owner/repo",
+  "prompt": "Add a focused test.",
+  "requester": "hermes",
+  "status": "proposed",
+  "createdAt": "2026-07-22T12:00:00.000Z",
+  "updatedAt": "2026-07-22T12:00:00.000Z",
+  "progressMessage": "Historical fields are preserved by the compatibility reader."
+}

--- a/test/fixtures/agent-integration/legacy-hermes-decision-v1.json
+++ b/test/fixtures/agent-integration/legacy-hermes-decision-v1.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 1,
+  "recordType": "hermes_decision_record",
+  "id": "hdr-routing-task-legacy",
+  "kind": "routing",
+  "subject": {
+    "type": "task",
+    "id": "codex-task-owner-repo-new-legacy",
+    "repo": "owner/repo"
+  },
+  "decision": "routed to codex",
+  "reasons": [
+    "The historical hard taxonomy selected Codex."
+  ],
+  "inputs": {
+    "riskTier": "low"
+  },
+  "outcome": {
+    "summary": "Task proposed.",
+    "waitingNext": "Operator approval."
+  },
+  "safety": {
+    "readOnly": true,
+    "mutates": false
+  },
+  "generatedAt": "2026-07-22T12:00:01.000Z"
+}

--- a/test/fixtures/agent-integration/verified-handoff-v1.json
+++ b/test/fixtures/agent-integration/verified-handoff-v1.json
@@ -1,0 +1,77 @@
+{
+  "schemaVersion": 1,
+  "kind": "verified_handoff",
+  "workItemId": "work-001",
+  "correlationId": "correlation-001",
+  "harnessRunId": "run-001",
+  "taskVersion": 1,
+  "taskHash": "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "taskIntentRef": {
+    "uri": "artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "sha256": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  "taskIntentHash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "runManifestRef": {
+    "uri": "artifact://sha256/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "sha256": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  },
+  "runManifestHash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "outcome": "completed",
+  "deliverables": {
+    "patchRef": {
+      "uri": "artifact://sha256/1111111111111111111111111111111111111111111111111111111111111111",
+      "sha256": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "mediaType": "text/x-diff"
+    },
+    "commitSha": "1111111111111111111111111111111111111111",
+    "summaryRef": {
+      "uri": "artifact://sha256/2222222222222222222222222222222222222222222222222222222222222222",
+      "sha256": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "mediaType": "text/markdown"
+    },
+    "structuredSubmissionRef": {
+      "uri": "artifact://sha256/3333333333333333333333333333333333333333333333333333333333333333",
+      "sha256": "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+      "mediaType": "application/json"
+    },
+    "artifacts": []
+  },
+  "checks": [
+    {
+      "name": "schemas typecheck",
+      "commandHash": "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+      "status": "passed",
+      "evidenceRef": {
+        "uri": "artifact://sha256/5555555555555555555555555555555555555555555555555555555555555555",
+        "sha256": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "mediaType": "text/plain"
+      }
+    }
+  ],
+  "verification": {
+    "verified": true,
+    "decision": "accept",
+    "verifier": {
+      "type": "verifier",
+      "id": "independent-verifier"
+    },
+    "planHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "decisionRef": {
+      "uri": "artifact://sha256/6666666666666666666666666666666666666666666666666666666666666666",
+      "sha256": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+      "mediaType": "application/json"
+    },
+    "decisionHash": "sha256:6666666666666666666666666666666666666666666666666666666666666666",
+    "evidenceRefs": [
+      {
+        "uri": "artifact://sha256/5555555555555555555555555555555555555555555555555555555555555555",
+        "sha256": "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+        "mediaType": "text/plain"
+      }
+    ],
+    "verifiedAt": "2026-07-23T12:30:00.000Z"
+  },
+  "openQuestions": [],
+  "eligibleForPrOpen": true,
+  "generatedAt": "2026-07-23T12:30:01.000Z"
+}

--- a/test/unit/agent-integration-contracts.test.ts
+++ b/test/unit/agent-integration-contracts.test.ts
@@ -1,0 +1,406 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  agentRunProjectionV1Schema,
+  agentTaskApprovalHashMatches,
+  agentTaskV1Schema,
+  assertAgentRunProjectionWithinTask,
+  assertVerifiedHandoffMatchesTaskAndRun,
+  canonicalContractJson,
+  hashAgentTaskApprovalPayload,
+  hashCanonicalContract,
+  hermesDecisionRecordV2Schema,
+  parseHermesDecisionRecord,
+  parseLegacyCodexTask,
+  toHermesDecisionCompatibilityView,
+  toLegacyAgentTaskCompatibilityView,
+  verifiedHandoffV1Schema,
+  type AgentTaskV1,
+} from "../../packages/schemas/src/index.js";
+
+describe("INT-0 agent integration contracts", () => {
+  it("accepts every published current-version fixture", () => {
+    const cases = [
+      [agentTaskV1Schema, fixture("agent-task-v1.json")],
+      [agentRunProjectionV1Schema, fixture("agent-run-projection-v1.json")],
+      [verifiedHandoffV1Schema, fixture("verified-handoff-v1.json")],
+      [hermesDecisionRecordV2Schema, fixture("hermes-decision-v2.json")],
+    ] as const;
+    for (const [schema, input] of cases) {
+      const parsed = schema.parse(input);
+      expect(schema.parse(JSON.parse(JSON.stringify(parsed)))).toEqual(parsed);
+    }
+  });
+
+  it("rejects unknown versions and undeclared fields", () => {
+    const task = fixtureRecord("agent-task-v1.json");
+    expect(() => agentTaskV1Schema.parse({ ...task, schemaVersion: 2 })).toThrow();
+    expect(() => agentTaskV1Schema.parse({ ...task, undeclaredAuthority: true })).toThrow();
+
+    const decision = fixtureRecord("hermes-decision-v2.json");
+    expect(() => parseHermesDecisionRecord({ ...decision, schemaVersion: 3 })).toThrow();
+  });
+
+  it("rejects inconsistent hashes, duplicate authority, and child delegation", () => {
+    const task = fixtureRecord("agent-task-v1.json");
+    expect(() => agentTaskV1Schema.parse({
+      ...task,
+      intent: {
+        ...(task.intent as Record<string, unknown>),
+        templateHash: hash("9"),
+      },
+    })).toThrow(/TaskIntent ref hash/);
+
+    const requestedAuthority = task.requestedAuthority as Record<string, unknown>;
+    expect(() => agentTaskV1Schema.parse({
+      ...task,
+      requestedAuthority: {
+        ...requestedAuthority,
+        delegable: true,
+      },
+    })).toThrow();
+    expect(() => agentTaskV1Schema.parse({
+      ...task,
+      requestedAuthority: {
+        ...requestedAuthority,
+        maxChildren: 1,
+        maxConcurrentChildren: 1,
+      },
+    })).toThrow(/zero child budgets/);
+    expect(() => agentTaskV1Schema.parse({
+      ...task,
+      requestedAuthority: {
+        ...requestedAuthority,
+        grants: [
+          ...requestedAuthority.grants as unknown[],
+          ...(requestedAuthority.grants as unknown[]),
+        ],
+      },
+    })).toThrow(/capability grant ids must be unique/);
+  });
+
+  it("keeps request and approval authority out of executor and verifier roles", async () => {
+    const task = fixtureRecord("agent-task-v1.json");
+    expect(() => agentTaskV1Schema.parse({
+      ...task,
+      proposal: {
+        ...(task.proposal as Record<string, unknown>),
+        requestedBy: { type: "harness", id: "executor" },
+      },
+    })).toThrow(/cannot request/);
+
+    const approved = await approvedTask();
+    expect(() => agentTaskV1Schema.parse({
+      ...approved,
+      approval: {
+        ...approved.approval,
+        actor: { type: "harness", id: "executor" },
+      },
+    })).toThrow(/cannot be decided/);
+  });
+});
+
+describe("canonical contract hashing and approval binding", () => {
+  it("serializes recursively by code-unit key order and hashes deterministically", async () => {
+    expect(canonicalContractJson({ b: 2, a: { d: 4, c: 3 } }))
+      .toBe('{"a":{"c":3,"d":4},"b":2}');
+    await expect(hashCanonicalContract({ b: 2, a: 1 })).resolves.toBe(
+      "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+    );
+    await expect(hashCanonicalContract({ a: 1, b: 2 })).resolves.toBe(
+      "sha256:43258cff783fe7036d8a43033f830adfc60ec037382473548ac742b888292777",
+    );
+  });
+
+  it("rejects values that cannot have an unambiguous authorization hash", () => {
+    expect(() => canonicalContractJson({ missing: undefined })).toThrow(/undefined field/);
+    expect(() => canonicalContractJson({ invalid: Number.NaN })).toThrow(/non-finite/);
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    expect(() => canonicalContractJson(cyclic)).toThrow(/cyclic/);
+  });
+
+  it("binds approval to immutable task content and invalidates material edits", async () => {
+    const task = await approvedTask();
+    await expect(agentTaskApprovalHashMatches(task)).resolves.toBe(true);
+
+    const changed = agentTaskV1Schema.parse({
+      ...task,
+      proposal: {
+        ...task.proposal,
+        objective: "A materially different objective.",
+      },
+    });
+    await expect(agentTaskApprovalHashMatches(changed)).resolves.toBe(false);
+  });
+
+  it("does not treat lifecycle bookkeeping as approved task content", async () => {
+    const proposed = agentTaskV1Schema.parse(fixture("agent-task-v1.json"));
+    const approved = await approvedTask();
+    await expect(hashAgentTaskApprovalPayload(proposed)).resolves.toBe(
+      await hashAgentTaskApprovalPayload(approved),
+    );
+  });
+});
+
+describe("task-to-run authority attenuation", () => {
+  it("accepts an identity-matched projection within approved grants and budgets", async () => {
+    const task = await approvedTask();
+    const projection = agentRunProjectionV1Schema.parse(fixture("agent-run-projection-v1.json"));
+    expect(() => assertAgentRunProjectionWithinTask(task, projection)).not.toThrow();
+  });
+
+  it("rejects capability, network, budget, policy, and identity expansion", async () => {
+    const task = await approvedTask();
+    const base = agentRunProjectionV1Schema.parse(fixture("agent-run-projection-v1.json"));
+
+    const capabilityExpansion = agentRunProjectionV1Schema.parse({
+      ...base,
+      manifest: {
+        ...base.manifest,
+        effectiveCapabilities: ["fs.write_file", "shell.run"],
+      },
+    });
+    expect(() => assertAgentRunProjectionWithinTask(task, capabilityExpansion))
+      .toThrow(/expands capability/);
+
+    const networkExpansion = agentRunProjectionV1Schema.parse({
+      ...base,
+      manifest: {
+        ...base.manifest,
+        network: { allowlist: ["example.com"] },
+      },
+    });
+    expect(() => assertAgentRunProjectionWithinTask(task, networkExpansion))
+      .toThrow(/network access/);
+
+    const budgetExpansion = agentRunProjectionV1Schema.parse({
+      ...base,
+      budget: {
+        ...base.budget,
+        toolCallsLimit: task.budget.toolCalls + 1,
+      },
+    });
+    expect(() => assertAgentRunProjectionWithinTask(task, budgetExpansion))
+      .toThrow(/budget exceeds/);
+
+    const policyMismatch = agentRunProjectionV1Schema.parse({
+      ...base,
+      manifest: {
+        ...base.manifest,
+        policyHash: hash("9"),
+      },
+    });
+    expect(() => assertAgentRunProjectionWithinTask(task, policyMismatch))
+      .toThrow(/policy hash/);
+
+    const identityMismatch = agentRunProjectionV1Schema.parse({
+      ...base,
+      workItemId: "work-other",
+    });
+    expect(() => assertAgentRunProjectionWithinTask(task, identityMismatch))
+      .toThrow(/identity/);
+  });
+
+  it("requires degraded and failed projections to explain themselves", () => {
+    const base = agentRunProjectionV1Schema.parse(fixture("agent-run-projection-v1.json"));
+    expect(() => agentRunProjectionV1Schema.parse({
+      ...base,
+      source: {
+        ...base.source,
+        health: "unavailable",
+      },
+    })).toThrow(/explicit reason/);
+    expect(() => agentRunProjectionV1Schema.parse({
+      ...base,
+      heartbeat: { ...base.heartbeat, status: "terminal" },
+      run: {
+        ...base.run,
+        state: "failed",
+        terminal: true,
+        outcome: "failed",
+      },
+    })).toThrow(/structured failure details/);
+  });
+});
+
+describe("verified handoff eligibility", () => {
+  it("accepts a completed independently verified handoff with all checks passed", () => {
+    const handoff = verifiedHandoffV1Schema.parse(fixture("verified-handoff-v1.json"));
+    expect(handoff.eligibleForPrOpen).toBe(true);
+    expect(handoff.verification.verifier.type).toBe("verifier");
+  });
+
+  it("never permits failed checks, rejected verification, or a non-verifier to open a PR", () => {
+    const handoff = fixtureRecord("verified-handoff-v1.json");
+    expect(() => verifiedHandoffV1Schema.parse({
+      ...handoff,
+      checks: [{
+        ...(handoff.checks as Array<Record<string, unknown>>)[0],
+        status: "failed",
+      }],
+    })).toThrow(/every recorded check/);
+
+    expect(() => verifiedHandoffV1Schema.parse({
+      ...handoff,
+      verification: {
+        ...(handoff.verification as Record<string, unknown>),
+        verified: false,
+        decision: "reject",
+      },
+    })).toThrow(/verified acceptance/);
+
+    expect(() => verifiedHandoffV1Schema.parse({
+      ...handoff,
+      verification: {
+        ...(handoff.verification as Record<string, unknown>),
+        verifier: { type: "harness", id: "executor" },
+      },
+    })).toThrow(/verifier type/);
+  });
+
+  it("binds an eligible handoff to the exact approved task, run, manifest, and verifier plan", async () => {
+    const task = await approvedTask();
+    const running = agentRunProjectionV1Schema.parse(fixture("agent-run-projection-v1.json"));
+    const handoffFixture = fixtureRecord("verified-handoff-v1.json");
+    const handoffDecisionHash = (
+      (handoffFixture.verification as Record<string, unknown>).decisionHash
+    ) as string;
+    const handoffDecisionRef = (
+      (handoffFixture.verification as Record<string, unknown>).decisionRef
+    ) as Record<string, unknown>;
+    const completed = agentRunProjectionV1Schema.parse({
+      ...running,
+      heartbeat: {
+        ...running.heartbeat,
+        status: "terminal",
+      },
+      run: {
+        ...running.run,
+        state: "completed",
+        terminal: true,
+        outcome: "completed",
+      },
+      verification: {
+        status: "passed",
+        decisionRef: handoffDecisionRef,
+        decisionHash: handoffDecisionHash,
+      },
+    });
+    const handoff = verifiedHandoffV1Schema.parse({
+      ...handoffFixture,
+      taskHash: task.approval.approvedTaskHash,
+    });
+
+    await expect(
+      assertVerifiedHandoffMatchesTaskAndRun(task, completed, handoff),
+    ).resolves.toBeUndefined();
+
+    const wrongManifest = verifiedHandoffV1Schema.parse({
+      ...handoff,
+      runManifestRef: {
+        ...handoff.runManifestRef,
+        sha256: hash("9"),
+      },
+      runManifestHash: hash("9"),
+    });
+    await expect(
+      assertVerifiedHandoffMatchesTaskAndRun(task, completed, wrongManifest),
+    ).rejects.toThrow(/manifest hash/);
+  });
+});
+
+describe("legacy read compatibility", () => {
+  it("reads V1 Hermes decisions without rewriting them", () => {
+    const input = fixture("legacy-hermes-decision-v1.json");
+    const parsed = parseHermesDecisionRecord(input);
+    const view = toHermesDecisionCompatibilityView(input);
+
+    expect(parsed).toEqual(input);
+    expect(view).toMatchObject({
+      sourceVersion: 1,
+      decisionType: "routing",
+      approvalDecision: "routed to codex",
+      mutates: false,
+      legacy: true,
+    });
+  });
+
+  it("reads legacy codex_task records conservatively and keeps them non-dispatchable", () => {
+    const input = fixture("legacy-codex-task-v1.json");
+    const parsed = parseLegacyCodexTask(input);
+    const view = toLegacyAgentTaskCompatibilityView(input);
+
+    expect(parsed.progressMessage).toBe(
+      "Historical fields are preserved by the compatibility reader.",
+    );
+    expect(view).toMatchObject({
+      workItemId: "codex-task-owner-repo-new-legacy",
+      executor: { kind: "direct", directAgent: "codex" },
+      legacyRiskTier: "unknown",
+      nonDispatchable: true,
+    });
+    expect(view.missingRequiredAgentTaskFields).toContain("taskIntentRef");
+    expect(view.missingRequiredAgentTaskFields).toContain("approvalPolicyHash");
+  });
+
+  it("rejects malformed legacy records instead of manufacturing missing identity", () => {
+    const legacy = fixtureRecord("legacy-codex-task-v1.json");
+    expect(() => parseLegacyCodexTask({ ...legacy, id: "" })).toThrow();
+    expect(() => parseLegacyCodexTask({ ...legacy, schemaVersion: 2 })).toThrow();
+  });
+
+  it("makes mutation truth explicit in V2 decisions", () => {
+    const decision = fixtureRecord("hermes-decision-v2.json");
+    expect(() => hermesDecisionRecordV2Schema.parse({
+      ...decision,
+      effects: {
+        mutates: false,
+        mutations: [{
+          system: "github",
+          action: "open_pr",
+          target: "owner/repo",
+        }],
+        authorityChanged: false,
+        budgetChanged: false,
+      },
+    })).toThrow(/non-mutating decisions/);
+  });
+});
+
+async function approvedTask(): Promise<AgentTaskV1> {
+  const proposed = agentTaskV1Schema.parse(fixture("agent-task-v1.json"));
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(proposed);
+  return agentTaskV1Schema.parse({
+    ...proposed,
+    lifecycle: "approved",
+    approval: {
+      ...proposed.approval,
+      status: "approved",
+      actor: { type: "operator", id: "operator-one" },
+      decidedAt: "2026-07-23T12:01:00.000Z",
+      approvedTaskHash,
+    },
+    timestamps: {
+      ...proposed.timestamps,
+      approvedAt: "2026-07-23T12:01:00.000Z",
+      updatedAt: "2026-07-23T12:01:00.000Z",
+    },
+  });
+}
+
+function fixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(new URL(`../fixtures/agent-integration/${name}`, import.meta.url), "utf8"),
+  ) as unknown;
+}
+
+function fixtureRecord(name: string): Record<string, unknown> {
+  return fixture(name) as Record<string, unknown>;
+}
+
+function hash(character: string): `sha256:${string}` {
+  return `sha256:${character.repeat(64)}`;
+}


### PR DESCRIPTION
## What changed

- adds the reviewed Agent Harness integration charter and INT-0 handback
- adds strict versioned `AgentTask`, `AgentRunProjection`, `VerifiedHandoff`, and `HermesDecisionRecord` contracts in `@avg/schemas`
- adds canonical SHA-256 approval hashing and pure cross-contract identity, policy, capability, network, budget, and verification assertions
- adds conservative read-only compatibility readers for Hermes decision V1 and legacy `codex_task` V1 records; legacy tasks remain explicitly non-dispatchable
- adds six JSON fixtures and 18 focused invariant tests

## Why

INT-1 read-only Harness visibility needs a reviewed, versioned boundary first. These contracts establish stable identities, source/authority separation, exact approval binding, and verified-handoff eligibility without changing any operational path.

## Validation

- `npm run typecheck` — passed
- `npx vitest run test/unit/agent-integration-contracts.test.ts` — 18/18 passed
- `npm test` — 176 files and 2,172 tests passed

One intermediate full-suite run observed the existing screencast timing test fail; its isolated rerun passed 3/3 and the final uninterrupted full suite passed. INT-0 does not touch that path.

## Affected surfaces

- shared schemas: yes
- docs and tests: yes
- MCP runtime: no
- monitor / Slack operator / task runners: no
- ops / compose / Caddy / environment: no
- Averray platform / indexer / contracts / public site: no
- generic Agent Harness kernel: no

## Environment and rollout

No environment variables, VPS secrets, migrations, dependencies, or lockfile changes are required. This PR adds no dispatch, GitHub mutation, settlement, wallet, deployment, or production authority.

Rollback is removal of the new schema modules, exports, fixtures, and documentation; there is no persisted state to migrate.