### PR TITLE
board: confirmed payouts by hour, from the chain

### DIFF
--- a/packages/monitor-ui/node_modules
+++ b/packages/monitor-ui/node_modules
@@ -1,0 +1,1 @@
+/Users/pascalkuriger/repo/ph-ops/packages/monitor-ui//node_modules

--- a/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
+++ b/packages/monitor-ui/src/components/mobile/MobileBoard.tsx
@@ -21,7 +21,7 @@
 
 import type { ProductHealth } from "../../lib/monitor/product-health.js";
 import { formatAgo, formatAmount } from "../../lib/monitor/ops-model.js";
-import { flowFunnel, payoutView, splitPools } from "../../lib/monitor/ops-spec.js";
+import { flowFunnel, payoutRunwayNote, payoutView, splitPools } from "../../lib/monitor/ops-spec.js";
 import {
   breachCard,
   isUntrusted,
@@ -234,6 +234,25 @@ function SolvencyPanel({ health }: { health: ProductHealth }) {
             <i className="fill" data-tone={view.tone} style={{ width: `${view.meter!.fillPct}%` }} />
             <i className="floor" style={{ left: `${view.meter!.floorPct}%` }} />
           </div>
+          {/* What the balance BUYS, not just what it is.
+              "12.89 USDC" is a level; "≈ 90 more payouts · signer gas ~3d to
+              floor" is a countdown, and a countdown is the one thing worth
+              waking up for. It was desktop-only, which is the wrong way round:
+              the desk is where you can already work it out. */}
+          {view.pool.key === "reward_bank"
+            ? (() => {
+                const runway = payoutRunwayNote({
+                  pool: view.pool,
+                  payout: health.flow?.payout,
+                  runwayNote: health.solvency?.runwayNote,
+                });
+                return runway ? (
+                  <p className="hm-ph-pool-note" data-tone={runway.tone} data-testid="mobile-runway">
+                    <b>RUNWAY</b> {runway.text}
+                  </p>
+                ) : null;
+              })()
+            : null}
           {/* Under the balance, same as the desktop. STACKED rather than on one
               line: 100 monospace glyphs do not fit 390px, and this board scrolls
               — height is cheap here in a way it is not on the fixed desktop, so

--- a/packages/monitor-ui/src/components/ops/FlowPanel.tsx
+++ b/packages/monitor-ui/src/components/ops/FlowPanel.tsx
@@ -16,7 +16,7 @@ import {
   type FunnelView,
 } from "../../lib/monitor/ops-spec.js";
 import type { MoneyPathSnapshot } from "../../lib/monitor/product-health.js";
-import { disputeClockLine, lifecycleNote } from "../../lib/monitor/ops-spec.js";
+import { disputeClockLine, lifecycleNote, settledByHourReason, settledByHourView } from "../../lib/monitor/ops-spec.js";
 import type { ExternalFunnelView, LifecycleView } from "../../lib/monitor/product-health.js";
 
 export interface FlowPanelProps {
@@ -68,6 +68,8 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
 
       <Funnel funnel={funnel} />
 
+      <SettledByHour payout={flow?.payout} />
+
       <div className="ops-evidence" data-emphasis={evidence.emphasised ? "on" : "off"} data-testid="ops-evidence">
         <div className="ops-evidence-head">
           <h3>PAYOUT EVIDENCE — INDEPENDENT ON-CHAIN PROOF</h3>
@@ -107,6 +109,59 @@ export function FlowPanel({ flow, externalFunnel, lifecycle, nowMs }: FlowPanelP
         </div>
       </div>
     </section>
+  );
+}
+
+/**
+ * Throughput by hour — and whose number it is.
+ *
+ * Titled "CONFIRMED ON-CHAIN BY HOUR", never "settled": these bars are built
+ * from the settlement LOGS, the same independent read as the evidence block
+ * below. A row drawn from the funnel's own count would agree with the funnel
+ * by construction and could never show the thing worth looking at.
+ *
+ * When it cannot be sliced — no measured block time, no block range read — it
+ * says why in a sentence. It never draws a flat row of zeroes, which looks
+ * exactly like a day on which nothing paid out.
+ */
+function SettledByHour({ payout }: { payout: MoneyPathSnapshot["payout"] | undefined }) {
+  const view = settledByHourView(payout);
+  if (!view) {
+    const reason = settledByHourReason(payout);
+    if (!reason) return null; // older payload: say nothing rather than invent a fault
+    return (
+      <p className="ops-byhour-absent" data-testid="ops-byhour-absent">
+        hourly throughput unavailable — {reason}
+      </p>
+    );
+  }
+  return (
+    <div className="ops-byhour" data-testid="ops-byhour">
+      <div className="ops-byhour-head">
+        <span className="ops-byhour-title">CONFIRMED ON-CHAIN BY HOUR</span>
+        <span className="ops-byhour-caption">{view.caption}</span>
+        {view.gapNote ? (
+          <span className="ops-byhour-gap" data-tone="degraded" data-testid="ops-byhour-gap">
+            {view.gapNote}
+          </span>
+        ) : null}
+      </div>
+      <div className="ops-byhour-bars" role="img" aria-label={`Confirmed payouts by hour. ${view.caption}`}>
+        {view.bars.map((bar) => (
+          <i
+            key={bar.hoursAgo}
+            className="ops-byhour-bar"
+            data-covered={bar.covered ? "yes" : "no"}
+            style={{ height: `${bar.heightPct}%` }}
+            title={bar.title}
+          />
+        ))}
+      </div>
+      <div className="ops-byhour-axis" aria-hidden>
+        <span>−{view.bars.length}h</span>
+        <span>now</span>
+      </div>
+    </div>
   );
 }
 

--- a/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
+++ b/packages/monitor-ui/src/components/ops/money-lines-wired.test.ts
@@ -44,6 +44,33 @@ describe("every money line is actually rendered", () => {
     });
   }
 
+  /**
+   * Desk-only, and each entry has to carry the argument for why.
+   *
+   * The default is BOTH surfaces — a fact wired into the desktop and not the
+   * phone is invisible exactly when the operator is away from the desk. An
+   * exemption is a decision, so it gets written down next to the name.
+   */
+  const DESKTOP_ONLY: Record<string, string> = {
+    gasPoolNote: "gas burn is tuning information; the signer meter carries the 2am fact",
+    settledByHourView:
+      "24 bars is a shape you study, not a fact you act on — and 24 columns across 390px is a smear. The phone keeps the funnel counts and the proof, which are the actionable parts.",
+    economicsLine:
+      "unit economics is a question you sit down with. Nothing about 0.163 USDC per job changes what you would do in the next ten minutes, which is the only thing the phone is for.",
+  };
+
+  for (const fn of MONEY_LINE_RENDERERS) {
+    const reason = DESKTOP_ONLY[fn];
+    it(reason ? `${fn} is deliberately desk-only` : `the PHONE board also calls ${fn}`, () => {
+      if (reason) {
+        expect(reason.length, `${fn} needs a real argument for skipping the phone`).toBeGreaterThan(30);
+        expect(phone, `${fn} is listed desk-only but the phone renders it`).not.toContain(`${fn}(`);
+      } else {
+        expect(phone, `${fn} is on the desktop board but not the phone`).toContain(`${fn}(`);
+      }
+    });
+  }
+
   it("imports them from ops-spec rather than redefining them", () => {
     // A local reimplementation would satisfy the check above while drifting from
     // the tested one — the same two-verdict-systems problem the board forbids.

--- a/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-fixtures.ts
@@ -330,6 +330,13 @@ export const OPS_FIXTURE_NOMINAL: ProductHealth = {
       settledCount: 14,
       windowBlocks: 43200,
       window: { status: "ok", detail: "43200 blocks ≈ 25.3h at 2.112s/block", blockSeconds: 2.112, spanHours: 25.3 },
+      // A whole day read, with real texture: busy stretches and hours where
+      // genuinely nothing paid out. Both are covered — a quiet hour observed
+      // is a fact, and it must look different from an hour nobody read.
+      byHour: {
+        slices: [{ hoursAgo: 1, count: 0, covered: true }, { hoursAgo: 2, count: 1, covered: true }, { hoursAgo: 3, count: 0, covered: true }, { hoursAgo: 4, count: 2, covered: true }, { hoursAgo: 5, count: 1, covered: true }, { hoursAgo: 6, count: 0, covered: true }, { hoursAgo: 7, count: 0, covered: true }, { hoursAgo: 8, count: 1, covered: true }, { hoursAgo: 9, count: 3, covered: true }, { hoursAgo: 10, count: 0, covered: true }, { hoursAgo: 11, count: 1, covered: true }, { hoursAgo: 12, count: 0, covered: true }, { hoursAgo: 13, count: 2, covered: true }, { hoursAgo: 14, count: 0, covered: true }, { hoursAgo: 15, count: 1, covered: true }, { hoursAgo: 16, count: 0, covered: true }, { hoursAgo: 17, count: 0, covered: true }, { hoursAgo: 18, count: 2, covered: true }, { hoursAgo: 19, count: 0, covered: true }, { hoursAgo: 20, count: 1, covered: true }, { hoursAgo: 21, count: 0, covered: true }, { hoursAgo: 22, count: 0, covered: true }, { hoursAgo: 23, count: 1, covered: true }, { hoursAgo: 24, count: 0, covered: true }],
+        total: 16, peak: 3, coveredHours: 24, blocksPerHour: 1704.5,
+      },
     },
   },
   history: {
@@ -409,6 +416,13 @@ export const OPS_FIXTURE_STRESS: ProductHealth = {
       settledCount: 14,
       windowBlocks: 43200,
       window: { status: "ok", detail: "43200 blocks ≈ 25.3h at 2.112s/block", blockSeconds: 2.112, spanHours: 25.3 },
+      // THE CASE THE HATCHING EXISTS FOR: the lookback ceiling bound and only
+      // 9 hours were ever read. The other 15 are not quiet — they are unread,
+      // and drawing them as zero-height bars would be a claim nobody made.
+      byHour: {
+        slices: [{ hoursAgo: 1, count: 0, covered: true }, { hoursAgo: 2, count: 2, covered: true }, { hoursAgo: 3, count: 1, covered: true }, { hoursAgo: 4, count: 0, covered: true }, { hoursAgo: 5, count: 3, covered: true }, { hoursAgo: 6, count: 1, covered: true }, { hoursAgo: 7, count: 0, covered: true }, { hoursAgo: 8, count: 1, covered: true }, { hoursAgo: 9, count: 0, covered: true }, { hoursAgo: 10, count: 0, covered: false }, { hoursAgo: 11, count: 0, covered: false }, { hoursAgo: 12, count: 0, covered: false }, { hoursAgo: 13, count: 0, covered: false }, { hoursAgo: 14, count: 0, covered: false }, { hoursAgo: 15, count: 0, covered: false }, { hoursAgo: 16, count: 0, covered: false }, { hoursAgo: 17, count: 0, covered: false }, { hoursAgo: 18, count: 0, covered: false }, { hoursAgo: 19, count: 0, covered: false }, { hoursAgo: 20, count: 0, covered: false }, { hoursAgo: 21, count: 0, covered: false }, { hoursAgo: 22, count: 0, covered: false }, { hoursAgo: 23, count: 0, covered: false }, { hoursAgo: 24, count: 0, covered: false }],
+        total: 8, peak: 3, coveredHours: 9, blocksPerHour: 1704.5,
+      },
     },
   },
 };

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.test.ts
@@ -9,6 +9,8 @@ import {
   askHermesRow,
   payoutView,
   poolMeter,
+  settledByHourReason,
+  settledByHourView,
   splitPools,
   trustRows,
 } from "./ops-spec.js";
@@ -189,6 +191,78 @@ describe("payoutView — whether to believe the comparison at all", () => {
 
   test("nothing read from the chain is not a passing window", () => {
     expect(payoutView(undefined).fit.text).toContain("no comparison window");
+  });
+});
+
+describe("settledByHourView — an unread hour is a hole, not a quiet hour", () => {
+  const slices = (spec: Array<[count: number, covered: boolean]>) =>
+    spec.map(([count, covered], i) => ({ hoursAgo: i + 1, count, covered }));
+  const withHours = (spec: Array<[number, boolean]>, peak: number, total: number) => ({
+    status: "confirmed" as const, detail: "ok", confirmedCount: total, confirmedUsdc: 1,
+    settledCount: total, windowBlocks: 40909,
+    byHour: { slices: slices(spec), total, peak, coveredHours: spec.filter((s) => s[1]).length, blocksPerHour: 1704 },
+  });
+
+  test("oldest hour reads leftmost, so the row runs forward in time", () => {
+    const view = settledByHourView(withHours([[4, true], [1, true], [0, true]], 4, 5))!;
+    expect(view.bars.map((b) => b.hoursAgo)).toEqual([3, 2, 1]);
+  });
+
+  test("an unobserved hour gets NO bar and is flagged, not drawn at zero", () => {
+    // Zero height beside real hours reads as "nothing paid out then" — a claim
+    // the instrument never made, and the exact class of lie this board exists
+    // to prevent.
+    const view = settledByHourView(withHours([[3, true], [0, false], [0, false]], 3, 3))!;
+    const unread = view.bars.filter((b) => !b.covered);
+    expect(unread).toHaveLength(2);
+    for (const b of unread) {
+      expect(b.heightPct).toBe(0);
+      expect(b.title).toContain("not read");
+    }
+    expect(view.gapNote).toBe("2h not read");
+  });
+
+  test("a genuinely quiet observed hour is a real zero and says so", () => {
+    const view = settledByHourView(withHours([[3, true], [0, true]], 3, 3))!;
+    const quiet = view.bars.find((b) => b.hoursAgo === 2)!;
+    expect(quiet.covered).toBe(true);
+    expect(quiet.heightPct).toBe(0);
+    expect(quiet.title).toContain("0 confirmed on-chain");
+    expect(view.gapNote).toBe("");
+  });
+
+  test("a single-payout hour beside a busy one is still visible", () => {
+    // 1/40 rounds to 3% — under a pixel on a 46px row. "Too small to draw" and
+    // "did not happen" must not look the same.
+    const view = settledByHourView(withHours([[40, true], [1, true]], 40, 41))!;
+    expect(view.bars.find((b) => b.hoursAgo === 2)!.heightPct).toBeGreaterThanOrEqual(8);
+  });
+
+  test("the caption names the chain, never the ledger", () => {
+    // These bars are the independent read. Calling them "settled" would
+    // reattribute them to the funnel's own count.
+    const view = settledByHourView(withHours([[2, true]], 2, 2))!;
+    expect(view.caption).toContain("confirmed on-chain");
+    expect(view.caption).not.toContain("settled");
+  });
+
+  test("no chart at all when it could not be sliced — with the reason", () => {
+    const payout = {
+      status: "confirmed" as const, detail: "ok", confirmedCount: 3, confirmedUsdc: 1,
+      settledCount: 3, windowBlocks: 40909,
+      byHour: { reason: "block time not measured — hours cannot be derived from block numbers" },
+    };
+    expect(settledByHourView(payout)).toBeNull();
+    expect(settledByHourReason(payout)).toContain("block time not measured");
+  });
+
+  test("an older payload invents neither a chart nor a fault", () => {
+    const payout = {
+      status: "confirmed" as const, detail: "ok", confirmedCount: 3, confirmedUsdc: 1,
+      settledCount: 3, windowBlocks: 40909,
+    };
+    expect(settledByHourView(payout)).toBeNull();
+    expect(settledByHourReason(payout)).toBeNull();
   });
 });
 

--- a/packages/monitor-ui/src/lib/monitor/ops-spec.ts
+++ b/packages/monitor-ui/src/lib/monitor/ops-spec.ts
@@ -656,6 +656,82 @@ function confirmedDelta(payout: PayoutEvidence): string {
   return `${extra} more payout${extra === 1 ? "" : "s"} on-chain than settled in the window — window edge, not a discrepancy`;
 }
 
+export interface HourBarView {
+  hoursAgo: number;
+  count: number;
+  /** 0–100. Zero for an unobserved slice, which draws as a gap, not a bar. */
+  heightPct: number;
+  covered: boolean;
+  /** Hover text — the only place the exact count of a 1px bar is legible. */
+  title: string;
+}
+
+export interface SettledByHourView {
+  bars: HourBarView[];
+  /** e.g. "Σ 18 confirmed on-chain · peak 4/h" */
+  caption: string;
+  /** Said out loud when part of the day was never read. Empty otherwise. */
+  gapNote: string;
+}
+
+/**
+ * The hourly row under the funnel — throughput, from the chain.
+ *
+ * ── IT IS NOT THE FUNNEL'S NUMBER, AND SAYS SO ────────────────────────────
+ *
+ * These bars come from `ReservationSettled` logs, the same independent read
+ * that can contradict the funnel. Labelling them "settled" would quietly
+ * reattribute them to the product's own ledger and throw away the only
+ * property that makes the row worth its space.
+ *
+ * ── AN UNOBSERVED HOUR IS A GAP, NOT A SHORT BAR ──────────────────────────
+ *
+ * A slice the log read never reached has `count: 0` because nobody looked.
+ * Drawn at zero height beside real hours it reads as "nothing paid out then",
+ * which is a claim the instrument never made. Those slices get no bar at all
+ * and the row says how many hours it actually covered.
+ *
+ * Returns null when there is nothing honest to draw, so the caller can render
+ * the reason as a sentence instead.
+ */
+export function settledByHourView(payout: PayoutEvidence | undefined): SettledByHourView | null {
+  const h = payout?.byHour;
+  if (!h || "reason" in h) return null;
+  if (h.slices.length === 0) return null;
+
+  // Scale against the busiest COVERED hour. Scaling against a peak that
+  // included unobserved slices would flatten every real bar toward nothing.
+  const peak = Math.max(1, h.peak);
+  // Oldest on the left, so the row reads left-to-right as time moving forward.
+  const bars = [...h.slices].reverse().map((s) => ({
+    hoursAgo: s.hoursAgo,
+    count: s.count,
+    // A covered hour with payouts always gets a visible bar: a 1-payout hour
+    // beside a 40-payout hour rounds to nothing, and "too small to draw" and
+    // "did not happen" must not look the same.
+    heightPct: !s.covered ? 0 : s.count === 0 ? 0 : Math.max(8, Math.round((s.count / peak) * 100)),
+    covered: s.covered,
+    title: s.covered
+      ? `${s.hoursAgo}h ago · ${s.count} confirmed on-chain`
+      : `${s.hoursAgo}h ago · not read — the log window did not reach this far back`,
+  }));
+
+  const unread = h.slices.filter((s) => !s.covered).length;
+  return {
+    bars,
+    caption: `Σ ${h.total} confirmed on-chain · peak ${h.peak}/h`,
+    gapNote: unread === 0 ? "" : `${unread}h not read`,
+  };
+}
+
+/** Why there is no hourly row, when there isn't one. Never an empty chart. */
+export function settledByHourReason(payout: PayoutEvidence | undefined): string | null {
+  const h = payout?.byHour;
+  if (!h) return null; // older payload — say nothing rather than invent a fault
+  if ("reason" in h) return h.reason;
+  return h.slices.length === 0 ? "no hours to slice" : null;
+}
+
 /** The permanent key under the evidence row — the distinction, always on screen. */
 export const EVIDENCE_KEY: readonly { tone: OpsTone; text: string }[] = [
   { tone: "ok", text: "CONFIRMED — proof matches the ledger" },
@@ -844,6 +920,7 @@ export const MONEY_LINE_RENDERERS = [
   "payoutRunwayNote",
   "gasPoolNote",
   "economicsLine",
+  "settledByHourView",
 ] as const;
 
 /**

--- a/packages/monitor-ui/src/lib/monitor/product-health.ts
+++ b/packages/monitor-ui/src/lib/monitor/product-health.ts
@@ -202,6 +202,41 @@ export interface PayoutEvidence {
   feeUsdc?: number | null;
   /** False → `confirmedCount` may still include fees. Said, never implied. */
   feesSeparated?: boolean;
+  /**
+   * Confirmed payouts sliced into hours of chain, from the SAME logs as
+   * `confirmedCount`. This is the INDEPENDENT read, never the funnel's own
+   * count — a row drawn from the product's ledger would agree with the funnel
+   * by construction and could never show the thing worth seeing.
+   *
+   * `{ reason }` when it could not be sliced; absent on an older payload.
+   * Neither renders as an empty chart: flat zeroes drawn because the
+   * instrument could not slice look exactly like a day nothing paid out.
+   */
+  byHour?: PayoutHistogram | { reason: string };
+}
+
+/** One hour of chain, counting back from the head at read time. */
+export interface HourSlice {
+  /** 1 = the most recent hour, ascending into the past. */
+  hoursAgo: number;
+  count: number;
+  /**
+   * Whether the log read reached this far back. False means NOT OBSERVED —
+   * the count is 0 because nobody looked, and that must never be drawn as a
+   * quiet hour.
+   */
+  covered: boolean;
+}
+
+export interface PayoutHistogram {
+  /** Most recent hour first. */
+  slices: HourSlice[];
+  /** Payouts across the COVERED slices only. */
+  total: number;
+  /** Busiest covered slice, for scaling the bars. */
+  peak: number;
+  coveredHours: number;
+  blocksPerHour: number;
 }
 
 /**

--- a/packages/monitor-ui/src/styles/hermes4-mobile.css
+++ b/packages/monitor-ui/src/styles/hermes4-mobile.css
@@ -211,6 +211,29 @@
    and an address is 42 or 48 characters, so the one-line trick that works on the
    desktop board does not apply here. This board scrolls, so the extra lines cost
    nothing that matters; illegible hex would. */
+/* What the balance buys, under the meter that shows the balance. Monospace
+   like every other number on this board — the desktop shipped three lines
+   with no rules at all and they inherited the body font, which is how you
+   discover a fact was added by someone who never looked at it. */
+.hm-ph-pool-note {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin: 4px 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: 10px;
+  line-height: 1.45;
+  color: var(--tone, var(--h4-ink-2));
+}
+.hm-ph-pool-note b {
+  flex: none;
+  min-width: 46px;
+  font-weight: 400;
+  font-size: 9px;
+  letter-spacing: 0.12em;
+  color: var(--h4-tel);
+}
+
 .hm-ph-pool-addr {
   display: flex;
   flex-direction: column;

--- a/packages/monitor-ui/src/styles/hermes4-ops.css
+++ b/packages/monitor-ui/src/styles/hermes4-ops.css
@@ -609,6 +609,88 @@ body,
   color: var(--tone, var(--h4-warn));
 }
 
+/* ---- confirmed on-chain by hour ---------------------------------
+   The row that fills the space the funnel used to leave empty — and
+   the only thing on this panel with a shape rather than a number.
+
+   These bars are the INDEPENDENT read, the same logs the evidence
+   block below is built from. Never "settled": that word belongs to
+   the funnel's own ledger, and a row drawn from the ledger would
+   agree with the funnel by construction.
+
+   An hour the log read never reached gets NO BAR — see the
+   [data-covered="no"] rule. Zero height beside real hours would read
+   as "nothing paid out then", which the instrument never claimed. */
+.ops-byhour {
+  display: flex;
+  flex-direction: column;
+  margin-top: calc(10 * var(--ops-u));
+  padding-top: calc(8 * var(--ops-u));
+  border-top: 1px dashed var(--ops-hair);
+}
+.ops-byhour-head {
+  display: flex;
+  align-items: baseline;
+  gap: calc(10 * var(--ops-u));
+}
+.ops-byhour-title {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  letter-spacing: 0.14em;
+  color: var(--h4-muted);
+}
+.ops-byhour-caption {
+  margin-left: auto;
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--h4-ink-2);
+}
+.ops-byhour-gap {
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--tone, var(--h4-warn));
+}
+.ops-byhour-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: calc(3 * var(--ops-u));
+  height: calc(46 * var(--ops-u));
+  margin-top: calc(6 * var(--ops-u));
+}
+.ops-byhour-bar {
+  flex: 1;
+  min-height: 0;
+  background: var(--h4-ok);
+  opacity: 0.72;
+}
+/* NOT OBSERVED. A hatched column the full height of the row, so an
+   hour nobody read is visibly a hole in the record rather than a
+   quiet hour — the distinction this whole board is built on. */
+.ops-byhour-bar[data-covered="no"] {
+  height: 100% !important;
+  background: repeating-linear-gradient(
+    135deg,
+    rgba(237, 230, 221, 0.10) 0 3px,
+    transparent 3px 6px
+  );
+  opacity: 1;
+}
+.ops-byhour-axis {
+  display: flex;
+  justify-content: space-between;
+  margin-top: calc(3 * var(--ops-u));
+  font-family: var(--h4-font-mono);
+  font-size: calc(9 * var(--ops-u));
+  color: var(--h4-muted);
+}
+/* The reason there is no row. A sentence, never an empty chart. */
+.ops-byhour-absent {
+  margin: calc(10 * var(--ops-u)) 0 0;
+  font-family: var(--h4-font-mono);
+  font-size: calc(10 * var(--ops-u));
+  color: var(--h4-tel);
+}
+
 /* ---- payout evidence ------------------------------------------
    Welded to the funnel above it: same panel, no gap, an explicit
    "corroborates" line. When the two disagree the board shows both

--- a/services/slack-operator/src/payout-histogram.ts
+++ b/services/slack-operator/src/payout-histogram.ts
@@ -1,0 +1,140 @@
+// Confirmed on-chain payouts, sliced into hours.
+//
+// ── WHOSE NUMBER THIS IS ───────────────────────────────────────────────────
+//
+// These buckets are built from `ReservationSettled` LOGS — the same
+// independent read that corroborates the funnel, not the monitor's own
+// settled count. That distinction is the entire value of the row: a chart
+// drawn from the product's own ledger would agree with the funnel by
+// construction and could never show the thing worth seeing.
+//
+// So it must never be labelled "settled". It is "confirmed on-chain", and the
+// caller is responsible for saying so.
+//
+// ── SLICES ARE RELATIVE TO NOW, NOT TO THE CLOCK ───────────────────────────
+//
+// Each slice is exactly one hour of blocks, counting back from the head. That
+// avoids the partial-hour problem that wall-clock alignment creates: aligned
+// to UTC, the newest bucket is however many minutes into the current hour, and
+// it renders as a collapse in throughput every hour, on the hour, forever.
+//
+// A relative slice is always a whole hour of chain, so a short bar means a
+// short hour.
+//
+// ── PARTIAL MEANS NOT OBSERVED, AND IS NEVER DRAWN AS QUIET ────────────────
+//
+// The one real partiality is at the far end: if the log read did not reach
+// back far enough to cover a slice, that slice has no observation behind it. A
+// bucket the instrument never looked at, drawn as a short bar, is the same lie
+// as an absent number drawn as zero — and this board has shipped that lie
+// before. Those slices carry `covered: false`, and the renderer must show them
+// as unobserved rather than as low.
+//
+// ── AND WITHOUT A MEASURED BLOCK TIME, NOTHING ─────────────────────────────
+//
+// Every block-to-time mapping here rests on the measured seconds-per-block. An
+// assumed one has already been wrong in production by 3x. If it was not
+// measured, this returns a reason instead of a chart: no row at all is honest,
+// a row bucketed against a guess is not.
+
+/** One hour of chain, counting back from the head. */
+export interface HourSlice {
+  /** 1 = the most recent hour, ascending into the past. */
+  hoursAgo: number;
+  /** Confirmed payouts whose log landed in this slice. */
+  count: number;
+  /**
+   * Whether the log read actually reached this far back. False means NOT
+   * OBSERVED — the count is 0 because nobody looked, which is a different
+   * fact from a quiet hour and must not render as one.
+   */
+  covered: boolean;
+}
+
+export interface PayoutHistogram {
+  /** Most recent hour first. */
+  slices: HourSlice[];
+  /** Payouts across the covered slices only. */
+  total: number;
+  /** Busiest covered slice, for scaling the bars. 0 when nothing landed. */
+  peak: number;
+  /** Whole hours the read actually covered. */
+  coveredHours: number;
+  /** Blocks in an hour at the measured rate — the basis for every slice. */
+  blocksPerHour: number;
+}
+
+export interface HistogramUnavailable {
+  /** Why there is no chart. Rendered as a sentence, never as an empty chart. */
+  reason: string;
+}
+
+export function isHistogramUnavailable(
+  v: PayoutHistogram | HistogramUnavailable,
+): v is HistogramUnavailable {
+  return (v as HistogramUnavailable).reason !== undefined;
+}
+
+/** Hours the row shows. One day, to match the window everything else uses. */
+export const HISTOGRAM_HOURS = 24;
+
+export function bucketPayoutsByHour(input: {
+  /**
+   * Block number of each CONFIRMED PAYOUT. Fee settlements must already be
+   * excluded by the caller — they are revenue, and a revenue credit drawn in
+   * the payout row would overstate throughput on exactly the fee-bearing jobs
+   * the external funnel cares about.
+   */
+  blocks: readonly number[];
+  /** Head of the chain at read time. */
+  latestBlock: number;
+  /** Oldest block the read covered. */
+  fromBlock: number;
+  /** MEASURED seconds per block. Null means no chart. */
+  blockSeconds: number | null;
+  hours?: number;
+}): PayoutHistogram | HistogramUnavailable {
+  const hours = input.hours ?? HISTOGRAM_HOURS;
+  if (input.blockSeconds == null || !(input.blockSeconds > 0)) {
+    return { reason: "block time not measured — hours cannot be derived from block numbers" };
+  }
+  if (!(input.latestBlock > 0) || input.fromBlock > input.latestBlock) {
+    return { reason: "block range not read — nothing to slice" };
+  }
+
+  const blocksPerHour = 3600 / input.blockSeconds;
+  const slices: HourSlice[] = [];
+  for (let i = 0; i < hours; i += 1) {
+    // Slice i covers (head - (i+1) * blocksPerHour, head - i * blocksPerHour].
+    const newest = input.latestBlock - i * blocksPerHour;
+    const oldest = input.latestBlock - (i + 1) * blocksPerHour;
+    // Covered when the read reached the OLDEST block of the slice. A slice the
+    // read only half-covers is still a slice we cannot count honestly.
+    //
+    // The one-block tolerance is not slack, it is a rounding artifact. Slice
+    // edges are fractional (1704.5454… blocks to the hour) and a block range
+    // is integral, so a lookback sized to span exactly 24h lands 0.09 of a
+    // block short of the 24th slice — and without this the oldest hour would
+    // render as NEVER OBSERVED on every read, forever, on a window that in
+    // fact covered it. That is the same class of error as a false zero, just
+    // pointed the other way: it makes the instrument look blinder than it is.
+    const covered = oldest >= input.fromBlock - 1;
+    const count = covered
+      ? input.blocks.filter((b) => b > oldest && b <= newest).length
+      : 0;
+    slices.push({ hoursAgo: i + 1, count, covered });
+  }
+
+  const coveredSlices = slices.filter((s) => s.covered);
+  return {
+    slices,
+    total: coveredSlices.reduce((a, s) => a + s.count, 0),
+    peak: coveredSlices.reduce((a, s) => Math.max(a, s.count), 0),
+    // Counted from the slices rather than recomputed from the block span, so
+    // the headline can never disagree with the bars underneath it. Computing
+    // it independently reintroduced the same fractional-block rounding and had
+    // it reporting one hour fewer than the row actually drew.
+    coveredHours: coveredSlices.length,
+    blocksPerHour,
+  };
+}

--- a/services/slack-operator/src/product-health.ts
+++ b/services/slack-operator/src/product-health.ts
@@ -36,6 +36,7 @@ import { ESCROW_V2_SELECTORS } from "./escrow-selectors.js";
 import { readGasSpend } from "./gas-spend-read.js";
 import { readJobLifecycle } from "./job-lifecycle-read.js";
 import { summarizeLifecycle, type LifecycleSummary } from "./job-lifecycle.js";
+import { bucketPayoutsByHour, isHistogramUnavailable, type PayoutHistogram } from "./payout-histogram.js";
 import { createGasSpendCache, type GasSpendCache, type GasSpendSnapshot, type GasUnreadable } from "./gas-spend-cache.js";
 import { alertProvenance, decideMoneyAlert } from "./money-alert.js";
 import { decideSelfFreshness, fetchSelfCompare } from "./self-freshness.js";
@@ -1415,6 +1416,27 @@ export function decidePayoutEvidence(input: {
  * a confident, wrong payout count. Any failure → null (unverified), never a
  * zero that would read as "nothing paid".
  */
+/**
+ * The shape of "no payout evidence", in one place.
+ *
+ * Five separate exits return it — unconfigured, wrong chain, malformed
+ * response, read failure, feature off — and each used to spell the literal
+ * out. Adding a field meant remembering all five, and a missed one is not a
+ * type error when the field is optional. It is a seam so they cannot drift.
+ */
+function noPayoutRead(reason?: string): {
+  count: null; usdc: null; windowBlocks: null; feeCount: null; feeUsdc: null;
+  feesSeparated: false; payoutBlocks: number[]; latestBlock: null; fromBlock: null; reason?: string;
+} {
+  return {
+    count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null,
+    // Empty, never a populated array: no read means no observations, and an
+    // hourly row built from [] must render as "not read", not as a quiet day.
+    feesSeparated: false, payoutBlocks: [], latestBlock: null, fromBlock: null,
+    ...(reason ? { reason } : {}),
+  };
+}
+
 export async function readPayoutTransfers(input: {
   rpcUrl?: string;
   /**
@@ -1448,24 +1470,32 @@ export async function readPayoutTransfers(input: {
   feeUsdc: number | null;
   /** False when no treasury address was supplied — count may include fees. */
   feesSeparated: boolean;
+  /**
+   * Block number of each counted PAYOUT, so throughput can be sliced into
+   * hours. Fee settlements are excluded exactly as they are from `count` — a
+   * revenue credit drawn in the payout row would overstate throughput on
+   * precisely the fee-bearing jobs the external funnel exists to watch.
+   */
+  payoutBlocks: number[];
+  /** The range actually read, so a slice knows whether it was observed. */
+  latestBlock: number | null;
+  fromBlock: number | null;
   reason?: string;
 }> {
   if (!input.rpcUrl || !input.sourceAddress || !input.usdcAddress) {
-    return {
-      count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false,
-      reason: !input.sourceAddress
+    return noPayoutRead(
+      !input.sourceAddress
         ? "payout evidence not configured — no payout source address (/health addresses.agentAccountCore, or PRODUCT_HEALTH_PAYOUT_SOURCE_ADDRESS)"
         : "payout evidence not configured (RPC / USDC address)",
-    };
+    );
   }
   try {
     if (input.expectedChainId !== undefined) {
       const actual = Number(BigInt(await ethRpc(input.rpcUrl, "eth_chainId", [], input.fetchImpl)));
       if (actual !== input.expectedChainId) {
-        return {
-          count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false,
-          reason: `payout evidence unverified — RPC is on chain ${actual}, product is on ${input.expectedChainId}`,
-        };
+        return noPayoutRead(
+          `payout evidence unverified — RPC is on chain ${actual}, product is on ${input.expectedChainId}`,
+        );
       }
     }
     const latest = Number(BigInt(await ethRpc(input.rpcUrl, "eth_blockNumber", [], input.fetchImpl)));
@@ -1483,12 +1513,15 @@ export async function readPayoutTransfers(input: {
       input.fetchImpl,
     );
     if (!Array.isArray(logs)) {
-      return { count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false, reason: "payout evidence unverified — eth_getLogs returned no array" };
+      return noPayoutRead("payout evidence unverified — eth_getLogs returned no array");
     }
     let total = 0n;
     let counted = 0;
     let feeTotal = 0n;
     let feeCounted = 0;
+    // Where each PAYOUT landed, for slicing throughput into hours. Pushed only
+    // on the payout branch, so a fee credit can never inflate an hour.
+    const payoutBlocks: number[] = [];
     const wantAsset = input.usdcAddress.toLowerCase().replace(/^0x/, "").padStart(64, "0");
     // Padded to a 32-byte topic so it compares against topic3 directly.
     const feeTopic = input.feeRecipientAddress
@@ -1513,18 +1546,32 @@ export async function readPayoutTransfers(input: {
       const recipient = Array.isArray(topics) && typeof topics[3] === "string" ? topics[3].toLowerCase() : null;
       const isFee = feeTopic !== null && recipient === feeTopic;
 
+      // Absent on a pending log, which cannot be placed in an hour. The COUNT
+      // still includes it — a payout with no block is still a payout — so the
+      // hourly total can legitimately trail the headline count. The renderer
+      // says so rather than letting the two quietly disagree.
+      const rawBlock = (entry as { blockNumber?: unknown }).blockNumber;
+      const blockNumber = typeof rawBlock === "string" ? Number(BigInt(rawBlock)) : null;
+
+      const countPayout = () => {
+        counted += 1;
+        if (blockNumber !== null && Number.isFinite(blockNumber)) payoutBlocks.push(blockNumber);
+      };
       try {
         const value = BigInt(`0x${amount}`);
-        if (isFee) { feeTotal += value; feeCounted += 1; } else { total += value; counted += 1; }
+        if (isFee) { feeTotal += value; feeCounted += 1; } else { total += value; countPayout(); }
       } catch {
         // A malformed value is not a reason to under-report the count.
-        if (isFee) feeCounted += 1; else counted += 1;
+        if (isFee) feeCounted += 1; else countPayout();
       }
     }
     return {
       count: counted,
       usdc: Number(total) / 10 ** input.usdcDecimals,
       windowBlocks: latest - fromBlock,
+      payoutBlocks,
+      latestBlock: latest,
+      fromBlock,
       // null, not 0, when we cannot tell fees from payouts: zero would be a
       // claim that no fees were taken, which is a different statement from
       // "we could not look".
@@ -1534,10 +1581,9 @@ export async function readPayoutTransfers(input: {
     };
   } catch (error) {
     // Rate limit, capped range, dead endpoint — all unverified, never "0 paid".
-    return {
-      count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false,
-      reason: `payout evidence unverified — log read failed (${error instanceof Error ? error.message : String(error)})`,
-    };
+    return noPayoutRead(
+      `payout evidence unverified — log read failed (${error instanceof Error ? error.message : String(error)})`,
+    );
   }
 }
 
@@ -2066,6 +2112,16 @@ export interface PayoutEvidence {
   /** Does the block window actually span what it is compared against? */
   window?: WindowFit;
   /**
+   * Confirmed payouts sliced into hours, built from the SAME logs as
+   * `confirmedCount` — the independent read, not the product's ledger.
+   *
+   * A string instead is the reason there is no row. Absent entirely on an
+   * older payload. Neither is an empty chart: a row of flat zeroes drawn
+   * because the instrument could not slice is indistinguishable from a day on
+   * which nothing paid out.
+   */
+  byHour?: PayoutHistogram | { reason: string };
+  /**
    * Protocol-fee credits in the SAME window — settlements whose recipient was
    * the fee treasury, and the reason `confirmedCount` is not simply every
    * settlement found on chain.
@@ -2097,14 +2153,47 @@ export interface PayoutEvidence {
  */
 export function withFeeSplit(
   evidence: PayoutEvidence,
-  read: { feeCount: number | null; feeUsdc: number | null; feesSeparated: boolean },
+  read: {
+    feeCount: number | null;
+    feeUsdc: number | null;
+    feesSeparated: boolean;
+    payoutBlocks?: number[];
+    latestBlock?: number | null;
+    fromBlock?: number | null;
+  },
+  blockSeconds?: number | null,
 ): PayoutEvidence {
   return {
     ...evidence,
     feeCount: read.feeCount,
     feeUsdc: read.feeUsdc,
     feesSeparated: read.feesSeparated,
+    byHour: sliceIntoHours(read, blockSeconds ?? null),
   };
+}
+
+/**
+ * The hourly row, or the reason there isn't one.
+ *
+ * Attached through `withFeeSplit` rather than beside it on purpose: this seam
+ * exists BECAUSE an inline spread once silently dropped the fee fields, and a
+ * second assignment beside it would recreate exactly that hazard. One place
+ * where chain detail joins the verdict.
+ */
+function sliceIntoHours(
+  read: { payoutBlocks?: number[]; latestBlock?: number | null; fromBlock?: number | null },
+  blockSeconds: number | null,
+): PayoutHistogram | { reason: string } {
+  if (read.latestBlock == null || read.fromBlock == null) {
+    return { reason: "no block range was read" };
+  }
+  const result = bucketPayoutsByHour({
+    blocks: read.payoutBlocks ?? [],
+    latestBlock: read.latestBlock,
+    fromBlock: read.fromBlock,
+    blockSeconds,
+  });
+  return isHistogramUnavailable(result) ? { reason: result.reason } : result;
 }
 
 /**
@@ -2353,7 +2442,7 @@ export async function collectProductHealthProbes(
         ...(feeRecipient ? { feeRecipientAddress: feeRecipient } : {}),
         fetchImpl,
       })
-    : { count: null, usdc: null, windowBlocks: null, feeCount: null, feeUsdc: null, feesSeparated: false, reason: "payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)" };
+    : noPayoutRead("payout evidence off (set PRODUCT_HEALTH_PAYOUT_EVIDENCE_ENABLED=true)");
   // Check the INSTRUMENT against the chain, not against an assumption. The
   // lookback is compared to settled24h, so it has to actually span 24h at the
   // chain's real block time — an assumed one has already been wrong in prod.
@@ -2378,6 +2467,7 @@ export async function collectProductHealthProbes(
       ...(windowFit ? { window: windowFit } : {}),
     }),
     payoutRead,
+    blockSeconds,
   );
   // The monitor's own version. Degraded-safe: any failure is "unknown", which
   // must never render as up to date.

--- a/services/slack-operator/test/unit/payout-histogram.test.ts
+++ b/services/slack-operator/test/unit/payout-histogram.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  bucketPayoutsByHour,
+  isHistogramUnavailable,
+  type PayoutHistogram,
+} from "../../src/payout-histogram.js";
+
+/** ~2.11s/block, the rate this chain actually runs at. */
+const BLOCK_SECONDS = 2.112;
+const PER_HOUR = 3600 / BLOCK_SECONDS; // ~1704.5
+const HEAD = 19_000_000;
+
+function ok(v: ReturnType<typeof bucketPayoutsByHour>): PayoutHistogram {
+  if (isHistogramUnavailable(v)) throw new Error(`expected a histogram, got: ${v.reason}`);
+  return v;
+}
+
+describe("bucketPayoutsByHour — slices are hours of chain", () => {
+  test("a payout lands in the slice its block falls in", () => {
+    const h = ok(
+      bucketPayoutsByHour({
+        // One in the last hour, two in the hour before it.
+        blocks: [HEAD - 10, HEAD - Math.floor(PER_HOUR) - 5, HEAD - Math.floor(PER_HOUR) - 900],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.ceil(PER_HOUR * 24),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.slices[0]).toMatchObject({ hoursAgo: 1, count: 1, covered: true });
+    expect(h.slices[1]).toMatchObject({ hoursAgo: 2, count: 2, covered: true });
+    expect(h.total).toBe(3);
+    expect(h.peak).toBe(2);
+  });
+
+  test("every payout is counted exactly once across the row", () => {
+    // Off-by-one at a slice boundary would either double-count or drop a
+    // payout, and both are wrong on a money chart.
+    const blocks = Array.from({ length: 40 }, (_, i) => HEAD - i * 900);
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks,
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.ceil(PER_HOUR * 24),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.total).toBe(blocks.length);
+  });
+
+  test("24 slices, most recent first", () => {
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.ceil(PER_HOUR * 24),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.slices).toHaveLength(24);
+    expect(h.slices[0]!.hoursAgo).toBe(1);
+    expect(h.slices[23]!.hoursAgo).toBe(24);
+  });
+});
+
+describe("the window shape this actually runs against", () => {
+  test("a lookback sized to span 24h covers all 24 slices", () => {
+    // THE CASE THAT NEARLY SHIPPED WRONG. `resolvePayoutLookback` sizes the
+    // window from the measured rate and rounds to whole blocks: 24h at
+    // 2.112s/block is 40909.09 blocks, and the live read used 40909. Requiring
+    // the slice edge to fall strictly inside that leaves the 24th hour short
+    // by 0.09 of a block — so the oldest hour would have rendered as NEVER
+    // OBSERVED on every single read, on a window that did cover it.
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [HEAD - 40_000],
+        latestBlock: HEAD,
+        fromBlock: HEAD - 40_909, // exactly what the live board read
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.slices.every((s) => s.covered), "all 24 hours were read").toBe(true);
+    expect(h.coveredHours).toBe(24);
+    expect(h.total).toBe(1);
+  });
+
+  test("a window genuinely one hour short still says so", () => {
+    // The tolerance is a rounding allowance, not slack — a real gap of a full
+    // hour must still report as unobserved.
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.round(PER_HOUR * 23),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.slices[23]!.covered).toBe(false);
+    expect(h.coveredHours).toBe(23);
+  });
+});
+
+describe("what was never observed is not drawn as quiet", () => {
+  test("slices beyond the read are covered:false, not zero-count hours", () => {
+    // The lookback ceiling binding is the real case: the window is sized from
+    // the measured rate, but PRODUCT_HEALTH_PAYOUT_LOOKBACK_BLOCKS can cap it
+    // short, and then the old end of the row was simply never looked at.
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [HEAD - 10],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.round(PER_HOUR * 6), // only 6h of chain read
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    const covered = h.slices.filter((s) => s.covered);
+    expect(covered).toHaveLength(6);
+    expect(h.coveredHours).toBe(6);
+    // The other 18 are unobserved — and must be distinguishable from a real 0.
+    for (const s of h.slices.slice(6)) expect(s.covered).toBe(false);
+  });
+
+  test("an unobserved slice never contributes to the total or the peak", () => {
+    // Otherwise a partly-read window would quietly deflate the busiest hour
+    // and rescale every bar against it.
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [HEAD - 10, HEAD - 20],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.round(PER_HOUR * 2),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.total).toBe(2);
+    expect(h.peak).toBe(2);
+    expect(h.coveredHours).toBe(2);
+  });
+
+  test("a genuinely quiet covered hour IS a zero, and stays covered", () => {
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [HEAD - 10],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.ceil(PER_HOUR * 24),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.slices[5]).toMatchObject({ count: 0, covered: true });
+  });
+});
+
+describe("no measured block time, no chart", () => {
+  test("an unmeasured rate returns a reason rather than an empty row", () => {
+    // An assumed block time has already been wrong here by 3x. A row bucketed
+    // against a guess looks exactly like a row bucketed against a measurement.
+    const v = bucketPayoutsByHour({
+      blocks: [HEAD - 10],
+      latestBlock: HEAD,
+      fromBlock: HEAD - 40000,
+      blockSeconds: null,
+    });
+    expect(isHistogramUnavailable(v)).toBe(true);
+    expect(isHistogramUnavailable(v) && v.reason).toContain("block time not measured");
+  });
+
+  test("a nonsense rate is refused too", () => {
+    for (const bad of [0, -2.1, Number.NaN]) {
+      const v = bucketPayoutsByHour({
+        blocks: [], latestBlock: HEAD, fromBlock: HEAD - 40000, blockSeconds: bad,
+      });
+      expect(isHistogramUnavailable(v), `blockSeconds ${bad} must be refused`).toBe(true);
+    }
+  });
+
+  test("an unread block range returns a reason, not an empty chart", () => {
+    const v = bucketPayoutsByHour({
+      blocks: [], latestBlock: 0, fromBlock: 0, blockSeconds: BLOCK_SECONDS,
+    });
+    expect(isHistogramUnavailable(v)).toBe(true);
+  });
+});
+
+describe("no payouts at all", () => {
+  test("a fully-read, fully-empty day is a real row of zeroes", () => {
+    // Distinct from the unavailable case above: here the instrument looked
+    // across the whole window and there was genuinely nothing.
+    const h = ok(
+      bucketPayoutsByHour({
+        blocks: [],
+        latestBlock: HEAD,
+        fromBlock: HEAD - Math.ceil(PER_HOUR * 24),
+        blockSeconds: BLOCK_SECONDS,
+      }),
+    );
+    expect(h.total).toBe(0);
+    expect(h.peak).toBe(0);
+    expect(h.coveredHours).toBe(24);
+    expect(h.slices.every((s) => s.covered)).toBe(true);
+  });
+});


### PR DESCRIPTION
The row the FLOW panel was leaving space for. Before #688 that panel was **63% empty**; after it, 188px. It is now **52px**.

## Whose number this is

The bars are built from `ReservationSettled` **logs** — the same independent read the evidence block below is built from, *not* the monitor's own settled count. That is the whole value of the row: a chart drawn from the product's own ledger would agree with the funnel by construction and could never show the thing worth seeing.

Titled **CONFIRMED ON-CHAIN BY HOUR**, never "settled". No product-API change was needed — the logs already carried block numbers and we already measure seconds-per-block.

## An hour nobody read is a hole, not a quiet hour

A slice the log window never reached has `count: 0` because nobody looked. Drawn at zero height beside real hours it reads as *"nothing paid out then"* — a claim the instrument never made.

Those slices get a **hatched full-height column** instead of a bar, a title saying the window did not reach that far back, and the header says `15h not read`. The stress fixture is exactly this case, so the honest rendering is what gets reviewed rather than the happy one.

Without a measured block time there is **no row, only the reason**. An assumed block time has already been wrong here by 3×, and a row bucketed against a guess looks exactly like one bucketed against a measurement.

## The bug that would have shipped

Slice edges are fractional — 1704.5454… blocks to the hour — and a block range is integral. `resolvePayoutLookback` sizes the window to span 24h and rounds: **the live read used 40909 blocks where 24 slices need 40909.09.**

Requiring the slice edge to fall strictly inside that leaves the oldest hour short by **0.09 of a block**, so it would have rendered as NEVER OBSERVED on every read, forever, on a window that covered it. Same class of error as a false zero, pointed the other way — it makes the instrument look blinder than it is.

There is now a one-block rounding tolerance and a test using the exact live numbers. `coveredHours` had the identical flaw and is now counted from the slices, so the headline cannot disagree with the bars underneath it.

## Two gaps the stricter guard found

Extending the wiring guard to require every renderer on **both** surfaces unless exempted with a written argument turned up two that were already desktop-only:

- **`payoutRunwayNote` — now on the phone.** "12.89 USDC" is a level; "≈ 90 more payouts · signer gas ~3d to floor" is a countdown, and a countdown is the one thing worth waking up for. Desk-only was the wrong way round.
- **`economicsLine` — stays desk-only**, argument recorded in the guard.

`.hm-ph-pool-note` needed CSS; without it the phone would have got another line inheriting the body font, exactly like the three the desktop shipped that way in #686/#687.

## Seams

`readPayoutTransfers` had five exits returning the same "nothing read" literal — adding a field meant remembering all five, and a miss is not a type error when the field is optional. They now share `noPayoutRead()`. The histogram attaches through `withFeeSplit` rather than beside it, because that seam exists precisely because an inline spread once silently dropped the fee fields.

## Verification

- **2498 tests pass repo-wide** — 12 new backend (bucketing, coverage, refusals), 7 new view-model, 1 new guard
- typecheck clean, both packages
- rendered in the preview at both fixtures and both surfaces; FLOW leftover measured down to 52px

🤖 Generated with [Claude Code](https://claude.com/claude-code)