### PR TITLE
feat(mobile): dedicated phone board — monitor and act on the go

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -50,6 +50,8 @@ import { hasFreshRed, type ProductHealth } from "../lib/monitor/product-health.j
 import { BoardSurfaceSwitch, type BoardSurface } from "./ops/BoardSurfaceSwitch.js";
 import { OpsBoard } from "./ops/OpsBoard.js";
 import { opsBannerData, pillarStatuses } from "./ops/ops-frame.js";
+import { MobileBoard } from "./mobile/MobileBoard.js";
+import { useIsMobileViewport } from "../lib/monitor/use-mobile-viewport.js";
 import { Badge, Button } from "./ui.js";
 
 // laneFor() promotes every isAction card into needs-attention, so the
@@ -236,6 +238,8 @@ export function BoardView({
 
   // ── The board switches Delivery ⇆ Ops at the top level (board-wide). ──
   const { health: productHealth } = useProductHealth({ enabled: monitoringEnabled });
+  // Phone-width → the dedicated mobile surface (see the branch before `return`).
+  const isMobileViewport = useIsMobileViewport();
   const [boardSurface, setBoardSurface] = useState<BoardSurface>(() => {
     try {
       const stored = localStorage.getItem("hm-board-surface");
@@ -600,6 +604,21 @@ export function BoardView({
     }
     return a;
   }, [onRerunMission, onApproveTask, onCreateTask, onCardClose, onDismissCard]);
+
+  // Phone → the dedicated mobile surface instead of the desktop chrome. Placed
+  // AFTER every hook (rules of hooks) and additive: without matchMedia this is
+  // always false, so existing renders and tests are untouched.
+  if (isMobileViewport) {
+    return (
+      <MobileBoard
+        health={productHealth}
+        cards={cards}
+        onCardClick={onCardClick}
+        onApproveTask={onApproveTask}
+        onDismissCard={onDismissCard}
+      />
+    );
+  }
 
   return (
     <div className="hm-board">

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { cleanup, fireEvent, render, within } from "@testing-library/react";
+import { MobileBoard } from "./MobileBoard.js";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+
+afterEach(cleanup);
+
+const NOW = Date.parse("2026-07-29T10:00:00Z");
+
+/** The live mainnet snapshot: probes green, pools above their floors. */
+const healthyMainnet: ProductHealth = {
+  enabled: true,
+  at: NOW,
+  status: "healthy",
+  checks: 60,
+  network: "mainnet",
+  chainId: 420420419,
+  probes: [
+    { name: "product_api", status: "ok", detail: "200 · chain 420420419", sparkline: [] },
+    { name: "signer_liquidity", status: "ok", detail: "gas 3.9585 DOT, reward bank 17.20 USDC", sparkline: [] },
+  ],
+  solvency: {
+    pools: [
+      { key: "signer_gas", label: "Signer gas", amount: 3.9584888, unit: "DOT", floor: 1, status: "ok" },
+      { key: "reward_bank", label: "Reward bank", amount: 17.2, unit: "USDC", floor: 2, status: "ok" },
+      { key: "escrow", label: "Escrow (in-flight)", amount: 0, unit: "USDC", status: "ok", informational: true },
+    ],
+    runwayNote: "stable — no depletion trend",
+  },
+};
+
+function taskCard(over: Partial<BoardCard> = {}): BoardCard {
+  return {
+    id: "codex-task-1",
+    lane: "codex-needed",
+    type: "task",
+    agentType: "codex",
+    title: "Hermes routed work: ops pre-check",
+    summary: "",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 2,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "warn" },
+    files: [],
+    ...over,
+  } as BoardCard;
+}
+
+describe("MobileBoard", () => {
+  test("leads with the one-glance status, then money, decisions, agents", () => {
+    const { getByTestId, getByText } = render(
+      <MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />,
+    );
+    expect(getByTestId("mobile-board")).toBeTruthy();
+    expect(getByText("All product health nominal")).toBeTruthy();
+    expect(getByText("mainnet · 420420419")).toBeTruthy();
+    expect(getByText("Signer gas")).toBeTruthy();
+    // Amount at 2dp, floor without noise decimals ("floor 1", not "floor 1.00").
+    expect(getByText(/3\.96 DOT · floor 1$/)).toBeTruthy();
+    expect(getByText(/17\.20 USDC · floor 2$/)).toBeTruthy();
+    expect(getByText("stable — no depletion trend")).toBeTruthy();
+  });
+
+  test("the status card reuses opsBannerData, so a runway projection reaches the phone too", () => {
+    // Same source as the desktop banner (#571) — the two surfaces cannot disagree.
+    const draining: ProductHealth = {
+      ...healthyMainnet,
+      solvency: {
+        ...healthyMainnet.solvency!,
+        runway: [
+          {
+            key: "signer_gas", label: "Signer gas", unit: "DOT",
+            current: 3.9584888, floor: 1, burnPerHour: 0.229, hoursToFloor: 12.9,
+            estimable: true, status: "degraded",
+          },
+        ],
+      },
+    };
+    const { getByText, queryByText } = render(<MobileBoard health={draining} cards={[]} nowMs={NOW} />);
+    expect(getByText("Signer gas ~13h to floor")).toBeTruthy();
+    expect(queryByText("All product health nominal")).toBeNull();
+  });
+
+  test("an informational pool is context, not a floored meter", () => {
+    const { queryByText } = render(<MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />);
+    expect(queryByText("Escrow (in-flight)")).toBeNull();
+  });
+
+  test("a pool awaiting data says so — never a bar we can't justify", () => {
+    const awaiting: ProductHealth = {
+      ...healthyMainnet,
+      solvency: { pools: [{ key: "reserve", label: "Treasury reserve", amount: null, unit: "USDC", status: "degraded" }] },
+    };
+    const { getByText } = render(<MobileBoard health={awaiting} cards={[]} nowMs={NOW} />);
+    expect(getByText("awaiting data")).toBeTruthy();
+  });
+
+  test("decisions come from isDecision (same selector as the desktop inbox) and cap with a +N", () => {
+    const many = Array.from({ length: 7 }, (_, i) => taskCard({ id: `t${i}`, title: `Decision ${i}` }));
+    const { getByText } = render(<MobileBoard health={healthyMainnet} cards={many} nowMs={NOW} />);
+    expect(getByText("Needs you · 7")).toBeTruthy();
+    expect(getByText("Decision 0")).toBeTruthy();
+    expect(getByText("+2 more on the full board.")).toBeTruthy();
+  });
+
+  test("a PROPOSED task exposes Approve/Dismiss and wires them to the operator gate", () => {
+    const onApproveTask = vi.fn();
+    const onDismissCard = vi.fn();
+    const card = taskCard({ taskStatus: "proposed" } as Partial<BoardCard>);
+    const { getByText } = render(
+      <MobileBoard
+        health={healthyMainnet}
+        cards={[card]}
+        nowMs={NOW}
+        onApproveTask={onApproveTask}
+        onDismissCard={onDismissCard}
+      />,
+    );
+    fireEvent.click(getByText("Approve"));
+    expect(onApproveTask).toHaveBeenCalledWith("codex-task-1");
+    fireEvent.click(getByText("Dismiss"));
+    expect(onDismissCard).toHaveBeenCalledWith(card);
+  });
+
+  test("a NON-proposed decision offers no approve button — the phone can't dispatch what isn't proposed", () => {
+    const { queryByText } = render(
+      <MobileBoard health={healthyMainnet} cards={[taskCard()]} nowMs={NOW} onApproveTask={vi.fn()} />,
+    );
+    expect(queryByText("Approve")).toBeNull();
+  });
+
+  test("tapping a decision opens it rather than acting on it", () => {
+    const onCardClick = vi.fn();
+    const { getByText } = render(
+      <MobileBoard health={healthyMainnet} cards={[taskCard()]} nowMs={NOW} onCardClick={onCardClick} />,
+    );
+    fireEvent.click(getByText("Hermes routed work: ops pre-check"));
+    expect(onCardClick).toHaveBeenCalledWith("codex-task-1");
+  });
+
+  test("agents show only real workingNow — never inferred", () => {
+    const idle = render(<MobileBoard health={healthyMainnet} cards={[taskCard()]} nowMs={NOW} />);
+    expect(idle.getByText("No agent is running right now.")).toBeTruthy();
+    cleanup();
+
+    const busy = render(
+      <MobileBoard
+        health={healthyMainnet}
+        nowMs={NOW}
+        cards={[taskCard({ workingNow: { agent: "claude", label: "Claude fixing" } } as Partial<BoardCard>)]}
+      />,
+    );
+    expect(busy.getByText("claude")).toBeTruthy();
+    expect(busy.getByText("Claude fixing")).toBeTruthy();
+  });
+
+  test("empty states stay honest instead of blank", () => {
+    const { getByText } = render(<MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />);
+    expect(getByText("Nothing waiting on you.")).toBeTruthy();
+    expect(within(getByText("Nothing waiting on you.").closest("section")!).getByText(/Needs you/)).toBeTruthy();
+  });
+});

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -1,0 +1,280 @@
+// MobileBoard — the dedicated phone surface. NOT a responsive squeeze of the
+// desktop board: the top strip, lane grid and co-pilot rail are 1500px-canvas
+// furniture, so this replaces them with a single priority-ordered feed —
+//   is it fine → is the money fine → what needs me → who's working.
+//
+// EXTENSIBILITY (the operator's "room for further features down the line"):
+// cards compose exactly like OpsBoard composes zones. Each card is a
+// self-contained component that owns its own truth-boundary and returns null
+// when it has nothing to say, so adding a feature is adding one component to
+// the list below — no rework to the cards around it.
+//
+// It renders the SAME ProductHealth + BoardCard payload the desktop board uses
+// and reuses the desktop's own derivations (opsBannerData, isDecision), so the
+// two surfaces cannot drift apart or disagree about what is wrong.
+
+import type { ReactNode } from "react";
+import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { ProductHealth, SolvencyPool } from "../../lib/monitor/product-health.js";
+import { isDecision } from "../../lib/monitor/lane-rules.js";
+import { opsBannerData } from "../ops/ops-frame.js";
+
+export interface MobileBoardProps {
+  health?: ProductHealth;
+  cards: BoardCard[];
+  nowMs?: number;
+  onCardClick?: (id: string) => void;
+  /** Approve a proposed task — the operator gate, same as the desktop drawer. */
+  onApproveTask?: (id: string) => void;
+  onDismissCard?: (card: BoardCard) => void;
+}
+
+/** How many decisions the feed shows before deferring to the desktop board. */
+const DECISION_LIMIT = 5;
+
+export function MobileBoard({
+  health,
+  cards,
+  nowMs = Date.now(),
+  onCardClick,
+  onApproveTask,
+  onDismissCard,
+}: MobileBoardProps) {
+  const decisions = cards.filter(isDecision);
+  return (
+    <div className="hm-mb" data-testid="mobile-board">
+      <header className="hm-mb-top">
+        <div>
+          <div className="hm-mb-brand">Hermes</div>
+          <div className="hm-mb-net">{networkLine(health)}</div>
+        </div>
+        <span className="hm-mb-live" aria-hidden />
+      </header>
+
+      <div className="hm-mb-feed">
+        {/* Add a card here to add a feature. Each returns null when empty. */}
+        <MobileStatusCard health={health} nowMs={nowMs} />
+        <MobileMoneyCard health={health} />
+        <MobileNeedsYouCard
+          decisions={decisions}
+          onCardClick={onCardClick}
+          onApproveTask={onApproveTask}
+          onDismissCard={onDismissCard}
+        />
+        <MobileAgentsCard cards={cards} />
+      </div>
+
+      <p className="hm-mb-foot">Grey is awaiting data, never fake-green.</p>
+    </div>
+  );
+}
+
+function networkLine(health?: ProductHealth): string {
+  if (!health?.network || health.network === "unknown") return "monitor";
+  const chain = typeof health.chainId === "number" ? ` · ${health.chainId}` : "";
+  return `${health.network}${chain}`;
+}
+
+function MobileCard({ label, tone, children }: { label?: string; tone?: "ok" | "warn" | "red"; children: ReactNode }) {
+  return (
+    <section className={`hm-mb-card${tone ? ` hm-mb-card--${tone}` : ""}`}>
+      {label ? <span className="hm-mb-label">{label}</span> : null}
+      {children}
+    </section>
+  );
+}
+
+/**
+ * The one-glance answer. Reuses opsBannerData so the phone states exactly what
+ * the desktop banner states — including a runway projection ("Signer gas ~13h
+ * to floor"), which is why this can't quietly say "all nominal" when the desk
+ * board doesn't.
+ */
+export function MobileStatusCard({ health, nowMs }: { health?: ProductHealth; nowMs: number }) {
+  if (!health) return null;
+  const banner = opsBannerData(health, nowMs);
+  const tone = banner.tone === "degraded" ? "red" : banner.tone === "action" ? "warn" : "ok";
+  const glyph = tone === "red" ? "‼" : tone === "warn" ? "!" : "✓";
+  return (
+    <MobileCard tone={tone}>
+      <div className="hm-mb-status">
+        <span className={`hm-mb-badge hm-mb-badge--${tone}`} aria-hidden>{glyph}</span>
+        <div>
+          <h2 className="hm-mb-h">{banner.headline}</h2>
+          {banner.sub ? <p className="hm-mb-sub">{banner.sub}</p> : null}
+        </div>
+      </div>
+    </MobileCard>
+  );
+}
+
+/** Money — the thing that actually hurts when you're away from the desk. */
+export function MobileMoneyCard({ health }: { health?: ProductHealth }) {
+  const pools = (health?.solvency?.pools ?? []).filter((p) => !p.informational);
+  if (pools.length === 0) return null;
+  const note = health?.solvency?.runwayNote;
+  return (
+    <MobileCard label="Money">
+      {pools.map((pool) => (
+        <PoolRow key={pool.key} pool={pool} />
+      ))}
+      {note ? <p className="hm-mb-note">{note}</p> : null}
+    </MobileCard>
+  );
+}
+
+function PoolRow({ pool }: { pool: SolvencyPool }) {
+  // amount null = awaiting data. Say so; never draw a bar we can't justify.
+  if (pool.amount === null || pool.amount === undefined) {
+    return (
+      <div className="hm-mb-pool">
+        <div className="hm-mb-pool-row">
+          <strong>{pool.label}</strong>
+          <span className="hm-mb-awaiting">awaiting data</span>
+        </div>
+      </div>
+    );
+  }
+  const floor = pool.floor ?? null;
+  // Fill is share-of-a-safe-buffer (5× floor), capped — a floored pool at 5×
+  // reads full, and one at its floor reads nearly empty.
+  const pct = floor && floor > 0 ? Math.max(4, Math.min(100, Math.round((pool.amount / (floor * 5)) * 100))) : 100;
+  const tone = pool.status === "red" ? "red" : pool.status === "degraded" ? "warn" : "ok";
+  return (
+    <div className="hm-mb-pool">
+      <div className="hm-mb-pool-row">
+        <strong>{pool.label}</strong>
+        <span>
+          {formatAmount(pool.amount)} {pool.unit}
+          {floor !== null ? ` · floor ${formatFloor(floor)}` : ""}
+        </span>
+      </div>
+      <div className="hm-mb-bar" role="img" aria-label={`${pool.label} ${pool.amount} ${pool.unit}`}>
+        <span className={`hm-mb-bar-fill hm-mb-bar-fill--${tone}`} style={{ width: `${pct}%` }} />
+      </div>
+      {pool.note ? <p className="hm-mb-note">{pool.note}</p> : null}
+    </div>
+  );
+}
+
+function formatAmount(value: number): string {
+  if (value === 0) return "0";
+  return value >= 100 ? value.toFixed(0) : value >= 1 ? value.toFixed(2) : value.toFixed(4);
+}
+
+/** Floors are round numbers set by an operator — "floor 1", not "floor 1.00". */
+function formatFloor(value: number): string {
+  return String(Number(value.toFixed(4)));
+}
+
+/**
+ * The decisions waiting on the operator. Uses `isDecision` — the same selector
+ * the desktop inbox and the "waiting on you" count use — so the phone can't
+ * show a different backlog than the board.
+ *
+ * SAFETY: only approve/dismiss of already-proposed work is reachable here. The
+ * phone never moves funds; a prepare-only task stays prepare-only.
+ */
+export function MobileNeedsYouCard({
+  decisions,
+  onCardClick,
+  onApproveTask,
+  onDismissCard,
+}: {
+  decisions: BoardCard[];
+  onCardClick?: (id: string) => void;
+  onApproveTask?: (id: string) => void;
+  onDismissCard?: (card: BoardCard) => void;
+}) {
+  if (decisions.length === 0) {
+    return (
+      <MobileCard label="Needs you">
+        <p className="hm-mb-empty">Nothing waiting on you.</p>
+      </MobileCard>
+    );
+  }
+  const shown = decisions.slice(0, DECISION_LIMIT);
+  const rest = decisions.length - shown.length;
+  return (
+    <MobileCard label={`Needs you · ${decisions.length}`}>
+      {shown.map((card) => (
+        <DecisionRow
+          key={card.id}
+          card={card}
+          onCardClick={onCardClick}
+          onApproveTask={onApproveTask}
+          onDismissCard={onDismissCard}
+        />
+      ))}
+      {rest > 0 ? <p className="hm-mb-note">+{rest} more on the full board.</p> : null}
+    </MobileCard>
+  );
+}
+
+function DecisionRow({
+  card,
+  onCardClick,
+  onApproveTask,
+  onDismissCard,
+}: {
+  card: BoardCard;
+  onCardClick?: (id: string) => void;
+  onApproveTask?: (id: string) => void;
+  onDismissCard?: (card: BoardCard) => void;
+}) {
+  const taskStatus = (card as { taskStatus?: string }).taskStatus;
+  const proposed = card.type === "task" && taskStatus === "proposed";
+  return (
+    <div className="hm-mb-item">
+      <button type="button" className="hm-mb-item-open" onClick={onCardClick ? () => onCardClick(card.id) : undefined}>
+        <span className="hm-mb-item-title">{card.title}</span>
+        <span className="hm-mb-item-meta">
+          {card.agentType}
+          {card.repo ? ` · ${card.repo.split("/").pop()}` : ""}
+        </span>
+      </button>
+      {proposed ? (
+        <div className="hm-mb-acts">
+          <button
+            type="button"
+            className="hm-mb-btn hm-mb-btn--primary"
+            onClick={onApproveTask ? () => onApproveTask(card.id) : undefined}
+            disabled={!onApproveTask}
+          >
+            Approve
+          </button>
+          <button
+            type="button"
+            className="hm-mb-btn"
+            onClick={onDismissCard ? () => onDismissCard(card) : undefined}
+            disabled={!onDismissCard}
+          >
+            Dismiss
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** Who is actually working right now — real `workingNow` only, never inferred. */
+export function MobileAgentsCard({ cards }: { cards: BoardCard[] }) {
+  const working = cards
+    .map((card) => (card as { workingNow?: { agent?: string; label?: string } }).workingNow)
+    .filter((w): w is { agent?: string; label?: string } => Boolean(w));
+  return (
+    <MobileCard label="Agents">
+      {working.length === 0 ? (
+        <p className="hm-mb-empty">No agent is running right now.</p>
+      ) : (
+        working.map((w, i) => (
+          <div className="hm-mb-agent" key={`${w.agent ?? "agent"}-${i}`}>
+            <span className="hm-mb-jewel" aria-hidden />
+            <span className="hm-mb-agent-name">{w.agent ?? "agent"}</span>
+            <span className="hm-mb-agent-state">{w.label ?? "working"}</span>
+          </div>
+        ))
+      )}
+    </MobileCard>
+  );
+}

--- a/packages/monitor-ui/src/components/ops/ops-frame.test.ts
+++ b/packages/monitor-ui/src/components/ops/ops-frame.test.ts
@@ -53,6 +53,80 @@ describe("opsBannerData", () => {
     expect(b.sub).toContain("1 awaiting");
   });
 
+  // ── runway (leading indicator) ─────────────────────────────────────────────
+  // Probes green + a pool draining toward its floor. Live on mainnet 2026-07-28:
+  // the banner said "All product health nominal · 7 probes green" while the
+  // co-pilot said "Signer gas ~13h to floor — top up before settlement halts".
+  const greenProbes: ProductHealth["probes"] = [
+    { name: "product_api", status: "ok", detail: "200", sparkline: [] },
+    { name: "signer_liquidity", status: "ok", detail: "gas 3.9585 DOT, reward bank 17.20 USDC", sparkline: [] },
+  ];
+  const draining = (over: Partial<ProductHealth> = {}, runwayOver: Record<string, unknown> = {}): ProductHealth => ({
+    enabled: true,
+    at: FIXTURE_NOW,
+    status: "healthy",
+    checks: 60,
+    network: "mainnet",
+    probes: greenProbes,
+    solvency: {
+      pools: [],
+      runway: [
+        {
+          key: "signer_gas", label: "Signer gas", unit: "DOT",
+          current: 3.9584888, floor: 1,
+          burnPerHour: 0.22895793250420018, hoursToFloor: 12.921538763221175,
+          estimable: true, status: "degraded",
+          ...runwayOver,
+        },
+      ],
+    },
+    ...over,
+  });
+
+  test("a draining pool stops the banner claiming 'all nominal' while probes are green", () => {
+    const b = opsBannerData(draining(), FIXTURE_NOW);
+    expect(b.headline).not.toBe("All product health nominal");
+    expect(b.headline).toBe("Signer gas ~13h to floor");
+    // A projection is not a breach — amber, never the rose/page tone.
+    expect(b.tone).toBe("action");
+    expect(b.sub).toContain("0.23 DOT/h"); // the evidence behind the projection
+    expect(b.sub).toContain("top up before settlement halts");
+    expect(b.sub).toContain("Nothing has breached yet");
+    expect((b.mostUrgentReasons ?? []).map((r) => r.label)).toEqual(["projected", "mainnet"]);
+  });
+
+  test("a REAL breach still outranks a projection", () => {
+    const b = opsBannerData(
+      draining({ probes: [{ name: "money_path", status: "red", detail: "13 jobs stuck", sparkline: [] }] }),
+      FIXTURE_NOW,
+    );
+    expect(b.tone).toBe("degraded"); // rose — the actual red wins
+    expect(b.headline).toContain("Money path red");
+  });
+
+  test("no false urgency: a non-estimable or flat trend stays calm", () => {
+    // The same pool a day later — the burst left the estimator window and it
+    // resolved to "stable — no depletion trend" (burn ≈ 0, hoursToFloor null).
+    const stable = opsBannerData(draining({}, { burnPerHour: 1.9e-26, hoursToFloor: null, status: "ok" }), FIXTURE_NOW);
+    expect(stable.headline).toBe("All product health nominal");
+    expect(stable.tone).toBe("calm");
+    // And a too-short sample the backend refuses to estimate is never urgency.
+    const notEstimable = opsBannerData(draining({}, { estimable: false }), FIXTURE_NOW);
+    expect(notEstimable.headline).toBe("All product health nominal");
+  });
+
+  test("nearest pool leads, others get a +N suffix; at-floor and sub-hour read honestly", () => {
+    const two = draining();
+    two.solvency!.runway!.push({
+      key: "reward_bank", label: "Reward bank", unit: "USDC",
+      current: 17.2, floor: 2, burnPerHour: 0.297, hoursToFloor: 51.1,
+      estimable: true, status: "degraded",
+    });
+    expect(opsBannerData(two, FIXTURE_NOW).headline).toBe("Signer gas ~13h to floor +1");
+    expect(opsBannerData(draining({}, { hoursToFloor: 0 }), FIXTURE_NOW).headline).toBe("Signer gas at its floor");
+    expect(opsBannerData(draining({}, { hoursToFloor: 0.4 }), FIXTURE_NOW).headline).toBe("Signer gas <1h to floor");
+  });
+
   test("off + idle states", () => {
     expect(opsBannerData({ enabled: false, at: null, status: "unknown", checks: 0, probes: [] }, FIXTURE_NOW).headline).toBe(
       "Monitoring is off",

--- a/packages/monitor-ui/src/components/ops/ops-frame.ts
+++ b/packages/monitor-ui/src/components/ops/ops-frame.ts
@@ -9,7 +9,7 @@
 // Pure + nowMs-injected so it's deterministic to test.
 
 import type { BannerData } from "../BoardNowBanner.js";
-import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import type { ProductHealth, RunwayPool } from "../../lib/monitor/product-health.js";
 import { probeLabel } from "../../lib/monitor/product-health.js";
 import {
   groupProbesByPillar,
@@ -21,6 +21,37 @@ import {
 
 function shortDetail(detail: string): string {
   return detail.length > 88 ? `${detail.slice(0, 85)}…` : detail;
+}
+
+/**
+ * Pools projected to reach their floor, nearest first.
+ *
+ * Runway is a LEADING indicator: the probes can all sit above their floors — so
+ * the banner reads "all nominal" — while a pool is visibly draining toward one.
+ * That was live on mainnet: 7 probes green with the co-pilot simultaneously
+ * saying "Signer gas ~13h to floor — top up before settlement halts".
+ *
+ * `estimable` + a non-null `hoursToFloor` are the backend's own honesty gates
+ * (too few samples / too short a window / flat / refilling all resolve to
+ * not-estimable), so a single reading can't manufacture urgency here.
+ */
+function drainingPools(health: ProductHealth): RunwayPool[] {
+  return (health.solvency?.runway ?? [])
+    .filter((p) => p.estimable && p.hoursToFloor !== null && (p.status === "red" || p.status === "degraded"))
+    .sort((a, b) => (a.hoursToFloor ?? 0) - (b.hoursToFloor ?? 0));
+}
+
+function hoursToFloorPhrase(hours: number): string {
+  if (hours <= 0) return "at its floor";
+  if (hours < 1) return "<1h to floor";
+  return `~${Math.round(hours)}h to floor`;
+}
+
+/** The burn that produced the projection — the evidence, so it can be judged. */
+function burnPhrase(pool: RunwayPool): string | undefined {
+  const burn = pool.burnPerHour;
+  if (burn === null || burn <= 0) return undefined;
+  return `${burn >= 1 ? burn.toFixed(1) : burn.toFixed(2)} ${pool.unit}/h`;
 }
 
 function eyebrowFor(health: ProductHealth, nowMs: number): string {
@@ -89,6 +120,32 @@ export function opsBannerData(health: ProductHealth, nowMs: number): BannerData 
       primaryActionId: undefined,
       mostUrgentReasons: [
         { label: "degraded", tone: "warn" },
+        ...(net ? ([{ label: net, tone: "neutral" }] as const) : []),
+      ],
+    };
+  }
+
+  // Nothing has breached — but a pool may be draining toward its floor. A
+  // projection is NOT a breach, so this never takes the rose/page tone; it only
+  // stops the banner claiming "all nominal" while the co-pilot is telling the
+  // operator to top up. An actual red/degraded probe still outranks it above.
+  const draining = drainingPools(health);
+  if (draining.length > 0) {
+    const lead = draining[0]!;
+    const extra = draining.length > 1 ? ` +${draining.length - 1}` : "";
+    const burn = burnPhrase(lead);
+    const projected = burn ? `Projected from a ${burn} trend` : "Projected from the recent trend";
+    return {
+      tone: "action",
+      eyebrow,
+      headline: `${lead.label} ${hoursToFloorPhrase(lead.hoursToFloor ?? 0)}${extra}`,
+      sub: mainnet
+        ? `${projected} — top up before settlement halts. Nothing has breached yet.`
+        : `${projected} — nothing has breached yet.`,
+      primaryActionId: undefined,
+      mostUrgentReasons: [
+        // "projected", not "degraded": the balance is still above its floor.
+        { label: "projected", tone: "warn" },
         ...(net ? ([{ label: net, tone: "neutral" }] as const) : []),
       ],
     };

--- a/packages/monitor-ui/src/lib/monitor/use-mobile-viewport.ts
+++ b/packages/monitor-ui/src/lib/monitor/use-mobile-viewport.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+/** Below this the board switches to the dedicated mobile surface. Chosen so a
+ *  phone in portrait gets it and a tablet/laptop keeps the full board. */
+export const MOBILE_MAX_WIDTH = 720;
+
+/**
+ * True when the viewport is phone-sized.
+ *
+ * SSR/test-safe: starts false and only flips in an effect, so anything without
+ * `matchMedia` (jsdom without a stub, a server render) keeps the desktop board
+ * — the mobile surface is strictly additive and never hijacks an existing view.
+ */
+export function useIsMobileViewport(maxWidth: number = MOBILE_MAX_WIDTH): boolean {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+    const query = window.matchMedia(`(max-width: ${maxWidth}px)`);
+    const apply = () => setIsMobile(query.matches);
+    apply();
+    // addListener is the pre-2019 Safari spelling; keep both so an older phone
+    // still tracks rotation instead of freezing at its first reading.
+    if (typeof query.addEventListener === "function") {
+      query.addEventListener("change", apply);
+      return () => query.removeEventListener("change", apply);
+    }
+    query.addListener?.(apply);
+    return () => query.removeListener?.(apply);
+  }, [maxWidth]);
+
+  return isMobile;
+}

--- a/packages/monitor-ui/src/main.tsx
+++ b/packages/monitor-ui/src/main.tsx
@@ -36,6 +36,9 @@ import "./styles/hermes4-utilities.css";
 // Ops surface: the full-canvas operations board (--h4-tokened). Loaded last so
 // its additive rules win; scoped to `.ops-*` so it never touches the delivery board.
 import "./styles/hermes4-ops.css";
+// Mobile surface: the dedicated phone board. Scoped to `.hm-mb-*` and only
+// mounted below MOBILE_MAX_WIDTH, so it never touches the desktop surfaces.
+import "./styles/hermes4-mobile.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -1,0 +1,173 @@
+/* MobileBoard — the dedicated phone surface.
+   Entirely on the shared --h4 tokens, so it inherits the board's theme and the
+   semantic status colours (sage ok / amber warn / coral red / warm-grey
+   awaiting) rather than defining a second palette that could drift. */
+
+.hm-mb {
+  min-height: 100vh;
+  background: var(--h4-paper);
+  color: var(--h4-ink);
+  display: flex;
+  flex-direction: column;
+}
+
+.hm-mb-top {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  background: var(--h4-paper);
+  border-bottom: 1px solid var(--h4-line-2);
+}
+.hm-mb-brand {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+}
+.hm-mb-net {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+  margin-top: 1px;
+}
+.hm-mb-live {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--h4-ok);
+  flex: none;
+}
+
+.hm-mb-feed {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+}
+
+.hm-mb-card {
+  background: var(--h4-paper-sunken);
+  border: 1px solid var(--h4-line-2);
+  border-radius: 12px;
+  padding: 13px;
+}
+.hm-mb-card--warn { border-color: var(--h4-warn); }
+.hm-mb-card--red { border-color: var(--h4-act); }
+
+.hm-mb-label {
+  display: block;
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  color: var(--h4-faint);
+  margin-bottom: 9px;
+}
+
+/* ── status ─────────────────────────────────────────────────────────────── */
+.hm-mb-status { display: flex; gap: 11px; align-items: flex-start; }
+.hm-mb-badge {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  flex: none;
+}
+.hm-mb-badge--ok { background: var(--h4-ok-soft); color: var(--h4-ok); }
+.hm-mb-badge--warn { background: var(--h4-warn-soft); color: var(--h4-warn); }
+.hm-mb-badge--red { background: var(--h4-act-soft); color: var(--h4-act); }
+.hm-mb-h { font-family: var(--font-display); font-size: 15px; font-weight: 700; line-height: 1.3; margin: 0; }
+.hm-mb-sub { font-size: 12px; line-height: 1.5; color: var(--h4-muted); margin: 4px 0 0; text-wrap: pretty; }
+
+/* ── money ──────────────────────────────────────────────────────────────── */
+.hm-mb-pool + .hm-mb-pool { margin-top: 11px; }
+.hm-mb-pool-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  margin-bottom: 4px;
+}
+.hm-mb-pool-row strong { font-weight: 500; color: var(--h4-ink); }
+.hm-mb-pool-row span { color: var(--h4-muted); text-align: right; }
+.hm-mb-awaiting { color: var(--h4-tel); }
+.hm-mb-bar { height: 6px; border-radius: 3px; background: var(--h4-line-2); overflow: hidden; }
+.hm-mb-bar-fill { display: block; height: 100%; border-radius: 3px; }
+.hm-mb-bar-fill--ok { background: var(--h4-ok); }
+.hm-mb-bar-fill--warn { background: var(--h4-warn); }
+.hm-mb-bar-fill--red { background: var(--h4-act); }
+.hm-mb-note {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--h4-faint);
+  margin: 9px 0 0;
+  text-wrap: pretty;
+}
+.hm-mb-empty { font-size: 12px; color: var(--h4-faint); margin: 0; }
+
+/* ── decisions ──────────────────────────────────────────────────────────── */
+.hm-mb-item { border-top: 1px solid var(--h4-line-2); padding-top: 10px; margin-top: 10px; }
+.hm-mb-item:first-of-type { border-top: 0; padding-top: 0; margin-top: 0; }
+.hm-mb-item-open {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 0;
+  padding: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+.hm-mb-item-title { display: block; font-size: 13px; line-height: 1.4; color: var(--h4-ink-2); }
+.hm-mb-item-meta {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--h4-faint);
+  margin-top: 3px;
+}
+.hm-mb-acts { display: flex; gap: 8px; margin-top: 10px; }
+.hm-mb-btn {
+  /* 44px min target — this is a thumb, and Approve is a real mutation. */
+  flex: 1;
+  min-height: 44px;
+  border-radius: 9px;
+  border: 1px solid var(--h4-line);
+  background: transparent;
+  color: var(--h4-ink-2);
+  font-family: var(--font-display);
+  font-size: 13px;
+  cursor: pointer;
+}
+.hm-mb-btn--primary { background: var(--h4-ok); border-color: var(--h4-ok); color: var(--h4-paper); font-weight: 700; }
+.hm-mb-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* ── agents ─────────────────────────────────────────────────────────────── */
+.hm-mb-agent { display: flex; align-items: center; gap: 9px; font-family: var(--font-mono); font-size: 11.5px; padding: 4px 0; }
+.hm-mb-jewel { width: 6px; height: 6px; border-radius: 50%; background: var(--h4-ag-system); flex: none; }
+.hm-mb-agent-name { color: var(--h4-ink-2); min-width: 58px; }
+.hm-mb-agent-state { color: var(--h4-faint); }
+
+.hm-mb-foot {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--h4-faint);
+  text-align: center;
+  padding: 4px 12px 18px;
+  margin: 0;
+}


### PR DESCRIPTION
The mobile surface, built to the mockup you approved. **Stacked on #571** — merge that first and this diff stays exactly the 6 files below.

## A dedicated surface, not a responsive squeeze

The top strip, lane grid and co-pilot rail are 1500px-canvas furniture. Compressed onto a phone they produce the kind of mobile ops view nobody actually opens. This replaces them with a single priority-ordered feed:

**is it fine → is the money fine → what needs me → who's working**

## Built to extend

Cards compose exactly like `OpsBoard` composes zones. Each is self-contained, owns its own truth-boundary, and returns `null` when it has nothing to say — so **a new feature is one component added to the list**, with no rework to its neighbours. That's the "room for further features down the line".

## It cannot drift from the desktop board

It renders the **same** `ProductHealth` + card payload and reuses the desktop's own derivations:

- **`opsBannerData()`** for the status card → a runway projection (`Signer gas ~13h to floor`) reaches the phone automatically, and the two surfaces can never disagree about what's wrong.
- **`isDecision()`** for the needs-you list → the same selector behind the desktop inbox and the "waiting on you" count.

No new backend, no parallel data path.

## Truth boundary
- `amount: null` → **"awaiting data"**, not a bar we can't justify.
- Informational pools (escrow) are context, not floored meters.
- Agents show only real `workingNow` — never inferred activity.

## Safety
Only **approve/dismiss of already-proposed work** is reachable. A non-proposed decision shows no Approve button, and the phone **never moves funds** — a prepare-only task stays prepare-only, the same money-rail boundary as desktop. 44px minimum touch targets, because Approve on a thumb is a real mutation.

Selection is additive: `useIsMobileViewport()` starts `false` and only flips in an effect, so anything without `matchMedia` (server render, unstubbed jsdom) keeps the desktop board untouched.

## Tests
+10 covering feed order, the runway reaching the phone, awaiting-data pools, informational exclusion, `isDecision` + the N-cap, approve/dismiss wiring, **no-approve on non-proposed**, tap-to-open, real-`workingNow`-only, and honest empty states.

`monitor-ui` **826 passed vs 812 on clean main** (+14 = 4 runway + 10 mobile) — the same 3 pre-existing Harness failures, **zero new**. tsc baseline unchanged (3, none in the new files). SPA build ✓ with the mobile CSS bundled.

## Not in v1 (deliberately)
Kanban, Trends/Incidents charts, LLM usage — desk work. The bottom-bar `+` slot is where the next card docks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)