### PR TITLE
fix(int2): sweep the run workspaces the suite orphans (#625)

### DIFF
--- a/scripts/ceremony/lib/int2-reap.sh
+++ b/scripts/ceremony/lib/int2-reap.sh
@@ -163,3 +163,64 @@ int2_reap_run_containers() {
   done
   return 0
 }
+
+# Record the agent-runtime-* workspace directories that exist BEFORE the run,
+# into $1, from workspace root $2 (issue #625, the workspace half of the
+# container reap above). The root — default_workspace_root() resolves to
+# ~/.agent-runtime/environments — is persistent and SHARED: an operator's
+# ceremony run and this suite write side by side, so anything present now is
+# somebody's workspace, possibly live, and must be spared.
+#
+# A root that does not exist yet is a legitimately empty set — the snapshot
+# is written empty and the run proceeds. A root that exists but cannot be
+# listed fails WITHOUT creating the file, which keeps the reap below
+# fail-safe: no snapshot, nothing removed.
+int2_reap_snapshot_workspaces() {
+  _int2_reap_ws_root="${2:-}"
+  [ -n "${1:-}" ] && [ -n "$_int2_reap_ws_root" ] || return 1
+  if [ ! -d "$_int2_reap_ws_root" ]; then
+    : > "$1"
+    return 0
+  fi
+  _int2_reap_ws_existing="$(
+    find "$_int2_reap_ws_root" -mindepth 1 -maxdepth 1 -type d \
+      -name 'agent-runtime-*' -exec basename {} \; 2>/dev/null
+  )" || return 1
+  printf '%s\n' "$_int2_reap_ws_existing" > "$1"
+}
+
+# $1 the snapshot file, $2 the workspace root, $3 log path. Removes every
+# agent-runtime-* directory under the root that was not in the snapshot.
+#
+# DockerEnvironment.destroy() removes the container AND the workspace, so the
+# happy path leaves nothing. Anything that died before destroy() leaves both —
+# and the container reap above, on its own, turns that pair into an orphaned
+# directory (#624 removed the container half only; #625 is this half). Runs
+# only after int2_reap_run_containers so no removed container's bind mount is
+# still attached to a directory being deleted.
+#
+# Same snapshot-diff reasoning as containers: child and verification runs
+# derive their own ids, so the suite cannot enumerate what it created — but it
+# can state exactly what it did NOT create, and everything in the snapshot is
+# spared. A missing or unreadable snapshot removes nothing at all; deleting an
+# operator's live workspace because the suite failed before it could look is
+# the one outcome worse than leaking 42 MB.
+int2_reap_workspaces() {
+  _int2_reap_ws_before="${1:-}"
+  _int2_reap_ws_root="${2:-}"
+  _int2_reap_ws_log="${3:-/dev/null}"
+  [ -n "$_int2_reap_ws_before" ] && [ -f "$_int2_reap_ws_before" ] || return 0
+  [ -n "$_int2_reap_ws_root" ] && [ -d "$_int2_reap_ws_root" ] || return 0
+  for _int2_reap_ws_dir in "$_int2_reap_ws_root"/agent-runtime-*/; do
+    [ -d "$_int2_reap_ws_dir" ] || continue
+    _int2_reap_ws_name="$(basename "$_int2_reap_ws_dir")"
+    case "$_int2_reap_ws_name" in agent-runtime-?*) ;; *) continue ;; esac
+    if grep -qxF "$_int2_reap_ws_name" "$_int2_reap_ws_before" 2>/dev/null; then
+      continue
+    fi
+    rm -rf "$_int2_reap_ws_root/$_int2_reap_ws_name" 2>/dev/null || continue
+    printf '%s\n' "INT2_WORKSPACE_REAPED name=$_int2_reap_ws_name" \
+      >> "$_int2_reap_ws_log" 2>/dev/null || true
+  done
+  return 0
+}

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -18,6 +18,12 @@ _int2_git_probe=""
 # the evidence directory: they are transient, and CI uploads the evidence.
 _int2_worker_pidfile="$_int2_root/worker-pids.txt"
 _int2_run_containers_before="$_int2_root/run-containers-before.txt"
+# The workspace half of the same leak family (#625): the Harness Docker tier
+# roots run workspaces under a persistent shared directory, and a run that
+# dies before destroy() leaves its agent-runtime-<run_id> directory behind.
+# INT2_WORKSPACE_ROOT exists for the unit tests; operators never set it.
+_int2_workspaces_before="$_int2_root/workspaces-before.txt"
+_int2_workspace_root="${INT2_WORKSPACE_ROOT:-$HOME/.agent-runtime/environments}"
 
 # shellcheck source=scripts/ceremony/lib/int2-reap.sh
 source "$_int2_repo/scripts/ceremony/lib/int2-reap.sh"
@@ -53,6 +59,11 @@ _int2_cleanup() {
   # The workers are gone, so no new run container can appear underneath this.
   int2_reap_run_containers \
     "$_int2_run_containers_before" "$_int2_bootstrap_log" || true
+  # After the containers, so no removed container's bind mount still points
+  # at a directory being deleted (#625 — the workspace half of the reap).
+  int2_reap_workspaces \
+    "$_int2_workspaces_before" "$_int2_workspace_root" "$_int2_bootstrap_log" \
+    || true
   docker rm --force "$_int2_harness_db" "$_int2_reference_db" \
     >/dev/null 2>&1 || true
   case "$_int2_git_probe" in
@@ -261,6 +272,18 @@ int2_reap_snapshot_run_containers "$_int2_run_containers_before" \
   }
 printf '%s\n' "INT2_RUN_CONTAINER_SNAPSHOT spared=$(
   grep -c . "$_int2_run_containers_before" 2>/dev/null || echo 0
+)" >> "$_int2_bootstrap_log"
+# The workspace snapshot shares the container snapshot's boundary: everything
+# under the root right now is somebody else's — possibly an operator's live
+# ceremony workspace — and the trap must not touch it.
+int2_reap_snapshot_workspaces "$_int2_workspaces_before" "$_int2_workspace_root" \
+  || {
+    echo "INT2_WORKSPACE_SNAPSHOT_FAILED: cannot list existing agent-runtime-* workspaces" \
+      | tee -a "$_int2_bootstrap_log" >&2
+    exit 35
+  }
+printf '%s\n' "INT2_WORKSPACE_SNAPSHOT spared=$(
+  grep -c . "$_int2_workspaces_before" 2>/dev/null || echo 0
 )" >> "$_int2_bootstrap_log"
 
 printf '%s\n' "INT2_CASES_STARTED expected=10" >> "$_int2_bootstrap_log"

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -3,6 +3,7 @@ import {
   chmod,
   mkdir,
   mkdtemp,
+  readdir,
   readFile,
   rm,
   writeFile,
@@ -842,5 +843,79 @@ describe("INT-2 suite reaping", () => {
     expect(integration).toContain("recordWorkerPid(child.pid)");
     expect(integration).toContain("appendFileSync(pidfile");
     expect(integration).toContain('"SIGKILL"');
+
+    // #625: the workspace half rides the same snapshot boundary and the same
+    // trap, after the container reap (bind mounts released first), with its
+    // own self-naming failure code.
+    expect(suite).toContain("int2_reap_snapshot_workspaces ");
+    expect(suite).toContain("int2_reap_workspaces ");
+    expect(suite).toContain("INT2_WORKSPACE_SNAPSHOT_FAILED");
+    expect(suite).toContain("exit 35");
+    expect(suite).toContain('INT2_WORKSPACE_ROOT:-$HOME/.agent-runtime/environments');
+    expect(suite.indexOf("int2_reap_workspaces ")).toBeGreaterThan(
+      suite.indexOf("int2_reap_run_containers "),
+    );
+  });
+
+  it("removes only the workspaces born during the run and spares the snapshot", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-workspaces-"));
+    temporaryRoots.push(root);
+    const workspaceRoot = path.join(root, "environments");
+    const before = path.join(root, "before.txt");
+    const log = path.join(root, "reap.log");
+    // An operator's pre-existing workspace and a days-old leak this run does
+    // not own: both are in the snapshot, both must survive.
+    await mkdir(path.join(workspaceRoot, "agent-runtime-operator-live"), { recursive: true });
+    await mkdir(path.join(workspaceRoot, "agent-runtime-old-leak"), { recursive: true });
+    runReaper(`int2_reap_snapshot_workspaces "${before}" "${workspaceRoot}"`);
+
+    // Born during the run: a top-level run and a derived verification run —
+    // the unknowable-up-front name shape that makes this a snapshot diff.
+    await mkdir(path.join(workspaceRoot, "agent-runtime-suite-run", "repo"), { recursive: true });
+    await writeFile(
+      path.join(workspaceRoot, "agent-runtime-suite-run", "repo", "file.txt"),
+      "contents",
+    );
+    await mkdir(path.join(workspaceRoot, "agent-runtime-suite-run-check-1"), { recursive: true });
+    // Not the reap's shape at all — spared regardless of the snapshot.
+    await mkdir(path.join(workspaceRoot, "unrelated-dir"), { recursive: true });
+
+    runReaper(`int2_reap_workspaces "${before}" "${workspaceRoot}" "${log}"`);
+
+    const survivors = (await readdir(workspaceRoot)).sort();
+    expect(survivors).toEqual([
+      "agent-runtime-old-leak",
+      "agent-runtime-operator-live",
+      "unrelated-dir",
+    ]);
+    const logged = await readFile(log, "utf8");
+    expect(logged).toContain("INT2_WORKSPACE_REAPED name=agent-runtime-suite-run");
+    expect(logged).toContain("INT2_WORKSPACE_REAPED name=agent-runtime-suite-run-check-1");
+  });
+
+  it("treats a root that does not exist yet as an empty snapshot, not a failure", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-ws-fresh-"));
+    temporaryRoots.push(root);
+    const workspaceRoot = path.join(root, "environments");
+    const before = path.join(root, "before.txt");
+    // Root absent: snapshot succeeds and is empty — nothing existed to spare.
+    runReaper(`int2_reap_snapshot_workspaces "${before}" "${workspaceRoot}"`);
+    // The run then creates the root and a workspace; both are the suite's.
+    await mkdir(path.join(workspaceRoot, "agent-runtime-first"), { recursive: true });
+    runReaper(`int2_reap_workspaces "${before}" "${workspaceRoot}" /dev/null`);
+    expect(await readdir(workspaceRoot)).toEqual([]);
+  });
+
+  it("removes no workspace at all when it never got to take a snapshot", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "int2-reap-ws-nosnap-"));
+    temporaryRoots.push(root);
+    const workspaceRoot = path.join(root, "environments");
+    await mkdir(path.join(workspaceRoot, "agent-runtime-unattributed"), { recursive: true });
+    // Same fail-safe as containers: deleting somebody's workspace because the
+    // suite failed before it could look is strictly worse than leaking.
+    runReaper(
+      `int2_reap_workspaces "${path.join(root, "absent.txt")}" "${workspaceRoot}" /dev/null`,
+    );
+    expect(await readdir(workspaceRoot)).toEqual(["agent-runtime-unattributed"]);
   });
 });


### PR DESCRIPTION
Bounty deliverable for the externally posted job on issue #625 (Averray job `0xaa4b7b03…`).

**The fix, in #624's own shape:** the suite snapshots `agent-runtime-*` names under the workspace root at the same *'during the run'* boundary as the container snapshot (own self-naming `exit 35`), and the trap — **after** `int2_reap_run_containers`, so no removed container's bind mount still points at a directory being deleted — removes only what the snapshot doesn't contain.

**Safety properties, mirrored from the container reap:**
- Everything pre-existing is spared: an operator's live ceremony workspace, days-old leaks this run doesn't own.
- A missing/unreadable snapshot removes **nothing** — deleting somebody's workspace because the suite failed before it could look is the one outcome worse than leaking 42 MB.
- A root that doesn't exist yet is an empty set, not a failure.
- Non-`agent-runtime-*` names are never touched regardless of the snapshot.
- `INT2_WORKSPACE_REAPED name=…` log lines per removal; `INT2_WORKSPACE_SNAPSHOT spared=N` at the boundary.

**Deliberately out of scope** (as the issue itself anticipates): artifacts (240 MB, content-addressed, not enumerable by run — this mechanism doesn't transfer; deserves its own issue) and kernel-side retention (`harness env prune`).

**Tests:** 21/21 in `int2-ceremony-scripts.test.ts` — three new (spares-snapshot/removes-only-new incl. a derived `-check-1` name, fresh-root-as-empty-set, no-snapshot-removes-nothing) plus wiring assertions (order after container reap, exit-code distinctness, root default).

Closes #625.

🤖 Generated with [Claude Code](https://claude.com/claude-code)