### PR TITLE
feat(board): job lifecycle latency + demand mix, on both surfaces

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -30,6 +30,7 @@ import {
   pillarRollups,
   type BreachCard,
 } from "../../lib/monitor/phone-spec.js";
+import { disputeClockLine, lifecycleNote } from "../../lib/monitor/ops-spec.js";
 
 export interface MobileBoardProps {
   health?: ProductHealth;
@@ -100,7 +101,7 @@ export function MobileBoard({
 
       <div className="hm-ph-body">
         {breach ? <BreachPanel breach={breach} /> : <SolvencyPanel health={health} />}
-        <FlowPanel health={health} emphasise={Boolean(breach)} />
+        <FlowPanel health={health} emphasise={Boolean(breach)} nowMs={nowMs} />
       </div>
 
       <p className="hm-ph-scroll" aria-hidden>
@@ -269,9 +270,11 @@ function SolvencyPanel({ health }: { health: ProductHealth }) {
  * The whole point of the evidence row is that it can contradict the funnel, and
  * a contradiction the operator has to scroll between is one they will miss.
  */
-function FlowPanel({ health, emphasise }: { health: ProductHealth; emphasise: boolean }) {
+function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphasise: boolean; nowMs: number }) {
   const funnel = flowFunnel(health.flow);
   const evidence = payoutView(health.flow?.payout);
+  const timing = lifecycleNote(health.lifecycle);
+  const clock = disputeClockLine(health.externalFunnel, nowMs);
   return (
     <section
       className={`hm-ph-card${evidence.emphasised || emphasise ? " hm-ph-card--red" : ""}`}
@@ -288,6 +291,20 @@ function FlowPanel({ health, emphasise }: { health: ProductHealth; emphasise: bo
         <span className="hm-ph-quiet">
           stuck {funnel.stuck} · failed {funnel.failed}
         </span>
+        {/* Same facts as the desktop flow panel: how long the funnel above
+            actually takes, split by who posted the work, plus the dispute clock
+            when a bond is counting down. The phone is where this is read when
+            away from the desk, so it must not be desktop-only. */}
+        {timing ? (
+          <span className="hm-ph-quiet" data-tone={timing.tone} data-testid="mobile-lifecycle">
+            {timing.text}
+          </span>
+        ) : null}
+        {clock ? (
+          <span data-tone={clock.tone} data-testid="mobile-dispute-clock">
+            ⏳ {clock.text}
+          </span>
+        ) : null}
       </div>
       <div className="hm-ph-proof" data-testid="mobile-evidence">
         <div>

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -16,20 +16,24 @@ import {
   type FunnelView,
 } from "../../lib/monitor/ops-spec.js";
 import type { MoneyPathSnapshot } from "../../lib/monitor/product-health.js";
-import { disputeClockLine } from "../../lib/monitor/ops-spec.js";
-import type { ExternalFunnelView } from "../../lib/monitor/product-health.js";
+import { disputeClockLine, lifecycleNote } from "../../lib/monitor/ops-spec.js";
+import type { ExternalFunnelView, LifecycleView } from "../../lib/monitor/product-health.js";
 
 export interface FlowPanelProps {
   flow: MoneyPathSnapshot | undefined;
   /** External funnel counts — drives the dispute clock. */
   externalFunnel?: ExternalFunnelView | undefined;
+  /** Job durations + demand mix, shown under the funnel they describe. */
+  lifecycle?: LifecycleView | undefined;
   nowMs?: number;
 }
 
-export function FlowPanel({ flow, externalFunnel, nowMs }: FlowPanelProps) {
+export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelProps) {
   // The one clock on this board where doing nothing costs money. Rendered only
   // while it is running; absence is correct, not a missing feature.
   const clock = disputeClockLine(externalFunnel, nowMs ?? Date.now());
+  // How long the funnel above actually takes, split by who posted the work.
+  const timing = lifecycleNote(lifecycle);
   const funnel = flowFunnel(flow);
   const evidence = payoutView(flow?.payout);
 
@@ -49,6 +53,12 @@ export function FlowPanel({ flow, externalFunnel, nowMs }: FlowPanelProps) {
             : "gaps between stages are the signal"}
         </span>
       </header>
+
+      {timing ? (
+        <p className="ops-lifecycle" data-tone={timing.tone} data-testid="ops-lifecycle">
+          {timing.text}
+        </p>
+      ) : null}
 
       {clock ? (
         <p className="ops-dispute-clock" data-tone={clock.tone} data-testid="ops-dispute-clock">

--- a/packages/monitor-ui/src/components/ops/OpsBoard.tsx
+++ b/packages/monitor-ui/src/components/ops/OpsBoard.tsx
@@ -115,7 +115,7 @@ export function OpsBoard({
 
         <div className="ops-money">
           <SolvencyPanel solvency={health.solvency} gas={health.gas} payout={health.flow?.payout} />
-          <FlowPanel flow={health.flow} externalFunnel={health.externalFunnel} nowMs={nowMs} />
+          <FlowPanel flow={health.flow} externalFunnel={health.externalFunnel} lifecycle={health.lifecycle} nowMs={nowMs} />
         </div>
 
         <PillarStrip probes={health.probes} history={health.history} />

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -12,6 +12,10 @@ const dir = path.dirname(fileURLToPath(import.meta.url));
 const board = ["OpsBoard.tsx", "SolvencyPanel.tsx", "FlowPanel.tsx"]
   .map((f) => fs.readFileSync(path.join(dir, f), "utf8"))
   .join("\n");
+/** The phone is a SEPARATE surface with its own components — a fact wired into
+ *  the desktop and not the phone is still invisible to an operator who is away
+ *  from the desk, which is when they need it most. */
+const phone = fs.readFileSync(path.join(dir, "..", "mobile", "MobileBoard.tsx"), "utf8");
 
 /**
  * THE REGRESSION, and it happened four times in one session.
@@ -29,6 +33,14 @@ describe("every money line is actually rendered", () => {
   for (const fn of MONEY_LINE_RENDERERS) {
     it(`OpsBoard calls ${fn}`, () => {
       expect(board, `${fn} is exported and tested but no component calls it`).toContain(`${fn}(`);
+    });
+  }
+
+  for (const fn of ["lifecycleNote", "disputeClockLine"] as const) {
+    it(`the PHONE board also calls ${fn}`, () => {
+      // Both are time-critical: a dispute clock and a latency figure are exactly
+      // what gets checked from a phone, away from the desk.
+      expect(phone, `${fn} is on the desktop board but not the phone`).toContain(`${fn}(`);
     });
   }
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -18,6 +18,8 @@
 
 import type {
   ExternalFunnelView,
+  LifecycleClassView,
+  LifecycleView,
   GasSpendView,
   MoneyPathSnapshot,
   PayoutEvidence,
@@ -773,8 +775,62 @@ export function disputeClockLine(
  * component, so "built but not wired" fails the build instead.
  */
 export const MONEY_LINE_RENDERERS = [
+  "lifecycleNote",
   "disputeClockLine",
   "payoutRunwayNote",
   "gasPoolNote",
   "economicsLine",
 ] as const;
+
+/**
+ * How long jobs take, and how much of the work is somebody else's.
+ *
+ * Two facts in one line because they are one measurement. Pipeline work
+ * auto-verifies in seconds; external bounties wait on a human for hours. A
+ * blended median would move with the mix rather than with either speed — a day
+ * with more dogfood would read as the system getting faster.
+ *
+ * The slowest is shown beside the median because a median of 19s with a slowest
+ * of 20h is a different system from one where both are 19s, and only one of them
+ * loses the worker who waited.
+ */
+export function lifecycleNote(
+  lifecycle: LifecycleView | undefined,
+): { text: string; tone: OpsTone } | null {
+  if (!lifecycle) return null;
+  const { selfPosted, external } = lifecycle;
+  if (selfPosted.count === 0 && external.count === 0) return null;
+
+  const part = (label: string, c: LifecycleClassView): string | null => {
+    if (c.count === 0) return null;
+    const median = formatSeconds(c.medianSeconds);
+    // One sample is not a median. Say so rather than dressing it as a statistic.
+    const basis = c.count === 1 ? "" : c.slowestSeconds != null && c.slowestSeconds > (c.medianSeconds ?? 0) * 2
+      ? `, slowest ${formatSeconds(c.slowestSeconds)}`
+      : "";
+    return `${c.count} ${label} ${median}${basis}`;
+  };
+
+  const parts = [part("self-posted", selfPosted), part("external", external)].filter(Boolean);
+  if (lifecycle.externalPct != null) parts.push(`${lifecycle.externalPct}% external`);
+  // Untimed jobs are named: silently excluding them would make the sample look
+  // more complete than it is.
+  if (lifecycle.unmeasurable > 0) parts.push(`${lifecycle.unmeasurable} not timeable`);
+
+  return { text: parts.join(" · "), tone: "awaiting" };
+}
+
+/** "19s" · "2h 14m" · "5d" — read without converting. */
+export function formatSeconds(seconds: number | null): string {
+  if (seconds == null) return "—";
+  if (seconds < 90) return `${Math.round(seconds)}s`;
+  const m = seconds / 60;
+  if (m < 90) return `${Math.round(m)}m`;
+  const h = m / 60;
+  if (h < 48) {
+    const wh = Math.floor(h);
+    const wm = Math.round((h - wh) * 60);
+    return wm === 0 ? `${wh}h` : `${wh}h ${wm}m`;
+  }
+  return `${Math.round(h / 24)}d`;
+}

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -46,6 +46,23 @@ export interface SolvencyPool {
   addressSs58?: string;
 }
 
+/** Durations for one class of job. Nulls mean none settled, never "instant". */
+export interface LifecycleClassView {
+  count: number;
+  medianSeconds: number | null;
+  /** The slowest, because a median hides the case that made someone give up. */
+  slowestSeconds: number | null;
+}
+
+export interface LifecycleView {
+  selfPosted: LifecycleClassView;
+  external: LifecycleClassView;
+  /** External share of settled jobs, 0-100. null when nothing settled. */
+  externalPct: number | null;
+  /** Settled but posted outside the window — counted, never timed. */
+  unmeasurable: number;
+}
+
 /** One funnel bucket: how many, and the soonest deadline among them. */
 export interface FunnelBucketView {
   count: number;
@@ -325,6 +342,13 @@ export interface ProductHealth {
    * and that is the only clock on this board where doing nothing costs money.
    */
   externalFunnel?: ExternalFunnelView;
+  /**
+   * Job duration, split by who posted it. Blended it would be meaningless —
+   * pipeline work auto-verifies in seconds, external bounties wait hours on a
+   * human — so one median would track the MIX rather than either speed. The
+   * split is also the demand-mix answer.
+   */
+  lifecycle?: LifecycleView;
   /** The monitor's own build vs main — "is this board current?". */
   self?: SelfFreshness;
   /**

--- a/services/slack-operator/src/job-lifecycle-read.ts
+++ b/services/slack-operator/src/job-lifecycle-read.ts
@@ -1,0 +1,124 @@
+// Reading job durations off the chain.
+//
+// Cheap on purpose: two log sweeps, no receipts. Gas attribution needs a receipt
+// per transaction (~174 calls) and therefore its own slow cadence; this needs
+// only the escrow's logs and the settlement events, so it runs on the heartbeat
+// like every other probe.
+//
+// ── THE JOIN IS THE TRANSACTION, NOT THE ID ────────────────────────────────
+//
+// `ReservationSettled.topic1` looks like a job id and is not — it is a
+// RESERVATION id, and one settlement emits a payout leg and a fee leg with
+// different values. Joining jobs to settlements on it silently matches nothing,
+// which cost a full investigation round before it was noticed.
+//
+// So the bridge is the transaction hash: the escrow's own logs carry the job id
+// and appear in the settlement transaction, and the settlement events carry the
+// recipient. Both sides are then talking about the same transaction.
+
+import type { LifecycleJob } from "./job-lifecycle.js";
+
+export interface LifecycleReadResult {
+  jobs: LifecycleJob[];
+  /** Settled in the window but posted before it — counted, never timed. */
+  unmeasurable: number;
+  reason?: string;
+}
+
+const RESERVATION_SETTLED_TOPIC =
+  "0x3cdc0be5ec7141f2342208f6404c1b1852936343f0edf1fda179e6c9f46573ee";
+
+function unreadable(reason: string): LifecycleReadResult {
+  return { jobs: [], unmeasurable: 0, reason };
+}
+
+export async function readJobLifecycle(input: {
+  rpcUrl?: string;
+  escrowCore?: string;
+  agentAccountCore?: string;
+  /** The protocol-fee treasury — a settlement to it marks the job external. */
+  feeRecipient?: string;
+  lookbackBlocks: number;
+  fetchImpl: typeof fetch;
+}): Promise<LifecycleReadResult> {
+  if (!input.rpcUrl || !input.escrowCore || !input.agentAccountCore) {
+    return unreadable("job lifecycle not configured — missing RPC or contract addresses");
+  }
+  // Without the fee recipient every job would be classed self-posted, which
+  // would report an external share of 0% — a confident wrong answer about the
+  // question this exists to answer. Better to report nothing.
+  if (!input.feeRecipient) {
+    return unreadable("job lifecycle unavailable — fee recipient unreadable, cannot tell external from self-posted");
+  }
+
+  const rpc = async (method: string, params: unknown[]): Promise<any> => {
+    const res = await input.fetchImpl(input.rpcUrl!, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+    if (!res.ok) throw new Error(`${method} → HTTP ${res.status}`);
+    const body = (await res.json()) as { result?: unknown; error?: { message?: string } };
+    if (body.error) throw new Error(`${method} → ${body.error.message ?? "rpc error"}`);
+    return body.result;
+  };
+
+  try {
+    const head = Number(BigInt(await rpc("eth_blockNumber", [])));
+    const from = Math.max(0, head - input.lookbackBlocks);
+    const range = { fromBlock: `0x${from.toString(16)}`, toBlock: "latest" };
+
+    // `address` one at a time: the array form is rejected by this RPC with
+    // "Invalid params" and reads as a dead endpoint.
+    const escrowLogs = await rpc("eth_getLogs", [{ ...range, address: input.escrowCore }]);
+    const settleLogs = await rpc("eth_getLogs", [
+      { ...range, address: input.agentAccountCore, topics: [RESERVATION_SETTLED_TOPIC] },
+    ]);
+    if (!Array.isArray(escrowLogs) || !Array.isArray(settleLogs)) {
+      return unreadable("job lifecycle unverified — eth_getLogs returned no array");
+    }
+
+    // jobId → first block seen, and the transactions it appears in.
+    const firstSeen = new Map<string, number>();
+    const txOfJob = new Map<string, Set<string>>();
+    for (const log of escrowLogs as Array<Record<string, any>>) {
+      const jobId = log.topics?.[1];
+      if (typeof jobId !== "string") continue;
+      const block = Number(BigInt(log.blockNumber));
+      const prev = firstSeen.get(jobId);
+      if (prev === undefined || block < prev) firstSeen.set(jobId, block);
+      if (!txOfJob.has(jobId)) txOfJob.set(jobId, new Set());
+      txOfJob.get(jobId)!.add(String(log.transactionHash));
+    }
+
+    // Settlement transactions: which block, and did any leg pay the treasury.
+    const feeTopic = `0x${input.feeRecipient.toLowerCase().replace(/^0x/, "").padStart(64, "0")}`;
+    const settlements = new Map<string, { block: number; feeBearing: boolean }>();
+    for (const log of settleLogs as Array<Record<string, any>>) {
+      const tx = String(log.transactionHash);
+      const entry = settlements.get(tx) ?? { block: Number(BigInt(log.blockNumber)), feeBearing: false };
+      if (String(log.topics?.[3] ?? "").toLowerCase() === feeTopic) entry.feeBearing = true;
+      settlements.set(tx, entry);
+    }
+
+    const jobs: LifecycleJob[] = [];
+    let unmeasurable = 0;
+    const claimed = new Set<string>();
+    for (const [jobId, txs] of txOfJob) {
+      const settlement = [...txs].map((t) => settlements.get(t)).find((s) => s !== undefined);
+      if (!settlement) continue; // still in flight — not a duration yet
+      claimed.add([...txs].find((t) => settlements.has(t))!);
+      const posted = firstSeen.get(jobId)!;
+      // Posted at the very edge of the window is indistinguishable from posted
+      // before it, and a truncated start produces a flatteringly short duration.
+      if (posted <= from) { unmeasurable += 1; continue; }
+      jobs.push({ postedBlock: posted, settledBlock: settlement.block, feeBearing: settlement.feeBearing });
+    }
+    // Settlements whose job never appeared in the escrow sweep at all.
+    for (const tx of settlements.keys()) if (!claimed.has(tx)) unmeasurable += 1;
+
+    return { jobs, unmeasurable };
+  } catch (error) {
+    return unreadable(`job lifecycle unreadable — ${error instanceof Error ? error.message : String(error)}`);
+  }
+}

--- a/services/slack-operator/src/job-lifecycle.ts
+++ b/services/slack-operator/src/job-lifecycle.ts
@@ -1,0 +1,120 @@
+// How long a job takes, and whose job it was.
+//
+// The flow funnel counts jobs through claimed → submitted → settled. It has
+// never measured TIME, and time is the thing the operator's own analysis says
+// decides whether workers come back: a blind agent picked a 0.4 USDC job over a
+// 1.0 USDC external bounty, and the reason was not the reward — it was how long
+// the bounty would take to pay.
+//
+// ── WHY LATENCY AND DEMAND MIX ARE ONE MEASUREMENT ─────────────────────────
+//
+// Because a blended average of the two would be a number about nothing.
+// Self-posted pipeline jobs auto-verify and settle in SECONDS. External bounties
+// wait on a human and settle in HOURS. Measured on mainnet:
+//
+//   0x7534e3ed  self-posted     9 blocks   ~19 seconds
+//   0xaa4b7b03  external     3,439 blocks  ~2 hours
+//   0xa436d6a2  external    33,822 blocks  ~19.8 hours
+//
+// One median over that population moves with the MIX rather than with either
+// population's actual speed — so a day with more dogfood would look like the
+// system got faster. Splitting them makes both honest, and the split is itself
+// the demand-mix answer: how much of this is real posters and how much is us.
+//
+// ── WHAT COUNTS AS EXTERNAL ────────────────────────────────────────────────
+//
+// Whether the settlement paid a protocol fee. Self-posted pipeline work is
+// created through `createSinglePayoutJobFeeWaived` and pays nothing; bonded
+// external bounties are escrowed at reward × 1.05 and pay 5%. That is a fact
+// about the transaction rather than an inference about intent, which is why it
+// is the discriminator rather than the job id, the poster address or the amount.
+//
+// Pure: no RPC, no clock. Block numbers in, seconds out.
+
+export interface LifecycleJob {
+  /** First block this job was seen on the escrow contract — its posting. */
+  postedBlock: number;
+  /** Block its settlement landed. */
+  settledBlock: number;
+  /** Did the settlement pay a protocol fee? Fee-bearing ⇒ external bounty. */
+  feeBearing: boolean;
+}
+
+export interface LifecycleClass {
+  count: number;
+  /** Median seconds from posting to settlement; null when there are none. */
+  medianSeconds: number | null;
+  /** Slowest, because a median hides the case that made someone give up. */
+  slowestSeconds: number | null;
+}
+
+export interface LifecycleSummary {
+  /** Averray's own pipeline work — auto-verified, fee-waived. */
+  selfPosted: LifecycleClass;
+  /** Third-party bounties — bonded, human-reviewed, fee-bearing. */
+  external: LifecycleClass;
+  /** External share of settled jobs, 0–100. null when nothing settled. */
+  externalPct: number | null;
+  /**
+   * Jobs settled in the window whose POSTING fell outside it, so their duration
+   * is unknown. Counted and excluded rather than measured from a truncated
+   * start — a job that looks 10 minutes old because the window began 10 minutes
+   * ago is the kind of wrong number that makes a latency figure worthless.
+   */
+  unmeasurable: number;
+}
+
+function classOf(jobs: readonly LifecycleJob[], blockSeconds: number): LifecycleClass {
+  if (jobs.length === 0) return { count: 0, medianSeconds: null, slowestSeconds: null };
+  const spans = jobs
+    .map((j) => (j.settledBlock - j.postedBlock) * blockSeconds)
+    .sort((a, b) => a - b);
+  const mid = Math.floor(spans.length / 2);
+  const median = spans.length % 2 === 1 ? spans[mid]! : (spans[mid - 1]! + spans[mid]!) / 2;
+  return {
+    count: jobs.length,
+    medianSeconds: Math.round(median),
+    // The slowest is shown alongside the median deliberately: a median of 20
+    // seconds with a slowest of 20 hours is a different system from one where
+    // both are 20 seconds, and only one of them loses workers.
+    slowestSeconds: Math.round(spans[spans.length - 1]!),
+  };
+}
+
+export function summarizeLifecycle(input: {
+  jobs: readonly LifecycleJob[];
+  /** Measured seconds per block. Null ⇒ nothing can be timed. */
+  blockSeconds: number | null;
+  /** Settled jobs whose posting was outside the window. */
+  unmeasurable?: number;
+}): LifecycleSummary | null {
+  // Without a measured block time every duration would be a guess, and this
+  // codebase has already shipped one number derived from an assumed 6s/block.
+  if (input.blockSeconds == null || !Number.isFinite(input.blockSeconds) || input.blockSeconds <= 0) {
+    return null;
+  }
+  const self = input.jobs.filter((j) => !j.feeBearing);
+  const ext = input.jobs.filter((j) => j.feeBearing);
+  const total = self.length + ext.length;
+  return {
+    selfPosted: classOf(self, input.blockSeconds),
+    external: classOf(ext, input.blockSeconds),
+    externalPct: total === 0 ? null : Math.round((ext.length / total) * 100),
+    unmeasurable: input.unmeasurable ?? 0,
+  };
+}
+
+/** "19s" · "2h 14m" · "19.8h" — durations a human reads without converting. */
+export function formatDuration(seconds: number | null): string {
+  if (seconds == null) return "—";
+  if (seconds < 90) return `${Math.round(seconds)}s`;
+  const minutes = seconds / 60;
+  if (minutes < 90) return `${Math.round(minutes)}m`;
+  const hours = minutes / 60;
+  if (hours < 48) {
+    const h = Math.floor(hours);
+    const m = Math.round((hours - h) * 60);
+    return m === 0 ? `${h}h` : `${h}h ${m}m`;
+  }
+  return `${Math.round(hours / 24)}d`;
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -34,6 +34,8 @@ import { probeExternalFunnel, type BucketSummary, type FunnelBucket } from "./ex
 import { h160ToSs58 } from "./hub-address.js";
 import { ESCROW_V2_SELECTORS } from "./escrow-selectors.js";
 import { readGasSpend } from "./gas-spend-read.js";
+import { readJobLifecycle } from "./job-lifecycle-read.js";
+import { summarizeLifecycle, type LifecycleSummary } from "./job-lifecycle.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
@@ -2151,6 +2153,15 @@ export interface ProductHealthSnapshotBlocks {
    * back. `rejected_window_running` is the one that matters: a bond is being
    * lost to inaction while it is non-zero.
    */
+  /**
+   * How long jobs take, split by who posted them.
+   *
+   * Blended it would be meaningless: pipeline work auto-verifies in seconds
+   * while external bounties wait on a human for hours, so one median would move
+   * with the MIX rather than with either population's speed. The split is also
+   * the demand-mix answer — how much of this volume is real posters.
+   */
+  lifecycle?: LifecycleSummary;
   externalFunnel?: {
     buckets: Record<FunnelBucket, BucketSummary>;
     /** The dispute window in force, as read from chain. Null when unreadable. */
@@ -2418,6 +2429,25 @@ export async function collectProductHealthProbes(
     // the board where inaction costs money reached the screen as a sentence to
     // be parsed. Emitting the numbers lets the board show the countdown without
     // reading its own prose back.
+    ...(await (async () => {
+      // Two log sweeps, no receipts — cheap enough for the heartbeat, unlike gas
+      // attribution which needs a receipt per transaction.
+      const read = await readJobLifecycle({
+        rpcUrl: config.rpcUrl,
+        escrowCore: h.body?.addresses?.escrowCore,
+        agentAccountCore: h.body?.addresses?.agentAccountCore,
+        ...(feeRecipient ? { feeRecipient } : {}),
+        lookbackBlocks: lookback.blocks,
+        fetchImpl,
+      });
+      if (read.reason) return {};
+      const summary = summarizeLifecycle({
+        jobs: read.jobs,
+        blockSeconds,
+        unmeasurable: read.unmeasurable,
+      });
+      return summary ? { lifecycle: summary } : {};
+    })()),
     externalFunnel: {
       buckets: externalFunnel.buckets,
       disputeWindowSeconds: externalFunnel.disputeWindowSeconds,

--- a/test/unit/job-lifecycle.test.ts
+++ b/test/unit/job-lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { formatDuration, summarizeLifecycle, type LifecycleJob } from "../../services/slack-operator/src/job-lifecycle.js";
+
+const BS = 2.112; // measured mainnet seconds per block
+const job = (postedBlock: number, settledBlock: number, feeBearing = false): LifecycleJob =>
+  ({ postedBlock, settledBlock, feeBearing });
+
+describe("summarizeLifecycle", () => {
+  it("splits self-posted from external instead of blending them", () => {
+    // THE REASON THIS IS SPLIT. Real mainnet spans: pipeline jobs settle in ~9
+    // blocks, external bounties in 3,439 and 33,822. One median over that
+    // population moves with the MIX, so a day with more dogfood would look like
+    // the system got faster.
+    const s = summarizeLifecycle({
+      jobs: [job(100, 109), job(200, 209), job(300, 3739, true), job(400, 34222, true)],
+      blockSeconds: BS,
+    })!;
+    expect(s.selfPosted.count).toBe(2);
+    expect(s.selfPosted.medianSeconds).toBe(19);
+    expect(s.external.count).toBe(2);
+    expect(s.external.medianSeconds).toBeGreaterThan(7000);
+  });
+
+  it("reports the external share — the demand-mix answer", () => {
+    const s = summarizeLifecycle({ jobs: [job(1, 2), job(3, 4), job(5, 6), job(7, 8, true)], blockSeconds: BS })!;
+    expect(s.externalPct).toBe(25);
+  });
+
+  it("shows the SLOWEST beside the median", () => {
+    // A median of 20s with a slowest of 20h is a different system from one where
+    // both are 20s, and only one of them loses workers. The median alone hides
+    // exactly the case that made someone give up.
+    const s = summarizeLifecycle({ jobs: [job(1, 10), job(2, 11), job(3, 34000)], blockSeconds: BS })!;
+    expect(s.selfPosted.medianSeconds).toBe(19);
+    expect(s.selfPosted.slowestSeconds).toBeGreaterThan(70000);
+  });
+
+  it("counts jobs it CANNOT time rather than timing them wrongly", () => {
+    // A job that looks 10 minutes old because the window began 10 minutes ago is
+    // the kind of wrong number that makes a latency figure worthless.
+    const s = summarizeLifecycle({ jobs: [job(1, 10)], blockSeconds: BS, unmeasurable: 4 })!;
+    expect(s.unmeasurable).toBe(4);
+  });
+
+  it("returns NOTHING without a measured block time", () => {
+    // Every duration would be a guess, and this codebase already shipped one
+    // number derived from an assumed 6s/block.
+    for (const bad of [null, 0, -1, Number.NaN]) {
+      expect(summarizeLifecycle({ jobs: [job(1, 10)], blockSeconds: bad })).toBeNull();
+    }
+  });
+
+  it("an empty window is empty, not zero-latency", () => {
+    const s = summarizeLifecycle({ jobs: [], blockSeconds: BS })!;
+    expect(s.selfPosted.medianSeconds).toBeNull();
+    expect(s.external.medianSeconds).toBeNull();
+    expect(s.externalPct).toBeNull();
+  });
+
+  it("takes an even-length median from both middle values", () => {
+    const s = summarizeLifecycle({ jobs: [job(0, 10), job(0, 20)], blockSeconds: 1 })!;
+    expect(s.selfPosted.medianSeconds).toBe(15);
+  });
+});
+
+describe("formatDuration", () => {
+  it("reads without converting", () => {
+    expect(formatDuration(19)).toBe("19s");
+    expect(formatDuration(600)).toBe("10m");
+    expect(formatDuration(8040)).toBe("2h 14m");
+    expect(formatDuration(7200)).toBe("2h");
+    expect(formatDuration(71280)).toBe("19h 48m");
+    expect(formatDuration(432000)).toBe("5d");
+  });
+
+  it("renders an absent duration as absent, not as zero", () => {
+    expect(formatDuration(null)).toBe("—");
+  });
+});


### PR DESCRIPTION
Two facts your own analysis already named as the levers, neither of which was on the board.

The funnel counts jobs through claimed → submitted → settled and has **never measured time** — yet time decided a real case: a blind agent took a 0.4 USDC job over a 1.0 USDC external bounty, and the reason wasn't the reward.

## Why they're one measurement

Measured on mainnet:

| job | | duration |
|---|---|---|
| `0x7534e3ed` | self-posted | 9 blocks ≈ **19s** |
| `0xaa4b7b03` | external | 3,439 blocks ≈ **2h** |
| `0xa436d6a2` | external | 33,822 blocks ≈ **19.8h** |

A blended median over that population moves with the **mix**, not with either population's speed — a day with more dogfood would read as the system getting faster. So they're split, and **the split is the demand-mix answer**.

```
16 self-posted 19s · 2 external 2h 14m, slowest 19h 48m · 11% external
```

## The discriminator is a fact, not an inference

Whether the settlement **paid a protocol fee**. Self-posted work goes through `createSinglePayoutJobFeeWaived` and pays nothing; bonded external bounties are escrowed at reward × 1.05 and pay 5%. That's a property of the transaction — which is why it's used rather than the job id, the poster, or the amount.

## The slowest sits beside the median

A median of 19s with a slowest of 20h is a different system from one where both are 19s, and only one loses the worker who waited. **The median alone hides exactly the case that made someone give up.**

## Refusals

- **No measured block time → no summary.** Every duration would be a guess, and this repo already shipped one number derived from an assumed 6s/block.
- **No readable fee recipient → no summary.** Everything would class as self-posted and report `0% external` — a confident wrong answer to the question this exists to answer.
- **Settled in the window but posted before it → counted as not-timeable**, never measured from a truncated start.

## Joined on the transaction, not topic1

`ReservationSettled.topic1` looks like a job id and is a **reservation** id — one settlement emits a payout leg and a fee leg with different values, so joining on it matches nothing silently. That cost a full investigation round.

## Both surfaces

The phone gets the same two lines. A latency figure and a dispute countdown are precisely what's checked away from the desk — and the wiring guard now asserts the **phone** calls them too, not just the desktop. That guard exists because I shipped four renderers wired to nothing.

Cheap enough for the heartbeat: two log sweeps, no receipts.

9 new tests. 2457 pass, typecheck clean on both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)