### PR TITLE
fix(board): actually render the money lines, and stop gas failing silently

### DIFF
--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -18,6 +18,12 @@
 import type { MonitorBoard } from "../../lib/monitor/board-cache.js";
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, incidentRows } from "../../lib/monitor/ops-model.js";
+import {
+  disputeClockLine,
+  economicsLine,
+  gasLine,
+  payoutRunwayLine,
+} from "../../lib/monitor/ops-spec.js";
 import { opsVerdict, staleAfterMs, trustRows } from "../../lib/monitor/ops-spec.js";
 import { FlowPanel } from "./FlowPanel.js";
 import { PillarStrip } from "./PillarStrip.js";
@@ -118,6 +124,38 @@ export function OpsBoard({
         </div>
 
         <PillarStrip probes={health.probes} history={health.history} />
+
+        {/* The money lines. Each is its own row so a caveat cannot be pushed
+            off the end of a shared line — the failure the wallet strip hit. */}
+        <div className="ops-money-lines">
+          {(() => {
+            // Only rendered when a bond is actually counting down. Absence here
+            // is CORRECT, not a missing feature: a permanently-present row that
+            // almost always says "0" is one nobody reads on the day it matters.
+            const clock = disputeClockLine(health.externalFunnel, nowMs);
+            return clock ? <span data-tone={clock.tone}>{clock.text}</span> : null;
+          })()}
+          {(() => {
+            const runway = payoutRunwayLine({
+              pool: (health.solvency?.pools ?? []).find((p) => p.key === "reward_bank"),
+              payout: health.flow?.payout,
+              runwayNote: health.solvency?.runwayNote,
+            });
+            return <span data-tone={runway.tone}>{runway.text}</span>;
+          })()}
+          {(() => {
+            const g = gasLine(health.gas, nowMs);
+            return <span data-tone={g.tone}>{g.text}</span>;
+          })()}
+          {(() => {
+            const e = economicsLine({
+              payout: health.flow?.payout,
+              gas: health.gas,
+              llmMonthlyUsd: board?.llmUsage?.billing?.monthlyTotalUsd ?? null,
+            });
+            return <span data-tone={e.tone}>{e.text}</span>;
+          })()}
+        </div>
 
         <div className="ops-foot">
           <span>INCIDENTS — {incidentSummary(health, nowMs)}</span>

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { MONEY_LINE_RENDERERS } from "../../lib/monitor/ops-spec.js";
+
+const board = fs.readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), "OpsBoard.tsx"),
+  "utf8",
+);
+
+/**
+ * THE REGRESSION, and it happened four times in one session.
+ *
+ * gasLine, economicsLine, payoutRunwayLine and disputeClockLine were each
+ * written, unit-tested, reviewed and merged — and called by no component. The
+ * tests passed because they invoked the functions directly. The board showed
+ * nothing, twice, and the operator had to say "nothing new added on the board"
+ * before anyone noticed.
+ *
+ * A view model nobody renders is dead code that looks like a feature. This makes
+ * that a failing build.
+ */
+describe("every money line is actually rendered", () => {
+  for (const fn of MONEY_LINE_RENDERERS) {
+    it(`OpsBoard calls ${fn}`, () => {
+      expect(board, `${fn} is exported and tested but no component calls it`).toContain(`${fn}(`);
+    });
+  }
+
+  it("imports them from ops-spec rather than redefining them", () => {
+    // A local reimplementation would satisfy the check above while drifting from
+    // the tested one — the same two-verdict-systems problem the board forbids.
+    expect(board).toContain('from "../../lib/monitor/ops-spec.js"');
+  });
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -831,3 +831,24 @@ export function disputeClockLine(
     tone,
   };
 }
+
+/**
+ * Every money line the board must render, by name.
+ *
+ * THIS EXISTS BECAUSE I SHIPPED FOUR VIEW MODELS THAT NOTHING CALLED. gasLine,
+ * economicsLine, payoutRunwayLine and disputeClockLine were each written,
+ * tested, reviewed and merged — and rendered by no component. The unit tests
+ * passed because they called the functions directly, which is exactly what a
+ * component was not doing.
+ *
+ * A list is not a fix on its own. Paired with the test that asserts OpsBoard
+ * references every name in it, it makes "built but not wired" a failing build
+ * rather than something an operator discovers by looking at a screen and asking
+ * why nothing changed.
+ */
+export const MONEY_LINE_RENDERERS = [
+  "disputeClockLine",
+  "payoutRunwayLine",
+  "gasLine",
+  "economicsLine",
+] as const;

--- a/services/slack-operator/src/gas-spend-cache.ts
+++ b/services/slack-operator/src/gas-spend-cache.ts
@@ -42,9 +42,31 @@ export interface GasSpendSnapshot extends GasSpend {
   staleReason?: string;
 }
 
+/**
+ * A read that has never succeeded, with the reason it has not.
+ *
+ * Before this existed, a first read that failed produced no snapshot, no log
+ * and no payload field — the board simply said nothing, forever, and the only
+ * way to discover it was to ask why a number was missing. That is the failure
+ * mode this whole board exists to prevent, and I built it into the board.
+ */
+export interface GasUnreadable {
+  unreadable: true;
+  reason: string;
+  /** When the failing attempt happened. */
+  at: number;
+}
+
+export function isGasUnreadable(v: GasSpendSnapshot | GasUnreadable | null): v is GasUnreadable {
+  return v !== null && (v as GasUnreadable).unreadable === true;
+}
+
 export interface GasSpendCache {
-  /** The current snapshot with a fresh age, or null before the first success. */
-  read(nowMs: number): GasSpendSnapshot | null;
+  /**
+   * The current snapshot, or — when no read has ever succeeded — the reason
+   * why. Null only before the first attempt has finished.
+   */
+  read(nowMs: number): GasSpendSnapshot | GasUnreadable | null;
   /**
    * Refresh if the snapshot has aged out. Returns immediately; the work happens
    * in the background. Safe to call every heartbeat.
@@ -66,6 +88,9 @@ export function createGasSpendCache(deps: {
 }): GasSpendCache {
   const refreshMs = deps.refreshMs ?? DEFAULT_GAS_REFRESH_MS;
   let snapshot: GasSpendSnapshot | null = null;
+  // Kept separately: a failure BEFORE any success has no snapshot to attach to,
+  // and dropping it is what made the whole feature silent in production.
+  let firstError: { reason: string; at: number } | null = null;
   // One refresh at a time. Without this a slow read plus a fast heartbeat
   // stacks passes, and each is 174 RPC calls against an endpoint that
   // rate-limits by answering 404.
@@ -73,8 +98,12 @@ export function createGasSpendCache(deps: {
 
   return {
     read(nowMs) {
-      if (!snapshot) return null;
-      return { ...snapshot, ageMs: Math.max(0, nowMs - snapshot.at) };
+      if (snapshot) return { ...snapshot, ageMs: Math.max(0, nowMs - snapshot.at) };
+      // Never succeeded. Say why rather than nothing — "the board shows no gas
+      // line" and "gas could not be read" are different facts and only one of
+      // them is actionable.
+      if (firstError) return { unreadable: true, reason: firstError.reason, at: firstError.at };
+      return null;
     },
 
     maybeRefresh(nowMs) {
@@ -88,6 +117,7 @@ export function createGasSpendCache(deps: {
             // Keep the previous figures and say why they stopped moving. An
             // unreadable chain is not zero spend.
             if (snapshot) snapshot = { ...snapshot, staleReason: result.reason };
+            else firstError = { reason: result.reason, at: nowMs };
             deps.onError?.(result.reason);
             return;
           }
@@ -95,6 +125,7 @@ export function createGasSpendCache(deps: {
             ...(deps.labels ? { labels: deps.labels } : {}),
             settledCount: deps.settledCount(),
           });
+          firstError = null;
           snapshot = {
             ...summary,
             at: nowMs,
@@ -106,6 +137,7 @@ export function createGasSpendCache(deps: {
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);
           if (snapshot) snapshot = { ...snapshot, staleReason: message };
+          else firstError = { reason: message, at: nowMs };
           deps.onError?.(message);
         } finally {
           running = false;

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -34,7 +34,7 @@ import { probeExternalFunnel, type BucketSummary, type FunnelBucket } from "./ex
 import { h160ToSs58 } from "./hub-address.js";
 import { ESCROW_V2_SELECTORS } from "./escrow-selectors.js";
 import { readGasSpend } from "./gas-spend-read.js";
-import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot } from "./gas-spend-cache.js";
+import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
 import type { SelfFreshness } from "./self-freshness.js";
@@ -1571,7 +1571,7 @@ export async function readGasAttributionCache(input: {
   agentAccountCore?: string;
   fetchImpl: typeof fetch;
   nowMs: number;
-}): Promise<GasSpendSnapshot | null> {
+}): Promise<GasSpendSnapshot | GasUnreadable | null> {
   return gasAttribution(input);
 }
 
@@ -1599,7 +1599,7 @@ function gasAttribution(input: {
   agentAccountCore?: string;
   fetchImpl: typeof fetch;
   nowMs: number;
-}): GasSpendSnapshot | null {
+}): GasSpendSnapshot | GasUnreadable | null {
   const { config } = input;
   if (!config.gasAttributionEnabled) return null;
   const contracts = [input.escrowCore, input.agentAccountCore].filter(


### PR DESCRIPTION
Two defects, both mine, both the failure mode this board exists to prevent.

## I shipped four view models that nothing called

`gasLine`, `economicsLine`, `payoutRunwayLine` and `disputeClockLine` were each written, unit-tested, reviewed and merged — and **rendered by no component**. The tests passed because they invoke the functions directly, which is exactly what a component was not doing.

You deployed twice and said *"again nothing new added on the board"* before anyone noticed.

This is the same defect I identified three times tonight — the fee split (#672), the inbound listener (#677), `runwayNote` (#683) — and then committed **four times in a row while describing it**. Recognising a pattern is not the same as being immune to it.

### The guard

`MONEY_LINE_RENDERERS` names every line the board must render, and a test asserts `OpsBoard` references each one. **"Built but not wired" is now a failing build**, not something found by looking at a screen.

Verified by simulating the pre-fix state — all four fail when unwired. Worth noting: my *first* attempt at that verification only stripped two of the four and reported the other two as passing. I'd have shipped a guard I believed in for the wrong reason.

## Gas failed silently

A read that never succeeded produced **no snapshot, no log and no payload field** — nothing at all.

I removed the logger for a defensible reason (a probe module shouldn't acquire a logging side effect) and **didn't replace the visibility**, so the one path that needed to speak was mute. The cache now keeps the first error when there's no snapshot to attach it to, and the board renders `GAS — unreadable: <reason>`.

That's why gas is absent in production right now with the flag on: the read is failing and the failure had nowhere to go. With this, the reason arrives on the board — most likely the 174-call burst meeting the rate limiter, the part I flagged as untested.

## Layout

Each line is its own row rather than a shared one, so a caveat can't be pushed off the end — the failure the wallet strip hit at 1440px.

2455 pass, typecheck clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)