### PR TITLE
Fix live Harness artifact projection for INT-1

### DIFF
--- a/docs/HARNESS_INT1_HANDBACK.md
+++ b/docs/HARNESS_INT1_HANDBACK.md
@@ -1,10 +1,12 @@
 # INT-1 handback — read-only Harness projection
 
-**Status:** implementation complete; pending review and live-pilot proof
+**Status:** live pilot complete; acceptance pending live-compatibility follow-up merge
 
-**Branch:** `codex/harness-int1-projection`
+**Original branch:** `codex/harness-int1-projection` (merged as `304c979`)
 
-**Baseline:** `3e559b85d99219ef3dc9ff174f30e9275af92512` (`origin/main`, merged INT-0)
+**Live-compatibility follow-up:** `codex/harness-int1-live-compat`
+
+**Follow-up baseline:** `304c9790e73be79622d173f72f3c1ef1f17ed5cd`
 
 **Runtime authority change:** read-only observation only, off by default
 
@@ -78,8 +80,9 @@ must not be copied into that file, logs, prompts, or the board.
    GitHub-write, Averray-mutation, or dispatch command exists in the adapter.
 4. Unknown Harness states or event types fail visibly rather than being coerced
    into current state.
-5. The live egress policy, compiled risk class, and observed model role/ref must
-   agree with the pinned manifest when the CLI exposes them.
+5. The final manifest hash, live egress policy, compiled risk class, and
+   observed model role/ref must agree with the pinned manifest when the CLI
+   exposes them.
 6. Terminal deliverables are content-addressed references only; INT-1 does not
    read artifact contents.
 7. Failed and quarantined records require structured failure detail.
@@ -89,25 +92,60 @@ must not be copied into that file, logs, prompts, or the board.
    “Ask Hermes” remains advisory.
 10. The flag defaults off and no `HARNESS_DISPATCH_ENABLED` path exists.
 
-## Live-pilot proof still required
+## Live-pilot proof — 2026-07-23
 
-This development environment had no `HARNESS_DATABASE_URL`, Harness CLI
-executable, or operator-selected immutable pilot IDs. The included successful,
-failed, and quarantined fixtures validate the current generic CLI grammar and
-projection behavior, but they are not claimed as production run evidence.
+The operator authorized a supervised local ceremony against Agent Harness
+`8ca7a27` using an isolated Postgres 18 database, the real Harness worker/CLI,
+and a deterministic scripted model. Both task intents were low risk, limited to
+30 seconds / 10,000 model tokens / 20 tool calls, and used deny-all network.
+No external model, production database, repository write, or dispatcher was
+involved.
 
-Before INT-1 is accepted for rollout, an operator must:
+| Case | Immutable run ID | Durable outcome | Verification report |
+|---|---|---|---|
+| Success | `9fa03502-2518-4023-a697-5ccf4c318b4c` | `completed` | `sha256:14798e631855ec89036e33568024e9337e9c9a2cfa1359e7390b6c1e336d7cb8` |
+| Intentional required-check failure | `ee4213a8-ace1-42dd-9694-71e091ff307b` | `failed` / `verification_failed` | `sha256:cacd7b2d3597c07637b7563b0aab06dfce94c2fb032954e1fdb50bfc63430106` |
 
-1. create/select one real successful and one real failed bounded Harness run;
-2. record their immutable IDs and final manifest pins in a secret-free registry;
-3. enable the flag in a non-production or supervised pilot environment;
-4. capture the board proof for both cards;
-5. deny/stop the read source once and confirm the card becomes degraded rather
-   than healthy;
-6. disable the flag after the proof unless the operator explicitly approves the
-   continued read-only pilot.
+The secret-free registry pinned the typed final manifests:
 
-This is a rollout proof, not a reason to add a dispatcher or broaden authority.
+- success manifest
+  `sha256:ed422b86eb9762ec4be00d5c1a44408209d179130f0096a448c30b73b9da70d5`;
+- failed manifest
+  `sha256:7067df6d9b07c2b3b14cd64aebb6125ba391f38bbb7c951abcb7e53c3dbc27e9`;
+- deny-all egress, low risk, the actual capability set, policy/verifier hashes,
+  and the `scripted-model` executor binding for each run.
+
+### Compatibility finding and correction
+
+The first read with merged `304c979` failed closed with `projection_invalid` for
+both runs. Current Harness emits a metadata-only
+`ArtifactCreated {"kind":"episode"}` after `RunCompleted`; the mapper incorrectly
+required every `ArtifactCreated` event to carry a deliverable URI. No card was
+reported healthy.
+
+The follow-up mapper now:
+
+- ignores metadata-only artifact lifecycle events while continuing to reject
+  malformed explicit artifact URIs/hashes;
+- binds verification decisions to the typed `verification_report` deliverable
+  when `VerificationCompleted` omits a `report_ref`;
+- rejects a live final-manifest hash that differs from the registry pin.
+
+With that correction, the success card projected as completed with passed
+verification and the failed card projected to `needs-attention` with failed
+verification. Both carried the correct report artifact, budget, final manifest,
+attempt, source, and Harness attribution.
+
+### Source-loss drill
+
+After the healthy read, the disposable Postgres source was stopped and removed.
+The next projection returned zero healthy items and two retryable `cli_failed`
+source failures. Both cards moved to `needs-attention` with
+`state=source-offline`; neither retained healthy state.
+
+The worker was then stopped, the projection flag remained disabled outside the
+scoped ceremony, and no pilot service or database was left running. This proof
+does not authorize a dispatcher or broaden Harness authority.
 
 ## Affected surfaces
 

--- a/services/slack-operator/src/harness-run-projection.ts
+++ b/services/slack-operator/src/harness-run-projection.ts
@@ -118,7 +118,7 @@ export function projectHarnessRun(
     : stale
       ? `Harness source has not updated for ${ageSeconds} seconds`
       : undefined;
-  const verification = verificationFromEvents(read.events);
+  const verification = verificationFromRead(read);
   const artifacts = artifactsFromRead(read);
   const failure = failureFromRead(read);
   const budget = budgetFromRead(binding, read);
@@ -198,6 +198,15 @@ function assertManifestMatchesLiveRead(
         throw new HarnessProjectionError(
           "manifest_mismatch",
           "Harness compiled risk class does not match the pinned pilot manifest",
+        );
+      }
+    }
+    if (event.type === "EnvironmentPrepared") {
+      const manifestHash = stringField(event.payload, "manifest_hash");
+      if (manifestHash && manifestHash !== binding.manifest.hash) {
+        throw new HarnessProjectionError(
+          "manifest_mismatch",
+          "Harness final manifest hash does not match the pinned pilot manifest",
         );
       }
     }
@@ -287,8 +296,12 @@ function artifactsFromRead(read: HarnessRunReadSnapshot): ArtifactRef[] {
   for (const event of read.events) {
     if (event.type !== "ArtifactCreated") continue;
     const uri = stringField(event.payload, "artifact_uri");
+    // Harness also emits metadata-only ArtifactCreated records for internal
+    // episode lifecycle. Only events carrying an immutable artifact URI are
+    // part of the board's artifact projection.
+    if (!uri) continue;
     const artifact = artifactFromUri(uri);
-    if (!uri || !artifact) {
+    if (!artifact) {
       throw new HarnessProjectionError(
         "projection_invalid",
         "Harness ArtifactCreated event has an unsupported artifact reference",
@@ -306,10 +319,10 @@ function artifactsFromRead(read: HarnessRunReadSnapshot): ArtifactRef[] {
   return [...artifacts.values()].sort((left, right) => left.uri.localeCompare(right.uri));
 }
 
-function verificationFromEvents(
-  events: HarnessEventRead[],
+function verificationFromRead(
+  read: HarnessRunReadSnapshot,
 ): AgentRunProjectionV1["verification"] {
-  const event = [...events].reverse().find((candidate) =>
+  const event = [...read.events].reverse().find((candidate) =>
     candidate.type === "VerificationCompleted"
     && stringField(candidate.payload, "scope") !== "plan_node"
   );
@@ -324,13 +337,34 @@ function verificationFromEvents(
         : "inconclusive"
       : "inconclusive";
   const reportUri = stringField(event.payload, "report_ref");
-  const decisionRef = artifactFromUri(reportUri);
-  if (reportUri && !decisionRef) {
+  const eventDecisionRef = artifactFromUri(reportUri);
+  if (reportUri && !eventDecisionRef) {
     throw new HarnessProjectionError(
       "projection_invalid",
       "Harness verification report has an unsupported artifact reference",
     );
   }
+  const deliverableReports = read.deliverables
+    .filter((deliverable) => deliverable.deliverableType === "verification_report")
+    .map((deliverable) => deliverable.artifact);
+  const uniqueDeliverableReports = new Map(
+    deliverableReports.map((artifact) => [artifact.uri, artifact] as const),
+  );
+  if (uniqueDeliverableReports.size > 1) {
+    throw new HarnessProjectionError(
+      "projection_invalid",
+      "Harness returned multiple verification report deliverables",
+    );
+  }
+  const deliverableDecisionRef = [...uniqueDeliverableReports.values()][0];
+  if (eventDecisionRef && deliverableDecisionRef
+      && eventDecisionRef.uri !== deliverableDecisionRef.uri) {
+    throw new HarnessProjectionError(
+      "projection_invalid",
+      "Harness verification event and deliverable references do not match",
+    );
+  }
+  const decisionRef = eventDecisionRef ?? deliverableDecisionRef;
   return {
     status,
     ...(decisionRef

--- a/test/fixtures/harness-integration/failed-deliverables.txt
+++ b/test/fixtures/harness-integration/failed-deliverables.txt
@@ -1,0 +1,1 @@
+verification_report artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/test/fixtures/harness-integration/failed-events.txt
+++ b/test/fixtures/harness-integration/failed-events.txt
@@ -1,6 +1,9 @@
 1 TaskAccepted payload={"task_id":"pilot-failed"}
 2 ContractCompiled payload={"draft_manifest_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","risk_class":"low","task_hash":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
-3 ModelRequested payload={"model_ref":"example-model","role":"executor"}
-4 ModelResponded payload={"usage":{"input_tokens":200,"output_tokens":75,"requests":1}}
-5 VerificationCompleted payload={"passed":false,"report_ref":"artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","verdict":"failed"}
-6 RunCompleted payload={"deliverables":{},"outcome":"failed","reason":"verification_failed"}
+3 EnvironmentPrepared payload={"manifest_hash":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","provider":"local"}
+4 ModelRequested payload={"model_ref":"example-model","role":"executor"}
+5 ModelResponded payload={"usage":{"input_tokens":200,"output_tokens":75,"requests":1}}
+6 VerificationCompleted payload={"passed":false,"verdict":"failed"}
+7 ArtifactCreated payload={"artifact_hash":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","artifact_uri":"artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","deliverable_type":"verification_report"}
+8 RunCompleted payload={"deliverables":{"verification_report":"artifact://sha256/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},"outcome":"failed","reason":"verification_failed"}
+9 ArtifactCreated payload={"kind":"episode"}

--- a/test/fixtures/harness-integration/successful-deliverables.txt
+++ b/test/fixtures/harness-integration/successful-deliverables.txt
@@ -1,1 +1,1 @@
-patch artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+verification_report artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/test/fixtures/harness-integration/successful-events.txt
+++ b/test/fixtures/harness-integration/successful-events.txt
@@ -1,8 +1,10 @@
 1 TaskAccepted payload={"task_id":"pilot-success"}
 2 ContractCompiled payload={"draft_manifest_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","risk_class":"low","task_hash":"sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}
-3 ModelRequested payload={"model_ref":"example-model","role":"executor"}
-4 ModelResponded payload={"usage":{"input_tokens":100,"output_tokens":50,"requests":1}}
-5 CapabilityDispatched payload={"capability":"fs.write_file"}
-6 ArtifactCreated payload={"artifact_hash":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","artifact_uri":"artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","deliverable_type":"patch"}
-7 VerificationCompleted payload={"passed":true,"report_ref":"artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","verdict":"completed"}
-8 RunCompleted payload={"deliverables":{"patch":"artifact://sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"outcome":"completed","reason":null}
+3 EnvironmentPrepared payload={"manifest_hash":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd","provider":"local"}
+4 ModelRequested payload={"model_ref":"example-model","role":"executor"}
+5 ModelResponded payload={"usage":{"input_tokens":100,"output_tokens":50,"requests":1}}
+6 CapabilityDispatched payload={"capability":"fs.write_file"}
+7 VerificationCompleted payload={"passed":true,"verdict":"completed"}
+8 ArtifactCreated payload={"artifact_hash":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","artifact_uri":"artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","deliverable_type":"verification_report"}
+9 RunCompleted payload={"deliverables":{"verification_report":"artifact://sha256/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"outcome":"completed","reason":null}
+10 ArtifactCreated payload={"kind":"episode"}

--- a/test/unit/harness-integration-projection.test.ts
+++ b/test/unit/harness-integration-projection.test.ts
@@ -52,8 +52,8 @@ function capturedExecutor(calls: string[][]): HarnessCommandExecutor {
       ? `${prefix}-status.txt`
       : verb === "events"
         ? `${prefix}-events.txt`
-        : prefix === "successful"
-          ? "successful-deliverables.txt"
+        : prefix !== "quarantined"
+          ? `${prefix}-deliverables.txt`
           : undefined;
     return {
       code: 0,
@@ -112,9 +112,13 @@ describe("INT-1 fixed Harness read port", () => {
       outcome: "completed",
       egressPolicy: "deny",
     });
-    expect(read.events.at(-1)?.type).toBe("RunCompleted");
+    expect(read.events.some((event) => event.type === "RunCompleted")).toBe(true);
+    expect(read.events.at(-1)).toMatchObject({
+      type: "ArtifactCreated",
+      payload: { kind: "episode" },
+    });
     expect(read.deliverables[0]?.artifact.sha256)
-      .toBe("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+      .toBe("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     expect(calls).toEqual([
       ["run", "status", "11111111-1111-4111-8111-111111111111"],
       ["run", "events", "11111111-1111-4111-8111-111111111111"],
@@ -188,7 +192,10 @@ describe("INT-1 deterministic AgentRunProjection", () => {
       workItemId: "work-harness-success-001",
       run: { state: "completed", terminal: true, outcome: "completed" },
       source: { health: "healthy" },
-      verification: { status: "passed" },
+      verification: {
+        status: "passed",
+        decisionHash: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
       budget: { modelTokensUsed: 150, toolCallsUsed: 1 },
     });
     expect(first.artifacts).toHaveLength(1);
@@ -200,7 +207,10 @@ describe("INT-1 deterministic AgentRunProjection", () => {
     );
     expect(failed).toMatchObject({
       run: { state: "failed", terminal: true, outcome: "failed" },
-      verification: { status: "failed" },
+      verification: {
+        status: "failed",
+        decisionHash: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      },
       failure: {
         code: "verification_failed",
         message: "verification_failed",
@@ -271,6 +281,18 @@ describe("INT-1 deterministic AgentRunProjection", () => {
       read,
       { now: NOW },
     )).toThrow(/does not match the pinned/);
+
+    expect(() => projectHarnessRun(
+      {
+        ...bindingAt(0),
+        manifest: {
+          ...bindingAt(0).manifest,
+          hash: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        },
+      },
+      read,
+      { now: NOW },
+    )).toThrow(/final manifest hash/);
   });
 
   it("turns source denial into a visible unavailable failure, never a healthy projection", async () => {


### PR DESCRIPTION
## What changed

- accept Harness metadata-only `ArtifactCreated` episode lifecycle events without projecting them as immutable deliverables
- derive verification evidence from the typed `verification_report` deliverable when `VerificationCompleted` omits `report_ref`
- reject final manifest hashes that differ from the registry-pinned manifest
- update projection fixtures/tests to match the two real pilot runs
- record the successful, failed, and source-outage ceremony evidence in the INT-1 handback

## Why

The live INT-1 ceremony exposed a compatibility gap after #532 merged. Current Harness emits a metadata-only `ArtifactCreated {"kind":"episode"}` event after `RunCompleted`; the mapper required every artifact event to include an immutable URI. It failed closed, so no unhealthy run appeared healthy, but both legitimate pilot runs were unavailable on the board.

This follow-up preserves strict validation for explicit artifact references while recognizing the current Harness event shape.

## Pilot evidence

- successful run: `9fa03502-2518-4023-a697-5ccf4c318b4c`
- intentional verification failure: `ee4213a8-ace1-42dd-9694-71e091ff307b`
- source-loss drill: zero healthy projections; both cards moved to `needs-attention` as `source-offline`

## Validation

- `npm run typecheck`
- `npm test` — 177 files, 2,192 tests passed
- `npm run build`
- focused Harness projection tests — 15/15 passed
- `git diff --check`

## Affected surfaces

- Slack operator Harness read-only projection
- Harness integration fixtures/tests
- INT-1 handback documentation

No backend mutation path, dispatcher, Caddy, contracts, public site, deployment behavior, or generated static output changes.

## Environment / VPS changes

None. The projection remains default-off, no secret or environment-variable change is required, and the disposable pilot database/worker were removed.