### PR TITLE
feat(harness): add supervised INT-3b PR actuation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,18 @@ TypeScript monorepo: npm workspaces (`packages/*`, `services/*`), Node ≥ 22, E
   `dispatch` Compose profile and `HARNESS_DISPATCH_ENABLED=false` by default.
   At concurrency one it acts only on operator-approved, hash-pinned AgentTasks,
   honors `HALT_FILE`, and cannot approve, deny, release, merge, deploy, or open
-  a PR.
+  a PR through the dispatch/reconciliation loop. INT-3a can construct a verified,
+  content-addressed PR payload but has no network client. INT-3b adds a separate,
+  operator-side sender that consumes only that result; it is not wired into the
+  agent container, dispatcher loop, production Compose profile, or a CLI. Before
+  its single PR-create call it re-reads the live base and HALT, verifies an actual
+  selected-repository GitHub App scope for exactly one repository, and adopts an
+  existing exact PR by deterministic head. It can create the verified head and
+  open a PR, but cannot merge, force-push, close, reopen, comment, edit branch
+  protection, push a default branch, or address another repository. The first
+  live send remains an explicit operator ceremony; no credential is provisioned
+  by the build. See
+  [docs/HARNESS_INT3B_CREDENTIAL_RUNBOOK.md](docs/HARNESS_INT3B_CREDENTIAL_RUNBOOK.md).
 - **Self-healing (B2, off by default).** On a failure signal (failed testbed
   mission, failed deploy/verification), Hermes auto-**proposes** a routed fix
   task (non-high-risk) — which still lands `proposed` and flows through the same
@@ -284,7 +295,15 @@ security-sensitive surface.
   move real funds, never raise policy budgets to enable spend without explicit
   operator sign-off.
 - **`HALT_FILE` is the kill switch.** Mutating MCP tools fail closed when the halt
-  file exists (`assertNoKillSwitch`). Don't add code paths that bypass it.
+  file exists (`assertNoKillSwitch`). The INT-3b sender independently re-reads
+  global/repository HALT immediately before its PR-create call. Don't add code
+  paths that bypass either check.
+- **INT-3b GitHub write stays operator-side and single-repository.** Its short-lived
+  GitHub App installation token is injected only into the operator-owned sender
+  process, never the agent/model/Compose environments or a CLI argument. Safe
+  evidence records the installation identity, selected repository, and actual
+  issued permissions but never the token. Rotation and revocation are defined in
+  [docs/HARNESS_INT3B_CREDENTIAL_RUNBOOK.md](docs/HARNESS_INT3B_CREDENTIAL_RUNBOOK.md).
 
 ---
 

--- a/docs/HARNESS_INT3B_CREDENTIAL_RUNBOOK.md
+++ b/docs/HARNESS_INT3B_CREDENTIAL_RUNBOOK.md
@@ -1,0 +1,106 @@
+# INT-3b credential and first-send runbook
+
+INT-3b is an operator-side, single-shot pull-request actuation seam. It consumes
+the content-addressed result produced by INT-3a. It is not wired into the agent
+container, the production Compose dispatch profile, a model environment, or a
+CLI. This implementation does not create, request, install, or use a real
+credential and does not perform a real send.
+
+The first target repository and the credential owner remain operator decisions.
+Do not provision a credential until the INT-3b refusal ceremony is green and the
+operator has selected both.
+
+## Required credential boundary
+
+Use a short-lived GitHub App installation access token. The app installation and
+the issued token must both be selected-repository scoped to exactly the one
+operator-approved repository. The only write permissions are:
+
+- Contents: write, to create the deterministic `harness/*` head without a force
+  push.
+- Pull requests: write, to open the PR.
+- Metadata: read is GitHub's implicit repository read permission.
+
+No organization-wide repository selection and no additional write permission is
+accepted. The sender reads the token's live repository list through GitHub's
+[installation repositories endpoint](https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation).
+It binds that response to the permission and repository-selection metadata from
+the token-issuance response. GitHub documents that an installation-token response
+contains its expiry, permissions, and selected repositories and that installation
+tokens expire after one hour in
+[Generating an installation access token](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
+
+Strip the token field before the issuance metadata enters the sender. The safe
+record contains only:
+
+- GitHub App/installation identity;
+- `repositorySelection: selected`;
+- the one selected `owner/repository`;
+- Contents and Pull requests permission levels;
+- any additional write permission names (the sender requires this list to be
+  empty); and
+- expiry, if the operator records it outside the decision contract.
+
+The token itself lives only in the operator-owned sender process's secret store.
+It is never a CLI argument, file artifact, decision record, suite summary, log,
+model environment, agent container variable, or Compose environment value. The
+GitHub App private key and token-minting authority never enter the sender.
+
+## Free pre-flight before the first send
+
+Run the committed INT-3b suite from a clean checkout:
+
+```bash
+npm run typecheck
+npm test
+npm run build
+npm run test:int3b
+```
+
+Then construct the INT-3a payload and call `preflightPullRequestPayload` from the
+operator-owned process with the live client. That function can only:
+
+1. read and validate the issued authorization metadata plus the live installation
+   repository list;
+2. query GitHub for the deterministic head;
+3. read the live base revision; and
+4. re-check global and repository HALT.
+
+It has no PR-create operation and must return `ready` (or `adoptable` when the
+exact PR already exists). Record identity, repository, selected-repository mode,
+permission names, live base SHA, derived head, and result. Never record request
+headers or the token.
+
+The send is a separate, single call to `sendPullRequestPayload`. Do not loop or
+retry it blindly. A process loss after GitHub accepts the create call is resolved
+by one operator re-run: the sender queries the deterministic head, adopts the
+existing exact PR, and does not create another.
+
+After the call, record the PR number, head commit SHA, payload artifact hash,
+decision record, credential identity/scope, and confirmation that the remote head
+tree equals the payload `treeSha`. Merge remains a human action.
+
+## Rotation and revocation
+
+Installation tokens are short-lived. For routine rotation, mint the replacement
+outside the sender, scope it to the same single repository and permissions,
+capture the safe issuance metadata, replace the operator-process secret, run the
+read-only pre-flight, and allow the old token to expire. Do not overlap a send
+across token rotation.
+
+For immediate revocation:
+
+1. declare global or repository HALT;
+2. stop the operator-side sender process;
+3. revoke the current installation token using GitHub's documented
+   [revoke installation access token endpoint](https://docs.github.com/en/rest/apps/installations#revoke-an-installation-access-token),
+   or remove the repository from the installation when the installation itself is
+   in doubt;
+4. rotate the GitHub App private key in its separate owner system if that owner
+   was compromised; and
+5. keep HALT active until the new token's issuance metadata and live repository
+   list pass pre-flight.
+
+The sender intentionally has no revocation, app-management, merge, force-push,
+close, reopen, comment, branch-protection, or default-branch operation. Those
+remain human/operator responsibilities outside the actuation capability.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc -b --pretty false packages/* services/*",
     "test": "vitest run",
     "test:int3a": "vitest run test/integration/int3a-payload-actuator.test.ts",
+    "test:int3b": "vitest run test/integration/int3b-payload-sender.test.ts",
     "dev:trace": "tsx packages/trace-mcp/src/index.ts",
     "dev:policy": "tsx packages/policy-mcp/src/index.ts",
     "dev:observer": "tsx services/skills-observer/src/index.ts"

--- a/services/harness-dispatcher/src/pr-payload-github-client.ts
+++ b/services/harness-dispatcher/src/pr-payload-github-client.ts
@@ -1,0 +1,566 @@
+import { spawn } from "node:child_process";
+import {
+  chmod,
+  mkdtemp,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  PrPayloadSendError,
+  PullRequestCreateConflictError,
+  type GitHubWriteAuthorization,
+  type PrPayloadGitHubClient,
+  type RemotePullRequest,
+} from "./pr-payload-sender.js";
+import type { PrPayloadActuationResult } from "./pr-payload-actuator.js";
+
+const FULL_GIT_OBJECT_ID = /^[a-f0-9]{40}$/;
+const REPOSITORY_NAME = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const GITHUB_API_BASE_URL = "https://api.github.com";
+const GIT_TIMEOUT_MS = 120_000;
+const GIT_OUTPUT_LIMIT = 4 * 1024 * 1024;
+
+type FetchImplementation = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+export interface GitHubPrClientConfig {
+  repository: string;
+  /** GitHub App installation access token. Never pass it as a CLI argument. */
+  installationToken: string;
+  /**
+   * Token-issuance response metadata after the token field was removed. GitHub
+   * installation tokens can list their live repositories but cannot call the
+   * app-JWT installation-detail endpoint; this binds that live list to the
+   * actual permissions returned when this short-lived token was issued.
+   */
+  issuedAuthorization: {
+    identity: string;
+    repositorySelection: "selected" | "all";
+    permissions: {
+      contents: "read" | "write" | "none";
+      pullRequests: "read" | "write" | "none";
+      extraWriteScopes: string[];
+    };
+  };
+  fetchImpl?: FetchImplementation;
+}
+
+/**
+ * Operator-side GitHub App client. The installation token stays in this
+ * process, is passed to GitHub only via HTTP headers or Git's askpass channel,
+ * and is never included in command arguments, return values, or errors.
+ */
+export function createGitHubPrClient(
+  config: GitHubPrClientConfig,
+): PrPayloadGitHubClient {
+  const repositoryParts = config.repository.split("/");
+  if (
+    !REPOSITORY_NAME.test(config.repository)
+    || repositoryParts.some((part) => part === "." || part === "..")
+  ) {
+    throw new PrPayloadSendError(
+      "credential_scope_invalid",
+      "GitHub client repository must be a pinned owner/name pair",
+      true,
+    );
+  }
+  if (!config.installationToken) {
+    throw new PrPayloadSendError(
+      "credential_scope_unavailable",
+      "GitHub App installation authorization is unavailable",
+      true,
+    );
+  }
+  const repository = config.repository;
+  const issuedAuthorization = structuredClone(config.issuedAuthorization);
+  const fetchImpl = config.fetchImpl ?? globalThis.fetch;
+  const [owner] = repository.split("/");
+  if (!owner) {
+    throw new PrPayloadSendError(
+      "credential_scope_invalid",
+      "GitHub client repository owner is unavailable",
+      true,
+    );
+  }
+
+  const request = async (
+    method: "GET" | "POST",
+    requestPath: string,
+    body?: unknown,
+    allowNotFound = false,
+  ): Promise<unknown | undefined> => {
+    const response = await fetchImpl(`${GITHUB_API_BASE_URL}${requestPath}`, {
+      method,
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${config.installationToken}`,
+        "x-github-api-version": "2022-11-28",
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+    if (allowNotFound && response.status === 404) return undefined;
+    if (
+      method === "POST"
+      && requestPath === repositoryApiPath(repository, "/pulls")
+      && response.status === 422
+    ) {
+      throw new PullRequestCreateConflictError();
+    }
+    if (!response.ok) {
+      throw new Error(`GitHub ${method} request failed with HTTP ${response.status}`);
+    }
+    return response.json() as Promise<unknown>;
+  };
+
+  const readCommitTree = async (commitSha: string): Promise<string> => {
+    assertFullObjectId(commitSha, "GitHub commit");
+    const commit = asRecord(await request(
+      "GET",
+      repositoryApiPath(repository, `/git/commits/${commitSha}`),
+    ));
+    const tree = asRecord(commit.tree);
+    return requiredObjectId(tree.sha, "GitHub commit tree");
+  };
+
+  const readHead = async (
+    headRef: string,
+  ): Promise<{ revision: string; treeSha: string } | undefined> => {
+    const found = await request(
+      "GET",
+      repositoryApiPath(repository, `/git/ref/heads/${encodeURIComponent(headRef)}`),
+      undefined,
+      true,
+    );
+    if (found === undefined) return undefined;
+    const object = asRecord(asRecord(found).object);
+    const revision = requiredObjectId(object.sha, "GitHub head commit");
+    return { revision, treeSha: await readCommitTree(revision) };
+  };
+
+  return {
+    async readWriteAuthorization(): Promise<GitHubWriteAuthorization> {
+      const repositoriesResponse = asRecord(await request(
+        "GET",
+        "/installation/repositories?per_page=100",
+      ));
+      const repositories = Array.isArray(repositoriesResponse.repositories)
+        ? repositoriesResponse.repositories
+        : [];
+      const totalCount = Number.isSafeInteger(repositoriesResponse.total_count)
+        ? Number(repositoriesResponse.total_count)
+        : repositories.length;
+      const writeRepositories = repositories.map((candidate) => {
+        const item = asRecord(candidate);
+        return requiredString(item.full_name, "GitHub installation repository");
+      });
+      if (totalCount !== writeRepositories.length) {
+        // The sender accepts exactly one live repository. A truncated or
+        // internally inconsistent list must therefore fail the length check.
+        writeRepositories.push("invalid/scope-list-incomplete");
+      }
+      return {
+        identity: issuedAuthorization.identity,
+        repositorySelection: issuedAuthorization.repositorySelection,
+        writeRepositories,
+        permissions: structuredClone(issuedAuthorization.permissions),
+      };
+    },
+
+    async readCurrentBase(requestedRepository, baseRef) {
+      assertPinnedRepository(repository, requestedRepository);
+      const found = asRecord(await request(
+        "GET",
+        repositoryApiPath(repository, `/git/ref/heads/${encodeURIComponent(baseRef)}`),
+      ));
+      const object = asRecord(found.object);
+      return {
+        ref: baseRef,
+        revision: requiredObjectId(object.sha, "GitHub base commit"),
+      };
+    },
+
+    async listPullRequestsByHead(requestedRepository, headRef) {
+      assertPinnedRepository(repository, requestedRepository);
+      const query = new URLSearchParams({
+        state: "all",
+        head: `${owner}:${headRef}`,
+        per_page: "100",
+      });
+      const response = await request(
+        "GET",
+        `${repositoryApiPath(repository, "/pulls")}?${query.toString()}`,
+      );
+      if (!Array.isArray(response)) {
+        throw new Error("GitHub pull-request list was not an array");
+      }
+      return Promise.all(response.map(async (candidate) => {
+        const pullRequest = parsePullRequest(repository, candidate);
+        return {
+          ...pullRequest,
+          head: {
+            ...pullRequest.head,
+            treeSha: await readCommitTree(pullRequest.head.revision),
+          },
+        };
+      }));
+    },
+
+    async materializeHead(actuation) {
+      assertPinnedRepository(repository, actuation.payload.repository);
+      await materializeVerifiedHead(
+        actuation,
+        config.installationToken,
+        readHead,
+      );
+    },
+
+    async openPullRequest(actuation) {
+      assertPinnedRepository(repository, actuation.payload.repository);
+      const created = await request(
+        "POST",
+        repositoryApiPath(repository, "/pulls"),
+        {
+          title: actuation.payload.title,
+          body: actuation.payload.body,
+          base: actuation.payload.base.ref,
+          head: actuation.payload.head.ref,
+        },
+      );
+      const pullRequest = parsePullRequest(repository, created);
+      return {
+        ...pullRequest,
+        head: {
+          ...pullRequest.head,
+          treeSha: await readCommitTree(pullRequest.head.revision),
+        },
+      };
+    },
+  };
+}
+
+async function materializeVerifiedHead(
+  actuation: PrPayloadActuationResult,
+  installationToken: string,
+  readHead: (
+    headRef: string,
+  ) => Promise<{ revision: string; treeSha: string } | undefined>,
+): Promise<void> {
+  const payload = actuation.payload;
+  if (
+    !payload.head.ref.startsWith("harness/")
+    || payload.head.ref === payload.base.ref
+  ) {
+    throw new PrPayloadSendError(
+      "head_conflict",
+      "Verified head is not an isolated deterministic Harness branch",
+      true,
+    );
+  }
+  const existing = await readHead(payload.head.ref);
+  if (existing) {
+    if (existing.treeSha !== payload.head.treeSha) {
+      throw new PrPayloadSendError(
+        "head_conflict",
+        `Derived head ${payload.head.ref} has a different tree`,
+        true,
+      );
+    }
+    return;
+  }
+
+  const stagingRoot = await mkdtemp(path.join(tmpdir(), "int3b-sender-"));
+  const repositoryRoot = path.join(stagingRoot, "repository");
+  const askpassPath = path.join(stagingRoot, "git-askpass.sh");
+  try {
+    await writeFile(
+      askpassPath,
+      [
+        "#!/bin/sh",
+        "case \"$1\" in",
+        "  *Username*) printf '%s\\n' 'x-access-token' ;;",
+        "  *Password*) printf '%s\\n' \"$INT3B_GITHUB_TOKEN\" ;;",
+        "  *) exit 1 ;;",
+        "esac",
+        "",
+      ].join("\n"),
+      { encoding: "utf8", mode: 0o700 },
+    );
+    await chmod(askpassPath, 0o700);
+    const gitEnvironment = {
+      GIT_ASKPASS: askpassPath,
+      GIT_ASKPASS_REQUIRE: "force",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_TERMINAL_PROMPT: "0",
+      INT3B_GITHUB_TOKEN: installationToken,
+    };
+    await requiredGit(
+      [
+        "clone",
+        "--no-checkout",
+        "--no-tags",
+        "--filter=blob:none",
+        "--",
+        `https://github.com/${payload.repository}.git`,
+        repositoryRoot,
+      ],
+      stagingRoot,
+      gitEnvironment,
+      undefined,
+      "clone",
+    );
+    await requiredGit(
+      ["checkout", "--detach", payload.base.revision],
+      repositoryRoot,
+      gitEnvironment,
+      undefined,
+      "base checkout",
+    );
+    await requiredGit(
+      ["apply", "--index", "--binary", "--whitespace=nowarn", "-"],
+      repositoryRoot,
+      gitEnvironment,
+      Buffer.from(payload.patch.bytes, "utf8"),
+      "verified patch apply",
+    );
+    const tree = await requiredGit(
+      ["write-tree"],
+      repositoryRoot,
+      gitEnvironment,
+      undefined,
+      "tree materialization",
+    );
+    const treeSha = tree.stdout.trim();
+    if (treeSha !== payload.head.treeSha) {
+      throw new PrPayloadSendError(
+        "pull_request_identity_mismatch",
+        "Sender materialized a tree different from the verified payload",
+        true,
+      );
+    }
+    const commit = await requiredGit(
+      ["commit-tree", treeSha, "-p", payload.base.revision],
+      repositoryRoot,
+      {
+        ...gitEnvironment,
+        GIT_AUTHOR_NAME: "Supervised Harness",
+        GIT_AUTHOR_EMAIL: "harness@users.noreply.github.com",
+        GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
+        GIT_COMMITTER_NAME: "Supervised Harness",
+        GIT_COMMITTER_EMAIL: "harness@users.noreply.github.com",
+        GIT_COMMITTER_DATE: "2000-01-01T00:00:00Z",
+      },
+      Buffer.from(`Verified payload ${actuation.artifact.sha256}\n`, "utf8"),
+      "commit materialization",
+    );
+    const commitSha = commit.stdout.trim();
+    assertFullObjectId(commitSha, "materialized head commit");
+    const pushed = await runGit(
+      [
+        "push",
+        "origin",
+        `${commitSha}:refs/heads/${payload.head.ref}`,
+      ],
+      repositoryRoot,
+      gitEnvironment,
+    );
+    if (pushed.code !== 0) {
+      const raced = await readHead(payload.head.ref);
+      if (!raced || raced.treeSha !== payload.head.treeSha) {
+        throw new PrPayloadSendError(
+          "pull_request_create_failed",
+          "Derived head could not be created without force-pushing",
+          true,
+        );
+      }
+    }
+  } finally {
+    await rm(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+interface GitResult {
+  code: number;
+  stdout: string;
+}
+
+interface GitEnvironment {
+  GIT_ASKPASS: string;
+  GIT_ASKPASS_REQUIRE: string;
+  GIT_CONFIG_GLOBAL: string;
+  GIT_CONFIG_NOSYSTEM: string;
+  GIT_TERMINAL_PROMPT: string;
+  INT3B_GITHUB_TOKEN: string;
+  GIT_AUTHOR_NAME?: string;
+  GIT_AUTHOR_EMAIL?: string;
+  GIT_AUTHOR_DATE?: string;
+  GIT_COMMITTER_NAME?: string;
+  GIT_COMMITTER_EMAIL?: string;
+  GIT_COMMITTER_DATE?: string;
+}
+
+async function requiredGit(
+  args: readonly string[],
+  cwd: string,
+  environment: GitEnvironment,
+  input: Uint8Array | undefined,
+  label: string,
+): Promise<GitResult> {
+  const result = await runGit(args, cwd, environment, input);
+  if (result.code !== 0) {
+    throw new PrPayloadSendError(
+      "pull_request_create_failed",
+      `Git ${label} failed with exit ${result.code}`,
+      true,
+    );
+  }
+  return result;
+}
+
+function runGit(
+  args: readonly string[],
+  cwd: string,
+  environment: GitEnvironment,
+  input?: Uint8Array,
+): Promise<GitResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("git", [...args], {
+      cwd,
+      shell: false,
+      stdio: [input ? "pipe" : "ignore", "pipe", "pipe"],
+      env: {
+        PATH: "/usr/local/bin:/usr/bin:/bin",
+        ...environment,
+      },
+    });
+    const stdoutStream = child.stdout;
+    const stderrStream = child.stderr;
+    const stdinStream = child.stdin;
+    if (!stdoutStream || !stderrStream || (input && !stdinStream)) {
+      child.kill("SIGKILL");
+      reject(new Error("Git command streams were unavailable"));
+      return;
+    }
+    const stdout: Buffer[] = [];
+    let outputBytes = 0;
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`Git command timed out after ${GIT_TIMEOUT_MS}ms`));
+    }, GIT_TIMEOUT_MS);
+    stdoutStream.on("data", (chunk: Buffer) => {
+      outputBytes += chunk.byteLength;
+      if (outputBytes > GIT_OUTPUT_LIMIT) {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timer);
+          child.kill("SIGKILL");
+          reject(new Error("Git command exceeded its output limit"));
+        }
+        return;
+      }
+      stdout.push(chunk);
+    });
+    // Git stderr can contain remote details. Drain it without recording it.
+    stderrStream.on("data", () => undefined);
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        code: code ?? 1,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+      });
+    });
+    if (input) stdinStream?.end(Buffer.from(input));
+  });
+}
+
+function parsePullRequest(
+  repository: string,
+  input: unknown,
+): RemotePullRequest {
+  const candidate = asRecord(input);
+  const base = asRecord(candidate.base);
+  const head = asRecord(candidate.head);
+  const state = candidate.state === "closed" ? "closed" : "open";
+  return {
+    repository,
+    number: requiredPositiveInteger(candidate.number, "GitHub pull request number"),
+    state,
+    title: requiredString(candidate.title, "GitHub pull request title"),
+    body: typeof candidate.body === "string" ? candidate.body : "",
+    base: {
+      ref: requiredString(base.ref, "GitHub pull request base ref"),
+      revision: requiredObjectId(base.sha, "GitHub pull request base commit"),
+    },
+    head: {
+      ref: requiredString(head.ref, "GitHub pull request head ref"),
+      revision: requiredObjectId(head.sha, "GitHub pull request head commit"),
+      treeSha: "",
+    },
+  };
+}
+
+function repositoryApiPath(repository: string, suffix: string): string {
+  const [owner, name] = repository.split("/");
+  if (!owner || !name) throw new Error("Pinned GitHub repository is invalid");
+  return `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}${suffix}`;
+}
+
+function assertPinnedRepository(expected: string, actual: string): void {
+  if (expected.toLowerCase() !== actual.toLowerCase()) {
+    throw new PrPayloadSendError(
+      "credential_scope_invalid",
+      `GitHub client is pinned to ${expected}; refused ${actual}`,
+      true,
+    );
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("GitHub response did not match the expected object shape");
+  }
+  return value as Record<string, unknown>;
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} is unavailable`);
+  }
+  return value;
+}
+
+function requiredPositiveInteger(value: unknown, label: string): number {
+  if (!Number.isSafeInteger(value) || Number(value) <= 0) {
+    throw new Error(`${label} is unavailable`);
+  }
+  return Number(value);
+}
+
+function requiredObjectId(value: unknown, label: string): string {
+  const candidate = requiredString(value, label);
+  assertFullObjectId(candidate, label);
+  return candidate;
+}
+
+function assertFullObjectId(value: string, label: string): void {
+  if (!FULL_GIT_OBJECT_ID.test(value)) {
+    throw new Error(`${label} is not a full Git object id`);
+  }
+}

--- a/services/harness-dispatcher/src/pr-payload-sender.ts
+++ b/services/harness-dispatcher/src/pr-payload-sender.ts
@@ -1,0 +1,446 @@
+import {
+  githubPullRequestRefSchema,
+  type ArtifactRef,
+  type GithubPullRequestRef,
+  type MutationRef,
+  type PullRequestPayloadV1,
+} from "@avg/schemas";
+
+import type {
+  ActuationHaltState,
+  PrPayloadActuationResult,
+} from "./pr-payload-actuator.js";
+
+export type PrPayloadSendRefusalReason =
+  | "base_drift"
+  | "credential_scope_invalid"
+  | "credential_scope_unavailable"
+  | "github_state_unavailable"
+  | "halt_global"
+  | "halt_repository"
+  | "halt_state_unavailable"
+  | "head_conflict"
+  | "pull_request_create_failed"
+  | "pull_request_identity_mismatch";
+
+export class PrPayloadSendError extends Error {
+  constructor(
+    readonly reason: PrPayloadSendRefusalReason,
+    message: string,
+    readonly escalationRequired = false,
+  ) {
+    super(message);
+    this.name = "PrPayloadSendError";
+  }
+}
+
+/**
+ * A transport-specific conflict means the create call did not produce a
+ * second PR. The sender resolves the race by querying the derived head again.
+ */
+export class PullRequestCreateConflictError extends Error {
+  constructor() {
+    super("A pull request already exists for the derived head");
+    this.name = "PullRequestCreateConflictError";
+  }
+}
+
+export interface GitHubWriteAuthorization {
+  identity: string;
+  repositorySelection: "selected" | "all";
+  writeRepositories: string[];
+  permissions: {
+    contents: "read" | "write" | "none";
+    pullRequests: "read" | "write" | "none";
+    extraWriteScopes: string[];
+  };
+}
+
+export interface GitHubWriteAuthorizationEvidence {
+  identity: string;
+  repository: string;
+  repositorySelection: "selected";
+  permissions: {
+    contents: "write";
+    pullRequests: "write";
+  };
+}
+
+export interface RemotePullRequest {
+  repository: string;
+  number: number;
+  state: "open" | "closed";
+  title: string;
+  body: string;
+  base: {
+    ref: string;
+    revision: string;
+  };
+  head: {
+    ref: string;
+    revision: string;
+    treeSha: string;
+  };
+}
+
+/**
+ * The complete GitHub write surface available to INT-3b. It deliberately has
+ * no merge, force-push, comment, close, reopen, protection, or arbitrary-repo
+ * operation. A live implementation owns the credential outside the agent
+ * container; neither the token nor an HTTP client crosses into INT-3a.
+ */
+export interface PrPayloadGitHubClient {
+  readWriteAuthorization(): Promise<GitHubWriteAuthorization>;
+  readCurrentBase(
+    repository: string,
+    baseRef: string,
+  ): Promise<{ ref: string; revision: string }>;
+  listPullRequestsByHead(
+    repository: string,
+    headRef: string,
+  ): Promise<RemotePullRequest[]>;
+  materializeHead(actuation: PrPayloadActuationResult): Promise<void>;
+  openPullRequest(
+    actuation: PrPayloadActuationResult,
+  ): Promise<RemotePullRequest>;
+}
+
+export interface PrPayloadSenderDeps {
+  github: PrPayloadGitHubClient;
+  readHaltState(): Promise<ActuationHaltState>;
+}
+
+export interface PrPayloadSendResult {
+  outcome: "opened" | "adopted";
+  pullRequest: GithubPullRequestRef;
+  payloadArtifact: ArtifactRef;
+  authorization: GitHubWriteAuthorizationEvidence;
+  mutation?: MutationRef;
+}
+
+export interface PrPayloadSendPreflight {
+  outcome: "ready" | "adoptable";
+  repository: string;
+  headRef: string;
+  authorization: GitHubWriteAuthorizationEvidence;
+  existingPullRequest?: GithubPullRequestRef;
+}
+
+/**
+ * Live-API dry run for the operator ceremony. It exercises authorization,
+ * repository resolution, deterministic head lookup, base drift, and HALT, but
+ * the type deliberately contains no operation capable of opening a PR.
+ */
+export async function preflightPullRequestPayload(
+  actuation: PrPayloadActuationResult,
+  deps: PrPayloadSenderDeps,
+): Promise<PrPayloadSendPreflight> {
+  const inspected = await inspectRemoteState(actuation, deps);
+  return {
+    outcome: inspected.existing ? "adoptable" : "ready",
+    repository: actuation.payload.repository,
+    headRef: actuation.payload.head.ref,
+    authorization: inspected.authorization,
+    ...(inspected.existing
+      ? { existingPullRequest: toPullRequestRef(inspected.existing) }
+      : {}),
+  };
+}
+
+export async function sendPullRequestPayload(
+  actuation: PrPayloadActuationResult,
+  deps: PrPayloadSenderDeps,
+): Promise<PrPayloadSendResult> {
+  const inspected = await inspectRemoteState(actuation, deps);
+  if (inspected.existing) {
+    return adoptedResult(actuation, inspected.authorization, inspected.existing);
+  }
+
+  try {
+    await deps.github.materializeHead(actuation);
+  } catch (error) {
+    if (error instanceof PrPayloadSendError) throw error;
+    refuse(
+      "pull_request_create_failed",
+      "GitHub did not confirm the deterministic verified head",
+      true,
+    );
+  }
+
+  // Head materialization can take time. Re-query remote idempotency state and
+  // re-read the base plus HALT after it, directly before the PR-create call.
+  const beforeCreate = await inspectBeforeCreate(actuation.payload, deps);
+  if (beforeCreate) {
+    return adoptedResult(
+      actuation,
+      inspected.authorization,
+      beforeCreate,
+    );
+  }
+
+  // The immediately preceding reads are the actuation-time base and HALT
+  // checks. openPullRequest performs only the GitHub create-PR request.
+  let opened: RemotePullRequest;
+  try {
+    opened = await deps.github.openPullRequest(actuation);
+  } catch (error) {
+    if (error instanceof PullRequestCreateConflictError) {
+      const afterConflict = await readPullRequests(actuation.payload, deps.github);
+      const existing = selectMatchingPullRequest(
+        actuation.payload,
+        afterConflict,
+      );
+      if (existing) {
+        return adoptedResult(
+          actuation,
+          inspected.authorization,
+          existing,
+        );
+      }
+    }
+    if (error instanceof PrPayloadSendError) throw error;
+    refuse(
+      "pull_request_create_failed",
+      "GitHub did not confirm pull-request creation for the verified payload",
+      true,
+    );
+  }
+
+  assertPullRequestMatchesPayload(actuation.payload, opened);
+  const pullRequest = toPullRequestRef(opened);
+  const mutation: MutationRef = {
+    system: "github",
+    action: "open_pull_request",
+    target: `${pullRequest.repository}#${pullRequest.number}`,
+    idempotencyKey: actuation.artifact.sha256,
+    resultRef: actuation.artifact,
+  };
+  return {
+    outcome: "opened",
+    pullRequest,
+    payloadArtifact: actuation.artifact,
+    authorization: inspected.authorization,
+    mutation,
+  };
+}
+
+async function inspectRemoteState(
+  actuation: PrPayloadActuationResult,
+  deps: PrPayloadSenderDeps,
+): Promise<{
+  authorization: GitHubWriteAuthorizationEvidence;
+  existing?: RemotePullRequest;
+}> {
+  const payload = actuation.payload;
+  const authorization = await readAndAssertAuthorization(
+    payload.repository,
+    deps.github,
+  );
+  const pullRequests = await readPullRequests(payload, deps.github);
+  const existing = selectMatchingPullRequest(payload, pullRequests);
+
+  await assertBaseAndHalt(payload, deps);
+  return { authorization, ...(existing ? { existing } : {}) };
+}
+
+async function inspectBeforeCreate(
+  payload: PullRequestPayloadV1,
+  deps: PrPayloadSenderDeps,
+): Promise<RemotePullRequest | undefined> {
+  const pullRequests = await readPullRequests(payload, deps.github);
+  const existing = selectMatchingPullRequest(payload, pullRequests);
+  await assertBaseAndHalt(payload, deps);
+  return existing;
+}
+
+async function assertBaseAndHalt(
+  payload: PullRequestPayloadV1,
+  deps: PrPayloadSenderDeps,
+): Promise<void> {
+
+  let base: { ref: string; revision: string };
+  try {
+    base = await deps.github.readCurrentBase(
+      payload.repository,
+      payload.base.ref,
+    );
+  } catch (error) {
+    if (error instanceof PrPayloadSendError) throw error;
+    refuse(
+      "github_state_unavailable",
+      `Live base state is unavailable for ${payload.repository}`,
+    );
+  }
+  if (
+    base.ref !== payload.base.ref
+    || base.revision !== payload.base.revision
+  ) {
+    refuse(
+      "base_drift",
+      `Base drift: payload ${payload.base.revision}, live ${base.revision}`,
+      true,
+    );
+  }
+
+  await assertHaltClear(payload.repository, deps);
+}
+
+async function readAndAssertAuthorization(
+  repository: string,
+  github: PrPayloadGitHubClient,
+): Promise<GitHubWriteAuthorizationEvidence> {
+  let authorization: GitHubWriteAuthorization;
+  try {
+    authorization = await github.readWriteAuthorization();
+  } catch (error) {
+    if (error instanceof PrPayloadSendError) throw error;
+    refuse(
+      "credential_scope_unavailable",
+      "GitHub write authorization could not be read back",
+      true,
+    );
+  }
+  const repositories = [...new Set(
+    authorization.writeRepositories.map((candidate) => candidate.toLowerCase()),
+  )];
+  if (
+    authorization.repositorySelection !== "selected"
+    || repositories.length !== 1
+    || repositories[0] !== repository.toLowerCase()
+    || authorization.permissions.contents !== "write"
+    || authorization.permissions.pullRequests !== "write"
+    || authorization.permissions.extraWriteScopes.length !== 0
+  ) {
+    refuse(
+      "credential_scope_invalid",
+      `GitHub write authorization is not restricted to ${repository}`,
+      true,
+    );
+  }
+  return {
+    identity: authorization.identity,
+    repository,
+    repositorySelection: "selected",
+    permissions: {
+      contents: "write",
+      pullRequests: "write",
+    },
+  };
+}
+
+async function readPullRequests(
+  payload: PullRequestPayloadV1,
+  github: PrPayloadGitHubClient,
+): Promise<RemotePullRequest[]> {
+  try {
+    return await github.listPullRequestsByHead(
+      payload.repository,
+      payload.head.ref,
+    );
+  } catch (error) {
+    if (error instanceof PrPayloadSendError) throw error;
+    refuse(
+      "github_state_unavailable",
+      `Pull-request state is unavailable for ${payload.repository}`,
+    );
+  }
+}
+
+function selectMatchingPullRequest(
+  payload: PullRequestPayloadV1,
+  pullRequests: RemotePullRequest[],
+): RemotePullRequest | undefined {
+  if (pullRequests.length === 0) return undefined;
+  const matching = pullRequests.filter(
+    (pullRequest) => pullRequestMatchesPayload(payload, pullRequest),
+  );
+  if (matching.length === 1 && pullRequests.length === 1) return matching[0];
+  refuse(
+    "head_conflict",
+    matching.length > 1
+      ? `More than one pull request exists for derived head ${payload.head.ref}`
+      : `Derived head ${payload.head.ref} belongs to a different payload`,
+    true,
+  );
+}
+
+function assertPullRequestMatchesPayload(
+  payload: PullRequestPayloadV1,
+  pullRequest: RemotePullRequest,
+): void {
+  if (!pullRequestMatchesPayload(payload, pullRequest)) {
+    refuse(
+      "pull_request_identity_mismatch",
+      "Created pull request does not match the verified payload",
+      true,
+    );
+  }
+}
+
+function pullRequestMatchesPayload(
+  payload: PullRequestPayloadV1,
+  pullRequest: RemotePullRequest,
+): boolean {
+  return pullRequest.repository.toLowerCase() === payload.repository.toLowerCase()
+    && pullRequest.title === payload.title
+    && pullRequest.body === payload.body
+    && pullRequest.base.ref === payload.base.ref
+    && pullRequest.base.revision === payload.base.revision
+    && pullRequest.head.ref === payload.head.ref
+    && pullRequest.head.treeSha === payload.head.treeSha;
+}
+
+async function assertHaltClear(
+  repository: string,
+  deps: Pick<PrPayloadSenderDeps, "readHaltState">,
+): Promise<void> {
+  let halt: ActuationHaltState;
+  try {
+    halt = await deps.readHaltState();
+  } catch {
+    refuse(
+      "halt_state_unavailable",
+      "HALT state is unavailable; pull-request sending fails closed",
+    );
+  }
+  if (halt.global) {
+    refuse("halt_global", "Global HALT is active; pull-request send refused");
+  }
+  if (halt.repositories.some(
+    (candidate) => candidate.toLowerCase() === repository.toLowerCase(),
+  )) {
+    refuse(
+      "halt_repository",
+      `Repository HALT is active for ${repository}; pull-request send refused`,
+    );
+  }
+}
+
+function adoptedResult(
+  actuation: PrPayloadActuationResult,
+  authorization: GitHubWriteAuthorizationEvidence,
+  existing: RemotePullRequest,
+): PrPayloadSendResult {
+  return {
+    outcome: "adopted",
+    pullRequest: toPullRequestRef(existing),
+    payloadArtifact: actuation.artifact,
+    authorization,
+  };
+}
+
+function toPullRequestRef(pullRequest: RemotePullRequest): GithubPullRequestRef {
+  return githubPullRequestRefSchema.parse({
+    repository: pullRequest.repository,
+    number: pullRequest.number,
+    headSha: pullRequest.head.revision,
+  });
+}
+
+function refuse(
+  reason: PrPayloadSendRefusalReason,
+  message: string,
+  escalationRequired = false,
+): never {
+  throw new PrPayloadSendError(reason, message, escalationRequired);
+}

--- a/services/harness-dispatcher/src/reconcile-run.ts
+++ b/services/harness-dispatcher/src/reconcile-run.ts
@@ -8,6 +8,7 @@ import {
   type AgentTaskLifecycle,
   type AgentTaskV1,
   type ArtifactRef,
+  type GithubPullRequestRef,
   type HarnessRunState,
   type HermesDecisionRecordV2,
   type MutationRef,
@@ -111,6 +112,59 @@ export interface ReconcileResult {
   reason?: string;
   projection?: AgentRunProjectionV1;
   handoff?: VerifiedHandoffV1;
+}
+
+export interface PullRequestActuationDecisionInput {
+  outcome: "opened" | "adopted";
+  pullRequest: GithubPullRequestRef;
+  payloadArtifact: ArtifactRef;
+  githubIdentity: string;
+  githubRepository: string;
+  mutation?: MutationRef;
+}
+
+/**
+ * Builds the post-actuation evidence record without giving reconciliation any
+ * GitHub transport capability. An adopted PR is observable but non-mutating;
+ * a PR opened by this actuation must carry its concrete mutation ref.
+ */
+export function buildPullRequestActuationDecision(
+  task: AgentTaskV1,
+  input: PullRequestActuationDecisionInput,
+  generatedAt: Date,
+): HermesDecisionRecordV2 {
+  if (input.pullRequest.repository !== input.githubRepository) {
+    throw new Error("pull request and authorization repository disagree");
+  }
+  if (input.outcome === "opened" && !input.mutation) {
+    throw new Error("opened pull request requires a mutation ref");
+  }
+  if (input.outcome === "adopted" && input.mutation) {
+    throw new Error("adopted pull request cannot claim a local mutation");
+  }
+  const mutations = input.mutation ? [input.mutation] : [];
+  return buildReconcileDecision(
+    task,
+    "handoff",
+    input.outcome === "opened"
+      ? "verified_payload_pull_request_opened"
+      : "verified_payload_pull_request_adopted",
+    generatedAt,
+    [input.payloadArtifact],
+    undefined,
+    [
+      `pull_request=${input.pullRequest.repository}#${input.pullRequest.number}`,
+      `github_identity=${input.githubIdentity}`,
+      `github_repository_scope=${input.githubRepository}`,
+    ],
+    {
+      mutations,
+      proposal: input.outcome === "opened"
+        ? "Record the pull request opened from the verified payload."
+        : "Record the existing pull request adopted for the verified payload.",
+      nextAction: "Operator reviews the pull request; merge remains human-only.",
+    },
+  );
 }
 
 export async function reconcileDispatchedRuns(
@@ -1026,6 +1080,11 @@ function buildReconcileDecision(
   evidenceRefs: ArtifactRef[] = [],
   projection?: AgentRunProjectionV1,
   additionalReasons: string[] = [],
+  actuation?: {
+    mutations: MutationRef[];
+    proposal: string;
+    nextAction: string;
+  },
 ): HermesDecisionRecordV2 {
   const approval = task.approval;
   const inputs: Array<{
@@ -1056,14 +1115,15 @@ function buildReconcileDecision(
       observedAt: projection.source.observedAt,
     });
   }
+  const mutations = actuation?.mutations ?? [];
   return buildHermesDecisionRecordV2({
     correlationId: task.correlationId,
     workItemId: task.workItemId,
     decisionType,
     proposal: {
-      what: decisionType === "handoff"
+      what: actuation?.proposal ?? (decisionType === "handoff"
         ? "Record a verified handoff for operator review."
-        : "Pause supervised execution for operator review.",
+        : "Pause supervised execution for operator review."),
       why: [reason, ...additionalReasons],
       evidenceRefs: uniqueArtifacts([
         ...task.proposal.sourceRefs,
@@ -1081,15 +1141,15 @@ function buildReconcileDecision(
       ...(approval.decidedAt ? { decidedAt: approval.decidedAt } : {}),
     },
     effects: {
-      mutates: false,
-      mutations: [],
+      mutates: mutations.length > 0,
+      mutations,
       authorityChanged: false,
       budgetChanged: false,
     },
     next: {
-      action: decisionType === "handoff"
+      action: actuation?.nextAction ?? (decisionType === "handoff"
         ? "Operator reviews the verified handoff; no PR is opened automatically."
-        : "Operator reviews the blocked task before any further action.",
+        : "Operator reviews the blocked task before any further action."),
       owner: "operator",
       ...(decisionType === "handoff" ? {} : { blockedBy: [reason] }),
     },

--- a/test/integration/int3b-payload-sender.test.ts
+++ b/test/integration/int3b-payload-sender.test.ts
@@ -1,0 +1,1151 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import {
+  agentRunProjectionV1Schema,
+  agentTaskV1Schema,
+  hashAgentTaskApprovalPayload,
+  verifiedHandoffV1Schema,
+  type AgentRunProjectionV1,
+  type AgentTaskV1,
+  type ArtifactRef,
+  type VerifiedHandoffV1,
+} from "@avg/schemas";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+} from "vitest";
+
+import {
+  actuatePullRequestPayload,
+  PrPayloadActuationError,
+  type PrPayloadActuationInput,
+  type PrPayloadActuationResult,
+  type PrPayloadActuatorDeps,
+  type PrPayloadRefusalReason,
+} from "../../services/harness-dispatcher/src/pr-payload-actuator.js";
+import {
+  createFilePrPayloadArtifactPort,
+  createLocalGitPrPayloadRepositoryPort,
+} from "../../services/harness-dispatcher/src/pr-payload-local-ports.js";
+import {
+  PrPayloadSendError,
+  sendPullRequestPayload,
+  preflightPullRequestPayload,
+  type GitHubWriteAuthorization,
+  type PrPayloadGitHubClient,
+  type PrPayloadSendRefusalReason,
+  type PrPayloadSendResult,
+  type RemotePullRequest,
+} from "../../services/harness-dispatcher/src/pr-payload-sender.js";
+import {
+  buildPullRequestActuationDecision,
+} from "../../services/harness-dispatcher/src/reconcile-run.js";
+import {
+  createGitHubPrClient,
+} from "../../services/harness-dispatcher/src/pr-payload-github-client.js";
+
+const execFileAsync = promisify(execFile);
+const PINNED_REPOSITORY = "depre-dev/averray-reference-agent";
+const OTHER_REPOSITORY = "depre-dev/another-repository";
+const EXPECTED_CASE_COUNT = 27;
+const ZERO_HASH = `sha256:${"0".repeat(64)}` as const;
+const A_HASH = `sha256:${"a".repeat(64)}` as const;
+const B_HASH = `sha256:${"b".repeat(64)}` as const;
+const C_HASH = `sha256:${"c".repeat(64)}` as const;
+const D_HASH = `sha256:${"d".repeat(64)}` as const;
+const E_HASH = `sha256:${"e".repeat(64)}` as const;
+const RUN_ID = "7db95d47-2cca-5572-a198-434723821fba";
+
+const INT3A_REFUSALS = [
+  "approval_hash_mismatch",
+  "artifact_hash_mismatch",
+  "artifact_unavailable",
+  "base_drift",
+  "base_revision_invalid",
+  "contract_invalid",
+  "eligibility_disagreement",
+  "halt_global",
+  "halt_repository",
+  "halt_state_unavailable",
+  "handoff_check_not_passed",
+  "handoff_identity_mismatch",
+  "handoff_outcome_not_completed",
+  "handoff_unverified",
+  "patch_apply_failed",
+  "patch_empty",
+  "patch_missing",
+  "path_forbidden",
+  "path_not_allowed",
+  "payload_artifact_mismatch",
+  "repository_mismatch",
+  "repository_unavailable",
+] as const satisfies readonly PrPayloadRefusalReason[];
+
+type Int3bCase =
+  | `3a:${PrPayloadRefusalReason}`
+  | "base-moved-after-construction"
+  | "halt-after-construction"
+  | "existing-pr-adopted"
+  | "crash-after-create"
+  | "credential-scope-too-wide";
+
+interface CeremonyEvidence {
+  case: Int3bCase;
+  outcome: "refused" | "adopted" | "recovered_after_crash";
+  refusalReason?: PrPayloadRefusalReason | PrPayloadSendRefusalReason;
+  refusalMessage?: string;
+  credentialIdentity?: string;
+  credentialRepository?: string;
+  remoteCalls: number;
+  createCalls: number;
+  pullRequestCount: number;
+  replayOutcome?: PrPayloadSendResult["outcome"];
+}
+
+class Int3bEvidenceError extends Error {}
+
+class FakeGitHubClient implements PrPayloadGitHubClient {
+  authorization: GitHubWriteAuthorization = {
+    identity: "ceremony-app#installation-1001",
+    repositorySelection: "selected",
+    writeRepositories: [PINNED_REPOSITORY],
+    permissions: {
+      contents: "write",
+      pullRequests: "write",
+      extraWriteScopes: [],
+    },
+  };
+  baseRevision: string;
+  remoteCalls = 0;
+  materializeCalls = 0;
+  createCalls = 0;
+  crashAfterCreate = false;
+  onMaterialize?: () => void;
+  readonly pullRequests: RemotePullRequest[] = [];
+
+  constructor(baseRevision: string) {
+    this.baseRevision = baseRevision;
+  }
+
+  async readWriteAuthorization(): Promise<GitHubWriteAuthorization> {
+    this.remoteCalls += 1;
+    return structuredClone(this.authorization);
+  }
+
+  async readCurrentBase(repository: string, baseRef: string) {
+    this.remoteCalls += 1;
+    expect(repository).toBe(PINNED_REPOSITORY);
+    return { ref: baseRef, revision: this.baseRevision };
+  }
+
+  async listPullRequestsByHead(repository: string, headRef: string) {
+    this.remoteCalls += 1;
+    return structuredClone(this.pullRequests.filter(
+      (pullRequest) => pullRequest.repository === repository
+        && pullRequest.head.ref === headRef,
+    ));
+  }
+
+  async materializeHead(): Promise<void> {
+    this.remoteCalls += 1;
+    this.materializeCalls += 1;
+    this.onMaterialize?.();
+  }
+
+  async openPullRequest(actuation: PrPayloadActuationResult) {
+    this.remoteCalls += 1;
+    this.createCalls += 1;
+    const opened = remotePullRequest(
+      actuation,
+      this.pullRequests.length + 1,
+    );
+    this.pullRequests.push(opened);
+    if (this.crashAfterCreate) {
+      this.crashAfterCreate = false;
+      throw new Error("simulated process loss after remote create");
+    }
+    return structuredClone(opened);
+  }
+}
+
+describe.sequential("INT-3b pull-request sending ceremony", () => {
+  let root: string;
+  let repositoryRoot: string;
+  let inputArtifactRoot: string;
+  let outputArtifactRoot: string;
+  let evidenceRoot: string;
+  let baseRevision: string;
+  let validPatch: string;
+  let outsidePatch: string;
+  let validPatchRef: ArtifactRef;
+  let outsidePatchRef: ArtifactRef;
+  let task: AgentTaskV1;
+  let run: AgentRunProjectionV1;
+  let handoff: VerifiedHandoffV1;
+  let validInput: PrPayloadActuationInput;
+  let actuationDeps: PrPayloadActuatorDeps;
+  const ceremonyEvidence: CeremonyEvidence[] = [];
+  const mutationResults: Array<{
+    case: Int3bCase;
+    mutation: string;
+    observedFailure: string;
+  }> = [];
+
+  beforeAll(async () => {
+    root = await mkdtemp(path.join(tmpdir(), "int3b-suite-"));
+    repositoryRoot = path.join(root, "repository");
+    inputArtifactRoot = path.join(root, "input-artifacts");
+    outputArtifactRoot = path.join(root, "payload-artifacts");
+    evidenceRoot = process.env.INT3B_SUITE_EVIDENCE_DIR
+      ? path.resolve(process.env.INT3B_SUITE_EVIDENCE_DIR)
+      : path.join(root, "evidence");
+    await Promise.all([
+      mkdir(repositoryRoot, { recursive: true }),
+      mkdir(inputArtifactRoot, { recursive: true }),
+      mkdir(outputArtifactRoot, { recursive: true }),
+      mkdir(evidenceRoot, { recursive: true }),
+      mkdir(path.join(repositoryRoot, "docs"), { recursive: true }),
+      mkdir(path.join(repositoryRoot, "src"), { recursive: true }),
+    ]);
+    await git(["init", "--initial-branch=main"], repositoryRoot);
+    await Promise.all([
+      writeFile(path.join(repositoryRoot, "docs/stage3b.md"), "base\n", "utf8"),
+      writeFile(
+        path.join(repositoryRoot, "src/guarded.ts"),
+        "export const guarded = true;\n",
+        "utf8",
+      ),
+    ]);
+    await git(["add", "docs/stage3b.md", "src/guarded.ts"], repositoryRoot);
+    await git([
+      "-c",
+      "user.name=INT-3b Suite",
+      "-c",
+      "user.email=int3b@example.invalid",
+      "commit",
+      "-m",
+      "fixture base",
+    ], repositoryRoot);
+    baseRevision = (await git(["rev-parse", "HEAD"], repositoryRoot)).trim();
+    validPatch = await makePatch(
+      repositoryRoot,
+      "docs/stage3b.md",
+      "base\nstage 3b payload\n",
+      "base\n",
+    );
+    outsidePatch = await makePatch(
+      repositoryRoot,
+      "src/guarded.ts",
+      "export const guarded = false;\n",
+      "export const guarded = true;\n",
+    );
+    const inputArtifacts = createFilePrPayloadArtifactPort(inputArtifactRoot);
+    validPatchRef = await inputArtifacts.write(
+      Buffer.from(validPatch, "utf8"),
+      "text/x-diff",
+    );
+    outsidePatchRef = await inputArtifacts.write(
+      Buffer.from(outsidePatch, "utf8"),
+      "text/x-diff",
+    );
+    task = await approvedTask(baseRevision);
+    run = completedRun(task);
+    handoff = acceptedHandoff(task, run, validPatchRef);
+    validInput = { task, run, handoff };
+    actuationDeps = defaultActuationDeps();
+  }, 30_000);
+
+  afterAll(async () => {
+    await writeFile(
+      path.join(evidenceRoot, "suite-summary.json"),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        executedCases: ceremonyEvidence.length,
+        expectedCases: EXPECTED_CASE_COUNT,
+        cases: ceremonyEvidence,
+        mutations: mutationResults,
+      }, null, 2)}\n`,
+      "utf8",
+    );
+    if (!process.env.INT3B_SUITE_EVIDENCE_DIR) {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 30_000);
+
+  it("keeps all 22 INT-3a refusals authoritative with GitHub write configured", async () => {
+    for (const reason of INT3A_REFUSALS) {
+      const fakeGitHub = new FakeGitHubClient(baseRevision);
+      const { input, deps } = await constructionCase(reason);
+      let observed: PrPayloadActuationError | undefined;
+      try {
+        const actuation = await actuatePullRequestPayload(input, deps);
+        await sendPullRequestPayload(actuation, senderDeps(fakeGitHub));
+      } catch (error) {
+        expect(error).toBeInstanceOf(PrPayloadActuationError);
+        observed = error as PrPayloadActuationError;
+      }
+      if (!observed) throw new Error(`Expected ${reason} to refuse in INT-3a`);
+      expect(observed.reason).toBe(reason);
+      expect(fakeGitHub.remoteCalls).toBe(0);
+      const evidence: CeremonyEvidence = {
+        case: `3a:${reason}`,
+        outcome: "refused",
+        refusalReason: observed.reason,
+        refusalMessage: observed.message,
+        credentialIdentity: fakeGitHub.authorization.identity,
+        credentialRepository: fakeGitHub.authorization.writeRepositories[0],
+        remoteCalls: fakeGitHub.remoteCalls,
+        createCalls: fakeGitHub.createCalls,
+        pullRequestCount: fakeGitHub.pullRequests.length,
+      };
+      recordAndMutate(
+        evidence,
+        (mutated) => {
+          mutated.refusalReason = reason === "base_drift"
+            ? "contract_invalid"
+            : "base_drift";
+        },
+        `refusal_reason:${reason}`,
+        `replace ${reason} with another refusal reason`,
+      );
+    }
+  }, 30_000);
+
+  it("refuses base drift introduced after payload construction", async () => {
+    const actuation = await createActuation();
+    const fakeGitHub = new FakeGitHubClient(baseRevision);
+    fakeGitHub.onMaterialize = () => {
+      fakeGitHub.baseRevision = "f".repeat(40);
+    };
+    const refusal = await captureSendRefusal(
+      actuation,
+      senderDeps(fakeGitHub),
+    );
+    const evidence: CeremonyEvidence = {
+      case: "base-moved-after-construction",
+      outcome: "refused",
+      refusalReason: refusal.reason,
+      refusalMessage: refusal.message,
+      remoteCalls: fakeGitHub.remoteCalls,
+      createCalls: fakeGitHub.createCalls,
+      pullRequestCount: fakeGitHub.pullRequests.length,
+    };
+    recordAndMutate(
+      evidence,
+      (mutated) => {
+        mutated.refusalReason = "github_state_unavailable";
+      },
+      "refusal_reason:base_drift",
+      "replace the actuation-time base_drift refusal",
+    );
+  });
+
+  it("refuses HALT declared after payload construction", async () => {
+    const actuation = await createActuation();
+    const fakeGitHub = new FakeGitHubClient(baseRevision);
+    let halted = false;
+    fakeGitHub.onMaterialize = () => {
+      halted = true;
+    };
+    const refusal = await captureSendRefusal(actuation, {
+      github: fakeGitHub,
+      readHaltState: async () => ({ global: halted, repositories: [] }),
+    });
+    const evidence: CeremonyEvidence = {
+      case: "halt-after-construction",
+      outcome: "refused",
+      refusalReason: refusal.reason,
+      refusalMessage: refusal.message,
+      remoteCalls: fakeGitHub.remoteCalls,
+      createCalls: fakeGitHub.createCalls,
+      pullRequestCount: fakeGitHub.pullRequests.length,
+    };
+    recordAndMutate(
+      evidence,
+      (mutated) => {
+        mutated.refusalMessage = "Send refused";
+      },
+      "halt_named",
+      "erase HALT from the send-time refusal",
+    );
+  });
+
+  it("adopts one existing PR for the exact derived head", async () => {
+    const actuation = await createActuation();
+    const fakeGitHub = new FakeGitHubClient(baseRevision);
+    fakeGitHub.pullRequests.push(remotePullRequest(actuation, 41));
+    const result = await sendPullRequestPayload(
+      actuation,
+      senderDeps(fakeGitHub),
+    );
+    expect(result).toMatchObject({ outcome: "adopted" });
+    expect(result).not.toHaveProperty("mutation");
+    const decision = buildPullRequestActuationDecision(task, {
+      outcome: result.outcome,
+      pullRequest: result.pullRequest,
+      payloadArtifact: result.payloadArtifact,
+      githubIdentity: result.authorization.identity,
+      githubRepository: result.authorization.repository,
+    }, new Date("2026-07-23T13:00:00.000Z"));
+    expect(decision.effects).toEqual({
+      mutates: false,
+      mutations: [],
+      authorityChanged: false,
+      budgetChanged: false,
+    });
+    const evidence: CeremonyEvidence = {
+      case: "existing-pr-adopted",
+      outcome: "adopted",
+      credentialIdentity: result.authorization.identity,
+      credentialRepository: result.authorization.repository,
+      remoteCalls: fakeGitHub.remoteCalls,
+      createCalls: fakeGitHub.createCalls,
+      pullRequestCount: fakeGitHub.pullRequests.length,
+    };
+    recordAndMutate(
+      evidence,
+      (mutated) => {
+        mutated.pullRequestCount = 2;
+      },
+      "exactly_one_pr",
+      "change the adopted remote PR count from one to two",
+    );
+  });
+
+  it("converges after a crash following remote creation", async () => {
+    const actuation = await createActuation();
+    const fakeGitHub = new FakeGitHubClient(baseRevision);
+    fakeGitHub.crashAfterCreate = true;
+    await expect(
+      sendPullRequestPayload(actuation, senderDeps(fakeGitHub)),
+    ).rejects.toMatchObject({ reason: "pull_request_create_failed" });
+    expect(fakeGitHub.pullRequests).toHaveLength(1);
+    const replay = await sendPullRequestPayload(
+      actuation,
+      senderDeps(fakeGitHub),
+    );
+    expect(replay.outcome).toBe("adopted");
+    expect(fakeGitHub.pullRequests).toHaveLength(1);
+    const evidence: CeremonyEvidence = {
+      case: "crash-after-create",
+      outcome: "recovered_after_crash",
+      credentialIdentity: replay.authorization.identity,
+      credentialRepository: replay.authorization.repository,
+      remoteCalls: fakeGitHub.remoteCalls,
+      createCalls: fakeGitHub.createCalls,
+      pullRequestCount: fakeGitHub.pullRequests.length,
+      replayOutcome: replay.outcome,
+    };
+    recordAndMutate(
+      evidence,
+      (mutated) => {
+        mutated.replayOutcome = "opened";
+      },
+      "crash_replay_adopts",
+      "record the crash replay as another create instead of adoption",
+    );
+  });
+
+  it("refuses a write authorization covering more than one repository", async () => {
+    const actuation = await createActuation();
+    const fakeGitHub = new FakeGitHubClient(baseRevision);
+    fakeGitHub.authorization.writeRepositories.push(OTHER_REPOSITORY);
+    const refusal = await captureSendRefusal(
+      actuation,
+      senderDeps(fakeGitHub),
+    );
+    const evidence: CeremonyEvidence = {
+      case: "credential-scope-too-wide",
+      outcome: "refused",
+      refusalReason: refusal.reason,
+      refusalMessage: refusal.message,
+      remoteCalls: fakeGitHub.remoteCalls,
+      createCalls: fakeGitHub.createCalls,
+      pullRequestCount: fakeGitHub.pullRequests.length,
+    };
+    recordAndMutate(
+      evidence,
+      (mutated) => {
+        mutated.refusalReason = "credential_scope_unavailable";
+      },
+      "refusal_reason:credential_scope_invalid",
+      "replace the over-broad scope refusal",
+    );
+    expect(ceremonyEvidence).toHaveLength(EXPECTED_CASE_COUNT);
+    expect(mutationResults).toHaveLength(EXPECTED_CASE_COUNT);
+  });
+
+  it("opens one PR, records its mutation, and keeps dry run read-only", async () => {
+    const actuation = await createActuation();
+    const preflightClient = new FakeGitHubClient(baseRevision);
+    const preflight = await preflightPullRequestPayload(
+      actuation,
+      senderDeps(preflightClient),
+    );
+    expect(preflight).toMatchObject({
+      outcome: "ready",
+      repository: PINNED_REPOSITORY,
+      headRef: actuation.payload.head.ref,
+    });
+    expect(preflightClient.createCalls).toBe(0);
+    expect(preflightClient.pullRequests).toHaveLength(0);
+
+    const fakeGitHub = new FakeGitHubClient(baseRevision);
+    const sent = await sendPullRequestPayload(
+      actuation,
+      senderDeps(fakeGitHub),
+    );
+    expect(sent.outcome).toBe("opened");
+    expect(fakeGitHub.createCalls).toBe(1);
+    expect(fakeGitHub.pullRequests).toHaveLength(1);
+    const decision = buildPullRequestActuationDecision(task, {
+      outcome: sent.outcome,
+      pullRequest: sent.pullRequest,
+      payloadArtifact: sent.payloadArtifact,
+      githubIdentity: sent.authorization.identity,
+      githubRepository: sent.authorization.repository,
+      mutation: sent.mutation,
+    }, new Date("2026-07-23T13:00:00.000Z"));
+    expect(decision.effects).toEqual({
+      mutates: true,
+      mutations: [sent.mutation],
+      authorityChanged: false,
+      budgetChanged: false,
+    });
+    expect(JSON.stringify(decision)).not.toMatch(
+      /installationToken|authorization|bearer/iu,
+    );
+  });
+
+  it("guards 3a imports, the computed mutation invariant, and PR-only authority", async () => {
+    const actuatorSource = await source("pr-payload-actuator.ts");
+    const localPortsSource = await source("pr-payload-local-ports.ts");
+    expect(importSpecifiers(actuatorSource)).toEqual([
+      "@avg/averray-mcp/dispatch-claim",
+      "@avg/schemas",
+      "node:crypto",
+      "node:path",
+    ]);
+    expect(importSpecifiers(localPortsSource)).toEqual([
+      "./pr-payload-actuator.js",
+      "@avg/schemas",
+      "node:child_process",
+      "node:crypto",
+      "node:fs/promises",
+      "node:os",
+      "node:path",
+    ]);
+    const protectedSource = `${actuatorSource}\n${localPortsSource}`;
+    expect(protectedSource).not.toMatch(/@octokit|https?:\/\/|\bfetch\s*\(/u);
+
+    const reconcileSource = await readFile(
+      new URL(
+        "../../services/harness-dispatcher/src/reconcile-run.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(reconcileSource).toContain("mutates: mutations.length > 0");
+    expect(reconcileSource).not.toMatch(
+      /effects:\s*\{\s*mutates:\s*false,\s*mutations:\s*\[\]/u,
+    );
+
+    const senderSource = await source("pr-payload-sender.ts");
+    const clientSource = await source("pr-payload-github-client.ts");
+    expect(senderSource).not.toMatch(
+      /\.(?:merge|forcePush|close|reopen|comment|editBranchProtection)\s*\(/u,
+    );
+    expect(clientSource).not.toContain("--force");
+    expect(clientSource).not.toMatch(
+      /\/(?:merges|comments|reviews|branches\/[^"`]*protection)/u,
+    );
+    expect(clientSource).toContain("repositoryApiPath(repository, \"/pulls\")");
+  });
+
+  it("binds issued permission metadata to the live installation repository list", async () => {
+    const requests: string[] = [];
+    const client = createGitHubPrClient({
+      repository: PINNED_REPOSITORY,
+      installationToken: "test-only-non-credential",
+      issuedAuthorization: {
+        identity: "ceremony-app#installation-1001",
+        repositorySelection: "selected",
+        permissions: {
+          contents: "write",
+          pullRequests: "write",
+          extraWriteScopes: [],
+        },
+      },
+      fetchImpl: async (input) => {
+        requests.push(String(input));
+        return new Response(JSON.stringify({
+          total_count: 1,
+          repositories: [{ full_name: PINNED_REPOSITORY }],
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    const authorization = await client.readWriteAuthorization();
+    expect(authorization).toEqual({
+      identity: "ceremony-app#installation-1001",
+      repositorySelection: "selected",
+      writeRepositories: [PINNED_REPOSITORY],
+      permissions: {
+        contents: "write",
+        pullRequests: "write",
+        extraWriteScopes: [],
+      },
+    });
+    expect(requests).toEqual([
+      "https://api.github.com/installation/repositories?per_page=100",
+    ]);
+    expect(JSON.stringify(authorization)).not.toContain(
+      "test-only-non-credential",
+    );
+  });
+
+  async function createActuation(): Promise<PrPayloadActuationResult> {
+    return actuatePullRequestPayload(cloneInput(), actuationDeps);
+  }
+
+  function cloneInput(): PrPayloadActuationInput {
+    return structuredClone(validInput);
+  }
+
+  function defaultActuationDeps(): PrPayloadActuatorDeps {
+    const inputArtifacts = createFilePrPayloadArtifactPort(inputArtifactRoot);
+    return {
+      artifacts: {
+        read: inputArtifacts.read,
+        write: createFilePrPayloadArtifactPort(outputArtifactRoot).write,
+      },
+      repository: createLocalGitPrPayloadRepositoryPort({
+        repositoryRoot,
+        repository: PINNED_REPOSITORY,
+        baseRef: "main",
+      }),
+      readHaltState: async () => ({ global: false, repositories: [] }),
+    };
+  }
+
+  function senderDeps(github: PrPayloadGitHubClient) {
+    return {
+      github,
+      readHaltState: async () => ({ global: false, repositories: [] }),
+    };
+  }
+
+  async function constructionCase(
+    reason: PrPayloadRefusalReason,
+  ): Promise<{
+    input: PrPayloadActuationInput;
+    deps: PrPayloadActuatorDeps;
+  }> {
+    const input = cloneInput();
+    let deps = defaultActuationDeps();
+    switch (reason) {
+      case "approval_hash_mismatch":
+        input.task.proposal.title = "Mutated after approval";
+        break;
+      case "artifact_hash_mismatch":
+        deps = {
+          ...deps,
+          artifacts: {
+            ...deps.artifacts,
+            read: async () => Buffer.from("different patch bytes", "utf8"),
+          },
+        };
+        break;
+      case "artifact_unavailable":
+        deps = {
+          ...deps,
+          artifacts: {
+            ...deps.artifacts,
+            read: async () => {
+              throw new Error("unavailable");
+            },
+          },
+        };
+        break;
+      case "base_drift":
+        deps = {
+          ...deps,
+          repository: {
+            ...deps.repository,
+            readCurrentBase: async () => ({
+              ref: "main",
+              revision: "f".repeat(40),
+            }),
+          },
+        };
+        break;
+      case "base_revision_invalid":
+        input.task.repository.baseRevision = "main";
+        await resign(input);
+        break;
+      case "contract_invalid":
+        (input.task as AgentTaskV1 & { unexpected?: boolean }).unexpected = true;
+        break;
+      case "eligibility_disagreement":
+        input.handoff.eligibleForPrOpen = false;
+        break;
+      case "halt_global":
+        deps = {
+          ...deps,
+          readHaltState: async () => ({ global: true, repositories: [] }),
+        };
+        break;
+      case "halt_repository":
+        deps = {
+          ...deps,
+          readHaltState: async () => ({
+            global: false,
+            repositories: [PINNED_REPOSITORY],
+          }),
+        };
+        break;
+      case "halt_state_unavailable":
+        deps = {
+          ...deps,
+          readHaltState: async () => {
+            throw new Error("unavailable");
+          },
+        };
+        break;
+      case "handoff_check_not_passed":
+        input.handoff.checks[0] = {
+          ...input.handoff.checks[0]!,
+          status: "failed",
+        };
+        input.handoff.eligibleForPrOpen = false;
+        break;
+      case "handoff_identity_mismatch":
+        input.handoff.correlationId = "different-correlation";
+        break;
+      case "handoff_outcome_not_completed":
+        input.handoff.outcome = "partial";
+        input.handoff.eligibleForPrOpen = false;
+        break;
+      case "handoff_unverified":
+        input.handoff.verification = {
+          ...input.handoff.verification,
+          verified: false,
+          decision: "reject",
+        };
+        input.handoff.eligibleForPrOpen = false;
+        break;
+      case "patch_apply_failed":
+        deps = {
+          ...deps,
+          repository: {
+            ...deps.repository,
+            applyPatch: async () => {
+              throw new Error("apply failed");
+            },
+          },
+        };
+        break;
+      case "patch_empty": {
+        const emptyRef = await createFilePrPayloadArtifactPort(
+          inputArtifactRoot,
+        ).write(new Uint8Array(), "text/x-diff");
+        input.handoff.deliverables.patchRef = emptyRef;
+        break;
+      }
+      case "patch_missing":
+        delete input.handoff.deliverables.patchRef;
+        break;
+      case "path_forbidden":
+        input.task.repository.allowedPaths = ["docs/**", "src/**"];
+        input.task.repository.forbiddenPaths = ["src/guarded.ts"];
+        input.handoff.deliverables.patchRef = outsidePatchRef;
+        await resign(input);
+        break;
+      case "path_not_allowed":
+        input.handoff.deliverables.patchRef = outsidePatchRef;
+        break;
+      case "payload_artifact_mismatch":
+        deps = {
+          ...deps,
+          artifacts: {
+            ...deps.artifacts,
+            write: async () => ref(A_HASH),
+          },
+        };
+        break;
+      case "repository_mismatch":
+        input.task.repository.nameWithOwner = OTHER_REPOSITORY;
+        await resign(input);
+        break;
+      case "repository_unavailable":
+        deps = {
+          ...deps,
+          repository: {
+            ...deps.repository,
+            readCurrentBase: async () => {
+              throw new Error("unavailable");
+            },
+          },
+        };
+        break;
+      default:
+        assertNever(reason);
+    }
+    return { input, deps };
+  }
+
+  async function resign(input: PrPayloadActuationInput): Promise<void> {
+    input.task.approval.approvedTaskHash = ZERO_HASH;
+    const approvedTaskHash = await hashAgentTaskApprovalPayload(input.task);
+    input.task.approval.approvedTaskHash = approvedTaskHash;
+    input.handoff.taskHash = approvedTaskHash;
+  }
+
+  async function captureSendRefusal(
+    actuation: PrPayloadActuationResult,
+    deps: ReturnType<typeof senderDeps>,
+  ): Promise<PrPayloadSendError> {
+    try {
+      await sendPullRequestPayload(actuation, deps);
+    } catch (error) {
+      expect(error).toBeInstanceOf(PrPayloadSendError);
+      return error as PrPayloadSendError;
+    }
+    throw new Error("Expected INT-3b send to refuse");
+  }
+
+  function recordAndMutate(
+    evidence: CeremonyEvidence,
+    mutate: (value: CeremonyEvidence) => void,
+    expectedFailure: string,
+    mutation: string,
+  ): void {
+    expect(() => verifyInt3bEvidence(evidence)).not.toThrow();
+    ceremonyEvidence.push(evidence);
+    const mutated = structuredClone(evidence);
+    mutate(mutated);
+    let observed = "";
+    try {
+      verifyInt3bEvidence(mutated);
+    } catch (error) {
+      expect(error).toBeInstanceOf(Int3bEvidenceError);
+      observed = (error as Error).message;
+    }
+    expect(observed).toContain(expectedFailure);
+    mutationResults.push({
+      case: evidence.case,
+      mutation,
+      observedFailure: expectedFailure,
+    });
+  }
+
+  async function source(file: string): Promise<string> {
+    return readFile(
+      new URL(
+        `../../services/harness-dispatcher/src/${file}`,
+        import.meta.url,
+      ),
+      "utf8",
+    );
+  }
+});
+
+function verifyInt3bEvidence(evidence: CeremonyEvidence): void {
+  if (evidence.case.startsWith("3a:")) {
+    const expected = evidence.case.slice("3a:".length);
+    requireEvidence(evidence.outcome === "refused", "construction_refused");
+    requireEvidence(
+      evidence.refusalReason === expected,
+      `refusal_reason:${expected}`,
+    );
+    requireEvidence(Boolean(evidence.credentialIdentity), "credential_configured");
+    requireEvidence(Boolean(evidence.credentialRepository), "repository_configured");
+    requireEvidence(evidence.remoteCalls === 0, "3a_before_github");
+    requireEvidence(evidence.createCalls === 0, "3a_no_create");
+    requireEvidence(evidence.pullRequestCount === 0, "3a_no_pr");
+    return;
+  }
+  if (evidence.case === "base-moved-after-construction") {
+    requireEvidence(evidence.outcome === "refused", "base_drift_refused");
+    requireEvidence(evidence.refusalReason === "base_drift", "refusal_reason:base_drift");
+    requireEvidence(evidence.createCalls === 0, "base_drift_no_create");
+    requireEvidence(evidence.pullRequestCount === 0, "base_drift_no_pr");
+  }
+  if (evidence.case === "halt-after-construction") {
+    requireEvidence(evidence.outcome === "refused", "halt_refused");
+    requireEvidence(evidence.refusalReason === "halt_global", "refusal_reason:halt_global");
+    requireEvidence(evidence.refusalMessage?.includes("HALT") === true, "halt_named");
+    requireEvidence(evidence.createCalls === 0, "halt_no_create");
+  }
+  if (evidence.case === "existing-pr-adopted") {
+    requireEvidence(evidence.outcome === "adopted", "existing_adopted");
+    requireEvidence(evidence.pullRequestCount === 1, "exactly_one_pr");
+    requireEvidence(evidence.createCalls === 0, "adoption_no_create");
+  }
+  if (evidence.case === "crash-after-create") {
+    requireEvidence(
+      evidence.outcome === "recovered_after_crash",
+      "crash_recovered",
+    );
+    requireEvidence(evidence.pullRequestCount === 1, "exactly_one_pr");
+    requireEvidence(evidence.createCalls === 1, "single_create_call");
+    requireEvidence(evidence.replayOutcome === "adopted", "crash_replay_adopts");
+  }
+  if (evidence.case === "credential-scope-too-wide") {
+    requireEvidence(evidence.outcome === "refused", "credential_refused");
+    requireEvidence(
+      evidence.refusalReason === "credential_scope_invalid",
+      "refusal_reason:credential_scope_invalid",
+    );
+    requireEvidence(evidence.createCalls === 0, "credential_no_create");
+    requireEvidence(evidence.pullRequestCount === 0, "credential_no_pr");
+  }
+}
+
+function requireEvidence(condition: boolean, reason: string): void {
+  if (!condition) throw new Int3bEvidenceError(`INT-3b evidence failed: ${reason}`);
+}
+
+function remotePullRequest(
+  actuation: PrPayloadActuationResult,
+  number: number,
+): RemotePullRequest {
+  return {
+    repository: actuation.payload.repository,
+    number,
+    state: "open",
+    title: actuation.payload.title,
+    body: actuation.payload.body,
+    base: structuredClone(actuation.payload.base),
+    head: {
+      ref: actuation.payload.head.ref,
+      revision: sha1(`commit:${actuation.artifact.sha256}`),
+      treeSha: actuation.payload.head.treeSha,
+    },
+  };
+}
+
+function importSpecifiers(source: string): string[] {
+  return [...source.matchAll(/\bfrom\s+["']([^"']+)["']/gu)]
+    .map((match) => match[1]!)
+    .sort();
+}
+
+async function approvedTask(baseRevision: string): Promise<AgentTaskV1> {
+  const fixture = JSON.parse(await readFile(
+    new URL(
+      "../fixtures/agent-integration/agent-task-v1.json",
+      import.meta.url,
+    ),
+    "utf8",
+  )) as Record<string, unknown>;
+  const candidate = agentTaskV1Schema.parse({
+    ...fixture,
+    workItemId: "int3b-one-work-item",
+    correlationId: "int3b-one-correlation",
+    lifecycle: "handoff_ready",
+    proposal: {
+      ...(fixture.proposal as object),
+      title: "Open the verified INT-3b pull request",
+      objective: "Send exactly one pull request for the verified documentation patch.",
+    },
+    repository: {
+      provider: "github",
+      nameWithOwner: PINNED_REPOSITORY,
+      baseRevision,
+      allowedPaths: ["docs/**"],
+      forbiddenPaths: ["src/**", "ops/**"],
+    },
+    requestedAuthority: {
+      ...(fixture.requestedAuthority as object),
+      grants: [{
+        capabilityId: "fs.write_file",
+        resource: PINNED_REPOSITORY,
+        constraints: { allowedPaths: ["docs/**"] },
+      }],
+    },
+    approval: {
+      required: "operator",
+      status: "approved",
+      actor: { type: "operator", id: "int3b-operator" },
+      decidedAt: "2026-07-23T12:05:00.000Z",
+      policyVersion: "dispatch-policy-v1",
+      policyHash: C_HASH,
+      approvedTaskHash: ZERO_HASH,
+    },
+    timestamps: {
+      proposedAt: "2026-07-23T12:00:00.000Z",
+      approvedAt: "2026-07-23T12:05:00.000Z",
+      runBoundAt: "2026-07-23T12:06:00.000Z",
+      updatedAt: "2026-07-23T12:30:00.000Z",
+    },
+    bindings: {
+      harnessRunId: RUN_ID,
+      runManifestRef: ref(D_HASH),
+      runManifestHash: D_HASH,
+    },
+  });
+  const approvedTaskHash = await hashAgentTaskApprovalPayload(candidate);
+  return agentTaskV1Schema.parse({
+    ...candidate,
+    approval: { ...candidate.approval, approvedTaskHash },
+  });
+}
+
+function completedRun(approved: AgentTaskV1): AgentRunProjectionV1 {
+  return agentRunProjectionV1Schema.parse({
+    schemaVersion: 1,
+    kind: "agent_run_projection",
+    workItemId: approved.workItemId,
+    correlationId: approved.correlationId,
+    harnessRunId: RUN_ID,
+    taskVersion: approved.taskVersion,
+    source: {
+      system: "agent-harness",
+      health: "healthy",
+      observedAt: "2026-07-23T12:30:00.000Z",
+      sourceUpdatedAt: "2026-07-23T12:29:59.000Z",
+    },
+    heartbeat: {
+      status: "terminal",
+      lastEventAt: "2026-07-23T12:29:59.000Z",
+      ageSeconds: 1,
+    },
+    run: {
+      state: "completed",
+      attempt: 1,
+      terminal: true,
+      outcome: "completed",
+      lastEventAt: "2026-07-23T12:29:59.000Z",
+    },
+    manifest: {
+      ref: ref(D_HASH),
+      hash: D_HASH,
+      profile: approved.intent.profile,
+      riskClass: "low",
+      effectiveCapabilities: ["fs.write_file"],
+      network: "deny",
+      policyHash: approved.approval.policyHash,
+      verifierHash: approved.acceptance.verifierPlanHash,
+      modelBindings: [],
+      skillVersions: [],
+    },
+    progress: { phase: "completed", summary: "Verified patch ready.", completedUnits: 1, totalUnits: 1 },
+    budget: {
+      elapsedSecondsUsed: 30,
+      elapsedSecondsLimit: approved.budget.elapsedSeconds,
+      modelTokensUsed: 1,
+      modelTokensLimit: approved.budget.modelTokens,
+      toolCallsUsed: 1,
+      toolCallsLimit: approved.budget.toolCalls,
+      estimatedUsdMicrosUsed: 0,
+      estimatedUsdMicrosLimit: approved.budget.estimatedUsdMicros,
+      exhausted: false,
+    },
+    artifacts: [],
+    verification: { status: "passed", decisionRef: ref(E_HASH), decisionHash: E_HASH },
+    bindings: approved.bindings,
+  });
+}
+
+function acceptedHandoff(
+  approved: AgentTaskV1,
+  projection: AgentRunProjectionV1,
+  patchRef: ArtifactRef,
+): VerifiedHandoffV1 {
+  return verifiedHandoffV1Schema.parse({
+    schemaVersion: 1,
+    kind: "verified_handoff",
+    workItemId: approved.workItemId,
+    correlationId: approved.correlationId,
+    harnessRunId: projection.harnessRunId,
+    taskVersion: approved.taskVersion,
+    taskHash: approved.approval.approvedTaskHash,
+    taskIntentRef: approved.intent.templateRef,
+    taskIntentHash: approved.intent.templateHash,
+    runManifestRef: projection.manifest.ref,
+    runManifestHash: projection.manifest.hash,
+    outcome: "completed",
+    deliverables: {
+      patchRef,
+      summaryRef: ref(A_HASH),
+      structuredSubmissionRef: ref(E_HASH),
+      artifacts: [patchRef],
+    },
+    checks: [{ name: "format-command", status: "passed", evidenceRef: ref(B_HASH) }],
+    verification: {
+      verified: true,
+      decision: "accept",
+      verifier: { type: "verifier", id: "int3b-independent-verifier" },
+      planHash: approved.acceptance.verifierPlanHash,
+      decisionRef: ref(E_HASH),
+      decisionHash: E_HASH,
+      evidenceRefs: [ref(B_HASH)],
+      verifiedAt: "2026-07-23T12:29:59.000Z",
+    },
+    openQuestions: [],
+    eligibleForPrOpen: true,
+    generatedAt: "2026-07-23T12:30:00.000Z",
+  });
+}
+
+async function makePatch(
+  repositoryRoot: string,
+  relativePath: string,
+  changed: string,
+  original: string,
+): Promise<string> {
+  const target = path.join(repositoryRoot, relativePath);
+  await writeFile(target, changed, "utf8");
+  const patch = await git(
+    ["diff", "--binary", "--no-ext-diff", "--", relativePath],
+    repositoryRoot,
+  );
+  await writeFile(target, original, "utf8");
+  if (!patch.trim()) throw new Error(`Fixture patch is empty for ${relativePath}`);
+  return patch;
+}
+
+function ref(hash: `sha256:${string}`): ArtifactRef {
+  return {
+    uri: `artifact://sha256/${hash.slice("sha256:".length)}`,
+    sha256: hash,
+  };
+}
+
+function sha1(value: string): string {
+  return createHash("sha1").update(value, "utf8").digest("hex");
+}
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const result = await execFileAsync("git", args, {
+    cwd,
+    env: {
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_NOSYSTEM: "1",
+      GIT_TERMINAL_PROMPT: "0",
+      PATH: process.env.PATH,
+    },
+  });
+  return result.stdout;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unexpected INT-3a refusal: ${String(value)}`);
+}


### PR DESCRIPTION
## What changed

- add the isolated INT-3b sender that consumes `PrPayloadActuationResult` from INT-3a without reimplementing INT-3a eligibility/refusal checks
- add an operator-side GitHub App client limited to live scope/base/head reads, deterministic verified-head materialization, and PR creation
- re-check live base and global/repository HALT directly before the create-PR call
- query the deterministic head first, adopt an exact existing PR, and converge to one PR after a crash following create
- compute Hermes `effects.mutates` from the concrete PR mutation ref when this actuation opens a PR; adopted/no-send paths remain non-mutating
- document the one-repository credential boundary, safe issuance metadata, preflight, rotation, and revocation
- add the independent INT-3b ceremony: all 22 inherited INT-3a refusal reasons plus the five send-only rows, each mutation-proven

## Safety / authority

- no real GitHub send was performed
- no credential was requested, minted, copied, printed, committed, or added to Compose/model/agent environments
- no production database or production Compose dispatch profile was used
- INT-3a remains the sole authority deciding what payload is eligible; its two source files retain their exact import surface and no HTTP client
- the sender exposes no merge, force-push, close, reopen, comment, branch-protection, default-branch, or arbitrary-repository operation
- INT-2 suite, fixtures, case count, workflow, and recorded proofs are unchanged
- merge and deploy remain human-only

## Checks

Clean committed checkout:

- `npm run typecheck` — exit 0
- `npm test` — 144 files passed, 2 expected external suites skipped; 2,060 tests passed, 14 skipped
- `npm run build` — exit 0
- `npm run test:int3a` — 8/8 green, unchanged suite
- `npm run test:int3b` — 9 test blocks green; evidence summary 27/27 cases and 27/27 deliberate mutations rejected by name
- `scripts/ceremony/run-int2-automated-suite.sh` — 10/10 through the real disposable-container path
- `docker build -f ops/Dockerfile.node -t averray-reference-agent:int3b-check .` — exit 0
- staged secret-pattern scan and `git diff --check` — clean

Observed send-only ceremony rows:

- base moved after construction → `base_drift`, no PR
- HALT declared after head materialization → `halt_global`, no PR
- exact PR already exists → adopted, create count 0, total PR count 1
- crash after create then re-run → adopted, create count 1, total PR count 1
- authorization spans two repositories → `credential_scope_invalid`, no PR

## Affected surfaces

Harness dispatcher backend, Hermes decision evidence, operator credential/runbook documentation, and integration tests only. No schema, migration, Compose, production configuration, money rail, wallet, signer, claim, submission, INT-2, or INT-3a contract changes.

## Operator follow-up before first real send

The operator still chooses the target repository and credential owner. Provisioning happens only after review/merge and a green refusal ceremony, followed by the committed live-API preflight that stops before PR creation.