### PR TITLE
fix(ops): actually surface the fee split, instead of computing and dropping it

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -1925,6 +1925,46 @@ export interface PayoutEvidence {
   windowBlocks: number | null;
   /** Does the block window actually span what it is compared against? */
   window?: WindowFit;
+  /**
+   * Protocol-fee credits in the SAME window — settlements whose recipient was
+   * the fee treasury, and the reason `confirmedCount` is not simply every
+   * settlement found on chain.
+   *
+   * Surfaced so a reader can SEE the split that produced the payout count
+   * instead of having to trust it. Excluding fees silently changes a number the
+   * operator has been reading for weeks, with nothing on screen to explain why —
+   * and an unexplained change in a money figure is its own kind of dishonesty.
+   *
+   * null means fees could not be told apart (no readable fee recipient), NOT
+   * that none were taken.
+   */
+  feeCount?: number | null;
+  feeUsdc?: number | null;
+  /** False → `confirmedCount` may still include fees. Stated, never implied. */
+  feesSeparated?: boolean;
+}
+
+/**
+ * Attach the fee split to the verdict.
+ *
+ * A named seam rather than an inline spread, because the first version of this
+ * change computed the split correctly and then dropped it: the payload shipped
+ * with no fee fields at all, and the whole suite stayed green because nothing
+ * asserted the assembly. A separate function is a thing a test can hold.
+ *
+ * Carried ALONGSIDE the verdict, never into it: fees do not change whether
+ * payouts reconcile, they explain which settlements were counted.
+ */
+export function withFeeSplit(
+  evidence: PayoutEvidence,
+  read: { feeCount: number | null; feeUsdc: number | null; feesSeparated: boolean },
+): PayoutEvidence {
+  return {
+    ...evidence,
+    feeCount: read.feeCount,
+    feeUsdc: read.feeUsdc,
+    feesSeparated: read.feesSeparated,
+  };
 }
 
 /**
@@ -2155,15 +2195,18 @@ export async function collectProductHealthProbes(
         targetHours: PAYOUT_COMPARISON_HOURS,
       })
     : undefined;
-  const payout = decidePayoutEvidence({
-    confirmedCount: payoutRead.count,
-    confirmedUsdc: payoutRead.usdc,
-    settledCount: settlement?.settled24h ?? null,
-    windowBlocks: payoutRead.windowBlocks,
-    tolerance: config.payoutTolerance,
-    ...(payoutRead.reason ? { unverifiedReason: payoutRead.reason } : {}),
-    ...(windowFit ? { window: windowFit } : {}),
-  });
+  const payout = withFeeSplit(
+    decidePayoutEvidence({
+      confirmedCount: payoutRead.count,
+      confirmedUsdc: payoutRead.usdc,
+      settledCount: settlement?.settled24h ?? null,
+      windowBlocks: payoutRead.windowBlocks,
+      tolerance: config.payoutTolerance,
+      ...(payoutRead.reason ? { unverifiedReason: payoutRead.reason } : {}),
+      ...(windowFit ? { window: windowFit } : {}),
+    }),
+    payoutRead,
+  );
   // The monitor's own version. Degraded-safe: any failure is "unknown", which
   // must never render as up to date.
   const selfFreshness = await deriveSelfFreshnessProbe({

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -18,6 +18,7 @@ import {
   decideWindowFit,
   measureBlockSeconds,
   readPayoutTransfers,
+  withFeeSplit,
   collectProductHealthProbes,
   chainBlockAge,
   decideProductHealthAlert,
@@ -1607,6 +1608,43 @@ describe("decidePayoutEvidence (pure verdict)", () => {
     const r = decidePayoutEvidence({ ...base, confirmedCount: 3, confirmedUsdc: 1.5, settledCount: null });
     expect(r.status).toBe("confirmed");
     expect(r.detail).toContain("no settled count to compare");
+  });
+});
+
+describe("withFeeSplit — the split must actually reach the payload", () => {
+  // THE REGRESSION, found on the live board. readPayoutTransfers computed
+  // feeCount/feeUsdc/feesSeparated correctly and PayoutEvidence never carried
+  // them, so /monitor/product-health shipped with the fields simply absent.
+  // The full suite stayed green because nothing asserted the assembly — the
+  // split was right and invisible.
+  const verdict = {
+    status: "confirmed" as const, detail: "ok",
+    confirmedCount: 16, confirmedUsdc: 2.9, settledCount: 16, windowBlocks: 43200,
+  };
+
+  it("carries the fee numbers through to the evidence", () => {
+    const r = withFeeSplit(verdict, { feeCount: 3, feeUsdc: 0.105, feesSeparated: true });
+    expect(r.feeCount).toBe(3);
+    expect(r.feeUsdc).toBeCloseTo(0.105, 6);
+    expect(r.feesSeparated).toBe(true);
+  });
+
+  it("preserves the verdict untouched", () => {
+    // Fees explain which settlements were counted; they must not alter whether
+    // payouts reconcile.
+    const r = withFeeSplit(verdict, { feeCount: 3, feeUsdc: 0.105, feesSeparated: true });
+    expect(r.status).toBe("confirmed");
+    expect(r.confirmedCount).toBe(16);
+    expect(r.settledCount).toBe(16);
+  });
+
+  it("passes through NULL when fees could not be separated", () => {
+    const r = withFeeSplit(verdict, { feeCount: null, feeUsdc: null, feesSeparated: false });
+    expect(r.feeCount).toBeNull();
+    expect(r.feesSeparated).toBe(false);
+    // null, not absent: a reader must be able to tell "could not look" from
+    // "this build does not report fees at all".
+    expect("feeCount" in r).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What was wrong

#670 split settlements by recipient so protocol fees stop being counted as payouts. **That half works.** The other half never shipped — `feeCount`, `feeUsdc` and `feesSeparated` were computed in `readPayoutTransfers`, never added to `PayoutEvidence`, and never reached the payload.

Found by reading the live board after deploying:

```
--- payout evidence ---
  status           confirmed
  confirmedCount   19
  settledCount     17
  windowBlocks     43200
```

The fee fields aren't `false` there. They're **absent**.

**2361 tests were green.** Nothing asserted the assembly, so the split was correct and invisible — the same failure mode as a probe that computes the right answer and renders nothing.

## Fix

The merge is now a named function, `withFeeSplit`, instead of an inline spread at the call site. A separate function is a thing a test can hold, and three now do:

- the fee numbers arrive in the evidence
- the verdict is untouched (fees explain *which settlements were counted*; they must not change whether payouts reconcile)
- an unseparable read passes through as `null` and the key still exists — a reader must be able to tell *"could not look"* from *"this build doesn't report fees"*

## Why the fields matter beyond completeness

Excluding fees silently changes a number the operator has been reading for weeks. Without the fee count on screen there's nothing to explain why `confirmed` dropped, and **an unexplained change in a money figure is its own kind of dishonesty.** `feesSeparated: false` says the count may still include fees rather than leaving it implied.

Fields are optional on the interface so existing `PayoutEvidence` literals in tests keep compiling; the seam is what guarantees the real path fills them.

2364 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)