### PR TITLE
fix(testbed): make live-screencast manifest publication race-free

### DIFF
--- a/services/slack-operator/src/testbed-live-screencast.ts
+++ b/services/slack-operator/src/testbed-live-screencast.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 import type { Page } from "playwright-core";
@@ -39,6 +39,8 @@ export interface TestbedScreencastManifest {
 export interface TestbedLiveScreencastController {
   stop: (reason?: string) => Promise<void>;
 }
+
+let manifestWriteSequence = 0;
 
 const DEFAULT_INTERVAL_MS = 500;
 const DEFAULT_MAX_FRAMES = 240;
@@ -116,9 +118,16 @@ export async function startPlaywrightLiveScreencast(input: {
   const startedAt = (input.now?.() ?? new Date()).toISOString();
   const streamUrl = `/monitor/testbed-missions/${encodeURIComponent(input.mission.id)}/screencast`;
   const latestFrameUrl = `${streamUrl}/latest.jpg`;
+  /** No further frames will be captured or scheduled. */
   let stopped = false;
+  /** A terminal ("ended") manifest has already been published. */
+  let terminated = false;
   let frameCount = 0;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  /** Settles when the capture started by the last fired timer has finished writing. */
+  let inFlightCapture: Promise<void> = Promise.resolve();
+  let manifestWrites: Promise<void> = Promise.resolve();
+  let stopRequest: Promise<void> | undefined;
 
   const publishState = (state: Omit<TestbedLiveScreencastState, "streamUrl" | "latestFrameUrl">) => {
     input.update({
@@ -128,20 +137,37 @@ export async function startPlaywrightLiveScreencast(input: {
     });
   };
 
+  // Manifest writes are serialized so the file on disk always ends up matching
+  // the last state we published, in publish order.
+  const queueManifestWrite = (state: {
+    status: "running" | "ended";
+    frameCount: number;
+    updatedAt: string;
+    endedAt?: string;
+    reason?: string;
+  }): Promise<void> => {
+    const write = manifestWrites.then(() => writeManifest({
+      ...state,
+      missionId: input.mission.id,
+      artifactsRoot: input.artifactsRoot,
+    }));
+    manifestWrites = write.catch(() => undefined);
+    return write;
+  };
+
   const capture = async () => {
     if (stopped) return;
     const now = (input.now?.() ?? new Date()).toISOString();
     if (frameCount >= input.config.maxFrames) {
       stopped = true;
-      await writeManifest({
-        missionId: input.mission.id,
+      terminated = true;
+      await queueManifestWrite({
         status: "ended",
         frameCount,
         updatedAt: now,
         endedAt: now,
         reason: "max_frames_reached",
-        artifactsRoot: input.artifactsRoot,
-      });
+      }).catch(() => undefined);
       publishState({ status: "ended", frameCount, updatedAt: now, endedAt: now, reason: "max_frames_reached" });
       return;
     }
@@ -160,13 +186,7 @@ export async function startPlaywrightLiveScreencast(input: {
         animations: "disabled",
       });
       frameCount += 1;
-      await writeManifest({
-        missionId: input.mission.id,
-        status: "running",
-        frameCount,
-        updatedAt: now,
-        artifactsRoot: input.artifactsRoot,
-      });
+      await queueManifestWrite({ status: "running", frameCount, updatedAt: now });
       publishState({ status: "running", frameCount, startedAt, updatedAt: now });
     } catch {
       publishState({ status: "running", frameCount, startedAt, updatedAt: now, reason: "frame_capture_failed" });
@@ -176,29 +196,38 @@ export async function startPlaywrightLiveScreencast(input: {
 
   const schedule = () => {
     if (stopped) return;
-    timer = setTimeout(() => void capture(), input.config.intervalMs);
+    // Captures are strictly sequential: the next one is only scheduled once the
+    // previous has settled, so tracking the latest is enough for stop() to know
+    // whether a capture is still writing.
+    timer = setTimeout(() => {
+      inFlightCapture = capture().catch(() => undefined);
+    }, input.config.intervalMs);
     timer.unref?.();
+  };
+
+  const stopStream = async (reason: string): Promise<void> => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+    // A capture that started before stop() can still be mid-write. Let it settle
+    // first so the terminal manifest below is the last write to land on disk.
+    await inFlightCapture;
+    if (terminated) return;
+    terminated = true;
+    const now = (input.now?.() ?? new Date()).toISOString();
+    await queueManifestWrite({ status: "ended", frameCount, updatedAt: now, endedAt: now, reason }).catch(() => undefined);
+    publishState({ status: "ended", frameCount, startedAt, updatedAt: now, endedAt: now, reason });
   };
 
   publishState({ status: "running", frameCount: 0, startedAt, updatedAt: startedAt });
   schedule();
 
   return {
-    async stop(reason = "mission_finished") {
-      if (stopped) return;
-      stopped = true;
-      if (timer) clearTimeout(timer);
-      const now = (input.now?.() ?? new Date()).toISOString();
-      await writeManifest({
-        missionId: input.mission.id,
-        status: "ended",
-        frameCount,
-        updatedAt: now,
-        endedAt: now,
-        reason,
-        artifactsRoot: input.artifactsRoot,
-      }).catch(() => undefined);
-      publishState({ status: "ended", frameCount, startedAt, updatedAt: now, endedAt: now, reason });
+    stop(reason = "mission_finished") {
+      // Repeat callers await the same shutdown rather than returning before the
+      // terminal manifest has been written.
+      stopRequest ??= stopStream(reason);
+      return stopRequest;
     },
   };
 }
@@ -224,7 +253,18 @@ async function writeManifest(input: {
     ...(input.endedAt ? { endedAt: input.endedAt } : {}),
     ...(input.reason ? { reason: input.reason } : {}),
   };
-  await writeFile(screencastManifestPath(input.artifactsRoot, input.missionId), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  // Publish atomically: readers (the monitor routes, tests) must never observe a
+  // truncated manifest, which is what a plain overwrite exposes mid-write.
+  const path = screencastManifestPath(input.artifactsRoot, input.missionId);
+  manifestWriteSequence += 1;
+  const tempPath = `${path}.${process.pid}.${manifestWriteSequence}.tmp`;
+  try {
+    await writeFile(tempPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    await rename(tempPath, path);
+  } catch (error) {
+    await unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 function isCaptureablePageUrl(value: string): boolean {

--- a/test/unit/testbed-live-screencast.test.ts
+++ b/test/unit/testbed-live-screencast.test.ts
@@ -92,6 +92,91 @@ describe("testbed live screencast", () => {
     });
     expect(manifest?.frameCount).toBeGreaterThanOrEqual(1);
   });
+
+  it("publishes the terminal manifest last when stop() lands mid-capture", async () => {
+    const root = mkdtempSync(join(tmpdir(), "averray-screencast-test-"));
+    const mission = missionRun({
+      id: "mission-live-stop-race",
+      targetUrl: "https://app.testnet.example/gold",
+      environment: "testnet",
+    });
+    let captureStarted!: () => void;
+    let releaseCapture!: () => void;
+    let framePublished!: () => void;
+    const captureInFlight = new Promise<void>((resolve) => { captureStarted = resolve; });
+    const captureReleased = new Promise<void>((resolve) => { releaseCapture = resolve; });
+    const framePersisted = new Promise<void>((resolve) => { framePublished = resolve; });
+    const page = {
+      url: () => "https://app.testnet.example/gold",
+      screenshot: vi.fn(async ({ path }: { path: string }) => {
+        captureStarted();
+        await captureReleased;
+        writeFileSync(path, Buffer.from("jpeg-frame"));
+      }),
+    } as unknown as Page;
+
+    const controller = await startPlaywrightLiveScreencast({
+      mission,
+      page,
+      artifactsRoot: root,
+      config: { enabled: true, intervalMs: 1, maxFrames: 10, jpegQuality: 40 },
+      update: (state) => {
+        if (state.status === "running" && state.frameCount === 1) framePublished();
+      },
+    });
+
+    await captureInFlight;
+    const stopping = controller?.stop("test_finished");
+    releaseCapture();
+    await stopping;
+    // The frame that was in flight has written its own "running" manifest by
+    // now; stop() must still be the last writer to land on disk.
+    await framePersisted;
+
+    expect(await readTestbedScreencastManifest(root, mission.id)).toMatchObject({
+      status: "ended",
+      reason: "test_finished",
+    });
+  });
+
+  it("never exposes a torn manifest to a concurrent reader", async () => {
+    const root = mkdtempSync(join(tmpdir(), "averray-screencast-test-"));
+    const mission = missionRun({
+      id: "mission-live-torn-read",
+      targetUrl: "https://app.testnet.example/gold",
+      environment: "testnet",
+    });
+    const page = {
+      url: () => "https://app.testnet.example/gold",
+      screenshot: vi.fn(async ({ path }: { path: string }) => {
+        writeFileSync(path, Buffer.from("jpeg-frame"));
+      }),
+    } as unknown as Page;
+
+    const controller = await startPlaywrightLiveScreencast({
+      mission,
+      page,
+      artifactsRoot: root,
+      config: { enabled: true, intervalMs: 0, maxFrames: 1000, jpegQuality: 40 },
+      update: () => {},
+    });
+
+    try {
+      await vi.waitFor(async () => {
+        expect(await readTestbedScreencastManifest(root, mission.id)).toBeDefined();
+      });
+      // The monitor SSE route polls this manifest while the runner rewrites it
+      // on every frame; once written it must never read back as missing.
+      for (let round = 0; round < 20; round += 1) {
+        const reads = await Promise.all(
+          Array.from({ length: 20 }, () => readTestbedScreencastManifest(root, mission.id)),
+        );
+        expect(reads.filter((manifest) => manifest === undefined)).toEqual([]);
+      }
+    } finally {
+      await controller?.stop("test_finished");
+    }
+  });
 });
 
 function missionRun(overrides: Partial<TestbedMissionRun>): TestbedMissionRun {


### PR DESCRIPTION
`test/unit/testbed-live-screencast.test.ts` was intermittently flaky under full-suite parallel execution (~1 in 4), failing with `readTestbedScreencastManifest` returning `undefined` where the terminal manifest was expected. Two real races in the screencast controller, not a test artifact:

1. `writeManifest` overwrote `manifest.json` in place. `writeFile` truncates before it writes, so a concurrent reader could observe an empty file and fall back to `undefined`. The monitor SSE route (`index.ts`) polls this manifest while the mission runner rewrites it on every frame, so a live stream could flicker to `no_screencast_frame_yet` in production for the same reason.
2. The capture loop was fired as `void capture()` and `stop()` never awaited it. A capture that had already passed its `stopped` check could write its `running` manifest *after* `stop()` had written the terminal `ended` one, leaving the stream permanently recorded as running.

## Fixes

- Publish the manifest atomically (sibling temp file + `rename`), so a reader sees either the previous or the next complete manifest, never a truncated one.
- Serialize manifest writes per controller so the file on disk matches the last state published, in publish order.
- Track the in-flight capture and have `stop()` await it before writing the terminal manifest, making stop the last writer. A stream that already ended on its own (`max_frames_reached`) keeps its reason.
- `stop()` is now idempotent for concurrent/repeat callers (the runner calls it twice on the success path) — they await the same shutdown instead of returning before the terminal manifest is on disk.

## Verification

A stress harness over the stop/read sequence failed 28/300 before (12 torn reads, 16 late overwrites) and 0/1000 after. Both new tests fail against the unfixed controller. Full suite green 20/20 consecutive runs.

Base for #-frame-race, which applies the same treatment to the JPEG frame the controller publishes alongside this manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)