### PR TITLE
A restart re-announced alarms that had not changed

### DIFF
--- a/services/slack-operator/src/probe-transitions.ts
+++ b/services/slack-operator/src/probe-transitions.ts
@@ -108,8 +108,19 @@ export function decideProbeTransitions(input: DecideProbeTransitionsInput): Prob
     next.set(probe.name, probe);
     const before = input.previous.get(probe.name);
 
-    // First sight — record it, say nothing.
-    if (!before) continue;
+    // First sight — say nothing, but REMEMBER what it was.
+    //
+    // Silence here is right: a probe already broken when the process started is
+    // not news, and alerting would page on every redeploy. But the key has to be
+    // retained anyway. Without it the posted set comes back empty, and on the
+    // NEXT tick the same unchanged alarm looks brand new and posts.
+    //
+    // Production found this, not the tests: three deploys in one night produced
+    // three duplicate money_path alerts, each one tick after a restart.
+    if (!before) {
+      if (isAlarm(probe.status)) keys.add(reasonClass(probe));
+      continue;
+    }
     if (before.status === probe.status && !isAlarm(probe.status)) continue;
 
     const enteringAlarm = isAlarm(probe.status) && before.status !== probe.status;

--- a/test/unit/probe-transitions.test.ts
+++ b/test/unit/probe-transitions.test.ts
@@ -164,4 +164,38 @@ describe("decideProbeTransitions", () => {
     });
     expect(r.alerts.map((x) => `${x.probe}:${x.kind}`).sort()).toEqual(["a:opened", "b:recovered"]);
   });
+
+  it("a restart does not re-announce an alarm that never changed", () => {
+    // THE REGRESSION. Tick 1 after a restart sees the probe for the first time
+    // and is correctly silent — but it must also REMEMBER, or tick 2 finds an
+    // empty posted set and treats the same unchanged alarm as fresh news.
+    // Production posted three duplicate money_path alerts this way, one per
+    // deploy, before this was caught.
+    const broken = p("money_path", "degraded", "stuck 1, settled24h 12");
+
+    // tick 1 — cold start, probe already degraded
+    const first = decide({ previous: new Map(), current: [broken] });
+    expect(first.alerts).toEqual([]);
+    expect(first.keys.has(reasonClass(broken))).toBe(true);
+
+    // tick 2 — nothing changed; the retained key must suppress it
+    const second = decide({ previous: first.next, current: [broken], posted: first.keys });
+    expect(second.alerts).toEqual([]);
+  });
+
+  it("a restart still lets a LATER genuine change through", () => {
+    // The fix must not over-suppress: a cold start followed by a real
+    // escalation is news, and staying quiet would be the opposite failure.
+    const degraded = p("money_path", "degraded", "stuck 1");
+    const first = decide({ previous: new Map(), current: [degraded] });
+    const worse = p("money_path", "red", "stuck 9, settlement stalled");
+    const second = decide({ previous: first.next, current: [worse], posted: first.keys });
+    expect(second.alerts).toHaveLength(1);
+    expect(second.alerts[0]?.to).toBe("red");
+  });
+
+  it("a probe that is HEALTHY at first sight retains nothing", () => {
+    const first = decide({ previous: new Map(), current: [p("x", "ok", "fine")] });
+    expect([...first.keys]).toEqual([]);
+  });
 });


### PR DESCRIPTION
Found **in production**, in the `#Ops` channel, by reading the messages that actually landed. Not by a test.

```
12:31  ⚠ money_path: settled24h 12 … submittedNotSettled 1 …
12:31  ⚠ money_path: settled24h 12 … submittedNotSettled 1 …   ← duplicate
12:57  ⚠ money_path: stuck 1, failed24h 0, settled24h 12 …
01:23  ⚠ money_path: stuck 1, failed24h 0, settled24h 13 …     ← same reason class
```

The last two differ only in `12` → `13`, which `reasonClass` blanks — so they share a class and the second should have been suppressed.

## One line

```js
if (!before) continue;   // never reached keys.add()
```

First sight is correctly **silent** about a probe already in alarm; alerting there would page on every redeploy. But the key was never retained, so the **next** tick found an empty posted set and read the same unchanged alarm as brand new.

**Every deploy last night bought one duplicate.**

## The real bug is the test gap

The tests covered *"restart → silent"*. They never covered *"restart → silent → tick again"* — the only sequence that exposes it. The missing line is just where it surfaced.

Three tests now:

- the restart sequence itself (tick 1 silent **and** retaining, tick 2 still silent)
- a genuine escalation after a restart still gets through — over-suppressing would be the opposite failure, and a quiet channel during a real crossing is worse than a duplicate
- a **healthy** probe at first sight retains nothing

## Context

The same screenshot showed the rest of the path working: narration in `#Ops` authored by **Hermes** with **"managed by you"** — the kind-0 profile and the NIP-OA owner attestation both rendering as designed.