### PR TITLE
feat(dispatch): seed prepared workspace dependencies offline

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -97,14 +97,14 @@ done
 
 ### 1.3 Create and pin the pilot profile
 
-Build or select a locally available, immutable pilot image that contains Node
-22, Git, and all dependencies required by the fixture's offline `npm`
-verification commands. Because Harness bind-mounts the task checkout at
-`/workspace` and runs with `--network none`, the image must make those
-dependencies available inside that mounted workspace without downloading
-anything at run time. Keep the image build recipe and clean source revision in
-the evidence bundle. It must contain no credentials. Do not use a floating tag
-in the evidence ceremony:
+Build or select a locally available, immutable pilot image that contains only
+the runtime tools needed by these fixtures: Node 22 and Git. Do not bake the
+reference agent's `node_modules` into `/workspace`: Harness bind-mounts the
+prepared task checkout there, which shadows image-baked workspace contents.
+The host-side cache flow in §1.4 seeds exact lockfile-matched dependencies
+before the offline run starts. Keep the image build recipe and clean source
+revision in the evidence bundle. It must contain no credentials. Do not use a
+floating tag in the evidence ceremony:
 
 ```sh
 export PILOT_IMAGE="reference-agent-pilot@sha256:<operator-recorded-digest>"
@@ -178,6 +178,7 @@ export HARNESS_DISPATCH_ARTIFACT_DIR="$CEREMONY_ROOT/dispatch-artifacts"
 export HARNESS_DISPATCH_INTENT_DIR="$CEREMONY_ROOT/dispatch-intents"
 export HARNESS_DISPATCH_HEARTBEAT_PATH="$CEREMONY_ROOT/dispatcher-heartbeat.json"
 export HARNESS_DISPATCH_ALERTS_PATH="$CEREMONY_ROOT/dispatcher-alerts.jsonl"
+export HARNESS_DISPATCH_DEP_CACHE_DIR="$CEREMONY_ROOT/dispatch-dependency-cache"
 export HALT_FILE="$CEREMONY_ROOT/HALT"
 export POLICY_CONFIG_PATH="$REFERENCE_CHECKOUT/hermes/config/policy.yaml"
 export HERMES_DISPATCH_ALLOWED_REPOS="depre-dev/averray-reference-agent"
@@ -189,6 +190,7 @@ export HARNESS_DISPATCH_ENABLED=false
 mkdir -p \
   "$HARNESS_DISPATCH_ARTIFACT_DIR" \
   "$HARNESS_DISPATCH_INTENT_DIR" \
+  "$HARNESS_DISPATCH_DEP_CACHE_DIR" \
   /var/lib/harness-dispatcher/workspaces
 ```
 
@@ -196,6 +198,47 @@ The final `mkdir` may require the operator to create the directory once with
 local administrator privileges and grant only their ceremony user write
 access. Do not change `DISPATCH_WORKSPACE_ROOT`: it is part of the approved task
 hash.
+
+The `lint-format` fixture uses only `git diff --check`, so it can run with
+`HARNESS_DISPATCH_DEP_CACHE_DIR` unset. The `docs-fix`, `add-unit-test`, and
+`small-refactor` fixtures execute `npm` verification and require the exact
+offline cache. Populate it once from a clean checkout of the fixture revision:
+
+```sh
+export PILOT_SOURCE_REVISION="8b94278578913b7cd7aa1acb276db48613090c7b"
+export PILOT_DEP_CHECKOUT="$CEREMONY_ROOT/reference-agent-dependency-source"
+
+for fixture in docs-fix add-unit-test small-refactor lint-format; do
+  grep -F \
+    "\"baseRevision\": \"$PILOT_SOURCE_REVISION\"" \
+    "$REFERENCE_CHECKOUT/test/fixtures/agent-integration/ceremony/$fixture.json" \
+    > /dev/null
+done
+
+git clone --local --no-hardlinks \
+  "$REFERENCE_CHECKOUT" "$PILOT_DEP_CHECKOUT"
+git -C "$PILOT_DEP_CHECKOUT" checkout --detach "$PILOT_SOURCE_REVISION"
+test "$(git -C "$PILOT_DEP_CHECKOUT" rev-parse HEAD)" = \
+  "$PILOT_SOURCE_REVISION"
+test -z "$(git -C "$PILOT_DEP_CHECKOUT" status --porcelain)"
+
+cd "$REFERENCE_CHECKOUT"
+node scripts/ops/build-dispatch-dep-cache.mjs \
+  --checkout "$PILOT_DEP_CHECKOUT" \
+  --cache-root "$HARNESS_DISPATCH_DEP_CACHE_DIR" \
+  > "$CEREMONY_ROOT/evidence/dependency-cache.json"
+```
+
+The builder copies the clean checkout to a temporary host directory, runs
+`npm ci` there, then atomically publishes
+`<cache-root>/<package-lock-sha256>/{node_modules,manifest.json}`. This is the
+only dependency-cache population step allowed to use network access. Re-running
+it for an already valid exact hash leaves that cache entry untouched. The
+dispatcher never runs `npm`, never falls back to another cache entry, and
+copies dependencies only after it has verified the prepared Git revision.
+Harness still runs with `--network none`. If the lockfile hash is absent or the
+cache is incomplete/stale, dispatch stops before submit and records one
+operator-visible alert.
 
 Start the local monitor in a dedicated terminal for projection snapshots. It
 has no Slack token, and every routine/mutation flag remains off:

--- a/scripts/ops/build-dispatch-dep-cache.mjs
+++ b/scripts/ops/build-dispatch-dep-cache.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rename,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const options = parseArguments(process.argv.slice(2));
+
+try {
+  const result = await buildDependencyCache(options);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+} catch (error) {
+  const message = error instanceof Error
+    ? error.message
+    : "Dependency cache build failed";
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}
+
+async function buildDependencyCache({ checkout, cacheRoot }) {
+  const checkoutRoot = path.resolve(checkout);
+  const cacheRootPath = path.resolve(cacheRoot);
+  const lockfilePath = path.join(checkoutRoot, "package-lock.json");
+  const lockfileBytes = await readFile(lockfilePath);
+  const lockfileSha256 = createHash("sha256")
+    .update(lockfileBytes)
+    .digest("hex");
+  const sourceRevision = (
+    await runCaptured("git", ["rev-parse", "HEAD"], checkoutRoot)
+  ).trim();
+  const status = await runCaptured(
+    "git",
+    ["status", "--porcelain", "--untracked-files=all"],
+    checkoutRoot,
+  );
+  if (status.trim()) {
+    throw new Error("Dependency cache source checkout must be clean");
+  }
+
+  await mkdir(cacheRootPath, { recursive: true });
+  const target = path.join(cacheRootPath, lockfileSha256);
+  const existing = await cacheEntryState(target, lockfileSha256);
+  if (existing === "valid") {
+    return {
+      outcome: "reused",
+      lockfileSha256,
+      sourceRevision,
+      cachePath: target,
+    };
+  }
+  if (existing === "invalid") {
+    throw new Error(
+      `Existing dependency cache entry is incomplete for sha256:${lockfileSha256}`,
+    );
+  }
+
+  const buildRoot = await mkdtemp(
+    path.join(tmpdir(), "harness-dispatch-deps-"),
+  );
+  const buildCheckout = path.join(buildRoot, "checkout");
+  const staging = path.join(
+    cacheRootPath,
+    `.staging-${lockfileSha256}-${randomUUID()}`,
+  );
+  try {
+    await cp(checkoutRoot, buildCheckout, {
+      recursive: true,
+      verbatimSymlinks: true,
+      filter(source) {
+        const relative = path.relative(checkoutRoot, source);
+        if (!relative) return true;
+        const firstSegment = relative.split(path.sep)[0];
+        return firstSegment !== ".git" && firstSegment !== "node_modules";
+      },
+    });
+    await runInherited("npm", ["ci"], buildCheckout);
+
+    const builtNodeModules = path.join(buildCheckout, "node_modules");
+    if (!(await statusOrUndefined(builtNodeModules))?.isDirectory()) {
+      throw new Error("npm ci did not produce a node_modules directory");
+    }
+
+    await mkdir(staging);
+    await cp(builtNodeModules, path.join(staging, "node_modules"), {
+      recursive: true,
+      verbatimSymlinks: true,
+    });
+    await writeFile(
+      path.join(staging, "manifest.json"),
+      `${JSON.stringify({
+        lockfileSha256,
+        createdAt: new Date().toISOString(),
+        sourceRevision,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+
+    try {
+      await rename(staging, target);
+    } catch {
+      if (await cacheEntryState(target, lockfileSha256) !== "valid") {
+        throw new Error(
+          `Could not publish dependency cache for sha256:${lockfileSha256}`,
+        );
+      }
+    }
+  } finally {
+    await rm(buildRoot, { recursive: true, force: true });
+    await rm(staging, { recursive: true, force: true });
+  }
+
+  return {
+    outcome: "created",
+    lockfileSha256,
+    sourceRevision,
+    cachePath: target,
+  };
+}
+
+async function cacheEntryState(target, expectedHash) {
+  const targetStatus = await statusOrUndefined(target);
+  if (!targetStatus) return "missing";
+  if (!targetStatus.isDirectory()) return "invalid";
+  const modules = await statusOrUndefined(path.join(target, "node_modules"));
+  if (!modules?.isDirectory()) return "invalid";
+  try {
+    const manifest = JSON.parse(
+      await readFile(path.join(target, "manifest.json"), "utf8"),
+    );
+    return manifest?.lockfileSha256 === expectedHash
+      && typeof manifest.createdAt === "string"
+      && typeof manifest.sourceRevision === "string"
+      ? "valid"
+      : "invalid";
+  } catch {
+    return "invalid";
+  }
+}
+
+async function statusOrUndefined(target) {
+  try {
+    return await stat(target);
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function runCaptured(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.once("error", () => reject(new Error(`${command} could not start`)));
+    child.once("close", (code) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`${command} exited with code ${code ?? 1}`));
+    });
+  });
+}
+
+function runInherited(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      stdio: "inherit",
+    });
+    child.once("error", () => reject(new Error(`${command} could not start`)));
+    child.once("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} exited with code ${code ?? 1}`));
+    });
+  });
+}
+
+function parseArguments(args) {
+  if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
+    process.stdout.write(
+      "Usage: build-dispatch-dep-cache.mjs --checkout <path> --cache-root <path>\n",
+    );
+    process.exit(0);
+  }
+  const values = new Map();
+  for (let index = 0; index < args.length; index += 2) {
+    const name = args[index];
+    const value = args[index + 1];
+    if (
+      (name !== "--checkout" && name !== "--cache-root")
+      || !value
+      || value.startsWith("--")
+    ) {
+      throw new Error(
+        "Usage: build-dispatch-dep-cache.mjs --checkout <path> --cache-root <path>",
+      );
+    }
+    values.set(name, value);
+  }
+  if (
+    values.size !== 2
+    || !values.get("--checkout")
+    || !values.get("--cache-root")
+  ) {
+    throw new Error(
+      "Usage: build-dispatch-dep-cache.mjs --checkout <path> --cache-root <path>",
+    );
+  }
+  return {
+    checkout: values.get("--checkout"),
+    cacheRoot: values.get("--cache-root"),
+  };
+}

--- a/services/harness-dispatcher/src/dispatch-attempt.ts
+++ b/services/harness-dispatcher/src/dispatch-attempt.ts
@@ -196,7 +196,13 @@ export async function runSingleDispatch(
       workspacePath = await deps.prepareWorkspace(task);
     } catch (error) {
       if (error instanceof WorkspacePrepError) {
-        return refuse(deps, task, intendedRunId, "workspace_prep_failed");
+        return refuse(
+          deps,
+          task,
+          intendedRunId,
+          "workspace_prep_failed",
+          dependencyRefusalAlert(error),
+        );
       }
       throw error;
     }
@@ -325,8 +331,9 @@ async function refuse(
   task: AgentTaskV1,
   intendedRunId: string,
   reason: string,
+  alert?: RefusalAlert,
 ): Promise<DispatchAttemptResult> {
-  await blockAndRecordRefusal(deps, task, intendedRunId, reason);
+  await blockAndRecordRefusal(deps, task, intendedRunId, reason, alert);
   return {
     outcome: "refused",
     workItemId: task.workItemId,
@@ -341,6 +348,7 @@ async function blockAndRecordRefusal(
   task: AgentTaskV1,
   intendedRunId: string | undefined,
   reason: string,
+  alert?: RefusalAlert,
 ): Promise<void> {
   const updatedAt = deps.now().toISOString();
   const blockedTask: AgentTaskV1 = {
@@ -356,12 +364,12 @@ async function blockAndRecordRefusal(
     buildDispatchDecision(blockedTask, "dispatch_refusal", reason, deps.now()),
   );
   await deps.alertSink({
-    severity: "warn",
-    code: "dispatch_refusal",
+    severity: alert?.severity ?? "warn",
+    code: alert?.code ?? "dispatch_refusal",
     workItemId: task.workItemId,
     taskVersion: task.taskVersion,
     ...(intendedRunId ? { harnessRunId: intendedRunId } : {}),
-    message: `Harness dispatch was refused: ${reason}.`,
+    message: alert?.message ?? `Harness dispatch was refused: ${reason}.`,
     at: deps.now().toISOString(),
   });
   deps.logger?.warn({
@@ -370,6 +378,29 @@ async function blockAndRecordRefusal(
     ...(intendedRunId ? { intendedRunId } : {}),
     reason,
   }, "Harness dispatch refused");
+}
+
+interface RefusalAlert {
+  severity: "warn" | "critical";
+  code: string;
+  message: string;
+}
+
+function dependencyRefusalAlert(
+  error: WorkspacePrepError,
+): RefusalAlert | undefined {
+  if (
+    error.reason !== "dependency_cache_missing"
+    && error.reason !== "dependency_cache_stale"
+    && error.reason !== "dependency_seed_failed"
+  ) {
+    return undefined;
+  }
+  return {
+    severity: error.reason === "dependency_cache_stale" ? "critical" : "warn",
+    code: error.reason,
+    message: `Harness dispatch dependency preparation failed: ${error.message}.`,
+  };
 }
 
 function buildDispatchDecision(

--- a/services/harness-dispatcher/src/index.ts
+++ b/services/harness-dispatcher/src/index.ts
@@ -46,7 +46,10 @@ import {
   type ReconcileResult,
   type ReconcileRunDeps,
 } from "./reconcile-run.js";
-import { prepareTaskWorkspace } from "./workspace-prep.js";
+import {
+  prepareTaskWorkspace,
+  seedWorkspaceDependencies,
+} from "./workspace-prep.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 15_000;
 const MIN_POLL_INTERVAL_MS = 5_000;
@@ -404,7 +407,18 @@ export function createProductionDispatcher(
     bindRun: bindRunToWorkItem,
     loadProfileManifest: (profileId) =>
       loadProfileManifest(profileId, environment),
-    prepareWorkspace: prepareTaskWorkspace,
+    prepareWorkspace: (task) =>
+      prepareTaskWorkspace(task, {
+        seedDependencies: (candidate, workspacePath) =>
+          seedWorkspaceDependencies(candidate, workspacePath, {
+            environment,
+          }),
+        logger: {
+          info(fields, message) {
+            logger.info(fields, message);
+          },
+        },
+      }),
     writeIntentArtifact: createIntentArtifactWriter(config.intentDir),
     controlPort,
     recordDecision: recordHermesDecision,

--- a/services/harness-dispatcher/src/workspace-prep.ts
+++ b/services/harness-dispatcher/src/workspace-prep.ts
@@ -1,7 +1,13 @@
 import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
 import {
+  cp as copyPath,
   mkdir as mkdirPath,
+  readFile as readFilePath,
+  realpath as resolveRealPath,
+  rename as renamePath,
   rm as removePath,
+  stat as statPath,
 } from "node:fs/promises";
 import path from "node:path";
 
@@ -21,7 +27,12 @@ export type WorkspacePrepReason =
   | "clone_failed"
   | "revision_mismatch"
   | "cleanup_failed"
-  | "invalid_repository";
+  | "invalid_repository"
+  | "dependency_cache_missing"
+  | "dependency_cache_stale"
+  | "dependency_seed_failed";
+
+export type DependencySeedOutcome = "skipped" | "seeded";
 
 export class WorkspacePrepError extends Error {
   constructor(
@@ -46,6 +57,40 @@ export interface WorkspacePrepDeps {
   ): Promise<GitCommandResult>;
   rm(path: string): Promise<void>;
   mkdir(path: string): Promise<void>;
+  seedDependencies(
+    task: AgentTaskV1,
+    workspacePath: string,
+  ): Promise<DependencySeedOutcome>;
+  logger?: {
+    info(fields: Record<string, unknown>, message: string): void;
+  };
+}
+
+interface FileStatus {
+  isDirectory(): boolean;
+  isFile(): boolean;
+}
+
+interface DependencyCopyOptions {
+  recursive: true;
+  dereference: true;
+  force: false;
+  errorOnExist: true;
+  filter(source: string): Promise<boolean>;
+}
+
+export interface DependencySeedDeps {
+  environment: Readonly<Record<string, string | undefined>>;
+  cp(
+    source: string,
+    destination: string,
+    options: DependencyCopyOptions,
+  ): Promise<void>;
+  stat(target: string): Promise<FileStatus>;
+  readFile(target: string): Promise<Buffer>;
+  realpath(target: string): Promise<string>;
+  rename(source: string, destination: string): Promise<void>;
+  rm(target: string): Promise<void>;
 }
 
 export async function prepareTaskWorkspace(
@@ -98,7 +143,155 @@ export async function prepareTaskWorkspace(
     );
   }
 
+  const dependencySeedOutcome = await resolved.seedDependencies(task, target);
+  if (dependencySeedOutcome === "seeded") {
+    await assertDependencySeedIsIgnored(resolved.runGit, target);
+  }
+  resolved.logger?.info({
+    workItemId: task.workItemId,
+    taskVersion: task.taskVersion,
+    dependencySeedOutcome,
+  }, "Prepared Harness task workspace dependencies");
+
   return target;
+}
+
+export async function seedWorkspaceDependencies(
+  task: AgentTaskV1,
+  workspacePath: string,
+  deps: Partial<DependencySeedDeps> = {},
+): Promise<DependencySeedOutcome> {
+  const resolved = dependencySeedDeps(deps);
+  const cacheRootInput =
+    resolved.environment.HARNESS_DISPATCH_DEP_CACHE_DIR?.trim();
+  if (!cacheRootInput) return "skipped";
+
+  const workspaceRoot = await requiredRealPath(
+    resolved,
+    workspacePath,
+    "Prepared workspace could not be resolved for dependency seeding",
+  );
+  const lockfilePath = path.join(workspaceRoot, "package-lock.json");
+  const lockfileStatus = await optionalStatus(resolved, lockfilePath);
+  if (!lockfileStatus) return "skipped";
+  if (!lockfileStatus.isFile()) {
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Prepared workspace package-lock.json is not a regular file",
+    );
+  }
+
+  let lockfileBytes: Buffer;
+  try {
+    lockfileBytes = await resolved.readFile(lockfilePath);
+  } catch {
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Prepared workspace package-lock.json could not be read",
+    );
+  }
+  const lockfileSha256 = createHash("sha256")
+    .update(lockfileBytes)
+    .digest("hex");
+  const expectedHash = `sha256:${lockfileSha256}`;
+  const cacheRoot = path.resolve(cacheRootInput);
+  const cacheRootStatus = await optionalStatus(resolved, cacheRoot);
+  if (!cacheRootStatus || !cacheRootStatus.isDirectory()) {
+    throw dependencyError(
+      "dependency_cache_missing",
+      `Dependency cache root is unavailable; expected ${expectedHash}`,
+    );
+  }
+
+  const cacheEntry = path.join(cacheRoot, lockfileSha256);
+  assertContainedPath(cacheRoot, cacheEntry, "dependency_seed_failed");
+  const cacheEntryStatus = await optionalStatus(resolved, cacheEntry);
+  if (!cacheEntryStatus || !cacheEntryStatus.isDirectory()) {
+    throw dependencyError(
+      "dependency_cache_stale",
+      `No exact dependency cache exists for expected ${expectedHash}`,
+    );
+  }
+
+  const manifestPath = path.join(cacheEntry, "manifest.json");
+  const cachedNodeModules = path.join(cacheEntry, "node_modules");
+  const [manifestStatus, nodeModulesStatus] = await Promise.all([
+    optionalStatus(resolved, manifestPath),
+    optionalStatus(resolved, cachedNodeModules),
+  ]);
+  if (!manifestStatus?.isFile() || !nodeModulesStatus?.isDirectory()) {
+    throw dependencyError(
+      "dependency_cache_missing",
+      `Dependency cache entry is incomplete for expected ${expectedHash}`,
+    );
+  }
+  await verifyDependencyCacheManifest(
+    resolved,
+    manifestPath,
+    lockfileSha256,
+  );
+
+  const cacheRootReal = await requiredRealPath(
+    resolved,
+    cacheRoot,
+    "Dependency cache root could not be resolved",
+  );
+  const cachedNodeModulesReal = await requiredRealPath(
+    resolved,
+    cachedNodeModules,
+    "Cached node_modules could not be resolved",
+  );
+  assertContainedOrEqual(
+    cacheRootReal,
+    cachedNodeModulesReal,
+    "dependency_seed_failed",
+  );
+
+  const target = path.join(workspaceRoot, "node_modules");
+  assertContainedPath(workspaceRoot, target, "dependency_seed_failed");
+  if (await optionalStatus(resolved, target)) {
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Prepared workspace already contains node_modules",
+    );
+  }
+
+  const staging = path.join(
+    workspaceRoot,
+    `.node_modules.seed-${randomUUID()}`,
+  );
+  assertContainedPath(workspaceRoot, staging, "dependency_seed_failed");
+  try {
+    await resolved.cp(cachedNodeModulesReal, staging, {
+      recursive: true,
+      dereference: true,
+      force: false,
+      errorOnExist: true,
+      filter: async (source) => {
+        const sourceReal = await resolved.realpath(source);
+        assertContainedOrEqual(
+          cachedNodeModulesReal,
+          sourceReal,
+          "dependency_seed_failed",
+        );
+        return true;
+      },
+    });
+    await resolved.rename(staging, target);
+  } catch (error) {
+    try {
+      await resolved.rm(staging);
+    } catch {
+      // The refusal reason remains deterministic even if staging cleanup fails.
+    }
+    if (error instanceof WorkspacePrepError) throw error;
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Cached dependencies could not be copied into the prepared workspace",
+    );
+  }
+
+  return "seeded";
 }
 
 export async function disposeTaskWorkspace(
@@ -127,6 +320,26 @@ function workspacePrepDeps(
     }),
     mkdir: deps.mkdir ?? (async (target) => {
       await mkdirPath(target, { recursive: true });
+    }),
+    seedDependencies: deps.seedDependencies ?? seedWorkspaceDependencies,
+    ...(deps.logger ? { logger: deps.logger } : {}),
+  };
+}
+
+function dependencySeedDeps(
+  deps: Partial<DependencySeedDeps>,
+): DependencySeedDeps {
+  return {
+    environment: deps.environment ?? process.env,
+    cp: deps.cp ?? (async (source, destination, options) => {
+      await copyPath(source, destination, options);
+    }),
+    stat: deps.stat ?? statPath,
+    readFile: deps.readFile ?? readFilePath,
+    realpath: deps.realpath ?? resolveRealPath,
+    rename: deps.rename ?? renamePath,
+    rm: deps.rm ?? (async (target) => {
+      await removePath(target, { recursive: true, force: true });
     }),
   };
 }
@@ -158,6 +371,34 @@ function assertContained(target: string): void {
       "Task workspace path must remain under the dispatch root",
     );
   }
+}
+
+function assertContainedPath(
+  root: string,
+  target: string,
+  reason: WorkspacePrepReason,
+): void {
+  const relative = path.relative(root, target);
+  if (
+    !relative
+    || relative.startsWith(`..${path.sep}`)
+    || relative === ".."
+    || path.isAbsolute(relative)
+  ) {
+    throw dependencyError(
+      reason,
+      "Dependency seed path escaped its required root",
+    );
+  }
+}
+
+function assertContainedOrEqual(
+  root: string,
+  target: string,
+  reason: WorkspacePrepReason,
+): void {
+  if (root === target) return;
+  assertContainedPath(root, target, reason);
 }
 
 function publicCloneUrl(task: AgentTaskV1): string {
@@ -199,6 +440,101 @@ async function runRequiredGitStep(
     );
   }
   return result;
+}
+
+async function assertDependencySeedIsIgnored(
+  execute: WorkspacePrepDeps["runGit"],
+  cwd: string,
+): Promise<void> {
+  let result: GitCommandResult;
+  try {
+    result = await execute(
+      ["status", "--porcelain", "--untracked-files=all"],
+      cwd,
+    );
+  } catch {
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Git status could not verify the seeded dependency directory",
+    );
+  }
+  if (result.code !== 0 || result.stdout.trim()) {
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Seeded dependencies changed the prepared workspace Git status",
+    );
+  }
+}
+
+async function verifyDependencyCacheManifest(
+  deps: DependencySeedDeps,
+  manifestPath: string,
+  expectedLockfileSha256: string,
+): Promise<void> {
+  let value: unknown;
+  try {
+    value = JSON.parse((await deps.readFile(manifestPath)).toString("utf8"));
+  } catch {
+    throw dependencyError(
+      "dependency_cache_stale",
+      `Dependency cache manifest is invalid for expected sha256:${expectedLockfileSha256}`,
+    );
+  }
+  if (
+    !isRecord(value)
+    || value.lockfileSha256 !== expectedLockfileSha256
+    || typeof value.createdAt !== "string"
+    || !Number.isFinite(Date.parse(value.createdAt))
+    || typeof value.sourceRevision !== "string"
+    || value.sourceRevision.trim().length === 0
+  ) {
+    throw dependencyError(
+      "dependency_cache_stale",
+      `Dependency cache manifest does not match expected sha256:${expectedLockfileSha256}`,
+    );
+  }
+}
+
+async function optionalStatus(
+  deps: DependencySeedDeps,
+  target: string,
+): Promise<FileStatus | undefined> {
+  try {
+    return await deps.stat(target);
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined;
+    throw dependencyError(
+      "dependency_seed_failed",
+      "Dependency seed path could not be inspected",
+    );
+  }
+}
+
+async function requiredRealPath(
+  deps: DependencySeedDeps,
+  target: string,
+  message: string,
+): Promise<string> {
+  try {
+    return await deps.realpath(target);
+  } catch {
+    throw dependencyError("dependency_seed_failed", message);
+  }
+}
+
+function dependencyError(
+  reason: WorkspacePrepReason,
+  message: string,
+): WorkspacePrepError {
+  return new WorkspacePrepError(reason, message);
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 const runGit: WorkspacePrepDeps["runGit"] = (

--- a/test/unit/dispatch-attempt.test.ts
+++ b/test/unit/dispatch-attempt.test.ts
@@ -272,6 +272,44 @@ describe("single-attempt Harness dispatch orchestration", () => {
     expect(deps.writeIntentArtifact).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["dependency_cache_missing", "warn"],
+    ["dependency_cache_stale", "critical"],
+    ["dependency_seed_failed", "warn"],
+  ] as const)("emits one distinct %s alert and never submits", async (
+    workspaceReason,
+    severity,
+  ) => {
+    const task = await approvedTask();
+    const deps = dispatchDeps(task);
+    const expectedHash = `sha256:${"a".repeat(64)}`;
+    vi.mocked(deps.prepareWorkspace).mockRejectedValue(
+      new WorkspacePrepError(
+        workspaceReason,
+        `Dependency preparation failed for expected ${expectedHash}`,
+      ),
+    );
+
+    await expect(runSingleDispatch(deps)).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "workspace_prep_failed",
+      intendedRunId: intendedId(task),
+    });
+
+    assertRefusal(deps, "workspace_prep_failed", {
+      severity,
+      code: workspaceReason,
+    });
+    expect(deps.alertSink).toHaveBeenCalledOnce();
+    expect(deps.alertSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining(expectedHash),
+      }),
+    );
+    expect(deps.controlPort.submit).not.toHaveBeenCalled();
+    expect(deps.writeIntentArtifact).not.toHaveBeenCalled();
+  });
+
   it("refuses a prepared path that differs from the shared deterministic path", async () => {
     const task = await approvedTask();
     const deps = dispatchDeps(task);
@@ -540,15 +578,29 @@ function dispatchDeps(task: AgentTaskV1): DispatchDeps {
   };
 }
 
-function assertRefusal(deps: DispatchDeps, reason: string): void {
+function assertRefusal(
+  deps: DispatchDeps,
+  reason: string,
+  alert: { severity: "warn" | "critical"; code: string } = {
+    severity: "warn",
+    code: "dispatch_refusal",
+  },
+): void {
   expect(deps.controlPort.submit).not.toHaveBeenCalled();
   expect(deps.saveTask).toHaveBeenCalledOnce();
   expect(savedTask(deps, 0).lifecycle).toBe("blocked");
-  assertDecision(deps, reason);
+  assertDecision(deps, reason, alert);
   expect(deps.releaseLease).toHaveBeenCalledOnce();
 }
 
-function assertDecision(deps: DispatchDeps, reason: string): void {
+function assertDecision(
+  deps: DispatchDeps,
+  reason: string,
+  alert: { severity: "warn" | "critical"; code: string } = {
+    severity: "warn",
+    code: "dispatch_refusal",
+  },
+): void {
   const records = decisionRecords(deps);
   expect(records).toHaveLength(1);
   expect(records[0]).toMatchObject({
@@ -560,10 +612,9 @@ function assertDecision(deps: DispatchDeps, reason: string): void {
   expect(deps.alertSink).toHaveBeenCalledOnce();
   expect(deps.alertSink).toHaveBeenCalledWith(
     expect.objectContaining({
-      severity: "warn",
-      code: "dispatch_refusal",
+      severity: alert.severity,
+      code: alert.code,
       workItemId: expect.any(String),
-      message: expect.stringContaining(reason),
     }),
   );
 }

--- a/test/unit/workspace-prep.test.ts
+++ b/test/unit/workspace-prep.test.ts
@@ -1,6 +1,18 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm as removePath,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   agentTaskV1Schema,
@@ -10,14 +22,27 @@ import {
   workspacePathForTask,
 } from "../../packages/averray-mcp/src/workspace-path.js";
 import {
+  buildTaskIntentArtifact,
+} from "../../packages/averray-mcp/src/task-intent-mapping.js";
+import {
   disposeTaskWorkspace,
   prepareTaskWorkspace,
+  seedWorkspaceDependencies,
   WorkspacePrepError,
+  type DependencySeedOutcome,
   type GitCommandResult,
   type WorkspacePrepDeps,
 } from "../../services/harness-dispatcher/src/workspace-prep.js";
 
 const FAKE_CREDENTIAL = "ghp_this-must-never-appear";
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) =>
+      removePath(root, { recursive: true, force: true })),
+  );
+});
 
 describe("task workspace preparation", () => {
   it("cleans first, uses fixed Git argv, verifies HEAD, and returns the path", async () => {
@@ -37,11 +62,16 @@ describe("task workspace preparation", () => {
       mkdir: vi.fn(async () => {
         order.push("mkdir");
       }),
+      seedDependencies: vi.fn(async () => {
+        order.push("seed:skipped");
+        return "skipped";
+      }),
     });
 
     await expect(prepareTaskWorkspace(task, deps)).resolves.toBe(target);
 
     expect(order.slice(0, 3)).toEqual(["rm", "mkdir", "git:init"]);
+    expect(order.at(-1)).toBe("seed:skipped");
     expect(deps.runGit).toHaveBeenCalledTimes(5);
     expect(deps.runGit).toHaveBeenNthCalledWith(1, ["init"], target);
     expect(deps.runGit).toHaveBeenNthCalledWith(
@@ -100,6 +130,7 @@ describe("task workspace preparation", () => {
     );
 
     expect(error.reason).toBe("revision_mismatch");
+    expect(deps.seedDependencies).not.toHaveBeenCalled();
   });
 
   it("maps a non-zero Git exit without exposing raw stderr credentials", async () => {
@@ -173,6 +204,198 @@ describe("task workspace preparation", () => {
     expect(deps.mkdir).not.toHaveBeenCalled();
     expect(deps.runGit).not.toHaveBeenCalled();
   });
+
+  it("seeds only after revision verification and proves Git status is unchanged", async () => {
+    const task = agentTaskFixture();
+    const order: string[] = [];
+    const deps = workspacePrepDeps({
+      runGit: vi.fn(async (args) => {
+        order.push(`git:${args.join(" ")}`);
+        return gitResult(
+          args[0] === "rev-parse" ? task.repository.baseRevision : "",
+        );
+      }),
+      seedDependencies: vi.fn(async () => {
+        order.push("seed");
+        return "seeded";
+      }),
+    });
+
+    await prepareTaskWorkspace(task, deps);
+
+    expect(order.indexOf("git:rev-parse HEAD")).toBeLessThan(
+      order.indexOf("seed"),
+    );
+    expect(order.at(-1)).toBe("git:status --porcelain --untracked-files=all");
+    expect(deps.runGit).toHaveBeenCalledTimes(6);
+  });
+
+  it("fails closed when seeded dependencies appear in Git status", async () => {
+    const task = agentTaskFixture();
+    const deps = workspacePrepDeps({
+      runGit: vi.fn(async (args) => {
+        if (args[0] === "rev-parse") {
+          return gitResult(task.repository.baseRevision);
+        }
+        if (args[0] === "status") {
+          return gitResult("?? node_modules/\n");
+        }
+        return gitResult();
+      }),
+      seedDependencies: vi.fn(async () => "seeded"),
+    });
+
+    const error = await capturedWorkspacePrepError(
+      prepareTaskWorkspace(task, deps),
+    );
+
+    expect(error.reason).toBe("dependency_seed_failed");
+  });
+
+  it("keeps the TaskIntent template hash identical with or without seeding", async () => {
+    const task = agentTaskFixture();
+    const skippedPath = await prepareTaskWorkspace(
+      task,
+      workspacePrepDeps({
+        seedDependencies: vi.fn(async () => "skipped"),
+      }),
+    );
+    const seededPath = await prepareTaskWorkspace(
+      task,
+      workspacePrepDeps({
+        seedDependencies: vi.fn(async () => "seeded"),
+      }),
+    );
+
+    const [skipped, seeded] = await Promise.all([
+      buildTaskIntentArtifact(task, { workspacePath: skippedPath }),
+      buildTaskIntentArtifact(task, { workspacePath: seededPath }),
+    ]);
+
+    expect(seeded.templateHash).toBe(skipped.templateHash);
+    expect(seeded.canonicalBytes).toBe(skipped.canonicalBytes);
+  });
+});
+
+describe("offline workspace dependency seeding", () => {
+  it("skips without a configured cache and never copies", async () => {
+    const cp = vi.fn(async () => undefined);
+
+    await expect(seedWorkspaceDependencies(
+      agentTaskFixture(),
+      "/workspace/does-not-need-to-exist",
+      { environment: {}, cp },
+    )).resolves.toBe("skipped");
+
+    expect(cp).not.toHaveBeenCalled();
+  });
+
+  it("skips a prepared workspace without package-lock.json", async () => {
+    const { workspace, cacheRoot } = await emptySeedFixture();
+    const cp = vi.fn(async () => undefined);
+
+    await expect(seedWorkspaceDependencies(
+      agentTaskFixture(),
+      workspace,
+      {
+        environment: { HARNESS_DISPATCH_DEP_CACHE_DIR: cacheRoot },
+        cp,
+      },
+    )).resolves.toBe("skipped");
+
+    expect(cp).not.toHaveBeenCalled();
+  });
+
+  it("copies the exact lockfile cache into workspace node_modules", async () => {
+    const fixture = await populatedSeedFixture();
+
+    await expect(seedWorkspaceDependencies(
+      agentTaskFixture(),
+      fixture.workspace,
+      {
+        environment: {
+          HARNESS_DISPATCH_DEP_CACHE_DIR: fixture.cacheRoot,
+        },
+      },
+    )).resolves.toBe("seeded");
+
+    await expect(readFile(
+      path.join(fixture.workspace, "node_modules", "example", "index.js"),
+      "utf8",
+    )).resolves.toBe("export const seeded = true;\n");
+  });
+
+  it("refuses a missing exact lockfile cache as stale without copying or networking", async () => {
+    const { workspace, cacheRoot } = await emptySeedFixture();
+    await writeFile(
+      path.join(workspace, "package-lock.json"),
+      "{\"lockfileVersion\":3}\n",
+    );
+    const cp = vi.fn(async () => undefined);
+
+    const error = await capturedWorkspacePrepError(
+      seedWorkspaceDependencies(agentTaskFixture(), workspace, {
+        environment: { HARNESS_DISPATCH_DEP_CACHE_DIR: cacheRoot },
+        cp,
+      }),
+    );
+
+    const expectedHash = createHash("sha256")
+      .update("{\"lockfileVersion\":3}\n")
+      .digest("hex");
+    expect(error.reason).toBe("dependency_cache_stale");
+    expect(error.message).toContain(`sha256:${expectedHash}`);
+    expect(cp).not.toHaveBeenCalled();
+
+    const source = readFileSync(
+      new URL(
+        "../../services/harness-dispatcher/src/workspace-prep.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(source).not.toContain("npm install");
+    expect(source).not.toContain("npm ci");
+    expect(source).not.toMatch(/\bfetch\s*\(/);
+  });
+
+  it("reports a configured but unavailable cache root as missing", async () => {
+    const { workspace, root } = await emptySeedFixture();
+    await writeFile(path.join(workspace, "package-lock.json"), "{}\n");
+
+    const error = await capturedWorkspacePrepError(
+      seedWorkspaceDependencies(agentTaskFixture(), workspace, {
+        environment: {
+          HARNESS_DISPATCH_DEP_CACHE_DIR: path.join(root, "missing-cache"),
+        },
+      }),
+    );
+
+    expect(error.reason).toBe("dependency_cache_missing");
+  });
+
+  it("rejects a cached symlink that resolves outside node_modules", async () => {
+    const fixture = await populatedSeedFixture();
+    const external = path.join(fixture.root, "outside.js");
+    await writeFile(external, "do not copy\n");
+    await symlink(
+      external,
+      path.join(fixture.cacheNodeModules, "escape.js"),
+    );
+
+    const error = await capturedWorkspacePrepError(
+      seedWorkspaceDependencies(agentTaskFixture(), fixture.workspace, {
+        environment: {
+          HARNESS_DISPATCH_DEP_CACHE_DIR: fixture.cacheRoot,
+        },
+      }),
+    );
+
+    expect(error.reason).toBe("dependency_seed_failed");
+    await expect(
+      stat(path.join(fixture.workspace, "node_modules")),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
 });
 
 function workspacePrepDeps(
@@ -185,7 +408,59 @@ function workspacePrepDeps(
         : "")),
     rm: overrides.rm ?? vi.fn(async () => undefined),
     mkdir: overrides.mkdir ?? vi.fn(async () => undefined),
+    seedDependencies: overrides.seedDependencies
+      ?? vi.fn(async (): Promise<DependencySeedOutcome> => "skipped"),
+    ...(overrides.logger ? { logger: overrides.logger } : {}),
   };
+}
+
+async function emptySeedFixture(): Promise<{
+  root: string;
+  workspace: string;
+  cacheRoot: string;
+}> {
+  const root = await mkdtemp(path.join(tmpdir(), "harness-dep-seed-"));
+  temporaryRoots.push(root);
+  const workspace = path.join(root, "workspace");
+  const cacheRoot = path.join(root, "cache");
+  await Promise.all([
+    mkdir(workspace, { recursive: true }),
+    mkdir(cacheRoot, { recursive: true }),
+  ]);
+  return { root, workspace, cacheRoot };
+}
+
+async function populatedSeedFixture(): Promise<{
+  root: string;
+  workspace: string;
+  cacheRoot: string;
+  cacheNodeModules: string;
+}> {
+  const fixture = await emptySeedFixture();
+  const lockfile = "{\"lockfileVersion\":3,\"packages\":{}}\n";
+  await writeFile(
+    path.join(fixture.workspace, "package-lock.json"),
+    lockfile,
+  );
+  const hash = createHash("sha256").update(lockfile).digest("hex");
+  const cacheEntry = path.join(fixture.cacheRoot, hash);
+  const cacheNodeModules = path.join(cacheEntry, "node_modules");
+  await mkdir(path.join(cacheNodeModules, "example"), { recursive: true });
+  await Promise.all([
+    writeFile(
+      path.join(cacheNodeModules, "example", "index.js"),
+      "export const seeded = true;\n",
+    ),
+    writeFile(
+      path.join(cacheEntry, "manifest.json"),
+      `${JSON.stringify({
+        lockfileSha256: hash,
+        createdAt: "2026-07-25T12:00:00.000Z",
+        sourceRevision: agentTaskFixture().repository.baseRevision,
+      })}\n`,
+    ),
+  ]);
+  return { ...fixture, cacheNodeModules };
 }
 
 function gitResult(


### PR DESCRIPTION
## What changed

- Added lockfile-addressed offline dependency seeding to prepared Harness workspaces after exact Git revision verification.
- Added fail-closed `dependency_cache_missing`, `dependency_cache_stale`, and `dependency_seed_failed` reasons with one distinct operator alert and no submit on refusal.
- Added `scripts/ops/build-dispatch-dep-cache.mjs`, which runs the only cache-population `npm ci` in a temporary host checkout and atomically publishes `<cacheRoot>/<lockfileSha256>/{node_modules,manifest.json}`. Exact valid entries are reused without modification.
- Updated the INT-2 ceremony runbook so the pilot image only needs Node 22 + Git and documents the cache flow for the three npm-backed fixtures; `lint-format` still needs no cache.
- Added tests for skip behavior, exact-hash seeding, stale/missing/failure refusal, symlink containment, revision-before-seed ordering, clean Git status, distinct single alerts, no submit, and unchanged TaskIntent template hashing.

Dependency seeding is offline-only at dispatch time: it invokes no package manager, performs no network fallback, and copies only an exact package-lock SHA-256 match. This PR does not change AgentTask/TaskIntent construction, canonical task hashes, dispatch enablement, production authority, or merge/deploy authority.

## Checks run

- `npm run typecheck` — passed
- `npm test` — passed: 194 files / 2,388 tests; 4 existing opt-in Postgres integration tests skipped
- `npx tsc -b services/harness-dispatcher --pretty false` — passed
- `npx vitest run test/unit/workspace-prep.test.ts test/unit/dispatch-attempt.test.ts` — passed: 43 tests
- `docker build -f ops/Dockerfile.node .` — passed
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config --quiet` — passed
- Cache builder smoke — first run `created`; second run `reused`; cache entry mtime unchanged
- `git diff --check` and `node --check scripts/ops/build-dispatch-dep-cache.mjs` — passed

## Affected surfaces

- Harness dispatcher workspace preparation and refusal alerts
- Operator-only dependency-cache build script
- INT-2 ceremony runbook
- Unit tests

No schema, migration, MCP contract, monitor UI, production Compose, Harness kernel, wallet, settlement, GitHub mutation, or secret/config value changes.

## Rollout / rollback

- Default behavior is unchanged when `HARNESS_DISPATCH_DEP_CACHE_DIR` is unset: seeding returns `skipped`.
- For npm-backed ceremony fixtures, the operator builds an exact cache entry and exports the cache root before enabling the local dispatcher.
- A missing/stale/incomplete cache fails closed before Harness submit and emits one alert.
- Roll back by reverting this PR and leaving `HARNESS_DISPATCH_DEP_CACHE_DIR` unset. No database or artifact migration is required.

## Known limits / follow-ups

- This PR does not run the ceremony or enable dispatch.
- The cache is intentionally npm/package-lock specific; workspaces without `package-lock.json` are skipped.
- No production authority changes; no runtime network access; no TaskIntent/hash changes.