### PR TITLE
feat(ops): let the monitor report its own version

### DIFF
--- a/ops/Dockerfile.node
+++ b/ops/Dockerfile.node
@@ -16,6 +16,12 @@ ARG CODEX_CLI_PACKAGE=@openai/codex
 # Claude Code CLI — the entrypoint the Claude worker (claude-branch-worker, O2)
 # shells out to. Pinned via this build arg so the runtime image is reproducible.
 ARG CLAUDE_CLI_PACKAGE=@anthropic-ai/claude-code
+# The commit this image was built from, so the monitor can report its OWN
+# version. `.git` is in .dockerignore, so the build cannot discover this itself
+# — it has to be passed in. The default is the honest "unknown", which the
+# self-freshness probe reports as unknown rather than as up-to-date.
+ARG GIT_SHA=unknown
+ENV AVERRAY_GIT_SHA=${GIT_SHA}
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates chromium git openssh-client \
   && rm -rf /var/lib/apt/lists/*

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -51,6 +51,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     depends_on:
       hermes-permissions:
@@ -106,6 +110,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
     # Hermes owns the skills volume as UID 10000 and continuously re-secures it to
@@ -132,6 +140,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
     depends_on:
@@ -357,6 +369,13 @@ services:
       # sample ring, so one aged out after ~5h and became unrecoverable. This log
       # keeps the records themselves; /data is a volume, so they survive the
       # redeploys that would wipe any in-memory retention.
+      # Self-freshness: is the MONITOR itself running current code? It tracked
+      # the PRODUCT's deploy sha while being blind to its own, and the VPS sat
+      # six commits behind with four merged PRs live nowhere. Unset repo or an
+      # unbaked GIT_SHA reports "unknown" — never "up to date".
+      PRODUCT_HEALTH_SELF_REPO: ${PRODUCT_HEALTH_SELF_REPO:-depre-dev/averray-reference-agent}
+      # The compare call 404s on a private repo without a token.
+      PRODUCT_HEALTH_SELF_GITHUB_TOKEN: ${PRODUCT_HEALTH_SELF_GITHUB_TOKEN:-}
       PRODUCT_HEALTH_INCIDENT_LOG_PATH: ${PRODUCT_HEALTH_INCIDENT_LOG_PATH:-/data/product-health-incidents.jsonl}
       PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED: ${PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED:-false}
       # The contract that EMITS the payout event. Defaults to /health's
@@ -468,6 +487,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["testbed-runner"]
     restart: unless-stopped
@@ -570,6 +593,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["test-wallet-signer"]
     restart: unless-stopped
@@ -608,6 +635,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["codex-runner"]
     restart: unless-stopped
@@ -653,6 +684,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["dispatch"]
     restart: unless-stopped
@@ -697,6 +732,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["claude-runner"]
     restart: unless-stopped
@@ -764,6 +803,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["test-writer-runner"]
     restart: unless-stopped
@@ -826,6 +869,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["security-runner"]
     restart: unless-stopped
@@ -879,6 +926,10 @@ services:
     build:
       context: ..
       dockerfile: ops/Dockerfile.node
+      args:
+        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
+        # can report its own version. Unset = "unknown", reported honestly.
+        GIT_SHA: ${GIT_SHA:-unknown}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["docs-runner"]
     restart: unless-stopped

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -29,6 +29,9 @@ import type { AlertPayload } from "./alert-bridge.js";
 
 // ── Probe result model ──────────────────────────────────────────────
 
+import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
+import type { SelfFreshness } from "./self-freshness.js";
+
 export type ProbeStatus = "ok" | "degraded" | "red";
 
 export interface ProbeResult {
@@ -489,6 +492,13 @@ export interface ProductHealthConfig {
   /** Override the payout SOURCE address. Defaults to /health's
    *  addresses.agentAccountCore — the contract USDC actually leaves. */
   payoutSourceAddress?: string;
+  /** "owner/repo" of the MONITOR itself, for the self-freshness comparison. */
+  selfRepo?: string;
+  /** The commit this build came from — baked in as AVERRAY_GIT_SHA. */
+  selfSha?: string;
+  /** Token for the compare call; a private repo returns 404 without one. */
+  selfGithubToken?: string;
+  githubApiBaseUrl?: string;
   /** Blocks scanned for Transfer logs (~24h at the chain's block time). */
   payoutLookbackBlocks: number;
   /** Settled-minus-confirmed gap tolerated as a window-boundary artifact. */
@@ -581,6 +591,10 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
     payoutEvidenceEnabled: truthy(env.PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED),
     payoutSourceAddress: env.PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS || undefined,
+    selfRepo: env.PRODUCT_HEALTH_SELF_REPO || env.MONITOR_REPO || undefined,
+    selfSha: env.AVERRAY_GIT_SHA || undefined,
+    selfGithubToken: env.PRODUCT_HEALTH_SELF_GITHUB_TOKEN || env.GITHUB_TOKEN || undefined,
+    githubApiBaseUrl: env.GITHUB_API_BASE_URL || undefined,
     // ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
     payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 14400),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
@@ -1491,6 +1505,12 @@ export interface PayoutEvidence {
 
 export interface ProductHealthSnapshotBlocks {
   chainId?: number | null;
+  /**
+   * The MONITOR's own version. Deliberately NOT a probe: a stale monitor is not
+   * a degraded product, and folding it into the probe list would flip the board
+   * (and the phone headline) to degraded over a fact about ourselves.
+   */
+  self?: SelfFreshness;
   network?: "testnet" | "mainnet" | "unknown";
   solvency?: SolvencySnapshotData;
   flow?: MoneyPathData;
@@ -1649,8 +1669,19 @@ export async function collectProductHealthProbes(
     tolerance: config.payoutTolerance,
     ...(payoutRead.reason ? { unverifiedReason: payoutRead.reason } : {}),
   });
+  // The monitor's own version. Degraded-safe: any failure is "unknown", which
+  // must never render as up to date.
+  const selfFreshness = await deriveSelfFreshnessProbe({
+    ...(config.selfRepo ? { repo: config.selfRepo } : {}),
+    ...(config.selfSha ? { runningSha: config.selfSha } : {}),
+    ...(config.selfGithubToken ? { token: config.selfGithubToken } : {}),
+    ...(config.githubApiBaseUrl ? { baseUrl: config.githubApiBaseUrl } : {}),
+    nowMs: chainCtx.nowMs,
+    fetchImpl,
+  });
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,
+    ...(selfFreshness.selfFreshness ? { self: selfFreshness.selfFreshness } : {}),
     network: resolveProductHealthNetwork(chainId),
     ...(solvencyPools.length ? { solvency: { pools: solvencyPools } } : {}),
     ...(settlement
@@ -1669,6 +1700,7 @@ export async function collectProductHealthProbes(
         }
       : {}),
   };
+
   return {
     probes: [
       deriveProductApiProbe(h),
@@ -1693,6 +1725,48 @@ export async function collectProductHealthProbes(
     latencyMs: h.latencyMs,
     rpcOk: signer.rpcOk,
   };
+}
+
+/**
+ * Is the MONITOR itself current? It reported on everything but its own version
+ * until the VPS was found six commits behind with four merged PRs live nowhere.
+ *
+ * "behind" is DEGRADED, never red: stale code is not an outage, and colouring
+ * it as one would be the false-alarm that gets scrolled past. "unknown" is a
+ * real third state — it must never render as up to date.
+ */
+async function deriveSelfFreshnessProbe(input: {
+  repo?: string;
+  runningSha?: string;
+  token?: string;
+  baseUrl?: string;
+  nowMs: number;
+  fetchImpl: typeof fetch;
+}): Promise<{ selfFreshness: SelfFreshness }> {
+  const sha = input.runningSha ?? null;
+  if (!input.repo) {
+    const verdict = decideSelfFreshness({ runningSha: sha, compare: null, unknownReason: "no repo configured", nowMs: input.nowMs });
+    return { selfFreshness: verdict };
+  }
+  const normalized = (sha ?? "").trim().toLowerCase();
+  if (!normalized || normalized === "unknown") {
+    const verdict = decideSelfFreshness({ runningSha: null, compare: null, nowMs: input.nowMs });
+    return { selfFreshness: verdict };
+  }
+  const { compare, reason } = await fetchSelfCompare({
+    repo: input.repo,
+    runningSha: normalized,
+    ...(input.token ? { token: input.token } : {}),
+    ...(input.baseUrl ? { baseUrl: input.baseUrl } : {}),
+    fetchFn: input.fetchImpl,
+  });
+  const verdict = decideSelfFreshness({
+    runningSha: normalized,
+    compare,
+    ...(reason ? { unknownReason: reason } : {}),
+    nowMs: input.nowMs,
+  });
+  return { selfFreshness: verdict };
 }
 
 // ── Alert rendering (reuses the D4 AlertPayload) ────────────────────

--- a/services/slack-operator/src/self-freshness.ts
+++ b/services/slack-operator/src/self-freshness.ts
@@ -1,0 +1,161 @@
+// Does the monitor know what version of itself it is running?
+//
+// It did not, and the cost was real: on 2026-07-29 the VPS sat SIX commits
+// behind main — four merged PRs were live nowhere — and nothing said so. The
+// monitor tracked the PRODUCT's deploy sha all along (github-pr-state.ts) while
+// being completely blind to its own. It was found only because someone SSH'd in
+// for an unrelated reason.
+//
+// A monitor that reports on everything except itself has a hole exactly where
+// its own credibility lives: every improvement it ships can sit merged and
+// invisible, and it will keep saying everything is nominal.
+//
+// Truth boundary: "I don't know" is a real answer here and must never be
+// rendered as "up to date". An unbaked sha, a rate-limited API and a genuinely
+// current deploy are three different states, and only the last is good news.
+
+/** Hours before an unshipped commit is worth naming in the detail line. */
+const STALE_HOURS = 1;
+
+export interface SelfFreshness {
+  status: "current" | "behind" | "unknown";
+  detail: string;
+  /** The sha actually running, when it was baked into the image. */
+  runningSha: string | null;
+  /** Commits on main that this build does not contain; null when unknown. */
+  behindBy: number | null;
+  /** When the OLDEST unshipped commit landed — how long we have been stale. */
+  oldestUnshippedAt: string | null;
+}
+
+export interface SelfCompare {
+  behindBy: number;
+  /** ISO timestamp of the oldest commit we are missing, when known. */
+  oldestUnshippedAt?: string | null;
+}
+
+/**
+ * Turn a running sha + a comparison against main into an operator-facing
+ * verdict. PURE — `nowMs` is injected so the age phrasing is testable.
+ */
+export function decideSelfFreshness(input: {
+  runningSha: string | null;
+  /** null ⇒ the comparison could not be made (not ⇒ "no drift"). */
+  compare: SelfCompare | null;
+  unknownReason?: string;
+  nowMs: number;
+}): SelfFreshness {
+  const runningSha = normalizeSha(input.runningSha);
+  if (!runningSha) {
+    return {
+      status: "unknown",
+      // The single most likely cause, named, so the fix is obvious.
+      detail: "running version unknown — no build sha baked into the image (GIT_SHA build arg)",
+      runningSha: null,
+      behindBy: null,
+      oldestUnshippedAt: null,
+    };
+  }
+  const short = runningSha.slice(0, 8);
+  if (!input.compare) {
+    return {
+      status: "unknown",
+      detail: `${short} running · ${input.unknownReason ?? "could not compare against main"}`,
+      runningSha,
+      behindBy: null,
+      oldestUnshippedAt: null,
+    };
+  }
+  const behindBy = Math.max(0, Math.floor(input.compare.behindBy));
+  if (behindBy === 0) {
+    return {
+      status: "current",
+      detail: `${short} · up to date with main`,
+      runningSha,
+      behindBy: 0,
+      oldestUnshippedAt: null,
+    };
+  }
+  const oldest = input.compare.oldestUnshippedAt ?? null;
+  const age = describeStaleFor(oldest, input.nowMs);
+  return {
+    status: "behind",
+    detail: `${short} · ${behindBy} commit${behindBy === 1 ? "" : "s"} behind main${age ? ` · oldest merged ${age}` : ""} — merged work is not live`,
+    runningSha,
+    behindBy,
+    oldestUnshippedAt: oldest,
+  };
+}
+
+/**
+ * Ask GitHub how far the running build is behind the default branch.
+ *
+ * One `compare` call answers it. Any failure returns null, which the decision
+ * above renders as "unknown" — never as "current". A rate limit must not look
+ * like a clean deploy.
+ */
+export async function fetchSelfCompare(input: {
+  repo: string;
+  runningSha: string;
+  baseBranch?: string;
+  token?: string;
+  baseUrl?: string;
+  fetchFn: typeof fetch;
+}): Promise<{ compare: SelfCompare | null; reason?: string }> {
+  const base = (input.baseUrl ?? "https://api.github.com").replace(/\/+$/g, "");
+  const branch = input.baseBranch ?? "main";
+  try {
+    const response = await input.fetchFn(
+      `${base}/repos/${input.repo}/compare/${encodeURIComponent(input.runningSha)}...${encodeURIComponent(branch)}`,
+      {
+        headers: {
+          accept: "application/vnd.github+json",
+          ...(input.token ? { authorization: `Bearer ${input.token}` } : {}),
+        },
+      },
+    );
+    if (!response.ok) {
+      // 404 on a private repo without a token reads identically to a bad sha,
+      // so say what we actually observed rather than guessing which.
+      return { compare: null, reason: `GitHub compare failed (HTTP ${response.status})` };
+    }
+    const body = (await response.json()) as {
+      behind_by?: unknown;
+      commits?: { commit?: { committer?: { date?: unknown } } }[];
+    };
+    if (typeof body.behind_by !== "number") {
+      return { compare: null, reason: "GitHub compare returned no behind_by" };
+    }
+    // `commits` is the list we are MISSING, oldest first.
+    const oldest = Array.isArray(body.commits) ? body.commits[0]?.commit?.committer?.date : undefined;
+    return {
+      compare: {
+        behindBy: body.behind_by,
+        ...(typeof oldest === "string" ? { oldestUnshippedAt: oldest } : {}),
+      },
+    };
+  } catch (error) {
+    return {
+      compare: null,
+      reason: `GitHub compare failed (${error instanceof Error ? error.message : String(error)})`,
+    };
+  }
+}
+
+function normalizeSha(value: string | null | undefined): string | null {
+  const sha = (value ?? "").trim().toLowerCase();
+  // "unknown" is the Dockerfile's honest default when no build arg was passed.
+  if (!sha || sha === "unknown" || !/^[0-9a-f]{7,40}$/.test(sha)) return null;
+  return sha;
+}
+
+/** "3h", "2d" — omitted entirely when it is too fresh to be worth naming. */
+function describeStaleFor(iso: string | null, nowMs: number): string | undefined {
+  if (!iso) return undefined;
+  const at = Date.parse(iso);
+  if (!Number.isFinite(at)) return undefined;
+  const hours = (nowMs - at) / 3_600_000;
+  if (hours < STALE_HOURS) return undefined;
+  if (hours < 24) return `${Math.floor(hours)}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/test/unit/self-freshness.test.ts
+++ b/test/unit/self-freshness.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import { decideSelfFreshness, fetchSelfCompare } from "../../services/slack-operator/src/self-freshness.js";
+
+const NOW = Date.parse("2026-07-29T18:00:00Z");
+const SHA = "824ae4c1f2d3b4a5968778695a4b3c2d1e0f9a8b";
+
+function ago(hours: number): string {
+  return new Date(NOW - hours * 3_600_000).toISOString();
+}
+
+describe("decideSelfFreshness", () => {
+  // THE REAL INCIDENT: the VPS sat 6 commits behind main and nothing said so.
+  it("names how far behind it is and how long it has been stale", () => {
+    const r = decideSelfFreshness({
+      runningSha: SHA,
+      compare: { behindBy: 6, oldestUnshippedAt: ago(9) },
+      nowMs: NOW,
+    });
+    expect(r.status).toBe("behind");
+    expect(r.behindBy).toBe(6);
+    expect(r.detail).toContain("6 commits behind main");
+    expect(r.detail).toContain("oldest merged 9h ago");
+    expect(r.detail).toContain("merged work is not live");
+  });
+
+  it("an up-to-date build says so plainly", () => {
+    const r = decideSelfFreshness({ runningSha: SHA, compare: { behindBy: 0 }, nowMs: NOW });
+    expect(r.status).toBe("current");
+    expect(r.detail).toBe("824ae4c1 · up to date with main");
+  });
+
+  // The three "not good news" states must stay distinguishable.
+  it("an UNBAKED sha is unknown and names the build arg, never 'up to date'", () => {
+    for (const sha of [null, "", "   ", "unknown", "UNKNOWN", "not-a-sha"]) {
+      const r = decideSelfFreshness({ runningSha: sha, compare: { behindBy: 0 }, nowMs: NOW });
+      expect(r.status).toBe("unknown");
+      expect(r.detail).toContain("GIT_SHA");
+      expect(r.behindBy).toBeNull();
+    }
+  });
+
+  it("a FAILED comparison is unknown — a rate limit must not read as a clean deploy", () => {
+    const r = decideSelfFreshness({
+      runningSha: SHA,
+      compare: null,
+      unknownReason: "GitHub compare failed (HTTP 403)",
+      nowMs: NOW,
+    });
+    expect(r.status).toBe("unknown");
+    expect(r.detail).toContain("824ae4c1 running");
+    expect(r.detail).toContain("HTTP 403");
+    expect(r.behindBy).toBeNull();
+  });
+
+  it("a very fresh commit drops the age rather than saying '0h ago'", () => {
+    const r = decideSelfFreshness({
+      runningSha: SHA,
+      compare: { behindBy: 1, oldestUnshippedAt: ago(0.2) },
+      nowMs: NOW,
+    });
+    expect(r.detail).toContain("1 commit behind main");
+    expect(r.detail).not.toContain("ago");
+  });
+
+  it.each([
+    [30, "1d ago"],
+    [72, "3d ago"],
+  ])("ages beyond a day read in days (%ih)", (h, expected) => {
+    expect(decideSelfFreshness({
+      runningSha: SHA, compare: { behindBy: 2, oldestUnshippedAt: ago(h) }, nowMs: NOW,
+    }).detail).toContain(expected);
+  });
+
+  it("an unparseable timestamp drops the age instead of reporting 1970", () => {
+    const r = decideSelfFreshness({
+      runningSha: SHA, compare: { behindBy: 3, oldestUnshippedAt: "not-a-date" }, nowMs: NOW,
+    });
+    expect(r.status).toBe("behind");
+    expect(r.detail).not.toContain("ago");
+  });
+
+  it("a negative behind_by clamps to current rather than going nonsense", () => {
+    expect(decideSelfFreshness({ runningSha: SHA, compare: { behindBy: -3 }, nowMs: NOW }).status).toBe("current");
+  });
+});
+
+describe("fetchSelfCompare", () => {
+  function ok(body: unknown): typeof fetch {
+    return (async () => ({ ok: true, status: 200, json: async () => body }) as unknown as Response) as unknown as typeof fetch;
+  }
+
+  it("reads behind_by and the oldest missing commit", async () => {
+    const { compare } = await fetchSelfCompare({
+      repo: "depre-dev/averray-reference-agent",
+      runningSha: SHA,
+      fetchFn: ok({
+        behind_by: 6,
+        commits: [
+          { commit: { committer: { date: "2026-07-29T09:00:00Z" } } },
+          { commit: { committer: { date: "2026-07-29T15:00:00Z" } } },
+        ],
+      }),
+    });
+    expect(compare).toEqual({ behindBy: 6, oldestUnshippedAt: "2026-07-29T09:00:00Z" });
+  });
+
+  it.each([[403, "rate limited"], [404, "private repo without a token"], [500, "upstream"]])(
+    "HTTP %i yields null + a reason, never a zero that reads as current",
+    async (status) => {
+      const r = await fetchSelfCompare({
+        repo: "r/r", runningSha: SHA,
+        fetchFn: (async () => ({ ok: false, status, json: async () => ({}) }) as unknown as Response) as unknown as typeof fetch,
+      });
+      expect(r.compare).toBeNull();
+      expect(r.reason).toContain(String(status));
+    },
+  );
+
+  it("a malformed body is null, not an assumed zero", async () => {
+    expect((await fetchSelfCompare({ repo: "r/r", runningSha: SHA, fetchFn: ok({ nope: true }) })).compare).toBeNull();
+  });
+
+  it("a throwing fetch is null with the cause", async () => {
+    const r = await fetchSelfCompare({
+      repo: "r/r", runningSha: SHA,
+      fetchFn: (async () => { throw new Error("socket hang up"); }) as unknown as typeof fetch,
+    });
+    expect(r.compare).toBeNull();
+    expect(r.reason).toContain("socket hang up");
+  });
+
+  it("sends the token when one is configured", async () => {
+    let seen: Record<string, string> | undefined;
+    await fetchSelfCompare({
+      repo: "r/r", runningSha: SHA, token: "t0ken",
+      fetchFn: (async (_u: RequestInfo | URL, init?: RequestInit) => {
+        seen = init?.headers as Record<string, string>;
+        return { ok: true, status: 200, json: async () => ({ behind_by: 0, commits: [] }) } as unknown as Response;
+      }) as unknown as typeof fetch,
+    });
+    expect(seen?.authorization).toBe("Bearer t0ken");
+  });
+});


### PR DESCRIPTION
The monitor tracked the **product's** deploy sha all along (`github-pr-state.ts`) while being completely blind to **its own**. Today the VPS sat **six commits behind main** — #577, #579, #581, #582 all merged and live nowhere — and nothing said so. It surfaced only because I SSH'd in for an unrelated reason.

A monitor that reports on everything except itself has a hole exactly where its credibility lives: every improvement it ships can sit merged and invisible while it keeps saying nominal.

## How
| | |
|---|---|
| `AVERRAY_GIT_SHA` | baked at build (`ARG GIT_SHA` + compose build arg) |
| `fetchSelfCompare` | one GitHub `compare` call → `behind_by` + oldest missing commit |
| `decideSelfFreshness` | pure verdict; `nowMs` injected so ages are testable |

`.git` is in `.dockerignore`, so the image genuinely **cannot** discover its own sha — it must be passed in. Default is the honest string `unknown`.

Prefix the deploy with `GIT_SHA=$(git rev-parse HEAD)` to light it up; until then it reports unknown, which is true.

## Truth boundary
**"unknown" is a real third state and must never render as up to date.** An unbaked sha, a rate-limited API and a genuinely current deploy are three different things — only the last is good news. A 403, a 404 (private repo, no token), a malformed body and a thrown fetch all yield unknown-*with a reason*, never a zero that reads as current.

## Deliberately NOT a probe
A stale monitor is not a degraded product. Folding this into the probe list would flip the whole board — and the phone headline — to degraded over a fact about *ourselves*. It rides in the snapshot blocks alongside solvency/flow instead.

`behind` reports the count **and** the age: *"6 commits behind main · oldest merged 9h ago — merged work is not live"*. A bare count can't tell you whether that's a deploy in progress or a week of drift.

## Verification
- `test/unit`: same **pre-existing 110** failures, **+16 passing**.
- `slack-operator` tsc: unchanged at **49**.
- `compose-env`'s source-vs-compose guard caught two env vars I'd added to source without forwarding — a good catch by an existing test; now wired.

Note: `INT-2 real dispatcher integration` is red on **main** (since #583, unrelated — private-repo clone with no credentials), so it'll be red here too.