### PR TITLE
external_funnel's own prose greyed it out on the board

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -300,6 +300,10 @@ const PROBE_PILLAR: Record<string, OpsPillar> = {
   signer_liquidity: "solvency",
   treasury_liquidity: "solvency",
   money_path: "flow",
+  // The external door is a money-path concern: it watches a dispute window
+  // counting down toward a bond slash. Unregistered it defaulted to
+  // "availability", where it read as a health check rather than a money one.
+  external_funnel: "flow",
 };
 
 /** Which operational pillar a probe belongs to (unknown probes → availability). */

--- a/services/slack-operator/src/external-funnel.ts
+++ b/services/slack-operator/src/external-funnel.ts
@@ -49,6 +49,22 @@
 // projection and can lag the chain, so a row it still calls "rejected" may
 // already be disputed on-chain. The chain wins.
 
+// ── A WORD THIS DETAIL MAY NOT USE ─────────────────────────────────────────
+//
+// Probe details are not only prose: `isAwaitingProbe` in @avg/schemas matches
+// /awaiting|not expose|not wired|not configured|unconfigured|no data/ against
+// the detail to decide that a probe HAS NO DATA YET, and tones it grey in the
+// board's census.
+//
+// This probe first shipped saying "1 awaiting review" — describing submissions
+// waiting on a poster, not missing data. The board read the word, greyed a
+// perfectly healthy probe, and the operator verdict counted "8 ok / 1 awaiting
+// data" against a probe that was reporting fine. Hence "in review".
+//
+// Keep those words out of this detail. A probe that reports its subject in
+// language the verdict layer reserves for its own state will be misread, and it
+// fails silently — the JSON says ok while the screen says otherwise.
+
 import type { ProbeResult, ProbeStatus } from "./product-health.js";
 
 /** A row of the public catalog projection (`GET /jobs?source=external`). */
@@ -263,7 +279,7 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
   const detailParts = [
     `${buckets.open_claimable.count} claimable`,
     `${buckets.claimed_active.count} claimed`,
-    `${buckets.submitted_awaiting_review.count} awaiting review`,
+    `${buckets.submitted_awaiting_review.count} in review`,
     `${buckets.rejected_window_running.count} in dispute window`,
   ];
   if (buckets.other.count > 0) detailParts.push(`${buckets.other.count} other`);

--- a/test/unit/external-funnel.test.ts
+++ b/test/unit/external-funnel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { isAwaitingProbe } from "@avg/schemas/ops-verdict";
 
 import {
   CHAIN_STATE_REJECTED,
@@ -264,5 +265,46 @@ describe("disputeWindowFrom", () => {
     expect(disputeWindowFrom({ workerFacts: {} })).toBeNull();
     expect(disputeWindowFrom({ workerFacts: { disputeWindow: { seconds: "604800" } } })).toBeNull();
     expect(disputeWindowFrom({ workerFacts: { disputeWindow: { seconds: 0 } } })).toBeNull();
+  });
+});
+
+describe("the detail must not trip the board's awaiting detector", () => {
+  // REGRESSION. isAwaitingProbe matches /awaiting|not expose|not wired|not
+  // configured|unconfigured|no data/ on the DETAIL to decide a probe has no
+  // data yet. This probe shipped saying "1 awaiting review" — about submissions
+  // waiting on a poster — and the board greyed a healthy probe and counted
+  // "1 awaiting data" in the operator verdict. The JSON said ok the whole time,
+  // so it looked like a UI bug.
+  const details = (rows: ExternalJobRow[], over = {}) => decide({ rows, ...over }).probe;
+
+  it("an ok funnel is never read as awaiting data", () => {
+    const probe = details([
+      { id: REAL_ID, state: "open", effectiveState: "claimable" },
+      { id: id("5ab"), state: "submitted", claimedAt: iso(NOW - HOUR) },
+      { id: id("a436"), state: "exhausted" },
+    ]);
+    expect(probe.status).toBe("ok");
+    expect(isAwaitingProbe(probe)).toBe(false);
+  });
+
+  it("holds for every branch that can report ok or degraded", () => {
+    const cases = [
+      details([]),
+      details([{ id: id("j"), state: "rejected" }], { rejections: new Map() }),
+      details([{ id: id("c"), state: "claimed", claimExpiresAt: iso(NOW + 60_000) }]),
+      details([{ id: id("5ab"), state: "submitted", claimedAt: iso(NOW - REVIEW_STALE_WARN_MS - HOUR) }]),
+    ];
+    for (const probe of cases) {
+      expect({ detail: probe.detail, awaiting: isAwaitingProbe(probe) }).toEqual({
+        detail: probe.detail,
+        awaiting: false,
+      });
+    }
+  });
+
+  it("the catalog-unreadable branch is the ONE case that may read as awaiting", () => {
+    // Here it is correct: the probe genuinely has no data.
+    const probe = decide({ rows: null, fetchError: "HTTP 503" }).probe;
+    expect(probe.status).toBe("degraded");
   });
 });


### PR DESCRIPTION
Caught by **looking at the live page**, not by a test. Every test was green while the board was wrong.

The probe reported `ok` in JSON and rendered **grey** on screen, and the operator verdict counted `8 ok / 1 awaiting data` against a probe that was reporting fine.

## Two independent causes

**1. The detail tripped a semantic detector.**

```js
const AWAITING_RE = /awaiting|not expose|not wired|not configured|unconfigured|no data/i;
```

`isAwaitingProbe` runs that against a probe's **detail** to decide it has no data yet. This probe said `1 awaiting review` — about submissions waiting on a *poster*, not about missing data — and the board believed it. Now `1 in review`.

A probe detail isn't only prose; **it's machine input**. Same lesson the alert dedupe key taught, arriving from the other direction: there a detail was used as an *identity* and drifted; here a detail was *read for meaning* and collided.

**2. No pillar registration.** `PROBE_PILLAR` had no entry, so it defaulted to `availability` — a money-path probe watching a bond-slash countdown filed under health checks. Now `flow`.

## The regression test

Asserts `isAwaitingProbe` is false across **every branch** that can report ok or degraded, so reintroducing a reserved word fails loudly instead of silently greying the row.

The catalog-unreadable branch is deliberately exempt — there the probe genuinely has no data, and reading as awaiting is correct.

## Named, not fixed here

**The regex is loose.** A bare "awaiting" anywhere in any detail mis-tones the probe. Phrases actually in use: `awaiting data`, `awaiting samples`, `awaiting history`, `awaiting settlement` — and that last one may be this same bug already shipped.

Tightening a detector every probe depends on needs its own pass across every consumer, not a drive-by inside a wording fix.

## Verification

- 3 new regression tests; **2127 passed / 146 files**
- typecheck clean on both workspaces