### PR TITLE
feat(harness): add INT-2d write-capable control port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,10 @@
       "resolved": "packages/averray-mcp",
       "link": true
     },
+    "node_modules/@avg/harness-dispatcher": {
+      "resolved": "services/harness-dispatcher",
+      "link": true
+    },
     "node_modules/@avg/mcp-common": {
       "resolved": "packages/mcp-common",
       "link": true
@@ -5246,6 +5250,13 @@
         "@modelcontextprotocol/sdk": "^1.13.3",
         "viem": "^2.23.7",
         "zod": "^3.24.1"
+      }
+    },
+    "services/harness-dispatcher": {
+      "name": "@avg/harness-dispatcher",
+      "version": "0.1.0",
+      "dependencies": {
+        "@avg/schemas": "0.1.0"
       }
     },
     "services/skills-observer": {

--- a/services/harness-dispatcher/package.json
+++ b/services/harness-dispatcher/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@avg/harness-dispatcher",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -b",
+    "typecheck": "tsc -b --pretty false"
+  },
+  "dependencies": {
+    "@avg/schemas": "0.1.0"
+  }
+}

--- a/services/harness-dispatcher/src/harness-control-port.ts
+++ b/services/harness-dispatcher/src/harness-control-port.ts
@@ -1,0 +1,310 @@
+/**
+ * Write-only Harness CLI boundary.
+ *
+ * A submit that times out or fails to connect is ambiguous: the requested run
+ * may already exist. The caller must reconcile with `run status <same runId>`
+ * and, if needed, re-submit the SAME run id, which DBOS safely deduplicates.
+ * Never mint a new run id when retrying an ambiguous submit.
+ */
+
+import { spawn } from "node:child_process";
+import { statSync } from "node:fs";
+import path from "node:path";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 256 * 1024;
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export type HarnessControlErrorCode =
+  | "dispatch_disabled"
+  | "invalid_run_id"
+  | "invalid_intent_path"
+  | "refused_command"
+  | "cli_failed"
+  | "cli_timeout"
+  | "cli_output_too_large"
+  | "submit_malformed"
+  | "submit_identity_mismatch";
+
+export class HarnessControlError extends Error {
+  constructor(
+    readonly code: HarnessControlErrorCode,
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "HarnessControlError";
+  }
+}
+
+export interface HarnessCommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type HarnessCommandExecutor = (
+  command: string,
+  args: readonly string[],
+  options: { timeoutMs: number; maxOutputBytes: number },
+) => Promise<HarnessCommandResult>;
+
+export interface HarnessControlPort {
+  submit(runId: string, intentPath: string): Promise<string>;
+  cancel(runId: string): Promise<void>;
+}
+
+export function harnessDispatchEnabled(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  const value = environment.HARNESS_DISPATCH_ENABLED?.trim().toLowerCase() ?? "false";
+  return value === "1" || value === "true";
+}
+
+export function createHarnessControlPort(options: {
+  command?: string;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  enabled?: boolean;
+  execute?: HarnessCommandExecutor;
+} = {}): HarnessControlPort {
+  const command = options.command?.trim() || "harness";
+  if (path.basename(command) !== "harness") {
+    throw new HarnessControlError(
+      "cli_failed",
+      "Harness control adapter requires an executable named harness",
+      false,
+    );
+  }
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxOutputBytes = options.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const enabled = options.enabled ?? harnessDispatchEnabled();
+  const execute = options.execute ?? executeHarnessCommand;
+
+  const assertEnabled = (): void => {
+    if (enabled !== true) {
+      throw new HarnessControlError(
+        "dispatch_disabled",
+        "Harness dispatch is disabled",
+        false,
+      );
+    }
+  };
+
+  return {
+    async submit(runId, intentPath) {
+      assertEnabled();
+      assertCanonicalRunId(runId);
+      assertRegularIntentFile(intentPath);
+
+      const result = await runControlCommand(
+        execute,
+        command,
+        ["run", "submit", "--run-id", runId, intentPath],
+        timeoutMs,
+        maxOutputBytes,
+      );
+      const lines = nonEmptyLines(result.stdout);
+      if (lines.length !== 1) {
+        throw new HarnessControlError(
+          "submit_malformed",
+          "Harness submit response must contain exactly one run id",
+          false,
+        );
+      }
+      if (lines[0] !== runId) {
+        throw new HarnessControlError(
+          "submit_identity_mismatch",
+          "Harness submit response does not match the requested run id",
+          false,
+        );
+      }
+      return runId;
+    },
+
+    async cancel(runId) {
+      assertEnabled();
+      assertCanonicalRunId(runId);
+
+      await runControlCommand(
+        execute,
+        command,
+        ["run", "cancel", runId],
+        timeoutMs,
+        maxOutputBytes,
+      );
+    },
+  };
+}
+
+export function assertControlArgs(args: readonly string[]): void {
+  const isSubmit = args.length === 5
+    && args[0] === "run"
+    && args[1] === "submit"
+    && args[2] === "--run-id";
+  const isCancel = args.length === 3
+    && args[0] === "run"
+    && args[1] === "cancel";
+  if (!isSubmit && !isCancel) {
+    throw new HarnessControlError(
+      "refused_command",
+      "Harness control adapter refused a non-allowlisted command",
+      false,
+    );
+  }
+}
+
+export const executeHarnessCommand: HarnessCommandExecutor = (
+  command,
+  args,
+  { timeoutMs, maxOutputBytes },
+) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, [...args], {
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+    let stdout = "";
+    let stderr = "";
+    let outputBytes = 0;
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const finishWithError = (error: HarnessControlError): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(error);
+    };
+    const collect = (target: "stdout" | "stderr", chunk: Buffer): void => {
+      outputBytes += chunk.byteLength;
+      if (outputBytes > maxOutputBytes) {
+        finishWithError(
+          new HarnessControlError(
+            "cli_output_too_large",
+            "Harness control response exceeded the configured output limit",
+            false,
+          ),
+        );
+        return;
+      }
+      if (target === "stdout") stdout += chunk.toString("utf8");
+      else stderr += chunk.toString("utf8");
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => collect("stdout", chunk));
+    child.stderr.on("data", (chunk: Buffer) => collect("stderr", chunk));
+    child.once("error", () => {
+      finishWithError(
+        new HarnessControlError(
+          "cli_failed",
+          "Harness control command could not be started",
+          true,
+        ),
+      );
+    });
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+    timer = setTimeout(() => {
+      finishWithError(
+        new HarnessControlError(
+          "cli_timeout",
+          "Harness control command timed out",
+          true,
+        ),
+      );
+    }, timeoutMs);
+    timer.unref();
+  });
+
+async function runControlCommand(
+  execute: HarnessCommandExecutor,
+  command: string,
+  args: readonly string[],
+  timeoutMs: number,
+  maxOutputBytes: number,
+): Promise<HarnessCommandResult> {
+  assertControlArgs(args);
+  let result: HarnessCommandResult;
+  try {
+    result = await execute(command, args, { timeoutMs, maxOutputBytes });
+  } catch (error) {
+    if (error instanceof HarnessControlError) throw error;
+    throw new HarnessControlError(
+      "cli_failed",
+      "Harness control command could not be started",
+      true,
+    );
+  }
+
+  if (
+    Buffer.byteLength(result.stdout, "utf8") + Buffer.byteLength(result.stderr, "utf8")
+      > maxOutputBytes
+  ) {
+    throw new HarnessControlError(
+      "cli_output_too_large",
+      "Harness control response exceeded the configured output limit",
+      false,
+    );
+  }
+  if (result.code !== 0) {
+    const safeDetail = safeCliFailureDetail(result.stderr);
+    throw new HarnessControlError(
+      "cli_failed",
+      `Harness control command failed with exit ${result.code}${safeDetail ? `: ${safeDetail}` : ""}`,
+      true,
+    );
+  }
+  return result;
+}
+
+function assertCanonicalRunId(runId: string): void {
+  if (!CANONICAL_UUID.test(runId)) {
+    throw new HarnessControlError(
+      "invalid_run_id",
+      "Harness run id must be a lowercase canonical UUID",
+      false,
+    );
+  }
+}
+
+function assertRegularIntentFile(intentPath: string): void {
+  if (!intentPath.trim() || !path.isAbsolute(intentPath)) {
+    throw new HarnessControlError(
+      "invalid_intent_path",
+      "Harness intent path must be an absolute regular file",
+      false,
+    );
+  }
+  try {
+    if (statSync(intentPath).isFile()) return;
+  } catch {
+    // Fall through to the same non-sensitive validation error.
+  }
+  throw new HarnessControlError(
+    "invalid_intent_path",
+    "Harness intent path must be an absolute regular file",
+    false,
+  );
+}
+
+function nonEmptyLines(value: string): string[] {
+  return value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
+function safeCliFailureDetail(stderr: string): string {
+  const text = stderr.replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  if (/schema missing/i.test(text)) return "Harness database schema is unavailable";
+  if (/record not found|completed run not found/i.test(text)) {
+    return "Harness run record is unavailable";
+  }
+  if (/configuration|connection/i.test(text)) return "Harness data source is unavailable";
+  return "Harness data source refused the control request";
+}

--- a/services/harness-dispatcher/tsconfig.json
+++ b/services/harness-dispatcher/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "references": [
+    { "path": "../../packages/schemas" }
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/test/unit/harness-control-port.test.ts
+++ b/test/unit/harness-control-port.test.ts
@@ -1,0 +1,215 @@
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertControlArgs,
+  createHarnessControlPort,
+  harnessDispatchEnabled,
+  HarnessControlError,
+  type HarnessCommandExecutor,
+} from "../../services/harness-dispatcher/src/harness-control-port.js";
+
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222";
+const INTENT_PATH = path.resolve(
+  "test/fixtures/agent-integration/task-intent-v1alpha1.json",
+);
+
+describe("INT-2d Harness control port", () => {
+  it("defaults dispatch off and never executes submit or cancel while disabled", async () => {
+    const prior = process.env.HARNESS_DISPATCH_ENABLED;
+    delete process.env.HARNESS_DISPATCH_ENABLED;
+    try {
+      const execute = vi.fn<HarnessCommandExecutor>(async () => ({
+        code: 0,
+        stdout: RUN_ID,
+        stderr: "",
+      }));
+      const port = createHarnessControlPort({ execute });
+
+      await expect(port.submit(RUN_ID, INTENT_PATH)).rejects.toMatchObject({
+        code: "dispatch_disabled",
+        retryable: false,
+      });
+      await expect(port.cancel(RUN_ID)).rejects.toMatchObject({
+        code: "dispatch_disabled",
+        retryable: false,
+      });
+      expect(execute).not.toHaveBeenCalled();
+    } finally {
+      if (prior === undefined) delete process.env.HARNESS_DISPATCH_ENABLED;
+      else process.env.HARNESS_DISPATCH_ENABLED = prior;
+    }
+  });
+
+  it("enables only the explicit 1 and true flag values", () => {
+    for (const value of [undefined, "", "0", "false", "no"]) {
+      expect(harnessDispatchEnabled({ HARNESS_DISPATCH_ENABLED: value })).toBe(false);
+    }
+    for (const value of ["1", "true", " TRUE ", " 1 "]) {
+      expect(harnessDispatchEnabled({ HARNESS_DISPATCH_ENABLED: value })).toBe(true);
+    }
+  });
+
+  it("submits and cancels with exact fixed argv and bounded defaults", async () => {
+    const execute = vi.fn<HarnessCommandExecutor>(async (_command, args) => ({
+      code: 0,
+      stdout: args[1] === "submit" ? `${RUN_ID}\n` : "",
+      stderr: "",
+    }));
+    const port = createHarnessControlPort({ enabled: true, execute });
+
+    await expect(port.submit(RUN_ID, INTENT_PATH)).resolves.toBe(RUN_ID);
+    await expect(port.cancel(RUN_ID)).resolves.toBeUndefined();
+
+    expect(execute).toHaveBeenNthCalledWith(
+      1,
+      "harness",
+      ["run", "submit", "--run-id", RUN_ID, INTENT_PATH],
+      { timeoutMs: 15_000, maxOutputBytes: 256 * 1024 },
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      "harness",
+      ["run", "cancel", RUN_ID],
+      { timeoutMs: 15_000, maxOutputBytes: 256 * 1024 },
+    );
+  });
+
+  it("rejects non-allowlisted control argv", () => {
+    const refused = [
+      ["run", "approve", RUN_ID],
+      ["run", "deny", RUN_ID],
+      ["run", "release", RUN_ID, "--to", "failed"],
+      ["run", "status", RUN_ID],
+      ["skill", "promote", "x"],
+    ];
+    for (const args of refused) {
+      expect(() => assertControlArgs(args)).toThrow(
+        expect.objectContaining({
+          code: "refused_command",
+          retryable: false,
+        }),
+      );
+    }
+  });
+
+  it("rejects a binary whose basename is not harness", () => {
+    expect(() => createHarnessControlPort({ command: "/usr/bin/bash" })).toThrow(
+      expect.objectContaining({
+        code: "cli_failed",
+        retryable: false,
+      }),
+    );
+  });
+
+  it("rejects non-canonical run ids without executing", async () => {
+    const execute = vi.fn<HarnessCommandExecutor>();
+    const port = createHarnessControlPort({ enabled: true, execute });
+
+    await expect(port.cancel("NOT-A-UUID")).rejects.toMatchObject({
+      code: "invalid_run_id",
+      retryable: false,
+    });
+    await expect(
+      port.submit("11111111-1111-4111-8111-11111111111A", INTENT_PATH),
+    ).rejects.toMatchObject({
+      code: "invalid_run_id",
+      retryable: false,
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("rejects relative and missing intent paths without executing", async () => {
+    const execute = vi.fn<HarnessCommandExecutor>();
+    const port = createHarnessControlPort({ enabled: true, execute });
+
+    await expect(port.submit(RUN_ID, "task.yaml")).rejects.toMatchObject({
+      code: "invalid_intent_path",
+      retryable: false,
+    });
+    await expect(
+      port.submit(RUN_ID, path.resolve("test/fixtures/missing-task.yaml")),
+    ).rejects.toMatchObject({
+      code: "invalid_intent_path",
+      retryable: false,
+    });
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["empty", ""],
+    ["multiple", `${RUN_ID}\n${RUN_ID}\n`],
+  ])("rejects %s submit stdout", async (_name, stdout) => {
+    const port = createHarnessControlPort({
+      enabled: true,
+      execute: async () => ({ code: 0, stdout, stderr: "" }),
+    });
+    await expect(port.submit(RUN_ID, INTENT_PATH)).rejects.toMatchObject({
+      code: "submit_malformed",
+      retryable: false,
+    });
+  });
+
+  it("rejects a submit identity mismatch", async () => {
+    const port = createHarnessControlPort({
+      enabled: true,
+      execute: async () => ({ code: 0, stdout: OTHER_RUN_ID, stderr: "" }),
+    });
+    await expect(port.submit(RUN_ID, INTENT_PATH)).rejects.toMatchObject({
+      code: "submit_identity_mismatch",
+      retryable: false,
+    });
+  });
+
+  it("maps non-zero exits without surfacing raw stderr credentials", async () => {
+    const port = createHarnessControlPort({
+      enabled: true,
+      execute: async () => ({
+        code: 2,
+        stdout: "",
+        stderr: "connection failed for postgresql://user:supersecret@host/db",
+      }),
+    });
+
+    const failure = await port.cancel(RUN_ID).catch((error: unknown) => error);
+    expect(failure).toBeInstanceOf(HarnessControlError);
+    expect(failure).toMatchObject({ code: "cli_failed", retryable: true });
+    expect((failure as Error).message).toContain("Harness data source is unavailable");
+    expect((failure as Error).message).not.toContain("supersecret");
+  });
+
+  it("preserves retryable timeout failures", async () => {
+    const port = createHarnessControlPort({
+      enabled: true,
+      execute: async () => {
+        throw new HarnessControlError(
+          "cli_timeout",
+          "Harness control command timed out",
+          true,
+        );
+      },
+    });
+    await expect(port.cancel(RUN_ID)).rejects.toMatchObject({
+      code: "cli_timeout",
+      retryable: true,
+    });
+  });
+
+  it("rejects oversized combined command output", async () => {
+    const port = createHarnessControlPort({
+      enabled: true,
+      maxOutputBytes: 8,
+      execute: async () => ({
+        code: 0,
+        stdout: RUN_ID,
+        stderr: "",
+      }),
+    });
+    await expect(port.submit(RUN_ID, INTENT_PATH)).rejects.toMatchObject({
+      code: "cli_output_too_large",
+      retryable: false,
+    });
+  });
+});


### PR DESCRIPTION
## What changed

- add the dormant `@avg/harness-dispatcher` workspace skeleton with one source module and no `start` script or entry point
- add a write-only Harness CLI control port for idempotent caller-bound submit and bounded cancel
- fail closed on a disabled flag, invalid canonical run ids, invalid intent paths, a non-`harness` executable, or non-allowlisted argv
- enforce fixed `shell:false` argv, a 15-second timeout, a 256 KB combined-output cap, safe CLI error details, exact one-line submit identity, and retryable ambiguous timeout/failure signaling
- add focused unit coverage for every control-port guard and register the workspace in the lockfile

## Checks run

- `npm run typecheck` — exit 0
- `npx vitest run test/unit/harness-control-port.test.ts` — 1 file passed, 13 tests passed
- `npm test` — 181 test files passed, 2,227 tests passed
- `docker build -f ops/Dockerfile.node -t averray-reference-agent:int2d-check .` — exit 0
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config --quiet` — exit 0
- `git diff --check` — exit 0

## Affected surfaces

New dormant `services/harness-dispatcher` workspace, root lockfile workspace registration, and unit tests only. No existing Slack operator/read port, board, projection, store, schema, migration, runtime, Ops/Compose, Caddy, contract, or public-site files changed. No external dependency, environment value, or VPS secret is added.

## Authority and rollout

Nothing calls this module, no process is started, no dispatcher loop or polling exists, and no Compose service was added. `HARNESS_DISPATCH_ENABLED` is read only inside this module and defaults false. The argv allowlist permits only `run submit --run-id <id> <absolute-file>` and `run cancel <id>`; it cannot approve, deny, release, or invoke read/admin command families. Ambiguous submits must be reconciled and retried with the same run id.

There is no production rollout in this PR. INT-2e is intentionally out of scope.