### PR TITLE
fix(testbed): wait for the atomic frame publish instead of racing it

### DIFF
--- a/test/unit/testbed-live-screencast.test.ts
+++ b/test/unit/testbed-live-screencast.test.ts
@@ -73,7 +73,13 @@ describe("testbed live screencast", () => {
     expect(controller).toBeDefined();
     await vi.advanceTimersByTimeAsync(5);
     expect(page.screenshot).toHaveBeenCalledOnce();
-    expect(readFileSync(screencastLatestFramePath(root, mission.id), "utf8")).toBe("jpeg-frame");
+    // The frame is published atomically: `screenshot` writes a sibling temp file
+    // and a separate `await rename` makes it visible as latest.jpg. So the frame
+    // appears one continuation AFTER `screenshot` resolves, not synchronously
+    // with it. Reading straight through raced that rename and hit ENOENT.
+    await vi.waitFor(() => {
+      expect(readFileSync(screencastLatestFramePath(root, mission.id), "utf8")).toBe("jpeg-frame");
+    });
     await vi.waitFor(() => {
       expect(updates).toEqual(expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
**Main is intermittently red.** This fixes it. Not caused by any recent feature PR — reproduced on `0d6912a` with no other changes.

```
FAIL captures bounded latest-frame evidence and publishes monitor stream metadata
Error: ENOENT: no such file or directory, open '.../live-screencast/latest.jpg'
```

~3 failures in 16 local full-suite runs, and it reddened CI on an unrelated PR.

## Cause — a stale timing assumption, not a product defect

#562 made frame publication atomic: `screenshot` writes a sibling temp file, and a separate `await rename` makes it visible as `latest.jpg`. The frame appears **one continuation after `screenshot` resolves**, where the previous in-place write made it visible synchronously. The test read straight through and raced the rename.

**The production reader is already correct.** The SSE route reads with `.catch(() => undefined)` plus a zero-length guard and surfaces `latest_frame_missing` / `no_screencast_frame_yet`. A missing frame is reported honestly — there is no product bug being papered over here. Only the test assumed the old write's timing.

## The fix, and what was deliberately left alone

One racing read now waits for the publish, matching the pattern the rest of the file already uses.

**Not wrapped:** the synchronous read at the mid-capture barrier, which asserts a reader sees the last **complete** frame while the next capture is in flight. That is the torn-read guarantee #562 exists to provide; wrapping it in `waitFor` would let it pass on a frame that merely appeared later, silently deleting the guard.

Verified the guard still bites — reverting the atomic publish to an in-place write fails three tests:

```
FAIL never publishes a torn frame while the next capture is in flight
FAIL captures into a sibling temp file and leaves no temp residue
```

## Evidence

| | Result |
|---|---|
| Base `0d6912a`, no changes | flaked ~3 / 16 full-suite runs, ENOENT on `latest.jpg` |
| With this fix | **12 / 12 green** (2,441 passed) |
| Torn-read guard | still fails when atomic publish is reverted ✓ |

Typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)