### PR TITLE
feat(harness): add INT-1 read-only projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,17 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   not merge, deploy, submit work, or run guarded live mutations during a handoff:
   its powers stay inside the **Durable invariants** above — gated, budgeted, and
   never extending to auto-merge or auto-deploy.
+- **Generic Agent Harness projection is observation-only (INT-1, off by
+  default).** When `HARNESS_PROJECTION_ENABLED` is explicitly enabled, the
+  Slack operator may inspect only allowlisted immutable Harness run IDs through
+  fixed `run status`, `run events`, and terminal `run deliverables` CLI reads.
+  The secret-free registry pins the final manifest metadata used by the board.
+  Unknown states/events, source denial, stale reads, or pin mismatches fail
+  visibly; they never become healthy cards. This path cannot submit, approve,
+  deny, cancel, release, dispatch, mutate GitHub/Averray, or read artifact
+  contents. Harness contributes structured run facts and a card tag; Hermes
+  remains the only conversational board voice. No Harness dispatcher exists
+  until a later separately guarded packet.
 - **Self-healing (B2, off by default).** On a failure signal (failed testbed
   mission, failed deploy/verification), Hermes auto-**proposes** a routed fix
   task (non-high-risk) — which still lands `proposed` and flows through the same

--- a/docs/HARNESS_INT1_HANDBACK.md
+++ b/docs/HARNESS_INT1_HANDBACK.md
@@ -1,0 +1,162 @@
+# INT-1 handback — read-only Harness projection
+
+**Status:** implementation complete; pending review and live-pilot proof
+
+**Branch:** `codex/harness-int1-projection`
+
+**Baseline:** `3e559b85d99219ef3dc9ff174f30e9275af92512` (`origin/main`, merged INT-0)
+
+**Runtime authority change:** read-only observation only, off by default
+
+## Built
+
+- Added a strict, secret-free pilot registry for immutable
+  `workItemId` / `correlationId` / `harnessRunId` bindings.
+- The registry pins final manifest metadata that the current generic Harness
+  CLI does not expose through `run status`, including profile, risk class,
+  effective capabilities, network policy, policy/verifier hashes, model
+  bindings, skill versions, and budget limits.
+- Added a fixed-argv CLI adapter that permits only:
+  - `harness run status <known-run-id>`;
+  - `harness run events <known-run-id>`;
+  - `harness run deliverables <known-terminal-run-id>`.
+- The adapter uses no shell interpolation, applies a timeout and combined output
+  cap, validates run identity/state/event vocabulary, parses immutable artifact
+  references, and does not surface raw stderr credentials.
+- Added a deterministic mapper into the shared `AgentRunProjection` V1
+  contract. It reports:
+  - source health and staleness;
+  - run state, attempt, terminal outcome, and failure;
+  - pinned manifest identity and effective authority;
+  - elapsed/model/tool usage derived from status/events;
+  - verification status and report hash;
+  - immutable deliverable artifacts;
+  - Harness/Averray/PR bindings when present.
+- Correlated projections join the existing monitor board by work item or
+  correlation ID. A legacy item and Harness projection cannot produce duplicate
+  cards; once a PR exists, GitHub remains lane-authoritative and the Harness
+  facts attach to that card.
+- Source denial, malformed/unknown output, stale reads, and manifest mismatches
+  become degraded/attention state. They never reuse or extend a healthy signal.
+- Added an explicit Harness tag, structured card progress, a manifest/budget/
+  artifact drawer, and a read-only authority notice.
+- Renamed visible shared-lane copy to **Work queue** while preserving the
+  internal `codex-needed` lane ID and existing API/card compatibility.
+- Hermes narration receives only bounded structured Harness facts. It does not
+  receive raw event payloads or model messages, and Harness never speaks in the
+  collaboration channel.
+
+## Feature configuration
+
+The path is a no-op unless explicitly enabled:
+
+```text
+HARNESS_PROJECTION_ENABLED=false
+```
+
+When an operator is ready to run the live pilot, configure:
+
+```text
+HARNESS_PROJECTION_ENABLED=true
+HARNESS_PROJECTION_BINDINGS_PATH=/run/secrets-free-config/harness-run-registry.json
+HARNESS_CLI_COMMAND=harness
+HARNESS_PROJECTION_READ_TIMEOUT_MS=5000
+```
+
+`HARNESS_PROJECTION_BINDINGS_PATH` is configuration, not a secret. Its schema is
+demonstrated by `test/fixtures/harness-integration/pilot-registry-v1.json`.
+The Harness CLI's own data-source credential remains runtime secret material and
+must not be copied into that file, logs, prompts, or the board.
+
+## Safety pins
+
+1. The registry rejects unknown versions, undeclared fields, duplicate work,
+   correlation, or run identities, and secret-like keys/values.
+2. Every CLI invocation is generated from a fixed read-only verb plus a
+   schema-validated allowlisted run ID.
+3. No submit, approve, deny, cancel, release, artifact-content, skill, wallet,
+   GitHub-write, Averray-mutation, or dispatch command exists in the adapter.
+4. Unknown Harness states or event types fail visibly rather than being coerced
+   into current state.
+5. The live egress policy, compiled risk class, and observed model role/ref must
+   agree with the pinned manifest when the CLI exposes them.
+6. Terminal deliverables are content-addressed references only; INT-1 does not
+   read artifact contents.
+7. Failed and quarantined records require structured failure detail.
+8. The same status/event/deliverable inputs and observation time produce the
+   same projection.
+9. Harness cards have no dispatch, retry, approval, merge, or send-back control.
+   “Ask Hermes” remains advisory.
+10. The flag defaults off and no `HARNESS_DISPATCH_ENABLED` path exists.
+
+## Live-pilot proof still required
+
+This development environment had no `HARNESS_DATABASE_URL`, Harness CLI
+executable, or operator-selected immutable pilot IDs. The included successful,
+failed, and quarantined fixtures validate the current generic CLI grammar and
+projection behavior, but they are not claimed as production run evidence.
+
+Before INT-1 is accepted for rollout, an operator must:
+
+1. create/select one real successful and one real failed bounded Harness run;
+2. record their immutable IDs and final manifest pins in a secret-free registry;
+3. enable the flag in a non-production or supervised pilot environment;
+4. capture the board proof for both cards;
+5. deny/stop the read source once and confirm the card becomes degraded rather
+   than healthy;
+6. disable the flag after the proof unless the operator explicitly approves the
+   continued read-only pilot.
+
+This is a rollout proof, not a reason to add a dispatcher or broaden authority.
+
+## Affected surfaces
+
+- Shared schema package: exported manifest projection schema only; V1 wire shape
+  unchanged
+- Slack operator: read-only Harness registry/CLI/projection source
+- Monitor board and Hermes narration: yes
+- Monitor UI: Harness facts and visible Work queue copy
+- Tests/fixtures/docs/working agreement: yes
+- Existing Codex/Claude runners and task queue: unchanged
+- Policy allowlists and budgets: unchanged
+- Ops/compose/environment files: unchanged
+- GitHub/Averray/wallet/settlement/deploy mutation paths: unchanged
+- Generic Agent Harness repository: unchanged
+
+## Dependencies
+
+The monitor UI and Slack operator now declare the existing workspace
+`@avg/schemas` package directly. The Slack operator also declares the repository's
+existing `zod` version directly because it validates the pilot registry. No new
+third-party package or lifecycle script was introduced.
+
+## Rollback
+
+Set `HARNESS_PROJECTION_ENABLED=false` for immediate rollback. The default-off
+code path performs no registry read and starts no Harness CLI process.
+
+Code rollback removes the three `harness-*` Slack-operator modules, monitor/UI
+projection fields and presentation, the direct workspace dependencies, fixtures,
+tests, and this handback. No stored data, migration, external mutation, or
+Harness run needs reversal. The internal `codex-needed` lane ID never changed.
+
+## Verification
+
+```text
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  177 passed (177)
+Tests       2192 passed (2192)
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+```
+
+The first sandboxed full-suite attempt completed typecheck and 2,187 tests but
+the sandbox denied loopback binding for the two existing test-wallet-signer HTTP
+tests. After correcting one new test expectation, the final full suite was
+rerun with loopback permission and passed 2,192/2,192.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5185,6 +5185,7 @@
       "name": "@avg/monitor-ui",
       "version": "0.1.0",
       "dependencies": {
+        "@avg/schemas": "0.1.0",
         "focus-trap-react": "^11.0.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5260,7 +5261,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@avg/averray-mcp": "0.1.0",
-        "@avg/mcp-common": "0.1.0"
+        "@avg/mcp-common": "0.1.0",
+        "@avg/schemas": "0.1.0",
+        "zod": "^3.24.1"
       }
     },
     "services/test-wallet-signer": {

--- a/packages/monitor-ui/package.json
+++ b/packages/monitor-ui/package.json
@@ -14,6 +14,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@avg/schemas": "0.1.0",
     "focus-trap-react": "^11.0.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/monitor-ui/src/components/Board.tsx
+++ b/packages/monitor-ui/src/components/Board.tsx
@@ -21,7 +21,7 @@ import type { BoardCard, Lane as LaneKey } from "../lib/monitor/card-types.js";
 export const LANE_DESCRIPTORS: readonly LaneDescriptor[] = [
   { id: "needs-attention", name: "Needs attention", action: "Review decision waiting", isAction: true },
   { id: "drafts", name: "Drafts", action: "Author finishes" },
-  { id: "codex-needed", name: "Codex needed", action: "Create / approve task" },
+  { id: "codex-needed", name: "Work queue", action: "Harness and builder work" },
   { id: "hermes-checking", name: "Hermes checking", action: "Pre-check in flight" },
   { id: "operator-review", name: "Operator review", action: "Risk decision" },
   { id: "release-queue", name: "Release queue", action: "Branch protection" },

--- a/packages/monitor-ui/src/components/BoardView.test.tsx
+++ b/packages/monitor-ui/src/components/BoardView.test.tsx
@@ -47,7 +47,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     const { container } = render(<BoardView board={richBoard} status="open" />);
     const view = within(container);
     expect(view.getByRole("region", { name: "Your decisions lane" })).toBeTruthy();
-    expect(view.getByRole("region", { name: "Builder tasks lane" })).toBeTruthy();
+    expect(view.getByRole("region", { name: "Work queue lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Drafts lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Hermes checking lane" })).toBeTruthy();
     expect(view.getByRole("region", { name: "Release queue lane" })).toBeTruthy();
@@ -323,7 +323,7 @@ describe("BoardView — rich-mix board (open stream)", () => {
     );
 
     const inbox = getByRole("region", { name: "Your decisions lane" });
-    const pipeline = getByRole("region", { name: "Builder tasks lane" });
+    const pipeline = getByRole("region", { name: "Work queue lane" });
     expect(within(inbox).getByRole("button", { name: /Approve & dispatch/ })).toBeTruthy();
     expect(within(pipeline).queryByRole("button", { name: /Approve & dispatch/ })).toBeNull();
     expect(within(pipeline).getByText("Fix the failed mission")).toBeTruthy();

--- a/packages/monitor-ui/src/components/KanbanBoard.test.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.test.tsx
@@ -49,7 +49,7 @@ describe("KanbanBoard", () => {
     const { getByRole } = render(
       <KanbanBoard grouped={g} expanded={expandedFor("codex-needed", "done")} onToggleLane={() => {}} renderCard={renderCard} />,
     );
-    expect(getByRole("region", { name: "Builder tasks lane" })).toBeTruthy();
+    expect(getByRole("region", { name: "Work queue lane" })).toBeTruthy();
     expect(getByRole("region", { name: "Done lane" })).toBeTruthy();
   });
 
@@ -81,7 +81,7 @@ describe("KanbanBoard", () => {
       <KanbanBoard grouped={g} expanded={expandedFor("codex-needed")} onToggleLane={onToggleLane} renderCard={renderCard} />,
     );
     expect(queryByRole("button", { name: /Collapse Your decisions lane/ })).toBeNull();
-    fireEvent.click(getByRole("button", { name: "Collapse Builder tasks lane" }));
+    fireEvent.click(getByRole("button", { name: "Collapse Work queue lane" }));
     expect(onToggleLane).toHaveBeenCalledWith("codex-needed");
   });
 

--- a/packages/monitor-ui/src/components/Lane.tsx
+++ b/packages/monitor-ui/src/components/Lane.tsx
@@ -24,7 +24,7 @@ export type { LaneDescriptor, LaneId };
 const LANE_EMPTY_COPY: Partial<Record<LaneId, string>> = {
   "needs-attention": "Nothing needs your review right now.",
   drafts: "No drafts in progress.",
-  "codex-needed": "No tasks waiting to be created.",
+  "codex-needed": "No Harness or builder work queued.",
   "hermes-checking": "Nothing in pre-check right now.",
   "operator-review": "Nothing waiting on your risk decision.",
   "release-queue": "Release queue is empty.",

--- a/packages/monitor-ui/src/components/TopStrip.test.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.test.tsx
@@ -42,7 +42,7 @@ describe("TopStrip", () => {
     const { getByText } = render(<TopStrip counts={busyCounts} />);
     // Each KPI label is present; the count lives in the sibling `.n` span.
     expect(getByText("Action needed")).toBeTruthy();
-    expect(getByText("Codex needed")).toBeTruthy();
+    expect(getByText("Work queue")).toBeTruthy();
     expect(getByText("Operator review")).toBeTruthy();
     expect(getByText("Hermes checking")).toBeTruthy();
     expect(getByText("Release queue")).toBeTruthy();

--- a/packages/monitor-ui/src/components/TopStrip.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.tsx
@@ -57,7 +57,7 @@ export function TopStrip({ counts, liveAt, deployHealth = "OK", automationHealth
         ) : (
           <>
             <Kpi count={counts.action} label="Action needed" tone={counts.action ? "action" : "zero"} />
-            <Kpi count={counts.codex} label="Codex needed" tone={counts.codex ? "default" : "zero"} />
+            <Kpi count={counts.codex} label="Work queue" tone={counts.codex ? "default" : "zero"} />
             <Kpi count={counts.review} label="Operator review" tone={counts.review ? "action" : "zero"} />
             <Kpi count={counts.checking} label="Hermes checking" tone={counts.checking ? "default" : "zero"} />
             <Kpi count={counts.queue} label="Release queue" tone={counts.queue ? "default" : "zero"} />

--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { cleanup, fireEvent, render, within } from "@testing-library/react";
 import { Card, deriveDecisionCardReason } from "./Card.js";
 import { FIXTURE_CARDS } from "../../lib/monitor/fixtures.js";
 import type { BoardCard, MissionCard, PRCard } from "../../lib/monitor/card-types.js";
+import type { AgentRunProjectionV1 } from "@avg/schemas";
 
 afterEach(cleanup);
 
@@ -11,6 +13,27 @@ function fixture(id: string): BoardCard {
   const card = FIXTURE_CARDS.find((c) => c.id === id);
   if (!card) throw new Error(`fixture not found: ${id}`);
   return card;
+}
+
+function harnessCard(): BoardCard {
+  const harnessRun = JSON.parse(
+    readFileSync("test/fixtures/agent-integration/agent-run-projection-v1.json", "utf8"),
+  ) as AgentRunProjectionV1;
+  return {
+    id: harnessRun.workItemId,
+    lane: "codex-needed",
+    type: "task",
+    agentType: "harness",
+    title: "Bounded Harness run",
+    summary: harnessRun.progress.summary,
+    repo: "depre-dev/agent",
+    freshness: 0,
+    state: "running",
+    risk: [],
+    waitingOn: { actor: "agent", tone: "info" },
+    taskStatus: "running",
+    harnessRun,
+  };
 }
 
 describe("Card — type coverage", () => {
@@ -75,6 +98,16 @@ describe("Card — type coverage", () => {
     const view = within(container);
     expect(view.getByText("Reduce audit-log noise when policy auto-applies")).toBeTruthy();
     expect(container.querySelector(".hm-checks-bar")).toBeNull();
+  });
+
+  test("Harness card renders an explicit tag and structured read-only progress", () => {
+    const { container } = render(<Card card={harnessCard()} />);
+    const view = within(container);
+    expect(view.getAllByText("Harness").length).toBeGreaterThan(0);
+    expect(view.getByText("executing")).toBeTruthy();
+    expect(view.getByText("Executing the bounded task.")).toBeTruthy();
+    expect(view.getByText("verification pending")).toBeTruthy();
+    expect(view.getByText("0 artifacts")).toBeTruthy();
   });
 
   test("a routed task's long machine id collapses to a short handle in the header", () => {

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -68,7 +68,7 @@ export type CardProps = {
 // ── Helpers (mirror the bundle's small inline helpers) ──────────────
 
 function agentLabel(t: AgentType | undefined): string {
-  if (t === "codex" || t === "claude" || t === "test-writer" || t === "security" || t === "docs" || t === "hermes") return t;
+  if (t === "codex" || t === "claude" || t === "test-writer" || t === "security" || t === "docs" || t === "hermes" || t === "harness") return t;
   return "ext";
 }
 
@@ -251,13 +251,15 @@ export function Card({
         </div>
       ) : null}
 
-      {cardSummary && !isClosed && !isInboxCard ? (
+      {cardSummary && !isClosed && !isInboxCard && !card.harnessRun ? (
         <div className="hm-card-meta" style={{ lineHeight: 1.5 }}>
           <span style={{ color: "var(--hm-ink-soft)", fontFamily: "var(--font-body)", fontSize: 12 }}>
             <HumanizedText text={cardSummary} />
           </span>
         </div>
       ) : null}
+
+      {!isClosed && card.harnessRun && !isInboxCard ? <HarnessRunSummary card={card} /> : null}
 
       {!isClosed && card.type === "mission" && !isInboxCard ? <MissionRunSummary card={card} /> : null}
 
@@ -440,6 +442,37 @@ function WorkingNowLine({ workingNow }: { workingNow: CardWorkingNow }) {
     <div className="hm-working-now" aria-label={`Working now: ${workingNow.label}`} title={details || undefined}>
       <AgentTag agent={workingNow.agent} label="working now" />
       <span className="target">{workingNow.label}</span>
+    </div>
+  );
+}
+
+function HarnessRunSummary({ card }: { card: BoardCard }) {
+  const run = card.harnessRun;
+  if (!run) return null;
+  const sourceTone: StateVariant = run.source.health === "healthy"
+    ? "pass"
+    : run.source.health === "stale"
+      ? "age"
+      : "degraded";
+  const verification = run.verification?.status ?? "pending";
+  const verificationTone: StateVariant = verification === "passed"
+    ? "pass"
+    : verification === "failed" || verification === "inconclusive"
+      ? "fail"
+      : "pending";
+  return (
+    <div className="hm-harness-run" aria-label={`Harness run ${run.run.state}`}>
+      <div className="hm-harness-run-top">
+        <Badge variant="info" dot>Harness</Badge>
+        <StatusPill variant={run.run.terminal ? "neutral" : "running"}>{run.run.state}</StatusPill>
+        <StatusPill variant={sourceTone}>{run.source.health}</StatusPill>
+      </div>
+      <div className="hm-harness-run-progress">{run.progress.summary}</div>
+      <div className="hm-harness-run-meta">
+        <StatusPill variant={verificationTone}>verification {verification}</StatusPill>
+        <span>{run.artifacts.length} artifact{run.artifacts.length === 1 ? "" : "s"}</span>
+        <span>attempt {run.run.attempt}</span>
+      </div>
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.tsx
@@ -28,7 +28,7 @@ import { ChecksBar } from "../cards/ChecksBar.js";
 import { deriveDecisionCardReason, deriveWhatHappensNext } from "../cards/Card.js";
 import { OperatorNotes } from "./OperatorNotes.js";
 
-export type DrawerVariant = "mission" | "action" | "done" | "draft" | "task" | "deploy" | "pr";
+export type DrawerVariant = "mission" | "action" | "done" | "draft" | "task" | "harness" | "deploy" | "pr";
 
 export interface DrawerAccent {
   /** Border + eyebrow accent variable. */
@@ -45,6 +45,7 @@ export const DRAWER_ACCENT: Record<DrawerVariant, DrawerAccent> = {
   done: { border: "var(--hm-sage)", pill: "hm-pill--ok", label: "Closed · in release history" },
   draft: { border: "var(--hm-muted)", pill: "hm-pill--draft", label: "Draft · author finishes" },
   task: { border: "var(--hm-sage)", pill: "hm-pill--neutral", label: "Codex task · awaiting dispatch" },
+  harness: { border: "var(--hm-hermes)", pill: "hm-pill--hermes", label: "Harness run · read-only projection" },
   deploy: { border: "var(--hm-sage)", pill: "hm-pill--neutral", label: "Deploying · post-merge verification" },
   pr: { border: "var(--hm-sage)", pill: "hm-pill--ok", label: "Automation in flight" },
 };
@@ -56,6 +57,7 @@ export const DRAWER_ACCENT: Record<DrawerVariant, DrawerAccent> = {
  *  closed, draft, and type. */
 export function drawerVariant(card: BoardCard): DrawerVariant {
   if (card.type === "mission") return "mission";
+  if (card.harnessRun) return "harness";
   if (card.isAction) return "action";
   const lane = laneFor(card);
   if (lane === "operator-review" || lane === "needs-attention") return "action";
@@ -80,6 +82,9 @@ export function DrawerBody({ card, variant }: { card: BoardCard; variant: Drawer
       break;
     case "task":
       body = <TaskBody card={card} />;
+      break;
+    case "harness":
+      body = <HarnessTaskBody card={card} />;
       break;
     case "draft":
       body = <DraftBody card={card} />;
@@ -569,6 +574,7 @@ function TaskBugPreview({ card, failureReason }: { card: BoardCard; prompt?: str
 }
 
 function TaskBody({ card }: { card: BoardCard }) {
+  if (card.harnessRun) return <HarnessTaskBody card={card} />;
   const prompt = "prompt" in card ? card.prompt : undefined;
   const heartbeat = "runnerHeartbeat" in card ? card.runnerHeartbeat : undefined;
   const failureReason = "failureReason" in card ? (card as { failureReason?: string }).failureReason : undefined;
@@ -597,6 +603,115 @@ function TaskBody({ card }: { card: BoardCard }) {
       ) : null}
     </>
   );
+}
+
+function HarnessTaskBody({ card }: { card: BoardCard }) {
+  const projection = card.harnessRun!;
+  const network = projection.manifest.network === "deny"
+    ? "deny all"
+    : projection.manifest.network.allowlist.join(", ");
+  const budgetRows = [
+    ["elapsed", budgetPair(projection.budget.elapsedSecondsUsed, projection.budget.elapsedSecondsLimit, "s")],
+    ["model tokens", budgetPair(projection.budget.modelTokensUsed, projection.budget.modelTokensLimit)],
+    ["tool calls", budgetPair(projection.budget.toolCallsUsed, projection.budget.toolCallsLimit)],
+  ] as const;
+  return (
+    <>
+      <VerdictBlock head="Read-only Harness run">{projection.progress.summary}</VerdictBlock>
+      <section>
+        <div className="hm-section-h">Run state</div>
+        <div className="hm-verdict-block">
+          <div className="head">{projection.run.state.toUpperCase()}</div>
+          <div className="body">
+            source {projection.source.health} · verification {projection.verification?.status ?? "pending"} · attempt {projection.run.attempt}
+            {projection.run.outcome ? ` · outcome ${projection.run.outcome}` : ""}
+          </div>
+          <div className="body hm-mono">
+            run {projection.harnessRunId} · work item {projection.workItemId} · correlation {projection.correlationId}
+          </div>
+          <div className="body hm-mono">
+            observed {projection.source.observedAt}
+            {projection.source.sourceUpdatedAt ? ` · source updated ${projection.source.sourceUpdatedAt}` : ""}
+          </div>
+        </div>
+      </section>
+      <section>
+        <div className="hm-section-h">Pinned manifest</div>
+        <div className="h4-bug">
+          <HarnessFact label="profile" value={`${projection.manifest.profile} · ${projection.manifest.riskClass} risk`} />
+          <HarnessFact label="manifest" value={projection.manifest.hash} mono />
+          <HarnessFact label="policy" value={projection.manifest.policyHash} mono />
+          <HarnessFact label="verifier" value={projection.manifest.verifierHash} mono />
+          <HarnessFact label="network" value={network} />
+          <HarnessFact
+            label="capabilities"
+            value={projection.manifest.effectiveCapabilities.length
+              ? projection.manifest.effectiveCapabilities.join(", ")
+              : "none"}
+          />
+          <HarnessFact
+            label="models"
+            value={projection.manifest.modelBindings.length
+              ? projection.manifest.modelBindings
+                .map((binding) =>
+                  `${binding.role}: ${binding.provider}/${binding.modelRef} via ${binding.adapter} · ${binding.profileHash}`)
+                .join(", ")
+              : "none"}
+          />
+          <HarnessFact
+            label="skills"
+            value={projection.manifest.skillVersions.length
+              ? projection.manifest.skillVersions.join(", ")
+              : "none"}
+          />
+        </div>
+      </section>
+      <section>
+        <div className="hm-section-h">Budget</div>
+        <div className="h4-bug">
+          {budgetRows.map(([label, value]) => <HarnessFact key={label} label={label} value={value} />)}
+          <HarnessFact label="exhausted" value={projection.budget.exhausted ? "yes" : "no"} />
+        </div>
+      </section>
+      <section>
+        <div className="hm-section-h">Immutable artifacts</div>
+        {projection.artifacts.length > 0 ? (
+          <div className="hm-files">
+            {projection.artifacts.map((artifact) => (
+              <div className="hm-file-row" key={artifact.uri}>
+                <span className="hm-mono">{artifact.uri}</span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <AwaitingData label="Artifacts" note="Harness has not recorded a deliverable artifact yet" />
+        )}
+      </section>
+      {projection.failure ? (
+        <VerdictBlock head={`Failure · ${projection.failure.code}`}>{projection.failure.message}</VerdictBlock>
+      ) : null}
+      <div className="h4-awaiting" role="note">
+        <span className="h4-awaiting-label">Authority</span>
+        <span className="h4-awaiting-chip">read only</span>
+        <span className="h4-awaiting-note">This view cannot submit, approve, cancel, release, or mutate the Harness run.</span>
+      </div>
+    </>
+  );
+}
+
+function HarnessFact({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="h4-bug-row">
+      <span className="h4-bug-k">{label}</span>
+      <span className={`h4-bug-v${mono ? " hm-mono" : ""}`}>{value}</span>
+    </div>
+  );
+}
+
+function budgetPair(used: number | undefined, limit: number | undefined, suffix = ""): string {
+  const usedText = used === undefined ? "unknown" : `${used}${suffix}`;
+  const limitText = limit === undefined ? "limit not projected" : `${limit}${suffix}`;
+  return `${usedText} / ${limitText}`;
 }
 
 /**

--- a/packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx
+++ b/packages/monitor-ui/src/components/drawer/DrawerBody.variant.test.tsx
@@ -1,8 +1,10 @@
 // @vitest-environment jsdom
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, test } from "vitest";
 import { cleanup, render } from "@testing-library/react";
 import { DrawerBody, drawerVariant } from "./DrawerBody.js";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { AgentRunProjectionV1 } from "@avg/schemas";
 
 afterEach(cleanup);
 
@@ -24,6 +26,12 @@ function card(over: Record<string, unknown>): BoardCard {
   } as BoardCard;
 }
 
+function projection(): AgentRunProjectionV1 {
+  return JSON.parse(
+    readFileSync("test/fixtures/agent-integration/agent-run-projection-v1.json", "utf8"),
+  ) as AgentRunProjectionV1;
+}
+
 describe("drawerVariant — operator-decision lanes get the risk-decision treatment (P1-1/P0)", () => {
   test("a PR in operator-review (isAction=false) is 'action', not 'pr'/'Automation in flight'", () => {
     expect(drawerVariant(card({ type: "pr", lane: "operator-review", isAction: false }))).toBe("action");
@@ -42,8 +50,35 @@ describe("drawerVariant — operator-decision lanes get the risk-decision treatm
     expect(drawerVariant(card({ type: "task", lane: "codex-needed", isAction: false }))).toBe("task");
   });
 
+  test("a Harness projection keeps its read-only Harness variant even in attention", () => {
+    expect(drawerVariant(card({
+      type: "task",
+      lane: "needs-attention",
+      harnessRun: projection(),
+    }))).toBe("harness");
+  });
+
   test("a plain in-flight PR (hermes-checking) stays 'pr'", () => {
     expect(drawerVariant(card({ type: "pr", lane: "hermes-checking", isAction: false }))).toBe("pr");
+  });
+});
+
+describe("DrawerBody — Harness evidence", () => {
+  test("shows state, manifest, budgets, artifacts, and the no-mutation boundary", () => {
+    const c = card({
+      id: "work-001",
+      type: "task",
+      agentType: "harness",
+      lane: "codex-needed",
+      harnessRun: projection(),
+    });
+    const { container } = render(<DrawerBody card={c} variant="harness" />);
+    expect(container.textContent).toContain("Read-only Harness run");
+    expect(container.textContent).toContain("Pinned manifest");
+    expect(container.textContent).toContain("coding-change");
+    expect(container.textContent).toContain("model tokens");
+    expect(container.textContent).toContain("read only");
+    expect(container.textContent).toContain("cannot submit, approve, cancel, release");
   });
 });
 

--- a/packages/monitor-ui/src/components/ui.tsx
+++ b/packages/monitor-ui/src/components/ui.tsx
@@ -39,6 +39,7 @@ export function agentDisplayName(agent: AgentTagAgent | undefined): string {
   if (agent === "security") return "security";
   if (agent === "docs") return "docs";
   if (agent === "hermes") return "hermes";
+  if (agent === "harness") return "harness";
   if (agent === "codex") return "codex";
   if (agent === "claude") return "claude";
   if (agent === "room") return "room";

--- a/packages/monitor-ui/src/lib/monitor/activity-feed.ts
+++ b/packages/monitor-ui/src/lib/monitor/activity-feed.ts
@@ -439,6 +439,7 @@ function cardTitle(card: BoardCard): string {
 
 function agentLabel(agent: AgentType | CardReviewRequest["requestedBy"] | CardReviewRequest["reviewer"]): string {
   if (agent === "hermes") return "Hermes";
+  if (agent === "harness") return "Harness";
   if (agent === "operator") return "Pascal";
   if (agent === "claude") return "Claude";
   if (agent === "test-writer") return "Test-writer";

--- a/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
@@ -41,7 +41,7 @@ describe("BOARD_COLUMNS", () => {
   });
 
   it("carries the design eyebrows for the named columns", () => {
-    expect(col("codex-needed").name).toBe("Builder tasks");
+    expect(col("codex-needed").name).toBe("Work queue");
     expect(col("operator-review").name).toBe("Runs needing review");
     expect(col("deploying").name).toBe("Deploying");
     expect(col("done").name).toBe("Done");

--- a/packages/monitor-ui/src/lib/monitor/board-columns.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.ts
@@ -39,7 +39,7 @@ export interface BoardColumnDef {
  */
 export const BOARD_COLUMNS: readonly BoardColumnDef[] = [
   { id: "inbox", inbox: true, gate: true, name: "Your decisions", sub: "Everything waiting on you" },
-  { id: "codex-needed", lane: "codex-needed", name: "Builder tasks", sub: "Proposed by Claude / Codex" },
+  { id: "codex-needed", lane: "codex-needed", name: "Work queue", sub: "Harness and builder work" },
   { id: "drafts", lane: "drafts", name: "Drafts", sub: "Author finishes" },
   { id: "hermes-checking", lane: "hermes-checking", name: "Hermes checking", sub: "Verifying" },
   { id: "operator-review", lane: "operator-review", gate: true, name: "Runs needing review", sub: "Failed / finished runs" },

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -282,7 +282,7 @@ test("boardNowBanner: calm board with in-flight automation reads correctly", () 
   assert.match(banner.headline, /2 automation\/release card/);
 });
 
-test("boardNowBanner: calm board names Codex-owned work instead of claiming the board is empty", () => {
+test("boardNowBanner: calm board names work-queue activity instead of claiming the board is empty", () => {
   const cards = [
     card({ id: "codex-1", type: "task", lane: "codex-needed", title: "Fix a failing check" }),
     card({ id: "deploy-1", type: "deploy", deployId: "#1", verification: { current: 1, total: 3, label: "" } }),
@@ -293,7 +293,7 @@ test("boardNowBanner: calm board names Codex-owned work instead of claiming the 
   // "No operator decision needed"), but still names the in-flight work.
   assert.match(banner.headline, /Nothing needs you right now/);
   assert.notMatch(banner.headline, /No operator decision needed/);
-  assert.match(banner.headline, /1 Codex-owned card/);
+  assert.match(banner.headline, /1 work-queue card/);
   assert.match(banner.headline, /1 automation\/release card/);
 });
 

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -224,7 +224,7 @@ function calmHeadline(counts: KPICounts): string {
 
   const automationCount = counts.checking + counts.queue + counts.deploying;
   const parts = [
-    counts.codex > 0 ? `${counts.codex} Codex-owned card(s)` : "",
+    counts.codex > 0 ? `${counts.codex} work-queue card(s)` : "",
     automationCount > 0 ? `${automationCount} automation/release card(s)` : "",
   ].filter(Boolean);
   // PR-F2: lead with the honest "nothing waiting on you" state (the calm banner

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -1,13 +1,14 @@
 // Hermes Handoff Monitor — shared card-type definitions.
 //
 // Mirrors the data shapes the slack-operator /monitor/v2/board endpoint
-// returns (see services/slack-operator/src/monitor-v2.ts). This is the
-// frontend's copy of the contract; the two cross an HTTP/JSON boundary,
-// so they're intentionally independent declarations rather than a shared
-// import.
+// returns (see services/slack-operator/src/monitor-v2.ts). Most UI fields are
+// boundary-local; the generic Harness projection stays on the shared INT-0
+// contract so the browser cannot drift into a second definition.
 //
 // Data model documented in §5 of docs/HERMES_MONITOR_REDESIGN_SPEC.md.
 // Lane derivation: lane-rules.ts. Freshness math: urgency.ts.
+
+import type { AgentRunProjectionV1 } from "@avg/schemas";
 
 export type Lane =
   | "needs-attention"
@@ -21,7 +22,7 @@ export type Lane =
 
 export type CardType = "pr" | "mission" | "task" | "deploy" | "draft" | "done";
 
-export type AgentType = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "ext";
+export type AgentType = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "harness" | "ext";
 
 export type RiskTag =
   | "workflow"
@@ -136,7 +137,7 @@ export interface CardDiscussionMessage {
 
 export interface CardSourceFailure {
   code: string;
-  source: "github" | "runner" | "deploy" | "codex";
+  source: "github" | "runner" | "deploy" | "codex" | "harness";
   message: string;
   lastGoodAt?: string;
 }
@@ -144,7 +145,7 @@ export interface CardSourceFailure {
 export interface CardWorkingNow {
   agent: AgentType;
   label: string;
-  source: "runner" | "mission" | "classifier";
+  source: "runner" | "mission" | "classifier" | "harness";
   runnerId?: string;
   taskId?: string;
   since?: string;
@@ -227,6 +228,8 @@ export interface CardBase {
   sourceFailure?: CardSourceFailure;
   /** Agent currently working this in-flight card, backed by live runner/classifier state. */
   workingNow?: CardWorkingNow;
+  /** Shared, schema-validated read projection for an allowlisted generic Harness run. */
+  harnessRun?: AgentRunProjectionV1;
   /**
    * Hermes's grounded, agentic read of WHY a failed decision card likely failed
    * plus a recommended next step. Present only on failure cards when the

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.test.ts
@@ -101,6 +101,19 @@ describe("buildDrawerFooter — mission variant", () => {
   });
 });
 
+describe("buildDrawerFooter — Harness read-only variant", () => {
+  it("exposes no dispatch, retry, approval, merge, or send-back control", () => {
+    const buttons = buildDrawerFooter(card({
+      type: "task",
+      agentType: "harness",
+      harnessRun: {},
+      lane: "needs-attention",
+      isAction: true,
+    }), { handlers: { onAskHermes: vi.fn(), onDismiss: vi.fn(), onApproveAndMerge: vi.fn() } });
+    expect(buttons.map((button) => button.key)).toEqual(["ask-hermes"]);
+  });
+});
+
 describe("buildDrawerFooter — action (PR) variant", () => {
   it("Approve & merge OPENS GitHub and records approval — the board never merges", () => {
     const openUrl = vi.fn();

--- a/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
+++ b/packages/monitor-ui/src/lib/monitor/drawer-footer.ts
@@ -199,7 +199,7 @@ export function buildDrawerFooter(card: BoardCard, deps: DrawerFooterDeps = {}):
       kind: "ghost",
       run: () => copy(card.id),
     });
-  } else {
+  } else if (variant !== "harness") {
     // Open the SPECIFIC PR — never the repo-root fallback. A task with no
     // resolved PR has nothing to open yet; silently linking to the repo root
     // sends the operator to the wrong target, so disable with an honest reason.

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -1473,6 +1473,7 @@ body { margin: 0; }
 .agent-dot--security { background: #a3414f; }
 .agent-dot--docs { background: #6b5b9a; }
 .agent-dot--hermes { background: var(--hm-hermes); }
+.agent-dot--harness { background: #2f7f72; }
 .agent-dot--operator { background: var(--hm-ink); }
 .agent-dot--system { background: var(--hm-muted-soft); }
 .agent-dot--room { background: var(--hm-hermes); }
@@ -1698,6 +1699,32 @@ body { margin: 0; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.hm-harness-run {
+  display: grid;
+  gap: 6px;
+  padding: 8px 0 2px;
+  border-top: 1px solid var(--hm-line-soft);
+  min-width: 0;
+}
+.hm-harness-run-top,
+.hm-harness-run-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+.hm-harness-run-progress {
+  color: var(--hm-ink-soft);
+  font-size: 11.5px;
+  line-height: 1.4;
+}
+.hm-harness-run-meta {
+  color: var(--hm-muted);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
 }
 
 .hm-mission-run {

--- a/packages/monitor-ui/tsconfig.json
+++ b/packages/monitor-ui/tsconfig.json
@@ -6,6 +6,9 @@
     "composite": true,
     "jsx": "react-jsx"
   },
+  "references": [
+    { "path": "../schemas" }
+  ],
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/main.tsx"]
 }

--- a/packages/schemas/src/agent-run-projection.ts
+++ b/packages/schemas/src/agent-run-projection.ts
@@ -20,6 +20,27 @@ import {
 
 const terminalOutcomeSchema = z.enum(["completed", "partial", "failed", "cancelled"]);
 
+export const agentRunManifestProjectionSchema = z.object({
+  ref: artifactRefSchema.optional(),
+  hash: sha256Schema,
+  profile: integrationIdSchema,
+  riskClass: z.enum(["low", "standard", "elevated"]),
+  effectiveCapabilities: uniqueNonEmptyStrings(200),
+  network: agentTaskNetworkPolicySchema,
+  policyHash: sha256Schema,
+  verifierHash: sha256Schema,
+  modelBindings: z.array(modelBindingMetadataSchema).max(100),
+  skillVersions: uniqueNonEmptyStrings(200),
+}).strict().superRefine((manifest, context) => {
+  if (manifest.ref && manifest.ref.sha256 !== manifest.hash) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "manifest ref hash must match manifest hash",
+      path: ["hash"],
+    });
+  }
+});
+
 export const agentRunProjectionV1Schema = z.object({
   schemaVersion: z.literal(1),
   kind: z.literal("agent_run_projection"),
@@ -47,18 +68,7 @@ export const agentRunProjectionV1Schema = z.object({
     reason: integrationTextSchema.optional(),
     lastEventAt: integrationTimestampSchema.optional(),
   }).strict(),
-  manifest: z.object({
-    ref: artifactRefSchema.optional(),
-    hash: sha256Schema,
-    profile: integrationIdSchema,
-    riskClass: z.enum(["low", "standard", "elevated"]),
-    effectiveCapabilities: uniqueNonEmptyStrings(200),
-    network: agentTaskNetworkPolicySchema,
-    policyHash: sha256Schema,
-    verifierHash: sha256Schema,
-    modelBindings: z.array(modelBindingMetadataSchema).max(100),
-    skillVersions: uniqueNonEmptyStrings(200),
-  }).strict(),
+  manifest: agentRunManifestProjectionSchema,
   progress: z.object({
     phase: integrationIdSchema,
     summary: integrationTextSchema,
@@ -115,13 +125,6 @@ export const agentRunProjectionV1Schema = z.object({
       path: ["source", "reason"],
     });
   }
-  if (projection.manifest.ref && projection.manifest.ref.sha256 !== projection.manifest.hash) {
-    context.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "manifest ref hash must match manifest hash",
-      path: ["manifest", "hash"],
-    });
-  }
   if (projection.run.terminal !== (projection.run.outcome !== undefined)) {
     context.addIssue({
       code: z.ZodIssueCode.custom,
@@ -164,6 +167,7 @@ export const agentRunProjectionV1Schema = z.object({
 });
 
 export type AgentRunProjectionV1 = z.infer<typeof agentRunProjectionV1Schema>;
+export type AgentRunManifestProjection = z.infer<typeof agentRunManifestProjectionSchema>;
 
 export function assertAgentRunProjectionWithinTask(
   taskInput: AgentTaskV1,

--- a/services/slack-operator/package.json
+++ b/services/slack-operator/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@avg/averray-mcp": "0.1.0",
-    "@avg/mcp-common": "0.1.0"
+    "@avg/mcp-common": "0.1.0",
+    "@avg/schemas": "0.1.0",
+    "zod": "^3.24.1"
   }
 }

--- a/services/slack-operator/src/harness-read-port.ts
+++ b/services/slack-operator/src/harness-read-port.ts
@@ -1,0 +1,465 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import {
+  artifactRefSchema,
+  harnessRunStateSchema,
+  type ArtifactRef,
+  type HarnessRunState,
+} from "@avg/schemas";
+
+import type { HarnessRunBinding } from "./harness-run-registry.js";
+
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const DEFAULT_TIMEOUT_MS = 5_000;
+const ALLOWED_EVENT_TYPES = new Set([
+  "TaskAccepted",
+  "ContractCompiled",
+  "EnvironmentPrepared",
+  "StrategySelected",
+  "ModelRequested",
+  "ModelResponded",
+  "CapabilityProposed",
+  "PolicyDecisionMade",
+  "CapabilityDispatched",
+  "CapabilityCompleted",
+  "ArtifactCreated",
+  "VerificationCompleted",
+  "ApprovalRequested",
+  "ApprovalGranted",
+  "MemoryCandidateCreated",
+  "RunCompleted",
+  "SafetyTripwireTriggered",
+  "ModelFallbackTriggered",
+  "MemoryRetrieved",
+]);
+const TERMINAL_STATES = new Set<HarnessRunState>([
+  "completed",
+  "partial",
+  "failed",
+  "cancelled",
+]);
+
+export interface HarnessStatusRead {
+  runId: string;
+  state: HarnessRunState;
+  attempt: number;
+  outcome?: "completed" | "partial" | "failed" | "cancelled";
+  outcomeReason?: string;
+  egressPolicy?: "deny" | { allowlist: string[] };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface HarnessEventRead {
+  seq: number;
+  type: string;
+  payload: Record<string, unknown> | null;
+}
+
+export interface HarnessDeliverableRead {
+  deliverableType: string;
+  artifact: ArtifactRef;
+}
+
+export interface HarnessRunReadSnapshot {
+  status: HarnessStatusRead;
+  events: HarnessEventRead[];
+  deliverables: HarnessDeliverableRead[];
+}
+
+export interface HarnessReadPort {
+  readRun(binding: HarnessRunBinding): Promise<HarnessRunReadSnapshot>;
+}
+
+export interface HarnessCommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type HarnessCommandExecutor = (
+  command: string,
+  args: readonly string[],
+  options: { timeoutMs: number; maxOutputBytes: number },
+) => Promise<HarnessCommandResult>;
+
+export class HarnessReadError extends Error {
+  constructor(
+    readonly code:
+      | "cli_timeout"
+      | "cli_failed"
+      | "cli_output_too_large"
+      | "run_not_started"
+      | "status_malformed"
+      | "status_identity_mismatch"
+      | "unknown_run_state"
+      | "unknown_event_type"
+      | "events_malformed"
+      | "deliverables_malformed",
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "HarnessReadError";
+  }
+}
+
+export function createHarnessCliReadPort(options: {
+  command?: string;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  execute?: HarnessCommandExecutor;
+} = {}): HarnessReadPort {
+  const command = options.command?.trim() || "harness";
+  if (path.basename(command) !== "harness") {
+    throw new HarnessReadError(
+      "cli_failed",
+      "Harness adapter requires an executable named harness",
+      false,
+    );
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxOutputBytes = options.maxOutputBytes ?? MAX_OUTPUT_BYTES;
+  const execute = options.execute ?? executeHarnessCommand;
+
+  return {
+    async readRun(binding) {
+      const [statusResult, eventsResult] = await Promise.all([
+        runReadCommand(execute, command, ["run", "status", binding.harnessRunId], timeoutMs, maxOutputBytes),
+        runReadCommand(execute, command, ["run", "events", binding.harnessRunId], timeoutMs, maxOutputBytes),
+      ]);
+      const status = parseHarnessStatus(statusResult.stdout, binding.harnessRunId);
+      const events = parseHarnessEvents(eventsResult.stdout);
+      const deliverables = status.outcome
+        ? parseHarnessDeliverables(
+            (
+              await runReadCommand(
+                execute,
+                command,
+                ["run", "deliverables", binding.harnessRunId],
+                timeoutMs,
+                maxOutputBytes,
+              )
+            ).stdout,
+          )
+        : [];
+      return { status, events, deliverables };
+    },
+  };
+}
+
+async function runReadCommand(
+  execute: HarnessCommandExecutor,
+  command: string,
+  args: readonly string[],
+  timeoutMs: number,
+  maxOutputBytes: number,
+): Promise<HarnessCommandResult> {
+  assertReadOnlyArgs(args);
+  let result: HarnessCommandResult;
+  try {
+    result = await execute(command, args, { timeoutMs, maxOutputBytes });
+  } catch (error) {
+    if (error instanceof HarnessReadError) throw error;
+    throw new HarnessReadError("cli_failed", "Harness read command could not be started", true);
+  }
+  if (result.code !== 0) {
+    const safeDetail = safeCliFailureDetail(result.stderr);
+    throw new HarnessReadError(
+      "cli_failed",
+      `Harness read command failed with exit ${result.code}${safeDetail ? `: ${safeDetail}` : ""}`,
+      true,
+    );
+  }
+  return result;
+}
+
+function assertReadOnlyArgs(args: readonly string[]): void {
+  const verb = args[1];
+  if (args.length !== 3 || args[0] !== "run"
+      || (verb !== "status" && verb !== "events" && verb !== "deliverables")) {
+    throw new HarnessReadError("cli_failed", "Harness adapter refused a non-read command", false);
+  }
+}
+
+export function parseHarnessStatus(stdout: string, expectedRunId: string): HarnessStatusRead {
+  const trimmed = stdout.trim();
+  if (trimmed === "pending — no worker has started it" || trimmed === "pending - no worker has started it") {
+    throw new HarnessReadError(
+      "run_not_started",
+      "Harness accepted the run id but no worker record is available yet",
+      true,
+    );
+  }
+  const allowedKeys = new Set([
+    "run_id",
+    "state",
+    "attempt",
+    "outcome",
+    "outcome_reason",
+    "egress_policy",
+    "created_at",
+    "updated_at",
+  ]);
+  const fields = new Map<string, string>();
+  for (const line of nonEmptyLines(stdout)) {
+    const delimiter = line.indexOf("=");
+    if (delimiter <= 0) {
+      throw new HarnessReadError("status_malformed", "Harness status response is malformed", false);
+    }
+    const key = line.slice(0, delimiter);
+    const value = line.slice(delimiter + 1);
+    if (!allowedKeys.has(key) || fields.has(key)) {
+      throw new HarnessReadError(
+        "status_malformed",
+        "Harness status response contains an unsupported or duplicate field",
+        false,
+      );
+    }
+    fields.set(key, value);
+  }
+
+  const runId = requiredField(fields, "run_id");
+  if (runId !== expectedRunId) {
+    throw new HarnessReadError(
+      "status_identity_mismatch",
+      "Harness status response does not match the allowlisted run id",
+      false,
+    );
+  }
+  const stateResult = harnessRunStateSchema.safeParse(requiredField(fields, "state"));
+  if (!stateResult.success) {
+    throw new HarnessReadError(
+      "unknown_run_state",
+      "Harness returned an unsupported run state",
+      false,
+    );
+  }
+  const attempt = parseNonNegativeInteger(requiredField(fields, "attempt"), "attempt");
+  const createdAt = parseTimestamp(requiredField(fields, "created_at"), "created_at");
+  const updatedAt = parseTimestamp(requiredField(fields, "updated_at"), "updated_at");
+  if (Date.parse(updatedAt) < Date.parse(createdAt)) {
+    throw new HarnessReadError(
+      "status_malformed",
+      "Harness status updated_at precedes created_at",
+      false,
+    );
+  }
+  const outcome = parseOutcome(fields.get("outcome"));
+  if (TERMINAL_STATES.has(stateResult.data) && !outcome) {
+    throw new HarnessReadError(
+      "status_malformed",
+      `Harness terminal state ${stateResult.data} is missing its outcome`,
+      false,
+    );
+  }
+  const outcomeReasonRaw = fields.get("outcome_reason");
+  const outcomeReason = outcomeReasonRaw && outcomeReasonRaw !== "-" ? outcomeReasonRaw : undefined;
+  const egressPolicy = parseEgressPolicy(fields.get("egress_policy"));
+
+  return {
+    runId,
+    state: stateResult.data,
+    attempt,
+    ...(outcome ? { outcome } : {}),
+    ...(outcomeReason ? { outcomeReason } : {}),
+    ...(egressPolicy ? { egressPolicy } : {}),
+    createdAt,
+    updatedAt,
+  };
+}
+
+export function parseHarnessEvents(stdout: string): HarnessEventRead[] {
+  const result: HarnessEventRead[] = [];
+  let lastSeq = -1;
+  for (const line of nonEmptyLines(stdout)) {
+    const match = /^([0-9]+) ([A-Za-z]+) payload=(.+)$/.exec(line);
+    if (!match) {
+      throw new HarnessReadError("events_malformed", "Harness events response is malformed", false);
+    }
+    const seq = parseNonNegativeInteger(match[1]!, "event sequence");
+    if (seq <= lastSeq) {
+      throw new HarnessReadError(
+        "events_malformed",
+        "Harness event sequences are not strictly increasing",
+        false,
+      );
+    }
+    const type = match[2]!;
+    if (!ALLOWED_EVENT_TYPES.has(type)) {
+      throw new HarnessReadError(
+        "unknown_event_type",
+        "Harness returned an unsupported event type",
+        false,
+      );
+    }
+    let payload: unknown;
+    try {
+      payload = JSON.parse(match[3]!);
+    } catch {
+      throw new HarnessReadError("events_malformed", "Harness event payload is not valid JSON", false);
+    }
+    if (payload !== null && (!payload || typeof payload !== "object" || Array.isArray(payload))) {
+      throw new HarnessReadError("events_malformed", "Harness event payload has an unsupported shape", false);
+    }
+    result.push({ seq, type, payload: payload as Record<string, unknown> | null });
+    lastSeq = seq;
+  }
+  return result;
+}
+
+export function parseHarnessDeliverables(stdout: string): HarnessDeliverableRead[] {
+  const result: HarnessDeliverableRead[] = [];
+  const seen = new Set<string>();
+  for (const line of nonEmptyLines(stdout)) {
+    const delimiter = line.indexOf(" ");
+    if (delimiter <= 0) {
+      throw new HarnessReadError(
+        "deliverables_malformed",
+        "Harness deliverables response is malformed",
+        false,
+      );
+    }
+    const deliverableType = line.slice(0, delimiter);
+    const uri = line.slice(delimiter + 1).trim();
+    const digest = /^artifact:\/\/sha256\/([a-f0-9]{64})$/.exec(uri)?.[1];
+    if (!digest) {
+      throw new HarnessReadError(
+        "deliverables_malformed",
+        "Harness deliverable has an unsupported artifact reference",
+        false,
+      );
+    }
+    const artifact = artifactRefSchema.parse({ uri, sha256: `sha256:${digest}` });
+    const key = `${deliverableType}\0${artifact.uri}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push({ deliverableType, artifact });
+  }
+  return result;
+}
+
+export const executeHarnessCommand: HarnessCommandExecutor = (
+  command,
+  args,
+  { timeoutMs, maxOutputBytes },
+) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let outputBytes = 0;
+    let settled = false;
+
+    const finishWithError = (error: HarnessReadError) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(error);
+    };
+    const collect = (target: "stdout" | "stderr", chunk: Buffer) => {
+      outputBytes += chunk.byteLength;
+      if (outputBytes > maxOutputBytes) {
+        finishWithError(
+          new HarnessReadError(
+            "cli_output_too_large",
+            "Harness read response exceeded the configured output limit",
+            false,
+          ),
+        );
+        return;
+      }
+      if (target === "stdout") stdout += chunk.toString("utf8");
+      else stderr += chunk.toString("utf8");
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => collect("stdout", chunk));
+    child.stderr.on("data", (chunk: Buffer) => collect("stderr", chunk));
+    child.once("error", () => {
+      finishWithError(new HarnessReadError("cli_failed", "Harness read command could not be started", true));
+    });
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+    const timer = setTimeout(() => {
+      finishWithError(
+        new HarnessReadError("cli_timeout", "Harness read command timed out", true),
+      );
+    }, timeoutMs);
+    timer.unref();
+  });
+
+function requiredField(fields: ReadonlyMap<string, string>, key: string): string {
+  const value = fields.get(key);
+  if (!value) {
+    throw new HarnessReadError("status_malformed", `Harness status response is missing ${key}`, false);
+  }
+  return value;
+}
+
+function parseNonNegativeInteger(value: string, field: string): number {
+  if (!/^[0-9]+$/.test(value)) {
+    throw new HarnessReadError("status_malformed", `Harness ${field} is not a non-negative integer`, false);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new HarnessReadError("status_malformed", `Harness ${field} exceeds the safe integer range`, false);
+  }
+  return parsed;
+}
+
+function parseTimestamp(value: string, field: string): string {
+  if (!Number.isFinite(Date.parse(value))) {
+    throw new HarnessReadError("status_malformed", `Harness ${field} is not a valid timestamp`, false);
+  }
+  return value;
+}
+
+function parseOutcome(value: string | undefined): HarnessStatusRead["outcome"] {
+  if (!value) return undefined;
+  if (value === "completed" || value === "partial" || value === "failed" || value === "cancelled") {
+    return value;
+  }
+  throw new HarnessReadError("status_malformed", "Harness returned an unsupported outcome", false);
+}
+
+function parseEgressPolicy(value: string | undefined): HarnessStatusRead["egressPolicy"] {
+  if (!value || value === "pending") return undefined;
+  const match = /^(deny_all|allowlist) \[(.*)\]$/.exec(value);
+  if (!match) {
+    throw new HarnessReadError("status_malformed", "Harness egress policy is malformed", false);
+  }
+  const destinations = match[2] ? match[2].split(",").filter(Boolean) : [];
+  if (match[1] === "deny_all") {
+    if (destinations.length > 0) {
+      throw new HarnessReadError("status_malformed", "Harness deny-all policy contains destinations", false);
+    }
+    return "deny";
+  }
+  if (destinations.length === 0) {
+    throw new HarnessReadError("status_malformed", "Harness allowlist policy contains no destinations", false);
+  }
+  return { allowlist: destinations };
+}
+
+function nonEmptyLines(value: string): string[] {
+  return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function safeCliFailureDetail(stderr: string): string {
+  const text = stderr.replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  if (/schema missing/i.test(text)) return "Harness database schema is unavailable";
+  if (/record not found|completed run not found/i.test(text)) return "Harness run record is unavailable";
+  if (/configuration|connection/i.test(text)) return "Harness data source is unavailable";
+  return "Harness data source refused the read";
+}

--- a/services/slack-operator/src/harness-run-projection.ts
+++ b/services/slack-operator/src/harness-run-projection.ts
@@ -1,0 +1,486 @@
+import {
+  agentRunProjectionV1Schema,
+  artifactRefSchema,
+  type AgentRunProjectionV1,
+  type ArtifactRef,
+  type HarnessRunState,
+} from "@avg/schemas";
+
+import {
+  HarnessReadError,
+  type HarnessEventRead,
+  type HarnessReadPort,
+  type HarnessRunReadSnapshot,
+} from "./harness-read-port.js";
+import type {
+  HarnessRunBinding,
+  HarnessRunRegistry,
+} from "./harness-run-registry.js";
+
+export interface HarnessRunBoardProjection {
+  binding: Pick<
+    HarnessRunBinding,
+    "workItemId" | "correlationId" | "harnessRunId" | "repository" | "title" | "summary"
+  >;
+  projection: AgentRunProjectionV1;
+}
+
+export interface HarnessProjectionFailure {
+  binding: Pick<
+    HarnessRunBinding,
+    "workItemId" | "correlationId" | "harnessRunId" | "repository" | "title" | "summary"
+  >;
+  code: string;
+  message: string;
+  retryable: boolean;
+  observedAt: string;
+}
+
+export interface HarnessProjectionSnapshot {
+  schemaVersion: 1;
+  kind: "harness_projection_snapshot";
+  enabled: true;
+  observedAt: string;
+  items: HarnessRunBoardProjection[];
+  failures: HarnessProjectionFailure[];
+}
+
+export class HarnessProjectionError extends Error {
+  constructor(
+    readonly code: "manifest_mismatch" | "projection_invalid",
+    message: string,
+    readonly retryable = false,
+  ) {
+    super(message);
+    this.name = "HarnessProjectionError";
+  }
+}
+
+export async function collectHarnessRunProjections(
+  registry: HarnessRunRegistry,
+  port: HarnessReadPort,
+  options: { now?: Date } = {},
+): Promise<HarnessProjectionSnapshot> {
+  const now = options.now ?? new Date();
+  const observedAt = now.toISOString();
+  const items: HarnessRunBoardProjection[] = [];
+  const failures: HarnessProjectionFailure[] = [];
+
+  // The pilot registry is intentionally small. Reading sequentially avoids an
+  // operator typo turning the monitor refresh into an unbounded CLI fan-out.
+  for (const binding of registry.bindings) {
+    const presentation = presentationFor(binding);
+    try {
+      const read = await port.readRun(binding);
+      items.push({
+        binding: presentation,
+        projection: projectHarnessRun(binding, read, { now }),
+      });
+    } catch (error) {
+      const known = error instanceof HarnessReadError || error instanceof HarnessProjectionError;
+      failures.push({
+        binding: presentation,
+        code: known ? error.code : "projection_failed",
+        message: known ? error.message : "Harness run projection failed",
+        retryable: known ? error.retryable : true,
+        observedAt,
+      });
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    kind: "harness_projection_snapshot",
+    enabled: true,
+    observedAt,
+    items,
+    failures,
+  };
+}
+
+export function projectHarnessRun(
+  binding: HarnessRunBinding,
+  read: HarnessRunReadSnapshot,
+  options: { now?: Date } = {},
+): AgentRunProjectionV1 {
+  const now = options.now ?? new Date();
+  assertManifestMatchesLiveRead(binding, read);
+
+  const terminal = read.status.outcome !== undefined;
+  const sourceUpdatedAtMs = Date.parse(read.status.updatedAt);
+  const rawAgeSeconds = Math.floor((now.getTime() - sourceUpdatedAtMs) / 1_000);
+  const ageSeconds = Math.max(0, rawAgeSeconds);
+  const clockAhead = rawAgeSeconds < -5;
+  const stale = !terminal && ageSeconds > binding.staleAfterSeconds;
+  const sourceHealth = clockAhead ? "degraded" : stale ? "stale" : "healthy";
+  const sourceReason = clockAhead
+    ? "Harness source timestamp is ahead of the monitor clock"
+    : stale
+      ? `Harness source has not updated for ${ageSeconds} seconds`
+      : undefined;
+  const verification = verificationFromEvents(read.events);
+  const artifacts = artifactsFromRead(read);
+  const failure = failureFromRead(read);
+  const budget = budgetFromRead(binding, read);
+  const progress = progressFor(read.status.state, read.events.length, read.status.outcomeReason);
+  const bindings = {
+    harnessRunId: binding.harnessRunId,
+    ...(binding.manifest.ref
+      ? {
+          runManifestRef: binding.manifest.ref,
+          runManifestHash: binding.manifest.hash,
+        }
+      : {}),
+    ...(binding.averrayJobId ? { averrayJobId: binding.averrayJobId } : {}),
+    ...(binding.averraySessionId ? { averraySessionId: binding.averraySessionId } : {}),
+    ...(binding.pullRequest ? { pullRequest: binding.pullRequest } : {}),
+  };
+
+  const candidate: AgentRunProjectionV1 = {
+    schemaVersion: 1,
+    kind: "agent_run_projection",
+    workItemId: binding.workItemId,
+    correlationId: binding.correlationId,
+    harnessRunId: binding.harnessRunId,
+    taskVersion: binding.taskVersion,
+    source: {
+      system: "agent-harness",
+      health: sourceHealth,
+      observedAt: now.toISOString(),
+      sourceUpdatedAt: read.status.updatedAt,
+      ...(sourceReason ? { reason: sourceReason } : {}),
+    },
+    heartbeat: {
+      status: terminal ? "terminal" : stale ? "stale" : "active",
+      ageSeconds,
+    },
+    run: {
+      state: read.status.state,
+      attempt: read.status.attempt,
+      terminal,
+      ...(read.status.outcome ? { outcome: read.status.outcome } : {}),
+      ...(read.status.outcomeReason ? { reason: sanitizeProjectionText(read.status.outcomeReason) } : {}),
+    },
+    manifest: binding.manifest,
+    progress,
+    budget,
+    artifacts,
+    verification,
+    ...(failure ? { failure } : {}),
+    bindings,
+  };
+
+  const parsed = agentRunProjectionV1Schema.safeParse(candidate);
+  if (!parsed.success) {
+    throw new HarnessProjectionError(
+      "projection_invalid",
+      `Harness run could not be represented by AgentRunProjection v1: ${parsed.error.issues[0]?.message ?? "validation failed"}`,
+    );
+  }
+  return parsed.data;
+}
+
+function assertManifestMatchesLiveRead(
+  binding: HarnessRunBinding,
+  read: HarnessRunReadSnapshot,
+): void {
+  if (read.status.egressPolicy !== undefined
+      && !networkPoliciesMatch(read.status.egressPolicy, binding.manifest.network)) {
+    throw new HarnessProjectionError(
+      "manifest_mismatch",
+      "Harness live egress policy does not match the pinned pilot manifest",
+    );
+  }
+  for (const event of read.events) {
+    if (event.type === "ContractCompiled") {
+      const riskClass = stringField(event.payload, "risk_class");
+      if (riskClass && riskClass !== binding.manifest.riskClass) {
+        throw new HarnessProjectionError(
+          "manifest_mismatch",
+          "Harness compiled risk class does not match the pinned pilot manifest",
+        );
+      }
+    }
+    if (event.type === "ModelRequested") {
+      const role = stringField(event.payload, "role");
+      const modelRef = stringField(event.payload, "model_ref");
+      if (!role || !modelRef) continue;
+      const pinned = binding.manifest.modelBindings.find((model) => model.role === role);
+      if (!pinned || pinned.modelRef !== modelRef) {
+        throw new HarnessProjectionError(
+          "manifest_mismatch",
+          "Harness model binding does not match the pinned pilot manifest",
+        );
+      }
+    }
+  }
+}
+
+function networkPoliciesMatch(
+  live: NonNullable<HarnessRunReadSnapshot["status"]["egressPolicy"]>,
+  pinned: HarnessRunBinding["manifest"]["network"],
+): boolean {
+  if (live === "deny" || pinned === "deny") return live === pinned;
+  const liveDestinations = [...live.allowlist].sort();
+  const pinnedDestinations = [...pinned.allowlist].sort();
+  return liveDestinations.length === pinnedDestinations.length
+    && liveDestinations.every((value, index) => value === pinnedDestinations[index]);
+}
+
+function budgetFromRead(
+  binding: HarnessRunBinding,
+  read: HarnessRunReadSnapshot,
+): AgentRunProjectionV1["budget"] {
+  const elapsedSecondsUsed = Math.max(
+    0,
+    Math.floor((Date.parse(read.status.updatedAt) - Date.parse(read.status.createdAt)) / 1_000),
+  );
+  let modelTokensUsed = 0;
+  let modelUsageComplete = true;
+  let toolCallsUsed = 0;
+  for (const event of read.events) {
+    if (event.type === "ModelResponded") {
+      const usage = recordField(event.payload, "usage");
+      const inputTokens = optionalNonNegativeIntegerField(usage, "input_tokens");
+      const outputTokens = optionalNonNegativeIntegerField(usage, "output_tokens");
+      if (inputTokens === undefined || outputTokens === undefined) modelUsageComplete = false;
+      else modelTokensUsed += inputTokens + outputTokens;
+    }
+    if (event.type === "CapabilityDispatched") toolCallsUsed += 1;
+  }
+  const exhausted = (
+    binding.budget.elapsedSecondsLimit !== undefined
+      && elapsedSecondsUsed >= binding.budget.elapsedSecondsLimit
+  ) || (
+    modelUsageComplete
+      && binding.budget.modelTokensLimit !== undefined
+      && modelTokensUsed >= binding.budget.modelTokensLimit
+  ) || (
+    binding.budget.toolCallsLimit !== undefined
+      && toolCallsUsed >= binding.budget.toolCallsLimit
+  );
+  return {
+    elapsedSecondsUsed,
+    ...(binding.budget.elapsedSecondsLimit !== undefined
+      ? { elapsedSecondsLimit: binding.budget.elapsedSecondsLimit }
+      : {}),
+    ...(modelUsageComplete ? { modelTokensUsed } : {}),
+    ...(binding.budget.modelTokensLimit !== undefined
+      ? { modelTokensLimit: binding.budget.modelTokensLimit }
+      : {}),
+    toolCallsUsed,
+    ...(binding.budget.toolCallsLimit !== undefined
+      ? { toolCallsLimit: binding.budget.toolCallsLimit }
+      : {}),
+    ...(binding.budget.estimatedUsdMicrosLimit !== undefined
+      ? { estimatedUsdMicrosLimit: binding.budget.estimatedUsdMicrosLimit }
+      : {}),
+    exhausted,
+  };
+}
+
+function artifactsFromRead(read: HarnessRunReadSnapshot): ArtifactRef[] {
+  const artifacts = new Map<string, ArtifactRef>();
+  for (const deliverable of read.deliverables) {
+    artifacts.set(deliverable.artifact.uri, deliverable.artifact);
+  }
+  for (const event of read.events) {
+    if (event.type !== "ArtifactCreated") continue;
+    const uri = stringField(event.payload, "artifact_uri");
+    const artifact = artifactFromUri(uri);
+    if (!uri || !artifact) {
+      throw new HarnessProjectionError(
+        "projection_invalid",
+        "Harness ArtifactCreated event has an unsupported artifact reference",
+      );
+    }
+    const declaredHash = stringField(event.payload, "artifact_hash");
+    if (declaredHash && declaredHash !== artifact.sha256) {
+      throw new HarnessProjectionError(
+        "projection_invalid",
+        "Harness ArtifactCreated hash does not match its artifact reference",
+      );
+    }
+    artifacts.set(artifact.uri, artifact);
+  }
+  return [...artifacts.values()].sort((left, right) => left.uri.localeCompare(right.uri));
+}
+
+function verificationFromEvents(
+  events: HarnessEventRead[],
+): AgentRunProjectionV1["verification"] {
+  const event = [...events].reverse().find((candidate) =>
+    candidate.type === "VerificationCompleted"
+    && stringField(candidate.payload, "scope") !== "plan_node"
+  );
+  if (!event) return { status: "pending" };
+  const passed = booleanField(event.payload, "passed");
+  const verdict = stringField(event.payload, "verdict");
+  const status = passed === true
+    ? "passed"
+    : passed === false
+      ? verdict === "failed" || verdict === "partial"
+        ? "failed"
+        : "inconclusive"
+      : "inconclusive";
+  const reportUri = stringField(event.payload, "report_ref");
+  const decisionRef = artifactFromUri(reportUri);
+  if (reportUri && !decisionRef) {
+    throw new HarnessProjectionError(
+      "projection_invalid",
+      "Harness verification report has an unsupported artifact reference",
+    );
+  }
+  return {
+    status,
+    ...(decisionRef
+      ? {
+          decisionRef,
+          decisionHash: decisionRef.sha256,
+        }
+      : {}),
+  };
+}
+
+function failureFromRead(
+  read: HarnessRunReadSnapshot,
+): AgentRunProjectionV1["failure"] {
+  if (
+    read.status.state !== "failed"
+    && read.status.state !== "quarantined"
+    && read.status.outcome !== "failed"
+  ) return undefined;
+  const completed = [...read.events].reverse().find((event) => event.type === "RunCompleted");
+  const eventReason = stringField(completed?.payload, "reason");
+  const reason = read.status.outcomeReason || eventReason || `${read.status.state} without a recorded reason`;
+  return {
+    code: failureCode(reason, read.status.state),
+    message: sanitizeProjectionText(reason),
+    retryable: retryableFailure(reason),
+  };
+}
+
+function progressFor(
+  state: HarnessRunState,
+  eventCount: number,
+  outcomeReason?: string,
+): AgentRunProjectionV1["progress"] {
+  const summaries: Record<HarnessRunState, string> = {
+    accepted: "Harness accepted the bounded task.",
+    contract_compiled: "Harness compiled the immutable run contract.",
+    environment_preparing: "Harness is preparing the isolated environment.",
+    environment_ready: "Harness prepared the isolated environment.",
+    strategy_selected: "Harness selected the execution strategy.",
+    executing: "Harness is executing the bounded task.",
+    verifying: "Harness is verifying the recorded deliverables.",
+    repairing: "Harness is repairing a failed verification.",
+    replanning: "Harness is replanning within the approved contract.",
+    approval_required: "Harness paused at an approval boundary.",
+    suspended: "Harness suspended the run.",
+    finalizing: "Harness is finalizing immutable deliverables.",
+    completed: "Harness completed the bounded run.",
+    partial: "Harness completed the run with a partial outcome.",
+    failed: "Harness recorded a failed run.",
+    cancel_requested: "Harness is processing a cancellation request.",
+    compensating: "Harness is applying bounded compensation.",
+    cancelled: "Harness recorded a cancelled run.",
+    quarantined: "Harness quarantined the run.",
+    learning_queued: "Harness queued post-run learning.",
+    learning_processed: "Harness processed post-run learning.",
+  };
+  const blocker = state === "approval_required"
+    || state === "suspended"
+    || state === "quarantined"
+    || state === "failed"
+    ? sanitizeProjectionText(outcomeReason || summaries[state])
+    : undefined;
+  return {
+    phase: state,
+    summary: summaries[state],
+    completedUnits: eventCount,
+    ...(blocker ? { blocker } : {}),
+  };
+}
+
+function artifactFromUri(uri: string | undefined): ArtifactRef | undefined {
+  if (!uri) return undefined;
+  const digest = /^artifact:\/\/sha256\/([a-f0-9]{64})$/.exec(uri)?.[1];
+  if (!digest) return undefined;
+  const result = artifactRefSchema.safeParse({ uri, sha256: `sha256:${digest}` });
+  return result.success ? result.data : undefined;
+}
+
+function presentationFor(binding: HarnessRunBinding): HarnessRunBoardProjection["binding"] {
+  return {
+    workItemId: binding.workItemId,
+    correlationId: binding.correlationId,
+    harnessRunId: binding.harnessRunId,
+    repository: binding.repository,
+    title: binding.title,
+    ...(binding.summary ? { summary: binding.summary } : {}),
+  };
+}
+
+function recordField(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): Record<string, unknown> | undefined {
+  const value = record?.[key];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function stringField(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function booleanField(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function optionalNonNegativeIntegerField(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): number | undefined {
+  const value = record?.[key];
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+}
+
+function failureCode(reason: string, state: HarnessRunState): string {
+  const normalized = reason.toLowerCase();
+  if (/verification/.test(normalized)) return "verification_failed";
+  if (/safety|tripwire|quarantin/.test(normalized)) return "safety_tripwire_triggered";
+  if (/policy[_ -]?denied/.test(normalized)) return "policy_denied";
+  if (/approval[_ -]?denied/.test(normalized)) return "approval_denied";
+  if (/invalid[_ -]?contract/.test(normalized)) return "invalid_contract";
+  if (/timed?[_ -]?out|timeout/.test(normalized)) return "timeout";
+  return `harness_${state}`;
+}
+
+function retryableFailure(reason: string): boolean {
+  return !/(?:policy_denied|approval_denied|safety|quarantin|invalid_contract|protected)/i.test(reason);
+}
+
+function sanitizeProjectionText(value: string): string {
+  return value
+    .replace(/-----BEGIN [^-]+-----[\s\S]*?-----END [^-]+-----/g, "[redacted]")
+    .replace(/\bBearer\s+\S+/gi, "Bearer [redacted]")
+    .replace(/\b(?:sk|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{12,}\b/g, "[redacted]")
+    .replace(
+      /\b((?:api[_-]?key|auth[_-]?token|access[_-]?token|refresh[_-]?token|password|passwd|secret|token|database[_-]?url|dsn)\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      "$1[redacted]",
+    )
+    .replace(/([a-z][a-z0-9+.-]*:\/\/)([^/\s:@]+):([^/\s@]+)@/gi, "$1[redacted]@")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1_000) || "Harness recorded no safe failure detail";
+}

--- a/services/slack-operator/src/harness-run-registry.ts
+++ b/services/slack-operator/src/harness-run-registry.ts
@@ -1,0 +1,214 @@
+import { readFile, stat } from "node:fs/promises";
+
+import {
+  agentRunManifestProjectionSchema,
+  githubPullRequestRefSchema,
+  integrationIdSchema,
+  integrationTextSchema,
+  integrationTimestampSchema,
+  nonNegativeSafeIntegerSchema,
+  positiveSafeIntegerSchema,
+} from "@avg/schemas";
+import { z } from "zod";
+
+const MAX_REGISTRY_BYTES = 512 * 1024;
+const MAX_PILOT_BINDINGS = 100;
+
+const harnessProjectionBudgetSchema = z.object({
+  elapsedSecondsLimit: positiveSafeIntegerSchema.optional(),
+  modelTokensLimit: positiveSafeIntegerSchema.optional(),
+  toolCallsLimit: positiveSafeIntegerSchema.optional(),
+  estimatedUsdMicrosLimit: nonNegativeSafeIntegerSchema.nullable().optional(),
+}).strict();
+
+export const harnessRunBindingSchema = z.object({
+  workItemId: integrationIdSchema,
+  correlationId: integrationIdSchema,
+  harnessRunId: z.string().uuid(),
+  taskVersion: positiveSafeIntegerSchema,
+  repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/).max(240),
+  title: integrationTextSchema,
+  summary: integrationTextSchema.optional(),
+  registeredAt: integrationTimestampSchema,
+  staleAfterSeconds: positiveSafeIntegerSchema.max(86_400).default(300),
+  manifest: agentRunManifestProjectionSchema,
+  budget: harnessProjectionBudgetSchema,
+  averrayJobId: integrationIdSchema.optional(),
+  averraySessionId: integrationIdSchema.optional(),
+  pullRequest: githubPullRequestRefSchema.optional(),
+}).strict().superRefine((binding, context) => {
+  const roles = new Set<string>();
+  for (let index = 0; index < binding.manifest.modelBindings.length; index += 1) {
+    const role = binding.manifest.modelBindings[index]!.role;
+    if (roles.has(role)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate model binding role: ${role}`,
+        path: ["manifest", "modelBindings", index, "role"],
+      });
+    }
+    roles.add(role);
+  }
+});
+
+export const harnessRunRegistrySchema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("harness_run_registry"),
+  bindings: z.array(harnessRunBindingSchema).max(MAX_PILOT_BINDINGS),
+}).strict().superRefine((registry, context) => {
+  for (const field of ["workItemId", "correlationId", "harnessRunId"] as const) {
+    const seen = new Set<string>();
+    for (let index = 0; index < registry.bindings.length; index += 1) {
+      const value = registry.bindings[index]![field];
+      if (seen.has(value)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `duplicate ${field}: ${value}`,
+          path: ["bindings", index, field],
+        });
+      }
+      seen.add(value);
+    }
+  }
+});
+
+export type HarnessRunBinding = z.infer<typeof harnessRunBindingSchema>;
+export type HarnessRunRegistry = z.infer<typeof harnessRunRegistrySchema>;
+
+export class HarnessRunRegistryError extends Error {
+  constructor(
+    readonly code:
+      | "registry_missing"
+      | "registry_too_large"
+      | "registry_read_failed"
+      | "registry_invalid_json"
+      | "registry_invalid"
+      | "registry_secret_like_value",
+    message: string,
+  ) {
+    super(message);
+    this.name = "HarnessRunRegistryError";
+  }
+}
+
+export function harnessProjectionEnabled(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  const value = environment.HARNESS_PROJECTION_ENABLED?.trim().toLowerCase() ?? "false";
+  return value === "1" || value === "true";
+}
+
+export function harnessProjectionReadTimeoutMs(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): number {
+  const raw = environment.HARNESS_PROJECTION_READ_TIMEOUT_MS ?? "5000";
+  if (!/^[0-9]+$/.test(raw)) return 5_000;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed)) return 5_000;
+  return Math.max(250, Math.min(30_000, parsed));
+}
+
+export function parseHarnessRunRegistry(input: unknown): HarnessRunRegistry {
+  const secretPath = firstSecretLikePath(input);
+  if (secretPath) {
+    throw new HarnessRunRegistryError(
+      "registry_secret_like_value",
+      `Harness pilot registry contains a secret-like value at ${secretPath}`,
+    );
+  }
+  const parsed = harnessRunRegistrySchema.safeParse(input);
+  if (!parsed.success) {
+    throw new HarnessRunRegistryError(
+      "registry_invalid",
+      `Harness pilot registry is invalid: ${parsed.error.issues[0]?.message ?? "schema validation failed"}`,
+    );
+  }
+  return parsed.data;
+}
+
+export async function loadHarnessRunRegistry(registryPath: string): Promise<HarnessRunRegistry> {
+  const normalizedPath = registryPath.trim();
+  if (!normalizedPath) {
+    throw new HarnessRunRegistryError(
+      "registry_missing",
+      "HARNESS_PROJECTION_BINDINGS_PATH is required when Harness projection is enabled",
+    );
+  }
+
+  try {
+    const info = await stat(normalizedPath);
+    if (!info.isFile()) {
+      throw new HarnessRunRegistryError("registry_read_failed", "Harness pilot registry path is not a file");
+    }
+    if (info.size > MAX_REGISTRY_BYTES) {
+      throw new HarnessRunRegistryError(
+        "registry_too_large",
+        `Harness pilot registry exceeds ${MAX_REGISTRY_BYTES} bytes`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof HarnessRunRegistryError) throw error;
+    throw new HarnessRunRegistryError("registry_read_failed", "Harness pilot registry could not be read");
+  }
+
+  let raw: string;
+  try {
+    raw = await readFile(normalizedPath, "utf8");
+  } catch {
+    throw new HarnessRunRegistryError("registry_read_failed", "Harness pilot registry could not be read");
+  }
+  if (Buffer.byteLength(raw, "utf8") > MAX_REGISTRY_BYTES) {
+    throw new HarnessRunRegistryError(
+      "registry_too_large",
+      `Harness pilot registry exceeds ${MAX_REGISTRY_BYTES} bytes`,
+    );
+  }
+
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch {
+    throw new HarnessRunRegistryError("registry_invalid_json", "Harness pilot registry is not valid JSON");
+  }
+  return parseHarnessRunRegistry(decoded);
+}
+
+function firstSecretLikePath(input: unknown): string | undefined {
+  const stack: Array<{ value: unknown; path: string }> = [{ value: input, path: "$" }];
+  while (stack.length > 0) {
+    const current = stack.pop()!;
+    if (Array.isArray(current.value)) {
+      current.value.forEach((value, index) => stack.push({ value, path: `${current.path}[${index}]` }));
+      continue;
+    }
+    if (!current.value || typeof current.value !== "object") continue;
+    for (const [key, value] of Object.entries(current.value as Record<string, unknown>)) {
+      const path = `${current.path}.${key}`;
+      const normalizedKey = key.replace(/[-_]/g, "").toLowerCase();
+      if ([
+        "secret",
+        "token",
+        "password",
+        "privatekey",
+        "apikey",
+        "databaseurl",
+        "dsn",
+        "authtoken",
+        "accesstoken",
+        "refreshtoken",
+      ].includes(normalizedKey)) {
+        return path;
+      }
+      if (typeof value === "string" && isSecretLikeString(value)) return path;
+      stack.push({ value, path });
+    }
+  }
+  return undefined;
+}
+
+function isSecretLikeString(value: string): boolean {
+  return /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/.test(value)
+    || /^Bearer\s+\S+/i.test(value)
+    || /^(?:sk|ghp|github_pat|xox[baprs])[-_][A-Za-z0-9_-]{16,}$/.test(value)
+    || /^0x[a-fA-F0-9]{64}$/.test(value);
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -57,6 +57,13 @@ import {
 } from "./monitor-collab.js";
 import { buildHermesBoardSnapshotFromMonitor } from "./monitor-hermes-board.js";
 import { buildV2BoardSnapshot, diffBoardSnapshots, failureAnalysisCardFor, type BoardSnapshotV2 } from "./monitor-v2.js";
+import { createHarnessCliReadPort } from "./harness-read-port.js";
+import { collectHarnessRunProjections, type HarnessProjectionSnapshot } from "./harness-run-projection.js";
+import {
+  harnessProjectionEnabled,
+  harnessProjectionReadTimeoutMs,
+  loadHarnessRunRegistry,
+} from "./harness-run-registry.js";
 import { buildBacklogSuggestionsResponse } from "./backlog-suggestions.js";
 import { listDecisionRecordsForMonitor } from "./decision-record-store.js";
 import {
@@ -4141,6 +4148,38 @@ async function loadMonitorSnapshot(
       error: error instanceof Error ? error.message : String(error),
     });
   }
+  let harnessRuns: HarnessProjectionSnapshot | undefined;
+  if (harnessProjectionEnabled()) {
+    const harnessStartedAt = Date.now();
+    try {
+      const registry = await loadHarnessRunRegistry(optionalEnv("HARNESS_PROJECTION_BINDINGS_PATH"));
+      harnessRuns = await collectHarnessRunProjections(
+        registry,
+        createHarnessCliReadPort({
+          command: optionalEnv("HARNESS_CLI_COMMAND", "harness"),
+          timeoutMs: harnessProjectionReadTimeoutMs(),
+        }),
+      );
+      const failed = harnessRuns.failures.length;
+      phases.push({
+        name: "harness_run_projection",
+        status: failed > 0 ? "skipped" : "ok",
+        durationMs: Date.now() - harnessStartedAt,
+        bindings: registry.bindings.length,
+        projected: harnessRuns.items.length,
+        failed,
+        ...(failed > 0 ? { error: `${failed} Harness run read(s) degraded` } : {}),
+      });
+    } catch (error) {
+      logger.warn({ err: error }, "monitor_harness_projection_skipped");
+      phases.push({
+        name: "harness_run_projection",
+        status: "skipped",
+        durationMs: Date.now() - harnessStartedAt,
+        error: error instanceof Error ? error.message : "Harness projection failed",
+      });
+    }
+  }
   const llmUsageStartedAt = Date.now();
   let llmUsageEvents: Awaited<ReturnType<typeof readLlmUsageEvents>> = [];
   try {
@@ -4173,6 +4212,7 @@ async function loadMonitorSnapshot(
   const snapshot = {
     ...enriched,
     codexTasks,
+    ...(harnessRuns ? { harnessRuns } : {}),
     testbedMissions: listTestbedMissionRuns({ limit: 20 }),
     testbedSuites: listTestbedSuites({ missionRuns: listTestbedMissionRuns({ limit: 50 }) }).suites,
     testbedMissionRunner: summarizeTestbedMissionRunnerHeartbeat(readTestbedMissionRunnerHeartbeat()),

--- a/services/slack-operator/src/monitor-hermes-board.ts
+++ b/services/slack-operator/src/monitor-hermes-board.ts
@@ -34,6 +34,7 @@ export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBo
   const missionItems = arrayRecords(snapshot.testbedMissions)
     .map((run) => testbedMissionRunToMonitorItem(run as unknown as TestbedMissionRun));
   const allRawItems = [...arrayRecords(snapshot.active), ...arrayRecords(snapshot.recent), ...missionItems];
+  const harnessCards = harnessBoardCards(snapshot);
   const quietSelfHealingCapacitySignals = allRawItems.filter(isQuietSelfHealingCapacityEvent).length;
   const rawItems = dedupeItems(allRawItems.filter((item) => !isQuietSelfHealingCapacityEvent(item)));
   const classified = rawItems
@@ -53,7 +54,7 @@ export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBo
     .filter((entry) => !isActiveMissionItem(entry.item))
     .map((entry) => entry.card)
     .slice(0, MAX_BOARD_CARDS);
-  const cards = [...pinnedMissionCards, ...cappedCards];
+  const cards = mergeHarnessCards([...pinnedMissionCards, ...cappedCards], harnessCards);
 
   const counts = boardCounts(cards, snapshot, { quietSelfHealingCapacitySignals });
   const runner = runnerSummary(snapshot);
@@ -65,6 +66,194 @@ export function buildHermesBoardSnapshotFromMonitor(snapshot: unknown): HermesBo
     ...(runner ? { runner } : {}),
     items: cards,
   };
+}
+
+function harnessBoardCards(snapshot: Record<string, unknown>): HermesBoardCardSnapshot[] {
+  const harnessRuns = recordProp(snapshot, "harnessRuns");
+  if (!harnessRuns || harnessRuns.enabled !== true) return [];
+  const cards: HermesBoardCardSnapshot[] = [];
+  for (const item of arrayRecords(harnessRuns.items)) {
+    const binding = recordProp(item, "binding");
+    const projection = recordProp(item, "projection");
+    if (!binding || !projection) continue;
+    const run = recordProp(projection, "run") ?? {};
+    const source = recordProp(projection, "source") ?? {};
+    const progress = recordProp(projection, "progress") ?? {};
+    const verification = recordProp(projection, "verification");
+    const failure = recordProp(projection, "failure");
+    const heartbeat = recordProp(projection, "heartbeat");
+    const workItemId = textProp(projection, "workItemId") || textProp(binding, "workItemId");
+    const correlationId = textProp(projection, "correlationId") || textProp(binding, "correlationId");
+    const runId = textProp(projection, "harnessRunId") || textProp(binding, "harnessRunId");
+    const title = textProp(binding, "title");
+    if (!workItemId || !correlationId || !runId || !title) continue;
+    const state = normalize(textProp(run, "state"));
+    const outcome = normalize(textProp(run, "outcome"));
+    const sourceHealth = normalize(textProp(source, "health")) || "unavailable";
+    const verificationStatus = normalize(textProp(verification ?? {}, "status"));
+    const failureMessage = textProp(failure ?? {}, "message");
+    const classification = classifyHarnessProjection({
+      state,
+      outcome,
+      sourceHealth,
+      verification: verificationStatus,
+      failure: failureMessage,
+    });
+    const ageSeconds = numberProp(heartbeat ?? {}, "ageSeconds");
+    const progressSummary = textProp(progress, "summary");
+    const artifactCount = Array.isArray(projection.artifacts) ? projection.artifacts.length : 0;
+    cards.push({
+      workItemId,
+      title,
+      lane: classification.lane,
+      owner: classification.owner,
+      verdict: classification.verdict,
+      why: [
+        progressSummary,
+        sourceHealth !== "healthy" ? `Harness source ${sourceHealth}` : "",
+        failureMessage,
+      ].filter(Boolean).join(" · "),
+      next: classification.next,
+      repo: textProp(binding, "repository"),
+      correlationId,
+      tags: ["harness"],
+      ...(ageSeconds !== undefined ? { ageLabel: ageLabelFromSeconds(ageSeconds) } : {}),
+      harnessRun: {
+        runId,
+        ...(state ? { state } : {}),
+        ...(outcome ? { outcome } : {}),
+        sourceHealth,
+        ...(textProp(progress, "phase") ? { phase: textProp(progress, "phase") } : {}),
+        ...(progressSummary ? { progress: progressSummary } : {}),
+        ...(verificationStatus ? { verification: verificationStatus } : {}),
+        artifactCount,
+        ...(failureMessage ? { failure: failureMessage } : {}),
+      },
+    });
+  }
+  for (const entry of arrayRecords(harnessRuns.failures)) {
+    const binding = recordProp(entry, "binding");
+    if (!binding) continue;
+    const workItemId = textProp(binding, "workItemId");
+    const correlationId = textProp(binding, "correlationId");
+    const runId = textProp(binding, "harnessRunId");
+    const title = textProp(binding, "title");
+    const message = textProp(entry, "message");
+    if (!workItemId || !correlationId || !runId || !title || !message) continue;
+    cards.push({
+      workItemId,
+      title,
+      lane: "Needs Attention",
+      owner: "Operator",
+      verdict: "Harness source degraded",
+      why: message,
+      next: "restore the read-only Harness source or correct the pinned pilot binding",
+      repo: textProp(binding, "repository"),
+      correlationId,
+      tags: ["harness"],
+      harnessRun: {
+        runId,
+        sourceHealth: "unavailable",
+        failure: message,
+      },
+    });
+  }
+  return cards;
+}
+
+function classifyHarnessProjection(input: {
+  state: string;
+  outcome: string;
+  sourceHealth: string;
+  verification: string;
+  failure: string;
+}): BoardClassification {
+  if (input.sourceHealth !== "healthy") {
+    return {
+      lane: "Needs Attention",
+      owner: "Operator",
+      verdict: `Harness source ${input.sourceHealth}`,
+      next: "restore the read-only Harness source before trusting newer run state",
+    };
+  }
+  if (
+    input.failure
+    || input.state === "failed"
+    || input.state === "partial"
+    || input.state === "cancelled"
+    || input.state === "quarantined"
+    || input.state === "approval_required"
+    || input.state === "suspended"
+    || input.verification === "failed"
+    || input.verification === "inconclusive"
+  ) {
+    return {
+      lane: "Needs Attention",
+      owner: "Operator",
+      verdict: input.failure ? "Harness run failed" : `Harness ${input.state || input.verification}`,
+      next: "inspect the immutable Harness evidence and decide the next bounded step",
+    };
+  }
+  if (input.state === "verifying" || input.state === "finalizing") {
+    return {
+      lane: "Hermes Checking",
+      owner: "Harness",
+      verdict: `Harness ${input.state}`,
+      next: "wait for Harness verification and immutable deliverables",
+    };
+  }
+  if (input.outcome === "completed" && input.verification === "passed") {
+    return {
+      lane: "Codex Needed",
+      owner: "Harness",
+      verdict: "Harness run verified",
+      next: "review the verified evidence before any GitHub or Averray mutation",
+    };
+  }
+  return {
+    lane: "Codex Needed",
+    owner: "Harness",
+    verdict: input.state ? `Harness ${input.state}` : "Harness run observed",
+    next: "follow the read-only Harness progress until verification completes",
+  };
+}
+
+function mergeHarnessCards(
+  sourceCards: HermesBoardCardSnapshot[],
+  harnessCards: HermesBoardCardSnapshot[],
+): HermesBoardCardSnapshot[] {
+  const byCorrelation = new Map(
+    harnessCards
+      .filter((card) => card.correlationId)
+      .map((card) => [card.correlationId!, card] as const),
+  );
+  const consumed = new Set<string>();
+  const merged = sourceCards.map((card) => {
+    const harness = card.correlationId ? byCorrelation.get(card.correlationId) : undefined;
+    if (!harness) return card;
+    consumed.add(harness.workItemId ?? harness.correlationId ?? "");
+    // Once a PR exists, GitHub remains lane-authoritative. Add only the safe
+    // Harness facts so the correlated work item stays a single card.
+    if (card.repo && card.number) {
+      return {
+        ...card,
+        workItemId: harness.workItemId,
+        harnessRun: harness.harnessRun,
+        tags: unique([...(card.tags ?? []), "harness"]),
+      };
+    }
+    return harness;
+  });
+  return [
+    ...merged,
+    ...harnessCards.filter((card) => !consumed.has(card.workItemId ?? card.correlationId ?? "")),
+  ];
+}
+
+function ageLabelFromSeconds(seconds: number): string {
+  if (seconds < 120) return "fresh";
+  if (seconds < 3_600) return `${Math.floor(seconds / 60)}m`;
+  return `${Math.floor(seconds / 3_600)}h`;
 }
 
 export function isQuietAutomationCapacityReason(value: unknown): boolean {
@@ -425,7 +614,7 @@ function boardHeadline(counts: Readonly<Record<string, number | string | boolean
   const deploying = numericCount(counts.deploying);
   if (attention > 0) parts.push(`${attention} blocked/attention item${attention === 1 ? "" : "s"}`);
   if (waiting > 0) parts.push(`${waiting} draft${waiting === 1 ? "" : "s"} parked`);
-  if (codex > 0) parts.push(`${codex} Codex-owned item${codex === 1 ? "" : "s"}`);
+  if (codex > 0) parts.push(`${codex} work-queue item${codex === 1 ? "" : "s"}`);
   if (operator > 0) parts.push(`${operator} operator decision${operator === 1 ? "" : "s"}`);
   if (queue > 0) parts.push(`${queue} ready for merge stewardship`);
   if (deploying > 0) parts.push(`${deploying} deploy verification${deploying === 1 ? "" : "s"}`);

--- a/services/slack-operator/src/monitor-hermes-narration.ts
+++ b/services/slack-operator/src/monitor-hermes-narration.ts
@@ -54,6 +54,12 @@ export function buildHermesBoardNarrationSignature(board: HermesBoardSnapshot | 
     item.verdict || "",
     item.why || "",
     item.next || "",
+    item.harnessRun?.runId || "",
+    item.harnessRun?.state || "",
+    item.harnessRun?.sourceHealth || "",
+    item.harnessRun?.verification || "",
+    item.harnessRun?.artifactCount ?? "",
+    item.harnessRun?.failure || "",
   ].join(":"));
   return [counts, ...cards].filter(Boolean).join("|");
 }
@@ -75,6 +81,18 @@ function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
     return board.headline || "The board is quiet right now. I do not see a live handoff that needs a next move.";
   }
   const label = prLabel(primary);
+  if (primary.harnessRun) {
+    const run = primary.harnessRun;
+    const evidence = [
+      run.state ? `state ${run.state}` : "",
+      run.verification ? `verification ${run.verification}` : "",
+      `${run.artifactCount ?? 0} immutable artifact${run.artifactCount === 1 ? "" : "s"}`,
+    ].filter(Boolean).join(", ");
+    return ownerAskNarration(
+      primary,
+      `${label} is a read-only Harness projection: ${sentence(run.progress || primary.why || evidence)} Source is ${run.sourceHealth}; ${evidence}.`,
+    );
+  }
   if (primary.lane === "Waiting / Drafts") {
     return decisionNarration(
       primary,
@@ -96,7 +114,7 @@ function fallbackHermesBoardNarrationBase(board: HermesBoardSnapshot): string {
   if (primary.lane === "Codex Needed") {
     return ownerAskNarration(
       primary,
-      `${label} is Codex-owned now: ${sentence(primary.why || "the board has a task for Codex")}`
+      `${label} is in the work queue: ${sentence(primary.why || "the board has a builder task")}`
     );
   }
   if (primary.lane === "Release Queue") {

--- a/services/slack-operator/src/monitor-hermes-voice.ts
+++ b/services/slack-operator/src/monitor-hermes-voice.ts
@@ -67,6 +67,8 @@ export interface HermesReplyPrSnapshot {
 }
 
 export interface HermesBoardCardSnapshot {
+  /** Stable integration work item id for a projected Harness run. */
+  workItemId?: string;
   repo?: string;
   number?: number;
   title: string;
@@ -98,6 +100,21 @@ export interface HermesBoardCardSnapshot {
    * via the branch-prefix convention. Absent for non-PR cards.
    */
   headBranch?: string;
+  /**
+   * Safe, structured Harness facts only. Raw event payloads and model messages
+   * never cross into Hermes narration context.
+   */
+  harnessRun?: {
+    runId: string;
+    state?: string;
+    outcome?: string;
+    sourceHealth: string;
+    phase?: string;
+    progress?: string;
+    verification?: string;
+    artifactCount?: number;
+    failure?: string;
+  };
 }
 
 /**
@@ -558,7 +575,7 @@ export function hermesMemoryInfluence(context: HermesWhyTraceContext): HermesMem
   const lowerNote = cleaned.toLowerCase();
   const lane = item?.lane ?? context.selectedPr?.lane ?? "";
   const owner = item?.owner ?? "";
-  const boardSaysCodex = owner === "Codex" || lane === "Codex Needed";
+  const boardSaysCodex = owner === "Codex" || (lane === "Codex Needed" && !item?.harnessRun);
   const noteSaysExternalDraftWait = saysExternalDraftShouldWait(lowerNote);
   const noteSaysDelegatedCodex = saysDelegatedCodex(lowerNote);
 
@@ -654,6 +671,19 @@ export function hermesDecisionCoachForCard(item: HermesBoardCardSnapshot): Herme
 }
 
 export function hermesOwnerAskForCard(item: HermesBoardCardSnapshot): HermesOwnerAsk | null {
+  if (item.harnessRun) {
+    const unhealthy = item.harnessRun.sourceHealth !== "healthy";
+    return {
+      target: unhealthy ? "Pascal" : "Harness",
+      ask: unhealthy
+        ? "restore the read-only Harness source or correct the allowlisted binding"
+        : "keep the bounded run moving and record verification plus immutable deliverables",
+      waitingFor: unhealthy
+        ? "a healthy read before treating newer run state as current"
+        : "a terminal Harness outcome; this board has no Harness mutation authority",
+    };
+  }
+
   if (item.lane === "Waiting / Drafts") {
     return {
       target: "PR author or owning agent",

--- a/services/slack-operator/src/monitor-v2-debug.ts
+++ b/services/slack-operator/src/monitor-v2-debug.ts
@@ -39,7 +39,7 @@ const LANES: readonly Lane[] = [
   "done",
 ];
 const CARD_TYPES: readonly CardType[] = ["pr", "mission", "task", "deploy", "draft", "done"];
-const AGENT_TYPES: readonly AgentType[] = ["claude", "codex", "test-writer", "security", "docs", "hermes", "ext"];
+const AGENT_TYPES: readonly AgentType[] = ["claude", "codex", "test-writer", "security", "docs", "hermes", "harness", "ext"];
 const CARD_STATES: readonly CardState[] = ["fresh", "stale", "failed-fetch", "source-offline", "running"];
 const RISK_TAGS: readonly RiskTag[] = [
   "workflow",

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -47,6 +47,10 @@ import {
   type HermesDecisionRecord,
 } from "@avg/averray-mcp/decision-records";
 import {
+  agentRunProjectionV1Schema,
+  type AgentRunProjectionV1,
+} from "@avg/schemas";
+import {
   evaluateReviewPanel,
   type ReviewPanelEvaluation,
   type ReviewPanelResponse,
@@ -68,7 +72,7 @@ export type Lane =
 
 export type CardType = "pr" | "mission" | "task" | "deploy" | "draft" | "done";
 
-export type AgentType = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "ext";
+export type AgentType = "claude" | "codex" | "test-writer" | "security" | "docs" | "hermes" | "harness" | "ext";
 
 export type CardState = "fresh" | "stale" | "failed-fetch" | "source-offline" | "running";
 
@@ -133,7 +137,7 @@ export interface CardRunnerHeartbeat {
 export interface CardWorkingNow {
   agent: AgentType;
   label: string;
-  source: "runner" | "mission" | "classifier";
+  source: "runner" | "mission" | "classifier" | "harness";
   runnerId?: string;
   taskId?: string;
   since?: string;
@@ -184,7 +188,7 @@ export interface CardDiscussionMessage {
 
 export interface CardSourceFailure {
   code: string;
-  source: "github" | "runner" | "deploy" | "codex";
+  source: "github" | "runner" | "deploy" | "codex" | "harness";
   message: string;
   lastGoodAt?: string;
 }
@@ -350,6 +354,8 @@ export interface BoardCard {
   output?: string;
   /** Codex task cards: failure reason when the task failed. */
   failureReason?: string;
+  /** Read-only, schema-validated projection of an allowlisted generic Harness run. */
+  harnessRun?: AgentRunProjectionV1;
   /** Source read / heartbeat failure behind a degraded card. */
   sourceFailure?: CardSourceFailure;
   /** Codex task cards: runner liveness. */
@@ -510,6 +516,7 @@ export function mapTagsToRisk(tags: ReadonlyArray<string> | undefined): RiskTag[
 export function inferCardType(item: HermesBoardCardSnapshot, lane: Lane): CardType {
   const tags = (item.tags ?? []).map((t) => String(t).toLowerCase());
   const title = (item.title ?? "").toLowerCase();
+  if (item.harnessRun) return "task";
   if (tags.includes("testbed") || /\bmission\b/.test(title)) return "mission";
   if (lane === "done") return "done";
   if (lane === "codex-needed") return "task";
@@ -542,6 +549,7 @@ export function agentTypeFromBranch(headBranch?: string): AgentType | undefined 
  */
 export function inferAgentType(item: HermesBoardCardSnapshot, type: CardType): AgentType {
   if (type === "mission") return "hermes";
+  if (item.harnessRun) return "harness";
   const fromBranch = agentTypeFromBranch(item.headBranch);
   if (fromBranch) return fromBranch;
   const owner = (item.owner ?? "").toLowerCase();
@@ -602,6 +610,7 @@ export function cardId(item: HermesBoardCardSnapshot): string {
   if (item.repo && typeof item.number === "number") {
     return `${shortRepo(item.repo)} #${item.number}`;
   }
+  if (item.workItemId) return item.workItemId;
   const slug = slugify(item.title ?? "card").slice(0, 40);
   // Identity-less cards (deploy verifications, missions, tasks) often
   // share a generic title — e.g. every "post-deploy verification" card.
@@ -699,6 +708,103 @@ function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
+interface IndexedHarnessProjection {
+  projection?: AgentRunProjectionV1;
+  failure?: {
+    code: string;
+    message: string;
+    observedAt?: string;
+  };
+}
+
+function indexHarnessProjections(rawSnapshot: unknown): Map<string, IndexedHarnessProjection> {
+  const root = asRecord(rawSnapshot);
+  const harnessRuns = asRecord(root?.harnessRuns);
+  const index = new Map<string, IndexedHarnessProjection>();
+  if (harnessRuns?.enabled !== true) return index;
+  for (const entry of asArray(harnessRuns.items)) {
+    const item = asRecord(entry);
+    const parsed = agentRunProjectionV1Schema.safeParse(item?.projection);
+    if (!parsed.success) continue;
+    index.set(parsed.data.workItemId, { projection: parsed.data });
+  }
+  for (const entry of asArray(harnessRuns.failures)) {
+    const failure = asRecord(entry);
+    const binding = asRecord(failure?.binding);
+    const workItemId = asString(binding?.workItemId);
+    const code = asString(failure?.code);
+    const message = asString(failure?.message);
+    if (!workItemId || !code || !message) continue;
+    index.set(workItemId, {
+      failure: {
+        code,
+        message,
+        ...(asString(failure?.observedAt) ? { observedAt: asString(failure?.observedAt) } : {}),
+      },
+    });
+  }
+  return index;
+}
+
+function attachHarnessProjection(
+  card: BoardCard,
+  item: HermesBoardCardSnapshot,
+  indexed: IndexedHarnessProjection | undefined,
+): BoardCard {
+  if (!item.harnessRun || !indexed) return card;
+  if (indexed.failure) {
+    card.state = "source-offline";
+    card.sourceFailure = {
+      source: "harness",
+      code: indexed.failure.code,
+      message: indexed.failure.message,
+    };
+    card.taskStatus = "failed";
+    card.failureReason = indexed.failure.message;
+    return card;
+  }
+  const projection = indexed.projection;
+  if (!projection) return card;
+  card.harnessRun = projection;
+  if (card.type === "task") card.agentType = "harness";
+  card.taskStatus = harnessTaskStatus(projection);
+  if (projection.failure) card.failureReason = projection.failure.message;
+  if (projection.source.health !== "healthy") {
+    card.state = projection.source.health === "stale"
+      ? "stale"
+      : projection.source.health === "unavailable"
+        ? "source-offline"
+        : "failed-fetch";
+    card.sourceFailure = {
+      source: "harness",
+      code: `harness_source_${projection.source.health}`,
+      message: projection.source.reason ?? `Harness source is ${projection.source.health}`,
+      ...(projection.source.sourceUpdatedAt
+        ? { lastGoodAt: projection.source.sourceUpdatedAt }
+        : {}),
+    };
+  } else if (!projection.run.terminal) {
+    card.state = "running";
+  }
+  if (!projection.run.terminal && projection.source.health === "healthy") {
+    card.workingNow = {
+      agent: "harness",
+      label: projection.progress.summary,
+      source: "harness",
+      taskId: projection.harnessRunId,
+      since: projection.source.sourceUpdatedAt,
+    };
+  }
+  return card;
+}
+
+function harnessTaskStatus(projection: AgentRunProjectionV1): TaskStatus {
+  if (projection.run.outcome === "completed") return "completed";
+  if (projection.run.outcome === "cancelled") return "cancelled";
+  if (projection.run.outcome === "failed" || projection.run.outcome === "partial") return "failed";
+  return "running";
+}
+
 function mapTaskEvents(task: Record<string, unknown>): TaskTimelineEvent[] {
   return asArray(task.events).flatMap((entry) => {
     const event = asRecord(entry);
@@ -738,6 +844,7 @@ function defaultWorkingNowLabel(agent: AgentType): string {
   if (agent === "security") return "Security reviewing";
   if (agent === "docs") return "Docs updating";
   if (agent === "hermes") return "Hermes reviewing";
+  if (agent === "harness") return "Harness executing";
   return "External agent working";
 }
 
@@ -2061,6 +2168,7 @@ function agentTypeFromTaskAgent(value: unknown): AgentType {
   if (value === "security") return "security";
   if (value === "docs") return "docs";
   if (value === "hermes") return "hermes";
+  if (value === "harness") return "harness";
   if (value === "ext") return "ext";
   return "codex";
 }
@@ -2361,6 +2469,7 @@ export function buildV2BoardSnapshot(
   const items = classified?.items ?? [];
   const summaryIndex = indexRawSummaries(rawSnapshot);
   const codexIndex = indexCodexTasks(rawSnapshot);
+  const harnessIndex = indexHarnessProjections(rawSnapshot);
   const missionIndex = indexTestbedMissions(rawSnapshot);
   const reviewRequests = reviewRequestsFromSnapshot(rawSnapshot);
   const discussionMessages = discussionMessagesFromSnapshot(rawSnapshot);
@@ -2370,7 +2479,7 @@ export function buildV2BoardSnapshot(
   const sourceCards = items.map((item) => {
     const base = toBoardCard(item);
     const key = prKey(item.repo, item.number);
-    const enriched = enrichBoardCard(base, item, {
+    const enriched = attachHarnessProjection(enrichBoardCard(base, item, {
       summary: key ? summaryIndex.get(key) : undefined,
       codexTask: key ? codexIndex.get(key) : undefined,
       runner,
@@ -2378,7 +2487,7 @@ export function buildV2BoardSnapshot(
         base.type === "mission" && item.correlationId
           ? missionIndex.get(item.correlationId)
           : undefined,
-    });
+    }), item, item.workItemId ? harnessIndex.get(item.workItemId) : undefined);
     const withReviews = attachReviewRequests(enriched, reviewRequests, {
       ...(key ? { relatedPrKey: key } : {}),
       ...(base.type === "mission" && item.correlationId ? { relatedMissionId: item.correlationId } : {}),

--- a/services/slack-operator/tsconfig.json
+++ b/services/slack-operator/tsconfig.json
@@ -7,7 +7,8 @@
   },
   "references": [
     { "path": "../../packages/mcp-common" },
-    { "path": "../../packages/averray-mcp" }
+    { "path": "../../packages/averray-mcp" },
+    { "path": "../../packages/schemas" }
   ],
   "include": ["src/**/*.ts"]
 }

--- a/test/fixtures/harness-integration/failed-events.txt
+++ b/test/fixtures/harness-integration/failed-events.txt
@@ -1,0 +1,6 @@
+1 TaskAccepted payload={"task_id":"pilot-failed"}
+2 ContractCompiled payload={"draft_manifest_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","risk_class":"low","task_hash":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+3 ModelRequested payload={"model_ref":"example-model","role":"executor"}
+4 ModelResponded payload={"usage":{"input_tokens":200,"output_tokens":75,"requests":1}}
+5 VerificationCompleted payload={"passed":false,"report_ref":"artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","verdict":"failed"}
+6 RunCompleted payload={"deliverables":{},"outcome":"failed","reason":"verification_failed"}

--- a/test/fixtures/harness-integration/failed-status.txt
+++ b/test/fixtures/harness-integration/failed-status.txt
@@ -1,0 +1,8 @@
+run_id=22222222-2222-4222-8222-222222222222
+state=failed
+attempt=2
+outcome=failed
+outcome_reason=verification_failed
+egress_policy=deny_all []
+created_at=2026-07-23T12:00:00+00:00
+updated_at=2026-07-23T12:11:00+00:00

--- a/test/fixtures/harness-integration/pilot-registry-v1.json
+++ b/test/fixtures/harness-integration/pilot-registry-v1.json
@@ -1,0 +1,124 @@
+{
+  "schemaVersion": 1,
+  "kind": "harness_run_registry",
+  "bindings": [
+    {
+      "workItemId": "work-harness-success-001",
+      "correlationId": "correlation-harness-success-001",
+      "harnessRunId": "11111111-1111-4111-8111-111111111111",
+      "taskVersion": 1,
+      "repository": "depre-dev/agent",
+      "title": "Successful Harness pilot fixture",
+      "summary": "A representative bounded coding run for the read-only Harness CLI adapter.",
+      "registeredAt": "2026-07-23T12:00:00.000Z",
+      "staleAfterSeconds": 300,
+      "manifest": {
+        "hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "profile": "coding-change",
+        "riskClass": "low",
+        "effectiveCapabilities": [
+          "fs.write_file"
+        ],
+        "network": "deny",
+        "policyHash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "verifierHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "modelBindings": [
+          {
+            "role": "executor",
+            "adapter": "openai-compatible",
+            "provider": "example-provider",
+            "modelRef": "example-model",
+            "profileHash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+          }
+        ],
+        "skillVersions": [
+          "coding-change@1.0.0"
+        ]
+      },
+      "budget": {
+        "elapsedSecondsLimit": 1800,
+        "modelTokensLimit": 50000,
+        "toolCallsLimit": 100,
+        "estimatedUsdMicrosLimit": 5000000
+      }
+    },
+    {
+      "workItemId": "work-harness-failed-001",
+      "correlationId": "correlation-harness-failed-001",
+      "harnessRunId": "22222222-2222-4222-8222-222222222222",
+      "taskVersion": 1,
+      "repository": "depre-dev/agent",
+      "title": "Failed Harness pilot fixture",
+      "registeredAt": "2026-07-23T12:00:00.000Z",
+      "staleAfterSeconds": 300,
+      "manifest": {
+        "hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "profile": "coding-change",
+        "riskClass": "low",
+        "effectiveCapabilities": [
+          "fs.write_file"
+        ],
+        "network": "deny",
+        "policyHash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "verifierHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "modelBindings": [
+          {
+            "role": "executor",
+            "adapter": "openai-compatible",
+            "provider": "example-provider",
+            "modelRef": "example-model",
+            "profileHash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+          }
+        ],
+        "skillVersions": [
+          "coding-change@1.0.0"
+        ]
+      },
+      "budget": {
+        "elapsedSecondsLimit": 1800,
+        "modelTokensLimit": 50000,
+        "toolCallsLimit": 100,
+        "estimatedUsdMicrosLimit": 5000000
+      }
+    },
+    {
+      "workItemId": "work-harness-quarantined-001",
+      "correlationId": "correlation-harness-quarantined-001",
+      "harnessRunId": "33333333-3333-4333-8333-333333333333",
+      "taskVersion": 1,
+      "repository": "depre-dev/agent",
+      "title": "Quarantined Harness pilot fixture",
+      "registeredAt": "2026-07-23T12:00:00.000Z",
+      "staleAfterSeconds": 300,
+      "manifest": {
+        "hash": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "profile": "coding-change",
+        "riskClass": "low",
+        "effectiveCapabilities": [
+          "fs.write_file"
+        ],
+        "network": "deny",
+        "policyHash": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "verifierHash": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "modelBindings": [
+          {
+            "role": "executor",
+            "adapter": "openai-compatible",
+            "provider": "example-provider",
+            "modelRef": "example-model",
+            "profileHash": "sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+          }
+        ],
+        "skillVersions": [
+          "coding-change@1.0.0"
+        ]
+      },
+      "budget": {
+        "elapsedSecondsLimit": 1800,
+        "modelTokensLimit": 50000,
+        "toolCallsLimit": 100,
+        "estimatedUsdMicrosLimit": 5000000
+      }
+    }
+  ]
+}

--- a/test/fixtures/harness-integration/quarantined-events.txt
+++ b/test/fixtures/harness-integration/quarantined-events.txt
@@ -1,0 +1,3 @@
+1 TaskAccepted payload={"task_id":"pilot-quarantined"}
+2 ContractCompiled payload={"draft_manifest_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","risk_class":"low","task_hash":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+3 SafetyTripwireTriggered payload={"action":"quarantine","reason":"protected_path_write"}

--- a/test/fixtures/harness-integration/quarantined-status.txt
+++ b/test/fixtures/harness-integration/quarantined-status.txt
@@ -1,0 +1,7 @@
+run_id=33333333-3333-4333-8333-333333333333
+state=quarantined
+attempt=1
+outcome_reason=safety_tripwire_triggered
+egress_policy=deny_all []
+created_at=2026-07-23T12:00:00+00:00
+updated_at=2026-07-23T12:02:00+00:00

--- a/test/fixtures/harness-integration/successful-deliverables.txt
+++ b/test/fixtures/harness-integration/successful-deliverables.txt
@@ -1,0 +1,1 @@
+patch artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa

--- a/test/fixtures/harness-integration/successful-events.txt
+++ b/test/fixtures/harness-integration/successful-events.txt
@@ -1,0 +1,8 @@
+1 TaskAccepted payload={"task_id":"pilot-success"}
+2 ContractCompiled payload={"draft_manifest_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","risk_class":"low","task_hash":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
+3 ModelRequested payload={"model_ref":"example-model","role":"executor"}
+4 ModelResponded payload={"usage":{"input_tokens":100,"output_tokens":50,"requests":1}}
+5 CapabilityDispatched payload={"capability":"fs.write_file"}
+6 ArtifactCreated payload={"artifact_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","artifact_uri":"artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","deliverable_type":"patch"}
+7 VerificationCompleted payload={"passed":true,"report_ref":"artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","verdict":"completed"}
+8 RunCompleted payload={"deliverables":{"patch":"artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"outcome":"completed","reason":null}

--- a/test/fixtures/harness-integration/successful-status.txt
+++ b/test/fixtures/harness-integration/successful-status.txt
@@ -1,0 +1,8 @@
+run_id=11111111-1111-4111-8111-111111111111
+state=completed
+attempt=1
+outcome=completed
+outcome_reason=-
+egress_policy=deny_all []
+created_at=2026-07-23T12:00:00+00:00
+updated_at=2026-07-23T12:10:00+00:00

--- a/test/unit/harness-integration-projection.test.ts
+++ b/test/unit/harness-integration-projection.test.ts
@@ -1,0 +1,382 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  createHarnessCliReadPort,
+  HarnessReadError,
+  parseHarnessEvents,
+  parseHarnessStatus,
+  type HarnessCommandExecutor,
+  type HarnessReadPort,
+} from "../../services/slack-operator/src/harness-read-port.js";
+import {
+  collectHarnessRunProjections,
+  projectHarnessRun,
+} from "../../services/slack-operator/src/harness-run-projection.js";
+import {
+  harnessProjectionEnabled,
+  harnessProjectionReadTimeoutMs,
+  parseHarnessRunRegistry,
+  type HarnessRunBinding,
+} from "../../services/slack-operator/src/harness-run-registry.js";
+import { buildHermesBoardSnapshotFromMonitor } from "../../services/slack-operator/src/monitor-hermes-board.js";
+import { buildV2BoardSnapshot } from "../../services/slack-operator/src/monitor-v2.js";
+
+const FIXTURE_ROOT = "test/fixtures/harness-integration";
+const NOW = new Date("2026-07-23T12:11:10.000Z");
+
+function textFixture(name: string): string {
+  return readFileSync(`${FIXTURE_ROOT}/${name}`, "utf8");
+}
+
+function registryFixture() {
+  return parseHarnessRunRegistry(JSON.parse(textFixture("pilot-registry-v1.json")));
+}
+
+function bindingAt(index: number): HarnessRunBinding {
+  return registryFixture().bindings[index]!;
+}
+
+function capturedExecutor(calls: string[][]): HarnessCommandExecutor {
+  return async (_command, args) => {
+    calls.push([...args]);
+    const runId = args[2];
+    const verb = args[1];
+    const prefix = runId?.startsWith("1111")
+      ? "successful"
+      : runId?.startsWith("2222")
+        ? "failed"
+        : "quarantined";
+    const name = verb === "status"
+      ? `${prefix}-status.txt`
+      : verb === "events"
+        ? `${prefix}-events.txt`
+        : prefix === "successful"
+          ? "successful-deliverables.txt"
+          : undefined;
+    return {
+      code: 0,
+      stdout: name ? textFixture(name) : "",
+      stderr: "",
+    };
+  };
+}
+
+describe("INT-1 Harness pilot registry", () => {
+  it("keeps projection off by default and bounds the read timeout", () => {
+    expect(harnessProjectionEnabled({})).toBe(false);
+    expect(harnessProjectionEnabled({ HARNESS_PROJECTION_ENABLED: "false" })).toBe(false);
+    expect(harnessProjectionEnabled({ HARNESS_PROJECTION_ENABLED: "true" })).toBe(true);
+    expect(harnessProjectionReadTimeoutMs({})).toBe(5_000);
+    expect(harnessProjectionReadTimeoutMs({ HARNESS_PROJECTION_READ_TIMEOUT_MS: "1" })).toBe(250);
+    expect(harnessProjectionReadTimeoutMs({ HARNESS_PROJECTION_READ_TIMEOUT_MS: "999999" })).toBe(30_000);
+  });
+
+  it("loads strict, secret-free, immutable pilot bindings", () => {
+    const registry = registryFixture();
+    expect(registry.schemaVersion).toBe(1);
+    expect(registry.bindings).toHaveLength(3);
+    expect(registry.bindings[0]?.staleAfterSeconds).toBe(300);
+  });
+
+  it("rejects unknown versions, duplicate identities, undeclared fields, and secret-like data", () => {
+    const input = JSON.parse(textFixture("pilot-registry-v1.json")) as Record<string, unknown>;
+    expect(() => parseHarnessRunRegistry({ ...input, schemaVersion: 2 })).toThrow(/invalid/i);
+    expect(() => parseHarnessRunRegistry({ ...input, undeclared: true })).toThrow(/invalid/i);
+
+    const bindings = structuredClone(input.bindings) as Array<Record<string, unknown>>;
+    bindings[1]!.workItemId = bindings[0]!.workItemId;
+    expect(() => parseHarnessRunRegistry({ ...input, bindings })).toThrow(/duplicate workItemId/);
+
+    const optionBindings = structuredClone(input.bindings) as Array<Record<string, unknown>>;
+    optionBindings[0]!.harnessRunId = "--help";
+    expect(() => parseHarnessRunRegistry({ ...input, bindings: optionBindings })).toThrow(/invalid/i);
+
+    const secretBindings = structuredClone(input.bindings) as Array<Record<string, unknown>>;
+    secretBindings[0]!.apiToken = "sk-example-example-example";
+    expect(() => parseHarnessRunRegistry({ ...input, bindings: secretBindings }))
+      .toThrow(/secret-like value/);
+  });
+});
+
+describe("INT-1 fixed Harness read port", () => {
+  it("uses only status, events, and terminal deliverables for a successful immutable run id", async () => {
+    const calls: string[][] = [];
+    const read = await createHarnessCliReadPort({ execute: capturedExecutor(calls) })
+      .readRun(bindingAt(0));
+
+    expect(read.status).toMatchObject({
+      runId: "11111111-1111-4111-8111-111111111111",
+      state: "completed",
+      outcome: "completed",
+      egressPolicy: "deny",
+    });
+    expect(read.events.at(-1)?.type).toBe("RunCompleted");
+    expect(read.deliverables[0]?.artifact.sha256)
+      .toBe("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(calls).toEqual([
+      ["run", "status", "11111111-1111-4111-8111-111111111111"],
+      ["run", "events", "11111111-1111-4111-8111-111111111111"],
+      ["run", "deliverables", "11111111-1111-4111-8111-111111111111"],
+    ]);
+  });
+
+  it("does not request deliverables for a quarantined non-terminal record", async () => {
+    const calls: string[][] = [];
+    const read = await createHarnessCliReadPort({ execute: capturedExecutor(calls) })
+      .readRun(bindingAt(2));
+    expect(read.status.state).toBe("quarantined");
+    expect(read.status.outcome).toBeUndefined();
+    expect(calls.map((args) => args[1])).toEqual(["status", "events"]);
+  });
+
+  it("refuses unknown run states and event versions visibly", () => {
+    const secretState = "future_state_with_password";
+    const status = textFixture("successful-status.txt").replace("state=completed", `state=${secretState}`);
+    expect(() => parseHarnessStatus(status, bindingAt(0).harnessRunId))
+      .toThrow(/unsupported run state/);
+    expect(() => parseHarnessStatus(status, bindingAt(0).harnessRunId))
+      .not.toThrow(new RegExp(secretState));
+    const secretEvent = "FutureEventWithPassword";
+    expect(() => parseHarnessEvents(`1 ${secretEvent} payload={"schemaVersion":2}\n`))
+      .toThrow(/unsupported event type/);
+    expect(() => parseHarnessEvents(`1 ${secretEvent} payload={"schemaVersion":2}\n`))
+      .not.toThrow(new RegExp(secretEvent));
+  });
+
+  it("propagates bounded read failures without leaking CLI credentials", async () => {
+    const port = createHarnessCliReadPort({
+      execute: async () => ({
+        code: 2,
+        stdout: "",
+        stderr: "connection failed for postgresql://pilot:super-secret@example.invalid/harness",
+      }),
+    });
+    await expect(port.readRun(bindingAt(0))).rejects.toThrow(/Harness data source is unavailable/);
+    await expect(port.readRun(bindingAt(0))).rejects.not.toThrow(/super-secret/);
+
+    const timeoutPort = createHarnessCliReadPort({
+      execute: async () => {
+        throw new HarnessReadError("cli_timeout", "Harness read command timed out", true);
+      },
+    });
+    await expect(timeoutPort.readRun(bindingAt(0))).rejects.toMatchObject({
+      code: "cli_timeout",
+      retryable: true,
+    });
+  });
+
+  it("contains no mutating Harness argv path", () => {
+    const source = readFileSync("services/slack-operator/src/harness-read-port.ts", "utf8");
+    for (const verb of ["submit", "approve", "deny", "cancel", "release"]) {
+      expect(source).not.toContain(`["run", "${verb}"`);
+    }
+    expect(source).not.toMatch(/\["(?:skills|wallet|github|artifact)",/);
+    expect(() => createHarnessCliReadPort({ command: "bash" })).toThrow(/executable named harness/);
+  });
+});
+
+describe("INT-1 deterministic AgentRunProjection", () => {
+  it("projects successful and failed CLI fixtures deterministically", async () => {
+    const port = createHarnessCliReadPort({ execute: capturedExecutor([]) });
+    const successfulRead = await port.readRun(bindingAt(0));
+    const first = projectHarnessRun(bindingAt(0), successfulRead, { now: NOW });
+    const second = projectHarnessRun(bindingAt(0), successfulRead, { now: NOW });
+    expect(second).toEqual(first);
+    expect(first).toMatchObject({
+      workItemId: "work-harness-success-001",
+      run: { state: "completed", terminal: true, outcome: "completed" },
+      source: { health: "healthy" },
+      verification: { status: "passed" },
+      budget: { modelTokensUsed: 150, toolCallsUsed: 1 },
+    });
+    expect(first.artifacts).toHaveLength(1);
+
+    const failed = projectHarnessRun(
+      bindingAt(1),
+      await port.readRun(bindingAt(1)),
+      { now: NOW },
+    );
+    expect(failed).toMatchObject({
+      run: { state: "failed", terminal: true, outcome: "failed" },
+      verification: { status: "failed" },
+      failure: {
+        code: "verification_failed",
+        message: "verification_failed",
+        retryable: true,
+      },
+    });
+  });
+
+  it("keeps quarantined runs visible with structured failure and no invented outcome", async () => {
+    const port = createHarnessCliReadPort({ execute: capturedExecutor([]) });
+    const projection = projectHarnessRun(
+      bindingAt(2),
+      await port.readRun(bindingAt(2)),
+      { now: new Date("2026-07-23T12:02:10.000Z") },
+    );
+    expect(projection.run).toMatchObject({ state: "quarantined", terminal: false });
+    expect(projection.run.outcome).toBeUndefined();
+    expect(projection.failure).toMatchObject({
+      code: "safety_tripwire_triggered",
+      retryable: false,
+    });
+  });
+
+  it("redacts failure details and never derives a failure code from secret text", async () => {
+    const port = createHarnessCliReadPort({ execute: capturedExecutor([]) });
+    const read = await port.readRun(bindingAt(1));
+    const projection = projectHarnessRun(
+      bindingAt(1),
+      {
+        ...read,
+        status: {
+          ...read.status,
+          outcomeReason: "password=hunter2",
+        },
+      },
+      { now: NOW },
+    );
+    expect(projection.run.reason).toBe("password=[redacted]");
+    expect(projection.failure).toMatchObject({
+      code: "harness_failed",
+      message: "password=[redacted]",
+    });
+    expect(JSON.stringify(projection)).not.toContain("hunter2");
+  });
+
+  it("marks old reads stale and rejects a live/pinned manifest mismatch", async () => {
+    const port = createHarnessCliReadPort({ execute: capturedExecutor([]) });
+    const read = await port.readRun(bindingAt(0));
+    const oldTerminal = projectHarnessRun(bindingAt(0), read, {
+      now: new Date("2026-07-23T12:20:00.000Z"),
+    });
+    expect(oldTerminal.source.health).toBe("healthy");
+
+    const stale = projectHarnessRun(bindingAt(2), await port.readRun(bindingAt(2)), {
+      now: new Date("2026-07-23T12:20:00.000Z"),
+    });
+    expect(stale.source).toMatchObject({ health: "stale" });
+    expect(stale.source.reason).toMatch(/not updated/);
+
+    expect(() => projectHarnessRun(
+      {
+        ...bindingAt(0),
+        manifest: {
+          ...bindingAt(0).manifest,
+          network: { allowlist: ["example.com"] },
+        },
+      },
+      read,
+      { now: NOW },
+    )).toThrow(/does not match the pinned/);
+  });
+
+  it("turns source denial into a visible unavailable failure, never a healthy projection", async () => {
+    const deniedPort: HarnessReadPort = {
+      readRun: async () => {
+        throw new HarnessReadError("cli_failed", "Harness data source refused the read", true);
+      },
+    };
+    const snapshot = await collectHarnessRunProjections(
+      { ...registryFixture(), bindings: [bindingAt(0)] },
+      deniedPort,
+      { now: NOW },
+    );
+    expect(snapshot.items).toHaveLength(0);
+    expect(snapshot.failures[0]).toMatchObject({
+      code: "cli_failed",
+      message: "Harness data source refused the read",
+      retryable: true,
+    });
+  });
+});
+
+describe("INT-1 monitor correlation", () => {
+  it("renders one Harness-tagged work-queue card with structured facts only", async () => {
+    const registry = { ...registryFixture(), bindings: [bindingAt(0)] };
+    const harnessRuns = await collectHarnessRunProjections(
+      registry,
+      createHarnessCliReadPort({ execute: capturedExecutor([]) }),
+      { now: NOW },
+    );
+    const raw = {
+      generatedAt: NOW.toISOString(),
+      active: [
+        {
+          correlationId: bindingAt(0).correlationId,
+          title: "Legacy duplicate for the same work item",
+          intent: "coding",
+          status: "running",
+        },
+      ],
+      recent: [],
+      harnessRuns,
+    };
+    const board = buildV2BoardSnapshot(raw, { now: () => NOW });
+    expect(board.cards).toHaveLength(1);
+    expect(board.cards[0]).toMatchObject({
+      id: "work-harness-success-001",
+      correlationId: "correlation-harness-success-001",
+      lane: "codex-needed",
+      type: "task",
+      agentType: "harness",
+      taskStatus: "completed",
+      harnessRun: {
+        harnessRunId: "11111111-1111-4111-8111-111111111111",
+      },
+    });
+
+    const hermesBoard = buildHermesBoardSnapshotFromMonitor(raw)!;
+    expect(hermesBoard.items).toHaveLength(1);
+    const context = JSON.stringify(hermesBoard.items?.[0]);
+    expect(context).toContain('"sourceHealth":"healthy"');
+    expect(context).not.toContain("ModelRequested");
+    expect(context).not.toContain("input_tokens");
+  });
+
+  it("routes failed and source-unavailable Harness records to attention", async () => {
+    const failedRuns = await collectHarnessRunProjections(
+      { ...registryFixture(), bindings: [bindingAt(1)] },
+      createHarnessCliReadPort({ execute: capturedExecutor([]) }),
+      { now: NOW },
+    );
+    const failedCard = buildV2BoardSnapshot({
+      generatedAt: NOW.toISOString(),
+      active: [],
+      recent: [],
+      harnessRuns: failedRuns,
+    }, { now: () => NOW }).cards[0]!;
+    expect(failedCard).toMatchObject({
+      lane: "needs-attention",
+      agentType: "harness",
+      taskStatus: "failed",
+      failureReason: "verification_failed",
+    });
+
+    const unavailable = await collectHarnessRunProjections(
+      { ...registryFixture(), bindings: [bindingAt(0)] },
+      {
+        readRun: async () => {
+          throw new HarnessReadError("cli_failed", "Harness data source refused the read", true);
+        },
+      },
+      { now: NOW },
+    );
+    const unavailableCard = buildV2BoardSnapshot({
+      generatedAt: NOW.toISOString(),
+      active: [],
+      recent: [],
+      harnessRuns: unavailable,
+    }, { now: () => NOW }).cards[0]!;
+    expect(unavailableCard).toMatchObject({
+      lane: "needs-attention",
+      state: "source-offline",
+      sourceFailure: {
+        source: "harness",
+        code: "cli_failed",
+      },
+    });
+  });
+});

--- a/test/unit/monitor-hermes-narration.test.ts
+++ b/test/unit/monitor-hermes-narration.test.ts
@@ -170,4 +170,37 @@ describe("Hermes proactive board narration", () => {
     expect(text).toContain("smallest verifiable fix");
     expect(text).toContain("waiting for the red signal to disappear");
   });
+
+  it("narrates only structured Harness facts in Hermes's voice", () => {
+    const text = fallbackHermesBoardNarration(board({
+      counts: { codex: 1 },
+      items: [
+        {
+          workItemId: "work-harness-1",
+          title: "Bounded Harness pilot",
+          lane: "Codex Needed",
+          owner: "Harness",
+          verdict: "Harness executing",
+          why: "Harness is executing the bounded task.",
+          next: "follow the read-only Harness progress",
+          correlationId: "correlation-harness-1",
+          harnessRun: {
+            runId: "run-harness-1",
+            state: "executing",
+            sourceHealth: "healthy",
+            phase: "executing",
+            progress: "Harness is executing the bounded task.",
+            verification: "pending",
+            artifactCount: 0,
+          },
+        },
+      ],
+    }));
+
+    expect(text).toContain("read-only Harness projection");
+    expect(text).toContain("Source is healthy");
+    expect(text).toContain("Harness, keep the bounded run moving");
+    expect(text).toContain("this board has no Harness mutation authority");
+    expect(text).not.toContain("Codex-owned");
+  });
 });


### PR DESCRIPTION
## What changed

- adds a strict, secret-free registry for allowlisted pilot Harness run bindings
- adds a fixed-argv, read-only Harness CLI port limited to known-run `status`, `events`, and terminal `deliverables`
- deterministically maps Harness evidence into the shared `AgentRunProjection` V1 contract
- correlates Harness projections into one existing board card per work item without changing persisted lane IDs
- adds Harness attribution, structured progress, manifest/budget/artifact details, failure redaction, and read-only controls to the monitor UI
- changes visible shared-lane copy to **Work queue** while preserving the internal `codex-needed` identifier
- updates Hermes narration with bounded structured Harness facts only
- documents configuration, rollback, safety pins, and the remaining live-pilot acceptance proof

## Why

INT-1 introduces honest Harness visibility before any dispatcher or mutation authority. It keeps Harness execution evidence separate from Hermes coordination and preserves GitHub/CI authority once a PR exists.

## Safety and authority

- `HARNESS_PROJECTION_ENABLED` defaults to false
- no `HARNESS_DISPATCH_ENABLED` path exists
- no submit, approve, deny, cancel, release, artifact-content, wallet, GitHub-write, Averray-mutation, or deployment command is available through the adapter
- unknown states/events, malformed output, source denial, stale data, and manifest mismatches fail visibly
- raw CLI credentials, event payloads, and model messages are not projected to the board or Hermes

## Checks

- `npm run typecheck`
- `npm test` — 177 files, 2,192 tests passed
- `npm run build`
- `git diff --check`

## Affected surfaces

- backend / Slack operator: yes, read-only and default-off
- frontend / monitor UI: yes
- shared schemas: exported existing manifest projection schema; V1 wire shape unchanged
- indexer: no
- contracts: no
- Caddy / deployment: no
- public site: no
- existing Codex/Claude runners: unchanged

## Environment and rollout

Optional pilot configuration only:

- `HARNESS_PROJECTION_ENABLED=true`
- `HARNESS_PROJECTION_BINDINGS_PATH=<secret-free registry path>`
- `HARNESS_CLI_COMMAND=harness`
- `HARNESS_PROJECTION_READ_TIMEOUT_MS=5000`

No new VPS secret is introduced by this PR. The Harness CLI data-source credential remains external runtime secret material.

## Remaining acceptance proof

The local environment did not have a Harness executable, `HARNESS_DATABASE_URL`, or operator-selected immutable run IDs. Before rollout acceptance, project one real successful and one real failed run, capture board evidence, simulate source denial, confirm the card degrades rather than staying healthy, and disable the flag unless continued supervised observation is explicitly approved.