### PR TITLE
feat(monitor): rank operator decisions money-first

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -302,8 +302,9 @@ export function BoardView({
         ? { hermesFocusCardId: scopeCandidateId(cards, focusedCardId, boardFocusId) }
         : {}),
       ...(board?.calmMetrics ? { calmMetrics: board.calmMetrics } : {}),
+      productHealth,
     }),
-    [board?.calmMetrics, boardFocusId, cards, focusedCardId, hermesFocusConversationActive, streamOnline, liveLabel],
+    [board?.calmMetrics, boardFocusId, cards, focusedCardId, hermesFocusConversationActive, streamOnline, liveLabel, productHealth],
   );
 
   // §14: announce the action-needed 0→>0 edge once, assertively, for
@@ -370,8 +371,8 @@ export function BoardView({
     [displayGrouped],
   );
   const inboxIds = useMemo(
-    () => new Set(inboxCards(displayGrouped).map((card) => card.id)),
-    [displayGrouped],
+    () => new Set(inboxCards(displayGrouped, productHealth).map((card) => card.id)),
+    [displayGrouped, productHealth],
   );
 
   const jumpToInbox = useCallback((card: BoardCard) => {
@@ -386,6 +387,7 @@ export function BoardView({
     <CardRouter
       key={card.id}
       card={card}
+      decisionHealth={productHealth}
       focused={card.id === boardFocusId}
       onClick={onCardClick ? (c) => onCardClick(c.id) : undefined}
       onApprove={onApproveTask ? (c) => onApproveTask(c.id) : undefined}
@@ -715,6 +717,7 @@ export function BoardView({
           ) : (
             <KanbanBoard
               grouped={displayGrouped}
+              decisionHealth={productHealth}
               ariaLabel="Kanban lane grid"
               expanded={surfacedExpanded}
               onToggleLane={onToggleLane}

--- a/packages/monitor-ui/src/components/KanbanBoard.tsx
+++ b/packages/monitor-ui/src/components/KanbanBoard.tsx
@@ -14,6 +14,7 @@
 
 import type { ReactNode } from "react";
 import type { BoardCard, Lane } from "../lib/monitor/card-types.js";
+import type { ProductHealth } from "../lib/monitor/product-health.js";
 import {
   BOARD_COLUMNS,
   columnTier,
@@ -41,6 +42,8 @@ export interface KanbanBoardProps {
   renderLaneBody?: (lane: Lane, cards: BoardCard[]) => ReactNode | undefined;
   /** Accessible label for the column row region. */
   ariaLabel?: string;
+  /** Live probe evidence used by the shared money-first decision ranker. */
+  decisionHealth?: ProductHealth;
 }
 
 export function KanbanBoard({
@@ -52,8 +55,9 @@ export function KanbanBoard({
   renderLaneHeader,
   renderLaneBody,
   ariaLabel = "Kanban lane grid",
+  decisionHealth,
 }: KanbanBoardProps) {
-  const inbox = inboxCards(grouped);
+  const inbox = inboxCards(grouped, decisionHealth);
   const inboxIds = new Set(inbox.map((card) => card.id));
 
   return (

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -30,6 +30,8 @@ import type {
   MissionCard,
   MissionReport,
 } from "../../lib/monitor/card-types.js";
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import { decisionPriorityFor } from "../../lib/monitor/decision-rank.js";
 import { deployStepsForCard } from "../../lib/monitor/deploy-stepper.js";
 import { shortId } from "../../lib/monitor/card-id.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
@@ -45,6 +47,8 @@ import { DeployStepper } from "../DeployStepper.js";
 
 export type CardProps = {
   card: BoardCard;
+  /** Live probe evidence for the shared money-first decision reason. */
+  decisionHealth?: ProductHealth;
   focused?: boolean;
   onClick?: (card: BoardCard) => void;
   /** Approve a proposed task card (O3). Operator-only; runs through a confirm. */
@@ -184,6 +188,7 @@ function isInboxDecisionCard(card: BoardCard, isClosed: boolean): boolean {
 
 export function Card({
   card,
+  decisionHealth,
   focused = false,
   onClick,
   onApprove,
@@ -244,6 +249,8 @@ export function Card({
       <CardHead card={card} isStale={isStale} isClosed={isClosed} />
 
       <div className="hm-card-title">{card.title}</div>
+
+      {isInboxCard ? <DecisionPriorityChip card={card} health={decisionHealth} /> : null}
 
       {card.repo && !isClosed && isInboxCard ? (
         <div className="hm-decision-repo hm-mono" title={card.repo}>
@@ -731,6 +738,25 @@ function DecisionCardExplanation({ card }: { card: BoardCard }) {
         </span>
       </div>
     </div>
+  );
+}
+
+function DecisionPriorityChip({
+  card,
+  health,
+}: {
+  card: BoardCard;
+  health?: ProductHealth;
+}) {
+  const priority = decisionPriorityFor(card, health);
+  return (
+    <span
+      className={`hm-decision-priority hm-decision-priority--${priority.tier}`}
+      data-decision-tier={priority.tier}
+      title="Money-first decision queue reason"
+    >
+      {priority.reason}
+    </span>
   );
 }
 

--- a/packages/monitor-ui/src/components/cards/CardRouter.tsx
+++ b/packages/monitor-ui/src/components/cards/CardRouter.tsx
@@ -7,12 +7,14 @@
 // broken" (§16).
 
 import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { pickRenderer, defaultDegradedContent } from "../../lib/monitor/card-router.js";
 import { Card } from "./Card.js";
 import { DegradedCard } from "./DegradedCard.js";
 
 export type CardRouterProps = {
   card: BoardCard;
+  decisionHealth?: ProductHealth;
   focused?: boolean;
   onClick?: (card: BoardCard) => void;
   /** Click handler for the degraded card's primary action (Retry / View last known). */
@@ -37,6 +39,7 @@ export type CardRouterProps = {
 
 export function CardRouter({
   card,
+  decisionHealth,
   focused,
   onClick,
   onDegradedAction,
@@ -68,6 +71,7 @@ export function CardRouter({
   return (
     <Card
       card={card}
+      decisionHealth={decisionHealth}
       focused={focused}
       onClick={onClick}
       onApprove={onApprove}

--- a/packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
+++ b/packages/monitor-ui/src/components/cards/DecisionInbox.test.tsx
@@ -68,6 +68,16 @@ describe("PR-E2 — Decision-Inbox card grammar", () => {
     expect(getByText(/Reason not recorded; open the drawer before acting/)).toBeTruthy();
   });
 
+  test("shows the shared money-first reason chip on the decision card", () => {
+    const card = decisionCard(record());
+    (card as BoardCard & { files: Array<{ path: string; diff: string; critical: boolean }> }).files = [
+      { path: "services/settlement/submit.ts", diff: "+3 -1", critical: false },
+    ];
+    const { getByText } = render(<Card card={card} />);
+    const chip = getByText("Money first · settlement path");
+    expect(chip.getAttribute("data-decision-tier")).toBe("money-blocking");
+  });
+
   test("PR-F3: the full decision grammar — why + what-next + recommended action + Choices ↓", () => {
     // A proposed task awaiting dispatch is a real inbox decision; wiring its
     // approve handler surfaces the recommended primary action and the collapsed

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -138,6 +138,34 @@ describe("MobileBoard", () => {
     expect(getByText("+2 more on the full board.")).toBeTruthy();
   });
 
+  test("uses the shared money-first order and shows why the first decision leads", () => {
+    const routine = taskCard({
+      id: "routine",
+      title: "post-production-deploy verification after workflow run #40",
+      isAction: true,
+    });
+    const unknown = taskCard({ id: "unknown", title: "Review an unclassified task" });
+    const money = taskCard({
+      id: "money",
+      type: "pr",
+      title: "Review settlement changes",
+      files: [{ path: "services/settlement/submit.ts", diff: "+3 -1", critical: false }],
+    });
+    const { container, getByText } = render(
+      <MobileBoard health={healthyMainnet} cards={[routine, unknown, money]} nowMs={NOW} />,
+    );
+
+    expect(
+      [...container.querySelectorAll(".hm-mb-item-title")].map((node) => node.textContent),
+    ).toEqual([
+      "Review settlement changes",
+      "Review an unclassified task",
+      "post-production-deploy verification after workflow run #40",
+    ]);
+    expect(getByText("Money first · settlement path").getAttribute("data-decision-tier"))
+      .toBe("money-blocking");
+  });
+
   test("a PROPOSED task exposes Approve/Dismiss and wires them to the operator gate", () => {
     const onApproveTask = vi.fn();
     const onDismissCard = vi.fn();

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -16,7 +16,7 @@
 import type { ReactNode } from "react";
 import type { BoardCard } from "../../lib/monitor/card-types.js";
 import type { ProductHealth, SolvencyPool } from "../../lib/monitor/product-health.js";
-import { isDecision } from "../../lib/monitor/lane-rules.js";
+import { decisionPriorityFor, rankDecisionCards } from "../../lib/monitor/decision-rank.js";
 import { opsBannerData } from "../ops/ops-frame.js";
 
 export interface MobileBoardProps {
@@ -40,7 +40,7 @@ export function MobileBoard({
   onApproveTask,
   onDismissCard,
 }: MobileBoardProps) {
-  const decisions = cards.filter(isDecision);
+  const decisions = rankDecisionCards(cards, health);
   return (
     <div className="hm-mb" data-testid="mobile-board">
       <header className="hm-mb-top">
@@ -57,6 +57,7 @@ export function MobileBoard({
         <MobileMoneyCard health={health} />
         <MobileNeedsYouCard
           decisions={decisions}
+          health={health}
           onCardClick={onCardClick}
           onApproveTask={onApproveTask}
           onDismissCard={onDismissCard}
@@ -176,20 +177,22 @@ function formatFloor(value: number): string {
 }
 
 /**
- * The decisions waiting on the operator. Uses `isDecision` — the same selector
- * the desktop inbox and the "waiting on you" count use — so the phone can't
- * show a different backlog than the board.
+ * The decisions waiting on the operator. Uses `rankDecisionCards`, which owns
+ * the shared `isDecision` filter and money-first order used by the desktop
+ * inbox, so the phone cannot show a different backlog or priority order.
  *
  * SAFETY: only approve/dismiss of already-proposed work is reachable here. The
  * phone never moves funds; a prepare-only task stays prepare-only.
  */
 export function MobileNeedsYouCard({
   decisions,
+  health,
   onCardClick,
   onApproveTask,
   onDismissCard,
 }: {
   decisions: BoardCard[];
+  health?: ProductHealth;
   onCardClick?: (id: string) => void;
   onApproveTask?: (id: string) => void;
   onDismissCard?: (card: BoardCard) => void;
@@ -209,6 +212,7 @@ export function MobileNeedsYouCard({
         <DecisionRow
           key={card.id}
           card={card}
+          health={health}
           onCardClick={onCardClick}
           onApproveTask={onApproveTask}
           onDismissCard={onDismissCard}
@@ -221,21 +225,30 @@ export function MobileNeedsYouCard({
 
 function DecisionRow({
   card,
+  health,
   onCardClick,
   onApproveTask,
   onDismissCard,
 }: {
   card: BoardCard;
+  health?: ProductHealth;
   onCardClick?: (id: string) => void;
   onApproveTask?: (id: string) => void;
   onDismissCard?: (card: BoardCard) => void;
 }) {
   const taskStatus = (card as { taskStatus?: string }).taskStatus;
   const proposed = card.type === "task" && taskStatus === "proposed";
+  const priority = decisionPriorityFor(card, health);
   return (
     <div className="hm-mb-item">
       <button type="button" className="hm-mb-item-open" onClick={onCardClick ? () => onCardClick(card.id) : undefined}>
         <span className="hm-mb-item-title">{card.title}</span>
+        <span
+          className={`hm-mb-priority hm-mb-priority--${priority.tier}`}
+          data-decision-tier={priority.tier}
+        >
+          {priority.reason}
+        </span>
         <span className="hm-mb-item-meta">
           {card.agentType}
           {card.repo ? ` · ${card.repo.split("/").pop()}` : ""}

--- a/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.test.ts
@@ -100,6 +100,25 @@ describe("inboxCards", () => {
   it("is empty when no card waits on the operator", () => {
     expect(inboxCards(grouped({ done: [card("done", "done", "agent")] }))).toEqual([]);
   });
+
+  it("applies the shared money-first rank after preserving inbox membership", () => {
+    const routine = {
+      ...card("needs-attention", "routine", "operator"),
+      title: "post-production-deploy verification after workflow run #40",
+      repo: "depre-dev/averray-reference-agent",
+    } as BoardCard;
+    const money = {
+      ...card("operator-review", "money", "operator"),
+      title: "Review change",
+      repo: "depre-dev/averray-reference-agent",
+      files: [{ path: "services/payout/settle.ts", diff: "+1 -0", critical: false }],
+    } as BoardCard;
+
+    expect(inboxCards(grouped({
+      "needs-attention": [routine],
+      "operator-review": [money],
+    })).map((entry) => entry.id)).toEqual(["money", "routine"]);
+  });
 });
 
 describe("columnVisibility", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-columns.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-columns.ts
@@ -13,7 +13,9 @@
 // board-columns.test.ts so the structure is litigated here, not in the view.
 
 import type { BoardCard, Lane } from "./card-types.js";
+import type { ProductHealth } from "./product-health.js";
 import { LANES } from "./card-types.js";
+import { rankDecisionCards } from "./decision-rank.js";
 import { isDecision, tierFor, type KanbanTier } from "./lane-rules.js";
 
 export interface BoardColumnDef {
@@ -68,7 +70,10 @@ export function tierLabel(tier: KanbanTier): string {
  * actionable card. `isDecision` excludes done / verified / closed release
  * history, so the hero never inflates with finished work.
  */
-export function inboxCards(grouped: Partial<Record<Lane, BoardCard[]>>): BoardCard[] {
+export function inboxCards(
+  grouped: Partial<Record<Lane, BoardCard[]>>,
+  health?: ProductHealth,
+): BoardCard[] {
   const seen = new Set<string>();
   const out: BoardCard[] = [];
   for (const lane of LANES) {
@@ -78,7 +83,7 @@ export function inboxCards(grouped: Partial<Record<Lane, BoardCard[]>>): BoardCa
       out.push(card);
     }
   }
-  return out;
+  return rankDecisionCards(out, health);
 }
 
 export type ColumnVisibility = "hidden" | "rail" | "column";

--- a/packages/monitor-ui/src/lib/monitor/board-state.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.test.ts
@@ -109,6 +109,27 @@ test("mostUrgentCard: picks the action card when one exists", () => {
   assert.equal(urgent.id, "action-1");
 });
 
+test("mostUrgentCard: money-blocking decision outranks a fresher routine verification", () => {
+  const cards = [
+    card({
+      id: "routine",
+      isAction: true,
+      freshness: 1,
+      title: "post-production-deploy verification after workflow run #40",
+    }),
+    card({
+      id: "money",
+      isAction: true,
+      freshness: 500,
+      title: "Review payout worker",
+      files: [{ path: "services/payout/worker.ts", diff: "+2 -1", critical: false }],
+    }),
+  ];
+  const urgent = mostUrgentCard(cards);
+  assert.equal(urgent.id, "money");
+  assert.equal(boardNowBanner(cards).primaryActionId, "money");
+});
+
 test("mostUrgentCard: falls back to freshest non-action card when nothing needs the operator", () => {
   const cards = [
     card({ id: "older", freshness: 60 }),
@@ -194,6 +215,7 @@ test("boardNowBanner: action mode produces an action-toned banner with the most 
   assert.deepEqual(
     banner.mostUrgentReasons?.map((reason) => ({ label: reason.label, tone: reason.tone })),
     [
+      { label: "Money relevance unknown", tone: "warn" },
       { label: "blocked 5m", tone: "neutral" },
       { label: "risk: secrets", tone: "risk" },
       { label: "safe: read-only", tone: "safe" },
@@ -222,11 +244,14 @@ test("boardNowBanner: action banner traces to existing most-urgent selection", (
   assert.equal(banner.sub, "Most urgent: Urgent decision — suggests Review now.");
 });
 
-test("boardNowBanner: most-urgent reasons stay empty when the card has no real signals", () => {
+test("boardNowBanner: a thin card reports unknown money relevance instead of implying safety", () => {
   const banner = boardNowBanner([
     card({ id: "thin", isAction: true, title: "Thin card", freshness: undefined, risk: [] }),
   ]);
-  assert.deepEqual(banner.mostUrgentReasons, []);
+  assert.deepEqual(
+    banner.mostUrgentReasons?.map((reason) => ({ label: reason.label, tone: reason.tone })),
+    [{ label: "Money relevance unknown", tone: "warn" }],
+  );
 });
 
 test("boardNowBanner: Hermes focus mode uses the scoped review card", () => {

--- a/packages/monitor-ui/src/lib/monitor/board-state.ts
+++ b/packages/monitor-ui/src/lib/monitor/board-state.ts
@@ -7,6 +7,8 @@
 // Per §5/§16 of docs/HERMES_MONITOR_REDESIGN_SPEC.md.
 
 import type { BoardCard, Lane } from "./card-types.js";
+import type { ProductHealth } from "./product-health.js";
+import { decisionPriorityFor, rankDecisionCards } from "./decision-rank.js";
 import { groupByLane, laneCounts, laneFor, isDecision } from "./lane-rules.js";
 import { formatFreshness, sortByUrgency } from "./urgency.js";
 
@@ -87,6 +89,7 @@ export interface DeriveBoardOpts {
   lastGoodLabel?: string;
   hermesFocusCardId?: string;
   calmMetrics?: CalmBoardMetrics;
+  productHealth?: ProductHealth;
 }
 
 export interface DerivedBoardState {
@@ -129,8 +132,13 @@ export function kpiCounts(cards: BoardCard[]): KPICounts {
 }
 
 /** The single most urgent live card, or undefined when calm. */
-export function mostUrgentCard(cards: BoardCard[]): BoardCard | undefined {
+export function mostUrgentCard(
+  cards: BoardCard[],
+  health?: ProductHealth,
+): BoardCard | undefined {
   if (!Array.isArray(cards) || cards.length === 0) return undefined;
+  const [decision] = rankDecisionCards(cards, health);
+  if (decision) return decision;
   const live = cards.filter((c) => c && c.lane !== "done" && c.type !== "done");
   if (live.length === 0) return undefined;
   const [first] = sortByUrgency(live);
@@ -175,7 +183,7 @@ export function boardNowBanner(cards: BoardCard[], opts: DeriveBoardOpts = {}): 
   }
 
   if (mode === "action") {
-    const urgent = mostUrgentCard(cards);
+    const urgent = mostUrgentCard(cards, opts.productHealth);
     const actionCount = counts.action;
     const headline =
       actionCount === 1
@@ -190,7 +198,7 @@ export function boardNowBanner(cards: BoardCard[], opts: DeriveBoardOpts = {}): 
         ? `Most urgent: ${urgent.title} — suggests ${suggestedAction}.`
         : `Review the decision inbox before approving anything.`,
       primaryActionId: urgent?.id,
-      mostUrgentReasons: urgent ? mostUrgentReasonsFor(urgent) : undefined,
+      mostUrgentReasons: urgent ? mostUrgentReasonsFor(urgent, opts.productHealth) : undefined,
     };
   }
 
@@ -285,8 +293,21 @@ function normalizeSuggestedAction(value: string): string {
   return trimmed.length > 72 ? `${trimmed.slice(0, 69).trim()}...` : trimmed;
 }
 
-function mostUrgentReasonsFor(card: BoardCard): MostUrgentReasonChip[] {
-  const chips: MostUrgentReasonChip[] = [];
+function mostUrgentReasonsFor(
+  card: BoardCard,
+  health?: ProductHealth,
+): MostUrgentReasonChip[] {
+  const priority = decisionPriorityFor(card, health);
+  const chips: MostUrgentReasonChip[] = [{
+    label: priority.reason,
+    tone:
+      priority.tier === "money-blocking"
+        ? "risk"
+        : priority.tier === "unknown"
+          ? "warn"
+          : "neutral",
+    title: "Money-first decision queue tier.",
+  }];
   const age = formatFreshness(card.freshness);
   if (age) {
     chips.push({
@@ -351,6 +372,6 @@ export function deriveBoardState(cards: BoardCard[], opts: DeriveBoardOpts = {})
     counts: kpiCounts(cards),
     mode: boardMode(cards, opts),
     banner: boardNowBanner(cards, opts),
-    mostUrgent: mostUrgentCard(cards),
+    mostUrgent: mostUrgentCard(cards, opts.productHealth),
   };
 }

--- a/packages/monitor-ui/src/lib/monitor/decision-rank.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/decision-rank.test.ts
@@ -137,4 +137,45 @@ describe("money-first decision ranking", () => {
     expect(rankDecisionCards(input).map((card) => card.id)).toEqual(["money", "unknown"]);
     expect(input).toEqual(snapshot);
   });
+
+  // GATE (#579): the demotion is title-driven, so on its own it sank a RED
+  // production deploy below "rename a label". Demoting a card that is reporting
+  // a failure is the same class of harm as hiding it — the board stops
+  // representing what is actually urgent.
+  test("a FAILING verification is not routine — failure evidence cancels the demotion", () => {
+    const failing = decision({
+      id: "failing",
+      type: "deploy",
+      title: "post-production-deploy verification after workflow run #41",
+      checkRuns: [{ name: "smoke", status: "fail" }],
+    });
+    const trivial = decision({ id: "trivial", title: "rename a label" });
+
+    expect(decisionPriorityFor(failing).tier).not.toBe("routine-verification");
+    expect(rankDecisionCards([failing, trivial]).map((card) => card.id)).toEqual([
+      "failing",
+      "trivial",
+    ]);
+  });
+
+  test.each([
+    ["a failing check run", { checkRuns: [{ name: "smoke", status: "fail" }] }],
+    ["a high-severity finding", { riskSignals: [{ severity: "high", code: "X", message: "m" }] }],
+    ["an offline upstream", { state: "source-offline" }],
+    ["a task failure reason", { type: "task", failureReason: "runner exited 1" }],
+    ["a FAILED verdict", { type: "pr", verdict: "FAILED — smoke red" }],
+  ])("%s keeps a verification card out of the bottom tier", (_label, over) => {
+    const card = decision({ title: "post-deploy verification", ...over });
+    expect(decisionPriorityFor(card).tier).not.toBe("routine-verification");
+  });
+
+  test("a CLEAN verification still sinks — the demotion itself is intact", () => {
+    const clean = decision({
+      id: "clean",
+      type: "deploy",
+      title: "post-production-deploy verification after workflow run #42",
+      checkRuns: [{ name: "smoke", status: "pass" }],
+    });
+    expect(decisionPriorityFor(clean).tier).toBe("routine-verification");
+  });
 });

--- a/packages/monitor-ui/src/lib/monitor/decision-rank.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/decision-rank.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "vitest";
+
+import type { BoardCard } from "./card-types.js";
+import type { ProductHealth } from "./product-health.js";
+import { decisionPriorityFor, rankDecisionCards } from "./decision-rank.js";
+
+function decision(overrides: Record<string, unknown> = {}): BoardCard {
+  return {
+    id: "task-1",
+    lane: "codex-needed",
+    type: "task",
+    agentType: "codex",
+    title: "Review proposed work",
+    summary: "",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 10,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "info" },
+    taskStatus: "proposed",
+    prompt: "Review the proposal.",
+    ...overrides,
+  } as BoardCard;
+}
+
+function health(
+  probes: ProductHealth["probes"],
+): ProductHealth {
+  return {
+    enabled: true,
+    at: 1,
+    status: probes.some((probe) => probe.status === "red")
+      ? "red"
+      : probes.some((probe) => probe.status === "degraded")
+        ? "degraded"
+        : "healthy",
+    checks: 1,
+    probes,
+  };
+}
+
+describe("money-first decision ranking", () => {
+  test("orders money-blocking, unknown, standard, then routine verification", () => {
+    const routine = decision({
+      id: "routine",
+      type: "deploy",
+      title: "post-production-deploy verification after workflow run #40",
+      isAction: true,
+      freshness: 1,
+    });
+    const standard = decision({
+      id: "standard",
+      type: "pr",
+      files: [{ path: "packages/monitor-ui/src/App.tsx", diff: "+1 -0", critical: false }],
+      isAction: true,
+      freshness: 1,
+    });
+    const unknown = decision({ id: "unknown", freshness: 999 });
+    const money = decision({
+      id: "money",
+      type: "pr",
+      files: [{ path: "services/settlement/submit.ts", diff: "+4 -1", critical: false }],
+      freshness: 999,
+    });
+
+    expect(rankDecisionCards([routine, standard, unknown, money]).map((card) => card.id))
+      .toEqual(["money", "unknown", "standard", "routine"]);
+  });
+
+  test("uses degraded probe status only when the card explicitly links to that probe", () => {
+    const degraded = health([
+      { name: "signer_liquidity", status: "degraded", detail: "runway low", sparkline: [] },
+    ]);
+    const linked = decision({ id: "linked", title: "Signer gas runway needs a top-up decision" });
+    const unrelated = decision({ id: "unrelated", title: "Review accessibility copy" });
+
+    expect(decisionPriorityFor(linked, degraded)).toEqual({
+      tier: "money-blocking",
+      reason: "Money first · Signer liquidity degraded",
+    });
+    expect(decisionPriorityFor(unrelated, degraded).tier).toBe("unknown");
+  });
+
+  test("recognizes money repos/paths and the server-provided critical-file flag", () => {
+    expect(decisionPriorityFor(decision({ repo: "depre-dev/settlement-worker" })).tier)
+      .toBe("money-blocking");
+    expect(decisionPriorityFor(decision({
+      type: "pr",
+      files: [{ path: "packages/api/src/treasury/routes.ts", diff: "+1 -0", critical: false }],
+    })).reason).toBe("Money first · treasury path");
+    expect(decisionPriorityFor(decision({
+      type: "pr",
+      files: [{ path: "contracts/AgentTreasury.sol", diff: "+1 -0", critical: true }],
+    })).reason).toBe("Money first · treasury path");
+    expect(decisionPriorityFor(decision({
+      type: "pr",
+      files: [{ path: "contracts/Registry.sol", diff: "+1 -0", critical: true }],
+    })).reason).toBe("Money first · critical file");
+  });
+
+  test("preserves the existing urgency order inside a tier", () => {
+    const fresh = decision({
+      id: "fresh",
+      type: "pr",
+      files: [{ path: "services/payout/read.ts", diff: "+1 -0", critical: false }],
+      freshness: 1,
+    });
+    const failing = decision({
+      id: "failing",
+      type: "pr",
+      files: [{ path: "services/escrow/write.ts", diff: "+1 -0", critical: false }],
+      freshness: 100,
+      checks: { pass: 0, running: 0, fail: 1, pending: 0, total: 1 },
+    });
+
+    expect(rankDecisionCards([fresh, failing]).map((card) => card.id))
+      .toEqual(["failing", "fresh"]);
+  });
+
+  test("keeps every isDecision card exactly once and does not mutate the input", () => {
+    const unknown = decision({ id: "unknown" });
+    const money = decision({
+      id: "money",
+      type: "pr",
+      files: [{ path: "services/escrow/index.ts", diff: "", critical: false }],
+    });
+    const finished = decision({
+      id: "finished",
+      type: "done",
+      lane: "done",
+      closedAt: "2026-07-29T10:00:00Z",
+      mergeStatus: "MERGED",
+    });
+    const input = [unknown, finished, money];
+    const snapshot = [...input];
+
+    expect(rankDecisionCards(input).map((card) => card.id)).toEqual(["money", "unknown"]);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/decision-rank.ts
+++ b/packages/monitor-ui/src/lib/monitor/decision-rank.ts
@@ -102,7 +102,13 @@ export function decisionPriorityFor(
     return { tier: "money-blocking", reason: "Money first · critical file" };
   }
 
-  if (ROUTINE_VERIFICATION_PATTERN.test(cardEvidenceText(card))) {
+  // Routine verification only sinks while it is actually routine. A verification
+  // card that is REPORTING A FAILURE is the opposite of routine, and demoting it
+  // on its title alone buries a red production deploy underneath trivia — the
+  // same class of harm as hiding it, just slower to notice. Failure evidence
+  // therefore cancels the demotion and the card falls through to be tiered on
+  // its money evidence like anything else.
+  if (ROUTINE_VERIFICATION_PATTERN.test(cardEvidenceText(card)) && !hasFailureEvidence(card)) {
     return { tier: "routine-verification", reason: "Routine verification" };
   }
 
@@ -111,6 +117,21 @@ export function decisionPriorityFor(
   }
 
   return { tier: "unknown", reason: "Money relevance unknown" };
+}
+
+/**
+ * Is this card reporting a failure? Reads only signals the payload already
+ * carries — a failing check run, a high-severity Hermes finding, an upstream
+ * blocked state, a task failure reason, or a FAILED verdict. Nothing here is
+ * inferred; absence of evidence stays absence, not "fine".
+ */
+function hasFailureEvidence(card: BoardCard): boolean {
+  if (card.state === "failed-fetch" || card.state === "source-offline") return true;
+  if ((card.checkRuns ?? []).some((run) => run.status === "fail")) return true;
+  if ((card.riskSignals ?? []).some((signal) => signal.severity === "high")) return true;
+  if (card.type === "task" && (card.failureReason ?? "").length > 0) return true;
+  if (card.type === "pr" && /\bfail(?:ed|ure|ing)?\b/i.test(card.verdict ?? "")) return true;
+  return false;
 }
 
 function cardFiles(card: BoardCard): CardFile[] {

--- a/packages/monitor-ui/src/lib/monitor/decision-rank.ts
+++ b/packages/monitor-ui/src/lib/monitor/decision-rank.ts
@@ -1,0 +1,164 @@
+// Hermes decision-queue ranking.
+//
+// This module is deliberately pure: it turns the card and product-health
+// evidence already present in the monitor payload into an ordering plus a short
+// operator-facing reason. It never removes an `isDecision` card. Missing money
+// evidence is an explicit "unknown" tier rather than an implied safe result.
+
+import type { BoardCard, CardFile } from "./card-types.js";
+import type { ProductHealth, ProductHealthProbe } from "./product-health.js";
+import { isDecision } from "./lane-rules.js";
+import { probeLabel } from "./product-health.js";
+import { sortByUrgency } from "./urgency.js";
+
+export type DecisionPriorityTier =
+  | "money-blocking"
+  | "unknown"
+  | "standard"
+  | "routine-verification";
+
+export interface DecisionPriority {
+  tier: DecisionPriorityTier;
+  /** Short, payload-backed explanation suitable for a chip. */
+  reason: string;
+}
+
+const TIER_RANK: Record<DecisionPriorityTier, number> = {
+  "money-blocking": 0,
+  unknown: 1,
+  standard: 2,
+  "routine-verification": 3,
+};
+
+const MONEY_PATH_PATTERN = /(settlement|escrow|treasury|payout)/i;
+const ROUTINE_VERIFICATION_PATTERN =
+  /\b(?:post[-\s]?(?:production[-\s]?deploy|deploy|merge)|deploy)\s+verification\b/i;
+
+const MONEY_PROBES = [
+  {
+    name: "money_path",
+    aliases: [/\bmoney[_\s-]?path\b/i],
+  },
+  {
+    name: "signer_liquidity",
+    aliases: [/\bsigner[_\s-]?liquidity\b/i, /\bsigner\s+gas\b/i, /\breward\s+bank\b/i],
+  },
+  {
+    name: "treasury_liquidity",
+    aliases: [/\btreasury[_\s-]?liquidity\b/i, /\btreasury\s+reserve\b/i],
+  },
+] as const;
+
+/**
+ * Rank every real operator decision without mutating or dropping the input.
+ *
+ * Money-blocking decisions come first. Unknown money relevance deliberately
+ * precedes evidence-backed standard work, and explicit routine deploy
+ * verification comes last. Existing urgency remains the tie-breaker inside
+ * every tier.
+ */
+export function rankDecisionCards(
+  cards: BoardCard[],
+  health?: ProductHealth,
+): BoardCard[] {
+  if (!Array.isArray(cards)) return [];
+  const byUrgency = sortByUrgency(cards.filter(isDecision));
+  return byUrgency.sort(
+    (a, b) =>
+      TIER_RANK[decisionPriorityFor(a, health).tier] -
+      TIER_RANK[decisionPriorityFor(b, health).tier],
+  );
+}
+
+/** Explain the tier using only evidence that exists on the card/health payload. */
+export function decisionPriorityFor(
+  card: BoardCard,
+  health?: ProductHealth,
+): DecisionPriority {
+  const files = cardFiles(card);
+
+  const linkedProbe = degradedLinkedMoneyProbe(card, health);
+  if (linkedProbe) {
+    return {
+      tier: "money-blocking",
+      reason: `Money first · ${probeLabel(linkedProbe.name)} ${linkedProbe.status}`,
+    };
+  }
+
+  const repoPath = firstMoneyPath(card.repo);
+  if (repoPath) {
+    return { tier: "money-blocking", reason: `Money first · ${repoPath} repo` };
+  }
+
+  for (const file of files) {
+    const pathSignal = firstMoneyPath(file.path);
+    if (pathSignal) {
+      return { tier: "money-blocking", reason: `Money first · ${pathSignal} path` };
+    }
+  }
+
+  const critical = files.find((file) => file.critical === true);
+  if (critical) {
+    return { tier: "money-blocking", reason: "Money first · critical file" };
+  }
+
+  if (ROUTINE_VERIFICATION_PATTERN.test(cardEvidenceText(card))) {
+    return { tier: "routine-verification", reason: "Routine verification" };
+  }
+
+  if (files.length > 0) {
+    return { tier: "standard", reason: "Standard decision" };
+  }
+
+  return { tier: "unknown", reason: "Money relevance unknown" };
+}
+
+function cardFiles(card: BoardCard): CardFile[] {
+  const files = (card as BoardCard & { files?: CardFile[] }).files;
+  return Array.isArray(files) ? files : [];
+}
+
+function firstMoneyPath(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value.match(MONEY_PATH_PATTERN)?.[1]?.toLowerCase();
+}
+
+function degradedLinkedMoneyProbe(
+  card: BoardCard,
+  health?: ProductHealth,
+): ProductHealthProbe | undefined {
+  if (!health) return undefined;
+  const text = cardEvidenceText(card);
+  for (const candidate of MONEY_PROBES) {
+    if (!candidate.aliases.some((pattern) => pattern.test(text))) continue;
+    const probe = health.probes.find(
+      (entry) =>
+        entry.name === candidate.name &&
+        (entry.status === "red" || entry.status === "degraded"),
+    );
+    if (probe) return probe;
+  }
+  return undefined;
+}
+
+function cardEvidenceText(card: BoardCard): string {
+  const taskPrompt = card.type === "task" ? card.prompt : undefined;
+  const taskFailure = card.type === "task" ? card.failureReason : undefined;
+  const verdict = card.type === "pr" ? card.verdict : undefined;
+  return [
+    card.title,
+    card.summary,
+    card.repo,
+    card.next,
+    card.correlationId,
+    taskPrompt,
+    taskFailure,
+    verdict,
+    ...(card.riskSignals ?? []).flatMap((signal) => [signal.code, signal.message]),
+    ...(card.decisionRecord?.reasons ?? []),
+    card.decisionRecord?.outcome.summary,
+    card.decisionRecord?.outcome.waitingNext,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join("\n");
+}

--- a/packages/monitor-ui/src/styles/hermes4-cards.css
+++ b/packages/monitor-ui/src/styles/hermes4-cards.css
@@ -250,6 +250,34 @@
 .hm-decision-next .lbl { font-weight: 600; color: var(--h4-ink-2); }
 
 /* ---- E2: Decision-card body grammar ---- */
+.hm-decision-priority {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: 7px;
+  padding: 3px 7px;
+  border: 1px solid var(--h4-line);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--h4-muted);
+  background: var(--h4-paper);
+}
+.hm-decision-priority--money-blocking {
+  border-color: var(--h4-act-line);
+  color: var(--h4-act-text);
+  background: var(--h4-act-soft);
+}
+.hm-decision-priority--unknown {
+  border-color: var(--h4-warn-line);
+  color: var(--h4-warn-text);
+  background: var(--h4-warn-soft);
+}
+.hm-decision-priority--routine-verification {
+  color: var(--h4-faint);
+  background: transparent;
+}
 .hm-decision-repo {
   margin-top: 5px;
   font-size: 11px;

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -136,6 +136,28 @@
   cursor: pointer;
 }
 .hm-mb-item-title { display: block; font-size: 13px; line-height: 1.4; color: var(--h4-ink-2); }
+.hm-mb-priority {
+  display: inline-block;
+  margin-top: 5px;
+  padding: 2px 6px;
+  border: 1px solid var(--h4-line);
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  color: var(--h4-muted);
+}
+.hm-mb-priority--money-blocking {
+  border-color: var(--h4-act-line);
+  color: var(--h4-act-text);
+  background: var(--h4-act-soft);
+}
+.hm-mb-priority--unknown {
+  border-color: var(--h4-warn-line);
+  color: var(--h4-warn-text);
+  background: var(--h4-warn-soft);
+}
+.hm-mb-priority--routine-verification { color: var(--h4-faint); }
 .hm-mb-item-meta {
   display: block;
   font-family: var(--font-mono);


### PR DESCRIPTION
## What changed

- Added a pure decision ranker that keeps every isDecision card and orders money-blocking, unknown, standard, then routine deploy verification.
- Uses only payload-backed signals: settlement/escrow/treasury/payout repo and file paths, server-provided critical file flags, and explicit links to red/degraded money_path, signer_liquidity, or treasury_liquidity probes.
- Preserves the existing urgency order inside each tier.
- Applies the same selector and ordering to the desktop inbox, banner, and mobile feed.
- Shows a short reason chip on desktop and mobile, including an explicit unknown state instead of implying safety.

## Why

The live queue contains many genuinely distinct decisions, so dedupe would not recover operator attention. Money-path and solvency work must lead the queue while routine post-production verification sinks, without hiding any work.

## Checks

- npx vitest run: 837 passed, 3 pre-existing Harness fixture failures; stashed origin/main baseline: 828 passed, the same 3 failures. Zero new failures.
- Focused ranking/desktop/mobile suite: 72 passed.
- npx tsc --noEmit: the same 3 baseline diagnostics (two existing implicit-any diagnostics in DrawerBody and the existing missing @avg/schemas declaration). Zero new diagnostics.
- npx vite build: passed.
- git diff --check: passed.

## Surface and rollout

- Affects the monitor UI frontend only.
- No backend, indexer, Caddy, contracts, public-site, environment, or VPS secret changes.
- No data migration or manual rollout step.
- Rollback is a revert of commit 1284184.

## Known limit

Probe-based promotion requires both an explicit card-to-probe text link and a red/degraded live probe. Missing linkage stays in the unknown tier; it is never treated as safe.