### PR TITLE
fix(hermes): opt the api_server platform in, and record the v0.19.1 smoke

### DIFF
--- a/docs/HERMES_UPGRADE_v019.md
+++ b/docs/HERMES_UPGRADE_v019.md
@@ -117,6 +117,87 @@ by design.
 Go only if §3.2 is fully green. A partial pass is a no-go: our client fails
 degraded-safe, so partial breakage looks like calm.
 
+## 3.5 SMOKE RESULTS — run 2026-07-31 against v0.19.1
+
+Image pinned by digest, isolated container/volume, loopback port 18642, prod
+`v2026.7.1` never touched.
+
+```
+nousresearch/hermes-agent:v2026.7.30
+sha256:b869e64d6496d4763d5e4fb675b5f504cb23b0e35ec9b790481a56118602b10f
+→ boots, self-reports "v0.19.1 (2026.7.30) · upstream cc4cab2f"
+```
+
+**Two undocumented changes found. Neither appears in any release note.**
+
+### 3.5.1 The gateway now runs under s6 supervision
+
+v0.19.1 supervises the gateway (`gateway run --replace` under s6, auto-restart
+on crash) instead of running it as the container's foreground process.
+`--no-supervise` / `HERMES_GATEWAY_NO_SUPERVISE=1` restores the old behaviour.
+
+**Why it matters to us specifically:** `Deploy Production` execs into the
+`avg-hermes` sidecar, and today a Hermes crash reds a deploy. Under s6 the
+gateway restarts and the container stays up, so the container exit code no
+longer reflects gateway health and that failure signature changes. Decide
+deliberately which we want; do not inherit it by accident.
+
+### 3.5.2 ★ `API_SERVER_ENABLED` alone no longer enables the Session API
+
+The blocker, and the fix is a config file — not code.
+
+`gateway/config.py` resolves **`env > config > default`**: the `API_SERVER_*`
+env vars are an OVERRIDE LAYER on top of a `platforms:` opt-in that must already
+exist in `config.yaml`. Our config had `model`, `auxiliary`, `mcp_servers`,
+`paths` — no `platforms:` key. So there was nothing to override, the platform
+never registered, the gateway logged `No messaging platforms enabled`, bound
+nothing, and **reported healthy the whole time**.
+
+v0.18 enabled it from container env alone, which is why the missing block was
+invisible for as long as it has existed.
+
+Fix (landed separately, harmless on v0.18 which ignores it):
+
+```yaml
+platforms:
+  api_server:
+    enabled: true
+```
+
+Key, port and bind address stay in the environment. Note `/opt/data/config.yaml`
+is mounted READ-ONLY from `hermes/config/hermes.yaml`, so `hermes gateway setup`
+cannot write it — it has to be a committed file change.
+
+### 3.5.3 Four wrong turns, recorded so nobody repeats them
+
+Each was plausible and each cost a cycle:
+
+1. **"v0.19 broke the Session API."** No — it was never enabled in the smoke.
+2. **"The API server needs a model configured."** No — it stayed dead with a
+   model present.
+3. **"The home was empty (the `gateway.py:2976` docstring describes exactly
+   this)."** No — the symptom persisted with a byte copy of the prod home. That
+   docstring is about systemd units baking a temp `HERMES_HOME`; it matched our
+   *symptom*, not our *cause*.
+4. **"It needs `/opt/data/.env` (doctor says so)."** No — writing one changed
+   nothing.
+
+Also: `hermes migrate` handles **xAI model retirement only**, and
+`gateway migrate-legacy` removes **systemd units** — neither migrates config.
+So doctor's `Config version outdated (v0 → v33)` is ADVISORY, not the blocker,
+and there is no general config-migration command to run.
+
+And the upstream docs say platforms live in `~/.hermes/gateway-config.yaml`;
+**the code says a `platforms:` section in `config.yaml`.** Following the docs
+would have created a file Hermes never reads. Same lesson as the deployed
+contract ABI: the artifact beats the description.
+
+### 3.5.4 What still has NOT been proven
+
+The four endpoints in §3.2 have **not** returned 201 yet — the smoke never got
+past platform registration. Re-run §3.2 with the `platforms:` block present
+before calling the upgrade green. **Still a no-go until that passes.**
+
 ## 4. Buzz replaces Slack as the control surface
 
 **Decision (operator, 2026-07-31):** Buzz becomes the control + monitoring

--- a/hermes/config/hermes.yaml
+++ b/hermes/config/hermes.yaml
@@ -35,3 +35,25 @@ paths:
   skills: /opt/data/skills
   memory: /opt/data/memory.db
   plugins: /opt/data/plugins
+
+# The Session API our monitor speaks to (POST /api/sessions, /chat, /chat/stream,
+# /fork) is served by the `api_server` PLATFORM, and a platform has to be opted
+# in HERE before any env var can turn it on.
+#
+# v0.18 enabled it from container env alone, so this block was never needed and
+# its absence was invisible. v0.19.1 does not: gateway/config.py resolves
+# `env > config > default`, meaning API_SERVER_* are an OVERRIDE LAYER on top of
+# a config opt-in that must already exist. With no `platforms:` key there is
+# nothing to override, the platform never registers, and the gateway logs
+# "No messaging platforms enabled" and binds nothing — while reporting healthy.
+#
+# Proven on a v0.19.1 smoke against a COPY of the prod home (2026-07-31): with
+# API_SERVER_ENABLED/HOST/PORT/KEY all set and a model configured, nothing
+# listened on 8642 until this block existed. Harmless on v0.18, which simply
+# ignores it — so it is safe to land BEFORE the upgrade.
+#
+# Key, port and bind address stay in the environment (ops/compose.command-center.yml);
+# only the opt-in lives here.
+platforms:
+  api_server:
+    enabled: true


### PR DESCRIPTION
Two things: a **one-block config fix** that's safe to land now, and the smoke results written into the plan.

## The fix
The Session API our monitor depends on is served by the `api_server` **platform**. `gateway/config.py` resolves **`env > config > default`** — so `API_SERVER_*` are an *override layer* on top of a `platforms:` opt-in that must already exist. Our `config.yaml` had `model`, `auxiliary`, `mcp_servers`, `paths` — **no `platforms:` key**, so there was nothing to override.

```yaml
platforms:
  api_server:
    enabled: true
```

v0.18 enables it from container env alone, which is why this has been missing for as long as it's existed without anyone noticing. **Harmless on v0.18** (ignores the key) — so it lands *before* the upgrade, not as part of it.

`/opt/data/config.yaml` is mounted **read-only** from `hermes/config/hermes.yaml`, so `hermes gateway setup` cannot write it. It has to be committed.

## Smoke results (§3.5, new)
Pinned digest, isolated container/volume, loopback port. Prod `v2026.7.1` never touched. **Two undocumented changes, neither in any release note:**

**1. s6 supervision.** v0.19.1 supervises the gateway (auto-restart) instead of running it as the container's foreground process. "Deploy Production" execs into the sidecar and today a Hermes crash reds a deploy — under s6 the container stays up, so **that failure signature changes**. Decide it deliberately; the `--no-supervise` flag restores the old behaviour.

**2. The platform opt-in above.** Gateway boots, logs `No messaging platforms enabled`, binds nothing, **reports healthy throughout**.

## Four wrong turns, recorded
Each plausible, each cost a cycle — and each is a trap for whoever reads this next:

1. *"v0.19 broke the Session API"* — no, it was never enabled in the smoke
2. *"needs a model configured"* — no, stayed dead with one
3. *"the home was empty"* — no, persisted with a byte copy of prod's home. A `gateway.py` docstring describes this symptom exactly, but it is about systemd units baking a temp `HERMES_HOME` — it matched the symptom, not the cause
4. *"needs `/opt/data/.env`"* — doctor recommends one; writing it changed nothing

Also: `hermes migrate` is **xAI-only** and `gateway migrate-legacy` removes **systemd units** — so doctor's `Config version outdated (v0 → v33)` is **advisory**, not the blocker, and there is no general config migration to run.

And upstream docs place platforms in `~/.hermes/gateway-config.yaml` while the **code** reads a `platforms:` section in `config.yaml`. Following the docs would have created a file Hermes never reads — same lesson as the deployed contract ABI this morning: the artifact beats the description.

## Still a NO-GO
§3.2's four endpoints have **not** returned 201 — the smoke never got past platform registration. Re-run with this block present before calling the upgrade green. This PR makes that re-run possible; it does not declare it passed.
