### PR TITLE
feat(ops): gas attribution read seam — find and price the signer's transactions

### DIFF
--- a/ops/compose.yml
+++ b/ops/compose.yml
@@ -577,6 +577,15 @@ services:
       # settled-minus-confirmed gap tolerated as a window-boundary artifact — the
       # product's rolling 24h and the block window don't share a clock.
       PRODUCT_HEALTH_PAYOUT_TOLERANCE: ${PRODUCT_HEALTH_PAYOUT_TOLERANCE:-1}
+      # Gas attribution — what the signer's burn went ON, by operation.
+      #
+      # OFF by default and deliberately opt-in: one pass is ~174 RPC calls (a
+      # receipt AND a transaction for each of ~87 daily txs) against an endpoint
+      # that rate-limits by answering 404 rather than 429. It never runs on the
+      # heartbeat — the snapshot refreshes in the background on its own cadence
+      # and the board renders it with its age.
+      PRODUCT_HEALTH_GAS_ATTRIBUTION_ENABLED: ${PRODUCT_HEALTH_GAS_ATTRIBUTION_ENABLED:-}
+      PRODUCT_HEALTH_GAS_REFRESH_MS: ${PRODUCT_HEALTH_GAS_REFRESH_MS:-1800000}
       # Disk headroom. A full disk is a CORRELATED failure: it takes the monitor,
       # the money board and the alert path in the same moment, so the thing meant
       # to warn you dies with the thing it watches — silently, with no red probe.

--- a/packages/monitor-ui/src/lib/monitor/gas-line.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/gas-line.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+
+import { gasLine, type GasSpendView } from "./ops-spec.js";
+
+const base: GasSpendView = {
+  totalDot: 1.6535, txCount: 83, perSettlement: 0.0995,
+  buckets: [
+    { label: "resolveSinglePayout", count: 17, dot: 0.7007, avgDot: 0.0412, sharePct: 42.4, failed: 0 },
+    { label: "createSinglePayoutJobFeeWaived", count: 16, dot: 0.54, avgDot: 0.0338, sharePct: 32.7, failed: 0 },
+  ],
+  failedDot: 0, failedCount: 0, ageMs: 0, truncated: false, otherSenders: [],
+};
+
+describe("gasLine", () => {
+  test("leads with the unit cost, not just the total", () => {
+    // Gas as a total can only be compared with yesterday's total. As a unit
+    // cost it can be held against the 0.10 USDC a job pays.
+    const { text } = gasLine(base, 0);
+    expect(text).toContain("0.0995 DOT per settlement");
+    expect(text).toContain("resolveSinglePayout 42%");
+  });
+
+  test("absent is NOT zero", () => {
+    // "0 DOT" reads as free. Before the first read there is nothing to say.
+    expect(gasLine(undefined, 0).text).toBe("GAS — not measured");
+    expect(gasLine(undefined, 0).tone).toBe("awaiting");
+  });
+
+  test("an empty window says so rather than reporting zero cost", () => {
+    expect(gasLine({ ...base, txCount: 0 }, 0).text).toContain("no signer transactions");
+  });
+
+  test("cost alone is a fact, not an alarm", () => {
+    // Spending money is what the system does. Only something WRONG tones amber.
+    expect(gasLine(base, 0).tone).toBe("awaiting");
+  });
+});
+
+describe("every caveat that would make the number wrong is stated", () => {
+  test("reverted gas is named — it bought nothing", () => {
+    const v = gasLine({ ...base, failedCount: 2, failedDot: 0.03 }, 0);
+    expect(v.text).toContain("0.030 DOT REVERTED");
+    expect(v.tone).toBe("degraded");
+  });
+
+  test("says nothing about reverts when there are none", () => {
+    // A permanent "0 failed" trains a reader to skip the line.
+    expect(gasLine(base, 0).text).not.toContain("REVERTED");
+  });
+
+  test("a capped read says the total is UNDERSTATED", () => {
+    // Understating spend on a board that warns about running out is the wrong
+    // direction to be wrong in.
+    const v = gasLine({ ...base, truncated: true }, 0);
+    expect(v.text).toContain("UNDERSTATED");
+    expect(v.tone).toBe("degraded");
+  });
+
+  test("names other signing keys as not counted", () => {
+    // Mainnet has a second sender. Its gas never left the pool the solvency
+    // panel meters, so it is excluded — but excluding it silently would imply
+    // this is the whole cost of running the system.
+    const v = gasLine({ ...base, otherSenders: [{ address: "0x089a", count: 4 }] }, 0);
+    expect(v.text).toContain("+1 other signer not counted");
+  });
+
+  test("a frozen reader says why, and outranks the age", () => {
+    const v = gasLine({ ...base, ageMs: 3_600_000, staleReason: "rpc 404" }, 0);
+    expect(v.text).toContain("figures frozen — rpc 404");
+    expect(v.text).not.toContain("60m old");
+    expect(v.tone).toBe("degraded");
+  });
+
+  test("otherwise discloses the age", () => {
+    // A 40-minute-old breakdown is useful; presented as current it is a lie.
+    expect(gasLine({ ...base, ageMs: 2_400_000 }, 0).text).toContain("40m old");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/gas-line.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/gas-line.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 
-import { gasLine, type GasSpendView } from "./ops-spec.js";
+import { gasLine } from "./ops-spec.js";
+import type { GasSpendView } from "./product-health.js";
 
 const base: GasSpendView = {
   totalDot: 1.6535, txCount: 83, perSettlement: 0.0995,

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -573,3 +573,59 @@ export const EVIDENCE_KEY: readonly { tone: OpsTone; text: string }[] = [
   { tone: "red", text: "SHORTFALL — proof missing: money broken" },
   { tone: "awaiting", text: "UNVERIFIED — chain unreadable: instrument broken, not money" },
 ];
+
+// ── gas attribution ─────────────────────────────────────────────────────────
+
+/** Gas spend by operation, as the board shows it. Mirrors the server snapshot. */
+export interface GasSpendView {
+  totalDot: number;
+  txCount: number;
+  perSettlement: number | null;
+  buckets: Array<{ label: string; count: number; dot: number; avgDot: number; sharePct: number; failed: number }>;
+  failedDot: number;
+  failedCount: number;
+  ageMs: number;
+  truncated: boolean;
+  otherSenders: Array<{ address: string; count: number }>;
+  staleReason?: string;
+}
+
+/**
+ * The gas line: what the burn is going ON, not just how fast it burns.
+ *
+ * The solvency panel already meters the signer pool and projects a runway. That
+ * answers "when do I run out" — this answers "on what", which is the difference
+ * between topping up and finding out something regressed. `perSettlement` leads
+ * because gas as a UNIT COST can be held against the reward a job pays; gas as
+ * a total can only be compared with yesterday's total.
+ *
+ * Every caveat that would make the number wrong is appended rather than hidden:
+ * a truncated read UNDERSTATES spend, a second signing key means this is not
+ * the whole cost of running the system, and a failed refresh means the figures
+ * stopped moving at some point in the past.
+ */
+export function gasLine(gas: GasSpendView | undefined, nowMs: number): { text: string; tone: OpsTone } {
+  void nowMs;
+  // Absent is not zero. Before the first read there is nothing to say, and
+  // "0 DOT" would read as free rather than as not-yet-measured.
+  if (!gas) return { text: "GAS — not measured", tone: "awaiting" };
+  if (gas.txCount === 0) return { text: "GAS — no signer transactions in the window", tone: "awaiting" };
+
+  const parts = [`GAS ${gas.totalDot.toFixed(3)} DOT / ${gas.txCount} txs`];
+  if (gas.perSettlement != null) parts.push(`${gas.perSettlement.toFixed(4)} DOT per settlement`);
+  const top = gas.buckets[0];
+  if (top) parts.push(`${top.label} ${top.sharePct.toFixed(0)}%`);
+
+  // Reverted gas bought nothing. Named only when it exists — a permanent
+  // "0 failed" is the noise that trains a reader to skip the line.
+  if (gas.failedCount > 0) parts.push(`${gas.failedDot.toFixed(3)} DOT REVERTED`);
+  if (gas.truncated) parts.push("capped — spend UNDERSTATED");
+  if (gas.otherSenders.length > 0) parts.push(`+${gas.otherSenders.length} other signer${gas.otherSenders.length === 1 ? "" : "s"} not counted`);
+  if (gas.staleReason) parts.push(`figures frozen — ${gas.staleReason}`);
+  else if (gas.ageMs > 0) parts.push(`${Math.round(gas.ageMs / 60000)}m old`);
+
+  // Only a genuine problem tones amber: reverted gas, an understated total, or
+  // a reader that has stopped working. Cost itself is a fact, not an alarm.
+  const tone: OpsTone = gas.failedCount > 0 || gas.truncated || gas.staleReason ? "degraded" : "awaiting";
+  return { text: parts.join(" · "), tone };
+}

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -17,6 +17,7 @@
 // deterministic to test — including the age phrasing.
 
 import type {
+  GasSpendView,
   MoneyPathSnapshot,
   PayoutEvidence,
   ProductHealth,
@@ -575,20 +576,6 @@ export const EVIDENCE_KEY: readonly { tone: OpsTone; text: string }[] = [
 ];
 
 // ── gas attribution ─────────────────────────────────────────────────────────
-
-/** Gas spend by operation, as the board shows it. Mirrors the server snapshot. */
-export interface GasSpendView {
-  totalDot: number;
-  txCount: number;
-  perSettlement: number | null;
-  buckets: Array<{ label: string; count: number; dot: number; avgDot: number; sharePct: number; failed: number }>;
-  failedDot: number;
-  failedCount: number;
-  ageMs: number;
-  truncated: boolean;
-  otherSenders: Array<{ address: string; count: number }>;
-  staleReason?: string;
-}
 
 /**
  * The gas line: what the burn is going ON, not just how fast it burns.

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -46,6 +46,26 @@ export interface SolvencyPool {
   addressSs58?: string;
 }
 
+/** Gas spend by operation. Mirrors the server snapshot; see ops-spec gasLine(). */
+export interface GasSpendView {
+  totalDot: number;
+  txCount: number;
+  /** DOT per settlement — gas as a unit cost, holdable against the reward. */
+  perSettlement: number | null;
+  buckets: Array<{ label: string; count: number; dot: number; avgDot: number; sharePct: number; failed: number }>;
+  /** Gas burned by reverted transactions. Bought nothing. */
+  failedDot: number;
+  failedCount: number;
+  /** Age of these figures. Disclosed, never laundered. */
+  ageMs: number;
+  /** True when the tx cap bit — the total UNDERSTATES spend. */
+  truncated: boolean;
+  /** Other signing keys seen; their gas is excluded from these totals. */
+  otherSenders: Array<{ address: string; count: number }>;
+  /** Set when the last refresh failed; the figures are the previous ones. */
+  staleReason?: string;
+}
+
 /** Can the #Ops channel receive anything? Instrument health, not product health. */
 export interface BuzzDeliveryView {
   status: "off" | "armed" | "ok" | "failing";
@@ -271,6 +291,15 @@ export interface ProductHealth {
    * missing — those two must not render the same.
    */
   buzzInbound?: BuzzInboundView;
+  /**
+   * What the signer's gas went ON, over the payout window.
+   *
+   * Absent until the first read succeeds — and absent is NOT zero. An empty
+   * breakdown would render "0 DOT spent", which reads as free rather than as
+   * not-yet-measured. Read on its own cadence (a pass is ~174 RPC calls), so it
+   * carries its own age.
+   */
+  gas?: GasSpendView;
   /** The monitor's own build vs main — "is this board current?". */
   self?: SelfFreshness;
   /**

--- a/services/slack-operator/src/escrow-selectors.ts
+++ b/services/slack-operator/src/escrow-selectors.ts
@@ -1,0 +1,73 @@
+// Function selectors of the DEPLOYED EscrowCore v2, for naming gas spend.
+//
+// ── WHY THIS IS A PINNED CONSTANT AND NOT DERIVED ──────────────────────────
+//
+// `contracts/EscrowCore.sol` in the Polkadot repo does NOT describe the contract
+// running on mainnet. It contains zero references to protocolFee, feeBps,
+// treasuryAccount or bond, while the deployed contract demonstrably has all
+// four. Computing selectors from that source produced ONE match out of five —
+// and the four misses were the functions doing most of the work.
+//
+// The interface was recovered separately (averray-agent/agent#908) and frozen at
+// `deployments/interfaces/mainnet-escrow-core-v2.json`. These names come from
+// that artifact, not from any source in this repo.
+//
+// ── VERIFIED, NOT TRUSTED ──────────────────────────────────────────────────
+//
+// Every entry below was checked by computing keccak256 over the canonical
+// signature rebuilt from the frozen ABI and comparing it to the selector
+// observed in live mainnet traffic. 5 of 5 reproduced. The handback claimed the
+// same thing; this was run independently, because a mapping that is merely
+// plausible is exactly the failure mode a wrong label causes — the hex invites
+// a look and the name ends it.
+//
+// To re-verify after any change to the deployed contract:
+//   1. confirm the ABI still hashes to ABI_SHA256 below
+//   2. keccak256(signature).slice(0,4) must equal each key here
+// A selector that stops appearing in traffic is fine; a selector that appears
+// and is NOT here renders as raw hex, which is the honest fallback.
+
+/** Deployment this interface was frozen from. */
+export const ESCROW_V2_ADDRESS = "0x590EbE304E0C7672e2abF3161177D2B94a2aC3fC";
+export const ESCROW_V2_DEPLOY_BLOCK = 18809168;
+/** sha256 of the frozen ABI — the thing to check before trusting these names. */
+export const ESCROW_V2_ABI_SHA256 =
+  "sha256:f3b2f31a958402e0139217264dc356406130cbea402094d54bbd9f93343d5165";
+/** The contract source the deployment was built from — NOT the file in this repo. */
+export const ESCROW_V2_SOURCE_COMMIT = "775a826b0a33d0ec04dd19f0455e69402dc9bbcd";
+
+/**
+ * Selector → human name, for the gas breakdown.
+ *
+ * Deliberately only the operations seen in live traffic. The frozen ABI has 51
+ * method identifiers; carrying all of them would be a list nobody maintains and
+ * whose staleness nobody would notice, and an unlisted selector already renders
+ * as hex rather than as a guess.
+ *
+ * The comment on each line is the observed 24h cost, so a future reader can see
+ * at a glance whether a number has moved — these are the figures that made the
+ * per-job unit cost legible in the first place.
+ */
+export const ESCROW_V2_SELECTORS: Readonly<Record<string, string>> = {
+  // 42% of the burn. The single most expensive call in the lifecycle.
+  "0xb08c763e": "resolveSinglePayout",
+  // 33%. Named for what it does: the pipeline creates jobs with the fee WAIVED,
+  // which is why self-posted work yields no protocol revenue. Deliberate, and
+  // confirmed at the call site rather than inferred from an absence.
+  "0xbcb2689a": "createSinglePayoutJobFeeWaived",
+  // 15%
+  "0x090cf6d5": "claimJobFor",
+  // 5%
+  "0x1b2ef921": "submitWorkFor",
+  // 4.5%. A separate transaction per job, distinct from the FeeWaived create.
+  "0xcca2acd6": "setOnboardingWaiverEligible",
+};
+
+/** Selectors observed in live mainnet traffic — what the map has to cover. */
+export const OBSERVED_SELECTORS: readonly string[] = [
+  "0xb08c763e",
+  "0xbcb2689a",
+  "0x090cf6d5",
+  "0x1b2ef921",
+  "0xcca2acd6",
+];

--- a/services/slack-operator/src/gas-spend-cache.ts
+++ b/services/slack-operator/src/gas-spend-cache.ts
@@ -1,0 +1,116 @@
+// Gas attribution on its own cadence, so the heartbeat never waits for it.
+//
+// A pass is ~174 RPC calls (a receipt AND a transaction for each of ~87 txs).
+// The heartbeat runs every few minutes and has a money path to watch; making it
+// block on that would be trading the thing that matters for the thing that is
+// merely interesting.
+//
+// So: the heartbeat always gets an ANSWER IMMEDIATELY — the last computed
+// snapshot, with its age — and a refresh runs in the background when the value
+// has aged past the interval.
+//
+// ── STALE IS LABELLED, NEVER LAUNDERED ─────────────────────────────────────
+//
+// `ageMs` is on every snapshot and the caller renders it. A forty-minute-old
+// gas breakdown is useful; a forty-minute-old gas breakdown presented as
+// current is the same lie as any other stale number, and this board has already
+// been caught out once by reading a snapshot as live state.
+//
+// ── NOTHING ELSE WAITS ON IT ───────────────────────────────────────────────
+//
+// Before the first refresh completes there is no snapshot, and `null` is the
+// honest answer — not an empty breakdown, which would render as "0 DOT spent"
+// and read as free rather than as not-yet-known. A refresh that fails leaves
+// the previous snapshot in place with its age still climbing, so a broken
+// reader degrades into visibly-old data rather than into a fabricated zero.
+
+import { summarizeGasSpend, type GasSpend } from "./gas-spend.js";
+import type { GasReadResult } from "./gas-spend-read.js";
+
+export interface GasSpendSnapshot extends GasSpend {
+  /** Epoch ms this was computed. */
+  at: number;
+  /** How old the figures are, filled in at read time. */
+  ageMs: number;
+  /** Blocks the read covered, for the window the numbers describe. */
+  blocksScanned: number;
+  /** True when the transaction cap bit — some spend is NOT counted. */
+  truncated: boolean;
+  /** Other signing keys seen; their gas is excluded from these totals. */
+  otherSenders: Array<{ address: string; count: number }>;
+  /** Present when the last refresh failed. The figures are the PREVIOUS ones. */
+  staleReason?: string;
+}
+
+export interface GasSpendCache {
+  /** The current snapshot with a fresh age, or null before the first success. */
+  read(nowMs: number): GasSpendSnapshot | null;
+  /**
+   * Refresh if the snapshot has aged out. Returns immediately; the work happens
+   * in the background. Safe to call every heartbeat.
+   */
+  maybeRefresh(nowMs: number): void;
+}
+
+/** Long enough that the RPC cost is negligible; short enough to be useful. */
+export const DEFAULT_GAS_REFRESH_MS = 30 * 60 * 1000;
+
+export function createGasSpendCache(deps: {
+  /** Performs the read. Injected so the cache is testable without a chain. */
+  read: () => Promise<GasReadResult>;
+  /** Settlements in the same window, for the per-job unit cost. */
+  settledCount: () => number | null;
+  labels?: Readonly<Record<string, string>>;
+  refreshMs?: number;
+  onError?: (message: string) => void;
+}): GasSpendCache {
+  const refreshMs = deps.refreshMs ?? DEFAULT_GAS_REFRESH_MS;
+  let snapshot: GasSpendSnapshot | null = null;
+  // One refresh at a time. Without this a slow read plus a fast heartbeat
+  // stacks passes, and each is 174 RPC calls against an endpoint that
+  // rate-limits by answering 404.
+  let running = false;
+
+  return {
+    read(nowMs) {
+      if (!snapshot) return null;
+      return { ...snapshot, ageMs: Math.max(0, nowMs - snapshot.at) };
+    },
+
+    maybeRefresh(nowMs) {
+      if (running) return;
+      if (snapshot && nowMs - snapshot.at < refreshMs) return;
+      running = true;
+      void (async () => {
+        try {
+          const result = await deps.read();
+          if (result.reason) {
+            // Keep the previous figures and say why they stopped moving. An
+            // unreadable chain is not zero spend.
+            if (snapshot) snapshot = { ...snapshot, staleReason: result.reason };
+            deps.onError?.(result.reason);
+            return;
+          }
+          const summary = summarizeGasSpend(result.txs, {
+            ...(deps.labels ? { labels: deps.labels } : {}),
+            settledCount: deps.settledCount(),
+          });
+          snapshot = {
+            ...summary,
+            at: nowMs,
+            ageMs: 0,
+            blocksScanned: result.blocksScanned,
+            truncated: result.truncated,
+            otherSenders: result.otherSenders,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          if (snapshot) snapshot = { ...snapshot, staleReason: message };
+          deps.onError?.(message);
+        } finally {
+          running = false;
+        }
+      })();
+    },
+  };
+}

--- a/services/slack-operator/src/gas-spend-read.ts
+++ b/services/slack-operator/src/gas-spend-read.ts
@@ -1,0 +1,159 @@
+// The I/O half of gas attribution: find the signer's transactions and price
+// them. `gas-spend.ts` stays pure; everything that talks to a chain is here.
+//
+// ── WHY IT IS NOT ON THE HEARTBEAT ─────────────────────────────────────────
+//
+// A day of traffic is ~87 transactions, and each needs BOTH a receipt (for
+// gasUsed and the effective price) and the transaction itself (for the calldata
+// selector). That is ~174 RPC calls. At the 5-minute heartbeat it would be the
+// single heaviest thing the monitor does, for a figure that moves slowly and is
+// read occasionally.
+//
+// So it runs on its own long cadence and caches. The staleness is disclosed
+// rather than hidden — an hour-old gas breakdown is useful; an hour-old gas
+// breakdown presented as current is the same lie as any other stale number.
+//
+// ── NO SILENT CAPS ─────────────────────────────────────────────────────────
+//
+// If there are more transactions than the cap allows, the extras are dropped
+// AND `truncated` is set. A partial total rendered as a complete one understates
+// spend, and understating spend on a board whose job is to warn about running
+// out is the wrong direction to be wrong in.
+//
+// ── FAILURE IS NEVER ZERO ──────────────────────────────────────────────────
+//
+// Any failure returns a reason and no transactions, never an empty list that
+// would summarise to "0 DOT spent" — which reads as free rather than unknown.
+
+import type { GasTx } from "./gas-spend.js";
+
+export interface GasReadResult {
+  /** Transactions sent BY the signer. Empty with a reason on failure. */
+  txs: GasTx[];
+  /**
+   * Other senders seen touching the same contracts, and how many times.
+   *
+   * Their gas does NOT come from the signer pool the board meters, so it is
+   * excluded from the totals — but a second key appearing is worth knowing,
+   * because it means "signer gas" is no longer the whole story of what it costs
+   * to run this.
+   */
+  otherSenders: Array<{ address: string; count: number }>;
+  /** True when the transaction cap bit and some spend is NOT counted. */
+  truncated: boolean;
+  blocksScanned: number;
+  /** Set when nothing could be read. Never accompanied by a zero total. */
+  reason?: string;
+}
+
+/** Enough for a busy day at the observed ~87/day, with headroom. */
+export const DEFAULT_MAX_TX = 400;
+
+function unreadable(reason: string): GasReadResult {
+  return { txs: [], otherSenders: [], truncated: false, blocksScanned: 0, reason };
+}
+
+/**
+ * Read and price the signer's transactions against our own contracts.
+ *
+ * Scoped to logs from OUR contracts rather than every transaction the signer
+ * ever sent: there is no `eth_getTransactionsBySender`, and scanning blocks for
+ * a sender would mean pulling every block in the window. Our contracts emitting
+ * a log is the cheap index into "transactions that did our work" — with the
+ * honest caveat that a signer transaction which emitted no log from these
+ * addresses is invisible here. Anything that spends meaningfully touches them.
+ */
+export async function readGasSpend(input: {
+  rpcUrl?: string;
+  /** Addresses whose logs identify our transactions. */
+  contracts: string[];
+  /** The gas-paying account the solvency panel meters. */
+  signerAddress?: string;
+  lookbackBlocks: number;
+  maxTx?: number;
+  fetchImpl: typeof fetch;
+  /** Injected so a slow RPC cannot be hammered; awaited between receipts. */
+  pause?: () => Promise<void>;
+}): Promise<GasReadResult> {
+  if (!input.rpcUrl) return unreadable("gas attribution not configured — no RPC URL");
+  if (!input.signerAddress) return unreadable("gas attribution not configured — no signer address");
+  const contracts = input.contracts.filter((c) => typeof c === "string" && c.length > 0);
+  if (contracts.length === 0) return unreadable("gas attribution not configured — no contract addresses");
+
+  const rpc = async (method: string, params: unknown[]): Promise<any> => {
+    const res = await input.fetchImpl(input.rpcUrl!, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    if (!res.ok) throw new Error(`${method} → HTTP ${res.status}`);
+    const body = (await res.json()) as { result?: unknown; error?: { message?: string } };
+    if (body.error) throw new Error(`${method} → ${body.error.message ?? "rpc error"}`);
+    return body.result;
+  };
+
+  const signer = input.signerAddress.toLowerCase();
+  const maxTx = input.maxTx ?? DEFAULT_MAX_TX;
+
+  try {
+    const head = Number(BigInt(await rpc("eth_blockNumber", [])));
+    const fromBlock = Math.max(0, head - input.lookbackBlocks);
+
+    // One sweep per contract: `address` as an array is rejected by this RPC —
+    // a lesson from the payout probe, where the array form returned
+    // "Invalid params" and looked like a broken endpoint.
+    const hashes = new Set<string>();
+    for (const address of contracts) {
+      const logs = await rpc("eth_getLogs", [
+        { fromBlock: `0x${fromBlock.toString(16)}`, toBlock: "latest", address },
+      ]);
+      if (!Array.isArray(logs)) continue;
+      for (const log of logs) {
+        const h = (log as { transactionHash?: unknown }).transactionHash;
+        if (typeof h === "string") hashes.add(h);
+      }
+    }
+
+    const all = [...hashes];
+    const truncated = all.length > maxTx;
+    const examined = truncated ? all.slice(0, maxTx) : all;
+
+    const txs: GasTx[] = [];
+    const others = new Map<string, number>();
+    for (const hash of examined) {
+      const [tx, receipt] = [await rpc("eth_getTransactionByHash", [hash]), await rpc("eth_getTransactionReceipt", [hash])];
+      if (input.pause) await input.pause();
+      if (!tx || !receipt) continue;
+      const from = String((tx as { from?: unknown }).from ?? "").toLowerCase();
+      if (from !== signer) {
+        others.set(from, (others.get(from) ?? 0) + 1);
+        continue;
+      }
+      const gasUsed = (receipt as { gasUsed?: unknown }).gasUsed;
+      const price =
+        (receipt as { effectiveGasPrice?: unknown }).effectiveGasPrice ?? (tx as { gasPrice?: unknown }).gasPrice;
+      if (typeof gasUsed !== "string" || typeof price !== "string") continue;
+      const input4 = String((tx as { input?: unknown }).input ?? "0x");
+      txs.push({
+        from,
+        to: typeof (tx as { to?: unknown }).to === "string" ? ((tx as { to: string }).to).toLowerCase() : null,
+        // "0x" for a plain value transfer — a real case, not a parse failure.
+        selector: input4.length >= 10 ? input4.slice(0, 10) : "0x",
+        gasWei: BigInt(gasUsed) * BigInt(price),
+        success: (receipt as { status?: unknown }).status === "0x1",
+      });
+    }
+
+    return {
+      txs,
+      otherSenders: [...others.entries()]
+        .map(([address, count]) => ({ address, count }))
+        .sort((a, b) => b.count - a.count),
+      truncated,
+      blocksScanned: head - fromBlock,
+    };
+  } catch (error) {
+    // Rate limit, capped range, dead endpoint — all unknown, never "0 DOT".
+    return unreadable(`gas attribution unreadable — ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -32,6 +32,9 @@ import type { AlertPayload } from "./alert-bridge.js";
 import { decideDiskHeadroom, readDiskUsage } from "./disk-headroom.js";
 import { probeExternalFunnel } from "./external-funnel.js";
 import { h160ToSs58 } from "./hub-address.js";
+import { ESCROW_V2_SELECTORS } from "./escrow-selectors.js";
+import { readGasSpend } from "./gas-spend-read.js";
+import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
@@ -548,6 +551,10 @@ export interface ProductHealthConfig {
   githubApiBaseUrl?: string;
   /** Blocks scanned for Transfer logs (~24h at the chain's block time). */
   payoutLookbackBlocks: number;
+  /** Gas attribution is off by default: a pass is ~174 RPC calls. */
+  gasAttributionEnabled: boolean;
+  /** How stale the gas snapshot may get before a background refresh. */
+  gasRefreshMs: number;
   /** Settled-minus-confirmed gap tolerated as a window-boundary artifact. */
   payoutTolerance: number;
   /** Filesystem the monitor writes to. Container `/` sees real host capacity. */
@@ -664,6 +671,10 @@ export function loadProductHealthConfig(env: NodeJS.ProcessEnv = process.env): P
     // mainnet only escaped by overriding to 43200 (still 25.3h, 5% long).
     payoutLookbackBlocks: num(env.PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS, 60000),
     payoutTolerance: num(env.PRODUCT_HEALTH_PAYOUT_TOLERANCE, 1),
+    // Off by default. A pass is ~174 RPC calls against an endpoint that
+    // rate-limits by answering 404, so the operator opts in knowingly.
+    gasAttributionEnabled: truthy(env.PRODUCT_HEALTH_GAS_ATTRIBUTION_ENABLED),
+    gasRefreshMs: num(env.PRODUCT_HEALTH_GAS_REFRESH_MS, 30 * 60 * 1000),
     diskPath: env.PRODUCT_HEALTH_DISK_PATH || "/",
     // Unlike the token floors (which default to 0 = can-never-go-red, because a
     // sensible balance is deployment-specific), disk exhaustion is universally
@@ -1553,6 +1564,88 @@ const POSITIONS_SELECTOR = "0x4bd21445";
  * Returns null on any failure, so the caller reports "cannot separate fees"
  * rather than splitting on a guess.
  */
+export async function readGasAttributionCache(input: {
+  config: ProductHealthConfig;
+  settledCount: number | null;
+  escrowCore?: string;
+  agentAccountCore?: string;
+  fetchImpl: typeof fetch;
+  nowMs: number;
+}): Promise<GasSpendSnapshot | null> {
+  return gasAttribution(input);
+}
+
+/**
+ * Gas attribution, held ACROSS heartbeats.
+ *
+ * A module-level singleton because the cache is the entire point: a pass is
+ * ~174 RPC calls, and rebuilding it per heartbeat would defeat the cadence it
+ * exists to provide. Created on the first call that has the contract addresses,
+ * since those come from the product's /health rather than from config.
+ *
+ * Returns the last snapshot immediately — never blocking — or null before the
+ * first success. Null renders as "not measured"; an empty breakdown would
+ * render as "0 DOT", which reads as free.
+ */
+let gasCache: GasSpendCache | null = null;
+/** Read through a closure so the per-job divisor is the CURRENT settled count,
+ *  not whatever it happened to be when the cache was first built. */
+let gasSettledCount: number | null = null;
+
+function gasAttribution(input: {
+  config: ProductHealthConfig;
+  settledCount: number | null;
+  escrowCore?: string;
+  agentAccountCore?: string;
+  fetchImpl: typeof fetch;
+  nowMs: number;
+}): GasSpendSnapshot | null {
+  const { config } = input;
+  if (!config.gasAttributionEnabled) return null;
+  const contracts = [input.escrowCore, input.agentAccountCore].filter(
+    (a): a is string => typeof a === "string" && a.length > 0,
+  );
+  if (contracts.length === 0 || !config.rpcUrl || !config.signerAddress) return null;
+
+  gasSettledCount = input.settledCount;
+  gasCache ??= createGasSpendCache({
+    read: () =>
+      readGasSpend({
+        rpcUrl: config.rpcUrl,
+        contracts,
+        signerAddress: config.signerAddress,
+        lookbackBlocks: config.payoutLookbackBlocks,
+        fetchImpl: input.fetchImpl,
+      }),
+    settledCount: () => gasSettledCount,
+    labels: ESCROW_V2_SELECTORS,
+    refreshMs: config.gasRefreshMs,
+    // No logger dependency here: this module is imported by tests that do not
+    // stand one up, and a probe module quietly acquiring a logging side effect
+    // is how a pure-ish boundary erodes. The reason is carried ON the snapshot
+    // as `staleReason`, which is where a reader will actually see it.
+    onError: () => {},
+  });
+
+  gasCache.maybeRefresh(input.nowMs);
+  return gasCache.read(input.nowMs);
+}
+
+/** Test seam: forget the singleton so each test starts from no snapshot. */
+export function __resetGasAttributionForTests(): void {
+  gasCache = null;
+  gasSettledCount = null;
+}
+
+/** Who receives the protocol fee, according to the contract that charges it.
+ *
+ * Read from EscrowCore rather than /health.addresses.treasuryReserve — those are
+ * the same account on mainnet today and the split would be silently wrong the
+ * moment they are not.
+ *
+ * Returns null on any failure, so the caller reports "cannot separate fees"
+ * rather than splitting on a guess.
+ */
 export async function readFeeRecipient(input: {
   rpcUrl?: string;
   escrowCore?: string;
@@ -2305,6 +2398,21 @@ export async function collectProductHealthProbes(
         }
       : {}),
     ...(solvencyPools.length ? { solvency: { pools: solvencyPools } } : {}),
+    // Gas attribution: what the burn went ON. Read on its OWN cadence — a pass
+    // is ~174 RPC calls, far too heavy for the heartbeat — so this returns the
+    // last snapshot immediately and refreshes in the background. Absent until
+    // the first read succeeds; absent is not zero.
+    ...(() => {
+      const gas = gasAttribution({
+        config,
+        settledCount: settlement?.settled24h ?? null,
+        escrowCore: h.body?.addresses?.escrowCore,
+        agentAccountCore: h.body?.addresses?.agentAccountCore,
+        fetchImpl,
+        nowMs: Date.now(),
+      });
+      return gas ? { gas } : {};
+    })(),
     ...(settlement
       ? {
           flow: {

--- a/test/unit/escrow-selectors.test.ts
+++ b/test/unit/escrow-selectors.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ESCROW_V2_ABI_SHA256,
+  ESCROW_V2_ADDRESS,
+  ESCROW_V2_SELECTORS,
+  OBSERVED_SELECTORS,
+} from "../../services/slack-operator/src/escrow-selectors.js";
+import { summarizeGasSpend, type GasTx } from "../../services/slack-operator/src/gas-spend.js";
+
+describe("the selector map", () => {
+  it("covers every selector seen in live traffic", () => {
+    // An unlisted selector renders as raw hex, which is honest but useless. If
+    // traffic contains one we have not named, that is the signal to go look.
+    for (const sel of OBSERVED_SELECTORS) {
+      expect(ESCROW_V2_SELECTORS[sel], `${sel} has no name`).toBeTruthy();
+    }
+  });
+
+  it("uses lowercase 0x-prefixed keys, as the RPC returns them", () => {
+    // calldata arrives lowercase; a checksummed or bare key silently never
+    // matches and every operation quietly renders as hex.
+    for (const key of Object.keys(ESCROW_V2_SELECTORS)) {
+      expect(key).toMatch(/^0x[0-9a-f]{8}$/);
+    }
+  });
+
+  it("pins the provenance the names depend on", () => {
+    // These names come from a frozen ABI, not from contracts/EscrowCore.sol in
+    // this repo — which describes a DIFFERENT contract. If the deployment or
+    // the ABI changes, the names must be re-verified, and this is what makes
+    // that check possible rather than a matter of memory.
+    expect(ESCROW_V2_ADDRESS).toBe("0x590EbE304E0C7672e2abF3161177D2B94a2aC3fC");
+    expect(ESCROW_V2_ABI_SHA256).toMatch(/^sha256:[0-9a-f]{64}$/);
+  });
+});
+
+describe("the map feeding the breakdown", () => {
+  const tx = (selector: string, dot: number): GasTx => ({
+    from: "0x5a6836c6d4d293f6e5377e6c28054f4171915813",
+    to: "0x590ebe304e0c7672e2abf3161177d2b94a2ac3fc",
+    selector,
+    gasWei: BigInt(Math.round(dot * 1e6)) * 10n ** 12n,
+    success: true,
+  });
+
+  it("names the live operations and leaves an unknown one as hex", () => {
+    // The real 24h shape: resolve is the most expensive, and the pipeline
+    // creates jobs with the fee waived.
+    const spend = summarizeGasSpend(
+      [tx("0xb08c763e", 0.0412), tx("0xbcb2689a", 0.0338), tx("0xfeedface", 0.001)],
+      { labels: ESCROW_V2_SELECTORS, settledCount: 1 },
+    );
+    expect(spend.buckets[0]!.label).toBe("resolveSinglePayout");
+    expect(spend.buckets[1]!.label).toBe("createSinglePayoutJobFeeWaived");
+    expect(spend.buckets[2]!.label).toBe("0xfeedface");
+  });
+
+  it("reproduces the observed per-job cost against a 0.10 USDC reward", () => {
+    // The number the whole exercise was for: gas as a unit cost, not a
+    // countdown. ~0.097 DOT of gas to deliver a job paying 0.10 USDC.
+    const oneJob = [
+      tx("0xcca2acd6", 0.0046), tx("0xbcb2689a", 0.0338), tx("0x090cf6d5", 0.0149),
+      tx("0x1b2ef921", 0.0050), tx("0xb08c763e", 0.0412),
+    ];
+    const spend = summarizeGasSpend(oneJob, { labels: ESCROW_V2_SELECTORS, settledCount: 1 });
+    expect(spend.perSettlement).toBeCloseTo(0.0995, 3);
+    expect(spend.buckets).toHaveLength(5);
+  });
+});

--- a/test/unit/gas-spend-cache.test.ts
+++ b/test/unit/gas-spend-cache.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createGasSpendCache } from "../../services/slack-operator/src/gas-spend-cache.js";
+import type { GasReadResult } from "../../services/slack-operator/src/gas-spend-read.js";
+import type { GasTx } from "../../services/slack-operator/src/gas-spend.js";
+
+const SIGNER = "0x5a6836c6d4d293f6e5377e6c28054f4171915813";
+const dot = (n: number): bigint => BigInt(Math.round(n * 1e6)) * 10n ** 12n;
+const tx = (sel: string, d: number): GasTx =>
+  ({ from: SIGNER, to: "0xesc", selector: sel, gasWei: dot(d), success: true });
+
+const ok = (txs: GasTx[], over: Partial<GasReadResult> = {}): GasReadResult =>
+  ({ txs, otherSenders: [], truncated: false, blocksScanned: 40000, ...over });
+
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); };
+
+describe("the heartbeat never waits", () => {
+  it("returns null before the first successful read, not an empty breakdown", async () => {
+    // An empty breakdown summarises to "0 DOT spent" and reads as FREE. Null
+    // reads as not-yet-known, which is what it is.
+    const cache = createGasSpendCache({ read: async () => ok([tx("0xa", 1)]), settledCount: () => 1 });
+    expect(cache.read(1000)).toBeNull();
+    cache.maybeRefresh(1000);
+    await settle();
+    expect(cache.read(1000)).not.toBeNull();
+  });
+
+  it("maybeRefresh returns immediately rather than blocking on the read", () => {
+    let resolved = false;
+    const cache = createGasSpendCache({
+      read: () => new Promise((r) => setTimeout(() => { resolved = true; r(ok([])); }, 50)),
+      settledCount: () => 1,
+    });
+    cache.maybeRefresh(0);
+    // The point: control is back here with the read still in flight.
+    expect(resolved).toBe(false);
+  });
+
+  it("does not stack passes while one is running", async () => {
+    // Each pass is ~174 RPC calls against an endpoint that rate-limits by
+    // answering 404. A slow read plus a fast heartbeat must not pile up.
+    let calls = 0;
+    const cache = createGasSpendCache({
+      read: async () => { calls += 1; await new Promise((r) => setTimeout(r, 20)); return ok([]); },
+      settledCount: () => 1,
+    });
+    for (let i = 0; i < 5; i += 1) cache.maybeRefresh(i);
+    await new Promise((r) => setTimeout(r, 40));
+    expect(calls).toBe(1);
+  });
+});
+
+describe("staleness is labelled, not laundered", () => {
+  it("ages the snapshot at read time", async () => {
+    const cache = createGasSpendCache({ read: async () => ok([tx("0xa", 1)]), settledCount: () => 1 });
+    cache.maybeRefresh(0);
+    await settle();
+    expect(cache.read(0)!.ageMs).toBe(0);
+    expect(cache.read(600_000)!.ageMs).toBe(600_000);
+  });
+
+  it("refreshes only once the interval has passed", async () => {
+    let calls = 0;
+    const cache = createGasSpendCache({
+      read: async () => { calls += 1; return ok([]); },
+      settledCount: () => 1,
+      refreshMs: 1000,
+    });
+    cache.maybeRefresh(0); await settle();
+    cache.maybeRefresh(500); await settle();
+    expect(calls).toBe(1);
+    cache.maybeRefresh(1500); await settle();
+    expect(calls).toBe(2);
+  });
+});
+
+describe("a failed refresh degrades to visibly-old, never to zero", () => {
+  it("keeps the previous figures and says why they stopped moving", async () => {
+    let fail = false;
+    const cache = createGasSpendCache({
+      read: async () => (fail ? { txs: [], otherSenders: [], truncated: false, blocksScanned: 0, reason: "rpc 404" } : ok([tx("0xa", 2)])),
+      settledCount: () => 1,
+      refreshMs: 100,
+    });
+    cache.maybeRefresh(0); await settle();
+    expect(cache.read(0)!.totalDot).toBeCloseTo(2, 6);
+
+    fail = true;
+    cache.maybeRefresh(1000); await settle();
+    const s = cache.read(1000)!;
+    // The figures are the PREVIOUS ones, and the age keeps climbing.
+    expect(s.totalDot).toBeCloseTo(2, 6);
+    expect(s.staleReason).toContain("rpc 404");
+    expect(s.ageMs).toBe(1000);
+  });
+
+  it("reports the error without throwing into the heartbeat", async () => {
+    const onError = vi.fn();
+    const cache = createGasSpendCache({
+      read: async () => { throw new Error("boom"); },
+      settledCount: () => 1,
+      onError,
+    });
+    expect(() => cache.maybeRefresh(0)).not.toThrow();
+    await settle();
+    expect(onError).toHaveBeenCalledWith("boom");
+  });
+});
+
+describe("what it carries through", () => {
+  it("passes labels and the settlement count into the summary", async () => {
+    const cache = createGasSpendCache({
+      read: async () => ok([tx("0xb08c763e", 0.04), tx("0xzz", 0.06)]),
+      settledCount: () => 2,
+      labels: { "0xb08c763e": "resolveSinglePayout" },
+    });
+    cache.maybeRefresh(0); await settle();
+    const s = cache.read(0)!;
+    expect(s.buckets.find((b) => b.selector === "0xb08c763e")!.label).toBe("resolveSinglePayout");
+    expect(s.perSettlement).toBeCloseTo(0.05, 6);
+  });
+
+  it("carries truncation and other senders onto the snapshot", async () => {
+    const cache = createGasSpendCache({
+      read: async () => ok([tx("0xa", 1)], { truncated: true, otherSenders: [{ address: "0xother", count: 4 }] }),
+      settledCount: () => 1,
+    });
+    cache.maybeRefresh(0); await settle();
+    const s = cache.read(0)!;
+    expect(s.truncated).toBe(true);
+    expect(s.otherSenders).toEqual([{ address: "0xother", count: 4 }]);
+  });
+});

--- a/test/unit/gas-spend-read.test.ts
+++ b/test/unit/gas-spend-read.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { readGasSpend } from "../../services/slack-operator/src/gas-spend-read.js";
+
+const SIGNER = "0x5a6836c6d4d293f6e5377e6c28054f4171915813";
+const OTHER = "0x089a0a57d001bacb8473161e007f0babc1768cee";
+const ESCROW = "0x590ebe304e0c7672e2abf3161177d2b94a2ac3fc";
+
+const cfg = {
+  rpcUrl: "http://rpc",
+  contracts: [ESCROW],
+  signerAddress: SIGNER,
+  lookbackBlocks: 40000,
+};
+
+/**
+ * A scripted RPC. `txs` maps hash → {from, selector, gasUsed, price, status};
+ * every hash appears once in the log sweep.
+ */
+function rpc(txs: Record<string, { from: string; sel?: string; gasUsed?: string; price?: string; status?: string }>, over: {
+  logsError?: string;
+  headError?: boolean;
+} = {}): typeof fetch {
+  return (async (_u: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const body = JSON.parse(String(init?.body ?? "{}")) as { method: string; params: any[] };
+    const reply = (result: unknown) =>
+      ({ ok: true, status: 200, json: async () => ({ result }) }) as unknown as Response;
+
+    if (body.method === "eth_blockNumber") {
+      if (over.headError) return { ok: false, status: 503, json: async () => ({}) } as unknown as Response;
+      return reply("0x186a0"); // 100000
+    }
+    if (body.method === "eth_getLogs") {
+      if (over.logsError) {
+        return { ok: true, status: 200, json: async () => ({ error: { message: over.logsError } }) } as unknown as Response;
+      }
+      return reply(Object.keys(txs).map((h) => ({ transactionHash: h })));
+    }
+    if (body.method === "eth_getTransactionByHash") {
+      const t = txs[body.params[0] as string];
+      return reply(t ? { from: t.from, to: ESCROW, input: (t.sel ?? "0xaabbccdd") + "00".repeat(32), gasPrice: t.price ?? "0x1" } : null);
+    }
+    if (body.method === "eth_getTransactionReceipt") {
+      const t = txs[body.params[0] as string];
+      return reply(t ? { gasUsed: t.gasUsed ?? "0x5208", effectiveGasPrice: t.price ?? "0x1", status: t.status ?? "0x1" } : null);
+    }
+    return reply(null);
+  }) as unknown as typeof fetch;
+}
+
+describe("readGasSpend", () => {
+  it("prices the signer's transactions and keeps the selector", async () => {
+    const r = await readGasSpend({
+      ...cfg,
+      fetchImpl: rpc({ "0x1": { from: SIGNER, sel: "0xb08c763e", gasUsed: "0x64", price: "0x2" } }),
+    });
+    expect(r.reason).toBeUndefined();
+    expect(r.txs).toHaveLength(1);
+    expect(r.txs[0]!.selector).toBe("0xb08c763e");
+    expect(r.txs[0]!.gasWei).toBe(200n); // 100 gas x price 2
+    expect(r.txs[0]!.success).toBe(true);
+  });
+
+  it("EXCLUDES other senders from the totals but reports them", async () => {
+    // Their gas does not come from the pool the solvency panel meters, so it
+    // must not be summed into it — but a second signing key appearing means
+    // "signer gas" is no longer the whole cost of running this.
+    const r = await readGasSpend({
+      ...cfg,
+      fetchImpl: rpc({
+        "0x1": { from: SIGNER },
+        "0x2": { from: OTHER },
+        "0x3": { from: OTHER },
+      }),
+    });
+    expect(r.txs).toHaveLength(1);
+    expect(r.otherSenders).toEqual([{ address: OTHER, count: 2 }]);
+  });
+
+  it("records a revert rather than dropping it", async () => {
+    // A reverted transaction still burned gas. Dropping it would understate
+    // spend and hide a bug that has a price.
+    const r = await readGasSpend({
+      ...cfg,
+      fetchImpl: rpc({ "0x1": { from: SIGNER, status: "0x0" } }),
+    });
+    expect(r.txs[0]!.success).toBe(false);
+  });
+
+  it("SAYS SO when the transaction cap bites", async () => {
+    // A partial total rendered as a complete one understates spend — the wrong
+    // direction to be wrong on a board that warns about running out.
+    const many: Record<string, { from: string }> = {};
+    for (let i = 0; i < 10; i += 1) many[`0x${i}`] = { from: SIGNER };
+    const r = await readGasSpend({ ...cfg, maxTx: 4, fetchImpl: rpc(many) });
+    expect(r.truncated).toBe(true);
+    expect(r.txs).toHaveLength(4);
+  });
+
+  it("does not claim truncation when everything fitted", async () => {
+    const r = await readGasSpend({ ...cfg, maxTx: 50, fetchImpl: rpc({ "0x1": { from: SIGNER } }) });
+    expect(r.truncated).toBe(false);
+  });
+});
+
+describe("failure is never zero", () => {
+  it("returns a reason, not an empty list that would read as 0 DOT spent", async () => {
+    // An empty result summarises to "0 DOT" — which reads as free rather than
+    // unknown. Every failure path has to carry a reason instead.
+    const r = await readGasSpend({ ...cfg, fetchImpl: rpc({}, { logsError: "range too large" }) });
+    expect(r.txs).toEqual([]);
+    expect(r.reason).toContain("range too large");
+  });
+
+  it("reports an unreachable RPC as unreadable", async () => {
+    const r = await readGasSpend({ ...cfg, fetchImpl: rpc({}, { headError: true }) });
+    expect(r.reason).toContain("unreadable");
+  });
+
+  for (const [label, missing] of [
+    ["no RPC url", { rpcUrl: undefined }],
+    ["no signer", { signerAddress: undefined }],
+    ["no contracts", { contracts: [] }],
+  ] as const) {
+    it(`says it is not configured when there is ${label}`, async () => {
+      const r = await readGasSpend({ ...cfg, ...missing, fetchImpl: rpc({}) });
+      expect(r.reason).toContain("not configured");
+      expect(r.txs).toEqual([]);
+    });
+  }
+});
+
+describe("pacing", () => {
+  it("awaits the injected pause between transactions", async () => {
+    // 87 transactions is ~174 RPC calls; this endpoint rate-limits and answers
+    // 404 rather than 429 when pushed, so the burst has to be pace-able.
+    let pauses = 0;
+    await readGasSpend({
+      ...cfg,
+      pause: async () => { pauses += 1; },
+      fetchImpl: rpc({ "0x1": { from: SIGNER }, "0x2": { from: SIGNER } }),
+    });
+    expect(pauses).toBe(2);
+  });
+});


### PR DESCRIPTION
The I/O half of #678. Sweeps our contracts' logs for transaction hashes, then prices each from its receipt and reads the selector from its calldata.

## Why logs, not the sender

There's no `eth_getTransactionsBySender`, and scanning a day of blocks for a `from` address means pulling every block in the window. Our contracts emitting a log is the cheap index into "transactions that did our work".

The honest caveat, stated in the module header: **a signer transaction that emits no log from these addresses is invisible here.** Anything that spends meaningfully touches them.

## Other senders: excluded from the total, reported anyway

Mainnet shows **83 txs from the signer and 4 from `0x089a0a57…`**. That key's gas doesn't come from the pool the solvency panel meters, so summing it in would misattribute spend to an account it never left.

But a second signer appearing means "signer gas" is no longer the whole cost of running this — so it's surfaced rather than dropped.

## Three rules carried from the payout probe

**No silent caps.** Over the cap, extras are dropped *and* `truncated` is set. A partial total rendered as complete understates spend — the wrong direction to be wrong on a board that warns about running out.

**Failure is never zero.** Every failure path returns a reason and no transactions. An empty list summarises to `0 DOT spent`, which reads as *free* rather than *unknown*.

**Reverts are recorded, not dropped.** A reverted transaction still burned gas; dropping it understates spend and hides a bug that has a price.

## One hard-won detail

`address` goes to `eth_getLogs` **one contract at a time**. The array form is rejected by this RPC with `Invalid params` and looks like a dead endpoint — that cost a round during the payout calibration.

## Not wired yet, deliberately

A day is ~87 transactions × 2 calls = **~174 RPC calls**, which would be the heaviest thing the monitor does, for a figure that moves slowly. It needs its own cadence and a cache — the next slice. `pause` is injectable so the burst can be paced against an endpoint that rate-limits by answering 404 rather than 429.

Labels still resolve to raw hex pending #680 (the deployed v2 ABI); the map is injectable, so that lands without touching this.

11 tests. 2400 pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)