### PR TITLE
Make the monitor's own version impossible to leave unbaked

### DIFF
--- a/ops/Dockerfile.node
+++ b/ops/Dockerfile.node
@@ -22,6 +22,13 @@ ARG CLAUDE_CLI_PACKAGE=@anthropic-ai/claude-code
 # self-freshness probe reports as unknown rather than as up-to-date.
 ARG GIT_SHA=unknown
 ENV AVERRAY_GIT_SHA=${GIT_SHA}
+# Was the working tree dirty when this image was built? A sha alone would then
+# be a LIE — the image is HEAD plus uncommitted changes, and self-freshness
+# would happily report "up to date with main" while running code that is in no
+# commit at all. This has bitten before: an un-popped stash on the VPS silently
+# reverted a built asset. Default false; ops/deploy-monitor.sh sets it.
+ARG GIT_DIRTY=false
+ENV AVERRAY_GIT_DIRTY=${GIT_DIRTY}
 RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates chromium git openssh-client \
   && rm -rf /var/lib/apt/lists/*

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -52,9 +52,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     depends_on:
       hermes-permissions:
@@ -111,9 +114,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
     # Hermes owns the skills volume as UID 10000 and continuously re-secures it to
@@ -141,9 +147,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     restart: unless-stopped
     depends_on:
@@ -500,9 +509,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["testbed-runner"]
     restart: unless-stopped
@@ -606,9 +618,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["test-wallet-signer"]
     restart: unless-stopped
@@ -648,9 +663,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["codex-runner"]
     restart: unless-stopped
@@ -697,9 +715,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["dispatch"]
     restart: unless-stopped
@@ -745,9 +766,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["claude-runner"]
     restart: unless-stopped
@@ -816,9 +840,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["test-writer-runner"]
     restart: unless-stopped
@@ -882,9 +909,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["security-runner"]
     restart: unless-stopped
@@ -939,9 +969,12 @@ services:
       context: ..
       dockerfile: ops/Dockerfile.node
       args:
-        # Prefix the deploy with GIT_SHA=$(git rev-parse HEAD) so the monitor
-        # can report its own version. Unset = "unknown", reported honestly.
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
         GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
     image: ${AVERRAY_IMAGE:-avg-node-runtime}
     profiles: ["docs-runner"]
     restart: unless-stopped

--- a/ops/deploy-monitor.sh
+++ b/ops/deploy-monitor.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Deploy the Hermes monitor (slack-operator) — with its own version baked in.
+#
+# WHY THIS EXISTS: the self-freshness probe answers "is this board running
+# current code?", and it needs a GIT_SHA build arg because `.git` is in
+# .dockerignore so the build cannot discover the sha itself. The compose file
+# has always documented the fix — "prefix the deploy with
+# GIT_SHA=$(git rev-parse HEAD)" — and in practice nobody ever typed it. The
+# probe therefore reported "unknown" from the day it shipped, which means the
+# one check that would have caught "the VPS is six commits behind with four
+# merged PRs live nowhere" has never once been able to answer.
+#
+# A correctness-critical value must not depend on an operator remembering a
+# shell prefix. So it lives here instead, where it cannot be omitted.
+#
+# Usage, from the repo root on the VPS:
+#   ops/deploy-monitor.sh                 # build + deploy slack-operator
+#   ops/deploy-monitor.sh --allow-dirty   # ...from a dirty tree, marked as such
+#   ops/deploy-monitor.sh web             # deploy a different service
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ALLOW_DIRTY=false
+SERVICE=slack-operator
+for arg in "$@"; do
+  case "$arg" in
+    --allow-dirty) ALLOW_DIRTY=true ;;
+    -*) echo "unknown flag: $arg" >&2; exit 2 ;;
+    *) SERVICE="$arg" ;;
+  esac
+done
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  # Fail closed. Building without a sha is what produced the silent "unknown",
+  # and doing it silently again is how it stays broken for another month.
+  echo "ERROR: not a git checkout — cannot determine the running version." >&2
+  echo "       Deploy from the git checkout, or the board can never tell you" >&2
+  echo "       whether it is running current code." >&2
+  exit 1
+fi
+
+GIT_SHA="$(git rev-parse HEAD)"
+GIT_DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  GIT_DIRTY=true
+  if [ "$ALLOW_DIRTY" != true ]; then
+    echo "ERROR: working tree is dirty — refusing to build." >&2
+    echo >&2
+    git status --short >&2
+    echo >&2
+    echo "The image would be ${GIT_SHA:0:8} PLUS these uncommitted changes, so the" >&2
+    echo "sha would not describe what is running. This has bitten before: an" >&2
+    echo "un-popped stash on this box silently reverted a built asset." >&2
+    echo >&2
+    echo "Commit/stash them, or re-run with --allow-dirty (the board will then" >&2
+    echo "report its version as unknown, which is the truth)." >&2
+    exit 1
+  fi
+  echo "WARNING: building from a DIRTY tree — self-freshness will report unknown."
+fi
+
+COMPOSE=(docker compose -p avg --env-file .env.prod
+  -f ops/compose.yml
+  -f ops/compose.prod.yml
+  -f ops/compose.command-center.yml
+  -f ops/compose.cloudflare-access.yml)
+
+echo "deploying ${SERVICE} at ${GIT_SHA:0:8}$([ "$GIT_DIRTY" = true ] && echo ' (dirty)')"
+
+# NEVER --remove-orphans here: this compose project shares a network with
+# services defined in other files, and it would take them down.
+GIT_SHA="$GIT_SHA" GIT_DIRTY="$GIT_DIRTY" "${COMPOSE[@]}" up -d --build "$SERVICE"
+
+echo
+echo "deployed. Confirm the monitor knows its own version:"
+echo "  curl -s localhost:8790/monitor/product-health | grep -o '\"self\":{[^}]*}'"

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -535,6 +535,8 @@ export interface ProductHealthConfig {
   selfRepo?: string;
   /** The commit this build came from — baked in as AVERRAY_GIT_SHA. */
   selfSha?: string;
+  /** Working tree was dirty at image build — the sha alone would be a lie. */
+  selfDirty?: boolean;
   /** Token for the compare call; a private repo returns 404 without one. */
   selfGithubToken?: string;
   githubApiBaseUrl?: string;
@@ -638,6 +640,7 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     payoutSourceAddress: env.PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS || undefined,
     selfRepo: env.PRODUCT_HEALTH_SELF_REPO || env.MONITOR_REPO || undefined,
     selfSha: env.AVERRAY_GIT_SHA || undefined,
+    selfDirty: truthy(env.AVERRAY_GIT_DIRTY),
     selfGithubToken: env.PRODUCT_HEALTH_SELF_GITHUB_TOKEN || env.GITHUB_TOKEN || undefined,
     githubApiBaseUrl: env.GITHUB_API_BASE_URL || undefined,
     // ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
@@ -1963,6 +1966,7 @@ export async function collectProductHealthProbes(
   const selfFreshness = await deriveSelfFreshnessProbe({
     ...(config.selfRepo ? { repo: config.selfRepo } : {}),
     ...(config.selfSha ? { runningSha: config.selfSha } : {}),
+    ...(config.selfDirty ? { dirty: true } : {}),
     ...(config.selfGithubToken ? { token: config.selfGithubToken } : {}),
     ...(config.githubApiBaseUrl ? { baseUrl: config.githubApiBaseUrl } : {}),
     nowMs: chainCtx.nowMs,
@@ -2049,12 +2053,19 @@ export async function collectProductHealthProbes(
 async function deriveSelfFreshnessProbe(input: {
   repo?: string;
   runningSha?: string;
+  dirty?: boolean;
   token?: string;
   baseUrl?: string;
   nowMs: number;
   fetchImpl: typeof fetch;
 }): Promise<{ selfFreshness: SelfFreshness }> {
   const sha = input.runningSha ?? null;
+  // A dirty build short-circuits BEFORE the GitHub compare — there is nothing
+  // to usefully compare, and a clean "0 behind" answer would launder the fact
+  // that the running code is in no commit at all.
+  if (input.dirty) {
+    return { selfFreshness: decideSelfFreshness({ runningSha: sha, compare: null, dirty: true, nowMs: input.nowMs }) };
+  }
   if (!input.repo) {
     const verdict = decideSelfFreshness({ runningSha: sha, compare: null, unknownReason: "no repo configured", nowMs: input.nowMs });
     return { selfFreshness: verdict };

--- a/services/slack-operator/src/self-freshness.ts
+++ b/services/slack-operator/src/self-freshness.ts
@@ -42,10 +42,33 @@ export function decideSelfFreshness(input: {
   runningSha: string | null;
   /** null ⇒ the comparison could not be made (not ⇒ "no drift"). */
   compare: SelfCompare | null;
+  /** The working tree had uncommitted changes when the image was built. */
+  dirty?: boolean;
   unknownReason?: string;
   nowMs: number;
 }): SelfFreshness {
   const runningSha = normalizeSha(input.runningSha);
+
+  // A DIRTY build has a sha, and the sha is a lie: the image is that commit
+  // PLUS uncommitted changes, so comparing it against main would report "up to
+  // date" for code that exists in no commit anywhere. That is the fake-green
+  // this probe exists to prevent, and it is not hypothetical — an un-popped
+  // stash on the VPS once silently reverted a built asset while everything
+  // downstream reported healthy.
+  //
+  // Checked BEFORE the compare, because a clean comparison is exactly what
+  // would launder the lie.
+  if (input.dirty) {
+    const short = runningSha ? `${runningSha.slice(0, 8)} + ` : "";
+    return {
+      status: "unknown",
+      detail: `${short}uncommitted changes — the running code is not any commit, so it cannot be compared to main`,
+      runningSha,
+      behindBy: null,
+      oldestUnshippedAt: null,
+    };
+  }
+
   if (!runningSha) {
     return {
       status: "unknown",

--- a/test/unit/self-freshness.test.ts
+++ b/test/unit/self-freshness.test.ts
@@ -9,6 +9,51 @@ function ago(hours: number): string {
   return new Date(NOW - hours * 3_600_000).toISOString();
 }
 
+// A DIRTY build is its own state, and the most dangerous one: it HAS a sha, so
+// a naive compare would answer "0 behind → up to date" for code that exists in
+// no commit anywhere. An un-popped stash on the VPS once silently reverted a
+// built asset while everything downstream reported healthy.
+describe("decideSelfFreshness — dirty builds", () => {
+  it("never claims up-to-date, even when the sha compares clean", () => {
+    const r = decideSelfFreshness({
+      runningSha: "abcdef1234567890",
+      compare: { behindBy: 0 },
+      dirty: true,
+      nowMs: 0,
+    });
+    expect(r.status).toBe("unknown");
+    expect(r.status).not.toBe("current");
+    expect(r.detail).toContain("uncommitted changes");
+    expect(r.behindBy).toBeNull();
+  });
+
+  it("keeps the sha visible so the operator knows the base commit", () => {
+    const r = decideSelfFreshness({
+      runningSha: "abcdef1234567890",
+      compare: null,
+      dirty: true,
+      nowMs: 0,
+    });
+    expect(r.runningSha).toBe("abcdef1234567890");
+    expect(r.detail).toContain("abcdef12");
+  });
+
+  it("a dirty build with no sha at all still reads unknown", () => {
+    const r = decideSelfFreshness({ runningSha: null, compare: null, dirty: true, nowMs: 0 });
+    expect(r.status).toBe("unknown");
+    expect(r.detail).toContain("uncommitted changes");
+  });
+
+  it("clean builds are unaffected — dirty defaults to false", () => {
+    const r = decideSelfFreshness({
+      runningSha: "abcdef1234567890",
+      compare: { behindBy: 0 },
+      nowMs: 0,
+    });
+    expect(r.status).toBe("current");
+  });
+});
+
 describe("decideSelfFreshness", () => {
   // THE REAL INCIDENT: the VPS sat 6 commits behind main and nothing said so.
   it("names how far behind it is and how long it has been stale", () => {


### PR DESCRIPTION
The self-freshness probe answers *"is this board running current code?"*. **It has answered `unknown` since the day it shipped.**

## Not a plumbing gap

All of it was already there — `Dockerfile.node` takes a `GIT_SHA` arg, compose forwards it, the config reads `AVERRAY_GIT_SHA`, the repo and token default correctly. The Dockerfile even explains why the build can't self-discover it (`.git` is in `.dockerignore`).

The only missing piece was a human typing `GIT_SHA=$(git rev-parse HEAD)` in front of the deploy — which the compose file has politely requested in a comment for weeks, and which nobody has ever done. **Including me, in every deploy command I handed over this session.**

So the one check that exists to catch *"the VPS is six commits behind with four merged PRs live nowhere"* — the incident that motivated building it — has never once been able to answer.

A correctness-critical value cannot depend on remembering a shell prefix.

## `ops/deploy-monitor.sh`

Owns the deploy: computes the sha, passes the full `-f` chain, cannot forget.

It also **fails closed** where the old path failed silent — no git checkout is an *error*, not another "unknown". Silently producing one more unknown is how this stayed broken for a month.

## Dirty trees are their own state — and the dangerous one

A dirty build **has** a sha, so a naive compare answers *"0 behind → up to date"* for code that exists in no commit anywhere. That's the exact fake-green this probe exists to prevent.

Not hypothetical: an un-popped stash on this box once silently reverted a built asset while everything downstream reported healthy.

- the script refuses a dirty tree by default, showing what's dirty, offering `--allow-dirty`
- a `GIT_DIRTY` arg rides alongside the sha
- `decideSelfFreshness` checks it **before** the compare — a clean comparison is precisely what would launder the lie
- the sha stays visible so you still know the base commit; the verdict is `unknown`, which is the truth

## Verification

- full suite **2035 passed**, 14 skipped
- 4 new tests on the dirty path, including *"never claims up-to-date even when the sha compares clean"*
- the dirty guard verified by running it against this worktree mid-change — it refused and listed the five modified files
- `bash -n` clean

## After merge

Deploy with `ops/deploy-monitor.sh` instead of the compose incantation. The MONITOR trust row should finally read something like `ae163f4b · current` — and if it reads `N behind main`, that's the probe doing the job it was built for, for the first time.