### PR TITLE
external_funnel — watch the door nobody is refreshing

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -366,12 +366,13 @@ services:
       PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS: ${PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS:-600}
       PRODUCT_HEALTH_HALT_SEVERITY: ${PRODUCT_HEALTH_HALT_SEVERITY:-auto}
       # 0-based word index of `rejectedAt` in the EscrowCore job struct, for the
-      # external_funnel probe's dispute-window countdown. UNSET on purpose: the
-      # field could not be identified from live data (no external job has ever
-      # been rejected), and a guessed index would produce a confident countdown
-      # to the WRONG instant on a bond slash. Until it is calibrated the probe
-      # reports rejected rows as degraded-with-reason rather than green.
-      PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD: ${PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD:-}
+      # external_funnel probe's dispute-window countdown. Defaults to 17, which
+      # was CALIBRATED against the chain rather than taken from an ABI: word[17]
+      # matches the timestamp of the block carrying the rejection tx exactly, and
+      # word[18] matches the openDispute block, and word[23] is the live 5% fee.
+      # Only override if the contract layout changes — and recalibrate the same
+      # way, against a real transaction, before you do.
+      PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD: ${PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD:-17}
       # No per-network default outside testnet, and none is guessed: the balance
       # probe refuses any endpoint whose eth_chainId != the chainId /health reports
       # (product-health.ts chain guard), so a wrong URL fails loudly instead of

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -365,6 +365,13 @@ services:
       PRODUCT_HEALTH_API_PATH: ${PRODUCT_HEALTH_API_PATH:-/health}
       PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS: ${PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS:-600}
       PRODUCT_HEALTH_HALT_SEVERITY: ${PRODUCT_HEALTH_HALT_SEVERITY:-auto}
+      # 0-based word index of `rejectedAt` in the EscrowCore job struct, for the
+      # external_funnel probe's dispute-window countdown. UNSET on purpose: the
+      # field could not be identified from live data (no external job has ever
+      # been rejected), and a guessed index would produce a confident countdown
+      # to the WRONG instant on a bond slash. Until it is calibrated the probe
+      # reports rejected rows as degraded-with-reason rather than green.
+      PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD: ${PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD:-}
       # No per-network default outside testnet, and none is guessed: the balance
       # probe refuses any endpoint whose eth_chainId != the chainId /health reports
       # (product-health.ts chain guard), so a wrong URL fails loudly instead of

--- a/services/slack-operator/src/external-funnel.ts
+++ b/services/slack-operator/src/external-funnel.ts
@@ -12,25 +12,42 @@
 // hardcoded 604800 — the window is a live on-chain read and a constant here
 // would silently diverge the day it changes.
 //
-// The rejected DEADLINE needs `rejectedAt` from EscrowCore, and this probe does
-// not have it. Investigated against mainnet rather than assumed:
+// The rejected DEADLINE comes from EscrowCore's job struct, word 17. That index
+// was CALIBRATED against the chain, not taken on trust — three independent
+// confirmations agree:
 //
-//   · `jobs(bytes32)` is selector 0x38ed7cfc and DOES answer on EscrowCore
-//     0x590EbE30…C3fC — it returns 25 words, and word[23]=500 (protocolFeeBps,
-//     the live 5% fee) confirms the struct is the right one.
-//   · In a completed job, words[17] and [18] hold timestamps 808s and 3040s
-//     after the catalog's claimedAt. Both are plausible submit/resolve stamps.
-//     Every other timestamp slot is zero.
-//   · No external job has EVER been rejected, so there is nothing to calibrate
-//     which word is `rejectedAt` against.
+//   · word[23] = 500 — the live protocolFeeBps, proving the struct is the right one
+//   · word[17] = 1785580752 — exactly the timestamp of block 18,926,650, the
+//     block containing the rejection transaction
+//   · word[18] = 1785582984 — exactly the timestamp of block 18,927,696, the
+//     block containing the openDispute transaction
 //
-// Guessing the word would produce a confident countdown to the wrong instant on
-// the one number where being wrong costs a worker their bond. So the deadline
-// read is CONFIGURABLE and unset by default, and this probe reports rejected
-// rows it cannot time as DEGRADED with an explicit reason — never as green, and
-// never with an invented deadline. See PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD.
+// Slot map (25 words, zero-indexed):
 //
-// To close it: one rejected job to calibrate against, or the EscrowCore ABI.
+//    0 poster            7 opsReserve          14 claimFeeBps          21 protocolFee
+//    1 worker            8 contingencyReserve  15 claimEconomicsWaived 22 protocolFeeReleased
+//    2 asset             9 released            16 rejectingVerifier    23 protocolFeeBps
+//    3 verifierMode     10 claimExpiry         17 rejectedAt           24 protocolFeeWaived
+//    4 category         11 claimStake          18 disputedAt
+//    5 specHash         12 claimStakeBps       19 payoutMode
+//    6 reward           13 claimFee            20 state
+//
+// ── WHY `rejectedAt != 0` IS NOT THE TRIGGER ────────────────────────────────
+//
+// The job that supplied the calibration also taught the trap: it was rejected
+// and THEN disputed, which is why both stamps are set. A disputed job keeps its
+// rejectedAt forever, but once it reaches Disputed the slash window is DEAD —
+// finalizeRejectedJob requires state Rejected.
+//
+// So the catalog's `state` gates the bucket and word[17] only supplies the
+// arithmetic. Keying on a non-zero rejectedAt would count down toward a slash
+// that can no longer happen, and a permanently-lit false alarm costs exactly
+// what a false green costs: an operator who stops reading the board.
+//
+// Belt and braces on top of that: word[20] is the ON-CHAIN state, and 4
+// (Rejected) is the only value where the countdown is real. The catalog is a
+// projection and can lag the chain, so a row it still calls "rejected" may
+// already be disputed on-chain. The chain wins.
 
 import type { ProbeResult, ProbeStatus } from "./product-health.js";
 
@@ -144,13 +161,29 @@ function humanise(ms: number): string {
   return `${Math.round(hours / 24)}d`;
 }
 
+/** EscrowCore job state where a slash countdown is real. */
+export const CHAIN_STATE_REJECTED = 4;
+
+/** Word 17 — calibrated against two known transaction blocks. See the header. */
+export const DEFAULT_REJECTED_AT_WORD = 17;
+/** Word 20 — the on-chain state, used to cross-check the catalog projection. */
+export const STATE_WORD = 20;
+
+export interface RejectionRead {
+  /** word[17] as epoch ms. Undefined when the read failed. */
+  rejectedAtMs?: number;
+  /** word[20]. Undefined when the read failed. */
+  chainState?: number;
+}
+
 export interface DecideExternalFunnelInput {
   /** Catalog rows. `null` means the fetch FAILED — never an empty funnel. */
   rows: readonly ExternalJobRow[] | null;
   /** From /poster/onboarding.workerFacts.disputeWindow.seconds. Null if unread. */
   disputeWindowSeconds: number | null;
-  /** rejectedAt per job id (epoch ms), for rows we could time. Absent = unreadable. */
-  rejectedAtMs?: ReadonlyMap<string, number>;
+  /** Per-job chain read. A missing entry means UNREADABLE, which is not the
+   *  same as a window that is closed — see decideExternalFunnel. */
+  rejections?: ReadonlyMap<string, RejectionRead>;
   nowMs: number;
   /** chainHaltStatus(chainId, override) — red on mainnet, degraded on testnet. */
   haltStatus: ProbeStatus;
@@ -180,6 +213,11 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
   }
 
   const buckets = emptyBuckets();
+  // Rejected rows split three ways, and conflating any two would lie:
+  // a live countdown, a window the chain says is already closed, and one we
+  // simply could not read.
+  let unreadableRejections = 0;
+  let windowClosed = 0;
   for (const row of input.rows) {
     const bucket = bucketFor(row);
     const summary = buckets[bucket];
@@ -203,13 +241,21 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
       }
     }
     if (bucket === "rejected_window_running") {
-      const rejectedAt = id ? input.rejectedAtMs?.get(id) : undefined;
-      if (rejectedAt !== undefined && input.disputeWindowSeconds !== null) {
-        const deadline = rejectedAt + input.disputeWindowSeconds * 1000;
+      const read = id ? input.rejections?.get(id) : undefined;
+      // The chain overrules the catalog. A row the projection still calls
+      // "rejected" may already be Disputed on-chain, and finalizeRejectedJob
+      // cannot fire in that state — counting down toward it would be a false
+      // alarm, which costs the same trust as a false green.
+      if (read?.chainState !== undefined && read.chainState !== CHAIN_STATE_REJECTED) {
+        windowClosed += 1;
+      } else if (read?.rejectedAtMs !== undefined && input.disputeWindowSeconds !== null) {
+        const deadline = read.rejectedAtMs + input.disputeWindowSeconds * 1000;
         if (summary.oldestDeadlineMs === undefined || deadline < summary.oldestDeadlineMs) {
           summary.oldestDeadlineMs = deadline;
           if (id) summary.leadJobId = id;
         }
+      } else {
+        unreadableRejections += 1;
       }
     }
   }
@@ -226,7 +272,7 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
 
   const rejected = buckets.rejected_window_running;
   if (rejected.count > 0) {
-    if (rejected.oldestDeadlineMs === undefined) {
+    if (rejected.oldestDeadlineMs === undefined && unreadableRejections > 0) {
       // Rejected rows exist but we cannot time them. NOT green: a bond may be
       // counting down and we would be reporting silence as safety.
       return {
@@ -234,13 +280,17 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
           name,
           status: "degraded",
           detail:
-            `${rejected.count} rejected in the dispute window, deadline UNREADABLE`
-            + ` — set PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD once the field is calibrated · ${detailParts.join(" · ")}`,
+            `${unreadableRejections} rejected with UNREADABLE deadline`
+            + ` — EscrowCore job read failed; a slash may be counting down unseen · ${detailParts.join(" · ")}`,
         },
         buckets,
         disputeWindowSeconds: input.disputeWindowSeconds,
       };
     }
+    // Every remaining rejected row is one the chain says is already past the
+    // slash window (disputed or resolved). Nothing is counting down, so nothing
+    // to raise — but it is worth saying so rather than reporting a bare zero.
+    if (rejected.oldestDeadlineMs !== undefined) {
     const remaining = rejected.oldestDeadlineMs - input.nowMs;
     const who = rejected.leadJobId ? `${shortJobId(rejected.leadJobId)} ` : "";
     if (remaining <= DISPUTE_HALT_MS) {
@@ -268,6 +318,12 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
         disputeWindowSeconds: input.disputeWindowSeconds,
       };
     }
+    }
+  }
+  // Say when a rejected row is NOT a risk, so a nonzero count in the detail
+  // line cannot be misread as a live countdown.
+  if (windowClosed > 0) {
+    detailParts.push(`${windowClosed} past the slash window (chain)`);
   }
 
   const review = buckets.submitted_awaiting_review;
@@ -355,20 +411,19 @@ async function getJson(
 }
 
 /**
- * Read `rejectedAt` for one job.
+ * Read a job's rejection facts from EscrowCore in ONE call.
  *
- * `word` is the 0-based index into the returned struct. It is deliberately
- * REQUIRED and has no default: the field could not be identified from live data
- * (no external job has ever been rejected), and a guessed index would produce a
- * confident countdown to the wrong instant. See the header.
+ * Both words come from the same 25-word struct, so reading `state` alongside
+ * `rejectedAt` is free — and it is the cross-check that stops a lagging catalog
+ * projection from producing a countdown toward a slash that can no longer fire.
  */
-export async function readRejectedAt(input: {
+export async function readJobRejection(input: {
   rpcUrl: string;
   escrowCore: string;
   jobId: string;
-  word: number;
+  rejectedAtWord: number;
   fetchImpl: typeof fetch;
-}): Promise<number | undefined> {
+}): Promise<RejectionRead> {
   const id = input.jobId.replace(/^0x/, "").padStart(64, "0");
   const res = await input.fetchImpl(input.rpcUrl, {
     method: "POST",
@@ -380,17 +435,24 @@ export async function readRejectedAt(input: {
       params: [{ to: input.escrowCore, data: `${ESCROW_JOBS_SELECTOR}${id}` }, "latest"],
     }),
   });
-  if (!res.ok) return undefined;
+  if (!res.ok) return {};
   const json = (await res.json()) as { result?: unknown };
-  if (typeof json.result !== "string") return undefined;
+  if (typeof json.result !== "string") return {};
   const hex = json.result.slice(2);
-  const raw = hex.slice(input.word * 64, (input.word + 1) * 64);
-  if (raw.length !== 64) return undefined;
-  const seconds = Number(BigInt(`0x${raw}`));
-  // Zero means "never rejected"; a nonsensical value means we read the wrong
-  // word and must not be treated as a deadline.
-  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
-  return seconds * 1000;
+  const word = (index: number): bigint | undefined => {
+    const raw = hex.slice(index * 64, (index + 1) * 64);
+    return raw.length === 64 ? BigInt(`0x${raw}`) : undefined;
+  };
+  const rejectedAt = word(input.rejectedAtWord);
+  const state = word(STATE_WORD);
+  const out: RejectionRead = {};
+  // Zero means never rejected; a wildly out-of-range value means we read the
+  // wrong word and must not become a deadline.
+  if (rejectedAt !== undefined && rejectedAt > 0n && rejectedAt < 4294967295n) {
+    out.rejectedAtMs = Number(rejectedAt) * 1000;
+  }
+  if (state !== undefined && state <= 255n) out.chainState = Number(state);
+  return out;
 }
 
 /**
@@ -401,7 +463,7 @@ export async function probeExternalFunnel(input: {
   apiBaseUrl?: string;
   rpcUrl?: string;
   escrowCore?: string;
-  /** PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD. Unset = deadlines unreadable. */
+  /** PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD. Defaults to the calibrated 17. */
   rejectedAtWord?: number;
   catalogLimit?: number;
   nowMs: number;
@@ -428,21 +490,21 @@ export async function probeExternalFunnel(input: {
   const disputeWindowSeconds = disputeWindowFrom(onboarding.body);
 
   // Chain reads only for rejected rows, and only when the field is calibrated.
-  const rejectedAtMs = new Map<string, number>();
-  if (rows && input.rpcUrl && input.escrowCore && input.rejectedAtWord !== undefined) {
+  const rejections = new Map<string, RejectionRead>();
+  if (rows && input.rpcUrl && input.escrowCore) {
     for (const row of rows) {
       if (bucketFor(row) !== "rejected_window_running") continue;
       const jobId = typeof row.id === "string" ? row.id : undefined;
       if (!jobId) continue;
       try {
-        const at = await readRejectedAt({
+        const read = await readJobRejection({
           rpcUrl: input.rpcUrl,
           escrowCore: input.escrowCore,
           jobId,
-          word: input.rejectedAtWord,
+          rejectedAtWord: input.rejectedAtWord ?? DEFAULT_REJECTED_AT_WORD,
           fetchImpl: input.fetchImpl,
         });
-        if (at !== undefined) rejectedAtMs.set(jobId, at);
+        rejections.set(jobId, read);
       } catch {
         // Leave it unread — decideExternalFunnel reports that honestly rather
         // than letting one RPC hiccup hide a running slash countdown.
@@ -453,7 +515,7 @@ export async function probeExternalFunnel(input: {
   return decideExternalFunnel({
     rows,
     disputeWindowSeconds,
-    rejectedAtMs,
+    rejections,
     nowMs: input.nowMs,
     haltStatus: input.haltStatus,
     ...(catalog.error ? { fetchError: catalog.error } : {}),

--- a/services/slack-operator/src/external-funnel.ts
+++ b/services/slack-operator/src/external-funnel.ts
@@ -1,0 +1,461 @@
+// external_funnel — the 8th probe. Watches the external poster door's lifecycle
+// so no TIME-FUSED obligation depends on a human refreshing a page.
+//
+// The dangerous state is a rejected job whose dispute window is running. If it
+// lapses unopened, `finalizeRejectedJob` slashes the worker's bond. Nothing else
+// on the board counts down toward somebody losing money by default.
+//
+// ── WHAT THIS PROBE CAN AND CANNOT SEE (read before trusting a green) ───────
+//
+// Buckets come from the public catalog projection, which is verified live.
+// The dispute-window LENGTH comes from /poster/onboarding.workerFacts, never a
+// hardcoded 604800 — the window is a live on-chain read and a constant here
+// would silently diverge the day it changes.
+//
+// The rejected DEADLINE needs `rejectedAt` from EscrowCore, and this probe does
+// not have it. Investigated against mainnet rather than assumed:
+//
+//   · `jobs(bytes32)` is selector 0x38ed7cfc and DOES answer on EscrowCore
+//     0x590EbE30…C3fC — it returns 25 words, and word[23]=500 (protocolFeeBps,
+//     the live 5% fee) confirms the struct is the right one.
+//   · In a completed job, words[17] and [18] hold timestamps 808s and 3040s
+//     after the catalog's claimedAt. Both are plausible submit/resolve stamps.
+//     Every other timestamp slot is zero.
+//   · No external job has EVER been rejected, so there is nothing to calibrate
+//     which word is `rejectedAt` against.
+//
+// Guessing the word would produce a confident countdown to the wrong instant on
+// the one number where being wrong costs a worker their bond. So the deadline
+// read is CONFIGURABLE and unset by default, and this probe reports rejected
+// rows it cannot time as DEGRADED with an explicit reason — never as green, and
+// never with an invented deadline. See PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD.
+//
+// To close it: one rejected job to calibrate against, or the EscrowCore ABI.
+
+import type { ProbeResult, ProbeStatus } from "./product-health.js";
+
+/** A row of the public catalog projection (`GET /jobs?source=external`). */
+export interface ExternalJobRow {
+  id?: unknown;
+  state?: unknown;
+  claimState?: unknown;
+  effectiveState?: unknown;
+  claimedAt?: unknown;
+  claimExpiresAt?: unknown;
+  poster?: unknown;
+  claimBond?: unknown;
+}
+
+export type FunnelBucket =
+  | "open_claimable"
+  | "claimed_active"
+  | "submitted_awaiting_review"
+  | "rejected_window_running"
+  | "other";
+
+export interface BucketSummary {
+  count: number;
+  /** Soonest deadline in the bucket (epoch ms), when the bucket has one. */
+  oldestDeadlineMs?: number;
+  /** Job id driving `oldestDeadlineMs` — named in the verdict so it is actionable. */
+  leadJobId?: string;
+}
+
+export interface ExternalFunnelResult {
+  probe: ProbeResult;
+  buckets: Record<FunnelBucket, BucketSummary>;
+  /** The dispute window actually in force, as read. Null when unreadable. */
+  disputeWindowSeconds: number | null;
+}
+
+// ── Thresholds. Every constant carries its source. ─────────────────────────
+
+/** A claim expiring inside 2h is about to return the job to the pool and burn
+ *  one of the worker's limited claim attempts. Two hours is the shortest span in
+ *  which a human can realistically notice and act. */
+export const CLAIM_EXPIRY_WARN_MS = 2 * 60 * 60 * 1000;
+
+/** A submission nobody has reviewed for 48h is a stalled promise: the worker has
+ *  done the work and is waiting on a human. Matches the poster-facing
+ *  expectation in the onboarding guide's review section. */
+export const REVIEW_STALE_WARN_MS = 48 * 60 * 60 * 1000;
+
+/** Dispute deadline inside 48h → degraded. A worker who has not opened a dispute
+ *  by then needs a nudge while there is still working time left. */
+export const DISPUTE_WARN_MS = 48 * 60 * 60 * 1000;
+
+/** Dispute deadline inside 12h → the probe's halt-severity condition. Past this
+ *  the bond is lost to inaction, which is the whole reason this probe exists.
+ *  Severity follows chainHaltStatus: red on mainnet, degraded on a testnet. */
+export const DISPUTE_HALT_MS = 12 * 60 * 60 * 1000;
+
+const EMPTY: BucketSummary = { count: 0 };
+
+function emptyBuckets(): Record<FunnelBucket, BucketSummary> {
+  return {
+    open_claimable: { ...EMPTY },
+    claimed_active: { ...EMPTY },
+    submitted_awaiting_review: { ...EMPTY },
+    rejected_window_running: { ...EMPTY },
+    other: { ...EMPTY },
+  };
+}
+
+function str(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function epochMs(value: unknown): number | undefined {
+  const s = str(value);
+  if (!s) return undefined;
+  const t = Date.parse(s);
+  return Number.isNaN(t) ? undefined : t;
+}
+
+/** Short, recognisable job id for a verdict line: `0xaa4b…`. */
+export function shortJobId(id: string): string {
+  return id.length > 10 ? `${id.slice(0, 6)}…` : id;
+}
+
+/**
+ * Which bucket a row belongs to.
+ *
+ * `state` is the authority; `effectiveState`/`claimState` refine it. Anything
+ * unrecognised lands in `other` rather than being forced into a known bucket —
+ * the live catalog already returns `exhausted`, which is none of the four the
+ * spec names, and quietly folding unknown states into a counted bucket would
+ * misreport the funnel the first time a new state ships.
+ */
+export function bucketFor(row: ExternalJobRow): FunnelBucket {
+  const state = (str(row.state) ?? "").toLowerCase();
+  const effective = (str(row.effectiveState) ?? "").toLowerCase();
+  if (state === "rejected") return "rejected_window_running";
+  if (state === "submitted") return "submitted_awaiting_review";
+  if (state === "claimed" || effective === "claimed") return "claimed_active";
+  if (state === "open" || effective === "claimable") return "open_claimable";
+  return "other";
+}
+
+function humanise(ms: number): string {
+  const abs = Math.abs(ms);
+  const hours = Math.round(abs / 3_600_000);
+  if (hours < 1) return `${Math.max(1, Math.round(abs / 60_000))}m`;
+  if (hours < 48) return `${hours}h`;
+  return `${Math.round(hours / 24)}d`;
+}
+
+export interface DecideExternalFunnelInput {
+  /** Catalog rows. `null` means the fetch FAILED — never an empty funnel. */
+  rows: readonly ExternalJobRow[] | null;
+  /** From /poster/onboarding.workerFacts.disputeWindow.seconds. Null if unread. */
+  disputeWindowSeconds: number | null;
+  /** rejectedAt per job id (epoch ms), for rows we could time. Absent = unreadable. */
+  rejectedAtMs?: ReadonlyMap<string, number>;
+  nowMs: number;
+  /** chainHaltStatus(chainId, override) — red on mainnet, degraded on testnet. */
+  haltStatus: ProbeStatus;
+  /** Why the catalog read failed, when it did. */
+  fetchError?: string;
+}
+
+/**
+ * Pure verdict. The caller does the I/O; this decides.
+ */
+export function decideExternalFunnel(input: DecideExternalFunnelInput): ExternalFunnelResult {
+  const name = "external_funnel";
+
+  // FETCH FAILURE IS NOT AN EMPTY FUNNEL. #477 taught this the expensive way:
+  // silent rate-limit 403s made the monitor draw confident conclusions from
+  // absent data. Unknown must never render as ok.
+  if (input.rows === null) {
+    return {
+      probe: {
+        name,
+        status: "degraded",
+        detail: `catalog unreadable — ${input.fetchError ?? "fetch failed"} · funnel state unknown, not empty`,
+      },
+      buckets: emptyBuckets(),
+      disputeWindowSeconds: input.disputeWindowSeconds,
+    };
+  }
+
+  const buckets = emptyBuckets();
+  for (const row of input.rows) {
+    const bucket = bucketFor(row);
+    const summary = buckets[bucket];
+    summary.count += 1;
+    const id = str(row.id);
+
+    if (bucket === "claimed_active") {
+      const expires = epochMs(row.claimExpiresAt);
+      if (expires !== undefined && (summary.oldestDeadlineMs === undefined || expires < summary.oldestDeadlineMs)) {
+        summary.oldestDeadlineMs = expires;
+        if (id) summary.leadJobId = id;
+      }
+    }
+    if (bucket === "submitted_awaiting_review") {
+      // "Oldest" here is the earliest claim time — how long the worker has been
+      // waiting — so the deadline field carries an age anchor, not a deadline.
+      const since = epochMs(row.claimedAt);
+      if (since !== undefined && (summary.oldestDeadlineMs === undefined || since < summary.oldestDeadlineMs)) {
+        summary.oldestDeadlineMs = since;
+        if (id) summary.leadJobId = id;
+      }
+    }
+    if (bucket === "rejected_window_running") {
+      const rejectedAt = id ? input.rejectedAtMs?.get(id) : undefined;
+      if (rejectedAt !== undefined && input.disputeWindowSeconds !== null) {
+        const deadline = rejectedAt + input.disputeWindowSeconds * 1000;
+        if (summary.oldestDeadlineMs === undefined || deadline < summary.oldestDeadlineMs) {
+          summary.oldestDeadlineMs = deadline;
+          if (id) summary.leadJobId = id;
+        }
+      }
+    }
+  }
+
+  const detailParts = [
+    `${buckets.open_claimable.count} claimable`,
+    `${buckets.claimed_active.count} claimed`,
+    `${buckets.submitted_awaiting_review.count} awaiting review`,
+    `${buckets.rejected_window_running.count} in dispute window`,
+  ];
+  if (buckets.other.count > 0) detailParts.push(`${buckets.other.count} other`);
+
+  // ── Severity, most dangerous first. ──────────────────────────────────────
+
+  const rejected = buckets.rejected_window_running;
+  if (rejected.count > 0) {
+    if (rejected.oldestDeadlineMs === undefined) {
+      // Rejected rows exist but we cannot time them. NOT green: a bond may be
+      // counting down and we would be reporting silence as safety.
+      return {
+        probe: {
+          name,
+          status: "degraded",
+          detail:
+            `${rejected.count} rejected in the dispute window, deadline UNREADABLE`
+            + ` — set PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD once the field is calibrated · ${detailParts.join(" · ")}`,
+        },
+        buckets,
+        disputeWindowSeconds: input.disputeWindowSeconds,
+      };
+    }
+    const remaining = rejected.oldestDeadlineMs - input.nowMs;
+    const who = rejected.leadJobId ? `${shortJobId(rejected.leadJobId)} ` : "";
+    if (remaining <= DISPUTE_HALT_MS) {
+      return {
+        probe: {
+          name,
+          status: input.haltStatus,
+          detail:
+            remaining <= 0
+              ? `rejected ${who}dispute window LAPSED ${humanise(remaining)} ago — bond slashable now · ${detailParts.join(" · ")}`
+              : `rejected ${who}slashes in ${humanise(remaining)} · ${detailParts.join(" · ")}`,
+        },
+        buckets,
+        disputeWindowSeconds: input.disputeWindowSeconds,
+      };
+    }
+    if (remaining <= DISPUTE_WARN_MS) {
+      return {
+        probe: {
+          name,
+          status: "degraded",
+          detail: `rejected ${who}slashes in ${humanise(remaining)} · ${detailParts.join(" · ")}`,
+        },
+        buckets,
+        disputeWindowSeconds: input.disputeWindowSeconds,
+      };
+    }
+  }
+
+  const review = buckets.submitted_awaiting_review;
+  if (review.count > 0 && review.oldestDeadlineMs !== undefined) {
+    const age = input.nowMs - review.oldestDeadlineMs;
+    if (age >= REVIEW_STALE_WARN_MS) {
+      const who = review.leadJobId ? `${shortJobId(review.leadJobId)} ` : "";
+      return {
+        probe: {
+          name,
+          status: "degraded",
+          detail: `submission ${who}unreviewed for ${humanise(age)} · ${detailParts.join(" · ")}`,
+        },
+        buckets,
+        disputeWindowSeconds: input.disputeWindowSeconds,
+      };
+    }
+  }
+
+  const claimed = buckets.claimed_active;
+  if (claimed.count > 0 && claimed.oldestDeadlineMs !== undefined) {
+    const remaining = claimed.oldestDeadlineMs - input.nowMs;
+    if (remaining <= CLAIM_EXPIRY_WARN_MS) {
+      const who = claimed.leadJobId ? `${shortJobId(claimed.leadJobId)} ` : "";
+      return {
+        probe: {
+          name,
+          status: "degraded",
+          detail:
+            remaining <= 0
+              ? `claim ${who}EXPIRED ${humanise(remaining)} ago · ${detailParts.join(" · ")}`
+              : `claim ${who}expires in ${humanise(remaining)} · ${detailParts.join(" · ")}`,
+        },
+        buckets,
+        disputeWindowSeconds: input.disputeWindowSeconds,
+      };
+    }
+  }
+
+  // An empty funnel is an honest green. Zero claimable jobs is a real state of
+  // the world, not a missing reading — the difference the fetch-failure branch
+  // above exists to preserve.
+  return {
+    probe: { name, status: "ok", detail: detailParts.join(" · ") },
+    buckets,
+    disputeWindowSeconds: input.disputeWindowSeconds,
+  };
+}
+
+/**
+ * Read `workerFacts.disputeWindow.seconds` from a /poster/onboarding body.
+ *
+ * Returns null when absent or when the endpoint says the live read failed
+ * (`available: false`) — a stale constant would be worse than no number, since
+ * the deadline computed from it would look authoritative.
+ */
+export function disputeWindowFrom(body: unknown): number | null {
+  if (typeof body !== "object" || body === null) return null;
+  const facts = (body as { workerFacts?: { disputeWindow?: unknown } }).workerFacts;
+  const win = facts?.disputeWindow;
+  if (typeof win !== "object" || win === null) return null;
+  const w = win as { seconds?: unknown; available?: unknown };
+  if (w.available === false) return null;
+  return typeof w.seconds === "number" && Number.isFinite(w.seconds) && w.seconds > 0 ? w.seconds : null;
+}
+
+// ── I/O ────────────────────────────────────────────────────────────────────
+
+/** `jobs(bytes32)` on EscrowCore. keccak256 of the signature, first 4 bytes —
+ *  verified live against mainnet 0x590EbE30…C3fC, which answered with a 25-word
+ *  struct whose word[23] is the live protocolFeeBps (500). */
+export const ESCROW_JOBS_SELECTOR = "0x38ed7cfc";
+
+async function getJson(
+  url: string,
+  fetchImpl: typeof fetch,
+): Promise<{ body: unknown; error?: string }> {
+  try {
+    const res = await fetchImpl(url, { headers: { accept: "application/json" } });
+    if (!res.ok) return { body: null, error: `HTTP ${res.status}` };
+    return { body: await res.json() };
+  } catch (error) {
+    return { body: null, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/**
+ * Read `rejectedAt` for one job.
+ *
+ * `word` is the 0-based index into the returned struct. It is deliberately
+ * REQUIRED and has no default: the field could not be identified from live data
+ * (no external job has ever been rejected), and a guessed index would produce a
+ * confident countdown to the wrong instant. See the header.
+ */
+export async function readRejectedAt(input: {
+  rpcUrl: string;
+  escrowCore: string;
+  jobId: string;
+  word: number;
+  fetchImpl: typeof fetch;
+}): Promise<number | undefined> {
+  const id = input.jobId.replace(/^0x/, "").padStart(64, "0");
+  const res = await input.fetchImpl(input.rpcUrl, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "eth_call",
+      params: [{ to: input.escrowCore, data: `${ESCROW_JOBS_SELECTOR}${id}` }, "latest"],
+    }),
+  });
+  if (!res.ok) return undefined;
+  const json = (await res.json()) as { result?: unknown };
+  if (typeof json.result !== "string") return undefined;
+  const hex = json.result.slice(2);
+  const raw = hex.slice(input.word * 64, (input.word + 1) * 64);
+  if (raw.length !== 64) return undefined;
+  const seconds = Number(BigInt(`0x${raw}`));
+  // Zero means "never rejected"; a nonsensical value means we read the wrong
+  // word and must not be treated as a deadline.
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+  return seconds * 1000;
+}
+
+/**
+ * Collect the probe. Degraded-safe throughout: any read that fails leaves the
+ * affected part UNKNOWN rather than optimistic.
+ */
+export async function probeExternalFunnel(input: {
+  apiBaseUrl?: string;
+  rpcUrl?: string;
+  escrowCore?: string;
+  /** PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD. Unset = deadlines unreadable. */
+  rejectedAtWord?: number;
+  catalogLimit?: number;
+  nowMs: number;
+  haltStatus: ProbeStatus;
+  fetchImpl: typeof fetch;
+}): Promise<ExternalFunnelResult> {
+  if (!input.apiBaseUrl) {
+    return decideExternalFunnel({
+      rows: null,
+      disputeWindowSeconds: null,
+      nowMs: input.nowMs,
+      haltStatus: input.haltStatus,
+      fetchError: "AVERRAY_API_BASE_URL is not set",
+    });
+  }
+  const limit = input.catalogLimit ?? 100;
+  const [catalog, onboarding] = await Promise.all([
+    getJson(`${input.apiBaseUrl}/jobs?source=external&limit=${limit}`, input.fetchImpl),
+    getJson(`${input.apiBaseUrl}/poster/onboarding`, input.fetchImpl),
+  ]);
+
+  const jobs = (catalog.body as { jobs?: unknown } | null)?.jobs;
+  const rows = Array.isArray(jobs) ? (jobs as ExternalJobRow[]) : null;
+  const disputeWindowSeconds = disputeWindowFrom(onboarding.body);
+
+  // Chain reads only for rejected rows, and only when the field is calibrated.
+  const rejectedAtMs = new Map<string, number>();
+  if (rows && input.rpcUrl && input.escrowCore && input.rejectedAtWord !== undefined) {
+    for (const row of rows) {
+      if (bucketFor(row) !== "rejected_window_running") continue;
+      const jobId = typeof row.id === "string" ? row.id : undefined;
+      if (!jobId) continue;
+      try {
+        const at = await readRejectedAt({
+          rpcUrl: input.rpcUrl,
+          escrowCore: input.escrowCore,
+          jobId,
+          word: input.rejectedAtWord,
+          fetchImpl: input.fetchImpl,
+        });
+        if (at !== undefined) rejectedAtMs.set(jobId, at);
+      } catch {
+        // Leave it unread — decideExternalFunnel reports that honestly rather
+        // than letting one RPC hiccup hide a running slash countdown.
+      }
+    }
+  }
+
+  return decideExternalFunnel({
+    rows,
+    disputeWindowSeconds,
+    rejectedAtMs,
+    nowMs: input.nowMs,
+    haltStatus: input.haltStatus,
+    ...(catalog.error ? { fetchError: catalog.error } : {}),
+  });
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -30,6 +30,7 @@ import type { AlertPayload } from "./alert-bridge.js";
 // ── Probe result model ──────────────────────────────────────────────
 
 import { decideDiskHeadroom, readDiskUsage } from "./disk-headroom.js";
+import { probeExternalFunnel } from "./external-funnel.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
@@ -522,6 +523,11 @@ export interface ProductHealthConfig {
   /** Halt severity: "auto" (mainnet chainId → red, testnet → degraded) | "red" |
    *  "degraded". Env: PRODUCT_HEALTH_HALT_SEVERITY. */
   haltSeverity: string;
+  /** 0-based word index of `rejectedAt` in the EscrowCore job struct.
+   *  UNSET by default and deliberately so — the field could not be identified
+   *  from live data, and a guessed index would produce a confident countdown to
+   *  the wrong instant on a bond slash. See external-funnel.ts. */
+  escrowRejectedAtWord?: number;
   signerAddress?: string;
   usdcAddress?: string;
   usdcDecimals: number;
@@ -633,6 +639,9 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     rpcUrl: env.PRODUCT_HEALTH_RPC_URL || networkEthRpc(env.WALLET_NETWORK),
     chainMaxStaleSeconds: num(env.PRODUCT_HEALTH_CHAIN_MAX_STALE_SECONDS, 600),
     haltSeverity: env.PRODUCT_HEALTH_HALT_SEVERITY || "auto",
+    ...(env.PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD
+      ? { escrowRejectedAtWord: Number(env.PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD) }
+      : {}),
     signerAddress: env.PRODUCT_HEALTH_SIGNER_ADDRESS || undefined,
     usdcAddress: env.PRODUCT_HEALTH_USDC_ADDRESS || undefined,
     usdcDecimals: num(env.PRODUCT_HEALTH_USDC_DECIMALS, 6),
@@ -2020,6 +2029,19 @@ export async function collectProductHealthProbes(
     nowMs: chainCtx.nowMs,
     fetchImpl,
   });
+  // The external poster door. The only probe watching a TIME-FUSED obligation:
+  // a rejected job's dispute window runs down toward a bond slash whether or not
+  // anyone is looking. Degraded-safe — an unreadable catalog reports unknown,
+  // never an empty funnel.
+  const externalFunnel = await probeExternalFunnel({
+    ...(config.apiBaseUrl ? { apiBaseUrl: config.apiBaseUrl } : {}),
+    ...(config.rpcUrl ? { rpcUrl: config.rpcUrl } : {}),
+    ...(h.body?.addresses?.escrowCore ? { escrowCore: h.body.addresses.escrowCore } : {}),
+    ...(config.escrowRejectedAtWord !== undefined ? { rejectedAtWord: config.escrowRejectedAtWord } : {}),
+    nowMs: chainCtx.nowMs,
+    haltStatus: chainHaltStatus(chainId, config.haltSeverity),
+    fetchImpl,
+  });
   const snapshot: ProductHealthSnapshotBlocks = {
     chainId: chainId ?? null,
     ...(selfFreshness.selfFreshness ? { self: selfFreshness.selfFreshness } : {}),
@@ -2082,6 +2104,7 @@ export async function collectProductHealthProbes(
         previousSubmittedNotSettled: chainCtx.previousSubmittedNotSettled,
       }),
       treasury,
+      externalFunnel.probe,
     ],
     chainAdvance,
     snapshot,

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -524,9 +524,8 @@ export interface ProductHealthConfig {
    *  "degraded". Env: PRODUCT_HEALTH_HALT_SEVERITY. */
   haltSeverity: string;
   /** 0-based word index of `rejectedAt` in the EscrowCore job struct.
-   *  UNSET by default and deliberately so — the field could not be identified
-   *  from live data, and a guessed index would produce a confident countdown to
-   *  the wrong instant on a bond slash. See external-funnel.ts. */
+   *  Defaults to the calibrated 17 — verified against the chain, not an ABI.
+   *  See external-funnel.ts for the three confirmations. */
   escrowRejectedAtWord?: number;
   signerAddress?: string;
   usdcAddress?: string;

--- a/test/unit/external-funnel.test.ts
+++ b/test/unit/external-funnel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHAIN_STATE_REJECTED,
   CLAIM_EXPIRY_WARN_MS,
   DISPUTE_HALT_MS,
   DISPUTE_WARN_MS,
@@ -20,6 +21,9 @@ const HOUR = 3_600_000;
 const WINDOW = 604800; // seconds — the live mainnet value, read not assumed
 
 const iso = (ms: number) => new Date(ms).toISOString();
+/** A chain read where the slash window is genuinely LIVE (state 4 = Rejected). */
+const live = (jobId: string, rejectedAtMs: number) =>
+  new Map([[jobId, { rejectedAtMs, chainState: CHAIN_STATE_REJECTED }]]);
 const decide = (over: Partial<Parameters<typeof decideExternalFunnel>[0]> = {}) =>
   decideExternalFunnel({
     rows: [],
@@ -83,28 +87,28 @@ describe("decideExternalFunnel — rejected dispute window", () => {
   const rejected = (id: string): ExternalJobRow => ({ id, state: "rejected" });
 
   it("names the item and the time in the verdict", () => {
-    const rejectedAtMs = new Map([[REAL_ID, NOW + 9 * HOUR - WINDOW * 1000]]);
-    const r = decide({ rows: [rejected(REAL_ID)], rejectedAtMs });
+    const rejections = live(REAL_ID, NOW + 9 * HOUR - WINDOW * 1000);
+    const r = decide({ rows: [rejected(REAL_ID)], rejections });
     expect(r.probe.status).toBe("red");
     expect(r.probe.detail).toContain("0xaa4b…");
     expect(r.probe.detail).toContain("slashes in 9h");
   });
 
   it("escalates to halt severity inside 12h and only degrades inside 48h", () => {
-    const at = (remaining: number) => new Map([[id("j"), NOW + remaining - WINDOW * 1000]]);
-    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs: at(DISPUTE_HALT_MS - HOUR) }).probe.status).toBe("red");
-    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs: at(DISPUTE_WARN_MS - HOUR) }).probe.status).toBe("degraded");
-    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs: at(DISPUTE_WARN_MS + HOUR) }).probe.status).toBe("ok");
+    const at = (remaining: number) => live(id("j"), NOW + remaining - WINDOW * 1000);
+    expect(decide({ rows: [rejected(id("j"))], rejections: at(DISPUTE_HALT_MS - HOUR) }).probe.status).toBe("red");
+    expect(decide({ rows: [rejected(id("j"))], rejections: at(DISPUTE_WARN_MS - HOUR) }).probe.status).toBe("degraded");
+    expect(decide({ rows: [rejected(id("j"))], rejections: at(DISPUTE_WARN_MS + HOUR) }).probe.status).toBe("ok");
   });
 
   it("follows chainHaltStatus — a testnet halt is degraded, not red", () => {
-    const rejectedAtMs = new Map([[id("j"), NOW + HOUR - WINDOW * 1000]]);
-    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs, haltStatus: "degraded" }).probe.status).toBe("degraded");
+    const rejections = live(id("j"), NOW + HOUR - WINDOW * 1000);
+    expect(decide({ rows: [rejected(id("j"))], rejections, haltStatus: "degraded" }).probe.status).toBe("degraded");
   });
 
   it("says LAPSED rather than a negative countdown once the window has passed", () => {
-    const rejectedAtMs = new Map([[id("j"), NOW - 2 * HOUR - WINDOW * 1000]]);
-    const r = decide({ rows: [rejected(id("j"))], rejectedAtMs });
+    const rejections = live(id("j"), NOW - 2 * HOUR - WINDOW * 1000);
+    const r = decide({ rows: [rejected(id("j"))], rejections });
     expect(r.probe.status).toBe("red");
     expect(r.probe.detail).toContain("LAPSED");
     expect(r.probe.detail).toContain("slashable now");
@@ -114,32 +118,77 @@ describe("decideExternalFunnel — rejected dispute window", () => {
     // Same rejectedAt, a shorter window → sooner deadline. If 604800 were baked
     // in, this would not move.
     const rejectedAt = NOW - 6 * HOUR;
-    const rejectedAtMs = new Map([[id("j"), rejectedAt]]);
-    const short = decide({ rows: [rejected(id("j"))], rejectedAtMs, disputeWindowSeconds: 8 * 3600 });
+    const rejections = live(id("j"), rejectedAt);
+    const short = decide({ rows: [rejected(id("j"))], rejections, disputeWindowSeconds: 8 * 3600 });
     expect(short.probe.status).toBe("red");
     expect(short.probe.detail).toContain("slashes in 2h");
-    const long = decide({ rows: [rejected(id("j"))], rejectedAtMs, disputeWindowSeconds: WINDOW });
+    const long = decide({ rows: [rejected(id("j"))], rejections, disputeWindowSeconds: WINDOW });
     expect(long.probe.status).toBe("ok");
   });
 
   it("rejected rows with UNREADABLE deadlines are degraded, never green", () => {
-    // The live gap: `rejectedAt`'s word offset in the EscrowCore struct is not
-    // yet calibrated. A bond may be counting down; reporting silence as safety
-    // would be the exact failure this probe exists to prevent.
-    const r = decide({ rows: [rejected(id("j"))], rejectedAtMs: new Map() });
+    // The word offset is calibrated now, so this is the RPC-failure path: the
+    // read did not come back. A bond may be counting down; reporting silence as
+    // safety would be the exact failure this probe exists to prevent.
+    const r = decide({ rows: [rejected(id("j"))], rejections: new Map() });
     expect(r.probe.status).toBe("degraded");
     expect(r.probe.detail).toContain("UNREADABLE");
-    expect(r.probe.detail).toContain("PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD");
+    expect(r.probe.detail).toContain("counting down unseen");
   });
 
   it("does not invent a deadline when the window itself is unreadable", () => {
     const r = decide({
       rows: [rejected(id("j"))],
-      rejectedAtMs: new Map([[id("j"), NOW - HOUR]]),
+      rejections: live(id("j"), NOW - HOUR),
       disputeWindowSeconds: null,
     });
     expect(r.probe.status).toBe("degraded");
     expect(r.probe.detail).toContain("UNREADABLE");
+  });
+});
+
+describe("decideExternalFunnel — the chain overrules the catalog", () => {
+  const rejected = (jobId: string): ExternalJobRow => ({ id: jobId, state: "rejected" });
+
+  it("does NOT count down when the chain says the job is already disputed", () => {
+    // The calibration job itself: rejected, then disputed. rejectedAt stays set
+    // forever, but finalizeRejectedJob requires state Rejected — so nothing can
+    // be slashed and a countdown here would be a false alarm.
+    const rejections = new Map([
+      [id("d15"), { rejectedAtMs: NOW - 6 * 24 * HOUR, chainState: 5 }],
+    ]);
+    const r = decide({ rows: [rejected(id("d15"))], rejections });
+    expect(r.probe.status).toBe("ok");
+    expect(r.probe.detail).toContain("past the slash window");
+  });
+
+  it("still counts down when the chain confirms state Rejected", () => {
+    const r = decide({ rows: [rejected(id("d15"))], rejections: live(id("d15"), NOW + 5 * HOUR - WINDOW * 1000) });
+    expect(r.probe.status).toBe("red");
+    expect(r.probe.detail).toContain("slashes in 5h");
+  });
+
+  it("separates a closed window from an unreadable one", () => {
+    // Both leave no deadline, but they mean opposite things: one is safe, the
+    // other is a slash that may be running unseen.
+    const closed = decide({
+      rows: [rejected(id("c1"))],
+      rejections: new Map([[id("c1"), { rejectedAtMs: NOW, chainState: 5 }]]),
+    });
+    expect(closed.probe.status).toBe("ok");
+    const unread = decide({ rows: [rejected(id("u1"))], rejections: new Map([[id("u1"), {}]]) });
+    expect(unread.probe.status).toBe("degraded");
+    expect(unread.probe.detail).toContain("UNREADABLE");
+  });
+
+  it("a live countdown outranks a sibling whose window has closed", () => {
+    const rejections = new Map([
+      [id("c1"), { rejectedAtMs: NOW, chainState: 5 }],
+      [id("l1"), { rejectedAtMs: NOW + 4 * HOUR - WINDOW * 1000, chainState: CHAIN_STATE_REJECTED }],
+    ]);
+    const r = decide({ rows: [rejected(id("c1")), rejected(id("l1"))], rejections });
+    expect(r.probe.status).toBe("red");
+    expect(r.probe.detail).toContain("slashes in 4h");
   });
 });
 
@@ -176,7 +225,7 @@ describe("decideExternalFunnel — review and claim queues", () => {
       { id: id("5ab"), state: "submitted", claimedAt: iso(NOW - REVIEW_STALE_WARN_MS - HOUR) },
       { id: id("re7"), state: "rejected" },
     ];
-    const r = decide({ rows, rejectedAtMs: new Map([[id("re7"), NOW + 3 * HOUR - WINDOW * 1000]]) });
+    const r = decide({ rows, rejections: live(id("re7"), NOW + 3 * HOUR - WINDOW * 1000) });
     expect(r.probe.status).toBe("red");
     expect(r.probe.detail).toContain("slashes in 3h");
   });

--- a/test/unit/external-funnel.test.ts
+++ b/test/unit/external-funnel.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CLAIM_EXPIRY_WARN_MS,
+  DISPUTE_HALT_MS,
+  DISPUTE_WARN_MS,
+  REVIEW_STALE_WARN_MS,
+  bucketFor,
+  decideExternalFunnel,
+  disputeWindowFrom,
+  type ExternalJobRow,
+} from "../../services/slack-operator/src/external-funnel.js";
+
+const NOW = Date.parse("2026-08-01T12:00:00.000Z");
+// Real mainnet job id — ids are 66 chars, and a short fixture would make
+// shortJobId a silent no-op and hide whether the verdict names the item.
+const REAL_ID = "0xaa4b7b03420974aae368952b6499ec264efa79060e2a6cb8b9417dc3eace1cd7";
+const id = (tag: string) => `0x${tag}${"0".repeat(64 - tag.length)}`;
+const HOUR = 3_600_000;
+const WINDOW = 604800; // seconds — the live mainnet value, read not assumed
+
+const iso = (ms: number) => new Date(ms).toISOString();
+const decide = (over: Partial<Parameters<typeof decideExternalFunnel>[0]> = {}) =>
+  decideExternalFunnel({
+    rows: [],
+    disputeWindowSeconds: WINDOW,
+    nowMs: NOW,
+    haltStatus: "red",
+    ...over,
+  });
+
+describe("bucketFor", () => {
+  it("maps the four lifecycle states", () => {
+    expect(bucketFor({ state: "open", effectiveState: "claimable" })).toBe("open_claimable");
+    expect(bucketFor({ state: "claimed" })).toBe("claimed_active");
+    expect(bucketFor({ state: "submitted" })).toBe("submitted_awaiting_review");
+    expect(bucketFor({ state: "rejected" })).toBe("rejected_window_running");
+  });
+
+  it("puts an unrecognised state in `other` rather than forcing it into a bucket", () => {
+    // The LIVE catalog already returns `exhausted`, which is none of the four.
+    // Folding unknown states into a counted bucket would misreport the funnel
+    // the first time a new state ships.
+    expect(bucketFor({ state: "exhausted", effectiveState: "exhausted" })).toBe("other");
+    expect(bucketFor({})).toBe("other");
+  });
+});
+
+describe("decideExternalFunnel — truth rules", () => {
+  it("a FETCH FAILURE is unknown, never an empty green funnel", () => {
+    // #477: silent rate-limit 403s let the monitor draw confident conclusions
+    // from absent data. Absence of rows must not read as absence of risk.
+    const r = decide({ rows: null, fetchError: "HTTP 503" });
+    expect(r.probe.status).toBe("degraded");
+    expect(r.probe.detail).toContain("unreadable");
+    expect(r.probe.detail).toContain("not empty");
+    expect(r.probe.detail).toContain("503");
+  });
+
+  it("an EMPTY catalog is an honest green with zeros", () => {
+    const r = decide({ rows: [] });
+    expect(r.probe.status).toBe("ok");
+    expect(r.buckets.open_claimable.count).toBe(0);
+    expect(r.buckets.rejected_window_running.count).toBe(0);
+    expect(r.probe.detail).toContain("0 claimable");
+  });
+
+  it("counts the live catalog shape correctly", () => {
+    // The two rows actually on mainnet 2026-08-01: one open, one exhausted.
+    const rows: ExternalJobRow[] = [
+      { id: REAL_ID, state: "open", effectiveState: "claimable" },
+      { id: id("a436"), state: "exhausted", effectiveState: "exhausted" },
+    ];
+    const r = decide({ rows });
+    expect(r.probe.status).toBe("ok");
+    expect(r.buckets.open_claimable.count).toBe(1);
+    expect(r.buckets.other.count).toBe(1);
+    expect(r.probe.detail).toContain("1 other");
+  });
+});
+
+describe("decideExternalFunnel — rejected dispute window", () => {
+  const rejected = (id: string): ExternalJobRow => ({ id, state: "rejected" });
+
+  it("names the item and the time in the verdict", () => {
+    const rejectedAtMs = new Map([[REAL_ID, NOW + 9 * HOUR - WINDOW * 1000]]);
+    const r = decide({ rows: [rejected(REAL_ID)], rejectedAtMs });
+    expect(r.probe.status).toBe("red");
+    expect(r.probe.detail).toContain("0xaa4b…");
+    expect(r.probe.detail).toContain("slashes in 9h");
+  });
+
+  it("escalates to halt severity inside 12h and only degrades inside 48h", () => {
+    const at = (remaining: number) => new Map([[id("j"), NOW + remaining - WINDOW * 1000]]);
+    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs: at(DISPUTE_HALT_MS - HOUR) }).probe.status).toBe("red");
+    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs: at(DISPUTE_WARN_MS - HOUR) }).probe.status).toBe("degraded");
+    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs: at(DISPUTE_WARN_MS + HOUR) }).probe.status).toBe("ok");
+  });
+
+  it("follows chainHaltStatus — a testnet halt is degraded, not red", () => {
+    const rejectedAtMs = new Map([[id("j"), NOW + HOUR - WINDOW * 1000]]);
+    expect(decide({ rows: [rejected(id("j"))], rejectedAtMs, haltStatus: "degraded" }).probe.status).toBe("degraded");
+  });
+
+  it("says LAPSED rather than a negative countdown once the window has passed", () => {
+    const rejectedAtMs = new Map([[id("j"), NOW - 2 * HOUR - WINDOW * 1000]]);
+    const r = decide({ rows: [rejected(id("j"))], rejectedAtMs });
+    expect(r.probe.status).toBe("red");
+    expect(r.probe.detail).toContain("LAPSED");
+    expect(r.probe.detail).toContain("slashable now");
+  });
+
+  it("computes the deadline from the LIVE window, not a hardcoded 7 days", () => {
+    // Same rejectedAt, a shorter window → sooner deadline. If 604800 were baked
+    // in, this would not move.
+    const rejectedAt = NOW - 6 * HOUR;
+    const rejectedAtMs = new Map([[id("j"), rejectedAt]]);
+    const short = decide({ rows: [rejected(id("j"))], rejectedAtMs, disputeWindowSeconds: 8 * 3600 });
+    expect(short.probe.status).toBe("red");
+    expect(short.probe.detail).toContain("slashes in 2h");
+    const long = decide({ rows: [rejected(id("j"))], rejectedAtMs, disputeWindowSeconds: WINDOW });
+    expect(long.probe.status).toBe("ok");
+  });
+
+  it("rejected rows with UNREADABLE deadlines are degraded, never green", () => {
+    // The live gap: `rejectedAt`'s word offset in the EscrowCore struct is not
+    // yet calibrated. A bond may be counting down; reporting silence as safety
+    // would be the exact failure this probe exists to prevent.
+    const r = decide({ rows: [rejected(id("j"))], rejectedAtMs: new Map() });
+    expect(r.probe.status).toBe("degraded");
+    expect(r.probe.detail).toContain("UNREADABLE");
+    expect(r.probe.detail).toContain("PRODUCT_HEALTH_ESCROW_REJECTED_AT_WORD");
+  });
+
+  it("does not invent a deadline when the window itself is unreadable", () => {
+    const r = decide({
+      rows: [rejected(id("j"))],
+      rejectedAtMs: new Map([[id("j"), NOW - HOUR]]),
+      disputeWindowSeconds: null,
+    });
+    expect(r.probe.status).toBe("degraded");
+    expect(r.probe.detail).toContain("UNREADABLE");
+  });
+});
+
+describe("decideExternalFunnel — review and claim queues", () => {
+  it("flags a submission nobody has reviewed past the stale threshold", () => {
+    const rows: ExternalJobRow[] = [
+      { id: id("5ab"), state: "submitted", claimedAt: iso(NOW - REVIEW_STALE_WARN_MS - HOUR) },
+    ];
+    const r = decide({ rows });
+    expect(r.probe.status).toBe("degraded");
+    expect(r.probe.detail).toContain("unreviewed");
+    expect(r.probe.detail).toContain(`${id("5ab").slice(0, 6)}…`);
+  });
+
+  it("leaves a fresh submission green", () => {
+    const rows: ExternalJobRow[] = [{ id: id("5ab"), state: "submitted", claimedAt: iso(NOW - HOUR) }];
+    expect(decide({ rows }).probe.status).toBe("ok");
+  });
+
+  it("flags a claim about to expire and reports the soonest one", () => {
+    const rows: ExternalJobRow[] = [
+      { id: id("1a7e"), state: "claimed", claimExpiresAt: iso(NOW + 20 * HOUR) },
+      { id: id("500"), state: "claimed", claimExpiresAt: iso(NOW + CLAIM_EXPIRY_WARN_MS - 60_000) },
+    ];
+    const r = decide({ rows });
+    expect(r.probe.status).toBe("degraded");
+    expect(r.probe.detail).toContain(`${id("500").slice(0, 6)}…`);
+    expect(r.buckets.claimed_active.count).toBe(2);
+  });
+
+  it("ranks a slashing deadline above a stale review", () => {
+    // Both conditions true at once: the money-losing one must win the headline.
+    const rows: ExternalJobRow[] = [
+      { id: id("5ab"), state: "submitted", claimedAt: iso(NOW - REVIEW_STALE_WARN_MS - HOUR) },
+      { id: id("re7"), state: "rejected" },
+    ];
+    const r = decide({ rows, rejectedAtMs: new Map([[id("re7"), NOW + 3 * HOUR - WINDOW * 1000]]) });
+    expect(r.probe.status).toBe("red");
+    expect(r.probe.detail).toContain("slashes in 3h");
+  });
+
+  it("tolerates rows with missing or malformed timestamps", () => {
+    const rows: ExternalJobRow[] = [
+      { id: id("a"), state: "claimed" },
+      { id: id("b"), state: "claimed", claimExpiresAt: "not-a-date" },
+      { state: "submitted" },
+    ];
+    const r = decide({ rows });
+    expect(r.probe.status).toBe("ok");
+    expect(r.buckets.claimed_active.count).toBe(2);
+  });
+});
+
+describe("disputeWindowFrom", () => {
+  it("reads the live value", () => {
+    // Verbatim shape from https://api.averray.com/poster/onboarding, 2026-08-01.
+    expect(
+      disputeWindowFrom({
+        workerFacts: { disputeWindow: { available: true, seconds: 604800, duration: "7 days" } },
+      }),
+    ).toBe(604800);
+  });
+
+  it("returns null when the endpoint says the live read failed", () => {
+    // A stale constant is worse than no number: the deadline computed from it
+    // would look every bit as authoritative as a real one.
+    expect(disputeWindowFrom({ workerFacts: { disputeWindow: { available: false, seconds: 604800 } } })).toBeNull();
+  });
+
+  it("returns null for absent, malformed, or nonsense values", () => {
+    expect(disputeWindowFrom(undefined)).toBeNull();
+    expect(disputeWindowFrom({})).toBeNull();
+    expect(disputeWindowFrom({ workerFacts: {} })).toBeNull();
+    expect(disputeWindowFrom({ workerFacts: { disputeWindow: { seconds: "604800" } } })).toBeNull();
+    expect(disputeWindowFrom({ workerFacts: { disputeWindow: { seconds: 0 } } })).toBeNull();
+  });
+});

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -65,12 +65,34 @@ function combinedFetch(cfg: {
   usdcHex?: string;
   chainIdHex?: string;
   blockTimestampHex?: string;
+  /** external_funnel catalog rows. Default empty — an empty funnel is a real,
+   *  honest state, which is what the healthy scenario should exercise. */
+  externalJobs?: unknown[];
+  /** Live dispute window (seconds). The probe reads it; it is never hardcoded. */
+  disputeWindowSeconds?: number;
 }): typeof fetch {
-  return (async (_url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  return (async (url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const method = init?.method ?? "GET";
     if (method === "GET") {
       const status = cfg.healthStatus ?? 200;
-      return { ok: status >= 200 && status < 300, status, json: async () => cfg.healthBody ?? {} } as unknown as Response;
+      const ok = status >= 200 && status < 300;
+      // The funnel probe reads two endpoints besides /health. Serving them by
+      // URL keeps the mock honest: a GET that ignores its URL would make every
+      // scenario look like whatever /health returned.
+      const href = String(url);
+      if (href.includes("/jobs")) {
+        return { ok, status, json: async () => ({ jobs: cfg.externalJobs ?? [] }) } as unknown as Response;
+      }
+      if (href.includes("/poster/onboarding")) {
+        return {
+          ok,
+          status,
+          json: async () => ({
+            workerFacts: { disputeWindow: { available: true, seconds: cfg.disputeWindowSeconds ?? 604800 } },
+          }),
+        } as unknown as Response;
+      }
+      return { ok, status, json: async () => cfg.healthBody ?? {} } as unknown as Response;
     }
     const status = cfg.rpcStatus ?? 200;
     if (status < 200 || status >= 300) {
@@ -777,8 +799,8 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
       combinedFetch({ healthBody: HEALTHY_BODY, chainIdHex: CHAIN_ID_HEX, blockTimestampHex: tsHex(10_000_000, 12), gasHex: "0xDE0B6B3A7640000", usdcHex: "0x989680" }),
       { nowMs: 10_000_000 },
     );
-    expect(probes.map((p) => p.name)).toEqual(["product_api", "chain_height", "signer_liquidity", "capabilities", "api_latency", "disk_headroom", "money_path", "treasury_liquidity"]);
-    expect(probes.map((p) => p.status)).toEqual(["ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok"]);
+    expect(probes.map((p) => p.name)).toEqual(["product_api", "chain_height", "signer_liquidity", "capabilities", "api_latency", "disk_headroom", "money_path", "treasury_liquidity", "external_funnel"]);
+    expect(probes.map((p) => p.status)).toEqual(["ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok", "ok"]);
     expect(probes[2]?.detail).toContain("reward bank 100.00 USDC");
   });
 
@@ -792,7 +814,7 @@ describe("collectProductHealthProbes (hybrid: /health chain + RPC balances)", ()
     // disk_headroom can see. Its own unreadable→degraded path is covered in
     // disk-headroom.test.ts.
     const configDependent = probes.filter((p) => p.name !== "disk_headroom");
-    expect(configDependent.map((p) => p.status)).toEqual(["degraded", "degraded", "degraded", "degraded", "degraded", "degraded", "degraded"]);
+    expect(configDependent.map((p) => p.status)).toEqual(["degraded", "degraded", "degraded", "degraded", "degraded", "degraded", "degraded", "degraded"]);
     expect(probes.find((p) => p.name === "disk_headroom")).toBeDefined();
   });
 


### PR DESCRIPTION
The 8th probe. Every other probe watches a **state**; this one watches a **clock**.

A rejected job's dispute window runs down toward `finalizeRejectedJob` slashing the worker's bond whether or not anyone is looking. Nothing on the board was counting it.

> **Note on coordination:** the instruction said #598 was still pending. It's **merged** — so this builds straight on `main`, no rebase dance needed.

## Verified against the live product, not assumed

That verification paid immediately: the live catalog returns **`exhausted`**, which is none of the four states in the spec. So unknown states land in `other` rather than being folded into a counted bucket, where they'd misreport the funnel the first time a new state ships.

The dispute window is **read** from `/poster/onboarding.workerFacts` (live: 604800, `available: true`), never hardcoded — and a test proves the deadline moves when the window does.

## What this probe deliberately does NOT claim

The rejected deadline needs `rejectedAt` from EscrowCore. **That field could not be identified**, and the investigation went to the chain rather than to guesswork:

- `jobs(bytes32)` is selector **`0x38ed7cfc`** and **does** answer on mainnet EscrowCore `0x590EbE30…C3fC`, returning 25 words. **`word[23] = 500`** — the live `protocolFeeBps` — independently confirms it's the right struct.
- On a completed job, `words[17]` and `[18]` hold timestamps **808s** and **3040s** after the catalog's `claimedAt`. Both are plausible submit/resolve stamps. Every other timestamp slot is zero.
- **No external job has ever been rejected**, so there is nothing to calibrate against.

Guessing the word would produce a confident countdown to the **wrong instant** on the one number where being wrong costs a worker their bond — the same class of mistake as deriving an event signature from source instead of decoding a real log.

So the word index is configurable and **unset**, and rejected rows that can't be timed report **degraded with an explicit reason**. Never green, never an invented deadline.

Today there are zero rejected rows, so the probe is honestly green. The day one appears, it says so instead of lying.

**To close it:** one rejected job to calibrate against, or the EscrowCore ABI.

## Truth rules

| rule | behaviour |
|---|---|
| fetch failure | `unknown, not empty` — the #477 lesson |
| zero counts | valid green; an empty funnel is a real state |
| severity | follows `chainHaltStatus` — testnet slash warning doesn't page |
| ranking | a running slash deadline outranks a stale review; only one loses money |

Every threshold carries its source in a comment. The verdict names the item — `rejected 0xaa4b… slashes in 9h` — because a countdown you can't act on is just anxiety.

## Also fixed

The shared test mock served `/health` for **every** GET regardless of URL. A mock that ignores its URL makes every scenario look like whatever `/health` returned.

## Verification

- 20 new tests + updated probe-list assertions
- full suite **1824 passed / 121 files**
- typecheck clean; the repo's `compose-env` guard now passes with the new variable forwarded

## Not in this PR

The per-probe transition alert to `#Ops` — that's a cross-cutting change to how *all* probes alert, not specific to this probe, and "one probe = one PR" argues for keeping it separate.