### PR TITLE
feat(int2): automate supervised dispatch proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -76,3 +78,44 @@ jobs:
       - name: Validate Compose file
         run: docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config
 
+  int2-supervised-dispatch:
+    name: INT-2 real dispatcher integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@v4
+        with:
+          # The scripted fixtures pin an older approved revision. A shallow
+          # checkout makes the local-only Git remote unable to serve it.
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install reference dependencies
+        run: npm ci
+
+      - name: Run required INT-2 mechanism suite
+        env:
+          INT2_SUITE_EVIDENCE_DIR: ${{ runner.temp }}/int2-suite-evidence
+        run: scripts/ceremony/run-int2-automated-suite.sh
+
+      - name: Prove the suite did not skip
+        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "9"
+
+      - name: Upload INT-2 evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: int2-supervised-dispatch-evidence
+          path: ${{ runner.temp }}/int2-suite-evidence
+          if-no-files-found: error

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,12 @@ npm test          # vitest run — must pass
 npm run build     # tsc -b emit (only needed to validate emit / run dist)
 ```
 
+Changes that can affect supervised Harness dispatch are additionally gated in
+CI by `scripts/ceremony/run-int2-automated-suite.sh`. It runs the deterministic
+INT-2 cases against the real dispatcher, disposable Postgres databases, the
+pinned Harness and Docker. Local `npm test` skips that slow tier unless its
+explicit environment is present; CI fails if the suite skips.
+
 If you touched `ops/`, the `Dockerfile`, or compose files, also validate what CI validates:
 
 ```bash
@@ -89,6 +95,7 @@ that SSH in to invoke Hermes. Don't edit the platform repo from here.
 | `ops/` | Docker Compose stack (`compose.yml`, `compose.prod.yml`, `compose.command-center.yml`, `compose.cloudflare-access.yml`), migrations |
 | `hermes/` | Hermes config (`hermes.yaml`, `policy.yaml`) + trace plugin |
 | `test/unit/` | Vitest suites (alongside `*.test.ts(x)` colocated in packages) |
+| `test/integration/` | Postgres and supervised-dispatch integration suites; slow external prerequisites are explicit and fail-required in their CI jobs |
 
 TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, ESM
 (`"type": "module"`, `NodeNext`), `strict` on.
@@ -238,6 +245,9 @@ CODEX_HANDOFF_PROTOCOL) is a separate release signal.
 1. **Typecheck + unit tests** on Node 22 (`npm ci` → `npm run typecheck` → `npm test`).
 2. **Docker build** of `ops/Dockerfile.node` (also builds the in-image Vite SPA) +
    **compose config validation**. On `main` it also pushes the runtime image to GHCR.
+3. **INT-2 supervised dispatch** in a separate required job: real dispatcher,
+   two disposable Postgres databases, Harness pin `0890a1f0`, Docker-isolated
+   scripted runs, and an executed-count assertion so skipping cannot pass.
 
 Run the smallest relevant subset locally before opening a PR. **Do not bypass
 failing checks.**

--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -1,0 +1,284 @@
+# INT-2 handback — automated supervised-dispatch suite
+
+**Status:** implementation and clean-checkout gates complete; independent review
+pending
+
+**Baseline:** `47de9f3bdb25eda7354297a951b9927368194791`
+
+**Implementation commit:** `a4066b4446290e91ec9e2a60589f76d9c8825a03`
+
+**Harness pin:** `0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2`
+
+**Runtime authority change:** none; this adds evidence, operator scripts, tests,
+and CI wiring without changing dispatcher or kernel runtime code
+
+## Built
+
+- Added a fail-required INT-2 integration suite that drives the real production
+  dispatcher, two disposable Postgres databases, the pinned Harness worker, the
+  Docker provider with `--network none`, and the committed scripted fixtures.
+- Added one shared evidence collector/verifier,
+  `scripts/ceremony/int2-evidence.mjs`, used by both the automated suite and the
+  operator verification scripts. It captures the AgentTask, claims, outbox,
+  decisions, Harness run/events/deliverables, reconstructed patch, criterion
+  result, manifest identity, eligibility evidence, and absence of pull-request
+  references.
+- Moved the six operator scripts into `scripts/ceremony/` and covered their
+  syntax and critical safety properties:
+  - `int2-bringup.sh`
+  - `int2-green-setup.sh`
+  - `int2-negative-setup.sh`
+  - `int2-green-verify.sh`
+  - `int2-negative-verify.sh`
+  - `int2-teardown.sh`
+- Preserved the human approval path. Automated approvals call the same
+  `runPilotCli(["approve", ..., "--confirm"])` implementation as the CLI,
+  including approved-task hashing and independently derived run identity.
+- Added an explicit unapproved-task case. Production dispatch sees no
+  dispatchable task and creates no claim, run, outbox binding, or decision.
+- Added the corrected §2.4 pair:
+  - `memory.propose` is rejected by the outer production profile loader as
+    `ProfileManifestError/unvetted_capability`, with no run, outbox, handoff, or
+    attenuation-flavoured refusal record;
+  - removing `fs.write_file` is accepted and the run manifest contains the
+    exact seven-capability effective authority.
+- Pinned the attenuation guards at their actual typed boundary:
+  - seven approved task grants plus the eight-capability profile produces
+    `capability_not_granted`;
+  - an external-effect profile capability produces
+    `capability_effect_external`;
+  - `VETTED_CAPABILITIES` and `PILOT_CAPABILITY_IDS` are asserted equal as sets,
+    documenting why neither inner error is reachable through production profile
+    loading today.
+- Added explicit replay to the restart case: after the first dispatcher submits,
+  the suite submits the same intent with the same run id, restarts the
+  dispatcher, and observes one run at attempt 1, one claim, and one outbox
+  binding.
+- Added a separate GitHub Actions job on every PR and `main`. It uses full Git
+  history, runs the real tier, requires exactly nine executed cases, and uploads
+  the evidence bundle even on failure. The fast job also uses full history
+  because the controlled-pair unit preflight resolves the fixture's pinned base.
+- Updated the runbook acceptance map to distinguish CI mechanism evidence from
+  human operator-practice evidence.
+
+No dispatcher production module, task schema, database migration, profile
+allowlist, fixture fence, acceptance criterion, kernel file, dependency,
+lockfile, wallet, settlement, deployment, or pull-request-opening path changed.
+
+## Exact case invariants
+
+All evidence cases reject any pull-request binding or URL. Every decision must
+be non-mutating with `mutations=[]`, except the HALT case's exact
+authority-reducing cancellation described below.
+
+| Case | Exact asserted result |
+|---|---|
+| Controlled red/green pair | Fixture fences are byte-equivalent across repository, profile, acceptance, budget, deadline, and risk. Both append one line to the same already-tracked `docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md`; all scripted-turn fields except the appended content are identical. Both produce non-empty `git diff --numstat`. Green returns exit 0; red returns exit 2 and names trailing whitespace; neither returns exit 128. |
+| Unapproved | Stored lifecycle remains `proposed`; production dispatcher returns idle; zero claims, outbox rows, runs, decisions, handoffs, and PR references. |
+| Approval-hash mismatch | Stored lifecycle is `blocked`; exactly one non-mutating `dispatch_refusal` with `approval_hash_mismatch`; zero claims, outbox rows, runs, handoffs, and PR references. |
+| Negative | Lifecycle `failed`; one run with the independently derived id, attempt 1, state `learning_processed`, outcome `failed`; one claim and one outbox binding; exactly one non-mutating `dispatch_approval` and no handoff/refusal. Manifest ref/hash are present and equal. The non-empty patch applies at the approved base and touches only the tracked expected path. The required criterion reports `exit_2`, names trailing whitespace, and has no exit 128. |
+| Green | Lifecycle `handoff_ready`; one derived-id run at attempt 1, state `learning_processed`, outcome `completed`; one claim and one outbox binding; exactly two non-mutating records, one `dispatch_approval` and one `handoff`. Manifest ref/hash match. The non-empty patch applies at the approved base, touches only the expected tracked path, and reconstructs to exit 0. Handoff evidence refs are non-empty and record both `eligible_for_pr_open=true` and the exact eligibility reason. No PR is opened. |
+| Replay/restart | First dispatcher submits, the identical intent is re-submitted under the same run id, and a new dispatcher reconciles it. Final invariants equal green: one run at attempt 1, one claim, one outbox binding, the same immutable run id, the exact decision pair, verified patch, and no PR. |
+| HALT | A real worker reaches `executing` on a bounded `sleep 30` tool call. Creating the configured HALT file yields task/run lifecycle `cancelled`; one run at attempt 1, one claim, one outbox, one `dispatch_approval`, no handoff, and one `escalation` decision carrying exactly `agent-task/cancelled` plus `agent-harness/cancel`. No other mutation and no PR is allowed. |
+| Narrower profile | The approved AgentTask retains its eight grants while the profile removes `fs.write_file`. The run completes and hands off as green, but its effective manifest contains exactly the other seven capabilities and never `fs.write_file`. |
+| Unvetted profile | Adding `memory.propose` produces the actual outer `ProfileManifestError/unvetted_capability`; dispatcher tick is operator-visible as an error. The task remains `approved`. The production dispatcher has already acquired one dispatch claim before loading the profile, but creates zero runs, outbox rows, decisions, handoffs, or PR references. This is explicitly not reported as `capability_not_granted`. |
+
+The final clean evidence rows were:
+
+```text
+case              lifecycle       claims  outbox  runs  attempt  run state           outcome    decisions
+green             handoff_ready   1       1       1     1        learning_processed  completed  dispatch_approval,handoff
+halt              cancelled       1       1       1     1        cancelled           cancelled  dispatch_approval,escalation
+hash-mismatch     blocked         0       0       0     -        -                   -          dispatch_refusal
+narrow            handoff_ready   1       1       1     1        learning_processed  completed  dispatch_approval,handoff
+negative          failed          1       1       1     1        learning_processed  failed     dispatch_approval
+profile-unvetted  approved        1       0       0     -        -                   -          -
+restart           handoff_ready   1       1       1     1        learning_processed  completed  dispatch_approval,handoff
+unapproved        proposed        0       0       0     -        -                   -          -
+```
+
+## D3 — every case can fail
+
+The shared verifier is the gate for both operator and CI evidence. Each case
+mutates an input to that verifier and asserts the named invariant failure; the
+controlled pair additionally runs both real criterion outcomes.
+
+| Case | D3 mutation | Observed failure |
+|---|---|---|
+| Controlled pair | Use the red fixture's trailing-whitespace append against the same tracked target and fence. | Real `git diff --check` exit 2. A separate unit mutation replaces red with green and is rejected because the pair no longer differs. |
+| Unapproved | Change stored lifecycle evidence from `proposed` to `approved`. | `terminal_lifecycle` |
+| Approval-hash mismatch | Replace the recorded refusal reason. | `decision_reason` |
+| Negative | Inject an exit-128 marker into the verifier evidence. | `events_have_no_exit_128` |
+| Green | Erase the reconstructed non-empty `git diff --numstat`. | `criterion_inspected_non_empty_diff` |
+| Replay/restart | Duplicate the Harness run projection. | `one_harness_run` |
+| HALT | Remove the escalation decision. | `decision_escalation_count` |
+| Narrower profile | Restore `fs.write_file` to the effective manifest. | `effective_authority_narrowed` |
+| Unvetted profile | Relabel the outer loader error as the unreachable inner guard. | `outer_profile_loader_refusal` |
+
+## Production and typed attenuation boundary
+
+The evidence bundle records:
+
+```json
+{
+  "production": [
+    "profile_loader_unvetted_capability",
+    "narrower_profile_accepted"
+  ],
+  "typedOnly": [
+    "capability_not_granted",
+    "capability_effect_external"
+  ],
+  "typedChecksReachableThroughProductionProfileLoading": false
+}
+```
+
+This is not presented as a production-path attenuation refusal. The production
+loader is the stronger outer boundary and runs first. `VETTED_CAPABILITIES` was
+not widened.
+
+## CI and operator split
+
+CI now covers the deterministic mechanism on every PR and `main`: controlled
+red/green verification, unapproved refusal, approval-hash refusal, explicit
+duplicate delivery plus restart, HALT, the production profile pair, and typed
+attenuation guards.
+
+The following deliberately remain manual:
+
+- a human's containment inspection and approval-gate practice, because a test
+  cannot prove that a person reviewed the task;
+- the §3 real-model budget case and representative docs/test/refactor breadth,
+  because this suite is deterministic and has zero model spend;
+- the two-live-dispatcher concurrency drill. CI proves duplicate-delivery and
+  restart idempotence directly; the operator ceremony retains the separate
+  process-concurrency practice;
+- any production, wallet, settlement, deployment, real target-repository, or
+  GitHub mutation. CI redirects the task repository to a local bare remote,
+  gives the Docker run no network, and asserts no PR evidence, but does not
+  pretend to perform a production non-mutation ceremony.
+
+## Affected surfaces
+
+- CI workflow: yes, one separate required integration job
+- Test and evidence infrastructure: yes
+- Versioned ceremony/operator scripts: yes
+- INT-2 runbook and contributor gate documentation: yes
+- Dispatcher or MCP production source: unchanged
+- Schemas and migrations: unchanged
+- Kernel source: unchanged; exact external pin only
+- Dependencies and lockfile: unchanged
+- Runtime secrets/config: unchanged
+- Wallet, settlement, deploy, PR opening, and GitHub mutation: unchanged
+
+## Rollout and rollback
+
+Rollout is the normal CI workflow update after human merge. It requires GitHub
+hosted runners with Docker and outbound access to fetch the exact Harness pin;
+the target repository used by runs remains a local bare clone.
+
+Rollback reverts implementation commit `a4066b4`. That removes the workflow job,
+suite, shared verifier, and versioned scripts. There is no schema, data,
+configuration, secret, deployment, or external-state rollback.
+
+## Definitive clean-checkout verification
+
+The definitive gates ran from detached clean checkout
+`/private/tmp/averray-reference-agent-int2-auto-clean-a4066b4` at implementation
+commit `a4066b4`.
+
+```text
+$ git status --porcelain
+# no output
+
+$ node --version
+v25.5.0
+
+$ npm --version
+11.8.0
+
+$ npm ci
+added 312 packages, and audited 325 packages in 3s
+# exit 0
+
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  199 passed | 2 skipped (201)
+Tests       2526 passed | 13 skipped (2539)
+Duration    12.76s
+# exit 0
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+
+$ INT2_SUITE_EVIDENCE_DIR=/private/tmp/int2-suite-evidence-clean-a4066b4 \
+    scripts/ceremony/run-int2-automated-suite.sh
+✓ preflights the controlled red/green pair against a real tracked diff
+✓ keeps an unapproved task outside the production dispatchable set
+✓ refuses an approval-hash mismatch before claim or submit
+✓ rejects the negative fixture on its merits with no handoff
+✓ produces one verified, unactuated green handoff
+✓ restarts between submit and reconcile without duplicating the run
+✓ HALT cancels a bound live run and never creates a handoff
+✓ accepts a seven-capability profile with strictly narrower authority
+✓ rejects memory.propose in the outer production profile loader
+Test Files  1 passed (1)
+Tests       9 passed (9)
+Duration    147.70s
+INT-2 automated suite: 9 cases executed in 166s
+# exit 0
+
+$ cat /private/tmp/int2-suite-evidence-clean-a4066b4/executed-count.txt
+9
+
+$ git status --porcelain
+# no output
+```
+
+The two fast-suite skips are the prerequisite-gated Postgres integration files.
+The dedicated INT-2 invocation supplied both databases, Docker, Harness, and
+the fail-required environment; all nine tests executed. The measured
+CI-equivalent wall time was **166 seconds**. The first actual GitHub-hosted wall
+time will be visible on the draft PR.
+
+`npm ci` reported the repository's existing audit inventory (17 findings).
+This PR changes neither dependency metadata nor the lockfile.
+
+## Decisions and rationale
+
+1. **Share the complete evidence verifier.** CI imports it and the operator
+   scripts invoke it, preventing separate definitions of green.
+2. **Use the CLI implementation for approval.** Calling `runPilotCli` keeps
+   task hashing, confirmation, identity derivation, and persistence identical
+   to the actual command without fabricating approval rows.
+3. **Use a local bare target remote.** Git URL rewriting lets workspace
+   preparation execute unchanged while preventing a test from reading or
+   mutating the real target repository.
+4. **Use a dedicated artifact root, not an isolated `HOME`.** Harness CLI reads
+   and its worker share `HARNESS_ARTIFACT_ROOT`; preserving `HOME` keeps the
+   operator's Docker context resolvable on desktop Docker.
+5. **Treat HALT cancellation as the sole mutation exception.** The work order's
+   blanket non-mutating-decision wording conflicts with proving a live run was
+   cancelled. The verifier permits only the exact two authority-reducing
+   cancel mutations and rejects every other mutation.
+6. **Record the corrected §2.4 layers honestly.** The outer loader result and
+   the accepted narrower profile are production-path tests; the two
+   attenuation errors remain direct typed tests.
+7. **Require both an environment gate and an executed-count marker.** Missing
+   prerequisites throw before test registration, and CI separately asserts
+   exactly nine executions.
+8. **Run on every PR with full history.** This avoids a silently narrowed path
+   gate and keeps the older fixture base resolvable in both the fast preflight
+   and real tier.
+9. **Refuse partial database attach state.** Re-sourcing bring-up attaches only
+   when both named databases are healthy; if either exists without a healthy
+   pair, it leaves both untouched and asks the operator to intervene.
+
+## Open questions
+
+None. The first GitHub-hosted execution will supply the hosted-runner wall time;
+the local clean-checkout mechanism and all required evidence are complete.

--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -676,6 +676,21 @@ evidence.
 
 ## 4. Evidence mapped to the INT-2 gate
 
+The deterministic mechanism proofs now run in CI through
+`scripts/ceremony/run-int2-automated-suite.sh`. CI uses the real production
+dispatcher, two disposable Postgres databases, the pinned Harness and the
+Docker provider. It proves the suite executed rather than treating a skipped
+suite as green. The six operator helpers are versioned beside it under
+`scripts/ceremony/`; both their verification path and CI call
+`int2-evidence.mjs`, so there is one definition of the evidence.
+
+CI does **not** replace the human ceremony. The operator still performs and
+records the containment inspection, the approval decision and the §3
+budget-capped real-model run once per release. CI proves the approval mechanism
+by invoking the exact `harness-pilot approve --confirm` implementation and its
+task hash; it does not claim a person reviewed the task. Recorded/scripted
+evidence and human-practice evidence remain separate in the bundle.
+
 For every work item, start with:
 
 ```sh
@@ -703,21 +718,23 @@ Export these reference-database rows as JSON without including the DSN:
 
 The following mapping is the acceptance checklist for plan section 21.1:
 
-| §21.1 gate statement | Required captured proof |
-|---|---|
-| Concurrent/replayed dispatch creates exactly one run | One immutable `intendedRunId`; one Harness run at attempt 1; one claim; one outbox binding; identical run id from duplicate submit; restart/replay does not change any identity. |
-| Approval/hash/policy/grant mismatches refuse | `dispatch_refusal` decisions for the approval-hash and attenuation drills; no Harness run or outbox row for either; the pinned task, policy, verifier, profile, capability-catalog, and manifest hashes. |
-| HALT wins | Before/after task and run snapshots; halted heartbeat; cancellation acknowledgement or critical alert; no later run started while HALT existed. |
-| No wallet/settlement/deploy/GitHub-merge capability | The exact eight-grant AgentTask and compiled run manifest, with `delegable:false`, `maxChildren:0`, `maxConcurrentChildren:0`, and deny-all egress. Review the manifest, not just the profile source. |
-| Representative low-risk tasks complete through supervision | At least docs/comment, unit-test, and small-refactor families, each with proposal output, explicit operator approval, `dispatch_approval` decision, run events, verifier evidence, budget actuals, and terminal projection. |
-| Failed verification produces no submission | The `lint-format-red` case: failed verifier event and failed lifecycle; no `handoff` decision, no VerifiedHandoff actuation, no PR/submission evidence; **and the failing check reports a content rejection (`trailing whitespace`), with no `exit_128` anywhere** — proving the criterion ran rather than erroring. |
-| Verified work produces a correct unactuated handoff | The `lint-format-green` case reaches `handoff_ready`; non-empty allowlisted patch; matching manifest ref/hash; one attempt, claim, and outbox; exactly one `dispatch_approval` plus one `handoff`; recorded eligibility value/reason and handoff verification evidence refs; no PR or GitHub mutation. §2.5 and §2.6 must both pass. |
-| Restart and duplicate delivery remain idempotent | Dispatcher restart timestamps, unchanged claim/outbox rows, same immutable run id, and one Harness attempt. |
+| §21.1 gate statement | Required captured proof | Evidence source |
+|---|---|---|
+| Concurrent/replayed dispatch creates exactly one run | One immutable `intendedRunId`; one Harness run at attempt 1; one claim; one outbox binding; restart/replay does not change any identity. | CI re-submits the same run id and restarts before reconciliation on every PR and `main`; the operator ceremony retains the two-dispatcher concurrency drill. |
+| Approval/hash/policy/grant mismatches refuse | Approval-hash mismatch produces `dispatch_refusal` before claim. `memory.propose` is refused earlier by the production profile loader as `unvetted_capability`, with no run/outbox/handoff; removing `fs.write_file` is accepted and the compiled manifest is strictly narrower. The currently unreachable `capability_not_granted` and `capability_effect_external` guards are typed boundary tests, not presented as production-path refusals. | CI mechanism suite plus typed unit tests. Human approval **practice** remains operator evidence. |
+| HALT wins | Before/after task and run snapshots; halted heartbeat; cancellation acknowledgement or critical alert; no handoff. | CI mechanism suite; operator repeats emergency-stop practice once per release. |
+| No wallet/settlement/deploy/GitHub-merge capability | The exact eight-grant AgentTask and compiled run manifest, with `delegable:false`, `maxChildren:0`, `maxConcurrentChildren:0`, and deny-all egress. Review the manifest, not just the profile source. | CI asserts the bytes and manifest; human inspection of containment remains operator evidence. |
+| Representative low-risk tasks complete through supervision | At least docs/comment, unit-test, and small-refactor families, each with proposal output, explicit operator approval, `dispatch_approval` decision, run events, verifier evidence, budget actuals, and terminal projection. | Human ceremony. CI deliberately covers the deterministic lint pair, not representative real-model breadth. |
+| Failed verification produces no submission | The `lint-format-red` case: failed verifier event and failed lifecycle; no `handoff`, PR or submission evidence; **the failing check reports `trailing whitespace`, with no `exit_128` anywhere**. | CI on every PR and `main`. |
+| Verified work produces a correct unactuated handoff | The `lint-format-green` case reaches `handoff_ready`; non-empty allowlisted patch; matching manifest ref/hash; one attempt, claim and outbox; exactly one `dispatch_approval` plus one `handoff`; eligibility value/reason and evidence refs; no PR or GitHub mutation. | CI on every PR and `main`; §2.5 and §2.6 are a controlled pair. |
+| Restart and duplicate delivery remain idempotent | Dispatcher restart, unchanged claim/outbox rows, same immutable run id and one Harness attempt. | CI on every PR and `main`. |
 
 A successful verified task should have a `dispatch_approval` decision and, when
 the projection constructs an unactuated handoff, a `handoff` decision. A
-negative case should have `dispatch_refusal`. Missing expected decision records
-fail the gate.
+pre-dispatch policy refusal should have `dispatch_refusal`; an intentional
+verification failure has `dispatch_approval` and no handoff; the outer profile
+loader failure occurs before attenuation's refusal-record catch and is recorded
+as such. Missing or misclassified expected evidence fails the gate.
 
 ### Source-loss projection drill
 

--- a/scripts/ceremony/int2-bringup.sh
+++ b/scripts/ceremony/int2-bringup.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# INT-2 §1 mechanical bring-up. Source this file from bash or zsh.
+# It never enables dispatch, never touches production, and attaches
+# non-destructively when both named disposable databases are already healthy.
+set -uo pipefail
+
+ok() { echo "  ✓ $*"; }
+fail() { echo "  ✗ $*" >&2; }
+die() { fail "$*"; return 1; }
+
+_int2_bringup() {
+  echo "=== INT-2 §1 bring-up ==="
+  export REFERENCE_CHECKOUT="${REFERENCE_CHECKOUT:-$PWD}"
+  export CEREMONY_ROOT="${CEREMONY_ROOT:-${CR:-}}"
+  [ -n "$CEREMONY_ROOT" ] \
+    || { die "CEREMONY_ROOT is required; create it per runbook §1"; return 1; }
+  export CR="$CEREMONY_ROOT"
+  export HARNESS_CHECKOUT="${HARNESS_CHECKOUT:-$CEREMONY_ROOT/agent-harness}"
+  export HARNESS_BIN="${HARNESS_BIN:-$HARNESS_CHECKOUT/.venv/bin/harness}"
+
+  [ -d "$CEREMONY_ROOT" ] \
+    || { die "ceremony root is absent: $CEREMONY_ROOT"; return 1; }
+  [ -d "$REFERENCE_CHECKOUT/.git" ] \
+    || { die "reference checkout is not a Git checkout"; return 1; }
+  [ -x "$HARNESS_BIN" ] \
+    || { die "Harness executable is absent: $HARNESS_BIN"; return 1; }
+  [ -d "$CEREMONY_ROOT/profiles/coding-change-pilot" ] \
+    || { die "pinned coding-change-pilot profile is absent"; return 1; }
+
+  _int2_pin="0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
+  _int2_head="$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD 2>/dev/null)" \
+    || { die "cannot read Harness revision"; return 1; }
+  if [ "$_int2_head" != "$_int2_pin" ]; then
+    [ -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)" ] \
+      || { die "Harness checkout is dirty; refusing to change its pin"; return 1; }
+    git -C "$HARNESS_CHECKOUT" fetch -q origin \
+      || { die "cannot fetch the Harness pin"; return 1; }
+    git -C "$HARNESS_CHECKOUT" checkout -q --detach "$_int2_pin" \
+      || { die "cannot check out the Harness pin"; return 1; }
+    (
+      cd "$HARNESS_CHECKOUT" && uv sync --frozen
+    ) || { die "uv sync failed after re-pinning Harness"; return 1; }
+  fi
+  [ "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = "$_int2_pin" ] \
+    || { die "Harness pin assertion failed"; return 1; }
+  "$HARNESS_BIN" --help >/dev/null 2>&1 \
+    || { die "Harness CLI cannot import after uv sync"; return 1; }
+  ok "Harness pinned and CLI healthy (${_int2_pin:0:12})"
+
+  _int2_attach=0
+  _int2_harness_exists=0
+  _int2_reference_exists=0
+  docker container inspect int2-harness-postgres >/dev/null 2>&1 \
+    && _int2_harness_exists=1
+  docker container inspect int2-reference-postgres >/dev/null 2>&1 \
+    && _int2_reference_exists=1
+  if docker exec int2-harness-postgres \
+      pg_isready -U postgres -d harness_ceremony >/dev/null 2>&1 \
+    && docker exec int2-reference-postgres \
+      pg_isready -U postgres -d reference_ceremony >/dev/null 2>&1; then
+    _int2_attach=1
+    ok "ATTACH mode: both existing databases are healthy; no data recreated"
+  fi
+
+  if [ "$_int2_attach" = "0" ]; then
+    if [ "$_int2_harness_exists" = "1" ] \
+      || [ "$_int2_reference_exists" = "1" ]; then
+      die "a named ceremony database already exists but the pair is not healthy; refusing destructive re-creation"
+      return 1
+    fi
+    docker run --rm --detach --name int2-harness-postgres \
+      --publish 127.0.0.1:55432:5432 \
+      --env POSTGRES_PASSWORD=harness-ceremony \
+      --env POSTGRES_DB=harness_ceremony \
+      postgres:18 >/dev/null \
+      || { die "cannot start the Harness database"; return 1; }
+    docker run --rm --detach --name int2-reference-postgres \
+      --publish 127.0.0.1:55433:5432 \
+      --env POSTGRES_PASSWORD=reference-ceremony \
+      --env POSTGRES_DB=reference_ceremony \
+      postgres:16-alpine >/dev/null \
+      || { die "cannot start the reference database"; return 1; }
+    for _int2_i in $(seq 1 60); do
+      docker exec int2-harness-postgres \
+        pg_isready -U postgres -d harness_ceremony >/dev/null 2>&1 && break
+      sleep 1
+    done
+    for _int2_i in $(seq 1 60); do
+      docker exec int2-reference-postgres \
+        pg_isready -U postgres -d reference_ceremony >/dev/null 2>&1 && break
+      sleep 1
+    done
+    docker exec int2-harness-postgres \
+      pg_isready -U postgres -d harness_ceremony >/dev/null 2>&1 \
+      || { die "Harness database did not become ready"; return 1; }
+    docker exec int2-reference-postgres \
+      pg_isready -U postgres -d reference_ceremony >/dev/null 2>&1 \
+      || { die "reference database did not become ready"; return 1; }
+  fi
+
+  export HARNESS_DATABASE_URL="postgresql://postgres:harness-ceremony@127.0.0.1:55432/harness_ceremony"
+  export DATABASE_URL="postgresql://postgres:reference-ceremony@127.0.0.1:55433/reference_ceremony"
+
+  if [ "$_int2_attach" = "0" ]; then
+    (
+      cd "$HARNESS_CHECKOUT" \
+        && HARNESS_DATABASE_URL="$HARNESS_DATABASE_URL" \
+          uv run harness db migrate
+    ) >/dev/null \
+      || { die "Harness migration failed"; return 1; }
+    for _int2_migration in "$REFERENCE_CHECKOUT"/ops/migrations/*.sql; do
+      docker exec -i int2-reference-postgres \
+        psql -U postgres -d reference_ceremony \
+          --set ON_ERROR_STOP=1 -q < "$_int2_migration" >/dev/null \
+        || {
+          die "reference migration failed: $(basename "$_int2_migration")"
+          return 1
+        }
+    done
+    ok "both disposable schemas migrated"
+  fi
+
+  if [ "$_int2_attach" = "1" ] \
+    && [ -f "$REFERENCE_CHECKOUT/services/harness-dispatcher/dist/index.js" ]; then
+    ok "dispatcher build already present in attach mode"
+  else
+    (
+      cd "$REFERENCE_CHECKOUT" && npm ci && npm run build
+    ) >/dev/null \
+      || { die "reference dependency install/build failed"; return 1; }
+    ok "reference dispatcher built"
+  fi
+
+  export HARNESS_PROFILES_ROOT="$CEREMONY_ROOT/profiles"
+  export HARNESS_PROFILE_SHA256="$(
+    shasum -a 256 \
+      "$HARNESS_PROFILES_ROOT/coding-change-pilot/profile.yaml" |
+      awk '{print $1}'
+  )"
+  export HARNESS_DISPATCH_ARTIFACT_DIR="$CEREMONY_ROOT/dispatch-artifacts"
+  export HARNESS_DISPATCH_INTENT_DIR="$CEREMONY_ROOT/dispatch-intents"
+  export HARNESS_DISPATCH_HEARTBEAT_PATH="$CEREMONY_ROOT/dispatcher-heartbeat.json"
+  export HARNESS_DISPATCH_ALERTS_PATH="$CEREMONY_ROOT/dispatcher-alerts.jsonl"
+  export HARNESS_DISPATCH_READ_TIMEOUT_MS=15000
+  export HALT_FILE="$CEREMONY_ROOT/HALT"
+  export POLICY_CONFIG_PATH="$REFERENCE_CHECKOUT/hermes/config/policy.yaml"
+  export HERMES_DISPATCH_ALLOWED_REPOS="depre-dev/averray-reference-agent"
+  export HARNESS_DISPATCH_ENABLED=false
+  unset HARNESS_DISPATCH_DEP_CACHE_DIR
+  ok "ceremony environment exported; dispatch remains disabled"
+  return 0
+}
+
+if ! _int2_bringup; then
+  echo "BRING-UP FAILED; correct the reported cause and source again." >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "Bring-up complete. Run a setup script; human propose/inspect/approve remains."

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -1,0 +1,1369 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { Pool } from "pg";
+
+export const INT2_HARNESS_PIN =
+  "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2";
+export const INT2_EXPECTED_PATH =
+  "docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
+export const INT2_PILOT_CAPABILITIES = Object.freeze([
+  "fs.read_file",
+  "fs.write_file",
+  "fs.list_files",
+  "shell.run",
+  "git.status",
+  "git.diff",
+  "artifact.put",
+  "artifact.get",
+]);
+export const INT2_CAPABILITY_BOUNDARY = Object.freeze({
+  productionProfileCapabilities: "subset_of_dispatcher_vetted_capabilities",
+  dispatcherVettedEqualsCliApproved: true,
+  profileLoaderPrecedesAttenuation: true,
+  productionInnerCapabilityChecksReachable: false,
+  innerChecksCoveredAtTypedBoundary: Object.freeze([
+    "capability_not_granted",
+    "capability_effect_external",
+  ]),
+});
+
+const DISPATCH_WORKSPACE_ROOT =
+  "/var/lib/harness-dispatcher/workspaces";
+const CASE_EXPECTATIONS = Object.freeze({
+  green: Object.freeze({
+    lifecycle: "handoff_ready",
+    runCount: 1,
+    runOutcome: "completed",
+    runState: "learning_processed",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 1,
+      dispatch_refusal: 0,
+    },
+    criterion: {
+      passed: true,
+      reason: "exit_0",
+      verdict: "completed",
+    },
+    requirePatch: true,
+    requireManifest: true,
+    requireFence: true,
+  }),
+  negative: Object.freeze({
+    lifecycle: "failed",
+    runCount: 1,
+    runOutcome: "failed",
+    runState: "learning_processed",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 0,
+      dispatch_refusal: 0,
+    },
+    criterion: {
+      passed: false,
+      reason: "exit_2",
+      verdict: "failed",
+    },
+    requirePatch: true,
+    requireManifest: true,
+    requireFence: true,
+  }),
+  restart: Object.freeze({
+    lifecycle: "handoff_ready",
+    runCount: 1,
+    runOutcome: "completed",
+    runState: "learning_processed",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 1,
+      dispatch_refusal: 0,
+    },
+    criterion: {
+      passed: true,
+      reason: "exit_0",
+      verdict: "completed",
+    },
+    requirePatch: true,
+    requireManifest: true,
+    requireFence: true,
+  }),
+  halt: Object.freeze({
+    lifecycle: "cancelled",
+    runCount: 1,
+    runState: "cancelled",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 0,
+      dispatch_refusal: 0,
+      escalation: 1,
+    },
+    requirePatch: false,
+    requireManifest: false,
+    requireFence: true,
+    decisionReason: "halt_active_run_cancelled",
+    expectedAuthorityReducingCancellation: true,
+  }),
+  "hash-mismatch": Object.freeze({
+    lifecycle: "blocked",
+    runCount: 0,
+    claimCount: 0,
+    outboxCount: 0,
+    decisions: {
+      dispatch_approval: 0,
+      handoff: 0,
+      dispatch_refusal: 1,
+    },
+    requirePatch: false,
+    requireManifest: false,
+    requireFence: false,
+    decisionReason: "approval_hash_mismatch",
+  }),
+  "profile-unvetted": Object.freeze({
+    lifecycle: "approved",
+    runCount: 0,
+    claimCount: 1,
+    outboxCount: 0,
+    decisions: {
+      dispatch_approval: 0,
+      handoff: 0,
+      dispatch_refusal: 0,
+    },
+    requirePatch: false,
+    requireManifest: false,
+    requireFence: true,
+    profileLoadErrorReason: "unvetted_capability",
+  }),
+  narrow: Object.freeze({
+    lifecycle: "handoff_ready",
+    runCount: 1,
+    runOutcome: "completed",
+    runState: "learning_processed",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 1,
+      dispatch_refusal: 0,
+    },
+    criterion: {
+      passed: true,
+      reason: "exit_0",
+      verdict: "completed",
+    },
+    requirePatch: true,
+    requireManifest: true,
+    requireFence: true,
+    effectiveCapabilities: Object.freeze(
+      INT2_PILOT_CAPABILITIES.filter(
+        (capability) => capability !== "fs.write_file",
+      ),
+    ),
+  }),
+  unapproved: Object.freeze({
+    lifecycle: "proposed",
+    runCount: 0,
+    claimCount: 0,
+    outboxCount: 0,
+    decisions: {
+      dispatch_approval: 0,
+      handoff: 0,
+      dispatch_refusal: 0,
+    },
+    requirePatch: false,
+    requireManifest: false,
+    requireFence: true,
+  }),
+});
+
+export class Int2EvidenceError extends Error {
+  constructor(failures) {
+    super(`INT-2 evidence failed: ${failures.join("; ")}`);
+    this.name = "Int2EvidenceError";
+    this.failures = [...failures];
+  }
+}
+
+export function expectationsForCase(caseName) {
+  const value = CASE_EXPECTATIONS[caseName];
+  if (!value) {
+    throw new Error(`Unknown INT-2 evidence case: ${caseName}`);
+  }
+  return value;
+}
+
+export async function verifyScriptedPairPreflight({
+  repositoryRoot,
+  greenFixturePath = path.join(
+    repositoryRoot,
+    "test/fixtures/agent-integration/ceremony/lint-format-green.json",
+  ),
+  negativeFixturePath = path.join(
+    repositoryRoot,
+    "test/fixtures/agent-integration/ceremony/lint-format-red.json",
+  ),
+  greenScriptPath = path.join(
+    repositoryRoot,
+    "test/fixtures/agent-integration/ceremony/lint-format-green.jsonl",
+  ),
+  negativeScriptPath = path.join(
+    repositoryRoot,
+    "test/fixtures/agent-integration/ceremony/lint-format-red.jsonl",
+  ),
+} = {}) {
+  if (!repositoryRoot) {
+    throw new Error("repositoryRoot is required");
+  }
+  const [greenFixture, negativeFixture, greenTurns, negativeTurns] =
+    await Promise.all([
+      readJson(greenFixturePath),
+      readJson(negativeFixturePath),
+      readJsonLines(greenScriptPath),
+      readJsonLines(negativeScriptPath),
+    ]);
+
+  const greenFence = fixtureFence(greenFixture);
+  const negativeFence = fixtureFence(negativeFixture);
+  assertEqual(
+    greenFence,
+    negativeFence,
+    "controlled pair fence differs",
+  );
+
+  const greenAction = scriptedAppend(greenTurns);
+  const negativeAction = scriptedAppend(negativeTurns);
+  assertEqual(
+    {
+      ...greenAction,
+      command: "<command>",
+      appendedLine: "<content>",
+    },
+    {
+      ...negativeAction,
+      command: "<command>",
+      appendedLine: "<content>",
+    },
+    "controlled pair differs outside appended content",
+  );
+  if (greenAction.appendedLine === negativeAction.appendedLine) {
+    throw new Error("controlled pair appended content must differ");
+  }
+  if (/[ \t]+$/u.test(greenAction.appendedLine)) {
+    throw new Error("green appended content contains trailing whitespace");
+  }
+  if (!/[ \t]+$/u.test(negativeAction.appendedLine)) {
+    throw new Error("negative appended content lacks trailing whitespace");
+  }
+
+  const [green, negative] = await Promise.all([
+    runFixtureCriterion({
+      repositoryRoot,
+      command: greenAction.command,
+      expectedPath: greenAction.targetPath,
+      baseRevision: greenFence.repository.baseRevision,
+    }),
+    runFixtureCriterion({
+      repositoryRoot,
+      command: negativeAction.command,
+      expectedPath: negativeAction.targetPath,
+      baseRevision: negativeFence.repository.baseRevision,
+    }),
+  ]);
+  if (green.numstat.length === 0 || negative.numstat.length === 0) {
+    throw new Error("controlled pair produced an empty git diff");
+  }
+  if (green.exitCode === 128 || negative.exitCode === 128) {
+    throw new Error("controlled pair criterion produced exit_128");
+  }
+  if (green.exitCode !== 0) {
+    throw new Error(
+      `green criterion rejected a clean tracked-file diff with exit ${green.exitCode}`,
+    );
+  }
+  if (negative.exitCode === 0) {
+    throw new Error("negative criterion accepted trailing whitespace");
+  }
+  if (!/whitespace/iu.test(`${negative.stdout}\n${negative.stderr}`)) {
+    throw new Error("negative criterion did not identify whitespace");
+  }
+
+  return {
+    fence: greenFence,
+    targetPath: greenAction.targetPath,
+    green: {
+      appendedLine: greenAction.appendedLine,
+      numstat: green.numstat,
+      exitCode: green.exitCode,
+    },
+    negative: {
+      appendedLine: negativeAction.appendedLine,
+      numstat: negative.numstat,
+      exitCode: negative.exitCode,
+    },
+  };
+}
+
+export async function collectInt2Evidence({
+  workItemId,
+  intendedRunId,
+  referenceDatabaseUrl = process.env.DATABASE_URL,
+  harnessDatabaseUrl = process.env.HARNESS_DATABASE_URL,
+  harnessBin = process.env.HARNESS_BIN || "harness",
+  expectedPath = INT2_EXPECTED_PATH,
+  evidenceDir,
+  profileLoadError,
+} = {}) {
+  requireValue(workItemId, "workItemId");
+  requireValue(intendedRunId, "intendedRunId");
+  requireValue(referenceDatabaseUrl, "referenceDatabaseUrl");
+  requireValue(harnessDatabaseUrl, "harnessDatabaseUrl");
+
+  const referencePool = new Pool({ connectionString: referenceDatabaseUrl });
+  const harnessPool = new Pool({ connectionString: harnessDatabaseUrl });
+  let raw;
+  try {
+    const [
+      taskRows,
+      claimRows,
+      outboxRows,
+      decisionRows,
+      runRows,
+    ] = await Promise.all([
+      referencePool.query(
+        `select task
+         from agent_tasks
+         where work_item_id = $1
+         order by task_version desc`,
+        [workItemId],
+      ),
+      referencePool.query(
+        `select *
+         from agent_task_dispatch_claims
+         where work_item_id = $1
+         order by claimed_at`,
+        [workItemId],
+      ),
+      referencePool.query(
+        `select *
+         from agent_task_run_outbox
+         where work_item_id = $1
+         order by bound_at`,
+        [workItemId],
+      ),
+      referencePool.query(
+        `select record
+         from hermes_decision_records
+         where work_item_id = $1
+         order by generated_at`,
+        [workItemId],
+      ),
+      harnessPool.query(
+        `select run_id, state, outcome, outcome_reason, attempt, task, manifest
+         from runs
+         where task->'metadata'->'labels'->>'averray_work_item_id' = $1
+         order by created_at, run_id`,
+        [workItemId],
+      ),
+    ]);
+    raw = {
+      task: taskRows.rows[0]?.task ?? null,
+      dispatchClaims: claimRows.rows,
+      outbox: outboxRows.rows,
+      decisions: decisionRows.rows.map((row) => row.record),
+      runs: runRows.rows.map(normalizeRunRow),
+    };
+  } finally {
+    await Promise.allSettled([
+      referencePool.end(),
+      harnessPool.end(),
+    ]);
+  }
+
+  let statusText = "";
+  let eventsText = "";
+  let deliverablesText = "";
+  if (raw.runs.some((run) => run.runId === intendedRunId)) {
+    [statusText, eventsText, deliverablesText] = await Promise.all([
+      harnessRead(harnessBin, ["run", "status", intendedRunId], {
+        HARNESS_DATABASE_URL: harnessDatabaseUrl,
+      }),
+      harnessRead(harnessBin, ["run", "events", intendedRunId], {
+        HARNESS_DATABASE_URL: harnessDatabaseUrl,
+      }),
+      harnessRead(harnessBin, ["run", "deliverables", intendedRunId], {
+        HARNESS_DATABASE_URL: harnessDatabaseUrl,
+      }),
+    ]);
+  }
+
+  const events = parseHarnessEvents(eventsText);
+  const deliverables = parseHarnessDeliverables(deliverablesText);
+  const run = raw.runs.find((item) => item.runId === intendedRunId);
+  const patchRef = deliverables.workspace_patch;
+  const patch = patchRef && run
+    ? await inspectWorkspacePatch({
+        harnessBin,
+        harnessDatabaseUrl,
+        patchRef,
+        workspacePath: run.workspacePath,
+        baseRevision: raw.task?.repository?.baseRevision,
+        expectedPath,
+      })
+    : null;
+  const verification = verificationFromEvents(events);
+  const evidence = {
+    schemaVersion: 1,
+    kind: "int2_automated_evidence",
+    workItemId,
+    intendedRunId,
+    expectedPath,
+    capabilityBoundary: INT2_CAPABILITY_BOUNDARY,
+    profileLoadError: profileLoadError ?? null,
+    task: raw.task,
+    dispatchClaims: raw.dispatchClaims,
+    outbox: raw.outbox,
+    decisions: raw.decisions,
+    runs: raw.runs,
+    status: parseKeyValueLines(statusText),
+    events,
+    deliverables,
+    verification,
+    patch,
+    exit128Present: /(?:exit_128|exit 128|exit_code["']?\s*:\s*128)/iu
+      .test(eventsText),
+    pullRequestReferences: findPullRequestReferences({
+      task: raw.task,
+      decisions: raw.decisions,
+      outbox: raw.outbox,
+    }),
+  };
+
+  if (evidenceDir) {
+    await writeEvidenceBundle(evidenceDir, {
+      evidence,
+      statusText,
+      eventsText,
+      deliverablesText,
+    });
+  }
+  return evidence;
+}
+
+export function verifyInt2Evidence(
+  evidence,
+  expectationsInput,
+) {
+  const expectations = typeof expectationsInput === "string"
+    ? expectationsForCase(expectationsInput)
+    : expectationsInput;
+  const failures = [];
+  const passed = [];
+  const check = (condition, code, detail) => {
+    if (condition) passed.push(code);
+    else failures.push(`${code}: ${detail}`);
+  };
+
+  check(
+    evidence?.task?.workItemId === evidence?.workItemId,
+    "task_identity",
+    "stored AgentTask does not match the evidence work item",
+  );
+  check(
+    evidence?.task?.bindings?.pullRequest === undefined,
+    "task_has_no_pull_request",
+    "AgentTask contains a pullRequest binding",
+  );
+  check(
+    evidence?.pullRequestReferences?.length === 0,
+    "no_pull_request_reference",
+    `found ${evidence?.pullRequestReferences?.length ?? "unknown"} PR references`,
+  );
+  check(
+    equal(evidence?.capabilityBoundary, INT2_CAPABILITY_BOUNDARY),
+    "capability_boundary_recorded",
+    "the evidence does not record the production-loader/typed-boundary split",
+  );
+  check(
+    evidence?.task?.lifecycle === expectations.lifecycle,
+    "terminal_lifecycle",
+    `expected ${expectations.lifecycle}, got ${evidence?.task?.lifecycle}`,
+  );
+
+  const runs = Array.isArray(evidence?.runs) ? evidence.runs : [];
+  check(
+    runs.length === expectations.runCount,
+    "one_harness_run",
+    `expected ${expectations.runCount}, got ${runs.length}`,
+  );
+  if (expectations.runCount === 1) {
+    const run = runs[0];
+    check(
+      run?.runId === evidence.intendedRunId,
+      "run_id_bound_to_intended",
+      `expected ${evidence.intendedRunId}, got ${run?.runId}`,
+    );
+    check(
+      run?.attempt === 1,
+      "attempt_one",
+      `expected attempt 1, got ${run?.attempt}`,
+    );
+    if (expectations.runOutcome) {
+      check(
+        run?.outcome === expectations.runOutcome,
+        "run_outcome",
+        `expected ${expectations.runOutcome}, got ${run?.outcome}`,
+      );
+    }
+    if (expectations.runState) {
+      check(
+        run?.state === expectations.runState,
+        "run_terminal_state",
+        `expected ${expectations.runState}, got ${run?.state}`,
+      );
+    }
+    if (expectations.effectiveCapabilities) {
+      check(
+        equal(
+          run?.manifest?.grants?.map((grant) => grant.capability),
+          expectations.effectiveCapabilities,
+        ),
+        "effective_authority_narrowed",
+        `effective capabilities=${JSON.stringify(
+          run?.manifest?.grants?.map((grant) => grant.capability),
+        )}`,
+      );
+      check(
+        !run?.manifest?.grants?.some(
+          (grant) => grant.capability === "fs.write_file",
+        ),
+        "removed_capability_absent",
+        "fs.write_file remained in the effective run manifest",
+      );
+    }
+  }
+
+  const claims = Array.isArray(evidence?.dispatchClaims)
+    ? evidence.dispatchClaims
+    : [];
+  check(
+    claims.length === expectations.claimCount,
+    "dispatch_claim_count",
+    `expected ${expectations.claimCount}, got ${claims.length}`,
+  );
+  const outbox = Array.isArray(evidence?.outbox) ? evidence.outbox : [];
+  check(
+    outbox.length === expectations.outboxCount,
+    "outbox_count",
+    `expected ${expectations.outboxCount}, got ${outbox.length}`,
+  );
+  if (expectations.outboxCount === 1) {
+    check(
+      outbox[0]?.harness_run_id === evidence.intendedRunId,
+      "outbox_run_binding",
+      `outbox is bound to ${outbox[0]?.harness_run_id}`,
+    );
+  }
+
+  const decisions = Array.isArray(evidence?.decisions)
+    ? evidence.decisions
+    : [];
+  const decisionCounts = countDecisions(decisions);
+  const expectedDecisionTotal = Object.values(
+    expectations.decisions ?? {},
+  ).reduce((total, count) => total + count, 0);
+  check(
+    decisions.length === expectedDecisionTotal,
+    "decision_total_count",
+    `expected ${expectedDecisionTotal}, got ${decisions.length}`,
+  );
+  for (const [decisionType, expectedCount] of Object.entries(
+    expectations.decisions ?? {},
+  )) {
+    check(
+      (decisionCounts[decisionType] ?? 0) === expectedCount,
+      `decision_${decisionType}_count`,
+      `expected ${expectedCount}, got ${decisionCounts[decisionType] ?? 0}`,
+    );
+  }
+  check(
+    decisions.every((decision) => {
+      if (
+        expectations.expectedAuthorityReducingCancellation
+        && decision?.decisionType === "escalation"
+      ) {
+        return decision?.effects?.mutates === true
+          && equal(
+            decision.effects.mutations?.map((mutation) => ({
+              system: mutation.system,
+              action: mutation.action,
+            })),
+            [
+              { system: "agent-task", action: "cancelled" },
+              { system: "agent-harness", action: "cancel" },
+            ],
+          );
+      }
+      return decision?.effects?.mutates === false
+        && Array.isArray(decision?.effects?.mutations)
+        && decision.effects.mutations.length === 0;
+    }),
+    "decision_records_non_mutating",
+    "a decision mutates outside the exact authority-reducing HALT cancellation",
+  );
+  if (expectations.decisionReason) {
+    check(
+      decisions.some((decision) =>
+        Array.isArray(decision?.proposal?.why)
+        && decision.proposal.why.includes(expectations.decisionReason)),
+      "decision_reason",
+      `missing ${expectations.decisionReason}`,
+    );
+  }
+  if (expectations.profileLoadErrorReason) {
+    check(
+      evidence?.profileLoadError?.name === "ProfileManifestError"
+      && evidence.profileLoadError.reason
+        === expectations.profileLoadErrorReason,
+      "outer_profile_loader_refusal",
+      `expected ProfileManifestError/${expectations.profileLoadErrorReason}, `
+        + `got ${JSON.stringify(evidence?.profileLoadError)}`,
+    );
+    check(
+      decisionCounts.dispatch_refusal === undefined,
+      "no_attenuation_refusal_claim",
+      "outer loader failure was incorrectly recorded as an attenuation refusal",
+    );
+  }
+
+  if (expectations.requireFence) {
+    verifyFence(evidence.task, check);
+  }
+  if (expectations.requireManifest) {
+    const binding = outbox[0];
+    const refHash = binding?.run_manifest_ref?.sha256;
+    const manifestHash = binding?.run_manifest_hash;
+    check(
+      typeof refHash === "string" && typeof manifestHash === "string",
+      "manifest_identity_present",
+      "runManifestRef or runManifestHash is missing",
+    );
+    check(
+      refHash === manifestHash,
+      "manifest_identity_consistent",
+      `${refHash} does not equal ${manifestHash}`,
+    );
+  }
+
+  if (expectations.requirePatch) {
+    const patch = evidence?.patch;
+    check(
+      typeof patch?.sha256 === "string" && patch?.byteLength > 0,
+      "patch_non_empty",
+      "workspace patch is empty or missing",
+    );
+    check(
+      patch?.appliesAtBase === true,
+      "patch_applies_at_base",
+      "workspace patch does not apply at the approved base",
+    );
+    check(
+      patch?.baseRevision === evidence?.task?.repository?.baseRevision,
+      "patch_base_revision",
+      "patch checkout HEAD does not equal AgentTask baseRevision",
+    );
+    check(
+      patch?.trackedTarget === true,
+      "criterion_target_tracked",
+      "expected path is not tracked at the prepared base",
+    );
+    check(
+      Array.isArray(patch?.touchedPaths)
+      && patch.touchedPaths.length === 1
+      && patch.touchedPaths[0] === evidence.expectedPath,
+      "patch_exact_path",
+      `touched ${JSON.stringify(patch?.touchedPaths)}`,
+    );
+    check(
+      typeof patch?.numstat === "string" && patch.numstat.trim().length > 0,
+      "criterion_inspected_non_empty_diff",
+      "git diff --numstat was empty",
+    );
+    check(
+      patch?.criterionExitCode !== 128,
+      "criterion_not_exit_128",
+      "reconstructed criterion returned exit 128",
+    );
+  }
+
+  if (expectations.criterion) {
+    const verification = evidence?.verification;
+    const format = verification?.details?.find(
+      (detail) => detail?.id === "format-command" && detail?.required === true,
+    );
+    check(
+      verification?.verdict === expectations.criterion.verdict,
+      "verification_verdict",
+      `expected ${expectations.criterion.verdict}, got ${verification?.verdict}`,
+    );
+    check(
+      format?.passed === expectations.criterion.passed,
+      "required_criterion_result",
+      `expected passed=${expectations.criterion.passed}, got ${format?.passed}`,
+    );
+    check(
+      format?.reason === expectations.criterion.reason,
+      "required_criterion_reason",
+      `expected ${expectations.criterion.reason}, got ${format?.reason}`,
+    );
+    check(
+      evidence?.exit128Present === false,
+      "events_have_no_exit_128",
+      "exit_128 appears in Harness events",
+    );
+    if (expectations.criterion.passed) {
+      check(
+        evidence?.patch?.criterionExitCode === 0,
+        "criterion_reconstruction_green",
+        `reconstructed exit ${evidence?.patch?.criterionExitCode}`,
+      );
+      check(
+        Array.isArray(verification?.requiredFailed)
+        && verification.requiredFailed.length === 0,
+        "required_failed_empty",
+        `required_failed=${JSON.stringify(verification?.requiredFailed)}`,
+      );
+    } else {
+      check(
+        evidence?.patch?.criterionExitCode !== 0
+        && evidence?.patch?.criterionExitCode !== 128,
+        "criterion_reconstruction_red",
+        `reconstructed exit ${evidence?.patch?.criterionExitCode}`,
+      );
+      check(
+        /whitespace/iu.test(
+          `${evidence?.patch?.criterionStdout ?? ""}\n`
+          + `${evidence?.patch?.criterionStderr ?? ""}`,
+        ),
+        "criterion_rejected_whitespace",
+        "reconstructed rejection did not name whitespace",
+      );
+      check(
+        Array.isArray(verification?.requiredFailed)
+        && verification.requiredFailed.includes("format-command"),
+        "required_failed_names_format",
+        `required_failed=${JSON.stringify(verification?.requiredFailed)}`,
+      );
+    }
+  }
+
+  const handoffs = decisions.filter(
+    (decision) => decision?.decisionType === "handoff",
+  );
+  if ((expectations.decisions?.handoff ?? 0) === 1) {
+    const handoff = handoffs[0];
+    check(
+      Array.isArray(handoff?.proposal?.evidenceRefs)
+      && handoff.proposal.evidenceRefs.length > 0,
+      "handoff_evidence_refs",
+      "handoff evidenceRefs are empty",
+    );
+    check(
+      handoff?.proposal?.why?.includes("eligible_for_pr_open=true")
+      && handoff?.proposal?.why?.includes(
+        "eligible_for_pr_open_reason=completed_outcome_verified_acceptance_all_checks_passed",
+      ),
+      "handoff_eligibility_evidence",
+      "handoff lacks the eligibility value or reason",
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Int2EvidenceError(failures);
+  }
+  return {
+    workItemId: evidence.workItemId,
+    intendedRunId: evidence.intendedRunId,
+    invariants: passed,
+  };
+}
+
+async function inspectWorkspacePatch({
+  harnessBin,
+  harnessDatabaseUrl,
+  patchRef,
+  workspacePath,
+  baseRevision,
+  expectedPath,
+}) {
+  if (
+    typeof workspacePath !== "string"
+    || !workspacePath.startsWith(`${DISPATCH_WORKSPACE_ROOT}/`)
+  ) {
+    throw new Error("Harness run workspace escaped the dispatch root");
+  }
+  const temporary = await mkdtemp(path.join(tmpdir(), "int2-patch-"));
+  const patchPath = path.join(temporary, "workspace.patch");
+  const checkout = path.join(temporary, "checkout");
+  try {
+    await harnessRead(
+      harnessBin,
+      ["artifacts", "get", patchRef, "--out", patchPath],
+      { HARNESS_DATABASE_URL: harnessDatabaseUrl },
+    );
+    const patchBytes = await readFile(patchPath);
+    await command("git", [
+      "clone",
+      "--quiet",
+      "--local",
+      "--no-hardlinks",
+      workspacePath,
+      checkout,
+    ]);
+    const head = (await command("git", [
+      "-C",
+      checkout,
+      "rev-parse",
+      "HEAD",
+    ])).stdout.trim();
+    const tracked = await command("git", [
+      "-C",
+      checkout,
+      "ls-files",
+      "--error-unmatch",
+      expectedPath,
+    ], { allowFailure: true });
+    const applyCheck = await command("git", [
+      "-C",
+      checkout,
+      "apply",
+      "--check",
+      patchPath,
+    ], { allowFailure: true });
+    const patchNumstat = await command("git", [
+      "-C",
+      checkout,
+      "apply",
+      "--numstat",
+      patchPath,
+    ], { allowFailure: true });
+    if (applyCheck.code === 0) {
+      await command("git", [
+        "-C",
+        checkout,
+        "apply",
+        patchPath,
+      ]);
+    }
+    const numstat = applyCheck.code === 0
+      ? (await command("git", [
+          "-C",
+          checkout,
+          "diff",
+          "--numstat",
+        ])).stdout.trim()
+      : "";
+    const criterion = applyCheck.code === 0
+      ? await command("git", [
+          "-C",
+          checkout,
+          "diff",
+          "--check",
+        ], { allowFailure: true })
+      : { code: -1, stdout: "", stderr: "patch did not apply" };
+    return {
+      ref: patchRef,
+      sha256:
+        `sha256:${createHash("sha256").update(patchBytes).digest("hex")}`,
+      byteLength: patchBytes.byteLength,
+      baseRevision: head,
+      expectedBaseRevision: baseRevision,
+      appliesAtBase: applyCheck.code === 0 && head === baseRevision,
+      trackedTarget: tracked.code === 0,
+      touchedPaths: numstatPaths(patchNumstat.stdout),
+      numstat,
+      criterionExitCode: criterion.code,
+      criterionStdout: criterion.stdout,
+      criterionStderr: criterion.stderr,
+      bytes: patchBytes.toString("utf8"),
+    };
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+async function runFixtureCriterion({
+  repositoryRoot,
+  command: fixtureCommand,
+  expectedPath,
+  baseRevision,
+}) {
+  const temporary = await mkdtemp(path.join(tmpdir(), "int2-preflight-"));
+  const checkout = path.join(temporary, "checkout");
+  try {
+    await command("git", [
+      "clone",
+      "--quiet",
+      "--local",
+      "--no-hardlinks",
+      repositoryRoot,
+      checkout,
+    ]);
+    await command("git", [
+      "-C",
+      checkout,
+      "checkout",
+      "--quiet",
+      "--detach",
+      baseRevision,
+    ]);
+    const tracked = await command("git", [
+      "-C",
+      checkout,
+      "ls-files",
+      "--error-unmatch",
+      expectedPath,
+    ], { allowFailure: true });
+    if (tracked.code !== 0) {
+      throw new Error(
+        `append target is not tracked in the checkout: ${expectedPath}`,
+      );
+    }
+    await command("sh", ["-c", fixtureCommand], { cwd: checkout });
+    const numstat = (await command("git", [
+      "-C",
+      checkout,
+      "diff",
+      "--numstat",
+    ])).stdout.trim();
+    const criterion = await command("git", [
+      "-C",
+      checkout,
+      "diff",
+      "--check",
+    ], { allowFailure: true });
+    return {
+      numstat,
+      exitCode: criterion.code,
+      stdout: criterion.stdout,
+      stderr: criterion.stderr,
+    };
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+}
+
+function verifyFence(task, check) {
+  check(
+    task?.repository?.nameWithOwner ===
+      "depre-dev/averray-reference-agent",
+    "fence_repository",
+    `unexpected repository ${task?.repository?.nameWithOwner}`,
+  );
+  check(
+    equal(task?.repository?.allowedPaths, ["docs/**", "test/**"]),
+    "fence_allowed_paths",
+    `unexpected allowed paths ${JSON.stringify(task?.repository?.allowedPaths)}`,
+  );
+  check(
+    task?.intent?.profile === "coding-change-pilot",
+    "fence_profile",
+    `unexpected profile ${task?.intent?.profile}`,
+  );
+  check(
+    task?.requestedAuthority?.network === "deny"
+    && task?.requestedAuthority?.delegable === false
+    && task?.requestedAuthority?.maxChildren === 0
+    && task?.requestedAuthority?.maxConcurrentChildren === 0,
+    "fence_non_delegating_deny_network",
+    "authority is not deny/non-delegating/zero-child",
+  );
+  const grants = task?.requestedAuthority?.grants;
+  check(
+    Array.isArray(grants)
+    && grants.length === INT2_PILOT_CAPABILITIES.length
+    && equal(
+      grants.map((grant) => grant.capabilityId),
+      INT2_PILOT_CAPABILITIES,
+    )
+    && grants.every((grant) =>
+      equal(grant.constraints, {})
+      && grant.resource === "depre-dev/averray-reference-agent"),
+    "fence_eight_grants",
+    `unexpected grants ${JSON.stringify(grants)}`,
+  );
+  check(
+    equal(task?.acceptance?.criteria, [{
+      id: "format-command",
+      type: "command",
+      command: "git diff --check",
+      required: true,
+    }]),
+    "fence_acceptance",
+    `unexpected acceptance ${JSON.stringify(task?.acceptance?.criteria)}`,
+  );
+  check(
+    equal(task?.budget, {
+      elapsedSeconds: 60,
+      modelTokens: 8000,
+      toolCalls: 30,
+      estimatedUsdMicros: null,
+    }),
+    "fence_budget",
+    `unexpected budget ${JSON.stringify(task?.budget)}`,
+  );
+}
+
+function fixtureFence(fixture) {
+  return {
+    repository: fixture.repository,
+    profile: fixture.profile,
+    acceptanceCriteria: fixture.acceptanceCriteria,
+    budget: fixture.budget,
+    deadline: fixture.deadline,
+    riskTier: fixture.riskTier,
+  };
+}
+
+function scriptedAppend(turns) {
+  if (!Array.isArray(turns) || turns.length !== 2) {
+    throw new Error("scripted pair must contain exactly two turns");
+  }
+  const first = turns[0];
+  const second = turns[1];
+  const calls = first?.tool_calls;
+  if (
+    !Array.isArray(calls)
+    || calls.length !== 1
+    || calls[0]?.name !== "shell_run"
+    || first?.finish_reason !== "tool_call"
+    || second?.finish_reason !== "stop"
+  ) {
+    throw new Error("scripted pair has an unexpected turn shape");
+  }
+  const commandText = calls[0]?.arguments?.command;
+  if (typeof commandText !== "string") {
+    throw new Error("scripted pair shell command is missing");
+  }
+  const match =
+    /^printf '%b' '\\n(.*)\\n' >> ([A-Za-z0-9_./-]+)$/u.exec(commandText);
+  if (!match) {
+    throw new Error("scripted pair must append exactly one newline-bounded line");
+  }
+  return {
+    command: commandText,
+    targetPath: match[2],
+    appendedLine: match[1],
+    firstUsage: first.usage,
+    firstFinishReason: first.finish_reason,
+    secondUsage: second.usage,
+    secondFinishReason: second.finish_reason,
+  };
+}
+
+function verificationFromEvents(events) {
+  const event = [...events].reverse().find(
+    (item) => item.type === "VerificationCompleted",
+  );
+  if (!event) return null;
+  return {
+    verdict: event.payload?.verdict,
+    passed: event.payload?.passed,
+    details: event.payload?.details,
+    requiredFailed: event.payload?.required_failed,
+    optionalFailed: event.payload?.optional_failed,
+  };
+}
+
+function parseHarnessEvents(text) {
+  return text.split(/\r?\n/u).filter(Boolean).map((line) => {
+    const match = /^(\d+)(?::(\d+))?\s+([A-Za-z0-9_]+)\s+payload=(.*)$/u
+      .exec(line);
+    if (!match) {
+      return { raw: line, type: "Unparsed", payload: null };
+    }
+    let payload = null;
+    try {
+      payload = JSON.parse(match[4]);
+    } catch {
+      payload = null;
+    }
+    return {
+      sequence: Number(match[1]),
+      ...(match[2] ? { attempt: Number(match[2]) } : {}),
+      type: match[3],
+      payload,
+      raw: line,
+    };
+  });
+}
+
+function parseHarnessDeliverables(text) {
+  return Object.fromEntries(
+    text.split(/\r?\n/u).filter(Boolean).flatMap((line) => {
+      const match = /^([a-z_]+)\s+(artifact:\/\/sha256\/[a-f0-9]{64})$/u
+        .exec(line.trim());
+      return match ? [[match[1], match[2]]] : [];
+    }),
+  );
+}
+
+function parseKeyValueLines(text) {
+  return Object.fromEntries(
+    text.split(/\r?\n/u).filter(Boolean).flatMap((line) => {
+      const index = line.indexOf("=");
+      return index > 0
+        ? [[line.slice(0, index), line.slice(index + 1)]]
+        : [];
+    }),
+  );
+}
+
+function normalizeRunRow(row) {
+  return {
+    runId: row.run_id,
+    state: row.state,
+    outcome: row.outcome,
+    outcomeReason: row.outcome_reason,
+    attempt: Number(row.attempt),
+    task: row.task,
+    manifest: row.manifest,
+    workspacePath: row.task?.spec?.context?.workspace?.path,
+  };
+}
+
+function countDecisions(decisions) {
+  const counts = {};
+  for (const decision of decisions) {
+    const key = decision?.decisionType;
+    if (typeof key === "string") counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function findPullRequestReferences(value) {
+  const references = [];
+  const visit = (candidate, location) => {
+    if (Array.isArray(candidate)) {
+      candidate.forEach((item, index) => visit(item, `${location}[${index}]`));
+      return;
+    }
+    if (candidate && typeof candidate === "object") {
+      for (const [key, item] of Object.entries(candidate)) {
+        if (/^(?:pullRequest|pull_request)$/u.test(key)) {
+          references.push(`${location}.${key}`);
+        }
+        visit(item, `${location}.${key}`);
+      }
+      return;
+    }
+    if (
+      typeof candidate === "string"
+      && /github\.com\/[^\s]+\/pull\/\d+/iu.test(candidate)
+    ) {
+      references.push(location);
+    }
+  };
+  visit(value, "$");
+  return references;
+}
+
+function numstatPaths(text) {
+  return text.split(/\r?\n/u).filter(Boolean).map((line) => {
+    const fields = line.split("\t");
+    return fields.at(-1);
+  }).filter((value) => typeof value === "string");
+}
+
+async function writeEvidenceBundle(directory, {
+  evidence,
+  statusText,
+  eventsText,
+  deliverablesText,
+}) {
+  await mkdir(directory, { recursive: true });
+  await Promise.all([
+    writeFile(
+      path.join(directory, "evidence.json"),
+      `${JSON.stringify(evidence, null, 2)}\n`,
+      "utf8",
+    ),
+    writeFile(path.join(directory, "harness-status.txt"), statusText, "utf8"),
+    writeFile(path.join(directory, "harness-events.txt"), eventsText, "utf8"),
+    writeFile(
+      path.join(directory, "harness-deliverables.txt"),
+      deliverablesText,
+      "utf8",
+    ),
+  ]);
+  if (evidence.patch?.bytes) {
+    await writeFile(
+      path.join(directory, "workspace.patch"),
+      evidence.patch.bytes,
+      "utf8",
+    );
+  }
+}
+
+async function harnessRead(harnessBin, args, environment) {
+  return (await command(harnessBin, args, {
+    env: { ...process.env, ...environment },
+  })).stdout;
+}
+
+async function command(executable, args, {
+  cwd,
+  env,
+  allowFailure = false,
+} = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, {
+      cwd,
+      env,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.once("error", reject);
+    child.once("close", (code) => {
+      const result = { code: code ?? 1, stdout, stderr };
+      if (!allowFailure && result.code !== 0) {
+        reject(new Error(
+          `${path.basename(executable)} failed with exit ${result.code}`,
+        ));
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+async function readJson(target) {
+  return JSON.parse(await readFile(target, "utf8"));
+}
+
+async function readJsonLines(target) {
+  return (await readFile(target, "utf8"))
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function requireValue(value, label) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} is required`);
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  if (!equal(actual, expected)) {
+    throw new Error(message);
+  }
+}
+
+function equal(left, right) {
+  return JSON.stringify(canonicalValue(left))
+    === JSON.stringify(canonicalValue(right));
+}
+
+function canonicalValue(value) {
+  if (Array.isArray(value)) return value.map(canonicalValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [
+        key,
+        canonicalValue(value[key]),
+      ]),
+    );
+  }
+  return value;
+}
+
+function parseCliArgs(argv) {
+  const commandName = argv[0];
+  const values = {};
+  for (let index = 1; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value === undefined) {
+      throw new Error("INT-2 evidence CLI expects --name value arguments");
+    }
+    values[key.slice(2)] = value;
+  }
+  return { commandName, values };
+}
+
+async function runCli(argv) {
+  const { commandName, values } = parseCliArgs(argv);
+  if (commandName === "preflight-pair") {
+    const result = await verifyScriptedPairPreflight({
+      repositoryRoot: values["repository-root"] ?? process.cwd(),
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  if (commandName === "verify") {
+    const caseName = values.case;
+    const evidence = await collectInt2Evidence({
+      workItemId: values["work-item"],
+      intendedRunId: values["run-id"],
+      expectedPath: values["expected-path"] ?? INT2_EXPECTED_PATH,
+      evidenceDir: values["evidence-dir"],
+    });
+    const result = verifyInt2Evidence(evidence, caseName);
+    if (values["evidence-dir"]) {
+      await writeFile(
+        path.join(values["evidence-dir"], "evidence-index.json"),
+        `${JSON.stringify(result, null, 2)}\n`,
+        "utf8",
+      );
+    }
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+  throw new Error(
+    "Usage: int2-evidence.mjs preflight-pair --repository-root <path>\n"
+    + "   or: int2-evidence.mjs verify --case <name> --work-item <id> "
+    + "--run-id <id> [--evidence-dir <path>]",
+  );
+}
+
+const invokedAsScript = process.argv[1]
+  && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+if (invokedAsScript) {
+  runCli(process.argv.slice(2)).catch((error) => {
+    const message = error instanceof Int2EvidenceError
+      ? error.message
+      : error instanceof Error
+        ? error.message
+        : String(error);
+    process.stderr.write(`int2-evidence: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/ceremony/int2-green-setup.sh
+++ b/scripts/ceremony/int2-green-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# INT-2 §2.6 mechanical setup. Source it; human approval remains manual.
+set -uo pipefail
+
+ok() { echo "  ✓ $*"; }
+fail() { echo "  ✗ $*" >&2; }
+die() { fail "$*"; return 1; }
+
+_int2_green_setup() {
+  for _int2_name in CEREMONY_ROOT REFERENCE_CHECKOUT HARNESS_CHECKOUT HARNESS_BIN; do
+    eval "_int2_value=\${${_int2_name}:-}"
+    [ -n "$_int2_value" ] \
+      || { die "$_int2_name is not set; source int2-bringup.sh"; return 1; }
+  done
+  pgrep -f "harness worker" >/dev/null 2>&1 \
+    && { die "a Harness worker is already running; stop it first"; return 1; }
+  pgrep -f "$REFERENCE_CHECKOUT/services/harness-dispatcher/dist/index.js" \
+    >/dev/null 2>&1 \
+    && { die "dispatcher is running; stop it before setup"; return 1; }
+  export HARNESS_DISPATCH_ENABLED=false
+  unset HARNESS_DISPATCH_DEP_CACHE_DIR
+  mkdir -p "$CEREMONY_ROOT/evidence"
+
+  node "$REFERENCE_CHECKOUT/scripts/ceremony/int2-evidence.mjs" \
+    preflight-pair --repository-root "$REFERENCE_CHECKOUT" \
+    > "$CEREMONY_ROOT/evidence/scripted-pair-preflight.json" \
+    || { die "controlled-pair preflight failed"; return 1; }
+
+  _int2_source="$REFERENCE_CHECKOUT/test/fixtures/agent-integration/ceremony/lint-format-green.jsonl"
+  export GREEN_MODEL_SCRIPT="$CEREMONY_ROOT/lint-format-green.jsonl"
+  cp "$_int2_source" "$GREEN_MODEL_SCRIPT"
+  shasum -a 256 "$_int2_source" "$GREEN_MODEL_SCRIPT" \
+    > "$CEREMONY_ROOT/evidence/lint-format-green-script.sha256"
+  _int2_a="$(sed -n '1s/ .*//p' "$CEREMONY_ROOT/evidence/lint-format-green-script.sha256")"
+  _int2_b="$(sed -n '2s/ .*//p' "$CEREMONY_ROOT/evidence/lint-format-green-script.sha256")"
+  [ "$_int2_a" = "$_int2_b" ] \
+    || { die "committed and staged model-script hashes differ"; return 1; }
+
+  export HARNESS_TEST_MODEL_SCRIPT="$GREEN_MODEL_SCRIPT"
+  export GREEN_WORK_ITEM="${GREEN_WORK_ITEM:-ceremony-lint-format-green-003}"
+  ok "green script staged and preflighted; worker may now be started"
+  return 0
+}
+
+if ! _int2_green_setup; then
+  unset HARNESS_TEST_MODEL_SCRIPT 2>/dev/null
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "Next: propose, inspect containment, approve once through harness-pilot, then enable dispatch."

--- a/scripts/ceremony/int2-green-verify.sh
+++ b/scripts/ceremony/int2-green-verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Shared evidence verifier for the supervised green path. Read-only.
+set -euo pipefail
+
+: "${CEREMONY_ROOT:?CEREMONY_ROOT is required}"
+: "${REFERENCE_CHECKOUT:?REFERENCE_CHECKOUT is required}"
+: "${GREEN_INTENDED_RUN_ID:?GREEN_INTENDED_RUN_ID is required}"
+
+_int2_work_item="${GREEN_WORK_ITEM:-ceremony-lint-format-green-003}"
+_int2_evidence="$CEREMONY_ROOT/evidence/$_int2_work_item"
+node "$REFERENCE_CHECKOUT/scripts/ceremony/int2-evidence.mjs" verify \
+  --case green \
+  --work-item "$_int2_work_item" \
+  --run-id "$GREEN_INTENDED_RUN_ID" \
+  --evidence-dir "$_int2_evidence"
+echo "Verified green evidence: $_int2_evidence"

--- a/scripts/ceremony/int2-negative-setup.sh
+++ b/scripts/ceremony/int2-negative-setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# INT-2 §2.5 mechanical setup. Source it; human approval remains manual.
+set -uo pipefail
+
+ok() { echo "  ✓ $*"; }
+fail() { echo "  ✗ $*" >&2; }
+die() { fail "$*"; return 1; }
+
+_int2_negative_setup() {
+  for _int2_name in CEREMONY_ROOT REFERENCE_CHECKOUT HARNESS_CHECKOUT HARNESS_BIN; do
+    eval "_int2_value=\${${_int2_name}:-}"
+    [ -n "$_int2_value" ] \
+      || { die "$_int2_name is not set; source int2-bringup.sh"; return 1; }
+  done
+  pgrep -f "harness worker" >/dev/null 2>&1 \
+    && { die "a Harness worker is already running; stop it first"; return 1; }
+  pgrep -f "$REFERENCE_CHECKOUT/services/harness-dispatcher/dist/index.js" \
+    >/dev/null 2>&1 \
+    && { die "dispatcher is running; stop it before setup"; return 1; }
+  export HARNESS_DISPATCH_ENABLED=false
+  unset HARNESS_DISPATCH_DEP_CACHE_DIR
+  mkdir -p "$CEREMONY_ROOT/evidence"
+
+  node "$REFERENCE_CHECKOUT/scripts/ceremony/int2-evidence.mjs" \
+    preflight-pair --repository-root "$REFERENCE_CHECKOUT" \
+    > "$CEREMONY_ROOT/evidence/scripted-pair-preflight.json" \
+    || { die "controlled-pair preflight failed"; return 1; }
+
+  _int2_source="$REFERENCE_CHECKOUT/test/fixtures/agent-integration/ceremony/lint-format-red.jsonl"
+  export NEG_MODEL_SCRIPT="$CEREMONY_ROOT/lint-format-red.jsonl"
+  cp "$_int2_source" "$NEG_MODEL_SCRIPT"
+  shasum -a 256 "$_int2_source" "$NEG_MODEL_SCRIPT" \
+    > "$CEREMONY_ROOT/evidence/lint-format-red-script.sha256"
+  _int2_a="$(sed -n '1s/ .*//p' "$CEREMONY_ROOT/evidence/lint-format-red-script.sha256")"
+  _int2_b="$(sed -n '2s/ .*//p' "$CEREMONY_ROOT/evidence/lint-format-red-script.sha256")"
+  [ "$_int2_a" = "$_int2_b" ] \
+    || { die "committed and staged model-script hashes differ"; return 1; }
+
+  export HARNESS_TEST_MODEL_SCRIPT="$NEG_MODEL_SCRIPT"
+  export NEG_WORK_ITEM="${NEG_WORK_ITEM:-ceremony-lint-format-red-003}"
+  ok "negative script staged and preflighted; worker may now be started"
+  return 0
+}
+
+if ! _int2_negative_setup; then
+  unset HARNESS_TEST_MODEL_SCRIPT 2>/dev/null
+  return 1 2>/dev/null || exit 1
+fi
+
+echo "Next: propose, inspect containment, approve once through harness-pilot, then enable dispatch."

--- a/scripts/ceremony/int2-negative-verify.sh
+++ b/scripts/ceremony/int2-negative-verify.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Shared evidence verifier for the intentional verification failure. Read-only.
+set -euo pipefail
+
+: "${CEREMONY_ROOT:?CEREMONY_ROOT is required}"
+: "${REFERENCE_CHECKOUT:?REFERENCE_CHECKOUT is required}"
+: "${NEG_INTENDED_RUN_ID:?NEG_INTENDED_RUN_ID is required}"
+
+_int2_work_item="${NEG_WORK_ITEM:-ceremony-lint-format-red-003}"
+_int2_evidence="$CEREMONY_ROOT/evidence/$_int2_work_item"
+node "$REFERENCE_CHECKOUT/scripts/ceremony/int2-evidence.mjs" verify \
+  --case negative \
+  --work-item "$_int2_work_item" \
+  --run-id "$NEG_INTENDED_RUN_ID" \
+  --evidence-dir "$_int2_evidence"
+echo "Verified negative evidence: $_int2_evidence"

--- a/scripts/ceremony/int2-teardown.sh
+++ b/scripts/ceremony/int2-teardown.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# INT-2 §5 teardown. Stops only named disposable resources and removes only
+# the exact ceremony root after evidence has been archived.
+set -euo pipefail
+
+: "${CEREMONY_ROOT:?CEREMONY_ROOT is required}"
+: "${REFERENCE_CHECKOUT:?REFERENCE_CHECKOUT is required}"
+_int2_archive="${1:?usage: int2-teardown.sh /path/to/archive}"
+
+pgrep -f "$REFERENCE_CHECKOUT/services/harness-dispatcher/dist/index.js" \
+  >/dev/null 2>&1 \
+  && { echo "dispatcher is still running; stop it first" >&2; exit 1; }
+pgrep -f "${HARNESS_CHECKOUT:-__none__}/.venv/bin/harness worker" \
+  >/dev/null 2>&1 \
+  && { echo "Harness worker is still running; stop it first" >&2; exit 1; }
+[ -d "$CEREMONY_ROOT/evidence" ] \
+  || { echo "evidence directory is absent; refusing teardown" >&2; exit 1; }
+
+mkdir -p "$_int2_archive"
+_int2_name="int2-evidence-$(basename "$CEREMONY_ROOT")"
+cp -R "$CEREMONY_ROOT/evidence" "$_int2_archive/$_int2_name"
+(
+  cd "$_int2_archive/$_int2_name"
+  find . -type f -exec shasum -a 256 {} \; | sort \
+    > "$_int2_archive/$_int2_name.sha256"
+)
+
+export HARNESS_DISPATCH_ENABLED=false
+docker stop int2-harness-postgres >/dev/null 2>&1 || true
+docker stop int2-reference-postgres >/dev/null 2>&1 || true
+
+case "$CEREMONY_ROOT" in
+  /|/home|/Users|/var|/var/lib|/var/lib/harness-dispatcher|"$HOME")
+    echo "refusing suspicious CEREMONY_ROOT=$CEREMONY_ROOT" >&2
+    exit 1
+    ;;
+esac
+rm -rf "$CEREMONY_ROOT"
+echo "Teardown complete; evidence archived at $_int2_archive/$_int2_name"

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Headless INT-2 mechanism gate: real production dispatcher, two real Postgres
+# databases, the pinned Harness, and Docker-isolated scripted runs.
+set -euo pipefail
+
+_int2_repo="$(cd "$(dirname "$0")/../.." && pwd)"
+_int2_root="$(mktemp -d -t int2-automated.XXXXXX)"
+_int2_suffix="${GITHUB_RUN_ID:-$$}-${GITHUB_RUN_ATTEMPT:-0}"
+_int2_harness_db="int2-suite-harness-${_int2_suffix}"
+_int2_reference_db="int2-suite-reference-${_int2_suffix}"
+_int2_evidence="${INT2_SUITE_EVIDENCE_DIR:-$_int2_root/evidence}"
+_int2_marker="$_int2_evidence/executed-count.txt"
+_int2_started="$(date +%s)"
+
+_int2_cleanup() {
+  docker stop "$_int2_harness_db" "$_int2_reference_db" \
+    >/dev/null 2>&1 || true
+  rm -rf "$_int2_root"
+}
+trap _int2_cleanup EXIT INT TERM
+
+for _int2_command in docker git node npm uv; do
+  command -v "$_int2_command" >/dev/null 2>&1 \
+    || { echo "INT-2 suite requires $_int2_command" >&2; exit 2; }
+done
+mkdir -p "$_int2_evidence"
+
+docker run --rm --detach --name "$_int2_harness_db" \
+  --publish 127.0.0.1::5432 \
+  --env POSTGRES_PASSWORD=int2-suite \
+  --env POSTGRES_DB=harness_suite \
+  postgres:18 >/dev/null
+docker run --rm --detach --name "$_int2_reference_db" \
+  --publish 127.0.0.1::5432 \
+  --env POSTGRES_PASSWORD=int2-suite \
+  --env POSTGRES_DB=reference_suite \
+  postgres:16-alpine >/dev/null
+
+for _int2_i in $(seq 1 60); do
+  docker exec "$_int2_harness_db" \
+    pg_isready -U postgres -d harness_suite >/dev/null 2>&1 && break
+  sleep 1
+done
+for _int2_i in $(seq 1 60); do
+  docker exec "$_int2_reference_db" \
+    pg_isready -U postgres -d reference_suite >/dev/null 2>&1 && break
+  sleep 1
+done
+docker exec "$_int2_harness_db" \
+  pg_isready -U postgres -d harness_suite >/dev/null
+docker exec "$_int2_reference_db" \
+  pg_isready -U postgres -d reference_suite >/dev/null
+
+_int2_harness_port="$(
+  docker port "$_int2_harness_db" 5432/tcp | sed -n '1s/.*://p'
+)"
+_int2_reference_port="$(
+  docker port "$_int2_reference_db" 5432/tcp | sed -n '1s/.*://p'
+)"
+export HARNESS_TEST_DATABASE_URL="postgresql://postgres:int2-suite@127.0.0.1:${_int2_harness_port}/harness_suite"
+export DISPATCH_TEST_DATABASE_URL="postgresql://postgres:int2-suite@127.0.0.1:${_int2_reference_port}/reference_suite"
+
+export HARNESS_CHECKOUT="${HARNESS_CHECKOUT:-$_int2_root/agent-harness}"
+_int2_pin="0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
+if [ ! -d "$HARNESS_CHECKOUT/.git" ]; then
+  git clone --quiet https://github.com/averray-agent/agent-harness.git \
+    "$HARNESS_CHECKOUT"
+fi
+test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)"
+git -C "$HARNESS_CHECKOUT" checkout --quiet --detach "$_int2_pin"
+test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = "$_int2_pin"
+(
+  cd "$HARNESS_CHECKOUT"
+  uv sync --frozen
+  HARNESS_DATABASE_URL="$HARNESS_TEST_DATABASE_URL" \
+    uv run harness db migrate
+)
+export HARNESS_BIN="$HARNESS_CHECKOUT/.venv/bin/harness"
+"$HARNESS_BIN" --help >/dev/null
+
+for _int2_migration in "$_int2_repo"/ops/migrations/*.sql; do
+  docker exec -i "$_int2_reference_db" \
+    psql -U postgres -d reference_suite \
+      --set ON_ERROR_STOP=1 -q < "$_int2_migration" >/dev/null
+done
+
+_int2_image_tag="reference-agent-pilot:int2-${_int2_suffix}"
+docker build --quiet -f "$_int2_repo/ops/Dockerfile.pilot" \
+  -t "$_int2_image_tag" "$_int2_repo" >/dev/null
+export INT2_PILOT_IMAGE="$(
+  docker image inspect --format '{{.Id}}' "$_int2_image_tag"
+)"
+
+export INT2_SUITE_REQUIRED=1
+export INT2_REPOSITORY_ROOT="$_int2_repo"
+export INT2_SUITE_EVIDENCE_DIR="$_int2_evidence"
+export INT2_SUITE_EXECUTION_MARKER="$_int2_marker"
+
+(
+  cd "$_int2_repo"
+  npm run build
+  npx vitest run test/integration/int2-automated-suite.test.ts \
+    --reporter=verbose
+)
+
+_int2_executed="$(tr -d '[:space:]' < "$_int2_marker")"
+test "$_int2_executed" = "9" \
+  || {
+    echo "INT-2 suite executed $_int2_executed cases; expected 9" >&2
+    exit 1
+  }
+_int2_elapsed="$(( $(date +%s) - _int2_started ))"
+printf '%s\n' "$_int2_elapsed" > "$_int2_evidence/wall-time-seconds.txt"
+echo "INT-2 automated suite: $_int2_executed cases executed in ${_int2_elapsed}s"

--- a/test/integration/int2-automated-suite.test.ts
+++ b/test/integration/int2-automated-suite.test.ts
@@ -1,0 +1,903 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+
+import { Pool } from "pg";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import { runPilotCli } from "../../scripts/ops/harness-pilot.mjs";
+import {
+  collectInt2Evidence,
+  INT2_EXPECTED_PATH,
+  INT2_HARNESS_PIN,
+  INT2_PILOT_CAPABILITIES,
+  Int2EvidenceError,
+  verifyInt2Evidence,
+  verifyScriptedPairPreflight,
+} from "../../scripts/ceremony/int2-evidence.mjs";
+import {
+  createProductionDispatcher,
+  type DispatcherLogger,
+  type DispatcherProcess,
+} from "../../services/harness-dispatcher/src/index.js";
+import {
+  loadProfileManifest,
+  ProfileManifestError,
+} from "../../services/harness-dispatcher/src/profile-manifest.js";
+
+const execFileAsync = promisify(execFile);
+const REQUIRED_ENVIRONMENT = [
+  "DISPATCH_TEST_DATABASE_URL",
+  "HARNESS_TEST_DATABASE_URL",
+  "HARNESS_BIN",
+  "HARNESS_CHECKOUT",
+  "INT2_PILOT_IMAGE",
+] as const;
+const missingEnvironment = REQUIRED_ENVIRONMENT.filter(
+  (name) => !process.env[name]?.trim(),
+);
+const required = process.env.INT2_SUITE_REQUIRED === "1";
+if (required && missingEnvironment.length > 0) {
+  throw new Error(
+    `INT-2 suite is required but missing: ${missingEnvironment.join(", ")}`,
+  );
+}
+const ready = missingEnvironment.length === 0;
+const REPOSITORY_ROOT = path.resolve(
+  process.env.INT2_REPOSITORY_ROOT ?? path.join(import.meta.dirname, "../.."),
+);
+const FIXTURE_ROOT = path.join(
+  REPOSITORY_ROOT,
+  "test/fixtures/agent-integration/ceremony",
+);
+const EXPECTED_CASE_COUNT = 9;
+const TEST_TIMEOUT_MS = 240_000;
+const TERMINAL_WAIT_MS = 180_000;
+const SENTINEL_RUN_ID = "00000000-0000-4000-8000-000000000000";
+
+describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
+  let root: string;
+  let profilesRoot: string;
+  let modelScriptPath: string;
+  let haltFile: string;
+  let evidenceRoot: string;
+  let workerHome: string;
+  let referencePool: Pool;
+  let harnessPool: Pool;
+  let suitePrefix: string;
+  let executedCases = 0;
+  const d3Results: Array<{
+    case: string;
+    mutation: string;
+    observedFailure: string;
+  }> = [];
+  const workers = new Set<HarnessWorker>();
+  const workItemIds = new Set<string>();
+  const loggerRecords: Array<{
+    level: "info" | "warn";
+    fields: Record<string, unknown>;
+    message: string;
+  }> = [];
+
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "int2-suite-"));
+    profilesRoot = path.join(root, "profiles");
+    modelScriptPath = path.join(root, "model-script.jsonl");
+    haltFile = path.join(root, "HALT");
+    evidenceRoot = process.env.INT2_SUITE_EVIDENCE_DIR
+      ? path.resolve(process.env.INT2_SUITE_EVIDENCE_DIR)
+      : path.join(root, "evidence");
+    workerHome = path.join(root, "worker-home");
+    suitePrefix = `int2-ci-${process.pid}-${Date.now()}`;
+    await Promise.all([
+      mkdir(profilesRoot, { recursive: true }),
+      mkdir(evidenceRoot, { recursive: true }),
+      mkdir(path.join(root, "dispatch-artifacts"), { recursive: true }),
+      mkdir(path.join(root, "dispatch-intents"), { recursive: true }),
+      mkdir(workerHome, { recursive: true }),
+    ]);
+
+    await assertHarnessPin();
+    await prepareLocalGitRemote();
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+    installProcessEnvironment();
+
+    referencePool = new Pool({
+      connectionString: process.env.DISPATCH_TEST_DATABASE_URL,
+    });
+    harnessPool = new Pool({
+      connectionString: process.env.HARNESS_TEST_DATABASE_URL,
+    });
+    await applyReferenceMigrations();
+  }, TEST_TIMEOUT_MS);
+
+  afterAll(async () => {
+    for (const worker of workers) {
+      await worker.stop();
+    }
+    await referencePool?.end();
+    await harnessPool?.end();
+    await Promise.all(
+      [...workItemIds].map((workItemId) =>
+        rm(
+          `/var/lib/harness-dispatcher/workspaces/${workItemId}-v1`,
+          { recursive: true, force: true },
+        )),
+    );
+    await writeFile(
+      path.join(evidenceRoot, "suite-summary.json"),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        harnessPin: INT2_HARNESS_PIN,
+        executedCases,
+        expectedCases: EXPECTED_CASE_COUNT,
+        attenuationBoundary: {
+          production: [
+            "profile_loader_unvetted_capability",
+            "narrower_profile_accepted",
+          ],
+          typedOnly: [
+            "capability_not_granted",
+            "capability_effect_external",
+          ],
+          typedChecksReachableThroughProductionProfileLoading: false,
+        },
+        d3: d3Results,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    if (process.env.INT2_SUITE_EXECUTION_MARKER) {
+      await writeFile(
+        process.env.INT2_SUITE_EXECUTION_MARKER,
+        `${executedCases}\n`,
+        "utf8",
+      );
+    }
+    await rm(root, { recursive: true, force: true });
+  }, TEST_TIMEOUT_MS);
+
+  it("preflights the controlled red/green pair against a real tracked diff", async () => {
+    executedCases += 1;
+    const result = await verifyScriptedPairPreflight({
+      repositoryRoot: REPOSITORY_ROOT,
+    });
+
+    expect(result.targetPath).toBe(INT2_EXPECTED_PATH);
+    expect(result.green.exitCode).toBe(0);
+    expect(result.negative.exitCode).not.toBe(0);
+    expect(result.negative.exitCode).not.toBe(128);
+    expect(result.green.numstat).not.toBe("");
+    expect(result.negative.numstat).not.toBe("");
+    d3Results.push({
+      case: "controlled-pair",
+      mutation: "the red fixture adds trailing whitespace to the same append",
+      observedFailure: `git diff --check exit ${result.negative.exitCode}`,
+    });
+  }, TEST_TIMEOUT_MS);
+
+  it("keeps an unapproved task outside the production dispatchable set", async () => {
+    executedCases += 1;
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+    const workItemId = nextWorkItem("unapproved");
+    await propose("lint-format-green", workItemId);
+
+    const dispatcher = createDispatcher();
+    await expect(dispatcher.tick()).resolves.toMatchObject({ outcome: "idle" });
+    await dispatcher.shutdown();
+
+    const evidence = await collectEvidence(
+      "unapproved",
+      workItemId,
+      SENTINEL_RUN_ID,
+    );
+    assertD3Mutation(
+      "unapproved",
+      evidence,
+      (mutated) => {
+        mutated.task.lifecycle = "approved";
+      },
+      "terminal_lifecycle",
+      "change the stored lifecycle from proposed to approved",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("refuses an approval-hash mismatch before claim or submit", async () => {
+    executedCases += 1;
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+    const workItemId = nextWorkItem("hash-mismatch");
+    const approval = await proposeAndApprove("lint-format-green", workItemId);
+    await referencePool.query(
+      `update agent_tasks
+       set task = jsonb_set(task, '{proposal,title}', '"tampered after approval"')
+       where work_item_id = $1 and task_version = 1`,
+      [workItemId],
+    );
+
+    const dispatcher = createDispatcher();
+    await expect(dispatcher.tick()).resolves.toMatchObject({
+      outcome: "refused",
+      reason: "approval_hash_mismatch",
+    });
+    await dispatcher.shutdown();
+
+    const evidence = await collectEvidence(
+      "hash-mismatch",
+      workItemId,
+      approval.intendedRunId,
+    );
+    assertD3Mutation(
+      "hash-mismatch",
+      evidence,
+      (mutated) => {
+        mutated.decisions[0].proposal.why = ["wrong_reason"];
+      },
+      "decision_reason",
+      "replace the recorded refusal reason",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("rejects the negative fixture on its merits with no handoff", async () => {
+    executedCases += 1;
+    const evidence = await runScriptedTerminalCase({
+      caseName: "negative",
+      fixture: "lint-format-red",
+      script: "lint-format-red.jsonl",
+      lifecycle: "failed",
+    });
+    assertD3Mutation(
+      "negative",
+      evidence,
+      (mutated) => {
+        mutated.exit128Present = true;
+      },
+      "events_have_no_exit_128",
+      "inject exit_128 into the recorded verifier evidence",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("produces one verified, unactuated green handoff", async () => {
+    executedCases += 1;
+    const evidence = await runScriptedTerminalCase({
+      caseName: "green",
+      fixture: "lint-format-green",
+      script: "lint-format-green.jsonl",
+      lifecycle: "handoff_ready",
+    });
+    assertD3Mutation(
+      "green",
+      evidence,
+      (mutated) => {
+        mutated.patch.numstat = "";
+      },
+      "criterion_inspected_non_empty_diff",
+      "erase the reconstructed git diff --numstat",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("restarts between submit and reconcile without duplicating the run", async () => {
+    executedCases += 1;
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+    await stageModelScript("lint-format-green.jsonl");
+    const workItemId = nextWorkItem("restart");
+    const approval = await proposeAndApprove("lint-format-green", workItemId);
+    const worker = await startWorker();
+    const first = createDispatcher();
+    await expect(first.tick()).resolves.toMatchObject({
+      outcome: "dispatched",
+      intendedRunId: approval.intendedRunId,
+    });
+    await first.shutdown();
+
+    const replay = await execFileAsync(
+      process.env.HARNESS_BIN!,
+      [
+        "run",
+        "submit",
+        "--run-id",
+        approval.intendedRunId,
+        path.join(root, "dispatch-intents", `${workItemId}-v1.json`),
+      ],
+      {
+        cwd: process.env.HARNESS_CHECKOUT,
+        env: process.env,
+      },
+    );
+    expect(replay.stdout.trim()).toBe(approval.intendedRunId);
+
+    const restarted = createDispatcher();
+    await waitForLifecycle(restarted, workItemId, "handoff_ready");
+    await restarted.shutdown();
+    await stopWorker(worker);
+
+    const evidence = await collectEvidence(
+      "restart",
+      workItemId,
+      approval.intendedRunId,
+    );
+    assertD3Mutation(
+      "restart",
+      evidence,
+      (mutated) => {
+        mutated.runs.push(structuredClone(mutated.runs[0]));
+      },
+      "one_harness_run",
+      "duplicate the Harness run projection",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("HALT cancels a bound live run and never creates a handoff", async () => {
+    executedCases += 1;
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+    await stageHaltModelScript();
+    const workItemId = nextWorkItem("halt");
+    const approval = await proposeAndApprove("lint-format-green", workItemId);
+    const worker = await startWorker();
+    const dispatcher = createDispatcher();
+    try {
+      await expect(dispatcher.tick()).resolves.toMatchObject({
+        outcome: "dispatched",
+        intendedRunId: approval.intendedRunId,
+      });
+      await waitForHarnessState(approval.intendedRunId, "executing");
+      await writeFile(haltFile, "INT-2 automated HALT drill\n", "utf8");
+      await expect(dispatcher.tick()).resolves.toMatchObject({ outcome: "halted" });
+      await waitForHarnessState(approval.intendedRunId, "cancelled");
+    } finally {
+      await dispatcher.shutdown();
+      await unlink(haltFile).catch(() => undefined);
+      await stopWorker(worker);
+    }
+
+    const evidence = await collectEvidence(
+      "halt",
+      workItemId,
+      approval.intendedRunId,
+    );
+    assertD3Mutation(
+      "halt",
+      evidence,
+      (mutated) => {
+        mutated.decisions = mutated.decisions.filter(
+          (decision) => decision.decisionType !== "escalation",
+        );
+      },
+      "decision_escalation_count",
+      "remove the HALT escalation decision",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("accepts a seven-capability profile with strictly narrower authority", async () => {
+    executedCases += 1;
+    const narrowed = INT2_PILOT_CAPABILITIES.filter(
+      (capability) => capability !== "fs.write_file",
+    );
+    await writePilotProfile(narrowed);
+    const evidence = await runScriptedTerminalCase({
+      caseName: "narrow",
+      fixture: "lint-format-green",
+      script: "lint-format-green.jsonl",
+      lifecycle: "handoff_ready",
+      preserveProfile: true,
+    });
+    assertD3Mutation(
+      "narrow",
+      evidence,
+      (mutated) => {
+        mutated.runs[0].manifest.grants.splice(1, 0, {
+          capability: "fs.write_file",
+        });
+      },
+      "effective_authority_narrowed",
+      "restore fs.write_file to the effective run manifest",
+    );
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+  }, TEST_TIMEOUT_MS);
+
+  it("rejects memory.propose in the outer production profile loader", async () => {
+    executedCases += 1;
+    await writePilotProfile([...INT2_PILOT_CAPABILITIES, "memory.propose"]);
+    let observedProfileFailure:
+      { name: string; reason: string } | undefined;
+    try {
+      await loadProfileManifest("coding-change-pilot", process.env);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ProfileManifestError);
+      const profileError = error as ProfileManifestError;
+      observedProfileFailure = {
+        name: profileError.name,
+        reason: profileError.reason,
+      };
+    }
+    expect(observedProfileFailure).toEqual({
+      name: "ProfileManifestError",
+      reason: "unvetted_capability",
+    });
+    if (!observedProfileFailure) {
+      throw new Error("profile loader did not reject the unvetted capability");
+    }
+    const workItemId = nextWorkItem("profile-unvetted");
+    const approval = await proposeAndApprove("lint-format-green", workItemId);
+    const loggerStart = loggerRecords.length;
+    const dispatcher = createDispatcher();
+    await expect(dispatcher.tick()).resolves.toEqual({
+      outcome: "error",
+      reason: "attempt_failed",
+    });
+    await dispatcher.shutdown();
+    const profileFailure = loggerRecords.slice(loggerStart).find(
+      (record) =>
+        record.level === "warn"
+        && record.fields.errorName === "ProfileManifestError",
+    );
+    expect(profileFailure).toBeDefined();
+
+    const evidence = await collectEvidence(
+      "profile-unvetted",
+      workItemId,
+      approval.intendedRunId,
+      {
+        profileLoadError: observedProfileFailure,
+      },
+    );
+    assertD3Mutation(
+      "profile-unvetted",
+      evidence,
+      (mutated) => {
+        mutated.profileLoadError.reason = "capability_not_granted";
+      },
+      "outer_profile_loader_refusal",
+      "mislabel the outer loader failure as the unreachable inner guard",
+    );
+    await writePilotProfile(INT2_PILOT_CAPABILITIES);
+  }, TEST_TIMEOUT_MS);
+
+  async function runScriptedTerminalCase({
+    caseName,
+    fixture,
+    script,
+    lifecycle,
+    preserveProfile = false,
+  }: {
+    caseName: "green" | "negative" | "narrow";
+    fixture: "lint-format-green" | "lint-format-red";
+    script: "lint-format-green.jsonl" | "lint-format-red.jsonl";
+    lifecycle: "handoff_ready" | "failed";
+    preserveProfile?: boolean;
+  }): Promise<any> {
+    if (!preserveProfile) {
+      await writePilotProfile(INT2_PILOT_CAPABILITIES);
+    }
+    await stageModelScript(script);
+    const workItemId = nextWorkItem(caseName);
+    const approval = await proposeAndApprove(fixture, workItemId);
+    const worker = await startWorker();
+    const dispatcher = createDispatcher();
+    try {
+      await waitForLifecycle(dispatcher, workItemId, lifecycle);
+    } finally {
+      await dispatcher.shutdown();
+      await stopWorker(worker);
+    }
+    return collectEvidence(caseName, workItemId, approval.intendedRunId);
+  }
+
+  async function collectEvidence(
+    caseName: string,
+    workItemId: string,
+    intendedRunId: string,
+    extras: {
+      profileLoadError?: { name: string; reason: string };
+    } = {},
+  ): Promise<any> {
+    const evidence = await collectInt2Evidence({
+      workItemId,
+      intendedRunId,
+      referenceDatabaseUrl: process.env.DISPATCH_TEST_DATABASE_URL,
+      harnessDatabaseUrl: process.env.HARNESS_TEST_DATABASE_URL,
+      harnessBin: process.env.HARNESS_BIN,
+      expectedPath: INT2_EXPECTED_PATH,
+      evidenceDir: path.join(evidenceRoot, caseName),
+      ...extras,
+    });
+    expect(() => verifyInt2Evidence(evidence, caseName)).not.toThrow();
+    return evidence;
+  }
+
+  function assertD3Mutation(
+    caseName: string,
+    evidence: any,
+    mutate: (value: any) => void,
+    expectedFailure: string,
+    mutation: string,
+  ): void {
+    const mutated = structuredClone(evidence);
+    mutate(mutated);
+    let observed = "";
+    try {
+      verifyInt2Evidence(mutated, caseName);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Int2EvidenceError);
+      observed = (error as Error).message;
+    }
+    expect(observed).toContain(expectedFailure);
+    d3Results.push({
+      case: caseName,
+      mutation,
+      observedFailure: expectedFailure,
+    });
+  }
+
+  async function propose(
+    fixture: string,
+    workItemId: string,
+  ): Promise<Record<string, any>> {
+    return pilotCommand([
+      "propose",
+      "--fixture",
+      fixture,
+      "--work-item",
+      workItemId,
+    ]);
+  }
+
+  async function proposeAndApprove(
+    fixture: string,
+    workItemId: string,
+  ): Promise<{ intendedRunId: string }> {
+    await propose(fixture, workItemId);
+    const result = await pilotCommand([
+      "approve",
+      "--work-item",
+      workItemId,
+      "--version",
+      "1",
+      "--operator",
+      "int2-ci-operator",
+      "--confirm",
+    ]);
+    expect(result.submissionAttemptedByCli).toBe(false);
+    expect(result.approvedTaskHash).toMatch(/^sha256:[a-f0-9]{64}$/u);
+    expect(result.intendedRunId).toMatch(
+      /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/u,
+    );
+    return { intendedRunId: result.intendedRunId };
+  }
+
+  async function pilotCommand(
+    args: string[],
+  ): Promise<Record<string, any>> {
+    let stdout = "";
+    let stderr = "";
+    const code = await runPilotCli(args, {
+      environment: process.env,
+      output: (line: string) => {
+        stdout += line;
+      },
+      errorOutput: (line: string) => {
+        stderr += line;
+      },
+    });
+    expect(code, stderr).toBe(0);
+    return JSON.parse(stdout) as Record<string, any>;
+  }
+
+  function nextWorkItem(caseName: string): string {
+    const value = `${suitePrefix}-${caseName}`;
+    workItemIds.add(value);
+    return value;
+  }
+
+  function createDispatcher(): DispatcherProcess {
+    return createProductionDispatcher(
+      { ...process.env },
+      suiteLogger,
+    );
+  }
+
+  async function waitForLifecycle(
+    dispatcher: DispatcherProcess,
+    workItemId: string,
+    expected: string,
+  ): Promise<void> {
+    const deadline = Date.now() + TERMINAL_WAIT_MS;
+    let lastLifecycle = "<missing>";
+    while (Date.now() < deadline) {
+      await dispatcher.tick();
+      const result = await referencePool.query<{
+        lifecycle: string;
+      }>(
+        `select lifecycle from agent_tasks
+         where work_item_id = $1 and task_version = 1`,
+        [workItemId],
+      );
+      lastLifecycle = result.rows[0]?.lifecycle ?? "<missing>";
+      if (lastLifecycle === expected) return;
+      if (["blocked", "cancelled", "failed", "handoff_ready"].includes(
+        lastLifecycle,
+      )) {
+        throw new Error(
+          `${workItemId} reached unexpected terminal lifecycle `
+            + `${lastLifecycle}; expected ${expected}`,
+        );
+      }
+      await delay(500);
+    }
+    throw new Error(
+      `Timed out waiting for ${workItemId} lifecycle ${expected}; `
+        + `last=${lastLifecycle}`,
+    );
+  }
+
+  async function writePilotProfile(
+    capabilities: readonly string[],
+  ): Promise<void> {
+    const directory = path.join(profilesRoot, "coding-change-pilot");
+    await mkdir(directory, { recursive: true });
+    const bytes = [
+      "name: coding-change-pilot",
+      'version: "1"',
+      "environment:",
+      "  provider: docker",
+      `  image: "${process.env.INT2_PILOT_IMAGE}"`,
+      "egress:",
+      "  mode: deny_all",
+      "  allowed_destinations: []",
+      "model:",
+      "  executor:",
+      "    adapter: openai-compatible",
+      "    model_ref: null",
+      "capabilities:",
+      ...capabilities.map((capability) => `  - ${capability}`),
+      "verification:",
+      "  baseline_command: null",
+      "  protected_paths: []",
+      "strategies:",
+      "  - direct_execution",
+      "retention_policy: standard",
+      "",
+    ].join("\n");
+    await writeFile(path.join(directory, "profile.yaml"), bytes, "utf8");
+    process.env.HARNESS_PROFILE_SHA256 = createHash("sha256")
+      .update(bytes, "utf8")
+      .digest("hex");
+  }
+
+  async function stageModelScript(file: string): Promise<void> {
+    await copyFile(path.join(FIXTURE_ROOT, file), modelScriptPath);
+  }
+
+  async function stageHaltModelScript(): Promise<void> {
+    await writeFile(
+      modelScriptPath,
+      [
+        JSON.stringify({
+          tool_calls: [{
+            id: "int2-halt-sleep",
+            name: "shell_run",
+            arguments: { command: "sleep 30" },
+          }],
+          usage: { input_tokens: 2, output_tokens: 1, requests: 1 },
+          finish_reason: "tool_call",
+        }),
+        JSON.stringify({
+          text: "The bounded HALT probe was interrupted.",
+          usage: { input_tokens: 2, output_tokens: 2, requests: 1 },
+          finish_reason: "stop",
+        }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+  }
+
+  async function startWorker(): Promise<HarnessWorker> {
+    const output: string[] = [];
+    const child = spawn(process.env.HARNESS_BIN!, ["worker"], {
+      cwd: process.env.HARNESS_CHECKOUT,
+      env: {
+        ...process.env,
+        HARNESS_DATABASE_URL: process.env.HARNESS_TEST_DATABASE_URL,
+        HARNESS_PROFILES_ROOT: profilesRoot,
+        HARNESS_TEST_MODEL_SCRIPT: modelScriptPath,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    child.stdout?.on("data", (chunk) => output.push(String(chunk)));
+    child.stderr?.on("data", (chunk) => output.push(String(chunk)));
+    const deadline = Date.now() + 15_000;
+    while (
+      Date.now() < deadline
+      && child.exitCode === null
+      && !output.join("").includes("worker ready")
+    ) {
+      await delay(100);
+    }
+    if (
+      child.exitCode !== null
+      || !output.join("").includes("worker ready")
+    ) {
+      child.kill("SIGTERM");
+      throw new Error(
+        `Harness worker did not become ready (${child.exitCode}): `
+          + output.join("").slice(-4_000),
+      );
+    }
+    const worker = new HarnessWorker(child, output);
+    workers.add(worker);
+    return worker;
+  }
+
+  async function stopWorker(worker: HarnessWorker): Promise<void> {
+    await worker.stop();
+    workers.delete(worker);
+  }
+
+  async function assertHarnessPin(): Promise<void> {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["-C", process.env.HARNESS_CHECKOUT!, "rev-parse", "HEAD"],
+    );
+    expect(stdout.trim()).toBe(INT2_HARNESS_PIN);
+    await execFileAsync(process.env.HARNESS_BIN!, ["--help"], {
+      cwd: process.env.HARNESS_CHECKOUT,
+    });
+  }
+
+  async function prepareLocalGitRemote(): Promise<void> {
+    const fixture = JSON.parse(
+      await readFile(path.join(FIXTURE_ROOT, "lint-format-green.json"), "utf8"),
+    ) as { repository: { baseRevision: string } };
+    await execFileAsync(
+      "git",
+      ["-C", REPOSITORY_ROOT, "cat-file", "-e", `${fixture.repository.baseRevision}^{commit}`],
+    );
+    const bare = path.join(root, "reference-agent.git");
+    await execFileAsync("git", [
+      "clone",
+      "--bare",
+      "--local",
+      "--no-hardlinks",
+      REPOSITORY_ROOT,
+      bare,
+    ]);
+    process.env.GIT_CONFIG_COUNT = "2";
+    process.env.GIT_CONFIG_KEY_0 = `url.file://${bare}.insteadOf`;
+    process.env.GIT_CONFIG_VALUE_0 =
+      "https://github.com/depre-dev/averray-reference-agent.git";
+    process.env.GIT_CONFIG_KEY_1 = "protocol.file.allow";
+    process.env.GIT_CONFIG_VALUE_1 = "always";
+  }
+
+  function installProcessEnvironment(): void {
+    // The worker, dispatcher CLI reads, and evidence collector must share one
+    // isolated artifact root. Do not override HOME: Docker CLI contexts are
+    // home-scoped, and the Docker provider's workspace must remain beneath a
+    // host path shared with the desktop VM.
+    process.env.HARNESS_ARTIFACT_ROOT =
+      path.join(workerHome, ".agent-runtime/artifacts");
+    process.env.DATABASE_URL = process.env.DISPATCH_TEST_DATABASE_URL;
+    process.env.HARNESS_DATABASE_URL = process.env.HARNESS_TEST_DATABASE_URL;
+    process.env.HARNESS_PROFILES_ROOT = profilesRoot;
+    process.env.HARNESS_DISPATCH_ARTIFACT_DIR =
+      path.join(root, "dispatch-artifacts");
+    process.env.HARNESS_DISPATCH_INTENT_DIR =
+      path.join(root, "dispatch-intents");
+    process.env.HARNESS_DISPATCH_HEARTBEAT_PATH =
+      path.join(root, "dispatcher-heartbeat.json");
+    process.env.HARNESS_DISPATCH_ALERTS_PATH =
+      path.join(root, "dispatcher-alerts.jsonl");
+    process.env.HARNESS_DISPATCH_READ_TIMEOUT_MS = "30000";
+    process.env.HARNESS_DISPATCH_ENABLED = "true";
+    process.env.HARNESS_DISPATCHER_ID = `int2-suite-${process.pid}`;
+    process.env.HALT_FILE = haltFile;
+    process.env.POLICY_CONFIG_PATH =
+      path.join(REPOSITORY_ROOT, "hermes/config/policy.yaml");
+    process.env.HERMES_DISPATCH_ALLOWED_REPOS =
+      "depre-dev/averray-reference-agent";
+    delete process.env.HARNESS_DISPATCH_DEP_CACHE_DIR;
+  }
+
+  async function applyReferenceMigrations(): Promise<void> {
+    const migrationRoot = path.join(REPOSITORY_ROOT, "ops/migrations");
+    for (const name of (await readdir(migrationRoot))
+      .filter((value) => value.endsWith(".sql"))
+      .sort()) {
+      await referencePool.query(
+        await readFile(path.join(migrationRoot, name), "utf8"),
+      );
+    }
+  }
+
+  async function waitForHarnessState(
+    runId: string,
+    expected: string,
+  ): Promise<void> {
+    const deadline = Date.now() + 45_000;
+    let lastState = "<missing>";
+    while (Date.now() < deadline) {
+      const result = await harnessPool.query<{ state: string }>(
+        "select state from runs where run_id = $1",
+        [runId],
+      );
+      lastState = result.rows[0]?.state ?? "<missing>";
+      if (lastState === expected) return;
+      if (
+        expected === "executing"
+        && ["cancelled", "failed", "learning_processed"].includes(lastState)
+      ) {
+        break;
+      }
+      await delay(100);
+    }
+    throw new Error(
+      `Timed out waiting for Harness run ${runId} state ${expected}; `
+        + `last=${lastState}`,
+    );
+  }
+
+  const suiteLogger: DispatcherLogger = {
+    info(fields, message) {
+      loggerRecords.push({ level: "info", fields, message });
+    },
+    warn(fields, message) {
+      loggerRecords.push({ level: "warn", fields, message });
+    },
+  };
+});
+
+class HarnessWorker {
+  private stopped = false;
+
+  constructor(
+    private readonly child: ChildProcess,
+    private readonly output: string[],
+  ) {}
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.child.exitCode !== null) return;
+    this.child.kill("SIGINT");
+    if (await waitForExit(this.child, 2_000)) return;
+    this.child.kill("SIGINT");
+    if (await waitForExit(this.child, 2_000)) return;
+    this.child.kill("SIGTERM");
+    if (await waitForExit(this.child, 2_000)) return;
+    throw new Error(
+      `Harness worker did not stop: ${this.output.join("").slice(-4_000)}`,
+    );
+  }
+}
+
+async function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.exitCode !== null) return true;
+  return Promise.race([
+    new Promise<boolean>((resolve) => {
+      child.once("exit", () => resolve(true));
+    }),
+    delay(timeoutMs).then(() => false),
+  ]);
+}

--- a/test/unit/attenuation.test.ts
+++ b/test/unit/attenuation.test.ts
@@ -15,8 +15,14 @@ import {
   AttenuationError,
 } from "../../packages/averray-mcp/src/attenuation.js";
 import {
+  PILOT_CAPABILITY_IDS,
+} from "../../packages/averray-mcp/src/agent-task-proposal.js";
+import {
   mapAgentTaskToTaskIntent,
 } from "../../packages/averray-mcp/src/task-intent-mapping.js";
+import {
+  VETTED_CAPABILITIES,
+} from "../../services/harness-dispatcher/src/profile-manifest.js";
 
 const CAPABILITIES: PilotProfileManifest["capabilities"] = [
   { id: "fs.read_file", effectClass: "none", delegable: false },
@@ -30,6 +36,12 @@ const CAPABILITIES: PilotProfileManifest["capabilities"] = [
 ];
 
 describe("pre-dispatch TaskIntent attenuation", () => {
+  it("records why profile capability checks are unreachable after production loading", () => {
+    expect(new Set(VETTED_CAPABILITIES.keys())).toEqual(
+      new Set(PILOT_CAPABILITY_IDS),
+    );
+  });
+
   it("accepts a hash-bound intent inside approved direct-execution authority", async () => {
     const setup = await passingSetup();
 
@@ -232,17 +244,22 @@ describe("pre-dispatch TaskIntent attenuation", () => {
     );
   });
 
-  it("rejects profile capabilities absent from approved grants", async () => {
+  it("rejects an eight-capability profile beside seven approved grants", async () => {
     const setup = await passingSetup();
-    const capabilities: PilotProfileManifest["capabilities"] = [
-      ...setup.profile.capabilities,
-      { id: "unapproved.capability", effectClass: "local", delegable: false },
-    ];
+    const task = agentTaskV1Schema.parse({
+      ...setup.task,
+      requestedAuthority: {
+        ...setup.task.requestedAuthority,
+        grants: setup.task.requestedAuthority.grants.filter(
+          (grant) => grant.capabilityId !== "fs.write_file",
+        ),
+      },
+    });
 
     await expectReason(
-      setup.task,
+      task,
       setup.intent,
-      { ...setup.profile, capabilities },
+      setup.profile,
       "capability_not_granted",
     );
   });

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  INT2_EXPECTED_PATH,
+  expectationsForCase,
+  verifyScriptedPairPreflight,
+} from "../../scripts/ceremony/int2-evidence.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const SCRIPT_ROOT = path.join(ROOT, "scripts/ceremony");
+const OPERATOR_SCRIPTS = [
+  "int2-bringup.sh",
+  "int2-green-setup.sh",
+  "int2-negative-setup.sh",
+  "int2-green-verify.sh",
+  "int2-negative-verify.sh",
+  "int2-teardown.sh",
+] as const;
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((value) =>
+      rm(value, { recursive: true, force: true })),
+  );
+});
+
+describe("committed INT-2 ceremony mechanics", () => {
+  it("keeps all six operator scripts parseable and on the shared evidence definition", async () => {
+    const contents = await Promise.all(
+      OPERATOR_SCRIPTS.map(async (name) => {
+        const target = path.join(SCRIPT_ROOT, name);
+        execFileSync("bash", ["-n", target]);
+        return [name, await readFile(target, "utf8")] as const;
+      }),
+    );
+    const byName = Object.fromEntries(contents);
+
+    expect(byName["int2-bringup.sh"]).toContain("ATTACH mode");
+    expect(byName["int2-bringup.sh"]).toContain(
+      "refusing destructive re-creation",
+    );
+    expect(byName["int2-bringup.sh"]).not.toContain(
+      "docker rm -f int2-harness-postgres",
+    );
+    expect(byName["int2-bringup.sh"]).toContain('"$HARNESS_BIN" --help');
+    expect(byName["int2-green-setup.sh"]).not.toContain("${!");
+    expect(byName["int2-negative-setup.sh"]).not.toContain("${!");
+    expect(byName["int2-green-setup.sh"]).toContain('pgrep -f "harness worker"');
+    expect(byName["int2-green-setup.sh"]).toContain("preflight-pair");
+    expect(byName["int2-negative-setup.sh"]).toContain("preflight-pair");
+    expect(byName["int2-green-verify.sh"]).toContain("int2-evidence.mjs");
+    expect(byName["int2-negative-verify.sh"]).toContain("int2-evidence.mjs");
+  });
+
+  it("proves the controlled pair passes and a non-discriminating mutation fails", async () => {
+    const result = await verifyScriptedPairPreflight({
+      repositoryRoot: ROOT,
+    });
+    expect(result.targetPath).toBe(INT2_EXPECTED_PATH);
+    expect(result.green.exitCode).toBe(0);
+    expect(result.negative.exitCode).not.toBe(0);
+    expect(result.negative.exitCode).not.toBe(128);
+
+    const temporary = await mkdtemp(path.join(tmpdir(), "int2-pair-mutation-"));
+    temporaryRoots.push(temporary);
+    const green = path.join(
+      ROOT,
+      "test/fixtures/agent-integration/ceremony/lint-format-green.jsonl",
+    );
+    const mutatedNegative = path.join(temporary, "mutated-red.jsonl");
+    await writeFile(mutatedNegative, await readFile(green));
+
+    await expect(
+      verifyScriptedPairPreflight({
+        repositoryRoot: ROOT,
+        negativeScriptPath: mutatedNegative,
+      }),
+    ).rejects.toThrow("controlled pair appended content must differ");
+  });
+
+  it("records the production-loader and typed-attenuation split", () => {
+    expect(expectationsForCase("profile-unvetted")).toMatchObject({
+      profileLoadErrorReason: "unvetted_capability",
+      runCount: 0,
+      outboxCount: 0,
+    });
+    expect(expectationsForCase("narrow")).toMatchObject({
+      runCount: 1,
+      effectiveCapabilities: expect.not.arrayContaining(["fs.write_file"]),
+    });
+  });
+});

--- a/test/unit/profile-manifest.test.ts
+++ b/test/unit/profile-manifest.test.ts
@@ -65,9 +65,9 @@ describe("pinned Harness profile manifests", () => {
     }).toThrow("Vetted capability registry is immutable");
   });
 
-  it("fails closed on an unvetted capability id", async () => {
+  it("refuses memory.propose before the production attenuation boundary", async () => {
     const fixture = await profileFixture(
-      validProfile(["fs.read_file", "network.fetch"]),
+      validProfile([...PILOT_CAPABILITIES, "memory.propose"]),
     );
 
     await expectProfileError(


### PR DESCRIPTION
## What changed

- Added the automated INT-2 supervised-dispatch suite with nine real integration cases against disposable Postgres databases, the pinned Harness worker, and Docker `--network none`.
- Added a shared evidence collector/verifier used by CI and the operator scripts, including patch reconstruction, manifest integrity, decision cardinality, handoff evidence, idempotence, HALT, and no-GitHub-mutation checks.
- Added six operator-facing ceremony scripts and a single CI orchestrator.
- Added an every-PR/main CI job with evidence upload.
- Updated the ceremony runbook and added the packet handback.

## Corrected capability boundary

- Production add `memory.propose` is refused by the outer profile loader as `unvetted_capability`, before any run, outbox item, or handoff exists.
- Production removal of `fs.write_file` is accepted and proves narrower effective authority.
- `capability_not_granted` is pinned at the attenuation boundary using seven approved task grants against the eight-capability profile.
- `capability_effect_external` is pinned at that same typed boundary.
- The suite and handback state explicitly that both attenuation refusal guards are unreachable through production profile loading today because the vetted and pilot capability sets are identical.
- `VETTED_CAPABILITIES` was not widened.

## Checks

Run from a clean checkout at `a4066b4`:

- `npm ci`
- `npm run typecheck` — passed
- `npm test` — 199 files passed, 2 skipped; 2526 tests passed, 13 skipped
- `npm run build` — passed
- `INT2_EVIDENCE_DIR=/private/tmp/int2-suite-evidence-clean-a4066b4 ./scripts/ceremony/run-int2-automated-suite.sh` — all 9 cases passed; marker count 9; 166 seconds wall time
- `git diff --check` — passed

The clean evidence rows and each deliberate mutation are recorded in
`docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md`.

## Affected surfaces

- CI workflow, tests, ceremony tooling, and documentation only.
- No production runtime source, schema/migration, dependency/lock, contract, deployment, or secret change.
- No production or GitHub mutation is performed by the suite.

## Rollback

Revert the two commits in this PR. The new CI job and ceremony tooling are additive and carry no persistent runtime state.
