### PR TITLE
fix(ops): read payout evidence from our own contract event, not USDC Transfer

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -359,12 +359,27 @@ services:
       # redeploys that would wipe any in-memory retention.
       PRODUCT_HEALTH_INCIDENT_LOG_PATH: ${PRODUCT_HEALTH_INCIDENT_LOG_PATH:-/data/product-health-incidents.jsonl}
       PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED: ${PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED:-false}
-      # ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
-      # The address USDC actually LEAVES on a payout. Defaults to /health's
+      # The contract that EMITS the payout event. Defaults to /health's
       # addresses.agentAccountCore — the reward bank is an IN-CONTRACT position,
-      # so the signer EOA only sends the tx and pays gas; it is never the
-      # Transfer `from`. Filtering on the signer finds zero and looks exactly
-      # like total payout failure (it did, on the first live run).
+      # so the signer EOA only sends the tx and pays gas. Filtering on the
+      # signer finds zero and looks exactly like total payout failure (it did,
+      # on the first live run).
+      #
+      # The probe watches AgentAccountCore's
+      #   ReservationSettled(bytes32 jobId, address account, address recipient,
+      #                      address asset, uint256 amount)
+      # topic0 0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee
+      # — NOT an ERC-20 Transfer. USDC is asset 1337 behind the precompile at
+      # 0x…1200000, which bridges to the Substrate assets pallet: transfers are
+      # PALLET events and never reach EVM log space. Verified on mainnet
+      # 2026-07-29 — that address has emitted zero logs, and there is not one
+      # ERC-20 Transfer topic anywhere on the chain.
+      #
+      # WATCH OUT: the DEPLOYED signature has drifted from contracts/*.sol —
+      # the live event carries a leading bytes32 jobId the checked-in source
+      # does not. If payouts ever read "unverified" with a healthy chain, the
+      # topic0 above is the first thing to re-derive against the deployed
+      # contract, not the last.
       PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS: ${PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS:-}
       PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS: ${PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS:-14400}
       # settled-minus-confirmed gap tolerated as a window-boundary artifact — the

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -990,12 +990,40 @@ async function ethRpc(
   return result;
 }
 
-// keccak256("Transfer(address,address,uint256)") — the ERC-20 Transfer topic.
-const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+/**
+ * keccak256("ReservationSettled(bytes32,address,address,address,uint256)") — the
+ * AgentAccountCore event a reward payout emits.
+ *
+ * NOT the ERC-20 Transfer topic. USDC here is asset 1337 behind the precompile
+ * at 0x…1200000, which bridges to the Substrate assets pallet: a transfer is a
+ * PALLET event and never enters EVM log space. Verified on mainnet 2026-07-29 —
+ * that address has emitted zero logs, and there is not a single ERC-20 Transfer
+ * topic anywhere on the chain. Watching for one finds nothing forever, which is
+ * indistinguishable from total payout failure.
+ *
+ * `eth_getLogs` itself works fine (368 logs over a ~130k-block window); an
+ * earlier 200-block sample of a mostly-empty chain wrongly suggested otherwise.
+ * Our own contracts emit normally, so the payout is read from OUR event — which
+ * is better evidence anyway: it is semantic, correlates 1:1 with a settlement,
+ * and is independent of the backend's own claim, which is the entire point.
+ *
+ * Layout (indexed → topics, the rest → data):
+ *   topic1 jobId · topic2 account · topic3 recipient
+ *   data[0] asset · data[1] amount
+ */
+const RESERVATION_SETTLED_TOPIC = "0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee";
 
-/** Pad an address to a 32-byte topic (topic1 = indexed `from`). */
+/** Pad an address to a 32-byte topic. */
 function addressTopic(address: string): string {
   return `0x${address.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+}
+
+/** One 32-byte word of a log's `data`, or undefined when it is not there. */
+function dataWord(data: unknown, index: number): string | undefined {
+  if (typeof data !== "string") return undefined;
+  const body = data.replace(/^0x/, "");
+  const start = index * 64;
+  return body.length >= start + 64 ? body.slice(start, start + 64) : undefined;
 }
 
 /**
@@ -1039,17 +1067,21 @@ export function decidePayoutEvidence(input: {
     return { ...base, status: "confirmed", detail: `${paid} · no settled count to compare` };
   }
   // A 100% miss is overwhelmingly a MISCONFIGURED FILTER, not 100% payout
-  // failure: point this at the wrong source address and you observe exactly
-  // zero transfers, which is indistinguishable from total failure. That is not
-  // hypothetical — the first live run watched the signer EOA instead of
-  // AgentAccountCore and put "12 unaccounted for" on a live money board.
+  // failure: point this at the wrong address or topic and you observe exactly
+  // zero events, which is indistinguishable from total failure. That is not
+  // hypothetical, and it has now happened twice — first watching the signer EOA
+  // instead of AgentAccountCore ("12 unaccounted for" on a live money board),
+  // then watching for an ERC-20 Transfer the USDC precompile never emits. The
+  // deployed event signature can also drift from the contract source (it has:
+  // the live ReservationSettled carries a jobId the checked-in source lacks),
+  // so a silent zero stays a question about the INSTRUMENT, not the money.
   // Refuse to accuse the money until the instrument has proven it can see
   // anything at all; one observed transfer is enough to trust it.
   if (input.confirmedCount === 0) {
     return {
       ...base,
       status: "unverified",
-      detail: `no transfers found from the configured payout source while ${input.settledCount} job${input.settledCount === 1 ? " is" : "s are"} marked settled — check the source address before suspecting the payouts`,
+      detail: `no payout events found on the configured payout contract while ${input.settledCount} job${input.settledCount === 1 ? " is" : "s are"} marked settled — check the contract address and event topic before suspecting the payouts`,
     };
   }
   const shortfall = input.settledCount - input.confirmedCount;
@@ -1064,7 +1096,8 @@ export function decidePayoutEvidence(input: {
 }
 
 /**
- * Read USDC Transfer logs FROM the signer over a recent block window.
+ * Read AgentAccountCore `ReservationSettled` logs over a recent block window —
+ * the on-chain record of a reward actually leaving the reward bank.
  *
  * Guarded the same way balances are (#543): logs are only trusted from an
  * endpoint on the product's chain, because a wrong-chain endpoint would return
@@ -1074,12 +1107,11 @@ export function decidePayoutEvidence(input: {
 export async function readPayoutTransfers(input: {
   rpcUrl?: string;
   /**
-   * The address USDC actually LEAVES on a payout — AgentAccountCore, not the
-   * signer EOA. The reward bank is an in-contract position (see #558), so the
-   * signer merely SENDS the transaction and pays the gas; the Transfer event's
-   * `from` is the contract holding the funds. Filtering on the signer finds
-   * nothing and looks exactly like total payout failure — which is precisely
-   * what it did on the first live run (12 settled, 0 found).
+   * The contract that EMITS the payout event — AgentAccountCore, which is also
+   * where the reward bank lives as an in-contract position (see #558). The
+   * signer EOA merely sends the transaction and pays gas, so watching the
+   * signer finds nothing and looks exactly like total payout failure — which is
+   * precisely what it did on the first live run (12 settled, 0 found).
    */
   sourceAddress?: string;
   usdcAddress?: string;
@@ -1114,8 +1146,9 @@ export async function readPayoutTransfers(input: {
       [{
         fromBlock: `0x${fromBlock.toString(16)}`,
         toBlock: "latest",
-        address: input.usdcAddress,
-        topics: [TRANSFER_TOPIC, addressTopic(input.sourceAddress)],
+        // The CONTRACT THAT EMITS the payout event, not the token.
+        address: input.sourceAddress,
+        topics: [RESERVATION_SETTLED_TOPIC],
       }],
       input.fetchImpl,
     );
@@ -1123,18 +1156,29 @@ export async function readPayoutTransfers(input: {
       return { count: null, usdc: null, windowBlocks: null, reason: "payout evidence unverified — eth_getLogs returned no array" };
     }
     let total = 0n;
+    let counted = 0;
+    const wantAsset = input.usdcAddress.toLowerCase().replace(/^0x/, "").padStart(64, "0");
     for (const entry of logs) {
       const data = (entry as { data?: unknown }).data;
-      if (typeof data === "string" && data.length > 2) {
-        try {
-          total += BigInt(data);
-        } catch {
-          // A malformed value is not a reason to under-report the count.
-        }
+      // data[0] is the ASSET. Counting a DOT settlement as USDC would break the
+      // unit invariant the same way the display math once did, so a payout in
+      // another asset is skipped rather than folded into a USDC total.
+      const asset = dataWord(data, 0);
+      if (asset === undefined || asset.toLowerCase() !== wantAsset) continue;
+      // data[1] is the AMOUNT. Reading the whole `data` as one integer — which
+      // is right for a single-word Transfer — would be off by ~10^48 here.
+      const amount = dataWord(data, 1);
+      if (amount === undefined) continue;
+      try {
+        total += BigInt(`0x${amount}`);
+        counted += 1;
+      } catch {
+        // A malformed value is not a reason to under-report the count.
+        counted += 1;
       }
     }
     return {
-      count: logs.length,
+      count: counted,
       usdc: Number(total) / 10 ** input.usdcDecimals,
       windowBlocks: latest - fromBlock,
     };

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -1464,11 +1464,28 @@ describe("decidePayoutEvidence (pure verdict)", () => {
 });
 
 describe("readPayoutTransfers (chain-guarded log read)", () => {
+  const USDC = "0x0000053900000000000000000000000001200000";
   const cfg = {
-    rpcUrl: "http://rpc", sourceAddress: "0xaac", usdcAddress: "0xusdc",
+    rpcUrl: "http://rpc", sourceAddress: "0xaac", usdcAddress: USDC,
     usdcDecimals: 6, lookbackBlocks: 100,
   };
-  // eth_chainId → chain, eth_blockNumber → height, eth_getLogs → transfers.
+  const word = (v: string) => v.replace(/^0x/, "").padStart(64, "0");
+  /**
+   * A ReservationSettled log, shaped exactly as mainnet emits it:
+   * data = [asset, amount]. Captured from a real payout on 2026-07-29
+   * (0.1 USDC, block ~18.8M) — the layout this probe has to parse.
+   */
+  const settled = (usdc: number, asset: string = USDC) => ({
+    topics: [
+      "0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee",
+      `0x${word("0xj0b")}`,
+      `0x${word("0x5a6836c6d4d293f6e5377e6c28054f4171915813")}`,
+      `0x${word("0x1734cd78a79cb3c1d926af5ae0ab466d9dfddc55")}`,
+    ],
+    data: `0x${word(asset)}${word(`0x${Math.round(usdc * 1e6).toString(16)}`)}`,
+  });
+
+  // eth_chainId → chain, eth_blockNumber → height, eth_getLogs → payout events.
   function rpc(chainIdHex: string, logs: unknown): typeof fetch {
     return (async (_u: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       const m = rpcMethod(init ?? {});
@@ -1477,16 +1494,41 @@ describe("readPayoutTransfers (chain-guarded log read)", () => {
     }) as unknown as typeof fetch;
   }
 
-  it("counts transfers and sums the USDC actually moved", async () => {
-    const logs = [{ data: "0xf4240" }, { data: "0x1e8480" }]; // 1 + 2 USDC
+  it("counts payout events and sums the USDC actually moved", async () => {
+    const logs = [settled(1), settled(2)];
     const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", logs) });
     expect(r.count).toBe(2);
     expect(r.usdc).toBeCloseTo(3, 6);
     expect(r.windowBlocks).toBe(100);
   });
 
+  // The amount is the SECOND data word. Reading the whole 64-byte `data` as one
+  // integer — correct for a single-word ERC-20 Transfer — is off by ~10^48 and
+  // would put an absurd USDC figure on a live money board.
+  it("reads the amount from data[1], not from the whole data blob", async () => {
+    const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", [settled(0.1)]) });
+    expect(r.usdc).toBeCloseTo(0.1, 6);
+  });
+
+  // Invariant 9: a settlement in another asset is NOT USDC. Folding it into the
+  // USDC total is the same class of error as the DOT/USDC display math (#…).
+  it("skips a settlement in a DIFFERENT asset rather than counting it as USDC", async () => {
+    const other = "0x0000006400000000000000000000000001200000";
+    const logs = [settled(1), settled(99, other)];
+    const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", logs) });
+    expect(r.count).toBe(1);
+    expect(r.usdc).toBeCloseTo(1, 6);
+  });
+
+  it("a truncated log is skipped, never counted as a zero-value payout", async () => {
+    const logs = [settled(1), { topics: [], data: "0x" }];
+    const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", logs) });
+    expect(r.count).toBe(1);
+    expect(r.usdc).toBeCloseTo(1, 6);
+  });
+
   it("refuses logs from the WRONG CHAIN — same guard as balances (#543)", async () => {
-    const logs = [{ data: "0xf4240" }];
+    const logs = [settled(1)];
     const r = await readPayoutTransfers({ ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b41", logs) });
     expect(r.count).toBeNull(); // a wrong-chain payout count would be confidently wrong
     expect(r.reason).toContain("chain 420420417");
@@ -1520,7 +1562,7 @@ describe("decidePayoutEvidence — a 100% miss is a broken filter, not lost mone
   it("zero confirmed against real settled jobs is UNVERIFIED, never a shortfall", () => {
     const r = decidePayoutEvidence({ ...base, confirmedCount: 0, confirmedUsdc: 0, settledCount: 12 });
     expect(r.status).toBe("unverified"); // was "shortfall" — the false alarm
-    expect(r.detail).toContain("check the source address");
+    expect(r.detail).toContain("check the contract address and event topic");
     expect(r.detail).not.toContain("unaccounted for");
   });
 


### PR DESCRIPTION
Unblocks reward-payout visibility. **The blocker was a wrong assumption of mine, not a chain limitation.**

## What was wrong
The probe watched for an ERC-20 `Transfer` from AgentAccountCore. That event does not exist and never will: USDC here is asset 1337 behind the precompile at `0x…1200000`, which bridges to the Substrate assets pallet — a transfer is a **pallet** event and never enters EVM log space. Verified on mainnet: that address has emitted **zero** logs, and there is not one ERC-20 `Transfer` topic anywhere on the chain.

I then concluded from a 200-block sample that `eth_getLogs` returns nothing at all here and payout verification was impossible. **That was wrong and it blocked this for no reason.** `eth_getLogs` is fine — 368 logs over ~130k blocks. Polkadot Hub blocks are mostly empty, so a small sample looks like a dead chain.

## The right source
Our own contracts emit normally. Over that window: `escrowCore` **189** logs (9 event types × 21), `agentAccountCore` **42** (2 × 21) — 21 complete job lifecycles. The payout is:

```
ReservationSettled(bytes32 jobId, address account, address recipient,
                   address asset, uint256 amount)
topic0 0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee
```

Decoded from a real mainnet log: jobId, our signer, the recipient agent, the USDC asset, 0.1 USDC. **This is better evidence than a token transfer would have been** — semantic, 1:1 with a settlement, and independent of the backend's own claim, which is the entire point of the probe.

## Two parsing consequences (both tested)
- The amount is **`data[1]`**, not the whole blob. Reading all 64 bytes as one integer — correct for a single-word `Transfer` — is off by ~10^48 and would put an absurd figure on a live money board.
- **`data[0]` is the asset**, so a settlement in another asset is skipped rather than folded into a USDC total. Invariant 9.

## Deployment drift — worth knowing
The **deployed** signature has drifted from `contracts/*.sol`: the live event carries a leading `bytes32 jobId` the checked-in source lacks. I found the topic by decoding a real log and confirming by keccak brute force. Recorded in the compose comment as the first thing to re-derive if payouts ever read unverified on a healthy chain.

`decidePayoutEvidence` and its zero-confirmed → `unverified` guard are **unchanged**, and now matter more: a drifted topic0 also produces a silent zero, which is exactly the shape that once put "12 unaccounted for" on a live money board.

## Verification
- **Live mainnet, production config, 14400-block window: 2 payout events, 2 USDC-asset confirmed, 0.2000 USDC, 2 distinct recipients.** A real green read.
- The throttled path was exercised too (I hit the RPC rate limit mid-test): returns `unverified` with an honest reason, never a zero.
- `test/unit` at its pre-existing **110** failures with **+3 passing**.
- `slack-operator` tsc identical modulo line shifts.

## To turn it on
Flag stays default-false. Set `PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true` in the `.env.prod` **file** (shell vars are ignored by `docker compose --env-file`). `PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS` needs nothing — it already defaults to `/health`'s `addresses.agentAccountCore`, which is the correct emitter.