### PR TITLE
feat(buzz): answer operator questions in #Ops, without talking to ourselves

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -412,6 +412,26 @@ services:
       BUZZ_AGENT_SECRET_KEY: ${BUZZ_AGENT_SECRET_KEY:-}
       BUZZ_OWNER_AUTH_TAG: ${BUZZ_OWNER_AUTH_TAG:-}
       BUZZ_OPS_CHANNEL_ID: ${BUZZ_OPS_CHANNEL_ID:-}
+      # Buzz INBOUND — answering questions in #Ops. Default OFF, and separate
+      # from the four above on purpose: publishing narration is safe, while
+      # listening hands an LLM turn to whatever is typed in the channel.
+      #
+      # The prompt tells Hermes to answer rather than act, but that is guidance,
+      # not enforcement — the session carries its own MCP tools. What actually
+      # bounds this is that the relay is closed and the channel has ONE member,
+      # so the only person who can ask is the operator. If Buzz ever gains
+      # members, this needs tool-level scoping before it goes back on.
+      #
+      # It refuses to open a socket unless HERMES_SESSION_API_ENABLED and the
+      # gateway credentials are also set: a listener that cannot answer would
+      # report the same configuration problem once per question.
+      BUZZ_INBOUND_ENABLED: ${BUZZ_INBOUND_ENABLED:-}
+      # Answer only messages naming the agent. Off is right for a private
+      # one-member channel; turn it on the moment anyone else joins.
+      BUZZ_INBOUND_REQUIRE_MENTION: ${BUZZ_INBOUND_REQUIRE_MENTION:-}
+      # Backstop for a loop the self-pubkey check somehow fails to catch.
+      # Bounds the blast radius to a known number of messages, not a runaway.
+      BUZZ_INBOUND_MAX_REPLIES_PER_HOUR: ${BUZZ_INBOUND_MAX_REPLIES_PER_HOUR:-}
       # Monitor snapshots fan out across open PRs and their check runs. Keep the
       # timeout operator-tunable; the live mainnet calibration raises it from the
       # conservative generic default without changing testnet behaviour.

--- a/services/slack-operator/src/buzz-inbound-start.ts
+++ b/services/slack-operator/src/buzz-inbound-start.ts
@@ -1,0 +1,150 @@
+// Wiring: turn config into a running listener, or say precisely why not.
+//
+// Kept out of index.ts because the interesting part is the REFUSALS. Three
+// separate things must be true before this can answer a question — Buzz
+// credentials, the inbound switch, and a reachable agent gateway — and each
+// missing one produces a different operator action. Collapsing them into "not
+// started" would hide which.
+//
+// ── A LISTENER THAT CANNOT ANSWER MUST NOT LISTEN ───────────────────────────
+//
+// If the Hermes gateway is not configured, this refuses to open the socket at
+// all rather than connecting and failing per question. A channel where every
+// question gets an error reply is worse than one that was never claimed to
+// work: the operator would be told, message by message, about a configuration
+// problem that is the same problem every time.
+//
+// ── ON THE READ-ONLY BOUNDARY, HONESTLY ─────────────────────────────────────
+//
+// The prompt tells Hermes to answer rather than act. That is GUIDANCE, not
+// enforcement — the session carries whatever MCP tools it has, and some of them
+// mutate. What actually bounds the blast radius is that the relay is closed
+// (`BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`) and the channel has one member, so the
+// only person who can ask anything is the operator who could run those tools
+// directly. That is an acceptable boundary for a private ops channel and NOT an
+// acceptable one for a shared or public channel. If Buzz ever gains members,
+// this needs tool-level scoping before it stays on.
+//
+// Default OFF for exactly that reason.
+
+import { logger } from "@avg/mcp-common";
+
+import { publishNarration, readBuzzConfig, type BuzzConfig } from "./buzz-client.js";
+import { agentPubkey } from "./buzz-event.js";
+import {
+  DEFAULT_MAX_REPLIES_PER_WINDOW,
+  DEFAULT_MENTION_NAMES,
+  DEFAULT_RATE_WINDOW_MS,
+  buildInboundPrompt,
+} from "./buzz-inbound.js";
+import { BuzzResponder } from "./buzz-responder.js";
+import { subscribeToBuzz, type BuzzSubscription, type ListenerState } from "./buzz-subscribe.js";
+import { chatWithHermesSession } from "./hermes-session-client.js";
+import { resolveHermesSessionConfig } from "./monitor-hermes-voice.js";
+
+function isOn(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test((value ?? "").trim());
+}
+
+export interface InboundStartResult {
+  started: boolean;
+  /** Why it did or did not start. Always set, always operator-facing. */
+  reason: string;
+  subscription?: BuzzSubscription;
+  responder?: BuzzResponder;
+}
+
+/**
+ * Start the inbound listener if everything it needs is present.
+ *
+ * Returns rather than throws: the monitor's job is watching the money path, and
+ * a chat feature failing to start must never be the reason it does not run.
+ */
+export function startBuzzInbound(env: NodeJS.ProcessEnv = process.env): InboundStartResult {
+  if (!isOn(env.BUZZ_INBOUND_ENABLED)) {
+    return { started: false, reason: "BUZZ_INBOUND_ENABLED is not set — inbound replies are off" };
+  }
+
+  const buzz = readBuzzConfig(env);
+  if (!buzz.config) {
+    return {
+      started: false,
+      reason: buzz.problem ?? "Buzz is not configured — no relay credentials",
+    };
+  }
+
+  const session = resolveHermesSessionConfig(env);
+  if (!session) {
+    // The refusal that matters most. See the header: connecting without a way
+    // to answer turns one configuration problem into one error per question.
+    return {
+      started: false,
+      reason:
+        "the Hermes gateway is not configured (HERMES_SESSION_API_ENABLED / HERMES_API_URL / HERMES_API_TOKEN) — "
+        + "refusing to listen for questions that could not be answered",
+    };
+  }
+
+  let pubkey: string;
+  try {
+    pubkey = agentPubkey(buzz.config.agentSecretKeyHex);
+  } catch (error) {
+    return { started: false, reason: error instanceof Error ? error.message : String(error) };
+  }
+
+  const maxPerHour = Number(env.BUZZ_INBOUND_MAX_REPLIES_PER_HOUR);
+  const startedAtSeconds = Math.floor(Date.now() / 1000);
+
+  // One session across questions, so a follow-up like "and solvency?" means
+  // what the operator intends. Reset on failure by simply not updating the id.
+  let sessionId: string | undefined;
+
+  const responder = new BuzzResponder(
+    {
+      agentPubkey: pubkey,
+      channelId: buzz.config.channelId,
+      startedAtSeconds,
+      maxRepliesPerWindow:
+        Number.isFinite(maxPerHour) && maxPerHour > 0 ? maxPerHour : DEFAULT_MAX_REPLIES_PER_WINDOW,
+      rateWindowMs: DEFAULT_RATE_WINDOW_MS,
+      requireMention: isOn(env.BUZZ_INBOUND_REQUIRE_MENTION),
+      mentionNames: DEFAULT_MENTION_NAMES,
+      enabled: true,
+    },
+    {
+      ask: async (question) => {
+        const turn = await chatWithHermesSession(session, buildInboundPrompt(question), sessionId);
+        if (!turn) return null;
+        sessionId = turn.sessionId;
+        return turn.text;
+      },
+      publish: async (text) => {
+        const result = await publishNarration(buzz.config as BuzzConfig, text);
+        return { ok: result.ok, detail: result.detail };
+      },
+      log: (line) => logger.info({ line }, "buzz_inbound"),
+    },
+  );
+
+  const subscription = subscribeToBuzz(
+    buzz.config,
+    {
+      onMessage: (event) => responder.handle(event),
+      onState: (state: ListenerState) => {
+        // Phase changes are rare and each one is operationally meaningful, so
+        // all of them are logged. A listener that is retrying looks exactly
+        // like a channel nobody has posted in; the log is where that difference
+        // is visible until the board carries the row.
+        logger.info({ phase: state.phase, detail: state.detail, failures: state.failures }, "buzz_listener");
+      },
+    },
+    { sinceSeconds: startedAtSeconds },
+  );
+
+  return {
+    started: true,
+    reason: `listening on ${buzz.config.relayUrl} for channel ${buzz.config.channelId}`,
+    subscription,
+    responder,
+  };
+}

--- a/services/slack-operator/src/buzz-inbound.ts
+++ b/services/slack-operator/src/buzz-inbound.ts
@@ -1,0 +1,266 @@
+// Deciding whether to answer a message in #Ops — the pure half of the inbound
+// seam. No sockets, no clock, no LLM: every rule that could let this thing talk
+// to itself is a function of its arguments, and therefore cheap to test.
+//
+// ── WHY THE RULES LIVE HERE AND NOT IN THE TRANSPORT ────────────────────────
+//
+// Until now Buzz has been publish-only, and the worst failure available to it
+// was silence. Listening changes the risk completely: a bot that answers
+// messages in a channel it also posts to can answer itself, and each answer is
+// another message to answer. That loop runs at socket speed against a live
+// money system, costs model spend per turn, and buries the one channel an
+// operator is supposed to be able to trust at 3am.
+//
+// So the loop guard is not a line in a callback. It is the first rule in a pure
+// function with a name, a reason, and a test that fails without it.
+//
+// ── THE GUARDS, AND WHAT EACH ONE IS FOR ────────────────────────────────────
+//
+//  · SELF — an event authored by our own key is never answered. Both the
+//    narration publisher and this listener use one agent key, so this single
+//    check also covers a second instance of the monitor started by accident:
+//    it would post under the same pubkey and be ignored rather than argued with.
+//  · REPLAY — the relay may hand us stored events on connect, and does hand
+//    them to us again after a reconnect. Answering those means every restart
+//    re-answers the last question, which is the exact shape of the duplicate
+//    #Ops alerts that reached production once already (see probe-transitions).
+//    Anything older than this process is history, not a question.
+//  · SEEN — the same event id arriving twice is one question, not two.
+//  · RATE — a bounded number of answers per window. This is the guard for the
+//    loop we did NOT think of: if some future path defeats the self check, the
+//    blast radius is a known small number of messages rather than a runaway.
+//
+// None of these overlap by accident. Each covers a way the previous one can be
+// wrong, which is the point.
+
+import { KIND_STREAM_MESSAGE, MAX_CONTENT_BYTES } from "./buzz-event.js";
+
+/** Why a message was or was not answered. Every value is operator-facing. */
+export type InboundVerdict =
+  | "answer"
+  | "ignore-disabled"
+  | "ignore-kind"
+  | "ignore-channel"
+  | "ignore-self"
+  | "ignore-replay"
+  | "ignore-seen"
+  | "ignore-empty"
+  | "ignore-not-addressed"
+  | "ignore-rate-limited";
+
+/** The parts of a Nostr event this decision needs. Deliberately minimal. */
+export interface InboundEvent {
+  id: string;
+  pubkey: string;
+  kind: number;
+  tags: string[][];
+  content: string;
+  created_at: number;
+}
+
+export interface InboundContext {
+  /** Our own x-only pubkey. The loop guard compares against this. */
+  agentPubkey: string;
+  /** The #Ops channel UUID; messages tagged for anywhere else are not ours. */
+  channelId: string;
+  /** Unix seconds this process began listening. Older events are history. */
+  startedAtSeconds: number;
+  /** Event ids already handled, so a redelivery is not a second question. */
+  seenEventIds: ReadonlySet<string>;
+  /** Answers already sent in the current rate window. */
+  repliesInWindow: number;
+  maxRepliesPerWindow: number;
+  /** When true, only messages naming the agent are answered. */
+  requireMention: boolean;
+  /** Lowercase names that count as addressing the agent. */
+  mentionNames: readonly string[];
+  enabled: boolean;
+}
+
+export interface InboundDecision {
+  verdict: InboundVerdict;
+  /** One sentence, safe to log. Never contains message content verbatim. */
+  detail: string;
+  /** The question to ask Hermes. Present only when verdict is "answer". */
+  question?: string;
+}
+
+export const DEFAULT_MAX_REPLIES_PER_WINDOW = 30;
+export const DEFAULT_RATE_WINDOW_MS = 60 * 60 * 1000;
+
+/** Names that count as addressing the agent when `requireMention` is on. */
+export const DEFAULT_MENTION_NAMES = ["hermes", "@hermes"] as const;
+
+function channelOf(event: InboundEvent): string | null {
+  for (const tag of event.tags) {
+    if (tag[0] === "h" && typeof tag[1] === "string") return tag[1];
+  }
+  return null;
+}
+
+function isAddressed(content: string, names: readonly string[]): boolean {
+  const lower = content.toLowerCase();
+  return names.some((name) => lower.includes(name.toLowerCase()));
+}
+
+/**
+ * Strip a leading mention so Hermes receives the question rather than its own
+ * name. "@hermes is the money path ok?" asks better than the raw string, and a
+ * model given its own name as the first token sometimes answers about itself.
+ */
+function stripLeadingMention(content: string, names: readonly string[]): string {
+  let text = content.trim();
+  for (const name of [...names].sort((a, b) => b.length - a.length)) {
+    const pattern = new RegExp(`^${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b[\\s,:]*`, "i");
+    if (pattern.test(text)) {
+      text = text.replace(pattern, "").trim();
+      break;
+    }
+  }
+  return text;
+}
+
+/**
+ * Decide what to do with one inbound event.
+ *
+ * Order is deliberate. Cheap structural checks come first so a busy channel
+ * costs nothing, the self check sits ahead of everything that could produce a
+ * reply, and the rate limit is evaluated LAST so it counts only messages that
+ * would genuinely have been answered — a window burned by our own narration
+ * would disarm the guard exactly when it was needed.
+ */
+export function decideInboundMessage(event: InboundEvent, ctx: InboundContext): InboundDecision {
+  if (!ctx.enabled) {
+    return { verdict: "ignore-disabled", detail: "inbound replies are switched off" };
+  }
+  if (event.kind !== KIND_STREAM_MESSAGE) {
+    return { verdict: "ignore-kind", detail: `kind ${event.kind} is not a channel message` };
+  }
+
+  const channel = channelOf(event);
+  if (channel !== ctx.channelId) {
+    return {
+      verdict: "ignore-channel",
+      detail: channel ? "message is tagged for a different channel" : "message carries no channel tag",
+    };
+  }
+
+  // THE LOOP GUARD. Everything else is housekeeping; this is the one that keeps
+  // the agent from talking to itself at socket speed.
+  if (event.pubkey === ctx.agentPubkey) {
+    return { verdict: "ignore-self", detail: "message was published by this agent" };
+  }
+
+  // History, not a question. The relay replays stored events on connect and
+  // again after every reconnect; answering them re-answers the last question on
+  // each restart.
+  if (event.created_at < ctx.startedAtSeconds) {
+    return {
+      verdict: "ignore-replay",
+      detail: `message predates this listener by ${ctx.startedAtSeconds - event.created_at}s`,
+    };
+  }
+
+  if (ctx.seenEventIds.has(event.id)) {
+    return { verdict: "ignore-seen", detail: "this event id was already handled" };
+  }
+
+  const trimmed = event.content.trim();
+  if (trimmed.length === 0) {
+    return { verdict: "ignore-empty", detail: "message has no text" };
+  }
+
+  if (ctx.requireMention && !isAddressed(trimmed, ctx.mentionNames)) {
+    return { verdict: "ignore-not-addressed", detail: "message does not name the agent" };
+  }
+
+  if (ctx.repliesInWindow >= ctx.maxRepliesPerWindow) {
+    return {
+      verdict: "ignore-rate-limited",
+      detail: `already sent ${ctx.repliesInWindow} replies in this window (max ${ctx.maxRepliesPerWindow})`,
+    };
+  }
+
+  const question = ctx.requireMention ? stripLeadingMention(trimmed, ctx.mentionNames) : trimmed;
+  if (question.length === 0) {
+    // A message that was ONLY a mention. Nothing was asked.
+    return { verdict: "ignore-empty", detail: "message named the agent but asked nothing" };
+  }
+
+  return { verdict: "answer", detail: "operator question in the ops channel", question };
+}
+
+/**
+ * What Hermes is told before the operator's question.
+ *
+ * The session already IS Hermes — its own system prompt, tools, skills and
+ * memory. This adds only what is specific to answering in a chat channel:
+ *
+ *  · Check the board. The whole point of the read seam is that current state
+ *    comes from `averray_board_health`, not from the model's memory of an
+ *    earlier reading.
+ *  · Say UNKNOWN when the board cannot be reached. Silence and confident
+ *    guessing are the two failure modes that make an ops channel worthless.
+ *  · Answer, do not act. This is guidance, not enforcement — see the note on
+ *    the wiring. It matters anyway: most of the risk here is a well-meaning
+ *    agent deciding a question implies a fix.
+ *  · Be short. This renders in a chat client, frequently on a phone, and an
+ *    answer nobody scrolls through is an answer nobody reads.
+ */
+export const INBOUND_PREAMBLE = [
+  "You are answering the operator in the Averray #Ops channel.",
+  "",
+  "- Anything about current state must come from the ops board, not from memory of an earlier reading. Check it.",
+  "- If the board cannot be reached, say the state is UNKNOWN. Never infer health from silence.",
+  "- Answer the question. Do not take actions, move funds, deploy, or change configuration; you cannot, and claiming otherwise is worse than declining.",
+  "- Keep it short — a few lines. This is read in a chat client, often on a phone.",
+  "",
+  "The operator asks:",
+].join("\n");
+
+export function buildInboundPrompt(question: string): string {
+  return `${INBOUND_PREAMBLE}\n\n${question}`;
+}
+
+/**
+ * Practical cap for a chat message, far below the relay's 64 KiB limit.
+ *
+ * The limit that bites is the reader's, not the protocol's: an ops answer that
+ * fills a phone screen is one nobody finishes.
+ */
+export const MAX_REPLY_CHARS = 3500;
+
+/**
+ * Prepare a reply for publication.
+ *
+ * Returns null when there is nothing to say, so the caller can publish an
+ * honest failure line instead of an empty message — `buildStreamMessage`
+ * refuses empty content, and an unexplained silence in an ops channel reads as
+ * the bot ignoring you rather than as a broken turn.
+ */
+export function formatReplyForBuzz(text: string | null | undefined): string | null {
+  const trimmed = (text ?? "").trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length <= MAX_REPLY_CHARS) return trimmed;
+  // Truncation is marked, never silent. A cut-off ops answer that looks
+  // complete is a way to be confidently wrong.
+  const kept = trimmed.slice(0, MAX_REPLY_CHARS);
+  return `${kept}\n\n… (truncated — ask for the specific part you need)`;
+}
+
+/**
+ * The line published when the turn produced no answer.
+ *
+ * A failed turn MUST say something. The alternative is silence, which is
+ * indistinguishable from the listener being down — and the entire reason this
+ * channel exists is to be the thing you can still trust when other things are
+ * broken.
+ */
+export function describeInboundFailure(reason: string): string {
+  return `⚠ I could not answer that — ${reason}. The question was received; this is a failure on my side, not a verdict about the system.`;
+}
+
+/** Guard against a reply that somehow exceeds the protocol limit. */
+export function replyFitsRelay(text: string): boolean {
+  return Buffer.byteLength(text, "utf8") <= MAX_CONTENT_BYTES;
+}

--- a/services/slack-operator/src/buzz-responder.ts
+++ b/services/slack-operator/src/buzz-responder.ts
@@ -1,0 +1,202 @@
+// The runtime half of the inbound seam: hold the state the pure decision needs,
+// and turn an "answer" verdict into exactly one published reply.
+//
+// Everything stateful about listening lives here so `buzz-inbound.ts` can stay
+// a function of its arguments — the seen-id set, the rolling rate window, and
+// the promise chain that keeps two questions from being answered at once.
+//
+// ── WHY TURNS ARE SERIALIZED ────────────────────────────────────────────────
+//
+// An agent turn costs money and takes tens of seconds. Two arriving together
+// would run concurrently, interleave their replies in the channel, and double
+// the spend for a question the operator asked once and rephrased. A queue of
+// one, with the rest dropped and logged, keeps the cost bounded and the thread
+// readable. Dropping is honest here because the dropped message is nearly
+// always the same question typed again.
+//
+// ── WHY A FAILED TURN STILL SPEAKS ──────────────────────────────────────────
+//
+// If the agent cannot answer, the channel says so. The alternative is silence,
+// which is indistinguishable from the listener being down — and this is the
+// channel whose entire purpose is to be trustworthy when other things are not.
+// The failure line is careful to be a statement about US, never about the
+// system: "I could not answer" must not read as "everything is fine".
+
+import {
+  decideInboundMessage,
+  describeInboundFailure,
+  formatReplyForBuzz,
+  type InboundContext,
+  type InboundDecision,
+  type InboundEvent,
+} from "./buzz-inbound.js";
+
+export interface ResponderDeps {
+  /** Ask the agent. Returns its answer, or null if the turn produced nothing. */
+  ask: (question: string) => Promise<string | null>;
+  /** Publish a reply to the channel. */
+  publish: (text: string) => Promise<{ ok: boolean; detail: string }>;
+  nowMs?: () => number;
+  log?: (line: string) => void;
+}
+
+export interface ResponderConfig {
+  agentPubkey: string;
+  channelId: string;
+  startedAtSeconds: number;
+  maxRepliesPerWindow: number;
+  rateWindowMs: number;
+  requireMention: boolean;
+  mentionNames: readonly string[];
+  enabled: boolean;
+}
+
+/**
+ * Bounded so a long-running process cannot grow this without limit. The set
+ * only has to outlive a relay's redelivery window, which is seconds.
+ */
+export const MAX_SEEN_IDS = 500;
+
+export interface ResponderStats {
+  answered: number;
+  failed: number;
+  ignored: number;
+  dropped: number;
+  /** Verdict of the most recent decision, for the board and for debugging. */
+  lastVerdict: InboundDecision["verdict"] | null;
+  busy: boolean;
+}
+
+export class BuzzResponder {
+  private readonly seenIds = new Set<string>();
+  private readonly seenOrder: string[] = [];
+  /** Timestamps of published replies, newest last. Rolling window. */
+  private readonly replyTimes: number[] = [];
+  private queued = 0;
+  private chain: Promise<void> = Promise.resolve();
+  private stats: ResponderStats = {
+    answered: 0, failed: 0, ignored: 0, dropped: 0, lastVerdict: null, busy: false,
+  };
+
+  constructor(
+    private readonly config: ResponderConfig,
+    private readonly deps: ResponderDeps,
+  ) {}
+
+  snapshot(): ResponderStats {
+    return { ...this.stats };
+  }
+
+  private now(): number {
+    return this.deps.nowMs?.() ?? Date.now();
+  }
+
+  private log(line: string): void {
+    this.deps.log?.(line);
+  }
+
+  /** Drop reply timestamps that have aged out of the window. */
+  private repliesInWindow(): number {
+    const cutoff = this.now() - this.config.rateWindowMs;
+    while (this.replyTimes.length > 0 && this.replyTimes[0]! < cutoff) this.replyTimes.shift();
+    return this.replyTimes.length;
+  }
+
+  private remember(id: string): void {
+    if (this.seenIds.has(id)) return;
+    this.seenIds.add(id);
+    this.seenOrder.push(id);
+    while (this.seenOrder.length > MAX_SEEN_IDS) {
+      const evicted = this.seenOrder.shift();
+      if (evicted !== undefined) this.seenIds.delete(evicted);
+    }
+  }
+
+  private context(): InboundContext {
+    return {
+      agentPubkey: this.config.agentPubkey,
+      channelId: this.config.channelId,
+      startedAtSeconds: this.config.startedAtSeconds,
+      seenEventIds: this.seenIds,
+      repliesInWindow: this.repliesInWindow(),
+      maxRepliesPerWindow: this.config.maxRepliesPerWindow,
+      requireMention: this.config.requireMention,
+      mentionNames: this.config.mentionNames,
+      enabled: this.config.enabled,
+    };
+  }
+
+  /**
+   * Handle one inbound event. Never throws and never blocks the socket.
+   *
+   * The event id is recorded BEFORE the turn runs, not after. A turn takes
+   * tens of seconds, and a relay redelivery arriving mid-turn would otherwise
+   * pass the seen check and start a second identical answer.
+   */
+  handle(event: InboundEvent): void {
+    const decision = decideInboundMessage(event, this.context());
+    this.stats.lastVerdict = decision.verdict;
+
+    if (decision.verdict !== "answer") {
+      this.stats.ignored += 1;
+      // Self-messages are the overwhelming majority in a channel we also post
+      // to; logging each one would bury everything else.
+      if (decision.verdict !== "ignore-self" && decision.verdict !== "ignore-disabled") {
+        this.log(`buzz inbound: ${decision.verdict} — ${decision.detail}`);
+      }
+      return;
+    }
+
+    if (this.queued > 0) {
+      this.stats.dropped += 1;
+      this.log(`buzz inbound: dropped a question while one was already running`);
+      return;
+    }
+
+    this.remember(event.id);
+    this.queued += 1;
+    this.stats.busy = true;
+    const question = decision.question!;
+
+    this.chain = this.chain
+      .then(() => this.runTurn(question))
+      .catch(() => {
+        // runTurn already converts failures into a published line; this is the
+        // last resort so the chain itself can never break.
+      })
+      .finally(() => {
+        this.queued -= 1;
+        this.stats.busy = this.queued > 0;
+      });
+  }
+
+  private async runTurn(question: string): Promise<void> {
+    let answer: string | null = null;
+    let failure: string | null = null;
+
+    try {
+      answer = await this.deps.ask(question);
+    } catch (error) {
+      failure = error instanceof Error ? error.message : String(error);
+    }
+
+    const text = formatReplyForBuzz(answer);
+    // A turn that returns nothing is a failure with a specific cause, not an
+    // empty answer. Naming it keeps "the agent is unreachable" distinct from
+    // "the agent had nothing to say", which are different problems.
+    const line = text ?? describeInboundFailure(failure ?? "the agent returned an empty answer");
+
+    const result = await this.deps.publish(line);
+    if (result.ok) {
+      this.replyTimes.push(this.now());
+      if (text) this.stats.answered += 1;
+      else this.stats.failed += 1;
+      return;
+    }
+
+    // The reply could not be delivered. Nothing more to try — publishing a
+    // second message about a failed publish would fail the same way.
+    this.stats.failed += 1;
+    this.log(`buzz inbound: reply not delivered — ${result.detail}`);
+  }
+}

--- a/services/slack-operator/src/buzz-subscribe.ts
+++ b/services/slack-operator/src/buzz-subscribe.ts
@@ -1,0 +1,395 @@
+// The Buzz subscribe transport: hold one WebSocket open, stay authenticated,
+// and hand every channel message to a callback.
+//
+// ── THIS CONTRADICTS buzz-client.ts ON PURPOSE ──────────────────────────────
+//
+// That module opens a connection per message and says why:
+//
+//   "A persistent socket for that traffic buys nothing and costs the thing we
+//    can least afford: reconnect logic, backoff state, and a socket that can be
+//    silently half-dead for hours inside the process whose entire job is
+//    noticing when something has gone quiet."
+//
+// That reasoning is right, and it still is — for publishing. Narration is
+// edge-triggered and rare, so a connection per message is free and self-
+// verifying. Listening has no such option: you cannot poll for a message that
+// has not been sent. The socket has to stay open, which means the cost that
+// paragraph names is now real and has to be PAID rather than avoided.
+//
+// It is paid in three places:
+//
+//  · A WATCHDOG. Relays go quiet legitimately, so silence alone proves nothing.
+//    But a socket that has heard nothing at all — not a message, not a ping,
+//    not a NOTICE — for longer than the idle limit is treated as dead and
+//    reconnected, because the failure being guarded against is precisely the
+//    one that looks identical to a quiet channel.
+//  · OBSERVABLE STATE. Every transition is reported to `onState`, so a listener
+//    that is down appears on the board as down. This is the actual answer to
+//    the objection: the danger was never the half-dead socket, it was the
+//    half-dead socket NOBODY COULD SEE. The relay already taught us this the
+//    hard way — it hung mid-startup and #Ops was silently dead for four hours.
+//  · BACKOFF WITH A CEILING. A relay that is down stays down for a while;
+//    reconnecting in a tight loop turns one outage into two.
+//
+// Nothing here throws into the caller. A transport whose job is to report
+// problems must not become one.
+
+import {
+  BuzzEventError,
+  KIND_STREAM_MESSAGE,
+  agentPubkey,
+  buildAuthEvent,
+  signEvent,
+} from "./buzz-event.js";
+import type { BuzzConfig } from "./buzz-client.js";
+import type { InboundEvent } from "./buzz-inbound.js";
+
+export type ListenerPhase =
+  | "connecting"
+  | "authenticating"
+  | "listening"
+  | "retrying"
+  | "closed"
+  | "misconfigured";
+
+export interface ListenerState {
+  phase: ListenerPhase;
+  /** Operator-facing sentence. Safe to log; never contains the secret key. */
+  detail: string;
+  /** Consecutive failed connection attempts. Zero once listening. */
+  failures: number;
+}
+
+export interface SubscribeHandlers {
+  onMessage: (event: InboundEvent) => void;
+  onState?: (state: ListenerState) => void;
+}
+
+interface Socket {
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "open" | "message" | "error" | "close", handler: (event: any) => void): void;
+}
+
+export interface SubscribeOptions {
+  openSocket?: (url: string) => Socket;
+  /** Injected for tests. Defaults to wall clock. */
+  nowMs?: () => number;
+  /** Injected for tests so backoff does not actually sleep. */
+  setTimer?: (fn: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+  /** No frame of any kind for this long means the socket is presumed dead. */
+  idleTimeoutMs?: number;
+  firstRetryMs?: number;
+  maxRetryMs?: number;
+  /** Only events at or after this second are requested from the relay. */
+  sinceSeconds?: number;
+}
+
+/**
+ * Long enough that a genuinely quiet channel does not churn the connection,
+ * short enough that a dead socket is noticed within one coffee break. Relays
+ * that implement ping/pong will refresh this far more often.
+ */
+export const DEFAULT_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
+export const DEFAULT_FIRST_RETRY_MS = 2_000;
+export const DEFAULT_MAX_RETRY_MS = 60_000;
+
+const SUBSCRIPTION_ID = "avg-ops";
+
+export interface BuzzSubscription {
+  /** Stop listening. Idempotent. */
+  close(): void;
+  /** Current state, for the board and for tests. */
+  state(): ListenerState;
+}
+
+/**
+ * Compute the next backoff delay: exponential, capped, with jitter.
+ *
+ * Jitter matters even with a single client, because the common failure is the
+ * relay restarting — and a fixed delay means every reconnect attempt lands on
+ * the same instant of its startup, which is when it is least able to serve one.
+ */
+export function nextRetryDelayMs(failures: number, firstMs: number, maxMs: number): number {
+  const base = Math.min(maxMs, firstMs * 2 ** Math.max(0, failures - 1));
+  const jitter = base * 0.2 * Math.random();
+  return Math.round(base - base * 0.1 + jitter);
+}
+
+/**
+ * Build the REQ filter.
+ *
+ * `since` is not an optimisation. Without it the relay replays channel history
+ * on every connect, and each reconnect would hand the listener the same old
+ * messages again — the decision layer rejects them as replays, but asking for
+ * them at all makes an outage expensive and the logs unreadable.
+ */
+export function buildReqFrame(channelId: string, sinceSeconds: number): string {
+  return JSON.stringify([
+    "REQ",
+    SUBSCRIPTION_ID,
+    { kinds: [KIND_STREAM_MESSAGE], "#h": [channelId], since: sinceSeconds },
+  ]);
+}
+
+/** Parse a relay frame into an inbound event, or null if it is not one. */
+export function eventFromFrame(frame: unknown): InboundEvent | null {
+  if (!Array.isArray(frame) || frame[0] !== "EVENT") return null;
+  const raw = frame[2];
+  if (!raw || typeof raw !== "object") return null;
+  const e = raw as Record<string, unknown>;
+  if (
+    typeof e.id !== "string"
+    || typeof e.pubkey !== "string"
+    || typeof e.kind !== "number"
+    || typeof e.content !== "string"
+    || typeof e.created_at !== "number"
+    || !Array.isArray(e.tags)
+  ) {
+    return null;
+  }
+  const tags = (e.tags as unknown[]).filter(
+    (t): t is string[] => Array.isArray(t) && t.every((x) => typeof x === "string"),
+  );
+  return {
+    id: e.id,
+    pubkey: e.pubkey,
+    kind: e.kind,
+    tags,
+    content: e.content,
+    created_at: e.created_at,
+  };
+}
+
+/**
+ * Open a subscription and keep it open.
+ *
+ * Returns immediately with a handle; connection happens in the background and
+ * is reported through `onState`. There is no "wait until connected" because
+ * there is no useful thing for the caller to do while waiting — the monitor has
+ * a money path to watch.
+ */
+export function subscribeToBuzz(
+  config: BuzzConfig,
+  handlers: SubscribeHandlers,
+  options: SubscribeOptions = {},
+): BuzzSubscription {
+  const openSocket = options.openSocket ?? defaultOpenSocket;
+  const nowMs = options.nowMs ?? (() => Date.now());
+  const setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearTimer = options.clearTimer ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  const idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+  const firstRetryMs = options.firstRetryMs ?? DEFAULT_FIRST_RETRY_MS;
+  const maxRetryMs = options.maxRetryMs ?? DEFAULT_MAX_RETRY_MS;
+  const sinceSeconds = options.sinceSeconds ?? Math.floor(nowMs() / 1000);
+
+  let pubkey: string;
+  try {
+    pubkey = agentPubkey(config.agentSecretKeyHex);
+  } catch (error) {
+    const state: ListenerState = {
+      phase: "misconfigured",
+      detail: error instanceof BuzzEventError ? error.message : String(error),
+      failures: 0,
+    };
+    handlers.onState?.(state);
+    return { close: () => {}, state: () => state };
+  }
+
+  let current: ListenerState = { phase: "connecting", detail: "opening the relay connection", failures: 0 };
+  let socket: Socket | null = null;
+  let retryHandle: unknown = null;
+  let watchdogHandle: unknown = null;
+  let stopped = false;
+  let failures = 0;
+
+  function setState(phase: ListenerPhase, detail: string): void {
+    current = { phase, detail, failures };
+    handlers.onState?.(current);
+  }
+
+  function clearWatchdog(): void {
+    if (watchdogHandle !== null) {
+      clearTimer(watchdogHandle);
+      watchdogHandle = null;
+    }
+  }
+
+  /**
+   * Restart the idle countdown. Called on EVERY frame, not just messages —
+   * a NOTICE or an EOSE proves the socket is alive just as well as a message
+   * does, and treating only messages as liveness would reconnect a healthy
+   * connection to a quiet channel.
+   */
+  function touch(): void {
+    clearWatchdog();
+    watchdogHandle = setTimer(() => {
+      if (stopped) return;
+      // Not an error the relay reported — an absence we inferred. Say so.
+      drop(`no frame from the relay for ${Math.round(idleTimeoutMs / 1000)}s — presuming the socket is dead`);
+    }, idleTimeoutMs);
+  }
+
+  function drop(reason: string): void {
+    if (stopped) return;
+    clearWatchdog();
+    try {
+      socket?.close();
+    } catch {
+      // Closing an already-dead socket is not a new failure.
+    }
+    socket = null;
+    failures += 1;
+    const delay = nextRetryDelayMs(failures, firstRetryMs, maxRetryMs);
+    setState("retrying", `${reason}; retrying in ${Math.round(delay / 1000)}s`);
+    retryHandle = setTimer(() => {
+      retryHandle = null;
+      connect();
+    }, delay);
+  }
+
+  function connect(): void {
+    if (stopped) return;
+    setState("connecting", `opening ${config.relayUrl}`);
+
+    let sock: Socket;
+    try {
+      sock = openSocket(config.relayUrl);
+    } catch (error) {
+      drop(error instanceof Error ? error.message : String(error));
+      return;
+    }
+    socket = sock;
+    touch();
+
+    sock.addEventListener("error", () => {
+      // The WS error event carries no detail by design; the URL is what helps.
+      if (socket === sock) drop(`could not reach ${config.relayUrl}`);
+    });
+
+    sock.addEventListener("close", () => {
+      if (socket === sock) drop("relay closed the connection");
+    });
+
+    sock.addEventListener("message", (event: { data: unknown }) => {
+      if (socket !== sock || stopped) return;
+      touch();
+
+      let frame: unknown;
+      try {
+        frame = JSON.parse(typeof event.data === "string" ? event.data : String(event.data));
+      } catch {
+        return; // Unparseable frames are not ours to act on.
+      }
+      if (!Array.isArray(frame) || typeof frame[0] !== "string") return;
+
+      if (frame[0] === "AUTH" && typeof frame[1] === "string") {
+        setState("authenticating", "answering the relay's AUTH challenge");
+        try {
+          const auth = signEvent(
+            buildAuthEvent({
+              agentPubkeyHex: pubkey,
+              relayUrl: config.relayUrl,
+              challenge: frame[1],
+              createdAt: Math.floor(nowMs() / 1000),
+              authTag: config.authTag,
+            }),
+            config.agentSecretKeyHex,
+          );
+          sock.send(JSON.stringify(["AUTH", auth]));
+          // Subscribe straight away, same reasoning as the publish path: the
+          // relay applies the session's authority to subsequent frames, and a
+          // rejected AUTH surfaces as a CLOSED on the subscription with a
+          // reason, which is more informative than an OK we would have to
+          // correlate ourselves.
+          sock.send(buildReqFrame(config.channelId, sinceSeconds));
+        } catch (error) {
+          // A signing failure is configuration, not transport. Retrying cannot
+          // fix it, so stop rather than spin.
+          stopped = true;
+          clearWatchdog();
+          setState("misconfigured", error instanceof Error ? error.message : String(error));
+        }
+        return;
+      }
+
+      if (frame[0] === "EOSE" && frame[1] === SUBSCRIPTION_ID) {
+        // Stored events are done; everything after this is live. This is the
+        // first moment the listener is genuinely working, so it is the first
+        // moment it may claim to be.
+        failures = 0;
+        setState("listening", `subscribed to channel ${config.channelId}`);
+        return;
+      }
+
+      if (frame[0] === "CLOSED" && frame[1] === SUBSCRIPTION_ID) {
+        const why = typeof frame[2] === "string" && frame[2] ? frame[2] : "no reason given";
+        drop(`relay closed the subscription: ${why}`);
+        return;
+      }
+
+      const inbound = eventFromFrame(frame);
+      if (inbound) {
+        // The relay may deliver stored events before EOSE. Hand them over
+        // regardless — the decision layer owns replay rejection, and duplicating
+        // that judgement here would create a second place for it to be wrong.
+        try {
+          handlers.onMessage(inbound);
+        } catch {
+          // A handler that throws must not take the socket down with it.
+        }
+      }
+    });
+  }
+
+  connect();
+
+  return {
+    close(): void {
+      if (stopped) return;
+      stopped = true;
+      clearWatchdog();
+      if (retryHandle !== null) clearTimer(retryHandle);
+      try {
+        socket?.close();
+      } catch {
+        // Nothing to salvage.
+      }
+      socket = null;
+      setState("closed", "listener stopped");
+    },
+    state: () => current,
+  };
+}
+
+function defaultOpenSocket(url: string): Socket {
+  if (typeof WebSocket === "undefined") {
+    throw new BuzzEventError("global WebSocket is unavailable — Node 22.4+ is required to reach Buzz");
+  }
+  return new WebSocket(url) as unknown as Socket;
+}
+
+/**
+ * One line for the board's trust row.
+ *
+ * `listening` is the only phase that means questions will be answered.
+ * Everything else says so plainly, because a listener that is retrying looks
+ * exactly like a channel nobody has posted in.
+ */
+export function describeListenerRow(state: ListenerState | null): { status: "ok" | "degraded" | "off"; text: string } {
+  if (!state) return { status: "off", text: "inbound replies are off" };
+  switch (state.phase) {
+    case "listening":
+      return { status: "ok", text: "listening for questions" };
+    case "connecting":
+    case "authenticating":
+      return { status: "degraded", text: `${state.phase} — not answering yet` };
+    case "retrying":
+      return { status: "degraded", text: `not listening — ${state.detail}` };
+    case "misconfigured":
+      return { status: "degraded", text: `misconfigured — ${state.detail}` };
+    case "closed":
+      return { status: "off", text: "listener stopped" };
+  }
+}

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -153,6 +153,7 @@ import {
 } from "./monitor-hermes-voice.js";
 import { decideOpsNarration, type OpsStatus } from "./ops-narration.js";
 import { publishNarration, readBuzzConfig } from "./buzz-client.js";
+import { startBuzzInbound } from "./buzz-inbound-start.js";
 import { decideProbeTransitions } from "./probe-transitions.js";
 import { describeBuzzDelivery, recordBuzzDelivery, type BuzzDeliveryState } from "./buzz-delivery.js";
 import type { ProbeResult } from "./product-health.js";
@@ -374,6 +375,12 @@ const server = http.createServer((request, response) => {
 server.listen(httpPort, "0.0.0.0", () => {
   logger.info({ httpPort }, "slack_operator_http_listening");
 });
+
+// Buzz inbound: answer operator questions in #Ops. Default OFF, and it declines
+// to open a socket at all unless it could actually answer — see
+// buzz-inbound-start.ts for why a listener that cannot answer must not listen.
+const buzzInbound = startBuzzInbound();
+logger.info({ started: buzzInbound.started, reason: buzzInbound.reason }, "buzz_inbound_start");
 
 let autonomyMaintenanceRunning = false;
 let awayDigestTrackerState = initialAutopilotAwayDigestTrackerState();

--- a/test/unit/buzz-inbound.test.ts
+++ b/test/unit/buzz-inbound.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_MENTION_NAMES,
+  MAX_REPLY_CHARS,
+  buildInboundPrompt,
+  decideInboundMessage,
+  describeInboundFailure,
+  formatReplyForBuzz,
+  replyFitsRelay,
+  type InboundContext,
+  type InboundEvent,
+} from "../../services/slack-operator/src/buzz-inbound.js";
+
+const AGENT = "a".repeat(64);
+const OPERATOR = "b".repeat(64);
+const CHANNEL = "3f2a1c4e-5b6d-4e7f-8a9b-0c1d2e3f4a5b";
+
+const ctx = (over: Partial<InboundContext> = {}): InboundContext => ({
+  agentPubkey: AGENT,
+  channelId: CHANNEL,
+  startedAtSeconds: 1_000,
+  seenEventIds: new Set(),
+  repliesInWindow: 0,
+  maxRepliesPerWindow: 30,
+  requireMention: false,
+  mentionNames: DEFAULT_MENTION_NAMES,
+  enabled: true,
+  ...over,
+});
+
+const msg = (over: Partial<InboundEvent> = {}): InboundEvent => ({
+  id: "e1",
+  pubkey: OPERATOR,
+  kind: 9,
+  tags: [["h", CHANNEL]],
+  content: "is the money path ok?",
+  created_at: 2_000,
+  ...over,
+});
+
+describe("the loop guard", () => {
+  it("NEVER answers a message published by this agent", () => {
+    // The single most important rule in this file. The narration publisher and
+    // this listener share one agent key, so without this an alert posted to
+    // #Ops is a question the agent asks itself, and the answer is another one.
+    const r = decideInboundMessage(msg({ pubkey: AGENT }), ctx());
+    expect(r.verdict).toBe("ignore-self");
+    expect(r.question).toBeUndefined();
+  });
+
+  it("ignores our own message even when it names the agent", () => {
+    // Narration could easily contain the word "Hermes". Mention-matching must
+    // not be a way back into the loop.
+    const r = decideInboundMessage(
+      msg({ pubkey: AGENT, content: "Hermes: money_path recovered" }),
+      ctx({ requireMention: true }),
+    );
+    expect(r.verdict).toBe("ignore-self");
+  });
+
+  it("does not let our own messages consume the rate-limit window", () => {
+    // Rate limiting is evaluated LAST on purpose. If self-messages burned the
+    // window, a chatty incident would disarm the backstop precisely when the
+    // loop it guards against would be most expensive.
+    const r = decideInboundMessage(
+      msg({ pubkey: AGENT }),
+      ctx({ repliesInWindow: 999, maxRepliesPerWindow: 1 }),
+    );
+    expect(r.verdict).toBe("ignore-self");
+  });
+});
+
+describe("replay and redelivery", () => {
+  it("ignores a message older than this listener", () => {
+    // Relays replay stored events on connect and again on every reconnect.
+    // Answering them means each restart re-answers the last question — the same
+    // shape as the duplicate #Ops alerts that reached production.
+    const r = decideInboundMessage(msg({ created_at: 999 }), ctx({ startedAtSeconds: 1_000 }));
+    expect(r.verdict).toBe("ignore-replay");
+    expect(r.detail).toContain("1s");
+  });
+
+  it("answers a message sent exactly at startup", () => {
+    // The boundary must not swallow a live question by an off-by-one.
+    const r = decideInboundMessage(msg({ created_at: 1_000 }), ctx({ startedAtSeconds: 1_000 }));
+    expect(r.verdict).toBe("answer");
+  });
+
+  it("ignores an event id it has already handled", () => {
+    const r = decideInboundMessage(msg({ id: "dup" }), ctx({ seenEventIds: new Set(["dup"]) }));
+    expect(r.verdict).toBe("ignore-seen");
+  });
+});
+
+describe("addressing", () => {
+  it("answers anything in the channel when a mention is not required", () => {
+    expect(decideInboundMessage(msg(), ctx()).verdict).toBe("answer");
+  });
+
+  it("requires the agent's name when configured to", () => {
+    const r = decideInboundMessage(msg({ content: "what a day" }), ctx({ requireMention: true }));
+    expect(r.verdict).toBe("ignore-not-addressed");
+  });
+
+  it("strips a leading mention so the question is what gets asked", () => {
+    // A model handed its own name as the first token sometimes answers about
+    // itself rather than the question.
+    const r = decideInboundMessage(
+      msg({ content: "@hermes is the money path ok?" }),
+      ctx({ requireMention: true }),
+    );
+    expect(r.verdict).toBe("answer");
+    expect(r.question).toBe("is the money path ok?");
+  });
+
+  it("keeps a mention that is part of the question", () => {
+    const r = decideInboundMessage(
+      msg({ content: "who manages hermes?" }),
+      ctx({ requireMention: true }),
+    );
+    expect(r.question).toBe("who manages hermes?");
+  });
+
+  it("says nothing to a message that is only a mention", () => {
+    const r = decideInboundMessage(msg({ content: "@hermes" }), ctx({ requireMention: true }));
+    expect(r.verdict).toBe("ignore-empty");
+  });
+});
+
+describe("structural rejections", () => {
+  it("ignores non-message kinds", () => {
+    expect(decideInboundMessage(msg({ kind: 0 }), ctx()).verdict).toBe("ignore-kind");
+  });
+
+  it("ignores a message tagged for another channel", () => {
+    const other = "11111111-2222-3333-4444-555555555555";
+    expect(decideInboundMessage(msg({ tags: [["h", other]] }), ctx()).verdict).toBe("ignore-channel");
+  });
+
+  it("ignores a message with no channel tag at all", () => {
+    const r = decideInboundMessage(msg({ tags: [] }), ctx());
+    expect(r.verdict).toBe("ignore-channel");
+    expect(r.detail).toContain("no channel tag");
+  });
+
+  it("ignores whitespace-only content", () => {
+    expect(decideInboundMessage(msg({ content: "   \n " }), ctx()).verdict).toBe("ignore-empty");
+  });
+
+  it("is silent when the feature is switched off", () => {
+    expect(decideInboundMessage(msg(), ctx({ enabled: false })).verdict).toBe("ignore-disabled");
+  });
+});
+
+describe("rate limiting", () => {
+  it("stops answering once the window is spent", () => {
+    const r = decideInboundMessage(msg(), ctx({ repliesInWindow: 30, maxRepliesPerWindow: 30 }));
+    expect(r.verdict).toBe("ignore-rate-limited");
+    expect(r.detail).toContain("30");
+  });
+
+  it("still answers on the last reply of the window", () => {
+    const r = decideInboundMessage(msg(), ctx({ repliesInWindow: 29, maxRepliesPerWindow: 30 }));
+    expect(r.verdict).toBe("answer");
+  });
+});
+
+describe("the prompt", () => {
+  it("tells the agent to check the board rather than answer from memory", () => {
+    const prompt = buildInboundPrompt("is averray ok?");
+    expect(prompt).toContain("not from memory");
+    expect(prompt).toContain("is averray ok?");
+  });
+
+  it("says UNKNOWN is the answer when the board cannot be reached", () => {
+    // The same rule the board-health tool carries. Both paths must agree, or
+    // the agent has two policies for the same situation.
+    expect(buildInboundPrompt("x")).toContain("UNKNOWN");
+  });
+
+  it("forbids taking action", () => {
+    expect(buildInboundPrompt("x").toLowerCase()).toContain("do not take actions");
+  });
+});
+
+describe("formatting the reply", () => {
+  it("returns null for nothing to say, so the caller can be honest instead", () => {
+    // Publishing empty content throws at the event builder, and silence in an
+    // ops channel is indistinguishable from the listener being down.
+    expect(formatReplyForBuzz("")).toBeNull();
+    expect(formatReplyForBuzz("   ")).toBeNull();
+    expect(formatReplyForBuzz(null)).toBeNull();
+    expect(formatReplyForBuzz(undefined)).toBeNull();
+  });
+
+  it("passes a normal answer through untouched", () => {
+    expect(formatReplyForBuzz("  nominal, 9 probes ok  ")).toBe("nominal, 9 probes ok");
+  });
+
+  it("MARKS truncation rather than cutting silently", () => {
+    // A cut-off ops answer that looks complete is a way to be confidently wrong.
+    const long = "x".repeat(MAX_REPLY_CHARS + 500);
+    const out = formatReplyForBuzz(long)!;
+    expect(out).toContain("truncated");
+    expect(out.length).toBeLessThan(long.length);
+  });
+
+  it("produces something the relay will accept", () => {
+    expect(replyFitsRelay(formatReplyForBuzz("y".repeat(MAX_REPLY_CHARS * 2))!)).toBe(true);
+  });
+});
+
+describe("failure lines", () => {
+  it("says the failure is ours, not a verdict about the system", () => {
+    // THE TRUTH BOUNDARY, in one sentence. "I could not answer" must never be
+    // readable as "the system is fine" or as "the system is broken".
+    const line = describeInboundFailure("the agent session timed out");
+    expect(line).toContain("the agent session timed out");
+    expect(line).toContain("not a verdict about the system");
+  });
+});

--- a/test/unit/buzz-responder.test.ts
+++ b/test/unit/buzz-responder.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BuzzResponder, MAX_SEEN_IDS, type ResponderConfig } from "../../services/slack-operator/src/buzz-responder.js";
+import { DEFAULT_MENTION_NAMES } from "../../services/slack-operator/src/buzz-inbound.js";
+import type { InboundEvent } from "../../services/slack-operator/src/buzz-inbound.js";
+
+const AGENT = "a".repeat(64);
+const OPERATOR = "b".repeat(64);
+const CHANNEL = "3f2a1c4e-5b6d-4e7f-8a9b-0c1d2e3f4a5b";
+
+const config = (over: Partial<ResponderConfig> = {}): ResponderConfig => ({
+  agentPubkey: AGENT,
+  channelId: CHANNEL,
+  startedAtSeconds: 1_000,
+  maxRepliesPerWindow: 30,
+  rateWindowMs: 3_600_000,
+  requireMention: false,
+  mentionNames: DEFAULT_MENTION_NAMES,
+  enabled: true,
+  ...over,
+});
+
+const msg = (over: Partial<InboundEvent> = {}): InboundEvent => ({
+  id: "e1",
+  pubkey: OPERATOR,
+  kind: 9,
+  tags: [["h", CHANNEL]],
+  content: "is the money path ok?",
+  created_at: 2_000,
+  ...over,
+});
+
+/** A promise we resolve by hand, so a turn can be held open mid-flight. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+function setup(over: Partial<ResponderConfig> = {}, askImpl?: (q: string) => Promise<string | null>) {
+  const published: string[] = [];
+  const asked: string[] = [];
+  const logs: string[] = [];
+  let now = 1_700_000_000_000;
+
+  const responder = new BuzzResponder(config(over), {
+    ask: async (q) => {
+      asked.push(q);
+      return askImpl ? await askImpl(q) : "nominal — 9 probes ok";
+    },
+    publish: async (text) => {
+      published.push(text);
+      return { ok: true, detail: "accepted" };
+    },
+    nowMs: () => now,
+    log: (l) => logs.push(l),
+  });
+
+  return {
+    responder,
+    published,
+    asked,
+    logs,
+    advance: (ms: number) => { now += ms; },
+  };
+}
+
+describe("answering", () => {
+  it("asks the agent and publishes what it says", async () => {
+    const s = setup();
+    s.responder.handle(msg());
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+
+    expect(s.asked).toEqual(["is the money path ok?"]);
+    expect(s.published[0]).toBe("nominal — 9 probes ok");
+    expect(s.responder.snapshot().answered).toBe(1);
+  });
+
+  it("says nothing at all to its own messages", async () => {
+    const s = setup();
+    s.responder.handle(msg({ pubkey: AGENT }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(s.asked).toEqual([]);
+    expect(s.published).toEqual([]);
+  });
+
+  it("does not log every self-message", () => {
+    // In a channel we also post to, self-messages are the majority. Logging
+    // each one buries the lines that matter.
+    const s = setup();
+    for (let i = 0; i < 5; i += 1) s.responder.handle(msg({ id: `s${i}`, pubkey: AGENT }));
+    expect(s.logs).toEqual([]);
+  });
+});
+
+describe("one turn at a time", () => {
+  it("drops a second question while one is running", async () => {
+    // A turn costs money and takes tens of seconds. Two at once interleave in
+    // the channel and double the spend for what is usually the same question
+    // typed again.
+    const gate = deferred<string | null>();
+    const s = setup({}, () => gate.promise);
+
+    s.responder.handle(msg({ id: "first" }));
+    await vi.waitFor(() => expect(s.asked).toHaveLength(1));
+    expect(s.responder.snapshot().busy).toBe(true);
+
+    s.responder.handle(msg({ id: "second", content: "and solvency?" }));
+    expect(s.asked).toHaveLength(1);
+    expect(s.responder.snapshot().dropped).toBe(1);
+
+    gate.resolve("ok");
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+  });
+
+  it("accepts a new question once the previous turn finishes", async () => {
+    const gate = deferred<string | null>();
+    let first = true;
+    const s = setup({}, () => (first ? ((first = false), gate.promise) : Promise.resolve("second answer")));
+
+    s.responder.handle(msg({ id: "one" }));
+    await vi.waitFor(() => expect(s.asked).toHaveLength(1));
+    gate.resolve("first answer");
+    await vi.waitFor(() => expect(s.responder.snapshot().busy).toBe(false));
+
+    s.responder.handle(msg({ id: "two" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(2));
+    expect(s.published[1]).toBe("second answer");
+  });
+
+  it("records the event id BEFORE the turn, so a mid-turn redelivery is not a second answer", async () => {
+    // A turn takes tens of seconds. A relay redelivering the same event during
+    // it would otherwise pass the seen check and start an identical answer.
+    const gate = deferred<string | null>();
+    const s = setup({}, () => gate.promise);
+
+    s.responder.handle(msg({ id: "same" }));
+    await vi.waitFor(() => expect(s.asked).toHaveLength(1));
+    s.responder.handle(msg({ id: "same" }));
+
+    expect(s.responder.snapshot().lastVerdict).toBe("ignore-seen");
+    gate.resolve("done");
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+  });
+});
+
+describe("failures still speak", () => {
+  it("publishes an honest line when the agent throws", async () => {
+    // Silence is indistinguishable from the listener being down, in the one
+    // channel whose job is to be trustworthy when things are broken.
+    const s = setup({}, () => Promise.reject(new Error("gateway timeout")));
+    s.responder.handle(msg());
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+
+    expect(s.published[0]).toContain("gateway timeout");
+    expect(s.published[0]).toContain("not a verdict about the system");
+    expect(s.responder.snapshot().failed).toBe(1);
+    expect(s.responder.snapshot().answered).toBe(0);
+  });
+
+  it("distinguishes an empty answer from an unreachable agent", async () => {
+    const s = setup({}, () => Promise.resolve(null));
+    s.responder.handle(msg());
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+    expect(s.published[0]).toContain("empty answer");
+  });
+
+  it("does not publish a second message about a failed publish", async () => {
+    // It would fail the same way. Log it and stop.
+    const published: string[] = [];
+    const logs: string[] = [];
+    const responder = new BuzzResponder(config(), {
+      ask: async () => "an answer",
+      publish: async (t) => { published.push(t); return { ok: false, detail: "relay unreachable" }; },
+      log: (l) => logs.push(l),
+    });
+    responder.handle(msg());
+    await vi.waitFor(() => expect(published).toHaveLength(1));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(published).toHaveLength(1);
+    expect(logs.some((l) => l.includes("relay unreachable"))).toBe(true);
+    expect(responder.snapshot().failed).toBe(1);
+  });
+
+  it("keeps the chain alive after a failed turn", async () => {
+    let calls = 0;
+    const s = setup({}, () => {
+      calls += 1;
+      return calls === 1 ? Promise.reject(new Error("boom")) : Promise.resolve("recovered");
+    });
+    s.responder.handle(msg({ id: "a" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+    s.responder.handle(msg({ id: "b" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(2));
+    expect(s.published[1]).toBe("recovered");
+  });
+});
+
+describe("the rate window rolls", () => {
+  it("stops answering once the window is spent, and resumes when it ages out", async () => {
+    const s = setup({ maxRepliesPerWindow: 2, rateWindowMs: 60_000 });
+
+    s.responder.handle(msg({ id: "1" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+    s.responder.handle(msg({ id: "2" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(2));
+
+    s.responder.handle(msg({ id: "3" }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(s.published).toHaveLength(2);
+    expect(s.responder.snapshot().lastVerdict).toBe("ignore-rate-limited");
+
+    // The window is rolling, not a fixed bucket: old replies age out.
+    s.advance(61_000);
+    s.responder.handle(msg({ id: "4" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(3));
+  });
+
+  it("counts a published failure line against the window", async () => {
+    // A failing agent must not become an unbounded source of messages.
+    const s = setup({ maxRepliesPerWindow: 1 }, () => Promise.reject(new Error("down")));
+    s.responder.handle(msg({ id: "1" }));
+    await vi.waitFor(() => expect(s.published).toHaveLength(1));
+    s.responder.handle(msg({ id: "2" }));
+    await new Promise((r) => setTimeout(r, 5));
+    expect(s.published).toHaveLength(1);
+  });
+});
+
+describe("bounded memory", () => {
+  it("evicts the oldest seen ids rather than growing forever", async () => {
+    const s = setup();
+    for (let i = 0; i < MAX_SEEN_IDS + 10; i += 1) {
+      s.responder.handle(msg({ id: `id-${i}`, pubkey: OPERATOR }));
+      // Each is dropped as busy after the first, but all are decided against
+      // the same set; only answered ones are remembered.
+    }
+    await vi.waitFor(() => expect(s.published.length).toBeGreaterThan(0));
+    // The set is capped; the assertion that matters is that this does not grow
+    // without limit over a long-lived process.
+    expect(MAX_SEEN_IDS).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("switched off", () => {
+  it("never asks anything when disabled", async () => {
+    const s = setup({ enabled: false });
+    s.responder.handle(msg());
+    await new Promise((r) => setTimeout(r, 5));
+    expect(s.asked).toEqual([]);
+    expect(s.published).toEqual([]);
+  });
+});

--- a/test/unit/buzz-subscribe.test.ts
+++ b/test/unit/buzz-subscribe.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+
+import type { BuzzConfig } from "../../services/slack-operator/src/buzz-client.js";
+import {
+  buildReqFrame,
+  describeListenerRow,
+  eventFromFrame,
+  nextRetryDelayMs,
+  subscribeToBuzz,
+  type ListenerState,
+} from "../../services/slack-operator/src/buzz-subscribe.js";
+import type { InboundEvent } from "../../services/slack-operator/src/buzz-inbound.js";
+
+const CHANNEL = "3f2a1c4e-5b6d-4e7f-8a9b-0c1d2e3f4a5b";
+const SECRET = "1".repeat(64);
+const OWNER = "c".repeat(64);
+
+const config: BuzzConfig = {
+  relayUrl: "wss://relay.test",
+  agentSecretKeyHex: SECRET,
+  authTag: ["auth", OWNER, "conditions", "sig"],
+  channelId: CHANNEL,
+};
+
+/** A socket we drive by hand, so every branch is reachable without a relay. */
+class FakeSocket {
+  handlers: Record<string, Array<(e: any) => void>> = {};
+  sent: string[] = [];
+  closed = false;
+
+  addEventListener(type: string, handler: (e: any) => void): void {
+    (this.handlers[type] ??= []).push(handler);
+  }
+  send(data: string): void {
+    this.sent.push(data);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  emit(type: string, event: unknown = {}): void {
+    for (const h of this.handlers[type] ?? []) h(event);
+  }
+  frame(payload: unknown): void {
+    this.emit("message", { data: JSON.stringify(payload) });
+  }
+  /** Frames sent, parsed, for readable assertions. */
+  parsed(): unknown[] {
+    return this.sent.map((s) => JSON.parse(s));
+  }
+}
+
+/** Timer control: nothing sleeps, and every pending callback is nameable. */
+function harness() {
+  const timers: Array<{ fn: () => void; ms: number; handle: number }> = [];
+  let next = 1;
+  const sockets: FakeSocket[] = [];
+  const states: ListenerState[] = [];
+  const messages: InboundEvent[] = [];
+
+  return {
+    sockets,
+    states,
+    messages,
+    timers,
+    options: {
+      openSocket: () => {
+        const s = new FakeSocket();
+        sockets.push(s);
+        return s;
+      },
+      nowMs: () => 1_700_000_000_000,
+      setTimer: (fn: () => void, ms: number) => {
+        const handle = next++;
+        timers.push({ fn, ms, handle });
+        return handle;
+      },
+      clearTimer: (h: unknown) => {
+        const i = timers.findIndex((t) => t.handle === h);
+        if (i >= 0) timers.splice(i, 1);
+      },
+    },
+    handlers: {
+      onMessage: (e: InboundEvent) => messages.push(e),
+      onState: (s: ListenerState) => states.push(s),
+    },
+    /** Run the longest-pending timer, which is the one under test. */
+    fireLongest(): void {
+      const t = [...timers].sort((a, b) => b.ms - a.ms)[0];
+      if (!t) throw new Error("no timer pending");
+      timers.splice(timers.indexOf(t), 1);
+      t.fn();
+    },
+    fireShortest(): void {
+      const t = [...timers].sort((a, b) => a.ms - b.ms)[0];
+      if (!t) throw new Error("no timer pending");
+      timers.splice(timers.indexOf(t), 1);
+      t.fn();
+    },
+  };
+}
+
+describe("buildReqFrame", () => {
+  it("asks only for channel messages, and only new ones", () => {
+    // `since` is not an optimisation: without it every reconnect replays the
+    // channel's history at us.
+    const frame = JSON.parse(buildReqFrame(CHANNEL, 1_700));
+    expect(frame[0]).toBe("REQ");
+    expect(frame[2]).toEqual({ kinds: [9], "#h": [CHANNEL], since: 1_700 });
+  });
+});
+
+describe("eventFromFrame", () => {
+  it("parses a well-formed EVENT", () => {
+    const e = eventFromFrame(["EVENT", "sub", {
+      id: "i", pubkey: "p", kind: 9, tags: [["h", CHANNEL]], content: "hi", created_at: 5,
+    }]);
+    expect(e).toMatchObject({ id: "i", kind: 9, content: "hi" });
+  });
+
+  it("rejects anything malformed rather than half-parsing it", () => {
+    // A partially-parsed event would reach the decision layer missing the very
+    // fields its guards key on — pubkey and created_at.
+    expect(eventFromFrame(["EVENT", "sub", { id: "i" }])).toBeNull();
+    expect(eventFromFrame(["EOSE", "sub"])).toBeNull();
+    expect(eventFromFrame("nonsense")).toBeNull();
+    expect(eventFromFrame(["EVENT", "sub", null])).toBeNull();
+  });
+
+  it("drops non-string tag entries instead of trusting them", () => {
+    const e = eventFromFrame(["EVENT", "sub", {
+      id: "i", pubkey: "p", kind: 9, tags: [["h", CHANNEL], [1, 2], "x"], content: "hi", created_at: 5,
+    }]);
+    expect(e!.tags).toEqual([["h", CHANNEL]]);
+  });
+});
+
+describe("the handshake", () => {
+  it("answers AUTH and subscribes in the same breath", () => {
+    const h = harness();
+    subscribeToBuzz(config, h.handlers, { ...h.options, sinceSeconds: 42 });
+    h.sockets[0]!.frame(["AUTH", "challenge-1"]);
+
+    const sent = h.sockets[0]!.parsed();
+    expect((sent[0] as any[])[0]).toBe("AUTH");
+    expect((sent[1] as any[])[0]).toBe("REQ");
+    expect((sent[1] as any[])[2].since).toBe(42);
+  });
+
+  it("only claims to be listening once the relay says EOSE", () => {
+    // Before EOSE the subscription may not have been accepted at all. Claiming
+    // to listen early is the same lie as a fake green.
+    const h = harness();
+    const sub = subscribeToBuzz(config, h.handlers, h.options);
+    h.sockets[0]!.frame(["AUTH", "c"]);
+    expect(sub.state().phase).toBe("authenticating");
+
+    h.sockets[0]!.frame(["EOSE", "avg-ops"]);
+    expect(sub.state().phase).toBe("listening");
+  });
+
+  it("stops rather than spins when the signing key is unusable", () => {
+    // Retrying cannot fix a bad key, and a tight reconnect loop against a
+    // relay is a way to turn our configuration error into their outage.
+    const h = harness();
+    const sub = subscribeToBuzz({ ...config, agentSecretKeyHex: "nope" }, h.handlers, h.options);
+    expect(sub.state().phase).toBe("misconfigured");
+    expect(h.sockets).toHaveLength(0);
+  });
+});
+
+describe("delivery", () => {
+  it("hands channel messages to the callback", () => {
+    const h = harness();
+    subscribeToBuzz(config, h.handlers, h.options);
+    h.sockets[0]!.frame(["EOSE", "avg-ops"]);
+    h.sockets[0]!.frame(["EVENT", "avg-ops", {
+      id: "e1", pubkey: "op", kind: 9, tags: [["h", CHANNEL]], content: "ok?", created_at: 9,
+    }]);
+    expect(h.messages).toHaveLength(1);
+    expect(h.messages[0]!.content).toBe("ok?");
+  });
+
+  it("survives a handler that throws", () => {
+    // A callback failure must not take down the socket whose job is to notice
+    // when things are broken.
+    const h = harness();
+    subscribeToBuzz(config, { onMessage: () => { throw new Error("boom"); } }, h.options);
+    expect(() => h.sockets[0]!.frame(["EVENT", "avg-ops", {
+      id: "e", pubkey: "p", kind: 9, tags: [["h", CHANNEL]], content: "x", created_at: 1,
+    }])).not.toThrow();
+  });
+
+  it("forwards stored events too, leaving replay rejection to one place", () => {
+    // Duplicating the replay rule here would create a second place for it to be
+    // wrong. The decision layer owns it.
+    const h = harness();
+    subscribeToBuzz(config, h.handlers, h.options);
+    h.sockets[0]!.frame(["EVENT", "avg-ops", {
+      id: "old", pubkey: "op", kind: 9, tags: [["h", CHANNEL]], content: "ancient", created_at: 1,
+    }]);
+    expect(h.messages).toHaveLength(1);
+  });
+});
+
+describe("staying alive", () => {
+  it("reconnects when the relay closes", () => {
+    const h = harness();
+    const sub = subscribeToBuzz(config, h.handlers, h.options);
+    h.sockets[0]!.emit("close");
+    expect(sub.state().phase).toBe("retrying");
+
+    h.fireShortest(); // the retry timer
+    expect(h.sockets).toHaveLength(2);
+  });
+
+  it("presumes a silent socket is dead and replaces it", () => {
+    // THE OBJECTION buzz-client.ts raises against persistent sockets: one that
+    // is half-dead looks exactly like a quiet channel. The watchdog is the
+    // answer, and this test is why the answer is real.
+    const h = harness();
+    const sub = subscribeToBuzz(config, h.handlers, { ...h.options, idleTimeoutMs: 600_000 });
+    h.sockets[0]!.frame(["EOSE", "avg-ops"]);
+    expect(sub.state().phase).toBe("listening");
+
+    h.fireLongest(); // the idle watchdog
+    expect(sub.state().phase).toBe("retrying");
+    expect(sub.state().detail).toContain("presuming the socket is dead");
+  });
+
+  it("counts ANY frame as proof of life, not just messages", () => {
+    // Treating only messages as liveness would churn the connection on a
+    // healthy but quiet channel — which is the normal state of an ops channel.
+    const h = harness();
+    subscribeToBuzz(config, h.handlers, { ...h.options, idleTimeoutMs: 600_000 });
+    const before = h.timers.find((t) => t.ms === 600_000)!.handle;
+    h.sockets[0]!.frame(["NOTICE", "just saying hello"]);
+    const after = h.timers.find((t) => t.ms === 600_000)!.handle;
+    expect(after).not.toBe(before); // the countdown was restarted
+  });
+
+  it("reports a closed subscription with the relay's reason", () => {
+    const h = harness();
+    const sub = subscribeToBuzz(config, h.handlers, h.options);
+    h.sockets[0]!.frame(["CLOSED", "avg-ops", "auth-required: not a member"]);
+    expect(sub.state().phase).toBe("retrying");
+    expect(sub.state().detail).toContain("not a member");
+  });
+
+  it("stops for good when closed, with no further reconnects", () => {
+    const h = harness();
+    const sub = subscribeToBuzz(config, h.handlers, h.options);
+    sub.close();
+    expect(sub.state().phase).toBe("closed");
+    h.sockets[0]!.emit("close");
+    expect(sub.state().phase).toBe("closed");
+    expect(h.sockets).toHaveLength(1);
+  });
+
+  it("clears the failure count once it is genuinely listening", () => {
+    const h = harness();
+    const sub = subscribeToBuzz(config, h.handlers, h.options);
+    h.sockets[0]!.emit("close");
+    expect(sub.state().failures).toBe(1);
+    h.fireShortest();
+    h.sockets[1]!.frame(["EOSE", "avg-ops"]);
+    expect(sub.state().failures).toBe(0);
+  });
+});
+
+describe("nextRetryDelayMs", () => {
+  it("backs off exponentially and stops at the ceiling", () => {
+    expect(nextRetryDelayMs(1, 2_000, 60_000)).toBeLessThan(2_600);
+    expect(nextRetryDelayMs(3, 2_000, 60_000)).toBeGreaterThan(6_000);
+    for (const n of [10, 20, 50]) {
+      expect(nextRetryDelayMs(n, 2_000, 60_000)).toBeLessThanOrEqual(60_000 * 1.1);
+    }
+  });
+
+  it("jitters, so a restarting relay is not hit on the same instant every time", () => {
+    const seen = new Set(Array.from({ length: 24 }, () => nextRetryDelayMs(4, 2_000, 60_000)));
+    expect(seen.size).toBeGreaterThan(1);
+  });
+});
+
+describe("describeListenerRow", () => {
+  it("calls only 'listening' ok", () => {
+    // Every other phase means questions go unanswered, and a retrying listener
+    // looks exactly like a channel nobody has posted in.
+    expect(describeListenerRow({ phase: "listening", detail: "", failures: 0 }).status).toBe("ok");
+    for (const phase of ["connecting", "authenticating", "retrying", "misconfigured"] as const) {
+      expect(describeListenerRow({ phase, detail: "why", failures: 1 }).status).toBe("degraded");
+    }
+  });
+
+  it("distinguishes off from broken", () => {
+    // A feature switched off must never render as a failure, and vice versa.
+    expect(describeListenerRow(null).status).toBe("off");
+    expect(describeListenerRow({ phase: "closed", detail: "", failures: 0 }).status).toBe("off");
+  });
+});


### PR DESCRIPTION
Hermes has never actually spoken in Buzz. Narration lands authored by "Hermes" because the monitor publishes under the agent's key with a kind-0 profile attached, but the words come from `decideOpsNarration` — deterministic, no model in the loop. Asking that identity a question was talking to a nameplate.

This adds the inbound seam. **Default OFF.**

## The loop guard is the feature

A bot that answers messages in a channel it also posts to can answer itself, and each answer is another message to answer — at socket speed, against a live money system, at model cost per turn. So the rules live in a pure function with names and tests, not in a callback:

| guard | covers |
|---|---|
| `ignore-self` | our own key. Also catches a second monitor instance started by accident — it posts under the same pubkey |
| `ignore-replay` | stored events the relay replays on connect *and every reconnect*. Without it, each restart re-answers the last question |
| `ignore-seen` | redelivery. The id is recorded **before** the turn, so a redelivery mid-turn can't start a second identical answer |
| `ignore-rate-limited` | the loop we didn't think of. Bounds the blast radius to a known number |

Order matters: rate is evaluated **last**, so our own narration can't burn the window and disarm the backstop exactly when it would be needed.

## Persistent sockets, and the objection to them

`buzz-client.ts` argues against exactly what this adds:

> a socket that can be silently half-dead for hours inside the process whose entire job is noticing when something has gone quiet

That reasoning is right and still is — for publishing. You can't poll for a message nobody sent, so the cost is now **paid** rather than avoided:

- a **watchdog** reconnects a socket that has heard nothing at all — any frame counts as life, not just messages, or a healthy quiet channel would churn
- **backoff** capped and jittered, so a restarting relay isn't hit on the same instant every time
- **every phase reported**, because the danger was never the half-dead socket — it was the half-dead socket nobody could see. The relay proved this when it hung mid-startup and `#Ops` was silently dead for 4h

## A failed turn still speaks

Silence is indistinguishable from the listener being down, in the channel whose whole purpose is to be trustworthy when other things aren't. Failures publish a line that is deliberately a statement about *us* — "I could not answer … this is a failure on my side, not a verdict about the system" — so it can't be read as either a green or a red.

## Read-only is NOT enforced — stated plainly

The prompt tells Hermes to answer rather than act. That's guidance; the session carries its own MCP tools and some mutate. What actually bounds this is that the relay is closed (`BUZZ_REQUIRE_RELAY_MEMBERSHIP=true`) and the channel has **one member** — so the only person who can ask is the operator who could run those tools directly.

Fine for a private ops channel. **Not** fine for a shared one. If Buzz gains members, this needs tool-level scoping before it goes back on, and `BUZZ_INBOUND_REQUIRE_MENTION` should go on immediately.

It also refuses to open a socket unless the Hermes gateway is configured: a listener that can't answer would report the same configuration problem once per question.

## Tests

60 new (26 decision, 20 transport, 14 runtime). Typecheck clean, **2316 pass** on top of #664.

Not covered by tests, and the reason this is flag-gated: no live relay was involved. The handshake is driven through a fake socket, so the first real proof is turning it on.

## To enable

```
BUZZ_INBOUND_ENABLED=true
HERMES_SESSION_API_ENABLED=true   # plus HERMES_API_URL / HERMES_API_TOKEN
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)