### PR TITLE
The Buzz relay must publish no host port

### DIFF
--- a/docs/BUZZ_DEPLOYMENT_PLAN.md
+++ b/docs/BUZZ_DEPLOYMENT_PLAN.md
@@ -135,10 +135,20 @@ handing that judgement to a message bus re-opens a fixed bug.
 
 ## Phasing
 
-**P1 — stand it up, empty.** Compose bundle on the VPS, pinned image, behind the
-existing edge on 3000, `BUZZ_AUTO_MIGRATE=true` for the first boot. Verify
-`/_liveness`. Nothing integrated. Confirms capacity and networking before any
-code depends on it.
+**P1 — stand it up, empty.** Compose bundle on the VPS, pinned image, reached
+only through the tunnel, `BUZZ_AUTO_MIGRATE=true` for the first boot. Nothing
+integrated. Confirms capacity and networking before any code depends on it.
+
+The relay publishes NO host port, so verify from inside its network:
+
+```bash
+docker run --rm --network buzz_buzz-net curlimages/curl -fsS http://relay:3000/_liveness
+curl -fsS https://buzz.averray.com/_liveness      # and through the tunnel
+```
+
+Run them separately: the first proves the relay booted, the second proves the
+tunnel route and the shared-network attachment. First passes and second does
+not → the fault is networking, not Buzz.
 
 **P2 — the bot can speak.** Bot keypair, signing client in slack-operator,
 publish one hand-triggered test message. Proves the whole path with no

--- a/ops/buzz/compose.averray.yml
+++ b/ops/buzz/compose.averray.yml
@@ -22,10 +22,15 @@
 # is. Cloudflare creates that DNS itself as a CNAME to cfargotunnel.com — no
 # hand-made A record, and none should be left lying around.
 #
-# The host port is kept but bound to LOOPBACK only: enough for
-# `curl 127.0.0.1:3000/_liveness` from the box, with no public listener. The
-# upstream bundle binds 0.0.0.0, which on a box with no firewall in front would
-# expose the relay beside the tunnel it is supposed to arrive through.
+# NO host port at all. The upstream bundle binds 0.0.0.0:3000, which on a box
+# whose entire exposure model is "no open ports" quietly undoes that model — and
+# the tunnel never needed it, since it dials the container over the network.
+#
+# A first pass kept it on loopback for `curl 127.0.0.1:3000/_liveness`
+# convenience. That collided on the first start: something already holds :3000
+# on this host (hermes-workspace, which this same tunnel serves as
+# command.averray.com), and the relay refused to start. Convenience was not
+# worth a port collision, nor the contradiction with the paragraph above.
 #
 # ── BLAST RADIUS ────────────────────────────────────────────────────────────
 # 22 GiB total with ~19 available, so these ceilings are not about scarcity.
@@ -38,10 +43,9 @@
 # raise reflexively.
 services:
   relay:
-    # `!override` replaces the upstream list instead of appending to it —
+    # `!reset` removes the upstream list rather than appending to it —
     # compose ≥ 2.24.4, which this bundle already requires.
-    ports: !override
-      - "127.0.0.1:${BUZZ_HTTP_PORT:-3000}:3000"
+    ports: !reset null
     networks:
       - buzz-net
       - avg-internal


### PR DESCRIPTION
Follow-up to #626, which merged just before this fix was pushed. **The first start failed on the state currently on main:**

```
Bind for 127.0.0.1:3000 failed: port is already allocated
```

`hermes-workspace` already holds `:3000` — the service this same tunnel publishes as `command.averray.com`.

## The binding should never have been there

This VPS's exposure model is *"no open inbound ports, everything arrives through the tunnel"*, and the tunnel dials the relay over the Docker network. The host port bought nothing except a shorter liveness curl.

The header comment in that very file argues for that model **two paragraphs above the line that broke it**. The collision just made the contradiction visible on the first try.

## Fix

`ports: !reset null`, and liveness moves inside the network:

```bash
docker run --rm --network buzz_buzz-net curlimages/curl -fsS http://relay:3000/_liveness
```

That's the better check regardless — it exercises **the same name resolution the tunnel depends on**, where a loopback curl would still pass even if the `avg_avg-internal` attachment were broken.

## Everything else was clean

On that first attempt: postgres, redis and minio all `Healthy`, `minio-init` exited `0`. Only the relay bounced, and only on the port.