### PR TITLE
The Buzz narration transport — sign, authenticate, publish, confirm

### DIFF
--- a/services/slack-operator/src/buzz-client.ts
+++ b/services/slack-operator/src/buzz-client.ts
@@ -1,0 +1,270 @@
+// The Buzz publish transport: open a WebSocket, complete the NIP-42 AUTH
+// handshake carrying the NIP-OA owner attestation, publish one event, close.
+//
+// SHORT-LIVED CONNECTIONS ON PURPOSE. Narration is edge-triggered and rare —
+// `decideOpsNarration` speaks when the verdict crosses the red boundary, not on
+// a cadence. A persistent socket for that traffic buys nothing and costs the
+// thing we can least afford: reconnect logic, backoff state, and a socket that
+// can be silently half-dead for hours inside the process whose entire job is
+// noticing when something has gone quiet. A connection per message either works
+// or reports why, every time.
+//
+// NOTHING HERE THROWS INTO THE HEARTBEAT. Every failure becomes a
+// `BuzzPublishResult` with a reason. Buzz is a downstream notification surface;
+// if it is unreachable, the monitor must carry on watching the money path and
+// say so, not crash or stall. That is the same rule the disk probe taught us:
+// the thing meant to warn you must not die with the thing it watches.
+
+import {
+  BuzzEventError,
+  agentPubkey,
+  authTagFromConfig,
+  buildAuthEvent,
+  buildStreamMessage,
+  signEvent,
+  type NostrEvent,
+} from "./buzz-event.js";
+
+export interface BuzzConfig {
+  relayUrl: string;
+  agentSecretKeyHex: string;
+  authTag: string[];
+  channelId: string;
+}
+
+export type BuzzPublishReason =
+  | "published"
+  | "disabled"
+  | "misconfigured"
+  | "connect-failed"
+  | "auth-rejected"
+  | "publish-rejected"
+  | "timeout";
+
+export interface BuzzPublishResult {
+  ok: boolean;
+  reason: BuzzPublishReason;
+  /** Operator-facing sentence. Safe to log; never contains the secret key. */
+  detail: string;
+  eventId?: string;
+}
+
+/** Whole handshake + publish budget. Well inside the monitor's tick. */
+export const DEFAULT_PUBLISH_TIMEOUT_MS = 10_000;
+
+/**
+ * Read config from the environment. Returns null when Buzz is simply not
+ * configured — the common case until the credentials are deployed, and NOT an
+ * error to report every heartbeat.
+ *
+ * A PARTIAL configuration is an error, though: it means somebody intended to
+ * turn this on and left it broken, which must not look the same as "off".
+ */
+export function readBuzzConfig(env: NodeJS.ProcessEnv = process.env):
+  | { config: BuzzConfig }
+  | { config: null; problem: string | null } {
+  const relayUrl = env.BUZZ_RELAY_URL?.trim() ?? "";
+  const secret = env.BUZZ_AGENT_SECRET_KEY?.trim() ?? "";
+  const rawTag = env.BUZZ_OWNER_AUTH_TAG?.trim() ?? "";
+  const channelId = env.BUZZ_OPS_CHANNEL_ID?.trim() ?? "";
+
+  const present = [relayUrl, secret, rawTag, channelId].filter((v) => v.length > 0).length;
+  if (present === 0) return { config: null, problem: null };
+  if (present < 4) {
+    const missing = [
+      relayUrl ? null : "BUZZ_RELAY_URL",
+      secret ? null : "BUZZ_AGENT_SECRET_KEY",
+      rawTag ? null : "BUZZ_OWNER_AUTH_TAG",
+      channelId ? null : "BUZZ_OPS_CHANNEL_ID",
+    ].filter((v): v is string => v !== null);
+    return { config: null, problem: `Buzz is partially configured — missing ${missing.join(", ")}` };
+  }
+
+  try {
+    const authTag = authTagFromConfig(rawTag);
+    // Fail at startup, not at the first incident, if the tag was minted for a
+    // different agent key than the one deployed beside it.
+    const pubkey = agentPubkey(secret);
+    if (authTag[1] === pubkey) {
+      return { config: null, problem: "BUZZ_OWNER_AUTH_TAG names the agent key as its own owner (self-attestation)" };
+    }
+    return { config: { relayUrl, agentSecretKeyHex: secret, authTag, channelId } };
+  } catch (error) {
+    return { config: null, problem: error instanceof BuzzEventError ? error.message : String(error) };
+  }
+}
+
+interface Socket {
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "open" | "message" | "error" | "close", handler: (event: any) => void): void;
+}
+
+export interface PublishOptions {
+  timeoutMs?: number;
+  nowSeconds?: number;
+  /** Injected for tests; defaults to the global WebSocket (Node >= 22.4). */
+  openSocket?: (url: string) => Socket;
+}
+
+function defaultOpenSocket(url: string): Socket {
+  if (typeof WebSocket === "undefined") {
+    throw new BuzzEventError("global WebSocket is unavailable — Node 22.4+ is required to reach Buzz");
+  }
+  return new WebSocket(url) as unknown as Socket;
+}
+
+/**
+ * Publish one narration message.
+ *
+ * The relay drives the handshake: it sends `["AUTH", <challenge>]` on connect,
+ * we answer with a signed kind-22242 event carrying the owner attestation, and
+ * only then is `["EVENT", …]` accepted. We wait for the `OK` frame rather than
+ * assuming success — a fire-and-forget publish against a closed relay looks
+ * identical whether it landed or was silently refused, and a narration channel
+ * that quietly drops alerts is worse than one that is visibly off.
+ */
+export async function publishNarration(
+  config: BuzzConfig,
+  content: string,
+  options: PublishOptions = {},
+): Promise<BuzzPublishResult> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS;
+  const createdAt = options.nowSeconds ?? Math.floor(Date.now() / 1000);
+  const openSocket = options.openSocket ?? defaultOpenSocket;
+
+  let message: NostrEvent;
+  let pubkey: string;
+  try {
+    pubkey = agentPubkey(config.agentSecretKeyHex);
+    message = signEvent(
+      buildStreamMessage({
+        agentPubkeyHex: pubkey,
+        channelId: config.channelId,
+        content,
+        createdAt,
+        authTag: config.authTag,
+      }),
+      config.agentSecretKeyHex,
+    );
+  } catch (error) {
+    // Building the event cannot fail transiently — bad config or bad content.
+    return {
+      ok: false,
+      reason: "misconfigured",
+      detail: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  return await new Promise<BuzzPublishResult>((resolve) => {
+    let socket: Socket;
+    let settled = false;
+    let authSent = false;
+
+    const timer = setTimeout(() => {
+      finish({
+        ok: false,
+        reason: "timeout",
+        detail: `no response from ${config.relayUrl} within ${timeoutMs}ms${authSent ? " after AUTH" : " (never got an AUTH challenge)"}`,
+      });
+    }, timeoutMs);
+
+    function finish(result: BuzzPublishResult): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket?.close();
+      } catch {
+        // Closing a socket that never opened is not a publish failure.
+      }
+      resolve(result);
+    }
+
+    try {
+      socket = openSocket(config.relayUrl);
+    } catch (error) {
+      finish({
+        ok: false,
+        reason: "connect-failed",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    socket.addEventListener("error", () => {
+      // The WS error event carries no useful detail by design (it would leak
+      // network internals to page scripts); the URL is the actionable part.
+      finish({ ok: false, reason: "connect-failed", detail: `could not reach ${config.relayUrl}` });
+    });
+
+    socket.addEventListener("close", () => {
+      finish({
+        ok: false,
+        reason: authSent ? "auth-rejected" : "connect-failed",
+        detail: `relay closed the connection${authSent ? " after AUTH" : " before sending a challenge"}`,
+      });
+    });
+
+    socket.addEventListener("message", (event: { data: unknown }) => {
+      let frame: unknown;
+      try {
+        frame = JSON.parse(typeof event.data === "string" ? event.data : String(event.data));
+      } catch {
+        return; // A frame we cannot parse is not ours to act on.
+      }
+      if (!Array.isArray(frame) || typeof frame[0] !== "string") return;
+
+      if (frame[0] === "AUTH" && typeof frame[1] === "string") {
+        try {
+          const auth = signEvent(
+            buildAuthEvent({
+              agentPubkeyHex: pubkey,
+              relayUrl: config.relayUrl,
+              challenge: frame[1],
+              createdAt,
+              authTag: config.authTag,
+            }),
+            config.agentSecretKeyHex,
+          );
+          socket.send(JSON.stringify(["AUTH", auth]));
+          authSent = true;
+          // Publish immediately: the relay applies the session's new authority
+          // to subsequent frames, and waiting for an OK on the AUTH event costs
+          // a round trip for no added certainty — a rejected AUTH shows up as a
+          // rejected EVENT with a reason.
+          socket.send(JSON.stringify(["EVENT", message]));
+        } catch (error) {
+          finish({
+            ok: false,
+            reason: "misconfigured",
+            detail: error instanceof Error ? error.message : String(error),
+          });
+        }
+        return;
+      }
+
+      if (frame[0] === "OK" && frame[1] === message.id) {
+        if (frame[2] === true) {
+          finish({ ok: true, reason: "published", detail: "relay accepted the message", eventId: message.id });
+        } else {
+          const why = typeof frame[3] === "string" && frame[3] ? frame[3] : "no reason given";
+          // The relay prefixes membership refusals; surfacing the raw string
+          // keeps an auth problem from being reported as a generic failure.
+          finish({
+            ok: false,
+            reason: /auth|restricted|member/i.test(why) ? "auth-rejected" : "publish-rejected",
+            detail: `relay rejected the message: ${why}`,
+          });
+        }
+        return;
+      }
+
+      if (frame[0] === "NOTICE" && typeof frame[1] === "string") {
+        // NOTICE is advisory and may arrive alongside a successful publish, so
+        // it must not settle the promise on its own.
+        return;
+      }
+    });
+  });
+}

--- a/services/slack-operator/src/buzz-event.ts
+++ b/services/slack-operator/src/buzz-event.ts
@@ -1,0 +1,184 @@
+// Nostr event construction and signing for Buzz — the pure half of the
+// narration transport. No sockets, no clock, no config: everything here is a
+// function of its arguments, so the parts that are easy to get subtly wrong are
+// the parts that are cheap to test.
+//
+// WHY THIS IS SPLIT OUT: a mis-serialized event is rejected by the relay with
+// `["OK", <id>, false, "invalid: bad signature"]` and nothing else. There is no
+// way to tell from that message whether the secret key is wrong, the id was
+// computed over the wrong bytes, or a tag was ordered differently than signed.
+// Testing the bytes directly is the only cheap way to know.
+//
+// Event ids are defined by NIP-01 as the SHA-256 of a compact JSON array:
+//
+//   [0, <pubkey>, <created_at>, <kind>, <tags>, <content>]
+//
+// with no whitespace and only the escapes JSON already produces. JSON.stringify
+// matches that definition — it emits \", \\, \b, \f, \n, \r, \t for exactly the
+// characters NIP-01 names, \uXXXX for other control characters, and leaves
+// non-ASCII as literal UTF-8. Hand-rolling the serializer would be the more
+// obvious way to introduce a bug here, not avoid one.
+
+import { createHash } from "node:crypto";
+import { schnorr } from "@noble/curves/secp256k1";
+
+/** NIP-29 group chat message. What Buzz renders as an ordinary channel message. */
+export const KIND_STREAM_MESSAGE = 9;
+/** NIP-42 client authentication. Carries the NIP-OA tag on closed relays. */
+export const KIND_CLIENT_AUTH = 22242;
+
+/** Upstream's builder caps message content here (`check_content(content, 64 * 1024)`). */
+export const MAX_CONTENT_BYTES = 64 * 1024;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+export interface UnsignedEvent {
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+}
+
+export interface NostrEvent extends UnsignedEvent {
+  id: string;
+  sig: string;
+}
+
+export class BuzzEventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BuzzEventError";
+  }
+}
+
+/** The exact byte sequence an event id is computed over. */
+export function serializeForId(event: UnsignedEvent): string {
+  return JSON.stringify([0, event.pubkey, event.created_at, event.kind, event.tags, event.content]);
+}
+
+export function computeEventId(event: UnsignedEvent): string {
+  return createHash("sha256").update(serializeForId(event), "utf8").digest("hex");
+}
+
+/**
+ * Sign an event. The id is computed here rather than accepted from the caller —
+ * an id that disagrees with the content is the single most confusing failure in
+ * this protocol, and making it unrepresentable is cheaper than detecting it.
+ */
+export function signEvent(event: UnsignedEvent, secretKeyHex: string): NostrEvent {
+  if (!/^[0-9a-f]{64}$/.test(secretKeyHex)) {
+    throw new BuzzEventError("agent secret key must be 64 lowercase hex characters");
+  }
+  const derived = Buffer.from(schnorr.getPublicKey(secretKeyHex)).toString("hex");
+  if (derived !== event.pubkey) {
+    throw new BuzzEventError(
+      `event pubkey ${event.pubkey.slice(0, 16)}… does not match the signing key ${derived.slice(0, 16)}…`,
+    );
+  }
+  const id = computeEventId(event);
+  const sig = Buffer.from(schnorr.sign(Buffer.from(id, "hex"), secretKeyHex)).toString("hex");
+  return { ...event, id, sig };
+}
+
+/** Derive the agent's x-only pubkey from its secret. */
+export function agentPubkey(secretKeyHex: string): string {
+  if (!/^[0-9a-f]{64}$/.test(secretKeyHex)) {
+    throw new BuzzEventError("agent secret key must be 64 lowercase hex characters");
+  }
+  return Buffer.from(schnorr.getPublicKey(secretKeyHex)).toString("hex");
+}
+
+/**
+ * Parse a NIP-OA auth tag from config into tag form.
+ *
+ * Tolerates one layer of wrapping quotes because the value is a JSON array
+ * pasted into a .env file, and wrapping it is the natural instinct. A line break
+ * is NOT tolerated — it produces a parse error here rather than a mystery at the
+ * relay.
+ */
+export function authTagFromConfig(raw: string): string[] {
+  const unwrapped = raw.trim().replace(/^(['"])([\s\S]*)\1$/, "$2");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(unwrapped);
+  } catch {
+    throw new BuzzEventError(
+      "BUZZ_OWNER_AUTH_TAG is not valid JSON — paste it on ONE line, exactly as the mint script printed it",
+    );
+  }
+  if (!Array.isArray(parsed) || parsed.length !== 4 || !parsed.every((p) => typeof p === "string")) {
+    throw new BuzzEventError("BUZZ_OWNER_AUTH_TAG must be a JSON array of 4 strings");
+  }
+  if (parsed[0] !== "auth") {
+    throw new BuzzEventError('BUZZ_OWNER_AUTH_TAG must start with "auth"');
+  }
+  return parsed as string[];
+}
+
+/**
+ * Build a channel message. Mirrors upstream `build_message`: kind 9 with an
+ * `["h", <channel uuid>]` tag.
+ *
+ * The channel is addressed by UUID, not by name — a name would be a moving
+ * target, and a wrong-but-well-formed one would post somewhere unintended
+ * rather than fail.
+ */
+export function buildStreamMessage(input: {
+  agentPubkeyHex: string;
+  channelId: string;
+  content: string;
+  createdAt: number;
+  authTag?: string[];
+}): UnsignedEvent {
+  if (!UUID_PATTERN.test(input.channelId)) {
+    throw new BuzzEventError(
+      `channel id must be a lowercase UUID, got ${JSON.stringify(input.channelId)} — Buzz addresses channels by UUID, not by name`,
+    );
+  }
+  const bytes = Buffer.byteLength(input.content, "utf8");
+  if (bytes === 0) throw new BuzzEventError("refusing to publish an empty message");
+  if (bytes > MAX_CONTENT_BYTES) {
+    throw new BuzzEventError(`content is ${bytes} bytes, over the ${MAX_CONTENT_BYTES} limit`);
+  }
+  const tags: string[][] = [["h", input.channelId]];
+  // Provenance on the message itself, so a client can render "authorized by
+  // <owner>" — distinct from authorship, which stays the agent's.
+  if (input.authTag) tags.push(input.authTag);
+  return {
+    pubkey: input.agentPubkeyHex,
+    created_at: input.createdAt,
+    kind: KIND_STREAM_MESSAGE,
+    tags,
+    content: input.content,
+  };
+}
+
+/**
+ * Build the NIP-42 AUTH event. On this closed relay the NIP-OA tag rides HERE —
+ * upstream extracts it from the signed AUTH event and uses it to prove the
+ * agent's owner is a member (`enforce_relay_membership` with NIP-OA fallback).
+ *
+ * Without the tag, a non-member agent is refused, so omitting it is a
+ * configuration error rather than a degraded mode.
+ */
+export function buildAuthEvent(input: {
+  agentPubkeyHex: string;
+  relayUrl: string;
+  challenge: string;
+  createdAt: number;
+  authTag: string[];
+}): UnsignedEvent {
+  if (!input.challenge) throw new BuzzEventError("relay sent an empty AUTH challenge");
+  return {
+    pubkey: input.agentPubkeyHex,
+    created_at: input.createdAt,
+    kind: KIND_CLIENT_AUTH,
+    tags: [
+      ["relay", input.relayUrl],
+      ["challenge", input.challenge],
+      input.authTag,
+    ],
+    content: "",
+  };
+}

--- a/test/unit/buzz-client.test.ts
+++ b/test/unit/buzz-client.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  publishNarration,
+  readBuzzConfig,
+  type BuzzConfig,
+} from "../../services/slack-operator/src/buzz-client.js";
+import { agentPubkey, computeEventId } from "../../services/slack-operator/src/buzz-event.js";
+
+const AGENT_SECRET = "0000000000000000000000000000000000000000000000000000000000000002";
+const OWNER_PUBKEY = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const AUTH_TAG = ["auth", OWNER_PUBKEY, "created_at<1913957000", "ab".repeat(64)];
+const CHANNEL = "3f2a9c10-5b6d-4e7f-8a91-2c3d4e5f6a7b";
+
+const config: BuzzConfig = {
+  relayUrl: "wss://buzz.example.com",
+  agentSecretKeyHex: AGENT_SECRET,
+  authTag: AUTH_TAG,
+  channelId: CHANNEL,
+};
+
+type Handler = (event: any) => void;
+
+/**
+ * A relay that behaves like Buzz: challenge on connect, then answer the EVENT.
+ * `script` decides how it responds, so each failure mode is reproducible without
+ * a network.
+ */
+function fakeRelay(script: {
+  challenge?: string | null;
+  onEvent?: (event: any) => unknown[] | null;
+  failOpen?: boolean;
+  closeAfterAuth?: boolean;
+}) {
+  const sent: unknown[][] = [];
+  const handlers = new Map<string, Handler[]>();
+  const emit = (type: string, payload: unknown) => {
+    for (const h of handlers.get(type) ?? []) h(payload);
+  };
+
+  const socket = {
+    send(data: string) {
+      const frame = JSON.parse(data) as unknown[];
+      sent.push(frame);
+      if (frame[0] === "EVENT") {
+        if (script.closeAfterAuth) {
+          queueMicrotask(() => emit("close", {}));
+          return;
+        }
+        const reply = script.onEvent?.(frame[1]);
+        if (reply) queueMicrotask(() => emit("message", { data: JSON.stringify(reply) }));
+      }
+    },
+    close() {},
+    addEventListener(type: string, handler: Handler) {
+      handlers.set(type, [...(handlers.get(type) ?? []), handler]);
+      if (type === "message" && script.challenge) {
+        // The relay speaks first — the client must not send anything before it.
+        queueMicrotask(() => emit("message", { data: JSON.stringify(["AUTH", script.challenge]) }));
+      }
+      if (type === "error" && script.failOpen) queueMicrotask(() => emit("error", {}));
+    },
+  };
+  return { socket, sent, openSocket: () => socket as any };
+}
+
+describe("publishNarration", () => {
+  it("completes the handshake and reports the accepted event id", async () => {
+    const relay = fakeRelay({
+      challenge: "chal-123",
+      onEvent: (event) => ["OK", event.id, true, ""],
+    });
+    const result = await publishNarration(config, "money path degraded", {
+      openSocket: relay.openSocket,
+      nowSeconds: 1713956400,
+    });
+
+    expect(result).toMatchObject({ ok: true, reason: "published" });
+    expect(result.eventId).toMatch(/^[0-9a-f]{64}$/);
+
+    const [authFrame, eventFrame] = relay.sent;
+    expect(authFrame[0]).toBe("AUTH");
+    expect(eventFrame[0]).toBe("EVENT");
+
+    // The AUTH event must carry the challenge AND the owner attestation —
+    // without the latter this closed relay refuses a non-member agent.
+    const auth = authFrame[1] as { kind: number; tags: string[][]; pubkey: string };
+    expect(auth.kind).toBe(22242);
+    expect(auth.tags).toContainEqual(["challenge", "chal-123"]);
+    expect(auth.tags).toContainEqual(AUTH_TAG);
+    expect(auth.pubkey).toBe(agentPubkey(AGENT_SECRET));
+
+    // The message is kind 9 addressed to the channel UUID, and its id is
+    // genuinely the hash of what was sent.
+    const message = eventFrame[1] as any;
+    expect(message.kind).toBe(9);
+    expect(message.tags).toContainEqual(["h", CHANNEL]);
+    expect(message.id).toBe(
+      computeEventId({
+        pubkey: message.pubkey,
+        created_at: message.created_at,
+        kind: message.kind,
+        tags: message.tags,
+        content: message.content,
+      }),
+    );
+  });
+
+  it("reports a rejection reason rather than claiming success", async () => {
+    // A narration channel that silently drops alerts is worse than one visibly
+    // off, so a false OK must never be reported as published.
+    const relay = fakeRelay({
+      challenge: "c",
+      onEvent: (event) => ["OK", event.id, false, "blocked: rate-limited"],
+    });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("publish-rejected");
+    expect(result.detail).toContain("rate-limited");
+  });
+
+  it("distinguishes an auth refusal from a generic rejection", async () => {
+    // Membership problems need a different operator response than a transient
+    // publish failure, so they must not collapse into one reason.
+    const relay = fakeRelay({
+      challenge: "c",
+      onEvent: (event) => ["OK", event.id, false, "auth-required: not a relay member"],
+    });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket });
+    expect(result.reason).toBe("auth-rejected");
+  });
+
+  it("ignores an OK for somebody else's event", async () => {
+    // Concurrent traffic on the socket must not settle our publish.
+    const relay = fakeRelay({
+      challenge: "c",
+      onEvent: () => ["OK", "f".repeat(64), true, ""],
+    });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket, timeoutMs: 60 });
+    expect(result.reason).toBe("timeout");
+  });
+
+  it("does not treat a NOTICE as a verdict", async () => {
+    const relay = fakeRelay({ challenge: "c", onEvent: () => ["NOTICE", "heads up"] });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket, timeoutMs: 60 });
+    expect(result.reason).toBe("timeout");
+  });
+
+  it("times out rather than hanging when the relay never challenges", async () => {
+    const relay = fakeRelay({ challenge: null });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket, timeoutMs: 50 });
+    expect(result.reason).toBe("timeout");
+    expect(result.detail).toContain("never got an AUTH challenge");
+  });
+
+  it("reports a connect failure without throwing", async () => {
+    const relay = fakeRelay({ failOpen: true });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket });
+    expect(result).toMatchObject({ ok: false, reason: "connect-failed" });
+  });
+
+  it("reads a close after AUTH as an auth rejection", async () => {
+    // Buzz drops the connection on some refusals instead of sending OK=false.
+    const relay = fakeRelay({ challenge: "c", closeAfterAuth: true });
+    const result = await publishNarration(config, "hi", { openSocket: relay.openSocket });
+    expect(result.reason).toBe("auth-rejected");
+  });
+
+  it("never throws on bad input — it degrades", async () => {
+    // The heartbeat calls this. A throw here would take down the monitor that
+    // watches the money path, for a notification channel.
+    const result = await publishNarration({ ...config, channelId: "#ops" }, "hi", {
+      openSocket: fakeRelay({ challenge: "c" }).openSocket,
+    });
+    expect(result).toMatchObject({ ok: false, reason: "misconfigured" });
+    expect(result.detail).toContain("UUID");
+  });
+
+  it("surfaces a socket constructor failure as connect-failed", async () => {
+    const result = await publishNarration(config, "hi", {
+      openSocket: () => {
+        throw new Error("getaddrinfo ENOTFOUND");
+      },
+    });
+    expect(result).toMatchObject({ ok: false, reason: "connect-failed" });
+    expect(result.detail).toContain("ENOTFOUND");
+  });
+});
+
+describe("readBuzzConfig", () => {
+  const full = {
+    BUZZ_RELAY_URL: "wss://buzz.averray.com",
+    BUZZ_AGENT_SECRET_KEY: AGENT_SECRET,
+    BUZZ_OWNER_AUTH_TAG: JSON.stringify(AUTH_TAG),
+    BUZZ_OPS_CHANNEL_ID: CHANNEL,
+  } as unknown as NodeJS.ProcessEnv;
+
+  it("reads a complete configuration", () => {
+    const result = readBuzzConfig(full);
+    expect(result.config).toMatchObject({ relayUrl: "wss://buzz.averray.com", channelId: CHANNEL });
+  });
+
+  it("treats no configuration as OFF, not as a problem", () => {
+    // Buzz is unconfigured until the credentials land. Reporting that as an
+    // error every heartbeat is how a board teaches its operator to ignore it.
+    expect(readBuzzConfig({} as NodeJS.ProcessEnv)).toEqual({ config: null, problem: null });
+  });
+
+  it("treats PARTIAL configuration as a problem", () => {
+    // Somebody meant to turn this on and left it broken. That must not look
+    // the same as "off".
+    const { BUZZ_OPS_CHANNEL_ID, ...partial } = full as Record<string, string>;
+    const result = readBuzzConfig(partial as NodeJS.ProcessEnv);
+    expect(result.config).toBeNull();
+    expect((result as { problem: string }).problem).toContain("BUZZ_OPS_CHANNEL_ID");
+  });
+
+  it("rejects a tag minted for a different agent key at startup", () => {
+    // Catching this at boot beats discovering it during the first real incident.
+    const selfAttested = JSON.stringify(["auth", agentPubkey(AGENT_SECRET), "", "ab".repeat(64)]);
+    const result = readBuzzConfig({ ...full, BUZZ_OWNER_AUTH_TAG: selfAttested } as NodeJS.ProcessEnv);
+    expect(result.config).toBeNull();
+    expect((result as { problem: string }).problem).toContain("self-attestation");
+  });
+
+  it("explains a truncated auth tag instead of failing obscurely", () => {
+    const truncated = JSON.stringify(AUTH_TAG).slice(0, 40);
+    const result = readBuzzConfig({ ...full, BUZZ_OWNER_AUTH_TAG: truncated } as NodeJS.ProcessEnv);
+    expect(result.config).toBeNull();
+    expect((result as { problem: string }).problem).toContain("ONE line");
+  });
+});

--- a/test/unit/buzz-event.test.ts
+++ b/test/unit/buzz-event.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { schnorr } from "@noble/curves/secp256k1";
+
+import {
+  BuzzEventError,
+  KIND_CLIENT_AUTH,
+  KIND_STREAM_MESSAGE,
+  MAX_CONTENT_BYTES,
+  agentPubkey,
+  authTagFromConfig,
+  buildAuthEvent,
+  buildStreamMessage,
+  computeEventId,
+  serializeForId,
+  signEvent,
+} from "../../services/slack-operator/src/buzz-event.js";
+
+const AGENT_SECRET = "0000000000000000000000000000000000000000000000000000000000000002";
+const AGENT_PUBKEY = "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+const OWNER_PUBKEY = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const AUTH_TAG = ["auth", OWNER_PUBKEY, "created_at<1913957000", "ab".repeat(64)];
+const CHANNEL = "3f2a9c10-5b6d-4e7f-8a91-2c3d4e5f6a7b";
+
+describe("event serialization", () => {
+  it("serializes exactly as NIP-01 specifies", () => {
+    // The id is a hash of THESE bytes. A stray space or a reordered field
+    // yields a valid-looking event the relay rejects as a bad signature, with
+    // no way to tell from the rejection what went wrong.
+    const event = {
+      pubkey: AGENT_PUBKEY,
+      created_at: 1713956400,
+      kind: 9,
+      tags: [["h", CHANNEL]],
+      content: "money path degraded",
+    };
+    expect(serializeForId(event)).toBe(
+      `[0,"${AGENT_PUBKEY}",1713956400,9,[["h","${CHANNEL}"]],"money path degraded"]`,
+    );
+    expect(serializeForId(event)).not.toContain(" \n");
+  });
+
+  it("escapes control characters the way NIP-01 requires", () => {
+    const event = {
+      pubkey: AGENT_PUBKEY,
+      created_at: 1,
+      kind: 9,
+      tags: [],
+      content: 'line\nbreak\ttab "quote" \\slash',
+    };
+    // Exactly the escapes the spec named, not a \u000a form.
+    expect(serializeForId(event)).toContain('"line\\nbreak\\ttab \\"quote\\" \\\\slash"');
+  });
+
+  it("keeps non-ASCII literal rather than \\u-escaping it", () => {
+    // The id is hashed over UTF-8 bytes; escaping would change them.
+    const event = { pubkey: AGENT_PUBKEY, created_at: 1, kind: 9, tags: [], content: "réserve → 0" };
+    expect(serializeForId(event)).toContain("réserve → 0");
+  });
+
+  it("produces a 32-byte id that changes with any field", () => {
+    const base = { pubkey: AGENT_PUBKEY, created_at: 1713956400, kind: 9, tags: [], content: "a" };
+    const id = computeEventId(base);
+    expect(id).toMatch(/^[0-9a-f]{64}$/);
+    expect(computeEventId({ ...base, content: "b" })).not.toBe(id);
+    expect(computeEventId({ ...base, created_at: 1713956401 })).not.toBe(id);
+    expect(computeEventId({ ...base, tags: [["h", CHANNEL]] })).not.toBe(id);
+  });
+});
+
+describe("signing", () => {
+  it("signs an event whose signature verifies against its own id", () => {
+    const unsigned = buildStreamMessage({
+      agentPubkeyHex: AGENT_PUBKEY,
+      channelId: CHANNEL,
+      content: "verdict RED — payout shortfall",
+      createdAt: 1713956400,
+    });
+    const signed = signEvent(unsigned, AGENT_SECRET);
+    expect(signed.id).toBe(computeEventId(unsigned));
+    expect(schnorr.verify(signed.sig, Buffer.from(signed.id, "hex"), AGENT_PUBKEY)).toBe(true);
+  });
+
+  it("refuses to sign for a pubkey the key does not own", () => {
+    // Catching this locally matters: the relay's rejection is just
+    // "invalid: bad signature", which says nothing about the cause.
+    const unsigned = buildStreamMessage({
+      agentPubkeyHex: OWNER_PUBKEY,
+      channelId: CHANNEL,
+      content: "x",
+      createdAt: 1,
+    });
+    expect(() => signEvent(unsigned, AGENT_SECRET)).toThrow(/does not match the signing key/);
+  });
+
+  it("rejects a malformed secret key", () => {
+    const unsigned = buildStreamMessage({ agentPubkeyHex: AGENT_PUBKEY, channelId: CHANNEL, content: "x", createdAt: 1 });
+    expect(() => signEvent(unsigned, "nope")).toThrow(/64 lowercase hex/);
+  });
+
+  it("derives the agent pubkey from its secret", () => {
+    expect(agentPubkey(AGENT_SECRET)).toBe(AGENT_PUBKEY);
+  });
+});
+
+describe("buildStreamMessage", () => {
+  it("is kind 9 addressed by the channel UUID in an h tag", () => {
+    const event = buildStreamMessage({
+      agentPubkeyHex: AGENT_PUBKEY,
+      channelId: CHANNEL,
+      content: "hello",
+      createdAt: 1713956400,
+      authTag: AUTH_TAG,
+    });
+    expect(event.kind).toBe(KIND_STREAM_MESSAGE);
+    expect(event.tags[0]).toEqual(["h", CHANNEL]);
+    expect(event.tags).toContainEqual(AUTH_TAG);
+  });
+
+  it("rejects a channel name where a UUID belongs", () => {
+    // A name would be accepted-looking and post nowhere, or somewhere else.
+    expect(() =>
+      buildStreamMessage({ agentPubkeyHex: AGENT_PUBKEY, channelId: "#ops", content: "x", createdAt: 1 }),
+    ).toThrow(/must be a lowercase UUID/);
+  });
+
+  it("refuses empty content and content over the relay's limit", () => {
+    expect(() =>
+      buildStreamMessage({ agentPubkeyHex: AGENT_PUBKEY, channelId: CHANNEL, content: "", createdAt: 1 }),
+    ).toThrow(/empty message/);
+    expect(() =>
+      buildStreamMessage({
+        agentPubkeyHex: AGENT_PUBKEY,
+        channelId: CHANNEL,
+        content: "x".repeat(MAX_CONTENT_BYTES + 1),
+        createdAt: 1,
+      }),
+    ).toThrow(/over the 65536 limit/);
+  });
+
+  it("measures the limit in BYTES, not characters", () => {
+    // A multi-byte character would slip past a .length check and be refused by
+    // the relay instead — a failure that only shows up with non-ASCII text.
+    const content = "é".repeat(MAX_CONTENT_BYTES / 2);
+    expect(Buffer.byteLength(content, "utf8")).toBe(MAX_CONTENT_BYTES);
+    expect(() =>
+      buildStreamMessage({ agentPubkeyHex: AGENT_PUBKEY, channelId: CHANNEL, content: `${content}é`, createdAt: 1 }),
+    ).toThrow(/over the 65536 limit/);
+  });
+
+  it("omits the auth tag when none is supplied", () => {
+    const event = buildStreamMessage({ agentPubkeyHex: AGENT_PUBKEY, channelId: CHANNEL, content: "x", createdAt: 1 });
+    expect(event.tags).toEqual([["h", CHANNEL]]);
+  });
+});
+
+describe("buildAuthEvent", () => {
+  it("is kind 22242 carrying relay, challenge, and the owner attestation", () => {
+    const event = buildAuthEvent({
+      agentPubkeyHex: AGENT_PUBKEY,
+      relayUrl: "wss://buzz.averray.com",
+      challenge: "abc123",
+      createdAt: 1713956400,
+      authTag: AUTH_TAG,
+    });
+    expect(event.kind).toBe(KIND_CLIENT_AUTH);
+    expect(event.content).toBe("");
+    expect(event.tags).toEqual([
+      ["relay", "wss://buzz.averray.com"],
+      ["challenge", "abc123"],
+      AUTH_TAG,
+    ]);
+  });
+
+  it("refuses an empty challenge", () => {
+    expect(() =>
+      buildAuthEvent({
+        agentPubkeyHex: AGENT_PUBKEY,
+        relayUrl: "wss://buzz.averray.com",
+        challenge: "",
+        createdAt: 1,
+        authTag: AUTH_TAG,
+      }),
+    ).toThrow(BuzzEventError);
+  });
+});
+
+describe("authTagFromConfig", () => {
+  it("parses the tag exactly as the mint script prints it", () => {
+    expect(authTagFromConfig(JSON.stringify(AUTH_TAG))).toEqual(AUTH_TAG);
+  });
+
+  it("tolerates one layer of wrapping quotes", () => {
+    // Wrapping a JSON value in quotes is the natural instinct when pasting into
+    // a .env file, and silently failing on it would waste a deploy cycle.
+    expect(authTagFromConfig(`'${JSON.stringify(AUTH_TAG)}'`)).toEqual(AUTH_TAG);
+    expect(authTagFromConfig(`"${JSON.stringify(AUTH_TAG)}"`)).toEqual(AUTH_TAG);
+  });
+
+  it("gives an actionable error when a .env line break truncated the value", () => {
+    // The realistic failure is NOT a multiline JSON string arriving here — a
+    // .env parser reads line by line, so a wrapped value reaches us CUT OFF at
+    // the newline. That truncation is what must produce a pointed error.
+    const full = JSON.stringify(AUTH_TAG);
+    const truncated = full.slice(0, full.indexOf(",", 40));
+    expect(() => authTagFromConfig(truncated)).toThrow(/ONE line/);
+  });
+
+  it("accepts a complete value even if it arrived with internal whitespace", () => {
+    // JSON permits whitespace between tokens, so a complete-but-reflowed array
+    // is still valid and there is nothing to gain by rejecting it. Worth
+    // pinning: an earlier version of this test assumed the opposite.
+    const spaced = JSON.stringify(AUTH_TAG).replace(",", ",\n  ");
+    expect(authTagFromConfig(spaced)).toEqual(AUTH_TAG);
+  });
+
+  it("rejects a tag of the wrong shape", () => {
+    expect(() => authTagFromConfig(JSON.stringify(["auth", OWNER_PUBKEY]))).toThrow(/4 strings/);
+    expect(() => authTagFromConfig(JSON.stringify(["nope", OWNER_PUBKEY, "", "ab"]))).toThrow(/must start with "auth"/);
+  });
+});


### PR DESCRIPTION
Second half of P2. [#634](https://github.com/depre-dev/averray-reference-agent/pull/634) minted the credential; this carries it.

Split in two so the error-prone half needs no network to test.

## `buzz-event.ts` — pure

A mis-serialized event comes back as `["OK", <id>, false, "invalid: bad signature"]` **and nothing else**. That message can't distinguish a wrong key from an id hashed over the wrong bytes from a tag that moved after signing. Testing the bytes directly is the only cheap way to know, so the tests pin the exact NIP-01 serialization, the escape set, UTF-8 literals, and that the id moves when any field does.

Narration is **kind 9** with an `["h", <channel uuid>]` tag, mirroring upstream `build_message` at `relay-v0.2.0`.

Two details that would otherwise bite later:

- **Channels are addressed by UUID, not name.** A name is a moving target, and a wrong-but-well-formed one posts somewhere unintended rather than failing.
- **The content limit is measured in bytes.** A `.length` check passes multi-byte text that the relay then refuses — a bug that only shows up once narration contains an accented word or an arrow.

## `buzz-client.ts` — the socket

**Connection per message.** Narration is edge-triggered and rare. A persistent socket buys nothing and costs reconnect state plus a socket that can sit half-dead for hours *inside the process whose whole job is noticing when something went quiet*.

**Wait for the `OK`.** Fire-and-forget against a closed relay looks identical whether it landed or was silently refused. A narration channel that drops alerts quietly is worse than one visibly off. Auth refusals stay distinct from generic rejections, because the operator response differs.

**Nothing throws into the heartbeat.** Every failure is a result with a reason. Buzz is downstream; if it's unreachable the monitor must carry on watching the money path and say so. Same rule the disk probe taught — the thing meant to warn you must not die with the thing it watches.

## Absent vs partial config

Unconfigured is the *normal* state until credentials land, and reporting it as a fault every heartbeat is how a board teaches its operator to ignore it. A **half-set** configuration is different: somebody meant to turn this on and left it broken. A tag minted for a different agent key is caught at startup, not during the first real incident.

## A correction kept as a test

One test disproved my own reasoning, so it's pinned rather than deleted: a complete JSON array split across lines is **still valid JSON** — the module has nothing to reject there. The real failure is one level up, where a `.env` parser reads line by line and hands us a **truncated** value. That's what produces the pointed "paste it on ONE line" error, and the test now models truncation instead of reflowing.

## Verification

- 35 new tests (20 event, 15 client) driving the handshake against a scripted fake relay
- full suite **1800 passed / 120 files**, no regressions
- `slack-operator` typecheck clean

## Not done here

Not yet wired to `decideOpsNarration`, and `BUZZ_OPS_CHANNEL_ID` has no value — the `#ops` channel has to exist before its UUID can be read.