### PR TITLE
The capabilities line counted a metric as a capability

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -240,7 +240,7 @@ const MAINNET_PROBES: ProductHealthProbe[] = [
   { name: "api_latency", status: "ok", detail: "/health 51 ms", sparkline: spark("ok") },
   { name: "disk_headroom", status: "ok", detail: "142.3 GiB free of 193 GiB (26% used)", sparkline: spark("ok") },
   { name: "chain_height", status: "ok", detail: "block #18,894,637 · chain 420420419", sparkline: spark("ok") },
-  { name: "capabilities", status: "degraded", detail: "4/7 capabilities up · 2 warnings acknowledged", sparkline: spark("degraded") },
+  { name: "capabilities", status: "degraded", detail: "2/2 required up · xcmObserver staged, gasSponsor disabled (acknowledged) · external-posting watcher lag 160s", sparkline: spark("degraded") },
   { name: "signer_liquidity", status: "ok", detail: "gas 2.6931 DOT · reward bank 15.89 USDC", sparkline: spark("ok") },
   { name: "treasury_liquidity", status: "ok", detail: "reward 15.89 · reserve 0.00 · AAC 26.15 · escrow 0.00 · revenue 0.01", sparkline: spark("ok") },
   { name: "money_path", status: "ok", detail: "settled24h 9 (0 stuck · 0 failed)", sparkline: spark("ok") },

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -249,7 +249,7 @@ describe("opsVerdict", () => {
     const health: ProductHealth = {
       ...OPS_FIXTURE_NOMINAL,
       probes: OPS_FIXTURE_NOMINAL.probes.map((p) =>
-        p.name === "capabilities" ? { ...p, detail: "4/7 capabilities up · 2 warnings" } : p,
+        p.name === "capabilities" ? { ...p, detail: "2/2 required up · xcmObserver staged" } : p,
       ),
     };
     const v = opsVerdict({ health, streamDegraded: false, nowMs: health.at! + 2_000 });

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -952,14 +952,62 @@ export function deriveCapabilityProbe(
       detail: `${critical ? "new CRITICAL" : "new"} capability warning: ${unexpected.map((w) => w.code).join(", ")}`,
     };
   }
-  const total = Object.keys(caps).length;
-  const up = Object.values(caps).filter(isUp).length;
-  const ackd = (h.body?.warnings ?? []).length;
-  return {
-    name,
-    status: "ok",
-    detail: `${up}/${total} capabilities up${ackd ? `, ${ackd} acknowledged warning${ackd === 1 ? "" : "s"}` : ""}`,
-  };
+  return { name, status: "ok", detail: describeHealthyCapabilities(caps, h.body?.warnings ?? [], config) };
+}
+
+/**
+ * The detail line for a HEALTHY capability probe.
+ *
+ * It used to read "4/7 capabilities up, 2 acknowledged warnings", which was
+ * arithmetically right and wrong three times over:
+ *
+ *  · `externalPostingWatcherLagSeconds: 160` shares the capabilityHealth object
+ *    but is a METRIC, not a capability. It has no healthy state, so it counted
+ *    as "not up" forever and made 7/7 unreachable by construction;
+ *  · `xcmObserver: staged` and `gasSponsor: disabled` are deliberate, already
+ *    acknowledged states — reading them as 2-of-3-broken invites someone to go
+ *    fix a decision;
+ *  · and the denominator buried the only number that gates money: whether the
+ *    REQUIRED capabilities are up. That is what the probe reds on.
+ *
+ * So: lead with required, name the rest as the states they are, and show any
+ * metric without judging it — nobody has decided what watcher lag is too much,
+ * and inventing a threshold would manufacture an alarm.
+ */
+function describeHealthyCapabilities(
+  caps: Record<string, unknown>,
+  warnings: ReadonlyArray<{ code?: string; severity?: string }>,
+  config: { requiredCapabilities: string[] },
+): string {
+  const isUp = (v: unknown): boolean => HEALTHY_CAPABILITY_STATES.has(String(v ?? "").toLowerCase());
+  // A capability reports a STATE (a string). Anything numeric riding along in
+  // the same object is telemetry, and must not be counted as a capability.
+  const states = Object.entries(caps).filter(([, v]) => typeof v === "string");
+  const metrics = Object.entries(caps).filter(([, v]) => typeof v === "number");
+
+  const required = config.requiredCapabilities;
+  const requiredUp = required.filter((k) => isUp(caps[k])).length;
+  const parts = [`${requiredUp}/${required.length} required up`];
+
+  const notUp = states.filter(([, v]) => !isUp(v));
+  if (notUp.length > 0) {
+    const named = notUp.map(([k, v]) => `${k} ${String(v).toLowerCase()}`).join(", ");
+    // Every warning is on the expected list in this branch (an unexpected one
+    // returns degraded above), so the states are accounted-for by definition.
+    parts.push(`${named}${warnings.length > 0 ? " (acknowledged)" : ""}`);
+  }
+
+  for (const [key, value] of metrics) parts.push(`${describeMetricKey(key)} ${value}${key.endsWith("Seconds") ? "s" : ""}`);
+  return parts.join(" · ");
+}
+
+/** `externalPostingWatcherLagSeconds` → "external-posting watcher lag". */
+function describeMetricKey(key: string): string {
+  return key
+    .replace(/Seconds$/, "")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .replace(/^external posting/, "external-posting");
 }
 
 /** Chain reachable + producing blocks, per the product's own /health. Unreadable

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -454,7 +454,43 @@ describe("deriveCapabilityProbe", () => {
     };
     const r = deriveCapabilityProbe(fetched(body), capConfig);
     expect(r.status).toBe("ok");
-    expect(r.detail).toBe("3/5 capabilities up, 2 acknowledged warnings");
+    // Required leads; the two deliberate states are NAMED rather than reduced
+    // to "3/5 up", which read as two things being broken.
+    expect(r.detail).toBe(
+      "2/2 required up · xcmObserver staged, gasSponsor disabled (acknowledged)",
+    );
+  });
+
+  // THE LIVE MAINNET PAYLOAD, exactly. `externalPostingWatcherLagSeconds` shares
+  // the capabilityHealth object but is a METRIC — it has no healthy state, so it
+  // counted as "not up" forever and made 7/7 unreachable by construction. The
+  // board read "4/7 capabilities up" while every required capability was fine.
+  it("does not count a metric as a capability, and shows it without judging it", () => {
+    const body: ProductHealthPayload = {
+      ...HEALTHY_BODY,
+      capabilityHealth: {
+        blockchain: "enabled",
+        treasuryMutations: "available",
+        xcmObserver: "staged",
+        indexer: "synced",
+        gasSponsor: "disabled",
+        externalPosting: "enabled",
+        externalPostingWatcherLagSeconds: 160,
+      } as ProductHealthPayload["capabilityHealth"],
+      warnings: [
+        { code: "xcm_observer_staged", severity: "warning" },
+        { code: "gas_sponsor_disabled", severity: "warning" },
+      ],
+    };
+    const r = deriveCapabilityProbe(fetched(body), capConfig);
+    expect(r.status).toBe("ok");
+    expect(r.detail).toBe(
+      "2/2 required up · xcmObserver staged, gasSponsor disabled (acknowledged) · external-posting watcher lag 160s",
+    );
+    // No threshold on the lag: nobody has decided what "too laggy" means, and
+    // inventing one would manufacture an alarm.
+    expect(r.status).not.toBe("degraded");
+    expect(r.detail).not.toContain("4/7");
   });
 
   it("red when a REQUIRED capability isn't up (money path down)", () => {


### PR DESCRIPTION
Live mainnet read `capabilities · 4/7 capabilities up, 2 acknowledged warnings` while every required capability was fine. The **status was right**; the sentence was wrong three separate ways.

## What's actually in `capabilityHealth`

| key | value | counted as |
|---|---|---|
| `blockchain` | `enabled` | up · **required** |
| `treasuryMutations` | `available` | up · **required** |
| `indexer` | `synced` | up |
| `externalPosting` | `enabled` | up |
| `xcmObserver` | `staged` | "down" — deliberate, acknowledged |
| `gasSponsor` | `disabled` | "down" — deliberate, acknowledged |
| `externalPostingWatcherLagSeconds` | `160` | "down" — **a metric** |

**`externalPostingWatcherLagSeconds` has no healthy state because it's a number**, so it counted as not-up on every check. `7/7` was unreachable by construction — the board could never have shown all-clear no matter how healthy the product got.

The other two "down" entries are *decisions*, not failures — staged and disabled, both already on the acknowledged-warnings list. Rendering them as 2-of-3-broken invites someone to go fix a decision.

And the denominator buried the only number that gates money: whether the **required** capabilities are up, which is what the probe actually reds on.

## After

Against the exact live payload:

```
capabilities  2/2 required up · xcmObserver staged, gasSponsor disabled (acknowledged) · external-posting watcher lag 160s
```

Required leads. The rest are named as the states they are. Metrics are shown without being judged.

**The lag deliberately gets no threshold** — Pascal's call, asked rather than guessed. Nobody has decided what "too laggy" means here, and inventing a number would manufacture exactly the kind of permanently-lit alarm the rest of this week has been spent removing. It's visible so drift is noticeable; it makes no claim.

## The part that stops this recurring

Capability detection is now **structural** rather than by name: a `string` value is a state, a `number` is telemetry. The next metric that lands in this object gets handled correctly instead of quietly decrementing the count.

## Verification

- full suite **2032 passed**, 14 skipped
- new test pins the exact live seven-key payload and asserts the detail never contains `4/7`
- rendered the new line against the real payload before writing the test, not after

Closes the last of the three findings from reviewing the deployed board.