### PR TITLE
test(int2): raise the pair-preflight timeout to 30s, with the measurement

### DIFF
--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -150,6 +150,44 @@ describe("committed INT-2 ceremony mechanics", () => {
     expect(workflow).toContain("executed-count.txt')\" = \"10\"");
   });
 
+  // verifyScriptedPairPreflight runs two full `git clone --local
+  // --no-hardlinks` of this repository concurrently, so this test's wall time
+  // tracks whole-suite disk and CPU contention rather than its own logic. It
+  // was landed on vitest's 5000ms default and outgrew it: on main it failed 1
+  // of 4 back-to-back full-suite runs at 5025ms — the timeout firing, not a
+  // wrong assertion.
+  //
+  // Measured over 24 full-suite runs on a 12-core host, part of them with the
+  // timeout lifted to 120s so the true cost was observable: 2628-4108ms, idle
+  // and under eight competing CPU burners alike. Every run finished inside
+  // that bounded window and passed, which is what rules out a race — a
+  // deadlock would not have a ceiling. The worst case was 82% of the 5000ms
+  // budget — no useful margin.
+  //
+  // The failures show up on high-core development hosts rather than in CI,
+  // which reads backwards until you account for vitest sizing its worker pool
+  // from CPU count: a 12-core box runs more test FILES concurrently, so more
+  // clones overlap and contend for disk than on a 4-core runner. CI has stayed
+  // green throughout and the 10-iteration flake-stress job passed 10/10 — both
+  // consistent with that explanation, and neither consistent with CI being the
+  // host nearest the cliff.
+  //
+  // 30_000 is not arbitrary: the section-3 test below does strictly MORE clone
+  // work (three fixture criteria, measured 3379-4530ms against this one's
+  // 2628-4108ms), has carried 30_000 since #594, and is green nightly. Same
+  // workload class, same budget.
+  //
+  // Raising the ceiling is the whole fix — the cost itself is irreducible
+  // here. Cloning with --no-checkout, so the tree is materialised once at
+  // baseRevision instead of at HEAD and again on detach, was measured at only
+  // ~100ms of ~850ms per clone, which does not justify editing a production
+  // evidence script. Dropping --no-hardlinks was measured too and is a
+  // REGRESSION, not a saving: hardlinked local cloning of this repository ran
+  // 484ms against 288ms for --no-hardlinks over three runs each. Both obvious
+  // avenues are therefore closed, and the ceiling is the fix.
+  //
+  // These two are also the only tests in the suite anywhere near the default:
+  // across all 24 runs every other test topped out at 412ms.
   it("proves the controlled pair passes and a non-discriminating mutation fails", async () => {
     const result = await verifyScriptedPairPreflight({
       repositoryRoot: ROOT,
@@ -174,7 +212,7 @@ describe("committed INT-2 ceremony mechanics", () => {
         negativeScriptPath: mutatedNegative,
       }),
     ).rejects.toThrow("controlled pair appended content must differ");
-  });
+  }, 30_000);
 
   it("preflights all three paid-task criterion outcomes at the pinned revision", async () => {
     const result = await verifySection3Preflight({


### PR DESCRIPTION
The controlled-pair preflight test failed 1 of 4 back-to-back full-suite runs at **5025ms** — vitest's 5000ms default firing, not a wrong assertion.

## Genuine timeout under contention, not a race

Across **24 full-suite runs** (part of them with the cap lifted to 120s so the true cost was observable):

| condition | pair test | section-3 sibling |
|---|---|---|
| idle, 5s cap (6 runs) | 2628–3916ms | 3379–3786ms |
| 8 CPU burners, 120s cap (8 runs) | 2877–4108ms | 3688–4530ms |
| 8 CPU burners, 30s cap (10 runs) | 2916–3628ms, **10/10 pass** | 3791–4030ms |

Every run finished inside a bounded 2.6–4.1s window and passed. **That ceiling is what rules out a race** — a deadlock has no upper bound. Worst case was 82% of the budget: no useful margin.

Shared-state contention was ruled out specifically: temp dirs are per-call `mkdtemp`, the clone source is read-only, and the other git-touching tests either mock git entirely or mutate only their own throwaway repo. No lock is contended.

## Why 30_000, and why not a cost fix

The section-3 test immediately below does **strictly more** clone work (three fixture criteria vs two), has carried `30_000` since #594, and is green nightly. Same workload class, same budget.

Both obvious ways to make it cheaper are closed — **measured, not assumed**:

| avenue | result |
|---|---|
| `--no-checkout` | ~100ms of ~850ms per clone, and would mean editing `int2-evidence.mjs`, a production evidence script shared with the real ceremony |
| `--no-hardlinks` | dropping it is a **regression**: 484ms hardlinked vs **288ms** with the flag, three runs each |

So the ceiling is the fix. The comment records the measurement and the reasoning, not just the number, so the next person to see `30_000` doesn't have to re-derive why.

## One correction to the original diagnosis

The first pass claimed *"CI's 4-core runners are slower than that"* and would fail. **They have not** — CI has been green throughout, and the 10-iteration flake-stress job passed 10/10.

The likelier mechanism runs the other way: **vitest sizes its worker pool from CPU count**, so a 12-core dev host runs more test *files* concurrently, overlapping more clones and contending harder for disk than a 4-core runner does. That explains why the flake appears locally while CI stays green — it *explains the observation* instead of predicting a failure we don't see.

Worth correcting because the sentence was about to be frozen into a permanent comment, and a justification our own CI record contradicts is worse than no justification.

## Scope

One file, one line of behaviour change plus the comment. Off `main`, deliberately not piled onto the ops-board branch. These two are the only tests in the suite anywhere near the default — across all 24 runs every other test topped out at 412ms, so there's no third one at the cliff.

Local: `11 passed`, pair test 2335ms, sibling 1816ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)