### PR TITLE
board: CONFIRMED must not claim a gap it is only tolerating

### DIFF
--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -192,6 +192,41 @@ describe("payoutView — whether to believe the comparison at all", () => {
   });
 });
 
+describe("CONFIRMED says what it actually confirmed", () => {
+  const base = { status: "confirmed" as const, detail: "ok", confirmedUsdc: 1.8, windowBlocks: 40909 };
+
+  test("no gap is stated as no gap", () => {
+    const view = payoutView({ ...base, confirmedCount: 16, settledCount: 16 });
+    expect(view.delta).toBe("proof matches ledger — no gap");
+    expect(view.tone).toBe("ok");
+  });
+
+  test("a TOLERATED gap is not described as no gap", () => {
+    // The live board on 2026-08-03: 15 confirmed, 16 settled, status confirmed
+    // because the default tolerance is 1 — printed under the words "no gap",
+    // with 15 and 16 on the row above it.
+    const view = payoutView({ ...base, confirmedCount: 15, settledCount: 16 });
+    expect(view.delta).not.toContain("no gap");
+    expect(view.delta).toContain("1 settled job not yet proven on-chain");
+    expect(view.delta).toContain("not a shortfall");
+    // Still sage, still unemphasised: the tolerance exists because a job on the
+    // window edge is expected, and paging for it would be a false red.
+    expect(view.tone).toBe("ok");
+    expect(view.emphasised).toBe(false);
+  });
+
+  test("more proof than ledger reads as a window edge, not a discrepancy", () => {
+    const view = payoutView({ ...base, confirmedCount: 17, settledCount: 16 });
+    expect(view.delta).toContain("1 more payout on-chain than settled");
+    expect(view.delta).not.toContain("no gap");
+  });
+
+  test("nothing to compare against never claims a match with a ledger", () => {
+    const view = payoutView({ ...base, confirmedCount: 15, settledCount: null });
+    expect(view.delta).not.toContain("no gap");
+  });
+});
+
 describe("payoutView — the fee exclusion is explained on screen", () => {
   const base = {
     status: "confirmed" as const, detail: "ok",

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -616,10 +616,44 @@ export function payoutView(payout: PayoutEvidence | undefined): EvidenceView {
     tone: "ok",
     line1: chainLine,
     line2: ledgerLine,
-    delta: "proof matches ledger — no gap",
+    delta: confirmedDelta(payout),
     fit,
     emphasised: false,
   };
+}
+
+/**
+ * What CONFIRMED actually means, given the numbers printed beside it.
+ *
+ * "proof matches ledger — no gap" was hard-coded, and `confirmed` does not mean
+ * zero gap — it means the gap is within `PRODUCT_HEALTH_PAYOUT_TOLERANCE`,
+ * which defaults to 1. So the live board showed
+ *
+ *     CONFIRMED · 15 payouts confirmed on-chain · 16 marked settled
+ *                 proof matches ledger — no gap
+ *
+ * with 15 and 16 on the same row. Anyone who subtracts gets a different answer
+ * from the board's own summary of itself, and the summary is the part written
+ * in the reassuring voice.
+ *
+ * The tolerance is right — a job settling within seconds of the window edge
+ * lands on one side of the chain read and the other side of the ledger count,
+ * and paging someone for that would be a false red. What was wrong was
+ * describing a tolerated gap as no gap. It stays sage, because the money is
+ * fine; it just stops claiming more than the evidence does.
+ */
+function confirmedDelta(payout: PayoutEvidence): string {
+  const { settledCount, confirmedCount } = payout;
+  if (settledCount == null || confirmedCount == null) return "proof matches ledger";
+  const gap = settledCount - confirmedCount;
+  if (gap === 0) return "proof matches ledger — no gap";
+  if (gap > 0) {
+    return `${gap} settled job${gap === 1 ? "" : "s"} not yet proven on-chain — inside the boundary tolerance, not a shortfall`;
+  }
+  // More proof than ledger: normal at a window edge, where the chain read
+  // reaches back slightly further than the 24h settled count.
+  const extra = -gap;
+  return `${extra} more payout${extra === 1 ? "" : "s"} on-chain than settled in the window — window edge, not a discrepancy`;
 }
 
 /** The permanent key under the evidence row — the distinction, always on screen. */


### PR DESCRIPTION
Found on the live board while checking #688 had landed.

```
CONFIRMED   15 payouts confirmed on-chain · 1.80 USDC
            16 marked settled by the monitor
            proof matches ledger — no gap
```

**15 and 16 are on the row above the words "no gap."** Anyone who subtracts gets a different answer from the board's own summary of itself — and the summary is the part written in the reassuring voice.

## What was actually wrong

`status: "confirmed"` never meant zero gap. It means the gap is within `PRODUCT_HEALTH_PAYOUT_TOLERANCE`, which **defaults to 1**. But the delta string was hard-coded to `"proof matches ledger — no gap"` for every confirmed reading, regardless of the counts printed underneath it.

**The tolerance is right and stays.** A job settling within seconds of the window edge lands on one side of the chain read and the other side of the 24h ledger count. Paging for that would be a false red, and this board has been burned by false reds before.

What was wrong was describing a *tolerated* gap as *no* gap.

## After

```
CONFIRMED   15 payouts confirmed on-chain · 1.80 USDC
            16 marked settled by the monitor
            window fit ok — chain read over 40,909 blocks · ~24h at 2.112s/block…
            1 settled job not yet proven on-chain — inside the boundary
            tolerance, not a shortfall
```

Still sage, still unemphasised — the money is fine. It just stops claiming more than the evidence does.

The reverse case is covered too: a chain read reaching slightly further back than the ledger count yields *more* proof than settled, which is a window edge rather than a discrepancy and now says so.

This is the same defect class as the window fit in #688 — a reassuring string stronger than the evidence behind it — except this one contradicted two numbers on the same row.

## Verification

- 4 new tests, one per branch (`gap === 0`, `0 < gap ≤ tolerance`, `gap < 0`, nothing to compare)
- 338 tests pass, typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)