### PR TITLE
feat(board): live block ticker beside the top-strip clock

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -237,7 +237,7 @@ export function BoardView({
   const [hermesFocusConversationActive, setHermesFocusConversationActive] = useState(false);
 
   // ── The board switches Delivery ⇆ Ops at the top level (board-wide). ──
-  const { health: productHealth } = useProductHealth({ enabled: monitoringEnabled });
+  const { health: productHealth, error: productHealthError } = useProductHealth({ enabled: monitoringEnabled });
   // Phone-width → the dedicated mobile surface (see the branch before `return`).
   const isMobileViewport = useIsMobileViewport();
   const [boardSurface, setBoardSurface] = useState<BoardSurface>(() => {
@@ -655,6 +655,18 @@ export function BoardView({
           automationHealth={board?.automationHealth}
           onRefresh={onRefresh}
           opsPillars={boardSurface === "ops" && productHealth ? pillarStatuses(productHealth.probes) : undefined}
+          chainTick={
+            // Only when the heartbeat routine is actually running — a board
+            // without product monitoring shows no chain chip at all rather
+            // than a permanently-awaiting one.
+            productHealth?.enabled
+              ? {
+                  chain: productHealth.chain,
+                  probe: productHealth.probes.find((p) => p.name === "chain_height"),
+                  pollError: Boolean(productHealthError),
+                }
+              : undefined
+          }
         />
       )}
 

--- a/packages/monitor-ui/src/components/ChainTicker.test.tsx
+++ b/packages/monitor-ui/src/components/ChainTicker.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+// ChainTicker component — the chip renders the derivation and ticks its age on
+// a 1s interval via an injected clock, so the test proves the height stays
+// frozen while the age advances.
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { ChainTicker } from "./ChainTicker.js";
+import type { ChainTick, ProductHealthProbe } from "../lib/monitor/product-health.js";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+const T0 = 1_700_000_000_000;
+
+const okProbe: ProductHealthProbe = {
+  name: "chain_height",
+  status: "ok",
+  detail: "block #18,812,345 · 3s old",
+  sparkline: ["ok"],
+};
+
+const chain: ChainTick = { height: 18_812_345, observedAtMs: T0, blockAgeSec: 3, lastAdvanceAtMs: T0, freshSeconds: 600 };
+
+describe("ChainTicker", () => {
+  test("renders the observed height with a ticking age — height frozen, age advancing", () => {
+    vi.useFakeTimers();
+    let nowMs = T0;
+    const { container } = render(<ChainTicker chain={chain} probe={okProbe} now={() => nowMs} />);
+    const pill = container.querySelector(".hm-chain-pill");
+    expect(pill?.textContent).toContain("#18,812,345");
+    expect(pill?.textContent).toContain("3s");
+
+    nowMs = T0 + 42_000;
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(pill?.textContent).toContain("#18,812,345"); // NEVER self-increments
+    expect(pill?.textContent).toContain("45s"); // 3s measured + 42s elapsed
+    expect(pill?.className).toContain("tone-ok");
+  });
+
+  test("renders the honest awaiting chip when no reading exists", () => {
+    const { container } = render(<ChainTicker chain={undefined} probe={undefined} now={() => T0} />);
+    const pill = container.querySelector(".hm-chain-pill");
+    expect(pill?.textContent).toContain("chain · —");
+    expect(pill?.className).toContain("tone-awaiting");
+  });
+
+  test("stale reading renders dashed (is-stale) and drops the confident green", () => {
+    const { container } = render(
+      <ChainTicker chain={chain} probe={okProbe} pollError now={() => T0 + 5_000} />,
+    );
+    const pill = container.querySelector(".hm-chain-pill");
+    expect(pill?.className).toContain("is-stale");
+    expect(pill?.className).toContain("tone-awaiting");
+  });
+});

--- a/packages/monitor-ui/src/components/ChainTicker.tsx
+++ b/packages/monitor-ui/src/components/ChainTicker.tsx
@@ -1,0 +1,52 @@
+// ChainTicker — the block-height chip that sits beside the Live clock in the
+// TopStrip. Data comes from the product-health poll (ChainTick block); the
+// visual contract is `.hm-chain-pill` in styles/monitor.css.
+//
+// The height NEVER self-increments — only the age ticks (1s interval), and all
+// display logic lives in the pure deriveChainTicker() so it unit-tests without
+// a DOM or a real clock.
+
+import { useEffect, useState } from "react";
+import type { ChainTick, ProductHealthProbe } from "../lib/monitor/product-health.js";
+import { deriveChainTicker } from "../lib/monitor/chain-ticker.js";
+
+export type ChainTickerProps = {
+  chain?: ChainTick;
+  /** The chain_height probe (tone authority). */
+  probe?: ProductHealthProbe;
+  /** True when the product-health poll is currently failing. */
+  pollError?: boolean;
+  /** Clock injection for tests; defaults to Date.now. */
+  now?: () => number;
+};
+
+export function ChainTicker({ chain, probe, pollError, now = () => Date.now() }: ChainTickerProps) {
+  const [nowMs, setNowMs] = useState(() => now());
+  useEffect(() => {
+    setNowMs(now());
+    const timer = setInterval(() => setNowMs(now()), 1_000);
+    return () => clearInterval(timer);
+  }, [now]);
+
+  const view = deriveChainTicker({ chain, probe, pollError: Boolean(pollError), nowMs });
+  if (view.kind === "awaiting") {
+    return (
+      <span className="hm-chain-pill tone-awaiting" role="status" aria-label={view.title} title={view.title}>
+        <span className="ledge" aria-hidden />
+        chain · —
+      </span>
+    );
+  }
+  return (
+    <span
+      className={`hm-chain-pill tone-${view.tone}${view.stale ? " is-stale" : ""}`}
+      role="status"
+      aria-label={view.title}
+      title={view.title}
+    >
+      <span className="ledge" aria-hidden />
+      {view.heightLabel}
+      <span className="hm-chain-age">· {view.ageLabel}</span>
+    </span>
+  );
+}

--- a/packages/monitor-ui/src/components/TopStrip.test.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.test.tsx
@@ -204,4 +204,28 @@ describe("TopStrip", () => {
     expect(getByText("unknown · task_queue_unavailable")).toBeTruthy();
     expect(getByText("Dispatch ? of 10")).toBeTruthy();
   });
+
+  test("renders the chain ticker beside the Live pill when chainTick is provided", () => {
+    const t0 = 1_700_000_000_000;
+    const { container } = render(
+      <TopStrip
+        counts={calmCounts}
+        liveAt="14:32:08"
+        chainTick={{
+          chain: { height: 18_812_345, observedAtMs: t0, blockAgeSec: 3, lastAdvanceAtMs: t0, freshSeconds: 600 },
+          probe: { name: "chain_height", status: "ok", detail: "block #18,812,345 · 3s old", sparkline: ["ok"] },
+          now: () => t0,
+        }}
+      />,
+    );
+    const pill = container.querySelector(".hm-chain-pill");
+    expect(pill?.textContent).toContain("#18,812,345");
+    // Sits in the top-right cluster, beside the Live clock.
+    expect(pill?.closest(".hm-top-right")?.textContent).toContain("Live · 14:32:08");
+  });
+
+  test("shows no chain chip at all when chainTick is absent (monitoring off)", () => {
+    const { container } = render(<TopStrip counts={calmCounts} />);
+    expect(container.querySelector(".hm-chain-pill")).toBeNull();
+  });
 });

--- a/packages/monitor-ui/src/components/TopStrip.tsx
+++ b/packages/monitor-ui/src/components/TopStrip.tsx
@@ -11,6 +11,7 @@
 
 import type { KPICounts } from "../lib/monitor/board-state.js";
 import type { AutomationHealth } from "../lib/monitor/board-cache.js";
+import { ChainTicker, type ChainTickerProps } from "./ChainTicker.js";
 
 export type TopStripProps = {
   /** Current KPI counts from `kpiCounts(cards)`. */
@@ -26,9 +27,12 @@ export type TopStripProps = {
   /** When provided (Ops surface), the KPI cluster shows pillar-status chips
       instead of the delivery lane counts — so the frame stays ops-relevant. */
   opsPillars?: Array<{ label: string; tone: "ok" | "degraded" | "red" | "awaiting" }>;
+  /** When provided, renders the block-height ticker beside the Live clock
+      (data from the product-health poll; absent → no chip at all). */
+  chainTick?: ChainTickerProps;
 };
 
-export function TopStrip({ counts, liveAt, deployHealth = "OK", automationHealth, onRefresh, opsPillars }: TopStripProps) {
+export function TopStrip({ counts, liveAt, deployHealth = "OK", automationHealth, onRefresh, opsPillars, chainTick }: TopStripProps) {
   return (
     <div className="hm-top" role="banner">
       <div className="hm-brand">
@@ -72,6 +76,7 @@ export function TopStrip({ counts, liveAt, deployHealth = "OK", automationHealth
       </div>
 
       <div className="hm-top-right">
+        {chainTick ? <ChainTicker {...chainTick} /> : null}
         <span className="hm-deploy-pill" aria-label={liveAt ? `Live as of ${liveAt}` : "Live indicator"}>
           <span className="ledge" aria-hidden />
           Live · {liveAt ?? "—"}

--- a/packages/monitor-ui/src/lib/monitor/chain-ticker.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/chain-ticker.test.ts
@@ -1,0 +1,97 @@
+// Chain-ticker derivation — the honesty contract, tested deterministically:
+// the height never changes client-side; only the age ticks; staleness dulls a
+// green but never softens an alarm.
+
+import { describe, expect, test } from "vitest";
+import { deriveChainTicker } from "./chain-ticker.js";
+import type { ChainTick, ProductHealthProbe } from "./product-health.js";
+
+const T0 = 1_700_000_000_000;
+
+const okProbe: ProductHealthProbe = {
+  name: "chain_height",
+  status: "ok",
+  detail: "block #18,812,345 · 3s old",
+  sparkline: ["ok"],
+};
+
+function tick(overrides: Partial<ChainTick> = {}): ChainTick {
+  return { height: 18_812_345, observedAtMs: T0, blockAgeSec: 3, lastAdvanceAtMs: T0, freshSeconds: 600, ...overrides };
+}
+
+describe("deriveChainTicker", () => {
+  test("awaiting when no chain block is present (never a fabricated number)", () => {
+    const view = deriveChainTicker({ chain: undefined, probe: okProbe, nowMs: T0 });
+    expect(view.kind).toBe("awaiting");
+  });
+
+  test("awaiting on a non-positive height", () => {
+    expect(deriveChainTicker({ chain: tick({ height: 0 }), probe: okProbe, nowMs: T0 }).kind).toBe("awaiting");
+    expect(deriveChainTicker({ chain: tick({ height: Number.NaN }), probe: okProbe, nowMs: T0 }).kind).toBe("awaiting");
+  });
+
+  test("formats the observed height and starts the age from the measured block age", () => {
+    const view = deriveChainTicker({ chain: tick(), probe: okProbe, nowMs: T0 });
+    expect(view).toMatchObject({ kind: "ready", heightLabel: "#18,812,345", tone: "ok", stale: false });
+    if (view.kind === "ready") expect(view.ageSeconds).toBe(3);
+  });
+
+  test("the age ticks with the clock; the height NEVER self-increments", () => {
+    const later = deriveChainTicker({ chain: tick(), probe: okProbe, nowMs: T0 + 42_000 });
+    expect(later.kind).toBe("ready");
+    if (later.kind === "ready") {
+      expect(later.heightLabel).toBe("#18,812,345"); // same block — no invented advance
+      expect(later.ageSeconds).toBe(45); // 3s measured + 42s elapsed
+      expect(later.ageLabel).toBe("45s");
+    }
+  });
+
+  test("falls back to the last-advance tracker when no measured block age exists", () => {
+    const chain = tick({ blockAgeSec: null, lastAdvanceAtMs: T0 - 30_000 });
+    const view = deriveChainTicker({ chain, probe: okProbe, nowMs: T0 + 10_000 });
+    expect(view.kind).toBe("ready");
+    if (view.kind === "ready") expect(view.ageSeconds).toBe(40); // 30s at observation + 10s since
+  });
+
+  test("weakest fallback: age = time since the reading itself", () => {
+    const chain = tick({ blockAgeSec: null, lastAdvanceAtMs: null });
+    const view = deriveChainTicker({ chain, probe: okProbe, nowMs: T0 + 20_000 });
+    expect(view.kind).toBe("ready");
+    if (view.kind === "ready") expect(view.ageSeconds).toBe(20);
+  });
+
+  test("stale past the producer's freshness window downgrades ok to telemetry-gray", () => {
+    const view = deriveChainTicker({ chain: tick(), probe: okProbe, nowMs: T0 + 601_000 });
+    expect(view.kind).toBe("ready");
+    if (view.kind === "ready") {
+      expect(view.stale).toBe(true);
+      expect(view.tone).toBe("awaiting"); // not confidently green on old data
+    }
+  });
+
+  test("staleness never softens an alarm — a red probe stays red", () => {
+    const redProbe: ProductHealthProbe = { ...okProbe, status: "red", detail: "chain not advancing" };
+    const view = deriveChainTicker({ chain: tick(), probe: redProbe, nowMs: T0 + 601_000 });
+    expect(view.kind).toBe("ready");
+    if (view.kind === "ready") {
+      expect(view.stale).toBe(true);
+      expect(view.tone).toBe("red");
+    }
+  });
+
+  test("a failing product-health poll marks the reading stale immediately", () => {
+    const view = deriveChainTicker({ chain: tick(), probe: okProbe, pollError: true, nowMs: T0 + 1_000 });
+    expect(view.kind).toBe("ready");
+    if (view.kind === "ready") {
+      expect(view.stale).toBe(true);
+      expect(view.tone).toBe("awaiting");
+    }
+  });
+
+  test("probe tone authority: degraded probe renders a degraded chip", () => {
+    const degradedProbe: ProductHealthProbe = { ...okProbe, status: "degraded" };
+    const view = deriveChainTicker({ chain: tick(), probe: degradedProbe, nowMs: T0 });
+    expect(view.kind).toBe("ready");
+    if (view.kind === "ready") expect(view.tone).toBe("degraded");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/chain-ticker.ts
+++ b/packages/monitor-ui/src/lib/monitor/chain-ticker.ts
@@ -1,0 +1,83 @@
+// Chain ticker — pure derivation for the TopStrip block-height chip.
+//
+// Honesty contract (truth-boundary): the HEIGHT is always the producer's last
+// observed value — it never self-increments in the browser. Only the AGE ticks
+// client-side, anchored to the observation the producer reported. A dead poll
+// or a frozen chain makes the age grow and the tone go stale-gray; the ticker
+// never invents a newer block and never stays confidently green on old data.
+//
+// Kept pure (no Date.now, no DOM): callers pass `nowMs`, so every state is
+// deterministic to unit-test — same discipline as ops-model.ts.
+
+import type { ChainTick, ProductHealthProbe } from "./product-health.js";
+import { probeOpsTone, formatDuration, type OpsTone } from "./ops-model.js";
+
+export type ChainTickerView =
+  | {
+      kind: "ready";
+      /** e.g. "#18,812,345" — the last observed height, formatted. */
+      heightLabel: string;
+      /** e.g. "45s" / "7m" — age of the reading, ticking client-side. */
+      ageLabel: string;
+      ageSeconds: number;
+      tone: OpsTone;
+      /** Reading older than the producer's freshness window (or the poll is
+       *  failing) — rendered visibly stale, never confidently green. */
+      stale: boolean;
+      /** Tooltip / aria text spelling out exactly what is shown. */
+      title: string;
+    }
+  | { kind: "awaiting"; title: string };
+
+const NUM = new Intl.NumberFormat("en-US");
+
+export function deriveChainTicker(input: {
+  chain: ChainTick | undefined;
+  /** The chain_height probe — the tone authority (ok/degraded/red/awaiting). */
+  probe: ProductHealthProbe | undefined;
+  /** True when the product-health poll itself is currently failing. */
+  pollError?: boolean;
+  nowMs: number;
+}): ChainTickerView {
+  const { chain, probe, pollError = false, nowMs } = input;
+  if (!chain || !Number.isFinite(chain.height) || chain.height <= 0) {
+    return { kind: "awaiting", title: "Chain height not reported yet — awaiting the next product-health check." };
+  }
+
+  // Age = (block age at observation, when the chain-matched RPC measured it)
+  //     + (time elapsed since the observation), ticking locally.
+  // Fallbacks get progressively weaker but stay honest — the title says which
+  // meaning applies.
+  const sinceObservedSec = Math.max(0, (nowMs - chain.observedAtMs) / 1000);
+  let baseAgeSec: number | null = null;
+  let ageMeaning: string;
+  if (typeof chain.blockAgeSec === "number" && chain.blockAgeSec >= 0) {
+    baseAgeSec = chain.blockAgeSec;
+    ageMeaning = "latest block age";
+  } else if (typeof chain.lastAdvanceAtMs === "number" && chain.lastAdvanceAtMs <= chain.observedAtMs) {
+    baseAgeSec = Math.max(0, (chain.observedAtMs - chain.lastAdvanceAtMs) / 1000);
+    ageMeaning = "since the height last advanced";
+  } else {
+    ageMeaning = "since this height was read";
+  }
+  const ageSeconds = (baseAgeSec ?? 0) + sinceObservedSec;
+
+  const staleWindow = typeof chain.freshSeconds === "number" && chain.freshSeconds > 0 ? chain.freshSeconds : undefined;
+  const stale = pollError || (staleWindow !== undefined && ageSeconds > staleWindow);
+
+  // Tone: the probe stays the single authority. Staleness only DOWNGRADES a
+  // green to telemetry-gray ("we don't currently know"); a degraded/red/awaiting
+  // verdict passes through — stale data never softens an alarm.
+  let tone: OpsTone = probe ? probeOpsTone(probe) : "awaiting";
+  if (stale && tone === "ok") tone = "awaiting";
+
+  const heightLabel = `#${NUM.format(Math.floor(chain.height))}`;
+  const ageLabel = formatDuration(ageSeconds * 1000);
+  const title =
+    `Block ${heightLabel} — last height observed by product-health` +
+    ` · ${ageLabel} ${ageMeaning}` +
+    (stale ? " · READING STALE (age exceeds the probe freshness window or the poll is failing)" : "") +
+    " · the height only changes when a new check lands; it never counts up on its own.";
+
+  return { kind: "ready", heightLabel, ageLabel, ageSeconds, tone, stale, title };
+}

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -104,6 +104,21 @@ export interface HealthHistory {
 
 export type OpsNetwork = "testnet" | "mainnet" | "unknown";
 
+/** Structured reading behind the chain_height probe (mirrors the backend's
+ *  ChainTickData) — drives the TopStrip block ticker. Absent → awaiting-data. */
+export interface ChainTick {
+  /** Block height as reported by the product's /health at the last check. */
+  height: number;
+  /** Epoch ms when that height was observed (server clock). */
+  observedAtMs: number;
+  /** Age (s) of the latest block at observation; null = not measurable. */
+  blockAgeSec?: number | null;
+  /** Epoch ms when the height was last seen to advance (tracker fallback). */
+  lastAdvanceAtMs?: number | null;
+  /** Producer's freshness window (s) — the ticker's stale threshold. */
+  freshSeconds?: number;
+}
+
 export interface ProductHealth {
   /** false = the heartbeat routine is off (honest "monitoring off", not a green). */
   enabled: boolean;
@@ -115,6 +130,7 @@ export interface ProductHealth {
   // ── optional structured blocks (forward-compat) ──
   chainId?: number | null;
   network?: OpsNetwork;
+  chain?: ChainTick;
   solvency?: SolvencySnapshot;
   flow?: MoneyPathSnapshot;
   history?: HealthHistory;

--- a/packages/monitor-ui/src/styles/monitor.css
+++ b/packages/monitor-ui/src/styles/monitor.css
@@ -300,6 +300,50 @@ body { margin: 0; }
   box-shadow: 0 0 0 3px rgba(30,102,66,0.18);
   animation: hm-pulse 2.4s infinite;
 }
+/* Block ticker — sits beside the Live clock. Same pill grammar as
+   .hm-deploy-pill; tabular numerals so the ticking age doesn't jitter the
+   width. The ledge pulses ONLY on tone-ok: a stale or awaiting reading must
+   not radiate liveness it doesn't have. */
+.hm-chain-pill {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 6px 11px;
+  border-radius: 999px;
+  background: var(--hm-sage-wash);
+  border: 1px solid rgba(30,102,66,0.18);
+  color: var(--hm-sage-deep);
+  font-family: var(--font-display);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.08em !important;
+  font-variant-numeric: tabular-nums;
+}
+.hm-chain-pill .ledge {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--hm-sage);
+  box-shadow: 0 0 0 3px rgba(30,102,66,0.18);
+}
+.hm-chain-pill.tone-ok .ledge { animation: hm-pulse 2.4s infinite; }
+.hm-chain-pill .hm-chain-age { font-weight: 650; opacity: 0.85; }
+.hm-chain-pill.tone-degraded {
+  background: var(--hm-amber-wash);
+  border-color: var(--hm-amber-ring);
+  color: var(--hm-amber-deep);
+}
+.hm-chain-pill.tone-degraded .ledge { background: var(--hm-amber); box-shadow: 0 0 0 3px rgba(167,97,34,0.20); }
+.hm-chain-pill.tone-red {
+  background: var(--hm-rose-soft);
+  border-color: rgba(162,58,58,0.35);
+  color: var(--hm-rose);
+}
+.hm-chain-pill.tone-red .ledge { background: var(--hm-rose); box-shadow: 0 0 0 3px rgba(162,58,58,0.20); }
+.hm-chain-pill.tone-awaiting {
+  background: var(--hm-paper-3);
+  border-color: var(--hm-line);
+  color: var(--hm-muted);
+}
+.hm-chain-pill.tone-awaiting .ledge { background: var(--hm-muted-soft); box-shadow: 0 0 0 3px var(--hm-line-soft); }
+.hm-chain-pill.is-stale { border-style: dashed; }
+
 @keyframes hm-pulse {
   0%, 100% { box-shadow: 0 0 0 3px rgba(30,102,66,0.16); }
   50%      { box-shadow: 0 0 0 5px rgba(30,102,66,0.06); }

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1489,9 +1489,29 @@ export interface PayoutEvidence {
   windowBlocks: number | null;
 }
 
+/** Structured reading behind the chain_height probe — drives the board's block
+ *  ticker (TopStrip, beside the clock). Emitted only when the product /health
+ *  reported a real height this cycle; absent otherwise, so the ticker renders
+ *  awaiting-data instead of a number nobody observed. */
+export interface ChainTickData {
+  /** Block height as reported by the product's /health this cycle. */
+  height: number;
+  /** Epoch ms when this cycle observed that height (server clock). */
+  observedAtMs: number;
+  /** Age (s) of the latest block per the chain-matched RPC at observation;
+   *  null = RPC absent/mismatched (UI falls back to lastAdvanceAtMs). */
+  blockAgeSec?: number | null;
+  /** Epoch ms when the cross-poll tracker last saw the height advance. */
+  lastAdvanceAtMs?: number | null;
+  /** The chain_height probe's freshness window (s). The UI's stale threshold
+   *  reads this so producer config stays the single authority. */
+  freshSeconds?: number;
+}
+
 export interface ProductHealthSnapshotBlocks {
   chainId?: number | null;
   network?: "testnet" | "mainnet" | "unknown";
+  chain?: ChainTickData;
   solvency?: SolvencySnapshotData;
   flow?: MoneyPathData;
 }
@@ -1652,6 +1672,20 @@ export async function collectProductHealthProbes(
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,
     network: resolveProductHealthNetwork(chainId),
+    // Block ticker data — same values the chain_height probe judged this cycle,
+    // structured instead of embedded in the detail string. Only emitted when a
+    // real height was observed (never a placeholder number).
+    ...(block !== undefined && block > 0
+      ? {
+          chain: {
+            height: block,
+            observedAtMs: chainCtx.nowMs,
+            blockAgeSec: blockAgeSec ?? null,
+            lastAdvanceAtMs: chainAdvance.lastAdvanceAtMs,
+            freshSeconds: config.chainMaxStaleSeconds,
+          },
+        }
+      : {}),
     ...(solvencyPools.length ? { solvency: { pools: solvencyPools } } : {}),
     ...(settlement
       ? {

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -744,6 +744,42 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
     expect(chainAdvance).toEqual({ lastBlock: 10612201, lastAdvanceAtMs: 1000 });
   });
 
+  it("emits the structured chain tick (height + observation + measured age) for the board ticker", async () => {
+    const { snapshot } = await collectProductHealthProbes(
+      cfg(),
+      combinedFetch({
+        healthBody: HEALTHY_BODY,
+        chainIdHex: CHAIN_ID_HEX,
+        blockTimestampHex: tsHex(10_000_000, 12),
+        gasHex: "0xDE0B6B3A7640000",
+        usdcHex: "0x989680",
+      }),
+      { nowMs: 10_000_000 },
+    );
+    expect(snapshot.chain).toBeDefined();
+    expect(snapshot.chain?.height).toBe(10612201);
+    expect(snapshot.chain?.observedAtMs).toBe(10_000_000);
+    expect(snapshot.chain?.blockAgeSec).toBe(12);
+    expect(snapshot.chain?.lastAdvanceAtMs).toBe(10_000_000);
+    expect(snapshot.chain?.freshSeconds).toBe(600);
+  });
+
+  it("omits the chain tick when /health reports no block height (never a placeholder number)", async () => {
+    const { snapshot } = await collectProductHealthProbes(
+      cfg(),
+      combinedFetch({
+        healthBody: { ...HEALTHY_BODY, components: { blockchain: { ok: true, enabled: true, signerConfigured: true } } },
+        chainIdHex: CHAIN_ID_HEX,
+        gasHex: "0xDE0B6B3A7640000",
+        usdcHex: "0x989680",
+      }),
+      { nowMs: 10_000_000 },
+    );
+    expect(snapshot.chain).toBeUndefined();
+    // The rest of the snapshot still assembles — the ticker gap never blanks the board.
+    expect(snapshot.chainId).toBe(420420417);
+  });
+
   it("assembles the structured snapshot: chainId / network / solvency, and flow when settlement is present", async () => {
     const { snapshot } = await collectProductHealthProbes(
       cfg(),


### PR DESCRIPTION
## What

The board's top strip gets a **block-height ticker chip** beside the `Live · HH:MM:SS` clock — the operator sees the chain moving (or honestly not moving) at a glance, in both Delivery and Ops surfaces.

```
[⏺ #18,812,345 · 45s]  [⏺ Live · 14:32:08]  [⟳ Refresh]
```

## How

**Producer** (`services/slack-operator/src/product-health.ts`): the chain_height probe already reads the height + measured block age every cycle — it just only emitted them inside the detail string. New `ChainTickData` on the snapshot blocks: `height`, `observedAtMs`, `blockAgeSec` (chain-matched RPC measurement), `lastAdvanceAtMs` (tracker fallback), `freshSeconds` (the probe's freshness window, so the UI stale threshold stays producer-authoritative). Emitted **only when a real height was observed** — never a placeholder. Zero new network calls.

**UI** (`packages/monitor-ui`): pure `deriveChainTicker()` (no Date.now, no DOM — ops-model discipline) + a thin `ChainTicker` component. TopStrip takes an optional `chainTick` prop; BoardView threads the product-health poll (+ its error state) into it.

## Honesty contract (truth-boundary)

- The **height never self-increments** in the browser. Only the age ticks (1s), anchored to the producer's observation. A new height appears only when a new check lands.
- **Stale** (age past the producer's window, or the poll failing) downgrades a confident green to telemetry-gray + dashed border — but **never softens** a degraded/red probe verdict.
- The ledge **pulses only on tone-ok** — a stale or awaiting chip cannot radiate liveness.
- Heartbeat routine off → **no chip at all** (not a fake one). Chain data absent → honest `chain · —` awaiting chip.
- Age semantics degrade explicitly (measured block age → since-last-advance → since-read), and the tooltip says which meaning applies.

## Tests

- `chain-ticker.test.ts` — 10 derivation cases: age math for all three fallbacks, height frozen across clock advance, stale downgrades green but red passes through, pollError → stale.
- `ChainTicker.test.tsx` — fake-timer render: age ticks 3s→45s while the height stays `#18,812,345`; awaiting + stale render states.
- `TopStrip.test.tsx` — chip renders beside the Live clock; absent entirely without the prop.
- `test/unit/product-health.test.ts` — producer emits the structured block (height/observation/measured age/window) and omits it when /health has no height.

Full repo suite: **2546 passed, 0 failed** · `tsc -b --force packages/* services/*`: **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)