### PR TITLE
fix(mobile): an empty pool drew a FULL GREEN bar; headline was invisible

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -89,6 +89,38 @@ describe("MobileBoard", () => {
     expect(queryByText("Escrow (in-flight)")).toBeNull();
   });
 
+  test("a ZERO pool draws NO bar — a full green meter on an empty pool is a fake-green", () => {
+    // Shipped exactly this on "Treasury reserve · 0 USDC" (floor null → pct 100).
+    const { getByText, container } = render(<MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />);
+    const reserve: ProductHealth = {
+      ...healthyMainnet,
+      solvency: {
+        pools: [
+          { key: "reserve", label: "Treasury reserve", amount: 0, unit: "USDC", status: "ok", note: "Intentionally unfunded." },
+          { key: "reward_bank", label: "Reward bank", amount: 17.2, unit: "USDC", floor: 2, status: "ok" },
+        ],
+      },
+    };
+    cleanup();
+    const r = render(<MobileBoard health={reserve} cards={[]} nowMs={NOW} />);
+    // The zero pool still reports its number and its reason...
+    expect(r.getByText("Treasury reserve")).toBeTruthy();
+    expect(r.getByText("Intentionally unfunded.")).toBeTruthy();
+    // ...but exactly ONE bar is drawn, for the funded pool that has a scale.
+    expect(r.container.querySelectorAll(".hm-mb-bar")).toHaveLength(1);
+    expect(container).toBeTruthy();
+  });
+
+  test("a pool with no floor has no scale, so it gets no meter either", () => {
+    const noFloor: ProductHealth = {
+      ...healthyMainnet,
+      solvency: { pools: [{ key: "x", label: "Unfloored", amount: 99, unit: "USDC", status: "ok" }] },
+    };
+    const { container, getByText } = render(<MobileBoard health={noFloor} cards={[]} nowMs={NOW} />);
+    expect(getByText(/99\.00 USDC/)).toBeTruthy(); // the number is still real
+    expect(container.querySelectorAll(".hm-mb-bar")).toHaveLength(0);
+  });
+
   test("a pool awaiting data says so — never a bar we can't justify", () => {
     const awaiting: ProductHealth = {
       ...healthyMainnet,

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -136,9 +136,15 @@ function PoolRow({ pool }: { pool: SolvencyPool }) {
     );
   }
   const floor = pool.floor ?? null;
+  // A meter needs a scale. Without a floor there's nothing to fill against, and
+  // an empty pool has nothing to show — so draw NO bar rather than a full one.
+  // Shipped as a full green bar on "Treasury reserve · 0 USDC", which read as
+  // "healthy and full" for a pool that is deliberately empty. A meter you can't
+  // justify is a fake-green, same rule as the awaiting-data branch above.
+  const scalable = floor !== null && floor > 0 && pool.amount > 0;
   // Fill is share-of-a-safe-buffer (5× floor), capped — a floored pool at 5×
   // reads full, and one at its floor reads nearly empty.
-  const pct = floor && floor > 0 ? Math.max(4, Math.min(100, Math.round((pool.amount / (floor * 5)) * 100))) : 100;
+  const pct = scalable ? Math.max(4, Math.min(100, Math.round((pool.amount / (floor * 5)) * 100))) : 0;
   const tone = pool.status === "red" ? "red" : pool.status === "degraded" ? "warn" : "ok";
   return (
     <div className="hm-mb-pool">
@@ -149,9 +155,11 @@ function PoolRow({ pool }: { pool: SolvencyPool }) {
           {floor !== null ? ` · floor ${formatFloor(floor)}` : ""}
         </span>
       </div>
-      <div className="hm-mb-bar" role="img" aria-label={`${pool.label} ${pool.amount} ${pool.unit}`}>
-        <span className={`hm-mb-bar-fill hm-mb-bar-fill--${tone}`} style={{ width: `${pct}%` }} />
-      </div>
+      {scalable ? (
+        <div className="hm-mb-bar" role="img" aria-label={`${pool.label} ${pool.amount} ${pool.unit}`}>
+          <span className={`hm-mb-bar-fill hm-mb-bar-fill--${tone}`} style={{ width: `${pct}%` }} />
+        </div>
+      ) : null}
       {pool.note ? <p className="hm-mb-note">{pool.note}</p> : null}
     </div>
   );

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -87,7 +87,9 @@
 .hm-mb-badge--ok { background: var(--h4-ok-soft); color: var(--h4-ok); }
 .hm-mb-badge--warn { background: var(--h4-warn-soft); color: var(--h4-warn); }
 .hm-mb-badge--red { background: var(--h4-act-soft); color: var(--h4-act); }
-.hm-mb-h { font-family: var(--font-display); font-size: 15px; font-weight: 700; line-height: 1.3; margin: 0; }
+/* colour is explicit: the global `h1,h2,…` rule in averray-tokens.css otherwise
+   wins and renders the headline near-invisible dark-on-dark on the phone. */
+.hm-mb-h { font-family: var(--font-display); font-size: 15px; font-weight: 700; line-height: 1.3; margin: 0; color: var(--h4-ink); }
 .hm-mb-sub { font-size: 12px; line-height: 1.5; color: var(--h4-muted); margin: 4px 0 0; text-wrap: pretty; }
 
 /* ── money ──────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Both caught on the live phone board, first deploy.

## 1. Fake-green on the money card

**"Treasury reserve · 0 USDC" rendered a complete green meter.**

The fill fell through to `pct = 100` whenever a pool had no floor — so a *deliberately empty* pool read as healthy and full. That's the exact class of bug this board exists to prevent, shipped by me, on the money card.

A meter needs a scale. No floor, or nothing in the pool, means there's nothing to fill against — so **no bar is drawn**. The number and the operator's note still show (*"Intentionally unfunded: mainnet payouts are funded from the signer reward bank…"*), which is the honest rendering: here is the balance, here is why it's zero, and no meter claiming otherwise.

Same rule as the awaiting-data branch immediately above it — *never draw a meter you can't justify.* I wrote that comment and then broke it two lines later.

## 2. Invisible headline

`.hm-mb-h` is an `<h2>`, and the global `h1,h2,…` rule in `averray-tokens.css` won on colour, rendering the status headline near-invisible dark-on-dark. Only the sub-line was legible on the phone. Now sets `--h4-ink` explicitly.

## Tests
+2: a zero pool draws no bar while keeping its number and note; an unfloored pool gets no meter either.

`monitor-ui` **12/12 mobile**, **828 passed vs 826 at base** — the same 3 pre-existing Harness failures, **zero new**. tsc baseline unchanged (3, none in the mobile files). SPA build ✓.

Both were only findable by looking at the real thing on a real phone — neither would have failed a unit test as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)