### PR TITLE
fix(ops): unblock the mainnet flip + refuse balances from the wrong chain

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -93,7 +93,7 @@ services:
       TRACE_HTTP_URL: http://127.0.0.1:${TRACE_HTTP_PORT:-8789}/hermes-event
       POLICY_CONFIG_PATH: /config/policy.yaml
       HALT_FILE: ${HALT_FILE:-/data/HALT}
-      WALLET_NETWORK: testnet
+      WALLET_NETWORK: ${WALLET_NETWORK:-testnet}
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
@@ -147,7 +147,7 @@ services:
       AVERRAY_API_BASE_URL: ${AVERRAY_API_BASE_URL}
       AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
       HALT_FILE: ${HALT_FILE:-/data/HALT}
-      WALLET_NETWORK: testnet
+      WALLET_NETWORK: ${WALLET_NETWORK:-testnet}
       SLACK_OPERATOR_ENABLED: ${SLACK_OPERATOR_ENABLED:-0}
       SLACK_OPERATOR_HTTP_PORT: ${SLACK_OPERATOR_HTTP_PORT:-8790}
       SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-}
@@ -428,7 +428,7 @@ services:
       # Board citation_repair runs are read-only/dry-run; real claim/submit
       # settlement stays operator-gated in the hermes container. Testnet only.
       AGENT_WALLET_PRIVATE_KEY: ${AGENT_WALLET_PRIVATE_KEY}
-      WALLET_NETWORK: testnet
+      WALLET_NETWORK: ${WALLET_NETWORK:-testnet}
       # Citation-repair workflow preflight also reads the shared policy store
       # (DATABASE_URL — mutation-policy checks prior claim/submit attempts;
       # missing it surfaces as policy_store_unavailable) and records handoff
@@ -875,7 +875,7 @@ services:
       AVERRAY_HANDOFF_EVENTS_PATH: ${AVERRAY_HANDOFF_EVENTS_PATH:-/data/handoff-events.jsonl}
       POLICY_CONFIG_PATH: /config/policy.yaml
       HALT_FILE: ${HALT_FILE:-/data/HALT}
-      WALLET_NETWORK: testnet
+      WALLET_NETWORK: ${WALLET_NETWORK:-testnet}
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -882,16 +882,41 @@ export async function probeSignerLiquidity(input: {
   usdcDecimals: number;
   minGasNative: number;
   minUsdc: number;
+  /** The chainId `/health` reports. When set, the RPC must agree before we trust
+   *  any balance it returns (chain guard below). */
+  expectedChainId?: number;
   fetchImpl: typeof fetch;
 }): Promise<ProbeResult & { pools?: SolvencyPoolData[]; rpcOk?: boolean }> {
   if (!input.rpcUrl || !input.signerAddress) {
+    // Name the missing piece: at a network cutover this is the difference between
+    // "monitor is fine" and "solvency has been unmonitored since the flip".
     return {
       name: "signer_liquidity",
       status: "degraded",
-      detail: "PRODUCT_HEALTH_RPC_URL / signer address not configured",
+      detail: !input.rpcUrl
+        ? "PRODUCT_HEALTH_RPC_URL not set (no built-in default outside testnet)"
+        : "PRODUCT_HEALTH_SIGNER_ADDRESS not set",
     };
   }
   try {
+    // CHAIN GUARD — mirrors chainBlockAge: never report a balance from an endpoint
+    // that isn't on the product's chain. Without it, a leftover testnet endpoint
+    // (a stale PRODUCT_HEALTH_RPC_BACKUPS entry, or a failover onto one) reads the
+    // TESTNET signer and paints solvency GREEN while the mainnet signer is dry.
+    // `rpcOk: false` also drives the failover loop, so a mismatched endpoint is
+    // rotated past and ultimately escalated to a human rather than trusted.
+    if (input.expectedChainId !== undefined) {
+      const actualChainId = Number(BigInt(await ethRpc(input.rpcUrl, "eth_chainId", [], input.fetchImpl)));
+      if (actualChainId !== input.expectedChainId) {
+        return {
+          name: "signer_liquidity",
+          // Same escalation rule as chainHaltStatus: being blind on mainnet pages.
+          status: MAINNET_CHAIN_IDS.has(input.expectedChainId) ? "red" : "degraded",
+          detail: `RPC chain mismatch — endpoint is on chain ${actualChainId}, product is on ${input.expectedChainId}; balances NOT trusted`,
+          rpcOk: false,
+        };
+      }
+    }
     const gasWei = BigInt(await ethRpc(input.rpcUrl, "eth_getBalance", [input.signerAddress, "latest"], input.fetchImpl));
     const gasNative = Number(gasWei) / 1e18;
     const parts: string[] = [];
@@ -1133,6 +1158,8 @@ export async function collectProductHealthProbes(
     usdcDecimals: config.usdcDecimals,
     minGasNative: config.minGasNative,
     minUsdc: config.minUsdc,
+    // Balances are only trusted from an RPC on the product's own chain.
+    expectedChainId: chainId,
     fetchImpl,
   });
   const treasury = await probeTreasuryLiquidity({

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -433,6 +433,70 @@ describe("probeSignerLiquidity (direct RPC)", () => {
     const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: throwingFetch() });
     expect(r.status).toBe("degraded");
   });
+
+  it("names WHICH piece is unconfigured (a cutover leaves solvency unmonitored)", async () => {
+    const noRpc = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: "0xabc", usdcAddress: undefined, ...floors, fetchImpl: balances("0x0", "0x0") });
+    expect(noRpc.detail).toContain("PRODUCT_HEALTH_RPC_URL");
+    const noSigner = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: undefined, usdcAddress: undefined, ...floors, fetchImpl: balances("0x0", "0x0") });
+    expect(noSigner.detail).toContain("PRODUCT_HEALTH_SIGNER_ADDRESS");
+  });
+
+  // ── chain guard ───────────────────────────────────────────────────────────
+  // A healthy-but-WRONG-chain endpoint returns perfectly good balances for the
+  // wrong signer. Never trust them: that's a fake-green on the money pillar.
+  const TESTNET = "0x190f1b41"; // 420420417
+  const MAINNET = "0x190f1b43"; // 420420419
+  function chainedBalances(chainIdHex: string, gasHex: string, usdcHex: string): typeof fetch {
+    return (async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const method = rpcMethod(init ?? {});
+      const result = method === "eth_chainId" ? chainIdHex : method === "eth_getBalance" ? gasHex : usdcHex;
+      return { ok: true, status: 200, json: async () => ({ result }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("reads balances normally when the RPC is on the product's chain", async () => {
+    const r = await probeSignerLiquidity({
+      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      expectedChainId: 420420417,
+      fetchImpl: chainedBalances(TESTNET, "0xDE0B6B3A7640000", "0x989680"),
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("USDC 10.00");
+  });
+
+  it("RED + rpcOk:false when the product is on MAINNET but the RPC is a leftover testnet endpoint", async () => {
+    // The exact cutover hazard: healthy testnet RPC, flush testnet signer, and the
+    // mainnet signer could be dry. Must NOT report those balances as green.
+    const r = await probeSignerLiquidity({
+      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      expectedChainId: 420420419, // product is live on mainnet
+      fetchImpl: chainedBalances(TESTNET, "0xDE0B6B3A7640000", "0x989680"), // fat testnet balances
+    });
+    expect(r.status).toBe("red"); // blind on mainnet pages
+    expect(r.detail).toContain("chain mismatch");
+    expect(r.detail).toContain("420420419");
+    expect(r.detail).not.toContain("USDC 10.00"); // the wrong chain's balance never surfaces
+    expect(r.rpcOk).toBe(false); // drives failover past this endpoint, then escalates
+  });
+
+  it("degraded (not red) on a mismatch while the product is still on a testnet", async () => {
+    const r = await probeSignerLiquidity({
+      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      expectedChainId: 420420417,
+      fetchImpl: chainedBalances(MAINNET, "0xDE0B6B3A7640000", "0x989680"),
+    });
+    expect(r.status).toBe("degraded");
+    expect(r.rpcOk).toBe(false);
+  });
+
+  it("skips the guard when the product's chainId is unknown (no /health chainId)", async () => {
+    const r = await probeSignerLiquidity({
+      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      expectedChainId: undefined,
+      fetchImpl: chainedBalances(TESTNET, "0xDE0B6B3A7640000", "0x989680"),
+    });
+    expect(r.status).toBe("ok");
+  });
 });
 
 const CHAIN_ID_HEX = "0x" + (420420417).toString(16); // matches HEALTHY_BODY auth.chainId


### PR DESCRIPTION
Mainnet cutover prep for the monitor. Two things stopped Hermes from following the product onto mainnet — **and one of them could have lied to you about solvency.**

## The core finding: Hermes would have *half-flipped*

The network signal is derived from the product's `/health` **chainId**, so these already follow automatically once the API reports `420420419` (no work needed):

| Auto-follows ✓ |
|---|
| Halt severity `degraded` → **red/page** (`MAINNET_CHAIN_IDS` already holds `420420419`) |
| Narration "Testnet — informational" → **"On-call is paged"** |
| Ops suggestions mainnet branch · board framing · `chain_height` probe |

**But the probes that read the chain *directly* follow `WALLET_NETWORK`/RPC env, which was pinned to testnet.** Net effect without this PR: Hermes **pages you like mainnet while reading balances from testnet.**

## What changed

**1. `WALLET_NETWORK` was un-flippable.** It was a hardcoded literal `testnet` in 4 service blocks of `ops/compose.yml` — setting it in `.env.prod` did *nothing*. Now `${WALLET_NETWORK:-testnet}`; **default unchanged**, so this is a no-op until the operator flips it.

**2. Chain guard on `probeSignerLiquidity`.** It now takes the chainId `/health` reports and verifies the RPC agrees (`eth_chainId`) before trusting **any** balance.

This mirrors `chainBlockAge`, which *already* refuses a mismatched endpoint — its comment reads *"so a retarget-stale endpoint can't false-halt on the wrong chain."* That exact reasoning was **never applied to balances**. The gap: a leftover testnet endpoint (a stale `PRODUCT_HEALTH_RPC_BACKUPS` entry, or an auto-failover onto one — the failover decides purely on `rpcHealthy`, with no chain check) returns perfectly healthy balances **for the testnet signer**, painting solvency **GREEN while the mainnet signer is dry.**

On mismatch it now returns `rpcOk: false` — which drives the existing failover to rotate *past* the bad endpoint and ultimately escalate to a human — and **red on mainnet / degraded on a testnet**, matching `chainHaltStatus`'s escalation rule.

**3. Honest unconfigured detail** — names *which* var is missing (`PRODUCT_HEALTH_RPC_URL` vs `PRODUCT_HEALTH_SIGNER_ADDRESS`). At a cutover that's the difference between "monitor is fine" and "solvency has been unmonitored since the flip."

## What I deliberately did NOT do
**No hardcoded mainnet RPC default.** The canonical endpoint for `420420419` could not be confirmed — the public docs now list a *different* testnet host than the one this repo verified live. Guessing a chain endpoint is precisely the failure this guard exists to prevent. Set `PRODUCT_HEALTH_RPC_URL` from `deployments/mainnet.json` (the authoritative, Codex-owned source).

## Tests
- `product-health` **107/107** (+5 guard tests, including the exact hazard: mainnet expected + testnet RPC + fat testnet balances → **red**, `rpcOk:false`, and the wrong chain's balance never surfaces).
- Full unit suite: **67 pre-existing failures on clean main, identical here, +5 passing → zero new** (verified by stashing and re-running against clean main).
- Backend `tsc` = the known 26 stale-`@avg` baseline; **none in `product-health.ts`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)