### PR TITLE
Give Hermes a name — publish the agent's kind-0 profile

### DIFF
--- a/services/slack-operator/src/buzz-client.ts
+++ b/services/slack-operator/src/buzz-client.ts
@@ -20,9 +20,12 @@ import {
   agentPubkey,
   authTagFromConfig,
   buildAuthEvent,
+  buildProfileEvent,
   buildStreamMessage,
   signEvent,
+  type AgentProfile,
   type NostrEvent,
+  type UnsignedEvent,
 } from "./buzz-event.js";
 
 export interface BuzzConfig {
@@ -129,6 +132,52 @@ export async function publishNarration(
   content: string,
   options: PublishOptions = {},
 ): Promise<BuzzPublishResult> {
+  return await publishBuilt(
+    config,
+    options,
+    (pubkey, createdAt) =>
+      buildStreamMessage({
+        agentPubkeyHex: pubkey,
+        channelId: config.channelId,
+        content,
+        createdAt,
+        authTag: config.authTag,
+      }),
+  );
+}
+
+/**
+ * Publish the agent's profile (kind 0), so clients show a name instead of a
+ * pubkey. Replaceable — publishing again supersedes the previous one.
+ *
+ * Deliberately NOT called on startup. Kind 0 is replaceable, so a boot-time
+ * publish would be harmless but pointless chatter on every deploy; a profile
+ * changes when someone decides it should, which is what a one-shot entry point
+ * models.
+ */
+export async function publishAgentProfile(
+  config: BuzzConfig,
+  profile: AgentProfile,
+  options: PublishOptions = {},
+): Promise<BuzzPublishResult> {
+  return await publishBuilt(
+    config,
+    options,
+    (pubkey, createdAt) =>
+      buildProfileEvent({ agentPubkeyHex: pubkey, profile, createdAt, authTag: config.authTag }),
+  );
+}
+
+/**
+ * Shared publish path: build, sign, then run the one handshake both callers
+ * need. Kept as a single implementation so the profile publish rides the exact
+ * code the narration publish proved, rather than a second copy that could drift.
+ */
+async function publishBuilt(
+  config: BuzzConfig,
+  options: PublishOptions,
+  build: (agentPubkeyHex: string, createdAt: number) => UnsignedEvent,
+): Promise<BuzzPublishResult> {
   const timeoutMs = options.timeoutMs ?? DEFAULT_PUBLISH_TIMEOUT_MS;
   const createdAt = options.nowSeconds ?? Math.floor(Date.now() / 1000);
   const openSocket = options.openSocket ?? defaultOpenSocket;
@@ -137,16 +186,7 @@ export async function publishNarration(
   let pubkey: string;
   try {
     pubkey = agentPubkey(config.agentSecretKeyHex);
-    message = signEvent(
-      buildStreamMessage({
-        agentPubkeyHex: pubkey,
-        channelId: config.channelId,
-        content,
-        createdAt,
-        authTag: config.authTag,
-      }),
-      config.agentSecretKeyHex,
-    );
+    message = signEvent(build(pubkey, createdAt), config.agentSecretKeyHex);
   } catch (error) {
     // Building the event cannot fail transiently — bad config or bad content.
     return {

--- a/services/slack-operator/src/buzz-event.ts
+++ b/services/slack-operator/src/buzz-event.ts
@@ -154,6 +154,61 @@ export function buildStreamMessage(input: {
   };
 }
 
+/** NIP-01 profile metadata. Replaceable: publishing again supersedes. */
+export const KIND_PROFILE = 0;
+
+export interface AgentProfile {
+  displayName?: string;
+  name?: string;
+  about?: string;
+  picture?: string;
+  nip05?: string;
+}
+
+/**
+ * Build the agent's profile. Mirrors upstream `build_profile`: kind 0, no tags,
+ * a JSON object of the set fields.
+ *
+ * WHY IT MATTERS: without this, clients have nothing to show but the pubkey, so
+ * narration arrives authored by `775a0f0a…a1af`. An alert read at 3am should say
+ * who is speaking. This is the difference between a message that reads like a
+ * colleague and one that reads like a hash.
+ *
+ * Fields are emitted in a fixed order because the content string is part of the
+ * signed event id — not because any reader depends on it, but because a stable
+ * input makes a republished profile diffable.
+ */
+export function buildProfileEvent(input: {
+  agentPubkeyHex: string;
+  profile: AgentProfile;
+  createdAt: number;
+  authTag?: string[];
+}): UnsignedEvent {
+  const fields: Array<[string, string | undefined]> = [
+    ["display_name", input.profile.displayName],
+    ["name", input.profile.name],
+    ["picture", input.profile.picture],
+    ["about", input.profile.about],
+    ["nip05", input.profile.nip05],
+  ];
+  const map: Record<string, string> = {};
+  for (const [key, value] of fields) {
+    if (typeof value === "string" && value.length > 0) map[key] = value;
+  }
+  if (Object.keys(map).length === 0) {
+    throw new BuzzEventError("refusing to publish an empty profile — it would erase the current one");
+  }
+  return {
+    pubkey: input.agentPubkeyHex,
+    created_at: input.createdAt,
+    kind: KIND_PROFILE,
+    // Provenance here too: the profile is where a reader looks to find out what
+    // this key is, so "authorized by <owner>" belongs on it.
+    tags: input.authTag ? [input.authTag] : [],
+    content: JSON.stringify(map),
+  };
+}
+
 /**
  * Build the NIP-42 AUTH event. On this closed relay the NIP-OA tag rides HERE —
  * upstream extracts it from the signed AUTH event and uses it to prove the

--- a/services/slack-operator/src/buzz-profile.ts
+++ b/services/slack-operator/src/buzz-profile.ts
@@ -1,0 +1,59 @@
+// Publish Hermes's Buzz profile, so narration is authored by a name rather than
+// a pubkey.
+//
+//   docker compose … exec slack-operator \
+//     node services/slack-operator/dist/buzz-profile.js
+//
+// WHY THIS EXISTS: the first real message landed authored by `775a0f0a…a1af`.
+// Nostr clients show the pubkey when there is no kind-0 metadata for a key, and
+// an alert read at 3am should say WHO is speaking. That is the whole change —
+// the difference between a message that reads like a colleague and one that
+// reads like a hash.
+//
+// Kind 0 is replaceable, so running this again supersedes rather than
+// duplicates. Safe to re-run after editing the text below.
+//
+// The `about` line is deliberately literal about what this agent is and what it
+// cannot do. Anyone who clicks the profile is asking "what is this thing and
+// should I trust what it just told me" — the honest answer belongs there, not a
+// tagline.
+
+import { publishAgentProfile, readBuzzConfig } from "./buzz-client.js";
+
+const PROFILE = {
+  displayName: "Hermes",
+  name: "hermes",
+  about:
+    "Averray ops monitor. Posts when product health crosses the red boundary "
+    + "and when it recovers. Reads the money path; never moves money. "
+    + "Authorized by the relay owner — see the auth tag on its events.",
+};
+
+async function main(): Promise<void> {
+  const result = readBuzzConfig();
+  if (!result.config) {
+    console.error(result.problem ?? "Buzz is not configured (no BUZZ_* variables set)");
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`publishing profile to ${result.config.relayUrl}`);
+  console.log(`  display_name  ${PROFILE.displayName}`);
+  console.log(`  name          ${PROFILE.name}`);
+  console.log(`  about         ${PROFILE.about}`);
+
+  const publish = await publishAgentProfile(result.config, PROFILE);
+  if (publish.ok) {
+    console.log(`\nOK — ${publish.detail} (event ${publish.eventId})`);
+    console.log("Buzz may cache the old profile briefly; reopen the channel if the name looks stale.");
+    return;
+  }
+
+  console.error(`\nFAILED [${publish.reason}] ${publish.detail}`);
+  process.exitCode = 1;
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/test/unit/buzz-event.test.ts
+++ b/test/unit/buzz-event.test.ts
@@ -4,11 +4,13 @@ import { schnorr } from "@noble/curves/secp256k1";
 import {
   BuzzEventError,
   KIND_CLIENT_AUTH,
+  KIND_PROFILE,
   KIND_STREAM_MESSAGE,
   MAX_CONTENT_BYTES,
   agentPubkey,
   authTagFromConfig,
   buildAuthEvent,
+  buildProfileEvent,
   buildStreamMessage,
   computeEventId,
   serializeForId,
@@ -150,6 +152,55 @@ describe("buildStreamMessage", () => {
   it("omits the auth tag when none is supplied", () => {
     const event = buildStreamMessage({ agentPubkeyHex: AGENT_PUBKEY, channelId: CHANNEL, content: "x", createdAt: 1 });
     expect(event.tags).toEqual([["h", CHANNEL]]);
+  });
+});
+
+describe("buildProfileEvent", () => {
+  it("is kind 0 with a JSON object of the set fields and no channel tag", () => {
+    // A profile is not addressed to a channel — it describes the KEY, and every
+    // client that renders any of its messages reads it.
+    const event = buildProfileEvent({
+      agentPubkeyHex: AGENT_PUBKEY,
+      profile: { displayName: "Hermes", name: "hermes", about: "Averray ops monitor." },
+      createdAt: 1713956400,
+      authTag: AUTH_TAG,
+    });
+    expect(event.kind).toBe(KIND_PROFILE);
+    expect(event.tags).toEqual([AUTH_TAG]);
+    expect(JSON.parse(event.content)).toEqual({
+      display_name: "Hermes",
+      name: "hermes",
+      about: "Averray ops monitor.",
+    });
+  });
+
+  it("omits unset and empty fields rather than writing empty strings", () => {
+    // An empty string is a VALUE in kind 0 — it would blank the field for every
+    // reader, which is not the same as leaving it alone.
+    const event = buildProfileEvent({
+      agentPubkeyHex: AGENT_PUBKEY,
+      profile: { displayName: "Hermes", about: "", picture: undefined },
+      createdAt: 1,
+    });
+    expect(JSON.parse(event.content)).toEqual({ display_name: "Hermes" });
+    expect(event.tags).toEqual([]);
+  });
+
+  it("refuses a wholly empty profile", () => {
+    // Publishing {} would REPLACE the existing profile with nothing, since kind
+    // 0 is replaceable. Silently erasing a name is worse than refusing.
+    expect(() =>
+      buildProfileEvent({ agentPubkeyHex: AGENT_PUBKEY, profile: {}, createdAt: 1 }),
+    ).toThrow(/empty profile/);
+  });
+
+  it("signs and verifies like any other event", () => {
+    const signed = signEvent(
+      buildProfileEvent({ agentPubkeyHex: AGENT_PUBKEY, profile: { displayName: "Hermes" }, createdAt: 1 }),
+      AGENT_SECRET,
+    );
+    expect(signed.id).toMatch(/^[0-9a-f]{64}$/);
+    expect(signed.sig).toHaveLength(128);
   });
 });
 


### PR DESCRIPTION
The first real narration landed like this:

```
775a0f0a…a1af   10:37 PM
Hermes checking in — first message over the real socket
```

Nostr clients show the raw pubkey when a key has no kind-0 metadata. **An alert read at 3am should say who is speaking.** That's the whole change — the difference between a message that reads like a colleague and one that reads like a hash.

```bash
docker compose … exec slack-operator \
  node services/slack-operator/dist/buzz-profile.js
```

Kind 0 is replaceable, so re-running supersedes rather than duplicates.

## Decisions

**Not published on startup.** A boot-time publish would be harmless but pointless chatter on every deploy. A profile changes when someone decides it should — which is what a one-shot entry point models.

**The socket half of the client is now shared, not copied.** The profile publish rides the exact handshake the narration publish proved against the live relay. A second implementation would be a second thing to keep correct, and the one we have is the one with evidence behind it.

**The `about` text is literal about what this agent won't do** — *"Reads the money path; never moves money."* Anyone clicking that profile is asking whether to trust what it just told them. That answer belongs there rather than a tagline.

## Two guards that earned tests

- **An empty string is a VALUE in kind 0.** `about: ""` would blank that field for every reader, which is not the same as leaving it alone — so unset and empty are both omitted.
- **A wholly empty profile is refused.** Publishing `{}` would *replace* the existing profile with nothing. Silently erasing a name is worse than failing.

## Verification

- 4 new tests; full suite **1804 passed / 120 files**
- `slack-operator` typecheck clean