### PR TITLE
fix(int2): make section 3 fixture discriminating

### DIFF
--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -201,7 +201,8 @@ hash.
 `HARNESS_DISPATCH_READ_TIMEOUT_MS` is bounded to 1–30 seconds. Keep the
 15-second pilot default when the Harness CLI crosses a container boundary.
 
-The `lint-format` fixture uses only `git diff --check`, so it can run with
+The `lint-format` fixture uses only
+`test -n "$(git diff --numstat)" && git diff --check`, so it can run with
 `HARNESS_DISPATCH_DEP_CACHE_DIR` unset; leave it unset for that fixture. The
 `docs-fix`, `add-unit-test`, and `small-refactor` fixtures execute `npm`
 verification and require the exact offline cache. For one of those fixtures,
@@ -636,20 +637,115 @@ remains reproducible and unchanged.
 Proceed only if every scripted proof is green and the operator records a
 go/no-go of `go`.
 
+This paid run has an additional hard gate: the git-based criterion must be
+green through the actual containerized ceremony path. The host pre-flight
+below is necessary, but it does not lift that gate. Record evidence that a
+clean non-empty diff returns `exit_0`, trailing whitespace returns `exit_2`
+with the offence named, an empty diff returns `exit_1`, and neither `exit_128`
+nor `exit_129` occurs. While the container path still reproduces `exit_129`
+(the state recorded for #589), **stop here and do not export a model
+credential**. Only the operator may record the evidence reference and lift
+this gate.
+
 1. Stop the scripted worker.
-2. Unset `HARNESS_TEST_MODEL_SCRIPT`.
-3. Select one approved real-model endpoint and keep its credential only in the
-   worker's local environment. Do not paste it into evidence or CLI arguments:
+2. Unset every model credential, then run the free three-case pre-flight
+   against the real `lint-format` fixture and its pinned `baseRevision`. This
+   clones three clean checkouts and fails unless all three verdicts
+   discriminate exactly:
 
    ```sh
    unset HARNESS_TEST_MODEL_SCRIPT
+   unset HARNESS_MODEL_API_KEY
+   test -z "${HARNESS_MODEL_API_KEY:-}"
+
+   node "$REFERENCE_CHECKOUT/scripts/ceremony/int2-evidence.mjs" \
+     preflight-section3 --repository-root "$REFERENCE_CHECKOUT" \
+     > "$CEREMONY_ROOT/evidence/section3-preflight.json"
+
+   jq -e \
+     '.correct.exitCode == 0
+      and .incorrect.exitCode == 2
+      and (.incorrect.details | test("trailing whitespace"; "i"))
+      and .noChange.exitCode == 1
+      and .exit128Present == false
+      and .exit129Present == false' \
+     "$CEREMONY_ROOT/evidence/section3-preflight.json" > /dev/null
+   ```
+
+3. Select one approved real-model endpoint without exporting its credential.
+   Record its published uncached input and output rates in USD per million
+   tokens, plus the authoritative pricing URL:
+
+   ```sh
    export HARNESS_MODEL_ADAPTER=openai-compatible
    export HARNESS_MODEL_REF="<operator-approved-model>"
    export HARNESS_MODEL_BASE_URL="<operator-approved-endpoint>"
+   export SECTION3_INPUT_USD_PER_MILLION="<published-input-rate>"
+   export SECTION3_OUTPUT_USD_PER_MILLION="<published-output-rate>"
+   export SECTION3_RATE_SOURCE="<authoritative-pricing-url>"
+   ```
+
+4. The fixture's `modelTokens: 8000` is the operative spend limit.
+   `estimatedUsdMicros` is `null` and is **not** a monetary enforcement
+   control. Compute a conservative worst case by charging all 8,000 tokens at
+   the higher published rate, then record the model identity, endpoint host,
+   rates, source, and result before approval:
+
+   ```sh
+   export SECTION3_TOKEN_CAP=8000
+   export SECTION3_WORST_CASE_USD="$(
+     node --input-type=module -e '
+       const [tokens, inputRate, outputRate] = process.argv.slice(1).map(Number);
+       if (![tokens, inputRate, outputRate].every(Number.isFinite)
+           || tokens <= 0 || inputRate < 0 || outputRate < 0) {
+         throw new Error("invalid token cap or published model rate");
+       }
+       process.stdout.write(
+         (tokens * Math.max(inputRate, outputRate) / 1_000_000).toFixed(6),
+       );
+     ' "$SECTION3_TOKEN_CAP" \
+       "$SECTION3_INPUT_USD_PER_MILLION" \
+       "$SECTION3_OUTPUT_USD_PER_MILLION"
+   )"
+   export SECTION3_ENDPOINT_HOST="$(
+     node --input-type=module -e \
+       'process.stdout.write(new URL(process.argv[1]).host)' \
+       "$HARNESS_MODEL_BASE_URL"
+   )"
+
+   jq -n \
+     --arg modelRef "$HARNESS_MODEL_REF" \
+     --arg endpointHost "$SECTION3_ENDPOINT_HOST" \
+     --arg rateSource "$SECTION3_RATE_SOURCE" \
+     --argjson tokenCap "$SECTION3_TOKEN_CAP" \
+     --argjson inputUsdPerMillion "$SECTION3_INPUT_USD_PER_MILLION" \
+     --argjson outputUsdPerMillion "$SECTION3_OUTPUT_USD_PER_MILLION" \
+     --argjson worstCaseUsd "$SECTION3_WORST_CASE_USD" \
+     '{
+       modelRef: $modelRef,
+       endpointHost: $endpointHost,
+       rateSource: $rateSource,
+       tokenCap: $tokenCap,
+       inputUsdPerMillion: $inputUsdPerMillion,
+       outputUsdPerMillion: $outputUsdPerMillion,
+       worstCaseUsd: $worstCaseUsd,
+       calculation: "tokenCap * max(inputRate, outputRate) / 1000000"
+     }' > "$CEREMONY_ROOT/evidence/section3-model-budget.json"
+   ```
+
+   Stop if the model, endpoint host, published-rate source, or computed ceiling
+   is missing. The evidence file must never contain the endpoint path, query,
+   user information, or credential.
+5. Only after the container-path gate, fixture pre-flight, and budget evidence
+   are green, keep `HARNESS_MODEL_API_KEY` in the worker's local environment.
+   Never paste it into chat or evidence, print it, commit it, or pass it as a
+   CLI argument:
+
+   ```sh
    export HARNESS_MODEL_API_KEY="<secret-kept-out-of-evidence>"
    ```
 
-4. Prove **no** Harness worker is already running, then start exactly one:
+6. Prove **no** Harness worker is already running, then start exactly one:
 
    ```sh
    pgrep -af "harness worker" && exit 1 || true
@@ -659,16 +755,22 @@ go/no-go of `go`.
    `HARNESS_TEST_MODEL_SCRIPT` and can claim this run, producing a result
    attributed to the wrong fixture. "Start one" is not the same as "only one
    exists" — assert the second.
-5. Propose exactly one `lint-format` or `docs-fix` task with a new work-item id
-   and a near-term deadline. Verify the fixture remains low-risk, deny-network,
-   `maxChildren: 0`, `maxConcurrentChildren: 0`, and within its fixed elapsed,
-   token, tool-call, and cost budget.
-6. Approve once with `--confirm`, then explicitly enable and start one
+7. Propose exactly one `lint-format` task with a new work-item id and a
+   near-term deadline. `docs-fix` is prohibited for §3 because its search
+   criterion scans no files. Verify `lint-format` remains low-risk,
+   deny-network, `maxChildren: 0`, `maxConcurrentChildren: 0`, and within its
+   fixed 60-second, 8,000-token, and 30-tool-call limits. Confirm its
+   `estimatedUsdMicros` is `null`; do not describe it as an enforced cost
+   budget.
+8. Approve once with `--confirm`, then explicitly enable and start one
    dispatcher.
-7. Capture the run status, events, deliverables, manifest hashes, actual budget
-   use, verifier result, task projection, decisions, binding, heartbeat, and
-   alerts. The ceremony does not open a PR even when verification succeeds.
-8. Stop the dispatcher immediately after the task reaches a terminal
+9. Capture the run status, events, deliverables, manifest hashes, actual tokens
+   against the 8,000-token cap, wall time against 60 seconds, tool calls
+   against 30, resolved model identity, the verifier's own `details` payload,
+   task projection, decisions, binding, heartbeat, and alerts **before
+   judging the result**. The ceremony does not open a PR even when verification
+   succeeds.
+10. Stop the dispatcher immediately after the task reaches a terminal
    lifecycle, then set `HARNESS_DISPATCH_ENABLED=false`.
 
 Do not run a second real-model task to improve the result. A failure is

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -19,6 +19,8 @@ export const INT2_HARNESS_PIN =
   "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2";
 export const INT2_EXPECTED_PATH =
   "docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
+export const INT2_SECTION3_CRITERION =
+  "test -n \"$(git diff --numstat)\" && git diff --check";
 export const INT2_PILOT_CAPABILITIES = Object.freeze([
   "fs.read_file",
   "fs.write_file",
@@ -46,6 +48,10 @@ const GREEN_TOOL_COMMAND =
   "printf '%b' '\\nINT-2 green-path proof line, cleanly formatted.\\n' >> docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
 const NEGATIVE_TOOL_COMMAND =
   "printf '%b' '\\nINT-2 negative-path proof line with trailing whitespace.   \\n' >> docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
+const SECTION3_CORRECT_TOOL_COMMAND =
+  "printf '%b' '\\nA paid real-model ceremony requires a three-case acceptance pre-flight before credentials are exported.\\n' >> docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
+const SECTION3_INCORRECT_TOOL_COMMAND =
+  "printf '%b' '\\nA paid real-model ceremony requires a three-case acceptance pre-flight before credentials are exported.   \\n' >> docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
 const HALT_TOOL_COMMAND = "sleep 30";
 const CASE_EXPECTATIONS = Object.freeze({
   green: Object.freeze({
@@ -290,13 +296,13 @@ export async function verifyScriptedPairPreflight({
   const [green, negative] = await Promise.all([
     runFixtureCriterion({
       repositoryRoot,
-      command: greenAction.command,
+      changeCommand: greenAction.command,
       expectedPath: greenAction.targetPath,
       baseRevision: greenFence.repository.baseRevision,
     }),
     runFixtureCriterion({
       repositoryRoot,
-      command: negativeAction.command,
+      changeCommand: negativeAction.command,
       expectedPath: negativeAction.targetPath,
       baseRevision: negativeFence.repository.baseRevision,
     }),
@@ -332,6 +338,138 @@ export async function verifyScriptedPairPreflight({
       numstat: negative.numstat,
       exitCode: negative.exitCode,
     },
+  };
+}
+
+export async function verifySection3Preflight({
+  repositoryRoot,
+  fixturePath = path.join(
+    repositoryRoot,
+    "test/fixtures/agent-integration/ceremony/lint-format.json",
+  ),
+} = {}) {
+  if (!repositoryRoot) {
+    throw new Error("repositoryRoot is required");
+  }
+  const fixture = await readJson(fixturePath);
+  const criterion = fixture?.acceptanceCriteria?.[0]?.command;
+  assertEqual(
+    fixture?.acceptanceCriteria,
+    [{
+      id: "format-command",
+      type: "command",
+      command: INT2_SECTION3_CRITERION,
+      required: true,
+    }],
+    "section 3 fixture does not use the discriminating criterion",
+  );
+  if (
+    fixture?.taskKind !== "lint_format"
+    || typeof fixture?.objective !== "string"
+    || !fixture.objective.startsWith("Append ")
+    || !fixture.objective.includes(INT2_EXPECTED_PATH)
+  ) {
+    throw new Error(
+      "section 3 fixture objective is not a tracked-file construction",
+    );
+  }
+  assertEqual(
+    fixture?.budget,
+    {
+      elapsedSeconds: 60,
+      modelTokens: 8000,
+      toolCalls: 30,
+      estimatedUsdMicros: null,
+    },
+    "section 3 fixture budget changed",
+  );
+
+  const baseRevision = fixture?.repository?.baseRevision;
+  if (
+    typeof baseRevision !== "string"
+    || !/^[0-9a-f]{40}$/u.test(baseRevision)
+  ) {
+    throw new Error("section 3 fixture baseRevision is not a full commit SHA");
+  }
+
+  const [correct, incorrect, noChange] = await Promise.all([
+    runFixtureCriterion({
+      repositoryRoot,
+      changeCommand: SECTION3_CORRECT_TOOL_COMMAND,
+      criterionCommand: criterion,
+      expectedPath: INT2_EXPECTED_PATH,
+      baseRevision,
+    }),
+    runFixtureCriterion({
+      repositoryRoot,
+      changeCommand: SECTION3_INCORRECT_TOOL_COMMAND,
+      criterionCommand: criterion,
+      expectedPath: INT2_EXPECTED_PATH,
+      baseRevision,
+    }),
+    runFixtureCriterion({
+      repositoryRoot,
+      criterionCommand: criterion,
+      expectedPath: INT2_EXPECTED_PATH,
+      baseRevision,
+    }),
+  ]);
+
+  const cases = [correct, incorrect, noChange];
+  if (cases.some((result) => result.baseRevision !== baseRevision)) {
+    throw new Error("section 3 pre-flight did not run at the fixture revision");
+  }
+  if (cases.some((result) => result.exitCode === 128)) {
+    throw new Error("section 3 criterion produced exit_128");
+  }
+  if (cases.some((result) => result.exitCode === 129)) {
+    throw new Error("section 3 criterion produced exit_129");
+  }
+  if (correct.numstat.length === 0 || correct.exitCode !== 0) {
+    throw new Error(
+      `section 3 correct change was not accepted with exit_0; got exit_${correct.exitCode}`,
+    );
+  }
+  if (incorrect.numstat.length === 0 || incorrect.exitCode !== 2) {
+    throw new Error(
+      `section 3 incorrect change was not refused with exit_2; got exit_${incorrect.exitCode}`,
+    );
+  }
+  const incorrectDetails = `${incorrect.stdout}\n${incorrect.stderr}`.trim();
+  if (!/trailing whitespace/iu.test(incorrectDetails)) {
+    throw new Error(
+      "section 3 incorrect change did not name trailing whitespace",
+    );
+  }
+  if (noChange.numstat.length !== 0 || noChange.exitCode !== 1) {
+    throw new Error(
+      `section 3 empty diff was not refused with exit_1; got exit_${noChange.exitCode}`,
+    );
+  }
+
+  return {
+    fixture: "lint-format",
+    baseRevision,
+    targetPath: INT2_EXPECTED_PATH,
+    criterion,
+    correct: {
+      numstat: correct.numstat,
+      exitCode: correct.exitCode,
+      reason: "clean_non_empty_diff",
+    },
+    incorrect: {
+      numstat: incorrect.numstat,
+      exitCode: incorrect.exitCode,
+      reason: "trailing_whitespace",
+      details: incorrectDetails,
+    },
+    noChange: {
+      numstat: noChange.numstat,
+      exitCode: noChange.exitCode,
+      reason: "empty_diff",
+    },
+    exit128Present: false,
+    exit129Present: false,
   };
 }
 
@@ -999,7 +1137,8 @@ async function inspectWorkspacePatch({
 
 async function runFixtureCriterion({
   repositoryRoot,
-  command: fixtureCommand,
+  changeCommand,
+  criterionCommand = "git diff --check",
   expectedPath,
   baseRevision,
 }) {
@@ -1034,20 +1173,28 @@ async function runFixtureCriterion({
         `append target is not tracked in the checkout: ${expectedPath}`,
       );
     }
-    await command("sh", ["-c", fixtureCommand], { cwd: checkout });
+    const head = (await command("git", [
+      "-C",
+      checkout,
+      "rev-parse",
+      "HEAD",
+    ])).stdout.trim();
+    if (changeCommand) {
+      await command("sh", ["-c", changeCommand], { cwd: checkout });
+    }
     const numstat = (await command("git", [
       "-C",
       checkout,
       "diff",
       "--numstat",
     ])).stdout.trim();
-    const criterion = await command("git", [
-      "-C",
-      checkout,
-      "diff",
-      "--check",
-    ], { allowFailure: true });
+    const criterion = await command(
+      "sh",
+      ["-c", criterionCommand],
+      { cwd: checkout, allowFailure: true },
+    );
     return {
+      baseRevision: head,
       numstat,
       exitCode: criterion.code,
       stdout: criterion.stdout,
@@ -1414,6 +1561,13 @@ async function runCli(argv) {
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
     return;
   }
+  if (commandName === "preflight-section3") {
+    const result = await verifySection3Preflight({
+      repositoryRoot: values["repository-root"] ?? process.cwd(),
+    });
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
   if (commandName === "verify") {
     const caseName = values.case;
     const evidence = await collectInt2Evidence({
@@ -1435,6 +1589,8 @@ async function runCli(argv) {
   }
   throw new Error(
     "Usage: int2-evidence.mjs preflight-pair --repository-root <path>\n"
+    + "   or: int2-evidence.mjs preflight-section3 "
+    + "--repository-root <path>\n"
     + "   or: int2-evidence.mjs verify --case <name> --work-item <id> "
     + "--run-id <id> [--evidence-dir <path>]",
   );

--- a/test/fixtures/agent-integration/ceremony/lint-format.json
+++ b/test/fixtures/agent-integration/ceremony/lint-format.json
@@ -2,9 +2,9 @@
   "workItemId": "ceremony-lint-format-001",
   "correlationId": "ceremony-lint-format-001",
   "taskKind": "lint_format",
-  "title": "Repair one bounded formatting defect",
-  "objective": "Correct a small formatting-only defect within the pilot path allowlist.",
-  "whyNow": "The supervised-dispatch ceremony needs a minimal lint and formatting family.",
+  "title": "Add one bounded paid-ceremony pre-flight note",
+  "objective": "Append one concise paragraph to docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md stating that a paid real-model ceremony requires a three-case acceptance pre-flight before credentials are exported, while preserving the surrounding guidance and clean formatting.",
+  "whyNow": "The supervised-dispatch ceremony needs a genuine construction task whose verifier refuses empty or malformed work.",
   "requestedBy": {
     "type": "operator",
     "id": "pilot-operator"
@@ -28,7 +28,7 @@
     {
       "id": "format-command",
       "type": "command",
-      "command": "git diff --check",
+      "command": "test -n \"$(git diff --numstat)\" && git diff --check",
       "required": true
     }
   ],
@@ -40,5 +40,5 @@
   },
   "deadline": "2027-12-31T23:59:59.000Z",
   "riskTier": "low",
-  "selectionReason": "A formatting-only task is the narrowest reversible Harness ceremony case."
+  "selectionReason": "A required paragraph in a tracked allowlisted plan is bounded, reversible, and produces a verifier-visible diff."
 }

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -14,7 +14,9 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   INT2_EXPECTED_PATH,
+  INT2_SECTION3_CRITERION,
   expectationsForCase,
+  verifySection3Preflight,
   verifyScriptedPairPreflight,
 } from "../../scripts/ceremony/int2-evidence.mjs";
 import {
@@ -97,6 +99,100 @@ describe("committed INT-2 ceremony mechanics", () => {
         negativeScriptPath: mutatedNegative,
       }),
     ).rejects.toThrow("controlled pair appended content must differ");
+  });
+
+  it("preflights all three paid-task criterion outcomes at the pinned revision", async () => {
+    const result = await verifySection3Preflight({
+      repositoryRoot: ROOT,
+    });
+
+    expect(result).toMatchObject({
+      fixture: "lint-format",
+      targetPath: INT2_EXPECTED_PATH,
+      criterion: INT2_SECTION3_CRITERION,
+      correct: {
+        exitCode: 0,
+        reason: "clean_non_empty_diff",
+      },
+      incorrect: {
+        exitCode: 2,
+        reason: "trailing_whitespace",
+        details: expect.stringMatching(/trailing whitespace/iu),
+      },
+      noChange: {
+        exitCode: 1,
+        reason: "empty_diff",
+      },
+      exit128Present: false,
+      exit129Present: false,
+    });
+    expect(result.correct.numstat).not.toBe("");
+    expect(result.incorrect.numstat).not.toBe("");
+    expect(result.noChange.numstat).toBe("");
+
+    const temporary = await mkdtemp(
+      path.join(tmpdir(), "int2-section3-mutation-"),
+    );
+    temporaryRoots.push(temporary);
+    const fixture = JSON.parse(
+      await readFile(
+        path.join(
+          ROOT,
+          "test/fixtures/agent-integration/ceremony/lint-format.json",
+        ),
+        "utf8",
+      ),
+    ) as {
+      acceptanceCriteria: Array<{ command: string }>;
+    };
+    fixture.acceptanceCriteria[0]!.command = "git diff --check";
+    const mutatedFixture = path.join(temporary, "lint-format.json");
+    await writeFile(mutatedFixture, `${JSON.stringify(fixture, null, 2)}\n`);
+
+    await expect(
+      verifySection3Preflight({
+        repositoryRoot: ROOT,
+        fixturePath: mutatedFixture,
+      }),
+    ).rejects.toThrow("does not use the discriminating criterion");
+  }, 30_000);
+
+  it("keeps the paid run behind pre-flight, container-path, and spend gates", async () => {
+    const runbook = await readFile(
+      path.join(ROOT, "docs/HARNESS_INT2_CEREMONY_RUNBOOK.md"),
+      "utf8",
+    );
+    const sectionStart = runbook.indexOf(
+      "## 3. One budget-capped real-model task",
+    );
+    const sectionEnd = runbook.indexOf(
+      "## 4. Evidence mapped to the INT-2 gate",
+    );
+    const section = runbook.slice(sectionStart, sectionEnd);
+    const preflight = section.indexOf("preflight-section3");
+    const credential = section.indexOf(
+      'export HARNESS_MODEL_API_KEY="<secret-kept-out-of-evidence>"',
+    );
+
+    expect(sectionStart).toBeGreaterThanOrEqual(0);
+    expect(sectionEnd).toBeGreaterThan(sectionStart);
+    expect(preflight).toBeGreaterThanOrEqual(0);
+    expect(credential).toBeGreaterThan(preflight);
+    expect(section).toContain("actual containerized ceremony path");
+    expect(section).toContain("exit_129");
+    expect(section).toContain(
+      "`modelTokens: 8000` is the operative spend limit",
+    );
+    expect(section).toContain(
+      "`estimatedUsdMicros` is `null` and is **not** a monetary enforcement",
+    );
+    expect(section).toContain("Propose exactly one `lint-format` task");
+    expect(section).not.toContain(
+      "Propose exactly one `lint-format` or `docs-fix` task",
+    );
+    expect(section).toContain(
+      "Do not run a second real-model task to improve the result. A failure is",
+    );
   });
 
   it("records the production-loader and typed-attenuation split", () => {


### PR DESCRIPTION
## What changed

- Turned the existing `lint-format` §3 fixture into a genuine construction task against a tracked allowlisted document at the unchanged pinned base revision.
- Replaced the vacuous verifier with `test -n "$(git diff --numstat)" && git diff --check`.
- Added `preflight-section3` to the existing ceremony evidence tool. It clones the fixture revision independently for correct, incorrect, and no-change cases and refuses any `exit_128` or `exit_129` result.
- Updated §3 of the ceremony runbook so the free pre-flight, the separate container-path gate, and the published-rate cost calculation all precede credential export and approval.
- Removed `docs-fix` from the §3 choice and states plainly that `modelTokens: 8000` is the operative spend limit; `estimatedUsdMicros: null` is not represented as enforcement.

## Why

The prior task described a formatting defect that does not exist, while `git diff --check` accepted an empty diff. A competent no-op could therefore pass the only paid ceremony case. The other offered fixture, `docs-fix`, cannot pass its current search criterion.

## Free pre-flight result

| Case | Numstat | Exit | Verdict |
|---|---|---:|---|
| correct clean construction | `2  0  docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md` | 0 | accepted |
| trailing-whitespace construction | `2  0  docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md` | 2 | refused; named `trailing whitespace` at line 704 |
| no change | empty | 1 | refused |

`exit128Present=false`; `exit129Present=false`.

## Checks

- `npm run typecheck` — exit 0
- `npm test` — 204 files passed, 2 skipped; 2,614 tests passed, 13 skipped
- `npm run build` — exit 0
- `git diff --check` — exit 0

## Scope and authority

Affected surfaces: ceremony fixture, ceremony evidence/pre-flight helper, runbook, and unit tests only.

This changes no production authority, enables no dispatch, starts no Harness process, exports no model credential, spends no model tokens, touches no money/wallet/signer/claim/submission path, and does not perform the §3 paid run.

The paid run remains prohibited until the operator has green evidence through the actual containerized git criterion path. #589 is merged, but its `exit_129` reproduction remains unresolved.

The dollar ceiling is deliberately not instantiated in this build because §3 leaves the operator-approved model and endpoint unresolved. Before approval, the runbook now requires a recorded model identity, endpoint host, authoritative published rate source, and the conservative calculation `8000 * max(inputRate, outputRate) / 1,000,000`. No credential is included in that evidence.