### PR TITLE
fix(ops): payout evidence watched the wrong address and cried wolf

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -360,6 +360,12 @@ services:
       PRODUCT_HEALTH_INCIDENT_LOG_PATH: ${PRODUCT_HEALTH_INCIDENT_LOG_PATH:-/data/product-health-incidents.jsonl}
       PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED: ${PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED:-false}
       # ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
+      # The address USDC actually LEAVES on a payout. Defaults to /health's
+      # addresses.agentAccountCore — the reward bank is an IN-CONTRACT position,
+      # so the signer EOA only sends the tx and pays gas; it is never the
+      # Transfer `from`. Filtering on the signer finds zero and looks exactly
+      # like total payout failure (it did, on the first live run).
+      PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS: ${PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS:-}
       PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS: ${PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS:-14400}
       # settled-minus-confirmed gap tolerated as a window-boundary artifact — the
       # product's rolling 24h and the block window don't share a clock.

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -486,6 +486,9 @@ export interface ProductHealthConfig {
   /** Verify settled jobs against real on-chain transfers. OFF by default: the
    *  log read is rate-limit sensitive, so the operator arms it deliberately. */
   payoutEvidenceEnabled: boolean;
+  /** Override the payout SOURCE address. Defaults to /health's
+   *  addresses.agentAccountCore — the contract USDC actually leaves. */
+  payoutSourceAddress?: string;
   /** Blocks scanned for Transfer logs (~24h at the chain's block time). */
   payoutLookbackBlocks: number;
   /** Settled-minus-confirmed gap tolerated as a window-boundary artifact. */
@@ -577,6 +580,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
     payoutEvidenceEnabled: truthy(env.PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED),
+    payoutSourceAddress: env.PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS || undefined,
     // ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
     payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 14400),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
@@ -1034,6 +1038,20 @@ export function decidePayoutEvidence(input: {
     // Real evidence, nothing to compare it against — say exactly that.
     return { ...base, status: "confirmed", detail: `${paid} · no settled count to compare` };
   }
+  // A 100% miss is overwhelmingly a MISCONFIGURED FILTER, not 100% payout
+  // failure: point this at the wrong source address and you observe exactly
+  // zero transfers, which is indistinguishable from total failure. That is not
+  // hypothetical — the first live run watched the signer EOA instead of
+  // AgentAccountCore and put "12 unaccounted for" on a live money board.
+  // Refuse to accuse the money until the instrument has proven it can see
+  // anything at all; one observed transfer is enough to trust it.
+  if (input.confirmedCount === 0) {
+    return {
+      ...base,
+      status: "unverified",
+      detail: `no transfers found from the configured payout source while ${input.settledCount} job${input.settledCount === 1 ? " is" : "s are"} marked settled — check the source address before suspecting the payouts`,
+    };
+  }
   const shortfall = input.settledCount - input.confirmedCount;
   if (shortfall > input.tolerance) {
     return {
@@ -1053,17 +1071,30 @@ export function decidePayoutEvidence(input: {
  * a confident, wrong payout count. Any failure → null (unverified), never a
  * zero that would read as "nothing paid".
  */
-export async function readSignerPayouts(input: {
+export async function readPayoutTransfers(input: {
   rpcUrl?: string;
-  signerAddress?: string;
+  /**
+   * The address USDC actually LEAVES on a payout — AgentAccountCore, not the
+   * signer EOA. The reward bank is an in-contract position (see #558), so the
+   * signer merely SENDS the transaction and pays the gas; the Transfer event's
+   * `from` is the contract holding the funds. Filtering on the signer finds
+   * nothing and looks exactly like total payout failure — which is precisely
+   * what it did on the first live run (12 settled, 0 found).
+   */
+  sourceAddress?: string;
   usdcAddress?: string;
   usdcDecimals: number;
   lookbackBlocks: number;
   expectedChainId?: number;
   fetchImpl: typeof fetch;
 }): Promise<{ count: number | null; usdc: number | null; windowBlocks: number | null; reason?: string }> {
-  if (!input.rpcUrl || !input.signerAddress || !input.usdcAddress) {
-    return { count: null, usdc: null, windowBlocks: null, reason: "payout evidence not configured (RPC / signer / USDC address)" };
+  if (!input.rpcUrl || !input.sourceAddress || !input.usdcAddress) {
+    return {
+      count: null, usdc: null, windowBlocks: null,
+      reason: !input.sourceAddress
+        ? "payout evidence not configured — no payout source address (/health addresses.agentAccountCore, or PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS)"
+        : "payout evidence not configured (RPC / USDC address)",
+    };
   }
   try {
     if (input.expectedChainId !== undefined) {
@@ -1084,7 +1115,7 @@ export async function readSignerPayouts(input: {
         fromBlock: `0x${fromBlock.toString(16)}`,
         toBlock: "latest",
         address: input.usdcAddress,
-        topics: [TRANSFER_TOPIC, addressTopic(input.signerAddress)],
+        topics: [TRANSFER_TOPIC, addressTopic(input.sourceAddress)],
       }],
       input.fetchImpl,
     );
@@ -1554,9 +1585,11 @@ export async function collectProductHealthProbes(
   // is rate-limit sensitive, so while it's off the block stays honestly
   // "unverified" rather than reporting a zero that would read as nothing-paid.
   const payoutRead = config.payoutEvidenceEnabled
-    ? await readSignerPayouts({
+    ? await readPayoutTransfers({
         rpcUrl: config.rpcUrl,
-        signerAddress: config.signerAddress,
+        // USDC leaves AgentAccountCore, not the signer EOA — the reward bank is
+        // an in-contract position and the signer only sends the tx (#558).
+        sourceAddress: config.payoutSourceAddress || h.body?.addresses?.agentAccountCore,
         usdcAddress: config.usdcAddress,
         usdcDecimals: config.usdcDecimals,
         lookbackBlocks: config.payoutLookbackBlocks,

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -14,7 +14,7 @@ import {
   chainHaltStatus,
   probeSignerLiquidity,
   decidePayoutEvidence,
-  readSignerPayouts,
+  readPayoutTransfers,
   collectProductHealthProbes,
   chainBlockAge,
   decideProductHealthAlert,
@@ -1463,9 +1463,9 @@ describe("decidePayoutEvidence (pure verdict)", () => {
   });
 });
 
-describe("readSignerPayouts (chain-guarded log read)", () => {
+describe("readPayoutTransfers (chain-guarded log read)", () => {
   const cfg = {
-    rpcUrl: "http://rpc", signerAddress: "0xabc", usdcAddress: "0xusdc",
+    rpcUrl: "http://rpc", sourceAddress: "0xaac", usdcAddress: "0xusdc",
     usdcDecimals: 6, lookbackBlocks: 100,
   };
   // eth_chainId → chain, eth_blockNumber → height, eth_getLogs → transfers.
@@ -1479,7 +1479,7 @@ describe("readSignerPayouts (chain-guarded log read)", () => {
 
   it("counts transfers and sums the USDC actually moved", async () => {
     const logs = [{ data: "0xf4240" }, { data: "0x1e8480" }]; // 1 + 2 USDC
-    const r = await readSignerPayouts({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", logs) });
+    const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", logs) });
     expect(r.count).toBe(2);
     expect(r.usdc).toBeCloseTo(3, 6);
     expect(r.windowBlocks).toBe(100);
@@ -1487,20 +1487,50 @@ describe("readSignerPayouts (chain-guarded log read)", () => {
 
   it("refuses logs from the WRONG CHAIN — same guard as balances (#543)", async () => {
     const logs = [{ data: "0xf4240" }];
-    const r = await readSignerPayouts({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b41", logs) });
+    const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b41", logs) });
     expect(r.count).toBeNull(); // a wrong-chain payout count would be confidently wrong
     expect(r.reason).toContain("chain 420420417");
   });
 
   it("a failed/rate-limited read is unverified, never zero", async () => {
-    const r = await readSignerPayouts({ ...cfg, fetchImpl: throwingFetch() });
+    const r = await readPayoutTransfers({ ...cfg, fetchImpl: throwingFetch() });
     expect(r.count).toBeNull();
     expect(r.reason).toContain("log read failed");
   });
 
   it("unconfigured is unverified too", async () => {
-    const r = await readSignerPayouts({ ...cfg, usdcAddress: undefined, fetchImpl: rpc("0x190f1b43", []) });
+    const r = await readPayoutTransfers({ ...cfg, usdcAddress: undefined, fetchImpl: rpc("0x190f1b43", []) });
     expect(r.count).toBeNull();
     expect(r.reason).toContain("not configured");
+  });
+
+  it("names the payout SOURCE when that's what's missing — the bug that shipped", async () => {
+    const r = await readPayoutTransfers({ ...cfg, sourceAddress: undefined, fetchImpl: rpc("0x190f1b43", []) });
+    expect(r.count).toBeNull();
+    expect(r.reason).toContain("agentAccountCore");
+  });
+});
+
+// Regression: the first live run watched the signer EOA instead of
+// AgentAccountCore, found zero transfers, and put "12 unaccounted for" on a
+// live money board. A total miss must accuse the INSTRUMENT, not the money.
+describe("decidePayoutEvidence — a 100% miss is a broken filter, not lost money", () => {
+  const base = { windowBlocks: 14400, tolerance: 1 };
+
+  it("zero confirmed against real settled jobs is UNVERIFIED, never a shortfall", () => {
+    const r = decidePayoutEvidence({ ...base, confirmedCount: 0, confirmedUsdc: 0, settledCount: 12 });
+    expect(r.status).toBe("unverified"); // was "shortfall" — the false alarm
+    expect(r.detail).toContain("check the source address");
+    expect(r.detail).not.toContain("unaccounted for");
+  });
+
+  it("but ONE observed transfer proves the filter works — then a shortfall is trustworthy", () => {
+    const r = decidePayoutEvidence({ ...base, confirmedCount: 1, confirmedUsdc: 0.3, settledCount: 12 });
+    expect(r.status).toBe("shortfall");
+    expect(r.detail).toContain("11 unaccounted for");
+  });
+
+  it("zero settled AND zero confirmed is a quiet period, not an alarm", () => {
+    expect(decidePayoutEvidence({ ...base, confirmedCount: 0, confirmedUsdc: 0, settledCount: 0 }).status).toBe("unverified");
   });
 });


### PR DESCRIPTION
The first live run of #573 put this on a **live mainnet money board**:

> *"12 jobs marked settled but only 0 payouts confirmed on-chain — 12 unaccounted for"*

That was wrong. **My bug, not lost money.**

## Cause

It filtered USDC `Transfer` logs on **`from = signer EOA`**. But the reward bank is an **in-contract position in AgentAccountCore** — #558 says it outright (*"reads the in-contract reward-bank position exposed by /health, not `balanceOf(signer)`"*), and the treasury note adds *"mainnet payouts are funded from the signer reward bank."*

On a payout the signer only **sends the transaction and pays the DOT gas**. The Transfer event's `from` is the *contract holding the funds*. So my filter matched nothing — which is **indistinguishable from every payout failing**.

## Two fixes; the second matters more

**1. Watch the real source.** `readSignerPayouts` → `readPayoutTransfers`, taking `sourceAddress`, defaulted from `/health` `addresses.agentAccountCore` — already consumed by the treasury probe at `product-health.ts:1515`. The right address was sitting there and I used the wrong one. `PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS` overrides.

**2. A 100% miss now accuses the instrument, not the money.** Zero observed transfers → **`unverified`** (*"check the source address before suspecting the payouts"*), never `shortfall`. Point this at a wrong address and you see exactly zero, so a total miss is overwhelmingly a misconfigured filter and must not be reported as a finding about the money.

**A shortfall now requires at least one observed transfer** — proof the filter can see anything at all before it's trusted to accuse.

That second rule is the same discipline as the #543 chain guard: *never trust an instrument that hasn't proven it's pointed at the right thing.* It should have been in the original PR.

## On the miss

#573 deliberately made a shortfall **report rather than page**, so nobody was woken — that design choice is the only reason this was embarrassing rather than an incident. But it still put a false accusation on a money surface, which is exactly what this repo's truth-boundary exists to prevent. **A fake RED is as harmful as a fake green**, and I'd only been guarding one direction.

## Tests
+4: zero-confirmed → `unverified` not `shortfall` (the exact false alarm), one-transfer-proves-the-filter → shortfall trustworthy, quiet period, missing-source names `agentAccountCore`.

`product-health` **134/134**. Full unit suite: **110 pre-existing failures at base, identical here, +4 passing → zero new**. tsc **49 at base, 49 here**.

Safe to re-arm `PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED` once this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)