### PR TITLE
fix(hermes): monitor the signer reward bank

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -346,10 +346,9 @@ services:
       # signer gas caused the 2026-06-30 canary failure; 1 DOT ≈ days of settlement
       # runway after the alert), REWARD_BANK=2 USDC (~5–10 jobs at 0.2–0.4/job), AAC=1.
       PRODUCT_HEALTH_MIN_GAS_NATIVE: ${PRODUCT_HEALTH_MIN_GAS_NATIVE:-0}
-      # NB: this is the SIGNER's own USDC (the reward-bank account) — distinct from
-      # MIN_REWARD_BANK below, which reads the treasury view. At 0 the USDC half of
-      # signer_liquidity is unfireable, so set it whenever MIN_REWARD_BANK is set.
-      PRODUCT_HEALTH_MIN_USDC: ${PRODUCT_HEALTH_MIN_USDC:-0}
+      # signer_liquidity reads the in-contract reward-bank position exposed by
+      # /health, not balanceOf(signer). PRODUCT_HEALTH_MIN_REWARD_BANK is the one
+      # payout floor shared with treasury_liquidity.
       PRODUCT_HEALTH_REQUIRED_CAPABILITIES: ${PRODUCT_HEALTH_REQUIRED_CAPABILITIES:-blockchain,treasuryMutations}
       PRODUCT_HEALTH_EXPECTED_WARNINGS: ${PRODUCT_HEALTH_EXPECTED_WARNINGS:-xcm_observer_staged,indexer_unavailable,gas_sponsor_disabled}
       PRODUCT_HEALTH_LATENCY_WARN_MS: ${PRODUCT_HEALTH_LATENCY_WARN_MS:-2000}
@@ -359,6 +358,9 @@ services:
       PRODUCT_HEALTH_SETTLEMENT_MAX_STALE_MINUTES: ${PRODUCT_HEALTH_SETTLEMENT_MAX_STALE_MINUTES:-15}
       PRODUCT_HEALTH_MIN_REWARD_BANK: ${PRODUCT_HEALTH_MIN_REWARD_BANK:-0}
       PRODUCT_HEALTH_MIN_TREASURY_RESERVE: ${PRODUCT_HEALTH_MIN_TREASURY_RESERVE:-5}
+      # Required when the reserve floor is deliberately 0. Without a reason the
+      # probe degrades rather than silently painting an unfunded reserve green.
+      PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON: ${PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON:-}
       PRODUCT_HEALTH_MIN_AAC: ${PRODUCT_HEALTH_MIN_AAC:-0}
       # Ops auto-remediation (docs/OPS_AUTO_REMEDIATION.md). OFF by default — a no-op
       # until OPS_AUTOREMEDIATE_ENABLED=true AND at least one PRODUCT_HEALTH_RPC_BACKUPS

--- a/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
+++ b/packages/monitor-ui/src/components/hermes/CoPilotRail.digest.test.tsx
@@ -65,7 +65,7 @@ describe("PR-D3d — rail Hermes digest", () => {
     );
     const box = container.querySelector(".hm-rail-ops-sugg") as HTMLElement;
     expect(box).toBeTruthy();
-    expect(box.textContent).toContain("Signer USDC below floor");
+    expect(box.textContent).toContain("Reward bank below floor");
     // Every incident now arrives pre-drafted — signer-floor + money-path both actionable.
     const propose = within(box).getAllByText("Propose task");
     expect(propose.length).toBeGreaterThan(1);

--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -55,7 +55,7 @@ describe("OpsBoard — live (today) fixture", () => {
 describe("OpsBoard — populated fixture", () => {
   test("solvency, funnel, trends, incidents, and deploy all render real data", () => {
     const { getByTestId, getByText } = render(<OpsBoard health={OPS_FIXTURE_POPULATED} nowMs={FIXTURE_NOW} />);
-    expect(getByTestId("ops-pool-signer_usdc")).toBeTruthy();
+    expect(getByTestId("ops-pool-reward_bank")).toBeTruthy();
     expect(getByTestId("ops-runway")).toBeTruthy();
     expect(within(getByTestId("ops-fstep-settled")).getByText("37")).toBeTruthy();
     expect(getByTestId("ops-zone-trends")).toBeTruthy();
@@ -66,6 +66,29 @@ describe("OpsBoard — populated fixture", () => {
   test("the ongoing chain incident shows an ongoing duration", () => {
     const { getByTestId } = render(<OpsBoard health={OPS_FIXTURE_POPULATED} nowMs={FIXTURE_NOW} />);
     expect(getByTestId("ops-incidents").textContent).toContain("ongoing");
+  });
+
+  test("shows the declared reason for an intentionally unfunded reserve", () => {
+    const health = {
+      ...OPS_FIXTURE_POPULATED,
+      solvency: {
+        ...OPS_FIXTURE_POPULATED.solvency!,
+        pools: OPS_FIXTURE_POPULATED.solvency!.pools.map((pool) =>
+          pool.key === "reserve"
+            ? {
+                ...pool,
+                amount: 0,
+                floor: null,
+                note: "Intentionally unfunded: pre-revenue reserve",
+              }
+            : pool,
+        ),
+      },
+    };
+    const { getByTestId } = render(<OpsBoard health={health} nowMs={FIXTURE_NOW} />);
+    expect(getByTestId("ops-pool-reserve").textContent).toContain(
+      "Intentionally unfunded: pre-revenue reserve",
+    );
   });
 });
 

--- a/packages/monitor-ui/src/components/ops/SolvencyZone.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyZone.tsx
@@ -33,6 +33,7 @@ export function SolvencyZone({ solvency }: SolvencyZoneProps) {
                       {row.floorLabel ? <span className="ops-gauge-floor"> · {row.floorLabel}</span> : null}
                     </span>
                   </div>
+                  {row.note ? <span className="ops-gauge-note">{row.note}</span> : null}
                   {row.fill == null ? null : (
                     <div className="ops-meter">
                       <i style={{ width: `${Math.round(row.fill * 100)}%` }} />

--- a/packages/monitor-ui/src/components/ops/TrendsZone.tsx
+++ b/packages/monitor-ui/src/components/ops/TrendsZone.tsx
@@ -1,5 +1,5 @@
 // Trends — the rolling-history zone. Uptime (a status strip + 24h %), API latency
-// (SVG line), and signer USDC balance (SVG line). All fed by the server-side
+// (SVG line), and reward bank balance (SVG line). All fed by the server-side
 // history store; until that store has data the zone shows an honest accruing
 // state rather than a flat fake line.
 //
@@ -79,12 +79,12 @@ export function TrendsZone({ history }: TrendsZoneProps) {
 
           <div className="ops-trend">
             <div className="ops-trend-head">
-              <span>Signer USDC</span>
+              <span>Reward bank</span>
               <span className="ops-trend-val">{lastNum(balance, "")}</span>
             </div>
             <AnomalyChip a={anomalyOf("balance")} />
             {hasSeries(balance) ? (
-              <LineSpark values={balance!} tone="ok" ariaLabel="Signer USDC balance trend" />
+              <LineSpark values={balance!} tone="ok" ariaLabel="Reward bank balance trend" />
             ) : (
               <p className="ops-await ops-await--inline">accruing</p>
             )}

--- a/packages/monitor-ui/src/lib/monitor/ops-anomaly.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-anomaly.ts
@@ -107,7 +107,7 @@ export function detectAnomalies(history: HealthHistory | undefined, config?: Par
   if (bal) {
     out.push({
       metric: "balance",
-      label: "Signer USDC",
+      label: "Reward bank",
       direction: "down",
       current: round(bal.current, 2),
       baseline: round(bal.baseline, 2),

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -92,7 +92,6 @@ export const OPS_FIXTURE_LIVE: ProductHealth = {
 
 // ── fully wired — every zone has real data ───────────────────────────────────
 const SOLVENCY_POOLS: SolvencyPool[] = [
-  { key: "signer_usdc", label: "Signer USDC", amount: 2.0, unit: "USDC", floor: 1.0, status: "degraded" },
   { key: "signer_gas", label: "Signer gas", amount: 4999.99, unit: "PAS", floor: 50, status: "ok" },
   { key: "reward_bank", label: "Reward bank", amount: 184.5, unit: "USDC", floor: 25, status: "ok" },
   { key: "aac", label: "Agent core", amount: 512.0, unit: "USDC", floor: 100, status: "ok" },
@@ -182,8 +181,8 @@ export const OPS_FIXTURE_RED: ProductHealth = {
   },
   solvency: {
     pools: SOLVENCY_POOLS.map((p) =>
-      p.key === "signer_usdc" ? { ...p, amount: 0.8, status: "red" } : p,
+      p.key === "reward_bank" ? { ...p, amount: 0.8, status: "red" } : p,
     ),
-    runwayNote: "signer USDC below floor — top up before next payout",
+    runwayNote: "reward bank below floor — top up before next payout",
   },
 };

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.test.ts
@@ -62,14 +62,14 @@ describe("opsSuggestions", () => {
         pools: [],
         runway: [
           { key: "signer_gas", label: "signer gas", unit: "PAS", current: 4999, floor: 1, burnPerHour: null, hoursToFloor: null, estimable: true, status: "ok" },
-          { key: "signer_usdc", label: "signer USDC", unit: "USDC", current: 3, floor: 1, burnPerHour: 0.4, hoursToFloor: 5, estimable: true, status: "red" },
+          { key: "reward_bank", label: "reward bank", unit: "USDC", current: 3, floor: 1, burnPerHour: 0.4, hoursToFloor: 5, estimable: true, status: "red" },
         ],
       },
     };
     const byId = Object.fromEntries(opsSuggestions(health).map((s) => [s.id, s]));
     expect(byId["signer-runway"]).toBeTruthy();
     expect(byId["signer-runway"].tone).toBe("act"); // red projection
-    expect(byId["signer-runway"].text).toContain("signer USDC ~5h to floor");
+    expect(byId["signer-runway"].text).toContain("reward bank ~5h to floor");
     expect(byId["signer-runway"].task?.prompt).toContain("PREPARE ONLY");
     expect(byId["signer-runway"].task?.prompt).toContain("do NOT move funds");
     expect(byId["signer-runway"].task?.repo).toContain("averray-reference-agent");
@@ -86,7 +86,7 @@ describe("opsSuggestions", () => {
       solvency: {
         pools: [],
         runway: [
-          { key: "signer_usdc", label: "signer USDC", unit: "USDC", current: 1, floor: 1, burnPerHour: 0.4, hoursToFloor: 0, estimable: true, status: "red" },
+          { key: "reward_bank", label: "reward bank", unit: "USDC", current: 1, floor: 1, burnPerHour: 0.4, hoursToFloor: 0, estimable: true, status: "red" },
         ],
       },
     };
@@ -105,7 +105,7 @@ describe("opsSuggestions", () => {
       solvency: {
         pools: [],
         runway: [
-          { key: "signer_usdc", label: "signer USDC", unit: "USDC", current: 3, floor: 1, burnPerHour: 0, hoursToFloor: null, estimable: true, status: "ok" },
+          { key: "reward_bank", label: "reward bank", unit: "USDC", current: 3, floor: 1, burnPerHour: 0, hoursToFloor: null, estimable: true, status: "ok" },
         ],
       },
     };

--- a/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-suggestions.ts
@@ -71,16 +71,16 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
     });
   }
 
-  // 2. Signer at/below floor — settlement halts. Funds are operator-only, so the
+  // 2. Reward bank at/below floor — settlement halts. Funds are operator-only, so the
   //    task PREPARES the top-up (compute + draft); it never moves money.
   const signer = live("signer_liquidity");
   if (signer && (signer.status === "red" || /below floor/i.test(signer.detail))) {
     out.push({
       id: "signer-floor",
       tone: signer.status === "red" ? "act" : "warn",
-      text: "Signer USDC below floor — top up before the next payout.",
+      text: "Reward bank below floor — top up before the next payout.",
       task: proposeTask(
-        `Prepare a signer top-up — do NOT move funds, PREPARE ONLY. The signer is at/below its floor: "${signer.detail}". Compute how much to add to restore a safe buffer (≈ 5× floor) and draft the exact top-up steps/command for the operator to execute.`,
+        `Prepare a reward-bank top-up — do NOT move funds, PREPARE ONLY. The in-contract reward bank is at/below its floor: "${signer.detail}". Compute how much to add to restore a safe buffer (≈ 5× floor) and draft the exact brokered deposit steps/command for the operator to execute.`,
       ),
     });
   }
@@ -99,7 +99,7 @@ export function opsSuggestions(health: ProductHealth | undefined): OpsSuggestion
       tone: nearest.status === "red" ? "act" : "warn",
       text: `${nearest.label} ${eta} to floor — top up before settlement halts.`,
       task: proposeTask(
-        `Prepare a signer top-up — do NOT move funds, PREPARE ONLY. ${nearest.label} is projected to reach its ${nearest.floor} ${nearest.unit} floor in ${eta} (current ${nearest.current} ${nearest.unit}${burn}). Compute how much ${nearest.unit} to add to reach a safe buffer (target ≈ 5× the floor) and draft the exact top-up steps/command for the operator to review and execute.`,
+        `Prepare a reward-bank top-up — do NOT move funds, PREPARE ONLY. ${nearest.label} is projected to reach its ${nearest.floor} ${nearest.unit} floor in ${eta} (current ${nearest.current} ${nearest.unit}${burn}). Compute how much ${nearest.unit} to add to reach a safe buffer (target ≈ 5× the floor) and draft the exact brokered deposit steps/command for the operator to review and execute.`,
       ),
     });
   }

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -32,6 +32,8 @@ export interface SolvencyPool {
   status: ProbeStatus;
   /** Shown for context but not floored (e.g. escrow balance). */
   informational?: boolean;
+  /** Operator-declared context for an intentionally unfloored pool. */
+  note?: string;
 }
 
 export interface SolvencySnapshot {
@@ -91,7 +93,7 @@ export interface HealthHistory {
   uptimeSeries?: ProbeStatus[];
   /** Per-check API latency ms (null = missing sample), oldest → newest. */
   latencySeriesMs?: (number | null)[];
-  /** Signer USDC balance over time (null = missing), oldest → newest. */
+  /** Reward bank balance over time (null = missing), oldest → newest. */
   balanceSeries?: (number | null)[];
   incidents?: OpsIncident[];
 }

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -306,6 +306,12 @@
 .ops-gauge-name { color: var(--h4-ink); }
 .ops-gauge-val { color: var(--h4-muted); font-variant-numeric: tabular-nums; text-align: right; }
 .ops-gauge-floor { color: var(--h4-faint); }
+.ops-gauge-note {
+  display: block;
+  margin-top: 3px;
+  color: var(--h4-faint);
+  font-size: 11.5px;
+}
 .ops-meter {
   height: 6px;
   margin-top: 5px;

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3536,10 +3536,12 @@ function startOperatorRoutines() {
         cooldownMs: routineConfig.productHealth.cooldownMs,
       });
       // Enrich each entry with the samples the Trends zone graphs + the runway
-      // projection reads: the /health round-trip latency and the signer USDC / gas
+      // projection reads: the /health round-trip latency and the reward bank / gas
       // balances (from the solvency block).
       const signerPools = collection.snapshot.solvency?.pools ?? [];
-      const signerUsdcSample = signerPools.find((p) => p.key === "signer_usdc")?.amount ?? null;
+      // Historical field name retained for stored-data compatibility; the
+      // sample is the in-contract reward bank, never signer wallet USDC.
+      const signerUsdcSample = signerPools.find((p) => p.key === "reward_bank")?.amount ?? null;
       const signerGasSample = signerPools.find((p) => p.key === "signer_gas")?.amount ?? null;
       productHealthHistory = appendHistory(
         productHealthHistory,
@@ -3555,7 +3557,7 @@ function startOperatorRoutines() {
       );
       // Liquidity runway: project time-to-floor from the balance series (incl. the
       // sample just appended) and write the honest note into the solvency block —
-      // "signer USDC ≈ 6h to floor" / "stable" / awaiting. Suggest-only: the board
+      // "reward bank ≈ 6h to floor" / "stable" / awaiting. Suggest-only: the board
       // tells the operator when to top up; it never moves funds.
       if (productHealthSnapshotBlocks?.solvency) {
         const runway = deriveLiquidityRunway(

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -13,9 +13,10 @@
 //    (it reads `auth.chainId`), with no separate endpoint that can drift to the
 //    wrong network. A frozen chain still reports its last block, so a block-advance
 //    tracker turns a static height into a halt signal.
-//  • Signer BALANCES come from a direct eth-RPC (eth_getBalance + erc20 balanceOf)
-//    — `/health` does not expose balances, so this is the only source of real
-//    solvency monitoring. Raw JSON-RPC over the injected `fetch` (no viem dep).
+//  • Signer gas comes from direct eth-RPC (`eth_getBalance`). Payout liquidity
+//    comes from `/health.rewardBank.liquid`, the authoritative
+//    AgentAccountCore.positions[signer][USDC].liquid position. Raw JSON-RPC uses
+//    the injected `fetch` (no viem dependency).
 //
 // TRUTH-BOUNDARY (the whole point): an UNCONFIGURED or unreadable probe reports
 // `degraded`, never a fake green; a probe the product self-reports as failing (or a
@@ -68,7 +69,9 @@ export interface ProductHealthSnapshot {
   probes: ProbeResult[];
   /** GET /health round-trip latency (ms) for this check — Trends latency series. */
   latencyMs?: number | null;
-  /** Signer USDC balance at this check — Trends balance series + USDC runway. */
+  /** Reward-bank USDC at this check — Trends balance series + payout runway.
+   *  The field name is retained for stored-history compatibility; the value is
+   *  AgentAccountCore.positions[signer][USDC].liquid, never wallet USDC. */
   signerUsdc?: number | null;
   /** Signer native-gas balance at this check — gas runway (matters on mainnet). */
   signerGas?: number | null;
@@ -208,11 +211,11 @@ function deriveIncidents(history: ReadonlyArray<ProductHealthSnapshot>): Product
 
 // ── Liquidity runway (projects time-to-floor from the balance series) ──
 
-/** Per-pool balance accessor into a history entry — only the live signer pools
- *  carry a stored series; treasury pools are forward-compat (no series yet). */
+/** Per-pool balance accessor into a history entry — only live payout/gas pools
+ *  carry a stored series; other treasury pools are forward-compat. */
 const RUNWAY_SERIES: Record<string, (s: ProductHealthSnapshot) => number | null | undefined> = {
   signer_gas: (s) => s.signerGas,
-  signer_usdc: (s) => s.signerUsdc,
+  reward_bank: (s) => s.signerUsdc,
 };
 
 export interface LiquidityRunwayPool {
@@ -447,8 +450,6 @@ export interface ProductHealthConfig {
   usdcDecimals: number;
   /** Native-gas floor in whole tokens (e.g. 0.1 DOT). 0 = don't threshold. */
   minGasNative: number;
-  /** USDC floor in whole tokens (e.g. 5). 0 = don't threshold. */
-  minUsdc: number;
   /** capabilityHealth keys that MUST be up; one dropping ⇒ red. Env
    *  PRODUCT_HEALTH_REQUIRED_CAPABILITIES (csv). Default blockchain,treasuryMutations. */
   requiredCapabilities: string[];
@@ -473,6 +474,9 @@ export interface ProductHealthConfig {
    *  PRODUCT_HEALTH_MIN_TREASURY_RESERVE / PRODUCT_HEALTH_MIN_AAC. */
   minRewardBank: number;
   minTreasuryReserve: number;
+  /** Required explanation when the treasury-reserve floor is deliberately 0.
+   *  Without it the reserve probe degrades instead of silently painting green. */
+  treasuryReserveZeroReason?: string;
   minAac: number;
 }
 
@@ -526,7 +530,6 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
     minGasNative: num(env.PRODUCT_HEALTH_MIN_GAS_NATIVE, 0),
-    minUsdc: num(env.PRODUCT_HEALTH_MIN_USDC, 0),
     requiredCapabilities: csv(env.PRODUCT_HEALTH_REQUIRED_CAPABILITIES, "blockchain,treasuryMutations"),
     expectedWarnings: csv(env.PRODUCT_HEALTH_EXPECTED_WARNINGS, "xcm_observer_staged,indexer_unavailable,gas_sponsor_disabled"),
     latencyWarnMs: num(env.PRODUCT_HEALTH_LATENCY_WARN_MS, 2000),
@@ -536,6 +539,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     settlementMaxStaleMinutes: num(env.PRODUCT_HEALTH_SETTLEMENT_MAX_STALE_MINUTES, 15),
     minRewardBank: num(env.PRODUCT_HEALTH_MIN_REWARD_BANK, 0),
     minTreasuryReserve: num(env.PRODUCT_HEALTH_MIN_TREASURY_RESERVE, 5),
+    treasuryReserveZeroReason: env.PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON?.trim() || undefined,
     minAac: num(env.PRODUCT_HEALTH_MIN_AAC, 0),
   };
 }
@@ -874,14 +878,20 @@ function encodeBalanceOf(address: string): string {
   return BALANCE_OF_SELECTOR + address.toLowerCase().replace(/^0x/, "").padStart(64, "0");
 }
 
-/** Signer solvency: native gas + (optionally) USDC vs floors. Read fails → degraded. */
+/** Signer solvency: native wallet gas + the in-contract reward bank.
+ *
+ * USDC intentionally lives in AgentAccountCore.positions[signer][USDC].liquid
+ * after funding. Reading ERC-20 balanceOf(signer) here alarms on the wrong
+ * number: it stays zero while payouts are healthy and does not fall when the
+ * reward bank drains. The product already exposes the authoritative position as
+ * /health.rewardBank.liquid, shared with treasury_liquidity below.
+ */
 export async function probeSignerLiquidity(input: {
   rpcUrl?: string;
   signerAddress?: string;
-  usdcAddress?: string;
-  usdcDecimals: number;
+  rewardBankLiquid?: number;
   minGasNative: number;
-  minUsdc: number;
+  minRewardBank: number;
   /** The chainId `/health` reports. When set, the RPC must agree before we trust
    *  any balance it returns (chain guard below). */
   expectedChainId?: number;
@@ -919,10 +929,12 @@ export async function probeSignerLiquidity(input: {
     }
     const gasWei = BigInt(await ethRpc(input.rpcUrl, "eth_getBalance", [input.signerAddress, "latest"], input.fetchImpl));
     const gasNative = Number(gasWei) / 1e18;
+    const gasUnit = input.expectedChainId === 420420419 ? "DOT" : "PAS";
     const parts: string[] = [];
     let red = false;
+    let degraded = false;
 
-    const gasPart = `gas ${gasNative.toFixed(4)}`;
+    const gasPart = `gas ${gasNative.toFixed(4)} ${gasUnit}`;
     if (input.minGasNative > 0 && gasNative < input.minGasNative) {
       red = true;
       parts.push(`${gasPart} < ${input.minGasNative}`);
@@ -930,21 +942,16 @@ export async function probeSignerLiquidity(input: {
       parts.push(gasPart);
     }
 
-    let usdc: number | undefined;
-    if (input.usdcAddress) {
-      const usdcRaw = await ethRpc(
-        input.rpcUrl,
-        "eth_call",
-        [{ to: input.usdcAddress, data: encodeBalanceOf(input.signerAddress) }, "latest"],
-        input.fetchImpl,
-      );
-      usdc = Number(BigInt(usdcRaw || "0x0")) / 10 ** input.usdcDecimals;
-      const usdcPart = `USDC ${usdc.toFixed(2)}`;
-      if (input.minUsdc > 0 && usdc < input.minUsdc) {
+    if (input.rewardBankLiquid === undefined) {
+      degraded = true;
+      parts.push("reward bank unreadable");
+    } else {
+      const rewardPart = `reward bank ${input.rewardBankLiquid.toFixed(2)} USDC`;
+      if (input.minRewardBank > 0 && input.rewardBankLiquid < input.minRewardBank) {
         red = true;
-        parts.push(`${usdcPart} < ${input.minUsdc}`);
+        parts.push(`${rewardPart} < ${input.minRewardBank}`);
       } else {
-        parts.push(usdcPart);
+        parts.push(rewardPart);
       }
     }
 
@@ -953,23 +960,29 @@ export async function probeSignerLiquidity(input: {
         key: "signer_gas",
         label: "Signer gas",
         amount: gasNative,
-        unit: "PAS",
+        unit: gasUnit,
         floor: input.minGasNative > 0 ? input.minGasNative : null,
         status: input.minGasNative > 0 && gasNative < input.minGasNative ? "red" : "ok",
       },
     ];
-    if (usdc !== undefined) {
+    if (input.rewardBankLiquid !== undefined) {
       pools.push({
-        key: "signer_usdc",
-        label: "Signer USDC",
-        amount: usdc,
+        key: "reward_bank",
+        label: "Reward bank",
+        amount: input.rewardBankLiquid,
         unit: "USDC",
-        floor: input.minUsdc > 0 ? input.minUsdc : null,
-        status: input.minUsdc > 0 && usdc < input.minUsdc ? "red" : "ok",
+        floor: input.minRewardBank > 0 ? input.minRewardBank : null,
+        status: input.minRewardBank > 0 && input.rewardBankLiquid < input.minRewardBank ? "red" : "ok",
       });
     }
 
-    return { name: "signer_liquidity", status: red ? "red" : "ok", detail: parts.join(", "), pools, rpcOk: true };
+    return {
+      name: "signer_liquidity",
+      status: red ? "red" : degraded ? "degraded" : "ok",
+      detail: parts.join(", "),
+      pools,
+      rpcOk: true,
+    };
   } catch (err) {
     // The direct RPC read itself failed (timeout / 1006 / bad endpoint) — distinct
     // from a low balance. rpcOk:false is the auto-remediation failover signal.
@@ -987,6 +1000,7 @@ export async function probeTreasuryLiquidity(input: {
   usdcDecimals: number;
   minRewardBank: number;
   minTreasuryReserve: number;
+  treasuryReserveZeroReason?: string;
   minAac: number;
   rpcUrl?: string;
   fetchImpl: typeof fetch;
@@ -1008,6 +1022,7 @@ export async function probeTreasuryLiquidity(input: {
     ]);
     const parts: string[] = [];
     let red = false;
+    let degraded = false;
     const withFloor = (label: string, val: number | undefined, floor: number): void => {
       if (val === undefined) return;
       const s = `${label} ${val.toFixed(2)}`;
@@ -1019,22 +1034,61 @@ export async function probeTreasuryLiquidity(input: {
       }
     };
     withFloor("reward", input.rewardBankLiquid, input.minRewardBank);
-    withFloor("reserve", reserve, input.minTreasuryReserve);
+    if (input.minTreasuryReserve === 0) {
+      if (input.treasuryReserveZeroReason) {
+        if (reserve !== undefined) {
+          parts.push(
+            `reserve ${reserve.toFixed(2)} (intentionally unfunded: ${input.treasuryReserveZeroReason})`,
+          );
+        }
+      } else {
+        degraded = true;
+        if (reserve !== undefined) {
+          parts.push(`reserve ${reserve.toFixed(2)} (floor disabled without a declared reason)`);
+        }
+      }
+    } else {
+      withFloor("reserve", reserve, input.minTreasuryReserve);
+    }
     withFloor("AAC", aac, input.minAac);
     if (escrow !== undefined) parts.push(`escrow ${escrow.toFixed(2)}`); // in-flight — informational, no floor
 
     const pools: SolvencyPoolData[] = [];
-    const pool = (key: string, label: string, val: number | undefined, floor: number): void => {
+    const pool = (
+      key: string,
+      label: string,
+      val: number | undefined,
+      floor: number,
+      note?: string,
+    ): void => {
       if (val === undefined) return;
-      pools.push({ key, label, amount: val, unit: "USDC", floor: floor > 0 ? floor : null, status: floor > 0 && val < floor ? "red" : "ok" });
+      pools.push({
+        key,
+        label,
+        amount: val,
+        unit: "USDC",
+        floor: floor > 0 ? floor : null,
+        status: floor > 0 && val < floor ? "red" : "ok",
+        ...(note ? { note } : {}),
+      });
     };
     pool("reward_bank", "Reward bank", input.rewardBankLiquid, input.minRewardBank);
-    pool("reserve", "Treasury reserve", reserve, input.minTreasuryReserve);
+    pool(
+      "reserve",
+      "Treasury reserve",
+      reserve,
+      input.minTreasuryReserve,
+      input.minTreasuryReserve === 0
+        ? input.treasuryReserveZeroReason
+          ? `Intentionally unfunded: ${input.treasuryReserveZeroReason}`
+          : "Floor disabled without a declared reason"
+        : undefined,
+    );
     pool("aac", "Agent core", aac, input.minAac);
     if (escrow !== undefined) pools.push({ key: "escrow", label: "Escrow (in-flight)", amount: escrow, unit: "USDC", status: "ok", informational: true });
 
     if (parts.length === 0) return { name, status: "degraded", detail: "no treasury balances readable" };
-    return { name, status: red ? "red" : "ok", detail: parts.join(", "), pools };
+    return { name, status: red ? "red" : degraded ? "degraded" : "ok", detail: parts.join(", "), pools };
   } catch (err) {
     return { name, status: "degraded", detail: `treasury read failed: ${errMsg(err)}` };
   }
@@ -1056,6 +1110,8 @@ export interface SolvencyPoolData {
   floor?: number | null;
   status: ProbeStatus;
   informational?: boolean;
+  /** Operator-declared context for a deliberately unfloored pool. */
+  note?: string;
 }
 export interface SolvencySnapshotData {
   pools: SolvencyPoolData[];
@@ -1154,10 +1210,9 @@ export async function collectProductHealthProbes(
   const signer = await probeSignerLiquidity({
     rpcUrl: config.rpcUrl,
     signerAddress: config.signerAddress,
-    usdcAddress: config.usdcAddress,
-    usdcDecimals: config.usdcDecimals,
+    rewardBankLiquid: pickNum(h.body?.rewardBank?.liquid),
     minGasNative: config.minGasNative,
-    minUsdc: config.minUsdc,
+    minRewardBank: config.minRewardBank,
     // Balances are only trusted from an RPC on the product's own chain.
     expectedChainId: chainId,
     fetchImpl,
@@ -1168,11 +1223,19 @@ export async function collectProductHealthProbes(
     usdcDecimals: config.usdcDecimals,
     minRewardBank: config.minRewardBank,
     minTreasuryReserve: config.minTreasuryReserve,
+    treasuryReserveZeroReason: config.treasuryReserveZeroReason,
     minAac: config.minAac,
     rpcUrl: config.rpcUrl,
     fetchImpl,
   });
-  const solvencyPools = [...(signer.pools ?? []), ...(treasury.pools ?? [])];
+  // signer_liquidity and treasury_liquidity intentionally share the same
+  // /health reward-bank position. Keep one board row while retaining both
+  // independently actionable probes.
+  const solvencyPools = [
+    ...new Map(
+      [...(signer.pools ?? []), ...(treasury.pools ?? [])].map((pool) => [pool.key, pool]),
+    ).values(),
+  ];
   const settlement = h.body?.settlement;
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -138,7 +138,6 @@ const cfg = (over: Partial<ProductHealthConfig> = {}): ProductHealthConfig => ({
   usdcAddress: "0xusdc",
   usdcDecimals: 6,
   minGasNative: 0,
-  minUsdc: 0,
   requiredCapabilities: ["blockchain", "treasuryMutations"],
   expectedWarnings: ["xcm_observer_staged", "indexer_unavailable", "gas_sponsor_disabled"],
   latencyWarnMs: 2000,
@@ -393,51 +392,57 @@ describe("deriveCapabilityProbe", () => {
 });
 
 describe("probeSignerLiquidity (direct RPC)", () => {
-  const floors = { usdcDecimals: 6, minGasNative: 0.1, minUsdc: 5 };
+  const floors = { minGasNative: 0.1, minRewardBank: 5 };
   // 1 ETH = 1e18 wei = 0xDE0B6B3A7640000 ; 0.01 ETH = 1e16 = 0x2386F26FC10000
   // 10 USDC = 10_000_000 = 0x989680 ; 1 USDC = 1_000_000 = 0xF4240
 
   it("degraded when RPC / signer address are unconfigured", async () => {
-    const r = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: undefined, usdcAddress: undefined, ...floors, fetchImpl: balances("0x0", "0x0") });
+    const r = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: undefined, rewardBankLiquid: 10, ...floors, fetchImpl: balances("0x0", "0x0") });
     expect(r.status).toBe("degraded");
   });
 
-  it("ok when gas and USDC are both above their floors", async () => {
-    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0x989680") });
+  it("ok when gas and the in-contract reward bank are both above their floors", async () => {
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0x989680") });
     expect(r.status).toBe("ok");
-    expect(r.detail).toContain("USDC 10.00");
+    expect(r.detail).toContain("reward bank 10.00 USDC");
   });
 
-  it("exposes structured signer pools (gas + USDC) for the Ops board", async () => {
-    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0x989680") });
-    expect(r.pools?.map((p) => p.key)).toEqual(["signer_gas", "signer_usdc"]);
-    const usdc = r.pools?.find((p) => p.key === "signer_usdc");
-    expect(usdc?.amount).toBe(10);
-    expect(usdc?.unit).toBe("USDC");
-    expect(usdc?.floor).toBe(5);
+  it("exposes structured signer gas + reward-bank pools for the Ops board", async () => {
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0x989680") });
+    expect(r.pools?.map((p) => p.key)).toEqual(["signer_gas", "reward_bank"]);
+    const reward = r.pools?.find((p) => p.key === "reward_bank");
+    expect(reward?.amount).toBe(10);
+    expect(reward?.unit).toBe("USDC");
+    expect(reward?.floor).toBe(5);
   });
 
   it("red when native gas is below the floor", async () => {
-    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: balances("0x2386F26FC10000", "0x989680") });
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors, fetchImpl: balances("0x2386F26FC10000", "0x989680") });
     expect(r.status).toBe("red");
     expect(r.detail).toContain("< 0.1");
   });
 
-  it("red when USDC is below the floor", async () => {
-    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0xF4240") });
+  it("red when the reward-bank position is below the floor", async () => {
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 1, ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0xF4240") });
     expect(r.status).toBe("red");
     expect(r.detail).toContain("< 5");
   });
 
+  it("degrades rather than reading wallet USDC when /health omits the reward bank", async () => {
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: undefined, ...floors, fetchImpl: balances("0xDE0B6B3A7640000", "0x989680") });
+    expect(r.status).toBe("degraded");
+    expect(r.detail).toContain("reward bank unreadable");
+  });
+
   it("degraded when the balance read fails", async () => {
-    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors, fetchImpl: throwingFetch() });
+    const r = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors, fetchImpl: throwingFetch() });
     expect(r.status).toBe("degraded");
   });
 
   it("names WHICH piece is unconfigured (a cutover leaves solvency unmonitored)", async () => {
-    const noRpc = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: "0xabc", usdcAddress: undefined, ...floors, fetchImpl: balances("0x0", "0x0") });
+    const noRpc = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: "0xabc", rewardBankLiquid: 10, ...floors, fetchImpl: balances("0x0", "0x0") });
     expect(noRpc.detail).toContain("PRODUCT_HEALTH_RPC_URL");
-    const noSigner = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: undefined, usdcAddress: undefined, ...floors, fetchImpl: balances("0x0", "0x0") });
+    const noSigner = await probeSignerLiquidity({ rpcUrl: "http://rpc", signerAddress: undefined, rewardBankLiquid: 10, ...floors, fetchImpl: balances("0x0", "0x0") });
     expect(noSigner.detail).toContain("PRODUCT_HEALTH_SIGNER_ADDRESS");
   });
 
@@ -456,32 +461,32 @@ describe("probeSignerLiquidity (direct RPC)", () => {
 
   it("reads balances normally when the RPC is on the product's chain", async () => {
     const r = await probeSignerLiquidity({
-      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors,
       expectedChainId: 420420417,
       fetchImpl: chainedBalances(TESTNET, "0xDE0B6B3A7640000", "0x989680"),
     });
     expect(r.status).toBe("ok");
-    expect(r.detail).toContain("USDC 10.00");
+    expect(r.detail).toContain("reward bank 10.00 USDC");
   });
 
   it("RED + rpcOk:false when the product is on MAINNET but the RPC is a leftover testnet endpoint", async () => {
     // The exact cutover hazard: healthy testnet RPC, flush testnet signer, and the
     // mainnet signer could be dry. Must NOT report those balances as green.
     const r = await probeSignerLiquidity({
-      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors,
       expectedChainId: 420420419, // product is live on mainnet
       fetchImpl: chainedBalances(TESTNET, "0xDE0B6B3A7640000", "0x989680"), // fat testnet balances
     });
     expect(r.status).toBe("red"); // blind on mainnet pages
     expect(r.detail).toContain("chain mismatch");
     expect(r.detail).toContain("420420419");
-    expect(r.detail).not.toContain("USDC 10.00"); // the wrong chain's balance never surfaces
+    expect(r.detail).not.toContain("reward bank 10.00"); // no balance is trusted through a wrong-chain RPC
     expect(r.rpcOk).toBe(false); // drives failover past this endpoint, then escalates
   });
 
   it("degraded (not red) on a mismatch while the product is still on a testnet", async () => {
     const r = await probeSignerLiquidity({
-      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors,
       expectedChainId: 420420417,
       fetchImpl: chainedBalances(MAINNET, "0xDE0B6B3A7640000", "0x989680"),
     });
@@ -491,7 +496,7 @@ describe("probeSignerLiquidity (direct RPC)", () => {
 
   it("skips the guard when the product's chainId is unknown (no /health chainId)", async () => {
     const r = await probeSignerLiquidity({
-      rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc", ...floors,
+      rpcUrl: "http://rpc", signerAddress: "0xabc", rewardBankLiquid: 10, ...floors,
       expectedChainId: undefined,
       fetchImpl: chainedBalances(TESTNET, "0xDE0B6B3A7640000", "0x989680"),
     });
@@ -540,6 +545,30 @@ describe("probeTreasuryLiquidity (direct RPC + /health rewardBank)", () => {
     expect(r.detail).toContain("reward 10.00 < 50");
   });
 
+  it("declares an intentionally unfunded reserve when its floor is explicitly zero", async () => {
+    const r = await probeTreasuryLiquidity({
+      ...base,
+      minTreasuryReserve: 0,
+      treasuryReserveZeroReason: "pre-revenue reserve; payouts use the reward bank",
+      rewardBankLiquid: 100,
+      fetchImpl: balances("0x0", "0x0"),
+    });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("intentionally unfunded: pre-revenue reserve");
+    expect(r.pools?.find((pool) => pool.key === "reserve")?.note).toContain("Intentionally unfunded");
+  });
+
+  it("degrades when a zero reserve floor has no declared reason", async () => {
+    const r = await probeTreasuryLiquidity({
+      ...base,
+      minTreasuryReserve: 0,
+      rewardBankLiquid: 100,
+      fetchImpl: balances("0x0", "0x0"),
+    });
+    expect(r.status).toBe("degraded");
+    expect(r.detail).toContain("floor disabled without a declared reason");
+  });
+
   it("degraded when a balance read fails", async () => {
     expect((await probeTreasuryLiquidity({ ...base, rewardBankLiquid: 100, fetchImpl: throwingFetch() })).status).toBe("degraded");
   });
@@ -554,7 +583,7 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
     );
     expect(probes.map((p) => p.name)).toEqual(["product_api", "chain_height", "signer_liquidity", "capabilities", "api_latency", "money_path", "treasury_liquidity"]);
     expect(probes.map((p) => p.status)).toEqual(["ok", "ok", "ok", "ok", "ok", "ok", "ok"]);
-    expect(probes[2]?.detail).toContain("USDC 10.00");
+    expect(probes[2]?.detail).toContain("reward bank 100.00 USDC");
   });
 
   it("all degraded when nothing is configured (never fake green)", async () => {
@@ -613,7 +642,8 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
     );
     expect(snapshot.chainId).toBe(420420417);
     expect(snapshot.network).toBe("testnet");
-    expect(snapshot.solvency?.pools.some((p) => p.key === "signer_usdc" && p.amount === 10)).toBe(true);
+    expect(snapshot.solvency?.pools.filter((p) => p.key === "reward_bank")).toHaveLength(1);
+    expect(snapshot.solvency?.pools.some((p) => p.key === "reward_bank" && p.amount === 100)).toBe(true);
     expect(snapshot.flow?.settled24h).toBe(37);
     expect(snapshot.flow?.stuck).toBe(1);
   });
@@ -751,7 +781,6 @@ describe("loadProductHealthConfig", () => {
     expect(c.haltSeverity).toBe("auto");
     expect(c.usdcDecimals).toBe(6);
     expect(c.minGasNative).toBe(0);
-    expect(c.minUsdc).toBe(0);
     expect(c.requiredCapabilities).toEqual(["blockchain", "treasuryMutations"]);
     expect(c.expectedWarnings).toContain("indexer_unavailable");
     expect(c.latencyWarnMs).toBe(2000);
@@ -769,14 +798,18 @@ describe("loadProductHealthConfig", () => {
       AVERRAY_API_BASE_URL: "https://api.x/",
       PRODUCT_HEALTH_RPC_URL: "http://rpc",
       PRODUCT_HEALTH_USDC_ADDRESS: "0xusdc",
-      PRODUCT_HEALTH_MIN_USDC: "5",
+      PRODUCT_HEALTH_MIN_REWARD_BANK: "5",
+      PRODUCT_HEALTH_MIN_TREASURY_RESERVE: "0",
+      PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON: "pre-revenue reserve",
       PRODUCT_HEALTH_HALT_SEVERITY: "red",
       PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS: "120",
     });
     expect(c.apiBaseUrl).toBe("https://api.x");
     expect(c.rpcUrl).toBe("http://rpc");
     expect(c.usdcAddress).toBe("0xusdc");
-    expect(c.minUsdc).toBe(5);
+    expect(c.minRewardBank).toBe(5);
+    expect(c.minTreasuryReserve).toBe(0);
+    expect(c.treasuryReserveZeroReason).toBe("pre-revenue reserve");
     expect(c.haltSeverity).toBe("red");
     expect(c.chainMaxStaleSeconds).toBe(120);
   });
@@ -959,8 +992,8 @@ describe("deriveLiquidityRunway", () => {
     signerGas: gas,
   });
   const usdcPool = (amount: number | null, floor: number | null = 1): SolvencyPoolData => ({
-    key: "signer_usdc",
-    label: "signer USDC",
+    key: "reward_bank",
+    label: "reward bank",
     amount,
     unit: "USDC",
     floor,
@@ -976,7 +1009,7 @@ describe("deriveLiquidityRunway", () => {
     expect(r.pools[0].burnPerHour).toBeCloseTo(1, 6);
     expect(r.pools[0].hoursToFloor).toBeCloseTo(12, 6);
     expect(r.pools[0].status).toBe("degraded");
-    expect(r.note).toBe("signer USDC ~12h to floor");
+    expect(r.note).toBe("reward bank ~12h to floor");
   });
 
   it("pages (red) when the floor is < 6h out", () => {
@@ -986,7 +1019,7 @@ describe("deriveLiquidityRunway", () => {
     const r = deriveLiquidityRunway(history, [usdcPool(5)], now);
     expect(r.pools[0].hoursToFloor).toBeCloseTo(2, 6);
     expect(r.pools[0].status).toBe("red");
-    expect(r.note).toBe("signer USDC ~2h to floor");
+    expect(r.note).toBe("reward bank ~2h to floor");
   });
 
   it("reads stable — not a fake countdown — when the balance is flat", () => {
@@ -1023,7 +1056,7 @@ describe("deriveLiquidityRunway", () => {
     const r = deriveLiquidityRunway(history, [usdcPool(1, 1)], now); // current == floor
     expect(r.pools[0].hoursToFloor).toBe(0);
     expect(r.pools[0].status).toBe("red");
-    expect(r.note).toBe("signer USDC at floor");
+    expect(r.note).toBe("reward bank at floor");
   });
 
   it("skips informational + series-less pools; the nearest depleting pool wins the note", () => {
@@ -1032,12 +1065,12 @@ describe("deriveLiquidityRunway", () => {
     const pools: SolvencyPoolData[] = [
       { key: "signer_gas", label: "signer gas", amount: 5000, unit: "PAS", floor: 1, status: "ok" }, // stable, kept
       usdcPool(13), // draining ⇒ 12h
-      { key: "reward_bank", label: "Reward bank", amount: 100, unit: "USDC", floor: 25, status: "ok" }, // no series ⇒ skip
+      { key: "reserve", label: "Treasury reserve", amount: 100, unit: "USDC", floor: 25, status: "ok" }, // no series ⇒ skip
       { key: "escrow", label: "Escrow", amount: 96, unit: "USDC", status: "ok", informational: true }, // informational ⇒ skip
     ];
     const r = deriveLiquidityRunway(history, pools, now);
-    expect(r.pools.map((p) => p.key)).toEqual(["signer_gas", "signer_usdc"]);
-    expect(r.note).toBe("signer USDC ~12h to floor"); // gas is stable ⇒ usdc is the nearest
+    expect(r.pools.map((p) => p.key)).toEqual(["signer_gas", "reward_bank"]);
+    expect(r.note).toBe("reward bank ~12h to floor"); // gas is stable ⇒ usdc is the nearest
   });
 });
 
@@ -1057,33 +1090,33 @@ describe("decideRunwayAlert", () => {
   const rw = (...pools: LiquidityRunwayPool[]): LiquidityRunway => ({ pools, note: null });
 
   it("fires on the rising edge into the danger band, then stays quiet within cooldown", () => {
-    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: initialRunwayAlertState(), nowMs: 1000, cooldownMs: HOUR });
+    const first = decideRunwayAlert({ runway: rw(pool("reward_bank", "degraded")), state: initialRunwayAlertState(), nowMs: 1000, cooldownMs: HOUR });
     expect(first.alert).toBe(true);
-    const again = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: first.state, nowMs: 1000 + 5 * 60_000, cooldownMs: HOUR });
+    const again = decideRunwayAlert({ runway: rw(pool("reward_bank", "degraded")), state: first.state, nowMs: 1000 + 5 * 60_000, cooldownMs: HOUR });
     expect(again.alert).toBe(false);
   });
 
   it("re-fires when the danger worsens (degraded → red) even within cooldown", () => {
-    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
-    const worse = decideRunwayAlert({ runway: rw(pool("signer_usdc", "red", 2)), state: first.state, nowMs: 60_000, cooldownMs: HOUR });
+    const first = decideRunwayAlert({ runway: rw(pool("reward_bank", "degraded")), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const worse = decideRunwayAlert({ runway: rw(pool("reward_bank", "red", 2)), state: first.state, nowMs: 60_000, cooldownMs: HOUR });
     expect(worse.alert).toBe(true);
   });
 
   it("re-fires after the cooldown while the danger persists", () => {
-    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
-    const later = decideRunwayAlert({ runway: rw(pool("signer_usdc", "degraded")), state: first.state, nowMs: HOUR + 1, cooldownMs: HOUR });
+    const first = decideRunwayAlert({ runway: rw(pool("reward_bank", "degraded")), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const later = decideRunwayAlert({ runway: rw(pool("reward_bank", "degraded")), state: first.state, nowMs: HOUR + 1, cooldownMs: HOUR });
     expect(later.alert).toBe(true);
   });
 
   it("clears (no alert, key reset) once every pool is out of the band", () => {
-    const first = decideRunwayAlert({ runway: rw(pool("signer_usdc", "red", 2)), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
-    const safe = decideRunwayAlert({ runway: rw(pool("signer_usdc", "ok", null)), state: first.state, nowMs: 60_000, cooldownMs: HOUR });
+    const first = decideRunwayAlert({ runway: rw(pool("reward_bank", "red", 2)), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const safe = decideRunwayAlert({ runway: rw(pool("reward_bank", "ok", null)), state: first.state, nowMs: 60_000, cooldownMs: HOUR });
     expect(safe.alert).toBe(false);
     expect(safe.state.lastDangerKey).toBe("");
   });
 
   it("stays quiet when nothing is in the danger band", () => {
-    const d = decideRunwayAlert({ runway: rw(pool("signer_usdc", "ok", null), pool("signer_gas", "ok", null)), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
+    const d = decideRunwayAlert({ runway: rw(pool("reward_bank", "ok", null), pool("signer_gas", "ok", null)), state: initialRunwayAlertState(), nowMs: 0, cooldownMs: HOUR });
     expect(d.alert).toBe(false);
   });
 });
@@ -1091,7 +1124,7 @@ describe("decideRunwayAlert", () => {
 describe("buildRunwayAlertPayload", () => {
   const pool = (key: string, status: ProbeResult["status"], hours: number): LiquidityRunwayPool => ({
     key,
-    label: key === "signer_usdc" ? "signer USDC" : "signer gas",
+    label: key === "reward_bank" ? "reward bank" : "signer gas",
     unit: "USDC",
     current: 3,
     floor: 1,
@@ -1102,18 +1135,18 @@ describe("buildRunwayAlertPayload", () => {
   });
 
   it("summarises the danger pools nearest-first with a board link", () => {
-    const runway: LiquidityRunway = { pools: [pool("signer_gas", "degraded", 20), pool("signer_usdc", "red", 3)], note: null };
+    const runway: LiquidityRunway = { pools: [pool("signer_gas", "degraded", 20), pool("reward_bank", "red", 3)], note: null };
     const p = buildRunwayAlertPayload(runway, "https://board");
     expect(p.count).toBe(2);
-    expect(p.items[0].id).toBe("runway-signer_usdc"); // nearest first
+    expect(p.items[0].id).toBe("runway-reward_bank"); // nearest first
     expect(p.items[0].title).toContain("~3h to floor");
     expect(p.boardUrl).toBe("https://board");
-    expect(p.text).toContain("signer USDC ~3h to floor");
+    expect(p.text).toContain("reward bank ~3h to floor");
     expect(p.text).toContain("operator action");
   });
 
   it("excludes stable pools from the payload", () => {
-    const runway: LiquidityRunway = { pools: [{ ...pool("signer_usdc", "ok", 0), hoursToFloor: null }, pool("signer_gas", "degraded", 10)], note: null };
+    const runway: LiquidityRunway = { pools: [{ ...pool("reward_bank", "ok", 0), hoursToFloor: null }, pool("signer_gas", "degraded", 10)], note: null };
     const p = buildRunwayAlertPayload(runway, "https://board");
     expect(p.count).toBe(1);
     expect(p.items[0].id).toBe("runway-signer_gas");


### PR DESCRIPTION
## What changed

- Make `signer_liquidity` read `/health.rewardBank.liquid` — the authoritative `AgentAccountCore.positions[signer][USDC].liquid` — instead of wallet USDC.
- Keep the signer native-wallet balance as the DOT/PAS gas check with the existing chain guard.
- Reuse the same reward-bank pool in `treasury_liquidity` and deduplicate the board row.
- Require an explicit reason when `PRODUCT_HEALTH_MIN_TREASURY_RESERVE=0`; otherwise the probe degrades rather than painting an unfunded reserve green.
- Carry the declared reason onto the Ops board and update runway labels/suggestions from signer wallet USDC to reward bank.

## Required production configuration

Set both values together for the current pre-revenue state:

```text
PRODUCT_HEALTH_MIN_TREASURY_RESERVE=0
PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON=pre-revenue reserve intentionally unfunded; payout safety is enforced by the AgentAccountCore reward-bank floor
```

## Checks

- `npm run typecheck`
- `npm test` (194 files passed, 1 skipped; 2,418 tests passed, 4 skipped)
- `HERMES_IMAGE=hermes:test docker compose --env-file /dev/null -f ops/compose.yml config`
- `git diff --check`

## Surfaces

Hermes Slack operator, monitor UI, and compose configuration. No Averray contracts or secrets change. Human merge/deploy is required by this repository's operator policy.