### PR TITLE
ci: build workspace packages before the stress loop

### DIFF
--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build workspace packages
+        # `tsc -b` produces the dist entries that @avg/* imports resolve to.
+        # Without it vitest fails to COLLECT every suite file with
+        # "Failed to resolve entry for package @avg/mcp-common" — which reads
+        # as a mass test failure rather than a missing build. ci.yml's node job
+        # gets this from its Typecheck step; this job runs the same suite and
+        # needs the same prerequisite.
+        run: npm run typecheck
+
       - name: Repeat the full suite
         env:
           ITERATIONS: ${{ github.event.inputs.iterations || '10' }}


### PR DESCRIPTION
#604 gave the stress job zsh and full history, and it **still failed every iteration**. My parity fix was incomplete.

The per-run logs the job uploads show why:

```
Error: Failed to resolve entry for package "@avg/mcp-common"
```

Every suite **file** fails to collect. That reads as mass test failure but is a missing build: tests import `@avg/*` from `packages/*/dist`, and `npm run typecheck` (`tsc -b packages/* services/*`) is what produces those entries. `ci.yml`'s node job gets it from its Typecheck step; this job went straight from install to the loop.

## Reproduced, not assumed

```
mv packages/mcp-common/dist aside  ->  Failed to resolve entry for package "@avg/mcp-common"
dist restored                      ->  Tests 5 passed
```

## Third time

This is the third setup gap in one workflow — zsh, shallow checkout, and now the build — each found only by running it. The first two I hand-copied from `ci.yml` and missed this one. So the step list is now **checked against** `ci.yml`'s node job rather than transcribed:

```
ci.yml node : Checkout, Setup Node, Install zsh, Install dependencies, Typecheck, Unit tests
stress      : Checkout full history, Setup Node, Install zsh, Install dependencies,
              Build workspace packages, Repeat the full suite, Upload failing run logs
still missing: none — parity reached
```

A stress job that fails for its own setup teaches nothing, and trains people to ignore a signal meant to say *"a concurrency-sensitive test is flaky"*. Worth getting right even though it is only CI plumbing.

The uploaded per-run logs are what made this diagnosable in one pass — that part of the design earned its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)