### PR TITLE
Make a bundle deploy reload the agents that run from it

### DIFF
--- a/docs/HERMES_INTEGRATION_MAP.md
+++ b/docs/HERMES_INTEGRATION_MAP.md
@@ -22,10 +22,13 @@ packages/
   mcp-common/  schemas/
 services/
   slack-operator/   ← serves the live /monitor board, the Codex task queue + runner, testbed mission runner
-  skills-observer/  ← sidecar ingesting Hermes skill files, and reporting when the
-                      skills volume stops matching the repo. Also holds `skills-sync`
-                      (dist/sync.js), the one-shot that copies hermes/skills/** into
-                      the avg-hermes-skills volume before Hermes starts.
+  skills-observer/  ← sidecar ingesting Hermes skill files, and reporting when either
+                      of the agent's two volumes stops matching what shipped: the
+                      skills tree vs the repo, and the consumers' MCP tool registries
+                      vs the published bundle (src/bundle-drift.ts). Also holds
+                      `skills-sync` (dist/sync.js), the one-shot that copies
+                      hermes/skills/** into the avg-hermes-skills volume before
+                      Hermes starts.
 ops/                ← Docker compose stack (base, prod, command-center, cloudflare-access)
 hermes/             ← Hermes config (hermes.yaml, policy.yaml), trace plugin, and
                       skills/ — the source of truth for what the agent loads
@@ -106,6 +109,14 @@ Two existing guardrail layers, **both about job/mission execution, neither about
 operator_command | testbed_e2e_read_only | testbed_suite | testbed_case
 | pr_code_review | pr_handoff | post_deploy_verification
 ```
+
+**⚠ KEY FINDING — shipping a tool is not the same as the agent having it.** The MCP servers do not live in any consumer's image. They live in the **`avg-app` volume**, which the `mcp-bundle` service rewrites (`rm -rf` + `cp -a`) on every deploy, and which `hermes` (`ops/compose.yml`) and `hermes-gateway` (`ops/compose.command-center.yml`) mount read-only at `/app`. **An MCP client registers its tool list once, at process startup.** So a deploy that ships a new tool leaves every consumer that was not restarted advertising the previous list — with nothing erroring. Worse, because the rewrite unlinks the old files, a consumer that later respawns an MCP subprocess gets *new* code behind an *old* registration.
+
+This bit twice on 2026-08-02 with `averray_board_health` (#657): `hermes` picked it up only because someone restarted it by hand; `hermes-gateway`, up nine hours, did not, so the Buzz inbound listener answered an operator's health question from `averray_ops_health` (the Postgres control plane, **not** the board) and reported "No issues on the board" having never read the board. It surfaced only because #666 made the prompt name the tool. Same class as the skills volume in #664.
+
+Two mechanisms now cover it, and **neither is allowed to fail quietly**:
+- `ops/deploy-monitor.sh` restarts every running consumer of the volume after republishing it, discovered with `docker ps --filter volume=avg_avg-app` — deliberately a *runtime* lookup, because `hermes-gateway` is behind `--profile command-center` and a Compose-level restart would silently miss it (and miss the next profiled consumer too). It restarts only when the bundle's id actually changed, and warns loudly when it restarts nothing.
+- Each MCP server process stamps which bundle it loaded (`packages/mcp-common/src/bundle-registry.ts`); `skills-observer` compares those stamps against the volume and reports a mismatch to Slack. Absence of stamps reads as **unknown**, never as agreement.
 
 **⚠ KEY FINDING.** There is **no dispatch/enqueue intent** — `invoke_agent_task` only reviews and tests. Today Hermes literally **cannot enqueue a worker task through MCP**; tasks enter only via the monitor HTTP endpoint (Q2). So Rung B/C requires either a **new intent** (e.g. `enqueue_agent_task`) or a Hermes path to the `POST /monitor/codex-tasks` endpoint — gated by the new guardrail from Q4.
 

--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -47,6 +47,26 @@ services:
       - avg-hermes-skills:/opt/data/skills
     networks: [avg-internal]
 
+  # Publishes the built monorepo into the avg-app volume, which is where the
+  # five MCP servers actually live. `hermes` and `hermes-gateway` mount it
+  # read-only at /app and spawn the servers from it.
+  #
+  # THE COPY IS NOT THE DELIVERY. An MCP client registers its tool list once,
+  # at process startup, so rewriting this volume under a consumer that keeps
+  # running changes the files and not the tool surface — the consumer keeps
+  # advertising the previous list, and nothing errors. Worse, the rewrite is an
+  # `rm -rf` + `cp -a`: a consumer that later respawns an MCP subprocess gets
+  # NEW code behind an OLD registration, so the running system is not "safely
+  # stale", it is undefined.
+  #
+  # This bit twice on 2026-08-02. `averray_board_health` (#657) shipped while
+  # hermes-gateway had been up nine hours; the gateway never saw the tool, so
+  # the Buzz listener answered an operator's question about system health from
+  # `averray_ops_health` — the Postgres control plane, explicitly not the board
+  # — and said "No issues on the board" having never read the board.
+  #
+  # So the copy stamps its own identity, and ops/deploy-monitor.sh restarts
+  # every consumer whose stamp it changed. See .mcp-bundle-id below.
   mcp-bundle:
     build:
       context: ..
@@ -63,12 +83,38 @@ services:
       hermes-permissions:
         condition: service_completed_successfully
     user: root
+    # `$$` keeps these for the container's shell — a single `$` would be
+    # substituted by Compose from the HOST environment, where AVERRAY_GIT_SHA
+    # is not set and the stamp would silently read "sha:".
     command:
-      [
-        "/bin/sh",
-        "-lc",
-        "rm -rf /runtime-app/* && cp -a /app/. /runtime-app/ && chmod -R a+rX /runtime-app"
-      ]
+      - /bin/sh
+      - -lc
+      - |
+        set -e
+        rm -rf /runtime-app/*
+        cp -a /app/. /runtime-app/
+        # WHAT THE STAMP HAS TO MEAN: "consumers loaded from a copy carrying a
+        # different id are stale." So it may only be stable across two copies
+        # when their CONTENTS are provably identical.
+        #
+        # A clean build is exactly that case — the tree is the commit — so it
+        # identifies by sha, and re-running a deploy at the same sha therefore
+        # leaves Hermes alone instead of bouncing the agent for nothing.
+        #
+        # A dirty or unstamped build is the case where the sha is a lie: the
+        # image is HEAD plus edits nobody can see. It cannot claim identity
+        # with anything, so every copy gets a fresh id and every consumer is
+        # restarted. Truthfully pessimistic beats cheaply wrong.
+        if [ "$$AVERRAY_GIT_DIRTY" = false ] && [ "$$AVERRAY_GIT_SHA" != unknown ]; then
+          BUNDLE_ID="sha:$$AVERRAY_GIT_SHA"
+        elif [ "$$AVERRAY_GIT_SHA" != unknown ]; then
+          BUNDLE_ID="dirty:$$AVERRAY_GIT_SHA@$$(date -u +%Y%m%dT%H%M%SZ)"
+        else
+          BUNDLE_ID="unknown:@$$(date -u +%Y%m%dT%H%M%SZ)"
+        fi
+        printf '%s\n' "$$BUNDLE_ID" > /runtime-app/.mcp-bundle-id
+        chmod -R a+rX /runtime-app
+        echo "mcp bundle published: $$BUNDLE_ID"
     volumes:
       - avg-app:/runtime-app
     networks: [avg-internal]
@@ -180,6 +226,11 @@ services:
     depends_on:
       hermes-permissions:
         condition: service_completed_successfully
+      # So the bundle stamp exists before the first check looks for it. Without
+      # this the observer's opening verdict on a cold box is UNKNOWN, which is
+      # true but is an alert nobody needed.
+      mcp-bundle:
+        condition: service_completed_successfully
     command: ["node", "services/skills-observer/dist/index.js"]
     environment:
       DATABASE_URL: ${DATABASE_URL}
@@ -188,12 +239,21 @@ services:
       # volume stops matching git. skills-sync makes the copy right; this makes
       # a later divergence visible instead of silent.
       REPO_SKILLS_DIR: /repo-skills
+      # The published MCP bundle and the stamps its consumers leave behind. See
+      # the second half of this service's job in src/bundle-drift.ts.
+      MCP_BUNDLE_DIR: /bundle
+      MCP_BUNDLE_REGISTRY_DIR: /data/mcp-bundle-registry
       SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL}
       LOG_LEVEL: ${LOG_LEVEL:-info}
     volumes:
       - avg-hermes:/opt/data:ro
       - avg-hermes-skills:/hermes-skills:ro
       - ../hermes/skills:/repo-skills:ro
+      # Read-only on both: this service reports, it never repairs. The bundle is
+      # what mcp-bundle published; the registry is what the consumers' own MCP
+      # server processes recorded about which copy they started from.
+      - avg-app:/bundle:ro
+      - avg-data:/data:ro
     networks: [avg-internal]
 
   slack-operator:

--- a/ops/deploy-monitor.sh
+++ b/ops/deploy-monitor.sh
@@ -18,15 +18,26 @@
 #   ops/deploy-monitor.sh                 # build + deploy slack-operator
 #   ops/deploy-monitor.sh --allow-dirty   # ...from a dirty tree, marked as such
 #   ops/deploy-monitor.sh web             # deploy a different service
+#   ops/deploy-monitor.sh --restart-consumers
+#                                         # ...and restart the MCP bundle's
+#                                         # consumers even if it did not change
+#                                         # (retry after a failed restart)
+#
+# Beyond the sha, this owns the two steps a deploy is not correct without and
+# that nobody remembers to type: syncing hermes/skills into the skills volume,
+# and restarting whatever runs from the MCP bundle once it has been republished.
+# Both are advisory and both are loud; see their notes below.
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
 ALLOW_DIRTY=false
+FORCE_RESTART=false
 SERVICE=slack-operator
 for arg in "$@"; do
   case "$arg" in
     --allow-dirty) ALLOW_DIRTY=true ;;
+    --restart-consumers) FORCE_RESTART=true ;;
     -*) echo "unknown flag: $arg" >&2; exit 2 ;;
     *) SERVICE="$arg" ;;
   esac
@@ -95,11 +106,32 @@ if [ -n "$TRACKED_DIRT" ] || [ -n "$SHIPPED_UNTRACKED" ]; then
   echo "WARNING: building from a DIRTY tree — self-freshness will report unknown."
 fi
 
-COMPOSE=(docker compose -p avg --env-file .env.prod
+PROJECT=avg
+COMPOSE=(docker compose -p "$PROJECT" --env-file .env.prod
   -f ops/compose.yml
   -f ops/compose.prod.yml
   -f ops/compose.command-center.yml
   -f ops/compose.cloudflare-access.yml)
+
+# The volume the MCP servers actually run from, project-prefixed as Docker
+# names it. See the bundle-consumer restart at the end of this script.
+BUNDLE_VOLUME="${PROJECT}_avg-app"
+BUNDLE_ID_PATH=/bundle/.mcp-bundle-id
+
+# Reading a named volume needs a container; there is no host path for one that
+# is not root-only and box-specific. alpine:3.20 is already pinned in
+# ops/compose.yml (mcp-env), so it is local on any box being deployed to.
+#
+# The existence check is not defensive padding: `docker run -v <name>:...`
+# CREATES a missing volume, and a volume created outside Compose has none of
+# Compose's labels — which is exactly the state Compose refuses to adopt. On a
+# first-ever deploy that would turn a read into a broken stack. No volume means
+# no previous bundle, which is what the empty string says.
+read_bundle_id() {
+  docker volume inspect "${BUNDLE_VOLUME}" >/dev/null 2>&1 || return 0
+  docker run --rm -v "${BUNDLE_VOLUME}:/bundle:ro" alpine:3.20 \
+    cat "${BUNDLE_ID_PATH}" 2>/dev/null | tr -d '\r\n' || true
+}
 
 # SYNC THE SKILL TREE FIRST — on every deploy, whatever service is being
 # deployed.
@@ -139,11 +171,135 @@ else
   echo >&2
 fi
 
+# Read BEFORE the deploy, because `up` re-runs mcp-bundle as a dependency and
+# republishes the volume. Comparing this against the id afterwards is what
+# tells us whether the consumers' code actually changed under them.
+BUNDLE_ID_BEFORE="$(read_bundle_id)"
+
 echo "deploying ${SERVICE} at ${GIT_SHA:0:8}$([ "$GIT_DIRTY" = true ] && echo ' (dirty)')"
 
 # NEVER --remove-orphans here: this compose project shares a network with
 # services defined in other files, and it would take them down.
 GIT_SHA="$GIT_SHA" GIT_DIRTY="$GIT_DIRTY" "${COMPOSE[@]}" up -d --build "$SERVICE"
+
+# RESTART WHATEVER RUNS FROM THE BUNDLE.
+#
+# The MCP servers are not in anyone's image: they live in the avg-app volume,
+# which mcp-bundle rewrites (rm -rf + cp -a) every time this script runs. An MCP
+# client registers its tool list ONCE, at process startup, so rewriting the
+# volume under a running consumer changes the files and not the tool surface —
+# it keeps advertising the previous list, and nothing errors.
+#
+# On 2026-08-02 that cost us twice. `averray_board_health` (#657) shipped;
+# `hermes` picked it up only because someone restarted it by hand, and
+# `hermes-gateway` — up nine hours — did not. The Buzz inbound listener then
+# answered an operator's question about system health from `averray_ops_health`
+# (the Postgres control plane, explicitly NOT the board) and said "No issues on
+# the board" having never read the board. It surfaced only because #666 made the
+# prompt name the tool. Same class as the skills volume in #664: the artifact
+# ships, the consumer never reloads, and nothing errors.
+#
+# Nor is leaving them alone the safe option. The rewrite unlinks the old files,
+# so a consumer that later respawns an MCP subprocess gets NEW code behind an
+# OLD registration. The running system is not stale, it is undefined.
+#
+# WHY `docker ps` AND NOT COMPOSE. hermes-gateway is behind
+# `--profile command-center`, so `compose restart hermes-gateway` finds nothing
+# unless the profile is passed — and the next consumer added behind the next
+# profile would be missed in exactly the same silence this is here to end.
+# Profile membership is a Compose concept; "who has this volume mounted right
+# now" is a runtime one, and the runtime is the thing we need the truth about.
+# This also cannot start something the operator deliberately stopped, which
+# `compose up` could.
+#
+# ADVISORY, not fatal — the same call #664 made for the skills sync. Deploying
+# the board is how the operator sees the money path, and the board does not run
+# from this volume. Failing that deploy because the agent would not restart
+# would be coupling the money path to the agent, which is precisely backwards.
+# A restart that does not happen is reported here and keeps being reported by
+# skills-observer until it does.
+BUNDLE_ID_AFTER="$(read_bundle_id)"
+
+if [ "$FORCE_RESTART" != true ] && [ -z "$BUNDLE_ID_AFTER" ]; then
+  # No stamp means mcp-bundle did not run in this deploy — `${SERVICE}` does not
+  # depend on it — or the volume predates the stamp. Either way nothing here
+  # established that the consumers changed, and restarting the agent on no
+  # evidence is the coupling this script is careful not to introduce. Say what
+  # is actually known, which is nothing.
+  echo
+  echo "no bundle id in ${BUNDLE_VOLUME} — this deploy did not republish it, so nothing here" >&2
+  echo "can say whether the consumers are current. skills-observer reports that separately," >&2
+  echo "and --restart-consumers restarts them anyway." >&2
+elif [ "$FORCE_RESTART" != true ] && [ -n "$BUNDLE_ID_BEFORE" ] &&
+     [ "$BUNDLE_ID_BEFORE" = "$BUNDLE_ID_AFTER" ]; then
+  # Only a clean build can produce a stable id, and a clean build at the same
+  # sha is byte-identical — so this deploy changed nothing under the consumers.
+  # Dirty builds never take this path (mcp-bundle stamps them uniquely), so
+  # "unchanged" is never a guess.
+  #
+  # Note what this does NOT say. "The bundle did not change" is not "the
+  # consumers are current" — nothing here looked at them, and one could still be
+  # stale from an earlier deploy whose restart failed. Claiming otherwise would
+  # be worst on the path where it matters most: the operator who just read the
+  # restart warning below and re-ran this script to retry would be told
+  # everything is fine while the stale consumer stayed stale. That is the
+  # original bug wearing the fix's clothes. Hence --restart-consumers.
+  echo
+  echo "MCP bundle unchanged (${BUNDLE_ID_AFTER}) — this deploy made nothing stale."
+  echo "  (Whether the consumers were already current is a separate question this"
+  echo "   does not answer; skills-observer does. Force one with --restart-consumers.)"
+else
+  echo
+  if [ "$FORCE_RESTART" = true ] && [ "$BUNDLE_ID_BEFORE" = "$BUNDLE_ID_AFTER" ]; then
+    echo "MCP bundle unchanged (${BUNDLE_ID_AFTER:-unknown}); restarting anyway as asked."
+  else
+    echo "MCP bundle is now ${BUNDLE_ID_AFTER:-unknown} (was ${BUNDLE_ID_BEFORE:-none})."
+  fi
+  echo "restarting everything that runs from it, so its tool list matches:"
+
+  BUNDLE_CONSUMERS="$(docker ps \
+    --filter "volume=${BUNDLE_VOLUME}" \
+    --filter "label=com.docker.compose.project=${PROJECT}" \
+    --format '{{.ID}} {{.Label "com.docker.compose.service"}}' || true)"
+
+  RESTART_FAILED=false
+  RESTARTED=0
+  while read -r cid service; do
+    [ -n "$cid" ] || continue
+    # The publisher mounts the same volume. It is a one-shot that has already
+    # exited by now, but skip it by name rather than by luck.
+    [ "$service" != mcp-bundle ] || continue
+    if docker restart "$cid" >/dev/null; then
+      echo "  restarted ${service} (${cid:0:12})"
+      RESTARTED=$((RESTARTED + 1))
+    else
+      echo "  FAILED to restart ${service} (${cid:0:12})" >&2
+      RESTART_FAILED=true
+    fi
+  done <<EOF
+$BUNDLE_CONSUMERS
+EOF
+
+  if [ "$RESTARTED" -eq 0 ]; then
+    # Not success. Every box that runs the agent has consumers of this volume,
+    # so finding none means either they are all down or the lookup is wrong —
+    # and "the deploy printed nothing" must not be how either one is discovered.
+    echo >&2
+    echo "WARNING: the bundle changed but NO running consumer of ${BUNDLE_VOLUME} was found." >&2
+    echo "         Nothing was restarted. If hermes / hermes-gateway are up, they are now" >&2
+    echo "         serving a tool list from the previous bundle: check" >&2
+    echo "         \`docker ps --filter volume=${BUNDLE_VOLUME}\`." >&2
+    echo >&2
+  elif [ "$RESTART_FAILED" = true ]; then
+    echo >&2
+    echo "WARNING: at least one consumer did not restart. It is still serving the tool list" >&2
+    echo "         from the previous bundle — a tool shipped by this deploy is invisible to" >&2
+    echo "         it, and it will answer as if that tool does not exist. The deploy of" >&2
+    echo "         ${SERVICE} continues (it does not run from this volume)." >&2
+    echo "         skills-observer keeps reporting the drift until it is resolved." >&2
+    echo >&2
+  fi
+fi
 
 echo
 echo "deployed. Confirm the monitor knows its own version:"

--- a/packages/mcp-common/src/bundle-registry.ts
+++ b/packages/mcp-common/src/bundle-registry.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { optionalEnv } from "./config.js";
+import { logger } from "./logger.js";
+
+/**
+ * Record which MCP bundle each running server process was started from.
+ *
+ * WHY THIS EXISTS. The five MCP servers are not in the consumer's image — they
+ * live in the `avg-app` volume, which the `mcp-bundle` service rewrites on
+ * every deploy (see ops/compose.yml). `hermes` and `hermes-gateway` mount that
+ * volume read-only at /app and spawn the servers from it, and an MCP client
+ * registers its tool list ONCE, at process startup. A consumer that is not
+ * restarted therefore keeps advertising the previous tool list against the new
+ * files, and nothing errors.
+ *
+ * On 2026-08-02 `averray_board_health` (#657) shipped while hermes-gateway had
+ * been up nine hours. It never saw the tool, so the Buzz inbound listener
+ * answered an operator's question about system health from `averray_ops_health`
+ * — the Postgres control plane, which is explicitly not the board — and
+ * reported "No issues on the board" having never read the board. A stale tool
+ * registry looks exactly like a working agent.
+ *
+ * ops/deploy-monitor.sh is the fix: it restarts every consumer of the volume.
+ * This is the backstop for every path that is not that script — a hand
+ * `docker compose up`, a restart that failed, a consumer nobody remembered.
+ * Each process stamps the bundle it loaded; skills-observer compares those
+ * stamps against the volume and reports when they disagree.
+ *
+ * Three rules this obeys, all of them load-bearing:
+ *
+ *   IT NEVER BREAKS THE SERVER. Every operation is best-effort and swallows its
+ *   own errors. An observability record that can take down the agent's tool
+ *   surface would be a worse bug than the one it reports.
+ *
+ *   IT IS SYNCHRONOUS. This runs in the startup path of a stdio server. An
+ *   async write that hangs would delay `server.connect`, and one that rejects
+ *   later would be an unhandled rejection in a process whose job is to stay up.
+ *   The payload is a couple of hundred bytes.
+ *
+ *   IT NEVER TOUCHES STDOUT. stdout IS the MCP transport — a stray write
+ *   corrupts the protocol. `logger` goes to stderr (logger.ts); keep it there.
+ */
+
+/** Written into the volume by `mcp-bundle` as the last step of publishing it. */
+export const BUNDLE_ID_FILE = ".mcp-bundle-id";
+
+/**
+ * What an unstamped bundle reports. NOT a bundle id that can match another: a
+ * consumer running an unstamped copy is unknown, not current, and the observer
+ * has to be able to tell those apart rather than folding one into the other.
+ */
+export const UNKNOWN_BUNDLE_ID = "unknown";
+
+/** The `avg-data` volume, which every bundle consumer already mounts at /data. */
+const DEFAULT_REGISTRY_DIR = "/data/mcp-bundle-registry";
+
+/**
+ * A record only means something while the process it describes is alive. A dead
+ * process's stamp would report drift forever, and drift that never clears is
+ * drift nobody reads (see services/skills-observer/src/drift-alert.ts). So each
+ * process rewrites its own record on this interval, and the reader ignores
+ * records that have stopped being refreshed.
+ */
+const DEFAULT_HEARTBEAT_MS = 60_000;
+
+/** Beyond this a record describes a process that is gone. Five missed beats. */
+export const RECORD_LIVE_MS = 5 * DEFAULT_HEARTBEAT_MS;
+
+/**
+ * Records this old are from containers that no longer exist — every consumer is
+ * recreated far more often than this. Pruned so a volume that is never emptied
+ * does not accumulate one file per server per container for the life of the box.
+ */
+const PRUNE_AFTER_MS = 24 * 60 * 60 * 1000;
+
+export interface McpProcessRecord {
+  /** The file that was executed, as the consumer sees it inside its own mounts. */
+  entry: string;
+  /** Container hostname — the identity of the consumer holding this process. */
+  host: string;
+  pid: number;
+  /** When this process started, not when the record was last refreshed. */
+  startedAt: string;
+  /** The bundle it loaded, read once at startup. Never re-read afterwards. */
+  bundleId: string;
+}
+
+/**
+ * One file per (consumer, entry point), so a restart overwrites its predecessor
+ * instead of leaving a second record that looks like a second live process.
+ */
+export function bundleRecordFileName(host: string, entry: string): string {
+  const slug = `${host}__${entry}`.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+  return `${slug || "unnamed"}.json`;
+}
+
+/**
+ * Find the stamp of the bundle `entryPath` was loaded from, by walking up from
+ * the entry towards the root.
+ *
+ * Deliberately derived from the executed file rather than from a configured
+ * path: what matters is the copy this process actually ran, and only the entry
+ * knows that. A dev run from a source checkout finds no stamp and reports
+ * unknown, which is the truth — there is no published bundle to be stale
+ * against.
+ */
+export function readBundleId(entryPath: string): string {
+  let dir = path.dirname(path.resolve(entryPath));
+  for (;;) {
+    try {
+      const contents = fs.readFileSync(path.join(dir, BUNDLE_ID_FILE), "utf8").trim();
+      if (contents) return contents;
+    } catch {
+      // Not here — keep climbing. An unreadable stamp is the same as no stamp:
+      // nothing can be claimed either way.
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return UNKNOWN_BUNDLE_ID;
+    dir = parent;
+  }
+}
+
+export function buildMcpProcessRecord(entryPath: string, startedAt: Date): McpProcessRecord {
+  return {
+    entry: entryPath,
+    host: os.hostname(),
+    pid: process.pid,
+    startedAt: startedAt.toISOString(),
+    bundleId: readBundleId(entryPath)
+  };
+}
+
+/** Best-effort. Returns whether the record reached disk, and never throws. */
+export function writeMcpProcessRecord(directory: string, record: McpProcessRecord): boolean {
+  try {
+    fs.mkdirSync(directory, { recursive: true });
+    fs.writeFileSync(
+      path.join(directory, bundleRecordFileName(record.host, record.entry)),
+      `${JSON.stringify(record, null, 2)}\n`
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort. Returns how many records it removed, and never throws. */
+export function pruneMcpProcessRecords(directory: string, now: number, olderThanMs: number): number {
+  let removed = 0;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(directory);
+  } catch {
+    return 0;
+  }
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const filePath = path.join(directory, name);
+    try {
+      if (now - fs.statSync(filePath).mtimeMs <= olderThanMs) continue;
+      fs.unlinkSync(filePath);
+      removed += 1;
+    } catch {
+      // Another process may own or have just replaced it. Not ours to insist on.
+    }
+  }
+  return removed;
+}
+
+/**
+ * Stamp this process into the registry and keep the stamp fresh for as long as
+ * it runs. Call once, at startup.
+ *
+ * The heartbeat timer is unref'd: a stdio server is kept alive by its transport,
+ * and a referenced timer would outlive it and leave the process hanging after
+ * the client disconnects. Bookkeeping must not decide when the server exits.
+ */
+export function registerMcpProcess(options: {
+  entryPath?: string;
+  directory?: string;
+  heartbeatMs?: number;
+  now?: () => Date;
+} = {}): void {
+  const entryPath = options.entryPath ?? process.argv[1];
+  if (!entryPath) return;
+
+  const directory = options.directory ?? optionalEnv("MCP_BUNDLE_REGISTRY_DIR", DEFAULT_REGISTRY_DIR);
+  const heartbeatMs = options.heartbeatMs ?? DEFAULT_HEARTBEAT_MS;
+  const now = options.now ?? (() => new Date());
+
+  const record = buildMcpProcessRecord(entryPath, now());
+  if (!writeMcpProcessRecord(directory, record)) {
+    // Worth a line, but only a line. The registry is a backstop; the deploy is
+    // the guarantee. Note that skills-observer reads the ABSENCE of records as
+    // unknown rather than as agreement, so a consumer failing this write cannot
+    // make the fleet look current — it makes it look unreadable, which it is.
+    logger.warn(
+      { directory, entry: entryPath },
+      "mcp_bundle_record_write_failed: this process cannot record which bundle it loaded, so " +
+        "drift detection cannot speak for it. ops/deploy-monitor.sh remains the guarantee."
+    );
+    return;
+  }
+
+  pruneMcpProcessRecords(directory, now().getTime(), PRUNE_AFTER_MS);
+  logger.info(
+    { entry: record.entry, bundleId: record.bundleId },
+    "mcp_bundle_record_written"
+  );
+
+  // Rewriting beats touching the mtime: it repairs a record that was deleted
+  // out from under us, and costs the same at this size.
+  setInterval(() => writeMcpProcessRecord(directory, record), heartbeatMs).unref();
+}

--- a/packages/mcp-common/src/index.ts
+++ b/packages/mcp-common/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./auth.js";
+export * from "./bundle-registry.js";
 export * from "./canonical-json.js";
 export * from "./config.js";
 export * from "./db.js";

--- a/packages/mcp-common/src/mcp.ts
+++ b/packages/mcp-common/src/mcp.ts
@@ -1,6 +1,8 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
+import { registerMcpProcess } from "./bundle-registry.js";
+
 export function jsonContent(value: unknown) {
   return {
     content: [
@@ -13,6 +15,10 @@ export function jsonContent(value: unknown) {
 }
 
 export async function runStdioServer(server: McpServer): Promise<void> {
+  // Before connect, because connecting is the moment the tool list this process
+  // holds becomes the answer the agent will give until it is restarted. That is
+  // exactly what the record is a record of. See bundle-registry.ts.
+  registerMcpProcess();
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/services/skills-observer/src/bundle-drift.ts
+++ b/services/skills-observer/src/bundle-drift.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  BUNDLE_ID_FILE,
+  RECORD_LIVE_MS,
+  UNKNOWN_BUNDLE_ID,
+  type McpProcessRecord
+} from "@avg/mcp-common";
+
+/**
+ * Report when a running consumer's MCP tool registry is older than the bundle.
+ *
+ * The bundle is the `avg-app` volume: the five MCP servers live there, not in
+ * the consumers' images. `mcp-bundle` rewrites it on every deploy, but an MCP
+ * client registers its tool list once, at process startup — so a consumer that
+ * is not restarted keeps serving the previous tool list against the new files,
+ * silently. That is the 2026-08-02 `averray_board_health` incident: the gateway
+ * answered a health question from the wrong tool because it had never seen the
+ * right one, and looked entirely healthy doing it.
+ *
+ * ops/deploy-monitor.sh is the guarantee — it restarts every consumer of the
+ * volume. This is the backstop for the paths that are not that script.
+ *
+ * WHAT IT COMPARES. Not tool lists: the bundle id. The tool list is downstream
+ * of which copy a process loaded, so the id catches strictly more (a changed
+ * description, a changed handler, a removed tool) and needs no build-time
+ * manifest to be kept honest. `packages/mcp-common/src/bundle-registry.ts`
+ * writes the stamps; this reads them.
+ *
+ * WHAT IT CANNOT SEE, stated plainly because a check that implies more coverage
+ * than it has is the failure it exists to prevent: a consumer whose MCP
+ * processes never manage to write a record is invisible here. It cannot make
+ * the fleet look current — zero records reads as unknown, never as agreement —
+ * but a consumer that is silent while another is healthy will not be singled
+ * out. The deploy-side restart, not this, is what makes coverage complete.
+ */
+
+/** A record still being refreshed by the process that wrote it. */
+export interface LiveMcpProcess extends McpProcessRecord {
+  /** How long ago the record was last refreshed. */
+  ageMs: number;
+}
+
+export type BundleObservation =
+  /** Every live process is running the bundle the volume currently holds. */
+  | { kind: "current"; live: LiveMcpProcess[] }
+  /** At least one live process is serving a tool list from an older copy. */
+  | { kind: "stale"; signature: string; stale: LiveMcpProcess[]; live: LiveMcpProcess[] }
+  /** The comparison could not be made. Never conflate this with agreement. */
+  | { kind: "unknown"; reason: string };
+
+/** One pass over the registry: what was read, and what could not be. */
+export interface RegistryReading {
+  live: LiveMcpProcess[];
+  /**
+   * Records present but unreadable this pass. Carried rather than dropped: a
+   * record skipped here is a live process the comparison cannot see, and the
+   * one thing that must never happen is a process disappearing from view and
+   * the remainder then reporting agreement.
+   */
+  unreadable: string[];
+}
+
+/** The published bundle's stamp, or undefined when it could not be read. */
+export async function readPublishedBundleId(bundleDir: string): Promise<string | undefined> {
+  try {
+    const contents = (await fs.readFile(path.join(bundleDir, BUNDLE_ID_FILE), "utf8")).trim();
+    return contents || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Read every record still being heart-beaten.
+ *
+ * Liveness is the mtime, not the file's existence: a record left by a container
+ * that is gone would otherwise report drift forever, and an alert that never
+ * clears is one nobody reads.
+ */
+export async function readMcpProcessRegistry(
+  registryDir: string,
+  now: number,
+  liveWithinMs = RECORD_LIVE_MS
+): Promise<RegistryReading> {
+  const entries = await fs.readdir(registryDir);
+  const live: LiveMcpProcess[] = [];
+  const unreadable: string[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".json")) continue;
+    const filePath = path.join(registryDir, name);
+    try {
+      const [raw, stat] = await Promise.all([fs.readFile(filePath, "utf8"), fs.stat(filePath)]);
+      const ageMs = now - stat.mtimeMs;
+      // Not unreadable — this one was read, and it says its process is gone.
+      if (ageMs > liveWithinMs) continue;
+      const record = parseRecord(raw);
+      if (record) live.push({ ...record, ageMs });
+      else unreadable.push(name);
+    } catch {
+      // Torn mid-rewrite, or unreadable. Skipping it silently would be the
+      // dangerous move: if the ONLY stale process is the one we could not read,
+      // the survivors all match and the check would report agreement. So it is
+      // counted, and agreement is withheld while any record is unaccounted for.
+      unreadable.push(name);
+    }
+  }
+  return {
+    live: live.sort((a, b) => `${a.host}${a.entry}`.localeCompare(`${b.host}${b.entry}`)),
+    unreadable: unreadable.sort()
+  };
+}
+
+function parseRecord(raw: string): McpProcessRecord | undefined {
+  const value: unknown = JSON.parse(raw);
+  if (typeof value !== "object" || value === null) return undefined;
+  const { entry, host, pid, startedAt, bundleId } = value as Record<string, unknown>;
+  if (typeof entry !== "string" || typeof host !== "string" || typeof bundleId !== "string") {
+    return undefined;
+  }
+  return {
+    entry,
+    host,
+    bundleId,
+    pid: typeof pid === "number" ? pid : 0,
+    startedAt: typeof startedAt === "string" ? startedAt : ""
+  };
+}
+
+/**
+ * Decide what the stamps say about the published bundle.
+ *
+ * `UNKNOWN_BUNDLE_ID` on either side is not a value that can match: a process
+ * that could not read its stamp, or a bundle published without one, tells us
+ * nothing about whether they agree — and "nothing" must not round to "yes".
+ */
+export function compareBundle(
+  publishedBundleId: string | undefined,
+  reading: RegistryReading
+): BundleObservation {
+  const { live, unreadable } = reading;
+  if (!publishedBundleId) {
+    return {
+      kind: "unknown",
+      reason:
+        "the published bundle carries no readable id, so what the consumers should be running " +
+        "cannot be established"
+    };
+  }
+  if (publishedBundleId === UNKNOWN_BUNDLE_ID) {
+    return {
+      kind: "unknown",
+      reason:
+        "the published bundle is stamped as unknown, so no consumer can be shown to match it"
+    };
+  }
+  if (live.length === 0 && unreadable.length === 0) {
+    return {
+      kind: "unknown",
+      reason:
+        "no MCP server process is recording which bundle it loaded — either no consumer of the " +
+        "bundle is running, or they cannot write the registry"
+    };
+  }
+
+  // Stale first: a process demonstrably on an older bundle is a fact, and an
+  // unreadable record elsewhere does not make it less true. Reporting the
+  // weaker verdict here would bury the finding under its own caveat.
+  const stale = live.filter((entry) => entry.bundleId !== publishedBundleId);
+  if (stale.length > 0) {
+    return { kind: "stale", signature: bundleDriftSignature(stale), stale, live };
+  }
+
+  if (unreadable.length > 0) {
+    return {
+      kind: "unknown",
+      reason:
+        `${unreadable.length} MCP process record(s) could not be read (${unreadable.join(", ")}), ` +
+        "so agreement cannot be claimed — the unread ones could be the stale ones"
+    };
+  }
+
+  return { kind: "current", live };
+}
+
+/**
+ * A stable key for "this is the same divergence as last time", so a standing
+ * condition is announced on the change rather than on every tick.
+ */
+export function bundleDriftSignature(stale: LiveMcpProcess[]): string {
+  return stale
+    .map((entry) => `${entry.host}:${entry.entry}@${entry.bundleId}`)
+    .sort()
+    .join("|");
+}
+
+/** One operator-facing line: which consumers, on what, instead of what. */
+export function describeBundleObservation(
+  observation: BundleObservation,
+  publishedBundleId: string | undefined
+): string {
+  if (observation.kind === "unknown") return observation.reason;
+  if (observation.kind === "current") {
+    // NAME THE CONTAINERS, not just the count. "Current" here means only "every
+    // process I could see is current", and a consumer whose records never
+    // arrive is invisible to this check — which is the same shape as the bug it
+    // exists to catch. Listing the containers is what lets an operator who
+    // knows there should be two notice that this speaks for one.
+    const consumers = [...new Set(observation.live.map((entry) => entry.host))].sort();
+    return (
+      `${observation.live.length} live MCP server processes across ${consumers.join(", ")} ` +
+      `are running ${publishedBundleId} (this speaks only for containers that record)`
+    );
+  }
+  const consumers = [...new Set(observation.stale.map((entry) => entry.host))].sort();
+  const loaded = [...new Set(observation.stale.map((entry) => entry.bundleId))].sort();
+  return (
+    `${observation.stale.length} of ${observation.live.length} live MCP server processes are ` +
+    `running ${loaded.join(", ")} while the bundle is ${publishedBundleId} ` +
+    `(containers: ${consumers.join(", ")})`
+  );
+}

--- a/services/skills-observer/src/drift-alert.ts
+++ b/services/skills-observer/src/drift-alert.ts
@@ -1,6 +1,12 @@
 /**
  * Decide whether a drift check should announce anything.
  *
+ * Shared by both of this service's checks — the skills volume against the repo,
+ * and the consumers' MCP tool registries against the published bundle
+ * (bundle-drift.ts). Each keeps its own state; the three failure modes below
+ * are identical for both, and having two copies of this reasoning is how one of
+ * them quietly stops obeying it.
+ *
  * Logging every result is free and always truthful; a Slack message is not, and
  * three ways of getting this wrong all end with the alert being worthless:
  *

--- a/services/skills-observer/src/index.ts
+++ b/services/skills-observer/src/index.ts
@@ -4,6 +4,14 @@ import chokidar from "chokidar";
 import { logger, optionalEnv, query, sha256Text } from "@avg/mcp-common";
 import { describeWatchError } from "./watch-error.js";
 import { decideDriftAlert, initialDriftAlertState } from "./drift-alert.js";
+import {
+  compareBundle,
+  describeBundleObservation,
+  readMcpProcessRegistry,
+  readPublishedBundleId,
+  type BundleObservation,
+  type RegistryReading
+} from "./bundle-drift.js";
 import { errorCode } from "./skills-sync.js";
 import {
   describeDrift,
@@ -17,6 +25,8 @@ import {
 
 const skillsDir = optionalEnv("HERMES_SKILLS_DIR", "/opt/data/skills");
 const repoSkillsDir = optionalEnv("REPO_SKILLS_DIR", "/repo-skills");
+const bundleDir = optionalEnv("MCP_BUNDLE_DIR", "/bundle");
+const bundleRegistryDir = optionalEnv("MCP_BUNDLE_REGISTRY_DIR", "/data/mcp-bundle-registry");
 const slackWebhookUrl = optionalEnv("SLACK_WEBHOOK_URL");
 const watchRetryMs = Number(optionalEnv("SKILLS_OBSERVER_WATCH_RETRY_MS", "30000"));
 const driftCheckMs = Number(optionalEnv("SKILLS_DRIFT_CHECK_MS", "900000"));
@@ -249,9 +259,128 @@ async function checkDrift(): Promise<void> {
   });
 }
 
+/**
+ * Report when a running consumer's MCP tool registry is older than the bundle.
+ *
+ * Second, unrelated volume; same shape of bug, and the same reason it lives
+ * here. `avg-app` is rewritten on every deploy, but an MCP client registers its
+ * tool list once at process startup, so a consumer that is not restarted keeps
+ * answering from the previous tool list with nothing erroring — which is how
+ * hermes-gateway came to answer a health question from the wrong tool on
+ * 2026-08-02. ops/deploy-monitor.sh restarts the consumers; this catches every
+ * path that is not that script.
+ *
+ * The name of this service predates the second check. It is still the right
+ * home: long-running, already holds the Slack route and the alert state
+ * machine, and mounts both sides read-only. It repairs neither.
+ */
+let bundleAlertState = initialDriftAlertState;
+
+/**
+ * Never throws. Anything that stops the comparison from being made comes back
+ * as `unknown` rather than as an exception, because an exception here would
+ * reject driftLoop's promise and take the process down — and a crash loop
+ * resets both state machines, whose first pass deliberately only observes. A
+ * fast enough loop would then never reach a pass that announces, and drift
+ * would go unreported while looking merely flaky.
+ */
+async function observeBundle(): Promise<{
+  observation: BundleObservation;
+  publishedBundleId: string | undefined;
+}> {
+  let publishedBundleId: string | undefined;
+  try {
+    publishedBundleId = await readPublishedBundleId(bundleDir);
+    let reading: RegistryReading = { live: [], unreadable: [] };
+    try {
+      reading = await readMcpProcessRegistry(bundleRegistryDir, Date.now());
+    } catch (error) {
+      // An absent registry directory is not a failure to look — it is nobody
+      // having recorded anything yet, which compareBundle already words
+      // honestly. Anything else means the check itself could not run.
+      if (errorCode(error) !== "ENOENT") throw error;
+    }
+    return { observation: compareBundle(publishedBundleId, reading), publishedBundleId };
+  } catch (error) {
+    logger.warn({ err: error, bundleDir, bundleRegistryDir }, "mcp_bundle_check_failed");
+    return {
+      observation: {
+        kind: "unknown",
+        reason:
+          "the MCP process registry could not be read, so which bundle the consumers loaded is unknown"
+      },
+      publishedBundleId
+    };
+  }
+}
+
+async function checkBundleDrift(): Promise<void> {
+  const { observation, publishedBundleId } = await observeBundle();
+  const live = observation.kind === "unknown" ? [] : observation.live;
+  const description = describeBundleObservation(observation, publishedBundleId);
+
+  const decision = decideDriftAlert(
+    bundleAlertState,
+    observation.kind === "current"
+      ? { kind: "in-sync" }
+      : observation.kind === "stale"
+        ? { kind: "drifted", signature: observation.signature }
+        : { kind: "unavailable" }
+  );
+  bundleAlertState = decision.state;
+
+  if (observation.kind === "current") {
+    logger.info({ bundleId: publishedBundleId, live: live.length }, "mcp_bundle_current");
+    if (decision.announce === "recovery") {
+      await postSlack({ text: `MCP tool registries are back in sync with the bundle: ${description}.` });
+    }
+    return;
+  }
+
+  if (observation.kind === "unknown") {
+    logger.warn({ bundleDir, bundleRegistryDir }, `mcp_bundle_check_unavailable: ${description}`);
+    if (decision.announce === "unavailable") {
+      await postSlack({
+        text:
+          `Cannot tell whether the running agent's MCP tool list matches the deployed bundle — ${description}. ` +
+          "Until this reads again, a tool shipped by a deploy may be invisible to the agent with nothing erroring."
+      });
+    }
+    return;
+  }
+
+  // Logged on every check whether or not it is announced, so the condition is
+  // always recoverable from the logs.
+  logger.error(
+    { stale: observation.stale.map((entry) => ({ host: entry.host, entry: entry.entry, bundleId: entry.bundleId })) },
+    `mcp_bundle_stale: ${description}. Those processes registered their tool list at startup and ` +
+      "have not restarted since, so tools shipped by later deploys are invisible to them. Restart " +
+      "the consumers: `ops/deploy-monitor.sh` does it, or `docker restart <container>`."
+  );
+  if (decision.announce !== "drift") return;
+  await postSlack({
+    text: `MCP tool registry is stale: ${description}`,
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text:
+            `*MCP tool registry is stale*\n${description}\n\n` +
+            "An MCP client registers its tool list once, at startup. Those processes are serving " +
+            "the list from an older bundle, so a tool shipped since then does not exist as far as " +
+            "the agent is concerned — and it will answer from whatever tool it *does* have.\n" +
+            "Restart the consumers: `ops/deploy-monitor.sh` does this, or `docker restart <container>`."
+        }
+      }
+    ]
+  });
+}
+
 async function driftLoop(): Promise<void> {
   const settling = !driftAlertState.settled;
   await checkDrift();
+  await checkBundleDrift();
   // The first pass only observes (skills-sync may still be copying), so follow
   // it up quickly rather than a full interval later — otherwise a divergence
   // that is real goes unannounced for the whole period.

--- a/test/unit/mcp-bundle-drift.test.ts
+++ b/test/unit/mcp-bundle-drift.test.ts
@@ -1,0 +1,258 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { registerMcpProcess } from "../../packages/mcp-common/src/bundle-registry.js";
+import {
+  bundleDriftSignature,
+  compareBundle,
+  describeBundleObservation,
+  readMcpProcessRegistry,
+  readPublishedBundleId,
+  type LiveMcpProcess,
+  type RegistryReading
+} from "../../services/skills-observer/src/bundle-drift.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await fsp.rm(root, { recursive: true, force: true });
+});
+
+async function makeDir(files: Record<string, string> = {}): Promise<string> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "bundle-drift-"));
+  roots.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath);
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(filePath, content);
+  }
+  return root;
+}
+
+function reading(live: LiveMcpProcess[], unreadable: string[] = []): RegistryReading {
+  return { live, unreadable };
+}
+
+function live(overrides: Partial<LiveMcpProcess> = {}): LiveMcpProcess {
+  return {
+    entry: "/app/packages/averray-mcp/dist/index.js",
+    host: "hermes-1",
+    pid: 41,
+    startedAt: "2026-08-02T01:00:00.000Z",
+    bundleId: "sha:08b214e",
+    ageMs: 1_000,
+    ...overrides
+  };
+}
+
+describe("compareBundle", () => {
+  it("agrees only when every live process is on the published bundle", () => {
+    const observation = compareBundle("sha:08b214e", reading([live(), live({ host: "gateway-1" })]));
+
+    expect(observation.kind).toBe("current");
+  });
+
+  it("reports the processes still serving an older bundle", () => {
+    const observation = compareBundle("sha:08b214e", reading([
+      live(),
+      live({ host: "gateway-1", bundleId: "sha:7332d80" })
+    ]));
+
+    expect(observation).toMatchObject({ kind: "stale" });
+    if (observation.kind !== "stale") throw new Error("expected stale");
+    expect(observation.stale.map((entry) => entry.host)).toEqual(["gateway-1"]);
+  });
+
+  it("does not read an unreadable bundle stamp as agreement", () => {
+    expect(compareBundle(undefined, reading([live()])).kind).toBe("unknown");
+  });
+
+  it("does not let two unknowns match each other", () => {
+    // A process that could not read its stamp and a bundle published without
+    // one both say "unknown". Comparing those as equal would manufacture
+    // agreement out of two absences of evidence.
+    const observation = compareBundle("unknown", reading([live({ bundleId: "unknown" })]));
+
+    expect(observation.kind).toBe("unknown");
+  });
+
+  it("reads no records as unknown, never as healthy", () => {
+    // This is the whole point: a stale tool registry looks exactly like a
+    // working agent, so silence must not be reported as agreement.
+    const observation = compareBundle("sha:08b214e", reading([]));
+
+    expect(observation.kind).toBe("unknown");
+    if (observation.kind !== "unknown") throw new Error("expected unknown");
+    expect(observation.reason).toContain("no MCP server process is recording");
+  });
+
+  it("withholds agreement while any record is unaccounted for", () => {
+    // The dangerous shape: every record we COULD read matches, so the survivors
+    // look unanimous — but the one we could not read could be the stale one.
+    const observation = compareBundle("sha:08b214e", reading([live()], ["gateway-1__averray.json"]));
+
+    expect(observation.kind).toBe("unknown");
+    if (observation.kind !== "unknown") throw new Error("expected unknown");
+    expect(observation.reason).toContain("gateway-1__averray.json");
+  });
+
+  it("still reports a demonstrably stale process rather than burying it in the caveat", () => {
+    const observation = compareBundle(
+      "sha:08b214e",
+      reading([live({ host: "gateway-1", bundleId: "sha:7332d80" })], ["torn.json"])
+    );
+
+    expect(observation.kind).toBe("stale");
+  });
+});
+
+describe("bundleDriftSignature", () => {
+  it("is stable regardless of the order the records were read in", () => {
+    const a = live({ host: "gateway-1", bundleId: "sha:old" });
+    const b = live({ host: "gateway-2", bundleId: "sha:old" });
+
+    expect(bundleDriftSignature([a, b])).toBe(bundleDriftSignature([b, a]));
+  });
+
+  it("changes when a different consumer goes stale", () => {
+    const first = bundleDriftSignature([live({ host: "gateway-1", bundleId: "sha:old" })]);
+    const second = bundleDriftSignature([live({ host: "hermes-1", bundleId: "sha:old" })]);
+
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("describeBundleObservation", () => {
+  it("names the containers, what they run, and what they should run", () => {
+    const observation = compareBundle("sha:08b214e", reading([
+      live(),
+      live({ host: "gateway-1", bundleId: "sha:7332d80" })
+    ]));
+
+    const description = describeBundleObservation(observation, "sha:08b214e");
+    expect(description).toContain("gateway-1");
+    expect(description).toContain("sha:7332d80");
+    expect(description).toContain("sha:08b214e");
+  });
+
+  it("names which containers a 'current' verdict actually speaks for", () => {
+    // The check is blind to a consumer whose records never arrive, so "current"
+    // must not read as fleet-wide coverage. Naming the containers is what lets
+    // an operator who knows there should be two notice that it saw one.
+    const description = describeBundleObservation(
+      compareBundle("sha:08b214e", reading([live({ host: "hermes-1" })])),
+      "sha:08b214e"
+    );
+
+    expect(description).toContain("hermes-1");
+    expect(description).toContain("only for containers that record");
+  });
+});
+
+describe("readMcpProcessRegistry", () => {
+  it("ignores records that have stopped being refreshed", async () => {
+    const now = 1_000_000_000_000;
+    const dir = await makeDir({
+      "fresh.json": JSON.stringify(live({ host: "hermes-1" })),
+      "abandoned.json": JSON.stringify(live({ host: "gone-1" }))
+    });
+    fs.utimesSync(path.join(dir, "fresh.json"), new Date(now - 1_000), new Date(now - 1_000));
+    fs.utimesSync(
+      path.join(dir, "abandoned.json"),
+      new Date(now - 600_000),
+      new Date(now - 600_000)
+    );
+
+    const found = await readMcpProcessRegistry(dir, now);
+
+    // A record left by a container that is gone would otherwise report drift
+    // forever, and an alert that never clears is one nobody reads. An expired
+    // record was read successfully, so it is not "unaccounted for" either.
+    expect(found.live.map((entry) => entry.host)).toEqual(["hermes-1"]);
+    expect(found.unreadable).toEqual([]);
+  });
+
+  it("counts records it cannot read instead of quietly dropping them", async () => {
+    const now = Date.now();
+    const dir = await makeDir({
+      "good.json": JSON.stringify(live({ host: "hermes-1" })),
+      "half-written.json": "{ not json",
+      "wrong-shape.json": JSON.stringify({ entry: 5 }),
+      "README.txt": "ignored"
+    });
+
+    const found = await readMcpProcessRegistry(dir, now);
+
+    expect(found.live.map((entry) => entry.host)).toEqual(["hermes-1"]);
+    expect(found.unreadable).toEqual(["half-written.json", "wrong-shape.json"]);
+  });
+
+  it("throws ENOENT for an absent registry, so the caller can tell it apart from empty", async () => {
+    // "Nobody has recorded anything yet" and "the check could not run" are
+    // different conditions and get different wording.
+    await expect(
+      readMcpProcessRegistry(path.join(await makeDir(), "absent"), Date.now())
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+});
+
+describe("the writer and the reader agree", () => {
+  // The record format spans two packages: mcp-common writes it inside the
+  // consumer, skills-observer reads it from a different container. Nothing
+  // else forces those two to keep matching, and a silently unreadable record
+  // would put the check straight back into the silence it exists to end.
+  it("catches a consumer left on the previous bundle after the volume is republished", async () => {
+    const bundle = await makeDir({
+      ".mcp-bundle-id": "sha:7332d80",
+      "packages/averray-mcp/dist/index.js": "//"
+    });
+    const registry = path.join(await makeDir(), "registry");
+    const entryPath = path.join(bundle, "packages/averray-mcp/dist/index.js");
+
+    // The consumer starts, and registers its tool list from what it loaded.
+    registerMcpProcess({ entryPath, directory: registry, heartbeatMs: 60_000 });
+
+    // A deploy republishes the volume. The running process is not restarted,
+    // so its tool list is now the previous bundle's — and nothing errors.
+    await fsp.writeFile(path.join(bundle, ".mcp-bundle-id"), "sha:08b214e\n");
+
+    const published = await readPublishedBundleId(bundle);
+    const observation = compareBundle(published, await readMcpProcessRegistry(registry, Date.now()));
+
+    expect(observation.kind).toBe("stale");
+    expect(describeBundleObservation(observation, published)).toContain("sha:7332d80");
+  });
+
+  it("reports current once that consumer restarts", async () => {
+    const bundle = await makeDir({
+      ".mcp-bundle-id": "sha:08b214e",
+      "packages/averray-mcp/dist/index.js": "//"
+    });
+    const registry = path.join(await makeDir(), "registry");
+    const entryPath = path.join(bundle, "packages/averray-mcp/dist/index.js");
+
+    registerMcpProcess({ entryPath, directory: registry, heartbeatMs: 60_000 });
+    // A restart re-registers over its own record rather than adding a second
+    // one, or the restarted consumer would keep looking stale forever.
+    registerMcpProcess({ entryPath, directory: registry, heartbeatMs: 60_000 });
+
+    const found = await readMcpProcessRegistry(registry, Date.now());
+    expect(found.live).toHaveLength(1);
+    expect(compareBundle(await readPublishedBundleId(bundle), found).kind).toBe("current");
+  });
+});
+
+describe("readPublishedBundleId", () => {
+  it("reads the stamp mcp-bundle wrote", async () => {
+    const dir = await makeDir({ ".mcp-bundle-id": "sha:08b214e\n" });
+
+    expect(await readPublishedBundleId(dir)).toBe("sha:08b214e");
+  });
+
+  it("returns nothing when the bundle is not mounted or not stamped", async () => {
+    expect(await readPublishedBundleId(path.join(await makeDir(), "absent"))).toBeUndefined();
+  });
+});

--- a/test/unit/mcp-bundle-registry.test.ts
+++ b/test/unit/mcp-bundle-registry.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  UNKNOWN_BUNDLE_ID,
+  buildMcpProcessRecord,
+  bundleRecordFileName,
+  pruneMcpProcessRecords,
+  readBundleId,
+  registerMcpProcess,
+  writeMcpProcessRecord
+} from "../../packages/mcp-common/src/bundle-registry.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.useRealTimers();
+  for (const root of roots.splice(0)) {
+    await fsp.chmod(root, 0o755).catch(() => undefined);
+    await fsp.rm(root, { recursive: true, force: true });
+  }
+});
+
+async function makeDir(files: Record<string, string> = {}): Promise<string> {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), "mcp-bundle-"));
+  roots.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath);
+    await fsp.mkdir(path.dirname(filePath), { recursive: true });
+    await fsp.writeFile(filePath, content);
+  }
+  return root;
+}
+
+describe("readBundleId", () => {
+  it("finds the stamp by climbing from the file that was executed", async () => {
+    const root = await makeDir({
+      ".mcp-bundle-id": "sha:08b214e\n",
+      "packages/averray-mcp/dist/index.js": "//"
+    });
+
+    expect(readBundleId(path.join(root, "packages/averray-mcp/dist/index.js"))).toBe("sha:08b214e");
+  });
+
+  it("reports unknown when the bundle carries no stamp", async () => {
+    const root = await makeDir({ "packages/averray-mcp/dist/index.js": "//" });
+
+    expect(readBundleId(path.join(root, "packages/averray-mcp/dist/index.js"))).toBe(
+      UNKNOWN_BUNDLE_ID
+    );
+  });
+
+  it("treats an empty stamp as no stamp rather than as an id", async () => {
+    // An empty id would compare equal to another empty id, which is agreement
+    // conjured out of two unknowns.
+    const root = await makeDir({ ".mcp-bundle-id": "  \n", "dist/index.js": "//" });
+
+    expect(readBundleId(path.join(root, "dist/index.js"))).toBe(UNKNOWN_BUNDLE_ID);
+  });
+});
+
+describe("bundleRecordFileName", () => {
+  it("is stable for a consumer and entry, so a restart overwrites its own record", () => {
+    const first = bundleRecordFileName("hermes-1", "/app/packages/averray-mcp/dist/index.js");
+    const second = bundleRecordFileName("hermes-1", "/app/packages/averray-mcp/dist/index.js");
+
+    expect(first).toBe(second);
+    expect(first.endsWith(".json")).toBe(true);
+  });
+
+  it("separates consumers and entry points", () => {
+    const gateway = bundleRecordFileName("gateway-1", "/app/packages/averray-mcp/dist/index.js");
+    const hermes = bundleRecordFileName("hermes-1", "/app/packages/averray-mcp/dist/index.js");
+    const otherEntry = bundleRecordFileName("hermes-1", "/app/packages/wallet-mcp/dist/index.js");
+
+    expect(new Set([gateway, hermes, otherEntry]).size).toBe(3);
+  });
+});
+
+describe("writeMcpProcessRecord", () => {
+  it("writes a record that round-trips", async () => {
+    const dir = path.join(await makeDir(), "registry");
+    const record = buildMcpProcessRecord("/app/packages/averray-mcp/dist/index.js", new Date(0));
+
+    expect(writeMcpProcessRecord(dir, record)).toBe(true);
+    const written = JSON.parse(
+      await fsp.readFile(path.join(dir, bundleRecordFileName(record.host, record.entry)), "utf8")
+    );
+    expect(written).toMatchObject({
+      entry: "/app/packages/averray-mcp/dist/index.js",
+      bundleId: UNKNOWN_BUNDLE_ID,
+      startedAt: "1970-01-01T00:00:00.000Z"
+    });
+  });
+
+  it("reports failure instead of throwing when the registry cannot be written", async () => {
+    // An observability record that can take down the agent's tool surface would
+    // be a worse bug than the one it reports.
+    if (process.getuid?.() === 0) return; // root ignores the mode bits
+    const root = await makeDir();
+    await fsp.chmod(root, 0o500);
+    const record = buildMcpProcessRecord("/app/packages/averray-mcp/dist/index.js", new Date(0));
+
+    expect(writeMcpProcessRecord(path.join(root, "registry"), record)).toBe(false);
+  });
+});
+
+describe("pruneMcpProcessRecords", () => {
+  it("removes records old enough to be from containers that no longer exist", async () => {
+    const now = 1_000_000_000_000;
+    const dir = await makeDir({ "fresh.json": "{}", "ancient.json": "{}", "notes.txt": "keep" });
+    fs.utimesSync(path.join(dir, "ancient.json"), new Date(now - 90_000), new Date(now - 90_000));
+    fs.utimesSync(path.join(dir, "fresh.json"), new Date(now - 1_000), new Date(now - 1_000));
+
+    expect(pruneMcpProcessRecords(dir, now, 60_000)).toBe(1);
+    expect((await fsp.readdir(dir)).sort()).toEqual(["fresh.json", "notes.txt"]);
+  });
+
+  it("returns zero rather than throwing when the registry does not exist", async () => {
+    expect(pruneMcpProcessRecords(path.join(await makeDir(), "absent"), Date.now(), 1)).toBe(0);
+  });
+});
+
+describe("registerMcpProcess", () => {
+  it("records the bundle the entry was actually loaded from", async () => {
+    const bundle = await makeDir({
+      ".mcp-bundle-id": "sha:08b214e",
+      "packages/averray-mcp/dist/index.js": "//"
+    });
+    const registry = path.join(await makeDir(), "registry");
+    const entryPath = path.join(bundle, "packages/averray-mcp/dist/index.js");
+
+    registerMcpProcess({ entryPath, directory: registry, heartbeatMs: 10_000 });
+
+    const [name] = await fsp.readdir(registry);
+    const record = JSON.parse(await fsp.readFile(path.join(registry, name), "utf8"));
+    expect(record.bundleId).toBe("sha:08b214e");
+    expect(record.entry).toBe(entryPath);
+  });
+
+  it("keeps the record alive, so a dead process's stamp ages out instead of alarming forever", async () => {
+    vi.useFakeTimers();
+    const registry = path.join(await makeDir(), "registry");
+    registerMcpProcess({
+      entryPath: "/app/packages/averray-mcp/dist/index.js",
+      directory: registry,
+      heartbeatMs: 1_000
+    });
+    const [name] = await fsp.readdir(registry);
+    await fsp.rm(path.join(registry, name));
+
+    vi.advanceTimersByTime(1_000);
+
+    // Rewritten, not merely touched — a record deleted out from under the
+    // process comes back rather than reading as a process that has gone.
+    expect(await fsp.readdir(registry)).toEqual([name]);
+  });
+
+  it("does nothing at all when there is no entry path to describe", () => {
+    expect(() => registerMcpProcess({ entryPath: "", directory: "/proc/definitely-not" })).not.toThrow();
+  });
+});


### PR DESCRIPTION
The artifact ships, the consumer never reloads, nothing errors. Same class as the skills volume in #664.

## What was actually broken

The five MCP servers are not in any consumer's image. They live in the **`avg-app` volume**, which `mcp-bundle` rewrites (`rm -rf` + `cp -a`) on every deploy, and which `hermes` and `hermes-gateway` mount read-only at `/app`. **An MCP client registers its tool list once, at process startup.**

So republishing the volume under a running consumer changes the *files* and not the *tool surface*. It keeps advertising the previous list, and nothing errors.

Twice on 2026-08-02 with `averray_board_health` (#657):

- `hermes` picked it up **only because someone restarted it by hand**.
- `hermes-gateway` — up nine hours — did not. The Buzz inbound listener then answered an operator's question about system health from `averray_ops_health` (the Postgres control plane, explicitly **not** the board) and reported *"No issues on the board"* having never read the board. It surfaced only because #666 made the prompt name the tool, after which the agent correctly reported UNKNOWN.

**Leaving them alone was never the safe option.** The rewrite unlinks the old files, so a consumer that later respawns an MCP subprocess gets *new* code behind an *old* registration. The running system was not stale, it was undefined.

## The deploy restarts what runs from the bundle

`ops/deploy-monitor.sh` restarts every running consumer after republishing.

**Discovery is a runtime lookup, not a Compose one** — `docker ps --filter volume=avg_avg-app`. This is the point of the change, not an implementation detail: `hermes-gateway` is behind `--profile command-center`, so `compose restart hermes-gateway` finds nothing unless the profile is passed, and the next consumer added behind the next profile would be missed in exactly the same silence. Profile membership is a Compose concept; *who has this volume mounted right now* is a runtime one. It also cannot start something the operator deliberately stopped, which `compose up` could.

**Advisory, not fatal** — the call #664 made for the skills sync. The board does not run from this volume, so failing its deploy because the agent would not restart would couple the money path to the agent, which is backwards. Restarting **nothing** is a warning, not a quiet success.

**And it only restarts when the bundle actually changed.** `mcp-bundle` now stamps what it published:

| build | id | why |
|---|---|---|
| clean | `sha:<GIT_SHA>` | the tree *is* the commit, so two copies at one sha are byte-identical — re-running a deploy leaves Hermes alone instead of bouncing the agent for nothing |
| dirty | `dirty:<sha>@<ts>` | the sha is a lie (HEAD plus edits nobody can see), so it cannot claim identity with anything and every consumer restarts |
| unstamped | `unknown:@<ts>` | same |

## The backstop, for every path that is not that script

Each MCP server process stamps which bundle it loaded (`packages/mcp-common/src/bundle-registry.ts`), and `skills-observer` compares those against the volume. It reuses `decideDriftAlert`, so a standing condition is announced once rather than every tick.

It compares **bundle ids, not tool lists**: the tool list is downstream of which copy a process loaded, so the id catches strictly more (a changed description, a changed handler, a removed tool) and needs no build-time manifest kept honest by hand.

The writer never breaks the server: synchronous (so it cannot hang `connect` or reject later), best-effort, and **stderr only** — stdout *is* the MCP transport. The heartbeat is unref'd so bookkeeping cannot decide when the server exits, and it exists so a dead process's stamp ages out instead of alarming forever.

### Truth boundaries, since this is a health-shaped surface

Three things a first cut got wrong and this does not:

- **No records reads as UNKNOWN, never as agreement.** A consumer that cannot write its record makes the fleet look *unreadable*, which it is — not current.
- **A record it cannot read withholds agreement.** If the only stale process is the one that could not be parsed, the survivors look unanimous. Agreement is withheld while any record is unaccounted for; a demonstrably stale process still wins, so the finding is not buried under its own caveat.
- **"Bundle unchanged" claims only that *this deploy* made nothing stale.** It never says the consumers were already current — nothing looked at them. The operator who just read the restart warning and re-ran the script is exactly who that would mislead, so `--restart-consumers` is there for them.

Stated plainly in the module header rather than implied: a consumer whose records never arrive is invisible to this check. It cannot make the fleet look current, but the deploy-side restart — not this — is what makes coverage complete. `current` names the containers it speaks for so an operator who knows there should be two can see it saw one.

## Verification

Against real Docker, not just unit tests:

- the stamp is stable across a clean republish and never repeats for a dirty one
- `read_bundle_id` does **not** conjure the volume into existence — `docker run -v` creates missing volumes, and a volume created outside Compose is one Compose refuses to adopt, which would have turned a read into a broken first-ever deploy
- discovery restarts `hermes-gateway` (the profiled one a naive restart misses) and leaves another project's container on the same volume alone
- all seven restart-decision branches, including the operator retry

30 new tests — including a round-trip pinning the record format across the two packages that write and read it. Full suite **2347 passed**, typecheck clean.