### PR TITLE
docs(int2): the evidence bundle for the INT-3 gate

### DIFF
--- a/docs/HARNESS_INT2_EVIDENCE_BUNDLE.md
+++ b/docs/HARNESS_INT2_EVIDENCE_BUNDLE.md
@@ -1,0 +1,167 @@
+# INT-2 evidence bundle
+
+> The artifact §21.3 requires before INT-3 may begin. It maps every clause of
+> the §21.1 gate to evidence, and states plainly what it does **not** cover.
+>
+> **Status: submitted for operator acceptance.** Assembled 2026-08-01. The gate
+> is the operator's to declare green; this document is the evidence, not the
+> declaration.
+
+## 1. What the evidence consists of
+
+| Source | What it is | Where |
+|---|---|---|
+| Automated INT-2 suite | 10 cases against the real production dispatcher, two real Postgres instances, the pinned Harness, Docker-isolated runs. Each case carries a D3 mutation proving it can go red. Runs on **every PR**. | `test/integration/int2-automated-suite.test.ts`, CI job "INT-2 real dispatcher integration" |
+| §2.5 / §2.6 controlled pair | The operator ceremony that proved failed verification produces no handoff and verified work produces one correct unactuated handoff. | `HARNESS_INT2_SCRIPTED_PROOFS_RESULT.md` (#578) |
+| §3 budget-capped real-model run | One paid run, one shot, a real model under supervision. | `~/int2-section3-evidence-20260801/` (34 events, task record, decisions, run record) |
+
+The suite is the load-bearing part: it is the only evidence that re-proves
+itself on every change. The two ceremonies are point-in-time.
+
+## 2. §21.1 gate — clause by clause
+
+### "Concurrent/replayed dispatch creates exactly one Harness run"
+
+- Suite case *restarts between submit and reconcile without duplicating the run*
+  — D3 mutation `duplicate the Harness run projection`.
+- Both ceremony pairs and the §3 run recorded `attempt=1`, one claim, one outbox
+  row, with the bound run id equal to an **independently re-derived**
+  `sha256(workItemId \0 taskVersion \0 approvedTaskHash)` shaped as UUIDv5.
+- §3: `b2547d81-8587-543a-a718-6d276771738d`, re-derived before dispatch and
+  matched exactly.
+
+### "approval/hash/policy/grant mismatches refuse"
+
+| Refusal | Suite case |
+|---|---|
+| unapproved task | *keeps an unapproved task outside the production dispatchable set* |
+| approval-hash mismatch | *refuses an approval-hash mismatch before claim or submit* |
+| unvetted capability | *rejects `memory.propose` in the outer production profile loader* |
+| narrowing accepted | *accepts a seven-capability profile with strictly narrower authority* |
+
+The last two encode the **production/typed split**: `unvetted_capability` is
+reachable through the production loader; the inner `capability_not_granted`
+guard is unreachable after production loading, and a companion assertion pins
+*why* — `VETTED_CAPABILITIES` keys equal `PILOT_CAPABILITY_IDS`. If those
+allowlists ever diverge, that test fails and forces re-examination.
+`suite-summary.json` records
+`typedChecksReachableThroughProductionProfileLoading: false` rather than
+implying a production-path demonstration.
+
+### "HALT wins"
+
+Suite case *HALT cancels a bound live run and never creates a handoff*, D3
+mutation `remove the HALT escalation decision`.
+
+### "No wallet/settlement/deploy/GitHub-merge capability is present"
+
+`VETTED_CAPABILITIES` is a frozen map of exactly eight entries — `fs.read_file`,
+`fs.write_file`, `fs.list_files`, `shell.run`, `git.status`, `git.diff`,
+`artifact.put`, `artifact.get` — and `profile-manifest.ts` throws
+`unvetted_capability` for anything else **before attenuation runs**.
+
+Verified live on the §3 task record immediately before approval: 8 grants, all
+repo-scoped, empty constraints, no wallet / settlement / deploy / GitHub /
+publish / merge grant.
+
+### "Several representative low-risk tasks complete through the supervised path"
+
+Four runs reached `handoff_ready` with a verified non-empty patch: ceremony
+`green-002`, and suite cases *green*, *narrow*, *restart*.
+
+**This is the weakest clause in the bundle and should not be read as stronger
+than it is.** All four are the same task family — a formatting-only append
+within `docs/**`. "Several representative" is satisfied in count, not in
+variety. §21.2 burn-in separately requires ≥3 task families across ≥20 work
+items; nothing here anticipates that, and this bundle makes no claim about it.
+
+### "Failed verification produces no submission"
+
+The strongest-covered clause, proven three ways, including once by a real model:
+
+| Run | Criterion | Lifecycle | Handoffs | PR |
+|---|---|---|---|---|
+| ceremony `red-002` | `exit_2`, offence named at `…PLAN.md:704` | `failed` | **0** | none |
+| suite `idle` | `exit_1` (empty diff) | `failed` | **0** | none |
+| **§3 real model** | **`exit_1` (empty diff)** | **`failed`** | **0** | none |
+
+### "Restart and duplicate delivery remain idempotent"
+
+Suite case *restarts between submit and reconcile without duplicating the run*,
+as above.
+
+## 3. The §3 real-model run
+
+One shot, `glm-5.2` via an OpenAI-compatible endpoint, capacity-tier provider.
+
+**The task failed, and that is the evidence.** The model read the correct file,
+ran `git status`, and inspected the file's tail — correct reconnaissance — with
+every turn ending `finish_reason: tool_call`, meaning it intended to continue.
+It never reached the write:
+
+```
+call 1  in=1953  out= 91     call 3  in=2247  out= 40
+call 2  in=2096  out=118     call 4  in=2373  out=131
+                             total  8669 + 380 = 9049  against an 8000 cap
+```
+
+Input grows every turn because the conversation replays. Four turns of reading a
+large document exhausted the budget before any write.
+
+Three things this demonstrates that a successful run would not have:
+
+1. **The token cap is a real control.** The §3 work order recorded that
+   `estimatedUsdMicros` is `null` and enforces nothing, leaving the token cap as
+   the operative limit. This run is the first time that limit has been observed
+   to bite.
+2. **The criterion discriminates against a real model**, not only a scripted
+   one. `exit_1` fired in the wild, on the same fixture and criterion the
+   scripted `idle` case had proven in-container hours earlier.
+3. **A budget-exhausted, verification-failed run still produces zero handoffs
+   and no PR.**
+
+**A finding for whoever sizes the next one:** 8000 tokens and this fixture are in
+tension. A task phrased as "append to this document" obliges a model to read the
+document first, at roughly 2000 tokens of context growth per turn. The budget is
+not wrong and the fixture is not wrong; they are wrong together.
+
+**One wording defect.** The dispatcher's alert reads *"The approved Harness
+budget was exhausted; the run was cancelled and the task failed."* The budget
+genuinely was exhausted, but the run was **not** cancelled — it completed
+(`RunCompleted`), verification failed on the empty diff, and the dispatcher
+observed the exhausted budget 12 seconds later during reconciliation. The
+substance is right; "cancelled" is not. Not fixed here, to keep this bundle a
+record rather than a change.
+
+## 4. What this bundle does not cover
+
+- **§21.2 burn-in.** Nothing here speaks to ≥20 work items, ≥3 task families,
+  or ≥14 consecutive incident-free days. Those gate *retiring a direct runner
+  and away mode*, not INT-3 entry.
+- **Task-family variety.** See §21.1 clause five above.
+- **Cost measurement.** The provider sells capacity, not tokens; there is no
+  USD-per-million figure to report, and none was invented. Marginal cost of the
+  run against already-purchased capacity was zero.
+- **Anything actuated.** No PR was opened by any run in this bundle.
+
+## 5. A process note that belongs in the record
+
+INT-3**a** — the PR *payload* actuator — was implemented and merged before this
+bundle was submitted. That is close enough to §21.3's line to be worth naming
+rather than leaving for someone to notice later.
+
+INT-3a does not implement the PR-opening seam. It computes a payload artifact
+and **cannot reach GitHub**: its entire import surface is `node:crypto`,
+`node:path`, and two internal packages, with no HTTP client, no GitHub client,
+and no credential anywhere in the component or its ports. That was a deliberate
+requirement of its work order — the property is structural, not a convention.
+
+The seam itself, INT-3b, remains gated on this bundle being accepted and the
+operator signing off, exactly as §21.3 requires.
+
+## 6. What acceptance means
+
+Accepting this bundle asserts that the §21.1 clauses above are adequately
+evidenced — including the honest weakness in clause five — and unblocks INT-3b
+work. It does not assert burn-in, and it does not authorise any PR being opened;
+INT-3b carries its own refusal ceremony before a credential is ever issued.

--- a/docs/HARNESS_INT2_SCRIPTED_PROOFS_RESULT.md
+++ b/docs/HARNESS_INT2_SCRIPTED_PROOFS_RESULT.md
@@ -87,6 +87,23 @@ both.
 
 ## Still outstanding for INT-2
 
-Not covered by these two cases: the §2 safety proofs (HALT stops a live run,
+**Nothing. This section is retained, corrected, because a bundle that quietly
+edits its own history is worth less than one that shows the correction.**
+
+As written on 2026-07-29 this said the §2 safety proofs (HALT stops a live run,
 approval-hash mismatch refuses, attenuation refusal), restart/duplicate-delivery
-idempotence, and the §3 budget-capped real-model task.
+idempotence, and the §3 budget-capped real-model task were not covered. All of
+them now are:
+
+| Then outstanding | Now proven by |
+|---|---|
+| HALT stops a live run | suite case *HALT cancels a bound live run and never creates a handoff* |
+| approval-hash mismatch refuses | suite case *refuses an approval-hash mismatch before claim or submit* |
+| attenuation refusal | suite cases *rejects `memory.propose` in the outer production profile loader* and *accepts a seven-capability profile with strictly narrower authority* |
+| restart / duplicate-delivery idempotence | suite case *restarts between submit and reconcile without duplicating the run* |
+| §3 budget-capped real-model task | executed 2026-08-01; token cap enforced at 8000, criterion returned `exit_1`, zero handoffs |
+
+Left uncorrected, this section made the evidence look thinner than it is — the
+opposite of the usual failure, and still a failure. See
+`HARNESS_INT2_EVIDENCE_BUNDLE.md` for the full §21.1 mapping, including the one
+clause that genuinely remains weak.


### PR DESCRIPTION
The artifact §21.3 requires before INT-3 may begin. It maps every §21.1 clause to evidence and states plainly what it does **not** cover.

**This is the evidence, not the declaration.** Accepting it is the operator's call.

## Three sources

| | |
|---|---|
| 10-case automated suite | the only part that **re-proves itself on every PR** |
| §2.5/§2.6 controlled pair | point-in-time (#578) |
| §3 real-model run | executed 2026-08-01, one shot |

## The §3 run failed, and that is better evidence than success

`glm-5.2` read the correct file, ran `git status`, inspected the tail — correct reconnaissance, every turn ending `finish_reason: tool_call` — then exhausted its budget before reaching the write:

```
call 1  in=1953 out= 91      call 3  in=2247 out= 40
call 2  in=2096 out=118      call 4  in=2373 out=131
                             9049 total against an 8000 cap
```

No diff → `exit_1` → verification failed → **zero handoffs, no PR**.

**It is the first time the token cap has been observed to bite.** That matters because the §3 work order had already recorded that `estimatedUsdMicros` is `null` and enforces nothing, leaving the token cap as the only real limit. A run that simply succeeded would never have shown that limit working.

Recorded as a finding for whoever sizes the next one: 8000 tokens and this fixture are in tension. "Append to this document" obliges a model to read the document first, at ~2000 tokens of context growth per turn. Neither is wrong alone — they are wrong together.

## The clause that stays weak

*"Several representative low-risk tasks complete through the supervised path"* is satisfied **in count** — four runs reached `handoff_ready` — but all four are the same task family, a formatting-only append within `docs/**`.

The bundle says so in those words. It's variety the gate doesn't strictly require and burn-in does, and it shouldn't be read as stronger than it is.

## A process fact, recorded rather than left to be noticed

INT-3a merged **before** this bundle was submitted — close enough to §21.3's line to name.

INT-3a does not implement the PR-opening seam and structurally cannot: its entire import surface is `node:crypto`, `node:path`, and two internal packages — no HTTP client, no GitHub client, no credential anywhere in the component or its ports. That was a deliberate requirement of its work order. The seam itself, INT-3b, stays gated on acceptance and sign-off.

## Also fixed

`HARNESS_INT2_SCRIPTED_PROOFS_RESULT.md` still listed HALT, approval-hash mismatch, attenuation refusal, restart idempotence, and the §3 run as outstanding. **All five are now proven.** Left alone it made the evidence look *thinner* than it is — the opposite of the usual failure mode, and still a failure.

Corrected in place with a then/now table rather than deleted, because a bundle that quietly edits its own history is worth less than one that shows the correction.

Ceremony-scripts test: 11/11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)