### PR TITLE
docs(int2): repin the ceremony to the PKT-040 kernel, assert one worker, correct the evidence claim

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -30,9 +30,9 @@ export HARNESS_CHECKOUT="$CEREMONY_ROOT/agent-harness"
 export REFERENCE_CHECKOUT="/absolute/path/to/averray-reference-agent"
 
 git clone https://github.com/averray-agent/agent-harness.git "$HARNESS_CHECKOUT"
-git -C "$HARNESS_CHECKOUT" checkout --detach be55b34
+git -C "$HARNESS_CHECKOUT" checkout --detach 0890a1f
 test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = \
-  "be55b348d365e7939b51ea979cee61d7cb210d15"
+  "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
 test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)"
 
 cd "$HARNESS_CHECKOUT"
@@ -431,6 +431,16 @@ If this drill broadens authority instead of tightening it, abort.
 
 An unverified handoff or any PR is an immediate abort.
 
+> **Re-run ordering after the PKT-040 kernel fix (2026-07-27).** Both §2.5 and
+> §2.6 must be re-run on the new pin, and **§2.5 must run first**. Before the
+> fix, `git diff --check` could not execute at all under the Docker provider
+> (`exit_128`), so §2.5's recorded `verification_failed` may have been that
+> environmental error rather than a judgement about the model's output. If §2.5
+> now **passes**, it never demonstrated its gate statement and needs a fixture
+> that fails for a substantive reason. Running §2.6 first would produce a green
+> positive proof beside an unexamined negative one — which reads as complete
+> while resting on the result under doubt.
+
 ### 2.6 Verified green handoff is complete but unactuated
 
 This positive proof and §2.5's negative proof are both required for acceptance.
@@ -542,7 +552,16 @@ go/no-go of `go`.
    export HARNESS_MODEL_API_KEY="<secret-kept-out-of-evidence>"
    ```
 
-4. Start exactly one Harness worker.
+4. Prove **no** Harness worker is already running, then start exactly one:
+
+   ```sh
+   pgrep -af "harness worker" && exit 1 || true
+   ```
+
+   A stale worker from an earlier session carries that session's
+   `HARNESS_TEST_MODEL_SCRIPT` and can claim this run, producing a result
+   attributed to the wrong fixture. "Start one" is not the same as "only one
+   exists" — assert the second.
 5. Propose exactly one `lint-format` or `docs-fix` task with a new work-item id
    and a near-term deadline. Verify the fixture remains low-risk, deny-network,
    `maxChildren: 0`, `maxConcurrentChildren: 0`, and within its fixed elapsed,

--- a/docs/HARNESS_INT2_FINDING_GIT_ACCEPTANCE.md
+++ b/docs/HARNESS_INT2_FINDING_GIT_ACCEPTANCE.md
@@ -123,10 +123,18 @@ the preserved evidence saved only run-level state (`harness-runs.txt`), not the
 the defect below is fixed and inspect `reason`. If it is `exit_128`, §2.5 must be
 re-run to count.
 
-**Evidence lesson:** the ceremony's §4 capture saves run state but not the
-verifier's per-criterion detail. Add `harness run events` (or the verification
-report artifact) to the required capture — without it a failure cannot be
-distinguished from a *different* failure after the fact.
+**CORRECTION (this doc's first version was wrong on this point).** I wrote that
+§4 saves run state but not verifier per-criterion detail, and that
+`harness run events` should be *added* to the required capture. That is false:
+§4 already requires `harness run status`, `run events`, **and**
+`run deliverables`. The `VerificationCompleted` event carries exactly the
+per-criterion detail in question.
+
+The real gap was in **execution**, not the runbook. The 2026-07-27 replay was
+driven by an ad-hoc preflight script and preserved only database rows and
+identity files — no `harness-*.txt` outputs at all — so it did not follow §4.
+That is why the `-003` verdict is unrecoverable. The fix is therefore to run the
+capture from automation that cannot skip it, not to change the runbook.
 
 ## The fix (shape, not implementation)
 


### PR DESCRIPTION
Prepares the INT-2 ceremony for its re-run now that PKT-040 has landed.

## 1. Repin

`be55b348` → **`0890a1f0`**, which carries the PKT-040 fix (git workspaces are now self-contained local clones pinned to the exact revision). Gated independently: offline **564 passed / 197 skipped**, PG + Docker **761 passed / 0 failed**, and the new Docker tests were proven to catch the original defect by reintroducing it.

**Correction to this PR's commit message:** it says the pilot image must be rebuilt against the new pin. **That is wrong.** `ops/Dockerfile.pilot` is `node:22-bookworm-slim` + `git` + `ca-certificates` and contains no kernel — the Harness runs on the host venv and bind-mounts `/workspace` into the container. The existing `reference-agent-pilot:ceremony` image stays valid across a pin change, and its recorded image ID remains the right evidence. Only the host checkout and its venv move.

## 2. Assert no stale worker before starting one

The runbook said *"Start exactly one Harness worker"* but never verified none was already running. Two worker sessions were alive during the §2.6 ceremony. The correct script happened to claim the run — the events show the green fixture's exact bytes — but a stale worker carries the previous session's `HARNESS_TEST_MODEL_SCRIPT` and can produce a result attributed to the wrong fixture.

"Start one" is not the same as "only one exists." The second is now asserted.

## 3. Correction — I was wrong about the evidence gap

`HARNESS_INT2_FINDING_GIT_ACCEPTANCE.md` claimed §4 saves run state but not verifier per-criterion detail, and that `harness run events` should be *added*. **That is false.** §4 already requires `run status`, `run events`, and `run deliverables`, and `VerificationCompleted` carries exactly the detail in question.

The real gap was in **execution**: the 2026-07-27 replay was driven by an ad-hoc preflight script and preserved only database rows and identity files — no `harness-*.txt` outputs — so it never followed §4. That is why the `-003` verdict is unrecoverable. The fix is to run the capture from automation that cannot skip it, not to change the runbook.

## 4. Re-run ordering — §2.5 before §2.6

Both scripted cases must re-run on the new pin, and **§2.5 goes first**. Before the fix, `git diff --check` could not execute at all under Docker (`exit_128`), so §2.5's recorded `verification_failed` may have been that environmental error rather than a judgement about the model's output.

If §2.5 now **passes**, it never demonstrated its gate statement and needs a fixture that fails for a substantive reason. Running §2.6 first would produce a green positive proof beside an unexamined negative one — complete-looking, resting on the result under doubt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)