### PR TITLE
feat(board): surface the dispute clock and the window fit

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/dispute-clock.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/dispute-clock.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import { disputeClockLine } from "./ops-spec.js";
+import type { ExternalFunnelView } from "./product-health.js";
+
+const NOW = Date.parse("2026-08-02T18:00:00.000Z");
+const H = 3_600_000;
+const funnel = (over: Partial<ExternalFunnelView["buckets"]["rejected_window_running"]> | null): ExternalFunnelView => ({
+  buckets: over === null ? {} : { rejected_window_running: { count: 1, ...over } },
+  disputeWindowSeconds: 94_000,
+});
+
+describe("disputeClockLine", () => {
+  test("is ABSENT when nothing is counting down", () => {
+    // A line always present and almost always saying "0" is one nobody reads on
+    // the day it matters.
+    expect(disputeClockLine(funnel(null), NOW)).toBeNull();
+    expect(disputeClockLine(funnel({ count: 0 }), NOW)).toBeNull();
+    expect(disputeClockLine(undefined, NOW)).toBeNull();
+  });
+
+  test("appears while the clock is still COMFORTABLE", () => {
+    // The whole gap this closes: at 60h the probe is correctly ok and the
+    // countdown was invisible — which is exactly when acting is cheapest.
+    const v = disputeClockLine(funnel({ oldestDeadlineMs: NOW + 60 * H, leadJobId: "0xaa4b7b03cd" }), NOW)!;
+    expect(v.text).toContain("slashes in 3d");
+    expect(v.text).toContain("0xaa4b7b03");
+    expect(v.tone).toBe("awaiting");
+  });
+
+  test("mirrors the probe's thresholds instead of inventing new ones", () => {
+    // A countdown shown twice in two different colours is how an operator
+    // learns to trust neither.
+    expect(disputeClockLine(funnel({ oldestDeadlineMs: NOW + 40 * H }), NOW)!.tone).toBe("degraded");
+    expect(disputeClockLine(funnel({ oldestDeadlineMs: NOW + 6 * H }), NOW)!.tone).toBe("red");
+  });
+
+  test("a lapsed window says so plainly, not as a countdown", () => {
+    const v = disputeClockLine(funnel({ oldestDeadlineMs: NOW - H }), NOW)!;
+    expect(v.text).toContain("LAPSED");
+    expect(v.text).toContain("slashable now");
+    expect(v.tone).toBe("red");
+  });
+
+  test("an unreadable deadline is NOT 'no bond at risk'", () => {
+    // Jobs are in the window and we cannot see the clock. That is an instrument
+    // fault; rendering it as calm would be the fake green this board forbids.
+    const v = disputeClockLine(funnel({ count: 2, oldestDeadlineMs: undefined }), NOW)!;
+    expect(v.text).toContain("UNREADABLE");
+    expect(v.text).toContain("2 bonds");
+    expect(v.tone).toBe("degraded");
+  });
+
+  test("shows minutes when that is what is left", () => {
+    expect(disputeClockLine(funnel({ oldestDeadlineMs: NOW + 25 * 60_000 }), NOW)!.text).toContain("slashes in 25m");
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -127,6 +127,40 @@ describe("askHermesRow — can Hermes answer?", () => {
   });
 });
 
+describe("payoutView — whether to believe the comparison at all", () => {
+  const base = {
+    status: "confirmed" as const, detail: "ok",
+    confirmedCount: 18, confirmedUsdc: 3.1, settledCount: 18, windowBlocks: 40000,
+  };
+
+  test("stays silent when the window actually fits", () => {
+    // A permanent "~24h at 2.16s/block" is always-true text a reader stops
+    // seeing, and the caption is only useful when it carries doubt.
+    const view = payoutView({ ...base, window: { status: "ok", detail: "window spans ~24h", blockSeconds: 2.16, spanHours: 24 } });
+    expect(view.line2).not.toContain("window");
+  });
+
+  test("says SUSPECT when the window is not the window it claims to be", () => {
+    // A count from an 8h window held against a 24h ledger figure is two
+    // different questions rendered as one answer.
+    const view = payoutView({
+      ...base,
+      window: { status: "suspect", detail: "spans ~8.4h, not the 24h it is compared against", blockSeconds: 2.11, spanHours: 8.4 },
+    });
+    expect(view.line2).toContain("WINDOW SUSPECT");
+    expect(view.line2).toContain("8.4h");
+  });
+
+  test("says UNCHECKED rather than implying a pass", () => {
+    const view = payoutView({ ...base, window: { status: "unknown", detail: "block time not measured", blockSeconds: null, spanHours: null } });
+    expect(view.line2).toContain("UNCHECKED");
+  });
+
+  test("an older payload with no fit says nothing", () => {
+    expect(payoutView(base).line2).not.toContain("window");
+  });
+});
+
 describe("payoutView — the fee exclusion is explained on screen", () => {
   const base = {
     status: "confirmed" as const, detail: "ok",

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -17,6 +17,7 @@
 // deterministic to test — including the age phrasing.
 
 import type {
+  ExternalFunnelView,
   GasSpendView,
   MoneyPathSnapshot,
   PayoutEvidence,
@@ -501,6 +502,27 @@ export interface EvidenceView {
  * none occurred in the window. `feesSeparated: false` is NOT that case — it
  * means the count may still include fees, and saying so is the whole point.
  */
+/**
+ * Whether the window being compared is the window it claims to be.
+ *
+ * `decideWindowFit` has always computed this and the board has never shown it —
+ * so the one sentence that says whether to BELIEVE the comparison above lived
+ * only in JSON. A payout count from a window that does not span 24h, held
+ * against a 24h ledger figure, is two different questions rendered as one
+ * answer.
+ *
+ * Silent when the fit is `ok`: a window that matches needs no caption, and a
+ * permanent "~24h at 2.16s/block" is the kind of always-true text a reader
+ * stops seeing. Spoken when it is suspect or unchecked, which are the two cases
+ * where the numbers beside it deserve doubt.
+ */
+function windowNote(payout: PayoutEvidence): string {
+  const fit = payout.window;
+  if (!fit || fit.status === "ok") return "";
+  if (fit.status === "unknown") return " · window fit UNCHECKED — block time not measured";
+  return ` · WINDOW SUSPECT — ${fit.detail}`;
+}
+
 function feeNote(payout: PayoutEvidence): string {
   if (payout.feesSeparated === false) return " · fees not separated — count may include them";
   if (payout.feesSeparated !== true) return ""; // older payload, nothing claimed
@@ -531,7 +553,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
   const ledgerLine =
     payout.settledCount == null
       ? "settled count unavailable"
-      : `${payout.settledCount} marked settled by the monitor`;
+      : `${payout.settledCount} marked settled by the monitor${windowNote(payout)}`;
 
   if (payout.status === "shortfall") {
     const gap = payoutGap(payout);
@@ -750,6 +772,62 @@ export function payoutRunwayLine(input: {
   const tone: OpsTone = payouts <= 5 ? "degraded" : "awaiting";
   return {
     text: `PAYOUT RUNWAY ≈ ${payouts} more payout${payouts === 1 ? "" : "s"} · ${usable.toFixed(2)} USDC above floor · ${basis}${note}`,
+    tone,
+  };
+}
+
+// ── the one clock where doing nothing costs money ───────────────────────────
+
+/**
+ * The dispute countdown, surfaced whenever it is running.
+ *
+ * `external_funnel` is a probe like any other, so it sits eighth in a pillar
+ * footer — and it is the ONLY thing on this board where inaction has a price. A
+ * rejected submission opens a window; if it lapses unopened, the worker's bond
+ * is slashed. Nothing else here degrades by being ignored.
+ *
+ * The probe already escalates under 48h and takes halt severity under 12h, so
+ * urgency is handled. What was missing is VISIBILITY while the clock is still
+ * comfortable: at 60 hours the probe is correctly `ok` and the countdown is
+ * invisible, which is precisely when acting is cheapest.
+ *
+ * So this line appears whenever the bucket is non-zero and stays calm until the
+ * probe's own thresholds say otherwise. It does not invent a second severity
+ * ladder — a countdown shown twice in two different colours is how an operator
+ * learns to trust neither.
+ */
+export function disputeClockLine(
+  funnel: ExternalFunnelView | undefined,
+  nowMs: number,
+): { text: string; tone: OpsTone } | null {
+  const bucket = funnel?.buckets?.rejected_window_running;
+  // Nothing counting down. Return null rather than a row saying "0" — a line
+  // that is always present and almost always says nothing is a line nobody
+  // reads on the day it matters.
+  if (!bucket || bucket.count === 0) return null;
+
+  const job = bucket.leadJobId ? ` ${bucket.leadJobId.slice(0, 10)}…` : "";
+  const plural = bucket.count === 1 ? "" : "s";
+
+  if (bucket.oldestDeadlineMs == null) {
+    // Jobs are in the window but the deadline could not be read. That is an
+    // instrument fault and must NOT read as "no bond at risk".
+    return {
+      text: `DISPUTE CLOCK — ${bucket.count} bond${plural} in the window, deadline UNREADABLE${job}`,
+      tone: "degraded",
+    };
+  }
+
+  const msLeft = bucket.oldestDeadlineMs - nowMs;
+  if (msLeft <= 0) {
+    return { text: `DISPUTE CLOCK — window LAPSED${job} · bond slashable now`, tone: "red" };
+  }
+  const hours = msLeft / 3_600_000;
+  const left = hours < 1 ? `${Math.max(1, Math.round(hours * 60))}m` : hours < 48 ? `${Math.round(hours)}h` : `${Math.round(hours / 24)}d`;
+  // Tone mirrors the probe's own thresholds rather than inventing new ones.
+  const tone: OpsTone = hours <= 12 ? "red" : hours <= 48 ? "degraded" : "awaiting";
+  return {
+    text: `DISPUTE CLOCK — ${bucket.count} bond${plural} in the window · slashes in ${left}${job}`,
     tone,
   };
 }

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -46,6 +46,24 @@ export interface SolvencyPool {
   addressSs58?: string;
 }
 
+/** One funnel bucket: how many, and the soonest deadline among them. */
+export interface FunnelBucketView {
+  count: number;
+  /** Soonest deadline in the bucket (epoch ms), when it has one. */
+  oldestDeadlineMs?: number;
+  /** The job driving that deadline — named so the line is actionable. */
+  leadJobId?: string;
+}
+
+export interface ExternalFunnelView {
+  buckets: Partial<Record<
+    "open_claimable" | "claimed_active" | "submitted_awaiting_review" | "rejected_window_running" | "other",
+    FunnelBucketView
+  >>;
+  /** The dispute window in force, as read from chain. Null when unreadable. */
+  disputeWindowSeconds: number | null;
+}
+
 /** Gas spend by operation. Mirrors the server snapshot; see ops-spec gasLine(). */
 export interface GasSpendView {
   totalDot: number;
@@ -300,6 +318,13 @@ export interface ProductHealth {
    * carries its own age.
    */
   gas?: GasSpendView;
+  /**
+   * External-job funnel counts, structured — the numbers behind the probe's
+   * prose. `rejected_window_running` is the one that matters: while it is
+   * non-zero a worker's bond is counting down toward being lost to inaction,
+   * and that is the only clock on this board where doing nothing costs money.
+   */
+  externalFunnel?: ExternalFunnelView;
   /** The monitor's own build vs main — "is this board current?". */
   self?: SelfFreshness;
   /**

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -30,7 +30,7 @@ import type { AlertPayload } from "./alert-bridge.js";
 // ── Probe result model ──────────────────────────────────────────────
 
 import { decideDiskHeadroom, readDiskUsage } from "./disk-headroom.js";
-import { probeExternalFunnel } from "./external-funnel.js";
+import { probeExternalFunnel, type BucketSummary, type FunnelBucket } from "./external-funnel.js";
 import { h160ToSs58 } from "./hub-address.js";
 import { ESCROW_V2_SELECTORS } from "./escrow-selectors.js";
 import { readGasSpend } from "./gas-spend-read.js";
@@ -2143,6 +2143,19 @@ export interface ChainTickData {
 }
 
 export interface ProductHealthSnapshotBlocks {
+  /**
+   * External-job funnel counts, structured.
+   *
+   * The probe's prose detail is for humans; these are the numbers the board
+   * needs to surface the dispute countdown without parsing its own sentence
+   * back. `rejected_window_running` is the one that matters: a bond is being
+   * lost to inaction while it is non-zero.
+   */
+  externalFunnel?: {
+    buckets: Record<FunnelBucket, BucketSummary>;
+    /** The dispute window in force, as read from chain. Null when unreadable. */
+    disputeWindowSeconds: number | null;
+  };
   chainId?: number | null;
   /**
    * The MONITOR's own version. Deliberately NOT a probe: a stale monitor is not
@@ -2398,6 +2411,17 @@ export async function collectProductHealthProbes(
         }
       : {}),
     ...(solvencyPools.length ? { solvency: { pools: solvencyPools } } : {}),
+    // The external funnel's STRUCTURED counts, not just its prose detail.
+    //
+    // probeExternalFunnel already computes buckets with the soonest deadline and
+    // the job id driving it; only `probe` was being emitted, so the one clock on
+    // the board where inaction costs money reached the screen as a sentence to
+    // be parsed. Emitting the numbers lets the board show the countdown without
+    // reading its own prose back.
+    externalFunnel: {
+      buckets: externalFunnel.buckets,
+      disputeWindowSeconds: externalFunnel.disputeWindowSeconds,
+    },
     // Gas attribution: what the burn went ON. Read on its OWN cadence — a pass
     // is ~174 RPC calls, far too heavy for the heartbeat — so this returns the
     // last snapshot immediately and refreshes in the background. Absent until


### PR DESCRIPTION
Two facts the board computes and hides — the fifth and sixth found tonight, after the fee split (#672), the inbound listener (#677) and `runwayNote` (#683).

## Dispute clock

`probeExternalFunnel` already computes per-bucket counts with the soonest deadline and the job driving it. Only `probe` was emitted, so **the one clock on this board where inaction costs money arrived as a sentence to be parsed.**

```
DISPUTE CLOCK — 1 bond in the window · slashes in 3d 0xaa4b7b03…
```

The probe already escalates under 48h and takes halt severity under 12h, so urgency was handled. What was missing is **visibility while the clock is still comfortable**: at 60 hours the probe is correctly `ok` and the countdown was invisible — which is exactly when acting is cheapest.

Tone mirrors the probe's own thresholds rather than inventing a second severity ladder. A countdown shown twice in two different colours is how an operator learns to trust neither.

**Absent when nothing is counting down**, rather than a row saying `0`. A line that's always present and almost always says nothing is one nobody reads on the day it matters.

**An unreadable deadline reads `UNREADABLE`**, never "no bond at risk" — jobs are in the window and we can't see the clock. That's an instrument fault, not calm.

## Window fit

`decideWindowFit` has always computed whether the payout window is the window it claims to be, and the board has never shown it. So the one sentence saying whether to **believe the comparison above** lived only in JSON.

A count from an 8.4h window held against a 24h ledger figure is two different questions rendered as one answer — which is exactly the bug #675 fixed, and which nothing on screen would have revealed.

Silent when the fit is `ok`: a matching window needs no caption, and a permanent `~24h at 2.16s/block` is always-true text a reader stops seeing. Spoken on `suspect` and `unchecked` — the two cases where the numbers beside it deserve doubt.

10 tests. 2441 pass, typecheck clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)