### PR TITLE
Two stacks both call a service postgres — untangle the namespaces

### DIFF
--- a/ops/buzz/compose.averray.yml
+++ b/ops/buzz/compose.averray.yml
@@ -17,10 +17,24 @@
 # will not proxy to port 3000 anyway; its origin ports are 80/8080/8880/2052…
 # and 443/2053/2083/8443.
 #
-# So the relay joins the tunnel's network and is published as a tunnel public
-# hostname (`buzz.averray.com` → `http://relay:3000`), exactly as the monitor
-# is. Cloudflare creates that DNS itself as a CNAME to cfargotunnel.com — no
-# hand-made A record, and none should be left lying around.
+# So `buzz.averray.com` is a tunnel published route to `http://relay:3000`,
+# exactly as the monitor is. Cloudflare creates that DNS itself as a CNAME to
+# cfargotunnel.com — no hand-made A record, and none should be left lying around.
+#
+# The tunnel joins BUZZ's network, not the other way round. The first cut had it
+# backwards — the relay was attached to avg-internal so cloudflared could see it,
+# and that broke the relay outright:
+#
+#   Failed to connect to Postgres: password authentication failed for user "buzz"
+#
+# The avg stack has its own `postgres` service. With the relay on both networks,
+# `postgres` in DATABASE_URL resolved to avg-postgres-1 instead of buzz's own,
+# where the `buzz` role does not exist. A container on buzz-net ALONE connected
+# with the identical URL — which is what finally located it.
+#
+# Joining two stacks' namespaces makes every generic service name a coin flip.
+# So Buzz keeps its namespace to itself, and cloudflared gains one network where
+# the only name it needs is `relay` (see ops/compose.cloudflare-access.yml).
 #
 # NO host port at all. The upstream bundle binds 0.0.0.0:3000, which on a box
 # whose entire exposure model is "no open ports" quietly undoes that model — and
@@ -46,9 +60,6 @@ services:
     # `!reset` removes the upstream list rather than appending to it —
     # compose ≥ 2.24.4, which this bundle already requires.
     ports: !reset null
-    networks:
-      - buzz-net
-      - avg-internal
     mem_limit: 1g
     restart: unless-stopped
 
@@ -65,10 +76,3 @@ services:
     # revisiting. Revisit it with evidence.
     mem_limit: 512m
     restart: unless-stopped
-
-networks:
-  # Created by the `avg` compose project; Docker prefixes the project name.
-  # Verify with `docker network ls | grep avg` before first start.
-  avg-internal:
-    external: true
-    name: avg_avg-internal

--- a/ops/compose.cloudflare-access.yml
+++ b/ops/compose.cloudflare-access.yml
@@ -22,4 +22,21 @@ services:
       hermes-workspace:
         condition: service_started
     command: ["tunnel", "--no-autoupdate", "run", "--token", "${CLOUDFLARED_TUNNEL_TOKEN:?Set CLOUDFLARED_TUNNEL_TOKEN in .env.prod}"]
-    networks: [avg-internal]
+    # buzz-net carries the Buzz relay, published as buzz.averray.com. The tunnel
+    # reaches INTO that stack rather than the relay reaching out into this one:
+    # both stacks run a service called `postgres`, so a container on both
+    # networks resolves that name unpredictably — which is exactly how the relay
+    # ended up authenticating against avg-postgres-1 and failing.
+    #
+    # cloudflared needs only one name from Buzz (`relay`), and buzz-net holds
+    # nothing that shadows a name cloudflared already uses, so the asymmetry is
+    # safe in this direction and not in the other.
+    networks: [avg-internal, buzz-net]
+
+networks:
+  # Created by the `buzz` compose project (deploy/compose + ops/buzz overrides).
+  # Optional-by-profile: this overlay only runs under the command-center profile,
+  # and the network must already exist when it does.
+  buzz-net:
+    external: true
+    name: buzz_buzz-net


### PR DESCRIPTION
The Buzz relay would not start:

```
Failed to connect to Postgres: password authentication failed for user "buzz"
```

## Every obvious explanation was wrong

Each was **disproved by a test**, not argued away:

| hypothesis | result |
|---|---|
| credential is wrong | `psql` over TCP with it → **works** |
| network path blocked | another container → host `postgres` → **works** |
| connection string truncated | 91 chars, exactly as expected |
| the relay's own URL is bad | taken verbatim from `docker inspect`, used by a different container → **works** |
| startup race | clean `--force-recreate` → **fails identically** |

## What it actually was

The only difference between the container that worked and the one that didn't was **which networks it was on**.

My override attached the relay to `avg-internal` so cloudflared could resolve it. **The `avg` stack has its own `postgres` service.** With the relay on both networks, `postgres` in `DATABASE_URL` resolved to `avg-postgres-1` — where the `buzz` role doesn't exist. The test container sat on `buzz-net` alone, so it resolved correctly.

Same URL. Different neighbours.

Joining two stacks' namespaces turns every generic service name into a coin flip, and `postgres` is as generic as they come.

## Fix: reverse the direction

**cloudflared joins `buzz-net`**, instead of the relay joining `avg-internal`.

The tunnel needs exactly one name from Buzz (`relay`), and `buzz-net` holds nothing that shadows a name cloudflared already uses — so the asymmetry is safe this way and not the other. Buzz keeps its namespace to itself.

## Deploy note

Recreating cloudflared briefly interrupts `monitor.averray.com` and `command.averray.com`. Both return with the tunnel — worth knowing before running it rather than after.