### PR TITLE
fix(ops): an ok probe is never "awaiting data", whatever its prose says

### DIFF
--- a/packages/schemas/src/ops-verdict.test.ts
+++ b/packages/schemas/src/ops-verdict.test.ts
@@ -39,6 +39,34 @@ describe("classifiers", () => {
     expect(isAcknowledgedProbe(probe({ status: "red", detail: "2 warnings acknowledged" }))).toBe(false);
   });
 
+  // THE REGRESSION. The predicate read `status !== "red"`, which also swept in
+  // `ok` — so a healthy probe whose prose happened to contain one of these words
+  // was demoted to grey and dropped from the ok count.
+  //
+  // external_funnel did exactly this in production: `ok`, detail "1 awaiting
+  // review", meaning one job genuinely under review. Nothing was missing, and
+  // the board greyed it anyway. Renaming the string fixed that probe and left
+  // every future one exposed.
+  //
+  // An ok probe HAS its data. That is what ok means.
+  test("an ok probe is NEVER awaiting, whatever its prose says", () => {
+    expect(isAwaitingProbe(probe({ status: "ok", detail: "1 awaiting review" }))).toBe(false);
+    expect(isAwaitingProbe(probe({ status: "ok", detail: "0 claimable · 2 awaiting settlement" }))).toBe(false);
+    expect(isAwaitingProbe(probe({ status: "ok", detail: "no data older than 5m" }))).toBe(false);
+    expect(isAwaitingProbe(probe({ status: "ok", detail: "gasSponsor not configured (by design)" }))).toBe(false);
+  });
+
+  test("an ok probe with awaiting prose still counts as ok in the census", () => {
+    // The consequence that reaches the screen: it was subtracted from green and
+    // labelled awaiting, so a fully healthy board read "8 ok · 1 awaiting".
+    const census = probeCensus([
+      probe({ name: "a", status: "ok", detail: "fine" }),
+      probe({ name: "external_funnel", status: "ok", detail: "1 awaiting review" }),
+    ]);
+    expect(census).toBe("2 ok / 0 red");
+    expect(census).not.toContain("awaiting");
+  });
+
   test("acknowledged only applies to a degraded probe that says so", () => {
     expect(isAcknowledgedProbe(probe({ status: "degraded", detail: "4/7 up · 2 warnings acknowledged" }))).toBe(true);
     expect(isAcknowledgedProbe(probe({ status: "degraded", detail: "4/7 up · 2 warnings" }))).toBe(false);

--- a/packages/schemas/src/ops-verdict.ts
+++ b/packages/schemas/src/ops-verdict.ts
@@ -100,9 +100,32 @@ export interface OpsVerdict {
 // trailing d) matches both "not exposed" and "does not expose".
 const AWAITING_RE = /awaiting|not expose|not wired|not configured|unconfigured|no data/i;
 
-/** A probe whose degraded status is really "upstream data not wired yet". */
+/**
+ * A probe whose degraded status is really "upstream data not wired yet".
+ *
+ * ONLY `degraded`. This read `status !== "red"` until it was found to also sweep
+ * in `ok` — and matching here is not cosmetic. An awaiting probe is dropped from
+ * `unacknowledgedDegraded` (so it cannot raise the verdict) and is subtracted
+ * from the ok count, rendering grey.
+ *
+ * So an `ok` probe whose prose merely contained one of these words was silently
+ * demoted. `external_funnel` hit exactly that: it reported `ok` with the detail
+ * "1 awaiting review" — a real job under review, nothing missing — and the board
+ * greyed it and stopped counting it green. Renaming that one string fixed the
+ * symptom and left the mechanism armed for the next probe to word itself badly.
+ *
+ * The rule that makes it unrepresentable: a probe reporting `ok` HAS its data.
+ * That is what ok means, so prose cannot demote it. Only a `degraded` probe can
+ * be degraded *because* something upstream is missing. `red` was already
+ * excluded for the mirror-image reason — page-worthy leads whatever its detail
+ * says.
+ *
+ * Note this now matches the shape of `isAcknowledgedProbe` below, which has
+ * required `degraded` all along. They are siblings and should never have
+ * differed.
+ */
 export function isAwaitingProbe(probe: { status: VerdictStatus; detail: string }): boolean {
-  return probe.status !== "red" && AWAITING_RE.test(probe.detail);
+  return probe.status === "degraded" && AWAITING_RE.test(probe.detail);
 }
 
 // A degradation the operator has already triaged and declared expected. On


### PR DESCRIPTION
## The bug

```ts
return probe.status !== "red" && AWAITING_RE.test(probe.detail);
```

`status !== "red"` also sweeps in **`ok`**. And matching here isn't cosmetic — an awaiting probe is:

- dropped from `unacknowledgedDegraded`, so it **cannot raise the verdict**
- subtracted from the ok count and **rendered grey**

So a healthy probe whose detail merely contained `awaiting`, `no data`, `not configured`, `not wired`, or `not expose` was silently demoted.

`external_funnel` did exactly this in production: status `ok`, detail `"1 awaiting review"` — one job genuinely under review, nothing missing — and the board greyed it and stopped counting it green. Renaming that one string fixed the probe and left the mechanism armed for whichever probe worded itself badly next.

The one that would have hurt: **`"awaiting settlement"` in a `money_path` detail** would suppress a real degradation from the verdict entirely.

## The fix

```ts
return probe.status === "degraded" && AWAITING_RE.test(probe.detail);
```

A probe reporting `ok` **has** its data — that's what ok means, so prose can't demote it. Only a `degraded` probe can be degraded *because* something upstream is missing. `red` was already excluded for the mirror-image reason.

This also makes the predicate match its sibling `isAcknowledgedProbe` twenty lines below, which has required `degraded` all along. They're siblings and should never have differed.

## The sweep

Every consumer reads the same shared predicate, so all are fixed at once:

| consumer | use |
|---|---|
| `unacknowledgedDegraded` | verdict suppression |
| `probeCensus` | green count |
| `ops-frame.ts` | tone + nominal sub-line |
| `ops-digest.ts` | lead degradation |
| `ops-model.ts` → `probeOpsTone` | grey rendering |
| `phone-spec.ts` | mobile census |
| `product-health.ts` → `isAwaitingDetail` | incident history |

`ops-frame`'s `green = total - awaiting` looked suspect but is only reached on the all-nominal branch, where everything left is `ok`. Correct as written.

Also confirmed every genuine awaiting site reports `degraded` — `product_api` unconfigured, settlement not exposed, treasury addresses missing, RPC unset. None report `ok`, so nothing legitimate loses its grey.

## Verification

All four new cases return `true` under the old predicate and `false` under the new one — the guard is real, not a test that passes either way.

No existing test asserted an `ok` probe was awaiting; every one already used `degraded`. **The tests were describing the intended behaviour the code didn't implement.**

2319 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)