### PR TITLE
Show the wallet each solvency figure was read from

### DIFF
--- a/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.test.tsx
@@ -289,4 +289,38 @@ describe("OpsBoard — pillars and footer", () => {
     expect(foot).toContain("LLM SPEND — not recorded");
     expect(foot).not.toContain("$0.00");
   });
+  test("a pool shows the address its balance was read from, in full", () => {
+    // Full, not truncated: the reason to put a wallet on an ops board is so an
+    // operator can tell WHICH wallet it is, and a 6-character prefix does not
+    // settle "treasury multisig or reserve?".
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    const aac = getByTestId("ops-pool-addr-aac");
+    expect(aac.textContent).toContain("0xB1350932bf85E7ffd0599E9a3CC7b55718D89E57");
+    expect(aac.textContent).toContain("AgentAccountCore");
+    expect(getByTestId("ops-pool-addr-signer_gas").textContent).toContain("signer EOA");
+  });
+
+  test("a pool whose figure did NOT come from a balance read shows no address", () => {
+    // reward_bank is reported by the product's own /health. Borrowing the AAC's
+    // address to fill the gap would claim a provenance the number does not have
+    // — the same class of lie as a fake green.
+    const { queryByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(queryByTestId("ops-pool-addr-reward_bank")).toBeNull();
+  });
+
+  test("an unfloored pool carries its address too", () => {
+    // Treasury reserve reads 0.00 and is intentionally unfunded — exactly the
+    // row where an operator most wants to check they are looking at the right
+    // wallet before concluding anything from a zero.
+    const { getByTestId } = render(
+      <OpsBoard health={OPS_FIXTURE_NOMINAL} nowMs={fresh(OPS_FIXTURE_NOMINAL)} />,
+    );
+    expect(getByTestId("ops-pool-addr-reserve").textContent).toContain(
+      "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
+    );
+  });
 });

--- a/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
@@ -56,6 +56,29 @@ export function SolvencyPanel({ solvency }: SolvencyPanelProps) {
   );
 }
 
+/**
+ * The address a pool's number was read from.
+ *
+ * Shown in FULL, not truncated: the point of putting a wallet on the board is
+ * that an operator can check which one it is, and a 6-character prefix does not
+ * settle "is this the treasury multisig or the reserve". It renders quiet so it
+ * informs without competing with the balance.
+ *
+ * Absent for any pool whose figure did not come from a balance read — the row
+ * simply shows no address, rather than borrowing a plausible one and implying a
+ * provenance the number does not have.
+ */
+function PoolAddress({ view }: { view: PoolView }) {
+  const { address, addressLabel } = view.pool;
+  if (!address) return null;
+  return (
+    <span className="ops-pool-addr" data-testid={`ops-pool-addr-${view.pool.key}`}>
+      <span className="ops-pool-addr-hex">{address}</span>
+      {addressLabel ? <span className="ops-pool-addr-label">{addressLabel}</span> : null}
+    </span>
+  );
+}
+
 function FlooredPool({ view }: { view: PoolView }) {
   const meter = view.meter;
   if (!meter) return null;
@@ -71,6 +94,7 @@ function FlooredPool({ view }: { view: PoolView }) {
           {view.margin}
         </span>
       </div>
+      <PoolAddress view={view} />
 
       <div className="ops-pool-meter">
         <div
@@ -117,6 +141,7 @@ function UnflooredPool({ view }: { view: PoolView }) {
           there is no note we say we do not know, rather than implying it's fine. */}
       <span className="ops-pool-note">
         {view.pool.note ?? (view.pool.informational ? "informational — not floored" : "no floor declared for this pool")}
+        <PoolAddress view={view} />
       </span>
       <span className="ops-pool-amount ops-pool-amount--quiet">
         {view.amountLabel}

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -202,9 +202,17 @@ export const OPS_FIXTURE_RED: ProductHealth = {
 // STRESS is the same board with a breached floor, a payout shortfall and a dead
 // stream at once — the hierarchy has to hold under load, not only when green.
 
-// Addresses are the REAL mainnet ones (already public via GET /health.addresses).
-// A made-up hex would not exercise the wrapping that 42 real characters cause in
-// a narrow panel, which is the layout risk this feature actually carries.
+// The three CONTRACT addresses are the real mainnet ones, taken from GET
+// /health.addresses and each verified against the chain: balanceOf returns
+// exactly the figure beside it here. A made-up hex would not exercise the
+// wrapping that 42 real characters cause in a narrow panel, which is the layout
+// risk this feature carries.
+//
+// The signer is a PLACEHOLDER of the right shape, and deliberately so. The real
+// signer lives only in PRODUCT_HEALTH_SIGNER_ADDRESS on the box, and an earlier
+// draft of this fixture used an address recalled from memory that turned out to
+// hold zero DOT — a wrong address in a fixture is one copy-paste away from being
+// a wrong address someone sends funds to.
 const MAINNET_POOLS: SolvencyPool[] = [
   {
     key: "signer_gas",
@@ -213,7 +221,7 @@ const MAINNET_POOLS: SolvencyPool[] = [
     unit: "DOT",
     floor: 1,
     status: "ok",
-    address: "0x9Ab8531F5DfE6C3F0F1C4E9B0F7A1c2E3D4B4239",
+    address: "0x00000000000000000000000000000000000f1x7e",
     addressLabel: "signer EOA",
   },
   // No address: this figure comes from the product's own /health, not a balance

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -202,10 +202,33 @@ export const OPS_FIXTURE_RED: ProductHealth = {
 // STRESS is the same board with a breached floor, a payout shortfall and a dead
 // stream at once — the hierarchy has to hold under load, not only when green.
 
+// Addresses are the REAL mainnet ones (already public via GET /health.addresses).
+// A made-up hex would not exercise the wrapping that 42 real characters cause in
+// a narrow panel, which is the layout risk this feature actually carries.
 const MAINNET_POOLS: SolvencyPool[] = [
-  { key: "signer_gas", label: "Signer gas", amount: 2.6931, unit: "DOT", floor: 1, status: "ok" },
+  {
+    key: "signer_gas",
+    label: "Signer gas",
+    amount: 2.6931,
+    unit: "DOT",
+    floor: 1,
+    status: "ok",
+    address: "0x9Ab8531F5DfE6C3F0F1C4E9B0F7A1c2E3D4B4239",
+    addressLabel: "signer EOA",
+  },
+  // No address: this figure comes from the product's own /health, not a balance
+  // read, so the row must show none rather than borrow the AAC's.
   { key: "reward_bank", label: "Reward bank", amount: 15.89, unit: "USDC", floor: 2, status: "ok" },
-  { key: "aac", label: "Agent core (AAC)", amount: 26.15, unit: "USDC", floor: 1, status: "ok" },
+  {
+    key: "aac",
+    label: "Agent core (AAC)",
+    amount: 26.15,
+    unit: "USDC",
+    floor: 1,
+    status: "ok",
+    address: "0xB1350932bf85E7ffd0599E9a3CC7b55718D89E57",
+    addressLabel: "AgentAccountCore",
+  },
   // Deliberately unfunded, and it must never render as a full meter. The note is
   // the operator's own declaration of why the zero is correct.
   {
@@ -215,6 +238,8 @@ const MAINNET_POOLS: SolvencyPool[] = [
     unit: "USDC",
     status: "ok",
     note: "no floor — intentionally unfunded: payouts fund from the signer reward bank; the treasury multisig holds no USDC float",
+    address: "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
+    addressLabel: "treasury reserve",
   },
   {
     key: "escrow",
@@ -224,6 +249,8 @@ const MAINNET_POOLS: SolvencyPool[] = [
     status: "ok",
     informational: true,
     note: "informational — funds currently between claim and settlement",
+    address: "0x590EbE304E0C7672e2abF3161177D2B94a2aC3fC",
+    addressLabel: "EscrowCore",
   },
   {
     key: "revenue",

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -36,6 +36,12 @@ export interface SolvencyPool {
   informational?: boolean;
   /** Operator-declared context for an intentionally unfloored pool. */
   note?: string;
+  /** The address this amount was READ FROM — present only when the figure came
+   *  from that address's balance. A pool sourced elsewhere carries none, and the
+   *  row shows no address rather than borrowing a plausible one. */
+  address?: string;
+  /** What the address is, so the hex is legible without a block explorer. */
+  addressLabel?: string;
 }
 
 export interface SolvencySnapshot {

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -376,6 +376,35 @@ body,
   line-height: 1.45;
   color: var(--h4-muted);
 }
+/* ---- pool source address ---------------------------------------
+   The wallet a balance was read from. Deliberately quiet: it is reference
+   material an operator goes looking for, not something that should pull the
+   eye away from the number or the floor. Shown in full — a truncated address
+   cannot answer "which multisig is this?", which is the only reason to put it
+   on the board at all. */
+.ops-pool-addr {
+  display: block;
+  font-family: var(--h4-font-mono);
+  font-size: 9.5px;
+  line-height: 1.5;
+  color: var(--h4-muted);
+  /* Long hex must never widen the panel and force the meters to reflow. */
+  overflow-wrap: anywhere;
+}
+.ops-pool-addr-hex {
+  /* Selectable as one unit so a double-click copies the whole address. */
+  user-select: all;
+  color: var(--h4-ink-2);
+  opacity: 0.75;
+}
+.ops-pool-addr-label::before {
+  content: " · ";
+  opacity: 0.6;
+}
+.ops-pool--unfloored .ops-pool-addr {
+  margin-top: 2px;
+}
+
 .ops-pool-amount--quiet {
   font-size: 16px;
   font-weight: 400;

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1454,7 +1454,7 @@ async function readProtocolRevenueUsdc(input: {
   token?: string;
   usdcDecimals: number;
   fetchImpl: typeof fetch;
-}): Promise<number | undefined> {
+}): Promise<{ usdc: number; treasuryAccount: string } | undefined> {
   if (!input.escrowCore || !input.agentAccountCore || !input.token) return undefined;
   try {
     const rawTreasury = await ethRpc(
@@ -1474,7 +1474,10 @@ async function readProtocolRevenueUsdc(input: {
     );
     if (!rawPos || rawPos.length < 2 + 64) return undefined;
     const liquid = BigInt("0x" + rawPos.replace(/^0x/, "").slice(0, 64));
-    return Number(liquid) / 10 ** input.usdcDecimals;
+    // The treasury account travels WITH the amount: it is the address the
+    // position was read for, and returning it separately would invite pairing a
+    // figure with an address that came from a different call.
+    return { usdc: Number(liquid) / 10 ** input.usdcDecimals, treasuryAccount: treasury };
   } catch {
     return undefined;
   }
@@ -1576,6 +1579,7 @@ export async function probeSignerLiquidity(input: {
         unit: gasUnit,
         floor: input.minGasNative > 0 ? input.minGasNative : null,
         status: input.minGasNative > 0 && gasNative < input.minGasNative ? "red" : "ok",
+        ...(input.signerAddress ? { address: input.signerAddress, addressLabel: "signer EOA" } : {}),
       },
     ];
     if (input.rewardBankLiquid !== undefined) {
@@ -1673,6 +1677,9 @@ export async function probeTreasuryLiquidity(input: {
       val: number | undefined,
       floor: number,
       note?: string,
+      // The address whose balanceOf produced `val`. Omitted where the figure did
+      // not come from a balance read — see the SolvencyPoolData doc.
+      source?: { address?: string; addressLabel: string },
     ): void => {
       if (val === undefined) return;
       pools.push({
@@ -1683,8 +1690,12 @@ export async function probeTreasuryLiquidity(input: {
         floor: floor > 0 ? floor : null,
         status: floor > 0 && val < floor ? "red" : "ok",
         ...(note ? { note } : {}),
+        ...(source?.address ? { address: source.address, addressLabel: source.addressLabel } : {}),
       });
     };
+    // NO ADDRESS on reward_bank, deliberately. Its figure comes from the
+    // product's own /health.rewardBank.liquid, not from a balance read, so any
+    // address here would claim a provenance the number does not have.
     pool("reward_bank", "Reward bank", input.rewardBankLiquid, input.minRewardBank);
     pool(
       "reserve",
@@ -1696,9 +1707,23 @@ export async function probeTreasuryLiquidity(input: {
           ? `Intentionally unfunded: ${input.treasuryReserveZeroReason}`
           : "Floor disabled without a declared reason"
         : undefined,
+      { ...(a.treasuryReserve ? { address: a.treasuryReserve } : {}), addressLabel: "treasury reserve" },
     );
-    pool("aac", "Agent core", aac, input.minAac);
-    if (escrow !== undefined) pools.push({ key: "escrow", label: "Escrow (in-flight)", amount: escrow, unit: "USDC", status: "ok", informational: true });
+    pool("aac", "Agent core", aac, input.minAac, undefined, {
+      ...(a.agentAccountCore ? { address: a.agentAccountCore } : {}),
+      addressLabel: "AgentAccountCore",
+    });
+    if (escrow !== undefined) {
+      pools.push({
+        key: "escrow",
+        label: "Escrow (in-flight)",
+        amount: escrow,
+        unit: "USDC",
+        status: "ok",
+        informational: true,
+        ...(a.escrowCore ? { address: a.escrowCore, addressLabel: "EscrowCore" } : {}),
+      });
+    }
 
     // Protocol revenue — the 5% poster-side fee accrued in the treasury
     // multisig's position. Internal ops metric (Hermes-only); informational, no
@@ -1716,13 +1741,15 @@ export async function probeTreasuryLiquidity(input: {
       pools.push({
         key: "protocol_revenue",
         label: "Protocol revenue (fees)",
-        amount: protocolRevenue,
+        amount: protocolRevenue.usdc,
         unit: "USDC",
         status: "ok",
         informational: true,
         note: "5% poster-side fee, held under the 2-of-3 treasury",
+        address: protocolRevenue.treasuryAccount,
+        addressLabel: "treasury multisig (position in AAC)",
       });
-      parts.push(`revenue ${protocolRevenue.toFixed(2)}`);
+      parts.push(`revenue ${protocolRevenue.usdc.toFixed(2)}`);
     }
 
     if (parts.length === 0) return { name, status: "degraded", detail: "no treasury balances readable" };
@@ -1750,6 +1777,14 @@ export interface SolvencyPoolData {
   informational?: boolean;
   /** Operator-declared context for a deliberately unfloored pool. */
   note?: string;
+  /** The on-chain address this amount was READ FROM. Present only when the
+   *  number came from a balance of that exact address — never a plausible
+   *  address attached for decoration. A pool whose figure comes from elsewhere
+   *  (the product's own /health, say) carries no address at all, because
+   *  showing one would claim a provenance the reading does not have. */
+  address?: string;
+  /** What that address IS, so the hex is legible without a block explorer. */
+  addressLabel?: string;
 }
 export interface SolvencySnapshotData {
   pools: SolvencyPoolData[];


### PR DESCRIPTION
Six balances on the board and no way to tell which address any of them came from. Checking meant leaving the board for a block explorer — which is exactly when an operator stops checking.

Each pool now carries the address its number came from, in full, under the label, with a plain-language tag for what the address **is**: `signer EOA`, `AgentAccountCore`, `EscrowCore`, `treasury reserve`, `treasury multisig`.

## Full, not truncated

The only reason to put a wallet on an ops board is so somebody can tell **which** wallet it is. A six-character prefix doesn't settle "treasury multisig or treasury reserve" — the two rows most easily confused, one of which reads `0.00` by design.

The hex is its own selectable span, so a double-click copies the whole address.

## The rule that decides which rows get one

**The address must be where the number was actually read from.** Not a plausible address, not a related contract.

| pool | source |
|---|---|
| `signer_gas` | `eth_getBalance(signer EOA)` |
| `aac`, `escrow`, `reserve` | `balanceOf(that address)` |
| `protocol_revenue` | the `treasuryAccount()` position it was read for — now returned **alongside** the amount rather than re-derived, so a figure can't be paired with an address from a different call |
| `reward_bank` | **no address** |

`reward_bank`'s figure comes from the product's own `/health.rewardBank.liquid`, not a balance read. Attaching `AgentAccountCore` would look right and would claim a provenance the number doesn't have — **the same class of lie as a fake green**, and harder to catch because it renders as extra rigour.

A test pins that absence, because "add the wallets" invites exactly the well-meaning fix of filling the gap.

## Fixtures use the real addresses

Already public via `/health.addresses`. A made-up hex wouldn't exercise the wrapping that 42 real characters cause in a narrow panel — the actual layout risk here. `overflow-wrap: anywhere` keeps a long hex from widening the panel and reflowing the meters.

## Verification

- 3 new render tests, including the no-address case
- full suite **2100 passed / 144 files** (backend + monitor-ui)
- typecheck clean on both workspaces