### PR TITLE
Put #Ops delivery health on the board

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -306,6 +306,8 @@ export const OPS_FIXTURE_NOMINAL: ProductHealth = {
     onBackup: false,
     detail: "rpc-1 primary · failover armed",
   },
+  // Configured and delivering — the state after the first real narration lands.
+  buzz: { status: "ok", detail: "delivered 4m ago" },
   solvency: { pools: MAINNET_POOLS },
   flow: {
     claimed24h: 9,

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -225,6 +225,7 @@ export function trustRows(input: {
   }
 
   rows.push(monitorRow(health.self));
+  rows.push(buzzRow(health.buzz));
 
   const rem = health.remediation;
   if (!rem || !rem.enabled || rem.state === "off") {
@@ -245,6 +246,25 @@ function shortRpcDetail(rem: NonNullable<ProductHealth["remediation"]>): string 
   const host = shortEndpoint(rem.activeEndpoint);
   if (!host) return rem.detail;
   return rem.detail.replace(/https?:\/\/\S+/g, host);
+}
+
+/**
+ * The #Ops delivery row.
+ *
+ * "armed" is deliberately NOT ok-toned: a configured channel that has never
+ * delivered anything is untested, and showing it green would be the same lie
+ * as a fake healthy probe — worse, because the thing it would be lying about
+ * is whether you will be TOLD when something breaks.
+ *
+ * An absent block means an older backend that does not report this. Silence is
+ * right there: inventing a status for a field the server never sent is exactly
+ * the fabrication this panel exists to avoid.
+ */
+function buzzRow(buzz: ProductHealth["buzz"]): TrustRow {
+  if (!buzz) return { key: "OPS CHANNEL", value: "not reported by this build", tone: "awaiting" };
+  const tone: OpsTone =
+    buzz.status === "ok" ? "ok" : buzz.status === "failing" ? "red" : "awaiting";
+  return { key: "OPS CHANNEL", value: buzz.detail, tone };
 }
 
 function monitorRow(self: SelfFreshness | undefined): TrustRow {

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -44,6 +44,14 @@ export interface SolvencyPool {
   addressLabel?: string;
 }
 
+/** Can the #Ops channel receive anything? Instrument health, not product health. */
+export interface BuzzDeliveryView {
+  status: "off" | "armed" | "ok" | "failing";
+  detail: string;
+  lastOkAt?: number;
+  lastFailureAt?: number;
+}
+
 export interface SolvencySnapshot {
   pools: SolvencyPool[];
   /** Honest runway note, e.g. "≈ 6 payouts to floor" or "pending settlement data". */
@@ -223,6 +231,8 @@ export interface ProductHealth {
   flow?: MoneyPathSnapshot;
   history?: HealthHistory;
   remediation?: RemediationStatus;
+  /** #Ops delivery health — see BuzzDeliveryView. */
+  buzz?: BuzzDeliveryView;
   /** The monitor's own build vs main — "is this board current?". */
   self?: SelfFreshness;
   /**

--- a/services/slack-operator/src/buzz-delivery.ts
+++ b/services/slack-operator/src/buzz-delivery.ts
@@ -1,0 +1,114 @@
+// Is the #Ops channel actually receiving anything?
+//
+// WHY THIS EXISTS: narration and per-probe alerts both log WARN when a publish
+// fails, and logs are not a surface anybody watches. So a Buzz channel that is
+// silently broken looks EXACTLY like one that is quiet because nothing is
+// wrong. That is the failure this entire monitor exists to prevent, aimed at
+// the monitor's own alerting.
+//
+// It reports on the INSTRUMENT, not the product. A relay we cannot reach does
+// not mean the money path is broken, so this never moves the operator verdict —
+// it sits in the trust panel beside DATA AGE and MONITOR, which answer the same
+// kind of question: should I believe what this screen is telling me, and will I
+// be told if it changes?
+//
+// ── ARMED IS NOT OK ────────────────────────────────────────────────────────
+// The state that matters most is "configured, credentials loaded, and nothing
+// has ever been sent". That is not a success. Until a message has actually
+// crossed the wire, the only honest thing to say is that the path is untested —
+// exactly the position this integration was in for most of its life, when every
+// piece had passed against a scripted fake relay and none against the real one.
+
+export type BuzzDeliveryStatus = "off" | "armed" | "ok" | "failing";
+
+export interface BuzzDelivery {
+  status: BuzzDeliveryStatus;
+  /** Operator-facing sentence. Never contains the agent secret. */
+  detail: string;
+  lastOkAt?: number;
+  lastFailureAt?: number;
+}
+
+export interface BuzzDeliveryState {
+  lastOkAt?: number;
+  lastFailureAt?: number;
+  /** Machine reason of the most recent failure, e.g. "auth-rejected". */
+  lastFailureReason?: string;
+  lastFailureDetail?: string;
+}
+
+function ago(fromMs: number, nowMs: number): string {
+  const mins = Math.max(0, Math.round((nowMs - fromMs) / 60_000));
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  return hours < 48 ? `${hours}h ago` : `${Math.round(hours / 24)}d ago`;
+}
+
+/**
+ * Describe the delivery path.
+ *
+ * `configured` and `problem` come from readBuzzConfig, which already separates
+ * "not set up" from "set up wrong" — a distinction this preserves, because one
+ * is a choice and the other is a mistake.
+ */
+export function describeBuzzDelivery(input: {
+  configured: boolean;
+  /** Non-null when the configuration is present but broken. */
+  problem?: string | null;
+  state: BuzzDeliveryState;
+  nowMs: number;
+}): BuzzDelivery {
+  const { state, nowMs } = input;
+
+  // Half-configured. Somebody meant to turn this on and left it broken, which
+  // must not read the same as deliberately leaving it off.
+  if (!input.configured && input.problem) {
+    return { status: "failing", detail: `misconfigured — ${input.problem}` };
+  }
+
+  // Deliberately off. Quiet, and NOT an alarm: Buzz is an optional surface, and
+  // a permanently-lit row for a feature nobody enabled is how a panel teaches
+  // its reader to ignore it.
+  if (!input.configured) {
+    return { status: "off", detail: "not configured" };
+  }
+
+  const failedAt = state.lastFailureAt;
+  const okAt = state.lastOkAt;
+
+  // Most recent attempt failed. Say what kind of failure — an auth rejection
+  // and an unreachable relay need different responses, and "delivery failed"
+  // sends the operator looking in the wrong place.
+  if (failedAt !== undefined && (okAt === undefined || failedAt >= okAt)) {
+    const reason = state.lastFailureReason ? `${state.lastFailureReason}` : "unknown reason";
+    const since = okAt === undefined ? "never delivered" : `last delivered ${ago(okAt, nowMs)}`;
+    return {
+      status: "failing",
+      detail: `FAILING ${ago(failedAt, nowMs)} — ${reason} · ${since}`,
+      lastFailureAt: failedAt,
+      ...(okAt !== undefined ? { lastOkAt: okAt } : {}),
+    };
+  }
+
+  if (okAt !== undefined) {
+    return { status: "ok", detail: `delivered ${ago(okAt, nowMs)}`, lastOkAt: okAt };
+  }
+
+  // Configured, credentials loaded, nothing ever sent. NOT ok — see the header.
+  return { status: "armed", detail: "armed · nothing delivered yet" };
+}
+
+/** Fold one publish outcome into the running state. Pure. */
+export function recordBuzzDelivery(
+  state: BuzzDeliveryState,
+  outcome: { ok: boolean; reason?: string; detail?: string; atMs: number },
+): BuzzDeliveryState {
+  if (outcome.ok) return { ...state, lastOkAt: outcome.atMs };
+  return {
+    ...state,
+    lastFailureAt: outcome.atMs,
+    ...(outcome.reason ? { lastFailureReason: outcome.reason } : {}),
+    ...(outcome.detail ? { lastFailureDetail: outcome.detail } : {}),
+  };
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -154,6 +154,7 @@ import {
 import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
 import { publishNarration, readBuzzConfig } from "./buzz-client.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
+import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
 import type { ProbeResult } from "./product-health.js";
 import {
   emitCopilotStreamEvent,
@@ -306,6 +307,10 @@ const PRODUCT_HEALTH_INCIDENT_MAX = 200;
 let productHealthChainAdvance: ChainAdvance | undefined;
 // Structured snapshot blocks (chain id / network / solvency / flow) for the Ops board.
 let productHealthSnapshotBlocks: ProductHealthSnapshotBlocks | undefined;
+// Buzz delivery outcomes. Module scope so the endpoint can report it without
+// the heartbeat having to thread it through — and in memory on purpose: after a
+// restart the honest answer is "nothing delivered yet", not a stale success.
+let buzzDeliveryState: BuzzDeliveryState = {};
 let productHealthRemediation: RemediationStatus | undefined;
 
 /** The settlement signer's address, derived from the key the monitor already holds
@@ -805,6 +810,21 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       // Structured Ops-board blocks (chain id / network / solvency / flow),
       // emitted only when their data is actually available — else absent (the
       // frontend renders honest awaiting-data).
+      // Can the #Ops channel actually receive anything? Narration and probe
+      // alerts only log their failures, and a silently-broken channel looks
+      // exactly like a quiet healthy one — which is the failure this monitor
+      // exists to prevent, pointed at its own alerting. Reported as instrument
+      // health beside DATA AGE and MONITOR; it never moves the verdict, because
+      // an unreachable relay does not mean the money path is broken.
+      buzz: (() => {
+        const cfg = readBuzzConfig();
+        return describeBuzzDelivery({
+          configured: cfg.config !== null,
+          problem: cfg.config === null ? (cfg as { problem: string | null }).problem : null,
+          state: buzzDeliveryState,
+          nowMs: Date.now(),
+        });
+      })(),
       ...(productHealthSnapshotBlocks ?? {}),
       // History-derived Trends + Incidents (uptime% / latency / balance series +
       // incident episodes) from the rolling buffer. Always present — the series
@@ -3731,6 +3751,12 @@ function startOperatorRoutines() {
         const buzz = readBuzzConfig();
         if (buzz.config) {
           const delivery = await publishNarration(buzz.config, opsNarration.text);
+          buzzDeliveryState = recordBuzzDelivery(buzzDeliveryState, {
+            ok: delivery.ok,
+            reason: delivery.reason,
+            detail: delivery.detail,
+            atMs: Date.now(),
+          });
           if (delivery.ok) {
             logger.info({ edge: opsNarration.edge, eventId: delivery.eventId }, "ops_narration_buzz_published");
           } else {
@@ -3771,6 +3797,12 @@ function startOperatorRoutines() {
             continue;
           }
           const delivery = await publishNarration(buzzForProbes.config, alert.text);
+          buzzDeliveryState = recordBuzzDelivery(buzzDeliveryState, {
+            ok: delivery.ok,
+            reason: delivery.reason,
+            detail: delivery.detail,
+            atMs: Date.now(),
+          });
           if (delivery.ok) {
             logger.info({ probe: alert.probe, kind: alert.kind, eventId: delivery.eventId }, "probe_transition_published");
           } else {

--- a/test/unit/buzz-delivery.test.ts
+++ b/test/unit/buzz-delivery.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describeBuzzDelivery,
+  recordBuzzDelivery,
+} from "../../services/slack-operator/src/buzz-delivery.js";
+
+const NOW = Date.parse("2026-08-02T12:00:00.000Z");
+const MIN = 60_000;
+
+const describe_ = (over: Partial<Parameters<typeof describeBuzzDelivery>[0]> = {}) =>
+  describeBuzzDelivery({ configured: true, state: {}, nowMs: NOW, ...over });
+
+describe("describeBuzzDelivery", () => {
+  it("ARMED is not ok — a channel that never delivered is untested", () => {
+    // The state this whole feature is for. Credentials loaded, nothing ever
+    // sent: showing that green would lie about whether you will be TOLD when
+    // something breaks, which is worse than lying about a probe.
+    const r = describe_();
+    expect(r.status).toBe("armed");
+    expect(r.detail).toContain("nothing delivered yet");
+    expect(r.status).not.toBe("ok");
+  });
+
+  it("reports a successful delivery with its age", () => {
+    const r = describe_({ state: { lastOkAt: NOW - 7 * MIN } });
+    expect(r.status).toBe("ok");
+    expect(r.detail).toBe("delivered 7m ago");
+  });
+
+  it("a failure since the last success reads FAILING and names the reason", () => {
+    // "delivery failed" sends the operator to the wrong place; an auth
+    // rejection and an unreachable relay need different responses.
+    const r = describe_({
+      state: { lastOkAt: NOW - 60 * MIN, lastFailureAt: NOW - 3 * MIN, lastFailureReason: "auth-rejected" },
+    });
+    expect(r.status).toBe("failing");
+    expect(r.detail).toContain("FAILING 3m ago");
+    expect(r.detail).toContain("auth-rejected");
+    // The last good delivery stays visible — "broken for 3 minutes" and "broken
+    // for a day" are different situations.
+    expect(r.detail).toContain("last delivered 1h ago");
+  });
+
+  it("says never delivered when every attempt has failed", () => {
+    const r = describe_({ state: { lastFailureAt: NOW - MIN, lastFailureReason: "connect-failed" } });
+    expect(r.status).toBe("failing");
+    expect(r.detail).toContain("never delivered");
+  });
+
+  it("a success AFTER a failure clears the alarm", () => {
+    const r = describe_({ state: { lastFailureAt: NOW - 20 * MIN, lastOkAt: NOW - 2 * MIN } });
+    expect(r.status).toBe("ok");
+  });
+
+  it("unconfigured is quiet, not an alarm", () => {
+    // Buzz is optional. A permanently-lit row for a feature nobody turned on is
+    // how a panel teaches its reader to ignore it.
+    const r = describe_({ configured: false, problem: null });
+    expect(r.status).toBe("off");
+    expect(r.detail).toBe("not configured");
+  });
+
+  it("HALF-configured is a failure, because somebody meant to enable it", () => {
+    const r = describe_({ configured: false, problem: "Buzz is partially configured — missing BUZZ_OPS_CHANNEL_ID" });
+    expect(r.status).toBe("failing");
+    expect(r.detail).toContain("BUZZ_OPS_CHANNEL_ID");
+  });
+
+  it("treats a failure at the same instant as a success as the failure", () => {
+    // Ties go to the bad news: reporting ok on an equal timestamp would hide a
+    // failure that landed in the same tick.
+    const r = describe_({ state: { lastOkAt: NOW - MIN, lastFailureAt: NOW - MIN, lastFailureReason: "timeout" } });
+    expect(r.status).toBe("failing");
+  });
+});
+
+describe("recordBuzzDelivery", () => {
+  it("keeps the last success and the last failure independently", () => {
+    let state = recordBuzzDelivery({}, { ok: true, atMs: NOW - 10 * MIN });
+    state = recordBuzzDelivery(state, { ok: false, reason: "timeout", detail: "no response", atMs: NOW });
+    expect(state.lastOkAt).toBe(NOW - 10 * MIN);
+    expect(state.lastFailureAt).toBe(NOW);
+    expect(state.lastFailureReason).toBe("timeout");
+  });
+
+  it("a success does not erase the failure history", () => {
+    // Which is what lets the row say "delivered 2m ago" while an operator can
+    // still see it was broken twenty minutes back.
+    const state = recordBuzzDelivery(
+      { lastFailureAt: NOW - 20 * MIN, lastFailureReason: "auth-rejected" },
+      { ok: true, atMs: NOW },
+    );
+    expect(state.lastOkAt).toBe(NOW);
+    expect(state.lastFailureAt).toBe(NOW - 20 * MIN);
+  });
+});


### PR DESCRIPTION
Closes the gap I've been flagging since narration shipped.

Narration and per-probe alerts both log WARN when a publish fails, and **logs are not a surface anybody watches**. So a Buzz channel that's silently broken looked *exactly* like one that's quiet because nothing is wrong — the failure this whole monitor exists to prevent, aimed at the monitor's own alerting.

## Instrument, not product

It goes in the **trust panel** beside `DATA AGE` and `MONITOR`, not into the probe list. An unreachable relay doesn't mean the money path is broken, and it must never move the operator verdict. What it must do is answer *"will I be told if something changes?"*

```
STREAM       live · last event 21:29:32
DATA AGE     2m ago — fresh
MONITOR      865942ef · current
OPS CHANNEL  delivered 4m ago          ← new
RPC          rpc-1 primary · failover armed
```

## ARMED is not OK

The state that matters most: **configured, credentials loaded, nothing ever sent.**

Showing that green would lie about whether you'll be *told* when something breaks — worse than lying about a probe. It's also exactly where this integration sat for most of its life: every piece passing against a scripted fake relay, none against the real one.

| state | meaning |
|---|---|
| `off` | not configured — quiet, **not** an alarm. Buzz is optional, and a permanently-lit row for a feature nobody enabled is how a panel teaches you to ignore it. |
| `armed` | configured, never delivered — untested, and says so |
| `ok` | `delivered 7m ago` |
| `failing` | latest attempt failed, **naming the reason** |

`failing` names the reason because an auth rejection and an unreachable relay send you to different places — "delivery failed" sends you to the wrong one. The last good delivery stays visible: broken-for-3-minutes and broken-for-a-day are different situations.

A **half-configured** setup is `failing`, not `off` — somebody meant to enable it and left it broken, which must not read as a choice.

**Ties go to the bad news**: a failure stamped at the same instant as a success reports `failing`, so a failure landing in the same tick can't be hidden.

## Two more deliberate choices

- **State is in memory.** After a restart the honest answer is "nothing delivered yet", not a stale success carried across a deploy.
- **An absent block reads "not reported by this build"** rather than inventing a status for a field the server never sent.

## Verification

- 10 new tests
- **2124 passed / 146 files**, typecheck clean on both workspaces
- verified by screenshot in the ops preview, not assertion alone