### PR TITLE
feat(ops): make the money signals page, and say which build is speaking

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3544,6 +3544,9 @@ function startOperatorRoutines() {
       });
       const result = await runProductHealthOnce({
         runProbes: async () => collection.probes,
+        // Money signals that are not probes (payout evidence) + the monitor's
+        // own version reach the alert path through here.
+        getSnapshot: () => collection.snapshot,
         alert: (payload) => alertChannel.dispatch(payload),
         boardUrl:
           optionalEnv("SLACK_OPERATOR_MONITOR_URL", "https://monitor.averray.com/monitor") ??

--- a/services/slack-operator/src/money-alert.ts
+++ b/services/slack-operator/src/money-alert.ts
@@ -1,0 +1,77 @@
+// What is worth waking you for, and what the page is allowed to claim.
+//
+// Product-health alerting is probe-driven: `evaluateProductHealth` collects the
+// RED probes and those page. That already covers a pool under its floor, a
+// halted chain and a degraded money path — they are probes, so they alert.
+//
+// One money signal is NOT a probe and therefore could never page: payout
+// evidence lives in the snapshot's `flow.payout` block. So the system could
+// observe "14 jobs settled, 2 payouts confirmed" and say nothing at all.
+//
+// Two rules govern what this is allowed to send:
+//
+//  1. NEVER page on "unverified". Unverified means the INSTRUMENT is in doubt —
+//     a drifted event topic, a throttled RPC, a window that does not span the
+//     comparison. Paging on it reports our own blind spot as a money failure,
+//     and a page that fires whenever we cannot see is the page you learn to
+//     swipe away. Only a SHORTFALL — real evidence, honestly short — pages.
+//
+//  2. Every page states the monitor version it speaks for. An alert from a
+//     build that is nine commits behind may be describing a world that no
+//     longer exists, and you cannot judge that from the message text alone.
+
+import type { ProductHealthSnapshotBlocks } from "./product-health.js";
+
+export interface MoneyAlert {
+  /** Money-blocking lines, most consequential first. Empty ⇒ nothing to page. */
+  lines: string[];
+  /**
+   * Stable de-dup key over what is wrong. Empty when nothing is wrong, so the
+   * caller can fold it into the existing rising-edge/cooldown logic.
+   */
+  key: string;
+}
+
+/**
+ * The money-blocking facts that no probe covers. PURE.
+ *
+ * Today that is exactly one: a payout shortfall. Pools, chain halt and money
+ * path are already red probes and already page — repeating them here would
+ * double-send, and two pages for one fact is its own kind of noise.
+ */
+export function decideMoneyAlert(snapshot?: ProductHealthSnapshotBlocks): MoneyAlert {
+  const payout = snapshot?.flow?.payout;
+  if (!payout || payout.status !== "shortfall") {
+    // "unverified" deliberately lands here: it is not evidence of lost money.
+    return { lines: [], key: "" };
+  }
+  const settled = payout.settledCount ?? null;
+  const confirmed = payout.confirmedCount ?? null;
+  const gap = settled !== null && confirmed !== null ? settled - confirmed : null;
+  return {
+    lines: [`• 💸 payout shortfall: ${payout.detail}`],
+    // Key on the SIZE of the gap, not the raw detail string: the detail carries
+    // USDC totals that drift every cycle and would re-page on noise alone.
+    key: `payout:${gap ?? "unknown"}`,
+  };
+}
+
+/**
+ * The version footer. Always names the running build; says so loudly when that
+ * build is stale, because a page from old code can describe a stale world.
+ */
+export function alertProvenance(snapshot?: ProductHealthSnapshotBlocks): string | undefined {
+  const self = snapshot?.self;
+  if (!self) return undefined;
+  if (self.status === "behind") {
+    return `⚠️ sent by monitor ${short(self.runningSha)}, ${self.behindBy ?? "?"} commits behind main — this alert may describe stale code`;
+  }
+  if (self.status === "unknown") {
+    return "monitor version unknown — cannot confirm this alert reflects current code";
+  }
+  return `monitor ${short(self.runningSha)}`;
+}
+
+function short(sha: string | null): string {
+  return sha ? sha.slice(0, 8) : "unknown";
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -29,6 +29,7 @@ import type { AlertPayload } from "./alert-bridge.js";
 
 // ── Probe result model ──────────────────────────────────────────────
 
+import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
 
@@ -1914,14 +1915,34 @@ async function deriveSelfFreshnessProbe(input: {
 
 // ── Alert rendering (reuses the D4 AlertPayload) ────────────────────
 
-export function buildProductHealthAlert(evaluation: ProductHealthEvaluation, boardUrl: string): AlertPayload {
-  const lines = evaluation.redProbes.map((p) => `• 🔴 ${p.name}: ${p.detail}`).join("\n");
+/** Probes whose failure is a MONEY failure — these lead the page. */
+const MONEY_PROBE_NAMES = new Set(["money_path", "signer_liquidity", "treasury_liquidity", "chain_height"]);
+
+export function buildProductHealthAlert(
+  evaluation: ProductHealthEvaluation,
+  boardUrl: string,
+  snapshot?: ProductHealthSnapshotBlocks,
+): AlertPayload {
+  // Money first. A red api_latency and a red money_path used to render
+  // identically, so the thing that costs money could sit below the thing that
+  // costs milliseconds.
+  const ordered = [...evaluation.redProbes].sort(
+    (a, b) => Number(MONEY_PROBE_NAMES.has(b.name)) - Number(MONEY_PROBE_NAMES.has(a.name)),
+  );
+  const money = decideMoneyAlert(snapshot);
+  const probeLines = ordered.map((p) => `• 🔴 ${p.name}: ${p.detail}`);
+  const lines = [...money.lines, ...probeLines];
+  const count = evaluation.redProbes.length + money.lines.length;
   const head =
-    evaluation.redProbes.length === 1
-      ? "1 product-health probe is RED"
-      : `${evaluation.redProbes.length} product-health probes are RED`;
-  const text = `:rotating_light: Averray product health — ${head}\n${lines}\nInspect: ${boardUrl}`;
-  return { count: evaluation.redProbes.length, items: [], boardUrl, text };
+    count === 1 ? "1 money-blocking signal" : `${count} money-blocking signals`;
+  const provenance = alertProvenance(snapshot);
+  const text = [
+    `:rotating_light: Averray product health — ${head}`,
+    ...lines,
+    `Inspect: ${boardUrl}`,
+    ...(provenance ? [provenance] : []),
+  ].join("\n");
+  return { count, items: [], boardUrl, text };
 }
 
 // ── De-dup: alert on a rising edge or a changed red-set, else after cooldown ──
@@ -1946,9 +1967,16 @@ export function decideProductHealthAlert(input: {
   state: ProductHealthAlertState;
   nowMs: number;
   cooldownMs: number;
+  /** Snapshot blocks, so a money signal that is not a probe can still page. */
+  snapshot?: ProductHealthSnapshotBlocks;
 }): { alert: boolean; state: ProductHealthAlertState } {
-  const key = redProbeKey(input.evaluation);
-  if (input.evaluation.status !== "red" || key === "") {
+  const money = decideMoneyAlert(input.snapshot);
+  // A payout shortfall is not a probe, so it never reached this gate: the
+  // system could see "14 settled, 2 confirmed" and stay silent. Fold it in so
+  // it pages on its own, and so a CHANGE in the gap re-pages.
+  const key = [redProbeKey(input.evaluation), money.key].filter(Boolean).join("|");
+  const worthPaging = input.evaluation.status === "red" || money.key !== "";
+  if (!worthPaging || key === "") {
     return { alert: false, state: { lastRedKey: "", lastAlertAtMs: input.state.lastAlertAtMs } };
   }
   const changed = key !== input.state.lastRedKey;
@@ -1964,6 +1992,12 @@ export function decideProductHealthAlert(input: {
 
 export interface ProductHealthDeps {
   runProbes: () => Promise<ProbeResult[]>;
+  /**
+   * The snapshot blocks for this cycle. Carries the money signals that are NOT
+   * probes (payout evidence) and the monitor's own version, so a page can fire
+   * on a shortfall and can state which build it speaks for.
+   */
+  getSnapshot?: () => ProductHealthSnapshotBlocks | undefined;
   alert: (payload: AlertPayload) => Promise<boolean>;
   boardUrl: string;
   nowMs: () => number;
@@ -1981,16 +2015,18 @@ export interface ProductHealthResult {
 export async function runProductHealthOnce(deps: ProductHealthDeps): Promise<ProductHealthResult> {
   const probes = await deps.runProbes();
   const evaluation = evaluateProductHealth(probes);
+  const snapshot = deps.getSnapshot?.();
   const { alert, state } = decideProductHealthAlert({
     evaluation,
     state: deps.getAlertState(),
     nowMs: deps.nowMs(),
     cooldownMs: deps.cooldownMs,
+    ...(snapshot ? { snapshot } : {}),
   });
   deps.setAlertState(state);
   let alerted = false;
   if (alert) {
-    await deps.alert(buildProductHealthAlert(evaluation, deps.boardUrl));
+    await deps.alert(buildProductHealthAlert(evaluation, deps.boardUrl, snapshot));
     alerted = true;
   }
   return { status: evaluation.status, evaluation, alerted };

--- a/test/unit/money-alert.test.ts
+++ b/test/unit/money-alert.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { alertProvenance, decideMoneyAlert } from "../../services/slack-operator/src/money-alert.js";
+import type { ProductHealthSnapshotBlocks } from "../../services/slack-operator/src/product-health.js";
+
+function snap(payout?: Record<string, unknown>, self?: Record<string, unknown>): ProductHealthSnapshotBlocks {
+  return {
+    chainId: 420420419,
+    ...(self ? { self: self as never } : {}),
+    ...(payout
+      ? { flow: { settled24h: 14, payout: payout as never } }
+      : {}),
+  } as ProductHealthSnapshotBlocks;
+}
+
+describe("decideMoneyAlert", () => {
+  it("a real SHORTFALL pages, with the gap as the dedup key", () => {
+    const r = decideMoneyAlert(snap({
+      status: "shortfall", detail: "14 jobs marked settled but only 2 payouts confirmed on-chain (0.20 USDC) — 12 unaccounted for",
+      settledCount: 14, confirmedCount: 2,
+    }));
+    expect(r.lines).toHaveLength(1);
+    expect(r.lines[0]).toContain("payout shortfall");
+    expect(r.key).toBe("payout:12");
+  });
+
+  // THE RULE THAT MATTERS. "unverified" means the instrument is in doubt — a
+  // drifted topic, a throttled RPC, a window that doesn't span the comparison.
+  // Paging on it reports our own blind spot as a money failure.
+  it("NEVER pages on unverified — that is our blind spot, not lost money", () => {
+    for (const detail of [
+      "no payout events found on the configured payout contract while 14 jobs are marked settled",
+      "cannot compare: window spans ~8.4h at a measured 2.11s/block, not the 24h it is compared against",
+      "payout evidence unverified — log read failed (HTTP 429)",
+    ]) {
+      const r = decideMoneyAlert(snap({ status: "unverified", detail, settledCount: 14, confirmedCount: null }));
+      expect(r.lines).toEqual([]);
+      expect(r.key).toBe("");
+    }
+  });
+
+  it("a confirmed payout is silence, not a page", () => {
+    expect(decideMoneyAlert(snap({ status: "confirmed", detail: "14 payouts confirmed", settledCount: 14, confirmedCount: 14 })))
+      .toEqual({ lines: [], key: "" });
+  });
+
+  it("no snapshot, and no flow block, are both silence", () => {
+    expect(decideMoneyAlert(undefined)).toEqual({ lines: [], key: "" });
+    expect(decideMoneyAlert(snap())).toEqual({ lines: [], key: "" });
+  });
+
+  // The detail line carries USDC totals that move every cycle; keying on it
+  // would re-page on noise while the underlying problem is unchanged.
+  it("the key tracks the GAP, so a drifting USDC total does not re-page", () => {
+    const a = decideMoneyAlert(snap({ status: "shortfall", detail: "… 0.20 USDC …", settledCount: 14, confirmedCount: 2 }));
+    const b = decideMoneyAlert(snap({ status: "shortfall", detail: "… 0.30 USDC …", settledCount: 14, confirmedCount: 2 }));
+    expect(a.key).toBe(b.key);
+  });
+
+  it("but a WORSENING gap re-pages", () => {
+    const a = decideMoneyAlert(snap({ status: "shortfall", detail: "d", settledCount: 14, confirmedCount: 2 }));
+    const b = decideMoneyAlert(snap({ status: "shortfall", detail: "d", settledCount: 20, confirmedCount: 2 }));
+    expect(a.key).not.toBe(b.key);
+  });
+
+  it("an unknowable gap still pages rather than being swallowed", () => {
+    const r = decideMoneyAlert(snap({ status: "shortfall", detail: "d", settledCount: null, confirmedCount: null }));
+    expect(r.lines).toHaveLength(1);
+    expect(r.key).toBe("payout:unknown");
+  });
+});
+
+describe("alertProvenance", () => {
+  it("a stale monitor WARNS that the alert may describe old code", () => {
+    const p = alertProvenance(snap(undefined, { status: "behind", runningSha: "824ae4c1f2d3", behindBy: 9 }));
+    expect(p).toContain("9 commits behind main");
+    expect(p).toContain("may describe stale code");
+    expect(p).toContain("824ae4c1");
+  });
+
+  it("a current monitor just names its build", () => {
+    expect(alertProvenance(snap(undefined, { status: "current", runningSha: "865942ef86220930", behindBy: 0 })))
+      .toBe("monitor 865942ef");
+  });
+
+  it("an unknown version says it cannot confirm — never implies current", () => {
+    const p = alertProvenance(snap(undefined, { status: "unknown", runningSha: null, behindBy: null }));
+    expect(p).toContain("cannot confirm");
+    expect(p).not.toContain("up to date");
+  });
+
+  it("no self block yields no footer rather than a fabricated one", () => {
+    expect(alertProvenance(snap())).toBeUndefined();
+    expect(alertProvenance(undefined)).toBeUndefined();
+  });
+});

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -14,6 +14,7 @@ import {
   chainHaltStatus,
   probeSignerLiquidity,
   decidePayoutEvidence,
+  buildProductHealthAlert,
   decideWindowFit,
   measureBlockSeconds,
   readPayoutTransfers,
@@ -1696,5 +1697,60 @@ describe("measureBlockSeconds", () => {
   it("no rpc url, or a throwing endpoint, is null — never an invented rate", async () => {
     expect(await measureBlockSeconds({ sampleBlocks: 1000, fetchImpl: rpc(1, {}) })).toBeNull();
     expect(await measureBlockSeconds({ rpcUrl: "http://rpc", sampleBlocks: 1000, fetchImpl: throwingFetch() })).toBeNull();
+  });
+});
+
+describe("a payout shortfall pages even with every probe green", () => {
+  const green = evaluateProductHealth([
+    { name: "product_api", status: "ok", detail: "" },
+    { name: "money_path", status: "ok", detail: "" },
+  ]);
+  const shortfallSnap = {
+    chainId: 420420419,
+    flow: { payout: { status: "shortfall", detail: "14 settled, only 2 confirmed — 12 unaccounted for", settledCount: 14, confirmedCount: 2 } },
+  } as never;
+
+  it("fires — it is not a probe, so it could never reach the gate before", () => {
+    const r = decideProductHealthAlert({
+      evaluation: green, state: initialProductHealthAlertState(), nowMs: 1_000, cooldownMs: 60_000,
+      snapshot: shortfallSnap,
+    });
+    expect(r.alert).toBe(true);
+  });
+
+  it("does NOT re-fire on the next cycle while the gap is unchanged", () => {
+    const first = decideProductHealthAlert({
+      evaluation: green, state: initialProductHealthAlertState(), nowMs: 1_000, cooldownMs: 60_000, snapshot: shortfallSnap,
+    });
+    const second = decideProductHealthAlert({
+      evaluation: green, state: first.state, nowMs: 2_000, cooldownMs: 60_000, snapshot: shortfallSnap,
+    });
+    expect(second.alert).toBe(false);
+  });
+
+  it("UNVERIFIED stays silent — our blind spot is not a page", () => {
+    const r = decideProductHealthAlert({
+      evaluation: green, state: initialProductHealthAlertState(), nowMs: 1_000, cooldownMs: 60_000,
+      snapshot: { chainId: 1, flow: { payout: { status: "unverified", detail: "cannot compare", settledCount: 14, confirmedCount: null } } } as never,
+    });
+    expect(r.alert).toBe(false);
+  });
+
+  it("the page leads with money and stamps the monitor version", () => {
+    const mixed = evaluateProductHealth([
+      { name: "api_latency", status: "red", detail: "2100ms" },
+      { name: "money_path", status: "red", detail: "3 stuck" },
+    ]);
+    const text = buildProductHealthAlert(mixed, "http://board", {
+      chainId: 420420419,
+      flow: { payout: { status: "shortfall", detail: "12 unaccounted for", settledCount: 14, confirmedCount: 2 } },
+      self: { status: "behind", detail: "", runningSha: "824ae4c1f2d3", behindBy: 9, oldestUnshippedAt: null },
+    } as never).text;
+    const lines = text.split("\n");
+    expect(lines[1]).toContain("payout shortfall");        // money leads
+    expect(lines[2]).toContain("money_path");              // then money probes
+    expect(lines[3]).toContain("api_latency");             // latency last
+    expect(text).toContain("9 commits behind main");       // provenance
+    expect(text).toContain("3 money-blocking signals");
   });
 });


### PR DESCRIPTION
Last of the four. Turns out most of this already existed — alerting is probe-driven, so a pool under its floor, a halted chain and a degraded money path **already page**. Re-sending those here would double-page, which is its own kind of noise. So this is deliberately narrow.

## The actual gap
**Payout evidence is not a probe.** It lives in the snapshot's `flow.payout` block, which the alert path never sees. The system could observe *"14 jobs settled, 2 payouts confirmed on-chain"* and say **nothing at all**.

## Three changes

**1. A payout shortfall pages on its own**, with no red probe required, folded into the existing rising-edge/cooldown de-dup.

**2. Never page on `unverified`.** Unverified means the *instrument* is in doubt — a drifted event topic, a throttled RPC, a window that doesn't span the comparison. Paging on it reports our own blind spot as a money failure, and an alert that fires whenever we can't see is the alert you learn to swipe away. Only real evidence that is honestly short pages.

The de-dup key is the **size of the gap**, not the detail string — the detail carries USDC totals that drift every cycle and would re-page on noise while the problem is unchanged. A *worsening* gap does re-page.

**3. Every page states the build it speaks for:**

> ⚠️ sent by monitor 824ae4c1, 9 commits behind main — this alert may describe stale code

That's #588 earning its keep. An alert from stale code may describe a world that no longer exists, and you can't tell from the message text. Unknown version says it *cannot confirm*; it never implies current.

## Money leads
A red `api_latency` and a red `money_path` rendered identically, so the thing that costs money could sit below the thing that costs milliseconds. Now money-blocking probes sort first, under any payout line.

## Verification
- `test/unit`: same **pre-existing 110** failures, **+35 passing**.
- `slack-operator` tsc: unchanged at **49**.
- Gate tests: a shortfall fires with **every probe green**; `unverified` stays silent across all three of its real detail strings; an unchanged gap does not re-fire.