### PR TITLE
Stop the board crying stale; make uptime state its own span

### DIFF
--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -58,6 +58,81 @@ describe("OpsBoard — the honest empty states", () => {
   });
 });
 
+describe("OpsBoard — the banner must not argue with the trust panel", () => {
+  // Caught on screen: the banner said "every value below is STALE" while the
+  // trust row two inches right said "4m ago — fresh". Both were computed
+  // correctly from different facts; the SENTENCE was the bug. A dead stream
+  // with a recent reading means frozen, not wrong.
+  test("stream down + a recent check says FROZEN, not stale", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    const nowMs = health.at! + 60_000;
+    const { getByTestId } = render(
+      <OpsBoard health={health} streamDegraded streamStatus="reconnecting" nowMs={nowMs} />,
+    );
+    const banner = getByTestId("ops-stale-banner").textContent ?? "";
+    expect(banner).toContain("FROZEN");
+    expect(banner).not.toContain("STALE and may be wrong");
+    // …and the trust row agrees rather than contradicting it.
+    expect(getByTestId("ops-trust").textContent).toContain("fresh");
+  });
+
+  test("a genuinely old check does say STALE", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    const nowMs = health.at! + 30 * 60_000;
+    const { getByTestId } = render(<OpsBoard health={health} nowMs={nowMs} />);
+    expect(getByTestId("ops-stale-banner").textContent).toContain("STALE and may be wrong");
+    expect(getByTestId("ops-trust").textContent).toContain("STALE");
+  });
+
+  // The regression that started this: a 3-minute threshold against a 2-minute
+  // heartbeat lit the alarm over a healthy system, most of the time.
+  test("a merely-late check raises NO banner at all", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    const { queryByTestId } = render(<OpsBoard health={health} nowMs={health.at! + 3 * 60_000} />);
+    expect(queryByTestId("ops-stale-banner")).toBeNull();
+  });
+});
+
+describe("OpsBoard — uptime states its span", () => {
+  // "uptime 100.0%" off one check, labelled 24h, printed beside "awaiting
+  // history" on the same line. The number was fine; the span was a claim we
+  // never observed.
+  test("a short buffer names the span it actually covers", () => {
+    const health = {
+      ...OPS_FIXTURE_NOMINAL,
+      history: {
+        ...OPS_FIXTURE_NOMINAL.history,
+        uptimePct24h: 100,
+        uptimeSamples: 6,
+        uptimeSpanMs: 12 * 60_000,
+        uptimeWindowMs: 24 * 3_600_000,
+      },
+    };
+    const { getByTestId } = render(<OpsBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("ops-pillars").textContent).toContain("uptime 100.0% over 12m");
+  });
+
+  test("a single check withholds the percentage entirely", () => {
+    const health = {
+      ...OPS_FIXTURE_NOMINAL,
+      history: { ...OPS_FIXTURE_NOMINAL.history, uptimePct24h: 100, uptimeSamples: 1, uptimeSpanMs: 0 },
+    };
+    const { getByTestId } = render(<OpsBoard health={health} nowMs={fresh(health)} />);
+    const pillars = getByTestId("ops-pillars").textContent ?? "";
+    expect(pillars).toContain("too few checks");
+    expect(pillars).not.toContain("100.0%");
+  });
+
+  test("a full window drops the qualifier", () => {
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const pillars = getByTestId("ops-pillars").textContent ?? "";
+    expect(pillars).toContain("uptime 100.0%");
+    expect(pillars).not.toContain("over ");
+  });
+});
+
 describe("OpsBoard — solvency meters", () => {
   test("only floored pools draw a bar", () => {
     const { container } = render(

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -18,7 +18,7 @@
 import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, incidentRows } from "../../lib/monitor/ops-model.js";
-import { DATA_STALE_MS, opsVerdict, trustRows } from "../../lib/monitor/ops-spec.js";
+import { opsVerdict, staleAfterMs, trustRows } from "../../lib/monitor/ops-spec.js";
 import { FlowPanel } from "./FlowPanel.js";
 import { PillarStrip } from "./PillarStrip.js";
 import { SolvencyPanel } from "./SolvencyPanel.js";
@@ -46,7 +46,7 @@ export function OpsBoard({
   const verdict = opsVerdict({ health, streamDegraded, nowMs });
   const trust = trustRows({ health, streamDegraded, streamStatus, streamAt: board?.at, nowMs });
   const ageMs = health.at == null ? null : Math.max(0, nowMs - health.at);
-  const dataStale = ageMs != null && ageMs > DATA_STALE_MS;
+  const dataStale = ageMs != null && ageMs > staleAfterMs(health);
   // "Untrusted" is broader than "disconnected": a stream that is nominally open
   // but has not delivered a check in minutes is equally unsafe to read calmly.
   const untrusted = streamDegraded || dataStale;
@@ -70,14 +70,15 @@ export function OpsBoard({
         </span>
       </div>
 
+      {/* The banner must claim exactly the fault that exists. A dead stream and
+          stale data are different failures and can occur separately: with the
+          stream down but the last check a couple of minutes old, "every value
+          below is STALE" contradicted the trust panel's own "4m ago — fresh"
+          two lines to the right. Frozen is not the same as wrong. */}
       {untrusted ? (
         <div className="ops-stale" role="alert" data-testid="ops-stale-banner">
           <strong>{streamDegraded ? "STREAM DISCONNECTED" : "DATA STALE"}</strong>
-          <span>
-            {health.at == null
-              ? "no successful check yet — nothing below is confirmed"
-              : `last update ${formatAgo(health.at, nowMs)} — every value below is STALE and may be wrong`}
-          </span>
+          <span>{staleBannerDetail({ health, nowMs, streamDegraded, dataStale })}</span>
           <span className="ops-stale-right">{streamDegraded ? `reconnecting · ${streamStatus}` : "poll failing"}</span>
         </div>
       ) : null}
@@ -126,6 +127,32 @@ export function OpsBoard({
       </div>
     </div>
   );
+}
+
+/**
+ * Say which thing is actually broken.
+ *
+ * Three distinct cases, and collapsing them into one sentence produced a banner
+ * that argued with the trust panel beside it:
+ *   · never checked  — nothing is confirmed, and nothing is stale either
+ *   · stream down, reading still recent — FROZEN, not wrong. It was true when
+ *     it was taken and it will not move until the stream returns
+ *   · genuinely old   — stale, and may no longer describe the product
+ */
+function staleBannerDetail(input: {
+  health: ProductHealth;
+  nowMs: number;
+  streamDegraded: boolean;
+  dataStale: boolean;
+}): string {
+  const { health, nowMs, streamDegraded, dataStale } = input;
+  if (health.at == null) return "no successful check yet — nothing below is confirmed";
+  const age = formatAgo(health.at, nowMs);
+  if (dataStale) return `last update ${age} — every value below is STALE and may be wrong`;
+  if (streamDegraded) {
+    return `last update ${age} — values below are FROZEN at that reading and will not update until the stream returns`;
+  }
+  return `last update ${age}`;
 }
 
 function metaLine(health: ProductHealth): string {

--- a/packages/monitor-ui/src/components/ops/PillarStrip.tsx
+++ b/packages/monitor-ui/src/components/ops/PillarStrip.tsx
@@ -10,7 +10,7 @@
 // amber count is how a board acquires a permanently-lit warning.
 
 import type { ProductHealthProbe, HealthHistory } from "../../lib/monitor/product-health.js";
-import { groupProbesByPillar, probeOpsTone, type OpsTone } from "../../lib/monitor/ops-model.js";
+import { formatDuration, groupProbesByPillar, probeOpsTone, type OpsTone } from "../../lib/monitor/ops-model.js";
 import { LineSpark } from "./OpsSparks.js";
 
 export interface PillarStripProps {
@@ -80,6 +80,38 @@ function rollup(tones: OpsTone[]): string {
 }
 
 /**
+ * Uptime, labelled with the span it was actually measured over.
+ *
+ * "uptime 100.0%" is a claim about a WINDOW, and the history buffer lives in
+ * memory — so a deploy empties it and a minute later that figure rested on one
+ * check while the board called it 24h. It even rendered beside "awaiting
+ * history" on the same line, the two halves contradicting each other.
+ *
+ * Nothing was wrong with the number; the span was. So the span is stated
+ * whenever it falls short of the window, and the percentage is withheld
+ * entirely below a couple of samples, where it carries no information at all
+ * (one check that passed is "100%", which is true and useless).
+ */
+function uptimeText(history: HealthHistory | undefined): string {
+  const pct = history?.uptimePct24h;
+  if (typeof pct !== "number") return "uptime accruing";
+
+  const samples = history?.uptimeSamples;
+  if (typeof samples === "number" && samples < 2) return "uptime — too few checks";
+
+  const span = history?.uptimeSpanMs;
+  const window = history?.uptimeWindowMs;
+  // No span reported (older snapshot) → say the coverage is unknown rather than
+  // silently implying the full window.
+  if (typeof span !== "number" || typeof window !== "number" || window <= 0) {
+    return `uptime ${pct.toFixed(1)}% · span unknown`;
+  }
+  // Within ~5% of the window is the window, allowing for check jitter.
+  if (span >= window * 0.95) return `uptime ${pct.toFixed(1)}%`;
+  return `uptime ${pct.toFixed(1)}% over ${formatDuration(span)}`;
+}
+
+/**
  * The one trend that earns space on this board: 24h latency + uptime. Both stay
  * honestly absent until the ring buffer has enough samples — a line drawn
  * through two points is a fabricated trend, so it reads "awaiting history"
@@ -88,8 +120,7 @@ function rollup(tones: OpsTone[]): string {
 function AvailabilityTrend({ history }: { history: HealthHistory | undefined }) {
   const series = history?.latencySeriesMs ?? [];
   const samples = series.filter((n): n is number => typeof n === "number");
-  const uptime = history?.uptimePct24h;
-  const uptimeLabel = typeof uptime === "number" ? `uptime ${uptime.toFixed(1)}%` : "uptime accruing";
+  const uptimeLabel = uptimeText(history);
 
   if (samples.length < 2) {
     return (

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -251,6 +251,7 @@ export const OPS_FIXTURE_NOMINAL: ProductHealth = {
   at: FIXTURE_NOW - 2_000,
   status: "degraded",
   checks: 1_284,
+  checkIntervalMs: 2 * 60_000,
   chainId: 420420419,
   network: "mainnet",
   probes: MAINNET_PROBES,
@@ -290,6 +291,11 @@ export const OPS_FIXTURE_NOMINAL: ProductHealth = {
   },
   history: {
     uptimePct24h: 100,
+    // A full window's worth — so the label reads a bare "uptime 100.0%". Drop
+    // uptimeSpanMs below the window and it becomes "100.0% over 47m" instead.
+    uptimeSamples: 48,
+    uptimeSpanMs: 24 * 3_600_000,
+    uptimeWindowMs: 24 * 3_600_000,
     uptimeSeries: Array.from({ length: 48 }, () => "ok" as ProbeStatus),
     latencySeriesMs: ramp(48, (i) => 48 + Math.round(9 * Math.abs(Math.sin(i / 2.7)))),
     balanceSeries: ramp(48, () => 15.89),

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  DATA_STALE_FALLBACK_MS,
   METER_RUNGS,
+  staleAfterMs,
   opsVerdict,
   payoutView,
   poolMeter,
@@ -168,8 +170,44 @@ describe("opsVerdict", () => {
   });
 
   test("stale data alone is enough to relabel, even on an open stream", () => {
-    const v = opsVerdict({ health: OPS_FIXTURE_NOMINAL, streamDegraded: false, nowMs: OPS_FIXTURE_NOMINAL.at! + 10 * 60_000 });
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    const v = opsVerdict({ health, streamDegraded: false, nowMs: health.at! + 6 * 60_000 });
     expect(v.kicker).toContain("DATA STALE");
+  });
+
+  // THE FALSE RED, PINNED. The threshold was a flat 3 minutes against a
+  // 2-minute heartbeat, so one late check lit "every value below may be wrong"
+  // over a healthy mainnet — and it was lit most of the time. An alarm that is
+  // always on is one the operator learns to scroll past.
+  test("one missed check does NOT raise a stale alarm", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    // 3 minutes old: a late check on a 2-minute cadence. Not an incident.
+    const v = opsVerdict({ health, streamDegraded: false, nowMs: health.at! + 3 * 60_000 });
+    expect(v.kicker).toContain("OPERATOR VERDICT");
+    expect(v.kicker).not.toContain("STALE");
+  });
+
+  test("the threshold follows the reported cadence rather than a constant", () => {
+    const slow = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 10 * 60_000 };
+    // 20 minutes is two intervals on a 10-minute cadence — still not stale…
+    expect(
+      opsVerdict({ health: slow, streamDegraded: false, nowMs: slow.at! + 20 * 60_000 }).kicker,
+    ).toContain("OPERATOR VERDICT");
+    // …while the same age on a 2-minute cadence is long past it.
+    const fast = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    expect(
+      opsVerdict({ health: fast, streamDegraded: false, nowMs: fast.at! + 20 * 60_000 }).kicker,
+    ).toContain("DATA STALE");
+  });
+
+  // A too-tight guess is what produced the false alarm, so an unknown cadence
+  // errs generous rather than crying stale.
+  test("an unreported cadence falls back generously, not tightly", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: undefined };
+    expect(staleAfterMs(health)).toBe(DATA_STALE_FALLBACK_MS);
+    expect(
+      opsVerdict({ health, streamDegraded: false, nowMs: health.at! + 5 * 60_000 }).kicker,
+    ).toContain("OPERATOR VERDICT");
   });
 
   // Being unable to SEE the money must not be shouted as money being broken.
@@ -309,12 +347,24 @@ describe("trustRows", () => {
   });
 
   test("a stale snapshot marks DATA AGE red even while the stream is open", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
     const rows = trustRows({
-      health: OPS_FIXTURE_NOMINAL,
+      health,
       streamDegraded: false,
       streamStatus: "open",
-      nowMs: OPS_FIXTURE_NOMINAL.at! + 10 * 60_000,
+      nowMs: health.at! + 10 * 60_000,
     });
     expect(rows.find((r) => r.key === "DATA AGE")!.tone).toBe("red");
+  });
+
+  test("a merely-late check keeps DATA AGE green", () => {
+    const health = { ...OPS_FIXTURE_NOMINAL, checkIntervalMs: 2 * 60_000 };
+    const rows = trustRows({
+      health,
+      streamDegraded: false,
+      streamStatus: "open",
+      nowMs: health.at! + 3 * 60_000,
+    });
+    expect(rows.find((r) => r.key === "DATA AGE")!.tone).toBe("ok");
   });
 });

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -26,8 +26,35 @@ import type {
 import { deriveOpsVerdict, payoutGap } from "@avg/schemas/ops-verdict";
 import { formatAgo, formatAmount, type OpsTone } from "./ops-model.js";
 
-/** Beyond this, a snapshot is old enough that the board says so out loud. */
-export const DATA_STALE_MS = 3 * 60 * 1000;
+/**
+ * When is a snapshot old enough to say so out loud?
+ *
+ * This was a flat 3 minutes, picked by intuition. The heartbeat runs every 2 —
+ * so a single late check lit "DATA STALE · every value below may be wrong" over
+ * a perfectly healthy mainnet, and it was lit most of the time. That is exactly
+ * the false red the board's own rules forbid: an alarm that is always on is one
+ * the operator learns to scroll past, which makes the next one invisible.
+ *
+ * The threshold now comes from the cadence the SERVER reports, so it follows a
+ * config change instead of drifting out of agreement with one. Two and a half
+ * intervals tolerates one missed check and not two.
+ *
+ * Same lesson as the block-time bug: measure the thing you are comparing
+ * against, don't assume it.
+ */
+export const STALE_INTERVAL_MULTIPLE = 2.5;
+
+/** Fallback when the server reports no cadence — generous on purpose, because a
+ *  too-tight guess produces precisely the false alarm described above. */
+export const DATA_STALE_FALLBACK_MS = 10 * 60 * 1000;
+
+export function staleAfterMs(health: Pick<ProductHealth, "checkIntervalMs">): number {
+  const interval = health.checkIntervalMs;
+  if (typeof interval !== "number" || !Number.isFinite(interval) || interval <= 0) {
+    return DATA_STALE_FALLBACK_MS;
+  }
+  return interval * STALE_INTERVAL_MULTIPLE;
+}
 
 // ── 1. the verdict ──────────────────────────────────────────────────────────
 
@@ -113,7 +140,7 @@ export function opsVerdict(input: {
   }
 
   const ageMs = health.at == null ? null : Math.max(0, nowMs - health.at);
-  const stale = streamDegraded || (ageMs != null && ageMs > DATA_STALE_MS);
+  const stale = streamDegraded || (ageMs != null && ageMs > staleAfterMs(health));
   return {
     kicker: stale
       ? `LAST KNOWN STATE — ${streamDegraded ? "STREAM DOWN" : "DATA STALE"} · ${health.at == null ? "age unknown" : formatAgo(health.at, nowMs)}`
@@ -167,7 +194,7 @@ export function trustRows(input: {
     rows.push({ key: "DATA AGE", value: "no check yet", tone: "awaiting" });
   } else {
     const ageMs = Math.max(0, nowMs - health.at);
-    const stale = ageMs > DATA_STALE_MS;
+    const stale = ageMs > staleAfterMs(health);
     rows.push({
       key: "DATA AGE",
       value: `${formatAgo(health.at, nowMs)} — ${stale ? "STALE" : "fresh"}`,

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -159,8 +159,16 @@ export interface OpsIncident {
  * and Incidents zones render their honest "history accruing" placeholders.
  */
 export interface HealthHistory {
-  /** 0..100 over the trailing 24h, or null if under 24h of data. */
+  /** 0..100 over the trailing window. Read `uptimeSpanMs` before labelling it:
+   *  the percentage does NOT imply the window is covered, and calling it "24h"
+   *  when one check backs it is a claim about a span we never observed. */
   uptimePct24h?: number | null;
+  /** Determinate samples behind the percentage. */
+  uptimeSamples?: number | null;
+  /** Elapsed time those samples actually span; null/absent = coverage unknown. */
+  uptimeSpanMs?: number | null;
+  /** The window the percentage claims to cover, for comparison against the span. */
+  uptimeWindowMs?: number | null;
   /** Per-check overall status, oldest → newest. */
   uptimeSeries?: ProbeStatus[];
   /** Per-check API latency ms (null = missing sample), oldest → newest. */
@@ -194,6 +202,9 @@ export interface ProductHealth {
   at: number | null;
   status: ProductHealthStatus;
   checks: number;
+  /** How often the heartbeat is expected to update this payload. Absent on
+   *  older snapshots — readers must fall back, never assume a value. */
+  checkIntervalMs?: number | null;
   probes: ProductHealthProbe[];
   // ── optional structured blocks (forward-compat) ──
   chainId?: number | null;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -17,9 +17,29 @@
    Loaded last in main.tsx so its additive rules win.
    ========================================================= */
 
+/* The board is sized to fill the window, so the money band can stretch and the
+   footer sits on the bottom edge. `height: 100%` needs an unbroken chain to
+   resolve against, and there wasn't one — nothing in the stylesheets gave
+   html/body/#root a height, so the board collapsed to its content and left the
+   lower third of the screen empty. `100dvh` so mobile browser chrome doesn't
+   push the footer under the address bar. */
+html,
+body,
+#root {
+  height: 100%;
+}
+.hm-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  min-height: 0;
+  overflow: hidden;
+}
+
 .ops-board {
   --ops-hair: rgba(237, 230, 221, 0.10);
   --ops-rule: rgba(237, 230, 221, 0.16);
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -366,6 +386,11 @@
 .ops-funnel {
   display: flex;
   align-items: center;
+  /* Take the slack between the header and the evidence rather than leaving it
+     all in one gap underneath. `align-items: center` then keeps the numerals
+     optically centred in whatever height the panel ends up with. */
+  flex: 1;
+  min-height: 0;
   margin-top: 10px;
   padding: 0 8px;
 }
@@ -571,7 +596,16 @@
   color: var(--h4-muted);
 }
 .ops-pillar-trend[data-tone="awaiting"] { color: var(--h4-tel); }
-.ops-pillar-trend .ops-linespark { flex: none; }
+/* LineSpark sets a viewBox but no width/height attributes, so the <svg> takes
+   whatever space it is given. Once the board filled the viewport that became a
+   lot — the 96×20 sparkline rendered ~4× oversized and shoved its own label
+   into a one-word-per-line column. Pin the box here. */
+.ops-pillar-trend .ops-linespark {
+  flex: none;
+  width: 96px;
+  height: 20px;
+}
+.ops-pillar-trend > span { min-width: 0; }
 
 /* ---- footer ------------------------------------------------------
    LLM spend lives here — one line. It is the least urgent number on

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -750,6 +750,18 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       at: last?.at ?? null,
       status: last?.status ?? "unknown",
       checks: productHealthHistory.length,
+      // How often this endpoint is expected to update.
+      //
+      // Without it a reader has to GUESS how old is too old, and the board
+      // guessed 3 minutes against a 2-minute heartbeat — one minute of slack, so
+      // a single late check lit "DATA STALE · every value below may be wrong"
+      // over a perfectly healthy system. A permanently-lit alarm is one the
+      // operator learns to scroll past, which makes the next one invisible; a
+      // false red costs as much as a false green.
+      //
+      // Publish the cadence and let each reader derive its own threshold from
+      // the measurement instead of from an assumption.
+      checkIntervalMs: routineConfig.productHealth.intervalMs,
       // THE OPERATOR VERDICT — the same `deriveOpsVerdict` the board renders,
       // from @avg/schemas, so this endpoint carries the board's CONCLUSION and
       // not merely the facts behind it.

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -135,6 +135,13 @@ export interface ProductHealthHistoryBlock {
    *  and healthy, 0..100. Unknown monitor samples are excluded; null means the
    *  window contains no determinate product-availability evidence. */
   uptimePct24h: number | null;
+  /** Determinate samples behind that percentage. */
+  uptimeSamples: number;
+  /** Elapsed time those samples actually span; null = none in-window. A
+   *  percentage without this is a claim about a window it may not cover. */
+  uptimeSpanMs: number | null;
+  /** The window the percentage claims — so a reader can compare the two. */
+  uptimeWindowMs: number;
   /** Per-check product_api availability (oldest→newest), bounded to `maxSeries`.
    *  Missing/unknown product_api evidence is degraded/grey, never fake-green. */
   uptimeSeries: ProbeStatus[];
@@ -178,8 +185,31 @@ export function deriveProductHealthHistory(
       ? Math.round((availability.filter((status) => status === "ok").length / availability.length) * 1000) / 10
       : null;
 
+  // HOW MUCH of the window those samples actually cover.
+  //
+  // This buffer is in memory, so a deploy empties it — and a minute later the
+  // percentage above is a confident "100.0" computed from one check, which the
+  // board rendered as "uptime 24h". Nobody lied about the value; the SPAN was
+  // wrong. Same shape as sizing a block lookback at 6s/block on a 2.11s chain,
+  // and worse in one way: the figure is most reassuring exactly when it is
+  // least earned — right after a deploy, when something is most likely broken.
+  //
+  // So the span travels with the number and the reader labels it honestly.
+  // A single sample spans zero: a point covers no interval, and rounding that
+  // up to "24h" is the bug again.
+  const uptimeSpanMs =
+    inWindow.length > 0
+      ? Math.max(0, (inWindow[inWindow.length - 1]?.at ?? 0) - (inWindow[0]?.at ?? 0))
+      : null;
+
   return {
     uptimePct24h,
+    /** Determinate samples behind the percentage (degraded/unknown excluded). */
+    uptimeSamples: availability.length,
+    /** Elapsed time the samples span. Null = nothing observed in-window. */
+    uptimeSpanMs,
+    /** The window the percentage CLAIMS to cover, so the two can be compared. */
+    uptimeWindowMs,
     uptimeSeries: series.map(productAvailabilityTone),
     latencySeriesMs: series.map((s) => s.latencyMs ?? null),
     balanceSeries: series.map((s) => s.signerUsdc ?? null),


### PR DESCRIPTION
Three defects found by opening the live board in Chrome after the deploy. **Two of them are mine, introduced by the redesign.**

## 1. A false red, lit most of the time

The board was showing **DATA STALE · "every value below is STALE and may be wrong"**, all values dimmed, over a perfectly healthy mainnet.

Threshold was a flat 3 minutes, picked by intuition. The heartbeat runs every **2** (`PRODUCT_HEALTH_INTERVAL_MINUTES || 2`). Sixty seconds of slack — so one late check trips it, and it is up more often than not.

This is the board's own rule, violated by the board: *an alarm that is always on is one the operator learns to scroll past, which makes the next one invisible.* It's also the same mistake as sizing a block lookback at 6s/block on a 2.11s chain — **assume the interval rather than measure it.**

The service now publishes `checkIntervalMs`; the board derives its threshold from it at 2.5 intervals (one missed check tolerated, two not). Config changes move both together. An unreported cadence falls back *generously*, because a tight guess is exactly what caused this.

## 2. Uptime claimed a span it never observed

The history buffer is in memory, so every deploy empties it. A minute later `uptime 100.0%` rested on **one check** while the board labelled it 24h — printed on the same line as "awaiting history", the two halves contradicting each other in a single sentence.

The number was right. The span was a fabrication. `uptimeSpanMs` / `uptimeSamples` / `uptimeWindowMs` now travel with the figure:

- short of the window → `uptime 100.0% over 47m`
- under two samples → withheld entirely (one passing check is "100%" — true, and worth nothing)
- full window → plain `uptime 100.0%`

## 3. The board didn't fill the window

Nothing gave `html`/`body`/`#root` a height, so `height: 100%` had nothing to resolve against and the lower third of the screen was black.

Fixing it exposed two consequences, both caught in the browser: `LineSpark` sets a viewBox but no width/height, so the sparkline rendered ~4× oversized and shoved its own label into a one-word-per-line column; and the funnel now absorbs the slack in the flow panel instead of leaving one dead 300px gap above the evidence.

## 4. …and fixing (1) exposed a fourth, also mine

With the stream down but the last check recent, the banner read *"every value below is STALE"* while the trust row two inches to the right read *"4m ago — fresh"*. Both were computed correctly from different facts — the **sentence** was wrong.

A dead stream with a recent reading means **FROZEN**, not wrong. The banner now distinguishes never-checked / frozen / genuinely-stale, so it can't argue with the panel beside it.

## Verification

- full suite **2008 passed**, 13 skipped
- `tsc -b` clean across schemas / monitor-ui / slack-operator
- six new tests, including the exact regression: *a 3-minute-old check on a 2-minute cadence raises no banner at all*
- rendered both fixtures in a browser before and after each change; the stress state still shows the coral fill left of the floor tick and the clean-funnel-vs-`SHORTFALL −2` contradiction

## Not fixed here

`committed INT-2 ceremony mechanics > proves the controlled pair passes…` flakes at a 5s timeout under load — roughly 1 run in 4, on a **clean main**, unrelated to this work. Flagged separately; the nightly flake-stress job will report it.

Still open from the deploy review: `capabilities` reads `ok` at "4/7 capabilities up". Either the status is right and the label misleads, or the label is right and the probe under-reports — that's a capability-semantics question I'm not guessing at on a money system.