### PR TITLE
feat(ops): watch the disk — the pillar nobody was watching

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -413,6 +413,18 @@ services:
       # settled-minus-confirmed gap tolerated as a window-boundary artifact — the
       # product's rolling 24h and the block window don't share a clock.
       PRODUCT_HEALTH_PAYOUT_TOLERANCE: ${PRODUCT_HEALTH_PAYOUT_TOLERANCE:-1}
+      # Disk headroom. A full disk is a CORRELATED failure: it takes the monitor,
+      # the money board and the alert path in the same moment, so the thing meant
+      # to warn you dies with the thing it watches — silently, with no red probe.
+      # Verified 2026-07-31: the container's overlay `/` reports the SAME
+      # capacity as the host (193G/155G), so no host mount is needed.
+      # Judged on ABSOLUTE GiB, never percent: 5% of 2TB is comfort, 20% of 20GB
+      # is about to fail. Unlike the token floors, these default to REAL values —
+      # disk exhaustion is universally fatal, and at 155 GiB free 10/25 cannot
+      # fire spuriously. Raise them once MinIO (Buzz) starts storing media.
+      PRODUCT_HEALTH_DISK_PATH: ${PRODUCT_HEALTH_DISK_PATH:-/}
+      PRODUCT_HEALTH_MIN_DISK_FREE_GB: ${PRODUCT_HEALTH_MIN_DISK_FREE_GB:-10}
+      PRODUCT_HEALTH_WARN_DISK_FREE_GB: ${PRODUCT_HEALTH_WARN_DISK_FREE_GB:-25}
       # Floors default to 0 = that probe can NEVER go red. Fine for a testnet, but
       # on a live network a 0 floor means no warning before you run dry. Mainnet
       # values in use (2026-07-25, sized off live balances): GAS_NATIVE=1 DOT (low

--- a/services/slack-operator/src/disk-headroom.ts
+++ b/services/slack-operator/src/disk-headroom.ts
@@ -1,0 +1,90 @@
+// Disk headroom — the pillar nobody was watching.
+//
+// The seven existing probes cover the product and the money. None watch the
+// disk the monitor itself runs on, and a full disk is a CORRELATED failure: it
+// takes the monitor, the money board and the alert path in the same moment. The
+// thing meant to warn you dies with the thing it is watching, and it dies
+// quietly — no page, no red probe, just a board that stopped updating.
+//
+// That was tolerable while disk sat flat. It stops being tolerable the moment
+// Buzz brings MinIO, because media storage grows with USE rather than staying
+// level (see docs/HERMES_UPGRADE_v019.md §4.4).
+//
+// Container visibility, verified on the live box 2026-07-31 rather than assumed:
+// the monitor's overlay `/` reports the SAME 193G/155G as the host, and `/data`
+// is the same `/dev/sda1`. So `fs.statfsSync("/")` sees real host capacity — no
+// host mount, no shelling out to `df`.
+
+import { statfsSync } from "node:fs";
+
+import type { ProbeResult } from "./product-health.js";
+
+const BYTES_PER_GB = 1024 ** 3;
+
+export interface DiskUsage {
+  /** Total capacity in bytes; null when unreadable. */
+  totalBytes: number | null;
+  /**
+   * Bytes available TO US. Deliberately `bavail`, not `bfree`: `bfree` counts
+   * root-reserved blocks we cannot actually write to, so it would overstate
+   * headroom by a few percent right at the point it matters.
+   */
+  availableBytes: number | null;
+}
+
+/**
+ * Read the filesystem the monitor actually writes to. Never throws; any failure
+ * returns nulls, which `decideDiskHeadroom` reports as unreadable rather than
+ * as healthy.
+ */
+export function readDiskUsage(path = "/"): DiskUsage {
+  try {
+    const s = statfsSync(path);
+    const total = Number(s.blocks) * Number(s.bsize);
+    const available = Number(s.bavail) * Number(s.bsize);
+    if (!Number.isFinite(total) || !Number.isFinite(available) || total <= 0) {
+      return { totalBytes: null, availableBytes: null };
+    }
+    return { totalBytes: total, availableBytes: available };
+  } catch {
+    return { totalBytes: null, availableBytes: null };
+  }
+}
+
+/**
+ * The verdict. PURE — the measurement is injected so the thresholds are
+ * testable without a filesystem.
+ *
+ * Judged on ABSOLUTE free space, not percentage. Percentage is the intuitive
+ * number and the wrong one: 5% of a 2 TB disk is 100 GB of comfort, while 20%
+ * of a 20 GB disk is 4 GB and about to fail. Writes fail on bytes. The percent
+ * is reported alongside because it is what a human reads at a glance, but it
+ * never decides the status.
+ */
+export function decideDiskHeadroom(input: {
+  usage: DiskUsage;
+  /** Below this ⇒ red. */
+  minFreeGb: number;
+  /** Below this ⇒ degraded. Ignored when <= minFreeGb. */
+  warnFreeGb: number;
+}): ProbeResult {
+  const name = "disk_headroom";
+  const { totalBytes, availableBytes } = input.usage;
+  if (totalBytes === null || availableBytes === null) {
+    // Unreadable is NOT healthy. A probe that cannot see must not report calm —
+    // that is the fake-green this whole board exists to avoid.
+    return { name, status: "degraded", detail: "disk headroom unreadable — capacity NOT verified" };
+  }
+  const freeGb = availableBytes / BYTES_PER_GB;
+  const totalGb = totalBytes / BYTES_PER_GB;
+  const usedPct = Math.round(((totalBytes - availableBytes) / totalBytes) * 100);
+  const where = `${freeGb.toFixed(1)} GiB free of ${totalGb.toFixed(0)} GiB (${usedPct}% used)`;
+
+  if (freeGb < input.minFreeGb) {
+    return { name, status: "red", detail: `${where} — below the ${input.minFreeGb} GiB floor; writes are at risk` };
+  }
+  if (input.warnFreeGb > input.minFreeGb && freeGb < input.warnFreeGb) {
+    return { name, status: "degraded", detail: `${where} — under the ${input.warnFreeGb} GiB warning line` };
+  }
+  return { name, status: "ok", detail: where };
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -29,6 +29,7 @@ import type { AlertPayload } from "./alert-bridge.js";
 
 // ── Probe result model ──────────────────────────────────────────────
 
+import { decideDiskHeadroom, readDiskUsage } from "./disk-headroom.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
@@ -504,6 +505,12 @@ export interface ProductHealthConfig {
   payoutLookbackBlocks: number;
   /** Settled-minus-confirmed gap tolerated as a window-boundary artifact. */
   payoutTolerance: number;
+  /** Filesystem the monitor writes to. Container `/` sees real host capacity. */
+  diskPath: string;
+  /** Free-space floor in GiB — below this the disk probe goes red. */
+  minDiskFreeGb: number;
+  /** Free-space warning line in GiB. */
+  warnDiskFreeGb: number;
   /** Native-gas floor in whole tokens (e.g. 0.1 DOT). 0 = don't threshold. */
   minGasNative: number;
   /** capabilityHealth keys that MUST be up; one dropping ⇒ red. Env
@@ -599,6 +606,13 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     // ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
     payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 14400),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
+    diskPath: env.PRODUCT_HEALTH_DISK_PATH || "/",
+    // Unlike the token floors (which default to 0 = can-never-go-red, because a
+    // sensible balance is deployment-specific), disk exhaustion is universally
+    // fatal, so these carry real defaults. Sized against the live box: 155 GiB
+    // free, so 10/25 cannot fire spuriously.
+    minDiskFreeGb: num(env.PRODUCT_HEALTH_MIN_DISK_FREE_GB, 10),
+    warnDiskFreeGb: num(env.PRODUCT_HEALTH_WARN_DISK_FREE_GB, 25),
     minGasNative: num(env.PRODUCT_HEALTH_MIN_GAS_NATIVE, 0),
     requiredCapabilities: csv(env.PRODUCT_HEALTH_REQUIRED_CAPABILITIES, "blockchain,treasuryMutations"),
     expectedWarnings: csv(env.PRODUCT_HEALTH_EXPECTED_WARNINGS, "xcm_observer_staged,indexer_unavailable,gas_sponsor_disabled"),
@@ -1889,6 +1903,14 @@ export async function collectProductHealthProbes(
         expectedWarnings: config.expectedWarnings,
       }),
       deriveLatencyProbe(h, { warnMs: config.latencyWarnMs, redMs: config.latencyRedMs }),
+      // The pillar nobody was watching. A full disk is a CORRELATED failure —
+      // it takes the monitor, the money board and the alert path together, so
+      // the thing meant to warn you dies with the thing it watches.
+      decideDiskHeadroom({
+        usage: readDiskUsage(config.diskPath),
+        minFreeGb: config.minDiskFreeGb,
+        warnFreeGb: config.warnDiskFreeGb,
+      }),
       deriveMoneyPathProbe(h, {
         maxStuck: config.maxStuck,
         maxFailed24h: config.maxFailed24h,

--- a/test/unit/disk-headroom.test.ts
+++ b/test/unit/disk-headroom.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { decideDiskHeadroom, readDiskUsage } from "../../services/slack-operator/src/disk-headroom.js";
+
+const GB = 1024 ** 3;
+const usage = (totalGb: number, freeGb: number) => ({
+  totalBytes: totalGb * GB,
+  availableBytes: freeGb * GB,
+});
+
+describe("decideDiskHeadroom", () => {
+  const floors = { minFreeGb: 10, warnFreeGb: 25 };
+
+  it("the live box today is comfortably ok", () => {
+    // Measured 2026-07-31 after the prune: 155 GiB free of 193.
+    const r = decideDiskHeadroom({ usage: usage(193, 155), ...floors });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("155.0 GiB free of 193 GiB");
+  });
+
+  it("the SAME box before the prune would also have been ok — 66% is not an alarm", () => {
+    // 68 GiB free. The percentage looked scary; absolute headroom was fine,
+    // which is exactly why this judges bytes and not percent.
+    expect(decideDiskHeadroom({ usage: usage(193, 68), ...floors }).status).toBe("ok");
+  });
+
+  it("degrades under the warning line", () => {
+    const r = decideDiskHeadroom({ usage: usage(193, 20), ...floors });
+    expect(r.status).toBe("degraded");
+    expect(r.detail).toContain("under the 25 GiB warning line");
+  });
+
+  it("goes RED under the floor and says writes are at risk", () => {
+    const r = decideDiskHeadroom({ usage: usage(193, 4), ...floors });
+    expect(r.status).toBe("red");
+    expect(r.detail).toContain("below the 10 GiB floor");
+    expect(r.detail).toContain("writes are at risk");
+  });
+
+  // Percentage is the intuitive number and the wrong one.
+  it("PERCENT DOES NOT DECIDE: 5% of a huge disk is healthy…", () => {
+    const r = decideDiskHeadroom({ usage: usage(2000, 100), ...floors });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toContain("95% used"); // alarming percent, real comfort
+  });
+
+  it("…and 20% of a small disk is RED", () => {
+    const r = decideDiskHeadroom({ usage: usage(20, 4), ...floors });
+    expect(r.status).toBe("red"); // reassuring percent, actually failing
+    expect(r.detail).toContain("80% used");
+  });
+
+  it("UNREADABLE is degraded, never ok — a probe that cannot see must not report calm", () => {
+    const r = decideDiskHeadroom({ usage: { totalBytes: null, availableBytes: null }, ...floors });
+    expect(r.status).toBe("degraded");
+    expect(r.detail).toContain("NOT verified");
+  });
+
+  it("a half-read measurement is also unreadable, not a guess", () => {
+    expect(decideDiskHeadroom({ usage: { totalBytes: 100 * GB, availableBytes: null }, ...floors }).status)
+      .toBe("degraded");
+  });
+
+  it("boundary: exactly at the floor is not yet red", () => {
+    expect(decideDiskHeadroom({ usage: usage(193, 10), ...floors }).status).toBe("degraded");
+    expect(decideDiskHeadroom({ usage: usage(193, 9.99), ...floors }).status).toBe("red");
+  });
+
+  it("a warn line at or below the floor is ignored rather than inverting the tiers", () => {
+    const r = decideDiskHeadroom({ usage: usage(193, 15), minFreeGb: 20, warnFreeGb: 10 });
+    expect(r.status).toBe("red"); // the floor still governs; a bad warn cannot mask it
+  });
+
+  it("floors of 0 mean the probe can only ever report ok — the documented footgun", () => {
+    expect(decideDiskHeadroom({ usage: usage(193, 0.5), minFreeGb: 0, warnFreeGb: 0 }).status).toBe("ok");
+  });
+});
+
+describe("readDiskUsage", () => {
+  it("reads the real filesystem it runs on", () => {
+    const u = readDiskUsage("/");
+    expect(u.totalBytes).toBeGreaterThan(0);
+    expect(u.availableBytes).toBeGreaterThanOrEqual(0);
+    expect(u.availableBytes!).toBeLessThanOrEqual(u.totalBytes!);
+  });
+
+  it("a nonexistent path is unreadable — not a throw, and not a zero-free false alarm", () => {
+    const u = readDiskUsage("/definitely/not/a/real/path/xyzzy");
+    expect(u).toEqual({ totalBytes: null, availableBytes: null });
+    expect(decideDiskHeadroom({ usage: u, minFreeGb: 10, warnFreeGb: 25 }).status).toBe("degraded");
+  });
+});

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -700,14 +700,23 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
       combinedFetch({ healthBody: HEALTHY_BODY, chainIdHex: CHAIN_ID_HEX, blockTimestampHex: tsHex(10_000_000, 12), gasHex: "0xDE0B6B3A7640000", usdcHex: "0x989680" }),
       { nowMs: 10_000_000 },
     );
-    expect(probes.map((p) => p.name)).toEqual(["product_api", "chain_height", "signer_liquidity", "capabilities", "api_latency", "money_path", "treasury_liquidity"]);
-    expect(probes.map((p) => p.status)).toEqual(["ok", "ok", "ok", "ok", "ok", "ok", "ok"]);
+    expect(probes.map((p) => p.name)).toEqual(["product_api", "chain_height", "signer_liquidity", "capabilities", "api_latency", "disk_headroom", "money_path", "treasury_liquidity"]);
+    expect(probes.map((p) => p.status)).toEqual(["ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok"]);
     expect(probes[2]?.detail).toContain("reward bank 100.00 USDC");
   });
 
-  it("all degraded when nothing is configured (never fake green)", async () => {
+  it("every CONFIG-DEPENDENT probe degrades when nothing is configured (never fake green)", async () => {
     const { probes } = await collectProductHealthProbes(cfg({ apiBaseUrl: undefined, rpcUrl: undefined }), combinedFetch({ healthBody: HEALTHY_BODY }), { nowMs: 1000 });
-    expect(probes.map((p) => p.status)).toEqual(["degraded", "degraded", "degraded", "degraded", "degraded", "degraded", "degraded"]);
+    // disk_headroom is deliberately excluded: it does not depend on product
+    // config at all. It measures the local filesystem, that measurement
+    // genuinely succeeds here, and the disk genuinely is fine — so reporting
+    // "ok" is the honest answer, not a fake green. The invariant this test
+    // protects is "a probe that CANNOT SEE must not report calm", and
+    // disk_headroom can see. Its own unreadable→degraded path is covered in
+    // disk-headroom.test.ts.
+    const configDependent = probes.filter((p) => p.name !== "disk_headroom");
+    expect(configDependent.map((p) => p.status)).toEqual(["degraded", "degraded", "degraded", "degraded", "degraded", "degraded", "degraded"]);
+    expect(probes.find((p) => p.name === "disk_headroom")).toBeDefined();
   });
 
   it("absolute age: a stale block halts IMMEDIATELY on a fresh start — no blind window (testnet → degraded)", async () => {


### PR DESCRIPTION
Prerequisite for MinIO/Buzz, per `HERMES_UPGRADE_v019.md` §4.4.

## Why
Seven probes cover the product and the money. **None watched the disk the monitor runs on.** A full disk is a **correlated** failure — it takes the monitor, the money board and the alert path in the same moment, so the thing meant to warn you dies with the thing it watches, and it dies quietly: no page, no red probe, just a board that stopped updating.

Tolerable while disk sat flat. Not tolerable once Buzz brings MinIO, because media grows with *use* rather than staying level.

## Verified, not assumed
Checked on the live box before writing a line: the monitor's overlay `/` reports the **same 193G/155G as the host**, and `/data` is the same `/dev/sda1`. So `fs.statfsSync()` sees real host capacity — no host mount, no shelling out to `df`.

Uses **`bavail`, not `bfree`** — `bfree` counts root-reserved blocks we can't actually write to, overstating headroom precisely when it matters.

## Absolute bytes, never percentage
Percent is the intuitive number and the wrong one:

| | percent | verdict |
|---|---|---|
| 100 GiB free of 2 TB | 95% used 😱 | **ok** — real comfort |
| 4 GiB free of 20 GB | 80% used 🙂 | **red** — about to fail |

Writes fail on bytes. Percent is *reported* because it's what a human reads at a glance, but it never decides the status. Both directions are tested. (Your pre-prune box at 66% would also have been `ok` — the percentage looked scary, the headroom was fine.)

## Truth boundary
- **Unreadable ⇒ degraded, never ok.** A probe that cannot see must not report calm.
- A nonexistent path returns nulls — not a throw, and not a zero-free false alarm.
- Unlike the token floors (default 0 = can-never-go-red, since a sensible balance is deployment-specific), these carry **real defaults**: disk exhaustion is universally fatal, and at 155 GiB free 10/25 can't fire spuriously.

## One test I narrowed rather than weakened
An existing test asserted *all* probes degrade when nothing is configured. That invariant is really *"a probe that cannot see must not report calm"* — and `disk_headroom` **can** see: it doesn't depend on product config, the measurement genuinely succeeds, and the disk genuinely is fine. So reporting `ok` is honest, not a fake green. I scoped the assertion to the config-dependent probes and documented why in the test.

## Verification
- `test/unit`: back at the **same pre-existing 110** failures, **+52 passing**.
- `slack-operator` tsc: unchanged at **49**.