### PR TITLE
fix(testbed): publish live-screencast frames atomically

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -2399,7 +2399,9 @@ async function handleMonitorTestbedMissionScreencastRequest(
   if (route.kind === "latest") {
     const framePath = screencastLatestFramePath(testbedMissionArtifactsRoot(), route.id);
     const body = await readFile(framePath).catch(() => undefined);
-    if (!body) {
+    // An empty Buffer is truthy, so check the length too: a zero-byte frame must
+    // read as missing rather than be served as a valid-looking JPEG.
+    if (!body || body.byteLength === 0) {
       writeJson(response, 404, { error: "testbed_screencast_frame_not_found", id: route.id });
       return;
     }
@@ -2451,7 +2453,9 @@ async function writeTestbedMissionScreencastStream(
     if (manifest.frameCount === lastFrameCount && manifest.status === "running") return;
     lastFrameCount = manifest.frameCount;
     const latest = await readFile(screencastLatestFramePath(testbedMissionArtifactsRoot(), missionId)).catch(() => undefined);
-    if (!latest) {
+    // An empty Buffer is truthy, so check the length too: a zero-byte frame must
+    // surface as `latest_frame_missing` rather than be streamed as a good frame.
+    if (!latest || latest.byteLength === 0) {
       writeSseEvent(response, "screencast.status", {
         missionId,
         status: manifest.status,

--- a/services/slack-operator/src/testbed-live-screencast.ts
+++ b/services/slack-operator/src/testbed-live-screencast.ts
@@ -41,6 +41,7 @@ export interface TestbedLiveScreencastController {
 }
 
 let manifestWriteSequence = 0;
+let frameWriteSequence = 0;
 
 const DEFAULT_INTERVAL_MS = 500;
 const DEFAULT_MAX_FRAMES = 240;
@@ -178,13 +179,13 @@ export async function startPlaywrightLiveScreencast(input: {
       return;
     }
     try {
-      await input.page.screenshot({
-        path: latestFramePath,
+      await captureFrameAtomically(latestFramePath, (path) => input.page.screenshot({
+        path,
         type: "jpeg",
         quality: input.config.jpegQuality,
         fullPage: false,
         animations: "disabled",
-      });
+      }));
       frameCount += 1;
       await queueManifestWrite({ status: "running", frameCount, updatedAt: now });
       publishState({ status: "running", frameCount, startedAt, updatedAt: now });
@@ -230,6 +231,34 @@ export async function startPlaywrightLiveScreencast(input: {
       return stopRequest;
     },
   };
+}
+
+/**
+ * Publish a frame atomically: capture into a sibling temp file, then `rename` it
+ * onto `latest.jpg`, mirroring how `writeManifest` publishes the manifest.
+ *
+ * Screenshotting straight to `latest.jpg` truncates and rewrites it in place on
+ * every frame, and the monitor routes read that same file concurrently — the
+ * `/screencast` SSE poll base64-encodes it into a `screencast.frame` event and
+ * `/screencast/latest.jpg` serves it directly. A read landing mid-write returns a
+ * truncated JPEG that is then presented to the viewer as a good frame. `rename`
+ * is atomic within a directory, so a reader sees either the previous or the next
+ * complete frame. It also keeps the last good frame published when a capture
+ * fails partway through, instead of leaving a truncated one in its place.
+ */
+async function captureFrameAtomically(
+  latestFramePath: string,
+  capture: (tempPath: string) => Promise<unknown>,
+): Promise<void> {
+  frameWriteSequence += 1;
+  const tempPath = `${latestFramePath}.${process.pid}.${frameWriteSequence}.tmp`;
+  try {
+    await capture(tempPath);
+    await rename(tempPath, latestFramePath);
+  } catch (error) {
+    await unlink(tempPath).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function writeManifest(input: {

--- a/test/unit/testbed-live-screencast.test.ts
+++ b/test/unit/testbed-live-screencast.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,6 +10,7 @@ import {
   liveScreencastAllowedForMission,
   parseTestbedLiveScreencastConfig,
   readTestbedScreencastManifest,
+  screencastArtifactsDir,
   screencastLatestFramePath,
   startPlaywrightLiveScreencast,
 } from "../../services/slack-operator/src/testbed-live-screencast.js";
@@ -176,6 +177,151 @@ describe("testbed live screencast", () => {
     } finally {
       await controller?.stop("test_finished");
     }
+  });
+  it("never publishes a torn frame while the next capture is in flight", async () => {
+    const root = mkdtempSync(join(tmpdir(), "averray-screencast-test-"));
+    const mission = missionRun({
+      id: "mission-live-torn-frame",
+      targetUrl: "https://app.testnet.example/gold",
+      environment: "testnet",
+    });
+    let captures = 0;
+    let secondFramePartial!: () => void;
+    let releaseSecondFrame!: () => void;
+    const secondFrameIsPartial = new Promise<void>((resolve) => { secondFramePartial = resolve; });
+    const secondFrameReleased = new Promise<void>((resolve) => { releaseSecondFrame = resolve; });
+    const page = {
+      url: () => "https://app.testnet.example/gold",
+      screenshot: vi.fn(async ({ path }: { path: string }) => {
+        captures += 1;
+        if (captures === 1) {
+          writeFileSync(path, Buffer.from("complete-frame-one"));
+          return;
+        }
+        // Playwright streams the JPEG into `path`; hold the window where only
+        // part of the next frame is on disk.
+        writeFileSync(path, Buffer.from("torn"));
+        secondFramePartial();
+        await secondFrameReleased;
+        writeFileSync(path, Buffer.from("complete-frame-two"));
+      }),
+    } as unknown as Page;
+
+    const controller = await startPlaywrightLiveScreencast({
+      mission,
+      page,
+      artifactsRoot: root,
+      config: { enabled: true, intervalMs: 1, maxFrames: 10, jpegQuality: 40 },
+      update: () => {},
+    });
+
+    try {
+      await secondFrameIsPartial;
+      // The monitor routes read latest.jpg on every poll — the SSE stream
+      // base64-encodes it into a frame event and /latest.jpg serves it directly.
+      // Mid-capture they must still see the last complete frame.
+      expect(readFileSync(screencastLatestFramePath(root, mission.id), "utf8")).toBe("complete-frame-one");
+      releaseSecondFrame();
+      await vi.waitFor(() => {
+        expect(readFileSync(screencastLatestFramePath(root, mission.id), "utf8")).toBe("complete-frame-two");
+      });
+    } finally {
+      releaseSecondFrame();
+      await controller?.stop("test_finished");
+    }
+  });
+
+  it("captures into a sibling temp file and leaves no temp residue", async () => {
+    const root = mkdtempSync(join(tmpdir(), "averray-screencast-test-"));
+    const mission = missionRun({
+      id: "mission-live-temp-publish",
+      targetUrl: "https://app.testnet.example/gold",
+      environment: "testnet",
+    });
+    const capturedPaths: string[] = [];
+    const page = {
+      url: () => "https://app.testnet.example/gold",
+      screenshot: vi.fn(async ({ path }: { path: string }) => {
+        capturedPaths.push(path);
+        writeFileSync(path, Buffer.from("jpeg-frame"));
+      }),
+    } as unknown as Page;
+
+    const controller = await startPlaywrightLiveScreencast({
+      mission,
+      page,
+      artifactsRoot: root,
+      config: { enabled: true, intervalMs: 1, maxFrames: 3, jpegQuality: 40 },
+      update: () => {},
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(capturedPaths.length).toBeGreaterThanOrEqual(1);
+      });
+    } finally {
+      await controller?.stop("test_finished");
+    }
+
+    const latestFramePath = screencastLatestFramePath(root, mission.id);
+    // Nothing may capture directly onto the published path.
+    expect(capturedPaths).not.toContain(latestFramePath);
+    for (const path of capturedPaths) {
+      expect(path.startsWith(`${latestFramePath}.`)).toBe(true);
+      expect(path.endsWith(".tmp")).toBe(true);
+    }
+    await vi.waitFor(() => {
+      expect(readdirSync(screencastArtifactsDir(root, mission.id)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+    });
+    expect(readFileSync(latestFramePath, "utf8")).toBe("jpeg-frame");
+  });
+
+  it("keeps the last good frame published when a capture fails partway through", async () => {
+    const root = mkdtempSync(join(tmpdir(), "averray-screencast-test-"));
+    const mission = missionRun({
+      id: "mission-live-failed-capture",
+      targetUrl: "https://app.testnet.example/gold",
+      environment: "testnet",
+    });
+    let captures = 0;
+    const reasons: (string | undefined)[] = [];
+    const page = {
+      url: () => "https://app.testnet.example/gold",
+      screenshot: vi.fn(async ({ path }: { path: string }) => {
+        captures += 1;
+        if (captures === 1) {
+          writeFileSync(path, Buffer.from("complete-frame"));
+          return;
+        }
+        if (captures === 2) {
+          // Half a frame on disk, then the page goes away.
+          writeFileSync(path, Buffer.from("half"));
+          throw new Error("target page closed mid-frame");
+        }
+        throw new Error("target page closed");
+      }),
+    } as unknown as Page;
+
+    const controller = await startPlaywrightLiveScreencast({
+      mission,
+      page,
+      artifactsRoot: root,
+      config: { enabled: true, intervalMs: 1, maxFrames: 10, jpegQuality: 40 },
+      update: (state) => reasons.push(state.reason),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(reasons).toContain("frame_capture_failed");
+      });
+    } finally {
+      await controller?.stop("test_finished");
+    }
+
+    // A failed capture must not leave a truncated frame published, and must not
+    // leave its temp file behind either.
+    expect(readFileSync(screencastLatestFramePath(root, mission.id), "utf8")).toBe("complete-frame");
+    expect(readdirSync(screencastArtifactsDir(root, mission.id)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
> Stacked on #561 — review only the second commit (`fix(testbed): publish live-screencast frames atomically`). Base retargets to `main` automatically once #561 merges.

`capture()` screenshotted straight to `live-screencast/latest.jpg`, so Playwright truncated and rewrote the published frame in place on every capture. Both monitor routes read that same file concurrently:

- [`index.ts`](https://github.com/depre-dev/averray-reference-agent/blob/main/services/slack-operator/src/index.ts#L2453) — the `/screencast` SSE poll `readFile`s it and base64-encodes the result into a `screencast.frame` event.
- [`index.ts`](https://github.com/depre-dev/averray-reference-agent/blob/main/services/slack-operator/src/index.ts#L2400) — `/screencast/latest.jpg` serves it as `image/jpeg`.

A read landing mid-write yields a truncated JPEG that renders broken in the live viewer. Same class of bug as the manifest race in #561, on the other file the controller publishes.

Impact is cosmetic — a momentary broken frame, self-correcting on the next poll — but a corrupt frame was being presented as a good one, so it is a real truth-boundary wrinkle.

## Fixes

- **Atomic frame publication.** Capture into a sibling temp file and `rename()` it onto `latest.jpg`, mirroring `writeManifest()`. `rename` is atomic within a directory, so a reader sees either the previous or the next complete frame. Best-effort `unlink` on failure, so a failed capture leaves no residue.
- **A failed capture no longer destroys the published frame.** Previously a screenshot that died partway through left a truncated `latest.jpg` published until the next successful capture; now the last good frame stays up.
- **Zero-length guards on both routes.** An empty `Buffer` is truthy, so `if (!latest)` passed a zero-byte read straight through as a valid-looking frame rather than reporting `latest_frame_missing` (SSE) / 404 (`latest.jpg`).

## Verification

`npm run typecheck` clean. Full suite **2422 passed / 4 skipped**, 0 failed.

All three new tests fail against the unfixed write and pass with it:

| test | what it catches without the fix |
| --- | --- |
| never publishes a torn frame while the next capture is in flight | reader observes the partially written next frame instead of the last complete one |
| captures into a sibling temp file and leaves no temp residue | capture targets the published path directly |
| keeps the last good frame published when a capture fails partway through | truncated frame left published after a mid-capture failure |

### Why this is stacked rather than standalone

The extra `await rename()` shifts capture timing enough to turn the #561 manifest race into a **deterministic** failure of the pre-existing `captures bounded latest-frame evidence` test — 10/10 red on plain `main` (which is 10/10 green without this change), 15/15 green stacked on #561. The race it exposes is the one #561 fixes, not a new one; the frame fix just makes the existing interleaving reproducible.

The two zero-length route guards are not covered by tests — the `index.ts` route handlers are module-private and have no unit harness. They are read-path guards only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)