### PR TITLE
ci(int2): re-land the exit-code collision fix dropped by #608's merge

### DIFF
--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -110,7 +110,7 @@ _int2_start_db() {
     || {
       echo "INT2_DB_START_FAILED: $1 ($3) did not start" \
         | tee -a "$_int2_bootstrap_log" >&2
-      exit 26
+      exit 31
     }
 }
 
@@ -136,7 +136,7 @@ _int2_wait_db() {
   echo "INT2_DB_NEVER_READY: $1 did not answer a TCP query within 60s" \
     | tee -a "$_int2_bootstrap_log" >&2
   _int2_db_diagnostics "$1"
-  exit 27
+  exit 32
 }
 
 # Sets _int2_port_value. Deliberately NOT called in a command substitution:
@@ -154,7 +154,7 @@ _int2_db_port() {
       echo "INT2_DB_PORT_UNMAPPED: $1 published no usable 5432/tcp port" \
         | tee -a "$_int2_bootstrap_log" >&2
       _int2_db_diagnostics "$1"
-      exit 28
+      exit 33
       ;;
   esac
 }

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -80,6 +80,35 @@ describe("committed INT-2 ceremony mechanics", () => {
     expect(byName["int2-negative-verify.sh"]).toContain("int2-evidence.mjs");
   });
 
+  it("gives every automated-suite failure a distinct, self-naming exit code", async () => {
+    const suite = await readFile(AUTOMATED_SUITE, "utf8");
+
+    // Two unrelated failures sharing an exit code make the code useless for
+    // telling them apart. This caught a real collision: a new database
+    // failure was assigned 26, already held by the pilot Git ownership probe.
+    const codes = [...suite.matchAll(/^\s+exit (\d+)$/gm)]
+      .map((match) => Number(match[1]))
+      .filter((code) => code !== 1);
+    expect(codes.length).toBeGreaterThan(0);
+    expect(new Set(codes).size).toBe(codes.length);
+
+    // The bring-up region once failed in CI having printed nothing at all,
+    // because pg_isready reports on stdout and stdout was sent to /dev/null.
+    // Each of these must survive as a named marker, and readiness must be
+    // probed over TCP — the transport the suite itself uses — rather than the
+    // unix socket, which answers during initdb's temporary server.
+    for (const marker of [
+      "INT2_DB_START_FAILED",
+      "INT2_DB_NEVER_READY",
+      "INT2_DB_PORT_UNMAPPED",
+      "INT2_DB_DIAGNOSTICS",
+    ]) {
+      expect(suite).toContain(marker);
+    }
+    expect(suite).toContain("psql -h 127.0.0.1");
+    expect(suite).not.toMatch(/pg_isready -U postgres -d \S+ >\/dev\/null$/m);
+  });
+
   it("proves the controlled pair passes and a non-discriminating mutation fails", async () => {
     const result = await verifyScriptedPairPreflight({
       repositoryRoot: ROOT,


### PR DESCRIPTION
Re-lands a commit that #608's squash merge dropped. **`main` currently carries an exit-code collision that #608's own PR discussion identified.**

```
line 113  exit 26  <- INT2_DB_START_FAILED           (new, from #608)
line 218  exit 26  <- INT2_PILOT_GIT_OWNERSHIP_FAILED (pre-existing)
```

Two unrelated failures reporting the same code defeats the point of naming them — and #608 exists precisely because a failure could not be named.

## What happened

#608 had two commits. The merge took only the first:

```
c5cc31a  make the bring-up diagnosable, and probe TCP   <- on main
78f1191  give each failure a distinct code + invariant  <- DROPPED
```

The PR head lagged behind the pushed ref for several minutes (`gh pr view` reported `8f7328a6` while the remote ref was already `3e5104a5`), so the merge squashed the stale head. Worth knowing as a process hazard: **merging while a push is in flight silently drops commits, and the result still reports green** — the checks that ran were valid for what they tested, just not for what was intended to land. #606 lost a commit the same way (re-landed separately).

## The change

Database codes move to **31/32/33**; nothing outside the script references any of them. Plus the invariant as a test, so the next collision fails loudly rather than waiting to be read:

- every `exit` in the suite script must be distinct
- the four `INT2_DB_*` markers must survive
- readiness must use `psql -h 127.0.0.1`, not a bare socket `pg_isready`

Proven able to fail, by mutation:

| mutation | result |
|---|---|
| baseline (unmutated) | 1 passed |
| re-introduce the collision | **1 failed** |
| drop a named marker | **1 failed** |
| revert to the socket probe | **1 failed** |
| restored | 1 passed |

Verified on this branch after cherry-pick: codes `1 23 24 25 26 31 32 33`, no duplicates, 10/10 in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)