### PR TITLE
feat(harness): add INT-2e durable dispatch persistence

### DIFF
--- a/ops/migrate.sh
+++ b/ops/migrate.sh
@@ -3,3 +3,4 @@ set -euo pipefail
 
 psql "${DATABASE_URL:?DATABASE_URL is required}" -f /migrations/001_init.sql
 psql "${DATABASE_URL:?DATABASE_URL is required}" -f /migrations/002_agent_tasks.sql
+psql "${DATABASE_URL:?DATABASE_URL is required}" -f /migrations/003_dispatch_claims_outbox_decisions.sql

--- a/ops/migrations/003_dispatch_claims_outbox_decisions.sql
+++ b/ops/migrations/003_dispatch_claims_outbox_decisions.sql
@@ -1,0 +1,40 @@
+create table if not exists dispatch_lease (
+  lease_id text primary key default 'global',
+  holder text not null,
+  acquired_at timestamptz not null,
+  expires_at timestamptz not null
+);
+
+create table if not exists agent_task_dispatch_claims (
+  work_item_id text not null,
+  task_version integer not null check (task_version > 0),
+  approved_task_hash text not null,
+  intended_run_id uuid not null,
+  claim_state text not null,
+  claimed_at timestamptz not null,
+  lease_expires_at timestamptz,
+  primary key (work_item_id, task_version)
+);
+
+create table if not exists agent_task_run_outbox (
+  work_item_id text primary key,
+  harness_run_id uuid not null,
+  run_manifest_ref jsonb,
+  run_manifest_hash text,
+  bound_at timestamptz not null
+);
+
+create table if not exists hermes_decision_records (
+  decision_id text primary key,
+  correlation_id text not null,
+  work_item_id text,
+  decision_type text not null,
+  generated_at timestamptz not null,
+  record jsonb not null
+);
+
+create index if not exists hermes_decision_records_correlation_id_idx
+  on hermes_decision_records(correlation_id);
+
+create index if not exists hermes_decision_records_work_item_id_idx
+  on hermes_decision_records(work_item_id);

--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -65,6 +65,18 @@
       "types": "./dist/agent-task-store.d.ts",
       "import": "./dist/agent-task-store.js"
     },
+    "./dispatch-claim": {
+      "types": "./dist/dispatch-claim.d.ts",
+      "import": "./dist/dispatch-claim.js"
+    },
+    "./run-binding-outbox": {
+      "types": "./dist/run-binding-outbox.d.ts",
+      "import": "./dist/run-binding-outbox.js"
+    },
+    "./decision-record-store": {
+      "types": "./dist/decision-record-store.d.ts",
+      "import": "./dist/decision-record-store.js"
+    },
     "./task-intent-mapping": {
       "types": "./dist/task-intent-mapping.d.ts",
       "import": "./dist/task-intent-mapping.js"

--- a/packages/averray-mcp/src/decision-record-store.ts
+++ b/packages/averray-mcp/src/decision-record-store.ts
@@ -1,0 +1,136 @@
+import { query as defaultQuery } from "@avg/mcp-common";
+import {
+  hermesDecisionRecordV2Schema,
+  type HermesDecisionRecordV2,
+} from "@avg/schemas";
+
+export type HermesDecisionStoreQuery = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[],
+) => Promise<T[]>;
+
+export interface HermesDecisionStoreDeps {
+  query?: HermesDecisionStoreQuery;
+}
+
+export interface HermesDecisionListFilter {
+  correlationId?: string;
+  workItemId?: string;
+  limit?: number;
+}
+
+interface HermesDecisionRow {
+  decision_id: string;
+  correlation_id: string;
+  work_item_id: string | null;
+  decision_type: string;
+  generated_at: string | Date;
+  record: unknown;
+}
+
+const DEFAULT_LIST_LIMIT = 100;
+const MAX_LIST_LIMIT = 1_000;
+const SELECT_COLUMNS = `
+  decision_id,
+  correlation_id,
+  work_item_id,
+  decision_type,
+  generated_at,
+  record
+`;
+
+export async function recordHermesDecision(
+  input: HermesDecisionRecordV2,
+  deps: HermesDecisionStoreDeps = {},
+): Promise<HermesDecisionRecordV2> {
+  const record = hermesDecisionRecordV2Schema.parse(input);
+  await storeQuery(deps)<HermesDecisionRow>(
+    `insert into hermes_decision_records (
+       decision_id,
+       correlation_id,
+       work_item_id,
+       decision_type,
+       generated_at,
+       record
+     ) values ($1, $2, $3, $4, $5::timestamptz, $6::jsonb)
+     on conflict (decision_id) do nothing
+     returning ${SELECT_COLUMNS}`,
+    [
+      record.decisionId,
+      record.correlationId,
+      record.workItemId ?? null,
+      record.decisionType,
+      record.generatedAt,
+      JSON.stringify(record),
+    ],
+  );
+  return record;
+}
+
+export async function listHermesDecisions(
+  filter: HermesDecisionListFilter = {},
+  deps: HermesDecisionStoreDeps = {},
+): Promise<HermesDecisionRecordV2[]> {
+  const clauses: string[] = [];
+  const values: unknown[] = [];
+  if (filter.correlationId !== undefined) {
+    values.push(filter.correlationId);
+    clauses.push(`correlation_id = $${values.length}`);
+  }
+  if (filter.workItemId !== undefined) {
+    values.push(filter.workItemId);
+    clauses.push(`work_item_id = $${values.length}`);
+  }
+  values.push(normalizedLimit(filter.limit));
+
+  const rows = await storeQuery(deps)<HermesDecisionRow>(
+    `select ${SELECT_COLUMNS}
+     from hermes_decision_records
+     ${clauses.length > 0 ? `where ${clauses.join(" and ")}` : ""}
+     order by generated_at desc, decision_id asc
+     limit $${values.length}`,
+    values,
+  );
+  return rows.map(parseHermesDecisionRow);
+}
+
+function parseHermesDecisionRow(row: HermesDecisionRow): HermesDecisionRecordV2 {
+  const rawRecord = typeof row.record === "string"
+    ? JSON.parse(row.record) as unknown
+    : row.record;
+  const record = hermesDecisionRecordV2Schema.parse(rawRecord);
+  const expected = {
+    decisionId: row.decision_id,
+    correlationId: row.correlation_id,
+    workItemId: row.work_item_id ?? undefined,
+    decisionType: row.decision_type,
+    generatedAt: timestamp(row.generated_at),
+  };
+  const actual = {
+    decisionId: record.decisionId,
+    correlationId: record.correlationId,
+    workItemId: record.workItemId,
+    decisionType: record.decisionType,
+    generatedAt: timestamp(record.generatedAt),
+  };
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+    throw new Error(`Hermes decision row columns do not match record JSON for ${record.decisionId}`);
+  }
+  return record;
+}
+
+function normalizedLimit(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_LIST_LIMIT;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("Hermes decision list limit must be a positive safe integer");
+  }
+  return Math.min(value, MAX_LIST_LIMIT);
+}
+
+function timestamp(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function storeQuery(deps: HermesDecisionStoreDeps): HermesDecisionStoreQuery {
+  return deps.query ?? defaultQuery;
+}

--- a/packages/averray-mcp/src/decision-records.ts
+++ b/packages/averray-mcp/src/decision-records.ts
@@ -1,3 +1,10 @@
+import { createHash } from "node:crypto";
+
+import {
+  hermesDecisionRecordV2Schema,
+  type HermesDecisionRecordV2,
+} from "@avg/schemas";
+
 export type HermesDecisionKind =
   | "routing"
   | "auto_approval"
@@ -67,6 +74,13 @@ export interface ExtendHermesDecisionRecordInput {
   safety?: HermesDecisionSafety;
 }
 
+export type BuildHermesDecisionRecordV2Input = Omit<
+  HermesDecisionRecordV2,
+  "schemaVersion" | "kind" | "decisionId" | "generatedAt"
+> & {
+  generatedAt: Date | string;
+};
+
 const SECRET_KEY_PATTERN = /(token|secret|private.?key|password|credential|mnemonic|authorization|cookie|webhook|api.?key|bearer)/i;
 const BEARER_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/=-]+/gi;
 const PRIVATE_KEY_PATTERN = /\b(?:private[_ -]?key|secret|token|password)\s*[:=]\s*([^\s,;]+)/gi;
@@ -88,6 +102,41 @@ export function createHermesDecisionRecord(input: CreateHermesDecisionRecordInpu
     safety: sanitizeSafety(input.safety),
     generatedAt,
   };
+}
+
+export function buildHermesDecisionRecordV2(
+  input: BuildHermesDecisionRecordV2Input,
+): HermesDecisionRecordV2 {
+  const generatedAt = normalizeGeneratedAt(input.generatedAt);
+  const correlationId = sanitizeText(input.correlationId);
+  const workItemId = input.workItemId === undefined
+    ? undefined
+    : sanitizeText(input.workItemId);
+  const sanitized = sanitizeDecisionValue({
+    correlationId,
+    ...(workItemId !== undefined ? { workItemId } : {}),
+    decisionType: input.decisionType,
+    proposal: input.proposal,
+    inputs: input.inputs,
+    ...(input.routing !== undefined ? { routing: input.routing } : {}),
+    risk: input.risk,
+    approval: input.approval,
+    effects: input.effects,
+    next: input.next,
+    generatedAt,
+  }) as Record<string, unknown>;
+  const decisionId = v2DecisionRecordId(
+    input.decisionType,
+    correlationId,
+    workItemId,
+    generatedAt,
+  );
+  return hermesDecisionRecordV2Schema.parse({
+    schemaVersion: 2,
+    kind: "hermes_decision",
+    decisionId,
+    ...sanitized,
+  });
 }
 
 export function extendHermesDecisionRecord(
@@ -206,6 +255,18 @@ function decisionRecordId(kind: HermesDecisionKind, subject: HermesDecisionSubje
     .replace(/^-|-$/g, "")
     .slice(0, 120);
   return `hdr-${slug || "decision"}`;
+}
+
+function v2DecisionRecordId(
+  decisionType: string,
+  correlationId: string,
+  workItemId: string | undefined,
+  generatedAt: string,
+): string {
+  const digest = createHash("sha256")
+    .update(`${decisionType}\0${correlationId}\0${workItemId ?? ""}\0${generatedAt}`, "utf8")
+    .digest("hex");
+  return `hdr-v2-${digest}`;
 }
 
 function isDecisionKind(value: unknown): value is HermesDecisionKind {

--- a/packages/averray-mcp/src/dispatch-claim.ts
+++ b/packages/averray-mcp/src/dispatch-claim.ts
@@ -1,0 +1,258 @@
+import { createHash } from "node:crypto";
+
+import { query as defaultQuery } from "@avg/mcp-common";
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const CLAIM_COLUMNS = `
+  work_item_id,
+  task_version,
+  approved_task_hash,
+  intended_run_id,
+  claim_state,
+  claimed_at,
+  lease_expires_at
+`;
+
+export type DispatchClaimErrorReason = "claim_conflict" | "binding_conflict";
+
+export class DispatchClaimError extends Error {
+  constructor(
+    readonly reason: DispatchClaimErrorReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = "DispatchClaimError";
+  }
+}
+
+export type DispatchStoreQuery = <T = Record<string, unknown>>(
+  text: string,
+  values?: unknown[],
+) => Promise<T[]>;
+
+export interface DispatchStoreDeps {
+  query?: DispatchStoreQuery;
+}
+
+export interface DispatchClaim {
+  workItemId: string;
+  taskVersion: number;
+  approvedTaskHash: string;
+  intendedRunId: string;
+  claimState: string;
+  claimedAt: string;
+  leaseExpiresAt?: string;
+}
+
+export interface ClaimDispatchInput {
+  workItemId: string;
+  taskVersion: number;
+  approvedTaskHash: string;
+  intendedRunId: string;
+}
+
+interface DispatchClaimRow {
+  work_item_id: string;
+  task_version: number;
+  approved_task_hash: string;
+  intended_run_id: string;
+  claim_state: string;
+  claimed_at: string | Date;
+  lease_expires_at: string | Date | null;
+}
+
+interface LeaseHolderRow {
+  holder: string;
+}
+
+export function deriveIntendedRunId(
+  workItemId: string,
+  taskVersion: number,
+  approvedTaskHash: string,
+): string {
+  const digest = createHash("sha256")
+    .update(`${workItemId}\0${taskVersion}\0${approvedTaskHash}`, "utf8")
+    .digest();
+  const bytes = Buffer.from(digest.subarray(0, 16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+export async function acquireDispatchLease(
+  input: { holder: string; ttlSeconds: number },
+  deps: DispatchStoreDeps = {},
+): Promise<boolean> {
+  const holder = normalizedHolder(input.holder);
+  const ttlSeconds = normalizedTtl(input.ttlSeconds);
+  const rows = await storeQuery(deps)<LeaseHolderRow>(
+    `insert into dispatch_lease (lease_id, holder, acquired_at, expires_at)
+     values ('global', $1, now(), now() + ($2 * interval '1 second'))
+     on conflict (lease_id) do update set
+       holder = excluded.holder,
+       acquired_at = excluded.acquired_at,
+       expires_at = excluded.expires_at
+     where dispatch_lease.expires_at < now()
+     returning holder`,
+    [holder, ttlSeconds],
+  );
+  return rows.length === 1 && rows[0]?.holder === holder;
+}
+
+export async function renewDispatchLease(
+  input: { holder: string; ttlSeconds: number },
+  deps: DispatchStoreDeps = {},
+): Promise<boolean> {
+  const holder = normalizedHolder(input.holder);
+  const ttlSeconds = normalizedTtl(input.ttlSeconds);
+  const rows = await storeQuery(deps)<LeaseHolderRow>(
+    `update dispatch_lease
+     set expires_at = now() + ($2 * interval '1 second')
+     where lease_id = 'global'
+       and holder = $1
+       and expires_at >= now()
+     returning holder`,
+    [holder, ttlSeconds],
+  );
+  return rows.length === 1 && rows[0]?.holder === holder;
+}
+
+export async function releaseDispatchLease(
+  holderInput: string,
+  deps: DispatchStoreDeps = {},
+): Promise<boolean> {
+  const holder = normalizedHolder(holderInput);
+  const rows = await storeQuery(deps)<LeaseHolderRow>(
+    `delete from dispatch_lease
+     where lease_id = 'global' and holder = $1
+     returning holder`,
+    [holder],
+  );
+  return rows.length === 1 && rows[0]?.holder === holder;
+}
+
+export async function claimDispatch(
+  input: ClaimDispatchInput,
+  deps: DispatchStoreDeps = {},
+): Promise<{ claim: DispatchClaim; created: boolean }> {
+  assertClaimInput(input);
+  const inserted = await storeQuery(deps)<DispatchClaimRow>(
+    `insert into agent_task_dispatch_claims (
+       work_item_id,
+       task_version,
+       approved_task_hash,
+       intended_run_id,
+       claim_state,
+       claimed_at,
+       lease_expires_at
+     ) values ($1, $2, $3, $4::uuid, 'claimed', now(), null)
+     on conflict (work_item_id, task_version) do nothing
+     returning ${CLAIM_COLUMNS}`,
+    [
+      input.workItemId,
+      input.taskVersion,
+      input.approvedTaskHash,
+      input.intendedRunId,
+    ],
+  );
+  if (inserted.length > 1) {
+    throw new Error(`Dispatch claim insert returned ${inserted.length} rows`);
+  }
+
+  const claim = await getDispatchClaim(input.workItemId, input.taskVersion, deps);
+  if (!claim) {
+    throw new Error(`Dispatch claim disappeared for ${input.workItemId}@${input.taskVersion}`);
+  }
+  if (
+    claim.approvedTaskHash !== input.approvedTaskHash
+    || claim.intendedRunId !== input.intendedRunId
+  ) {
+    throw new DispatchClaimError(
+      "claim_conflict",
+      `Dispatch claim conflicts with the immutable binding for ${input.workItemId}@${input.taskVersion}`,
+    );
+  }
+  return { claim, created: inserted.length === 1 };
+}
+
+export async function getDispatchClaim(
+  workItemId: string,
+  taskVersion: number,
+  deps: DispatchStoreDeps = {},
+): Promise<DispatchClaim | undefined> {
+  const rows = await storeQuery(deps)<DispatchClaimRow>(
+    `select ${CLAIM_COLUMNS}
+     from agent_task_dispatch_claims
+     where work_item_id = $1 and task_version = $2
+     limit 1`,
+    [workItemId, taskVersion],
+  );
+  if (rows.length === 0) return undefined;
+  if (rows.length !== 1) {
+    throw new Error(`Dispatch claim read returned ${rows.length} rows`);
+  }
+  return parseDispatchClaimRow(rows[0]!);
+}
+
+function assertClaimInput(input: ClaimDispatchInput): void {
+  if (!input.workItemId.trim()) {
+    throw new Error("Dispatch claim work item id must not be empty");
+  }
+  if (!Number.isSafeInteger(input.taskVersion) || input.taskVersion < 1) {
+    throw new Error("Dispatch claim task version must be a positive safe integer");
+  }
+  if (!input.approvedTaskHash.trim()) {
+    throw new Error("Dispatch claim approved task hash must not be empty");
+  }
+  if (!CANONICAL_UUID.test(input.intendedRunId)) {
+    throw new Error("Dispatch claim intended run id must be a lowercase canonical UUID");
+  }
+}
+
+function parseDispatchClaimRow(row: DispatchClaimRow): DispatchClaim {
+  if (!CANONICAL_UUID.test(row.intended_run_id)) {
+    throw new Error("Stored dispatch claim has a non-canonical intended run id");
+  }
+  if (!Number.isSafeInteger(row.task_version) || row.task_version < 1) {
+    throw new Error("Stored dispatch claim has an invalid task version");
+  }
+  return {
+    workItemId: row.work_item_id,
+    taskVersion: row.task_version,
+    approvedTaskHash: row.approved_task_hash,
+    intendedRunId: row.intended_run_id,
+    claimState: row.claim_state,
+    claimedAt: timestamp(row.claimed_at),
+    ...(row.lease_expires_at
+      ? { leaseExpiresAt: timestamp(row.lease_expires_at) }
+      : {}),
+  };
+}
+
+function normalizedHolder(holder: string): string {
+  const normalized = holder.trim();
+  if (!normalized) throw new Error("Dispatch lease holder must not be empty");
+  return normalized;
+}
+
+function normalizedTtl(ttlSeconds: number): number {
+  if (!Number.isSafeInteger(ttlSeconds) || ttlSeconds < 1) {
+    throw new Error("Dispatch lease TTL must be a positive safe integer");
+  }
+  return ttlSeconds;
+}
+
+function timestamp(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function storeQuery(deps: DispatchStoreDeps): DispatchStoreQuery {
+  return deps.query ?? defaultQuery;
+}

--- a/packages/averray-mcp/src/run-binding-outbox.ts
+++ b/packages/averray-mcp/src/run-binding-outbox.ts
@@ -1,0 +1,209 @@
+import { query as defaultQuery } from "@avg/mcp-common";
+import {
+  artifactRefSchema,
+  sha256Schema,
+  type ArtifactRef,
+} from "@avg/schemas";
+
+import {
+  DispatchClaimError,
+  type DispatchStoreDeps,
+  type DispatchStoreQuery,
+} from "./dispatch-claim.js";
+
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const BINDING_COLUMNS = `
+  work_item_id,
+  harness_run_id,
+  run_manifest_ref,
+  run_manifest_hash,
+  bound_at
+`;
+
+export interface RunBinding {
+  workItemId: string;
+  harnessRunId: string;
+  runManifestRef?: ArtifactRef;
+  runManifestHash?: string;
+  boundAt: string;
+}
+
+export interface BindRunInput {
+  workItemId: string;
+  harnessRunId: string;
+  runManifestRef?: ArtifactRef;
+  runManifestHash?: string;
+}
+
+interface RunBindingRow {
+  work_item_id: string;
+  harness_run_id: string;
+  run_manifest_ref: unknown | null;
+  run_manifest_hash: string | null;
+  bound_at: string | Date;
+}
+
+export async function bindRunToWorkItem(
+  input: BindRunInput,
+  deps: DispatchStoreDeps = {},
+): Promise<{ binding: RunBinding; created: boolean }> {
+  const normalized = parseBindingInput(input);
+  const inserted = await storeQuery(deps)<RunBindingRow>(
+    `insert into agent_task_run_outbox (
+       work_item_id,
+       harness_run_id,
+       run_manifest_ref,
+       run_manifest_hash,
+       bound_at
+     ) values ($1, $2::uuid, $3::jsonb, $4, now())
+     on conflict (work_item_id) do nothing
+     returning ${BINDING_COLUMNS}`,
+    bindingValues(normalized),
+  );
+  if (inserted.length > 1) {
+    throw new Error(`Run binding insert returned ${inserted.length} rows`);
+  }
+  if (inserted[0]) {
+    return { binding: parseRunBindingRow(inserted[0]), created: true };
+  }
+
+  const updated = await storeQuery(deps)<RunBindingRow>(
+    `update agent_task_run_outbox
+     set run_manifest_ref = coalesce(run_manifest_ref, $3::jsonb),
+         run_manifest_hash = coalesce(run_manifest_hash, $4)
+     where work_item_id = $1
+       and harness_run_id = $2::uuid
+       and ($3::jsonb is null or run_manifest_ref is null or run_manifest_ref = $3::jsonb)
+       and ($4::text is null or run_manifest_hash is null or run_manifest_hash = $4)
+       and (
+         coalesce(run_manifest_hash, $4::text) is null
+         or coalesce(run_manifest_ref, $3::jsonb) is null
+         or coalesce(run_manifest_ref, $3::jsonb)->>'sha256'
+           = coalesce(run_manifest_hash, $4::text)
+       )
+     returning ${BINDING_COLUMNS}`,
+    bindingValues(normalized),
+  );
+  if (updated.length === 1) {
+    return { binding: parseRunBindingRow(updated[0]!), created: false };
+  }
+  if (updated.length > 1) {
+    throw new Error(`Run binding update returned ${updated.length} rows`);
+  }
+
+  const existing = await getRunBinding(input.workItemId, deps);
+  if (existing) {
+    throw new DispatchClaimError(
+      "binding_conflict",
+      `Run binding conflicts with the immutable binding for ${input.workItemId}`,
+    );
+  }
+  throw new Error(`Run binding disappeared for ${input.workItemId}`);
+}
+
+export async function getRunBinding(
+  workItemId: string,
+  deps: DispatchStoreDeps = {},
+): Promise<RunBinding | undefined> {
+  const rows = await storeQuery(deps)<RunBindingRow>(
+    `select ${BINDING_COLUMNS}
+     from agent_task_run_outbox
+     where work_item_id = $1
+     limit 1`,
+    [workItemId],
+  );
+  if (rows.length === 0) return undefined;
+  if (rows.length !== 1) {
+    throw new Error(`Run binding read returned ${rows.length} rows`);
+  }
+  return parseRunBindingRow(rows[0]!);
+}
+
+function parseBindingInput(input: BindRunInput): BindRunInput {
+  if (!input.workItemId.trim()) {
+    throw new DispatchClaimError(
+      "binding_conflict",
+      "Run binding work item id must not be empty",
+    );
+  }
+  if (!CANONICAL_UUID.test(input.harnessRunId)) {
+    throw new DispatchClaimError(
+      "binding_conflict",
+      "Run binding Harness run id must be a lowercase canonical UUID",
+    );
+  }
+  const runManifestRef = input.runManifestRef
+    ? artifactRefSchema.parse(input.runManifestRef)
+    : undefined;
+  const runManifestHash = input.runManifestHash
+    ? sha256Schema.parse(input.runManifestHash)
+    : undefined;
+  if (
+    runManifestRef
+    && runManifestHash
+    && runManifestRef.sha256 !== runManifestHash
+  ) {
+    throw new DispatchClaimError(
+      "binding_conflict",
+      "Run manifest reference and hash disagree",
+    );
+  }
+  return {
+    workItemId: input.workItemId,
+    harnessRunId: input.harnessRunId,
+    ...(runManifestRef ? { runManifestRef } : {}),
+    ...(runManifestHash ? { runManifestHash } : {}),
+  };
+}
+
+function bindingValues(input: BindRunInput): unknown[] {
+  return [
+    input.workItemId,
+    input.harnessRunId,
+    input.runManifestRef ? JSON.stringify(input.runManifestRef) : null,
+    input.runManifestHash ?? null,
+  ];
+}
+
+function parseRunBindingRow(row: RunBindingRow): RunBinding {
+  if (!CANONICAL_UUID.test(row.harness_run_id)) {
+    throw new DispatchClaimError(
+      "binding_conflict",
+      "Stored run binding has a non-canonical Harness run id",
+    );
+  }
+  const rawRef = typeof row.run_manifest_ref === "string"
+    ? JSON.parse(row.run_manifest_ref) as unknown
+    : row.run_manifest_ref;
+  const runManifestRef = rawRef === null
+    ? undefined
+    : artifactRefSchema.parse(rawRef);
+  const runManifestHash = row.run_manifest_hash === null
+    ? undefined
+    : sha256Schema.parse(row.run_manifest_hash);
+  if (
+    runManifestRef
+    && runManifestHash
+    && runManifestRef.sha256 !== runManifestHash
+  ) {
+    throw new DispatchClaimError(
+      "binding_conflict",
+      "Stored run manifest reference and hash disagree",
+    );
+  }
+  return {
+    workItemId: row.work_item_id,
+    harnessRunId: row.harness_run_id,
+    ...(runManifestRef ? { runManifestRef } : {}),
+    ...(runManifestHash ? { runManifestHash } : {}),
+    boundAt: timestamp(row.bound_at),
+  };
+}
+
+function timestamp(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+function storeQuery(deps: DispatchStoreDeps): DispatchStoreQuery {
+  return deps.query ?? defaultQuery;
+}

--- a/test/unit/decision-record-v2.test.ts
+++ b/test/unit/decision-record-v2.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  listHermesDecisions,
+  recordHermesDecision,
+  type HermesDecisionStoreQuery,
+} from "../../packages/averray-mcp/src/decision-record-store.js";
+import {
+  buildHermesDecisionRecordV2,
+  createHermesDecisionRecord,
+  type BuildHermesDecisionRecordV2Input,
+} from "../../packages/averray-mcp/src/decision-records.js";
+import {
+  hermesDecisionRecordV2Schema,
+  type HermesDecisionRecordV2,
+} from "../../packages/schemas/src/index.js";
+
+const HASH = `sha256:${"a".repeat(64)}`;
+
+describe("INT-2e HermesDecisionRecord V2 audit layer", () => {
+  it("builds, validates, stores, and lists a deterministic V2 record", async () => {
+    const db = new MemoryDecisionDatabase();
+    const input = decisionInput();
+    const first = buildHermesDecisionRecordV2(input);
+    const second = buildHermesDecisionRecordV2(input);
+
+    expect(second.decisionId).toBe(first.decisionId);
+    expect(hermesDecisionRecordV2Schema.parse(first)).toEqual(first);
+    await expect(recordHermesDecision(first, { query: db.query }))
+      .resolves.toEqual(first);
+    await expect(
+      listHermesDecisions(
+        { correlationId: first.correlationId, workItemId: first.workItemId },
+        { query: db.query },
+      ),
+    ).resolves.toEqual([first]);
+  });
+
+  it("redacts secret-looking free text and input references before validation", () => {
+    const input = decisionInput({
+      proposal: {
+        what: "Refuse Bearer abc.def.ghi before dispatch.",
+        why: ["password=supersecret must never reach the audit record."],
+        whyNow: "An sk-abcdefghijklmnop credential appeared.",
+        evidenceRefs: [],
+      },
+      inputs: [{
+        name: "task-input",
+        ref: {
+          uri: "artifact://input/password=hidden-value",
+          sha256: HASH,
+        },
+        hash: HASH,
+        observedAt: "2026-07-24T12:00:00.000Z",
+      }],
+    });
+
+    const record = buildHermesDecisionRecordV2(input);
+    const serialized = JSON.stringify(record);
+    for (const secret of [
+      "abc.def.ghi",
+      "supersecret",
+      "abcdefghijklmnop",
+      "hidden-value",
+    ]) {
+      expect(serialized).not.toContain(secret);
+    }
+    expect(serialized).toContain("[redacted]");
+  });
+
+  it("inserts duplicate decision ids once and never updates the original row", async () => {
+    const db = new MemoryDecisionDatabase();
+    const original = buildHermesDecisionRecordV2(decisionInput());
+    const conflictingReplay = hermesDecisionRecordV2Schema.parse({
+      ...original,
+      proposal: {
+        ...original.proposal,
+        what: "A changed replay must not update the append-only row.",
+      },
+    });
+
+    await recordHermesDecision(original, { query: db.query });
+    await recordHermesDecision(original, { query: db.query });
+    await recordHermesDecision(conflictingReplay, { query: db.query });
+
+    expect(db.size).toBe(1);
+    await expect(listHermesDecisions({}, { query: db.query }))
+      .resolves.toEqual([original]);
+  });
+
+  it("leaves the V1 builder behavior intact", () => {
+    const record = createHermesDecisionRecord({
+      kind: "routing",
+      subject: { type: "task", id: "task-one" },
+      decision: "route to the approved executor",
+      reasons: ["The scorecard selected it."],
+      inputs: { privateKey: "must-redact" },
+      outcome: { summary: "Routing recorded." },
+      safety: { readOnly: true, mutates: false },
+      generatedAt: "2026-07-24T12:00:00.000Z",
+    });
+
+    expect(record).toMatchObject({
+      schemaVersion: 1,
+      recordType: "hermes_decision_record",
+      kind: "routing",
+    });
+    expect(record.inputs.privateKey).toBe("[redacted]");
+  });
+});
+
+interface MemoryDecisionRow {
+  decision_id: string;
+  correlation_id: string;
+  work_item_id: string | null;
+  decision_type: string;
+  generated_at: string;
+  record: HermesDecisionRecordV2;
+}
+
+class MemoryDecisionDatabase {
+  private readonly rows = new Map<string, MemoryDecisionRow>();
+
+  get size(): number {
+    return this.rows.size;
+  }
+
+  readonly query: HermesDecisionStoreQuery = async <T>(
+    text: string,
+    values: unknown[] = [],
+  ): Promise<T[]> => {
+    if (/insert into hermes_decision_records/i.test(text)) {
+      const decisionId = String(values[0]);
+      if (this.rows.has(decisionId)) return [];
+      const row: MemoryDecisionRow = {
+        decision_id: decisionId,
+        correlation_id: String(values[1]),
+        work_item_id: values[2] === null ? null : String(values[2]),
+        decision_type: String(values[3]),
+        generated_at: String(values[4]),
+        record: JSON.parse(String(values[5])) as HermesDecisionRecordV2,
+      };
+      this.rows.set(decisionId, row);
+      return [structuredClone(row) as T];
+    }
+    if (/from hermes_decision_records/i.test(text)) {
+      let rows = [...this.rows.values()];
+      const correlationMatch = /correlation_id = \$(\d+)/i.exec(text);
+      if (correlationMatch) {
+        rows = rows.filter((row) =>
+          row.correlation_id === values[Number(correlationMatch[1]) - 1]);
+      }
+      const workItemMatch = /work_item_id = \$(\d+)/i.exec(text);
+      if (workItemMatch) {
+        rows = rows.filter((row) =>
+          row.work_item_id === values[Number(workItemMatch[1]) - 1]);
+      }
+      rows.sort((left, right) =>
+        Date.parse(right.generated_at) - Date.parse(left.generated_at));
+      const limitMatch = /limit \$(\d+)/i.exec(text);
+      const limit = limitMatch
+        ? Number(values[Number(limitMatch[1]) - 1])
+        : rows.length;
+      return rows.slice(0, limit).map((row) => structuredClone(row) as T);
+    }
+    throw new Error(`Unexpected decision-record test query: ${text}`);
+  };
+}
+
+function decisionInput(
+  overrides: Partial<BuildHermesDecisionRecordV2Input> = {},
+): BuildHermesDecisionRecordV2Input {
+  return {
+    correlationId: "correlation-one",
+    workItemId: "work-one",
+    decisionType: "dispatch_refusal",
+    proposal: {
+      what: "Refuse dispatch until the invariant is restored.",
+      why: ["The immutable claim did not match."],
+      whyNow: "The mismatch was observed before submission.",
+      evidenceRefs: [],
+    },
+    inputs: [{
+      name: "approved-task",
+      hash: HASH,
+      observedAt: "2026-07-24T12:00:00.000Z",
+    }],
+    routing: {
+      executor: "harness",
+      reason: "The approved task selected the isolated Harness executor.",
+    },
+    risk: {
+      tier: "medium",
+      reasons: ["A conflicting dispatch identity must fail closed."],
+      irreversible: false,
+    },
+    approval: {
+      required: "operator",
+      decision: "approved",
+      actor: { type: "operator", id: "operator-one" },
+      policyVersion: "policy-v1",
+      policyHash: HASH,
+      decidedAt: "2026-07-24T11:59:00.000Z",
+    },
+    effects: {
+      mutates: false,
+      mutations: [],
+      authorityChanged: false,
+      budgetChanged: false,
+    },
+    next: {
+      action: "Operator resolves the conflicting immutable claim.",
+      owner: "operator",
+    },
+    generatedAt: "2026-07-24T12:00:00.000Z",
+    ...overrides,
+  };
+}

--- a/test/unit/dispatch-claim.test.ts
+++ b/test/unit/dispatch-claim.test.ts
@@ -1,0 +1,242 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  acquireDispatchLease,
+  claimDispatch,
+  deriveIntendedRunId,
+  DispatchClaimError,
+  getDispatchClaim,
+  releaseDispatchLease,
+  renewDispatchLease,
+  type DispatchStoreQuery,
+} from "../../packages/averray-mcp/src/dispatch-claim.js";
+
+const HASH = `sha256:${"a".repeat(64)}`;
+const OTHER_HASH = `sha256:${"b".repeat(64)}`;
+const CANONICAL_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+describe("INT-2e deterministic dispatch claims", () => {
+  it("derives a stable canonical UUID that changes with every identity input", () => {
+    const base = deriveIntendedRunId("work-one", 1, HASH);
+
+    expect(deriveIntendedRunId("work-one", 1, HASH)).toBe(base);
+    expect(base).toMatch(CANONICAL_UUID);
+    expect(base[14]).toBe("5");
+    expect(["8", "9", "a", "b"]).toContain(base[19]);
+    expect(deriveIntendedRunId("work-two", 1, HASH)).not.toBe(base);
+    expect(deriveIntendedRunId("work-one", 2, HASH)).not.toBe(base);
+    expect(deriveIntendedRunId("work-one", 1, OTHER_HASH)).not.toBe(base);
+  });
+
+  it("acquires, expires, renews, and releases the global lease without stealing", async () => {
+    const db = new MemoryDispatchDatabase();
+
+    await expect(
+      acquireDispatchLease({ holder: "dispatcher-a", ttlSeconds: 30 }, { query: db.query }),
+    ).resolves.toBe(true);
+    await expect(
+      acquireDispatchLease({ holder: "dispatcher-b", ttlSeconds: 30 }, { query: db.query }),
+    ).resolves.toBe(false);
+    await expect(
+      renewDispatchLease({ holder: "dispatcher-b", ttlSeconds: 30 }, { query: db.query }),
+    ).resolves.toBe(false);
+    await expect(releaseDispatchLease("dispatcher-b", { query: db.query }))
+      .resolves.toBe(false);
+    await expect(
+      renewDispatchLease({ holder: "dispatcher-a", ttlSeconds: 60 }, { query: db.query }),
+    ).resolves.toBe(true);
+
+    db.advanceSeconds(61);
+    await expect(
+      renewDispatchLease({ holder: "dispatcher-a", ttlSeconds: 30 }, { query: db.query }),
+    ).resolves.toBe(false);
+    await expect(
+      acquireDispatchLease({ holder: "dispatcher-b", ttlSeconds: 30 }, { query: db.query }),
+    ).resolves.toBe(true);
+    await expect(releaseDispatchLease("dispatcher-a", { query: db.query }))
+      .resolves.toBe(false);
+    await expect(releaseDispatchLease("dispatcher-b", { query: db.query }))
+      .resolves.toBe(true);
+  });
+
+  it("creates one immutable claim and treats an identical replay as a no-op", async () => {
+    const db = new MemoryDispatchDatabase();
+    const input = {
+      workItemId: "work-one",
+      taskVersion: 1,
+      approvedTaskHash: HASH,
+      intendedRunId: deriveIntendedRunId("work-one", 1, HASH),
+    };
+
+    await expect(claimDispatch(input, { query: db.query })).resolves.toMatchObject({
+      created: true,
+      claim: {
+        workItemId: "work-one",
+        taskVersion: 1,
+        approvedTaskHash: HASH,
+        intendedRunId: input.intendedRunId,
+        claimState: "claimed",
+      },
+    });
+    await expect(claimDispatch(input, { query: db.query })).resolves.toMatchObject({
+      created: false,
+      claim: { intendedRunId: input.intendedRunId },
+    });
+    await expect(getDispatchClaim("work-one", 1, { query: db.query }))
+      .resolves.toMatchObject({ intendedRunId: input.intendedRunId });
+    expect(db.claimCount).toBe(1);
+  });
+
+  it("refuses conflicting approval hashes and intended run ids", async () => {
+    const db = new MemoryDispatchDatabase();
+    const intendedRunId = deriveIntendedRunId("work-one", 1, HASH);
+    const input = {
+      workItemId: "work-one",
+      taskVersion: 1,
+      approvedTaskHash: HASH,
+      intendedRunId,
+    };
+    await claimDispatch(input, { query: db.query });
+
+    await expect(
+      claimDispatch({ ...input, approvedTaskHash: OTHER_HASH }, { query: db.query }),
+    ).rejects.toMatchObject({
+      reason: "claim_conflict",
+    });
+    await expect(
+      claimDispatch({
+        ...input,
+        intendedRunId: deriveIntendedRunId("work-one", 2, HASH),
+      }, { query: db.query }),
+    ).rejects.toBeInstanceOf(DispatchClaimError);
+    await expect(
+      claimDispatch({
+        ...input,
+        intendedRunId: deriveIntendedRunId("work-one", 2, HASH),
+      }, { query: db.query }),
+    ).rejects.toMatchObject({
+      reason: "claim_conflict",
+    });
+    expect(db.claimCount).toBe(1);
+  });
+
+  it("pins the additive migration and migration runner ordering", () => {
+    const migration = readFileSync(
+      new URL(
+        "../../ops/migrations/003_dispatch_claims_outbox_decisions.sql",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const runner = readFileSync(
+      new URL("../../ops/migrate.sh", import.meta.url),
+      "utf8",
+    );
+
+    for (const table of [
+      "dispatch_lease",
+      "agent_task_dispatch_claims",
+      "agent_task_run_outbox",
+      "hermes_decision_records",
+    ]) {
+      expect(migration).toMatch(new RegExp(`create table if not exists ${table}`, "i"));
+    }
+    expect(migration).toMatch(/primary key\s*\(work_item_id,\s*task_version\)/i);
+    expect(migration).toMatch(/hermes_decision_records_correlation_id_idx/i);
+    expect(migration).toMatch(/hermes_decision_records_work_item_id_idx/i);
+    expect(runner.indexOf("002_agent_tasks.sql"))
+      .toBeLessThan(runner.indexOf("003_dispatch_claims_outbox_decisions.sql"));
+  });
+});
+
+interface MemoryLease {
+  holder: string;
+  acquiredAt: number;
+  expiresAt: number;
+}
+
+interface MemoryClaimRow {
+  work_item_id: string;
+  task_version: number;
+  approved_task_hash: string;
+  intended_run_id: string;
+  claim_state: string;
+  claimed_at: string;
+  lease_expires_at: string | null;
+}
+
+class MemoryDispatchDatabase {
+  private now = Date.parse("2026-07-24T12:00:00.000Z");
+  private lease: MemoryLease | undefined;
+  private readonly claims = new Map<string, MemoryClaimRow>();
+
+  get claimCount(): number {
+    return this.claims.size;
+  }
+
+  advanceSeconds(seconds: number): void {
+    this.now += seconds * 1_000;
+  }
+
+  readonly query: DispatchStoreQuery = async <T>(
+    text: string,
+    values: unknown[] = [],
+  ): Promise<T[]> => {
+    if (/insert into dispatch_lease/i.test(text)) {
+      const holder = String(values[0]);
+      const ttlSeconds = Number(values[1]);
+      if (this.lease && this.lease.expiresAt >= this.now) return [];
+      this.lease = {
+        holder,
+        acquiredAt: this.now,
+        expiresAt: this.now + ttlSeconds * 1_000,
+      };
+      return [{ holder } as T];
+    }
+    if (/update dispatch_lease/i.test(text)) {
+      const holder = String(values[0]);
+      const ttlSeconds = Number(values[1]);
+      if (
+        !this.lease
+        || this.lease.holder !== holder
+        || this.lease.expiresAt < this.now
+      ) {
+        return [];
+      }
+      this.lease.expiresAt = this.now + ttlSeconds * 1_000;
+      return [{ holder } as T];
+    }
+    if (/delete from dispatch_lease/i.test(text)) {
+      const holder = String(values[0]);
+      if (!this.lease || this.lease.holder !== holder) return [];
+      this.lease = undefined;
+      return [{ holder } as T];
+    }
+    if (/insert into agent_task_dispatch_claims/i.test(text)) {
+      const row: MemoryClaimRow = {
+        work_item_id: String(values[0]),
+        task_version: Number(values[1]),
+        approved_task_hash: String(values[2]),
+        intended_run_id: String(values[3]),
+        claim_state: "claimed",
+        claimed_at: new Date(this.now).toISOString(),
+        lease_expires_at: null,
+      };
+      const rowKey = claimKey(row.work_item_id, row.task_version);
+      if (this.claims.has(rowKey)) return [];
+      this.claims.set(rowKey, row);
+      return [structuredClone(row) as T];
+    }
+    if (/from agent_task_dispatch_claims/i.test(text)) {
+      const row = this.claims.get(claimKey(String(values[0]), Number(values[1])));
+      return row ? [structuredClone(row) as T] : [];
+    }
+    throw new Error(`Unexpected dispatch test query: ${text}`);
+  };
+}
+
+function claimKey(workItemId: string, taskVersion: number): string {
+  return `${workItemId}:${taskVersion}`;
+}

--- a/test/unit/run-binding-outbox.test.ts
+++ b/test/unit/run-binding-outbox.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import { DispatchClaimError } from "../../packages/averray-mcp/src/dispatch-claim.js";
+import {
+  bindRunToWorkItem,
+  getRunBinding,
+} from "../../packages/averray-mcp/src/run-binding-outbox.js";
+import type { DispatchStoreQuery } from "../../packages/averray-mcp/src/dispatch-claim.js";
+
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222";
+const MANIFEST_HASH = `sha256:${"a".repeat(64)}`;
+const OTHER_MANIFEST_HASH = `sha256:${"b".repeat(64)}`;
+const MANIFEST_REF = {
+  uri: `artifact://sha256/${"a".repeat(64)}`,
+  sha256: MANIFEST_HASH,
+};
+
+describe("INT-2e run-binding outbox", () => {
+  it("creates one binding and treats an identical rebind as an idempotent replay", async () => {
+    const db = new MemoryRunBindingDatabase();
+
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "work-one", harnessRunId: RUN_ID },
+        { query: db.query },
+      ),
+    ).resolves.toMatchObject({
+      created: true,
+      binding: { workItemId: "work-one", harnessRunId: RUN_ID },
+    });
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "work-one", harnessRunId: RUN_ID },
+        { query: db.query },
+      ),
+    ).resolves.toMatchObject({
+      created: false,
+      binding: { harnessRunId: RUN_ID },
+    });
+    await expect(getRunBinding("work-one", { query: db.query }))
+      .resolves.toMatchObject({ harnessRunId: RUN_ID });
+    expect(db.size).toBe(1);
+  });
+
+  it("fills the immutable manifest reference and hash after the initial bind", async () => {
+    const db = new MemoryRunBindingDatabase();
+    await bindRunToWorkItem(
+      { workItemId: "work-one", harnessRunId: RUN_ID },
+      { query: db.query },
+    );
+
+    await expect(
+      bindRunToWorkItem({
+        workItemId: "work-one",
+        harnessRunId: RUN_ID,
+        runManifestRef: MANIFEST_REF,
+        runManifestHash: MANIFEST_HASH,
+      }, { query: db.query }),
+    ).resolves.toMatchObject({
+      created: false,
+      binding: {
+        harnessRunId: RUN_ID,
+        runManifestRef: MANIFEST_REF,
+        runManifestHash: MANIFEST_HASH,
+      },
+    });
+    expect(db.size).toBe(1);
+  });
+
+  it("refuses a second Harness run id for the same work item", async () => {
+    const db = new MemoryRunBindingDatabase();
+    await bindRunToWorkItem(
+      { workItemId: "work-one", harnessRunId: RUN_ID },
+      { query: db.query },
+    );
+
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "work-one", harnessRunId: OTHER_RUN_ID },
+        { query: db.query },
+      ),
+    ).rejects.toBeInstanceOf(DispatchClaimError);
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "work-one", harnessRunId: OTHER_RUN_ID },
+        { query: db.query },
+      ),
+    ).rejects.toMatchObject({ reason: "binding_conflict" });
+    expect(db.size).toBe(1);
+  });
+
+  it("refuses manifest reference/hash disagreement and immutable manifest changes", async () => {
+    const db = new MemoryRunBindingDatabase();
+    await expect(
+      bindRunToWorkItem({
+        workItemId: "work-one",
+        harnessRunId: RUN_ID,
+        runManifestRef: MANIFEST_REF,
+        runManifestHash: OTHER_MANIFEST_HASH,
+      }, { query: db.query }),
+    ).rejects.toMatchObject({ reason: "binding_conflict" });
+
+    await bindRunToWorkItem({
+      workItemId: "work-one",
+      harnessRunId: RUN_ID,
+      runManifestRef: MANIFEST_REF,
+      runManifestHash: MANIFEST_HASH,
+    }, { query: db.query });
+    await expect(
+      bindRunToWorkItem({
+        workItemId: "work-one",
+        harnessRunId: RUN_ID,
+        runManifestHash: OTHER_MANIFEST_HASH,
+      }, { query: db.query }),
+    ).rejects.toMatchObject({ reason: "binding_conflict" });
+  });
+});
+
+interface MemoryRunBindingRow {
+  work_item_id: string;
+  harness_run_id: string;
+  run_manifest_ref: unknown | null;
+  run_manifest_hash: string | null;
+  bound_at: string;
+}
+
+class MemoryRunBindingDatabase {
+  private readonly rows = new Map<string, MemoryRunBindingRow>();
+
+  get size(): number {
+    return this.rows.size;
+  }
+
+  readonly query: DispatchStoreQuery = async <T>(
+    text: string,
+    values: unknown[] = [],
+  ): Promise<T[]> => {
+    if (/insert into agent_task_run_outbox/i.test(text)) {
+      const workItemId = String(values[0]);
+      if (this.rows.has(workItemId)) return [];
+      const row: MemoryRunBindingRow = {
+        work_item_id: workItemId,
+        harness_run_id: String(values[1]),
+        run_manifest_ref: parseJsonValue(values[2]),
+        run_manifest_hash: values[3] === null ? null : String(values[3]),
+        bound_at: "2026-07-24T12:00:00.000Z",
+      };
+      this.rows.set(workItemId, row);
+      return [structuredClone(row) as T];
+    }
+    if (/update agent_task_run_outbox/i.test(text)) {
+      const row = this.rows.get(String(values[0]));
+      if (!row || row.harness_run_id !== values[1]) return [];
+      const incomingRef = parseJsonValue(values[2]);
+      const incomingHash = values[3] === null ? null : String(values[3]);
+      if (
+        incomingRef !== null
+        && row.run_manifest_ref !== null
+        && JSON.stringify(incomingRef) !== JSON.stringify(row.run_manifest_ref)
+      ) {
+        return [];
+      }
+      if (
+        incomingHash !== null
+        && row.run_manifest_hash !== null
+        && incomingHash !== row.run_manifest_hash
+      ) {
+        return [];
+      }
+      const mergedRef = row.run_manifest_ref ?? incomingRef;
+      const mergedHash = row.run_manifest_hash ?? incomingHash;
+      if (
+        mergedRef !== null
+        && mergedHash !== null
+        && manifestSha(mergedRef) !== mergedHash
+      ) {
+        return [];
+      }
+      row.run_manifest_ref = mergedRef;
+      row.run_manifest_hash = mergedHash;
+      return [structuredClone(row) as T];
+    }
+    if (/from agent_task_run_outbox/i.test(text)) {
+      const row = this.rows.get(String(values[0]));
+      return row ? [structuredClone(row) as T] : [];
+    }
+    throw new Error(`Unexpected run-binding test query: ${text}`);
+  };
+}
+
+function parseJsonValue(value: unknown): unknown | null {
+  if (value === null) return null;
+  return typeof value === "string" ? JSON.parse(value) as unknown : value;
+}
+
+function manifestSha(value: unknown): unknown {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  return (value as Record<string, unknown>).sha256;
+}


### PR DESCRIPTION
## What changed

- add migration `003_dispatch_claims_outbox_decisions.sql` for the global dispatch lease, immutable dispatch claims, run-binding outbox, and append-only Hermes decision records, and append it to `ops/migrate.sh`
- add deterministic RFC-4122 v5-shaped intended run-id derivation plus atomic lease acquire/renew/release and conflict-safe dispatch claim persistence
- add immutable work-item → Harness-run outbox binding with idempotent replay and late manifest ref/hash completion
- add an additive, secret-sanitized `HermesDecisionRecordV2` builder with deterministic decision ids
- add an append-only V2 decision-record store and package subpath exports
- add in-memory query-stub coverage for lease expiry/contention, claim and binding conflicts, replay idempotency, late manifest binding, sanitization, append-only decisions, and unchanged V1 behavior

## Checks run

- `npm run typecheck` — exit 0
- `npm test` — 184 test files passed, 2,240 tests passed
- `docker build -f ops/Dockerfile.node -t averray-reference-agent:int2e-check .` — exit 0
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config --quiet` — exit 0
- `git diff origin/main...HEAD --check` — exit 0

## Affected surfaces

Additive database migration/migration runner, pure `@avg/averray-mcp` persistence and audit modules, the additive V2 decision builder, package exports, and unit tests. No schemas, AgentTask store, TaskIntent mapping/attenuation, Harness control port, Slack operator, board/projection, Compose service, Caddy, contracts, public site, environment values, or secrets changed. No new dependency was added.

## Authority and rollout

This PR contains no dispatcher loop, process or entry point, polling, Harness/control-port call, submit/cancel invocation, board write, or production dispatch path. Nothing runs on its own and production authority is unchanged. INT-2f is intentionally out of scope.

Rollout applies the additive migration through the existing migration runner. Rollback is to revert the pure code while leaving the unused coordination/audit tables in place; dropping append-only audit data is neither required nor recommended.