### PR TITLE
feat(harness): add INT-2c TaskIntent mapping and attenuation

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -64,6 +64,14 @@
     "./agent-task-store": {
       "types": "./dist/agent-task-store.d.ts",
       "import": "./dist/agent-task-store.js"
+    },
+    "./task-intent-mapping": {
+      "types": "./dist/task-intent-mapping.d.ts",
+      "import": "./dist/task-intent-mapping.js"
+    },
+    "./attenuation": {
+      "types": "./dist/attenuation.d.ts",
+      "import": "./dist/attenuation.js"
     }
   },
   "scripts": {

--- a/packages/averray-mcp/src/attenuation.ts
+++ b/packages/averray-mcp/src/attenuation.ts
@@ -1,0 +1,170 @@
+import {
+  hashTaskIntent,
+  type AgentTaskV1,
+  type PilotProfileManifest,
+  type TaskIntent,
+} from "@avg/schemas";
+
+export class AttenuationError extends Error {
+  constructor(
+    readonly reason: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "AttenuationError";
+  }
+}
+
+export async function assertTaskIntentWithinApprovedAuthority(
+  task: AgentTaskV1,
+  intent: TaskIntent,
+  profile: PilotProfileManifest,
+): Promise<void> {
+  let intentHash: `sha256:${string}`;
+  try {
+    intentHash = await hashTaskIntent(intent);
+  } catch {
+    fail("template_hash_mismatch", "TaskIntent cannot be hashed as a valid contract");
+  }
+  if (intentHash !== task.intent.templateHash) {
+    fail("template_hash_mismatch", "TaskIntent hash does not match the approved template hash");
+  }
+
+  if (
+    intent.spec.profile !== task.intent.profile
+    || intent.spec.profile !== profile.profileId
+  ) {
+    fail("profile_mismatch", "TaskIntent, AgentTask, and profile identities must match");
+  }
+
+  assertNetworkWithinTask(task, intent);
+  assertPathsWithinTask(task, intent);
+  assertBudgetWithinTask(task, intent);
+
+  const authority = task.requestedAuthority;
+  if (
+    authority.maxChildren !== 0
+    || authority.maxConcurrentChildren !== 0
+    || authority.delegable !== false
+  ) {
+    fail("children_not_zero", "Approved authority must disable children and delegation");
+  }
+
+  if (
+    !Array.isArray(profile.strategies)
+    || profile.strategies.length !== 1
+    || profile.strategies[0] !== "direct_execution"
+  ) {
+    fail(
+      "profile_not_direct_execution",
+      "The approved profile must use direct execution only",
+    );
+  }
+
+  if (!Array.isArray(profile.capabilities) || profile.capabilities.length === 0) {
+    fail(
+      "capability_not_granted",
+      "The approved profile must declare a non-empty capability manifest",
+    );
+  }
+
+  const delegableCapability = profile.capabilities.find((capability) => capability.delegable);
+  if (delegableCapability) {
+    fail(
+      "capability_delegable",
+      `Profile capability is delegable: ${delegableCapability.id}`,
+    );
+  }
+
+  const externalCapability = profile.capabilities.find(
+    (capability) =>
+      capability.effectClass !== "none" && capability.effectClass !== "local",
+  );
+  if (externalCapability) {
+    fail(
+      "capability_effect_external",
+      `Profile capability has an external effect class: ${externalCapability.id}`,
+    );
+  }
+
+  const approvedCapabilities = new Set(
+    authority.grants.map((grant) => grant.capabilityId),
+  );
+  const unapprovedCapability = profile.capabilities.find(
+    (capability) => !approvedCapabilities.has(capability.id),
+  );
+  if (unapprovedCapability) {
+    fail(
+      "capability_not_granted",
+      `Profile capability is not present in the approved grants: ${unapprovedCapability.id}`,
+    );
+  }
+}
+
+function assertNetworkWithinTask(task: AgentTaskV1, intent: TaskIntent): void {
+  const approved = task.requestedAuthority.network;
+  const requested = intent.spec.constraints.network;
+  if (approved === "deny") {
+    if (requested !== "deny") {
+      fail("network_expanded", "A deny network policy cannot be expanded");
+    }
+    return;
+  }
+  if (requested === "deny") return;
+
+  const approvedDestinations = new Set(approved.allowlist);
+  const expandedDestination = requested.allow.find(
+    (destination) => !approvedDestinations.has(destination),
+  );
+  if (expandedDestination) {
+    fail(
+      "network_expanded",
+      `TaskIntent network destination is not approved: ${expandedDestination}`,
+    );
+  }
+}
+
+function assertPathsWithinTask(task: AgentTaskV1, intent: TaskIntent): void {
+  const approvedAllowedPaths = new Set(task.repository.allowedPaths);
+  const outsideAllowedPaths = intent.spec.constraints.allowed_paths.find(
+    (path) => !approvedAllowedPaths.has(path),
+  );
+  if (outsideAllowedPaths) {
+    fail("path_not_allowed", `TaskIntent path is not approved: ${outsideAllowedPaths}`);
+  }
+
+  const requestedForbiddenPaths = new Set(intent.spec.constraints.forbidden_paths);
+  const removedForbiddenPath = task.repository.forbiddenPaths.find(
+    (path) => !requestedForbiddenPaths.has(path),
+  );
+  if (removedForbiddenPath) {
+    fail(
+      "forbidden_paths_narrowed",
+      `TaskIntent removed an approved forbidden path: ${removedForbiddenPath}`,
+    );
+  }
+
+  const conflictingPath = intent.spec.constraints.allowed_paths.find(
+    (path) => requestedForbiddenPaths.has(path),
+  );
+  if (conflictingPath) {
+    fail("path_not_allowed", `TaskIntent path is also forbidden: ${conflictingPath}`);
+  }
+}
+
+function assertBudgetWithinTask(task: AgentTaskV1, intent: TaskIntent): void {
+  const elapsedMatch = /^PT(\d+)S$/.exec(intent.spec.budgets.elapsed);
+  const elapsedSeconds = elapsedMatch ? Number(elapsedMatch[1]) : Number.NaN;
+  if (
+    !Number.isSafeInteger(elapsedSeconds)
+    || elapsedSeconds > task.budget.elapsedSeconds
+    || intent.spec.budgets.model_tokens > task.budget.modelTokens
+    || intent.spec.budgets.tool_calls > task.budget.toolCalls
+  ) {
+    fail("budget_exceeded", "TaskIntent budget exceeds the approved AgentTask budget");
+  }
+}
+
+function fail(reason: string, message: string): never {
+  throw new AttenuationError(reason, message);
+}

--- a/packages/averray-mcp/src/task-intent-mapping.ts
+++ b/packages/averray-mcp/src/task-intent-mapping.ts
@@ -1,0 +1,141 @@
+import {
+  hashTaskIntent,
+  serializeTaskIntent,
+  taskIntentSchema,
+  type AgentTaskV1,
+  type TaskIntent,
+} from "@avg/schemas";
+
+export interface TaskIntentMappingOptions {
+  workspacePath: string;
+}
+
+export interface TaskIntentArtifact {
+  intent: TaskIntent;
+  canonicalBytes: string;
+  templateHash: `sha256:${string}`;
+}
+
+export function mapAgentTaskToTaskIntent(
+  task: AgentTaskV1,
+  options: TaskIntentMappingOptions,
+): TaskIntent {
+  return taskIntentSchema.parse({
+    apiVersion: "harness/v1alpha1",
+    kind: "TaskIntent",
+    metadata: {
+      id: slugWorkItemId(task.workItemId),
+      labels: {
+        averray_work_item_id: task.workItemId,
+        correlation_id: task.correlationId,
+        task_version: String(task.taskVersion),
+      },
+    },
+    spec: {
+      profile: task.intent.profile,
+      objective: [
+        task.proposal.objective,
+        `Title: ${task.proposal.title}`,
+        `Why now: ${task.proposal.whyNow}`,
+      ].join("\n\n"),
+      deliverables: [
+        { type: "workspace_patch" },
+        { type: "verification_report" },
+        { type: "change_summary" },
+      ],
+      context: {
+        workspace: {
+          path: options.workspacePath,
+          revision: task.repository.baseRevision,
+        },
+        references: [],
+      },
+      constraints: {
+        allowed_paths: [...task.repository.allowedPaths],
+        forbidden_paths: [...task.repository.forbiddenPaths],
+        network: task.requestedAuthority.network === "deny"
+          ? "deny"
+          : { allow: [...task.requestedAuthority.network.allowlist] },
+      },
+      acceptance: task.acceptance.criteria.map(mapAcceptanceCriterion),
+      approvals: [],
+      budgets: {
+        elapsed: `PT${task.budget.elapsedSeconds}S`,
+        model_tokens: task.budget.modelTokens,
+        tool_calls: task.budget.toolCalls,
+        // Zero-child authority is enforced structurally by a direct-execution-only profile.
+        // The TaskIntent contract requires these numeric fields to be positive.
+        max_children: 1,
+        max_concurrent_children: 1,
+      },
+      learning: {
+        episode_capture: true,
+        memory_write: "none",
+        skill_generation: "ineligible",
+      },
+    },
+  });
+}
+
+export async function buildTaskIntentArtifact(
+  task: AgentTaskV1,
+  options: TaskIntentMappingOptions,
+): Promise<TaskIntentArtifact> {
+  const intent = mapAgentTaskToTaskIntent(task, options);
+  const canonicalBytes = serializeTaskIntent(intent);
+  const templateHash = await hashTaskIntent(intent);
+  return { intent, canonicalBytes, templateHash };
+}
+
+function mapAcceptanceCriterion(
+  criterion: AgentTaskV1["acceptance"]["criteria"][number],
+): TaskIntent["spec"]["acceptance"][number] {
+  switch (criterion.type) {
+    case "command":
+      return {
+        id: criterion.id,
+        type: criterion.type,
+        command: criterion.command,
+        ...(criterion.workingDirectory
+          ? { working_directory: criterion.workingDirectory }
+          : {}),
+        required: criterion.required,
+      };
+    case "search":
+      return {
+        id: criterion.id,
+        type: criterion.type,
+        include: [...criterion.include],
+        pattern: criterion.pattern,
+        expected_matches: criterion.expectedMatches,
+        required: criterion.required,
+      };
+    case "baseline_comparison":
+      return {
+        id: criterion.id,
+        type: criterion.type,
+        rule: criterion.rule,
+        ...(criterion.baselineCommand
+          ? { baseline_command: criterion.baselineCommand }
+          : {}),
+        required: criterion.required,
+      };
+    case "rubric":
+      return {
+        id: criterion.id,
+        type: criterion.type,
+        rubric: criterion.rubric,
+        threshold: criterion.threshold,
+        judged_deliverables: [...criterion.judgedDeliverables],
+        borderline_margin: criterion.borderlineMargin,
+        required: criterion.required,
+      };
+  }
+}
+
+function slugWorkItemId(workItemId: string): string {
+  return workItemId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -4,5 +4,6 @@ export * from "./agent-run-projection.js";
 export * from "./agent-task.js";
 export * from "./hermes-decision-record.js";
 export * from "./legacy-agent-task.js";
+export * from "./task-intent.js";
 export * from "./verified-handoff.js";
 export * from "./wikipedia.js";

--- a/packages/schemas/src/task-intent.ts
+++ b/packages/schemas/src/task-intent.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+import {
+  canonicalContractJson,
+  hashCanonicalContract,
+} from "./agent-contract-hash.js";
+
+const taskIntentIdSchema = z.string().regex(/^[a-z0-9-]+$/);
+
+const taskIntentMetadataSchema = z.object({
+  id: taskIntentIdSchema,
+  labels: z.record(z.string()),
+}).strict();
+
+const taskIntentWorkspaceSchema = z.object({
+  path: z.string(),
+  revision: z.string(),
+}).strict();
+
+const taskIntentReferenceSchema = z.object({
+  path: z.string(),
+  authority: z.string(),
+}).strict();
+
+const taskIntentContextSchema = z.object({
+  workspace: taskIntentWorkspaceSchema,
+  references: z.array(taskIntentReferenceSchema),
+}).strict();
+
+const taskIntentNetworkSchema = z.union([
+  z.literal("deny"),
+  z.object({
+    allow: z.array(z.string()),
+  }).strict(),
+]);
+
+const taskIntentConstraintsSchema = z.object({
+  allowed_paths: z.array(z.string()),
+  forbidden_paths: z.array(z.string()),
+  network: taskIntentNetworkSchema,
+}).strict();
+
+const taskIntentDeliverableSchema = z.object({
+  type: z.string(),
+  scope: z.string().optional(),
+}).strict();
+
+const taskIntentCommandAcceptanceSchema = z.object({
+  id: z.string(),
+  type: z.literal("command"),
+  command: z.string(),
+  working_directory: z.string().optional(),
+  required: z.boolean(),
+}).strict();
+
+const taskIntentSearchAcceptanceSchema = z.object({
+  id: z.string(),
+  type: z.literal("search"),
+  include: z.array(z.string()),
+  pattern: z.string(),
+  expected_matches: z.number().int().nonnegative().safe(),
+  required: z.boolean(),
+}).strict();
+
+const taskIntentBaselineAcceptanceSchema = z.object({
+  id: z.string(),
+  type: z.literal("baseline_comparison"),
+  rule: z.literal("no_new_failures"),
+  baseline_command: z.string().optional(),
+  required: z.boolean(),
+}).strict();
+
+const taskIntentRubricAcceptanceSchema = z.object({
+  id: z.string(),
+  type: z.literal("rubric"),
+  rubric: z.string().min(1),
+  threshold: z.number().min(0).max(1),
+  judged_deliverables: z.array(z.string()).min(1),
+  borderline_margin: z.number().min(0).max(1),
+  required: z.boolean(),
+}).strict();
+
+const taskIntentAcceptanceSchema = z.discriminatedUnion("type", [
+  taskIntentCommandAcceptanceSchema,
+  taskIntentSearchAcceptanceSchema,
+  taskIntentBaselineAcceptanceSchema,
+  taskIntentRubricAcceptanceSchema,
+]);
+
+const taskIntentApprovalSchema = z.object({
+  when: z.string(),
+}).strict();
+
+const taskIntentBudgetsSchema = z.object({
+  elapsed: z.string(),
+  model_tokens: z.number().int().positive().safe(),
+  tool_calls: z.number().int().positive().safe(),
+  max_children: z.number().int().positive().safe(),
+  max_concurrent_children: z.number().int().positive().safe(),
+}).strict();
+
+const taskIntentLearningSchema = z.object({
+  episode_capture: z.boolean(),
+  memory_write: z.enum(["none", "candidate_only"]),
+  skill_generation: z.enum(["eligible", "ineligible"]),
+}).strict();
+
+const taskIntentSpecSchema = z.object({
+  profile: z.string(),
+  objective: z.string().min(1),
+  deliverables: z.array(taskIntentDeliverableSchema).min(1),
+  context: taskIntentContextSchema,
+  constraints: taskIntentConstraintsSchema,
+  acceptance: z.array(taskIntentAcceptanceSchema),
+  approvals: z.array(taskIntentApprovalSchema),
+  budgets: taskIntentBudgetsSchema,
+  learning: taskIntentLearningSchema,
+}).strict();
+
+export const taskIntentSchema = z.object({
+  apiVersion: z.literal("harness/v1alpha1"),
+  kind: z.literal("TaskIntent"),
+  metadata: taskIntentMetadataSchema,
+  spec: taskIntentSpecSchema,
+}).strict();
+
+export interface PilotProfileManifest {
+  profileId: string;
+  strategies: string[];
+  capabilities: Array<{
+    id: string;
+    effectClass: "none" | "local" | "external_read" | "external_write";
+    delegable: boolean;
+  }>;
+}
+
+export type TaskIntent = z.infer<typeof taskIntentSchema>;
+
+export function serializeTaskIntent(intent: TaskIntent): string {
+  return canonicalContractJson(taskIntentSchema.parse(intent));
+}
+
+export async function hashTaskIntent(intent: TaskIntent): Promise<`sha256:${string}`> {
+  return hashCanonicalContract(taskIntentSchema.parse(intent));
+}

--- a/test/fixtures/agent-integration/task-intent-v1alpha1.json
+++ b/test/fixtures/agent-integration/task-intent-v1alpha1.json
@@ -1,0 +1,93 @@
+{
+  "apiVersion": "harness/v1alpha1",
+  "kind": "TaskIntent",
+  "metadata": {
+    "id": "migrate-auth-tests",
+    "labels": {
+      "project": "auth-service"
+    }
+  },
+  "spec": {
+    "profile": "coding-change",
+    "objective": "Migrate the auth service tests without changing production behavior.",
+    "deliverables": [
+      {
+        "type": "workspace_patch",
+        "scope": "auth-service/tests"
+      },
+      {
+        "type": "verification_report"
+      },
+      {
+        "type": "change_summary"
+      }
+    ],
+    "context": {
+      "workspace": {
+        "path": "./auth-service",
+        "revision": "HEAD"
+      },
+      "references": [
+        {
+          "path": "./docs/testing.md",
+          "authority": "project_guidance"
+        }
+      ]
+    },
+    "constraints": {
+      "allowed_paths": [
+        "auth-service/tests/**",
+        "auth-service/pyproject.toml"
+      ],
+      "forbidden_paths": [
+        "auth-service/src/**"
+      ],
+      "network": "deny"
+    },
+    "acceptance": [
+      {
+        "id": "tests",
+        "type": "command",
+        "command": "pytest tests/ -x",
+        "working_directory": "auth-service",
+        "required": true
+      },
+      {
+        "id": "no-unittest",
+        "type": "search",
+        "include": [
+          "auth-service/tests/**/*.py"
+        ],
+        "pattern": "\\bimport unittest\\b|\\bfrom unittest\\b",
+        "expected_matches": 0,
+        "required": true
+      },
+      {
+        "id": "behavior",
+        "type": "baseline_comparison",
+        "rule": "no_new_failures",
+        "required": true
+      }
+    ],
+    "approvals": [
+      {
+        "when": "before_external_publish"
+      },
+      {
+        "when": "change_outside_allowed_paths"
+      }
+    ],
+    "budgets": {
+      "elapsed": "PT45M",
+      "model_tokens": 2000000,
+      "tool_calls": 400,
+      "max_children": 2,
+      "max_concurrent_children": 2
+    },
+    "learning": {
+      "episode_capture": true,
+      "memory_write": "candidate_only",
+      "skill_generation": "eligible"
+    }
+  }
+}

--- a/test/unit/attenuation.test.ts
+++ b/test/unit/attenuation.test.ts
@@ -1,0 +1,344 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  agentTaskV1Schema,
+  hashTaskIntent,
+  taskIntentSchema,
+  type AgentTaskV1,
+  type PilotProfileManifest,
+  type TaskIntent,
+} from "../../packages/schemas/src/index.js";
+import {
+  assertTaskIntentWithinApprovedAuthority,
+  AttenuationError,
+} from "../../packages/averray-mcp/src/attenuation.js";
+import {
+  mapAgentTaskToTaskIntent,
+} from "../../packages/averray-mcp/src/task-intent-mapping.js";
+
+const CAPABILITIES: PilotProfileManifest["capabilities"] = [
+  { id: "fs.read_file", effectClass: "none", delegable: false },
+  { id: "fs.write_file", effectClass: "local", delegable: false },
+  { id: "fs.list_files", effectClass: "none", delegable: false },
+  { id: "shell.run", effectClass: "local", delegable: false },
+  { id: "git.status", effectClass: "none", delegable: false },
+  { id: "git.diff", effectClass: "none", delegable: false },
+  { id: "artifact.put", effectClass: "local", delegable: false },
+  { id: "artifact.get", effectClass: "none", delegable: false },
+];
+
+describe("pre-dispatch TaskIntent attenuation", () => {
+  it("accepts a hash-bound intent inside approved direct-execution authority", async () => {
+    const setup = await passingSetup();
+
+    await expect(
+      assertTaskIntentWithinApprovedAuthority(
+        setup.task,
+        setup.intent,
+        setup.profile,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a tampered template hash first", async () => {
+    const setup = await passingSetup();
+    const tampered = {
+      ...setup.task,
+      intent: {
+        ...setup.task.intent,
+        templateHash:
+          "sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      },
+    } as AgentTaskV1;
+
+    await expectReason(tampered, setup.intent, setup.profile, "template_hash_mismatch");
+  });
+
+  it("rejects a mismatched profile identity", async () => {
+    const setup = await passingSetup();
+
+    await expectReason(
+      setup.task,
+      setup.intent,
+      { ...setup.profile, profileId: "other-profile" },
+      "profile_mismatch",
+    );
+  });
+
+  it("rejects expansion from network deny to an allowlist", async () => {
+    const setup = await passingSetup();
+    const intent = taskIntentSchema.parse({
+      ...setup.intent,
+      spec: {
+        ...setup.intent.spec,
+        constraints: {
+          ...setup.intent.spec.constraints,
+          network: { allow: ["api.example.test"] },
+        },
+      },
+    });
+    const task = await bindTaskToIntent(setup.task, intent);
+
+    await expectReason(task, intent, setup.profile, "network_expanded");
+  });
+
+  it("rejects a network allowlist superset", async () => {
+    const setup = await passingSetup({
+      network: { allowlist: ["api.example.test"] },
+    });
+    const intent = taskIntentSchema.parse({
+      ...setup.intent,
+      spec: {
+        ...setup.intent.spec,
+        constraints: {
+          ...setup.intent.spec.constraints,
+          network: {
+            allow: ["api.example.test", "unapproved.example.test"],
+          },
+        },
+      },
+    });
+    const task = await bindTaskToIntent(setup.task, intent);
+
+    await expectReason(task, intent, setup.profile, "network_expanded");
+  });
+
+  it("rejects paths outside the approved allowlist", async () => {
+    const setup = await passingSetup();
+    const intent = taskIntentSchema.parse({
+      ...setup.intent,
+      spec: {
+        ...setup.intent.spec,
+        constraints: {
+          ...setup.intent.spec.constraints,
+          allowed_paths: [
+            ...setup.intent.spec.constraints.allowed_paths,
+            "unapproved/path",
+          ],
+        },
+      },
+    });
+    const task = await bindTaskToIntent(setup.task, intent);
+
+    await expectReason(task, intent, setup.profile, "path_not_allowed");
+  });
+
+  it("rejects narrowing the approved forbidden paths", async () => {
+    const setup = await passingSetup();
+    const intent = taskIntentSchema.parse({
+      ...setup.intent,
+      spec: {
+        ...setup.intent.spec,
+        constraints: {
+          ...setup.intent.spec.constraints,
+          forbidden_paths: [],
+        },
+      },
+    });
+    const task = await bindTaskToIntent(setup.task, intent);
+
+    await expectReason(task, intent, setup.profile, "forbidden_paths_narrowed");
+  });
+
+  it("rejects elapsed, model-token, and tool-call budget expansion", async () => {
+    const setup = await passingSetup();
+    const expandedBudgets: TaskIntent["spec"]["budgets"][] = [
+      {
+        ...setup.intent.spec.budgets,
+        elapsed: `PT${setup.task.budget.elapsedSeconds + 1}S`,
+      },
+      {
+        ...setup.intent.spec.budgets,
+        model_tokens: setup.task.budget.modelTokens + 1,
+      },
+      {
+        ...setup.intent.spec.budgets,
+        tool_calls: setup.task.budget.toolCalls + 1,
+      },
+    ];
+
+    for (const budgets of expandedBudgets) {
+      const intent = taskIntentSchema.parse({
+        ...setup.intent,
+        spec: { ...setup.intent.spec, budgets },
+      });
+      const task = await bindTaskToIntent(setup.task, intent);
+      await expectReason(task, intent, setup.profile, "budget_exceeded");
+    }
+  });
+
+  it("rejects non-zero or delegable child authority", async () => {
+    const setup = await passingSetup();
+    const expandedAuthorities: AgentTaskV1["requestedAuthority"][] = [
+      { ...setup.task.requestedAuthority, maxChildren: 1 },
+      { ...setup.task.requestedAuthority, maxConcurrentChildren: 1 },
+      {
+        ...setup.task.requestedAuthority,
+        delegable: true,
+      } as unknown as AgentTaskV1["requestedAuthority"],
+    ];
+
+    for (const requestedAuthority of expandedAuthorities) {
+      const task = {
+        ...setup.task,
+        requestedAuthority,
+      } as AgentTaskV1;
+      await expectReason(task, setup.intent, setup.profile, "children_not_zero");
+    }
+  });
+
+  it("rejects profiles that include planning", async () => {
+    const setup = await passingSetup();
+
+    await expectReason(
+      setup.task,
+      setup.intent,
+      {
+        ...setup.profile,
+        strategies: ["direct_execution", "plan_execute"],
+      },
+      "profile_not_direct_execution",
+    );
+  });
+
+  it("rejects delegable profile capabilities", async () => {
+    const setup = await passingSetup();
+    const capabilities = setup.profile.capabilities.map((capability, index) =>
+      index === 0 ? { ...capability, delegable: true } : capability);
+
+    await expectReason(
+      setup.task,
+      setup.intent,
+      { ...setup.profile, capabilities },
+      "capability_delegable",
+    );
+  });
+
+  it("rejects externally effective profile capabilities", async () => {
+    const setup = await passingSetup();
+    const capabilities: PilotProfileManifest["capabilities"] =
+      setup.profile.capabilities.map((capability, index) =>
+        index === 0
+          ? { ...capability, effectClass: "external_write" }
+          : capability);
+
+    await expectReason(
+      setup.task,
+      setup.intent,
+      { ...setup.profile, capabilities },
+      "capability_effect_external",
+    );
+  });
+
+  it("rejects profile capabilities absent from approved grants", async () => {
+    const setup = await passingSetup();
+    const capabilities: PilotProfileManifest["capabilities"] = [
+      ...setup.profile.capabilities,
+      { id: "unapproved.capability", effectClass: "local", delegable: false },
+    ];
+
+    await expectReason(
+      setup.task,
+      setup.intent,
+      { ...setup.profile, capabilities },
+      "capability_not_granted",
+    );
+  });
+
+  it("rejects an empty profile capability manifest", async () => {
+    const setup = await passingSetup();
+
+    await expectReason(
+      setup.task,
+      setup.intent,
+      { ...setup.profile, capabilities: [] },
+      "capability_not_granted",
+    );
+  });
+});
+
+async function passingSetup(
+  overrides: {
+    network?: AgentTaskV1["requestedAuthority"]["network"];
+  } = {},
+): Promise<{
+  task: AgentTaskV1;
+  intent: TaskIntent;
+  profile: PilotProfileManifest;
+}> {
+  const base = agentTaskFixture();
+  const taskWithAuthority = agentTaskV1Schema.parse({
+    ...base,
+    requestedAuthority: {
+      ...base.requestedAuthority,
+      grants: CAPABILITIES.map((capability) => ({
+        capabilityId: capability.id,
+        resource: base.repository.nameWithOwner,
+        constraints: {},
+      })),
+      network: overrides.network ?? base.requestedAuthority.network,
+    },
+  });
+  const intent = mapAgentTaskToTaskIntent(taskWithAuthority, {
+    workspacePath: "/workspaces/task-checkout",
+  });
+  const task = await bindTaskToIntent(taskWithAuthority, intent);
+  return {
+    task,
+    intent,
+    profile: {
+      profileId: task.intent.profile,
+      strategies: ["direct_execution"],
+      capabilities: CAPABILITIES.map((capability) => ({ ...capability })),
+    },
+  };
+}
+
+async function bindTaskToIntent(
+  task: AgentTaskV1,
+  intent: TaskIntent,
+): Promise<AgentTaskV1> {
+  const templateHash = await hashTaskIntent(intent);
+  return agentTaskV1Schema.parse({
+    ...task,
+    intent: {
+      ...task.intent,
+      templateRef: {
+        ...task.intent.templateRef,
+        uri: `artifact://sha256/${templateHash.slice("sha256:".length)}`,
+        sha256: templateHash,
+      },
+      templateHash,
+    },
+  });
+}
+
+async function expectReason(
+  task: AgentTaskV1,
+  intent: TaskIntent,
+  profile: PilotProfileManifest,
+  reason: string,
+): Promise<void> {
+  await expect(
+    assertTaskIntentWithinApprovedAuthority(task, intent, profile),
+  ).rejects.toMatchObject({
+    name: "AttenuationError",
+    reason,
+  });
+  await assertTaskIntentWithinApprovedAuthority(task, intent, profile).catch((error) => {
+    expect(error).toBeInstanceOf(AttenuationError);
+  });
+}
+
+function agentTaskFixture(): AgentTaskV1 {
+  return agentTaskV1Schema.parse(
+    JSON.parse(
+      readFileSync(
+        new URL("../fixtures/agent-integration/agent-task-v1.json", import.meta.url),
+        "utf8",
+      ),
+    ),
+  );
+}

--- a/test/unit/task-intent-mapping.test.ts
+++ b/test/unit/task-intent-mapping.test.ts
@@ -1,0 +1,199 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  agentTaskV1Schema,
+  hashTaskIntent,
+  serializeTaskIntent,
+  taskIntentSchema,
+  type AgentTaskV1,
+} from "../../packages/schemas/src/index.js";
+import {
+  buildTaskIntentArtifact,
+  mapAgentTaskToTaskIntent,
+} from "../../packages/averray-mcp/src/task-intent-mapping.js";
+
+describe("TaskIntent contract", () => {
+  it("accepts the v1alpha1 fixture and rejects unknown keys and wrong types", () => {
+    const fixture = taskIntentFixture();
+
+    expect(taskIntentSchema.parse(fixture)).toEqual(fixture);
+    expect(() => taskIntentSchema.parse({ ...fixture, extra: true })).toThrow();
+    expect(() =>
+      taskIntentSchema.parse({
+        ...fixture,
+        spec: {
+          ...fixture.spec,
+          budgets: {
+            ...fixture.spec.budgets,
+            model_tokens: "many",
+          },
+        },
+      })
+    ).toThrow();
+  });
+});
+
+describe("AgentTask to TaskIntent mapping", () => {
+  it("maps identity, authority, budgets, and snake_case acceptance fields", () => {
+    const base = agentTaskFixture();
+    const task = agentTaskV1Schema.parse({
+      ...base,
+      workItemId: "Work Item/001",
+      requestedAuthority: {
+        ...base.requestedAuthority,
+        network: {
+          allowlist: ["api.example.test", "artifacts.example.test"],
+        },
+      },
+      acceptance: {
+        ...base.acceptance,
+        criteria: [
+          {
+            id: "command",
+            type: "command",
+            command: "npm test",
+            workingDirectory: "packages/schemas",
+            required: true,
+          },
+          {
+            id: "search",
+            type: "search",
+            include: ["packages/**/*.ts"],
+            pattern: "TaskIntent",
+            expectedMatches: 2,
+            required: true,
+          },
+          {
+            id: "baseline",
+            type: "baseline_comparison",
+            rule: "no_new_failures",
+            baselineCommand: "npm test -- --baseline",
+            required: true,
+          },
+          {
+            id: "rubric",
+            type: "rubric",
+            rubric: "The change remains bounded and verifiable.",
+            threshold: 0.9,
+            judgedDeliverables: ["workspace_patch", "verification_report"],
+            borderlineMargin: 0.05,
+            required: true,
+          },
+        ],
+      },
+    });
+
+    const intent = mapAgentTaskToTaskIntent(task, {
+      workspacePath: "/workspaces/task-checkout",
+    });
+
+    expect(taskIntentSchema.parse(intent)).toEqual(intent);
+    expect(intent.metadata).toEqual({
+      id: "work-item-001",
+      labels: {
+        averray_work_item_id: "Work Item/001",
+        correlation_id: task.correlationId,
+        task_version: "1",
+      },
+    });
+    expect(intent.spec.objective).toContain(task.proposal.objective);
+    expect(intent.spec.objective).toContain(`Title: ${task.proposal.title}`);
+    expect(intent.spec.objective).toContain(`Why now: ${task.proposal.whyNow}`);
+    expect(intent.spec.context).toEqual({
+      workspace: {
+        path: "/workspaces/task-checkout",
+        revision: task.repository.baseRevision,
+      },
+      references: [],
+    });
+    expect(intent.spec.constraints).toEqual({
+      allowed_paths: task.repository.allowedPaths,
+      forbidden_paths: task.repository.forbiddenPaths,
+      network: {
+        allow: ["api.example.test", "artifacts.example.test"],
+      },
+    });
+    expect(intent.spec.acceptance).toEqual([
+      {
+        id: "command",
+        type: "command",
+        command: "npm test",
+        working_directory: "packages/schemas",
+        required: true,
+      },
+      {
+        id: "search",
+        type: "search",
+        include: ["packages/**/*.ts"],
+        pattern: "TaskIntent",
+        expected_matches: 2,
+        required: true,
+      },
+      {
+        id: "baseline",
+        type: "baseline_comparison",
+        rule: "no_new_failures",
+        baseline_command: "npm test -- --baseline",
+        required: true,
+      },
+      {
+        id: "rubric",
+        type: "rubric",
+        rubric: "The change remains bounded and verifiable.",
+        threshold: 0.9,
+        judged_deliverables: ["workspace_patch", "verification_report"],
+        borderline_margin: 0.05,
+        required: true,
+      },
+    ]);
+    expect(intent.spec.budgets).toEqual({
+      elapsed: `PT${task.budget.elapsedSeconds}S`,
+      model_tokens: task.budget.modelTokens,
+      tool_calls: task.budget.toolCalls,
+      max_children: 1,
+      max_concurrent_children: 1,
+    });
+    expect(intent.spec.approvals).toEqual([]);
+    expect(intent.spec.learning).toEqual({
+      episode_capture: true,
+      memory_write: "none",
+      skill_generation: "ineligible",
+    });
+  });
+
+  it("builds canonical bytes and their matching template hash", async () => {
+    const task = agentTaskV1Schema.parse(agentTaskFixture());
+    const built = await buildTaskIntentArtifact(task, {
+      workspacePath: "/workspaces/task-checkout",
+    });
+
+    expect(built.canonicalBytes).toBe(serializeTaskIntent(built.intent));
+    expect(await hashTaskIntent(built.intent)).toBe(built.templateHash);
+    expect(JSON.parse(built.canonicalBytes)).toEqual(built.intent);
+  });
+});
+
+function agentTaskFixture(): AgentTaskV1 {
+  return JSON.parse(
+    readFileSync(
+      new URL("../fixtures/agent-integration/agent-task-v1.json", import.meta.url),
+      "utf8",
+    ),
+  ) as AgentTaskV1;
+}
+
+function taskIntentFixture(): ReturnType<typeof taskIntentSchema.parse> {
+  return taskIntentSchema.parse(
+    JSON.parse(
+      readFileSync(
+        new URL(
+          "../fixtures/agent-integration/task-intent-v1alpha1.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## What changed

- add a strict `TaskIntent` v1alpha1 Zod contract mirroring the Harness kernel shape, with canonical serialization and hashing
- add pure `AgentTask` → `TaskIntent` mapping and artifact construction
- add fail-closed pre-dispatch attenuation proof against an approved template, pilot profile, grants, paths, network, budgets, delegation, and external-effect constraints
- add the canonical TaskIntent fixture and focused mapping/attenuation coverage
- export the new schema and pure MCP package entry points

## Checks run

- `npm run typecheck` — exit 0
- `npm test` — 180 test files passed, 2,214 tests passed
- `docker build -f ops/Dockerfile.node -t averray-reference-agent:int2c-check .` — exit 0
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config --quiet` — exit 0
- `git diff --check` — exit 0

## Affected surfaces

Schemas, pure backend mapping/attenuation modules, fixture, and unit tests only. No frontend, Slack operator/board, store, migration, dispatcher, runtime, contracts, Caddy, or public-site changes. No environment or VPS secret changes are required.

## Authority and rollout

This is pure and side-effect-free. It does not call or start Harness, submit work, add a dispatcher or dispatch flag, write runtime/store state, or change production authority. The landed INT-0 contract schemas are unchanged. INT-2d is intentionally out of scope.