### PR TITLE
fix(ops): calibrate mainnet monitor

### DIFF
--- a/docs/MAINNET_MONITOR_CALIBRATION.md
+++ b/docs/MAINNET_MONITOR_CALIBRATION.md
@@ -1,0 +1,83 @@
+# Mainnet monitor calibration
+
+This packet calibrates the reference-agent board for Polkadot Hub mainnet
+without weakening any health condition. The live values are versioned in
+`ops/.env.mainnet-monitor.example`; operators copy them into the root
+`.env.prod` and force-recreate only `slack-operator`.
+
+The generic Compose defaults remain suitable for testnet. In particular, the
+mainnet RPC endpoints and the intentionally-zero treasury floor are never
+selected implicitly.
+
+## Decisions
+
+- The owner/treasury multisig intentionally holds no USDC float. Mainnet payouts
+  come from the signer reward-bank position in AgentAccountCore, so the
+  treasury reserve floor is `0` with a mandatory, operator-visible reason.
+- The monitor samples every five minutes rather than every two minutes.
+- The official `services.polkadothub-rpc.com/mainnet` endpoint is the primary
+  monitor RPC. The former `eth-rpc.polkadot.io` primary remains a same-chain
+  backup, and read-only RPC auto-remediation is enabled.
+- Health-transition narration observes the same thirty-minute cooldown as
+  product-health alerts. Probe state remains live on the board during cooldown.
+- GitHub monitor enrichment gets five seconds. A bad credential must still be
+  rotated; a larger timeout is not an authentication workaround.
+
+## GitHub credential boundary
+
+The two reported GitHub symptoms do not share a credential path in code:
+
+- `github_pr_enrichment` runs in this repository's `slack-operator` container
+  and resolves `GITHUB_REPO_TOKENS`, then `GITHUB_OWNER_TOKENS`, then
+  owner/repository-specific environment variables, then `GITHUB_TOKEN`.
+- Averray platform `github_ingest` runs in the platform backend and uses its own
+  backend ingestion secret.
+
+Rotate or repair each credential in its owning stack. A `401 Bad credentials`
+from platform ingestion cannot be fixed by changing only the reference-agent
+token, and a 2500 ms reference-agent timeout is not evidence of a 401.
+
+## Rollout
+
+1. Verify the root `.env.prod` selects the mainnet board before applying the
+   overlay. Never print the env file or any token.
+2. Copy the exact non-secret assignments from
+   `ops/.env.mainnet-monitor.example` into `.env.prod`.
+3. Render Compose and confirm the `slack-operator` environment contains the
+   expected values:
+
+   ```sh
+   docker compose -p avg --env-file .env.prod \
+     -f ops/compose.yml -f ops/compose.prod.yml config
+   ```
+
+4. Force-recreate the monitor so it re-reads `.env.prod`:
+
+   ```sh
+   docker compose -p avg --env-file .env.prod \
+     -f ops/compose.yml -f ops/compose.prod.yml \
+     up -d --build --force-recreate slack-operator
+   ```
+
+## Thirty-minute acceptance sample
+
+Capture one continuous sample after the recreated container is healthy:
+
+```sh
+docker compose -p avg --env-file .env.prod \
+  -f ops/compose.yml -f ops/compose.prod.yml \
+  logs --since 30m slack-operator
+```
+
+The sample passes only when:
+
+- no `treasury_liquidity` detail reports `reserve 0.00 < 5`;
+- no product-health narration oscillates red → recovered → red;
+- no probe detail contains HTTP `429`;
+- `signer_liquidity` still reports DOT gas and the AgentAccountCore reward bank;
+- the treasury row states that the zero reserve is intentionally unfunded and
+  includes the declared reason.
+
+If the official primary also starts throttling, keep the condition alertable
+and provision a keyed same-chain RPC. Do not lower other floors or suppress RPC
+errors.

--- a/ops/.env.mainnet-monitor.example
+++ b/ops/.env.mainnet-monitor.example
@@ -1,0 +1,29 @@
+# Mainnet-only product-health calibration.
+#
+# Copy these non-secret values into the live root .env.prod only when the board
+# is monitoring Polkadot Hub mainnet (chain 420420419). Do not use this file as
+# the complete Compose env file and do not apply it to testnet.
+#
+# Primary and backup are the two HTTP endpoints published in the official
+# Polkadot Hub connection guide. Both were verified against chain 420420419 and
+# the read methods used by the monitor on 2026-07-27. The current primary is the
+# endpoint that did not reproduce the rate limit during that verification.
+PRODUCT_HEALTH_RPC_URL=https://services.polkadothub-rpc.com/mainnet/
+PRODUCT_HEALTH_RPC_BACKUPS=https://eth-rpc.polkadot.io/
+OPS_AUTOREMEDIATE_ENABLED=true
+
+# Five-minute sampling reduces read volume by 2.5x from the former two-minute
+# production cadence. A thirty-minute transition cooldown keeps a real red
+# visible while suppressing transient red/recovered narration churn.
+PRODUCT_HEALTH_INTERVAL_MINUTES=5
+PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES=30
+
+# Mainnet payouts use the signer reward-bank position in AgentAccountCore. The
+# owner/treasury multisig intentionally carries no USDC float. The reason is
+# required: a zero floor without it remains degraded rather than silently green.
+PRODUCT_HEALTH_MIN_TREASURY_RESERVE=0
+PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON=Mainnet payouts are funded from the signer reward bank; the treasury multisig intentionally holds no USDC float.
+
+# GitHub enrichment fans out across open PR/check endpoints. This does not fix
+# an invalid token; it only gives a valid credential enough time to complete.
+GITHUB_MONITOR_ENRICH_TIMEOUT_MS=5000

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -324,7 +324,13 @@ services:
       PRODUCT_HEALTH_INTERVAL_MINUTES: ${PRODUCT_HEALTH_INTERVAL_MINUTES:-2}
       # Repeat an unchanged RED incident at most every 6h. Set 0 for edge-only alerts.
       PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES: ${PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES:-360}
+      # Monitor snapshots fan out across open PRs and their check runs. Keep the
+      # timeout operator-tunable; the live mainnet calibration raises it from the
+      # conservative generic default without changing testnet behaviour.
+      GITHUB_MONITOR_ENRICH_TIMEOUT_MS: ${GITHUB_MONITOR_ENRICH_TIMEOUT_MS:-2500}
       PRODUCT_HEALTH_API_PATH: ${PRODUCT_HEALTH_API_PATH:-/health}
+      PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS: ${PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS:-600}
+      PRODUCT_HEALTH_HALT_SEVERITY: ${PRODUCT_HEALTH_HALT_SEVERITY:-auto}
       # No per-network default outside testnet, and none is guessed: the balance
       # probe refuses any endpoint whose eth_chainId != the chainId /health reports
       # (product-health.ts chain guard), so a wrong URL fails loudly instead of
@@ -370,9 +376,8 @@ services:
       # liveness alone, so a leftover other-network endpoint would be rotated onto;
       # the chain guard then refuses its balances rather than trusting them. Empty
       # is honest — a dead or wrong-chain backup is worse than none.
-      # Mainnet: empty as of 2026-07-25 — polkadot-asset-hub-eth-rpc.polkadot.io and
-      # asset-hub-polkadot-eth-rpc.polkadot.io were probed and did not respond.
-      # TODO: add a second verified mainnet eth-rpc (Dwellir/OnFinality-class).
+      # Mainnet has two official HTTP endpoints. Keep their ordering in the
+      # mainnet-only calibration overlay; never make either a testnet default.
       PRODUCT_HEALTH_RPC_BACKUPS: ${PRODUCT_HEALTH_RPC_BACKUPS:-}
       OPS_AUTOREMEDIATE_FAIL_THRESHOLD: ${OPS_AUTOREMEDIATE_FAIL_THRESHOLD:-2}
       OPS_AUTOREMEDIATE_MAX_ATTEMPTS: ${OPS_AUTOREMEDIATE_MAX_ATTEMPTS:-3}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3220,6 +3220,7 @@ function startOperatorRoutines() {
   // Slice 3: previous overall product-health status, so the co-pilot narrates
   // only on an edge across the red boundary (entered-red / recovered).
   let prevProductHealthStatus: OpsStatus = "unknown";
+  let lastOpsNarrationPostedAtMs = 0;
   let taskHealthRunning = false;
   const anomalyConfig = loadAnomalyConfig();
   const dispatchPerDayCap = Number(process.env.HERMES_DISPATCH_PER_DAY_MAX) || 10;
@@ -3593,8 +3594,10 @@ function startOperatorRoutines() {
         }
       }
       // Slice 3: proactive ops narration — Hermes posts a co-pilot turn on a
-      // fresh red / recovery edge (self-deduped by the transition; muted = quiet,
-      // the Digest still shows state). Network tunes the wording.
+      // fresh red / recovery edge, with the product-health alert cooldown damping
+      // rapid transition churn (muted = quiet; the Digest still shows state).
+      // Network tunes the wording.
+      const opsNarrationNowMs = Date.now();
       const opsNarration = decideOpsNarration({
         prev: prevProductHealthStatus,
         curr: result.status as OpsStatus,
@@ -3602,11 +3605,15 @@ function startOperatorRoutines() {
         network:
           (process.env.WALLET_NETWORK ?? "").trim().toLowerCase() === "mainnet" ? "mainnet" : "testnet",
         muted: getServerAlertMuteUntilMs() > Date.now(),
+        lastPostedAtMs: lastOpsNarrationPostedAtMs,
+        nowMs: opsNarrationNowMs,
+        cooldownMs: routineConfig.productHealth.cooldownMs,
       });
       prevProductHealthStatus = result.status as OpsStatus;
       if (opsNarration.post && opsNarration.text) {
         try {
           recordCollaborationMessage({ author: "hermes", text: opsNarration.text, kind: "chat" });
+          lastOpsNarrationPostedAtMs = opsNarrationNowMs;
           logger.info({ edge: opsNarration.edge }, "ops_narration_posted");
         } catch (err) {
           logger.warn({ err }, "ops_narration_post_failed");

--- a/services/slack-operator/src/ops-narration.ts
+++ b/services/slack-operator/src/ops-narration.ts
@@ -2,15 +2,16 @@
 // co-pilot turn about a product-health change, and what to say.
 //
 // Fires ONLY on an overall-status edge across the red boundary (entered-red /
-// recovered). This is self-deduping (transitions only), so a probe staying red
-// never re-posts. It stays silent on the boot transition (prev "unknown", so a
-// restart doesn't spam), on routine degraded↔healthy moves (those live in the
-// Digest ops line), and while the operator is muted. Network tunes the wording:
-// a mainnet red pages on-call; a testnet red is informational.
+// recovered). A probe staying red never re-posts, and the operator-configured
+// product-health cooldown damps rapid red/recovered/red edge churn. It stays
+// silent on the boot transition (prev "unknown", so a restart doesn't spam), on
+// routine degraded↔healthy moves (those live in the Digest ops line), and while
+// the operator is muted. Network tunes the wording: a mainnet red pages on-call;
+// a testnet red is informational.
 //
 // Kept pure (no I/O, no @avg deps) so it runs in the local unit suite; the
 // caller (index.ts checkProductHealth) supplies prev/curr, the probes, the
-// resolved network, and the current mute state.
+// resolved network, current mute state, and the last successful narration time.
 
 export type OpsStatus = "healthy" | "degraded" | "red" | "unknown";
 export type OpsNetwork = "testnet" | "mainnet" | "unknown";
@@ -27,6 +28,11 @@ export interface DecideOpsNarrationInput {
   probes: readonly OpsNarrationProbe[];
   network: OpsNetwork;
   muted: boolean;
+  /** Timestamp of the last successfully persisted narration post. */
+  lastPostedAtMs?: number;
+  nowMs?: number;
+  /** Reuses PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES for transition narration. */
+  cooldownMs?: number;
 }
 
 export interface OpsNarrationDecision {
@@ -36,7 +42,7 @@ export interface OpsNarrationDecision {
   /** The Hermes turn text — present only when `post` is true. */
   text?: string;
   /** Why a real edge did not post (for observability). */
-  suppressed?: "muted";
+  suppressed?: "muted" | "cooldown";
 }
 
 const PROBE_LABELS: Record<string, string> = {
@@ -72,6 +78,20 @@ export function decideOpsNarration(input: DecideOpsNarrationInput): OpsNarration
 
   // Mute = quiet everywhere; the state still shows passively in the Digest ops line.
   if (muted) return { post: false, edge, suppressed: "muted" };
+
+  // A health probe can briefly cross red and recover when its upstream flakes.
+  // Use the same operator-configured cooldown as D4 alerts so those edges remain
+  // visible on the board without producing a red → recovered → red chat storm.
+  const lastPostedAtMs = input.lastPostedAtMs ?? 0;
+  const nowMs = input.nowMs ?? Date.now();
+  const cooldownMs = Math.max(0, input.cooldownMs ?? 0);
+  if (
+    cooldownMs > 0
+    && lastPostedAtMs > 0
+    && nowMs - lastPostedAtMs < cooldownMs
+  ) {
+    return { post: false, edge, suppressed: "cooldown" };
+  }
 
   if (edge === "red") {
     const reds = probes.filter((p) => p.status === "red");

--- a/test/unit/compose-env.test.ts
+++ b/test/unit/compose-env.test.ts
@@ -19,6 +19,52 @@ describe("compose environment wiring", () => {
     expect(env?.LLM_USAGE_LOG_PATH).toBe("${LLM_USAGE_LOG_PATH:-/data/llm-usage.jsonl}");
   });
 
+  it("forwards every product-health source control into slack-operator", () => {
+    const compose = parse(readText("../../ops/compose.yml")) as {
+      services?: Record<string, { environment?: Record<string, string> }>;
+    };
+    const env = compose.services?.["slack-operator"]?.environment;
+    const source = [
+      readText("../../services/slack-operator/src/product-health.ts"),
+      readText("../../services/slack-operator/src/routines.ts"),
+      readText("../../services/slack-operator/src/ops-remediation.ts"),
+    ].join("\n");
+    const sourceControls = new Set(
+      source.match(/(?:PRODUCT_HEALTH|OPS_AUTOREMEDIATE)_[A-Z0-9_]+/g) ?? [],
+    );
+
+    for (const control of sourceControls) {
+      expect(env, `${control} is present in source but missing from Compose`).toHaveProperty(control);
+    }
+
+    expect(env?.PRODUCT_HEALTH_INTERVAL_MINUTES).toBe("${PRODUCT_HEALTH_INTERVAL_MINUTES:-2}");
+    expect(env?.PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES).toBe("${PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES:-360}");
+    expect(env?.PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS).toBe("${PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS:-600}");
+    expect(env?.PRODUCT_HEALTH_HALT_SEVERITY).toBe("${PRODUCT_HEALTH_HALT_SEVERITY:-auto}");
+    expect(env?.PRODUCT_HEALTH_MIN_GAS_NATIVE).toBe("${PRODUCT_HEALTH_MIN_GAS_NATIVE:-0}");
+    expect(env?.PRODUCT_HEALTH_MIN_REWARD_BANK).toBe("${PRODUCT_HEALTH_MIN_REWARD_BANK:-0}");
+    expect(env?.PRODUCT_HEALTH_MIN_TREASURY_RESERVE).toBe("${PRODUCT_HEALTH_MIN_TREASURY_RESERVE:-5}");
+    expect(env?.PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON).toBe("${PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON:-}");
+    expect(env?.PRODUCT_HEALTH_RPC_BACKUPS).toBe("${PRODUCT_HEALTH_RPC_BACKUPS:-}");
+    expect(env?.OPS_AUTOREMEDIATE_ENABLED).toBe("${OPS_AUTOREMEDIATE_ENABLED:-false}");
+    expect(env?.GITHUB_MONITOR_ENRICH_TIMEOUT_MS).toBe("${GITHUB_MONITOR_ENRICH_TIMEOUT_MS:-2500}");
+  });
+
+  it("records the mainnet-only monitor calibration without changing testnet defaults", () => {
+    const calibration = readText("../../ops/.env.mainnet-monitor.example");
+
+    expect(calibration).toContain("PRODUCT_HEALTH_INTERVAL_MINUTES=5");
+    expect(calibration).toContain("PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES=30");
+    expect(calibration).toContain("PRODUCT_HEALTH_MIN_TREASURY_RESERVE=0");
+    expect(calibration).toContain(
+      "PRODUCT_HEALTH_TREASURY_RESERVE_ZERO_REASON=Mainnet payouts are funded from the signer reward bank; the treasury multisig intentionally holds no USDC float.",
+    );
+    expect(calibration).toContain("PRODUCT_HEALTH_RPC_URL=https://services.polkadothub-rpc.com/mainnet/");
+    expect(calibration).toContain("PRODUCT_HEALTH_RPC_BACKUPS=https://eth-rpc.polkadot.io/");
+    expect(calibration).toContain("OPS_AUTOREMEDIATE_ENABLED=true");
+    expect(calibration).toContain("GITHUB_MONITOR_ENRICH_TIMEOUT_MS=5000");
+  });
+
   it("passes the shared LLM usage log path into Hermes and its MCP env", () => {
     const compose = parse(readText("../../ops/compose.yml")) as {
       services?: Record<string, { environment?: Record<string, string> }>;

--- a/test/unit/ops-narration.test.ts
+++ b/test/unit/ops-narration.test.ts
@@ -55,4 +55,36 @@ describe("decideOpsNarration", () => {
     expect(d.edge).toBe("red");
     expect(d.suppressed).toBe("muted");
   });
+
+  it("uses the product-health cooldown to damp red/recovered narration thrash", () => {
+    const lastPostedAtMs = 1_000;
+    const recovered = decideOpsNarration({
+      prev: "red",
+      curr: "healthy",
+      probes: probes(),
+      network: "mainnet",
+      muted: false,
+      lastPostedAtMs,
+      nowMs: 2_000,
+      cooldownMs: 60_000,
+    });
+    expect(recovered).toMatchObject({
+      post: false,
+      edge: "recovered",
+      suppressed: "cooldown",
+    });
+
+    const redAgain = decideOpsNarration({
+      prev: "healthy",
+      curr: "red",
+      probes: probes({ money_path: "red" }),
+      network: "mainnet",
+      muted: false,
+      lastPostedAtMs,
+      nowMs: 61_000,
+      cooldownMs: 60_000,
+    });
+    expect(redAgain.post).toBe(true);
+    expect(redAgain.edge).toBe("red");
+  });
 });


### PR DESCRIPTION
## What changed

- add a mainnet-only, non-secret product-health calibration overlay:
  - five-minute probe cadence
  - thirty-minute alert/narration cooldown
  - treasury reserve floor 0 with the required declared reason
  - official Polkadot Hub RPC as primary, former primary as backup
  - read-only RPC auto-remediation enabled
  - five-second GitHub monitor enrichment timeout
- apply the existing product-health cooldown to red/recovered Hermes narration
- forward every product-health/remediation source control through Compose, including the two previously missing chain-staleness controls
- add a source-to-Compose regression test so future knobs cannot be silently inert
- document that reference-agent PR enrichment and platform backend ingestion use separate credentials

## Verification

- `npm test` — 2,432 passed, 4 skipped
- `npm run typecheck`
- focused product-health/Compose/remediation/narration suite — 158 passed
- generic Compose render
- mainnet calibration overlay Compose render with exact value assertions
- live read-only RPC verification: both endpoints returned chain 420420419 and supported the balance/code/USDC reads used by the monitor; the new primary did not reproduce the old endpoint's throttling

## Surfaces

- Backend: no
- Frontend: no
- Indexer: no
- Caddy: no
- Contracts: no
- Public site: no
- Slack operator / Compose ops: yes

## Rollout

Human operator action is required after merge:

1. copy the exact assignments from `ops/.env.mainnet-monitor.example` into the root `.env.prod`;
2. validate the rendered Compose config;
3. force-recreate only `slack-operator`;
4. capture the documented continuous 30-minute acceptance sample.

The live GitHub credentials must be validated independently in their owning stacks. No secret value is part of this PR.

## Rollback

Restore the prior `.env.prod` values and force-recreate `slack-operator`. No chain write or fund movement is involved.
