### PR TITLE
SS58 beside every address, and the phone gets what it can act on

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.test.tsx
@@ -247,3 +247,78 @@ describe("phone board — degraded transports", () => {
     expect(getByTestId("mobile-verdict").textContent).toContain("NOT WATCHING");
   });
 });
+
+describe("phone board — what you can act on, and what you would not be told", () => {
+  // A breached pool that IS a wallet, with both encodings the way the backend
+  // emits them.
+  const breachedSigner: SolvencyPool = {
+    key: "signer_gas",
+    label: "Signer gas",
+    amount: 0.42,
+    unit: "DOT",
+    floor: 1,
+    status: "red",
+    address: "0x5a6836c6D4d293F6E5377E6c28054F4171915813",
+    addressSs58: "133YGXLeo4Rf2aWc7JXUbq7rmDnTrFp7tLj7Q9xdCt4bcYcg",
+  };
+  const withBreach = (pool: SolvencyPool): ProductHealth => ({
+    ...OPS_FIXTURE_STRESS,
+    solvency: { pools: [pool] },
+  });
+
+  test("a dry signer shows where to send funds, in BOTH encodings", () => {
+    // An alert that says the signer is empty and makes you go find the address
+    // somewhere else has stopped short of the point.
+    const { getByTestId } = render(<MobileBoard health={withBreach(breachedSigner)} nowMs={STRESS_NOW} />);
+    const topUp = getByTestId("mobile-breach-topup");
+    expect(topUp.textContent).toContain("0x5a6836c6D4d293F6E5377E6c28054F4171915813");
+    expect(topUp.textContent).toContain("133YGXLeo4Rf2aWc7JXUbq7rmDnTrFp7tLj7Q9xdCt4bcYcg");
+  });
+
+  test("a breached pool that is NOT a wallet offers no address", () => {
+    // Reward bank is an in-contract position; a contract address beside it
+    // would invite sending DOT somewhere with no way back, at the worst moment,
+    // on the smallest screen.
+    const { queryByTestId } = render(
+      <MobileBoard
+        health={withBreach({ key: "reward_bank", label: "Reward bank", amount: 0.5, unit: "USDC", floor: 2, status: "red" })}
+        nowMs={STRESS_NOW}
+      />,
+    );
+    expect(queryByTestId("mobile-breach-topup")).toBeNull();
+  });
+
+  test("a failing #ops channel is stated — you would not have been told", () => {
+    // The fact that changes what the operator does next: the next alert will
+    // not arrive. It belongs on the phone more than anywhere else.
+    const { container } = render(
+      <MobileBoard
+        health={{ ...OPS_FIXTURE_NOMINAL, buzz: { status: "failing", detail: "FAILING 2m ago — auth-rejected" } }}
+        nowMs={fresh(OPS_FIXTURE_NOMINAL)}
+      />,
+    );
+    expect(container.textContent).toContain("#ops NOT DELIVERING");
+  });
+
+  test("an untested channel says so rather than staying silent", () => {
+    const { container } = render(
+      <MobileBoard
+        health={{ ...OPS_FIXTURE_NOMINAL, buzz: { status: "armed", detail: "armed · nothing delivered yet" } }}
+        nowMs={fresh(OPS_FIXTURE_NOMINAL)}
+      />,
+    );
+    expect(container.textContent).toContain("#ops untested");
+  });
+
+  test("a HEALTHY channel does not spend the phone's trust line saying so", () => {
+    // Space on this screen is the scarcest thing it has.
+    const { container } = render(
+      <MobileBoard
+        health={{ ...OPS_FIXTURE_NOMINAL, buzz: { status: "ok", detail: "delivered 4m ago" } }}
+        nowMs={fresh(OPS_FIXTURE_NOMINAL)}
+      />,
+    );
+    expect(container.textContent).not.toContain("#ops");
+  });
+});
+

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -179,6 +179,28 @@ function BreachPanel({ breach }: { breach: BreachCard }) {
           <dd data-tone={breach.stillTrueTone}>{breach.stillTrue}</dd>
           <dt>IF IT EMPTIES</dt>
           <dd>{breach.consequence}</dd>
+          {/* The only ACTIONABLE thing on this screen. An alert that tells you
+              the signer is dry and makes you go find the address elsewhere has
+              stopped short of the point. Both encodings, because the wallet on
+              this phone may speak either — and converting one by hand is where
+              a wrong character costs real money.
+
+              Only ever present for a pool that IS a wallet; see TOP_UP_POOLS. */}
+          {breach.topUp ? (
+            <>
+              <dt>TOP UP</dt>
+              <dd className="hm-ph-topup" data-testid="mobile-breach-topup">
+                <span className="hm-ph-addr">{breach.topUp.evm}</span>
+                <span className="hm-ph-addr-tag">EVM</span>
+                {breach.topUp.ss58 ? (
+                  <>
+                    <span className="hm-ph-addr">{breach.topUp.ss58}</span>
+                    <span className="hm-ph-addr-tag">SS58 · same account</span>
+                  </>
+                ) : null}
+              </dd>
+            </>
+          ) : null}
         </dl>
       </div>
     </section>

--- a/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
@@ -69,13 +69,25 @@ export function SolvencyPanel({ solvency }: SolvencyPanelProps) {
  * provenance the number does not have.
  */
 function PoolAddress({ view }: { view: PoolView }) {
-  const { address, addressLabel } = view.pool;
+  const { address, addressLabel, addressSs58 } = view.pool;
   if (!address) return null;
   return (
-    <span className="ops-pool-addr" data-testid={`ops-pool-addr-${view.pool.key}`}>
-      <span className="ops-pool-addr-hex">{address}</span>
-      {addressLabel ? <span className="ops-pool-addr-label">{addressLabel}</span> : null}
-    </span>
+    <>
+      <span className="ops-pool-addr" data-testid={`ops-pool-addr-${view.pool.key}`}>
+        <span className="ops-pool-addr-hex">{address}</span>
+        {addressLabel ? <span className="ops-pool-addr-label">{addressLabel}</span> : null}
+      </span>
+      {/* The SAME account, in the form a Substrate wallet accepts. Both are
+          shown because the board cannot know which wallet the operator will
+          reach for, and converting an address by hand is exactly where a wrong
+          character costs real money. */}
+      {addressSs58 ? (
+        <span className="ops-pool-addr ops-pool-addr--ss58" data-testid={`ops-pool-ss58-${view.pool.key}`}>
+          <span className="ops-pool-addr-hex">{addressSs58}</span>
+          <span className="ops-pool-addr-label">SS58 · same account</span>
+        </span>
+      ) : null}
+    </>
   );
 }
 

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -235,6 +235,7 @@ const MAINNET_POOLS: SolvencyPool[] = [
     floor: 1,
     status: "ok",
     address: "0xB1350932bf85E7ffd0599E9a3CC7b55718D89E57",
+    addressSs58: "151MENb3J9ZiBv147yhNkPDiY8rXF7TrWc13PqWYJeLuupBd",
     addressLabel: "AgentAccountCore",
   },
   // Deliberately unfunded, and it must never render as a full meter. The note is
@@ -247,6 +248,7 @@ const MAINNET_POOLS: SolvencyPool[] = [
     status: "ok",
     note: "no floor — intentionally unfunded: payouts fund from the signer reward bank; the treasury multisig holds no USDC float",
     address: "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
+    addressSs58: "13VefHVLFhdvis2hA75gVSrAR6psiRqaqBzFPdwxW6GG6aJ",
     addressLabel: "treasury reserve",
   },
   {
@@ -258,6 +260,7 @@ const MAINNET_POOLS: SolvencyPool[] = [
     informational: true,
     note: "informational — funds currently between claim and settlement",
     address: "0x590EbE304E0C7672e2abF3161177D2B94a2aC3fC",
+    addressSs58: "131meCLjePjUWf9dRC7RuhNcsGx9nHa1wasKVfy6u3M7mZBL",
     addressLabel: "EscrowCore",
   },
   {
@@ -268,6 +271,7 @@ const MAINNET_POOLS: SolvencyPool[] = [
     status: "ok",
     note: "5% poster-side fee · held under the 2-of-3 treasury multisig",
       address: "0x01e6eed856e989201f4ff6346e18eab7e46c874c",
+    addressSs58: "13VefHVLFhdvis2hA75gVSrAR6psiRqaqBzFPdwxW6GG6aJ",
     addressLabel: "treasury multisig",
 },
 ];

--- a/packages/monitor-ui/src/lib/monitor/phone-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/phone-spec.ts
@@ -159,6 +159,15 @@ export function phoneTrust(input: {
           : "build unknown",
   );
 
+  // Whether the alert channel works belongs on the PHONE more than anywhere
+  // else: this screen is what an operator reaches for after a notification, so
+  // "you would not have been told" is the one fact that changes what they do
+  // next. Only said when it is not fine — a healthy channel does not need to
+  // spend a phone's trust line saying so.
+  const buzz = health.buzz;
+  if (buzz && buzz.status === "failing") parts.push("#ops NOT DELIVERING");
+  else if (buzz && buzz.status === "armed") parts.push("#ops untested");
+
   const rem = health.remediation;
   if (rem?.enabled && rem.state !== "off") {
     // The host, not the URL — in prod this is a full endpoint and it took the
@@ -170,9 +179,14 @@ export function phoneTrust(input: {
     ? "red"
     : isUntrusted({ health, streamDegraded, nowMs })
       ? "red"
-      : self && self.status === "behind"
+      // A channel that cannot deliver means the next alert will not arrive.
+      // Degraded, not red: the product is fine and colouring it red would be
+      // the false alarm this board is careful never to raise.
+      : health.buzz?.status === "failing"
         ? "degraded"
-        : "ok";
+        : self && self.status === "behind"
+          ? "degraded"
+          : "ok";
 
   return { line: parts.join(" · "), tone };
 }
@@ -194,7 +208,21 @@ export interface BreachCard {
   stillTrueTone: OpsTone;
   /** What happens if it empties. */
   consequence: string;
+  /** Where to send funds, when the breached pool is one you can top up.
+   *  Absent for pools that are not wallets — see topUpAddress. */
+  topUp?: { evm: string; ss58?: string };
 }
+
+/**
+ * Which breached pools an operator can actually FUND from their phone.
+ *
+ * Only signer gas. The reward bank is an in-contract position with no address
+ * of its own, and the rest are contracts — DOT sent to EscrowCore lands
+ * somewhere with no way back. Showing an address beside a pool you cannot top
+ * up would invite exactly that mistake, at the worst moment, on the smallest
+ * screen.
+ */
+const TOP_UP_POOLS = new Set(["signer_gas"]);
 
 const POOL_CONSEQUENCE: Record<string, string> = {
   reward_bank: "payouts halt — the reward bank funds every payout",
@@ -240,6 +268,14 @@ export function breachCard(input: {
       : `yes — confirmed ${health.at == null ? "—" : formatAgo(health.at, nowMs)}`,
     stillTrueTone: untrusted ? "degraded" : "ok",
     consequence: POOL_CONSEQUENCE[breached.key] ?? "this pool is below the level the system needs",
+    ...(TOP_UP_POOLS.has(breached.key) && breached.address
+      ? {
+          topUp: {
+            evm: breached.address,
+            ...(breached.addressSs58 ? { ss58: breached.addressSs58 } : {}),
+          },
+        }
+      : {}),
   };
 }
 

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -300,6 +300,10 @@ const PROBE_PILLAR: Record<string, OpsPillar> = {
   signer_liquidity: "solvency",
   treasury_liquidity: "solvency",
   money_path: "flow",
+  // The external door is a money-path concern: it watches a dispute window
+  // counting down toward a bond slash. Unregistered it defaulted to
+  // "availability", where it read as a health check rather than a money one.
+  external_funnel: "flow",
 };
 
 /** Which operational pillar a probe belongs to (unknown probes → availability). */

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -42,6 +42,8 @@ export interface SolvencyPool {
   address?: string;
   /** What the address is, so the hex is legible without a block explorer. */
   addressLabel?: string;
+  /** The same account in SS58, for Substrate wallets (Nova, Talisman, …). */
+  addressSs58?: string;
 }
 
 /** Can the #Ops channel receive anything? Instrument health, not product health. */

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -207,6 +207,30 @@
   font-size: 11px;
   line-height: 1.5;
 }
+/* Top-up addresses on the breach card. Full, wrapping, selectable — on a phone
+   the operator is going to long-press this and paste it into a wallet, so it
+   must be complete and it must be grabbable. Truncation would make the row
+   decorative, which is worse than omitting it. */
+.hm-ph-topup {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.hm-ph-addr {
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  user-select: all;
+  color: var(--h4-ink-2);
+}
+.hm-ph-addr-tag {
+  font-family: var(--h4-font-mono);
+  font-size: 9px;
+  color: var(--h4-muted);
+  margin-bottom: 4px;
+}
+
 .hm-ph-facts dt {
   letter-spacing: 0.1em;
   color: var(--h4-muted);

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -414,6 +414,11 @@ body,
   content: " · ";
   opacity: 0.6;
 }
+.ops-pool-addr--ss58 {
+  /* Sits directly under its EVM twin with no gap, so the pair reads as one
+     block belonging to the balance above rather than two separate facts. */
+  margin-top: -3px;
+}
 .ops-pool--unfloored .ops-pool-addr {
   /* This row has smaller padding than a floored one, so it needs less pull-up. */
   margin-top: -6px;

--- a/services/slack-operator/src/external-funnel.ts
+++ b/services/slack-operator/src/external-funnel.ts
@@ -49,6 +49,22 @@
 // projection and can lag the chain, so a row it still calls "rejected" may
 // already be disputed on-chain. The chain wins.
 
+// ── A WORD THIS DETAIL MAY NOT USE ─────────────────────────────────────────
+//
+// Probe details are not only prose: `isAwaitingProbe` in @avg/schemas matches
+// /awaiting|not expose|not wired|not configured|unconfigured|no data/ against
+// the detail to decide that a probe HAS NO DATA YET, and tones it grey in the
+// board's census.
+//
+// This probe first shipped saying "1 awaiting review" — describing submissions
+// waiting on a poster, not missing data. The board read the word, greyed a
+// perfectly healthy probe, and the operator verdict counted "8 ok / 1 awaiting
+// data" against a probe that was reporting fine. Hence "in review".
+//
+// Keep those words out of this detail. A probe that reports its subject in
+// language the verdict layer reserves for its own state will be misread, and it
+// fails silently — the JSON says ok while the screen says otherwise.
+
 import type { ProbeResult, ProbeStatus } from "./product-health.js";
 
 /** A row of the public catalog projection (`GET /jobs?source=external`). */
@@ -263,7 +279,7 @@ export function decideExternalFunnel(input: DecideExternalFunnelInput): External
   const detailParts = [
     `${buckets.open_claimable.count} claimable`,
     `${buckets.claimed_active.count} claimed`,
-    `${buckets.submitted_awaiting_review.count} awaiting review`,
+    `${buckets.submitted_awaiting_review.count} in review`,
     `${buckets.rejected_window_running.count} in dispute window`,
   ];
   if (buckets.other.count > 0) detailParts.push(`${buckets.other.count} other`);

--- a/services/slack-operator/src/hub-address.ts
+++ b/services/slack-operator/src/hub-address.ts
@@ -1,0 +1,78 @@
+// Polkadot Hub accounts have two encodings of the same account, and an operator
+// needs whichever one their wallet speaks.
+//
+// The board reads balances over eth-rpc, so every address it shows is an H160
+// (`0x…`). But DOT arrives from Substrate wallets — Nova, Talisman, Polkadot.js
+// — and those want SS58. Without it, "the signer needs gas" is a fact you cannot
+// act on without leaving the board to convert an address by hand, which is
+// exactly the moment a wrong character costs real money.
+//
+// ── THE MAPPING, AND WHY IT IS SAFE TO DERIVE ──────────────────────────────
+//
+// `pallet_revive` extends a 20-byte H160 to an AccountId32 by appending twelve
+// 0xEE bytes; that suffix marks an Ethereum-controlled account and makes the
+// conversion reversible. Deterministic, documented, no lookup required.
+//
+// The one case where derivation would LIE is an explicitly mapped account — a
+// Substrate account that registered its own H160 via `map_account`, where the
+// 0xEE padding is not the real mapping. That applies to externally-owned
+// accounts, not to contract addresses, which get their H160 from CREATE.
+//
+// So the EOA is the one that had to be checked, and it was — against the chain,
+// not against the documentation:
+//
+//   eth_getTransactionCount(0x5a6836c6…)                     → 222
+//   state_call AccountNonceApi_account_nonce(AccountId32)    → 222
+//
+// Two RPCs, two encodings, same nonce. That pair is the test vector below, so
+// the derivation is pinned to something a real chain confirmed rather than to
+// this comment.
+
+import { blake2b } from "@noble/hashes/blake2b";
+import { base58 } from "@scure/base";
+
+const SS58_PREFIX = new TextEncoder().encode("SS58PRE");
+
+/** Polkadot (and Polkadot Hub) address format. */
+export const POLKADOT_SS58_FORMAT = 0;
+
+/** The twelve bytes pallet_revive appends. Their presence marks an eth account. */
+const ETH_SUFFIX_BYTE = 0xee;
+const ETH_SUFFIX_LEN = 12;
+
+/** H160 → AccountId32, the pallet_revive way. */
+export function h160ToAccountId32(addressHex: string): Uint8Array | undefined {
+  const hex = addressHex.trim().replace(/^0x/, "").toLowerCase();
+  if (hex.length !== 40 || !/^[0-9a-f]+$/.test(hex)) return undefined;
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 20; i += 1) out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  out.fill(ETH_SUFFIX_BYTE, 20, 20 + ETH_SUFFIX_LEN);
+  return out;
+}
+
+/**
+ * Encode an AccountId32 as SS58.
+ *
+ * The checksum is the first two bytes of blake2b-512 over "SS58PRE" + format +
+ * pubkey — that prefix is what stops an address from one chain validating on
+ * another, so it is not optional decoration.
+ */
+export function encodeSs58(publicKey: Uint8Array, format = POLKADOT_SS58_FORMAT): string {
+  const body = new Uint8Array(1 + publicKey.length);
+  body[0] = format;
+  body.set(publicKey, 1);
+  const checksum = blake2b(new Uint8Array([...SS58_PREFIX, ...body]), { dkLen: 64 }).slice(0, 2);
+  return base58.encode(new Uint8Array([...body, ...checksum]));
+}
+
+/**
+ * The SS58 form of an EVM address on Polkadot Hub.
+ *
+ * Returns undefined for anything that is not a well-formed H160 — a malformed
+ * input must produce NO address rather than a plausible one, because the only
+ * use for the result is pasting it into a wallet.
+ */
+export function h160ToSs58(addressHex: string, format = POLKADOT_SS58_FORMAT): string | undefined {
+  const account = h160ToAccountId32(addressHex);
+  return account ? encodeSs58(account, format) : undefined;
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -31,6 +31,7 @@ import type { AlertPayload } from "./alert-bridge.js";
 
 import { decideDiskHeadroom, readDiskUsage } from "./disk-headroom.js";
 import { probeExternalFunnel } from "./external-funnel.js";
+import { h160ToSs58 } from "./hub-address.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
@@ -1785,6 +1786,9 @@ export interface SolvencyPoolData {
   address?: string;
   /** What that address IS, so the hex is legible without a block explorer. */
   addressLabel?: string;
+  /** The SAME account in SS58, for Substrate wallets. Derived, not read — see
+   *  hub-address.ts for why that derivation is safe and how it was verified. */
+  addressSs58?: string;
 }
 export interface SolvencySnapshotData {
   pools: SolvencyPoolData[];
@@ -2004,6 +2008,14 @@ export async function collectProductHealthProbes(
               config.minRewardBank > 0 && rewardBankLiquid < config.minRewardBank ? "red" : "ok",
           },
         ];
+  // Every address gets its SS58 twin here rather than at each construction
+  // site: one derivation, no chance of a pool shipping an EVM address without
+  // the form a Substrate wallet can actually accept.
+  const withSs58 = (pool: SolvencyPoolData): SolvencyPoolData => {
+    if (!pool.address) return pool;
+    const ss58 = h160ToSs58(pool.address);
+    return ss58 ? { ...pool, addressSs58: ss58 } : pool;
+  };
   const solvencyPools = [
     ...new Map(
       [...(signer.pools ?? []), ...(treasury.pools ?? []), ...rewardBankPool].map((pool) => [
@@ -2011,7 +2023,7 @@ export async function collectProductHealthProbes(
         pool,
       ]),
     ).values(),
-  ];
+  ].map(withSs58);
   const settlement = h.body?.settlement;
   // Independent proof that the settled jobs actually PAID. Opt-in: the log read
   // is rate-limit sensitive, so while it's off the block stays honestly

--- a/test/unit/external-funnel.test.ts
+++ b/test/unit/external-funnel.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { isAwaitingProbe } from "@avg/schemas/ops-verdict";
 
 import {
   CHAIN_STATE_REJECTED,
@@ -264,5 +265,46 @@ describe("disputeWindowFrom", () => {
     expect(disputeWindowFrom({ workerFacts: {} })).toBeNull();
     expect(disputeWindowFrom({ workerFacts: { disputeWindow: { seconds: "604800" } } })).toBeNull();
     expect(disputeWindowFrom({ workerFacts: { disputeWindow: { seconds: 0 } } })).toBeNull();
+  });
+});
+
+describe("the detail must not trip the board's awaiting detector", () => {
+  // REGRESSION. isAwaitingProbe matches /awaiting|not expose|not wired|not
+  // configured|unconfigured|no data/ on the DETAIL to decide a probe has no
+  // data yet. This probe shipped saying "1 awaiting review" — about submissions
+  // waiting on a poster — and the board greyed a healthy probe and counted
+  // "1 awaiting data" in the operator verdict. The JSON said ok the whole time,
+  // so it looked like a UI bug.
+  const details = (rows: ExternalJobRow[], over = {}) => decide({ rows, ...over }).probe;
+
+  it("an ok funnel is never read as awaiting data", () => {
+    const probe = details([
+      { id: REAL_ID, state: "open", effectiveState: "claimable" },
+      { id: id("5ab"), state: "submitted", claimedAt: iso(NOW - HOUR) },
+      { id: id("a436"), state: "exhausted" },
+    ]);
+    expect(probe.status).toBe("ok");
+    expect(isAwaitingProbe(probe)).toBe(false);
+  });
+
+  it("holds for every branch that can report ok or degraded", () => {
+    const cases = [
+      details([]),
+      details([{ id: id("j"), state: "rejected" }], { rejections: new Map() }),
+      details([{ id: id("c"), state: "claimed", claimExpiresAt: iso(NOW + 60_000) }]),
+      details([{ id: id("5ab"), state: "submitted", claimedAt: iso(NOW - REVIEW_STALE_WARN_MS - HOUR) }]),
+    ];
+    for (const probe of cases) {
+      expect({ detail: probe.detail, awaiting: isAwaitingProbe(probe) }).toEqual({
+        detail: probe.detail,
+        awaiting: false,
+      });
+    }
+  });
+
+  it("the catalog-unreadable branch is the ONE case that may read as awaiting", () => {
+    // Here it is correct: the probe genuinely has no data.
+    const probe = decide({ rows: null, fetchError: "HTTP 503" }).probe;
+    expect(probe.status).toBe("degraded");
   });
 });

--- a/test/unit/hub-address.test.ts
+++ b/test/unit/hub-address.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  h160ToAccountId32,
+  h160ToSs58,
+} from "../../services/slack-operator/src/hub-address.js";
+
+// CHAIN-VERIFIED VECTOR. This is the live mainnet gas signer, and the pair was
+// confirmed against the chain rather than against documentation:
+//
+//   eth_getTransactionCount(0x5a6836c6…)                  → 222
+//   state_call AccountNonceApi_account_nonce(AccountId32)  → 222
+//
+// Two RPCs, two encodings, one nonce. If this expectation ever fails, the
+// derivation changed — not the test.
+const SIGNER_H160 = "0x5a6836c6D4d293F6E5377E6c28054F4171915813";
+const SIGNER_ACCOUNT = "5a6836c6d4d293f6e5377e6c28054f4171915813eeeeeeeeeeeeeeeeeeeeeeee";
+const SIGNER_SS58 = "133YGXLeo4Rf2aWc7JXUbq7rmDnTrFp7tLj7Q9xdCt4bcYcg";
+
+const hex = (b: Uint8Array) => Buffer.from(b).toString("hex");
+
+describe("h160ToAccountId32", () => {
+  it("appends exactly twelve 0xEE bytes", () => {
+    expect(hex(h160ToAccountId32(SIGNER_H160)!)).toBe(SIGNER_ACCOUNT);
+    expect(h160ToAccountId32(SIGNER_H160)!.length).toBe(32);
+  });
+
+  it("accepts mixed case and a missing 0x, since both get pasted", () => {
+    expect(hex(h160ToAccountId32(SIGNER_H160.toUpperCase().replace("0X", "0x"))!)).toBe(SIGNER_ACCOUNT);
+    expect(hex(h160ToAccountId32(SIGNER_H160.slice(2))!)).toBe(SIGNER_ACCOUNT);
+  });
+
+  it("returns nothing for anything that is not a well-formed H160", () => {
+    // A malformed input must produce NO address, never a plausible one — the
+    // only use for the result is pasting it into a wallet.
+    for (const bad of ["", "0x", "0xnothex000000000000000000000000000000000000", SIGNER_H160 + "00", "0x1234"]) {
+      expect(h160ToAccountId32(bad)).toBeUndefined();
+    }
+  });
+});
+
+describe("h160ToSs58", () => {
+  it("produces the address the chain confirmed for the live signer", () => {
+    expect(h160ToSs58(SIGNER_H160)).toBe(SIGNER_SS58);
+  });
+
+  it("is stable across input spellings", () => {
+    expect(h160ToSs58(SIGNER_H160.toLowerCase())).toBe(SIGNER_SS58);
+    expect(h160ToSs58(` ${SIGNER_H160} `)).toBe(SIGNER_SS58);
+  });
+
+  it("changes completely when one character of the address changes", () => {
+    // The checksum is why a typo is caught by the wallet rather than by the
+    // recipient discovering the funds never arrived.
+    const off = `0x5a6836c6D4d293F6E5377E6c28054F4171915814`;
+    expect(h160ToSs58(off)).not.toBe(SIGNER_SS58);
+  });
+
+  it("returns undefined rather than a partial address for bad input", () => {
+    expect(h160ToSs58("not-an-address")).toBeUndefined();
+  });
+
+  it("a different SS58 format yields a different address for the same account", () => {
+    // Guards the prefix actually entering the checksum: without it an address
+    // from one chain would validate on another.
+    expect(h160ToSs58(SIGNER_H160, 2)).not.toBe(SIGNER_SS58);
+  });
+});


### PR DESCRIPTION
Stacked on #648 (which fixes the greyed probe); merge that first.

The board reads balances over eth-rpc, so every address on it was an H160. But DOT arrives from **Substrate wallets**, which want SS58 — so "the signer needs gas" was a fact you couldn't act on without leaving the board to convert an address by hand. That's exactly where a wrong character costs real money.

## The derivation is safe, and it was checked

`pallet_revive` appends twelve `0xEE` bytes to an H160 to make an AccountId32 — deterministic, documented, reversible.

The one case it would **lie** about is an *explicitly mapped* account, where a Substrate account claimed an H160 via `map_account`. That applies to EOAs, not to contract addresses, which get their H160 from `CREATE`.

So the EOA is the one that needed checking, and it was checked **against the chain**, not the docs:

```
eth_getTransactionCount(0x5a6836c6…)                   → 222
state_call AccountNonceApi_account_nonce(AccountId32)  → 222
```

Two RPCs, two encodings, one nonce. **That pair is the test vector**, so the derivation is pinned to something a real chain confirmed rather than to a comment that could rot.

Derived in one place as pools are assembled, so no construction site can ship an EVM address without the form a wallet accepts.

## The phone is not a copy of the desktop

That screen collapses three unfloored pools onto a single grey line. Pasting 42- and 48-character addresses onto every row would destroy the density it was designed around. It gets the two things that change what an operator **does**:

**TOP UP — breach card only, wallets only.** An alert that says the signer is dry and then makes you go find the address somewhere else has stopped short of the point. Both encodings, because the wallet on that phone may speak either.

Guarded by an explicit allowlist. The reward bank is an in-contract position with no address of its own; the rest are contracts. **DOT sent to EscrowCore lands somewhere with no way back**, and offering an address beside a pool you can't top up invites exactly that — at the worst moment, on the smallest screen. A test pins the absence.

**`#ops` delivery — but only when it is NOT fine.** *"You would not have been told"* is the single fact that changes what you do next, and it matters more on the phone than anywhere: this is the screen you reach for after a notification.

A healthy channel stays silent rather than spending the scarcest line on the board. Failing tones the line **degraded, not red** — the product is fine, and red would be the false alarm this board is careful never to raise.

## Verification

- 13 new tests (8 derivation incl. the chain-verified vector, 5 mobile)
- **2140 passed / 147 files**, typecheck clean
- desktop verified by screenshot in the preview