### PR TITLE
fix(ops): don't say "all nominal" while a pool drains toward its floor

### DIFF
--- a/packages/monitor-ui/src/components/ops/ops-frame.test.ts
+++ b/packages/monitor-ui/src/components/ops/ops-frame.test.ts
@@ -53,6 +53,80 @@ describe("opsBannerData", () => {
     expect(b.sub).toContain("1 awaiting");
   });
 
+  // ── runway (leading indicator) ─────────────────────────────────────────────
+  // Probes green + a pool draining toward its floor. Live on mainnet 2026-07-28:
+  // the banner said "All product health nominal · 7 probes green" while the
+  // co-pilot said "Signer gas ~13h to floor — top up before settlement halts".
+  const greenProbes: ProductHealth["probes"] = [
+    { name: "product_api", status: "ok", detail: "200", sparkline: [] },
+    { name: "signer_liquidity", status: "ok", detail: "gas 3.9585 DOT, reward bank 17.20 USDC", sparkline: [] },
+  ];
+  const draining = (over: Partial<ProductHealth> = {}, runwayOver: Record<string, unknown> = {}): ProductHealth => ({
+    enabled: true,
+    at: FIXTURE_NOW,
+    status: "healthy",
+    checks: 60,
+    network: "mainnet",
+    probes: greenProbes,
+    solvency: {
+      pools: [],
+      runway: [
+        {
+          key: "signer_gas", label: "Signer gas", unit: "DOT",
+          current: 3.9584888, floor: 1,
+          burnPerHour: 0.22895793250420018, hoursToFloor: 12.921538763221175,
+          estimable: true, status: "degraded",
+          ...runwayOver,
+        },
+      ],
+    },
+    ...over,
+  });
+
+  test("a draining pool stops the banner claiming 'all nominal' while probes are green", () => {
+    const b = opsBannerData(draining(), FIXTURE_NOW);
+    expect(b.headline).not.toBe("All product health nominal");
+    expect(b.headline).toBe("Signer gas ~13h to floor");
+    // A projection is not a breach — amber, never the rose/page tone.
+    expect(b.tone).toBe("action");
+    expect(b.sub).toContain("0.23 DOT/h"); // the evidence behind the projection
+    expect(b.sub).toContain("top up before settlement halts");
+    expect(b.sub).toContain("Nothing has breached yet");
+    expect((b.mostUrgentReasons ?? []).map((r) => r.label)).toEqual(["projected", "mainnet"]);
+  });
+
+  test("a REAL breach still outranks a projection", () => {
+    const b = opsBannerData(
+      draining({ probes: [{ name: "money_path", status: "red", detail: "13 jobs stuck", sparkline: [] }] }),
+      FIXTURE_NOW,
+    );
+    expect(b.tone).toBe("degraded"); // rose — the actual red wins
+    expect(b.headline).toContain("Money path red");
+  });
+
+  test("no false urgency: a non-estimable or flat trend stays calm", () => {
+    // The same pool a day later — the burst left the estimator window and it
+    // resolved to "stable — no depletion trend" (burn ≈ 0, hoursToFloor null).
+    const stable = opsBannerData(draining({}, { burnPerHour: 1.9e-26, hoursToFloor: null, status: "ok" }), FIXTURE_NOW);
+    expect(stable.headline).toBe("All product health nominal");
+    expect(stable.tone).toBe("calm");
+    // And a too-short sample the backend refuses to estimate is never urgency.
+    const notEstimable = opsBannerData(draining({}, { estimable: false }), FIXTURE_NOW);
+    expect(notEstimable.headline).toBe("All product health nominal");
+  });
+
+  test("nearest pool leads, others get a +N suffix; at-floor and sub-hour read honestly", () => {
+    const two = draining();
+    two.solvency!.runway!.push({
+      key: "reward_bank", label: "Reward bank", unit: "USDC",
+      current: 17.2, floor: 2, burnPerHour: 0.297, hoursToFloor: 51.1,
+      estimable: true, status: "degraded",
+    });
+    expect(opsBannerData(two, FIXTURE_NOW).headline).toBe("Signer gas ~13h to floor +1");
+    expect(opsBannerData(draining({}, { hoursToFloor: 0 }), FIXTURE_NOW).headline).toBe("Signer gas at its floor");
+    expect(opsBannerData(draining({}, { hoursToFloor: 0.4 }), FIXTURE_NOW).headline).toBe("Signer gas <1h to floor");
+  });
+
   test("off + idle states", () => {
     expect(opsBannerData({ enabled: false, at: null, status: "unknown", checks: 0, probes: [] }, FIXTURE_NOW).headline).toBe(
       "Monitoring is off",

--- a/packages/monitor-ui/src/components/ops/ops-frame.ts
+++ b/packages/monitor-ui/src/components/ops/ops-frame.ts
@@ -9,7 +9,7 @@
 // Pure + nowMs-injected so it's deterministic to test.
 
 import type { BannerData } from "../BoardNowBanner.js";
-import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import type { ProductHealth, RunwayPool } from "../../lib/monitor/product-health.js";
 import { probeLabel } from "../../lib/monitor/product-health.js";
 import {
   groupProbesByPillar,
@@ -21,6 +21,37 @@ import {
 
 function shortDetail(detail: string): string {
   return detail.length > 88 ? `${detail.slice(0, 85)}…` : detail;
+}
+
+/**
+ * Pools projected to reach their floor, nearest first.
+ *
+ * Runway is a LEADING indicator: the probes can all sit above their floors — so
+ * the banner reads "all nominal" — while a pool is visibly draining toward one.
+ * That was live on mainnet: 7 probes green with the co-pilot simultaneously
+ * saying "Signer gas ~13h to floor — top up before settlement halts".
+ *
+ * `estimable` + a non-null `hoursToFloor` are the backend's own honesty gates
+ * (too few samples / too short a window / flat / refilling all resolve to
+ * not-estimable), so a single reading can't manufacture urgency here.
+ */
+function drainingPools(health: ProductHealth): RunwayPool[] {
+  return (health.solvency?.runway ?? [])
+    .filter((p) => p.estimable && p.hoursToFloor !== null && (p.status === "red" || p.status === "degraded"))
+    .sort((a, b) => (a.hoursToFloor ?? 0) - (b.hoursToFloor ?? 0));
+}
+
+function hoursToFloorPhrase(hours: number): string {
+  if (hours <= 0) return "at its floor";
+  if (hours < 1) return "<1h to floor";
+  return `~${Math.round(hours)}h to floor`;
+}
+
+/** The burn that produced the projection — the evidence, so it can be judged. */
+function burnPhrase(pool: RunwayPool): string | undefined {
+  const burn = pool.burnPerHour;
+  if (burn === null || burn <= 0) return undefined;
+  return `${burn >= 1 ? burn.toFixed(1) : burn.toFixed(2)} ${pool.unit}/h`;
 }
 
 function eyebrowFor(health: ProductHealth, nowMs: number): string {
@@ -89,6 +120,32 @@ export function opsBannerData(health: ProductHealth, nowMs: number): BannerData 
       primaryActionId: undefined,
       mostUrgentReasons: [
         { label: "degraded", tone: "warn" },
+        ...(net ? ([{ label: net, tone: "neutral" }] as const) : []),
+      ],
+    };
+  }
+
+  // Nothing has breached — but a pool may be draining toward its floor. A
+  // projection is NOT a breach, so this never takes the rose/page tone; it only
+  // stops the banner claiming "all nominal" while the co-pilot is telling the
+  // operator to top up. An actual red/degraded probe still outranks it above.
+  const draining = drainingPools(health);
+  if (draining.length > 0) {
+    const lead = draining[0]!;
+    const extra = draining.length > 1 ? ` +${draining.length - 1}` : "";
+    const burn = burnPhrase(lead);
+    const projected = burn ? `Projected from a ${burn} trend` : "Projected from the recent trend";
+    return {
+      tone: "action",
+      eyebrow,
+      headline: `${lead.label} ${hoursToFloorPhrase(lead.hoursToFloor ?? 0)}${extra}`,
+      sub: mainnet
+        ? `${projected} — top up before settlement halts. Nothing has breached yet.`
+        : `${projected} — nothing has breached yet.`,
+      primaryActionId: undefined,
+      mostUrgentReasons: [
+        // "projected", not "degraded": the balance is still above its floor.
+        { label: "projected", tone: "warn" },
         ...(net ? ([{ label: net, tone: "neutral" }] as const) : []),
       ],
     };


### PR DESCRIPTION
## The bug, live on mainnet

Same snapshot, two answers:

> **Banner:** ✅ All product health nominal — 7 probes green · all pillars nominal
> **Co-pilot rail:** Signer gas ~13h to floor — top up before settlement halts.

Both statements were true. They just disagreed — and the operator's eye lands on the banner.

`opsBannerData()` ranked **probe status only**. Runway is a *leading* indicator: every balance can sit above its floor (so every probe is green) while one is visibly draining toward it. So no matter how close the projection got, it could never reach the headline.

## Fix

A runway branch between real breaches and the calm fallback:

- **A real breach still outranks a projection** — an actual red/degraded probe wins.
- **A projection is not a breach.** Amber `action`, never the rose/page tone, and the sub says it outright: *"Nothing has breached yet."*
- Headline names pool + hours — `Signer gas ~13h to floor` — matching the wording the co-pilot already uses, so the two surfaces stop contradicting each other.
- Sub carries **the burn that produced the projection** (`0.23 DOT/h`) so the operator can judge it rather than trust it.
- Reason chip is `projected`, not `degraded` — the balance is above its floor.

## No false urgency

This was the risk worth designing against, and I got to test it against reality. The `~13h` figure came from a **transient burst** (the funding/settlement activity). A day later that burst had left the estimator's window: burn fell to ~0, `hoursToFloor` to `null`, and the backend reported *"stable — no depletion trend"*.

The branch consumes the backend's own honesty gates (`estimable` + non-null `hoursToFloor`) — which already resolve too-few-samples / too-short-window / flat / refilling to not-estimable — so it correctly returns to "All product health nominal" in that state. Both directions are covered by tests.

## Tests
+4: the live 13h scenario, breach-outranks-projection, the stable **and** not-estimable no-urgency cases, and +N / at-floor / sub-hour wording.

`monitor-ui` **816 passed vs 812 on clean main** — the same 3 pre-existing Harness failures (`@avg/schemas` missing `AgentRunProjectionV1`), **zero new**, verified by stashing and re-running. tsc baseline unchanged at 3, none in `ops-frame.ts`. SPA build ✓.

First of five from the operator's list (runway headline · rail de-noise · agent-intent + payout evidence · mobile · latency spike).

🤖 Generated with [Claude Code](https://claude.com/claude-code)