### PR TITLE
Add verified INT-2 green-path ceremony

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -214,7 +214,7 @@ mkdir -p "$HARNESS_DISPATCH_DEP_CACHE_DIR"
 export PILOT_SOURCE_REVISION="8b94278578913b7cd7aa1acb276db48613090c7b"
 export PILOT_DEP_CHECKOUT="$CEREMONY_ROOT/reference-agent-dependency-source"
 
-for fixture in docs-fix add-unit-test small-refactor lint-format; do
+for fixture in docs-fix add-unit-test small-refactor lint-format lint-format-green; do
   grep -F \
     "\"baseRevision\": \"$PILOT_SOURCE_REVISION\"" \
     "$REFERENCE_CHECKOUT/test/fixtures/agent-integration/ceremony/$fixture.json" \
@@ -431,6 +431,99 @@ If this drill broadens authority instead of tightening it, abort.
 
 An unverified handoff or any PR is an immediate abort.
 
+### 2.6 Verified green handoff is complete but unactuated
+
+This positive proof and §2.5's negative proof are both required for acceptance.
+They use sibling fixtures and separate work-item ids so the negative evidence
+remains reproducible and unchanged.
+
+1. Stop the dispatcher and worker. Confirm `HARNESS_DISPATCH_ENABLED=false`.
+   Copy the committed two-turn script into the ceremony root, record both
+   copies' hashes, and point the next worker at the ceremony-root copy:
+
+   ```sh
+   export GREEN_MODEL_SCRIPT="$CEREMONY_ROOT/lint-format-green.jsonl"
+   cp \
+     "$REFERENCE_CHECKOUT/test/fixtures/agent-integration/ceremony/lint-format-green.jsonl" \
+     "$GREEN_MODEL_SCRIPT"
+   shasum -a 256 \
+     "$REFERENCE_CHECKOUT/test/fixtures/agent-integration/ceremony/lint-format-green.jsonl" \
+     "$GREEN_MODEL_SCRIPT" \
+     > "$CEREMONY_ROOT/evidence/lint-format-green-script.sha256"
+   test "$(sed -n '1s/ .*//p' \
+     "$CEREMONY_ROOT/evidence/lint-format-green-script.sha256")" = \
+     "$(sed -n '2s/ .*//p' \
+     "$CEREMONY_ROOT/evidence/lint-format-green-script.sha256")"
+   export HARNESS_TEST_MODEL_SCRIPT="$GREEN_MODEL_SCRIPT"
+   unset HARNESS_DISPATCH_DEP_CACHE_DIR
+   ```
+
+   Start one worker from the same pinned Harness checkout used by every other
+   case. The script path is under `CEREMONY_ROOT`; it is not a kernel fixture
+   and does not change the Harness pin.
+2. Propose `lint-format-green` as `ceremony-lint-format-green-001`. Before
+   approval, verify the immutable base revision, `docs/**` and `test/**`
+   allowlist, deny-all network, the unchanged `git diff --check` criterion,
+   and the fixed 60-second / 8,000-token / 30-tool-call budget. Approve once
+   with the exact `--confirm` flag, record the printed intended run id, then
+   enable and start one dispatcher.
+3. Wait for both the Harness run and AgentTask to become terminal. Stop the
+   dispatcher immediately and restore `HARNESS_DISPATCH_ENABLED=false`.
+   The task lifecycle must be `handoff_ready`, its bound run id must equal the
+   intended run id, and `harness run status` must show attempt `1`.
+4. Save the standard §4 evidence. Extract the non-empty patch artifact and
+   inspect it against a clean checkout of the fixture's base revision:
+
+   ```sh
+   export GREEN_EVIDENCE="$CEREMONY_ROOT/evidence/ceremony-lint-format-green-001"
+   export GREEN_PATCH_REF="$(
+     awk '$1 == "workspace_patch" { print $2 }' \
+       "$GREEN_EVIDENCE/harness-deliverables.txt"
+   )"
+   test -n "$GREEN_PATCH_REF"
+   "$HARNESS_BIN" artifacts get "$GREEN_PATCH_REF" \
+     --out "$GREEN_EVIDENCE/workspace.patch"
+   test -s "$GREEN_EVIDENCE/workspace.patch"
+
+   export GREEN_PATCH_CHECKOUT="$CEREMONY_ROOT/green-patch-checkout"
+   git clone --local --no-hardlinks \
+     "$REFERENCE_CHECKOUT" "$GREEN_PATCH_CHECKOUT"
+   git -C "$GREEN_PATCH_CHECKOUT" checkout --detach \
+     8b94278578913b7cd7aa1acb276db48613090c7b
+   git -C "$GREEN_PATCH_CHECKOUT" apply --check \
+     "$GREEN_EVIDENCE/workspace.patch"
+   test "$(
+     git -C "$GREEN_PATCH_CHECKOUT" apply --numstat \
+       "$GREEN_EVIDENCE/workspace.patch" |
+       awk '{ print $3 }'
+   )" = "docs/harness-int2-green-path-proof.md"
+   ```
+
+   Any empty patch, second path, or path outside `docs/**` and `test/**` fails
+   the gate.
+5. Inspect the reference-database rows. Require exactly one dispatch claim,
+   exactly one outbox row, exactly one `dispatch_approval` decision whose first
+   reason is `dispatch_succeeded`, and exactly one `handoff` decision whose
+   reasons include all three of:
+
+   - `verified_handoff_ready_for_operator`
+   - `eligible_for_pr_open=true`
+   - `eligible_for_pr_open_reason=completed_outcome_verified_acceptance_all_checks_passed`
+
+   Save the handoff decision's `proposal.evidenceRefs` separately. They must be
+   non-empty and include every verification evidence ref reported by the
+   completed run. The handoff decision remains non-mutating:
+   `effects.mutates=false`, `mutations=[]`.
+6. Compare the AgentTask binding, outbox row, and handoff decision input. The
+   `runManifestRef` and `runManifestHash` must both be present, the ref's
+   `sha256` must equal the hash, and every source must identify the same
+   manifest.
+7. Record `eligibleForPrOpen=true` and its predicate reason, but do not actuate
+   it. Confirm there is no `pullRequest` on the handoff evidence, no GitHub
+   mutation reference, no mutating decision, and no submission or PR. Do not
+   run a GitHub CLI or API command during this proof. Eligibility is evidence
+   for an operator; it is not permission to open a PR.
+
 ## 3. One budget-capped real-model task
 
 Proceed only if every scripted proof is green and the operator records a
@@ -502,6 +595,7 @@ The following mapping is the acceptance checklist for plan section 21.1:
 | No wallet/settlement/deploy/GitHub-merge capability | The exact eight-grant AgentTask and compiled run manifest, with `delegable:false`, `maxChildren:0`, `maxConcurrentChildren:0`, and deny-all egress. Review the manifest, not just the profile source. |
 | Representative low-risk tasks complete through supervision | At least docs/comment, unit-test, and small-refactor families, each with proposal output, explicit operator approval, `dispatch_approval` decision, run events, verifier evidence, budget actuals, and terminal projection. |
 | Failed verification produces no submission | Failed verifier event and failed lifecycle; no `handoff` decision, no VerifiedHandoff actuation, and no PR/submission evidence. |
+| Verified work produces a correct unactuated handoff | The `lint-format-green` case reaches `handoff_ready`; non-empty allowlisted patch; matching manifest ref/hash; one attempt, claim, and outbox; exactly one `dispatch_approval` plus one `handoff`; recorded eligibility value/reason and handoff verification evidence refs; no PR or GitHub mutation. §2.5 and §2.6 must both pass. |
 | Restart and duplicate delivery remain idempotent | Dispatcher restart timestamps, unchanged claim/outbox rows, same immutable run id, and one Harness attempt. |
 
 A successful verified task should have a `dispatch_approval` decision and, when
@@ -537,8 +631,9 @@ evidence green.
 
 Finish with an evidence index containing the Harness SHA, image digest, profile
 SHA, policy hash/version, every work-item/version, run id, task/template/
-verifier/manifest hash, decision ids, outbox row, alerts file hash, projection
-snapshot hashes, operator id, and the operator's gate verdict.
+verifier/manifest hash, decision ids and counts by type, handoff verification
+evidence refs, outbox row, alerts file hash, projection snapshot hashes,
+operator id, and the operator's gate verdict.
 
 ## 5. Teardown and prove nothing remains armed
 

--- a/docs/HARNESS_INT2_GREEN_PATH_HANDBACK.md
+++ b/docs/HARNESS_INT2_GREEN_PATH_HANDBACK.md
@@ -1,0 +1,218 @@
+# INT-2 handback — verified green-path ceremony
+
+**Status:** implementation and clean-checkout gates complete; independent review and live operator ceremony pending
+
+**Baseline:** `720165cc5c44ea6c1c8fb6814b76a1ba7a2615ab`
+
+**Implementation commit:** `8403bcaf28f425d2a117e1611c5f9df8b50d6237`
+
+**Runtime authority change:** none; the new scripted turn uses the already-approved
+`fs.write_file` grant inside the existing path allowlist
+
+## Built
+
+- Added the sibling `lint-format-green` ceremony proposal. The existing
+  `lint-format` proposal and the pinned kernel's `finish.jsonl` remain
+  byte-unchanged, so §2.5's negative proof is preserved.
+- Added a committed deterministic two-turn model script. It writes one new
+  file under `docs/**`, makes no network or external call, and stays within the
+  existing 60-second, 8,000-token, and 30-tool-call budget.
+- Kept the acceptance fence unchanged: the only required command remains
+  `git diff --check`.
+- Added the sibling fixture to the pilot CLI allowlist and help.
+- Made the positive handoff's immutable decision record carry the evaluated
+  eligibility value and predicate reason without adding a third decision:
+  - `verified_handoff_ready_for_operator`
+  - `eligible_for_pr_open=true`
+  - `eligible_for_pr_open_reason=completed_outcome_verified_acceptance_all_checks_passed`
+- Preserved exactly one handoff decision. Its `proposal.evidenceRefs` contains
+  every `VerifiedHandoff.verification.evidenceRefs` entry, and it remains
+  explicitly non-mutating.
+- Strengthened reconciliation coverage for the handoff's non-empty patch ref,
+  consistent manifest ref/hash, absent pull-request field, exact handoff
+  decision count, eligibility evidence, and verification evidence refs.
+- Kept the existing dispatch test that pins exactly one
+  `dispatch_approval` / `dispatch_succeeded` decision for a successful
+  dispatch. Together, the green path produces the architect-confirmed two
+  records: one dispatch approval and one handoff.
+- Added runbook §2.6. It copies the committed script beneath
+  `CEREMONY_ROOT`, retains Harness commit `be55b34`, requires both the §2.5
+  negative and §2.6 positive proofs, materializes and inspects the patch,
+  checks the manifest, records evidence refs and eligibility, enforces the
+  exact claim/outbox/decision counts, and forbids PR/GitHub actuation.
+
+No Harness kernel, Harness pin, profile, capability list, acceptance
+criterion, schema, migration, database, wallet, settlement, deploy, dependency,
+lockfile, or existing ceremony fixture changed.
+
+## Exact scripted model
+
+Committed as
+`test/fixtures/agent-integration/ceremony/lint-format-green.jsonl`.
+SHA-256: `71389a0ad18a2fc756d1b238a2b6bf73d621afa734122c965acc800715236c5a`.
+
+```jsonl
+{"tool_calls":[{"id":"int2-green-write","name":"fs_write_file","arguments":{"path":"docs/harness-int2-green-path-proof.md","content":"# INT-2 green-path proof\n\nThis deterministic change verifies the supervised handoff path.\n"}}],"usage":{"input_tokens":2,"output_tokens":1,"requests":1},"finish_reason":"tool_call"}
+{"text":"Wrote the deterministic allowlisted proof file.","usage":{"input_tokens":2,"output_tokens":2,"requests":1},"finish_reason":"stop"}
+```
+
+The script contract test parses both lines and pins the complete objects. It
+also asserts exactly two turns, one `fs_write_file` call, an allowlisted path,
+a trailing newline, no trailing whitespace, no space-before-tab, and the
+unchanged acceptance command and budget.
+
+## Deterministic resulting patch
+
+The script output was materialized byte-for-byte in a disposable Git
+repository. `git diff --check` passed. The patch SHA-256 is
+`bf8cfa329e9fdd6d7e75da6c4688e28f9dab4c6d9c22410572a37d89bad847a9`;
+the new file SHA-256 is
+`3f5aa31bf3a3e0ce4043e46b43a9f4d460c734ff59821554d1ba56cc16514bb2`.
+
+```diff
+diff --git a/docs/harness-int2-green-path-proof.md b/docs/harness-int2-green-path-proof.md
+new file mode 100644
+index 0000000..79672fc
+--- /dev/null
++++ b/docs/harness-int2-green-path-proof.md
+@@ -0,0 +1,3 @@
++# INT-2 green-path proof
++
++This deterministic change verifies the supervised handoff path.
+```
+
+Only `docs/harness-int2-green-path-proof.md` is touched.
+
+## Handoff result and non-actuation proof
+
+For the completed, verification-passed projection pinned by the unit fixture:
+
+```text
+AgentTask.lifecycle=handoff_ready
+VerifiedHandoff.outcome=completed
+VerifiedHandoff.verification.decision=accept
+VerifiedHandoff.verification.verified=true
+VerifiedHandoff.eligibleForPrOpen=true
+eligibility reason=completed_outcome_verified_acceptance_all_checks_passed
+VerifiedHandoff.pullRequest=absent
+handoff decision effects.mutates=false
+handoff decision effects.mutations=[]
+```
+
+`eligibleForPrOpen=true` follows only from a completed outcome, verified
+acceptance, and all recorded checks passing. It is evidence for later operator
+review, not actuation authority. The reconciliation source fence still asserts
+that the module has no submit, approve, deny, release, pull-request-open,
+platform-claim, platform-submit, or GitHub-client call.
+
+No live ceremony was executed during implementation: it requires the
+operator-pinned local image and disposable control plane described by the
+runbook. Therefore this handback does not claim a live `handoff_ready` result.
+It records the exact deterministic input/output and the locally asserted
+handoff result; the operator ceremony will capture real artifact refs, the one
+attempt/claim/outbox rows, and both immutable decisions. No ceremony-path
+GitHub mutation occurred.
+
+## Affected surfaces
+
+- Ceremony fixtures and pilot CLI: yes
+- Dispatcher handoff decision evidence: yes
+- Dispatcher and proposal unit tests: yes
+- INT-2 ceremony runbook: yes
+- Harness kernel or pin: unchanged
+- Existing negative ceremony fixture: unchanged
+- Schema, migration, database, ops/compose, secrets/config: unchanged
+- Wallet, settlement, deploy, PR opening, GitHub mutation: unchanged
+
+## Rollout and rollback
+
+Rollout is the normal dispatcher image deployment after human merge and CI.
+There is no migration or environment change. The committed script is copied
+to the disposable ceremony root only when the operator explicitly runs §2.6.
+
+Rollback reverts implementation commit `8403bca`. It removes the sibling
+fixture, eligibility-reason audit fields, tests, and runbook case. No data,
+database, secret, image, or external-state rollback is required.
+
+## Clean-checkout verification
+
+The definitive gates ran from detached clean checkout
+`/private/tmp/averray-reference-agent-int2-green-path-clean` at implementation
+commit `8403bca`.
+
+```text
+$ node --version
+v25.5.0
+
+$ npm --version
+11.8.0
+
+$ git status --porcelain
+# no output
+
+$ npm ci
+added 312 packages, and audited 325 packages in 3s
+# exit 0
+
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  194 passed | 1 skipped (195)
+Tests       2417 passed | 4 skipped (2421)
+Duration    10.57s
+# exit 0
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+
+$ git status --porcelain
+# no output
+```
+
+Focused proof before the definitive clean gate:
+
+```text
+$ npm exec -- vitest run test/unit/agent-task-proposal.test.ts \
+    test/unit/harness-pilot-cli.test.ts \
+    test/unit/reconcile-run.test.ts \
+    test/unit/dispatch-attempt.test.ts
+Test Files  4 passed (4)
+Tests       117 passed (117)
+# exit 0
+```
+
+The four skipped tests require `HARNESS_TEST_DATABASE_URL`; this change adds no
+database behavior or migration. Docker/compose validation was not run because
+the PR changes no `ops/`, Dockerfile, Compose, environment, image-build, or
+deployment surface. CI remains the Docker build and compose-config merge gate.
+
+## Decisions and rationale
+
+1. **Use a sibling fixture.** This keeps the legitimate no-write failure proof
+   reproducible and gives the positive proof its own immutable identity.
+2. **Commit the script with the fixture, then copy it under `CEREMONY_ROOT`.**
+   The repository pins reviewed bytes while the runtime still receives the
+   environment path required by the pinned Harness.
+3. **Write one new allowlisted document.** A new file makes the patch
+   deterministic against the pinned base and avoids depending on unrelated
+   prose bytes while still exercising the real filesystem tool and verifier.
+4. **Keep `git diff --check` unchanged.** The green result comes from a correct
+   deterministic change, not a relaxed acceptance criterion.
+5. **Record eligibility in the existing handoff decision's reasons.** The V2
+   decision schema has no dedicated eligibility-result field. Adding the value
+   and stable predicate reason to `proposal.why` makes them durable and
+   queryable without widening the schema or creating an incorrect third
+   decision.
+6. **Carry verification refs through the handoff decision.** This uses the
+   existing evidence-ref contract and lets the live bundle prove what was
+   verified rather than only counting records.
+7. **Keep eligibility non-actuating.** The handoff record is non-mutating, has
+   no pull-request field, and sends the next action to the operator.
+
+## Open questions
+
+None for implementation. The live §2.6 operator ceremony remains the acceptance
+step and must be recorded alongside the preserved §2.5 negative proof.

--- a/scripts/ops/harness-pilot.mjs
+++ b/scripts/ops/harness-pilot.mjs
@@ -9,6 +9,7 @@ const FIXTURES = new Set([
   "add-unit-test",
   "small-refactor",
   "lint-format",
+  "lint-format-green",
 ]);
 const POLICY_VERSION = "dispatch-policy-v1";
 const DEFAULT_ALERTS_PATH = "/data/harness-dispatch-alerts.jsonl";
@@ -610,7 +611,7 @@ function helpText() {
   return `Usage: node scripts/ops/harness-pilot.mjs <subcommand> [options]
 
 Human-operated supervised-pilot commands:
-  propose --fixture <docs-fix|add-unit-test|small-refactor|lint-format>
+  propose --fixture <docs-fix|add-unit-test|small-refactor|lint-format|lint-format-green>
           [--work-item <id>] [--deadline <iso>]
   approve --work-item <id> --version <n> --operator <id> --confirm
   cancel  --work-item <id> --version <n> --operator <id> --confirm

--- a/services/harness-dispatcher/src/reconcile-run.ts
+++ b/services/harness-dispatcher/src/reconcile-run.ts
@@ -547,6 +547,10 @@ async function reconcileTask(
         deps.now(),
         handoff.verification.evidenceRefs,
         projection,
+        [
+          `eligible_for_pr_open=${handoff.eligibleForPrOpen}`,
+          "eligible_for_pr_open_reason=completed_outcome_verified_acceptance_all_checks_passed",
+        ],
       ),
     );
     return result(task, {
@@ -1021,6 +1025,7 @@ function buildReconcileDecision(
   generatedAt: Date,
   evidenceRefs: ArtifactRef[] = [],
   projection?: AgentRunProjectionV1,
+  additionalReasons: string[] = [],
 ): HermesDecisionRecordV2 {
   const approval = task.approval;
   const inputs: Array<{
@@ -1059,7 +1064,7 @@ function buildReconcileDecision(
       what: decisionType === "handoff"
         ? "Record a verified handoff for operator review."
         : "Pause supervised execution for operator review.",
-      why: [reason],
+      why: [reason, ...additionalReasons],
       evidenceRefs: uniqueArtifacts([
         ...task.proposal.sourceRefs,
         ...evidenceRefs,

--- a/test/fixtures/agent-integration/ceremony/lint-format-green.json
+++ b/test/fixtures/agent-integration/ceremony/lint-format-green.json
@@ -1,0 +1,44 @@
+{
+  "workItemId": "ceremony-lint-format-green-001",
+  "correlationId": "ceremony-lint-format-green-001",
+  "taskKind": "lint_format",
+  "title": "Create one bounded formatting proof",
+  "objective": "Create the deterministic green-path proof document within the pilot path allowlist.",
+  "whyNow": "The supervised-dispatch ceremony needs a verified positive handoff without changing the negative fixture.",
+  "requestedBy": {
+    "type": "operator",
+    "id": "pilot-operator"
+  },
+  "repository": {
+    "nameWithOwner": "depre-dev/averray-reference-agent",
+    "baseRevision": "8b94278578913b7cd7aa1acb276db48613090c7b",
+    "allowedPaths": [
+      "docs/**",
+      "test/**"
+    ],
+    "forbiddenPaths": [
+      "contracts/**",
+      "ops/**",
+      "scripts/ops/**",
+      ".github/**"
+    ]
+  },
+  "profile": "coding-change-pilot",
+  "acceptanceCriteria": [
+    {
+      "id": "format-command",
+      "type": "command",
+      "command": "git diff --check",
+      "required": true
+    }
+  ],
+  "budget": {
+    "elapsedSeconds": 60,
+    "modelTokens": 8000,
+    "toolCalls": 30,
+    "estimatedUsdMicros": null
+  },
+  "deadline": "2027-12-31T23:59:59.000Z",
+  "riskTier": "low",
+  "selectionReason": "A deterministic allowlisted write is the narrowest reversible positive Harness ceremony case."
+}

--- a/test/fixtures/agent-integration/ceremony/lint-format-green.jsonl
+++ b/test/fixtures/agent-integration/ceremony/lint-format-green.jsonl
@@ -1,0 +1,2 @@
+{"tool_calls":[{"id":"int2-green-write","name":"fs_write_file","arguments":{"path":"docs/harness-int2-green-path-proof.md","content":"# INT-2 green-path proof\n\nThis deterministic change verifies the supervised handoff path.\n"}}],"usage":{"input_tokens":2,"output_tokens":1,"requests":1},"finish_reason":"tool_call"}
+{"text":"Wrote the deterministic allowlisted proof file.","usage":{"input_tokens":2,"output_tokens":2,"requests":1},"finish_reason":"stop"}

--- a/test/unit/agent-task-proposal.test.ts
+++ b/test/unit/agent-task-proposal.test.ts
@@ -53,6 +53,7 @@ const CEREMONY_FIXTURES = [
   "add-unit-test",
   "small-refactor",
   "lint-format",
+  "lint-format-green",
 ] as const;
 const temporaryRoots: string[] = [];
 
@@ -477,6 +478,73 @@ describe("pilot ceremony proposal fixtures", () => {
       expect(built.templateHash).toBe(task.intent.templateHash);
     },
   );
+
+  it("pins the green-path scripted write inside its unchanged acceptance fence", async () => {
+    const input = await ceremonyFixture("lint-format-green");
+    const scriptBytes = await readFile(
+      new URL(
+        "../fixtures/agent-integration/ceremony/lint-format-green.jsonl",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    const lines = scriptBytes.trimEnd().split("\n");
+
+    expect(input.acceptanceCriteria).toEqual([{
+      id: "format-command",
+      type: "command",
+      command: "git diff --check",
+      required: true,
+    }]);
+    expect(input.budget).toEqual({
+      elapsedSeconds: 60,
+      modelTokens: 8_000,
+      toolCalls: 30,
+      estimatedUsdMicros: null,
+    });
+    expect(lines).toHaveLength(2);
+
+    const writeTurn = JSON.parse(lines[0] ?? "{}") as {
+      tool_calls?: Array<{
+        id?: string;
+        name?: string;
+        arguments?: { path?: string; content?: string };
+      }>;
+      finish_reason?: string;
+      usage?: Record<string, number>;
+    };
+    const stopTurn = JSON.parse(lines[1] ?? "{}") as {
+      text?: string;
+      tool_calls?: unknown;
+      finish_reason?: string;
+      usage?: Record<string, number>;
+    };
+    expect(writeTurn).toEqual({
+      tool_calls: [{
+        id: "int2-green-write",
+        name: "fs_write_file",
+        arguments: {
+          path: "docs/harness-int2-green-path-proof.md",
+          content:
+            "# INT-2 green-path proof\n\nThis deterministic change verifies the supervised handoff path.\n",
+        },
+      }],
+      usage: { input_tokens: 2, output_tokens: 1, requests: 1 },
+      finish_reason: "tool_call",
+    });
+    expect(stopTurn).toEqual({
+      text: "Wrote the deterministic allowlisted proof file.",
+      usage: { input_tokens: 2, output_tokens: 2, requests: 1 },
+      finish_reason: "stop",
+    });
+
+    const write = writeTurn.tool_calls?.[0]?.arguments;
+    expect(write?.path).toMatch(/^(?:docs|test)\//);
+    expect(input.repository.allowedPaths).toContain("docs/**");
+    expect(write?.content).toMatch(/\n$/);
+    expect(write?.content).not.toMatch(/[ \t]+$/mu);
+    expect(write?.content).not.toContain(" \t");
+  });
 });
 
 function proposalInput(): ProposeAgentTaskInput {

--- a/test/unit/harness-pilot-cli.test.ts
+++ b/test/unit/harness-pilot-cli.test.ts
@@ -295,6 +295,17 @@ describe("Harness pilot CLI", () => {
       deadline: "2026-07-25T13:00:00.000Z",
     });
   });
+
+  it("accepts the separate deterministic green-path fixture", () => {
+    expect(parsePilotArgs([
+      "propose",
+      "--fixture",
+      "lint-format-green",
+    ])).toEqual({
+      command: "propose",
+      fixture: "lint-format-green",
+    });
+  });
 });
 
 function pilotServices(overrides: Record<string, unknown> = {}) {

--- a/test/unit/reconcile-run.test.ts
+++ b/test/unit/reconcile-run.test.ts
@@ -476,15 +476,36 @@ describe("dispatched Harness run reconciliation", () => {
         },
       },
     });
-    expect(recordedDecisions(deps).at(-1)).toMatchObject({
+    const handoff = reconciled?.handoff;
+    if (!handoff) throw new Error("Expected a verified handoff");
+    expect(handoff.runManifestRef.sha256).toBe(handoff.runManifestHash);
+    expect(handoff.deliverables.patchRef).toBeDefined();
+    expect(handoff).not.toHaveProperty("pullRequest");
+
+    const handoffDecisions = recordedDecisions(deps).filter(
+      (record) => record.decisionType === "handoff",
+    );
+    expect(handoffDecisions).toHaveLength(1);
+    expect(handoffDecisions[0]).toMatchObject({
       decisionType: "handoff",
+      proposal: {
+        why: [
+          "verified_handoff_ready_for_operator",
+          "eligible_for_pr_open=true",
+          "eligible_for_pr_open_reason=completed_outcome_verified_acceptance_all_checks_passed",
+        ],
+      },
       next: { owner: "operator" },
       effects: {
         mutates: false,
+        mutations: [],
         authorityChanged: false,
         budgetChanged: false,
       },
     });
+    expect(handoffDecisions[0]?.proposal.evidenceRefs).toEqual(
+      expect.arrayContaining(handoff.verification.evidenceRefs),
+    );
 
     const moduleSource = await readFile(
       new URL(


### PR DESCRIPTION
## What changed

- add a separate `lint-format-green` ceremony proposal and deterministic two-turn `fs_write_file` script while preserving the existing no-write negative fixture
- record the positive handoff's PR-open eligibility value and predicate reason in the existing immutable handoff decision, with all verification evidence refs
- pin the non-empty patch ref, manifest integrity, one handoff record, eligibility evidence, absent PR field, and non-mutating result in tests
- add runbook §2.6 for the positive proof, including exact dispatch/handoff decision counts, evidence-ref capture, patch inspection, and an explicit no-GitHub-actuation fence
- add `docs/HARNESS_INT2_GREEN_PATH_HANDBACK.md` with the exact script, derived patch, gate output, decisions, and live-ceremony boundary

## Why

The INT-2 ceremony had proved only the legitimate failed-verification path. This adds a reproducible positive fixture and evidence procedure for `handoff_ready` without weakening the negative proof or changing the pinned Harness kernel.

## Validation

From detached clean checkout `8403bcaf28f425d2a117e1611c5f9df8b50d6237`:

- `npm ci`
- `npm run typecheck`
- `npm test` — 194 files passed, 1 skipped; 2,417 tests passed, 4 skipped
- `npm run build`
- focused dispatcher/proposal/CLI suite — 117/117 passed
- `git diff --check`
- deterministic derived patch passes `git diff --check` and touches only `docs/harness-int2-green-path-proof.md`

The four skipped tests require `HARNESS_TEST_DATABASE_URL`; this change has no database or migration surface. Docker/Compose validation was not run because no ops, image, environment, or deploy file changed.

## Affected surfaces

Harness dispatcher handoff audit evidence, ceremony fixtures, pilot CLI, unit tests, and INT-2 runbook/docs. No schema, migration, lockfile, secret/config, wallet, settlement, deploy, kernel, existing negative fixture, or GitHub-actuation path changed.

## Rollout / rollback

Normal dispatcher image rollout after human merge and CI. No migration or environment change. Rollback reverts the two branch commits; no data or external-state rollback is needed.

The live §2.6 operator ceremony remains pending and must be captured alongside §2.5 before INT-2 acceptance.