### PR TITLE
feat(harness): add INT-2a AgentTask store and dual-read board path

### DIFF
--- a/ops/migrate.sh
+++ b/ops/migrate.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 psql "${DATABASE_URL:?DATABASE_URL is required}" -f /migrations/001_init.sql
-
+psql "${DATABASE_URL:?DATABASE_URL is required}" -f /migrations/002_agent_tasks.sql

--- a/ops/migrations/002_agent_tasks.sql
+++ b/ops/migrations/002_agent_tasks.sql
@@ -1,0 +1,18 @@
+create table if not exists agent_tasks (
+  work_item_id text not null,
+  task_version integer not null check (task_version > 0),
+  correlation_id text not null,
+  lifecycle text not null,
+  executor_kind text not null,
+  approved_task_hash text,
+  deadline timestamptz not null,
+  updated_at timestamptz not null,
+  task jsonb not null,
+  primary key (work_item_id, task_version)
+);
+
+create index if not exists agent_tasks_lifecycle_idx
+  on agent_tasks(lifecycle);
+
+create index if not exists agent_tasks_correlation_id_idx
+  on agent_tasks(correlation_id);

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -60,6 +60,10 @@
     "./decision-records": {
       "types": "./dist/decision-records.d.ts",
       "import": "./dist/decision-records.js"
+    },
+    "./agent-task-store": {
+      "types": "./dist/agent-task-store.d.ts",
+      "import": "./dist/agent-task-store.js"
     }
   },
   "scripts": {

--- a/packages/averray-mcp/src/agent-task-store.ts
+++ b/packages/averray-mcp/src/agent-task-store.ts
@@ -1,0 +1,217 @@
+import { query as defaultQuery } from "@avg/mcp-common";
+import {
+  agentTaskV1Schema,
+  type AgentTaskV1,
+  type AgentTaskLifecycle,
+} from "@avg/schemas";
+
+export type AgentTaskExecutorKind = AgentTaskV1["executor"]["kind"];
+
+export interface AgentTaskListFilter {
+  workItemId?: string;
+  correlationId?: string;
+  lifecycle?: AgentTaskLifecycle;
+  executorKind?: AgentTaskExecutorKind;
+  limit?: number;
+}
+
+export type AgentTaskStoreQuery = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[],
+) => Promise<T[]>;
+
+export interface AgentTaskStoreDeps {
+  query?: AgentTaskStoreQuery;
+}
+
+interface AgentTaskRow {
+  work_item_id: string;
+  task_version: number;
+  correlation_id: string;
+  lifecycle: string;
+  executor_kind: string;
+  approved_task_hash: string | null;
+  deadline: string | Date;
+  updated_at: string | Date;
+  task: unknown;
+}
+
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 1_000;
+const SELECT_COLUMNS = `
+  work_item_id,
+  task_version,
+  correlation_id,
+  lifecycle,
+  executor_kind,
+  approved_task_hash,
+  deadline,
+  updated_at,
+  task
+`;
+
+export async function putAgentTask(
+  input: AgentTaskV1,
+  deps: AgentTaskStoreDeps = {},
+): Promise<AgentTaskV1> {
+  const task = agentTaskV1Schema.parse(input);
+  const rows = await storeQuery(deps)<AgentTaskRow>(
+    `insert into agent_tasks (
+       work_item_id,
+       task_version,
+       correlation_id,
+       lifecycle,
+       executor_kind,
+       approved_task_hash,
+       deadline,
+       updated_at,
+       task
+     ) values ($1, $2, $3, $4, $5, $6, $7::timestamptz, $8::timestamptz, $9::jsonb)
+     on conflict (work_item_id, task_version) do update set
+       correlation_id = excluded.correlation_id,
+       lifecycle = excluded.lifecycle,
+       executor_kind = excluded.executor_kind,
+       approved_task_hash = excluded.approved_task_hash,
+       deadline = excluded.deadline,
+       updated_at = excluded.updated_at,
+       task = excluded.task
+     returning ${SELECT_COLUMNS}`,
+    taskValues(task),
+  );
+  return parseSingleRow(rows, "put");
+}
+
+export async function getAgentTask(
+  workItemId: string,
+  taskVersion: number,
+  deps: AgentTaskStoreDeps = {},
+): Promise<AgentTaskV1 | undefined> {
+  const rows = await storeQuery(deps)<AgentTaskRow>(
+    `select ${SELECT_COLUMNS}
+     from agent_tasks
+     where work_item_id = $1 and task_version = $2
+     limit 1`,
+    [workItemId, taskVersion],
+  );
+  if (rows.length === 0) return undefined;
+  return parseSingleRow(rows, "get");
+}
+
+export async function listAgentTasks(
+  filter: AgentTaskListFilter = {},
+  deps: AgentTaskStoreDeps = {},
+): Promise<AgentTaskV1[]> {
+  const clauses: string[] = [];
+  const values: unknown[] = [];
+  const add = (column: string, value: unknown) => {
+    values.push(value);
+    clauses.push(`${column} = $${values.length}`);
+  };
+
+  if (filter.workItemId !== undefined) add("work_item_id", filter.workItemId);
+  if (filter.correlationId !== undefined) add("correlation_id", filter.correlationId);
+  if (filter.lifecycle !== undefined) add("lifecycle", filter.lifecycle);
+  if (filter.executorKind !== undefined) add("executor_kind", filter.executorKind);
+  const limit = normalizedLimit(filter.limit);
+  values.push(limit);
+
+  const rows = await storeQuery(deps)<AgentTaskRow>(
+    `select ${SELECT_COLUMNS}
+     from agent_tasks
+     ${clauses.length > 0 ? `where ${clauses.join(" and ")}` : ""}
+     order by updated_at desc, work_item_id asc, task_version desc
+     limit $${values.length}`,
+    values,
+  );
+  return rows.map(parseAgentTaskRow);
+}
+
+export async function listDispatchableAgentTasks(
+  deps: AgentTaskStoreDeps = {},
+): Promise<AgentTaskV1[]> {
+  const rows = await storeQuery(deps)<AgentTaskRow>(
+    `select ${SELECT_COLUMNS}
+     from agent_tasks
+     where executor_kind = 'harness'
+       and lifecycle = 'approved'
+       and approved_task_hash is not null
+     order by updated_at asc, work_item_id asc, task_version asc
+     limit $1`,
+    [MAX_LIST_LIMIT],
+  );
+  return rows
+    .map(parseAgentTaskRow)
+    .filter(isDispatchableAgentTask);
+}
+
+export function isDispatchableAgentTask(task: AgentTaskV1): boolean {
+  return task.executor.kind === "harness"
+    && task.lifecycle === "approved"
+    && task.approval.approvedTaskHash !== undefined;
+}
+
+function taskValues(task: AgentTaskV1): unknown[] {
+  return [
+    task.workItemId,
+    task.taskVersion,
+    task.correlationId,
+    task.lifecycle,
+    task.executor.kind,
+    task.approval.approvedTaskHash ?? null,
+    task.deadline,
+    task.timestamps.updatedAt,
+    JSON.stringify(task),
+  ];
+}
+
+function parseSingleRow(rows: AgentTaskRow[], operation: string): AgentTaskV1 {
+  if (rows.length !== 1) {
+    throw new Error(`AgentTask store ${operation} expected one row, received ${rows.length}`);
+  }
+  return parseAgentTaskRow(rows[0]!);
+}
+
+function parseAgentTaskRow(row: AgentTaskRow): AgentTaskV1 {
+  const rawTask = typeof row.task === "string" ? JSON.parse(row.task) as unknown : row.task;
+  const task = agentTaskV1Schema.parse(rawTask);
+  const expected = {
+    workItemId: row.work_item_id,
+    taskVersion: row.task_version,
+    correlationId: row.correlation_id,
+    lifecycle: row.lifecycle,
+    executorKind: row.executor_kind,
+    approvedTaskHash: row.approved_task_hash ?? undefined,
+    deadline: timestamp(row.deadline),
+    updatedAt: timestamp(row.updated_at),
+  };
+  const actual = {
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    correlationId: task.correlationId,
+    lifecycle: task.lifecycle,
+    executorKind: task.executor.kind,
+    approvedTaskHash: task.approval.approvedTaskHash,
+    deadline: timestamp(task.deadline),
+    updatedAt: timestamp(task.timestamps.updatedAt),
+  };
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+    throw new Error(`AgentTask row columns do not match task JSON for ${task.workItemId}@${task.taskVersion}`);
+  }
+  return task;
+}
+
+function timestamp(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function normalizedLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("AgentTask list limit must be a positive safe integer");
+  }
+  return Math.min(value, MAX_LIST_LIMIT);
+}
+
+function storeQuery(deps: AgentTaskStoreDeps): AgentTaskStoreQuery {
+  return deps.query ?? defaultQuery;
+}

--- a/services/slack-operator/src/agent-task-board.ts
+++ b/services/slack-operator/src/agent-task-board.ts
@@ -1,0 +1,152 @@
+import {
+  agentTaskV1Schema,
+  toLegacyAgentTaskCompatibilityView,
+  type AgentTaskV1,
+} from "@avg/schemas";
+
+import type { CodexTask, CodexTaskStatus } from "./codex-task-queue.js";
+
+export interface AgentTaskBoardItem extends Record<string, unknown> {
+  id: string;
+  workItemId: string;
+  sourceKind: "agent_task" | "codex_task";
+  status: CodexTaskStatus;
+  repo: string;
+  prompt: string;
+  agent: string;
+  createdAt: string;
+  updatedAt: string;
+  nonDispatchable: boolean;
+}
+
+export interface DualReadTaskCounts {
+  total: number;
+  proposed: number;
+  approved: number;
+  running: number;
+  terminal: number;
+}
+
+const TERMINAL_STATUSES = new Set<CodexTaskStatus>(["completed", "failed", "cancelled"]);
+
+export function mergeAgentTaskBoardItems(
+  legacyInputs: readonly CodexTask[],
+  agentTaskInputs: readonly AgentTaskV1[],
+  limit = 100,
+): AgentTaskBoardItem[] {
+  const legacyItems = legacyInputs.map(legacyTaskBoardItem);
+  const latestAgentItems = latestAgentTaskItems(agentTaskInputs);
+  const agentWorkItemIds = new Set(latestAgentItems.map((item) => item.workItemId));
+  return [
+    ...latestAgentItems,
+    ...legacyItems.filter((item) => !agentWorkItemIds.has(item.workItemId)),
+  ]
+    .sort((left, right) => {
+      const updated = Date.parse(right.updatedAt) - Date.parse(left.updatedAt);
+      return updated !== 0 ? updated : left.workItemId.localeCompare(right.workItemId);
+    })
+    .slice(0, normalizedLimit(limit));
+}
+
+export function countAgentTaskBoardItems(
+  items: readonly AgentTaskBoardItem[],
+): DualReadTaskCounts {
+  return {
+    total: items.length,
+    proposed: items.filter((task) => task.status === "proposed").length,
+    approved: items.filter((task) => task.status === "approved").length,
+    running: items.filter((task) => task.status === "running").length,
+    terminal: items.filter((task) => TERMINAL_STATUSES.has(task.status)).length,
+  };
+}
+
+function legacyTaskBoardItem(task: CodexTask): AgentTaskBoardItem {
+  const compatibility = toLegacyAgentTaskCompatibilityView(task);
+  return {
+    ...task,
+    agent: task.agent ?? compatibility.executor.directAgent,
+    workItemId: compatibility.workItemId,
+    sourceKind: compatibility.sourceKind,
+    nonDispatchable: compatibility.nonDispatchable,
+    missingRequiredAgentTaskFields: compatibility.missingRequiredAgentTaskFields,
+  };
+}
+
+function latestAgentTaskItems(inputs: readonly AgentTaskV1[]): AgentTaskBoardItem[] {
+  const latest = new Map<string, AgentTaskV1>();
+  for (const input of inputs) {
+    const task = agentTaskV1Schema.parse(input);
+    const current = latest.get(task.workItemId);
+    if (
+      !current
+      || task.taskVersion > current.taskVersion
+      || (
+        task.taskVersion === current.taskVersion
+        && Date.parse(task.timestamps.updatedAt) > Date.parse(current.timestamps.updatedAt)
+      )
+    ) {
+      latest.set(task.workItemId, task);
+    }
+  }
+  return [...latest.values()].map(agentTaskBoardItem);
+}
+
+function agentTaskBoardItem(task: AgentTaskV1): AgentTaskBoardItem {
+  const directAgent = task.executor.kind === "direct" ? task.executor.directAgent : "harness";
+  const dispatchable = task.executor.kind === "harness"
+    && task.lifecycle === "approved"
+    && task.approval.approvedTaskHash !== undefined;
+  return {
+    id: task.workItemId,
+    workItemId: task.workItemId,
+    sourceKind: "agent_task",
+    schemaVersion: task.schemaVersion,
+    kind: task.kind,
+    taskVersion: task.taskVersion,
+    correlationId: task.correlationId,
+    status: legacyBoardStatus(task.lifecycle),
+    agentTaskLifecycle: task.lifecycle,
+    repo: task.repository.nameWithOwner,
+    title: task.proposal.title,
+    prompt: task.proposal.objective,
+    reason: task.proposal.whyNow,
+    requester: `${task.proposal.requestedBy.type}:${task.proposal.requestedBy.id}`,
+    agent: directAgent,
+    riskTier: task.risk.tier === "low" ? "low" : "high",
+    agentTaskRiskTier: task.risk.tier,
+    routingReason: task.executor.selectionReason,
+    createdAt: task.proposal.createdAt,
+    updatedAt: task.timestamps.updatedAt,
+    ...(task.timestamps.approvedAt ? { approvedAt: task.timestamps.approvedAt } : {}),
+    nonDispatchable: !dispatchable,
+    dispatchable,
+  };
+}
+
+function legacyBoardStatus(lifecycle: AgentTaskV1["lifecycle"]): CodexTaskStatus {
+  switch (lifecycle) {
+    case "proposed":
+      return "proposed";
+    case "approved":
+      return "approved";
+    case "dispatching":
+    case "running":
+    case "verifying":
+      return "running";
+    case "handoff_ready":
+      return "completed";
+    case "blocked":
+    case "failed":
+      return "failed";
+    case "cancelled":
+      return "cancelled";
+  }
+  throw new Error(`Unsupported AgentTask lifecycle: ${lifecycle satisfies never}`);
+}
+
+function normalizedLimit(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("AgentTask board limit must be a positive safe integer");
+  }
+  return value;
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -17,6 +17,7 @@ import {
   recordLlmUsageFromResult,
 } from "@avg/averray-mcp/llm-usage";
 import { handleOperatorCommandText } from "@avg/averray-mcp/operator-handler";
+import { listAgentTasks } from "@avg/averray-mcp/agent-task-store";
 import {
   formatOperatorResultForSlack,
   isAuthorizedSlackCommand,
@@ -218,6 +219,10 @@ import {
   taskAgent,
   type CodexTask,
 } from "./codex-task-queue.js";
+import {
+  countAgentTaskBoardItems,
+  mergeAgentTaskBoardItems,
+} from "./agent-task-board.js";
 import { parseProposeTaskPayload } from "./codex-task-request.js";
 import {
   acceptTestbedMissionFailure,
@@ -4139,6 +4144,15 @@ async function loadMonitorSnapshot(
       status: "ok",
       durationMs: Date.now() - codexStartedAt,
     });
+    phases.push({
+      name: "agent_task_store",
+      status: codexTasks.agentTaskStore.status === "ok" ? "ok" : "skipped",
+      durationMs: codexTasks.agentTaskStore.durationMs,
+      rows: codexTasks.agentTaskStore.rows,
+      ...(codexTasks.agentTaskStore.status === "unavailable"
+        ? { error: codexTasks.agentTaskStore.reason }
+        : {}),
+    });
   } catch (error) {
     logger.warn({ err: error }, "monitor_codex_task_queue_skipped");
     phases.push({
@@ -4615,9 +4629,42 @@ async function recordHermesRouterAudit(record: HermesRouterAuditRecord): Promise
 }
 
 async function loadCodexTaskQueueSummary() {
-  const codexTasks = await listCodexTasks();
-  const codexRunner = await readCodexRunnerHeartbeat().catch(() => undefined);
-  return summarizeCodexTasks(codexTasks, 100, { runner: codexRunner });
+  const [codexTasks, codexRunner] = await Promise.all([
+    listCodexTasks(),
+    readCodexRunnerHeartbeat().catch(() => undefined),
+  ]);
+  const agentTaskStartedAt = Date.now();
+  let agentTasks: Awaited<ReturnType<typeof listAgentTasks>> = [];
+  let agentTaskStore: {
+    status: "ok" | "unavailable";
+    durationMs: number;
+    rows: number;
+    reason?: string;
+  };
+  try {
+    agentTasks = await listAgentTasks();
+    agentTaskStore = {
+      status: "ok",
+      durationMs: Date.now() - agentTaskStartedAt,
+      rows: agentTasks.length,
+    };
+  } catch (error) {
+    logger.warn({ err: error }, "monitor_agent_task_store_unavailable");
+    agentTaskStore = {
+      status: "unavailable",
+      durationMs: Date.now() - agentTaskStartedAt,
+      rows: 0,
+      reason: "AgentTask store read failed; legacy task records remain available.",
+    };
+  }
+  const legacySummary = summarizeCodexTasks(codexTasks, 100, { runner: codexRunner });
+  const items = mergeAgentTaskBoardItems(codexTasks, agentTasks, 100);
+  return {
+    ...legacySummary,
+    counts: countAgentTaskBoardItems(items),
+    items,
+    agentTaskStore,
+  };
 }
 
 function monitorGithubEnrichTimeoutMs(): number {

--- a/test/unit/agent-task-store.test.ts
+++ b/test/unit/agent-task-store.test.ts
@@ -1,0 +1,337 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  getAgentTask,
+  listAgentTasks,
+  listDispatchableAgentTasks,
+  putAgentTask,
+  type AgentTaskStoreQuery,
+} from "../../packages/averray-mcp/src/agent-task-store.js";
+import {
+  agentTaskV1Schema,
+  canonicalContractJson,
+  hashAgentTaskApprovalPayload,
+  type AgentTaskV1,
+} from "../../packages/schemas/src/index.js";
+import {
+  mergeAgentTaskBoardItems,
+} from "../../services/slack-operator/src/agent-task-board.js";
+import type { CodexTask } from "../../services/slack-operator/src/codex-task-queue.js";
+import { buildV2BoardSnapshot } from "../../services/slack-operator/src/monitor-v2.js";
+
+describe("INT-2a AgentTask Postgres store", () => {
+  it("round-trips schema-validated AgentTask V1 records and rejects invalid writes and reads", async () => {
+    const db = new MemoryAgentTaskDatabase();
+    const task = proposedTask();
+
+    await expect(putAgentTask(task, { query: db.query })).resolves.toEqual(task);
+    const stored = await getAgentTask(task.workItemId, task.taskVersion, { query: db.query });
+    expect(stored).toEqual(task);
+    expect(canonicalContractJson(stored)).toBe(canonicalContractJson(task));
+    await expect(listAgentTasks({}, { query: db.query })).resolves.toEqual([task]);
+
+    const invalid = {
+      ...task,
+      requestedAuthority: {
+        ...task.requestedAuthority,
+        delegable: true,
+      },
+    } as unknown as AgentTaskV1;
+    await expect(putAgentTask(invalid, { query: db.query })).rejects.toThrow();
+    expect(db.size).toBe(1);
+
+    db.corruptStoredTask(task.workItemId, task.taskVersion, { ...task, schemaVersion: 2 });
+    await expect(getAgentTask(task.workItemId, task.taskVersion, { query: db.query }))
+      .rejects.toThrow();
+  });
+
+  it("keeps one row per work item and task version while storing newer versions separately", async () => {
+    const db = new MemoryAgentTaskDatabase();
+    const v1 = proposedTask();
+    const v1Updated = proposedTask({
+      proposal: {
+        ...v1.proposal,
+        title: "Updated title for the same task version",
+      },
+      timestamps: {
+        ...v1.timestamps,
+        updatedAt: "2026-07-23T12:05:00.000Z",
+      },
+    });
+    const v2 = proposedTask({
+      taskVersion: 2,
+      timestamps: {
+        ...v1.timestamps,
+        updatedAt: "2026-07-23T12:10:00.000Z",
+      },
+    });
+
+    await putAgentTask(v1, { query: db.query });
+    await putAgentTask(v1Updated, { query: db.query });
+    expect(db.size).toBe(1);
+    await expect(getAgentTask(v1.workItemId, 1, { query: db.query }))
+      .resolves.toMatchObject({ proposal: { title: "Updated title for the same task version" } });
+
+    await putAgentTask(v2, { query: db.query });
+    expect(db.size).toBe(2);
+    await expect(listAgentTasks({}, { query: db.query }))
+      .resolves.toEqual([v2, v1Updated]);
+  });
+
+  it("lists only approved, hash-bound Harness tasks as dispatchable", async () => {
+    const db = new MemoryAgentTaskDatabase();
+    const harnessApproved = await approvedTask({
+      workItemId: "work-harness-approved",
+      correlationId: "correlation-harness-approved",
+    });
+    const directApproved = await approvedTask({
+      workItemId: "work-direct-approved",
+      correlationId: "correlation-direct-approved",
+      executor: {
+        kind: "direct",
+        directAgent: "codex",
+        selectionReason: "The legacy direct runner remains the explicit fallback.",
+      },
+    });
+    const harnessProposed = proposedTask({
+      workItemId: "work-harness-proposed",
+      correlationId: "correlation-harness-proposed",
+    });
+
+    for (const task of [harnessApproved, directApproved, harnessProposed]) {
+      await putAgentTask(task, { query: db.query });
+    }
+    await expect(
+      putAgentTask(legacyTask() as unknown as AgentTaskV1, { query: db.query }),
+    ).rejects.toThrow();
+    expect(db.size).toBe(3);
+
+    await expect(listDispatchableAgentTasks({ query: db.query }))
+      .resolves.toEqual([harnessApproved]);
+  });
+
+  it("pins the additive migration primary key and lookup indexes", () => {
+    const migration = readFileSync(
+      new URL("../../ops/migrations/002_agent_tasks.sql", import.meta.url),
+      "utf8",
+    );
+    expect(migration).toMatch(/primary key\s*\(work_item_id,\s*task_version\)/i);
+    expect(migration).toMatch(/agent_tasks_lifecycle_idx/i);
+    expect(migration).toMatch(/agent_tasks_correlation_id_idx/i);
+  });
+});
+
+describe("INT-2a dual-read board path", () => {
+  it("preserves legacy rows as non-dispatchable and emits one card per work item", () => {
+    const legacy = legacyTask();
+    const legacyBefore = structuredClone(legacy);
+    const currentAgentTask = proposedTask({
+      workItemId: legacy.id,
+      correlationId: legacy.correlationId!,
+      proposal: {
+        ...proposedTask().proposal,
+        title: "Current AgentTask replaces the correlated legacy board row",
+      },
+    });
+    const olderVersion = proposedTask({
+      workItemId: legacy.id,
+      correlationId: legacy.correlationId!,
+      taskVersion: 1,
+      timestamps: {
+        ...proposedTask().timestamps,
+        updatedAt: "2026-07-23T11:00:00.000Z",
+      },
+    });
+    const latestVersion = proposedTask({
+      ...currentAgentTask,
+      taskVersion: 2,
+      timestamps: {
+        ...currentAgentTask.timestamps,
+        updatedAt: "2026-07-23T12:10:00.000Z",
+      },
+    });
+    const legacyOnly = legacyTask({
+      id: "legacy-only",
+      correlationId: "correlation-legacy-only",
+    });
+
+    const items = mergeAgentTaskBoardItems(
+      [legacy, legacyOnly],
+      [olderVersion, latestVersion],
+    );
+
+    expect(legacy).toEqual(legacyBefore);
+    expect(items).toHaveLength(2);
+    expect(items.filter((item) => item.workItemId === legacy.id)).toEqual([
+      expect.objectContaining({
+        sourceKind: "agent_task",
+        taskVersion: 2,
+        agent: "harness",
+      }),
+    ]);
+    expect(items.find((item) => item.workItemId === legacyOnly.id)).toMatchObject({
+      sourceKind: "codex_task",
+      nonDispatchable: true,
+      missingRequiredAgentTaskFields: expect.arrayContaining([
+        "taskIntentRef",
+        "approvalPolicyHash",
+      ]),
+    });
+
+    const board = buildV2BoardSnapshot(
+      {
+        active: [],
+        recent: [],
+        codexTasks: { items },
+      },
+      { now: () => new Date("2026-07-23T12:11:00.000Z") },
+    );
+    expect(board.cards.filter((card) => card.id === legacy.id)).toHaveLength(1);
+    expect(board.cards.find((card) => card.id === legacy.id)).toMatchObject({
+      type: "task",
+      agentType: "harness",
+      taskStatus: "proposed",
+      correlationId: legacy.correlationId,
+    });
+    expect(board.cards.find((card) => card.id === legacyOnly.id)).toMatchObject({
+      type: "task",
+      agentType: "codex",
+      taskStatus: "proposed",
+    });
+  });
+});
+
+class MemoryAgentTaskDatabase {
+  readonly rows = new Map<string, MemoryAgentTaskRow>();
+
+  get size(): number {
+    return this.rows.size;
+  }
+
+  readonly query: AgentTaskStoreQuery = async <T>(
+    text: string,
+    values: unknown[] = [],
+  ): Promise<T[]> => {
+    if (/insert into agent_tasks/i.test(text)) {
+      const row: MemoryAgentTaskRow = {
+        work_item_id: String(values[0]),
+        task_version: Number(values[1]),
+        correlation_id: String(values[2]),
+        lifecycle: String(values[3]),
+        executor_kind: String(values[4]),
+        approved_task_hash: values[5] === null ? null : String(values[5]),
+        deadline: String(values[6]),
+        updated_at: String(values[7]),
+        task: JSON.parse(String(values[8])) as unknown,
+      };
+      this.rows.set(key(row.work_item_id, row.task_version), row);
+      return [structuredClone(row) as T];
+    }
+
+    let rows = [...this.rows.values()];
+    if (/where work_item_id = \$1 and task_version = \$2/i.test(text)) {
+      rows = rows.filter((row) =>
+        row.work_item_id === values[0] && row.task_version === values[1]);
+    } else {
+      rows = filterColumn(rows, text, values, "work_item_id");
+      rows = filterColumn(rows, text, values, "correlation_id");
+      rows = filterColumn(rows, text, values, "lifecycle");
+      rows = filterColumn(rows, text, values, "executor_kind");
+      if (/approved_task_hash is not null/i.test(text)) {
+        rows = rows.filter((row) => row.approved_task_hash !== null);
+      }
+    }
+    rows.sort((left, right) => {
+      const ascending = /order by updated_at asc/i.test(text);
+      const updated = Date.parse(left.updated_at) - Date.parse(right.updated_at);
+      return ascending ? updated : -updated;
+    });
+    const limitMatch = /limit \$(\d+)/i.exec(text);
+    const limit = limitMatch ? Number(values[Number(limitMatch[1]) - 1]) : rows.length;
+    return rows.slice(0, limit).map((row) => structuredClone(row) as T);
+  };
+
+  corruptStoredTask(workItemId: string, taskVersion: number, task: unknown): void {
+    const row = this.rows.get(key(workItemId, taskVersion));
+    if (!row) throw new Error("missing row");
+    row.task = task;
+  }
+}
+
+interface MemoryAgentTaskRow {
+  work_item_id: string;
+  task_version: number;
+  correlation_id: string;
+  lifecycle: string;
+  executor_kind: string;
+  approved_task_hash: string | null;
+  deadline: string;
+  updated_at: string;
+  task: unknown;
+}
+
+function filterColumn(
+  rows: MemoryAgentTaskRow[],
+  text: string,
+  values: unknown[],
+  column: keyof MemoryAgentTaskRow,
+): MemoryAgentTaskRow[] {
+  const match = new RegExp(`${column} = \\$(\\d+)`, "i").exec(text);
+  if (!match) return rows;
+  return rows.filter((row) => row[column] === values[Number(match[1]) - 1]);
+}
+
+function proposedTask(overrides: Partial<AgentTaskV1> = {}): AgentTaskV1 {
+  const base = JSON.parse(
+    readFileSync(
+      new URL("../fixtures/agent-integration/agent-task-v1.json", import.meta.url),
+      "utf8",
+    ),
+  ) as AgentTaskV1;
+  return agentTaskV1Schema.parse({ ...base, ...overrides });
+}
+
+async function approvedTask(overrides: Partial<AgentTaskV1> = {}): Promise<AgentTaskV1> {
+  const proposed = proposedTask(overrides);
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(proposed);
+  return agentTaskV1Schema.parse({
+    ...proposed,
+    lifecycle: "approved",
+    approval: {
+      ...proposed.approval,
+      status: "approved",
+      actor: { type: "operator", id: "operator-one" },
+      decidedAt: "2026-07-23T12:01:00.000Z",
+      approvedTaskHash,
+    },
+    timestamps: {
+      ...proposed.timestamps,
+      approvedAt: "2026-07-23T12:01:00.000Z",
+      updatedAt: "2026-07-23T12:01:00.000Z",
+    },
+  });
+}
+
+function legacyTask(overrides: Partial<CodexTask> = {}): CodexTask {
+  return {
+    schemaVersion: 1,
+    kind: "codex_task",
+    id: "work-shared",
+    repo: "owner/repo",
+    agent: "codex",
+    correlationId: "correlation-shared",
+    title: "Legacy task",
+    prompt: "Preserve this legacy task without rewriting it.",
+    requester: "hermes",
+    status: "proposed",
+    createdAt: "2026-07-22T12:00:00.000Z",
+    updatedAt: "2026-07-22T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function key(workItemId: string, taskVersion: number): string {
+  return `${workItemId}:${taskVersion}`;
+}


### PR DESCRIPTION
## What changed

- Add an additive `agent_tasks` Postgres migration with canonical `jsonb` storage, extracted lookup columns, the `(work_item_id, task_version)` primary key, and lifecycle/correlation indexes.
- Add schema-validated AgentTask CRUD/read helpers: `putAgentTask`, `getAgentTask`, `listAgentTasks`, and `listDispatchableAgentTasks`.
- Dual-read the Slack operator board/API path from the AgentTask store and the existing file-backed `codex_task` queue.
- Map legacy rows through `toLegacyAgentTaskCompatibilityView`, retain them as `nonDispatchable: true`, and emit one newest card per work item without rewriting legacy records.
- Add focused unit coverage for contract validation, round trips, version-key uniqueness, dispatchability filtering, migration shape, and board dedupe/compatibility.

## Why

This is the INT-2a storage/read migration described in #534. It establishes durable AgentTask persistence and compatibility visibility before any supervised-dispatch runtime is introduced.

## Affected surfaces

- Backend store: `packages/averray-mcp`
- Slack operator board/API read path
- Additive database migration and migration runner
- Unit tests

No contract schemas, direct-runner write paths, frontend surface, Harness process, dispatcher, GitHub mutation path, contracts, settlement, Caddy, or public site are changed.

## Validation

- `npm run typecheck` — exit 0
- `npm test` — 178/178 files passed; 2,197/2,197 tests passed
- `docker build -f ops/Dockerfile.node -t averray-reference-agent:int2a-check .` — exit 0
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config --quiet` — exit 0
- `git diff --check` — exit 0

## Authority and rollout

This changes no production authority and enables no dispatch. It starts no Harness process, opens no workload PR, adds no dispatch flag, and never promotes or rewrites legacy `codex_task` rows. The existing legacy proposal/runner paths remain unchanged.

The migration is additive and idempotent; the existing migration service applies `002_agent_tasks.sql` after `001_init.sql`. No environment or VPS secret changes are required. Reverting the application changes restores the prior read path; the unused additive table can remain in place.

## Follow-ups

INT-2b and later dispatcher/control/projection packets remain explicitly out of scope for this PR.