### PR TITLE
fix(ops): size the payout window from the measured block time, not an assumption

### DIFF
--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -652,8 +652,17 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     selfDirty: truthy(env.AVERRAY_GIT_DIRTY),
     selfGithubToken: env.PRODUCT_HEALTH_SELF_GITHUB_TOKEN || env.GITHUB_TOKEN || undefined,
     githubApiBaseUrl: env.GITHUB_API_BASE_URL || undefined,
-    // ~24h at a 6s block time. Lower it if the RPC caps eth_getLogs ranges.
-    payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 14400),
+    // A CEILING, not the window. The window itself is derived from the chain's
+    // MEASURED block time (see resolvePayoutLookback) so it actually spans the
+    // 24h it is compared against; this only bounds how far we are willing to
+    // ask the RPC to scan. Lower it if eth_getLogs ranges are capped.
+    //
+    // Was 14400 with the comment "~24h at a 6s block time". The measured rate is
+    // 2.112s, so that default spanned 8.4 HOURS while being compared against a
+    // 24h ledger count — the short direction, which under-counts payouts and
+    // manufactures a shortfall. Any deployment on the default was exposed to it;
+    // mainnet only escaped by overriding to 43200 (still 25.3h, 5% long).
+    payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 60000),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
     diskPath: env.PRODUCT_HEALTH_DISK_PATH || "/",
     // Unlike the token floors (which default to 0 = can-never-go-red, because a
@@ -1238,6 +1247,42 @@ export function decideWindowFit(input: {
     blockSeconds,
     spanHours: span,
   };
+}
+
+/**
+ * Size the log window from the chain's MEASURED block time.
+ *
+ * decideWindowFit already computed the right number and only ever printed it:
+ * `~40909 blocks would match`. Reporting the correct window while continuing to
+ * scan the wrong one leaves the operator to reconcile two numbers by hand,
+ * every day, forever.
+ *
+ * The configured value becomes a CEILING rather than the window. It exists for
+ * RPCs that cap eth_getLogs ranges, and that is a limit on what we may ask for —
+ * not a statement about how long 24 hours is.
+ *
+ * Falling back to the ceiling when the chain cannot be sampled is deliberate:
+ * an unmeasured block time is exactly when a guess is least trustworthy, so the
+ * behaviour stays what the operator configured, and decideWindowFit reports the
+ * fit as "unchecked" rather than implying a pass.
+ *
+ * When the ceiling binds, the window is SHORT — the dangerous direction, which
+ * under-counts payouts and manufactures a shortfall. That is not silently
+ * accepted: the same decideWindowFit call flags it as `suspect` and names the
+ * direction.
+ */
+export function resolvePayoutLookback(input: {
+  blockSeconds: number | null;
+  /** Upper bound on blocks we are willing to scan. */
+  maxBlocks: number;
+  targetHours: number;
+}): { blocks: number; derived: boolean } {
+  const { blockSeconds, maxBlocks, targetHours } = input;
+  if (blockSeconds === null || !Number.isFinite(blockSeconds) || blockSeconds <= 0) {
+    return { blocks: maxBlocks, derived: false };
+  }
+  const wanted = Math.round((targetHours * 3600) / blockSeconds);
+  return { blocks: Math.min(wanted, maxBlocks), derived: true };
 }
 
 /**
@@ -2167,6 +2212,17 @@ export async function collectProductHealthProbes(
         fetchImpl,
       })
     : null;
+  // Measure BEFORE reading logs, so the window is sized by the chain's real
+  // rate rather than merely checked against it afterwards. One sample serves
+  // both the sizing and the fit report.
+  const blockSeconds = config.payoutEvidenceEnabled
+    ? await measureBlockSeconds({ rpcUrl: config.rpcUrl, sampleBlocks: PAYOUT_BLOCK_TIME_SAMPLE, fetchImpl })
+    : null;
+  const lookback = resolvePayoutLookback({
+    blockSeconds,
+    maxBlocks: config.payoutLookbackBlocks,
+    targetHours: PAYOUT_COMPARISON_HOURS,
+  });
   const payoutRead = config.payoutEvidenceEnabled
     ? await readPayoutTransfers({
         rpcUrl: config.rpcUrl,
@@ -2175,7 +2231,7 @@ export async function collectProductHealthProbes(
         sourceAddress: config.payoutSourceAddress || h.body?.addresses?.agentAccountCore,
         usdcAddress: config.usdcAddress,
         usdcDecimals: config.usdcDecimals,
-        lookbackBlocks: config.payoutLookbackBlocks,
+        lookbackBlocks: lookback.blocks,
         expectedChainId: chainId,
         ...(feeRecipient ? { feeRecipientAddress: feeRecipient } : {}),
         fetchImpl,
@@ -2184,14 +2240,13 @@ export async function collectProductHealthProbes(
   // Check the INSTRUMENT against the chain, not against an assumption. The
   // lookback is compared to settled24h, so it has to actually span 24h at the
   // chain's real block time — an assumed one has already been wrong in prod.
+  // Checks the window we ACTUALLY scanned, not the ceiling. Sizing it from the
+  // measurement should make this read "ok" — and when it does not, the ceiling
+  // is binding and the window is genuinely short, which is worth saying.
   const windowFit = config.payoutEvidenceEnabled
     ? decideWindowFit({
-        blockSeconds: await measureBlockSeconds({
-          rpcUrl: config.rpcUrl,
-          sampleBlocks: PAYOUT_BLOCK_TIME_SAMPLE,
-          fetchImpl,
-        }),
-        lookbackBlocks: config.payoutLookbackBlocks,
+        blockSeconds,
+        lookbackBlocks: lookback.blocks,
         targetHours: PAYOUT_COMPARISON_HOURS,
       })
     : undefined;

--- a/test/unit/product-health.test.ts
+++ b/test/unit/product-health.test.ts
@@ -18,6 +18,7 @@ import {
   decideWindowFit,
   measureBlockSeconds,
   readPayoutTransfers,
+  resolvePayoutLookback,
   withFeeSplit,
   collectProductHealthProbes,
   chainBlockAge,
@@ -1608,6 +1609,47 @@ describe("decidePayoutEvidence (pure verdict)", () => {
     const r = decidePayoutEvidence({ ...base, confirmedCount: 3, confirmedUsdc: 1.5, settledCount: null });
     expect(r.status).toBe("confirmed");
     expect(r.detail).toContain("no settled count to compare");
+  });
+});
+
+describe("resolvePayoutLookback — size the window, do not assume it", () => {
+  // decideWindowFit already computed the right number and only ever PRINTED it
+  // ("~40909 blocks would match"). Reporting the correct window while scanning
+  // the wrong one leaves the operator reconciling two numbers by hand forever.
+  it("derives the window from the measured block time", () => {
+    // Mainnet 2026-08-02: 2.112s/block, so 24h is 40909 blocks — not the 43200
+    // that was configured for an assumed 2.0s.
+    const r = resolvePayoutLookback({ blockSeconds: 2.112, maxBlocks: 60000, targetHours: 24 });
+    expect(r.blocks).toBe(40909);
+    expect(r.derived).toBe(true);
+  });
+
+  it("treats the configured value as a CEILING, never as the window", () => {
+    // It exists for RPCs that cap eth_getLogs ranges — a limit on what we may
+    // ask for, not a statement about how long 24 hours is.
+    const r = resolvePayoutLookback({ blockSeconds: 2.112, maxBlocks: 10000, targetHours: 24 });
+    expect(r.blocks).toBe(10000);
+    expect(r.derived).toBe(true);
+  });
+
+  it("falls back to the ceiling when the chain could not be sampled", () => {
+    // An unmeasured block time is exactly when a guess is least trustworthy, so
+    // behaviour stays what the operator configured and the fit reads unchecked.
+    for (const bad of [null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const r = resolvePayoutLookback({ blockSeconds: bad, maxBlocks: 43200, targetHours: 24 });
+      expect(r.blocks).toBe(43200);
+      expect(r.derived).toBe(false);
+    }
+  });
+
+  it("would have caught the 6s assumption that shipped as the default", () => {
+    // The old default was 14400 with the comment "~24h at a 6s block time". At
+    // the real 2.112s that spans 8.4 HOURS against a 24h ledger count — the
+    // SHORT direction, which under-counts payouts and manufactures a shortfall.
+    const span = (14400 * 2.112) / 3600;
+    expect(span).toBeLessThan(9);
+    const r = resolvePayoutLookback({ blockSeconds: 2.112, maxBlocks: 14400, targetHours: 24 });
+    expect(r.blocks).toBe(14400); // ceiling binds — and decideWindowFit says "suspect"
   });
 });
 


### PR DESCRIPTION
## The gap that started it

`19 payouts confirmed on-chain · 16 marked settled` — and after excluding fees, still +3. Calibration showed why:

| window | span | payouts |
|---|---|---|
| probe (43200 blocks) | **25.3h** | 19 |
| true 24h (40909 blocks) | 24.0h | **17** |

Two of the three came from the window being 1.3 hours too wide. The third is ordinary timing, inside tolerance.

## What was already there

`decideWindowFit` **already computed the right answer** and only ever printed it:

> `window spans ~25.3h at a measured 2.112s/block, not the 24h it is compared against — longer than the comparison period; ~40909 blocks would match`

The probe then scanned the configured number anyway. **Reporting the correct window while using the wrong one** leaves the operator reconciling two numbers by hand, every day, forever.

## Fix

Measure before the log read; size the window from it. One sample serves both the sizing and the fit report.

The configured value becomes a **ceiling**, not the window — it exists for RPCs that cap `eth_getLogs` ranges, which is a limit on what we may *ask for*, not a statement about how long 24 hours is. When it binds, the window is genuinely short and `decideWindowFit` still says so.

## The default was worse than mainnet's setting

`14400`, shipped with the comment *"~24h at a 6s block time"*. At the measured 2.112s that spans **8.4 hours** against a 24h ledger count — the **short** direction, which under-counts payouts and **manufactures a shortfall**. That's the exact false red this board exists to avoid, and every deployment on the default was exposed to it. Mainnet escaped only by overriding to 43200, which errs long and harmless.

Ceiling default is now 60000: generous enough that the derivation decides the window, not the constant.

## Unmeasured falls back to the ceiling, not to a guess

An unmeasured block time is precisely when a guess is least trustworthy. Behaviour stays what the operator configured, and the fit reads `unchecked` rather than implying a pass.

## Tests

4 new, including one that pins the 6s assumption so it can't come back. 2368 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)