### PR TITLE
feat(board): show the fee credits that were excluded from the payout count

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -93,6 +93,51 @@ describe("splitPools", () => {
   });
 });
 
+describe("payoutView — the fee exclusion is explained on screen", () => {
+  const base = {
+    status: "confirmed" as const, detail: "ok",
+    confirmedCount: 19, confirmedUsdc: 3.1, settledCount: 16, windowBlocks: 43200,
+  };
+
+  test("names the fee credits that were excluded from the count", () => {
+    // Excluding fees moved a number the operator had been reading for weeks.
+    // Without this the count silently drops and nothing explains why — which is
+    // its own kind of dishonesty about a money figure.
+    const view = payoutView({ ...base, feeCount: 1, feeUsdc: 0.05, feesSeparated: true });
+    expect(view.line1).toContain("1 fee credit");
+    expect(view.line1).toContain("excluded");
+  });
+
+  test("says so when fees could NOT be separated", () => {
+    // The count may still include fees. Silence here would let a conflated
+    // number read as a clean one.
+    const view = payoutView({ ...base, feeCount: null, feeUsdc: null, feesSeparated: false });
+    expect(view.line1).toContain("fees not separated");
+  });
+
+  test("stays quiet when fees were separable and there were none", () => {
+    // Nothing to explain. A permanent "0 fees excluded" is the noise that
+    // teaches an operator to stop reading the line.
+    const view = payoutView({ ...base, feeCount: 0, feeUsdc: 0, feesSeparated: true });
+    expect(view.line1).not.toContain("fee");
+  });
+
+  test("stays quiet on a payload that predates the split", () => {
+    // An older monitor claims nothing either way; inventing a note would be a
+    // statement it never made.
+    expect(payoutView(base).line1).not.toContain("fee");
+  });
+
+  test("does not change the verdict", () => {
+    // Fees explain WHICH settlements were counted. They must not affect whether
+    // payouts reconcile.
+    const view = payoutView({ ...base, feeCount: 3, feeUsdc: 0.105, feesSeparated: true });
+    expect(view.status).toBe("CONFIRMED");
+    expect(view.tone).toBe("ok");
+    expect(view.emphasised).toBe(false);
+  });
+});
+
 describe("payoutView — instrument broken vs money broken", () => {
   // The distinction the whole row exists for. `unverified` means we cannot see
   // the chain; paging on it is the false red that teaches an operator to ignore

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -460,6 +460,27 @@ export interface EvidenceView {
  * may be perfectly fine). Collapsing the last two into one alarm is how a board
  * trains its operator to ignore it.
  */
+/**
+ * Why the payout count is not simply every settlement on chain.
+ *
+ * The protocol fee is credited by the SAME event as a payout and differs only
+ * in recipient, so it is excluded from the count. That exclusion moved a number
+ * the operator had been reading for weeks, and a money figure that changes with
+ * nothing on screen to explain it is its own kind of dishonesty.
+ *
+ * Silent only when there is genuinely nothing to say: fees were separable and
+ * none occurred in the window. `feesSeparated: false` is NOT that case — it
+ * means the count may still include fees, and saying so is the whole point.
+ */
+function feeNote(payout: PayoutEvidence): string {
+  if (payout.feesSeparated === false) return " · fees not separated — count may include them";
+  if (payout.feesSeparated !== true) return ""; // older payload, nothing claimed
+  const n = payout.feeCount ?? 0;
+  if (n === 0) return "";
+  const amount = payout.feeUsdc == null ? "" : ` ${formatAmount(payout.feeUsdc)} USDC`;
+  return ` · ${n} fee credit${n === 1 ? "" : "s"}${amount} excluded`;
+}
+
 export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
   if (!payout) {
     return {
@@ -477,7 +498,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       ? "chain not readable in this window"
       : `${payout.confirmedCount} payout${payout.confirmedCount === 1 ? "" : "s"} confirmed on-chain${
           payout.confirmedUsdc == null ? "" : ` · ${formatAmount(payout.confirmedUsdc)} USDC`
-        }`;
+        }${feeNote(payout)}`;
   const ledgerLine =
     payout.settledCount == null
       ? "settled count unavailable"

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -124,6 +124,21 @@ export interface PayoutEvidence {
   windowBlocks: number | null;
   /** Does the block window actually span the period being compared? */
   window?: WindowFit;
+  /**
+   * Protocol-fee credits in the SAME window — the reason `confirmedCount` is
+   * not simply every settlement on chain. Fees ride the identical event and
+   * differ only in recipient.
+   *
+   * RENDERED, not merely carried: excluding fees changed a number the operator
+   * had been reading for weeks, and a money figure that moves with nothing on
+   * screen to explain it is its own kind of dishonesty.
+   *
+   * null = could not be told apart. NOT "none were taken".
+   */
+  feeCount?: number | null;
+  feeUsdc?: number | null;
+  /** False → `confirmedCount` may still include fees. Said, never implied. */
+  feesSeparated?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Why

#672 got `feeCount` / `feeUsdc` / `feesSeparated` into the payload. The board rendered **none of it** — so from the operator's seat nothing changed, which is exactly the report I got back after deploying.

That's worse than incomplete. Excluding fees moved a number that had been read the same way for weeks: `19 payouts confirmed` quietly became a *different* 19, with nothing on screen to say why. **A money figure that changes without explanation is its own kind of dishonesty, even when the new number is the correct one.**

## What it reads now

```
19 payouts confirmed on-chain · 3.10 USDC · 1 fee credit 0.05 USDC excluded
16 marked settled by the monitor
```

Three states, each deliberate:

| condition | shows |
|---|---|
| separable, non-zero | names the credits and the amount |
| `feesSeparated: false` | *"fees not separated — count may include them"* |
| separable and zero, or a payload predating the split | **silent** |

The silence is the considered part. A permanent `0 fees excluded` is the noise that teaches an operator to stop reading the line — and inventing a note for an older payload that never made the claim would be putting words in its mouth.

## Scope

Appended to `line1` (what the **chain** says). Touches neither the verdict nor the tone: fees explain *which settlements were counted*, not whether payouts reconcile. A test pins that.

## Bond question, settled

Ran the calibration alongside this. **Zero** settlement transactions carry more than one non-fee leg — there are no bond refunds in `ReservationSettled`, and my hypothesis was wrong.

The remaining `19 vs 16` is fully explained:

| window | span | payouts |
|---|---|---|
| probe (43200 blocks) | **25.3h** | 19 |
| true 24h (40909 blocks) | 24.0h | **17** |

Two of the three come from the lookback being 1.3h too wide — `43200` was sized for a 2.0s block time and the measured rate is **2.112s**. The last is ordinary timing, inside the tolerance of 1.

Not fixed here (separate change): the lookback should be derived from the measured block time rather than assumed, which is the same mistake the ops skill already warns about for 6s.

5 tests, 2369 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)