### PR TITLE
fix(int2): make pilot Git verification portable on Linux CI

### DIFF
--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -1,8 +1,8 @@
 # INT-2 handback — automated supervised-dispatch suite
 
-**Status:** CI/authentication and model-environment fixes implemented; clean
-fast gates green; clean Docker re-gate exposed the separately flagged
-intermittent provider-mount failure below
+**Status:** CI authentication, model-environment, and hosted Linux Git ownership
+fixes implemented; fast gates and the real nine-case Docker/Postgres suite are
+green locally; hosted re-gate pending
 
 **Baseline:** `47de9f3bdb25eda7354297a951b9927368194791`
 
@@ -12,6 +12,137 @@ intermittent provider-mount failure below
 
 **Runtime authority change:** none; this adds evidence, operator scripts, tests,
 and CI wiring without changing dispatcher or kernel runtime code
+
+## Hosted Linux Git ownership amendment
+
+**Fix baseline:** `e7c21806b6e2a7a2b2a46863a0f63f31f927c0bb`
+
+**Source evidence:** GitHub Actions run `30476014572`, main
+`0b0b1d7f0470f1215ca27fea059fcaf11f6a4c13`, artifact
+`int2-supervised-dispatch-evidence` id `8733742749`, archive digest
+`sha256:6921c1c6f9a4556e5fe037ec099dac1d26fa433f57a6e5a6ce9e03f61469ab4b`.
+
+The deploy-key checkout, pin verification, databases, image build, dispatcher,
+script selection, tool dispatch, and tool completion were correct. The four
+failed cases all crossed the same remaining hosted-runner boundary:
+
+- the green, restart, and narrowed-authority cases wrote the expected file with
+  tool exit 0, then failed their required `git diff --check` with exit 129;
+- the negative case wrote its intended whitespace violation with tool exit 0,
+  but the in-run criterion returned exit 129 rather than the expected exit 2;
+- the uploaded criterion stderr was identical in all four cases:
+  `warning: Not a git repository. Use --no-index...`;
+- the evidence collector subsequently reconstructed each patch from the same
+  host workspace and ran the same criterion correctly, proving the repository
+  and mutation survived. The mismatch was specifically inside the sandbox.
+
+A controlled Linux-container reproduction established the cause. The pilot
+image has no `USER`, so the sandbox runs as root. A Git repository owned by the
+GitHub runner uid is bind-mounted at `/workspace`. With no trust entry,
+`git diff --check` emits the artifact's generic warning and returns 129;
+`git status` exposes the underlying
+`fatal: detected dubious ownership in repository`. Adding the exact
+system-level safe directory `/workspace` makes the same foreign-owned
+repository return exit 0. This was not SIGHUP, a missing verdict, or dispatcher
+failure.
+
+The amendment:
+
+- adds `safe.directory=/workspace` to the ceremony-only pilot image's system
+  Git config. It does not use `*`, trust another path, add a credential, change
+  the image user, or change the network-none runtime;
+- corrects the image comment: the sandbox runs as the image's default root
+  user, not as the host operator uid;
+- adds a real pre-case ownership probe. The script creates a self-contained Git
+  repository under `$HOME/.agent-runtime`, the same Docker-visible root the
+  pinned Harness uses, mounts it at `/workspace` under `--network none`, and
+  requires `git diff --check` to pass;
+- exits 26 with
+  `INT2_PILOT_GIT_OWNERSHIP_FAILED` before any case if that property fails, and
+  records `INT2_PILOT_GIT_OWNERSHIP_VERIFIED` when it holds;
+- prefix-validates cleanup of the disposable probe directory;
+- pins the exact `/workspace` trust entry, forbids a wildcard entry, and pins
+  both probe markers in the fast unit suite.
+
+No acceptance criterion, expected verdict, evidence invariant, fixture,
+capability, dispatcher path, kernel source, Harness pin, dependency, or lockfile
+changed.
+
+### Hosted Linux amendment gate output
+
+```text
+$ npm ci
+added 312 packages in 3s
+# exit 0
+
+$ npm run typecheck
+> tsc -b --pretty false packages/* services/*
+# exit 0
+
+$ npm test
+Test Files  204 passed | 2 skipped (206)
+Tests       2613 passed | 13 skipped (2626)
+Duration    13.83s
+# exit 0
+
+$ npm run build
+> tsc -b packages/* services/*
+# exit 0
+
+$ HARNESS_CHECKOUT=/Users/pascalkuriger/repo/agent-harness \
+    INT2_SUITE_EVIDENCE_DIR=/private/tmp/int2-suite-evidence-docker-mount-fix-3 \
+    scripts/ceremony/run-int2-automated-suite.sh
+INT2_PILOT_GIT_OWNERSHIP_VERIFIED
+✓ preflights the controlled red/green pair against a real tracked diff
+✓ keeps an unapproved task outside the production dispatchable set
+✓ refuses an approval-hash mismatch before claim or submit
+✓ rejects the negative fixture on its merits with no handoff
+✓ produces one verified, unactuated green handoff
+✓ restarts between submit and reconcile without duplicating the run
+✓ HALT cancels a bound live run and never creates a handoff
+✓ accepts a seven-capability profile with strictly narrower authority
+✓ rejects memory.propose in the outer production profile loader
+Test Files  1 passed (1)
+Tests       9 passed (9)
+Duration    142.00s
+INT-2 automated suite: 9 cases executed in 150s
+# exit 0
+```
+
+The evidence bootstrap terminates with:
+
+```text
+INT2_HARNESS_PIN_VERIFIED pin=0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2
+INT2_HARNESS_RUNTIME_READY
+INT2_PILOT_GIT_OWNERSHIP_VERIFIED
+INT2_CASES_STARTED expected=9
+INT2_CASES_COMPLETED executed=9 elapsed=150
+INT2_SUITE_EXIT_CODE=0
+```
+
+### Hosted Linux amendment decisions
+
+1. **Trust the fixed mount point, never every repository.** The container has
+   one network-disabled workspace mount. `/workspace` is the minimum Git trust
+   boundary that makes its checked-out metadata usable across host uid
+   mappings; `safe.directory=*` would be needlessly broad.
+2. **Keep the image's root user.** Selecting a fixed image uid would merely
+   exchange the Git refusal for cross-host write failures. The exact safe path
+   preserves the existing write behavior without adding authority.
+3. **Probe the property before the cases.** A static Dockerfile assertion alone
+   cannot prove the built image and bind mount work together. The runtime probe
+   turns the prior four-case ambiguity into one named bootstrap failure.
+4. **Use the Docker-visible home root for the probe.** A first local probe under
+   the script's `mktemp` root correctly failed because Colima does not share
+   that host path. Moving only the disposable probe under the same root used by
+   Harness makes the probe portable without changing Harness workspace
+   placement.
+
+### Hosted Linux amendment open questions
+
+- The exact GitHub-hosted re-gate remains pending until this branch is pushed.
+  Local gates exercise the complete mechanism, but the Linux uid split is the
+  environment that discriminates this fix.
 
 ## Re-gate amendment — CI checkout and cross-machine determinism
 

--- a/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
+++ b/docs/HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md
@@ -2,7 +2,7 @@
 
 **Status:** CI authentication, model-environment, and hosted Linux Git ownership
 fixes implemented; fast gates and the real nine-case Docker/Postgres suite are
-green locally; hosted re-gate pending
+green locally and on the GitHub-hosted Linux runner
 
 **Baseline:** `47de9f3bdb25eda7354297a951b9927368194791`
 
@@ -120,6 +120,28 @@ INT2_CASES_COMPLETED executed=9 elapsed=150
 INT2_SUITE_EXIT_CODE=0
 ```
 
+### GitHub-hosted re-gate
+
+Run `30478826796` at
+`0f8b7373acea503d1e07b38531468fbbb88fa4b7` reproduced the Linux uid split
+and passed:
+
+```text
+Typecheck and test                 success
+Docker build                       success
+INT-2 real dispatcher integration success
+Prove the suite did not skip       success
+Upload INT-2 evidence              success
+
+Test Files  1 passed (1)
+Tests       9 passed (9)
+Duration    170.55s
+INT-2 automated suite: 9 cases executed in 241s
+```
+
+The hosted evidence artifact is id `8734856204`, size `89,645` bytes, digest
+`sha256:dbce3fa64e50b98f502f143eb87267c5f3bf242eb6fbbbbc1f0281be0766bb3d`.
+
 ### Hosted Linux amendment decisions
 
 1. **Trust the fixed mount point, never every repository.** The container has
@@ -140,9 +162,7 @@ INT2_SUITE_EXIT_CODE=0
 
 ### Hosted Linux amendment open questions
 
-- The exact GitHub-hosted re-gate remains pending until this branch is pushed.
-  Local gates exercise the complete mechanism, but the Linux uid split is the
-  environment that discriminates this fix.
+None.
 
 ## Re-gate amendment — CI checkout and cross-machine determinism
 
@@ -366,9 +386,8 @@ precedence fix addresses.
 
 ### Re-gate open questions
 
-- Pascal must provision `INT2_HARNESS_DEPLOY_KEY` before the GitHub-hosted job
-  can pass. Absence is intentionally red and produces a named evidence
-  artifact.
+- Resolved: `INT2_HARNESS_DEPLOY_KEY` is provisioned. Hosted run `30478826796`
+  authenticated the pinned private checkout and completed all nine cases.
 - The intermittent local Docker mount observation above is outside this
   repository's runtime surface. If it reproduces on an otherwise controlled
   clean gate, it should become a separate kernel/provider finding rather than a

--- a/ops/Dockerfile.pilot
+++ b/ops/Dockerfile.pilot
@@ -33,12 +33,14 @@ FROM node:22-bookworm-slim
 # provider runs the container with no network.
 RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
+  && git config --system --add safe.directory /workspace \
   && rm -rf /var/lib/apt/lists/*
 
-# No USER directive: the ceremony runs the worker as the operator's own uid and
-# the workspace must share that identity. Introducing an image user (as the
-# application image does with uid 10001) is what produced the dubious-ownership
-# failure in the first attempt.
+# No USER directive: Harness starts this sandbox as the image's default root
+# user so it can write a bind-mounted workspace across both desktop and Linux
+# Docker hosts. On Linux CI the checkout remains owned by the runner uid, so Git
+# otherwise refuses it as dubious ownership. The system exception above trusts
+# only the fixed, network-disabled sandbox mount point — never a wildcard.
 
 WORKDIR /workspace
 CMD ["sleep", "infinity"]

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -12,6 +12,8 @@ _int2_evidence="${INT2_SUITE_EVIDENCE_DIR:-$_int2_root/evidence}"
 _int2_marker="$_int2_evidence/executed-count.txt"
 _int2_bootstrap_log="$_int2_evidence/bootstrap.log"
 _int2_started="$(date +%s)"
+_int2_docker_shared_root="${HOME:?}/.agent-runtime"
+_int2_git_probe=""
 
 _int2_cleanup() {
   _int2_exit="$?"
@@ -19,6 +21,11 @@ _int2_cleanup() {
     >> "$_int2_bootstrap_log" 2>/dev/null || true
   docker stop "$_int2_harness_db" "$_int2_reference_db" \
     >/dev/null 2>&1 || true
+  case "$_int2_git_probe" in
+    "$_int2_docker_shared_root"/int2-pilot-git-probe.*)
+      rm -rf "$_int2_git_probe"
+      ;;
+  esac
   rm -rf "$_int2_root"
 }
 trap _int2_cleanup EXIT INT TERM
@@ -116,6 +123,32 @@ docker build --quiet -f "$_int2_repo/ops/Dockerfile.pilot" \
 export INT2_PILOT_IMAGE="$(
   docker image inspect --format '{{.Id}}' "$_int2_image_tag"
 )"
+mkdir -p "$_int2_docker_shared_root"
+_int2_git_probe="$(
+  mktemp -d "$_int2_docker_shared_root/int2-pilot-git-probe.XXXXXX"
+)"
+git -C "$_int2_git_probe" init --quiet
+printf '%s\n' "INT-2 pilot Git ownership probe" \
+  > "$_int2_git_probe/tracked.txt"
+git -C "$_int2_git_probe" add tracked.txt
+git -C "$_int2_git_probe" \
+  -c user.name=int2-suite \
+  -c user.email=int2-suite.invalid \
+  commit --quiet -m "INT-2 pilot Git ownership probe"
+docker run --rm --network none \
+  --volume "$_int2_git_probe:/workspace" \
+  --workdir /workspace \
+  "$INT2_PILOT_IMAGE" \
+  /bin/sh -lc \
+    'test "$(git config --system --get-all safe.directory)" = "/workspace" && git diff --check' \
+  >> "$_int2_bootstrap_log" 2>&1 \
+  || {
+    echo "INT2_PILOT_GIT_OWNERSHIP_FAILED: pilot cannot run Git in the mounted workspace" \
+      | tee -a "$_int2_bootstrap_log" >&2
+    exit 26
+  }
+printf '%s\n' "INT2_PILOT_GIT_OWNERSHIP_VERIFIED" \
+  >> "$_int2_bootstrap_log"
 
 export INT2_SUITE_REQUIRED=1
 export INT2_REPOSITORY_ROOT="$_int2_repo"

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -27,6 +27,11 @@ const CHECKOUT_HELPER = path.join(
   SCRIPT_ROOT,
   "lib/int2-harness-checkout.sh",
 );
+const AUTOMATED_SUITE = path.join(
+  SCRIPT_ROOT,
+  "run-int2-automated-suite.sh",
+);
+const PILOT_DOCKERFILE = path.join(ROOT, "ops/Dockerfile.pilot");
 const OPERATOR_SCRIPTS = [
   "int2-bringup.sh",
   "int2-green-setup.sh",
@@ -248,5 +253,25 @@ describe("committed INT-2 ceremony mechanics", () => {
     expect(controlled).not.toHaveProperty(
       "HARNESS_TEST_MODEL_FACTORY_COUNTER",
     );
+  });
+
+  it("trusts only the fixed sandbox workspace and probes Git before running cases", async () => {
+    const [dockerfile, suite] = await Promise.all([
+      readFile(PILOT_DOCKERFILE, "utf8"),
+      readFile(AUTOMATED_SUITE, "utf8"),
+    ]);
+
+    expect(dockerfile).toContain(
+      "git config --system --add safe.directory /workspace",
+    );
+    expect(dockerfile).not.toMatch(
+      /safe\.directory\s+(?:"|')?\*(?:"|')?/u,
+    );
+    expect(suite).toContain("INT2_PILOT_GIT_OWNERSHIP_FAILED");
+    expect(suite).toContain("INT2_PILOT_GIT_OWNERSHIP_VERIFIED");
+    expect(suite).toContain(
+      'git config --system --get-all safe.directory',
+    );
+    expect(suite).toContain("git diff --check");
   });
 });


### PR DESCRIPTION
## What changed

- Mark only `/workspace` as a Git safe directory in the ceremony-only pilot image.
- Add a real pre-case bind-mount probe that requires the built image to expose exactly that trust entry and run `git diff --check` against a self-contained repository under the Docker-visible Harness home root.
- Fail bootstrap with the named `INT2_PILOT_GIT_OWNERSHIP_FAILED` error before any cases if the property is absent.
- Pin the exact path, prohibit a wildcard trust entry, and record the investigation and gates in the INT-2 handback.

## Root cause

[Main run 30476014572](https://github.com/depre-dev/averray-reference-agent/actions/runs/30476014572) proved checkout, databases, image build, dispatcher, script selection, and tool execution were healthy. The four git-verification cases all failed inside the sandbox with `git diff --check` exit 129.

On Linux, the pilot container runs as root while the bind-mounted standalone clone is owned by the GitHub runner uid. A controlled reproduction produces the artifact's generic `Not a git repository` / exit 129 output; `git status` reveals the underlying `detected dubious ownership`. The same repository passes once the protected system config trusts the single fixed mount point `/workspace`.

This is not a criterion relaxation: the negative case must still return its real formatting verdict and all green cases must still reach verified handoff.

## Checks

- `npm ci`
- `npm run typecheck`
- `npm test` — 204 files passed, 2 skipped; 2,613 tests passed, 13 skipped
- `npm run build`
- `docker compose --env-file ops/.env.example -f ops/compose.yml -f ops/compose.prod.yml config`
- Full local pinned-Harness Docker/Postgres INT-2 suite — 9/9 passed; 142.00s test duration, 150s wall time
- [Implementation run 30478826796](https://github.com/depre-dev/averray-reference-agent/actions/runs/30478826796) — typecheck/tests, Docker build, INT-2 9/9, non-skip proof, and evidence upload all passed
- [Final-head run 30479273811](https://github.com/depre-dev/averray-reference-agent/actions/runs/30479273811) — all three jobs passed again at `dcc1089`
- Final-head evidence artifact `8735048597`: 89,672 bytes, `sha256:ddfcae702727976d9f455445faa3992298d5b94d1a8af7bd498971f7b56f0952`

## Affected surfaces

- Ceremony pilot image
- INT-2 automated-suite bootstrap
- INT-2 unit regression pins and handback

No dispatcher production path, kernel source/pin, profile, capability, fixture, database migration, dependency, lockfile, secret, or production Compose service changed.

## Rollout / rollback

The pilot image is rebuilt only for the mandatory INT-2 CI/ceremony flow. Rollout is the normal merge-and-CI path; no VPS or secret change is required. Rollback is the implementation commit, but would restore the deterministic Linux exit-129 failure.