### PR TITLE
Close incidents orphaned by a restart; stop showing a raw RPC URL

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   DATA_STALE_FALLBACK_MS,
   METER_RUNGS,
+  shortEndpoint,
   staleAfterMs,
   opsVerdict,
   payoutView,
@@ -336,6 +337,34 @@ describe("trustRows", () => {
       nowMs: NOW,
     });
     expect(rows.find((r) => r.key === "STREAM")!.value).toBe("live · last event 10:30:00");
+  });
+
+  // Caught on the phone, which cannot hide it behind an ellipsis the way the
+  // desktop did: activeEndpoint is a full URL in prod and took the whole line.
+  test("the RPC endpoint shows its host, not the whole URL", () => {
+    expect(shortEndpoint("https://services.polkadothub-rpc.com/mainnet/")).toBe(
+      "services.polkadothub-rpc.com",
+    );
+    const health: ProductHealth = {
+      ...OPS_FIXTURE_NOMINAL,
+      remediation: {
+        state: "armed",
+        enabled: true,
+        activeEndpoint: "https://services.polkadothub-rpc.com/mainnet/",
+        onBackup: false,
+        detail: "armed · primary https://services.polkadothub-rpc.com/mainnet/",
+      },
+    };
+    const rpc = trustRows({ health, streamDegraded: false, streamStatus: "open", nowMs: health.at! })
+      .find((r) => r.key === "RPC")!;
+    expect(rpc.value).toBe("armed · primary services.polkadothub-rpc.com");
+    expect(rpc.value).not.toContain("https://");
+  });
+
+  test("a short endpoint name is left exactly as it is", () => {
+    expect(shortEndpoint("rpc-1")).toBe("rpc-1");
+    expect(shortEndpoint("")).toBeNull();
+    expect(shortEndpoint(null)).toBeNull();
   });
 
   test("no failover configured is awaiting, not a green 'armed'", () => {

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -76,6 +76,27 @@ function clockOf(at: number | null | undefined): string {
   return Number.isNaN(d.getTime()) ? "—" : `${d.toISOString().slice(11, 19)}Z`;
 }
 
+/**
+ * An RPC endpoint, short enough to sit on one line.
+ *
+ * `remediation.activeEndpoint` is a full URL in production —
+ * "https://services.polkadothub-rpc.com/mainnet/" — which the desktop hid
+ * behind an ellipsis and the phone could not hide at all: it became the longest
+ * thing on the trust line. The host is the part that identifies WHICH endpoint
+ * we are on, which is the only question the row answers.
+ */
+export function shortEndpoint(endpoint: string | null | undefined): string | null {
+  const raw = (endpoint ?? "").trim();
+  if (!raw) return null;
+  try {
+    return new URL(raw).host || raw;
+  } catch {
+    // Already a short name ("rpc-1") or something unparseable — show it as-is
+    // rather than dropping the only identifying detail on the row.
+    return raw;
+  }
+}
+
 /** "10:30:00" from an ISO string, or undefined when there is nothing to show. */
 function isoClock(iso: string | undefined): string | undefined {
   if (!iso) return undefined;
@@ -211,12 +232,19 @@ export function trustRows(input: {
   } else {
     rows.push({
       key: "RPC",
-      value: rem.detail,
+      value: shortRpcDetail(rem),
       tone: rem.state === "halted" ? "red" : rem.state === "failover" ? "degraded" : "ok",
     });
   }
 
   return rows;
+}
+
+/** The remediation detail with any full URL in it reduced to its host. */
+function shortRpcDetail(rem: NonNullable<ProductHealth["remediation"]>): string {
+  const host = shortEndpoint(rem.activeEndpoint);
+  if (!host) return rem.detail;
+  return rem.detail.replace(/https?:\/\/\S+/g, host);
 }
 
 function monitorRow(self: SelfFreshness | undefined): TrustRow {

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.ts
@@ -19,7 +19,7 @@
 import type { HealthHistory, ProductHealth, SolvencyPool } from "./product-health.js";
 import { deriveOpsVerdict, verdictProbeLabel } from "@avg/schemas/ops-verdict";
 import { formatAgo, formatAmount, formatDuration, groupProbesByPillar, probeOpsTone, type OpsTone } from "./ops-model.js";
-import { poolMeter, staleAfterMs, type MeterView } from "./ops-spec.js";
+import { poolMeter, shortEndpoint, staleAfterMs, type MeterView } from "./ops-spec.js";
 
 // ── the verdict field ───────────────────────────────────────────────────────
 
@@ -161,7 +161,9 @@ export function phoneTrust(input: {
 
   const rem = health.remediation;
   if (rem?.enabled && rem.state !== "off") {
-    parts.push(rem.activeEndpoint ?? rem.state);
+    // The host, not the URL — in prod this is a full endpoint and it took the
+    // whole line, which on a phone is the entire trust budget.
+    parts.push(shortEndpoint(rem.activeEndpoint) ?? rem.state);
   }
 
   const tone: OpsTone = streamDegraded

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -3636,6 +3636,14 @@ function startOperatorRoutines() {
           persisted: productHealthIncidents,
           derived,
           limit: PRODUCT_HEALTH_INCIDENT_MAX,
+          // Present-tense evidence, so an episode orphaned by a restart can be
+          // closed on it. Without this the footer counts upward forever beside a
+          // green probe — the buffer that would have closed it is gone.
+          currentProbeStatus: new Map(
+            (productHealthHistory[productHealthHistory.length - 1]?.probes ?? []).map(
+              (p) => [p.name, p.status] as const,
+            ),
+          ),
         });
         productHealthIncidents = reconciled.merged;
         await appendIncidents(reconciled.writes);

--- a/services/slack-operator/src/product-health-incidents.ts
+++ b/services/slack-operator/src/product-health-incidents.ts
@@ -40,11 +40,17 @@ export function reconcileIncidents(input: {
   persisted: readonly ProductHealthIncident[];
   derived: readonly ProductHealthIncident[];
   limit: number;
+  /** Probe → status in the LATEST snapshot. Lets an episode whose samples are
+   *  gone be closed on present evidence. Omit it and nothing closes this way. */
+  currentProbeStatus?: ReadonlyMap<string, "ok" | "degraded" | "red">;
+  /** Clock for the recovery stamp; injected so the close is deterministic. */
+  nowMs?: number;
 }): { merged: ProductHealthIncident[]; writes: ProductHealthIncident[] } {
   const byId = new Map<string, ProductHealthIncident>();
   for (const incident of input.persisted) byId.set(incident.id, incident);
 
   const writes: ProductHealthIncident[] = [];
+  const derivedIds = new Set(input.derived.map((i) => i.id));
   for (const incident of input.derived) {
     const existing = byId.get(incident.id);
     // New incident, or one that changed state (usually open → closed). Comparing
@@ -52,6 +58,42 @@ export function reconcileIncidents(input: {
     if (!existing || !sameIncident(existing, incident)) {
       writes.push(incident);
       byId.set(incident.id, incident);
+    }
+  }
+
+  // ORPHANS — an episode that was open when the process restarted.
+  //
+  // The header above says the worst case is "an incident that stays open until
+  // the next tick reconciles it". The next tick cannot. Closing is driven by the
+  // DERIVED set, which is computed from the in-memory ring, and a restart empties
+  // that ring — so the episode simply stops being derived, the persisted open
+  // record is never overwritten, and it stays open forever.
+  //
+  // Seen on mainnet: the board read "money_path degraded for 1h 33m" beside a
+  // green money_path probe, counting upward. That is a permanently-lit alarm,
+  // and a board that grows those teaches its operator to ignore the footer.
+  //
+  // So an open record is closed when its probe is CURRENTLY ok and this buffer
+  // no longer knows about the episode. The recovery time is stamped now and the
+  // note says the real one is unknown, because the samples that would have told
+  // us are gone. An honest approximate close beats an eternal open one — and
+  // inventing a plausible recovery time would be worse than either.
+  const status = input.currentProbeStatus;
+  if (status) {
+    const closedAt = input.nowMs ?? Date.now();
+    for (const incident of byId.values()) {
+      if (incident.endedAt != null) continue;
+      if (derivedIds.has(incident.id)) continue; // this buffer still sees it
+      // Not ok, or a probe we have no reading for at all → leave it open. An
+      // incident must never be closed by absence of evidence.
+      if (status.get(incident.probe) !== "ok") continue;
+      const closed: ProductHealthIncident = {
+        ...incident,
+        endedAt: closedAt,
+        note: `${incident.note ? `${incident.note} · ` : ""}recovered while the monitor was restarting — exact recovery time unknown`,
+      };
+      writes.push(closed);
+      byId.set(closed.id, closed);
     }
   }
 

--- a/test/unit/product-health-incidents.test.ts
+++ b/test/unit/product-health-incidents.test.ts
@@ -27,6 +27,85 @@ async function tmpLog(): Promise<string> {
   return join(dir, "incidents.jsonl");
 }
 
+// An episode orphaned by a restart: persisted and open, but the in-memory ring
+// that would close it was emptied, so it is no longer derived from anything.
+describe("reconcileIncidents — orphans left open by a restart", () => {
+  const orphan = incident({ id: "money_path-500", probe: "money_path", startedAt: 500 });
+
+  // SEEN ON MAINNET: the board read "money_path degraded for 1h 33m" next to a
+  // green money_path probe, and the counter would have kept climbing forever.
+  it("closes an open episode whose probe is now ok", () => {
+    const r = reconcileIncidents({
+      persisted: [orphan],
+      derived: [],
+      limit: 50,
+      currentProbeStatus: new Map([["money_path", "ok"]]),
+      nowMs: 9_000,
+    });
+    expect(r.writes).toHaveLength(1);
+    expect(r.writes[0]!.endedAt).toBe(9_000);
+    // …and admits the recovery time is a stamp, not an observation.
+    expect(r.writes[0]!.note).toContain("exact recovery time unknown");
+  });
+
+  it("leaves it open while the probe is still failing", () => {
+    for (const status of ["red", "degraded"] as const) {
+      const r = reconcileIncidents({
+        persisted: [orphan],
+        derived: [],
+        limit: 50,
+        currentProbeStatus: new Map([["money_path", status]]),
+        nowMs: 9_000,
+      });
+      expect(r.writes).toEqual([]);
+      expect(r.merged[0]!.endedAt).toBeNull();
+    }
+  });
+
+  // Closing on a probe we have no reading for would be closing on ABSENCE of
+  // evidence — the same mistake as a fake green, pointed the other way.
+  it("leaves it open when the probe is missing from the snapshot entirely", () => {
+    const r = reconcileIncidents({
+      persisted: [orphan],
+      derived: [],
+      limit: 50,
+      currentProbeStatus: new Map([["api_latency", "ok"]]),
+      nowMs: 9_000,
+    });
+    expect(r.writes).toEqual([]);
+  });
+
+  it("does not touch an episode this buffer still derives", () => {
+    const r = reconcileIncidents({
+      persisted: [orphan],
+      derived: [orphan],
+      limit: 50,
+      currentProbeStatus: new Map([["money_path", "ok"]]),
+      nowMs: 9_000,
+    });
+    expect(r.writes).toEqual([]);
+  });
+
+  it("never re-closes an already-closed record", () => {
+    const closed = incident({ id: "money_path-500", probe: "money_path", endedAt: 700 });
+    const r = reconcileIncidents({
+      persisted: [closed],
+      derived: [],
+      limit: 50,
+      currentProbeStatus: new Map([["money_path", "ok"]]),
+      nowMs: 9_000,
+    });
+    expect(r.writes).toEqual([]);
+  });
+
+  // Without the status map nothing may close — the old behaviour exactly, so a
+  // caller that cannot supply present evidence changes nothing.
+  it("closes nothing when no current status is supplied", () => {
+    const r = reconcileIncidents({ persisted: [orphan], derived: [], limit: 50 });
+    expect(r.writes).toEqual([]);
+  });
+});
+
 describe("reconcileIncidents (pure)", () => {
   it("writes a newly opened incident", () => {
     const r = reconcileIncidents({ persisted: [], derived: [incident()], limit: 50 });


### PR DESCRIPTION
Two contradictions found by looking at the deployed board after #613/#615 landed. Neither was caught by a test — both were visible on screen.

## 1. An incident that could never close

The footer read:

```
INCIDENTS — 1 ongoing · money_path degraded for 1h 33m
```

…while money_path was green and the FLOW pillar read `1/1 ok`. That counter would have kept climbing — 3h, 2d, a week — beside a healthy probe.

**Cause:** closing an episode is driven by the *derived* set, computed from the in-memory sample ring. A restart empties that ring, so the episode stops being derived at all, the persisted open record is never overwritten, and it stays open forever.

The module header already predicted this without quite seeing it:

> the worst case is an incident that stays open until the next tick reconciles it

The next tick **cannot**. The evidence that would close it lived only in the buffer the restart destroyed.

**Fix:** an open record is closed when its probe is *currently* ok and this buffer no longer knows the episode. The recovery time is stamped at reconcile and the note says the true one is unknown — because the samples that would have told us are gone. An honest approximate close beats an eternal open one, and inventing a plausible recovery time would be worse than either.

Three guards, all tested:

- a still-failing probe stays open
- a probe **missing** from the snapshot stays open — closing on *absence* of evidence is a fake green pointed the other way
- with no status map supplied, nothing closes at all, so behaviour is exactly preserved for any other caller

## 2. A raw URL where a name belongs

The trust row rendered `https://services.polkadothub-rpc.com/mainnet/` — the longest thing on the line.

The desktop had been hiding it behind an ellipsis. It only became visible when the phone board put the same row on a 390px screen and couldn't. The **host** is the part that answers *"which endpoint am I on"*, which is the only question that row asks. Short names (`rpc-1`) pass through untouched.

Worth noting as a pattern: the narrower surface exposed a defect the wider one had been quietly truncating. Building the phone board improved the desktop.

## Verification

- full suite **2031 passed**, 14 skipped
- `tsc -b` clean, vite build clean
- 6 new tests on the orphan path, 2 on the endpoint label

## Still open, not fixed here

The MONITOR trust row reads **`build unknown`** in prod, because the running sha isn't baked into the image. That means the self-freshness probe from #588 **has been inert since it shipped** — we currently cannot tell whether the board is running current code, which is exactly what that probe exists to answer.

It's a build-arg change on the deploy rather than a code change, so it's Pascal's rather than mine.