### PR TITLE
The compose project is buzz-prod, not buzz

### DIFF
--- a/ops/buzz/compose.averray.yml
+++ b/ops/buzz/compose.averray.yml
@@ -1,7 +1,16 @@
 # Averray's overrides on top of the upstream Buzz deploy/compose bundle.
 #
+#   cd /srv/buzz/deploy/compose
 #   docker compose -f compose.yml \
 #     -f /srv/averray-reference-agent/ops/buzz/compose.averray.yml up -d
+#
+# ALWAYS that exact form — never upstream's ./run.sh. compose.yml line 1 declares
+# `name: buzz-prod`, but run.sh passes `-p buzz` and overrides it. Mixing the two
+# does not reconfigure one stack, it builds a SECOND one: a `./run.sh start`
+# followed by a plain `docker compose up -d` left `buzz` AND `buzz-prod` running
+# side by side, with separate networks and separate database volumes. The old
+# containers keep their old logs, which is a good way to read a stale failure and
+# think a fix did not work.
 #
 # Two jobs: reach the relay through the existing Cloudflare Tunnel, and stop a
 # Buzz problem from killing the money monitor.

--- a/ops/compose.cloudflare-access.yml
+++ b/ops/compose.cloudflare-access.yml
@@ -34,9 +34,16 @@ services:
     networks: [avg-internal, buzz-net]
 
 networks:
-  # Created by the `buzz` compose project (deploy/compose + ops/buzz overrides).
+  # Created by the Buzz compose project. The project is `buzz-prod`, NOT `buzz` —
+  # upstream's compose.yml declares `name: buzz-prod` on line 1, so every Docker
+  # object is prefixed with that. The first stand-up used upstream's ./run.sh,
+  # which passes `-p buzz` and overrides it, producing a `buzz`-prefixed stack
+  # that a later plain `docker compose -f compose.yml -f <override>` did not
+  # reuse — it built a SECOND, parallel stack instead. Hence: always invoke Buzz
+  # with the plain form (see ops/buzz/compose.averray.yml), never run.sh.
+  #
   # Optional-by-profile: this overlay only runs under the command-center profile,
   # and the network must already exist when it does.
   buzz-net:
     external: true
-    name: buzz_buzz-net
+    name: buzz-prod_buzz-net


### PR DESCRIPTION
#632 attached cloudflared to `buzz_buzz-net`. That network exists — but it belongs to a stack that shouldn't.

## Two stacks, silently

Upstream's `compose.yml` declares `name: buzz-prod` on line 1. Upstream's `./run.sh` passes `-p buzz`, overriding it.

The first stand-up used `run.sh`. A later plain `docker compose -f compose.yml -f <override> up -d` therefore **did not reconfigure that stack — it created a second one**, with its own network, volumes, and containers. Both running:

```
buzz         restarting(1), running(3)
buzz-prod    running(4)
```

## Why this is worth more than a name fix

It presented as a fix that didn't work:

```
✔ Network buzz-prod_buzz-net   Created
✔ Container buzz-prod-relay-1  Started
```
```
$ docker logs --tail 20 buzz-relay-1
ERROR Failed to connect to Postgres: password authentication failed for user "buzz"
```

Same error, apparently after the fix. But that's the **old** container — the new one is `buzz-prod-relay-1`. The tell was the timestamps: four minutes of once-a-minute restarts in a container started eight seconds earlier.

`buzz-prod-relay-1` was healthy the whole time:

```
git object-store backend admitted: A3 conformance probe passed
buzz-relay TCP listening  addr: 0.0.0.0:3000
NIP-43 membership list published  member_count: 1
```

## Changes

- tunnel pins `buzz-prod_buzz-net`
- both compose headers document the exact invocation and why `run.sh` must not be mixed with it — the two forms aren't interchangeable, and the failure mode is a silent duplicate rather than an error

## Caveat on #632

The working relay differs from the broken one in **two** ways: off `avg-internal`, and a fresh Postgres volume. So this doesn't isolate which fixed the auth error.

The DNS collision stands on its own evidence — a container on both networks resolves `postgres` to `172.19.0.5`, the **avg** database, where role `buzz` doesn't exist. But a stale password on the old volume (Postgres only applies `POSTGRES_PASSWORD` when it *creates* the data directory) may have been a second cause behind it. Both are gone now; I can't claim a single-variable confirmation.

## Follow-up

The `buzz` project is redundant and should be torn down. Its volumes never took a successful connection, so they hold nothing.