### PR TITLE
feat(mobile): ops-first phone board, and no approving what you can't identify

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -130,46 +130,57 @@ describe("MobileBoard", () => {
     expect(getByText("awaiting data")).toBeTruthy();
   });
 
-  test("decisions come from isDecision (same selector as the desktop inbox) and cap with a +N", () => {
+  test("non-approvable work becomes a DELIVERY COUNT, not seven demands", () => {
     const many = Array.from({ length: 7 }, (_, i) => taskCard({ id: `t${i}`, title: `Decision ${i}` }));
-    const { getByText } = render(<MobileBoard health={healthyMainnet} cards={many} nowMs={NOW} />);
-    expect(getByText("Needs you · 7")).toBeTruthy();
-    expect(getByText("Decision 0")).toBeTruthy();
-    expect(getByText("+2 more on the full board.")).toBeTruthy();
+    const { getByText, getByTestId } = render(<MobileBoard health={healthyMainnet} cards={many} nowMs={NOW} />);
+    // None are proposed, so none are actionable from a phone...
+    expect(getByText("Nothing needs you right now.")).toBeTruthy();
+    // ...but the count is real and tappable. Collapsed, never hidden.
+    expect(getByTestId("mobile-delivery-line")).toBeTruthy();
+    expect(getByText("7")).toBeTruthy();
+    expect(getByText(/delivery items waiting/)).toBeTruthy();
   });
 
-  test("uses the shared money-first order and shows why the first decision leads", () => {
-    const routine = taskCard({
-      id: "routine",
-      title: "post-production-deploy verification after workflow run #40",
-      isAction: true,
-    });
-    const unknown = taskCard({ id: "unknown", title: "Review an unclassified task" });
-    const money = taskCard({
-      id: "money",
-      type: "pr",
-      title: "Review settlement changes",
-      files: [{ path: "services/settlement/submit.ts", diff: "+3 -1", critical: false }],
-    });
-    const { container, getByText } = render(
-      <MobileBoard health={healthyMainnet} cards={[routine, unknown, money]} nowMs={NOW} />,
-    );
+  test("an explicable PROPOSED task reaches Act now and states what it does", () => {
+    const card = taskCard({
+      id: "real", title: "codex task", taskStatus: "proposed",
+      prompt: "Rotate the hosted smoke token",
+      reason: "admin JWT expires in 3 days",
+      riskTier: "low",
+    } as Partial<BoardCard>);
+    const { getByText } = render(<MobileBoard health={healthyMainnet} cards={[card]} nowMs={NOW} />);
+    expect(getByText("Act now · 1")).toBeTruthy();
+    expect(getByText("Rotate the hosted smoke token")).toBeTruthy();
+    expect(getByText("admin JWT expires in 3 days")).toBeTruthy();
+    expect(getByText(/low risk/)).toBeTruthy();
+    expect(getByText("Approve")).toBeTruthy();
+  });
 
-    expect(
-      [...container.querySelectorAll(".hm-mb-item-title")].map((node) => node.textContent),
-    ).toEqual([
-      "Review settlement changes",
-      "Review an unclassified task",
-      "post-production-deploy verification after workflow run #40",
-    ]);
-    expect(getByText("Money first · settlement path").getAttribute("data-decision-tier"))
-      .toBe("money-blocking");
+  // THE SHIPPED BOARD (operator screenshot, 2026-07-29 17:42): a green Approve
+  // button under a card whose only title was "codex task".
+  test("a task that cannot say what it does offers NO Approve button", () => {
+    const opaque = taskCard({ id: "opaque", title: "codex task", taskStatus: "proposed" } as Partial<BoardCard>);
+    const { queryByText, getByText } = render(
+      <MobileBoard health={healthyMainnet} cards={[opaque]} nowMs={NOW} onApproveTask={vi.fn()} />,
+    );
+    expect(queryByText("Approve")).toBeNull();
+    expect(getByText(/review on the full board/i)).toBeTruthy();
+  });
+
+  test("routine deploy verifications never reach Act now", () => {
+    const v = taskCard({
+      id: "v", type: "deploy", taskStatus: undefined,
+      title: "post-production-deploy verification after workflow run",
+    } as Partial<BoardCard>);
+    const { getByText, getByTestId } = render(<MobileBoard health={healthyMainnet} cards={[v]} nowMs={NOW} />);
+    expect(getByText("Nothing needs you right now.")).toBeTruthy();
+    expect(getByTestId("mobile-delivery-line")).toBeTruthy();
   });
 
   test("a PROPOSED task exposes Approve/Dismiss and wires them to the operator gate", () => {
     const onApproveTask = vi.fn();
     const onDismissCard = vi.fn();
-    const card = taskCard({ taskStatus: "proposed" } as Partial<BoardCard>);
+    const card = taskCard({ taskStatus: "proposed", prompt: "Rotate the smoke token" } as Partial<BoardCard>);
     const { getByText } = render(
       <MobileBoard
         health={healthyMainnet}
@@ -195,9 +206,14 @@ describe("MobileBoard", () => {
   test("tapping a decision opens it rather than acting on it", () => {
     const onCardClick = vi.fn();
     const { getByText } = render(
-      <MobileBoard health={healthyMainnet} cards={[taskCard()]} nowMs={NOW} onCardClick={onCardClick} />,
+      <MobileBoard
+        health={healthyMainnet}
+        cards={[taskCard({ taskStatus: "proposed", prompt: "Rotate the smoke token" } as Partial<BoardCard>)]}
+        nowMs={NOW}
+        onCardClick={onCardClick}
+      />,
     );
-    fireEvent.click(getByText("Hermes routed work: ops pre-check"));
+    fireEvent.click(getByText("Rotate the smoke token"));
     expect(onCardClick).toHaveBeenCalledWith("codex-task-1");
   });
 
@@ -219,8 +235,8 @@ describe("MobileBoard", () => {
 
   test("empty states stay honest instead of blank", () => {
     const { getByText } = render(<MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />);
-    expect(getByText("Nothing waiting on you.")).toBeTruthy();
-    expect(within(getByText("Nothing waiting on you.").closest("section")!).getByText(/Needs you/)).toBeTruthy();
+    expect(getByText("Nothing needs you right now.")).toBeTruthy();
+    expect(within(getByText("Nothing needs you right now.").closest("section")!).getByText(/Act now/)).toBeTruthy();
   });
 
   // #135: "Claude fixing" said an agent was busy but never what it was busy

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -16,7 +16,8 @@
 import type { ReactNode } from "react";
 import type { BoardCard, CardWorkingNow } from "../../lib/monitor/card-types.js";
 import type { ProductHealth, SolvencyPool } from "../../lib/monitor/product-health.js";
-import { decisionPriorityFor, rankDecisionCards } from "../../lib/monitor/decision-rank.js";
+import { decisionPriorityFor } from "../../lib/monitor/decision-rank.js";
+import { approvalBasisFor, triageForPhone } from "../../lib/monitor/phone-triage.js";
 import { describeWorkingNow } from "../../lib/monitor/working-now.js";
 import { opsBannerData } from "../ops/ops-frame.js";
 
@@ -41,7 +42,10 @@ export function MobileBoard({
   onApproveTask,
   onDismissCard,
 }: MobileBoardProps) {
-  const decisions = rankDecisionCards(cards, health);
+  // A phone is an ACTION surface, not a triage board: ops-blocking work and
+  // approvals that can explain themselves earn a slot; the rest is an honest
+  // count. Nothing is dropped — see phone-triage.ts.
+  const { actNow, delivery } = triageForPhone(cards, health);
   return (
     <div className="hm-mb" data-testid="mobile-board">
       <header className="hm-mb-top">
@@ -56,13 +60,14 @@ export function MobileBoard({
         {/* Add a card here to add a feature. Each returns null when empty. */}
         <MobileStatusCard health={health} nowMs={nowMs} />
         <MobileMoneyCard health={health} />
-        <MobileNeedsYouCard
-          decisions={decisions}
+        <MobileActNowCard
+          decisions={actNow}
           health={health}
           onCardClick={onCardClick}
           onApproveTask={onApproveTask}
           onDismissCard={onDismissCard}
         />
+        <MobileDeliveryLine delivery={delivery} onCardClick={onCardClick} />
         <MobileAgentsCard cards={cards} nowMs={nowMs} />
       </div>
 
@@ -178,14 +183,15 @@ function formatFloor(value: number): string {
 }
 
 /**
- * The decisions waiting on the operator. Uses `rankDecisionCards`, which owns
- * the shared `isDecision` filter and money-first order used by the desktop
- * inbox, so the phone cannot show a different backlog or priority order.
+ * ACT NOW — money-blocking work plus approvals that can state their basis.
  *
- * SAFETY: only approve/dismiss of already-proposed work is reachable here. The
- * phone never moves funds; a prepare-only task stays prepare-only.
+ * The shipped version listed every decision and put a green Approve button
+ * under a card whose only title was "codex task". The operator's words: "what
+ * should I approve here if I have no clue what it is". An approval you cannot
+ * identify is worse than one you were never shown, so the button is now GATED
+ * on the card being able to say what it will do.
  */
-export function MobileNeedsYouCard({
+export function MobileActNowCard({
   decisions,
   health,
   onCardClick,
@@ -200,15 +206,15 @@ export function MobileNeedsYouCard({
 }) {
   if (decisions.length === 0) {
     return (
-      <MobileCard label="Needs you">
-        <p className="hm-mb-empty">Nothing waiting on you.</p>
+      <MobileCard label="Act now">
+        <p className="hm-mb-empty">Nothing needs you right now.</p>
       </MobileCard>
     );
   }
   const shown = decisions.slice(0, DECISION_LIMIT);
   const rest = decisions.length - shown.length;
   return (
-    <MobileCard label={`Needs you · ${decisions.length}`}>
+    <MobileCard label={`Act now · ${decisions.length}`}>
       {shown.map((card) => (
         <DecisionRow
           key={card.id}
@@ -221,6 +227,35 @@ export function MobileNeedsYouCard({
       ))}
       {rest > 0 ? <p className="hm-mb-note">+{rest} more on the full board.</p> : null}
     </MobileCard>
+  );
+}
+
+/**
+ * Delivery work, as a number rather than a demand. Renders nothing when there
+ * is none. This is a COLLAPSE, not a hide: the count is real and the desktop
+ * board still lists every one of these cards unchanged.
+ */
+export function MobileDeliveryLine({
+  delivery,
+  onCardClick,
+}: {
+  delivery: BoardCard[];
+  onCardClick?: (id: string) => void;
+}) {
+  if (delivery.length === 0) return null;
+  const first = delivery[0]!;
+  return (
+    <button
+      type="button"
+      className="hm-mb-delivery"
+      onClick={onCardClick ? () => onCardClick(first.id) : undefined}
+      data-testid="mobile-delivery-line"
+    >
+      <span className="hm-mb-delivery-n">{delivery.length}</span>
+      <span className="hm-mb-delivery-t">
+        delivery item{delivery.length === 1 ? "" : "s"} waiting · review on the full board
+      </span>
+    </button>
   );
 }
 
@@ -237,25 +272,27 @@ function DecisionRow({
   onApproveTask?: (id: string) => void;
   onDismissCard?: (card: BoardCard) => void;
 }) {
-  const taskStatus = (card as { taskStatus?: string }).taskStatus;
-  const proposed = card.type === "task" && taskStatus === "proposed";
   const priority = decisionPriorityFor(card, health);
+  const basis = approvalBasisFor(card);
+  const proposed = card.type === "task" && (card as { taskStatus?: string }).taskStatus === "proposed";
+  // Approve requires a basis. Without one the row says so and sends you to the
+  // desktop rather than offering a decision you cannot make.
+  const approvable = proposed && basis !== undefined;
   return (
     <div className="hm-mb-item">
       <button type="button" className="hm-mb-item-open" onClick={onCardClick ? () => onCardClick(card.id) : undefined}>
-        <span className="hm-mb-item-title">{card.title}</span>
-        <span
-          className={`hm-mb-priority hm-mb-priority--${priority.tier}`}
-          data-decision-tier={priority.tier}
-        >
+        <span className="hm-mb-item-title">{basis?.what ?? card.title}</span>
+        <span className={`hm-mb-chip hm-mb-chip--${priority.tier === "money-blocking" ? "act" : "warn"}`}>
           {priority.reason}
         </span>
+        {basis?.why ? <span className="hm-mb-item-why">{basis.why}</span> : null}
         <span className="hm-mb-item-meta">
           {card.agentType}
           {card.repo ? ` · ${card.repo.split("/").pop()}` : ""}
+          {basis?.risk ? ` · ${basis.risk} risk` : ""}
         </span>
       </button>
-      {proposed ? (
+      {approvable ? (
         <div className="hm-mb-acts">
           <button
             type="button"
@@ -274,6 +311,8 @@ function DecisionRow({
             Dismiss
           </button>
         </div>
+      ) : proposed ? (
+        <p className="hm-mb-nobasis">Can&rsquo;t say what this does — review on the full board.</p>
       ) : null}
     </div>
   );

--- a/packages/monitor-ui/src/lib/monitor/phone-triage.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-triage.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "vitest";
+
+import type { BoardCard } from "./card-types.js";
+import type { ProductHealth } from "./product-health.js";
+import { approvalBasisFor, triageForPhone } from "./phone-triage.js";
+
+function decision(over: Record<string, unknown> = {}): BoardCard {
+  return {
+    id: "t1",
+    lane: "codex-needed",
+    type: "task",
+    agentType: "codex",
+    title: "codex task",
+    summary: "",
+    repo: "depre-dev/averray-reference-agent",
+    freshness: 5,
+    state: "fresh",
+    risk: [],
+    waitingOn: { actor: "operator", tone: "warn" },
+    taskStatus: "proposed",
+    ...over,
+  } as BoardCard;
+}
+
+const healthy: ProductHealth = {
+  enabled: true, at: 1, status: "healthy", checks: 7, network: "mainnet", chainId: 420420419,
+  probes: [{ name: "money_path", status: "ok", detail: "", sparkline: [] }],
+};
+
+describe("approvalBasisFor", () => {
+  // THE SHIPPED CARD: title "codex task", no prompt. It offered a green Approve
+  // button and the operator had no way to know what they were approving.
+  test("a card that only names its KIND cannot justify an approval", () => {
+    expect(approvalBasisFor(decision({ title: "codex task" }))).toBeUndefined();
+    expect(approvalBasisFor(decision({ title: "task" }))).toBeUndefined();
+    expect(approvalBasisFor(decision({ title: "   " }))).toBeUndefined();
+  });
+
+  test("the prompt carries the basis when the title is generic", () => {
+    const basis = approvalBasisFor(decision({ title: "codex task", prompt: "Rotate the hosted smoke token\nthen re-run the canary." }));
+    expect(basis?.what).toBe("Rotate the hosted smoke token");
+  });
+
+  test("a specific title is basis enough on its own", () => {
+    expect(approvalBasisFor(decision({ title: "Fix settlement rounding drift", prompt: "" }))?.what)
+      .toBe("Fix settlement rounding drift");
+  });
+
+  test("why + risk ride along when the card carries them", () => {
+    const basis = approvalBasisFor(decision({
+      prompt: "Re-run the payout probe",
+      reason: "money_path degraded for 20m",
+      riskTier: "high",
+    }));
+    expect(basis).toEqual({ what: "Re-run the payout probe", why: "money_path degraded for 20m", risk: "high" });
+  });
+
+  test("falls back to the decision record when there is no plain reason", () => {
+    const basis = approvalBasisFor(decision({
+      prompt: "Top up the reward bank",
+      decisionRecord: { reasons: ["reward bank 1.2 USDC below floor 2"], outcome: { summary: "queued" } },
+    }));
+    expect(basis?.why).toBe("reward bank 1.2 USDC below floor 2");
+  });
+
+  test("a long basis is clipped with an ellipsis, never silently truncated", () => {
+    const basis = approvalBasisFor(decision({ prompt: "x".repeat(200) }));
+    expect(basis!.what.endsWith("…")).toBe(true);
+    expect(basis!.what.length).toBeLessThanOrEqual(120);
+  });
+});
+
+describe("triageForPhone", () => {
+  test("REGRESSION: the shipped board — unexplained task on top, two routine verifications", () => {
+    const opaque = decision({ id: "opaque", title: "codex task" });
+    const v1 = decision({ id: "v1", type: "deploy", title: "post-production-deploy verification after workflow run", taskStatus: undefined });
+    const v2 = decision({ id: "v2", type: "deploy", title: "post-production-deploy verification after workflow dispatch", taskStatus: undefined });
+
+    const { actNow, delivery } = triageForPhone([opaque, v1, v2], healthy);
+    // Nothing on the phone demands a decision it cannot explain...
+    expect(actNow).toEqual([]);
+    // ...but all three are still accounted for.
+    expect(delivery.map((c) => c.id).sort()).toEqual(["opaque", "v1", "v2"]);
+  });
+
+  test("an explicable proposed task DOES earn the phone", () => {
+    const good = decision({ id: "good", prompt: "Rotate the hosted smoke token" });
+    const { actNow, delivery } = triageForPhone([good], healthy);
+    expect(actNow.map((c) => c.id)).toEqual(["good"]);
+    expect(delivery).toEqual([]);
+  });
+
+  test("money-blocking work reaches the phone even when it is not approvable", () => {
+    const money = decision({
+      id: "money", type: "pr", taskStatus: undefined, title: "PR",
+      files: [{ path: "services/settlement/submit.ts" }],
+    });
+    const { actNow } = triageForPhone([money], healthy);
+    expect(actNow.map((c) => c.id)).toEqual(["money"]);
+  });
+
+  test("money-blocking outranks an explicable task inside ACT NOW", () => {
+    const task = decision({ id: "task", prompt: "Rotate the smoke token" });
+    const money = decision({
+      id: "money", type: "pr", taskStatus: undefined, title: "PR",
+      files: [{ path: "contracts/EscrowCore.sol" }],
+    });
+    expect(triageForPhone([task, money], healthy).actNow.map((c) => c.id)).toEqual(["money", "task"]);
+  });
+
+  test("routine verification never reaches ACT NOW, even if it looks approvable", () => {
+    const routine = decision({ id: "r", title: "post-deploy verification", prompt: "verify the deploy" });
+    const { actNow, delivery } = triageForPhone([routine], healthy);
+    expect(actNow).toEqual([]);
+    expect(delivery.map((c) => c.id)).toEqual(["r"]);
+  });
+
+  test("TRUTH BOUNDARY: nothing is ever dropped — the split is exhaustive", () => {
+    const cards = [
+      decision({ id: "a", title: "codex task" }),
+      decision({ id: "b", prompt: "Do a real thing" }),
+      decision({ id: "c", type: "deploy", title: "post-deploy verification", taskStatus: undefined }),
+      decision({ id: "d", type: "pr", taskStatus: undefined, title: "PR", files: [{ path: "src/treasury.ts" }] }),
+    ];
+    const { actNow, delivery } = triageForPhone(cards, healthy);
+    expect(actNow.length + delivery.length).toBe(cards.length);
+    expect([...actNow, ...delivery].map((c) => c.id).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("no health payload still triages rather than throwing", () => {
+    const { actNow, delivery } = triageForPhone([decision({ id: "x", prompt: "Real work" })]);
+    expect(actNow.length + delivery.length).toBe(1);
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/phone-triage.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-triage.ts
@@ -1,0 +1,118 @@
+// What earns a slot on a phone.
+//
+// The desktop board is a triage surface: you have a diff, a drawer, and time,
+// so EVERY decision belongs there and `unknown` correctly outranks `standard`
+// (missing money evidence must never read as safe — decision-rank.ts).
+//
+// A phone is an ACTION surface. The operator is away from the desk and can only
+// usefully do a small number of things. Shipping the desktop ordering to the
+// phone put a card titled "codex task" at the top with a green Approve button
+// under it — top billing for the one card that explained itself least, and an
+// approval the operator had no basis to give. Approving what you cannot
+// identify is worse than not being asked.
+//
+// So the phone splits decisions two ways:
+//   ACT NOW  — money-blocking work, plus approvals that can state their basis;
+//   DELIVERY — everything else, as an honest count you can tap.
+//
+// Truth boundary: this REORDERS and COLLAPSES, it never drops. `actNow` and
+// `delivery` together always equal every `isDecision` card, the count is real,
+// and the desktop board is untouched. "Not on the phone" is not "hidden".
+
+import type { BoardCard } from "./card-types.js";
+import { decisionPriorityFor, rankDecisionCards } from "./decision-rank.js";
+import type { ProductHealth } from "./product-health.js";
+
+/** Longest basis line we put on a phone before the desktop takes over. */
+const BASIS_MAX = 120;
+
+export interface ApprovalBasis {
+  /** WHAT it will do — the operator-authored prompt/title, verbatim. */
+  what: string;
+  /** WHY Hermes proposed it, when the card carries a reason. */
+  why?: string;
+  /** Routing risk tier, when known. */
+  risk?: "high" | "low";
+}
+
+export interface PhoneTriage {
+  /** Money-blocking work + approvals that can justify themselves. */
+  actNow: BoardCard[];
+  /** Everything else — surfaced as a count, not as a demand. */
+  delivery: BoardCard[];
+}
+
+/**
+ * Can this card justify the approval it is asking for?
+ *
+ * Returns undefined when it cannot — and the UI must then withhold the Approve
+ * button rather than render one over a blank. Every field is read straight off
+ * the payload; nothing is summarised or inferred.
+ */
+export function approvalBasisFor(card: BoardCard | undefined): ApprovalBasis | undefined {
+  if (!card) return undefined;
+  // `??` is wrong here: an EMPTY prompt is not nullish, so it would swallow the
+  // title fallback. Take the first source that actually yields a line.
+  const what = firstLine((card as { prompt?: string }).prompt)
+    ?? (isSpecificTitle(card.title) ? firstLine(card.title) : undefined);
+  if (!what) return undefined;
+  const why = firstLine(
+    (card as { reason?: string }).reason
+      ?? card.decisionRecord?.reasons?.find((r) => typeof r === "string" && r.trim().length > 0)
+      ?? card.decisionRecord?.outcome?.summary,
+  );
+  const risk = (card as { riskTier?: "high" | "low" }).riskTier;
+  return { what, ...(why ? { why } : {}), ...(risk ? { risk } : {}) };
+}
+
+/**
+ * A title like "codex task" or "task" names the CARD KIND, not the work. It is
+ * the shape that produced the unapprovable card, so it does not count as a
+ * basis — the prompt has to carry it instead.
+ */
+function isSpecificTitle(title: string | undefined): boolean {
+  const t = (title ?? "").trim().toLowerCase();
+  if (!t) return false;
+  return !["codex task", "claude task", "task", "board card", "agent task"].includes(t);
+}
+
+function firstLine(value: string | undefined): string | undefined {
+  const line = (value ?? "")
+    .split("\n")
+    .map((l) => l.trim())
+    .find((l) => l.length > 0);
+  if (!line) return undefined;
+  return line.length > BASIS_MAX ? `${line.slice(0, BASIS_MAX - 1).trimEnd()}…` : line;
+}
+
+/**
+ * Split the operator's decisions into what deserves the phone and what is just
+ * a number on it. Input order is the shared money-first ranking, so ACT NOW is
+ * still money-first internally.
+ */
+export function triageForPhone(cards: BoardCard[], health?: ProductHealth): PhoneTriage {
+  const ranked = rankDecisionCards(cards, health);
+  const actNow: BoardCard[] = [];
+  const delivery: BoardCard[] = [];
+  for (const card of ranked) {
+    (belongsOnPhone(card, health) ? actNow : delivery).push(card);
+  }
+  return { actNow, delivery };
+}
+
+function belongsOnPhone(card: BoardCard, health?: ProductHealth): boolean {
+  const tier = decisionPriorityFor(card, health).tier;
+  // Routine verification is the definition of what does NOT need you at 17:42.
+  if (tier === "routine-verification") return false;
+  // Money is why you look at your phone.
+  if (tier === "money-blocking") return true;
+  // Otherwise it has to earn the slot by being actionable AND explicable: a
+  // proposed task you can identify. An unexplained card is exactly the one the
+  // phone should stop demanding a decision on.
+  return isProposedTask(card) && approvalBasisFor(card) !== undefined;
+}
+
+/** Only an already-proposed task is approvable; nothing else is phone-actionable. */
+export function isProposedTask(card: BoardCard): boolean {
+  return card.type === "task" && (card as { taskStatus?: string }).taskStatus === "proposed";
+}

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -218,3 +218,57 @@
 .hm-mb-agent-step.is-stale { color: var(--h4-tel); }
 .hm-mb-agent-step.is-empty { color: var(--h4-faint); font-style: italic; }
 .hm-mb-agent-age { color: var(--h4-faint); }
+
+/* ── act now / delivery (#141) ───────────────────────────────────────────── */
+/* The basis lines. `why` is the reason Hermes proposed it; without a `what`
+   there is no Approve button at all — see phone-triage.ts. */
+.hm-mb-item-why {
+  display: block;
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--h4-muted);
+  margin-top: 4px;
+  text-wrap: pretty;
+}
+.hm-mb-chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 5px;
+  margin-top: 5px;
+  border: 1px solid transparent;
+}
+.hm-mb-chip--act { color: var(--h4-act); border-color: var(--h4-act); }
+.hm-mb-chip--warn { color: var(--h4-warn); border-color: var(--h4-warn); }
+/* Honest dead-end: we cannot describe it, so we do not offer the decision. */
+.hm-mb-nobasis {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--h4-tel);
+  margin: 9px 0 0;
+  font-style: italic;
+}
+/* Delivery is a COUNT, not a demand — flat, quiet, tappable. */
+.hm-mb-delivery {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 1px dashed var(--h4-line-2);
+  border-radius: 12px;
+  padding: 11px 13px;
+  cursor: pointer;
+  font: inherit;
+}
+.hm-mb-delivery-n {
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--h4-ink-2);
+  flex: none;
+}
+.hm-mb-delivery-t { font-size: 11.5px; line-height: 1.4; color: var(--h4-faint); }


### PR DESCRIPTION
From your screenshot of the live board: "Needs you · 3" led with a card whose entire title was **"codex task"**, under a green Approve button — *"what should I approve here if I have no clue what it is"* — then two routine deploy verifications.

## Part of this was mine
#579 made `unknown` outrank `standard`. That's correct for the **desktop** triage board — missing money evidence must never read as safe. It's wrong on a **phone**: it promotes the least explicable card to the top and puts an Approve button under it. Unknown should mean *"not decidable here"*, not *"act on this first"*.

## The split
A phone is an action surface, so decisions now go two ways:

- **ACT NOW** — money-blocking work, plus approvals that can state their basis
- **Delivery · N** — everything else, as an honest tappable count

## Approve is gated on basis
A card must be able to say **what it will do** before the button renders — its `prompt`, or a title that names the *work* rather than the *card kind* (`"codex task"`, `"task"` don't count; that's exactly the shape that produced the unapprovable card). Without it the row reads *"Can't say what this does — review on the full board"*.

Where a basis exists the row also carries **why** Hermes proposed it (`reason` / `decisionRecord.reasons`) and the **risk tier** — so the decision has grounds rather than a name.

Routine verifications never reach ACT NOW.

## Truth boundary
This **reorders and collapses; it never drops.** A test asserts `actNow + delivery` equals every `isDecision` card, the count is real, and the **desktop board is untouched**. "Not on the phone" is not "hidden" — it's about what earns a slot on a 6-inch screen at 17:42.

## Verification
- `packages/monitor-ui`: **865 → 880**, zero failures. Includes a regression test reproducing your exact screenshot (opaque card → no Approve) and the exhaustiveness assertion.
- `tsc`: unchanged at the pre-existing 3. `vite build` green.

Logic lives in one pure module (`phone-triage.ts`) so the rules are testable without a browser, and it reuses `decisionPriorityFor` from #579 rather than forking the tiering.