### PR TITLE
feat(ops): prove rewards were PAID, not just marked settled

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -346,6 +346,19 @@ services:
       # Confirmed against the official docs and by live balanceOf calls (2026-07-25).
       PRODUCT_HEALTH_USDC_ADDRESS: ${PRODUCT_HEALTH_USDC_ADDRESS:-}
       PRODUCT_HEALTH_USDC_DECIMALS: ${PRODUCT_HEALTH_USDC_DECIMALS:-6}
+      # Payout evidence — proves jobs marked settled ACTUALLY PAID, by reading
+      # USDC Transfer logs from the signer. settled24h counts rows in the
+      # product's own DB; this counts money that moved, and the GAP between them
+      # is the signal (settled jobs with no transfer = a silent money failure).
+      # OFF by default: eth_getLogs is rate-limit sensitive (see the #564
+      # calibration). While off the block reads "unverified" — never a zero,
+      # which would look like nothing-paid.
+      PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED: ${PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED:-false}
+      # ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
+      PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS: ${PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS:-14400}
+      # settled-minus-confirmed gap tolerated as a window-boundary artifact — the
+      # product's rolling 24h and the block window don't share a clock.
+      PRODUCT_HEALTH_PAYOUT_TOLERANCE: ${PRODUCT_HEALTH_PAYOUT_TOLERANCE:-1}
       # Floors default to 0 = that probe can NEVER go red. Fine for a testnet, but
       # on a live network a 0 floor means no warning before you run dry. Mainnet
       # values in use (2026-07-25, sized off live balances): GAS_NATIVE=1 DOT (low

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -483,6 +483,13 @@ export interface ProductHealthConfig {
   signerAddress?: string;
   usdcAddress?: string;
   usdcDecimals: number;
+  /** Verify settled jobs against real on-chain transfers. OFF by default: the
+   *  log read is rate-limit sensitive, so the operator arms it deliberately. */
+  payoutEvidenceEnabled: boolean;
+  /** Blocks scanned for Transfer logs (~24h at the chain's block time). */
+  payoutLookbackBlocks: number;
+  /** Settled-minus-confirmed gap tolerated as a window-boundary artifact. */
+  payoutTolerance: number;
   /** Native-gas floor in whole tokens (e.g. 0.1 DOT). 0 = don't threshold. */
   minGasNative: number;
   /** capabilityHealth keys that MUST be up; one dropping ⇒ red. Env
@@ -518,6 +525,11 @@ export interface ProductHealthConfig {
 function num(value: unknown, fallback: number): number {
   const n = typeof value === "number" ? value : Number(value);
   return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+/** Opt-in switch, same spelling as OPS_AUTOREMEDIATE_ENABLED. */
+function truthy(value: string | undefined): boolean {
+  return (value ?? "").trim().toLowerCase() === "true";
 }
 
 function csv(value: string | undefined, fallback: string): string[] {
@@ -564,6 +576,10 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     signerAddress: env.PRODUCT_HEALTH_SIGNER_ADDRESS || undefined,
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
+    payoutEvidenceEnabled: truthy(env.PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED),
+    // ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
+    payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 14400),
+    payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
     minGasNative: num(env.PRODUCT_HEALTH_MIN_GAS_NATIVE, 0),
     requiredCapabilities: csv(env.PRODUCT_HEALTH_REQUIRED_CAPABILITIES, "blockchain,treasuryMutations"),
     expectedWarnings: csv(env.PRODUCT_HEALTH_EXPECTED_WARNINGS, "xcm_observer_staged,indexer_unavailable,gas_sponsor_disabled"),
@@ -970,6 +986,136 @@ async function ethRpc(
   return result;
 }
 
+// keccak256("Transfer(address,address,uint256)") — the ERC-20 Transfer topic.
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+/** Pad an address to a 32-byte topic (topic1 = indexed `from`). */
+function addressTopic(address: string): string {
+  return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+}
+
+/**
+ * The payout verdict. PURE — the tolerance reasoning is the delicate part, so
+ * it's testable without a chain.
+ *
+ * The two counts come from different clocks: `settled24h` is the product's
+ * rolling 24h, the log read is an approximate block window. A small mismatch is
+ * a boundary artifact, not a lost payout, so a shortfall inside `tolerance` is
+ * still "confirmed" — crying wolf on an off-by-one would train the operator to
+ * ignore the one that matters. A material shortfall is reported honestly but
+ * NOT as red: the window really is approximate, and "investigate" is the true
+ * instruction, not "settlement is down".
+ */
+export function decidePayoutEvidence(input: {
+  confirmedCount: number | null;
+  confirmedUsdc: number | null;
+  settledCount: number | null;
+  windowBlocks: number | null;
+  tolerance: number;
+  unverifiedReason?: string;
+}): PayoutEvidence {
+  const base = {
+    confirmedCount: input.confirmedCount,
+    confirmedUsdc: input.confirmedUsdc,
+    settledCount: input.settledCount,
+    windowBlocks: input.windowBlocks,
+  };
+  if (input.confirmedCount === null) {
+    return {
+      ...base,
+      status: "unverified",
+      detail: input.unverifiedReason ?? "payout evidence unverified",
+    };
+  }
+  const paid = `${input.confirmedCount} payout${input.confirmedCount === 1 ? "" : "s"} confirmed on-chain${
+    input.confirmedUsdc !== null ? ` (${input.confirmedUsdc.toFixed(2)} USDC)` : ""
+  }`;
+  if (input.settledCount === null) {
+    // Real evidence, nothing to compare it against — say exactly that.
+    return { ...base, status: "confirmed", detail: `${paid} · no settled count to compare` };
+  }
+  const shortfall = input.settledCount - input.confirmedCount;
+  if (shortfall > input.tolerance) {
+    return {
+      ...base,
+      status: "shortfall",
+      detail: `${input.settledCount} jobs marked settled but only ${paid} — ${shortfall} unaccounted for; windows are approximate, investigate`,
+    };
+  }
+  return { ...base, status: "confirmed", detail: `${paid} · ${input.settledCount} marked settled` };
+}
+
+/**
+ * Read USDC Transfer logs FROM the signer over a recent block window.
+ *
+ * Guarded the same way balances are (#543): logs are only trusted from an
+ * endpoint on the product's chain, because a wrong-chain endpoint would return
+ * a confident, wrong payout count. Any failure → null (unverified), never a
+ * zero that would read as "nothing paid".
+ */
+export async function readSignerPayouts(input: {
+  rpcUrl?: string;
+  signerAddress?: string;
+  usdcAddress?: string;
+  usdcDecimals: number;
+  lookbackBlocks: number;
+  expectedChainId?: number;
+  fetchImpl: typeof fetch;
+}): Promise<{ count: number | null; usdc: number | null; windowBlocks: number | null; reason?: string }> {
+  if (!input.rpcUrl || !input.signerAddress || !input.usdcAddress) {
+    return { count: null, usdc: null, windowBlocks: null, reason: "payout evidence not configured (RPC / signer / USDC address)" };
+  }
+  try {
+    if (input.expectedChainId !== undefined) {
+      const actual = Number(BigInt(await ethRpc(input.rpcUrl, "eth_chainId", [], input.fetchImpl)));
+      if (actual !== input.expectedChainId) {
+        return {
+          count: null, usdc: null, windowBlocks: null,
+          reason: `payout evidence unverified — RPC is on chain ${actual}, product is on ${input.expectedChainId}`,
+        };
+      }
+    }
+    const latest = Number(BigInt(await ethRpc(input.rpcUrl, "eth_blockNumber", [], input.fetchImpl)));
+    const fromBlock = Math.max(0, latest - input.lookbackBlocks);
+    const logs = await ethRpcRaw(
+      input.rpcUrl,
+      "eth_getLogs",
+      [{
+        fromBlock: `0x${fromBlock.toString(16)}`,
+        toBlock: "latest",
+        address: input.usdcAddress,
+        topics: [TRANSFER_TOPIC, addressTopic(input.signerAddress)],
+      }],
+      input.fetchImpl,
+    );
+    if (!Array.isArray(logs)) {
+      return { count: null, usdc: null, windowBlocks: null, reason: "payout evidence unverified — eth_getLogs returned no array" };
+    }
+    let total = 0n;
+    for (const entry of logs) {
+      const data = (entry as { data?: unknown }).data;
+      if (typeof data === "string" && data.length > 2) {
+        try {
+          total += BigInt(data);
+        } catch {
+          // A malformed value is not a reason to under-report the count.
+        }
+      }
+    }
+    return {
+      count: logs.length,
+      usdc: Number(total) / 10 ** input.usdcDecimals,
+      windowBlocks: latest - fromBlock,
+    };
+  } catch (error) {
+    // Rate limit, capped range, dead endpoint — all unverified, never "0 paid".
+    return {
+      count: null, usdc: null, windowBlocks: null,
+      reason: `payout evidence unverified — log read failed (${error instanceof Error ? error.message : String(error)})`,
+    };
+  }
+}
+
 // erc20 balanceOf(address) selector.
 const BALANCE_OF_SELECTOR = "0x70a08231";
 
@@ -1238,7 +1384,36 @@ export interface MoneyPathData {
   stuck?: number | null;
   failed24h?: number | null;
   asOf?: number | null;
+  /** Independent on-chain proof that the settled jobs actually PAID. */
+  payout?: PayoutEvidence;
 }
+
+/**
+ * Evidence that rewards were actually PAID, not merely marked settled.
+ *
+ * `settled24h` and friends are job-state counts from the product's own
+ * database — "13 rows say settled". That is not proof any money moved. This
+ * reads USDC Transfer logs FROM the signer straight off the chain, so the two
+ * numbers come from independent sources, and THE DISCREPANCY IS THE SIGNAL:
+ * matching → genuinely paid; fewer transfers than settled jobs → jobs marked
+ * settled that never paid, which nothing else on the board can currently see.
+ *
+ * `confirmedCount: null` means UNVERIFIED (disabled, unconfigured, or the log
+ * read failed). It never falls back to inferring payment from job state.
+ */
+export interface PayoutEvidence {
+  status: "confirmed" | "shortfall" | "unverified";
+  detail: string;
+  /** Transfers observed on-chain in the window; null = unverified. */
+  confirmedCount: number | null;
+  /** Summed USDC actually transferred; null = unverified. */
+  confirmedUsdc: number | null;
+  /** The product's own settled count, for the comparison. */
+  settledCount: number | null;
+  /** Blocks scanned. The window is approximate — the verdict allows for it. */
+  windowBlocks: number | null;
+}
+
 export interface ProductHealthSnapshotBlocks {
   chainId?: number | null;
   network?: "testnet" | "mainnet" | "unknown";
@@ -1375,6 +1550,28 @@ export async function collectProductHealthProbes(
     ).values(),
   ];
   const settlement = h.body?.settlement;
+  // Independent proof that the settled jobs actually PAID. Opt-in: the log read
+  // is rate-limit sensitive, so while it's off the block stays honestly
+  // "unverified" rather than reporting a zero that would read as nothing-paid.
+  const payoutRead = config.payoutEvidenceEnabled
+    ? await readSignerPayouts({
+        rpcUrl: config.rpcUrl,
+        signerAddress: config.signerAddress,
+        usdcAddress: config.usdcAddress,
+        usdcDecimals: config.usdcDecimals,
+        lookbackBlocks: config.payoutLookbackBlocks,
+        expectedChainId: chainId,
+        fetchImpl,
+      })
+    : { count: null, usdc: null, windowBlocks: null, reason: "payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)" };
+  const payout = decidePayoutEvidence({
+    confirmedCount: payoutRead.count,
+    confirmedUsdc: payoutRead.usdc,
+    settledCount: settlement?.settled24h ?? null,
+    windowBlocks: payoutRead.windowBlocks,
+    tolerance: config.payoutTolerance,
+    ...(payoutRead.reason ? { unverifiedReason: payoutRead.reason } : {}),
+  });
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,
     network: resolveProductHealthNetwork(chainId),
@@ -1390,6 +1587,7 @@ export async function collectProductHealthProbes(
             stuck: settlement.stuck ?? null,
             failed24h: settlement.failed24h ?? null,
             asOf: parseHealthAsOf(settlement.asOf),
+            payout,
           },
         }
       : {}),

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -13,6 +13,8 @@ import {
   trackChainAdvance,
   chainHaltStatus,
   probeSignerLiquidity,
+  decidePayoutEvidence,
+  readSignerPayouts,
   collectProductHealthProbes,
   chainBlockAge,
   decideProductHealthAlert,
@@ -1408,5 +1410,97 @@ describe("buildRunwayAlertPayload", () => {
     const p = buildRunwayAlertPayload(runway, "https://board");
     expect(p.count).toBe(1);
     expect(p.items[0].id).toBe("runway-signer_gas");
+  });
+});
+
+// ── payout evidence ────────────────────────────────────────────────────────
+// `settled24h` counts rows in the product's DB. These prove money actually
+// moved, and the DISCREPANCY between the two is the signal.
+describe("decidePayoutEvidence (pure verdict)", () => {
+  const base = { windowBlocks: 14400, tolerance: 1 };
+
+  it("confirmed when on-chain transfers match the settled count", () => {
+    const r = decidePayoutEvidence({ ...base, confirmedCount: 13, confirmedUsdc: 4.2, settledCount: 13 });
+    expect(r.status).toBe("confirmed");
+    expect(r.detail).toContain("13 payouts confirmed on-chain");
+    expect(r.detail).toContain("4.20 USDC");
+  });
+
+  it("SHORTFALL when jobs are marked settled but the money never moved", () => {
+    // The failure nothing else on the board can see today.
+    const r = decidePayoutEvidence({ ...base, confirmedCount: 9, confirmedUsdc: 2.7, settledCount: 13 });
+    expect(r.status).toBe("shortfall");
+    expect(r.detail).toContain("13 jobs marked settled");
+    expect(r.detail).toContain("4 unaccounted for");
+    expect(r.detail).toContain("investigate");
+  });
+
+  it("tolerates a 1-job gap — the two windows have different clocks", () => {
+    // settled24h is a rolling 24h; the log read is an approximate block window.
+    // Crying wolf on a boundary artifact trains the operator to ignore the real one.
+    const r = decidePayoutEvidence({ ...base, confirmedCount: 12, confirmedUsdc: 3.6, settledCount: 13 });
+    expect(r.status).toBe("confirmed");
+  });
+
+  it("more transfers than settled jobs is never a shortfall", () => {
+    expect(decidePayoutEvidence({ ...base, confirmedCount: 20, confirmedUsdc: 6, settledCount: 13 }).status).toBe("confirmed");
+  });
+
+  it("UNVERIFIED (never 'nothing paid') when the read failed or is off", () => {
+    const r = decidePayoutEvidence({
+      ...base, confirmedCount: null, confirmedUsdc: null, settledCount: 13, windowBlocks: null,
+      unverifiedReason: "payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)",
+    });
+    expect(r.status).toBe("unverified");
+    expect(r.detail).toContain("PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED");
+    expect(r.confirmedCount).toBeNull(); // never 0 — 0 would read as "nothing paid"
+  });
+
+  it("reports real evidence even with nothing to compare against", () => {
+    const r = decidePayoutEvidence({ ...base, confirmedCount: 3, confirmedUsdc: 1.5, settledCount: null });
+    expect(r.status).toBe("confirmed");
+    expect(r.detail).toContain("no settled count to compare");
+  });
+});
+
+describe("readSignerPayouts (chain-guarded log read)", () => {
+  const cfg = {
+    rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc",
+    usdcDecimals: 6, lookbackBlocks: 100,
+  };
+  // eth_chainId → chain, eth_blockNumber → height, eth_getLogs → transfers.
+  function rpc(chainIdHex: string, logs: unknown): typeof fetch {
+    return (async (_u: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const m = rpcMethod(init ?? {});
+      const result = m === "eth_chainId" ? chainIdHex : m === "eth_blockNumber" ? "0x3e8" : logs;
+      return { ok: true, status: 200, json: async () => ({ result }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("counts transfers and sums the USDC actually moved", async () => {
+    const logs = [{ data: "0xf4240" }, { data: "0x1e8480" }]; // 1 + 2 USDC
+    const r = await readSignerPayouts({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", logs) });
+    expect(r.count).toBe(2);
+    expect(r.usdc).toBeCloseTo(3, 6);
+    expect(r.windowBlocks).toBe(100);
+  });
+
+  it("refuses logs from the WRONG CHAIN — same guard as balances (#543)", async () => {
+    const logs = [{ data: "0xf4240" }];
+    const r = await readSignerPayouts({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b41", logs) });
+    expect(r.count).toBeNull(); // a wrong-chain payout count would be confidently wrong
+    expect(r.reason).toContain("chain 420420417");
+  });
+
+  it("a failed/rate-limited read is unverified, never zero", async () => {
+    const r = await readSignerPayouts({ ...cfg, fetchImpl: throwingFetch() });
+    expect(r.count).toBeNull();
+    expect(r.reason).toContain("log read failed");
+  });
+
+  it("unconfigured is unverified too", async () => {
+    const r = await readSignerPayouts({ ...cfg, usdcAddress: undefined, fetchImpl: rpc("0x190f1b43", []) });
+    expect(r.count).toBeNull();
+    expect(r.reason).toContain("not configured");
   });
 });


### PR DESCRIPTION
## The gap

*"Did the reward actually get paid?"* has had **no honest answer** on either board.

The money pillar reports `settled24h 13 (0 stuck, 0 failed)`. Those are **job-state counts from the product's own database** — thirteen rows say `settled`. Nothing in the monitor observed a transfer: no tx, no amount, no confirmation.

So the board reads *"money moved 13 times"* while only proving *"13 rows say settled."* Same family as the balance bug #543 fixed — a confident green sourced from something other than the thing being claimed.

## The check

Uses config the monitor **already holds** (`PRODUCT_HEALTH_RPC_URL` + `SIGNER_ADDRESS` + `USDC_ADDRESS`) — no new infrastructure, no indexer dependency. Reads USDC `Transfer` logs **from the signer** and counts what actually moved.

**The discrepancy is the signal, not either number alone:**

| | |
|---|---|
| 13 settled ≈ 13 transfers | genuinely paid ✓ |
| 13 settled, **9 transfers** | **four jobs marked settled that never paid** |

That second row is a silent money failure, and today nothing on either board can see it.

## Design

- **`decidePayoutEvidence()` is pure.** The tolerance reasoning is the delicate part, so it's testable without a chain.
- **Boundary tolerance.** The counts run on different clocks — the product's rolling 24h vs an approximate block window — so a gap inside `tolerance` stays `confirmed`. Crying wolf on an off-by-one would train the operator to ignore the one that matters.
- **A shortfall is reported, not paged.** It's `shortfall`, not red: the window really is approximate, so *"investigate"* is the true instruction, not *"settlement is down"*.
- **Chain-guarded like balances (#543)** — logs are only trusted from an endpoint on the product's chain, since a wrong-chain endpoint returns a confidently wrong payout count.
- **Never infers payment from job state.** Disabled / unconfigured / rate-limited / failed all resolve to `confirmedCount: null` → **"unverified"**, never `0` (which would read as *nothing paid*).
- **OFF by default.** `eth_getLogs` is rate-limit sensitive per the #564 calibration, so the operator arms it deliberately — same pattern as `OPS_AUTOREMEDIATE_ENABLED`.

## Scope
Backend only. The board + mobile surfacing follows once it's armed and we know what the real numbers look like — I'd rather see live output before designing around a shape I guessed.

## Tests
+13: match, shortfall, boundary tolerance, over-count, unverified-not-zero, no-comparison-available, log summing, **wrong-chain refusal**, failed read, unconfigured.

`product-health` **130/130**. Full unit suite: **110 pre-existing failures on current main, identical here, +10 passing → zero new** (re-baselined against today's main, not the stale count from earlier in the week). slack-operator `tsc` **49 on current main, 49 here**, none in `product-health.ts`.

## To arm
```
PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true
```
Optionally lower `PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS` (default 14400 ≈ 24h) if the RPC caps log ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)