### PR TITLE
test(int3b): see the created-PR identity check actually refuse

### DIFF
--- a/test/integration/int3b-payload-sender.test.ts
+++ b/test/integration/int3b-payload-sender.test.ts
@@ -531,6 +531,39 @@ describe.sequential("INT-3b pull-request sending ceremony", () => {
     );
   });
 
+  it("refuses a created pull request that does not match the payload", async () => {
+    const actuation = await createActuation();
+
+    // The one check in the sender whose refusal nothing exercised. It runs on
+    // the PR GitHub hands back after creation, and it is the last thing
+    // standing between "the PR we opened" and "the PR we verified" — so it
+    // must be seen refusing, not merely seen running.
+    //
+    // A server that returns a different head than the one requested is
+    // unlikely. That is exactly why the path needs a test: it will never be
+    // exercised by accident, and an unfireable check is indistinguishable
+    // from a working one.
+    class MismatchingGitHubClient extends FakeGitHubClient {
+      override async openPullRequest(
+        ...args: Parameters<FakeGitHubClient["openPullRequest"]>
+      ): ReturnType<FakeGitHubClient["openPullRequest"]> {
+        const opened = await super.openPullRequest(...args);
+        return {
+          ...opened,
+          head: {
+            ...opened.head,
+            treeSha: "0000000000000000000000000000000000000000",
+          },
+        };
+      }
+    }
+
+    const fakeGitHub = new MismatchingGitHubClient(baseRevision);
+    const refusal = await captureSendRefusal(actuation, senderDeps(fakeGitHub));
+    expect(refusal.reason).toBe("pull_request_identity_mismatch");
+    expect(fakeGitHub.createCalls).toBe(1);
+  });
+
   it("guards 3a imports, the computed mutation invariant, and PR-only authority", async () => {
     const actuatorSource = await source("pr-payload-actuator.ts");
     const localPortsSource = await source("pr-payload-local-ports.ts");


### PR DESCRIPTION
The one finding from the #635 gate, closed.

`assertPullRequestMatchesPayload` ran on every created pull request, but nothing ever handed it a mismatch:

```
make it throw       -> 1 failed   (it IS called)
disable the assert  -> 9 passed   (its refusal was never exercised)
```

A check that has never been seen refusing is indistinguishable from one that cannot. This one is also **the last thing standing between "the PR we opened" and "the PR we verified"** — a poor place to find out.

## The test

Returns a pull request whose head `treeSha` differs from the payload, and asserts the sender refuses with `pull_request_identity_mismatch` after exactly one create call.

A server returning a different head than the one requested is unlikely. That's precisely why the path needed a test — it will never be exercised by accident.

## Proven able to fail

| | |
|---|---|
| baseline | **10 passed** |
| assertion disabled | **1 failed** (this test, only this test) |
| restored | 10 passed |

INT-3a untouched at 8/8, typecheck green.

## Two of my own probes were wrong first

Both would have been filed as defects had I trusted them:

- I overrode `createPullRequest` — the sender calls **`openPullRequest`**. The mismatch never reached the code under test, which looked exactly like the check being vacuous.
- I matched the thrown error against the reason code — the message carries prose, and the reason lives on `error.reason`. The check *was* firing; my assertion was reading the wrong field.

**The check was correct throughout. The tests exercising it were not.** Recording it because that's the third time today an incomplete probe has impersonated a real defect, and the only thing separating the two is checking the probe before believing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)