### PR TITLE
feat(ops): protocol revenue on the Hermes solvency zone

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1335,6 +1335,55 @@ function encodeBalanceOf(address: string): string {
   return BALANCE_OF_SELECTOR + address.toLowerCase().replace(/^0x/, "").padStart(64, "0");
 }
 
+// Protocol revenue = the fee treasury's AgentAccountCore *position*, not an
+// ERC20 balanceOf. treasuryAccount() (0x339b2cff) is read off the live
+// EscrowCore so the address is derived from chain, never hardcoded; then
+// positions(treasury, USDC) (0x4bd21445) returns 6 words, [0] = liquid.
+const TREASURY_ACCOUNT_SELECTOR = "0x339b2cff";
+const POSITIONS_SELECTOR = "0x4bd21445";
+
+function encodePositions(account: string, asset: string): string {
+  const pad = (a: string) => a.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+  return POSITIONS_SELECTOR + pad(account) + pad(asset);
+}
+
+/** Read the protocol-fee treasury's liquid USDC position (fees accrued). Best-effort:
+ *  any failure returns undefined so the treasury probe still reports the rest. The
+ *  address is derived from EscrowCore.treasuryAccount(), so it follows a contract
+ *  cutover automatically. */
+async function readProtocolRevenueUsdc(input: {
+  rpcUrl: string;
+  escrowCore?: string;
+  agentAccountCore?: string;
+  token?: string;
+  usdcDecimals: number;
+  fetchImpl: typeof fetch;
+}): Promise<number | undefined> {
+  if (!input.escrowCore || !input.agentAccountCore || !input.token) return undefined;
+  try {
+    const rawTreasury = await ethRpc(
+      input.rpcUrl,
+      "eth_call",
+      [{ to: input.escrowCore, data: TREASURY_ACCOUNT_SELECTOR }, "latest"],
+      input.fetchImpl,
+    );
+    if (!rawTreasury || rawTreasury.length < 66) return undefined;
+    const treasury = "0x" + rawTreasury.slice(-40);
+    if (/^0x0+$/.test(treasury)) return undefined;
+    const rawPos = await ethRpc(
+      input.rpcUrl,
+      "eth_call",
+      [{ to: input.agentAccountCore, data: encodePositions(treasury, input.token) }, "latest"],
+      input.fetchImpl,
+    );
+    if (!rawPos || rawPos.length < 2 + 64) return undefined;
+    const liquid = BigInt("0x" + rawPos.replace(/^0x/, "").slice(0, 64));
+    return Number(liquid) / 10 ** input.usdcDecimals;
+  } catch {
+    return undefined;
+  }
+}
+
 const NATIVE_GAS_SYMBOL_BY_CHAIN_ID = new Map<number, string>([
   [420420417, "PAS"],
   [420420419, "DOT"],
@@ -1554,6 +1603,31 @@ export async function probeTreasuryLiquidity(input: {
     );
     pool("aac", "Agent core", aac, input.minAac);
     if (escrow !== undefined) pools.push({ key: "escrow", label: "Escrow (in-flight)", amount: escrow, unit: "USDC", status: "ok", informational: true });
+
+    // Protocol revenue — the 5% poster-side fee accrued in the treasury
+    // multisig's position. Internal ops metric (Hermes-only); informational, no
+    // floor. Omitted entirely if unreadable — never shown as a fake zero, since
+    // a zero here is a real "no fees yet" statement.
+    const protocolRevenue = await readProtocolRevenueUsdc({
+      rpcUrl: input.rpcUrl,
+      escrowCore: a.escrowCore,
+      agentAccountCore: a.agentAccountCore,
+      token: a.token,
+      usdcDecimals: input.usdcDecimals,
+      fetchImpl: input.fetchImpl,
+    });
+    if (protocolRevenue !== undefined) {
+      pools.push({
+        key: "protocol_revenue",
+        label: "Protocol revenue (fees)",
+        amount: protocolRevenue,
+        unit: "USDC",
+        status: "ok",
+        informational: true,
+        note: "5% poster-side fee, held under the 2-of-3 treasury",
+      });
+      parts.push(`revenue ${protocolRevenue.toFixed(2)}`);
+    }
 
     if (parts.length === 0) return { name, status: "degraded", detail: "no treasury balances readable" };
     return { name, status: red ? "red" : degraded ? "degraded" : "ok", detail: parts.join(", "), pools };

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -691,6 +691,47 @@ describe("probeTreasuryLiquidity (direct RPC + /health rewardBank)", () => {
   it("degraded when a balance read fails", async () => {
     expect((await probeTreasuryLiquidity({ ...base, rewardBankLiquid: 100, fetchImpl: throwingFetch() })).status).toBe("degraded");
   });
+
+  // Selector-aware mock: balanceOf → usdcHex; treasuryAccount() → an address;
+  // positions() → six words with liquid first. Lets us assert the derived
+  // protocol_revenue pool without touching the balanceOf path.
+  function revenueFetch(cfg: { usdcHex: string; treasury?: string; positionsLiquidHex?: string }): typeof fetch {
+    return (async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const data = String((JSON.parse(String((init as RequestInit).body)) as { params: [{ data?: string }] }).params[0]?.data ?? "");
+      let result: string = cfg.usdcHex;
+      if (data.startsWith("0x339b2cff") && cfg.treasury) result = "0x" + cfg.treasury.replace(/^0x/, "").padStart(64, "0");
+      else if (data.startsWith("0x4bd21445")) result = cfg.positionsLiquidHex ?? "0x" + "0".repeat(64 * 6);
+      return { ok: true, status: 200, json: async () => ({ result }) } as unknown as Response;
+    }) as unknown as typeof fetch;
+  }
+
+  it("emits a protocol_revenue pool from the treasury's derived AAC position", async () => {
+    // treasuryAccount() → 0x01e6…; positions().liquid = 0x1388 = 5000 raw = 0.005 USDC
+    const r = await probeTreasuryLiquidity({
+      ...base,
+      rewardBankLiquid: 100,
+      fetchImpl: revenueFetch({
+        usdcHex: "0x989680",
+        treasury: "0x01E6eed856e989201F4FF6346E18EAb7e46C874C",
+        positionsLiquidHex: "0x" + (5000).toString(16).padStart(64, "0") + "0".repeat(64 * 5),
+      }),
+    });
+    const revenue = (r.pools ?? []).find((p) => p.key === "protocol_revenue");
+    expect(revenue).toBeDefined();
+    expect(revenue?.amount).toBe(0.005);
+    expect(revenue?.informational).toBe(true);
+    expect(revenue?.status).toBe("ok"); // informational, never pages
+  });
+
+  it("omits protocol_revenue rather than faking a zero when the treasury read fails", async () => {
+    // treasuryAccount() returns the zero address → reading is abandoned, no pool.
+    const r = await probeTreasuryLiquidity({
+      ...base,
+      rewardBankLiquid: 100,
+      fetchImpl: revenueFetch({ usdcHex: "0x989680", treasury: "0x0000000000000000000000000000000000000000" }),
+    });
+    expect((r.pools ?? []).some((p) => p.key === "protocol_revenue")).toBe(false);
+  });
 });
 
 describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", () => {


### PR DESCRIPTION
## What

Surfaces the **5% protocol fee — the platform's earnings** — on the **internal Hermes ops board only**. Per Pascal: revenue is a founder/business metric; it belongs on Hermes (operator-only, behind Access), **not** the operator app (a product surface agents sign in to) or public pages. (The operator-app version, averray-agent/agent#870, was closed for exactly this reason.)

Renders as a **Protocol revenue (fees)** gauge in the Ops board's Solvency & runway zone:

```
Solvency & runway
  Reward bank      …
  Agent core       …
  Escrow (in-flight) …
  Protocol revenue (fees)  0.005 USDC   ← new
    5% poster-side fee, held under the 2-of-3 treasury
```

## How

- The `treasury_liquidity` probe now derives the fee treasury **from chain** — `EscrowCore.treasuryAccount()` — so it automatically follows a contract cutover (no hardcoded address), then reads that account's **AgentAccountCore position**. This is a *position* read (`positions(treasury, USDC).liquid`), distinct from the reward-bank / contract-`balanceOf` pools already shown.
- Pushes an **informational** `protocol_revenue` solvency pool (no floor, never pages). `SolvencyZone` renders pools generically → **no UI change**.

## Truth boundary

An unreadable treasury (RPC failure or a zero-address answer) **omits the pool entirely** rather than showing a fake zero — on this metric a zero is a real *"no fees earned yet"* statement, so it must come only from a successful read.

## Verification

- Derivation **live-verified end-to-end** against mainnet: `treasuryAccount()` → `0x01E6eed8…` (the multisig) → `0.005 USDC` (the exact dogfood fee).
- +2 unit tests (emit the pool from a derived position; omit-not-fake when the read fails). Full `product-health` suite **162 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)