### PR TITLE
The pool address broke the row it was added to

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ops-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--workspace", "packages/monitor-ui", "--", "--port", "5175"],
+      "port": 5175
+    }
+  ]
+}

--- a/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
@@ -94,7 +94,6 @@ function FlooredPool({ view }: { view: PoolView }) {
           {view.margin}
         </span>
       </div>
-      <PoolAddress view={view} />
 
       <div className="ops-pool-meter">
         <div
@@ -128,6 +127,9 @@ function FlooredPool({ view }: { view: PoolView }) {
         {view.amountLabel}
         <span className="ops-pool-unit">{view.unit}</span>
       </div>
+      {/* LAST on purpose: .ops-pool is a three-column grid, so anything
+          placed before the amount pushes it onto a second row. */}
+      <PoolAddress view={view} />
     </div>
   );
 }
@@ -141,12 +143,12 @@ function UnflooredPool({ view }: { view: PoolView }) {
           there is no note we say we do not know, rather than implying it's fine. */}
       <span className="ops-pool-note">
         {view.pool.note ?? (view.pool.informational ? "informational — not floored" : "no floor declared for this pool")}
-        <PoolAddress view={view} />
       </span>
       <span className="ops-pool-amount ops-pool-amount--quiet">
         {view.amountLabel}
         <span className="ops-pool-unit">{view.unit}</span>
       </span>
+      <PoolAddress view={view} />
     </div>
   );
 }

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -267,7 +267,9 @@ const MAINNET_POOLS: SolvencyPool[] = [
     unit: "USDC",
     status: "ok",
     note: "5% poster-side fee · held under the 2-of-3 treasury multisig",
-  },
+      address: "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
+    addressLabel: "treasury multisig",
+},
 ];
 
 const MAINNET_PROBES: ProductHealthProbe[] = [

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -383,13 +383,26 @@ body,
    cannot answer "which multisig is this?", which is the only reason to put it
    on the board at all. */
 .ops-pool-addr {
+  /* SPAN THE WHOLE ROW. .ops-pool is a three-column grid — name | meter |
+     amount — and an address dropped in as a fourth item became a second grid
+     ROW, pushing the amount below the meter and tripling every row's height.
+     Spanning to the end keeps those three cells on one line and puts the
+     address on a quiet line of its own beneath them. */
+  grid-column: 1 / -1;
   display: block;
+  /* .ops-pool sets gap:16px, which applies BETWEEN grid rows too and left the
+     address floating halfway to the next pool. Pull it back under its own row
+     so it reads as belonging to the balance above it. */
+  margin-top: -11px;
   font-family: var(--h4-font-mono);
   font-size: 9.5px;
-  line-height: 1.5;
+  line-height: 1.4;
   color: var(--h4-muted);
-  /* Long hex must never widen the panel and force the meters to reflow. */
-  overflow-wrap: anywhere;
+  /* One line: 42 hex characters do not fit the 168px name column, and letting
+     them wrap is what made this ugly in the first place. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .ops-pool-addr-hex {
   /* Selectable as one unit so a double-click copies the whole address. */
@@ -402,10 +415,19 @@ body,
   opacity: 0.6;
 }
 .ops-pool--unfloored .ops-pool-addr {
-  margin-top: 2px;
+  /* This row has smaller padding than a floored one, so it needs less pull-up. */
+  margin-top: -6px;
 }
 
+.ops-pool--unfloored .ops-pool-note {
+  /* The note column takes the slack; the amount must not. A long address in
+     here clipped the "USDC" off protocol revenue — the one row where the unit
+     is doing real work — which is why the address moved out of this column. */
+  min-width: 0;
+}
 .ops-pool-amount--quiet {
+  flex: 0 0 auto;
+  white-space: nowrap;
   font-size: 16px;
   font-weight: 400;
   color: var(--h4-muted);

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1747,7 +1747,7 @@ export async function probeTreasuryLiquidity(input: {
         informational: true,
         note: "5% poster-side fee, held under the 2-of-3 treasury",
         address: protocolRevenue.treasuryAccount,
-        addressLabel: "treasury multisig (position in AAC)",
+        addressLabel: "treasury multisig",
       });
       parts.push(`revenue ${protocolRevenue.usdc.toFixed(2)}`);
     }


### PR DESCRIPTION
I shipped #642 without looking at the rendered board. It showed — Pascal's first reaction to the live UI was that it looked weird, and it did.

Fixed by running the preview and reading the screenshot, which is what should have happened before it merged.

## What was wrong

`.ops-pool` is a **three-column grid** — `name | meter | amount`. The address went in as a *fourth item*, so it became a second grid **row**: the amount got pushed below the meter and every floored pool tripled in height.

Two changes, and the first alone wasn't enough:

- `grid-column: 1 / -1` so it spans the row instead of taking a cell
- **place it last in the JSX** — spanning it while it still sat before the meter just moved the break, pushing meter *and* amount onto their own row

Then the 16px grid gap applied between rows too, leaving the address floating halfway to the next pool. A `-11px` pull-up puts it back under the balance it describes.

## Unfloored rows had it in a different shape

The address lived inside the **note** column, which is narrow, so it ellipsised to `· treasur…` — address readable, label not. Its width also clipped the `USDC` off **protocol revenue**, the one row where the unit is doing real work.

Now it takes its own full-width line like the floored rows, the amount column is pinned so a long neighbour can't eat it, and `treasury multisig (position in AAC)` drops the parenthetical the row's own note already states.

## Also

The fixture now carries protocol revenue's address, which the live endpoint returns — that omission is why the clipping wasn't visible in tests.

## Verification

- **2114 passed / 145 files**, typecheck clean on both workspaces
- verified by screenshot in the ops preview, not by assertion alone

No behaviour change: same data, same rule about which pools get an address. This is only the part I should have checked before calling it done.