### PR TITLE
ci: give the stress job the same setup as the suite it runs

### DIFF
--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -40,14 +40,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Checkout
+      - name: Checkout full history
         uses: actions/checkout@v4
+        with:
+          # Some suite tests resolve a fixture's baseRevision; a shallow clone
+          # cannot, and fails with `git 128`.
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: npm
+
+      - name: Install zsh syntax-check shell
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends zsh
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The nightly stress job failed **every iteration**, and both causes are gaps in this workflow — not flakes it was built to find.

```
Error: spawnSync zsh ENOENT   path: 'zsh'
Error: git failed with exit 128
```

## Cause

**No zsh.** `ubuntu-latest` ships none. `ci.yml`'s node job already installs it, because the ceremony-script test syntax-checks under **both** bash and zsh — the operator sources those scripts from zsh, so checking only bash would enforce the mechanism rather than the property. This job runs the same suite and never got the same step.

**Shallow checkout.** Some suite tests resolve a fixture's `baseRevision`, which a shallow clone cannot — hence `git 128`. Same trap that broke the fixture tests in CI earlier, fixed there with `fetch-depth: 0`.

## Fix

Both steps now mirror `ci.yml`. Nothing else changes.

## Why it matters more than it looks

A stress job that fails for its own setup teaches nothing, and trains people to ignore a red tick that is supposed to mean "a concurrency-sensitive test is flaky". That is worse than not having the job at all — it is a check that fires for the wrong reason, which is the same family as the checks that could not fire at all.

Main CI is green on `dcf1337`; only this workflow was red.

## Verification note

The zsh dependency is established from **CI's own failure log**, not reproduced locally. zsh lives at `/bin/zsh` on macOS, so removing it from `PATH` also removes `sh` — my attempted local probe was invalid and I am not presenting it as evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)