### PR TITLE
fix(int2): authenticate CI and pin scripted execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
           node-version: 22
           cache: npm
 
+      - name: Install zsh syntax-check shell
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends zsh
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         run: scripts/ceremony/run-int2-automated-suite.sh
 
       - name: Prove the suite did not skip
+        if: always()
         run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "9"
 
       - name: Upload INT-2 evidence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
 
       - name: Run required INT-2 mechanism suite
         env:
+          INT2_HARNESS_DEPLOY_KEY: ${{ secrets.INT2_HARNESS_DEPLOY_KEY }}
           INT2_SUITE_EVIDENCE_DIR: ${{ runner.temp }}/int2-suite-evidence
         run: scripts/ceremony/run-int2-automated-suite.sh
 

--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -12,6 +12,176 @@ pending
 **Runtime authority change:** none; this adds evidence, operator scripts, tests,
 and CI wiring without changing dispatcher or kernel runtime code
 
+## Re-gate amendment — CI checkout and cross-machine determinism
+
+**Fix baseline:** `734a520`
+
+**Required GitHub Actions secret:** `INT2_HARNESS_DEPLOY_KEY`, containing the
+private half of a read-only deploy key registered on the private pinned Harness
+repository.
+
+The main-branch failure and the independent-review run-completion split had
+separate causes:
+
+1. The runner cloned the private Harness over unauthenticated HTTPS. A developer
+   checkout or credential helper hid that dependency locally, while a GitHub
+   runner failed with Git exit 128 before creating the evidence directory.
+2. The suite passed the staged script only through
+   `HARNESS_TEST_MODEL_SCRIPT`, but the pinned Harness resolves executor-role
+   and adapter-specific script variables first. The worker inherited the entire
+   operator environment, so an existing higher-precedence script or live-model
+   configuration could shadow the staged JSONL. This explains the review
+   machine's apparently contradictory results: terminal cases followed
+   uncontrolled model behavior, while the HALT case reached
+   `learning_processed` without ever dispatching its intended `sleep 30`.
+
+The amendment:
+
+- creates `bootstrap.log` before attempting the private checkout and records the
+  final suite exit code, so the always-uploaded artifact is non-empty even when
+  checkout fails;
+- uses the read-only deploy key through strict SSH with GitHub's pinned
+  published Ed25519 host key, `IdentitiesOnly`, `BatchMode`, and
+  `StrictHostKeyChecking`; the secret is unset before Git or any later child
+  process is started;
+- exits 20 with the named
+  `INT2_HARNESS_DEPLOY_KEY_MISSING` error when CI has neither an existing
+  checkout nor the key, and exits with a separate named checkout error when
+  authenticated cloning fails;
+- preserves developer behavior: an explicitly supplied clean
+  `HARNESS_CHECKOUT` is reused, otherwise local Git credentials may supply the
+  HTTPS checkout outside CI;
+- constructs a controlled worker environment that removes inherited model
+  credentials, model selection, scripted-model precedence variables, and
+  factory counters, then sets all four applicable executor/adapter script
+  precedence levels to the one staged JSONL and pins the model identity to
+  `openai-compatible/int2-scripted-model`;
+- waits for the exact `CapabilityProposed` →
+  matching-`args_hash` `CapabilityDispatched` chain for `sleep 30`, instead of
+  treating the broad `executing` state as proof;
+- verifies the exact command chain for every scripted run. Ordinary fixture
+  commands must have a broker-successful completion and exit 0. HALT must record
+  at least 29 seconds and the expected `command_timeout`;
+- emits a diagnostic JSON bundle on either timeout or an unexpected terminal
+  lifecycle, including Harness state/outcome, selected events, worker output,
+  and dispatcher logs;
+- parses every operator script with both `bash -n` and `zsh -n`.
+
+No acceptance criterion, case count, evidence invariant, fixture mutation,
+dispatcher production path, kernel source, Harness pin, dependency, or lockfile
+was changed.
+
+The definitive HALT record from the re-gate contains:
+
+```json
+{
+  "command": "sleep 30",
+  "duration_seconds": 30.058548083063215,
+  "outcome": {
+    "ok": false,
+    "error": {
+      "code": "command_timeout"
+    }
+  }
+}
+```
+
+That is the expected bounded-shell result: the command ran for the full bound
+and timed out. It is not reported as a successful command exit, and a
+fast/no-op execution fails `scripted_tool_duration`.
+
+### Re-gate output
+
+```text
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  199 passed | 2 skipped (201)
+Tests       2532 passed | 13 skipped (2545)
+Duration    10.96s
+# exit 0
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+
+$ HARNESS_CHECKOUT=/Users/pascalkuriger/repo/agent-harness \
+    INT2_SUITE_EVIDENCE_DIR=/private/tmp/int2-suite-evidence-ci-repro-fix-5 \
+    scripts/ceremony/run-int2-automated-suite.sh
+✓ preflights the controlled red/green pair against a real tracked diff
+✓ keeps an unapproved task outside the production dispatchable set
+✓ refuses an approval-hash mismatch before claim or submit
+✓ rejects the negative fixture on its merits with no handoff
+✓ produces one verified, unactuated green handoff
+✓ restarts between submit and reconcile without duplicating the run
+✓ HALT cancels a bound live run and never creates a handoff
+✓ accepts a seven-capability profile with strictly narrower authority
+✓ rejects memory.propose in the outer production profile loader
+Test Files  1 passed (1)
+Tests       9 passed (9)
+Duration    138.10s
+INT-2 automated suite: 9 cases executed in 145s
+# exit 0
+
+$ env -u HARNESS_CHECKOUT -u INT2_HARNESS_DEPLOY_KEY \
+    CI=true \
+    INT2_SUITE_EVIDENCE_DIR=/private/tmp/int2-missing-key-evidence-fix \
+    scripts/ceremony/run-int2-automated-suite.sh
+INT2_HARNESS_DEPLOY_KEY_MISSING: CI requires the read-only private Harness deploy key
+# exit 20
+
+$ cat /private/tmp/int2-missing-key-evidence-fix/bootstrap.log
+INT2_SUITE_BOOTSTRAP_STARTED pin=0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2
+INT2_HARNESS_DEPLOY_KEY_MISSING: CI requires the read-only private Harness deploy key
+INT2_SUITE_EXIT_CODE=20
+```
+
+The full suite output above is the implementation-worktree gate. A second
+clean-checkout run is recorded below before handback.
+
+### Diagnostic observation kept separate from the fix
+
+During diagnosis, repeated runs on the local Colima host also exposed an
+intermittent provider-mount symptom: a scripted file write completed, but a
+later `git diff --check` sometimes saw no `.git` and exited 129. The pin is
+already the PKT-040 self-contained-workspace merge; no pin advance or acceptance
+relaxation can honestly address it. An instrumented run observed the
+self-contained `.git` directory from both host and live container during the
+tool call and then completed green, while the finalized uninstrumented suite
+also completed 9/9. The new failure diagnostics retain the natural event
+evidence if this host-specific symptom recurs. It is not conflated with the
+review machine's 180-second `running` timeouts, which the model-environment
+precedence fix addresses.
+
+### Re-gate decisions
+
+1. **Raw read-only deploy key, not a token or job skip.** This grants the one
+   private repository read needed by the mandatory job and leaves the
+   fail-required semantics intact.
+2. **Pin GitHub's published host key.** An unauthenticated `ssh-keyscan` during
+   the gate would merely move the trust problem.
+3. **Close only the worker's model environment.** Database, profile, artifact,
+   Docker, and dispatcher settings remain inherited as before; only sources
+   capable of changing which model/script executes are stripped.
+4. **Treat shell exit separately from broker completion.** A `shell.run`
+   capability can be broker-successful while its command exits nonzero. The
+   evidence now asserts exit 0 for ordinary fixture commands and the exact
+   bounded timeout for HALT.
+5. **Preserve the 180-second lifecycle ceiling.** The review failure was not
+   solved by making a structural misconfiguration wait longer.
+
+### Re-gate open questions
+
+- Pascal must provision `INT2_HARNESS_DEPLOY_KEY` before the GitHub-hosted job
+  can pass. Absence is intentionally red and produces a named evidence
+  artifact.
+- The intermittent local Docker mount observation above is outside this
+  repository's runtime surface. If it reproduces on an otherwise controlled
+  clean gate, it should become a separate kernel/provider finding rather than a
+  retry or weakened criterion here.
+
 ## Built
 
 - Added a fail-required INT-2 integration suite that drives the real production

--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -1,7 +1,8 @@
 # INT-2 handback — automated supervised-dispatch suite
 
-**Status:** implementation and clean-checkout gates complete; independent review
-pending
+**Status:** CI/authentication and model-environment fixes implemented; clean
+fast gates green; clean Docker re-gate exposed the separately flagged
+intermittent provider-mount failure below
 
 **Baseline:** `47de9f3bdb25eda7354297a951b9927368194791`
 
@@ -138,8 +139,63 @@ INT2_HARNESS_DEPLOY_KEY_MISSING: CI requires the read-only private Harness deplo
 INT2_SUITE_EXIT_CODE=20
 ```
 
-The full suite output above is the implementation-worktree gate. A second
-clean-checkout run is recorded below before handback.
+The full suite output above is the implementation-worktree gate.
+
+### Detached clean-checkout result
+
+The second gate ran at commit `8d4df94` from
+`/private/tmp/int2-ci-fix-clean.dHm8Mp/checkout`.
+
+```text
+$ git status --porcelain
+# no output
+
+$ npm ci
+added 312 packages in 3s
+# exit 0
+
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  199 passed | 2 skipped (201)
+Tests       2532 passed | 13 skipped (2545)
+Duration    15.39s
+# exit 0
+
+$ HARNESS_CHECKOUT=/Users/pascalkuriger/repo/agent-harness \
+    INT2_SUITE_EVIDENCE_DIR=/private/tmp/int2-suite-evidence-clean-8d4df94 \
+    scripts/ceremony/run-int2-automated-suite.sh
+✓ controlled pair
+✓ unapproved
+✓ approval-hash mismatch
+× negative: expected exit_2, got exit_129
+✓ green
+× restart: terminal failed; VerificationCompleted exit_129
+✓ HALT
+✓ narrower profile
+✓ unvetted profile
+Test Files  1 failed (1)
+Tests       2 failed | 7 passed (9)
+Duration    145.21s
+# exit 1
+```
+
+Both failures have the same natural Harness evidence:
+
+```text
+warning: Not a git repository. Use --no-index to compare two paths outside a working tree
+```
+
+The scripted commands were selected deterministically and ran; the later
+unchanged `git diff --check` criterion could not see `.git`. This is the
+intermittent mount observation below reproduced from a detached clean checkout,
+so this handback does **not** label all gates green and does not tune around it.
 
 ### Diagnostic observation kept separate from the fix
 

--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -41,6 +41,9 @@ The amendment:
 - creates `bootstrap.log` before attempting the private checkout and records the
   final suite exit code, so the always-uploaded artifact is non-empty even when
   checkout fails;
+- runs the separate nine-case non-skip assertion under `if: always()`, so an
+  absent credential cannot bypass the assertion merely by failing an earlier
+  step;
 - uses the read-only deploy key through strict SSH with GitHub's pinned
   published Ed25519 host key, `IdentitiesOnly`, `BatchMode`, and
   `StrictHostKeyChecking`; the secret is unset before Git or any later child

--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -66,7 +66,9 @@ The amendment:
 - emits a diagnostic JSON bundle on either timeout or an unexpected terminal
   lifecycle, including Harness state/outcome, selected events, worker output,
   and dispatcher logs;
-- parses every operator script with both `bash -n` and `zsh -n`.
+- installs `zsh` explicitly in the Ubuntu fast-test job and parses every
+  operator script with both `bash -n` and `zsh -n`. The test is never skipped
+  merely because the runner image omitted the operator shell.
 
 No acceptance criterion, case count, evidence invariant, fixture mutation,
 dispatcher production path, kernel source, Harness pin, dependency, or lockfile

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -42,6 +42,11 @@ export const INT2_CAPABILITY_BOUNDARY = Object.freeze({
 
 const DISPATCH_WORKSPACE_ROOT =
   "/var/lib/harness-dispatcher/workspaces";
+const GREEN_TOOL_COMMAND =
+  "printf '%b' '\\nINT-2 green-path proof line, cleanly formatted.\\n' >> docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
+const NEGATIVE_TOOL_COMMAND =
+  "printf '%b' '\\nINT-2 negative-path proof line with trailing whitespace.   \\n' >> docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
+const HALT_TOOL_COMMAND = "sleep 30";
 const CASE_EXPECTATIONS = Object.freeze({
   green: Object.freeze({
     lifecycle: "handoff_ready",
@@ -63,6 +68,7 @@ const CASE_EXPECTATIONS = Object.freeze({
     requirePatch: true,
     requireManifest: true,
     requireFence: true,
+    expectedToolCommand: GREEN_TOOL_COMMAND,
   }),
   negative: Object.freeze({
     lifecycle: "failed",
@@ -84,6 +90,7 @@ const CASE_EXPECTATIONS = Object.freeze({
     requirePatch: true,
     requireManifest: true,
     requireFence: true,
+    expectedToolCommand: NEGATIVE_TOOL_COMMAND,
   }),
   restart: Object.freeze({
     lifecycle: "handoff_ready",
@@ -105,6 +112,7 @@ const CASE_EXPECTATIONS = Object.freeze({
     requirePatch: true,
     requireManifest: true,
     requireFence: true,
+    expectedToolCommand: GREEN_TOOL_COMMAND,
   }),
   halt: Object.freeze({
     lifecycle: "cancelled",
@@ -123,6 +131,9 @@ const CASE_EXPECTATIONS = Object.freeze({
     requireFence: true,
     decisionReason: "halt_active_run_cancelled",
     expectedAuthorityReducingCancellation: true,
+    expectedToolCommand: HALT_TOOL_COMMAND,
+    expectedToolError: "command_timeout",
+    minimumToolDurationSeconds: 29,
   }),
   "hash-mismatch": Object.freeze({
     lifecycle: "blocked",
@@ -179,6 +190,7 @@ const CASE_EXPECTATIONS = Object.freeze({
         (capability) => capability !== "fs.write_file",
       ),
     ),
+    expectedToolCommand: GREEN_TOOL_COMMAND,
   }),
   unapproved: Object.freeze({
     lifecycle: "proposed",
@@ -772,6 +784,80 @@ export function verifyInt2Evidence(
         && verification.requiredFailed.includes("format-command"),
         "required_failed_names_format",
         `required_failed=${JSON.stringify(verification?.requiredFailed)}`,
+      );
+    }
+  }
+
+  if (expectations.expectedToolCommand) {
+    const proposed = evidence?.events?.find(
+      (event) =>
+        event?.type === "CapabilityProposed"
+        && event?.payload?.capability_id === "shell.run"
+        && event?.payload?.arguments?.command
+          === expectations.expectedToolCommand,
+    );
+    const dispatched = proposed
+      ? evidence?.events?.find(
+          (event) =>
+            event?.type === "CapabilityDispatched"
+            && event?.payload?.capability_id === "shell.run"
+            && event?.payload?.args_hash === proposed.payload?.args_hash,
+        )
+      : undefined;
+    const completed = dispatched
+      ? evidence?.events?.find(
+          (event) =>
+            event?.type === "CapabilityCompleted"
+            && event?.payload?.capability_id === "shell.run"
+            && event?.payload?.invocation_id
+              === dispatched.payload?.invocation_id,
+        )
+      : undefined;
+    check(
+      proposed !== undefined,
+      "scripted_tool_proposed",
+      `the exact ${JSON.stringify(expectations.expectedToolCommand)} command was not proposed`,
+    );
+    check(
+      dispatched !== undefined,
+      "scripted_tool_dispatched",
+      "the exact scripted shell command was not dispatched",
+    );
+    check(
+      completed !== undefined,
+      "scripted_tool_completed",
+      "the exact scripted shell command has no completion evidence",
+    );
+    if (expectations.minimumToolDurationSeconds !== undefined) {
+      check(
+        completed?.payload?.outcome?.duration_seconds
+          >= expectations.minimumToolDurationSeconds,
+        "scripted_tool_duration",
+        `expected at least ${expectations.minimumToolDurationSeconds}s, got ${
+          completed?.payload?.outcome?.duration_seconds ?? "missing"
+        }`,
+      );
+      check(
+        completed?.payload?.outcome?.error?.code
+          === expectations.expectedToolError,
+        "scripted_tool_terminal_error",
+        `expected ${expectations.expectedToolError}, got ${
+          completed?.payload?.outcome?.error?.code ?? "missing"
+        }`,
+      );
+    } else {
+      check(
+        completed?.payload?.outcome?.ok === true,
+        "scripted_tool_succeeded",
+        "the exact scripted shell command did not complete successfully",
+      );
+      check(
+        completed?.payload?.outcome?.output_inline?.exit_code === 0
+          && completed?.payload?.action?.exit_code === 0,
+        "scripted_tool_exit_zero",
+        `expected the exact scripted shell command to exit 0, got ${
+          completed?.payload?.outcome?.output_inline?.exit_code ?? "missing"
+        }`,
       );
     }
   }

--- a/scripts/ceremony/int2-worker-environment.mjs
+++ b/scripts/ceremony/int2-worker-environment.mjs
@@ -1,0 +1,51 @@
+const MODEL_ENVIRONMENT_KEYS = new Set([
+  "ANTHROPIC_API_KEY",
+  "GEMINI_API_KEY",
+  "HARNESS_BASELINE_MODEL",
+  "HARNESS_GEMINI_API_KEY",
+  "HARNESS_MODEL_ADAPTER",
+  "HARNESS_MODEL_API_KEY",
+  "HARNESS_MODEL_BASE_URL",
+  "HARNESS_MODEL_REF",
+  "HARNESS_OPENAI_API_KEY",
+  "OLLAMA_API_KEY",
+  "OLLAMA_BASE_URL",
+  "OPENAI_API_KEY",
+]);
+
+const SCRIPT_OVERRIDE =
+  /^HARNESS_TEST_(?:(?:CHILD|EXECUTOR|JUDGE|PLANNER)_)?MODEL_(?:FACTORY_COUNTER|SCRIPT)(?:_[A-Z0-9_]+)?$/u;
+
+export function createInt2WorkerEnvironment(
+  environment,
+  {
+    databaseUrl,
+    profilesRoot,
+    modelScriptPath,
+    artifactRoot,
+  },
+) {
+  const controlled = { ...environment };
+  for (const key of Object.keys(controlled)) {
+    if (MODEL_ENVIRONMENT_KEYS.has(key) || SCRIPT_OVERRIDE.test(key)) {
+      delete controlled[key];
+    }
+  }
+
+  return {
+    ...controlled,
+    HARNESS_APP_VERSION: "pkt-003",
+    HARNESS_ARTIFACT_ROOT: artifactRoot,
+    HARNESS_DATABASE_URL: databaseUrl,
+    HARNESS_MODEL_ADAPTER: "openai-compatible",
+    HARNESS_MODEL_BASE_URL: "http://127.0.0.1",
+    HARNESS_MODEL_REF: "int2-scripted-model",
+    HARNESS_PROFILES_ROOT: profilesRoot,
+    // Set every precedence level used by the pinned Harness to the same script.
+    // A sourced operator environment therefore cannot shadow the test fixture.
+    HARNESS_TEST_EXECUTOR_MODEL_SCRIPT_OPENAI_COMPATIBLE: modelScriptPath,
+    HARNESS_TEST_EXECUTOR_MODEL_SCRIPT: modelScriptPath,
+    HARNESS_TEST_MODEL_SCRIPT_OPENAI_COMPATIBLE: modelScriptPath,
+    HARNESS_TEST_MODEL_SCRIPT: modelScriptPath,
+  };
+}

--- a/scripts/ceremony/lib/int2-harness-checkout.sh
+++ b/scripts/ceremony/lib/int2-harness-checkout.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# Checkout the private pinned Harness without leaking its read-only deploy key
+# to the worker or later test processes. The caller remains responsible for
+# verifying the checkout's cleanliness and exact revision.
+int2_checkout_harness() {
+  if [ "$#" -ne 3 ]; then
+    echo "INT2_HARNESS_CHECKOUT_ARGUMENTS_INVALID: expected checkout, pin, and evidence log" >&2
+    return 2
+  fi
+
+  _int2_checkout_target="$1"
+  _int2_checkout_pin="$2"
+  _int2_checkout_log="$3"
+  _int2_checkout_key="${INT2_HARNESS_DEPLOY_KEY:-}"
+
+  if [ -d "$_int2_checkout_target/.git" ]; then
+    unset INT2_HARNESS_DEPLOY_KEY
+    printf '%s\n' \
+      "INT2_HARNESS_CHECKOUT_REUSED target=$_int2_checkout_target pin=$_int2_checkout_pin" \
+      >> "$_int2_checkout_log"
+    return 0
+  fi
+
+  if [ "${CI:-}" = "true" ] && [ -z "$_int2_checkout_key" ]; then
+    unset INT2_HARNESS_DEPLOY_KEY
+    echo "INT2_HARNESS_DEPLOY_KEY_MISSING: CI requires the read-only private Harness deploy key" \
+      | tee -a "$_int2_checkout_log" >&2
+    return 20
+  fi
+
+  if [ -n "$_int2_checkout_key" ]; then
+    _int2_checkout_ssh_root="$(dirname "$_int2_checkout_target")/harness-ssh"
+    _int2_checkout_key_path="$_int2_checkout_ssh_root/deploy-key"
+    _int2_checkout_known_hosts="$_int2_checkout_ssh_root/known-hosts"
+    mkdir -p "$_int2_checkout_ssh_root"
+    printf '%s\n' "$_int2_checkout_key" > "$_int2_checkout_key_path"
+    # GitHub's published Ed25519 host key. Strict verification avoids trusting
+    # an unauthenticated ssh-keyscan result in the mechanism gate.
+    printf '%s\n' \
+      "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl" \
+      > "$_int2_checkout_known_hosts"
+    chmod 600 "$_int2_checkout_key_path" "$_int2_checkout_known_hosts"
+    _int2_checkout_key=""
+    unset INT2_HARNESS_DEPLOY_KEY
+    _int2_checkout_ssh_command="ssh -i $_int2_checkout_key_path -o IdentitiesOnly=yes -o BatchMode=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=$_int2_checkout_known_hosts"
+    if ! GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="$_int2_checkout_ssh_command" \
+      git clone --quiet git@github.com:averray-agent/agent-harness.git \
+        "$_int2_checkout_target" 2>> "$_int2_checkout_log"; then
+      echo "INT2_HARNESS_CHECKOUT_FAILED: authenticated SSH clone of the private pinned Harness failed" \
+        | tee -a "$_int2_checkout_log" >&2
+      return 21
+    fi
+    printf '%s\n' \
+      "INT2_HARNESS_CHECKOUT_AUTHENTICATED method=read-only-deploy-key pin=$_int2_checkout_pin" \
+      >> "$_int2_checkout_log"
+    return 0
+  fi
+
+  unset INT2_HARNESS_DEPLOY_KEY
+  if ! GIT_TERMINAL_PROMPT=0 \
+    git clone --quiet https://github.com/averray-agent/agent-harness.git \
+      "$_int2_checkout_target" 2>> "$_int2_checkout_log"; then
+    echo "INT2_HARNESS_CHECKOUT_FAILED: private Harness checkout unavailable; set HARNESS_CHECKOUT or INT2_HARNESS_DEPLOY_KEY" \
+      | tee -a "$_int2_checkout_log" >&2
+    return 22
+  fi
+  printf '%s\n' \
+    "INT2_HARNESS_CHECKOUT_AUTHENTICATED method=developer-git-credentials pin=$_int2_checkout_pin" \
+    >> "$_int2_checkout_log"
+}

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -10,9 +10,13 @@ _int2_harness_db="int2-suite-harness-${_int2_suffix}"
 _int2_reference_db="int2-suite-reference-${_int2_suffix}"
 _int2_evidence="${INT2_SUITE_EVIDENCE_DIR:-$_int2_root/evidence}"
 _int2_marker="$_int2_evidence/executed-count.txt"
+_int2_bootstrap_log="$_int2_evidence/bootstrap.log"
 _int2_started="$(date +%s)"
 
 _int2_cleanup() {
+  _int2_exit="$?"
+  printf '%s\n' "INT2_SUITE_EXIT_CODE=$_int2_exit" \
+    >> "$_int2_bootstrap_log" 2>/dev/null || true
   docker stop "$_int2_harness_db" "$_int2_reference_db" \
     >/dev/null 2>&1 || true
   rm -rf "$_int2_root"
@@ -24,6 +28,36 @@ for _int2_command in docker git node npm uv; do
     || { echo "INT-2 suite requires $_int2_command" >&2; exit 2; }
 done
 mkdir -p "$_int2_evidence"
+printf '%s\n' \
+  "INT2_SUITE_BOOTSTRAP_STARTED pin=0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2" \
+  > "$_int2_bootstrap_log"
+
+export HARNESS_CHECKOUT="${HARNESS_CHECKOUT:-$_int2_root/agent-harness}"
+_int2_pin="0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
+# shellcheck source=scripts/ceremony/lib/int2-harness-checkout.sh
+source "$_int2_repo/scripts/ceremony/lib/int2-harness-checkout.sh"
+int2_checkout_harness "$HARNESS_CHECKOUT" "$_int2_pin" "$_int2_bootstrap_log"
+test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)" \
+  || {
+    echo "INT2_HARNESS_CHECKOUT_DIRTY: the private Harness checkout is not clean" \
+      | tee -a "$_int2_bootstrap_log" >&2
+    exit 23
+  }
+git -C "$HARNESS_CHECKOUT" checkout --quiet --detach "$_int2_pin" \
+  2>> "$_int2_bootstrap_log" \
+  || {
+    echo "INT2_HARNESS_PIN_UNAVAILABLE: checkout does not contain the required pinned revision" \
+      | tee -a "$_int2_bootstrap_log" >&2
+    exit 24
+  }
+test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = "$_int2_pin" \
+  || {
+    echo "INT2_HARNESS_PIN_MISMATCH: checkout did not resolve to the required revision" \
+      | tee -a "$_int2_bootstrap_log" >&2
+    exit 25
+  }
+printf '%s\n' "INT2_HARNESS_PIN_VERIFIED pin=$_int2_pin" \
+  >> "$_int2_bootstrap_log"
 
 docker run --rm --detach --name "$_int2_harness_db" \
   --publish 127.0.0.1::5432 \
@@ -60,15 +94,6 @@ _int2_reference_port="$(
 export HARNESS_TEST_DATABASE_URL="postgresql://postgres:int2-suite@127.0.0.1:${_int2_harness_port}/harness_suite"
 export DISPATCH_TEST_DATABASE_URL="postgresql://postgres:int2-suite@127.0.0.1:${_int2_reference_port}/reference_suite"
 
-export HARNESS_CHECKOUT="${HARNESS_CHECKOUT:-$_int2_root/agent-harness}"
-_int2_pin="0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
-if [ ! -d "$HARNESS_CHECKOUT/.git" ]; then
-  git clone --quiet https://github.com/averray-agent/agent-harness.git \
-    "$HARNESS_CHECKOUT"
-fi
-test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)"
-git -C "$HARNESS_CHECKOUT" checkout --quiet --detach "$_int2_pin"
-test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = "$_int2_pin"
 (
   cd "$HARNESS_CHECKOUT"
   uv sync --frozen
@@ -77,6 +102,7 @@ test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = "$_int2_pin"
 )
 export HARNESS_BIN="$HARNESS_CHECKOUT/.venv/bin/harness"
 "$HARNESS_BIN" --help >/dev/null
+printf '%s\n' "INT2_HARNESS_RUNTIME_READY" >> "$_int2_bootstrap_log"
 
 for _int2_migration in "$_int2_repo"/ops/migrations/*.sql; do
   docker exec -i "$_int2_reference_db" \
@@ -96,6 +122,7 @@ export INT2_REPOSITORY_ROOT="$_int2_repo"
 export INT2_SUITE_EVIDENCE_DIR="$_int2_evidence"
 export INT2_SUITE_EXECUTION_MARKER="$_int2_marker"
 
+printf '%s\n' "INT2_CASES_STARTED expected=9" >> "$_int2_bootstrap_log"
 (
   cd "$_int2_repo"
   npm run build
@@ -111,4 +138,6 @@ test "$_int2_executed" = "9" \
   }
 _int2_elapsed="$(( $(date +%s) - _int2_started ))"
 printf '%s\n' "$_int2_elapsed" > "$_int2_evidence/wall-time-seconds.txt"
+printf '%s\n' "INT2_CASES_COMPLETED executed=$_int2_executed elapsed=$_int2_elapsed" \
+  >> "$_int2_bootstrap_log"
 echo "INT-2 automated suite: $_int2_executed cases executed in ${_int2_elapsed}s"

--- a/test/integration/int2-automated-suite.test.ts
+++ b/test/integration/int2-automated-suite.test.ts
@@ -36,6 +36,9 @@ import {
   verifyScriptedPairPreflight,
 } from "../../scripts/ceremony/int2-evidence.mjs";
 import {
+  createInt2WorkerEnvironment,
+} from "../../scripts/ceremony/int2-worker-environment.mjs";
+import {
   createProductionDispatcher,
   type DispatcherLogger,
   type DispatcherProcess,
@@ -73,6 +76,8 @@ const FIXTURE_ROOT = path.join(
 const EXPECTED_CASE_COUNT = 9;
 const TEST_TIMEOUT_MS = 240_000;
 const TERMINAL_WAIT_MS = 180_000;
+const HARNESS_STATE_WAIT_MS = 90_000;
+const HALT_COMMAND = "sleep 30";
 const SENTINEL_RUN_ID = "00000000-0000-4000-8000-000000000000";
 
 describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
@@ -325,7 +330,13 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     expect(replay.stdout.trim()).toBe(approval.intendedRunId);
 
     const restarted = createDispatcher();
-    await waitForLifecycle(restarted, workItemId, "handoff_ready");
+    await waitForLifecycle(
+      restarted,
+      workItemId,
+      "handoff_ready",
+      approval.intendedRunId,
+      worker,
+    );
     await restarted.shutdown();
     await stopWorker(worker);
 
@@ -358,7 +369,10 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
         outcome: "dispatched",
         intendedRunId: approval.intendedRunId,
       });
-      await waitForHarnessState(approval.intendedRunId, "executing");
+      await waitForHarnessToolDispatch(
+        approval.intendedRunId,
+        HALT_COMMAND,
+      );
       await writeFile(haltFile, "INT-2 automated HALT drill\n", "utf8");
       await expect(dispatcher.tick()).resolves.toMatchObject({ outcome: "halted" });
       await waitForHarnessState(approval.intendedRunId, "cancelled");
@@ -493,7 +507,13 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     const worker = await startWorker();
     const dispatcher = createDispatcher();
     try {
-      await waitForLifecycle(dispatcher, workItemId, lifecycle);
+      await waitForLifecycle(
+        dispatcher,
+        workItemId,
+        lifecycle,
+        approval.intendedRunId,
+        worker,
+      );
     } finally {
       await dispatcher.shutdown();
       await stopWorker(worker);
@@ -618,6 +638,8 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     dispatcher: DispatcherProcess,
     workItemId: string,
     expected: string,
+    intendedRunId: string,
+    worker: HarnessWorker,
   ): Promise<void> {
     const deadline = Date.now() + TERMINAL_WAIT_MS;
     let lastLifecycle = "<missing>";
@@ -635,16 +657,33 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
       if (["blocked", "cancelled", "failed", "handoff_ready"].includes(
         lastLifecycle,
       )) {
+        const diagnostics = await writeLifecycleDiagnostics({
+          workItemId,
+          intendedRunId,
+          expectedLifecycle: expected,
+          lastLifecycle,
+          worker,
+        });
         throw new Error(
           `${workItemId} reached unexpected terminal lifecycle `
-            + `${lastLifecycle}; expected ${expected}`,
+            + `${lastLifecycle}; expected ${expected}; harness=${
+              diagnostics.harnessRun?.state ?? "<missing>"
+            }; diagnostics=${diagnostics.path}`,
         );
       }
       await delay(500);
     }
+    const diagnostics = await writeLifecycleDiagnostics({
+      workItemId,
+      intendedRunId,
+      expectedLifecycle: expected,
+      lastLifecycle,
+      worker,
+    });
     throw new Error(
       `Timed out waiting for ${workItemId} lifecycle ${expected}; `
-        + `last=${lastLifecycle}`,
+        + `last=${lastLifecycle}; harness=${diagnostics.harnessRun?.state
+          ?? "<missing>"}; diagnostics=${diagnostics.path}`,
     );
   }
 
@@ -694,7 +733,7 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
           tool_calls: [{
             id: "int2-halt-sleep",
             name: "shell_run",
-            arguments: { command: "sleep 30" },
+            arguments: { command: HALT_COMMAND },
           }],
           usage: { input_tokens: 2, output_tokens: 1, requests: 1 },
           finish_reason: "tool_call",
@@ -714,12 +753,12 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     const output: string[] = [];
     const child = spawn(process.env.HARNESS_BIN!, ["worker"], {
       cwd: process.env.HARNESS_CHECKOUT,
-      env: {
-        ...process.env,
-        HARNESS_DATABASE_URL: process.env.HARNESS_TEST_DATABASE_URL,
-        HARNESS_PROFILES_ROOT: profilesRoot,
-        HARNESS_TEST_MODEL_SCRIPT: modelScriptPath,
-      },
+      env: createInt2WorkerEnvironment(process.env, {
+        databaseUrl: process.env.HARNESS_TEST_DATABASE_URL!,
+        profilesRoot,
+        modelScriptPath,
+        artifactRoot: process.env.HARNESS_ARTIFACT_ROOT!,
+      }),
       stdio: ["ignore", "pipe", "pipe"],
     });
     child.stdout?.on("data", (chunk) => output.push(String(chunk)));
@@ -832,7 +871,7 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     runId: string,
     expected: string,
   ): Promise<void> {
-    const deadline = Date.now() + 45_000;
+    const deadline = Date.now() + HARNESS_STATE_WAIT_MS;
     let lastState = "<missing>";
     while (Date.now() < deadline) {
       const result = await harnessPool.query<{ state: string }>(
@@ -855,6 +894,136 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     );
   }
 
+  async function waitForHarnessToolDispatch(
+    runId: string,
+    command: string,
+  ): Promise<void> {
+    const deadline = Date.now() + HARNESS_STATE_WAIT_MS;
+    let lastState = "<missing>";
+    while (Date.now() < deadline) {
+      const [runResult, eventResult] = await Promise.all([
+        harnessPool.query<{ state: string }>(
+          "select state from runs where run_id = $1",
+          [runId],
+        ),
+        harnessPool.query<{
+          event_type: string;
+          payload: Record<string, any>;
+        }>(
+          `select event_type, payload
+           from domain_events
+           where run_id = $1
+             and event_type in ('CapabilityProposed', 'CapabilityDispatched')
+           order by seq`,
+          [runId],
+        ),
+      ]);
+      lastState = runResult.rows[0]?.state ?? "<missing>";
+      const proposed = eventResult.rows.find(
+        (event) =>
+          event.event_type === "CapabilityProposed"
+          && event.payload?.capability_id === "shell.run"
+          && event.payload?.arguments?.command === command,
+      );
+      const dispatched = proposed
+        ? eventResult.rows.find(
+            (event) =>
+              event.event_type === "CapabilityDispatched"
+              && event.payload?.capability_id === "shell.run"
+              && event.payload?.args_hash === proposed.payload?.args_hash,
+          )
+        : undefined;
+      if (dispatched) return;
+      if (["cancelled", "failed", "learning_processed"].includes(lastState)) {
+        throw new Error(
+          `Harness run ${runId} reached ${lastState} before dispatching `
+            + `the exact ${JSON.stringify(command)} shell command`,
+        );
+      }
+      await delay(100);
+    }
+    throw new Error(
+      `Timed out waiting for Harness run ${runId} to dispatch `
+        + `${JSON.stringify(command)}; last=${lastState}`,
+    );
+  }
+
+  async function writeLifecycleDiagnostics({
+    workItemId,
+    intendedRunId,
+    expectedLifecycle,
+    lastLifecycle,
+    worker,
+  }: {
+    workItemId: string;
+    intendedRunId: string;
+    expectedLifecycle: string;
+    lastLifecycle: string;
+    worker: HarnessWorker;
+  }): Promise<{
+    path: string;
+    harnessRun: { state: string; outcome: string | null } | undefined;
+  }> {
+    const [runResult, eventResult] = await Promise.all([
+      harnessPool.query<{
+        state: string;
+        outcome: string | null;
+        outcome_reason: string | null;
+      }>(
+        "select state, outcome, outcome_reason from runs where run_id = $1",
+        [intendedRunId],
+      ),
+      harnessPool.query<{
+        seq: number;
+        event_type: string;
+        payload: Record<string, any>;
+      }>(
+        `select seq, event_type, payload
+         from domain_events
+         where run_id = $1
+           and event_type in (
+             'EnvironmentPrepared',
+             'ModelResponded',
+             'CapabilityProposed',
+             'PolicyDecisionMade',
+             'CapabilityDispatched',
+             'CapabilityCompleted',
+             'VerificationCompleted',
+             'RunCompleted'
+           )
+         order by seq desc
+         limit 25`,
+        [intendedRunId],
+      ),
+    ]);
+    const target = path.join(
+      evidenceRoot,
+      "diagnostics",
+      `${workItemId}.json`,
+    );
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(
+      target,
+      `${JSON.stringify({
+        schemaVersion: 1,
+        kind: "int2_lifecycle_failure",
+        workItemId,
+        intendedRunId,
+        expectedLifecycle,
+        lastLifecycle,
+        harnessRun: runResult.rows[0] ?? null,
+        latestEvents: eventResult.rows.reverse(),
+        workerOutputTail: worker.outputTail(),
+        dispatcherLogTail: loggerRecords.slice(-50),
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    return {
+      path: target,
+      harnessRun: runResult.rows[0],
+    };
+  }
+
   const suiteLogger: DispatcherLogger = {
     info(fields, message) {
       loggerRecords.push({ level: "info", fields, message });
@@ -872,6 +1041,10 @@ class HarnessWorker {
     private readonly child: ChildProcess,
     private readonly output: string[],
   ) {}
+
+  outputTail(): string {
+    return this.output.join("").slice(-8_000);
+  }
 
   async stop(): Promise<void> {
     if (this.stopped) return;

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -1,5 +1,7 @@
 import { execFileSync } from "node:child_process";
 import {
+  chmod,
+  mkdir,
   mkdtemp,
   readFile,
   rm,
@@ -15,9 +17,16 @@ import {
   expectationsForCase,
   verifyScriptedPairPreflight,
 } from "../../scripts/ceremony/int2-evidence.mjs";
+import {
+  createInt2WorkerEnvironment,
+} from "../../scripts/ceremony/int2-worker-environment.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 const SCRIPT_ROOT = path.join(ROOT, "scripts/ceremony");
+const CHECKOUT_HELPER = path.join(
+  SCRIPT_ROOT,
+  "lib/int2-harness-checkout.sh",
+);
 const OPERATOR_SCRIPTS = [
   "int2-bringup.sh",
   "int2-green-setup.sh",
@@ -41,6 +50,7 @@ describe("committed INT-2 ceremony mechanics", () => {
       OPERATOR_SCRIPTS.map(async (name) => {
         const target = path.join(SCRIPT_ROOT, name);
         execFileSync("bash", ["-n", target]);
+        execFileSync("zsh", ["-n", target]);
         return [name, await readFile(target, "utf8")] as const;
       }),
     );
@@ -99,5 +109,144 @@ describe("committed INT-2 ceremony mechanics", () => {
       runCount: 1,
       effectiveCapabilities: expect.not.arrayContaining(["fs.write_file"]),
     });
+  });
+
+  it("fails CI with a named error when the private Harness key is absent", async () => {
+    const temporary = await mkdtemp(path.join(tmpdir(), "int2-checkout-missing-"));
+    temporaryRoots.push(temporary);
+    const log = path.join(temporary, "bootstrap.log");
+    let stderr = "";
+    let exitCode: number | undefined;
+    try {
+      execFileSync(
+        "bash",
+        [
+          "-c",
+          'source "$1"; int2_checkout_harness "$2" "$3" "$4"',
+          "int2-checkout-test",
+          CHECKOUT_HELPER,
+          path.join(temporary, "agent-harness"),
+          "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2",
+          log,
+        ],
+        {
+          env: {
+            ...process.env,
+            CI: "true",
+            INT2_HARNESS_DEPLOY_KEY: "",
+          },
+          stdio: ["ignore", "ignore", "pipe"],
+        },
+      );
+    } catch (error) {
+      exitCode = (error as { status?: number }).status;
+      stderr = String((error as { stderr?: Buffer }).stderr ?? "");
+    }
+    expect(exitCode).toBe(20);
+    expect(stderr).toContain("INT2_HARNESS_DEPLOY_KEY_MISSING");
+    expect(await readFile(log, "utf8")).toContain(
+      "INT2_HARNESS_DEPLOY_KEY_MISSING",
+    );
+  });
+
+  it("uses the deploy key only for a strict authenticated Harness checkout", async () => {
+    const temporary = await mkdtemp(path.join(tmpdir(), "int2-checkout-key-"));
+    temporaryRoots.push(temporary);
+    const fakeBin = path.join(temporary, "bin");
+    const fakeGit = path.join(fakeBin, "git");
+    const fakeGitLog = path.join(temporary, "git.log");
+    const bootstrapLog = path.join(temporary, "bootstrap.log");
+    const checkout = path.join(temporary, "agent-harness");
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(
+      fakeGit,
+      [
+        "#!/bin/sh",
+        'printf "key=%s\\nssh=%s\\nargs=%s\\n" \\',
+        '  "${INT2_HARNESS_DEPLOY_KEY:-absent}" \\',
+        '  "${GIT_SSH_COMMAND:-missing}" "$*" >> "$INT2_FAKE_GIT_LOG"',
+        'for value in "$@"; do destination="$value"; done',
+        'mkdir -p "$destination/.git"',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(fakeGit, 0o755);
+
+    execFileSync(
+      "bash",
+      [
+        "-c",
+        'source "$1"; int2_checkout_harness "$2" "$3" "$4"',
+        "int2-checkout-test",
+        CHECKOUT_HELPER,
+        checkout,
+        "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2",
+        bootstrapLog,
+      ],
+      {
+        env: {
+          ...process.env,
+          CI: "true",
+          INT2_FAKE_GIT_LOG: fakeGitLog,
+          INT2_HARNESS_DEPLOY_KEY: "test-only-private-key",
+          PATH: `${fakeBin}:${process.env.PATH}`,
+        },
+      },
+    );
+
+    const invocation = await readFile(fakeGitLog, "utf8");
+    expect(invocation).toContain("key=absent");
+    expect(invocation).toContain(
+      "args=clone --quiet git@github.com:averray-agent/agent-harness.git",
+    );
+    expect(invocation).toContain("IdentitiesOnly=yes");
+    expect(invocation).toContain("BatchMode=yes");
+    expect(invocation).toContain("StrictHostKeyChecking=yes");
+    expect(await readFile(bootstrapLog, "utf8")).toContain(
+      "INT2_HARNESS_CHECKOUT_AUTHENTICATED method=read-only-deploy-key",
+    );
+  });
+
+  it("removes inherited live-model and script-precedence ambiguity", () => {
+    const controlled = createInt2WorkerEnvironment(
+      {
+        PATH: "/test/bin",
+        HARNESS_APP_VERSION: "foreign-version",
+        HARNESS_BASELINE_MODEL: "live-model",
+        HARNESS_MODEL_ADAPTER: "gemini",
+        HARNESS_MODEL_API_KEY: "secret",
+        HARNESS_TEST_EXECUTOR_MODEL_SCRIPT_OPENAI_COMPATIBLE:
+          "/wrong/highest-precedence.jsonl",
+        HARNESS_TEST_MODEL_SCRIPT: "/wrong/generic.jsonl",
+        HARNESS_TEST_MODEL_FACTORY_COUNTER: "/wrong/counter",
+      },
+      {
+        databaseUrl: "postgresql://test",
+        profilesRoot: "/profiles",
+        modelScriptPath: "/controlled/model.jsonl",
+        artifactRoot: "/artifacts",
+      },
+    );
+
+    expect(controlled).toMatchObject({
+      PATH: "/test/bin",
+      HARNESS_APP_VERSION: "pkt-003",
+      HARNESS_DATABASE_URL: "postgresql://test",
+      HARNESS_MODEL_ADAPTER: "openai-compatible",
+      HARNESS_MODEL_BASE_URL: "http://127.0.0.1",
+      HARNESS_MODEL_REF: "int2-scripted-model",
+      HARNESS_TEST_EXECUTOR_MODEL_SCRIPT_OPENAI_COMPATIBLE:
+        "/controlled/model.jsonl",
+      HARNESS_TEST_EXECUTOR_MODEL_SCRIPT: "/controlled/model.jsonl",
+      HARNESS_TEST_MODEL_SCRIPT_OPENAI_COMPATIBLE:
+        "/controlled/model.jsonl",
+      HARNESS_TEST_MODEL_SCRIPT: "/controlled/model.jsonl",
+    });
+    expect(controlled).not.toHaveProperty("HARNESS_BASELINE_MODEL");
+    expect(controlled).not.toHaveProperty("HARNESS_MODEL_API_KEY");
+    expect(controlled).not.toHaveProperty(
+      "HARNESS_TEST_MODEL_FACTORY_COUNTER",
+    );
   });
 });


### PR DESCRIPTION
## What changed

- authenticate the required private Harness checkout with a read-only deploy key from `INT2_HARNESS_DEPLOY_KEY`
- create `bootstrap.log` before checkout and fail with named exit codes instead of raw Git exit 128
- pin GitHub's published Ed25519 host key and remove the deploy-key secret from the environment before Git or later child processes run
- close the Harness worker's model environment so inherited live-model settings and higher-precedence scripted-model variables cannot shadow the staged JSONL
- make HALT wait for the exact `sleep 30` proposal/dispatch chain and verify its full bounded duration plus `command_timeout`
- verify exact command proposal, dispatch, completion, and shell exit semantics for every scripted run
- emit lifecycle diagnostics on timeout or unexpected terminal state
- parse all operator scripts with both `bash -n` and `zsh -n`

## Root causes

Main cloned a private repository over unauthenticated HTTPS, which only worked when a developer credential helper or pre-set checkout was present. Separately, the suite set only the lowest-precedence generic model-script variable while inheriting the operator environment. On the independent-review machine, a higher-precedence or live-model setting could therefore execute instead of the staged fixture. That explains both the 180-second run timeouts and the HALT run that finished without ever executing `sleep 30`.

## Validation

- `npm ci` — green
- `npm run typecheck` — green
- `npm run build` — green
- `npm test` — 199 files passed, 2 skipped; 2,532 tests passed, 13 skipped
- implementation-worktree real Docker/Postgres suite — 9/9 in 145 seconds
- missing-key CI path — named `INT2_HARNESS_DEPLOY_KEY_MISSING`, exit 20, non-empty bootstrap evidence

## Flagged clean-gate finding

A detached clean checkout reproduced a separate intermittent Docker-provider mount symptom: 7/9 passed; the negative and restart cases reached the unchanged `git diff --check` with `.git` unavailable and exited 129. The kernel pin is already the self-contained-workspace fix merge. The scripted commands were deterministic and did execute. I did not add a retry, delay, pin substitution, or weakened criterion to turn that finding green. Full natural diagnostics and both gate outputs are in `docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md`.

This PR is intentionally draft pending the hosted Linux CI result, provisioning of `INT2_HARNESS_DEPLOY_KEY`, and independent review of that separate provider-mount observation.

## Impact

CI and test/evidence infrastructure only. No dispatcher production module, schema, migration, kernel source, dependency, lockfile, wallet, settlement, deployment, or PR-opening path changes.