### PR TITLE
feat(ops): add supervised Harness pilot CLI

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -1,0 +1,569 @@
+# INT-2 supervised Harness ceremony
+
+This runbook is for one human-operated, local, disposable acceptance
+ceremony. It does not authorize a production pilot. The Harness worker,
+dispatcher, monitor used for projection evidence, and both Postgres instances
+run locally and are destroyed afterward. The VPS Compose `dispatch` profile
+stays dormant.
+
+`HARNESS_DISPATCH_ENABLED` is default-off. Enabling it is a separate, explicit
+operator action taken only after the operator has inspected a proposed task,
+and only for the duration of this ceremony. The pilot CLI proposes, approves,
+cancels, and reads state; it never submits a run, opens a pull request, or
+actuates GitHub or Averray.
+
+Use a new work-item id for every positive or negative case. Do not reuse a task
+version after changing its fixture, profile, policy, or acceptance criteria.
+
+## 1. Provision a disposable local control plane
+
+### 1.1 Preflight and clean pinned Harness checkout
+
+Do not inherit production configuration. In a fresh shell:
+
+```sh
+unset HARNESS_DISPATCH_ENABLED
+test "${HARNESS_DISPATCH_ENABLED:-false}" != "true"
+
+export CEREMONY_ROOT="$(mktemp -d -t harness-int2-ceremony.XXXXXX)"
+export HARNESS_CHECKOUT="$CEREMONY_ROOT/agent-harness"
+export REFERENCE_CHECKOUT="/absolute/path/to/averray-reference-agent"
+
+git clone https://github.com/averray-agent/agent-harness.git "$HARNESS_CHECKOUT"
+git -C "$HARNESS_CHECKOUT" checkout --detach 2f60cab
+test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = \
+  "2f60cab649c02c611b646fb36ac31d13ed0469a8"
+test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)"
+
+cd "$HARNESS_CHECKOUT"
+uv sync --frozen
+```
+
+Record the full Harness commit in the evidence directory. Stop if the checkout
+is not clean or the commit differs.
+
+```sh
+mkdir -p "$CEREMONY_ROOT/evidence"
+git -C "$HARNESS_CHECKOUT" rev-parse HEAD \
+  > "$CEREMONY_ROOT/evidence/harness-commit.txt"
+```
+
+### 1.2 Start two purpose-specific Postgres instances
+
+The Harness and reference agent must not share a database. These containers
+have no durable volume; `docker stop` destroys their state.
+
+```sh
+docker run --rm --detach --name int2-harness-postgres \
+  --publish 127.0.0.1:55432:5432 \
+  --env POSTGRES_PASSWORD=harness-ceremony \
+  --env POSTGRES_DB=harness_ceremony \
+  postgres:18
+
+docker run --rm --detach --name int2-reference-postgres \
+  --publish 127.0.0.1:55433:5432 \
+  --env POSTGRES_PASSWORD=reference-ceremony \
+  --env POSTGRES_DB=reference_ceremony \
+  postgres:16-alpine
+
+export HARNESS_DATABASE_URL="postgresql://postgres:harness-ceremony@127.0.0.1:55432/harness_ceremony"
+export DATABASE_URL="postgresql://postgres:reference-ceremony@127.0.0.1:55433/reference_ceremony"
+
+until docker exec int2-harness-postgres \
+  pg_isready -U postgres -d harness_ceremony; do sleep 1; done
+until docker exec int2-reference-postgres \
+  pg_isready -U postgres -d reference_ceremony; do sleep 1; done
+```
+
+Migrate the Harness database from the pinned clean checkout:
+
+```sh
+cd "$HARNESS_CHECKOUT"
+uv run harness db migrate
+```
+
+Install and build the reference agent, then apply only its additive ops
+migrations to the disposable reference database:
+
+```sh
+cd "$REFERENCE_CHECKOUT"
+npm ci
+npm run build
+
+for migration in ops/migrations/*.sql; do
+  psql "$DATABASE_URL" --set ON_ERROR_STOP=1 --file "$migration"
+done
+```
+
+### 1.3 Create and pin the pilot profile
+
+Build or select a locally available, immutable pilot image that contains Node
+22, Git, and all dependencies required by the fixture's offline `npm`
+verification commands. Because Harness bind-mounts the task checkout at
+`/workspace` and runs with `--network none`, the image must make those
+dependencies available inside that mounted workspace without downloading
+anything at run time. Keep the image build recipe and clean source revision in
+the evidence bundle. It must contain no credentials. Do not use a floating tag
+in the evidence ceremony:
+
+```sh
+export PILOT_IMAGE="reference-agent-pilot@sha256:<operator-recorded-digest>"
+docker image inspect "$PILOT_IMAGE" > /dev/null
+
+export HARNESS_PROFILES_ROOT="$CEREMONY_ROOT/profiles"
+mkdir -p "$HARNESS_PROFILES_ROOT/coding-change-pilot"
+```
+
+Create
+`$HARNESS_PROFILES_ROOT/coding-change-pilot/profile.yaml` with exactly:
+
+```yaml
+name: coding-change-pilot
+version: "1"
+environment:
+  provider: docker
+  image: "reference-agent-pilot@sha256:<operator-recorded-digest>"
+egress:
+  mode: deny_all
+  allowed_destinations: []
+model:
+  executor:
+    adapter: openai-compatible
+    model_ref: null
+capabilities:
+  - fs.read_file
+  - fs.write_file
+  - fs.list_files
+  - shell.run
+  - git.status
+  - git.diff
+  - artifact.put
+  - artifact.get
+verification:
+  baseline_command: null
+  protected_paths: []
+strategies:
+  - direct_execution
+retention_policy: standard
+```
+
+The profile has only the eight vetted local capabilities, no delegation
+capability, no wallet, settlement, deploy, GitHub-publish, or merge capability,
+one `direct_execution` strategy, deny-all egress, and the Docker provider.
+Verify the configured image string matches `PILOT_IMAGE`, then pin the exact
+profile bytes:
+
+```sh
+export HARNESS_PROFILE_SHA256="$(
+  shasum -a 256 \
+    "$HARNESS_PROFILES_ROOT/coding-change-pilot/profile.yaml" |
+    awk '{print $1}'
+)"
+
+cp "$HARNESS_PROFILES_ROOT/coding-change-pilot/profile.yaml" \
+  "$CEREMONY_ROOT/evidence/profile.yaml"
+printf '%s\n' "$HARNESS_PROFILE_SHA256" \
+  > "$CEREMONY_ROOT/evidence/profile.sha256"
+```
+
+The dispatcher and Harness worker must receive the same
+`HARNESS_PROFILES_ROOT`. The dispatcher additionally verifies
+`HARNESS_PROFILE_SHA256`.
+
+### 1.4 Configure local-only artifact and observation paths
+
+```sh
+export HARNESS_BIN="$HARNESS_CHECKOUT/.venv/bin/harness"
+export HARNESS_DISPATCH_ARTIFACT_DIR="$CEREMONY_ROOT/dispatch-artifacts"
+export HARNESS_DISPATCH_INTENT_DIR="$CEREMONY_ROOT/dispatch-intents"
+export HARNESS_DISPATCH_HEARTBEAT_PATH="$CEREMONY_ROOT/dispatcher-heartbeat.json"
+export HARNESS_DISPATCH_ALERTS_PATH="$CEREMONY_ROOT/dispatcher-alerts.jsonl"
+export HALT_FILE="$CEREMONY_ROOT/HALT"
+export POLICY_CONFIG_PATH="$REFERENCE_CHECKOUT/hermes/config/policy.yaml"
+export HERMES_DISPATCH_ALLOWED_REPOS="depre-dev/averray-reference-agent"
+export SLACK_OPERATOR_HTTP_PORT=18790
+export SLACK_OPERATOR_MONITOR_ENABLED=1
+export SLACK_OPERATOR_ENABLED=0
+export HARNESS_DISPATCH_ENABLED=false
+
+mkdir -p \
+  "$HARNESS_DISPATCH_ARTIFACT_DIR" \
+  "$HARNESS_DISPATCH_INTENT_DIR" \
+  /var/lib/harness-dispatcher/workspaces
+```
+
+The final `mkdir` may require the operator to create the directory once with
+local administrator privileges and grant only their ceremony user write
+access. Do not change `DISPATCH_WORKSPACE_ROOT`: it is part of the approved task
+hash.
+
+Start the local monitor in a dedicated terminal for projection snapshots. It
+has no Slack token, and every routine/mutation flag remains off:
+
+```sh
+cd "$REFERENCE_CHECKOUT"
+node services/slack-operator/dist/index.js
+```
+
+Capture a pre-ceremony board snapshot:
+
+```sh
+curl --fail --silent \
+  "http://127.0.0.1:${SLACK_OPERATOR_HTTP_PORT}/monitor/v2/board" \
+  > "$CEREMONY_ROOT/evidence/board-before.json"
+```
+
+Do **not** start the dispatcher yet. Confirm the CLI sees no tasks and reports
+dispatch as unattempted:
+
+```sh
+cd "$REFERENCE_CHECKOUT"
+node scripts/ops/harness-pilot.mjs status \
+  > "$CEREMONY_ROOT/evidence/status-before.json"
+```
+
+### 1.5 Start the deterministic worker
+
+For scripted cases, the worker uses the pinned Harness test-model seam and a
+script from the same clean checkout. The example `finish.jsonl` performs no
+write and is useful for a deliberately unmet verifier:
+
+```sh
+export HARNESS_MODEL_ADAPTER=openai-compatible
+export HARNESS_MODEL_REF=scripted-model
+export HARNESS_MODEL_BASE_URL=http://127.0.0.1:11434/v1
+export HARNESS_TEST_MODEL_SCRIPT="$HARNESS_CHECKOUT/tests/fixtures/model_scripts/finish.jsonl"
+```
+
+In a dedicated worker terminal with the same exported environment:
+
+```sh
+cd "$HARNESS_CHECKOUT"
+uv run harness worker
+```
+
+Wait for `worker ready`. A worker that exits or reports a different commit,
+profile, database, provider, or image pin aborts the ceremony.
+
+### 1.6 The only dispatch enablement step
+
+For each approved case, first inspect the proposal while dispatch remains
+disabled:
+
+```sh
+cd "$REFERENCE_CHECKOUT"
+node scripts/ops/harness-pilot.mjs propose \
+  --fixture docs-fix \
+  --work-item ceremony-docs-001
+node scripts/ops/harness-pilot.mjs status \
+  --work-item ceremony-docs-001
+```
+
+Only after the operator checks the repository revision, path allowlist,
+deny-all network, eight grants, budgets, deadline, template hash, and verifier
+hash may they approve:
+
+```sh
+node scripts/ops/harness-pilot.mjs approve \
+  --work-item ceremony-docs-001 \
+  --version 1 \
+  --operator <approved-operator-id> \
+  --confirm
+```
+
+The approve output gives `approvedTaskHash` and `intendedRunId`, but explicitly
+does not submit a run. Record both.
+
+The operator may now take the separate action of starting one local dispatcher
+terminal:
+
+```sh
+cd "$REFERENCE_CHECKOUT"
+export HARNESS_DISPATCH_ENABLED=true
+node services/harness-dispatcher/dist/index.js
+```
+
+Stop that dispatcher and set `HARNESS_DISPATCH_ENABLED=false` between fault
+injections. Never enable the VPS Compose profile.
+
+## 2. Scripted-model safety proofs
+
+Run every negative proof before any real-model task. Give each case a unique
+work-item id and save the CLI output, Harness status/events/deliverables,
+relevant database rows, heartbeat, alerts, and board snapshots under
+`$CEREMONY_ROOT/evidence/<work-item>/`.
+
+### 2.1 Exactly once under replay and restart
+
+1. Propose and inspect `lint-format` as `ceremony-replay-001`.
+2. Approve it with the exact `--confirm` flag.
+3. Start two local dispatcher processes at nearly the same time. The global
+   lease allows only one to claim and submit.
+4. After the outbox binding appears, stop both dispatchers and restart one with
+   the same database. This re-delivers the same approved task version.
+5. Re-submit the generated intent once with the same printed idempotency key:
+
+   ```sh
+   "$HARNESS_BIN" run submit \
+     --run-id <intendedRunId> \
+   "$HARNESS_DISPATCH_INTENT_DIR/ceremony-replay-001-v1.json"
+   ```
+
+6. Both the original and replay must print the same run id and return zero.
+   `harness run status <intendedRunId>` must show attempt `1`, and the Harness
+   database must contain exactly one domain run for that id.
+7. The reference database must contain one dispatch claim for
+   `(ceremony-replay-001, 1)` and one immutable outbox binding.
+
+Any second run id, attempt `2`, changed binding, or second domain run is a gate
+failure.
+
+### 2.2 HALT stops a live run
+
+1. Stop the worker and restart it with a long-running deterministic script such
+   as the pinned `hanging_shell_then_finish.jsonl`.
+2. Propose and approve a fresh bounded task.
+3. Start the dispatcher and wait until status shows `dispatching` or `running`.
+4. Create the exact configured HALT file:
+
+   ```sh
+   printf 'INT-2 ceremony HALT drill\n' > "$HALT_FILE"
+   ```
+
+5. The dispatcher must start no new work. Reconciliation must issue bounded
+   cancel for the live run. Use `harness-pilot status` and
+   `harness run status <id>` until the task and run are terminal/cancelled.
+6. Confirm the heartbeat reports `halted`, cancellation has an acknowledgement
+   or a critical `cancel_unacknowledged` alert, and no handoff exists.
+7. Stop the dispatcher before removing the HALT file. Resume only by explicit
+   operator decision.
+
+### 2.3 Approval-hash mismatch refuses before submit
+
+1. With dispatch disabled, propose and approve a fresh task.
+2. In the disposable reference database only, alter one material field inside
+   the stored task JSON while leaving `approvedTaskHash` unchanged. Record the
+   before/after JSON and SQL as fault-injection evidence.
+3. Start the dispatcher.
+4. Expect lifecycle `blocked`, a `dispatch_refusal` decision with reason
+   `approval_hash_mismatch`, no Harness run, no outbox binding, and no handoff.
+
+Do not repair the same task version. Stop the dispatcher and move to a new work
+item.
+
+### 2.4 Attenuation refuses a tighter manifest mismatch
+
+This proof tightens containment; it must never add a capability.
+
+1. Propose and approve a fresh task against the pinned eight-capability profile
+   while dispatch is disabled.
+2. Copy the profile evidence file, then temporarily remove
+   `fs.write_file` from the live profile and recompute
+   `HARNESS_PROFILE_SHA256`.
+3. Start the dispatcher. The seven-capability profile is still vetted, but it
+   cannot satisfy the approved TaskIntent's capability set.
+4. Expect a `dispatch_refusal` attenuation reason, no Harness run, no outbox
+   binding, and no handoff.
+5. Stop the dispatcher. Restore the byte-identical eight-capability profile and
+   its original SHA-256 before any later case.
+
+If this drill broadens authority instead of tightening it, abort.
+
+### 2.5 Intentional failed verification produces no handoff
+
+1. Restart the worker with `finish.jsonl`, which makes no workspace change.
+2. Propose `docs-fix` with a unique work-item id. Inspect its command and search
+   criteria, then approve.
+3. Enable and start the dispatcher.
+4. The unchanged workspace must fail at least one required criterion. Confirm:
+   the Harness run outcome is `failed`; the AgentTask lifecycle becomes
+   `failed`; no `handoff` decision is recorded; no `VerifiedHandoff` is
+   actuated; no submission or pull request exists.
+
+An unverified handoff or any PR is an immediate abort.
+
+## 3. One budget-capped real-model task
+
+Proceed only if every scripted proof is green and the operator records a
+go/no-go of `go`.
+
+1. Stop the scripted worker.
+2. Unset `HARNESS_TEST_MODEL_SCRIPT`.
+3. Select one approved real-model endpoint and keep its credential only in the
+   worker's local environment. Do not paste it into evidence or CLI arguments:
+
+   ```sh
+   unset HARNESS_TEST_MODEL_SCRIPT
+   export HARNESS_MODEL_ADAPTER=openai-compatible
+   export HARNESS_MODEL_REF="<operator-approved-model>"
+   export HARNESS_MODEL_BASE_URL="<operator-approved-endpoint>"
+   export HARNESS_MODEL_API_KEY="<secret-kept-out-of-evidence>"
+   ```
+
+4. Start exactly one Harness worker.
+5. Propose exactly one `lint-format` or `docs-fix` task with a new work-item id
+   and a near-term deadline. Verify the fixture remains low-risk, deny-network,
+   `maxChildren: 0`, `maxConcurrentChildren: 0`, and within its fixed elapsed,
+   token, tool-call, and cost budget.
+6. Approve once with `--confirm`, then explicitly enable and start one
+   dispatcher.
+7. Capture the run status, events, deliverables, manifest hashes, actual budget
+   use, verifier result, task projection, decisions, binding, heartbeat, and
+   alerts. The ceremony does not open a PR even when verification succeeds.
+8. Stop the dispatcher immediately after the task reaches a terminal
+   lifecycle, then set `HARNESS_DISPATCH_ENABLED=false`.
+
+Do not run a second real-model task to improve the result. A failure is
+evidence.
+
+## 4. Evidence mapped to the INT-2 gate
+
+For every work item, start with:
+
+```sh
+mkdir -p "$CEREMONY_ROOT/evidence/<work-item>"
+
+node scripts/ops/harness-pilot.mjs status --work-item <work-item> \
+  > "$CEREMONY_ROOT/evidence/<work-item>/pilot-status.json"
+"$HARNESS_BIN" run status <intendedRunId> \
+  > "$CEREMONY_ROOT/evidence/<work-item>/harness-status.txt"
+"$HARNESS_BIN" run events <intendedRunId> \
+  > "$CEREMONY_ROOT/evidence/<work-item>/harness-events.txt"
+"$HARNESS_BIN" run deliverables <intendedRunId> \
+  > "$CEREMONY_ROOT/evidence/<work-item>/harness-deliverables.txt"
+```
+
+Export these reference-database rows as JSON without including the DSN:
+
+- `agent_tasks` for the exact work item and version;
+- `agent_task_dispatch_claims` for the exact work item and version;
+- `agent_task_run_outbox` for the exact work item;
+- `hermes_decision_records` for the exact work item, ordered by
+  `generated_at`;
+- the tail of `HARNESS_DISPATCH_ALERTS_PATH`;
+- the dispatcher heartbeat.
+
+The following mapping is the acceptance checklist for plan section 21.1:
+
+| §21.1 gate statement | Required captured proof |
+|---|---|
+| Concurrent/replayed dispatch creates exactly one run | One immutable `intendedRunId`; one Harness run at attempt 1; one claim; one outbox binding; identical run id from duplicate submit; restart/replay does not change any identity. |
+| Approval/hash/policy/grant mismatches refuse | `dispatch_refusal` decisions for the approval-hash and attenuation drills; no Harness run or outbox row for either; the pinned task, policy, verifier, profile, capability-catalog, and manifest hashes. |
+| HALT wins | Before/after task and run snapshots; halted heartbeat; cancellation acknowledgement or critical alert; no later run started while HALT existed. |
+| No wallet/settlement/deploy/GitHub-merge capability | The exact eight-grant AgentTask and compiled run manifest, with `delegable:false`, `maxChildren:0`, `maxConcurrentChildren:0`, and deny-all egress. Review the manifest, not just the profile source. |
+| Representative low-risk tasks complete through supervision | At least docs/comment, unit-test, and small-refactor families, each with proposal output, explicit operator approval, `dispatch_approval` decision, run events, verifier evidence, budget actuals, and terminal projection. |
+| Failed verification produces no submission | Failed verifier event and failed lifecycle; no `handoff` decision, no VerifiedHandoff actuation, and no PR/submission evidence. |
+| Restart and duplicate delivery remain idempotent | Dispatcher restart timestamps, unchanged claim/outbox rows, same immutable run id, and one Harness attempt. |
+
+A successful verified task should have a `dispatch_approval` decision and, when
+the projection constructs an unactuated handoff, a `handoff` decision. A
+negative case should have `dispatch_refusal`. Missing expected decision records
+fail the gate.
+
+### Source-loss projection drill
+
+With a completed task visible, save a healthy local board snapshot:
+
+```sh
+curl --fail --silent \
+  "http://127.0.0.1:${SLACK_OPERATOR_HTTP_PORT}/monitor/v2/board" \
+  > "$CEREMONY_ROOT/evidence/board-source-healthy.json"
+```
+
+Stop only `int2-reference-postgres`, then request another snapshot. A non-2xx
+response is acceptable evidence if the source is explicitly unavailable. If a
+snapshot is returned, it must be degraded/unknown and must not preserve a
+stale healthy card:
+
+```sh
+docker stop int2-reference-postgres
+curl --silent --show-error \
+  "http://127.0.0.1:${SLACK_OPERATOR_HTTP_PORT}/monitor/v2/board" \
+  > "$CEREMONY_ROOT/evidence/board-source-lost.json"
+```
+
+Record the HTTP status separately. A source-lost snapshot that still claims
+healthy is a gate failure. Do not recreate the database merely to make the
+evidence green.
+
+Finish with an evidence index containing the Harness SHA, image digest, profile
+SHA, policy hash/version, every work-item/version, run id, task/template/
+verifier/manifest hash, decision ids, outbox row, alerts file hash, projection
+snapshot hashes, operator id, and the operator's gate verdict.
+
+## 5. Teardown and prove nothing remains armed
+
+1. Stop the dispatcher first with `Ctrl-C`.
+2. In the controlling shell:
+
+   ```sh
+   export HARNESS_DISPATCH_ENABLED=false
+   test "$HARNESS_DISPATCH_ENABLED" = "false"
+   ```
+
+3. Stop the Harness worker and local monitor with `Ctrl-C`.
+4. Remove only the exact per-task paths printed by the pilot CLI. Never delete
+   `/var/lib/harness-dispatcher` or another broad root.
+5. Stop either disposable database container that still exists:
+
+   ```sh
+   docker stop int2-harness-postgres 2>/dev/null || true
+   docker stop int2-reference-postgres 2>/dev/null || true
+   ```
+
+6. Verify no ceremony container, deterministic run container, dispatcher, or
+   worker remains:
+
+   ```sh
+   docker ps --format '{{.Names}}' |
+     grep -E '^(int2-|harness-run-)' && exit 1 || true
+   pgrep -af "$REFERENCE_CHECKOUT/services/harness-dispatcher/dist/index.js" &&
+     exit 1 || true
+   pgrep -af "$HARNESS_CHECKOUT/.venv/bin/harness worker" &&
+     exit 1 || true
+   ```
+
+7. Confirm the VPS dispatch profile was never started:
+
+   ```sh
+   cd "$REFERENCE_CHECKOUT/ops"
+   docker compose ps harness-dispatcher
+   ```
+
+   It must show no running service.
+
+8. Copy the evidence directory to the operator-approved archive location, then
+   remove the exact `CEREMONY_ROOT`. Unset all ceremony variables, especially
+   both database URLs, model credentials, profile paths, and dispatch paths.
+9. In a new shell, confirm `HARNESS_DISPATCH_ENABLED` is unset:
+
+   ```sh
+   test -z "${HARNESS_DISPATCH_ENABLED:-}"
+   ```
+
+Teardown is incomplete until both databases, every per-task workspace, every
+Harness run container, the dispatcher, worker, and local monitor are gone and
+dispatch is unset/false.
+
+## 6. Abort conditions
+
+Stop the dispatcher, set `HARNESS_DISPATCH_ENABLED=false`, create `HALT_FILE`
+when a run may still be live, and preserve evidence immediately if any of
+these occurs:
+
+- any containment expansion: extra capability, network access, delegation,
+  child execution, broader path, unpinned image/profile/revision, or unexpected
+  authority;
+- any unexpected `ApprovalPacket`, approval actor, implicit approval, or
+  approval without the exact operator confirmation;
+- more than one Harness run or run id for one approved
+  `(workItemId, taskVersion, approvedTaskHash)`;
+- any submission, pull request, GitHub mutation, or handoff actuation from
+  unverified work;
+- a stale healthy projection after its source is lost;
+- a dispatcher or worker using a non-disposable database;
+- any secret or DSN appearing in CLI output or captured evidence.
+
+An abort is a failed ceremony, not a reason to weaken the proof or retry under
+the same task version. INT-3 remains blocked until the complete INT-2 evidence
+bundle is reviewed and explicitly accepted by the operator.

--- a/scripts/ops/harness-pilot.mjs
+++ b/scripts/ops/harness-pilot.mjs
@@ -1,0 +1,633 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const FIXTURES = new Set([
+  "docs-fix",
+  "add-unit-test",
+  "small-refactor",
+  "lint-format",
+]);
+const POLICY_VERSION = "dispatch-policy-v1";
+const DEFAULT_ALERTS_PATH = "/data/harness-dispatch-alerts.jsonl";
+const DEFAULT_CANCEL_REASON =
+  "Operator cancelled the supervised Harness pilot task.";
+const STATUS_LIMIT = 20;
+const SECRET_KEY =
+  /(authorization|bearer|cookie|credential|dsn|mnemonic|password|private.?key|secret|token|webhook|api.?key)/iu;
+const DSN =
+  /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|redis):\/\/[^\s"',}]+/giu;
+const BEARER = /\bBearer\s+[A-Za-z0-9._~+/=-]+/giu;
+const SECRET_ASSIGNMENT =
+  /\b(?:authorization|credential|mnemonic|password|private[_ -]?key|secret|token|webhook|api[_ -]?key)\s*[:=]\s*[^\s"',;}]+/giu;
+const SECRET_TOKEN =
+  /\b(?:github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|sk-[A-Za-z0-9_-]{12,})\b/gu;
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPOSITORY_ROOT = path.resolve(SCRIPT_DIR, "../..");
+
+export function parsePilotArgs(argv) {
+  if (!Array.isArray(argv)) {
+    throw new PilotCliError("arguments must be an array");
+  }
+  if (argv.length === 0) {
+    throw new PilotCliError("a subcommand is required; use --help for usage");
+  }
+  if (argv[0] === "--help" || argv[0] === "-h") {
+    if (argv.length !== 1) {
+      throw new PilotCliError("--help does not accept other arguments");
+    }
+    return { command: "help" };
+  }
+
+  const command = argv[0];
+  const rest = argv.slice(1);
+  switch (command) {
+    case "propose": {
+      const options = parseOptions(rest, {
+        values: ["fixture", "work-item", "deadline"],
+      });
+      const fixture = requiredOption(options, "fixture");
+      if (!FIXTURES.has(fixture)) {
+        throw new PilotCliError(
+          `--fixture must be one of: ${[...FIXTURES].join(", ")}`,
+        );
+      }
+      return {
+        command,
+        fixture,
+        ...(options["work-item"]
+          ? { workItemId: nonEmpty(options["work-item"], "--work-item") }
+          : {}),
+        ...(options.deadline
+          ? { deadline: canonicalTimestamp(options.deadline, "--deadline") }
+          : {}),
+      };
+    }
+    case "approve":
+    case "cancel": {
+      const options = parseOptions(rest, {
+        values: command === "approve"
+          ? ["work-item", "version", "operator"]
+          : ["work-item", "version", "operator", "reason"],
+        booleans: ["confirm"],
+      });
+      return {
+        command,
+        workItemId: nonEmpty(
+          requiredOption(options, "work-item"),
+          "--work-item",
+        ),
+        taskVersion: positiveInteger(
+          requiredOption(options, "version"),
+          "--version",
+        ),
+        actorType: "operator",
+        operatorId: nonEmpty(
+          requiredOption(options, "operator"),
+          "--operator",
+        ),
+        confirm: options.confirm === true,
+        ...(command === "cancel"
+          ? {
+              reason: options.reason
+                ? nonEmpty(options.reason, "--reason")
+                : DEFAULT_CANCEL_REASON,
+            }
+          : {}),
+      };
+    }
+    case "status": {
+      const options = parseOptions(rest, {
+        values: ["work-item"],
+      });
+      return {
+        command,
+        ...(options["work-item"]
+          ? {
+              workItemId: nonEmpty(
+                options["work-item"],
+                "--work-item",
+              ),
+            }
+          : {}),
+      };
+    }
+    default:
+      throw new PilotCliError(
+        `unknown subcommand ${JSON.stringify(command)}; use --help for usage`,
+      );
+  }
+}
+
+export async function runPilotCli(argv, options = {}) {
+  const output = options.output ?? ((line) => process.stdout.write(line));
+  const errorOutput =
+    options.errorOutput ?? ((line) => process.stderr.write(line));
+  const context = {
+    environment: options.environment ?? process.env,
+    output,
+    services: options.services,
+    defaultServices: undefined,
+  };
+
+  try {
+    const command = parsePilotArgs(argv);
+    await executePilotCommand(command, context);
+    return 0;
+  } catch (error) {
+    errorOutput(`harness-pilot: ${readableError(error)}\n`);
+    return 1;
+  } finally {
+    const services = context.defaultServices;
+    if (services?.close) {
+      await services.close().catch(() => undefined);
+    }
+  }
+}
+
+export async function executePilotCommand(command, context) {
+  switch (command.command) {
+    case "help":
+      context.output(`${helpText()}\n`);
+      return;
+    case "propose":
+      await handlePropose(command, context);
+      return;
+    case "approve":
+      await handleApprove(command, context);
+      return;
+    case "cancel":
+      await handleCancel(command, context);
+      return;
+    case "status":
+      await handleStatus(command, context);
+      return;
+    default:
+      throw new PilotCliError("unsupported command");
+  }
+}
+
+export async function handlePropose(command, context) {
+  requireEnvironment(context.environment, [
+    "DATABASE_URL",
+    "HARNESS_DISPATCH_ARTIFACT_DIR",
+  ]);
+  const services = await resolveServices(context);
+  const fixture = await services.loadFixture(command.fixture);
+  const workItemId = command.workItemId ?? fixture.workItemId;
+  const input = {
+    ...fixture,
+    workItemId,
+    correlationId: command.workItemId
+      ? workItemId
+      : fixture.correlationId,
+    ...(command.deadline ? { deadline: command.deadline } : {}),
+  };
+  const task = await services.proposeAgentTask(input);
+  if (
+    task.lifecycle !== "proposed"
+    || task.approval?.status !== "pending"
+    || task.approval?.approvedTaskHash !== undefined
+  ) {
+    throw new PilotCliError(
+      "proposal refused because it did not remain pending operator approval",
+    );
+  }
+
+  writeResult(context, {
+    operation: "propose",
+    lifecycle: task.lifecycle,
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    templateHash: task.intent.templateHash,
+    verifierPlanHash: task.acceptance.verifierPlanHash,
+    workspacePath: services.workspacePathForTask(
+      task.workItemId,
+      task.taskVersion,
+    ),
+    submissionAttemptedByCli: false,
+  });
+}
+
+export async function handleApprove(command, context) {
+  assertConfirmedOperatorCommand(command, "approval");
+  requireEnvironment(context.environment, ["DATABASE_URL"]);
+  const services = await resolveServices(context);
+  const task = await services.approveAgentTask({
+    workItemId: command.workItemId,
+    taskVersion: command.taskVersion,
+    actor: {
+      type: "operator",
+      id: command.operatorId,
+    },
+  });
+  const approvedTaskHash = task.approval?.approvedTaskHash;
+  if (
+    task.lifecycle !== "approved"
+    || typeof approvedTaskHash !== "string"
+    || approvedTaskHash.length === 0
+  ) {
+    throw new PilotCliError(
+      "approval did not produce a durable approved task hash",
+    );
+  }
+
+  writeResult(context, {
+    operation: "approve",
+    lifecycle: task.lifecycle,
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    approvedTaskHash,
+    intendedRunId: services.deriveIntendedRunId(
+      task.workItemId,
+      task.taskVersion,
+      approvedTaskHash,
+    ),
+    submissionAttemptedByCli: false,
+  });
+}
+
+export async function handleCancel(command, context) {
+  assertConfirmedOperatorCommand(command, "cancellation");
+  requireEnvironment(context.environment, ["DATABASE_URL"]);
+  const services = await resolveServices(context);
+  const result = await services.cancelAgentTask({
+    workItemId: command.workItemId,
+    taskVersion: command.taskVersion,
+    actor: {
+      type: "operator",
+      id: command.operatorId,
+    },
+    reason: command.reason,
+  });
+  writeResult(context, {
+    operation: "cancel",
+    lifecycle: result.task.lifecycle,
+    workItemId: result.task.workItemId,
+    taskVersion: result.task.taskVersion,
+    harnessCancelAcknowledged: result.harnessAcknowledged === true,
+    submissionAttemptedByCli: false,
+  });
+}
+
+export async function handleStatus(command, context) {
+  requireEnvironment(context.environment, ["DATABASE_URL"]);
+  const services = await resolveServices(context);
+  const [tasks, decisions, heartbeat, alerts] = await Promise.all([
+    services.listAgentTasks({
+      ...(command.workItemId ? { workItemId: command.workItemId } : {}),
+      limit: 1_000,
+    }),
+    services.listHermesDecisions({
+      ...(command.workItemId ? { workItemId: command.workItemId } : {}),
+      limit: STATUS_LIMIT,
+    }),
+    readHeartbeat(context.environment, services.readTextFile),
+    readAlerts(context.environment, services.readTextFile),
+  ]);
+
+  writeResult(context, {
+    operation: "status",
+    readOnly: true,
+    tasks: tasks.map((task) => ({
+      workItemId: task.workItemId,
+      taskVersion: task.taskVersion,
+      lifecycle: task.lifecycle,
+      bindings: {
+        harnessRunId: task.bindings?.harnessRunId ?? null,
+      },
+    })),
+    dispatcherHeartbeat: heartbeat,
+    recentDecisions: decisions.map(decisionStatusView),
+    alerts,
+    submissionAttemptedByCli: false,
+  });
+}
+
+async function createDefaultServices(environment) {
+  const [
+    proposal,
+    taskStore,
+    policy,
+    workspace,
+    dispatchClaim,
+    decisionStore,
+    readPortModule,
+    cancellation,
+    control,
+    alerts,
+    common,
+  ] = await Promise.all([
+    import("../../packages/averray-mcp/dist/agent-task-proposal.js"),
+    import("../../packages/averray-mcp/dist/agent-task-store.js"),
+    import("../../packages/averray-mcp/dist/dispatch-policy.js"),
+    import("../../packages/averray-mcp/dist/workspace-path.js"),
+    import("../../packages/averray-mcp/dist/dispatch-claim.js"),
+    import("../../packages/averray-mcp/dist/decision-record-store.js"),
+    import("../../packages/averray-mcp/dist/harness-read-port.js"),
+    import("../../services/harness-dispatcher/dist/cancel-task.js"),
+    import("../../services/harness-dispatcher/dist/harness-control-port.js"),
+    import("../../services/harness-dispatcher/dist/alerts.js"),
+    import("../../packages/mcp-common/dist/index.js"),
+  ]);
+
+  return {
+    async loadFixture(fixture) {
+      const target = path.join(
+        REPOSITORY_ROOT,
+        "test",
+        "fixtures",
+        "agent-integration",
+        "ceremony",
+        `${fixture}.json`,
+      );
+      return JSON.parse(await readFile(target, "utf8"));
+    },
+    proposeAgentTask(input) {
+      return proposal.proposeAgentTask(input, {
+        policyConfig: policy.loadDispatchPolicyConfig(environment),
+        policyVersion: POLICY_VERSION,
+        environment,
+      });
+    },
+    approveAgentTask: proposal.approveAgentTask,
+    async cancelAgentTask(input) {
+      let harnessAcknowledged = true;
+      const persistedAlertSink = alerts.createDispatchAlertSink({
+        environment,
+        logger: { warn() {} },
+      });
+      const alertSink = async (alert) => {
+        if (alert.code === "cancel_unacknowledged") {
+          harnessAcknowledged = false;
+        }
+        await persistedAlertSink(alert);
+      };
+      const command = environment.HARNESS_BIN?.trim() || "harness";
+      const task = await cancellation.cancelAgentTask(input, {
+        readPort: readPortModule.createHarnessCliReadPort({ command }),
+        controlPort: control.createHarnessControlPort({
+          command,
+          enabled: false,
+        }),
+        alertSink,
+      });
+      return { task, harnessAcknowledged };
+    },
+    listAgentTasks: taskStore.listAgentTasks,
+    listHermesDecisions: decisionStore.listHermesDecisions,
+    workspacePathForTask: workspace.workspacePathForTask,
+    deriveIntendedRunId: dispatchClaim.deriveIntendedRunId,
+    readTextFile: (target) => readFile(target, "utf8"),
+    close: common.closePool,
+  };
+}
+
+async function resolveServices(context) {
+  if (context.services) return context.services;
+  context.defaultServices ??= await createDefaultServices(
+    context.environment,
+  );
+  return context.defaultServices;
+}
+
+function parseOptions(argv, specification) {
+  const values = new Set(specification.values ?? []);
+  const booleans = new Set(specification.booleans ?? []);
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (!argument.startsWith("--")) {
+      throw new PilotCliError(
+        `unexpected positional argument ${JSON.stringify(argument)}`,
+      );
+    }
+    const name = argument.slice(2);
+    if (Object.hasOwn(parsed, name)) {
+      throw new PilotCliError(`--${name} may be supplied only once`);
+    }
+    if (booleans.has(name)) {
+      parsed[name] = true;
+      continue;
+    }
+    if (!values.has(name)) {
+      throw new PilotCliError(`unknown option --${name}`);
+    }
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new PilotCliError(`--${name} requires a value`);
+    }
+    parsed[name] = value;
+    index += 1;
+  }
+  return parsed;
+}
+
+function requiredOption(options, name) {
+  const value = options[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new PilotCliError(`--${name} is required`);
+  }
+  return value;
+}
+
+function nonEmpty(value, label) {
+  const normalized = String(value).trim();
+  if (!normalized) {
+    throw new PilotCliError(`${label} must not be empty`);
+  }
+  return normalized;
+}
+
+function positiveInteger(value, label) {
+  if (!/^[1-9][0-9]*$/u.test(value)) {
+    throw new PilotCliError(`${label} must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new PilotCliError(`${label} must be a safe integer`);
+  }
+  return parsed;
+}
+
+function canonicalTimestamp(value, label) {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp) || !/[zZ]|[+-][0-9]{2}:[0-9]{2}$/u.test(value)) {
+    throw new PilotCliError(`${label} must be an ISO-8601 timestamp with a timezone`);
+  }
+  return new Date(timestamp).toISOString();
+}
+
+function assertConfirmedOperatorCommand(command, operation) {
+  if (command.confirm !== true) {
+    throw new PilotCliError(
+      `${operation} refused: repeat the command with the exact --confirm flag`,
+    );
+  }
+  if (command.actorType !== "operator") {
+    throw new PilotCliError(
+      `${operation} refused: actor type must be operator`,
+    );
+  }
+}
+
+function requireEnvironment(environment, names) {
+  for (const name of names) {
+    if (!environment[name]?.trim()) {
+      throw new PilotCliError(`${name} is required`);
+    }
+  }
+}
+
+async function readHeartbeat(environment, readTextFile) {
+  const configured = environment.HARNESS_DISPATCH_HEARTBEAT_PATH?.trim();
+  if (!configured) {
+    return {
+      available: false,
+      status: "unavailable",
+      lastOutcome: null,
+      reason: "HARNESS_DISPATCH_HEARTBEAT_PATH is unset",
+    };
+  }
+  try {
+    const value = JSON.parse(await readTextFile(path.resolve(configured)));
+    return {
+      available: true,
+      status: safeScalar(value.status),
+      lastOutcome: safeScalar(value.lastOutcome),
+      updatedAt: safeScalar(value.updatedAt),
+      reconciledCount: Number.isSafeInteger(value.reconciledCount)
+        ? value.reconciledCount
+        : null,
+    };
+  } catch {
+    return {
+      available: false,
+      status: "unavailable",
+      lastOutcome: null,
+      reason: "dispatcher heartbeat is unreadable",
+    };
+  }
+}
+
+async function readAlerts(environment, readTextFile) {
+  const configured =
+    environment.HARNESS_DISPATCH_ALERTS_PATH?.trim() || DEFAULT_ALERTS_PATH;
+  try {
+    const lines = (await readTextFile(path.resolve(configured)))
+      .split(/\r?\n/u)
+      .filter(Boolean)
+      .slice(-STATUS_LIMIT);
+    return lines.flatMap((line) => {
+      try {
+        const alert = JSON.parse(line);
+        return [{
+          severity: safeScalar(alert.severity),
+          code: safeScalar(alert.code),
+          workItemId: safeScalar(alert.workItemId),
+          taskVersion: Number.isSafeInteger(alert.taskVersion)
+            ? alert.taskVersion
+            : null,
+          harnessRunId: safeScalar(alert.harnessRunId),
+          message: safeScalar(alert.message),
+          at: safeScalar(alert.at),
+        }];
+      } catch {
+        return [];
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+function decisionStatusView(record) {
+  return {
+    decisionId: safeScalar(record.decisionId),
+    correlationId: safeScalar(record.correlationId),
+    workItemId: safeScalar(record.workItemId),
+    decisionType: safeScalar(record.decisionType),
+    approvalDecision: safeScalar(record.approval?.decision),
+    mutates: record.effects?.mutates === true,
+    authorityChanged: record.effects?.authorityChanged === true,
+    nextAction: safeScalar(record.next?.action),
+    generatedAt: safeScalar(record.generatedAt),
+  };
+}
+
+function safeScalar(value) {
+  if (typeof value === "string") return redactText(value);
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "boolean") return value;
+  return null;
+}
+
+function writeResult(context, value) {
+  context.output(`${JSON.stringify(sanitizeValue(value), null, 2)}\n`);
+}
+
+function sanitizeValue(value) {
+  if (Array.isArray(value)) {
+    return value.slice(0, 1_000).map(sanitizeValue);
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, field]) => [
+        key,
+        SECRET_KEY.test(key) ? "[redacted]" : sanitizeValue(field),
+      ]),
+    );
+  }
+  if (typeof value === "string") return redactText(value);
+  if (
+    typeof value === "number"
+    || typeof value === "boolean"
+    || value === null
+  ) {
+    return value;
+  }
+  return null;
+}
+
+function redactText(value) {
+  return value
+    .replace(DSN, "[redacted-dsn]")
+    .replace(BEARER, "Bearer [redacted]")
+    .replace(SECRET_ASSIGNMENT, "[redacted-secret]")
+    .replace(SECRET_TOKEN, "[redacted-secret]")
+    .slice(0, 2_000);
+}
+
+function readableError(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return redactText(message || "command failed");
+}
+
+function helpText() {
+  return `Usage: node scripts/ops/harness-pilot.mjs <subcommand> [options]
+
+Human-operated supervised-pilot commands:
+  propose --fixture <docs-fix|add-unit-test|small-refactor|lint-format>
+          [--work-item <id>] [--deadline <iso>]
+  approve --work-item <id> --version <n> --operator <id> --confirm
+  cancel  --work-item <id> --version <n> --operator <id> --confirm
+          [--reason <text>]
+  status  [--work-item <id>]
+
+Propose never approves. Approve and cancel refuse without the exact --confirm
+flag. This CLI never submits a Harness run and never opens a pull request.`;
+}
+
+export class PilotCliError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PilotCliError";
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  process.exitCode = await runPilotCli(process.argv.slice(2));
+}

--- a/test/unit/harness-pilot-cli.test.ts
+++ b/test/unit/harness-pilot-cli.test.ts
@@ -1,0 +1,382 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  handleApprove,
+  parsePilotArgs,
+  runPilotCli,
+} from "../../scripts/ops/harness-pilot.mjs";
+
+const HASH = `sha256:${"a".repeat(64)}`;
+const VERIFIER_HASH = `sha256:${"b".repeat(64)}`;
+const RUN_ID = "11111111-1111-5111-8111-111111111111";
+
+describe("Harness pilot CLI", () => {
+  it("proposes a pending task and never approves or submits it", async () => {
+    const output: string[] = [];
+    const services = pilotServices();
+
+    const exitCode = await runPilotCli([
+      "propose",
+      "--fixture",
+      "docs-fix",
+      "--work-item",
+      "ceremony-docs-007",
+    ], {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+        HARNESS_DISPATCH_ARTIFACT_DIR: "/tmp/pilot-artifacts",
+      },
+      services,
+      output: (line: string) => output.push(line),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(services.proposeAgentTask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workItemId: "ceremony-docs-007",
+        correlationId: "ceremony-docs-007",
+      }),
+    );
+    const result = JSON.parse(output.join("")) as Record<string, unknown>;
+    expect(result).toMatchObject({
+      operation: "propose",
+      lifecycle: "proposed",
+      workItemId: "ceremony-docs-007",
+      taskVersion: 1,
+      submissionAttemptedByCli: false,
+    });
+    expect(result).not.toHaveProperty("approvedTaskHash");
+    expect(services.approveAgentTask).not.toHaveBeenCalled();
+    expect(services.cancelAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("refuses approval without the exact confirmation flag and performs no write", async () => {
+    const errors: string[] = [];
+    const services = pilotServices();
+
+    const exitCode = await runPilotCli([
+      "approve",
+      "--work-item",
+      "ceremony-docs-001",
+      "--version",
+      "1",
+      "--operator",
+      "pilot-operator",
+    ], {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+      },
+      services,
+      errorOutput: (line: string) => errors.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors.join("")).toContain("exact --confirm flag");
+    expect(services.approveAgentTask).not.toHaveBeenCalled();
+
+    const typoExitCode = await runPilotCli([
+      "approve",
+      "--work-item",
+      "ceremony-docs-001",
+      "--version",
+      "1",
+      "--operator",
+      "pilot-operator",
+      "--comfirm",
+    ], {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+      },
+      services,
+      errorOutput: (line: string) => errors.push(line),
+    });
+
+    expect(typoExitCode).toBe(1);
+    expect(services.approveAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("passes an operator actor to approval and refuses every other actor type", async () => {
+    const services = pilotServices({
+      approveAgentTask: vi.fn(async (input) => approvedTask(input.workItemId)),
+    });
+
+    await expect(runPilotCli([
+      "approve",
+      "--work-item",
+      "ceremony-docs-001",
+      "--version",
+      "1",
+      "--operator",
+      "pilot-operator",
+      "--confirm",
+    ], {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+      },
+      services,
+      output: vi.fn(),
+    })).resolves.toBe(0);
+
+    expect(services.approveAgentTask).toHaveBeenCalledWith({
+      workItemId: "ceremony-docs-001",
+      taskVersion: 1,
+      actor: {
+        type: "operator",
+        id: "pilot-operator",
+      },
+    });
+
+    const write = vi.fn();
+    await expect(handleApprove({
+      command: "approve",
+      workItemId: "ceremony-docs-001",
+      taskVersion: 1,
+      actorType: "hermes",
+      operatorId: "not-an-operator",
+      confirm: true,
+    }, {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+      },
+      services: {
+        ...services,
+        approveAgentTask: write,
+      },
+      output: vi.fn(),
+    })).rejects.toThrow("actor type must be operator");
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("refuses cancellation without confirmation", async () => {
+    const services = pilotServices();
+    const errors: string[] = [];
+
+    const exitCode = await runPilotCli([
+      "cancel",
+      "--work-item",
+      "ceremony-docs-001",
+      "--version",
+      "1",
+      "--operator",
+      "pilot-operator",
+    ], {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+      },
+      services,
+      errorOutput: (line: string) => errors.push(line),
+    });
+
+    expect(exitCode).toBe(1);
+    expect(errors.join("")).toContain("exact --confirm flag");
+    expect(services.cancelAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("keeps status read-only and redacts DSNs, tokens, and secret-looking values", async () => {
+    const output: string[] = [];
+    const proposed = proposedTask("ceremony-status-001");
+    const services = pilotServices({
+      listAgentTasks: vi.fn(async () => [proposed]),
+      listHermesDecisions: vi.fn(async () => [{
+        decisionId: "decision-one",
+        correlationId: proposed.correlationId,
+        workItemId: proposed.workItemId,
+        decisionType: "dispatch_refusal",
+        approval: { decision: "denied" },
+        effects: { mutates: false, authorityChanged: false },
+        next: {
+          action:
+            "inspect postgresql://pilot:dsn-password@localhost/db with token=decision-secret",
+        },
+        generatedAt: "2026-07-25T12:00:00.000Z",
+      }]),
+      readTextFile: vi.fn(async (target: string) => {
+        if (target.endsWith("heartbeat.json")) {
+          return JSON.stringify({
+            status: "idle",
+            lastOutcome: "refused",
+            updatedAt: "2026-07-25T12:00:00.000Z",
+            reconciledCount: 1,
+            secret: "heartbeat-secret",
+          });
+        }
+        return `${JSON.stringify({
+          severity: "critical",
+          code: "pilot_alert",
+          message: "Bearer alert-token and password=alert-secret",
+          at: "2026-07-25T12:00:00.000Z",
+        })}\n`;
+      }),
+    });
+
+    const exitCode = await runPilotCli([
+      "status",
+      "--work-item",
+      proposed.workItemId,
+    ], {
+      environment: {
+        DATABASE_URL:
+          "postgresql://operator:environment-secret@localhost/reference",
+        HARNESS_DISPATCH_HEARTBEAT_PATH: "/tmp/heartbeat.json",
+        HARNESS_DISPATCH_ALERTS_PATH: "/tmp/alerts.jsonl",
+      },
+      services,
+      output: (line: string) => output.push(line),
+    });
+
+    const rendered = output.join("");
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(rendered)).toMatchObject({
+      operation: "status",
+      readOnly: true,
+      dispatcherHeartbeat: {
+        status: "idle",
+        lastOutcome: "refused",
+      },
+      submissionAttemptedByCli: false,
+    });
+    expect(rendered).not.toContain("postgresql://");
+    expect(rendered).not.toContain("environment-secret");
+    expect(rendered).not.toContain("decision-secret");
+    expect(rendered).not.toContain("alert-token");
+    expect(rendered).not.toContain("alert-secret");
+    expect(rendered).not.toContain("heartbeat-secret");
+    expect(services.proposeAgentTask).not.toHaveBeenCalled();
+    expect(services.approveAgentTask).not.toHaveBeenCalled();
+    expect(services.cancelAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("reports missing database and artifact configuration without loading services", async () => {
+    const errors: string[] = [];
+    const services = pilotServices();
+    const first = await runPilotCli([
+      "propose",
+      "--fixture",
+      "docs-fix",
+    ], {
+      environment: {
+        HARNESS_DISPATCH_ARTIFACT_DIR: "/tmp/pilot-artifacts",
+      },
+      services,
+      errorOutput: (line: string) => errors.push(line),
+    });
+    const second = await runPilotCli([
+      "propose",
+      "--fixture",
+      "docs-fix",
+    ], {
+      environment: {
+        DATABASE_URL: "postgresql://pilot.invalid/reference",
+      },
+      services,
+      errorOutput: (line: string) => errors.push(line),
+    });
+
+    expect(first).toBe(1);
+    expect(second).toBe(1);
+    expect(errors.join("")).toContain("DATABASE_URL is required");
+    expect(errors.join("")).toContain(
+      "HARNESS_DISPATCH_ARTIFACT_DIR is required",
+    );
+    expect(services.loadFixture).not.toHaveBeenCalled();
+    expect(services.proposeAgentTask).not.toHaveBeenCalled();
+  });
+
+  it("parses a timezone-bearing deadline canonically", () => {
+    expect(parsePilotArgs([
+      "propose",
+      "--fixture",
+      "small-refactor",
+      "--deadline",
+      "2026-07-25T15:00:00+02:00",
+    ])).toMatchObject({
+      command: "propose",
+      fixture: "small-refactor",
+      deadline: "2026-07-25T13:00:00.000Z",
+    });
+  });
+});
+
+function pilotServices(overrides: Record<string, unknown> = {}) {
+  return {
+    loadFixture: vi.fn(async () => fixture()),
+    proposeAgentTask: vi.fn(async (input) => proposedTask(input.workItemId)),
+    approveAgentTask: vi.fn(async (input) => approvedTask(input.workItemId)),
+    cancelAgentTask: vi.fn(async (input) => ({
+      task: {
+        ...proposedTask(input.workItemId),
+        lifecycle: "cancelled",
+      },
+      harnessAcknowledged: true,
+    })),
+    listAgentTasks: vi.fn(async () => []),
+    listHermesDecisions: vi.fn(async () => []),
+    workspacePathForTask: vi.fn(
+      (workItemId: string, taskVersion: number) =>
+        `/var/lib/harness-dispatcher/workspaces/${workItemId}-v${taskVersion}`,
+    ),
+    deriveIntendedRunId: vi.fn(() => RUN_ID),
+    readTextFile: vi.fn(async () => {
+      throw new Error("file missing");
+    }),
+    ...overrides,
+  };
+}
+
+function fixture() {
+  return {
+    workItemId: "ceremony-docs-001",
+    correlationId: "ceremony-docs-001",
+    taskKind: "docs_fix",
+    title: "Fix one document",
+    objective: "Fix one bounded document.",
+    whyNow: "The pilot needs a documentation task.",
+    requestedBy: { type: "operator", id: "pilot-operator" },
+    repository: {
+      nameWithOwner: "example/reference",
+      baseRevision: "a".repeat(40),
+      allowedPaths: ["docs/**"],
+      forbiddenPaths: [".github/**"],
+    },
+    profile: "coding-change-pilot",
+    acceptanceCriteria: [],
+    budget: {
+      elapsedSeconds: 60,
+      modelTokens: 1_000,
+      toolCalls: 10,
+      estimatedUsdMicros: null,
+    },
+    deadline: "2027-12-31T23:59:59.000Z",
+    riskTier: "low",
+    selectionReason: "Bounded and reversible.",
+  };
+}
+
+function proposedTask(workItemId: string) {
+  return {
+    workItemId,
+    taskVersion: 1,
+    correlationId: workItemId,
+    lifecycle: "proposed",
+    intent: {
+      templateHash: HASH,
+    },
+    acceptance: {
+      verifierPlanHash: VERIFIER_HASH,
+    },
+    approval: {
+      status: "pending",
+    },
+  };
+}
+
+function approvedTask(workItemId: string) {
+  return {
+    ...proposedTask(workItemId),
+    lifecycle: "approved",
+    approval: {
+      status: "approved",
+      approvedTaskHash: HASH,
+    },
+  };
+}


### PR DESCRIPTION
## What changed

- Added `scripts/ops/harness-pilot.mjs`, a human-operated Node 22 CLI for proposing, explicitly approving, explicitly cancelling, and reading supervised Harness pilot tasks.
- Approval and cancellation require the exact `--confirm` flag. Proposal remains `proposed` with pending operator approval. CLI output states that it did not submit a run.
- Status reports curated AgentTask lifecycle/binding data, dispatcher heartbeat status and last outcome, recent decision records, and an alerts tail with secret/DSN redaction.
- Added `docs/HARNESS_INT2_CEREMONY_RUNBOOK.md` covering clean pinned Harness provisioning, two disposable Postgres instances, the pinned eight-capability Docker profile, scripted safety proofs, one budget-capped real-model task, §21.1 evidence mapping, source-loss proof, teardown, and abort conditions.
- Added focused parser/handler tests without spawning a process or touching a database.

## Authority and safety

This CLI is human-operated only and cannot auto-approve. It adds no scheduler, service change, dispatch authority, PR/GitHub/Averray actuation, or production authority. It never submits a Harness run or opens a PR. `HARNESS_DISPATCH_ENABLED` remains default-off; ceremony enablement is a separate explicit operator action described in the runbook.

## Checks

Run after rebasing onto current `origin/main`:

- `npm run typecheck` — exit 0
- `npm test` — 194 files passed, 1 skipped; 2,376 tests passed, 4 skipped
- `docker build --quiet -f ops/Dockerfile.node -t averray-reference-agent:int2l .` — exit 0 (`sha256:fa8a4e70ac223fc4b07cbb3fe7e23fd56dd9ada6ca9006bbd49bf299fb0f2be1`)
- `docker compose -f ops/compose.yml -f ops/compose.prod.yml config --quiet` with non-secret placeholder configuration — exit 0
- In-image `node scripts/ops/harness-pilot.mjs --help` smoke — exit 0

## Affected surfaces

- Ops: new human-operated pilot CLI
- Documentation: local disposable ceremony runbook
- Tests: focused CLI unit coverage
- Backend services, frontend, migrations, contracts, GitHub integration, and production Compose authority: unchanged

## Environment / secrets

No production environment or VPS secret changes are required. The ceremony-only local variables and disposable resource setup are documented in the runbook. No dependency or lockfile changes.