### PR TITLE
feat(harness): add AgentTask proposal writer and operator approval

### DIFF
--- a/packages/averray-mcp/package.json
+++ b/packages/averray-mcp/package.json
@@ -65,6 +65,10 @@
       "types": "./dist/agent-task-store.d.ts",
       "import": "./dist/agent-task-store.js"
     },
+    "./agent-task-proposal": {
+      "types": "./dist/agent-task-proposal.d.ts",
+      "import": "./dist/agent-task-proposal.js"
+    },
     "./dispatch-claim": {
       "types": "./dist/dispatch-claim.d.ts",
       "import": "./dist/dispatch-claim.js"

--- a/packages/averray-mcp/src/agent-task-proposal.ts
+++ b/packages/averray-mcp/src/agent-task-proposal.ts
@@ -1,0 +1,364 @@
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+import { assertNoKillSwitch } from "@avg/mcp-common";
+import {
+  actorRefSchema,
+  agentTaskV1Schema,
+  artifactRefSchema,
+  canonicalContractJson,
+  hashAgentTaskApprovalPayload,
+  hashCanonicalContract,
+  integrationIdSchema,
+  type AcceptanceCriterion,
+  type ActorRef,
+  type AgentTaskV1,
+  type ArtifactRef,
+} from "@avg/schemas";
+
+import {
+  getAgentTask,
+  putAgentTask,
+} from "./agent-task-store.js";
+import {
+  buildTaskIntentArtifact,
+} from "./task-intent-mapping.js";
+import {
+  workspacePathForTask,
+} from "./workspace-path.js";
+
+const PLACEHOLDER_HASH =
+  `sha256:${"0".repeat(64)}` as const;
+
+export const PILOT_CAPABILITY_IDS = Object.freeze([
+  "fs.read_file",
+  "fs.write_file",
+  "fs.list_files",
+  "shell.run",
+  "git.status",
+  "git.diff",
+  "artifact.put",
+  "artifact.get",
+] as const);
+
+export type AgentTaskRequester = Omit<ActorRef, "type"> & {
+  type: "operator" | "hermes" | "averray";
+};
+
+export interface ProposeAgentTaskInput {
+  workItemId: string;
+  taskVersion?: number;
+  correlationId: string;
+  taskKind: string;
+  title: string;
+  objective: string;
+  whyNow: string;
+  requestedBy: AgentTaskRequester;
+  repository: {
+    nameWithOwner: string;
+    baseRevision: string;
+    allowedPaths: string[];
+    forbiddenPaths: string[];
+  };
+  profile: string;
+  acceptanceCriteria: AcceptanceCriterion[];
+  budget: {
+    elapsedSeconds: number;
+    modelTokens: number;
+    toolCalls: number;
+    estimatedUsdMicros: number | null;
+  };
+  deadline: string;
+  riskTier?: "low" | "medium";
+  selectionReason: string;
+}
+
+export type AgentTaskArtifactWriter = (
+  bytes: string,
+) => Promise<ArtifactRef>;
+
+export interface ProposeAgentTaskDeps {
+  policyConfig: unknown;
+  policyVersion: string;
+  now?: () => Date;
+  assertMutationAllowed?: (operation: string) => Promise<void>;
+  writeArtifact?: AgentTaskArtifactWriter;
+  putTask?: (task: AgentTaskV1) => Promise<AgentTaskV1>;
+  environment?: Readonly<Record<string, string | undefined>>;
+}
+
+export interface ApproveAgentTaskInput {
+  workItemId: string;
+  taskVersion: number;
+  actor: ActorRef;
+}
+
+export interface ApproveAgentTaskDeps {
+  now?: () => Date;
+  assertMutationAllowed?: (operation: string) => Promise<void>;
+  getTask?: (
+    workItemId: string,
+    taskVersion: number,
+  ) => Promise<AgentTaskV1 | undefined>;
+  putTask?: (task: AgentTaskV1) => Promise<AgentTaskV1>;
+}
+
+export async function dispatchPolicyIdentity(
+  config: unknown,
+  version: string,
+): Promise<{
+  policyVersion: string;
+  policyHash: `sha256:${string}`;
+}> {
+  return {
+    policyVersion: integrationIdSchema.parse(version),
+    policyHash: await hashCanonicalContract(config),
+  };
+}
+
+export async function proposeAgentTask(
+  input: ProposeAgentTaskInput,
+  deps: ProposeAgentTaskDeps,
+): Promise<AgentTaskV1> {
+  await (deps.assertMutationAllowed ?? assertNoKillSwitch)(
+    "agent_task_propose",
+  );
+  const proposedAt = nowIso(deps.now);
+  const deadlineMs = Date.parse(input.deadline);
+  if (!Number.isFinite(deadlineMs) || deadlineMs <= Date.parse(proposedAt)) {
+    throw new Error("AgentTask proposal deadline must be later than now");
+  }
+  const riskTier = input.riskTier ?? "low";
+  if (riskTier !== "low" && riskTier !== "medium") {
+    throw new Error("High-risk Harness tasks cannot be proposed");
+  }
+  const requestedBy = actorRefSchema.parse(input.requestedBy);
+  if (
+    requestedBy.type !== "operator"
+    && requestedBy.type !== "hermes"
+    && requestedBy.type !== "averray"
+  ) {
+    throw new Error(`${requestedBy.type} cannot request an AgentTask`);
+  }
+
+  const taskVersion = input.taskVersion ?? 1;
+  const policy = await dispatchPolicyIdentity(
+    deps.policyConfig,
+    deps.policyVersion,
+  );
+  const verifierPlanBytes = canonicalContractJson(
+    input.acceptanceCriteria,
+  );
+  const verifierPlanHash = await hashCanonicalContract(
+    input.acceptanceCriteria,
+  );
+  const verifierPlanRef = contentAddressedRef(verifierPlanHash);
+  const placeholderRef = contentAddressedRef(PLACEHOLDER_HASH);
+
+  const draft = agentTaskV1Schema.parse({
+    schemaVersion: 1,
+    kind: "agent_task",
+    workItemId: input.workItemId,
+    taskVersion,
+    correlationId: input.correlationId,
+    taskKind: input.taskKind,
+    lifecycle: "proposed",
+    proposal: {
+      title: input.title,
+      objective: input.objective,
+      whyNow: input.whyNow,
+      requestedBy,
+      createdAt: proposedAt,
+      sourceRefs: [],
+    },
+    repository: {
+      provider: "github",
+      ...input.repository,
+    },
+    intent: {
+      apiVersion: "harness/v1alpha1",
+      profile: input.profile,
+      templateRef: placeholderRef,
+      templateHash: PLACEHOLDER_HASH,
+    },
+    acceptance: {
+      criteria: input.acceptanceCriteria,
+      verifierPlanRef,
+      verifierPlanHash,
+    },
+    risk: {
+      tier: riskTier,
+      reasons: [input.whyNow],
+      irreversible: false,
+    },
+    requestedAuthority: {
+      grants: PILOT_CAPABILITY_IDS.map((capabilityId) => ({
+        capabilityId,
+        resource: input.repository.nameWithOwner,
+        constraints: {},
+      })),
+      network: "deny",
+      maxChildren: 0,
+      maxConcurrentChildren: 0,
+      delegable: false,
+    },
+    budget: input.budget,
+    deadline: input.deadline,
+    executor: {
+      kind: "harness",
+      selectionReason: input.selectionReason,
+    },
+    approval: {
+      required: "operator",
+      status: "pending",
+      ...policy,
+    },
+    timestamps: {
+      proposedAt,
+      updatedAt: proposedAt,
+    },
+  });
+
+  const intentArtifact = await buildTaskIntentArtifact(draft, {
+    workspacePath: workspacePathForTask(input.workItemId, taskVersion),
+  });
+  const templateRef = contentAddressedRef(intentArtifact.templateHash);
+  const task = agentTaskV1Schema.parse({
+    ...draft,
+    intent: {
+      ...draft.intent,
+      templateRef,
+      templateHash: intentArtifact.templateHash,
+    },
+  });
+
+  const writer = deps.writeArtifact
+    ?? ((bytes) =>
+      writeDispatchArtifact(bytes, deps.environment ?? process.env));
+  assertStoredArtifact(
+    await writer(verifierPlanBytes),
+    verifierPlanRef,
+  );
+  assertStoredArtifact(
+    await writer(intentArtifact.canonicalBytes),
+    templateRef,
+  );
+  return (deps.putTask ?? putAgentTask)(task);
+}
+
+export async function approveAgentTask(
+  input: ApproveAgentTaskInput,
+  deps: ApproveAgentTaskDeps = {},
+): Promise<AgentTaskV1> {
+  await (deps.assertMutationAllowed ?? assertNoKillSwitch)(
+    "agent_task_approve",
+  );
+  const actor = actorRefSchema.parse(input.actor);
+  if (actor.type !== "operator") {
+    throw new Error("Only an operator may approve an AgentTask");
+  }
+  const task = await (deps.getTask ?? getAgentTask)(
+    input.workItemId,
+    input.taskVersion,
+  );
+  if (!task) {
+    throw new Error("AgentTask approval target was not found");
+  }
+  if (
+    task.lifecycle !== "proposed"
+    || task.approval.status !== "pending"
+  ) {
+    throw new Error(
+      "AgentTask approval requires a proposed task with pending approval",
+    );
+  }
+  const decidedAt = nowIso(deps.now);
+  if (Date.parse(task.deadline) <= Date.parse(decidedAt)) {
+    throw new Error("Expired AgentTasks cannot be approved");
+  }
+
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(task);
+  const approved = agentTaskV1Schema.parse({
+    ...task,
+    lifecycle: "approved",
+    approval: {
+      ...task.approval,
+      status: "approved",
+      actor,
+      decidedAt,
+      approvedTaskHash,
+    },
+    timestamps: {
+      ...task.timestamps,
+      approvedAt: decidedAt,
+      updatedAt: decidedAt,
+    },
+  });
+  return (deps.putTask ?? putAgentTask)(approved);
+}
+
+export async function writeDispatchArtifact(
+  bytes: string,
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): Promise<ArtifactRef> {
+  const configuredRoot = environment.HARNESS_DISPATCH_ARTIFACT_DIR?.trim();
+  if (!configuredRoot) {
+    throw new Error("HARNESS_DISPATCH_ARTIFACT_DIR is required");
+  }
+  const hash = rawSha256(bytes);
+  const reference = contentAddressedRef(hash);
+  const root = path.resolve(configuredRoot);
+  const target = path.join(root, `${hash.slice("sha256:".length)}.json`);
+  await mkdir(root, { recursive: true });
+  try {
+    await writeFile(target, bytes, { encoding: "utf8", flag: "wx" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    const existing = await readFile(target, "utf8");
+    if (existing !== bytes) {
+      throw new Error("Content-addressed artifact bytes do not match");
+    }
+  }
+  return reference;
+}
+
+function contentAddressedRef(
+  hash: `sha256:${string}`,
+): ArtifactRef {
+  return artifactRefSchema.parse({
+    uri: `artifact://sha256/${hash.slice("sha256:".length)}`,
+    sha256: hash,
+  });
+}
+
+function assertStoredArtifact(
+  actualInput: ArtifactRef,
+  expected: ArtifactRef,
+): void {
+  const actual = artifactRefSchema.parse(actualInput);
+  if (
+    actual.uri !== expected.uri
+    || actual.sha256 !== expected.sha256
+  ) {
+    throw new Error(
+      "Artifact writer returned a different content address",
+    );
+  }
+}
+
+function rawSha256(bytes: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes, "utf8").digest("hex")}`;
+}
+
+function nowIso(now: (() => Date) | undefined): string {
+  const value = (now ?? (() => new Date()))();
+  if (!Number.isFinite(value.getTime())) {
+    throw new Error("AgentTask clock returned an invalid date");
+  }
+  return value.toISOString();
+}

--- a/test/fixtures/agent-integration/ceremony/add-unit-test.json
+++ b/test/fixtures/agent-integration/ceremony/add-unit-test.json
@@ -1,0 +1,51 @@
+{
+  "workItemId": "ceremony-add-unit-test-001",
+  "correlationId": "ceremony-add-unit-test-001",
+  "taskKind": "add_unit_test",
+  "title": "Add one focused unit regression test",
+  "objective": "Add a narrowly scoped unit test for an existing behavior without changing production authority.",
+  "whyNow": "The supervised-dispatch ceremony needs a test-writing family with measurable regression evidence.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-reference-agent",
+    "baseRevision": "8b94278578913b7cd7aa1acb276db48613090c7b",
+    "allowedPaths": [
+      "docs/**",
+      "test/**"
+    ],
+    "forbiddenPaths": [
+      "contracts/**",
+      "ops/**",
+      "scripts/ops/**",
+      ".github/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "unit-test-command",
+      "type": "command",
+      "command": "npm test",
+      "required": true
+    },
+    {
+      "id": "unit-test-baseline",
+      "type": "baseline_comparison",
+      "rule": "no_new_failures",
+      "baselineCommand": "npm test",
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 120,
+    "modelTokens": 12000,
+    "toolCalls": 50,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "A test-only change is reversible and independently verifiable."
+}

--- a/test/fixtures/agent-integration/ceremony/docs-fix.json
+++ b/test/fixtures/agent-integration/ceremony/docs-fix.json
@@ -1,0 +1,54 @@
+{
+  "workItemId": "ceremony-docs-fix-001",
+  "correlationId": "ceremony-docs-fix-001",
+  "taskKind": "docs_fix",
+  "title": "Clarify one bounded integration document",
+  "objective": "Correct a small documentation inconsistency and keep the surrounding guidance accurate.",
+  "whyNow": "The supervised-dispatch ceremony needs a reversible documentation-family task.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-reference-agent",
+    "baseRevision": "8b94278578913b7cd7aa1acb276db48613090c7b",
+    "allowedPaths": [
+      "docs/**",
+      "test/**"
+    ],
+    "forbiddenPaths": [
+      "contracts/**",
+      "ops/**",
+      "scripts/ops/**",
+      ".github/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "docs-command",
+      "type": "command",
+      "command": "npm run typecheck",
+      "required": true
+    },
+    {
+      "id": "docs-search",
+      "type": "search",
+      "include": [
+        "docs/**"
+      ],
+      "pattern": "supervised",
+      "expectedMatches": 1,
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 120,
+    "modelTokens": 10000,
+    "toolCalls": 40,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "A bounded documentation edit is suitable for the supervised Harness pilot."
+}

--- a/test/fixtures/agent-integration/ceremony/lint-format.json
+++ b/test/fixtures/agent-integration/ceremony/lint-format.json
@@ -1,0 +1,44 @@
+{
+  "workItemId": "ceremony-lint-format-001",
+  "correlationId": "ceremony-lint-format-001",
+  "taskKind": "lint_format",
+  "title": "Repair one bounded formatting defect",
+  "objective": "Correct a small formatting-only defect within the pilot path allowlist.",
+  "whyNow": "The supervised-dispatch ceremony needs a minimal lint and formatting family.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-reference-agent",
+    "baseRevision": "8b94278578913b7cd7aa1acb276db48613090c7b",
+    "allowedPaths": [
+      "docs/**",
+      "test/**"
+    ],
+    "forbiddenPaths": [
+      "contracts/**",
+      "ops/**",
+      "scripts/ops/**",
+      ".github/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "format-command",
+      "type": "command",
+      "command": "git diff --check",
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 60,
+    "modelTokens": 8000,
+    "toolCalls": 30,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "A formatting-only task is the narrowest reversible Harness ceremony case."
+}

--- a/test/fixtures/agent-integration/ceremony/small-refactor.json
+++ b/test/fixtures/agent-integration/ceremony/small-refactor.json
@@ -1,0 +1,51 @@
+{
+  "workItemId": "ceremony-small-refactor-001",
+  "correlationId": "ceremony-small-refactor-001",
+  "taskKind": "small_refactor",
+  "title": "Perform one behavior-preserving test helper refactor",
+  "objective": "Simplify a small test helper while preserving observable behavior and the existing test baseline.",
+  "whyNow": "The supervised-dispatch ceremony needs a bounded refactor family with explicit no-regression evidence.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-reference-agent",
+    "baseRevision": "8b94278578913b7cd7aa1acb276db48613090c7b",
+    "allowedPaths": [
+      "docs/**",
+      "test/**"
+    ],
+    "forbiddenPaths": [
+      "contracts/**",
+      "ops/**",
+      "scripts/ops/**",
+      ".github/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "refactor-command",
+      "type": "command",
+      "command": "npm run typecheck",
+      "required": true
+    },
+    {
+      "id": "refactor-baseline",
+      "type": "baseline_comparison",
+      "rule": "no_new_failures",
+      "baselineCommand": "npm test",
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 120,
+    "modelTokens": 14000,
+    "toolCalls": 60,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "A test-surface refactor is bounded, reversible, and baseline-gated."
+}

--- a/test/unit/agent-task-proposal.test.ts
+++ b/test/unit/agent-task-proposal.test.ts
@@ -1,0 +1,651 @@
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  approveAgentTask,
+  dispatchPolicyIdentity,
+  PILOT_CAPABILITY_IDS,
+  proposeAgentTask,
+  type AgentTaskArtifactWriter,
+  type ProposeAgentTaskDeps,
+  type ProposeAgentTaskInput,
+} from "../../packages/averray-mcp/src/agent-task-proposal.js";
+import {
+  listDispatchableAgentTasks,
+  type AgentTaskStoreQuery,
+} from "../../packages/averray-mcp/src/agent-task-store.js";
+import {
+  buildTaskIntentArtifact,
+} from "../../packages/averray-mcp/src/task-intent-mapping.js";
+import {
+  workspacePathForTask,
+} from "../../packages/averray-mcp/src/workspace-path.js";
+import {
+  agentTaskApprovalHashMatches,
+  agentTaskV1Schema,
+  canonicalContractJson,
+  serializeTaskIntent,
+  type AgentTaskV1,
+  type ArtifactRef,
+} from "../../packages/schemas/src/index.js";
+import {
+  VETTED_CAPABILITIES,
+} from "../../services/harness-dispatcher/src/profile-manifest.js";
+
+const NOW = new Date("2026-07-25T14:00:00.000Z");
+const APPROVED_AT = new Date("2026-07-25T14:05:00.000Z");
+const POLICY_CONFIG = {
+  allowedRepos: ["depre-dev/averray-reference-agent"],
+  allowedRiskTiers: ["low", "medium"],
+  requireOperatorApproval: true,
+};
+const CEREMONY_FIXTURES = [
+  "docs-fix",
+  "add-unit-test",
+  "small-refactor",
+  "lint-format",
+] as const;
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("AgentTask proposal authoring", () => {
+  it("persists a pending, deny-network proposal with pinned audit artifacts and pilot authority", async () => {
+    const store = new MemoryTaskStore();
+    const artifacts = new MemoryArtifactStore();
+
+    const task = await proposeAgentTask(
+      proposalInput(),
+      proposalDeps(store, artifacts),
+    );
+
+    expect(agentTaskV1Schema.parse(task)).toEqual(task);
+    expect(store.get(task.workItemId, task.taskVersion)).toEqual(task);
+    expect(task).toMatchObject({
+      schemaVersion: 1,
+      kind: "agent_task",
+      taskVersion: 1,
+      lifecycle: "proposed",
+      risk: {
+        tier: "low",
+        irreversible: false,
+      },
+      requestedAuthority: {
+        network: "deny",
+        maxChildren: 0,
+        maxConcurrentChildren: 0,
+        delegable: false,
+      },
+      executor: {
+        kind: "harness",
+      },
+      approval: {
+        required: "operator",
+        status: "pending",
+        policyVersion: "dispatch-policy-v1",
+      },
+    });
+    expect(task.approval).not.toHaveProperty("approvedTaskHash");
+    expect(task.requestedAuthority.grants.map(({ capabilityId }) =>
+      capabilityId)).toEqual([...PILOT_CAPABILITY_IDS]);
+    expect(task.intent.templateRef.sha256).toBe(task.intent.templateHash);
+    expect(task.acceptance.verifierPlanRef.sha256).toBe(
+      task.acceptance.verifierPlanHash,
+    );
+    expect(artifacts.refs).toEqual([
+      task.acceptance.verifierPlanRef,
+      task.intent.templateRef,
+    ]);
+  });
+
+  it("maps byte-identical TaskIntents for different valid placeholder hashes", async () => {
+    const store = new MemoryTaskStore();
+    const task = await proposeAgentTask(
+      proposalInput(),
+      proposalDeps(store, new MemoryArtifactStore()),
+    );
+    const firstHash = `sha256:${"1".repeat(64)}` as const;
+    const secondHash = `sha256:${"2".repeat(64)}` as const;
+    const first = agentTaskV1Schema.parse({
+      ...task,
+      intent: {
+        ...task.intent,
+        templateHash: firstHash,
+        templateRef: contentRef(firstHash),
+      },
+    });
+    const second = agentTaskV1Schema.parse({
+      ...task,
+      intent: {
+        ...task.intent,
+        templateHash: secondHash,
+        templateRef: contentRef(secondHash),
+      },
+    });
+    const workspacePath = workspacePathForTask(
+      task.workItemId,
+      task.taskVersion,
+    );
+
+    const firstBytes = serializeTaskIntent(
+      (await buildTaskIntentArtifact(first, { workspacePath })).intent,
+    );
+    const secondBytes = serializeTaskIntent(
+      (await buildTaskIntentArtifact(second, { workspacePath })).intent,
+    );
+
+    expect(firstBytes).toBe(secondBytes);
+    expect(JSON.parse(firstBytes)).not.toHaveProperty(
+      "spec.intent.templateHash",
+    );
+  });
+
+  it("uses an explicit newer task version in the persisted task and workspace identity", async () => {
+    const task = await proposeAgentTask({
+      ...proposalInput(),
+      taskVersion: 2,
+    }, proposalDeps(
+      new MemoryTaskStore(),
+      new MemoryArtifactStore(),
+    ));
+    const workspacePath = workspacePathForTask(
+      task.workItemId,
+      task.taskVersion,
+    );
+    const built = await buildTaskIntentArtifact(task, { workspacePath });
+
+    expect(task.taskVersion).toBe(2);
+    expect(built.intent.metadata.labels.task_version).toBe("2");
+    expect(built.intent.spec.context.workspace.path).toBe(
+      "/var/lib/harness-dispatcher/workspaces/proposal-work-001-v2",
+    );
+  });
+
+  it("changes the policy hash whenever the bound policy config changes", async () => {
+    const first = await dispatchPolicyIdentity(
+      POLICY_CONFIG,
+      "dispatch-policy-v1",
+    );
+    const second = await dispatchPolicyIdentity(
+      { ...POLICY_CONFIG, allowedRiskTiers: ["low"] },
+      "dispatch-policy-v1",
+    );
+
+    expect(first.policyVersion).toBe(second.policyVersion);
+    expect(first.policyHash).not.toBe(second.policyHash);
+  });
+
+  it("writes default artifacts content-addressed and treats identical rewrites as no-ops", async () => {
+    const root = await temporaryRoot("agent-task-artifacts-");
+    const store = new MemoryTaskStore();
+    const deps: ProposeAgentTaskDeps = {
+      policyConfig: POLICY_CONFIG,
+      policyVersion: "dispatch-policy-v1",
+      now: () => NOW,
+      assertMutationAllowed: async () => undefined,
+      putTask: store.put,
+      environment: {
+        HARNESS_DISPATCH_ARTIFACT_DIR: root,
+      },
+    };
+
+    const first = await proposeAgentTask(proposalInput(), deps);
+    const second = await proposeAgentTask(proposalInput(), deps);
+    const files = (await readdir(root)).sort();
+
+    expect(second).toEqual(first);
+    expect(files).toEqual([
+      `${first.acceptance.verifierPlanHash.slice("sha256:".length)}.json`,
+      `${first.intent.templateHash.slice("sha256:".length)}.json`,
+    ].sort());
+    await expect(readFile(
+      path.join(
+        root,
+        `${first.acceptance.verifierPlanHash.slice("sha256:".length)}.json`,
+      ),
+      "utf8",
+    )).resolves.toBe(canonicalContractJson(
+      proposalInput().acceptanceCriteria,
+    ));
+  });
+
+  it("refuses high risk and a deadline that is not later than now", async () => {
+    const store = new MemoryTaskStore();
+    const artifacts = new MemoryArtifactStore();
+    const deps = proposalDeps(store, artifacts);
+
+    await expect(proposeAgentTask({
+      ...proposalInput(),
+      riskTier: "high",
+    } as unknown as ProposeAgentTaskInput, deps)).rejects.toThrow(
+      "High-risk Harness tasks cannot be proposed",
+    );
+    await expect(proposeAgentTask({
+      ...proposalInput(),
+      deadline: NOW.toISOString(),
+    }, deps)).rejects.toThrow(
+      "deadline must be later than now",
+    );
+    expect(store.size).toBe(0);
+    expect(artifacts.refs).toEqual([]);
+  });
+
+  it.each(["harness", "verifier", "dispatcher"] as const)(
+    "refuses a requestedBy actor of type %s",
+    async (type) => {
+      const store = new MemoryTaskStore();
+      await expect(proposeAgentTask({
+        ...proposalInput(),
+        requestedBy: { type, id: `${type}-one` },
+      } as unknown as ProposeAgentTaskInput, proposalDeps(
+        store,
+        new MemoryArtifactStore(),
+      ))).rejects.toThrow(`${type} cannot request an AgentTask`);
+      expect(store.size).toBe(0);
+    },
+  );
+
+  it("keeps the proposal capability list identical to the vetted profile registry", () => {
+    expect([...PILOT_CAPABILITY_IDS]).toEqual([
+      ...VETTED_CAPABILITIES.keys(),
+    ]);
+  });
+
+  it("honors HALT before proposal or approval persistence", async () => {
+    const store = new MemoryTaskStore();
+    const halted = async (): Promise<void> => {
+      throw new Error("Kill switch active");
+    };
+    await expect(proposeAgentTask(
+      proposalInput(),
+      {
+        ...proposalDeps(store, new MemoryArtifactStore()),
+        assertMutationAllowed: halted,
+      },
+    )).rejects.toThrow("Kill switch active");
+    expect(store.size).toBe(0);
+
+    const proposed = await proposeAgentTask(
+      proposalInput(),
+      proposalDeps(store, new MemoryArtifactStore()),
+    );
+    await expect(approveAgentTask({
+      workItemId: proposed.workItemId,
+      taskVersion: proposed.taskVersion,
+      actor: { type: "operator", id: "pilot-operator" },
+    }, {
+      ...approvalDeps(store),
+      assertMutationAllowed: halted,
+    })).rejects.toThrow("Kill switch active");
+    expect(store.get(
+      proposed.workItemId,
+      proposed.taskVersion,
+    )?.lifecycle).toBe("proposed");
+  });
+});
+
+describe("explicit operator approval", () => {
+  it("hash-binds one task and makes only that task dispatchable", async () => {
+    const store = new MemoryTaskStore();
+    const proposed = await proposeAgentTask(
+      proposalInput(),
+      proposalDeps(store, new MemoryArtifactStore()),
+    );
+
+    const approved = await approveAgentTask({
+      workItemId: proposed.workItemId,
+      taskVersion: proposed.taskVersion,
+      actor: { type: "operator", id: "pilot-operator" },
+    }, approvalDeps(store));
+
+    expect(approved).toMatchObject({
+      lifecycle: "approved",
+      approval: {
+        required: "operator",
+        status: "approved",
+        actor: { type: "operator", id: "pilot-operator" },
+        decidedAt: APPROVED_AT.toISOString(),
+        approvedTaskHash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      },
+      timestamps: {
+        approvedAt: APPROVED_AT.toISOString(),
+        updatedAt: APPROVED_AT.toISOString(),
+      },
+    });
+    await expect(agentTaskApprovalHashMatches(approved)).resolves.toBe(true);
+    await expect(listDispatchableAgentTasks({
+      query: store.query,
+    })).resolves.toEqual([approved]);
+  });
+
+  it("refuses a non-operator, a second approval, and an expired task", async () => {
+    const store = new MemoryTaskStore();
+    const proposed = await proposeAgentTask(
+      proposalInput(),
+      proposalDeps(store, new MemoryArtifactStore()),
+    );
+
+    await expect(approveAgentTask({
+      workItemId: proposed.workItemId,
+      taskVersion: proposed.taskVersion,
+      actor: { type: "hermes", id: "hermes-one" },
+    }, approvalDeps(store))).rejects.toThrow(
+      "Only an operator may approve",
+    );
+
+    await approveAgentTask({
+      workItemId: proposed.workItemId,
+      taskVersion: proposed.taskVersion,
+      actor: { type: "operator", id: "pilot-operator" },
+    }, approvalDeps(store));
+    await expect(approveAgentTask({
+      workItemId: proposed.workItemId,
+      taskVersion: proposed.taskVersion,
+      actor: { type: "operator", id: "pilot-operator" },
+    }, approvalDeps(store))).rejects.toThrow(
+      "requires a proposed task with pending approval",
+    );
+
+    const expiringStore = new MemoryTaskStore();
+    const expiring = await proposeAgentTask({
+      ...proposalInput(),
+      workItemId: "expiring-task",
+      correlationId: "expiring-task",
+      deadline: "2026-07-25T14:01:00.000Z",
+    }, proposalDeps(expiringStore, new MemoryArtifactStore()));
+    await expect(approveAgentTask({
+      workItemId: expiring.workItemId,
+      taskVersion: expiring.taskVersion,
+      actor: { type: "operator", id: "pilot-operator" },
+    }, {
+      ...approvalDeps(expiringStore),
+      now: () => new Date("2026-07-25T14:01:00.000Z"),
+    })).rejects.toThrow("Expired AgentTasks cannot be approved");
+  });
+
+  it("invalidates approval after every material proposal field mutation", async () => {
+    const store = new MemoryTaskStore();
+    const proposed = await proposeAgentTask(
+      proposalInput(),
+      proposalDeps(store, new MemoryArtifactStore()),
+    );
+    const approved = await approveAgentTask({
+      workItemId: proposed.workItemId,
+      taskVersion: proposed.taskVersion,
+      actor: { type: "operator", id: "pilot-operator" },
+    }, approvalDeps(store));
+    const mutations: AgentTaskV1[] = [
+      {
+        ...approved,
+        proposal: {
+          ...approved.proposal,
+          objective: "A materially different objective.",
+        },
+      },
+      {
+        ...approved,
+        repository: {
+          ...approved.repository,
+          allowedPaths: [...approved.repository.allowedPaths, "packages/**"],
+        },
+      },
+      {
+        ...approved,
+        budget: {
+          ...approved.budget,
+          elapsedSeconds: approved.budget.elapsedSeconds + 1,
+        },
+      },
+      {
+        ...approved,
+        requestedAuthority: {
+          ...approved.requestedAuthority,
+          grants: approved.requestedAuthority.grants.map((grant, index) =>
+            index === 0
+              ? { ...grant, constraints: { mode: "read_only" } }
+              : grant),
+        },
+      },
+      {
+        ...approved,
+        deadline: "2028-01-01T00:00:00.000Z",
+      },
+      {
+        ...approved,
+        intent: {
+          ...approved.intent,
+          profile: "different-pilot-profile",
+        },
+      },
+    ].map((task) => agentTaskV1Schema.parse(task));
+
+    for (const mutation of mutations) {
+      await expect(agentTaskApprovalHashMatches(mutation))
+        .resolves.toBe(false);
+    }
+  });
+});
+
+describe("pilot ceremony proposal fixtures", () => {
+  it.each(CEREMONY_FIXTURES)(
+    "proposes the %s family with the exact dispatcher workspace path",
+    async (name) => {
+      const input = await ceremonyFixture(name);
+      const store = new MemoryTaskStore();
+      const task = await proposeAgentTask(
+        input,
+        proposalDeps(store, new MemoryArtifactStore()),
+      );
+      const expectedWorkspace = workspacePathForTask(
+        task.workItemId,
+        task.taskVersion,
+      );
+      const built = await buildTaskIntentArtifact(task, {
+        workspacePath: expectedWorkspace,
+      });
+
+      expect(agentTaskV1Schema.parse(task)).toEqual(task);
+      expect(task.risk.tier).toBe("low");
+      expect(task.requestedAuthority.network).toBe("deny");
+      expect(task.repository).toMatchObject({
+        nameWithOwner: "depre-dev/averray-reference-agent",
+        allowedPaths: ["docs/**", "test/**"],
+        forbiddenPaths: expect.arrayContaining([
+          "contracts/**",
+          "ops/**",
+          "scripts/ops/**",
+          ".github/**",
+        ]),
+      });
+      expect(built.intent.spec.context.workspace.path).toBe(
+        expectedWorkspace,
+      );
+      expect(built.templateHash).toBe(task.intent.templateHash);
+    },
+  );
+});
+
+function proposalInput(): ProposeAgentTaskInput {
+  return {
+    workItemId: "proposal-work-001",
+    correlationId: "proposal-correlation-001",
+    taskKind: "unit_test",
+    title: "Add a focused unit test",
+    objective: "Add one regression test for the approved behavior.",
+    whyNow: "The supervised pilot needs a bounded test-only task.",
+    requestedBy: {
+      type: "operator",
+      id: "pilot-operator",
+    },
+    repository: {
+      nameWithOwner: "depre-dev/averray-reference-agent",
+      baseRevision: "8b94278578913b7cd7aa1acb276db48613090c7b",
+      allowedPaths: ["docs/**", "test/**"],
+      forbiddenPaths: [
+        "contracts/**",
+        "ops/**",
+        "scripts/ops/**",
+        ".github/**",
+      ],
+    },
+    profile: "coding-change-pilot",
+    acceptanceCriteria: [
+      {
+        id: "test",
+        type: "command",
+        command: "npm test",
+        required: true,
+      },
+    ],
+    budget: {
+      elapsedSeconds: 120,
+      modelTokens: 10_000,
+      toolCalls: 40,
+      estimatedUsdMicros: null,
+    },
+    deadline: "2027-12-31T23:59:59.000Z",
+    selectionReason: "A test-only task is bounded and reversible.",
+  };
+}
+
+function proposalDeps(
+  store: MemoryTaskStore,
+  artifacts: MemoryArtifactStore,
+): ProposeAgentTaskDeps {
+  return {
+    policyConfig: POLICY_CONFIG,
+    policyVersion: "dispatch-policy-v1",
+    now: () => NOW,
+    assertMutationAllowed: async () => undefined,
+    writeArtifact: artifacts.write,
+    putTask: store.put,
+  };
+}
+
+function approvalDeps(
+  store: MemoryTaskStore,
+): {
+  now: () => Date;
+  getTask: (
+    workItemId: string,
+    taskVersion: number,
+  ) => Promise<AgentTaskV1 | undefined>;
+  putTask: (task: AgentTaskV1) => Promise<AgentTaskV1>;
+} {
+  return {
+    now: () => APPROVED_AT,
+    assertMutationAllowed: async () => undefined,
+    getTask: store.getTask,
+    putTask: store.put,
+  };
+}
+
+class MemoryArtifactStore {
+  readonly refs: ArtifactRef[] = [];
+  readonly bytes = new Map<string, string>();
+
+  readonly write: AgentTaskArtifactWriter = async (bytes) => {
+    const hash = rawHash(bytes);
+    const reference = contentRef(hash);
+    this.bytes.set(hash, bytes);
+    this.refs.push(reference);
+    return reference;
+  };
+}
+
+class MemoryTaskStore {
+  readonly tasks = new Map<string, AgentTaskV1>();
+
+  get size(): number {
+    return this.tasks.size;
+  }
+
+  get(workItemId: string, taskVersion: number): AgentTaskV1 | undefined {
+    return this.tasks.get(taskKey(workItemId, taskVersion));
+  }
+
+  readonly getTask = async (
+    workItemId: string,
+    taskVersion: number,
+  ): Promise<AgentTaskV1 | undefined> => {
+    const task = this.get(workItemId, taskVersion);
+    return task ? structuredClone(task) : undefined;
+  };
+
+  readonly put = async (
+    input: AgentTaskV1,
+  ): Promise<AgentTaskV1> => {
+    const task = agentTaskV1Schema.parse(input);
+    this.tasks.set(
+      taskKey(task.workItemId, task.taskVersion),
+      structuredClone(task),
+    );
+    return structuredClone(task);
+  };
+
+  readonly query: AgentTaskStoreQuery = async <T>(
+    text: string,
+  ): Promise<T[]> => {
+    if (!/from agent_tasks/i.test(text)) {
+      throw new Error("Unexpected memory store query");
+    }
+    return [...this.tasks.values()].map((task) => ({
+      work_item_id: task.workItemId,
+      task_version: task.taskVersion,
+      correlation_id: task.correlationId,
+      lifecycle: task.lifecycle,
+      executor_kind: task.executor.kind,
+      approved_task_hash: task.approval.approvedTaskHash ?? null,
+      deadline: task.deadline,
+      updated_at: task.timestamps.updatedAt,
+      task: structuredClone(task),
+    }) as T);
+  };
+}
+
+async function ceremonyFixture(
+  name: typeof CEREMONY_FIXTURES[number],
+): Promise<ProposeAgentTaskInput> {
+  return JSON.parse(await readFile(
+    new URL(
+      `../fixtures/agent-integration/ceremony/${name}.json`,
+      import.meta.url,
+    ),
+    "utf8",
+  )) as ProposeAgentTaskInput;
+}
+
+async function temporaryRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), prefix));
+  temporaryRoots.push(root);
+  return root;
+}
+
+function rawHash(bytes: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes, "utf8").digest("hex")}`;
+}
+
+function contentRef(hash: `sha256:${string}`): ArtifactRef {
+  return {
+    uri: `artifact://sha256/${hash.slice("sha256:".length)}`,
+    sha256: hash,
+  };
+}
+
+function taskKey(workItemId: string, taskVersion: number): string {
+  return `${workItemId}@${taskVersion}`;
+}


### PR DESCRIPTION
## What changed

- Added an exported AgentTask proposal library that authors schema-valid V1 tasks at lifecycle `proposed`, persists them through the landed store, and never attaches an approval hash.
- Resolved the TaskIntent hash circularity with a schema-valid placeholder, the landed `workspacePathForTask` mapping, canonical intent bytes, and a final content-addressed template reference.
- Added canonical, content-addressed audit artifacts for the verifier criteria and TaskIntent. The default writer uses `HARNESS_DISPATCH_ARTIFACT_DIR`, creates the directory, and treats identical rewrites as no-ops.
- Added stable dispatch-policy identity hashing and the exact eight-capability pilot grant list, with a drift guard against the dispatcher profile registry.
- Added the explicit one-task operator approval function. It refuses non-operator actors, non-pending/non-proposed tasks, expired deadlines, repeated approval, and computes the approval hash over the current material payload before persistence.
- Both proposal and approval persistence honor the existing global kill-switch guard.
- Added four low-risk ceremony input fixtures: docs fix, unit test, small refactor, and lint/format.

There is no auto-approval or policy-approval branch. Proposals land `proposed` only; one explicit operator call is required to make one task `approved` and dispatchable.

## Checks run

- `npm run typecheck` — exit 0
- `npx vitest run test/unit/agent-task-proposal.test.ts` — 18 passed
- `npm test` — 190 files passed, 2,318 tests passed; 1 integration file / 4 Postgres tests skipped as expected
- `docker build --file ops/Dockerfile.node --tag averray-reference-agent:int2i-check .` — exit 0
- `docker compose --env-file ops/.env.example --file ops/compose.yml config --quiet` — exit 0
- `docker compose --env-file ops/.env.example --file ops/compose.yml --file ops/compose.prod.yml config --quiet` — exit 0
- `git diff --check` — exit 0

## Affected surfaces

- Backend library: AgentTask proposal, artifact authoring, policy identity, and operator approval
- Package surface: new `@avg/averray-mcp/agent-task-proposal` export
- Tests/fixtures: focused unit suite and four ceremony families
- Dispatcher process, board/projection, proposal UI/API, ops/Compose, migrations, contracts, frontend, Caddy, workflows, and public site: unchanged
- Dependencies/lockfile: unchanged
- Secrets: none

## Authority, rollout, and rollback

This PR creates no production call site and changes no production authority. Dispatch remains behind the dormant non-default Compose profile and `HARNESS_DISPATCH_ENABLED=false`. Proposal creation does not approve or dispatch work; approval is operator-only, explicit, single-task, deadline-bound, and hash-bound. HALT prevents both proposal and approval persistence.

When a future operator-facing call site is wired, the operator must configure `HARNESS_DISPATCH_ARTIFACT_DIR`; this PR does not add that wiring or enable dispatch. Rollback is a code revert only: there are no migrations, runtime-service changes, or stored production records created by this PR.