### PR TITLE
feat(harness): add the INT-3a PR payload actuator

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc -b packages/* services/*",
     "typecheck": "tsc -b --pretty false packages/* services/*",
     "test": "vitest run",
+    "test:int3a": "vitest run test/integration/int3a-payload-actuator.test.ts",
     "dev:trace": "tsx packages/trace-mcp/src/index.ts",
     "dev:policy": "tsx packages/policy-mcp/src/index.ts",
     "dev:observer": "tsx services/skills-observer/src/index.ts"

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -5,6 +5,7 @@ export * from "./agent-task.js";
 export * from "./hermes-decision-record.js";
 export * from "./legacy-agent-task.js";
 export * from "./ops-verdict.js";
+export * from "./pull-request-payload.js";
 export * from "./task-intent.js";
 export * from "./verified-handoff.js";
 export * from "./wikipedia.js";

--- a/packages/schemas/src/pull-request-payload.ts
+++ b/packages/schemas/src/pull-request-payload.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+
+import {
+  artifactRefSchema,
+  integrationIdSchema,
+  integrationTextSchema,
+  sha256Schema,
+} from "./agent-integration-common.js";
+
+const gitObjectIdSchema = z.string().regex(/^[a-f0-9]{40}$/);
+const gitRefSchema = z.string()
+  .trim()
+  .min(1)
+  .max(240)
+  .refine(isSafeGitRef, "invalid Git ref");
+
+/**
+ * The immutable INT-3a artifact. It is deliberately richer than GitHub's
+ * create-PR request: the refs are paired with the exact base revision, patched
+ * tree, and patch bytes that a later actuator would have to materialize.
+ */
+export const pullRequestPayloadV1Schema = z.object({
+  schemaVersion: z.literal(1),
+  kind: z.literal("pull_request_payload"),
+  repository: z.string().regex(/^[^/\s]+\/[^/\s]+$/).max(240),
+  base: z.object({
+    ref: gitRefSchema,
+    revision: gitObjectIdSchema,
+  }).strict(),
+  head: z.object({
+    ref: gitRefSchema,
+    treeSha: gitObjectIdSchema,
+  }).strict(),
+  title: integrationTextSchema,
+  body: z.string().trim().min(1).max(65_536),
+  patch: z.object({
+    ref: artifactRefSchema,
+    sha256: sha256Schema,
+    bytes: z.string().max(10_000_000),
+  }).strict(),
+  source: z.object({
+    workItemId: integrationIdSchema,
+    taskVersion: z.number().int().positive().safe(),
+    approvedTaskHash: sha256Schema,
+    harnessRunId: integrationIdSchema,
+    verificationDecisionHash: sha256Schema,
+  }).strict(),
+}).strict().superRefine((payload, context) => {
+  if (payload.patch.ref.sha256 !== payload.patch.sha256) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "patch ref hash must match the declared patch hash",
+      path: ["patch", "sha256"],
+    });
+  }
+});
+
+export type PullRequestPayloadV1 = z.infer<
+  typeof pullRequestPayloadV1Schema
+>;
+
+function isSafeGitRef(value: string): boolean {
+  const components = value.split("/");
+  return value !== "@"
+    && !value.startsWith("/")
+    && !value.endsWith("/")
+    && !value.endsWith(".")
+    && !value.includes("..")
+    && !value.includes("@{")
+    && !value.includes("//")
+    && !components.some(
+      (component) => component.startsWith(".") || component.endsWith(".lock"),
+    )
+    && ![...value].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x20
+        || code === 0x7f
+        || "~^:?*[\\".includes(character);
+    });
+}

--- a/services/harness-dispatcher/src/pr-payload-actuator.ts
+++ b/services/harness-dispatcher/src/pr-payload-actuator.ts
@@ -1,0 +1,475 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import { deriveIntendedRunId } from "@avg/averray-mcp/dispatch-claim";
+import {
+  agentRunProjectionV1Schema,
+  agentTaskApprovalHashMatches,
+  agentTaskV1Schema,
+  artifactRefSchema,
+  assertVerifiedHandoffMatchesTaskAndRun,
+  canonicalContractJson,
+  pullRequestPayloadV1Schema,
+  verifiedHandoffV1Schema,
+  type AgentRunProjectionV1,
+  type AgentTaskV1,
+  type ArtifactRef,
+  type PullRequestPayloadV1,
+  type VerifiedHandoffV1,
+} from "@avg/schemas";
+
+export type PrPayloadRefusalReason =
+  | "approval_hash_mismatch"
+  | "artifact_hash_mismatch"
+  | "artifact_unavailable"
+  | "base_drift"
+  | "base_revision_invalid"
+  | "contract_invalid"
+  | "eligibility_disagreement"
+  | "halt_global"
+  | "halt_repository"
+  | "halt_state_unavailable"
+  | "handoff_check_not_passed"
+  | "handoff_identity_mismatch"
+  | "handoff_outcome_not_completed"
+  | "handoff_unverified"
+  | "patch_apply_failed"
+  | "patch_empty"
+  | "patch_missing"
+  | "path_forbidden"
+  | "path_not_allowed"
+  | "payload_artifact_mismatch"
+  | "repository_mismatch"
+  | "repository_unavailable";
+
+export class PrPayloadActuationError extends Error {
+  constructor(
+    readonly reason: PrPayloadRefusalReason,
+    message: string,
+    readonly escalationRequired = false,
+  ) {
+    super(message);
+    this.name = "PrPayloadActuationError";
+  }
+}
+
+export interface PrPayloadArtifactPort {
+  read(ref: ArtifactRef): Promise<Uint8Array>;
+  write(bytes: Uint8Array, mediaType: string): Promise<ArtifactRef>;
+}
+
+export interface PrPayloadRepositoryBase {
+  ref: string;
+  revision: string;
+}
+
+export interface AppliedPatchTree {
+  treeSha: string;
+  touchedPaths: string[];
+}
+
+export interface PrPayloadRepositoryPort {
+  readCurrentBase(repository: string): Promise<PrPayloadRepositoryBase>;
+  applyPatch(input: {
+    repository: string;
+    baseRevision: string;
+    patch: Uint8Array;
+  }): Promise<AppliedPatchTree>;
+}
+
+export interface ActuationHaltState {
+  global: boolean;
+  repositories: readonly string[];
+}
+
+export interface PrPayloadActuatorDeps {
+  artifacts: PrPayloadArtifactPort;
+  repository: PrPayloadRepositoryPort;
+  readHaltState(): Promise<ActuationHaltState>;
+}
+
+export interface PrPayloadActuationInput {
+  task: AgentTaskV1;
+  run: AgentRunProjectionV1;
+  handoff: VerifiedHandoffV1;
+}
+
+export interface PrPayloadActuationResult {
+  artifact: ArtifactRef;
+  payload: PullRequestPayloadV1;
+  canonicalBytes: string;
+}
+
+const FULL_GIT_OBJECT_ID = /^[a-f0-9]{40}$/;
+const PAYLOAD_MEDIA_TYPE = "application/vnd.averray.pull-request-payload.v1+json";
+
+/**
+ * Build the immutable INT-3a payload. This boundary has no GitHub client,
+ * credential, environment lookup, or outward-effect port.
+ */
+export async function actuatePullRequestPayload(
+  input: PrPayloadActuationInput,
+  deps: PrPayloadActuatorDeps,
+): Promise<PrPayloadActuationResult> {
+  const task = parseContract(agentTaskV1Schema, input.task, "AgentTask");
+  const run = parseContract(
+    agentRunProjectionV1Schema,
+    input.run,
+    "AgentRunProjection",
+  );
+
+  await assertHaltClear(task.repository.nameWithOwner, deps);
+  assertEligibilityAgreement(input.handoff);
+  const handoff = parseContract(
+    verifiedHandoffV1Schema,
+    input.handoff,
+    "VerifiedHandoff",
+  );
+
+  if (!await agentTaskApprovalHashMatches(task)) {
+    refuse(
+      "approval_hash_mismatch",
+      "Approved task hash does not match the actuation-time AgentTask",
+    );
+  }
+  try {
+    await assertVerifiedHandoffMatchesTaskAndRun(task, run, handoff);
+  } catch {
+    refuse(
+      "handoff_identity_mismatch",
+      "VerifiedHandoff does not match the approved task and bound run",
+    );
+  }
+  assertEligibility(handoff);
+
+  const patchRef = handoff.deliverables.patchRef;
+  if (!patchRef) {
+    refuse("patch_missing", "VerifiedHandoff has no patch artifact");
+  }
+  if (!FULL_GIT_OBJECT_ID.test(task.repository.baseRevision)) {
+    refuse(
+      "base_revision_invalid",
+      "Approved baseRevision is not a full Git object id",
+    );
+  }
+
+  const patchBytes = await readVerifiedArtifact(patchRef, deps.artifacts);
+  if (patchBytes.byteLength === 0) {
+    refuse("patch_empty", "Verified patch artifact is empty");
+  }
+  const patchText = decodeExactUtf8Patch(patchBytes);
+
+  const baseBefore = await readBase(task.repository.nameWithOwner, deps);
+  assertBaseCurrent(task.repository.baseRevision, baseBefore.revision);
+  const applied = await applyPatch(task, patchBytes, deps);
+  assertTouchedPaths(task, applied.touchedPaths);
+  const baseAfter = await readBase(task.repository.nameWithOwner, deps);
+  assertBaseCurrent(task.repository.baseRevision, baseAfter.revision);
+  if (baseAfter.ref !== baseBefore.ref) {
+    refuse(
+      "base_drift",
+      `Base ref drifted from ${baseBefore.ref} to ${baseAfter.ref}`,
+    );
+  }
+
+  const approvedTaskHash = task.approval.approvedTaskHash;
+  if (!approvedTaskHash) {
+    refuse(
+      "approval_hash_mismatch",
+      "Approved task has no immutable approval hash",
+    );
+  }
+  const headRef = `harness/${deriveIntendedRunId(
+    task.workItemId,
+    task.taskVersion,
+    approvedTaskHash,
+  )}`;
+  const payload = parseContract(
+    pullRequestPayloadV1Schema,
+    {
+      schemaVersion: 1,
+      kind: "pull_request_payload",
+      repository: task.repository.nameWithOwner,
+      base: {
+        ref: baseBefore.ref,
+        revision: task.repository.baseRevision,
+      },
+      head: {
+        ref: headRef,
+        treeSha: applied.treeSha,
+      },
+      title: task.proposal.title,
+      body: buildPullRequestBody(task, handoff, applied.treeSha),
+      patch: {
+        ref: patchRef,
+        sha256: patchRef.sha256,
+        bytes: patchText,
+      },
+      source: {
+        workItemId: task.workItemId,
+        taskVersion: task.taskVersion,
+        approvedTaskHash,
+        harnessRunId: handoff.harnessRunId,
+        verificationDecisionHash: handoff.verification.decisionHash,
+      },
+    },
+    "pull-request payload",
+  );
+  const canonicalBytes = canonicalContractJson(payload);
+
+  // HALT is sampled again immediately before the only write in stage 3a.
+  await assertHaltClear(task.repository.nameWithOwner, deps);
+  const bytes = Buffer.from(canonicalBytes, "utf8");
+  const expectedHash = rawSha256(bytes);
+  let artifact: ArtifactRef;
+  try {
+    artifact = artifactRefSchema.parse(
+      await deps.artifacts.write(bytes, PAYLOAD_MEDIA_TYPE),
+    );
+  } catch (error) {
+    if (error instanceof PrPayloadActuationError) throw error;
+    refuse(
+      "payload_artifact_mismatch",
+      "Pull-request payload artifact could not be written",
+    );
+  }
+  const expectedUri = `artifact://sha256/${expectedHash.slice("sha256:".length)}`;
+  if (
+    artifact.sha256 !== expectedHash
+    || artifact.uri !== expectedUri
+    || (artifact.sizeBytes !== undefined && artifact.sizeBytes !== bytes.byteLength)
+  ) {
+    refuse(
+      "payload_artifact_mismatch",
+      "Pull-request payload writer returned a different content address",
+    );
+  }
+
+  return { artifact, payload, canonicalBytes };
+}
+
+function assertEligibility(handoff: VerifiedHandoffV1): void {
+  assertEligibilityAgreement(handoff);
+  if (handoff.outcome !== "completed") {
+    refuse(
+      "handoff_outcome_not_completed",
+      `VerifiedHandoff outcome is ${handoff.outcome}, not completed`,
+    );
+  }
+
+  if (!handoff.verification.verified) {
+    refuse(
+      "handoff_unverified",
+      "VerifiedHandoff has no verified acceptance",
+    );
+  }
+  const notPassed = handoff.checks.find((check) => check.status !== "passed");
+  if (notPassed) {
+    refuse(
+      "handoff_check_not_passed",
+      `VerifiedHandoff check did not pass: ${notPassed.name}`,
+    );
+  }
+}
+
+function assertEligibilityAgreement(handoff: VerifiedHandoffV1): void {
+  const recomputed = handoff.outcome === "completed"
+    && handoff.verification.verified
+    && handoff.checks.every((check) => check.status === "passed");
+  if (recomputed !== handoff.eligibleForPrOpen) {
+    refuse(
+      "eligibility_disagreement",
+      "Stored eligibleForPrOpen disagrees with actuation-time recomputation",
+      true,
+    );
+  }
+}
+
+async function assertHaltClear(
+  repository: string,
+  deps: PrPayloadActuatorDeps,
+): Promise<void> {
+  let halt: ActuationHaltState;
+  try {
+    halt = await deps.readHaltState();
+  } catch {
+    refuse(
+      "halt_state_unavailable",
+      "HALT state is unavailable; payload generation fails closed",
+    );
+  }
+  if (halt.global) {
+    refuse("halt_global", "Global HALT is active; payload generation refused");
+  }
+  if (halt.repositories.some(
+    (candidate) => candidate.toLowerCase() === repository.toLowerCase(),
+  )) {
+    refuse(
+      "halt_repository",
+      `Repository HALT is active for ${repository}; payload generation refused`,
+    );
+  }
+}
+
+async function readVerifiedArtifact(
+  ref: ArtifactRef,
+  artifacts: PrPayloadArtifactPort,
+): Promise<Uint8Array> {
+  let bytes: Uint8Array;
+  try {
+    bytes = await artifacts.read(ref);
+  } catch (error) {
+    if (error instanceof PrPayloadActuationError) throw error;
+    refuse("artifact_unavailable", "Verified patch artifact could not be read");
+  }
+  const digest = rawSha256(bytes);
+  if (
+    digest !== ref.sha256
+    || (ref.sizeBytes !== undefined && ref.sizeBytes !== bytes.byteLength)
+  ) {
+    refuse(
+      "artifact_hash_mismatch",
+      "Verified patch bytes do not match deliverables.patchRef",
+    );
+  }
+  return bytes;
+}
+
+function decodeExactUtf8Patch(bytes: Uint8Array): string {
+  let decoded: string;
+  try {
+    decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    refuse("patch_apply_failed", "Verified patch is not valid UTF-8 text");
+  }
+  if (!Buffer.from(decoded, "utf8").equals(Buffer.from(bytes))) {
+    refuse("patch_apply_failed", "Verified patch bytes are not stable UTF-8");
+  }
+  return decoded;
+}
+
+async function readBase(
+  repository: string,
+  deps: PrPayloadActuatorDeps,
+): Promise<PrPayloadRepositoryBase> {
+  try {
+    return await deps.repository.readCurrentBase(repository);
+  } catch (error) {
+    if (error instanceof PrPayloadActuationError) throw error;
+    refuse(
+      "repository_unavailable",
+      `Pinned repository state is unavailable for ${repository}`,
+    );
+  }
+}
+
+async function applyPatch(
+  task: AgentTaskV1,
+  patch: Uint8Array,
+  deps: PrPayloadActuatorDeps,
+): Promise<AppliedPatchTree> {
+  try {
+    return await deps.repository.applyPatch({
+      repository: task.repository.nameWithOwner,
+      baseRevision: task.repository.baseRevision,
+      patch,
+    });
+  } catch (error) {
+    if (error instanceof PrPayloadActuationError) throw error;
+    refuse(
+      "patch_apply_failed",
+      "Verified patch could not be applied to the approved baseRevision",
+    );
+  }
+}
+
+function assertBaseCurrent(expected: string, actual: string): void {
+  if (actual !== expected) {
+    refuse(
+      "base_drift",
+      `Base drift: approved ${expected}, current ${actual}`,
+    );
+  }
+}
+
+function assertTouchedPaths(task: AgentTaskV1, touchedPaths: string[]): void {
+  if (touchedPaths.length === 0) {
+    refuse("patch_empty", "Applying the verified patch changes no paths");
+  }
+  for (const touchedPath of touchedPaths) {
+    if (!isSafeRepositoryPath(touchedPath)) {
+      refuse(
+        "path_not_allowed",
+        `Patch path is not a safe repository-relative path: ${touchedPath}`,
+      );
+    }
+    if (!task.repository.allowedPaths.some(
+      (pattern) => path.posix.matchesGlob(touchedPath, pattern),
+    )) {
+      refuse(
+        "path_not_allowed",
+        `Patch path is outside repository.allowedPaths: ${touchedPath}`,
+      );
+    }
+    if (task.repository.forbiddenPaths.some(
+      (pattern) => path.posix.matchesGlob(touchedPath, pattern),
+    )) {
+      refuse(
+        "path_forbidden",
+        `Patch path matches repository.forbiddenPaths: ${touchedPath}`,
+      );
+    }
+  }
+}
+
+function isSafeRepositoryPath(value: string): boolean {
+  return value.length > 0
+    && !value.includes("\\")
+    && !path.posix.isAbsolute(value)
+    && path.posix.normalize(value) === value
+    && value !== ".."
+    && !value.startsWith("../");
+}
+
+function buildPullRequestBody(
+  task: AgentTaskV1,
+  handoff: VerifiedHandoffV1,
+  treeSha: string,
+): string {
+  return [
+    task.proposal.objective,
+    "",
+    "---",
+    "Verified Harness handoff",
+    `- Work item: ${task.workItemId}@${task.taskVersion}`,
+    `- Run: ${handoff.harnessRunId}`,
+    `- Approved task: ${task.approval.approvedTaskHash}`,
+    `- Verification decision: ${handoff.verification.decisionHash}`,
+    `- Patch: ${handoff.deliverables.patchRef?.sha256}`,
+    `- Head tree: ${treeSha}`,
+  ].join("\n");
+}
+
+function rawSha256(bytes: Uint8Array): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+}
+
+function parseContract<T>(
+  schema: { parse(input: unknown): T },
+  value: unknown,
+  label: string,
+): T {
+  try {
+    return schema.parse(value);
+  } catch {
+    refuse("contract_invalid", `${label} failed strict schema validation`);
+  }
+}
+
+function refuse(
+  reason: PrPayloadRefusalReason,
+  message: string,
+  escalationRequired = false,
+): never {
+  throw new PrPayloadActuationError(reason, message, escalationRequired);
+}

--- a/services/harness-dispatcher/src/pr-payload-local-ports.ts
+++ b/services/harness-dispatcher/src/pr-payload-local-ports.ts
@@ -1,0 +1,331 @@
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+
+import { artifactRefSchema, type ArtifactRef } from "@avg/schemas";
+
+import {
+  PrPayloadActuationError,
+  type PrPayloadArtifactPort,
+  type PrPayloadRepositoryPort,
+} from "./pr-payload-actuator.js";
+
+const FULL_GIT_OBJECT_ID = /^[a-f0-9]{40}$/;
+const REPOSITORY_NAME = /^[^/\s]+\/[^/\s]+$/;
+const GIT_TIMEOUT_MS = 120_000;
+const GIT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024;
+
+export function createFilePrPayloadArtifactPort(
+  rootInput: string,
+): PrPayloadArtifactPort {
+  const root = path.resolve(rootInput);
+  return {
+    async read(refInput): Promise<Uint8Array> {
+      const ref = artifactRefSchema.parse(refInput);
+      const digest = digestFromRef(ref);
+      return readFile(path.join(root, digest));
+    },
+    async write(bytes, mediaType): Promise<ArtifactRef> {
+      const buffer = Buffer.from(bytes);
+      const digest = createHash("sha256").update(buffer).digest("hex");
+      const target = path.join(root, digest);
+      await mkdir(root, { recursive: true });
+      try {
+        await writeFile(target, buffer, { flag: "wx" });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+        const existing = await readFile(target);
+        if (!existing.equals(buffer)) {
+          throw new PrPayloadActuationError(
+            "payload_artifact_mismatch",
+            "Existing content-addressed artifact has different bytes",
+          );
+        }
+      }
+      return artifactRefSchema.parse({
+        uri: `artifact://sha256/${digest}`,
+        sha256: `sha256:${digest}`,
+        mediaType,
+        sizeBytes: buffer.byteLength,
+      });
+    },
+  };
+}
+
+export interface LocalGitPrPayloadRepositoryConfig {
+  repositoryRoot: string;
+  repository: string;
+  baseRef: string;
+}
+
+/**
+ * A local-only repository port. Every Git invocation uses a fixed argument
+ * vector with shell=false; there is no fetch, push, remote URL, or credential.
+ */
+export function createLocalGitPrPayloadRepositoryPort(
+  config: LocalGitPrPayloadRepositoryConfig,
+): PrPayloadRepositoryPort {
+  if (!REPOSITORY_NAME.test(config.repository)) {
+    throw new PrPayloadActuationError(
+      "repository_mismatch",
+      "Pinned repository must be an owner/name pair",
+    );
+  }
+  if (!isSafeGitRef(config.baseRef)) {
+    throw new PrPayloadActuationError(
+      "repository_mismatch",
+      "Pinned base ref is not a safe Git ref",
+    );
+  }
+  const configuredRoot = path.resolve(config.repositoryRoot);
+
+  return {
+    async readCurrentBase(repository) {
+      assertPinnedRepository(config.repository, repository);
+      const repositoryRoot = await resolvedRepositoryRoot(configuredRoot);
+      const result = await runGit(
+        ["rev-parse", "--verify", `refs/heads/${config.baseRef}^{commit}`],
+        repositoryRoot,
+      );
+      if (result.code !== 0 || !FULL_GIT_OBJECT_ID.test(result.stdout.trim())) {
+        throw new PrPayloadActuationError(
+          "repository_unavailable",
+          `Pinned base ref is unavailable for ${repository}`,
+        );
+      }
+      return {
+        ref: config.baseRef,
+        revision: result.stdout.trim(),
+      };
+    },
+
+    async applyPatch(input) {
+      assertPinnedRepository(config.repository, input.repository);
+      if (!FULL_GIT_OBJECT_ID.test(input.baseRevision)) {
+        throw new PrPayloadActuationError(
+          "base_revision_invalid",
+          "Patch base is not a full Git object id",
+        );
+      }
+      const repositoryRoot = await resolvedRepositoryRoot(configuredRoot);
+      const stagingRoot = await mkdtemp(path.join(tmpdir(), "int3a-payload-"));
+      const stagingRepository = path.join(stagingRoot, "repository");
+      try {
+        await requiredGit(
+          [
+            "clone",
+            "--local",
+            "--no-hardlinks",
+            "--no-checkout",
+            "--",
+            repositoryRoot,
+            stagingRepository,
+          ],
+          stagingRoot,
+          undefined,
+          "local clone",
+        );
+        await requiredGit(
+          ["checkout", "--detach", input.baseRevision],
+          stagingRepository,
+          undefined,
+          "base checkout",
+        );
+        await requiredGit(
+          ["apply", "--index", "--binary", "--whitespace=nowarn", "-"],
+          stagingRepository,
+          input.patch,
+          "patch apply",
+        );
+        const paths = await requiredGit(
+          ["diff", "--cached", "--name-only", "-z", "--no-renames"],
+          stagingRepository,
+          undefined,
+          "touched-path inspection",
+        );
+        const tree = await requiredGit(
+          ["write-tree"],
+          stagingRepository,
+          undefined,
+          "tree materialization",
+        );
+        const treeSha = tree.stdout.trim();
+        if (!FULL_GIT_OBJECT_ID.test(treeSha)) {
+          throw new PrPayloadActuationError(
+            "patch_apply_failed",
+            "Git did not produce a full tree object id",
+          );
+        }
+        return {
+          treeSha,
+          touchedPaths: paths.stdout.split("\0").filter(Boolean),
+        };
+      } finally {
+        await rm(stagingRoot, { recursive: true, force: true });
+      }
+    },
+  };
+}
+
+interface GitResult {
+  code: number;
+  stdout: string;
+}
+
+async function requiredGit(
+  args: readonly string[],
+  cwd: string,
+  input: Uint8Array | undefined,
+  label: string,
+): Promise<GitResult> {
+  const result = await runGit(args, cwd, input);
+  if (result.code !== 0) {
+    throw new PrPayloadActuationError(
+      "patch_apply_failed",
+      `Git ${label} failed with exit ${result.code}`,
+    );
+  }
+  return result;
+}
+
+function runGit(
+  args: readonly string[],
+  cwd: string,
+  input?: Uint8Array,
+): Promise<GitResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", [...args], {
+      cwd,
+      shell: false,
+      stdio: [input ? "pipe" : "ignore", "pipe", "pipe"],
+      env: {
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_TERMINAL_PROMPT: "0",
+        PATH: "/usr/local/bin:/usr/bin:/bin",
+      },
+    });
+    const stdoutStream = child.stdout;
+    const stderrStream = child.stderr;
+    const stdinStream = child.stdin;
+    if (!stdoutStream || !stderrStream || (input && !stdinStream)) {
+      child.kill("SIGKILL");
+      reject(new PrPayloadActuationError(
+        "repository_unavailable",
+        "Local Git command streams were unavailable",
+      ));
+      return;
+    }
+    const stdout: Buffer[] = [];
+    let outputBytes = 0;
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new PrPayloadActuationError(
+        "repository_unavailable",
+        `Local Git command timed out after ${GIT_TIMEOUT_MS}ms`,
+      ));
+    }, GIT_TIMEOUT_MS);
+
+    const capture = (chunk: Buffer): void => {
+      outputBytes += chunk.byteLength;
+      if (outputBytes > GIT_MAX_OUTPUT_BYTES) {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          child.kill("SIGKILL");
+          reject(new PrPayloadActuationError(
+            "repository_unavailable",
+            "Local Git command exceeded its output limit",
+          ));
+        }
+        return;
+      }
+      stdout.push(chunk);
+    };
+    stdoutStream.on("data", capture);
+    // Drain stderr without recording it. Even a local Git configuration can
+    // contain sensitive values, and refusal evidence must never echo them.
+    stderrStream.on("data", () => undefined);
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+      });
+    });
+    if (input) stdinStream?.end(Buffer.from(input));
+  });
+}
+
+async function resolvedRepositoryRoot(configuredRoot: string): Promise<string> {
+  try {
+    return await realpath(configuredRoot);
+  } catch {
+    throw new PrPayloadActuationError(
+      "repository_unavailable",
+      "Pinned local repository root is unavailable",
+    );
+  }
+}
+
+function assertPinnedRepository(expected: string, actual: string): void {
+  if (actual !== expected) {
+    throw new PrPayloadActuationError(
+      "repository_mismatch",
+      `Actuation is pinned to ${expected}; refused ${actual}`,
+    );
+  }
+}
+
+function isSafeGitRef(value: string): boolean {
+  const components = value.split("/");
+  return value.length > 0
+    && value.length <= 240
+    && value !== "@"
+    && !value.startsWith("/")
+    && !value.endsWith("/")
+    && !value.endsWith(".")
+    && !value.includes("..")
+    && !value.includes("@{")
+    && !value.includes("//")
+    && !components.some(
+      (component) => component.startsWith(".") || component.endsWith(".lock"),
+    )
+    && ![...value].some((character) => {
+      const code = character.charCodeAt(0);
+      return code <= 0x20
+        || code === 0x7f
+        || "~^:?*[\\".includes(character);
+    });
+}
+
+function digestFromRef(ref: ArtifactRef): string {
+  const digest = ref.sha256.slice("sha256:".length);
+  if (ref.uri !== `artifact://sha256/${digest}`) {
+    throw new PrPayloadActuationError(
+      "artifact_hash_mismatch",
+      "Artifact URI does not match its declared content hash",
+    );
+  }
+  return digest;
+}

--- a/test/integration/int3a-payload-actuator.test.ts
+++ b/test/integration/int3a-payload-actuator.test.ts
@@ -1,0 +1,790 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import {
+  agentRunProjectionV1Schema,
+  agentTaskV1Schema,
+  hashAgentTaskApprovalPayload,
+  verifiedHandoffV1Schema,
+  type AgentRunProjectionV1,
+  type AgentTaskV1,
+  type ArtifactRef,
+  type VerifiedHandoffV1,
+} from "@avg/schemas";
+import { deriveIntendedRunId } from "@avg/averray-mcp/dispatch-claim";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  actuatePullRequestPayload,
+  PrPayloadActuationError,
+  type PrPayloadActuationInput,
+  type PrPayloadActuatorDeps,
+  type PrPayloadRefusalReason,
+} from "../../services/harness-dispatcher/src/pr-payload-actuator.js";
+import {
+  createFilePrPayloadArtifactPort,
+  createLocalGitPrPayloadRepositoryPort,
+} from "../../services/harness-dispatcher/src/pr-payload-local-ports.js";
+
+const execFileAsync = promisify(execFile);
+const PINNED_REPOSITORY = "depre-dev/averray-reference-agent";
+const EXPECTED_CASE_COUNT = 8;
+const ZERO_HASH = `sha256:${"0".repeat(64)}` as const;
+const A_HASH = `sha256:${"a".repeat(64)}` as const;
+const B_HASH = `sha256:${"b".repeat(64)}` as const;
+const C_HASH = `sha256:${"c".repeat(64)}` as const;
+const D_HASH = `sha256:${"d".repeat(64)}` as const;
+const E_HASH = `sha256:${"e".repeat(64)}` as const;
+const RUN_ID = "7db95d47-2cca-5572-a198-434723821fba";
+
+type CeremonyCase =
+  | "unverified-handoff"
+  | "failed-check"
+  | "path-outside-allowed"
+  | "base-drift"
+  | "halt-active"
+  | "eligibility-disagreement"
+  | "eligible-clean"
+  | "replay-identical";
+
+interface CeremonyEvidence {
+  case: CeremonyCase;
+  outcome: "refused" | "payload_ready";
+  refusalReason?: PrPayloadRefusalReason;
+  refusalMessage?: string;
+  escalationRequired?: boolean;
+  approvedBase?: string;
+  observedBase?: string;
+  payloadCount: number;
+  artifactSha256?: string;
+  canonicalSha256?: string;
+  replayArtifactSha256?: string;
+  replayCanonicalSha256?: string;
+}
+
+class Int3aEvidenceError extends Error {}
+
+describe.sequential("INT-3a actuated-handoff payload ceremony", () => {
+  let root: string;
+  let repositoryRoot: string;
+  let inputArtifactRoot: string;
+  let outputArtifactRoot: string;
+  let evidenceRoot: string;
+  let baseRevision: string;
+  let validPatch: string;
+  let outsidePatch: string;
+  let task: AgentTaskV1;
+  let run: AgentRunProjectionV1;
+  let handoff: VerifiedHandoffV1;
+  let validInput: PrPayloadActuationInput;
+  let deps: PrPayloadActuatorDeps;
+  let cleanArtifactSha256: string;
+  let cleanCanonicalSha256: string;
+  let cleanCanonicalBytes: string;
+  const ceremonyEvidence: CeremonyEvidence[] = [];
+  const d3Results: Array<{
+    case: CeremonyCase;
+    mutation: string;
+    observedFailure: string;
+  }> = [];
+
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "int3a-suite-"));
+    repositoryRoot = path.join(root, "repository");
+    inputArtifactRoot = path.join(root, "input-artifacts");
+    outputArtifactRoot = path.join(root, "payload-artifacts");
+    evidenceRoot = process.env.INT3A_SUITE_EVIDENCE_DIR
+      ? path.resolve(process.env.INT3A_SUITE_EVIDENCE_DIR)
+      : path.join(root, "evidence");
+    await Promise.all([
+      mkdir(repositoryRoot, { recursive: true }),
+      mkdir(inputArtifactRoot, { recursive: true }),
+      mkdir(outputArtifactRoot, { recursive: true }),
+      mkdir(evidenceRoot, { recursive: true }),
+      mkdir(path.join(repositoryRoot, "docs"), { recursive: true }),
+      mkdir(path.join(repositoryRoot, "src"), { recursive: true }),
+    ]);
+    await git(["init", "--initial-branch=main"], repositoryRoot);
+    await Promise.all([
+      writeFile(path.join(repositoryRoot, "docs/stage3a.md"), "base\n", "utf8"),
+      writeFile(
+        path.join(repositoryRoot, "src/guarded.ts"),
+        "export const guarded = true;\n",
+        "utf8",
+      ),
+    ]);
+    await git(["add", "docs/stage3a.md", "src/guarded.ts"], repositoryRoot);
+    await git([
+      "-c",
+      "user.name=INT-3a Suite",
+      "-c",
+      "user.email=int3a@example.invalid",
+      "commit",
+      "-m",
+      "fixture base",
+    ], repositoryRoot);
+    baseRevision = (await git(["rev-parse", "HEAD"], repositoryRoot)).trim();
+
+    validPatch = await makePatch(
+      "docs/stage3a.md",
+      "base\nstage 3a payload\n",
+      "base\n",
+    );
+    outsidePatch = await makePatch(
+      "src/guarded.ts",
+      "export const guarded = false;\n",
+      "export const guarded = true;\n",
+    );
+
+    const inputArtifacts = createFilePrPayloadArtifactPort(inputArtifactRoot);
+    const patchRef = await inputArtifacts.write(
+      Buffer.from(validPatch, "utf8"),
+      "text/x-diff",
+    );
+    task = await approvedTask();
+    run = completedRun(task);
+    handoff = acceptedHandoff(task, run, patchRef);
+    validInput = { task, run, handoff };
+    deps = {
+      artifacts: {
+        read: inputArtifacts.read,
+        write: createFilePrPayloadArtifactPort(outputArtifactRoot).write,
+      },
+      repository: createLocalGitPrPayloadRepositoryPort({
+        repositoryRoot,
+        repository: PINNED_REPOSITORY,
+        baseRef: "main",
+      }),
+      readHaltState: async () => ({ global: false, repositories: [] }),
+    };
+  }, 30_000);
+
+  afterAll(async () => {
+    await writeFile(
+      path.join(evidenceRoot, "suite-summary.json"),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        executedCases: ceremonyEvidence.length,
+        expectedCases: EXPECTED_CASE_COUNT,
+        cases: ceremonyEvidence,
+        d3: d3Results,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    if (cleanCanonicalBytes) {
+      await writeFile(
+        path.join(evidenceRoot, "sample-payload.json"),
+        `${JSON.stringify(JSON.parse(cleanCanonicalBytes), null, 2)}\n`,
+        "utf8",
+      );
+    }
+    if (!process.env.INT3A_SUITE_EVIDENCE_DIR) {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("refuses an unverified handoff by name", async () => {
+    const input = cloneInput();
+    input.handoff.verification = {
+      ...input.handoff.verification,
+      verified: false,
+      decision: "reject",
+    };
+    input.handoff.eligibleForPrOpen = false;
+    const refusal = await captureRefusal(input);
+    const evidence = refusalEvidence("unverified-handoff", refusal);
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.refusalReason = "handoff_check_not_passed";
+      },
+      "refusal_reason",
+      "replace handoff_unverified with a different refusal",
+    );
+  });
+
+  it("refuses one failed verification check by name", async () => {
+    const input = cloneInput();
+    input.handoff.checks[0] = {
+      ...input.handoff.checks[0]!,
+      status: "failed",
+    };
+    input.handoff.eligibleForPrOpen = false;
+    const refusal = await captureRefusal(input);
+    const evidence = refusalEvidence("failed-check", refusal);
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.refusalReason = "handoff_unverified";
+      },
+      "refusal_reason",
+      "replace handoff_check_not_passed with a different refusal",
+    );
+  });
+
+  it("refuses a patch path outside allowedPaths and names the path", async () => {
+    const inputArtifacts = createFilePrPayloadArtifactPort(inputArtifactRoot);
+    const outsideRef = await inputArtifacts.write(
+      Buffer.from(outsidePatch, "utf8"),
+      "text/x-diff",
+    );
+    const input = cloneInput();
+    input.handoff.deliverables.patchRef = outsideRef;
+    const refusal = await captureRefusal(input);
+    const evidence = refusalEvidence("path-outside-allowed", refusal);
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.refusalMessage = "Patch path is outside repository.allowedPaths";
+      },
+      "refusal_path",
+      "erase src/guarded.ts from the recorded refusal",
+    );
+  });
+
+  it("refuses when the approved base is no longer current", async () => {
+    const observedBase = "f".repeat(40);
+    const input = cloneInput();
+    const refusal = await captureRefusal(input, {
+      ...deps,
+      repository: {
+        ...deps.repository,
+        readCurrentBase: async () => ({
+          ref: "main",
+          revision: observedBase,
+        }),
+      },
+    });
+    const evidence = {
+      ...refusalEvidence("base-drift", refusal),
+      approvedBase: baseRevision,
+      observedBase,
+    };
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.observedBase = mutated.approvedBase;
+      },
+      "base_drift_present",
+      "make the recorded current base equal the approved base",
+    );
+  });
+
+  it("refuses both global and repository HALT before artifact generation", async () => {
+    const globalRefusal = await captureRefusal(cloneInput(), {
+      ...deps,
+      readHaltState: async () => ({ global: true, repositories: [] }),
+    });
+    expect(globalRefusal).toMatchObject({
+      reason: "halt_global",
+      message: expect.stringContaining("HALT"),
+    });
+    const repositoryRefusal = await captureRefusal(cloneInput(), {
+      ...deps,
+      readHaltState: async () => ({
+        global: false,
+        repositories: [PINNED_REPOSITORY],
+      }),
+    });
+    const evidence = refusalEvidence("halt-active", repositoryRefusal);
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.refusalMessage = "Payload generation refused";
+      },
+      "halt_named",
+      "erase HALT from the recorded refusal",
+    );
+  });
+
+  it("escalates a stored-vs-recomputed eligibility disagreement", async () => {
+    const input = cloneInput();
+    input.handoff.eligibleForPrOpen = false;
+    const refusal = await captureRefusal(input);
+    const reverseInput = cloneInput();
+    reverseInput.handoff.verification = {
+      ...reverseInput.handoff.verification,
+      verified: false,
+      decision: "reject",
+    };
+    const reverseRefusal = await captureRefusal(reverseInput);
+    expect(reverseRefusal).toMatchObject({
+      reason: "eligibility_disagreement",
+      escalationRequired: true,
+    });
+    const evidence = refusalEvidence("eligibility-disagreement", refusal);
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.escalationRequired = false;
+      },
+      "eligibility_escalation",
+      "clear the required escalation bit",
+    );
+  });
+
+  it("produces exactly one complete content-addressed payload", async () => {
+    const result = await actuatePullRequestPayload(cloneInput(), deps);
+    const files = await readdir(outputArtifactRoot);
+    expect(files).toHaveLength(1);
+    expect(result.payload).toMatchObject({
+      repository: PINNED_REPOSITORY,
+      base: { ref: "main", revision: baseRevision },
+      head: {
+        ref: expect.stringMatching(/^harness\/[0-9a-f-]{36}$/),
+        treeSha: expect.stringMatching(/^[a-f0-9]{40}$/),
+      },
+      title: task.proposal.title,
+      patch: {
+        bytes: validPatch,
+        sha256: handoff.deliverables.patchRef?.sha256,
+      },
+    });
+    expect(result.payload.head.ref).toBe(
+      `harness/${deriveIntendedRunId(
+        task.workItemId,
+        task.taskVersion,
+        task.approval.approvedTaskHash!,
+      )}`,
+    );
+    const independentlyApplied = await deps.repository.applyPatch({
+      repository: PINNED_REPOSITORY,
+      baseRevision,
+      patch: Buffer.from(validPatch, "utf8"),
+    });
+    expect(result.payload.head.treeSha).toBe(independentlyApplied.treeSha);
+    expect(independentlyApplied.touchedPaths).toEqual(["docs/stage3a.md"]);
+    expect(
+      await readFile(path.join(outputArtifactRoot, files[0]!), "utf8"),
+    ).toBe(result.canonicalBytes);
+    expect(files[0]).toBe(result.artifact.sha256.slice("sha256:".length));
+
+    const source = await Promise.all([
+      readFile(
+        new URL(
+          "../../services/harness-dispatcher/src/pr-payload-actuator.ts",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+      readFile(
+        new URL(
+          "../../services/harness-dispatcher/src/pr-payload-local-ports.ts",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ]).then((parts) => parts.join("\n"));
+    expect(source).not.toMatch(/@octokit|GITHUB_TOKEN|https?:\/\//);
+    expect(source).not.toMatch(/\b(?:fetch|openPullRequest|createPullRequest)\s*\(/);
+    expect(source).toContain("shell: false");
+    await expect(
+      deps.repository.readCurrentBase("someone/else"),
+    ).rejects.toMatchObject({ reason: "repository_mismatch" });
+
+    cleanArtifactSha256 = result.artifact.sha256;
+    cleanCanonicalBytes = result.canonicalBytes;
+    cleanCanonicalSha256 = sha256(result.canonicalBytes);
+    const evidence: CeremonyEvidence = {
+      case: "eligible-clean",
+      outcome: "payload_ready",
+      payloadCount: files.length,
+      artifactSha256: cleanArtifactSha256,
+      canonicalSha256: cleanCanonicalSha256,
+    };
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.payloadCount = 2;
+      },
+      "payload_count",
+      "change exactly one recorded payload to two",
+    );
+  }, 30_000);
+
+  it("replays the same handoff as one byte-identical payload artifact", async () => {
+    const replay = await actuatePullRequestPayload(cloneInput(), deps);
+    const files = await readdir(outputArtifactRoot);
+    expect(files).toHaveLength(1);
+    expect(replay.artifact.sha256).toBe(cleanArtifactSha256);
+    expect(replay.canonicalBytes).toBe(cleanCanonicalBytes);
+    const evidence: CeremonyEvidence = {
+      case: "replay-identical",
+      outcome: "payload_ready",
+      payloadCount: files.length,
+      artifactSha256: cleanArtifactSha256,
+      canonicalSha256: cleanCanonicalSha256,
+      replayArtifactSha256: replay.artifact.sha256,
+      replayCanonicalSha256: sha256(replay.canonicalBytes),
+    };
+    recordAndVerify(evidence);
+    assertD3Mutation(
+      evidence,
+      (mutated) => {
+        mutated.replayCanonicalSha256 = ZERO_HASH;
+      },
+      "replay_identity",
+      "replace the replayed canonical-byte hash",
+    );
+    expect(ceremonyEvidence).toHaveLength(EXPECTED_CASE_COUNT);
+    expect(d3Results).toHaveLength(EXPECTED_CASE_COUNT);
+  }, 30_000);
+
+  function cloneInput(): PrPayloadActuationInput {
+    return structuredClone(validInput);
+  }
+
+  async function captureRefusal(
+    input: PrPayloadActuationInput,
+    actuationDeps: PrPayloadActuatorDeps = deps,
+  ): Promise<PrPayloadActuationError> {
+    try {
+      await actuatePullRequestPayload(input, actuationDeps);
+    } catch (error) {
+      expect(error).toBeInstanceOf(PrPayloadActuationError);
+      expect(await readdir(outputArtifactRoot)).toHaveLength(0);
+      return error as PrPayloadActuationError;
+    }
+    throw new Error("Expected INT-3a payload actuation to refuse");
+  }
+
+  function refusalEvidence(
+    caseName: CeremonyCase,
+    refusal: PrPayloadActuationError,
+  ): CeremonyEvidence {
+    return {
+      case: caseName,
+      outcome: "refused",
+      refusalReason: refusal.reason,
+      refusalMessage: refusal.message,
+      escalationRequired: refusal.escalationRequired,
+      payloadCount: 0,
+    };
+  }
+
+  function recordAndVerify(evidence: CeremonyEvidence): void {
+    expect(() => verifyInt3aEvidence(evidence)).not.toThrow();
+    ceremonyEvidence.push(evidence);
+  }
+
+  function assertD3Mutation(
+    evidence: CeremonyEvidence,
+    mutate: (value: CeremonyEvidence) => void,
+    expectedFailure: string,
+    mutation: string,
+  ): void {
+    const mutated = structuredClone(evidence);
+    mutate(mutated);
+    let observed = "";
+    try {
+      verifyInt3aEvidence(mutated);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Int3aEvidenceError);
+      observed = (error as Error).message;
+    }
+    expect(observed).toContain(expectedFailure);
+    d3Results.push({
+      case: evidence.case,
+      mutation,
+      observedFailure: expectedFailure,
+    });
+  }
+
+  async function approvedTask(): Promise<AgentTaskV1> {
+    const fixture = JSON.parse(await readFile(
+      new URL(
+        "../fixtures/agent-integration/agent-task-v1.json",
+        import.meta.url,
+      ),
+      "utf8",
+    )) as Record<string, unknown>;
+    const candidate = agentTaskV1Schema.parse({
+      ...fixture,
+      workItemId: "int3a-one-work-item",
+      correlationId: "int3a-one-correlation",
+      lifecycle: "handoff_ready",
+      proposal: {
+        ...(fixture.proposal as object),
+        title: "Construct the INT-3a payload artifact",
+        objective: "Materialize the verified documentation patch as a deterministic pull-request payload.",
+      },
+      repository: {
+        provider: "github",
+        nameWithOwner: PINNED_REPOSITORY,
+        baseRevision,
+        allowedPaths: ["docs/**"],
+        forbiddenPaths: ["src/**", "ops/**"],
+      },
+      requestedAuthority: {
+        ...(fixture.requestedAuthority as object),
+        grants: [{
+          capabilityId: "fs.write_file",
+          resource: PINNED_REPOSITORY,
+          constraints: { allowedPaths: ["docs/**"] },
+        }],
+      },
+      approval: {
+        required: "operator",
+        status: "approved",
+        actor: { type: "operator", id: "int3a-operator" },
+        decidedAt: "2026-07-23T12:05:00.000Z",
+        policyVersion: "dispatch-policy-v1",
+        policyHash: C_HASH,
+        approvedTaskHash: ZERO_HASH,
+      },
+      timestamps: {
+        proposedAt: "2026-07-23T12:00:00.000Z",
+        approvedAt: "2026-07-23T12:05:00.000Z",
+        runBoundAt: "2026-07-23T12:06:00.000Z",
+        updatedAt: "2026-07-23T12:30:00.000Z",
+      },
+      bindings: {
+        harnessRunId: RUN_ID,
+        runManifestRef: ref(D_HASH),
+        runManifestHash: D_HASH,
+      },
+    });
+    const approvedTaskHash = await hashAgentTaskApprovalPayload(candidate);
+    return agentTaskV1Schema.parse({
+      ...candidate,
+      approval: {
+        ...candidate.approval,
+        approvedTaskHash,
+      },
+    });
+  }
+
+  function completedRun(approved: AgentTaskV1): AgentRunProjectionV1 {
+    return agentRunProjectionV1Schema.parse({
+      schemaVersion: 1,
+      kind: "agent_run_projection",
+      workItemId: approved.workItemId,
+      correlationId: approved.correlationId,
+      harnessRunId: RUN_ID,
+      taskVersion: approved.taskVersion,
+      source: {
+        system: "agent-harness",
+        health: "healthy",
+        observedAt: "2026-07-23T12:30:00.000Z",
+        sourceUpdatedAt: "2026-07-23T12:29:59.000Z",
+      },
+      heartbeat: {
+        status: "terminal",
+        lastEventAt: "2026-07-23T12:29:59.000Z",
+        ageSeconds: 1,
+      },
+      run: {
+        state: "completed",
+        attempt: 1,
+        terminal: true,
+        outcome: "completed",
+        lastEventAt: "2026-07-23T12:29:59.000Z",
+      },
+      manifest: {
+        ref: ref(D_HASH),
+        hash: D_HASH,
+        profile: approved.intent.profile,
+        riskClass: "low",
+        effectiveCapabilities: ["fs.write_file"],
+        network: "deny",
+        policyHash: approved.approval.policyHash,
+        verifierHash: approved.acceptance.verifierPlanHash,
+        modelBindings: [],
+        skillVersions: [],
+      },
+      progress: {
+        phase: "completed",
+        summary: "Verified patch ready for handoff.",
+        completedUnits: 1,
+        totalUnits: 1,
+      },
+      budget: {
+        elapsedSecondsUsed: 30,
+        elapsedSecondsLimit: approved.budget.elapsedSeconds,
+        modelTokensUsed: 1,
+        modelTokensLimit: approved.budget.modelTokens,
+        toolCallsUsed: 1,
+        toolCallsLimit: approved.budget.toolCalls,
+        estimatedUsdMicrosUsed: 0,
+        estimatedUsdMicrosLimit: approved.budget.estimatedUsdMicros,
+        exhausted: false,
+      },
+      artifacts: [],
+      verification: {
+        status: "passed",
+        decisionRef: ref(E_HASH),
+        decisionHash: E_HASH,
+      },
+      bindings: approved.bindings,
+    });
+  }
+
+  function acceptedHandoff(
+    approved: AgentTaskV1,
+    projection: AgentRunProjectionV1,
+    patchRef: ArtifactRef,
+  ): VerifiedHandoffV1 {
+    return verifiedHandoffV1Schema.parse({
+      schemaVersion: 1,
+      kind: "verified_handoff",
+      workItemId: approved.workItemId,
+      correlationId: approved.correlationId,
+      harnessRunId: projection.harnessRunId,
+      taskVersion: approved.taskVersion,
+      taskHash: approved.approval.approvedTaskHash,
+      taskIntentRef: approved.intent.templateRef,
+      taskIntentHash: approved.intent.templateHash,
+      runManifestRef: projection.manifest.ref,
+      runManifestHash: projection.manifest.hash,
+      outcome: "completed",
+      deliverables: {
+        patchRef,
+        summaryRef: ref(A_HASH),
+        structuredSubmissionRef: ref(E_HASH),
+        artifacts: [patchRef],
+      },
+      checks: [{
+        name: "format-command",
+        status: "passed",
+        evidenceRef: ref(B_HASH),
+      }],
+      verification: {
+        verified: true,
+        decision: "accept",
+        verifier: { type: "verifier", id: "int3a-independent-verifier" },
+        planHash: approved.acceptance.verifierPlanHash,
+        decisionRef: ref(E_HASH),
+        decisionHash: E_HASH,
+        evidenceRefs: [ref(B_HASH)],
+        verifiedAt: "2026-07-23T12:29:59.000Z",
+      },
+      openQuestions: [],
+      eligibleForPrOpen: true,
+      generatedAt: "2026-07-23T12:30:00.000Z",
+    });
+  }
+
+  async function makePatch(
+    relativePath: string,
+    changed: string,
+    original: string,
+  ): Promise<string> {
+    const target = path.join(repositoryRoot, relativePath);
+    await writeFile(target, changed, "utf8");
+    const patch = await git(
+      ["diff", "--binary", "--no-ext-diff", "--", relativePath],
+      repositoryRoot,
+    );
+    await writeFile(target, original, "utf8");
+    if (!patch.trim()) throw new Error(`Fixture patch is empty for ${relativePath}`);
+    return patch;
+  }
+});
+
+function verifyInt3aEvidence(evidence: CeremonyEvidence): void {
+  const expectedRefusal: Partial<Record<CeremonyCase, PrPayloadRefusalReason>> = {
+    "unverified-handoff": "handoff_unverified",
+    "failed-check": "handoff_check_not_passed",
+    "path-outside-allowed": "path_not_allowed",
+    "base-drift": "base_drift",
+    "halt-active": "halt_repository",
+    "eligibility-disagreement": "eligibility_disagreement",
+  };
+  const reason = expectedRefusal[evidence.case];
+  if (reason) {
+    requireEvidence(evidence.outcome === "refused", "refusal_outcome");
+    requireEvidence(evidence.payloadCount === 0, "refusal_payload_count");
+    requireEvidence(evidence.refusalReason === reason, "refusal_reason");
+  }
+  if (evidence.case === "path-outside-allowed") {
+    requireEvidence(
+      evidence.refusalMessage?.includes("src/guarded.ts") === true,
+      "refusal_path",
+    );
+  }
+  if (evidence.case === "base-drift") {
+    requireEvidence(
+      evidence.approvedBase !== evidence.observedBase,
+      "base_drift_present",
+    );
+  }
+  if (evidence.case === "halt-active") {
+    requireEvidence(
+      evidence.refusalMessage?.includes("HALT") === true,
+      "halt_named",
+    );
+  }
+  if (evidence.case === "eligibility-disagreement") {
+    requireEvidence(
+      evidence.escalationRequired === true,
+      "eligibility_escalation",
+    );
+  }
+  if (evidence.case === "eligible-clean") {
+    requireEvidence(evidence.outcome === "payload_ready", "payload_outcome");
+    requireEvidence(evidence.payloadCount === 1, "payload_count");
+    requireEvidence(Boolean(evidence.artifactSha256), "payload_artifact");
+    requireEvidence(Boolean(evidence.canonicalSha256), "payload_canonical_bytes");
+  }
+  if (evidence.case === "replay-identical") {
+    requireEvidence(evidence.outcome === "payload_ready", "replay_outcome");
+    requireEvidence(evidence.payloadCount === 1, "payload_count");
+    requireEvidence(
+      evidence.artifactSha256 === evidence.replayArtifactSha256
+      && evidence.canonicalSha256 === evidence.replayCanonicalSha256,
+      "replay_identity",
+    );
+  }
+}
+
+function requireEvidence(condition: boolean, reason: string): void {
+  if (!condition) throw new Int3aEvidenceError(`INT-3a evidence failed: ${reason}`);
+}
+
+function ref(hash: `sha256:${string}`): ArtifactRef {
+  return {
+    uri: `artifact://sha256/${hash.slice("sha256:".length)}`,
+    sha256: hash,
+  };
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    env: {
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_TERMINAL_PROMPT: "0",
+      PATH: process.env.PATH,
+    },
+  });
+  return result.stdout;
+}
+
+function sha256(value: string): `sha256:${string}` {
+  return `sha256:${createHash("sha256").update(value, "utf8").digest("hex")}`;
+}


### PR DESCRIPTION
## What changed

- adds a typed `pull_request_payload` V1 contract containing the pinned base ref/revision, deterministic head ref, materialized head tree, approved title/body, exact patch bytes/ref, and source bindings
- adds the INT-3a payload actuator with actuation-time eligibility recomputation, approval-hash and task/run/handoff verification, patch content-hash validation, allowed/forbidden path re-checks, base-drift refusal, and global/repository HALT checks
- adds local-only, content-addressed artifact and Git repository ports; Git uses fixed argument vectors with `shell: false`, a pinned repository, local clone/apply/write-tree only, and no network or credential surface
- adds a dedicated eight-case INT-3a ceremony suite with an `assertD3Mutation`-style failure proof for every row and a reproducible sample payload artifact

## Safety boundary

This is stage 3a only. It writes one content-addressed payload artifact and has zero outward effect. It does not open a PR, call any GitHub API, read a GitHub credential, push a branch, merge, deploy, or compute `effects.mutates`. Stage 3b is not implemented.

The existing `VerifiedHandoff` schema and all INT-2 suite files, fixtures, counts, and workflow assertions are unchanged. No production authority or capability set changes.

## Checks

- `npm run typecheck` — exit 0
- `npm test` — 143 files passed, 2 integration files skipped by their normal environment gates; 2,031 tests passed, 14 skipped
- `npm run build` — exit 0
- `npm run test:int3a` — 8/8 cases, 8/8 deliberate evidence mutations rejected
- `HARNESS_CHECKOUT=<pinned-local-checkout> ./scripts/ceremony/run-int2-automated-suite.sh` — 10/10, pinned Harness `0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2`

Observed INT-3a refusals: `handoff_unverified`, `handoff_check_not_passed`, `path_not_allowed` naming `src/guarded.ts`, `base_drift`, `halt_global`/`halt_repository`, and `eligibility_disagreement` with escalation required. The clean case produced one artifact; replay returned the same artifact and canonical-byte hash.

## Affected surfaces

- backend schema package
- Harness dispatcher library surface
- dedicated INT-3a integration test

No frontend, indexer, Caddy, contracts, public-site, environment, secret, database migration, Compose, or VPS changes.
