### PR TITLE
ci(int2): create the dispatcher workspace root before the suite runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,17 @@ jobs:
       - name: Install reference dependencies
         run: npm ci
 
+      - name: Prepare the dispatcher workspace root
+        # DISPATCH_WORKSPACE_ROOT is a FIXED path baked into every approved task
+        # hash (packages/averray-mcp/src/workspace-path.ts), so it cannot be
+        # relocated to the runner temp — it must exist and be writable by the
+        # runner. Without this, workspace preparation fails and the dispatcher
+        # refuses with `workspace_prep_failed` before any Harness run is created.
+        run: |
+          sudo mkdir -p /var/lib/harness-dispatcher/workspaces
+          sudo chown -R "$(id -u):$(id -g)" /var/lib/harness-dispatcher
+          test -w /var/lib/harness-dispatcher/workspaces
+
       - name: Run required INT-2 mechanism suite
         env:
           INT2_HARNESS_DEPLOY_KEY: ${{ secrets.INT2_HARNESS_DEPLOY_KEY }}


### PR DESCRIPTION
**Main is red on every push, on one job only.** `Typecheck and test` and `Docker build` are green on all of them — this is the new INT-2 job, and no deployment workflow is involved.

The deploy key worked: the job now clears bootstrap and executes cases (33s, versus dying at 24s on `git 128`). Six of nine then fail.

## Cause — from the evidence artifact, not inference

```
lastLifecycle : blocked
harnessRun    : None
"Harness dispatch was refused: workspace_prep_failed."
```

**No Harness run is ever created.** Dispatch is refused at workspace preparation.

The three cases that **pass** are precisely those that refuse *before* needing a workspace — unapproved, approval-hash mismatch, and the profile-loader rejection. That split is the tell.

`DISPATCH_WORKSPACE_ROOT` is `/var/lib/harness-dispatcher/workspaces`, and it is **baked into every approved task hash**:

> *Changing DISPATCH_WORKSPACE_ROOT or the slug algorithm invalidates every previously approved task hash, so it is a breaking change requiring re-approval.* — `workspace-path.ts`

So it cannot be pointed at the runner temp. On a GitHub runner the path does not exist and the runner user cannot create it.

## Fix

Create it, chown it to the runner, and **assert writability** before the suite starts — so a permissions problem surfaces as a named step failure rather than as six opaque case failures downstream.

CI-only: no product code, no schema, no hashes, no fixtures.

## Note

This is the second environment where the suite needed something the author's machine already had — after the private-kernel credential. Both were invisible locally and obvious in CI, which is the argument for the job existing, even while it is the thing currently red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)