### PR TITLE
Fix terminal Harness task projection from run outcome

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -178,7 +178,6 @@ export HARNESS_DISPATCH_ARTIFACT_DIR="$CEREMONY_ROOT/dispatch-artifacts"
 export HARNESS_DISPATCH_INTENT_DIR="$CEREMONY_ROOT/dispatch-intents"
 export HARNESS_DISPATCH_HEARTBEAT_PATH="$CEREMONY_ROOT/dispatcher-heartbeat.json"
 export HARNESS_DISPATCH_ALERTS_PATH="$CEREMONY_ROOT/dispatcher-alerts.jsonl"
-export HARNESS_DISPATCH_DEP_CACHE_DIR="$CEREMONY_ROOT/dispatch-dependency-cache"
 export HARNESS_DISPATCH_READ_TIMEOUT_MS=15000
 export HALT_FILE="$CEREMONY_ROOT/HALT"
 export POLICY_CONFIG_PATH="$REFERENCE_CHECKOUT/hermes/config/policy.yaml"
@@ -191,7 +190,6 @@ export HARNESS_DISPATCH_ENABLED=false
 mkdir -p \
   "$HARNESS_DISPATCH_ARTIFACT_DIR" \
   "$HARNESS_DISPATCH_INTENT_DIR" \
-  "$HARNESS_DISPATCH_DEP_CACHE_DIR" \
   /var/lib/harness-dispatcher/workspaces
 ```
 
@@ -204,11 +202,15 @@ hash.
 15-second pilot default when the Harness CLI crosses a container boundary.
 
 The `lint-format` fixture uses only `git diff --check`, so it can run with
-`HARNESS_DISPATCH_DEP_CACHE_DIR` unset. The `docs-fix`, `add-unit-test`, and
-`small-refactor` fixtures execute `npm` verification and require the exact
-offline cache. Populate it once from a clean checkout of the fixture revision:
+`HARNESS_DISPATCH_DEP_CACHE_DIR` unset; leave it unset for that fixture. The
+`docs-fix`, `add-unit-test`, and `small-refactor` fixtures execute `npm`
+verification and require the exact offline cache. For one of those fixtures,
+set the cache directory and populate it once from a clean checkout of the
+fixture revision:
 
 ```sh
+export HARNESS_DISPATCH_DEP_CACHE_DIR="$CEREMONY_ROOT/dispatch-dependency-cache"
+mkdir -p "$HARNESS_DISPATCH_DEP_CACHE_DIR"
 export PILOT_SOURCE_REVISION="8b94278578913b7cd7aa1acb276db48613090c7b"
 export PILOT_DEP_CHECKOUT="$CEREMONY_ROOT/reference-agent-dependency-source"
 

--- a/docs/HARNESS_INT2_TERMINAL_PROJECTION_HANDBACK.md
+++ b/docs/HARNESS_INT2_TERMINAL_PROJECTION_HANDBACK.md
@@ -1,0 +1,196 @@
+# INT-2 handback — terminal Harness projection lifecycle
+
+**Status:** implementation and clean-checkout gates complete; independent review pending
+
+**Baseline:** `86e58f7ab4c8b3965ec3b22bd15649cf85223dde`
+
+**Implementation commit:** `65bd7b65b74b6638617c07badf7134959b3da61d`
+
+**Runtime authority change:** none; reconciliation only
+
+## Built
+
+- Changed dispatcher lifecycle resolution to inspect `projection.run.terminal`
+  before any state-name mapping.
+- Terminal projections now resolve exclusively from `projection.run.outcome`:
+  - `completed` plus passed verification → `handoff_ready`;
+  - `completed` without passed verification → `failed`;
+  - `partial` or `failed` → `failed`;
+  - `cancelled` → `cancelled`.
+- State-name progress mapping and the existing approval/suspension/quarantine
+  safety handling now apply only while `run.terminal` is false. An observed
+  `ApprovalRequested` event remains a refusal independently of the state name.
+- Added an exhaustive outcome switch with a compile-time `never` guard. A
+  malformed terminal projection without a recognized outcome is blocked,
+  marked unhealthy, recorded as a dispatch refusal, and emits one critical
+  `terminal_projection_unresolved` operator alert instead of retaining the
+  current lifecycle silently.
+- Added terminal `learning_processed` cases for completed/pass,
+  completed/fail, partial, failed, and cancelled outcomes.
+- Added a terminal `learning_queued` case with an outcome.
+- Added the forward-compatibility guard: it iterates every value in
+  `harnessRunStateSchema.options`, projects it with `terminal:true` and
+  `outcome:"failed"`, and asserts that reconciliation returns the terminal
+  `failed` lifecycle without cancellation or an alert. The state name therefore
+  cannot control a terminal result.
+- Preserved the existing non-terminal state mappings and their safety alerts.
+- Corrected ceremony runbook §1.4: the common export block no longer sets or
+  creates `HARNESS_DISPATCH_DEP_CACHE_DIR`. The `lint-format` instructions say
+  to leave it unset; the cache-backed fixture section exports and creates it
+  immediately before population.
+
+No learning state name was added to a dispatcher lifecycle set or conditional.
+No read timeout, Harness read port, workspace-preparation behavior, dispatcher
+configuration, task schema, ops file, policy, budget, or authority path changed.
+PR #550's read-timeout fix is untouched.
+
+## Lifecycle proof
+
+The terminal mapping is state-independent:
+
+| `run.outcome` | Verification | AgentTask lifecycle |
+|---|---|---|
+| `completed` | `passed` | `handoff_ready` |
+| `completed` | absent, failed, inconclusive, or pending | `failed` |
+| `partial` | any | `failed` |
+| `failed` | any | `failed` |
+| `cancelled` | any | `cancelled` |
+
+The live replay shape from the finding is directly covered:
+
+```text
+state=learning_processed
+terminal=true
+outcome=failed
+verification=failed
+=> lifecycle=failed
+```
+
+The same result is obtained for every other current `HarnessRunState` when the
+terminal outcome is `failed`. `learning_queued` and `learning_processed` are not
+named by production lifecycle code.
+
+Malformed terminal input produces:
+
+```text
+result.outcome=refused
+result.lifecycle=blocked
+result.healthy=false
+alert.severity=critical
+alert.code=terminal_projection_unresolved
+```
+
+The task does not remain healthy or silently keep `running`, and the dispatcher
+does not issue a redundant cancel against a projection that claims to be
+terminal.
+
+## Finding discrepancy
+
+The work order states that no dispatcher test referenced `learning_queued` or
+`learning_processed`. At baseline `86e58f7`, the original state table did
+reference both, but only with a projection that had no outcome and therefore
+`terminal:false`; because the source task already had lifecycle `running`, both
+assertions merely confirmed the generic `return current` fallthrough.
+
+Those two weak assertions were removed and replaced with outcome-bearing
+terminal cases plus the all-state terminal guard. This is a test-fixture
+discrepancy only; the reported production defect and required fix are unchanged.
+
+## Affected surfaces
+
+- Harness dispatcher reconciliation: yes
+- Dispatcher unit tests: yes
+- INT-2 ceremony runbook: yes
+- Harness read timeout/read port: unchanged
+- Workspace dependency-cache implementation: unchanged
+- Slack operator, monitor UI, MCP servers, runners, ops/compose: unchanged
+- Schemas, migrations, secrets/config, wallet, settlement: unchanged
+- Dependencies and lockfile: unchanged
+
+## Rollout and rollback
+
+Rollout is the normal dispatcher image deployment after human merge and CI.
+Existing active tasks need no migration; their next reconciliation read uses
+the authoritative terminal outcome already present in the projection.
+
+Rollback reverts commit `65bd7b6`. There is no schema, data, migration,
+configuration, secret, or external-state rollback. Reverting would restore the
+known stuck-task defect, so rollback is appropriate only if a separate
+reconciliation regression is observed.
+
+## Clean-checkout verification
+
+The definitive gates ran from detached clean checkout
+`/private/tmp/averray-reference-agent-int2-terminal-projection-clean-65bd7b6`
+at implementation commit `65bd7b6`.
+
+```text
+$ node --version
+v25.5.0
+
+$ npm --version
+11.8.0
+
+$ npm ci
+added 312 packages in 3s
+# exit 0
+
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  194 passed | 1 skipped (195)
+Tests       2414 passed | 4 skipped (2418)
+Duration    11.67s
+# exit 0
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+```
+
+Focused proof before the definitive clean gate:
+
+```text
+$ npm test -- test/unit/reconcile-run.test.ts
+Test Files  1 passed (1)
+Tests       63 passed (63)
+# exit 0
+```
+
+During the pre-commit rehearsal, the first full-suite run had one unrelated
+timing failure in `testbed-live-screencast.test.ts` because its manifest read
+returned `undefined`. That existing suite passed immediately in isolation
+(`3/3`), the full rehearsal rerun passed (`2414/2414` non-skipped), and the
+definitive clean-checkout full run also passed (`2414/2414` non-skipped). No
+out-of-scope screencast code was changed.
+
+Docker/compose validation was not run because this PR changes no `ops/`,
+Dockerfile, compose, environment, or image-build surface. CI remains the Docker
+build and compose-config merge gate.
+
+## Decisions and rationale
+
+1. **Use the projection's existing terminal/outcome contract rather than a new
+   state set.** This makes post-run learning states and future states irrelevant
+   to terminal lifecycle resolution.
+2. **Keep the completed-run verification consult exactly as before.** A
+   completed outcome cannot become handoff-ready without passed verification.
+3. **Gate state-based approval, suspension, and quarantine checks on
+   `!run.terminal`.** This preserves their active-run safety behavior while
+   preventing state names from overriding an authoritative terminal outcome.
+4. **Keep observed approval events fail-closed even on a terminal read.** An
+   approval packet is a security boundary independent of state-name progress
+   mapping.
+5. **Block malformed terminal projections without cancelling them.** The
+   projection already claims terminality; an operator-visible refusal is safer
+   than issuing a redundant control mutation.
+6. **Move the dependency-cache export to the cache population block.** Absence
+   retains the documented `lint-format` skip behavior, while cache-backed
+   fixtures still receive the exact same directory when explicitly selected.
+
+## Open questions
+
+None. The change is limited to the proven projection defect and the runbook trap
+identified in the work order.

--- a/services/harness-dispatcher/src/reconcile-run.ts
+++ b/services/harness-dispatcher/src/reconcile-run.ts
@@ -369,7 +369,7 @@ async function reconcileTask(
     });
   }
 
-  let projection: AgentRunProjectionV1;
+  let projection: AgentRunProjectionV1 | undefined;
   try {
     projection = (deps.projectRun ?? projectHarnessRun)(
       projectionBinding,
@@ -378,6 +378,21 @@ async function reconcileTask(
     );
     assertAgentRunProjectionWithinTask(task, projection);
   } catch (error) {
+    if (
+      projection?.run.terminal
+      && !isTerminalOutcome(projection.run.outcome)
+    ) {
+      const reason =
+        `terminal_projection_unresolved: ${safeErrorMessage(error)}`;
+      return refuseTask(deps, task, reason, {
+        severity: "critical",
+        code: "terminal_projection_unresolved",
+        harnessRunId,
+        message:
+          "A terminal Harness projection had no resolvable outcome; "
+          + "reconciliation stopped for operator review.",
+      });
+    }
     return forceCancelTask(deps, task, harnessRunId, {
       lifecycle: "blocked",
       decisionType: "dispatch_refusal",
@@ -451,7 +466,13 @@ async function reconcileTask(
   const approvalPacketObserved = read.events.some(
     (event) => event.type === "ApprovalRequested",
   );
-  if (approvalPacketObserved || projection.run.state === "approval_required") {
+  if (
+    approvalPacketObserved
+    || (
+      !projection.run.terminal
+      && projection.run.state === "approval_required"
+    )
+  ) {
     return forceCancelTask(deps, task, harnessRunId, {
       lifecycle: "blocked",
       decisionType: "dispatch_refusal",
@@ -470,7 +491,7 @@ async function reconcileTask(
       outboxBinding,
     });
   }
-  if (projection.run.state === "suspended") {
+  if (!projection.run.terminal && projection.run.state === "suspended") {
     return forceCancelTask(deps, task, harnessRunId, {
       lifecycle: "blocked",
       decisionType: "dispatch_refusal",
@@ -485,7 +506,7 @@ async function reconcileTask(
       outboxBinding,
     });
   }
-  if (projection.run.state === "quarantined") {
+  if (!projection.run.terminal && projection.run.state === "quarantined") {
     return forceCancelTask(deps, task, harnessRunId, {
       lifecycle: "blocked",
       decisionType: "dispatch_refusal",
@@ -719,6 +740,26 @@ function lifecycleForProjection(
   current: AgentTaskLifecycle,
   projection: AgentRunProjectionV1,
 ): AgentTaskLifecycle {
+  if (projection.run.terminal) {
+    const outcome = projection.run.outcome;
+    if (outcome === undefined) {
+      throw new Error("terminal Harness projection has no outcome");
+    }
+    switch (outcome) {
+      case "completed":
+        return projection.verification?.status === "passed"
+          ? "handoff_ready"
+          : "failed";
+      case "partial":
+      case "failed":
+        return "failed";
+      case "cancelled":
+        return "cancelled";
+      default:
+        return assertNever(outcome);
+    }
+  }
+
   const state = projection.run.state;
   if (RUNNING_STATES.has(state)) return "running";
   if (VERIFYING_STATES.has(state)) return "verifying";
@@ -735,6 +776,21 @@ function lifecycleForProjection(
   }
   if (CANCELLED_STATES.has(state)) return "cancelled";
   return current;
+}
+
+function isTerminalOutcome(
+  value: AgentRunProjectionV1["run"]["outcome"],
+): value is NonNullable<AgentRunProjectionV1["run"]["outcome"]> {
+  return value === "completed"
+    || value === "partial"
+    || value === "failed"
+    || value === "cancelled";
+}
+
+function assertNever(value: never): never {
+  throw new Error(
+    `terminal Harness projection has unknown outcome: ${String(value)}`,
+  );
 }
 
 function taskWithProjectionFacts(
@@ -845,6 +901,10 @@ async function refuseTask(
   deps: ReconcileRunDeps,
   task: AgentTaskV1,
   reason: string,
+  alert?: Pick<
+    DispatchAlert,
+    "severity" | "code" | "harnessRunId" | "message"
+  >,
 ): Promise<ReconcileResult> {
   const updatedAt = deps.now().toISOString();
   const blocked: AgentTaskV1 = {
@@ -864,11 +924,15 @@ async function refuseTask(
       deps.now(),
     ),
   );
-  await emitTaskAlert(deps, blocked, {
-    severity: "warn",
-    code: "dispatch_refusal",
-    message: `Harness reconciliation refused to proceed: ${reason}.`,
-  });
+  await emitTaskAlert(
+    deps,
+    blocked,
+    alert ?? {
+      severity: "warn",
+      code: "dispatch_refusal",
+      message: `Harness reconciliation refused to proceed: ${reason}.`,
+    },
+  );
   return result(task, {
     outcome: "refused",
     lifecycle: "blocked",

--- a/test/unit/reconcile-run.test.ts
+++ b/test/unit/reconcile-run.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import {
   agentRunProjectionV1Schema,
   agentTaskV1Schema,
+  harnessRunStateSchema,
   hashAgentTaskApprovalPayload,
   type AgentRunProjectionV1,
   type AgentTaskLifecycle,
@@ -38,6 +39,14 @@ const MANIFEST_REF = {
   sha256: MANIFEST_HASH,
   mediaType: "application/json",
 } as const;
+const TERMINAL_LIFECYCLES = new Set<AgentTaskLifecycle>([
+  "handoff_ready",
+  "failed",
+  "cancelled",
+]);
+type TerminalOutcome = NonNullable<
+  AgentRunProjectionV1["run"]["outcome"]
+>;
 
 describe("dispatched Harness run reconciliation", () => {
   it.each([
@@ -60,8 +69,6 @@ describe("dispatched Harness run reconciliation", () => {
     ["cancel_requested", "cancelled"],
     ["compensating", "cancelled"],
     ["cancelled", "cancelled"],
-    ["learning_queued", "running"],
-    ["learning_processed", "running"],
   ] satisfies Array<[HarnessRunState, AgentTaskLifecycle]>)(
     "projects Harness state %s to AgentTask lifecycle %s",
     async (state, expectedLifecycle) => {
@@ -107,6 +114,124 @@ describe("dispatched Harness run reconciliation", () => {
       }
     },
   );
+
+  it.each([
+    ["completed", true, "handoff_ready"],
+    ["completed", false, "failed"],
+    ["partial", undefined, "failed"],
+    ["failed", undefined, "failed"],
+    ["cancelled", undefined, "cancelled"],
+  ] satisfies Array<
+    [TerminalOutcome, boolean | undefined, AgentTaskLifecycle]
+  >)(
+    "projects terminal learning_processed outcome %s (verification=%s) to %s",
+    async (outcome, verificationPassed, expectedLifecycle) => {
+      const task = await runningTask();
+      const deps = reconcileDeps(
+        task,
+        snapshot("learning_processed", {
+          outcome,
+          ...(verificationPassed === undefined
+            ? {}
+            : { verificationPassed }),
+        }),
+      );
+
+      const [reconciled] = await reconcileDispatchedRuns(deps);
+
+      expect(reconciled?.lifecycle).toBe(expectedLifecycle);
+      expect(reconciled?.projection?.run).toMatchObject({
+        state: "learning_processed",
+        terminal: true,
+        outcome,
+      });
+      expect(TERMINAL_LIFECYCLES.has(reconciled!.lifecycle)).toBe(true);
+      expect(savedTasks(deps).at(-1)?.lifecycle).toBe(expectedLifecycle);
+      expect(deps.controlPort.cancel).not.toHaveBeenCalled();
+      expect(deps.alertSink).not.toHaveBeenCalled();
+    },
+  );
+
+  it("projects terminal learning_queued from its outcome", async () => {
+    const task = await runningTask();
+    const deps = reconcileDeps(
+      task,
+      snapshot("learning_queued", { outcome: "partial" }),
+    );
+
+    const [reconciled] = await reconcileDispatchedRuns(deps);
+
+    expect(reconciled).toMatchObject({
+      lifecycle: "failed",
+      healthy: true,
+      projection: {
+        run: {
+          state: "learning_queued",
+          terminal: true,
+          outcome: "partial",
+        },
+      },
+    });
+    expect(savedTasks(deps).at(-1)?.lifecycle).toBe("failed");
+  });
+
+  it.each(harnessRunStateSchema.options)(
+    "resolves terminal Harness state %s to a terminal lifecycle",
+    async (state) => {
+      const task = await runningTask();
+      const deps = reconcileDeps(
+        task,
+        snapshot(state, { outcome: "failed" }),
+      );
+
+      const [reconciled] = await reconcileDispatchedRuns(deps);
+
+      expect(reconciled?.projection?.run).toMatchObject({
+        state,
+        terminal: true,
+        outcome: "failed",
+      });
+      expect(reconciled?.lifecycle).toBe("failed");
+      expect(TERMINAL_LIFECYCLES.has(reconciled!.lifecycle)).toBe(true);
+      expect(reconciled?.lifecycle).not.toBe(task.lifecycle);
+      expect(deps.controlPort.cancel).not.toHaveBeenCalled();
+      expect(deps.alertSink).not.toHaveBeenCalled();
+    },
+  );
+
+  it("alerts and blocks an unresolvable terminal projection", async () => {
+    const task = await runningTask();
+    const unresolved: AgentRunProjectionV1 = {
+      ...projectionFor(task, "learning_processed"),
+      run: {
+        state: "learning_processed",
+        attempt: 1,
+        terminal: true,
+      },
+    };
+    const deps = reconcileDeps(task, snapshot("learning_processed"), {
+      projectRun: vi.fn(() => unresolved),
+    });
+
+    const [reconciled] = await reconcileDispatchedRuns(deps);
+
+    expect(reconciled).toMatchObject({
+      outcome: "refused",
+      lifecycle: "blocked",
+      healthy: false,
+      reason: expect.stringContaining("terminal_projection_unresolved"),
+    });
+    expect(savedTasks(deps).at(-1)?.lifecycle).toBe("blocked");
+    expect(deps.controlPort.cancel).not.toHaveBeenCalled();
+    expect(deps.alertSink).toHaveBeenCalledOnce();
+    expect(deps.alertSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: "critical",
+        code: "terminal_projection_unresolved",
+        harnessRunId: RUN_ID,
+      }),
+    );
+  });
 
   it.each([
     {
@@ -683,17 +808,19 @@ function snapshot(
   options: {
     verificationPassed?: boolean;
     runId?: string;
+    outcome?: TerminalOutcome;
   } = {},
 ): HarnessRunReadSnapshot {
-  const terminalOutcome = state === "completed"
-    ? "completed"
-    : state === "partial"
-      ? "partial"
-      : state === "failed"
-        ? "failed"
-        : state === "cancelled"
-          ? "cancelled"
-          : undefined;
+  const terminalOutcome = options.outcome
+    ?? (state === "completed"
+      ? "completed"
+      : state === "partial"
+        ? "partial"
+        : state === "failed"
+          ? "failed"
+          : state === "cancelled"
+            ? "cancelled"
+            : undefined);
   const verificationPassed = options.verificationPassed;
   const events: HarnessRunReadSnapshot["events"] = [
     {
@@ -748,7 +875,7 @@ function snapshot(
       state,
       attempt: 1,
       ...(terminalOutcome ? { outcome: terminalOutcome } : {}),
-      ...(state === "failed" || state === "quarantined"
+      ...(terminalOutcome === "failed" || state === "quarantined"
         ? { outcomeReason: "verification_failed" }
         : {}),
       egressPolicy: "deny",


### PR DESCRIPTION
## What changed

- resolve terminal AgentTask lifecycle from `projection.run.outcome` before any run-state matching
- keep completed runs handoff-ready only when independent verification passed
- restrict approval/suspension/quarantine state-name handling to non-terminal runs
- fail closed with a critical operator alert when a terminal projection has no resolvable outcome
- cover `learning_processed` across all outcomes, `learning_queued` with an outcome, and every schema-defined run state with `terminal:true`
- correct the INT-2 runbook so `HARNESS_DISPATCH_DEP_CACHE_DIR` stays unset for `lint-format` and is exported only for cache-backed fixtures
- add the implementation handback

## Root cause and impact

The dispatcher mapped lifecycle from `run.state` alone. Post-run learning states fell through to the current task lifecycle, so a terminal run could leave its AgentTask permanently `running` while reconciliation still reported healthy. Terminality and outcome already exist in the projection, so this PR makes them authoritative and leaves learning state names out of production mapping code.

PR #550's separate bounded read-timeout fix is untouched.

## Validation

From detached clean checkout at implementation commit `65bd7b6`:

- `npm ci` — green
- `npm run typecheck` — green
- `npm test` — 194 files passed, 1 skipped; 2414 tests passed, 4 skipped
- `npm run build` — green
- focused reconciliation suite — 63/63 passed

The pre-commit rehearsal had one transient unrelated screencast timing failure; it passed immediately in isolation, in the full rerun, and in the definitive clean-checkout full run. No screencast code changed.

## Affected surfaces

Harness dispatcher reconciliation, reconciliation tests, and the INT-2 ceremony runbook. No MCP, monitor UI, runner, schema, migration, ops/compose, secret/config, wallet, settlement, read-port, or timeout change.

## Rollout / rollback

Normal dispatcher image rollout after human merge and CI. Existing tasks need no migration; their next reconciliation uses the outcome already in the projection. Rollback is a code revert only, with no data/config reversal, but restores the known stuck-task defect.

Full proof, decisions, and the baseline test-fixture discrepancy are in `docs/HARNESS_INT2_TERMINAL_PROJECTION_HANDBACK.md`.