### PR TITLE
docs(hermes): v0.19.1 upgrade plan + the Buzz-replaces-Slack cutover

### DIFF
--- a/docs/HERMES_UPGRADE_v019.md
+++ b/docs/HERMES_UPGRADE_v019.md
@@ -171,13 +171,63 @@ Therefore:
    alarm must itself be monitored. A `buzz_relay` probe belongs next to the
    other seven.
 
-### 4.4 Ops weight — be honest about it
+### 4.4 Ops weight — MEASURED 2026-07-31, it fits
 
-Buzz is a Rust relay plus **Postgres, Redis and S3/MinIO**. The VPS already runs
-the monitor, its Postgres, the Hermes sidecar and the task runners. This is not
-a plugin; it is a second stack. Size the box before, not after.
+Buzz is a Rust relay plus **Postgres, Redis and S3/MinIO** — a second stack, not
+a plugin. So we measured the box rather than guessing.
 
-### 4.5 Why it is nonetheless the right direction
+| | |
+|---|---|
+| CPU | 8 cores, load 0.85 → **~10% utilised** |
+| RAM | 22 GiB total, 6.2 used, **16 GiB available**, no swap |
+| Disk | **155 GB free / 21% used** (after the prune below) |
+| Running | 17 containers — two Postgres *and* two Redis already |
+
+Sized against what comparable services already cost **on this box**, not docs:
+
+| component | local evidence | estimate |
+|---|---|---|
+| Rust relay (Axum) | — | 100–300 MiB |
+| Postgres | `avg-postgres` **50 MiB**, `agent-postgres` 1.03 GiB | 50 MiB–1 GiB |
+| Redis | both live instances **~22 MiB** | ~25 MiB |
+| MinIO | — | 200–400 MiB |
+
+**≈0.5–1.5 GiB against 16 GiB free — 3–9% of headroom.** Postgres and Redis are
+already proven cheap here, so the stack is heavier in *components* than in
+resources. CPU is a non-issue at our message volume. **Verdict: it fits.**
+
+Disk was the only sore point and it was mostly garbage: 76 GB build cache +
+32.8 GB stale images. One prune took it from **126 GB used (66%) → 39 GB (21%)**,
+reclaiming ~74 GB, with all 17 containers still up:
+
+```bash
+docker builder prune -f && docker image prune -af --filter "until=168h" && df -h /
+```
+
+**But nothing watches disk.** The seven probes are `product_api`, `chain_height`,
+`signer_liquidity`, `capabilities`, `api_latency`, `money_path`,
+`treasury_liquidity` — no disk. MinIO stores media, which grows with use rather
+than staying flat, and a full disk is a *correlated* failure: it takes the
+monitor, the money board and the alert path at the same moment, so the thing
+meant to warn you dies with the thing it watches. A `disk_headroom` probe is a
+prerequisite for MinIO, on the same logic as `buzz_relay` in §4.3.
+
+### 4.5 Rollback pin — record it BEFORE upgrading
+
+The prune deleted older Hermes images (`v2026.6.19`, and a digest-pinned tag),
+so old versions demonstrably do get cleaned. The current image survives only
+because it is in use. Rollback target, captured 2026-07-31:
+
+```
+nousresearch/hermes-agent:v2026.7.1
+sha256:b6c019227889e6675424a2b6223b2cafdd36bf7d1048d1ddd8e043b880d6cc0f
+```
+
+Confirm that digest is present (or re-pullable) **before** starting §3, not
+after a bad bump. Monitor rollback images are also retained: `sha-9ff2d56`
+(current), `sha-8e69416`, `sha-cb6da52`.
+
+### 4.6 Why it is nonetheless the right direction
 
 Every Buzz participant — human or agent — is a **keypair**, and every message is
 a signed event on a relay we control. That is the same identity model Averray

--- a/docs/HERMES_UPGRADE_v019.md
+++ b/docs/HERMES_UPGRADE_v019.md
@@ -1,0 +1,204 @@
+# Hermes v0.18 → v0.19.1 — Upgrade Plan + Buzz-Replaces-Slack Cutover
+
+Written 2026-07-31. Companion to `HERMES_UPGRADE_v018.md`; same shape — upstream
+changes diffed against **what we actually use**, not a feature tour.
+
+## 0. Bottom line
+
+| | |
+|---|---|
+| Running | **v0.18.0** (`nousresearch/hermes-agent:v2026.7.1`) |
+| Target | **v0.19.1** (`v2026.7.30`), published 2026-07-30 |
+| Path | v0.18.1 → v0.18.2 → v0.19.0 → v0.19.1 |
+
+Two decisions, and **they are sequenced, not parallel**: Buzz messaging support
+landed in the v0.19.x line ([#68871](https://github.com/NousResearch/hermes-agent/issues/68871),
+closed 2026-07-29; v0.19.1 notes list *"continued platform work (Buzz/Nostr
+channel …)"*). It is **not backportable to v0.18** — the upgrade gates the Buzz
+work entirely.
+
+**⚠ v0.19.1 is ~1 day old and rolls up ~2,789 commits / ~4,748 files changed
+since v0.19.0.** Our last bump needed two follow-up fixes (#491 `dashboard`→
+`serve` + aux-model pin, #492 CI bootstrap-pin sync). Recommendation: stage it,
+and prefer v0.19.2 for prod if it appears before we finish the smoke.
+
+## 1. What we actually depend on
+
+Everything below is a real call site in `services/slack-operator/`. This is the
+blast-radius surface; anything upstream that doesn't touch these doesn't matter
+to us regardless of how prominent it is in the release notes.
+
+| Surface | Where | Notes |
+|---|---|---|
+| HTTP Session API | `hermes-session-client.ts` | `POST /api/sessions`, `/{id}/chat`, `/{id}/chat/stream` (SSE), `/{id}/fork` |
+| Gateway base + auth | `HERMES_API_URL` → `http://hermes-gateway:8642`, `HERMES_API_TOKEN` / `API_SERVER_KEY` | `resolveHermesSessionConfig()` returns null ⇒ degraded-safe no-op |
+| SSE frame parsing | `parseSseFrames()` | we parse frames ourselves — a format change breaks us silently |
+| Co-pilot rail, router narration, failure analysis | `index.ts` ×4 `resolveHermesSessionConfig()` call sites | `HERMES_FAILURE_ANALYSIS=1` is live in prod |
+| Voice | `monitor-hermes-voice.ts` | same gateway |
+
+## 2. What upstream changed that touches it
+
+### 2.1 Session storage moved — **the one to actually watch**
+
+v0.19.0: *"Gateway session metadata consolidated into `state.db`; routing index
+moved to `state.db` (`sessions.json` now an optional legacy mirror)."*
+
+That is an **internal storage** change, not a documented API change. Our client
+speaks HTTP, so we are *probably* unaffected — but "probably" is what burned us
+last time: the v0.18 Session-API 401 looked like a code change and turned out to
+be a recreate artifact. Verify empirically (§3.2), do not reason about it.
+
+### 2.2 `pre_tool_call` approve action — reverted mid-window, then re-landed
+
+Affects anything hanging off that extension point. We do not ship a Hermes
+plugin today, so this is **informational** — but it becomes load-bearing the
+moment we adopt the Buzz platform plugin (§4).
+
+### 2.3 Provider config gained `enabled: false` + `excluded_providers`
+
+Optional. Relevant only if we want to pin the aux model harder than #491 did.
+
+### 2.4 What upstream does **NOT** document — plan around this
+
+I checked the notes for v0.18.1, v0.18.2, v0.19.0 and v0.19.1 specifically for
+the Session API, gateway auth / `API_SERVER_KEY`, the `serve` command and its
+flags, SSE event names and frame format, and required migrations.
+
+**None of them are mentioned.** Not "unchanged" — *unaddressed*. The notes are
+user-facing (speed, MoA, desktop, billing, password managers); backend API
+stability is simply not covered.
+
+So the upgrade's blast radius on our integration is **undocumented upstream**.
+That is exactly the shape of today's two production defects — a belief about a
+system nobody had measured. Treat §3 as the source of truth, not the changelog.
+
+## 3. Staging smoke
+
+### 3.0 Resolve the real digest (never `:latest`)
+
+```bash
+docker buildx imagetools inspect nousresearch/hermes-agent:v2026.7.30 | grep -i digest | head -1
+```
+
+Record the sha256 — that is the new pin. Do not invent one.
+
+### 3.1 Isolated bring-up
+
+Bring it up on a scratch port with its own volume. **Never** against the prod
+`avg_avg-hermes-skills` volume: Hermes owns it as UID 10000 and re-secures it to
+0700, and `Deploy Production` execs into the `avg-hermes` sidecar — so a Hermes
+crash can red an averray deploy while the backend is healthy (#657 made that
+gate advisory, it did not remove the coupling).
+
+### 3.2 ⚠ THE HIGHEST-VALUE CHECK — the Session API still answers
+
+The storage move (§2.1) is the one plausible breakage. Prove the four endpoints
+we actually call, against the new image, before anything else:
+
+```bash
+# 201 expected — a 401 here is the v0.18 recreate artifact, NOT a code change
+curl -si -X POST "$H/api/sessions" -H "Authorization: Bearer $KEY" -d '{}' | head -1
+```
+
+Then `/chat`, `/chat/stream` (confirm SSE frame names still parse through
+`parseSseFrames`), and `/fork`. A green boot with a broken stream is the failure
+mode that would reach prod silently, because the co-pilot rail degrades quietly
+by design.
+
+### 3.3 Regression surface
+
+- Failure analysis still writes `hermes_failure_analysis_written` / `_done`.
+- Router narration and the co-pilot rail still return (not silently null).
+- Voice path still resolves the gateway.
+- `state.db` created cleanly on a fresh volume; no manual migration demanded.
+
+### 3.4 Go / no-go
+
+Go only if §3.2 is fully green. A partial pass is a no-go: our client fails
+degraded-safe, so partial breakage looks like calm.
+
+## 4. Buzz replaces Slack as the control surface
+
+**Decision (operator, 2026-07-31):** Buzz becomes the control + monitoring
+surface, replacing Slack — it is native to agents and to Hermes, and it is a
+relay we own rather than a SaaS we post into.
+
+### 4.1 Which of the three connection methods
+
+| Method | Verdict |
+|---|---|
+| **Native gateway platform** | **ADOPT.** Buzz becomes a Hermes messaging platform alongside Telegram/Discord, keeping Hermes' approval system, memory and session handling. NIP-42 auth, BIP-340 signing, cron delivery (`deliver=buzz`). |
+| Relay bridge (`buzz-acp`) | Reject for us. Buzz's harness owns the transport, so we lose the Hermes-side approval semantics we rely on. |
+| Desktop runtime | **Reject.** The docs state it **auto-approves tool permissions**. Unacceptable for anything sharing a channel with an agent that can act. |
+
+### 4.2 What changes in our code — less than it sounds
+
+`alert-bridge.ts` already anticipated this. Its own header says *"AlertChannel:
+the pluggable dispatch interface (Slack now; a push channel later)"* and
+*"same AlertChannel interface later — the routine never changes."*
+
+```ts
+export interface AlertChannel {
+  readonly name: string;
+  dispatch(payload: AlertPayload): Promise<boolean>;
+}
+```
+
+So the work is **one new implementation**, `buzzAlertChannel()`, plus swapping
+five `alertChannel.dispatch(...)` call sites in `index.ts`. The alert *decision*
+layer — `decideMoneyAlert`, `alertProvenance`, the gap-keyed de-dup (#590) — is
+transport-agnostic and does not change at all. #590 was not wasted work; it was
+the right layering.
+
+### 4.3 The hazard that must govern the cutover
+
+**A money-alerting system whose only channel can fail silently is worse than one
+that pages noisily.** Slack is a hosted service we currently trust; a
+self-hosted Nostr relay is infrastructure *we* now have to keep up. If the relay
+is down and Buzz is the sole path, alerts do not fail loudly — they simply never
+arrive, and the board looks calm.
+
+Therefore:
+
+1. **Dual-dispatch during bake.** `AlertChannel.dispatch` already returns
+   `boolean` (sent / no-op), so a composite channel can send to both and report
+   honestly. Run both for a full bake period.
+2. **Do not cut Slack until Buzz has delivered a real money alert** — not a test
+   ping. The first genuine `payout shortfall` or pool-below-floor that lands in
+   Buzz is the gate.
+3. **Add relay reachability to the probes.** Once Buzz is the control surface it
+   is production infrastructure, and by our own rule the thing that carries the
+   alarm must itself be monitored. A `buzz_relay` probe belongs next to the
+   other seven.
+
+### 4.4 Ops weight — be honest about it
+
+Buzz is a Rust relay plus **Postgres, Redis and S3/MinIO**. The VPS already runs
+the monitor, its Postgres, the Hermes sidecar and the task runners. This is not
+a plugin; it is a second stack. Size the box before, not after.
+
+### 4.5 Why it is nonetheless the right direction
+
+Every Buzz participant — human or agent — is a **keypair**, and every message is
+a signed event on a relay we control. That is the same identity model Averray
+runs on-chain. Slack can only ever be a place agents *post into*; Buzz is a
+place they are *members of*, with the audit trail as a first-class artifact
+rather than a channel history we scrape.
+
+## 5. Sequencing
+
+1. §3 smoke on v0.19.1 (or v0.19.2 if it lands first) — **gates everything**.
+2. Prod bump + the existing post-bump checks.
+3. Stand up the Buzz relay; `hermes gateway setup` → Buzz; native platform.
+4. `buzzAlertChannel()` + composite dual-dispatch; bake.
+5. `buzz_relay` probe.
+6. Cut Slack only after §4.3.2 is satisfied.
+
+## 6. Open questions
+
+- Does v0.19.x's `state.db` consolidation need a one-time migration from an
+  existing v0.18 volume, or only on fresh state? §3.2 answers it; the notes do not.
+- Does the bundled `buzz` plugin use `pre_tool_call` (§2.2)? If so its
+  revert/re-land history becomes load-bearing for us.
+- Relay hosting: same VPS, or its own box? §4.4 argues this is a sizing
+  decision, not a detail.


### PR DESCRIPTION
Plan only — no runtime change. Companion to `HERMES_UPGRADE_v018.md`, same shape: upstream diffed against **what we actually use**, not a feature tour.

## The two decisions are sequenced, not parallel
Buzz messaging landed in the **v0.19.x** line ([#68871](https://github.com/NousResearch/hermes-agent/issues/68871) closed 2026-07-29; v0.19.1 notes list *"continued platform work (Buzz/Nostr channel …)"*). It **cannot** be backported to the v0.18.0 we run — the upgrade gates the Buzz work entirely.

## The finding that shaped the plan
I checked v0.18.1, v0.18.2, v0.19.0 and v0.19.1 release notes specifically for: the Session API, gateway auth / `API_SERVER_KEY`, the `serve` command, SSE frame format, and required migrations.

**None are mentioned — not "unchanged", *unaddressed*.** The notes are user-facing (speed, MoA, desktop, billing); backend API stability isn't covered. So the blast radius on our integration is **undocumented upstream** — the same shape as today's two production defects, a belief about a system nobody had measured. The smoke is the source of truth, not the changelog.

## The one real risk
v0.19.0 moved *"gateway session metadata into `state.db`; routing index moved to `state.db`"*. Internal storage, not a documented API change, and our client speaks HTTP — but "probably fine" is what burned us on the v0.18 bump, where a Session-API 401 looked like a code change and was a recreate artifact.

So the highest-value check is simply: **do the four endpoints we actually call still answer**, against the new image, before anything else. Our client degrades degraded-safe, so partial breakage looks like calm — **a partial pass is a no-go.**

⚠️ v0.19.1 is ~1 day old and rolls up ~2,789 commits. Last bump needed two follow-ups (#491, #492). Prefer v0.19.2 for prod if it lands first.

## Buzz: adopt the native gateway platform
| method | verdict |
|---|---|
| **Native gateway platform** | **adopt** — keeps Hermes' approval system, memory, sessions; NIP-42 + BIP-340 |
| Relay bridge (`buzz-acp`) | reject — Buzz's harness owns transport, we lose Hermes-side approvals |
| Desktop runtime | **reject** — docs state it **auto-approves tool permissions** |

**The code change is small.** `alert-bridge.ts` already anticipated this — its header says *"Slack now; a push channel later … the routine never changes"*. So: one `buzzAlertChannel()` plus five `dispatch` call sites. #590's decision layer (`decideMoneyAlert`, `alertProvenance`, gap-keyed de-dup) is transport-agnostic and doesn't change. That work wasn't wasted; it was the right layering.

## The hazard governing the cutover
**A money-alerting system whose only channel can fail silently is worse than one that pages noisily.** A self-hosted relay becomes *our* uptime problem — if it's down, alerts don't fail loudly, they never arrive and the board looks calm.

So: **dual-dispatch during bake**, don't cut Slack until Buzz has carried a **real** money alert rather than a test ping, and add a `buzz_relay` probe — by our own rule, the thing carrying the alarm must itself be monitored.

Also honest about weight: Buzz is a Rust relay **plus Postgres, Redis and S3/MinIO** on a VPS already running the monitor, its Postgres, the Hermes sidecar and the runners. Size the box first.