### PR TITLE
docs(harness): pin compatible ceremony runtime

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -30,9 +30,9 @@ export HARNESS_CHECKOUT="$CEREMONY_ROOT/agent-harness"
 export REFERENCE_CHECKOUT="/absolute/path/to/averray-reference-agent"
 
 git clone https://github.com/averray-agent/agent-harness.git "$HARNESS_CHECKOUT"
-git -C "$HARNESS_CHECKOUT" checkout --detach 2f60cab
+git -C "$HARNESS_CHECKOUT" checkout --detach be55b34
 test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = \
-  "2f60cab649c02c611b646fb36ac31d13ed0469a8"
+  "be55b348d365e7939b51ea979cee61d7cb210d15"
 test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)"
 
 cd "$HARNESS_CHECKOUT"


### PR DESCRIPTION
## What changed

- Update the supervised INT-2 ceremony Harness pin from `2f60cab649c02c611b646fb36ac31d13ed0469a8` to merged commit `be55b348d365e7939b51ea979cee61d7cb210d15`.
- Keep the checkout detached, clean, and full-SHA verified exactly as before.

## Why

The deployed dispatcher submits with `harness run submit --run-id`. The old ceremony pin predates that CLI option, so following the runbook exactly would fail before submission. The new immutable pin is the minimal merged Harness revision containing the caller-supplied run-id compatibility change (agent-harness PR #14).

## Checks

- `git diff --check`
- Verified the full Harness SHA resolves locally.
- Verified `be55b34` is an ancestor of Harness `origin/main`.
- Verified the pinned CLI source contains both the `--run-id` parser and resolved-id submission path.

TypeScript tests were not run because this is a two-line documentation-only pin correction; repository CI remains the merge gate.

## Affected surfaces

- Documentation/runbook only.
- No backend, monitor, dispatcher logic, migrations, Compose, Hermes configuration, secrets, or production authority changes.

## Rollout / rollback

After merge, use the updated immutable pin for the disposable supervised ceremony. The production Compose `dispatch` profile remains dormant. Rollback is the inverse two-line documentation change, though the old pin is incompatible with the current dispatcher CLI contract.