### PR TITLE
fix(ops): sync hermes/skills into the volume, and report when it drifts

### DIFF
--- a/docs/HERMES_INTEGRATION_MAP.md
+++ b/docs/HERMES_INTEGRATION_MAP.md
@@ -22,9 +22,13 @@ packages/
   mcp-common/  schemas/
 services/
   slack-operator/   ← serves the live /monitor board, the Codex task queue + runner, testbed mission runner
-  skills-observer/  ← sidecar ingesting Hermes skill files
+  skills-observer/  ← sidecar ingesting Hermes skill files, and reporting when the
+                      skills volume stops matching the repo. Also holds `skills-sync`
+                      (dist/sync.js), the one-shot that copies hermes/skills/** into
+                      the avg-hermes-skills volume before Hermes starts.
 ops/                ← Docker compose stack (base, prod, command-center, cloudflare-access)
-hermes/             ← Hermes config (hermes.yaml, policy.yaml) + trace plugin
+hermes/             ← Hermes config (hermes.yaml, policy.yaml), trace plugin, and
+                      skills/ — the source of truth for what the agent loads
 ```
 
 ---

--- a/hermes/skills/ops/averray-ops/SKILL.md
+++ b/hermes/skills/ops/averray-ops/SKILL.md
@@ -12,7 +12,15 @@ quiet when it isn't.
 
 Lives at `/opt/data/skills/ops/averray-ops/SKILL.md`, copied from
 `hermes/skills/ops/averray-ops/SKILL.md` in `depre-dev/averray-reference-agent`.
-Edit it there, not in the volume.
+Edit it there, not in the volume: the `skills-sync` service copies the repo tree
+in before Hermes starts and on every `ops/deploy-monitor.sh` run, so an edit
+made in the volume is overwritten, and one made only in the volume is invisible
+to everyone reading the repo. `skills-observer` reports when the two diverge.
+
+That sync is recent. Before it, the copy was placed by hand, nothing checked it,
+and a merged edit reached the running agent only if someone remembered to
+re-copy it — which is how this file came to be weeks stale while still being
+read as current.
 
 The layout is not decoration, and all three levels were checked against the
 running image rather than assumed:

--- a/ops/compose.command-center.yml
+++ b/ops/compose.command-center.yml
@@ -14,6 +14,10 @@ services:
         condition: service_completed_successfully
       mcp-env:
         condition: service_completed_successfully
+      # Mounts the same skills volume below, so it needs the guarantee the
+      # `hermes` service has: the tree is current before the agent reads it.
+      skills-sync:
+        condition: service_completed_successfully
       skills-observer:
         condition: service_started
     environment:

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -109,6 +109,55 @@ services:
     entrypoint: ["/bin/sh", "/write-mcp-env.sh", "/mcp-env/reference-agent.env"]
     networks: [avg-internal]
 
+  # Copies hermes/skills/** from the git checkout into the skills volume, so
+  # that merging a change to a SKILL.md actually reaches the running agent.
+  #
+  # Before this existed nothing connected the two: the volume copy was placed by
+  # hand, so a merged edit had no effect and the live copy could diverge from
+  # git with no error and no signal. One skill sat unreachable for weeks in a
+  # misnamed location, and the agent answered a production question wrongly
+  # because of it. Hermes is gated on this completing (see its depends_on) so it
+  # cannot boot onto a stale tree.
+  #
+  # The mount is a bind of ../hermes/skills, matching how hermes.yaml,
+  # policy.yaml and plugins already reach the container. Directory structure is
+  # copied verbatim: Hermes discovers skills with skills_dir.rglob("SKILL.md")
+  # and takes the NAME from the parent directory and the CATEGORY from its
+  # grandparent, so ops/averray-ops/SKILL.md must land at exactly that path.
+  #
+  # It never deletes: Hermes writes its own skills into this volume at runtime
+  # and mirroring the repo would destroy them.
+  skills-sync:
+    build:
+      context: ..
+      dockerfile: ops/Dockerfile.node
+      args:
+        # Baked so the monitor can report its own version. Use
+        # ops/deploy-monitor.sh — it computes both and refuses a dirty tree.
+        # Deploying by hand leaves these unset, which is why self-freshness
+        # read "unknown" from the day it shipped until 2026-08-01.
+        GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_DIRTY: ${GIT_DIRTY:-false}
+    image: ${AVERRAY_IMAGE:-avg-node-runtime}
+    # Same reason as skills-observer below: Hermes owns this volume as UID 10000
+    # and continuously re-secures it to 0700, so this is the only user that can
+    # write it once Hermes has run. Writes that lose that race are retried, and
+    # the exit code comes from re-reading the volume afterwards rather than from
+    # whether every individual write succeeded.
+    user: "10000:10000"
+    depends_on:
+      hermes-permissions:
+        condition: service_completed_successfully
+    command: ["node", "services/skills-observer/dist/sync.js"]
+    environment:
+      REPO_SKILLS_DIR: /repo-skills
+      HERMES_SKILLS_DIR: /opt/data/skills
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+    volumes:
+      - ../hermes/skills:/repo-skills:ro
+      - avg-hermes-skills:/opt/data/skills
+    networks: [avg-internal]
+
   skills-observer:
     build:
       context: ..
@@ -135,11 +184,16 @@ services:
     environment:
       DATABASE_URL: ${DATABASE_URL}
       HERMES_SKILLS_DIR: /hermes-skills
+      # Second copy of the tree, read-only, so the observer can report when the
+      # volume stops matching git. skills-sync makes the copy right; this makes
+      # a later divergence visible instead of silent.
+      REPO_SKILLS_DIR: /repo-skills
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-hermes:/opt/data:ro
       - avg-hermes-skills:/hermes-skills:ro
+      - ../hermes/skills:/repo-skills:ro
     networks: [avg-internal]
 
   slack-operator:
@@ -1051,6 +1105,14 @@ services:
       mcp-bundle:
         condition: service_completed_successfully
       mcp-env:
+        condition: service_completed_successfully
+      # Gate the agent on the skill tree being current. Hermes reads
+      # /opt/data/skills at startup, so syncing after it boots would leave it
+      # running the previous copy until the next restart. A failed sync holds
+      # Hermes back rather than letting it answer from a stale skill; the ops
+      # board does not depend on Hermes, so this costs the agent, not the
+      # money path. To start it anyway: `up -d --no-deps hermes`.
+      skills-sync:
         condition: service_completed_successfully
       skills-observer:
         condition: service_started

--- a/ops/deploy-monitor.sh
+++ b/ops/deploy-monitor.sh
@@ -101,6 +101,44 @@ COMPOSE=(docker compose -p avg --env-file .env.prod
   -f ops/compose.command-center.yml
   -f ops/compose.cloudflare-access.yml)
 
+# SYNC THE SKILL TREE FIRST — on every deploy, whatever service is being
+# deployed.
+#
+# hermes/skills/** is not baked into any image. It reaches the agent by being
+# bind-mounted in and copied into the avg-hermes-skills volume, and until that
+# copy happens a merged SKILL.md edit is live nowhere. Compose gates `hermes`
+# on skills-sync, but that only fires when Hermes itself restarts, which a
+# monitor deploy does not do — so the sync would run days late, or not at all.
+#
+# This is the same lesson as GIT_SHA above: a correctness-critical step must not
+# depend on an operator remembering to type it, so it lives here.
+#
+# ADVISORY, not fatal. Deploying the board is how the operator sees the money
+# path, and the board reads none of these skills; failing that deploy because a
+# skill file could not be copied would be the coupling #657 removed. A stale
+# tree still fails closed where it matters (Hermes will not boot onto one) and
+# skills-observer keeps reporting the drift until it is fixed.
+#
+# --no-deps is deliberate. skills-sync depends on hermes-permissions, which is
+# a one-shot that has already exited by the time anyone deploys; pulling it in
+# here would re-run its `chmod -R 0777 /opt/data` and re-open the Hermes data
+# volume that Hermes spends its life securing to 0700 — a permissions change
+# nobody asked a monitor deploy to make. The volume already exists on any box
+# being deployed to, and the first-boot ordering is handled by compose's
+# dependency graph, not by this script.
+echo "syncing hermes/skills -> the skills volume"
+if GIT_SHA="$GIT_SHA" GIT_DIRTY="$GIT_DIRTY" "${COMPOSE[@]}" run --rm --no-deps --build skills-sync; then
+  echo
+else
+  echo >&2
+  echo "WARNING: the skills sync did not complete — the running agent may be" >&2
+  echo "         reading a skill tree that does not match this commit. The" >&2
+  echo "         deploy of ${SERVICE} continues (it does not read these files)." >&2
+  echo "         Check the log above; skills-observer will keep reporting the" >&2
+  echo "         drift until it is resolved." >&2
+  echo >&2
+fi
+
 echo "deploying ${SERVICE} at ${GIT_SHA:0:8}$([ "$GIT_DIRTY" = true ] && echo ' (dirty)')"
 
 # NEVER --remove-orphans here: this compose project shares a network with

--- a/services/skills-observer/src/drift-alert.ts
+++ b/services/skills-observer/src/drift-alert.ts
@@ -1,0 +1,74 @@
+/**
+ * Decide whether a drift check should announce anything.
+ *
+ * Logging every result is free and always truthful; a Slack message is not, and
+ * three ways of getting this wrong all end with the alert being worthless:
+ *
+ *   REPEATING. Drift is a standing condition, not an event. Re-posting the same
+ *   divergence every interval trains the reader to skim past it.
+ *
+ *   CRYING WOLF AT BOOT. skills-observer and skills-sync start together, so the
+ *   observer's first look can catch the volume mid-copy. That is not drift, it
+ *   is a race with the fix. The first check therefore only observes — and it
+ *   deliberately does NOT record what it saw, so a divergence that is real is
+ *   still announced on the next pass rather than swallowed as "unchanged".
+ *
+ *   GOING QUIET WHEN IT BREAKS. A check that cannot run says nothing about
+ *   whether the trees match, and silence on a notification channel reads as
+ *   "nothing wrong". That is the very failure this whole mechanism exists to
+ *   remove — a skill sat unreachable for weeks because nothing surfaced it — so
+ *   an unavailable check is itself announced, once.
+ */
+
+export interface DriftAlertState {
+  /** The drift currently announced, if any. Absent means none outstanding. */
+  alerted?: string;
+  /** Whether an unavailable check has already been announced. */
+  unavailableAnnounced: boolean;
+  /** False until one check has completed — see CRYING WOLF AT BOOT above. */
+  settled: boolean;
+}
+
+export type DriftObservation =
+  | { kind: "in-sync" }
+  /** `signature` is the stable identity of this divergence; see driftSignature(). */
+  | { kind: "drifted"; signature: string }
+  | { kind: "unavailable" };
+
+export type DriftAnnouncement = "none" | "drift" | "recovery" | "unavailable";
+
+export const initialDriftAlertState: DriftAlertState = {
+  settled: false,
+  unavailableAnnounced: false
+};
+
+export function decideDriftAlert(
+  state: DriftAlertState,
+  observation: DriftObservation
+): { announce: DriftAnnouncement; state: DriftAlertState } {
+  if (!state.settled) {
+    return { announce: "none", state: { settled: true, unavailableAnnounced: false } };
+  }
+
+  if (observation.kind === "unavailable") {
+    // Drop any outstanding drift verdict: a check that could not run does not
+    // confirm the old one, and re-detecting it later deserves a fresh alert.
+    return {
+      announce: state.unavailableAnnounced ? "none" : "unavailable",
+      state: { settled: true, unavailableAnnounced: true }
+    };
+  }
+
+  if (observation.kind === "in-sync") {
+    const hadSomethingOutstanding = state.alerted !== undefined || state.unavailableAnnounced;
+    return {
+      announce: hadSomethingOutstanding ? "recovery" : "none",
+      state: { settled: true, unavailableAnnounced: false }
+    };
+  }
+
+  return {
+    announce: state.alerted === observation.signature ? "none" : "drift",
+    state: { settled: true, unavailableAnnounced: false, alerted: observation.signature }
+  };
+}

--- a/services/skills-observer/src/index.ts
+++ b/services/skills-observer/src/index.ts
@@ -3,12 +3,28 @@ import path from "node:path";
 import chokidar from "chokidar";
 import { logger, optionalEnv, query, sha256Text } from "@avg/mcp-common";
 import { describeWatchError } from "./watch-error.js";
+import { decideDriftAlert, initialDriftAlertState } from "./drift-alert.js";
+import { errorCode } from "./skills-sync.js";
+import {
+  describeDrift,
+  diffSkillTrees,
+  driftSignature,
+  hashBytes,
+  isInSync,
+  readSkillTree,
+  type SkillDrift
+} from "./skills-tree.js";
 
 const skillsDir = optionalEnv("HERMES_SKILLS_DIR", "/opt/data/skills");
+const repoSkillsDir = optionalEnv("REPO_SKILLS_DIR", "/repo-skills");
 const slackWebhookUrl = optionalEnv("SLACK_WEBHOOK_URL");
 const watchRetryMs = Number(optionalEnv("SKILLS_OBSERVER_WATCH_RETRY_MS", "30000"));
+const driftCheckMs = Number(optionalEnv("SKILLS_DRIFT_CHECK_MS", "900000"));
+// Gap before the second check only — the first runs while skills-sync may still
+// be copying, so it observes without announcing.
+const driftSettleMs = Number(optionalEnv("SKILLS_DRIFT_SETTLE_MS", "60000"));
 
-logger.info({ skillsDir }, "skills_observer_starting");
+logger.info({ skillsDir, repoSkillsDir }, "skills_observer_starting");
 
 let retryTimer: NodeJS.Timeout | undefined;
 
@@ -41,8 +57,14 @@ function startWatcher(): void {
     }
   });
 
-  watcher.on("add", ingest);
-  watcher.on("change", ingest);
+  // `ingest` is async, so an unhandled rejection from it takes the whole
+  // process down — a Postgres blip during the initial scan is enough. That now
+  // costs more than a lost ingest: the drift check shares this process, and a
+  // restart resets its state machine, whose first pass deliberately only
+  // observes. A fast enough crash loop would therefore never reach a pass that
+  // announces, and drift would go unreported while looking merely flaky.
+  watcher.on("add", (relativePath) => void ingestSafely(relativePath));
+  watcher.on("change", (relativePath) => void ingestSafely(relativePath));
   watcher.on("error", (error) => {
     const disposition = describeWatchError(error);
     if (!disposition.retryable) {
@@ -62,6 +84,51 @@ function startWatcher(): void {
 
 startWatcher();
 
+/**
+ * Who wrote the file that just landed in the volume.
+ *
+ * Before skills-sync existed, everything appearing here came from Hermes, so
+ * the watcher could announce it as such. Now the sync writes into the same
+ * directory, and announcing its copies as "Hermes wrote a skill" would report
+ * agent behaviour that never happened. Classify by comparing against the repo
+ * copy instead of assuming.
+ *
+ * `repo`  — byte-identical to what the repo ships: our own sync landing.
+ * `edited-over-repo` — a repo-managed path the agent has since changed. This is
+ *   drift; the periodic check owns that message so it is not said twice.
+ * `agent` — no repo counterpart, so the agent genuinely authored it.
+ * `unknown` — the repo tree could not be consulted. Nothing is claimed either
+ *   way; notably NOT folded into `agent`, or a broken repo mount would report
+ *   every file the sync just copied as the agent having written it.
+ */
+type SkillOrigin = "repo" | "edited-over-repo" | "agent" | "unknown";
+
+async function classifyOrigin(relativePath: string, content: string): Promise<SkillOrigin> {
+  let repoBytes: Buffer;
+  try {
+    repoBytes = await fs.readFile(path.join(repoSkillsDir, relativePath));
+  } catch (error) {
+    // Only "the repo does not ship this path" means the agent wrote it. Any
+    // other error means we could not look.
+    return errorCode(error) === "ENOENT" ? "agent" : "unknown";
+  }
+  // The watcher only ever ingests .md, so re-encoding the text it already read
+  // reproduces the bytes on disk exactly.
+  return hashBytes(repoBytes) === hashBytes(Buffer.from(content, "utf8"))
+    ? "repo"
+    : "edited-over-repo";
+}
+
+async function ingestSafely(relativePath: string): Promise<void> {
+  try {
+    await ingest(relativePath);
+  } catch (error) {
+    // Chokidar re-emits on the next change, and a restart re-scans, so a failed
+    // ingest is recoverable. Losing the process is not worth it.
+    logger.error({ err: error, filePath: relativePath }, "skill_ingest_failed");
+  }
+}
+
 async function ingest(relativePath: string) {
   const filePath = path.join(skillsDir, relativePath);
   const content = await fs.readFile(filePath, "utf8");
@@ -75,7 +142,12 @@ async function ingest(relativePath: string) {
     [relativePath, sha256, content, stat.mtime.toISOString()]
   );
   if (!rows[0]) return;
-  logger.info({ filePath: relativePath, sha256 }, "skill_observed");
+  const origin = await classifyOrigin(relativePath, content);
+  logger.info({ filePath: relativePath, sha256, origin }, "skill_observed");
+  // Every version is recorded above regardless of origin — that audit trail is
+  // the point. Only a skill the agent demonstrably authored is news worth a
+  // notification, and `unknown` is not a demonstration.
+  if (origin !== "agent") return;
   await postSlack({
     text: `Hermes wrote or updated a skill: ${relativePath}`,
     blocks: [
@@ -89,6 +161,107 @@ async function ingest(relativePath: string) {
     ]
   });
 }
+
+/**
+ * Report when the volume copy stops matching the repo.
+ *
+ * skills-sync makes the copy correct at boot and on deploy; this makes a later
+ * divergence visible. Both failure modes it catches used to be silent: a sync
+ * that could not write (Hermes re-secures the volume to 0700 as it works), and
+ * the agent editing a skill the repo owns.
+ *
+ * Detection lives here rather than in skills-sync because it is a standing
+ * condition, not a boot step, and this service is already the long-running
+ * reader of that volume — it holds the right UID, the Slack route, and a
+ * read-only mount of both trees. It writes to neither.
+ */
+let driftAlertState = initialDriftAlertState;
+
+async function checkDrift(): Promise<void> {
+  let signature: string;
+  let drift: SkillDrift;
+  try {
+    const [repoTree, volumeTree] = await Promise.all([
+      readSkillTree(repoSkillsDir),
+      readSkillTree(skillsDir)
+    ]);
+    drift = diffSkillTrees(repoTree, volumeTree);
+    signature = driftSignature(drift);
+  } catch (error) {
+    // Unreadable is NOT in sync. Say only what was established — that the check
+    // could not run — and announce that, because a drift check that has quietly
+    // stopped working is the same silence this mechanism exists to end.
+    const decision = decideDriftAlert(driftAlertState, { kind: "unavailable" });
+    driftAlertState = decision.state;
+    logger.warn(
+      { err: error, skillsDir, repoSkillsDir },
+      "skills_drift_check_unavailable: could not compare the volume against the repo, so " +
+        "whether they match is currently unknown."
+    );
+    if (decision.announce === "unavailable") {
+      await postSlack({
+        text:
+          "Cannot check the skills volume against the repo, so whether the agent is loading " +
+          "current skills is unknown. Check the /repo-skills and skills volume mounts on " +
+          "skills-observer."
+      });
+    }
+    return;
+  }
+
+  const decision = decideDriftAlert(
+    driftAlertState,
+    isInSync(drift) ? { kind: "in-sync" } : { kind: "drifted", signature }
+  );
+  driftAlertState = decision.state;
+
+  if (isInSync(drift)) {
+    logger.info({ skillsDir }, "skills_drift_none");
+    if (decision.announce === "recovery") {
+      await postSlack({ text: "Skills volume is back in sync with the repo." });
+    }
+    return;
+  }
+
+  // Logged on every check regardless of whether it is announced, so the
+  // condition is always recoverable from the logs.
+  logger.error(
+    { missing: drift.missing, modified: drift.modified },
+    `skills_drift_detected: ${describeDrift(drift)}. The running agent is not loading what the ` +
+      "repo says it is. Re-run ops/deploy-monitor.sh (it syncs first), or " +
+      "`docker compose -p avg run --rm --no-deps skills-sync`."
+  );
+  if (decision.announce !== "drift") return;
+  await postSlack({
+    text: `Skills volume has drifted from the repo: ${describeDrift(drift)}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `*Skills volume has drifted from the repo*\n${describeDrift(drift)}\n\n` +
+            "The running agent is not loading what `hermes/skills/**` says it is. " +
+            "Re-run `ops/deploy-monitor.sh`, which syncs before it deploys."
+        }
+      }
+    ]
+  });
+}
+
+async function driftLoop(): Promise<void> {
+  const settling = !driftAlertState.settled;
+  await checkDrift();
+  // The first pass only observes (skills-sync may still be copying), so follow
+  // it up quickly rather than a full interval later — otherwise a divergence
+  // that is real goes unannounced for the whole period.
+  // Not unref'd, for the same reason as the watch-retry timer above: a pending
+  // timer keeps the process alive, so an unreadable volume degrades to periodic
+  // re-checks instead of the process exiting into a Docker restart loop.
+  setTimeout(() => void driftLoop(), settling ? driftSettleMs : driftCheckMs);
+}
+
+void driftLoop();
 
 async function postSlack(payload: unknown) {
   if (!slackWebhookUrl) return;

--- a/services/skills-observer/src/skills-sync.ts
+++ b/services/skills-observer/src/skills-sync.ts
@@ -1,0 +1,170 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { diffSkillTrees, isInSync, readSkillTree, type SkillDrift, type SkillTree } from "./skills-tree.js";
+
+/**
+ * Copy the repo's skill tree into the volume Hermes reads.
+ *
+ * Kept separate from the sync entrypoint (sync.ts) so the two properties that
+ * actually matter can be tested:
+ *
+ *   NEVER DELETES. Only paths the repo ships are written. Hermes authors its
+ *   own skills into this same volume at runtime — that is what skills-observer
+ *   watches for — so mirroring the repo would destroy the agent's own work.
+ *
+ *   VERIFIES, THEN REPORTS. Hermes owns the volume as UID 10000 and
+ *   continuously re-secures it to 0700 as it writes, so an individual write can
+ *   lose that race and fail EACCES. What matters is not whether every write
+ *   succeeded but whether the volume ends up matching the repo, so the verdict
+ *   comes from re-reading the tree afterwards. A write that failed on a file
+ *   that was already correct is not a failure.
+ */
+
+export interface SyncOptions {
+  repoDir: string;
+  volumeDir: string;
+  /** Retries per file, for losing a race with Hermes re-securing the volume. */
+  writeAttempts?: number;
+  writeRetryMs?: number;
+}
+
+export interface SyncFailure {
+  relativePath: string;
+  code?: string;
+  message: string;
+}
+
+export type SyncStatus =
+  /** The repo tree could not be read at all — almost always a broken mount. */
+  | "repo-unreadable"
+  /** The repo tree is empty, which no real checkout is. Treated as a fault. */
+  | "repo-empty"
+  /** The volume could not be read, so nothing about it can be established. */
+  | "volume-unreadable"
+  /** The volume already matched; nothing was written. */
+  | "current"
+  /** Files were copied and the volume now matches. */
+  | "synced"
+  /** Writes were attempted and the volume still does not match. */
+  | "incomplete";
+
+export interface SyncResult {
+  status: SyncStatus;
+  /** Repo-managed paths written during this run. */
+  synced: string[];
+  /** Individual write failures — informational; `drift` is the verdict. */
+  failures: SyncFailure[];
+  /** How the volume compares to the repo AFTER the attempt. */
+  drift: SkillDrift;
+  error?: unknown;
+}
+
+const ACCESS_CODES = new Set(["EACCES", "EPERM"]);
+const NO_DRIFT: SkillDrift = { missing: [], modified: [] };
+
+export function errorCode(error: unknown): string | undefined {
+  return typeof error === "object" && error !== null && "code" in error
+    ? String((error as { code: unknown }).code)
+    : undefined;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function readVolumeTree(volumeDir: string): Promise<SkillTree> {
+  try {
+    return await readSkillTree(volumeDir);
+  } catch (error) {
+    // An absent volume directory is the normal first-boot state, not a fault:
+    // treat it as empty and let the copy below create it.
+    if (errorCode(error) === "ENOENT") return new Map();
+    throw error;
+  }
+}
+
+export async function syncSkills(options: SyncOptions): Promise<SyncResult> {
+  const { repoDir, volumeDir } = options;
+  const writeAttempts = Math.max(1, options.writeAttempts ?? 3);
+  const writeRetryMs = Math.max(0, options.writeRetryMs ?? 250);
+
+  let repoTree: SkillTree;
+  try {
+    repoTree = await readSkillTree(repoDir);
+  } catch (error) {
+    // Fail closed and loudly. A missing repo mount that silently syncs nothing
+    // is indistinguishable from the bug this exists to fix.
+    return { status: "repo-unreadable", synced: [], failures: [], drift: NO_DRIFT, error };
+  }
+
+  if (repoTree.size === 0) {
+    return { status: "repo-empty", synced: [], failures: [], drift: NO_DRIFT };
+  }
+
+  // An unreadable volume is the failure this whole service is shaped around
+  // (Hermes secures it to 0700 as UID 10000), so it gets its own status and its
+  // own remediation rather than escaping as an unhandled rejection.
+  let before: SkillDrift;
+  try {
+    before = diffSkillTrees(repoTree, await readVolumeTree(volumeDir));
+  } catch (error) {
+    return { status: "volume-unreadable", synced: [], failures: [], drift: NO_DRIFT, error };
+  }
+
+  const stale = [...before.missing, ...before.modified];
+  if (stale.length === 0) {
+    return { status: "current", synced: [], failures: [], drift: NO_DRIFT };
+  }
+
+  const synced: string[] = [];
+  const failures: SyncFailure[] = [];
+  for (const relativePath of stale) {
+    const failure = await copyOne(repoDir, volumeDir, relativePath, writeAttempts, writeRetryMs);
+    if (failure) failures.push(failure);
+    else synced.push(relativePath);
+  }
+
+  let drift: SkillDrift;
+  try {
+    drift = diffSkillTrees(repoTree, await readVolumeTree(volumeDir));
+  } catch (error) {
+    // Writes may well have landed, but with no way to re-read the tree we
+    // cannot claim they did. Unverified is not the same as done.
+    return { status: "volume-unreadable", synced, failures, drift: NO_DRIFT, error };
+  }
+  return { status: isInSync(drift) ? "synced" : "incomplete", synced, failures, drift };
+}
+
+async function copyOne(
+  repoDir: string,
+  volumeDir: string,
+  relativePath: string,
+  writeAttempts: number,
+  writeRetryMs: number
+): Promise<SyncFailure | undefined> {
+  const destination = path.join(volumeDir, relativePath);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= writeAttempts; attempt += 1) {
+    try {
+      // Read inside the loop so a retry cannot write a stale buffer, and copy
+      // raw bytes so the volume file is byte-identical to the repo's.
+      const bytes = await fs.readFile(path.join(repoDir, relativePath));
+      await fs.mkdir(path.dirname(destination), { recursive: true });
+      await fs.writeFile(destination, bytes);
+      return undefined;
+    } catch (error) {
+      lastError = error;
+      const code = errorCode(error);
+      // Only an access error is worth retrying — it is the race with Hermes
+      // re-securing the directory. Anything else will fail the same way again.
+      if (!code || !ACCESS_CODES.has(code)) break;
+      if (attempt < writeAttempts) await sleep(writeRetryMs);
+    }
+  }
+  return {
+    relativePath,
+    code: errorCode(lastError),
+    message: lastError instanceof Error ? lastError.message : String(lastError)
+  };
+}

--- a/services/skills-observer/src/skills-tree.ts
+++ b/services/skills-observer/src/skills-tree.ts
@@ -1,0 +1,102 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Read and compare the two copies of the Hermes skill tree.
+ *
+ * `hermes/skills/**` in this repo is the source of truth; `/opt/data/skills`
+ * (the `avg-hermes-skills` volume) is what the running agent actually loads.
+ * Nothing used to connect them — the volume copy was placed by hand — so
+ * merging a SKILL.md change had no effect and the two could diverge with no
+ * error and no signal. These helpers are the shared basis for both halves of
+ * the fix: `sync.ts` writes repo → volume, and the observer re-runs the same
+ * comparison on a timer so a divergence is reported instead of sitting silent.
+ *
+ * Hashes are over raw bytes, so a copy is "the same" only if it is byte-exact.
+ */
+
+/** Relative POSIX path → sha256 of the file's bytes. */
+export type SkillTree = Map<string, string>;
+
+export interface SkillDrift {
+  /** In the repo, absent from the volume — the agent cannot load it at all. */
+  missing: string[];
+  /** In both, with different bytes — the agent is loading something else. */
+  modified: string[];
+}
+
+export function hashBytes(bytes: Buffer): string {
+  return crypto.createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Walk `root` and hash every file, keyed by its path relative to `root`.
+ *
+ * Dot-prefixed entries are skipped at every level: the repo side of this is a
+ * bind mount of a working checkout, so `.git`, `.DS_Store` and friends turn up
+ * there and are not skills.
+ *
+ * Throws ENOENT if `root` does not exist — an absent tree is a different
+ * condition from an empty one, and callers must not be able to confuse the two.
+ */
+export async function readSkillTree(root: string): Promise<SkillTree> {
+  const tree: SkillTree = new Map();
+  await walk(root, "", tree);
+  return tree;
+}
+
+async function walk(root: string, relativeDir: string, tree: SkillTree): Promise<void> {
+  const entries = await fs.readdir(path.join(root, relativeDir), { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name.startsWith(".")) continue;
+    const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      await walk(root, relativePath, tree);
+    } else if (entry.isFile()) {
+      tree.set(relativePath, hashBytes(await fs.readFile(path.join(root, relativePath))));
+    }
+  }
+}
+
+/**
+ * Compare the volume against the repo.
+ *
+ * Deliberately asymmetric: a file present ONLY in the volume is not drift.
+ * Hermes authors skills at runtime — that is the whole reason skills-observer
+ * exists — and treating those as extras to be reported (or worse, deleted)
+ * would fight the agent for ownership of its own directory. The repo owns the
+ * paths it ships; everything else in the volume belongs to the agent.
+ */
+export function diffSkillTrees(repo: SkillTree, volume: SkillTree): SkillDrift {
+  const missing: string[] = [];
+  const modified: string[] = [];
+  for (const [relativePath, sha256] of repo) {
+    const found = volume.get(relativePath);
+    if (found === undefined) missing.push(relativePath);
+    else if (found !== sha256) modified.push(relativePath);
+  }
+  return { missing: missing.sort(), modified: modified.sort() };
+}
+
+export function isInSync(drift: SkillDrift): boolean {
+  return drift.missing.length === 0 && drift.modified.length === 0;
+}
+
+/**
+ * A stable key for "the drift is the same as last time", so the observer can
+ * report a change of state rather than re-announcing the same divergence on
+ * every tick. An alert that repeats every interval stops being read.
+ */
+export function driftSignature(drift: SkillDrift): string {
+  return `missing:${drift.missing.join(",")}|modified:${drift.modified.join(",")}`;
+}
+
+/** One operator-facing line naming the files, not just the counts. */
+export function describeDrift(drift: SkillDrift): string {
+  if (isInSync(drift)) return "the skills volume matches the repo";
+  const parts: string[] = [];
+  if (drift.missing.length) parts.push(`missing from the volume: ${drift.missing.join(", ")}`);
+  if (drift.modified.length) parts.push(`changed in the volume: ${drift.modified.join(", ")}`);
+  return parts.join("; ");
+}

--- a/services/skills-observer/src/sync.ts
+++ b/services/skills-observer/src/sync.ts
@@ -1,0 +1,82 @@
+import { logger, optionalEnv } from "@avg/mcp-common";
+
+import { describeDrift } from "./skills-tree.js";
+import { syncSkills } from "./skills-sync.js";
+
+/**
+ * One-shot: copy `hermes/skills/**` from the git checkout into the skills
+ * volume, so the repo genuinely is the source of truth for what the running
+ * agent loads.
+ *
+ * Runs before Hermes starts (the `skills-sync` service in ops/compose.yml gates
+ * it) and again on every deploy (ops/deploy-monitor.sh). Until this existed the
+ * volume copy was placed by hand: merging a SKILL.md change did nothing, and
+ * one skill sat unreachable for weeks with no error and no signal, which
+ * produced a wrong production answer.
+ *
+ * The copying rules — never delete, verify afterwards — live in skills-sync.ts.
+ * This file is the environment, the log lines and the exit code.
+ */
+
+const repoDir = optionalEnv("REPO_SKILLS_DIR", "/repo-skills");
+const volumeDir = optionalEnv("HERMES_SKILLS_DIR", "/opt/data/skills");
+
+const UID_REMEDIATION =
+  "Hermes owns the skills volume as UID 10000 and secures it to mode 0700, so the writer must " +
+  'run as user "10000:10000" (see the skills-sync service in ops/compose.yml).';
+
+logger.info({ repoDir, volumeDir }, "skills_sync_starting");
+
+const result = await syncSkills({ repoDir, volumeDir });
+
+switch (result.status) {
+  case "repo-unreadable":
+    logger.error(
+      { err: result.error, repoDir },
+      "skills_sync_repo_unreadable: cannot read the repo skill tree. It is bind-mounted from the " +
+        "git checkout (../hermes/skills); check that mount before trusting the volume copy."
+    );
+    process.exitCode = 1;
+    break;
+
+  case "volume-unreadable":
+    logger.error(
+      { err: result.error, volumeDir, synced: result.synced },
+      "skills_sync_volume_unreadable: could not read the skills volume, so whether it matches " +
+        `the repo is unknown — this run cannot claim a sync. ${UID_REMEDIATION}`
+    );
+    process.exitCode = 1;
+    break;
+
+  case "repo-empty":
+    logger.error(
+      { repoDir },
+      "skills_sync_repo_empty: the repo skill tree has no files. Refusing to report a sync that " +
+        "copied nothing — check the ../hermes/skills bind mount."
+    );
+    process.exitCode = 1;
+    break;
+
+  case "current":
+    logger.info({ volumeDir }, "skills_sync_already_current");
+    break;
+
+  case "synced":
+    // Failures are still worth naming even though the volume verified clean:
+    // they are how a permissions problem shows up before it starts mattering.
+    logger.info(
+      { synced: result.synced, failures: result.failures },
+      "skills_sync_complete"
+    );
+    break;
+
+  case "incomplete":
+    logger.error(
+      { failures: result.failures, missing: result.drift.missing, modified: result.drift.modified },
+      `skills_sync_incomplete: ${describeDrift(result.drift)}. ${UID_REMEDIATION} Hermes is gated ` +
+        "on this step so it cannot boot onto a stale skill tree; to start it anyway use " +
+        "`docker compose -p avg up -d --no-deps hermes`."
+    );
+    process.exitCode = 1;
+    break;
+}

--- a/test/unit/skills-drift-alert.test.ts
+++ b/test/unit/skills-drift-alert.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decideDriftAlert,
+  initialDriftAlertState,
+  type DriftObservation
+} from "../../services/skills-observer/src/drift-alert.js";
+
+const CLEAN: DriftObservation = { kind: "in-sync" };
+const DOWN: DriftObservation = { kind: "unavailable" };
+const DRIFT_A: DriftObservation = {
+  kind: "drifted",
+  signature: "missing:ops/a/SKILL.md|modified:"
+};
+const DRIFT_B: DriftObservation = {
+  kind: "drifted",
+  signature: "missing:ops/a/SKILL.md,ops/b/SKILL.md|modified:"
+};
+
+/** Feed a sequence of observations through the state machine. */
+function run(observations: DriftObservation[]): string[] {
+  let state = initialDriftAlertState;
+  return observations.map((observation) => {
+    const decision = decideDriftAlert(state, observation);
+    state = decision.state;
+    return decision.announce;
+  });
+}
+
+describe("decideDriftAlert", () => {
+  it("stays quiet on the first check, which races skills-sync still copying", () => {
+    expect(run([DRIFT_A])).toEqual(["none"]);
+  });
+
+  it("does not swallow drift that is real: the pass after the first announces it", () => {
+    // The boot suppression must not double as a permanent mute. This is the
+    // whole reason the first check does not record what it saw.
+    expect(run([DRIFT_A, DRIFT_A])).toEqual(["none", "drift"]);
+  });
+
+  it("says nothing when the boot race resolves itself", () => {
+    // Drifted at startup only because the sync had not finished; no alert, and
+    // no "recovered" for a problem that was never announced.
+    expect(run([DRIFT_A, CLEAN])).toEqual(["none", "none"]);
+  });
+
+  it("announces a standing divergence exactly once", () => {
+    expect(run([CLEAN, DRIFT_A, DRIFT_A, DRIFT_A])).toEqual(["none", "drift", "none", "none"]);
+  });
+
+  it("re-announces when the divergence widens to more files", () => {
+    expect(run([CLEAN, DRIFT_A, DRIFT_B])).toEqual(["none", "drift", "drift"]);
+  });
+
+  it("reports recovery only after something was announced", () => {
+    expect(run([CLEAN, DRIFT_A, CLEAN])).toEqual(["none", "drift", "recovery"]);
+    // Never drifted, so there is nothing to say it recovered from.
+    expect(run([CLEAN, CLEAN, CLEAN])).toEqual(["none", "none", "none"]);
+  });
+
+  it("recovers once, not on every subsequent clean check", () => {
+    expect(run([CLEAN, DRIFT_A, CLEAN, CLEAN])).toEqual(["none", "drift", "recovery", "none"]);
+  });
+
+  it("announces again if the same drift returns after a recovery", () => {
+    expect(run([CLEAN, DRIFT_A, CLEAN, DRIFT_A])).toEqual([
+      "none",
+      "drift",
+      "recovery",
+      "drift"
+    ]);
+  });
+});
+
+describe("decideDriftAlert, when the check itself cannot run", () => {
+  it("announces that the check is down — silence would read as 'nothing wrong'", () => {
+    // A drift check that has quietly stopped working reproduces the exact
+    // failure this mechanism exists to end.
+    expect(run([CLEAN, DOWN])).toEqual(["none", "unavailable"]);
+  });
+
+  it("says it once, not on every interval it stays down", () => {
+    expect(run([CLEAN, DOWN, DOWN, DOWN])).toEqual(["none", "unavailable", "none", "none"]);
+  });
+
+  it("stays quiet if the very first check cannot run, then announces on the next", () => {
+    expect(run([DOWN, DOWN])).toEqual(["none", "unavailable"]);
+  });
+
+  it("re-announces drift seen again after the check recovers", () => {
+    // Being unable to look does not confirm the previous verdict, so the alert
+    // must not be suppressed as "already reported".
+    expect(run([CLEAN, DRIFT_A, DOWN, DRIFT_A])).toEqual([
+      "none",
+      "drift",
+      "unavailable",
+      "drift"
+    ]);
+  });
+
+  it("does not claim recovery for a divergence it merely stopped being able to see", () => {
+    // The recovery here closes the "cannot check" alert, and it is backed by an
+    // actual in-sync reading rather than by the drift having been forgotten.
+    expect(run([CLEAN, DRIFT_A, DOWN, CLEAN, CLEAN])).toEqual([
+      "none",
+      "drift",
+      "unavailable",
+      "recovery",
+      "none"
+    ]);
+  });
+
+  it("closes an unavailable alert once the check works again", () => {
+    expect(run([CLEAN, DOWN, CLEAN])).toEqual(["none", "unavailable", "recovery"]);
+  });
+
+  it("does not announce recovery when the check comes back to find real drift", () => {
+    expect(run([CLEAN, DOWN, DRIFT_A])).toEqual(["none", "unavailable", "drift"]);
+  });
+});
+
+describe("initial state", () => {
+  it("treats an in-sync first check as settled without announcing", () => {
+    const decision = decideDriftAlert(initialDriftAlertState, CLEAN);
+    expect(decision.announce).toBe("none");
+    expect(decision.state.settled).toBe(true);
+    expect(decision.state.alerted).toBeUndefined();
+    expect(decision.state.unavailableAnnounced).toBe(false);
+  });
+});

--- a/test/unit/skills-sync.test.ts
+++ b/test/unit/skills-sync.test.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { syncSkills } from "../../services/skills-observer/src/skills-sync.js";
+
+const roots: string[] = [];
+
+// chmod-based tests are meaningless as root, which ignores the mode bits.
+const asRoot = process.getuid?.() === 0;
+
+/** Undo any chmod 0o500 below so the tree can actually be removed. */
+async function restoreModes(dir: string): Promise<void> {
+  await fs.chmod(dir, 0o755).catch(() => undefined);
+  const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (entry.isDirectory()) await restoreModes(path.join(dir, entry.name));
+  }
+}
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await restoreModes(root);
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
+
+async function makeDir(files: Record<string, string> = {}): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "skills-sync-"));
+  roots.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+  }
+  return root;
+}
+
+function read(root: string, relativePath: string): Promise<string> {
+  return fs.readFile(path.join(root, relativePath), "utf8");
+}
+
+describe("syncSkills", () => {
+  it("copies a repo skill into an empty volume, preserving category/name nesting", async () => {
+    const repoDir = await makeDir({ "ops/averray-ops/SKILL.md": "# watching averray" });
+    const volumeDir = await makeDir();
+
+    const result = await syncSkills({ repoDir, volumeDir });
+
+    expect(result.status).toBe("synced");
+    expect(result.synced).toEqual(["ops/averray-ops/SKILL.md"]);
+    // Hermes reads the NAME from the parent dir and the CATEGORY from its
+    // grandparent, so a flattened copy would be discovered as a different skill.
+    expect(await read(volumeDir, "ops/averray-ops/SKILL.md")).toBe("# watching averray");
+  });
+
+  it("overwrites a volume copy that has drifted from the repo", async () => {
+    const repoDir = await makeDir({ "ops/x/SKILL.md": "current" });
+    const volumeDir = await makeDir({ "ops/x/SKILL.md": "edited by hand months ago" });
+
+    const result = await syncSkills({ repoDir, volumeDir });
+
+    expect(result.status).toBe("synced");
+    expect(await read(volumeDir, "ops/x/SKILL.md")).toBe("current");
+  });
+
+  it("never deletes a skill Hermes authored into the volume itself", async () => {
+    const repoDir = await makeDir({ "ops/x/SKILL.md": "from git" });
+    const volumeDir = await makeDir({ "learned/self-heal/SKILL.md": "written by the agent" });
+
+    const result = await syncSkills({ repoDir, volumeDir });
+
+    expect(result.status).toBe("synced");
+    expect(await read(volumeDir, "learned/self-heal/SKILL.md")).toBe("written by the agent");
+  });
+
+  it("writes nothing and reports `current` when the volume already matches", async () => {
+    const repoDir = await makeDir({ "ops/x/SKILL.md": "same" });
+    const volumeDir = await makeDir({ "ops/x/SKILL.md": "same" });
+    const before = (await fs.stat(path.join(volumeDir, "ops/x/SKILL.md"))).mtimeMs;
+
+    const result = await syncSkills({ repoDir, volumeDir });
+
+    expect(result.status).toBe("current");
+    expect(result.synced).toEqual([]);
+    expect((await fs.stat(path.join(volumeDir, "ops/x/SKILL.md"))).mtimeMs).toBe(before);
+  });
+
+  it("copies a skill's supporting files, not just SKILL.md", async () => {
+    const repoDir = await makeDir({
+      "ops/x/SKILL.md": "# x",
+      "ops/x/references/verdicts.md": "| reason | means |"
+    });
+    const volumeDir = await makeDir();
+
+    await syncSkills({ repoDir, volumeDir });
+
+    expect(await read(volumeDir, "ops/x/references/verdicts.md")).toBe("| reason | means |");
+  });
+
+  it("reports repo-unreadable rather than silently syncing nothing when the mount is missing", async () => {
+    const volumeDir = await makeDir();
+
+    const result = await syncSkills({
+      repoDir: path.join(os.tmpdir(), "skills-sync-no-such-mount"),
+      volumeDir
+    });
+
+    expect(result.status).toBe("repo-unreadable");
+    expect(result.synced).toEqual([]);
+  });
+
+  it("treats an empty repo tree as a fault, not as a successful no-op sync", async () => {
+    const result = await syncSkills({ repoDir: await makeDir(), volumeDir: await makeDir() });
+
+    expect(result.status).toBe("repo-empty");
+  });
+
+  it.skipIf(asRoot)("reports volume-unreadable rather than throwing when it cannot be read", async () => {
+    // The documented failure mode: Hermes owns the volume as UID 10000 and
+    // secures it to 0700. An unreadable volume has to arrive as a status with a
+    // remediation, not as an unhandled rejection.
+    const repoDir = await makeDir({ "ops/x/SKILL.md": "from git" });
+    const volumeDir = await makeDir({ "ops/x/SKILL.md": "stale" });
+    await fs.chmod(volumeDir, 0o000);
+
+    const result = await syncSkills({ repoDir, volumeDir });
+
+    expect(result.status).toBe("volume-unreadable");
+    expect(["EACCES", "EPERM"]).toContain(
+      (result.error as NodeJS.ErrnoException | undefined)?.code
+    );
+  });
+
+  it.skipIf(asRoot)("reports incomplete, with the drift, when the volume cannot be written", async () => {
+    const repoDir = await makeDir({ "ops/x/SKILL.md": "from git" });
+    const volumeDir = await makeDir();
+    // Stand in for Hermes having secured the volume against this user.
+    await fs.chmod(volumeDir, 0o500);
+
+    const result = await syncSkills({ repoDir, volumeDir, writeAttempts: 2, writeRetryMs: 0 });
+
+    expect(result.status).toBe("incomplete");
+    expect(result.drift.missing).toEqual(["ops/x/SKILL.md"]);
+    expect(result.failures[0]?.relativePath).toBe("ops/x/SKILL.md");
+    expect(["EACCES", "EPERM"]).toContain(result.failures[0]?.code);
+  });
+
+  it.skipIf(asRoot)("takes its verdict from the resulting tree, not from the writes", async () => {
+    // One destination is writable and one is not, so the run both succeeds and
+    // fails. What it reports has to come from re-reading the volume: the file
+    // that landed is not drift, and the one that did not is — regardless of how
+    // many write calls threw.
+    const repoDir = await makeDir({ "ops/x/SKILL.md": "x-current", "ops/y/SKILL.md": "y-current" });
+    const volumeDir = await makeDir({ "ops/y/SKILL.md": "y-stale" });
+    // The file, not its directory: overwriting an existing entry is governed by
+    // the file's own mode, while creating ops/x needs the directory's.
+    await fs.chmod(path.join(volumeDir, "ops/y/SKILL.md"), 0o400);
+
+    const result = await syncSkills({ repoDir, volumeDir, writeAttempts: 2, writeRetryMs: 0 });
+
+    expect(result.status).toBe("incomplete");
+    expect(result.synced).toEqual(["ops/x/SKILL.md"]);
+    expect(result.drift.missing).toEqual([]);
+    expect(result.drift.modified).toEqual(["ops/y/SKILL.md"]);
+    expect(await read(volumeDir, "ops/x/SKILL.md")).toBe("x-current");
+  });
+});

--- a/test/unit/skills-tree.test.ts
+++ b/test/unit/skills-tree.test.ts
@@ -1,0 +1,178 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  describeDrift,
+  diffSkillTrees,
+  driftSignature,
+  isInSync,
+  readSkillTree,
+  type SkillTree
+} from "../../services/skills-observer/src/skills-tree.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await fs.rm(root, { recursive: true, force: true });
+});
+
+/** Build a throwaway tree from relative path -> content. */
+async function makeTree(files: Record<string, string>): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "skills-tree-"));
+  roots.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(filePath, content);
+  }
+  return root;
+}
+
+function tree(entries: Record<string, string>): SkillTree {
+  return new Map(Object.entries(entries));
+}
+
+describe("readSkillTree", () => {
+  it("keys files by their path relative to the root, preserving the category/name nesting", async () => {
+    const root = await makeTree({
+      "ops/averray-ops/SKILL.md": "# ops",
+      "autonomous-ai-agents/codex/SKILL.md": "# codex"
+    });
+
+    const result = await readSkillTree(root);
+
+    // Hermes takes the skill NAME from the parent dir and the CATEGORY from its
+    // grandparent, so these exact keys are what the sync has to reproduce.
+    expect([...result.keys()].sort()).toEqual([
+      "autonomous-ai-agents/codex/SKILL.md",
+      "ops/averray-ops/SKILL.md"
+    ]);
+  });
+
+  it("hashes content, so identical trees compare equal and any edit shows up", async () => {
+    const a = await readSkillTree(await makeTree({ "ops/x/SKILL.md": "same" }));
+    const b = await readSkillTree(await makeTree({ "ops/x/SKILL.md": "same" }));
+    const c = await readSkillTree(await makeTree({ "ops/x/SKILL.md": "same " }));
+
+    expect(a.get("ops/x/SKILL.md")).toBe(b.get("ops/x/SKILL.md"));
+    expect(a.get("ops/x/SKILL.md")).not.toBe(c.get("ops/x/SKILL.md"));
+  });
+
+  it("carries non-SKILL.md files too, so a skill's supporting files sync with it", async () => {
+    const result = await readSkillTree(
+      await makeTree({ "ops/x/SKILL.md": "# x", "ops/x/references/table.md": "| a |" })
+    );
+
+    expect(result.has("ops/x/references/table.md")).toBe(true);
+  });
+
+  it("skips dot-prefixed entries at every level (the repo side is a working checkout)", async () => {
+    const result = await readSkillTree(
+      await makeTree({
+        "ops/x/SKILL.md": "# x",
+        ".DS_Store": "junk",
+        "ops/.DS_Store": "junk",
+        ".git/config": "[core]"
+      })
+    );
+
+    expect([...result.keys()]).toEqual(["ops/x/SKILL.md"]);
+  });
+
+  it("throws ENOENT for an absent root rather than reporting an empty tree", async () => {
+    // An unmounted directory must not be able to masquerade as "no skills",
+    // which would read as in-sync.
+    await expect(readSkillTree(path.join(os.tmpdir(), "skills-tree-does-not-exist"))).rejects.toMatchObject(
+      { code: "ENOENT" }
+    );
+  });
+});
+
+describe("diffSkillTrees", () => {
+  it("reports a repo file the volume does not have", () => {
+    const drift = diffSkillTrees(tree({ "ops/x/SKILL.md": "aaa" }), tree({}));
+
+    expect(drift.missing).toEqual(["ops/x/SKILL.md"]);
+    expect(drift.modified).toEqual([]);
+    expect(isInSync(drift)).toBe(false);
+  });
+
+  it("reports a repo file the volume has with different content", () => {
+    const drift = diffSkillTrees(
+      tree({ "ops/x/SKILL.md": "aaa" }),
+      tree({ "ops/x/SKILL.md": "bbb" })
+    );
+
+    expect(drift.modified).toEqual(["ops/x/SKILL.md"]);
+    expect(drift.missing).toEqual([]);
+  });
+
+  it("does NOT report a volume-only file — Hermes authors its own skills there", () => {
+    const drift = diffSkillTrees(
+      tree({ "ops/x/SKILL.md": "aaa" }),
+      tree({ "ops/x/SKILL.md": "aaa", "learned/self-heal/SKILL.md": "written by the agent" })
+    );
+
+    expect(isInSync(drift)).toBe(true);
+    expect(drift.missing).toEqual([]);
+    expect(drift.modified).toEqual([]);
+  });
+
+  it("is in sync when every repo path matches", () => {
+    const both = { "ops/x/SKILL.md": "aaa", "ops/y/SKILL.md": "bbb" };
+    expect(isInSync(diffSkillTrees(tree(both), tree(both)))).toBe(true);
+  });
+
+  it("sorts each list so the signature is stable across walk order", () => {
+    const drift = diffSkillTrees(
+      tree({ "b/x/SKILL.md": "1", "a/x/SKILL.md": "2" }),
+      tree({})
+    );
+    const reordered = diffSkillTrees(
+      tree({ "a/x/SKILL.md": "2", "b/x/SKILL.md": "1" }),
+      tree({})
+    );
+
+    expect(drift.missing).toEqual(["a/x/SKILL.md", "b/x/SKILL.md"]);
+    expect(driftSignature(drift)).toBe(driftSignature(reordered));
+  });
+});
+
+describe("driftSignature", () => {
+  it("distinguishes a missing file from a modified one at the same path", () => {
+    const missing = diffSkillTrees(tree({ "ops/x/SKILL.md": "aaa" }), tree({}));
+    const modified = diffSkillTrees(
+      tree({ "ops/x/SKILL.md": "aaa" }),
+      tree({ "ops/x/SKILL.md": "bbb" })
+    );
+
+    expect(driftSignature(missing)).not.toBe(driftSignature(modified));
+  });
+
+  it("changes when a further file drifts, so a widening problem is re-announced", () => {
+    const one = diffSkillTrees(tree({ "a/x/SKILL.md": "1" }), tree({}));
+    const two = diffSkillTrees(tree({ "a/x/SKILL.md": "1", "b/x/SKILL.md": "2" }), tree({}));
+
+    expect(driftSignature(one)).not.toBe(driftSignature(two));
+  });
+});
+
+describe("describeDrift", () => {
+  it("names the files rather than only counting them", () => {
+    const drift = diffSkillTrees(
+      tree({ "ops/x/SKILL.md": "aaa", "ops/y/SKILL.md": "bbb" }),
+      tree({ "ops/y/SKILL.md": "changed" })
+    );
+
+    expect(describeDrift(drift)).toContain("ops/x/SKILL.md");
+    expect(describeDrift(drift)).toContain("ops/y/SKILL.md");
+    expect(describeDrift(drift)).toMatch(/missing from the volume/);
+    expect(describeDrift(drift)).toMatch(/changed in the volume/);
+  });
+
+  it("states a match plainly when there is no drift", () => {
+    expect(describeDrift({ missing: [], modified: [] })).toBe("the skills volume matches the repo");
+  });
+});


### PR DESCRIPTION
## The problem

`hermes/skills/**` is documented as the source of truth for what Hermes loads — the header of [`hermes/skills/ops/averray-ops/SKILL.md`](hermes/skills/ops/averray-ops/SKILL.md) says so — but nothing copied it into the `avg-hermes-skills` volume mounted at `/opt/data/skills` (`ops/compose.yml`, `ops/compose.command-center.yml`). The live copy was placed by hand.

So merging a change to a SKILL.md had **no effect on the running agent**, and the volume copy could diverge from git with no error and no signal. That already cost a wrong production answer once: a skill sat unreachable for weeks in a misnamed location and nothing surfaced it.

## The sync

A one-shot `skills-sync` service copies the repo tree in. Four properties are load-bearing:

- **Runs as `10000:10000`** — the only user that can write once Hermes has secured the volume to 0700, the same constraint that shaped `skills-observer` (#464). Writes that lose that race are retried.
- **Verifies, then reports.** The exit code comes from re-reading the tree afterwards, not from whether every write succeeded. A write that failed on an already-correct file is not a failure; a tree that cannot be re-read is not a sync.
- **Never deletes.** Hermes authors its own skills into this volume at runtime — that is what `skills-observer` watches for — so mirroring the repo would destroy the agent's own work. Only repo-managed paths are written.
- **Structure verbatim.** Hermes discovers skills with `rglob("SKILL.md")` and takes the name from the parent directory and the category from the grandparent, so `ops/averray-ops/SKILL.md` has to land at exactly that path.

`hermes` and `hermes-gateway` are gated on it completing, so the agent cannot boot onto a stale tree. A failed sync holds back only Hermes — the ops board does not depend on it — and `up -d --no-deps hermes` is the escape hatch.

`ops/deploy-monitor.sh` runs it on **every** deploy, because a monitor deploy does not restart Hermes, so the compose gate alone would fire days late or never. This is the same lesson the script's own header already tells about `GIT_SHA`: a correctness-critical step must not depend on an operator remembering to type it. There it is **advisory** — the board reads none of these files, and failing that deploy over a skill copy is the coupling #657 deliberately removed. It is pinned `--no-deps` so it cannot pull in `hermes-permissions` and re-open `/opt/data` to 0777 as a side effect of deploying the board.

## The drift check

Detection stays in `skills-observer` rather than moving into the sync. Drift is a standing condition, not a boot step, and that service is already the long-running reader of the volume — it holds the right UID, the Slack route, and a read-only view. It gains a read-only mount of the repo tree and compares them on a timer, writing to neither.

The sync is the wrong home for it: it exits, and gating the observer on it would disable the reporter exactly when the sync is failing.

## Three ways the new reporting would have lied

Caught reviewing the change against the repo's truth-boundary rule:

- The sync's own writes would have been announced to Slack as *"Hermes wrote or updated a skill"* — agent behaviour that never happened. Origin is now classified against the repo copy, and "cannot read the repo" is `unknown`, not `agent`; otherwise a broken mount reports every file the sync just copied as the agent having written it.
- The observer starts alongside the sync, so its first look can catch the volume mid-copy. The first pass only observes — and records nothing, so drift that is real is still announced on the next pass rather than swallowed as unchanged.
- A check that cannot run establishes nothing about whether the trees match, and silence on a notification channel reads as "nothing wrong" — the exact failure this PR removes. An unavailable check is announced, once.

Also: an ingest failure no longer kills the process. It shares this process with the drift check now, and a restart resets the check's state machine, whose first pass only observes — a fast enough crash loop would never reach a pass that announces, and drift would go unreported while looking merely flaky.

## Verification

- 2248 unit tests pass (44 new, across the tree walk, the sync, and the alert state machine); full `typecheck` clean.
- Compose renders as intended: `skills-sync` at `user: 10000:10000` with the repo mount read-only and the volume read-write; `skills-observer` still read-only on both; `hermes` and `hermes-gateway` both gated on `service_completed_successfully`.
- Ran end-to-end against the real tree: lands `ops/averray-ops/SKILL.md` byte-identically at the right path, idempotent on re-run, repairs a hand-edited stale copy while leaving an agent-authored `learned/self-heal/SKILL.md` untouched, after which the observer reports no drift.
- Exit codes walked: missing repo mount, empty repo tree, and unreadable volume each exit 1 with their own remediation; happy path and already-current exit 0.
- Drift path walked live: a stale volume copy is named in the log with the command to fix it, and the observer survives a Postgres outage instead of exiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)