### PR TITLE
NIP-OA owner attestation — let Hermes speak without holding the key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5277,6 +5277,7 @@
         "@avg/averray-mcp": "0.1.0",
         "@avg/mcp-common": "0.1.0",
         "@avg/schemas": "0.1.0",
+        "@noble/curves": "^1.9.1",
         "zod": "^3.24.1"
       }
     },

--- a/scripts/ops/mint-buzz-agent-auth.ts
+++ b/scripts/ops/mint-buzz-agent-auth.ts
@@ -1,0 +1,148 @@
+#!/usr/bin/env npx tsx
+//
+// Mint Hermes's Buzz credentials: a fresh agent keypair plus a NIP-OA `auth`
+// tag proving the operator authorized it.
+//
+//   npx tsx scripts/ops/mint-buzz-agent-auth.ts
+//
+// RUN THIS ON YOUR OWN MACHINE, NEVER ON THE VPS. It needs the owner secret
+// key, and the entire point of NIP-OA here is that the owner secret never
+// reaches the server — only the signature it produces does. Running it on the
+// box would put the key in that box's shell history, process table, and any
+// scrollback, which is precisely the exposure the design avoids.
+//
+// The owner secret is read from stdin with terminal echo OFF. It is never taken
+// as an argv value (argv is world-readable via `ps` and lands in shell history),
+// never logged, and never written to disk.
+//
+// See services/slack-operator/src/nip-oa.ts for what the tag can and cannot do —
+// in particular, the expiry is NOT enforced by the relay.
+
+import { createInterface } from "node:readline";
+import { randomBytes } from "node:crypto";
+import { bech32 } from "@scure/base";
+import { schnorr } from "@noble/curves/secp256k1";
+
+import {
+  computeAuthTag,
+  expiringConditions,
+  verifyAuthTag,
+} from "../../services/slack-operator/src/nip-oa.js";
+
+const DEFAULT_VALID_DAYS = 365;
+
+/** Accept either a bech32 `nsec1…` or raw 64-char hex. */
+function normalizeSecret(raw: string): string {
+  const trimmed = raw.trim();
+  if (/^[0-9a-f]{64}$/i.test(trimmed)) return trimmed.toLowerCase();
+  if (trimmed.startsWith("nsec1")) {
+    const { prefix, words } = bech32.decode(trimmed as `nsec1${string}`, 200);
+    if (prefix !== "nsec") throw new Error(`expected an nsec key, got prefix "${prefix}"`);
+    return Buffer.from(bech32.fromWords(words)).toString("hex");
+  }
+  if (trimmed.startsWith("npub1")) {
+    throw new Error("that is an npub (public key) — minting needs the nsec (secret key)");
+  }
+  throw new Error("expected an nsec1… key or 64-character hex");
+}
+
+function toNpub(pubkeyHex: string): string {
+  return bech32.encode("npub", bech32.toWords(Buffer.from(pubkeyHex, "hex")), 200);
+}
+
+/** Read one line with echo disabled so the secret never appears on screen. */
+async function readSecret(prompt: string): Promise<string> {
+  const input = process.stdin;
+  const wasRaw = input.isTTY ? input.isRaw : false;
+  process.stdout.write(prompt);
+  if (input.isTTY) input.setRawMode?.(true);
+
+  const rl = createInterface({ input, terminal: true });
+  try {
+    const line = await new Promise<string>((resolve, reject) => {
+      let buffer = "";
+      const ETX = 3; // Ctrl-C
+      const EOT = 4; // Ctrl-D
+      const BACKSPACE = 8;
+      const DELETE = 127;
+      const onData = (chunk: Buffer) => {
+        for (const code of chunk) {
+          if (code === 13 || code === 10) {
+            input.off("data", onData);
+            resolve(buffer);
+            return;
+          }
+          // Abort paths still have to restore the terminal, which is why the
+          // reset lives in the finally block below and not here.
+          if (code === ETX || code === EOT) {
+            input.off("data", onData);
+            reject(new Error("aborted"));
+            return;
+          }
+          if (code === BACKSPACE || code === DELETE) {
+            buffer = buffer.slice(0, -1);
+            continue;
+          }
+          buffer += String.fromCharCode(code);
+        }
+      };
+      input.on("data", onData);
+    });
+    return line;
+  } finally {
+    if (input.isTTY) input.setRawMode?.(wasRaw);
+    rl.close();
+    process.stdout.write("\n");
+  }
+}
+
+async function main(): Promise<void> {
+  const days = Number(process.env.BUZZ_AUTH_VALID_DAYS ?? DEFAULT_VALID_DAYS);
+  if (!Number.isFinite(days) || days <= 0) {
+    throw new Error(`BUZZ_AUTH_VALID_DAYS must be a positive number, got ${process.env.BUZZ_AUTH_VALID_DAYS}`);
+  }
+
+  console.log("Minting Buzz agent credentials for Hermes.\n");
+  console.log("  The owner secret is used once, in memory, to sign one capability.");
+  console.log("  It is not stored, not logged, and not deployed anywhere.\n");
+
+  const ownerSecret = normalizeSecret(await readSecret("Owner nsec (input hidden): "));
+
+  // Fresh agent identity. Distinct from the owner key by construction, so
+  // narration is attributable to Hermes and a leak of it cannot touch the owner.
+  const agentSecret = Buffer.from(randomBytes(32)).toString("hex");
+  const agentPubkey = Buffer.from(schnorr.getPublicKey(agentSecret)).toString("hex");
+  const ownerPubkey = Buffer.from(schnorr.getPublicKey(ownerSecret)).toString("hex");
+
+  const expiresAt = Math.floor(Date.now() / 1000) + Math.round(days * 86400);
+  const conditions = expiringConditions(expiresAt);
+  const authTag = computeAuthTag({ ownerSecretKeyHex: ownerSecret, agentPubkeyHex: agentPubkey, conditions });
+
+  // Verify before printing. A tag that does not verify locally will not verify
+  // at the relay either, and finding that out here beats finding it out as an
+  // auth failure that looks like a bad key.
+  const provenOwner = verifyAuthTag(authTag, agentPubkey);
+  if (provenOwner !== ownerPubkey) {
+    throw new Error("minted tag verified to a different owner — refusing to emit it");
+  }
+
+  console.log("Verified locally: the tag proves this owner authorized this agent.\n");
+  console.log(`  owner npub    ${toNpub(ownerPubkey)}`);
+  console.log(`  agent npub    ${toNpub(agentPubkey)}`);
+  console.log(`  capability    expires ${new Date(expiresAt * 1000).toISOString()} (${days}d)`);
+  console.log(`                NOT enforced by the relay — see nip-oa.ts. Rotation is the real control.\n`);
+  console.log("Add to .env.prod on the VPS (both lines), then redeploy slack-operator:\n");
+  console.log(`BUZZ_AGENT_SECRET_KEY=${agentSecret}`);
+  console.log(`BUZZ_OWNER_AUTH_TAG=${authTag}`);
+  console.log("\nPaste the tag line EXACTLY as printed. It is a JSON array, so it carries");
+  console.log("quotes and commas: do not wrap it in outer quotes, and do not let an editor");
+  console.log("reflow it onto two lines. A stray wrapping quote is tolerated by the reader;");
+  console.log("a line break is not, and produces a parse error rather than a warning.\n");
+  console.log("BUZZ_AGENT_SECRET_KEY is a credential: store it in 1Password alongside the");
+  console.log("other production secrets. Anyone holding it can post as Hermes.");
+}
+
+main().catch((error: unknown) => {
+  console.error(`\n${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/services/slack-operator/package.json
+++ b/services/slack-operator/package.json
@@ -13,6 +13,7 @@
     "@avg/averray-mcp": "0.1.0",
     "@avg/mcp-common": "0.1.0",
     "@avg/schemas": "0.1.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "@noble/curves": "^1.9.1"
   }
 }

--- a/services/slack-operator/src/nip-oa.ts
+++ b/services/slack-operator/src/nip-oa.ts
@@ -1,0 +1,247 @@
+// NIP-OA — Owner Attestation. The credential that lets Hermes speak on Buzz
+// without the monitor ever holding the operator's key.
+//
+// WHY THIS EXISTS: buzz.averray.com runs closed —
+// `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true` with a single member, the operator. A bot
+// that just connects and posts is rejected. NIP-OA is the relay's answer: an
+// agent presents a tag proving its OWNER is a member, and gets session-scoped
+// access on that basis (`BUZZ_ALLOW_NIP_OA_AUTH=true`).
+//
+// The property that makes this worth implementing rather than working around:
+// the owner signs ONCE, offline. The spec calls the tag "a reusable capability:
+// the same tag MAY appear on multiple events by the same agent key". So the
+// operator mints a tag on their own machine and we deploy the resulting
+// SIGNATURE. The owner secret never reaches the VPS, never enters an env file,
+// and is not what an attacker gets by reading `.env.prod`.
+//
+// Authorship stays honest, which is the other reason not to fake this with a
+// shared key: `event.pubkey` remains the agent's. The spec is explicit that
+// relays "MUST NOT rewrite event authorship" and clients "MUST NOT display the
+// owner key as the author". Narration reads as Hermes speaking with the
+// operator's authorization — never as the operator.
+//
+// ── WHAT THE CONDITIONS DO NOT DO ──────────────────────────────────────────
+// Read this before treating `created_at<…` as an expiry.
+//
+// The relay's verifier is `verify_auth_tag(auth_tag_json, agent_pubkey)` — it
+// takes the tag and the agent key and NO EVENT. It validates the conditions
+// SYNTACTICALLY and checks the signature over the preimage. It never evaluates
+// a clause against an event. On Buzz's membership path the conditions are part
+// of the signed string and nothing more.
+//
+// So a `created_at<` clause is not enforced by this relay at all. The spec is
+// separately clear that even a compliant verifier gets little from it: the
+// clause "constrains the event's self-declared created_at field, which the agent
+// controls", so "a misbehaving agent can backdate". It bounds an honest agent.
+//
+// The real control is bot-key hygiene: if the agent key leaks, rotate the agent
+// key — there is no revocation. "Owners MAY revoke future authorization by
+// refusing to issue new auth tags" is the whole revocation story. We still set
+// an expiry, because a capability with a stated lifetime is easier to reason
+// about than one without, but nothing here should be sold as enforcement.
+//
+// Reference: docs/nips/NIP-OA.md and crates/buzz-sdk/src/nip_oa.rs at tag
+// relay-v0.2.0 — the exact ref of the image running in production
+// (ghcr.io/block/buzz:0.2.0). Validation below mirrors that implementation
+// clause for clause, so a tag we mint and a tag the relay accepts cannot drift.
+
+import { createHash } from "node:crypto";
+import { schnorr } from "@noble/curves/secp256k1";
+
+/** Domain separator. Exact bytes — it is inside the signed preimage. */
+export const AUTH_TAG_DOMAIN = "nostr:agent-auth:";
+
+const KIND_MAX = 65535;
+const TIMESTAMP_MAX = 4294967295;
+
+export class NipOaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NipOaError";
+  }
+}
+
+/** A parsed `auth` tag. `conditions` is kept verbatim — see verifyAuthTag. */
+export interface AuthTag {
+  ownerPubkey: string;
+  conditions: string;
+  signature: string;
+}
+
+function assertLowercaseHex(value: string, length: number, label: string): void {
+  if (value.length !== length || !/^[0-9a-f]*$/.test(value)) {
+    throw new NipOaError(`${label} must be ${length} lowercase hex characters`);
+  }
+}
+
+/**
+ * Canonical base-10, mirroring `validate_canonical_decimal`. "01" and "" are
+ * rejected: the conditions string is signed verbatim, so two spellings of the
+ * same number are two different credentials, and allowing both would let a
+ * verifier and a signer disagree about what was authorized.
+ */
+function validateCanonicalDecimal(value: string, max: number, label: string): void {
+  if (value.length === 0) throw new NipOaError(`${label} value must not be empty`);
+  if (value.length > 1 && value.startsWith("0")) {
+    throw new NipOaError(`${label} value has a leading zero: ${JSON.stringify(value)}`);
+  }
+  if (!/^[0-9]+$/.test(value)) {
+    throw new NipOaError(`${label} value is not a valid decimal: ${JSON.stringify(value)}`);
+  }
+  if (Number(value) > max) {
+    throw new NipOaError(`${label} value ${value} is out of range [0, ${max}]`);
+  }
+}
+
+function validateClause(clause: string): void {
+  if (clause.startsWith("kind=")) {
+    validateCanonicalDecimal(clause.slice("kind=".length), KIND_MAX, "kind");
+  } else if (clause.startsWith("created_at<")) {
+    validateCanonicalDecimal(clause.slice("created_at<".length), TIMESTAMP_MAX, "created_at<");
+  } else if (clause.startsWith("created_at>")) {
+    validateCanonicalDecimal(clause.slice("created_at>".length), TIMESTAMP_MAX, "created_at>");
+  } else {
+    throw new NipOaError(`unsupported clause: ${JSON.stringify(clause)}`);
+  }
+}
+
+/**
+ * Validate a conditions string. Empty is valid and imposes no constraints.
+ *
+ * Splitting on "&" and rejecting empty parts is what makes a leading, trailing,
+ * or doubled "&" an error rather than a silently-ignored one — all three appear
+ * in the spec's invalid-vector list.
+ */
+export function validateConditions(conditions: string): void {
+  if (conditions.length === 0) return;
+  if (/\s/.test(conditions)) {
+    throw new NipOaError("conditions must not contain whitespace");
+  }
+  for (const clause of conditions.split("&")) {
+    if (clause.length === 0) {
+      throw new NipOaError("empty clause in conditions (leading, trailing, or doubled '&')");
+    }
+    validateClause(clause);
+  }
+}
+
+/** `nostr:agent-auth:<agent-pubkey>:<conditions>` — signed verbatim. */
+export function buildAuthPreimage(agentPubkeyHex: string, conditions: string): string {
+  return `${AUTH_TAG_DOMAIN}${agentPubkeyHex}:${conditions}`;
+}
+
+/** SHA-256 of the preimage. This 32-byte digest is the signed message. */
+export function authTagDigest(agentPubkeyHex: string, conditions: string): Uint8Array {
+  return new Uint8Array(createHash("sha256").update(buildAuthPreimage(agentPubkeyHex, conditions)).digest());
+}
+
+/**
+ * Mint an `auth` tag. THIS TAKES THE OWNER SECRET KEY — it runs on the
+ * operator's machine, never on a server. The deployable output is the returned
+ * JSON string.
+ */
+export function computeAuthTag(input: {
+  ownerSecretKeyHex: string;
+  agentPubkeyHex: string;
+  conditions: string;
+}): string {
+  assertLowercaseHex(input.ownerSecretKeyHex, 64, "owner secret key");
+  assertLowercaseHex(input.agentPubkeyHex, 64, "agent pubkey");
+  validateConditions(input.conditions);
+
+  const ownerPubkey = Buffer.from(schnorr.getPublicKey(input.ownerSecretKeyHex)).toString("hex");
+  // Self-attestation proves nothing — an agent asserting its own authority.
+  if (ownerPubkey === input.agentPubkeyHex) {
+    throw new NipOaError("owner and agent pubkeys must differ (self-attestation rejected)");
+  }
+
+  const digest = authTagDigest(input.agentPubkeyHex, input.conditions);
+  const signature = Buffer.from(schnorr.sign(digest, input.ownerSecretKeyHex)).toString("hex");
+  return JSON.stringify(["auth", ownerPubkey, input.conditions, signature]);
+}
+
+/**
+ * Verify an `auth` tag against the agent key that will author events with it.
+ * Returns the owner pubkey on success; throws otherwise.
+ *
+ * Deliberately mirrors the relay: no event is taken, and conditions are checked
+ * for FORM only. See the header — this function cannot tell you a tag has
+ * expired, because nothing in this protocol path can.
+ */
+export function verifyAuthTag(authTagJson: string, agentPubkeyHex: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(authTagJson);
+  } catch {
+    throw new NipOaError("auth tag is not valid JSON");
+  }
+  if (!Array.isArray(parsed)) throw new NipOaError("auth tag must be a JSON array");
+  if (parsed.length !== 4) {
+    throw new NipOaError(`auth tag must have 4 elements, got ${parsed.length}`);
+  }
+  if (!parsed.every((element): element is string => typeof element === "string")) {
+    throw new NipOaError("every auth tag element must be a string");
+  }
+  const [label, ownerPubkey, conditions, signature] = parsed;
+  if (label !== "auth") {
+    throw new NipOaError(`first element must be "auth", got ${JSON.stringify(label)}`);
+  }
+  assertLowercaseHex(ownerPubkey, 64, "owner pubkey");
+  assertLowercaseHex(signature, 128, "signature");
+  assertLowercaseHex(agentPubkeyHex, 64, "agent pubkey");
+  validateConditions(conditions);
+  if (ownerPubkey === agentPubkeyHex) {
+    throw new NipOaError("owner and agent pubkeys must differ (self-attestation rejected)");
+  }
+
+  // The conditions string from the tag is used EXACTLY as it appears. The spec
+  // forbids reordering, deduplicating, or canonicalizing it before hashing —
+  // any of those would compute a different preimage and reject a valid tag.
+  const digest = authTagDigest(agentPubkeyHex, conditions);
+  if (!schnorr.verify(signature, digest, ownerPubkey)) {
+    throw new NipOaError("signature verification failed");
+  }
+  return ownerPubkey;
+}
+
+/**
+ * Structural check with no crypto — the cheap startup path, so a malformed tag
+ * in config fails at boot with a clear message instead of at the first attempt
+ * to speak.
+ */
+export function parseAuthTag(authTagJson: string): AuthTag {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(authTagJson);
+  } catch {
+    throw new NipOaError("auth tag is not valid JSON");
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 4) {
+    throw new NipOaError("auth tag must be a JSON array of 4 elements");
+  }
+  const [label, ownerPubkey, conditions, signature] = parsed as unknown[];
+  if (label !== "auth") throw new NipOaError('first element must be "auth"');
+  if (typeof ownerPubkey !== "string" || typeof conditions !== "string" || typeof signature !== "string") {
+    throw new NipOaError("owner pubkey, conditions, and signature must be strings");
+  }
+  assertLowercaseHex(ownerPubkey, 64, "owner pubkey");
+  assertLowercaseHex(signature, 128, "signature");
+  validateConditions(conditions);
+  return { ownerPubkey, conditions, signature };
+}
+
+/**
+ * Conditions for a capability that stops being claimable after `expiresAt`.
+ *
+ * No `kind=` clause, on purpose. The same tag rides on the NIP-42 AUTH event
+ * (kind 22242) AND on the kind-9 messages it authorizes; a `kind=9` clause would
+ * make the tag formally invalid on the AUTH event for any verifier stricter than
+ * today's relay. It also buys nothing real — a clause constrains provenance
+ * claims, never what the agent is able to publish.
+ */
+export function expiringConditions(expiresAtUnixSeconds: number): string {
+  if (!Number.isInteger(expiresAtUnixSeconds) || expiresAtUnixSeconds < 0 || expiresAtUnixSeconds > TIMESTAMP_MAX) {
+    throw new NipOaError(`expiry must be an integer in [0, ${TIMESTAMP_MAX}]`);
+  }
+  return `created_at<${expiresAtUnixSeconds}`;
+}

--- a/test/unit/nip-oa.test.ts
+++ b/test/unit/nip-oa.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTH_TAG_DOMAIN,
+  NipOaError,
+  authTagDigest,
+  buildAuthPreimage,
+  computeAuthTag,
+  expiringConditions,
+  parseAuthTag,
+  validateConditions,
+  verifyAuthTag,
+} from "../../services/slack-operator/src/nip-oa.js";
+
+// Vectors copied verbatim from docs/nips/NIP-OA.md at tag relay-v0.2.0 — the ref
+// of the image running in production. They are the reason this module can be
+// trusted before anything is deployed: the preimage and digest are fully
+// deterministic, so the byte-level construction is PROVEN rather than plausible.
+// Getting the domain separator or the colon placement subtly wrong produces a
+// tag that fails at the relay with an auth error indistinguishable from a bad
+// key — which is exactly the debugging session these tests exist to prevent.
+const OWNER_PUBKEY = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const OWNER_SECRET = "0000000000000000000000000000000000000000000000000000000000000001";
+const AGENT_PUBKEY = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+const AGENT_SECRET = "0000000000000000000000000000000000000000000000000000000000000002";
+const CONDITIONS = "kind=1&created_at<1713957000";
+const SPEC_DIGEST = "08cdecd55af4c28d3801fd69615dcf5cc04fab3bc134b38a840bf157197069a6";
+const SPEC_SIG =
+  "8b7df2575caf0a108374f8471722b233c53f9ff827a8b0f91861966c3b9dd5cb2e189eae9f49d72187674c2f5bd244145e10ff86c9f257ffe65a1ee5f108b369";
+const SPEC_TAG = JSON.stringify(["auth", OWNER_PUBKEY, CONDITIONS, SPEC_SIG]);
+
+const hex = (bytes: Uint8Array) => Buffer.from(bytes).toString("hex");
+
+describe("NIP-OA spec vectors", () => {
+  it("builds the exact preimage from the spec", () => {
+    expect(buildAuthPreimage(AGENT_PUBKEY, CONDITIONS)).toBe(
+      `${AUTH_TAG_DOMAIN}${AGENT_PUBKEY}:${CONDITIONS}`,
+    );
+    expect(buildAuthPreimage(AGENT_PUBKEY, CONDITIONS)).toBe(
+      "nostr:agent-auth:c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5:kind=1&created_at<1713957000",
+    );
+  });
+
+  it("hashes the preimage to the digest the spec publishes", () => {
+    expect(hex(authTagDigest(AGENT_PUBKEY, CONDITIONS))).toBe(SPEC_DIGEST);
+  });
+
+  it("accepts the spec's own signed tag", () => {
+    // Verifying a signature we did NOT produce is the strongest available check
+    // that our preimage matches the relay's — a self-consistent round trip would
+    // pass even if both sides were wrong in the same way.
+    expect(verifyAuthTag(SPEC_TAG, AGENT_PUBKEY)).toBe(OWNER_PUBKEY);
+  });
+
+  it("mints a tag that verifies (BIP-340 signing is randomized, so compare by verification)", () => {
+    const minted = computeAuthTag({
+      ownerSecretKeyHex: OWNER_SECRET,
+      agentPubkeyHex: AGENT_PUBKEY,
+      conditions: CONDITIONS,
+    });
+    const [label, owner, conditions, signature] = JSON.parse(minted) as string[];
+    expect(label).toBe("auth");
+    expect(owner).toBe(OWNER_PUBKEY);
+    expect(conditions).toBe(CONDITIONS);
+    expect(signature).toHaveLength(128);
+    expect(verifyAuthTag(minted, AGENT_PUBKEY)).toBe(OWNER_PUBKEY);
+  });
+
+  it("rejects a tag presented by an agent key it was not minted for", () => {
+    // The whole point of binding the agent key into the preimage: a stolen tag
+    // is useless to a different agent.
+    const other = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee4";
+    expect(() => verifyAuthTag(SPEC_TAG, other)).toThrow(NipOaError);
+  });
+});
+
+describe("NIP-OA invalid vectors", () => {
+  // One case per bullet in the spec's "Invalid Test Vectors" section.
+  it("rejects a tag with the wrong element count", () => {
+    expect(() => verifyAuthTag(JSON.stringify(["auth", OWNER_PUBKEY, CONDITIONS]), AGENT_PUBKEY)).toThrow(
+      /4 elements/,
+    );
+    expect(() =>
+      verifyAuthTag(JSON.stringify(["auth", OWNER_PUBKEY, CONDITIONS, SPEC_SIG, "extra"]), AGENT_PUBKEY),
+    ).toThrow(/4 elements/);
+  });
+
+  it("rejects a trailing delimiter in conditions", () => {
+    expect(() => validateConditions("kind=1&")).toThrow(/empty clause/);
+    expect(() => validateConditions("&kind=1")).toThrow(/empty clause/);
+    expect(() => validateConditions("kind=1&&kind=2")).toThrow(/empty clause/);
+  });
+
+  it("rejects a leading zero in a clause value", () => {
+    expect(() => validateConditions("kind=01")).toThrow(/leading zero/);
+    // "0" itself is canonical and must still be accepted.
+    expect(() => validateConditions("kind=0")).not.toThrow();
+  });
+
+  it("rejects self-attestation", () => {
+    expect(() =>
+      computeAuthTag({ ownerSecretKeyHex: OWNER_SECRET, agentPubkeyHex: OWNER_PUBKEY, conditions: "" }),
+    ).toThrow(/self-attestation/);
+  });
+
+  it("rejects a well-formed tag whose signature does not verify", () => {
+    const tampered = JSON.stringify(["auth", OWNER_PUBKEY, "kind=2&created_at<1713957000", SPEC_SIG]);
+    expect(() => verifyAuthTag(tampered, AGENT_PUBKEY)).toThrow(/signature verification failed/);
+  });
+
+  it("rejects whitespace and unsupported clauses", () => {
+    expect(() => validateConditions("kind=1 & kind=2")).toThrow(/whitespace/);
+    expect(() => validateConditions("expires=99")).toThrow(/unsupported clause/);
+    expect(() => validateConditions("created_at=99")).toThrow(/unsupported clause/);
+  });
+
+  it("enforces the documented value ranges", () => {
+    expect(() => validateConditions("kind=65535")).not.toThrow();
+    expect(() => validateConditions("kind=65536")).toThrow(/out of range/);
+    expect(() => validateConditions("created_at<4294967295")).not.toThrow();
+    expect(() => validateConditions("created_at<4294967296")).toThrow(/out of range/);
+  });
+
+  it("treats an empty conditions string as valid and unconstrained", () => {
+    expect(() => validateConditions("")).not.toThrow();
+    const minted = computeAuthTag({
+      ownerSecretKeyHex: OWNER_SECRET,
+      agentPubkeyHex: AGENT_PUBKEY,
+      conditions: "",
+    });
+    expect(verifyAuthTag(minted, AGENT_PUBKEY)).toBe(OWNER_PUBKEY);
+  });
+});
+
+describe("parseAuthTag", () => {
+  it("accepts a structurally valid tag without doing crypto", () => {
+    // Same shape, deliberately bogus signature: the startup path must not need
+    // the agent key to tell an operator their config is malformed.
+    const bogus = JSON.stringify(["auth", OWNER_PUBKEY, CONDITIONS, "0".repeat(128)]);
+    expect(parseAuthTag(bogus)).toEqual({
+      ownerPubkey: OWNER_PUBKEY,
+      conditions: CONDITIONS,
+      signature: "0".repeat(128),
+    });
+  });
+
+  it("rejects malformed hex lengths", () => {
+    expect(() => parseAuthTag(JSON.stringify(["auth", "abc", CONDITIONS, SPEC_SIG]))).toThrow(
+      /64 lowercase hex/,
+    );
+    expect(() => parseAuthTag(JSON.stringify(["auth", OWNER_PUBKEY, CONDITIONS, "ff"]))).toThrow(
+      /128 lowercase hex/,
+    );
+  });
+
+  it("rejects uppercase hex", () => {
+    // Nostr convention is lowercase; the relay compares hex strings, so an
+    // uppercase pubkey would fail a comparison rather than an obvious check.
+    expect(() => parseAuthTag(JSON.stringify(["auth", OWNER_PUBKEY.toUpperCase(), CONDITIONS, SPEC_SIG]))).toThrow(
+      /64 lowercase hex/,
+    );
+  });
+
+  it("rejects non-JSON and non-array input", () => {
+    expect(() => parseAuthTag("not json")).toThrow(/not valid JSON/);
+    expect(() => parseAuthTag(JSON.stringify({ auth: true }))).toThrow(/array of 4 elements/);
+  });
+});
+
+describe("expiringConditions", () => {
+  it("emits a single created_at clause and no kind clause", () => {
+    // The absence of `kind=` is deliberate — the same tag must stay valid on the
+    // kind-22242 AUTH event as well as the kind-9 messages it authorizes.
+    const conditions = expiringConditions(1913957000);
+    expect(conditions).toBe("created_at<1913957000");
+    expect(conditions).not.toContain("kind=");
+    expect(() => validateConditions(conditions)).not.toThrow();
+  });
+
+  it("produces conditions that survive a real mint/verify round trip", () => {
+    const minted = computeAuthTag({
+      ownerSecretKeyHex: AGENT_SECRET,
+      agentPubkeyHex: OWNER_PUBKEY,
+      conditions: expiringConditions(1913957000),
+    });
+    expect(verifyAuthTag(minted, OWNER_PUBKEY)).toBe(AGENT_PUBKEY);
+  });
+
+  it("rejects a non-integer or out-of-range expiry", () => {
+    expect(() => expiringConditions(1.5)).toThrow(NipOaError);
+    expect(() => expiringConditions(-1)).toThrow(NipOaError);
+    expect(() => expiringConditions(4294967296)).toThrow(NipOaError);
+  });
+});


### PR DESCRIPTION
P2 groundwork. `buzz.averray.com` runs closed — `BUZZ_REQUIRE_RELAY_MEMBERSHIP=true` with exactly one member, you. A bot that connects and posts gets rejected.

NIP-OA is the relay's own answer (`BUZZ_ALLOW_NIP_OA_AUTH=true` is already set), and it has one property worth building on:

## The owner signs once, offline

The spec: *"a reusable capability: the same tag MAY appear on multiple events by the same agent key."*

So you mint a tag on your Mac and we deploy **the signature**. Your owner secret never reaches the VPS, never enters an env file, and isn't what an attacker gets from reading `.env.prod`.

Authorship stays honest too — `event.pubkey` remains the agent's, relays *"MUST NOT rewrite event authorship"*, clients *"MUST NOT display the owner key as the author"*. Narration reads as Hermes speaking **with your authorization**, never as you.

## What the conditions do NOT do

Worth stating loudly, because `created_at<` looks like an expiry:

The relay's verifier is `verify_auth_tag(auth_tag_json, agent_pubkey)` — **it takes no event**. It validates conditions *syntactically* and checks the signature. It never evaluates a clause against an event. On Buzz's membership path the expiry **is not enforced at all**.

The spec adds that even a compliant verifier gains little, since `created_at` is *"the event's self-declared"* field *"which the agent controls."*

We still set one, because a capability with a stated lifetime is easier to reason about than one without — but it is not enforcement. **The real control is rotating the agent key**, and there's no revocation beyond declining to reissue.

Conditions carry no `kind=` clause on purpose: the same tag rides on the kind-22242 AUTH event *and* the kind-9 messages, and a kind clause would make it formally invalid on the former for any verifier stricter than today's relay.

## Tests are the spec's vectors, not round trips

The preimage and digest are deterministic, so byte-level construction is **proven**. And the suite verifies **the spec's own signature** — which this code did not produce. A self-consistent round trip would pass even with both sides wrong in the same way; this can't.

Every bullet in the spec's *Invalid Test Vectors* list gets a negative test: two `auth` tags, wrong element count, trailing `&`, leading zero, self-attestation, bad signature.

Validation mirrors `crates/buzz-sdk/src/nip_oa.rs` at tag **`relay-v0.2.0`** — the exact ref of the running image `ghcr.io/block/buzz:0.2.0` — clause for clause, so a tag we mint and a tag the relay accepts cannot drift.

## The minting script

`npx tsx scripts/ops/mint-buzz-agent-auth.ts`, run **on your Mac, never the VPS**. Reads the owner secret from stdin with echo off — never argv, which is world-readable via `ps` and lands in shell history. Verifies the tag locally before printing it, since a tag that fails here would fail at the relay as an auth error indistinguishable from a bad key.

## Verification

- 20 new tests green; full suite **1765 passed / 118 files**, no regressions
- `slack-operator` typecheck clean
- script exercised end to end with a throwaway key; owner npub round-trips to the spec's owner pubkey

Adds one declared dependency, `@noble/curves` (already present transitively — this stops us relying on someone else's tree).

Nothing is wired to the relay yet. Next slice is the WebSocket client that carries this tag in a NIP-42 AUTH event.