### PR TITLE
feat(harness): add dormant dispatcher process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,12 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   visibly; they never become healthy cards. This path cannot submit, approve,
   deny, cancel, release, dispatch, mutate GitHub/Averray, or read artifact
   contents. Harness contributes structured run facts and a card tag; Hermes
-  remains the only conversational board voice. No Harness dispatcher exists
-  until a later separately guarded packet.
+  remains the only conversational board voice. A separate Harness dispatcher
+  service exists but is dormant: it is isolated behind the non-default
+  `dispatch` Compose profile and `HARNESS_DISPATCH_ENABLED=false` by default.
+  At concurrency one it acts only on operator-approved, hash-pinned AgentTasks,
+  honors `HALT_FILE`, and cannot approve, deny, release, merge, deploy, or open
+  a PR.
 - **Self-healing (B2, off by default).** On a failure signal (failed testbed
   mission, failed deploy/verification), Hermes auto-**proposes** a routed fix
   task (non-high-risk) — which still lands `proposed` and flows through the same

--- a/ops/.env.example
+++ b/ops/.env.example
@@ -200,6 +200,21 @@ DOCS_TASK_RUNNER_ENABLED=0
 DOCS_TASK_RUNNER_ID=vps-docs-task-runner
 DOCS_TASK_RUNNER_ARGS=services/slack-operator/dist/docs-branch-worker.js
 
+# INT-2 supervised Harness dispatcher (Compose profile "dispatch").
+# The service is absent from normal startup and independently defaults disabled.
+# Enabling it remains a separate operator action after the pinned Harness CLI,
+# isolated Harness database, and exact pilot profile are provisioned.
+HARNESS_DISPATCH_ENABLED=false
+HARNESS_DISPATCHER_ID=vps-harness-dispatcher
+HARNESS_DISPATCH_POLL_INTERVAL_MS=15000
+HARNESS_DISPATCH_LEASE_TTL_SECONDS=120
+HARNESS_DISPATCH_INTENT_DIR=/data/harness-dispatch-intents
+HARNESS_DISPATCH_HEARTBEAT_PATH=/data/harness-dispatcher-heartbeat.json
+HARNESS_BIN=harness
+HARNESS_DATABASE_URL=
+HARNESS_PROFILES_ROOT=
+HARNESS_PROFILE_SHA256=
+
 # Claude branch worker (the greenfield executor the runner spawns). It creates
 # a claude/<slug> branch, runs Claude, pushes, and opens a PR for review.
 # ALLOWED_REPOS is the gate on this unattended push power: empty = refuse every

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -37,11 +37,12 @@ services:
       [
         "/bin/sh",
         "-lc",
-        "mkdir -p /opt/data/skills /opt/data/browser-profiles /data && chmod -R 0777 /opt/data /data"
+        "mkdir -p /opt/data/skills /opt/data/browser-profiles /data /harness-dispatcher/workspaces && chmod -R 0777 /opt/data /data /harness-dispatcher"
       ]
     volumes:
       - avg-hermes:/opt/data
       - avg-data:/data
+      - harness-dispatch-workspaces:/harness-dispatcher
       - ../hermes/profiles:/opt/data/browser-profiles
       - avg-hermes-skills:/opt/data/skills
     networks: [avg-internal]
@@ -563,6 +564,45 @@ services:
       - avg-data:/data
     networks: [avg-internal]
 
+  # INT-2 supervised Harness dispatcher. DORMANT by construction: Compose
+  # excludes this service unless the operator selects profile "dispatch", and
+  # the independent runtime authority flag remains false unless explicitly set.
+  harness-dispatcher:
+    init: true
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
+    profiles: ["dispatch"]
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      hermes-permissions:
+        condition: service_completed_successfully
+      mcp-bundle:
+        condition: service_completed_successfully
+    command: ["node", "services/harness-dispatcher/dist/index.js"]
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      HARNESS_DATABASE_URL: ${HARNESS_DATABASE_URL:-}
+      HALT_FILE: ${HALT_FILE:-/data/HALT}
+      HARNESS_BIN: ${HARNESS_BIN:-harness}
+      HARNESS_PROFILES_ROOT: ${HARNESS_PROFILES_ROOT:-}
+      HARNESS_PROFILE_SHA256: ${HARNESS_PROFILE_SHA256:-}
+      HARNESS_DISPATCH_ENABLED: ${HARNESS_DISPATCH_ENABLED:-false}
+      HARNESS_DISPATCHER_ID: ${HARNESS_DISPATCHER_ID:-vps-harness-dispatcher}
+      HARNESS_DISPATCH_POLL_INTERVAL_MS: ${HARNESS_DISPATCH_POLL_INTERVAL_MS:-15000}
+      HARNESS_DISPATCH_LEASE_TTL_SECONDS: ${HARNESS_DISPATCH_LEASE_TTL_SECONDS:-120}
+      HARNESS_DISPATCH_INTENT_DIR: ${HARNESS_DISPATCH_INTENT_DIR:-/data/harness-dispatch-intents}
+      HARNESS_DISPATCH_HEARTBEAT_PATH: ${HARNESS_DISPATCH_HEARTBEAT_PATH:-/data/harness-dispatcher-heartbeat.json}
+    volumes:
+      - avg-data:/data
+      - harness-dispatch-workspaces:/var/lib/harness-dispatcher
+    networks: [avg-internal]
+
   # Claude task runner (O2). Mirrors codex-task-runner; claims approved
   # agent="claude" tasks. The startup route gate (claude-worker-auth) refuses
   # to claim on a billing-route mismatch. Disabled by default; the operator
@@ -863,6 +903,7 @@ services:
 volumes:
   avg-postgres:
   avg-data:
+  harness-dispatch-workspaces:
   avg-app:
   avg-mcp-env:
   avg-hermes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5257,7 +5257,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@avg/averray-mcp": "0.1.0",
-        "@avg/schemas": "0.1.0"
+        "@avg/mcp-common": "0.1.0",
+        "@avg/schemas": "0.1.0",
+        "yaml": "^2.7.0"
       }
     },
     "services/skills-observer": {

--- a/services/harness-dispatcher/package.json
+++ b/services/harness-dispatcher/package.json
@@ -6,10 +6,13 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b",
-    "typecheck": "tsc -b --pretty false"
+    "typecheck": "tsc -b --pretty false",
+    "start": "node dist/index.js"
   },
   "dependencies": {
     "@avg/averray-mcp": "0.1.0",
-    "@avg/schemas": "0.1.0"
+    "@avg/mcp-common": "0.1.0",
+    "@avg/schemas": "0.1.0",
+    "yaml": "^2.7.0"
   }
 }

--- a/services/harness-dispatcher/src/index.ts
+++ b/services/harness-dispatcher/src/index.ts
@@ -1,0 +1,504 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { hostname, tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  listDispatchableAgentTasks,
+  putAgentTask,
+} from "@avg/averray-mcp/agent-task-store";
+import {
+  acquireDispatchLease,
+  claimDispatch,
+  releaseDispatchLease,
+  renewDispatchLease,
+} from "@avg/averray-mcp/dispatch-claim";
+import {
+  recordHermesDecision,
+} from "@avg/averray-mcp/decision-record-store";
+import {
+  bindRunToWorkItem,
+  getRunBinding,
+} from "@avg/averray-mcp/run-binding-outbox";
+import { closePool } from "@avg/mcp-common";
+import { taskIntentSchema } from "@avg/schemas";
+
+import {
+  readHaltFile,
+  runSingleDispatch,
+  type DispatchAttemptResult,
+  type DispatchDeps,
+} from "./dispatch-attempt.js";
+import {
+  createHarnessControlPort,
+  harnessDispatchEnabled,
+} from "./harness-control-port.js";
+import { loadProfileManifest } from "./profile-manifest.js";
+import { prepareTaskWorkspace } from "./workspace-prep.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const MIN_POLL_INTERVAL_MS = 5_000;
+const MAX_POLL_INTERVAL_MS = 300_000;
+const DEFAULT_LEASE_TTL_SECONDS = 120;
+const MIN_LEASE_TTL_SECONDS = 30;
+const MAX_LEASE_TTL_SECONDS = 900;
+
+export type DispatcherHeartbeatStatus =
+  | "disabled"
+  | "halted"
+  | "idle"
+  | "dispatching"
+  | "error";
+
+export interface DispatcherHeartbeat {
+  schemaVersion: 1;
+  kind: "harness_dispatcher_heartbeat";
+  dispatcherId: string;
+  status: DispatcherHeartbeatStatus;
+  message: string;
+  updatedAt: string;
+  lastOutcome?: string;
+}
+
+export interface DispatcherConfig {
+  dispatcherId: string;
+  pollIntervalMs: number;
+  leaseTtlSeconds: number;
+  intentDir: string;
+  heartbeatPath: string;
+  harnessBin: string;
+}
+
+export interface DispatcherLogger {
+  info(fields: Record<string, unknown>, message: string): void;
+  warn(fields: Record<string, unknown>, message: string): void;
+}
+
+export interface DispatcherScheduler {
+  setTimeout(callback: () => void, delayMs: number): NodeJS.Timeout;
+  clearTimeout(timer: NodeJS.Timeout): void;
+}
+
+export type DispatcherTickResult =
+  | DispatchAttemptResult
+  | { outcome: "error"; reason: "attempt_failed" };
+
+export interface DispatcherProcessDeps {
+  runAttempt(): Promise<DispatchAttemptResult>;
+  isDispatchEnabled(): boolean;
+  isHalted(): boolean;
+  releaseLease(holder: string): Promise<boolean>;
+  writeHeartbeat(heartbeat: DispatcherHeartbeat): Promise<void>;
+  now(): Date;
+  logger: DispatcherLogger;
+  scheduler: DispatcherScheduler;
+}
+
+export interface DispatcherProcess {
+  start(): void;
+  tick(): Promise<DispatcherTickResult>;
+  shutdown(): Promise<void>;
+}
+
+export function parseDispatcherConfig(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+  runtime: { hostname?: string; pid?: number; tmpdir?: string } = {},
+): DispatcherConfig {
+  const runtimeHostname = runtime.hostname ?? hostname();
+  const runtimePid = runtime.pid ?? process.pid;
+  const runtimeTmpdir = runtime.tmpdir ?? tmpdir();
+  const dispatcherId = environment.HARNESS_DISPATCHER_ID?.trim()
+    || `${runtimeHostname}-${runtimePid}`;
+  const intentDir = path.resolve(
+    environment.HARNESS_DISPATCH_INTENT_DIR?.trim()
+      || path.join(
+        runtimeTmpdir,
+        "averray-reference-agent",
+        "harness-dispatch-intents",
+      ),
+  );
+  const heartbeatPath = path.resolve(
+    environment.HARNESS_DISPATCH_HEARTBEAT_PATH?.trim()
+      || path.join(
+        runtimeTmpdir,
+        "averray-reference-agent",
+        "harness-dispatcher-heartbeat.json",
+      ),
+  );
+
+  return {
+    dispatcherId,
+    pollIntervalMs: boundedInteger(
+      environment.HARNESS_DISPATCH_POLL_INTERVAL_MS,
+      DEFAULT_POLL_INTERVAL_MS,
+      MIN_POLL_INTERVAL_MS,
+      MAX_POLL_INTERVAL_MS,
+    ),
+    leaseTtlSeconds: boundedInteger(
+      environment.HARNESS_DISPATCH_LEASE_TTL_SECONDS,
+      DEFAULT_LEASE_TTL_SECONDS,
+      MIN_LEASE_TTL_SECONDS,
+      MAX_LEASE_TTL_SECONDS,
+    ),
+    intentDir,
+    heartbeatPath,
+    harnessBin: environment.HARNESS_BIN?.trim() || "harness",
+  };
+}
+
+export function createDispatcherProcess(
+  config: DispatcherConfig,
+  deps: DispatcherProcessDeps,
+): DispatcherProcess {
+  let stopped = true;
+  let timer: NodeJS.Timeout | undefined;
+  let inFlight: Promise<DispatcherTickResult> | undefined;
+  let shutdownPromise: Promise<void> | undefined;
+  let lastOutcome: string | undefined;
+
+  const heartbeat = async (
+    status: DispatcherHeartbeatStatus,
+    message: string,
+    outcome = lastOutcome,
+  ): Promise<void> => {
+    await deps.writeHeartbeat({
+      schemaVersion: 1,
+      kind: "harness_dispatcher_heartbeat",
+      dispatcherId: config.dispatcherId,
+      status,
+      message,
+      updatedAt: deps.now().toISOString(),
+      ...(outcome ? { lastOutcome: outcome } : {}),
+    });
+  };
+
+  const writeHeartbeatBestEffort = async (
+    status: DispatcherHeartbeatStatus,
+    message: string,
+    outcome = lastOutcome,
+  ): Promise<void> => {
+    try {
+      await heartbeat(status, message, outcome);
+    } catch (error) {
+      deps.logger.warn(
+        { errorName: errorName(error), status },
+        "Harness dispatcher heartbeat could not be written",
+      );
+    }
+  };
+
+  const performTick = async (): Promise<DispatcherTickResult> => {
+    try {
+      const enabled = deps.isDispatchEnabled();
+      const halted = enabled && deps.isHalted();
+      if (enabled && !halted) {
+        await writeHeartbeatBestEffort(
+          "dispatching",
+          "A single supervised dispatch attempt is in progress.",
+        );
+      }
+      const result = await deps.runAttempt();
+      lastOutcome = result.outcome;
+      logAttempt(deps.logger, result);
+      await writeHeartbeatBestEffort(
+        heartbeatStatusForResult(result),
+        attemptMessage(result),
+        result.outcome,
+      );
+      return result;
+    } catch (error) {
+      lastOutcome = "error";
+      deps.logger.warn(
+        { errorName: errorName(error) },
+        "Harness dispatch attempt failed",
+      );
+      await writeHeartbeatBestEffort(
+        "error",
+        "Harness dispatch attempt failed; the next tick may retry polling.",
+        "error",
+      );
+      return { outcome: "error", reason: "attempt_failed" };
+    }
+  };
+
+  const tick = (): Promise<DispatcherTickResult> => {
+    if (inFlight) return inFlight;
+    const current = performTick().finally(() => {
+      if (inFlight === current) inFlight = undefined;
+    });
+    inFlight = current;
+    return current;
+  };
+
+  const runLoopTick = async (): Promise<void> => {
+    if (stopped) return;
+    await tick();
+    if (stopped) return;
+    timer = deps.scheduler.setTimeout(() => {
+      timer = undefined;
+      void runLoopTick();
+    }, config.pollIntervalMs);
+  };
+
+  const start = (): void => {
+    if (!stopped) return;
+    stopped = false;
+    void runLoopTick();
+  };
+
+  const shutdown = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      stopped = true;
+      if (timer) {
+        deps.scheduler.clearTimeout(timer);
+        timer = undefined;
+      }
+      if (inFlight) await inFlight;
+      const enabled = deps.isDispatchEnabled();
+      const halted = enabled && deps.isHalted();
+      if (enabled) {
+        try {
+          await deps.releaseLease(config.dispatcherId);
+        } catch (error) {
+          deps.logger.warn(
+            { errorName: errorName(error) },
+            "Harness dispatch lease could not be released during shutdown",
+          );
+        }
+      }
+      const status = !enabled
+        ? "disabled"
+        : halted
+          ? "halted"
+          : "idle";
+      try {
+        await heartbeat(
+          status,
+          shutdownMessage(status),
+        );
+      } catch (error) {
+        deps.logger.warn(
+          { errorName: errorName(error) },
+          "Harness dispatcher final heartbeat could not be written",
+        );
+      }
+    })();
+    return shutdownPromise;
+  };
+
+  return { start, tick, shutdown };
+}
+
+export function createIntentArtifactWriter(
+  intentDir: string,
+): DispatchDeps["writeIntentArtifact"] {
+  const root = path.resolve(intentDir);
+  return async (bytes, workItemId) => {
+    if (
+      !workItemId
+      || workItemId.includes("/")
+      || workItemId.includes("\\")
+    ) {
+      throw new Error("Harness intent work item id is not filename-safe");
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(bytes);
+    } catch {
+      throw new Error("Harness intent artifact is not canonical JSON");
+    }
+    const intent = taskIntentSchema.parse(parsed);
+    if (intent.metadata.labels.averray_work_item_id !== workItemId) {
+      throw new Error("Harness intent work item label does not match its task");
+    }
+    const versionLabel = intent.metadata.labels.task_version;
+    if (!/^[1-9][0-9]*$/.test(versionLabel)) {
+      throw new Error("Harness intent task version label is invalid");
+    }
+    const target = path.resolve(
+      root,
+      `${workItemId}-v${versionLabel}.json`,
+    );
+    assertPathContained(root, target);
+    await mkdir(root, { recursive: true });
+    await writeFile(target, bytes, "utf8");
+    return target;
+  };
+}
+
+export function createHeartbeatWriter(
+  heartbeatPath: string,
+): DispatcherProcessDeps["writeHeartbeat"] {
+  const target = path.resolve(heartbeatPath);
+  return async (heartbeat) => {
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, `${JSON.stringify(heartbeat, null, 2)}\n`, "utf8");
+  };
+}
+
+export function createProductionDispatcher(
+  environmentInput: Readonly<Record<string, string | undefined>> = process.env,
+  logger: DispatcherLogger = consoleDispatcherLogger,
+): DispatcherProcess {
+  const environment = Object.freeze({ ...environmentInput });
+  const config = parseDispatcherConfig(environment);
+  const controlPort = createHarnessControlPort({
+    command: config.harnessBin,
+    enabled: harnessDispatchEnabled(environment),
+  });
+  const dispatchDeps: DispatchDeps = {
+    now: () => new Date(),
+    dispatcherId: config.dispatcherId,
+    leaseTtlSeconds: config.leaseTtlSeconds,
+    isDispatchEnabled: () => harnessDispatchEnabled(environment),
+    isHalted: () => readHaltFile(environment),
+    listDispatchable: listDispatchableAgentTasks,
+    saveTask: putAgentTask,
+    acquireLease: acquireDispatchLease,
+    renewLease: renewDispatchLease,
+    releaseLease: releaseDispatchLease,
+    claimDispatch,
+    getRunBinding,
+    bindRun: bindRunToWorkItem,
+    loadProfileManifest: (profileId) =>
+      loadProfileManifest(profileId, environment),
+    prepareWorkspace: prepareTaskWorkspace,
+    writeIntentArtifact: createIntentArtifactWriter(config.intentDir),
+    controlPort,
+    recordDecision: recordHermesDecision,
+    logger: {
+      warn(object, message) {
+        logger.warn(asLogFields(object), message);
+      },
+    },
+  };
+
+  return createDispatcherProcess(config, {
+    runAttempt: () => runSingleDispatch(dispatchDeps),
+    isDispatchEnabled: dispatchDeps.isDispatchEnabled,
+    isHalted: dispatchDeps.isHalted,
+    releaseLease: releaseDispatchLease,
+    writeHeartbeat: createHeartbeatWriter(config.heartbeatPath),
+    now: dispatchDeps.now,
+    logger,
+    scheduler: {
+      setTimeout: (callback, delayMs) => setTimeout(callback, delayMs),
+      clearTimeout: (handle) => clearTimeout(handle),
+    },
+  });
+}
+
+function boundedInteger(
+  input: string | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (!input?.trim()) return fallback;
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(maximum, Math.max(minimum, Math.floor(parsed)));
+}
+
+function heartbeatStatusForResult(
+  result: DispatchAttemptResult,
+): DispatcherHeartbeatStatus {
+  if (result.outcome === "disabled") return "disabled";
+  if (result.outcome === "halted") return "halted";
+  if (result.outcome === "submit_failed") return "error";
+  return "idle";
+}
+
+function attemptMessage(result: DispatchAttemptResult): string {
+  const reason = "reason" in result ? ` (${result.reason})` : "";
+  return `Harness dispatch attempt finished: ${result.outcome}${reason}.`;
+}
+
+function logAttempt(
+  logger: DispatcherLogger,
+  result: DispatchAttemptResult,
+): void {
+  const fields: Record<string, unknown> = {
+    outcome: result.outcome,
+    ...("reason" in result ? { reason: result.reason } : {}),
+    ...("workItemId" in result ? { workItemId: result.workItemId } : {}),
+    ...("taskVersion" in result ? { taskVersion: result.taskVersion } : {}),
+  };
+  logger.info(fields, "Harness dispatch attempt completed");
+  if (
+    result.outcome === "refused"
+    || result.outcome === "submit_failed"
+  ) {
+    logger.warn(fields, "Harness dispatch attempt requires attention");
+  }
+}
+
+function shutdownMessage(status: DispatcherHeartbeatStatus): string {
+  if (status === "disabled") {
+    return "Harness dispatcher stopped while dispatch remained disabled.";
+  }
+  if (status === "halted") {
+    return "Harness dispatcher stopped while HALT_FILE remained present.";
+  }
+  return "Harness dispatcher stopped after releasing its lease.";
+}
+
+function assertPathContained(root: string, target: string): void {
+  const relative = path.relative(root, target);
+  if (
+    !relative
+    || relative === ".."
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)
+  ) {
+    throw new Error("Harness intent artifact path escaped its configured root");
+  }
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : "UnknownError";
+}
+
+function asLogFields(value: unknown): Record<string, unknown> {
+  return typeof value === "object" && value !== null
+    ? value as Record<string, unknown>
+    : { detail: String(value) };
+}
+
+const consoleDispatcherLogger: DispatcherLogger = {
+  info(fields, message) {
+    console.info(`[harness-dispatcher] ${message}`, fields);
+  },
+  warn(fields, message) {
+    console.warn(`[harness-dispatcher] ${message}`, fields);
+  },
+};
+
+async function main(): Promise<void> {
+  const dispatcher = createProductionDispatcher();
+  let shutdownPromise: Promise<void> | undefined;
+  const shutdown = (): Promise<void> => {
+    shutdownPromise ??= (async () => {
+      await dispatcher.shutdown();
+      await closePool();
+      process.exitCode = 0;
+    })();
+    return shutdownPromise;
+  };
+  process.once("SIGINT", () => {
+    void shutdown();
+  });
+  process.once("SIGTERM", () => {
+    void shutdown();
+  });
+  dispatcher.start();
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((error) => {
+    console.error("[harness-dispatcher] fatal", {
+      errorName: errorName(error),
+    });
+    process.exitCode = 1;
+  });
+}

--- a/services/harness-dispatcher/src/profile-manifest.ts
+++ b/services/harness-dispatcher/src/profile-manifest.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { PilotProfileManifest } from "@avg/schemas";
+import { parse } from "yaml";
+
+export type VettedCapability = Readonly<{
+  effectClass: "none" | "local";
+  delegable: false;
+}>;
+
+export const VETTED_CAPABILITIES: ReadonlyMap<string, VettedCapability> =
+  frozenReadonlyMap([
+    ["fs.read_file", Object.freeze({ effectClass: "none", delegable: false })],
+    ["fs.write_file", Object.freeze({ effectClass: "local", delegable: false })],
+    ["fs.list_files", Object.freeze({ effectClass: "none", delegable: false })],
+    ["shell.run", Object.freeze({ effectClass: "local", delegable: false })],
+    ["git.status", Object.freeze({ effectClass: "none", delegable: false })],
+    ["git.diff", Object.freeze({ effectClass: "none", delegable: false })],
+    ["artifact.put", Object.freeze({ effectClass: "local", delegable: false })],
+    ["artifact.get", Object.freeze({ effectClass: "none", delegable: false })],
+  ]);
+
+export type ProfileManifestErrorReason =
+  | "missing_profiles_root"
+  | "invalid_profile_id"
+  | "profile_unreadable"
+  | "profile_malformed"
+  | "profile_hash_mismatch"
+  | "invalid_strategy"
+  | "unvetted_capability"
+  | "delegable_capability";
+
+export class ProfileManifestError extends Error {
+  constructor(
+    readonly reason: ProfileManifestErrorReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ProfileManifestError";
+  }
+}
+
+export async function loadProfileManifest(
+  profileId: string,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<PilotProfileManifest> {
+  assertProfileId(profileId);
+  const profilesRoot = environment.HARNESS_PROFILES_ROOT?.trim();
+  if (!profilesRoot) {
+    throw new ProfileManifestError(
+      "missing_profiles_root",
+      "HARNESS_PROFILES_ROOT is required",
+    );
+  }
+
+  const profilePath = path.resolve(profilesRoot, profileId, "profile.yaml");
+  assertProfilePathContained(profilesRoot, profilePath);
+  let raw: Buffer;
+  try {
+    raw = await readFile(profilePath);
+  } catch {
+    throw new ProfileManifestError(
+      "profile_unreadable",
+      `Harness profile ${profileId} could not be read`,
+    );
+  }
+
+  verifyProfileHash(raw, environment.HARNESS_PROFILE_SHA256);
+  const document = parseProfile(raw, profileId);
+  const strategies = parseStrategies(document, profileId);
+  const capabilities = parseCapabilities(document, profileId);
+  return { profileId, strategies, capabilities };
+}
+
+function assertProfileId(profileId: string): void {
+  if (
+    !profileId
+    || profileId !== profileId.trim()
+    || profileId.includes("/")
+    || profileId.includes("\\")
+    || profileId.includes("..")
+  ) {
+    throw new ProfileManifestError(
+      "invalid_profile_id",
+      "Harness profile id must be a single safe path segment",
+    );
+  }
+}
+
+function assertProfilePathContained(
+  profilesRoot: string,
+  profilePath: string,
+): void {
+  const resolvedRoot = path.resolve(profilesRoot);
+  const relative = path.relative(resolvedRoot, profilePath);
+  if (
+    !relative
+    || relative === ".."
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)
+  ) {
+    throw new ProfileManifestError(
+      "invalid_profile_id",
+      "Harness profile path must remain under HARNESS_PROFILES_ROOT",
+    );
+  }
+}
+
+function verifyProfileHash(
+  raw: Buffer,
+  expectedInput: string | undefined,
+): void {
+  const expected = expectedInput?.trim();
+  if (!expected) return;
+  const match = /^(?:sha256:)?([a-f0-9]{64})$/i.exec(expected);
+  const actual = createHash("sha256").update(raw).digest("hex");
+  if (!match || match[1]!.toLowerCase() !== actual) {
+    throw new ProfileManifestError(
+      "profile_hash_mismatch",
+      "Harness profile SHA-256 does not match the configured pin",
+    );
+  }
+}
+
+function parseProfile(raw: Buffer, profileId: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = parse(raw.toString("utf8"));
+  } catch {
+    throw new ProfileManifestError(
+      "profile_malformed",
+      `Harness profile ${profileId} is malformed`,
+    );
+  }
+  if (!isRecord(parsed)) {
+    throw new ProfileManifestError(
+      "profile_malformed",
+      `Harness profile ${profileId} must contain a YAML object`,
+    );
+  }
+  return parsed;
+}
+
+function parseStrategies(
+  document: Record<string, unknown>,
+  profileId: string,
+): string[] {
+  const strategies = document.strategies;
+  if (
+    !Array.isArray(strategies)
+    || strategies.length === 0
+    || strategies.some((strategy) =>
+      typeof strategy !== "string" || !strategy.trim())
+  ) {
+    throw new ProfileManifestError(
+      "profile_malformed",
+      `Harness profile ${profileId} has malformed strategies`,
+    );
+  }
+  if (
+    strategies.length !== 1
+    || strategies[0] !== "direct_execution"
+  ) {
+    throw new ProfileManifestError(
+      "invalid_strategy",
+      `Harness profile ${profileId} must use direct_execution only`,
+    );
+  }
+  return [...strategies] as string[];
+}
+
+function parseCapabilities(
+  document: Record<string, unknown>,
+  profileId: string,
+): PilotProfileManifest["capabilities"] {
+  const declared = document.capabilities;
+  if (!Array.isArray(declared) || declared.length === 0) {
+    throw new ProfileManifestError(
+      "profile_malformed",
+      `Harness profile ${profileId} has malformed capabilities`,
+    );
+  }
+
+  const seen = new Set<string>();
+  return declared.map((entry) => {
+    const capability = parseCapabilityEntry(entry, profileId);
+    if (seen.has(capability.id)) {
+      throw new ProfileManifestError(
+        "profile_malformed",
+        `Harness profile ${profileId} repeats a capability id`,
+      );
+    }
+    seen.add(capability.id);
+    if (capability.delegable) {
+      throw new ProfileManifestError(
+        "delegable_capability",
+        `Harness profile ${profileId} declares a delegable capability`,
+      );
+    }
+    const vetted = VETTED_CAPABILITIES.get(capability.id);
+    if (!vetted) {
+      throw new ProfileManifestError(
+        "unvetted_capability",
+        `Harness profile ${profileId} declares an unvetted capability`,
+      );
+    }
+    return { id: capability.id, ...vetted };
+  });
+}
+
+function parseCapabilityEntry(
+  entry: unknown,
+  profileId: string,
+): { id: string; delegable: boolean } {
+  if (typeof entry === "string" && entry.trim()) {
+    return { id: entry, delegable: false };
+  }
+  if (
+    isRecord(entry)
+    && typeof entry.id === "string"
+    && entry.id.trim()
+    && (entry.delegable === undefined || typeof entry.delegable === "boolean")
+  ) {
+    return { id: entry.id, delegable: entry.delegable === true };
+  }
+  throw new ProfileManifestError(
+    "profile_malformed",
+    `Harness profile ${profileId} has a malformed capability declaration`,
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function frozenReadonlyMap(
+  entries: ReadonlyArray<readonly [string, VettedCapability]>,
+): ReadonlyMap<string, VettedCapability> {
+  const map = new Map(entries);
+  const rejectMutation = (): never => {
+    throw new TypeError("Vetted capability registry is immutable");
+  };
+  Object.defineProperties(map, {
+    set: { value: rejectMutation },
+    delete: { value: rejectMutation },
+    clear: { value: rejectMutation },
+  });
+  return Object.freeze(map);
+}

--- a/services/harness-dispatcher/tsconfig.json
+++ b/services/harness-dispatcher/tsconfig.json
@@ -7,6 +7,7 @@
   },
   "references": [
     { "path": "../../packages/averray-mcp" },
+    { "path": "../../packages/mcp-common" },
     { "path": "../../packages/schemas" }
   ],
   "include": ["src/**/*.ts"]

--- a/test/unit/dispatcher-process.test.ts
+++ b/test/unit/dispatcher-process.test.ts
@@ -1,0 +1,396 @@
+import {
+  mkdtemp,
+  readFile,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createDispatcherProcess,
+  createIntentArtifactWriter,
+  parseDispatcherConfig,
+  type DispatcherConfig,
+  type DispatcherHeartbeat,
+  type DispatcherProcessDeps,
+  type DispatcherScheduler,
+} from "../../services/harness-dispatcher/src/index.js";
+import {
+  buildTaskIntentArtifact,
+} from "../../packages/averray-mcp/src/task-intent-mapping.js";
+import {
+  workspacePathForTask,
+} from "../../packages/averray-mcp/src/workspace-path.js";
+import {
+  agentTaskV1Schema,
+} from "../../packages/schemas/src/index.js";
+import type {
+  DispatchAttemptResult,
+  DispatchDeps,
+} from "../../services/harness-dispatcher/src/dispatch-attempt.js";
+import {
+  runSingleDispatch,
+} from "../../services/harness-dispatcher/src/dispatch-attempt.js";
+
+const NOW = new Date("2026-07-25T12:00:00.000Z");
+
+describe("Harness dispatcher process", () => {
+  it("parses startup config once with bounded polling and lease values", () => {
+    expect(parseDispatcherConfig({
+      HARNESS_DISPATCHER_ID: "dispatcher-one",
+      HARNESS_DISPATCH_POLL_INTERVAL_MS: "1",
+      HARNESS_DISPATCH_LEASE_TTL_SECONDS: "9999",
+      HARNESS_DISPATCH_INTENT_DIR: "./intents",
+      HARNESS_DISPATCH_HEARTBEAT_PATH: "./heartbeat.json",
+      HARNESS_BIN: "/opt/harness/bin/harness",
+    }, {
+      hostname: "host",
+      pid: 42,
+      tmpdir: "/tmp",
+    })).toMatchObject({
+      dispatcherId: "dispatcher-one",
+      pollIntervalMs: 5_000,
+      leaseTtlSeconds: 900,
+      harnessBin: "/opt/harness/bin/harness",
+    });
+
+    expect(parseDispatcherConfig({}, {
+      hostname: "host",
+      pid: 42,
+      tmpdir: "/tmp",
+    })).toEqual({
+      dispatcherId: "host-42",
+      pollIntervalMs: 15_000,
+      leaseTtlSeconds: 120,
+      intentDir: "/tmp/averray-reference-agent/harness-dispatch-intents",
+      heartbeatPath:
+        "/tmp/averray-reference-agent/harness-dispatcher-heartbeat.json",
+      harnessBin: "harness",
+    });
+  });
+
+  it("reports disabled honestly while the guarded attempt touches no store dependency", async () => {
+    const attemptDeps = dispatchAttemptDeps(false, false);
+    const harness = processHarness({
+      runAttempt: vi.fn(() => runSingleDispatch(attemptDeps)),
+      isDispatchEnabled: vi.fn(() => false),
+    });
+
+    await expect(harness.process.tick()).resolves.toEqual({
+      outcome: "disabled",
+    });
+
+    expect(harness.deps.runAttempt).toHaveBeenCalledOnce();
+    expect(attemptDeps.acquireLease).not.toHaveBeenCalled();
+    expect(attemptDeps.listDispatchable).not.toHaveBeenCalled();
+    expect(heartbeats(harness.deps)).toEqual([
+      expect.objectContaining({
+        status: "disabled",
+        lastOutcome: "disabled",
+      }),
+    ]);
+    expect(heartbeats(harness.deps)).not.toContainEqual(
+      expect.objectContaining({ status: "dispatching" }),
+    );
+
+    await harness.process.shutdown();
+    expect(harness.deps.releaseLease).not.toHaveBeenCalled();
+    expect(heartbeats(harness.deps).at(-1)).toMatchObject({
+      status: "disabled",
+    });
+  });
+
+  it("reports HALT honestly without starting store work", async () => {
+    const attemptDeps = dispatchAttemptDeps(true, true);
+    const harness = processHarness({
+      runAttempt: vi.fn(() => runSingleDispatch(attemptDeps)),
+      isHalted: vi.fn(() => true),
+    });
+
+    await expect(harness.process.tick()).resolves.toEqual({
+      outcome: "halted",
+    });
+
+    expect(harness.deps.runAttempt).toHaveBeenCalledOnce();
+    expect(attemptDeps.acquireLease).not.toHaveBeenCalled();
+    expect(attemptDeps.listDispatchable).not.toHaveBeenCalled();
+    expect(heartbeats(harness.deps)).toEqual([
+      expect.objectContaining({
+        status: "halted",
+        lastOutcome: "halted",
+      }),
+    ]);
+  });
+
+  it("shares an in-flight tick so a slow attempt never overlaps", async () => {
+    const pending = deferred<DispatchAttemptResult>();
+    const runAttempt = vi.fn(() => pending.promise);
+    const harness = processHarness({ runAttempt });
+
+    const first = harness.process.tick();
+    const second = harness.process.tick();
+
+    expect(second).toBe(first);
+    await vi.waitFor(() => {
+      expect(runAttempt).toHaveBeenCalledOnce();
+    });
+    pending.resolve({ outcome: "idle" });
+    await expect(first).resolves.toEqual({ outcome: "idle" });
+    expect(runAttempt).toHaveBeenCalledOnce();
+    expect(heartbeats(harness.deps).map(({ status }) => status)).toEqual([
+      "dispatching",
+      "idle",
+    ]);
+  });
+
+  it("still runs exactly one attempt when the dispatching heartbeat fails", async () => {
+    const runAttempt = vi.fn(async () => ({ outcome: "idle" as const }));
+    const writeHeartbeat = vi.fn()
+      .mockRejectedValueOnce(new Error("heartbeat unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const harness = processHarness({ runAttempt, writeHeartbeat });
+
+    await expect(harness.process.tick()).resolves.toEqual({
+      outcome: "idle",
+    });
+
+    expect(runAttempt).toHaveBeenCalledOnce();
+    expect(harness.deps.logger.warn).toHaveBeenCalledWith(
+      { errorName: "Error", status: "dispatching" },
+      "Harness dispatcher heartbeat could not be written",
+    );
+    expect(heartbeats(harness.deps).at(-1)).toMatchObject({
+      status: "idle",
+      lastOutcome: "idle",
+    });
+  });
+
+  it.each([
+    {
+      outcome: "refused" as const,
+      workItemId: "work-1",
+      taskVersion: 1,
+      reason: "attenuation_failed",
+    },
+    {
+      outcome: "submit_failed" as const,
+      workItemId: "work-1",
+      taskVersion: 1,
+      intendedRunId: "00000000-0000-4000-8000-000000000001",
+      reason: "submit_refused" as const,
+      ambiguous: false,
+    },
+  ])("warns operators when an attempt is $outcome", async (result) => {
+    const harness = processHarness({
+      runAttempt: vi.fn(async () => result),
+    });
+
+    await expect(harness.process.tick()).resolves.toEqual(result);
+
+    expect(harness.deps.logger.info).toHaveBeenCalledOnce();
+    expect(harness.deps.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: result.outcome }),
+      "Harness dispatch attempt requires attention",
+    );
+  });
+
+  it("shutdown awaits the active attempt, releases the lease, and flushes a final heartbeat", async () => {
+    const pending = deferred<DispatchAttemptResult>();
+    const harness = processHarness({
+      runAttempt: vi.fn(() => pending.promise),
+    });
+
+    const tick = harness.process.tick();
+    await vi.waitFor(() => {
+      expect(harness.deps.runAttempt).toHaveBeenCalledOnce();
+    });
+    const shutdown = harness.process.shutdown();
+    expect(harness.deps.releaseLease).not.toHaveBeenCalled();
+
+    pending.resolve({ outcome: "idle" });
+    await tick;
+    await shutdown;
+
+    expect(harness.deps.releaseLease).toHaveBeenCalledOnce();
+    expect(harness.deps.releaseLease).toHaveBeenCalledWith("dispatcher-one");
+    expect(heartbeats(harness.deps).at(-1)).toMatchObject({
+      status: "idle",
+      lastOutcome: "idle",
+      message: "Harness dispatcher stopped after releasing its lease.",
+    });
+  });
+
+  it("catches a failed attempt, logs an error heartbeat, and schedules the next tick", async () => {
+    const callbacks: Array<() => void> = [];
+    const scheduler: DispatcherScheduler = {
+      setTimeout: vi.fn((callback) => {
+        callbacks.push(callback);
+        return { hasRef: () => true } as NodeJS.Timeout;
+      }),
+      clearTimeout: vi.fn(),
+    };
+    const runAttempt = vi.fn()
+      .mockRejectedValueOnce(new Error("database unavailable"))
+      .mockResolvedValueOnce({ outcome: "idle" });
+    const harness = processHarness({ runAttempt, scheduler });
+
+    harness.process.start();
+    await vi.waitFor(() => {
+      expect(runAttempt).toHaveBeenCalledTimes(1);
+      expect(callbacks).toHaveLength(1);
+    });
+    expect(heartbeats(harness.deps)).toContainEqual(
+      expect.objectContaining({
+        status: "error",
+        lastOutcome: "error",
+      }),
+    );
+    expect(harness.deps.logger.warn).toHaveBeenCalledWith(
+      { errorName: "Error" },
+      "Harness dispatch attempt failed",
+    );
+
+    callbacks.shift()?.();
+    await vi.waitFor(() => {
+      expect(runAttempt).toHaveBeenCalledTimes(2);
+      expect(callbacks).toHaveLength(1);
+    });
+    expect(heartbeats(harness.deps).at(-1)).toMatchObject({
+      status: "idle",
+      lastOutcome: "idle",
+    });
+
+    await harness.process.shutdown();
+    expect(scheduler.clearTimeout).toHaveBeenCalledOnce();
+  });
+
+  it("writes canonical intent bytes to the configured versioned absolute path", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "harness-intent-test-"));
+    try {
+      const task = agentTaskV1Schema.parse(JSON.parse(
+        await readFile(
+          new URL(
+            "../fixtures/agent-integration/agent-task-v1.json",
+            import.meta.url,
+          ),
+          "utf8",
+        ),
+      ));
+      const artifact = await buildTaskIntentArtifact(task, {
+        workspacePath: workspacePathForTask(
+          task.workItemId,
+          task.taskVersion,
+        ),
+      });
+      const writer = createIntentArtifactWriter(root);
+
+      const target = await writer(artifact.canonicalBytes, task.workItemId);
+
+      expect(target).toBe(path.join(
+        root,
+        `${task.workItemId}-v${task.taskVersion}.json`,
+      ));
+      expect(path.isAbsolute(target)).toBe(true);
+      await expect(readFile(target, "utf8")).resolves.toBe(
+        artifact.canonicalBytes,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function processHarness(
+  overrides: Partial<DispatcherProcessDeps> = {},
+): {
+  process: ReturnType<typeof createDispatcherProcess>;
+  deps: DispatcherProcessDeps;
+} {
+  const deps: DispatcherProcessDeps = {
+    runAttempt: overrides.runAttempt ?? vi.fn(async () => ({ outcome: "idle" })),
+    isDispatchEnabled:
+      overrides.isDispatchEnabled ?? vi.fn(() => true),
+    isHalted: overrides.isHalted ?? vi.fn(() => false),
+    releaseLease:
+      overrides.releaseLease ?? vi.fn(async () => true),
+    writeHeartbeat:
+      overrides.writeHeartbeat ?? vi.fn(async () => undefined),
+    now: overrides.now ?? vi.fn(() => NOW),
+    logger: overrides.logger ?? {
+      info: vi.fn(),
+      warn: vi.fn(),
+    },
+    scheduler: overrides.scheduler ?? {
+      setTimeout: vi.fn(() => {
+        throw new Error("Unexpected scheduled timer in direct tick test");
+      }),
+      clearTimeout: vi.fn(),
+    },
+  };
+  return {
+    process: createDispatcherProcess(dispatcherConfig(), deps),
+    deps,
+  };
+}
+
+function dispatcherConfig(): DispatcherConfig {
+  return {
+    dispatcherId: "dispatcher-one",
+    pollIntervalMs: 15_000,
+    leaseTtlSeconds: 120,
+    intentDir: "/tmp/harness-intents",
+    heartbeatPath: "/tmp/harness-heartbeat.json",
+    harnessBin: "harness",
+  };
+}
+
+function dispatchAttemptDeps(
+  enabled: boolean,
+  halted: boolean,
+): DispatchDeps {
+  return {
+    now: vi.fn(() => NOW),
+    dispatcherId: "dispatcher-one",
+    leaseTtlSeconds: 120,
+    isDispatchEnabled: vi.fn(() => enabled),
+    isHalted: vi.fn(() => halted),
+    listDispatchable: vi.fn(async () => []),
+    saveTask: vi.fn(async () => undefined),
+    acquireLease: vi.fn(async () => true),
+    renewLease: vi.fn(async () => true),
+    releaseLease: vi.fn(async () => true),
+    claimDispatch: vi.fn(async () => undefined),
+    getRunBinding: vi.fn(async () => undefined),
+    bindRun: vi.fn(async () => undefined),
+    loadProfileManifest: vi.fn(async (profileId) => ({
+      profileId,
+      strategies: ["direct_execution"],
+      capabilities: [],
+    })),
+    prepareWorkspace: vi.fn(async () => "/workspace"),
+    writeIntentArtifact: vi.fn(async () => "/intent.json"),
+    controlPort: {
+      submit: vi.fn(async (runId) => runId),
+      cancel: vi.fn(async () => undefined),
+    },
+    recordDecision: vi.fn(async () => undefined),
+  };
+}
+
+function heartbeats(deps: DispatcherProcessDeps): DispatcherHeartbeat[] {
+  return vi.mocked(deps.writeHeartbeat).mock.calls.map(([heartbeat]) =>
+    heartbeat);
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}

--- a/test/unit/profile-manifest.test.ts
+++ b/test/unit/profile-manifest.test.ts
@@ -1,0 +1,213 @@
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  loadProfileManifest,
+  ProfileManifestError,
+  VETTED_CAPABILITIES,
+} from "../../services/harness-dispatcher/src/profile-manifest.js";
+
+const PILOT_CAPABILITIES = [
+  "fs.read_file",
+  "fs.write_file",
+  "fs.list_files",
+  "shell.run",
+  "git.status",
+  "git.diff",
+  "artifact.put",
+  "artifact.get",
+];
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("pinned Harness profile manifests", () => {
+  it("loads the real profile strategies and vetted capability metadata", async () => {
+    const fixture = await profileFixture(validProfile());
+
+    const manifest = await loadProfileManifest("pilot", fixture.environment);
+
+    expect(manifest).toEqual({
+      profileId: "pilot",
+      strategies: ["direct_execution"],
+      capabilities: [
+        { id: "fs.read_file", effectClass: "none", delegable: false },
+        { id: "fs.write_file", effectClass: "local", delegable: false },
+        { id: "fs.list_files", effectClass: "none", delegable: false },
+        { id: "shell.run", effectClass: "local", delegable: false },
+        { id: "git.status", effectClass: "none", delegable: false },
+        { id: "git.diff", effectClass: "none", delegable: false },
+        { id: "artifact.put", effectClass: "local", delegable: false },
+        { id: "artifact.get", effectClass: "none", delegable: false },
+      ],
+    });
+    expect(Object.isFrozen(VETTED_CAPABILITIES)).toBe(true);
+    expect(() => {
+      (VETTED_CAPABILITIES as Map<string, unknown>).set(
+        "network.fetch",
+        {},
+      );
+    }).toThrow("Vetted capability registry is immutable");
+  });
+
+  it("fails closed on an unvetted capability id", async () => {
+    const fixture = await profileFixture(
+      validProfile(["fs.read_file", "network.fetch"]),
+    );
+
+    await expectProfileError(
+      loadProfileManifest("pilot", fixture.environment),
+      "unvetted_capability",
+    );
+  });
+
+  it("fails closed on a capability marked delegable", async () => {
+    const fixture = await profileFixture([
+      "name: pilot",
+      "capabilities:",
+      "  - {id: fs.read_file, delegable: true}",
+      "strategies: [direct_execution]",
+      "",
+    ].join("\n"));
+
+    await expectProfileError(
+      loadProfileManifest("pilot", fixture.environment),
+      "delegable_capability",
+    );
+  });
+
+  it("fails closed on plan_execute or any non-direct strategy set", async () => {
+    const fixture = await profileFixture(
+      validProfile(PILOT_CAPABILITIES, [
+        "direct_execution",
+        "plan_execute",
+      ]),
+    );
+
+    await expectProfileError(
+      loadProfileManifest("pilot", fixture.environment),
+      "invalid_strategy",
+    );
+  });
+
+  it.each(["../pilot", "nested/pilot", "pilot..backup"])(
+    "fails closed on traversal-shaped profile id %s",
+    async (profileId) => {
+      await expectProfileError(
+        loadProfileManifest(profileId, {
+          HARNESS_PROFILES_ROOT: "/profiles",
+        }),
+        "invalid_profile_id",
+      );
+    },
+  );
+
+  it("fails closed when HARNESS_PROFILES_ROOT is missing", async () => {
+    await expectProfileError(
+      loadProfileManifest("pilot", {}),
+      "missing_profiles_root",
+    );
+  });
+
+  it("distinguishes an unreadable profile from malformed content", async () => {
+    const root = await temporaryRoot();
+    await expectProfileError(
+      loadProfileManifest("missing", {
+        HARNESS_PROFILES_ROOT: root,
+      }),
+      "profile_unreadable",
+    );
+  });
+
+  it("fails closed on malformed YAML", async () => {
+    const fixture = await profileFixture("capabilities: [");
+
+    await expectProfileError(
+      loadProfileManifest("pilot", fixture.environment),
+      "profile_malformed",
+    );
+  });
+
+  it("fails closed when the raw profile bytes do not match the SHA-256 pin", async () => {
+    const fixture = await profileFixture(validProfile());
+
+    await expectProfileError(
+      loadProfileManifest("pilot", {
+        ...fixture.environment,
+        HARNESS_PROFILE_SHA256: "0".repeat(64),
+      }),
+      "profile_hash_mismatch",
+    );
+  });
+
+  it("accepts a matching raw-byte SHA-256 pin", async () => {
+    const yaml = validProfile();
+    const fixture = await profileFixture(yaml);
+    const hash = createHash("sha256").update(yaml, "utf8").digest("hex");
+
+    await expect(loadProfileManifest("pilot", {
+      ...fixture.environment,
+      HARNESS_PROFILE_SHA256: `sha256:${hash}`,
+    })).resolves.toMatchObject({ profileId: "pilot" });
+  });
+});
+
+function validProfile(
+  capabilities = PILOT_CAPABILITIES,
+  strategies = ["direct_execution"],
+): string {
+  return [
+    "name: pilot",
+    "capabilities:",
+    ...capabilities.map((capability) => `  - ${capability}`),
+    `strategies: [${strategies.join(", ")}]`,
+    "",
+  ].join("\n");
+}
+
+async function profileFixture(
+  yaml: string,
+): Promise<{
+  environment: Readonly<Record<string, string | undefined>>;
+}> {
+  const root = await temporaryRoot();
+  const directory = path.join(root, "pilot");
+  await mkdir(directory, { recursive: true });
+  await writeFile(path.join(directory, "profile.yaml"), yaml, "utf8");
+  return { environment: { HARNESS_PROFILES_ROOT: root } };
+}
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-profile-test-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+async function expectProfileError(
+  promise: Promise<unknown>,
+  reason: ProfileManifestError["reason"],
+): Promise<void> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(ProfileManifestError);
+    expect((error as ProfileManifestError).reason).toBe(reason);
+    return;
+  }
+  throw new Error(`Expected profile manifest failure: ${reason}`);
+}


### PR DESCRIPTION
## What changed

- Added a fail-closed loader for the real pinned Harness `profile.yaml`, including an immutable eight-capability allowlist, direct-execution-only enforcement, traversal rejection, delegable/unvetted capability rejection, and optional raw-byte SHA-256 verification.
- Added the dedicated dispatcher process entry point that wires the already-landed INT-2 store/claim/outbox/decision/workspace/control components into unchanged `runSingleDispatch` logic.
- Added non-overlapping, completion-scheduled ticks; honest disabled/halted/idle/dispatching/error heartbeats; bounded startup configuration; canonical intent artifact writes; outcome logging; and graceful SIGINT/SIGTERM shutdown.
- Added the `harness-dispatcher` Compose service behind the non-default `dispatch` profile, with `HARNESS_DISPATCH_ENABLED=false` by default and no Slack, GitHub-write, wallet, or signing credentials.
- Updated the Agent roles invariant and documented the dormant dispatcher environment.
- Added profile-loader and process-factory unit coverage without real timers, databases, Harness calls, or git operations.

`runSingleDispatch` and the landed dispatch logic are unchanged. This PR adds no board/projection path and no proposal writer.

## Checks run

- `npm run typecheck` — exit 0
- `npx tsc -b services/harness-dispatcher --pretty false` — exit 0
- `npx vitest run test/unit/profile-manifest.test.ts test/unit/dispatcher-process.test.ts` — 22 passed
- `npm test -- --maxWorkers=1 --minWorkers=1` — 189 files passed, 2,300 tests passed; 1 integration file / 4 Postgres tests skipped as expected
- `docker build --file ops/Dockerfile.node --tag averray-reference-agent:int2h-check .` — exit 0
- `docker compose --env-file ops/.env.example --file ops/compose.yml config --quiet` — exit 0
- Default Compose service audit — dispatcher absent
- `docker compose ... --profile dispatch config --services` — dispatcher present
- `git diff --check` — exit 0

Local parallel `npm test` exposed an unrelated existing race twice in `test/unit/testbed-live-screencast.test.ts` (manifest temporarily read as absent). That test passes alone and the complete single-worker suite is green; no screencast code is changed in this narrow PR.

## Affected surfaces

- Backend: dispatcher process, profile loader, dependency metadata
- Operations: dormant Compose service/profile, workspace volume permissions, example environment
- Documentation: Agent role invariant
- Tests: dispatcher process and profile manifest
- Frontend/indexer/Caddy/contracts/public site: unaffected
- Database migrations: none

## Authority, rollout, and rollback

The Compose service is behind a non-default profile and `HARNESS_DISPATCH_ENABLED` defaults to `false`. Normal Compose startup does not include it. Disabled ticks perform no store or Harness call, and the heartbeat reports `disabled`; it never overstates liveness while disabled or halted.

Enabling dispatch remains a separate operator action after provisioning a pinned Harness CLI, isolated `HARNESS_DATABASE_URL`, exact pilot profile root, and profile SHA-256. The dispatcher is concurrency-one, honors `HALT_FILE`, and acts only on operator-approved, hash-pinned AgentTasks. It cannot approve, deny, release, merge, deploy, or open a PR.

Rollback is to leave the profile unselected / flag false or revert this additive PR. No migration or data rollback is required.