### PR TITLE
test(int2): refuse an idle model in the container suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Prove the suite did not skip
         if: always()
-        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "9"
+        run: test "$(tr -d '[:space:]' < '${{ runner.temp }}/int2-suite-evidence/executed-count.txt')" = "10"
 
       - name: Upload INT-2 evidence
         if: always()

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -98,6 +98,30 @@ const CASE_EXPECTATIONS = Object.freeze({
     requireFence: true,
     expectedToolCommand: NEGATIVE_TOOL_COMMAND,
   }),
+  idle: Object.freeze({
+    lifecycle: "failed",
+    runCount: 1,
+    runOutcome: "failed",
+    runState: "learning_processed",
+    claimCount: 1,
+    outboxCount: 1,
+    decisions: {
+      dispatch_approval: 1,
+      handoff: 0,
+      dispatch_refusal: 0,
+    },
+    criterion: {
+      passed: false,
+      reason: "exit_1",
+      verdict: "failed",
+    },
+    requirePatch: false,
+    expectEmptyOrAbsentPatch: true,
+    requireManifest: true,
+    requireFence: true,
+    expectedAcceptanceCommand: INT2_SECTION3_CRITERION,
+    expectNoCapabilityEvents: true,
+  }),
   restart: Object.freeze({
     lifecycle: "handoff_ready",
     runCount: 1,
@@ -806,7 +830,11 @@ export function verifyInt2Evidence(
   }
 
   if (expectations.requireFence) {
-    verifyFence(evidence.task, check);
+    verifyFence(
+      evidence.task,
+      check,
+      expectations.expectedAcceptanceCommand,
+    );
   }
   if (expectations.requireManifest) {
     const binding = outbox[0];
@@ -864,6 +892,20 @@ export function verifyInt2Evidence(
       "reconstructed criterion returned exit 128",
     );
   }
+  if (expectations.expectEmptyOrAbsentPatch) {
+    const patch = evidence?.patch;
+    const patchAbsent = patch === null
+      && evidence?.deliverables?.workspace_patch === undefined;
+    const patchEmpty = patch?.byteLength === 0
+      && (patch?.numstat ?? "").trim().length === 0
+      && Array.isArray(patch?.touchedPaths)
+      && patch.touchedPaths.length === 0;
+    check(
+      patchAbsent || patchEmpty,
+      "workspace_patch_empty_or_absent",
+      `workspace patch=${JSON.stringify(patch)}`,
+    );
+  }
 
   if (expectations.criterion) {
     const verification = evidence?.verification;
@@ -903,20 +945,22 @@ export function verifyInt2Evidence(
         `required_failed=${JSON.stringify(verification?.requiredFailed)}`,
       );
     } else {
-      check(
-        evidence?.patch?.criterionExitCode !== 0
-        && evidence?.patch?.criterionExitCode !== 128,
-        "criterion_reconstruction_red",
-        `reconstructed exit ${evidence?.patch?.criterionExitCode}`,
-      );
-      check(
-        /whitespace/iu.test(
-          `${evidence?.patch?.criterionStdout ?? ""}\n`
-          + `${evidence?.patch?.criterionStderr ?? ""}`,
-        ),
-        "criterion_rejected_whitespace",
-        "reconstructed rejection did not name whitespace",
-      );
+      if (!expectations.expectEmptyOrAbsentPatch) {
+        check(
+          evidence?.patch?.criterionExitCode !== 0
+          && evidence?.patch?.criterionExitCode !== 128,
+          "criterion_reconstruction_red",
+          `reconstructed exit ${evidence?.patch?.criterionExitCode}`,
+        );
+        check(
+          /whitespace/iu.test(
+            `${evidence?.patch?.criterionStdout ?? ""}\n`
+            + `${evidence?.patch?.criterionStderr ?? ""}`,
+          ),
+          "criterion_rejected_whitespace",
+          "reconstructed rejection did not name whitespace",
+        );
+      }
       check(
         Array.isArray(verification?.requiredFailed)
         && verification.requiredFailed.includes("format-command"),
@@ -924,6 +968,17 @@ export function verifyInt2Evidence(
         `required_failed=${JSON.stringify(verification?.requiredFailed)}`,
       );
     }
+  }
+
+  if (expectations.expectNoCapabilityEvents) {
+    const capabilityEvents = (evidence?.events ?? []).filter(
+      (event) => /^Capability/u.test(event?.type ?? ""),
+    );
+    check(
+      capabilityEvents.length === 0,
+      "idle_model_no_tool_calls",
+      `found ${capabilityEvents.length} capability events`,
+    );
   }
 
   if (expectations.expectedToolCommand) {
@@ -1205,7 +1260,11 @@ async function runFixtureCriterion({
   }
 }
 
-function verifyFence(task, check) {
+function verifyFence(
+  task,
+  check,
+  expectedAcceptanceCommand = "git diff --check",
+) {
   check(
     task?.repository?.nameWithOwner ===
       "depre-dev/averray-reference-agent",
@@ -1248,7 +1307,7 @@ function verifyFence(task, check) {
     equal(task?.acceptance?.criteria, [{
       id: "format-command",
       type: "command",
-      command: "git diff --check",
+      command: expectedAcceptanceCommand,
       required: true,
     }]),
     "fence_acceptance",

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -225,7 +225,7 @@ export INT2_REPOSITORY_ROOT="$_int2_repo"
 export INT2_SUITE_EVIDENCE_DIR="$_int2_evidence"
 export INT2_SUITE_EXECUTION_MARKER="$_int2_marker"
 
-printf '%s\n' "INT2_CASES_STARTED expected=9" >> "$_int2_bootstrap_log"
+printf '%s\n' "INT2_CASES_STARTED expected=10" >> "$_int2_bootstrap_log"
 (
   cd "$_int2_repo"
   npm run build
@@ -234,9 +234,9 @@ printf '%s\n' "INT2_CASES_STARTED expected=9" >> "$_int2_bootstrap_log"
 )
 
 _int2_executed="$(tr -d '[:space:]' < "$_int2_marker")"
-test "$_int2_executed" = "9" \
+test "$_int2_executed" = "10" \
   || {
-    echo "INT-2 suite executed $_int2_executed cases; expected 9" >&2
+    echo "INT-2 suite executed $_int2_executed cases; expected 10" >&2
     exit 1
   }
 _int2_elapsed="$(( $(date +%s) - _int2_started ))"

--- a/test/fixtures/agent-integration/ceremony/lint-format-idle.jsonl
+++ b/test/fixtures/agent-integration/ceremony/lint-format-idle.jsonl
@@ -1,0 +1,1 @@
+{"text":"No changes were made.","usage":{"input_tokens":2,"output_tokens":2,"requests":1},"finish_reason":"stop"}

--- a/test/integration/int2-automated-suite.test.ts
+++ b/test/integration/int2-automated-suite.test.ts
@@ -73,7 +73,7 @@ const FIXTURE_ROOT = path.join(
   REPOSITORY_ROOT,
   "test/fixtures/agent-integration/ceremony",
 );
-const EXPECTED_CASE_COUNT = 9;
+const EXPECTED_CASE_COUNT = 10;
 const TEST_TIMEOUT_MS = 240_000;
 const TERMINAL_WAIT_MS = 180_000;
 const HARNESS_STATE_WAIT_MS = 90_000;
@@ -277,6 +277,28 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
       },
       "events_have_no_exit_128",
       "inject exit_128 into the recorded verifier evidence",
+    );
+  }, TEST_TIMEOUT_MS);
+
+  it("refuses an idle model on the exact paid-task criterion", async () => {
+    executedCases += 1;
+    const evidence = await runScriptedTerminalCase({
+      caseName: "idle",
+      fixture: "lint-format",
+      script: "lint-format-idle.jsonl",
+      lifecycle: "failed",
+    });
+    assertD3Mutation(
+      "idle",
+      evidence,
+      (mutated) => {
+        const format = mutated.verification.details.find(
+          (detail: any) => detail.id === "format-command",
+        );
+        format.reason = "exit_0";
+      },
+      "required_criterion_reason",
+      "change the recorded criterion reason from exit_1 to exit_0",
     );
   }, TEST_TIMEOUT_MS);
 
@@ -492,9 +514,12 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
     lifecycle,
     preserveProfile = false,
   }: {
-    caseName: "green" | "negative" | "narrow";
-    fixture: "lint-format-green" | "lint-format-red";
-    script: "lint-format-green.jsonl" | "lint-format-red.jsonl";
+    caseName: "green" | "idle" | "negative" | "narrow";
+    fixture: "lint-format" | "lint-format-green" | "lint-format-red";
+    script:
+      | "lint-format-green.jsonl"
+      | "lint-format-idle.jsonl"
+      | "lint-format-red.jsonl";
     lifecycle: "handoff_ready" | "failed";
     preserveProfile?: boolean;
   }): Promise<any> {

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -109,6 +109,47 @@ describe("committed INT-2 ceremony mechanics", () => {
     expect(suite).not.toMatch(/pg_isready -U postgres -d \S+ >\/dev\/null$/m);
   });
 
+  it("keeps the idle model text-only and all three suite counts at ten", async () => {
+    const [idleScript, integrationSuite, shellSuite, workflow] =
+      await Promise.all([
+        readFile(
+          path.join(
+            ROOT,
+            "test/fixtures/agent-integration/ceremony/lint-format-idle.jsonl",
+          ),
+          "utf8",
+        ),
+        readFile(
+          path.join(ROOT, "test/integration/int2-automated-suite.test.ts"),
+          "utf8",
+        ),
+        readFile(AUTOMATED_SUITE, "utf8"),
+        readFile(path.join(ROOT, ".github/workflows/ci.yml"), "utf8"),
+      ]);
+    const turns = idleScript.trimEnd().split("\n").map((line) =>
+      JSON.parse(line) as Record<string, unknown>
+    );
+
+    expect(turns).toEqual([expect.objectContaining({
+      text: expect.any(String),
+      finish_reason: "stop",
+    })]);
+    expect(turns[0]).not.toHaveProperty("tool_calls");
+    expect(expectationsForCase("idle")).toMatchObject({
+      lifecycle: "failed",
+      criterion: { passed: false, reason: "exit_1", verdict: "failed" },
+      decisions: { dispatch_approval: 1, handoff: 0 },
+      expectEmptyOrAbsentPatch: true,
+      expectedAcceptanceCommand: INT2_SECTION3_CRITERION,
+      expectNoCapabilityEvents: true,
+    });
+
+    expect(integrationSuite).toContain("const EXPECTED_CASE_COUNT = 10;");
+    expect(shellSuite).toContain("INT2_CASES_STARTED expected=10");
+    expect(shellSuite).toContain('test "$_int2_executed" = "10"');
+    expect(workflow).toContain("executed-count.txt')\" = \"10\"");
+  });
+
   it("proves the controlled pair passes and a non-discriminating mutation fails", async () => {
     const result = await verifyScriptedPairPreflight({
       repositoryRoot: ROOT,


### PR DESCRIPTION
## What changed

- Added `lint-format-idle.jsonl`, a committed one-turn, text-only scripted model with `finish_reason: "stop"` and no tool call.
- Added the tenth INT-2 container-suite case using the existing `lint-format` fixture and its exact §3 criterion.
- Added idle-case evidence expectations for `exit_1`, failed verification/lifecycle, one approval and no handoff, attempt one, no capability events, and an empty-or-absent workspace patch.
- Added the D3 mutation `exit_1 -> exit_0`; `verifyInt2Evidence` rejects it with `required_criterion_reason` and the mutation is recorded in `suite-summary.json`.
- Moved the expected case count from 9 to 10 in the integration suite, shell gate, and CI skip-detector together, with a unit guard covering all three sites.

## Observed real container evidence

The disposable suite ran through the production dispatcher path with the pinned Harness and pilot Docker image:

- criterion: `format-command`, `passed=false`, `reason=exit_1`
- verifier: `verdict=failed`, `required_failed=["format-command"]`
- AgentTask lifecycle: `failed`
- Harness: one run, `attempt=1`, `outcome=failed`
- decisions: exactly one `dispatch_approval`; zero `handoff`
- model activity: zero capability events/tool calls
- workspace patch: present as the empty SHA-256 artifact, `byteLength=0`, no touched paths, empty numstat
- `exit128Present=false`; the exact `exit_1` reason excludes `exit_0`, `exit_128`, and `exit_129`

D3 in `suite-summary.json`:

```json
{
  "case": "idle",
  "mutation": "change the recorded criterion reason from exit_1 to exit_0",
  "observedFailure": "required_criterion_reason"
}
```

The same summary records `executedCases=10` and `expectedCases=10`.

## Checks

- `npm run typecheck` — exit 0
- `npm test` — 142 files passed, 2 skipped; 1,999 tests passed, 14 skipped
- `npm run build` — exit 0
- `scripts/ceremony/run-int2-automated-suite.sh` — 10/10 through the real container path, exit 0, 175 seconds
- `git diff --check` — exit 0

## Scope and authority

Affected surfaces: CI workflow skip-detector, ceremony evidence verifier, automated-suite shell runner, scripted fixture, integration test, and ceremony unit tests.

No §3 criterion or task fixture changed. No `lint-format-red`/`lint-format-green` fixture or recorded §2.5/§2.6 proof changed. This does not run the paid task, enable production dispatch, access production databases, add authority, change secrets/config, or touch money, wallet, signer, claim, or submission paths.

## Count synchronization note

The TypeScript, shell, and workflow counts remain three explicit hand-synchronized contract sites. Deriving YAML and shell literals from a new generated/shared source would add parsing or generation machinery beyond this narrow evidence case. Instead, a focused unit invariant now reads all three committed files and fails if any site is not 10.

## Rollout / rollback

Rollout is CI-only: the required INT-2 job runs one additional scripted container case and its skip-detector expects ten. No production rollout or environment change is required.

Rollback is a revert of this PR, which removes the idle case and returns all three count sites to nine together. Human merge/deploy ownership is unchanged.