### PR TITLE
Per-probe transition alerts — say which probe crossed, in #Ops

### DIFF
--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -153,6 +153,8 @@ import {
 } from "./monitor-hermes-voice.js";
 import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
 import { publishNarration, readBuzzConfig } from "./buzz-client.js";
+import { decideProbeTransitions } from "./probe-transitions.js";
+import type { ProbeResult } from "./product-health.js";
 import {
   emitCopilotStreamEvent,
   onCopilotStreamEvent,
@@ -3279,6 +3281,11 @@ function startOperatorRoutines() {
   // only on an edge across the red boundary (entered-red / recovered).
   let prevProductHealthStatus: OpsStatus = "unknown";
   let lastOpsNarrationPostedAtMs = 0;
+  // Per-probe edge detection. Held in memory on purpose: after a restart every
+  // probe is "first sight" and says nothing, which is the correct behaviour —
+  // a redeploy must not page the operator about states that have not changed.
+  let prevProbes = new Map<string, ProbeResult>();
+  let postedProbeKeys = new Set<string>();
   let taskHealthRunning = false;
   const anomalyConfig = loadAnomalyConfig();
   const dispatchPerDayCap = Number(process.env.HERMES_DISPATCH_PER_DAY_MAX) || 10;
@@ -3741,6 +3748,41 @@ function startOperatorRoutines() {
         }
       } else if (opsNarration.suppressed) {
         logger.info({ edge: opsNarration.edge, suppressed: opsNarration.suppressed }, "ops_narration_suppressed");
+      }
+      // Per-probe transitions. Distinct from the narration above, which speaks
+      // only when the OVERALL verdict crosses red. "external_funnel says a bond
+      // slashes in 9h" is actionable and specific and may not move the overall
+      // verdict at all — that is precisely the alert worth having.
+      const transitions = decideProbeTransitions({
+        previous: prevProbes,
+        current: result.evaluation.probes,
+        posted: postedProbeKeys,
+        muted: getServerAlertMuteUntilMs() > Date.now(),
+      });
+      // State advances even while muted, so unmuting does not replay an edge
+      // that happened hours ago.
+      prevProbes = transitions.next;
+      postedProbeKeys = transitions.keys;
+      if (transitions.alerts.length > 0) {
+        const buzzForProbes = readBuzzConfig();
+        for (const alert of transitions.alerts) {
+          if (!buzzForProbes.config) {
+            logger.info({ probe: alert.probe, kind: alert.kind }, "probe_transition_undelivered");
+            continue;
+          }
+          const delivery = await publishNarration(buzzForProbes.config, alert.text);
+          if (delivery.ok) {
+            logger.info({ probe: alert.probe, kind: alert.kind, eventId: delivery.eventId }, "probe_transition_published");
+          } else {
+            // The key was already retained above, so a failed post is not
+            // retried forever — but it must be loud, because a transition
+            // nobody heard is the failure this whole channel exists to avoid.
+            logger.warn(
+              { probe: alert.probe, kind: alert.kind, reason: delivery.reason, detail: delivery.detail },
+              "probe_transition_publish_failed",
+            );
+          }
+        }
       }
       if (result.status !== "healthy") {
         logger.warn(

--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -1,0 +1,149 @@
+// Per-probe transition alerts — what gets said in #Ops when a single probe
+// crosses, as opposed to when the whole board does.
+//
+// `decideOpsNarration` already speaks on the OVERALL status crossing the red
+// boundary. That is the right granularity for "the product is in trouble" and
+// the wrong one for "external_funnel says a bond slashes in 9h" — which is
+// actionable, specific, and does not necessarily move the overall verdict at
+// all. This module covers the second case and leaves the first alone.
+//
+// ── EDGE-TRIGGERED, AND WHY THE KEY IS NOT THE DETAIL ───────────────────────
+//
+// Firing on state rather than on transitions is how a channel becomes noise: a
+// probe that stays degraded for six hours would repost every heartbeat, and an
+// operator learns to scroll past the one channel built to be worth reading.
+//
+// But "has the detail changed" is the WRONG test for whether something is new,
+// and the external_funnel probe proves it: its detail counts down — "slashes in
+// 9h", then "8h", then "7h". Keyed on the raw string, that re-alerts every
+// single poll while saying nothing new. Same trap the payout alert hit, where
+// the detail carried drifting USDC totals and the key had to become the gap.
+//
+// So the key is a REASON CLASS: the probe, its status, and its detail with the
+// volatile parts blanked. A countdown ticking is the same alert; a countdown
+// becoming a different problem is a new one.
+//
+// Kept pure — no clock, no I/O, no config — so every rule here is testable
+// without a relay or a heartbeat.
+
+import type { ProbeResult, ProbeStatus } from "./product-health.js";
+
+export interface ProbeTransitionAlert {
+  probe: string;
+  /** "opened" — entered degraded/red. "recovered" — returned to ok. */
+  kind: "opened" | "recovered";
+  from: ProbeStatus;
+  to: ProbeStatus;
+  /** The message to post, carrying the probe's own reason verbatim. */
+  text: string;
+  /** Stable identity of THIS alert; the caller stores it to avoid repeats. */
+  key: string;
+}
+
+export interface DecideProbeTransitionsInput {
+  /** Probe status + detail as of the previous tick. Empty on first run. */
+  previous: ReadonlyMap<string, ProbeResult>;
+  current: readonly ProbeResult[];
+  /** Keys already posted; a key present here is not posted again. */
+  posted: ReadonlySet<string>;
+  /** Operator mute — quiet everywhere, same rule the narration follows. */
+  muted: boolean;
+}
+
+export interface ProbeTransitionDecision {
+  alerts: ProbeTransitionAlert[];
+  /** Keys to retain for the next tick — the caller replaces its set with this. */
+  keys: Set<string>;
+  /** Probe state to carry into the next tick. */
+  next: Map<string, ProbeResult>;
+}
+
+/**
+ * Collapse a probe's detail to its SHAPE, so a moving number is not mistaken
+ * for a new problem.
+ *
+ * Hex ids and digits are the two things that drift while the situation holds
+ * still: a countdown, a balance, a job id rotating through a queue. Blanking
+ * them means "rejected 0xaa4b… slashes in 9h" and "…in 8h" share a class, while
+ * "…slashes in 9h" and "…dispute window LAPSED" do not.
+ */
+export function reasonClass(probe: ProbeResult): string {
+  const shape = probe.detail
+    .toLowerCase()
+    .replace(/0x[0-9a-f]+/g, "0x*")
+    .replace(/\d+(\.\d+)?/g, "*");
+  return `${probe.name}:${probe.status}:${shape}`;
+}
+
+/** Human line for the channel. The probe's own words, prefixed so it is greppable. */
+function alertText(probe: ProbeResult, kind: "opened" | "recovered"): string {
+  return kind === "opened"
+    ? `⚠ ${probe.name}: ${probe.detail}`
+    : `✓ ${probe.name} recovered: ${probe.detail}`;
+}
+
+const isAlarm = (status: ProbeStatus): boolean => status === "degraded" || status === "red";
+
+/**
+ * Decide which probes changed in a way worth saying out loud.
+ *
+ * Rules, each with a reason:
+ *  · A probe with no previous reading NEVER alerts. First sight is the boot
+ *    transition — the same reason `decideOpsNarration` stays silent on prev
+ *    "unknown". Otherwise every restart pages the operator about a state that
+ *    has not changed.
+ *  · Entering degraded or red alerts, including degraded→red and red→degraded:
+ *    both are a material change in what is wrong.
+ *  · Returning to ok alerts once, because a channel that only reports bad news
+ *    leaves you to guess whether it is over.
+ *  · A probe that vanishes says nothing. Absence is not recovery, and claiming
+ *    it would be the same lie as a fake green.
+ */
+export function decideProbeTransitions(input: DecideProbeTransitionsInput): ProbeTransitionDecision {
+  const alerts: ProbeTransitionAlert[] = [];
+  const keys = new Set<string>();
+  const next = new Map<string, ProbeResult>();
+
+  for (const probe of input.current) {
+    next.set(probe.name, probe);
+    const before = input.previous.get(probe.name);
+
+    // First sight — record it, say nothing.
+    if (!before) continue;
+    if (before.status === probe.status && !isAlarm(probe.status)) continue;
+
+    const enteringAlarm = isAlarm(probe.status) && before.status !== probe.status;
+    const recovered = !isAlarm(probe.status) && isAlarm(before.status);
+
+    if (isAlarm(probe.status)) {
+      // Carry the key forward whether or not we post: a probe that stays in the
+      // same reason class must not re-post when some other probe changes.
+      const key = reasonClass(probe);
+      keys.add(key);
+      if (!enteringAlarm && !input.posted.has(key)) {
+        // Status unchanged but the reason CLASS moved — a different problem
+        // wearing the same severity. Worth saying; the operator's next action
+        // differs.
+        if (!input.muted) {
+          alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened"), key });
+        }
+        continue;
+      }
+      if (enteringAlarm && !input.posted.has(key) && !input.muted) {
+        alerts.push({ probe: probe.name, kind: "opened", from: before.status, to: probe.status, text: alertText(probe, "opened"), key });
+      }
+      continue;
+    }
+
+    if (recovered) {
+      const key = `${probe.name}:recovered:${reasonClass(before)}`;
+      if (!input.posted.has(key) && !input.muted) {
+        alerts.push({ probe: probe.name, kind: "recovered", from: before.status, to: probe.status, text: alertText(probe, "recovered"), key });
+      }
+      // Recovery keys are NOT retained: the next time this probe breaks and
+      // heals, that is genuinely new and must be sayable again.
+    }
+  }
+
+  return { alerts, keys, next };
+}

--- a/test/unit/probe-transitions.test.ts
+++ b/test/unit/probe-transitions.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideProbeTransitions,
+  reasonClass,
+  type ProbeTransitionDecision,
+} from "../../services/slack-operator/src/probe-transitions.js";
+import type { ProbeResult } from "../../services/slack-operator/src/product-health.js";
+
+const p = (name: string, status: ProbeResult["status"], detail = "fine"): ProbeResult => ({
+  name,
+  status,
+  detail,
+});
+
+const decide = (
+  over: Partial<Parameters<typeof decideProbeTransitions>[0]> = {},
+): ProbeTransitionDecision =>
+  decideProbeTransitions({
+    previous: new Map(),
+    current: [],
+    posted: new Set(),
+    muted: false,
+    ...over,
+  });
+
+describe("reasonClass", () => {
+  it("blanks the numbers that drift while the situation holds still", () => {
+    // external_funnel counts DOWN. Keyed on the raw detail, this alerts every
+    // poll while saying nothing new — the same trap the payout alert hit.
+    const nine = p("external_funnel", "red", "rejected 0xaa4b… slashes in 9h · 1 in dispute window");
+    const eight = p("external_funnel", "red", "rejected 0xaa4b… slashes in 8h · 1 in dispute window");
+    expect(reasonClass(nine)).toBe(reasonClass(eight));
+  });
+
+  it("separates a different problem wearing the same severity", () => {
+    const counting = p("external_funnel", "red", "rejected 0xaa4b… slashes in 9h");
+    const lapsed = p("external_funnel", "red", "rejected 0xaa4b… dispute window LAPSED — bond slashable now");
+    expect(reasonClass(counting)).not.toBe(reasonClass(lapsed));
+  });
+
+  it("separates severities of the same text", () => {
+    expect(reasonClass(p("x", "degraded", "same"))).not.toBe(reasonClass(p("x", "red", "same")));
+  });
+});
+
+describe("decideProbeTransitions", () => {
+  it("says nothing about a probe it is seeing for the first time", () => {
+    // First sight is the boot transition. Alerting here pages the operator on
+    // every restart about a state that has not changed.
+    const r = decide({ current: [p("money_path", "red", "settlement stalled")] });
+    expect(r.alerts).toEqual([]);
+    expect(r.next.get("money_path")?.status).toBe("red");
+  });
+
+  it("alerts when a probe enters degraded, carrying its own words", () => {
+    const r = decide({
+      previous: new Map([["external_funnel", p("external_funnel", "ok", "0 in dispute window")]]),
+      current: [p("external_funnel", "red", "rejected 0xaa4b… slashes in 9h")],
+    });
+    expect(r.alerts).toHaveLength(1);
+    expect(r.alerts[0]).toMatchObject({ probe: "external_funnel", kind: "opened", from: "ok", to: "red" });
+    expect(r.alerts[0]?.text).toBe("⚠ external_funnel: rejected 0xaa4b… slashes in 9h");
+  });
+
+  it("does NOT repeat while the same reason class persists", () => {
+    // The whole point of edge-triggering: a probe degraded for six hours must
+    // not repost every heartbeat, or the one channel worth reading becomes the
+    // one you scroll past.
+    const previous = new Map([["external_funnel", p("external_funnel", "red", "slashes in 9h")]]);
+    const current = [p("external_funnel", "red", "slashes in 8h")];
+    const key = reasonClass(current[0]!);
+    const r = decide({ previous, current, posted: new Set([key]) });
+    expect(r.alerts).toEqual([]);
+    // …and the key survives, so an unrelated probe changing does not revive it.
+    expect(r.keys.has(key)).toBe(true);
+  });
+
+  it("alerts again when the reason class changes at the same severity", () => {
+    // Still red, but a countdown becoming "LAPSED" is a different problem and
+    // the operator's next action differs.
+    const previous = new Map([["external_funnel", p("external_funnel", "red", "slashes in 9h")]]);
+    const r = decide({
+      previous,
+      current: [p("external_funnel", "red", "dispute window LAPSED — bond slashable now")],
+      posted: new Set([reasonClass(p("external_funnel", "red", "slashes in 9h"))]),
+    });
+    expect(r.alerts).toHaveLength(1);
+    expect(r.alerts[0]?.text).toContain("LAPSED");
+  });
+
+  it("treats an escalation and a de-escalation as material changes", () => {
+    const up = decide({
+      previous: new Map([["x", p("x", "degraded", "a")]]),
+      current: [p("x", "red", "b")],
+    });
+    expect(up.alerts).toHaveLength(1);
+    const down = decide({
+      previous: new Map([["x", p("x", "red", "a")]]),
+      current: [p("x", "degraded", "b")],
+    });
+    expect(down.alerts).toHaveLength(1);
+  });
+
+  it("posts one recovery when a probe returns to ok", () => {
+    // A channel that only reports bad news leaves you guessing whether it ended.
+    const r = decide({
+      previous: new Map([["signer_liquidity", p("signer_liquidity", "red", "gas 0.4 < 1")]]),
+      current: [p("signer_liquidity", "ok", "gas 5.2 DOT")],
+    });
+    expect(r.alerts).toHaveLength(1);
+    expect(r.alerts[0]).toMatchObject({ kind: "recovered", from: "red", to: "ok" });
+    expect(r.alerts[0]?.text).toBe("✓ signer_liquidity recovered: gas 5.2 DOT");
+  });
+
+  it("does not retain recovery keys — breaking twice is two events", () => {
+    const r = decide({
+      previous: new Map([["x", p("x", "red", "bad")]]),
+      current: [p("x", "ok", "fine")],
+    });
+    expect([...r.keys]).toEqual([]);
+  });
+
+  it("stays silent about an ok probe that was already ok", () => {
+    const r = decide({
+      previous: new Map([["x", p("x", "ok", "fine")]]),
+      current: [p("x", "ok", "still fine")],
+    });
+    expect(r.alerts).toEqual([]);
+  });
+
+  it("says NOTHING when a probe disappears", () => {
+    // Absence is not recovery. Claiming it would be the same lie as a fake
+    // green — the probe stopped reporting, which is not the same as fine.
+    const r = decide({
+      previous: new Map([["gone", p("gone", "red", "was broken")]]),
+      current: [p("other", "ok", "fine")],
+    });
+    expect(r.alerts).toEqual([]);
+    expect(r.next.has("gone")).toBe(false);
+  });
+
+  it("is silent while muted but still tracks state", () => {
+    // Mute must not desynchronise the edge detector, or the first post after
+    // unmuting would be about a transition that happened hours ago.
+    const r = decide({
+      previous: new Map([["x", p("x", "ok", "fine")]]),
+      current: [p("x", "red", "broken")],
+      muted: true,
+    });
+    expect(r.alerts).toEqual([]);
+    expect(r.next.get("x")?.status).toBe("red");
+    expect(r.keys.has(reasonClass(p("x", "red", "broken")))).toBe(true);
+  });
+
+  it("handles several probes crossing in the same tick", () => {
+    const r = decide({
+      previous: new Map([
+        ["a", p("a", "ok", "fine")],
+        ["b", p("b", "red", "broken")],
+        ["c", p("c", "ok", "fine")],
+      ]),
+      current: [p("a", "red", "now broken"), p("b", "ok", "healed"), p("c", "ok", "fine")],
+    });
+    expect(r.alerts.map((x) => `${x.probe}:${x.kind}`).sort()).toEqual(["a:opened", "b:recovered"]);
+  });
+});


### PR DESCRIPTION
Completes the alert-delivery half of the `external_funnel` brief, now that Buzz can speak.

`decideOpsNarration` fires when the **overall** verdict crosses red. That's right for "the product is in trouble" and wrong for *"external_funnel says a bond slashes in 9h"* — which is actionable, specific, and may not move the overall verdict at all. This covers the second case and leaves the first alone.

## The key is not the detail, and `external_funnel` is why

Its detail **counts down**: `slashes in 9h` → `8h` → `7h`. Keyed on the raw string, that re-alerts every heartbeat while saying nothing new — the same trap the payout alert hit, where the detail carried drifting USDC totals and the key had to become the gap.

So the key is a **reason class**: probe + status + detail with hex ids and digits blanked.

- `slashes in 9h` and `slashes in 8h` → same class, **one alert**
- `slashes in 9h` and `dispute window LAPSED — bond slashable now` → different classes, **both posted**, because the operator's next action differs

## Rules that earned tests

| rule | why |
|---|---|
| first sight never alerts | it's the boot transition — otherwise every redeploy pages about unchanged state |
| recovery posts once | a channel that only reports bad news leaves you guessing whether it ended |
| recovery keys not retained | breaking twice is two events |
| a vanished probe says **nothing** | absence is not recovery — calling it that is the same lie as a fake green |
| muted is silent but still tracks | otherwise unmuting replays a transition from hours ago |

Edge state lives in memory deliberately: a restart makes every probe first-sight and therefore quiet, which is what a redeploy should be.

A failed publish logs **WARN** and isn't retried forever — but it's loud, because a transition nobody heard is the exact failure this channel exists to prevent.

## Verification

- 14 new tests
- full suite **1842 passed / 122 files**
- typecheck clean

No new config: it uses the same `BUZZ_*` variables and the publish path already proven against the live relay.