### PR TITLE
skill(ops): advertise the wallet questions, and name the tool that answers them wrongly

### DIFF
--- a/hermes/skills/ops/averray-ops/SKILL.md
+++ b/hermes/skills/ops/averray-ops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: averray-ops
-description: Read and explain the Averray ops board — the live health of a system that settles real USDC on Polkadot Hub mainnet. Use whenever asked whether Averray is working, or about the money path, payouts, settlements, solvency, liquidity floors, probes, incidents, the dispute window on external jobs, or why the board shows a particular verdict. Also use before answering any question that implies the system's current state, so the answer comes from the board rather than from memory.
+description: Read and explain the Averray ops board — the live health of a system that settles real USDC on Polkadot Hub mainnet. Use for any question about the operator's wallets, addresses or balances: where to send DOT or USDC, topping up signer gas, funding the reward bank, which address is safe to send funds to. The agent's own wallet tools answer a different question and must not be used for those. Use it whenever asked whether Averray is working, or about the money path, payouts, settlements, solvency, liquidity floors, probes, incidents, the dispute window on external jobs, or why the board shows a particular verdict. Use it before answering anything that implies the system's current state, so the answer comes from the board rather than from memory.
 ---
 
 # Watching Averray
@@ -234,9 +234,25 @@ Substrate wallets), and `addressLabel`. Two rules:
 - Only the **signer** is a wallet somebody should send funds to. The others are
   contracts; DOT sent to `EscrowCore` lands somewhere with no way back. If asked
   where to top up gas, give the signer and say the others are contracts.
+- **The `wallet_*` tools are not this.** `wallet_export_address` /
+  `wallet_status` return the *agent's own* SIWE identity — the key it logs into
+  the Averray API with, reported as `siweFallbackMode`. It is not operator
+  infrastructure and it is not the gas signer. The word "signer" means two
+  different things across these tools, and that collision has already produced a
+  confident wrong answer: asked where to send DOT for gas, the agent returned
+  its own login wallet. Funds sent there do not top up gas. Operator balances
+  come from `solvency.pools[]` and nowhere else.
 
 Native DOT reads as 18 decimals over eth-rpc, and funds must be on **Asset Hub**,
 not the relay chain — relay DOT needs teleporting first.
+
+**No bridge is involved, and do not invent one.** The `0x…` and the `1…` SS58 on
+a pool are the SAME account: pallet_revive maps H160 → AccountId32 by appending
+twelve `0xEE` bytes, and this was verified against mainnet by cross-checking the
+nonce on both RPCs (both returned 222). So a Substrate wallet sends DOT to the
+SS58 form and it lands as that account's gas — no bridge, no wrapper, no
+contract call. Telling an operator otherwise strands a top-up during an outage,
+which is when the question always gets asked.
 
 ---
 

--- a/test/unit/averray-ops-skill.test.ts
+++ b/test/unit/averray-ops-skill.test.ts
@@ -1,0 +1,105 @@
+// The ops skill is a DELIVERABLE, and its failure mode is silence.
+//
+// Every way this file can be wrong — misnamed, misplaced, unparseable
+// frontmatter, a trigger that does not name the question being asked — produces
+// no error anywhere. Hermes simply never loads it, which reads as the agent
+// ignoring its guidance rather than as a broken file. This document spent its
+// first weeks in exactly that state, and a duplicate copy survived on main
+// through two squash merges without a single test noticing.
+//
+// So the shape gets asserted here. These tests do not check prose; they check
+// the handful of properties that decide whether the prose is ever read.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const skillPath = join(repoRoot, "hermes", "skills", "ops", "averray-ops", "SKILL.md");
+
+const raw = readFileSync(skillPath, "utf8");
+
+function frontmatter(text: string): { name: string; description: string } {
+  const match = /^---\n([\s\S]*?)\n---\n/.exec(text);
+  if (!match) throw new Error("no YAML frontmatter");
+  const block = match[1]!;
+  const name = /^name:\s*(.+)$/m.exec(block)?.[1]?.trim();
+  const description = /^description:\s*(.+)$/m.exec(block)?.[1]?.trim();
+  if (!name || !description) throw new Error("frontmatter missing name or description");
+  return { name, description };
+}
+
+describe("averray-ops skill file shape", () => {
+  it("is named SKILL.md inside a directory named for the skill", () => {
+    // Hermes discovers skills with `skills_dir.rglob("SKILL.md")`, and takes the
+    // skill name from the parent directory and the category from its
+    // grandparent. A flat `averray-ops.md` is never found at all.
+    expect(skillPath.endsWith(join("ops", "averray-ops", "SKILL.md"))).toBe(true);
+    expect(frontmatter(raw).name).toBe("averray-ops");
+  });
+
+  it("has a single-line description — a wrapped one breaks the YAML", () => {
+    const { description } = frontmatter(raw);
+    expect(description).not.toContain("\n");
+    expect(description.length).toBeGreaterThan(80);
+  });
+});
+
+describe("the description is a TRIGGER, not a label", () => {
+  const { description } = frontmatter(raw);
+  const lower = description.toLowerCase();
+
+  it("names the money-path questions it should answer", () => {
+    for (const term of ["money path", "payouts", "settlements", "solvency", "verdict"]) {
+      expect(lower).toContain(term);
+    }
+  });
+
+  it("names wallet and funding questions", () => {
+    // THE REGRESSION. The first version of this description listed only board
+    // and money-path vocabulary — no wallet, address, gas, DOT or top-up. Asked
+    // "where do I send DOT to top up the signer's gas", the model matched
+    // nothing here, never reached the board, and answered from the agent's own
+    // `wallet_export_address` instead: a real, valid-looking address that is not
+    // the gas signer, plus invented advice that the transfer needed a bridge.
+    //
+    // A skill that does not advertise a question does not get asked it.
+    for (const term of ["wallet", "address", "gas", "dot", "usdc"]) {
+      expect(lower).toContain(term);
+    }
+  });
+
+  it("puts the funding vocabulary early, before any truncation could bite", () => {
+    // Hermes's truncation behaviour for long descriptions is not verified, so
+    // the clause whose absence produced a wrong money answer leads rather than
+    // trails. This is cheap insurance, not a claim about the limit.
+    expect(description.slice(0, 260).toLowerCase()).toContain("wallet");
+  });
+});
+
+describe("the body carries the facts that were answered wrongly", () => {
+  const lower = raw.toLowerCase();
+
+  it("separates the agent's own wallet from operator infrastructure", () => {
+    // "signer" means two different things across these tools: the operator's gas
+    // account, and the agent's SIWE login identity. That collision is what
+    // produced the wrong answer, so the file has to name it explicitly.
+    expect(lower).toContain("wallet_export_address");
+    expect(lower).toContain("siwefallbackmode");
+  });
+
+  it("says plainly that no bridge is involved", () => {
+    // pallet_revive maps H160 -> AccountId32 by appending twelve 0xEE bytes, so
+    // the 0x form and the SS58 form are the same account and a Substrate wallet
+    // can fund gas directly. Inventing a bridge strands a top-up during an
+    // outage, which is exactly when the question gets asked.
+    expect(lower).toContain("no bridge");
+    expect(lower).toContain("0xee");
+  });
+
+  it("still says only the signer takes funds, and the rest are contracts", () => {
+    expect(lower).toContain("lands somewhere with no way back");
+  });
+});


### PR DESCRIPTION
## What happened

Asked *"where do I send DOT to top up the signer's gas"*, Hermes never reached the board:

```
⚡ mcp_wallet_wallet_export_address
⚡ mcp_wallet_wallet_status
⚡ mcp_averray_averray_operator_status
```

It answered `0x30BC468dA4E95a8FA4b3f2043c86687a57CdeE05` — "the signer's address (Polkadot mainnet, SIWE fallback wallet)". That is the **agent's own login identity** (`siweFallbackMode`, `packages/wallet-mcp/src/index.ts:18`), not the gas signer. It then added that DOT could not be sent to that hex form and would need "a bridge or the contract address your wallet exposes".

A real, valid-looking address that is not the one you want, plus advice that strands the top-up. Following it does not fix a gas outage.

## Why

The description is the trigger, and it listed only board vocabulary — *money path, payouts, settlements, solvency, liquidity floors, probes, incidents, dispute window, verdict*. No **wallet**, **address**, **gas**, **DOT** or **top up**. The question sat entirely outside the surface the skill advertises, so the skill was never reached and the model matched on tool names instead.

Nothing errors when this happens. That is the recurring shape of this file's defects.

## Changes

- **Description leads with wallets and funding**, ahead of the money-path list. Deliberate: Hermes's truncation behaviour for long descriptions is unverified, so the clause whose absence caused a wrong money answer goes first rather than last.
- **Body names the collision.** `wallet_export_address` / `wallet_status` return the agent's SIWE identity; operator balances come from `solvency.pools[]` and nowhere else. "Signer" means two different things across these tools.
- **Body states no bridge is involved, with the reason.** pallet_revive maps H160 → AccountId32 via twelve `0xEE` bytes, so the `0x…` and `1…` forms are the same account — verified against mainnet by nonce cross-check (both RPCs returned 222), not inferred from docs.

## Tests

8 tests on the properties that decide whether the prose is ever read: file name and location, single-line frontmatter, trigger vocabulary, funding terms appearing early, and the three body facts above.

Verified the guard is real — the previous description fails `wallet`, `address` and `gas` and fails the early-vocabulary check. It does not merely pass against the new text.

## What this does NOT fix

Whether `SKILL.md` reaches the model at all is still unknown. Both of tonight's answers are explicable by the tool payload alone, since `averray_board_health` carries its own `guidance` by design — so the good board answer proves the tool, not the skill. A discriminating question is running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)