### PR TITLE
feat(board): an ASK HERMES row — can the agent answer, or only speak?

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -6,6 +6,7 @@ import {
   shortEndpoint,
   staleAfterMs,
   opsVerdict,
+  askHermesRow,
   payoutView,
   poolMeter,
   splitPools,
@@ -90,6 +91,39 @@ describe("splitPools", () => {
     const { floored } = splitPools([pool({ amount: 1.42, floor: 2, status: "red" })]);
     expect(floored[0]!.margin).toBe("BELOW FLOOR · short 0.58");
     expect(floored[0]!.marginTone).toBe("red");
+  });
+});
+
+describe("askHermesRow — can Hermes answer?", () => {
+  test("only listening counts as ok", () => {
+    // Every other phase means a question asked right now goes unanswered.
+    expect(askHermesRow({ phase: "listening", detail: "subscribed", failures: 0 }).tone).toBe("ok");
+    for (const phase of ["connecting", "authenticating", "retrying", "misconfigured"] as const) {
+      const row = askHermesRow({ phase, detail: "why", failures: 2 });
+      expect(row.tone).toBe("degraded");
+      expect(row.value).toContain("NOT answering");
+    }
+  });
+
+  test("off is not a fault", () => {
+    // A feature nobody enabled must never render as broken, or the row becomes
+    // one more permanently-lit thing to scroll past.
+    const row = askHermesRow({ phase: "off", detail: "BUZZ_INBOUND_ENABLED is not set", failures: 0 });
+    expect(row.tone).toBe("awaiting");
+    expect(row.value).toContain("BUZZ_INBOUND_ENABLED");
+  });
+
+  test("an older build says so instead of inventing a status", () => {
+    const row = askHermesRow(undefined);
+    expect(row.value).toBe("not reported by this build");
+    expect(row.tone).toBe("awaiting");
+  });
+
+  test("a retrying listener does not look like a quiet one", () => {
+    // THE POINT. Without this row a dead listener is found by asking a question
+    // and getting silence — indistinguishable from having nothing to say.
+    const row = askHermesRow({ phase: "retrying", detail: "relay closed", failures: 3 });
+    expect(row.value).toContain("3 failed attempts");
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -226,6 +226,7 @@ export function trustRows(input: {
 
   rows.push(monitorRow(health.self));
   rows.push(buzzRow(health.buzz));
+  rows.push(askHermesRow(health.buzzInbound));
 
   const rem = health.remediation;
   if (!rem || !rem.enabled || rem.state === "off") {
@@ -265,6 +266,33 @@ function buzzRow(buzz: ProductHealth["buzz"]): TrustRow {
   const tone: OpsTone =
     buzz.status === "ok" ? "ok" : buzz.status === "failing" ? "red" : "awaiting";
   return { key: "OPS CHANNEL", value: buzz.detail, tone };
+}
+
+/**
+ * Can Hermes ANSWER? — the other half of the ops channel.
+ *
+ * `OPS CHANNEL` above says whether alerts get OUT. This says whether a question
+ * gets IN, and the two fail differently: a dead listener emits no alert and no
+ * error, so it is found by asking something and getting silence — which reads
+ * as the agent having nothing to say.
+ *
+ * Only `listening` is ok. Every other phase means questions go unanswered, and
+ * a retrying listener looks exactly like a channel nobody has posted in.
+ * `off` is not a fault — a feature nobody enabled must never render as broken,
+ * or the row becomes one more permanently-lit thing to scroll past.
+ */
+export function askHermesRow(inbound: ProductHealth["buzzInbound"]): TrustRow {
+  // Absent means this build predates the feature. Inventing a status for a
+  // field the server never sent is the fabrication this panel exists to avoid.
+  if (!inbound) return { key: "ASK HERMES", value: "not reported by this build", tone: "awaiting" };
+  if (inbound.phase === "listening") return { key: "ASK HERMES", value: "listening — questions answered", tone: "ok" };
+  if (inbound.phase === "off" || inbound.phase === "closed") {
+    return { key: "ASK HERMES", value: inbound.detail || "not enabled", tone: "awaiting" };
+  }
+  // connecting / authenticating / retrying / misconfigured — all mean a question
+  // asked right now goes unanswered. Say which, and say it is not answering.
+  const retries = inbound.failures > 0 ? ` · ${inbound.failures} failed attempt${inbound.failures === 1 ? "" : "s"}` : "";
+  return { key: "ASK HERMES", value: `${inbound.phase} — NOT answering${retries}`, tone: "degraded" };
 }
 
 function monitorRow(self: SelfFreshness | undefined): TrustRow {

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -54,6 +54,14 @@ export interface BuzzDeliveryView {
   lastFailureAt?: number;
 }
 
+/** The inbound listener's live socket state. `listening` is the only one that answers. */
+export interface BuzzInboundView {
+  phase: "off" | "connecting" | "authenticating" | "listening" | "retrying" | "closed" | "misconfigured";
+  detail: string;
+  /** Consecutive failed connection attempts; zero once listening. */
+  failures: number;
+}
+
 export interface SolvencySnapshot {
   pools: SolvencyPool[];
   /** Honest runway note, e.g. "≈ 6 payouts to floor" or "pending settlement data". */
@@ -250,6 +258,19 @@ export interface ProductHealth {
   remediation?: RemediationStatus;
   /** #Ops delivery health — see BuzzDeliveryView. */
   buzz?: BuzzDeliveryView;
+  /**
+   * Whether Hermes can ANSWER in #Ops — the inbound listener's live socket.
+   *
+   * `buzz` above reports OUTBOUND narration: whether alerts get delivered. This
+   * is the other direction, and it fails differently. A dead listener produces
+   * no alert and no error; you discover it by asking a question and getting
+   * silence, which is indistinguishable from the agent having nothing to say.
+   *
+   * Absent when the build predates the feature. `phase: "off"` means it was
+   * deliberately not started, and `detail` carries which precondition was
+   * missing — those two must not render the same.
+   */
+  buzzInbound?: BuzzInboundView;
   /** The monitor's own build vs main — "is this board current?". */
   self?: SelfFreshness;
   /**

--- a/services/slack-operator/src/index.ts
+++ b/services/slack-operator/src/index.ts
@@ -838,6 +838,22 @@ async function handleHttpRequest(request: http.IncomingMessage, response: http.S
           ...(phase === undefined ? {} : { relayReachableNow: phase === "listening" }),
         });
       })(),
+      // Can Hermes ANSWER? The row above reports outbound narration; without
+      // this one, a dead listener is discovered by asking a question and getting
+      // silence — which is the failure this board exists to prevent, pointed at
+      // the newest part of it.
+      //
+      // Absent (not "off") when the feature was never started, so an older build
+      // and a stopped listener do not render identically.
+      ...(() => {
+        const state = buzzInbound.subscription?.state();
+        if (!state) {
+          return buzzInbound.started
+            ? {}
+            : { buzzInbound: { phase: "off" as const, detail: buzzInbound.reason, failures: 0 } };
+        }
+        return { buzzInbound: { phase: state.phase, detail: state.detail, failures: state.failures } };
+      })(),
       ...(productHealthSnapshotBlocks ?? {}),
       // History-derived Trends + Incidents (uptime% / latency / balance series +
       // incident episodes) from the rolling buffer. Always present — the series


### PR DESCRIPTION
## The gap

The trust rail has `OPS CHANNEL` for **outbound** narration — whether alerts get out. Since #665 there's an inbound listener too, and **nothing on the board says whether it's alive.** Its phase went to logs only, and `describeListenerRow` — which I wrote in that same PR — was never called from anywhere. Dead code.

The two directions fail differently, which is why one row can't cover both. A dead listener emits no alert and no error: you find it by asking a question and getting silence, and **silence is indistinguishable from the agent having nothing to say.**

## What it reads

```
ASK HERMES   listening — questions answered
ASK HERMES   retrying — NOT answering · 3 failed attempts
ASK HERMES   BUZZ_INBOUND_ENABLED is not set
```

Only `listening` is ok. `connecting`, `authenticating`, `retrying` and `misconfigured` all mean a question asked right now goes unanswered — and each says so in those words rather than leaving you to infer it from a phase name.

## Two deliberate non-alarms

**`off` is not a fault.** A feature nobody enabled rendering as broken is how a panel earns a permanently-lit row that teaches its reader to skip the whole rail. It carries the *reason* instead, because "not enabled" and "enabled but the gateway is unconfigured" send you to different places.

**Absent says so.** A build predating the feature reads `not reported by this build` — inventing a status for a field the server never sent is the fabrication this panel exists to avoid, and the rule `buzzRow` already follows.

## Still not on the board, for a follow-up

`payout.window` — `window spans ~24h at 2.16s/block` — is in the payload and no frontend code reads it. That's the sentence that says whether to trust the payout comparison, and it's currently JSON-only.

4 tests. 2377 pass, typecheck clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)