### PR TITLE
fix(ops): remember incidents past the sample buffer and past a redeploy

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -353,6 +353,11 @@ services:
       # OFF by default: eth_getLogs is rate-limit sensitive (see the #564
       # calibration). While off the block reads "unverified" — never a zero,
       # which would look like nothing-paid.
+      # Durable incident memory. Incidents used to be DERIVED from the 60-slot
+      # sample ring, so one aged out after ~5h and became unrecoverable. This log
+      # keeps the records themselves; /data is a volume, so they survive the
+      # redeploys that would wipe any in-memory retention.
+      PRODUCT_HEALTH_INCIDENT_LOG_PATH: ${PRODUCT_HEALTH_INCIDENT_LOG_PATH:-/data/product-health-incidents.jsonl}
       PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED: ${PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED:-false}
       # ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
       PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS: ${PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS:-14400}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -181,9 +181,11 @@ import {
   probeSparkline,
   runProductHealthOnce,
   type ChainAdvance,
+  type ProductHealthIncident,
   type ProductHealthSnapshot,
   type ProductHealthSnapshotBlocks,
 } from "./product-health.js";
+import { appendIncidents, readIncidents, reconcileIncidents } from "./product-health-incidents.js";
 import {
   loadRemediationConfig,
   decideRpcRemediation,
@@ -291,6 +293,11 @@ const routineConfig = parseSlackRoutineConfig(process.env, authConfig.allowedCha
 // Resets on restart; a monitoring sparkline doesn't need durability.
 const PRODUCT_HEALTH_HISTORY_MAX = 60;
 let productHealthHistory: ProductHealthSnapshot[] = [];
+/** Durable incident memory — outlives both the sample ring and a redeploy.
+ *  Hydrated from disk on the first health tick. */
+let productHealthIncidents: ProductHealthIncident[] = [];
+let productHealthIncidentsHydrated = false;
+const PRODUCT_HEALTH_INCIDENT_MAX = 200;
 // Block-advance tracker so a frozen chain (static height) isn't read as green.
 let productHealthChainAdvance: ChainAdvance | undefined;
 // Structured snapshot blocks (chain id / network / solvency / flow) for the Ops board.
@@ -755,7 +762,13 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       // History-derived Trends + Incidents (uptime% / latency / balance series +
       // incident episodes) from the rolling buffer. Always present — the series
       // are honestly short and uptimePct24h is null until a check lands in-window.
-      history: deriveProductHealthHistory(productHealthHistory, Date.now()),
+      // Incidents come from the DURABLE log, not just this buffer: an incident
+      // whose samples aged out (or that predates a deploy) must still be
+      // investigable. See product-health-incidents.ts.
+      history: {
+        ...deriveProductHealthHistory(productHealthHistory, Date.now()),
+        incidents: productHealthIncidents,
+      },
       // RPC auto-remediation status for the Ops "RPC failover" row (undefined =
       // omitted by JSON when the routine hasn't run a cycle yet).
       remediation: productHealthRemediation,
@@ -3562,6 +3575,28 @@ function startOperatorRoutines() {
         },
         PRODUCT_HEALTH_HISTORY_MAX,
       );
+      // Durable incidents: reconcile what this buffer currently derives against
+      // the persisted log, then write only what changed. Without this, an
+      // incident vanished once its samples aged out of the ring — a real 10.2s
+      // /health spike was detected, shown, and then unrecoverable ~5h later.
+      try {
+        if (!productHealthIncidentsHydrated) {
+          productHealthIncidents = await readIncidents();
+          productHealthIncidentsHydrated = true;
+        }
+        const derived = deriveProductHealthHistory(productHealthHistory, Date.now()).incidents;
+        const reconciled = reconcileIncidents({
+          persisted: productHealthIncidents,
+          derived,
+          limit: PRODUCT_HEALTH_INCIDENT_MAX,
+        });
+        productHealthIncidents = reconciled.merged;
+        await appendIncidents(reconciled.writes);
+      } catch (error) {
+        // Incident memory is forensics, not a probe — a write failure must never
+        // take down the health tick that the alert bridge depends on.
+        logger.warn({ err: error }, "product_health_incident_log_skipped");
+      }
       // Liquidity runway: project time-to-floor from the balance series (incl. the
       // sample just appended) and write the honest note into the solvency block —
       // "reward bank ≈ 6h to floor" / "stable" / awaiting. Suggest-only: the board

--- a/services/slack-operator/src/product-health-incidents.ts
+++ b/services/slack-operator/src/product-health-incidents.ts
@@ -1,0 +1,129 @@
+// Durable incident memory for the product-health monitor.
+//
+// WHY THIS EXISTS: incidents used to be DERIVED from the rolling sample buffer
+// (`deriveIncidents(history)` over a 60-slot ring). When a sample aged out, the
+// incident computed from it ceased to exist — so at the 5-minute cadence Hermes
+// forgot everything older than ~5 hours. A real 10.2s /health spike on
+// 2026-07-28 was detected, displayed, and then evaporated before it could be
+// investigated. An incident you can't look up after the fact is an incident the
+// monitor didn't really record.
+//
+// The sample ring stays as-is (it drives sparklines/trends and must stay bounded).
+// This adds a separate append-only JSONL log of incident RECORDS — a few fields
+// each — mirroring the LLM-usage log. It survives restarts, which matters
+// because the slack-operator restarts on every deploy: in-memory retention would
+// still lose the overnight incident whenever a deploy landed before anyone looked.
+//
+// Append-only with last-write-wins per id: an incident is written when it opens
+// and rewritten when it closes, so a crash mid-run can never corrupt earlier
+// records — the worst case is an incident that stays open until the next tick
+// reconciles it.
+
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { ProductHealthIncident } from "./product-health.js";
+
+const DEFAULT_INCIDENT_LOG_PATH = "/data/product-health-incidents.jsonl";
+
+export function incidentLogPath(env: NodeJS.ProcessEnv = process.env): string {
+  return env.PRODUCT_HEALTH_INCIDENT_LOG_PATH?.trim() || DEFAULT_INCIDENT_LOG_PATH;
+}
+
+/**
+ * Merge freshly-derived incidents into the persisted set. PURE — the
+ * last-write-wins reasoning is the part worth testing without a filesystem.
+ *
+ * Returns the full merged view (newest first, capped) plus only the records
+ * that actually need writing, so a steady state writes nothing.
+ */
+export function reconcileIncidents(input: {
+  persisted: readonly ProductHealthIncident[];
+  derived: readonly ProductHealthIncident[];
+  limit: number;
+}): { merged: ProductHealthIncident[]; writes: ProductHealthIncident[] } {
+  const byId = new Map<string, ProductHealthIncident>();
+  for (const incident of input.persisted) byId.set(incident.id, incident);
+
+  const writes: ProductHealthIncident[] = [];
+  for (const incident of input.derived) {
+    const existing = byId.get(incident.id);
+    // New incident, or one that changed state (usually open → closed). Comparing
+    // the whole record also catches a note that sharpened as the run went on.
+    if (!existing || !sameIncident(existing, incident)) {
+      writes.push(incident);
+      byId.set(incident.id, incident);
+    }
+  }
+
+  const merged = [...byId.values()]
+    .sort((a, b) => b.startedAt - a.startedAt)
+    .slice(0, input.limit);
+  return { merged, writes };
+}
+
+function sameIncident(a: ProductHealthIncident, b: ProductHealthIncident): boolean {
+  return (
+    a.severity === b.severity &&
+    a.startedAt === b.startedAt &&
+    (a.endedAt ?? null) === (b.endedAt ?? null) &&
+    (a.note ?? "") === (b.note ?? "")
+  );
+}
+
+/**
+ * Read the incident log, collapsing by id so the last record for an id wins
+ * (that's how a close supersedes the open). A missing file is an empty history,
+ * not an error — the first run has nothing to read.
+ */
+export async function readIncidents(path: string = incidentLogPath()): Promise<ProductHealthIncident[]> {
+  let content: string;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as { code?: string } | null)?.code === "ENOENT") return [];
+    throw error;
+  }
+  const byId = new Map<string, ProductHealthIncident>();
+  for (const line of content.split(/\r?\n/)) {
+    const parsed = parseIncidentLine(line);
+    if (parsed) byId.set(parsed.id, parsed);
+  }
+  return [...byId.values()].sort((a, b) => b.startedAt - a.startedAt);
+}
+
+export async function appendIncidents(
+  incidents: readonly ProductHealthIncident[],
+  options: { path?: string } = {},
+): Promise<void> {
+  if (incidents.length === 0) return;
+  const path = options.path ?? incidentLogPath();
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, incidents.map((i) => `${JSON.stringify(i)}\n`).join(""), "utf8");
+}
+
+/** A malformed line is skipped, never thrown — one bad write can't blind the log. */
+function parseIncidentLine(line: string): ProductHealthIncident | undefined {
+  const trimmed = line.trim();
+  if (!trimmed) return undefined;
+  try {
+    const value: unknown = JSON.parse(trimmed);
+    if (typeof value !== "object" || value === null) return undefined;
+    const record = value as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : "";
+    const probe = typeof record.probe === "string" ? record.probe : "";
+    const severity = record.severity === "red" || record.severity === "degraded" ? record.severity : undefined;
+    const startedAt = typeof record.startedAt === "number" && Number.isFinite(record.startedAt) ? record.startedAt : undefined;
+    if (!id || !probe || !severity || startedAt === undefined) return undefined;
+    const endedAt = typeof record.endedAt === "number" && Number.isFinite(record.endedAt) ? record.endedAt : null;
+    return {
+      id,
+      probe,
+      severity,
+      startedAt,
+      endedAt,
+      ...(typeof record.note === "string" && record.note ? { note: record.note } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/test/unit/product-health-incidents.test.ts
+++ b/test/unit/product-health-incidents.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  appendIncidents,
+  incidentLogPath,
+  readIncidents,
+  reconcileIncidents,
+} from "../../services/slack-operator/src/product-health-incidents.js";
+import type { ProductHealthIncident } from "../../services/slack-operator/src/product-health.js";
+
+function incident(over: Partial<ProductHealthIncident> = {}): ProductHealthIncident {
+  return {
+    id: "api_latency-1000",
+    probe: "api_latency",
+    severity: "red",
+    startedAt: 1000,
+    endedAt: null,
+    note: "/health 10212ms (> 10000ms)",
+    ...over,
+  };
+}
+
+async function tmpLog(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "hermes-incidents-"));
+  return join(dir, "incidents.jsonl");
+}
+
+describe("reconcileIncidents (pure)", () => {
+  it("writes a newly opened incident", () => {
+    const r = reconcileIncidents({ persisted: [], derived: [incident()], limit: 50 });
+    expect(r.writes).toHaveLength(1);
+    expect(r.merged).toHaveLength(1);
+  });
+
+  it("writes again when an open incident closes (last-write-wins on the id)", () => {
+    const open = incident();
+    const closed = incident({ endedAt: 2000 });
+    const r = reconcileIncidents({ persisted: [open], derived: [closed], limit: 50 });
+    expect(r.writes).toEqual([closed]);
+    expect(r.merged[0]!.endedAt).toBe(2000); // the close supersedes the open
+  });
+
+  it("writes NOTHING in a steady state — no churn on an unchanged incident", () => {
+    const same = incident();
+    expect(reconcileIncidents({ persisted: [same], derived: [same], limit: 50 }).writes).toHaveLength(0);
+  });
+
+  it("KEEPS an incident the sample ring has already forgotten — the whole point", () => {
+    // The 2026-07-28 latency spike: aged out of the 60-slot buffer, so it is no
+    // longer derived. It must survive anyway, or it can never be investigated.
+    const old = incident({ id: "api_latency-1", startedAt: 1, endedAt: 2 });
+    const r = reconcileIncidents({ persisted: [old], derived: [], limit: 50 });
+    expect(r.merged).toEqual([old]);
+    expect(r.writes).toHaveLength(0); // retained without rewriting
+  });
+
+  it("orders newest first and caps at the limit", () => {
+    const persisted = Array.from({ length: 5 }, (_, i) => incident({ id: `i${i}`, startedAt: i * 100 }));
+    const r = reconcileIncidents({ persisted, derived: [], limit: 3 });
+    expect(r.merged.map((i) => i.startedAt)).toEqual([400, 300, 200]);
+  });
+
+  it("a sharpened note counts as a change worth persisting", () => {
+    const r = reconcileIncidents({
+      persisted: [incident({ note: "slow" })],
+      derived: [incident({ note: "/health 10212ms (> 10000ms)" })],
+      limit: 50,
+    });
+    expect(r.writes).toHaveLength(1);
+  });
+});
+
+describe("incident log I/O", () => {
+  it("round-trips, and a later record for an id supersedes the earlier one", async () => {
+    const path = await tmpLog();
+    await appendIncidents([incident()], { path });
+    await appendIncidents([incident({ endedAt: 2000 })], { path });
+    const read = await readIncidents(path);
+    expect(read).toHaveLength(1); // collapsed by id
+    expect(read[0]!.endedAt).toBe(2000); // the close won
+  });
+
+  it("survives a restart — that's why this is on disk and not in memory", async () => {
+    const path = await tmpLog();
+    await appendIncidents([incident({ id: "a", startedAt: 10 }), incident({ id: "b", startedAt: 20 })], { path });
+    // A fresh process reads the same file; the slack-operator restarts on every deploy.
+    expect((await readIncidents(path)).map((i) => i.id)).toEqual(["b", "a"]);
+  });
+
+  it("a missing log is an empty history, not an error", async () => {
+    expect(await readIncidents(join(tmpdir(), "hermes-does-not-exist", "nope.jsonl"))).toEqual([]);
+  });
+
+  it("skips malformed lines instead of blinding the whole log", async () => {
+    const path = await tmpLog();
+    await writeFile(path, `not json\n${JSON.stringify(incident({ id: "good" }))}\n{"id":"partial"}\n`, "utf8");
+    const read = await readIncidents(path);
+    expect(read.map((i) => i.id)).toEqual(["good"]);
+  });
+
+  it("appending nothing writes nothing (no empty-file churn)", async () => {
+    const path = await tmpLog();
+    await appendIncidents([], { path });
+    await expect(readFile(path, "utf8")).rejects.toThrow();
+  });
+
+  it("path comes from env, with a /data default that outlives the container", () => {
+    expect(incidentLogPath({} as NodeJS.ProcessEnv)).toBe("/data/product-health-incidents.jsonl");
+    expect(incidentLogPath({ PRODUCT_HEALTH_INCIDENT_LOG_PATH: "/x/y.jsonl" } as NodeJS.ProcessEnv)).toBe("/x/y.jsonl");
+  });
+});


### PR DESCRIPTION
Investigating the 2026-07-28 `/health` latency spike (10,212ms, over the 10s red threshold) turned up something worse than the spike itself: **it was gone.** Not resolved — *unrecoverable*. `incidents: []`, no trace in the latency series.

## Cause: incidents were derived, never retained

```
index.ts:292            PRODUCT_HEALTH_HISTORY_MAX = 60      ← bounded sample ring
product-health.ts:180   incidents: deriveIncidents(history)  ← recomputed from it every tick
```

The moment a sample aged out of the ring, the incident computed from it ceased to exist. At the post-#564 five-minute cadence that's a **~5 hour memory**. Hermes could not investigate anything it hadn't caught live — which is precisely what happened here.

## Fix

The sample ring stays bounded (it drives sparklines/trends and should). This adds a separate **append-only JSONL log of incident records** — a handful of fields each — mirroring the LLM-usage log. Reconciled each tick, written **only on change**, so a steady state writes nothing.

**On disk, not in memory**, per your call — and it matters concretely: the slack-operator restarts on every deploy, and you deploy often, so in-memory retention would still lose the 3am incident whenever a deploy landed before you looked. It writes to `/data/product-health-incidents.jsonl`, and I verified `/data` is the named `avg-data` volume, so records genuinely outlive the container.

## Design
- **`reconcileIncidents()` is pure** — the last-write-wins reasoning is the part worth testing without a filesystem.
- **Append-only, last-write-wins per id**: written when an incident opens, rewritten when it closes. A crash mid-run can't corrupt earlier records; worst case is one left open until the next tick reconciles it.
- A **malformed line is skipped, never thrown** — one bad write can't blind the log.
- A **missing file is an empty history**, not an error.
- The whole block is `try`/caught: incident memory is *forensics, not a probe*, and must never take down the health tick the alert bridge depends on.

## Also from the investigation (both benign — recording so they're not mistaken for problems later)
- **Current latency is healthy**: p50 45ms, p90 159ms, max 291ms, **zero** samples over the 2s warn threshold, uptime 100%.
- The series is cleanly **bimodal** — ~15-25ms alternating with ~130-290ms — consistent with alternating cache-hit/miss rather than instability.

## Tests
+12: new/close/steady-state write behaviour, **retention of an incident the ring has already forgotten** (the whole point), ordering + cap, note sharpening, round-trip, **restart survival**, missing file, malformed lines, empty append, env path.

Full unit suite: **110 pre-existing failures at this branch's base, identical here, +12 passing → zero new.** slack-operator `tsc` **49 at base, 49 here**, none in the new files.

Closes the investigation properly: next time something spikes overnight, it'll still be there in the morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)