### PR TITLE
feat(monitor): show what each agent is actually attempting

### DIFF
--- a/packages/monitor-ui/src/components/cards/Card.test.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.test.tsx
@@ -715,4 +715,56 @@ describe("Card — failed mission readable summary", () => {
     expect(text).not.toContain("npx playwright install");
     expect(text).not.toContain("|");
   });
+
+  // #135: the desktop card said "Codex fixing" and stopped there. Both new
+  // lines are payload passthrough; neither is rendered when absent.
+  test("the working-now line states the intent and the last reported step", () => {
+    const running = {
+      id: "pr-562", lane: "hermes-checking", type: "pr", agentType: "claude",
+      title: "PR", summary: "", repo: "depre-dev/agent", freshness: 2,
+      state: "running", risk: [], waitingOn: { actor: "agent", tone: "info" }, files: [],
+      workingNow: {
+        agent: "codex", label: "Codex fixing", source: "runner",
+        intent: "Fix the settlement rounding drift",
+        progress: "Codex is using Edit.",
+        progressAt: new Date(Date.now() - 30_000).toISOString(),
+      },
+    } as unknown as BoardCard;
+
+    const { container } = render(<Card card={running} />);
+    const view = within(container);
+    expect(view.getByText("Fix the settlement rounding drift")).toBeTruthy();
+    expect(view.getByText("Codex is using Edit.")).toBeTruthy();
+    expect(view.getByText("just now")).toBeTruthy();
+    expect(container.querySelector(".hm-wn-step.is-stale")).toBeNull();
+  });
+
+  test("a step that has gone quiet is marked stale rather than shown as current", () => {
+    const running = {
+      id: "pr-563", lane: "hermes-checking", type: "pr", agentType: "claude",
+      title: "PR", summary: "", repo: "depre-dev/agent", freshness: 2,
+      state: "running", risk: [], waitingOn: { actor: "agent", tone: "info" }, files: [],
+      workingNow: {
+        agent: "codex", label: "Codex fixing", source: "runner",
+        progress: "Codex is using Bash.",
+        progressAt: new Date(Date.now() - 40 * 60 * 1000).toISOString(),
+      },
+    } as unknown as BoardCard;
+
+    const { container } = render(<Card card={running} />);
+    expect(container.querySelector(".hm-wn-step.is-stale")).toBeTruthy();
+    expect(within(container).getByText("40m ago")).toBeTruthy();
+  });
+
+  test("a runner with nothing reported says so instead of rendering a blank step", () => {
+    const running = {
+      id: "pr-564", lane: "hermes-checking", type: "pr", agentType: "claude",
+      title: "PR", summary: "", repo: "depre-dev/agent", freshness: 2,
+      state: "running", risk: [], waitingOn: { actor: "agent", tone: "info" }, files: [],
+      workingNow: { agent: "codex", label: "Codex fixing", source: "runner", intent: "Rotate the smoke token" },
+    } as unknown as BoardCard;
+
+    const { container } = render(<Card card={running} />);
+    expect(within(container).getByText("No step reported yet.")).toBeTruthy();
+  });
 });

--- a/packages/monitor-ui/src/components/cards/Card.tsx
+++ b/packages/monitor-ui/src/components/cards/Card.tsx
@@ -36,6 +36,7 @@ import { deployStepsForCard } from "../../lib/monitor/deploy-stepper.js";
 import { shortId } from "../../lib/monitor/card-id.js";
 import { formatFreshness, freshnessTier } from "../../lib/monitor/urgency.js";
 import { laneFor, isWaitingOnOperator } from "../../lib/monitor/lane-rules.js";
+import { describeWorkingNow } from "../../lib/monitor/working-now.js";
 import { humanizedSignalParts, humanizeSignalText } from "../../lib/monitor/signal-labels.js";
 import { missionFailureCardSummary } from "../../lib/monitor/mission-failure.js";
 import { relatedPrForCard } from "../../lib/monitor/collaboration.js";
@@ -437,18 +438,31 @@ function actorDisplayName(actor: "hermes" | "operator" | "codex" | "claude" | "t
   return "Codex";
 }
 
-function WorkingNowLine({ workingNow }: { workingNow: CardWorkingNow }) {
+function WorkingNowLine({ workingNow, nowMs = Date.now() }: { workingNow: CardWorkingNow; nowMs?: number }) {
   const details = [
     workingNow.runnerId ? `runner: ${workingNow.runnerId}` : undefined,
     workingNow.taskId ? `task: ${workingNow.taskId}` : undefined,
     workingNow.since ? `since: ${workingNow.since}` : undefined,
     `source: ${workingNow.source}`,
   ].filter(Boolean).join(" · ");
+  // What it is ATTEMPTING and what it last REPORTED — the half `label` never
+  // said. Each line renders only when the payload actually carried it.
+  const view = describeWorkingNow(workingNow, nowMs);
 
   return (
     <div className="hm-working-now" aria-label={`Working now: ${workingNow.label}`} title={details || undefined}>
-      <AgentTag agent={workingNow.agent} label="working now" />
-      <span className="target">{workingNow.label}</span>
+      <div className="hm-wn-head">
+        <AgentTag agent={workingNow.agent} label="working now" />
+        <span className="target">{workingNow.label}</span>
+      </div>
+      {view?.intent ? <div className="hm-wn-intent">{view.intent}</div> : null}
+      {view?.progress ? (
+        <div className={`hm-wn-step${view.stale ? " is-stale" : ""}`}>
+          <span className="hm-wn-step-text">{view.progress}</span>
+          {view.progressAge ? <span className="hm-wn-step-age">{view.progressAge}</span> : null}
+        </div>
+      ) : null}
+      {view?.emptyNote ? <div className="hm-wn-step is-empty">{view.emptyNote}</div> : null}
     </div>
   );
 }

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -222,4 +222,45 @@ describe("MobileBoard", () => {
     expect(getByText("Nothing waiting on you.")).toBeTruthy();
     expect(within(getByText("Nothing waiting on you.").closest("section")!).getByText(/Needs you/)).toBeTruthy();
   });
+
+  // #135: "Claude fixing" said an agent was busy but never what it was busy
+  // WITH. Both lines are payload passthrough — nothing here is inferred.
+  test("an agent row states what it is ATTEMPTING and its last reported step", () => {
+    const card = taskCard({
+      workingNow: {
+        agent: "claude",
+        label: "Claude fixing",
+        source: "runner",
+        intent: "Fix the settlement rounding drift",
+        progress: "Claude is using Edit.",
+        progressAt: new Date(NOW - 30_000).toISOString(),
+      },
+    } as Partial<BoardCard>);
+    const { getByText } = render(<MobileBoard health={healthyMainnet} cards={[card]} nowMs={NOW} />);
+    expect(getByText("Fix the settlement rounding drift")).toBeTruthy();
+    expect(getByText(/Claude is using Edit\./)).toBeTruthy();
+    expect(getByText(/just now/)).toBeTruthy();
+  });
+
+  test("a step that has gone quiet is toned down, not presented as current", () => {
+    const card = taskCard({
+      workingNow: {
+        agent: "claude", label: "Claude fixing", source: "runner",
+        progress: "Claude is using Bash.",
+        progressAt: new Date(NOW - 40 * 60 * 1000).toISOString(),
+      },
+    } as Partial<BoardCard>);
+    const { container, getByText } = render(<MobileBoard health={healthyMainnet} cards={[card]} nowMs={NOW} />);
+    expect(getByText(/40m ago/)).toBeTruthy();
+    expect(container.querySelector(".hm-mb-agent-step.is-stale")).toBeTruthy();
+  });
+
+  test("a runner that reported nothing says so instead of showing an empty line", () => {
+    const card = taskCard({
+      workingNow: { agent: "codex", label: "Codex fixing", source: "runner", intent: "Rotate the smoke token" },
+    } as Partial<BoardCard>);
+    const { getByText } = render(<MobileBoard health={healthyMainnet} cards={[card]} nowMs={NOW} />);
+    expect(getByText("Rotate the smoke token")).toBeTruthy();
+    expect(getByText("No step reported yet.")).toBeTruthy();
+  });
 });

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -14,9 +14,10 @@
 // two surfaces cannot drift apart or disagree about what is wrong.
 
 import type { ReactNode } from "react";
-import type { BoardCard } from "../../lib/monitor/card-types.js";
+import type { BoardCard, CardWorkingNow } from "../../lib/monitor/card-types.js";
 import type { ProductHealth, SolvencyPool } from "../../lib/monitor/product-health.js";
 import { decisionPriorityFor, rankDecisionCards } from "../../lib/monitor/decision-rank.js";
+import { describeWorkingNow } from "../../lib/monitor/working-now.js";
 import { opsBannerData } from "../ops/ops-frame.js";
 
 export interface MobileBoardProps {
@@ -62,7 +63,7 @@ export function MobileBoard({
           onApproveTask={onApproveTask}
           onDismissCard={onDismissCard}
         />
-        <MobileAgentsCard cards={cards} />
+        <MobileAgentsCard cards={cards} nowMs={nowMs} />
       </div>
 
       <p className="hm-mb-foot">Grey is awaiting data, never fake-green.</p>
@@ -278,23 +279,42 @@ function DecisionRow({
   );
 }
 
-/** Who is actually working right now — real `workingNow` only, never inferred. */
-export function MobileAgentsCard({ cards }: { cards: BoardCard[] }) {
+/**
+ * Who is actually working right now — real `workingNow` only, never inferred.
+ * Away from the desk the useful question isn't "is something running" but
+ * "what is it trying to do", so each row carries the agent's own intent and its
+ * last reported step, aged. A step past the staleness bound is toned down
+ * rather than presented as current.
+ */
+export function MobileAgentsCard({ cards, nowMs }: { cards: BoardCard[]; nowMs: number }) {
   const working = cards
-    .map((card) => (card as { workingNow?: { agent?: string; label?: string } }).workingNow)
-    .filter((w): w is { agent?: string; label?: string } => Boolean(w));
+    .map((card) => (card as { workingNow?: CardWorkingNow }).workingNow)
+    .filter((w): w is CardWorkingNow => Boolean(w));
   return (
     <MobileCard label="Agents">
       {working.length === 0 ? (
         <p className="hm-mb-empty">No agent is running right now.</p>
       ) : (
-        working.map((w, i) => (
-          <div className="hm-mb-agent" key={`${w.agent ?? "agent"}-${i}`}>
-            <span className="hm-mb-jewel" aria-hidden />
-            <span className="hm-mb-agent-name">{w.agent ?? "agent"}</span>
-            <span className="hm-mb-agent-state">{w.label ?? "working"}</span>
-          </div>
-        ))
+        working.map((w, i) => {
+          const view = describeWorkingNow(w, nowMs);
+          return (
+            <div className="hm-mb-agent-row" key={`${w.agent ?? "agent"}-${i}`}>
+              <div className="hm-mb-agent">
+                <span className="hm-mb-jewel" aria-hidden />
+                <span className="hm-mb-agent-name">{w.agent ?? "agent"}</span>
+                <span className="hm-mb-agent-state">{w.label ?? "working"}</span>
+              </div>
+              {view?.intent ? <p className="hm-mb-agent-intent">{view.intent}</p> : null}
+              {view?.progress ? (
+                <p className={`hm-mb-agent-step${view.stale ? " is-stale" : ""}`}>
+                  {view.progress}
+                  {view.progressAge ? <span className="hm-mb-agent-age"> · {view.progressAge}</span> : null}
+                </p>
+              ) : null}
+              {view?.emptyNote ? <p className="hm-mb-agent-step is-empty">{view.emptyNote}</p> : null}
+            </div>
+          );
+        })
       )}
     </MobileCard>
   );

--- a/packages/monitor-ui/src/lib/monitor/card-types.ts
+++ b/packages/monitor-ui/src/lib/monitor/card-types.ts
@@ -149,6 +149,12 @@ export interface CardWorkingNow {
   runnerId?: string;
   taskId?: string;
   since?: string;
+  /** WHAT the agent is attempting, verbatim from the task title/prompt. */
+  intent?: string;
+  /** The agent's own last reported step, verbatim from the runner stream. */
+  progress?: string;
+  /** When `progress` was reported — lets the UI age it instead of implying live. */
+  progressAt?: string;
 }
 
 export interface HermesDecisionSubject {

--- a/packages/monitor-ui/src/lib/monitor/working-now.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/working-now.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "vitest";
+
+import type { CardWorkingNow } from "./card-types.js";
+import { describeWorkingNow, WORKING_NOW_STALE_MS } from "./working-now.js";
+
+const NOW = Date.parse("2026-07-29T12:00:00Z");
+
+function workingNow(over: Partial<CardWorkingNow> = {}): CardWorkingNow {
+  return { agent: "claude", label: "Claude fixing", source: "runner", ...over };
+}
+
+function at(msAgo: number): string {
+  return new Date(NOW - msAgo).toISOString();
+}
+
+describe("describeWorkingNow", () => {
+  test("no workingNow yields nothing at all", () => {
+    expect(describeWorkingNow(undefined, NOW)).toBeUndefined();
+  });
+
+  test("surfaces WHAT the agent is attempting, not just that it is busy", () => {
+    const view = describeWorkingNow(
+      workingNow({ intent: "Fix the settlement rounding drift", progress: "Claude is using Edit.", progressAt: at(30_000) }),
+      NOW,
+    );
+    expect(view?.intent).toBe("Fix the settlement rounding drift");
+    expect(view?.progress).toBe("Claude is using Edit.");
+    expect(view?.progressAge).toBe("just now");
+    expect(view?.stale).toBe(false);
+  });
+
+  test("a runner that has reported nothing SAYS so rather than showing a blank", () => {
+    const view = describeWorkingNow(workingNow({ intent: "Rotate the smoke token" }), NOW);
+    expect(view?.progress).toBeUndefined();
+    expect(view?.emptyNote).toBe("No step reported yet.");
+    expect(view?.stale).toBe(false);
+  });
+
+  test("a step past the bound is stale — it must not keep reading as live", () => {
+    const view = describeWorkingNow(
+      workingNow({ progress: "Claude is using Bash.", progressAt: at(WORKING_NOW_STALE_MS + 60_000) }),
+      NOW,
+    );
+    expect(view?.stale).toBe(true);
+    expect(view?.progressAge).toBe("11m ago");
+  });
+
+  test("the boundary itself is stale, one millisecond earlier is not", () => {
+    expect(describeWorkingNow(workingNow({ progress: "x", progressAt: at(WORKING_NOW_STALE_MS) }), NOW)?.stale).toBe(true);
+    expect(describeWorkingNow(workingNow({ progress: "x", progressAt: at(WORKING_NOW_STALE_MS - 1) }), NOW)?.stale).toBe(false);
+  });
+
+  test("an UNTIMESTAMPED step is shown without an age and never claimed as current", () => {
+    // We can't age it, so we must not imply it is live — but we also must not
+    // hide the only thing the agent told us.
+    const view = describeWorkingNow(workingNow({ progress: "Claude is using Read." }), NOW);
+    expect(view?.progress).toBe("Claude is using Read.");
+    expect(view?.progressAge).toBeUndefined();
+    expect(view?.stale).toBe(false);
+  });
+
+  test("an unparseable timestamp degrades to no-age rather than to 1970", () => {
+    const view = describeWorkingNow(workingNow({ progress: "step", progressAt: "not-a-date" }), NOW);
+    expect(view?.progressAge).toBeUndefined();
+    expect(view?.stale).toBe(false);
+  });
+
+  test("a clock skewed into the future clamps to zero, never a negative age", () => {
+    const view = describeWorkingNow(workingNow({ progress: "step", progressAt: at(-120_000) }), NOW);
+    expect(view?.progressAge).toBe("just now");
+    expect(view?.stale).toBe(false);
+  });
+
+  test("blank strings count as absent, not as content", () => {
+    const view = describeWorkingNow(workingNow({ intent: "   ", progress: "" }), NOW);
+    expect(view?.intent).toBeUndefined();
+    expect(view?.progress).toBeUndefined();
+    expect(view?.emptyNote).toBe("No step reported yet.");
+  });
+
+  test.each([
+    [30 * 60 * 1000, "30m ago"],
+    [3 * 60 * 60 * 1000, "3h ago"],
+    [2 * 24 * 60 * 60 * 1000, "2d ago"],
+  ])("ages coarsely at %ims", (ms, expected) => {
+    expect(describeWorkingNow(workingNow({ progress: "s", progressAt: at(ms) }), NOW)?.progressAge).toBe(expected);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/working-now.ts
+++ b/packages/monitor-ui/src/lib/monitor/working-now.ts
@@ -1,0 +1,98 @@
+// What a running agent is actually attempting — the readable half of
+// `workingNow`.
+//
+// `label` ("Claude fixing") only ever said that SOME agent was busy. The task
+// record already carried what it was asked to do and what the runner last
+// reported; this turns those into something an operator can read at a glance,
+// and — the part that matters — ages the progress line instead of letting a
+// forty-minute-old step sit on the board looking live.
+//
+// Truth boundary: every field here is passed through from the payload. When a
+// signal is missing this says so rather than filling the gap. "No step reported
+// yet" is a real state; inventing activity to fill the line would be the same
+// fake-green as a full meter on an empty pool.
+
+import type { CardWorkingNow } from "./card-types.js";
+
+/**
+ * How long a running agent may go without reporting a step before the board
+ * stops presenting that step as current.
+ *
+ * The runner throttles progress writes to one per 2s and emits on every
+ * assistant event (including each tool call), so healthy gaps are seconds.
+ * Ten minutes is well clear of a slow test run or a long edit while still
+ * catching a runner that died without updating its task status.
+ */
+export const WORKING_NOW_STALE_MS = 10 * 60 * 1000;
+
+export interface WorkingNowView {
+  /** What it was asked to do. Absent when the task carried no title or prompt. */
+  intent?: string;
+  /** The last reported step, verbatim. Absent when nothing has been reported. */
+  progress?: string;
+  /** Age of that step, e.g. "14m ago". Absent when it carried no timestamp. */
+  progressAge?: string;
+  /**
+   * True when the last step is older than WORKING_NOW_STALE_MS. A statement of
+   * fact about the data, NOT a diagnosis — the agent may be mid-way through
+   * something long. The UI tones it down; it must not claim the agent is stuck.
+   */
+  stale: boolean;
+  /** Copy for when the runner has reported nothing yet. */
+  emptyNote?: string;
+}
+
+/**
+ * Project the readable view. Pure: takes `nowMs` rather than reading the clock,
+ * so the staleness boundary is testable.
+ */
+export function describeWorkingNow(
+  workingNow: CardWorkingNow | undefined,
+  nowMs: number,
+): WorkingNowView | undefined {
+  if (!workingNow) return undefined;
+  const intent = nonEmpty(workingNow.intent);
+  const progress = nonEmpty(workingNow.progress);
+  if (!progress) {
+    return {
+      ...(intent ? { intent } : {}),
+      stale: false,
+      emptyNote: "No step reported yet.",
+    };
+  }
+  const at = parseTime(workingNow.progressAt);
+  // No timestamp ⇒ we cannot age it, so we must not imply it is current. Show
+  // the step without an age and leave it untoned rather than guessing.
+  if (at === undefined) {
+    return { ...(intent ? { intent } : {}), progress, stale: false };
+  }
+  const elapsed = Math.max(0, nowMs - at);
+  return {
+    ...(intent ? { intent } : {}),
+    progress,
+    progressAge: formatAge(elapsed),
+    stale: elapsed >= WORKING_NOW_STALE_MS,
+  };
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = (value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parseTime(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Coarse, glanceable ages — "just now", "4m ago", "2h ago", "3d ago". */
+function formatAge(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 45) return "just now";
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${Math.max(1, minutes)}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -195,3 +195,26 @@
   padding: 4px 12px 18px;
   margin: 0;
 }
+
+/* ── agent intent (#135) ─────────────────────────────────────────────────── */
+.hm-mb-agent-row + .hm-mb-agent-row { border-top: 1px solid var(--h4-line-2); margin-top: 9px; padding-top: 9px; }
+.hm-mb-agent-intent {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--h4-ink-2);
+  margin: 3px 0 0 15px;
+  text-wrap: pretty;
+}
+.hm-mb-agent-step {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--h4-muted);
+  margin: 4px 0 0 15px;
+  text-wrap: pretty;
+}
+/* A step nobody has refreshed is warm-grey, the awaiting-data colour — it is
+   NOT evidence the agent is stuck, so it must not read as an alarm either. */
+.hm-mb-agent-step.is-stale { color: var(--h4-tel); }
+.hm-mb-agent-step.is-empty { color: var(--h4-faint); font-style: italic; }
+.hm-mb-agent-age { color: var(--h4-faint); }

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -4055,3 +4055,31 @@ button.hm-turn-pin {
   border-top: 1px solid var(--hm-line);
   margin: 0;
 }
+
+/* Agent intent + last reported step (#135). `label` alone said an agent was
+   busy; these two lines say what it is busy WITH. */
+.hm-working-now { flex-direction: column; align-items: stretch; gap: 4px; }
+.hm-wn-head { display: flex; align-items: center; gap: 8px; }
+.hm-wn-intent {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--h4-ink-2, #d7d3cb);
+  text-wrap: pretty;
+}
+.hm-wn-step {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--h4-muted, #9b968c);
+  text-wrap: pretty;
+}
+.hm-wn-step-text { min-width: 0; overflow-wrap: anywhere; }
+.hm-wn-step-age { color: var(--h4-faint, #6f6a61); white-space: nowrap; flex: none; }
+/* Warm-grey = awaiting/aged, the same token the ops board uses. A step going
+   quiet is a fact about the data, not proof the agent is stuck — so it is
+   toned DOWN, never coloured as an alarm. */
+.hm-wn-step.is-stale, .hm-wn-step.is-stale .hm-wn-step-text { color: var(--h4-tel, #867F78); }
+.hm-wn-step.is-empty { color: var(--h4-faint, #6f6a61); font-style: italic; }

--- a/services/slack-operator/src/monitor-v2.ts
+++ b/services/slack-operator/src/monitor-v2.ts
@@ -141,6 +141,21 @@ export interface CardWorkingNow {
   runnerId?: string;
   taskId?: string;
   since?: string;
+  /**
+   * WHAT the agent is attempting, as the operator wrote it — the task title, or
+   * the opening line of the prompt when a task carries no title. `label` alone
+   * ("Claude fixing") says an agent is busy but never what it is busy WITH.
+   * Absent when the task carries neither; we do not summarise or invent one.
+   */
+  intent?: string;
+  /**
+   * The agent's own last reported step, verbatim from the runner's stream
+   * ("Claude is using Edit.", or its assistant text). Never synthesised — when
+   * the runner has reported nothing, this is absent and the UI says so.
+   */
+  progress?: string;
+  /** When `progress` was reported, so the UI can age it instead of implying it is live. */
+  progressAt?: string;
 }
 
 /** One CI check run, for the per-check breakdown under the checks bar. */
@@ -861,6 +876,12 @@ function workingNowFromRunningTask(
   const label = asString(persisted?.label) ?? defaultWorkingNowLabel(agent);
   const runnerId = asString(persisted?.runnerId) ?? asString(task.runnerId) ?? asString(runner.runnerId);
   const since = asString(persisted?.since) ?? asString(task.startedAt) ?? asString(runner.updatedAt);
+  // The task already carries WHAT it was asked to do and WHAT the runner last
+  // reported; both were simply never projected onto the card. Read them
+  // straight through — no summarising, no inference.
+  const intent = workingNowIntent(task);
+  const progress = asString(task.progressMessage);
+  const progressAt = asString(task.progressAt);
   return {
     agent,
     label,
@@ -868,7 +889,29 @@ function workingNowFromRunningTask(
     taskId,
     ...(runnerId ? { runnerId } : {}),
     ...(since ? { since } : {}),
+    ...(intent ? { intent } : {}),
+    ...(progress ? { progress } : {}),
+    ...(progress && progressAt ? { progressAt } : {}),
   };
+}
+
+/** Longest intent we put on a card before the drawer takes over. */
+const WORKING_NOW_INTENT_MAX = 140;
+
+/**
+ * What the agent is attempting, taken verbatim from the task. Prefers the
+ * operator-facing title; falls back to the prompt's first non-empty line, which
+ * is where a titleless task states its objective. Truncation is marked with an
+ * ellipsis so a clipped intent never reads as the whole instruction.
+ */
+function workingNowIntent(task: Record<string, unknown>): string | undefined {
+  const title = asString(task.title);
+  const raw = title ?? asString(task.prompt)?.split("\n").map((line) => line.trim()).find(Boolean);
+  if (!raw) return undefined;
+  const text = humanizeTaskTitle(raw);
+  return text.length > WORKING_NOW_INTENT_MAX
+    ? `${text.slice(0, WORKING_NOW_INTENT_MAX - 1).trimEnd()}…`
+    : text;
 }
 
 /** Project a running mission's live poll snapshot (stage + recent output). */

--- a/test/unit/monitor-v2.test.ts
+++ b/test/unit/monitor-v2.test.ts
@@ -766,7 +766,61 @@ describe("enrichBoardCard", () => {
       taskId: "task-1",
       runnerId: "runner-a",
       since: "2026-05-28T11:55:00Z",
+      // #135: a titleless task states its objective in the prompt's first line.
+      intent: "Coalesce repeated policy-attach entries",
     });
+  });
+
+  // #135: the task record already carried WHAT it was asked to do and WHAT the
+  // runner last reported; neither was ever projected onto the card, so the
+  // board could only ever say "Codex fixing".
+  it("projects the agent's intent and its last reported step onto a running task", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: {
+        id: "task-2",
+        status: "running",
+        title: "Fix the settlement rounding drift",
+        prompt: "Long prompt body that must NOT win over the title.",
+        progressMessage: "Codex is using Edit.",
+        progressAt: "2026-05-28T12:00:30Z",
+        workingNow: { agent: "codex", runnerId: "runner-a", label: "Codex fixing", since: "2026-05-28T11:55:00Z" },
+      },
+      runner: { status: "running", runnerId: "runner-a", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "task-2" },
+    });
+    expect(card.workingNow).toMatchObject({
+      intent: "Fix the settlement rounding drift",
+      progress: "Codex is using Edit.",
+      progressAt: "2026-05-28T12:00:30Z",
+    });
+  });
+
+  it("omits progress entirely when the runner has reported nothing", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: {
+        id: "task-3",
+        status: "running",
+        title: "Rotate the smoke token",
+        workingNow: { agent: "codex", runnerId: "runner-a", label: "Codex fixing", since: "2026-05-28T11:55:00Z" },
+      },
+      runner: { status: "running", runnerId: "runner-a", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "task-3" },
+    });
+    expect(card.workingNow?.intent).toBe("Rotate the smoke token");
+    expect(card.workingNow?.progress).toBeUndefined();
+    expect(card.workingNow?.progressAt).toBeUndefined();
+  });
+
+  it("drops a progress timestamp that arrives without its message", () => {
+    const card = enrichBoardCard(base({ type: "task", lane: "codex-needed" }), slim({ lane: "Codex Needed" }), {
+      codexTask: {
+        id: "task-4",
+        status: "running",
+        title: "T",
+        progressAt: "2026-05-28T12:00:30Z",
+        workingNow: { agent: "codex", runnerId: "runner-a", label: "Codex fixing", since: "2026-05-28T11:55:00Z" },
+      },
+      runner: { status: "running", runnerId: "runner-a", updatedAt: "2026-05-28T12:00:00Z", activeTaskId: "task-4" },
+    });
+    expect(card.workingNow?.progressAt).toBeUndefined();
   });
 
   it("shows the runner currently working a PR separately from branch author attribution", () => {


### PR DESCRIPTION
Closes the unbuilt half of the agent-visibility work: the board could say an agent was busy, never what it was busy **with**.

`workingNow.label` is a static per-agent verb chosen at claim time, so every running Claude task read "Claude fixing" no matter the work.

## Nothing new is collected
The task record already carried both halves; neither was projected onto the card.

| | source | already existed |
|---|---|---|
| **intent** — what it was asked to do | task `title`, or the prompt's first line when titleless | yes |
| **progress** — what it last reported | `progressMessage`, written by the runner from the agent's own stream (`"Codex is using Edit."`, assistant text) on a 2s throttle | yes |
| **progressAt** — when | written alongside it | yes |

Intents get the same `humanizeTaskTitle` cleanup card titles already get. Both surfaces render from one pure helper (`describeWorkingNow`), so the phone and the desktop card cannot disagree.

## Truth boundary
- Every field is **payload passthrough** — no summarising, no inference.
- A step older than **10 minutes** is toned to the warm-grey awaiting-data colour instead of continuing to read as current. That's a statement about the **data**, not a diagnosis — a long test run is not a stuck agent, so it's toned *down*, never coloured as an alarm.
- A step with **no timestamp** is shown *without* an age rather than assumed current; an unparseable one degrades to no-age, not to 1970.
- A future-skewed clock clamps to zero, never a negative age.
- A runner that has reported nothing says **"No step reported yet."** rather than rendering a blank line.
- A clipped intent keeps an ellipsis so it never reads as the whole instruction.

The 10-minute bound is deliberate: the runner emits on every assistant event including each tool call, so healthy gaps are seconds. Ten minutes clears a slow test run while still catching a runner that died without updating its task status.

## Verification
- `packages/monitor-ui`: **847 → 865**, zero failures.
- `test/unit/monitor-v2.test.ts`: back to its pre-existing **19** failures (the `@avg/schemas` env issue) with **+3 passing**. One existing assertion updated — it used `toEqual` and now correctly sees `intent`.
- `tsc` slack-operator: diffed before/after — **byte-identical modulo line-number shift** (errors moved exactly the 43 lines added).
- `tsc` monitor-ui: same pre-existing 3. `vite build` green.

## Still open on this thread
Reward-payout evidence stays flagged off (`PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=false`) pending Codex task `795lmh` — `eth_getLogs` returns zero logs of any kind from the USDC precompile on this chain, so that half needs a different source, not a different address.