### PR TITLE
fix(ops): payout lookback assumed 6s blocks; mainnet runs at ~2.1s

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -381,7 +381,16 @@ services:
       # topic0 above is the first thing to re-derive against the deployed
       # contract, not the last.
       PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS: ${PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS:-}
-      PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS: ${PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS:-14400}
+      # ~24h of blocks. Polkadot Hub mainnet runs at ~2.1s/block, NOT the 6s
+      # this was originally sized against — measured 2026-07-29: 14400 blocks
+      # spanned 8h26m, so the old default compared ~8h of payouts against the
+      # product's 24h settled count and under-reported by ~3x. That is a FALSE
+      # SHORTFALL on the money board, which trains the operator to ignore the
+      # one that matters. Verified at 43200: 14 payouts vs settled24h 14 —
+      # an exact match, where 14400 saw only 2 of the same 14.
+      # Erring LONG is safe (confirmed > settled still reads "confirmed");
+      # erring short manufactures an alarm. Lower only if the RPC caps ranges.
+      PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS: ${PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS:-43200}
       # settled-minus-confirmed gap tolerated as a window-boundary artifact — the
       # product's rolling 24h and the block window don't share a clock.
       PRODUCT_HEALTH_PAYOUT_TOLERANCE: ${PRODUCT_HEALTH_PAYOUT_TOLERANCE:-1}


### PR DESCRIPTION
Follow-up to #582, found while verifying the live deploy.

`PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS` defaulted to **14400**, commented "~24h at a 6s block time". **Polkadot Hub mainnet does not run at 6s.** Measured against the live chain today:

| | |
|---|---|
| 14400 blocks | spans **8h 26m** (~2.11 s/block) |
| 1000 blocks | 34m 24s — same rate, independently |

So the probe compared **~8 hours** of payout events against the product's **24-hour** `settled24h`, under-reporting by ~3×.

## Why that matters
With `settled24h = 14`, the 14400 window finds **2** — a shortfall of 12 against a tolerance of 1. That is a **permanent false alarm on the money board**. A fake red is as harmful as a fake green: a shortfall that is always there is one the operator learns to scroll past, which is precisely what this guard exists to prevent.

## Verified on the live chain
| lookback | payout events | vs settled24h=14 |
|---|---|---|
| 14400 (old) | 2 | shortfall 12 — **false alarm** |
| **43200 (new)** | **14** | **exact match → `confirmed`** |
| 86400 | 21 | steady rate, confirms it's a window bug not a settlement gap |

## Direction of error is deliberate
Erring **long** is safe — `decidePayoutEvidence` only flags a SHORTFALL, so `confirmed > settled` still reads `confirmed`. Erring short manufactures the alarm. The comment records the measurement so the next person doesn't re-derive block time from a stale assumption.

Env-only change on the VPS — `up -d slack-operator` picks it up with no rebuild.