### PR TITLE
Give the agent the board's verdict, not a second opinion

### DIFF
--- a/packages/averray-mcp/src/board-health.ts
+++ b/packages/averray-mcp/src/board-health.ts
@@ -1,0 +1,139 @@
+// The board's verdict, handed to an agent as a CONCLUSION.
+//
+// WHY THIS EXISTS: `averray_ops_health` already describes itself to the model as
+// the "canonical read-only operator health snapshot" — but it reads Postgres
+// (`source: "postgres_read_only"`) and computes its own health from table stats,
+// operator events and recent errors. That is control-plane health, and it is
+// genuinely useful, but it is NOT what the ops board says and it is NOT what the
+// operator is looking at.
+//
+// So an agent asked "is Averray ok?" reached for a tool named canonical, read a
+// different source, and could confidently contradict the screen. Two verdict
+// systems — one deterministic and tested, one that can hallucinate — will
+// eventually disagree, and the first time that happens in front of the operator
+// neither is trustworthy again.
+//
+// This tool closes that. It returns the SAME `verdict` block the board renders,
+// produced by the same `deriveOpsVerdict` in @avg/schemas. The agent reads a
+// conclusion instead of assembling one.
+//
+// ── WHAT IT DELIBERATELY DOES NOT DO ───────────────────────────────────────
+//
+// It does not summarise, re-rank, or soften. `verdict.reason` is passed through
+// untouched because it is the machine contract; `headline` and `sub` are prose
+// for humans and are marked as such. Anything that reduced the payload to a
+// friendlier sentence here would be a third opinion, which is the same bug in
+// a smaller box.
+//
+// It also does not decide staleness. How old a snapshot is is a property of the
+// READER, so `at` and `checkIntervalMs` are returned raw with a note, and the
+// caller judges. That mirrors the board, which layers its own staleness on top
+// of the shared verdict rather than baking it in.
+
+export interface BoardHealthDeps {
+  fetchImpl?: typeof fetch;
+  env?: NodeJS.ProcessEnv;
+}
+
+function monitorBase(env: NodeJS.ProcessEnv): string {
+  return (env.AVERRAY_MONITOR_BASE_URL?.trim() || "http://slack-operator:8790").replace(/\/+$/, "");
+}
+
+function monitorAuthHeaders(env: NodeJS.ProcessEnv): Record<string, string> {
+  const token = env.SLACK_OPERATOR_MONITOR_TOKEN?.trim();
+  return token ? { authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Fetch the board's health payload.
+ *
+ * A failure returns `reachable: false` with the reason rather than throwing or
+ * returning an empty shell. An agent that cannot read the board must say so —
+ * "everything appears operational" after a failed fetch is worse than silence,
+ * and an empty object invites exactly that sentence.
+ */
+export async function getBoardHealth(deps: BoardHealthDeps = {}): Promise<Record<string, unknown>> {
+  const env = deps.env ?? process.env;
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const url = `${monitorBase(env)}/monitor/product-health`;
+
+  let body: Record<string, unknown>;
+  try {
+    const res = await fetchImpl(url, { headers: { accept: "application/json", ...monitorAuthHeaders(env) } });
+    if (!res.ok) {
+      return unreachable(url, `HTTP ${res.status}`);
+    }
+    body = (await res.json()) as Record<string, unknown>;
+  } catch (error) {
+    return unreachable(url, error instanceof Error ? error.message : String(error));
+  }
+
+  // `enabled: false` is monitoring being OFF, which is not health — it is the
+  // absence of health data. Passing it through as if it were a reading is how a
+  // switched-off monitor gets reported as a quiet one.
+  const enabled = body.enabled !== false;
+  const verdict = body.verdict as Record<string, unknown> | undefined;
+
+  return {
+    schemaVersion: 1,
+    kind: "board_health",
+    mutates: false,
+    reachable: true,
+    source: `${url} — the same payload the ops board renders`,
+
+    // THE ANSWER. Everything below is supporting detail for explaining it.
+    verdict: verdict ?? null,
+    verdictReason: verdict?.reason ?? null,
+
+    monitoringEnabled: enabled,
+    ...(enabled ? {} : { note: "monitoring is OFF — this is unknown, not healthy" }),
+
+    at: body.at ?? null,
+    checkIntervalMs: body.checkIntervalMs ?? null,
+    checks: body.checks ?? null,
+    staleness:
+      "Judge it yourself: compare `at` against now. The verdict deliberately excludes staleness "
+      + "because how old a snapshot is depends on who is reading it.",
+
+    probes: body.probes ?? [],
+    solvency: body.solvency ?? null,
+    flow: body.flow ?? null,
+    buzz: body.buzz ?? null,
+    self: body.self ?? null,
+    remediation: body.remediation ?? null,
+    history: body.history ?? null,
+
+    guidance: {
+      readFirst: "verdict.reason",
+      neverMatchOn: ["verdict.headline", "verdict.sub"],
+      why:
+        "reason is the machine contract and is stable; headline and sub are prose for a human and get "
+        + "reworded. This verdict comes from the same tested deriveOpsVerdict the board renders, so "
+        + "explaining it keeps you and the operator's screen in agreement.",
+      notThisTool:
+        "averray_ops_health answers a DIFFERENT question — database and control-plane health read from "
+        + "Postgres. It is not the product verdict and the two can legitimately disagree; say which one "
+        + "you are quoting.",
+    },
+    safety: { mutatesByDefault: false, source: "monitor_read_only" },
+  };
+}
+
+function unreachable(url: string, reason: string): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    kind: "board_health",
+    mutates: false,
+    reachable: false,
+    source: url,
+    verdict: null,
+    verdictReason: null,
+    error: reason,
+    guidance: {
+      // The single most important sentence in this file.
+      say: "The board could not be reached, so the current state is UNKNOWN. Do not infer health from "
+        + "silence, and do not answer from memory of an earlier reading.",
+    },
+    safety: { mutatesByDefault: false, source: "monitor_read_only" },
+  };
+}

--- a/packages/averray-mcp/src/index.ts
+++ b/packages/averray-mcp/src/index.ts
@@ -15,6 +15,7 @@ import { evaluateClaimMutationPolicy, evaluateSubmitMutationPolicy, isUuid } fro
 import { postSlackAlert, validationFailureDetails } from "./slack-alerts.js";
 import { buildSubmitRequestBody } from "./submit-payload.js";
 import { validateSubmissionLocally } from "./validate-submission.js";
+import { getBoardHealth } from "./board-health.js";
 import {
   getDraftSubmission,
   listDraftSubmissions,
@@ -238,8 +239,17 @@ server.tool(
 );
 
 server.tool(
+  "averray_board_health",
+  "THE authoritative answer to whether Averray is working. Returns the ops board's own verdict — the same payload and the same tested deriveOpsVerdict the operator is looking at — plus the probes, solvency pools, money-path flow, on-chain payout proof, #Ops delivery state and incident log behind it. Read `verdict.reason` (nominal, probe-degraded, probe-red, floor-breach, pool-draining, payout-shortfall, no-data, not-watching); never match on the prose headline. Use this for any question about system health, the money path, payouts, settlements, solvency, liquidity floors, probes, incidents, or the dispute window on external jobs. Prefer it over averray_ops_health for product state: that one reads Postgres control-plane data and answers a different question. Read-only; mutates nothing.",
+  {},
+  async () => {
+    return jsonContent(await getBoardHealth());
+  }
+);
+
+server.tool(
   "averray_ops_health",
-  "Canonical read-only operator health snapshot for humans, Slack, Command Center, and other agents. Summarizes wallet/budget readiness, latest run state, control-plane table counts, recent operator events, and recent failures. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
+  "Read-only DATABASE and control-plane health: wallet/budget readiness, latest run state, control-plane table counts, recent operator events, and recent failures, read from Postgres. This is NOT the product health verdict and NOT what the ops board shows — for whether Averray is actually working, whether money is moving, or why the board shows a verdict, use averray_board_health instead. The two read different sources and can legitimately disagree; if you quote this one, say so. Does not claim, submit, request approval, edit Wikipedia, or mutate Averray state.",
   {},
   async () => {
     return jsonContent(await getOpsHealth({ query, workflowDeps: workflowDeps() }));

--- a/test/unit/board-health.test.ts
+++ b/test/unit/board-health.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import { getBoardHealth } from "../../packages/averray-mcp/src/board-health.js";
+
+const env = { AVERRAY_MONITOR_BASE_URL: "http://monitor:8790" } as NodeJS.ProcessEnv;
+
+const payload = {
+  enabled: true,
+  at: 1_700_000_000_000,
+  checkIntervalMs: 300_000,
+  checks: 42,
+  verdict: { headline: "NOMINAL", tone: "ok", sub: "money is moving", reason: "nominal" },
+  probes: [{ name: "money_path", status: "ok", detail: "settled24h 15" }],
+  buzz: { status: "ok", detail: "delivered 4m ago" },
+};
+
+const ok = (body: unknown): typeof fetch =>
+  (async () => ({ ok: true, status: 200, json: async () => body }) as unknown as Response) as never;
+
+describe("getBoardHealth", () => {
+  it("hands back the board's verdict, not a summary of it", () => {
+    // The whole point: the agent reads a CONCLUSION produced by the same tested
+    // deriveOpsVerdict the operator's screen renders. Anything reduced or
+    // re-ranked here would be a third opinion.
+    return getBoardHealth({ env, fetchImpl: ok(payload) }).then((r) => {
+      expect(r.reachable).toBe(true);
+      expect(r.verdict).toEqual(payload.verdict);
+      expect(r.verdictReason).toBe("nominal");
+    });
+  });
+
+  it("points the agent at reason and away from the prose", async () => {
+    const r = await getBoardHealth({ env, fetchImpl: ok(payload) });
+    const g = r.guidance as Record<string, unknown>;
+    expect(g.readFirst).toBe("verdict.reason");
+    expect(g.neverMatchOn).toEqual(["verdict.headline", "verdict.sub"]);
+  });
+
+  it("names the OTHER health tool so the two are not confused", async () => {
+    // averray_ops_health reads Postgres and answers a different question. The
+    // two can legitimately disagree, and an agent quoting one as the other is
+    // the exact failure this tool exists to prevent.
+    const r = await getBoardHealth({ env, fetchImpl: ok(payload) });
+    expect(String((r.guidance as Record<string, unknown>).notThisTool)).toContain("averray_ops_health");
+  });
+
+  it("an unreachable board is UNKNOWN, never healthy", async () => {
+    const r = await getBoardHealth({
+      env,
+      fetchImpl: (async () => {
+        throw new Error("ECONNREFUSED");
+      }) as never,
+    });
+    expect(r.reachable).toBe(false);
+    expect(r.verdict).toBeNull();
+    expect(r.error).toContain("ECONNREFUSED");
+    expect(String((r.guidance as Record<string, unknown>).say)).toContain("UNKNOWN");
+  });
+
+  it("an HTTP error is also unknown, with the status", async () => {
+    const r = await getBoardHealth({
+      env,
+      fetchImpl: (async () => ({ ok: false, status: 503 }) as unknown as Response) as never,
+    });
+    expect(r.reachable).toBe(false);
+    expect(r.error).toBe("HTTP 503");
+  });
+
+  it("monitoring switched OFF is not health — it is the absence of it", async () => {
+    // enabled:false passed through as a reading is how a switched-off monitor
+    // gets reported as a quiet one.
+    const r = await getBoardHealth({ env, fetchImpl: ok({ ...payload, enabled: false }) });
+    expect(r.monitoringEnabled).toBe(false);
+    expect(String(r.note)).toContain("unknown, not healthy");
+  });
+
+  it("does not judge staleness — it hands over the clock and says so", async () => {
+    // How old a snapshot is is a property of the READER. The board layers its
+    // own staleness on top of the shared verdict rather than baking it in.
+    const r = await getBoardHealth({ env, fetchImpl: ok(payload) });
+    expect(r.at).toBe(payload.at);
+    expect(r.checkIntervalMs).toBe(payload.checkIntervalMs);
+    expect(String(r.staleness)).toContain("Judge it yourself");
+  });
+
+  it("carries the supporting blocks an explanation needs", async () => {
+    const r = await getBoardHealth({ env, fetchImpl: ok(payload) });
+    expect(r.probes).toEqual(payload.probes);
+    expect(r.buzz).toEqual(payload.buzz);
+  });
+
+  it("declares itself read-only", async () => {
+    const r = await getBoardHealth({ env, fetchImpl: ok(payload) });
+    expect(r.mutates).toBe(false);
+  });
+});


### PR DESCRIPTION
P4's read seam. **The problem wasn't a missing tool — it was a competing one.**

## What I found

`averray_ops_health` describes itself to the model as:

> **Canonical** read-only operator health snapshot…

But it reads **Postgres** — table counts, operator events, recent errors — and computes its own `health`:

```ts
safety: { source: "postgres_read_only" }
```

That's control-plane health. Genuinely useful, and **not what the ops board says.**

So an agent asked *"is Averray ok?"* reaches for a tool named canonical, reads a different source, and can confidently contradict the screen the operator is looking at. That's the exact failure this whole design exists to prevent — two verdict systems, one deterministic and tested, one that can hallucinate — and it was **already wired**. The first time they disagree in front of the operator, neither is trustworthy again.

## `averray_board_health`

Returns the board's own payload, including the `verdict` from the same `deriveOpsVerdict` in `@avg/schemas` the board renders. The agent reads a **conclusion** instead of assembling one.

**Deliberately not done:** no summarising, re-ranking or softening. `verdict.reason` passes through untouched (it's the machine contract); headline and sub are marked as prose. Reducing this to a friendlier sentence would be a third opinion — the same bug in a smaller box.

**It doesn't judge staleness either.** How old a snapshot is is a property of the *reader*, so `at` and `checkIntervalMs` come back raw with a note telling the caller to decide — mirroring the board, which layers reader-side staleness on top of the shared verdict rather than baking it in.

## Three states that must not collapse into "fine"

| condition | what it returns |
|---|---|
| unreachable | `reachable:false` + *"the current state is UNKNOWN. Do not infer health from silence, and do not answer from memory."* |
| HTTP error | same, carrying the status |
| `enabled:false` | monitoring is **off** — the absence of health data, not a reading of it |

## And the overclaim is gone

`averray_ops_health`'s description now says plainly what it is, that it is **not** the board, and that the two can legitimately disagree — so an agent quoting it says which one it's quoting.

## Verification

- 9 new tests; full suite **1881 passed**
- typecheck clean