### PR TITLE
feat(harness): add single-attempt dispatch orchestration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5256,6 +5256,7 @@
       "name": "@avg/harness-dispatcher",
       "version": "0.1.0",
       "dependencies": {
+        "@avg/averray-mcp": "0.1.0",
         "@avg/schemas": "0.1.0"
       }
     },

--- a/services/harness-dispatcher/package.json
+++ b/services/harness-dispatcher/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc -b --pretty false"
   },
   "dependencies": {
+    "@avg/averray-mcp": "0.1.0",
     "@avg/schemas": "0.1.0"
   }
 }

--- a/services/harness-dispatcher/src/dispatch-attempt.ts
+++ b/services/harness-dispatcher/src/dispatch-attempt.ts
@@ -1,0 +1,409 @@
+import { existsSync } from "node:fs";
+
+import {
+  agentTaskApprovalHashMatches,
+  type AgentTaskV1,
+  type HermesDecisionRecordV2,
+  type PilotProfileManifest,
+} from "@avg/schemas";
+import {
+  assertTaskIntentWithinApprovedAuthority,
+  AttenuationError,
+} from "@avg/averray-mcp/attenuation";
+import {
+  deriveIntendedRunId,
+  DispatchClaimError,
+  type ClaimDispatchInput,
+} from "@avg/averray-mcp/dispatch-claim";
+import {
+  buildHermesDecisionRecordV2,
+} from "@avg/averray-mcp/decision-records";
+import {
+  type BindRunInput,
+  type RunBinding,
+} from "@avg/averray-mcp/run-binding-outbox";
+import {
+  buildTaskIntentArtifact,
+} from "@avg/averray-mcp/task-intent-mapping";
+
+import {
+  HarnessControlError,
+  type HarnessControlErrorCode,
+  type HarnessControlPort,
+} from "./harness-control-port.js";
+
+const DISPATCH_WORKSPACE_PATH = "/workspaces/task-checkout";
+
+const DEFINITELY_NO_RUN_CODES = new Set<HarnessControlErrorCode>([
+  "dispatch_disabled",
+  "invalid_run_id",
+  "invalid_intent_path",
+  "refused_command",
+]);
+
+export interface DispatchDeps {
+  now(): Date;
+  dispatcherId: string;
+  leaseTtlSeconds: number;
+  isDispatchEnabled(): boolean;
+  isHalted(): boolean;
+  listDispatchable(): Promise<AgentTaskV1[]>;
+  saveTask(task: AgentTaskV1): Promise<unknown>;
+  acquireLease(input: { holder: string; ttlSeconds: number }): Promise<boolean>;
+  renewLease(input: { holder: string; ttlSeconds: number }): Promise<boolean>;
+  releaseLease(holder: string): Promise<boolean>;
+  claimDispatch(input: ClaimDispatchInput): Promise<unknown>;
+  getRunBinding(workItemId: string): Promise<RunBinding | undefined>;
+  bindRun(input: BindRunInput): Promise<unknown>;
+  loadProfileManifest(profileId: string): Promise<PilotProfileManifest>;
+  writeIntentArtifact(bytes: string, workItemId: string): Promise<string>;
+  controlPort: HarnessControlPort;
+  recordDecision(record: HermesDecisionRecordV2): Promise<unknown>;
+  logger?: { warn(object: unknown, message: string): void };
+}
+
+export type DispatchAttemptResult =
+  | { outcome: "disabled" }
+  | { outcome: "halted" }
+  | { outcome: "lease_unavailable" }
+  | { outcome: "idle" }
+  | DispatchIdentity & { outcome: "already_bound" }
+  | {
+    outcome: "refused";
+    workItemId: string;
+    taskVersion: number;
+    intendedRunId?: string;
+    reason: string;
+  }
+  | DispatchIdentity & {
+    outcome: "submit_failed";
+    reason: "submit_refused" | "submit_ambiguous";
+    ambiguous: boolean;
+  }
+  | DispatchIdentity & { outcome: "dispatched" };
+
+interface DispatchIdentity {
+  workItemId: string;
+  taskVersion: number;
+  intendedRunId: string;
+}
+
+export function readHaltFile(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): boolean {
+  const haltFile = environment.HALT_FILE?.trim() || "/data/HALT";
+  return existsSync(haltFile);
+}
+
+export async function runSingleDispatch(
+  deps: DispatchDeps,
+): Promise<DispatchAttemptResult> {
+  if (!deps.isDispatchEnabled()) return { outcome: "disabled" };
+  if (deps.isHalted()) return { outcome: "halted" };
+
+  const leaseAcquired = await deps.acquireLease({
+    holder: deps.dispatcherId,
+    ttlSeconds: deps.leaseTtlSeconds,
+  });
+  if (!leaseAcquired) return { outcome: "lease_unavailable" };
+
+  try {
+    const task = (await deps.listDispatchable())[0];
+    if (!task) return { outcome: "idle" };
+
+    const refuseBeforeIdentity = async (
+      reason: string,
+    ): Promise<DispatchAttemptResult> => {
+      await blockAndRecordRefusal(deps, task, undefined, reason);
+      return {
+        outcome: "refused",
+        workItemId: task.workItemId,
+        taskVersion: task.taskVersion,
+        reason,
+      };
+    };
+
+    if (task.executor.kind !== "harness") {
+      return refuseBeforeIdentity("executor_not_harness");
+    }
+    if (task.lifecycle !== "approved") {
+      return refuseBeforeIdentity("not_approved");
+    }
+    if (!await agentTaskApprovalHashMatches(task)) {
+      return refuseBeforeIdentity("approval_hash_mismatch");
+    }
+    if (!(Date.parse(task.deadline) > deps.now().getTime())) {
+      return refuseBeforeIdentity("deadline_expired");
+    }
+
+    const approvedTaskHash = task.approval.approvedTaskHash!;
+    const intendedRunId = deriveIntendedRunId(
+      task.workItemId,
+      task.taskVersion,
+      approvedTaskHash,
+    );
+    const identity: DispatchIdentity = {
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      intendedRunId,
+    };
+
+    const existing = await deps.getRunBinding(task.workItemId);
+    if (existing) {
+      if (existing.harnessRunId !== intendedRunId) {
+        return refuse(deps, task, intendedRunId, "binding_conflict");
+      }
+      const updatedAt = deps.now().toISOString();
+      await deps.saveTask({
+        ...task,
+        lifecycle: "running",
+        timestamps: {
+          ...task.timestamps,
+          runBoundAt: existing.boundAt,
+          updatedAt,
+        },
+        bindings: {
+          ...task.bindings,
+          harnessRunId: intendedRunId,
+        },
+      });
+      return { outcome: "already_bound", ...identity };
+    }
+
+    try {
+      await deps.claimDispatch({
+        workItemId: task.workItemId,
+        taskVersion: task.taskVersion,
+        approvedTaskHash,
+        intendedRunId,
+      });
+    } catch (error) {
+      if (isDispatchClaimError(error, "claim_conflict")) {
+        return refuse(deps, task, intendedRunId, "claim_conflict");
+      }
+      throw error;
+    }
+
+    const artifact = await buildTaskIntentArtifact(task, {
+      workspacePath: DISPATCH_WORKSPACE_PATH,
+    });
+    if (artifact.templateHash !== task.intent.templateHash) {
+      return refuse(deps, task, intendedRunId, "template_hash_mismatch");
+    }
+
+    const profile = await deps.loadProfileManifest(task.intent.profile);
+    try {
+      await assertTaskIntentWithinApprovedAuthority(task, artifact.intent, profile);
+    } catch (error) {
+      if (error instanceof AttenuationError) {
+        return refuse(deps, task, intendedRunId, error.reason);
+      }
+      throw error;
+    }
+
+    const intentPath = await deps.writeIntentArtifact(
+      artifact.canonicalBytes,
+      task.workItemId,
+    );
+    if (deps.isHalted()) {
+      return refuse(deps, task, intendedRunId, "halted_before_submit");
+    }
+
+    const dispatchClaimedAt = deps.now().toISOString();
+    const dispatchingTask: AgentTaskV1 = {
+      ...task,
+      lifecycle: "dispatching",
+      timestamps: {
+        ...task.timestamps,
+        dispatchClaimedAt,
+        updatedAt: dispatchClaimedAt,
+      },
+    };
+    await deps.saveTask(dispatchingTask);
+
+    let boundRunId: string;
+    try {
+      boundRunId = await deps.controlPort.submit(intendedRunId, intentPath);
+    } catch (error) {
+      if (!(error instanceof HarnessControlError)) throw error;
+      const ambiguous = !DEFINITELY_NO_RUN_CODES.has(error.code);
+      const reason = ambiguous ? "submit_ambiguous" : "submit_refused";
+
+      // Ambiguous submission is reconciled later through `run status
+      // <intendedRunId>`. This write-only packet deliberately has no read path.
+      // Re-submitting the same intended run id is safe because DBOS deduplicates it.
+      await blockAndRecordRefusal(
+        deps,
+        dispatchingTask,
+        intendedRunId,
+        reason,
+      );
+      return {
+        outcome: "submit_failed",
+        ...identity,
+        ambiguous,
+        reason,
+      };
+    }
+
+    if (boundRunId !== intendedRunId) {
+      return refuse(
+        deps,
+        dispatchingTask,
+        intendedRunId,
+        "submit_identity_mismatch",
+      );
+    }
+
+    try {
+      await deps.bindRun({
+        workItemId: task.workItemId,
+        harnessRunId: boundRunId,
+      });
+    } catch (error) {
+      if (isDispatchClaimError(error, "binding_conflict")) {
+        return refuse(
+          deps,
+          dispatchingTask,
+          intendedRunId,
+          "binding_conflict",
+        );
+      }
+      throw error;
+    }
+
+    const runBoundAt = deps.now().toISOString();
+    const runningTask: AgentTaskV1 = {
+      ...dispatchingTask,
+      lifecycle: "running",
+      timestamps: {
+        ...dispatchingTask.timestamps,
+        runBoundAt,
+        updatedAt: runBoundAt,
+      },
+      bindings: {
+        ...dispatchingTask.bindings,
+        harnessRunId: boundRunId,
+      },
+    };
+    await deps.saveTask(runningTask);
+    await deps.recordDecision(
+      buildDispatchDecision(runningTask, "dispatch_approval", "dispatch_succeeded", deps.now()),
+    );
+
+    return { outcome: "dispatched", ...identity };
+  } finally {
+    await deps.releaseLease(deps.dispatcherId);
+  }
+}
+
+async function refuse(
+  deps: DispatchDeps,
+  task: AgentTaskV1,
+  intendedRunId: string,
+  reason: string,
+): Promise<DispatchAttemptResult> {
+  await blockAndRecordRefusal(deps, task, intendedRunId, reason);
+  return {
+    outcome: "refused",
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    intendedRunId,
+    reason,
+  };
+}
+
+async function blockAndRecordRefusal(
+  deps: DispatchDeps,
+  task: AgentTaskV1,
+  intendedRunId: string | undefined,
+  reason: string,
+): Promise<void> {
+  const updatedAt = deps.now().toISOString();
+  const blockedTask: AgentTaskV1 = {
+    ...task,
+    lifecycle: "blocked",
+    timestamps: {
+      ...task.timestamps,
+      updatedAt,
+    },
+  };
+  await deps.saveTask(blockedTask);
+  await deps.recordDecision(
+    buildDispatchDecision(blockedTask, "dispatch_refusal", reason, deps.now()),
+  );
+  deps.logger?.warn({
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    ...(intendedRunId ? { intendedRunId } : {}),
+    reason,
+  }, "Harness dispatch refused");
+}
+
+function buildDispatchDecision(
+  task: AgentTaskV1,
+  decisionType: "dispatch_approval" | "dispatch_refusal",
+  reason: string,
+  generatedAt: Date,
+): HermesDecisionRecordV2 {
+  const approval = task.approval;
+  return buildHermesDecisionRecordV2({
+    correlationId: task.correlationId,
+    workItemId: task.workItemId,
+    decisionType,
+    proposal: {
+      what: decisionType === "dispatch_refusal"
+        ? "Refuse the supervised dispatch attempt."
+        : "Record the supervised dispatch approval.",
+      why: [reason],
+      evidenceRefs: task.proposal.sourceRefs,
+    },
+    inputs: [{
+      name: "approved-task",
+      ...(approval.approvedTaskHash
+        ? { hash: approval.approvedTaskHash }
+        : {}),
+      observedAt: generatedAt.toISOString(),
+    }],
+    risk: task.risk,
+    approval: {
+      required: approval.required,
+      decision: approval.status,
+      ...(approval.actor ? { actor: approval.actor } : {}),
+      policyVersion: approval.policyVersion,
+      policyHash: approval.policyHash,
+      ...(approval.decidedAt ? { decidedAt: approval.decidedAt } : {}),
+    },
+    effects: {
+      mutates: false,
+      mutations: [],
+      authorityChanged: false,
+      budgetChanged: false,
+    },
+    next: decisionType === "dispatch_refusal"
+      ? {
+        action: "Operator reviews the refusal before any new dispatch attempt.",
+        owner: "operator",
+        blockedBy: [reason],
+      }
+      : {
+        action: "Harness owns execution under the approved immutable task.",
+        owner: "harness",
+      },
+    generatedAt,
+  });
+}
+
+function isDispatchClaimError(
+  error: unknown,
+  reason: "claim_conflict" | "binding_conflict",
+): error is DispatchClaimError {
+  return (
+    error instanceof DispatchClaimError
+    || (
+      error instanceof Error
+      && error.name === "DispatchClaimError"
+      && "reason" in error
+    )
+  ) && (error as DispatchClaimError).reason === reason;
+}

--- a/services/harness-dispatcher/tsconfig.json
+++ b/services/harness-dispatcher/tsconfig.json
@@ -6,6 +6,7 @@
     "composite": true
   },
   "references": [
+    { "path": "../../packages/averray-mcp" },
     { "path": "../../packages/schemas" }
   ],
   "include": ["src/**/*.ts"]

--- a/test/integration/dispatch-store-postgres.test.ts
+++ b/test/integration/dispatch-store-postgres.test.ts
@@ -1,0 +1,290 @@
+import {
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+import { setTimeout as delay } from "node:timers/promises";
+
+import { Pool } from "pg";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  acquireDispatchLease,
+  claimDispatch,
+  deriveIntendedRunId,
+  releaseDispatchLease,
+  renewDispatchLease,
+  type DispatchStoreQuery,
+} from "../../packages/averray-mcp/src/dispatch-claim.js";
+import {
+  buildHermesDecisionRecordV2,
+} from "../../packages/averray-mcp/src/decision-records.js";
+import {
+  listHermesDecisions,
+  recordHermesDecision,
+  type HermesDecisionStoreQuery,
+} from "../../packages/averray-mcp/src/decision-record-store.js";
+import {
+  bindRunToWorkItem,
+  getRunBinding,
+} from "../../packages/averray-mcp/src/run-binding-outbox.js";
+
+const DATABASE_URL = process.env.DISPATCH_TEST_DATABASE_URL;
+const HASH = `sha256:${"a".repeat(64)}`;
+const OTHER_HASH = `sha256:${"b".repeat(64)}`;
+const RUN_ID = "11111111-1111-4111-8111-111111111111";
+const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222";
+const MANIFEST_REF = {
+  uri: `artifact://sha256/${"c".repeat(64)}`,
+  sha256: `sha256:${"c".repeat(64)}`,
+};
+
+describe.skipIf(!DATABASE_URL)("INT-2e dispatch stores against Postgres", () => {
+  let pool: Pool;
+  let dispatchQuery: DispatchStoreQuery;
+  let decisionQuery: HermesDecisionStoreQuery;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: DATABASE_URL });
+    const query = async <T>(
+      text: string,
+      values: unknown[] = [],
+    ): Promise<T[]> => {
+      const result = await pool.query(text, values);
+      return result.rows as T[];
+    };
+    dispatchQuery = query;
+    decisionQuery = query;
+
+    const migrationsDirectory = new URL("../../ops/migrations/", import.meta.url);
+    const migrations = readdirSync(migrationsDirectory)
+      .filter((file) => file.endsWith(".sql"))
+      .sort();
+    for (const migration of migrations) {
+      await pool.query(
+        readFileSync(new URL(migration, migrationsDirectory), "utf8"),
+      );
+    }
+  });
+
+  beforeEach(async () => {
+    await pool.query("delete from hermes_decision_records");
+    await pool.query("delete from agent_task_run_outbox");
+    await pool.query("delete from agent_task_dispatch_claims");
+    await pool.query("delete from dispatch_lease");
+  });
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  it("enforces live lease ownership, expiry, renewal, and release", async () => {
+    await expect(
+      acquireDispatchLease(
+        { holder: "dispatcher-a", ttlSeconds: 1 },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      acquireDispatchLease(
+        { holder: "dispatcher-b", ttlSeconds: 1 },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      renewDispatchLease(
+        { holder: "dispatcher-b", ttlSeconds: 1 },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      releaseDispatchLease("dispatcher-b", { query: dispatchQuery }),
+    ).resolves.toBe(false);
+    await expect(
+      renewDispatchLease(
+        { holder: "dispatcher-a", ttlSeconds: 1 },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toBe(true);
+
+    await delay(1_200);
+
+    await expect(
+      renewDispatchLease(
+        { holder: "dispatcher-a", ttlSeconds: 1 },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toBe(false);
+    await expect(
+      acquireDispatchLease(
+        { holder: "dispatcher-b", ttlSeconds: 1 },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toBe(true);
+    await expect(
+      releaseDispatchLease("dispatcher-a", { query: dispatchQuery }),
+    ).resolves.toBe(false);
+    await expect(
+      releaseDispatchLease("dispatcher-b", { query: dispatchQuery }),
+    ).resolves.toBe(true);
+  });
+
+  it("deduplicates identical claims and refuses a conflicting hash", async () => {
+    const intendedRunId = deriveIntendedRunId("pg-work-claim", 1, HASH);
+    const input = {
+      workItemId: "pg-work-claim",
+      taskVersion: 1,
+      approvedTaskHash: HASH,
+      intendedRunId,
+    };
+
+    await expect(
+      claimDispatch(input, { query: dispatchQuery }),
+    ).resolves.toMatchObject({
+      created: true,
+      claim: { intendedRunId },
+    });
+    await expect(
+      claimDispatch(input, { query: dispatchQuery }),
+    ).resolves.toMatchObject({
+      created: false,
+      claim: { intendedRunId },
+    });
+    await expect(
+      claimDispatch(
+        { ...input, approvedTaskHash: OTHER_HASH },
+        { query: dispatchQuery },
+      ),
+    ).rejects.toMatchObject({ reason: "claim_conflict" });
+
+    const result = await pool.query<{ count: string }>(
+      `select count(*)::text as count
+       from agent_task_dispatch_claims
+       where work_item_id = $1 and task_version = $2`,
+      [input.workItemId, input.taskVersion],
+    );
+    expect(result.rows[0]?.count).toBe("1");
+  });
+
+  it("keeps run binding immutable while allowing a late manifest fill-in", async () => {
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "pg-work-binding", harnessRunId: RUN_ID },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toMatchObject({ created: true });
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "pg-work-binding", harnessRunId: RUN_ID },
+        { query: dispatchQuery },
+      ),
+    ).resolves.toMatchObject({ created: false });
+    await expect(
+      bindRunToWorkItem(
+        { workItemId: "pg-work-binding", harnessRunId: OTHER_RUN_ID },
+        { query: dispatchQuery },
+      ),
+    ).rejects.toMatchObject({ reason: "binding_conflict" });
+
+    await expect(
+      bindRunToWorkItem({
+        workItemId: "pg-work-binding",
+        harnessRunId: RUN_ID,
+        runManifestRef: MANIFEST_REF,
+        runManifestHash: MANIFEST_REF.sha256,
+      }, { query: dispatchQuery }),
+    ).resolves.toMatchObject({
+      created: false,
+      binding: {
+        harnessRunId: RUN_ID,
+        runManifestRef: MANIFEST_REF,
+        runManifestHash: MANIFEST_REF.sha256,
+      },
+    });
+    await expect(
+      getRunBinding("pg-work-binding", { query: dispatchQuery }),
+    ).resolves.toMatchObject({
+      harnessRunId: RUN_ID,
+      runManifestRef: MANIFEST_REF,
+      runManifestHash: MANIFEST_REF.sha256,
+    });
+  });
+
+  it("inserts a duplicate decision id once without updating its record", async () => {
+    const original = buildHermesDecisionRecordV2(decisionInput(
+      "The immutable claim conflicts with the approved task.",
+    ));
+    const conflictingReplay = buildHermesDecisionRecordV2(decisionInput(
+      "A replay must not replace the original append-only decision.",
+    ));
+    expect(conflictingReplay.decisionId).toBe(original.decisionId);
+
+    await recordHermesDecision(original, { query: decisionQuery });
+    await recordHermesDecision(original, { query: decisionQuery });
+    await recordHermesDecision(conflictingReplay, { query: decisionQuery });
+
+    const result = await pool.query<{ count: string; record: unknown }>(
+      `select count(*) over ()::text as count, record
+       from hermes_decision_records
+       where decision_id = $1`,
+      [original.decisionId],
+    );
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.count).toBe("1");
+    expect(result.rows[0]?.record).toEqual(original);
+    await expect(
+      listHermesDecisions(
+        { workItemId: original.workItemId },
+        { query: decisionQuery },
+      ),
+    ).resolves.toEqual([original]);
+  });
+});
+
+function decisionInput(reason: string) {
+  return {
+    correlationId: "pg-correlation",
+    workItemId: "pg-work-decision",
+    decisionType: "dispatch_refusal" as const,
+    proposal: {
+      what: "Refuse the supervised dispatch attempt.",
+      why: [reason],
+      evidenceRefs: [],
+    },
+    inputs: [{
+      name: "approved-task",
+      hash: HASH,
+      observedAt: "2026-07-24T12:00:00.000Z",
+    }],
+    risk: {
+      tier: "medium" as const,
+      reasons: ["Conflicting immutable state must fail closed."],
+      irreversible: false,
+    },
+    approval: {
+      required: "operator" as const,
+      decision: "approved" as const,
+      actor: { type: "operator" as const, id: "operator-one" },
+      policyVersion: "policy-v1",
+      policyHash: HASH,
+      decidedAt: "2026-07-24T11:59:00.000Z",
+    },
+    effects: {
+      mutates: false,
+      mutations: [],
+      authorityChanged: false,
+      budgetChanged: false,
+    },
+    next: {
+      action: "Operator resolves the conflicting immutable state.",
+      owner: "operator" as const,
+    },
+    generatedAt: "2026-07-24T12:00:00.000Z",
+  };
+}

--- a/test/unit/dispatch-attempt.test.ts
+++ b/test/unit/dispatch-attempt.test.ts
@@ -1,0 +1,609 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  agentTaskApprovalHashMatches,
+  agentTaskV1Schema,
+  hashAgentTaskApprovalPayload,
+  type AgentTaskV1,
+  type HermesDecisionRecordV2,
+  type PilotProfileManifest,
+} from "../../packages/schemas/src/index.js";
+import {
+  DispatchClaimError,
+  deriveIntendedRunId,
+} from "../../packages/averray-mcp/src/dispatch-claim.js";
+import {
+  buildTaskIntentArtifact,
+} from "../../packages/averray-mcp/src/task-intent-mapping.js";
+import {
+  readHaltFile,
+  runSingleDispatch,
+  type DispatchDeps,
+} from "../../services/harness-dispatcher/src/dispatch-attempt.js";
+import {
+  HarnessControlError,
+} from "../../services/harness-dispatcher/src/harness-control-port.js";
+
+const NOW = "2026-07-24T12:00:00.000Z";
+const DEADLINE = "2026-07-24T13:00:00.000Z";
+const WORKSPACE_PATH = "/workspaces/task-checkout";
+const OTHER_HASH = `sha256:${"f".repeat(64)}`;
+const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222";
+
+const CAPABILITIES: PilotProfileManifest["capabilities"] = [
+  { id: "fs.read_file", effectClass: "none", delegable: false },
+  { id: "fs.write_file", effectClass: "local", delegable: false },
+  { id: "fs.list_files", effectClass: "none", delegable: false },
+  { id: "shell.run", effectClass: "local", delegable: false },
+  { id: "git.status", effectClass: "none", delegable: false },
+  { id: "git.diff", effectClass: "none", delegable: false },
+  { id: "artifact.put", effectClass: "local", delegable: false },
+  { id: "artifact.get", effectClass: "none", delegable: false },
+];
+
+describe("single-attempt Harness dispatch orchestration", () => {
+  it("reads HALT_FILE from the supplied environment", () => {
+    expect(readHaltFile({
+      HALT_FILE: path.resolve(process.cwd(), "package.json"),
+    })).toBe(true);
+    expect(readHaltFile({
+      HALT_FILE: path.resolve(process.cwd(), "missing-halt-file"),
+    })).toBe(false);
+  });
+
+  it("returns disabled without touching the lease, store, or control port", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.isDispatchEnabled).mockReturnValue(false);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({ outcome: "disabled" });
+
+    expect(deps.acquireLease).not.toHaveBeenCalled();
+    expect(deps.releaseLease).not.toHaveBeenCalled();
+    expect(deps.listDispatchable).not.toHaveBeenCalled();
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+  });
+
+  it("gives HALT precedence without claiming, listing, or submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.isHalted).mockReturnValue(true);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({ outcome: "halted" });
+
+    expect(deps.acquireLease).not.toHaveBeenCalled();
+    expect(deps.releaseLease).not.toHaveBeenCalled();
+    expect(deps.listDispatchable).not.toHaveBeenCalled();
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+  });
+
+  it("returns lease_unavailable without claiming or submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.acquireLease).mockResolvedValue(false);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({
+      outcome: "lease_unavailable",
+    });
+
+    expect(deps.listDispatchable).not.toHaveBeenCalled();
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+    expect(deps.releaseLease).not.toHaveBeenCalled();
+  });
+
+  it("returns idle after releasing the acquired lease", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.listDispatchable).mockResolvedValue([]);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({ outcome: "idle" });
+
+    expect(deps.listDispatchable).toHaveBeenCalledTimes(1);
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+    expect(deps.releaseLease).toHaveBeenCalledWith(deps.dispatcherId);
+  });
+
+  it("refuses an approval hash mismatch without submitting", async () => {
+    const approved = await approvedTask();
+    const task = {
+      ...approved,
+      proposal: {
+        ...approved.proposal,
+        objective: `${approved.proposal.objective} Materially changed.`,
+      },
+    } as AgentTaskV1;
+    const deps = dispatchDeps(task);
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "approval_hash_mismatch",
+    });
+
+    assertRefusal(deps, "approval_hash_mismatch");
+  });
+
+  it("refuses an executor other than Harness before deriving or claiming", async () => {
+    const task = await reapprove({
+      ...await approvedTask(),
+      executor: {
+        kind: "direct",
+        directAgent: "codex",
+        selectionReason: "The direct path was selected.",
+      },
+    });
+    const deps = dispatchDeps(task);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({
+      outcome: "refused",
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      reason: "executor_not_harness",
+    });
+
+    assertRefusal(deps, "executor_not_harness");
+    expect(deps.getRunBinding).not.toHaveBeenCalled();
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-approved lifecycle before deriving or claiming", async () => {
+    const task = await reapprove({
+      ...await approvedTask(),
+      lifecycle: "proposed",
+    });
+    const deps = dispatchDeps(task);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({
+      outcome: "refused",
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      reason: "not_approved",
+    });
+
+    assertRefusal(deps, "not_approved");
+    expect(deps.getRunBinding).not.toHaveBeenCalled();
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+  });
+
+  it("refuses an expired deadline without submitting", async () => {
+    const task = await reapprove({
+      ...await approvedTask(),
+      deadline: "2026-07-24T12:00:00.000Z",
+    });
+    const deps = dispatchDeps(task);
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "deadline_expired",
+    });
+
+    assertRefusal(deps, "deadline_expired");
+  });
+
+  it("refuses a TaskIntent template hash mismatch without submitting", async () => {
+    const approved = await approvedTask();
+    const task = await reapprove({
+      ...approved,
+      intent: {
+        ...approved.intent,
+        templateHash: OTHER_HASH,
+        templateRef: {
+          ...approved.intent.templateRef,
+          uri: `artifact://sha256/${OTHER_HASH.slice("sha256:".length)}`,
+          sha256: OTHER_HASH,
+        },
+      },
+    });
+    const deps = dispatchDeps(task);
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "template_hash_mismatch",
+    });
+
+    assertRefusal(deps, "template_hash_mismatch");
+    expect(deps.loadProfileManifest).not.toHaveBeenCalled();
+  });
+
+  it("propagates an AttenuationError reason verbatim without submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.loadProfileManifest).mockResolvedValue({
+      ...profileFor(task),
+      capabilities: CAPABILITIES.map((capability, index) =>
+        index === 0
+          ? { ...capability, effectClass: "external_write" }
+          : capability),
+    });
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "capability_effect_external",
+    });
+
+    assertRefusal(deps, "capability_effect_external");
+  });
+
+  it("refuses a claim conflict without submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.claimDispatch).mockRejectedValue(
+      new DispatchClaimError("claim_conflict", "immutable claim conflict"),
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "claim_conflict",
+    });
+
+    assertRefusal(deps, "claim_conflict");
+    expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.writeIntentArtifact).not.toHaveBeenCalled();
+  });
+
+  it("refuses a conflicting recovery binding without claiming or submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.getRunBinding).mockResolvedValue({
+      workItemId: task.workItemId,
+      harnessRunId: OTHER_RUN_ID,
+      boundAt: NOW,
+    });
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "binding_conflict",
+    });
+
+    assertRefusal(deps, "binding_conflict");
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+  });
+
+  it("re-checks HALT immediately before submit and refuses when it trips", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.isHalted)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "halted_before_submit",
+    });
+
+    assertRefusal(deps, "halted_before_submit");
+    expect(deps.isHalted).toHaveBeenCalledTimes(2);
+    expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.writeIntentArtifact).toHaveBeenCalledOnce();
+  });
+
+  it("submits and binds exactly once, preserving the approved task hash", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    const intendedRunId = intendedId(task);
+    const ignoredTask = await reapprove({
+      ...task,
+      workItemId: "work-ignored",
+      taskVersion: 2,
+    });
+    vi.mocked(deps.listDispatchable).mockResolvedValue([task, ignoredTask]);
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({
+      outcome: "dispatched",
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      intendedRunId,
+    });
+
+    expect(deps.listDispatchable).toHaveBeenCalledOnce();
+    expect(deps.renewLease).not.toHaveBeenCalled();
+    expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.controlPort.submit).toHaveBeenCalledOnce();
+    expect(deps.controlPort.submit).toHaveBeenCalledWith(
+      intendedRunId,
+      expect.any(String),
+    );
+    const intentPath = vi.mocked(deps.controlPort.submit).mock.calls[0]?.[1];
+    expect(intentPath && path.isAbsolute(intentPath)).toBe(true);
+    expect(deps.bindRun).toHaveBeenCalledOnce();
+    expect(deps.bindRun).toHaveBeenCalledWith({
+      workItemId: task.workItemId,
+      harnessRunId: intendedRunId,
+    });
+    expect(deps.saveTask).toHaveBeenCalledTimes(2);
+    const finalTask = savedTask(deps, 1);
+    expect(finalTask.lifecycle).toBe("running");
+    expect(finalTask.bindings?.harnessRunId).toBe(intendedRunId);
+    expect(finalTask.timestamps.runBoundAt).toBe(NOW);
+    await expect(agentTaskApprovalHashMatches(finalTask)).resolves.toBe(true);
+    expect(decisionRecords(deps)).toHaveLength(1);
+    expect(decisionRecords(deps)[0]?.decisionType).toBe("dispatch_approval");
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+
+  it("recovers an identical existing binding without claiming or submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    const intendedRunId = intendedId(task);
+    vi.mocked(deps.getRunBinding).mockResolvedValue({
+      workItemId: task.workItemId,
+      harnessRunId: intendedRunId,
+      boundAt: "2026-07-24T11:59:00.000Z",
+    });
+
+    await expect(runSingleDispatch(deps)).resolves.toEqual({
+      outcome: "already_bound",
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      intendedRunId,
+    });
+
+    expect(deps.claimDispatch).not.toHaveBeenCalled();
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+    expect(deps.bindRun).not.toHaveBeenCalled();
+    expect(deps.saveTask).toHaveBeenCalledOnce();
+    expect(savedTask(deps, 0)).toMatchObject({
+      lifecycle: "running",
+      bindings: { harnessRunId: intendedRunId },
+      timestamps: { runBoundAt: "2026-07-24T11:59:00.000Z" },
+    });
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+
+  it("blocks an ambiguous submit without binding or marking the task failed", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.controlPort.submit).mockRejectedValue(
+      new HarnessControlError("cli_timeout", "timed out", true),
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "submit_failed",
+      ambiguous: true,
+      reason: "submit_ambiguous",
+      intendedRunId: intendedId(task),
+    });
+
+    expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.controlPort.submit).toHaveBeenCalledOnce();
+    expect(deps.bindRun).not.toHaveBeenCalled();
+    expect(deps.saveTask).toHaveBeenCalledTimes(2);
+    expect(savedTask(deps, 1).lifecycle).toBe("blocked");
+    expect(savedTask(deps, 1).lifecycle).not.toBe("failed");
+    assertDecision(deps, "submit_ambiguous");
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a definitely-no-run submit refusal as non-ambiguous", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.controlPort.submit).mockRejectedValue(
+      new HarnessControlError(
+        "invalid_intent_path",
+        "intent path is invalid",
+        false,
+      ),
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "submit_failed",
+      ambiguous: false,
+      reason: "submit_refused",
+      intendedRunId: intendedId(task),
+    });
+
+    expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.bindRun).not.toHaveBeenCalled();
+    expect(savedTask(deps, 1).lifecycle).toBe("blocked");
+    assertDecision(deps, "submit_refused");
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+
+  it("refuses a successful submit response with the wrong run identity", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.controlPort.submit).mockResolvedValue(OTHER_RUN_ID);
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "submit_identity_mismatch",
+      intendedRunId: intendedId(task),
+    });
+
+    expect(deps.controlPort.submit).toHaveBeenCalledOnce();
+    expect(deps.bindRun).not.toHaveBeenCalled();
+    expect(savedTask(deps, 1).lifecycle).toBe("blocked");
+    assertDecision(deps, "submit_identity_mismatch");
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+
+  it("refuses an outbox binding conflict after a single successful submit", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.bindRun).mockRejectedValue(
+      new DispatchClaimError("binding_conflict", "immutable binding conflict"),
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "binding_conflict",
+      intendedRunId: intendedId(task),
+    });
+
+    expect(deps.controlPort.submit).toHaveBeenCalledOnce();
+    expect(deps.bindRun).toHaveBeenCalledOnce();
+    expect(savedTask(deps, 1).lifecycle).toBe("blocked");
+    assertDecision(deps, "binding_conflict");
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the lease before propagating an unexpected dependency error", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.listDispatchable).mockRejectedValue(
+      new Error("unexpected store failure"),
+    );
+
+    await expect(runSingleDispatch(deps)).rejects.toThrow(
+      "unexpected store failure",
+    );
+
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+    expect(deps.releaseLease).toHaveBeenCalledOnce();
+  });
+});
+
+function dispatchDeps(task: AgentTaskV1): DispatchDeps {
+  return {
+    now: vi.fn(() => new Date(NOW)),
+    dispatcherId: "dispatcher-one",
+    leaseTtlSeconds: 30,
+    isDispatchEnabled: vi.fn(() => true),
+    isHalted: vi.fn(() => false),
+    listDispatchable: vi.fn(async () => [task]),
+    saveTask: vi.fn(async () => undefined),
+    acquireLease: vi.fn(async () => true),
+    renewLease: vi.fn(async () => true),
+    releaseLease: vi.fn(async () => true),
+    claimDispatch: vi.fn(async () => undefined),
+    getRunBinding: vi.fn(async () => undefined),
+    bindRun: vi.fn(async () => undefined),
+    loadProfileManifest: vi.fn(async () => profileFor(task)),
+    writeIntentArtifact: vi.fn(async (_bytes, workItemId) =>
+      `/tmp/${workItemId}-intent.json`),
+    controlPort: {
+      submit: vi.fn(async (runId) => runId),
+      cancel: vi.fn(async () => undefined),
+    },
+    recordDecision: vi.fn(async () => undefined),
+    logger: { warn: vi.fn() },
+  };
+}
+
+function assertRefusal(deps: DispatchDeps, reason: string): void {
+  expect(deps.controlPort.submit).not.toHaveBeenCalled();
+  expect(deps.saveTask).toHaveBeenCalledOnce();
+  expect(savedTask(deps, 0).lifecycle).toBe("blocked");
+  assertDecision(deps, reason);
+  expect(deps.releaseLease).toHaveBeenCalledOnce();
+}
+
+function assertDecision(deps: DispatchDeps, reason: string): void {
+  const records = decisionRecords(deps);
+  expect(records).toHaveLength(1);
+  expect(records[0]).toMatchObject({
+    decisionType: "dispatch_refusal",
+    proposal: { why: [reason] },
+    effects: { mutates: false },
+    next: { owner: "operator" },
+  });
+}
+
+function savedTask(deps: DispatchDeps, call: number): AgentTaskV1 {
+  const task = vi.mocked(deps.saveTask).mock.calls[call]?.[0];
+  if (!task) throw new Error(`No saved task at call ${call}`);
+  return task;
+}
+
+function decisionRecords(deps: DispatchDeps): HermesDecisionRecordV2[] {
+  return vi.mocked(deps.recordDecision).mock.calls.map(([record]) => record);
+}
+
+function intendedId(task: AgentTaskV1): string {
+  return deriveIntendedRunId(
+    task.workItemId,
+    task.taskVersion,
+    task.approval.approvedTaskHash!,
+  );
+}
+
+function profileFor(task: AgentTaskV1): PilotProfileManifest {
+  return {
+    profileId: task.intent.profile,
+    strategies: ["direct_execution"],
+    capabilities: CAPABILITIES.map((capability) => ({ ...capability })),
+  };
+}
+
+async function approvedTask(): Promise<AgentTaskV1> {
+  const base = agentTaskFixture();
+  const withApproval = {
+    ...base,
+    lifecycle: "approved",
+    requestedAuthority: {
+      ...base.requestedAuthority,
+      grants: CAPABILITIES.map((capability) => ({
+        capabilityId: capability.id,
+        resource: base.repository.nameWithOwner,
+        constraints: {},
+      })),
+    },
+    deadline: DEADLINE,
+    approval: {
+      ...base.approval,
+      status: "approved",
+      actor: { type: "operator", id: "operator-one" },
+      decidedAt: "2026-07-24T11:55:00.000Z",
+      approvedTaskHash: OTHER_HASH,
+    },
+    timestamps: {
+      ...base.timestamps,
+      approvedAt: "2026-07-24T11:55:00.000Z",
+      updatedAt: "2026-07-24T11:55:00.000Z",
+    },
+  } as AgentTaskV1;
+  const artifact = await buildTaskIntentArtifact(withApproval, {
+    workspacePath: WORKSPACE_PATH,
+  });
+  return reapprove({
+    ...withApproval,
+    intent: {
+      ...withApproval.intent,
+      templateRef: {
+        ...withApproval.intent.templateRef,
+        uri: `artifact://sha256/${artifact.templateHash.slice("sha256:".length)}`,
+        sha256: artifact.templateHash,
+      },
+      templateHash: artifact.templateHash,
+    },
+  });
+}
+
+async function reapprove(task: AgentTaskV1): Promise<AgentTaskV1> {
+  const withPlaceholder = agentTaskV1Schema.parse({
+    ...task,
+    approval: {
+      ...task.approval,
+      approvedTaskHash: OTHER_HASH,
+    },
+  });
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(withPlaceholder);
+  return agentTaskV1Schema.parse({
+    ...withPlaceholder,
+    approval: {
+      ...withPlaceholder.approval,
+      approvedTaskHash,
+    },
+  });
+}
+
+function agentTaskFixture(): AgentTaskV1 {
+  return agentTaskV1Schema.parse(
+    JSON.parse(
+      readFileSync(
+        new URL(
+          "../fixtures/agent-integration/agent-task-v1.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## What changed

- Added the pure `runSingleDispatch(deps)` orchestration function with every side-effecting dependency injected.
- Enforced the fail-closed single-attempt order: feature flag, HALT, global lease, first eligible task only, approval/deadline validation, deterministic claim, recovery binding check, TaskIntent construction and attenuation proof, second HALT check, submit, immutable binding, lifecycle writes, and V2 decision records.
- Classified write-only Harness submit failures into definitely-no-run and ambiguous outcomes without retrying, falling back, or marking the task failed.
- Added the default `readHaltFile(env)` implementation with `/data/HALT` fallback.
- Added exhaustive unit coverage with dependency call-count assertions and an opt-in PostgreSQL integration suite for the landed INT-2e SQL.
- Declared the dispatcher’s `@avg/averray-mcp` workspace dependency and TypeScript project reference, with the workspace-only lockfile update.

## Safety and affected surfaces

Affected surfaces are limited to a new backend dispatcher orchestration module, its package metadata, and unit/integration tests. There is no process, entry point, timer, polling loop, Compose service, heartbeat, or board/projection change. Nothing calls `runSingleDispatch` in this PR. `HARNESS_DISPATCH_ENABLED` still defaults to false, HALT is checked twice, and concurrency remains one through the global lease and first-task-only selection. No production authority or environment/VPS secret requirement changes. This does not start INT-2g.

## Checks

- `npx tsc -b services/harness-dispatcher` — exit 0
- `npm run typecheck` — exit 0
- `npm test` — 185 test files passed, 1 opt-in integration file skipped; 2,261 tests passed, 4 skipped
- `docker build -f ops/Dockerfile.node -t avg-int2f-dispatch-attempt .` — exit 0
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config` — exit 0
- `git diff --cached --check` — exit 0

PostgreSQL integration one-liner:

```sh
DISPATCH_TEST_DATABASE_URL=<postgres-url> npx vitest run test/integration/dispatch-store-postgres.test.ts
```

Run once against a disposable PostgreSQL 16 container:

```text
✓ test/integration/dispatch-store-postgres.test.ts (4 tests) 1325ms
  ✓ INT-2e dispatch stores against Postgres > enforces live lease ownership, expiry, renewal, and release 1213ms

Test Files  1 passed (1)
Tests       4 passed (4)
Duration    1.88s
```
