### PR TITLE
feat(board): a PAYOUT RUNWAY line — the reward bank in payouts, not hours

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -689,3 +689,67 @@ export function economicsLine(input: EconomicsInput): { text: string; tone: OpsT
   // in a line about unit economics would make both easier to ignore.
   return { text: `${head} · ${tail.join(" · ")}`, tone: "awaiting" };
 }
+
+// ── how much longer can we pay? ─────────────────────────────────────────────
+
+/**
+ * The reward bank, denominated in PAYOUTS rather than in hours.
+ *
+ * The solvency panel shows 13.79 USDC against a 2.00 floor and leaves the
+ * division to the reader. The runway projection next to it is in hours — right
+ * for signer gas, which drains continuously, and wrong for the reward bank,
+ * which drains PER PAYOUT. If the pipeline pauses overnight, "3d to floor"
+ * silently becomes false while "≈ 11 more payouts" stays exactly true.
+ *
+ * So this counts payouts. The time note is carried alongside when the server
+ * produced one — it was being computed and rendered nowhere, which is the third
+ * value tonight found shipped into the payload and displayed by nobody.
+ *
+ * ── WHAT IT WILL NOT DO ───────────────────────────────────────────────────
+ *
+ * It will not project from an average it cannot support. The sample size is
+ * stated on the line, because "≈ 11 more payouts" derived from two observations
+ * is a guess wearing a number's clothes, and the reader deserves to see which
+ * they are looking at.
+ */
+export function payoutRunwayLine(input: {
+  /** The reward bank pool — the hard spend cap on payouts. */
+  pool: SolvencyPool | undefined;
+  /** On-chain payout evidence, for the observed average payout. */
+  payout: PayoutEvidence | undefined;
+  /** The server's time-based note, when it made one. */
+  runwayNote?: string | null | undefined;
+}): { text: string; tone: OpsTone } {
+  const { pool, payout } = input;
+  const note = input.runwayNote ? ` · ${input.runwayNote}` : "";
+
+  if (!pool) return { text: "PAYOUT RUNWAY — reward bank not reported", tone: "awaiting" };
+  // null is unreadable, NOT empty. Coercing it to 0 would render a funded bank
+  // as exhausted, which is the alarm that costs most to get wrong.
+  if (pool.amount == null) return { text: "PAYOUT RUNWAY — reward bank balance unreadable", tone: "awaiting" };
+
+  const floor = pool.floor ?? 0;
+  const usable = pool.amount - floor;
+  if (usable <= 0) {
+    return { text: `PAYOUT RUNWAY — reward bank BELOW FLOOR (${pool.amount.toFixed(2)} / ${floor.toFixed(2)} USDC)${note}`, tone: "red" };
+  }
+
+  const count = payout?.confirmedCount ?? 0;
+  const total = payout?.confirmedUsdc ?? null;
+  if (count <= 0 || total == null || total <= 0) {
+    // No observed average means no projection. Saying how much is spendable is
+    // still useful and is a fact rather than a forecast.
+    return { text: `PAYOUT RUNWAY — ${usable.toFixed(2)} USDC above floor · no payout average yet${note}`, tone: "awaiting" };
+  }
+
+  const average = total / count;
+  const payouts = Math.floor(usable / average);
+  // Sample size on the line: a projection from two payouts and one from fifty
+  // must not read identically.
+  const basis = `avg ${average.toFixed(3)} USDC from ${count} payout${count === 1 ? "" : "s"}`;
+  const tone: OpsTone = payouts <= 5 ? "degraded" : "awaiting";
+  return {
+    text: `PAYOUT RUNWAY ≈ ${payouts} more payout${payouts === 1 ? "" : "s"} · ${usable.toFixed(2)} USDC above floor · ${basis}${note}`,
+    tone,
+  };
+}

--- a/packages/monitor-ui/src/lib/monitor/payout-runway.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/payout-runway.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest";
+
+import { payoutRunwayLine } from "./ops-spec.js";
+import type { PayoutEvidence, SolvencyPool } from "./product-health.js";
+
+// Live mainnet: reward bank 13.79 USDC against a 2.00 floor, 18 payouts
+// totalling 1.80 USDC (so 0.100 each).
+const pool: SolvencyPool = {
+  key: "reward_bank", label: "Reward bank", amount: 13.79, unit: "USDC", floor: 2, status: "ok",
+};
+const payout: PayoutEvidence = {
+  status: "confirmed", detail: "", confirmedCount: 18, confirmedUsdc: 1.8,
+  settledCount: 18, windowBlocks: 40000,
+};
+
+describe("payoutRunwayLine", () => {
+  test("counts PAYOUTS, not hours", () => {
+    // 11.79 usable / 0.100 average = 117. Hours would go stale the moment the
+    // pipeline pauses; a payout count stays true.
+    const { text } = payoutRunwayLine({ pool, payout });
+    expect(text).toContain("≈ 117 more payouts");
+    expect(text).toContain("11.79 USDC above floor");
+  });
+
+  test("states the sample the average came from", () => {
+    // A projection from 2 payouts and one from 50 must not read identically.
+    expect(payoutRunwayLine({ pool, payout }).text).toContain("from 18 payouts");
+  });
+
+  test("carries the server's time note when there is one", () => {
+    // It was being computed and rendered nowhere.
+    const { text } = payoutRunwayLine({ pool, payout, runwayNote: "~3d to floor" });
+    expect(text).toContain("~3d to floor");
+  });
+});
+
+describe("what it refuses to project", () => {
+  test("an unreadable balance is not an empty one", () => {
+    // Coercing null to 0 would render a funded bank as exhausted — the alarm
+    // that costs most to get wrong.
+    const { text, tone } = payoutRunwayLine({ pool: { ...pool, amount: null }, payout });
+    expect(text).toContain("unreadable");
+    expect(tone).not.toBe("red");
+  });
+
+  test("no observed average means no projection, but still says what is spendable", () => {
+    const { text } = payoutRunwayLine({ pool, payout: { ...payout, confirmedCount: 0, confirmedUsdc: 0 } });
+    expect(text).toContain("no payout average yet");
+    expect(text).toContain("11.79 USDC above floor");
+    expect(text).not.toContain("Infinity");
+  });
+
+  test("says nothing rather than inventing a pool that was not reported", () => {
+    expect(payoutRunwayLine({ pool: undefined, payout }).text).toContain("not reported");
+  });
+});
+
+describe("the alarm", () => {
+  test("below floor is red and states both numbers", () => {
+    const { text, tone } = payoutRunwayLine({ pool: { ...pool, amount: 1.5 }, payout });
+    expect(tone).toBe("red");
+    expect(text).toContain("BELOW FLOOR");
+    expect(text).toContain("1.50 / 2.00 USDC");
+  });
+
+  test("a short runway tones amber before it breaches", () => {
+    // The point of a runway: act before the floor, not at it.
+    const { tone } = payoutRunwayLine({ pool: { ...pool, amount: 2.4 }, payout });
+    expect(tone).toBe("degraded");
+  });
+
+  test("a comfortable runway is not an alarm", () => {
+    expect(payoutRunwayLine({ pool, payout }).tone).toBe("awaiting");
+  });
+});


### PR DESCRIPTION
## Why payouts and not hours

The solvency panel shows `13.79 USDC` against a `2.00` floor and leaves the division to you. The runway projection beside it is in **hours** — right for signer gas, which drains continuously, and wrong for the reward bank, which drains **per payout**.

If the pipeline pauses overnight, `~3d to floor` silently becomes false while `≈ 117 more payouts` stays exactly true. Same pool, same balance; only one denomination survives the system going idle.

```
PAYOUT RUNWAY ≈ 117 more payouts · 11.79 USDC above floor ·
avg 0.100 USDC from 18 payouts · ~3d to floor
```

## The sample size is on the line

`≈ 117 more payouts` derived from **two** observations is a guess wearing a number's clothes. One from eighteen is a projection. Those must not read identically, so the basis is stated.

## It also renders runwayNote

The server has been computing that note and shipping it in the payload since the runway work, and **nobody displayed it**. That's the third value found in that state tonight, after the fee split (#672) and the inbound listener (#677).

Rather than add a second row, it rides on this line — the two answer the same question in different units.

## Refusals

| case | behaviour |
|---|---|
| `amount: null` | **unreadable**, not empty. Coercing to 0 renders a funded bank as exhausted — the alarm that costs most to get wrong |
| no observed average | no projection, but still states what's spendable — a fact rather than a forecast |
| pool absent | named as not reported, never invented |

Amber at five payouts left — *before* the floor rather than at it. Red only when the balance is genuinely under, with both numbers stated.

9 tests. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)