### PR TITLE
feat(board): an ECONOMICS line — what a job costs against what it earns

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/economics-line.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/economics-line.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "vitest";
+
+import { economicsLine } from "./ops-spec.js";
+import type { GasSpendView, PayoutEvidence } from "./product-health.js";
+
+// The real 24h mainnet shape: 18 settlements, 1.80 USDC out, 1 fee credit of
+// 0.05, and 1.653 DOT of gas.
+const payout: PayoutEvidence = {
+  status: "confirmed", detail: "", confirmedCount: 18, confirmedUsdc: 1.8,
+  settledCount: 18, windowBlocks: 40000, feeCount: 1, feeUsdc: 0.05, feesSeparated: true,
+};
+const gas: GasSpendView = {
+  totalDot: 1.6535, txCount: 83, perSettlement: 0.0995, buckets: [],
+  failedDot: 0, failedCount: 0, ageMs: 0, truncated: false, otherSenders: [],
+};
+
+describe("economicsLine", () => {
+  test("puts the reward, the gas and the fee revenue in one place", () => {
+    // These live in three separate parts of the board today — a runway meter, a
+    // footnote and a solvency pool — so the relationship has never been visible.
+    const { text } = economicsLine({ payout, gas, llmMonthlyUsd: 20 });
+    expect(text).toContain("0.100 USDC paid out");
+    expect(text).toContain("0.0995 DOT gas");
+    expect(text).toContain("0.0028 USDC fee revenue");
+    expect(text).toContain("LLM $20.00/mo");
+  });
+
+  test("NEVER sums across currencies, and says why", () => {
+    // Adding DOT to USDC needs a price this monitor does not have. Inventing one
+    // would turn honest figures into a single confident wrong one — and it would
+    // hide, because the output would look tidier than the truth.
+    const { text } = economicsLine({ payout, gas });
+    expect(text).toContain("not summed");
+    expect(text).toContain("no price assumed");
+    expect(text).not.toMatch(/total|combined|net /i);
+  });
+
+  test("a cost is a fact, not an alarm", () => {
+    // The board already has a runway meter for "you are running out". Repeating
+    // that urgency here would make both easier to ignore.
+    expect(economicsLine({ payout, gas }).tone).toBe("awaiting");
+  });
+});
+
+describe("what it does when a number is missing", () => {
+  test("names what is unavailable instead of omitting it silently", () => {
+    const { text } = economicsLine({ payout, gas: undefined });
+    expect(text).toContain("0.100 USDC paid out");
+    expect(text).toContain("gas unavailable");
+  });
+
+  test("distinguishes an unmade fee split from zero revenue", () => {
+    // feesSeparated:false means we could not tell fees from payouts. Rendering
+    // that as 0.0000 USDC earned would be a claim we cannot support.
+    const { text } = economicsLine({ payout: { ...payout, feesSeparated: false, feeUsdc: null }, gas });
+    expect(text).toContain("fee split unavailable");
+    expect(text).not.toContain("0.0000 USDC fee revenue");
+  });
+
+  test("says it is not measurable rather than printing an empty row", () => {
+    const { text } = economicsLine({});
+    expect(text).toContain("not measurable");
+    expect(text).toContain("payouts");
+  });
+
+  test("does not divide by zero settlements", () => {
+    // "Infinite cost per job" is a number that means nothing.
+    const { text } = economicsLine({ payout: { ...payout, confirmedCount: 0 }, gas });
+    expect(text).not.toContain("Infinity");
+    expect(text).not.toContain("NaN");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -616,3 +616,76 @@ export function gasLine(gas: GasSpendView | undefined, nowMs: number): { text: s
   const tone: OpsTone = gas.failedCount > 0 || gas.truncated || gas.staleReason ? "degraded" : "awaiting";
   return { text: parts.join(" · "), tone };
 }
+
+// ── economics: what a job costs against what it earns ───────────────────────
+
+export interface EconomicsInput {
+  /** On-chain payout evidence for the window. */
+  payout?: PayoutEvidence | undefined;
+  /** Gas attribution for the same window. */
+  gas?: GasSpendView | undefined;
+  /** Month-to-date LLM cost in USD, when recorded. */
+  llmMonthlyUsd?: number | null | undefined;
+}
+
+/**
+ * The two numbers that are the business, in one place.
+ *
+ * The board meters gas as a runway and LLM spend as a footnote, and states
+ * revenue in a solvency pool — three places, never adjacent, so the relationship
+ * between them has never been on screen. Per settled job it is stark, and this
+ * is the internal board, which is exactly where an uncomfortable number belongs.
+ *
+ * ── WHAT IT REFUSES TO DO ─────────────────────────────────────────────────
+ *
+ * It does NOT add these together. Gas is DOT, revenue and payouts are USDC, LLM
+ * spend is USD. Summing them needs a DOT price this monitor does not have and
+ * must not invent — a made-up exchange rate would turn an honest set of figures
+ * into one confident wrong one, and it would be invisible because the output
+ * would look tidier than the truth.
+ *
+ * So the units stay side by side and the reader applies the price they believe.
+ * The whole point is the RATIO being visible, and it is visible without one.
+ */
+export function economicsLine(input: EconomicsInput): { text: string; tone: OpsTone } {
+  const { payout, gas } = input;
+  const settled = payout?.confirmedCount ?? null;
+
+  const parts: string[] = [];
+  const missing: string[] = [];
+
+  // Reward paid per job — what the work costs in the currency it is paid in.
+  if (settled != null && settled > 0 && payout?.confirmedUsdc != null) {
+    parts.push(`${(payout.confirmedUsdc / settled).toFixed(3)} USDC paid out`);
+  } else missing.push("payouts");
+
+  // Gas per job — the unit cost that can sit beside the reward.
+  if (gas?.perSettlement != null) parts.push(`${gas.perSettlement.toFixed(4)} DOT gas`);
+  else missing.push("gas");
+
+  // Fee revenue per job. Averaged over ALL settlements, not only fee-bearing
+  // ones: the question is what the platform earns per unit of work done, and
+  // most work is deliberately fee-waived. `feesSeparated` false means the split
+  // could not be made, which is not the same as zero revenue.
+  if (payout?.feesSeparated === true && payout.feeUsdc != null && settled != null && settled > 0) {
+    parts.push(`${(payout.feeUsdc / settled).toFixed(4)} USDC fee revenue`);
+  } else if (payout?.feesSeparated === false) missing.push("fee split");
+  else missing.push("fees");
+
+  if (parts.length === 0) {
+    return { text: `ECONOMICS — not measurable (${missing.join(", ")} unavailable)`, tone: "awaiting" };
+  }
+
+  const head = `ECONOMICS / settled job — ${parts.join(" · ")}`;
+  const tail: string[] = [];
+  if (typeof input.llmMonthlyUsd === "number") tail.push(`LLM $${input.llmMonthlyUsd.toFixed(2)}/mo`);
+  // Named so nobody reads the figures as addable. The absent DOT price is the
+  // reason, and stating it is cheaper than someone assuming one.
+  tail.push("DOT and USDC not summed — no price assumed");
+  if (missing.length > 0) tail.push(`${missing.join(", ")} unavailable`);
+
+  // A cost is a fact, not an alarm. Nothing here tones amber: the board already
+  // has a runway meter for "you are running out", and duplicating that urgency
+  // in a line about unit economics would make both easier to ignore.
+  return { text: `${head} · ${tail.join(" · ")}`, tone: "awaiting" };
+}


### PR DESCRIPTION
## Why

The board meters gas as a **runway**, states LLM spend as a **footnote**, and reports revenue inside a **solvency pool**. Three places, never adjacent — so the relationship between them has never been on screen.

Per settled job it's stark:

```
ECONOMICS / settled job — 0.100 USDC paid out · 0.0995 DOT gas ·
0.0028 USDC fee revenue · LLM $20.00/mo · DOT and USDC not summed
```

Roughly a tenth of a DOT of gas to deliver a tenth of a USDC of reward.

This is the internal board, which is where an uncomfortable number belongs — the revenue-surface rule keeps founder/platform economics off the operator app and public pages, not away from the person running the thing.

## It refuses to add them up

Gas is DOT. Payouts and revenue are USDC. LLM spend is USD. Summing needs **a DOT price this monitor does not have and must not invent.**

A made-up rate would turn an honest set of figures into one confident wrong one — and it would *hide*, because the tidier output would look more authoritative than the truth. The units stay side by side; the reader applies the price they believe. **The ratio is visible either way**, which was the whole point.

## Two judgement calls

**Fee revenue is averaged over all settlements**, not just fee-bearing ones. The question is what the platform earns per unit of work done, and most work is deliberately fee-waived — `createSinglePayoutJobFeeWaived`, confirmed at the call site in #681.

**An unmade split is not zero revenue.** `feesSeparated: false` renders `fee split unavailable`, never `0.0000 USDC earned` — the same `unverified` vs `shortfall` distinction the rest of the board makes.

## Tone stays neutral

A cost is a fact. The board already has a runway meter for "you are running out"; repeating that urgency here would make both easier to ignore.

7 tests, including one that pins the no-summing rule and one that stops a zero settlement count producing `Infinity per job`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)