### PR TITLE
board: scale with the viewport, and never hide the window fit

### DIFF
--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -238,10 +238,24 @@ function SolvencyPanel({ health }: { health: ProductHealth }) {
               line: 100 monospace glyphs do not fit 390px, and this board scrolls
               — height is cheap here in a way it is not on the fixed desktop, so
               the addresses can be legible instead of clever. */}
+          {/* Which encoding is which — and this matters MORE here than on the
+              desktop. The phone is where the address gets long-pressed and
+              pasted into a wallet, and the two forms are not interchangeable:
+              the hex is for an EVM wallet, the SS58 for a Substrate one. Two
+              unlabelled 40-character strings is the setup for pasting the
+              wrong one while standing somewhere with a phone in one hand. */}
           {view.pool.address ? (
             <div className="hm-ph-pool-addr" data-testid={`mobile-pool-addr-${view.pool.key}`}>
-              <span>{view.pool.address}</span>
-              {view.pool.addressSs58 ? <span>{view.pool.addressSs58}</span> : null}
+              <span>
+                <b>EVM</b> {view.pool.address}
+              </span>
+              {view.pool.addressSs58 ? (
+                <span>
+                  <b>SS58</b> {view.pool.addressSs58}
+                </span>
+              ) : (
+                <em>SS58 unavailable</em>
+              )}
               {view.pool.addressLabel ? <em>{view.pool.addressLabel}</em> : null}
             </div>
           ) : null}
@@ -313,6 +327,12 @@ function FlowPanel({ health, emphasise, nowMs }: { health: ProductHealth; emphas
           <span className="hm-ph-quiet">{evidence.line1}</span>
         </div>
         <p>{evidence.delta}</p>
+        {/* Whether to believe the line above. The phone is where a SHORTFALL is
+            read at 2am, away from any way to check it — which makes this the
+            surface that needs it most, not least. */}
+        <p className="hm-ph-fit" data-tone={evidence.fit.tone} data-testid="mobile-evidence-fit">
+          {evidence.fit.text}
+        </p>
       </div>
     </section>
   );

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -81,6 +81,13 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
           <div className="ops-evidence-lines">
             <div>{evidence.line1}</div>
             <div>{evidence.line2}</div>
+            {/* Whether the two counts above cover the same period. Always
+                present — this board once showed SHORTFALL −2 with no window
+                information at all, which is an accusation without the one
+                fact that decides whether to believe it. */}
+            <div className="ops-evidence-fit" data-tone={evidence.fit.tone} data-testid="ops-evidence-fit">
+              {evidence.fit.text}
+            </div>
           </div>
           <div className="ops-evidence-delta" data-tone={evidence.tone}>
             {evidence.delta}

--- a/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/SolvencyPanel.tsx
@@ -40,6 +40,19 @@ function gasNoteFor(
   return gasPoolNote(gas);
 }
 
+/**
+ * What each pool's sub-fact is ABOUT, named before it is read.
+ *
+ * Deliberately keyed by pool rather than derived from the note text: a key that
+ * guessed from the words would silently mislabel a note that changed wording,
+ * and the two notes here answer questions the reader picked the pool to ask.
+ * A pool with no entry gets no key and renders exactly as it did before.
+ */
+const POOL_NOTE_KEY: Readonly<Record<string, string>> = {
+  signer_gas: "BURN",
+  reward_bank: "RUNWAY",
+};
+
 export function SolvencyPanel({ solvency, gas, payout }: SolvencyPanelProps) {
   const pools = solvency?.pools ?? [];
   const { floored, unfloored } = splitPools(pools);
@@ -67,12 +80,21 @@ export function SolvencyPanel({ solvency, gas, payout }: SolvencyPanelProps) {
             : view.pool.key === "reward_bank"
               ? payoutRunwayNote({ pool: view.pool, payout, runwayNote: solvency?.runwayNote })
               : null;
+        // The key names the question before the eye starts reading the answer.
+        // Two pools' sub-facts answer two different questions and used to look
+        // like one continuous grey paragraph running down the panel.
+        const noteKey = POOL_NOTE_KEY[view.pool.key];
         return (
           <div key={view.pool.key}>
             <FlooredPool view={view} />
             {note ? (
-              <p className="ops-pool-note" data-tone={note.tone} data-testid={`ops-pool-note-${view.pool.key}`}>
-                {note.text}
+              <p
+                className={`ops-pool-note${noteKey ? " ops-pool-note--keyed" : ""}`}
+                data-tone={note.tone}
+                data-testid={`ops-pool-note-${view.pool.key}`}
+              >
+                {noteKey ? <span className="ops-pool-note-key">{noteKey}</span> : null}
+                <span className="ops-pool-note-val">{note.text}</span>
               </p>
             ) : null}
           </div>
@@ -113,10 +135,23 @@ function PoolAddress({ view }: { view: PoolView }) {
   if (!address) return null;
   return (
     <span className="ops-pool-addr" data-testid={`ops-pool-addr-${view.pool.key}`}>
+      {/* Which encoding is which. Two 40-odd-character strings separated by a
+          dot told the reader nothing about which wallet each one belongs in,
+          and they are not interchangeable — the hex is what an EVM wallet and
+          a block explorer take, the SS58 is what a Substrate wallet takes.
+          Sending to the wrong form is the class of mistake this board exists
+          to prevent, so the encoding is named rather than inferred. */}
+      <span className="ops-pool-addr-key">EVM</span>
       <span className="ops-pool-addr-hex">{address}</span>
       <span className="ops-pool-addr-sep">·</span>
+      {/* The key rides with the value it names. The absent case already says
+          "SS58 unavailable" in words, and a key in front of it read as the
+          stutter it was: "SS58 SS58 unavailable". */}
       {addressSs58 ? (
-        <span className="ops-pool-addr-hex ops-pool-addr-hex--ss58">{addressSs58}</span>
+        <>
+          <span className="ops-pool-addr-key">SS58</span>
+          <span className="ops-pool-addr-hex ops-pool-addr-hex--ss58">{addressSs58}</span>
+        </>
       ) : (
         <span className="ops-pool-addr-none">SS58 unavailable</span>
       )}

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -50,3 +50,33 @@ describe("every money line is actually rendered", () => {
     expect(board).toContain('from "../../lib/monitor/ops-spec.js"');
   });
 });
+
+/**
+ * Facts that qualify a money figure must reach BOTH surfaces.
+ *
+ * The window fit says whether to believe the payout comparison. It is needed
+ * most on the phone — that is where a SHORTFALL gets read at 2am, away from
+ * any means of checking it — so a desktop-only fit is the wrong way round.
+ */
+describe("the qualifiers travel with the numbers they qualify", () => {
+  for (const [surface, source] of [
+    ["desktop", board],
+    ["phone", phone],
+  ] as const) {
+    it(`${surface} renders the payout window fit`, () => {
+      expect(source, `evidence.fit is computed but ${surface} never renders it`).toContain("evidence.fit");
+    });
+  }
+
+  for (const [surface, source] of [
+    ["desktop", board],
+    ["phone", phone],
+  ] as const) {
+    it(`${surface} names which address encoding is which`, () => {
+      // Two unlabelled 40-character strings, one EVM and one SS58, are not
+      // interchangeable — and the phone is where they get pasted into a wallet.
+      expect(source).toContain("SS58");
+      expect(source, `${surface} shows an address with no EVM/SS58 key`).toContain("EVM");
+    });
+  }
+});

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -133,11 +133,32 @@ describe("payoutView — whether to believe the comparison at all", () => {
     confirmedCount: 18, confirmedUsdc: 3.1, settledCount: 18, windowBlocks: 40000,
   };
 
-  test("stays silent when the window actually fits", () => {
-    // A permanent "~24h at 2.16s/block" is always-true text a reader stops
-    // seeing, and the caption is only useful when it carries doubt.
+  test("states the fit even when it is fine, with the numbers behind it", () => {
+    // This used to render nothing on a good fit — and on 2026-08-02 the live
+    // board showed SHORTFALL −2 with no window information at all, because
+    // the fit was ok and therefore silent. A caveat that hides while things
+    // look fine is missing every time it would have mattered.
     const view = payoutView({ ...base, window: { status: "ok", detail: "window spans ~24h", blockSeconds: 2.16, spanHours: 24 } });
-    expect(view.line2).not.toContain("window");
+    expect(view.fit.text).toContain("window fit ok");
+    expect(view.fit.text).toContain("40,000 blocks");
+    expect(view.fit.text).toContain("2.16s/block");
+    // Grey, not green: it is reassurance about the METHOD. Only the money
+    // line above is entitled to a status colour.
+    expect(view.fit.tone).toBe("awaiting");
+  });
+
+  test("a good fit never softens a shortfall above it", () => {
+    const view = payoutView({
+      ...base,
+      status: "shortfall",
+      confirmedCount: 19,
+      settledCount: 21,
+      window: { status: "ok", detail: "window spans ~24h", blockSeconds: 2.22, spanHours: 24 },
+    });
+    expect(view.status).toBe("SHORTFALL −2");
+    expect(view.tone).toBe("red");
+    expect(view.emphasised).toBe(true);
+    expect(view.fit.text).toContain("window fit ok");
   });
 
   test("says SUSPECT when the window is not the window it claims to be", () => {
@@ -147,17 +168,27 @@ describe("payoutView — whether to believe the comparison at all", () => {
       ...base,
       window: { status: "suspect", detail: "spans ~8.4h, not the 24h it is compared against", blockSeconds: 2.11, spanHours: 8.4 },
     });
-    expect(view.line2).toContain("WINDOW SUSPECT");
-    expect(view.line2).toContain("8.4h");
+    expect(view.fit.text).toContain("WINDOW SUSPECT");
+    expect(view.fit.text).toContain("8.4h");
+    expect(view.fit.tone).toBe("degraded");
   });
 
   test("says UNCHECKED rather than implying a pass", () => {
     const view = payoutView({ ...base, window: { status: "unknown", detail: "block time not measured", blockSeconds: null, spanHours: null } });
-    expect(view.line2).toContain("UNCHECKED");
+    expect(view.fit.text).toContain("UNCHECKED");
+    expect(view.fit.tone).toBe("degraded");
   });
 
-  test("an older payload with no fit says nothing", () => {
-    expect(payoutView(base).line2).not.toContain("window");
+  test("an older payload with no fit says so, rather than claiming a good one", () => {
+    // Absent is not ok. A build that never reported a fit must not render as
+    // one that reported a passing fit.
+    const view = payoutView(base);
+    expect(view.fit.text).toContain("not reported by this build");
+    expect(view.fit.text).not.toContain("ok —");
+  });
+
+  test("nothing read from the chain is not a passing window", () => {
+    expect(payoutView(undefined).fit.text).toContain("no comparison window");
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -479,6 +479,8 @@ export interface EvidenceView {
   line2: string;
   /** The comparison — the reason this row exists. */
   delta: string;
+  /** Whether the two counts were measured over the same period. Never absent. */
+  fit: { text: string; tone: OpsTone };
   /** Only a real shortfall gets the alarming frame. */
   emphasised: boolean;
 }
@@ -505,24 +507,45 @@ export interface EvidenceView {
  * means the count may still include fees, and saying so is the whole point.
  */
 /**
- * Whether the window being compared is the window it claims to be.
+ * Whether the two counts above were measured over the same period.
  *
- * `decideWindowFit` has always computed this and the board has never shown it —
- * so the one sentence that says whether to BELIEVE the comparison above lived
- * only in JSON. A payout count from a window that does not span 24h, held
- * against a 24h ledger figure, is two different questions rendered as one
- * answer.
+ * ── WHY THIS IS NOW ALWAYS ON SCREEN ──────────────────────────────────────
  *
- * Silent when the fit is `ok`: a window that matches needs no caption, and a
- * permanent "~24h at 2.16s/block" is the kind of always-true text a reader
- * stops seeing. Spoken when it is suspect or unchecked, which are the two cases
- * where the numbers beside it deserve doubt.
+ * This used to render nothing when the fit was `ok`, on the reasoning that a
+ * matching window needs no caption and a permanent "~24h at 2.16s/block" is
+ * the kind of always-true text a reader stops seeing.
+ *
+ * That reasoning fails in precisely the case that matters. On 2026-08-02 the
+ * live board read SHORTFALL −2 — "2 settled jobs have no on-chain proof, money
+ * did not move" — while saying nothing whatsoever about the window, because
+ * the fit was `ok` and therefore silent. The operator got the accusation and
+ * was denied the fact that decides whether to believe it: whether the chain
+ * count and the ledger count cover the same 24 hours, or whether a job simply
+ * sat on the edge of one of them.
+ *
+ * A caveat that hides while things look fine is a caveat that is missing every
+ * time it would have carried weight. It costs one quiet line.
+ *
+ * Tone follows meaning, not alarm. A good fit is stated in grey: it is
+ * reassurance about the METHOD, not about the money, and only the line above
+ * is entitled to be red.
  */
-function windowNote(payout: PayoutEvidence): string {
+export function windowFitLine(payout: PayoutEvidence): { text: string; tone: OpsTone } {
   const fit = payout.window;
-  if (!fit || fit.status === "ok") return "";
-  if (fit.status === "unknown") return " · window fit UNCHECKED — block time not measured";
-  return ` · WINDOW SUSPECT — ${fit.detail}`;
+  if (!fit) return { text: "window fit not reported by this build", tone: "awaiting" };
+  if (fit.status === "unknown") {
+    return { text: "window fit UNCHECKED — block time not measured", tone: "degraded" };
+  }
+  if (fit.status !== "ok") return { text: `WINDOW SUSPECT — ${fit.detail}`, tone: "degraded" };
+  // State what was actually compared, so "same window" is a claim with numbers
+  // behind it rather than a reassuring adjective.
+  const blocks = payout.windowBlocks == null ? "" : `${payout.windowBlocks.toLocaleString()} blocks · `;
+  const span = fit.spanHours == null ? "window" : `~${fit.spanHours}h`;
+  const rate = fit.blockSeconds == null ? "" : ` at ${fit.blockSeconds}s/block`;
+  return {
+    text: `window fit ok — chain read over ${blocks}${span}${rate}, against a 24h ledger count`,
+    tone: "awaiting",
+  };
 }
 
 function feeNote(payout: PayoutEvidence): string {
@@ -542,6 +565,9 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       line1: "no on-chain read configured",
       line2: "the funnel above is the product's own ledger, uncorroborated",
       delta: "nothing independent is checking that payouts landed",
+      // Nothing was compared, so there is no fit to report — and saying so is
+      // not the same as reporting a good one.
+      fit: { text: "no comparison window — nothing was read from the chain", tone: "awaiting" },
       emphasised: false,
     };
   }
@@ -555,7 +581,8 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
   const ledgerLine =
     payout.settledCount == null
       ? "settled count unavailable"
-      : `${payout.settledCount} marked settled by the monitor${windowNote(payout)}`;
+      : `${payout.settledCount} marked settled by the monitor`;
+  const fit = windowFitLine(payout);
 
   if (payout.status === "shortfall") {
     const gap = payoutGap(payout);
@@ -565,6 +592,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       line1: chainLine,
       line2: ledgerLine,
       delta: `${gap.replace("−", "")} settled jobs have no on-chain proof — money did not move`,
+      fit,
       emphasised: true,
     };
   }
@@ -578,6 +606,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
       // Say which thing is broken, in words, so it cannot be misread as a
       // money problem at a glance.
       delta: payout.detail || "chain unreadable — instrument broken, not money",
+      fit,
       emphasised: false,
     };
   }
@@ -588,6 +617,7 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
     line1: chainLine,
     line2: ledgerLine,
     delta: "proof matches ledger — no gap",
+    fit,
     emphasised: false,
   };
 }

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -227,6 +227,17 @@
   /* Long-press selects the whole address, which is how it gets into a wallet. */
   user-select: all;
 }
+/* The encoding key. Deliberately OUTSIDE the long-press selection: the whole
+   point of `user-select: all` above is that the grab yields a pasteable
+   address, and a key inside it would yield "EVM 0x…" instead. */
+.hm-ph-pool-addr b {
+  display: inline-block;
+  min-width: 30px;
+  user-select: none;
+  font-weight: 400;
+  letter-spacing: 0.1em;
+  color: var(--h4-tel);
+}
 .hm-ph-pool-addr em {
   font-style: normal;
   opacity: 0.72;
@@ -392,6 +403,13 @@
   font-size: 11px;
   line-height: 1.55;
   color: var(--h4-ink-2);
+}
+/* Quieter than the verdict it qualifies. It is about the METHOD, not the
+   money, and must never compete with a red sitting above it. */
+.hm-ph-proof p.hm-ph-fit {
+  margin-top: 4px;
+  font-size: 9.5px;
+  color: var(--tone, var(--h4-tel));
 }
 .hm-ph-sq {
   width: 8px;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -39,13 +39,35 @@ body,
 .ops-board {
   --ops-hair: rgba(237, 230, 221, 0.10);
   --ops-rule: rgba(237, 230, 221, 0.16);
+  /* ---- the scaled pixel ------------------------------------------
+     The board had exactly two media queries and both were `max-width`
+     guards, so it rendered at identical size on a 1440 laptop and a
+     3840 wall. On the 4K it was mostly void: a 795px FLOW panel
+     showing a 64px row.
+
+     `--ops-u` is one scaled pixel. Below 1920 it is exactly 1px, so
+     every size written as `calc(N * var(--ops-u))` is byte-identical
+     to what shipped — 1440×900 is the regression floor and it stays
+     untouched. Above 1920 it grows with the viewport and everything
+     expressed in it grows together, in proportion, from one number.
+
+     Capped at 1.85 rather than the 2.0 the ratio would give at 3840:
+     type that scales perfectly linearly with a very wide viewport
+     outruns comfortable line length before it outruns the panel.
+
+     WHAT DOES NOT SCALE: hairlines, panel borders, the floor tick.
+     A 2px floor tick at 3840 is still the same fact as at 1440, and
+     a hairline that thickens with the window stops reading as a rule
+     and starts reading as a border. Those stay in real px, on
+     purpose — if you are tempted to convert one, don't. */
+  --ops-u: clamp(1px, calc(100vw / 1920), 1.85px);
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: calc(10 * var(--ops-u));
   height: 100%;
   min-height: 0;
-  padding: 14px 22px 12px;
+  padding: calc(14 * var(--ops-u)) calc(22 * var(--ops-u)) calc(12 * var(--ops-u));
   background: var(--h4-surface);
   color: var(--h4-ink);
   font-family: var(--h4-font-body);
@@ -61,9 +83,9 @@ body,
 .ops-meta {
   display: flex;
   justify-content: space-between;
-  gap: 24px;
+  gap: calc(24 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 11px;
+  font-size: calc(11 * var(--ops-u));
   letter-spacing: 0.06em;
   color: var(--h4-muted);
 }
@@ -85,8 +107,8 @@ body,
 .ops-stale {
   display: flex;
   align-items: center;
-  gap: 14px;
-  padding: 7px 14px;
+  gap: calc(14 * var(--ops-u));
+  padding: calc(7 * var(--ops-u)) calc(14 * var(--ops-u));
   border: 1px solid var(--h4-act);
   background: repeating-linear-gradient(
     135deg,
@@ -96,27 +118,27 @@ body,
 }
 .ops-stale strong {
   font-family: var(--h4-font-display);
-  font-size: 19px;
+  font-size: calc(19 * var(--ops-u));
   font-weight: 600;
   letter-spacing: 0.04em;
   color: var(--h4-act);
 }
 .ops-stale span {
   font-family: var(--h4-font-mono);
-  font-size: 12px;
+  font-size: calc(12 * var(--ops-u));
   color: var(--h4-ink);
 }
 .ops-stale .ops-stale-right {
   margin-left: auto;
   color: var(--h4-act);
-  font-size: 11px;
+  font-size: calc(11 * var(--ops-u));
   white-space: nowrap;
 }
 
 .ops-content {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: calc(10 * var(--ops-u));
   flex: 1;
   min-height: 0;
 }
@@ -126,62 +148,67 @@ body,
 /* ---- verdict + trust ------------------------------------------ */
 .ops-verdict-row {
   display: flex;
-  gap: 24px;
+  gap: calc(24 * var(--ops-u));
   align-items: stretch;
 }
 .ops-verdict { flex: 1; min-width: 0; }
 .ops-verdict-kicker {
   font-family: var(--h4-font-mono);
-  font-size: 11px;
+  font-size: calc(11 * var(--ops-u));
   letter-spacing: 0.12em;
   color: var(--tone, var(--h4-tel));
 }
-/* The only oversized element on the board. It earns that from priority. */
+/* The only oversized element on the board. It earns that from priority.
+   One number changed here — the ceiling, 62px → 148px — and that alone
+   is the difference between a verdict you read across a room and one
+   that stays laptop-sized on a wall. 4.1vw tracks the design's stated
+   "≈ viewport / 26" closely enough to be the same rule: 59px at 1440
+   (unchanged), 105px at 2560, and it meets the ceiling at 3610. */
 .ops-verdict-line {
   margin: 2px 0 0;
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: clamp(38px, 4.1vw, 62px);
+  font-size: clamp(38px, 4.1vw, 148px);
   line-height: 0.98;
   letter-spacing: 0.005em;
   color: var(--tone, var(--h4-ink));
 }
 .ops-verdict-sub {
-  margin: 6px 0 0;
+  margin: calc(6 * var(--ops-u)) 0 0;
   font-family: var(--h4-font-mono);
-  font-size: 13px;
+  font-size: calc(13 * var(--ops-u));
   line-height: 1.45;
   color: var(--tone, var(--h4-muted));
 }
 
 .ops-trust {
-  width: 440px;
+  width: calc(440 * var(--ops-u));
   flex: none;
   display: grid;
-  gap: 6px;
+  gap: calc(6 * var(--ops-u));
   align-content: center;
-  padding: 10px 14px;
+  padding: calc(10 * var(--ops-u)) calc(14 * var(--ops-u));
   border: 1px solid var(--ops-rule);
 }
 .ops-trust-row {
   display: grid;
-  grid-template-columns: 96px 1fr;
-  gap: 10px;
+  grid-template-columns: calc(96 * var(--ops-u)) 1fr;
+  gap: calc(10 * var(--ops-u));
   align-items: baseline;
 }
 .ops-trust-key {
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   letter-spacing: 0.12em;
   color: var(--h4-muted);
 }
 .ops-trust-val {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: calc(8 * var(--ops-u));
   min-width: 0;
   font-family: var(--h4-font-mono);
-  font-size: 12px;
+  font-size: calc(12 * var(--ops-u));
 }
 .ops-trust-val > span[data-tone] {
   color: var(--tone, var(--h4-ink-2));
@@ -192,13 +219,13 @@ body,
 
 /* ---- shared tone dot ------------------------------------------ */
 .ops-dot {
-  width: 9px;
-  height: 9px;
+  width: calc(9 * var(--ops-u));
+  height: calc(9 * var(--ops-u));
   flex: none;
   border-radius: 50%;
   background: var(--tone, var(--h4-tel));
 }
-.ops-dot--sm { width: 7px; height: 7px; }
+.ops-dot--sm { width: calc(7 * var(--ops-u)); height: calc(7 * var(--ops-u)); }
 
 /* ---- the money band ------------------------------------------- */
 .ops-money {
@@ -212,7 +239,7 @@ body,
   flex: none;
   display: flex;
   flex-direction: column;
-  padding: 10px 16px;
+  padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u));
   border-right: 1px solid var(--ops-rule);
   overflow: hidden;
 }
@@ -221,42 +248,42 @@ body,
   min-width: 0;
   display: flex;
   flex-direction: column;
-  padding: 10px 16px;
+  padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u));
   overflow: hidden;
 }
 
 .ops-panel-head {
   display: flex;
   align-items: baseline;
-  gap: 10px;
+  gap: calc(10 * var(--ops-u));
   flex-wrap: wrap;
 }
 .ops-panel-title {
   margin: 0;
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: 15px;
+  font-size: calc(15 * var(--ops-u));
   letter-spacing: 0.08em;
   color: var(--h4-ink);
 }
 .ops-panel-note {
   margin-left: auto;
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   color: var(--tone, var(--h4-muted));
 }
 .ops-chip {
-  padding: 2px 8px;
+  padding: calc(2 * var(--ops-u)) calc(8 * var(--ops-u));
   border: 1px dashed var(--ops-rule);
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   white-space: nowrap;
   color: var(--tone, var(--h4-muted));
 }
 .ops-awaiting {
-  margin: 8px 0 0;
+  margin: calc(8 * var(--ops-u)) 0 0;
   font-family: var(--h4-font-mono);
-  font-size: 11px;
+  font-size: calc(11 * var(--ops-u));
   color: var(--h4-tel);
 }
 
@@ -265,48 +292,53 @@ body,
    through to .ops-pool--unfloored, which has no bar at all.     */
 .ops-pool {
   display: grid;
-  grid-template-columns: minmax(120px, 168px) 1fr minmax(120px, 176px);
-  gap: 16px;
+  grid-template-columns:
+    minmax(calc(120 * var(--ops-u)), calc(168 * var(--ops-u)))
+    1fr
+    minmax(calc(120 * var(--ops-u)), calc(176 * var(--ops-u)));
+  gap: calc(16 * var(--ops-u));
   align-items: center;
   /* 8px -> 6px. Each pool now carries an address line, and the board has no
      spare height; two pixels a side across six pools is 24px, which is most of
      what that line costs. Cheaper than truncating anything. */
-  padding: 6px 0;
+  padding: calc(6 * var(--ops-u)) 0;
   border-bottom: 1px dashed var(--ops-hair);
 }
 .ops-pool-name {
   display: block;
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: 14px;
+  font-size: calc(14 * var(--ops-u));
   letter-spacing: 0.05em;
   color: var(--h4-ink);
 }
 .ops-pool-margin {
   display: block;
-  margin-top: 2px;
+  margin-top: calc(2 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   color: var(--tone, var(--h4-muted));
 }
+/* The vw term still governs below 1920 — the scaled ceiling only lifts the cap
+   that used to freeze this at 27px from 1588px upward. */
 .ops-pool-amount {
   text-align: right;
   font-family: var(--h4-font-mono);
   font-weight: 700;
-  font-size: clamp(19px, 1.7vw, 27px);
+  font-size: clamp(19px, 1.7vw, calc(27 * var(--ops-u)));
   white-space: nowrap;
   color: var(--tone, var(--h4-ink));
 }
 .ops-pool-unit {
-  margin-left: 6px;
-  font-size: 12px;
+  margin-left: calc(6 * var(--ops-u));
+  font-size: calc(12 * var(--ops-u));
   font-weight: 400;
   color: var(--h4-muted);
 }
 
 .ops-meter {
   position: relative;
-  height: 12px;
+  height: calc(12 * var(--ops-u));
   background: var(--h4-paper-sunken);
   border: 1px solid var(--ops-rule);
 }
@@ -315,11 +347,14 @@ body,
   inset: 0 auto 0 0;
   background: var(--tone, var(--h4-tel));
 }
-/* The floor tick. Fixed per rung, so a draining pool moves and it doesn't. */
+/* The floor tick. Fixed per rung, so a draining pool moves and it doesn't.
+   Its WIDTH stays 2px at every viewport — it marks a threshold, and a
+   threshold that gets fatter on a bigger screen marks a fuzzier one. The
+   overhang scales, so it keeps clearing a taller meter by the same look. */
 .ops-meter-floor {
   position: absolute;
-  top: -4px;
-  bottom: -4px;
+  top: calc(-4 * var(--ops-u));
+  bottom: calc(-4 * var(--ops-u));
   width: 2px;
   background: var(--h4-ink);
 }
@@ -330,7 +365,7 @@ body,
   top: 0;
   right: 0;
   bottom: 0;
-  width: 5px;
+  width: calc(5 * var(--ops-u));
   background: repeating-linear-gradient(
     90deg,
     var(--h4-ink) 0 1px,
@@ -339,10 +374,10 @@ body,
 }
 .ops-meter-scale {
   position: relative;
-  height: 14px;
-  margin-top: 3px;
+  height: calc(14 * var(--ops-u));
+  margin-top: calc(3 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 9px;
+  font-size: calc(9 * var(--ops-u));
   color: var(--h4-muted);
 }
 .ops-meter-scale .at-zero  { position: absolute; left: 0; }
@@ -352,10 +387,10 @@ body,
 .ops-solvency-divider {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin-top: 8px;
+  gap: calc(10 * var(--ops-u));
+  margin-top: calc(8 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   letter-spacing: 0.12em;
   color: var(--h4-muted);
 }
@@ -366,19 +401,41 @@ body,
 }
 .ops-pool--unfloored {
   align-items: baseline;
-  padding: 4px 0;
+  padding: calc(4 * var(--ops-u)) 0;
   border-bottom: 0;
 }
 .ops-pool--unfloored .ops-pool-name {
-  font-size: 12.5px;
+  font-size: calc(12.5 * var(--ops-u));
   color: var(--h4-ink-2);
 }
 .ops-pool-note {
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   line-height: 1.45;
   color: var(--h4-muted);
 }
+/* ---- pool sub-fact key -----------------------------------------
+   BURN under the signer, RUNWAY under the reward bank. The note used
+   to be one undifferentiated grey line, which meant the eye had to
+   read it to find out what it was about; the key says that before
+   you start reading, and lines up down the column so two pools'
+   sub-facts are visibly answering two different questions.
+
+   Scoped to --keyed: the unfloored pools reuse .ops-pool-note as a
+   plain grid cell and must stay a plain grid cell. */
+.ops-pool-note--keyed {
+  display: flex;
+  align-items: baseline;
+  gap: calc(8 * var(--ops-u));
+}
+.ops-pool-note-key {
+  flex: none;
+  min-width: calc(52 * var(--ops-u));
+  font-size: calc(9 * var(--ops-u));
+  letter-spacing: 0.14em;
+  color: var(--h4-tel);
+}
+.ops-pool-note-val { min-width: 0; }
 /* ---- pool address ----------------------------------------------
    One line under the balance, spanning the whole pool row. .ops-pool is a
    three-column grid, so anything that does not span becomes a fourth cell and
@@ -391,11 +448,13 @@ body,
   grid-column: 1 / -1;
   display: flex;
   align-items: baseline;
-  gap: 6px;
-  /* .ops-pool sets gap:16px, which applies between grid ROWS too. */
-  margin-top: -13px;
+  gap: calc(6 * var(--ops-u));
+  /* .ops-pool sets gap:16px, which applies between grid ROWS too — so this
+     cancellation has to scale with that gap or the address drifts off the
+     row it belongs to as the board grows. */
+  margin-top: calc(-13 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 9px;
+  font-size: calc(9 * var(--ops-u));
   line-height: 1.35;
   color: var(--h4-muted);
   min-width: 0;
@@ -410,6 +469,19 @@ body,
 .ops-pool-addr-hex--ss58 {
   opacity: 0.6;
 }
+/* ---- which encoding is which -----------------------------------
+   Two 40-odd-character strings separated by a dot, and nothing said
+   which was which. They are not interchangeable: one is what a block
+   explorer and an EVM wallet want, the other is what a Substrate
+   wallet wants, and sending to the wrong form is the sort of mistake
+   this board exists to prevent. The key is small and permanent. */
+.ops-pool-addr-key {
+  flex: none;
+  font-size: calc(8 * var(--ops-u));
+  letter-spacing: 0.14em;
+  color: var(--h4-tel);
+  opacity: 0.85;
+}
 .ops-pool-addr-sep {
   opacity: 0.45;
 }
@@ -421,7 +493,7 @@ body,
   /* Pushed right and first to yield: the addresses are the payload, the label
      is the gloss. At a narrow width the gloss truncates, never the hex. */
   margin-left: auto;
-  padding-left: 8px;
+  padding-left: calc(8 * var(--ops-u));
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -429,45 +501,49 @@ body,
   opacity: 0.8;
 }
 .ops-pool--unfloored .ops-pool-addr {
-  margin-top: -6px;
+  margin-top: calc(-6 * var(--ops-u));
 }
 
 .ops-pool-amount--quiet {
   flex: 0 0 auto;
   white-space: nowrap;
-  font-size: 16px;
+  font-size: calc(16 * var(--ops-u));
   font-weight: 400;
   color: var(--h4-muted);
 }
 
 /* ---- flow funnel ----------------------------------------------- */
+/* Take the slack between the header and the evidence rather than leaving it
+   all in one gap underneath — but only up to a point. `flex: 1` with no
+   ceiling meant that on a tall 4K window this row claimed 564px to display
+   64px of numerals: 63% of the FLOW panel was empty, and the emptiest part
+   of the board was the part about money. It now grows to a bounded height
+   and stops, and the evidence block below rises to meet it. */
 .ops-funnel {
   display: flex;
   align-items: center;
-  /* Take the slack between the header and the evidence rather than leaving it
-     all in one gap underneath. `align-items: center` then keeps the numerals
-     optically centred in whatever height the panel ends up with. */
-  flex: 1;
+  flex: 1 1 auto;
   min-height: 0;
-  margin-top: 10px;
-  padding: 0 8px;
+  max-height: calc(150 * var(--ops-u));
+  margin-top: calc(10 * var(--ops-u));
+  padding: 0 calc(8 * var(--ops-u));
 }
 .ops-funnel-stage {
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 96px;
+  min-width: calc(96 * var(--ops-u));
 }
 .ops-funnel-label {
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   letter-spacing: 0.14em;
   color: var(--h4-muted);
 }
 .ops-funnel-value {
   font-family: var(--h4-font-mono);
   font-weight: 700;
-  font-size: clamp(28px, 2.6vw, 42px);
+  font-size: clamp(28px, 2.6vw, calc(47 * var(--ops-u)));
   line-height: 1.12;
   /* Sage would read as "9 good things happened". A count is not a verdict —
      the verdict is upstairs — so the numerals stay ink and only an absent
@@ -480,16 +556,16 @@ body,
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 5px;
-  margin-top: 10px;
-  padding: 0 12px;
+  gap: calc(5 * var(--ops-u));
+  margin-top: calc(10 * var(--ops-u));
+  padding: 0 calc(12 * var(--ops-u));
 }
 .ops-funnel-arrow {
   display: flex;
   align-items: center;
   width: 100%;
   color: var(--h4-muted);
-  font-size: 11px;
+  font-size: calc(11 * var(--ops-u));
 }
 .ops-funnel-arrow i {
   flex: 1;
@@ -497,90 +573,130 @@ body,
   background: var(--ops-rule);
 }
 .ops-funnel-gap-label {
-  padding: 2px 8px;
+  padding: calc(2 * var(--ops-u)) calc(8 * var(--ops-u));
   border: 1px solid var(--ops-rule);
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   white-space: nowrap;
   color: var(--tone, var(--h4-muted));
+}
+
+/* ---- the two lines under the panel head -------------------------
+   Shipped in #686/#687 with no rules of their own, so they inherited
+   the board's BODY font while every other fact on the board is
+   monospace — the two newest money facts were the two that did not
+   look like they belonged to it.
+
+   The dispute clock is the one line here where doing nothing costs
+   money, so it is boxed and toned; the lifecycle line is context for
+   the funnel beneath it and stays quiet. */
+.ops-lifecycle {
+  margin: calc(6 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(11 * var(--ops-u));
+  line-height: 1.45;
+  color: var(--tone, var(--h4-ink-2));
+}
+.ops-dispute-clock {
+  display: flex;
+  align-items: baseline;
+  gap: calc(8 * var(--ops-u));
+  margin: calc(8 * var(--ops-u)) 0 0;
+  padding: calc(5 * var(--ops-u)) calc(10 * var(--ops-u));
+  border: 1px solid var(--tone, var(--h4-warn));
+  font-family: var(--h4-font-mono);
+  font-size: calc(11.5 * var(--ops-u));
+  color: var(--tone, var(--h4-warn));
 }
 
 /* ---- payout evidence ------------------------------------------
    Welded to the funnel above it: same panel, no gap, an explicit
    "corroborates" line. When the two disagree the board shows both
    numbers rather than averaging them into one reassuring figure. */
+/* `margin-top: auto` pinned this to the panel's bottom edge, which is the
+   opposite of the weld the comment above describes: it put the panel's whole
+   surplus height between the funnel and the proof that corroborates it. The
+   two now sit together and the surplus falls below both, where it reads as
+   margin instead of as a gap between two things that belong to each other. */
 .ops-evidence {
-  margin-top: auto;
+  margin-top: calc(12 * var(--ops-u));
   border: 1px solid var(--ops-rule);
 }
 .ops-evidence[data-emphasis="on"] { border-color: var(--h4-act); }
 .ops-evidence-head {
   display: flex;
   align-items: baseline;
-  gap: 12px;
-  padding: 8px 14px;
+  gap: calc(12 * var(--ops-u));
+  padding: calc(8 * var(--ops-u)) calc(14 * var(--ops-u));
   border-bottom: 1px dashed var(--ops-rule);
 }
 .ops-evidence-head h3 {
   margin: 0;
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: 12.5px;
+  font-size: calc(12.5 * var(--ops-u));
   letter-spacing: 0.1em;
   color: var(--h4-ink);
 }
 .ops-evidence-head span {
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   color: var(--h4-muted);
 }
 .ops-evidence-body {
   display: flex;
   align-items: center;
-  gap: 24px;
-  padding: 10px 14px;
+  gap: calc(24 * var(--ops-u));
+  padding: calc(10 * var(--ops-u)) calc(14 * var(--ops-u));
 }
 .ops-evidence-status {
-  min-width: 210px;
+  min-width: calc(210 * var(--ops-u));
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: clamp(22px, 2vw, 32px);
+  font-size: clamp(22px, 2vw, calc(32 * var(--ops-u)));
   letter-spacing: 0.02em;
   color: var(--tone, var(--h4-ink));
 }
 .ops-evidence-lines {
   font-family: var(--h4-font-mono);
-  font-size: 12px;
+  font-size: calc(12 * var(--ops-u));
   line-height: 1.6;
   color: var(--h4-ink-2);
 }
+/* The window-fit caption, under the ledger line it qualifies. Quieter than
+   the counts — it is about whether to believe them, not about the money. */
+.ops-evidence-fit {
+  margin-top: calc(2 * var(--ops-u));
+  font-size: calc(10 * var(--ops-u));
+  color: var(--tone, var(--h4-tel));
+}
 .ops-evidence-delta {
   margin-left: auto;
-  max-width: 280px;
+  max-width: calc(280 * var(--ops-u));
   text-align: right;
   font-family: var(--h4-font-mono);
-  font-size: 12px;
+  font-size: calc(12 * var(--ops-u));
   color: var(--tone, var(--h4-muted));
 }
 .ops-evidence-key {
   display: flex;
-  gap: 18px;
+  gap: calc(18 * var(--ops-u));
   align-items: center;
   flex-wrap: wrap;
-  padding: 7px 14px;
+  padding: calc(7 * var(--ops-u)) calc(14 * var(--ops-u));
   border-top: 1px dashed var(--ops-rule);
 }
 .ops-evidence-key span {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: calc(6 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 10px;
+  font-size: calc(10 * var(--ops-u));
   color: var(--h4-muted);
 }
 .ops-evidence-key i {
-  width: 8px;
-  height: 8px;
+  width: calc(8 * var(--ops-u));
+  height: calc(8 * var(--ops-u));
   flex: none;
   background: var(--tone, var(--h4-tel));
 }
@@ -589,23 +705,23 @@ body,
 .ops-pillars {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  padding: 10px 16px;
+  padding: calc(10 * var(--ops-u)) calc(16 * var(--ops-u));
   border: 1px solid var(--ops-rule);
 }
 .ops-pillar {
-  padding: 0 16px;
+  padding: 0 calc(16 * var(--ops-u));
   min-width: 0;
 }
 .ops-pillar + .ops-pillar { border-left: 1px dashed var(--ops-hair); }
 .ops-pillar-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: calc(8 * var(--ops-u));
 }
 .ops-pillar-name {
   font-family: var(--h4-font-display);
   font-weight: 600;
-  font-size: 13px;
+  font-size: calc(13 * var(--ops-u));
   letter-spacing: 0.1em;
   color: var(--h4-ink);
 }
@@ -613,30 +729,30 @@ body,
   margin-left: auto;
   text-align: right;
   font-family: var(--h4-font-mono);
-  font-size: 9.5px;
+  font-size: calc(9.5 * var(--ops-u));
   color: var(--h4-muted);
 }
 .ops-pillar-probes {
   display: grid;
-  gap: 7px;
-  margin-top: 9px;
+  gap: calc(7 * var(--ops-u));
+  margin-top: calc(9 * var(--ops-u));
 }
 .ops-probe {
   display: flex;
-  gap: 8px;
+  gap: calc(8 * var(--ops-u));
   align-items: baseline;
   min-width: 0;
 }
-.ops-probe .ops-dot { position: relative; top: -1px; }
+.ops-probe .ops-dot { position: relative; top: calc(-1 * var(--ops-u)); }
 .ops-probe-id {
   font-family: var(--h4-font-mono);
-  font-size: 11.5px;
+  font-size: calc(11.5 * var(--ops-u));
   white-space: nowrap;
   color: var(--h4-ink);
 }
 .ops-probe-detail {
   font-family: var(--h4-font-mono);
-  font-size: 10.5px;
+  font-size: calc(10.5 * var(--ops-u));
   line-height: 1.4;
   min-width: 0;
   color: var(--h4-ink-2);
@@ -647,10 +763,10 @@ body,
 .ops-pillar-trend {
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin: 9px 0 0;
+  gap: calc(10 * var(--ops-u));
+  margin: calc(9 * var(--ops-u)) 0 0;
   font-family: var(--h4-font-mono);
-  font-size: 9.5px;
+  font-size: calc(9.5 * var(--ops-u));
   color: var(--h4-muted);
 }
 .ops-pillar-trend[data-tone="awaiting"] { color: var(--h4-tel); }
@@ -660,10 +776,22 @@ body,
    into a one-word-per-line column. Pin the box here. */
 .ops-pillar-trend .ops-linespark {
   flex: none;
-  width: 96px;
-  height: 20px;
+  width: calc(96 * var(--ops-u));
+  height: calc(20 * var(--ops-u));
 }
 .ops-pillar-trend > span { min-width: 0; }
+
+/* ---- per-job economics -------------------------------------------
+   What one job costs and earns, on one line between the probes and
+   the footer. Also shipped unstyled; also monospace now, because it
+   is three numbers and numbers on this board are monospace.        */
+.ops-economics {
+  padding: calc(4 * var(--ops-u)) 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(12 * var(--ops-u));
+  letter-spacing: 0.02em;
+  color: var(--tone, var(--h4-ink-2));
+}
 
 /* ---- footer ------------------------------------------------------
    LLM spend lives here — one line. It is the least urgent number on
@@ -672,9 +800,9 @@ body,
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 24px;
+  gap: calc(24 * var(--ops-u));
   font-family: var(--h4-font-mono);
-  font-size: 11px;
+  font-size: calc(11 * var(--ops-u));
   color: var(--h4-muted);
 }
 .ops-foot span { white-space: nowrap; }
@@ -690,18 +818,18 @@ body,
 }
 .ops-empty {
   display: grid;
-  gap: 6px;
+  gap: calc(6 * var(--ops-u));
   justify-items: center;
   text-align: center;
 }
 .ops-empty-title {
   font-family: var(--h4-font-display);
-  font-size: 20px;
+  font-size: calc(20 * var(--ops-u));
   color: var(--h4-ink);
 }
 .ops-empty-detail {
   font-family: var(--h4-font-mono);
-  font-size: 12px;
+  font-size: calc(12 * var(--ops-u));
   color: var(--h4-tel);
 }
 
@@ -713,8 +841,8 @@ body,
 .ops-linespark--act polyline { stroke: var(--h4-act); }
 .ops-linespark--empty {
   display: inline-block;
-  width: 96px;
-  height: 20px;
+  width: calc(96 * var(--ops-u));
+  height: calc(20 * var(--ops-u));
 }
 
 /* ---- narrow desktop / split screen ------------------------------- */

--- a/packages/monitor-ui/src/styles/ops-scaling.test.ts
+++ b/packages/monitor-ui/src/styles/ops-scaling.test.ts
@@ -1,0 +1,78 @@
+// The ops board's scaling contract, guarded at the source.
+//
+// This board shipped with exactly two media queries, both `max-width`, and so
+// rendered at identical size on a 1440 laptop and a 3840 wall — on the 4K it
+// was mostly void. The fix was one custom property, `--ops-u`, that every size
+// is expressed in.
+//
+// That kind of fix decays quietly. A new panel gets a hard-coded `font-size:
+// 13px`, nothing looks wrong on the machine it was written on, and the board
+// grows a patch that stays laptop-sized on the wall. Nobody notices until
+// somebody stands in front of the wall.
+//
+// So the rules are asserted against the stylesheet text rather than against a
+// rendered page: a rendering test would need a real viewport, and the failure
+// this guards against is precisely one that looks fine at the viewport the
+// author happened to have.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const CSS = readFileSync(fileURLToPath(new URL("./hermes4-ops.css", import.meta.url)), "utf8");
+
+/** Declarations, minus comments — comments discuss px sizes and are not rules. */
+const RULES = CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+
+describe("--ops-u — the scaled pixel", () => {
+  test("resolves to exactly 1px below 1920, so 1440x900 is untouched", () => {
+    // The regression floor. Every `calc(N * var(--ops-u))` is N real pixels
+    // there, which is what makes this a pure addition rather than a redesign.
+    const decl = /--ops-u:\s*clamp\(\s*1px\s*,\s*calc\(100vw\s*\/\s*1920\)\s*,\s*([\d.]+)px\s*\)/.exec(RULES);
+    expect(decl, "--ops-u must clamp from 1px at a 1920 divisor").not.toBeNull();
+    // And a ceiling, so type stops before it outruns comfortable line length.
+    expect(Number(decl![1])).toBeGreaterThan(1);
+    expect(Number(decl![1])).toBeLessThanOrEqual(2);
+  });
+
+  test("every font-size scales, except the verdict's own curve", () => {
+    // The verdict is the one element sized by viewport directly — it is meant
+    // to be read across a room and follows the design's "≈ viewport / 26"
+    // rather than the body scale.
+    const fixed = [...RULES.matchAll(/font-size:\s*([^;]+);/g)]
+      .map((m) => m[1]!.trim())
+      .filter((v) => !v.includes("var(--ops-u)"))
+      .filter((v) => !/^clamp\(38px,\s*4\.1vw,\s*148px\)$/.test(v))
+      .filter((v) => v !== "inherit");
+    expect(fixed, "a fixed font-size freezes at 4K — express it in var(--ops-u)").toEqual([]);
+  });
+
+  test("the verdict ceiling is high enough to be worth raising", () => {
+    // 62px was the old ceiling and the whole defect: the board's single most
+    // important element stopped growing at 1512px.
+    const cap = /font-size:\s*clamp\(38px,\s*4\.1vw,\s*(\d+)px\)/.exec(RULES);
+    expect(cap).not.toBeNull();
+    expect(Number(cap![1])).toBeGreaterThanOrEqual(140);
+  });
+});
+
+describe("what must NOT scale", () => {
+  test("the floor tick stays 2px at every viewport", () => {
+    // It marks a threshold. A threshold that gets fatter on a bigger screen
+    // marks a fuzzier one, and this tick is the scale the whole meter is read
+    // against.
+    const block = /\.ops-meter-floor\s*\{([^}]*)\}/.exec(RULES);
+    expect(block).not.toBeNull();
+    expect(block![1]).toMatch(/width:\s*2px;/);
+    expect(block![1]).not.toMatch(/width:[^;]*--ops-u/);
+  });
+
+  test("no border or hairline is expressed in the scaled unit", () => {
+    // A hairline that thickens with the window stops reading as a rule and
+    // starts reading as a border.
+    const scaledBorders = [...RULES.matchAll(/border[a-z-]*:\s*([^;]+);/g)]
+      .map((m) => m[1]!)
+      .filter((v) => v.includes("--ops-u"));
+    expect(scaledBorders, "borders stay at real pixels").toEqual([]);
+  });
+});


### PR DESCRIPTION
The board had exactly two media queries and both were `max-width` guards, so it rendered at identical size on a 1440 laptop and a 3840 wall. On the 4K it was mostly void — a 795px FLOW panel displaying a 64px row, **63% empty**, and the emptiest part of the board was the part about money.

Measured on the live board at 2303 CSS px before this change: verdict headline **62px**, frozen since 1512px.

## The scaled pixel

`--ops-u` is one scaled pixel — exactly `1px` below 1920, growing with the viewport above it, capped at 1.85. Every size on the board is expressed in it, so the whole thing grows in proportion from one number instead of from forty breakpoints.

**1440×900 is the regression floor and is untouched.** Verified empirically: 21 of 21 computed sizes identical with the unit pinned to `1px`.

At 2303px: verdict 62 → **94px**, funnel numerals 42 → 56, panel titles 15 → 18, meters 12 → 14.

**Hairlines, panel borders and the floor tick deliberately do not scale.** A threshold that gets fatter on a bigger screen marks a fuzzier one. `ops-scaling.test.ts` asserts both halves at source level — every `font-size` must be expressed in the unit, and no `border` may be — because this class of fix decays quietly: someone adds `font-size: 13px`, it looks fine on their machine, and the board grows a patch that stays laptop-sized on the wall.

## The window fit, always on screen

`windowNote` returned `""` when the fit was `ok`, reasoning that a matching window needs no caption.

That failed in the one case where it mattered. The live board read **SHORTFALL −2** — *"2 settled jobs have no on-chain proof, money did not move"* — while saying nothing whatsoever about the window, because the fit was fine and therefore silent. The operator got the accusation and was denied the fact that decides whether to believe it: whether the chain count and the ledger count cover the same 24 hours, or whether a job simply sat on the edge of one of them.

It is now permanent on **both** surfaces, stating what was actually compared:

> `window fit ok — chain read over 38,919 blocks · ~24h at 2.22s/block, against a 24h ledger count`

Grey, not green — it is reassurance about the *method*, not about the money, and only the line above it is entitled to be red. Absent is not ok: a build that never reported a fit says so rather than rendering as one that reported a passing fit.

## Named, not inferred

- **EVM / SS58 keys** on every address, on both surfaces. Two unlabelled 40-character strings are not interchangeable, and the phone is where they get pasted into a wallet. The key sits outside the long-press selection so the grab still yields a pasteable address.
- **BURN / RUNWAY keys** on the pool sub-facts, which were one continuous grey paragraph answering two different questions.
- `.ops-lifecycle`, `.ops-dispute-clock` and `.ops-economics` shipped in #686/#687 **with no CSS at all** — the board's two newest money facts were inheriting the body font while every other fact on it is monospace.

## The void

`.ops-evidence` had `margin-top: auto`, which pinned it to the panel's bottom edge — the opposite of the weld its own comment describes. It put the panel's entire surplus height between the funnel and the proof that corroborates it. They now sit together and the surplus falls below both, where it reads as margin instead of as a gap.

## Verification

- 334 tests pass (5 new scaling guards, 4 new fit-branch assertions, 4 new cross-surface parity checks)
- typecheck clean
- rendered in the browser at both surfaces; regression floor verified by pinning `--ops-u` to `1px` and comparing 21 computed sizes against the shipped literals

## Not in this PR

The design's **settled-by-hour row** (which is what genuinely fills the remaining FLOW space) and the **3-column history band at 3840** both need an hourly settlement series. That can be derived from the `ReservationSettled` block numbers we already read, with no product-API change — next packet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)