### PR TITLE
fix(ops): separate monitor health from product uptime

### DIFF
--- a/packages/monitor-ui/src/components/ops/TrendsZone.test.tsx
+++ b/packages/monitor-ui/src/components/ops/TrendsZone.test.tsx
@@ -16,6 +16,11 @@ const base = (over: Partial<HealthHistory>): HealthHistory => ({
 });
 
 describe("TrendsZone anomaly flags", () => {
+  test("labels availability as product uptime, not overall monitor success", () => {
+    const { getByText } = render(<TrendsZone history={base({})} />);
+    expect(getByText("Product uptime 24h")).toBeTruthy();
+  });
+
   test("renders a leading-indicator flag when latency spikes off its baseline", () => {
     const history = base({ latencySeriesMs: [...Array(10).fill(75), 320] });
     const { getByTestId } = render(<TrendsZone history={history} />);

--- a/packages/monitor-ui/src/components/ops/TrendsZone.tsx
+++ b/packages/monitor-ui/src/components/ops/TrendsZone.tsx
@@ -52,7 +52,7 @@ export function TrendsZone({ history }: TrendsZoneProps) {
         <div className="ops-trends">
           <div className="ops-trend">
             <div className="ops-trend-head">
-              <span>Uptime 24h</span>
+              <span>Product uptime 24h</span>
               <span className="ops-trend-val">
                 {typeof history?.uptimePct24h === "number" ? `${history.uptimePct24h.toFixed(1)}%` : "—"}
               </span>

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -125,25 +125,32 @@ export interface ProductHealthIncident {
 }
 
 export interface ProductHealthHistoryBlock {
-  /** Share of trailing-24h checks that were NOT red, 0..100; null under-window. */
+  /** Share of determinate trailing-24h product_api checks that were reachable
+   *  and healthy, 0..100. Unknown monitor samples are excluded; null means the
+   *  window contains no determinate product-availability evidence. */
   uptimePct24h: number | null;
-  /** Per-check overall tone (oldest→newest), bounded to `maxSeries`. */
+  /** Per-check product_api availability (oldest→newest), bounded to `maxSeries`.
+   *  Missing/unknown product_api evidence is degraded/grey, never fake-green. */
   uptimeSeries: ProbeStatus[];
   latencySeriesMs: (number | null)[];
   balanceSeries: (number | null)[];
   incidents: ProductHealthIncident[];
 }
 
-/** Overall check status → probe tone for the uptime sparkline. */
-function overallTone(status: ProductHealthStatus): ProbeStatus {
-  return status === "healthy" ? "ok" : status;
+/** Product reachability is deliberately independent from the overall monitor
+ * status. RPC, GitHub, or balance-reader failures can degrade the monitor while
+ * the product's own /health endpoint remains available. */
+function productAvailabilityTone(snapshot: ProductHealthSnapshot): ProbeStatus {
+  const probe = snapshot.probes.find((p) => p.name === "product_api");
+  return probe?.status === "ok" || probe?.status === "red" ? probe.status : "degraded";
 }
 
 /**
  * Derive the Ops Trends + Incidents block from the rolling history. Pure — the
  * caller passes `nowMs`. The series are newest-anchored to `maxSeries` bins; the
- * uptime% is over the trailing `uptimeWindowMs` and counts "not red" as up (a
- * degraded product still serves; only red is a page-worthy outage).
+ * uptime% is over determinate product_api checks in the trailing
+ * `uptimeWindowMs`. A degraded/missing product_api sample is unknown and is
+ * excluded from the percentage rather than being counted as either up or down.
  */
 export function deriveProductHealthHistory(
   history: ReadonlyArray<ProductHealthSnapshot>,
@@ -157,23 +164,48 @@ export function deriveProductHealthHistory(
 
   const windowStart = nowMs - uptimeWindowMs;
   const inWindow = history.filter((s) => s.at >= windowStart);
+  const availability = inWindow
+    .map(productAvailabilityTone)
+    .filter((status): status is "ok" | "red" => status === "ok" || status === "red");
   const uptimePct24h =
-    inWindow.length > 0
-      ? Math.round((inWindow.filter((s) => s.status !== "red").length / inWindow.length) * 1000) / 10
+    availability.length > 0
+      ? Math.round((availability.filter((status) => status === "ok").length / availability.length) * 1000) / 10
       : null;
 
   return {
     uptimePct24h,
-    uptimeSeries: series.map((s) => overallTone(s.status)),
+    uptimeSeries: series.map(productAvailabilityTone),
     latencySeriesMs: series.map((s) => s.latencyMs ?? null),
     balanceSeries: series.map((s) => s.signerUsdc ?? null),
     incidents: deriveIncidents(history),
   };
 }
 
+const PRODUCT_API_DEPENDENT_PROBES = new Set([
+  "chain_height",
+  "capabilities",
+  "api_latency",
+  "money_path",
+]);
+
+/** These probe failures carry no evidence beyond an unreadable product /health.
+ * Keep the product_api incident as the root instead of multiplying one outage
+ * into four nominal incidents. Independent probe failures remain visible. */
+function isProductApiDependentFailure(
+  snapshot: ProductHealthSnapshot,
+  probe: ProbeResult | undefined,
+): boolean {
+  if (!probe || !PRODUCT_API_DEPENDENT_PROBES.has(probe.name)) return false;
+  const productApi = snapshot.probes.find((candidate) => candidate.name === "product_api");
+  if (!productApi || productApi.status === "ok") return false;
+  return /product \/health not readable|no response after/i.test(probe.detail);
+}
+
 /** Contiguous degraded/red runs per probe → incident episodes (newest-first,
  *  capped). Awaiting-data degradations are excluded — a forward-compat gap is
- *  not an incident. An unrecovered run stays open (`endedAt: null`). */
+ *  not an incident. Failures derived solely from an unreadable product_api are
+ *  folded into that root incident. An unrecovered run stays open
+ *  (`endedAt: null`). */
 function deriveIncidents(history: ReadonlyArray<ProductHealthSnapshot>): ProductHealthIncident[] {
   const names: string[] = [];
   for (const snap of history) {
@@ -186,6 +218,9 @@ function deriveIncidents(history: ReadonlyArray<ProductHealthSnapshot>): Product
     let note = "";
     for (const snap of history) {
       const probe = snap.probes.find((p) => p.name === name);
+      // Do not treat root-cause suppression as recovery for a pre-existing
+      // independent incident; wait for an observable sample to close it.
+      if (isProductApiDependentFailure(snap, probe)) continue;
       const bad =
         !!probe &&
         (probe.status === "red" ||
@@ -852,7 +887,17 @@ async function ethRpcRaw(
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
   });
-  if (!res.ok) throw new Error(`${method} → HTTP ${res.status}`);
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new Error(
+        `${method} → RPC endpoint misconfigured (HTTP 404: JSON-RPC route not found)`,
+      );
+    }
+    if (res.status === 429) {
+      throw new Error(`${method} → RPC endpoint throttled (HTTP 429)`);
+    }
+    throw new Error(`${method} → RPC endpoint HTTP ${res.status}`);
+  }
   const json = (await res.json()) as { result?: unknown; error?: { message?: string } };
   if (json.error) throw new Error(`${method}: ${json.error.message ?? "rpc error"}`);
   if (json.result === undefined || json.result === null) throw new Error(`${method}: missing result`);
@@ -1202,6 +1247,7 @@ export async function collectProductHealthProbes(
     fetchImpl,
   });
   const chainId = h.body?.auth?.chainId;
+  const rewardBankLiquid = pickNum(h.body?.rewardBank?.liquid);
   const block = pickNum(h.body?.components?.blockchain?.blockNumber);
   const chainAdvance = trackChainAdvance(chainCtx.advance, block, chainCtx.nowMs);
   // Absolute block age from the (chain-matched) settlement RPC — no startup blind
@@ -1221,7 +1267,7 @@ export async function collectProductHealthProbes(
   const signer = await probeSignerLiquidity({
     rpcUrl: config.rpcUrl,
     signerAddress: config.signerAddress,
-    rewardBankLiquid: pickNum(h.body?.rewardBank?.liquid),
+    rewardBankLiquid,
     minGasNative: config.minGasNative,
     minRewardBank: config.minRewardBank,
     // Balances are only trusted from an RPC on the product's own chain.
@@ -1230,7 +1276,7 @@ export async function collectProductHealthProbes(
   });
   const treasury = await probeTreasuryLiquidity({
     addresses: h.body?.addresses,
-    rewardBankLiquid: pickNum(h.body?.rewardBank?.liquid),
+    rewardBankLiquid,
     usdcDecimals: config.usdcDecimals,
     minRewardBank: config.minRewardBank,
     minTreasuryReserve: config.minTreasuryReserve,
@@ -1241,10 +1287,29 @@ export async function collectProductHealthProbes(
   });
   // signer_liquidity and treasury_liquidity intentionally share the same
   // /health reward-bank position. Keep one board row while retaining both
-  // independently actionable probes.
+  // independently actionable probes. The direct /health row is added last so
+  // RPC-only gas/treasury failures cannot erase reward-bank data the product
+  // already supplied; absent /health data still remains honestly absent.
+  const rewardBankPool: SolvencyPoolData[] =
+    rewardBankLiquid === undefined
+      ? []
+      : [
+          {
+            key: "reward_bank",
+            label: "Reward bank",
+            amount: rewardBankLiquid,
+            unit: "USDC",
+            floor: config.minRewardBank > 0 ? config.minRewardBank : null,
+            status:
+              config.minRewardBank > 0 && rewardBankLiquid < config.minRewardBank ? "red" : "ok",
+          },
+        ];
   const solvencyPools = [
     ...new Map(
-      [...(signer.pools ?? []), ...(treasury.pools ?? [])].map((pool) => [pool.key, pool]),
+      [...(signer.pools ?? []), ...(treasury.pools ?? []), ...rewardBankPool].map((pool) => [
+        pool.key,
+        pool,
+      ]),
     ).values(),
   ];
   const settlement = h.body?.settlement;

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -55,6 +55,7 @@ function rpcMethod(init: RequestInit): string {
 function combinedFetch(cfg: {
   healthBody?: unknown;
   healthStatus?: number;
+  rpcStatus?: number;
   gasHex?: string;
   usdcHex?: string;
   chainIdHex?: string;
@@ -65,6 +66,10 @@ function combinedFetch(cfg: {
     if (method === "GET") {
       const status = cfg.healthStatus ?? 200;
       return { ok: status >= 200 && status < 300, status, json: async () => cfg.healthBody ?? {} } as unknown as Response;
+    }
+    const status = cfg.rpcStatus ?? 200;
+    if (status < 200 || status >= 300) {
+      return { ok: false, status, json: async () => ({}) } as unknown as Response;
     }
     const m = rpcMethod(init ?? {});
     const result =
@@ -459,6 +464,27 @@ describe("probeSignerLiquidity (direct RPC)", () => {
     expect(r.status).toBe("degraded");
   });
 
+  it("distinguishes a misconfigured JSON-RPC route from endpoint throttling", async () => {
+    const withHttpStatus = (status: number): typeof fetch =>
+      (async () =>
+        ({ ok: false, status, json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch;
+    const base = {
+      rpcUrl: "http://rpc",
+      signerAddress: "0xabc",
+      rewardBankLiquid: 10,
+      expectedChainId: 420420419,
+      ...floors,
+    };
+
+    const wrongEndpoint = await probeSignerLiquidity({ ...base, fetchImpl: withHttpStatus(404) });
+    expect(wrongEndpoint.detail).toContain("RPC endpoint misconfigured");
+    expect(wrongEndpoint.detail).toContain("HTTP 404");
+
+    const throttled = await probeSignerLiquidity({ ...base, fetchImpl: withHttpStatus(429) });
+    expect(throttled.detail).toContain("RPC endpoint throttled");
+    expect(throttled.detail).toContain("HTTP 429");
+  });
+
   it("names WHICH piece is unconfigured (a cutover leaves solvency unmonitored)", async () => {
     const noRpc = await probeSignerLiquidity({ rpcUrl: undefined, signerAddress: "0xabc", rewardBankLiquid: 10, ...floors, fetchImpl: balances("0x0", "0x0") });
     expect(noRpc.detail).toContain("PRODUCT_HEALTH_RPC_URL");
@@ -678,6 +704,26 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
     expect(snapshot.solvency?.pools.some((p) => p.key === "reward_bank" && p.amount === 100)).toBe(true);
     expect(snapshot.flow?.settled24h).toBe(37);
     expect(snapshot.flow?.stuck).toBe(1);
+  });
+
+  it("keeps /health reward-bank solvency visible when direct RPC reads fail", async () => {
+    const { probes, snapshot } = await collectProductHealthProbes(
+      cfg(),
+      combinedFetch({
+        healthBody: HEALTHY_BODY,
+        rpcStatus: 429,
+      }),
+      { nowMs: 10_000_000 },
+    );
+
+    expect(probes.find((p) => p.name === "signer_liquidity")?.status).toBe("degraded");
+    expect(snapshot.solvency?.pools).toContainEqual(
+      expect.objectContaining({
+        key: "reward_bank",
+        amount: 100,
+        unit: "USDC",
+      }),
+    );
   });
 
   it("omits the flow block when the product /health exposes no settlement (honest awaiting)", async () => {
@@ -927,19 +973,36 @@ describe("deriveProductHealthHistory", () => {
     expect(b.balanceSeries).toEqual([10, 8, null]);
   });
 
-  it("uptimePct24h counts non-red checks; null when nothing is in-window", () => {
+  it("uptimePct24h uses only determinate product-api availability samples", () => {
     const now = 100 * HOUR;
-    // 4 checks in the last 24h: 3 non-red (healthy/degraded/healthy), 1 red → 75.0
+    // A degraded product_api result is unknown, not evidence of either uptime or
+    // downtime: two reachable samples / three determinate samples → 66.7%.
     const history = [
       snap(now - 3 * HOUR, "healthy"),
       snap(now - 2 * HOUR, "degraded"),
       snap(now - 1 * HOUR, "red"),
       snap(now, "healthy"),
     ];
-    expect(deriveProductHealthHistory(history, now).uptimePct24h).toBe(75);
+    expect(deriveProductHealthHistory(history, now).uptimePct24h).toBe(66.7);
     // a check older than the 24h window doesn't count → null
     const stale = [snap(now - 30 * HOUR, "healthy")];
     expect(deriveProductHealthHistory(stale, now).uptimePct24h).toBeNull();
+  });
+
+  it("does not count monitor/RPC failures as product downtime", () => {
+    const now = 100 * HOUR;
+    const history = Array.from({ length: 5 }, (_, i) =>
+      snap(now - (4 - i) * HOUR, "red", {
+        probes: [
+          probe("product_api", "ok", "HTTP 200 · service ok"),
+          probe("signer_liquidity", "red", "balance read failed: RPC endpoint throttled (HTTP 429)"),
+        ],
+      }),
+    );
+
+    const block = deriveProductHealthHistory(history, now);
+    expect(block.uptimePct24h).toBe(100);
+    expect(block.uptimeSeries).toEqual(["ok", "ok", "ok", "ok", "ok"]);
   });
 
   it("bounds the series to maxSeries (newest-anchored); uptime% still spans the window", () => {
@@ -989,6 +1052,26 @@ describe("deriveProductHealthHistory", () => {
       severity: "degraded",
       startedAt: now - 4 * HOUR,
       endedAt: now - 3 * HOUR,
+    });
+  });
+
+  it("records one root incident when an unreadable /health fans out to dependent probes", () => {
+    const now = 100 * HOUR;
+    const probes: ProbeResult[] = [
+      probe("product_api", "red", "unreachable: fetch failed"),
+      probe("chain_height", "degraded", "chain status unavailable (product /health not readable)"),
+      probe("capabilities", "degraded", "capability status unavailable (product /health not readable)"),
+      probe("api_latency", "degraded", "no response after 45ms"),
+      probe("money_path", "degraded", "settlement status unavailable (product /health not readable)"),
+    ];
+    const history = [snap(now, "red", { probes })];
+
+    const incidents = deriveProductHealthHistory(history, now).incidents;
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]).toMatchObject({
+      probe: "product_api",
+      severity: "red",
+      note: "unreachable: fetch failed",
     });
   });
 


### PR DESCRIPTION
## What changed

- derive 24h product availability only from determinate `product_api` evidence; monitor/RPC failures no longer count as product downtime, and unknown samples remain grey/excluded
- collapse `/health`-unreadable chain/capability/latency/money-path entries into the root `product_api` incident
- distinguish RPC HTTP 404 (misconfigured JSON-RPC route) from HTTP 429 (endpoint throttling)
- keep the `/health.rewardBank` pool visible in Solvency even when direct RPC gas/treasury reads degrade
- label the board metric explicitly as **Product uptime 24h**

Both configured mainnet RPC endpoints were live-checked on 2026-07-28: each returned HTTP 200 and chain ID 420420419, so no endpoint was replaced.

## Checks

- `npm run typecheck` ✅
- `npm test` ✅ 2,435 tests passed; the two localhost-listener tests were sandbox-blocked (`listen EPERM`) and then passed in an allowed localhost run
- targeted regression suite: 116/116 passed
- all five new baseline assertions were confirmed failing before the implementation

## Surface / ops impact

- affects Slack operator product-health derivation and the monitor UI
- no backend product, indexer, Caddy, contracts, or public-site changes
- no environment or VPS secret changes
- normal human-owned merge/deploy flow applies