### PR TITLE
feat(ops): gas spend by operation — the pure core

### DIFF
--- a/services/slack-operator/src/gas-spend.ts
+++ b/services/slack-operator/src/gas-spend.ts
@@ -1,0 +1,159 @@
+// What the signer's gas actually went ON.
+//
+// The board already says signer gas is 6.10 DOT burning ~0.065 DOT/hour. That
+// answers "when do I run out" and nothing about "on what" — so a change in how
+// the system spends gas shows up only as the runway shortening, which reads
+// identically to simply doing more work.
+//
+// This splits the burn by operation, which turns two different questions apart:
+//   · volume went up      → cost per settlement is FLAT, spend rose. Fine.
+//   · something regressed → cost per settlement ROSE. Not fine, and invisible
+//     on a runway chart.
+//
+// ── WHAT IT REFUSES TO GUESS ────────────────────────────────────────────────
+//
+// Operations are identified by the call's 4-byte selector, and a selector is
+// only given a NAME when one is supplied for it. An unrecognised selector is
+// shown as the raw hex, never bucketed into "other" and never labelled by
+// inference. This repo has already been bitten by deriving on-chain identifiers
+// from checked-in Solidity that had drifted from the deployed contract; a
+// plausible wrong label on a money board is worse than an unfamiliar hex string,
+// because the hex invites a look and the label ends it.
+//
+// ── FAILED TRANSACTIONS ARE COUNTED SEPARATELY ──────────────────────────────
+//
+// A reverted transaction still burns gas and produces nothing. Folded into the
+// totals it looks like ordinary cost; called out, it is a bug with a price tag.
+//
+// Pure: no RPC, no clock. The caller fetches receipts.
+
+export interface GasTx {
+  /** Sender, lowercase. Used to confirm the "signer gas" framing holds. */
+  from: string;
+  to: string | null;
+  /** First 4 bytes of calldata, e.g. "0x38ed7cfc". "0x" for a plain transfer. */
+  selector: string;
+  /** gasUsed × effectiveGasPrice, in wei. */
+  gasWei: bigint;
+  /** False when the transaction reverted — gas spent for nothing. */
+  success: boolean;
+}
+
+export interface GasBucket {
+  /** A supplied name, or the raw selector when none is known. Never inferred. */
+  label: string;
+  selector: string;
+  count: number;
+  dot: number;
+  /** Mean cost of one call — the number that exposes a regression. */
+  avgDot: number;
+  sharePct: number;
+  /** Reverted calls in this bucket. Gas burned for nothing. */
+  failed: number;
+}
+
+export interface GasSpend {
+  totalDot: number;
+  txCount: number;
+  buckets: GasBucket[];
+  /** Gas burned by reverted transactions. Pure waste, named as such. */
+  failedDot: number;
+  failedCount: number;
+  /**
+   * DOT per settlement — gas as a UNIT COST rather than a countdown, so it can
+   * be held against the reward a job pays. null when no settlement count was
+   * supplied, or when there were none: dividing by zero to get "infinite cost
+   * per job" would be a number that means nothing.
+   */
+  perSettlement: number | null;
+  /**
+   * Distinct senders seen. More than one means the backend signs with several
+   * keys and "signer gas" is the wrong frame for this figure — surfaced rather
+   * than silently summed, because the pool on the board is ONE account.
+   */
+  senders: string[];
+}
+
+/** Native DOT reads as 18 decimals over eth-rpc (see the ops skill). */
+export const DOT_DECIMALS = 18n;
+
+function toDot(wei: bigint): number {
+  // Divide in bigint down to micro-DOT, then convert — Number(wei) alone loses
+  // precision above 2^53, and these are 18-decimal values.
+  const micro = wei / 10n ** (DOT_DECIMALS - 6n);
+  return Number(micro) / 1e6;
+}
+
+/**
+ * Summarise gas spend by operation.
+ *
+ * `labels` maps selector → human name. Anything absent keeps its hex, which is
+ * the honest rendering of "we know it cost this much and not what it was".
+ */
+export function summarizeGasSpend(
+  txs: readonly GasTx[],
+  options: {
+    labels?: Readonly<Record<string, string>>;
+    /** Settlements in the same window, for the per-job unit cost. */
+    settledCount?: number | null;
+  } = {},
+): GasSpend {
+  const labels = options.labels ?? {};
+  const totalWei = txs.reduce((sum, t) => sum + t.gasWei, 0n);
+
+  const grouped = new Map<string, { count: number; wei: bigint; failed: number }>();
+  for (const tx of txs) {
+    const entry = grouped.get(tx.selector) ?? { count: 0, wei: 0n, failed: 0 };
+    entry.count += 1;
+    entry.wei += tx.gasWei;
+    if (!tx.success) entry.failed += 1;
+    grouped.set(tx.selector, entry);
+  }
+
+  const buckets: GasBucket[] = [...grouped.entries()]
+    .map(([selector, e]) => ({
+      label: labels[selector] ?? selector,
+      selector,
+      count: e.count,
+      dot: toDot(e.wei),
+      avgDot: toDot(e.wei / BigInt(e.count)),
+      sharePct: totalWei === 0n ? 0 : Number((e.wei * 10000n) / totalWei) / 100,
+      failed: e.failed,
+    }))
+    // Largest spend first: the board has room for a few rows, and the question
+    // is always "what is this going on", not "what is the full inventory".
+    .sort((a, b) => b.dot - a.dot);
+
+  const failedTxs = txs.filter((t) => !t.success);
+  const settled = options.settledCount ?? null;
+
+  return {
+    totalDot: toDot(totalWei),
+    txCount: txs.length,
+    buckets,
+    failedDot: toDot(failedTxs.reduce((s, t) => s + t.gasWei, 0n)),
+    failedCount: failedTxs.length,
+    perSettlement: settled != null && settled > 0 ? toDot(totalWei / BigInt(settled)) : null,
+    senders: [...new Set(txs.map((t) => t.from.toLowerCase()))].sort(),
+  };
+}
+
+/**
+ * The one-line summary for the board.
+ *
+ * Leads with the total and the unit cost, because those are the two an operator
+ * acts on. Reverted gas is appended only when there IS some — a permanent
+ * "0 failed" is the noise that trains someone to stop reading the line.
+ */
+export function describeGasSpend(spend: GasSpend, windowHours: number): string {
+  if (spend.txCount === 0) return `no signer transactions in ${windowHours}h`;
+  const parts = [`${spend.totalDot.toFixed(4)} DOT over ${spend.txCount} txs (${windowHours}h)`];
+  if (spend.perSettlement != null) parts.push(`${spend.perSettlement.toFixed(5)} DOT per settlement`);
+  if (spend.failedCount > 0) {
+    parts.push(`${spend.failedDot.toFixed(4)} DOT burned by ${spend.failedCount} REVERTED tx${spend.failedCount === 1 ? "" : "s"}`);
+  }
+  // Several signing keys means this total is not "the signer pool" the board
+  // meters. Say so rather than letting the two be read as the same account.
+  if (spend.senders.length > 1) parts.push(`${spend.senders.length} distinct senders — not one signer`);
+  return parts.join(" · ");
+}

--- a/test/unit/gas-spend.test.ts
+++ b/test/unit/gas-spend.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { describeGasSpend, summarizeGasSpend, type GasTx } from "../../services/slack-operator/src/gas-spend.js";
+
+const SIGNER = "0x5a6836c6d4d293f6e5377e6c28054f4171915813";
+/** 1 DOT = 1e18 wei; these are realistic per-tx costs (~0.012 DOT). */
+const dot = (n: number): bigint => BigInt(Math.round(n * 1e6)) * 10n ** 12n;
+
+const tx = (over: Partial<GasTx> = {}): GasTx => ({
+  from: SIGNER,
+  to: "0xb1350932bf85e7ffd0599e9a3cc7b55718d89e57",
+  selector: "0x38ed7cfc",
+  gasWei: dot(0.012),
+  success: true,
+  ...over,
+});
+
+describe("summarizeGasSpend", () => {
+  it("splits the burn by operation, largest first", () => {
+    const s = summarizeGasSpend([
+      tx({ selector: "0xaaaaaaaa", gasWei: dot(0.01) }),
+      tx({ selector: "0xaaaaaaaa", gasWei: dot(0.01) }),
+      tx({ selector: "0xbbbbbbbb", gasWei: dot(0.05) }),
+    ]);
+    expect(s.totalDot).toBeCloseTo(0.07, 6);
+    expect(s.buckets.map((b) => b.selector)).toEqual(["0xbbbbbbbb", "0xaaaaaaaa"]);
+    expect(s.buckets[0]!.sharePct).toBeCloseTo(71.42, 1);
+  });
+
+  it("keeps the raw selector when no name is known, rather than guessing", () => {
+    // Deriving on-chain identifiers from checked-in Solidity has already been
+    // wrong here — the deployed event signature had drifted from source. A
+    // plausible wrong label ends the investigation; an unfamiliar hex invites it.
+    const s = summarizeGasSpend([tx({ selector: "0xdeadbeef" })], { labels: { "0x38ed7cfc": "settle" } });
+    expect(s.buckets[0]!.label).toBe("0xdeadbeef");
+  });
+
+  it("uses a supplied name when there is one", () => {
+    const s = summarizeGasSpend([tx({ selector: "0x38ed7cfc" })], { labels: { "0x38ed7cfc": "settle" } });
+    expect(s.buckets[0]!.label).toBe("settle");
+  });
+
+  it("reports the MEAN cost per call — the number a regression moves", () => {
+    // Total spend rising is ambiguous: more volume, or each call got dearer.
+    // The average separates them, and only one of the two is a problem.
+    const s = summarizeGasSpend([
+      tx({ selector: "0xaa", gasWei: dot(0.01) }),
+      tx({ selector: "0xaa", gasWei: dot(0.03) }),
+    ]);
+    expect(s.buckets[0]!.avgDot).toBeCloseTo(0.02, 6);
+  });
+});
+
+describe("reverted transactions are named, not absorbed", () => {
+  it("counts gas burned by failures separately", () => {
+    // A revert still costs gas and produces nothing. Folded into the totals it
+    // looks like ordinary cost; called out, it is a bug with a price tag.
+    const s = summarizeGasSpend([
+      tx({ gasWei: dot(0.01) }),
+      tx({ gasWei: dot(0.004), success: false }),
+    ]);
+    expect(s.failedCount).toBe(1);
+    expect(s.failedDot).toBeCloseTo(0.004, 6);
+    expect(s.totalDot).toBeCloseTo(0.014, 6); // still counted in the total — it was spent
+    expect(s.buckets[0]!.failed).toBe(1);
+  });
+
+  it("mentions reverts in the summary ONLY when there are some", () => {
+    // A permanent "0 failed" is the noise that trains someone to stop reading.
+    expect(describeGasSpend(summarizeGasSpend([tx()]), 24)).not.toContain("REVERTED");
+    expect(describeGasSpend(summarizeGasSpend([tx({ success: false })]), 24)).toContain("REVERTED");
+  });
+});
+
+describe("unit cost", () => {
+  it("expresses gas as DOT per settlement, not just a total", () => {
+    // Gas as a countdown tells you when you run out. As a unit cost it can be
+    // held against the 0.10 USDC a job pays.
+    const s = summarizeGasSpend([tx({ gasWei: dot(0.06) }), tx({ gasWei: dot(0.04) })], { settledCount: 10 });
+    expect(s.perSettlement).toBeCloseTo(0.01, 6);
+    expect(describeGasSpend(s, 24)).toContain("per settlement");
+  });
+
+  it("returns null rather than dividing by zero settlements", () => {
+    // "Infinite DOT per job" is a number that means nothing.
+    expect(summarizeGasSpend([tx()], { settledCount: 0 }).perSettlement).toBeNull();
+    expect(summarizeGasSpend([tx()], { settledCount: null }).perSettlement).toBeNull();
+    expect(summarizeGasSpend([tx()]).perSettlement).toBeNull();
+  });
+});
+
+describe("the signer framing", () => {
+  it("flags more than one sender — the board meters ONE account", () => {
+    // If the backend signs with several keys, this total is not the pool the
+    // solvency panel is showing, and summing them silently would imply it is.
+    const s = summarizeGasSpend([tx(), tx({ from: "0x00000000000000000000000000000000deadbeef" })]);
+    expect(s.senders).toHaveLength(2);
+    expect(describeGasSpend(s, 24)).toContain("not one signer");
+  });
+
+  it("says nothing about senders when there is only the one", () => {
+    expect(describeGasSpend(summarizeGasSpend([tx(), tx()]), 24)).not.toContain("distinct senders");
+  });
+});
+
+describe("arithmetic at 18 decimals", () => {
+  it("does not lose precision on values above 2^53 wei", () => {
+    // Number(wei) alone breaks here: 1 DOT is 1e18, and 2^53 is ~9.0e15.
+    const s = summarizeGasSpend([tx({ gasWei: 1234567890123456789n })]);
+    expect(s.totalDot).toBeCloseTo(1.234567, 5);
+  });
+
+  it("reports an empty window as empty, not as zero cost", () => {
+    const s = summarizeGasSpend([]);
+    expect(s.txCount).toBe(0);
+    expect(s.buckets).toEqual([]);
+    expect(describeGasSpend(s, 24)).toBe("no signer transactions in 24h");
+  });
+});


### PR DESCRIPTION
## Why

The board says signer gas is `6.10 DOT` burning `~0.065 DOT/hr`. That answers **when do I run out** and nothing about **on what** — so a regression in how the system spends gas appears only as a shortening runway, which reads identically to simply doing more work.

Splitting by operation separates them:

- volume rose → cost per settlement **flat**. Fine.
- something regressed → cost per settlement **rose**. Not fine, and invisible on a runway chart.

`perSettlement` is the number worth having: gas as a **unit cost** that can be held against the 0.10 USDC a job pays, rather than a countdown.

## What it refuses to guess

Operations are keyed by the call's 4-byte selector and named **only from a supplied map**. An unrecognised selector keeps its raw hex — never bucketed into "other", never labelled by inference.

This repo has already been burned deriving on-chain identifiers from checked-in Solidity that had drifted from the deployed contract. **A plausible wrong label on a money board is worse than an unfamiliar hex string**, because the hex invites a look and the label ends it. The names will come from a calibration against mainnet, not from reading `contracts/*.sol`.

## Reverted transactions are named

A revert still burns gas and produces nothing. Folded into the totals it's ordinary cost; called out it's **a bug with a price tag**. It stays in the total — the money was spent — but `failedDot` says how much bought nothing.

## Several senders are surfaced

The solvency panel meters **one** account. If the backend signs with more than one key, this total isn't that pool, and summing silently would imply it is.

## Precision

bigint down to micro-DOT. 1 DOT is `1e18` wei and 2^53 is ~`9.0e15`, so `Number(wei)` loses precision on a *single transaction*. Pinned by a test.

## Scope

Pure core only — no RPC, no clock. The read seam and the board row follow once the selector calibration returns from mainnet; building the classifier against guessed selectors is how you ship a probe that reports zero forever.

12 tests. 2385 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)