### PR TITLE
fix(ops): stop counting protocol fees as payouts

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1134,8 +1134,27 @@ async function ethRpc(
  * and is independent of the backend's own claim, which is the entire point.
  *
  * Layout (indexed → topics, the rest → data):
- *   topic1 jobId · topic2 account · topic3 recipient
+ *   topic1 reservationId · topic2 account · topic3 recipient
  *   data[0] asset · data[1] amount
+ *
+ * topic1 is a RESERVATION id, not a job id — this said jobId until a mainnet
+ * read disproved it. One settlement transaction emits a payout leg and a fee leg
+ * with DIFFERENT topic1 values (tx 0x7afd7fbf: 0x50f48b3a and 0xf541d2ab), so
+ * joining settlements to jobs on topic1 silently matches nothing. Bridge through
+ * the transaction hash instead.
+ *
+ * ── NOT EVERY SETTLEMENT IS A PAYOUT ───────────────────────────────────────
+ *
+ * The 5% protocol fee is credited by this SAME event, distinguished only by
+ * topic3 being the fee treasury. Counting those as payouts inflates the
+ * on-chain side of the comparison — and because a fee arrives on every
+ * fee-bearing settlement, the inflation is PERMANENT: three genuinely missing
+ * payouts plus three fee credits net to zero, and `shortfall` can never fire.
+ *
+ * Verified on mainnet 2026-08-02: the panel read 19 confirmed against 16
+ * settled, and the excess of exactly 3 was exactly the 3 fee credits. So the
+ * recipient is checked here, and fees are reported separately rather than
+ * folded into the payout total.
  */
 /** settled24h is a rolling 24h count, so that is what the window must span. */
 const PAYOUT_COMPARISON_HOURS = 24;
@@ -1352,11 +1371,30 @@ export async function readPayoutTransfers(input: {
   usdcDecimals: number;
   lookbackBlocks: number;
   expectedChainId?: number;
+  /**
+   * The protocol-fee treasury. A settlement to THIS recipient is revenue, not a
+   * payout, and must not be counted as one — see the header.
+   *
+   * Optional, and its absence is reported rather than assumed away: without it
+   * the two cannot be told apart, so `feesSeparated` is false and the caller
+   * must not claim the payout count is fee-free.
+   */
+  feeRecipientAddress?: string;
   fetchImpl: typeof fetch;
-}): Promise<{ count: number | null; usdc: number | null; windowBlocks: number | null; reason?: string }> {
+}): Promise<{
+  count: number | null;
+  usdc: number | null;
+  windowBlocks: number | null;
+  /** Settlements whose recipient was the fee treasury. null when unknowable. */
+  feeCount: number | null;
+  feeUsdc: number | null;
+  /** False when no treasury address was supplied — count may include fees. */
+  feesSeparated: boolean;
+  reason?: string;
+}> {
   if (!input.rpcUrl || !input.sourceAddress || !input.usdcAddress) {
     return {
-      count: null, usdc: null, windowBlocks: null,
+      count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false,
       reason: !input.sourceAddress
         ? "payout evidence not configured — no payout source address (/health addresses.agentAccountCore, or PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS)"
         : "payout evidence not configured (RPC / USDC address)",
@@ -1367,7 +1405,7 @@ export async function readPayoutTransfers(input: {
       const actual = Number(BigInt(await ethRpc(input.rpcUrl, "eth_chainId", [], input.fetchImpl)));
       if (actual !== input.expectedChainId) {
         return {
-          count: null, usdc: null, windowBlocks: null,
+          count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false,
           reason: `payout evidence unverified — RPC is on chain ${actual}, product is on ${input.expectedChainId}`,
         };
       }
@@ -1387,11 +1425,17 @@ export async function readPayoutTransfers(input: {
       input.fetchImpl,
     );
     if (!Array.isArray(logs)) {
-      return { count: null, usdc: null, windowBlocks: null, reason: "payout evidence unverified — eth_getLogs returned no array" };
+      return { count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false, reason: "payout evidence unverified — eth_getLogs returned no array" };
     }
     let total = 0n;
     let counted = 0;
+    let feeTotal = 0n;
+    let feeCounted = 0;
     const wantAsset = input.usdcAddress.toLowerCase().replace(/^0x/, "").padStart(64, "0");
+    // Padded to a 32-byte topic so it compares against topic3 directly.
+    const feeTopic = input.feeRecipientAddress
+      ? `0x${input.feeRecipientAddress.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`
+      : null;
     for (const entry of logs) {
       const data = (entry as { data?: unknown }).data;
       // data[0] is the ASSET. Counting a DOT settlement as USDC would break the
@@ -1403,23 +1447,37 @@ export async function readPayoutTransfers(input: {
       // is right for a single-word Transfer — would be off by ~10^48 here.
       const amount = dataWord(data, 1);
       if (amount === undefined) continue;
+
+      // topic3 is the recipient. A settlement to the fee treasury is REVENUE,
+      // and folding it into payouts is what let the on-chain side run
+      // permanently ahead of the ledger.
+      const topics = (entry as { topics?: unknown }).topics;
+      const recipient = Array.isArray(topics) && typeof topics[3] === "string" ? topics[3].toLowerCase() : null;
+      const isFee = feeTopic !== null && recipient === feeTopic;
+
       try {
-        total += BigInt(`0x${amount}`);
-        counted += 1;
+        const value = BigInt(`0x${amount}`);
+        if (isFee) { feeTotal += value; feeCounted += 1; } else { total += value; counted += 1; }
       } catch {
         // A malformed value is not a reason to under-report the count.
-        counted += 1;
+        if (isFee) feeCounted += 1; else counted += 1;
       }
     }
     return {
       count: counted,
       usdc: Number(total) / 10 ** input.usdcDecimals,
       windowBlocks: latest - fromBlock,
+      // null, not 0, when we cannot tell fees from payouts: zero would be a
+      // claim that no fees were taken, which is a different statement from
+      // "we could not look".
+      feeCount: feeTopic === null ? null : feeCounted,
+      feeUsdc: feeTopic === null ? null : Number(feeTotal) / 10 ** input.usdcDecimals,
+      feesSeparated: feeTopic !== null,
     };
   } catch (error) {
     // Rate limit, capped range, dead endpoint — all unverified, never "0 paid".
     return {
-      count: null, usdc: null, windowBlocks: null,
+      count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false,
       reason: `payout evidence unverified — log read failed (${error instanceof Error ? error.message : String(error)})`,
     };
   }
@@ -1438,6 +1496,38 @@ function encodeBalanceOf(address: string): string {
 // positions(treasury, USDC) (0x4bd21445) returns 6 words, [0] = liquid.
 const TREASURY_ACCOUNT_SELECTOR = "0x339b2cff";
 const POSITIONS_SELECTOR = "0x4bd21445";
+
+/**
+ * Who receives the protocol fee, according to the contract that charges it.
+ *
+ * Read from EscrowCore rather than taken from `/health.addresses.treasuryReserve`
+ * — those two happen to be the same account on mainnet today, and the payout
+ * split would be silently wrong the moment they are not. The contract is the
+ * authority on where its own fee goes.
+ *
+ * Returns null on any failure, so the caller reports "cannot separate fees"
+ * rather than splitting on a guess.
+ */
+export async function readFeeRecipient(input: {
+  rpcUrl?: string;
+  escrowCore?: string;
+  fetchImpl: typeof fetch;
+}): Promise<string | null> {
+  if (!input.rpcUrl || !input.escrowCore) return null;
+  try {
+    const raw = await ethRpc(
+      input.rpcUrl,
+      "eth_call",
+      [{ to: input.escrowCore, data: TREASURY_ACCOUNT_SELECTOR }, "latest"],
+      input.fetchImpl,
+    );
+    if (!raw || raw.length < 66) return null;
+    const address = `0x${raw.slice(-40)}`;
+    return /^0x0+$/.test(address) ? null : address;
+  } catch {
+    return null;
+  }
+}
 
 function encodePositions(account: string, asset: string): string {
   const pad = (a: string) => a.toLowerCase().replace(/^0x/, "").padStart(64, "0");
@@ -2028,6 +2118,15 @@ export async function collectProductHealthProbes(
   // Independent proof that the settled jobs actually PAID. Opt-in: the log read
   // is rate-limit sensitive, so while it's off the block stays honestly
   // "unverified" rather than reporting a zero that would read as nothing-paid.
+  // Ask the contract who receives its fee, so fee credits can be told apart
+  // from payouts. Both are the SAME event; only the recipient differs.
+  const feeRecipient = config.payoutEvidenceEnabled
+    ? await readFeeRecipient({
+        rpcUrl: config.rpcUrl,
+        escrowCore: h.body?.addresses?.escrowCore,
+        fetchImpl,
+      })
+    : null;
   const payoutRead = config.payoutEvidenceEnabled
     ? await readPayoutTransfers({
         rpcUrl: config.rpcUrl,
@@ -2038,9 +2137,10 @@ export async function collectProductHealthProbes(
         usdcDecimals: config.usdcDecimals,
         lookbackBlocks: config.payoutLookbackBlocks,
         expectedChainId: chainId,
+        ...(feeRecipient ? { feeRecipientAddress: feeRecipient } : {}),
         fetchImpl,
       })
-    : { count: null, usdc: null, windowBlocks: null, reason: "payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)" };
+    : { count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false, reason: "payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)" };
   // Check the INSTRUMENT against the chain, not against an assumption. The
   // lookback is compared to settled24h, so it has to actually span 24h at the
   // chain's real block time — an assumed one has already been wrong in prod.

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -1649,6 +1649,74 @@ describe("readPayoutTransfers (chain-guarded log read)", () => {
     expect(r.windowBlocks).toBe(100);
   });
 
+  // ── Fees ride the SAME event, distinguished only by recipient ────────────
+  const TREASURY = "0x01e6eed856e989201f4ff6346e18eab7e46c874c";
+  /** Same event, recipient = the fee treasury. Revenue, not a payout. */
+  const feeCredit = (usdc: number) => ({
+    ...settled(usdc),
+    topics: [
+      "0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee",
+      `0x${word("0xfee")}`,
+      `0x${word("0x5a6836c6d4d293f6e5377e6c28054f4171915813")}`,
+      `0x${word(TREASURY)}`,
+    ],
+  });
+
+  it("does NOT count a fee credit as a payout", async () => {
+    // THE DEFECT, from mainnet 2026-08-02: the panel read 19 confirmed against
+    // 16 settled and called it "no gap". The excess of exactly 3 was exactly
+    // the 3 fee credits — same ReservationSettled event, recipient = treasury.
+    const logs = [settled(1), settled(1), feeCredit(0.05)];
+    const r = await readPayoutTransfers({
+      ...cfg, expectedChainId: 420420419, feeRecipientAddress: TREASURY,
+      fetchImpl: rpc("0x190f1b43", logs),
+    });
+    expect(r.count).toBe(2);
+    expect(r.usdc).toBeCloseTo(2, 6);
+    expect(r.feeCount).toBe(1);
+    expect(r.feeUsdc).toBeCloseTo(0.05, 6);
+    expect(r.feesSeparated).toBe(true);
+  });
+
+  it("keeps a real shortfall visible instead of letting fees mask it", async () => {
+    // WHY IT MATTERS. A fee arrives on every fee-bearing settlement, so the
+    // inflation is permanent: three missing payouts plus three fee credits net
+    // to zero and `shortfall` can never fire. Ledger claims 5; the chain has 2
+    // payouts and 3 fees. Conflated that reads 5 — clean. Split, the gap lives.
+    const logs = [settled(1), settled(1), feeCredit(0.05), feeCredit(0.05), feeCredit(0.05)];
+    const r = await readPayoutTransfers({
+      ...cfg, expectedChainId: 420420419, feeRecipientAddress: TREASURY,
+      fetchImpl: rpc("0x190f1b43", logs),
+    });
+    expect(r.count).toBe(2);
+    expect(r.count! + (r.feeCount ?? 0)).toBe(5); // what it used to report
+  });
+
+  it("says it CANNOT separate fees rather than assuming none", async () => {
+    // Without a treasury address the two are indistinguishable. Reporting 0
+    // fees would claim none were taken; null says we could not look — the same
+    // unverified-vs-shortfall distinction the rest of the board makes.
+    const r = await readPayoutTransfers({
+      ...cfg, expectedChainId: 420420419, fetchImpl: rpc("0x190f1b43", [settled(1), feeCredit(0.05)]),
+    });
+    expect(r.feesSeparated).toBe(false);
+    expect(r.feeCount).toBeNull();
+    expect(r.feeUsdc).toBeNull();
+    expect(r.count).toBe(2); // legacy behaviour, honestly flagged
+  });
+
+  it("matches the recipient case-insensitively", async () => {
+    // topic3 arrives lowercase from the RPC; a checksummed address in config
+    // must still match, or the split silently never fires.
+    const r = await readPayoutTransfers({
+      ...cfg, expectedChainId: 420420419,
+      feeRecipientAddress: "0x01E6EEd856E989201F4fF6346E18eAb7e46C874C",
+      fetchImpl: rpc("0x190f1b43", [settled(1), feeCredit(0.05)]),
+    });
+    expect(r.feeCount).toBe(1);
+    expect(r.count).toBe(1);
+  });
+
   // The amount is the SECOND data word. Reading the whole 64-byte `data` as one
   // integer — correct for a single-word ERC-20 Transfer — is off by ~10^48 and
   // would put an absurd USDC figure on a live money board.


### PR DESCRIPTION
## The defect

The payout-evidence panel filtered `ReservationSettled` by `topic0` and asset — **never by recipient**. But the 5% protocol fee is credited by the *same event*, differing only in `topic3` being the fee treasury. So fees were counted as payouts.

Mainnet, tonight:

> `19 payouts confirmed on-chain · 3.05 USDC` — `16 marked settled by the monitor`
> **CONFIRMED — proof matches ledger — no gap**

The excess of **exactly 3** was **exactly the 3 fee credits**.

## Why it's worse than a wrong count

A fee arrives on **every** fee-bearing settlement, so the on-chain side runs permanently ahead of the ledger by however many fees were taken. Three genuinely missing payouts plus three fee credits net to zero — and **`shortfall`, the entire reason this panel exists, can never fire.**

The panel built to catch "the chain can't account for payouts the ledger claims" had a structural offset hiding exactly that.

## The fix

Check the recipient. One split, three correct numbers: payouts, fees, and a gap that can actually open.

The fee recipient comes from **`EscrowCore.treasuryAccount()`** via a new `readFeeRecipient`, not from `/health.addresses.treasuryReserve`. Those are the same account on mainnet today, and the split would be silently wrong the moment they aren't — the contract is the authority on where its own fee goes.

When it can't be read, `feeCount`/`feeUsdc` are **null** and `feesSeparated` is false: *"we could not look"*, not a zero claiming no fees were taken. Same `unverified` vs `shortfall` distinction the board makes everywhere else.

## Also corrected

`topic1` is a **reservation** id, not a job id. One settlement tx emits a payout leg and a fee leg with different `topic1` values (`0x7afd7fbf`: `0x50f48b3a` vs `0xf541d2ab`), so joining settlements to jobs on `topic1` matches nothing. The comment said jobId; a mainnet read disproved it, at the cost of a full investigation round.

## Calibration

Derived from real logs, not the ABI — deployed signatures have drifted from source before. Confirmed on mainnet: fee legs carry `topic3` = treasury, `5000 + 50000 + 50000 = 0.105 USDC`, matching the board's protocol-revenue figure exactly.

Also established, and **not** a defect: the 24 settlements that paid no fee were escrowed at exactly their reward (`word[1] = 100000`), while fee-bearing ones were escrowed at `reward × 1.05` (`105000`). `escrowed == payout + fee` holds to the unit in every case. Nothing is leaking — those jobs were never charged, being self-posted pipeline work rather than bonded external bounties.

## Tests

5 new, including the one that matters: a ledger claiming 5 against a chain holding 2 payouts + 3 fees still reports a gap.

167 in the file, typecheck clean.

## ~~main is red~~ — RETRACTED

An earlier revision of this description claimed main had 5 failing tests in `mcp-bundle-drift.test.ts`. **That was wrong.** The failures were a stale `packages/mcp-common/dist` in my working copy: `UNKNOWN_BUNDLE_ID` existed in source but not in `dist`, so the import resolved to `undefined`, the guard in `compareBundle` could not match, and it fell through to `current`.

`npx tsc -b packages/mcp-common` and all 18 pass. Main is green; #669 is correct as written, including the safety property I doubted.
