### PR TITLE
INT-2 pilot image recipe (ops/Dockerfile.pilot)

### DIFF
--- a/ops/Dockerfile.pilot
+++ b/ops/Dockerfile.pilot
@@ -1,0 +1,44 @@
+# INT-2 supervised-ceremony pilot image.
+#
+# Runbook §1.3 requires an immutable image containing ONLY the runtime tools the
+# ceremony fixtures need — Node 22 and Git — with no credentials. This is
+# deliberately NOT ops/Dockerfile.node: that is the application image and
+# carries Chromium, Playwright, and the Codex/Claude CLIs, none of which a
+# confined lint/docs/test fixture may have.
+#
+# Do not add anything here without re-running the ceremony. In particular:
+#   - no credentials, tokens, or SSH keys;
+#   - no agent CLIs or anything that can actuate GitHub, Averray, or a wallet;
+#   - no application node_modules — Harness bind-mounts the prepared task
+#     checkout over /workspace, which shadows image-baked contents, and the
+#     dispatcher seeds lockfile-matched dependencies host-side (§1.4).
+#
+# Build and record the digest (the ceremony pins by digest, never by tag):
+#
+#   docker build -f ops/Dockerfile.pilot -t reference-agent-pilot:ceremony .
+#   docker images --digests | grep reference-agent-pilot
+#
+# A locally built image has no registry digest until it is pushed. For a local
+# ceremony, pin the image ID instead and record it in evidence:
+#
+#   docker image inspect --format '{{.Id}}' reference-agent-pilot:ceremony
+#
+# For full reproducibility the base should itself be digest-pinned; replace the
+# FROM below with the resolved digest and record it alongside the build recipe.
+
+FROM node:22-bookworm-slim
+
+# git only. ca-certificates is present for git's own TLS verification, not for
+# network access: the pilot profile is egress deny_all and the Harness Docker
+# provider runs the container with no network.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends git ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# No USER directive: the ceremony runs the worker as the operator's own uid and
+# the workspace must share that identity. Introducing an image user (as the
+# application image does with uid 10001) is what produced the dubious-ownership
+# failure in the first attempt.
+
+WORKDIR /workspace
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
The runbook (§1.3) requires an immutable pilot image with **only Node 22 and Git**, no credentials, and requires the **build recipe be kept in the evidence bundle**. No recipe existed — the image used for the first attempt was unrecorded.

`ops/Dockerfile.node` cannot serve as the pilot image: it's the **application** image, carrying Chromium, Playwright, and the Codex/Claude CLIs. None of those belong in a confined lint/docs/test fixture.

It also explains the first failure. `ops/Dockerfile.node` does `useradd --create-home --uid 10001 appuser` — **that is where the `10001` came from.** The dispatcher prepared workspaces as the image's user while the Harness worker ran as root, and git rejected the repository as dubious ownership.

This recipe is minimal by design and adds **no `USER` directive**: the ceremony runs the worker as the operator's own uid, and the workspace must share that identity. It also documents that a locally built image has no registry digest, so a local ceremony pins the **image id** instead — and the preflight accepts a registry digest or a bare image id while refusing a floating tag, which could be repointed after approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)