### PR TITLE
Narration reaches a human — wire the heartbeat, add a hand trigger

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -345,6 +345,19 @@ services:
       PRODUCT_HEALTH_INTERVAL_MINUTES: ${PRODUCT_HEALTH_INTERVAL_MINUTES:-2}
       # Repeat an unchanged RED incident at most every 6h. Set 0 for edge-only alerts.
       PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES: ${PRODUCT_HEALTH_ALERT_COOLDOWN_MINUTES:-360}
+      # Buzz narration delivery. ALL FOUR or none: a partial set is treated as a
+      # misconfiguration and logged, because somebody meaning to turn this on and
+      # leaving it half-done must not look identical to leaving it off.
+      #
+      # BUZZ_OWNER_AUTH_TAG is a NIP-OA capability signed by the operator's key —
+      # not the key itself, which never reaches this box. BUZZ_AGENT_SECRET_KEY
+      # IS a credential: anyone holding it can post as Hermes.
+      #
+      # The channel is addressed by UUID, not name (see buzz-event.ts).
+      BUZZ_RELAY_URL: ${BUZZ_RELAY_URL:-}
+      BUZZ_AGENT_SECRET_KEY: ${BUZZ_AGENT_SECRET_KEY:-}
+      BUZZ_OWNER_AUTH_TAG: ${BUZZ_OWNER_AUTH_TAG:-}
+      BUZZ_OPS_CHANNEL_ID: ${BUZZ_OPS_CHANNEL_ID:-}
       # Monitor snapshots fan out across open PRs and their check runs. Keep the
       # timeout operator-tunable; the live mainnet calibration raises it from the
       # conservative generic default without changing testnet behaviour.

--- a/services/slack-operator/src/buzz-say.ts
+++ b/services/slack-operator/src/buzz-say.ts
@@ -1,0 +1,59 @@
+// Hand-triggered Buzz publish — the first real test of the narration path.
+//
+//   docker compose … exec slack-operator \
+//     node services/slack-operator/dist/buzz-say.js "hello from Hermes"
+//
+// WHY A SEPARATE ENTRY POINT rather than waiting for a real incident: every
+// piece of this path has so far only been proven against a scripted fake relay.
+// The credential, the owner attestation, the closed-relay membership check, the
+// channel UUID, and TLS through the Cloudflare tunnel have never been exercised
+// together. Discovering a problem in any of them for the first time DURING a
+// money-path incident — when narration is the thing meant to tell you — is the
+// worst possible moment.
+//
+// It runs INSIDE the container on purpose. The point is to test the deployed
+// configuration, not a local approximation of it: same env, same credentials,
+// same network path, same code. A script that passes on a laptop and fails in
+// production has tested the wrong thing.
+
+import { publishNarration, readBuzzConfig } from "./buzz-client.js";
+
+async function main(): Promise<void> {
+  const text = process.argv.slice(2).join(" ").trim()
+    || `Hermes checking in — narration path test at ${new Date().toISOString()}`;
+
+  const result = readBuzzConfig();
+  if (!result.config) {
+    // Distinguish "not set up" from "set up wrong" — the same distinction the
+    // heartbeat makes, for the same reason.
+    console.error(result.problem ?? "Buzz is not configured (no BUZZ_* variables set)");
+    process.exitCode = 1;
+    return;
+  }
+
+  const { relayUrl, channelId } = result.config;
+  console.log(`publishing to ${relayUrl} channel ${channelId}`);
+  console.log(`  ${text}`);
+
+  const publish = await publishNarration(result.config, text);
+  if (publish.ok) {
+    console.log(`\nOK — ${publish.detail} (event ${publish.eventId})`);
+    console.log("Check the channel in Buzz. If it is not there, the relay accepted an event");
+    console.log("addressed to a DIFFERENT channel — verify BUZZ_OPS_CHANNEL_ID.");
+    return;
+  }
+
+  console.error(`\nFAILED [${publish.reason}] ${publish.detail}`);
+  if (publish.reason === "auth-rejected") {
+    console.error("\nThe relay refused the owner attestation. Likely causes, in order:");
+    console.error("  · BUZZ_OWNER_AUTH_TAG was minted for a different agent key");
+    console.error("  · the owner in the tag is no longer a relay member");
+    console.error("  · BUZZ_ALLOW_NIP_OA_AUTH is not true on the relay");
+  }
+  process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -152,6 +152,7 @@ import {
   type HermesProductHealthSnapshot,
 } from "./monitor-hermes-voice.js";
 import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
+import { publishNarration, readBuzzConfig } from "./buzz-client.js";
 import {
   emitCopilotStreamEvent,
   onCopilotStreamEvent,
@@ -3709,6 +3710,34 @@ function startOperatorRoutines() {
           logger.info({ edge: opsNarration.edge }, "ops_narration_posted");
         } catch (err) {
           logger.warn({ err }, "ops_narration_post_failed");
+        }
+        // Deliver to Buzz, where a human will actually see it. The collaboration
+        // record above is the local, durable copy and stays regardless: it is
+        // written synchronously and cannot fail because a relay is unreachable.
+        //
+        // The cooldown is stamped on the LOCAL record, not on this delivery. A
+        // Buzz outage must not re-arm the edge and produce a burst of duplicates
+        // once the relay comes back.
+        //
+        // Awaited rather than fired-and-forgotten: an unhandled rejection inside
+        // the heartbeat is exactly how a monitor dies of a notification channel.
+        const buzz = readBuzzConfig();
+        if (buzz.config) {
+          const delivery = await publishNarration(buzz.config, opsNarration.text);
+          if (delivery.ok) {
+            logger.info({ edge: opsNarration.edge, eventId: delivery.eventId }, "ops_narration_buzz_published");
+          } else {
+            // WARN, not INFO: a narration channel that is silent because it is
+            // broken looks exactly like one that is silent because all is well.
+            // Whoever reads these logs must be able to tell those apart.
+            logger.warn(
+              { edge: opsNarration.edge, reason: delivery.reason, detail: delivery.detail },
+              "ops_narration_buzz_failed",
+            );
+          }
+        } else if (buzz.problem) {
+          // Absent config is silent by design; a BROKEN one is not.
+          logger.warn({ problem: buzz.problem }, "ops_narration_buzz_misconfigured");
         }
       } else if (opsNarration.suppressed) {
         logger.info({ edge: opsNarration.edge, suppressed: opsNarration.suppressed }, "ops_narration_suppressed");


### PR DESCRIPTION
P3, stacked on [#636](https://github.com/depre-dev/averray-reference-agent/pull/636).

`decideOpsNarration` has been deciding correctly and **writing into a void** — its only sink was `recordCollaborationMessage`, a thread nothing has rendered since the co-pilot rail was removed. The logic needed a transport, not a rewrite. That's all this adds.

## Both sinks, and why the split matters

| sink | role |
|---|---|
| `recordCollaborationMessage` | local durable copy — synchronous, can't fail because a relay is unreachable |
| `publishNarration` | delivery to a human |

**The cooldown is stamped on the local record, not the delivery.** Leaving the edge un-stamped during a Buzz outage would re-arm it and fire a burst of duplicates when the relay came back.

**The publish is awaited, not fired and forgotten.** An unhandled rejection inside the heartbeat is precisely how a monitor dies of its notification channel.

## Silence has to be legible

A failed delivery logs at **WARN**, and that isn't cosmetic: *a narration channel that is silent because it is broken looks exactly like one that is silent because nothing is wrong.* Whoever reads these logs must be able to tell those apart.

- **absent** config → silent (unconfigured is the normal state; nagging every heartbeat is how a board teaches you to ignore it)
- **partial** config → warns (somebody meant to turn this on and left it half-done)

## `buzz-say.ts` — the hand trigger

```bash
docker compose … exec slack-operator \
  node services/slack-operator/dist/buzz-say.js "hello from Hermes"
```

Everything in this path has so far only been proven against a **scripted fake relay**. The credential, the owner attestation, the closed-relay membership check, the channel UUID, and TLS through the Cloudflare tunnel have never been exercised together. Meeting a problem in any of them for the first time *during a money-path incident* — when narration is the thing meant to tell you — is the worst available moment.

It runs **inside the container** deliberately: the point is to test the deployed configuration, not a local approximation. Same env, same credentials, same network path, same code.

On an auth rejection it names the three likely causes in order, because `auth-rejected` alone sends you looking at the key when the tag or the membership is just as likely.

## Verification

- full suite **1800 passed / 120 files**, no regressions
- `slack-operator` typecheck clean
- `docker compose config` exits 0 with the new block

## Known gap, named rather than hidden

Buzz delivery health is visible **only in logs** — the ops board doesn't show it. So a persistently failing narration channel is currently invisible on the surface built to tell you what's wrong. That's the same class of problem this PR's WARN logging addresses one level down, and it deserves its own change rather than being smuggled in here.