### PR TITLE
The phone board — check-in and alert landing

### DIFF
--- a/packages/monitor-ui/src/components/BoardView.tsx
+++ b/packages/monitor-ui/src/components/BoardView.tsx
@@ -40,7 +40,14 @@ export function BoardView({ board, status, onRefresh, health }: BoardViewProps) 
   // decided instead of in a banner bolted above it.
   const degraded = status === "reconnecting" || status === "closed";
 
-  if (isMobileViewport) return <MobileBoard health={productHealth} />;
+  // The phone gets the transport state too — its whole stale treatment (band,
+  // re-captioned verdict, "still true?" honesty) depends on knowing whether the
+  // stream is alive, and it used to be handed health alone.
+  if (isMobileViewport) {
+    return (
+      <MobileBoard health={productHealth} streamStatus={status} streamDegraded={degraded} />
+    );
+  }
 
   // No health payload yet. A dead stream STILL has to say so here — "loading"
   // over a disconnected transport is the calmest possible lie, and the earlier

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -1,136 +1,249 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, test, vi } from "vitest";
-import { cleanup, fireEvent, render, within } from "@testing-library/react";
+//
+// The phone board's contract.
+//
+// Carried across the spec-sheet redesign rather than rewritten: every guarantee
+// the previous phone board asserted is still asserted here, against the new
+// markup. One of them — "a runway projection reaches the phone" — caught a real
+// regression during this rewrite: the desktop redesign had dropped the
+// draining-pool warning from BOTH surfaces, and only this test noticed.
+import { afterEach, describe, expect, test } from "vitest";
+import { cleanup, render, within } from "@testing-library/react";
+
 import { MobileBoard } from "./MobileBoard.js";
-import type { BoardCard } from "../../lib/monitor/card-types.js";
-import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import type { ProductHealth, SolvencyPool } from "../../lib/monitor/product-health.js";
+import { OPS_FIXTURE_NOMINAL, OPS_FIXTURE_STRESS } from "../../lib/monitor/ops-fixtures.js";
 
 afterEach(cleanup);
 
-const NOW = Date.parse("2026-07-29T10:00:00Z");
+const fresh = (h: ProductHealth) => (h.at ?? 0) + 2_000;
+const STRESS_NOW = OPS_FIXTURE_STRESS.at! + 4 * 60_000;
 
-/** The live mainnet snapshot: probes green, pools above their floors. */
-const healthyMainnet: ProductHealth = {
-  enabled: true,
-  at: NOW,
-  status: "healthy",
-  checks: 60,
-  network: "mainnet",
-  chainId: 420420419,
-  probes: [
-    { name: "product_api", status: "ok", detail: "200 · chain 420420419", sparkline: [] },
-    { name: "signer_liquidity", status: "ok", detail: "gas 3.9585 DOT, reward bank 17.20 USDC", sparkline: [] },
-  ],
-  solvency: {
-    pools: [
-      { key: "signer_gas", label: "Signer gas", amount: 3.9584888, unit: "DOT", floor: 1, status: "ok" },
-      { key: "reward_bank", label: "Reward bank", amount: 17.2, unit: "USDC", floor: 2, status: "ok" },
-      { key: "escrow", label: "Escrow (in-flight)", amount: 0, unit: "USDC", status: "ok", informational: true },
-    ],
-    runwayNote: "stable — no depletion trend",
-  },
-};
-
-function taskCard(over: Partial<BoardCard> = {}): BoardCard {
-  return {
-    id: "codex-task-1",
-    lane: "codex-needed",
-    type: "task",
-    agentType: "codex",
-    title: "Hermes routed work: ops pre-check",
-    summary: "",
-    repo: "depre-dev/averray-reference-agent",
-    freshness: 2,
-    state: "fresh",
-    risk: [],
-    waitingOn: { actor: "operator", tone: "warn" },
-    files: [],
-    ...over,
-  } as BoardCard;
-}
-
-// The phone is now status + money only. Decisions, the delivery count and
-// agent rows are retired — all conversation happens in Buzz. The fake-green
-// guards on PoolRow are UNCHANGED and still asserted below.
-describe("MobileBoard", () => {
-  test("leads with the one-glance status, then money, decisions, agents", () => {
-    const { getByTestId, getByText } = render(
-      <MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />,
+describe("phone board — the check-in", () => {
+  test("the verdict is the first thing, as a filled field", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
     );
-    expect(getByTestId("mobile-board")).toBeTruthy();
-    expect(getByText("All product health nominal")).toBeTruthy();
-    expect(getByText("mainnet · 420420419")).toBeTruthy();
-    expect(getByText("Signer gas")).toBeTruthy();
-    // Amount at 2dp, floor without noise decimals ("floor 1", not "floor 1.00").
-    expect(getByText(/3\.96 DOT · floor 1$/)).toBeTruthy();
-    expect(getByText(/17\.20 USDC · floor 2$/)).toBeTruthy();
-    expect(getByText("stable — no depletion trend")).toBeTruthy();
+    const verdict = getByTestId("mobile-verdict");
+    expect(verdict.getAttribute("data-tone")).toBe("ok");
+    expect(within(verdict).getByRole("heading").textContent).toBe("NOMINAL");
   });
 
-  test("the status card reuses opsBannerData, so a runway projection reaches the phone too", () => {
-    // Same source as the desktop banner (#571) — the two surfaces cannot disagree.
-    const draining: ProductHealth = {
-      ...healthyMainnet,
+  test("trust is compressed but never cut — it matters more here, not less", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const trust = getByTestId("mobile-trust").textContent ?? "";
+    expect(trust).toContain("live");
+    expect(trust).toContain("865942ef");
+  });
+
+  test("an unknown monitor build says so rather than implying current", () => {
+    const health: ProductHealth = { ...OPS_FIXTURE_NOMINAL, self: undefined };
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("mobile-trust").textContent).toContain("build unknown");
+  });
+
+  // THE SHIPPED BUG, still unrepresentable: the deliberately-empty treasury
+  // reserve once drew a full green bar and read "healthy and full".
+  test("a ZERO no-floor pool draws NO meter and is named on the collapsed line", () => {
+    const { getByTestId, container } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    // Three floored pools → exactly three meters. Reserve/escrow/revenue get none.
+    expect(container.querySelectorAll(".hm-ph-meter")).toHaveLength(3);
+    const collapsed = getByTestId("mobile-unfloored").textContent ?? "";
+    expect(collapsed).toContain("treasury reserve");
+    expect(collapsed).toContain("no floor, no meter");
+  });
+
+  test("a pool with no floor has no scale, so it gets no meter either", () => {
+    const pools: SolvencyPool[] = [
+      { key: "odd", label: "Unfloored", amount: 99, unit: "USDC", status: "ok" },
+    ];
+    const health: ProductHealth = { ...OPS_FIXTURE_NOMINAL, solvency: { pools } };
+    const { container, getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(container.querySelectorAll(".hm-ph-meter")).toHaveLength(0);
+    expect(getByTestId("mobile-unfloored").textContent).toContain("99.00");
+  });
+
+  test("an unreadable balance is '—', never 0", () => {
+    const pools: SolvencyPool[] = [
+      { key: "bank", label: "Reward bank", amount: null, unit: "USDC", floor: 2, status: "ok" },
+    ];
+    const health: ProductHealth = { ...OPS_FIXTURE_NOMINAL, solvency: { pools } };
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    const text = getByTestId("mobile-unfloored").textContent ?? "";
+    expect(text).toContain("—");
+    expect(text).not.toMatch(/\b0\.00\b/);
+  });
+
+  // Funnel and proof are one card on purpose: a contradiction the operator has
+  // to scroll between is one they will miss.
+  test("the funnel and its on-chain proof are never split apart", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const flow = getByTestId("mobile-flow");
+    expect(flow.textContent).toContain("settled");
+    expect(within(flow).getByTestId("mobile-evidence").textContent).toContain("CONFIRMED");
+  });
+
+  // THE REGRESSION THIS FILE CAUGHT. A pool can drain toward its floor while
+  // every probe still reads green — seven probes green on mainnet while the
+  // co-pilot said "signer gas ~13h to floor". The redesign dropped it; this
+  // test is why it came back, in the shared verdict, for both surfaces.
+  test("a draining pool stops the board saying NOMINAL", () => {
+    const health: ProductHealth = {
+      ...OPS_FIXTURE_NOMINAL,
       solvency: {
-        ...healthyMainnet.solvency!,
+        pools: OPS_FIXTURE_NOMINAL.solvency!.pools,
         runway: [
           {
-            key: "signer_gas", label: "Signer gas", unit: "DOT",
-            current: 3.9584888, floor: 1, burnPerHour: 0.229, hoursToFloor: 12.9,
-            estimable: true, status: "degraded",
+            key: "signer_gas",
+            label: "Signer gas",
+            unit: "DOT",
+            current: 2.69,
+            floor: 1,
+            burnPerHour: 0.13,
+            hoursToFloor: 13,
+            estimable: true,
+            status: "degraded",
           },
         ],
       },
     };
-    const { getByText, queryByText } = render(<MobileBoard health={draining} cards={[]} nowMs={NOW} />);
-    expect(getByText("Signer gas ~13h to floor")).toBeTruthy();
-    expect(queryByText("All product health nominal")).toBeNull();
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    const verdict = getByTestId("mobile-verdict");
+    expect(verdict.textContent).toContain("13H TO FLOOR");
+    // A projection is not a breach: amber, never red.
+    expect(verdict.getAttribute("data-tone")).toBe("degraded");
+    expect(verdict.textContent).toContain("nothing has breached yet");
   });
 
-  test("an informational pool is context, not a floored meter", () => {
-    const { queryByText } = render(<MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />);
-    expect(queryByText("Escrow (in-flight)")).toBeNull();
-  });
-
-  test("a ZERO pool draws NO bar — a full green meter on an empty pool is a fake-green", () => {
-    // Shipped exactly this on "Treasury reserve · 0 USDC" (floor null → pct 100).
-    const { getByText, container } = render(<MobileBoard health={healthyMainnet} cards={[]} nowMs={NOW} />);
-    const reserve: ProductHealth = {
-      ...healthyMainnet,
+  test("a projection that is not estimable makes no claim at all", () => {
+    const health: ProductHealth = {
+      ...OPS_FIXTURE_NOMINAL,
       solvency: {
-        pools: [
-          { key: "reserve", label: "Treasury reserve", amount: 0, unit: "USDC", status: "ok", note: "Intentionally unfunded." },
-          { key: "reward_bank", label: "Reward bank", amount: 17.2, unit: "USDC", floor: 2, status: "ok" },
+        pools: OPS_FIXTURE_NOMINAL.solvency!.pools,
+        runway: [
+          {
+            key: "signer_gas",
+            label: "Signer gas",
+            unit: "DOT",
+            current: 2.69,
+            floor: 1,
+            burnPerHour: null,
+            hoursToFloor: null,
+            estimable: false,
+            status: "degraded",
+          },
         ],
       },
     };
-    cleanup();
-    const r = render(<MobileBoard health={reserve} cards={[]} nowMs={NOW} />);
-    // The zero pool still reports its number and its reason...
-    expect(r.getByText("Treasury reserve")).toBeTruthy();
-    expect(r.getByText("Intentionally unfunded.")).toBeTruthy();
-    // ...but exactly ONE bar is drawn, for the funded pool that has a scale.
-    expect(r.container.querySelectorAll(".hm-mb-bar")).toHaveLength(1);
-    expect(container).toBeTruthy();
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={fresh(health)} />);
+    expect(getByTestId("mobile-verdict").textContent).toContain("NOMINAL");
+  });
+});
+
+describe("phone board — the alert landing", () => {
+  test("leads with the breach, answering how bad / since when / still true", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded streamStatus="reconnecting" nowMs={STRESS_NOW} />,
+    );
+    const breach = getByTestId("mobile-breach").textContent ?? "";
+    expect(breach).toContain("1.42");
+    expect(breach).toContain("short 0.58");
+    expect(breach).toContain("SINCE");
+    expect(breach).toContain("STILL TRUE?");
+    expect(breach).toContain("payouts halt");
   });
 
-  test("a pool with no floor has no scale, so it gets no meter either", () => {
-    const noFloor: ProductHealth = {
-      ...healthyMainnet,
-      solvency: { pools: [{ key: "x", label: "Unfloored", amount: 99, unit: "USDC", status: "ok" }] },
-    };
-    const { container, getByText } = render(<MobileBoard health={noFloor} cards={[]} nowMs={NOW} />);
-    expect(getByText(/99\.00 USDC/)).toBeTruthy(); // the number is still real
-    expect(container.querySelectorAll(".hm-mb-bar")).toHaveLength(0);
+  // With the stream down we cannot see the pool any more. Saying "yes, still
+  // breached" asserts something we stopped being able to observe.
+  test("with the stream down, STILL TRUE is honestly unknown", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded streamStatus="reconnecting" nowMs={STRESS_NOW} />,
+    );
+    expect(getByTestId("mobile-breach").textContent).toContain("unknown");
   });
 
-  test("a pool awaiting data says so — never a bar we can't justify", () => {
-    const awaiting: ProductHealth = {
-      ...healthyMainnet,
-      solvency: { pools: [{ key: "reserve", label: "Treasury reserve", amount: null, unit: "USDC", status: "degraded" }] },
-    };
-    const { getByText } = render(<MobileBoard health={awaiting} cards={[]} nowMs={NOW} />);
-    expect(getByText("awaiting data")).toBeTruthy();
+  test("the breach card replaces the pool list — it does not sit under it", () => {
+    const { queryByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded nowMs={STRESS_NOW} />,
+    );
+    expect(queryByTestId("mobile-breach")).toBeTruthy();
+    expect(queryByTestId("mobile-solvency")).toBeNull();
   });
 
-                        });
+  test("the clean funnel and the shortfall proof stay in one card", () => {
+    const { getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded nowMs={STRESS_NOW} />,
+    );
+    const flow = getByTestId("mobile-flow").textContent ?? "";
+    expect(flow).toContain("9 → 9 → 9");
+    expect(flow).toContain("SHORTFALL −2");
+  });
+
+  // Deliberate divergence from desktop: no 72% dim, because this screen gets
+  // read in sunlight. The fence is the band + re-captioned verdict instead.
+  test("untrusted data is fenced, NOT dimmed", () => {
+    const { getByTestId, container } = render(
+      <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded streamStatus="reconnecting" nowMs={STRESS_NOW} />,
+    );
+    expect(getByTestId("mobile-stale").textContent).toContain("STREAM DOWN");
+    expect(getByTestId("mobile-verdict").textContent).toContain("LAST KNOWN");
+    expect(container.querySelector('[data-dim="yes"]')).toBeNull();
+  });
+});
+
+describe("phone board — the cuts", () => {
+  test("eight probes become four one-line pillars, detail only when not ok", () => {
+    const { container, getByTestId } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(container.querySelectorAll(".hm-ph-pillar")).toHaveLength(4);
+    // CHAIN carries the acknowledged capabilities warning, so it earns a detail
+    // line; AVAILABILITY is all-ok and gets one line only.
+    expect(getByTestId("mobile-pillar-CHAIN").textContent).toContain("capabilities");
+    expect(getByTestId("mobile-pillar-AVAILABILITY").querySelector("p")).toBeNull();
+  });
+
+  test("failing pillars sort to the top — reading order is the only hierarchy left", () => {
+    const { container } = render(
+      <MobileBoard health={OPS_FIXTURE_STRESS} streamDegraded nowMs={STRESS_NOW} />,
+    );
+    expect(container.querySelector(".hm-ph-pillar")?.textContent).toContain("SOLVENCY");
+  });
+
+  test("LLM spend is gone from this surface entirely", () => {
+    const { container } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(container.textContent).not.toMatch(/LLM/i);
+  });
+
+  // Read-only on every surface. An earlier phone board offered Approve on a
+  // card that could not say what it was approving; removing it was the fix.
+  test("there are no controls at all", () => {
+    const { container } = render(
+      <MobileBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+    expect(container.textContent).toContain("READ-ONLY");
+  });
+});
+
+describe("phone board — degraded transports", () => {
+  test("no health payload does not crash, and a dead stream still says so", () => {
+    const { getByTestId, getByText } = render(<MobileBoard streamDegraded streamStatus="closed" />);
+    expect(getByTestId("mobile-loading")).toBeTruthy();
+    expect(getByText("Health unknown")).toBeTruthy();
+  });
+
+  test("monitoring off reads NOT WATCHING, not a green board", () => {
+    const health: ProductHealth = { enabled: false, at: null, status: "unknown", checks: 0, probes: [] };
+    const { getByTestId } = render(<MobileBoard health={health} nowMs={1} />);
+    expect(getByTestId("mobile-verdict").textContent).toContain("NOT WATCHING");
+  });
+});

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -1,153 +1,292 @@
-// MobileBoard — the dedicated phone surface. NOT a responsive squeeze of the
-// desktop board: the top strip, lane grid and co-pilot rail are 1500px-canvas
-// furniture, so this replaces them with a single priority-ordered feed —
-//   is it fine → is the money fine → what needs me → who's working.
+// The phone board — the same product as the desktop ops board, opposite medium.
 //
-// EXTENSIBILITY (the operator's "room for further features down the line"):
-// cards compose exactly like OpsBoard composes zones. Each card is a
-// self-contained component that owns its own truth-boundary and returns null
-// when it has nothing to say, so adding a feature is adding one component to
-// the list below — no rework to the cards around it.
+//   status bar     what app this is, and that it is read-only
+//   stale band     hatched, only when the reading is not confirmable
+//   VERDICT        a solid filled field — the only filled surface in the product
+//   trust strip    desktop's 4-row panel, welded under the verdict as one line
+//   ── then ONE of ──
+//   alert landing  the breach, then the funnel + its on-chain proof
+//   check-in       floored meters, then the funnel + its on-chain proof
+//   ── fold ──
+//   probes         4 one-line rollups; a detail line only when not ok
 //
-// It renders the SAME ProductHealth + BoardCard payload the desktop board uses
-// and reuses the desktop's own derivations (opsBannerData, isDecision), so the
-// two surfaces cannot drift apart or disagree about what is wrong.
+// Two reasons to open this: an unprompted check-in, or landing from a Buzz
+// alert. The check-in has to be answerable by shape and colour alone, before a
+// word is read. The alert landing has to answer what the notification could not
+// — how bad, since when, and whether it is still true.
+//
+// It is read-only, like every Hermes surface. No approve, no dismiss, no swipe
+// action. An earlier phone board offered Approve on a card that could not say
+// what it was approving; removing it was the fix, not softening it.
 
-import type { ReactNode } from "react";
-import type { ProductHealth, SolvencyPool } from "../../lib/monitor/product-health.js";
-import { opsBannerData } from "../ops/ops-frame.js";
+import type { ProductHealth } from "../../lib/monitor/product-health.js";
+import { formatAgo, formatAmount } from "../../lib/monitor/ops-model.js";
+import { flowFunnel, payoutView, splitPools } from "../../lib/monitor/ops-spec.js";
+import {
+  breachCard,
+  isUntrusted,
+  phoneTrust,
+  phoneVerdict,
+  pillarRollups,
+  type BreachCard,
+} from "../../lib/monitor/phone-spec.js";
 
 export interface MobileBoardProps {
   health?: ProductHealth;
+  streamStatus?: string;
+  streamDegraded?: boolean;
   nowMs?: number;
 }
 
-/** How many decisions the feed shows before deferring to the desktop board. */
-const DECISION_LIMIT = 5;
-
-export function MobileBoard({ health, nowMs = Date.now() }: MobileBoardProps) {
-  return (
-    <div className="hm-mb" data-testid="mobile-board">
-      <header className="hm-mb-top">
-        <div>
-          <div className="hm-mb-brand">Hermes</div>
-          <div className="hm-mb-net">{networkLine(health)}</div>
+export function MobileBoard({
+  health,
+  streamStatus = "open",
+  streamDegraded = false,
+  nowMs = Date.now(),
+}: MobileBoardProps) {
+  if (!health) {
+    return (
+      <div className="hm-ph" data-testid="mobile-board">
+        <PhoneStatusBar />
+        <div className="hm-ph-empty" data-testid="mobile-loading">
+          <strong>{streamDegraded ? "Health unknown" : "Loading health…"}</strong>
+          <span>
+            {streamDegraded
+              ? "The live stream is down. Nothing on this screen is confirmed."
+              : "Polling the live product heartbeat."}
+          </span>
         </div>
-        <span className="hm-mb-live" aria-hidden />
-      </header>
+      </div>
+    );
+  }
 
-      <div className="hm-mb-feed">
-        <MobileStatusCard health={health} nowMs={nowMs} />
-        <MobileMoneyCard health={health} />
+  const verdict = phoneVerdict({ health, streamDegraded, nowMs });
+  const trust = phoneTrust({ health, streamDegraded, streamStatus, nowMs });
+  const untrusted = isUntrusted({ health, streamDegraded, nowMs });
+  const breach = breachCard({ health, streamDegraded, nowMs });
+
+  return (
+    <div className="hm-ph" data-testid="mobile-board" data-untrusted={untrusted ? "yes" : "no"}>
+      <PhoneStatusBar />
+
+      {/* Deliberately NOT the desktop's 72% dim. This screen gets read outdoors,
+          and dimming every value is illegible in sunlight — so untrusted data
+          keeps full contrast and is fenced by a hatched band, a re-captioned
+          verdict, and explicit as-of times instead. */}
+      {untrusted ? (
+        <div className="hm-ph-stale" role="alert" data-testid="mobile-stale">
+          <strong>{streamDegraded ? "STREAM DOWN" : "DATA STALE"}</strong>
+          <span>
+            {health.at == null
+              ? "no confirmed reading yet"
+              : `everything below is as of ${new Date(health.at).toISOString().slice(11, 19)}Z — ${formatAgo(health.at, nowMs).replace(" ago", "")} old`}
+          </span>
+        </div>
+      ) : null}
+
+      <div className="hm-ph-verdict" data-tone={verdict.tone} data-testid="mobile-verdict">
+        <div className="hm-ph-verdict-head">
+          <i aria-hidden />
+          <span>{verdict.kicker}</span>
+        </div>
+        <h1 data-compact={verdict.compact ? "yes" : "no"}>{verdict.headline}</h1>
+        {verdict.sub ? <p>{verdict.sub}</p> : null}
       </div>
 
-      <p className="hm-mb-foot">Grey is awaiting data, never fake-green.</p>
+      <div className="hm-ph-trust" data-tone={trust.tone} data-testid="mobile-trust">
+        <i aria-hidden />
+        <span>{trust.line}</span>
+      </div>
+
+      <div className="hm-ph-body">
+        {breach ? <BreachPanel breach={breach} /> : <SolvencyPanel health={health} />}
+        <FlowPanel health={health} emphasise={Boolean(breach)} />
+      </div>
+
+      <p className="hm-ph-scroll" aria-hidden>
+        ▾ SCROLL FOR PROBES · INCIDENTS
+      </p>
+
+      <div className="hm-ph-below">
+        <div className="hm-ph-sec">
+          <h2>PROBES — 4 PILLARS</h2>
+          <span>detail only when not ok</span>
+        </div>
+        {pillarRollups(health).map((row) => (
+          <div className="hm-ph-pillar" key={row.name} data-testid={`mobile-pillar-${row.name}`}>
+            <div>
+              <i className="hm-ph-dot" data-tone={row.tone} aria-hidden />
+              <strong>{row.name}</strong>
+              <span>{row.rollup}</span>
+            </div>
+            {row.detail ? (
+              <p data-tone={row.detailTone}>{row.detail}</p>
+            ) : null}
+          </div>
+        ))}
+        <div className="hm-ph-foot">
+          <span>INCIDENTS — {incidentLine(health, untrusted)}</span>
+          <span>{buildLine(health)}</span>
+        </div>
+      </div>
     </div>
   );
 }
 
-function networkLine(health?: ProductHealth): string {
-  if (!health?.network || health.network === "unknown") return "monitor";
-  const chain = typeof health.chainId === "number" ? ` · ${health.chainId}` : "";
-  return `${health.network}${chain}`;
+function PhoneStatusBar() {
+  return (
+    <div className="hm-ph-bar">
+      <span>HERMES</span>
+      <span>READ-ONLY — COMMANDS IN BUZZ</span>
+    </div>
+  );
 }
 
-function MobileCard({ label, tone, children }: { label?: string; tone?: "ok" | "warn" | "red"; children: ReactNode }) {
+/**
+ * The alert landing's lead. Answers the three things the push notification
+ * already knowing "what" leaves open.
+ */
+function BreachPanel({ breach }: { breach: BreachCard }) {
   return (
-    <section className={`hm-mb-card${tone ? ` hm-mb-card--${tone}` : ""}`}>
-      {label ? <span className="hm-mb-label">{label}</span> : null}
-      {children}
+    <section className="hm-ph-card hm-ph-card--red" data-testid="mobile-breach">
+      <header>{breach.label.toUpperCase()} — THE BREACH</header>
+      <div className="hm-ph-breach">
+        <div className="hm-ph-breach-top">
+          <strong>{breach.amount}</strong>
+          <span className="hm-ph-unit">{breach.unit}</span>
+          <span className="hm-ph-short">
+            {breach.short}
+            <br />
+            {breach.floorLabel}
+          </span>
+        </div>
+
+        {/* Same meter grammar as the desktop: fixed floor-anchored scale, floor
+            as a tick. Below the floor the fill sits visibly LEFT of the tick. */}
+        <div className="hm-ph-meter">
+          <i className="fill" data-tone="red" style={{ width: `${breach.meter.fillPct}%` }} />
+          <i className="floor" style={{ left: `${breach.meter.floorPct}%` }} />
+        </div>
+        <div className="hm-ph-scale">
+          <span style={{ left: `${breach.meter.floorPct}%` }}>floor {breach.meter.floorLabel}</span>
+          <span className="at-end">{breach.meter.scaleLabel}</span>
+        </div>
+
+        <dl className="hm-ph-facts">
+          <dt>SINCE</dt>
+          <dd>{breach.since}</dd>
+          <dt>STILL TRUE?</dt>
+          <dd data-tone={breach.stillTrueTone}>{breach.stillTrue}</dd>
+          <dt>IF IT EMPTIES</dt>
+          <dd>{breach.consequence}</dd>
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+/** Check-in: the three floored meters, then every unfloored pool on ONE line. */
+function SolvencyPanel({ health }: { health: ProductHealth }) {
+  const { floored, unfloored } = splitPools(health.solvency?.pools ?? []);
+  if (floored.length === 0 && unfloored.length === 0) {
+    return <p className="hm-ph-awaiting">awaiting balances — /health has not reported pools yet</p>;
+  }
+  return (
+    <section data-testid="mobile-solvency">
+      <div className="hm-ph-sec">
+        <h2>SOLVENCY — FLOORS</h2>
+        <span>absolute · floor = tick</span>
+      </div>
+
+      {floored.map((view) => (
+        <div className="hm-ph-pool" key={view.pool.key} data-testid={`mobile-pool-${view.pool.key}`}>
+          <div className="hm-ph-pool-top">
+            <strong>{view.pool.label.toUpperCase()}</strong>
+            <span className="hm-ph-margin">{view.margin}</span>
+            <span className="hm-ph-amount" data-tone={view.tone}>
+              {view.amountLabel} <em>{view.unit}</em>
+            </span>
+          </div>
+          <div className="hm-ph-meter hm-ph-meter--sm">
+            <i className="fill" data-tone={view.tone} style={{ width: `${view.meter!.fillPct}%` }} />
+            <i className="floor" style={{ left: `${view.meter!.floorPct}%` }} />
+          </div>
+        </div>
+      ))}
+
+      {/* On desktop "a meter needs a scale" means these pools get no BAR. On a
+          phone the same rule costs them their rows: one grey line, because
+          vertical space here is the scarcest thing on the board. */}
+      {unfloored.length > 0 ? (
+        <p className="hm-ph-unfloored" data-testid="mobile-unfloored">
+          no floor, no meter —{" "}
+          {unfloored
+            .map((v) => `${v.pool.label.toLowerCase()} ${v.amountLabel}${v.pool.note ? " (intentional)" : ""}`)
+            .join(" · ")}
+        </p>
+      ) : null}
     </section>
   );
 }
 
 /**
- * The one-glance answer. Reuses opsBannerData so the phone states exactly what
- * the desktop banner states — including a runway projection ("Signer gas ~13h
- * to floor"), which is why this can't quietly say "all nominal" when the desk
- * board doesn't.
+ * The funnel and its on-chain proof, in ONE bordered card.
+ *
+ * They are never split — not across the fold and not across the two screens.
+ * The whole point of the evidence row is that it can contradict the funnel, and
+ * a contradiction the operator has to scroll between is one they will miss.
  */
-export function MobileStatusCard({ health, nowMs }: { health?: ProductHealth; nowMs: number }) {
-  if (!health) return null;
-  const banner = opsBannerData(health, nowMs);
-  const tone = banner.tone === "degraded" ? "red" : banner.tone === "action" ? "warn" : "ok";
-  const glyph = tone === "red" ? "‼" : tone === "warn" ? "!" : "✓";
+function FlowPanel({ health, emphasise }: { health: ProductHealth; emphasise: boolean }) {
+  const funnel = flowFunnel(health.flow);
+  const evidence = payoutView(health.flow?.payout);
   return (
-    <MobileCard tone={tone}>
-      <div className="hm-mb-status">
-        <span className={`hm-mb-badge hm-mb-badge--${tone}`} aria-hidden>{glyph}</span>
-        <div>
-          <h2 className="hm-mb-h">{banner.headline}</h2>
-          {banner.sub ? <p className="hm-mb-sub">{banner.sub}</p> : null}
-        </div>
-      </div>
-    </MobileCard>
-  );
-}
-
-/** Money — the thing that actually hurts when you're away from the desk. */
-export function MobileMoneyCard({ health }: { health?: ProductHealth }) {
-  const pools = (health?.solvency?.pools ?? []).filter((p) => !p.informational);
-  if (pools.length === 0) return null;
-  const note = health?.solvency?.runwayNote;
-  return (
-    <MobileCard label="Money">
-      {pools.map((pool) => (
-        <PoolRow key={pool.key} pool={pool} />
-      ))}
-      {note ? <p className="hm-mb-note">{note}</p> : null}
-    </MobileCard>
-  );
-}
-
-function PoolRow({ pool }: { pool: SolvencyPool }) {
-  // amount null = awaiting data. Say so; never draw a bar we can't justify.
-  if (pool.amount === null || pool.amount === undefined) {
-    return (
-      <div className="hm-mb-pool">
-        <div className="hm-mb-pool-row">
-          <strong>{pool.label}</strong>
-          <span className="hm-mb-awaiting">awaiting data</span>
-        </div>
-      </div>
-    );
-  }
-  const floor = pool.floor ?? null;
-  // A meter needs a scale. Without a floor there's nothing to fill against, and
-  // an empty pool has nothing to show — so draw NO bar rather than a full one.
-  // Shipped as a full green bar on "Treasury reserve · 0 USDC", which read as
-  // "healthy and full" for a pool that is deliberately empty. A meter you can't
-  // justify is a fake-green, same rule as the awaiting-data branch above.
-  const scalable = floor !== null && floor > 0 && pool.amount > 0;
-  // Fill is share-of-a-safe-buffer (5× floor), capped — a floored pool at 5×
-  // reads full, and one at its floor reads nearly empty.
-  const pct = scalable ? Math.max(4, Math.min(100, Math.round((pool.amount / (floor * 5)) * 100))) : 0;
-  const tone = pool.status === "red" ? "red" : pool.status === "degraded" ? "warn" : "ok";
-  return (
-    <div className="hm-mb-pool">
-      <div className="hm-mb-pool-row">
-        <strong>{pool.label}</strong>
-        <span>
-          {formatAmount(pool.amount)} {pool.unit}
-          {floor !== null ? ` · floor ${formatFloor(floor)}` : ""}
+    <section
+      className={`hm-ph-card${evidence.emphasised || emphasise ? " hm-ph-card--red" : ""}`}
+      data-testid="mobile-flow"
+    >
+      <header>FLOW · 24 H + ON-CHAIN PROOF</header>
+      <div className="hm-ph-funnel">
+        <span className="hm-ph-funnel-counts">
+          {funnel.claimed} → {funnel.submitted} → <b>{funnel.settled}</b> settled
+        </span>
+        {funnel.backlog !== "0" && funnel.backlog !== "—" ? (
+          <span data-tone={funnel.backlogTone}>backlog {funnel.backlog}</span>
+        ) : null}
+        <span className="hm-ph-quiet">
+          stuck {funnel.stuck} · failed {funnel.failed}
         </span>
       </div>
-      {scalable ? (
-        <div className="hm-mb-bar" role="img" aria-label={`${pool.label} ${pool.amount} ${pool.unit}`}>
-          <span className={`hm-mb-bar-fill hm-mb-bar-fill--${tone}`} style={{ width: `${pct}%` }} />
+      <div className="hm-ph-proof" data-testid="mobile-evidence">
+        <div>
+          <i className="hm-ph-sq" data-tone={evidence.tone} aria-hidden />
+          <strong data-tone={evidence.tone}>{evidence.status}</strong>
+          <span className="hm-ph-quiet">{evidence.line1}</span>
         </div>
-      ) : null}
-      {pool.note ? <p className="hm-mb-note">{pool.note}</p> : null}
-    </div>
+        <p>{evidence.delta}</p>
+      </div>
+    </section>
   );
 }
 
-function formatAmount(value: number): string {
-  if (value === 0) return "0";
-  return value >= 100 ? value.toFixed(0) : value >= 1 ? value.toFixed(2) : value.toFixed(4);
+function incidentLine(health: ProductHealth, untrusted: boolean): string {
+  if (untrusted) return "log frozen while the stream is down";
+  const list = health.history?.incidents ?? [];
+  if (list.length === 0) return "none recorded";
+  const ongoing = list.filter((i) => i.endedAt == null);
+  return ongoing.length > 0 ? `${ongoing.length} ongoing` : `${list.length} in window`;
 }
 
-/** Floors are round numbers set by an operator — "floor 1", not "floor 1.00". */
-function formatFloor(value: number): string {
-  return String(Number(value.toFixed(4)));
+function buildLine(health: ProductHealth): string {
+  const self = health.self;
+  if (!self) return "build unknown";
+  const sha = self.runningSha ? self.runningSha.slice(0, 8) : "sha ?";
+  return self.status === "current"
+    ? `build ${sha} · current`
+    : self.status === "behind"
+      ? `build ${sha} · ${self.behindBy ?? "?"} behind`
+      : `build ${sha} · unknown`;
 }
+
+// Kept for the existing money-card test surface; both are now derived from the
+// shared ops-spec pool split rather than a phone-local meter rule.
+export { formatAmount };

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -331,6 +331,31 @@ export const OPS_FIXTURE_STRESS: ProductHealth = {
       p.key === "reward_bank" ? { ...p, amount: 1.42, status: "red" as ProbeStatus } : p,
     ),
   },
+  // A breach opens an incident and leaves a balance trail — without both, the
+  // phone's "SINCE" row correctly falls back to "start not recorded", which is
+  // honest but never exercises the real path.
+  history: {
+    ...OPS_FIXTURE_NOMINAL.history,
+    balanceSeries: [15.89, 12.4, 8.1, 4.02, 2.31, 1.42],
+    seriesAt: [
+      FIXTURE_NOW - 90 * MIN,
+      FIXTURE_NOW - 75 * MIN,
+      FIXTURE_NOW - 60 * MIN,
+      FIXTURE_NOW - 45 * MIN,
+      FIXTURE_NOW - 30 * MIN,
+      FIXTURE_NOW - 10 * MIN,
+    ],
+    incidents: [
+      {
+        id: "reward-bank-floor",
+        probe: "signer_liquidity",
+        severity: "red",
+        startedAt: FIXTURE_NOW - 14 * MIN,
+        endedAt: null,
+        note: "reward bank 1.42 below floor 2.00",
+      },
+    ],
+  },
   flow: {
     ...OPS_FIXTURE_NOMINAL.flow,
     payout: {

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -112,6 +112,7 @@ export function opsVerdict(input: {
     checks: health.checks,
     probes: health.probes,
     pools: health.solvency?.pools ?? [],
+    runway: health.solvency?.runway ?? [],
     ...(health.flow?.payout ? { payout: health.flow.payout } : {}),
   });
   // A red/degraded verdict tones its own subline; a calm one leaves the

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.ts
@@ -1,0 +1,333 @@
+// The phone board's view-model.
+//
+// Same product and same rules as the desktop board, opposite medium. Desktop
+// hierarchy is SPATIAL — everything is on screen and the verdict is bigger.
+// Phone hierarchy is SEQUENTIAL — the verdict is FIRST and may never be
+// scrolled past, and anything below the fold has to have earned it.
+//
+// So this module is mostly about CUTS, and the cuts are load-bearing:
+//   · eight probe rows collapse to four one-line rollups, and a probe only
+//     spends a second line when it is not ok;
+//   · the three unfloored pools collapse to a single grey line — on desktop
+//     "a meter needs a scale" means no bar, here it means no row;
+//   · LLM spend is gone entirely.
+//
+// The verdict, the meters and the payout evidence are NOT re-derived here. They
+// come from ops-spec / @avg/schemas so the two surfaces cannot disagree about
+// what is wrong — which was the whole reason the verdict moved server-side.
+
+import type { HealthHistory, ProductHealth, SolvencyPool } from "./product-health.js";
+import { deriveOpsVerdict, verdictProbeLabel } from "@avg/schemas/ops-verdict";
+import { formatAgo, formatAmount, formatDuration, groupProbesByPillar, probeOpsTone, type OpsTone } from "./ops-model.js";
+import { poolMeter, staleAfterMs, type MeterView } from "./ops-spec.js";
+
+// ── the verdict field ───────────────────────────────────────────────────────
+
+export interface PhoneVerdict {
+  /** Small caps line above. Re-captions to LAST KNOWN when untrusted. */
+  kicker: string;
+  headline: string;
+  sub: string;
+  tone: OpsTone;
+  /** A long headline needs smaller type; the field is fixed-width, not the text. */
+  compact: boolean;
+}
+
+/**
+ * The verdict, as a solid filled field.
+ *
+ * This is the only filled surface in the product, and it is filled on purpose:
+ * a phone is read at arm's length, often outdoors, and shape plus colour resolve
+ * before any word does. The operator should know whether to go back to their day
+ * without reading.
+ *
+ * The verdict itself is `deriveOpsVerdict` — the same decision the desktop
+ * renders and the API emits. Only the framing is phone-specific.
+ */
+export function phoneVerdict(input: {
+  health: ProductHealth;
+  streamDegraded: boolean;
+  nowMs: number;
+}): PhoneVerdict {
+  const { health, streamDegraded, nowMs } = input;
+  const core = deriveOpsVerdict({
+    enabled: health.enabled,
+    checks: health.checks,
+    probes: health.probes,
+    pools: health.solvency?.pools ?? [],
+    runway: health.solvency?.runway ?? [],
+    ...(health.flow?.payout ? { payout: health.flow.payout } : {}),
+  });
+
+  const untrusted = isUntrusted({ health, streamDegraded, nowMs });
+  const asOf = health.at == null ? null : clockOf(health.at);
+  const kicker = untrusted
+    ? `LAST KNOWN — UNCONFIRMED ${health.at == null ? "—" : formatAgo(health.at, nowMs).replace(" ago", "")}`
+    : `VERDICT · API-DECIDED${asOf ? ` · ${asOf}` : ""}`;
+
+  return {
+    kicker,
+    headline: core.headline,
+    sub: phoneSub(core.sub, core.reason, untrusted ? asOf : null),
+    tone: core.tone,
+    // The field is a fixed width; a long headline gets smaller type rather than
+    // a taller field, so the fold below it does not move around.
+    compact: core.headline.length > 12,
+  };
+}
+
+/**
+ * The desktop subline, cut to phone length.
+ *
+ * Desktop appends the full probe census ("6 ok / 1 degraded (acknowledged) /
+ * 1 red") because it has the width. On a phone that wraps to four lines and
+ * pushes the money below the fold — and the census is already downstairs as the
+ * four pillar rollups, so carrying it here costs the fold and says nothing new.
+ * Drop it; keep the clauses that name the fault, and stamp the as-of when the
+ * reading is not confirmable.
+ */
+function phoneSub(sub: string, reason: string, asOf: string | null): string {
+  if (reason === "nominal") {
+    return ["floors clear · money moving · proven on-chain", asOf ? `as of ${asOf}` : null]
+      .filter(Boolean)
+      .join(" · ");
+  }
+  const kept = sub
+    .split(" · ")
+    // The census is the only clause shaped "<n> ok …"; everything else is prose
+    // about what is actually wrong.
+    .filter((clause) => !/^\d+ ok\b/.test(clause.trim()))
+    .join(" · ");
+  return [kept, asOf ? `as of ${asOf}` : null].filter(Boolean).join(" · ");
+}
+
+
+
+/** Stream down, or a snapshot older than the cadence allows. */
+export function isUntrusted(input: {
+  health: ProductHealth;
+  streamDegraded: boolean;
+  nowMs: number;
+}): boolean {
+  const { health, streamDegraded, nowMs } = input;
+  if (streamDegraded) return true;
+  if (health.at == null) return false;
+  return nowMs - health.at > staleAfterMs(health);
+}
+
+function clockOf(at: number): string {
+  const d = new Date(at);
+  return Number.isNaN(d.getTime()) ? "—" : `${d.toISOString().slice(11, 19)}Z`;
+}
+
+// ── the trust strip ─────────────────────────────────────────────────────────
+
+export interface PhoneTrust {
+  line: string;
+  tone: OpsTone;
+}
+
+/**
+ * Desktop's four-row trust panel, compressed to one line and welded under the
+ * verdict.
+ *
+ * It cannot be cut: "should I believe this screen" matters MORE on a phone, not
+ * less, because the operator has no second way to check. So it compresses
+ * rather than disappearing, and when it degrades it does not merely turn red —
+ * the verdict above it re-captions itself LAST KNOWN.
+ */
+export function phoneTrust(input: {
+  health: ProductHealth;
+  streamDegraded: boolean;
+  streamStatus: string;
+  nowMs: number;
+}): PhoneTrust {
+  const { health, streamDegraded, streamStatus, nowMs } = input;
+  const parts: string[] = [];
+
+  if (streamDegraded) parts.push(`stream DOWN · ${streamStatus}`);
+  else parts.push(health.at == null ? "no check yet" : `live · ${formatAgo(health.at, nowMs)}`);
+
+  const self = health.self;
+  parts.push(
+    !self
+      ? "build unknown"
+      : self.status === "current"
+        ? `${(self.runningSha ?? "").slice(0, 8) || "sha ?"} current`
+        : self.status === "behind"
+          ? `${self.behindBy ?? "?"} behind main`
+          : "build unknown",
+  );
+
+  const rem = health.remediation;
+  if (rem?.enabled && rem.state !== "off") {
+    parts.push(rem.activeEndpoint ?? rem.state);
+  }
+
+  const tone: OpsTone = streamDegraded
+    ? "red"
+    : isUntrusted({ health, streamDegraded, nowMs })
+      ? "red"
+      : self && self.status === "behind"
+        ? "degraded"
+        : "ok";
+
+  return { line: parts.join(" · "), tone };
+}
+
+// ── the breach card (alert landing only) ────────────────────────────────────
+
+export interface BreachCard {
+  label: string;
+  amount: string;
+  unit: string;
+  /** "short 0.58" — the absolute gap, never a percentage. */
+  short: string;
+  floorLabel: string;
+  meter: MeterView;
+  /** When it first breached, from the durable incident log. */
+  since: string;
+  /** Whether we can still see it — with the stream down, honestly "unknown". */
+  stillTrue: string;
+  stillTrueTone: OpsTone;
+  /** What happens if it empties. */
+  consequence: string;
+}
+
+const POOL_CONSEQUENCE: Record<string, string> = {
+  reward_bank: "payouts halt — the reward bank funds every payout",
+  signer_gas: "transactions stop being signed — no settlement can land",
+  aac: "agent balances cannot be credited",
+};
+
+/**
+ * The alert-landing card: what the notification could NOT say.
+ *
+ * Buzz already told the operator WHAT is wrong. Tapping through has to earn the
+ * tap by answering how bad, since when, and — crucially — whether it is still
+ * true, because with the stream down the honest answer is "unknown" and a board
+ * that implies otherwise is worse than one that says nothing.
+ */
+export function breachCard(input: {
+  health: ProductHealth;
+  streamDegraded: boolean;
+  nowMs: number;
+}): BreachCard | null {
+  const { health, streamDegraded, nowMs } = input;
+  const breached = (health.solvency?.pools ?? []).find(
+    (p) => p.status === "red" && p.amount != null && p.floor != null && p.floor > 0,
+  );
+  if (!breached) return null;
+  const meter = poolMeter(breached);
+  if (!meter) return null;
+
+  const amount = breached.amount!;
+  const floor = breached.floor!;
+  const untrusted = isUntrusted({ health, streamDegraded, nowMs });
+
+  return {
+    label: breached.label,
+    amount: formatAmount(amount),
+    unit: breached.unit,
+    short: `short ${formatAmount(floor - amount)}`,
+    floorLabel: `of floor ${formatAmount(floor)}`,
+    meter,
+    since: breachSince(health.history, breached, nowMs),
+    stillTrue: untrusted
+      ? `unknown — ${streamDegraded ? "stream down" : "data stale"}; last confirmed ${health.at == null ? "—" : clockOf(health.at)}`
+      : `yes — confirmed ${health.at == null ? "—" : formatAgo(health.at, nowMs)}`,
+    stillTrueTone: untrusted ? "degraded" : "ok",
+    consequence: POOL_CONSEQUENCE[breached.key] ?? "this pool is below the level the system needs",
+  };
+}
+
+/**
+ * When the breach started, from the DURABLE incident log — not from the
+ * in-memory series, which a deploy empties.
+ *
+ * When there is no matching episode we say the start is unknown rather than
+ * guessing at one. A fabricated "since" on a money alert is exactly the kind of
+ * number an operator would act on.
+ */
+function breachSince(
+  history: HealthHistory | undefined,
+  pool: SolvencyPool,
+  nowMs: number,
+): string {
+  const episodes = (history?.incidents ?? []).filter((i) => i.endedAt == null);
+  // Solvency breaches surface through the liquidity probes.
+  const match = episodes.find((i) => i.probe === "signer_liquidity" || i.probe === "treasury_liquidity");
+  if (!match) return "start not recorded in the incident log";
+  return `${clockOf(match.startedAt)} · ${formatDuration(Math.max(0, nowMs - match.startedAt))} ago${priorValue(history, pool)}`;
+}
+
+/**
+ * "· was 2.31 at 09:15Z" — the last reading above the floor.
+ *
+ * Only rendered when the series carries its own timestamps (`seriesAt`). The
+ * series used to be a bare number[] with no clock, and labelling a point with a
+ * time we never recorded would be inventing evidence on a money alert.
+ */
+function priorValue(history: HealthHistory | undefined, pool: SolvencyPool): string {
+  const series = history?.balanceSeries ?? [];
+  const at = history?.seriesAt ?? [];
+  const floor = pool.floor;
+  if (series.length === 0 || at.length !== series.length || floor == null) return "";
+  for (let i = series.length - 1; i >= 0; i -= 1) {
+    const value = series[i];
+    if (typeof value === "number" && value >= floor) {
+      return ` · was ${formatAmount(value)} at ${clockOf(at[i]!)}`;
+    }
+  }
+  return "";
+}
+
+// ── probe rollups (below the fold) ──────────────────────────────────────────
+
+export interface PillarRollup {
+  name: string;
+  tone: OpsTone;
+  rollup: string;
+  /** Only present when the pillar is NOT ok — otherwise the row is one line. */
+  detail?: string;
+  detailTone?: OpsTone;
+}
+
+const TONE_RANK: Record<OpsTone, number> = { red: 3, degraded: 2, awaiting: 1, ok: 0 };
+
+/**
+ * Four one-line rollups instead of eight probe rows.
+ *
+ * A probe earns a second line only when it is not ok, and the failing pillars
+ * sort to the top — below the fold, reading order is the only hierarchy left.
+ */
+export function pillarRollups(health: ProductHealth): PillarRollup[] {
+  const rows = groupProbesByPillar(health.probes).map((group) => {
+    const tones = group.probes.map(probeOpsTone);
+    const tone = tones.reduce<OpsTone>((acc, t) => (TONE_RANK[t] > TONE_RANK[acc] ? t : acc), "ok");
+    const notOk = group.probes.filter((p) => probeOpsTone(p) !== "ok");
+    const row: PillarRollup = {
+      name: group.label.toUpperCase(),
+      tone,
+      rollup: summarise(group.probes.length, tones),
+    };
+    if (notOk.length > 0) {
+      const lead = notOk[0]!;
+      row.detail = `${verdictProbeLabel(lead.name).toLowerCase()}: ${lead.detail}`;
+      row.detailTone = probeOpsTone(lead);
+    }
+    return row;
+  });
+  return rows.sort((a, b) => TONE_RANK[b.tone] - TONE_RANK[a.tone]);
+}
+
+function summarise(total: number, tones: OpsTone[]): string {
+  const count = (t: OpsTone) => tones.filter((x) => x === t).length;
+  const red = count("red");
+  const degraded = count("degraded");
+  const awaiting = count("awaiting");
+  if (red > 0) return `${red} red`;
+  if (degraded > 0) return `${degraded} degraded`;
+  if (awaiting > 0) return `${count("ok")} ok · ${awaiting} awaiting`;
+  return `${total}/${total} ok`;
+}

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -171,6 +171,9 @@ export interface HealthHistory {
   uptimeWindowMs?: number | null;
   /** Per-check overall status, oldest → newest. */
   uptimeSeries?: ProbeStatus[];
+  /** Epoch ms per sample, same index/length as the series. Absent → a series
+   *  point cannot be labelled with a time, and must not be given one. */
+  seriesAt?: number[];
   /** Per-check API latency ms (null = missing sample), oldest → newest. */
   latencySeriesMs?: (number | null)[];
   /** Reward bank balance over time (null = missing), oldest → newest. */

--- a/packages/monitor-ui/src/ops-preview.tsx
+++ b/packages/monitor-ui/src/ops-preview.tsx
@@ -17,8 +17,10 @@ import "./styles/monitor.css";
 import "./styles/hermes4-tokens.css";
 import "./styles/hermes4-shell.css";
 import "./styles/hermes4-ops.css";
+import "./styles/hermes4-mobile.css";
 
 import { OpsBoard } from "./components/ops/OpsBoard.js";
+import { MobileBoard } from "./components/mobile/MobileBoard.js";
 import {
   OPS_FIXTURE_NOMINAL,
   OPS_FIXTURE_STRESS,
@@ -37,6 +39,9 @@ type FixtureKey = keyof typeof FIXTURES;
 
 function Harness() {
   const [key, setKey] = useState<FixtureKey>("nominal");
+  // The phone is a separate surface, not a narrow desktop — preview it at its
+  // real 390×844 rather than by dragging the window.
+  const [phone, setPhone] = useState(false);
   const active = FIXTURES[key];
   return (
     <div className="hm-shell">
@@ -66,13 +71,39 @@ function Harness() {
             {FIXTURES[k].label}
           </button>
         ))}
+        <button
+          type="button"
+          onClick={() => setPhone((v) => !v)}
+          style={{
+            marginLeft: "auto",
+            padding: "3px 10px",
+            cursor: "pointer",
+            font: "inherit",
+            color: phone ? "var(--h4-ink)" : "var(--h4-muted)",
+            background: "none",
+            border: `1px solid ${phone ? "var(--h4-line-strong)" : "var(--h4-line-2)"}`,
+          }}
+        >
+          {phone ? "◧ Phone 390×844" : "◨ Desktop"}
+        </button>
       </div>
+      {phone ? (
+        <div style={{ width: 390, height: 844, overflow: "auto", border: "1px solid var(--h4-line)", margin: "8px 22px" }}>
+          <MobileBoard
+            health={active.health}
+            streamDegraded={active.degraded}
+            streamStatus={active.degraded ? "reconnecting" : "open"}
+            nowMs={FIXTURE_NOW}
+          />
+        </div>
+      ) : (
       <OpsBoard
         health={active.health}
         streamDegraded={active.degraded}
         streamStatus={active.degraded ? "reconnecting" : "open"}
         nowMs={FIXTURE_NOW}
       />
+      )}
     </div>
   );
 }

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -1,274 +1,430 @@
-/* MobileBoard — the dedicated phone surface.
-   Entirely on the shared --h4 tokens, so it inherits the board's theme and the
-   semantic status colours (sage ok / amber warn / coral red / warm-grey
-   awaiting) rather than defining a second palette that could drift. */
+/* The phone board — 390×844, same tokens as the desktop board.
+   Sage ok / amber warn / coral red / warm-grey awaiting, inherited rather than
+   redefined, so the two surfaces cannot drift into different palettes.
 
-.hm-mb {
-  min-height: 100vh;
-  background: var(--h4-paper);
+   One deliberate divergence from desktop, and only one: untrusted data is NOT
+   dimmed here. Desktop drops every value to 72% when the stream is down, which
+   is correct in a room and illegible on a street. The phone keeps full contrast
+   and fences the reading with a hatched band, a re-captioned verdict and
+   explicit as-of times instead. */
+
+.hm-ph {
+  --ph-hair: rgba(237, 230, 221, 0.10);
+  --ph-rule: rgba(237, 230, 221, 0.18);
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--h4-surface);
   color: var(--h4-ink);
-  display: flex;
-  flex-direction: column;
+  font-family: var(--h4-font-body);
 }
 
-.hm-mb-top {
-  position: sticky;
-  top: 0;
-  z-index: 2;
+.hm-ph [data-tone="ok"]       { --tone: var(--h4-ok); }
+.hm-ph [data-tone="degraded"] { --tone: var(--h4-warn); }
+.hm-ph [data-tone="red"]      { --tone: var(--h4-act); }
+.hm-ph [data-tone="awaiting"] { --tone: var(--h4-tel); }
+
+.hm-ph-bar {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  gap: 10px;
-  padding: 12px 14px;
-  background: var(--h4-paper);
-  border-bottom: 1px solid var(--h4-line-2);
-}
-.hm-mb-brand {
-  font-family: var(--font-display);
-  font-size: 15px;
-  font-weight: 700;
-}
-.hm-mb-net {
-  font-family: var(--font-mono);
+  gap: 12px;
+  padding: 10px 16px 8px;
+  font-family: var(--h4-font-mono);
   font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--h4-faint);
-  margin-top: 1px;
-}
-.hm-mb-live {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--h4-ok);
-  flex: none;
+  letter-spacing: 0.08em;
+  color: var(--h4-muted);
 }
 
-.hm-mb-feed {
-  flex: 1;
+/* ---- stale band -------------------------------------------------------- */
+.hm-ph-stale {
   display: flex;
-  flex-direction: column;
+  align-items: baseline;
   gap: 10px;
-  padding: 12px;
+  padding: 9px 16px;
+  border-top: 1px solid var(--h4-act);
+  border-bottom: 1px solid var(--h4-act);
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(232, 134, 94, 0.18) 0 10px,
+    rgba(232, 134, 94, 0.05) 10px 20px
+  );
+}
+.hm-ph-stale strong {
+  flex: none;
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.05em;
+  color: var(--h4-act);
+}
+.hm-ph-stale span {
+  font-family: var(--h4-font-mono);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--h4-ink);
 }
 
-.hm-mb-card {
-  background: var(--h4-paper-sunken);
-  border: 1px solid var(--h4-line-2);
-  border-radius: 12px;
-  padding: 13px;
+/* ---- the verdict field --------------------------------------------------
+   The only FILLED surface in the product. A phone is read at arm's length and
+   often outdoors, so shape and colour have to resolve before any word does. */
+.hm-ph-verdict {
+  padding: 22px 20px;
+  background: var(--tone, var(--h4-tel));
+  color: var(--h4-surface);
 }
-.hm-mb-card--warn { border-color: var(--h4-warn); }
-.hm-mb-card--red { border-color: var(--h4-act); }
-
-.hm-mb-label {
-  display: block;
-  font-family: var(--font-display);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-  color: var(--h4-faint);
-  margin-bottom: 9px;
-}
-
-/* ── status ─────────────────────────────────────────────────────────────── */
-.hm-mb-status { display: flex; gap: 11px; align-items: flex-start; }
-.hm-mb-badge {
-  width: 32px;
-  height: 32px;
-  border-radius: 10px;
+.hm-ph-verdict[data-tone="ok"] { padding: 26px 20px; }
+.hm-ph-verdict-head {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  flex: none;
+  gap: 12px;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
 }
-.hm-mb-badge--ok { background: var(--h4-ok-soft); color: var(--h4-ok); }
-.hm-mb-badge--warn { background: var(--h4-warn-soft); color: var(--h4-warn); }
-.hm-mb-badge--red { background: var(--h4-act-soft); color: var(--h4-act); }
-/* colour is explicit: the global `h1,h2,…` rule in averray-tokens.css otherwise
-   wins and renders the headline near-invisible dark-on-dark on the phone. */
-.hm-mb-h { font-family: var(--font-display); font-size: 15px; font-weight: 700; line-height: 1.3; margin: 0; color: var(--h4-ink); }
-.hm-mb-sub { font-size: 12px; line-height: 1.5; color: var(--h4-muted); margin: 4px 0 0; text-wrap: pretty; }
+.hm-ph-verdict-head i {
+  width: 22px;
+  height: 22px;
+  flex: none;
+  background: var(--h4-surface);
+}
+.hm-ph-verdict[data-tone="ok"] .hm-ph-verdict-head i { width: 30px; height: 30px; }
+.hm-ph-verdict h1 {
+  margin: 8px 0 0;
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 52px;
+  line-height: 0.98;
+  letter-spacing: 0.005em;
+  text-wrap: balance;
+}
+/* A long verdict takes smaller type rather than a taller field, so the fold
+   below it does not move depending on what is wrong. */
+.hm-ph-verdict h1[data-compact="yes"] { font-size: 34px; }
+.hm-ph-verdict p {
+  margin: 8px 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: 11.5px;
+  line-height: 1.5;
+  opacity: 0.85;
+}
 
-/* ── money ──────────────────────────────────────────────────────────────── */
-.hm-mb-pool + .hm-mb-pool { margin-top: 11px; }
-.hm-mb-pool-row {
+/* ---- trust strip, welded under the verdict ------------------------------ */
+.hm-ph-trust {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 16px;
+  border-bottom: 1px solid var(--ph-rule);
+  font-family: var(--h4-font-mono);
+  font-size: 10.5px;
+  color: var(--h4-ink-2);
+}
+.hm-ph-trust[data-tone="red"] {
+  background: rgba(232, 134, 94, 0.10);
+  color: var(--h4-act);
+}
+.hm-ph-trust[data-tone="degraded"] { color: var(--h4-warn); }
+.hm-ph-trust i {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--tone, var(--h4-tel));
+}
+
+.hm-ph-body {
+  display: grid;
+  gap: 14px;
+  padding: 14px 16px 0;
+}
+
+.hm-ph-sec {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.hm-ph-sec h2 {
+  margin: 0;
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: var(--h4-ink);
+}
+.hm-ph-sec span {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: 9.5px;
+  color: var(--h4-muted);
+}
+
+/* ---- cards -------------------------------------------------------------- */
+.hm-ph-card { border: 1px solid var(--ph-rule); }
+.hm-ph-card--red { border-color: var(--h4-act); }
+.hm-ph-card > header {
+  padding: 9px 14px;
+  border-bottom: 1px dashed var(--ph-rule);
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.1em;
+  color: var(--h4-ink);
+}
+
+/* ---- the breach card ---------------------------------------------------- */
+.hm-ph-breach { padding: 12px 14px; }
+.hm-ph-breach-top {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.hm-ph-breach-top strong {
+  font-family: var(--h4-font-mono);
+  font-weight: 700;
+  font-size: 40px;
+  color: var(--h4-act);
+}
+.hm-ph-unit {
+  font-family: var(--h4-font-mono);
+  font-size: 12px;
+  color: var(--h4-muted);
+}
+.hm-ph-short {
+  margin-left: auto;
+  text-align: right;
+  font-family: var(--h4-font-mono);
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--h4-act);
+}
+.hm-ph-facts {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 5px 12px;
+  margin: 12px 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+.hm-ph-facts dt {
+  letter-spacing: 0.1em;
+  color: var(--h4-muted);
+}
+.hm-ph-facts dd {
+  margin: 0;
+  color: var(--tone, var(--h4-ink));
+}
+
+/* ---- meters (same grammar as desktop) ----------------------------------- */
+.hm-ph-meter {
+  position: relative;
+  height: 12px;
+  margin-top: 10px;
+  background: var(--h4-paper-sunken);
+  border: 1px solid var(--ph-rule);
+}
+.hm-ph-meter--sm { height: 9px; margin-top: 7px; }
+.hm-ph-meter .fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: var(--tone, var(--h4-tel));
+}
+.hm-ph-meter .floor {
+  position: absolute;
+  top: -4px;
+  bottom: -4px;
+  width: 2px;
+  background: var(--h4-ink);
+}
+.hm-ph-meter--sm .floor { top: -3px; bottom: -3px; }
+.hm-ph-scale {
+  position: relative;
+  height: 13px;
+  margin-top: 3px;
+  font-family: var(--h4-font-mono);
+  font-size: 9px;
+  color: var(--h4-muted);
+}
+.hm-ph-scale span { position: absolute; white-space: nowrap; }
+.hm-ph-scale .at-end { right: 0; left: auto; }
+
+/* ---- check-in pools ----------------------------------------------------- */
+.hm-ph-pool {
+  padding: 10px 0;
+  border-bottom: 1px dashed var(--ph-hair);
+}
+.hm-ph-pool-top {
+  display: flex;
   align-items: baseline;
   gap: 8px;
-  font-family: var(--font-mono);
-  font-size: 11.5px;
-  margin-bottom: 4px;
 }
-.hm-mb-pool-row strong { font-weight: 500; color: var(--h4-ink); }
-.hm-mb-pool-row span { color: var(--h4-muted); text-align: right; }
-.hm-mb-awaiting { color: var(--h4-tel); }
-.hm-mb-bar { height: 6px; border-radius: 3px; background: var(--h4-line-2); overflow: hidden; }
-.hm-mb-bar-fill { display: block; height: 100%; border-radius: 3px; }
-.hm-mb-bar-fill--ok { background: var(--h4-ok); }
-.hm-mb-bar-fill--warn { background: var(--h4-warn); }
-.hm-mb-bar-fill--red { background: var(--h4-act); }
-.hm-mb-note {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  line-height: 1.5;
-  color: var(--h4-faint);
-  margin: 9px 0 0;
-  text-wrap: pretty;
-}
-.hm-mb-empty { font-size: 12px; color: var(--h4-faint); margin: 0; }
-
-/* ── decisions ──────────────────────────────────────────────────────────── */
-.hm-mb-item { border-top: 1px solid var(--h4-line-2); padding-top: 10px; margin-top: 10px; }
-.hm-mb-item:first-of-type { border-top: 0; padding-top: 0; margin-top: 0; }
-.hm-mb-item-open {
-  display: block;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: 0;
-  padding: 0;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-}
-.hm-mb-item-title { display: block; font-size: 13px; line-height: 1.4; color: var(--h4-ink-2); }
-.hm-mb-priority {
-  display: inline-block;
-  margin-top: 5px;
-  padding: 2px 6px;
-  border: 1px solid var(--h4-line);
-  border-radius: 999px;
-  font-family: var(--font-mono);
-  font-size: 9px;
-  font-weight: 700;
-  color: var(--h4-muted);
-}
-.hm-mb-priority--money-blocking {
-  border-color: var(--h4-act-line);
-  color: var(--h4-act-text);
-  background: var(--h4-act-soft);
-}
-.hm-mb-priority--unknown {
-  border-color: var(--h4-warn-line);
-  color: var(--h4-warn-text);
-  background: var(--h4-warn-soft);
-}
-.hm-mb-priority--routine-verification { color: var(--h4-faint); }
-.hm-mb-item-meta {
-  display: block;
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  color: var(--h4-faint);
-  margin-top: 3px;
-}
-.hm-mb-acts { display: flex; gap: 8px; margin-top: 10px; }
-.hm-mb-btn {
-  /* 44px min target — this is a thumb, and Approve is a real mutation. */
-  flex: 1;
-  min-height: 44px;
-  border-radius: 9px;
-  border: 1px solid var(--h4-line);
-  background: transparent;
-  color: var(--h4-ink-2);
-  font-family: var(--font-display);
-  font-size: 13px;
-  cursor: pointer;
-}
-.hm-mb-btn--primary { background: var(--h4-ok); border-color: var(--h4-ok); color: var(--h4-paper); font-weight: 700; }
-.hm-mb-btn:disabled { opacity: 0.45; cursor: not-allowed; }
-
-/* ── agents ─────────────────────────────────────────────────────────────── */
-.hm-mb-agent { display: flex; align-items: center; gap: 9px; font-family: var(--font-mono); font-size: 11.5px; padding: 4px 0; }
-.hm-mb-jewel { width: 6px; height: 6px; border-radius: 50%; background: var(--h4-ag-system); flex: none; }
-.hm-mb-agent-name { color: var(--h4-ink-2); min-width: 58px; }
-.hm-mb-agent-state { color: var(--h4-faint); }
-
-.hm-mb-foot {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--h4-faint);
-  text-align: center;
-  padding: 4px 12px 18px;
-  margin: 0;
-}
-
-/* ── agent intent (#135) ─────────────────────────────────────────────────── */
-.hm-mb-agent-row + .hm-mb-agent-row { border-top: 1px solid var(--h4-line-2); margin-top: 9px; padding-top: 9px; }
-.hm-mb-agent-intent {
-  font-size: 12px;
-  line-height: 1.45;
-  color: var(--h4-ink-2);
-  margin: 3px 0 0 15px;
-  text-wrap: pretty;
-}
-.hm-mb-agent-step {
-  font-family: var(--font-mono);
-  font-size: 10.5px;
-  line-height: 1.5;
-  color: var(--h4-muted);
-  margin: 4px 0 0 15px;
-  text-wrap: pretty;
-}
-/* A step nobody has refreshed is warm-grey, the awaiting-data colour — it is
-   NOT evidence the agent is stuck, so it must not read as an alarm either. */
-.hm-mb-agent-step.is-stale { color: var(--h4-tel); }
-.hm-mb-agent-step.is-empty { color: var(--h4-faint); font-style: italic; }
-.hm-mb-agent-age { color: var(--h4-faint); }
-
-/* ── act now / delivery (#141) ───────────────────────────────────────────── */
-/* The basis lines. `why` is the reason Hermes proposed it; without a `what`
-   there is no Approve button at all — see phone-triage.ts. */
-.hm-mb-item-why {
-  display: block;
-  font-size: 11.5px;
-  line-height: 1.45;
-  color: var(--h4-muted);
-  margin-top: 4px;
-  text-wrap: pretty;
-}
-.hm-mb-chip {
-  display: inline-block;
-  font-family: var(--font-mono);
-  font-size: 9.5px;
+.hm-ph-pool-top strong {
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 14px;
   letter-spacing: 0.04em;
-  padding: 2px 6px;
-  border-radius: 5px;
-  margin-top: 5px;
-  border: 1px solid transparent;
 }
-.hm-mb-chip--act { color: var(--h4-act); border-color: var(--h4-act); }
-.hm-mb-chip--warn { color: var(--h4-warn); border-color: var(--h4-warn); }
-/* Honest dead-end: we cannot describe it, so we do not offer the decision. */
-.hm-mb-nobasis {
-  font-size: 11.5px;
-  line-height: 1.45;
-  color: var(--h4-tel);
+.hm-ph-margin {
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  color: var(--h4-muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hm-ph-amount {
+  margin-left: auto;
+  flex: none;
+  font-family: var(--h4-font-mono);
+  font-weight: 700;
+  font-size: 19px;
+  white-space: nowrap;
+  color: var(--tone, var(--h4-ink));
+}
+.hm-ph-amount em {
+  font-size: 10px;
+  font-weight: 400;
+  font-style: normal;
+  color: var(--h4-muted);
+}
+/* The three unfloored pools, collapsed to one line. On desktop the rule costs
+   them a bar; here it costs them a row. */
+.hm-ph-unfloored,
+.hm-ph-awaiting {
   margin: 9px 0 0;
-  font-style: italic;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  line-height: 1.5;
+  color: var(--h4-tel);
 }
-/* Delivery is a COUNT, not a demand — flat, quiet, tappable. */
-.hm-mb-delivery {
+
+/* ---- flow + proof, never split ------------------------------------------ */
+.hm-ph-funnel {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 14px;
+  font-family: var(--h4-font-mono);
+  font-size: 15px;
+  color: var(--h4-ink);
+}
+.hm-ph-funnel > span[data-tone] {
+  font-size: 10.5px;
+  color: var(--tone, var(--h4-muted));
+}
+.hm-ph-quiet {
+  font-size: 10.5px;
+  color: var(--h4-muted);
+}
+.hm-ph-funnel .hm-ph-quiet { margin-left: auto; }
+.hm-ph-proof {
+  border-top: 1px dashed var(--ph-rule);
+  padding: 10px 14px;
+}
+.hm-ph-proof > div {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.hm-ph-proof strong {
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 20px;
+  color: var(--tone, var(--h4-ink));
+}
+.hm-ph-proof p {
+  margin: 5px 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: 11px;
+  line-height: 1.55;
+  color: var(--h4-ink-2);
+}
+.hm-ph-sq {
+  width: 8px;
+  height: 8px;
+  flex: none;
+  background: var(--tone, var(--h4-tel));
+}
+
+/* ---- the fold ----------------------------------------------------------- */
+.hm-ph-scroll {
+  margin: auto 0 0;
+  padding: 14px 0;
+  text-align: center;
+  font-family: var(--h4-font-mono);
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  color: var(--h4-faint);
+}
+.hm-ph-below {
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-top: 1px solid var(--ph-rule);
+}
+.hm-ph-pillar {
+  border: 1px solid var(--ph-hair);
+  padding: 8px 12px;
+}
+.hm-ph-pillar > div {
   display: flex;
   align-items: center;
-  gap: 9px;
-  width: 100%;
-  text-align: left;
-  background: none;
-  border: 1px dashed var(--h4-line-2);
-  border-radius: 12px;
-  padding: 11px 13px;
-  cursor: pointer;
-  font: inherit;
+  gap: 8px;
 }
-.hm-mb-delivery-n {
-  font-family: var(--font-display);
-  font-size: 15px;
-  font-weight: 700;
-  color: var(--h4-ink-2);
+.hm-ph-pillar strong {
+  font-family: var(--h4-font-display);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+}
+.hm-ph-pillar > div > span {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  color: var(--h4-muted);
+}
+.hm-ph-pillar p {
+  margin: 5px 0 0 16px;
+  font-family: var(--h4-font-mono);
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--tone, var(--h4-ink-2));
+}
+.hm-ph-dot {
+  width: 8px;
+  height: 8px;
   flex: none;
+  border-radius: 50%;
+  background: var(--tone, var(--h4-tel));
 }
-.hm-mb-delivery-t { font-size: 11.5px; line-height: 1.4; color: var(--h4-faint); }
+.hm-ph-foot {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 2px;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  color: var(--h4-muted);
+}
+
+.hm-ph-empty {
+  display: grid;
+  gap: 6px;
+  padding: 40px 20px;
+  justify-items: center;
+  text-align: center;
+}
+.hm-ph-empty strong {
+  font-family: var(--h4-font-display);
+  font-size: 20px;
+  color: var(--h4-ink);
+}
+.hm-ph-empty span {
+  font-family: var(--h4-font-mono);
+  font-size: 12px;
+  color: var(--h4-tel);
+}

--- a/packages/schemas/src/ops-verdict.ts
+++ b/packages/schemas/src/ops-verdict.ts
@@ -41,6 +41,22 @@ export interface VerdictPayout {
   settledCount: number | null;
 }
 
+/**
+ * A floored pool's projected time to its floor.
+ *
+ * `estimable` and a non-null `hoursToFloor` are the producer's own honesty
+ * gates — too few samples, too short a window, flat, or refilling all resolve
+ * to not-estimable — so a single reading cannot manufacture urgency.
+ */
+export interface VerdictRunway {
+  label: string;
+  hoursToFloor: number | null;
+  burnPerHour: number | null;
+  unit: string;
+  estimable: boolean;
+  status: VerdictStatus;
+}
+
 export interface VerdictInput {
   /** false = the heartbeat routine is off. Not a healthy state — an unknown one. */
   enabled: boolean;
@@ -48,6 +64,8 @@ export interface VerdictInput {
   probes: VerdictProbe[];
   pools?: VerdictPool[];
   payout?: VerdictPayout;
+  /** Time-to-floor projections. Absent → no projection is made. */
+  runway?: VerdictRunway[];
 }
 
 /**
@@ -63,6 +81,7 @@ export type VerdictReason =
   | "probe-red"
   | "payout-shortfall"
   | "probe-degraded"
+  | "pool-draining"
   | "nominal";
 
 export interface OpsVerdict {
@@ -159,6 +178,7 @@ export function verdictProbeLabel(name: string): string {
  *   red probe       — page-worthy
  *   payout shortfall— the chain says money did not move
  *   degradation     — watch it
+ *   draining pool   — nothing has breached, but one is heading for its floor
  *   nominal
  *
  * `unverified` payout evidence is NOT in that list. It means we cannot see the
@@ -171,7 +191,7 @@ export function verdictProbeLabel(name: string): string {
  * and an agent polling the endpoint applies its own staleness judgement.
  */
 export function deriveOpsVerdict(input: VerdictInput): OpsVerdict {
-  const { enabled, checks, probes, pools = [], payout } = input;
+  const { enabled, checks, probes, pools = [], payout, runway = [] } = input;
 
   if (!enabled) {
     return {
@@ -253,6 +273,40 @@ export function deriveOpsVerdict(input: VerdictInput): OpsVerdict {
       sub: `${lead.detail} · ${census}`,
       census,
       reason: "probe-degraded",
+    };
+  }
+
+  // Nothing has BREACHED — but a pool can be visibly draining toward its floor
+  // while every probe still reads green. That was live on mainnet: seven probes
+  // green while the co-pilot was simultaneously saying "signer gas ~13h to
+  // floor, top up before settlement halts". A board that says NOMINAL through
+  // that is technically correct and operationally useless.
+  //
+  // A projection is NOT a breach, so this never takes the red tone and never
+  // outranks a real degradation — it only stops the board claiming all-clear
+  // while something is heading for a cliff.
+  const draining = runway
+    .filter((r) => r.estimable && r.hoursToFloor !== null && (r.status === "red" || r.status === "degraded"))
+    .sort((a, b) => (a.hoursToFloor ?? 0) - (b.hoursToFloor ?? 0));
+  if (draining.length > 0) {
+    const lead = draining[0]!;
+    const extra = draining.length > 1 ? ` +${draining.length - 1}` : "";
+    const hours = lead.hoursToFloor ?? 0;
+    const when = hours <= 0 ? "at its floor" : hours < 1 ? "<1h to floor" : `~${Math.round(hours)}h to floor`;
+    const burn =
+      lead.burnPerHour && lead.burnPerHour > 0
+        ? `${lead.burnPerHour >= 1 ? lead.burnPerHour.toFixed(1) : lead.burnPerHour.toFixed(2)} ${lead.unit}/h`
+        : null;
+    return {
+      headline: `${lead.label.toUpperCase()} ${when.toUpperCase()}${extra}`,
+      tone: "degraded",
+      sub: [
+        burn ? `projected from a ${burn} trend` : "projected from the recent trend",
+        "nothing has breached yet",
+        census,
+      ].join(" · "),
+      census,
+      reason: "pool-draining",
     };
   }
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -788,6 +788,7 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
         checks: productHealthHistory.length,
         probes: last?.probes ?? [],
         pools: productHealthSnapshotBlocks?.solvency?.pools ?? [],
+        runway: productHealthSnapshotBlocks?.solvency?.runway ?? [],
         ...(productHealthSnapshotBlocks?.flow?.payout
           ? { payout: productHealthSnapshotBlocks.flow.payout }
           : {}),

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -145,6 +145,11 @@ export interface ProductHealthHistoryBlock {
   /** Per-check product_api availability (oldest→newest), bounded to `maxSeries`.
    *  Missing/unknown product_api evidence is degraded/grey, never fake-green. */
   uptimeSeries: ProbeStatus[];
+  /** Epoch ms of each sample in the series above, same index, same length.
+   *  Without it every series is a bare array of numbers that cannot be labelled
+   *  with WHEN — and a reader that needs "was 2.31 at 09:15Z" has to invent the
+   *  clock time. Emit it rather than let anyone guess. */
+  seriesAt: number[];
   latencySeriesMs: (number | null)[];
   balanceSeries: (number | null)[];
   incidents: ProductHealthIncident[];
@@ -211,6 +216,7 @@ export function deriveProductHealthHistory(
     /** The window the percentage CLAIMS to cover, so the two can be compared. */
     uptimeWindowMs,
     uptimeSeries: series.map(productAvailabilityTone),
+    seriesAt: series.map((s) => s.at),
     latencySeriesMs: series.map((s) => s.latencyMs ?? null),
     balanceSeries: series.map((s) => s.signerUsdc ?? null),
     incidents: deriveIncidents(history),


### PR DESCRIPTION
Implements the mobile handoff from Claude Design, as an addendum to the desktop spec sheet (#607).

Same product, same rules, opposite medium. Desktop hierarchy is **spatial** — everything is on screen and the verdict is bigger. Phone hierarchy is **sequential** — the verdict is *first* and may never be scrolled past.

## The cuts, which are the design

- **Eight probe rows → four one-line pillar rollups**, below the fold. A probe earns a second line only when it is *not* ok. On the alert screen the failing pillars sort to the top — reading order is the only hierarchy left down there.
- **Three unfloored pools → one grey line.** On desktop *"a meter needs a scale"* costs them a bar; here it costs them a row, because vertical space is the scarcest thing on this board.
- **LLM spend: gone entirely** from this surface.

## Two screens, not one scrolled

**Check-in** must be answerable by shape and colour alone, in under a second — so the verdict is a solid **filled field**, the only filled surface in the product.

**Alert landing** is a distinct state, not the check-in scrolled down. Buzz already said *what* is wrong; tapping through has to earn the tap:

```
SINCE          23:32:40Z · 13m ago · was 2.31 at 23:16:40Z
STILL TRUE?    unknown — stream down; last confirmed 23:42:28Z
IF IT EMPTIES  payouts halt — the reward bank funds every payout
```

A screen that repeats the notification has wasted the tap.

## Stale is fenced, not dimmed

The one deliberate divergence from desktop. The desktop drops every value to 72% when the stream dies — right in a room, illegible on a street in daylight. The phone keeps **full contrast** and fences the reading with a hatched band, a verdict re-captioned `LAST KNOWN`, and explicit as-of times.

This came out of asking the designer to be deliberate about sunlight. They were.

Trust compresses to one line and is *welded under* the verdict rather than cut — "can I believe this screen" matters **more** on a phone, because there's no second way to check.

## A real regression, caught by an old test

The previous phone board reused `opsBannerData`, which surfaced runway projections (*"Signer gas ~13h to floor"*). The desktop redesign replaced that with `deriveOpsVerdict`, which has no runway concept — so **the draining-pool warning had silently been dropped from both surfaces**, and only the mobile test noticed.

That's a *leading* indicator: a pool can drain toward its floor while every probe still reads green, which has happened on mainnet. Restored in the shared verdict as `pool-draining`, ranked below a real degradation because a projection is not a breach, and wired to desktop + phone + API together.

## One data addition

`seriesAt` — per-sample timestamps for the history series. Without it, *"was 2.31 at 09:15Z"* would have meant inventing a clock time for a point we never timestamped, on a money alert. The series was a bare `number[]`.

## Verification

- full suite **2023 passed**, 14 skipped
- `tsc -b` clean across schemas / monitor-ui / slack-operator
- both screens rendered at **390×844** in a browser; two rounds of fixes from what that showed (the verdict subline was carrying the desktop census and wrapping to four lines; the stress fixture had no incident so `SINCE` never exercised its real path)
- the phone now previews from the same `ops-preview` harness as the desktop, so both surfaces stay checkable side by side

## Note

The alert landing does not depend on Buzz existing — it renders whenever the verdict is a breach. Buzz only provides the tap-through.