### PR TITLE
feat(ops): check the payout window against the chain, not against an assumption

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1011,6 +1011,11 @@ async function ethRpc(
  *   topic1 jobId · topic2 account · topic3 recipient
  *   data[0] asset · data[1] amount
  */
+/** settled24h is a rolling 24h count, so that is what the window must span. */
+const PAYOUT_COMPARISON_HOURS = 24;
+/** Blocks sampled to measure block time — long enough to smooth jitter. */
+const PAYOUT_BLOCK_TIME_SAMPLE = 2000;
+
 const RESERVATION_SETTLED_TOPIC = "0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee";
 
 /** Pad an address to a 32-byte topic. */
@@ -1038,6 +1043,93 @@ function dataWord(data: unknown, index: number): string | undefined {
  * NOT as red: the window really is approximate, and "investigate" is the true
  * instruction, not "settlement is down".
  */
+/** How far the real span may drift from the target before we distrust it. */
+const WINDOW_FIT_TOLERANCE = 0.2;
+
+/**
+ * Does the configured block lookback actually span the period it is compared
+ * against? PURE — the measurement is injected, so the boundary is testable.
+ *
+ * Reports on the INSTRUMENT, never on the money. "suspect" means this probe may
+ * be misconfigured; it never means a payout failed.
+ */
+export function decideWindowFit(input: {
+  /** Measured seconds per block; null when the chain could not be sampled. */
+  blockSeconds: number | null;
+  lookbackBlocks: number;
+  /** The period the count is compared against — settled24h ⇒ 24. */
+  targetHours: number;
+}): WindowFit {
+  if (input.blockSeconds === null || !Number.isFinite(input.blockSeconds) || input.blockSeconds <= 0) {
+    return {
+      status: "unknown",
+      // Unmeasured is NOT "fine". Say we could not check rather than implying a pass.
+      detail: "block time not measured — window fit unchecked",
+      blockSeconds: null,
+      spanHours: null,
+    };
+  }
+  const spanHours = (input.lookbackBlocks * input.blockSeconds) / 3600;
+  const ratio = spanHours / input.targetHours;
+  const blockSeconds = Number(input.blockSeconds.toFixed(3));
+  const span = Number(spanHours.toFixed(1));
+  if (Math.abs(ratio - 1) <= WINDOW_FIT_TOLERANCE) {
+    return {
+      status: "ok",
+      detail: `window spans ~${span}h at ${blockSeconds}s/block (target ${input.targetHours}h)`,
+      blockSeconds,
+      spanHours: span,
+    };
+  }
+  // Short is the dangerous direction: it under-counts and manufactures a
+  // shortfall. Long merely over-counts, which decidePayoutEvidence reads as
+  // "confirmed". Name the direction so the fix is obvious.
+  const suggested = Math.round((input.targetHours * 3600) / input.blockSeconds);
+  return {
+    status: "suspect",
+    detail: `window spans ~${span}h at a measured ${blockSeconds}s/block, not the ${input.targetHours}h it is compared against — ${
+      ratio < 1 ? "too SHORT, which under-counts payouts" : "longer than the comparison period"
+    }; ~${suggested} blocks would match`,
+    blockSeconds,
+    spanHours: span,
+  };
+}
+
+/**
+ * Measure seconds per block from two real block timestamps.
+ *
+ * Never throws and never guesses: any failure returns null, which
+ * decideWindowFit reports as "unchecked" rather than as a pass.
+ */
+export async function measureBlockSeconds(input: {
+  rpcUrl?: string;
+  sampleBlocks: number;
+  fetchImpl: typeof fetch;
+}): Promise<number | null> {
+  if (!input.rpcUrl || input.sampleBlocks <= 0) return null;
+  try {
+    const head = Number(BigInt(await ethRpc(input.rpcUrl, "eth_blockNumber", [], input.fetchImpl)));
+    const earlier = Math.max(0, head - input.sampleBlocks);
+    if (earlier >= head) return null;
+    const [a, b] = await Promise.all([
+      blockTimestamp(input.rpcUrl, head, input.fetchImpl),
+      blockTimestamp(input.rpcUrl, earlier, input.fetchImpl),
+    ]);
+    if (a === null || b === null || a <= b) return null;
+    return (a - b) / (head - earlier);
+  } catch {
+    return null;
+  }
+}
+
+async function blockTimestamp(rpcUrl: string, block: number, fetchImpl: typeof fetch): Promise<number | null> {
+  const raw = await ethRpcRaw(rpcUrl, "eth_getBlockByNumber", [`0x${block.toString(16)}`, false], fetchImpl);
+  const ts = (raw as { timestamp?: unknown } | null)?.timestamp;
+  if (typeof ts !== "string") return null;
+  const parsed = Number(BigInt(ts));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 export function decidePayoutEvidence(input: {
   confirmedCount: number | null;
   confirmedUsdc: number | null;
@@ -1045,12 +1137,15 @@ export function decidePayoutEvidence(input: {
   windowBlocks: number | null;
   tolerance: number;
   unverifiedReason?: string;
+  /** Whether the block window really spans the comparison period. */
+  window?: WindowFit;
 }): PayoutEvidence {
   const base = {
     confirmedCount: input.confirmedCount,
     confirmedUsdc: input.confirmedUsdc,
     settledCount: input.settledCount,
     windowBlocks: input.windowBlocks,
+    ...(input.window ? { window: input.window } : {}),
   };
   if (input.confirmedCount === null) {
     return {
@@ -1086,6 +1181,19 @@ export function decidePayoutEvidence(input: {
   }
   const shortfall = input.settledCount - input.confirmedCount;
   if (shortfall > input.tolerance) {
+    // A shortfall computed over a window that does not span the comparison
+    // period is not evidence about money — it is arithmetic on mismatched
+    // units. This exact case shipped: a lookback sized for 6s blocks on a
+    // ~2.1s chain covered 8h against a 24h settled count and would have posted
+    // a permanent "12 unaccounted for" on a system paying every job. An
+    // untrustworthy instrument SUPPRESSES the accusation; it never creates one.
+    if (input.window?.status === "suspect") {
+      return {
+        ...base,
+        status: "unverified",
+        detail: `cannot compare: ${input.window.detail} — fix the window before reading ${shortfall} unaccounted for as a payout problem`,
+      };
+    }
     return {
       ...base,
       status: "shortfall",
@@ -1487,6 +1595,26 @@ export interface PayoutEvidence {
   settledCount: number | null;
   /** Blocks scanned. The window is approximate — the verdict allows for it. */
   windowBlocks: number | null;
+  /** Does the block window actually span what it is compared against? */
+  window?: WindowFit;
+}
+
+/**
+ * Whether the configured block lookback really covers the period it is being
+ * compared to — checked against MEASURED block time, not an assumed one.
+ *
+ * This exists because the assumption was wrong in production: the lookback was
+ * sized "~24h at 6s/block" on a chain that runs at ~2.1s, so it spanned 8h26m
+ * and made a fully-paying system look like it had 12 unaccounted payouts.
+ * Nobody had measured the chain.
+ */
+export interface WindowFit {
+  status: "ok" | "suspect" | "unknown";
+  detail: string;
+  /** Measured seconds per block; null when the chain could not be sampled. */
+  blockSeconds: number | null;
+  /** Hours the configured lookback actually spans at that rate. */
+  spanHours: number | null;
 }
 
 export interface ProductHealthSnapshotBlocks {
@@ -1641,6 +1769,20 @@ export async function collectProductHealthProbes(
         fetchImpl,
       })
     : { count: null, usdc: null, windowBlocks: null, reason: "payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)" };
+  // Check the INSTRUMENT against the chain, not against an assumption. The
+  // lookback is compared to settled24h, so it has to actually span 24h at the
+  // chain's real block time — an assumed one has already been wrong in prod.
+  const windowFit = config.payoutEvidenceEnabled
+    ? decideWindowFit({
+        blockSeconds: await measureBlockSeconds({
+          rpcUrl: config.rpcUrl,
+          sampleBlocks: PAYOUT_BLOCK_TIME_SAMPLE,
+          fetchImpl,
+        }),
+        lookbackBlocks: config.payoutLookbackBlocks,
+        targetHours: PAYOUT_COMPARISON_HOURS,
+      })
+    : undefined;
   const payout = decidePayoutEvidence({
     confirmedCount: payoutRead.count,
     confirmedUsdc: payoutRead.usdc,
@@ -1648,6 +1790,7 @@ export async function collectProductHealthProbes(
     windowBlocks: payoutRead.windowBlocks,
     tolerance: config.payoutTolerance,
     ...(payoutRead.reason ? { unverifiedReason: payoutRead.reason } : {}),
+    ...(windowFit ? { window: windowFit } : {}),
   });
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -14,6 +14,8 @@ import {
   chainHaltStatus,
   probeSignerLiquidity,
   decidePayoutEvidence,
+  decideWindowFit,
+  measureBlockSeconds,
   readPayoutTransfers,
   collectProductHealthProbes,
   chainBlockAge,
@@ -1574,5 +1576,125 @@ describe("decidePayoutEvidence — a 100% miss is a broken filter, not lost mone
 
   it("zero settled AND zero confirmed is a quiet period, not an alarm", () => {
     expect(decidePayoutEvidence({ ...base, confirmedCount: 0, confirmedUsdc: 0, settledCount: 0 }).status).toBe("unverified");
+  });
+});
+
+describe("decideWindowFit — measure the chain, don't assume it", () => {
+  // The real 2026-07-29 defect: sized "~24h at 6s/block" on a ~2.1s chain.
+  it("flags the shipped 14400/6s assumption against real ~2.1s blocks", () => {
+    const fit = decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 14400, targetHours: 24 });
+    expect(fit.status).toBe("suspect");
+    expect(fit.spanHours).toBeCloseTo(8.4, 1);
+    expect(fit.detail).toContain("too SHORT");
+    expect(fit.detail).toMatch(/~40\d{3} blocks would match|~4[01]\d{3} blocks/);
+  });
+
+  it("accepts the corrected 43200 window", () => {
+    const fit = decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 43200, targetHours: 24 });
+    expect(fit.status).toBe("ok");
+    expect(fit.spanHours).toBeCloseTo(25.3, 1);
+  });
+
+  it("an UNMEASURED chain is 'unknown', never a silent pass", () => {
+    const fit = decideWindowFit({ blockSeconds: null, lookbackBlocks: 43200, targetHours: 24 });
+    expect(fit.status).toBe("unknown");
+    expect(fit.detail).toContain("not measured");
+    expect(fit.spanHours).toBeNull();
+  });
+
+  it.each([[0], [-1], [Number.NaN], [Number.POSITIVE_INFINITY]])(
+    "a nonsense block time (%s) degrades to unknown rather than dividing by it",
+    (bs) => {
+      expect(decideWindowFit({ blockSeconds: bs as number, lookbackBlocks: 43200, targetHours: 24 }).status).toBe("unknown");
+    },
+  );
+
+  it("names the direction — long is safe, short manufactures the alarm", () => {
+    const long = decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 200000, targetHours: 24 });
+    expect(long.status).toBe("suspect");
+    expect(long.detail).toContain("longer than the comparison period");
+  });
+});
+
+describe("a suspect window SUPPRESSES a shortfall — instrument is not money", () => {
+  const base = { confirmedUsdc: 0.2, windowBlocks: 14400, tolerance: 1 };
+
+  it("the exact shipped false alarm becomes unverified, not a payout accusation", () => {
+    const r = decidePayoutEvidence({
+      ...base, confirmedCount: 2, settledCount: 14,
+      window: decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 14400, targetHours: 24 }),
+    });
+    expect(r.status).toBe("unverified"); // NOT "shortfall"
+    expect(r.detail).toContain("cannot compare");
+    expect(r.detail).not.toMatch(/^14 jobs marked settled/);
+  });
+
+  it("a REAL shortfall still reports when the window is sound", () => {
+    const r = decidePayoutEvidence({
+      ...base, confirmedCount: 2, settledCount: 14, windowBlocks: 43200,
+      window: decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 43200, targetHours: 24 }),
+    });
+    expect(r.status).toBe("shortfall");
+  });
+
+  it("an UNKNOWN window does not suppress — we only suppress on positive evidence of a bad instrument", () => {
+    const r = decidePayoutEvidence({
+      ...base, confirmedCount: 2, settledCount: 14,
+      window: decideWindowFit({ blockSeconds: null, lookbackBlocks: 43200, targetHours: 24 }),
+    });
+    expect(r.status).toBe("shortfall");
+  });
+
+  it("a suspect window never turns a healthy count INTO a problem", () => {
+    const r = decidePayoutEvidence({
+      ...base, confirmedCount: 14, settledCount: 14,
+      window: decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 14400, targetHours: 24 }),
+    });
+    expect(r.status).toBe("confirmed");
+  });
+
+  it("the fit rides along on the evidence for the board to render", () => {
+    const window = decideWindowFit({ blockSeconds: 2.11, lookbackBlocks: 43200, targetHours: 24 });
+    expect(decidePayoutEvidence({ ...base, confirmedCount: 14, settledCount: 14, window }).window).toEqual(window);
+  });
+});
+
+describe("measureBlockSeconds", () => {
+  function rpc(head: number, stamps: Record<number, number>): typeof fetch {
+    return (async (_u: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const body = JSON.parse(String((init as { body?: string })?.body ?? "{}"));
+      let result: unknown = null;
+      if (body.method === "eth_blockNumber") result = `0x${head.toString(16)}`;
+      if (body.method === "eth_getBlockByNumber") {
+        const n = Number(BigInt(body.params[0]));
+        result = stamps[n] === undefined ? null : { timestamp: `0x${stamps[n].toString(16)}` };
+      }
+      return { ok: true, status: 200, json: async () => ({ result }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("derives seconds per block from two real timestamps", async () => {
+    const s = await measureBlockSeconds({
+      rpcUrl: "http://rpc", sampleBlocks: 1000,
+      fetchImpl: rpc(11000, { 11000: 1_000_000 + 2110, 10000: 1_000_000 }),
+    });
+    expect(s).toBeCloseTo(2.11, 3);
+  });
+
+  it("a missing block yields null, so the fit reads 'unchecked' not 'fine'", async () => {
+    expect(await measureBlockSeconds({ rpcUrl: "http://rpc", sampleBlocks: 1000, fetchImpl: rpc(11000, { 11000: 5 }) }))
+      .toBeNull();
+  });
+
+  it("non-advancing timestamps yield null rather than 0 or a negative rate", async () => {
+    expect(await measureBlockSeconds({
+      rpcUrl: "http://rpc", sampleBlocks: 1000,
+      fetchImpl: rpc(11000, { 11000: 1_000_000, 10000: 1_000_000 }),
+    })).toBeNull();
+  });
+
+  it("no rpc url, or a throwing endpoint, is null — never an invented rate", async () => {
+    expect(await measureBlockSeconds({ sampleBlocks: 1000, fetchImpl: rpc(1, {}) })).toBeNull();
+    expect(await measureBlockSeconds({ rpcUrl: "http://rpc", sampleBlocks: 1000, fetchImpl: throwingFetch() })).toBeNull();
   });
 });


### PR DESCRIPTION
Both of today's defects were **beliefs about the chain nobody had measured**: that USDC emits ERC-20 `Transfer` logs (it emits none at all), and that blocks are 6s (they're ~2.1s). The second sized the payout lookback at 14400 blocks "for ~24h" when it really spanned **8h26m** — so ~8h of payouts were compared against a 24h settled count, a permanent false shortfall on a system paying every single job.

#584 fixed the number. This fixes **the class**.

## What it does
| | |
|---|---|
| `measureBlockSeconds()` | two real block timestamps → seconds/block, or `null` |
| `decideWindowFit()` | pure — does `lookbackBlocks × blockSeconds` span the compared period, within 20%? |

It never guesses. An unsampled chain is **`unknown`** with *"window fit unchecked"*, **not** a silent pass — absence of a measurement is not evidence of a good one. A zero, negative or NaN rate degrades to unknown rather than being divided by.

## The safety property that matters
**A suspect window SUPPRESSES a shortfall.** A shortfall computed over a window that doesn't span the comparison period isn't evidence about money — it's arithmetic on mismatched units. It becomes:

> `unverified` · cannot compare: window spans ~8.4h at a measured 2.11s/block, not the 24h it is compared against — too SHORT, which under-counts payouts; ~40947 blocks would match

The instrument can **veto** an accusation. It can never **manufacture** one:

- a healthy count stays `confirmed` no matter how bad the window is;
- an **unknown** window does *not* suppress — we only stay quiet on positive evidence the instrument is wrong.

Same rule as the zero-confirmed guard: never let a broken measurement look like broken money. A fake red is as harmful as a fake green, and one that's always there is the one you learn to scroll past.

## Verification
- `test/unit`: **1340 → 1357** passing against the **same pre-existing 110** failures.
- `slack-operator` tsc: diffed before/after — **byte-identical modulo line shifts** (49 both sides).
- Tests reproduce the real defect: 14400 blocks at a measured 2.11s/block ⇒ `suspect`, and the shipped 2-vs-14 false alarm becomes `unverified` rather than `shortfall`.

Note: the `INT-2 real dispatcher integration` check is red on **main** (since #583 — it clones the private `averray-agent/agent-harness` with no credentials), so it will be red here too. Unrelated to this change; you said it's already being handled.