### PR TITLE
fix(int2): reap the workers and run containers the suite starts

### DIFF
--- a/scripts/ceremony/lib/int2-reap.sh
+++ b/scripts/ceremony/lib/int2-reap.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Reaping for the INT-2 automated suite: the Harness worker processes it spawns
+# and the per-run Docker containers those workers create.
+#
+# The suite's EXIT trap used to remove its temp root and its two Postgres
+# containers and stop there. Both of the things below outlived it:
+#
+#   * A worker survived with PPID 1 for nearly three days, its command line
+#     still pointing at a temp root the same trap had already deleted. It was
+#     found by the §3 ceremony's "assert no worker is already running"
+#     preflight, which it blocked, during a live paid run.
+#   * harness-run-* containers accumulated one per run — the Harness Docker
+#     environment tier starts them with a durable name and no --rm, on purpose,
+#     so a crashed run can still be inspected.
+#
+# Kept in its own file so test/unit/int2-ceremony-scripts.test.ts can drive it
+# directly, with fake workers and a fake docker, and prove the safety property
+# below without standing up databases, a Harness checkout, or Docker. Every
+# function takes what it needs as arguments and reads no suite global.
+#
+# THE SAFETY PROPERTY. Reaping is by RECORDED PID, never by pattern. The
+# obvious fix, `pkill -f "harness worker"`, would kill an operator's own
+# ceremony worker — the very process the leak was obstructing. Worse, a pid
+# recorded hours earlier is not by itself trustworthy either: the worker may
+# have exited and the OS may have recycled its pid onto something unrelated.
+# So every pid is re-identified against THIS run's Harness binary in the
+# instant before it is signalled, and a pid that no longer answers to that
+# identity is left alone.
+
+# macOS mktemp hands back /var/folders/... while ps reports the same path as
+# /private/var/folders/..., so comparing the two literally never matches.
+# Applied to both sides, this makes them comparable. On Linux there is no
+# /private prefix to strip and both sides pass through unchanged.
+int2_reap_unprivate() {
+  case "$1" in
+    /private/*) printf '%s' "${1#/private}" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# $1 pid, $2 the command fragment that identifies this run's workers — the
+# suite passes "$HARNESS_BIN worker", whose Harness path is unique per run
+# because it lives under the run's own mktemp root.
+#
+# A substring test rather than a prefix test because the pid's command line
+# takes either of two shapes: `<harness> worker` when the shim is exec'd
+# directly, or `<python> <harness> worker` once the kernel has resolved the
+# console script's shebang. Both contain the fragment; a worker rooted
+# anywhere else contains neither.
+int2_reap_is_tracked_worker() {
+  # The fragment must be an absolute path, which is the one thing that makes it
+  # discriminating. The trap composes it as "$HARNESS_BIN worker", and
+  # HARNESS_BIN is not exported until well into the run: an unset one would
+  # degrade the fragment to " worker" and match every worker on the machine.
+  # Nothing reaches here with a pidfile that early today — but a fragment that
+  # matches everything is precisely the outcome this file exists to prevent, so
+  # it is refused at the door rather than left to depend on ordering.
+  case "${2:-}" in /?*) ;; *) return 1 ;; esac
+  _int2_reap_seen="$(ps -o command= -p "$1" 2>/dev/null)" || return 1
+  [ -n "$_int2_reap_seen" ] || return 1
+  case "$(int2_reap_unprivate "$_int2_reap_seen")" in
+    *"$(int2_reap_unprivate "$2")"*) return 0 ;;
+  esac
+  return 1
+}
+
+# Signal one worker's whole process group when it leads one — the suite spawns
+# workers detached, so it does — and fall back to the bare pid when it does
+# not. The group form takes anything the worker itself spawned with it.
+# $1 signal name, $2 pid.
+int2_reap_signal() {
+  if kill -s "$1" -- "-$2" 2>/dev/null; then
+    return 0
+  fi
+  if kill -s "$1" -- "$2" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# $1 pidfile written by the suite's workers, $2 identifying command fragment,
+# $3 log path. TERM first, then KILL for anything still answering to the
+# tracked identity five seconds later.
+int2_reap_workers() {
+  _int2_reap_pidfile="${1:-}"
+  _int2_reap_expect="${2:-}"
+  _int2_reap_log="${3:-/dev/null}"
+  [ -n "$_int2_reap_pidfile" ] && [ -f "$_int2_reap_pidfile" ] || return 0
+
+  _int2_reap_signalled=""
+  while IFS= read -r _int2_reap_pid || [ -n "$_int2_reap_pid" ]; do
+    case "$_int2_reap_pid" in '' | *[!0-9]*) continue ;; esac
+    int2_reap_is_tracked_worker "$_int2_reap_pid" "$_int2_reap_expect" \
+      || continue
+    int2_reap_signal TERM "$_int2_reap_pid" || continue
+    _int2_reap_signalled="$_int2_reap_signalled $_int2_reap_pid"
+    printf '%s\n' "INT2_WORKER_REAPED pid=$_int2_reap_pid signal=TERM" \
+      >> "$_int2_reap_log" 2>/dev/null || true
+  done < "$_int2_reap_pidfile"
+  [ -n "$_int2_reap_signalled" ] || return 0
+
+  _int2_reap_alive=""
+  for _int2_reap_try in 1 2 3 4 5; do
+    _int2_reap_alive=""
+    for _int2_reap_pid in $_int2_reap_signalled; do
+      if int2_reap_is_tracked_worker "$_int2_reap_pid" "$_int2_reap_expect"
+      then
+        _int2_reap_alive="$_int2_reap_alive $_int2_reap_pid"
+      fi
+    done
+    [ -n "$_int2_reap_alive" ] || return 0
+    sleep 1
+  done
+  for _int2_reap_pid in $_int2_reap_alive; do
+    int2_reap_signal KILL "$_int2_reap_pid" || true
+    printf '%s\n' "INT2_WORKER_REAPED pid=$_int2_reap_pid signal=KILL" \
+      >> "$_int2_reap_log" 2>/dev/null || true
+  done
+  return 0
+}
+
+# Record the harness-run-* containers that exist BEFORE the run, into $1.
+# Fails without creating the file when Docker cannot be listed, which is what
+# makes the reap below fail safe: no snapshot, nothing removed.
+int2_reap_snapshot_run_containers() {
+  _int2_reap_existing="$(
+    docker ps --all --filter 'name=^harness-run-' --format '{{.Names}}' 2>/dev/null
+  )" || return 1
+  printf '%s\n' "$_int2_reap_existing" > "$1"
+}
+
+# $1 the snapshot file, $2 log path. Removes every harness-run-* container that
+# was not in the snapshot.
+#
+# Why a snapshot diff and not a list of ids the suite can compute: a container
+# is named for the Harness run that created it, and only top-level runs get a
+# row in the runs table. Child and verification runs derive their own ids
+# (uuid5 of the parent, and `<child>-check-<cycle>`), so they are unknowable up
+# front and unrecoverable afterwards. What the suite CAN state exactly is which
+# containers it did not create — and everything in the snapshot is spared,
+# including the days-old leaks this fix does not retroactively own and any
+# container belonging to an operator's already-running ceremony.
+#
+# A missing or unreadable snapshot removes nothing at all. Deleting every
+# harness-run-* container because the suite failed before it could look is the
+# one outcome worse than leaking.
+int2_reap_run_containers() {
+  _int2_reap_before="${1:-}"
+  _int2_reap_log="${2:-/dev/null}"
+  [ -n "$_int2_reap_before" ] && [ -f "$_int2_reap_before" ] || return 0
+  _int2_reap_now="$(
+    docker ps --all --filter 'name=^harness-run-' --format '{{.Names}}' 2>/dev/null
+  )" || return 0
+
+  for _int2_reap_name in $_int2_reap_now; do
+    case "$_int2_reap_name" in harness-run-?*) ;; *) continue ;; esac
+    if grep -qxF "$_int2_reap_name" "$_int2_reap_before" 2>/dev/null; then
+      continue
+    fi
+    docker rm --force "$_int2_reap_name" >/dev/null 2>&1 || continue
+    printf '%s\n' "INT2_RUN_CONTAINER_REAPED name=$_int2_reap_name" \
+      >> "$_int2_reap_log" 2>/dev/null || true
+  done
+  return 0
+}

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -14,11 +14,28 @@ _int2_bootstrap_log="$_int2_evidence/bootstrap.log"
 _int2_started="$(date +%s)"
 _int2_docker_shared_root="${HOME:?}/.agent-runtime"
 _int2_git_probe=""
+# Bookkeeping the cleanup trap reaps from. Both live under the temp root, not
+# the evidence directory: they are transient, and CI uploads the evidence.
+_int2_worker_pidfile="$_int2_root/worker-pids.txt"
+_int2_run_containers_before="$_int2_root/run-containers-before.txt"
+
+# shellcheck source=scripts/ceremony/lib/int2-reap.sh
+source "$_int2_repo/scripts/ceremony/lib/int2-reap.sh"
 
 _int2_cleanup() {
   _int2_exit="$?"
   printf '%s\n' "INT2_SUITE_EXIT_CODE=$_int2_exit" \
     >> "$_int2_bootstrap_log" 2>/dev/null || true
+  # First: stop the workers this run spawned. Ahead of the postmortem so
+  # nothing is still writing to the databases it is about to read, and ahead of
+  # everything else because a vitest crash never reaches the suite's own
+  # afterAll — which is how one of these came to outlive its own temp root by
+  # three days. Reaping is by recorded pid with re-verified identity; see
+  # lib/int2-reap.sh for why `pkill -f "harness worker"` is not an option.
+  int2_reap_workers \
+    "$_int2_worker_pidfile" \
+    "${HARNESS_BIN:-} worker" \
+    "$_int2_bootstrap_log" || true
   # On any failure, preserve why the databases were unhappy before removing
   # them. Containers outlive their crash on purpose (no --rm) so this works.
   if [ "$_int2_exit" -ne 0 ]; then
@@ -33,6 +50,9 @@ _int2_cleanup() {
         >> "$_int2_bootstrap_log" 2>&1 || true
     done
   fi
+  # The workers are gone, so no new run container can appear underneath this.
+  int2_reap_run_containers \
+    "$_int2_run_containers_before" "$_int2_bootstrap_log" || true
   docker rm --force "$_int2_harness_db" "$_int2_reference_db" \
     >/dev/null 2>&1 || true
   case "$_int2_git_probe" in
@@ -224,6 +244,24 @@ export INT2_SUITE_REQUIRED=1
 export INT2_REPOSITORY_ROOT="$_int2_repo"
 export INT2_SUITE_EVIDENCE_DIR="$_int2_evidence"
 export INT2_SUITE_EXECUTION_MARKER="$_int2_marker"
+# The suite spawns its Harness workers from inside vitest, so the trap cannot
+# see their pids unless the tests hand them over. Each worker appends its own
+# the instant it exists.
+export INT2_SUITE_WORKER_PIDFILE="$_int2_worker_pidfile"
+
+# Everything from here on is "during the run": nothing above this line starts a
+# Harness run, so anything named harness-run-* that exists now belongs to
+# somebody else and the trap must not touch it. Recorded immediately before the
+# cases start so the window is as narrow as it can be made.
+int2_reap_snapshot_run_containers "$_int2_run_containers_before" \
+  || {
+    echo "INT2_RUN_CONTAINER_SNAPSHOT_FAILED: cannot list existing harness-run-* containers" \
+      | tee -a "$_int2_bootstrap_log" >&2
+    exit 34
+  }
+printf '%s\n' "INT2_RUN_CONTAINER_SNAPSHOT spared=$(
+  grep -c . "$_int2_run_containers_before" 2>/dev/null || echo 0
+)" >> "$_int2_bootstrap_log"
 
 printf '%s\n' "INT2_CASES_STARTED expected=10" >> "$_int2_bootstrap_log"
 (

--- a/test/integration/int2-automated-suite.test.ts
+++ b/test/integration/int2-automated-suite.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
+import { appendFileSync } from "node:fs";
 import {
   copyFile,
   mkdir,
@@ -137,9 +138,13 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
   }, TEST_TIMEOUT_MS);
 
   afterAll(async () => {
-    for (const worker of workers) {
-      await worker.stop();
-    }
+    // Every worker gets stopped even when an earlier one refuses to. The
+    // sequential `await` this replaces abandoned the rest of the set on the
+    // first throw, so one stuck worker leaked all the others behind it.
+    // Failures are re-raised below, after the evidence is written.
+    const stops = await Promise.allSettled(
+      [...workers].map((worker) => worker.stop()),
+    );
     await referencePool?.end();
     await harnessPool?.end();
     await Promise.all(
@@ -179,6 +184,13 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
       );
     }
     await rm(root, { recursive: true, force: true });
+    const stuck = stops.filter((stop) => stop.status === "rejected");
+    if (stuck.length > 0) {
+      throw new Error(
+        `${stuck.length} Harness worker(s) could not be stopped: `
+          + stuck.map((stop) => String(stop.reason)).join("; "),
+      );
+    }
   }, TEST_TIMEOUT_MS);
 
   it("preflights the controlled red/green pair against a real tracked diff", async () => {
@@ -785,7 +797,11 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
         artifactRoot: process.env.HARNESS_ARTIFACT_ROOT!,
       }),
       stdio: ["ignore", "pipe", "pipe"],
+      // Leads its own process group, so the suite script's cleanup trap can
+      // take the worker and everything it spawned with one signal to -pid.
+      detached: true,
     });
+    recordWorkerPid(child.pid);
     child.stdout?.on("data", (chunk) => output.push(String(chunk)));
     child.stderr?.on("data", (chunk) => output.push(String(chunk)));
     const deadline = Date.now() + 15_000;
@@ -1059,6 +1075,20 @@ describe.skipIf(!ready)("INT-2 automated supervised-dispatch suite", () => {
   };
 });
 
+// Hand the pid to the suite script's cleanup trap, which is the only reaper
+// that still runs when this process dies without reaching afterAll.
+//
+// Synchronous and appended the instant the child exists — before it is known
+// healthy, and before anything can await. A worker that never reports ready
+// still has to be reaped, and a crash one line later must still leave the trap
+// something to act on. The file is the trap's whole picture of what to kill:
+// what is not written here leaks.
+function recordWorkerPid(pid: number | undefined): void {
+  const pidfile = process.env.INT2_SUITE_WORKER_PIDFILE;
+  if (pidfile === undefined || pid === undefined) return;
+  appendFileSync(pidfile, `${pid}\n`, "utf8");
+}
+
 class HarnessWorker {
   private stopped = false;
 
@@ -1071,18 +1101,23 @@ class HarnessWorker {
     return this.output.join("").slice(-8_000);
   }
 
+  // Two SIGINTs then SIGTERM is the Harness worker's own documented shutdown
+  // ladder. SIGKILL is the addition: without it this threw and left the
+  // process running, which is one of the two ways a worker used to outlive the
+  // suite. A process that survives SIGKILL is genuinely stuck rather than
+  // merely slow, and the suite script's trap has no better move either, so
+  // that alone is worth failing the run over.
   async stop(): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;
-    if (this.child.exitCode !== null) return;
-    this.child.kill("SIGINT");
-    if (await waitForExit(this.child, 2_000)) return;
-    this.child.kill("SIGINT");
-    if (await waitForExit(this.child, 2_000)) return;
-    this.child.kill("SIGTERM");
-    if (await waitForExit(this.child, 2_000)) return;
+    for (const signal of ["SIGINT", "SIGINT", "SIGTERM", "SIGKILL"] as const) {
+      if (this.child.exitCode !== null || this.child.signalCode !== null) return;
+      this.child.kill(signal);
+      if (await waitForExit(this.child, 2_000)) return;
+    }
     throw new Error(
-      `Harness worker did not stop: ${this.output.join("").slice(-4_000)}`,
+      `Harness worker survived SIGKILL (pid ${this.child.pid}): `
+        + this.output.join("").slice(-4_000),
     );
   }
 }

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import {
   chmod,
   mkdir,
@@ -9,6 +9,7 @@ import {
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -33,6 +34,7 @@ const AUTOMATED_SUITE = path.join(
   SCRIPT_ROOT,
   "run-int2-automated-suite.sh",
 );
+const REAP_HELPER = path.join(SCRIPT_ROOT, "lib/int2-reap.sh");
 const PILOT_DOCKERFILE = path.join(ROOT, "ops/Dockerfile.pilot");
 const OPERATOR_SCRIPTS = [
   "int2-bringup.sh",
@@ -43,13 +45,94 @@ const OPERATOR_SCRIPTS = [
   "int2-teardown.sh",
 ] as const;
 const temporaryRoots: string[] = [];
+const strayProcesses: ChildProcess[] = [];
 
 afterEach(async () => {
+  // A test about not leaking processes must not leak processes.
+  for (const stray of strayProcesses.splice(0)) {
+    if (stray.exitCode === null && stray.signalCode === null) {
+      try {
+        process.kill(-stray.pid!, "SIGKILL");
+      } catch {
+        stray.kill("SIGKILL");
+      }
+    }
+  }
   await Promise.all(
     temporaryRoots.splice(0).map((value) =>
       rm(value, { recursive: true, force: true })),
   );
 });
+
+// A stand-in for `<checkout>/.venv/bin/harness`, laid out at the real path so
+// the identifying fragment the suite passes has the real shape. Extensionless,
+// like the console script it imitates, so Node loads it as CommonJS whatever
+// this package declares.
+const FAKE_WORKER = [
+  'if (process.argv[2] !== "worker") process.exit(2);',
+  "if (process.env.FAKE_WORKER_GRANDCHILD) {",
+  '  import("node:child_process").then(({ spawn }) => {',
+  "    const child = spawn(",
+  '      process.execPath, ["-e", "setInterval(() => {}, 1 << 30)"],',
+  '      { stdio: "ignore" },',
+  "    );",
+  '    import("node:fs").then((fs) => fs.writeFileSync(',
+  "      process.env.FAKE_WORKER_GRANDCHILD, `${child.pid}\\n`,",
+  "    ));",
+  "  });",
+  "}",
+  "setInterval(() => {}, 1 << 30);",
+].join("\n");
+
+async function fakeHarnessBin(root: string, name: string): Promise<string> {
+  const directory = path.join(root, name, "agent-harness/.venv/bin");
+  await mkdir(directory, { recursive: true });
+  const bin = path.join(directory, "harness");
+  await writeFile(bin, `${FAKE_WORKER}\n`, "utf8");
+  return bin;
+}
+
+// Spawned exactly the way the suite spawns a real worker: detached, so it
+// leads its own process group. `node <bin> worker` puts "<bin> worker" in the
+// command line, which is the fragment the reaper matches on — the same
+// substring the kernel leaves behind after resolving the real shim's shebang.
+function startFakeWorker(
+  bin: string,
+  environment: NodeJS.ProcessEnv = {},
+): ChildProcess {
+  const child = spawn(process.execPath, [bin, "worker"], {
+    stdio: "ignore",
+    detached: true,
+    env: { ...process.env, ...environment },
+  });
+  child.unref();
+  strayProcesses.push(child);
+  return child;
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntilDead(pid: number, timeoutMs = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline && isAlive(pid)) await delay(50);
+}
+
+// Drive one reaper function out of the committed library, in bash, exactly as
+// the suite's cleanup trap does.
+function runReaper(call: string, environment: NodeJS.ProcessEnv = {}): string {
+  return execFileSync(
+    "bash",
+    ["-euo", "pipefail", "-c", `source "${REAP_HELPER}"\n${call}`],
+    { encoding: "utf8", env: { ...process.env, ...environment } },
+  );
+}
 
 describe("committed INT-2 ceremony mechanics", () => {
   it("keeps all six operator scripts parseable and on the shared evidence definition", async () => {
@@ -477,5 +560,259 @@ describe("committed INT-2 ceremony mechanics", () => {
       'git config --system --get-all safe.directory',
     );
     expect(suite).toContain("git diff --check");
+  });
+});
+
+describe("INT-2 suite reaping", () => {
+  it("kills the worker it recorded and spares an operator's worker at a recorded pid", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-workers-"));
+    temporaryRoots.push(root);
+    const [mine, operator] = await Promise.all([
+      fakeHarnessBin(root, "suite-run"),
+      fakeHarnessBin(root, "operator-ceremony"),
+    ]);
+
+    const suiteWorker = startFakeWorker(mine);
+    const operatorWorker = startFakeWorker(operator);
+    await delay(500);
+    expect(isAlive(suiteWorker.pid!)).toBe(true);
+    expect(isAlive(operatorWorker.pid!)).toBe(true);
+
+    // The pidfile is DELIBERATELY poisoned with the operator's pid, which is
+    // the worst case the design has to survive: a pid recorded by an earlier
+    // run, whose worker has since exited and whose number the OS has recycled
+    // onto somebody else's process. Tracking pids is not on its own enough —
+    // it is tracking plus re-identification that makes this safe. A reaper
+    // built on `pkill -f "harness worker"` fails this test on the first line,
+    // and that is the failure that blocked a live paid run.
+    const pidfile = path.join(root, "worker-pids.txt");
+    const log = path.join(root, "bootstrap.log");
+    await writeFile(
+      pidfile,
+      `${suiteWorker.pid}\n${operatorWorker.pid}\n`,
+      "utf8",
+    );
+
+    runReaper(
+      `int2_reap_workers "${pidfile}" "${mine} worker" "${log}"`,
+    );
+
+    await waitUntilDead(suiteWorker.pid!);
+    expect(isAlive(suiteWorker.pid!)).toBe(false);
+    expect(isAlive(operatorWorker.pid!)).toBe(true);
+
+    const reaped = await readFile(log, "utf8");
+    expect(reaped).toContain(`INT2_WORKER_REAPED pid=${suiteWorker.pid}`);
+    expect(reaped).not.toContain(`pid=${operatorWorker.pid}`);
+  }, 30_000);
+
+  it("refuses a non-discriminating identity rather than killing everything", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-blank-"));
+    temporaryRoots.push(root);
+    const bin = await fakeHarnessBin(root, "suite-run");
+    const worker = startFakeWorker(bin);
+    await delay(500);
+
+    const pidfile = path.join(root, "worker-pids.txt");
+    await writeFile(pidfile, `${worker.pid}\n`, "utf8");
+
+    // What an unset HARNESS_BIN composes: " worker", which as a substring
+    // matches every Harness worker on the machine. A reaper that accepted it
+    // would be `pkill -f "harness worker"` wearing a pidfile.
+    runReaper(`int2_reap_workers "${pidfile}" " worker" /dev/null`);
+    await delay(500);
+    expect(isAlive(worker.pid!)).toBe(true);
+
+    runReaper(`int2_reap_workers "${pidfile}" "${bin} worker" /dev/null`);
+    await waitUntilDead(worker.pid!);
+    expect(isAlive(worker.pid!)).toBe(false);
+  }, 30_000);
+
+  it("takes what the worker spawned with it", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-group-"));
+    temporaryRoots.push(root);
+    const bin = await fakeHarnessBin(root, "suite-run");
+    const grandchildPidfile = path.join(root, "grandchild.pid");
+
+    const worker = startFakeWorker(bin, {
+      FAKE_WORKER_GRANDCHILD: grandchildPidfile,
+    });
+    const deadline = Date.now() + 10_000;
+    let grandchild = 0;
+    while (Date.now() < deadline && grandchild === 0) {
+      grandchild = Number(
+        await readFile(grandchildPidfile, "utf8").catch(() => ""),
+      );
+      if (grandchild === 0) await delay(50);
+    }
+    expect(grandchild).toBeGreaterThan(0);
+    expect(isAlive(grandchild)).toBe(true);
+
+    const pidfile = path.join(root, "worker-pids.txt");
+    await writeFile(pidfile, `${worker.pid}\n`, "utf8");
+    runReaper(`int2_reap_workers "${pidfile}" "${bin} worker" /dev/null`);
+
+    // Signalling -pid rather than pid is the whole point of spawning workers
+    // detached: a worker reaped alone leaves its own children orphaned, which
+    // is the leak one level down.
+    await Promise.all([
+      waitUntilDead(worker.pid!),
+      waitUntilDead(grandchild),
+    ]);
+    expect(isAlive(worker.pid!)).toBe(false);
+    expect(isAlive(grandchild)).toBe(false);
+  }, 30_000);
+
+  it("removes only the run containers that appeared during the run", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-containers-"));
+    temporaryRoots.push(root);
+    const removals = path.join(root, "removed.txt");
+    const listing = path.join(root, "listing.txt");
+    const before = path.join(root, "before.txt");
+    const log = path.join(root, "bootstrap.log");
+    const fakeBin = path.join(root, "bin");
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(
+      path.join(fakeBin, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "ps" ]; then cat "$INT2_FAKE_DOCKER_LISTING"; exit 0; fi',
+        'if [ "$1" = "rm" ]; then',
+        '  printf "%s\\n" "$3" >> "$INT2_FAKE_DOCKER_REMOVALS"; exit 0',
+        "fi",
+        "exit 0",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(path.join(fakeBin, "docker"), 0o755);
+
+    // Two leaks predating the run — the days-old ones this fix does not
+    // retroactively own — plus a container an operator's concurrent ceremony
+    // owns. All three are in the snapshot, so all three survive.
+    const preexisting = [
+      "harness-run-docker-lifecycle-17e77683d9934e4b84604c100d938777",
+      "harness-run-cd16137f-4a63-49f0-8820-40550904afa9",
+      "harness-run-0aa6914b-b9b2-4f32-bc09-45894222107b",
+    ];
+    await writeFile(before, `${preexisting.join("\n")}\n`, "utf8");
+    await writeFile(
+      listing,
+      `${[
+        ...preexisting,
+        "harness-run-63882cbb-0aa3-5b3b-8459-f11fdb09717b",
+        "harness-run-11111111-2222-3333-4444-555555555555-check-1",
+      ].join("\n")}\n`,
+      "utf8",
+    );
+    await writeFile(removals, "", "utf8");
+
+    runReaper(`int2_reap_run_containers "${before}" "${log}"`, {
+      PATH: `${fakeBin}:${process.env.PATH}`,
+      INT2_FAKE_DOCKER_LISTING: listing,
+      INT2_FAKE_DOCKER_REMOVALS: removals,
+    });
+
+    // The `-check-1` name is why this is a snapshot diff and not a list of run
+    // ids read out of the runs table: verification runs derive ids that no
+    // table holds, so a query-driven reaper would leak exactly that container.
+    expect((await readFile(removals, "utf8")).trim().split("\n")).toEqual([
+      "harness-run-63882cbb-0aa3-5b3b-8459-f11fdb09717b",
+      "harness-run-11111111-2222-3333-4444-555555555555-check-1",
+    ]);
+    expect(await readFile(log, "utf8")).not.toContain("docker-lifecycle");
+  });
+
+  it("removes nothing at all when it never got to take a snapshot", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-nosnapshot-"));
+    temporaryRoots.push(root);
+    const removals = path.join(root, "removed.txt");
+    const listing = path.join(root, "listing.txt");
+    const fakeBin = path.join(root, "bin");
+    await mkdir(fakeBin, { recursive: true });
+    await writeFile(
+      path.join(fakeBin, "docker"),
+      [
+        "#!/usr/bin/env bash",
+        'if [ "$1" = "ps" ]; then cat "$INT2_FAKE_DOCKER_LISTING"; exit 0; fi',
+        'if [ "$1" = "rm" ]; then',
+        '  printf "%s\\n" "$3" >> "$INT2_FAKE_DOCKER_REMOVALS"; exit 0',
+        "fi",
+        "exit 0",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await chmod(path.join(fakeBin, "docker"), 0o755);
+    await writeFile(
+      listing,
+      "harness-run-cd16137f-4a63-49f0-8820-40550904afa9\n",
+      "utf8",
+    );
+    await writeFile(removals, "", "utf8");
+
+    // Wiping every harness-run-* container because the suite died before it
+    // could look is strictly worse than leaking, so a missing snapshot is
+    // inaction, not licence.
+    runReaper(
+      `int2_reap_run_containers "${path.join(root, "absent.txt")}" /dev/null`,
+      {
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        INT2_FAKE_DOCKER_LISTING: listing,
+        INT2_FAKE_DOCKER_REMOVALS: removals,
+      },
+    );
+
+    expect(await readFile(removals, "utf8")).toBe("");
+  });
+
+  it("wires the suite to hand its workers and its snapshot to the trap", async () => {
+    const [suite, reaper, integration] = await Promise.all([
+      readFile(AUTOMATED_SUITE, "utf8"),
+      readFile(REAP_HELPER, "utf8"),
+      readFile(
+        path.join(ROOT, "test/integration/int2-automated-suite.test.ts"),
+        "utf8",
+      ),
+    ]);
+    execFileSync("bash", ["-n", REAP_HELPER]);
+
+    // Pattern-killing is the fix that looks right and is not: an operator's
+    // ceremony worker matches "harness worker" just as well as the suite's.
+    // Comments are stripped first — both files discuss `pkill` at length, and
+    // an assertion that forbids naming the trap is an assertion that will be
+    // deleted rather than satisfied.
+    const withoutComments = (source: string): string =>
+      source
+        .split("\n")
+        .filter((line) => !line.trimStart().startsWith("#"))
+        .join("\n");
+    for (const source of [suite, reaper]) {
+      expect(withoutComments(source)).not.toContain("pkill");
+      expect(withoutComments(source)).not.toMatch(
+        /pgrep -f ["']?harness worker/u,
+      );
+    }
+
+    expect(suite).toContain("lib/int2-reap.sh");
+    expect(suite).toContain("int2_reap_workers");
+    expect(suite).toContain("int2_reap_run_containers");
+    expect(suite).toContain("export INT2_SUITE_WORKER_PIDFILE=");
+
+    // The snapshot has to be the last thing before the cases: it defines
+    // "during the run", and every container born after it is the suite's.
+    const snapshotAt = suite.indexOf("int2_reap_snapshot_run_containers ");
+    expect(snapshotAt).toBeGreaterThan(-1);
+    expect(snapshotAt).toBeLessThan(suite.indexOf("INT2_CASES_STARTED"));
+    expect(snapshotAt).toBeGreaterThan(suite.indexOf("npx vitest run") === -1
+      ? -1
+      : suite.indexOf("INT2_PILOT_GIT_OWNERSHIP_VERIFIED"));
+
+    // A worker whose pid never reached the pidfile is a worker the trap cannot
+    // reap, so recording must not be able to slip behind an await.
+    expect(integration).toContain("detached: true");
+    expect(integration).toContain("recordWorkerPid(child.pid)");
+    expect(integration).toContain("appendFileSync(pidfile");
+    expect(integration).toContain('"SIGKILL"');
   });
 });


### PR DESCRIPTION
The suite's EXIT trap removed its temp root and its two Postgres containers and stopped there. Two things outlived it:

- A Harness worker survived with **PPID 1 for nearly three days**, its command line still pointing at a temp root the same trap had already deleted. It was found by the §3 ceremony's "assert no worker is already running" preflight, which it blocked, during a live paid run.
- `harness-run-*` containers accumulated one per failed run. The Docker environment tier names them durably and starts them without `--rm` on purpose, so a crashed run stays inspectable; nothing then removed them.

The trap now reaps both, from a new `scripts/ceremony/lib/int2-reap.sh` kept separate so the fast unit suite can drive it with fake workers and a fake `docker`, no databases or Docker required.

## The safety property

Workers are reaped by **recorded PID, never by pattern**. `pkill -f "harness worker"` would kill an operator's own ceremony worker — the very process this leak was obstructing.

Tracking PIDs is not on its own enough: a PID recorded earlier may have been recycled onto something unrelated by the time cleanup runs. So every PID is re-identified against this run's own `$HARNESS_BIN` in the instant before it is signalled.

**The evidence for that is that I broke it.** Stubbing out the identity re-check and re-running the decoy test kills the unrelated worker; the committed version spares it. That is what makes the check load-bearing rather than decorative — the code alone doesn't demonstrate it, and a reviewer has no reason to believe it without the mutation.

## Three things that look like details and are not

**`/private` normalization.** macOS `mktemp` hands back `/var/folders/...` while `ps` reports the same path as `/private/var/folders/...`. Without normalizing both sides the identity check never matches, and the reaper silently reaps nothing — **a check that cannot fire**, the exact class this repo has spent the week removing. Both sides pass through unchanged on Linux.

**Substring, not prefix.** The kernel rewrites the console script's shebang, so a live worker's real command line is `<python> <harness> worker`, not `<harness> worker`. A prefix test matches neither shape reliably.

**Why the container reaper is a snapshot diff and not a query.** Every reviewer reaches for `select run_id from runs` first — I did too, and it is wrong. Only top-level runs get a `runs` row. Child and verification runs derive their own ids (`uuid5` of the parent, and `<child>-check-<cycle>`), so a query-driven reaper leaks **exactly the containers it exists to catch**. The committed test asserts a `harness-run-...-check-1` name is removed, which is what stops the approach being re-introduced.

A missing snapshot removes nothing at all. Wiping every `harness-run-*` container because the suite died before it could look is the one outcome worse than leaking.

## Test side

Each worker appends its PID synchronously the instant it exists — before it is known healthy, so a worker that never reports ready still gets reaped. Workers spawn `detached`, so the trap's signal to `-pid` takes anything the worker spawned. `stop()` escalates to SIGKILL instead of throwing with the process still running. `afterAll` stops all workers via `allSettled`; the sequential `await` it replaces abandoned the rest of the set on the first throw, leaking every worker behind a stuck one.

## Proof

Three full suite runs, plus 6 unit tests, plus typecheck and the full fast suite (2045 passed).

- **The reported failure mode, reproduced directly.** SIGKILLing the vitest pool worker with a Harness worker live orphaned it onto PPID 1 — the exact state the three-day-old orphan was found in. The trap logged `INT2_WORKER_REAPED pid=29800 signal=TERM` and reaped it.
- **An unrelated worker survives.** A decoy `harness worker` rooted under `harness-int2-ceremony.*`, with **its PID injected into the suite's own pidfile** on all three runs, survived every cleanup.
- **Zero leftovers.** `harness-run-*` count held at 13 → 13 across all runs; no suite database container, temp root, or stray worker remained.

A clean run reaps nothing, because the tests shut down cleanly and the kernel destroys its own containers on the happy path. That run shows the reaper is harmless; the crash run is what shows it works.

## Scoped out, deliberately

- **The HALT case is a genuine tie**, not a regression here: `HALT_COMMAND = "sleep 30"` against the kernel's `_SHELL_TIMEOUT_SECONDS = 30`. Run 1 lost it by ~10ms (`duration_seconds: 30.0099`, `ok: true`) on identical code that passed twice after; the handback's own reference record is `30.0585` with `command_timeout`. This also explains a HALT failure recorded as unexplained during the #583 gate. `sleep 45` is the fix, in its own PR.
- **`harness-run-docker-lifecycle-*` is not this suite's.** That string exists only at `agent-harness/tests/test_environments.py:498`, against `docker.py:41`. This suite runs vitest and never invokes pytest, so it cannot reap those and correctly spares them. Separate repo, separate fix.
- **`~/.agent-runtime` holds 364 orphaned workspaces / 240 MB.** Same leak family, outside the processes-and-containers scope. Filed separately.

The 13 pre-existing containers are deliberately untouched — the fix is not retroactive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)