### PR TITLE
chore(harness): move pinned kernel revision to f010c993

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ CODEX_HANDOFF_PROTOCOL) is a separate release signal.
 2. **Docker build** of `ops/Dockerfile.node` (also builds the in-image Vite SPA) +
    **compose config validation**. On `main` it also pushes the runtime image to GHCR.
 3. **INT-2 supervised dispatch** in a separate required job: real dispatcher,
-   two disposable Postgres databases, Harness pin `0890a1f0`, Docker-isolated
+   two disposable Postgres databases, Harness pin `f010c99`, Docker-isolated
    scripted runs, and an executed-count assertion so skipping cannot pass.
 
 Run the smallest relevant subset locally before opening a PR. **Do not bypass

--- a/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
+++ b/docs/HARNESS_INT2_CEREMONY_RUNBOOK.md
@@ -31,9 +31,9 @@ export HARNESS_CHECKOUT="$CEREMONY_ROOT/agent-harness"
 export REFERENCE_CHECKOUT="/absolute/path/to/averray-reference-agent"
 
 git clone https://github.com/averray-agent/agent-harness.git "$HARNESS_CHECKOUT"
-git -C "$HARNESS_CHECKOUT" checkout --detach 0890a1f
+git -C "$HARNESS_CHECKOUT" checkout --detach f010c99
 test "$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD)" = \
-  "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
+  "f010c993b0adfe55899b84a60777b0a4331fd972"
 test -z "$(git -C "$HARNESS_CHECKOUT" status --porcelain)"
 
 cd "$HARNESS_CHECKOUT"

--- a/scripts/ceremony/int2-bringup.sh
+++ b/scripts/ceremony/int2-bringup.sh
@@ -27,7 +27,7 @@ _int2_bringup() {
   [ -d "$CEREMONY_ROOT/profiles/coding-change-pilot" ] \
     || { die "pinned coding-change-pilot profile is absent"; return 1; }
 
-  _int2_pin="0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
+  _int2_pin="f010c993b0adfe55899b84a60777b0a4331fd972"
   _int2_head="$(git -C "$HARNESS_CHECKOUT" rev-parse HEAD 2>/dev/null)" \
     || { die "cannot read Harness revision"; return 1; }
   if [ "$_int2_head" != "$_int2_pin" ]; then

--- a/scripts/ceremony/int2-evidence.mjs
+++ b/scripts/ceremony/int2-evidence.mjs
@@ -16,7 +16,7 @@ import { pathToFileURL } from "node:url";
 import { Pool } from "pg";
 
 export const INT2_HARNESS_PIN =
-  "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2";
+  "f010c993b0adfe55899b84a60777b0a4331fd972";
 export const INT2_EXPECTED_PATH =
   "docs/HARNESS_INT2_SUPERVISED_DISPATCH_PLAN.md";
 export const INT2_SECTION3_CRITERION =

--- a/scripts/ceremony/run-int2-automated-suite.sh
+++ b/scripts/ceremony/run-int2-automated-suite.sh
@@ -81,11 +81,11 @@ for _int2_command in docker git node npm uv; do
 done
 mkdir -p "$_int2_evidence"
 printf '%s\n' \
-  "INT2_SUITE_BOOTSTRAP_STARTED pin=0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2" \
+  "INT2_SUITE_BOOTSTRAP_STARTED pin=f010c993b0adfe55899b84a60777b0a4331fd972" \
   > "$_int2_bootstrap_log"
 
 export HARNESS_CHECKOUT="${HARNESS_CHECKOUT:-$_int2_root/agent-harness}"
-_int2_pin="0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2"
+_int2_pin="f010c993b0adfe55899b84a60777b0a4331fd972"
 # shellcheck source=scripts/ceremony/lib/int2-harness-checkout.sh
 source "$_int2_repo/scripts/ceremony/lib/int2-harness-checkout.sh"
 int2_checkout_harness "$HARNESS_CHECKOUT" "$_int2_pin" "$_int2_bootstrap_log"

--- a/test/unit/int2-ceremony-scripts.test.ts
+++ b/test/unit/int2-ceremony-scripts.test.ts
@@ -447,7 +447,7 @@ describe("committed INT-2 ceremony mechanics", () => {
           "int2-checkout-test",
           CHECKOUT_HELPER,
           path.join(temporary, "agent-harness"),
-          "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2",
+          "f010c993b0adfe55899b84a60777b0a4331fd972",
           log,
         ],
         {
@@ -502,7 +502,7 @@ describe("committed INT-2 ceremony mechanics", () => {
         "int2-checkout-test",
         CHECKOUT_HELPER,
         checkout,
-        "0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2",
+        "f010c993b0adfe55899b84a60777b0a4331fd972",
         bootstrapLog,
       ],
       {


### PR DESCRIPTION
Moves the Harness pin so the executor fix from kernel [#32](https://github.com/averray-agent/agent-harness/pull/32) becomes reachable here.

```
0890a1f04c2729cbd310e21f66dd9dc6fbc66dc2  ->  f010c993b0adfe55899b84a60777b0a4331fd972
```

Two commits: the fix and its merge.

**Published on the implementer's behalf** — their `gh` token for this org is invalid. The commit is theirs (`9e6577c`), unmodified; I pushed and opened the PR.

## Nine live sites moved, five historical untouched

| moved | |
|---|---|
| `scripts/ceremony/int2-bringup.sh:30` | full |
| `scripts/ceremony/int2-evidence.mjs:19` | full |
| `scripts/ceremony/run-int2-automated-suite.sh:84,88` | full |
| `test/unit/int2-ceremony-scripts.test.ts:450,505` | full |
| `docs/HARNESS_INT2_CEREMONY_RUNBOOK.md:34` | **short** — the actual `checkout --detach` |
| `docs/HARNESS_INT2_CEREMONY_RUNBOOK.md:36` | full |
| `AGENTS.md:260` | **short** |

Untouched, as historical records of what ran on a given day: `HARNESS_INT2_SCRIPTED_PROOFS_RESULT.md:4`, `HARNESS_INT2_AUTOMATED_SUITE_HANDBACK.md:11,115,293`, `HARNESS_KERNEL_BUDGET_PRESERVATION_WORK_ORDER.md:6`, and the pin-move order itself.

## On runbook:34

That site was **missing from the work order** — I listed line 36, the assertion, but not line 34, the checkout it checks. Following the order literally would have checked out the old kernel and asserted the new one.

The implementer audited independently, found nine live sites where the order claimed eight, and **stopped before editing anything**. The order was corrected in #673 before this work proceeded.

## Verification

Implementer: typecheck exit 0 · `npm test` 2364 passed / 14 skipped · build exit 0 · real container-backed INT-2 suite **10/10** · pin verified as `f010c993…`

Gate: both pins audited with a short-form-safe pattern — 9 live moved, 0 old-pin leftovers in any live site, 5 historical intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)