### PR TITLE
feat(harness): prepare per-work-item workspaces

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -84,6 +84,10 @@
     "./attenuation": {
       "types": "./dist/attenuation.d.ts",
       "import": "./dist/attenuation.js"
+    },
+    "./workspace-path": {
+      "types": "./dist/workspace-path.d.ts",
+      "import": "./dist/workspace-path.js"
     }
   },
   "scripts": {

--- a/packages/averray-mcp/src/workspace-path.ts
+++ b/packages/averray-mcp/src/workspace-path.ts
@@ -1,0 +1,26 @@
+export const DISPATCH_WORKSPACE_ROOT =
+  "/var/lib/harness-dispatcher/workspaces";
+
+/**
+ * Changing DISPATCH_WORKSPACE_ROOT or the slug algorithm invalidates every
+ * previously approved task hash, so it is a breaking change requiring
+ * re-approval.
+ */
+export function workspacePathForTask(
+  workItemId: string,
+  taskVersion: number,
+): string {
+  const slug = workItemId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (!slug) {
+    throw new Error("Workspace path requires a non-empty work item slug");
+  }
+
+  const target = `${DISPATCH_WORKSPACE_ROOT}/${slug}-v${taskVersion}`;
+  if (!target.startsWith(`${DISPATCH_WORKSPACE_ROOT}/`)) {
+    throw new Error("Workspace path must remain under the dispatch root");
+  }
+  return target;
+}

--- a/services/harness-dispatcher/src/dispatch-attempt.ts
+++ b/services/harness-dispatcher/src/dispatch-attempt.ts
@@ -25,14 +25,16 @@ import {
 import {
   buildTaskIntentArtifact,
 } from "@avg/averray-mcp/task-intent-mapping";
+import {
+  workspacePathForTask,
+} from "@avg/averray-mcp/workspace-path";
 
 import {
   HarnessControlError,
   type HarnessControlErrorCode,
   type HarnessControlPort,
 } from "./harness-control-port.js";
-
-const DISPATCH_WORKSPACE_PATH = "/workspaces/task-checkout";
+import { WorkspacePrepError } from "./workspace-prep.js";
 
 const DEFINITELY_NO_RUN_CODES = new Set<HarnessControlErrorCode>([
   "dispatch_disabled",
@@ -56,6 +58,7 @@ export interface DispatchDeps {
   getRunBinding(workItemId: string): Promise<RunBinding | undefined>;
   bindRun(input: BindRunInput): Promise<unknown>;
   loadProfileManifest(profileId: string): Promise<PilotProfileManifest>;
+  prepareWorkspace(task: AgentTaskV1): Promise<string>;
   writeIntentArtifact(bytes: string, workItemId: string): Promise<string>;
   controlPort: HarnessControlPort;
   recordDecision(record: HermesDecisionRecordV2): Promise<unknown>;
@@ -184,8 +187,24 @@ export async function runSingleDispatch(
       throw error;
     }
 
+    let workspacePath: string;
+    try {
+      workspacePath = await deps.prepareWorkspace(task);
+    } catch (error) {
+      if (error instanceof WorkspacePrepError) {
+        return refuse(deps, task, intendedRunId, "workspace_prep_failed");
+      }
+      throw error;
+    }
+    if (
+      workspacePath
+      !== workspacePathForTask(task.workItemId, task.taskVersion)
+    ) {
+      return refuse(deps, task, intendedRunId, "workspace_prep_failed");
+    }
+
     const artifact = await buildTaskIntentArtifact(task, {
-      workspacePath: DISPATCH_WORKSPACE_PATH,
+      workspacePath,
     });
     if (artifact.templateHash !== task.intent.templateHash) {
       return refuse(deps, task, intendedRunId, "template_hash_mismatch");

--- a/services/harness-dispatcher/src/workspace-prep.ts
+++ b/services/harness-dispatcher/src/workspace-prep.ts
@@ -1,0 +1,256 @@
+import { spawn } from "node:child_process";
+import {
+  mkdir as mkdirPath,
+  rm as removePath,
+} from "node:fs/promises";
+import path from "node:path";
+
+import type { AgentTaskV1 } from "@avg/schemas";
+import {
+  DISPATCH_WORKSPACE_ROOT,
+  workspacePathForTask,
+} from "@avg/averray-mcp/workspace-path";
+
+const DEFAULT_GIT_TIMEOUT_MS = 120_000;
+const DEFAULT_GIT_MAX_OUTPUT_BYTES = 256 * 1024;
+const REPOSITORY_NAME = /^[^/\s]+\/[^/\s]+$/;
+const UNSAFE_REPOSITORY_URL_CHARACTER = /[@\\:?#]/;
+
+export type WorkspacePrepReason =
+  | "path_outside_root"
+  | "clone_failed"
+  | "revision_mismatch"
+  | "cleanup_failed"
+  | "invalid_repository";
+
+export class WorkspacePrepError extends Error {
+  constructor(
+    readonly reason: WorkspacePrepReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WorkspacePrepError";
+  }
+}
+
+export interface GitCommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface WorkspacePrepDeps {
+  runGit(
+    args: readonly string[],
+    cwd?: string,
+  ): Promise<GitCommandResult>;
+  rm(path: string): Promise<void>;
+  mkdir(path: string): Promise<void>;
+}
+
+export async function prepareTaskWorkspace(
+  task: AgentTaskV1,
+  deps: Partial<WorkspacePrepDeps> = {},
+): Promise<string> {
+  const resolved = workspacePrepDeps(deps);
+  const target = deriveContainedWorkspacePath(task);
+  const cloneUrl = publicCloneUrl(task);
+
+  try {
+    await resolved.rm(target);
+    await resolved.mkdir(target);
+  } catch {
+    throw new WorkspacePrepError(
+      "cleanup_failed",
+      "Could not create a clean task workspace",
+    );
+  }
+
+  await runRequiredGitStep(resolved.runGit, ["init"], target, "init");
+  await runRequiredGitStep(
+    resolved.runGit,
+    ["remote", "add", "origin", cloneUrl],
+    target,
+    "remote setup",
+  );
+  await runRequiredGitStep(
+    resolved.runGit,
+    ["fetch", "--depth", "1", "origin", task.repository.baseRevision],
+    target,
+    "fetch",
+  );
+  await runRequiredGitStep(
+    resolved.runGit,
+    ["checkout", "--detach", "FETCH_HEAD"],
+    target,
+    "checkout",
+  );
+  const head = await runRequiredGitStep(
+    resolved.runGit,
+    ["rev-parse", "HEAD"],
+    target,
+    "revision verification",
+  );
+  if (head.stdout.trim() !== task.repository.baseRevision) {
+    throw new WorkspacePrepError(
+      "revision_mismatch",
+      "Prepared workspace revision does not match the approved revision",
+    );
+  }
+
+  return target;
+}
+
+export async function disposeTaskWorkspace(
+  task: AgentTaskV1,
+  deps: Partial<WorkspacePrepDeps> = {},
+): Promise<void> {
+  const resolved = workspacePrepDeps(deps);
+  const target = deriveContainedWorkspacePath(task);
+  try {
+    await resolved.rm(target);
+  } catch {
+    throw new WorkspacePrepError(
+      "cleanup_failed",
+      "Could not remove the task workspace",
+    );
+  }
+}
+
+function workspacePrepDeps(
+  deps: Partial<WorkspacePrepDeps>,
+): WorkspacePrepDeps {
+  return {
+    runGit: deps.runGit ?? runGit,
+    rm: deps.rm ?? (async (target) => {
+      await removePath(target, { recursive: true, force: true });
+    }),
+    mkdir: deps.mkdir ?? (async (target) => {
+      await mkdirPath(target, { recursive: true });
+    }),
+  };
+}
+
+function deriveContainedWorkspacePath(task: AgentTaskV1): string {
+  let target: string;
+  try {
+    target = workspacePathForTask(task.workItemId, task.taskVersion);
+  } catch {
+    throw new WorkspacePrepError(
+      "path_outside_root",
+      "Task workspace path could not be contained under the dispatch root",
+    );
+  }
+  assertContained(target);
+  return target;
+}
+
+function assertContained(target: string): void {
+  const relative = path.relative(DISPATCH_WORKSPACE_ROOT, target);
+  if (
+    !relative
+    || relative.startsWith(`..${path.sep}`)
+    || relative === ".."
+    || path.isAbsolute(relative)
+  ) {
+    throw new WorkspacePrepError(
+      "path_outside_root",
+      "Task workspace path must remain under the dispatch root",
+    );
+  }
+}
+
+function publicCloneUrl(task: AgentTaskV1): string {
+  const { provider, nameWithOwner } = task.repository;
+  if (
+    provider !== "github"
+    || !REPOSITORY_NAME.test(nameWithOwner)
+    || UNSAFE_REPOSITORY_URL_CHARACTER.test(nameWithOwner)
+  ) {
+    throw new WorkspacePrepError(
+      "invalid_repository",
+      "Task repository must be a public GitHub owner/name pair",
+    );
+  }
+  return `https://github.com/${nameWithOwner}.git`;
+}
+
+async function runRequiredGitStep(
+  execute: WorkspacePrepDeps["runGit"],
+  args: readonly string[],
+  cwd: string,
+  label: string,
+): Promise<GitCommandResult> {
+  let result: GitCommandResult;
+  try {
+    result = await execute(args, cwd);
+  } catch {
+    throw new WorkspacePrepError(
+      "clone_failed",
+      `Git ${label} could not be completed`,
+    );
+  }
+  if (result.code !== 0) {
+    // Deliberately omit raw stderr: Git output can contain credential material
+    // supplied by the host even though this adapter never supplies credentials.
+    throw new WorkspacePrepError(
+      "clone_failed",
+      `Git ${label} failed with exit ${result.code}`,
+    );
+  }
+  return result;
+}
+
+const runGit: WorkspacePrepDeps["runGit"] = (
+  args,
+  cwd,
+) =>
+  new Promise((resolve, reject) => {
+    const child = spawn("git", [...args], {
+      cwd,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_TERMINAL_PROMPT: "0",
+        PATH: "/usr/local/bin:/usr/bin:/bin",
+      },
+    });
+    let stdout = "";
+    let stderr = "";
+    let outputBytes = 0;
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    const fail = (message: string): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      child.kill("SIGKILL");
+      reject(new Error(message));
+    };
+    const collect = (target: "stdout" | "stderr", chunk: Buffer): void => {
+      outputBytes += chunk.byteLength;
+      if (outputBytes > DEFAULT_GIT_MAX_OUTPUT_BYTES) {
+        fail("Git output exceeded the configured limit");
+        return;
+      }
+      if (target === "stdout") stdout += chunk.toString("utf8");
+      else stderr += chunk.toString("utf8");
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => collect("stdout", chunk));
+    child.stderr.on("data", (chunk: Buffer) => collect("stderr", chunk));
+    child.once("error", () => fail("Git could not be started"));
+    child.once("close", (code) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve({ code: code ?? 1, stdout, stderr });
+    });
+    timer = setTimeout(() => {
+      fail("Git command timed out");
+    }, DEFAULT_GIT_TIMEOUT_MS);
+    timer.unref();
+  });

--- a/test/unit/dispatch-attempt.test.ts
+++ b/test/unit/dispatch-attempt.test.ts
@@ -19,6 +19,9 @@ import {
   buildTaskIntentArtifact,
 } from "../../packages/averray-mcp/src/task-intent-mapping.js";
 import {
+  workspacePathForTask,
+} from "../../packages/averray-mcp/src/workspace-path.js";
+import {
   readHaltFile,
   runSingleDispatch,
   type DispatchDeps,
@@ -26,10 +29,12 @@ import {
 import {
   HarnessControlError,
 } from "../../services/harness-dispatcher/src/harness-control-port.js";
+import {
+  WorkspacePrepError,
+} from "../../services/harness-dispatcher/src/workspace-prep.js";
 
 const NOW = "2026-07-24T12:00:00.000Z";
 const DEADLINE = "2026-07-24T13:00:00.000Z";
-const WORKSPACE_PATH = "/workspaces/task-checkout";
 const OTHER_HASH = `sha256:${"f".repeat(64)}`;
 const OTHER_RUN_ID = "22222222-2222-4222-8222-222222222222";
 
@@ -248,6 +253,41 @@ describe("single-attempt Harness dispatch orchestration", () => {
     expect(deps.writeIntentArtifact).not.toHaveBeenCalled();
   });
 
+  it("refuses a workspace preparation error after claiming without submitting", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.prepareWorkspace).mockRejectedValue(
+      new WorkspacePrepError("clone_failed", "Public checkout failed"),
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "workspace_prep_failed",
+      intendedRunId: intendedId(task),
+    });
+
+    assertRefusal(deps, "workspace_prep_failed");
+    expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.prepareWorkspace).toHaveBeenCalledOnce();
+    expect(deps.writeIntentArtifact).not.toHaveBeenCalled();
+  });
+
+  it("refuses a prepared path that differs from the shared deterministic path", async () => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    vi.mocked(deps.prepareWorkspace).mockResolvedValue(
+      "/var/lib/harness-dispatcher/workspaces/unapproved-v1",
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "workspace_prep_failed",
+    });
+
+    assertRefusal(deps, "workspace_prep_failed");
+    expect(deps.writeIntentArtifact).not.toHaveBeenCalled();
+  });
+
   it("refuses a conflicting recovery binding without claiming or submitting", async () => {
     const task = await approvedTask();
     const deps = dispatchDeps(task);
@@ -305,6 +345,8 @@ describe("single-attempt Harness dispatch orchestration", () => {
     expect(deps.listDispatchable).toHaveBeenCalledOnce();
     expect(deps.renewLease).not.toHaveBeenCalled();
     expect(deps.claimDispatch).toHaveBeenCalledOnce();
+    expect(deps.prepareWorkspace).toHaveBeenCalledOnce();
+    expect(deps.prepareWorkspace).toHaveBeenCalledWith(task);
     expect(deps.controlPort.submit).toHaveBeenCalledOnce();
     expect(deps.controlPort.submit).toHaveBeenCalledWith(
       intendedRunId,
@@ -312,6 +354,13 @@ describe("single-attempt Harness dispatch orchestration", () => {
     );
     const intentPath = vi.mocked(deps.controlPort.submit).mock.calls[0]?.[1];
     expect(intentPath && path.isAbsolute(intentPath)).toBe(true);
+    const intentBytes = vi.mocked(deps.writeIntentArtifact).mock.calls[0]?.[0];
+    const writtenIntent = JSON.parse(intentBytes ?? "{}") as {
+      spec?: { context?: { workspace?: { path?: string } } };
+    };
+    expect(writtenIntent.spec?.context?.workspace?.path).toBe(
+      workspacePathForTask(task.workItemId, task.taskVersion),
+    );
     expect(deps.bindRun).toHaveBeenCalledOnce();
     expect(deps.bindRun).toHaveBeenCalledWith({
       workItemId: task.workItemId,
@@ -346,6 +395,7 @@ describe("single-attempt Harness dispatch orchestration", () => {
     });
 
     expect(deps.claimDispatch).not.toHaveBeenCalled();
+    expect(deps.prepareWorkspace).not.toHaveBeenCalled();
     expect(deps.controlPort.submit).not.toHaveBeenCalled();
     expect(deps.bindRun).not.toHaveBeenCalled();
     expect(deps.saveTask).toHaveBeenCalledOnce();
@@ -476,6 +526,8 @@ function dispatchDeps(task: AgentTaskV1): DispatchDeps {
     getRunBinding: vi.fn(async () => undefined),
     bindRun: vi.fn(async () => undefined),
     loadProfileManifest: vi.fn(async () => profileFor(task)),
+    prepareWorkspace: vi.fn(async (candidate) =>
+      workspacePathForTask(candidate.workItemId, candidate.taskVersion)),
     writeIntentArtifact: vi.fn(async (_bytes, workItemId) =>
       `/tmp/${workItemId}-intent.json`),
     controlPort: {
@@ -560,7 +612,10 @@ async function approvedTask(): Promise<AgentTaskV1> {
     },
   } as AgentTaskV1;
   const artifact = await buildTaskIntentArtifact(withApproval, {
-    workspacePath: WORKSPACE_PATH,
+    workspacePath: workspacePathForTask(
+      withApproval.workItemId,
+      withApproval.taskVersion,
+    ),
   });
   return reapprove({
     ...withApproval,

--- a/test/unit/workspace-path.test.ts
+++ b/test/unit/workspace-path.test.ts
@@ -1,0 +1,47 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DISPATCH_WORKSPACE_ROOT,
+  workspacePathForTask,
+} from "../../packages/averray-mcp/src/workspace-path.js";
+
+describe("dispatch workspace paths", () => {
+  it("is deterministic, absolute, and contained under the fixed root", () => {
+    const first = workspacePathForTask("Issue ABC_123", 4);
+    const second = workspacePathForTask("Issue ABC_123", 4);
+
+    expect(first).toBe(second);
+    expect(first).toBe(
+      `${DISPATCH_WORKSPACE_ROOT}/issue-abc-123-v4`,
+    );
+    expect(path.isAbsolute(first)).toBe(true);
+    expect(first.startsWith(`${DISPATCH_WORKSPACE_ROOT}/`)).toBe(true);
+  });
+
+  it("uses a distinct directory for each task version", () => {
+    expect(workspacePathForTask("issue-123", 1)).not.toBe(
+      workspacePathForTask("issue-123", 2),
+    );
+  });
+
+  it.each([
+    ["../../etc", "etc"],
+    ["a/b", "a-b"],
+  ])("keeps traversal-shaped id %s inside the root", (workItemId, slug) => {
+    const target = workspacePathForTask(workItemId, 1);
+
+    expect(target).toBe(`${DISPATCH_WORKSPACE_ROOT}/${slug}-v1`);
+    expect(path.relative(DISPATCH_WORKSPACE_ROOT, target)).not.toMatch(/^\.\./);
+  });
+
+  it.each(["", "...", "///"])(
+    "rejects work item ids with an empty slug: %j",
+    (workItemId) => {
+      expect(() => workspacePathForTask(workItemId, 1)).toThrow(
+        "non-empty work item slug",
+      );
+    },
+  );
+});

--- a/test/unit/workspace-prep.test.ts
+++ b/test/unit/workspace-prep.test.ts
@@ -1,0 +1,223 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  agentTaskV1Schema,
+  type AgentTaskV1,
+} from "../../packages/schemas/src/index.js";
+import {
+  workspacePathForTask,
+} from "../../packages/averray-mcp/src/workspace-path.js";
+import {
+  disposeTaskWorkspace,
+  prepareTaskWorkspace,
+  WorkspacePrepError,
+  type GitCommandResult,
+  type WorkspacePrepDeps,
+} from "../../services/harness-dispatcher/src/workspace-prep.js";
+
+const FAKE_CREDENTIAL = "ghp_this-must-never-appear";
+
+describe("task workspace preparation", () => {
+  it("cleans first, uses fixed Git argv, verifies HEAD, and returns the path", async () => {
+    const task = agentTaskFixture();
+    const target = workspacePathForTask(task.workItemId, task.taskVersion);
+    const order: string[] = [];
+    const deps = workspacePrepDeps({
+      runGit: vi.fn(async (args) => {
+        order.push(`git:${args.join(" ")}`);
+        return gitResult(
+          args[0] === "rev-parse" ? task.repository.baseRevision : "",
+        );
+      }),
+      rm: vi.fn(async () => {
+        order.push("rm");
+      }),
+      mkdir: vi.fn(async () => {
+        order.push("mkdir");
+      }),
+    });
+
+    await expect(prepareTaskWorkspace(task, deps)).resolves.toBe(target);
+
+    expect(order.slice(0, 3)).toEqual(["rm", "mkdir", "git:init"]);
+    expect(deps.runGit).toHaveBeenCalledTimes(5);
+    expect(deps.runGit).toHaveBeenNthCalledWith(1, ["init"], target);
+    expect(deps.runGit).toHaveBeenNthCalledWith(
+      2,
+      [
+        "remote",
+        "add",
+        "origin",
+        `https://github.com/${task.repository.nameWithOwner}.git`,
+      ],
+      target,
+    );
+    expect(deps.runGit).toHaveBeenNthCalledWith(
+      3,
+      [
+        "fetch",
+        "--depth",
+        "1",
+        "origin",
+        task.repository.baseRevision,
+      ],
+      target,
+    );
+    expect(deps.runGit).toHaveBeenNthCalledWith(
+      4,
+      ["checkout", "--detach", "FETCH_HEAD"],
+      target,
+    );
+    expect(deps.runGit).toHaveBeenNthCalledWith(
+      5,
+      ["rev-parse", "HEAD"],
+      target,
+    );
+    for (const [args] of vi.mocked(deps.runGit).mock.calls) {
+      expect(Array.isArray(args)).toBe(true);
+      expect(args.every((argument) => typeof argument === "string")).toBe(true);
+    }
+
+    const remoteArgs = vi.mocked(deps.runGit).mock.calls[1]?.[0];
+    const cloneUrl = remoteArgs?.[3];
+    expect(cloneUrl).toBe("https://github.com/owner/repo.git");
+    expect(cloneUrl).not.toContain("@");
+    expect(cloneUrl).not.toContain(FAKE_CREDENTIAL);
+    expect(cloneUrl).not.toContain(task.repository.baseRevision);
+  });
+
+  it("refuses a checked-out revision other than the exact approved revision", async () => {
+    const task = agentTaskFixture();
+    const deps = workspacePrepDeps({
+      runGit: vi.fn(async (args) =>
+        gitResult(args[0] === "rev-parse" ? "f".repeat(40) : "")),
+    });
+
+    const error = await capturedWorkspacePrepError(
+      prepareTaskWorkspace(task, deps),
+    );
+
+    expect(error.reason).toBe("revision_mismatch");
+  });
+
+  it("maps a non-zero Git exit without exposing raw stderr credentials", async () => {
+    const task = agentTaskFixture();
+    const deps = workspacePrepDeps({
+      runGit: vi.fn(async (args) =>
+        args[0] === "fetch"
+          ? gitResult("", 128, `Authorization: Bearer ${FAKE_CREDENTIAL}`)
+          : gitResult("")),
+    });
+
+    const error = await capturedWorkspacePrepError(
+      prepareTaskWorkspace(task, deps),
+    );
+
+    expect(error.reason).toBe("clone_failed");
+    expect(error.message).not.toContain(FAKE_CREDENTIAL);
+    expect(error.message).not.toContain("Authorization");
+  });
+
+  it.each([
+    "owner-only",
+    "owner/repo/extra",
+    "owner@host/repo",
+  ])("rejects invalid repository name %s before touching the workspace", async (
+    nameWithOwner,
+  ) => {
+    const task = agentTaskFixture();
+    const invalidTask = {
+      ...task,
+      repository: { ...task.repository, nameWithOwner },
+    } as AgentTaskV1;
+    const deps = workspacePrepDeps();
+
+    const error = await capturedWorkspacePrepError(
+      prepareTaskWorkspace(invalidTask, deps),
+    );
+
+    expect(error.reason).toBe("invalid_repository");
+    expect(deps.rm).not.toHaveBeenCalled();
+    expect(deps.runGit).not.toHaveBeenCalled();
+  });
+
+  it("maps clean-slate failures and never starts Git", async () => {
+    const task = agentTaskFixture();
+    const deps = workspacePrepDeps({
+      rm: vi.fn(async () => {
+        throw new Error("filesystem unavailable");
+      }),
+    });
+
+    const error = await capturedWorkspacePrepError(
+      prepareTaskWorkspace(task, deps),
+    );
+
+    expect(error.reason).toBe("cleanup_failed");
+    expect(deps.mkdir).not.toHaveBeenCalled();
+    expect(deps.runGit).not.toHaveBeenCalled();
+  });
+
+  it("disposes only the same derived workspace path", async () => {
+    const task = agentTaskFixture();
+    const deps = workspacePrepDeps();
+
+    await disposeTaskWorkspace(task, deps);
+
+    expect(deps.rm).toHaveBeenCalledOnce();
+    expect(deps.rm).toHaveBeenCalledWith(
+      workspacePathForTask(task.workItemId, task.taskVersion),
+    );
+    expect(deps.mkdir).not.toHaveBeenCalled();
+    expect(deps.runGit).not.toHaveBeenCalled();
+  });
+});
+
+function workspacePrepDeps(
+  overrides: Partial<WorkspacePrepDeps> = {},
+): WorkspacePrepDeps {
+  return {
+    runGit: overrides.runGit ?? vi.fn(async (args) =>
+      gitResult(args[0] === "rev-parse"
+        ? agentTaskFixture().repository.baseRevision
+        : "")),
+    rm: overrides.rm ?? vi.fn(async () => undefined),
+    mkdir: overrides.mkdir ?? vi.fn(async () => undefined),
+  };
+}
+
+function gitResult(
+  stdout = "",
+  code = 0,
+  stderr = "",
+): GitCommandResult {
+  return { code, stdout, stderr };
+}
+
+async function capturedWorkspacePrepError(
+  promise: Promise<unknown>,
+): Promise<WorkspacePrepError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(WorkspacePrepError);
+    return error as WorkspacePrepError;
+  }
+  throw new Error("Expected workspace preparation to fail");
+}
+
+function agentTaskFixture(): AgentTaskV1 {
+  return agentTaskV1Schema.parse(
+    JSON.parse(
+      readFileSync(
+        new URL(
+          "../fixtures/agent-integration/agent-task-v1.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ),
+  );
+}


### PR DESCRIPTION
## What changed

- Added a shared, deterministic workspace-path contract rooted at `/var/lib/harness-dispatcher/workspaces`, including a package subpath export and the approval-hash breaking-change warning.
- Added injectable workspace preparation/disposal that cleans the target, uses fixed `git` argv with `shell: false`, fetches the public GitHub repository at the approved revision, and verifies `rev-parse HEAD` exactly.
- Wired preparation into `runSingleDispatch` after recovery/claim and before TaskIntent construction. Already-bound work skips preparation; prep errors or path mismatches fail closed as `workspace_prep_failed` with no Harness submit.
- Added focused path, prep, redaction, ordering, exact-argv, revision, and orchestration tests.

## Checks run

- `npm run typecheck` — exit 0
- `npm test` — 187 files passed, 1 skipped; 2,278 tests passed, 4 skipped
- `docker build --file ops/Dockerfile.node --tag averray-reference-agent:int2g-check .` — exit 0
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config --quiet` — exit 0

## Affected surfaces

- Backend shared package: workspace-path contract/export
- Harness dispatcher: workspace preparation and single-attempt wiring
- Unit tests
- No frontend, indexer, Caddy, contracts, public site, migration, or Compose changes
- No new dependency, environment variable, or VPS secret is required

## Safety / authority

- No dispatcher service/process, scheduler, polling timer, heartbeat, or loop is introduced; nothing runs on its own. The only timer is the required bounded timeout for an invoked Git subprocess.
- Workspace fetches are public read-only HTTPS. No credential is read, used, or embedded, and raw Git stderr is not surfaced.
- The clean checkout is required to resolve to the exact approved revision before TaskIntent construction can continue.
- This changes no production authority and does not start the dispatcher process packet.