### PR TITLE
ci: run the stress job on PRs that change the stress job

### DIFF
--- a/.github/workflows/flake-stress.yml
+++ b/.github/workflows/flake-stress.yml
@@ -25,8 +25,13 @@ on:
         required: false
         default: "10"
   pull_request:
-    # PR-time coverage only for the areas whose races we have actually seen.
+    # PR-time coverage only for the areas whose races we have actually seen —
+    # plus this workflow itself, so a change to the job is exercised by the PR
+    # that makes it. Without that last path the job never ran on its own PRs,
+    # which is why three setup gaps (missing zsh, shallow checkout, missing
+    # build) each merged green and surfaced only on a later dispatched run.
     paths:
+      - ".github/workflows/flake-stress.yml"
       - "services/slack-operator/src/testbed-live-screencast.ts"
       - "test/unit/testbed-live-screencast.test.ts"
       - "services/slack-operator/src/index.ts"


### PR DESCRIPTION
Re-lands the second commit from #606, dropped by the same stale-head squash merge that dropped #608's.

## The gap

`flake-stress.yml`'s `pull_request` trigger is path-filtered to three screencast files, so **a PR touching only `flake-stress.yml` never runs `flake-stress.yml`.**

That is why the job's three setup gaps each merged green and surfaced only later, one round trip apiece:

| gap | how it failed | found by |
|---|---|---|
| no zsh | `zsh: ENOENT` | dispatched run |
| shallow checkout | `git 128` on baseRevision | dispatched run |
| no build | `Failed to resolve entry for @avg/mcp-common` on every file | dispatched run |

Each time I fixed one and asserted parity; the next run found another. The job that exists to catch flakes could not catch its own.

## The change

One line — the workflow's own path:

```yaml
paths:
  - ".github/workflows/flake-stress.yml"
  - "services/slack-operator/src/testbed-live-screencast.ts"
  - "test/unit/testbed-live-screencast.test.ts"
  - "services/slack-operator/src/index.ts"
```

This PR is the first to test itself.

The build fix in #606 is already verified independently — a dispatched 2-iteration run went `run 1: pass`, `run 2: pass`, `completed 2 run(s), 0 failure(s)`, with zero resolve-entry errors. This makes the *next* such change self-verifying instead of relying on someone remembering to dispatch one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)