### PR TITLE
fix(buzz): a past delivery failure stops being a claim about now

### DIFF
--- a/services/slack-operator/src/buzz-delivery.ts
+++ b/services/slack-operator/src/buzz-delivery.ts
@@ -37,6 +37,36 @@ export interface BuzzDeliveryState {
   lastFailureDetail?: string;
 }
 
+/**
+ * After this long with no fresh attempt, a past failure stops being a claim
+ * about NOW.
+ *
+ * Deliveries are edge-triggered — narration speaks when the verdict crosses,
+ * probe alerts when a probe does — so hours can pass between attempts, and the
+ * row would otherwise keep asserting FAILING long after the relay recovered.
+ * That is a fake red, and this codebase treats one as costing exactly what a
+ * fake green costs: the operator learns to scroll past the row, and the next
+ * real failure is invisible.
+ *
+ * Six hours is deliberately generous. The one real outage so far ran four hours
+ * and reading FAILING throughout was correct and useful.
+ */
+export const FAILURE_GOES_STALE_AFTER_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * Failures the inbound listener can DISPROVE.
+ *
+ * The listener holds a persistent socket to the same relay, authenticated with
+ * the same key and the same NIP-OA tag. So while it reports `listening`, the
+ * relay is reachable and those credentials are accepted — which contradicts a
+ * stored connect/auth/timeout failure directly.
+ *
+ * `publish-rejected` is NOT in this set, and that is the important part: the
+ * relay accepted our auth and refused the message itself. A healthy listener
+ * says nothing about that, so it must not clear it.
+ */
+const LISTENER_DISPROVABLE = new Set(["connect-failed", "auth-rejected", "timeout"]);
+
 function ago(fromMs: number, nowMs: number): string {
   const mins = Math.max(0, Math.round((nowMs - fromMs) / 60_000));
   if (mins < 1) return "just now";
@@ -58,6 +88,14 @@ export function describeBuzzDelivery(input: {
   problem?: string | null;
   state: BuzzDeliveryState;
   nowMs: number;
+  /**
+   * Is the relay reachable RIGHT NOW, per the inbound listener's live socket?
+   *
+   * `undefined` means nobody is listening and there is no live evidence either
+   * way — which is different from `false` (we looked, it is not reachable) and
+   * must not be collapsed into it.
+   */
+  relayReachableNow?: boolean;
 }): BuzzDelivery {
   const { state, nowMs } = input;
 
@@ -83,11 +121,42 @@ export function describeBuzzDelivery(input: {
   if (failedAt !== undefined && (okAt === undefined || failedAt >= okAt)) {
     const reason = state.lastFailureReason ? `${state.lastFailureReason}` : "unknown reason";
     const since = okAt === undefined ? "never delivered" : `last delivered ${ago(okAt, nowMs)}`;
+    const carry = {
+      lastFailureAt: failedAt,
+      ...(okAt !== undefined ? { lastOkAt: okAt } : {}),
+    };
+
+    // The listener disproves it. Its socket is open to the same relay on the
+    // same credentials, so a stored connect/auth/timeout failure is a fact
+    // about the past, not a claim about now.
+    //
+    // `armed` rather than `ok` is the honest landing: nothing has actually been
+    // published since the failure, so the delivery path itself is untested —
+    // which is exactly what armed has always meant here. It renders grey and
+    // reads "#ops untested", not green.
+    if (input.relayReachableNow === true && LISTENER_DISPROVABLE.has(reason)) {
+      return {
+        status: "armed",
+        detail: `last attempt failed ${ago(failedAt, nowMs)} (${reason}) — relay reachable now · nothing delivered since`,
+        ...carry,
+      };
+    }
+
+    // Nobody has tried in a long time. We do not know that it is failing; we
+    // know it failed once and was never retried. Say the unknown out loud
+    // instead of asserting a red we cannot currently support.
+    if (input.relayReachableNow === undefined && nowMs - failedAt > FAILURE_GOES_STALE_AFTER_MS) {
+      return {
+        status: "armed",
+        detail: `last attempt failed ${ago(failedAt, nowMs)} (${reason}) · untested since — delivery is UNKNOWN`,
+        ...carry,
+      };
+    }
+
     return {
       status: "failing",
       detail: `FAILING ${ago(failedAt, nowMs)} — ${reason} · ${since}`,
-      lastFailureAt: failedAt,
-      ...(okAt !== undefined ? { lastOkAt: okAt } : {}),
+      ...carry,
     };
   }
 
@@ -96,6 +165,11 @@ export function describeBuzzDelivery(input: {
   }
 
   // Configured, credentials loaded, nothing ever sent. NOT ok — see the header.
+  // A listening socket proves the relay accepts these credentials, which is
+  // worth saying, but it is still not a delivery.
+  if (input.relayReachableNow === true) {
+    return { status: "armed", detail: "armed · relay reachable, nothing delivered yet" };
+  }
   return { status: "armed", detail: "armed · nothing delivered yet" };
 }
 

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -825,11 +825,17 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
       // an unreachable relay does not mean the money path is broken.
       buzz: (() => {
         const cfg = readBuzzConfig();
+        // The inbound listener holds a live socket to the same relay on the same
+        // credentials, so it can DISPROVE a stale connect/auth failure that
+        // nothing has retried since. `undefined` when no listener is running —
+        // no evidence either way, which is not the same as "not reachable".
+        const phase = buzzInbound.subscription?.state().phase;
         return describeBuzzDelivery({
           configured: cfg.config !== null,
           problem: cfg.config === null ? (cfg as { problem: string | null }).problem : null,
           state: buzzDeliveryState,
           nowMs: Date.now(),
+          ...(phase === undefined ? {} : { relayReachableNow: phase === "listening" }),
         });
       })(),
       ...(productHealthSnapshotBlocks ?? {}),

--- a/test/unit/buzz-delivery.test.ts
+++ b/test/unit/buzz-delivery.test.ts
@@ -75,6 +75,95 @@ describe("describeBuzzDelivery", () => {
   });
 });
 
+describe("a past failure stops being a claim about now", () => {
+  const HOUR = 60 * MIN;
+
+  it("the listener DISPROVES a stale connect failure", () => {
+    // The inbound listener holds a socket to the same relay on the same key and
+    // NIP-OA tag. While it reports listening, "connect-failed 5h ago" is a fact
+    // about the past, and asserting it as current is a fake red — which costs
+    // exactly what a fake green costs: the row gets scrolled past.
+    const r = describe_({
+      state: { lastFailureAt: NOW - 5 * HOUR, lastFailureReason: "connect-failed" },
+      relayReachableNow: true,
+    });
+    expect(r.status).toBe("armed");
+    expect(r.detail).toContain("relay reachable now");
+    expect(r.detail).toContain("nothing delivered since");
+  });
+
+  it("lands on ARMED, never ok — nothing has actually been delivered", () => {
+    // The distinction that matters: the relay being reachable is not a
+    // delivery. `armed` renders grey and reads "#ops untested", not green.
+    const r = describe_({
+      state: { lastFailureAt: NOW - 5 * HOUR, lastFailureReason: "timeout" },
+      relayReachableNow: true,
+    });
+    expect(r.status).not.toBe("ok");
+    expect(r.status).toBe("armed");
+  });
+
+  it("does NOT clear a publish-rejection, which the listener cannot speak to", () => {
+    // THE LINE THAT MATTERS. A reachable relay disproves connect/auth/timeout.
+    // `publish-rejected` means the relay accepted our auth and refused the
+    // MESSAGE — a healthy listener says nothing about that, so clearing it
+    // would be inventing evidence.
+    const r = describe_({
+      state: { lastFailureAt: NOW - 5 * HOUR, lastFailureReason: "publish-rejected" },
+      relayReachableNow: true,
+    });
+    expect(r.status).toBe("failing");
+    expect(r.detail).toContain("publish-rejected");
+  });
+
+  it("keeps FAILING while the listener agrees the relay is unreachable", () => {
+    // The four-hour outage: the row read FAILING throughout and that was
+    // correct and useful. Nothing here may weaken that case.
+    const r = describe_({
+      state: { lastFailureAt: NOW - 3 * HOUR, lastFailureReason: "connect-failed" },
+      relayReachableNow: false,
+    });
+    expect(r.status).toBe("failing");
+  });
+
+  it("ages an untested failure into UNKNOWN when nobody is listening", () => {
+    // Deliveries are edge-triggered, so hours pass between attempts. After long
+    // enough with no retry we do not know it is failing — only that it failed
+    // once and was never tried again. Say the unknown out loud.
+    const r = describe_({
+      state: { lastFailureAt: NOW - 7 * HOUR, lastFailureReason: "connect-failed" },
+    });
+    expect(r.status).toBe("armed");
+    expect(r.detail).toContain("untested since");
+    expect(r.detail).toContain("UNKNOWN");
+  });
+
+  it("still reports a RECENT failure as failing with no listener", () => {
+    const r = describe_({
+      state: { lastFailureAt: NOW - 2 * HOUR, lastFailureReason: "connect-failed" },
+    });
+    expect(r.status).toBe("failing");
+    expect(r.detail).toContain("FAILING");
+  });
+
+  it("treats no-listener as no evidence, not as unreachable", () => {
+    // `undefined` and `false` must not collapse: one is "we did not look", the
+    // other is "we looked and it is down". A recent failure with no listener
+    // stays failing rather than being cleared by absent evidence.
+    const recent = { lastFailureAt: NOW - 10 * MIN, lastFailureReason: "connect-failed" };
+    expect(describe_({ state: recent }).status).toBe("failing");
+    expect(describe_({ state: recent, relayReachableNow: false }).status).toBe("failing");
+    expect(describe_({ state: recent, relayReachableNow: true }).status).toBe("armed");
+  });
+
+  it("notes reachability even when nothing was ever sent", () => {
+    const r = describe_({ relayReachableNow: true });
+    expect(r.status).toBe("armed");
+    expect(r.detail).toContain("relay reachable");
+    expect(r.detail).toContain("nothing delivered yet");
+  });
+});
+
 describe("recordBuzzDelivery", () => {
   it("keeps the last success and the last failure independently", () => {
     let state = recordBuzzDelivery({}, { ok: true, atMs: NOW - 10 * MIN });


### PR DESCRIPTION
## The bug

The `OPS CHANNEL` row reports the last delivery **attempt**. Deliveries are edge-triggered — narration speaks when the verdict crosses a boundary, probe alerts when a probe does — so hours pass between attempts, and a single failure kept the row lit `FAILING` long after the relay recovered. `buzz-say` runs out-of-process and could never clear it.

That's a **fake red**, and this codebase already holds that one costs what a fake green costs: a permanently-lit row is one the operator learns to scroll past, which makes the next real failure invisible.

## Fix 1 — the listener disproves it

Since #665 the inbound listener holds a persistent socket to the **same relay**, authenticated with the **same key** and the **same NIP-OA tag**. While it reports `listening`, the relay is reachable and those credentials are accepted — which contradicts a stored `connect-failed` / `auth-rejected` / `timeout` outright.

This is new evidence, not a heuristic. It didn't exist when the row was written.

**`publish-rejected` is deliberately not disprovable.** That reason means the relay took our auth and refused the *message*. A healthy listener says nothing about that, so clearing it would be inventing evidence.

## Fix 2 — ageing, for when inbound is off

After six hours with no fresh attempt, we don't know it's failing — only that it failed once and was never retried:

> `last attempt failed 7h ago (connect-failed) · untested since — delivery is UNKNOWN`

Six hours is deliberately generous. The one real outage ran four, and reading `FAILING` throughout was correct and useful; nothing here weakens that case.

## Both land on `armed`, never `ok`

Nothing has actually been delivered, so the path is **untested** — which is precisely what `armed` has meant since this file was written ("ARMED IS NOT OK"). It already renders grey on the board and reads *"#ops untested"* on the phone, so **no new status and no consumer changes** were needed.

## `relayReachableNow` is tri-state on purpose

`undefined` means nobody is listening and there's no evidence either way. That must not collapse into `false` ("we looked, it's down") — the same `unverified` vs `shortfall` distinction the board makes everywhere else. A recent failure with no listener stays `FAILING`.

## Tests

8 new, including the two that keep this honest: `publish-rejected` survives a reachable relay, and a recent failure is not cleared by absent evidence.

2325 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)